### PR TITLE
docs(mobile): simplify workflow instructions for weaker models

### DIFF
--- a/apps/mobile/.kilo/MOBILE_WORKFLOW.md
+++ b/apps/mobile/.kilo/MOBILE_WORKFLOW.md
@@ -1,108 +1,136 @@
 # Mobile Agent Workflow
 
-Use this workflow when the product surface of the work is the mobile app. Start Kilo from `apps/mobile/` so the role agents in `.kilo/agent/` are discovered. The accepted plan may still change cloud services, tRPC routers, shared packages, infrastructure, or a sibling checkout such as `~/Projects/kilocode`: "mobile" describes the product, not a directory boundary.
+Use this workflow when the product surface of the work is the mobile app. Start Kilo from `apps/mobile/` so the role agents in `.kilo/agent/` are discovered. The plan may still change cloud services, tRPC routers, shared packages, infrastructure, or a sibling checkout such as `~/Projects/kilocode`: "mobile" is the product, not a directory boundary.
 
 ## Ground Rules
 
-These rules apply to every session and role. Later sections do not repeat them.
+These apply to every session and role. Later sections do not repeat them.
 
-- Work only in dedicated worktrees, in every repository the plan touches. Never edit the primary or main checkout of any repository.
+- Work only in dedicated worktrees, in every repository the plan touches. Never edit a primary or main checkout.
 - The first session is the planner. After plan approval, a fresh session becomes the orchestrator.
-- Model policy: the four role agents always run on `kilo/x-ai/grok-4.5` at high reasoning, pinned in their agent definitions. The orchestrator runs on `kilo/moonshotai/kimi-k3` at high reasoning. The planner runs on `kilo/moonshotai/kimi-k3` at high reasoning unless the user chooses a different model. Product-side LLM calls in E2E flows are governed by the Real LLM responses rule below, not by this policy. `kilo/kilo-auto/free` is rate-limited and must never be used, including as a fallback: if a call stalls or errors, retry or relaunch on the assigned model — never switch to `free`.
-- Role agents always run inside the Kilo CLI. The four role agents under `apps/mobile/.kilo/agent/` (`mobile-plan-reviewer`, `mobile-implementer`, `mobile-reviewer`, `mobile-e2e-verifier`) are configured with `mode: all`, making them available as both primary and subagents. They can be invoked directly via `kilo run --agent <agent-name>` even when the orchestrating agent is not itself running in a Kilo CLI harness.
+- The orchestrator owns product judgment, architecture, loop control, final verification, Git, and the PR. Role agents never dispatch agents, commit, push, or create or update a PR.
+- Every reviewer and verifier invocation is a fresh session, so earlier conclusions cannot anchor later passes.
+- Choose the simplest maintainable implementation that fully satisfies the accepted requirements. Reuse existing code and contracts. Do not add abstraction or scope without evidence it is required.
+- Commit in small, logically scoped commits. Never squash everything into one catch-all commit unless the user asks.
 
-  Example command a non-kilo harness would run to dispatch a role agent:
-  ```bash
-  cd /path/to/mobile/worktree
-  kilo run \
-    --model kilo/x-ai/grok-4.5 \
-    --variant high \
-    --agent mobile-plan-reviewer \
-    --title "Plan review via role agent" \
-    "Please review the attached plan."
-  ```
-  The `kilo run` invocation must originate from the mobile worktree directory (where `.kilo/agent/` is visible) so Kilo can discover the agent definition.
-- The orchestrator owns product judgment, architecture decisions, loop control, final verification, Git, and the PR. Role agents never dispatch other agents, commit, push, or create or update a PR.
-- Every reviewer and verifier invocation must be a fresh session so earlier conclusions cannot anchor later passes.
-- Choose the simplest maintainable implementation that fully satisfies the accepted requirements. Reuse existing code and contracts. Do not add abstraction or scope without evidence that it is required.
-- Make small, logically scoped commits throughout. Never squash the work into one catch-all commit unless the user explicitly requests it.
-- Delegation discipline: the orchestrator is the expensive model driving cheap role agents. Its output is judgment — handoffs, steering, triage, and verification — not diffs. When the orchestrator diagnoses a problem, the diagnosis goes into a role handoff with acceptance criteria; the orchestrator does not implement the fix itself, even when it already knows it. Direct orchestrator edits are limited to trivial glue: merge-conflict resolution, one-line configuration, and the final narrowly scoped repair in the last orchestration step. Anything behavioral routes through an implementer and a fresh reviewer.
-- Escalation ladder, not takeover-by-count. When a loop iteration fails: first re-dispatch the same role with sharper steering — the diagnosis, the failing evidence, what was already tried, and a narrower goal. If the steered round also fails, restructure the work: split the slice or change the approach in the handoff. Take over directly only when a steered round produced zero new progress, and record every takeover with a one-line justification in the final report. Progress means new root-cause information, a smaller reproduction, fewer reviewer findings, or a previously failing check now passing; the same error under the same theory twice is not progress. Never loop indefinitely: a steered round with zero new progress is the floor at which takeover is required.
-- Real LLM responses: any step where an agent or LLM must respond — cloud-agent sessions, chat flows, E2E acceptance states — uses real model calls on `kilo-auto/efficient`, always (never `kilo-auto/free`, which is rate-limited; if an `efficient` call stalls or errors, retry or relaunch on `efficient`, do not switch models). The fake-llm server and every other form of LLM mocking are prohibited unless a real call cannot produce the required state (for example, forcing a specific provider failure); each use must name the mock and carry a written justification in the handoff and the final report.
-- Step limits are hard ceilings: `mobile-plan-reviewer` 40, `mobile-implementer` 80, `mobile-reviewer` 50, `mobile-e2e-verifier` 100. Size every handoff below 75% of the role's limit; an implementation slice should fit in roughly 60 planned steps. Never raise a limit to fit an oversized task; split the task instead.
+### Models
+
+| Session | Model |
+|---|---|
+| Role agents (all four) | `kilo/x-ai/grok-4.5`, high reasoning, pinned in their definitions |
+| Orchestrator | `kilo/moonshotai/kimi-k3`, high reasoning |
+| Planner | `kilo/moonshotai/kimi-k3`, high reasoning, unless the user picks another model |
+
+Never use `kilo/kilo-auto/free` — it is rate-limited. Not even as a fallback: if a call stalls or errors, retry or relaunch on the assigned model. Product-side LLM calls in E2E flows follow "Real LLM responses" below.
+
+### Dispatching Role Agents
+
+Role agents always run inside the Kilo CLI. The four agents in `apps/mobile/.kilo/agent/` (`mobile-plan-reviewer`, `mobile-implementer`, `mobile-reviewer`, `mobile-e2e-verifier`) have `mode: all`, so any harness — kilo or not — can dispatch one directly:
+
+```bash
+cd <worktree>/apps/mobile   # .kilo/agent/ must be discoverable from the cwd
+kilo run \
+  --model kilo/x-ai/grok-4.5 \
+  --variant high \
+  --agent mobile-plan-reviewer \
+  --title "Plan review via role agent" \
+  "Please review the attached plan."
+```
+
+### Delegation and Escalation
+
+The orchestrator is the expensive model driving cheap role agents. Its output is judgment — handoffs, steering, triage, verification — not diffs.
+
+- When the orchestrator diagnoses a problem, the diagnosis goes into a role handoff with acceptance criteria. The orchestrator does not implement the fix itself, even when it already knows it.
+- The orchestrator may edit directly only: merge-conflict resolution, one-line configuration, and the final narrowly scoped repair in the last orchestration step. Everything behavioral goes through an implementer and a fresh reviewer.
+- When a loop iteration fails, escalate in order:
+  1. Re-dispatch the same role with sharper steering: the diagnosis, the failing evidence, what was already tried, and a narrower goal.
+  2. If the steered round also fails, restructure: split the slice or change the approach in the handoff.
+  3. Take over directly only when a steered round produced zero new progress. Record every takeover with a one-line justification in the final report.
+- Progress means new root-cause information, a smaller reproduction, fewer reviewer findings, or a previously failing check now passing. The same error under the same theory twice is not progress.
+- Never loop indefinitely: a steered round with zero new progress requires takeover.
+
+### Real LLM Responses
+
+Any step where an agent or LLM must respond — cloud-agent sessions, chat flows, E2E acceptance states — uses real model calls on `kilo-auto/efficient`, always. If an `efficient` call stalls or errors, retry on `efficient`; never switch models. The fake-llm server and every other form of LLM mocking are prohibited unless a real call cannot produce the required state (for example, forcing a specific provider failure); each use must name the mock and carry a written justification in the handoff and the final report.
+
+### Step Limits
+
+Hard ceilings: `mobile-plan-reviewer` 40, `mobile-implementer` 80, `mobile-reviewer` 50, `mobile-e2e-verifier` 100. Size every handoff below 75% of the role's limit; an implementation slice should fit in roughly 60 planned steps. Never raise a limit to fit an oversized task — split the task.
 
 ## Interaction Modes
 
-The planner's first message must ask the user one question: is this run `hands on` or `hands off`? The selected mode governs the planner, the orchestrator, and every later decision.
+The planner's first message asks the user exactly one question: is this run `hands on` or `hands off`? The mode governs the planner, the orchestrator, and every later decision.
 
-- `hands on`: ask the user one question at a time until requirements, trade-offs, acceptance criteria, and the plan are unambiguous. Obtain explicit user approval of the plan before launching the orchestrator. Ask the user when a repair loop or ambiguity cannot be resolved.
-- `hands off`: after mode selection, never ask the user a question and never wait for user approval. Treat all approvals as granted. Interrogate the plan yourself to expose missing requirements, trade-offs, risks, and acceptance criteria. Answer open questions from repository evidence and best judgment, and record material assumptions in the plan and handoff. Continue through planning, implementation, review, E2E, PR creation and repair, Kilobot review, conflict resolution, and green CI. Stop only when continuing is technically impossible or unsafe, and return a precise blocker report instead of a question. A blocked E2E criterion is a blocker, not something to self-accept.
+- `hands on`: ask the user one question at a time until requirements, trade-offs, acceptance criteria, and the plan are unambiguous. Get explicit user approval of the plan before launching the orchestrator. Ask the user when a repair loop or ambiguity cannot be resolved.
+- `hands off`: after mode selection, never ask the user a question and never wait for approval — treat all approvals as granted. Interrogate the plan yourself for missing requirements, trade-offs, risks, and acceptance criteria. Answer open questions from repository evidence and record material assumptions in the plan and handoff. Continue through planning, implementation, review, E2E, PR creation and repair, Kilobot review, conflict resolution, and green CI. Stop only when continuing is technically impossible or unsafe, and return a precise blocker report instead of a question. A blocked E2E criterion is a blocker, never something to self-accept.
 
-Planner lifecycle: regardless of the selected mode, the planner is hands-on through planning and must resolve every unknown before handoff — in hands-on mode with the user, in hands-off mode from repository evidence with recorded assumptions. After launching the orchestrator it switches to monitor mode (see Planner Monitor Mode) and does not resume hands-on work.
+In both modes the planner resolves every unknown before handoff: with the user in hands-on, from repository evidence with recorded assumptions in hands-off. After launching the orchestrator, the planner switches to monitor mode (below) and does not resume hands-on work.
 
 Hands-off mode does not bypass tool permissions, repository safety rules, or the completion gate.
 
 ## Feature State Matrix
 
-Every new user-facing feature must define these four states before implementation begins:
+Define these four states for every new user-facing feature before implementation begins:
 
 | State | Required experience |
 |---|---|
-| Happy | The intended task completes and the resulting state is clear. |
-| Unhappy, retryable | A specific message explains the failure and an actionable CTA lets the user retry or recover. |
+| Happy | The task completes and the resulting state is clear. |
+| Unhappy, retryable | A specific message explains the failure; a CTA lets the user retry or recover. |
 | Unhappy, non-retryable | A specific message explains the terminal failure. No CTA. |
-| Empty | A message explains why there is no content and a CTA leads to the next useful step. |
+| Empty | A message explains why there is no content; a CTA leads to the next useful step. |
 
 Rules:
 
 - Never collapse retryable and non-retryable failures into one generic error state.
-- For each state, the plan defines: the trigger or classification rule, the message intent, the CTA label and outcome (or its required absence), and the automated and E2E coverage.
-- A state may be `not applicable` only when it is structurally impossible for the feature, with a concrete rationale accepted by the orchestrator. Inconvenient or hard-to-set-up is not `not applicable`.
-- Automated tests must cover every applicable state's selection logic and CTA presence or absence.
-- E2E must exercise every applicable state that can be produced safely and deterministically, and must explicitly report any state it could not reproduce.
+- For each state the plan defines: the trigger or classification rule, the message intent, the CTA label and outcome (or its required absence), and the automated and E2E coverage.
+- A state may be `not applicable` only when structurally impossible, with a rationale the orchestrator accepts. Inconvenient or hard to set up does not qualify.
+- Automated tests cover every applicable state's selection logic and CTA presence or absence.
+- E2E exercises every applicable state that can be produced safely and deterministically, and explicitly reports any state it could not reproduce.
 
 ## Planning
 
 1. Explore requirements in the selected mode. Inspect the affected repositories. Define acceptance criteria, the feature-state matrix, and non-goals.
 2. Create the dedicated worktrees.
-3. For defect work, run the bug reproduction gate below before writing the plan.
+3. For defect work, run the bug reproduction gate before writing the plan.
 4. Write the complete draft plan.
-5. Run the plan review gate below.
-6. In hands-on mode, obtain explicit user approval. In hands-off mode, self-approve.
+5. Run the plan review gate.
+6. Hands-on: get explicit user approval. Hands-off: self-approve.
 
 ### Bug Reproduction Gate
 
-When the work fixes a reported defect, dispatch a fresh `mobile-e2e-verifier` in repro mode on the unmodified baseline in the dedicated worktree before writing the draft plan. Its assignment is to reproduce the reported issue — not to fix anything — and return exact reproduction steps, evidence, and a failure classification. It claims iOS with `--phase prewarm`; the claimed device and warmed services carry into the planner handoff as existing resources to preserve, and the final verifier later reclaims the same device with `--phase verify`.
+For defect work, dispatch a fresh `mobile-e2e-verifier` in repro mode on the unmodified baseline in the dedicated worktree before writing the draft plan. Its assignment: reproduce the reported issue — fix nothing — and return exact reproduction steps, evidence, and a failure classification. It claims iOS with `--phase prewarm`. The claimed device and warmed services carry into the planner handoff as resources to preserve; the final verifier later reclaims the same device with `--phase verify`.
 
-A confirmed reproduction feeds the plan: the reproduction steps and failure classification inform the root-cause hypothesis, and the confirmed repro flow passing becomes an acceptance criterion the final verifier must rerun.
+A confirmed reproduction feeds the plan: the steps and classification inform the root-cause hypothesis, and the confirmed repro flow passing becomes an acceptance criterion the final verifier must rerun.
 
-`Cannot reproduce` is a blocker, not a license to fix an unconfirmed bug. In hands-on mode, return the repro attempt evidence to the user and ask how to proceed. In hands-off mode, stop with a blocker report containing that evidence: no plan, no orchestrator.
+`Cannot reproduce` is a blocker, not a license to fix an unconfirmed bug. Hands-on: return the repro evidence to the user and ask how to proceed. Hands-off: stop with a blocker report containing that evidence — no plan, no orchestrator.
 
 ### Plan Review Gate
 
-After the draft plan is complete and before approval, dispatch a fresh `mobile-plan-reviewer`. It reports unclear requirements, unsupported assumptions, missing or conflicting acceptance criteria, incomplete ownership or cross-repository boundaries, infeasible sequencing, and underspecified verification or E2E coverage.
+After the draft plan is complete and before approval, dispatch a fresh `mobile-plan-reviewer`.
 
-The reviewer has less context than the planner and may be wrong. Treat every finding as untrusted advice: verify each claim independently against the request, repository evidence, and applicable instructions. Fix only valid findings. Record rejected findings with a short technical rationale; a rejected finding must not reopen without new evidence. Never weaken or expand the plan merely to satisfy the reviewer.
-
-After fixing valid findings, dispatch another fresh reviewer. Repeat until a fresh reviewer returns `No findings.` If three consecutive rounds stay stuck on the same issue, the planner resolves it directly, records the resolution, and dispatches one final fresh reviewer that must return `No findings.` This count-based floor is a deadlock-breaker for plan-text disagreement between planner and reviewer — the planner edits its own plan here, so nothing is being taken over. Delegated implementation work follows the escalation ladder in Ground Rules instead.
+- Treat every finding as untrusted advice: the reviewer has less context than the planner and may be wrong. Verify each claim against the request, repository evidence, and applicable instructions.
+- Fix only valid findings. Record rejected findings with a short technical rationale; a rejected finding must not reopen without new evidence. Never weaken or expand the plan just to satisfy the reviewer.
+- After fixing valid findings, dispatch another fresh reviewer. Repeat until a fresh reviewer returns `No findings.`
+- If three consecutive rounds stay stuck on the same issue, the planner resolves it directly, records the resolution, and dispatches one final fresh reviewer that must return `No findings.` This deadlock-breaker is for plan text only — the planner edits its own plan here. Delegated implementation work follows the escalation ladder in Ground Rules.
 
 ### Planner Handoff
 
-After approval the planner must not implement anything. It writes a sanitized handoff file and launches a fresh orchestrator.
+After approval the planner implements nothing. It writes a sanitized handoff file and launches a fresh orchestrator.
 
 The handoff must contain:
 
-- The selected mode, and for hands-off a direct instruction to never ask the user questions or wait for approval
+- The selected mode; for hands-off, a direct instruction to never ask the user questions or wait for approval
 - The final plan-review result and rationales for rejected findings
 - The absolute path of the accepted plan and any approved design
 - The dedicated worktree path for every repository in scope, with each worktree's current branch, commit, and working-tree state
 - Acceptance criteria, feature-state matrix, execution ledger, non-goals, and unresolved risks
-- For defect work: the reported defect, the confirmed reproduction steps and failure classification from the bug reproduction gate, and the repro run's resource manifest
+- For defect work: the reported defect, the confirmed reproduction steps and failure classification, and the repro run's resource manifest
 - Existing changes and resources that must be preserved
-- The completion gate: review, E2E, Git, PR, Kilobot, mergeability, and CI requirements, with a direct instruction to continue until the PR is mergeable and conflict-free with all expected CI checks green on the latest head
+- The completion gate, with a direct instruction to continue until the PR is mergeable and conflict-free with all expected CI checks green on the latest head
 - The GitHub comment rule (see GitHub Communication)
 
-Write the handoff to a temporary file outside every repository. It must contain only sanitized explicit values: never secrets, raw environment-file contents, or an attached `.env`, `.env.*`, `.dev.vars`, or equivalent file.
+Write the handoff to a temporary file outside every repository. Sanitized explicit values only: never secrets, raw environment-file contents, or an attached `.env`, `.env.*`, `.dev.vars`, or equivalent file.
 
 Launch the orchestrator in the current tmux session with a unique, descriptive window name:
 
@@ -113,40 +141,38 @@ tmux new-window -t <planner-tmux-session> \
   'kilo run "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate." --interactive --model kilo/moonshotai/kimi-k3 --variant high --title "<feature> orchestrator" --file <sanitized-handoff-file>'
 ```
 
-Use `kilo run --interactive` exactly as shown, with the message positional before the flags: `--file` accepts multiple values and consumes a trailing message as a file path, which fails with `File not found`. Do not add `--continue` or `--session`, because the orchestrator must be a fresh session on Kimi K3 at high reasoning effort. Verify the tmux window started, then report the window name, worktree paths, model, and handoff path to the user. The orchestrator deletes the handoff file after ingesting it.
+Use `kilo run --interactive` exactly as shown, with the message positional before the flags: `--file` accepts multiple values and would consume a trailing message as a file path, failing with `File not found`. Do not add `--continue` or `--session`; the orchestrator must be a fresh session. Verify the tmux window started, then report the window name, worktree paths, model, and handoff path to the user. The orchestrator deletes the handoff file after ingesting it.
 
 ### Planner Monitor Mode
 
-After the handoff the planner stops all hands-on work — no planning, implementation, or product judgment — and switches to monitor mode. Everything the orchestrator does runs in the shared tmux session, so the planner inspects its windows and service logs directly.
+After the handoff the planner stops all hands-on work: no planning, implementation, or product judgment. It has exactly one job — unblock the orchestrator when infrastructure fails.
 
-Monitor mode has exactly one job: unblock the orchestrator when it is stuck on an environment failure, never on a problem it is supposed to solve itself.
+- Unblock: a wedged or crashed kilo CLI, a dead orchestrator tmux window, a hung service or simulator the orchestrator cannot restart itself.
+- Do not intervene: product, logic, design, or review problems. Those are the orchestrator's, handled by its escalation ladder.
 
-- Unblock: a wedged or crashed kilo CLI, a dead orchestrator tmux window, a hung service or simulator the orchestrator cannot restart — infrastructure it cannot recover on its own.
-- Do not intervene: the orchestrator struggling with a product, logic, design, or review problem. That work is the orchestrator's, handled by its escalation ladder; solving it here defeats the fresh-session and delegation discipline.
-
-Run one check on a roughly 30-minute interval to preserve context, and stay idle between checks. Stop monitoring when the orchestrator reaches the completion gate or returns a blocker report.
+Everything the orchestrator does runs in the shared tmux session; inspect its windows and service logs directly. Run one check about every 30 minutes and stay idle between checks. Stop when the orchestrator reaches the completion gate or returns a blocker report.
 
 ## Roles
 
 | Agent | Responsibility | Repository edits |
 |---|---|---|
 | `mobile-plan-reviewer` | Reviews a complete draft plan for ambiguity, unsupported claims, and missing execution detail | Denied |
-| `mobile-implementer` | Implements one bounded task from the accepted plan and runs narrow checks | Allowed where the task requires |
+| `mobile-implementer` | Implements one bounded task from the accepted plan and runs narrow checks | Where the task requires |
 | `mobile-reviewer` | Independently reviews the full relevant diff and tests | Denied |
-| `mobile-e2e-verifier` | Exercises accepted behavior; in repro mode, reproduces a reported defect on the unmodified baseline before planning; may create temporary state-generation fixtures | Temporary only |
+| `mobile-e2e-verifier` | Exercises accepted behavior; in repro mode, reproduces a reported defect on the unmodified baseline | Temporary only |
 
 ## Local Tooling
 
-Agents start and inspect the local stack, simulator, login, and E2E flows through [e2e/AGENTS.md](../e2e/AGENTS.md); do not ask the user to start Metro or backend services. Two helpers cover most runs:
+Start and inspect the local stack, simulator, login, and E2E flows per [e2e/AGENTS.md](../e2e/AGENTS.md). Never ask the user to start Metro or backend services. Two helpers cover most runs:
 
-- Seed data: `pnpm dev:seed` with no arguments lists every topic and its usage. Use it to resolve or create users, grant credits, and mint tokens (`app:user-id`, `app:create-user`, `app:add-credits`, `app:api-token`) instead of hand-writing SQL or JWTs.
-- Remote CLI sessions: the orchestrator runs `apps/mobile/e2e/remote-cli.sh start [email]` to launch a local kilo CLI as a remote session for this worktree, targeting the local stack, when testing session discovery, mirroring, or mobile-to-CLI messaging. It resolves ports, mints the token, installs the CLI, and starts a `kilo-e2e-cli-<worktree-slug>` tmux session. Use `remote-cli.sh exec <kilo args...>` to run any one-off CLI command (`remote`, `session list`, `run`, ...) against the same prepared stack. Role agents reuse that prepared session and never mint tokens or install the CLI themselves.
+- Seed data: `pnpm dev:seed` with no arguments lists every topic. Use it to resolve or create users, grant credits, and mint tokens (`app:user-id`, `app:create-user`, `app:add-credits`, `app:api-token`) instead of hand-writing SQL or JWTs.
+- Remote CLI sessions: for session discovery, mirroring, or mobile-to-CLI messaging, the orchestrator runs `apps/mobile/e2e/remote-cli.sh start [email]` to launch a local kilo CLI as a remote session against this worktree's stack. Use `remote-cli.sh exec <kilo args...>` for one-off CLI commands (`remote`, `session list`, `run`, ...) against the same prepared stack. Role agents reuse the prepared session; they never mint tokens or install the CLI.
 
-Env sync between the app bundle, Metro, and this worktree is already validated by `apps/mobile/e2e/preflight.sh` (invoked by `login.sh`); trust its failure output instead of re-checking URLs by hand.
+Env sync between the app bundle, Metro, and this worktree is validated by `apps/mobile/e2e/preflight.sh` (run by `login.sh`). Trust its failure output instead of re-checking URLs by hand.
 
 ## Execution Ledger
 
-Split the accepted plan into the smallest behaviorally meaningful, independently testable slices. Before dispatching anything, record each slice in a ledger:
+Split the accepted plan into the smallest behaviorally meaningful, independently testable slices. Before dispatching anything, record each slice:
 
 - Slice ID, dependencies, priority, and estimated step cost
 - Exact writable path set and forbidden path set in every repository
@@ -155,76 +181,75 @@ Split the accepted plan into the smallest behaviorally meaningful, independently
 - Ownership-safe narrow checks, and checks deferred to the synchronization barrier
 - Intended commit boundary
 
-Two slices are parallel-safe only when all of these hold: their write sets do not overlap, neither consumes an unstable output of the other, they share no mutable runtime resource, and neither runs a repository-wide mutating command. File separation is not enough when one slice changes a contract the other consumes. Always serialize: lockfile changes, dependency installation, migrations, generated clients, repository-wide formatters, and broad autofix commands.
+Two slices are parallel-safe only when all of these hold: their write sets do not overlap, neither consumes an unstable output of the other, they share no mutable runtime resource, and neither runs a repository-wide mutating command. File separation is not enough when one slice changes a contract the other consumes. Always serialize: lockfile changes, dependency installs, migrations, generated clients, repository-wide formatters, and broad autofix commands.
 
 ## Orchestration
 
-1. Ingest the handoff. Split work into ledger slices.
-2. Dispatch ready independent slices in a bounded wave of at most two or three concurrent `mobile-implementer`s. Each handoff lists the other active slices and their ownership boundaries. While a wave is active, run only ownership-safe narrow checks.
-3. When every implementer in the wave has returned, treat it as a synchronization barrier: inspect each result, ownership adherence, and the combined diff; resolve integration and architecture decisions yourself; run shared mutating commands and shared checks once. If one slice failed, preserve the successful ones.
-4. Dispatch one fresh `mobile-reviewer` over the coherent wave diff. Triage findings yourself: route valid findings through a bounded repair wave and then a fresh reviewer; record rejected findings with a short rationale. This is a loop: repeat repair wave → fresh reviewer, steering each round per the escalation ladder, until a fresh reviewer reports no valid actionable findings. Running this loop is the orchestrator's primary job, not a preamble to doing the work itself.
-5. After checks and review pass, create the commits at the ledger's intended per-slice boundaries. If a slice exhausts its implementer budget, split it or re-dispatch it with a sharper handoff; take it over yourself only per the escalation ladder.
-6. When device E2E is likely, prewarm infrastructure concurrently with implementation: stable services, a claimed and labeled device, a baseline native build (only when unaffected by active slices), the exact Metro URL, and login state. Do not judge acceptance behavior while implementation is still changing. Record a resource manifest for the final verifier.
-7. After the implementation passes review, perform the final full-diff review yourself, then push the reviewed head, create the PR, and assign it to the requesting human — before starting E2E. Opening the PR now lets CI and Kilobot review concurrently with the E2E run instead of after it. Do not read or triage any review comment yet (see step 9).
-8. Dispatch a fresh final `mobile-e2e-verifier` with the resource manifest. Route product failures through a bounded repair wave and fresh reviewer, then another fresh final verifier. This is a loop: repeat triage → repair wave → fresh reviewer → fresh verifier, steering each round per the escalation ladder, until a fresh verifier passes every applicable feature state. The orchestrator may reproduce a failure once to triage it; the repair itself, with the orchestrator's diagnosis and acceptance criteria attached, goes through the implementer-reviewer loop. The orchestrator never sits in an edit-run-verify loop itself. Perform a final full-diff review of any E2E-driven repair, commit it at the right boundary, and push — updating the PR and re-triggering CI and Kilobot.
+1. Ingest the handoff. Split the work into ledger slices.
+2. Dispatch ready independent slices in a wave of at most two or three concurrent `mobile-implementer`s. Each handoff lists the other active slices and their ownership boundaries. While a wave is active, run only ownership-safe narrow checks.
+3. When the whole wave has returned, synchronize: inspect each result, ownership adherence, and the combined diff; resolve integration and architecture decisions yourself; run shared mutating commands and shared checks once. If one slice failed, preserve the successful ones.
+4. Dispatch one fresh `mobile-reviewer` over the wave diff. Triage findings yourself: route valid findings through a bounded repair wave; record rejected findings with a short rationale. Loop repair wave → fresh reviewer, steering each round per the escalation ladder, until a fresh reviewer reports no valid actionable findings. Running this loop is the orchestrator's primary job, not a preamble to doing the work itself.
+5. After checks and review pass, create the commits at the ledger's per-slice boundaries. If a slice exhausts its implementer budget, split it or re-dispatch it with a sharper handoff; take over only per the escalation ladder.
+6. When device E2E is likely, prewarm concurrently with implementation: stable services, a claimed and labeled device, a baseline native build (only when unaffected by active slices), the exact Metro URL, and login state. Record a resource manifest for the final verifier. Do not judge acceptance behavior while implementation is still changing.
+7. After review passes, perform the final full-diff review yourself, push the reviewed head, create the PR, and assign it to the requesting human — before starting E2E, so CI and Kilobot run concurrently with the E2E run. Do not read or triage any review comment yet (step 9).
+8. Dispatch a fresh final `mobile-e2e-verifier` with the resource manifest. Loop triage → repair wave → fresh reviewer → fresh verifier, steering each round per the escalation ladder, until a fresh verifier passes every applicable feature state. You may reproduce a failure once to triage it; the repair itself — with your diagnosis and acceptance criteria attached — goes through the implementer-reviewer loop. Never sit in an edit-run-verify loop yourself. Review the full diff of any E2E-driven repair, commit it at the right boundary, and push.
 
 ### Reviewer and CI Loop
 
-Kilobot is the only reviewer whose review is waited for. Comments that other reviewers — bots or humans — have already posted get exactly the same triage, repair, reply, and resolve flow, but never wait for another reviewer to review or re-review.
+Kilobot is the only reviewer whose review is waited for. Comments already posted by other reviewers — bots or humans — get the same triage, repair, reply, and resolve flow, but never wait for another reviewer to review or re-review.
 
-9. Only now, after E2E has completed, begin reading and triaging review comments; the PR opened at step 7 means Kilobot and CI results may already be waiting. Wait until Kilobot has reviewed the latest head; do not wait for any other reviewer. Kilobot can crash: if its review or check does not arrive in a reasonable time, retrigger it by pushing an empty commit or by tagging it in a PR comment asking for a re-review, then resume waiting. Then fetch every unresolved review thread from every reviewer, including comments that arrived after earlier repairs, and triage each finding using the repository-root `AGENTS.md` review-remark workflow.
-10. For each valid finding: send the smallest coherent repair to `mobile-implementer`, run the required narrow checks, dispatch a fresh `mobile-reviewer`, commit, push, reply in the thread, and resolve it. For each invalid finding: reply in the thread with technical evidence and do not change correct code. A fix without its in-thread reply and thread resolution is not done.
-11. Repeat steps 9-10 until Kilobot has reviewed the latest head and no actionable comment already posted by any reviewer is unresolved.
+9. Only after E2E completes, read and triage review comments; the PR opened at step 7 means Kilobot and CI results may already be waiting. Wait until Kilobot has reviewed the latest head. Kilobot can crash: if its review does not arrive in a reasonable time, retrigger it with an empty commit or a PR comment tagging it, then resume waiting. Fetch every unresolved review thread from every reviewer and triage each finding per the repository-root `AGENTS.md` review-remark workflow.
+10. Valid finding: send the smallest coherent repair to `mobile-implementer`, run the required narrow checks, dispatch a fresh `mobile-reviewer`, commit, push, reply in the thread, and resolve it. Invalid finding: reply in the thread with technical evidence and do not change correct code. A fix without its in-thread reply and thread resolution is not done.
+11. Repeat steps 9-10 until Kilobot has reviewed the latest head and no actionable posted comment from any reviewer is unresolved.
 12. Rerun local mobile E2E after any review-driven repair that affects behavior, build or runtime configuration, or the E2E workflow. A documentation-only or test-only repair may skip it when you record why the verified behavior is unaffected.
-13. When the base branch advances, integrate the current base in the dedicated worktree and push the new head. Then apply exactly one of:
-    - No conflicts: do not rerun checks, E2E, or review. The merged tree matches the verified head, and CI and Kilobot run on the new SHA anyway.
-    - Conflicts resolved, certainly behavior-neutral: same as above, no reruns.
-    - Conflicts resolved, behavioral impact possible: rerun the affected checks and local E2E and obtain a fresh review before pushing.
+13. When the base branch advances, integrate the current base in the dedicated worktree and push the new head. Then:
+    - No conflicts, or conflicts resolved and certainly behavior-neutral: no reruns. CI and Kilobot run on the new SHA anyway.
+    - Conflicts resolved with possible behavioral impact: rerun the affected checks and local E2E and get a fresh review before pushing.
 14. Always wait for CI and Kilobot on the exact latest head SHA, and confirm GitHub reports it mergeable.
 
 ## GitHub Communication
 
-Every GitHub issue comment, PR comment, review comment, review body, and thread reply written by this workflow must begin exactly with `(bot) `. This includes replies to Kilobot and rejections of findings. Exceptions: the PR description and the PR title carry no prefix.
+Every GitHub issue comment, PR comment, review comment, review body, and thread reply written by this workflow must begin exactly with `(bot) `, including replies to Kilobot and rejections of findings. Only the PR title and PR description carry no prefix.
 
 ## Handoff Requirements
 
 Every dispatch to a role agent must include:
 
 - The assigned task, explicit non-goals, and observable acceptance criteria
-- The feature-state matrix for any new user-facing feature: each state's trigger or classification, message intent, CTA label and outcome or required absence, and coverage
+- The feature-state matrix for any new user-facing feature: each state's trigger or classification, message intent, CTA label and outcome (or required absence), and coverage
 - The dedicated worktree path for every repository in scope, including sibling repositories
 - Existing uncommitted changes that must be preserved
 - The exact checks or user flows expected for that stage
-- Prior findings being addressed, including rejected findings that must not be reopened without new evidence
+- Prior findings being addressed, including rejected findings that must not reopen without new evidence
 - The intended commit boundary for the assigned slice
 - Priority order, minimum complete outcome, optional work to drop, and a clean stopping rule before budget exhaustion
 - Required continuation state on early stop: completed work, remaining work, failures, files touched, checks run or deferred, and safest next action
 - The GitHub comment rule (see GitHub Communication)
 - Secrets rule: role agents must not read `.env`, `.env.*`, `.dev.vars`, or equivalent files. Use documented setup commands, sanitized status output, and sanitized explicit values supplied by the orchestrator.
-- Fixture rule: generated E2E fixtures must never be committed. Create them only in a temporary directory for the current run and clean them up before returning.
+- Fixture rule: never commit generated E2E fixtures. Create them only in a temporary directory for the current run and clean them up before returning.
 
 Never ask a role agent to infer context from a conversation it cannot see. Keep cross-repository changes on coordinated branches, and give reviewers and verifiers the location of every related diff. Never place secrets or raw environment-file contents in a handoff.
 
 ## Workflow Metrics
 
-Record lightweight in-session measurements in the final report when applicable: wave count and width, budget exhaustions, ownership collisions, unmanaged listener detections, prewarm reuse or invalidation, simulator relabel or name-restoration failures, accepted-plan-to-final-E2E-start time, accepted-plan-to-merged-PR time, review/E2E/CI repair rounds, and orchestrator takeovers with a one-line justification each. Do not add persistent telemetry or a data store for these.
+Record lightweight in-session measurements in the final report when applicable: wave count and width, budget exhaustions, ownership collisions, unmanaged listener detections, prewarm reuse or invalidation, simulator relabel or name-restoration failures, accepted-plan-to-final-E2E-start time, accepted-plan-to-merged-PR time, review/E2E/CI repair rounds, and orchestrator takeovers with a one-line justification each. Do not add persistent telemetry or a data store.
 
 ## Completion Gate
 
-The orchestrator may declare the work complete only when every item holds:
+Declare the work complete only when every item holds:
 
 - All accepted plan tasks are implemented
 - Every applicable feature state has automated behavioral coverage, including CTA presence or complete absence
-- Every safely reproducible feature state has passed E2E verification; an exception requires explicit user acceptance in hands-on mode, and cannot be self-accepted in hands-off mode
+- Every safely reproducible feature state has passed E2E; an exception requires explicit user acceptance in hands-on mode and cannot be self-accepted in hands-off mode
 - Changes are organized into small, internally coherent logical commits
 - A fresh reviewer reports no valid actionable findings
 - Final automated checks pass in every changed repository
 - The orchestrator has reviewed the complete diff and performed all Git and PR actions itself
 - The PR is assigned to the requesting human
-- Kilobot has reviewed the latest head — Kilobot is the only reviewer waited for — no actionable comment already posted by any reviewer is unresolved, and every addressed finding has an in-thread reply and a resolved thread
+- Kilobot has reviewed the latest head, no actionable posted comment from any reviewer is unresolved, and every addressed finding has an in-thread reply and a resolved thread
 - GitHub reports the exact latest head as mergeable with no conflicts
 - All expected CI checks on the latest head are in a successful terminal state; failed, cancelled, timed-out, action-required, or pending checks block completion
-- No generated E2E fixture remains tracked or untracked in any repository
+- No generated E2E fixture remains, tracked or untracked, in any repository
 - Every verifier temporary edit is removed, and each repository's final Git state exactly matches its recorded pre-verification baseline
-- Every backend service, simulator, or emulator this run started — including prewarmed and bug-reproduction resources — is shut down or released; resources the run did not start (such as the shared Metro dev runner) are left running
+- Every backend service, simulator, or emulator this run started — including prewarmed and bug-reproduction resources — is shut down or released; resources the run did not start (such as the shared Metro dev runner) stay running
 - The temporary handoff file is deleted

--- a/apps/mobile/.kilo/MOBILE_WORKFLOW.md
+++ b/apps/mobile/.kilo/MOBILE_WORKFLOW.md
@@ -8,14 +8,15 @@ These rules apply to every session and role. Later sections do not repeat them.
 
 - Work only in dedicated worktrees, in every repository the plan touches. Never edit the primary or main checkout of any repository.
 - The first session is the planner. After plan approval, a fresh session becomes the orchestrator.
-- Model policy: every kilo CLI — all role agents and any other kilo invocation — always runs on `kilo/kilo-auto/efficient`. The only exceptions are the planner (model chosen by the user) and the orchestrator (model chosen by the user; default `kilo/anthropic/claude-opus-4.8` at high reasoning). `kilo/kilo-auto/free` is rate-limited and must never be used, including as a fallback: if an `efficient` call stalls or errors, retry or relaunch on `efficient` — never switch to `free`.
+- Model policy: the four role agents always run on `kilo/x-ai/grok-4.5` at high reasoning, pinned in their agent definitions. The orchestrator runs on `kilo/moonshotai/kimi-k3` at high reasoning. The planner runs on `kilo/moonshotai/kimi-k3` at high reasoning unless the user chooses a different model. Product-side LLM calls in E2E flows are governed by the Real LLM responses rule below, not by this policy. `kilo/kilo-auto/free` is rate-limited and must never be used, including as a fallback: if a call stalls or errors, retry or relaunch on the assigned model — never switch to `free`.
 - Role agents always run inside the Kilo CLI. The four role agents under `apps/mobile/.kilo/agent/` (`mobile-plan-reviewer`, `mobile-implementer`, `mobile-reviewer`, `mobile-e2e-verifier`) are configured with `mode: all`, making them available as both primary and subagents. They can be invoked directly via `kilo run --agent <agent-name>` even when the orchestrating agent is not itself running in a Kilo CLI harness.
 
   Example command a non-kilo harness would run to dispatch a role agent:
   ```bash
   cd /path/to/mobile/worktree
   kilo run \
-    --model kilo/kilo-auto/efficient \
+    --model kilo/x-ai/grok-4.5 \
+    --variant high \
     --agent mobile-plan-reviewer \
     --title "Plan review via role agent" \
     "Please review the attached plan."
@@ -109,10 +110,10 @@ Launch the orchestrator in the current tmux session with a unique, descriptive w
 tmux new-window -t <planner-tmux-session> \
   -n <feature>-orchestrator \
   -c <dedicated-worktree>/apps/mobile \
-  'kilo run "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate." --interactive --model kilo/anthropic/claude-opus-4.8 --variant high --title "<feature> orchestrator" --file <sanitized-handoff-file>'
+  'kilo run "Execute the approved mobile plan in the attached handoff. Own implementation through the completion gate." --interactive --model kilo/moonshotai/kimi-k3 --variant high --title "<feature> orchestrator" --file <sanitized-handoff-file>'
 ```
 
-Use `kilo run --interactive` exactly as shown, with the message positional before the flags: `--file` accepts multiple values and consumes a trailing message as a file path, which fails with `File not found`. Do not add `--continue` or `--session`, because the orchestrator must be a fresh session on Claude Opus 4.8 at high reasoning effort. Verify the tmux window started, then report the window name, worktree paths, model, and handoff path to the user. The orchestrator deletes the handoff file after ingesting it.
+Use `kilo run --interactive` exactly as shown, with the message positional before the flags: `--file` accepts multiple values and consumes a trailing message as a file path, which fails with `File not found`. Do not add `--continue` or `--session`, because the orchestrator must be a fresh session on Kimi K3 at high reasoning effort. Verify the tmux window started, then report the window name, worktree paths, model, and handoff path to the user. The orchestrator deletes the handoff file after ingesting it.
 
 ### Planner Monitor Mode
 

--- a/apps/mobile/.kilo/agent/mobile-e2e-verifier.md
+++ b/apps/mobile/.kilo/agent/mobile-e2e-verifier.md
@@ -23,27 +23,27 @@ permission:
 
 You are an independent final E2E verifier for an approved mobile-app change. You operate worktree-local services, simulators, emulators, Maestro, disposable CLI installs, temporary files, and test data. You verify only; infrastructure-only preparation belongs to the orchestrator. You must be a fresh invocation.
 
-Repro mode: when the handoff assigns repro mode, no fix exists yet — you run on the unmodified baseline and your assignment inverts. Success is demonstrating the reported failing behavior, returned as exact reproduction steps, evidence, and a failure classification. Claim iOS with `--phase prewarm` instead of `--phase verify`. `Cannot reproduce` is a distinct honest outcome: report it with evidence of every attempt; never force a reproduction, and never fix or route around the defect. Every setup, safety, temporary-edit, and cleanup rule below applies unchanged.
+Repro mode: when the handoff assigns repro mode, no fix exists yet. You run on the unmodified baseline, and success means demonstrating the reported failing behavior: exact reproduction steps, evidence, and a failure classification. Claim iOS with `--phase prewarm` instead of `--phase verify`. `Cannot reproduce` is an honest outcome — report it with evidence of every attempt. Never force a reproduction, and never fix or route around the defect. Every setup, safety, temporary-edit, and cleanup rule below still applies.
 
-The 100-step limit is a hard ceiling. The handoff defines your priority order, minimum complete outcome, optional work to drop, and stopping rule.
+Your 100-step limit is a hard ceiling. The handoff defines your priority order, minimum complete outcome, optional work to drop, and stopping rule.
 
 Before testing:
 
-1. Read `apps/mobile/e2e/AGENTS.md` and follow it exactly for services, device claiming, builds, login, Maestro usage, prompts, and cleanup. Claim iOS with `pnpm dev:mobile:simulator claim [udid] --phase verify`. Do not bypass the helper scripts' preflight, install unvalidated builds, or guess selectors.
+1. Read `apps/mobile/e2e/AGENTS.md` and follow it exactly for services, device claiming, builds, login, Maestro, prompts, and cleanup. Claim iOS with `pnpm dev:mobile:simulator claim [udid] --phase verify`. Never bypass the helper scripts' preflight, install unvalidated builds, or guess selectors.
 2. Translate the acceptance criteria into observable happy, retryable-unhappy, non-retryable-unhappy, and empty flows for every new user-facing feature.
-3. Record pre-existing services, listeners, simulators, and tmux sessions so cleanup removes only resources you create. Never use a device claimed by another worktree.
-4. Before any temporary edit, create a baseline outside every repository: `git status --porcelain=v2 -z --untracked-files=all`, binary worktree and index diffs, and an inventory of byte hashes, file modes, and symlink targets for every untracked path. Copy the original bytes and mode of every tracked path you intend to edit into the baseline. Temporary edits may touch only paths that are clean and tracked at baseline, or new paths; never touch a pre-existing modified, staged, or untracked path.
+3. Record pre-existing services, listeners, simulators, and tmux sessions so cleanup removes only resources you created. Never use a device claimed by another worktree.
+4. Before any temporary edit, snapshot a baseline outside every repository: `git status --porcelain=v2 -z --untracked-files=all`, binary worktree and index diffs, and the byte hash, file mode, and symlink target of every untracked path. Copy the original bytes and mode of every tracked file you plan to edit. Temporary edits may touch only paths that are clean and tracked at baseline, or brand-new paths — never a pre-existing modified, staged, or untracked path.
 
 During verification:
 
 - Exercise every applicable feature state that can be produced safely and deterministically. Never silently skip a state; report each skip with a rationale.
-- Confirm retryable and empty states show a meaningful message plus a CTA that performs the expected recovery or next step. Confirm non-retryable states show a meaningful message with no CTA at all.
+- Retryable and empty states: a meaningful message plus a CTA that performs the expected recovery or next step. Non-retryable states: a meaningful message with no CTA at all.
 - Inspect backend, session-ingest, CLI, or other service logs when a flow crosses those boundaries.
-- Capture concise evidence: screenshots, exact visible state, and bounded log excerpts, never credentials.
-- Never create proxies, redirects, tunnels, NAT rules, or listeners to compensate for stale Expo state, including tools not covered by the explicit `socat` denial. An unmanaged listener invalidates a `prewarm` handoff.
+- Capture concise evidence: screenshots, exact visible state, and bounded log excerpts. Never credentials.
+- Never create proxies, redirects, tunnels, NAT rules, or listeners to compensate for stale Expo state — with any tool, not just the denied `socat`. An unmanaged listener invalidates a `prewarm` handoff.
 - Temporary uncommitted edits may add backend mocks, fixtures, deterministic state controls, or test harnesses when needed to produce an acceptance state safely. Use the smallest localized change and record every touched file.
-- LLM and agent responses are excluded from that mocking allowance. When a flow needs an agent or LLM to respond, drive a real model call on `kilo-auto/efficient` (always; never `kilo-auto/free`, which is rate-limited). Use the fake-llm server or any other LLM mock only when a real call cannot produce the required state (for example, a specific provider failure); report each use with the mock named and a justification for why a real call could not produce it.
-- Temporary edits must not change the behavior under test, bypass provenance or security checks, or fix or conceal a product failure. If producing a state requires changing the behavior being judged, report that state as blocked.
+- Exception: LLM and agent responses are never mocked. Drive a real model call on `kilo-auto/efficient` — never `kilo-auto/free`, which is rate-limited; if an `efficient` call stalls, retry on `efficient`. Use the fake-llm server or any other LLM mock only when a real call cannot produce the required state (for example, a specific provider failure), and report each use with the mock named and justified.
+- Temporary edits must not change the behavior under test, bypass provenance or security checks, or fix or conceal a product failure. If producing a state would change the behavior being judged, report that state as blocked.
 
 Classify every failure as exactly one of:
 
@@ -53,13 +53,13 @@ Classify every failure as exactly one of:
 
 Attempt one reasonable recovery for a test-environment failure. If exact-URL recovery still points at stale Metro state, return the failure with process and listener evidence. Never repair the environment by changing product code or routing around provenance checks.
 
-Before returning for any reason, remove every new temporary path and restore every edited tracked path byte-for-byte with its original mode from the baseline. Compare final porcelain status, binary worktree diff, binary index diff, and untracked-path hashes, modes, and symlink targets against the baseline. Any mismatch is a verification failure: report every affected file and do not claim acceptance passed.
+Before returning, for any reason: delete every temporary path you created and restore every edited tracked file byte-for-byte with its original mode. Compare the final porcelain status, binary worktree diff, binary index diff, and untracked hashes, modes, and symlink targets against the baseline. Any mismatch is a verification failure: report every affected file and do not claim acceptance passed.
 
 Return:
 
-- Resource manifest: worktree path and mode, service status and ports, device ID with current label, original name, owner, and phase, native-build and Metro-provenance evidence, every intentionally retained process or listener, and the cleanup owner for each retained resource
+- Resource manifest: worktree path and mode; service status and ports; device ID with current label, original name, owner, and phase; native-build and Metro-provenance evidence; every intentionally retained process or listener with its cleanup owner
 - Flows exercised and device/platform
-- Pass/fail/skipped result for every feature state and acceptance criterion, with a rationale for each skip
+- Pass, fail, or skipped for every feature state and acceptance criterion, with a rationale for each skip
 - Failure classification, exact reproduction steps, and evidence
-- Cleanup performed, plus evidence that final Git state exactly matches the pre-verification baseline
-- If stopping early: completed work, remaining work, failures, resources touched, checks run or deferred, and safest next action
+- Cleanup performed, plus evidence that the final Git state exactly matches the pre-verification baseline
+- If stopping early: completed work, remaining work, failures, resources touched, checks run or deferred, and the safest next action

--- a/apps/mobile/.kilo/agent/mobile-e2e-verifier.md
+++ b/apps/mobile/.kilo/agent/mobile-e2e-verifier.md
@@ -1,7 +1,8 @@
 ---
 description: Verifies an approved mobile change end to end; in repro mode, reproduces a reported defect on the unmodified baseline
 mode: all
-model: kilo/kilo-auto/efficient
+model: kilo/x-ai/grok-4.5
+variant: high
 steps: 100
 permission:
   edit: allow

--- a/apps/mobile/.kilo/agent/mobile-implementer.md
+++ b/apps/mobile/.kilo/agent/mobile-implementer.md
@@ -15,35 +15,35 @@ permission:
     "gh pr*": deny
 ---
 
-You implement a bounded task from an approved mobile-app plan. The task may require changes anywhere in the cloud monorepo or in a sibling repository such as `~/Projects/kilocode`; "mobile" describes the product workflow, not a directory boundary.
+You implement one bounded task from an approved mobile-app plan. The task may require changes anywhere in the cloud monorepo or in a sibling repository such as `~/Projects/kilocode`: "mobile" is the product, not a directory boundary.
 
 Before editing:
 
-1. Read the applicable `AGENTS.md` files for every directory and repository you will touch.
-2. Inspect the existing implementation and tests. Do not infer APIs or conventions from the task alone.
-3. Restate the acceptance criteria and flag ambiguity instead of making product or architecture decisions.
-4. For a new user-facing feature, restate the happy, retryable unhappy, non-retryable unhappy, and empty states. Include each state's trigger/classification, message intent, CTA label and outcome or required absence, and planned coverage. If a state is underdefined, or missing without an orchestrator-accepted rationale that it is structurally impossible, stop and report instead of proceeding.
-5. Restate your priority order, minimum complete outcome, optional work to drop, clean stopping rule before the 80-step hard limit, owned paths, forbidden paths, and all other active slices.
+1. Read the `AGENTS.md` files for every directory and repository you will touch.
+2. Inspect the existing implementation and tests. Do not infer APIs or conventions from the task text alone.
+3. Restate the acceptance criteria. Flag ambiguity instead of making product or architecture decisions.
+4. For a new user-facing feature, restate its four states — happy, retryable unhappy, non-retryable unhappy, empty — each with trigger or classification, message intent, CTA label and outcome (or required absence), and planned coverage. If a state is underdefined, or missing without an orchestrator-accepted rationale that it is structurally impossible, stop and report.
+5. Restate your priority order, minimum complete outcome, optional work to drop, stopping rule before the 80-step hard limit, owned paths, forbidden paths, and the other active slices.
 
 While implementing:
 
 - Make the smallest complete change that satisfies the assigned task.
-- Add or update focused behavioral tests for every applicable feature state. Verify meaningful messages and CTA behavior: retryable and empty states have an actionable CTA; non-retryable states have no CTA at all.
-- Do not merge retryable and non-retryable failures into a generic error presentation.
-- Preserve unrelated working-tree changes and never revert work you did not create.
-- Edit only the paths assigned to this slice and do not reformat another active slice's changes. If unexpected changes appear inside owned paths, stop and report the collision. If they appear outside owned paths, continue while preserving them.
-- Defer checks that require another active slice's unstable output until the orchestrator's synchronization barrier.
-- Run narrow formatting, type, lint, and test checks appropriate to the files changed.
-- Keep changes in small, logically scoped, independently reviewable slices. Finish and report one slice before starting the next when the orchestrator assigns multiple slices.
-- Do not expand scope, dispatch subagents, commit, push, or create/update a pull request.
-- Do not claim the overall mobile task is complete. The orchestrator owns review, E2E, and final verification.
+- Add or update focused behavioral tests for every applicable feature state. Verify messages and CTAs: retryable and empty states have an actionable CTA; non-retryable states have no CTA at all.
+- Never merge retryable and non-retryable failures into one generic error presentation.
+- Preserve unrelated working-tree changes. Never revert work you did not create.
+- Edit only your slice's paths and do not reformat another slice's changes. Unexpected changes inside your paths: stop and report the collision. Outside your paths: continue and preserve them.
+- Defer checks that need another active slice's unstable output to the orchestrator's synchronization barrier.
+- Run narrow format, type, lint, and test checks for the files you changed.
+- Work in small, independently reviewable slices. Finish and report one slice before starting the next.
+- Never expand scope, dispatch subagents, commit, push, or create or update a PR.
+- Never claim the overall mobile task is complete. Review, E2E, and final verification belong to the orchestrator.
 
 Return:
 
 - Acceptance criteria addressed
 - Files changed and why
-- Checks run with exact outcomes
-- Feature-state matrix coverage, including triggers, message semantics, CTA assertions, and any accepted structurally impossible states
-- Suggested commit boundary and concise commit message for the completed slice
-- Remaining risks, ambiguity, or work not completed
-- Continuation state when stopping early: completed work, remaining work, failures, files touched, checks run or deferred, and safest next action
+- Checks run, with exact outcomes
+- Feature-state coverage: triggers, message semantics, CTA assertions, and any accepted structurally impossible states
+- Suggested commit boundary and a concise commit message for the completed slice
+- Remaining risks, ambiguity, or unfinished work
+- If stopping early: completed work, remaining work, failures, files touched, checks run or deferred, and the safest next action

--- a/apps/mobile/.kilo/agent/mobile-implementer.md
+++ b/apps/mobile/.kilo/agent/mobile-implementer.md
@@ -1,7 +1,8 @@
 ---
 description: Implements an approved mobile-app plan, including required changes in cloud services, shared packages, or sibling repositories
 mode: all
-model: kilo/kilo-auto/efficient
+model: kilo/x-ai/grok-4.5
+variant: high
 steps: 80
 permission:
   edit: allow

--- a/apps/mobile/.kilo/agent/mobile-plan-reviewer.md
+++ b/apps/mobile/.kilo/agent/mobile-plan-reviewer.md
@@ -14,26 +14,26 @@ permission:
     "true": allow
 ---
 
-You are an independent, read-only reviewer for a drafted mobile implementation plan. Review the plan and relevant repository evidence, but do not use shell commands, edit files, decide product requirements, or fix findings yourself.
+You are an independent, read-only reviewer for a drafted mobile implementation plan. Read the plan and the relevant repository files. Do not run shell commands, edit files, decide product requirements, or fix findings yourself.
 
-The 40-step limit is a hard ceiling. The handoff must provide the plan path, requirements, planning mode, repositories and dedicated worktrees in scope, priority order, minimum complete review, and a clean stopping rule before exhaustion.
+Your 40-step limit is a hard ceiling. The handoff gives you the plan path, requirements, planning mode, repositories and worktrees in scope, priority order, minimum complete review, and a stopping rule.
 
-Identify:
+Report:
 
 - Unclear requirements, unsupported assumptions or claims, and missing or conflicting acceptance criteria
 - Missing feature states, non-goals, dependencies, ownership boundaries, or cross-repository contracts
 - Infeasible or ambiguous sequencing, unsafe parallel work, and underspecified verification or E2E coverage
-- Steps that do not choose the simplest maintainable implementation or that introduce unnecessary scope or abstraction
-- Handoffs that omit information an implementer, reviewer, verifier, or orchestrator needs to act without guessing
+- Steps that are not the simplest maintainable implementation, or that add unneeded scope or abstraction
+- Handoffs missing information an implementer, reviewer, verifier, or orchestrator needs to act without guessing
 
-Inspect repository evidence for claims that materially affect feasibility or correctness. Do not invent requirements beyond the request, and do not assume that uncertainty is a defect when the plan records a reasonable evidence-backed decision.
+Check repository files for claims that materially affect feasibility or correctness. Do not invent requirements beyond the request. A recorded, evidence-backed decision is not a defect just because uncertainty remains.
 
-Return findings first, ordered by severity. Every finding must include:
+Output findings first, ordered by severity. Each finding contains:
 
 - Severity: critical, high, medium, or low
-- Plan section and relevant repository file or instruction reference
-- The unclear, unsupported, conflicting, or missing detail
+- Plan section and the relevant repository file or instruction
+- What is unclear, unsupported, conflicting, or missing
 - The concrete implementation, verification, or product decision that could fail
-- The required clarification or evidence, without prescribing unnecessary implementation details
+- The clarification or evidence required — do not prescribe unnecessary implementation detail
 
-If there are no actionable findings, return exactly `No findings.` followed by any residual risks. Do not praise or summarize the plan before findings. If you must stop early, return the reviewed scope, remaining scope, evidence inspected, and safest next action.
+If there are no actionable findings, return exactly `No findings.` followed by any residual risks. Do not praise or summarize the plan before findings. If you must stop early, return: reviewed scope, remaining scope, evidence inspected, and the safest next action.

--- a/apps/mobile/.kilo/agent/mobile-plan-reviewer.md
+++ b/apps/mobile/.kilo/agent/mobile-plan-reviewer.md
@@ -1,7 +1,8 @@
 ---
 description: Reviews a drafted mobile implementation plan for ambiguity, unsupported claims, and missing execution detail
 mode: all
-model: kilo/kilo-auto/efficient
+model: kilo/x-ai/grok-4.5
+variant: high
 steps: 40
 permission:
   edit: deny

--- a/apps/mobile/.kilo/agent/mobile-reviewer.md
+++ b/apps/mobile/.kilo/agent/mobile-reviewer.md
@@ -1,7 +1,8 @@
 ---
 description: Reviews an implementation produced for an approved mobile-app plan, including cross-repository changes
 mode: all
-model: kilo/kilo-auto/efficient
+model: kilo/x-ai/grok-4.5
+variant: high
 steps: 50
 permission:
   edit: deny

--- a/apps/mobile/.kilo/agent/mobile-reviewer.md
+++ b/apps/mobile/.kilo/agent/mobile-reviewer.md
@@ -26,31 +26,33 @@ permission:
     "pnpm exec oxfmt --list-different*": allow
 ---
 
-You are an independent, read-only reviewer for an approved mobile-app plan. Review every relevant change, including cloud backend, shared-package, and sibling-repository changes when present. Do not edit files or fix findings yourself.
+You are an independent, read-only reviewer of an implementation for an approved mobile-app plan. Review every relevant change, including cloud backend, shared-package, and sibling-repository changes. Do not edit files or fix findings yourself.
 
-The 50-step limit is a hard ceiling. The handoff must define a priority order, minimum complete outcome, optional work to drop, and clean stopping rule before exhaustion. Review one coherent wave diff rather than partial output from active implementers.
+Your 50-step limit is a hard ceiling. The handoff gives you the priority order, minimum complete outcome, optional work to drop, and a stopping rule. Review one coherent wave diff, not partial output from active implementers.
 
 Review against:
 
-- The orchestrator's accepted plan and acceptance criteria
+- The accepted plan and acceptance criteria
 - Every applicable `AGENTS.md`
 - Correctness, regressions, error paths, security, and maintainability
 - Test quality and missing automated coverage
 - Cross-repository contract consistency
-- For every new user-facing feature: happy, retryable unhappy, non-retryable unhappy, and empty behavior
-- Meaningful state-specific messages; actionable CTAs for retryable and empty states; no CTA at all for non-retryable states
-- Explicit trigger/classification, message intent, CTA outcome or absence, and automated/E2E coverage for every state
-- Explicit orchestrator-accepted rationale showing that any `not applicable` state is structurally impossible, not merely inconvenient or difficult to test
 
-Inspect the actual diff and surrounding code. Run narrow read-only checks when useful, but do not dispatch subagents, commit, push, or create/update a pull request. Do not invent requirements beyond the accepted plan.
+For every new user-facing feature, also check its four states — happy, retryable unhappy, non-retryable unhappy, empty:
 
-Return findings first, ordered by severity. Every finding must include:
+- State-specific meaningful messages; an actionable CTA for retryable and empty states; no CTA at all for non-retryable states
+- An explicit trigger or classification, message intent, CTA outcome or absence, and automated/E2E coverage for every state
+- Any `not applicable` state has an orchestrator-accepted rationale showing it is structurally impossible, not merely hard to test
+
+Inspect the actual diff and surrounding code. Run narrow read-only checks when useful. Do not dispatch subagents, commit, push, or create or update a PR. Do not invent requirements beyond the accepted plan.
+
+Output findings first, ordered by severity. Each finding contains:
 
 - Severity: critical, high, medium, or low
 - File and line reference
 - Concrete failure mode or violated requirement
-- Required outcome, without prescribing unnecessary implementation details
+- Required outcome — do not prescribe unnecessary implementation detail
 
-If there are no actionable findings, return exactly `No findings.` followed by any residual testing risks. Do not praise the implementation or provide a general summary before findings.
+If there are no actionable findings, return exactly `No findings.` followed by any residual testing risks. Do not praise the implementation or summarize before findings.
 
-If you must stop early, return continuation state containing completed review scope, remaining scope, failures, files inspected, checks run or deferred, and the safest next action.
+If you must stop early, return: completed review scope, remaining scope, failures, files inspected, checks run or deferred, and the safest next action.

--- a/apps/mobile/AGENTS.md
+++ b/apps/mobile/AGENTS.md
@@ -2,11 +2,10 @@
 
 ## Scope
 
-Expo Router app for iOS and Android only. Use dev builds, never Expo Go, and do not add web-specific code.
+Expo Router app for iOS and Android only. Use dev builds, never Expo Go. No web-specific code.
 
-For a fresh-worktree backend, simulator, login, Maestro, remote CLI, logs, and cleanup workflow, follow [e2e/AGENTS.md](e2e/AGENTS.md). Agents may start what they need there; do not ask the user to start Metro or backend services.
-
-For substantial mobile work, follow the orchestrated implement-review-E2E loop in [.kilo/MOBILE_WORKFLOW.md](.kilo/MOBILE_WORKFLOW.md). Its mobile role agents may change backend, shared-package, infrastructure, or sibling CLI code when the accepted plan requires it; mobile describes the product workflow, not a directory boundary.
+- Backend, simulator, login, Maestro, remote CLI, logs, cleanup: follow [e2e/AGENTS.md](e2e/AGENTS.md). Start what you need yourself; never ask the user to start Metro or backend services.
+- Substantial mobile work: follow [.kilo/MOBILE_WORKFLOW.md](.kilo/MOBILE_WORKFLOW.md). Plans may require edits to backend, shared packages, infrastructure, or sibling repositories; that is in scope.
 
 ## Stack
 
@@ -17,77 +16,69 @@ For substantial mobile work, follow the orchestrated implement-review-E2E loop i
 
 ## Commands
 
-Run from `apps/mobile/`:
+Run from `apps/mobile/`: `pnpm typecheck`, `pnpm lint`, `pnpm format` (or `format:check`), `pnpm check:unused`, `pnpm test`.
 
-```bash
-pnpm typecheck
-pnpm lint
-pnpm format
-pnpm format:check
-pnpm check:unused
-pnpm test
-```
-
-The repository dev runner owns Metro during E2E work. Do not also run `pnpm start`.
-
-## Dependencies
-
-Use `npx expo install <package>` (or `--dev`), never `pnpm add`. After dependency changes, run `pnpx expo-doctor` and fix every issue.
-
-`@kilocode/kilo-chat-hooks` is injected rather than symlinked. After editing it, refresh the copy and Metro cache:
-
-```bash
-pnpm install --filter kilo-app...
-rm -rf "$TMPDIR/metro-cache" "$TMPDIR"/metro-file-map-*
-```
-
-Then restart Metro and force-quit the app.
-
-## Implementation Rules
-
-- Prefer the smallest boring implementation. Reuse existing helpers, components, contracts, and native platform behavior.
-- Keep shared contracts at their owning boundary. Derive mobile types from shared exports or tRPC results rather than copying shapes.
-- Fetch backend data through tRPC. Parse genuinely untrusted HTTP input with Zod at entry; do not re-parse trusted tRPC/shared-package data in components.
-- Parse backend dates with `parseTimestamp()` from `@/lib/utils`; Hermes cannot reliably parse PostgreSQL timestamps with `new Date()`.
-- Every mutation hook must show `toast.error(error.message)` in `onError`. Put shared error handling in the hook, not each component.
-- Use optimistic updates for obvious reversible mutations: snapshot in `onMutate`, roll back in `onError`, reconcile in `onSettled`.
-- Keep route files thin. Extract screen logic to components or hooks.
-
-## React Native Rules
-
-- Default exports are allowed only where Expo Router requires them in `src/app/`.
-- Import React Native primitives from `react-native`; NativeWind adds `className` support.
-- Import `Image` from `@/components/ui/image` and other UI primitives from `@/components/ui/<component>`.
-- Add reusables with `pnpm dlx @react-native-reusables/cli@latest add <component> --styling-library nativewind -y`.
-- Style with Tailwind `className`, not inline styles or `StyleSheet.create`. Merge classes with `cn()` from `@/lib/utils`.
-- Theme colors are CSS variables. Opacity modifiers such as `bg-destructive/10` do not work on them; use a concrete Tailwind color with a dark variant. Non-variable colors such as `bg-black/5` are fine.
-- Use `Href` for dynamic Expo Router paths. Never silence route types with `as never`.
-- Use Lucide icons, not emoji. Set icon colors with `color={colors.<token>}` from `useThemeColors()`; native Lucide icons do not resolve `className` colors.
-
-### Text inputs
-
-- On iOS, do not control text with `value` plus state. Store text in a ref via `onChangeText`, use state only for derived UI, and read the ref on submit.
-- Use `defaultValue` only for initial content and set an explicit Tailwind line height.
-- Put input screens in a `ScrollView` with `automaticallyAdjustKeyboardInsets`.
-
-## UI and UX Invariants
-
-- Use `ScreenHeader` as the first child of a screen root and set stack `headerShown: false`.
-- Prefer native sheets, alerts, pickers, gestures, and keyboard behavior. Use `Alert.alert()` for destructive confirmation.
-- Every pressable needs lightweight feedback unless navigation or a native control already provides it.
-- Data screens must handle loading, empty, error, and happy states. Use `Skeleton` matching final dimensions, `EmptyState`, and pagination when results can grow.
-- Use `ActivityIndicator` only for inline waits. Smooth dynamic swaps with existing Reanimated `FadeIn`, `FadeOut`, and `LinearTransition` patterns where layout would otherwise jump.
-- Set `freezeOnBlur: true` on tabs. Use haptics for commits/outcomes, not passive interaction or duplicate feedback.
-- Set `transition={0}` on small/header `expo-image` images to avoid flicker.
-
-## Debugging
-
-For reproducible bugs, add narrow temporary logs at the real boundaries, reproduce, inspect the relevant tmux service logs, fix the demonstrated cause, and remove the logs. Do not guess or leave debug logging committed.
-
-## Before Pushing
+Before pushing:
 
 ```bash
 pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused
+git diff --check
 ```
 
-Run `git diff --check`. Fix lint rules in spirit; use autofix before hand edits and extract code instead of compressing it to evade line limits. Do not commit plans, specs, or other non-code Markdown files.
+- Fix lint rules in spirit: autofix first, then extract code. Never compress code to dodge line limits.
+- Do not commit plans, specs, or other non-code Markdown files.
+- The repository dev runner owns Metro. Never run `pnpm start`.
+
+## Dependencies
+
+- Install with `npx expo install <package>` (or `--dev`), never `pnpm add`.
+- After dependency changes, run `pnpx expo-doctor` and fix every issue.
+- `@kilocode/kilo-chat-hooks` is copied, not symlinked. After editing it:
+
+  ```bash
+  pnpm install --filter kilo-app...
+  rm -rf "$TMPDIR/metro-cache" "$TMPDIR"/metro-file-map-*
+  ```
+
+  Then restart Metro and force-quit the app.
+
+## Implementation Rules
+
+- Write the smallest boring implementation. Reuse existing helpers, components, and contracts.
+- Derive mobile types from shared exports or tRPC results. Do not copy shapes.
+- Fetch backend data through tRPC. Zod-parse only genuinely untrusted HTTP input at entry; do not re-parse trusted tRPC or shared-package data in components.
+- Parse backend dates with `parseTimestamp()` from `@/lib/utils`; `new Date()` breaks on PostgreSQL timestamps in Hermes.
+- Every mutation hook shows `toast.error(error.message)` in `onError`. Put shared error handling in the hook, not in each component.
+- Use optimistic updates for obvious reversible mutations: snapshot in `onMutate`, roll back in `onError`, reconcile in `onSettled`.
+- Keep route files thin. Put screen logic in components or hooks.
+
+## React Native Rules
+
+- Default exports only where Expo Router requires them, in `src/app/`.
+- Import React Native primitives from `react-native`; NativeWind adds `className`.
+- Import `Image` from `@/components/ui/image` and other UI primitives from `@/components/ui/<component>`.
+- Add reusables with `pnpm dlx @react-native-reusables/cli@latest add <component> --styling-library nativewind -y`.
+- Style with Tailwind `className`. No inline styles, no `StyleSheet.create`. Merge classes with `cn()` from `@/lib/utils`.
+- Opacity modifiers do not work on theme colors (CSS variables): `bg-destructive/10` fails. Use a concrete Tailwind color with a dark variant. Non-variable colors like `bg-black/5` are fine.
+- Type dynamic Expo Router paths as `Href`. Never silence route types with `as never`.
+- Use Lucide icons, never emoji. Color icons with `color={colors.<token>}` from `useThemeColors()`; `className` colors do not work on them.
+
+### Text inputs
+
+- iOS: never control text with `value` plus state. Store text in a ref via `onChangeText`, use state only for derived UI, read the ref on submit.
+- Use `defaultValue` only for initial content. Set an explicit Tailwind line height.
+- Put input screens in a `ScrollView` with `automaticallyAdjustKeyboardInsets`.
+
+## UI and UX Rules
+
+- `ScreenHeader` is the first child of the screen root; set stack `headerShown: false`.
+- Prefer native sheets, alerts, pickers, gestures, and keyboard behavior. Confirm destructive actions with `Alert.alert()`.
+- Every pressable gives lightweight feedback unless navigation or a native control already provides it.
+- Every data screen handles loading, empty, error, and happy states. Use `Skeleton` matching final dimensions, `EmptyState`, and pagination when results can grow.
+- Use `ActivityIndicator` only for inline waits. Where layout would jump, use the existing Reanimated `FadeIn`/`FadeOut`/`LinearTransition` patterns.
+- Set `freezeOnBlur: true` on tabs. Use haptics for commits and outcomes only, never passive interaction.
+- Set `transition={0}` on small or header `expo-image` images to avoid flicker.
+
+## Debugging
+
+Add narrow temporary logs at the real boundaries. Reproduce. Read the tmux service logs. Fix the demonstrated cause. Remove the logs. Do not guess, and do not commit debug logging.

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -34,6 +34,7 @@ Rules:
 
 - Do not export `KILO_PORT_OFFSET` or source `apps/mobile/.env`; stale shell values select the wrong bundle endpoints. Secondary worktrees get an isolated port offset automatically, and startup injects this worktree's LAN URLs before Metro starts.
 - The `dev:env` step creates the JWT Secrets Store binding. Without it, session-ingest looks healthy but rejects every session request.
+- Secrets Store state is local to each Worker directory. `dev:start` refreshes every source-backed secret for its service graph before launching Workers; a secret-creation failure is fatal, not something to retry past.
 - `event-service` is required for presence and notification behavior.
 - Never run bare `wrangler secrets-store` commands. Use `pnpm dev:env -y <group>` from the repository root so values come from the canonical local source.
 - Confirm `mobile`, `nextjs`, `cloudflare-session-ingest`, `cloud-agent-next`, `kiloclaw`, and `event-service` are `up`. Restarts are asynchronous: if `mobile` is still starting, read its log and rerun status instead of restarting the stack.

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -1,13 +1,13 @@
 # Mobile E2E Runbook
 
-Use this runbook for interactive verification against a local backend. Run commands from the repository root unless a step says otherwise. The repository dev runner keeps long-lived services in a worktree-specific tmux session; use it instead of loose background processes.
+Interactive verification against a local backend. Run commands from the repository root unless a step says otherwise. Long-lived services live in a worktree-specific tmux session owned by the repository dev runner; use it, never loose background processes.
 
 ## Fresh Worktree Quickstart
 
-If dependencies or local env files are missing, run this once. It authorizes both worktree `.envrc` files and copies local env files from the primary checkout:
+If dependencies or local env files are missing, run once (authorizes both worktree `.envrc` files and copies local env files from the primary checkout):
 
 ```bash
-node --version # must be v24; activate the root .nvmrc first if needed
+node --version   # must be v24; activate the root .nvmrc first if needed
 pnpm dev:worktree:prepare
 ```
 
@@ -19,11 +19,9 @@ tmux ls
 xcrun simctl list devices booted
 ```
 
-Reuse a complete stack already running for this worktree. Do not start a competing stack or stop an unrelated `kilo-dev-*` session.
+If a complete stack is already running for this worktree, reuse it. Never start a competing stack or stop an unrelated `kilo-dev-*` session.
 
-Port `23750` is the sole intentional host-wide exception: the repository-managed `kiloclaw-docker-tcp` service is a stateless loopback proxy to the shared Docker socket, and the runner reuses it when the port is occupied. Never kill a `socat` process owned by another worktree to free this port.
-
-When this worktree has no stack, start the complete mobile flow. Secondary worktrees automatically receive an isolated port offset, and mobile startup generates and injects this worktree's LAN URLs before Metro starts. Do not export `KILO_PORT_OFFSET` or source `apps/mobile/.env`; stale parent-shell values must not select the bundle endpoints:
+If this worktree has no stack, start the complete mobile flow:
 
 ```bash
 pnpm dev:env -y cloudflare-session-ingest
@@ -32,25 +30,24 @@ pnpm drizzle migrate
 pnpm dev:status --json
 ```
 
-Notes:
+Rules:
 
-- The `dev:env` step creates the JWT Secrets Store binding. Without it the session-ingest worker looks healthy while rejecting every session request.
+- Do not export `KILO_PORT_OFFSET` or source `apps/mobile/.env`; stale shell values select the wrong bundle endpoints. Secondary worktrees get an isolated port offset automatically, and startup injects this worktree's LAN URLs before Metro starts.
+- The `dev:env` step creates the JWT Secrets Store binding. Without it, session-ingest looks healthy but rejects every session request.
 - `event-service` is required for presence and notification behavior.
-- Secrets Store state is local to each Worker directory. `dev:start` syncs env for its service graph and refreshes every source-backed secret before launching Workers; a secret creation failure is fatal.
-- Never run bare `wrangler secrets-store` commands. Use `pnpm dev:env -y <group>` from the repository root so values come from the canonical local source and Wrangler gets a complete non-interactive prompt.
-- Confirm `mobile`, `nextjs`, `cloudflare-session-ingest`, `cloud-agent-next`, `kiloclaw`, and `event-service` are `up`. Restarts are asynchronous: if `mobile` is still starting, inspect its log and rerun status instead of restarting the stack.
-- Use the ports reported by `dev:status`; never assume defaults in a secondary worktree.
+- Never run bare `wrangler secrets-store` commands. Use `pnpm dev:env -y <group>` from the repository root so values come from the canonical local source.
+- Confirm `mobile`, `nextjs`, `cloudflare-session-ingest`, `cloud-agent-next`, `kiloclaw`, and `event-service` are `up`. Restarts are asynchronous: if `mobile` is still starting, read its log and rerun status instead of restarting the stack.
+- Use the ports reported by `dev:status`. Never assume defaults in a secondary worktree.
+- Port `23750` is the only host-wide exception: `kiloclaw-docker-tcp` is a stateless loopback proxy to the shared Docker socket, and the runner reuses it when the port is occupied. Never kill a `socat` process owned by another worktree.
 
 ### Host Networking Safety
 
 - Never map port `8081` or any other shared host port to a worktree Metro port.
-- Except for the `23750` proxy above, never create ad hoc proxies, redirects, tunnels, NAT rules, or listeners to repair stale Expo state.
-- If an exact development-client URL reconnect fails, perform at most one supported recovery through the existing preflight and launch flow. If the client still targets stale Metro state, return a test-environment failure with the Metro manifest, worktree root, expected URL, process evidence, and listener evidence. Do not route around bundle-provenance validation.
-- If an unexpected listener exists, report its PID, parent PID, command, bind address, and port. Stop it only when you can prove the current invocation created it; otherwise return the ownership evidence to the orchestrator.
+- Except for the `23750` proxy above, never create proxies, redirects, tunnels, NAT rules, or listeners to repair stale Expo state.
+- If reconnecting to the exact dev-client URL fails, perform at most one supported recovery through the existing preflight and launch flow. If the client still targets stale Metro state, return a test-environment failure with the Metro manifest, worktree root, expected URL, process evidence, and listener evidence. Do not route around bundle-provenance validation.
+- If an unexpected listener exists, report its PID, parent PID, command, bind address, and port. Stop it only when you can prove your invocation created it; otherwise return the ownership evidence to the orchestrator.
 
 ## Logs and tmux
-
-Prefer the stable log files, and let the runner locate a service pane wherever the dashboard moved it:
 
 ```bash
 pnpm dev:status --json
@@ -58,23 +55,23 @@ tail -n 200 dev/logs/<service>.log
 pnpm dev:capture mobile
 ```
 
-- Never guess a tmux window from `tmux ls` or address `<session>:<service>` directly; a service pane may be joined into the dashboard with no same-named window. Use `pnpm dev:capture <service>` for inspection.
+- Never guess a tmux window from `tmux ls` or address `<session>:<service>` directly; a service pane may be joined into the dashboard with no same-named window. Use `pnpm dev:capture <service>`.
 - Use raw tmux only for an interactive process, after reading the exact `session` from `pnpm dev:status --json` and resolving the pane with `tmux list-panes -a`.
 - Put any extra long-lived CLI, recorder, or log follower in a clearly named `kilo-e2e-*` tmux session so it is visible and easy to remove.
-- E2E fixtures must never be committed. Create generated fixtures in a temporary directory (`mktemp -d`), run the flow against it, and delete it before finishing.
+- Never commit E2E fixtures. Generate them in a temporary directory (`mktemp -d`) and delete it before finishing.
 
 ## iOS Simulator
 
-Never share a simulator with another worktree. Claim one before any build, install, login, Maestro, or MCP action; the claim command prefers an unclaimed shutdown iPhone and boots it. A prewarm verifier uses `--phase prewarm`; the fresh acceptance verifier reclaims the same worktree-owned device with `--phase verify`:
+Never share a simulator with another worktree. Claim one before any build, install, login, Maestro, or MCP action; the claim command prefers an unclaimed shutdown iPhone and boots it:
 
 ```bash
-pnpm dev:mobile:simulator claim [udid] --phase prewarm
-pnpm dev:mobile:simulator claim [udid] --phase verify
+pnpm dev:mobile:simulator claim [udid] --phase prewarm   # prewarm verifier
+pnpm dev:mobile:simulator claim [udid] --phase verify    # fresh acceptance verifier reclaims the same device
 ```
 
-The wrapper visibly renames a claimed device to `Kilo E2E - <sanitized-worktree-basename> - <phase>` and restores the original simulator name on release. Never call `xcrun simctl rename` directly.
+The wrapper renames the claimed device to `Kilo E2E - <sanitized-worktree-basename> - <phase>` and restores the original name on release. Never call `xcrun simctl rename` yourself.
 
-Install a validated cached native build. A compatible fingerprint skips rebuilding; a cache miss is serialized through the host-wide native compiler semaphore. Do not consume an arbitrary DerivedData app or run a separate Expo native build:
+Install a validated cached native build. A compatible fingerprint skips rebuilding; a cache miss serializes through the host-wide native compiler semaphore. Never install an arbitrary DerivedData app or run a separate Expo native build:
 
 ```bash
 pnpm dev:mobile:ios build <udid>
@@ -87,33 +84,32 @@ xcrun simctl openurl <udid> \
   "exp+kilo-app://expo-development-client/?url=http%3A%2F%2F<lan-ip>%3A<metro-port>"
 ```
 
-Prefer `xcrun simctl openurl` for scheme reconnection: it avoids Safari's external-app confirmation. When an acceptance flow intentionally goes through Safari or a WebView, inspect the hierarchy for the exact message `Open this page in "Kilo"?` and tap the exact `Open` accessibility action. This is one bounded optional prompt inside the existing five-second optional-prompt budget, not permission to add another fixed wait.
-
-Before testing, capture the `mobile` pane and verify `Starting project at <this-worktree>/apps/mobile` plus a fresh `iOS Bundled` line. Seeing the Kilo login screen does not prove bundle provenance. The login preflight additionally reads Metro's development manifest and checks `expoConfig.extra.apiBaseUrl` and `_internal.projectRoot` against this worktree. A dev client gets these extras from the Metro manifest, so after env changes: regenerate env, restart Metro, reconnect the dev client to the exact Metro URL, and reload. Rebuild only when native config or plugins changed.
-
-The shared launch flows dismiss the clean-install tracking alert, accept the Expo dev-menu introduction with `Continue`, and close the full Expo/React Native developer menu (the one containing Fast Refresh and Element Inspector) with its `Close` accessibility action.
+- Prefer `simctl openurl` for scheme reconnection; it skips Safari's external-app confirmation. When a flow intentionally goes through Safari or a WebView, look for the exact message `Open this page in "Kilo"?` and tap the exact `Open` accessibility action — one bounded optional prompt inside the existing five-second optional-prompt budget, never a new fixed wait.
+- Before testing, capture the `mobile` pane and verify `Starting project at <this-worktree>/apps/mobile` plus a fresh `iOS Bundled` line. Seeing the Kilo login screen does not prove the bundle came from this worktree.
+- The dev client reads `expoConfig.extra.apiBaseUrl` and `_internal.projectRoot` from Metro's manifest; the login preflight checks both against this worktree. After env changes: regenerate env, restart Metro, reconnect the dev client to the exact Metro URL, and reload. Rebuild only when native config or plugins changed.
+- The shared launch flows dismiss the clean-install tracking alert, accept the Expo dev-menu introduction with `Continue`, and close the full developer menu (Fast Refresh / Element Inspector) with its `Close` accessibility action.
 
 ## Sign In and Out
 
-Backend and Metro must be running. These idempotent wrappers verify simulator ownership, required services, the generated API port, and Metro project provenance, then reconnect the dev client to this worktree's exact Metro URL before Maestro runs. Never bypass their preflight or call the YAML login steps directly:
+Backend and Metro must be running. These idempotent wrappers verify simulator ownership, required services, the generated API port, and Metro project provenance, then reconnect the dev client to this worktree's exact Metro URL before Maestro runs. Never bypass their preflight or call the login YAML flows directly:
 
 ```bash
-apps/mobile/e2e/login.sh <udid> [email]  # default: e2e-mobile+<worktree-basename>@example.com
+apps/mobile/e2e/login.sh <udid> [email]   # default: e2e-mobile+<worktree-basename>@example.com
 apps/mobile/e2e/logout.sh <udid>
 ```
 
-The default email is unique per worktree (`e2e-mobile+<worktree-basename>@example.com`), so concurrent worktrees sign into distinct backend users and never cross-pollute each other's sessions. Pass an explicit email only when a test needs a specific account.
+The default email is unique per worktree, so concurrent worktrees sign into distinct backend users. Pass an explicit email only when a test needs a specific account.
 
-Login requests an email OTP, waits up to 30 seconds for the worktree-local outbox, verifies the code, accepts first-account consent, and asserts Home. It retries only the known dev-client launch/request boundary once. The wrappers open the exact dev-client URL via preflight, then `flows/settle-app.yaml` handles late tracking and Expo developer-menu prompts without restarting the app. `flows/open-app.yaml` is the standalone cold-launch flow.
+Login requests an email OTP, waits up to 30 seconds for the worktree-local outbox, verifies the code, accepts first-account consent, and asserts Home. It retries the known dev-client launch boundary once. `flows/settle-app.yaml` handles late tracking and Expo developer-menu prompts without restarting the app; `flows/open-app.yaml` is the standalone cold-launch flow.
 
 Native prompts are states in the flow, not errors to tap through blindly:
 
-- The shared launch flow answers the iOS tracking prompt (`Allow “Kilo” to track your activity across other companies’ apps and websites?`) with `Ask App Not to Track`.
+- The shared launch flow answers the iOS tracking prompt with `Ask App Not to Track`.
 - Login handles the notification permission after authentication.
-- Handle feature-triggered prompts (speech recognition, microphone) only when the acceptance flow reaches that feature: inspect the hierarchy, copy the exact button accessibility text (`Allow` or `Don’t Allow`), and choose the state the test requires.
+- Feature-triggered prompts (speech recognition, microphone): handle only when the flow reaches that feature. Inspect the hierarchy, copy the exact button accessibility text (`Allow` or `Don’t Allow`), and choose the state the test requires.
 - Never use a generic `tapOn: 'Allow'` before identifying which prompt is visible.
 
-Maestro can emit a large interactive transcript. For agent-driven runs, keep successful output out of context and show only a bounded failure tail:
+Maestro can emit a large interactive transcript. Keep successful output out of context; show only a bounded failure tail:
 
 ```bash
 LOGIN_LOG=$(mktemp /tmp/kilo-login.XXXXXX)
@@ -128,10 +124,9 @@ When editing the flows, preserve these device-tested constraints:
 - Target the email field by its placeholder `you@example.com`, and tap `Verify code` without trying to dismiss the number pad.
 - The native sign-out confirmation is the first case-insensitive `Sign Out` match (`index: 0`).
 
-Seed only when needed. Run `pnpm dev:seed` with no arguments to list every available topic and its usage:
+Seed only when needed. `pnpm dev:seed` with no arguments lists every topic and its usage:
 
 ```bash
-pnpm dev:seed                                    # list all seed topics
 pnpm dev:seed app:user-id <email>                # resolve a user id
 pnpm dev:seed app:create-user "<name>" <email>   # create a local user
 pnpm dev:seed app:add-credits <user-id> <usd>    # grant credits
@@ -142,12 +137,10 @@ pnpm dev:seed app:api-token <email>              # mint a bearer token (used by 
 
 One-time machine setup: `brew install maestro`. For MCP, use stdio command `maestro mcp`, then restart the agent session so its tools appear.
 
-Rules:
-
-- Use Maestro as the primary automation driver on both iOS and Android. Fall back to `xcrun simctl` (iOS) or repository-wrapped ADB (Android) only when Maestro cannot inspect or operate a native state, or when low-level device control is required. Setup still uses `simctl`/ADB for boot, install, dev-client URL reconnection, screenshots, shutdown, and cleanup.
-- Inspect the screen before selecting elements and re-inspect after UI changes.
-- Never guess a selector from a visible label or screenshot. Copy the exact `txt` or `a11y` value from `maestro_inspect_screen`, mapping `a11y` to Maestro `text:`. Maestro text matching is full-string regex, not substring matching.
-- Tab buttons expose React Navigation's full accessibility labels, not the visible uppercase text. Current iOS labels: `Home, tab, 1 of 4`, `KiloClaw, tab, 2 of 4`, `Agents, tab, 3 of 4`, `Profile, tab, 4 of 4`. `tapOn: 'Agents'` is wrong. Inspect again before relying on these examples; tab count and labels can change.
+- Maestro is the primary automation driver on both iOS and Android. Fall back to `xcrun simctl` (iOS) or repository-wrapped ADB (Android) only when Maestro cannot inspect or operate a native state, or when low-level device control is required. Setup still uses `simctl`/ADB for boot, install, dev-client URL reconnection, screenshots, shutdown, and cleanup.
+- Inspect the screen before selecting elements; re-inspect after UI changes.
+- Never guess a selector from a visible label or screenshot. Copy the exact `txt` or `a11y` value from `maestro_inspect_screen` (`a11y` maps to Maestro `text:`). Maestro text matching is full-string regex, not substring.
+- Tab buttons expose React Navigation's full accessibility labels, not the visible uppercase text. Current iOS labels: `Home, tab, 1 of 4`, `KiloClaw, tab, 2 of 4`, `Agents, tab, 3 of 4`, `Profile, tab, 4 of 4`. `tapOn: 'Agents'` is wrong. Inspect again before relying on these examples; the count and labels can change.
 
 CLI fallback:
 
@@ -157,11 +150,11 @@ xcrun simctl io <udid> screenshot <path>      # iOS
 adb exec-out screencap -p > <path>            # Android
 ```
 
-Attach a screenshot of the changed flow to the PR when it helps review. For transitions, prefer a short screenshot loop over `simctl io recordVideo`, which can produce one-frame recordings.
+Attach a screenshot of a changed flow to the PR when it helps review. For transitions, prefer a short screenshot loop over `simctl io recordVideo`, which can produce one-frame recordings.
 
 ## Remote CLI Session Flows
 
-Use this only when testing session discovery, mirroring, or mobile-to-CLI messaging. The orchestrator prepares the CLI with a single helper; role agents must not read environment files, mint or accept a bearer token, install the CLI, or run `wrangler` commands.
+Use this only when testing session discovery, mirroring, or mobile-to-CLI messaging. The orchestrator prepares the CLI; role agents never read environment files, mint or accept a bearer token, install the CLI, or run `wrangler` commands.
 
 The orchestrator starts a local CLI as a remote session for this worktree:
 
@@ -169,9 +162,9 @@ The orchestrator starts a local CLI as a remote session for this worktree:
 apps/mobile/e2e/remote-cli.sh start [email]
 ```
 
-The helper resolves this worktree's stack ports from `pnpm dev:status --json`, mints a token for the given user (defaulting to the per-worktree login account, `e2e-mobile+<worktree-slug>@example.com`), installs the CLI into a disposable per-worktree directory, and launches it in a `kilo-e2e-cli-<worktree-slug>` tmux session already pointed at the local API, session-ingest, and event-service. Pass the account the app is signed in as when it differs from the default. Manage it with `remote-cli.sh status` and `remote-cli.sh stop`.
+The helper resolves this worktree's stack ports, mints a token for the given user (default: the per-worktree login account, `e2e-mobile+<worktree-slug>@example.com`), installs the CLI into a disposable per-worktree directory, and launches it in a `kilo-e2e-cli-<worktree-slug>` tmux session already pointed at the local API, session-ingest, and event-service. Pass the account the app is signed in as when it differs from the default. Manage it with `remote-cli.sh status` and `remote-cli.sh stop`.
 
-Run any one-off CLI command against the same prepared stack (reusing the token and URLs) with `exec`, instead of the interactive TUI:
+Run any one-off CLI command against the same prepared stack with `exec` instead of the interactive TUI:
 
 ```bash
 apps/mobile/e2e/remote-cli.sh exec remote              # enable the real-time relay
@@ -183,7 +176,6 @@ Role agents reuse the orchestrator-prepared session and verify discovery and mir
 
 ```bash
 CLI_SESSION="kilo-e2e-cli-$(basename "$PWD")"
-tmux ls
 tmux capture-pane -p -t "$CLI_SESSION" -S -100
 ```
 
@@ -210,9 +202,9 @@ pnpm dev:mobile:android adb reverse tcp:<metro-port> tcp:<metro-port>
 pnpm dev:mobile:android build <serial>
 ```
 
-The build command installs a validated cached APK when the Android native fingerprint and toolchain match. Do not install an APK from another output path or invoke Gradle directly.
+The build command installs a validated cached APK when the Android native fingerprint and toolchain match. Never install an APK from another output path or invoke Gradle directly.
 
-ADB fallback commands (Maestro remains the primary driver, as above):
+ADB fallback commands (Maestro stays the primary driver):
 
 ```bash
 pnpm dev:mobile:android adb devices -l
@@ -227,21 +219,21 @@ pnpm dev:mobile:android adb -s <serial> shell input keyevent KEYCODE_BACK
 Android specifics:
 
 - Derive tap coordinates from the current `uiautomator` bounds, never from screenshots or remembered positions. Re-dump after every navigation or prompt.
-- Android's `localhost` is the emulator itself, so restore both `adb reverse` mappings after clearing app data.
+- Android's `localhost` is the emulator itself. Restore both `adb reverse` mappings after clearing app data.
 - The dev-client scheme is `exp+kilo-app`. `adb shell pm clear com.kilocode.kiloapp` also forgets the Metro URL; re-open the dev-client URL afterward with `adb shell am start`.
-- The login/logout helpers accept either an iOS simulator UDID or an Android ADB serial; their shared preflight applies platform-specific ownership checks and reconnects the dev client to this worktree.
+- `login.sh` and `logout.sh` accept an iOS simulator UDID or an Android ADB serial; their shared preflight applies platform-specific ownership checks and reconnects the dev client to this worktree.
 
 ## Cleanup
 
-Clean up only resources you started. The remote CLI session and its disposable install belong to the orchestrator; do not kill `kilo-e2e-cli-*` sessions or remove CLI scratch directories you did not create.
+Clean up only resources you started. The remote CLI session and its disposable install belong to the orchestrator; never kill `kilo-e2e-cli-*` sessions or remove CLI scratch directories you did not create.
 
 ```bash
 tmux kill-session -t "$ANDROID_SESSION"      # if created
 rm -f "$LOGIN_LOG"                           # if created
 pnpm dev:stop                                # only if you started this worktree's stack
 xcrun simctl shutdown <udid>                 # only if you booted it
-pnpm dev:mobile:simulator release <udid>     # release every simulator you claimed
-pnpm dev:mobile:android release <serial>     # release every Android device you claimed
+pnpm dev:mobile:simulator release <udid>     # every simulator you claimed
+pnpm dev:mobile:android release <serial>     # every Android device you claimed
 ```
 
 Also stop recorders, log followers, and emulator processes you created. Never use `tmux kill-server`, kill an unrelated `kilo-dev-*` session, shut down a simulator that was already booted, or use `pnpm dev:stop --force` while sibling worktrees are active.

--- a/dev/local/mobile-workflow.test.ts
+++ b/dev/local/mobile-workflow.test.ts
@@ -301,31 +301,3 @@ test('dev CLI shares only the Docker proxy port between worktrees', () => {
   assert.match(cli, /name === 'kiloclaw-docker-tcp'/);
   assert.match(cli, /Refusing to share occupied worktree service ports/);
 });
-
-test('remote CLI runbook is secret-free and defers credential-bearing setup to the orchestrator', () => {
-  const runbook = fs.readFileSync('apps/mobile/e2e/AGENTS.md', 'utf8');
-  const remoteCliSection = runbook.slice(
-    runbook.indexOf('## Remote CLI Session Flows'),
-    runbook.indexOf('## Android Emulator')
-  );
-
-  // The role-agent runbook must not contain bearer tokens, signing secrets,
-  // or credential-bearing environment variables.
-  assert.doesNotMatch(remoteCliSection, /KILO_E2E_AUTH_TOKEN/);
-  assert.doesNotMatch(remoteCliSection, /KILO_AUTH_CONTENT/);
-  assert.doesNotMatch(remoteCliSection, /NEXTAUTH_SECRET/);
-  assert.doesNotMatch(remoteCliSection, /\$\{KILO_[A-Z_]+/);
-
-  // The role-agent runbook must not install the CLI or set up the CLI session.
-  assert.doesNotMatch(remoteCliSection, /npm install.*@kilocode\/cli/);
-  assert.doesNotMatch(remoteCliSection, /CLI_SCRATCH=/);
-  assert.doesNotMatch(remoteCliSection, /tmux set-environment/);
-  assert.doesNotMatch(remoteCliSection, /wrangler secrets/);
-
-  // The role-agent runbook must clearly delegate credential-bearing setup
-  // to the orchestrator and describe how the role agent reuses the prepared
-  // session to verify mobile session discovery and mirroring.
-  assert.match(remoteCliSection, /orchestrator/i);
-  assert.match(remoteCliSection, /kilo-e2e-cli-/);
-  assert.match(remoteCliSection, /session discovery|mirroring/);
-});


### PR DESCRIPTION
## Summary
- Rewrite mobile workflow agent docs for weaker-model readability: imperative one-rule-per-bullet style, clearer ground rules (models table, role-agent dispatch, 3-step escalation, real device E2E).
- Update orchestrator/planner and role-agent model policy (kimi-k3 orchestrator/planner; grok-4.5 roles).
- Drop obsolete `.kilo` workflow unit tests per workflow policy.

## Test plan
- [ ] Skim `apps/mobile/AGENTS.md`, `apps/mobile/.kilo/MOBILE_WORKFLOW.md`, and role agent files for dropped load-bearing rules
- [ ] Confirm model table matches intended orchestrator/role policy