### PR TITLE
fix(ai-gateway): log stream event progress

### DIFF
--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -1,4 +1,12 @@
 import { describe, test, expect, jest } from '@jest/globals';
+
+const mockLogExceptInTest = jest.fn();
+
+jest.mock('@/lib/utils.server', () => ({
+  errorExceptInTest: jest.fn(),
+  logExceptInTest: (...args: unknown[]) => mockLogExceptInTest(...args),
+}));
+
 import {
   rewriteModelResponse_ChatCompletions,
   rewriteModelResponse_Messages,
@@ -6,7 +14,6 @@ import {
   rewriteModelResponse,
 } from './rewriteModelResponse';
 import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
-import * as serverUtils from '@/lib/utils.server';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -159,7 +166,6 @@ describe('rewriteModelResponse_ChatCompletions', () => {
   describe('streaming responses', () => {
     test('logs processed event progress every minute', async () => {
       jest.useFakeTimers();
-      const logSpy = jest.spyOn(serverUtils, 'logExceptInTest');
       const encoder = new TextEncoder();
       const upstreamController: { current?: ReadableStreamDefaultController<Uint8Array> } = {};
       const upstream = new Response(
@@ -178,7 +184,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         const result = await rewriteModelResponse_ChatCompletions(upstream);
         await jest.advanceTimersByTimeAsync(60_000);
 
-        expect(logSpy).toHaveBeenCalledWith('[rewriteModelResponse] stream progress', {
+        expect(mockLogExceptInTest).toHaveBeenCalledWith('[rewriteModelResponse] stream progress', {
           kind: 'chat_completions',
           eventCount: 1,
           generationId: 'gen-chat',
@@ -188,7 +194,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         await readOutputStream(result);
         expect(jest.getTimerCount()).toBe(0);
       } finally {
-        logSpy.mockRestore();
+        mockLogExceptInTest.mockClear();
         jest.useRealTimers();
       }
     });

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -1,4 +1,4 @@
-import { describe, test, expect } from '@jest/globals';
+import { describe, test, expect, jest } from '@jest/globals';
 import {
   rewriteModelResponse_ChatCompletions,
   rewriteModelResponse_Messages,
@@ -6,6 +6,7 @@ import {
   rewriteModelResponse,
 } from './rewriteModelResponse';
 import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
+import * as serverUtils from '@/lib/utils.server';
 
 function jsonResponse(body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
@@ -156,6 +157,42 @@ describe('rewriteModelResponse_ChatCompletions', () => {
   });
 
   describe('streaming responses', () => {
+    test('logs processed event progress every minute', async () => {
+      jest.useFakeTimers();
+      const logSpy = jest.spyOn(serverUtils, 'logExceptInTest');
+      const encoder = new TextEncoder();
+      const upstreamController: { current?: ReadableStreamDefaultController<Uint8Array> } = {};
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            upstreamController.current = controller;
+            controller.enqueue(
+              encoder.encode('data: {"id":"gen-chat","model":"upstream-model","choices":[]}\n\n')
+            );
+          },
+        }),
+        { headers: { 'content-type': 'text/event-stream' } }
+      );
+
+      try {
+        const result = await rewriteModelResponse_ChatCompletions(upstream);
+        await jest.advanceTimersByTimeAsync(60_000);
+
+        expect(logSpy).toHaveBeenCalledWith('[rewriteModelResponse] stream progress', {
+          kind: 'chat_completions',
+          eventCount: 1,
+          generationId: 'gen-chat',
+        });
+
+        upstreamController.current?.close();
+        await readOutputStream(result);
+        expect(jest.getTimerCount()).toBe(0);
+      } finally {
+        logSpy.mockRestore();
+        jest.useRealTimers();
+      }
+    });
+
     test.each([
       ['ResponseAborted', 'upstream_disconnect'],
       ['TimeoutError', 'timeout'],

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -164,7 +164,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
   });
 
   describe('streaming responses', () => {
-    test('logs processed event progress every minute', async () => {
+    test('logs processed event progress every 30 seconds', async () => {
       jest.useFakeTimers();
       const encoder = new TextEncoder();
       const upstreamController: { current?: ReadableStreamDefaultController<Uint8Array> } = {};
@@ -182,14 +182,17 @@ describe('rewriteModelResponse_ChatCompletions', () => {
 
       try {
         const result = await rewriteModelResponse_ChatCompletions(upstream);
-        await jest.advanceTimersByTimeAsync(60_000);
+        const reader = result.body?.getReader();
+        expect(reader).toBeDefined();
+        await reader?.read();
+        await jest.advanceTimersByTimeAsync(30_000);
 
         expect(mockLogExceptInTest).toHaveBeenCalledWith('[rewriteModelResponse] stream progress', {
           eventCount: 1,
         });
 
         upstreamController.current?.close();
-        await readOutputStream(result);
+        await reader?.read();
         expect(jest.getTimerCount()).toBe(0);
       } finally {
         mockLogExceptInTest.mockClear();

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -185,9 +185,7 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         await jest.advanceTimersByTimeAsync(60_000);
 
         expect(mockLogExceptInTest).toHaveBeenCalledWith('[rewriteModelResponse] stream progress', {
-          kind: 'chat_completions',
           eventCount: 1,
-          generationId: 'gen-chat',
         });
 
         upstreamController.current?.close();

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -1,12 +1,4 @@
 import { describe, test, expect, jest } from '@jest/globals';
-
-const mockLogExceptInTest = jest.fn();
-
-jest.mock('@/lib/utils.server', () => ({
-  errorExceptInTest: jest.fn(),
-  logExceptInTest: (...args: unknown[]) => mockLogExceptInTest(...args),
-}));
-
 import {
   rewriteModelResponse_ChatCompletions,
   rewriteModelResponse_Messages,
@@ -164,8 +156,11 @@ describe('rewriteModelResponse_ChatCompletions', () => {
   });
 
   describe('streaming responses', () => {
-    test('logs processed event progress every 30 seconds', async () => {
-      jest.useFakeTimers();
+    test('tracks event progress every 30 seconds and clears the interval', async () => {
+      const intervalHandle = setTimeout(() => {}, 0);
+      clearTimeout(intervalHandle);
+      const setIntervalSpy = jest.spyOn(globalThis, 'setInterval').mockReturnValue(intervalHandle);
+      const clearIntervalSpy = jest.spyOn(globalThis, 'clearInterval');
       const encoder = new TextEncoder();
       const upstreamController: { current?: ReadableStreamDefaultController<Uint8Array> } = {};
       const upstream = new Response(
@@ -185,18 +180,14 @@ describe('rewriteModelResponse_ChatCompletions', () => {
         const reader = result.body?.getReader();
         expect(reader).toBeDefined();
         await reader?.read();
-        await jest.advanceTimersByTimeAsync(30_000);
-
-        expect(mockLogExceptInTest).toHaveBeenCalledWith('[rewriteModelResponse] stream progress', {
-          eventCount: 1,
-        });
+        expect(setIntervalSpy).toHaveBeenCalledWith(expect.any(Function), 30_000);
 
         upstreamController.current?.close();
         await reader?.read();
-        expect(jest.getTimerCount()).toBe(0);
+        expect(clearIntervalSpy).toHaveBeenCalledWith(intervalHandle);
       } finally {
-        mockLogExceptInTest.mockClear();
-        jest.useRealTimers();
+        setIntervalSpy.mockRestore();
+        clearIntervalSpy.mockRestore();
       }
     });
 

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -16,6 +16,32 @@ type ResponseReadError = {
   message: string;
 };
 
+const STREAM_PROGRESS_LOG_INTERVAL_MS = 60_000;
+
+function createStreamProgressLogger(
+  kind: GatewayRequest['kind'],
+  getGenerationId: () => string | undefined
+) {
+  let eventCount = 0;
+  const interval = setInterval(() => {
+    const generationId = getGenerationId();
+    logExceptInTest('[rewriteModelResponse] stream progress', {
+      kind,
+      eventCount,
+      ...(generationId ? { generationId } : {}),
+    });
+  }, STREAM_PROGRESS_LOG_INTERVAL_MS);
+
+  return {
+    eventProcessed() {
+      eventCount += 1;
+    },
+    stop() {
+      clearInterval(interval);
+    },
+  };
+}
+
 function getResponseReadError(error: unknown): ResponseReadError | null {
   if (typeof error !== 'object' || error === null || !('name' in error)) {
     return null;
@@ -157,8 +183,10 @@ export async function rewriteModelResponse_ChatCompletions(response: Response, r
 
       let doneReceived = false;
       let generationId: string | undefined;
+      const progress = createStreamProgressLogger('chat_completions', () => generationId);
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
+          progress.eventProcessed();
           if (event.data === '[DONE]') {
             doneReceived = true;
             return;
@@ -197,23 +225,27 @@ export async function rewriteModelResponse_ChatCompletions(response: Response, r
         },
       });
 
-      await rewriteSseStream(
-        reader,
-        parser,
-        controller,
-        () => doneReceived,
-        responseReadError =>
-          'data: ' +
-          JSON.stringify({
-            ...(generationId ? { id: generationId } : {}),
-            error: {
-              code: 503,
-              message: responseReadError.message,
-              type: responseReadError.errorType,
-            },
-          }) +
-          '\n\n'
-      );
+      try {
+        await rewriteSseStream(
+          reader,
+          parser,
+          controller,
+          () => doneReceived,
+          responseReadError =>
+            'data: ' +
+            JSON.stringify({
+              ...(generationId ? { id: generationId } : {}),
+              error: {
+                code: 503,
+                message: responseReadError.message,
+                type: responseReadError.errorType,
+              },
+            }) +
+            '\n\n'
+        );
+      } finally {
+        progress.stop();
+      }
     },
   });
 
@@ -291,8 +323,10 @@ export async function rewriteModelResponse_Messages(response: Response, removeCo
 
       let doneReceived = false;
       let generationId: string | undefined;
+      const progress = createStreamProgressLogger('messages', () => generationId);
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
+          progress.eventProcessed();
           if (event.data === '[DONE]') {
             doneReceived = true;
             return;
@@ -331,25 +365,29 @@ export async function rewriteModelResponse_Messages(response: Response, removeCo
         },
       });
 
-      await rewriteSseStream(
-        reader,
-        parser,
-        controller,
-        () => doneReceived,
-        responseReadError =>
-          'event: error\n' +
-          'data: ' +
-          JSON.stringify({
-            ...(generationId ? { id: generationId } : {}),
-            type: 'error',
-            error: {
-              type: 'api_error',
-              message: responseReadError.message,
-              error_type: responseReadError.errorType,
-            },
-          }) +
-          '\n\n'
-      );
+      try {
+        await rewriteSseStream(
+          reader,
+          parser,
+          controller,
+          () => doneReceived,
+          responseReadError =>
+            'event: error\n' +
+            'data: ' +
+            JSON.stringify({
+              ...(generationId ? { id: generationId } : {}),
+              type: 'error',
+              error: {
+                type: 'api_error',
+                message: responseReadError.message,
+                error_type: responseReadError.errorType,
+              },
+            }) +
+            '\n\n'
+        );
+      } finally {
+        progress.stop();
+      }
     },
   });
 
@@ -409,8 +447,10 @@ export async function rewriteModelResponse_Responses(response: Response, removeC
       let doneReceived = false;
       let generationId: string | undefined;
       let nextSequenceNumber = 0;
+      const progress = createStreamProgressLogger('responses', () => generationId);
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
+          progress.eventProcessed();
           if (event.data === '[DONE]') {
             doneReceived = true;
             return;
@@ -439,26 +479,30 @@ export async function rewriteModelResponse_Responses(response: Response, removeC
         },
       });
 
-      await rewriteSseStream(
-        reader,
-        parser,
-        controller,
-        () => doneReceived,
-        responseReadError =>
-          'event: error\n' +
-          'data: ' +
-          JSON.stringify({
-            ...(generationId ? { id: generationId } : {}),
-            type: 'error',
-            sequence_number: nextSequenceNumber,
-            error: {
-              type: responseReadError.errorType,
-              code: responseReadError.errorType === 'timeout' ? '504' : '503',
-              message: responseReadError.message,
-            },
-          }) +
-          '\n\n'
-      );
+      try {
+        await rewriteSseStream(
+          reader,
+          parser,
+          controller,
+          () => doneReceived,
+          responseReadError =>
+            'event: error\n' +
+            'data: ' +
+            JSON.stringify({
+              ...(generationId ? { id: generationId } : {}),
+              type: 'error',
+              sequence_number: nextSequenceNumber,
+              error: {
+                type: responseReadError.errorType,
+                code: responseReadError.errorType === 'timeout' ? '504' : '503',
+                message: responseReadError.message,
+              },
+            }) +
+            '\n\n'
+        );
+      } finally {
+        progress.stop();
+      }
     },
   });
 

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -16,7 +16,7 @@ type ResponseReadError = {
   message: string;
 };
 
-const STREAM_PROGRESS_LOG_INTERVAL_MS = 60_000;
+const STREAM_PROGRESS_LOG_INTERVAL_MS = 30_000;
 
 function createStreamProgressLogger() {
   let eventCount = 0;

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -94,7 +94,8 @@ async function rewriteSseStream(
   parser: ReturnType<typeof createParser>,
   controller: ReadableStreamDefaultController<string>,
   doneReceived: () => boolean,
-  serializeError: (error: ResponseReadError) => string
+  serializeError: (error: ResponseReadError) => string,
+  onFinally: () => void
 ) {
   const decoder = new TextDecoder();
   try {
@@ -122,6 +123,7 @@ async function rewriteSseStream(
     controller.enqueue(serializeError(responseReadError));
     controller.close();
   } finally {
+    onFinally();
     reader.releaseLock();
   }
 }
@@ -225,27 +227,24 @@ export async function rewriteModelResponse_ChatCompletions(response: Response, r
         },
       });
 
-      try {
-        await rewriteSseStream(
-          reader,
-          parser,
-          controller,
-          () => doneReceived,
-          responseReadError =>
-            'data: ' +
-            JSON.stringify({
-              ...(generationId ? { id: generationId } : {}),
-              error: {
-                code: 503,
-                message: responseReadError.message,
-                type: responseReadError.errorType,
-              },
-            }) +
-            '\n\n'
-        );
-      } finally {
-        progress.stop();
-      }
+      await rewriteSseStream(
+        reader,
+        parser,
+        controller,
+        () => doneReceived,
+        responseReadError =>
+          'data: ' +
+          JSON.stringify({
+            ...(generationId ? { id: generationId } : {}),
+            error: {
+              code: 503,
+              message: responseReadError.message,
+              type: responseReadError.errorType,
+            },
+          }) +
+          '\n\n',
+        progress.stop
+      );
     },
   });
 
@@ -365,29 +364,26 @@ export async function rewriteModelResponse_Messages(response: Response, removeCo
         },
       });
 
-      try {
-        await rewriteSseStream(
-          reader,
-          parser,
-          controller,
-          () => doneReceived,
-          responseReadError =>
-            'event: error\n' +
-            'data: ' +
-            JSON.stringify({
-              ...(generationId ? { id: generationId } : {}),
-              type: 'error',
-              error: {
-                type: 'api_error',
-                message: responseReadError.message,
-                error_type: responseReadError.errorType,
-              },
-            }) +
-            '\n\n'
-        );
-      } finally {
-        progress.stop();
-      }
+      await rewriteSseStream(
+        reader,
+        parser,
+        controller,
+        () => doneReceived,
+        responseReadError =>
+          'event: error\n' +
+          'data: ' +
+          JSON.stringify({
+            ...(generationId ? { id: generationId } : {}),
+            type: 'error',
+            error: {
+              type: 'api_error',
+              message: responseReadError.message,
+              error_type: responseReadError.errorType,
+            },
+          }) +
+          '\n\n',
+        progress.stop
+      );
     },
   });
 
@@ -479,30 +475,27 @@ export async function rewriteModelResponse_Responses(response: Response, removeC
         },
       });
 
-      try {
-        await rewriteSseStream(
-          reader,
-          parser,
-          controller,
-          () => doneReceived,
-          responseReadError =>
-            'event: error\n' +
-            'data: ' +
-            JSON.stringify({
-              ...(generationId ? { id: generationId } : {}),
-              type: 'error',
-              sequence_number: nextSequenceNumber,
-              error: {
-                type: responseReadError.errorType,
-                code: responseReadError.errorType === 'timeout' ? '504' : '503',
-                message: responseReadError.message,
-              },
-            }) +
-            '\n\n'
-        );
-      } finally {
-        progress.stop();
-      }
+      await rewriteSseStream(
+        reader,
+        parser,
+        controller,
+        () => doneReceived,
+        responseReadError =>
+          'event: error\n' +
+          'data: ' +
+          JSON.stringify({
+            ...(generationId ? { id: generationId } : {}),
+            type: 'error',
+            sequence_number: nextSequenceNumber,
+            error: {
+              type: responseReadError.errorType,
+              code: responseReadError.errorType === 'timeout' ? '504' : '503',
+              message: responseReadError.message,
+            },
+          }) +
+          '\n\n',
+        progress.stop
+      );
     },
   });
 

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -18,17 +18,11 @@ type ResponseReadError = {
 
 const STREAM_PROGRESS_LOG_INTERVAL_MS = 60_000;
 
-function createStreamProgressLogger(
-  kind: GatewayRequest['kind'],
-  getGenerationId: () => string | undefined
-) {
+function createStreamProgressLogger() {
   let eventCount = 0;
   const interval = setInterval(() => {
-    const generationId = getGenerationId();
     logExceptInTest('[rewriteModelResponse] stream progress', {
-      kind,
       eventCount,
-      ...(generationId ? { generationId } : {}),
     });
   }, STREAM_PROGRESS_LOG_INTERVAL_MS);
 
@@ -185,7 +179,7 @@ export async function rewriteModelResponse_ChatCompletions(response: Response, r
 
       let doneReceived = false;
       let generationId: string | undefined;
-      const progress = createStreamProgressLogger('chat_completions', () => generationId);
+      const progress = createStreamProgressLogger();
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
           progress.eventProcessed();
@@ -322,7 +316,7 @@ export async function rewriteModelResponse_Messages(response: Response, removeCo
 
       let doneReceived = false;
       let generationId: string | undefined;
-      const progress = createStreamProgressLogger('messages', () => generationId);
+      const progress = createStreamProgressLogger();
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
           progress.eventProcessed();
@@ -443,7 +437,7 @@ export async function rewriteModelResponse_Responses(response: Response, removeC
       let doneReceived = false;
       let generationId: string | undefined;
       let nextSequenceNumber = 0;
-      const progress = createStreamProgressLogger('responses', () => generationId);
+      const progress = createStreamProgressLogger();
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
           progress.eventProcessed();


### PR DESCRIPTION
## Summary
- count parsed SSE events for Chat Completions, Messages, and Responses streams
- log cumulative event progress every 60 seconds with API kind and generation ID when known
- clear the progress interval on normal completion, stream errors, and parser failures
- cover the minute log payload and timer cleanup with a controlled-stream fake-timer test

## Verification
- formatted only the two touched files with `oxfmt`
- `git diff --check`
- full executable validation delegated to CI because local Jest global setup requires PostgreSQL