### PR TITLE
feat(mobile): target PostHog feature flags by app version

### DIFF
--- a/apps/mobile/src/lib/analytics/posthog.ts
+++ b/apps/mobile/src/lib/analytics/posthog.ts
@@ -1,3 +1,4 @@
+import * as Application from 'expo-application';
 import PostHog from 'posthog-react-native';
 import { useCallback, useSyncExternalStore } from 'react';
 
@@ -40,6 +41,22 @@ let client: PostHog | null = null;
 // flags later load. init wires the client's single update into this registry.
 const flagListeners = new Set<() => void>();
 
+// App version + build for PostHog. Both are strings; `app_build` is a monotonic
+// integer-as-string, so it's the reliable field for "release >= N" flag rules
+// (`app_version` compares lexicographically). Native SDK auto-captures
+// $app_version/$app_build on events; flag targeting needs them as person
+// properties, which this supplies.
+function appVersionProperties(): Record<string, string> {
+  const props: Record<string, string> = {};
+  if (Application.nativeApplicationVersion) {
+    props.app_version = Application.nativeApplicationVersion;
+  }
+  if (Application.nativeBuildVersion) {
+    props.app_build = Application.nativeBuildVersion;
+  }
+  return props;
+}
+
 export function initPostHog(): void {
   if (client) {
     return;
@@ -52,6 +69,9 @@ export function initPostHog(): void {
   // Super property on every event so dashboards can filter mobile vs web
   // without relying on $lib.
   void client.register({ platform: 'mobile' });
+  // Feed app version/build into flag evaluation so flags can target by release
+  // even before (or without) an identified user. Triggers a flag reload.
+  client.setPersonPropertiesForFlags(appVersionProperties());
   client.onFeatureFlags(() => {
     for (const listener of flagListeners) {
       listener();
@@ -71,7 +91,9 @@ export function captureScreen(name: string): void {
 }
 
 export function identifyUser(email: string): void {
-  client?.identify(email, { email });
+  // Persist version/build on the person profile too, so cohorts and insights
+  // can segment by release (not just flag targeting).
+  client?.identify(email, { email, ...appVersionProperties() });
   // Pull the freshly-identified user's flags so gated UI resolves promptly.
   void client?.reloadFeatureFlags();
 }


### PR DESCRIPTION
## What

Feeds the app's version and build number into PostHog so mobile feature flags can be **targeted by release**.

## Why

Feature flags in PostHog evaluate against **person properties**, not super/event properties — so the existing `register({ platform: 'mobile' })` (an event super property) does nothing for flag targeting, and app version wasn't sent anywhere for flags. This wires it up.

## How

In `apps/mobile/src/lib/analytics/posthog.ts`:

- `setPersonPropertiesForFlags({ app_version, app_build })` on init — feeds version into flag evaluation (race-safe, auto-triggers a flag reload), works even before/without an identified user.
- Adds the same props to the `identify()` `$set` so they persist on the person profile for cohorts and insight segmentation.
- Values come from `expo-application` (`nativeApplicationVersion` / `nativeBuildVersion`), the accessors already used elsewhere in the app.

`app_build` is a monotonic integer-as-string, so it's the reliable field for "release >= N" flag rules (`app_version` compares lexicographically). Events already get `$app_version`/`$app_build` auto-captured by the native SDK, so event filtering was already covered — this is purely about flag targeting + person segmentation.

## Setting up targeting

Create a flag release condition on the `app_build` (or `app_version`) person property in the PostHog UI. No further app changes needed for new flags.

## Testing

`pnpm format && pnpm typecheck && pnpm lint` clean.