### PR TITLE
fix(cloud-agent): exclude suspended integrations from repository picker

### DIFF
--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
@@ -1,0 +1,210 @@
+import { describe, expect, it, jest, beforeEach } from '@jest/globals';
+import type { PlatformIntegration } from '@kilocode/db/schema';
+import type { Owner } from '@/lib/integrations/core/types';
+
+// Define mock functions at module level with proper typing
+const mockGetIntegrationForOrganization =
+  jest.fn<(organizationId: string, platform: string) => Promise<PlatformIntegration | null>>();
+const mockGetIntegrationForOwner =
+  jest.fn<(owner: Owner, platform: string) => Promise<PlatformIntegration | null>>();
+const mockUpdateRepositoriesForIntegration =
+  jest.fn<(integrationId: string, repositories: unknown[]) => Promise<void>>();
+const mockFetchGitHubRepositories =
+  jest.fn<(installationId: string, appType: string) => Promise<unknown[]>>();
+const mockGenerateGitHubInstallationToken =
+  jest.fn<(installationId: string, appType: string) => Promise<{ token: string }>>();
+const mockCheckExistingFork =
+  jest.fn<
+    (
+      installationId: string,
+      accountLogin: string,
+      sourceOwner: string,
+      sourceRepoName: string
+    ) => Promise<{ exists: boolean; fullName: string | null }>
+  >();
+
+// Wire up the mocks
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationForOrganization: mockGetIntegrationForOrganization,
+  getIntegrationForOwner: mockGetIntegrationForOwner,
+  updateRepositoriesForIntegration: mockUpdateRepositoriesForIntegration,
+}));
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  fetchGitHubRepositories: mockFetchGitHubRepositories,
+  generateGitHubInstallationToken: mockGenerateGitHubInstallationToken,
+  checkExistingFork: mockCheckExistingFork,
+}));
+
+jest.mock('@/components/cloud-agent/demo-config', () => ({
+  DEMO_SOURCE_OWNER: 'demo-owner',
+  DEMO_SOURCE_REPO_NAME: 'demo-repo',
+}));
+
+const cachedRepositories = [{ id: 1, name: 'repo', full_name: 'org/repo', private: false }];
+
+const buildIntegration = (overrides: Partial<PlatformIntegration> = {}): PlatformIntegration =>
+  ({
+    id: 'integration-1',
+    platform: 'github',
+    integration_status: 'active',
+    suspended_at: null,
+    auth_invalid_at: null,
+    platform_installation_id: 'installation-1',
+    github_app_type: 'standard',
+    repositories: cachedRepositories,
+    repositories_synced_at: '2024-01-01T00:00:00Z',
+    ...overrides,
+  }) as PlatformIntegration;
+
+describe('github-integration-helpers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.resetModules();
+  });
+
+  describe('fetchGitHubRepositoriesForUser', () => {
+    it('returns cached repositories for an active integration', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(buildIntegration());
+
+      const { fetchGitHubRepositoriesForUser } = await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForUser('user-123');
+
+      expect(result.integrationInstalled).toBe(true);
+      expect(result.repositories).toEqual([
+        { id: 1, name: 'repo', fullName: 'org/repo', private: false },
+      ]);
+      expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+    });
+
+    it('returns integrationInstalled false when no integration exists', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(null);
+
+      const { fetchGitHubRepositoriesForUser } = await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForUser('user-123');
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(result.repositories).toEqual([]);
+    });
+
+    it('returns no repositories when the integration is suspended', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(
+        buildIntegration({
+          integration_status: 'suspended',
+          suspended_at: '2026-06-25 18:00:00+00',
+          suspended_by: 'someone',
+        })
+      );
+
+      const { fetchGitHubRepositoriesForUser } = await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForUser('user-123');
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(result.repositories).toEqual([]);
+      expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+    });
+
+    it('returns no repositories when suspended_at is set even if status is active', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(
+        buildIntegration({ suspended_at: '2026-06-25 18:00:00+00' })
+      );
+
+      const { fetchGitHubRepositoriesForUser } = await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForUser('user-123');
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(result.repositories).toEqual([]);
+      expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh repositories for a suspended integration even with forceRefresh', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(
+        buildIntegration({ integration_status: 'suspended' })
+      );
+
+      const { fetchGitHubRepositoriesForUser } = await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForUser('user-123', true);
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+      expect(mockUpdateRepositoriesForIntegration).not.toHaveBeenCalled();
+    });
+
+    it('fetches fresh repositories when forceRefresh is true', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(buildIntegration());
+      mockFetchGitHubRepositories.mockResolvedValue([
+        { id: 2, name: 'fresh', full_name: 'org/fresh', private: true },
+      ]);
+
+      const { fetchGitHubRepositoriesForUser } = await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForUser('user-123', true);
+
+      expect(result.integrationInstalled).toBe(true);
+      expect(result.repositories).toEqual([
+        { id: 2, name: 'fresh', fullName: 'org/fresh', private: true },
+      ]);
+      expect(mockUpdateRepositoriesForIntegration).toHaveBeenCalledWith('integration-1', [
+        { id: 2, name: 'fresh', full_name: 'org/fresh', private: true },
+      ]);
+    });
+  });
+
+  describe('fetchGitHubRepositoriesForOrganization', () => {
+    it('returns cached repositories for an active integration', async () => {
+      mockGetIntegrationForOrganization.mockResolvedValue(buildIntegration());
+
+      const { fetchGitHubRepositoriesForOrganization } =
+        await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForOrganization('org-123');
+
+      expect(result.integrationInstalled).toBe(true);
+      expect(result.repositories).toEqual([
+        { id: 1, name: 'repo', fullName: 'org/repo', private: false },
+      ]);
+      expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+    });
+
+    it('returns integrationInstalled false when no integration exists', async () => {
+      mockGetIntegrationForOrganization.mockResolvedValue(null);
+
+      const { fetchGitHubRepositoriesForOrganization } =
+        await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForOrganization('org-123');
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(result.repositories).toEqual([]);
+    });
+
+    it('returns no repositories when the integration is suspended', async () => {
+      mockGetIntegrationForOrganization.mockResolvedValue(
+        buildIntegration({
+          integration_status: 'suspended',
+          suspended_at: '2026-06-25 18:00:00+00',
+          suspended_by: 'someone',
+        })
+      );
+
+      const { fetchGitHubRepositoriesForOrganization } =
+        await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForOrganization('org-123');
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(result.repositories).toEqual([]);
+      expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+    });
+
+    it('does not refresh repositories for a suspended integration even with forceRefresh', async () => {
+      mockGetIntegrationForOrganization.mockResolvedValue(
+        buildIntegration({ integration_status: 'suspended' })
+      );
+
+      const { fetchGitHubRepositoriesForOrganization } =
+        await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForOrganization('org-123', true);
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+      expect(mockUpdateRepositoriesForIntegration).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
@@ -11,6 +11,7 @@ import {
 } from '@/lib/integrations/platforms/github/adapter';
 import { DEMO_SOURCE_OWNER, DEMO_SOURCE_REPO_NAME } from '@/components/cloud-agent/demo-config';
 import { PLATFORM } from '@/lib/integrations/core/constants';
+import { isPlatformIntegrationSuspended } from '@/lib/integrations/core/health';
 import {
   requireNumericPlatformRepositories,
   type PlatformRepository,
@@ -128,6 +129,10 @@ export async function fetchGitHubRepositoriesForOrganization(
     return missingIntegrationResponse('No GitHub integration found for this organization');
   }
 
+  if (isPlatformIntegrationSuspended(integration)) {
+    return missingIntegrationResponse('GitHub integration is suspended');
+  }
+
   if (!integration.platform_installation_id) {
     return missingIntegrationResponse('GitHub integration is not properly configured');
   }
@@ -171,6 +176,10 @@ export async function fetchGitHubRepositoriesForUser(
 
   if (!integration) {
     return missingIntegrationResponse('No GitHub integration found for this user');
+  }
+
+  if (isPlatformIntegrationSuspended(integration)) {
+    return missingIntegrationResponse('GitHub integration is suspended');
   }
 
   if (!integration.platform_installation_id) {

--- a/apps/web/src/lib/cloud-agent/gitlab-integration-helpers.test.ts
+++ b/apps/web/src/lib/cloud-agent/gitlab-integration-helpers.test.ts
@@ -465,4 +465,121 @@ describe('gitlab-integration-helpers', () => {
       expect(result).toBe(true);
     });
   });
+
+  describe('fetchGitLabRepositoriesForUser', () => {
+    const buildIntegration = (overrides: Partial<PlatformIntegration> = {}): PlatformIntegration =>
+      ({
+        id: 'integration-1',
+        platform: 'gitlab',
+        integration_status: 'active',
+        suspended_at: null,
+        auth_invalid_at: null,
+        metadata: {},
+        repositories: [{ id: 1, name: 'project', full_name: 'group/project', private: false }],
+        repositories_synced_at: '2024-01-01T00:00:00Z',
+        ...overrides,
+      }) as PlatformIntegration;
+
+    it('should return cached repositories for an active integration', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(buildIntegration());
+
+      const { fetchGitLabRepositoriesForUser } = await import('./gitlab-integration-helpers');
+      const result = await fetchGitLabRepositoriesForUser('user-123');
+
+      expect(result.integrationInstalled).toBe(true);
+      expect(result.repositories).toEqual([
+        { id: 1, name: 'project', fullName: 'group/project', private: false },
+      ]);
+      expect(mockFetchGitLabProjects).not.toHaveBeenCalled();
+    });
+
+    it('should return no repositories when the integration is suspended', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(
+        buildIntegration({
+          integration_status: 'suspended',
+          suspended_at: '2026-06-25 18:00:00+00',
+        })
+      );
+
+      const { fetchGitLabRepositoriesForUser } = await import('./gitlab-integration-helpers');
+      const result = await fetchGitLabRepositoriesForUser('user-123');
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(result.repositories).toEqual([]);
+      expect(mockFetchGitLabProjects).not.toHaveBeenCalled();
+    });
+
+    it('should not refresh repositories for a suspended integration even with forceRefresh', async () => {
+      mockGetIntegrationForOwner.mockResolvedValue(
+        buildIntegration({ integration_status: 'suspended' })
+      );
+
+      const { fetchGitLabRepositoriesForUser } = await import('./gitlab-integration-helpers');
+      const result = await fetchGitLabRepositoriesForUser('user-123', true);
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(mockFetchGitLabProjects).not.toHaveBeenCalled();
+      expect(mockUpdateRepositoriesForIntegration).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('fetchGitLabRepositoriesForOrganization', () => {
+    const buildIntegration = (overrides: Partial<PlatformIntegration> = {}): PlatformIntegration =>
+      ({
+        id: 'integration-1',
+        platform: 'gitlab',
+        integration_status: 'active',
+        suspended_at: null,
+        auth_invalid_at: null,
+        metadata: {},
+        repositories: [{ id: 1, name: 'project', full_name: 'org/project', private: false }],
+        repositories_synced_at: '2024-01-01T00:00:00Z',
+        ...overrides,
+      }) as PlatformIntegration;
+
+    it('should return cached repositories for an active integration', async () => {
+      mockGetIntegrationForOrganization.mockResolvedValue(buildIntegration());
+
+      const { fetchGitLabRepositoriesForOrganization } =
+        await import('./gitlab-integration-helpers');
+      const result = await fetchGitLabRepositoriesForOrganization('org-123', 'actor-123');
+
+      expect(result.integrationInstalled).toBe(true);
+      expect(result.repositories).toEqual([
+        { id: 1, name: 'project', fullName: 'org/project', private: false },
+      ]);
+      expect(mockFetchGitLabProjects).not.toHaveBeenCalled();
+    });
+
+    it('should return no repositories when the integration is suspended', async () => {
+      mockGetIntegrationForOrganization.mockResolvedValue(
+        buildIntegration({
+          integration_status: 'suspended',
+          suspended_at: '2026-06-25 18:00:00+00',
+        })
+      );
+
+      const { fetchGitLabRepositoriesForOrganization } =
+        await import('./gitlab-integration-helpers');
+      const result = await fetchGitLabRepositoriesForOrganization('org-123', 'actor-123');
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(result.repositories).toEqual([]);
+      expect(mockFetchGitLabProjects).not.toHaveBeenCalled();
+    });
+
+    it('should not refresh repositories for a suspended integration even with forceRefresh', async () => {
+      mockGetIntegrationForOrganization.mockResolvedValue(
+        buildIntegration({ integration_status: 'suspended' })
+      );
+
+      const { fetchGitLabRepositoriesForOrganization } =
+        await import('./gitlab-integration-helpers');
+      const result = await fetchGitLabRepositoriesForOrganization('org-123', 'actor-123', true);
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(mockFetchGitLabProjects).not.toHaveBeenCalled();
+      expect(mockUpdateRepositoriesForIntegration).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/apps/web/src/lib/cloud-agent/gitlab-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/gitlab-integration-helpers.ts
@@ -7,6 +7,7 @@ import {
 import { getGitLabIntegration, getValidGitLabToken } from '@/lib/integrations/gitlab-service';
 import { fetchGitLabProjects } from '@/lib/integrations/platforms/gitlab/adapter';
 import { PLATFORM } from '@/lib/integrations/core/constants';
+import { isPlatformIntegrationSuspended } from '@/lib/integrations/core/health';
 import {
   requireNumericPlatformRepositories,
   type PlatformRepository,
@@ -119,6 +120,10 @@ export async function fetchGitLabRepositoriesForOrganization(
     return missingIntegrationResponse('No GitLab integration found for this organization');
   }
 
+  if (isPlatformIntegrationSuspended(integration)) {
+    return missingIntegrationResponse('GitLab integration is suspended');
+  }
+
   const metadata = integration.metadata as GitLabMetadata | null;
   const instanceUrl = metadata?.gitlab_instance_url || DEFAULT_GITLAB_URL;
 
@@ -167,6 +172,10 @@ export async function fetchGitLabRepositoriesForUser(
 
   if (!integration) {
     return missingIntegrationResponse('No GitLab integration found for this user');
+  }
+
+  if (isPlatformIntegrationSuspended(integration)) {
+    return missingIntegrationResponse('GitLab integration is suspended');
   }
 
   const metadata = integration.metadata as GitLabMetadata | null;

--- a/apps/web/src/lib/integrations/core/health.test.ts
+++ b/apps/web/src/lib/integrations/core/health.test.ts
@@ -1,4 +1,4 @@
-import { isPlatformIntegrationHealthy } from './health';
+import { isPlatformIntegrationHealthy, isPlatformIntegrationSuspended } from './health';
 
 const healthyIntegration = {
   integration_status: 'active',
@@ -29,5 +29,31 @@ describe('isPlatformIntegrationHealthy', () => {
   it('rejects a missing integration', () => {
     expect(isPlatformIntegrationHealthy(null)).toBe(false);
     expect(isPlatformIntegrationHealthy(undefined)).toBe(false);
+  });
+});
+
+describe('isPlatformIntegrationSuspended', () => {
+  it('accepts an active integration that was never suspended', () => {
+    expect(isPlatformIntegrationSuspended(healthyIntegration)).toBe(false);
+  });
+
+  it('detects suspension by status', () => {
+    expect(
+      isPlatformIntegrationSuspended({ ...healthyIntegration, integration_status: 'suspended' })
+    ).toBe(true);
+  });
+
+  it('detects suspension by suspended_at timestamp', () => {
+    expect(
+      isPlatformIntegrationSuspended({
+        ...healthyIntegration,
+        suspended_at: '2026-06-25 18:00:00+00',
+      })
+    ).toBe(true);
+  });
+
+  it('rejects a missing integration', () => {
+    expect(isPlatformIntegrationSuspended(null)).toBe(false);
+    expect(isPlatformIntegrationSuspended(undefined)).toBe(false);
   });
 });

--- a/apps/web/src/lib/integrations/core/health.ts
+++ b/apps/web/src/lib/integrations/core/health.ts
@@ -18,6 +18,20 @@ export function isPlatformIntegrationHealthy(
   );
 }
 
+type PlatformIntegrationSuspensionState = Pick<
+  PlatformIntegrationHealthState,
+  'integration_status' | 'suspended_at'
+>;
+
+export function isPlatformIntegrationSuspended(
+  integration: PlatformIntegrationSuspensionState | null | undefined
+): boolean {
+  return (
+    integration?.integration_status === INTEGRATION_STATUS.SUSPENDED ||
+    integration?.suspended_at != null
+  );
+}
+
 export function platformIntegrationHealthSql(): SQL {
   return sql`
     ${platform_integrations.integration_status} = ${INTEGRATION_STATUS.ACTIVE}


### PR DESCRIPTION
## Problem

The cloud agent (next) web UI repository picker listed repositories from **suspended** integrations. When a GitHub App installation is suspended on GitHub (or a GitLab integration is disconnected, which marks it suspended), the webhook handler sets `integration_status='suspended'` + `suspended_at`, but the repository fetch helpers kept returning that integration's cached repositories — so suspended-integration repos still showed up in the picker.

## Fix

- Added `isPlatformIntegrationSuspended` to `apps/web/src/lib/integrations/core/health.ts` (true when `integration_status === 'suspended'` or `suspended_at` is set, matching the 'broken integration' definition used by org recommendations).
- `fetchGitHubRepositoriesForUser` / `fetchGitHubRepositoriesForOrganization` and `fetchGitLabRepositoriesForUser` / `fetchGitLabRepositoriesForOrganization` now return `integrationInstalled: false` with no repositories for suspended integrations — consistent with `platformIntegrations.listSetupStatus`, which already treats suspended as not installed, and with both Bitbucket repository paths, which already gate on `integration_status === 'active'`.
- This also prevents fresh repository syncs (`forceRefresh`) against suspended installations, which would fail against GitHub anyway.

The picker consequently hides those repositories and surfaces the existing repository-provider onboarding panel, which links to the integration settings page where the suspension is shown.

## Tests

- New `github-integration-helpers.test.ts` covering active/suspended/`suspended_at`-only/`forceRefresh` behavior for both user and org fetchers.
- Extended `gitlab-integration-helpers.test.ts` with the same coverage for the GitLab fetchers.
- Extended `health.test.ts` for `isPlatformIntegrationSuspended`.

## Verification

- `oxlint` on changed files: 0 warnings/errors.
- `oxfmt` applied.
- Unit tests not run locally: this sandbox has no Docker/PostgreSQL with pgvector for the repo's jest DB provisioning — relying on CI.