### PR TITLE
fix(ai-gateway): structure response read errors

### DIFF
--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -19,6 +19,25 @@ function sseResponse(body: string, status = 200): Response {
   });
 }
 
+function failingResponse(contentType: string, errorName: string, initialBody?: string): Response {
+  const encoder = new TextEncoder();
+  let pullCount = 0;
+  const body = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (pullCount++ === 0 && initialBody !== undefined) {
+        controller.enqueue(encoder.encode(initialBody));
+        return;
+      }
+
+      const error = new Error(errorName);
+      error.name = errorName;
+      controller.error(error);
+    },
+  });
+
+  return new Response(body, { headers: { 'content-type': contentType } });
+}
+
 async function readOutputStream(response: Response): Promise<string> {
   const reader = response.body?.getReader();
   if (!reader) return '';
@@ -52,6 +71,28 @@ function dataObjects(sse: string): unknown[] {
     .filter(payload => payload !== '[DONE]')
     .map(payload => JSON.parse(payload));
 }
+
+const rewriters = [
+  ['Chat Completions', rewriteModelResponse_ChatCompletions],
+  ['Messages', rewriteModelResponse_Messages],
+  ['Responses', rewriteModelResponse_Responses],
+] as const;
+
+describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
+  test.each([
+    ['ResponseAborted', 'upstream_disconnect', 'disconnected'],
+    ['TimeoutError', 'timeout', 'timed out'],
+  ])('returns structured JSON for %s', async (errorName, errorType, messageFragment) => {
+    const result = await rewrite(failingResponse('application/json', errorName));
+
+    expect(result.status).toBe(503);
+    expect(await result.json()).toEqual({
+      error: expect.stringContaining(messageFragment),
+      error_type: errorType,
+      message: expect.stringContaining(messageFragment),
+    });
+  });
+});
 
 describe('rewriteModelResponse_ChatCompletions', () => {
   describe('JSON responses', () => {
@@ -113,6 +154,25 @@ describe('rewriteModelResponse_ChatCompletions', () => {
   });
 
   describe('streaming responses', () => {
+    test.each([
+      ['ResponseAborted', 'upstream_disconnect'],
+      ['TimeoutError', 'timeout'],
+    ])('emits a structured SSE error for %s', async (errorName, errorType) => {
+      const upstream = failingResponse(
+        'text/event-stream',
+        errorName,
+        'data: {"model":"upstream-model","choices":[]}\n\n'
+      );
+
+      const result = await rewriteModelResponse_ChatCompletions(upstream);
+      const sse = await readOutputStream(result);
+      const events = dataObjects(sse) as Array<{ error?: { code: number; type: string } }>;
+
+      expect(events[0]).toMatchObject({ model: 'upstream-model' });
+      expect(events[1]?.error).toMatchObject({ code: 503, type: errorType });
+      expect(dataPayloads(sse)).not.toContain('[DONE]');
+    });
+
     test('drops null delta role and emits [DONE]', async () => {
       const upstream = sseResponse(
         'data: {"model":"upstream-model","choices":[{"delta":{"role":null,"content":"hi"}}]}\n\n' +
@@ -181,6 +241,28 @@ describe('rewriteModelResponse_ChatCompletions', () => {
 });
 
 describe('rewriteModelResponse_Messages', () => {
+  test.each([
+    ['ResponseAborted', 'upstream_disconnect'],
+    ['TimeoutError', 'timeout'],
+  ])('emits an Anthropic SSE error for %s', async (errorName, errorType) => {
+    const result = await rewriteModelResponse_Messages(
+      failingResponse('text/event-stream', errorName)
+    );
+    const sse = await readOutputStream(result);
+
+    expect(sse).toContain('event: error\n');
+    expect(dataObjects(sse)).toEqual([
+      {
+        type: 'error',
+        error: {
+          type: 'api_error',
+          message: expect.any(String),
+          error_type: errorType,
+        },
+      },
+    ]);
+  });
+
   test('strips cost fields for JSON responses', async () => {
     const upstream = jsonResponse({
       type: 'message',
@@ -260,6 +342,24 @@ describe('rewriteModelResponse_Messages', () => {
 });
 
 describe('rewriteModelResponse_Responses', () => {
+  test.each([
+    ['ResponseAborted', 'upstream_disconnect'],
+    ['TimeoutError', 'timeout'],
+  ])('emits an OpenAI Responses SSE error for %s', async (errorName, errorType) => {
+    const result = await rewriteModelResponse_Responses(
+      failingResponse('text/event-stream', errorName)
+    );
+    const sse = await readOutputStream(result);
+
+    expect(sse).toContain('event: error\n');
+    expect(dataObjects(sse)).toEqual([
+      {
+        type: 'error',
+        error: { code: errorType, message: expect.any(String) },
+      },
+    ]);
+  });
+
   test('strips cost fields for JSON responses', async () => {
     const upstream = jsonResponse({
       id: 'resp_1',

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -9,6 +9,94 @@ import { NextResponse } from 'next/server';
 import type OpenAI from 'openai';
 import type Anthropic from '@anthropic-ai/sdk';
 
+type ResponseReadError = {
+  errorType: 'timeout' | 'upstream_disconnect';
+  message: string;
+};
+
+function getResponseReadError(error: unknown): ResponseReadError | null {
+  if (typeof error !== 'object' || error === null || !('name' in error)) {
+    return null;
+  }
+
+  if (error.name === 'ResponseAborted') {
+    return {
+      errorType: 'upstream_disconnect',
+      message: 'The upstream provider disconnected while sending the response.',
+    };
+  }
+
+  if (error.name === 'TimeoutError') {
+    return {
+      errorType: 'timeout',
+      message: 'The upstream provider timed out while sending the response.',
+    };
+  }
+
+  return null;
+}
+
+async function readResponseText(
+  response: Response,
+  headers: Headers
+): Promise<{ text: string } | { errorResponse: NextResponse }> {
+  try {
+    return { text: await response.text() };
+  } catch (error) {
+    const responseReadError = getResponseReadError(error);
+    if (!responseReadError) {
+      throw error;
+    }
+
+    return {
+      errorResponse: NextResponse.json(
+        {
+          error: responseReadError.message,
+          error_type: responseReadError.errorType,
+          message: responseReadError.message,
+        },
+        { status: 503, headers }
+      ),
+    };
+  }
+}
+
+async function rewriteSseStream(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  parser: ReturnType<typeof createParser>,
+  controller: ReadableStreamDefaultController<string>,
+  doneReceived: () => boolean,
+  serializeError: (error: ResponseReadError) => string
+) {
+  const decoder = new TextDecoder();
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        // Flush any event left buffered when the stream ends without a
+        // trailing blank line, so its data isn't silently dropped.
+        parser.reset({ consume: true });
+        if (doneReceived()) {
+          controller.enqueue('data: [DONE]\n\n');
+        }
+        controller.close();
+        return;
+      }
+      parser.feed(decoder.decode(value, { stream: true }));
+    }
+  } catch (error) {
+    const responseReadError = getResponseReadError(error);
+    if (!responseReadError) {
+      throw error;
+    }
+
+    controller.enqueue(serializeError(responseReadError));
+    controller.close();
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 function rewriteUsage(usage: OpenRouterUsage) {
   // We only rewrite the response for free models, strip upstream cost
   delete usage.cost;
@@ -27,7 +115,11 @@ export async function rewriteModelResponse_ChatCompletions(response: Response) {
   if (headers.get('content-type')?.includes('application/json')) {
     // Read the body text once to avoid "Response body object should not be
     // disturbed or locked" errors that occur when `.clone().json()` fails.
-    const text = await response.text();
+    const textResult = await readResponseText(response, headers);
+    if ('errorResponse' in textResult) {
+      return textResult.errorResponse;
+    }
+    const { text } = textResult;
     let json: OpenAI.ChatCompletion;
     try {
       json = JSON.parse(text) as OpenAI.ChatCompletion;
@@ -93,21 +185,22 @@ export async function rewriteModelResponse_ChatCompletions(response: Response) {
         },
       });
 
-      const decoder = new TextDecoder();
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          // Flush any event left buffered when the stream ends without a
-          // trailing blank line, so its data isn't silently dropped.
-          parser.reset({ consume: true });
-          if (doneReceived) {
-            controller.enqueue('data: [DONE]\n\n');
-          }
-          controller.close();
-          break;
-        }
-        parser.feed(decoder.decode(value, { stream: true }));
-      }
+      await rewriteSseStream(
+        reader,
+        parser,
+        controller,
+        () => doneReceived,
+        responseReadError =>
+          'data: ' +
+          JSON.stringify({
+            error: {
+              code: 503,
+              message: responseReadError.message,
+              type: responseReadError.errorType,
+            },
+          }) +
+          '\n\n'
+      );
     },
   });
 
@@ -145,7 +238,11 @@ export async function rewriteModelResponse_Messages(response: Response) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
-    const text = await response.text();
+    const textResult = await readResponseText(response, headers);
+    if ('errorResponse' in textResult) {
+      return textResult.errorResponse;
+    }
+    const { text } = textResult;
     let json: Anthropic.Messages.Message & { usage?: MessagesApiUsage };
     try {
       json = JSON.parse(text) as Anthropic.Messages.Message & {
@@ -211,21 +308,24 @@ export async function rewriteModelResponse_Messages(response: Response) {
         },
       });
 
-      const decoder = new TextDecoder();
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          // Flush any event left buffered when the stream ends without a
-          // trailing blank line, so its data isn't silently dropped.
-          parser.reset({ consume: true });
-          if (doneReceived) {
-            controller.enqueue('data: [DONE]\n\n');
-          }
-          controller.close();
-          break;
-        }
-        parser.feed(decoder.decode(value, { stream: true }));
-      }
+      await rewriteSseStream(
+        reader,
+        parser,
+        controller,
+        () => doneReceived,
+        responseReadError =>
+          'event: error\n' +
+          'data: ' +
+          JSON.stringify({
+            type: 'error',
+            error: {
+              type: 'api_error',
+              message: responseReadError.message,
+              error_type: responseReadError.errorType,
+            },
+          }) +
+          '\n\n'
+      );
     },
   });
 
@@ -245,7 +345,11 @@ export async function rewriteModelResponse_Responses(response: Response) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
-    const text = await response.text();
+    const textResult = await readResponseText(response, headers);
+    if ('errorResponse' in textResult) {
+      return textResult.errorResponse;
+    }
+    const { text } = textResult;
     let json: OpenAI.Responses.Response & { usage?: OpenRouterUsage | null };
     try {
       json = JSON.parse(text) as OpenAI.Responses.Response & {
@@ -298,21 +402,23 @@ export async function rewriteModelResponse_Responses(response: Response) {
         },
       });
 
-      const decoder = new TextDecoder();
-      while (true) {
-        const { done, value } = await reader.read();
-        if (done) {
-          // Flush any event left buffered when the stream ends without a
-          // trailing blank line, so its data isn't silently dropped.
-          parser.reset({ consume: true });
-          if (doneReceived) {
-            controller.enqueue('data: [DONE]\n\n');
-          }
-          controller.close();
-          break;
-        }
-        parser.feed(decoder.decode(value, { stream: true }));
-      }
+      await rewriteSseStream(
+        reader,
+        parser,
+        controller,
+        () => doneReceived,
+        responseReadError =>
+          'event: error\n' +
+          'data: ' +
+          JSON.stringify({
+            type: 'error',
+            error: {
+              code: responseReadError.errorType,
+              message: responseReadError.message,
+            },
+          }) +
+          '\n\n'
+      );
     },
   });
 


### PR DESCRIPTION
## Summary
- guard JSON response body reads against `ResponseAborted` and `TimeoutError`
- convert streaming read failures into API-native structured SSE errors
- preserve unknown-error propagation and cover all supported response kinds

## Verification
- `pnpm --filter web exec jest src/lib/rewriteModelResponse.test.ts --runInBand --config=...` (25 tests passed using the normal environment setup without the database worker setup)
- `pnpm exec oxlint apps/web/src/lib/rewriteModelResponse.ts apps/web/src/lib/rewriteModelResponse.test.ts`
- `pnpm exec oxfmt --check apps/web/src/lib/rewriteModelResponse.ts apps/web/src/lib/rewriteModelResponse.test.ts`
- `git diff --check`