### PR TITLE
fix(ai-gateway): rewrite Kilo org responses

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -985,7 +985,8 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     response,
     effectiveModelIdLowerCased,
     effectiveProviderContext.provider.id,
-    requestBodyParsed.kind
+    requestBodyParsed.kind,
+    organizationId
   );
   if (rewrittenResponse) {
     return rewrittenResponse;

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -3,7 +3,9 @@ import {
   rewriteModelResponse_ChatCompletions,
   rewriteModelResponse_Messages,
   rewriteModelResponse_Responses,
+  rewriteModelResponse,
 } from './rewriteModelResponse';
+import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -161,7 +163,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
       const upstream = failingResponse(
         'text/event-stream',
         errorName,
-        'data: {"model":"upstream-model","choices":[]}\n\n'
+        'data: {"id":"gen-chat","model":"upstream-model","choices":[]}\n\n'
       );
 
       const result = await rewriteModelResponse_ChatCompletions(upstream);
@@ -169,6 +171,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
       const events = dataObjects(sse) as Array<{ error?: { code: number; type: string } }>;
 
       expect(events[0]).toMatchObject({ model: 'upstream-model' });
+      expect(events[1]).toMatchObject({ id: 'gen-chat' });
       expect(events[1]?.error).toMatchObject({ code: 503, type: errorType });
       expect(dataPayloads(sse)).not.toContain('[DONE]');
     });
@@ -246,13 +249,25 @@ describe('rewriteModelResponse_Messages', () => {
     ['TimeoutError', 'timeout'],
   ])('emits an Anthropic SSE error for %s', async (errorName, errorType) => {
     const result = await rewriteModelResponse_Messages(
-      failingResponse('text/event-stream', errorName)
+      failingResponse(
+        'text/event-stream',
+        errorName,
+        'data: {"type":"message_start","message":{"id":"gen-message","usage":{"input_tokens":1,"output_tokens":0}}}\n\n'
+      )
     );
     const sse = await readOutputStream(result);
 
     expect(sse).toContain('event: error\n');
     expect(dataObjects(sse)).toEqual([
       {
+        type: 'message_start',
+        message: {
+          id: 'gen-message',
+          usage: { input_tokens: 1, output_tokens: 0 },
+        },
+      },
+      {
+        id: 'gen-message',
         type: 'error',
         error: {
           type: 'api_error',
@@ -347,13 +362,22 @@ describe('rewriteModelResponse_Responses', () => {
     ['TimeoutError', 'timeout'],
   ])('emits an OpenAI Responses SSE error for %s', async (errorName, errorType) => {
     const result = await rewriteModelResponse_Responses(
-      failingResponse('text/event-stream', errorName)
+      failingResponse(
+        'text/event-stream',
+        errorName,
+        'data: {"type":"response.created","response":{"id":"gen-response"}}\n\n'
+      )
     );
     const sse = await readOutputStream(result);
 
     expect(sse).toContain('event: error\n');
     expect(dataObjects(sse)).toEqual([
       {
+        type: 'response.created',
+        response: { id: 'gen-response' },
+      },
+      {
+        id: 'gen-response',
         type: 'error',
         error: { code: errorType, message: expect.any(String) },
       },
@@ -410,5 +434,63 @@ describe('rewriteModelResponse_Responses', () => {
     expect(event.response.usage.prompt_tokens_details.cached_tokens).toBe(1);
     expect(sse).toContain('event: response.completed');
     expect(dataPayloads(sse)).toContain('[DONE]');
+  });
+});
+
+describe('rewriteModelResponse', () => {
+  test('rewrites paid-model Kilo organization traffic without stripping cost', async () => {
+    const result = await rewriteModelResponse(
+      jsonResponse({
+        model: 'openai/gpt-5',
+        usage: {
+          cost: 0.5,
+          cost_details: { upstream_inference_cost: 0.4 },
+          is_byok: false,
+        },
+      }),
+      'openai/gpt-5',
+      'openrouter',
+      'chat_completions',
+      KILO_ORGANIZATION_ID
+    );
+
+    expect(result).not.toBeNull();
+    expect(await result?.json()).toMatchObject({
+      usage: {
+        cost: 0.5,
+        cost_details: { upstream_inference_cost: 0.4 },
+        is_byok: false,
+      },
+    });
+  });
+
+  test('does not rewrite paid-model traffic for other organizations', async () => {
+    const result = await rewriteModelResponse(
+      jsonResponse({ model: 'openai/gpt-5' }),
+      'openai/gpt-5',
+      'openrouter',
+      'chat_completions',
+      '00000000-0000-0000-0000-000000000000'
+    );
+
+    expect(result).toBeNull();
+  });
+
+  test('continues stripping cost for free models outside the Kilo organization', async () => {
+    const result = await rewriteModelResponse(
+      jsonResponse({
+        model: 'google/gemma-4-26b-a4b-it:free',
+        usage: { cost: 0, is_byok: false },
+      }),
+      'google/gemma-4-26b-a4b-it:free',
+      'openrouter',
+      'chat_completions'
+    );
+
+    expect(result).not.toBeNull();
+    expect(await result?.json()).toEqual({
+      model: 'google/gemma-4-26b-a4b-it:free',
+      usage: {},
+    });
   });
 });

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -3,6 +3,7 @@ import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 import { getOutputHeaders } from '@/lib/ai-gateway/llm-proxy-helpers';
 import type { ChatCompletionChunk, OpenRouterUsage } from '@/lib/ai-gateway/processUsage.types';
+import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
 import type { EventSourceMessage } from 'eventsource-parser';
 import { createParser } from 'eventsource-parser';
 import { NextResponse } from 'next/server';
@@ -97,11 +98,12 @@ async function rewriteSseStream(
   }
 }
 
-function rewriteUsage(usage: OpenRouterUsage) {
-  // We only rewrite the response for free models, strip upstream cost
-  delete usage.cost;
-  delete usage.cost_details;
-  delete usage.is_byok;
+function rewriteUsage(usage: OpenRouterUsage, removeCost: boolean) {
+  if (removeCost) {
+    delete usage.cost;
+    delete usage.cost_details;
+    delete usage.is_byok;
+  }
   if (usage.prompt_tokens_details) {
     if (usage.prompt_tokens_details.cached_tokens === undefined) {
       usage.prompt_tokens_details.cached_tokens = 0; // OpenCode crashes if this is absent
@@ -109,7 +111,7 @@ function rewriteUsage(usage: OpenRouterUsage) {
   }
 }
 
-export async function rewriteModelResponse_ChatCompletions(response: Response) {
+export async function rewriteModelResponse_ChatCompletions(response: Response, removeCost = true) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -133,7 +135,7 @@ export async function rewriteModelResponse_ChatCompletions(response: Response) {
     }
     const usage = json.usage as OpenRouterUsage;
     if (usage) {
-      rewriteUsage(usage);
+      rewriteUsage(usage, removeCost);
     }
 
     return NextResponse.json(json, {
@@ -152,6 +154,7 @@ export async function rewriteModelResponse_ChatCompletions(response: Response) {
       }
 
       let doneReceived = false;
+      let generationId: string | undefined;
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
           if (event.data === '[DONE]') {
@@ -159,6 +162,7 @@ export async function rewriteModelResponse_ChatCompletions(response: Response) {
             return;
           }
           const json = JSON.parse(event.data) as ChatCompletionChunk;
+          generationId = json.id ?? generationId;
 
           const delta = json.choices?.[0]?.delta;
           if (delta) {
@@ -174,7 +178,7 @@ export async function rewriteModelResponse_ChatCompletions(response: Response) {
           }
 
           if (json.usage) {
-            rewriteUsage(json.usage);
+            rewriteUsage(json.usage, removeCost);
           }
 
           const eventLine = event.event ? 'event: ' + event.event + '\n' : '';
@@ -193,6 +197,7 @@ export async function rewriteModelResponse_ChatCompletions(response: Response) {
         responseReadError =>
           'data: ' +
           JSON.stringify({
+            ...(generationId ? { id: generationId } : {}),
             error: {
               code: 503,
               message: responseReadError.message,
@@ -228,13 +233,15 @@ type MessagesApiMessageDelta = {
   delta: Anthropic.Messages.MessageDeltaEvent['delta'];
 };
 
-function rewriteMessagesUsage(usage: MessagesApiUsage) {
-  delete usage.cost;
-  delete usage.cost_details;
-  delete usage.is_byok;
+function rewriteMessagesUsage(usage: MessagesApiUsage, removeCost: boolean) {
+  if (removeCost) {
+    delete usage.cost;
+    delete usage.cost_details;
+    delete usage.is_byok;
+  }
 }
 
-export async function rewriteModelResponse_Messages(response: Response) {
+export async function rewriteModelResponse_Messages(response: Response, removeCost = true) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -257,7 +264,7 @@ export async function rewriteModelResponse_Messages(response: Response) {
       });
     }
     if (json.usage) {
-      rewriteMessagesUsage(json.usage);
+      rewriteMessagesUsage(json.usage, removeCost);
     }
     return NextResponse.json(json, {
       status: response.status,
@@ -275,6 +282,7 @@ export async function rewriteModelResponse_Messages(response: Response) {
       }
 
       let doneReceived = false;
+      let generationId: string | undefined;
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
           if (event.data === '[DONE]') {
@@ -288,15 +296,16 @@ export async function rewriteModelResponse_Messages(response: Response) {
 
           if (json.type === 'message_start') {
             const e = json as MessagesApiMessageStart;
+            generationId = e.message.id ?? generationId;
             if (e.message.usage) {
-              rewriteMessagesUsage(e.message.usage);
+              rewriteMessagesUsage(e.message.usage, removeCost);
             }
           }
 
           if (json.type === 'message_delta') {
             const e = json as MessagesApiMessageDelta;
             if (e.usage) {
-              rewriteMessagesUsage(e.usage);
+              rewriteMessagesUsage(e.usage, removeCost);
             }
           }
 
@@ -317,6 +326,7 @@ export async function rewriteModelResponse_Messages(response: Response) {
           'event: error\n' +
           'data: ' +
           JSON.stringify({
+            ...(generationId ? { id: generationId } : {}),
             type: 'error',
             error: {
               type: 'api_error',
@@ -341,7 +351,7 @@ type ResponsesApiEvent = {
   response?: OpenAI.Responses.Response & { usage?: OpenRouterUsage | null };
 };
 
-export async function rewriteModelResponse_Responses(response: Response) {
+export async function rewriteModelResponse_Responses(response: Response, removeCost = true) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
@@ -364,7 +374,7 @@ export async function rewriteModelResponse_Responses(response: Response) {
       });
     }
     if (json.usage) {
-      rewriteUsage(json.usage);
+      rewriteUsage(json.usage, removeCost);
     }
     return NextResponse.json(json, {
       status: response.status,
@@ -382,6 +392,7 @@ export async function rewriteModelResponse_Responses(response: Response) {
       }
 
       let doneReceived = false;
+      let generationId: string | undefined;
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
           if (event.data === '[DONE]') {
@@ -390,8 +401,9 @@ export async function rewriteModelResponse_Responses(response: Response) {
           }
           const json = JSON.parse(event.data) as ResponsesApiEvent;
           if (json.response) {
+            generationId = json.response.id ?? generationId;
             if (json.response.usage) {
-              rewriteUsage(json.response.usage);
+              rewriteUsage(json.response.usage, removeCost);
             }
           }
           const eventLine = event.event ? 'event: ' + event.event + '\n' : '';
@@ -411,6 +423,7 @@ export async function rewriteModelResponse_Responses(response: Response) {
           'event: error\n' +
           'data: ' +
           JSON.stringify({
+            ...(generationId ? { id: generationId } : {}),
             type: 'error',
             error: {
               code: responseReadError.errorType,
@@ -433,25 +446,26 @@ export async function rewriteModelResponse(
   response: Response,
   model: string,
   providerId: ProviderId,
-  kind: GatewayRequest['kind']
+  kind: GatewayRequest['kind'],
+  organizationId?: string
 ): Promise<NextResponse | null> {
   const isFreeModelRequiringCostRemoval =
     (providerId === 'openrouter' || providerId === 'vercel') && isKiloExclusiveFreeModel(model);
 
-  if (!isFreeModelRequiringCostRemoval) {
+  if (!isFreeModelRequiringCostRemoval && organizationId !== KILO_ORGANIZATION_ID) {
     console.debug('[rewriteModelResponse] skipping rewrite for %s', model);
     return null;
   }
 
   console.debug('[rewriteModelResponse] rewriting response for %s', model);
   if (kind === 'chat_completions') {
-    return rewriteModelResponse_ChatCompletions(response);
+    return rewriteModelResponse_ChatCompletions(response, isFreeModelRequiringCostRemoval);
   }
   if (kind === 'responses') {
-    return rewriteModelResponse_Responses(response);
+    return rewriteModelResponse_Responses(response, isFreeModelRequiringCostRemoval);
   }
   if (kind === 'messages') {
-    return rewriteModelResponse_Messages(response);
+    return rewriteModelResponse_Messages(response, isFreeModelRequiringCostRemoval);
   }
 
   console.error('[rewriteModelResponse] implementation error: unrecognized API kind %s', kind);


### PR DESCRIPTION
## Summary
- trigger model response rewriting for all canonical Kilo organization traffic
- retain generation IDs and include them in synthetic abort/timeout stream events
- keep upstream cost removal restricted to the existing free-model criteria

## Verification
- `pnpm exec oxfmt apps/web/src/lib/rewriteModelResponse.ts apps/web/src/lib/rewriteModelResponse.test.ts apps/web/src/app/api/openrouter/[...path]/route.ts`
- `git diff --check`
- focused Jest suite attempted, but repository test setup could not connect to PostgreSQL and failed before assertions