### PR TITLE
fix(ai-gateway): handle interrupted usage responses

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.shared.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.shared.ts
@@ -86,7 +86,7 @@ export function extractVercelIsByok(
 
 /**
  * Drains a ReadableStream of binary chunks, calling `onTextChunk` for each
- * decoded piece of text. Handles client-abort (`ResponseAborted`) gracefully
+ * decoded piece of text. Handles client aborts and upstream timeouts gracefully
  * and always releases the reader lock and ends `streamProcessingSpan`.
  *
  * Returns `true` if the stream was aborted before completion.
@@ -106,7 +106,10 @@ export async function drainSseStream(
       onTextChunk(decoder.decode(value, { stream: true }));
     }
   } catch (error) {
-    if (error instanceof Error && error.name === 'ResponseAborted') {
+    if (
+      error instanceof Error &&
+      (error.name === 'ResponseAborted' || error.name === 'TimeoutError')
+    ) {
       wasAborted = true;
     } else {
       throw error;

--- a/apps/web/src/lib/ai-gateway/processUsage.shared.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.shared.ts
@@ -84,6 +84,11 @@ export function extractVercelIsByok(
   return null;
 }
 
+export function isResponseInterruptedError(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null || !('name' in error)) return false;
+  return error.name === 'ResponseAborted' || error.name === 'TimeoutError';
+}
+
 /**
  * Drains a ReadableStream of binary chunks, calling `onTextChunk` for each
  * decoded piece of text. Handles client aborts and upstream timeouts gracefully
@@ -106,10 +111,7 @@ export async function drainSseStream(
       onTextChunk(decoder.decode(value, { stream: true }));
     }
   } catch (error) {
-    if (
-      error instanceof Error &&
-      (error.name === 'ResponseAborted' || error.name === 'TimeoutError')
-    ) {
+    if (isResponseInterruptedError(error)) {
       wasAborted = true;
     } else {
       throw error;

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -230,10 +230,14 @@ describe('parseMicrodollarUsageFromStream approval tests', () => {
     );
 
     await expect(
-      countAndStoreUsage(response, {
-        api_kind: apiKind,
-        isStreaming: false,
-      } as MicrodollarUsageContext, undefined)
+      countAndStoreUsage(
+        response,
+        {
+          api_kind: apiKind,
+          isStreaming: false,
+        } as MicrodollarUsageContext,
+        undefined
+      )
     ).resolves.toBeNull();
   });
 

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -3,6 +3,7 @@ import type { MicrodollarUsageStats, MicrodollarUsageContext } from './processUs
 import {
   extractPromptInfo,
   extractUsageContextInfo,
+  countAndStoreUsage,
   parseMicrodollarUsageFromStream,
   parseMicrodollarUsageFromString,
   mapToUsageStats,
@@ -209,6 +210,32 @@ describe('parseMicrodollarUsageFromStream approval tests', () => {
       expect(result.hasError).toBe(true);
     }
   );
+
+  test.each([
+    ['chat_completions', 'ResponseAborted'],
+    ['chat_completions', 'TimeoutError'],
+    ['responses', 'ResponseAborted'],
+    ['responses', 'TimeoutError'],
+    ['messages', 'ResponseAborted'],
+    ['messages', 'TimeoutError'],
+  ] as const)('handles %s response.text() %s errors', async (apiKind, errorName) => {
+    const streamError = new Error('Response interrupted');
+    streamError.name = errorName;
+    const response = new Response(
+      new ReadableStream({
+        start(controller) {
+          controller.error(streamError);
+        },
+      })
+    );
+
+    await expect(
+      countAndStoreUsage(response, {
+        api_kind: apiKind,
+        isStreaming: false,
+      } as MicrodollarUsageContext, undefined)
+    ).resolves.toBeNull();
+  });
 
   test('captures numeric error.code from in-stream error event as status_code_override', async () => {
     const errorChunk = `data: {"id":"gen-1","object":"chat.completion.chunk","created":1,"model":"","provider":"Amazon Bedrock","choices":[],"error":{"code":502,"message":"Internal server error","metadata":{"error_type":"provider_unavailable"}}}\n\n`;

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -174,42 +174,41 @@ describe('parseMicrodollarUsageFromStream approval tests', () => {
     await verifyApproval(resultString, approvalFilePath);
   });
 
-  test('handles ResponseAborted error gracefully and returns partial data', async () => {
-    // Create a stream that emits some SSE data then throws ResponseAborted
-    const partialSSEData = `data: {"id":"gen-123","model":"anthropic/claude-3-5-sonnet","choices":[{"delta":{"content":"Hello"}}]}\n\ndata: {"id":"gen-123","model":"anthropic/claude-3-5-sonnet","choices":[{"delta":{"content":" world"}}]}\n\n`;
+  test.each(['ResponseAborted', 'TimeoutError'])(
+    'handles %s gracefully and returns partial data',
+    async errorName => {
+      // Create a stream that emits some SSE data then fails.
+      const partialSSEData = `data: {"id":"gen-123","model":"anthropic/claude-3-5-sonnet","choices":[{"delta":{"content":"Hello"}}]}\n\ndata: {"id":"gen-123","model":"anthropic/claude-3-5-sonnet","choices":[{"delta":{"content":" world"}}]}\n\n`;
 
-    // Create a custom error that mimics ResponseAborted
-    const responseAbortedError = new Error('Response aborted');
-    responseAbortedError.name = 'ResponseAborted';
+      const streamError = new Error('Response interrupted');
+      streamError.name = errorName;
 
-    let pullCount = 0;
-    // Create a readable stream that emits partial data then throws on second pull
-    const stream = new ReadableStream<Uint8Array>({
-      pull(controller) {
-        pullCount++;
-        if (pullCount === 1) {
-          controller.enqueue(new TextEncoder().encode(partialSSEData));
-        } else {
-          // Simulate abort on subsequent read
-          controller.error(responseAbortedError);
-        }
-      },
-    });
+      let pullCount = 0;
+      const stream = new ReadableStream<Uint8Array>({
+        pull(controller) {
+          pullCount++;
+          if (pullCount === 1) {
+            controller.enqueue(new TextEncoder().encode(partialSSEData));
+          } else {
+            controller.error(streamError);
+          }
+        },
+      });
 
-    const result = await parseMicrodollarUsageFromStream(
-      stream,
-      'fake-user-id',
-      undefined,
-      'openrouter',
-      200
-    );
+      const result = await parseMicrodollarUsageFromStream(
+        stream,
+        'fake-user-id',
+        undefined,
+        'openrouter',
+        200
+      );
 
-    // Should have captured partial data before abort
-    expect(result.messageId).toBe('gen-123');
-    expect(result.model).toBe('anthropic/claude-3-5-sonnet');
-    expect(result.responseContent).toBe('Hello world');
-    expect(result.hasError).toBe(true); // Should be marked as error due to abort
-  });
+      expect(result.messageId).toBe('gen-123');
+      expect(result.model).toBe('anthropic/claude-3-5-sonnet');
+      expect(result.responseContent).toBe('Hello world');
+      expect(result.hasError).toBe(true);
+    }
+  );
 
   test('captures numeric error.code from in-stream error event as status_code_override', async () => {
     const errorChunk = `data: {"id":"gen-1","object":"chat.completion.chunk","created":1,"model":"","provider":"Amazon Bedrock","choices":[],"error":{"code":502,"message":"Internal server error","metadata":{"error_type":"provider_unavailable"}}}\n\n`;

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -76,6 +76,7 @@ import {
   computeOpenRouterCostFields,
   drainSseStream,
   extractVercelIsByok,
+  isResponseInterruptedError,
 } from '@/lib/ai-gateway/processUsage.shared';
 import {
   calculateCost_mUsd,
@@ -928,6 +929,17 @@ export function countAndStoreUsage(
 ) {
   let usageStatsPromise: Promise<MicrodollarUsageStats | null> = Promise.resolve(null);
 
+  const parseResponseText = async (
+    parse: (content: string) => MicrodollarUsageStats
+  ): Promise<MicrodollarUsageStats | null> => {
+    try {
+      return parse(await clonedReponse.text());
+    } catch (error) {
+      if (isResponseInterruptedError(error)) return null;
+      throw error;
+    }
+  };
+
   if (clonedReponse.body) {
     if (usageContext.api_kind === 'responses') {
       usageStatsPromise = usageContext.isStreaming
@@ -938,11 +950,9 @@ export function countAndStoreUsage(
             usageContext.provider,
             clonedReponse.status
           )
-        : clonedReponse
-            .text()
-            .then(content =>
-              parseResponsesMicrodollarUsageFromString(content, clonedReponse.status)
-            );
+        : parseResponseText(content =>
+            parseResponsesMicrodollarUsageFromString(content, clonedReponse.status)
+          );
     }
     if (usageContext.api_kind === 'chat_completions') {
       usageStatsPromise = usageContext.isStreaming
@@ -953,15 +963,13 @@ export function countAndStoreUsage(
             usageContext.provider,
             clonedReponse.status
           )
-        : clonedReponse
-            .text()
-            .then(content =>
-              parseMicrodollarUsageFromString(
-                content,
-                usageContext.kiloUserId,
-                clonedReponse.status
-              )
-            );
+        : parseResponseText(content =>
+            parseMicrodollarUsageFromString(
+              content,
+              usageContext.kiloUserId,
+              clonedReponse.status
+            )
+          );
     }
     if (usageContext.api_kind === 'messages') {
       usageStatsPromise = usageContext.isStreaming
@@ -972,11 +980,9 @@ export function countAndStoreUsage(
             usageContext.provider,
             clonedReponse.status
           )
-        : clonedReponse
-            .text()
-            .then(content =>
-              parseMessagesMicrodollarUsageFromString(content, clonedReponse.status)
-            );
+        : parseResponseText(content =>
+            parseMessagesMicrodollarUsageFromString(content, clonedReponse.status)
+          );
     }
   }
 

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -964,11 +964,7 @@ export function countAndStoreUsage(
             clonedReponse.status
           )
         : parseResponseText(content =>
-            parseMicrodollarUsageFromString(
-              content,
-              usageContext.kiloUserId,
-              clonedReponse.status
-            )
+            parseMicrodollarUsageFromString(content, usageContext.kiloUserId, clonedReponse.status)
           );
     }
     if (usageContext.api_kind === 'messages') {


### PR DESCRIPTION
## Summary
- treat upstream TimeoutError like ResponseAborted while draining streamed usage
- prevent non-streaming response.text() interruptions from rejecting Next.js after() work
- cover both interruption types across chat completions, responses, and messages

## Testing
- not run locally per request; relying on GitHub CI