### PR TITLE
fix(bitbucket): normalize workspace access tokens

### DIFF
--- a/apps/web/src/components/integrations/BitbucketConnectSetup.tsx
+++ b/apps/web/src/components/integrations/BitbucketConnectSetup.tsx
@@ -116,6 +116,7 @@ export function BitbucketConnectSetup({
     trpc.organizations.bitbucket.connect.mutationOptions({
       gcTime: 0,
       onSuccess: result => {
+        setAccessToken('');
         setConnectError(null);
         queryClient.setQueryData(
           statusQueryKey,
@@ -133,7 +134,6 @@ export function BitbucketConnectSetup({
         toast.error("Couldn't connect the Bitbucket workspace", { description: error.message });
       },
       onSettled: () => {
-        setAccessToken('');
         queueMicrotask(() => mutationResetRef.current());
       },
     })
@@ -142,14 +142,14 @@ export function BitbucketConnectSetup({
 
   const handleConnect = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!accessToken) return;
+    const normalizedAccessToken = accessToken.trim();
+    if (!normalizedAccessToken) return;
 
     setConnectError(null);
     connectMutation.mutate({
       organizationId,
-      accessToken,
+      accessToken: normalizedAccessToken,
     });
-    setAccessToken('');
   };
 
   const clearError = () => setConnectError(null);
@@ -287,7 +287,7 @@ export function BitbucketConnectSetup({
                   <Button
                     type="submit"
                     className="min-h-control-touch w-full sm:h-9 sm:min-h-0"
-                    disabled={connectMutation.isPending || accessToken.length === 0}
+                    disabled={connectMutation.isPending || accessToken.trim().length === 0}
                   >
                     {connectMutation.isPending ? 'Connecting workspace...' : 'Connect workspace'}
                   </Button>

--- a/apps/web/src/components/integrations/BitbucketIntegrationControls.tsx
+++ b/apps/web/src/components/integrations/BitbucketIntegrationControls.tsx
@@ -104,7 +104,6 @@ function ReplaceTokenDialog({
         });
       },
       onSettled: () => {
-        setToken('');
         queueMicrotask(() => mutationResetRef.current());
       },
     })
@@ -129,11 +128,11 @@ function ReplaceTokenDialog({
 
   const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
     event.preventDefault();
-    if (!token) return;
+    const normalizedToken = token.trim();
+    if (!normalizedToken) return;
 
     setError(null);
-    mutation.mutate({ organizationId, integrationId, accessToken: token });
-    setToken('');
+    mutation.mutate({ organizationId, integrationId, accessToken: normalizedToken });
   };
 
   return (
@@ -217,7 +216,7 @@ function ReplaceTokenDialog({
             <Button
               type="submit"
               className="min-h-control-touch sm:h-9 sm:min-h-0"
-              disabled={mutation.isPending || token.length === 0}
+              disabled={mutation.isPending || token.trim().length === 0}
             >
               {mutation.isPending ? 'Replacing token...' : 'Replace token'}
             </Button>

--- a/apps/web/src/routers/organizations/organization-bitbucket-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-bitbucket-router.test.ts
@@ -630,7 +630,7 @@ describe('organization Bitbucket router', () => {
     expect(new Date(unchanged?.syncedAt ?? '').toISOString()).toBe(VALIDATED_AT);
   });
 
-  it('lets a billing manager connect with a token-only Workspace Access Token payload', async () => {
+  it('normalizes a billing manager Workspace Access Token before connecting', async () => {
     mockConnect.mockResolvedValue({
       integrationId: '33333333-3333-4333-8333-333333333333',
       workspace: {
@@ -647,7 +647,7 @@ describe('organization Bitbucket router', () => {
 
     await caller.organizations.bitbucket.connect({
       organizationId: organization.id,
-      accessToken: 'ATCT-manager-secret',
+      accessToken: '  ATCT-manager-secret\n',
     });
 
     expect(mockConnect).toHaveBeenCalledWith({

--- a/apps/web/src/routers/organizations/organization-bitbucket-router.ts
+++ b/apps/web/src/routers/organizations/organization-bitbucket-router.ts
@@ -32,7 +32,7 @@ import {
 } from '@/routers/organizations/utils';
 import { platform_integrations } from '@kilocode/db/schema';
 
-const AccessTokenSchema = z.string().min(1).max(8_192);
+const AccessTokenSchema = z.string().trim().min(1).max(8_192);
 const IntegrationIdSchema = z.uuid();
 
 const ConnectInputSchema = OrganizationIdInputSchema.extend({


### PR DESCRIPTION
## Summary

- Normalize surrounding whitespace on Bitbucket Workspace Access Tokens at both the form and tRPC boundaries so copied spaces or newlines do not trigger a false format error.
- Preserve submitted tokens in the connect and replacement forms after failures, which allows retrying a one-time Bitbucket credential without retrieving it again.
- Continue clearing token state after successful connection or replacement.

## Verification



## Visual Changes

N/A

## Reviewer Notes

Only surrounding whitespace is removed. Failed tokens remain temporarily in client component state for correction or retry, but are still cleared after success or when the replacement dialog is closed.