### PR TITLE
feat(code reviewer) council hard exclusions

### DIFF
--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -102,7 +102,7 @@ function pullRequestPayload(overrides: Record<string, unknown> = {}) {
       state: 'open',
       draft: false,
       html_url: 'https://github.com/acme/widgets/pull/42',
-      user: { id: 111, login: 'alice', avatar_url: 'https://example.com/a.png' },
+      user: { id: 111, login: 'alice', avatar_url: 'https://example.com/a.png', type: 'User' },
       head: { sha: 'abc123', ref: 'feature/widgets', repo: { full_name: 'acme/widgets' } },
       base: { sha: 'def456', ref: 'main' },
     },

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-checkout-ref.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-checkout-ref.ts
@@ -33,7 +33,12 @@ export function resolvePullRequestCheckoutRef(
   payload: PullRequestCheckoutRefInput
 ): PullRequestCheckoutRef {
   const headRepoFullName = payload.pull_request.head.repo?.full_name ?? null;
-  const isForkPr = headRepoFullName !== null && headRepoFullName !== payload.repository.full_name;
+  // A same-repo PR always carries `head.repo` (it is the base repo itself), so a missing/null
+  // `head.repo` can only be a fork PR whose fork repo was deleted after the PR was opened (GitHub
+  // allows this and nulls `head.repo`). Treat null as a fork: this is both accurate and fail-closed
+  // for the security-sensitive `fork-pr` council exclusion that consumes this flag. Only an
+  // explicit head repo equal to the base repo is treated as non-fork.
+  const isForkPr = headRepoFullName !== payload.repository.full_name;
   const checkoutRef = getGitHubPullRequestCheckoutRef(payload.pull_request.number);
 
   return {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
@@ -363,6 +363,35 @@ describe('handlePullRequest', () => {
       );
       expect(mockIsCouncilEntitledForOwner).toHaveBeenCalled();
     });
+
+    it('hard-excludes a bot-authored PR from council (downgrades to standard)', async () => {
+      mockGetBotUserId.mockResolvedValue('bot-user-1');
+      mockGetAgentConfigForOwner.mockResolvedValue(councilConfig);
+      mockIsCouncilEntitledForOwner.mockResolvedValue(true);
+
+      const payload = pullRequestPayload();
+      payload.pull_request.user.type = 'Bot';
+      await handlePullRequest(payload, platformIntegration());
+
+      expect(mockCreateCodeReview).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewType: 'standard' })
+      );
+    });
+
+    it('hard-excludes a fork PR from council (downgrades to standard)', async () => {
+      mockGetBotUserId.mockResolvedValue('bot-user-1');
+      mockGetAgentConfigForOwner.mockResolvedValue(councilConfig);
+      mockIsCouncilEntitledForOwner.mockResolvedValue(true);
+
+      // Head repo differs from the base repo → resolvePullRequestCheckoutRef marks it a fork PR.
+      const payload = pullRequestPayload();
+      payload.pull_request.head.repo = { full_name: 'contributor/widgets' };
+      await handlePullRequest(payload, platformIntegration());
+
+      expect(mockCreateCodeReview).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewType: 'standard' })
+      );
+    });
   });
 
   it('cancels superseded DB rows, interrupts queued/running only, and creates the new review', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
@@ -172,7 +172,9 @@ describe('resolvePullRequestCheckoutRef', () => {
     });
   });
 
-  it('uses refs/pull/<number>/head when head.repo is missing', () => {
+  it('treats a missing head.repo as a fork PR (deleted fork fails closed)', () => {
+    // A same-repo PR always carries head.repo, so a null one can only be a fork whose repo was
+    // deleted after opening. It must resolve to isForkPr: true so the council fork-exclusion holds.
     const result = resolvePullRequestCheckoutRef({
       pull_request: {
         number: 789,
@@ -187,7 +189,7 @@ describe('resolvePullRequestCheckoutRef', () => {
 
     expect(result).toEqual({
       checkoutRef: 'refs/pull/789/head',
-      isForkPr: false,
+      isForkPr: true,
       headRepoFullName: null,
     });
   });
@@ -386,6 +388,21 @@ describe('handlePullRequest', () => {
       // Head repo differs from the base repo → resolvePullRequestCheckoutRef marks it a fork PR.
       const payload = pullRequestPayload();
       payload.pull_request.head.repo = { full_name: 'contributor/widgets' };
+      await handlePullRequest(payload, platformIntegration());
+
+      expect(mockCreateCodeReview).toHaveBeenCalledWith(
+        expect.objectContaining({ reviewType: 'standard' })
+      );
+    });
+
+    it('hard-excludes a fork PR whose fork was deleted (null head.repo) from council', async () => {
+      mockGetBotUserId.mockResolvedValue('bot-user-1');
+      mockGetAgentConfigForOwner.mockResolvedValue(councilConfig);
+      mockIsCouncilEntitledForOwner.mockResolvedValue(true);
+
+      // GitHub nulls head.repo when the contributor deletes their fork; this must still be a fork.
+      const payload = pullRequestPayload();
+      payload.pull_request.head.repo = null;
       await handlePullRequest(payload, platformIntegration());
 
       expect(mockCreateCodeReview).toHaveBeenCalledWith(

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.test.ts
@@ -82,7 +82,7 @@ function pullRequestPayload(overrides: Partial<PullRequestPayload> = {}): PullRe
       state: 'open',
       draft: false,
       html_url: 'https://github.com/acme/widgets/pull/42',
-      user: { id: 111, login: 'alice', avatar_url: 'https://example.com/a.png' },
+      user: { id: 111, login: 'alice', avatar_url: 'https://example.com/a.png', type: 'User' },
       head: { sha: 'abc123', ref: 'feature/widgets', repo: { full_name: 'acme/widgets' } },
       base: { sha: 'def456', ref: 'main' },
     },

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
@@ -14,8 +14,10 @@ import {
 import { tryDispatchPendingReviews } from '@/lib/code-reviews/dispatch/dispatch-pending-reviews';
 import { getAgentConfigForOwner } from '@/lib/agent-config/db/agent-configs';
 import {
+  councilHardExcludeReason,
   determineAutomatedReviewType,
   isCouncilActive,
+  type AutomatedReviewPrFacts,
 } from '@kilocode/worker-utils/code-review-council';
 import { isCouncilEntitledForOwner } from '@/lib/code-reviews/core/council-entitlement';
 import type { PlatformIntegration } from '@kilocode/db/schema';
@@ -312,10 +314,33 @@ export async function handlePullRequestCodeReview(
       config.council_enabled_repository_ids.includes(repository.id);
     const councilEntitled =
       councilConfigActive && councilEnabledForRepo ? await isCouncilEntitledForOwner(owner) : false;
-    const reviewType = determineAutomatedReviewType(
-      { isDraft: pull_request.draft ?? false, author: pull_request.user.login },
-      { councilEntitled, councilConfigActive, councilEnabledForRepo }
-    );
+    // Hard, code-owned facts that can veto council even when it is otherwise available. Bot type and
+    // fork origin are GitHub-authoritative (not author-controlled), so they cannot be spoofed to
+    // reach the expensive council path.
+    const prFacts: AutomatedReviewPrFacts = {
+      isDraft: pull_request.draft ?? false,
+      isBot: pull_request.user.type === 'Bot',
+      isFork: checkoutRef.isForkPr,
+      author: pull_request.user.login,
+    };
+    const reviewType = determineAutomatedReviewType(prFacts, {
+      councilEntitled,
+      councilConfigActive,
+      councilEnabledForRepo,
+    });
+    if (
+      councilEntitled &&
+      councilConfigActive &&
+      councilEnabledForRepo &&
+      reviewType !== 'council'
+    ) {
+      // Council was available but hard-excluded; record why for observability.
+      const hardExcludeReason = councilHardExcludeReason(prFacts);
+      logExceptInTest(
+        `Council hard-excluded for ${repository.full_name}#${pull_request.number}: ${hardExcludeReason}`,
+        { pr_number: pull_request.number, repo: repository.full_name, reason: hardExcludeReason }
+      );
+    }
 
     // 7. Create review record (session_id will be updated async)
     const reviewId = await createCodeReview({

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-requests.test.ts
@@ -46,7 +46,7 @@ function makePayload(overrides: {
       merged: overrides.merged,
       draft: overrides.draft,
       html_url: overrides.prUrl ?? `https://github.com/${repo}/pull/${overrides.prNumber}`,
-      user: { id: 1, login: 'octocat', avatar_url: 'https://example.com/a.png' },
+      user: { id: 1, login: 'octocat', avatar_url: 'https://example.com/a.png', type: 'User' },
       head: {
         sha: overrides.headSha,
         ref: overrides.headRef,

--- a/apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts
@@ -146,6 +146,10 @@ export const PullRequestPayloadSchema = z.object({
       id: z.number(),
       login: z.string(),
       avatar_url: z.string(),
+      // GitHub account type: 'User' | 'Bot' | 'Organization'. Used to hard-exclude bot-authored
+      // PRs (dependabot/renovate/etc.) from the council review path. Optional for forward/back
+      // compatibility with payloads/fixtures that omit it.
+      type: z.string().optional(),
     }),
     head: z.object({
       sha: z.string(),

--- a/apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-schemas.ts
@@ -147,9 +147,12 @@ export const PullRequestPayloadSchema = z.object({
       login: z.string(),
       avatar_url: z.string(),
       // GitHub account type: 'User' | 'Bot' | 'Organization'. Used to hard-exclude bot-authored
-      // PRs (dependabot/renovate/etc.) from the council review path. Optional for forward/back
-      // compatibility with payloads/fixtures that omit it.
-      type: z.string().optional(),
+      // PRs (dependabot/renovate/etc.) from the council review path. GitHub always sends this on
+      // real PR webhooks; a missing value only occurs in partial payloads/fixtures. Defaults to
+      // 'User' (a regular, non-bot account) so an absent type fails open: the PR stays eligible for
+      // council rather than being treated as a bot. Explicit default over `.optional()` documents
+      // the assumption and removes the `undefined` case for consumers.
+      type: z.string().default('User'),
     }),
     head: z.object({
       sha: z.string(),

--- a/packages/worker-utils/src/code-review-council.test.ts
+++ b/packages/worker-utils/src/code-review-council.test.ts
@@ -8,6 +8,7 @@ import {
   buildCouncilReviewSection,
   computeCouncilDecision,
   councilDecisionBlocksMerge,
+  councilHardExcludeReason,
   decideCouncilFromManifest,
   deriveSpecialistVote,
   determineAutomatedReviewType,
@@ -581,6 +582,41 @@ describe('determineAutomatedReviewType', () => {
         { councilEntitled: false, councilConfigActive: false, councilEnabledForRepo: false }
       )
     ).toBe('standard');
+  });
+
+  it('hard-excludes downgrade an otherwise-available council to standard', () => {
+    expect(determineAutomatedReviewType({ isDraft: true }, ALL_ON)).toBe('standard');
+    expect(determineAutomatedReviewType({ isBot: true }, ALL_ON)).toBe('standard');
+    expect(determineAutomatedReviewType({ isFork: true }, ALL_ON)).toBe('standard');
+    // A clean PR with council available still gets council.
+    expect(
+      determineAutomatedReviewType({ isDraft: false, isBot: false, isFork: false }, ALL_ON)
+    ).toBe('council');
+  });
+
+  it('a hard-excluded PR without council available is unaffected (stays standard)', () => {
+    expect(
+      determineAutomatedReviewType(
+        { isFork: true, isBot: true },
+        { ...ALL_ON, councilEnabledForRepo: false }
+      )
+    ).toBe('standard');
+  });
+});
+
+describe('councilHardExcludeReason', () => {
+  it('returns null when nothing excludes council', () => {
+    expect(councilHardExcludeReason({})).toBeNull();
+    expect(councilHardExcludeReason({ isDraft: false, isBot: false, isFork: false })).toBeNull();
+  });
+
+  it('reports the reason, ordered draft → bot-author → fork-pr', () => {
+    expect(councilHardExcludeReason({ isDraft: true })).toBe('draft');
+    expect(councilHardExcludeReason({ isBot: true })).toBe('bot-author');
+    expect(councilHardExcludeReason({ isFork: true })).toBe('fork-pr');
+    // When several apply, the earliest-listed reason wins (deterministic).
+    expect(councilHardExcludeReason({ isDraft: true, isBot: true, isFork: true })).toBe('draft');
+    expect(councilHardExcludeReason({ isBot: true, isFork: true })).toBe('bot-author');
   });
 });
 

--- a/packages/worker-utils/src/code-review-council.ts
+++ b/packages/worker-utils/src/code-review-council.ts
@@ -713,12 +713,47 @@ export function presetToSpecialist(preset: CouncilSpecialistPreset): CouncilSpec
  */
 export type AutomatedReviewPrFacts = {
   isDraft?: boolean;
+  // The PR is authored by a bot account (GitHub `user.type === 'Bot'`, e.g. dependabot/renovate).
+  isBot?: boolean;
+  // The PR head is a fork / cross-repo branch (the author does not have write access to the base).
+  isFork?: boolean;
   labels?: string[];
   baseRef?: string;
   changedFileCount?: number;
   changedLineCount?: number;
   author?: string;
 };
+
+/**
+ * Code-owned reasons the COUNCIL review type is HARD-EXCLUDED for an automated run, regardless of
+ * config or entitlement. These are non-configurable abuse/cost floors, not customer choices:
+ * council is the expensive path, so untrusted or low-value PRs must never reach it. A hard-excluded
+ * PR still gets a `'standard'` review — this vetoes council only, it does not skip the review.
+ *
+ * - `draft`      — draft PRs are WIP; in practice the webhook handler skips them entirely before
+ *                  this runs, so this is a defensive belt-and-suspenders check.
+ * - `bot-author` — bot PRs (dependabot/renovate/etc.) are high-volume and low council value.
+ * - `fork-pr`    — fork / cross-repo PRs come from authors without base write access. On public
+ *                  repos this is the primary abuse vector: an external contributor must not be able
+ *                  to trigger the expensive council path (or spend the org's council budget) by
+ *                  opening/pushing PRs.
+ */
+export type CouncilHardExcludeReason = 'draft' | 'bot-author' | 'fork-pr';
+
+/**
+ * Returns the first hard-exclude reason that vetoes council for this PR, or `null` if none apply.
+ * Pure and code-owned (never driven by SCM-controlled input or org config); ordered cheapest and
+ * most-fundamental first. Returning the reason (not just a bool) lets callers log/surface WHY
+ * council was downgraded without re-deriving it.
+ */
+export function councilHardExcludeReason(
+  facts: AutomatedReviewPrFacts
+): CouncilHardExcludeReason | null {
+  if (facts.isDraft) return 'draft';
+  if (facts.isBot) return 'bot-author';
+  if (facts.isFork) return 'fork-pr';
+  return null;
+}
 
 /**
  * Determines the review type for an AUTOMATED (webhook) run.
@@ -731,20 +766,24 @@ export type AutomatedReviewPrFacts = {
  * - `councilEnabledForRepo` — the target repo explicitly opted in
  *   (`config.council_enabled_repository_ids`). Council is per-repo opt-in, not org-wide.
  *
- * PR-facts based gating (draft/size/labels) is intentionally NOT applied yet: every PR on an
- * opted-in repo gets a council review. `prFacts` is threaded through so that policy can be added
- * here later without re-wiring the webhook handlers. Manual runs never call this — they carry an
- * explicit user-selected review type.
+ * Even when all three hold, `councilHardExcludeReason` can still veto council (draft/bot/fork) and
+ * fall back to `'standard'`. These are non-configurable floors evaluated last so no config or
+ * entitlement can opt a PR past them. Further PR-facts gating (size/labels) is intentionally NOT
+ * applied yet; `prFacts` is threaded through so that policy can be added here without re-wiring the
+ * webhook handlers. Manual runs never call this — they carry an explicit user-selected review type.
  */
 export function determineAutomatedReviewType(
-  _prFacts: AutomatedReviewPrFacts,
+  prFacts: AutomatedReviewPrFacts,
   options: {
     councilEntitled: boolean;
     councilConfigActive: boolean;
     councilEnabledForRepo: boolean;
   }
 ): CodeReviewType {
-  const useCouncil =
+  const councilAvailable =
     options.councilEntitled && options.councilConfigActive && options.councilEnabledForRepo;
-  return useCouncil ? 'council' : 'standard';
+  if (!councilAvailable) return 'standard';
+  // Hard, code-owned vetoes win over an otherwise-available council.
+  if (councilHardExcludeReason(prFacts)) return 'standard';
+  return 'council';
 }


### PR DESCRIPTION
## Summary

Adds non-configurable, code-owned rules that prevent an automated (webhook) code
review from using the expensive Council review type for certain PRs, even when
the repo is opted in and the org is council-entitled. Draft, bot-authored, and
fork/cross-repo PRs are downgraded to a standard review. This closes the main
open-source abuse vector, where an external contributor could otherwise trigger
Council runs (and spend the org's council budget) by opening or pushing PRs.
It downgrades to standard; it does not skip the review.

## Changes

- `packages/worker-utils/src/code-review-council.ts`: add `CouncilHardExcludeReason`
  (`'draft' | 'bot-author' | 'fork-pr'`) and a pure `councilHardExcludeReason(facts)`
  that returns the first applicable reason or `null`. `determineAutomatedReviewType`
  now returns `standard` when council is unavailable, `standard` when a hard exclude
  applies, and `council` otherwise. The vetoes run after the entitlement/config/opt-in
  checks, so no config can opt a PR past them (fail closed). Extends
  `AutomatedReviewPrFacts` with `isBot` and `isFork`.
- `apps/web/.../github/webhook-schemas.ts`: parse the PR author's `user.type`
  (optional) so the bot signal comes from GitHub's authoritative account type
  rather than a login-string heuristic.
- `apps/web/.../github/webhook-handlers/pull-request-handler.ts`: build the PR facts
  (`isDraft`, `isBot` from `user.type === 'Bot'`, `isFork` from the resolved checkout
  ref, `author`), pass them into the decision, and log the exclude reason when council
  was available but vetoed.
- Tests: unit coverage for `councilHardExcludeReason` and the updated
  `determineAutomatedReviewType` (each exclude downgrades an otherwise-available
  council; a clean PR still gets council), plus handler integration tests asserting
  bot-authored and fork PRs create a `standard` review.

## Verification

- [ ] No manual testing for this PR. The change is pure decision logic covered by
  unit tests (worker-utils) and handler integration tests (web), both passing. The
  live webhook to Council execution and merge-gate flow was validated end to end in
  the predecessor PR that introduced automated Council reviews; this PR only narrows
  which PRs reach that path.

## Visual Changes

N/A

## Reviewer Notes

- Bot detection uses GitHub's `user.type === 'Bot'` and fork detection uses the
  existing checkout-ref resolution, both server-side and not author-controlled, so
  they cannot be spoofed to reach the council path.
- `draft` is already skipped earlier in the handler before this code runs, so its
  exclude is defensive and a no-op in practice; it is kept so the rule set is complete
  and self-contained.
- `councilHardExcludeReason` returns a reason (not a bool) to support surfacing "why
  no council" later without re-deriving it, and as the extension point for the next
  round of selection gates (author association, size, labels, budget), which are out
  of scope here.
