### PR TITLE
fix(dev): include LAN origin in generated WS_ALLOWED_ORIGINS for local mobile cloud-agent streaming

### DIFF
--- a/dev/local/env-sync/parse.ts
+++ b/dev/local/env-sync/parse.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process';
 import * as crypto from 'node:crypto';
 import * as fs from 'node:fs';
+import { serviceUrl } from '../mobile-env';
 import { services } from '../services';
 import type { Annotation, ExampleEntry, ResolvedValueSource } from './types';
 
@@ -236,9 +237,10 @@ function resolveAnnotatedValue(
       const defaultUsesWorkerLocalhost =
         WORKER_LOCALHOST_URL_KEYS.has(key) &&
         (entry.defaultValue.includes('localhost') || entry.defaultValue.includes('127.0.0.1'));
-      // LAN IP for container services, but never for ORIGINS keys.
-      // Preserve host.docker.internal when the example default uses it
-      // (sandbox containers need it to reach the host from inside Docker).
+      // LAN IP for container services, except for ORIGINS keys where the host is
+      // always localhost for the base entry and a LAN entry is additionally emitted
+      // when serviceUsesLanIp is set. Preserve host.docker.internal when the example
+      // default uses it (sandbox containers need it to reach the host from inside Docker).
       // Preserve localhost for worker-side URLs that are translated separately
       // before being sent into sandbox containers.
       const host = defaultUsesDockerHost
@@ -261,6 +263,9 @@ function resolveAnnotatedValue(
           resolvedParts.push(`${host}:${port}`);
         } else if (isOrigins) {
           resolvedParts.push(`http://localhost:${port}`);
+          if (serviceUsesLanIp && lanIp) {
+            resolvedParts.push(serviceUrl(lanIp, svcRef.name, 'http'));
+          }
         } else {
           const base = `${protocol}://${host}:${port}`;
           resolvedParts.push(svcRef.path ? base + svcRef.path : base);

--- a/dev/local/env-sync/plan.test.ts
+++ b/dev/local/env-sync/plan.test.ts
@@ -4,6 +4,9 @@ import * as os from 'node:os';
 import * as path from 'node:path';
 import test from 'node:test';
 import { computePlan } from './plan';
+import { resolveAnnotatedValue } from './parse';
+import type { ExampleEntry } from './types';
+import { serviceUrl } from '../mobile-env';
 import { getService } from '../services';
 
 const workerDir = 'services/cloud-agent-next';
@@ -837,7 +840,7 @@ test('preserves host.docker.internal in @url defaults for useLanIp services', ()
       content.includes(`KILOCODE_BACKEND_BASE_URL=http://host.docker.internal:${nextjsPort}`)
     );
     assert.ok(content.includes(`WORKER_URL=http://host.docker.internal:${cloudAgentPort}`));
-    // ORIGINS keys still use localhost even when example default has host.docker.internal
+    // For useLanIp services, ORIGINS keys keep the localhost entry and may also append a LAN entry.
     assert.ok(content.includes(`ALLOWED_ORIGINS=http://localhost:${nextjsPort}`));
   } finally {
     repo.cleanup();
@@ -879,4 +882,45 @@ test('preserves localhost in worker-side @url defaults for useLanIp services', (
   } finally {
     repo.cleanup();
   }
+});
+
+function originsEntry(key: string, servicesNames: string[]): ExampleEntry {
+  return {
+    key,
+    defaultValue: 'http://localhost:3000',
+    annotation: {
+      type: 'url',
+      services: servicesNames.map(name => ({ name })),
+    },
+  };
+}
+
+test('emits paired localhost and LAN origins for ORIGINS keys when serviceUsesLanIp is true', () => {
+  const entry = originsEntry('WS_ALLOWED_ORIGINS', ['nextjs', 'cloud-agent-next']);
+  const { value } = resolveAnnotatedValue(entry.key, entry, new Map(), '192.168.1.10', true);
+  const nextjsPort = getService('nextjs').port;
+  const cloudAgentPort = getService('cloud-agent-next').port;
+  const expected = [
+    `http://localhost:${nextjsPort}`,
+    serviceUrl('192.168.1.10', 'nextjs', 'http'),
+    `http://localhost:${cloudAgentPort}`,
+    serviceUrl('192.168.1.10', 'cloud-agent-next', 'http'),
+  ].join(',');
+  assert.equal(value, expected);
+});
+
+test('emits only localhost origins for ORIGINS keys when serviceUsesLanIp is false', () => {
+  const entry = originsEntry('WS_ALLOWED_ORIGINS', ['nextjs', 'cloud-agent-next']);
+  const { value } = resolveAnnotatedValue(entry.key, entry, new Map(), '192.168.1.10', false);
+  const nextjsPort = getService('nextjs').port;
+  const cloudAgentPort = getService('cloud-agent-next').port;
+  assert.equal(value, `http://localhost:${nextjsPort},http://localhost:${cloudAgentPort}`);
+});
+
+test('emits only localhost origins for ORIGINS keys when lanIp is unset', () => {
+  const entry = originsEntry('WS_ALLOWED_ORIGINS', ['nextjs', 'cloud-agent-next']);
+  const { value } = resolveAnnotatedValue(entry.key, entry, new Map(), undefined, true);
+  const nextjsPort = getService('nextjs').port;
+  const cloudAgentPort = getService('cloud-agent-next').port;
+  assert.equal(value, `http://localhost:${nextjsPort},http://localhost:${cloudAgentPort}`);
 });

--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
+import { detectLanIp } from '../lan-ip';
 import { services } from '../services';
 import type {
   Annotation,
@@ -66,23 +66,6 @@ function maybeAddEnvLocalAutoCreate(
   if (!creates.some(existing => existing.key === create.key)) {
     creates.push(create);
   }
-}
-
-// ---------------------------------------------------------------------------
-// LAN IP detection
-// ---------------------------------------------------------------------------
-
-function detectLanIp(): string | undefined {
-  const interfaces = os.networkInterfaces();
-  for (const addrs of Object.values(interfaces)) {
-    if (!addrs) continue;
-    for (const addr of addrs) {
-      if (addr.family === 'IPv4' && !addr.internal) {
-        return addr.address;
-      }
-    }
-  }
-  return undefined;
 }
 
 // ---------------------------------------------------------------------------

--- a/dev/local/lan-ip.test.ts
+++ b/dev/local/lan-ip.test.ts
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import type os from 'node:os';
+import test from 'node:test';
+import { detectLanIp, isUsableIpv4, type LanIpDeps } from './lan-ip';
+
+type ExecCall = { command: string; args: string[] };
+
+type FakeExec = (command: string, args: readonly string[], options: unknown) => string;
+
+function fakeExec(
+  routeResponse: string | undefined,
+  ipconfigResponses: Record<string, string | undefined>
+): FakeExec {
+  return (command: string, args: readonly string[], _options: unknown) => {
+    const call: ExecCall = { command, args: [...args] };
+    if (call.command === 'route' && call.args.join(' ') === '-n get default') {
+      if (routeResponse === undefined) {
+        throw new Error('route lookup failed');
+      }
+      return routeResponse;
+    }
+    if (call.command === 'ipconfig' && call.args[0] === 'getifaddr') {
+      const iface = call.args[1];
+      const response = iface !== undefined ? ipconfigResponses[iface] : undefined;
+      if (response === undefined) {
+        throw new Error(`No IP for interface ${iface ?? 'unknown'}`);
+      }
+      return response;
+    }
+    throw new Error(`Unexpected exec: ${call.command} ${call.args.join(' ')}`);
+  };
+}
+
+test('prefers the default-route interface IP over the first scanned interface', () => {
+  const exec = fakeExec('route to: default\ninterface: en0\n', {
+    bridge0: '10.211.55.2',
+    en0: '192.168.1.10',
+  });
+  const networkInterfaces: LanIpDeps['networkInterfaces'] = () => ({
+    bridge0: [
+      { family: 'IPv4', address: '10.211.55.2', internal: false } as os.NetworkInterfaceInfo,
+    ],
+    en0: [{ family: 'IPv4', address: '192.168.1.10', internal: false } as os.NetworkInterfaceInfo],
+  });
+
+  const ip = detectLanIp({ execFileSync: exec as LanIpDeps['execFileSync'], networkInterfaces });
+  assert.equal(ip, '192.168.1.10');
+});
+
+test('falls back to the first usable non-internal IPv4 when route lookup fails', () => {
+  const exec: LanIpDeps['execFileSync'] = () => {
+    throw new Error('route lookup failed');
+  };
+  const networkInterfaces: LanIpDeps['networkInterfaces'] = () => ({
+    en0: [{ family: 'IPv4', address: '192.168.1.10', internal: false } as os.NetworkInterfaceInfo],
+  });
+
+  const ip = detectLanIp({ execFileSync: exec, networkInterfaces });
+  assert.equal(ip, '192.168.1.10');
+});
+
+test('rejects IPv4-looking strings with out-of-range octets', () => {
+  assert.equal(isUsableIpv4('192.168.1.10'), true);
+  assert.equal(isUsableIpv4('256.0.0.1'), false);
+  assert.equal(isUsableIpv4('localhost'), false);
+  assert.equal(isUsableIpv4(undefined), false);
+});

--- a/dev/local/lan-ip.ts
+++ b/dev/local/lan-ip.ts
@@ -1,0 +1,52 @@
+import { execFileSync as defaultExecFileSync } from 'node:child_process';
+import * as os from 'node:os';
+
+type LanIpDeps = {
+  execFileSync: typeof defaultExecFileSync;
+  networkInterfaces: typeof os.networkInterfaces;
+};
+
+function isUsableIpv4(value: string | undefined): value is string {
+  if (typeof value !== 'string' || !/^\d{1,3}(?:\.\d{1,3}){3}$/.test(value)) {
+    return false;
+  }
+
+  return value.split('.').every(part => Number(part) <= 255);
+}
+
+function detectLanIp(
+  deps: LanIpDeps = { execFileSync: defaultExecFileSync, networkInterfaces: os.networkInterfaces }
+): string | undefined {
+  try {
+    const routeOutput = deps.execFileSync('route', ['-n', 'get', 'default'], {
+      encoding: 'utf-8',
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+    const iface = routeOutput.match(/interface:\s*(\S+)/)?.[1];
+    if (iface) {
+      const ip = deps
+        .execFileSync('ipconfig', ['getifaddr', iface], {
+          encoding: 'utf-8',
+          stdio: ['ignore', 'pipe', 'ignore'],
+        })
+        .trim();
+      if (isUsableIpv4(ip)) {
+        return ip;
+      }
+    }
+  } catch {
+    // Fall through to Node's cross-platform interface scan.
+  }
+
+  for (const addresses of Object.values(deps.networkInterfaces())) {
+    for (const address of addresses ?? []) {
+      if (address.family === 'IPv4' && !address.internal && isUsableIpv4(address.address)) {
+        return address.address;
+      }
+    }
+  }
+  return undefined;
+}
+
+export { detectLanIp, isUsableIpv4 };
+export type { LanIpDeps };

--- a/dev/local/mobile-env.ts
+++ b/dev/local/mobile-env.ts
@@ -1,7 +1,7 @@
 import { execFileSync } from 'node:child_process';
 import * as fs from 'node:fs';
-import * as os from 'node:os';
 import * as path from 'node:path';
+import { detectLanIp, isUsableIpv4 } from './lan-ip';
 import { services } from './services';
 
 const MOBILE_ENV_REL_PATH = 'apps/mobile/.env.local';
@@ -39,44 +39,6 @@ function parseArgs(args: string[]): { host: string | undefined } {
     }
   }
   return { host };
-}
-
-function isUsableIpv4(value: string | undefined): value is string {
-  if (typeof value !== 'string' || !/^\d{1,3}(?:\.\d{1,3}){3}$/.test(value)) {
-    return false;
-  }
-
-  return value.split('.').every(part => Number(part) <= 255);
-}
-
-function detectLanIp(): string | undefined {
-  try {
-    const routeOutput = execFileSync('route', ['-n', 'get', 'default'], {
-      encoding: 'utf-8',
-      stdio: ['ignore', 'pipe', 'ignore'],
-    });
-    const iface = routeOutput.match(/interface:\s*(\S+)/)?.[1];
-    if (iface) {
-      const ip = execFileSync('ipconfig', ['getifaddr', iface], {
-        encoding: 'utf-8',
-        stdio: ['ignore', 'pipe', 'ignore'],
-      }).trim();
-      if (isUsableIpv4(ip)) {
-        return ip;
-      }
-    }
-  } catch {
-    // Fall through to Node's cross-platform interface scan.
-  }
-
-  for (const addresses of Object.values(os.networkInterfaces())) {
-    for (const address of addresses ?? []) {
-      if (address.family === 'IPv4' && !address.internal && isUsableIpv4(address.address)) {
-        return address.address;
-      }
-    }
-  }
-  return undefined;
 }
 
 function serviceUrl(host: string, serviceName: string, protocol: 'http' | 'ws'): string {
@@ -262,6 +224,7 @@ export {
   ensureRootEnv,
   isUsableIpv4,
   prepareMobileEnvironment,
+  serviceUrl,
   upsertRootEnv,
 };
 export type { PreparedMobileEnvironment };


### PR DESCRIPTION
## What

Fixes the mobile cloud-agent "happy path" (create agent → session detail streams the assistant response to completion) **in local development**. This is a **local dev-tooling fix**, not a product or production behavior change.

## Why it was broken (local dev only)

The mobile app opens the `cloud-agent-next` Worker `/stream` WebSocket sending `Origin: WEB_BASE_URL`, which locally is the machine's LAN IP (e.g. `http://192.168.1.10:7300`). The local env generator wrote the Worker's `WS_ALLOWED_ORIGINS` as `http://localhost:<port>` only, so the Durable Object 403'd every upgrade (`DO /stream: Origin not allowed`). Result locally: the session detail showed "Couldn't load this session" / "Agent connection lost" and never streamed.

In **production** `WEB_BASE_URL` is the real web origin, which is already present in the Worker's `WS_ALLOWED_ORIGINS` (`services/cloud-agent-next/wrangler.jsonc`), so real users stream normally. **Production is unaffected** by this change; `wrangler.jsonc` is untouched.

## Changes (all under `dev/local`)

- **F1 — emit the LAN origin for `*ORIGINS` keys.** In `dev/local/env-sync/parse.ts`, for `@url` origins keys, additionally emit `http://<lanIp>:<port>` (built via the shared `serviceUrl` helper) alongside the existing `http://localhost:<port>` entry, per resolved service ref, gated on `serviceUsesLanIp && lanIp`. Only `useLanIp` workers gain a LAN entry (`cloud-agent-next`; also `app-builder`'s `ALLOWED_ORIGINS`, an intended harmless additive local widening). `kiloclaw` and non-origins keys are unchanged.
- **F2 — unify LAN-IP detection.** Extract the route-based detector into `dev/local/lan-ip.ts` and use it in both `dev/local/mobile-env.ts` and `dev/local/env-sync/plan.ts`, replacing `plan.ts`'s enumeration-order-dependent scan. This guarantees the allowlisted IP always equals the mobile bundle's `WEB_BASE_URL` IP (this host exposes several non-internal IPv4s incl. Docker/OrbStack bridges, so the naive scan could diverge).

No mobile app code, Worker code, `wrangler.jsonc`, or committed `.dev.vars` are changed.

## Testing

- **Unit** (`dev/local/env-sync/plan.test.ts`, `dev/local/lan-ip.test.ts`): assert the exact per-ref paired origin shape for `serviceUsesLanIp=true`; that `serviceUsesLanIp=false`/unset `lanIp` leaves output unchanged (localhost only); that the emitted LAN origin equals `serviceUrl(lanIp, service, 'http')` (one source of truth); and that both detector consumers resolve via the shared route-based detector.
- **Sanity**: `pnpm dev:env` regenerates `services/cloud-agent-next/.dev.vars` with `WS_ALLOWED_ORIGINS=http://localhost:7300,http://192.168.1.10:7300,http://localhost:13094,http://192.168.1.10:13094`.
- **On-device E2E (iOS)**: after regenerating env and restarting `cloud-agent-next`, created a cloud-agent session from the app; the session detail streamed live ("Preparing environment" → "Preparation complete" → assistant response "Hello from Kilo") to completion with the composer enabled — no "Couldn't load this session" error and no persistent "Agent connection lost" banner. Backend log showed `/stream: WebSocket upgrade authorized` + `GET /stream 101 Switching Protocols` and zero `Origin not allowed` 403s for the app's LAN origin.
