### PR TITLE
fix(ai-gateway): emit compatible stream errors

### DIFF
--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -365,7 +365,7 @@ describe('rewriteModelResponse_Responses', () => {
       failingResponse(
         'text/event-stream',
         errorName,
-        'data: {"type":"response.created","response":{"id":"gen-response"}}\n\n'
+        'data: {"type":"response.created","sequence_number":4,"response":{"id":"gen-response"}}\n\n'
       )
     );
     const sse = await readOutputStream(result);
@@ -374,12 +374,18 @@ describe('rewriteModelResponse_Responses', () => {
     expect(dataObjects(sse)).toEqual([
       {
         type: 'response.created',
+        sequence_number: 4,
         response: { id: 'gen-response' },
       },
       {
         id: 'gen-response',
         type: 'error',
-        error: { code: errorType, message: expect.any(String) },
+        sequence_number: 5,
+        error: {
+          type: errorType,
+          code: errorType === 'timeout' ? '504' : '503',
+          message: expect.any(String),
+        },
       },
     ]);
   });

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -4,6 +4,7 @@ import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 import { getOutputHeaders } from '@/lib/ai-gateway/llm-proxy-helpers';
 import type { ChatCompletionChunk, OpenRouterUsage } from '@/lib/ai-gateway/processUsage.types';
 import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
+import { errorExceptInTest } from '@/lib/utils.server';
 import type { EventSourceMessage } from 'eventsource-parser';
 import { createParser } from 'eventsource-parser';
 import { NextResponse } from 'next/server';
@@ -91,6 +92,7 @@ async function rewriteSseStream(
       throw error;
     }
 
+    errorExceptInTest('[rewriteModelResponse] emitting stream error event', responseReadError);
     controller.enqueue(serializeError(responseReadError));
     controller.close();
   } finally {
@@ -348,6 +350,7 @@ export async function rewriteModelResponse_Messages(response: Response, removeCo
 
 type ResponsesApiEvent = {
   type: string;
+  sequence_number?: number;
   response?: OpenAI.Responses.Response & { usage?: OpenRouterUsage | null };
 };
 
@@ -393,6 +396,7 @@ export async function rewriteModelResponse_Responses(response: Response, removeC
 
       let doneReceived = false;
       let generationId: string | undefined;
+      let nextSequenceNumber = 0;
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
           if (event.data === '[DONE]') {
@@ -400,6 +404,9 @@ export async function rewriteModelResponse_Responses(response: Response, removeC
             return;
           }
           const json = JSON.parse(event.data) as ResponsesApiEvent;
+          if (json.sequence_number !== undefined) {
+            nextSequenceNumber = Math.max(nextSequenceNumber, json.sequence_number + 1);
+          }
           if (json.response) {
             generationId = json.response.id ?? generationId;
             if (json.response.usage) {
@@ -425,8 +432,10 @@ export async function rewriteModelResponse_Responses(response: Response, removeC
           JSON.stringify({
             ...(generationId ? { id: generationId } : {}),
             type: 'error',
+            sequence_number: nextSequenceNumber,
             error: {
-              code: responseReadError.errorType,
+              type: responseReadError.errorType,
+              code: responseReadError.errorType === 'timeout' ? '504' : '503',
               message: responseReadError.message,
             },
           }) +


### PR DESCRIPTION
## Summary
- make synthetic OpenAI Responses errors parse as errors in Vercel AI SDK v6
- carry forward the next Responses `sequence_number` and emit HTTP-like error codes
- log every synthetic stream error before enqueueing it

## AI SDK v6 verification
- OpenAI Chat Completions and OpenAI-compatible providers accept the existing nested `error` shape
- Anthropic accepts the existing `{ type: "error", error: { type, message } }` shape
- OpenAI Responses requires `sequence_number` and string `error.type`, `error.code`, and `error.message`
- all three providers strip top-level IDs from parsed error chunks, but consume IDs from preceding normal metadata chunks

## Verification
- formatted only the two touched files with `oxfmt`
- `git diff --check`
- local focused Jest remains blocked by unavailable PostgreSQL in global test setup; CI will run the full suite