### PR TITLE
fix(ai-gateway): log request even when response body is unreadable

### DIFF
--- a/apps/web/src/lib/ai-gateway/handleRequestLogging.ts
+++ b/apps/web/src/lib/ai-gateway/handleRequestLogging.ts
@@ -44,10 +44,23 @@ export async function handleRequestLogging(params: {
     return;
   }
   after(async () => {
+    // Read the response body in its own try/catch: if it cannot be read (e.g.
+    // the stream errored mid-flight), still log the request without it.
     let response: string | undefined;
+    let responseReadError: string | undefined;
     try {
       response = await clonedResponse.text();
-      const error = detectToolCallArgumentErrors(response, request);
+    } catch (e) {
+      responseReadError = String(e).substring(0, 4000);
+      logExceptInTest(
+        `[handleRequestLogging] failed to read response body (user=${user?.id}, status=${clonedResponse.status}, model=${model}): ${responseReadError}`
+      );
+    }
+    try {
+      const error =
+        response !== undefined
+          ? detectToolCallArgumentErrors(response, request)
+          : { response_body_read_error: responseReadError };
       const apiRequestLogId = await db
         .insert(api_request_log)
         .values({


### PR DESCRIPTION
Reading the cloned response body with `clonedResponse.text()` can fail (e.g. the upstream stream errored mid-flight). Previously that threw before the insert, so the request was never recorded in `api_request_log` at all.

This change reads the body in its own try/catch and still inserts the log row when reading fails — with `response` left null and the read failure recorded in the `error` column as `{ response_body_read_error: ... }`, so the row explains why the body is missing. Successful reads behave exactly as before (including `detectToolCallArgumentErrors`).