### PR TITLE
Only register upstream timeout listener when vercel id is available

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -874,6 +874,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     extraHeaders,
     provider: effectiveProviderContext.provider,
     signal: request.signal,
+    request,
   });
   if (upstreamResult.type === 'error') {
     return upstreamResult.response;

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -156,6 +156,7 @@ export async function upstreamRequest({
   extraHeaders,
   provider,
   signal,
+  request,
 }: {
   path: string;
   search: string;
@@ -164,6 +165,7 @@ export async function upstreamRequest({
   extraHeaders: Record<string, string>;
   provider: Provider;
   signal?: AbortSignal;
+  request?: Request;
 }): Promise<{ type: 'success'; response: Response } | { type: 'error'; response: NextResponse }> {
   const headers = new Headers();
   for (const [key, value] of Object.entries(ATTRIBUTION_HEADERS)) {
@@ -180,9 +182,16 @@ export async function upstreamRequest({
 
   const TEN_MINUTES_MS = 10 * 60 * 1000;
   const timeoutSignal = AbortSignal.timeout(TEN_MINUTES_MS);
-  timeoutSignal.addEventListener('abort', () => {
-    errorExceptInTest('[upstreamRequest] timeout');
-  });
+  const vercelId = request?.headers.get('x-vercel-id');
+  if (request && vercelId) {
+    const req = request;
+    timeoutSignal.addEventListener('abort', () => {
+      const currentVercelId = req.headers.get('x-vercel-id');
+      if (currentVercelId === vercelId) {
+        errorExceptInTest(`[upstreamRequest] timeout (vercelId: ${currentVercelId})`);
+      }
+    });
+  }
   const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 
   try {


### PR DESCRIPTION
Guard the timeout abort listener in upstreamRequest so it is only registered when an x-vercel-id header is present on the incoming request. Inside the listener, re-read the header and only log if it matches the originally captured value.