### PR TITLE
fix(ai-gateway): prefer Novita for DeepSeek models

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -71,6 +71,14 @@ describe('applyPreferredProvider', () => {
     });
   });
 
+  it('prefers Novita for DeepSeek models', () => {
+    const request = makeRequest('deepseek/deepseek-v4-pro');
+
+    applyPreferredProvider('deepseek/deepseek-v4-pro', request.body);
+
+    expect(request.body.provider).toEqual({ order: ['novita', 'deepseek'] });
+  });
+
   it('overwrites a malformed provider value', () => {
     const request = makeRequest('anthropic/claude-sonnet-4.5');
     Object.assign(request.body, { provider: 'lmstudio' });

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -76,7 +76,7 @@ describe('applyPreferredProvider', () => {
 
     applyPreferredProvider('deepseek/deepseek-v4-pro', request.body);
 
-    expect(request.body.provider).toEqual({ order: ['novita', 'deepseek'] });
+    expect(request.body.provider).toEqual({ order: ['novita'] });
   });
 
   it('overwrites a malformed provider value', () => {

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -20,6 +20,7 @@ import { isGlmModel } from '@/lib/ai-gateway/providers/zai';
 import { isMinimaxModel } from '@/lib/ai-gateway/providers/minimax';
 import type { BYOKResult, Provider, ProviderId } from '@/lib/ai-gateway/providers/types';
 import { isStepModel } from '@/lib/ai-gateway/providers/stepfun';
+import { isDeepseekModel } from '@/lib/ai-gateway/providers/deepseek';
 import type { FraudDetectionHeaders } from '@/lib/utils';
 import { applyTrackingIds } from '@/lib/ai-gateway/providerHash';
 import {
@@ -58,6 +59,12 @@ export function getPreferredProviderOrder(requestedModel: string): string[] {
   }
   if (isStepModel(requestedModel)) {
     return [OpenRouterInferenceProviderIdSchema.enum.stepfun];
+  }
+  if (isDeepseekModel(requestedModel)) {
+    return [
+      OpenRouterInferenceProviderIdSchema.enum.novita,
+      OpenRouterInferenceProviderIdSchema.enum.deepseek,
+    ];
   }
   if (isGlmModel(requestedModel)) {
     return [

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -61,10 +61,7 @@ export function getPreferredProviderOrder(requestedModel: string): string[] {
     return [OpenRouterInferenceProviderIdSchema.enum.stepfun];
   }
   if (isDeepseekModel(requestedModel)) {
-    return [
-      OpenRouterInferenceProviderIdSchema.enum.novita,
-      OpenRouterInferenceProviderIdSchema.enum.deepseek,
-    ];
+    return [OpenRouterInferenceProviderIdSchema.enum.novita];
   }
   if (isGlmModel(requestedModel)) {
     return [


### PR DESCRIPTION
The Novita tool call issues for DeepSeek V4 have been resolved (#4667). Route DeepSeek models to Novita first, falling back to the native DeepSeek provider, matching the existing GLM routing pattern.

Discounted Kilo-exclusive DeepSeek models are unaffected: their `inference_provider_restriction: ['deepseek']` sets `provider.only`, which filters the preferred order.