### PR TITLE
Mobile session UI layout and empty-state chrome polish

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/new.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/new.tsx
@@ -30,6 +30,7 @@ import { useAutoSelectModel } from '@/lib/hooks/use-auto-select-model';
 import { useModelPreferences } from '@/lib/hooks/use-model-preferences';
 import { usePersistedAgentModel } from '@/lib/hooks/use-persisted-agent-model';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { isRepositorySectionVisible } from '@/lib/is-repository-section-visible';
 import { resolveNewSessionSubmitDisabled } from '@/lib/new-session-submit';
 import { type InstancePickerInstance } from '@/lib/picker-bridge';
 import { shouldShowRunOnSelector } from '@/lib/should-show-run-on-selector';
@@ -264,17 +265,7 @@ export default function NewSessionScreen() {
     <View className="flex-1 bg-background">
       <ScreenHeader title="New session" />
 
-      {isRemoteTargetSelected ? (
-        <RemoteSpawnComposer
-          runOnInstance={runOnInstance}
-          instanceList={instanceList}
-          isLoadingInstances={isLoadingInstances}
-          onChangeRunOnInstance={handleRunOnInstanceChange}
-          isSpawningRemote={remoteSpawn.isSpawningRemote}
-          isStartDisabled={isStartDisabled}
-          onStart={handleStartSession}
-        />
-      ) : (
+      {isRepositorySectionVisible(runOnInstance) ? (
         <ScrollView
           className="flex-1"
           contentContainerClassName="flex-grow px-4 pb-8 pt-4"
@@ -309,23 +300,6 @@ export default function NewSessionScreen() {
             voiceInputSettlerRef={voiceInputSettlerRef}
           />
 
-          <NewSessionRepositorySection
-            disabled={isCreating}
-            isError={isReposError}
-            isLoading={isLoadingRepos}
-            isRefetching={isRefetchingRepos}
-            onChange={setSelectedRepo}
-            onOpenGitHubIntegration={() => {
-              void handleOpenGitHubIntegration();
-            }}
-            onRefetch={() => {
-              void refetchRepos();
-            }}
-            repositories={repositories}
-            showGitHubIntegrationPrompt={showGitHubIntegrationPrompt}
-            value={selectedRepo}
-          />
-
           {showRunOnSelector ? (
             <View className="mt-5">
               <Text className="mb-2 text-sm font-medium text-muted-foreground">Run on</Text>
@@ -344,6 +318,23 @@ export default function NewSessionScreen() {
             </View>
           ) : null}
 
+          <NewSessionRepositorySection
+            disabled={isCreating}
+            isError={isReposError}
+            isLoading={isLoadingRepos}
+            isRefetching={isRefetchingRepos}
+            onChange={setSelectedRepo}
+            onOpenGitHubIntegration={() => {
+              void handleOpenGitHubIntegration();
+            }}
+            onRefetch={() => {
+              void refetchRepos();
+            }}
+            repositories={repositories}
+            showGitHubIntegrationPrompt={showGitHubIntegrationPrompt}
+            value={selectedRepo}
+          />
+
           <Button
             size="lg"
             className="mt-6"
@@ -357,6 +348,16 @@ export default function NewSessionScreen() {
             )}
           </Button>
         </ScrollView>
+      ) : (
+        <RemoteSpawnComposer
+          runOnInstance={runOnInstance}
+          instanceList={instanceList}
+          isLoadingInstances={isLoadingInstances}
+          onChangeRunOnInstance={handleRunOnInstanceChange}
+          isSpawningRemote={remoteSpawn.isSpawningRemote}
+          isStartDisabled={isStartDisabled}
+          onStart={handleStartSession}
+        />
       )}
     </View>
   );

--- a/apps/mobile/src/components/agents/new-session-prompt.tsx
+++ b/apps/mobile/src/components/agents/new-session-prompt.tsx
@@ -166,20 +166,6 @@ export function NewSessionPrompt({
         onRetry={onRetryAttachment}
       />
       <View className="flex-row items-end px-2 pt-2">
-        <Pressable
-          onPress={handlePaperclipPress}
-          disabled={paperclipDisabled}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          className={cn(
-            'h-9 w-9 items-center justify-center rounded-full active:opacity-70',
-            paperclipDisabled && 'opacity-50'
-          )}
-          accessibilityRole="button"
-          accessibilityLabel="Add attachment"
-          accessibilityState={{ disabled: paperclipDisabled }}
-        >
-          <Paperclip size={18} color={colors.mutedForeground} />
-        </Pressable>
         {promptMeasure.measureElement}
         <RNTextInput
           ref={promptInputRef}
@@ -215,6 +201,22 @@ export function NewSessionPrompt({
             />
           </View>
         ) : null}
+      </View>
+      <View className="flex-row items-center px-2 pt-1">
+        <Pressable
+          onPress={handlePaperclipPress}
+          disabled={paperclipDisabled}
+          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+          className={cn(
+            'h-9 w-9 items-center justify-center rounded-full active:opacity-70',
+            paperclipDisabled && 'opacity-50'
+          )}
+          accessibilityRole="button"
+          accessibilityLabel="Add attachment"
+          accessibilityState={{ disabled: paperclipDisabled }}
+        >
+          <Paperclip size={18} color={colors.mutedForeground} />
+        </Pressable>
       </View>
       <View className="px-3 pb-1">
         <VoiceInputStatus status={voiceInput.status} />

--- a/apps/mobile/src/components/agents/session-list-content.tsx
+++ b/apps/mobile/src/components/agents/session-list-content.tsx
@@ -1,12 +1,11 @@
 import { useFocusEffect } from 'expo-router';
 import { Bot, Plus } from 'lucide-react-native';
-import { useCallback, useMemo, useRef, useState } from 'react';
+import { useCallback, useMemo, useState } from 'react';
 import {
   ActivityIndicator,
   Platform,
   RefreshControl,
   SectionList,
-  type TextInput,
   useWindowDimensions,
   View,
 } from 'react-native';
@@ -19,7 +18,6 @@ import {
   type SessionListBodyModel,
 } from '@/components/agents/session-list-body-model';
 import { type SessionSection } from '@/components/agents/session-list-helpers';
-import { SessionListSearchHeader } from '@/components/agents/session-list-search-header';
 import { SessionListSectionHeader } from '@/components/agents/session-list-section-header';
 import { StoredSessionRow } from '@/components/agents/session-row';
 import { EmptyState } from '@/components/empty-state';
@@ -34,9 +32,6 @@ import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { getRevisionSnapshot } from '@/lib/session-attention';
 import { getTabBarOverlayHeight } from '@/lib/tab-bar-layout';
 
-// Height of the hidden-by-default search bar (mt-3 12 + border 1 + py-1.5 12 + line-20 + border 1 + mb-14 14 = 60).
-const SEARCH_BAR_HEIGHT = 60;
-
 type AgentSessionListContentProps = {
   sections: SessionSection[];
   hasAnySessions: boolean;
@@ -46,7 +41,6 @@ type AgentSessionListContentProps = {
    * thing on screen. */
   hasPinnedActive: boolean;
   isLoading: boolean;
-  isSearchPending: boolean;
   /** Body-driving error flag — a search failure (when searching) OR a
    * stored/history failure. Active-only failures are surfaced separately
    * via the body's `showInlineError` output, NEVER as the empty-state
@@ -59,17 +53,9 @@ type AgentSessionListContentProps = {
   onRetry: () => void;
   onEndReached: () => void;
   onSessionPress: (sessionId: string, organizationId?: string | null) => void;
-  onSearchChange: (text: string) => void;
   hasActiveQuery: boolean;
   isSearching: boolean;
   onClearQuery: () => void;
-  /**
-   * Narrow clear path used by the in-field X: resets the debounced search
-   * query (and the local `hasText` flag) WITHOUT touching the persisted
-   * platform/project filters. The empty-state "Clear search"/"Clear filters"
-   * CTA keeps owning the broader `onClearQuery` path.
-   */
-  onClearSearchOnly: () => void;
   onCreateSession: () => void;
   sortBy: AgentSessionSortBy;
 };
@@ -79,7 +65,6 @@ export function AgentSessionListContent({
   hasAnySessions,
   hasPinnedActive,
   isLoading,
-  isSearchPending,
   isError,
   activeIsError,
   isFetchingNextPage,
@@ -87,11 +72,9 @@ export function AgentSessionListContent({
   onRetry,
   onEndReached,
   onSessionPress,
-  onSearchChange,
   hasActiveQuery,
   isSearching,
   onClearQuery,
-  onClearSearchOnly,
   onCreateSession,
   sortBy,
 }: Readonly<AgentSessionListContentProps>) {
@@ -100,36 +83,7 @@ export function AgentSessionListContent({
   const { fontScale } = useWindowDimensions();
   const { deleteSession, renameSession } = useSessionMutations();
   const [refreshing, setRefreshing] = useState(false);
-  const searchInputRef = useRef<TextInput>(null);
-  // Drives the in-field X's visibility only — the input itself stays
-  // uncontrolled (see iOS TextInput rules). Derived from `onChangeText`.
-  const [hasText, setHasText] = useState(false);
 
-  // The search TextInput is uncontrolled (see iOS TextInput rules — controlled
-  // `value` causes keystroke races), so clearing the query in state alone
-  // wouldn't clear what's visibly typed. Imperatively clear the input too.
-  const handleClearQuery = useCallback(() => {
-    searchInputRef.current?.clear();
-    setHasText(false);
-    onClearQuery();
-  }, [onClearQuery]);
-
-  const handleSearchInputChange = useCallback(
-    (text: string) => {
-      setHasText(text.length > 0);
-      onSearchChange(text);
-    },
-    [onSearchChange]
-  );
-
-  // Narrow path used by the in-field X: clears the input, dismisses the
-  // keyboard, and resets `hasText` so the X hides — without touching filters.
-  const handleClearSearchOnly = useCallback(() => {
-    searchInputRef.current?.clear();
-    searchInputRef.current?.blur();
-    setHasText(false);
-    onClearSearchOnly();
-  }, [onClearSearchOnly]);
   // The tab bar is an absolutely-positioned overlay, so scrollable content
   // must clear it or the last rows are stuck underneath it.
   const tabBarClearanceStyle = useMemo(
@@ -153,26 +107,6 @@ export function AgentSessionListContent({
     [activeIsError, hasActiveQuery, hasHistoryContent, hasPinnedActive, isError, isSearching]
   );
 
-  const listHeader = useMemo(
-    () => (
-      <SessionListSearchHeader
-        inputRef={searchInputRef}
-        hasText={hasText}
-        isSearchPending={isSearchPending}
-        showInlineError={bodyModel.showInlineError}
-        onChangeText={handleSearchInputChange}
-        onClearSearch={handleClearSearchOnly}
-      />
-    ),
-    [
-      bodyModel.showInlineError,
-      handleClearSearchOnly,
-      handleSearchInputChange,
-      hasText,
-      isSearchPending,
-    ]
-  );
-
   const emptyStateAction = useMemo(
     () => (
       <Button variant="outline" onPress={onCreateSession}>
@@ -185,11 +119,11 @@ export function AgentSessionListContent({
 
   const clearQueryAction = useMemo(
     () => (
-      <Button variant="outline" onPress={handleClearQuery}>
+      <Button variant="outline" onPress={onClearQuery}>
         <Text>{isSearching ? 'Clear search' : 'Clear filters'}</Text>
       </Button>
     ),
-    [handleClearQuery, isSearching]
+    [isSearching, onClearQuery]
   );
 
   // The tabs navigator uses `freezeOnBlur`, so while the session detail screen
@@ -278,10 +212,10 @@ export function AgentSessionListContent({
     );
   }
 
-  // The `contentOffset` trick that hides the search bar by default requires
-  // scrollable content, so when the user has no sessions at all we skip
-  // the SectionList entirely — mounting it with only a ListEmptyComponent
-  // would leave the search bar fully visible.
+  // The screen gates the search header on `hasAnySessions` to keep the
+  // first-use "No sessions yet" empty state chrome-free, so when the user
+  // has no sessions at all we skip the SectionList entirely here and just
+  // render the empty state.
   if (!hasAnySessions) {
     return (
       <Animated.View
@@ -324,7 +258,6 @@ export function AgentSessionListContent({
         renderSectionHeader={renderSectionHeader}
         keyExtractor={keyExtractor}
         extraData={attentionListKey}
-        ListHeaderComponent={listHeader}
         ListEmptyComponent={emptyComponent}
         ListFooterComponent={
           isFetchingNextPage ? (
@@ -334,7 +267,6 @@ export function AgentSessionListContent({
           ) : null
         }
         contentContainerStyle={tabBarClearanceStyle}
-        contentOffset={{ x: 0, y: SEARCH_BAR_HEIGHT }}
         keyboardDismissMode="on-drag"
         onEndReached={onEndReached}
         onEndReachedThreshold={0.5}

--- a/apps/mobile/src/components/agents/session-list-screen.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.tsx
@@ -3,14 +3,12 @@ import { View } from 'react-native';
 import Animated, { LinearTransition } from 'react-native-reanimated';
 
 import { ActiveNowSection } from '@/components/agents/active-now-section';
+import { selectSessionListBodyModel } from '@/components/agents/session-list-body-model';
 import { getNewAgentSessionPath } from '@/components/agents/session-list-routes';
 import { AgentSessionListContent } from '@/components/agents/session-list-content';
 import { SessionListHeaderActions } from '@/components/agents/session-list-header-actions';
-import {
-  createDefaultSearchTimer,
-  createSessionSearchController,
-  type SessionSearchController,
-} from '@/components/agents/session-search-state';
+import { SessionListSearchHeader } from '@/components/agents/session-list-search-header';
+import { useSessionSearchInput } from '@/components/agents/use-session-search-input';
 import {
   type ProjectFilterOption,
   SessionFilterChips,
@@ -49,39 +47,15 @@ export function AgentSessionListScreen() {
   } = usePersistedAgentSessionFilters();
   const [showFilterModal, setShowFilterModal] = useState(false);
 
-  const [searchQuery, setSearchQuery] = useState('');
-
-  // Search debounce + clear semantics live in a pure controller so the
-  // 300ms timing and the two clear paths (search-only vs. broad) can be
-  // unit tested without react-native or real timers. The controller
-  // holds its own pending-handle state — no setTimeout leaks into React.
-  const searchControllerRef = useRef<SessionSearchController | null>(null);
-  searchControllerRef.current ??= createSessionSearchController({
-    timer: createDefaultSearchTimer(),
-    commitSearchQuery: setSearchQuery,
-  });
-  const searchController = searchControllerRef.current;
-
-  const handleSearchChange = useCallback(
-    (text: string) => {
-      searchController.scheduleSearch(text);
-    },
-    [searchController]
-  );
-
-  // Search-only clear used by the in-field X: resets the debounced
-  // query without touching the persisted platform/project narrowing
-  // filters — the broad empty-state clear still owns that.
-  const handleClearSearchOnly = useCallback(() => {
-    searchController.clearSearchOnly();
-  }, [searchController]);
-
-  useEffect(
-    () => () => {
-      searchController.dispose();
-    },
-    [searchController]
-  );
+  const {
+    searchQuery,
+    searchInputRef,
+    hasText,
+    handleSearchInputChange,
+    handleClearSearchInput,
+    clearSearchInput,
+    searchController,
+  } = useSessionSearchInput();
 
   const createdOnPlatform = useMemo(
     () => (platformFilter.length > 0 ? expandPlatformFilter(platformFilter) : undefined),
@@ -249,12 +223,28 @@ export function AgentSessionListScreen() {
   const hasActiveFilter = platformFilter.length > 0 || projectFilter.length > 0;
   const hasAnySessions = storedSessions.length > 0 || activeSessions.length > 0;
 
+  // Search header is rendered at the screen level (above the pinned tray)
+  // so it's always visible. Recompute the body's `showInlineError` here
+  // via the SAME pure selector, with the same inputs, so the inline
+  // "Couldn't refresh" line stays identical and the body-model test keeps
+  // covering it.
+  const showInlineError = useMemo(
+    () =>
+      selectSessionListBodyModel({
+        hasHistoryContent: sections.length > 0,
+        hasPinnedActive,
+        hasActiveQuery: isSearching || hasActiveFilter,
+        isSearching,
+        isError: contentIsError,
+        activeIsError,
+      }).showInlineError,
+    [activeIsError, contentIsError, hasActiveFilter, hasPinnedActive, isSearching, sections]
+  );
+
   const handleClearQuery = useCallback(() => {
-    // Functional update so the persisted sort preference is preserved
-    // across "Clear search" / "Clear filters" — the controller's
-    // clearBroadly is the single source of truth for the reset pair.
+    clearSearchInput();
     searchController.clearBroadly(setFilters);
-  }, [searchController, setFilters]);
+  }, [clearSearchInput, searchController, setFilters]);
 
   return (
     <View className="flex-1 bg-background">
@@ -289,6 +279,16 @@ export function AgentSessionListScreen() {
           }}
         />
       </Animated.View>
+      {hasAnySessions ? (
+        <SessionListSearchHeader
+          inputRef={searchInputRef}
+          hasText={hasText}
+          isSearchPending={isSearchPending}
+          showInlineError={showInlineError}
+          onChangeText={handleSearchInputChange}
+          onClearSearch={handleClearSearchInput}
+        />
+      ) : null}
       <ActiveNowSection
         pinned={pinnedActive}
         organizationIdBySessionId={organizationIdBySessionId}
@@ -300,7 +300,6 @@ export function AgentSessionListScreen() {
           hasAnySessions={hasAnySessions}
           hasPinnedActive={hasPinnedActive}
           isLoading={isLoading || !ready}
-          isSearchPending={isSearchPending}
           isError={contentIsError}
           activeIsError={activeIsError}
           isFetchingNextPage={isFetchingNextPage}
@@ -308,11 +307,9 @@ export function AgentSessionListScreen() {
           onRetry={handleRetry}
           onEndReached={handleEndReached}
           onSessionPress={navigateToSession}
-          onSearchChange={handleSearchChange}
           hasActiveQuery={isSearching || hasActiveFilter}
           isSearching={isSearching}
           onClearQuery={handleClearQuery}
-          onClearSearchOnly={handleClearSearchOnly}
           onCreateSession={() => {
             router.push(getNewAgentSessionPath(organizationId) as Href);
           }}

--- a/apps/mobile/src/components/agents/use-session-search-input.ts
+++ b/apps/mobile/src/components/agents/use-session-search-input.ts
@@ -1,0 +1,108 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { type TextInput } from 'react-native';
+
+import {
+  createDefaultSearchTimer,
+  createSessionSearchController,
+  type SessionSearchController,
+} from '@/components/agents/session-search-state';
+
+type UseSessionSearchInputResult = {
+  /** Committed (debounced) search query that drives the list body. */
+  searchQuery: string;
+  /** Ref for the uncontrolled search TextInput. */
+  searchInputRef: React.RefObject<TextInput | null>;
+  /** Whether the search TextInput currently has non-empty text. */
+  hasText: boolean;
+  /** Call on every `onChangeText` from the search TextInput. */
+  handleSearchInputChange: (text: string) => void;
+  /** In-field X: imperatively clear the typed text, blur, and drop the query. */
+  handleClearSearchInput: () => void;
+  /** Imperatively clear the typed text and reset `hasText` (no blur). */
+  clearSearchInput: () => void;
+  /** Pure search controller for broader clear semantics (e.g. empty-state CTA). */
+  searchController: SessionSearchController;
+};
+
+/**
+ * Encapsulates the Agents search input's debounced commit, uncontrolled
+ * TextInput ref, and the two clear paths (search-only vs. broad). Keeps the
+ * screen focused on layout/query consumption while preserving the exact 300ms
+ * debounce and dispose-on-unmount behavior.
+ */
+export function useSessionSearchInput(): UseSessionSearchInputResult {
+  const [searchQuery, setSearchQuery] = useState('');
+
+  // Search debounce + clear semantics live in a pure controller so the
+  // 300ms timing and the two clear paths (search-only vs. broad) can be
+  // unit tested without react-native or real timers. The controller
+  // holds its own pending-handle state — no setTimeout leaks into React.
+  const searchControllerRef = useRef<SessionSearchController | null>(null);
+  searchControllerRef.current ??= createSessionSearchController({
+    timer: createDefaultSearchTimer(),
+    commitSearchQuery: setSearchQuery,
+  });
+  const searchController = searchControllerRef.current;
+
+  const handleSearchChange = useCallback(
+    (text: string) => {
+      searchController.scheduleSearch(text);
+    },
+    [searchController]
+  );
+
+  // Search-only clear used by the in-field X: resets the debounced
+  // query without touching the persisted platform/project narrowing
+  // filters — the broad empty-state clear still owns that.
+  const handleClearSearchOnly = useCallback(() => {
+    searchController.clearSearchOnly();
+  }, [searchController]);
+
+  // The search TextInput lives above the pinned "Active now" tray (so it's
+  // always visible) but must stay uncontrolled — see iOS TextInput rules.
+  const searchInputRef = useRef<TextInput>(null);
+  const [hasText, setHasText] = useState(false);
+
+  const handleSearchInputChange = useCallback(
+    (text: string) => {
+      setHasText(text.length > 0);
+      handleSearchChange(text);
+    },
+    [handleSearchChange]
+  );
+
+  // In-field X: imperatively clear what's visibly typed + dismiss the
+  // keyboard, then drop the debounced query. Persisted filters are left
+  // alone — the empty-state "Clear filters" CTA still owns the broad reset.
+  const handleClearSearchInput = useCallback(() => {
+    searchInputRef.current?.clear();
+    searchInputRef.current?.blur();
+    setHasText(false);
+    handleClearSearchOnly();
+  }, [handleClearSearchOnly]);
+
+  // Broad clear primitive: reset the uncontrolled TextInput's visible text
+  // and `hasText` flag without blurring. The caller still orchestrates the
+  // query/filters reset via `searchController.clearBroadly`.
+  const clearSearchInput = useCallback(() => {
+    searchInputRef.current?.clear();
+    setHasText(false);
+  }, []);
+
+  useEffect(
+    () => () => {
+      searchController.dispose();
+    },
+    [searchController]
+  );
+
+  return {
+    searchQuery,
+    searchInputRef,
+    hasText,
+    handleSearchInputChange,
+    handleClearSearchInput,
+    clearSearchInput,
+    searchController,
+  };
+}

--- a/apps/mobile/src/components/pr-review/pr-review-connect-gate-view.test.ts
+++ b/apps/mobile/src/components/pr-review/pr-review-connect-gate-view.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type PrReviewGateView,
+  selectPrReviewGateView,
+  type SelectPrReviewGateViewInput,
+} from './pr-review-connect-gate-view';
+
+const base: SelectPrReviewGateViewInput = {
+  isError: false,
+  isLoading: false,
+  connected: true,
+  revoked: false,
+};
+
+function viewFor(patch: Partial<SelectPrReviewGateViewInput>): PrReviewGateView {
+  return selectPrReviewGateView({ ...base, ...patch });
+}
+
+describe('selectPrReviewGateView', () => {
+  it('returns loading while the query is loading', () => {
+    expect(viewFor({ isLoading: true })).toBe('loading');
+  });
+
+  it('returns error when the query failed and is not loading', () => {
+    expect(viewFor({ isError: true })).toBe('error');
+  });
+
+  it('returns error when both error and loading are true', () => {
+    expect(selectPrReviewGateView({ ...base, isError: true, isLoading: true })).toBe('error');
+  });
+
+  it('returns connect when not connected and not revoked', () => {
+    expect(viewFor({ connected: false })).toBe('connect');
+  });
+
+  it('returns reconnect when the connection was revoked', () => {
+    expect(viewFor({ connected: false, revoked: true })).toBe('reconnect');
+  });
+
+  it('returns children when connected', () => {
+    expect(viewFor({ connected: true })).toBe('children');
+  });
+
+  it('exposes only one happy view and four non-happy header-bearing views', () => {
+    const inputs: Partial<SelectPrReviewGateViewInput>[] = [
+      { isLoading: true },
+      { isError: true },
+      { connected: false },
+      { connected: false, revoked: true },
+      { connected: true },
+    ];
+    const views = inputs.map(patch => viewFor(patch));
+    expect(views.filter(view => view === 'children')).toHaveLength(1);
+    expect(views.filter(view => view !== 'children')).toHaveLength(4);
+    expect(new Set(views).size).toBe(views.length);
+  });
+});

--- a/apps/mobile/src/components/pr-review/pr-review-connect-gate-view.ts
+++ b/apps/mobile/src/components/pr-review/pr-review-connect-gate-view.ts
@@ -1,0 +1,29 @@
+export type PrReviewGateView = 'error' | 'loading' | 'connect' | 'reconnect' | 'children';
+
+export type SelectPrReviewGateViewInput = {
+  readonly isError: boolean;
+  readonly isLoading: boolean;
+  readonly connected: boolean;
+  readonly revoked: boolean;
+};
+
+/**
+ * Pure view selector for the PR-review connect gate.
+ *
+ * The gate is intentionally a simple priority ladder: error → loading →
+ * not-connected → children. This mirrors the original component's branch
+ * order and keeps every non-happy outcome in a fixed set of header-bearing
+ * states.
+ */
+export function selectPrReviewGateView(args: SelectPrReviewGateViewInput): PrReviewGateView {
+  if (args.isError) {
+    return 'error';
+  }
+  if (args.isLoading) {
+    return 'loading';
+  }
+  if (!args.connected) {
+    return args.revoked ? 'reconnect' : 'connect';
+  }
+  return 'children';
+}

--- a/apps/mobile/src/components/pr-review/pr-review-connect-gate.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-connect-gate.tsx
@@ -6,10 +6,12 @@ import { toast } from 'sonner-native';
 
 import { EmptyState } from '@/components/empty-state';
 import { QueryError } from '@/components/query-error';
+import { ScreenHeader } from '@/components/screen-header';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { openAuthorizationAndWaitForReturn } from '@/lib/pr-review/connect-gate-platform';
+import { selectPrReviewGateView } from './pr-review-connect-gate-view';
 import { useTRPC } from '@/lib/trpc';
 
 type PrReviewConnectGateProps = {
@@ -108,9 +110,17 @@ export function PrReviewConnectGate({ children }: PrReviewConnectGateProps) {
     }
   };
 
-  if (authorization.isError) {
+  const view = selectPrReviewGateView({
+    isError: authorization.isError,
+    isLoading: authorization.isLoading,
+    connected: authorization.data?.connected === true,
+    revoked: authorization.data?.revoked === true,
+  });
+
+  if (view === 'error') {
     return (
       <View className="flex-1 bg-background">
+        <ScreenHeader title="PR Review" />
         <QueryError
           variant="server"
           title="Could not check GitHub connection"
@@ -124,18 +134,22 @@ export function PrReviewConnectGate({ children }: PrReviewConnectGateProps) {
     );
   }
 
-  if (authorization.isLoading) {
+  if (view === 'loading') {
     return (
-      <View className="flex-1 items-center justify-center bg-background">
-        <ActivityIndicator size="small" color={colors.mutedForeground} />
+      <View className="flex-1 bg-background">
+        <ScreenHeader title="PR Review" />
+        <View className="flex-1 items-center justify-center">
+          <ActivityIndicator size="small" color={colors.mutedForeground} />
+        </View>
       </View>
     );
   }
 
-  if (!authorization.data?.connected) {
-    const revoked = authorization.data?.revoked === true;
+  if (view === 'connect' || view === 'reconnect') {
+    const revoked = view === 'reconnect';
     return (
       <View className="flex-1 bg-background">
+        <ScreenHeader title="PR Review" />
         <EmptyState
           icon={revoked ? ShieldAlert : PlugZap}
           title={revoked ? 'Reconnect GitHub' : 'Connect GitHub'}

--- a/apps/mobile/src/components/security-agent/scope-entry-render.test.ts
+++ b/apps/mobile/src/components/security-agent/scope-entry-render.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type ScopeEntryView,
+  selectScopeEntryView,
+  type SelectScopeEntryViewInput,
+} from './scope-entry-render';
+
+const base: SelectScopeEntryViewInput = {
+  isLoading: false,
+  isError: false,
+  hasIntegration: true,
+  hasPermissions: true,
+  isEnabled: true,
+};
+
+function viewFor(patch: Partial<SelectScopeEntryViewInput>): ScopeEntryView {
+  return selectScopeEntryView({ ...base, ...patch });
+}
+
+describe('selectScopeEntryView', () => {
+  it('returns loading while any dependent query is loading', () => {
+    expect(viewFor({ isLoading: true })).toBe('loading');
+  });
+
+  it('returns error when not loading and any query errored', () => {
+    expect(viewFor({ isError: true })).toBe('error');
+  });
+
+  it('returns loading before error when both flags are true', () => {
+    expect(selectScopeEntryView({ ...base, isLoading: true, isError: true })).toBe('loading');
+  });
+
+  it('returns connect-github when integrated is missing', () => {
+    expect(viewFor({ hasIntegration: false })).toBe('connect-github');
+  });
+
+  it('returns reauthorize when integration exists but permissions are missing', () => {
+    expect(viewFor({ hasPermissions: false })).toBe('reauthorize');
+  });
+
+  it('returns connect-github before reauthorize when both are missing', () => {
+    expect(selectScopeEntryView({ ...base, hasIntegration: false, hasPermissions: false })).toBe(
+      'connect-github'
+    );
+  });
+
+  it('returns disabled-settings when connected but disabled', () => {
+    expect(viewFor({ isEnabled: false })).toBe('disabled-settings');
+  });
+
+  it('returns dashboard when connected and enabled', () => {
+    expect(viewFor({ isEnabled: true })).toBe('dashboard');
+  });
+
+  it('does not return a blank/redirect outcome for the disabled case', () => {
+    const result = viewFor({ isEnabled: false });
+    expect(result).toBe('disabled-settings');
+    expect(result).not.toBe('loading');
+    expect(result).not.toBe('error');
+    expect(result).not.toBe('dashboard');
+  });
+});

--- a/apps/mobile/src/components/security-agent/scope-entry-render.ts
+++ b/apps/mobile/src/components/security-agent/scope-entry-render.ts
@@ -1,0 +1,46 @@
+export type ScopeEntryView =
+  | 'loading'
+  | 'error'
+  | 'connect-github'
+  | 'reauthorize'
+  | 'disabled-settings'
+  | 'dashboard';
+
+export type SelectScopeEntryViewInput = {
+  isLoading: boolean;
+  isError: boolean;
+  hasIntegration: boolean;
+  hasPermissions: boolean;
+  isEnabled: boolean;
+};
+
+/**
+ * Pure selector deciding which view the Security Agent scope entry should
+ * render. Mirrors the precedence in ScopeEntryScreen: loading first, then
+ * error, then the missing-integration / missing-permission gates, then the
+ * connected-but-disabled state, and finally the enabled dashboard.
+ */
+export function selectScopeEntryView({
+  isLoading,
+  isError,
+  hasIntegration,
+  hasPermissions,
+  isEnabled,
+}: SelectScopeEntryViewInput): ScopeEntryView {
+  if (isLoading) {
+    return 'loading';
+  }
+  if (isError) {
+    return 'error';
+  }
+  if (!hasIntegration) {
+    return 'connect-github';
+  }
+  if (!hasPermissions) {
+    return 'reauthorize';
+  }
+  if (!isEnabled) {
+    return 'disabled-settings';
+  }
+  return 'dashboard';
+}

--- a/apps/mobile/src/components/security-agent/scope-entry-screen.tsx
+++ b/apps/mobile/src/components/security-agent/scope-entry-screen.tsx
@@ -1,13 +1,13 @@
 import { isPersonalSecurityScope } from '@kilocode/app-shared/security-agent';
-import { useRouter } from 'expo-router';
-import { useEffect } from 'react';
 import { View } from 'react-native';
 
 import { AuditReportButton } from '@/components/security-agent/audit-report-button';
+import { selectScopeEntryView } from '@/components/security-agent/scope-entry-render';
 import { PlatformErrorScreen } from '@/components/platform-error-screen';
 import { ScreenHeader } from '@/components/screen-header';
 import { DashboardScreen } from '@/components/security-agent/dashboard-screen';
 import { SecurityAgentSetup } from '@/components/security-agent/security-agent-setup';
+import { SettingsOverviewScreen } from '@/components/security-agent/settings-overview-screen';
 import { Skeleton } from '@/components/ui/skeleton';
 import { getGitHubIntegrationUrl } from '@/lib/agent-github-integration';
 import { WEB_BASE_URL } from '@/lib/config';
@@ -17,7 +17,6 @@ import {
   useSecurityAgentPermissionStatus,
   useSecurityAgentRepositories,
 } from '@/lib/hooks/use-security-agent';
-import { getSecurityAgentPath } from '@/lib/security-agent';
 
 function ScopeEntrySkeleton() {
   return (
@@ -39,7 +38,6 @@ function ScopeEntrySkeleton() {
 }
 
 export function ScopeEntryScreen({ scope }: Readonly<{ scope: string }>) {
-  const router = useRouter();
   const permission = useSecurityAgentPermissionStatus(scope);
   const config = useSecurityAgentConfig(scope);
   const repositories = useSecurityAgentRepositories(scope);
@@ -51,13 +49,14 @@ export function ScopeEntryScreen({ scope }: Readonly<{ scope: string }>) {
   const hasIntegration = permission.data?.hasIntegration ?? false;
   const hasPermissions = permission.data?.hasPermissions ?? false;
   const isEnabled = config.data?.isEnabled ?? false;
-  const isDisabled = !isLoading && !isError && hasIntegration && hasPermissions && !isEnabled;
 
-  useEffect(() => {
-    if (isDisabled) {
-      router.replace(getSecurityAgentPath(scope, 'settings'));
-    }
-  }, [isDisabled, router, scope]);
+  const view = selectScopeEntryView({
+    isLoading,
+    isError,
+    hasIntegration,
+    hasPermissions,
+    isEnabled,
+  });
 
   const refetchAll = async () => {
     await Promise.all([
@@ -68,11 +67,11 @@ export function ScopeEntryScreen({ scope }: Readonly<{ scope: string }>) {
     ]);
   };
 
-  if (isLoading) {
+  if (view === 'loading') {
     return <ScopeEntrySkeleton />;
   }
 
-  if (isError) {
+  if (view === 'error') {
     return (
       <PlatformErrorScreen
         title="Security Agent"
@@ -93,50 +92,52 @@ export function ScopeEntryScreen({ scope }: Readonly<{ scope: string }>) {
   // gates below, whenever the caller can manage the agent.
   const auditAction = capability.canManage ? <AuditReportButton scope={scope} /> : null;
 
-  if (!hasIntegration) {
-    return (
-      <View className="flex-1 bg-background">
-        <ScreenHeader title="Security Agent" headerRight={auditAction} />
-        <SecurityAgentSetup
-          title="Connect GitHub to get started"
-          description="Install the Kilo GitHub App to automatically sync Dependabot alerts and manage security findings across your repositories."
-          buttonLabel="Install GitHub App"
-          url={getGitHubIntegrationUrl(
-            WEB_BASE_URL,
-            isPersonalSecurityScope(scope) ? undefined : scope
-          )}
-          onConnected={refetchAll}
-        />
-      </View>
-    );
-  }
-
-  if (!hasPermissions) {
-    return (
-      <View className="flex-1 bg-background">
-        <ScreenHeader title="Security Agent" headerRight={auditAction} />
-        <SecurityAgentSetup
-          title="Additional permissions required"
-          description="Security Agent requires the vulnerability_alerts permission to access Dependabot alerts. Re-authorize the GitHub App to grant this permission."
-          buttonLabel="Re-authorize GitHub App"
-          url={
-            permission.data?.reauthorizeUrl ??
-            getGitHubIntegrationUrl(
+  switch (view) {
+    case 'connect-github': {
+      return (
+        <View className="flex-1 bg-background">
+          <ScreenHeader title="Security Agent" headerRight={auditAction} />
+          <SecurityAgentSetup
+            title="Connect GitHub to get started"
+            description="Install the Kilo GitHub App to automatically sync Dependabot alerts and manage security findings across your repositories."
+            buttonLabel="Install GitHub App"
+            url={getGitHubIntegrationUrl(
               WEB_BASE_URL,
               isPersonalSecurityScope(scope) ? undefined : scope
-            )
-          }
-          onConnected={refetchAll}
-        />
-      </View>
-    );
+            )}
+            onConnected={refetchAll}
+          />
+        </View>
+      );
+    }
+    case 'reauthorize': {
+      return (
+        <View className="flex-1 bg-background">
+          <ScreenHeader title="Security Agent" headerRight={auditAction} />
+          <SecurityAgentSetup
+            title="Additional permissions required"
+            description="Security Agent requires the vulnerability_alerts permission to access Dependabot alerts. Re-authorize the GitHub App to grant this permission."
+            buttonLabel="Re-authorize GitHub App"
+            url={
+              permission.data?.reauthorizeUrl ??
+              getGitHubIntegrationUrl(
+                WEB_BASE_URL,
+                isPersonalSecurityScope(scope) ? undefined : scope
+              )
+            }
+            onConnected={refetchAll}
+          />
+        </View>
+      );
+    }
+    case 'disabled-settings': {
+      return <SettingsOverviewScreen scope={scope} />;
+    }
+    case 'dashboard': {
+      return <DashboardScreen scope={scope} />;
+    }
+    default: {
+      throw new Error('Unexpected scope entry view');
+    }
   }
-
-  if (isDisabled) {
-    // router.replace to settings fires in the effect above; render nothing
-    // while the navigation takes effect.
-    return null;
-  }
-
-  return <DashboardScreen scope={scope} />;
 }

--- a/apps/mobile/src/lib/is-repository-section-visible.test.ts
+++ b/apps/mobile/src/lib/is-repository-section-visible.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+
+import { isRepositorySectionVisible } from './is-repository-section-visible';
+
+describe('isRepositorySectionVisible', () => {
+  it('shows the repository section for the Cloud-Agent target (runOnInstance is null)', () => {
+    expect(isRepositorySectionVisible(null)).toBe(true);
+  });
+
+  it('hides the repository section when a remote instance is selected', () => {
+    const remoteInstance = {
+      connectionId: 'conn-123',
+      name: 'My remote instance',
+      projectName: 'my-project',
+    };
+    expect(isRepositorySectionVisible(remoteInstance)).toBe(false);
+  });
+});

--- a/apps/mobile/src/lib/is-repository-section-visible.ts
+++ b/apps/mobile/src/lib/is-repository-section-visible.ts
@@ -1,0 +1,12 @@
+import { type InstancePickerInstance } from '@/lib/picker-bridge';
+
+/**
+ * Whether the new-agent screen should render the repository picker section.
+ *
+ * The repository picker is part of the Cloud-Agent composer. When the user
+ * selects a remote `kilo remote` instance (`runOnInstance !== null`), the
+ * screen swaps to `RemoteSpawnComposer`, which has no repository picker.
+ */
+export function isRepositorySectionVisible(runOnInstance: InstancePickerInstance | null): boolean {
+  return runOnInstance === null;
+}


### PR DESCRIPTION
Layout and empty-state chrome polish for the mobile session UI. Six focused, layout-scoped changes with unit coverage; all six verified on-device (iOS).

## Changes
1. **Agents list: search above "Active now".** Lift `SessionListSearchHeader` out of the SectionList and render it between the filter chips and the pinned `ActiveNowSection`, gated on `hasAnySessions`. Removes the old `contentOffset`/`SEARCH_BAR_HEIGHT` hide-trick and the now-unused search-only props from `session-list-content.tsx`. Search/clear and the inline "Couldn't refresh" staleness line are preserved (`showInlineError` still flows through `selectSessionListBodyModel`). First-use empty still shows no search bar. A new `use-session-search-input` hook owns the input ref and `hasText` wiring.
2. **New-session composer left padding.** The leading paperclip no longer pushes the prompt text ~52px to the right; it moves to its own row so the input's leading edge aligns with the composer content inset. No change to vertical layout, input height math, Android horizontal-inset constants, or the toolbar.
3. **New-session field order.** "Run on" now renders above "Select repository" in the Cloud-Agent branch: prompt → Run on → Repository → Start. Pure JSX reorder.
4. **Repository picker gating (regression lock).** The repository picker is already Cloud-Agent-only via the two-composer branch split; rather than add a duplicate guard, this adds `is-repository-section-visible` + a unit test locking the contract (repo section shown iff the Cloud-Agent target is selected, respecting `shouldShowRunOnSelector`). No production guard added, composers not merged.
5. **Security agent disable → back no longer shows a blank screen (defect).** `ScopeEntryScreen` no longer does `router.replace` + `return null` for the connected-but-disabled state; it renders the settings/enable UI in place, so back pops normally with no blank frame or redirect race. The render decision is extracted into a pure `scope-entry-render` selector with tests.
6. **PR-review connect gate header (defect + chrome).** The gate's loading/error/not-connected states now render a `ScreenHeader title="PR Review"` as the first child (previously a headerless bare view), keeping the existing `EmptyState` + connect CTA. Header presence is locked by `pr-review-connect-gate-view` + tests.

## Verification
- Unit: `pnpm typecheck`, `pnpm lint`, `pnpm format:check`, `pnpm check:unused` all pass; targeted vitest green (`session-list-body-model`, `is-repository-section-visible`, `scope-entry-render`, `pr-review-connect-gate-view`).
- On-device (iOS): all six items verified — search above a populated Active-now tray with working filter/clear; composer prompt alignment; Run-on/Repository order; repo picker present for Cloud Agent; security-agent disable→back renders a non-empty screen; PR-review connect state shows the "PR Review" header + EmptyState + CTA.

## Notes
- Non-goals (owned elsewhere): session type/label derivation and session-load states, merging the two new-session composers, redesigning the Active-now tray or security-agent settings screens.
- Item 4's remote-target-hides-picker path is covered by the unit test (no connected remote CLI instance available in the local E2E environment).
