### PR TITLE
fix(billing): end free Inception Mercury Edit 2 promo

### DIFF
--- a/apps/web/src/lib/constants.ts
+++ b/apps/web/src/lib/constants.ts
@@ -57,7 +57,7 @@ export const TRIAL_DURATION_DAYS = 14;
 
 export const AUTOCOMPLETE_MODEL = 'codestral-2508';
 export const INCEPTION_PROMO_MODEL = 'inception/mercury-edit-2';
-export const INCEPTION_PROMO_RUNNING = true;
+export const INCEPTION_PROMO_RUNNING = false;
 
 export const ENABLE_DEPLOY_FEATURE = true;
 


### PR DESCRIPTION
Mercury Edit 2 (`inception/mercury-edit-2`) is no longer free.

The model was zero-rated through the Inception promo flag (`INCEPTION_PROMO_RUNNING`), which both bypassed the insufficient-credits balance check and set the billed cost to zero in the FIM and edit usage paths.

This flips `INCEPTION_PROMO_RUNNING` to `false`, so the model is now:
- subject to the standard balance check (returns 402 when out of credits), and
- billed at its published rates.

Tests mock `INCEPTION_PROMO_RUNNING` independently, so they are unaffected.