### PR TITLE
feat(admin): show organization integrations

### DIFF
--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminDashboard.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminDashboard.tsx
@@ -12,6 +12,7 @@ import { OrganizationAdminCreatedBy } from './OrganizationAdminCreatedBy';
 import { OrganizationAdminHierarchyManagement } from './OrganizationAdminHierarchyManagement';
 import { OrganizationWorkOSCard } from './OrganizationWorkOSCard';
 import { OrganizationAdminWebhooks } from './OrganizationAdminWebhooks';
+import { OrganizationAdminIntegrations } from './OrganizationAdminIntegrations';
 import { OrganizationContextProvider } from '@/components/organizations/OrganizationContext';
 import AdminPage from '@/app/admin/components/AdminPage';
 import {
@@ -56,6 +57,7 @@ export function OrganizationAdminDashboard({ organizationId }: { organizationId:
             <div className="grid grid-cols-1 gap-8 lg:grid-cols-2">
               <div className="space-y-4">
                 <OrganizationInfoCard organizationId={organizationId} showAdminControls />
+                <OrganizationAdminIntegrations organizationId={organizationId} />
                 <OrganizationAdminHierarchyManagement organizationId={organizationId} />
               </div>
               <div className="space-y-7">

--- a/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminIntegrations.tsx
+++ b/apps/web/src/app/admin/components/OrganizationAdmin/OrganizationAdminIntegrations.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Plug } from 'lucide-react';
+import { useAdminOrganizationDetails } from '@/app/admin/api/organizations/hooks';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PLATFORM_DEFINITIONS } from '@/lib/integrations/platform-definitions';
+
+function getPlatformName(platform: string): string {
+  return PLATFORM_DEFINITIONS.find(definition => definition.id === platform)?.name ?? platform;
+}
+
+export function OrganizationAdminIntegrations({ organizationId }: { organizationId: string }) {
+  const { data, isError } = useAdminOrganizationDetails(organizationId);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Plug className="size-4" />
+          Integrations
+        </CardTitle>
+        <CardDescription>Active integrations owned by this organization.</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {isError ? (
+          <p className="type-body text-status-destructive">Unable to load integrations.</p>
+        ) : !data ? (
+          <div className="flex gap-2" aria-label="Loading integrations">
+            <Skeleton className="h-6 w-20 rounded-full" />
+            <Skeleton className="h-6 w-16 rounded-full" />
+          </div>
+        ) : data.integrations.length === 0 ? (
+          <p className="type-body text-muted-foreground">No active integrations.</p>
+        ) : (
+          <div className="flex flex-wrap gap-2">
+            {data.integrations.map(integration => (
+              <Badge key={integration.platform} variant="secondary">
+                {getPlatformName(integration.platform)}
+                {integration.installation_count > 1 && ` (${integration.installation_count})`}
+              </Badge>
+            ))}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/routers/organizations/organization-admin-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.test.ts
@@ -6,6 +6,7 @@ import {
   organization_seats_purchases,
   organization_memberships,
   kilo_pass_subscriptions,
+  platform_integrations,
 } from '@kilocode/db/schema';
 import { eq, and, inArray, sql } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -13,6 +14,7 @@ import { createOrganization, addUserToOrganization } from '@/lib/organizations/o
 import { KiloPassCadence, KiloPassTier } from '@/lib/kilo-pass/enums';
 import { fetchExpiringTransactionsForOrganization } from '@/lib/creditExpiration';
 import type { User, Organization } from '@kilocode/db/schema';
+import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
 
 jest.mock('@/lib/organizations/organization-billing', () => ({
   getOrCreateStripeCustomerIdForOrganization: jest.fn().mockResolvedValue('cus_test_admin_org'),
@@ -49,6 +51,63 @@ describe('organization admin router', () => {
 
   afterAll(async () => {
     await db.delete(organizations).where(eq(organizations.id, testOrganization.id));
+  });
+
+  describe('getDetails', () => {
+    beforeEach(async () => {
+      await db
+        .delete(platform_integrations)
+        .where(eq(platform_integrations.owned_by_organization_id, testOrganization.id));
+    });
+
+    afterEach(async () => {
+      await db
+        .delete(platform_integrations)
+        .where(eq(platform_integrations.owned_by_organization_id, testOrganization.id));
+    });
+
+    it('returns active organization integrations grouped by platform', async () => {
+      await db.insert(platform_integrations).values([
+        {
+          owned_by_organization_id: testOrganization.id,
+          platform: PLATFORM.GITHUB,
+          integration_type: 'app',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          platform_installation_id: 'admin-details-github-1',
+        },
+        {
+          owned_by_organization_id: testOrganization.id,
+          platform: PLATFORM.GITHUB,
+          integration_type: 'app',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          platform_installation_id: 'admin-details-github-2',
+        },
+        {
+          owned_by_organization_id: testOrganization.id,
+          platform: PLATFORM.LINEAR,
+          integration_type: 'oauth',
+          integration_status: INTEGRATION_STATUS.ACTIVE,
+          platform_installation_id: 'admin-details-linear',
+        },
+        {
+          owned_by_organization_id: testOrganization.id,
+          platform: PLATFORM.SLACK,
+          integration_type: 'oauth',
+          integration_status: INTEGRATION_STATUS.PENDING,
+          platform_installation_id: 'admin-details-slack',
+        },
+      ]);
+
+      const caller = await createCallerForUser(adminUser.id);
+      const result = await caller.organizations.admin.getDetails({
+        organizationId: testOrganization.id,
+      });
+
+      expect(result.integrations).toEqual([
+        { platform: PLATFORM.GITHUB, installation_count: 2 },
+        { platform: PLATFORM.LINEAR, installation_count: 1 },
+      ]);
+    });
   });
 
   describe('nullifyCredits', () => {

--- a/apps/web/src/routers/organizations/organization-admin-router.ts
+++ b/apps/web/src/routers/organizations/organization-admin-router.ts
@@ -57,6 +57,7 @@ import {
   ORGANIZATION_TRIAL_ACTIVE_MIN_DAYS_REMAINING,
   ORGANIZATION_TRIAL_DURATION_DAYS,
 } from '@kilocode/organization-entitlement';
+import { INTEGRATION_STATUS } from '@/lib/integrations/core/constants';
 
 const OrganizationListInputSchema = z.object({
   page: z.number().int().min(1).default(1),
@@ -142,6 +143,12 @@ const AdminOrganizationDetailsSchema = z.object({
   created_by_kilo_user_id: z.string().nullable(),
   created_by_user_email: z.string().nullable(),
   created_by_user_name: z.string().nullable(),
+  integrations: z.array(
+    z.object({
+      platform: z.string(),
+      installation_count: z.number(),
+    })
+  ),
 });
 
 const OrganizationHierarchySummarySchema = z.object({
@@ -446,22 +453,38 @@ export const organizationAdminRouter = createTRPCRouter({
     .query(async ({ input }) => {
       const { organizationId } = input;
 
-      const organizationDetails = await db
-        .select({
-          id: organizations.id,
-          name: organizations.name,
-          created_at: organizations.created_at,
-          updated_at: organizations.updated_at,
-          total_microdollars_acquired: organizations.total_microdollars_acquired,
-          microdollars_used: organizations.microdollars_used,
-          created_by_kilo_user_id: organizations.created_by_kilo_user_id,
-          created_by_user_email: kilocode_users.google_user_email,
-          created_by_user_name: kilocode_users.google_user_name,
-        })
-        .from(organizations)
-        .leftJoin(kilocode_users, eq(organizations.created_by_kilo_user_id, kilocode_users.id))
-        .where(eq(organizations.id, organizationId))
-        .limit(1);
+      const [organizationDetails, integrations] = await Promise.all([
+        db
+          .select({
+            id: organizations.id,
+            name: organizations.name,
+            created_at: organizations.created_at,
+            updated_at: organizations.updated_at,
+            total_microdollars_acquired: organizations.total_microdollars_acquired,
+            microdollars_used: organizations.microdollars_used,
+            created_by_kilo_user_id: organizations.created_by_kilo_user_id,
+            created_by_user_email: kilocode_users.google_user_email,
+            created_by_user_name: kilocode_users.google_user_name,
+          })
+          .from(organizations)
+          .leftJoin(kilocode_users, eq(organizations.created_by_kilo_user_id, kilocode_users.id))
+          .where(eq(organizations.id, organizationId))
+          .limit(1),
+        db
+          .select({
+            platform: platform_integrations.platform,
+            installation_count: count(),
+          })
+          .from(platform_integrations)
+          .where(
+            and(
+              eq(platform_integrations.owned_by_organization_id, organizationId),
+              eq(platform_integrations.integration_status, INTEGRATION_STATUS.ACTIVE)
+            )
+          )
+          .groupBy(platform_integrations.platform)
+          .orderBy(asc(platform_integrations.platform)),
+      ]);
 
       if (!organizationDetails || organizationDetails.length === 0) {
         throw new TRPCError({
@@ -470,7 +493,7 @@ export const organizationAdminRouter = createTRPCRouter({
         });
       }
 
-      return organizationDetails[0];
+      return { ...organizationDetails[0], integrations };
     }),
 
   getHierarchy: adminProcedure


### PR DESCRIPTION
## Summary

- Add an Integrations card to the admin organization detail page so Kilo admins can see active organization-owned platforms at a glance.
- Extend the existing admin organization details query with a generic, grouped integration summary rather than platform-specific flags, including installation counts for platforms with multiple connections.
- Keep pending and suspended integrations out of the enabled list.

## Verification


## Visual Changes

N/A

## Reviewer Notes

The card only displays:
- Platform name, such as GitHub, Slack, or Linear
- Installation count when greater than one, such as GitHub (2)
- No active integrations when empty