### PR TITLE
feat(admin): add errors-only filter and error JSON to API request log download

### DIFF
--- a/apps/web/src/app/admin/api-request-log/page.tsx
+++ b/apps/web/src/app/admin/api-request-log/page.tsx
@@ -7,6 +7,7 @@ import { useTRPC } from '@/lib/trpc/utils';
 import AdminPage from '@/app/admin/components/AdminPage';
 import { BreadcrumbItem } from '@/components/ui/breadcrumb';
 import { Button } from '@/components/ui/button';
+import { Checkbox } from '@/components/ui/checkbox';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
@@ -18,6 +19,7 @@ export default function ApiRequestLogPage() {
   const [endDate, setEndDate] = useState('');
   const [model, setModel] = useState('');
   const [sessionId, setSessionId] = useState('');
+  const [errorsOnly, setErrorsOnly] = useState(false);
 
   const trpc = useTRPC();
   const oldestEntryQuery = useQuery(trpc.admin.apiRequestLog.getOldestEntry.queryOptions());
@@ -38,6 +40,9 @@ export default function ApiRequestLogPage() {
     }
     if (sessionId.trim()) {
       params.set('sessionId', sessionId.trim());
+    }
+    if (errorsOnly) {
+      params.set('errorsOnly', 'true');
     }
 
     // Navigate directly to preserve server-side streaming
@@ -114,6 +119,17 @@ export default function ApiRequestLogPage() {
                   onChange={e => setEndDate(e.target.value)}
                 />
               </div>
+            </div>
+
+            <div className="flex items-center gap-2">
+              <Checkbox
+                id="errorsOnly"
+                checked={errorsOnly}
+                onCheckedChange={checked => setErrorsOnly(checked === true)}
+              />
+              <Label htmlFor="errorsOnly" className="cursor-pointer">
+                Errors only (status &ge; 400 or error present)
+              </Label>
             </div>
 
             <Button onClick={handleDownload} className="w-full">

--- a/apps/web/src/app/admin/api/api-request-log/download/route.ts
+++ b/apps/web/src/app/admin/api/api-request-log/download/route.ts
@@ -87,7 +87,13 @@ function buildFilter(
     conditions.push(eq(api_request_log.session_id, sessionId));
   }
   if (errorsOnly) {
-    conditions.push(or(gte(api_request_log.status_code, 400), isNotNull(api_request_log.error)));
+    const errorsCondition = or(
+      gte(api_request_log.status_code, 400),
+      isNotNull(api_request_log.error)
+    );
+    if (errorsCondition) {
+      conditions.push(errorsCondition);
+    }
   }
   return and(...conditions);
 }

--- a/apps/web/src/app/admin/api/api-request-log/download/route.ts
+++ b/apps/web/src/app/admin/api/api-request-log/download/route.ts
@@ -2,7 +2,7 @@ import { connection, type NextRequest } from 'next/server';
 import { getUserFromAuth } from '@/lib/user/server';
 import { db } from '@/lib/drizzle';
 import { api_request_log } from '@kilocode/db/schema';
-import { and, gte, lte, eq, asc, gt, count, type SQL } from 'drizzle-orm';
+import { and, gte, lte, eq, asc, gt, count, or, isNotNull, type SQL } from 'drizzle-orm';
 import archiver from 'archiver';
 import { Readable } from 'node:stream';
 
@@ -67,7 +67,8 @@ function buildFilter(
   parsedStart: Date | null,
   parsedEnd: Date | null,
   model: string | null,
-  sessionId: string | null
+  sessionId: string | null,
+  errorsOnly: boolean
 ) {
   const conditions: SQL[] = [];
   if (userId) {
@@ -84,6 +85,9 @@ function buildFilter(
   }
   if (sessionId) {
     conditions.push(eq(api_request_log.session_id, sessionId));
+  }
+  if (errorsOnly) {
+    conditions.push(or(gte(api_request_log.status_code, 400), isNotNull(api_request_log.error)));
   }
   return and(...conditions);
 }
@@ -102,6 +106,7 @@ export async function GET(request: NextRequest) {
   const endDate = searchParams.get('endDate');
   const model = searchParams.get('model');
   const sessionId = searchParams.get('sessionId') || searchParams.get('session_id');
+  const errorsOnly = searchParams.get('errorsOnly') === 'true';
 
   const parsedStart = startDate ? parseDate(startDate) : null;
   const parsedEnd = endDate ? parseDate(endDate + 'T23:59:59.999Z') : null;
@@ -109,7 +114,7 @@ export async function GET(request: NextRequest) {
     return jsonError('Invalid date format. Use YYYY-MM-DD.', 400);
   }
 
-  const filter = buildFilter(userId, parsedStart, parsedEnd, model, sessionId);
+  const filter = buildFilter(userId, parsedStart, parsedEnd, model, sessionId, errorsOnly);
 
   const [result] = await db.select({ total: count() }).from(api_request_log).where(filter);
   if (result.total === 0) {
@@ -147,6 +152,13 @@ export async function GET(request: NextRequest) {
         if (responseContent) {
           archive.append(responseContent, { name: `${ts}_${id}_response.${responseExt}` });
         }
+
+        if (row.error !== null && row.error !== undefined) {
+          const errorContent = tryFormatJson(row.error);
+          if (errorContent) {
+            archive.append(errorContent, { name: `${ts}_${id}_error.json` });
+          }
+        }
       }
 
       cursor = rows[rows.length - 1].id;
@@ -183,7 +195,8 @@ export async function GET(request: NextRequest) {
   const safeUserId = userId ? sanitize(userId) : 'all-users';
   const safeModel = model ? `_${sanitize(model)}` : '';
   const safeSessionId = sessionId ? `_${sanitize(sessionId)}` : '';
-  const filename = `api-request-log_${safeUserId}_${startDate ?? 'any-start'}_${endDate ?? 'any-end'}${safeModel}${safeSessionId}.zip`;
+  const safeErrorsOnly = errorsOnly ? '_errors-only' : '';
+  const filename = `api-request-log_${safeUserId}_${startDate ?? 'any-start'}_${endDate ?? 'any-end'}${safeModel}${safeSessionId}${safeErrorsOnly}.zip`;
 
   return new Response(webStream, {
     headers: {


### PR DESCRIPTION
## Summary

Adds an "Errors only" filter to the API request log download at `/admin/gateway?tab=api-request-log`.

## Changes

- **Error JSON files in download**: When a log row has a value in the `error` column, the downloaded ZIP now includes a `<timestamp>_<id>_error.json` file with the formatted error payload (alongside the existing request/response files).
- **"Errors only" checkbox filter**: A new checkbox on the page filters the download to only rows where `status_code >= 400` or `error IS NOT NULL`. When enabled, the `errorsOnly=true` query param is sent and the resulting filename is suffixed with `_errors-only`.