### PR TITLE
Revert "drop direct ingest pct to 0 to test"

### DIFF
--- a/services/session-ingest/wrangler.jsonc
+++ b/services/session-ingest/wrangler.jsonc
@@ -21,7 +21,7 @@
     "mode": "smart",
   },
   "vars": {
-    "DIRECT_INGEST_PERCENT": "0",
+    "DIRECT_INGEST_PERCENT": "100",
     "DIRECT_INGEST_USER_IDS": "f1a848ca-bade-48d8-a5ad-1042d08651e6",
     "DIRECT_INGEST_MAX_BYTES": "4194304",
   },


### PR DESCRIPTION
Reverts Kilo-Org/cloud#4685 and puts direct ingest back to 100%