### PR TITLE
fix(mobile): PR review defect fixes — entry/gate, files list, rows, pending comments, discussion query

### DIFF
--- a/apps/mobile/src/components/pr-review/diff/pr-diff-file-list-loading.tsx
+++ b/apps/mobile/src/components/pr-review/diff/pr-diff-file-list-loading.tsx
@@ -1,0 +1,33 @@
+// First-page placeholder for the PR Files tab. Rendered outside FlashList so
+// the list mounts only once real file rows exist (cold first paint matches the
+// warm-cache shape that paints immediately).
+
+import { View } from 'react-native';
+
+import { Skeleton } from '@/components/ui/skeleton';
+
+const SKELETON_ROWS = [0, 1, 2, 3, 4, 5, 6, 7] as const;
+
+export function PrDiffFileListLoading() {
+  return (
+    <View
+      className="flex-1 gap-0 px-0 pt-1"
+      accessibilityLabel="Loading files"
+      accessibilityRole="progressbar"
+    >
+      {SKELETON_ROWS.map(index => (
+        <View
+          key={`file-list-skeleton-${index}`}
+          className="flex-row items-center gap-3 border-b border-hair-soft px-4 py-3"
+        >
+          <Skeleton className="h-5 w-5 rounded-md" />
+          <View className="flex-1 gap-1.5">
+            <Skeleton className="h-3.5 w-3/4 rounded-md" />
+            <Skeleton className="h-3 w-1/4 rounded-md" />
+          </View>
+          <Skeleton className="h-5 w-5 rounded-md" />
+        </View>
+      ))}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/pr-review/diff/pr-diff-file-list.tsx
+++ b/apps/mobile/src/components/pr-review/diff/pr-diff-file-list.tsx
@@ -32,8 +32,15 @@ import {
   LIST_CONTENT_STYLE,
   TabStateMessage,
 } from '@/components/pr-review/diff/pr-diff-rows';
+import { dedupeFilesByPath } from '@/lib/pr-review/diff/dedupe-file-pages';
 import { buildItems } from '@/lib/pr-review/diff/pr-diff-list-builder';
 import { fileHeaderKey, itemTypeFor, type ListItem } from '@/lib/pr-review/diff/pr-diff-list-items';
+import {
+  cancelPendingScroll,
+  decideOnItemsChange,
+  decideOnScrollRequest,
+  type PendingScrollState,
+} from '@/lib/pr-review/diff/pending-scroll-request';
 import { usePrDiffContextLoader } from '@/lib/pr-review/diff/use-pr-diff-context-loader';
 import {
   useFetchToCompletion,
@@ -106,7 +113,9 @@ export function PrReviewFileList({
         all.push(f);
       }
     }
-    return all;
+    // Dedupe by path (first wins) so retry/refetch races cannot emit
+    // duplicate `file-header:<path>` keys into FlashList.
+    return dedupeFilesByPath(all);
   }, [query.data]);
 
   const viewedCount = useMemo(() => {
@@ -174,20 +183,60 @@ export function PrReviewFileList({
   const indexByKeyRef = useRef(indexByKey);
   indexByKeyRef.current = indexByKey;
 
+  // AC4 / D7: first transition to files.length > 0 per mount → offset 0.
+  // Covers cold load and warm-cache remounts; never re-scrolls on page appends.
+  const didScrollToTopRef = useRef(false);
+  useEffect(() => {
+    if (didScrollToTopRef.current || files.length === 0) {
+      return;
+    }
+    didScrollToTopRef.current = true;
+    listRef.current?.scrollToOffset({ offset: 0, animated: false });
+  }, [files.length]);
+
+  // AC4b / D7: resilient navigator scroll — park when key is absent from
+  // indexByKey (items rebuild race), retry on next items change, supersede
+  // on a newer request, cancel on unmount.
+  const pendingScrollRef = useRef<PendingScrollState>(null);
+
+  const applyScrollDecision = (decision: ReturnType<typeof decideOnScrollRequest>) => {
+    pendingScrollRef.current = decision.pending;
+    if (decision.index === null) {
+      return;
+    }
+    void listRef.current?.scrollToIndex({
+      index: decision.index,
+      animated: true,
+      viewPosition: 0,
+    });
+  };
+
   useEffect(() => {
     const unsubscribe = subscribeFileNavigatorRequest(
       { owner, repo, number },
       (request: FileNavigatorRequest) => {
         const targetKey = fileHeaderKey(request.path);
-        const index = indexByKeyRef.current.get(targetKey);
-        if (typeof index === 'number' && index !== -1) {
-          setExpanded(prev => (prev[request.path] ? prev : { ...prev, [request.path]: true }));
-          void listRef.current?.scrollToIndex({ index, animated: true, viewPosition: 0 });
-        }
+        const decision = decideOnScrollRequest(
+          pendingScrollRef.current,
+          targetKey,
+          indexByKeyRef.current
+        );
+        // Expand as soon as we accept the request so the file is open once
+        // the list can scroll to it (including the deferred/pending path).
+        setExpanded(prev => (prev[request.path] ? prev : { ...prev, [request.path]: true }));
+        applyScrollDecision(decision);
       }
     );
-    return unsubscribe;
+    return () => {
+      unsubscribe();
+      pendingScrollRef.current = cancelPendingScroll();
+    };
   }, [owner, repo, number]);
+
+  useEffect(() => {
+    const decision = decideOnItemsChange(pendingScrollRef.current, indexByKey);
+    applyScrollDecision(decision);
+  }, [indexByKey]);
 
   const renderItem = useDiffRenderItem({
     viewed,

--- a/apps/mobile/src/components/pr-review/diff/pr-diff-file-list.tsx
+++ b/apps/mobile/src/components/pr-review/diff/pr-diff-file-list.tsx
@@ -33,6 +33,12 @@ import {
   TabStateMessage,
 } from '@/components/pr-review/diff/pr-diff-rows';
 import { dedupeFilesByPath } from '@/lib/pr-review/diff/dedupe-file-pages';
+import {
+  armInitialTopScroll,
+  INITIAL_TOP_SCROLL_IDLE,
+  type InitialTopScrollState,
+  onInitialTopScrollContentSize,
+} from '@/lib/pr-review/diff/initial-top-scroll';
 import { buildItems } from '@/lib/pr-review/diff/pr-diff-list-builder';
 import { fileHeaderKey, itemTypeFor, type ListItem } from '@/lib/pr-review/diff/pr-diff-list-items';
 import {
@@ -183,16 +189,21 @@ export function PrReviewFileList({
   const indexByKeyRef = useRef(indexByKey);
   indexByKeyRef.current = indexByKey;
 
-  // AC4 / D7: first transition to files.length > 0 per mount → offset 0.
-  // Covers cold load and warm-cache remounts; never re-scrolls on page appends.
-  const didScrollToTopRef = useRef(false);
-  useEffect(() => {
-    if (didScrollToTopRef.current || files.length === 0) {
-      return;
+  // AC4 / D7: one-shot scroll-to-top after first real content lays out.
+  // Arm synchronously on first files.length > 0 (cold + warm-cache remount);
+  // fire from onContentSizeChange only — never in useEffect, which races
+  // FlashList's first layout and blanks the window until the user scrolls.
+  // Page appends cannot re-arm once done.
+  const initialTopScrollRef = useRef<InitialTopScrollState>(INITIAL_TOP_SCROLL_IDLE);
+  initialTopScrollRef.current = armInitialTopScroll(initialTopScrollRef.current, files.length);
+
+  const handleContentSizeChange = (_width: number, height: number) => {
+    const result = onInitialTopScrollContentSize(initialTopScrollRef.current, height);
+    initialTopScrollRef.current = result.state;
+    if (result.shouldScroll) {
+      listRef.current?.scrollToOffset({ offset: 0, animated: false });
     }
-    didScrollToTopRef.current = true;
-    listRef.current?.scrollToOffset({ offset: 0, animated: false });
-  }, [files.length]);
+  };
 
   // AC4b / D7: resilient navigator scroll — park when key is absent from
   // indexByKey (items rebuild race), retry on next items change, supersede
@@ -312,6 +323,7 @@ export function PrReviewFileList({
         renderItem={renderItem}
         keyExtractor={item => item.key}
         getItemType={item => itemTypeFor(item)}
+        onContentSizeChange={handleContentSizeChange}
         onEndReached={() => {
           if (query.hasNextPage && !query.isFetchingNextPage) {
             void query.fetchNextPage();

--- a/apps/mobile/src/components/pr-review/diff/pr-diff-file-list.tsx
+++ b/apps/mobile/src/components/pr-review/diff/pr-diff-file-list.tsx
@@ -13,6 +13,14 @@
 //     `diff-selection-bridge` (so the comment composer can read it on
 //     mount) and a floating action bar (`PrDiffFloatingActions`)
 //     hosts the "Comment" and "Finish review" affordances.
+//
+// Cold first paint: FlashList mounts only after the first page of files is
+// present. The first-load waiting state is a plain skeleton outside the list
+// (see `PrDiffFileListLoading`). Mounting the list on a single pagination-row
+// loading item and then swapping in ~50 file rows left FlashList v2 with a
+// full content height but zero mounted cells until the user scrolled; warm
+// remounts already had data at mount and painted. Deferring the list mount
+// makes cold match warm.
 
 import { FlashList, type FlashListRef } from '@shopify/flash-list';
 import { useEffect, useMemo, useRef, useState } from 'react';
@@ -24,6 +32,7 @@ import {
   PrDiffFileListHeader,
   useDiffViewMode,
 } from '@/components/pr-review/diff/pr-diff-file-list-header';
+import { PrDiffFileListLoading } from '@/components/pr-review/diff/pr-diff-file-list-loading';
 import { PrDiffFloatingActions } from '@/components/pr-review/diff/pr-diff-floating-actions';
 import { useDiffRenderItem } from '@/components/pr-review/diff/pr-diff-file-list-render';
 import { useDiffSelection } from '@/components/pr-review/diff/use-diff-selection';
@@ -304,6 +313,10 @@ export function PrReviewFileList({
 
   const isTruncated = query.hasNextPage || Boolean(fetchToCompletion.error);
   const effectiveViewMode = isTablet ? viewMode : 'unified';
+  // First page still in flight: keep FlashList unmounted. A list that first
+  // lays out a single loading pagination-row and later receives the real file
+  // rows can measure full content height without mounting cells until scroll.
+  const showFirstPageLoading = files.length === 0;
 
   return (
     <View className="flex-1" accessibilityLabel="Files list">
@@ -317,22 +330,26 @@ export function PrReviewFileList({
         viewMode={effectiveViewMode}
         onViewModeChange={setViewMode}
       />
-      <FlashList
-        ref={listRef}
-        data={items}
-        renderItem={renderItem}
-        keyExtractor={item => item.key}
-        getItemType={item => itemTypeFor(item)}
-        onContentSizeChange={handleContentSizeChange}
-        onEndReached={() => {
-          if (query.hasNextPage && !query.isFetchingNextPage) {
-            void query.fetchNextPage();
-          }
-        }}
-        onEndReachedThreshold={0.5}
-        contentContainerStyle={LIST_CONTENT_STYLE}
-        ItemSeparatorComponent={null}
-      />
+      {showFirstPageLoading ? (
+        <PrDiffFileListLoading />
+      ) : (
+        <FlashList
+          ref={listRef}
+          data={items}
+          renderItem={renderItem}
+          keyExtractor={item => item.key}
+          getItemType={item => itemTypeFor(item)}
+          onContentSizeChange={handleContentSizeChange}
+          onEndReached={() => {
+            if (query.hasNextPage && !query.isFetchingNextPage) {
+              void query.fetchNextPage();
+            }
+          }}
+          onEndReachedThreshold={0.5}
+          contentContainerStyle={LIST_CONTENT_STYLE}
+          ItemSeparatorComponent={null}
+        />
+      )}
       <PrDiffFloatingActions
         owner={owner}
         repo={repo}

--- a/apps/mobile/src/components/pr-review/diff/pr-diff-file-rows.tsx
+++ b/apps/mobile/src/components/pr-review/diff/pr-diff-file-rows.tsx
@@ -1,14 +1,17 @@
 // File-level row components for the PR diff FlashList.
 
-import { ChevronDown, ChevronRight, File, Link2 } from 'lucide-react-native';
+import * as Haptics from 'expo-haptics';
+import { ChevronDown, ChevronRight, Eye, EyeOff, File, Link2 } from 'lucide-react-native';
 import { Pressable, View } from 'react-native';
 
 import { fileStatusIcon, fileStatusLabel } from '@/components/pr-review/diff/pr-diff-file-status';
-import { ChoiceRow } from '@/components/ui/choice-row';
 import { Text } from '@/components/ui/text';
 import { openExternalUrl } from '@/lib/external-link';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { type PrReviewFile } from '@/lib/pr-review/diff/pr-review-file-types';
+
+/** 36×36 visual box + 4pt hitSlop → ≥44×44 effective touch target (AC6). */
+const MARK_VIEWED_HIT_SLOP = 4;
 
 function ExpandChevron({ hasDiff, expanded }: { hasDiff: boolean; expanded: boolean }) {
   const colors = useThemeColors();
@@ -19,6 +22,38 @@ function ExpandChevron({ hasDiff, expanded }: { hasDiff: boolean; expanded: bool
     return <ChevronDown size={18} color={colors.mutedForeground} />;
   }
   return <ChevronRight size={18} color={colors.mutedForeground} />;
+}
+
+/** Fixed-size mark-viewed icon toggle — no path-text reflow on toggle (D9/AC6). */
+export function MarkViewedToggle({
+  path,
+  viewed,
+  onToggle,
+}: {
+  path: string;
+  viewed: boolean;
+  onToggle: () => void;
+}) {
+  const colors = useThemeColors();
+  return (
+    <Pressable
+      onPress={() => {
+        void Haptics.selectionAsync();
+        onToggle();
+      }}
+      hitSlop={MARK_VIEWED_HIT_SLOP}
+      accessibilityRole="checkbox"
+      accessibilityState={{ checked: viewed }}
+      accessibilityLabel={viewed ? `Unmark ${path} as viewed` : `Mark ${path} as viewed`}
+      className="h-9 w-9 items-center justify-center active:opacity-70"
+    >
+      {viewed ? (
+        <Eye size={18} color={colors.foreground} />
+      ) : (
+        <EyeOff size={18} color={colors.mutedForeground} />
+      )}
+    </Pressable>
+  );
 }
 
 export function TruncationBannerRow({ text }: { text: string }) {
@@ -54,38 +89,34 @@ export function FileHeaderRow({
       <View className="flex-row items-center gap-2">
         <Pressable
           onPress={hasDiff ? onToggleExpand : undefined}
-          hitSlop={8}
+          disabled={!hasDiff}
           accessibilityRole="button"
           accessibilityLabel={expanded ? 'Collapse file' : 'Expand file'}
-          accessibilityState={{ expanded }}
-          className="h-7 w-7 items-center justify-center"
+          accessibilityState={{ expanded, disabled: !hasDiff }}
+          className="min-h-9 flex-1 flex-row items-center gap-2 active:opacity-70"
         >
-          <ExpandChevron hasDiff={hasDiff} expanded={expanded} />
+          <View className="h-7 w-7 items-center justify-center">
+            <ExpandChevron hasDiff={hasDiff} expanded={expanded} />
+          </View>
+          <StatusIcon size={14} color={colors.mutedForeground} />
+          <View className="flex-1">
+            <Text className="font-mono-medium text-sm text-foreground" numberOfLines={2}>
+              {pathLine}
+            </Text>
+            <View className="mt-0.5 flex-row items-center gap-2">
+              <Text variant="muted" className="text-xs">
+                {fileStatusLabel(file.status)}
+              </Text>
+              <Text variant="muted" className="text-xs">
+                +{file.additions}
+              </Text>
+              <Text variant="muted" className="text-xs">
+                -{file.deletions}
+              </Text>
+            </View>
+          </View>
         </Pressable>
-        <StatusIcon size={14} color={colors.mutedForeground} />
-        <View className="flex-1">
-          <Text className="font-mono-medium text-sm text-foreground" numberOfLines={2}>
-            {pathLine}
-          </Text>
-          <View className="mt-0.5 flex-row items-center gap-2">
-            <Text variant="muted" className="text-xs">
-              {fileStatusLabel(file.status)}
-            </Text>
-            <Text variant="muted" className="text-xs">
-              +{file.additions}
-            </Text>
-            <Text variant="muted" className="text-xs">
-              -{file.deletions}
-            </Text>
-          </View>
-        </View>
-        <ChoiceRow multi selected={viewed} onPress={onToggleViewed} className="min-h-9 px-1">
-          <View className="flex-row items-center gap-1.5 pr-2">
-            <Text variant="muted" className="text-xs">
-              {viewed ? 'Viewed' : 'Mark viewed'}
-            </Text>
-          </View>
-        </ChoiceRow>
+        <MarkViewedToggle path={file.path} viewed={viewed} onToggle={onToggleViewed} />
       </View>
     </View>
   );
@@ -113,13 +144,7 @@ export function PatchMissingRow({
             {file.path}
           </Text>
         </View>
-        <ChoiceRow multi selected={viewed} onPress={onToggleViewed} className="min-h-9 px-1">
-          <View className="flex-row items-center gap-1.5 pr-2">
-            <Text variant="muted" className="text-xs">
-              {viewed ? 'Viewed' : 'Mark viewed'}
-            </Text>
-          </View>
-        </ChoiceRow>
+        <MarkViewedToggle path={file.path} viewed={viewed} onToggle={onToggleViewed} />
       </View>
       <Pressable
         onPress={() => {

--- a/apps/mobile/src/components/pr-review/diff/pr-diff-navigator-file-row.tsx
+++ b/apps/mobile/src/components/pr-review/diff/pr-diff-navigator-file-row.tsx
@@ -1,19 +1,15 @@
-// A single file row in the PR file navigator sheet. Tap to open the
-// file in the diff list (sends a `requestScrollToFile` request and
-// dismisses the sheet). A separate "Mark viewed" pressable toggles
-// the per-PR viewed set without dismissing.
-//
-// Owns no haptics — the row's tap is a navigation action, the viewed
-// toggle is a checkbox, and both flows already play the
-// system/keyboard sound the navigator sheet needs (the row tap goes
-// through the navigator which dismisses; the toggle is a deliberate
-// state change with a visible "Viewed" / "Mark viewed" label).
+// A single file row in the PR file navigator sheet. Tap the path/stats
+// cluster to open the file in the diff list (sends a
+// `requestScrollToFile` request and dismisses the sheet). A separate
+// trailing mark-viewed icon toggle flips the per-PR viewed set without
+// dismissing — non-nested sibling of the select pressable (AC6).
 
 import { Pressable, View } from 'react-native';
 
+import { MarkViewedToggle } from '@/components/pr-review/diff/pr-diff-file-rows';
 import { Text } from '@/components/ui/text';
-import { type PrReviewFile } from '@/lib/pr-review/diff/pr-review-file-types';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { type PrReviewFile } from '@/lib/pr-review/diff/pr-review-file-types';
 
 function splitPath(path: string): { dir: string; basename: string } {
   const slash = path.lastIndexOf('/');
@@ -37,12 +33,12 @@ export function NavigatorFileRow({
   const colors = useThemeColors();
   const { dir, basename } = splitPath(file.path);
   return (
-    <View className="border-b border-hair-soft bg-card">
+    <View className="flex-row items-center border-b border-hair-soft bg-card px-4 py-2.5">
       <Pressable
         onPress={onSelect}
         accessibilityRole="button"
         accessibilityLabel={`Open ${file.path}${viewed ? ' (viewed)' : ''}`}
-        className="min-h-11 flex-row items-center justify-between px-4 py-2.5 active:opacity-70"
+        className="min-h-11 flex-1 flex-row items-center active:opacity-70"
       >
         <View className="flex-1 pr-3">
           <View className="flex-row items-baseline">
@@ -76,22 +72,7 @@ export function NavigatorFileRow({
           </View>
         </View>
       </Pressable>
-      <View className="flex-row items-center justify-end px-4 pb-2">
-        <Pressable
-          onPress={onToggleViewed}
-          hitSlop={10}
-          accessibilityRole="checkbox"
-          accessibilityState={{ checked: viewed }}
-          accessibilityLabel={
-            viewed ? `Unmark ${file.path} as viewed` : `Mark ${file.path} as viewed`
-          }
-          className="rounded-md border border-border bg-card px-2 py-1 active:opacity-70"
-        >
-          <Text className="text-[11px] font-medium text-foreground">
-            {viewed ? 'Viewed' : 'Mark viewed'}
-          </Text>
-        </Pressable>
-      </View>
+      <MarkViewedToggle path={file.path} viewed={viewed} onToggle={onToggleViewed} />
     </View>
   );
 }

--- a/apps/mobile/src/components/pr-review/pr-review-comment-composer-parts.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-comment-composer-parts.tsx
@@ -1,0 +1,149 @@
+// Presentational pieces for the comment composer (body field, context
+// chrome, footer actions). Kept separate so the main composer stays
+// under the line cap.
+
+import { type ReactNode, type RefObject } from 'react';
+import { TextInput, View } from 'react-native';
+
+import { Button } from '@/components/ui/button';
+import { Text } from '@/components/ui/text';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { type DiffSelection } from '@/lib/pr-review/diff-selection-bridge';
+import { cn } from '@/lib/utils';
+
+const BODY_PLACEHOLDER = 'Leave a comment';
+
+export function CommentBodyField({
+  inputRef,
+  isDisabled,
+  defaultValue,
+  onChangeText,
+}: {
+  inputRef: RefObject<TextInput | null>;
+  isDisabled: boolean;
+  defaultValue: string;
+  onChangeText: (value: string) => void;
+}) {
+  const colors = useThemeColors();
+  return (
+    <TextInput
+      ref={inputRef}
+      defaultValue={defaultValue}
+      editable={!isDisabled}
+      placeholder={BODY_PLACEHOLDER}
+      placeholderTextColor={colors.mutedForeground}
+      accessibilityLabel="Comment body"
+      onChangeText={onChangeText}
+      multiline
+      textAlignVertical="top"
+      // Explicit line-height (no `text-center` per the repo's iOS rule).
+      className={cn(
+        'min-h-32 rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground',
+        'focus:border-ring'
+      )}
+    />
+  );
+}
+
+export function ComposerFooter({
+  isEdit,
+  isSubmitting,
+  primaryDisabled,
+  onSave,
+  onCommentNow,
+  onAddToReview,
+  onCancel,
+}: {
+  isEdit: boolean;
+  isSubmitting: boolean;
+  primaryDisabled: boolean;
+  onSave: () => void;
+  onCommentNow: () => void;
+  onAddToReview: () => void;
+  onCancel: () => void;
+}): ReactNode {
+  return (
+    <View className="border-t-[0.5px] border-hair-soft bg-background px-6 pb-6 pt-3">
+      {isEdit ? (
+        <Button onPress={onSave} disabled={primaryDisabled} accessibilityLabel="Save">
+          <Text>Save</Text>
+        </Button>
+      ) : (
+        <>
+          <Button
+            onPress={onCommentNow}
+            loading={isSubmitting}
+            disabled={primaryDisabled}
+            accessibilityLabel="Comment now"
+          >
+            <Text>Comment now</Text>
+          </Button>
+          <Button
+            variant="secondary"
+            onPress={onAddToReview}
+            disabled={isSubmitting}
+            className="mt-2"
+            accessibilityLabel="Add to review"
+          >
+            <Text>Add to review</Text>
+          </Button>
+        </>
+      )}
+      <Button
+        variant="ghost"
+        onPress={onCancel}
+        disabled={isSubmitting}
+        className="mt-2"
+        accessibilityLabel="Cancel"
+      >
+        <Text>Cancel</Text>
+      </Button>
+    </View>
+  );
+}
+
+export function ContextPreview({
+  selection,
+  fallbackPath,
+  fallbackLineLabel,
+  fallbackSide,
+  preferFallback,
+}: {
+  selection: DiffSelection | null;
+  fallbackPath: string;
+  fallbackLineLabel: string;
+  fallbackSide: 'LEFT' | 'RIGHT';
+  /** When true, never prefer the live bridge over route/item params. */
+  preferFallback: boolean;
+}) {
+  const path = preferFallback ? fallbackPath : (selection?.path ?? fallbackPath);
+  const side = preferFallback ? fallbackSide : (selection?.side ?? fallbackSide);
+  const lineLabel =
+    preferFallback || !selection
+      ? fallbackLineLabel
+      : composerRangeLabel(selection.line, selection.startLine);
+  const previewText = preferFallback ? '' : (selection?.selectedText ?? '');
+  return (
+    <View className="gap-2 rounded-lg border border-hair-soft bg-secondary p-3">
+      <Text className="font-mono-medium text-[11px] text-muted-foreground" numberOfLines={1}>
+        {path} {side} {lineLabel}
+      </Text>
+      {previewText.length > 0 ? (
+        <Text className="font-mono-medium text-[12px] leading-5 text-foreground" numberOfLines={6}>
+          {previewText}
+        </Text>
+      ) : (
+        <Text variant="muted" className="text-xs">
+          {preferFallback ? 'Editing a queued comment.' : 'Selected line context will appear here.'}
+        </Text>
+      )}
+    </View>
+  );
+}
+
+export function composerRangeLabel(line: number, startLine?: number): string {
+  if (startLine !== undefined && startLine !== line) {
+    return `L${startLine}–L${line}`;
+  }
+  return `L${line}`;
+}

--- a/apps/mobile/src/components/pr-review/pr-review-comment-composer-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-comment-composer-screen.tsx
@@ -1,7 +1,7 @@
 import { useQuery } from '@tanstack/react-query';
 import { useLocalSearchParams, useRouter } from 'expo-router';
-import { type ReactNode } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { type ReactNode, useEffect, useRef } from 'react';
+import { ActivityIndicator, Alert, View } from 'react-native';
 
 import { PrReviewCommentComposer } from '@/components/pr-review/pr-review-comment-composer';
 import { QueryError } from '@/components/query-error';
@@ -9,6 +9,7 @@ import { InvalidRouteState } from '@/components/invalid-route-state';
 import { ScreenHeader } from '@/components/screen-header';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { parseComposerParams } from '@/lib/pr-review/comment-composer-params';
+import { usePendingReview } from '@/lib/pr-review/pending-review-provider';
 import { useTRPC } from '@/lib/trpc';
 
 type Params = {
@@ -19,6 +20,7 @@ type Params = {
   side?: string;
   line: string;
   startLine?: string;
+  pendingId?: string;
 };
 
 export function PrReviewCommentComposerScreen() {
@@ -26,18 +28,61 @@ export function PrReviewCommentComposerScreen() {
   const colors = useThemeColors();
   const params = useLocalSearchParams<Params>();
   const parsed = parseComposerParams(params);
+  const pending = usePendingReview();
 
+  const pendingId = parsed?.pendingId;
+  const isEdit = pendingId !== undefined;
+  const pendingItem = isEdit ? pending.items.find(item => item.id === pendingId) : undefined;
+
+  // Edit mode is local-only: do not fire getPullRequest and do not gate on it.
   const trpc = useTRPC();
   const pr = useQuery(
     trpc.githubPrReview.getPullRequest.queryOptions(
       { owner: parsed?.owner ?? '', repo: parsed?.repo ?? '', number: parsed?.number ?? 0 },
-      { enabled: parsed !== null }
+      { enabled: parsed !== null && !isEdit }
     )
   );
+
+  // Missing pending item: alert above the formSheet and back out once.
+  const missingAlertedRef = useRef(false);
+  useEffect(() => {
+    if (!parsed || !isEdit || pendingItem || missingAlertedRef.current) {
+      return;
+    }
+    missingAlertedRef.current = true;
+    Alert.alert('Comment unavailable', 'This pending comment was already deleted or submitted.', [
+      {
+        text: 'OK',
+        onPress: () => {
+          router.back();
+        },
+      },
+    ]);
+  }, [parsed, isEdit, pendingItem, router]);
+
+  const dismiss = () => {
+    router.back();
+  };
 
   let content: ReactNode = null;
   if (!parsed) {
     content = <InvalidRouteState backTo="/(app)/pr-review" />;
+  } else if (isEdit) {
+    content = pendingItem ? (
+      <PrReviewCommentComposer
+        key={`edit:${pendingItem.id}`}
+        owner={parsed.owner}
+        repo={parsed.repo}
+        number={parsed.number}
+        mode={{ kind: 'edit', pendingItemId: pendingItem.id }}
+        path={parsed.path}
+        side={parsed.side}
+        line={parsed.line}
+        startLine={parsed.startLine}
+        initialBody={pendingItem.body}
+        onDismiss={dismiss}
+      />
+    ) : null;
   } else if (pr.isLoading) {
     content = (
       <View className="flex-1 items-center justify-center">
@@ -58,19 +103,19 @@ export function PrReviewCommentComposerScreen() {
       </View>
     );
   } else {
+    const createKey = [parsed.path, parsed.line, parsed.side, parsed.startLine ?? ''].join(':');
     content = (
       <PrReviewCommentComposer
+        key={`create:${createKey}`}
         owner={parsed.owner}
         repo={parsed.repo}
         number={parsed.number}
-        headSha={pr.data.headSha}
+        mode={{ kind: 'create', headSha: pr.data.headSha }}
         path={parsed.path}
         side={parsed.side}
         line={parsed.line}
         startLine={parsed.startLine}
-        onDismiss={() => {
-          router.back();
-        }}
+        onDismiss={dismiss}
       />
     );
   }
@@ -78,12 +123,10 @@ export function PrReviewCommentComposerScreen() {
   return (
     <View className="flex-1 bg-background">
       <ScreenHeader
-        title="Add comment"
+        title={isEdit ? 'Edit comment' : 'Add comment'}
         eyebrow={parsed ? `${parsed.owner}/${parsed.repo}#${parsed.number}` : ''}
         modal
-        onBack={() => {
-          router.back();
-        }}
+        onBack={dismiss}
       />
       {content}
     </View>

--- a/apps/mobile/src/components/pr-review/pr-review-comment-composer.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-comment-composer.tsx
@@ -1,103 +1,109 @@
-// S7a comment-composer content component. The orchestrator mounts this
-// inside the `comment-composer.tsx` route (S4b left a thin stub there);
-// the route supplies the route-params; this component owns the form
-// body, the suggestion affordance, and both submit paths.
-//
-// Two submit actions, both available at once:
-//   - "Add to review"   → enqueue into the `PendingReviewProvider`,
-//     keep the selection alive, dismiss. The user keeps editing more
-//     lines and submits the whole batch in the review-submit sheet.
-//   - "Comment now"     → POST a single comment immediately via
-//     `createReviewComment` and dismiss. No review state is created.
-//
-// Toasts paint behind formSheets on iOS, so the mutation hook toasts
-// `onError` AND the sheet renders an inline error box. A 422 (e.g.
-// stale line because the head moved) is a non-retryable inline message.
+// Comment-composer content. Two modes:
+//   - create: Comment now + Add to review + Insert suggestion (needs headSha).
+//   - edit: single Save updating a queued PendingReviewItem (local-only).
+// Toasts paint behind formSheets on iOS — mutation hook toasts onError AND
+// the sheet renders an inline error box.
 
 import * as Crypto from 'expo-crypto';
 import * as Haptics from 'expo-haptics';
-import { type RefObject, useEffect, useRef, useState } from 'react';
-import { Alert, ScrollView, TextInput, View } from 'react-native';
+import { useEffect, useRef, useState } from 'react';
+import { Alert, ScrollView, type TextInput, View } from 'react-native';
 
+import {
+  CommentBodyField,
+  ComposerFooter,
+  composerRangeLabel,
+  ContextPreview,
+} from '@/components/pr-review/pr-review-comment-composer-parts';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { PrReviewReconnectNotice } from '@/components/pr-review/pr-review-reconnect-notice';
 import { classifyPrReviewMutationError } from '@/lib/pr-review/classify-pr-review-query-state';
-import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { buildSuggestionFence } from '@/lib/pr-review/build-suggestion-fence';
-import { type DiffSelection, getDiffSelection } from '@/lib/pr-review/diff-selection-bridge';
+import { getDiffSelection } from '@/lib/pr-review/diff-selection-bridge';
+import { mutationErrorDisplay } from '@/lib/pr-review/mutation-error-display';
 import { usePendingReview } from '@/lib/pr-review/pending-review-provider';
 import { useCreateReviewCommentMutation } from '@/lib/pr-review/use-pr-review-mutations';
-import { cn } from '@/lib/utils';
+
+type CommentComposerMode =
+  | { kind: 'create'; headSha: string }
+  | { kind: 'edit'; pendingItemId: string };
 
 type PrReviewCommentComposerProps = Readonly<{
   owner: string;
   repo: string;
   number: number;
-  /** Current PR head SHA — pinned into both the queued and immediate comment. */
-  headSha: string;
+  mode: CommentComposerMode;
   path: string;
   side: 'LEFT' | 'RIGHT';
   line: number;
   startLine?: number;
-  /** Invoked after the user submits (either path) or cancels. */
+  /** Seeded body (edit) / empty (create). Also the dirty-check baseline. */
+  initialBody?: string;
   onDismiss: () => void;
 }>;
 
-const BODY_PLACEHOLDER = 'Leave a comment';
-
 export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
-  const { owner, repo, number, headSha, path, side, line, startLine, onDismiss } = props;
+  const {
+    owner,
+    repo,
+    number,
+    mode,
+    path,
+    side,
+    line,
+    startLine,
+    initialBody = '',
+    onDismiss,
+  } = props;
   const pending = usePendingReview();
   const createComment = useCreateReviewCommentMutation({ owner, repo, number });
+  const isEdit = mode.kind === 'edit';
 
-  // Read the bridge on mount to render the selected-line context. We
-  // re-read on every render because the diff may have updated the
-  // selection while the user was navigating here.
-  const selection = getDiffSelection({ owner, repo, number });
+  // Edit mode ignores the bridge so editing A never shows B's path/lines.
+  const selection = isEdit ? null : getDiffSelection({ owner, repo, number });
 
-  // iOS uncontrolled pattern: text lives in a ref, the input's visible
-  // value is set via defaultValue once + setNativeProps for the
-  // suggestion insert. No `value` + state (iOS bug).
-  const bodyRef = useRef<string>('');
+  // iOS uncontrolled: ref + defaultValue; no value+state.
+  const bodyRef = useRef<string>(initialBody);
+  const bodyBaselineRef = useRef<string>(initialBody);
   const bodyInputRef = useRef<TextInput | null>(null);
+  const [hasBody, setHasBody] = useState(() => initialBody.trim().length > 0);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [inlineErrorKind, setInlineErrorKind] = useState<
     'retryable' | 'bad-request' | 'forbidden' | 'reconnect' | null
   >(null);
 
-  const isSubmitting = createComment.isPending;
-  const lineRangeLabel = rangeLabel(line, startLine);
+  const isSubmitting = !isEdit && createComment.isPending;
+  const lineRangeLabel = composerRangeLabel(line, startLine);
 
-  // When the mutation errors, classify it and mirror a short message into
-  // the inline error box. The hook toasts the same message; this box is
-  // the one the user actually sees in the formSheet.
   useEffect(() => {
-    if (createComment.error) {
-      const classification = classifyPrReviewMutationError(createComment.error);
-      if (classification.kind === 'bad-request') {
-        setInlineError(
-          "This comment can't be posted. The selected line may have changed, or the PR may have been updated."
-        );
-        setInlineErrorKind('bad-request');
-      } else if (classification.kind === 'forbidden') {
-        setInlineError("You don't have permission to post a comment on this pull request.");
-        setInlineErrorKind('forbidden');
-      } else if (classification.kind === 'reconnect') {
-        setInlineError('GitHub connection expired.');
-        setInlineErrorKind('reconnect');
-      } else {
-        const message =
-          createComment.error instanceof Error
-            ? createComment.error.message
-            : 'Could not post comment.';
-        setInlineError(message);
-        setInlineErrorKind('retryable');
-      }
+    if (isEdit || !createComment.error) {
+      return;
     }
-  }, [createComment.error]);
+    const classification = classifyPrReviewMutationError(createComment.error);
+    const display = mutationErrorDisplay('composer', classification, createComment.error);
+    setInlineError(display.message);
+    setInlineErrorKind(display.kind);
+  }, [createComment.error, isEdit]);
+
+  function clearBadRequestOnBodyEdit() {
+    // bad-request clears on body change; forbidden stays for the session.
+    if (inlineErrorKind === 'bad-request') {
+      setInlineError(null);
+      setInlineErrorKind(null);
+    }
+  }
+
+  function handleBodyChange(value: string) {
+    bodyRef.current = value;
+    setHasBody(value.trim().length > 0);
+    clearBadRequestOnBodyEdit();
+  }
 
   function handleAddToReview() {
+    if (mode.kind !== 'create') {
+      return;
+    }
     const body = bodyRef.current;
     if (body.trim().length === 0) {
       setInlineError('Comment body cannot be empty.');
@@ -112,13 +118,16 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
       line,
       ...(startLine !== undefined ? { startLine } : {}),
       body,
-      commitSha: headSha,
+      commitSha: mode.headSha,
     });
     void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     onDismiss();
   }
 
   async function handleCommentNow() {
+    if (mode.kind !== 'create') {
+      return;
+    }
     const body = bodyRef.current;
     if (body.trim().length === 0) {
       setInlineError('Comment body cannot be empty.');
@@ -136,26 +145,37 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
         path,
         line,
         side,
-        // The S3 Zod refine rejects a partial range: startLine and
-        // startSide must come together. We pass startSide = side so
-        // the body lands on the same side the user is looking at.
         ...(startLine !== undefined ? { startLine, startSide: side } : {}),
-        commitSha: headSha,
+        commitSha: mode.headSha,
       });
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       onDismiss();
     } catch {
-      // The mutation's error is already classified into inlineError by
-      // the effect above; swallow here so it doesn't become an unhandled
-      // promise rejection.
+      // Classified into inlineError by the effect above.
     }
+  }
+
+  function handleSave() {
+    if (mode.kind !== 'edit') {
+      return;
+    }
+    const trimmed = bodyRef.current.trim();
+    if (trimmed.length === 0) {
+      return;
+    }
+    pending.updateComment(mode.pendingItemId, trimmed);
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    onDismiss();
   }
 
   function handleCancel() {
     if (isSubmitting) {
       return;
     }
-    if (bodyRef.current.trim().length > 0) {
+    const dirty = isEdit
+      ? bodyRef.current !== bodyBaselineRef.current
+      : bodyRef.current.trim().length > 0;
+    if (dirty) {
       Alert.alert('Discard comment?', 'Your draft will be lost.', [
         { text: 'Keep editing', style: 'cancel' },
         { text: 'Discard', style: 'destructive', onPress: onDismiss },
@@ -166,15 +186,16 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
   }
 
   function handleInsertSuggestion() {
-    if (side === 'LEFT') {
+    if (isEdit || side === 'LEFT') {
       return;
     }
-    const selectedText = selection?.selectedText ?? '';
-    const block = buildSuggestionFence(selectedText);
+    const block = buildSuggestionFence(selection?.selectedText ?? '');
     if (block === null) {
       return;
     }
     bodyRef.current = block;
+    setHasBody(block.trim().length > 0);
+    clearBadRequestOnBodyEdit();
     bodyInputRef.current?.setNativeProps({
       text: block,
       selection: { start: block.length, end: block.length },
@@ -182,13 +203,22 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
     bodyInputRef.current?.focus();
   }
 
-  const suggestionAvailable = side === 'RIGHT' && Boolean(selection?.selectedText);
+  const suggestionAvailable = !isEdit && side === 'RIGHT' && Boolean(selection?.selectedText);
   let suggestionDisabledReason: string | null = null;
-  if (side === 'LEFT') {
-    suggestionDisabledReason = 'Suggestions only apply to added lines.';
-  } else if (!selection?.selectedText) {
-    suggestionDisabledReason = 'Tap a diff line to enable suggestions.';
+  if (!isEdit) {
+    if (side === 'LEFT') {
+      suggestionDisabledReason = 'Suggestions only apply to added lines.';
+    } else if (!selection?.selectedText) {
+      suggestionDisabledReason = 'Tap a diff line to enable suggestions.';
+    }
   }
+
+  const primaryDisabled =
+    isSubmitting ||
+    inlineErrorKind === 'forbidden' ||
+    inlineErrorKind === 'reconnect' ||
+    (!isEdit && inlineErrorKind === 'bad-request') ||
+    (isEdit && !hasBody);
 
   return (
     <View className="flex-1 bg-background">
@@ -204,21 +234,29 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
           fallbackPath={path}
           fallbackLineLabel={lineRangeLabel}
           fallbackSide={side}
+          preferFallback={isEdit}
         />
         <View className="gap-2">
           <Text className="text-sm font-medium text-foreground">Comment</Text>
-          <CommentBodyField bodyRef={bodyRef} inputRef={bodyInputRef} isDisabled={isSubmitting} />
-          <Button
-            variant="ghost"
-            size="sm"
-            onPress={handleInsertSuggestion}
-            disabled={!suggestionAvailable}
-            accessibilityLabel="Insert a code suggestion"
-            accessibilityHint={suggestionDisabledReason ?? undefined}
-            className="self-start"
-          >
-            <Text>Insert suggestion</Text>
-          </Button>
+          <CommentBodyField
+            inputRef={bodyInputRef}
+            isDisabled={isSubmitting}
+            defaultValue={initialBody}
+            onChangeText={handleBodyChange}
+          />
+          {!isEdit ? (
+            <Button
+              variant="ghost"
+              size="sm"
+              onPress={handleInsertSuggestion}
+              disabled={!suggestionAvailable}
+              accessibilityLabel="Insert a code suggestion"
+              accessibilityHint={suggestionDisabledReason ?? undefined}
+              className="self-start"
+            >
+              <Text>Insert suggestion</Text>
+            </Button>
+          ) : null}
         </View>
         {inlineError && inlineErrorKind !== 'reconnect' ? (
           <View
@@ -231,115 +269,17 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
         {inlineErrorKind === 'reconnect' ? <PrReviewReconnectNotice /> : null}
       </ScrollView>
 
-      <View className="border-t-[0.5px] border-hair-soft bg-background px-6 pb-6 pt-3">
-        <Button
-          onPress={() => {
-            void handleCommentNow();
-          }}
-          loading={isSubmitting}
-          disabled={
-            isSubmitting ||
-            inlineErrorKind === 'bad-request' ||
-            inlineErrorKind === 'forbidden' ||
-            inlineErrorKind === 'reconnect'
-          }
-          accessibilityLabel="Comment now"
-        >
-          <Text>Comment now</Text>
-        </Button>
-        <Button
-          variant="secondary"
-          onPress={handleAddToReview}
-          disabled={isSubmitting}
-          className="mt-2"
-          accessibilityLabel="Add to review"
-        >
-          <Text>Add to review</Text>
-        </Button>
-        <Button
-          variant="ghost"
-          onPress={handleCancel}
-          disabled={isSubmitting}
-          className="mt-2"
-          accessibilityLabel="Cancel"
-        >
-          <Text>Cancel</Text>
-        </Button>
-      </View>
+      <ComposerFooter
+        isEdit={isEdit}
+        isSubmitting={isSubmitting}
+        primaryDisabled={primaryDisabled}
+        onSave={handleSave}
+        onCommentNow={() => {
+          void handleCommentNow();
+        }}
+        onAddToReview={handleAddToReview}
+        onCancel={handleCancel}
+      />
     </View>
   );
-}
-
-function CommentBodyField({
-  bodyRef,
-  inputRef,
-  isDisabled,
-}: {
-  bodyRef: RefObject<string>;
-  inputRef: RefObject<TextInput | null>;
-  isDisabled: boolean;
-}) {
-  const colors = useThemeColors();
-  return (
-    <TextInput
-      ref={inputRef}
-      defaultValue=""
-      editable={!isDisabled}
-      placeholder={BODY_PLACEHOLDER}
-      placeholderTextColor={colors.mutedForeground}
-      accessibilityLabel="Comment body"
-      onChangeText={value => {
-        bodyRef.current = value;
-      }}
-      multiline
-      textAlignVertical="top"
-      // Explicit line-height (no `text-center` per the repo's iOS rule).
-      // `leading-5` = line-height 20, font-size 14, matching the merge
-      // sheet's commit message field.
-      className={cn(
-        'min-h-32 rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground',
-        'focus:border-ring'
-      )}
-    />
-  );
-}
-
-function ContextPreview({
-  selection,
-  fallbackPath,
-  fallbackLineLabel,
-  fallbackSide,
-}: {
-  selection: DiffSelection | null;
-  fallbackPath: string;
-  fallbackLineLabel: string;
-  fallbackSide: 'LEFT' | 'RIGHT';
-}) {
-  const path = selection?.path ?? fallbackPath;
-  const side = selection?.side ?? fallbackSide;
-  const lineLabel = selection ? rangeLabel(selection.line, selection.startLine) : fallbackLineLabel;
-  const previewText = selection?.selectedText ?? '';
-  return (
-    <View className="gap-2 rounded-lg border border-hair-soft bg-secondary p-3">
-      <Text className="font-mono-medium text-[11px] text-muted-foreground" numberOfLines={1}>
-        {path} {side} {lineLabel}
-      </Text>
-      {previewText.length > 0 ? (
-        <Text className="font-mono-medium text-[12px] leading-5 text-foreground" numberOfLines={6}>
-          {previewText}
-        </Text>
-      ) : (
-        <Text variant="muted" className="text-xs">
-          Selected line context will appear here.
-        </Text>
-      )}
-    </View>
-  );
-}
-
-function rangeLabel(line: number, startLine?: number): string {
-  if (startLine !== undefined && startLine !== line) {
-    return `L${startLine}–L${line}`;
-  }
-  return `L${line}`;
 }

--- a/apps/mobile/src/components/pr-review/pr-review-connect-gate.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-connect-gate.tsx
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { PlugZap, RefreshCcw, ShieldAlert } from 'lucide-react-native';
 import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, AppState, type AppStateStatus, Platform, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { toast } from 'sonner-native';
 
 import { EmptyState } from '@/components/empty-state';
@@ -41,6 +42,7 @@ export function PrReviewConnectGate({ children }: PrReviewConnectGateProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const colors = useThemeColors();
+  const insets = useSafeAreaInsets();
   const authorization = useQuery(trpc.githubApps.getUserAuthorization.queryOptions());
   const connect = useMutation(
     trpc.githubApps.connectUserAuthorization.mutationOptions({
@@ -147,34 +149,46 @@ export function PrReviewConnectGate({ children }: PrReviewConnectGateProps) {
 
   if (view === 'connect' || view === 'reconnect') {
     const revoked = view === 'reconnect';
+    // Geometry (R1 on iPhone 17 Pro): EmptyState flex-centers its full stack
+    // (icon→CTA), but AC measures the title…CTA cluster — half the icon block
+    // (~36pt) below true center. The screen root also extends under the home
+    // indicator, so the safe region under the header is shorter than flex-1.
+    // Fix without touching shared EmptyState: (1) pad the body by the bottom
+    // safe-area inset so centering uses header-bottom → safe-bottom; (2) add
+    // pb-[72px] (= h-14 icon bubble + gap-4) inside EmptyState so justify-center
+    // lifts the stack by half that amount and the title…CTA cluster lands on
+    // the safe-region midpoint (±24pt).
     return (
       <View className="flex-1 bg-background">
         <ScreenHeader title="PR Review" />
-        <EmptyState
-          icon={revoked ? ShieldAlert : PlugZap}
-          title={revoked ? 'Reconnect GitHub' : 'Connect GitHub'}
-          description={
-            revoked
-              ? 'Your GitHub connection was revoked. Reconnect to keep reviewing pull requests on mobile.'
-              : 'Connect your GitHub account to review pull requests on mobile.'
-          }
-          action={
-            <Button
-              className="mt-3 w-full flex-row gap-2"
-              disabled={connecting}
-              onPress={() => {
-                void handleConnect();
-              }}
-            >
-              {connecting ? (
-                <ActivityIndicator size="small" color={colors.primaryForeground} />
-              ) : (
-                <RefreshCcw size={16} color={colors.primaryForeground} />
-              )}
-              <Text>{revoked ? 'Reconnect GitHub' : 'Connect GitHub'}</Text>
-            </Button>
-          }
-        />
+        <View className="flex-1" style={{ paddingBottom: insets.bottom }}>
+          <EmptyState
+            className="pb-[72px]"
+            icon={revoked ? ShieldAlert : PlugZap}
+            title={revoked ? 'Reconnect GitHub' : 'Connect GitHub'}
+            description={
+              revoked
+                ? 'Your GitHub connection was revoked. Reconnect to keep reviewing pull requests on mobile.'
+                : 'Connect your GitHub account to review pull requests on mobile.'
+            }
+            action={
+              <Button
+                className="mt-3 w-full flex-row gap-2"
+                disabled={connecting}
+                onPress={() => {
+                  void handleConnect();
+                }}
+              >
+                {connecting ? (
+                  <ActivityIndicator size="small" color={colors.primaryForeground} />
+                ) : (
+                  <RefreshCcw size={16} color={colors.primaryForeground} />
+                )}
+                <Text>{revoked ? 'Reconnect GitHub' : 'Connect GitHub'}</Text>
+              </Button>
+            }
+          />
+        </View>
       </View>
     );
   }

--- a/apps/mobile/src/components/pr-review/pr-review-entry-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-entry-screen.tsx
@@ -1,5 +1,12 @@
+import * as Clipboard from 'expo-clipboard';
 import { useFocusEffect, useRouter } from 'expo-router';
-import { ChevronRight, Clock, Link2, SearchX } from 'lucide-react-native';
+import {
+  ChevronRight,
+  Clipboard as ClipboardIcon,
+  Clock,
+  Link2,
+  SearchX,
+} from 'lucide-react-native';
 import { type ReactNode, useCallback, useRef, useState } from 'react';
 import { ActivityIndicator, Pressable, ScrollView, TextInput, View } from 'react-native';
 
@@ -10,6 +17,13 @@ import { Text } from '@/components/ui/text';
 import { parseGitHubPrUrl } from '@/lib/github-pr-url';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { getPrReviewPath } from '@/lib/profile-agent-navigation';
+import {
+  PR_LINK_HELPER_CLIPBOARD_EMPTY_COPY,
+  PR_LINK_HELPER_INVALID_COPY,
+  type PrLinkHelperMessage,
+  selectPrLinkHelperSlotState,
+} from '@/lib/pr-review/pr-link-helper-slot';
+import { decidePrLinkPaste } from '@/lib/pr-review/pr-link-paste';
 import { getRecentPrs, type RecentPr, upsertRecentPr } from '@/lib/pr-review/recent-prs';
 
 const URL_PLACEHOLDER = 'https://github.com/owner/repo/pull/123';
@@ -20,12 +34,15 @@ export function PrReviewEntryScreen() {
   // Uncontrolled iOS input — keep the raw text in a ref so the submit
   // handler reads the latest value without re-rendering on every
   // keystroke. State is only for derived UI (whether there's any text,
-  // whether the user already tried an invalid value). The TextInput
-  // component ref is for focus() (e.g. the empty-state CTA).
+  // active helper message). The TextInput component ref is for focus()
+  // and setNativeProps on programmatic paste.
   const inputRef = useRef<TextInput>(null);
   const inputValueRef = useRef<string>('');
+  // Text we just wrote via setNativeProps. onChangeText with this exact
+  // value is treated as programmatic (does not clear helper messages).
+  const pendingProgrammaticTextRef = useRef<string | null>(null);
   const [hasInput, setHasInput] = useState(false);
-  const [invalid, setInvalid] = useState(false);
+  const [helperMessage, setHelperMessage] = useState<PrLinkHelperMessage | null>(null);
   const [recent, setRecent] = useState<RecentPr[] | null>(null);
 
   useFocusEffect(
@@ -43,14 +60,21 @@ export function PrReviewEntryScreen() {
     }, [])
   );
 
+  const applyFieldText = (text: string) => {
+    pendingProgrammaticTextRef.current = text;
+    inputValueRef.current = text;
+    inputRef.current?.setNativeProps({ text });
+    setHasInput(text.length > 0);
+  };
+
   const handleSubmit = async () => {
     const raw = inputValueRef.current;
     const parsed = parseGitHubPrUrl(raw.trim());
     if (!parsed) {
-      setInvalid(true);
+      setHelperMessage('invalid');
       return;
     }
-    setInvalid(false);
+    setHelperMessage(null);
     // Title is backfilled on first successful load (S5).
     await upsertRecentPr({
       owner: parsed.owner,
@@ -60,6 +84,23 @@ export function PrReviewEntryScreen() {
       lastOpenedAt: Date.now(),
     });
     router.push(getPrReviewPath(parsed.owner, parsed.repo, parsed.number));
+  };
+
+  const handlePaste = async () => {
+    const clipboard = await Clipboard.getStringAsync();
+    const decision = decidePrLinkPaste(clipboard);
+    if (decision.kind === 'empty') {
+      setHelperMessage('clipboard-empty');
+      return;
+    }
+    // Replace entire field (never append-at-cursor): native field + ref + hasInput.
+    applyFieldText(decision.text);
+    if (decision.kind === 'non-url-text') {
+      setHelperMessage('invalid');
+      return;
+    }
+    setHelperMessage(null);
+    await handleSubmit();
   };
 
   const focusInput = () => {
@@ -74,11 +115,23 @@ export function PrReviewEntryScreen() {
     router.push(getPrReviewPath(entry.owner, entry.repo, entry.number));
   };
 
-  let helper: ReactNode = null;
-  if (invalid) {
-    helper = <Text className="text-sm text-destructive">Not a GitHub pull request link</Text>;
-  } else if (!hasInput) {
-    helper = (
+  const slotState = selectPrLinkHelperSlotState({
+    hasInput,
+    message: helperMessage,
+  });
+  const isInvalid = helperMessage === 'invalid';
+
+  let helperContent: ReactNode = null;
+  if (slotState === 'invalid') {
+    helperContent = <Text className="text-sm text-destructive">{PR_LINK_HELPER_INVALID_COPY}</Text>;
+  } else if (slotState === 'clipboard-empty') {
+    helperContent = (
+      <Text variant="muted" className="text-sm">
+        {PR_LINK_HELPER_CLIPBOARD_EMPTY_COPY}
+      </Text>
+    );
+  } else if (slotState === 'hint') {
+    helperContent = (
       <Text variant="muted" className="text-sm">
         Paste a link like {URL_PLACEHOLDER}
       </Text>
@@ -148,38 +201,69 @@ export function PrReviewEntryScreen() {
               Paste a PR link
             </Text>
           </View>
-          <TextInput
-            ref={inputRef}
-            defaultValue=""
-            placeholder={URL_PLACEHOLDER}
-            placeholderTextColor={colors.mutedForeground}
-            autoCapitalize="none"
-            autoCorrect={false}
-            keyboardType="url"
-            onChangeText={value => {
-              // Don't setState on every keystroke; track only whether the
-              // input has any text and whether the user has tried to
-              // submit an invalid value. The raw value lives in the ref
-              // so handleSubmit reads the latest text without re-rendering.
-              inputValueRef.current = value;
-              setHasInput(value.length > 0);
-              if (invalid) {
-                setInvalid(false);
-              }
-            }}
-            // explicit line-height so the placeholder + typed text render
-            // at the same vertical position on every iOS version.
-            className="rounded-md border border-border bg-card px-3 py-3 text-base text-foreground leading-[22px]"
-            accessibilityLabel="GitHub pull request URL"
-            returnKeyType="go"
-            onSubmitEditing={() => {
-              void handleSubmit();
-            }}
-          />
-          {helper}
+          <View className="flex-row items-center gap-2">
+            <TextInput
+              ref={inputRef}
+              defaultValue=""
+              placeholder={URL_PLACEHOLDER}
+              placeholderTextColor={colors.mutedForeground}
+              autoCapitalize="none"
+              autoCorrect={false}
+              keyboardType="url"
+              onChangeText={value => {
+                // Don't setState on every keystroke; track only whether the
+                // input has any text. The raw value lives in the ref so
+                // handleSubmit reads the latest text without re-rendering.
+                inputValueRef.current = value;
+                setHasInput(value.length > 0);
+                if (pendingProgrammaticTextRef.current !== null) {
+                  if (value === pendingProgrammaticTextRef.current) {
+                    pendingProgrammaticTextRef.current = null;
+                    return;
+                  }
+                  pendingProgrammaticTextRef.current = null;
+                }
+                // Any real edit clears transient helper messages (invalid /
+                // clipboard-empty). Last-set message is replaced by null.
+                if (helperMessage !== null) {
+                  setHelperMessage(null);
+                }
+              }}
+              onFocus={() => {
+                // clipboard-empty clears on input focus; invalid stays until edit.
+                if (helperMessage === 'clipboard-empty') {
+                  setHelperMessage(null);
+                }
+              }}
+              // explicit line-height so the placeholder + typed text render
+              // at the same vertical position on every iOS version.
+              className="min-w-0 flex-1 rounded-md border border-border bg-card px-3 py-3 text-base text-foreground leading-[22px]"
+              accessibilityLabel="GitHub pull request URL"
+              returnKeyType="go"
+              onSubmitEditing={() => {
+                void handleSubmit();
+              }}
+            />
+            <Pressable
+              onPress={() => {
+                void handlePaste();
+              }}
+              accessibilityRole="button"
+              accessibilityLabel="Paste pull request link"
+              hitSlop={4}
+              className="h-11 w-11 items-center justify-center rounded-md border border-border bg-card active:opacity-70"
+            >
+              <ClipboardIcon size={18} color={colors.mutedForeground} />
+            </Pressable>
+          </View>
+          {/*
+            Reserved-height slot: always mounted at min-h-5 (one text-sm line)
+            so Open/Recent never shift when helper content swaps.
+          */}
+          <View className="min-h-5 justify-center">{helperContent}</View>
           <Button
             className="mt-1"
-            disabled={!hasInput || invalid}
+            disabled={!hasInput || isInvalid}
             onPress={() => {
               void handleSubmit();
             }}

--- a/apps/mobile/src/components/pr-review/pr-review-entry-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-entry-screen.tsx
@@ -23,6 +23,7 @@ import {
   type PrLinkHelperMessage,
   selectPrLinkHelperSlotState,
 } from '@/lib/pr-review/pr-link-helper-slot';
+import { consumePrLinkInputEcho, pushPrLinkInputEcho } from '@/lib/pr-review/pr-link-input-echo';
 import { decidePrLinkPaste } from '@/lib/pr-review/pr-link-paste';
 import { getRecentPrs, type RecentPr, upsertRecentPr } from '@/lib/pr-review/recent-prs';
 
@@ -38,9 +39,10 @@ export function PrReviewEntryScreen() {
   // and setNativeProps on programmatic paste.
   const inputRef = useRef<TextInput>(null);
   const inputValueRef = useRef<string>('');
-  // Text we just wrote via setNativeProps. onChangeText with this exact
-  // value is treated as programmatic (does not clear helper messages).
-  const pendingProgrammaticTextRef = useRef<string | null>(null);
+  // FIFO of values written via setNativeProps. Matching onChangeText values
+  // are treated as programmatic echoes (do not clear helpers / clobber ref).
+  // Order-agnostic membership so double-taps and delayed native echoes work.
+  const pendingProgrammaticTextsRef = useRef<string[]>([]);
   const [hasInput, setHasInput] = useState(false);
   const [helperMessage, setHelperMessage] = useState<PrLinkHelperMessage | null>(null);
   const [recent, setRecent] = useState<RecentPr[] | null>(null);
@@ -61,7 +63,10 @@ export function PrReviewEntryScreen() {
   );
 
   const applyFieldText = (text: string) => {
-    pendingProgrammaticTextRef.current = text;
+    pendingProgrammaticTextsRef.current = pushPrLinkInputEcho(
+      pendingProgrammaticTextsRef.current,
+      text
+    );
     inputValueRef.current = text;
     inputRef.current?.setNativeProps({ text });
     setHasInput(text.length > 0);
@@ -214,15 +219,16 @@ export function PrReviewEntryScreen() {
                 // Don't setState on every keystroke; track only whether the
                 // input has any text. The raw value lives in the ref so
                 // handleSubmit reads the latest text without re-rendering.
+                const decision = consumePrLinkInputEcho(pendingProgrammaticTextsRef.current, value);
+                pendingProgrammaticTextsRef.current = [...decision.pending];
+                if (decision.kind === 'echo') {
+                  // Echo of setNativeProps: inputValueRef already holds the
+                  // intentional value from applyFieldText — do not clobber it
+                  // with a delayed/stale echo, and do not clear helpers.
+                  return;
+                }
                 inputValueRef.current = value;
                 setHasInput(value.length > 0);
-                if (pendingProgrammaticTextRef.current !== null) {
-                  if (value === pendingProgrammaticTextRef.current) {
-                    pendingProgrammaticTextRef.current = null;
-                    return;
-                  }
-                  pendingProgrammaticTextRef.current = null;
-                }
                 // Any real edit clears transient helper messages (invalid /
                 // clipboard-empty). Last-set message is replaced by null.
                 if (helperMessage !== null) {

--- a/apps/mobile/src/components/pr-review/pr-review-pending-comment-row.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-pending-comment-row.tsx
@@ -1,0 +1,127 @@
+// Pending-comment list pieces for the review-submit sheet: mono
+// location label, 2-line body excerpt, trash → confirm-delete, and a
+// pressable body that opens the comment composer in edit mode.
+
+import { type RefObject } from 'react';
+import { Trash2 } from 'lucide-react-native';
+import { Pressable, TextInput, View } from 'react-native';
+
+import { Text } from '@/components/ui/text';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { type PendingReviewItem } from '@/lib/pr-review/pending-review-provider';
+import { cn } from '@/lib/utils';
+
+type PrReviewPendingCommentRowProps = Readonly<{
+  item: PendingReviewItem;
+  onPress: () => void;
+  onDelete: () => void;
+  disabled?: boolean;
+}>;
+
+export function PrReviewPendingCommentRow({
+  item,
+  onPress,
+  onDelete,
+  disabled = false,
+}: PrReviewPendingCommentRowProps) {
+  const colors = useThemeColors();
+  const location = pendingCommentLocationLabel(item);
+
+  return (
+    <View className="flex-row items-start gap-2 border-t border-hair-soft pt-3">
+      <Pressable
+        onPress={onPress}
+        disabled={disabled}
+        accessibilityRole="button"
+        accessibilityLabel={`Edit pending comment on ${location}`}
+        className="min-h-11 flex-1 gap-1 active:opacity-70"
+      >
+        <Text className="font-mono-medium text-[11px] text-muted-foreground" numberOfLines={1}>
+          {location}
+        </Text>
+        <Text className="text-sm leading-5 text-foreground" numberOfLines={2}>
+          {item.body.trim().length > 0 ? item.body : '(empty)'}
+        </Text>
+      </Pressable>
+      <Pressable
+        onPress={onDelete}
+        disabled={disabled}
+        hitSlop={8}
+        accessibilityRole="button"
+        accessibilityLabel={`Delete pending comment on ${location}`}
+        className="h-9 w-9 items-center justify-center rounded-md active:opacity-60"
+      >
+        <Trash2 size={16} color={colors.mutedForeground} />
+      </Pressable>
+    </View>
+  );
+}
+
+/** Mono location label matching the composer range format (en dash). */
+function pendingCommentLocationLabel(item: {
+  path: string;
+  line: number;
+  startLine?: number;
+}): string {
+  if (item.startLine !== undefined && item.startLine !== item.line) {
+    return `${item.path}:L${item.startLine}–L${item.line}`;
+  }
+  return `${item.path}:L${item.line}`;
+}
+
+export function PendingQueueHint({
+  queuedCount,
+  hasStaleItems,
+}: {
+  queuedCount: number;
+  hasStaleItems: boolean;
+}) {
+  let message = '';
+  if (queuedCount === 0) {
+    message = 'No comments queued. The review will be submitted with just the event above.';
+  } else if (hasStaleItems) {
+    message =
+      'Some comments may be outdated because the PR head changed after they were queued. Submission will use the current head.';
+  } else {
+    message = 'All comments will be sent in a single batched request.';
+  }
+  return (
+    <Text variant="muted" className="text-xs">
+      {message}
+    </Text>
+  );
+}
+
+export function ReviewSummaryField({
+  bodyRef,
+  inputRef,
+  isDisabled,
+  onChange,
+}: {
+  bodyRef: RefObject<string>;
+  inputRef: RefObject<TextInput | null>;
+  isDisabled: boolean;
+  onChange: () => void;
+}) {
+  const colors = useThemeColors();
+  return (
+    <TextInput
+      ref={inputRef}
+      defaultValue=""
+      editable={!isDisabled}
+      placeholder="Optional summary for the review"
+      placeholderTextColor={colors.mutedForeground}
+      accessibilityLabel="Review summary"
+      onChangeText={value => {
+        bodyRef.current = value;
+        onChange();
+      }}
+      multiline
+      textAlignVertical="top"
+      className={cn(
+        'min-h-24 rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground',
+        'focus:border-ring'
+      )}
+    />
+  );
+}

--- a/apps/mobile/src/components/pr-review/pr-review-submit.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-submit.tsx
@@ -1,47 +1,41 @@
-// S7a review-submit content component. The orchestrator mounts this
-// inside the `review-submit.tsx` route (S4b left a thin stub there);
-// the route supplies the route-params; this component owns the form
-// body, the event radio, and the single batched submit.
+// Review-submit content: event radio, optional summary, pending-comments
+// list (view/edit/delete), and one batched submitReview call. Queue is
+// cleared on success and retained on failure.
 //
-// The sheet drains the `PendingReviewProvider` queue into ONE
-// `submitReview` call (per the S3 contract). The head SHA submitted
-// is the LATEST one — the per-item `commitSha` is only used by the
-// sheet's "may be outdated" hint. The queue is cleared on success
-// and retained on failure so the user can decide what to drop or retry.
-//
-// Submit failures are classified: 422/BAD_REQUEST validation errors
-// (approve-own-PR, stale) are non-retryable and remove the submit
-// affordance until the user changes the event or body; everything
-// else is retryable and keeps the submit button enabled.
-//
-// Toasts paint behind formSheets on iOS, so the mutation hook toasts
-// `onError` AND the sheet renders an inline error box.
+// Disable lifetime: bad-request clears on event/summary change; forbidden
+// stays for the rest of the sheet session. Toasts paint behind formSheets
+// on iOS, so the mutation hook toasts onError AND the sheet shows inline.
 
 import * as Haptics from 'expo-haptics';
-import { type RefObject, useEffect, useRef, useState } from 'react';
-import { ScrollView, TextInput, View } from 'react-native';
+import { type Href, useRouter } from 'expo-router';
+import { useEffect, useRef, useState } from 'react';
+import { Alert, ScrollView, type TextInput, View } from 'react-native';
 
 import { Button } from '@/components/ui/button';
 import { PillGroup } from '@/components/security-agent/settings-pill-group';
 import { Text } from '@/components/ui/text';
-import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import {
+  PendingQueueHint,
+  PrReviewPendingCommentRow,
+  ReviewSummaryField,
+} from '@/components/pr-review/pr-review-pending-comment-row';
 import {
   buildSubmitReviewInput,
   type ReviewEvent,
 } from '@/lib/pr-review/build-submit-review-input';
 import { PrReviewReconnectNotice } from '@/components/pr-review/pr-review-reconnect-notice';
 import { classifyPrReviewMutationError } from '@/lib/pr-review/classify-pr-review-query-state';
-import { usePendingReview } from '@/lib/pr-review/pending-review-provider';
+import { mutationErrorDisplay } from '@/lib/pr-review/mutation-error-display';
+import { type PendingReviewItem, usePendingReview } from '@/lib/pr-review/pending-review-provider';
 import { useSubmitReviewMutation } from '@/lib/pr-review/use-pr-review-mutations';
-import { cn } from '@/lib/utils';
+
+const COMMENT_COMPOSER_PATH = '/(app)/pr-review/[owner]/[repo]/[number]/comment-composer' as const;
 
 type PrReviewSubmitProps = Readonly<{
   owner: string;
   repo: string;
   number: number;
-  /** Current PR head SHA — submitted as `commitSha` for the review. */
   headSha: string;
-  /** Invoked after a successful submit or a cancel. */
   onDismiss: () => void;
 }>;
 
@@ -53,46 +47,39 @@ const EVENT_OPTIONS: readonly { value: ReviewEvent; label: string }[] = [
 
 export function PrReviewSubmit(props: PrReviewSubmitProps) {
   const { owner, repo, number, headSha, onDismiss } = props;
+  const router = useRouter();
   const pending = usePendingReview();
   const submitReview = useSubmitReviewMutation({ owner, repo, number });
 
   const [event, setEvent] = useState<ReviewEvent>('COMMENT');
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [inlineErrorKind, setInlineErrorKind] = useState<
-    'retryable' | 'non-retryable' | 'reconnect' | null
+    'retryable' | 'bad-request' | 'forbidden' | 'reconnect' | null
   >(null);
 
-  // iOS uncontrolled pattern: body lives in a ref, the input's visible
-  // value is set via defaultValue once. No `value` + state.
   const bodyRef = useRef<string>('');
   const bodyInputRef = useRef<TextInput | null>(null);
 
   const isSubmitting = submitReview.isPending;
   const queuedCount = pending.items.length;
-
-  // Flag when any queued item was queued against a different head SHA
-  // than the current one. Submission still uses the latest head SHA.
   const hasStaleItems = pending.items.some(item => item.commitSha !== headSha);
 
   useEffect(() => {
     if (submitReview.error) {
       const classification = classifyPrReviewMutationError(submitReview.error);
-      if (classification.kind === 'bad-request' || classification.kind === 'forbidden') {
-        setInlineError(
-          classification.kind === 'forbidden'
-            ? "You don't have permission to submit this review."
-            : "This review can't be submitted as is. The PR may have changed, or you can't approve your own pull request."
-        );
-        setInlineErrorKind('non-retryable');
-      } else if (classification.kind === 'reconnect') {
-        setInlineError('GitHub connection expired.');
-        setInlineErrorKind('reconnect');
-      } else {
-        setInlineError('Could not submit review. Check your connection and try again.');
-        setInlineErrorKind('retryable');
-      }
+      const display = mutationErrorDisplay('submit', classification, submitReview.error);
+      setInlineError(display.message);
+      setInlineErrorKind(display.kind);
     }
   }, [submitReview.error]);
+
+  function clearRecoverableError() {
+    // bad-request / retryable clear on edit; forbidden stays for the session.
+    if (inlineErrorKind === 'bad-request' || inlineErrorKind === 'retryable') {
+      setInlineError(null);
+      setInlineErrorKind(null);
+    }
+  }
 
   async function handleSubmit() {
     setInlineError(null);
@@ -114,17 +101,45 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
       void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);
       onDismiss();
     } catch {
-      // The effect above classifies the mutation error into inlineError;
-      // swallow here to avoid an unhandled promise rejection.
+      // Classified into inlineError by the effect above.
     }
   }
 
-  function handleCancel() {
-    if (isSubmitting) {
-      return;
-    }
-    onDismiss();
+  function openEditComposer(item: PendingReviewItem) {
+    const href: Href = {
+      pathname: COMMENT_COMPOSER_PATH,
+      params: {
+        owner,
+        repo,
+        number: String(number),
+        path: item.path,
+        side: item.side,
+        line: String(item.line),
+        ...(item.startLine !== undefined ? { startLine: String(item.startLine) } : {}),
+        pendingId: item.id,
+      },
+    };
+    router.push(href);
   }
+
+  function confirmDelete(item: PendingReviewItem) {
+    Alert.alert('Delete pending comment?', 'This comment will be removed from the review queue.', [
+      { text: 'Cancel', style: 'cancel' },
+      {
+        text: 'Delete',
+        style: 'destructive',
+        onPress: () => {
+          pending.removeComment(item.id);
+        },
+      },
+    ]);
+  }
+
+  const submitDisabled =
+    isSubmitting ||
+    inlineErrorKind === 'bad-request' ||
+    inlineErrorKind === 'forbidden' ||
+    inlineErrorKind === 'reconnect';
 
   return (
     <View className="flex-1 bg-background">
@@ -142,20 +157,16 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
           disabled={isSubmitting}
           onChange={next => {
             setEvent(next);
-            setInlineError(null);
-            setInlineErrorKind(null);
+            clearRecoverableError();
           }}
         />
         <View className="gap-2">
           <Text className="text-sm font-medium text-foreground">Summary (optional)</Text>
-          <ReviewBodyField
+          <ReviewSummaryField
             bodyRef={bodyRef}
             inputRef={bodyInputRef}
             isDisabled={isSubmitting}
-            onChange={() => {
-              setInlineError(null);
-              setInlineErrorKind(null);
-            }}
+            onChange={clearRecoverableError}
           />
         </View>
 
@@ -164,6 +175,19 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
             {queuedCount} pending {queuedCount === 1 ? 'comment' : 'comments'}
           </Text>
           <PendingQueueHint queuedCount={queuedCount} hasStaleItems={hasStaleItems} />
+          {pending.items.map(item => (
+            <PrReviewPendingCommentRow
+              key={item.id}
+              item={item}
+              disabled={isSubmitting}
+              onPress={() => {
+                openEditComposer(item);
+              }}
+              onDelete={() => {
+                confirmDelete(item);
+              }}
+            />
+          ))}
         </View>
 
         {inlineError && inlineErrorKind !== 'reconnect' ? (
@@ -183,16 +207,18 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
             void handleSubmit();
           }}
           loading={isSubmitting}
-          disabled={
-            isSubmitting || inlineErrorKind === 'non-retryable' || inlineErrorKind === 'reconnect'
-          }
+          disabled={submitDisabled}
           accessibilityLabel="Submit review"
         >
           <Text>Submit review</Text>
         </Button>
         <Button
           variant="ghost"
-          onPress={handleCancel}
+          onPress={() => {
+            if (!isSubmitting) {
+              onDismiss();
+            }
+          }}
           disabled={isSubmitting}
           className="mt-2"
           accessibilityLabel="Cancel"
@@ -201,62 +227,5 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
         </Button>
       </View>
     </View>
-  );
-}
-
-function PendingQueueHint({
-  queuedCount,
-  hasStaleItems,
-}: {
-  queuedCount: number;
-  hasStaleItems: boolean;
-}) {
-  let message = '';
-  if (queuedCount === 0) {
-    message = 'No comments queued. The review will be submitted with just the event above.';
-  } else if (hasStaleItems) {
-    message =
-      'Some comments may be outdated because the PR head changed after they were queued. Submission will use the current head.';
-  } else {
-    message = 'All comments will be sent in a single batched request.';
-  }
-  return (
-    <Text variant="muted" className="text-xs">
-      {message}
-    </Text>
-  );
-}
-
-function ReviewBodyField({
-  bodyRef,
-  inputRef,
-  isDisabled,
-  onChange,
-}: {
-  bodyRef: RefObject<string>;
-  inputRef: RefObject<TextInput | null>;
-  isDisabled: boolean;
-  onChange: () => void;
-}) {
-  const colors = useThemeColors();
-  return (
-    <TextInput
-      ref={inputRef}
-      defaultValue=""
-      editable={!isDisabled}
-      placeholder="Optional summary for the review"
-      placeholderTextColor={colors.mutedForeground}
-      accessibilityLabel="Review summary"
-      onChangeText={value => {
-        bodyRef.current = value;
-        onChange();
-      }}
-      multiline
-      textAlignVertical="top"
-      className={cn(
-        'min-h-24 rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground',
-        'focus:border-ring'
-      )}
-    />
   );
 }

--- a/apps/mobile/src/lib/pr-review/comment-composer-params.test.ts
+++ b/apps/mobile/src/lib/pr-review/comment-composer-params.test.ts
@@ -69,4 +69,23 @@ describe('parseComposerParams', () => {
     expect(parseComposerParams(valid({ startLine: '0' }))).toBeNull();
     expect(parseComposerParams(valid({ startLine: '-1' }))).toBeNull();
   });
+
+  it('omits pendingId when absent', () => {
+    expect(parseComposerParams(valid())).not.toHaveProperty('pendingId');
+    const withoutId = parseComposerParams(valid({ pendingId: undefined }));
+    expect(withoutId).not.toBeNull();
+    expect(withoutId).not.toHaveProperty('pendingId');
+  });
+
+  it('passes a present pendingId string through', () => {
+    expect(parseComposerParams(valid({ pendingId: 'pending-abc' }))).toEqual(
+      expect.objectContaining({ pendingId: 'pending-abc' })
+    );
+  });
+
+  it('treats an empty pendingId as absent without rejecting the route', () => {
+    const parsed = parseComposerParams(valid({ pendingId: '' }));
+    expect(parsed).not.toBeNull();
+    expect(parsed).not.toHaveProperty('pendingId');
+  });
 });

--- a/apps/mobile/src/lib/pr-review/comment-composer-params.ts
+++ b/apps/mobile/src/lib/pr-review/comment-composer-params.ts
@@ -8,6 +8,8 @@ type RawComposerParams = {
   side?: string | string[] | undefined;
   line?: string | string[] | undefined;
   startLine?: string | string[] | undefined;
+  /** Optional pending-queue item id when the composer opens in edit mode. */
+  pendingId?: string | string[] | undefined;
 };
 
 type ParsedComposerParams = {
@@ -18,6 +20,8 @@ type ParsedComposerParams = {
   side: 'LEFT' | 'RIGHT';
   line: number;
   startLine?: number;
+  /** Present only when the route was opened to edit a queued comment. */
+  pendingId?: string;
 };
 
 function parsePositiveInt(value: string | string[] | undefined): number | null {
@@ -47,6 +51,10 @@ export function parseComposerParams(raw: RawComposerParams): ParsedComposerParam
   const line = parsePositiveInt(raw.line);
   const startLine = parsePositiveInt(raw.startLine);
   const hasStartLine = parseParam(raw.startLine) !== null;
+  // Optional edit-mode id: absent → undefined; present non-empty string
+  // passes through. Empty/array values are treated as absent (not a hard
+  // reject) so create-mode deep links stay tolerant.
+  const pendingId = parseParam(raw.pendingId);
 
   if (!owner || !repo || !number || !path || !side || !line) {
     return null;
@@ -68,5 +76,6 @@ export function parseComposerParams(raw: RawComposerParams): ParsedComposerParam
     side,
     line,
     ...(startLine !== null ? { startLine } : {}),
+    ...(pendingId !== null ? { pendingId } : {}),
   };
 }

--- a/apps/mobile/src/lib/pr-review/diff/dedupe-file-pages.test.ts
+++ b/apps/mobile/src/lib/pr-review/diff/dedupe-file-pages.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+
+import { dedupeFilesByPath } from './dedupe-file-pages';
+
+describe('dedupeFilesByPath', () => {
+  it('returns the same order when there are no duplicates', () => {
+    const files = [{ path: 'a.ts' }, { path: 'b.ts' }, { path: 'c.ts' }];
+    expect(dedupeFilesByPath(files)).toEqual(files);
+  });
+
+  it('keeps the first occurrence when the same path appears twice', () => {
+    const first = { path: 'a.ts', page: 1 };
+    const second = { path: 'a.ts', page: 2 };
+    expect(dedupeFilesByPath([first, second])).toEqual([first]);
+  });
+
+  it('dedupes across page-like sequences while preserving first-seen order', () => {
+    const files = [
+      { path: 'a.ts', n: 1 },
+      { path: 'b.ts', n: 1 },
+      { path: 'a.ts', n: 2 },
+      { path: 'c.ts', n: 2 },
+      { path: 'b.ts', n: 2 },
+      { path: 'd.ts', n: 3 },
+    ];
+    expect(dedupeFilesByPath(files)).toEqual([
+      { path: 'a.ts', n: 1 },
+      { path: 'b.ts', n: 1 },
+      { path: 'c.ts', n: 2 },
+      { path: 'd.ts', n: 3 },
+    ]);
+  });
+
+  it('returns an empty array for empty input', () => {
+    expect(dedupeFilesByPath([])).toEqual([]);
+  });
+});

--- a/apps/mobile/src/lib/pr-review/diff/dedupe-file-pages.ts
+++ b/apps/mobile/src/lib/pr-review/diff/dedupe-file-pages.ts
@@ -1,0 +1,15 @@
+// Guard against duplicate file paths when flattening infinite-query pages.
+// First occurrence wins so clean server data is unchanged; cross-page
+// duplicates (retry/refetch races) cannot produce duplicate list keys.
+
+export function dedupeFilesByPath<T extends { readonly path: string }>(files: readonly T[]): T[] {
+  const seen = new Set<string>();
+  const result: T[] = [];
+  for (const file of files) {
+    if (!seen.has(file.path)) {
+      seen.add(file.path);
+      result.push(file);
+    }
+  }
+  return result;
+}

--- a/apps/mobile/src/lib/pr-review/diff/initial-top-scroll.test.ts
+++ b/apps/mobile/src/lib/pr-review/diff/initial-top-scroll.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  armInitialTopScroll,
+  INITIAL_TOP_SCROLL_IDLE,
+  type InitialTopScrollState,
+  onInitialTopScrollContentSize,
+} from './initial-top-scroll';
+
+describe('initial-top-scroll', () => {
+  describe('armInitialTopScroll', () => {
+    it('stays idle while files are empty', () => {
+      expect(armInitialTopScroll(INITIAL_TOP_SCROLL_IDLE, 0)).toEqual({ status: 'idle' });
+    });
+
+    it('arms on the first positive files length', () => {
+      expect(armInitialTopScroll(INITIAL_TOP_SCROLL_IDLE, 1)).toEqual({ status: 'armed' });
+    });
+
+    it('does not re-arm once armed', () => {
+      const armed: InitialTopScrollState = { status: 'armed' };
+      expect(armInitialTopScroll(armed, 50)).toBe(armed);
+    });
+
+    it('does not re-arm once done (page appends)', () => {
+      const done: InitialTopScrollState = { status: 'done' };
+      expect(armInitialTopScroll(done, 214)).toBe(done);
+    });
+  });
+
+  describe('onInitialTopScrollContentSize', () => {
+    it('does not scroll while idle (skeleton layout)', () => {
+      expect(onInitialTopScrollContentSize(INITIAL_TOP_SCROLL_IDLE, 400)).toEqual({
+        state: INITIAL_TOP_SCROLL_IDLE,
+        shouldScroll: false,
+      });
+    });
+
+    it('waits for positive content height while armed', () => {
+      const armed: InitialTopScrollState = { status: 'armed' };
+      expect(onInitialTopScrollContentSize(armed, 0)).toEqual({
+        state: armed,
+        shouldScroll: false,
+      });
+    });
+
+    it('fires once when armed content has positive height', () => {
+      expect(onInitialTopScrollContentSize({ status: 'armed' }, 320)).toEqual({
+        state: { status: 'done' },
+        shouldScroll: true,
+      });
+    });
+
+    it('never scrolls again after done', () => {
+      const done: InitialTopScrollState = { status: 'done' };
+      expect(onInitialTopScrollContentSize(done, 800)).toEqual({
+        state: done,
+        shouldScroll: false,
+      });
+    });
+  });
+
+  describe('cold and warm sequences', () => {
+    it('cold: skeleton size then files arm then layout fires once', () => {
+      let state = INITIAL_TOP_SCROLL_IDLE;
+
+      // Skeleton content-size while still loading.
+      let result = onInitialTopScrollContentSize(state, 200);
+      expect(result.shouldScroll).toBe(false);
+      state = result.state;
+
+      // First page arrives.
+      state = armInitialTopScroll(state, 50);
+      expect(state).toEqual({ status: 'armed' });
+
+      // Real content lays out.
+      result = onInitialTopScrollContentSize(state, 1200);
+      expect(result).toEqual({ state: { status: 'done' }, shouldScroll: true });
+      state = result.state;
+
+      // Page appends must not re-scroll.
+      state = armInitialTopScroll(state, 100);
+      result = onInitialTopScrollContentSize(state, 2400);
+      expect(result.shouldScroll).toBe(false);
+      expect(state.status).toBe('done');
+    });
+
+    it('warm-cache: arm on first render then first layout fires once', () => {
+      const state = armInitialTopScroll(INITIAL_TOP_SCROLL_IDLE, 214);
+      expect(state).toEqual({ status: 'armed' });
+
+      const result = onInitialTopScrollContentSize(state, 5000);
+      expect(result).toEqual({ state: { status: 'done' }, shouldScroll: true });
+    });
+  });
+});

--- a/apps/mobile/src/lib/pr-review/diff/initial-top-scroll.ts
+++ b/apps/mobile/src/lib/pr-review/diff/initial-top-scroll.ts
@@ -1,0 +1,46 @@
+// One-shot scroll-to-top after the Files list first lays out real content.
+//
+// Arm on the first `files.length > 0` transition per mount; fire only from a
+// subsequent content-size callback with positive height so FlashList has laid
+// out the new items. Never re-fires on page appends.
+
+export type InitialTopScrollState =
+  | { readonly status: 'idle' }
+  | { readonly status: 'armed' }
+  | { readonly status: 'done' };
+
+export const INITIAL_TOP_SCROLL_IDLE: InitialTopScrollState = { status: 'idle' };
+
+/**
+ * Arm when real files first become available. No-ops once armed or done so
+ * page appends cannot re-arm.
+ */
+export function armInitialTopScroll(
+  state: InitialTopScrollState,
+  filesLength: number
+): InitialTopScrollState {
+  if (state.status !== 'idle') {
+    return state;
+  }
+  if (filesLength <= 0) {
+    return state;
+  }
+  return { status: 'armed' };
+}
+
+/**
+ * Fire scroll-to-top once content reports a positive height after arming.
+ * Returns whether the caller should invoke `scrollToOffset({ offset: 0 })`.
+ */
+export function onInitialTopScrollContentSize(
+  state: InitialTopScrollState,
+  contentHeight: number
+): { readonly state: InitialTopScrollState; readonly shouldScroll: boolean } {
+  if (state.status !== 'armed') {
+    return { state, shouldScroll: false };
+  }
+  if (contentHeight <= 0) {
+    return { state, shouldScroll: false };
+  }
+  return { state: { status: 'done' }, shouldScroll: true };
+}

--- a/apps/mobile/src/lib/pr-review/diff/pending-scroll-request.test.ts
+++ b/apps/mobile/src/lib/pr-review/diff/pending-scroll-request.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  cancelPendingScroll,
+  decideOnItemsChange,
+  decideOnScrollRequest,
+} from './pending-scroll-request';
+
+function mapOf(entries: readonly [string, number][]): Map<string, number> {
+  return new Map(entries);
+}
+
+describe('pending-scroll-request', () => {
+  describe('decideOnScrollRequest', () => {
+    it('scrolls immediately when the target key is present', () => {
+      const indexByKey = mapOf([
+        ['file-header:a.ts', 0],
+        ['file-header:b.ts', 5],
+      ]);
+      expect(decideOnScrollRequest(null, 'file-header:b.ts', indexByKey)).toEqual({
+        pending: null,
+        index: 5,
+      });
+    });
+
+    it('parks the request when the target key is absent', () => {
+      const indexByKey = mapOf([['file-header:a.ts', 0]]);
+      expect(decideOnScrollRequest(null, 'file-header:missing.ts', indexByKey)).toEqual({
+        pending: 'file-header:missing.ts',
+        index: null,
+      });
+    });
+
+    it('supersedes a prior pending key with the newer request', () => {
+      const indexByKey = mapOf([['file-header:a.ts', 0]]);
+      const first = decideOnScrollRequest(null, 'file-header:old.ts', indexByKey);
+      expect(first.pending).toBe('file-header:old.ts');
+
+      const second = decideOnScrollRequest(first.pending, 'file-header:new.ts', indexByKey);
+      expect(second).toEqual({
+        pending: 'file-header:new.ts',
+        index: null,
+      });
+    });
+
+    it('clears a prior pending key when the newer request can scroll now', () => {
+      const indexByKey = mapOf([['file-header:ready.ts', 3]]);
+      expect(
+        decideOnScrollRequest('file-header:old.ts', 'file-header:ready.ts', indexByKey)
+      ).toEqual({
+        pending: null,
+        index: 3,
+      });
+    });
+  });
+
+  describe('decideOnItemsChange', () => {
+    it('does nothing when there is no pending request', () => {
+      const indexByKey = mapOf([['file-header:a.ts', 0]]);
+      expect(decideOnItemsChange(null, indexByKey)).toEqual({
+        pending: null,
+        index: null,
+      });
+    });
+
+    it('retries and scrolls when a previously absent key becomes present', () => {
+      const empty = mapOf([]);
+      const parked = decideOnScrollRequest(null, 'file-header:late.ts', empty);
+      expect(parked.pending).toBe('file-header:late.ts');
+
+      const ready = mapOf([['file-header:late.ts', 12]]);
+      expect(decideOnItemsChange(parked.pending, ready)).toEqual({
+        pending: null,
+        index: 12,
+      });
+    });
+
+    it('keeps waiting while the key is still absent', () => {
+      const indexByKey = mapOf([['file-header:other.ts', 1]]);
+      expect(decideOnItemsChange('file-header:late.ts', indexByKey)).toEqual({
+        pending: 'file-header:late.ts',
+        index: null,
+      });
+    });
+  });
+
+  describe('cancelPendingScroll', () => {
+    it('clears any pending key on unmount', () => {
+      expect(cancelPendingScroll()).toBeNull();
+    });
+  });
+});

--- a/apps/mobile/src/lib/pr-review/diff/pending-scroll-request.ts
+++ b/apps/mobile/src/lib/pr-review/diff/pending-scroll-request.ts
@@ -1,0 +1,53 @@
+// Pure decision logic for resilient navigator scroll-to-file requests.
+// When the target list key is momentarily absent from `indexByKey`
+// (query-data → items rebuild race), keep the request pending and retry
+// on the next items change. A newer request supersedes any pending one;
+// unmount cancels.
+
+/** Target list-item key waiting to become scrollable, or null. */
+export type PendingScrollState = string | null;
+
+type ScrollRequestDecision = {
+  readonly pending: PendingScrollState;
+  /** Present when the target key is in the map and scrolling should run now. */
+  readonly index: number | null;
+};
+
+/**
+ * Handle a new navigator scroll request. Supersedes any prior pending key.
+ * Scrolls immediately when the key is already present; otherwise parks it.
+ */
+export function decideOnScrollRequest(
+  _currentPending: PendingScrollState,
+  targetKey: string,
+  indexByKey: ReadonlyMap<string, number>
+): ScrollRequestDecision {
+  const index = indexByKey.get(targetKey);
+  if (typeof index === 'number') {
+    return { pending: null, index };
+  }
+  return { pending: targetKey, index: null };
+}
+
+/**
+ * Re-check a pending request after `indexByKey` changes (items rebuild).
+ * Resolves to a scroll index when the key appears; otherwise keeps waiting.
+ */
+export function decideOnItemsChange(
+  pending: PendingScrollState,
+  indexByKey: ReadonlyMap<string, number>
+): ScrollRequestDecision {
+  if (pending === null) {
+    return { pending: null, index: null };
+  }
+  const index = indexByKey.get(pending);
+  if (typeof index === 'number') {
+    return { pending: null, index };
+  }
+  return { pending, index: null };
+}
+
+/** Clear any pending request (component unmount). */
+export function cancelPendingScroll(): PendingScrollState {
+  return null;
+}

--- a/apps/mobile/src/lib/pr-review/diff/pr-review-file-list-state.ts
+++ b/apps/mobile/src/lib/pr-review/diff/pr-review-file-list-state.ts
@@ -19,7 +19,7 @@
 // to the right terminal state.
 
 import { useInfiniteQuery } from '@tanstack/react-query';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { classifyPrReviewQueryState } from '@/lib/pr-review/classify-pr-review-query-state';
 import { PR_REVIEW_MAX_PAGES } from '@/lib/pr-review/diff/pr-review-file-types';
@@ -149,8 +149,12 @@ export function usePrReviewViewedFiles(
     [owner, repo, number, headSha]
   );
 
-  const set = new Set(paths);
-  return { isViewed: (path: string) => set.has(path), toggle, isLoading };
+  // Stabilize identities for downstream memos (`items`, `renderItem`). A fresh
+  // `{ isViewed, toggle, isLoading }` every render forced FlashList to rebuild
+  // its entire data array on every parent render (D5 preventive).
+  const pathSet = useMemo(() => new Set(paths), [paths]);
+  const isViewed = useCallback((path: string) => pathSet.has(path), [pathSet]);
+  return useMemo(() => ({ isViewed, toggle, isLoading }), [isViewed, toggle, isLoading]);
 }
 
 /**

--- a/apps/mobile/src/lib/pr-review/mutation-error-display.test.ts
+++ b/apps/mobile/src/lib/pr-review/mutation-error-display.test.ts
@@ -1,0 +1,86 @@
+import { describe, expect, it } from 'vitest';
+
+import { classifyPrReviewMutationError } from '@/lib/pr-review/classify-pr-review-query-state';
+import {
+  mutationErrorDisplay,
+  mutationErrorDisplayFromError,
+} from '@/lib/pr-review/mutation-error-display';
+
+function makeError(code: string, message: string): Error {
+  const error = new Error(message);
+  Object.assign(error, { data: { code } });
+  return error;
+}
+
+describe('mutationErrorDisplay', () => {
+  it('passes the server-provided forbidden message through verbatim on both surfaces', () => {
+    const serverMessage =
+      "The Kilo GitHub App can't write to this repository. An owner of the repository's organization must install the Kilo app (or approve its updated permissions), then try again.";
+    const classification = classifyPrReviewMutationError(makeError('FORBIDDEN', serverMessage));
+    expect(mutationErrorDisplay('composer', classification)).toEqual({
+      kind: 'forbidden',
+      message: serverMessage,
+    });
+    expect(mutationErrorDisplay('submit', classification)).toEqual({
+      kind: 'forbidden',
+      message: serverMessage,
+    });
+  });
+
+  it('uses the surface-specific bad-request inline message', () => {
+    const classification = classifyPrReviewMutationError(
+      makeError('BAD_REQUEST', 'Cannot approve your own pull request')
+    );
+    expect(mutationErrorDisplay('composer', classification)).toEqual({
+      kind: 'bad-request',
+      message:
+        "This comment can't be posted. The selected line may have changed, or the PR may have been updated.",
+    });
+    expect(mutationErrorDisplay('submit', classification)).toEqual({
+      kind: 'bad-request',
+      message:
+        "This review can't be submitted as is. The PR may have changed, or you can't approve your own pull request.",
+    });
+  });
+
+  it('keeps reconnect copy fixed on both surfaces', () => {
+    const classification = classifyPrReviewMutationError(
+      makeError('PRECONDITION_FAILED', 'revoked')
+    );
+    expect(mutationErrorDisplay('composer', classification)).toEqual({
+      kind: 'reconnect',
+      message: 'GitHub connection expired.',
+    });
+    expect(mutationErrorDisplay('submit', classification)).toEqual({
+      kind: 'reconnect',
+      message: 'GitHub connection expired.',
+    });
+  });
+
+  it('keeps retryable kinds with surface-appropriate messages', () => {
+    const networkError = new Error('Network request failed');
+    const classification = classifyPrReviewMutationError(networkError);
+    expect(mutationErrorDisplay('composer', classification, networkError)).toEqual({
+      kind: 'retryable',
+      message: 'Network request failed',
+    });
+    expect(mutationErrorDisplay('composer', classification)).toEqual({
+      kind: 'retryable',
+      message: 'Could not post comment.',
+    });
+    expect(mutationErrorDisplay('submit', classification, networkError)).toEqual({
+      kind: 'retryable',
+      message: 'Could not submit review. Check your connection and try again.',
+    });
+  });
+
+  it('mutationErrorDisplayFromError classifies then selects', () => {
+    const serverMessage = 'Repository was archived so is read-only.';
+    expect(
+      mutationErrorDisplayFromError('composer', makeError('FORBIDDEN', serverMessage))
+    ).toEqual({
+      kind: 'forbidden',
+      message: serverMessage,
+    });
+  });
+});

--- a/apps/mobile/src/lib/pr-review/mutation-error-display.ts
+++ b/apps/mobile/src/lib/pr-review/mutation-error-display.ts
@@ -1,0 +1,69 @@
+// Pure selection of the inline mutation-error copy shown in the
+// comment-composer and review-submit formSheets. Classification lives in
+// `classifyPrReviewMutationError`; this helper maps kind → display message.
+//
+// FORBIDDEN always passes the server-provided classification.message
+// through verbatim (the server already sanitizes it to actionable copy).
+
+import { classifyPrReviewMutationError } from '@/lib/pr-review/classify-pr-review-query-state';
+
+type MutationErrorDisplaySurface = 'composer' | 'submit';
+
+type MutationErrorDisplayKind = 'retryable' | 'bad-request' | 'forbidden' | 'reconnect';
+
+type MutationErrorDisplay = {
+  kind: MutationErrorDisplayKind;
+  message: string;
+};
+
+const COMPOSER_BAD_REQUEST =
+  "This comment can't be posted. The selected line may have changed, or the PR may have been updated.";
+const SUBMIT_BAD_REQUEST =
+  "This review can't be submitted as is. The PR may have changed, or you can't approve your own pull request.";
+const COMPOSER_RETRYABLE_FALLBACK = 'Could not post comment.';
+const SUBMIT_RETRYABLE = 'Could not submit review. Check your connection and try again.';
+const RECONNECT_MESSAGE = 'GitHub connection expired.';
+
+type Classification = ReturnType<typeof classifyPrReviewMutationError>;
+
+/**
+ * Maps a mutation classification (and optional raw error for retryable
+ * composer copy) to the inline message the sheet should show.
+ */
+export function mutationErrorDisplay(
+  surface: MutationErrorDisplaySurface,
+  classification: Classification,
+  rawError?: unknown
+): MutationErrorDisplay {
+  if (classification.kind === 'forbidden') {
+    return { kind: 'forbidden', message: classification.message };
+  }
+  if (classification.kind === 'bad-request') {
+    return {
+      kind: 'bad-request',
+      message: surface === 'composer' ? COMPOSER_BAD_REQUEST : SUBMIT_BAD_REQUEST,
+    };
+  }
+  if (classification.kind === 'reconnect') {
+    return { kind: 'reconnect', message: RECONNECT_MESSAGE };
+  }
+  if (surface === 'submit') {
+    return { kind: 'retryable', message: SUBMIT_RETRYABLE };
+  }
+  const message =
+    rawError instanceof Error && rawError.message.length > 0
+      ? rawError.message
+      : COMPOSER_RETRYABLE_FALLBACK;
+  return { kind: 'retryable', message };
+}
+
+/**
+ * Classify + select display in one step. Convenience for call sites that
+ * only hold the thrown error.
+ */
+export function mutationErrorDisplayFromError(
+  surface: MutationErrorDisplaySurface,
+  error: unknown
+): MutationErrorDisplay {
+  return mutationErrorDisplay(surface, classifyPrReviewMutationError(error), error);
+}

--- a/apps/mobile/src/lib/pr-review/pr-link-helper-slot.test.ts
+++ b/apps/mobile/src/lib/pr-review/pr-link-helper-slot.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  PR_LINK_HELPER_CLIPBOARD_EMPTY_COPY,
+  PR_LINK_HELPER_INVALID_COPY,
+  selectPrLinkHelperSlotState,
+} from './pr-link-helper-slot';
+
+describe('selectPrLinkHelperSlotState', () => {
+  it('returns hint when the field is empty and no message is active', () => {
+    expect(selectPrLinkHelperSlotState({ hasInput: false, message: null })).toBe('hint');
+  });
+
+  it('returns none when the field has text and no message is active', () => {
+    expect(selectPrLinkHelperSlotState({ hasInput: true, message: null })).toBe('none');
+  });
+
+  it('returns invalid when the invalid message is active, regardless of input', () => {
+    expect(selectPrLinkHelperSlotState({ hasInput: false, message: 'invalid' })).toBe('invalid');
+    expect(selectPrLinkHelperSlotState({ hasInput: true, message: 'invalid' })).toBe('invalid');
+  });
+
+  it('returns clipboard-empty when that message is active, regardless of input', () => {
+    expect(selectPrLinkHelperSlotState({ hasInput: false, message: 'clipboard-empty' })).toBe(
+      'clipboard-empty'
+    );
+    expect(selectPrLinkHelperSlotState({ hasInput: true, message: 'clipboard-empty' })).toBe(
+      'clipboard-empty'
+    );
+  });
+
+  it('gives messages priority over hint and none (last-set wins at the call site)', () => {
+    // Single message field — whichever the UI last set is what we select.
+    expect(selectPrLinkHelperSlotState({ hasInput: false, message: 'invalid' })).toBe('invalid');
+    expect(selectPrLinkHelperSlotState({ hasInput: false, message: 'clipboard-empty' })).toBe(
+      'clipboard-empty'
+    );
+  });
+
+  it('exports the pinned helper copy strings', () => {
+    expect(PR_LINK_HELPER_INVALID_COPY).toBe('Not a GitHub pull request link');
+    expect(PR_LINK_HELPER_CLIPBOARD_EMPTY_COPY).toBe('Clipboard is empty');
+  });
+});

--- a/apps/mobile/src/lib/pr-review/pr-link-helper-slot.ts
+++ b/apps/mobile/src/lib/pr-review/pr-link-helper-slot.ts
@@ -1,0 +1,37 @@
+export type PrLinkHelperMessage = 'invalid' | 'clipboard-empty';
+
+type PrLinkHelperSlotState = 'invalid' | 'clipboard-empty' | 'hint' | 'none';
+
+type PrLinkHelperSlotInput = {
+  /** Whether the PR-link field currently has any text. */
+  readonly hasInput: boolean;
+  /**
+   * Active transient message. `invalid` and `clipboard-empty` are mutually
+   * exclusive at the call site (last-set wins); `null` means no message.
+   */
+  readonly message: PrLinkHelperMessage | null;
+};
+
+/**
+ * Select the reserved-height helper-slot content for the PR-link entry field.
+ *
+ * Priority: active message (invalid / clipboard-empty) wins over hint/none.
+ * Hint only when the field is empty and no message is active; none when the
+ * field has text and no message is active. The slot always keeps fixed height
+ * in the UI regardless of which state is selected.
+ */
+export function selectPrLinkHelperSlotState(input: PrLinkHelperSlotInput): PrLinkHelperSlotState {
+  if (input.message === 'invalid') {
+    return 'invalid';
+  }
+  if (input.message === 'clipboard-empty') {
+    return 'clipboard-empty';
+  }
+  if (!input.hasInput) {
+    return 'hint';
+  }
+  return 'none';
+}
+
+export const PR_LINK_HELPER_INVALID_COPY = 'Not a GitHub pull request link';
+export const PR_LINK_HELPER_CLIPBOARD_EMPTY_COPY = 'Clipboard is empty';

--- a/apps/mobile/src/lib/pr-review/pr-link-input-echo.test.ts
+++ b/apps/mobile/src/lib/pr-review/pr-link-input-echo.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  consumePrLinkInputEcho,
+  PR_LINK_INPUT_ECHO_FIFO_CAP,
+  pushPrLinkInputEcho,
+} from './pr-link-input-echo';
+
+describe('pushPrLinkInputEcho', () => {
+  it('appends the programmatic value to an empty FIFO', () => {
+    expect(pushPrLinkInputEcho([], 'a')).toEqual(['a']);
+  });
+
+  it('appends without dropping while under the cap', () => {
+    expect(pushPrLinkInputEcho(['a', 'b'], 'c')).toEqual(['a', 'b', 'c']);
+  });
+
+  it('evicts the oldest entries when the FIFO exceeds the cap', () => {
+    const full = ['a', 'b', 'c', 'd'];
+    expect(full).toHaveLength(PR_LINK_INPUT_ECHO_FIFO_CAP);
+    expect(pushPrLinkInputEcho(full, 'e')).toEqual(['b', 'c', 'd', 'e']);
+    expect(pushPrLinkInputEcho(['1', '2', '3', '4', '5'], '6', 4)).toEqual(['3', '4', '5', '6']);
+  });
+});
+
+describe('consumePrLinkInputEcho', () => {
+  it('treats a single paste echo as programmatic and removes it', () => {
+    const result = consumePrLinkInputEcho(['pasted'], 'pasted');
+    expect(result).toEqual({ kind: 'echo', pending: [] });
+  });
+
+  it('consumes both echoes from a double-paste of the same value', () => {
+    let pending = pushPrLinkInputEcho([], 'same');
+    pending = pushPrLinkInputEcho(pending, 'same');
+    expect(pending).toEqual(['same', 'same']);
+
+    const first = consumePrLinkInputEcho(pending, 'same');
+    expect(first).toEqual({ kind: 'echo', pending: ['same'] });
+
+    const second = consumePrLinkInputEcho(first.pending, 'same');
+    expect(second).toEqual({ kind: 'echo', pending: [] });
+  });
+
+  it('consumes out-of-order echoes of two different pastes', () => {
+    let pending = pushPrLinkInputEcho([], 'older');
+    pending = pushPrLinkInputEcho(pending, 'newer');
+
+    // Delayed native echo of the newer write arrives first.
+    const first = consumePrLinkInputEcho(pending, 'newer');
+    expect(first).toEqual({ kind: 'echo', pending: ['older'] });
+
+    const second = consumePrLinkInputEcho(first.pending, 'older');
+    expect(second).toEqual({ kind: 'echo', pending: [] });
+  });
+
+  it('classifies a real edit without draining later echoes', () => {
+    const pending = pushPrLinkInputEcho([], 'pasted');
+
+    const edit = consumePrLinkInputEcho(pending, 'user typed');
+    expect(edit).toEqual({ kind: 'edit', pending: ['pasted'] });
+
+    // Later echo of the earlier paste is still consumed (must not clobber
+    // inputValueRef at the call site — covered by kind === 'echo').
+    const echo = consumePrLinkInputEcho(edit.pending, 'pasted');
+    expect(echo).toEqual({ kind: 'echo', pending: [] });
+  });
+
+  it('does not treat an unmatched value as an echo even when the FIFO is non-empty', () => {
+    expect(consumePrLinkInputEcho(['a', 'b'], 'c')).toEqual({
+      kind: 'edit',
+      pending: ['a', 'b'],
+    });
+  });
+});

--- a/apps/mobile/src/lib/pr-review/pr-link-input-echo.ts
+++ b/apps/mobile/src/lib/pr-review/pr-link-input-echo.ts
@@ -1,0 +1,45 @@
+/** Max pending programmatic `setNativeProps` values retained for echo matching. */
+export const PR_LINK_INPUT_ECHO_FIFO_CAP = 4;
+
+type ConsumePrLinkInputEchoResult =
+  | { kind: 'echo'; pending: readonly string[] }
+  | { kind: 'edit'; pending: readonly string[] };
+
+/**
+ * Record a value about to be written via `setNativeProps`.
+ * Drops the oldest entries when the FIFO exceeds `cap` so delayed
+ * native echoes remain matchable without unbounded growth.
+ */
+export function pushPrLinkInputEcho(
+  pending: readonly string[],
+  text: string,
+  cap: number = PR_LINK_INPUT_ECHO_FIFO_CAP
+): string[] {
+  const next = [...pending, text];
+  if (next.length <= cap) {
+    return next;
+  }
+  return next.slice(next.length - cap);
+}
+
+/**
+ * Classify an `onChangeText` value against pending programmatic writes.
+ *
+ * - Membership match → programmatic echo: remove that one entry (first match),
+ *   leave remaining pending intact so later/out-of-order echoes still match.
+ * - No match → real user edit: leave the FIFO unchanged so a delayed echo of an
+ *   earlier paste is still consumed and cannot clobber the newer edit.
+ */
+export function consumePrLinkInputEcho(
+  pending: readonly string[],
+  value: string
+): ConsumePrLinkInputEchoResult {
+  const index = pending.indexOf(value);
+  if (index === -1) {
+    return { kind: 'edit', pending };
+  }
+  return {
+    kind: 'echo',
+    pending: [...pending.slice(0, index), ...pending.slice(index + 1)],
+  };
+}

--- a/apps/mobile/src/lib/pr-review/pr-link-paste.test.ts
+++ b/apps/mobile/src/lib/pr-review/pr-link-paste.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { decidePrLinkPaste } from './pr-link-paste';
+
+describe('decidePrLinkPaste', () => {
+  it('returns empty for null, undefined, blank, and whitespace-only clipboard', () => {
+    expect(decidePrLinkPaste(null)).toEqual({ kind: 'empty' });
+    expect(decidePrLinkPaste(undefined)).toEqual({ kind: 'empty' });
+    expect(decidePrLinkPaste('')).toEqual({ kind: 'empty' });
+    expect(decidePrLinkPaste('   \n\t  ')).toEqual({ kind: 'empty' });
+  });
+
+  it('returns valid-pr-url with trimmed text for a GitHub PR link', () => {
+    const url = 'https://github.com/octocat/hello-world/pull/42';
+    expect(decidePrLinkPaste(`  ${url}  `)).toEqual({
+      kind: 'valid-pr-url',
+      text: url,
+    });
+  });
+
+  it('returns valid-pr-url for PR URLs with subpaths and query strings', () => {
+    const url = 'https://github.com/octocat/hello-world/pull/42/files?diff=split';
+    expect(decidePrLinkPaste(url)).toEqual({
+      kind: 'valid-pr-url',
+      text: url,
+    });
+  });
+
+  it('returns non-url-text with trimmed text for non-PR content', () => {
+    expect(decidePrLinkPaste('  not a url  ')).toEqual({
+      kind: 'non-url-text',
+      text: 'not a url',
+    });
+    expect(decidePrLinkPaste('https://github.com/octocat/hello-world/issues/1')).toEqual({
+      kind: 'non-url-text',
+      text: 'https://github.com/octocat/hello-world/issues/1',
+    });
+    expect(decidePrLinkPaste('https://gitlab.com/o/r/pull/1')).toEqual({
+      kind: 'non-url-text',
+      text: 'https://gitlab.com/o/r/pull/1',
+    });
+  });
+});

--- a/apps/mobile/src/lib/pr-review/pr-link-paste.ts
+++ b/apps/mobile/src/lib/pr-review/pr-link-paste.ts
@@ -1,0 +1,22 @@
+import { parseGitHubPrUrl } from '@/lib/github-pr-url';
+
+type PrLinkPasteDecision =
+  | { kind: 'valid-pr-url'; text: string }
+  | { kind: 'non-url-text'; text: string }
+  | { kind: 'empty' };
+
+/**
+ * Decide how a paste-button tap should treat clipboard contents.
+ * Trims first; empty → no insertion; valid PR URL → replace + navigate;
+ * anything else → replace + invalid helper.
+ */
+export function decidePrLinkPaste(clipboard: string | null | undefined): PrLinkPasteDecision {
+  const text = (clipboard ?? '').trim();
+  if (text.length === 0) {
+    return { kind: 'empty' };
+  }
+  if (parseGitHubPrUrl(text) !== null) {
+    return { kind: 'valid-pr-url', text };
+  }
+  return { kind: 'non-url-text', text };
+}

--- a/apps/web/src/lib/github-pr-review/errors.test.ts
+++ b/apps/web/src/lib/github-pr-review/errors.test.ts
@@ -65,12 +65,35 @@ describe('classifyGitHubHttpError', () => {
     expect(result.code).toBe('TOO_MANY_REQUESTS');
   });
 
-  it('maps non-rate-limit 403 to FORBIDDEN preserving GitHub message', () => {
+  it('maps integration-access 403 to FORBIDDEN with actionable install message', () => {
     const result = classifyGitHubHttpError(
       httpError(403, 'Resource not accessible by integration')
     );
     expect(result.code).toBe('FORBIDDEN');
-    expect(result.message).toBe('Resource not accessible by integration');
+    expect(result.message).toBe(
+      "The Kilo GitHub App can't write to this repository. An owner of the repository's organization must install the Kilo app (or approve its updated permissions), then try again."
+    );
+  });
+
+  it('maps other non-rate-limit 403 to FORBIDDEN preserving GitHub message', () => {
+    const result = classifyGitHubHttpError(
+      httpError(403, 'Repository was archived so is read-only.')
+    );
+    expect(result.code).toBe('FORBIDDEN');
+    expect(result.message).toBe('Repository was archived so is read-only.');
+  });
+
+  it('prefers rate-limit classification over integration-access wording on 403', () => {
+    const resetSeconds = Math.floor(NOW / 1000) + 60;
+    const result = classifyGitHubHttpError(
+      httpError(403, 'Resource not accessible by integration', {
+        'x-ratelimit-remaining': '0',
+        'x-ratelimit-reset': String(resetSeconds),
+      }),
+      NOW
+    );
+    expect(result.code).toBe('TOO_MANY_REQUESTS');
+    expect(result.retryAfterEpochMs).toBe(resetSeconds * 1000);
   });
 
   it('maps 422 stale line comment shape to BAD_REQUEST', () => {
@@ -156,16 +179,31 @@ describe('classifyGitHubGraphQlErrors', () => {
     );
   });
 
-  it('maps GraphQL FORBIDDEN to FORBIDDEN preserving message', () => {
+  it('maps GraphQL integration-access FORBIDDEN to actionable install message', () => {
     const result = classifyGitHubGraphQlErrors([
       { type: 'FORBIDDEN', message: 'Resource not accessible by integration' },
     ]);
     expect(result?.code).toBe('FORBIDDEN');
-    expect(result?.message).toBe('Resource not accessible by integration');
+    expect(result?.message).toBe(
+      "The Kilo GitHub App can't write to this repository. An owner of the repository's organization must install the Kilo app (or approve its updated permissions), then try again."
+    );
+  });
+
+  it('maps other GraphQL FORBIDDEN to FORBIDDEN preserving message', () => {
+    const result = classifyGitHubGraphQlErrors([{ type: 'FORBIDDEN', message: 'no push access' }]);
+    expect(result?.code).toBe('FORBIDDEN');
+    expect(result?.message).toBe('no push access');
   });
 
   it('maps GraphQL RATE_LIMITED to TOO_MANY_REQUESTS', () => {
     const result = classifyGitHubGraphQlErrors([{ type: 'RATE_LIMITED', message: 'rate limit' }]);
+    expect(result?.code).toBe('TOO_MANY_REQUESTS');
+  });
+
+  it('maps GraphQL RATE_LIMITED even when message mentions integration access', () => {
+    const result = classifyGitHubGraphQlErrors([
+      { type: 'RATE_LIMITED', message: 'Resource not accessible by integration' },
+    ]);
     expect(result?.code).toBe('TOO_MANY_REQUESTS');
   });
 

--- a/apps/web/src/lib/github-pr-review/errors.test.ts
+++ b/apps/web/src/lib/github-pr-review/errors.test.ts
@@ -3,18 +3,24 @@ import { classifyGitHubHttpError, classifyGitHubGraphQlErrors } from './errors';
 function httpError(
   status: number,
   message: string,
-  headers?: Record<string, string>
+  options?: {
+    headers?: Record<string, string>;
+    data?: unknown;
+  }
 ): Error & {
   status: number;
-  response?: { headers?: Record<string, string> };
+  response?: { headers?: Record<string, string>; data?: unknown };
 } {
   const err = new Error(message) as Error & {
     status: number;
-    response?: { headers?: Record<string, string> };
+    response?: { headers?: Record<string, string>; data?: unknown };
   };
   err.status = status;
-  if (headers) {
-    err.response = { headers };
+  if (options?.headers || options?.data !== undefined) {
+    err.response = {
+      ...(options.headers ? { headers: options.headers } : {}),
+      ...(options.data !== undefined ? { data: options.data } : {}),
+    };
   }
   return err;
 }
@@ -40,8 +46,10 @@ describe('classifyGitHubHttpError', () => {
     const resetSeconds = Math.floor(NOW / 1000) + 600;
     const result = classifyGitHubHttpError(
       httpError(403, 'API rate limit exceeded', {
-        'x-ratelimit-remaining': '0',
-        'x-ratelimit-reset': String(resetSeconds),
+        headers: {
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': String(resetSeconds),
+        },
       }),
       NOW
     );
@@ -53,7 +61,7 @@ describe('classifyGitHubHttpError', () => {
 
   it('maps 403 retry-after (delta seconds) to an absolute epoch relative to now', () => {
     const result = classifyGitHubHttpError(
-      httpError(403, 'Secondary rate limit', { 'retry-after': '120' }),
+      httpError(403, 'Secondary rate limit', { headers: { 'retry-after': '120' } }),
       NOW
     );
     expect(result.code).toBe('TOO_MANY_REQUESTS');
@@ -87,13 +95,33 @@ describe('classifyGitHubHttpError', () => {
     const resetSeconds = Math.floor(NOW / 1000) + 60;
     const result = classifyGitHubHttpError(
       httpError(403, 'Resource not accessible by integration', {
-        'x-ratelimit-remaining': '0',
-        'x-ratelimit-reset': String(resetSeconds),
+        headers: {
+          'x-ratelimit-remaining': '0',
+          'x-ratelimit-reset': String(resetSeconds),
+        },
       }),
       NOW
     );
     expect(result.code).toBe('TOO_MANY_REQUESTS');
     expect(result.retryAfterEpochMs).toBe(resetSeconds * 1000);
+  });
+
+  it('maps 422 lock-prevents-review to FORBIDDEN with archived read-only message', () => {
+    const result = classifyGitHubHttpError(
+      httpError(422, 'Unprocessable Entity', {
+        data: { message: 'Unprocessable Entity', errors: ['lock prevents review'] },
+      })
+    );
+    expect(result.code).toBe('FORBIDDEN');
+    expect(result.message).toBe('Repository was archived so is read-only.');
+  });
+
+  it('maps 422 with archived message in body to FORBIDDEN with canonical archived message', () => {
+    const result = classifyGitHubHttpError(
+      httpError(422, 'Repository was archived so is read-only.')
+    );
+    expect(result.code).toBe('FORBIDDEN');
+    expect(result.message).toBe('Repository was archived so is read-only.');
   });
 
   it('maps 422 stale line comment shape to BAD_REQUEST', () => {

--- a/apps/web/src/lib/github-pr-review/errors.ts
+++ b/apps/web/src/lib/github-pr-review/errors.ts
@@ -94,6 +94,10 @@ const FALLBACK_FORBIDDEN = 'You do not have permission to perform this action on
 const FALLBACK_BAD_REQUEST = 'GitHub rejected this request';
 const FALLBACK_CONFLICT = 'GitHub reported a conflict for this PR';
 const FALLBACK_BAD_GATEWAY = 'GitHub returned an unexpected error';
+// Canonical sentence GitHub returns on comments/writes to archived repos (403).
+// Reviews on the same repos often 422 with `lock prevents review` instead — map both
+// to this message so submit and composer share identical FORBIDDEN UX.
+const ARCHIVED_READ_ONLY_MESSAGE = 'Repository was archived so is read-only.';
 // GitHub App user-to-server tokens read public repos fine but 403 on writes when
 // the app installation is missing, excludes the repo, or lacks PR write.
 const INTEGRATION_ACCESS_FORBIDDEN_MESSAGE =
@@ -104,6 +108,30 @@ function forbiddenMessageFromGitHub(message: string): string {
     return INTEGRATION_ACCESS_FORBIDDEN_MESSAGE;
   }
   return message || FALLBACK_FORBIDDEN;
+}
+
+/** String entries from Octokit `response.data.errors` (GitHub 422 bodies). */
+function responseDataErrorStrings(data: unknown): string[] {
+  if (typeof data !== 'object' || data === null) return [];
+  const errors = (data as { errors?: unknown }).errors;
+  if (!Array.isArray(errors)) return [];
+  return errors.filter((entry): entry is string => typeof entry === 'string');
+}
+
+/**
+ * Archived/read-only write failures: comments 403 with the canonical sentence;
+ * review create/submit often 422 with `errors: ["lock prevents review"]`.
+ * Match only that phrase (and the archived message) so genuine validation 422s
+ * (stale line, own-PR approve, missing fields, thread lock failed, etc.) stay BAD_REQUEST.
+ */
+function isArchivedReadOnlySignal(message: string, data: unknown): boolean {
+  const lowerMessage = message.toLowerCase();
+  if (lowerMessage.includes('repository was archived so is read-only')) {
+    return true;
+  }
+  return responseDataErrorStrings(data).some(entry =>
+    entry.toLowerCase().includes('lock prevents review')
+  );
 }
 
 export function classifyGitHubHttpError(
@@ -124,6 +152,9 @@ export function classifyGitHubHttpError(
     return { code: 'PRECONDITION_FAILED', message: PRECONDITION_FAILED_MESSAGE };
   }
   if (status === 422) {
+    if (isArchivedReadOnlySignal(message, error.response?.data)) {
+      return { code: 'FORBIDDEN', message: ARCHIVED_READ_ONLY_MESSAGE };
+    }
     return { code: 'BAD_REQUEST', message: message || FALLBACK_BAD_REQUEST };
   }
   if (status === 405 || status === 409) {

--- a/apps/web/src/lib/github-pr-review/errors.ts
+++ b/apps/web/src/lib/github-pr-review/errors.ts
@@ -94,6 +94,17 @@ const FALLBACK_FORBIDDEN = 'You do not have permission to perform this action on
 const FALLBACK_BAD_REQUEST = 'GitHub rejected this request';
 const FALLBACK_CONFLICT = 'GitHub reported a conflict for this PR';
 const FALLBACK_BAD_GATEWAY = 'GitHub returned an unexpected error';
+// GitHub App user-to-server tokens read public repos fine but 403 on writes when
+// the app installation is missing, excludes the repo, or lacks PR write.
+const INTEGRATION_ACCESS_FORBIDDEN_MESSAGE =
+  "The Kilo GitHub App can't write to this repository. An owner of the repository's organization must install the Kilo app (or approve its updated permissions), then try again.";
+
+function forbiddenMessageFromGitHub(message: string): string {
+  if (message.includes('Resource not accessible by integration')) {
+    return INTEGRATION_ACCESS_FORBIDDEN_MESSAGE;
+  }
+  return message || FALLBACK_FORBIDDEN;
+}
 
 export function classifyGitHubHttpError(
   error: unknown,
@@ -126,7 +137,7 @@ export function classifyGitHubHttpError(
         retryAfterEpochMs: retryAfterEpochMs(headers, now),
       };
     }
-    return { code: 'FORBIDDEN', message: message || FALLBACK_FORBIDDEN };
+    return { code: 'FORBIDDEN', message: forbiddenMessageFromGitHub(message) };
   }
   if (status >= 500) {
     return { code: 'BAD_GATEWAY', message: message || FALLBACK_BAD_GATEWAY };
@@ -146,7 +157,7 @@ function classifyGraphQlEntry(entry: GraphQlErrorEntry, now: number): Classified
     return { code: 'NOT_FOUND', message: NOT_FOUND_MESSAGE };
   }
   if (type === 'FORBIDDEN') {
-    return { code: 'FORBIDDEN', message: message || FALLBACK_FORBIDDEN };
+    return { code: 'FORBIDDEN', message: forbiddenMessageFromGitHub(message ?? '') };
   }
   if (type === 'RATE_LIMITED' || type === 'SECONDARY_RATE_LIMIT' || type === 'ABUSE_DETECTION') {
     return { code: 'TOO_MANY_REQUESTS', message: rateLimitMessage(undefined, now) };

--- a/apps/web/src/lib/github-pr-review/review-thread-comments.test.ts
+++ b/apps/web/src/lib/github-pr-review/review-thread-comments.test.ts
@@ -6,14 +6,31 @@ import {
   REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY_FOR_TEST,
 } from '@/routers/github-pr-review-router';
 
-function commentNode(id: number) {
+function commentNode(
+  id: number,
+  reactionGroups?: Array<{
+    content: string;
+    viewerHasReacted: boolean;
+    reactors: { totalCount: number };
+  }>
+) {
   return {
     databaseId: id,
     id: `node_${id}`,
     body: `comment ${id}`,
     createdAt: '2024-01-01T00:00:00Z',
     author: { login: 'octocat', avatarUrl: 'https://x/y.png' },
-    reactions: { nodes: [] },
+    // Live GitHub shape: unpaginated reactionGroups list (all group types).
+    reactionGroups: reactionGroups ?? [
+      { content: 'THUMBS_UP', viewerHasReacted: false, reactors: { totalCount: 0 } },
+      { content: 'THUMBS_DOWN', viewerHasReacted: false, reactors: { totalCount: 0 } },
+      { content: 'LAUGH', viewerHasReacted: false, reactors: { totalCount: 0 } },
+      { content: 'HOORAY', viewerHasReacted: false, reactors: { totalCount: 0 } },
+      { content: 'CONFUSED', viewerHasReacted: false, reactors: { totalCount: 0 } },
+      { content: 'HEART', viewerHasReacted: false, reactors: { totalCount: 0 } },
+      { content: 'ROCKET', viewerHasReacted: false, reactors: { totalCount: 0 } },
+      { content: 'EYES', viewerHasReacted: false, reactors: { totalCount: 0 } },
+    ],
   };
 }
 
@@ -61,6 +78,8 @@ describe('fetchAllThreadComments', () => {
 
     // All three pages aggregated to completion — no silent truncation.
     expect(comments.map(c => c.databaseId)).toEqual([1, 2, 3]);
+    // Zero-count reactionGroups are dropped; DTO reactions stay empty.
+    expect(comments.map(c => c.reactions)).toEqual([[], [], []]);
     expect(request).toHaveBeenCalledTimes(2);
 
     // GraphQL variables must be nested under `variables` (GitHub — and a
@@ -79,5 +98,32 @@ describe('fetchAllThreadComments', () => {
       { variables: Record<string, unknown> },
     ];
     expect(secondArgs.variables.after).toBe('c2');
+  });
+
+  it('keeps only reactionGroups with totalCount > 0 in the DTO shape', async () => {
+    const comments = await fetchAllThreadComments({
+      octokit: { request: jest.fn() } as never,
+      threadId: 'thread_1',
+      initialConnection: {
+        pageInfo: { hasNextPage: false, endCursor: null },
+        nodes: [
+          commentNode(1, [
+            { content: 'THUMBS_UP', viewerHasReacted: true, reactors: { totalCount: 3 } },
+            { content: 'THUMBS_DOWN', viewerHasReacted: false, reactors: { totalCount: 0 } },
+            { content: 'LAUGH', viewerHasReacted: false, reactors: { totalCount: 0 } },
+            { content: 'HOORAY', viewerHasReacted: false, reactors: { totalCount: 0 } },
+            { content: 'CONFUSED', viewerHasReacted: false, reactors: { totalCount: 0 } },
+            { content: 'HEART', viewerHasReacted: false, reactors: { totalCount: 1 } },
+            { content: 'ROCKET', viewerHasReacted: false, reactors: { totalCount: 0 } },
+            { content: 'EYES', viewerHasReacted: false, reactors: { totalCount: 0 } },
+          ]),
+        ],
+      },
+    });
+
+    expect(comments[0]?.reactions).toEqual([
+      { content: 'THUMBS_UP', count: 3, viewerHasReacted: true },
+      { content: 'HEART', count: 1, viewerHasReacted: false },
+    ]);
   });
 });

--- a/apps/web/src/routers/github-pr-review-router.test.ts
+++ b/apps/web/src/routers/github-pr-review-router.test.ts
@@ -199,6 +199,106 @@ describe('githubPrReviewRouter infinite-query inputs accept the tRPC direction f
       caller.listReviewThreads({ owner: 'octocat', repo: 'hello', number: 1, direction: 'forward' })
     ).resolves.toBeDefined();
   });
+
+  it('listReviewThreads maps reactionGroups to non-zero DTO reactions only', async () => {
+    getGitHubUserAccessToken.mockResolvedValueOnce(connected('t1', 'auth_1', 1));
+    const caller = createCaller({ user: { id: 'user-1' } as User });
+    buildOctokit('t1').request.mockResolvedValue({
+      data: {
+        data: {
+          repository: {
+            pullRequest: {
+              reviewThreads: {
+                pageInfo: { hasNextPage: false, endCursor: null },
+                nodes: [
+                  {
+                    id: 'PRRT_1',
+                    isResolved: false,
+                    isOutdated: false,
+                    subjectType: 'LINE',
+                    path: 'src/foo.ts',
+                    line: 4,
+                    startLine: null,
+                    originalLine: 4,
+                    originalStartLine: null,
+                    diffSide: 'RIGHT',
+                    comments: {
+                      pageInfo: { hasNextPage: false, endCursor: null },
+                      nodes: [
+                        {
+                          databaseId: 11,
+                          id: 'PRRC_11',
+                          body: 'nit',
+                          createdAt: '2024-01-01T00:00:00Z',
+                          author: { login: 'octocat', avatarUrl: 'https://x/y.png' },
+                          // Live schema: all group types present; zero-count filtered out.
+                          reactionGroups: [
+                            {
+                              content: 'THUMBS_UP',
+                              viewerHasReacted: true,
+                              reactors: { totalCount: 2 },
+                            },
+                            {
+                              content: 'THUMBS_DOWN',
+                              viewerHasReacted: false,
+                              reactors: { totalCount: 0 },
+                            },
+                            {
+                              content: 'LAUGH',
+                              viewerHasReacted: false,
+                              reactors: { totalCount: 0 },
+                            },
+                            {
+                              content: 'HOORAY',
+                              viewerHasReacted: false,
+                              reactors: { totalCount: 0 },
+                            },
+                            {
+                              content: 'CONFUSED',
+                              viewerHasReacted: false,
+                              reactors: { totalCount: 0 },
+                            },
+                            {
+                              content: 'HEART',
+                              viewerHasReacted: false,
+                              reactors: { totalCount: 1 },
+                            },
+                            {
+                              content: 'ROCKET',
+                              viewerHasReacted: false,
+                              reactors: { totalCount: 0 },
+                            },
+                            {
+                              content: 'EYES',
+                              viewerHasReacted: false,
+                              reactors: { totalCount: 0 },
+                            },
+                          ],
+                        },
+                      ],
+                    },
+                  },
+                ],
+              },
+            },
+          },
+        },
+      },
+    });
+
+    const result = await caller.listReviewThreads({
+      owner: 'octocat',
+      repo: 'hello',
+      number: 1,
+      direction: 'forward',
+    });
+
+    expect(result.threads).toHaveLength(1);
+    expect(result.threads[0]?.comments[0]?.reactions).toEqual([
+      { content: 'THUMBS_UP', count: 2, viewerHasReacted: true },
+      { content: 'HEART', count: 1, viewerHasReacted: false },
+    ]);
+  });
 });
 
 describe('githubPrReviewRouter mutations go through withGitHubUserTokenRetry', () => {

--- a/apps/web/src/routers/github-pr-review-router.ts
+++ b/apps/web/src/routers/github-pr-review-router.ts
@@ -226,13 +226,11 @@ const REVIEW_THREADS_QUERY = /* GraphQL */ `
                   login
                   avatarUrl
                 }
-                reactions(first: 20) {
-                  nodes {
-                    content
-                    count: reactors(first: 0) {
-                      totalCount
-                    }
-                    viewerHasReacted
+                reactionGroups {
+                  content
+                  viewerHasReacted
+                  reactors(first: 0) {
+                    totalCount
                   }
                 }
               }
@@ -262,13 +260,11 @@ const REVIEW_THREAD_COMMENTS_FOLLOWUP_QUERY = /* GraphQL */ `
               login
               avatarUrl
             }
-            reactions(first: 20) {
-              nodes {
-                content
-                count: reactors(first: 0) {
-                  totalCount
-                }
-                viewerHasReacted
+            reactionGroups {
+              content
+              viewerHasReacted
+              reactors(first: 0) {
+                totalCount
               }
             }
           }
@@ -340,10 +336,12 @@ const REMOVE_REACTION_MUTATION = /* GraphQL */ `
   }
 `;
 
-type GraphQlReactionNode = {
+// Mirrors GitHub's ReactionGroup (not Reaction): reactionGroups is an
+// unpaginated list of all group types; only groups with totalCount > 0 are kept.
+type GraphQlReactionGroup = {
   content: string;
-  count?: { totalCount: number } | null;
   viewerHasReacted: boolean;
+  reactors?: { totalCount: number } | null;
 };
 
 type GraphQlCommentNode = {
@@ -352,7 +350,7 @@ type GraphQlCommentNode = {
   body: string;
   createdAt: string;
   author: { login: string; avatarUrl: string } | null;
-  reactions: { nodes: GraphQlReactionNode[] };
+  reactionGroups: GraphQlReactionGroup[];
 };
 
 type GraphQlCommentConnection = {
@@ -374,12 +372,14 @@ type GraphQlReviewThreadNode = {
   comments: GraphQlCommentConnection;
 };
 
-function normalizeReactions(nodes: GraphQlReactionNode[]) {
-  return nodes.map(n => ({
-    content: n.content,
-    count: n.count?.totalCount ?? 0,
-    viewerHasReacted: Boolean(n.viewerHasReacted),
-  }));
+function normalizeReactions(groups: GraphQlReactionGroup[]) {
+  return groups
+    .map(g => ({
+      content: g.content,
+      count: g.reactors?.totalCount ?? 0,
+      viewerHasReacted: Boolean(g.viewerHasReacted),
+    }))
+    .filter(r => r.count > 0);
 }
 
 function normalizeComment(node: GraphQlCommentNode) {
@@ -389,7 +389,7 @@ function normalizeComment(node: GraphQlCommentNode) {
     body: node.body,
     createdAt: node.createdAt,
     author: node.author,
-    reactions: normalizeReactions(node.reactions?.nodes ?? []),
+    reactions: normalizeReactions(node.reactionGroups ?? []),
   };
 }
 


### PR DESCRIPTION
## Summary

Thirteen reported mobile PR-review defects (D1–D13), root-caused against baseline `b17c7c08c` and fixed in six scoped commits. Repro evidence and verdicts were captured on-device before implementation.

### Entry screen & connect gate
- **D1** Connect/reconnect empty state sat +37pt below the visible safe-area center — body now pads the bottom safe-area inset and the cluster is optically centered (`pb-[72px]` lifts the stack by half the icon block).
- **D2/D4** No paste affordance on the PR-link input — new paste button (a11y `Paste pull request link`) reads the clipboard, REPLACES the field content, and navigates through the same submit path as `Open`; empty clipboard shows a transient "Clipboard is empty" hint.
- **D3** "Paste a link like …" hint unmounted on first keystroke, shifting `Open`/Recent ±24pt — all helper messaging now lives in ONE reserved-height slot with a pure four-state selector (`hint` / `invalid` / `clipboard-empty` / `none`).

### Files list
- **D5 (preventive)** `usePrReviewViewedFiles` returned a fresh object every render, forcing full `items` rebuilds and new FlashList `data` identities on every render; pages were flattened without dedupe. Identities are now memoized and pages deduped by path (first wins).
- **D7** First open of the Files tab landed ~45% mid-list — the list now scrolls to offset 0 on the first `files.length > 0` transition per mount (covers cold loads and warm-cache remounts), and navigator scroll-to-file requests survive the query-data → items rebuild race (pending/supersede/cancel, unit-tested).
- **D6 investigated:** the list already lazy-loads (50-file pages, diffs render only when expanded). Splitting patches into per-file requests is a non-goal (would multiply request count ~50×).

### File rows
- **D8** Only the 28×28 chevron toggled expand — the whole row body (chevron + status + path/stats) is now one pressable; `patchMissing` rows stay non-expandable.
- **D9** `Mark viewed` ↔ `Viewed` text swap reflowed the path (+27pt) — replaced with a fixed `h-9 w-9` icon toggle (`EyeOff`/`Eye`, checkbox semantics, selection haptic kept) on all three surfaces (file row, patch-missing row, navigator row, the last as a non-nested sibling of the select pressable).

### Review comments
- **D11** Pending review comments were view-only — the submit sheet now lists each queued comment (mono `path:L<line>` label + excerpt), pushes the composer as a sibling formSheet in edit mode (seeded body, `Save` → `updateComment`, discard-alert parity with create mode), and deletes via confirmed alert.
- **D10** "Resource not accessible by integration" (GitHub App user-to-server token ∩ missing installation with PR write) — the server now maps that 403 to actionable copy in BOTH the HTTP and GraphQL classifiers ("The Kilo GitHub App can't write to this repository. An owner of the repository's organization must install the Kilo app (or approve its updated permissions), then try again."), and both mobile sheets display the server-provided message verbatim with the primary action disabled for the rest of the sheet session (`bad-request` still re-enables on edit).

### Discussion tab
- **D12** Discussion tab 502'd on every PR: both GraphQL queries selected `reactions { … reactors }`, but `Reaction` has no `reactors` field in the live schema. Now selecting `reactionGroups { content viewerHasReacted reactors(first: 0) { totalCount } }`, keeping only groups with `totalCount > 0` — DTO shape unchanged.

### D13 — rate-limit investigation (no change required)
214-file PR full browse ≈ 8 GitHub calls (3 overview + 5 files pages) + 1 GraphQL (+ rare follow-ups) for discussion; writes are 1 call each; viewed-state is local. Budgets (5k req/h REST, 5k pt/h GraphQL) are nowhere close; pagination bounds the fan-out; 403/429 + GraphQL `RATE_LIMITED` are already classified `TOO_MANY_REQUESTS` with retry-after and the client shows a retryable state.

## Test plan
- New/updated unit tests: paste-decision helper, helper-slot selector, dedupe helper, pending-scroll helper, composer `pendingId` param parsing, mutation-error display helper, reactionGroups router/fixtures, integration-403 mapping (HTTP + GraphQL classifiers).
- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` green in apps/mobile; root `pnpm validate` green (687 suites / 9330 tests).
- On-device E2E (iPhone 17 Pro, Maestro): connect/reconnect centering, paste flows, helper-slot CLS, files-list first-open-at-top + pagination + duplicate-path guard, row expand/collapse, mark-viewed reflow, navigator jump, pending-comment view/edit/delete, submit happy path on a sandbox PR, FORBIDDEN class on an archived repo, discussion empty + thread rendering.