### PR TITLE
fix(kilo-pass): keep bonus threshold reachable

### DIFF
--- a/.specs/kilo-pass.md
+++ b/.specs/kilo-pass.md
@@ -146,9 +146,10 @@ with welcome-promo overrides. Yearly subscriptions use a flat 50% monthly bonus.
 10. Stripe yearly subscriptions MUST receive an initial monthly base grant from invoice handling and later monthly base
     grants from the yearly monthly-base cron. The cron processes Stripe rows only.
 11. Base credits for a subscription and issue month MUST be issued at most once through the normal issuance path.
-12. A successful qualifying base grant MUST overwrite the user-global threshold with cumulative user usage plus the
-    configured monthly base amount. The threshold belongs to the user, not to one subscription or issuance. A later
-    qualifying base grant MAY replace an earlier threshold.
+12. A successful qualifying base grant MUST overwrite the user-global threshold with the lesser of cumulative user
+    usage plus the configured monthly base amount and total acquired credits after the grant. This keeps the effective
+    threshold reachable when the pre-grant balance is negative. The threshold belongs to the user, not to one
+    subscription or issuance. A later qualifying base grant MAY replace an earlier threshold.
 
 ### Monthly Ramp and Welcome Promo
 

--- a/apps/web/src/lib/kilo-pass/issuance.test.ts
+++ b/apps/web/src/lib/kilo-pass/issuance.test.ts
@@ -45,6 +45,7 @@ import {
 } from './subscription-accounting';
 
 import { KILO_PASS_TIER_CONFIG } from './constants';
+import { getEffectiveKiloPassThreshold } from './threshold';
 
 async function createTestSubscription(params: {
   kiloUserId: string;
@@ -260,21 +261,65 @@ test('computeMonthlyKiloPassStreak counts consecutive issuance months', async ()
   });
 });
 
-test('updateKiloPassThresholdAfterBaseCredits anchors threshold to current usage plus base amount', async () => {
-  const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 123 });
+test.each([
+  [KiloPassTier.Tier19, KiloPassCadence.Monthly],
+  [KiloPassTier.Tier49, KiloPassCadence.Monthly],
+  [KiloPassTier.Tier199, KiloPassCadence.Monthly],
+  [KiloPassTier.Tier19, KiloPassCadence.Yearly],
+  [KiloPassTier.Tier49, KiloPassCadence.Yearly],
+  [KiloPassTier.Tier199, KiloPassCadence.Yearly],
+] as const)(
+  'updateKiloPassThresholdAfterBaseCredits keeps %s %s grants reachable',
+  async (tier, _cadence) => {
+    const baseMicrodollars = KILO_PASS_TIER_CONFIG[tier].monthlyPriceUsd * 1_000_000;
+    const openingBalances = [
+      ['positive', 2_000_000],
+      ['zero', 0],
+      ['between zero and -$1', -500_000],
+      ['below -$1', -2_000_000],
+      ['very large negative', -1_000_000_000],
+    ] as const;
 
-  await db.transaction(async tx => {
-    await updateKiloPassThresholdAfterBaseCredits(tx, {
-      kiloUserId: user.id,
-      baseAmountUsd: 19,
-    });
-  });
+    for (const [_balanceName, openingBalance] of openingBalances) {
+      const openingAcquired = 2_000_000_000;
+      const openingUsed = openingAcquired - openingBalance;
+      const user = await insertTestUser({
+        total_microdollars_acquired: openingAcquired,
+        microdollars_used: openingUsed,
+      });
 
-  const updatedUser = await db.query.kilocode_users.findFirst({
-    where: eq(kilocode_users.id, user.id),
-  });
-  expect(updatedUser?.kilo_pass_threshold).toBe(19_000_000 + 123);
-});
+      // Simulate the just-issued base-credit transaction before setting its threshold.
+      const postGrantAcquired = openingAcquired + baseMicrodollars;
+      await db
+        .update(kilocode_users)
+        .set({ total_microdollars_acquired: postGrantAcquired })
+        .where(eq(kilocode_users.id, user.id));
+
+      for (let issuance = 0; issuance < 2; issuance += 1) {
+        await db.transaction(async tx => {
+          await updateKiloPassThresholdAfterBaseCredits(tx, {
+            kiloUserId: user.id,
+            baseAmountUsd: KILO_PASS_TIER_CONFIG[tier].monthlyPriceUsd,
+          });
+        });
+      }
+
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, user.id),
+      });
+      const expectedThreshold = Math.min(openingUsed + baseMicrodollars, postGrantAcquired);
+      expect(updatedUser?.kilo_pass_threshold).toBe(expectedThreshold);
+
+      const effectiveThreshold = getEffectiveKiloPassThreshold(
+        updatedUser?.kilo_pass_threshold ?? null
+      );
+      expect(effectiveThreshold).not.toBeNull();
+      if (effectiveThreshold === null) throw new Error('Expected a Kilo Pass threshold');
+      expect(effectiveThreshold).toBeLessThan(postGrantAcquired);
+      expect(postGrantAcquired - effectiveThreshold).toBeGreaterThanOrEqual(1_000_000);
+    }
+  }
+);
 
 test('createOrGetIssuanceHeader throws if the same stripeInvoiceId is reused for a different subscription/month', async () => {
   const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });

--- a/apps/web/src/lib/kilo-pass/store-subscription-completion.test.ts
+++ b/apps/web/src/lib/kilo-pass/store-subscription-completion.test.ts
@@ -14,6 +14,7 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 import { getMonthlyPriceUsd } from './bonus';
 import { KiloPassCadence, KiloPassIssuanceItemKind, KiloPassTier } from './enums';
 import { KiloPassIssuanceSource, KiloPassPaymentProvider } from './enums';
+import { getEffectiveKiloPassThreshold } from './threshold';
 import {
   completeStoreKiloPassPurchase,
   type ValidatedStoreKiloPassPurchase,
@@ -103,6 +104,19 @@ describe('completeStoreKiloPassPurchase', () => {
       .from(credit_transactions)
       .where(eq(credit_transactions.id, items[0]?.creditTransactionId ?? ''));
     expect(creditRows[0]?.amountMicrodollars).toBe(49_000_000);
+
+    const [updatedUser] = await db
+      .select({
+        totalMicrodollarsAcquired: kilocode_users.total_microdollars_acquired,
+        threshold: kilocode_users.kilo_pass_threshold,
+      })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, user.id));
+    const effectiveThreshold = getEffectiveKiloPassThreshold(updatedUser?.threshold ?? null);
+    expect(effectiveThreshold).toBe(48_000_000);
+    expect(
+      (updatedUser?.totalMicrodollarsAcquired ?? 0) - (effectiveThreshold ?? 0)
+    ).toBeGreaterThanOrEqual(1_000_000);
   });
 
   it('returns idempotently when the same provider transaction is replayed by the same user', async () => {
@@ -425,10 +439,15 @@ describe('completeStoreKiloPassPurchase', () => {
     ]);
 
     const [updatedUser] = await db
-      .select({ totalMicrodollarsAcquired: kilocode_users.total_microdollars_acquired })
+      .select({
+        totalMicrodollarsAcquired: kilocode_users.total_microdollars_acquired,
+        threshold: kilocode_users.kilo_pass_threshold,
+      })
       .from(kilocode_users)
       .where(eq(kilocode_users.id, user.id));
     expect(updatedUser?.totalMicrodollarsAcquired).toBe(58_500_000);
+    expect(updatedUser?.threshold).toBe(49_000_000);
+    expect(getEffectiveKiloPassThreshold(updatedUser?.threshold ?? null)).toBe(48_000_000);
     expect(creditRows.reduce((sum, row) => sum + row.amountMicrodollars, 0)).toBe(58_500_000);
   });
 
@@ -602,6 +621,10 @@ describe('completeStoreKiloPassPurchase', () => {
         bonus_percent_applied: 0.25,
       },
     ]);
+    await db
+      .update(kilocode_users)
+      .set({ microdollars_used: 20_000_000 })
+      .where(eq(kilocode_users.id, user.id));
 
     await completeStoreKiloPassPurchase({
       user,
@@ -646,10 +669,15 @@ describe('completeStoreKiloPassPurchase', () => {
     );
 
     const [updatedUser] = await db
-      .select({ totalMicrodollarsAcquired: kilocode_users.total_microdollars_acquired })
+      .select({
+        totalMicrodollarsAcquired: kilocode_users.total_microdollars_acquired,
+        threshold: kilocode_users.kilo_pass_threshold,
+      })
       .from(kilocode_users)
       .where(eq(kilocode_users.id, user.id));
     expect(updatedUser?.totalMicrodollarsAcquired).toBe(58_500_000);
+    expect(updatedUser?.threshold).toBe(58_500_000);
+    expect(getEffectiveKiloPassThreshold(updatedUser?.threshold ?? null)).toBe(57_500_000);
   });
 
   it('keeps one current base item across multiple App Store upgrades in the same month', async () => {

--- a/apps/web/src/lib/kilo-pass/store-subscription-completion.ts
+++ b/apps/web/src/lib/kilo-pass/store-subscription-completion.ts
@@ -388,13 +388,6 @@ async function applyStoreUpgradeCreditAdjustments(
     originalBaselineMicrodollarsUsed: freshUser.microdollarsUsed,
   });
 
-  if (issueResult.wasInserted) {
-    await updateKiloPassThresholdAfterBaseCredits(tx, {
-      kiloUserId: params.user.id,
-      baseAmountUsd: newTierAmountUsd,
-    });
-  }
-
   await appendKiloPassAuditLog(tx, {
     action: KiloPassAuditLogAction.BaseCreditsIssued,
     result: issueResult.wasInserted
@@ -426,6 +419,13 @@ async function applyStoreUpgradeCreditAdjustments(
     upgradedBaseAmountUsd: newTierAmountUsd,
     originalBaselineMicrodollarsUsed: freshUser.microdollarsUsed,
   });
+
+  if (issueResult.wasInserted) {
+    await updateKiloPassThresholdAfterBaseCredits(tx, {
+      kiloUserId: params.user.id,
+      baseAmountUsd: newTierAmountUsd,
+    });
+  }
 }
 
 export async function completeStoreKiloPassPurchase(params: {

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.test.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.test.ts
@@ -1508,7 +1508,7 @@ describe('handleKiloPassInvoicePaid', () => {
       await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
 
     const user = await insertTestUser({
-      total_microdollars_acquired: 0,
+      total_microdollars_acquired: 7_000_000,
       microdollars_used: 7_000_000,
     });
     const stripeSubId = `sub_${Math.random()}`;
@@ -2010,7 +2010,7 @@ describe('handleKiloPassInvoicePaid', () => {
       await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
 
     const user = await insertTestUser({
-      total_microdollars_acquired: 0,
+      total_microdollars_acquired: 3_000_000,
       microdollars_used: 3_000_000,
     });
     const stripeSubId = `sub_${Math.random()}`;

--- a/apps/web/src/lib/kilo-pass/subscription-accounting.ts
+++ b/apps/web/src/lib/kilo-pass/subscription-accounting.ts
@@ -16,9 +16,9 @@ export async function updateKiloPassThresholdAfterBaseCredits(
   await tx
     .update(kilocode_users)
     .set({
-      kilo_pass_threshold: sql`${kilocode_users.microdollars_used} + ${toMicrodollars(
+      kilo_pass_threshold: sql`LEAST(${kilocode_users.microdollars_used} + ${toMicrodollars(
         params.baseAmountUsd
-      )}`,
+      )}, ${kilocode_users.total_microdollars_acquired})`,
     })
     .where(eq(kilocode_users.id, params.kiloUserId));
 }

--- a/apps/web/src/lib/kilo-pass/yearly-monthly-base-cron.test.ts
+++ b/apps/web/src/lib/kilo-pass/yearly-monthly-base-cron.test.ts
@@ -37,7 +37,10 @@ describe('runKiloPassYearlyMonthlyBaseCron', () => {
     const now = new Date('2026-01-06T00:00:00.000Z');
     const dueAtIso = '2025-12-01T00:00:00.000Z';
 
-    const user = await insertTestUser();
+    const user = await insertTestUser({
+      total_microdollars_acquired: 0,
+      microdollars_used: 100_000_000,
+    });
 
     const inserted = await db
       .insert(kilo_pass_subscriptions)
@@ -135,7 +138,7 @@ describe('runKiloPassYearlyMonthlyBaseCron', () => {
       .where(eq(kilocode_users.id, user.id))
       .limit(1);
     expect(userRow[0]?.threshold).toBe(
-      toMicrodollars(KILO_PASS_TIER_CONFIG[KiloPassTier.Tier49].monthlyPriceUsd)
+      toMicrodollars(KILO_PASS_TIER_CONFIG[KiloPassTier.Tier49].monthlyPriceUsd) * 2
     );
   });
 

--- a/apps/web/src/lib/kilo-pass/yearly-monthly-base-cron.ts
+++ b/apps/web/src/lib/kilo-pass/yearly-monthly-base-cron.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { kilo_pass_issuances, kilo_pass_subscriptions, kilocode_users } from '@kilocode/db/schema';
+import { kilo_pass_issuances, kilo_pass_subscriptions } from '@kilocode/db/schema';
 import {
   KiloPassAuditLogResult,
   KiloPassCadence,
@@ -18,9 +18,9 @@ import {
   createOrGetIssuanceHeader,
   issueBaseCreditsForIssuance,
 } from '@/lib/kilo-pass/issuance';
-import { toMicrodollars } from '@/lib/utils';
 import { forceImmediateExpirationRecomputation } from '@/lib/balanceCache';
 import { dayjs } from '@/lib/kilo-pass/dayjs';
+import { updateKiloPassThresholdAfterBaseCredits } from './subscription-accounting';
 
 type Db = typeof defaultDb;
 
@@ -134,12 +134,10 @@ async function issueYearlyCadenceMonthlyBaseOnce(
   });
 
   if (baseResult.wasIssued) {
-    await tx
-      .update(kilocode_users)
-      .set({
-        kilo_pass_threshold: sql`${kilocode_users.microdollars_used} + ${toMicrodollars(baseAmountUsd)}`,
-      })
-      .where(eq(kilocode_users.id, kiloUserId));
+    await updateKiloPassThresholdAfterBaseCredits(tx, {
+      kiloUserId,
+      baseAmountUsd,
+    });
   }
 
   // Use GREATEST() to ensure monotonic advancement - prevents regression under overlapping runs.


### PR DESCRIPTION
## Summary

Keep the Kilo Pass bonus threshold reachable when a base-credit grant starts from a negative balance.

### Why this change is needed

The previous threshold always added the full base grant to cumulative usage. When a user was overdrawn, part of that grant immediately covered the deficit, so the user could exhaust the remaining credits before reaching the bonus threshold.

The existing $1 early-unlock allowance did not solve this for balances below -$1.

### How this is addressed

- Cap the stored threshold at total acquired credits after the base grant.
- Apply the same calculation to Stripe invoices, yearly monthly-base issuance, store purchases, and store upgrades.
- Calculate upgrade thresholds after replacement credits and bonus or promo reversals are complete.
- Preserve the existing $1 early-unlock allowance, bonus percentages, and issuance idempotency.
- Add regression coverage for all Kilo Pass tiers, monthly and yearly issuance, balance boundaries, and replay behavior.

## Human Verification

- Confirmed the formula against the current balance model and transaction ordering for every production threshold-writing path.
- Completed an eight-focus local code review with no findings.

## Reviewer Notes

### Human Reviewer Flags

- The Kilo Pass specification now defines the stored threshold as the lesser of usage plus the base grant and total acquired credits after the grant.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- The shared threshold writer uses the post-grant `total_microdollars_acquired` value in the same transaction.
- Store upgrades calculate the threshold only after refund, replacement-credit, and bonus or promo reversal adjustments.
- Focused database-backed tests could not run locally because PostgreSQL and Docker were unavailable; CI should execute them.

</details>
