### PR TITLE
fix(extension): treat empty streamed tool-call arguments as empty object

### DIFF
--- a/apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-stream-client.test.ts
@@ -220,6 +220,82 @@ describe('kilo gateway chat stream client', () => {
     expect(reasoningDeltas).toStrictEqual(['Thinking']);
   });
 
+  it('treats a single empty-arguments tool call delta as an empty object', async () => {
+    const fetch: FetchLike = () =>
+      streamResponse([
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_snapshot_1","type":"function","function":{"name":"get_page_snapshot","arguments":""}}]}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+
+    await expect(
+      fetchKiloGatewayChatCompletionStream({
+        apiBaseUrl: 'https://app.kilo.ai',
+        fetch,
+        messages: [{ content: 'Read this page', role: 'user' }],
+        model: 'kilo-auto/frontier',
+        onContentDelta: () => {},
+        token: 'token-1',
+        tools: [],
+      })
+    ).resolves.toStrictEqual({
+      toolCalls: [
+        {
+          arguments: {},
+          id: 'call_snapshot_1',
+          name: 'get_page_snapshot',
+        },
+      ],
+    });
+  });
+
+  it('treats tool call deltas that omit arguments as an empty object', async () => {
+    const fetch: FetchLike = () =>
+      streamResponse([
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_snapshot_1","type":"function","function":{"name":"get_page_snapshot"}}]}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+
+    await expect(
+      fetchKiloGatewayChatCompletionStream({
+        apiBaseUrl: 'https://app.kilo.ai',
+        fetch,
+        messages: [{ content: 'Read this page', role: 'user' }],
+        model: 'kilo-auto/frontier',
+        onContentDelta: () => {},
+        token: 'token-1',
+        tools: [],
+      })
+    ).resolves.toStrictEqual({
+      toolCalls: [
+        {
+          arguments: {},
+          id: 'call_snapshot_1',
+          name: 'get_page_snapshot',
+        },
+      ],
+    });
+  });
+
+  it('rejects non-empty invalid tool call arguments from the gateway stream', async () => {
+    const fetch: FetchLike = () =>
+      streamResponse([
+        'data: {"choices":[{"delta":{"tool_calls":[{"index":0,"id":"call_snapshot_1","type":"function","function":{"name":"get_page_snapshot","arguments":"not-json"}}]}}]}\n\n',
+        'data: [DONE]\n\n',
+      ]);
+
+    await expect(
+      fetchKiloGatewayChatCompletionStream({
+        apiBaseUrl: 'https://app.kilo.ai',
+        fetch,
+        messages: [{ content: 'Read this page', role: 'user' }],
+        model: 'anthropic/claude-sonnet-4',
+        onContentDelta: () => {},
+        token: 'token-1',
+        tools: [],
+      })
+    ).rejects.toThrow('Gateway tool call arguments were not valid JSON.');
+  });
+
   it('rejects non-object tool call arguments from the gateway stream', async () => {
     const fetch: FetchLike = () =>
       streamResponse([

--- a/apps/extension/src/shared/kilo-gateway-chat-stream-client.ts
+++ b/apps/extension/src/shared/kilo-gateway-chat-stream-client.ts
@@ -173,7 +173,9 @@ const parseToolCallBuffer = (value: StreamingToolCallBuffer): KiloGatewayToolCal
 
   const parsedArguments = (() => {
     try {
-      return parseJson(value.arguments);
+      // Bedrock-served Claude streams a zero-argument tool call as a single empty
+      // `arguments: ""` delta; an empty accumulated buffer is a zero-argument call.
+      return value.arguments === '' ? {} : parseJson(value.arguments);
     } catch {
       throw new TypeError('Gateway tool call arguments were not valid JSON.');
     }

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -36,6 +36,7 @@ const chromeWorkflowNames = [
   'native side panel is outside the page DOM',
   'dangerous mode conversation can eval against a normal tab',
   'safe mode conversation reads the selected tab with safe tools',
+  'safe mode conversation completes a tool call streamed with empty arguments',
   'dangerous mode conversation can use safe read tools',
   'running conversation can be stopped',
   'target tab list updates automatically',
@@ -1536,6 +1537,53 @@ const scenarios: FirefoxScenario[] = [
           await sendMessage(session.driver, 'What is on this page?');
           await waitForText(session.driver, 'get_page_snapshot completed');
           await waitForText(session.driver, 'The page is the Kilo extension fixture.');
+        }
+      ),
+  },
+  {
+    name: 'safe mode conversation completes a tool call streamed with empty arguments',
+    run: context =>
+      withSession(
+        context.api,
+        {
+          firstCompletionEvents: [
+            { choices: [{ delta: { content: 'I will read the page.' } }] },
+            {
+              choices: [
+                {
+                  delta: {
+                    tool_calls: [
+                      {
+                        function: {
+                          arguments: '',
+                          name: 'get_page_snapshot',
+                        },
+                        id: 'call_snapshot_1',
+                        index: 0,
+                        type: 'function',
+                      },
+                    ],
+                  },
+                },
+              ],
+            },
+          ],
+          secondCompletionEvents: [
+            { choices: [{ delta: { content: 'The page is the Kilo extension fixture.' } }] },
+          ],
+          toolNames: ['get_page_snapshot', 'get_element_details', 'find_in_page'],
+        },
+        async session => {
+          await session.openTargetPage();
+          await openAuthenticatedPanel(session);
+          await waitForModel(session.driver);
+          await waitForTargetTab(session.driver, 'Kilo extension fixture');
+          await sendMessage(session.driver, 'What is on this page?');
+          await waitForText(session.driver, 'get_page_snapshot completed');
+          await waitForText(session.driver, 'The page is the Kilo extension fixture.');
+          await getButtonByText(session.driver, 'Send message');
+          const bodyText = await getBodyText(session.driver);
+          assert.ok(!bodyText.includes('Gateway tool call arguments were not valid JSON.'));
         }
       ),
   },

--- a/apps/extension/tests/e2e/safe-mode.test.ts
+++ b/apps/extension/tests/e2e/safe-mode.test.ts
@@ -1,4 +1,4 @@
-/* eslint-disable import/no-nodejs-modules */
+/* eslint-disable import/no-nodejs-modules, max-lines */
 import { expect, test } from '@playwright/test';
 import { mkdtemp, rm, writeFile } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
@@ -75,6 +75,75 @@ test('safe mode conversation reads the selected tab with safe tools', async () =
     await expect(sidePanel.getByText('get_page_snapshot completed')).toBeVisible();
     await expect(sidePanel.getByText('The page is the Kilo extension fixture.')).toBeVisible();
     await expect(sidePanel.getByText('Switch to dangerous mode')).toBeHidden();
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});
+
+test('safe mode conversation completes a tool call streamed with empty arguments', async () => {
+  const fixture = await startFixtureServer();
+  const { context, extensionId, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context, {
+      firstCompletionEvents: [
+        { choices: [{ delta: { content: 'I will read the page.' } }] },
+        {
+          choices: [
+            {
+              delta: {
+                tool_calls: [
+                  {
+                    function: {
+                      arguments: '',
+                      name: 'get_page_snapshot',
+                    },
+                    id: 'call_snapshot_1',
+                    index: 0,
+                    type: 'function',
+                  },
+                ],
+              },
+            },
+          ],
+        },
+      ],
+      secondCompletionEvents: [
+        {
+          choices: [
+            {
+              delta: {
+                content: 'The page is the Kilo extension fixture.',
+              },
+            },
+          ],
+        },
+      ],
+      toolNames: ['get_page_snapshot', 'get_element_details', 'find_in_page'],
+    });
+
+    const page = await context.newPage();
+    await page.goto(fixture.url);
+
+    const sidePanel = await context.newPage();
+    await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+    await seedExtensionAuth(sidePanel);
+    await sidePanel.reload();
+
+    await expect(sidePanel.getByRole('button', { name: /Safe mode/u })).toBeVisible();
+    await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo extension fixture');
+
+    await sidePanel.getByLabel('Message agent').fill('What is on this page?');
+    await sidePanel.getByLabel('Message agent').press('Enter');
+
+    await expect(sidePanel.getByText('get_page_snapshot completed')).toBeVisible();
+    await expect(sidePanel.getByText('The page is the Kilo extension fixture.')).toBeVisible();
+    await expect(sidePanel.getByRole('button', { name: 'Send message' })).toBeVisible();
+    await expect(
+      sidePanel.getByText('Gateway tool call arguments were not valid JSON.')
+    ).toHaveCount(0);
   } finally {
     await context.close();
     await fixture.close();


### PR DESCRIPTION
## Problem

Auto models (`kilo-auto/frontier`, and any model routed to Bedrock-served Claude) showed **"Gateway tool call arguments were not valid JSON."** in the browser extension whenever the model made a zero-argument tool call (e.g. `get_page_snapshot`). Dedicated models on other upstreams worked fine.

Root cause is a contract/parser boundary: Claude models served via AWS Bedrock stream a zero-argument tool call as exactly one `tool_calls` delta whose `function.arguments` is `""` — and nothing more (mirroring Anthropic's `tool_use` block with empty input and no `input_json_delta` chunks). The extension's strict SSE parser concatenates argument fragments and runs `JSON.parse('')` on the empty buffer, which throws and kills the agent turn.

Raw-stream evidence (local gateway, extension-shaped request to `/api/gateway/v1/chat/completions`):

| Model / shape | Streamed arguments deltas | Baseline result |
|---|---|---|
| `kilo-auto/frontier`, `anthropic/claude-sonnet-5/-4.5/-4` (Bedrock) | `""` only | ❌ `not valid JSON` error, turn dies |
| Same Bedrock models, one-argument tool (`find_in_page`) | `""` then JSON fragments | ✅ accumulates to valid JSON |
| `kilo-auto/balanced`, `/efficient` (Qwen), `/small` (Gemma) | `"{}"` | ✅ |
| `openai/gpt-4.1` | `""` then `"{}"` | ✅ accumulates to `"{}"` |

The blast radius is larger than the report: `kilo-auto/frontier` pins Claude Sonnet 5 on Bedrock-preferred routing so the auto selection always hits the quirk, but **dedicated Claude models failed identically** and are fixed by the same change.

## Fix

Extension-only (decided against gateway stream normalization — that would add SSE parse/re-emit machinery to the paid-model passthrough hot path, which is disproportionate).

In `parseToolCallBuffer` (`apps/extension/src/shared/kilo-gateway-chat-stream-client.ts`): an **empty accumulated `arguments` buffer is exactly the zero-argument-call case** — parse it as `{}`. Everything else is unchanged:

- non-empty invalid JSON still throws `Gateway tool call arguments were not valid JSON.`
- valid non-object JSON still throws `...were not an object.`
- whitespace-only arguments remain invalid (still throws)

Both stream entry points (`parseKiloGatewayChatCompletionStream` and the live `fetchKiloGatewayChatCompletionStream` reader) share `parseToolCallBuffer` via `toCompletion`, so the one change covers both.

Accepted edge (recorded in the plan): if a required-argument tool's stream is truncated after only an empty payload, the tool now runs with `{}` and returns its own soft validation error instead of a turn-killing `TypeError` — the model can observe and recover, which is strictly better than a dead turn.

## Coverage

- **Unit** (`kilo-gateway-chat-stream-client.test.ts`): a single `arguments: ""` delta yields `arguments: {}`; deltas omitting `arguments` entirely also yield `{}`; non-empty invalid JSON still throws the exact `not valid JSON` error; the existing not-an-object rejection and all accumulation tests stay green.
- **Mock E2E, Chrome (Playwright)** and **Firefox (Selenium)**: a new dedicated scenario streams the exact Bedrock shape (a `get_page_snapshot` tool call whose only argument payload is `arguments: ""`) and asserts the tool row completes, the follow-up answer renders, the `Send message` button returns, and the error text never appears. Existing `"{}"`-arguments cases are untouched.
- **Live E2E** (real unpacked extension build against the local backend, real model calls, Chrome; tool-forcing prompt `What do you see? Answer in two short sentences.`): every model completed a zero-argument `get_page_snapshot` turn on the first attempt — `kilo-auto/frontier`, `kilo-auto/balanced`, `kilo-auto/efficient`, `kilo-auto/small`, dedicated `anthropic/claude-sonnet-5` (failed on baseline), and dedicated `openai/gpt-4.1` (regression control). The error text appeared in no attempt. A raw frontier SSE capture confirms the upstream still emits the zero-argument call as one `arguments: ""` delta (tool id `toolu_bdrk_*`) while the extension now completes — the fix is client-side.

## `kilo-auto/free`

No live E2E for `kilo-auto/free`: its random provider rotation is non-deterministic. It is covered by the root-cause classification (the quirk is the Bedrock stream shape, and the parser fix is upstream-agnostic) plus the unit and mock-E2E coverage of that shape.

## Verification

- `pnpm --filter kilo-extension verify` ✅ (typecheck, lint, format, 226 unit tests)
- `pnpm --filter kilo-extension build` / `build:firefox` ✅
- `pnpm --filter kilo-extension e2e:chrome` ✅ (53 passed, incl. the new scenario)
- `pnpm --filter kilo-extension e2e:firefox` ✅ (26/26 workflows, incl. the new scenario)
