### PR TITLE
Revert "Remove Vercel routing for StepFun"

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/stepfun.ts
+++ b/apps/web/src/lib/ai-gateway/providers/stepfun.ts
@@ -12,7 +12,7 @@ export const stepfun_37_flash_free_model: KiloExclusiveModel = {
   context_length: 262_144,
   max_completion_tokens: 262_144,
   status: 'public',
-  flags: ['reasoning', 'vision'],
+  flags: ['reasoning', 'vision', 'vercel-routing'],
   gateway: 'openrouter',
   internal_id: 'stepfun/step-3.7-flash',
   pricing: null,


### PR DESCRIPTION
Reverts Kilo-Org/cloud#4653

It's 50/50 now https://github.com/Kilo-Org/cloud/pull/4712