### PR TITLE
fix(ai-gateway): unregister upstream timeout abort listener after response

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -10,7 +10,7 @@ import type {
 } from '@/lib/ai-gateway/providers/openrouter/types';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
-import { NextResponse } from 'next/server';
+import { after, NextResponse } from 'next/server';
 import { ProxyErrorType } from '@/lib/proxy-error-types';
 
 type UpstreamFetchFailureFamily =
@@ -180,8 +180,12 @@ export async function upstreamRequest({
 
   const TEN_MINUTES_MS = 10 * 60 * 1000;
   const timeoutSignal = AbortSignal.timeout(TEN_MINUTES_MS);
-  timeoutSignal.addEventListener('abort', () => {
+  const onTimeoutAbort = () => {
     errorExceptInTest('[upstreamRequest] timeout');
+  };
+  timeoutSignal.addEventListener('abort', onTimeoutAbort);
+  after(() => {
+    timeoutSignal.removeEventListener('abort', onTimeoutAbort);
   });
   const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -7,6 +7,16 @@ jest.mock('@sentry/nextjs', () => ({
   captureMessage: jest.fn(),
 }));
 
+// `upstreamRequest` schedules its timeout-listener cleanup through `next/server`'s
+// `after()` post-response hook, which only works in a request context. Replace it
+// with an immediate invocation so the test can run outside a request scope.
+jest.mock('next/server', () => ({
+  ...(jest.requireActual('next/server') as Record<string, unknown>),
+  after: jest.fn((work: Promise<unknown> | (() => Promise<unknown>)) => {
+    void (typeof work === 'function' ? work() : work);
+  }),
+}));
+
 const mockCaptureException = jest.mocked(captureException);
 const originalFetch = global.fetch;
 


### PR DESCRIPTION
The `abort` listener added to the 10-minute `timeoutSignal` in `upstreamRequest` was never removed, so its closure stayed retained for the full timeout window after each request completed.

Register an `after()` hook to `removeEventListener` once the response completes, allowing the listener closure to be garbage-collected promptly.

- Extracted the handler into a named `onTimeoutAbort` reference so it can be removed.
- Added `after(() => timeoutSignal.removeEventListener('abort', onTimeoutAbort))`.