### PR TITLE
fix(db): keep read replica local reads on primary

### DIFF
--- a/apps/web/src/lib/drizzle.test.ts
+++ b/apps/web/src/lib/drizzle.test.ts
@@ -1,4 +1,4 @@
-import { pool, db } from '@/lib/drizzle';
+import { pool, db, selectReplicaUrl } from '@/lib/drizzle';
 
 describe('drizzle', () => {
   describe('pool', () => {
@@ -13,5 +13,62 @@ describe('drizzle', () => {
   it('should use application name', async () => {
     const res = await db.execute("SELECT current_setting('application_name')");
     expect(res.rows[0].current_setting).toBe('kilocode-web');
+  });
+
+  describe('replica selection', () => {
+    const primaryUrl = 'postgres://primary';
+
+    it('uses the primary outside Vercel even when replicas are configured', () => {
+      expect(
+        selectReplicaUrl({
+          primaryUrl,
+          vercelRegion: undefined,
+          usReplicaUrl: 'postgres://us-replica',
+          euReplicaUrls: ['postgres://eu-replica'],
+        })
+      ).toBe(primaryUrl);
+    });
+
+    it('uses the US replica in a US Vercel region', () => {
+      expect(
+        selectReplicaUrl({
+          primaryUrl,
+          vercelRegion: 'iad1',
+          usReplicaUrl: 'postgres://us-replica',
+          euReplicaUrls: ['postgres://eu-replica'],
+        })
+      ).toBe('postgres://us-replica');
+    });
+
+    it('selects between EU replicas in an EU Vercel region', () => {
+      expect(
+        selectReplicaUrl({
+          primaryUrl,
+          vercelRegion: 'fra1',
+          usReplicaUrl: 'postgres://us-replica',
+          euReplicaUrls: ['postgres://eu-1', 'postgres://eu-2'],
+          random: () => 0.75,
+        })
+      ).toBe('postgres://eu-2');
+    });
+
+    it('falls back to the primary when the regional replica is unavailable', () => {
+      expect(
+        selectReplicaUrl({
+          primaryUrl,
+          vercelRegion: 'iad1',
+          usReplicaUrl: undefined,
+          euReplicaUrls: ['postgres://eu-replica'],
+        })
+      ).toBe(primaryUrl);
+      expect(
+        selectReplicaUrl({
+          primaryUrl,
+          vercelRegion: 'fra1',
+          usReplicaUrl: 'postgres://us-replica',
+          euReplicaUrls: [],
+        })
+      ).toBe(primaryUrl);
+    });
   });
 });

--- a/apps/web/src/lib/drizzle.test.ts
+++ b/apps/web/src/lib/drizzle.test.ts
@@ -18,10 +18,11 @@ describe('drizzle', () => {
   describe('replica selection', () => {
     const primaryUrl = 'postgres://primary';
 
-    it('uses the primary outside Vercel even when replicas are configured', () => {
+    it('uses the primary in local development even when replicas are configured', () => {
       expect(
         selectReplicaUrl({
           primaryUrl,
+          nodeEnv: 'development',
           vercelRegion: undefined,
           usReplicaUrl: 'postgres://us-replica',
           euReplicaUrls: ['postgres://eu-replica'],
@@ -29,10 +30,24 @@ describe('drizzle', () => {
       ).toBe(primaryUrl);
     });
 
+    it('preserves EU replica selection for regionless non-development processes', () => {
+      expect(
+        selectReplicaUrl({
+          primaryUrl,
+          nodeEnv: 'production',
+          vercelRegion: undefined,
+          usReplicaUrl: 'postgres://us-replica',
+          euReplicaUrls: ['postgres://eu-replica'],
+          random: () => 0,
+        })
+      ).toBe('postgres://eu-replica');
+    });
+
     it('uses the US replica in a US Vercel region', () => {
       expect(
         selectReplicaUrl({
           primaryUrl,
+          nodeEnv: 'production',
           vercelRegion: 'iad1',
           usReplicaUrl: 'postgres://us-replica',
           euReplicaUrls: ['postgres://eu-replica'],
@@ -44,6 +59,7 @@ describe('drizzle', () => {
       expect(
         selectReplicaUrl({
           primaryUrl,
+          nodeEnv: 'production',
           vercelRegion: 'fra1',
           usReplicaUrl: 'postgres://us-replica',
           euReplicaUrls: ['postgres://eu-1', 'postgres://eu-2'],
@@ -56,6 +72,7 @@ describe('drizzle', () => {
       expect(
         selectReplicaUrl({
           primaryUrl,
+          nodeEnv: 'production',
           vercelRegion: 'iad1',
           usReplicaUrl: undefined,
           euReplicaUrls: ['postgres://eu-replica'],
@@ -64,6 +81,7 @@ describe('drizzle', () => {
       expect(
         selectReplicaUrl({
           primaryUrl,
+          nodeEnv: 'production',
           vercelRegion: 'fra1',
           usReplicaUrl: 'postgres://us-replica',
           euReplicaUrls: [],

--- a/apps/web/src/lib/drizzle.ts
+++ b/apps/web/src/lib/drizzle.ts
@@ -5,8 +5,13 @@ import { sql as drizzleSql } from 'drizzle-orm';
 import assert from 'node:assert';
 import { attachDatabasePool } from '@vercel/functions';
 export const { Client, Pool } = pg;
-const { POSTGRES_CONNECT_TIMEOUT, POSTGRES_MAX_QUERY_TIME, DEBUG_QUERY_LOGGING, VERCEL_REGION } =
-  process.env;
+const {
+  POSTGRES_CONNECT_TIMEOUT,
+  POSTGRES_MAX_QUERY_TIME,
+  DEBUG_QUERY_LOGGING,
+  VERCEL_REGION,
+  NODE_ENV,
+} = process.env;
 
 const POSTGRES_URL = getEnvVariable('POSTGRES_URL');
 
@@ -41,18 +46,20 @@ export function isUSRegion(region = VERCEL_REGION): boolean {
 
 export function selectReplicaUrl({
   primaryUrl,
+  nodeEnv,
   vercelRegion,
   usReplicaUrl,
   euReplicaUrls,
   random = Math.random,
 }: {
   primaryUrl: string;
+  nodeEnv: string | undefined;
   vercelRegion: string | undefined;
   usReplicaUrl: string | undefined;
   euReplicaUrls: string[];
   random?: () => number;
 }): string {
-  if (!vercelRegion) return primaryUrl;
+  if (nodeEnv === 'development') return primaryUrl;
   if (isUSRegion(vercelRegion)) return usReplicaUrl || primaryUrl;
   if (euReplicaUrls.length === 0) return primaryUrl;
   return euReplicaUrls.at(Math.floor(random() * euReplicaUrls.length)) ?? primaryUrl;
@@ -66,9 +73,10 @@ export function selectReplicaUrl({
  * - Falls back to primary if no replica URL is configured for the region
  */
 function getReplicaUrl(): string {
-  if (!VERCEL_REGION) return postgresUrl;
+  if (NODE_ENV === 'development') return postgresUrl;
   return selectReplicaUrl({
     primaryUrl: postgresUrl,
+    nodeEnv: NODE_ENV,
     vercelRegion: VERCEL_REGION,
     usReplicaUrl: getEnvVariable('POSTGRES_REPLICA_US_URL'),
     euReplicaUrls: [

--- a/apps/web/src/lib/drizzle.ts
+++ b/apps/web/src/lib/drizzle.ts
@@ -29,14 +29,33 @@ if (IS_SCRIPT) {
 
 const appName = IS_SCRIPT ? 'kilocode-script' : 'kilocode-web';
 
-export function isUSRegion(): boolean {
-  if (!VERCEL_REGION) return false;
+export function isUSRegion(region = VERCEL_REGION): boolean {
+  if (!region) return false;
   return (
-    VERCEL_REGION.startsWith('sfo') ||
-    VERCEL_REGION.startsWith('iad') ||
-    VERCEL_REGION.startsWith('pdx') ||
-    VERCEL_REGION.startsWith('cle')
+    region.startsWith('sfo') ||
+    region.startsWith('iad') ||
+    region.startsWith('pdx') ||
+    region.startsWith('cle')
   );
+}
+
+export function selectReplicaUrl({
+  primaryUrl,
+  vercelRegion,
+  usReplicaUrl,
+  euReplicaUrls,
+  random = Math.random,
+}: {
+  primaryUrl: string;
+  vercelRegion: string | undefined;
+  usReplicaUrl: string | undefined;
+  euReplicaUrls: string[];
+  random?: () => number;
+}): string {
+  if (!vercelRegion) return primaryUrl;
+  if (isUSRegion(vercelRegion)) return usReplicaUrl || primaryUrl;
+  if (euReplicaUrls.length === 0) return primaryUrl;
+  return euReplicaUrls.at(Math.floor(random() * euReplicaUrls.length)) ?? primaryUrl;
 }
 
 /**
@@ -47,20 +66,16 @@ export function isUSRegion(): boolean {
  * - Falls back to primary if no replica URL is configured for the region
  */
 function getReplicaUrl(): string {
-  if (isUSRegion()) {
-    const usReplica = getEnvVariable('POSTGRES_REPLICA_US_URL');
-    if (usReplica) return usReplica;
-  } else {
-    const euReplicas = [
+  if (!VERCEL_REGION) return postgresUrl;
+  return selectReplicaUrl({
+    primaryUrl: postgresUrl,
+    vercelRegion: VERCEL_REGION,
+    usReplicaUrl: getEnvVariable('POSTGRES_REPLICA_US_URL'),
+    euReplicaUrls: [
       getEnvVariable('POSTGRES_REPLICA_EU_URL'),
       getEnvVariable('POSTGRES_REPLICA_EU_URL_2'),
-    ].filter(Boolean) as string[];
-    if (euReplicas.length > 0) {
-      return euReplicas[Math.floor(Math.random() * euReplicas.length)];
-    }
-  }
-
-  return postgresUrl;
+    ].filter(Boolean) as string[],
+  });
 }
 
 // 48h of production pool metrics show most instances use 2-5 connections with zero


### PR DESCRIPTION
## Summary

- Make `readDb` use the configured primary connection only when `NODE_ENV=development`, even if replica environment variables exist locally.
- Preserve all non-development behavior, including regionless EU-replica selection, regional US/EU selection, and primary fallback when a regional replica is unavailable.
- Extract replica selection into a pure helper with deterministic local-development, regionless production, US, EU, and fallback regression coverage.

## Verification

- [x] Focused `drizzle.test.ts`: development resolves to primary with replica URLs configured.
- [x] Focused `drizzle.test.ts`: regionless production preserves EU-replica selection.
- [x] Focused `drizzle.test.ts`: US Vercel region selects the US replica.
- [x] Focused `drizzle.test.ts`: EU Vercel region selects between EU replicas.
- [x] Focused `drizzle.test.ts`: missing regional replicas fall back to primary.

## Visual Changes

None.

## Reviewer Notes

- This does not add or change environment variables.
- `getReplicaUrl()` returns before reading replica variables only in explicit development mode.
- Production, test, script, and unknown deployment behavior remains unchanged unless they explicitly set `NODE_ENV=development`.
- Automated checks: 7 focused database-client tests, full `apps/web` typecheck, focused oxlint, `pnpm format`, and `git diff --check`.
