### PR TITLE
Make Vercel routing percentage for free models separately configurable

### DIFF
--- a/apps/web/src/app/admin/gateway/RoutingContent.tsx
+++ b/apps/web/src/app/admin/gateway/RoutingContent.tsx
@@ -11,6 +11,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import {
   DEFAULT_VERCEL_PERCENTAGE,
+  DEFAULT_VERCEL_PERCENTAGE_FREE,
   NOTE_MAX_LENGTH,
   VercelRoutingPercentageSchema,
 } from '@/lib/ai-gateway/gateway-config';
@@ -22,12 +23,14 @@ export function RoutingContent() {
   const { data, isLoading } = useQuery(trpc.admin.gatewayConfig.get.queryOptions());
 
   const [inputValue, setInputValue] = useState('');
+  const [freeInputValue, setFreeInputValue] = useState('');
   const [noteValue, setNoteValue] = useState('');
   const [hasChanges, setHasChanges] = useState(false);
 
   useEffect(() => {
     if (data) {
       setInputValue(data.vercel_routing_percentage?.toString() ?? '');
+      setFreeInputValue(data.vercel_routing_percentage_free?.toString() ?? '');
       setNoteValue('');
       setHasChanges(false);
     }
@@ -52,25 +55,37 @@ export function RoutingContent() {
     return trimmed === '' ? null : trimmed;
   }
 
+  function parsePercentage(raw: string): number | null | undefined {
+    const trimmed = raw.trim();
+    if (trimmed === '') return null;
+    const num = Number(trimmed);
+    if (!VercelRoutingPercentageSchema.safeParse(num).success) return undefined;
+    return num;
+  }
+
   function handleSave() {
-    const trimmed = inputValue.trim();
     const note = noteInput();
-    if (trimmed === '') {
-      mutation.mutate({ vercel_routing_percentage: null, note });
-    } else {
-      const num = Number(trimmed);
-      if (!VercelRoutingPercentageSchema.safeParse(num).success) {
-        toast.error(
-          'Enter a percentage between 0 and 100 with up to 3 decimal places, or leave it empty for the default.'
-        );
-        return;
-      }
-      mutation.mutate({ vercel_routing_percentage: num, note });
+    const paid = parsePercentage(inputValue);
+    const free = parsePercentage(freeInputValue);
+    if (paid === undefined || free === undefined) {
+      toast.error(
+        'Enter a percentage between 0 and 100 with up to 3 decimal places, or leave it empty for the default.'
+      );
+      return;
     }
+    mutation.mutate({
+      vercel_routing_percentage: paid,
+      vercel_routing_percentage_free: free,
+      note,
+    });
   }
 
   function handleClear() {
-    mutation.mutate({ vercel_routing_percentage: null, note: noteInput() });
+    mutation.mutate({
+      vercel_routing_percentage: null,
+      vercel_routing_percentage_free: null,
+      note: noteInput(),
+    });
   }
 
   if (isLoading) {
@@ -78,7 +93,10 @@ export function RoutingContent() {
   }
 
   const currentOverride = data?.vercel_routing_percentage;
-  const isOverrideActive = currentOverride !== null && currentOverride !== undefined;
+  const currentFreeOverride = data?.vercel_routing_percentage_free;
+  const isOverrideActive =
+    (currentOverride !== null && currentOverride !== undefined) ||
+    (currentFreeOverride !== null && currentFreeOverride !== undefined);
 
   return (
     <div className="flex w-full flex-col gap-y-6">
@@ -88,13 +106,18 @@ export function RoutingContent() {
           <CardDescription>
             For models available on the Vercel AI Gateway, controls the percentage of traffic routed
             to Vercel (vs OpenRouter). Models not available on Vercel always go to OpenRouter, so
-            overall traffic may still be skewed towards OpenRouter. Leave empty to use the default (
-            {DEFAULT_VERCEL_PERCENTAGE}%).
+            overall traffic may still be skewed towards OpenRouter. Paid and free models are
+            configured separately. Leave empty to use the default ({DEFAULT_VERCEL_PERCENTAGE}% for
+            paid, {DEFAULT_VERCEL_PERCENTAGE_FREE}% for free).
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col gap-4">
           <div className="flex items-center gap-3">
+            <Label htmlFor="routing-paid" className="w-24 shrink-0">
+              Paid models
+            </Label>
             <Input
+              id="routing-paid"
               type="number"
               min={0}
               max={100}
@@ -111,6 +134,31 @@ export function RoutingContent() {
               className="w-48"
             />
             <span className="text-muted-foreground text-sm">%</span>
+          </div>
+          <div className="flex items-center gap-3">
+            <Label htmlFor="routing-free" className="w-24 shrink-0">
+              Free models
+            </Label>
+            <Input
+              id="routing-free"
+              type="number"
+              min={0}
+              max={100}
+              step={0.001}
+              placeholder={`Default: ${DEFAULT_VERCEL_PERCENTAGE_FREE}%`}
+              value={freeInputValue}
+              onChange={e => {
+                setFreeInputValue(e.target.value);
+                setHasChanges(true);
+              }}
+              onKeyDown={e => {
+                if (e.key === 'Enter') handleSave();
+              }}
+              className="w-48"
+            />
+            <span className="text-muted-foreground text-sm">%</span>
+          </div>
+          <div className="flex items-center gap-3">
             <Button onClick={handleSave} disabled={mutation.isPending || !hasChanges} size="sm">
               {mutation.isPending ? 'Saving...' : 'Save'}
             </Button>
@@ -145,8 +193,14 @@ export function RoutingContent() {
             {isOverrideActive ? (
               <p>
                 Override active:{' '}
-                <span className="text-foreground font-medium">{currentOverride}%</span> of traffic
-                goes to Vercel.
+                <span className="text-foreground font-medium">
+                  {currentOverride ?? DEFAULT_VERCEL_PERCENTAGE}%
+                </span>{' '}
+                of paid traffic and{' '}
+                <span className="text-foreground font-medium">
+                  {currentFreeOverride ?? DEFAULT_VERCEL_PERCENTAGE_FREE}%
+                </span>{' '}
+                of free traffic goes to Vercel.
                 {data?.updated_by_email && (
                   <span className="ml-1">
                     Set by {data.updated_by_email}
@@ -156,7 +210,8 @@ export function RoutingContent() {
               </p>
             ) : (
               <p>
-                No override set. Using default routing ({DEFAULT_VERCEL_PERCENTAGE}% to Vercel).
+                No override set. Using default routing ({DEFAULT_VERCEL_PERCENTAGE}% of paid and{' '}
+                {DEFAULT_VERCEL_PERCENTAGE_FREE}% of free traffic to Vercel).
               </p>
             )}
             {data?.note && (

--- a/apps/web/src/lib/ai-gateway/gateway-config.test.ts
+++ b/apps/web/src/lib/ai-gateway/gateway-config.test.ts
@@ -41,7 +41,10 @@ describe('GatewayPercentageSchema', () => {
 
   test('accepts a separate free percentage', () => {
     expect(
-      GatewayPercentageSchema.parse({ vercel_routing_percentage: 25, vercel_routing_percentage_free: 80 })
+      GatewayPercentageSchema.parse({
+        vercel_routing_percentage: 25,
+        vercel_routing_percentage_free: 80,
+      })
     ).toEqual({ vercel_routing_percentage: 25, vercel_routing_percentage_free: 80 });
   });
 
@@ -49,7 +52,10 @@ describe('GatewayPercentageSchema', () => {
     expect(() => GatewayPercentageSchema.parse({ vercel_routing_percentage: 101 })).toThrow();
     expect(() => GatewayPercentageSchema.parse({ vercel_routing_percentage: -1 })).toThrow();
     expect(() =>
-      GatewayPercentageSchema.parse({ vercel_routing_percentage: 25, vercel_routing_percentage_free: 101 })
+      GatewayPercentageSchema.parse({
+        vercel_routing_percentage: 25,
+        vercel_routing_percentage_free: 101,
+      })
     ).toThrow();
   });
 });
@@ -85,7 +91,11 @@ describe('GatewayConfigInputSchema', () => {
         vercel_routing_percentage_free: 60,
         note: 'Rollout stable',
       })
-    ).toEqual({ vercel_routing_percentage: 75, vercel_routing_percentage_free: 60, note: 'Rollout stable' });
+    ).toEqual({
+      vercel_routing_percentage: 75,
+      vercel_routing_percentage_free: 60,
+      note: 'Rollout stable',
+    });
   });
 
   test('accepts a null note', () => {
@@ -95,7 +105,11 @@ describe('GatewayConfigInputSchema', () => {
         vercel_routing_percentage_free: null,
         note: null,
       })
-    ).toEqual({ vercel_routing_percentage: null, vercel_routing_percentage_free: null, note: null });
+    ).toEqual({
+      vercel_routing_percentage: null,
+      vercel_routing_percentage_free: null,
+      note: null,
+    });
   });
 
   test('rejects notes longer than the maximum', () => {

--- a/apps/web/src/lib/ai-gateway/gateway-config.test.ts
+++ b/apps/web/src/lib/ai-gateway/gateway-config.test.ts
@@ -21,18 +21,36 @@ describe('GatewayPercentageSchema', () => {
   test('accepts a numeric percentage', () => {
     expect(GatewayPercentageSchema.parse({ vercel_routing_percentage: 25 })).toEqual({
       vercel_routing_percentage: 25,
+      vercel_routing_percentage_free: null,
     });
   });
 
   test('accepts null (written when an admin clears the override)', () => {
     expect(GatewayPercentageSchema.parse({ vercel_routing_percentage: null })).toEqual({
       vercel_routing_percentage: null,
+      vercel_routing_percentage_free: null,
     });
+  });
+
+  test('defaults the free percentage to null for pre-existing entries', () => {
+    expect(GatewayPercentageSchema.parse({ vercel_routing_percentage: 25 })).toEqual({
+      vercel_routing_percentage: 25,
+      vercel_routing_percentage_free: null,
+    });
+  });
+
+  test('accepts a separate free percentage', () => {
+    expect(
+      GatewayPercentageSchema.parse({ vercel_routing_percentage: 25, vercel_routing_percentage_free: 80 })
+    ).toEqual({ vercel_routing_percentage: 25, vercel_routing_percentage_free: 80 });
   });
 
   test('rejects out-of-range values', () => {
     expect(() => GatewayPercentageSchema.parse({ vercel_routing_percentage: 101 })).toThrow();
     expect(() => GatewayPercentageSchema.parse({ vercel_routing_percentage: -1 })).toThrow();
+    expect(() =>
+      GatewayPercentageSchema.parse({ vercel_routing_percentage: 25, vercel_routing_percentage_free: 101 })
+    ).toThrow();
   });
 });
 
@@ -62,20 +80,29 @@ describe('GatewayConfigSchema', () => {
 describe('GatewayConfigInputSchema', () => {
   test('accepts a note alongside a percentage', () => {
     expect(
-      GatewayConfigInputSchema.parse({ vercel_routing_percentage: 75, note: 'Rollout stable' })
-    ).toEqual({ vercel_routing_percentage: 75, note: 'Rollout stable' });
+      GatewayConfigInputSchema.parse({
+        vercel_routing_percentage: 75,
+        vercel_routing_percentage_free: 60,
+        note: 'Rollout stable',
+      })
+    ).toEqual({ vercel_routing_percentage: 75, vercel_routing_percentage_free: 60, note: 'Rollout stable' });
   });
 
   test('accepts a null note', () => {
-    expect(GatewayConfigInputSchema.parse({ vercel_routing_percentage: null, note: null })).toEqual(
-      { vercel_routing_percentage: null, note: null }
-    );
+    expect(
+      GatewayConfigInputSchema.parse({
+        vercel_routing_percentage: null,
+        vercel_routing_percentage_free: null,
+        note: null,
+      })
+    ).toEqual({ vercel_routing_percentage: null, vercel_routing_percentage_free: null, note: null });
   });
 
   test('rejects notes longer than the maximum', () => {
     expect(() =>
       GatewayConfigInputSchema.parse({
         vercel_routing_percentage: 50,
+        vercel_routing_percentage_free: 50,
         note: 'x'.repeat(NOTE_MAX_LENGTH + 1),
       })
     ).toThrow();

--- a/apps/web/src/lib/ai-gateway/gateway-config.ts
+++ b/apps/web/src/lib/ai-gateway/gateway-config.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 
 export const DEFAULT_VERCEL_PERCENTAGE = 50;
+export const DEFAULT_VERCEL_PERCENTAGE_FREE = 50;
 
 export const VercelRoutingPercentageSchema = z.number().min(0).max(100).multipleOf(0.001);
 
@@ -10,6 +11,7 @@ const note = z.string().max(NOTE_MAX_LENGTH);
 
 export const GatewayConfigSchema = z.object({
   vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
+  vercel_routing_percentage_free: VercelRoutingPercentageSchema.nullable().default(null),
   updated_at: z.string().nullable(),
   updated_by: z.string().nullable(),
   updated_by_email: z.string().nullable(),
@@ -20,6 +22,7 @@ export type GatewayConfig = z.infer<typeof GatewayConfigSchema>;
 
 export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {
   vercel_routing_percentage: null,
+  vercel_routing_percentage_free: null,
   updated_at: null,
   updated_by: null,
   updated_by_email: null,
@@ -31,14 +34,21 @@ export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {
  *
  * `vercel_routing_percentage` is nullable because clearing the override in
  * the admin UI persists an explicit `null`. Callers should treat `null` as
- * "no override, use DEFAULT_VERCEL_PERCENTAGE".
+ * "no override, use DEFAULT_VERCEL_PERCENTAGE". It applies to paid models.
+ *
+ * `vercel_routing_percentage_free` is the separate override for free models
+ * and defaults to `null` so pre-existing Redis entries without the field
+ * parse cleanly. Callers should treat `null` as "no override, use
+ * DEFAULT_VERCEL_PERCENTAGE_FREE".
  */
 export const GatewayPercentageSchema = z.object({
   vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
+  vercel_routing_percentage_free: VercelRoutingPercentageSchema.nullable().default(null),
 });
 
 /** Schema for the admin set-mutation input. */
 export const GatewayConfigInputSchema = z.object({
   vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
+  vercel_routing_percentage_free: VercelRoutingPercentageSchema.nullable(),
   note: note.nullable(),
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -17,24 +17,40 @@ import { createCachedFetch } from '@/lib/cached-fetch';
 import {
   GatewayPercentageSchema,
   DEFAULT_VERCEL_PERCENTAGE,
+  DEFAULT_VERCEL_PERCENTAGE_FREE,
 } from '@/lib/ai-gateway/gateway-config';
 import { VERCEL_ROUTING_REDIS_KEY } from '@/lib/redis-keys';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
+import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
 import {
   getCachedVercelInferenceProviderIdsForModel,
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 
-const getVercelRoutingPercentage = createCachedFetch(
+type VercelRoutingPercentages = {
+  paid: number;
+  free: number;
+};
+
+const DEFAULT_VERCEL_ROUTING_PERCENTAGES: VercelRoutingPercentages = {
+  paid: DEFAULT_VERCEL_PERCENTAGE,
+  free: DEFAULT_VERCEL_PERCENTAGE_FREE,
+};
+
+const getVercelRoutingPercentages = createCachedFetch<VercelRoutingPercentages>(
   async () => {
     const raw = await redisClient.get<string>(VERCEL_ROUTING_REDIS_KEY);
-    if (!raw) return DEFAULT_VERCEL_PERCENTAGE;
-    const { vercel_routing_percentage } = GatewayPercentageSchema.parse(JSON.parse(raw));
-    return vercel_routing_percentage ?? DEFAULT_VERCEL_PERCENTAGE;
+    if (!raw) return DEFAULT_VERCEL_ROUTING_PERCENTAGES;
+    const { vercel_routing_percentage, vercel_routing_percentage_free } =
+      GatewayPercentageSchema.parse(JSON.parse(raw));
+    return {
+      paid: vercel_routing_percentage ?? DEFAULT_VERCEL_PERCENTAGE,
+      free: vercel_routing_percentage_free ?? DEFAULT_VERCEL_PERCENTAGE_FREE,
+    };
   },
   600_000,
-  DEFAULT_VERCEL_PERCENTAGE
+  DEFAULT_VERCEL_ROUTING_PERCENTAGES
 );
 
 export function hasCompatibleVercelInferenceProvider(
@@ -79,7 +95,10 @@ export async function shouldRouteToVercel(
   randomSeed: string
 ) {
   console.debug('[shouldRouteToVercel] randomizing user to either OpenRouter or Vercel');
-  const routingPercentage = await getVercelRoutingPercentage();
+  const percentages = await getVercelRoutingPercentages();
+  const routingPercentage = (await isFreeModel(requestedModel))
+    ? percentages.free
+    : percentages.paid;
 
   const passedRandomization = passesVercelRoutingPercentage(randomSeed, routingPercentage);
 

--- a/apps/web/src/routers/admin/gateway-config-router.ts
+++ b/apps/web/src/routers/admin/gateway-config-router.ts
@@ -27,6 +27,7 @@ export const adminGatewayConfigRouter = createTRPCRouter({
   set: adminProcedure.input(GatewayConfigInputSchema).mutation(async ({ input, ctx }) => {
     const config: GatewayConfig = {
       vercel_routing_percentage: input.vercel_routing_percentage,
+      vercel_routing_percentage_free: input.vercel_routing_percentage_free,
       updated_at: new Date().toISOString(),
       updated_by: ctx.user.id,
       updated_by_email: ctx.user.google_user_email,


### PR DESCRIPTION
Adds a separate `vercel_routing_percentage_free` field to the Vercel routing Redis config object, defaulting to 50%.

- The existing `vercel_routing_percentage` continues to apply to paid models.
- Free models (per `isFreeModel`) now use the new `vercel_routing_percentage_free` override.
- The admin gateway routing UI exposes separate inputs for paid and free models.
- Both fields default to `null` (no override) so pre-existing Redis entries parse cleanly.