### PR TITLE
Map poolside/laguna-s-2.1:free to poolside/laguna-s-2.1-free in Vercel model ID mapping

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -54,6 +54,7 @@ describe('mapModelIdToVercel', () => {
       ['mistralai/mistral-medium-3-5', 'mistral/mistral-medium-3.5'],
       ['mistralai/mistral-small-2603', 'mistral/mistral-small'],
       ['mistralai/pixtral-large-2411', 'mistral/pixtral-large'],
+      ['poolside/laguna-s-2.1:free', 'poolside/laguna-s-2.1-free'],
       ['qwen/qwen3-14b', 'alibaba/qwen-3-14b'],
       ['qwen/qwen3-235b-a22b', 'alibaba/qwen-3-235b'],
       ['qwen/qwen3-30b-a3b', 'alibaba/qwen-3-30b'],

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -39,6 +39,7 @@ const vercelModelIdMapping: Record<string, string | undefined> = {
   'mistralai/mistral-medium-3-5': 'mistral/mistral-medium-3.5',
   'mistralai/mistral-small-2603': 'mistral/mistral-small',
   'mistralai/pixtral-large-2411': 'mistral/pixtral-large',
+  'poolside/laguna-s-2.1:free': 'poolside/laguna-s-2.1-free',
   'qwen/qwen3-14b': 'alibaba/qwen-3-14b',
   'qwen/qwen3-235b-a22b': 'alibaba/qwen-3-235b',
   'qwen/qwen3-30b-a3b': 'alibaba/qwen-3-30b',


### PR DESCRIPTION
Adds a hardcoded Vercel model ID mapping for `poolside/laguna-s-2.1:free` → `poolside/laguna-s-2.1-free`.