### PR TITLE
Stop rewriting model names in proxied AI gateway responses

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -114,14 +114,6 @@ export function shouldRedactErrorResponse(provider: ProviderId, model: string): 
   return provider === 'custom' || provider === 'experiment' || isKiloStealthModel(model);
 }
 
-export function shouldRedactModelNameInResponse(provider: ProviderId, model: string): boolean {
-  // custom is only used internally so we don't have to risk the perf or reliablity impact of rewriting the response
-  return (
-    provider !== 'martian' && // this is a stealth provider, but the models aren't stealth, so we can keep the model name in place
-    (provider === 'experiment' || isKiloStealthModel(model))
-  );
-}
-
 export function isDeadFreeModel(model: string): boolean {
   return !!kiloExclusiveModels.find(
     m => m.public_id === model && m.status === 'disabled' && !m.pricing

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -5,8 +5,6 @@ import {
   rewriteModelResponse_Responses,
 } from './rewriteModelResponse';
 
-const REWRITTEN_MODEL = 'kilo/my-free-model';
-
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
@@ -57,7 +55,7 @@ function dataObjects(sse: string): unknown[] {
 
 describe('rewriteModelResponse_ChatCompletions', () => {
   describe('JSON responses', () => {
-    test('rewrites the model and strips upstream cost fields', async () => {
+    test('strips upstream cost fields', async () => {
       const upstream = jsonResponse({
         model: 'upstream-model',
         usage: {
@@ -71,10 +69,10 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         },
       });
 
-      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream);
       const json = await result.json();
 
-      expect(json.model).toBe(REWRITTEN_MODEL);
+      expect(json.model).toBe('upstream-model');
       expect(json.usage.cost).toBeUndefined();
       expect(json.usage.cost_details).toBeUndefined();
       expect(json.usage.is_byok).toBeUndefined();
@@ -94,7 +92,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         },
       });
 
-      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream);
       const json = await result.json();
 
       expect(json.usage.prompt_tokens_details.cached_tokens).toBe(0);
@@ -107,7 +105,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         headers: { 'content-type': 'application/json' },
       });
 
-      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream);
 
       expect(result.status).toBe(502);
       expect(await result.text()).toBe('not-json{');
@@ -115,20 +113,20 @@ describe('rewriteModelResponse_ChatCompletions', () => {
   });
 
   describe('streaming responses', () => {
-    test('rewrites model, drops null delta role, and emits [DONE]', async () => {
+    test('drops null delta role and emits [DONE]', async () => {
       const upstream = sseResponse(
         'data: {"model":"upstream-model","choices":[{"delta":{"role":null,"content":"hi"}}]}\n\n' +
           'data: [DONE]\n\n'
       );
 
-      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream);
       const sse = await readOutputStream(result);
       const [chunk] = dataObjects(sse) as Array<{
         model: string;
         choices: Array<{ delta: { role?: unknown; content: string } }>;
       }>;
 
-      expect(chunk.model).toBe(REWRITTEN_MODEL);
+      expect(chunk.model).toBe('upstream-model');
       expect('role' in chunk.choices[0].delta).toBe(false);
       expect(chunk.choices[0].delta.content).toBe('hi');
       expect(dataPayloads(sse)).toContain('[DONE]');
@@ -139,7 +137,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         'data: {"model":"upstream-model","usage":{"cost":1,"is_byok":true,"prompt_tokens":4,"completion_tokens":2,"total_tokens":6,"prompt_tokens_details":{}}}\n\n'
       );
 
-      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream);
       const sse = await readOutputStream(result);
       const [chunk] = dataObjects(sse) as Array<{
         model: string;
@@ -151,7 +149,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         };
       }>;
 
-      expect(chunk.model).toBe(REWRITTEN_MODEL);
+      expect(chunk.model).toBe('upstream-model');
       expect(chunk.choices).toEqual([]);
       expect(chunk.usage.cost).toBeUndefined();
       expect(chunk.usage.is_byok).toBeUndefined();
@@ -163,7 +161,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         ': openrouter heartbeat\n\n' + 'data: {"model":"upstream-model","choices":[]}\n\n'
       );
 
-      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream);
       const sse = await readOutputStream(result);
 
       expect(sse).toContain(': KILO PROCESSING');
@@ -175,7 +173,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         headers: { 'content-type': 'text/event-stream' },
       });
 
-      const result = await rewriteModelResponse_ChatCompletions(upstream, REWRITTEN_MODEL);
+      const result = await rewriteModelResponse_ChatCompletions(upstream);
 
       expect(await readOutputStream(result)).toBe('');
     });
@@ -183,7 +181,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
 });
 
 describe('rewriteModelResponse_Messages', () => {
-  test('rewrites model and strips cost fields for JSON responses', async () => {
+  test('strips cost fields for JSON responses', async () => {
     const upstream = jsonResponse({
       type: 'message',
       model: 'upstream-model',
@@ -196,10 +194,10 @@ describe('rewriteModelResponse_Messages', () => {
       },
     });
 
-    const result = await rewriteModelResponse_Messages(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Messages(upstream);
     const json = await result.json();
 
-    expect(json.model).toBe(REWRITTEN_MODEL);
+    expect(json.model).toBe('upstream-model');
     expect(json.usage.input_tokens).toBe(20);
     expect(json.usage.cost).toBeUndefined();
     expect(json.usage.cost_details).toBeUndefined();
@@ -212,7 +210,7 @@ describe('rewriteModelResponse_Messages', () => {
       headers: { 'content-type': 'application/json' },
     });
 
-    const result = await rewriteModelResponse_Messages(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Messages(upstream);
 
     expect(result.status).toBe(500);
     expect(await result.text()).toBe('}{');
@@ -225,7 +223,7 @@ describe('rewriteModelResponse_Messages', () => {
         'data: [DONE]\n\n'
     );
 
-    const result = await rewriteModelResponse_Messages(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Messages(upstream);
     const sse = await readOutputStream(result);
     const events = dataObjects(sse) as Array<{
       type: string;
@@ -236,7 +234,7 @@ describe('rewriteModelResponse_Messages', () => {
       usage?: { cost?: number; is_byok?: boolean; output_tokens: number };
     }>;
 
-    expect(events[0].message?.model).toBe(REWRITTEN_MODEL);
+    expect(events[0].message?.model).toBe('upstream-model');
     expect(events[0].message?.usage.cost).toBeUndefined();
     expect(events[0].message?.usage.is_byok).toBeUndefined();
     expect(events[0].message?.usage.input_tokens).toBe(11);
@@ -254,7 +252,7 @@ describe('rewriteModelResponse_Messages', () => {
       'data: {"type":"message_delta","usage":{"output_tokens":9},"delta":{}}\n\n'
     );
 
-    const result = await rewriteModelResponse_Messages(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Messages(upstream);
     const sse = await readOutputStream(result);
 
     expect(dataPayloads(sse)).not.toContain('[DONE]');
@@ -262,7 +260,7 @@ describe('rewriteModelResponse_Messages', () => {
 });
 
 describe('rewriteModelResponse_Responses', () => {
-  test('rewrites model and strips cost fields for JSON responses', async () => {
+  test('strips cost fields for JSON responses', async () => {
     const upstream = jsonResponse({
       id: 'resp_1',
       model: 'upstream-model',
@@ -276,23 +274,23 @@ describe('rewriteModelResponse_Responses', () => {
       },
     });
 
-    const result = await rewriteModelResponse_Responses(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Responses(upstream);
     const json = await result.json();
 
-    expect(json.model).toBe(REWRITTEN_MODEL);
+    expect(json.model).toBe('upstream-model');
     expect(json.usage.cost).toBeUndefined();
     expect(json.usage.is_byok).toBeUndefined();
     expect(json.usage.prompt_tokens_details.cached_tokens).toBe(0);
   });
 
-  test('rewrites the nested response model and usage in stream events and emits [DONE]', async () => {
+  test('strips the nested response usage in stream events and emits [DONE]', async () => {
     const upstream = sseResponse(
       'event: response.completed\n' +
         'data: {"type":"response.completed","response":{"model":"upstream-model","usage":{"cost":0.5,"is_byok":true,"prompt_tokens":3,"completion_tokens":1,"total_tokens":4,"prompt_tokens_details":{"cached_tokens":1}}}}\n\n' +
         'data: [DONE]\n\n'
     );
 
-    const result = await rewriteModelResponse_Responses(upstream, REWRITTEN_MODEL);
+    const result = await rewriteModelResponse_Responses(upstream);
     const sse = await readOutputStream(result);
     const [event] = dataObjects(sse) as Array<{
       type: string;
@@ -306,7 +304,7 @@ describe('rewriteModelResponse_Responses', () => {
       };
     }>;
 
-    expect(event.response.model).toBe(REWRITTEN_MODEL);
+    expect(event.response.model).toBe('upstream-model');
     expect(event.response.usage.cost).toBeUndefined();
     expect(event.response.usage.is_byok).toBeUndefined();
     expect(event.response.usage.prompt_tokens_details.cached_tokens).toBe(1);

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -21,7 +21,7 @@ function rewriteUsage(usage: OpenRouterUsage) {
   }
 }
 
-export async function rewriteModelResponse_ChatCompletions(response: Response, model: string) {
+export async function rewriteModelResponse_ChatCompletions(response: Response) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -39,10 +39,6 @@ export async function rewriteModelResponse_ChatCompletions(response: Response, m
         headers,
       });
     }
-    if (json.model) {
-      json.model = model;
-    }
-
     const usage = json.usage as OpenRouterUsage;
     if (usage) {
       rewriteUsage(usage);
@@ -71,9 +67,6 @@ export async function rewriteModelResponse_ChatCompletions(response: Response, m
             return;
           }
           const json = JSON.parse(event.data) as ChatCompletionChunk;
-          if (json.model) {
-            json.model = model;
-          }
 
           const delta = json.choices?.[0]?.delta;
           if (delta) {
@@ -148,7 +141,7 @@ function rewriteMessagesUsage(usage: MessagesApiUsage) {
   delete usage.is_byok;
 }
 
-export async function rewriteModelResponse_Messages(response: Response, model: string) {
+export async function rewriteModelResponse_Messages(response: Response) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -165,9 +158,6 @@ export async function rewriteModelResponse_Messages(response: Response, model: s
         statusText: response.statusText,
         headers,
       });
-    }
-    if (json.model) {
-      json.model = model;
     }
     if (json.usage) {
       rewriteMessagesUsage(json.usage);
@@ -201,9 +191,6 @@ export async function rewriteModelResponse_Messages(response: Response, model: s
 
           if (json.type === 'message_start') {
             const e = json as MessagesApiMessageStart;
-            if (e.message.model) {
-              e.message.model = model;
-            }
             if (e.message.usage) {
               rewriteMessagesUsage(e.message.usage);
             }
@@ -254,7 +241,7 @@ type ResponsesApiEvent = {
   response?: OpenAI.Responses.Response & { usage?: OpenRouterUsage | null };
 };
 
-export async function rewriteModelResponse_Responses(response: Response, model: string) {
+export async function rewriteModelResponse_Responses(response: Response) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -271,9 +258,6 @@ export async function rewriteModelResponse_Responses(response: Response, model: 
         statusText: response.statusText,
         headers,
       });
-    }
-    if (json.model) {
-      json.model = model;
     }
     if (json.usage) {
       rewriteUsage(json.usage);
@@ -302,9 +286,6 @@ export async function rewriteModelResponse_Responses(response: Response, model: 
           }
           const json = JSON.parse(event.data) as ResponsesApiEvent;
           if (json.response) {
-            if (json.response.model) {
-              json.response.model = model;
-            }
             if (json.response.usage) {
               rewriteUsage(json.response.usage);
             }
@@ -358,13 +339,13 @@ export async function rewriteModelResponse(
 
   console.debug('[rewriteModelResponse] rewriting response for %s', model);
   if (kind === 'chat_completions') {
-    return rewriteModelResponse_ChatCompletions(response, model);
+    return rewriteModelResponse_ChatCompletions(response);
   }
   if (kind === 'responses') {
-    return rewriteModelResponse_Responses(response, model);
+    return rewriteModelResponse_Responses(response);
   }
   if (kind === 'messages') {
-    return rewriteModelResponse_Messages(response, model);
+    return rewriteModelResponse_Messages(response);
   }
 
   console.error('[rewriteModelResponse] implementation error: unrecognized API kind %s', kind);

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -1,4 +1,4 @@
-import { isKiloExclusiveFreeModel, shouldRedactModelNameInResponse } from '@/lib/ai-gateway/models';
+import { isKiloExclusiveFreeModel } from '@/lib/ai-gateway/models';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 import { getOutputHeaders } from '@/lib/ai-gateway/llm-proxy-helpers';
@@ -351,7 +351,7 @@ export async function rewriteModelResponse(
   const isFreeModelRequiringCostRemoval =
     (providerId === 'openrouter' || providerId === 'vercel') && isKiloExclusiveFreeModel(model);
 
-  if (!isFreeModelRequiringCostRemoval && !shouldRedactModelNameInResponse(providerId, model)) {
+  if (!isFreeModelRequiringCostRemoval) {
     console.debug('[rewriteModelResponse] skipping rewrite for %s', model);
     return null;
   }


### PR DESCRIPTION
Removes all model-name rewriting from `apps/web/src/lib/rewriteModelResponse.ts` so the upstream model name passes through to clients unchanged.

## Changes

- **Drop the redaction trigger:** remove the `shouldRedactModelNameInResponse` check so responses are no longer rewritten to hide stealth/experiment model names. Responses are now only rewritten for free-model cost removal.
- **Drop free-model renaming:** remove the `json.model = model` rewrites from the chat-completions, messages, and responses rewriters (both JSON and streaming paths).
- **Remove unused code:** delete the now-unused `shouldRedactModelNameInResponse` helper from `apps/web/src/lib/ai-gateway/models.ts` and drop the now-unused `model` parameter from the three rewrite helpers.
- **Update tests:** `rewriteModelResponse.test.ts` now asserts the upstream model name passes through unchanged.

## Notes

- The `model` parameter on `rewriteModelResponse` itself is retained — it is still needed for the `isKiloExclusiveFreeModel(model)` cost-removal check and debug logging.
- `shouldRedactModelNameInMicrodollarUsage` and `shouldRedactErrorResponse` are intentionally left untouched (used elsewhere for usage tracking and error redaction).