### PR TITLE
fix(ai-gateway): use :free suffix for inclusionai/ling-3.0-flash

### DIFF
--- a/apps/web/src/lib/ai-gateway/is-free-model.ts
+++ b/apps/web/src/lib/ai-gateway/is-free-model.ts
@@ -18,8 +18,7 @@ export async function isFreeModel(model: string): Promise<boolean> {
     model === KILO_AUTO_FREE_MODEL.id ||
     (model ?? '').endsWith(':free') ||
     model === 'openrouter/free' ||
-    (await isPublicIdExperimented(model ?? '')) ||
-    model === 'inclusionai/ling-3.0-flash'
+    (await isPublicIdExperimented(model ?? ''))
   );
 }
 

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -50,7 +50,7 @@ export const preferredModels = [
   KILO_AUTO_FREE_MODEL.id,
 
   ...autoFreeModels,
-  'inclusionai/ling-3.0-flash',
+  'inclusionai/ling-3.0-flash:free',
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -28,6 +28,7 @@ const vercelModelIdMapping: Record<string, string | undefined> = {
   '~google/gemini-pro-latest': GEMINI_PRO_CURRENT_VERCEL_MODEL_ID,
   '~google/gemini-flash-latest': GEMINI_FLASH_CURRENT_VERCEL_MODEL_ID,
   '~x-ai/grok-latest': GROK_CURRENT_VERCEL_MODEL_ID,
+  'inclusionai/ling-3.0-flash:free': 'inclusionai/ling-3.0-flash-free',
   'mistralai/codestral-2508': 'mistral/codestral',
   'mistralai/devstral-2512': 'mistral/devstral-2',
   'mistralai/mistral-embed-2312': 'mistral/mistral-embed',


### PR DESCRIPTION
Replace hardcoded free model check with the standard `:free` suffix convention and add the Vercel model ID mapping.