### PR TITLE
Mobile: keep the markdown table modal open during streaming

### DIFF
--- a/apps/mobile/src/components/agents/markdown-renderer.test.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.test.ts
@@ -1,0 +1,144 @@
+// eslint-disable-next-line import/no-nodejs-modules -- patching the CJS loader is the only way to stub react-native for the externalized react-native-marked; the library under test stays real
+import Module from 'node:module';
+import { type ReactElement, type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type MarkdownPalette } from './markdown-palette';
+import { type MarkdownRenderer } from './markdown-renderer';
+
+// react-native-marked is externalized by vitest, so vi.mock('react-native') does
+// not intercept its nested requires. Patch Module._load before loading the
+// library so the real Renderer (and github-slugger) can construct under node.
+const rnStub = {
+  Text: 'Text',
+  View: 'View',
+  ScrollView: 'ScrollView',
+  TouchableHighlight: 'TouchableHighlight',
+  Image: 'Image',
+  StyleSheet: {
+    create: (styles: Record<string, unknown>) => styles,
+    hairlineWidth: 1,
+    flatten: (style: unknown) => style,
+  },
+  Dimensions: {
+    get: () => ({ width: 390, height: 844, scale: 3, fontScale: 1 }),
+    addEventListener: () => ({ remove: () => undefined }),
+  },
+  Platform: {
+    OS: 'ios',
+    select: (spec: { ios?: unknown; default?: unknown }) => spec.ios ?? spec.default,
+  },
+  I18nManager: { isRTL: false },
+  PixelRatio: { get: () => 3 },
+  NativeModules: {},
+  requireNativeComponent: () => 'NativeComponent',
+};
+
+type CjsLoad = (request: string, parent: NodeJS.Module | null, isMain: boolean) => unknown;
+const ModuleWithLoad = Module as unknown as { _load: CjsLoad };
+const originalLoad = ModuleWithLoad._load.bind(ModuleWithLoad);
+ModuleWithLoad._load = (request: string, parent: NodeJS.Module | null, isMain: boolean) => {
+  if (request === 'react-native') {
+    return rnStub;
+  }
+  if (request === 'react-native-svg') {
+    return { default: 'Svg', Svg: 'Svg', Path: 'Path', G: 'G', Rect: 'Rect', Circle: 'Circle' };
+  }
+  return originalLoad(request, parent, isMain);
+};
+
+vi.mock('react-native', () => rnStub);
+vi.mock('react-native-svg', () => ({
+  default: 'Svg',
+  Svg: 'Svg',
+  Path: 'Path',
+  G: 'G',
+  Rect: 'Rect',
+  Circle: 'Circle',
+}));
+vi.mock('./markdown-table', () => ({
+  MarkdownTable: 'MarkdownTable',
+}));
+vi.mock('./markdown-link', () => ({
+  getLinkAccessibilityActions: () => [],
+  getLinkLongPressHandler: () => undefined,
+  LINK_ACCESSIBILITY_HINT: 'hint',
+  resolveLinkAccessibilityLabel: () => 'label',
+}));
+vi.mock('@/lib/external-link', () => ({
+  openExternalUrl: vi.fn(),
+}));
+
+const palette: MarkdownPalette = {
+  textColor: '#111111',
+  mutedTextColor: '#666666',
+  codeBackground: '#f0f0f0',
+  borderColor: '#cccccc',
+  surfaceColor: '#ffffff',
+};
+
+const emptyStyle = undefined;
+
+async function createRenderer() {
+  const { MarkdownRenderer: RendererClass } = await import('./markdown-renderer');
+  return new RendererClass(palette, true, {});
+}
+
+function keySequence(renderer: { getKey: () => string }, count: number): string[] {
+  return Array.from({ length: count }, () => renderer.getKey());
+}
+
+function tableHostKey(
+  renderer: MarkdownRenderer,
+  header: ReactNode[][],
+  rows: ReactNode[][][]
+): string | null {
+  const element = renderer.table(header, rows, emptyStyle, emptyStyle, emptyStyle) as ReactElement;
+  return element.key ?? null;
+}
+
+describe('MarkdownRenderer key stability', () => {
+  it('two fresh instances produce identical getKey() sequences', async () => {
+    const a = await createRenderer();
+    const b = await createRenderer();
+    expect(keySequence(a, 8)).toEqual(keySequence(b, 8));
+  });
+
+  it('a reused instance produces different keys across identical call sequences', async () => {
+    const renderer = await createRenderer();
+    const first = keySequence(renderer, 5);
+    const second = keySequence(renderer, 5);
+    expect(first).not.toEqual(second);
+  });
+
+  it('table hosts are keyed ordinally in call order', async () => {
+    const renderer = await createRenderer();
+    const header: ReactNode[][] = [['H']];
+    const rows: ReactNode[][][] = [[['r1']]];
+    expect(tableHostKey(renderer, header, rows)).toBe('md-table-0');
+    expect(tableHostKey(renderer, header, rows)).toBe('md-table-1');
+    expect(tableHostKey(renderer, header, rows)).toBe('md-table-2');
+  });
+
+  it('table host key is independent of preceding getKey() consumption', async () => {
+    const a = await createRenderer();
+    const b = await createRenderer();
+    keySequence(a, 2);
+    keySequence(b, 11);
+    const header: ReactNode[][] = [['H']];
+    const rows: ReactNode[][][] = [[['r1']]];
+    expect(tableHostKey(a, header, rows)).toBe('md-table-0');
+    expect(tableHostKey(b, header, rows)).toBe('md-table-0');
+  });
+
+  it('table host key is independent of row/cell counts', async () => {
+    const a = await createRenderer();
+    const b = await createRenderer();
+    const smallHeader: ReactNode[][] = [['A']];
+    const smallRows: ReactNode[][][] = [[['1']]];
+    const largeHeader: ReactNode[][] = [['A', 'B', 'C']];
+    const largeRows: ReactNode[][][] = [[['1', '2', '3']], [['4', '5', '6']], [['7', '8', '9']]];
+    expect(tableHostKey(a, smallHeader, smallRows)).toBe('md-table-0');
+    expect(tableHostKey(b, largeHeader, largeRows)).toBe('md-table-0');
+  });
+});

--- a/apps/mobile/src/components/agents/markdown-renderer.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.ts
@@ -1,0 +1,187 @@
+import { createElement, type ReactNode } from 'react';
+import {
+  type AccessibilityActionEvent,
+  type GestureResponderEvent,
+  Text,
+  type TextStyle,
+  View,
+  type ViewStyle,
+} from 'react-native';
+import { Renderer } from 'react-native-marked';
+
+import { openExternalUrl } from '@/lib/external-link';
+
+import {
+  getLinkAccessibilityActions,
+  getLinkLongPressHandler,
+  LINK_ACCESSIBILITY_HINT,
+  resolveLinkAccessibilityLabel,
+} from './markdown-link';
+import { type MarkdownPalette } from './markdown-palette';
+import { MarkdownTable } from './markdown-table';
+
+export type MarkdownLinkLongPressHandler = (href: string, event?: GestureResponderEvent) => void;
+
+export type MarkdownLinkPressHandler = (href: string) => boolean;
+
+// The library's default `Renderer` renders code blocks with the `em` text
+// style (italic) and renders tables with fixed column widths that frequently
+// overflow the screen with no way to scroll within a chat bubble. We subclass
+// it to render code blocks in a monospace font and to render tables as a
+// "View table" chip that opens a full-screen modal (see `MarkdownTable`).
+//
+// Notes on horizontal scrolling: the default library renders code (and we
+// previously rendered tables) inside a horizontal ScrollView, but on RN 0.83
+// Fabric a horizontal ScrollView inside a width-constrained bubble produces
+// spurious vertical height (measured up to ~10x the actual content height,
+// growing as sibling messages re-rendered the list), and its scroll gesture
+// loses to the chat bubble's swipe-to-reply pan. We render code as a plain
+// wrapping Text and tables behind a chip instead — no horizontal ScrollView
+// ever renders inside a bubble.
+type MarkdownRendererHandlers = {
+  onLongPressLink?: MarkdownLinkLongPressHandler;
+  onPressLink?: MarkdownLinkPressHandler;
+};
+
+export class MarkdownRenderer extends Renderer {
+  private readonly palette: MarkdownPalette;
+  private readonly selectable: boolean;
+  private readonly onLongPressLink?: MarkdownLinkLongPressHandler;
+  private readonly onPressLink?: MarkdownLinkPressHandler;
+  // Ordinal host key: Parser parses every header/body cell (each consuming
+  // getKey()) before table() returns, so a slugger-based host key would shift
+  // as rows/cells grow. A fresh renderer per parse restarts this counter, so
+  // the k-th table keeps `md-table-(k-1)` across re-parses regardless of size.
+  private tableIndex = 0;
+
+  constructor(palette: MarkdownPalette, selectable: boolean, handlers: MarkdownRendererHandlers) {
+    super();
+    this.palette = palette;
+    this.selectable = selectable;
+    this.onLongPressLink = handlers.onLongPressLink;
+    this.onPressLink = handlers.onPressLink;
+  }
+
+  private textNode(children: string | ReactNode[], styles?: TextStyle): ReactNode {
+    return createElement(
+      Text,
+      { selectable: this.selectable, key: this.getKey(), style: styles },
+      children
+    );
+  }
+
+  override heading(text: string | ReactNode[], styles?: TextStyle): ReactNode {
+    return this.textNode(text, styles);
+  }
+
+  // eslint-disable-next-line eslint/max-params -- signature fixed by react-native-marked's RendererInterface
+  override code(
+    text: string,
+    _language: string | undefined,
+    containerStyle: ViewStyle | undefined,
+    _textStyle: TextStyle | undefined
+  ): ReactNode {
+    return createElement(
+      View,
+      { key: this.getKey(), style: containerStyle },
+      createElement(
+        Text,
+        {
+          selectable: this.selectable,
+          className: 'font-mono text-sm leading-5',
+          // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant text color
+          style: { color: this.palette.textColor },
+        },
+        text
+      )
+    );
+  }
+
+  override escape(text: string, styles?: TextStyle): ReactNode {
+    return this.textNode(text, styles);
+  }
+
+  // eslint-disable-next-line eslint/max-params -- signature fixed by react-native-marked's RendererInterface
+  override link(
+    children: string | ReactNode[],
+    href: string,
+    styles?: TextStyle,
+    title?: string
+  ): ReactNode {
+    const accessibilityLabel = resolveLinkAccessibilityLabel(children, href, title);
+    const linkActionsEnabled = this.onLongPressLink !== undefined;
+
+    return createElement(
+      Text,
+      {
+        selectable: this.selectable,
+        accessibilityRole: 'link',
+        accessibilityHint: LINK_ACCESSIBILITY_HINT,
+        accessibilityLabel,
+        accessibilityActions: getLinkAccessibilityActions(linkActionsEnabled),
+        key: this.getKey(),
+        onAccessibilityAction: (event: AccessibilityActionEvent) => {
+          if (event.nativeEvent.actionName === 'showLinkActions') {
+            this.onLongPressLink?.(href);
+          }
+        },
+        onLongPress: getLinkLongPressHandler(this.onLongPressLink, href),
+        onPress: () => {
+          const handled = this.onPressLink?.(href);
+          if (handled) {
+            return;
+          }
+          void openExternalUrl(href, { label: accessibilityLabel });
+        },
+        style: styles,
+      },
+      children
+    );
+  }
+
+  override strong(children: string | ReactNode[], styles?: TextStyle): ReactNode {
+    return this.textNode(children, styles);
+  }
+
+  override em(children: string | ReactNode[], styles?: TextStyle): ReactNode {
+    return this.textNode(children, styles);
+  }
+
+  override codespan(text: string, styles?: TextStyle): ReactNode {
+    return this.textNode(text, styles);
+  }
+
+  override br(): ReactNode {
+    return this.textNode('\n', {});
+  }
+
+  override del(children: string | ReactNode[], styles?: TextStyle): ReactNode {
+    return this.textNode(children, styles);
+  }
+
+  override text(text: string | ReactNode[], styles?: TextStyle): ReactNode {
+    return this.textNode(text, styles);
+  }
+
+  override html(text: string | ReactNode[], styles?: TextStyle): ReactNode {
+    return this.textNode(text, styles);
+  }
+
+  // eslint-disable-next-line eslint/max-params -- signature fixed by react-native-marked's RendererInterface
+  override table(
+    header: ReactNode[][],
+    rows: ReactNode[][][],
+    _tableStyle: ViewStyle | undefined,
+    _rowStyle: ViewStyle | undefined,
+    _cellStyle: ViewStyle | undefined
+  ): ReactNode {
+    const key = `md-table-${this.tableIndex}`;
+    this.tableIndex += 1;
+    return createElement(MarkdownTable, {
+      key,
+      palette: this.palette,
+      header,
+      rows,
+    });
+  }
+}

--- a/apps/mobile/src/components/agents/markdown-text.tsx
+++ b/apps/mobile/src/components/agents/markdown-text.tsx
@@ -1,35 +1,17 @@
-import { type ReactNode, useMemo } from 'react';
-import {
-  type AccessibilityActionEvent,
-  type GestureResponderEvent,
-  Text,
-  type TextStyle,
-  useColorScheme,
-  View,
-  type ViewStyle,
-} from 'react-native';
-import { Renderer, useMarkdown } from 'react-native-marked';
+import { useMemo } from 'react';
+import { useColorScheme, View } from 'react-native';
+import { useMarkdown } from 'react-native-marked';
 
-import { openExternalUrl } from '@/lib/external-link';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 
+import { getMarkdownStyles, getPalette, type MarkdownVariant } from './markdown-palette';
 import {
-  getLinkAccessibilityActions,
-  getLinkLongPressHandler,
-  LINK_ACCESSIBILITY_HINT,
-  resolveLinkAccessibilityLabel,
-} from './markdown-link';
-import {
-  getMarkdownStyles,
-  getPalette,
-  type MarkdownPalette,
-  type MarkdownVariant,
-} from './markdown-palette';
-import { MarkdownTable } from './markdown-table';
+  type MarkdownLinkLongPressHandler,
+  type MarkdownLinkPressHandler,
+  MarkdownRenderer,
+} from './markdown-renderer';
 
-export type MarkdownLinkLongPressHandler = (href: string, event?: GestureResponderEvent) => void;
-
-export type MarkdownLinkPressHandler = (href: string) => boolean;
+export type { MarkdownLinkLongPressHandler, MarkdownLinkPressHandler };
 
 export type MarkdownTextProps = {
   value: string;
@@ -45,154 +27,6 @@ export type MarkdownTextProps = {
   onPressLink?: MarkdownLinkPressHandler;
 };
 
-// The library's default `Renderer` renders code blocks with the `em` text
-// style (italic) and renders tables with fixed column widths that frequently
-// overflow the screen with no way to scroll within a chat bubble. We subclass
-// it to render code blocks in a monospace font and to render tables as a
-// "View table" chip that opens a full-screen modal (see `MarkdownTable`).
-//
-// Notes on horizontal scrolling: the default library renders code (and we
-// previously rendered tables) inside a horizontal ScrollView, but on RN 0.83
-// Fabric a horizontal ScrollView inside a width-constrained bubble produces
-// spurious vertical height (measured up to ~10x the actual content height,
-// growing as sibling messages re-rendered the list), and its scroll gesture
-// loses to the chat bubble's swipe-to-reply pan. We render code as a plain
-// wrapping Text and tables behind a chip instead — no horizontal ScrollView
-// ever renders inside a bubble.
-type MarkdownRendererHandlers = {
-  onLongPressLink?: MarkdownLinkLongPressHandler;
-  onPressLink?: MarkdownLinkPressHandler;
-};
-
-class MarkdownRenderer extends Renderer {
-  private readonly palette: MarkdownPalette;
-  private readonly selectable: boolean;
-  private readonly onLongPressLink?: MarkdownLinkLongPressHandler;
-  private readonly onPressLink?: MarkdownLinkPressHandler;
-
-  constructor(palette: MarkdownPalette, selectable: boolean, handlers: MarkdownRendererHandlers) {
-    super();
-    this.palette = palette;
-    this.selectable = selectable;
-    this.onLongPressLink = handlers.onLongPressLink;
-    this.onPressLink = handlers.onPressLink;
-  }
-
-  private textNode(children: string | ReactNode[], styles?: TextStyle): ReactNode {
-    return (
-      <Text selectable={this.selectable} key={this.getKey()} style={styles}>
-        {children}
-      </Text>
-    );
-  }
-
-  override heading(text: string | ReactNode[], styles?: TextStyle): ReactNode {
-    return this.textNode(text, styles);
-  }
-
-  // eslint-disable-next-line eslint/max-params -- signature fixed by react-native-marked's RendererInterface
-  override code(
-    text: string,
-    _language: string | undefined,
-    containerStyle: ViewStyle | undefined,
-    _textStyle: TextStyle | undefined
-  ): ReactNode {
-    return (
-      <View key={this.getKey()} style={containerStyle}>
-        <Text
-          selectable={this.selectable}
-          className="font-mono text-sm leading-5"
-          // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant text color
-          style={{ color: this.palette.textColor }}
-        >
-          {text}
-        </Text>
-      </View>
-    );
-  }
-
-  override escape(text: string, styles?: TextStyle): ReactNode {
-    return this.textNode(text, styles);
-  }
-
-  // eslint-disable-next-line eslint/max-params -- signature fixed by react-native-marked's RendererInterface
-  override link(
-    children: string | ReactNode[],
-    href: string,
-    styles?: TextStyle,
-    title?: string
-  ): ReactNode {
-    const accessibilityLabel = resolveLinkAccessibilityLabel(children, href, title);
-    const linkActionsEnabled = this.onLongPressLink !== undefined;
-
-    return (
-      <Text
-        selectable={this.selectable}
-        accessibilityRole="link"
-        accessibilityHint={LINK_ACCESSIBILITY_HINT}
-        accessibilityLabel={accessibilityLabel}
-        accessibilityActions={getLinkAccessibilityActions(linkActionsEnabled)}
-        key={this.getKey()}
-        onAccessibilityAction={(event: AccessibilityActionEvent) => {
-          if (event.nativeEvent.actionName === 'showLinkActions') {
-            this.onLongPressLink?.(href);
-          }
-        }}
-        onLongPress={getLinkLongPressHandler(this.onLongPressLink, href)}
-        onPress={() => {
-          const handled = this.onPressLink?.(href);
-          if (handled) {
-            return;
-          }
-          void openExternalUrl(href, { label: accessibilityLabel });
-        }}
-        style={styles}
-      >
-        {children}
-      </Text>
-    );
-  }
-
-  override strong(children: string | ReactNode[], styles?: TextStyle): ReactNode {
-    return this.textNode(children, styles);
-  }
-
-  override em(children: string | ReactNode[], styles?: TextStyle): ReactNode {
-    return this.textNode(children, styles);
-  }
-
-  override codespan(text: string, styles?: TextStyle): ReactNode {
-    return this.textNode(text, styles);
-  }
-
-  override br(): ReactNode {
-    return this.textNode('\n', {});
-  }
-
-  override del(children: string | ReactNode[], styles?: TextStyle): ReactNode {
-    return this.textNode(children, styles);
-  }
-
-  override text(text: string | ReactNode[], styles?: TextStyle): ReactNode {
-    return this.textNode(text, styles);
-  }
-
-  override html(text: string | ReactNode[], styles?: TextStyle): ReactNode {
-    return this.textNode(text, styles);
-  }
-
-  // eslint-disable-next-line eslint/max-params -- signature fixed by react-native-marked's RendererInterface
-  override table(
-    header: ReactNode[][],
-    rows: ReactNode[][][],
-    _tableStyle: ViewStyle | undefined,
-    _rowStyle: ViewStyle | undefined,
-    _cellStyle: ViewStyle | undefined
-  ): ReactNode {
-    return <MarkdownTable key={this.getKey()} palette={this.palette} header={header} rows={rows} />;
-  }
-}
-
 export function MarkdownText({
   value,
   variant = 'assistant',
@@ -203,21 +37,33 @@ export function MarkdownText({
   const colorScheme = useColorScheme();
   const colors = useThemeColors();
 
-  const { styles, renderer, theme } = useMemo(() => {
-    const palette = getPalette(variant, colors);
-    return {
-      styles: getMarkdownStyles(palette),
-      renderer: new MarkdownRenderer(palette, selectable, { onLongPressLink, onPressLink }),
-      theme: {
-        colors: {
-          text: palette.textColor,
-          code: palette.textColor,
-          link: palette.textColor,
-          border: palette.borderColor,
-        },
+  const palette = useMemo(() => getPalette(variant, colors), [variant, colors]);
+
+  const styles = useMemo(() => getMarkdownStyles(palette), [palette]);
+
+  const theme = useMemo(
+    () => ({
+      colors: {
+        text: palette.textColor,
+        code: palette.textColor,
+        link: palette.textColor,
+        border: palette.borderColor,
       },
-    };
-  }, [variant, colors, selectable, onLongPressLink, onPressLink]);
+    }),
+    [palette]
+  );
+
+  // react-native-marked keys elements with a per-instance monotonic slugger;
+  // reusing one instance across re-parses re-keys every element and remounts
+  // the subtree, resetting local state such as MarkdownTable's open modal
+  // during streaming. A fresh instance per `value` change yields identical
+  // keys for identical parse prefixes, so element state survives while
+  // streaming updates flow in as props.
+  const renderer = useMemo(
+    () => new MarkdownRenderer(palette, selectable, { onLongPressLink, onPressLink }),
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- `value` intentionally recreates the renderer per markdown-source change so element keys stay stable across streaming re-parses
+    [palette, selectable, onLongPressLink, onPressLink, value]
+  );
 
   const elements = useMarkdown(value, {
     colorScheme,


### PR DESCRIPTION
## Defect

In remote-agent and cloud-agent conversations, tapping **View table** on a markdown table while the assistant response is still streaming opens the full-screen table modal, which then **closes by itself** as the stream continues.

## Root cause

`react-native-marked` keys rendered elements with `Renderer.getKey()`, a per-instance monotonic `github-slugger` counter that never resets. `MarkdownText` memoized a single `MarkdownRenderer` whose memo deps did not include the markdown source, while `useMarkdown(value, …)` re-parses on every `value` change. Every streaming token therefore re-keyed **every** element, React unmounted and remounted the entire markdown subtree per token, and `MarkdownTable`'s local `open` state (the RN `Modal` visibility) reset — closing the modal mid-stream. (The same mechanism silently reset any other element-local state and wasted a full subtree rebuild per token.)

## Fix

- **Recreate the renderer whenever the markdown source changes** (`value` added to the renderer memo deps). A fresh instance restarts the slugger, so the i-th element of an identical parse prefix gets the **same key on every parse**; React preserves those component instances and streaming updates flow in as props. Static content (`value` never changes) sees zero behavior or performance change.
- **Key table hosts ordinally** (`md-table-N`) instead of via the slugger. `Parser` parses every header/body cell — each consuming `getKey()` calls — before `renderer.table(...)` returns, so a slugger-based host key shifts whenever the row/cell count changes and would remount `MarkdownTable` even with a fresh renderer per parse. Because the renderer instance is fresh per parse, the ordinal counter restarts every parse, so the k-th table keeps `md-table-(k-1)` on every parse **including while its rows grow** — new rows render into the open modal.
- **Extraction + tests:** `MarkdownRenderer` moved to `markdown-renderer.ts` (no behavior change) and `markdown-renderer.test.ts` pins the three key-stability invariants (fresh-instance prefix stability, reused-instance drift, ordinal table host keys independent of preceding key consumption and of row/cell counts).

One render path serves all reported surfaces (`text-part-renderer` → `ChatMarkdownText` → `MarkdownText`), so remote-agent, cloud-agent, and kilo-chat conversations are all covered.

## Accepted limitation

A new element (paragraph, code block, second table) appearing **before** an open table's position mid-stream shifts later keys/ordinals and can still remount-close the modal. This is rare versus the dominant case (completed or growing table with text streaming after it). Elements after a growing table remount on row arrival but hold no modal state, so this is invisible.

## Testing

- New unit suite: 5 cases pinning the key-stability invariants against the real `react-native-marked` `Renderer` + `github-slugger`.
- `pnpm test` (212 files / 1754 tests), `pnpm typecheck`, `pnpm lint`, `pnpm check:unused` all green.
- On-device E2E (open modal mid-stream stays open, live row updates, post-stream regression spot-check) verified by the requesting human on this build.