### PR TITLE
chore(byok): remove deprecated codestral API key test

### DIFF
--- a/apps/web/src/routers/byok-router.test.ts
+++ b/apps/web/src/routers/byok-router.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect, beforeAll, afterEach, jest } from '@jest/globals';
+import { describe, test, expect, beforeAll, afterEach } from '@jest/globals';
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
@@ -473,28 +473,6 @@ describe('BYOK Router', () => {
       const keys = await db.select().from(byok_api_keys).where(eq(byok_api_keys.id, keyA.id));
 
       expect(keys).toHaveLength(1);
-    });
-  });
-
-  describe('key validation error safety', () => {
-    test('does not return upstream provider error bodies from API key tests', async () => {
-      const caller = await createCallerForUser(ownerUser.id);
-      const key = await caller.byok.create({ provider_id: 'codestral', api_key: 'stored-secret' });
-      const fetchSpy = jest
-        .spyOn(global, 'fetch')
-        .mockResolvedValue(
-          new Response('authorization=stored-secret provider detail', { status: 401 })
-        );
-
-      try {
-        await expect(caller.byok.testApiKey({ id: key.id })).resolves.toEqual({
-          success: false,
-          message:
-            'API key test failed. Check the credential and supported models, then try again.',
-        });
-      } finally {
-        fetchSpy.mockRestore();
-      }
     });
   });
 

--- a/apps/web/src/routers/byok-router.test.ts
+++ b/apps/web/src/routers/byok-router.test.ts
@@ -476,6 +476,18 @@ describe('BYOK Router', () => {
     });
   });
 
+  describe('deprecated codestral provider', () => {
+    test('declines to test a legacy codestral key with a deprecation message', async () => {
+      const caller = await createCallerForUser(ownerUser.id);
+      const key = await caller.byok.create({ provider_id: 'codestral', api_key: 'stored-secret' });
+
+      await expect(caller.byok.testApiKey({ id: key.id })).resolves.toEqual({
+        success: false,
+        message: 'Codestral is deprecated and its API key can no longer be tested.',
+      });
+    });
+  });
+
   describe('MiniMax Coding Plan-installed credentials', () => {
     test('rejects removed dedicated provider identity in manual creation requests', async () => {
       const caller = await createCallerForUser(ownerUser.id);

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -402,6 +402,16 @@ export const byokRouter = createTRPCRouter({
 
       const decryptedKey = decryptByokRow(existingKey);
 
+      // Codestral is deprecated and its key only authenticates against codestral.mistral.ai,
+      // which the gateway test path below cannot reach (it routes codestral to api.mistral.ai).
+      // Decline to test it rather than returning a misleading failure for a still-valid key.
+      if (decryptedKey.providerId === 'codestral') {
+        return {
+          success: false,
+          message: 'Codestral is deprecated and its API key can no longer be tested.',
+        };
+      }
+
       function setup() {
         const provider = UserByokProviderIdSchema.parse(decryptedKey.providerId);
         const model = UserByokTestModels[provider];

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -41,8 +41,6 @@ import {
   formatDirectByokModelId,
 } from '@/lib/ai-gateway/providers/direct-byok';
 
-const CODESTRAL_FIM_URL = 'https://codestral.mistral.ai/v1/fim/completions';
-const CODESTRAL_TEST_MODEL = 'codestral-2508';
 const GENERIC_TEST_FAILURE_MESSAGE =
   'API key test failed. Check the credential and supported models, then try again.';
 const MANAGED_KEY_READ_ONLY_MESSAGE =
@@ -55,41 +53,6 @@ function rejectManagedKeyMutation(managementSource: 'user' | 'coding_plan') {
       code: 'CONFLICT',
       message: MANAGED_KEY_READ_ONLY_MESSAGE,
     });
-  }
-}
-
-async function testCodestralApiKey(apiKey: string): Promise<{ success: boolean; message: string }> {
-  try {
-    const res = await fetch(CODESTRAL_FIM_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: CODESTRAL_TEST_MODEL,
-        prompt: 'def hi():\n    ',
-        suffix: '\n',
-        max_tokens: 1,
-        stream: false,
-      }),
-    });
-    // Always drain the body so the underlying Undici connection is released.
-    await res.text().catch(() => '');
-    if (res.ok) {
-      return {
-        success: true,
-        message: `API key test success. Provider: codestral. Model: ${CODESTRAL_TEST_MODEL}.`,
-      };
-    }
-    logByokWarning('Codestral BYOK key test failed', {
-      providerId: 'codestral',
-      status: res.status,
-    });
-    return { success: false, message: GENERIC_TEST_FAILURE_MESSAGE };
-  } catch {
-    logByokWarning('Codestral BYOK key test request failed', { providerId: 'codestral' });
-    return { success: false, message: GENERIC_TEST_FAILURE_MESSAGE };
   }
 }
 
@@ -438,13 +401,6 @@ export const byokRouter = createTRPCRouter({
       }
 
       const decryptedKey = decryptByokRow(existingKey);
-
-      // Codestral keys only authenticate against codestral.mistral.ai, not api.mistral.ai
-      // (the endpoint the Vercel gateway's `mistral` provider uses). Test the key directly
-      // against the Codestral FIM endpoint instead of going through the gateway.
-      if (decryptedKey.providerId === 'codestral') {
-        return await testCodestralApiKey(decryptedKey.decryptedAPIKey);
-      }
 
       function setup() {
         const provider = UserByokProviderIdSchema.parse(decryptedKey.providerId);


### PR DESCRIPTION
Removes the API key test feature for the deprecated `codestral` provider.

- Delete the `testCodestralApiKey` helper and its `CODESTRAL_FIM_URL` / `CODESTRAL_TEST_MODEL` constants.
- Remove the special-case branch in `testApiKey` that routed codestral keys to that helper.
- Drop the now-obsolete test that exercised the codestral fetch path (and the unused `jest` import).