### PR TITLE
Rename rewriteFreeModelResponse to rewriteModelResponse

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -56,7 +56,7 @@ import {
 import { ProxyErrorType } from '@/lib/proxy-error-types';
 import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage';
 import { isDataCollectionExplicitlyDisallowed } from '@/lib/ai-gateway/providers/openrouter/types';
-import { rewriteFreeModelResponse } from '@/lib/rewriteModelResponse';
+import { rewriteModelResponse } from '@/lib/rewriteModelResponse';
 import {
   createAnonymousContext,
   isAnonymousContext,
@@ -981,7 +981,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     }
   }
 
-  const rewrittenResponse = await rewriteFreeModelResponse(
+  const rewrittenResponse = await rewriteModelResponse(
     response,
     effectiveModelIdLowerCased,
     effectiveProviderContext.provider.id,

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -1,8 +1,8 @@
 import { describe, test, expect } from '@jest/globals';
 import {
-  rewriteFreeModelResponse_ChatCompletions,
-  rewriteFreeModelResponse_Messages,
-  rewriteFreeModelResponse_Responses,
+  rewriteModelResponse_ChatCompletions,
+  rewriteModelResponse_Messages,
+  rewriteModelResponse_Responses,
 } from './rewriteModelResponse';
 
 const REWRITTEN_MODEL = 'kilo/my-free-model';
@@ -55,7 +55,7 @@ function dataObjects(sse: string): unknown[] {
     .map(payload => JSON.parse(payload));
 }
 
-describe('rewriteFreeModelResponse_ChatCompletions', () => {
+describe('rewriteModelResponse_ChatCompletions', () => {
   describe('JSON responses', () => {
     test('rewrites the model and strips upstream cost fields', async () => {
       const upstream = jsonResponse({
@@ -71,7 +71,7 @@ describe('rewriteFreeModelResponse_ChatCompletions', () => {
         },
       });
 
-      const result = await rewriteFreeModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
       const json = await result.json();
 
       expect(json.model).toBe(REWRITTEN_MODEL);
@@ -94,7 +94,7 @@ describe('rewriteFreeModelResponse_ChatCompletions', () => {
         },
       });
 
-      const result = await rewriteFreeModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
       const json = await result.json();
 
       expect(json.usage.prompt_tokens_details.cached_tokens).toBe(0);
@@ -107,7 +107,7 @@ describe('rewriteFreeModelResponse_ChatCompletions', () => {
         headers: { 'content-type': 'application/json' },
       });
 
-      const result = await rewriteFreeModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
 
       expect(result.status).toBe(502);
       expect(await result.text()).toBe('not-json{');
@@ -121,7 +121,7 @@ describe('rewriteFreeModelResponse_ChatCompletions', () => {
           'data: [DONE]\n\n'
       );
 
-      const result = await rewriteFreeModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
       const sse = await readOutputStream(result);
       const [chunk] = dataObjects(sse) as Array<{
         model: string;
@@ -139,7 +139,7 @@ describe('rewriteFreeModelResponse_ChatCompletions', () => {
         'data: {"model":"upstream-model","usage":{"cost":1,"is_byok":true,"prompt_tokens":4,"completion_tokens":2,"total_tokens":6,"prompt_tokens_details":{}}}\n\n'
       );
 
-      const result = await rewriteFreeModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
       const sse = await readOutputStream(result);
       const [chunk] = dataObjects(sse) as Array<{
         model: string;
@@ -163,7 +163,7 @@ describe('rewriteFreeModelResponse_ChatCompletions', () => {
         ': openrouter heartbeat\n\n' + 'data: {"model":"upstream-model","choices":[]}\n\n'
       );
 
-      const result = await rewriteFreeModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
       const sse = await readOutputStream(result);
 
       expect(sse).toContain(': KILO PROCESSING');
@@ -175,14 +175,14 @@ describe('rewriteFreeModelResponse_ChatCompletions', () => {
         headers: { 'content-type': 'text/event-stream' },
       });
 
-      const result = await rewriteFreeModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
 
       expect(await readOutputStream(result)).toBe('');
     });
   });
 });
 
-describe('rewriteFreeModelResponse_Messages', () => {
+describe('rewriteModelResponse_Messages', () => {
   test('rewrites model and strips cost fields for JSON responses', async () => {
     const upstream = jsonResponse({
       type: 'message',
@@ -196,7 +196,7 @@ describe('rewriteFreeModelResponse_Messages', () => {
       },
     });
 
-    const result = await rewriteFreeModelResponse_Messages(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Messages(upstream, REWRITTEN_MODEL);
     const json = await result.json();
 
     expect(json.model).toBe(REWRITTEN_MODEL);
@@ -212,7 +212,7 @@ describe('rewriteFreeModelResponse_Messages', () => {
       headers: { 'content-type': 'application/json' },
     });
 
-    const result = await rewriteFreeModelResponse_Messages(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Messages(upstream, REWRITTEN_MODEL);
 
     expect(result.status).toBe(500);
     expect(await result.text()).toBe('}{');
@@ -225,7 +225,7 @@ describe('rewriteFreeModelResponse_Messages', () => {
         'data: [DONE]\n\n'
     );
 
-    const result = await rewriteFreeModelResponse_Messages(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Messages(upstream, REWRITTEN_MODEL);
     const sse = await readOutputStream(result);
     const events = dataObjects(sse) as Array<{
       type: string;
@@ -254,14 +254,14 @@ describe('rewriteFreeModelResponse_Messages', () => {
       'data: {"type":"message_delta","usage":{"output_tokens":9},"delta":{}}\n\n'
     );
 
-    const result = await rewriteFreeModelResponse_Messages(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Messages(upstream, REWRITTEN_MODEL);
     const sse = await readOutputStream(result);
 
     expect(dataPayloads(sse)).not.toContain('[DONE]');
   });
 });
 
-describe('rewriteFreeModelResponse_Responses', () => {
+describe('rewriteModelResponse_Responses', () => {
   test('rewrites model and strips cost fields for JSON responses', async () => {
     const upstream = jsonResponse({
       id: 'resp_1',
@@ -276,7 +276,7 @@ describe('rewriteFreeModelResponse_Responses', () => {
       },
     });
 
-    const result = await rewriteFreeModelResponse_Responses(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Responses(upstream, REWRITTEN_MODEL);
     const json = await result.json();
 
     expect(json.model).toBe(REWRITTEN_MODEL);
@@ -292,7 +292,7 @@ describe('rewriteFreeModelResponse_Responses', () => {
         'data: [DONE]\n\n'
     );
 
-    const result = await rewriteFreeModelResponse_Responses(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Responses(upstream, REWRITTEN_MODEL);
     const sse = await readOutputStream(result);
     const [event] = dataObjects(sse) as Array<{
       type: string;

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -21,7 +21,7 @@ function rewriteUsage(usage: OpenRouterUsage) {
   }
 }
 
-export async function rewriteFreeModelResponse_ChatCompletions(response: Response, model: string) {
+export async function rewriteModelResponse_ChatCompletions(response: Response, model: string) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -148,7 +148,7 @@ function rewriteMessagesUsage(usage: MessagesApiUsage) {
   delete usage.is_byok;
 }
 
-export async function rewriteFreeModelResponse_Messages(response: Response, model: string) {
+export async function rewriteModelResponse_Messages(response: Response, model: string) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -254,7 +254,7 @@ type ResponsesApiEvent = {
   response?: OpenAI.Responses.Response & { usage?: OpenRouterUsage | null };
 };
 
-export async function rewriteFreeModelResponse_Responses(response: Response, model: string) {
+export async function rewriteModelResponse_Responses(response: Response, model: string) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -342,7 +342,7 @@ export async function rewriteFreeModelResponse_Responses(response: Response, mod
   });
 }
 
-export async function rewriteFreeModelResponse(
+export async function rewriteModelResponse(
   response: Response,
   model: string,
   providerId: ProviderId,
@@ -352,21 +352,21 @@ export async function rewriteFreeModelResponse(
     (providerId === 'openrouter' || providerId === 'vercel') && isKiloExclusiveFreeModel(model);
 
   if (!isFreeModelRequiringCostRemoval && !shouldRedactModelNameInResponse(providerId, model)) {
-    console.debug('[rewriteFreeModelResponse] skipping rewrite for %s', model);
+    console.debug('[rewriteModelResponse] skipping rewrite for %s', model);
     return null;
   }
 
-  console.debug('[rewriteFreeModelResponse] rewriting response for %s', model);
+  console.debug('[rewriteModelResponse] rewriting response for %s', model);
   if (kind === 'chat_completions') {
-    return rewriteFreeModelResponse_ChatCompletions(response, model);
+    return rewriteModelResponse_ChatCompletions(response, model);
   }
   if (kind === 'responses') {
-    return rewriteFreeModelResponse_Responses(response, model);
+    return rewriteModelResponse_Responses(response, model);
   }
   if (kind === 'messages') {
-    return rewriteFreeModelResponse_Messages(response, model);
+    return rewriteModelResponse_Messages(response, model);
   }
 
-  console.error('[rewriteFreeModelResponse] implementation error: unrecognized API kind %s', kind);
+  console.error('[rewriteModelResponse] implementation error: unrecognized API kind %s', kind);
   return null;
 }


### PR DESCRIPTION
Renames all variations of `rewriteFreeModelResponse` to the more generic `rewriteModelResponse` across source, tests, and the route consumer.