### PR TITLE
feat(extension): collapse long assistant code blocks

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agent-chat-atoms.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-atoms.ts
@@ -20,14 +20,21 @@ export const contextUsageAtomFamily = atomFamily((_conversationId: string) =>
   atom<ContextUsage | undefined>()
 );
 
+// Event id of the assistant message currently streaming content for a conversation.
+// Cleared when that message's stream ends (even if later tool rounds continue).
+export const streamingMessageIdAtomFamily = atomFamily((_conversationId: string) =>
+  atom<string | undefined>()
+);
+
 // Ids of conversations with an in-flight run / compaction.
 export const runningConversationIdsAtom = atom<readonly string[]>([]);
 export const compactingConversationIdsAtom = atom<readonly string[]>([]);
 
-// Evict a single conversation's in-memory atoms (draft + context usage).
+// Evict a single conversation's in-memory atoms (draft + context usage + streaming id).
 export const evictConversationAtoms = (conversationId: string): void => {
   draftAtomFamily.remove(conversationId);
   contextUsageAtomFamily.remove(conversationId);
+  streamingMessageIdAtomFamily.remove(conversationId);
 };
 
 /*
@@ -37,7 +44,11 @@ export const evictConversationAtoms = (conversationId: string): void => {
  * the atom families would otherwise hand back the old account's values.
  */
 export const clearPerConversationAtoms = (): void => {
-  const ids = new Set([...draftAtomFamily.getParams(), ...contextUsageAtomFamily.getParams()]);
+  const ids = new Set([
+    ...draftAtomFamily.getParams(),
+    ...contextUsageAtomFamily.getParams(),
+    ...streamingMessageIdAtomFamily.getParams(),
+  ]);
   for (const id of ids) {
     evictConversationAtoms(id);
   }

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -10,6 +10,7 @@ import {
   evictConversationAtoms,
   remoteMcpStoreAtom,
   runningConversationIdsAtom,
+  streamingMessageIdAtomFamily,
 } from './agent-chat-atoms';
 import {
   createAssistantMessage,
@@ -161,6 +162,7 @@ export const AgentChatPanel = ({
   const isCompacting = compactingConversationIds.includes(activeConversationId);
   const activeUsage = useAtomValue(contextUsageAtomFamily(activeConversationId));
   const activePromptTokens = activeUsage?.promptTokens ?? 0;
+  const streamingMessageId = useAtomValue(streamingMessageIdAtomFamily(activeConversationId));
   const contextLength = selectedModel?.contextLength;
 
   const compactConversation = useCallback(
@@ -513,6 +515,11 @@ export const AgentChatPanel = ({
             }),
           fetch: fetchFromWindow,
           model: runModel,
+          onAssistantStreaming: eventId => {
+            if (isCurrentRun()) {
+              store.set(streamingMessageIdAtomFamily(conversationId), eventId);
+            }
+          },
           onUsage: updateRunUsage,
           organizationId,
           remoteMcpTools,
@@ -528,6 +535,7 @@ export const AgentChatPanel = ({
         });
       } finally {
         if (isCurrentRun()) {
+          store.set(streamingMessageIdAtomFamily(conversationId), undefined);
           runStatesRef.current.delete(conversationId);
           setRunningConversationIds(currentIds =>
             currentIds.filter(currentId => currentId !== conversationId)
@@ -619,11 +627,14 @@ export const AgentChatPanel = ({
     (conversationId: string): void => {
       runStatesRef.current.get(conversationId)?.abort.abort();
       runStatesRef.current.delete(conversationId);
+      // Required: deleting run-state makes the run's later finally see isCurrentRun() === false
+      // And skip cleanup; without this, close/delete mid-stream leaks a stale streaming id.
+      store.set(streamingMessageIdAtomFamily(conversationId), undefined);
       setRunningConversationIds(currentIds =>
         currentIds.filter(currentId => currentId !== conversationId)
       );
     },
-    [setRunningConversationIds]
+    [setRunningConversationIds, store]
   );
 
   const closeConversation = useCallback(
@@ -732,7 +743,7 @@ export const AgentChatPanel = ({
         onCreateConversation={createConversation}
         onSelectConversation={selectConversation}
       />
-      <ConversationList items={groupedEvents} />
+      <ConversationList items={groupedEvents} streamingMessageId={streamingMessageId} />
 
       {remoteMcpToolWarning === undefined ? null : (
         <p className="border-t border-amber-500/30 bg-amber-950/20 px-4 py-2 text-xs text-amber-300">

--- a/apps/extension/entrypoints/sidepanel/agent-conversation-events.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-conversation-events.tsx
@@ -1,4 +1,6 @@
-import type { JSX } from 'react';
+import type { JSX, ReactNode } from 'react';
+import { isValidElement } from 'react';
+import type { Components } from 'react-markdown';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
 import type {
@@ -6,9 +8,76 @@ import type {
   GroupedConversationItem,
 } from '@/src/shared/agent-conversation';
 import { getViewportScreenshotDataUrl } from '@/src/shared/agent-tool-output';
+// Explicit .tsx: collapsible-code-block.ts (pure helpers) shadows the default resolution.
+import { CollapsibleCodeBlock } from './collapsible-code-block.tsx';
 
 // Hoisted so the array reference is stable (react-perf) across renders.
 const remarkPlugins = [remarkGfm];
+
+const extractCodeText = (codeChildren: unknown): string | undefined => {
+  if (typeof codeChildren === 'string') {
+    return codeChildren;
+  }
+
+  if (Array.isArray(codeChildren) && codeChildren.every(part => typeof part === 'string')) {
+    return codeChildren.join('');
+  }
+
+  return undefined;
+};
+
+const asNodeList = (children: ReactNode): readonly unknown[] => {
+  if (Array.isArray(children)) {
+    return children;
+  }
+
+  return [children];
+};
+
+const extractCodeChild = (
+  children: ReactNode
+): { readonly className: string | undefined; readonly code: string } | undefined => {
+  for (const child of asNodeList(children)) {
+    if (child === null || typeof child !== 'object') {
+      // Skip non-element children (text nodes, null).
+    } else if (
+      isValidElement<{ children?: unknown; className?: string }>(child) &&
+      child.type === 'code'
+    ) {
+      const code = extractCodeText(child.props.children);
+
+      if (code === undefined) {
+        return undefined;
+      }
+
+      return { className: child.props.className, code };
+    }
+  }
+
+  return undefined;
+};
+
+const createAssistantMarkdownComponents = (forceExpanded: boolean): Components => ({
+  pre: ({ children }) => {
+    const extracted = extractCodeChild(children);
+
+    if (extracted === undefined) {
+      return <pre>{children}</pre>;
+    }
+
+    return (
+      <CollapsibleCodeBlock
+        code={extracted.code}
+        forceExpanded={forceExpanded}
+        languageClassName={extracted.className}
+      />
+    );
+  },
+});
+
+// Hoisted so the object reference is stable (react-perf) across renders.
+const assistantMarkdownComponentsStreaming = createAssistantMarkdownComponents(true);
+const assistantMarkdownComponentsFinalized = createAssistantMarkdownComponents(false);
 
 const formatToolValue = (value: unknown): string => {
   if (typeof value === 'string') {
@@ -37,10 +106,20 @@ const formatToolValue = (value: unknown): string => {
 
 const MessageEvent = ({
   event,
+  streamingMessageId,
 }: {
   event: Extract<AgentConversationEvent, { readonly type: 'message' }>;
+  streamingMessageId?: string | undefined;
 }): JSX.Element => {
   const isUser = event.role === 'user';
+  // Only assistant messages get collapsible code blocks; user branch keeps default rendering.
+  let assistantComponents: Components | undefined = undefined;
+  if (!isUser) {
+    assistantComponents =
+      event.id === streamingMessageId
+        ? assistantMarkdownComponentsStreaming
+        : assistantMarkdownComponentsFinalized;
+  }
 
   return (
     <div className={isUser ? 'flex justify-end' : 'flex justify-start'}>
@@ -52,7 +131,9 @@ const MessageEvent = ({
         }
       >
         <div className="agent-message-markdown">
-          <ReactMarkdown remarkPlugins={remarkPlugins}>{event.text}</ReactMarkdown>
+          <ReactMarkdown components={assistantComponents} remarkPlugins={remarkPlugins}>
+            {event.text}
+          </ReactMarkdown>
         </div>
       </div>
     </div>
@@ -169,8 +250,10 @@ const StandaloneToolEvent = ({
 
 export const AgentConversationItemView = ({
   item,
+  streamingMessageId,
 }: {
   item: GroupedConversationItem;
+  streamingMessageId?: string | undefined;
 }): JSX.Element => {
   if (item.type === 'tool-exchange') {
     return <ToolExchangeEvent item={item} />;
@@ -179,7 +262,7 @@ export const AgentConversationItemView = ({
   const { event } = item;
 
   if (event.type === 'message') {
-    return <MessageEvent event={event} />;
+    return <MessageEvent event={event} streamingMessageId={streamingMessageId} />;
   }
 
   if (event.type === 'thinking') {

--- a/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-llm-turn-runner.ts
@@ -45,6 +45,7 @@ interface RunDangerousLlmTurnOptions {
   readonly token: string;
   readonly updateAssistantMessage: (eventId: string, text: string) => void;
   readonly updateThinkingBlock: (eventId: string, text: string) => void;
+  readonly onAssistantStreaming?: ((eventId: string | undefined) => void) | undefined;
 }
 
 type DangerousToolCallEvent =

--- a/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.ts
+++ b/apps/extension/entrypoints/sidepanel/agent-safe-llm-turn-runner.ts
@@ -41,6 +41,7 @@ interface RunSafeLlmTurnOptions {
   readonly token: string;
   readonly updateAssistantMessage: (eventId: string, text: string) => void;
   readonly updateThinkingBlock: (eventId: string, text: string) => void;
+  readonly onAssistantStreaming?: ((eventId: string | undefined) => void) | undefined;
 }
 
 type SafeRunToolCallEvent =

--- a/apps/extension/entrypoints/sidepanel/collapsible-code-block.test.ts
+++ b/apps/extension/entrypoints/sidepanel/collapsible-code-block.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import {
+  COLLAPSE_LINE_THRESHOLD,
+  COLLAPSE_PREVIEW_LINES,
+  countCodeLines,
+  isCollapsible,
+  previewCode,
+  resolveCodeBlockChrome,
+} from './collapsible-code-block';
+
+const lines = (count: number, ending = '\n'): string =>
+  Array.from({ length: count }, (_unused, index) => `line-${index + 1}`).join('\n') + ending;
+
+describe('countCodeLines helper', () => {
+  it('returns 0 for the empty string', () => {
+    expect(countCodeLines('')).toBe(0);
+  });
+
+  it('returns 0 for a lone trailing newline', () => {
+    expect(countCodeLines('\n')).toBe(0);
+  });
+
+  it('does not count a single trailing newline as a phantom empty line', () => {
+    expect(countCodeLines('a\n')).toBe(1);
+    expect(countCodeLines('a\nb\n')).toBe(2);
+  });
+
+  it('counts content without a trailing newline', () => {
+    expect(countCodeLines('a')).toBe(1);
+    expect(countCodeLines('a\nb')).toBe(2);
+  });
+
+  it('handles CRLF and bare CR', () => {
+    expect(countCodeLines('a\r\nb\r\n')).toBe(2);
+    expect(countCodeLines('a\rb\r')).toBe(2);
+    expect(countCodeLines('a\r\nb\rc\n')).toBe(3);
+  });
+
+  it('counts a real empty line before a trailing newline', () => {
+    expect(countCodeLines('a\n\n')).toBe(2);
+  });
+});
+
+describe('isCollapsible helper', () => {
+  it(`is false at the threshold (${COLLAPSE_LINE_THRESHOLD} lines)`, () => {
+    expect(isCollapsible(lines(COLLAPSE_LINE_THRESHOLD))).toBe(false);
+    expect(isCollapsible(lines(COLLAPSE_LINE_THRESHOLD, ''))).toBe(false);
+  });
+
+  it(`is true above the threshold (${COLLAPSE_LINE_THRESHOLD + 1} lines)`, () => {
+    expect(isCollapsible(lines(COLLAPSE_LINE_THRESHOLD + 1))).toBe(true);
+    expect(isCollapsible(lines(COLLAPSE_LINE_THRESHOLD + 1, ''))).toBe(true);
+  });
+
+  it('is false for short and empty blocks', () => {
+    expect(isCollapsible('')).toBe(false);
+    expect(isCollapsible(lines(1))).toBe(false);
+  });
+});
+
+describe('previewCode helper', () => {
+  it(`returns the first ${COLLAPSE_PREVIEW_LINES} lines`, () => {
+    const code = lines(20);
+    const preview = previewCode(code);
+    expect(preview.split('\n')).toHaveLength(COLLAPSE_PREVIEW_LINES);
+    expect(preview).toBe(lines(COLLAPSE_PREVIEW_LINES, ''));
+  });
+
+  it('returns the full short block when under the preview length', () => {
+    expect(previewCode('a\nb')).toBe('a\nb');
+    expect(previewCode('a\nb\n')).toBe('a\nb');
+  });
+
+  it('returns empty for empty input', () => {
+    expect(previewCode('')).toBe('');
+  });
+});
+
+describe('resolveCodeBlockChrome helper', () => {
+  it('returns plain when not collapsible regardless of forceExpanded', () => {
+    expect(resolveCodeBlockChrome({ collapsible: false, forceExpanded: false })).toBe('plain');
+    expect(resolveCodeBlockChrome({ collapsible: false, forceExpanded: true })).toBe('plain');
+  });
+
+  it('returns expanded-no-chrome when collapsible and forceExpanded (this message streaming)', () => {
+    expect(resolveCodeBlockChrome({ collapsible: true, forceExpanded: true })).toBe(
+      'expanded-no-chrome'
+    );
+  });
+
+  it('returns collapsible when collapsible and not forceExpanded (finalized long block)', () => {
+    expect(resolveCodeBlockChrome({ collapsible: true, forceExpanded: false })).toBe('collapsible');
+  });
+
+  it('treats a streaming id for a previous message as forceExpanded false on the current message', () => {
+    // MessageEvent computes forceExpanded as event.id === streamingMessageId.
+    // When streamingMessageId points at a previous message, the current message
+    // Receives forceExpanded: false and a long block must still collapse.
+    const currentMessageForceExpanded = false;
+    expect(
+      resolveCodeBlockChrome({
+        collapsible: true,
+        forceExpanded: currentMessageForceExpanded,
+      })
+    ).toBe('collapsible');
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/collapsible-code-block.ts
+++ b/apps/extension/entrypoints/sidepanel/collapsible-code-block.ts
@@ -1,0 +1,66 @@
+export const COLLAPSE_LINE_THRESHOLD = 15;
+export const COLLAPSE_PREVIEW_LINES = 8;
+
+const normalizeNewlines = (code: string): string =>
+  code.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+
+/** Trailing-newline tolerant line count (a trailing `\n` does not create a phantom empty line). */
+export const countCodeLines = (code: string): number => {
+  if (code === '') {
+    return 0;
+  }
+
+  const normalized = normalizeNewlines(code);
+  const withoutTrailingNewline = normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized;
+
+  if (withoutTrailingNewline === '') {
+    return 0;
+  }
+
+  return withoutTrailingNewline.split('\n').length;
+};
+
+export const isCollapsible = (code: string): boolean =>
+  countCodeLines(code) > COLLAPSE_LINE_THRESHOLD;
+
+/** First {@link COLLAPSE_PREVIEW_LINES} lines of the code block. */
+export const previewCode = (code: string): string => {
+  if (code === '') {
+    return '';
+  }
+
+  const normalized = normalizeNewlines(code);
+  const withoutTrailingNewline = normalized.endsWith('\n') ? normalized.slice(0, -1) : normalized;
+
+  if (withoutTrailingNewline === '') {
+    return '';
+  }
+
+  return withoutTrailingNewline.split('\n').slice(0, COLLAPSE_PREVIEW_LINES).join('\n');
+};
+
+export type CodeBlockChrome = 'plain' | 'expanded-no-chrome' | 'collapsible';
+
+/**
+ * Pure render decision for an assistant markdown code block.
+ * - plain: short block, identical to default ReactMarkdown output
+ * - expanded-no-chrome: long block while this message is still streaming
+ * - collapsible: long finalized block with collapse chrome
+ */
+export const resolveCodeBlockChrome = ({
+  collapsible,
+  forceExpanded,
+}: {
+  readonly collapsible: boolean;
+  readonly forceExpanded: boolean;
+}): CodeBlockChrome => {
+  if (!collapsible) {
+    return 'plain';
+  }
+
+  if (forceExpanded) {
+    return 'expanded-no-chrome';
+  }
+
+  return 'collapsible';
+};

--- a/apps/extension/entrypoints/sidepanel/collapsible-code-block.tsx
+++ b/apps/extension/entrypoints/sidepanel/collapsible-code-block.tsx
@@ -1,0 +1,76 @@
+import { ChevronDown, ChevronUp } from 'lucide-react';
+import { useState } from 'react';
+import type { JSX } from 'react';
+import {
+  countCodeLines,
+  isCollapsible,
+  previewCode,
+  resolveCodeBlockChrome,
+} from './collapsible-code-block';
+
+interface CollapsibleCodeBlockProps {
+  readonly code: string;
+  readonly forceExpanded: boolean;
+  readonly languageClassName?: string | undefined;
+}
+
+const CodePre = ({
+  children,
+  languageClassName,
+}: {
+  readonly children: string;
+  readonly languageClassName: string | undefined;
+}): JSX.Element => (
+  <pre>
+    <code className={languageClassName}>{children}</code>
+  </pre>
+);
+
+export const CollapsibleCodeBlock = ({
+  code,
+  forceExpanded,
+  languageClassName,
+}: CollapsibleCodeBlockProps): JSX.Element => {
+  // Always call hooks: collapsible can flip false→true while streaming crosses the
+  // Threshold, and forceExpanded can flip true→false at finalize. Conditional hooks
+  // Would break order and drop expand state at that handoff.
+  const [expanded, setExpanded] = useState(false);
+  const collapsible = isCollapsible(code);
+  const chrome = resolveCodeBlockChrome({ collapsible, forceExpanded });
+
+  if (chrome === 'plain' || chrome === 'expanded-no-chrome') {
+    return <CodePre languageClassName={languageClassName}>{code}</CodePre>;
+  }
+
+  const lineCount = countCodeLines(code);
+  const displayCode = expanded ? code : previewCode(code);
+
+  return (
+    <div className="relative min-w-0">
+      <div className="relative min-w-0">
+        <CodePre languageClassName={languageClassName}>{displayCode}</CodePre>
+        {expanded ? null : (
+          <div
+            aria-hidden="true"
+            className="pointer-events-none absolute inset-x-0 bottom-0 h-10 rounded-b bg-gradient-to-t from-[rgb(9_9_11)] to-transparent"
+          />
+        )}
+      </div>
+      <button
+        aria-expanded={expanded}
+        className="mt-1 flex w-full items-center gap-1 rounded px-1 py-0.5 text-left text-[11px] font-medium text-zinc-400 outline-none transition hover:text-zinc-200 focus-visible:ring-2 focus-visible:ring-[#EDFF00] focus-visible:ring-offset-2 focus-visible:ring-offset-zinc-950"
+        onClick={() => {
+          setExpanded(current => !current);
+        }}
+        type="button"
+      >
+        {expanded ? (
+          <ChevronUp aria-hidden="true" className="size-3 shrink-0" />
+        ) : (
+          <ChevronDown aria-hidden="true" className="size-3 shrink-0" />
+        )}
+        <span>{expanded ? 'Show less' : `Show more (${lineCount} lines)`}</span>
+      </button>
+    </div>
+  );
+};

--- a/apps/extension/entrypoints/sidepanel/conversation-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/conversation-list.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { ArrowDown } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { CSSProperties, JSX } from 'react';
@@ -23,11 +24,13 @@ const ConversationVirtualRow = ({
   item,
   measureElement,
   start,
+  streamingMessageId,
 }: {
   index: number;
   item: GroupedConversationItem;
   measureElement: (element: HTMLElement) => void;
   start: number;
+  streamingMessageId?: string | undefined;
 }): JSX.Element => {
   const rowRef = useRef<HTMLDivElement | null>(null);
 
@@ -59,12 +62,18 @@ const ConversationVirtualRow = ({
       ref={rowRef}
       style={getVirtualRowStyle(start)}
     >
-      <AgentConversationItemView item={item} />
+      <AgentConversationItemView item={item} streamingMessageId={streamingMessageId} />
     </div>
   );
 };
 
-export const ConversationList = ({ items }: { items: GroupedConversationItem[] }): JSX.Element => {
+export const ConversationList = ({
+  items,
+  streamingMessageId,
+}: {
+  items: GroupedConversationItem[];
+  streamingMessageId?: string | undefined;
+}): JSX.Element => {
   const listRef = useRef<HTMLElement | null>(null);
   // Source of truth for auto-scroll, owned outside React so a streaming render cannot race it. The state mirror below only drives the jump button.
   const isStuckToBottomRef = useRef(true);
@@ -280,6 +289,7 @@ export const ConversationList = ({ items }: { items: GroupedConversationItem[] }
                 key={getConversationItemKey(item)}
                 measureElement={virtualizer.measureElement}
                 start={virtualItem.start}
+                streamingMessageId={streamingMessageId}
               />
             );
           })}

--- a/apps/extension/src/shared/agent-chat-atoms.test.ts
+++ b/apps/extension/src/shared/agent-chat-atoms.test.ts
@@ -9,25 +9,29 @@ import {
   draftAtomFamily,
   evictConversationAtoms,
   runningConversationIdsAtom,
+  streamingMessageIdAtomFamily,
 } from '@/entrypoints/sidepanel/agent-chat-atoms';
 
 describe('per-conversation atom eviction', () => {
-  it('evictConversationAtoms resets draft and usage for a conversation id', () => {
+  it('evictConversationAtoms resets draft, usage, and streaming id for a conversation id', () => {
     const store = getDefaultStore();
     store.set(draftAtomFamily('conversation-1'), 'hello');
     store.set(contextUsageAtomFamily('conversation-1'), { promptTokens: 42 });
+    store.set(streamingMessageIdAtomFamily('conversation-1'), 'msg-streaming');
 
     evictConversationAtoms('conversation-1');
 
     // A fresh atom (post-remove) starts from its initial value.
     expect(store.get(draftAtomFamily('conversation-1'))).toBe('');
     expect(store.get(contextUsageAtomFamily('conversation-1'))).toBeUndefined();
+    expect(store.get(streamingMessageIdAtomFamily('conversation-1'))).toBeUndefined();
   });
 
-  it('clearPerConversationAtoms wipes all drafts, usage, and run-state on sign-out', () => {
+  it('clearPerConversationAtoms wipes all drafts, usage, streaming ids, and run-state on sign-out', () => {
     const store = getDefaultStore();
     store.set(draftAtomFamily('conversation-1'), 'prev account draft');
     store.set(contextUsageAtomFamily('conversation-2'), { promptTokens: 999 });
+    store.set(streamingMessageIdAtomFamily('conversation-3'), 'msg-only-streaming');
     store.set(runningConversationIdsAtom, ['conversation-1']);
     store.set(compactingConversationIdsAtom, ['conversation-2']);
 
@@ -35,7 +39,17 @@ describe('per-conversation atom eviction', () => {
 
     expect(store.get(draftAtomFamily('conversation-1'))).toBe('');
     expect(store.get(contextUsageAtomFamily('conversation-2'))).toBeUndefined();
+    expect(store.get(streamingMessageIdAtomFamily('conversation-3'))).toBeUndefined();
     expect(store.get(runningConversationIdsAtom)).toStrictEqual([]);
     expect(store.get(compactingConversationIdsAtom)).toStrictEqual([]);
+  });
+
+  it('clearPerConversationAtoms wipes a conversation that has only a streaming entry', () => {
+    const store = getDefaultStore();
+    store.set(streamingMessageIdAtomFamily('conversation-streaming-only'), 'msg-mid-first-run');
+
+    clearPerConversationAtoms();
+
+    expect(store.get(streamingMessageIdAtomFamily('conversation-streaming-only'))).toBeUndefined();
   });
 });

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines */
 import { describe, expect, it } from 'vitest';
 import { z } from 'zod';
 import { createSafeToolCall, createUserMessage } from './agent-conversation';
@@ -192,5 +193,140 @@ describe('agent LLM turn runner core', () => {
       text: 'Too many tool rounds.',
       type: 'message',
     });
+  });
+
+  it('fires onAssistantStreaming with the event id at first content delta and undefined when the stream resolves', async () => {
+    const streamingCalls: (string | undefined)[] = [];
+    const appendedEvents: AgentConversationEvent[] = [];
+    const fetch: FetchLike = () =>
+      streamResponse([
+        'data: {"choices":[{"delta":{"content":"Hello"}}]}\n\n',
+        'data: {"choices":[{"delta":{"content":" world"}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+
+    await runLlmTurn({
+      apiBaseUrl: 'https://app.kilo.ai',
+      appendEvents: events => {
+        appendedEvents.push(...events);
+      },
+      conversationEvents: [createUserMessage('Hi')],
+      executeToolCall: () => Promise.resolve({ ok: true, value: { text: '' } }),
+      failureMessage: String,
+      fetch,
+      maxToolRounds: 4,
+      model: 'anthropic/claude-sonnet-4',
+      noResponseMessage: 'No response.',
+      onAssistantStreaming: eventId => {
+        streamingCalls.push(eventId);
+      },
+      signal: undefined,
+      toToolCallEvents: () => [],
+      token: 'token-1',
+      tooManyToolRoundsMessage: 'Too many rounds.',
+      tools: [],
+      updateAssistantMessage: () => {},
+      updateThinkingBlock: () => {},
+    });
+
+    const assistantMessages = appendedEvents.filter(
+      (event): event is Extract<AgentConversationEvent, { type: 'message' }> =>
+        event.type === 'message'
+    );
+    expect(assistantMessages).toHaveLength(1);
+    expect(streamingCalls).toHaveLength(2);
+    expect(streamingCalls[0]).toBe(assistantMessages[0]?.id);
+    expect(streamingCalls[1]).toBeUndefined();
+  });
+
+  it('fires onAssistantStreaming undefined via try/finally when the stream rejects after a start', async () => {
+    const streamingCalls: (string | undefined)[] = [];
+    const encoder = new TextEncoder();
+    // Pull 1 delivers a content delta (starts streaming); pull 2 errors the stream.
+    // Array dispatch avoids controller.error wiping an already-enqueued chunk before the first read.
+    const pullActions: ((controller: ReadableStreamDefaultController<Uint8Array>) => void)[] = [
+      controller => {
+        controller.enqueue(
+          encoder.encode('data: {"choices":[{"delta":{"content":"Partial"}}]}\n\n')
+        );
+      },
+      controller => {
+        controller.error(new Error('network dropped'));
+      },
+    ];
+    let pullIndex = 0;
+    const fetch: FetchLike = () =>
+      new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            pullActions[pullIndex]?.(controller);
+            pullIndex += 1;
+          },
+        }),
+        {
+          headers: { 'Content-Type': 'text/event-stream' },
+          status: 200,
+        }
+      );
+
+    await runLlmTurn({
+      apiBaseUrl: 'https://app.kilo.ai',
+      appendEvents: () => {},
+      conversationEvents: [createUserMessage('Hi')],
+      executeToolCall: () => Promise.resolve({ ok: true, value: { text: '' } }),
+      failureMessage: String,
+      fetch,
+      maxToolRounds: 4,
+      model: 'anthropic/claude-sonnet-4',
+      noResponseMessage: 'No response.',
+      onAssistantStreaming: eventId => {
+        streamingCalls.push(eventId);
+      },
+      signal: undefined,
+      toToolCallEvents: () => [],
+      token: 'token-1',
+      tooManyToolRoundsMessage: 'Too many rounds.',
+      tools: [],
+      updateAssistantMessage: () => {},
+      updateThinkingBlock: () => {},
+    });
+
+    expect(streamingCalls).toHaveLength(2);
+    const [startedId, endedId] = streamingCalls;
+    expect(startedId).toBeDefined();
+    expect(startedId).not.toBe('');
+    expect(endedId).toBeUndefined();
+  });
+
+  it('never fires onAssistantStreaming when the stream has no content deltas', async () => {
+    const streamingCalls: (string | undefined)[] = [];
+    // Empty stream: no onContentDelta calls, so the non-streamed start path never runs.
+    // Deltas absent means the defensive completion.content branch is not exercised here;
+    // The public stream client never produces content without deltas.
+    const fetch: FetchLike = () => streamResponse(['data: [DONE]\n\n']);
+
+    await runLlmTurn({
+      apiBaseUrl: 'https://app.kilo.ai',
+      appendEvents: () => {},
+      conversationEvents: [createUserMessage('Hi')],
+      executeToolCall: () => Promise.resolve({ ok: true, value: { text: '' } }),
+      failureMessage: String,
+      fetch,
+      maxToolRounds: 4,
+      model: 'anthropic/claude-sonnet-4',
+      noResponseMessage: 'No response.',
+      onAssistantStreaming: eventId => {
+        streamingCalls.push(eventId);
+      },
+      signal: undefined,
+      toToolCallEvents: () => [],
+      token: 'token-1',
+      tooManyToolRoundsMessage: 'Too many rounds.',
+      tools: [],
+      updateAssistantMessage: () => {},
+      updateThinkingBlock: () => {},
+    });
+
+    expect(streamingCalls).toStrictEqual([]);
   });
 });

--- a/apps/extension/src/shared/agent-llm-turn-runner-core.ts
+++ b/apps/extension/src/shared/agent-llm-turn-runner-core.ts
@@ -36,6 +36,8 @@ interface RunLlmTurnOptions<ToolCall extends ToolCallEvent> {
   readonly toToolCallEvents: (toolCalls: KiloGatewayToolCallRequest[]) => ToolCall[];
   readonly updateAssistantMessage: (eventId: string, text: string) => void;
   readonly updateThinkingBlock: (eventId: string, text: string) => void;
+  /** Fires with the assistant event id on first content delta; fires undefined when that stream ends. */
+  readonly onAssistantStreaming?: ((eventId: string | undefined) => void) | undefined;
 }
 
 // Attach the turn's reasoning blocks to the first tool call so the harness can replay them on the assistant tool-call message (providers may require signed/encrypted reasoning for a continuation).
@@ -78,6 +80,7 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
   toToolCallEvents,
   updateAssistantMessage,
   updateThinkingBlock,
+  onAssistantStreaming,
 }: RunLlmTurnOptions<ToolCall>): Promise<void> => {
   const getGatewayChatCompletion = (
     nextEvents: AgentConversationEvent[],
@@ -109,94 +112,107 @@ export const runLlmTurn = async <ToolCall extends ToolCallEvent>({
     let streamedAssistantEventId: string | undefined = undefined;
     let streamedThinkingText = '';
     let streamedThinkingEventId: string | undefined = undefined;
-    const completion = await getGatewayChatCompletion(
-      nextEvents,
-      delta => {
-        streamedText += delta;
+    let didStartAssistantStreaming = false;
 
-        if (streamedAssistantEventId === undefined) {
-          const assistantEvent = createAssistantMessage(streamedText);
+    try {
+      const completion = await getGatewayChatCompletion(
+        nextEvents,
+        delta => {
+          streamedText += delta;
 
-          streamedAssistantEventId = assistantEvent.id;
-          completionEvents.push(assistantEvent);
-          appendEvents([assistantEvent]);
-          return;
+          if (streamedAssistantEventId === undefined) {
+            const assistantEvent = createAssistantMessage(streamedText);
+
+            streamedAssistantEventId = assistantEvent.id;
+            didStartAssistantStreaming = true;
+            onAssistantStreaming?.(assistantEvent.id);
+            completionEvents.push(assistantEvent);
+            appendEvents([assistantEvent]);
+            return;
+          }
+
+          updateAssistantMessage(streamedAssistantEventId, streamedText);
+        },
+        delta => {
+          streamedThinkingText += delta;
+
+          if (streamedThinkingEventId === undefined) {
+            const thinkingEvent = createThinkingBlock(streamedThinkingText);
+
+            streamedThinkingEventId = thinkingEvent.id;
+            completionEvents.push(thinkingEvent);
+            appendEvents([thinkingEvent]);
+            return;
+          }
+
+          updateThinkingBlock(streamedThinkingEventId, streamedThinkingText);
         }
-
-        updateAssistantMessage(streamedAssistantEventId, streamedText);
-      },
-      delta => {
-        streamedThinkingText += delta;
-
-        if (streamedThinkingEventId === undefined) {
-          const thinkingEvent = createThinkingBlock(streamedThinkingText);
-
-          streamedThinkingEventId = thinkingEvent.id;
-          completionEvents.push(thinkingEvent);
-          appendEvents([thinkingEvent]);
-          return;
-        }
-
-        updateThinkingBlock(streamedThinkingEventId, streamedThinkingText);
-      }
-    );
-
-    if (completion.usage !== undefined) {
-      onUsage?.(completion.usage);
-    }
-
-    if (streamedThinkingEventId !== undefined) {
-      const finalStreamedThinkingText = completion.reasoning ?? streamedThinkingText;
-      const streamedThinkingEventIndex = completionEvents.findIndex(
-        event => event.id === streamedThinkingEventId
       );
 
-      if (streamedThinkingEventIndex !== -1) {
-        completionEvents.splice(streamedThinkingEventIndex, 1, {
-          id: streamedThinkingEventId,
-          text: finalStreamedThinkingText,
-          type: 'thinking',
-        });
+      if (completion.usage !== undefined) {
+        onUsage?.(completion.usage);
       }
-    }
 
-    if (streamedAssistantEventId !== undefined) {
-      const finalStreamedText = completion.content ?? streamedText;
-      const streamedAssistantEventIndex = completionEvents.findIndex(
-        event => event.id === streamedAssistantEventId
+      if (streamedThinkingEventId !== undefined) {
+        const finalStreamedThinkingText = completion.reasoning ?? streamedThinkingText;
+        const streamedThinkingEventIndex = completionEvents.findIndex(
+          event => event.id === streamedThinkingEventId
+        );
+
+        if (streamedThinkingEventIndex !== -1) {
+          completionEvents.splice(streamedThinkingEventIndex, 1, {
+            id: streamedThinkingEventId,
+            text: finalStreamedThinkingText,
+            type: 'thinking',
+          });
+        }
+      }
+
+      if (streamedAssistantEventId !== undefined) {
+        const finalStreamedText = completion.content ?? streamedText;
+        const streamedAssistantEventIndex = completionEvents.findIndex(
+          event => event.id === streamedAssistantEventId
+        );
+
+        if (streamedAssistantEventIndex !== -1) {
+          completionEvents.splice(streamedAssistantEventIndex, 1, {
+            id: streamedAssistantEventId,
+            role: 'assistant',
+            text: finalStreamedText,
+            type: 'message',
+          });
+        }
+      }
+
+      // Non-streamed completion.content path: no onAssistantStreaming start/end.
+      if (completion.content !== undefined && streamedAssistantEventId === undefined) {
+        completionEvents.push(createAssistantMessage(completion.content));
+      }
+
+      if (completion.reasoning !== undefined && streamedThinkingEventId === undefined) {
+        completionEvents.push(createThinkingBlock(completion.reasoning));
+      }
+
+      const toolCallEvents = withReasoningDetails(
+        toToolCallEvents(completion.toolCalls),
+        completion.reasoningDetails
+      );
+      completionEvents.push(...toolCallEvents);
+
+      appendEvents(
+        completionEvents.filter(
+          event => event.id !== streamedAssistantEventId && event.id !== streamedThinkingEventId
+        )
       );
 
-      if (streamedAssistantEventIndex !== -1) {
-        completionEvents.splice(streamedAssistantEventIndex, 1, {
-          id: streamedAssistantEventId,
-          role: 'assistant',
-          text: finalStreamedText,
-          type: 'message',
-        });
+      return { completionEvents, toolCallEvents };
+    } finally {
+      if (didStartAssistantStreaming) {
+        // Explicit clear: callers key collapse chrome off this id being undefined.
+        const cleared: string | undefined = undefined;
+        onAssistantStreaming?.(cleared);
       }
     }
-
-    if (completion.content !== undefined && streamedAssistantEventId === undefined) {
-      completionEvents.push(createAssistantMessage(completion.content));
-    }
-
-    if (completion.reasoning !== undefined && streamedThinkingEventId === undefined) {
-      completionEvents.push(createThinkingBlock(completion.reasoning));
-    }
-
-    const toolCallEvents = withReasoningDetails(
-      toToolCallEvents(completion.toolCalls),
-      completion.reasoningDetails
-    );
-    completionEvents.push(...toolCallEvents);
-
-    appendEvents(
-      completionEvents.filter(
-        event => event.id !== streamedAssistantEventId && event.id !== streamedThinkingEventId
-      )
-    );
-
-    return { completionEvents, toolCallEvents };
   };
 
   try {

--- a/apps/extension/tests/e2e/collapsible-code-blocks.test.ts
+++ b/apps/extension/tests/e2e/collapsible-code-blocks.test.ts
@@ -1,0 +1,147 @@
+/* eslint-disable import/no-nodejs-modules */
+import { expect, test } from '@playwright/test';
+import { rm } from 'node:fs/promises';
+import { mockKiloApi, readSidePanelScrollState } from './kilo-api-fixture';
+import {
+  launchExtensionContext,
+  seedExtensionAuth,
+  startFixtureServer,
+} from './extension-context-fixture';
+
+const longCodeBlock = (prefix: string, lineCount: number, language: string): string => {
+  const lines = Array.from({ length: lineCount }, (_value, index) => `${prefix} ${index + 1}`);
+
+  return `\`\`\`${language}\n${lines.join('\n')}\n\`\`\``;
+};
+
+const collapsibleCodeMarkdown = [
+  longCodeBlock('line', 20, 'ts'),
+  '',
+  longCodeBlock('other', 18, 'ts'),
+  '',
+  longCodeBlock('short', 3, 'ts'),
+].join('\n');
+
+const readHorizontalOverflowState = (): {
+  conversationHasHorizontalScroll: boolean;
+  documentFitsWidth: boolean;
+} => {
+  const conversation = document.querySelector('[aria-label="Agent conversation"]');
+
+  if (!(conversation instanceof HTMLElement)) {
+    throw new Error('Agent conversation pane was not found.');
+  }
+
+  return {
+    conversationHasHorizontalScroll: conversation.scrollWidth > conversation.clientWidth,
+    documentFitsWidth: document.documentElement.scrollWidth <= document.documentElement.clientWidth,
+  };
+};
+
+test('long assistant code blocks are collapsible', async () => {
+  const fixture = await startFixtureServer();
+  const { context, extensionId, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context, {
+      firstCompletionEvents: [
+        {
+          choices: [
+            {
+              delta: {
+                content: collapsibleCodeMarkdown,
+              },
+            },
+          ],
+        },
+      ],
+    });
+
+    const page = await context.newPage();
+    await page.goto(fixture.url);
+
+    const sidePanel = await context.newPage();
+    await sidePanel.setViewportSize({ height: 420, width: 360 });
+    await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+    await seedExtensionAuth(sidePanel);
+    await sidePanel.reload();
+
+    await sidePanel.getByRole('button', { name: /Safe mode/u }).click();
+    await sidePanel.getByRole('button', { name: 'Dangerous' }).click();
+    await sidePanel.getByLabel('Message agent').fill('Show collapsible code');
+    await sidePanel.getByLabel('Message agent').press('Enter');
+
+    const showMore20 = sidePanel.getByRole('button', { name: 'Show more (20 lines)' });
+    const showMore18 = sidePanel.getByRole('button', { name: 'Show more (18 lines)' });
+
+    await expect(showMore20).toBeVisible();
+    await expect(showMore18).toBeVisible();
+    await expect(showMore20).toHaveAttribute('aria-expanded', 'false');
+    await expect(showMore18).toHaveAttribute('aria-expanded', 'false');
+    await expect(sidePanel.getByRole('button', { name: /^Show more|^Show less/u })).toHaveCount(2);
+
+    const firstBlock = sidePanel
+      .locator('div.relative.min-w-0')
+      .filter({ has: showMore20 })
+      .first();
+    const secondBlock = sidePanel
+      .locator('div.relative.min-w-0')
+      .filter({ has: showMore18 })
+      .first();
+
+    await expect(firstBlock.locator('pre code')).toContainText('line 1');
+    await expect(firstBlock.locator('pre code')).toContainText('line 8');
+    await expect(firstBlock.locator('pre code')).not.toContainText('line 9');
+    await expect(sidePanel.locator('body')).not.toContainText('line 9');
+    await expect(firstBlock.locator('div[aria-hidden="true"]')).toBeVisible();
+
+    await expect(secondBlock.locator('pre code')).toContainText('other 1');
+    await expect(secondBlock.locator('pre code')).toContainText('other 8');
+    await expect(secondBlock.locator('pre code')).not.toContainText('other 9');
+    await expect(sidePanel.locator('body')).not.toContainText('other 9');
+
+    await expect(sidePanel.locator('pre code').filter({ hasText: 'short 1' })).toContainText(
+      'short 3'
+    );
+    await expect(sidePanel.locator('body')).toContainText('short 1');
+    await expect(sidePanel.locator('body')).toContainText('short 2');
+    await expect(sidePanel.locator('body')).toContainText('short 3');
+    await expect(sidePanel.getByRole('button', { name: 'Show more (3 lines)' })).toHaveCount(0);
+
+    const noHorizontalOverflow = await sidePanel.evaluate(readHorizontalOverflowState);
+
+    expect(noHorizontalOverflow.documentFitsWidth).toBe(true);
+    expect(noHorizontalOverflow.conversationHasHorizontalScroll).toBe(false);
+
+    await showMore20.click();
+
+    const showLess = sidePanel.getByRole('button', { name: 'Show less' });
+
+    await expect(showLess).toBeVisible();
+    await expect(showLess).toHaveAttribute('aria-expanded', 'true');
+    await expect(sidePanel.getByRole('button', { name: 'Show more (20 lines)' })).toHaveCount(0);
+    await expect(sidePanel.locator('body')).toContainText('line 20');
+    await expect(sidePanel.locator('body')).not.toContainText('other 18');
+    await expect(showMore18).toBeVisible();
+    await expect(showMore18).toHaveAttribute('aria-expanded', 'false');
+    await expect(showMore18).toHaveText(/Show more \(18 lines\)/u);
+
+    await showLess.click();
+
+    await expect(showMore20).toBeVisible();
+    await expect(showMore20).toHaveAttribute('aria-expanded', 'false');
+    await expect(sidePanel.getByRole('button', { name: 'Show less' })).toHaveCount(0);
+    await expect(sidePanel.locator('body')).not.toContainText('line 20');
+    await expect(showMore18).toHaveAttribute('aria-expanded', 'false');
+
+    await expect(sidePanel.getByLabel('Agent conversation')).toBeVisible();
+
+    const scrollState = await sidePanel.evaluate(readSidePanelScrollState);
+
+    expect(scrollState.documentScrollHeight).toBe(scrollState.documentClientHeight);
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -29,6 +29,7 @@ const chromeWorkflowNames = [
   'closing a conversation removes only that tab',
   'conversation tab bar scrolls horizontally',
   'assistant messages render markdown',
+  'long assistant code blocks are collapsible',
   'only the message pane scrolls virtualized overflowing conversation content',
   'manual scroll up shows jump to latest without following new messages',
   'scrolling back to bottom reactivates automatic scroll to new messages',
@@ -1137,7 +1138,116 @@ const scenarios: FirefoxScenario[] = [
       ),
   },
   {
+    name: 'long assistant code blocks are collapsible',
+    run: context =>
+      withSession(
+        context.api,
+        {
+          firstCompletionEvents: [
+            {
+              choices: [
+                {
+                  delta: {
+                    content: [
+                      '```ts',
+                      ...Array.from({ length: 20 }, (_value, index) => `line ${index + 1}`),
+                      '```',
+                      '',
+                      '```ts',
+                      ...Array.from({ length: 18 }, (_value, index) => `other ${index + 1}`),
+                      '```',
+                      '',
+                      '```ts',
+                      ...Array.from({ length: 3 }, (_value, index) => `short ${index + 1}`),
+                      '```',
+                    ].join('\n'),
+                  },
+                },
+              ],
+            },
+          ],
+        },
+        async session => {
+          await submitDangerousPrompt(session, 'Show collapsible code');
+          await waitForText(session.driver, 'Show more (20 lines)');
+          await waitForText(session.driver, 'Show more (18 lines)');
+          await waitForText(session.driver, 'short 3');
+
+          const showMore20 = await session.driver.findElement(
+            By.xpath('//button[contains(normalize-space(.), "Show more (20 lines)")]')
+          );
+          const showMore18 = await session.driver.findElement(
+            By.xpath('//button[contains(normalize-space(.), "Show more (18 lines)")]')
+          );
+
+          assert.equal(await showMore20.getAttribute('aria-expanded'), 'false');
+          assert.equal(await showMore18.getAttribute('aria-expanded'), 'false');
+
+          const toggleCount = await session.driver.executeScript(
+            () =>
+              [...document.querySelectorAll('button')].filter(button => {
+                const label = button.textContent?.replaceAll(/\s+/gu, ' ').trim() ?? '';
+
+                return label.startsWith('Show more') || label === 'Show less';
+              }).length
+          );
+
+          assert.equal(toggleCount, 2);
+
+          const bodyTextCollapsed = await getBodyText(session.driver);
+
+          assert.match(bodyTextCollapsed, /line 1/u);
+          assert.match(bodyTextCollapsed, /line 8/u);
+          assert.doesNotMatch(bodyTextCollapsed, /line 9/u);
+          assert.match(bodyTextCollapsed, /other 1/u);
+          assert.match(bodyTextCollapsed, /other 8/u);
+          assert.doesNotMatch(bodyTextCollapsed, /other 9/u);
+          assert.match(bodyTextCollapsed, /short 1/u);
+          assert.match(bodyTextCollapsed, /short 2/u);
+          assert.match(bodyTextCollapsed, /short 3/u);
+          assert.doesNotMatch(bodyTextCollapsed, /Show more \(3 lines\)/u);
+
+          await showMore20.click();
+          await waitForText(session.driver, 'Show less');
+          await waitForText(session.driver, 'line 20');
+
+          const showLess = await session.driver.findElement(
+            By.xpath('//button[contains(normalize-space(.), "Show less")]')
+          );
+
+          assert.equal(await showLess.getAttribute('aria-expanded'), 'true');
+
+          const bodyTextExpanded = await getBodyText(session.driver);
+
+          assert.match(bodyTextExpanded, /line 20/u);
+          assert.doesNotMatch(bodyTextExpanded, /other 18/u);
+          assert.match(bodyTextExpanded, /Show more \(18 lines\)/u);
+
+          const secondExpanded = await session.driver
+            .findElement(By.xpath('//button[contains(normalize-space(.), "Show more (18 lines)")]'))
+            .getAttribute('aria-expanded');
+
+          assert.equal(secondExpanded, 'false');
+
+          await showLess.click();
+          await waitForText(session.driver, 'Show more (20 lines)');
+
+          const bodyTextRecollapsed = await getBodyText(session.driver);
+
+          assert.doesNotMatch(bodyTextRecollapsed, /line 20/u);
+          assert.doesNotMatch(bodyTextRecollapsed, /Show less/u);
+
+          const firstRecollapsed = await session.driver
+            .findElement(By.xpath('//button[contains(normalize-space(.), "Show more (20 lines)")]'))
+            .getAttribute('aria-expanded');
+
+          assert.equal(firstRecollapsed, 'false');
+        }
+      ),
+  },
+  {
     name: 'only the message pane scrolls virtualized overflowing conversation content',
+
     run: context =>
       withSession(context.api, {}, async session => {
         await openAuthenticatedPanel(session);


### PR DESCRIPTION
## Summary

Long code blocks (>15 lines) in **assistant** chat messages in the Kilo browser extension side panel now render collapsed once the message finishes streaming: an 8-line preview with a fade-out and a `Show more (N lines)` toggle. Tool panels, thinking blocks, and user messages are unchanged.

## Product decisions

- Scope: assistant-message markdown `pre` blocks only (fenced and indented uniformly; inline code untouched)
- Threshold: >15 lines (trailing-newline tolerant); default collapsed; per-block toggle; not persisted
- Streaming: while a message's own stream is active, its blocks render fully with no collapse chrome; collapse applies the moment that message's stream ends — even while later tool rounds of the same run continue — and previously finalized messages never flash open on a new run
- Appearance: 8-line preview + fade + `Show more (N lines)` / `Show less` with `aria-expanded`

## Implementation

- New pure module + `CollapsibleCodeBlock` component (`entrypoints/sidepanel/collapsible-code-block.ts(x)`); unconditional hooks so the streaming→collapsed handoff keeps hook order
- `MessageEvent` overrides ReactMarkdown's `pre` renderer for the assistant branch only, with a defensive fallback to the default renderer on unexpected child shapes
- Precise streaming signal: `streamingMessageIdAtomFamily` + core `onAssistantStreaming` start/end callback (start at the first content delta; end guaranteed by `try/finally` on success, abort, and error), wired through both turn runners; three clear points (core end signal, run `finally`, `abortConversationRun`) so stop/close/delete mid-stream never leaks a stale id
- `clearPerConversationAtoms` evicts the new family (covers a conversation whose only entry is a mid-first-run streaming id)

## Test plan

- Vitest: line counting (trailing newlines, CRLF, empty), 15/16 boundary, preview slicing, chrome decision matrix, atom eviction (incl. streaming-only conversation), core start/end/reject/non-streamed streaming-callback contract — 243 pass
- Chrome E2E (`tests/e2e/collapsible-code-blocks.test.ts`): scripted-SSE assistant message with 20-line + 18-line + 3-line fenced blocks; asserts collapsed previews, exact toggle labels, per-block independent expand/collapse with `aria-expanded`, short block plain, no horizontal overflow
- Firefox E2E: same flow mirrored in `firefox-selenium-e2e.ts` (scroll assertions omitted — no helper idiom in that suite)
- Mid-stream chrome state is unit-covered only: the scripted-SSE harness fulfills the whole body in one shot, so intermediate streaming paints are not stably observable. **Named-mock justification**: the mock is the extension's established `tests/e2e/kilo-api-fixture.ts` `mockKiloApi` harness — a real model call cannot deterministically produce an exact >15-line fenced block with a stable assertable line count and timing; every existing extension rendering E2E uses this harness per `apps/extension/AGENTS.md`.

## Gate

`verify` (typecheck + lint + format:check + 243 unit tests), `build`, `build:firefox`, `e2e:chrome` (53 passed), `e2e:firefox` (26/26), `pnpm format` — all green.