### PR TITLE
Log session id in upstream response status message

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -880,9 +880,10 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   }
   const response = upstreamResult.response;
   logExceptInTest(
-    'upstream response status: %s, x-vercel-id: %s',
+    'upstream response status: %s, x-vercel-id: %s, session_id: %s',
     response.status,
-    response.headers.get('x-vercel-id') || '<none>'
+    response.headers.get('x-vercel-id') || '<none>',
+    usageContext.session_id || '<none>'
   );
 
   const ttfbMs = Math.max(0, Math.round(performance.now() - requestStartedAt));


### PR DESCRIPTION
Adds the session id to the upstream response status log line in the OpenRouter proxy route, when available.