### PR TITLE
fix(mobile): AppsFlyer AdAttributionKit postback copies + IAP revenue via Purchase Connector

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -39,9 +39,11 @@ const config: ExpoConfig = {
     infoPlist: {
       ITSAppUsesNonExemptEncryption: false,
       NSAdvertisingAttributionReportEndpoint: 'https://appsflyer-skadnetwork.com/',
-      AdAttributionKit: {
-        PostbackCopyURL: 'https://appsflyer-skadnetwork.com/',
-      },
+      // Apple's raw key for AdAttributionKit postback copies is the top-level
+      // string `AttributionCopyEndpoint` (Xcode displays it as "AdAttributionKit -
+      // Postback Copy URL"). A nested AdAttributionKit dictionary is silently
+      // ignored by iOS, so copies never reached AppsFlyer.
+      AttributionCopyEndpoint: 'https://appsflyer-skadnetwork.com/',
       // Make the app's Documents directory user-visible in the iOS Files
       // app so downloaded any-file attachments (uploaded via the cloud-agent
       // composer) can be opened in place.
@@ -146,7 +148,7 @@ const config: ExpoConfig = {
           'This identifier is used to measure the effectiveness of advertising campaigns.',
       },
     ],
-    ['react-native-appsflyer', {}],
+    ['react-native-appsflyer', { shouldUsePurchaseConnector: true }],
     './plugins/withAndroidManifestFix',
     // ponytail: only registered when GOOGLE_IOS_CLIENT_ID is set, so prebuild works before the
     // Google OAuth clients exist.

--- a/apps/mobile/src/lib/appsflyer.test.ts
+++ b/apps/mobile/src/lib/appsflyer.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockedPlatform = vi.hoisted(() => ({ OS: 'ios' }));
+
+const mockedAppsFlyer = vi.hoisted(() => ({
+  initSdk: vi.fn(),
+  logEvent: vi.fn(),
+  create: vi.fn(),
+  startObservingTransactions: vi.fn(),
+}));
+
+vi.mock('react-native', () => ({
+  Platform: mockedPlatform,
+}));
+
+vi.mock('react-native-appsflyer', () => ({
+  default: {
+    initSdk: mockedAppsFlyer.initSdk,
+    logEvent: mockedAppsFlyer.logEvent,
+  },
+  AppsFlyerPurchaseConnector: {
+    create: mockedAppsFlyer.create,
+    startObservingTransactions: mockedAppsFlyer.startObservingTransactions,
+  },
+  StoreKitVersion: { SK1: 'SK1', SK2: 'SK2' },
+}));
+
+vi.mock('@sentry/react-native', () => ({ captureException: vi.fn() }));
+vi.mock('@/lib/analytics/posthog', () => ({ captureEvent: vi.fn() }));
+vi.mock('@/lib/config', () => ({
+  APPSFLYER_DEV_KEY: 'dev-key',
+  APPSFLYER_APP_ID: 'app-id',
+}));
+
+vi.stubGlobal('__DEV__', false);
+
+async function loadInit() {
+  vi.resetModules();
+  const module = await import('./appsflyer');
+  return module.initAppsFlyer;
+}
+
+describe('initAppsFlyer purchase connector', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // initSdk fires its success callback so startObservingTransactions runs.
+    mockedAppsFlyer.initSdk.mockImplementation(
+      (_options: unknown, onSuccess: (result: string) => void) => {
+        onSuccess('ok');
+      }
+    );
+  });
+
+  it('creates the connector and observes transactions on iOS', async () => {
+    mockedPlatform.OS = 'ios';
+    const initAppsFlyer = await loadInit();
+
+    initAppsFlyer();
+
+    expect(mockedAppsFlyer.create).toHaveBeenCalledWith({
+      logSubscriptions: true,
+      logInApps: false,
+      sandbox: false,
+      storeKitVersion: 'SK2',
+    });
+    expect(mockedAppsFlyer.startObservingTransactions).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not touch the purchase connector on Android', async () => {
+    mockedPlatform.OS = 'android';
+    const initAppsFlyer = await loadInit();
+
+    initAppsFlyer();
+
+    expect(mockedAppsFlyer.initSdk).toHaveBeenCalledTimes(1);
+    expect(mockedAppsFlyer.create).not.toHaveBeenCalled();
+    expect(mockedAppsFlyer.startObservingTransactions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/lib/appsflyer.ts
+++ b/apps/mobile/src/lib/appsflyer.ts
@@ -1,5 +1,6 @@
 import * as Sentry from '@sentry/react-native';
-import appsFlyer from 'react-native-appsflyer';
+import { Platform } from 'react-native';
+import appsFlyer, { AppsFlyerPurchaseConnector, StoreKitVersion } from 'react-native-appsflyer';
 
 import { captureEvent } from '@/lib/analytics/posthog';
 import { APPSFLYER_APP_ID, APPSFLYER_DEV_KEY } from '@/lib/config';
@@ -33,6 +34,20 @@ export function initAppsFlyer(): void {
     return;
   }
 
+  // Purchase Connector auto-observes StoreKit transactions and validates
+  // purchase revenue server-side, so revenue is attributed without touching the
+  // purchase flow. iOS-only: Kilo Pass IAP ships on iOS only (subscriptions,
+  // StoreKit 2 via expo-iap). Create it before initSdk and start observing once
+  // the SDK has started (in the success callback below).
+  if (Platform.OS === 'ios') {
+    AppsFlyerPurchaseConnector.create({
+      logSubscriptions: true,
+      logInApps: false,
+      sandbox: __DEV__,
+      storeKitVersion: StoreKitVersion.SK2,
+    });
+  }
+
   appsFlyer.initSdk(
     {
       devKey: APPSFLYER_DEV_KEY,
@@ -43,6 +58,9 @@ export function initAppsFlyer(): void {
     },
     () => {
       initialized = true;
+      if (Platform.OS === 'ios') {
+        AppsFlyerPurchaseConnector.startObservingTransactions();
+      }
       drainPendingEvents();
     },
     handleError('AppsFlyer init failed')


### PR DESCRIPTION
## What & why

Two AppsFlyer items requested by product:

### 1. SKAN / AdAttributionKit postback copies → AppsFlyer (the "not working" report)
The AdAttributionKit postback-copy endpoint was configured as a **nested** `AdAttributionKit: { PostbackCopyURL }` dictionary in the iOS `Info.plist`. iOS silently ignores that structure, so AdAttributionKit postback copies never reached AppsFlyer — matching product's report that it wasn't working.

Apple's actual key is the **top-level string** `AttributionCopyEndpoint` (Xcode's plist editor only *displays* it as the friendly name "AdAttributionKit - Postback Copy URL"). Fixed to write the correct key. The SKAdNetwork `NSAdvertisingAttributionReportEndpoint` key was already correct and is unchanged.

Refs: [Apple AdAttributionKit](https://developer.apple.com/documentation/AdAttributionKit), [AppsFlyer help center](https://support.appsflyer.com/hc/en-us/articles/4402320969617-Send-SKAN-and-AdAttributionKit-postback-copies-directly-to-AppsFlyer-iOS-15).

### 2. Push in-app purchase revenue to AppsFlyer
Enabled the [AppsFlyer Purchase Connector](https://dev.appsflyer.com/hc/docs/purchase-connector-unity) (`shouldUsePurchaseConnector: true` on the config plugin → activates the native `PurchaseConnector` pod). On iOS, the connector is created and starts observing StoreKit transactions during AppsFlyer init. It auto-observes StoreKit 2 transactions and validates purchase revenue server-side, so **no changes to the Kilo Pass purchase flow were needed**.

- iOS-only, matching the current subscriptions-only IAP (Android purchase context is inert).
- `logSubscriptions: true, logInApps: false` — Kilo Pass is subscriptions only.
- `storeKitVersion: SK2` — matches expo-iap (StoreKit 2).
- `sandbox: __DEV__`.

## Changes
- `app.config.ts`: fix `AttributionCopyEndpoint` key; set `shouldUsePurchaseConnector: true`.
- `src/lib/appsflyer.ts`: create + start the Purchase Connector on iOS inside `initAppsFlyer()` (stays behind the existing analytics-consent gate).
- `src/lib/appsflyer.test.ts`: unit test — connector created + observing on iOS, untouched on Android.

## Verification
- ✅ `pnpm typecheck`, `pnpm lint`, `pnpm check:unused`, `pnpm test` (2/2 pass)
- ✅ `expo config --introspect` confirms `AttributionCopyEndpoint` is a top-level string and the old nested `AdAttributionKit` dict is gone.
- ⚠️ Both are **native-only** changes → a new dev/production build is required to take effect; revenue/postback flow can't be verified from JS alone.

## ⚠️ Required non-code follow-ups (AppsFlyer dashboard side)
These must be done for revenue/postbacks to actually flow — they are **not** part of this code change:
1. **Purchase Connector validation** — configure the iOS App-Specific Shared Secret / StoreKit 2 S2S in-app-purchase validation in the AppsFlyer dashboard, or revenue events won't validate.
2. **Postback endpoint registration** — ensure the SKAN/AdAttributionKit postback endpoint is enabled for this app on AppsFlyer's side.
3. **New build required** — cut a new dev/TestFlight build so the native Podfile/Info.plist changes ship.