### PR TITLE
fix(cloud-agent): coalesce completion push notifications

### DIFF
--- a/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
+++ b/services/cloud-agent-next/src/session/message-settlement-outbox.test.ts
@@ -305,6 +305,32 @@ describe('MessageSettlementOutbox', () => {
     expect(persisted?.terminalEffects?.push?.disposition).toBe('suppressed');
   });
 
+  it('suppresses only the push effect when requested and does not re-arm it during repair', async () => {
+    const harness = createHarness({ metadata: pushMetadata });
+    await putSessionMessageState(
+      harness.storage,
+      acceptedMessageState(firstMessageId, { url: 'https://example.com/suppressed-push' })
+    );
+
+    await harness.outbox.terminalizeSessionMessageOnce(
+      firstMessageId,
+      { kind: 'completed', completionSource: 'idle_reconciliation' },
+      { suppressPush: true }
+    );
+    await harness.outbox.repairTerminalEffects();
+
+    expect(harness.events).toHaveLength(1);
+    expect(harness.callbackJobs).toHaveLength(1);
+    expect(harness.pushJobs).toEqual([]);
+    await expect(getSessionMessageState(harness.storage, firstMessageId)).resolves.toMatchObject({
+      terminalEffects: {
+        event: 'accounted',
+        callback: { disposition: 'accounted' },
+        push: { disposition: 'suppressed' },
+      },
+    });
+  });
+
   it('keeps terminal persistence successful when report scheduling throws', async () => {
     const storage = createMemoryStorage();
     await putSessionMessageState(storage, acceptedMessageState(firstMessageId));

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.test.ts
@@ -43,6 +43,7 @@ const WRAPPER_RUN_ID = 'wr_supervisor';
 const WRAPPER_CONNECTION_ID = 'conn_supervisor';
 const MESSAGE_ID = 'msg_018f1e2d3c4bSupvMsgAbCdEfG';
 const NEWER_MESSAGE_ID = 'msg_018f1e2d3c4bNewerMsgAbCdEF';
+const NEWEST_MESSAGE_ID = 'msg_018f1e2d3c4bNewestMsgAbCdE';
 const OWNED_WRAPPER_LEASE: [string, unknown] = [
   'wrapper_lease',
   {
@@ -129,6 +130,7 @@ function createHarness(
   const storage = options?.storage ?? createMemoryStorage(initialEntries, options?.storageHooks);
   const events: MessageEvent[] = [];
   const callbackJobs: CallbackJob[] = [];
+  const pushJobs: Array<{ executionId: string; status: string }> = [];
   const sentPings: string[] = [];
   const stops: string[] = [];
   const stopWrappers = vi.fn().mockResolvedValue({ status: 'absent' });
@@ -144,7 +146,10 @@ function createHarness(
         callbackJobs.push(job);
       },
     }),
-    sendPushNotification: async () => ({ dispatched: true }),
+    sendPushNotification: async params => {
+      pushJobs.push({ executionId: params.executionId, status: params.status });
+      return { dispatched: true };
+    },
     hasConnectedStreamClients: () => false,
     getAssistantMessageForUserMessage: () => null,
     ensureTerminalMessageEvent: event => {
@@ -185,6 +190,7 @@ function createHarness(
     storage,
     events,
     callbackJobs,
+    pushJobs,
     sentPings,
     stops,
     stopWrappers,
@@ -1325,6 +1331,141 @@ describe('WrapperSupervisor', () => {
       status: 'completed',
     });
     expect(harness.requestPendingDrainIfNeeded).toHaveBeenCalledOnce();
+  });
+
+  it('coalesces successful sealed batch pushes to the newest admitted message', async () => {
+    const assistantMessageIds = new Map([
+      [MESSAGE_ID, 'ase_batch_oldest'],
+      [NEWER_MESSAGE_ID, 'ase_batch_newer'],
+      [NEWEST_MESSAGE_ID, 'ase_batch_newest'],
+    ]);
+    const harness = createHarness([liveRuntimeState(), OWNED_WRAPPER_LEASE], {
+      metadata: {
+        ...createMetadata(),
+        identity: { ...createMetadata().identity, createdOnPlatform: 'cloud-agent-web' },
+      },
+      getAssistantMessageForUserMessage: (_sessionId, _kiloSessionId, messageId) =>
+        ({
+          info: { id: assistantMessageIds.get(messageId) ?? '', role: 'assistant' },
+          parts: [],
+        }) as unknown as LatestAssistantMessage,
+    });
+    for (const messageId of [MESSAGE_ID, NEWER_MESSAGE_ID, NEWEST_MESSAGE_ID]) {
+      await putSessionMessageState(harness.storage, {
+        ...acceptedMessage(messageId),
+        callbackRequired: true,
+        callbackTarget: { url: `https://example.com/${messageId}` },
+      });
+    }
+
+    await harness.supervisor.onTerminalEvent({
+      wrapperRunId: WRAPPER_RUN_ID,
+      status: 'completed',
+      messageIds: [MESSAGE_ID, NEWER_MESSAGE_ID, NEWEST_MESSAGE_ID],
+    });
+
+    for (const messageId of [MESSAGE_ID, NEWER_MESSAGE_ID, NEWEST_MESSAGE_ID]) {
+      await expect(getSessionMessageState(harness.storage, messageId)).resolves.toMatchObject({
+        status: 'completed',
+        assistantMessageId: assistantMessageIds.get(messageId),
+        completionSource: 'idle_reconciliation',
+      });
+    }
+    expect(harness.events).toHaveLength(3);
+    expect(harness.pushJobs).toEqual([{ executionId: NEWEST_MESSAGE_ID, status: 'completed' }]);
+    expect(harness.callbackJobs).toHaveLength(1);
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      terminalEffects: { push: { disposition: 'suppressed' } },
+    });
+    await expect(getSessionMessageState(harness.storage, NEWER_MESSAGE_ID)).resolves.toMatchObject({
+      terminalEffects: { push: { disposition: 'suppressed' } },
+    });
+
+    await harness.supervisor.onTerminalEvent({
+      wrapperRunId: WRAPPER_RUN_ID,
+      status: 'completed',
+      messageIds: [MESSAGE_ID, NEWER_MESSAGE_ID, NEWEST_MESSAGE_ID],
+    });
+
+    expect(harness.pushJobs).toEqual([{ executionId: NEWEST_MESSAGE_ID, status: 'completed' }]);
+  });
+
+  it('keeps the newest already-completed sealed member as the replay representative', async () => {
+    const harness = createHarness([liveRuntimeState(), OWNED_WRAPPER_LEASE], {
+      getAssistantMessageForUserMessage: (_sessionId, _kiloSessionId, messageId) =>
+        ({
+          info: { id: `ase_${messageId}`, role: 'assistant' },
+          parts: [],
+        }) as unknown as LatestAssistantMessage,
+    });
+    await putSessionMessageState(harness.storage, acceptedMessage(MESSAGE_ID));
+    await putSessionMessageState(harness.storage, {
+      ...acceptedMessage(NEWER_MESSAGE_ID),
+      status: 'completed',
+      terminalAt: 3_000,
+      completionSource: 'idle_reconciliation',
+      terminalEffects: {
+        event: 'accounted',
+        callback: { disposition: 'not-required' },
+        push: { disposition: 'accounted' },
+      },
+    });
+
+    await harness.supervisor.onTerminalEvent({
+      wrapperRunId: WRAPPER_RUN_ID,
+      status: 'completed',
+      messageIds: [MESSAGE_ID, NEWER_MESSAGE_ID],
+    });
+
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      status: 'completed',
+      terminalEffects: { push: { disposition: 'suppressed' } },
+    });
+    expect(harness.pushJobs).toEqual([]);
+  });
+
+  it('keeps failure pushes while coalescing successful sealed batch members', async () => {
+    const harness = createHarness([liveRuntimeState(), OWNED_WRAPPER_LEASE], {
+      metadata: {
+        ...createMetadata(),
+        identity: { ...createMetadata().identity, createdOnPlatform: 'cloud-agent-web' },
+      },
+      getAssistantMessageForUserMessage: (_sessionId, _kiloSessionId, messageId) =>
+        ({
+          info:
+            messageId === NEWEST_MESSAGE_ID
+              ? { id: 'ase_batch_failed', role: 'assistant', error: 'assistant failed' }
+              : { id: `ase_${messageId}`, role: 'assistant' },
+          parts: [],
+        }) as unknown as LatestAssistantMessage,
+    });
+    for (const messageId of [MESSAGE_ID, NEWER_MESSAGE_ID, NEWEST_MESSAGE_ID]) {
+      await putSessionMessageState(harness.storage, acceptedMessage(messageId));
+    }
+
+    await harness.supervisor.onTerminalEvent({
+      wrapperRunId: WRAPPER_RUN_ID,
+      status: 'completed',
+      messageIds: [MESSAGE_ID, NEWER_MESSAGE_ID, NEWEST_MESSAGE_ID],
+    });
+
+    expect(harness.pushJobs).toEqual([
+      { executionId: NEWER_MESSAGE_ID, status: 'completed' },
+      { executionId: NEWEST_MESSAGE_ID, status: 'failed' },
+    ]);
+    await expect(getSessionMessageState(harness.storage, MESSAGE_ID)).resolves.toMatchObject({
+      terminalEffects: { push: { disposition: 'suppressed' } },
+    });
+    await expect(getSessionMessageState(harness.storage, NEWEST_MESSAGE_ID)).resolves.toMatchObject(
+      {
+        status: 'failed',
+        terminalEffects: { push: { disposition: 'accounted' } },
+      }
+    );
+    await expect(getWrapperLease(harness.storage)).resolves.toMatchObject({
+      state: 'stop_needed',
+      reason: 'terminal-failed',
+    });
   });
 
   it('settles current accepted work from a legacy complete without sealed membership', async () => {

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -20,6 +20,7 @@ import {
   listNonTerminalAcceptedMessages,
   type SessionMessageState,
   type SessionMessageStorage,
+  type TerminalizeParams,
 } from './session-message-state.js';
 import type { WrapperTerminalFailureCode } from '../shared/protocol.js';
 import type { LatestAssistantMessage } from './types.js';
@@ -120,6 +121,12 @@ export type WrapperTerminalEvent = {
 
 type SealedBatchSettlementResult = {
   failedTerminalObserved: boolean;
+};
+
+type ProjectedSealedBatchSettlement = {
+  message: SessionMessageState;
+  params?: TerminalizeParams;
+  observeCorrelatedActivity: boolean;
 };
 
 export type WrapperSupervisorStorage = DurableObjectStorage &
@@ -951,56 +958,110 @@ export function createWrapperSupervisor(
     const metadata = await getMetadata();
     if (!metadata) return null;
     const kiloSessionId = metadata.auth.kiloSessionId;
-    let failedTerminalObserved = wrapperRunMessages.some(
-      message =>
-        sealedSet.has(message.messageId) &&
-        (message.status === 'failed' || message.status === 'interrupted')
-    );
-
+    const projectedSettlements: ProjectedSealedBatchSettlement[] = [];
     for (const messageId of sealedMessageIds) {
       const message = wrapperRunMessagesById.get(messageId);
-      if (!message || message.status !== 'accepted') continue;
+      if (!message) continue;
+      if (message.status !== 'accepted') {
+        projectedSettlements.push({ message, observeCorrelatedActivity: false });
+        continue;
+      }
       const assistantMessage = kiloSessionId
         ? getAssistantMessageForUserMessage(metadata.identity.sessionId, kiloSessionId, messageId)
         : null;
       const assistantError = getAssistantErrorMessage(assistantMessage?.info.error);
       if (assistantError !== undefined) {
         const assistantFailure = classifyAssistantFailure(assistantError);
-        failedTerminalObserved = true;
-        await observeCorrelatedAgentActivity?.(messageId);
-        await messageSettlementOutbox.terminalizeSessionMessageOnce(messageId, {
-          kind: 'failed',
-          reason: 'assistant_error',
-          error: assistantError,
-          completionSource: 'idle_reconciliation',
-          failureStage: 'agent_activity',
-          failureCode: assistantFailure.terminalCode ?? 'assistant_error',
-          assistantFailureReason: assistantFailure.reason,
-          providerOwnership: assistantFailure.providerOwnership,
-          safeFailureMessage: assistantFailure.safeMessage,
+        projectedSettlements.push({
+          message,
+          observeCorrelatedActivity: true,
+          params: {
+            kind: 'failed',
+            reason: 'assistant_error',
+            error: assistantError,
+            completionSource: 'idle_reconciliation',
+            failureStage: 'agent_activity',
+            failureCode: assistantFailure.terminalCode ?? 'assistant_error',
+            assistantFailureReason: assistantFailure.reason,
+            providerOwnership: assistantFailure.providerOwnership,
+            safeFailureMessage: assistantFailure.safeMessage,
+          },
         });
       } else if (assistantMessage) {
-        await observeCorrelatedAgentActivity?.(messageId);
-        await messageSettlementOutbox.terminalizeSessionMessageOnce(messageId, {
-          kind: 'completed',
-          assistantMessageId: assistantMessage.info.id,
-          completionSource: 'idle_reconciliation',
+        projectedSettlements.push({
+          message,
+          observeCorrelatedActivity: true,
+          params: {
+            kind: 'completed',
+            assistantMessageId: assistantMessage.info.id,
+            completionSource: 'idle_reconciliation',
+          },
         });
       } else if (!isPromptMessage(message)) {
-        await messageSettlementOutbox.terminalizeSessionMessageOnce(messageId, {
-          kind: 'completed',
-          completionSource: 'idle_reconciliation',
+        projectedSettlements.push({
+          message,
+          observeCorrelatedActivity: false,
+          params: { kind: 'completed', completionSource: 'idle_reconciliation' },
         });
       } else {
-        failedTerminalObserved = true;
-        await messageSettlementOutbox.terminalizeSessionMessageOnce(messageId, {
-          kind: 'failed',
-          reason: 'missing_assistant_reply',
-          error: 'No assistant reply found during wrapper completion',
-          completionSource: 'idle_reconciliation',
-          failureStage: 'post_dispatch_no_activity',
-          failureCode: 'missing_assistant_reply',
+        projectedSettlements.push({
+          message,
+          observeCorrelatedActivity: false,
+          params: {
+            kind: 'failed',
+            reason: 'missing_assistant_reply',
+            error: 'No assistant reply found during wrapper completion',
+            completionSource: 'idle_reconciliation',
+            failureStage: 'post_dispatch_no_activity',
+            failureCode: 'missing_assistant_reply',
+          },
         });
+      }
+    }
+
+    const successfulCompletions = projectedSettlements.filter(
+      settlement =>
+        settlement.message.status === 'completed' || settlement.params?.kind === 'completed'
+    );
+    const representativeMessageId = successfulCompletions.at(-1)?.message.messageId;
+    const failedOrInterruptedCount = projectedSettlements.filter(
+      settlement =>
+        settlement.message.status === 'failed' ||
+        settlement.message.status === 'interrupted' ||
+        settlement.params?.kind === 'failed' ||
+        settlement.params?.kind === 'interrupted'
+    ).length;
+    const failedTerminalObserved = failedOrInterruptedCount > 0;
+
+    if (representativeMessageId) {
+      logger
+        .withFields({
+          wrapperRunId,
+          sealedMessageCount: sealedMessageIds.length,
+          projectedCompletionCount: successfulCompletions.length,
+          suppressedCompletionPushCount: successfulCompletions.length - 1,
+          representativeMessageId,
+          failedOrInterruptedCount,
+        })
+        .info('Selected sealed batch completion push representative');
+    }
+
+    for (const settlement of projectedSettlements) {
+      if (!settlement.params) continue;
+      if (settlement.observeCorrelatedActivity) {
+        await observeCorrelatedAgentActivity?.(settlement.message.messageId);
+      }
+      if (settlement.params.kind === 'completed') {
+        await messageSettlementOutbox.terminalizeSessionMessageOnce(
+          settlement.message.messageId,
+          settlement.params,
+          { suppressPush: settlement.message.messageId !== representativeMessageId }
+        );
+      } else {
+        await messageSettlementOutbox.terminalizeSessionMessageOnce(
+          settlement.message.messageId,
+          settlement.params
+        );
       }
     }
 

--- a/services/cloud-agent-next/test/integration/session/push-notifications.test.ts
+++ b/services/cloud-agent-next/test/integration/session/push-notifications.test.ts
@@ -18,6 +18,8 @@ const INTERRUPTED_MESSAGE_ID = 'msg_018f1e2d3c4bPushIntrptABCD';
 const RETRY_MESSAGE_ID = 'msg_018f1e2d3c4bPushRetryABCDE';
 const MISSING_KILO_SESSION_MESSAGE_ID = 'msg_018f1e2d3c4bPushNoSessionA';
 const SUPPRESSED_MESSAGE_ID = 'msg_018f1e2d3c4bPushSuppressAB';
+const BATCH_OLDER_MESSAGE_ID = 'msg_018f1e2d3c4bBatchOlderMsg1';
+const BATCH_REPRESENTATIVE_MESSAGE_ID = 'msg_018f1e2d3c4bBatchNewestMsg';
 
 async function createSession(userId: string) {
   const sessionId = `agent_${crypto.randomUUID()}`;
@@ -70,10 +72,10 @@ async function seedAssistantText(
   state: DurableObjectState,
   sessionId: string,
   parentMessageId: string,
-  text: string
+  text: string,
+  assistantMessageId = 'msg_push_assistant_response_0001'
 ): Promise<void> {
   const events = createEventQueries(drizzle(state.storage, { logger: false }), state.storage.sql);
-  const assistantMessageId = 'msg_push_assistant_response_0001';
   const timestamp = Date.now();
   events.upsert({
     executionId: 'exc_push',
@@ -152,6 +154,73 @@ describe('CloudAgentSession push notification producer', () => {
           executionId: COMPLETED_MESSAGE_ID,
           status: 'completed',
           body: 'Assistant finished the task.',
+          suppressIfViewingSession: true,
+        },
+      ]);
+  });
+
+  it('dispatches only the unsuppressed representative completion through the outbox binding', async () => {
+    const userId = 'user_push_coalesced_batch';
+    const { sessionId, stub } = await createSession(userId);
+
+    await runInDurableObject(stub, async (instance, state) => {
+      await registerSession(instance, sessionId, userId);
+      await seedAssistantText(
+        state,
+        sessionId,
+        BATCH_OLDER_MESSAGE_ID,
+        'Older assistant reply.',
+        'msg_push_assistant_older'
+      );
+      await seedAssistantText(
+        state,
+        sessionId,
+        BATCH_REPRESENTATIVE_MESSAGE_ID,
+        'Newest assistant reply.',
+        'msg_push_assistant_newest'
+      );
+      await putSessionMessageState(
+        instance.ctx.storage,
+        acceptedMessageState(BATCH_OLDER_MESSAGE_ID)
+      );
+      await putSessionMessageState(
+        instance.ctx.storage,
+        acceptedMessageState(BATCH_REPRESENTATIVE_MESSAGE_ID)
+      );
+      await (instance as any).terminalizeSessionMessageOnce(
+        BATCH_OLDER_MESSAGE_ID,
+        { kind: 'completed', completionSource: 'idle_reconciliation' },
+        { suppressPush: true }
+      );
+      await (instance as any).terminalizeSessionMessageOnce(BATCH_REPRESENTATIVE_MESSAGE_ID, {
+        kind: 'completed',
+        completionSource: 'idle_reconciliation',
+      });
+      await instance.alarm();
+
+      await expect(
+        getSessionMessageState(instance.ctx.storage, BATCH_OLDER_MESSAGE_ID)
+      ).resolves.toMatchObject({
+        status: 'completed',
+        terminalEffects: { push: { disposition: 'suppressed' } },
+      });
+      await expect(
+        getSessionMessageState(instance.ctx.storage, BATCH_REPRESENTATIVE_MESSAGE_ID)
+      ).resolves.toMatchObject({
+        status: 'completed',
+        terminalEffects: { push: { disposition: 'accounted' } },
+      });
+    });
+
+    await expect
+      .poll(() => getNotificationJobs())
+      .toEqual([
+        {
+          userId,
+          cliSessionId: KILO_SESSION_ID,
+          executionId: BATCH_REPRESENTATIVE_MESSAGE_ID,
+          status: 'completed',
+          body: 'Newest assistant reply.',
           suppressIfViewingSession: true,
         },
       ]);

--- a/services/session-ingest/src/ingest/direct-ingest.test.ts
+++ b/services/session-ingest/src/ingest/direct-ingest.test.ts
@@ -66,7 +66,7 @@ function makeReadableStream(bytes: Uint8Array): ReadableStream<Uint8Array> {
 
 function makeRequest(params: {
   items: unknown[];
-  sessionRow: { parentSessionId: string | null } | null;
+  sessionRow: { parentSessionId: string | null; createdOnPlatform?: string | null } | null;
   sessionLookupError?: Error;
   ingest?: ReturnType<typeof vi.fn>;
   sendAgentSessionNotification?: ReturnType<typeof vi.fn>;
@@ -98,7 +98,14 @@ function makeRequest(params: {
   } as never);
 
   const sessionRows =
-    params.sessionRow === null ? [] : [{ parentSessionId: params.sessionRow.parentSessionId }];
+    params.sessionRow === null
+      ? []
+      : [
+          {
+            parentSessionId: params.sessionRow.parentSessionId,
+            createdOnPlatform: params.sessionRow.createdOnPlatform ?? null,
+          },
+        ];
   const limit = vi.fn(async () => {
     if (params.sessionLookupError) throw params.sessionLookupError;
     return sessionRows;
@@ -146,6 +153,44 @@ function makeRequest(params: {
 }
 
 describe('agent_notification direct ingest', () => {
+  it('suppresses completed signals owned by a cloud-agent-web session', async () => {
+    const ingest = vi.fn(async () => ({
+      accepted: true,
+      changes: [],
+      attentionSignals: [{ kind: 'completed' as const, signalId: 'sig_1', messageExcerpt: 'Done' }],
+    }));
+    const { request, hasActiveCliSession, sendCloudAgentSessionNotification } = makeRequest({
+      items: [{ type: 'message', data: { id: 'msg_1' } }],
+      sessionRow: { parentSessionId: null, createdOnPlatform: 'cloud-agent-web' },
+      ingest,
+    });
+
+    const result = await handleDirectIngestRequest(request);
+
+    expect(result.status).toBe(200);
+    expect(hasActiveCliSession).not.toHaveBeenCalled();
+    expect(sendCloudAgentSessionNotification).not.toHaveBeenCalled();
+  });
+
+  it('continues dispatching completed signals for ordinary remote CLI sessions', async () => {
+    const ingest = vi.fn(async () => ({
+      accepted: true,
+      changes: [],
+      attentionSignals: [{ kind: 'completed' as const, signalId: 'sig_1', messageExcerpt: 'Done' }],
+    }));
+    const { request, hasActiveCliSession, sendCloudAgentSessionNotification } = makeRequest({
+      items: [{ type: 'message', data: { id: 'msg_1' } }],
+      sessionRow: { parentSessionId: null, createdOnPlatform: 'cli' },
+      ingest,
+    });
+
+    const result = await handleDirectIngestRequest(request);
+
+    expect(result.status).toBe(200);
+    expect(hasActiveCliSession).toHaveBeenCalledWith('ses_agent');
+    expect(sendCloudAgentSessionNotification).toHaveBeenCalledOnce();
+  });
+
   it('dispatches a valid agent_notification and marks it dispatched', async () => {
     const { request, sendAgentSessionNotification, markAgentNotificationDispatched } = makeRequest({
       items: [{ type: 'agent_notification', data: { id: 'note_1', message: 'Build done' } }],

--- a/services/session-ingest/src/ingest/direct-ingest.ts
+++ b/services/session-ingest/src/ingest/direct-ingest.ts
@@ -423,6 +423,7 @@ async function runDirectPostCommitTasks(
       const [session] = await db
         .select({
           parentSessionId: cli_sessions_v2.parent_session_id,
+          createdOnPlatform: cli_sessions_v2.created_on_platform,
         })
         .from(cli_sessions_v2)
         .where(
@@ -437,7 +438,12 @@ async function runDirectPostCommitTasks(
         for (const signal of legacySignals) {
           try {
             await dispatchRemoteSessionAttentionSignal(
-              { kiloUserId: request.kiloUserId, sessionId: request.sessionId, signal },
+              {
+                kiloUserId: request.kiloUserId,
+                sessionId: request.sessionId,
+                createdOnPlatform: session.createdOnPlatform,
+                signal,
+              },
               {
                 hasActiveCliSession: () => userConnection.hasActiveCliSession(request.sessionId),
                 sendPush: pushParams =>

--- a/services/session-ingest/src/queue-consumer.test.ts
+++ b/services/session-ingest/src/queue-consumer.test.ts
@@ -1124,7 +1124,7 @@ describe('remote session attention notifications', () => {
   const attentionSignal = { signalId: 'msg_1', kind: 'completed', messageExcerpt: 'All done' };
 
   function setUpAttentionTest(params: {
-    sessionRow: { parent_session_id: string | null };
+    sessionRow: { parent_session_id: string | null; created_on_platform?: string | null };
     activeCliSession?: boolean;
     ingest?: ReturnType<typeof vi.fn>;
     stagedItems?: unknown[];
@@ -1199,9 +1199,9 @@ describe('remote session attention notifications', () => {
     return { ack, retry };
   }
 
-  it.skip('dispatches a push notification for an active root session', async () => {
+  it('dispatches a push notification for an active ordinary remote CLI root session', async () => {
     const { env, hasActiveCliSession, sendCloudAgentSessionNotification } = setUpAttentionTest({
-      sessionRow: { parent_session_id: null },
+      sessionRow: { parent_session_id: null, created_on_platform: 'cli' },
       activeCliSession: true,
     });
 
@@ -1219,7 +1219,7 @@ describe('remote session attention notifications', () => {
     });
   });
 
-  it.skip('suppresses the push when no active CLI owns the root session', async () => {
+  it('suppresses the push when no active CLI owns the root session', async () => {
     const { env, hasActiveCliSession, sendCloudAgentSessionNotification } = setUpAttentionTest({
       sessionRow: { parent_session_id: null },
       activeCliSession: false,
@@ -1228,6 +1228,18 @@ describe('remote session attention notifications', () => {
     await runAttentionQueue(env);
 
     expect(hasActiveCliSession).toHaveBeenCalledWith('ses_remote');
+    expect(sendCloudAgentSessionNotification).not.toHaveBeenCalled();
+  });
+
+  it('suppresses cloud-agent-web completed signals before checking active CLI state', async () => {
+    const { env, hasActiveCliSession, sendCloudAgentSessionNotification } = setUpAttentionTest({
+      sessionRow: { parent_session_id: null, created_on_platform: 'cloud-agent-web' },
+      activeCliSession: true,
+    });
+
+    await runAttentionQueue(env);
+
+    expect(hasActiveCliSession).not.toHaveBeenCalled();
     expect(sendCloudAgentSessionNotification).not.toHaveBeenCalled();
   });
 

--- a/services/session-ingest/src/queue-consumer.ts
+++ b/services/session-ingest/src/queue-consumer.ts
@@ -87,6 +87,7 @@ async function processMessage(
 type IngestSessionRow = {
   session_id: string;
   parent_session_id: string | null;
+  created_on_platform: string | null;
 };
 
 /**
@@ -105,6 +106,7 @@ async function loadSessionOrCleanupStaging(
     .select({
       session_id: cli_sessions_v2.session_id,
       parent_session_id: cli_sessions_v2.parent_session_id,
+      created_on_platform: cli_sessions_v2.created_on_platform,
     })
     .from(cli_sessions_v2)
     .where(
@@ -370,10 +372,17 @@ function scheduleAttentionSignalDispatch(
           kiloUserId: msg.kiloUserId,
           sessionId: msg.sessionId,
         });
-        await dispatchRemoteSessionAttentionSignals(env, msg.kiloUserId, msg.sessionId, signals, {
-          markAgentNotificationDispatched: (notificationId: string) =>
-            sessionDO.markAgentNotificationDispatched(notificationId),
-        });
+        await dispatchRemoteSessionAttentionSignals(
+          env,
+          msg.kiloUserId,
+          msg.sessionId,
+          sessionRow.created_on_platform,
+          signals,
+          {
+            markAgentNotificationDispatched: (notificationId: string) =>
+              sessionDO.markAgentNotificationDispatched(notificationId),
+          }
+        );
       } catch (error) {
         console.error('Failed to dispatch remote session attention signals (non-fatal)', {
           sessionId: msg.sessionId,
@@ -412,6 +421,7 @@ async function dispatchRemoteSessionAttentionSignals(
   env: Env,
   kiloUserId: string,
   sessionId: string,
+  createdOnPlatform: string | null,
   signals: AttentionSignal[],
   deps: {
     markAgentNotificationDispatched: (notificationId: string) => unknown;
@@ -428,7 +438,7 @@ async function dispatchRemoteSessionAttentionSignals(
   for (const signal of legacySignals) {
     try {
       await dispatchRemoteSessionAttentionSignal(
-        { kiloUserId, sessionId, signal },
+        { kiloUserId, sessionId, createdOnPlatform, signal },
         {
           hasActiveCliSession: async () => {
             const stub = getUserConnectionDO(env, { kiloUserId });

--- a/services/session-ingest/src/remote-session-notifications.test.ts
+++ b/services/session-ingest/src/remote-session-notifications.test.ts
@@ -52,7 +52,7 @@ describe('dispatchRemoteSessionAttentionSignal', () => {
     const sendPush = vi.fn(async () => ({ dispatched: true }));
     const signal = completedSignal('Done');
     const outcome = await dispatchRemoteSessionAttentionSignal(
-      { kiloUserId: 'usr_1', sessionId: 'ses_1', signal },
+      { kiloUserId: 'usr_1', sessionId: 'ses_1', createdOnPlatform: null, signal },
       {
         hasActiveCliSession,
         sendPush,
@@ -76,7 +76,12 @@ describe('dispatchRemoteSessionAttentionSignal', () => {
     const hasActiveCliSession = vi.fn(async () => false);
     const sendPush = vi.fn(async () => ({ dispatched: true }));
     const outcome = await dispatchRemoteSessionAttentionSignal(
-      { kiloUserId: 'usr_1', sessionId: 'ses_1', signal: completedSignal('Done') },
+      {
+        kiloUserId: 'usr_1',
+        sessionId: 'ses_1',
+        createdOnPlatform: null,
+        signal: completedSignal('Done'),
+      },
       {
         hasActiveCliSession,
         sendPush,
@@ -96,7 +101,12 @@ describe('dispatchRemoteSessionAttentionSignal', () => {
     const sendPush = vi.fn(async () => ({ dispatched: true }));
     const sendAgentSessionNotification = vi.fn(async () => ({ dispatched: true }));
     const outcome = await dispatchRemoteSessionAttentionSignal(
-      { kiloUserId: 'usr_1', sessionId: 'ses_1', signal: agentNotificationSignal('Build done') },
+      {
+        kiloUserId: 'usr_1',
+        sessionId: 'ses_1',
+        createdOnPlatform: 'cloud-agent-web',
+        signal: agentNotificationSignal('Build done'),
+      },
       { hasActiveCliSession, sendPush, sendAgentSessionNotification }
     );
 
@@ -120,7 +130,12 @@ describe('dispatchRemoteSessionAttentionSignal', () => {
     });
     await expect(
       dispatchRemoteSessionAttentionSignal(
-        { kiloUserId: 'usr_1', sessionId: 'ses_1', signal: agentNotificationSignal('hi') },
+        {
+          kiloUserId: 'usr_1',
+          sessionId: 'ses_1',
+          createdOnPlatform: 'cloud-agent-web',
+          signal: agentNotificationSignal('hi'),
+        },
         { hasActiveCliSession, sendPush, sendAgentSessionNotification }
       )
     ).rejects.toThrow('transport down');
@@ -136,8 +151,77 @@ describe('dispatchRemoteSessionAttentionSignal', () => {
       })
     );
     const outcome = await dispatchRemoteSessionAttentionSignal(
-      { kiloUserId: 'usr_1', sessionId: 'ses_1', signal: agentNotificationSignal('hi') },
+      {
+        kiloUserId: 'usr_1',
+        sessionId: 'ses_1',
+        createdOnPlatform: 'cloud-agent-web',
+        signal: agentNotificationSignal('hi'),
+      },
       { hasActiveCliSession, sendPush, sendAgentSessionNotification }
+    );
+
+    expect(outcome).toBe('suppressed');
+  });
+
+  it('suppresses cloud-agent-web completed signals before checking active CLI state', async () => {
+    const hasActiveCliSession = vi.fn(async () => true);
+    const sendPush = vi.fn(async () => ({ dispatched: true }));
+
+    const outcome = await dispatchRemoteSessionAttentionSignal(
+      {
+        kiloUserId: 'usr_1',
+        sessionId: 'ses_1',
+        createdOnPlatform: 'cloud-agent-web',
+        signal: completedSignal('Done'),
+      },
+      {
+        hasActiveCliSession,
+        sendPush,
+        sendAgentSessionNotification: vi.fn(async () => ({ dispatched: true })),
+      }
+    );
+
+    expect(outcome).toBe('suppressed');
+    expect(hasActiveCliSession).not.toHaveBeenCalled();
+    expect(sendPush).not.toHaveBeenCalled();
+  });
+
+  it('still sends cloud-agent-web needs-input signals when the CLI is active', async () => {
+    const hasActiveCliSession = vi.fn(async () => true);
+    const sendPush = vi.fn(async () => ({ dispatched: true }));
+
+    const outcome = await dispatchRemoteSessionAttentionSignal(
+      {
+        kiloUserId: 'usr_1',
+        sessionId: 'ses_1',
+        createdOnPlatform: 'cloud-agent-web',
+        signal: needsInputSignal(),
+      },
+      {
+        hasActiveCliSession,
+        sendPush,
+        sendAgentSessionNotification: vi.fn(async () => ({ dispatched: true })),
+      }
+    );
+
+    expect(outcome).toBe('sent');
+    expect(hasActiveCliSession).toHaveBeenCalledOnce();
+    expect(sendPush).toHaveBeenCalledOnce();
+  });
+
+  it('returns suppressed when the notifications service declines a legacy push', async () => {
+    const outcome = await dispatchRemoteSessionAttentionSignal(
+      {
+        kiloUserId: 'usr_1',
+        sessionId: 'ses_1',
+        createdOnPlatform: 'unknown',
+        signal: completedSignal('Done'),
+      },
+      {
+        hasActiveCliSession: vi.fn(async () => true),
+        sendPush: vi.fn(async () => ({ dispatched: false, reason: 'missing_session' }) as const),
+        sendAgentSessionNotification: vi.fn(async () => ({ dispatched: true })),
+      }
     );
 
     expect(outcome).toBe('suppressed');

--- a/services/session-ingest/src/remote-session-notifications.ts
+++ b/services/session-ingest/src/remote-session-notifications.ts
@@ -53,48 +53,83 @@ export type DispatchRemoteSessionAttentionOutcome = 'sent' | 'suppressed';
  * `isEligibleForRemoteSessionAttention` for the owning session.
  */
 export async function dispatchRemoteSessionAttentionSignal(
-  params: { kiloUserId: string; sessionId: string; signal: AttentionSignal },
+  params: {
+    kiloUserId: string;
+    sessionId: string;
+    createdOnPlatform: string | null;
+    signal: AttentionSignal;
+  },
   deps: DispatchRemoteSessionAttentionDeps
 ): Promise<DispatchRemoteSessionAttentionOutcome> {
+  const signal = params.signal;
   // §4.3: `agent_notification` signals are an explicit `notify_user` tool call. The user
   // asked for the ping, and a headless `kilo run` may exit right after emitting it — neither
   // the per-user rollout gate nor the live-CLI gate must apply, or this single notification
   // the user explicitly requested would silently be lost. Root-session eligibility is still
   // enforced one level up by the caller, and presence-suppression is handled downstream by
   // the notifications service.
-  if (params.signal.kind === 'agent_notification') {
+  if (signal.kind === 'agent_notification') {
     const result = await deps.sendAgentSessionNotification({
       userId: params.kiloUserId,
       cliSessionId: params.sessionId,
-      notificationId: params.signal.notificationId,
-      message: params.signal.message,
+      notificationId: signal.notificationId,
+      message: signal.message,
     });
     console.log({
       event: 'agent_push_outcome',
       cliSessionId: params.sessionId,
-      notificationId: params.signal.notificationId,
+      notificationId: signal.notificationId,
       outcome: result.dispatched ? 'dispatched' : (result.reason ?? 'failed'),
     });
     return result.dispatched ? 'sent' : 'suppressed';
   }
 
-  // Legacy attention pushes (completed / needs_input) remain gated behind the live-CLI
-  // presence check.
-  if (!(await deps.hasActiveCliSession())) {
+  if (signal.kind === 'completed' && params.createdOnPlatform === 'cloud-agent-web') {
+    logLegacyAttentionOutcome(params, signal, 'suppressed_cloud_agent_completion_owner');
     return 'suppressed';
   }
 
-  await deps.sendPush({
+  // Legacy attention pushes (completed / needs_input) remain gated behind the live-CLI
+  // presence check.
+  if (!(await deps.hasActiveCliSession())) {
+    logLegacyAttentionOutcome(params, signal, 'suppressed_no_active_cli');
+    return 'suppressed';
+  }
+
+  const result = await deps.sendPush({
     userId: params.kiloUserId,
     cliSessionId: params.sessionId,
-    executionId: `remote:${params.signal.signalId}`,
+    executionId: `remote:${signal.signalId}`,
     // The push status enum has no needs_input value and the notifications service ignores
     // status when building the push — the body carries the real semantics. Extending the
     // enum would fail validation on a notifications worker deployed with the old schema.
     status: 'completed',
-    body: buildRemoteSessionAttentionPushBody(params.signal),
+    body: buildRemoteSessionAttentionPushBody(signal),
     suppressIfViewingSession: true,
   });
 
-  return 'sent';
+  logLegacyAttentionOutcome(
+    params,
+    signal,
+    result.dispatched ? 'dispatched' : (result.reason ?? 'failed')
+  );
+  return result.dispatched ? 'sent' : 'suppressed';
+}
+
+function logLegacyAttentionOutcome(
+  params: {
+    sessionId: string;
+    createdOnPlatform: string | null;
+  },
+  signal: ExcerptAttentionSignal,
+  outcome: string
+): void {
+  console.log({
+    event: 'remote_session_attention_outcome',
+    sessionId: params.sessionId,
+    signalId: signal.signalId,
+    signalKind: signal.kind,
+    createdOnPlatform: params.createdOnPlatform,
+    outcome,
+  });
 }


### PR DESCRIPTION
## Summary

- Coalesce successful completion pushes from one sealed Cloud Agent wrapper batch to its newest successful message, while preserving each message's terminal state, events, callbacks, and failure/interruption notifications.
- Keep Cloud Agent's durable terminal outbox as the completion-push owner and suppress the parallel session-ingest `completed` producer only for exact `cloud-agent-web` sessions.
- Propagate the session origin through direct and queued ingest so ordinary remote CLI completion notifications, Cloud Agent `needs_input`, and explicit agent notifications remain unchanged.

## Visual Changes

N/A

## Reviewer Notes

- Review the deterministic reverse sealed-order representative selection, including replay behavior when the representative is already terminal.
- Failure and interruption pushes are intentionally not coalesced. Session-ingest fails open for legacy or non-`cloud-agent-web` origins.