### PR TITLE
feat(extension): add PostHog analytics

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -351,6 +351,11 @@ When `VERCEL_TARGET_ENV` is absent in local development or a script process, tra
 - `DOCKER_PROXY_SOCKET` - Path to the Docker privileged proxy socket. [SERVER]
 - `SECRET` - Generic secret env var used in `services/kiloclaw/src/auth/sandbox-id-adversarial.test.ts` for sandbox auth tests. `[SECRET]`
 
+## Browser Extension (apps/extension)
+
+- `VITE_POSTHOG_API_KEY` - PostHog public project API key baked into extension builds; read in `apps/extension/src/shared/analytics.ts`; absent → analytics disabled. [PUBLIC]
+- `VITE_KILO_API_BASE_URL` - Selects the Kilo API base URL at build time; read in `apps/extension/src/shared/auth.ts`. [PUBLIC]
+
 ## Mobile
 
 - `API_BASE_URL` - Base HTTPS URL for the mobile app's API (e.g. `https://api.kilo.ai`). Bundled into the binary. [PUBLIC]

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -24,6 +24,11 @@ import {
   hasCompactableHistory,
 } from '@/src/shared/agent-context-compaction';
 import { defaultMode } from '@/src/shared/agent-chat-placeholder';
+import {
+  captureEvent,
+  CONVERSATION_CREATED_EVENT,
+  MESSAGE_SENT_EVENT,
+} from '@/src/shared/analytics';
 import { getKiloApiBaseUrl } from '@/src/shared/auth';
 import type { StoredAuth } from '@/src/shared/auth';
 import {
@@ -497,6 +502,7 @@ export const AgentChatPanel = ({
       try {
         const runTurn = runMode === 'dangerous' ? runDangerousLlmTurn : runSafeLlmTurn;
 
+        captureEvent(MESSAGE_SENT_EVENT, { mode: runMode });
         await runTurn({
           apiBaseUrl,
           appendEvents: appendRunEvents,
@@ -587,6 +593,8 @@ export const AgentChatPanel = ({
     if (!isConversationStoreLoaded) {
       return;
     }
+
+    captureEvent(CONVERSATION_CREATED_EVENT);
 
     const settings = {
       mode,

--- a/apps/extension/entrypoints/sidepanel/analytics-settings-logic.test.ts
+++ b/apps/extension/entrypoints/sidepanel/analytics-settings-logic.test.ts
@@ -1,0 +1,209 @@
+import { describe, expect, it } from 'vitest';
+import {
+  ANALYTICS_SETTINGS_SAVE_ERROR,
+  FIREFOX_USAGE_DATA_BLOCKED_HINT,
+  applyAnalyticsSettingsLoaded,
+  beginAnalyticsSettingsFlip,
+  completeAnalyticsSettingsFlip,
+  createInitialAnalyticsSettingsState,
+  failAnalyticsSettingsFlip,
+  isAnalyticsSettingsInteractive,
+  mapAnalyticsSettingsSaveRejection,
+  resolveAnalyticsOptOutIdentity,
+  shouldShowFirefoxUsageDataHint,
+} from './analytics-settings-logic';
+
+describe('analytics-settings-logic', () => {
+  describe('happy path — load reflects persisted state', () => {
+    it('starts in loading with checked true (enabled default)', () => {
+      const state = createInitialAnalyticsSettingsState();
+      expect(state.phase).toBe('loading');
+      expect(state.checked).toBe(true);
+      expect(state.errorMessage).toBeNull();
+      expect(isAnalyticsSettingsInteractive(state)).toBe(false);
+    });
+
+    it('maps absent opt-out (false) to checked true / enabled', () => {
+      const state = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      expect(state.phase).toBe('settled');
+      expect(state.checked).toBe(true);
+      expect(state.errorMessage).toBeNull();
+      expect(isAnalyticsSettingsInteractive(state)).toBe(true);
+    });
+
+    it('maps optedOut true to checked false / disabled', () => {
+      const state = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: true,
+      });
+      expect(state.phase).toBe('settled');
+      expect(state.checked).toBe(false);
+      expect(state.errorMessage).toBeNull();
+    });
+  });
+
+  describe('happy path — flip transitions and persist args', () => {
+    it('flip from enabled starts saving with optedOut true', () => {
+      const settled = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      const started = beginAnalyticsSettingsFlip(settled);
+      expect(started).not.toBeNull();
+      expect(started?.nextChecked).toBe(false);
+      expect(started?.optedOut).toBe(true);
+      expect(started?.priorChecked).toBe(true);
+      expect(started?.state.phase).toBe('saving');
+    });
+
+    it('opt-out flip does not require identity', () => {
+      expect(resolveAnalyticsOptOutIdentity(true, 'user@kilo.ai')).toBeUndefined();
+      const settled = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      const started = beginAnalyticsSettingsFlip(settled);
+      expect(started?.state.checked).toBe(false);
+      expect(started?.state.errorMessage).toBeNull();
+    });
+
+    it('flip from disabled re-enables with email identity', () => {
+      const settled = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: true,
+      });
+      const started = beginAnalyticsSettingsFlip(settled);
+      expect(started).not.toBeNull();
+      expect(started?.nextChecked).toBe(true);
+      expect(started?.optedOut).toBe(false);
+      expect(started?.priorChecked).toBe(false);
+      expect(resolveAnalyticsOptOutIdentity(false, 'user@kilo.ai')).toStrictEqual({
+        email: 'user@kilo.ai',
+      });
+    });
+
+    it('complete settles at the optimistic checked value', () => {
+      const settled = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      const started = beginAnalyticsSettingsFlip(settled);
+      expect(started).not.toBeNull();
+      const done = completeAnalyticsSettingsFlip(started!.state);
+      expect(done.phase).toBe('settled');
+      expect(done.checked).toBe(false);
+      expect(done.errorMessage).toBeNull();
+      expect(done.priorChecked).toBeNull();
+    });
+
+    it('ignores flip while loading or saving', () => {
+      expect(beginAnalyticsSettingsFlip(createInitialAnalyticsSettingsState())).toBeNull();
+
+      const settled = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      const started = beginAnalyticsSettingsFlip(settled);
+      expect(started).not.toBeNull();
+      expect(beginAnalyticsSettingsFlip(started!.state)).toBeNull();
+    });
+  });
+
+  describe('unhappy retryable — storage rejection', () => {
+    it('reverts to prior position with exact error message', () => {
+      const settled = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      const started = beginAnalyticsSettingsFlip(settled);
+      expect(started).not.toBeNull();
+
+      const failed = failAnalyticsSettingsFlip(started!.state, started!.priorChecked);
+      expect(failed.phase).toBe('error');
+      expect(failed.checked).toBe(true);
+      expect(failed.errorMessage).toBe(ANALYTICS_SETTINGS_SAVE_ERROR);
+      expect(failed.errorMessage).toBe("Couldn't save the setting. Try again.");
+    });
+
+    it('error state remains interactive for retry CTA', () => {
+      const settled = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      const started = beginAnalyticsSettingsFlip(settled);
+      const failed = failAnalyticsSettingsFlip(started!.state, started!.priorChecked);
+      expect(isAnalyticsSettingsInteractive(failed)).toBe(true);
+    });
+
+    it('subsequent flip retries and clears the error', () => {
+      const settled = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      const first = beginAnalyticsSettingsFlip(settled);
+      const failed = failAnalyticsSettingsFlip(first!.state, first!.priorChecked);
+      expect(failed.errorMessage).toBe(ANALYTICS_SETTINGS_SAVE_ERROR);
+
+      const retry = beginAnalyticsSettingsFlip(failed);
+      expect(retry).not.toBeNull();
+      expect(retry?.state.phase).toBe('saving');
+      expect(retry?.state.errorMessage).toBeNull();
+      expect(retry?.optedOut).toBe(true);
+    });
+  });
+
+  describe('unhappy non-retryable — structurally impossible', () => {
+    it('maps every rejection to the retryable save error', () => {
+      expect(mapAnalyticsSettingsSaveRejection(new Error('quota'))).toBe(
+        ANALYTICS_SETTINGS_SAVE_ERROR
+      );
+      expect(mapAnalyticsSettingsSaveRejection('string reject')).toBe(
+        ANALYTICS_SETTINGS_SAVE_ERROR
+      );
+      expect(mapAnalyticsSettingsSaveRejection(null)).toBe(ANALYTICS_SETTINGS_SAVE_ERROR);
+      expect(mapAnalyticsSettingsSaveRejection({ code: 42 })).toBe(ANALYTICS_SETTINGS_SAVE_ERROR);
+    });
+  });
+
+  describe('firefox hint visibility', () => {
+    it('hides the hint when usage data is granted', () => {
+      expect(shouldShowFirefoxUsageDataHint(true)).toBe(false);
+      const state = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: true,
+        optedOut: false,
+      });
+      expect(shouldShowFirefoxUsageDataHint(state.firefoxUsageDataGranted)).toBe(false);
+    });
+
+    it('shows the hint when usage data is not granted', () => {
+      expect(shouldShowFirefoxUsageDataHint(false)).toBe(true);
+      const state = applyAnalyticsSettingsLoaded({
+        firefoxUsageDataGranted: false,
+        optedOut: false,
+      });
+      expect(shouldShowFirefoxUsageDataHint(state.firefoxUsageDataGranted)).toBe(true);
+      expect(FIREFOX_USAGE_DATA_BLOCKED_HINT.length).toBeGreaterThan(0);
+    });
+  });
+
+  describe('opt-out identity resolution', () => {
+    it('returns undefined when opting out even if email is present', () => {
+      expect(resolveAnalyticsOptOutIdentity(true, 'user@kilo.ai')).toBeUndefined();
+    });
+
+    it('returns undefined when re-enabling without an email', () => {
+      expect(resolveAnalyticsOptOutIdentity(false)).toBeUndefined();
+      expect(resolveAnalyticsOptOutIdentity(false, '')).toBeUndefined();
+      expect(resolveAnalyticsOptOutIdentity(false, '   ')).toBeUndefined();
+    });
+
+    it('returns email identity when re-enabling with email', () => {
+      expect(resolveAnalyticsOptOutIdentity(false, 'user@kilo.ai')).toStrictEqual({
+        email: 'user@kilo.ai',
+      });
+    });
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/analytics-settings-logic.ts
+++ b/apps/extension/entrypoints/sidepanel/analytics-settings-logic.ts
@@ -1,0 +1,118 @@
+export const ANALYTICS_SETTINGS_SAVE_ERROR = "Couldn't save the setting. Try again.";
+
+export const FIREFOX_USAGE_DATA_BLOCKED_HINT = 'Firefox is blocking usage data collection.';
+
+export type AnalyticsSettingsPhase = 'loading' | 'settled' | 'saving' | 'error';
+
+export interface AnalyticsSettingsState {
+  readonly checked: boolean;
+  readonly errorMessage: string | null;
+  readonly firefoxUsageDataGranted: boolean;
+  readonly phase: AnalyticsSettingsPhase;
+  readonly priorChecked: boolean | null;
+}
+
+export interface AnalyticsSettingsLoadResult {
+  readonly firefoxUsageDataGranted: boolean;
+  readonly optedOut: boolean;
+}
+
+export interface AnalyticsSettingsFlipStart {
+  readonly nextChecked: boolean;
+  readonly optedOut: boolean;
+  readonly priorChecked: boolean;
+  readonly state: AnalyticsSettingsState;
+}
+
+/** Default while the flag is unread: enabled (opt-out absent). */
+export const createInitialAnalyticsSettingsState = (): AnalyticsSettingsState => ({
+  checked: true,
+  errorMessage: null,
+  firefoxUsageDataGranted: true,
+  phase: 'loading',
+  priorChecked: null,
+});
+
+export const applyAnalyticsSettingsLoaded = (
+  input: AnalyticsSettingsLoadResult
+): AnalyticsSettingsState => ({
+  checked: !input.optedOut,
+  errorMessage: null,
+  firefoxUsageDataGranted: input.firefoxUsageDataGranted,
+  phase: 'settled',
+  priorChecked: null,
+});
+
+export const isAnalyticsSettingsInteractive = (state: AnalyticsSettingsState): boolean =>
+  state.phase === 'settled' || state.phase === 'error';
+
+export const shouldShowFirefoxUsageDataHint = (firefoxUsageDataGranted: boolean): boolean =>
+  !firefoxUsageDataGranted;
+
+/**
+ * Every storage-write rejection is retryable. The CTA is flipping the toggle again.
+ * Non-retryable failures are structurally impossible for this control.
+ */
+export const mapAnalyticsSettingsSaveRejection = (
+  _error: unknown
+): typeof ANALYTICS_SETTINGS_SAVE_ERROR => ANALYTICS_SETTINGS_SAVE_ERROR;
+
+export const beginAnalyticsSettingsFlip = (
+  state: AnalyticsSettingsState
+): AnalyticsSettingsFlipStart | null => {
+  if (!isAnalyticsSettingsInteractive(state)) {
+    return null;
+  }
+
+  const priorChecked = state.checked;
+  const nextChecked = !priorChecked;
+  return {
+    nextChecked,
+    optedOut: !nextChecked,
+    priorChecked,
+    state: {
+      checked: nextChecked,
+      errorMessage: null,
+      firefoxUsageDataGranted: state.firefoxUsageDataGranted,
+      phase: 'saving',
+      priorChecked,
+    },
+  };
+};
+
+export const completeAnalyticsSettingsFlip = (
+  state: AnalyticsSettingsState
+): AnalyticsSettingsState => ({
+  checked: state.checked,
+  errorMessage: null,
+  firefoxUsageDataGranted: state.firefoxUsageDataGranted,
+  phase: 'settled',
+  priorChecked: null,
+});
+
+export const failAnalyticsSettingsFlip = (
+  state: AnalyticsSettingsState,
+  priorChecked: boolean
+): AnalyticsSettingsState => ({
+  checked: priorChecked,
+  errorMessage: ANALYTICS_SETTINGS_SAVE_ERROR,
+  firefoxUsageDataGranted: state.firefoxUsageDataGranted,
+  phase: 'error',
+  priorChecked: null,
+});
+
+/** Identity payload for `setAnalyticsOptOut` when re-enabling analytics. */
+export const resolveAnalyticsOptOutIdentity = (
+  optedOut: boolean,
+  email?: string
+): { readonly email: string } | undefined => {
+  if (optedOut) {
+    return undefined;
+  }
+
+  if (email === undefined || email.trim().length === 0) {
+    return undefined;
+  }
+
+  return { email };
+};

--- a/apps/extension/entrypoints/sidepanel/app.tsx
+++ b/apps/extension/entrypoints/sidepanel/app.tsx
@@ -1,7 +1,8 @@
 import { browser, storage } from '#imports';
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import type { JSX } from 'react';
+import { resetAnalyticsUser } from '@/src/shared/analytics';
 import {
   clearStoredSession,
   createDeviceAuthRequest,
@@ -22,6 +23,8 @@ import {
   ValidationErrorView,
 } from './auth-views';
 import { clearPerConversationAtoms } from './agent-chat-atoms';
+import { useAnalyticsIdentity } from './use-analytics-identity';
+import type { SignInSource } from './use-analytics-identity';
 
 const pollIntervalMs = 3000;
 const apiBaseUrl = getKiloApiBaseUrl();
@@ -45,6 +48,11 @@ export const App = (): JSX.Element => {
   const queryClient = useQueryClient();
   const [pendingAuthRequest, setPendingAuthRequest] = useState<DeviceAuthRequest | undefined>();
   const [signedOutMessage, setSignedOutMessage] = useState<string | undefined>();
+  /*
+   * Ref (not state): device-approval must write the source synchronously before
+   * the signed-in cache write, so the identity hook never sees a stale source.
+   */
+  const signInSourceRef = useRef<SignInSource>('stored_session');
   const {
     data: storedAuth,
     isLoading: isStoredAuthLoading,
@@ -135,6 +143,8 @@ export const App = (): JSX.Element => {
     if (authValidationData?.status === 'signedOut') {
       setSignedOutMessage(authValidationData.message);
       queryClient.setQueryData(storedAuthQueryKey, undefined);
+      signInSourceRef.current = 'stored_session';
+      void resetAnalyticsUser({ reason: 'expired' });
     }
   }, [authValidationData, queryClient]);
 
@@ -157,6 +167,11 @@ export const App = (): JSX.Element => {
         }
 
         setSignedOutMessage(undefined);
+        /*
+         * Must precede the signed-in cache writes so the identity hook reads
+         * device_auth for this transition (ref is sync; useState would race).
+         */
+        signInSourceRef.current = 'device_auth';
         queryClient.setQueryData(storedAuthQueryKey, persistence.auth);
         queryClient.setQueryData(getAuthValidationQueryKey(persistence.auth.token), {
           auth: persistence.auth,
@@ -179,6 +194,14 @@ export const App = (): JSX.Element => {
     }
   }, [devicePollQuery.isError]);
 
+  useAnalyticsIdentity({
+    email:
+      authValidationData?.status === 'signedIn' ? authValidationData.auth.userEmail : undefined,
+    signInSource: signInSourceRef,
+    status: authValidationData?.status,
+    storageArea: storage,
+  });
+
   const cancelSignIn = useCallback((): void => {
     setPendingAuthRequest(undefined);
   }, []);
@@ -186,6 +209,8 @@ export const App = (): JSX.Element => {
   const signOut = useCallback((): void => {
     setPendingAuthRequest(undefined);
     setSignedOutMessage(undefined);
+    signInSourceRef.current = 'stored_session';
+    void resetAnalyticsUser({ reason: 'explicit' });
     void (async (): Promise<void> => {
       try {
         await clearStoredSession(storage);

--- a/apps/extension/entrypoints/sidepanel/auth-shell.tsx
+++ b/apps/extension/entrypoints/sidepanel/auth-shell.tsx
@@ -1,9 +1,27 @@
-import { useState } from 'react';
+import { storage } from '#imports';
+import { useEffect, useState } from 'react';
 import type { JSX, ReactNode } from 'react';
 import { Settings, X } from 'lucide-react';
+import {
+  getFirefoxUsageDataGranted,
+  loadAnalyticsOptOut,
+  setAnalyticsOptOut,
+} from '@/src/shared/analytics';
 import type { StoredAuth } from '@/src/shared/auth';
 import type { KiloOrganizationOption } from '@/src/shared/kilo-api-client';
 import { KiloLogo } from '@/src/shared/kilo-logo';
+import type { AnalyticsSettingsState } from './analytics-settings-logic';
+import {
+  FIREFOX_USAGE_DATA_BLOCKED_HINT,
+  applyAnalyticsSettingsLoaded,
+  beginAnalyticsSettingsFlip,
+  completeAnalyticsSettingsFlip,
+  createInitialAnalyticsSettingsState,
+  failAnalyticsSettingsFlip,
+  isAnalyticsSettingsInteractive,
+  resolveAnalyticsOptOutIdentity,
+  shouldShowFirefoxUsageDataHint,
+} from './analytics-settings-logic';
 import { OrganizationCreditAccountSelect } from './organization-credit-account';
 import { RemoteMcpSettings } from './remote-mcp-settings';
 
@@ -27,6 +45,99 @@ const IconButton = ({
     {children}
   </button>
 );
+
+const AnalyticsSettingsRow = ({ userEmail }: { userEmail: string | undefined }): JSX.Element => {
+  const [state, setState] = useState<AnalyticsSettingsState>(createInitialAnalyticsSettingsState);
+  const interactive = isAnalyticsSettingsInteractive(state);
+  const showFirefoxHint = shouldShowFirefoxUsageDataHint(state.firefoxUsageDataGranted);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      const [optedOut, firefoxUsageDataGranted] = await Promise.all([
+        loadAnalyticsOptOut(storage),
+        getFirefoxUsageDataGranted(),
+      ]);
+
+      if (cancelled) {
+        return;
+      }
+
+      setState(
+        applyAnalyticsSettingsLoaded({
+          firefoxUsageDataGranted,
+          optedOut,
+        })
+      );
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const onToggle = (): void => {
+    const started = beginAnalyticsSettingsFlip(state);
+    if (started === null) {
+      return;
+    }
+
+    setState(started.state);
+
+    void (async () => {
+      try {
+        await setAnalyticsOptOut(
+          storage,
+          started.optedOut,
+          resolveAnalyticsOptOutIdentity(started.optedOut, userEmail)
+        );
+        setState(current => completeAnalyticsSettingsFlip(current));
+      } catch {
+        setState(current => failAnalyticsSettingsFlip(current, started.priorChecked));
+      }
+    })();
+  };
+
+  return (
+    <div className="min-w-0 rounded-md border border-zinc-800 bg-zinc-900/40 p-3">
+      <div className="flex items-start justify-between gap-3">
+        <div className="min-w-0 flex-1">
+          <p className="text-sm font-medium text-zinc-200">Share usage analytics</p>
+          <p className="mt-0.5 text-xs leading-4 text-zinc-500">
+            Helps improve Kilo. No page content is collected.
+          </p>
+          {showFirefoxHint ? (
+            <p className="mt-1 text-xs leading-4 text-zinc-500">
+              {FIREFOX_USAGE_DATA_BLOCKED_HINT}
+            </p>
+          ) : null}
+          {state.errorMessage === null ? null : (
+            <p className="mt-1 text-xs leading-4 text-red-400">{state.errorMessage}</p>
+          )}
+        </div>
+        <button
+          aria-checked={state.checked}
+          aria-label="Share usage analytics"
+          className={`relative mt-0.5 h-5 w-9 shrink-0 rounded-full border transition focus:outline-none focus:ring-2 focus:ring-[#EDFF00] focus:ring-offset-2 focus:ring-offset-zinc-950 disabled:cursor-not-allowed disabled:opacity-50 ${
+            state.checked ? 'border-[#EDFF00]/40 bg-[#EDFF00]/20' : 'border-zinc-700 bg-zinc-800'
+          }`}
+          disabled={!interactive}
+          onClick={onToggle}
+          role="switch"
+          type="button"
+        >
+          <span
+            aria-hidden="true"
+            className={`absolute top-0.5 size-3.5 rounded-full transition ${
+              state.checked ? 'left-4 bg-[#EDFF00]' : 'left-0.5 bg-zinc-400'
+            }`}
+          />
+        </button>
+      </div>
+    </div>
+  );
+};
 
 const HeaderActions = ({
   auth,
@@ -88,6 +199,7 @@ const HeaderActions = ({
               selectedOrganizationId={selectedOrganizationId}
             />
             <RemoteMcpSettings />
+            <AnalyticsSettingsRow userEmail={auth.userEmail} />
             <button
               className="h-9 rounded-md border border-zinc-700 px-3 text-sm font-medium text-zinc-200 transition hover:border-zinc-600 hover:bg-zinc-900 focus:outline-none focus:ring-2 focus:ring-[#EDFF00] focus:ring-offset-2 focus:ring-offset-zinc-950"
               onClick={() => {

--- a/apps/extension/entrypoints/sidepanel/use-analytics-identity.test.ts
+++ b/apps/extension/entrypoints/sidepanel/use-analytics-identity.test.ts
@@ -1,0 +1,214 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const analyticsMocks = vi.hoisted(() => ({
+  captureEvent: vi.fn(),
+  initAnalytics: vi.fn(),
+}));
+
+// Match the import specifier used by use-analytics-identity.ts.
+// eslint-disable-next-line vitest/prefer-import-in-mock, jest/no-untyped-mock-factory
+vi.mock('@/src/shared/analytics', () => ({
+  EXTENSION_SIGNED_IN_EVENT: 'extension_signed_in',
+  captureEvent: analyticsMocks.captureEvent,
+  initAnalytics: analyticsMocks.initAnalytics,
+}));
+
+// eslint-disable-next-line import/first
+import type { AnalyticsStorageArea } from '@/src/shared/analytics';
+// eslint-disable-next-line import/first
+import {
+  createAnalyticsIdentityTracker,
+  resolveSignedInTransition,
+} from './use-analytics-identity';
+
+const EMAIL = 'user@kilo.ai';
+const OTHER_EMAIL = 'other@kilo.ai';
+
+const storageArea: AnalyticsStorageArea = {
+  getItem: vi.fn(),
+  setItem: vi.fn(),
+};
+
+const signedIn = (email: string | undefined = EMAIL) => ({ email, status: 'signedIn' }) as const;
+
+const emailLessSignedIn = { email: undefined as string | undefined, status: 'signedIn' as const };
+
+const signedOut = { email: undefined, status: 'signedOut' } as const;
+
+const resetMocks = (): void => {
+  analyticsMocks.captureEvent.mockReset();
+  analyticsMocks.initAnalytics.mockReset();
+};
+
+describe('signed-in transition decision', () => {
+  it('identifies on cold start (previous undefined → signedIn with email)', () => {
+    expect(resolveSignedInTransition(undefined, signedIn())).toBe('identify');
+  });
+
+  it('identifies on device approval (previous signedOut → signedIn with email)', () => {
+    expect(resolveSignedInTransition(signedOut, signedIn())).toBe('identify');
+  });
+
+  it('identifies when email arrives after an email-less signedIn', () => {
+    expect(resolveSignedInTransition(emailLessSignedIn, signedIn(EMAIL))).toBe('identify');
+  });
+
+  it('identifies on re-sign-in after sign-out with the same email', () => {
+    expect(resolveSignedInTransition(signedOut, signedIn(EMAIL))).toBe('identify');
+  });
+
+  it('returns null for same-email re-render while still signed in', () => {
+    expect(resolveSignedInTransition(signedIn(EMAIL), signedIn(EMAIL))).toBeNull();
+  });
+
+  it('returns null for email-less signedIn', () => {
+    expect(resolveSignedInTransition(undefined, emailLessSignedIn)).toBeNull();
+    expect(resolveSignedInTransition(undefined, { email: '', status: 'signedIn' })).toBeNull();
+  });
+
+  it('returns null when next is not signedIn', () => {
+    expect(resolveSignedInTransition(undefined, signedOut)).toBeNull();
+    expect(
+      resolveSignedInTransition(signedIn(), { email: EMAIL, status: 'validationError' })
+    ).toBeNull();
+  });
+
+  it('identifies when the signed-in email changes', () => {
+    expect(resolveSignedInTransition(signedIn(EMAIL), signedIn(OTHER_EMAIL))).toBe('identify');
+  });
+});
+
+describe('analytics identity tracker', () => {
+  const createTracker = () => {
+    const emitSignedIn = vi.fn();
+    const tracker = createAnalyticsIdentityTracker({
+      emitSignedIn,
+      storageArea,
+    });
+    return { emitSignedIn, tracker };
+  };
+
+  it('re-identifies on signedOut → signedIn with the same email', async () => {
+    resetMocks();
+    analyticsMocks.initAnalytics.mockResolvedValue(true);
+    const { emitSignedIn, tracker } = createTracker();
+
+    await tracker.observe(signedIn(EMAIL), 'stored_session');
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(analyticsMocks.initAnalytics).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(emitSignedIn).toHaveBeenCalledTimes(1);
+
+    await tracker.observe(signedOut, 'stored_session');
+    await tracker.observe(signedIn(EMAIL), 'device_auth');
+
+    expect(analyticsMocks.initAnalytics).toHaveBeenCalledTimes(2);
+    expect(emitSignedIn).toHaveBeenCalledTimes(2);
+    expect(emitSignedIn).toHaveBeenLastCalledWith('device_auth');
+  });
+
+  it('dedupes identical observations across runs to a single init+emit', async () => {
+    resetMocks();
+    analyticsMocks.initAnalytics.mockResolvedValue(true);
+    const { emitSignedIn, tracker } = createTracker();
+
+    await tracker.observe(signedIn(EMAIL), 'stored_session');
+    await tracker.observe(signedIn(EMAIL), 'stored_session');
+    await tracker.observe(signedIn(EMAIL), 'device_auth');
+
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(analyticsMocks.initAnalytics).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(emitSignedIn).toHaveBeenCalledTimes(1);
+    expect(emitSignedIn).toHaveBeenCalledWith('stored_session');
+  });
+
+  it('does not emit extension_signed_in when initAnalytics returns false', async () => {
+    resetMocks();
+    analyticsMocks.initAnalytics.mockResolvedValue(false);
+    const { emitSignedIn, tracker } = createTracker();
+
+    await tracker.observe(signedIn(EMAIL), 'stored_session');
+
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(analyticsMocks.initAnalytics).toHaveBeenCalledTimes(1);
+    expect(emitSignedIn).not.toHaveBeenCalled();
+  });
+
+  it('emits device_auth source for a device-approval observation', async () => {
+    resetMocks();
+    analyticsMocks.initAnalytics.mockResolvedValue(true);
+    const { emitSignedIn, tracker } = createTracker();
+
+    await tracker.observe(signedIn(EMAIL), 'device_auth');
+
+    expect(emitSignedIn).toHaveBeenCalledWith('device_auth');
+  });
+
+  it('emits stored_session source on cold start', async () => {
+    resetMocks();
+    analyticsMocks.initAnalytics.mockResolvedValue(true);
+    const { emitSignedIn, tracker } = createTracker();
+
+    await tracker.observe(signedIn(EMAIL), 'stored_session');
+
+    expect(emitSignedIn).toHaveBeenCalledWith('stored_session');
+  });
+
+  it('advances previous on signedOut/undefined so a later re-identify works', async () => {
+    resetMocks();
+    analyticsMocks.initAnalytics.mockResolvedValue(true);
+    const { emitSignedIn, tracker } = createTracker();
+
+    await tracker.observe(signedIn(EMAIL), 'stored_session');
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(emitSignedIn).toHaveBeenCalledTimes(1);
+
+    // Observe undefined status (query disabled after sign-out) without identify.
+    await tracker.observe({ email: undefined, status: undefined }, 'stored_session');
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(emitSignedIn).toHaveBeenCalledTimes(1);
+
+    await tracker.observe(signedIn(EMAIL), 'stored_session');
+    expect(emitSignedIn).toHaveBeenCalledTimes(2);
+  });
+
+  it('advances previous before await so an in-flight observe does not use stale previous', async () => {
+    resetMocks();
+    const deferred = Promise.withResolvers<boolean>();
+    analyticsMocks.initAnalytics.mockReturnValue(deferred.promise);
+
+    const { emitSignedIn, tracker } = createTracker();
+
+    const first = tracker.observe(signedIn(EMAIL), 'stored_session');
+    /*
+     * While first init is in flight, a newer identical observation must see
+     * previous already advanced to signedIn+email and skip identify.
+     */
+    const second = tracker.observe(signedIn(EMAIL), 'device_auth');
+
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(analyticsMocks.initAnalytics).toHaveBeenCalledTimes(1);
+
+    deferred.resolve(true);
+    await Promise.all([first, second]);
+
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(analyticsMocks.initAnalytics).toHaveBeenCalledTimes(1);
+    // eslint-disable-next-line vitest/prefer-called-once
+    expect(emitSignedIn).toHaveBeenCalledTimes(1);
+    expect(emitSignedIn).toHaveBeenCalledWith('stored_session');
+  });
+
+  it('does not identify when signedIn has no email', async () => {
+    resetMocks();
+    analyticsMocks.initAnalytics.mockResolvedValue(true);
+    const { emitSignedIn, tracker } = createTracker();
+
+    await tracker.observe(emailLessSignedIn, 'stored_session');
+    await tracker.observe({ email: '', status: 'signedIn' }, 'stored_session');
+
+    expect(analyticsMocks.initAnalytics).not.toHaveBeenCalled();
+    expect(emitSignedIn).not.toHaveBeenCalled();
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/use-analytics-identity.ts
+++ b/apps/extension/entrypoints/sidepanel/use-analytics-identity.ts
@@ -1,0 +1,104 @@
+import { useEffect, useRef } from 'react';
+import type { RefObject } from 'react';
+import { EXTENSION_SIGNED_IN_EVENT, captureEvent, initAnalytics } from '@/src/shared/analytics';
+import type { AnalyticsStorageArea } from '@/src/shared/analytics';
+
+export interface ObservedAuthState {
+  readonly email: string | undefined;
+  readonly status: string | undefined;
+}
+
+export type SignInSource = 'device_auth' | 'stored_session';
+
+/**
+ * Returns `'identify'` when `next` is a newly observed signed-in session with a
+ * non-empty email that differs from a still-signed-in previous observation.
+ */
+export const resolveSignedInTransition = (
+  previous: ObservedAuthState | undefined,
+  next: ObservedAuthState
+): 'identify' | null => {
+  if (next.status !== 'signedIn') {
+    return null;
+  }
+
+  if (typeof next.email !== 'string' || next.email.length === 0) {
+    return null;
+  }
+
+  if (previous?.status === 'signedIn' && previous.email === next.email) {
+    return null;
+  }
+
+  return 'identify';
+};
+
+interface AnalyticsIdentityTrackerOptions {
+  readonly emitSignedIn: (source: SignInSource) => void;
+  readonly storageArea: AnalyticsStorageArea;
+}
+
+interface AnalyticsIdentityTracker {
+  observe(next: ObservedAuthState, signInSource: SignInSource): Promise<void>;
+}
+
+export const createAnalyticsIdentityTracker = ({
+  emitSignedIn,
+  storageArea,
+}: AnalyticsIdentityTrackerOptions): AnalyticsIdentityTracker => {
+  // eslint-disable-next-line unicorn/no-useless-undefined -- explicit unset sentinel
+  let previous: ObservedAuthState | undefined = undefined;
+
+  return {
+    observe: async (next, signInSource): Promise<void> => {
+      const decision = resolveSignedInTransition(previous, next);
+      /*
+       * Advance synchronously on EVERY observation (including signed-out and
+       * undefined status) before any await so overlapping runs dedupe and
+       * re-sign-in after sign-out re-identifies.
+       */
+      previous = next;
+
+      if (decision !== 'identify' || typeof next.email !== 'string' || next.email.length === 0) {
+        return;
+      }
+
+      const activated = await initAnalytics(storageArea, next.email);
+
+      if (activated) {
+        emitSignedIn(signInSource);
+      }
+    },
+  };
+};
+
+interface UseAnalyticsIdentityOptions {
+  readonly email: string | undefined;
+  readonly signInSource: RefObject<SignInSource>;
+  readonly status: string | undefined;
+  readonly storageArea: AnalyticsStorageArea;
+}
+
+/**
+ * Observes auth status/email transitions and identifies the analytics user on
+ * each transition into a signed-in-with-email session. Never drives rendering.
+ */
+export const useAnalyticsIdentity = ({
+  email,
+  signInSource,
+  status,
+  storageArea,
+}: UseAnalyticsIdentityOptions): void => {
+  const trackerRef = useRef<AnalyticsIdentityTracker | null>(null);
+
+  trackerRef.current ??= createAnalyticsIdentityTracker({
+    emitSignedIn: source => {
+      captureEvent(EXTENSION_SIGNED_IN_EVENT, { source });
+    },
+    storageArea,
+  });
+
+  useEffect(() => {
+    void trackerRef.current?.observe({ email, status }, signInSource.current);
+  }, [email, signInSource, status]);
+};

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -11,7 +11,7 @@
     "build": "wxt build",
     "build:firefox": "wxt build -b firefox --mv3",
     "e2e": "pnpm run e2e:chrome && pnpm run e2e:firefox",
-    "e2e:chrome": "pnpm run build && playwright test -c playwright.config.ts --grep-invert \"firefox build installs\"",
+    "e2e:chrome": "VITE_POSTHOG_API_KEY=e2e-test-key pnpm run build && playwright test -c playwright.config.ts --grep-invert \"firefox build installs\"",
     "e2e:debug": "pnpm run build && pnpm run build:firefox && playwright test -c playwright.config.ts --debug",
     "e2e:firefox": "echo 'Running Firefox extension e2e via Selenium/geckodriver' && tsx tests/e2e/firefox-selenium-e2e.ts",
     "e2e:local": "VITE_KILO_API_BASE_URL=http://localhost:3000 EXTENSION_LOCAL_BACKEND_E2E=1 pnpm run build && EXTENSION_LOCAL_BACKEND_E2E=1 playwright test -c playwright.config.ts tests/e2e/local-backend-live.test.ts",

--- a/apps/extension/package.json
+++ b/apps/extension/package.json
@@ -35,6 +35,7 @@
     "jotai": "2.18.1",
     "jotai-family": "1.0.2",
     "lucide-react": "0.552.0",
+    "posthog-js": "1.360.2",
     "react": "19.2.6",
     "react-dom": "19.2.6",
     "react-markdown": "10.1.0",

--- a/apps/extension/src/shared/analytics.test.ts
+++ b/apps/extension/src/shared/analytics.test.ts
@@ -1,0 +1,599 @@
+/* eslint-disable max-lines */
+import { describe, expect, it, vi } from 'vitest';
+
+interface MockClient {
+  capture: ReturnType<typeof vi.fn>;
+  identify: ReturnType<typeof vi.fn>;
+  init: ReturnType<typeof vi.fn>;
+  register: ReturnType<typeof vi.fn>;
+  reset: ReturnType<typeof vi.fn>;
+}
+
+const mocks = vi.hoisted(() => {
+  const clients: MockClient[] = [];
+
+  class MockPostHog {
+    capture = vi.fn();
+    identify = vi.fn();
+    init = vi.fn();
+    register = vi.fn();
+    reset = vi.fn();
+
+    constructor() {
+      clients.push(this);
+    }
+  }
+
+  return { MockPostHog, clients };
+});
+
+// eslint-disable-next-line vitest/prefer-import-in-mock, jest/no-untyped-mock-factory
+vi.mock('posthog-js/dist/module.no-external', () => ({
+  PostHog: mocks.MockPostHog,
+}));
+
+// eslint-disable-next-line import/first
+import {
+  ANALYTICS_OPT_OUT_STORAGE_KEY,
+  EXTENSION_SIGNED_OUT_EVENT,
+  __setFirefoxPermissionsReaderForTests,
+  captureEvent,
+  getFirefoxUsageDataGranted,
+  initAnalytics,
+  loadAnalyticsOptOut,
+  resetAnalyticsUser,
+  setAnalyticsOptOut,
+  shouldStartAnalytics,
+} from './analytics';
+// eslint-disable-next-line import/first
+import type { AnalyticsStorageArea } from './analytics';
+
+const API_KEY = 'phc_test_key';
+const EMAIL = 'user@kilo.ai';
+
+const EXPECTED_INIT_OPTIONS = {
+  advanced_disable_flags: true,
+  api_host: 'https://us.i.posthog.com',
+  autocapture: false,
+  capture_pageleave: false,
+  capture_pageview: false,
+  disable_external_dependency_loading: true,
+  disable_session_recording: true,
+  persistence: 'localStorage',
+} as const;
+
+const ALLOWED_STRING_ENUMS = new Set([
+  'dangerous',
+  'device_auth',
+  'expired',
+  'explicit',
+  'extension',
+  'safe',
+  'stored_session',
+]);
+
+const createStorage = (initial?: unknown): AnalyticsStorageArea & { value: unknown } => {
+  let storedValue = initial;
+
+  return {
+    getItem: key => {
+      expect(key).toBe(ANALYTICS_OPT_OUT_STORAGE_KEY);
+      return storedValue;
+    },
+    setItem: (key, value) => {
+      expect(key).toBe(ANALYTICS_OPT_OUT_STORAGE_KEY);
+      storedValue = value;
+    },
+    get value() {
+      return storedValue;
+    },
+  };
+};
+
+const createDeferredStorage = (): AnalyticsStorageArea & {
+  resolveGet: (value: unknown) => void;
+  value: unknown;
+} => {
+  let storedValue: unknown = false;
+  let resolveGet: ((value: unknown) => void) | undefined = undefined;
+  // eslint-disable-next-line promise/avoid-new
+  const getPromise = new Promise<unknown>(resolve => {
+    resolveGet = resolve;
+  });
+
+  return {
+    getItem: key => {
+      expect(key).toBe(ANALYTICS_OPT_OUT_STORAGE_KEY);
+      // eslint-disable-next-line promise/prefer-await-to-then
+      return getPromise.then(() => storedValue);
+    },
+    resolveGet: (value: unknown) => {
+      storedValue = value;
+      resolveGet?.(value);
+    },
+    setItem: (key, value) => {
+      expect(key).toBe(ANALYTICS_OPT_OUT_STORAGE_KEY);
+      storedValue = value;
+    },
+    get value() {
+      return storedValue;
+    },
+  };
+};
+
+const withEnv = async (
+  env: {
+    readonly DEV?: boolean;
+    readonly FIREFOX?: 'true' | 'false';
+    readonly VITE_POSTHOG_API_KEY?: string;
+  },
+  run: () => Promise<void> | void
+): Promise<void> => {
+  vi.unstubAllEnvs();
+  if (env.DEV !== undefined) {
+    vi.stubEnv('DEV', env.DEV);
+  }
+  if (env.FIREFOX !== undefined) {
+    vi.stubEnv('FIREFOX', env.FIREFOX);
+  }
+  if (env.VITE_POSTHOG_API_KEY !== undefined) {
+    vi.stubEnv('VITE_POSTHOG_API_KEY', env.VITE_POSTHOG_API_KEY);
+  }
+  try {
+    await run();
+  } finally {
+    vi.unstubAllEnvs();
+  }
+};
+
+const productionEnv = {
+  DEV: false,
+  VITE_POSTHOG_API_KEY: API_KEY,
+} as const;
+
+const allCaptureCalls = (): unknown[][] =>
+  mocks.clients.flatMap(client => client.capture.mock.calls);
+
+const isPlainPropertiesRecord = (
+  value: unknown
+): value is Record<string, string | number | boolean> => {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  return Object.values(value).every(
+    entry => typeof entry === 'string' || typeof entry === 'number' || typeof entry === 'boolean'
+  );
+};
+
+const assertCapturedPropertiesAreEnums = (): void => {
+  for (const call of allCaptureCalls()) {
+    const [, properties] = call;
+    if (isPlainPropertiesRecord(properties)) {
+      for (const value of Object.values(properties)) {
+        if (typeof value === 'string') {
+          expect(ALLOWED_STRING_ENUMS.has(value)).toBe(true);
+        } else {
+          expect(['boolean', 'number']).toContain(typeof value);
+        }
+      }
+    }
+  }
+};
+
+const resetModule = async (): Promise<void> => {
+  __setFirefoxPermissionsReaderForTests();
+  vi.unstubAllEnvs();
+  await resetAnalyticsUser({ reason: 'explicit' });
+  mocks.clients.length = 0;
+};
+
+describe('analytics gating', () => {
+  it('allows start only when every gate passes', async () => {
+    await resetModule();
+    expect(
+      shouldStartAnalytics({
+        firefoxUsageDataGranted: true,
+        hasApiKey: true,
+        hasEmail: true,
+        isDev: false,
+        optedOut: false,
+      })
+    ).toBe(true);
+  });
+
+  it.each([
+    ['isDev', { isDev: true }],
+    ['hasApiKey', { hasApiKey: false }],
+    ['hasEmail', { hasEmail: false }],
+    ['optedOut', { optedOut: true }],
+    ['firefoxUsageDataGranted', { firefoxUsageDataGranted: false }],
+  ] as const)('vetoes when %s fails', async (_label, override) => {
+    await resetModule();
+    expect(
+      shouldStartAnalytics({
+        firefoxUsageDataGranted: true,
+        hasApiKey: true,
+        hasEmail: true,
+        isDev: false,
+        optedOut: false,
+        ...override,
+      })
+    ).toBe(false);
+  });
+
+  it('covers multi-gate combinations independently', async () => {
+    await resetModule();
+    const cases = [
+      {
+        firefoxUsageDataGranted: true,
+        hasApiKey: true,
+        hasEmail: true,
+        isDev: true,
+        optedOut: false,
+      },
+      {
+        firefoxUsageDataGranted: true,
+        hasApiKey: false,
+        hasEmail: true,
+        isDev: false,
+        optedOut: false,
+      },
+      {
+        firefoxUsageDataGranted: true,
+        hasApiKey: true,
+        hasEmail: false,
+        isDev: false,
+        optedOut: false,
+      },
+      {
+        firefoxUsageDataGranted: true,
+        hasApiKey: true,
+        hasEmail: true,
+        isDev: false,
+        optedOut: true,
+      },
+      {
+        firefoxUsageDataGranted: false,
+        hasApiKey: true,
+        hasEmail: true,
+        isDev: false,
+        optedOut: false,
+      },
+    ] as const;
+
+    for (const input of cases) {
+      expect(shouldStartAnalytics(input)).toBe(false);
+    }
+  });
+});
+
+describe('firefox usage data grant', () => {
+  it('returns true on non-Firefox builds without reading permissions', async () => {
+    await resetModule();
+    const reader = vi.fn();
+    __setFirefoxPermissionsReaderForTests(reader);
+
+    await withEnv({ FIREFOX: 'false' }, async () => {
+      await expect(getFirefoxUsageDataGranted()).resolves.toBe(true);
+      expect(reader).not.toHaveBeenCalled();
+    });
+  });
+
+  it('returns false when data_collection key is absent', async () => {
+    await resetModule();
+    __setFirefoxPermissionsReaderForTests(() => ({ permissions: [] }));
+
+    await withEnv({ FIREFOX: 'true' }, async () => {
+      await expect(getFirefoxUsageDataGranted()).resolves.toBe(false);
+    });
+  });
+
+  it('returns false when technicalAndInteraction is not granted', async () => {
+    await resetModule();
+    __setFirefoxPermissionsReaderForTests(() => ({
+      data_collection: ['personallyIdentifyingInfo'],
+    }));
+
+    await withEnv({ FIREFOX: 'true' }, async () => {
+      await expect(getFirefoxUsageDataGranted()).resolves.toBe(false);
+    });
+  });
+
+  it('returns true when technicalAndInteraction is granted', async () => {
+    await resetModule();
+    __setFirefoxPermissionsReaderForTests(() => ({
+      data_collection: ['technicalAndInteraction'],
+    }));
+
+    await withEnv({ FIREFOX: 'true' }, async () => {
+      await expect(getFirefoxUsageDataGranted()).resolves.toBe(true);
+    });
+  });
+
+  it('returns false for invalid browser API responses', async () => {
+    await resetModule();
+    __setFirefoxPermissionsReaderForTests(() => 'not-an-object');
+
+    await withEnv({ FIREFOX: 'true' }, async () => {
+      await expect(getFirefoxUsageDataGranted()).resolves.toBe(false);
+    });
+  });
+});
+
+describe('analytics client lifecycle', () => {
+  it('starts client, registers platform, and identifies on pass', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      const storage = createStorage(false);
+      await expect(initAnalytics(storage, EMAIL)).resolves.toBe(true);
+
+      expect(mocks.clients).toHaveLength(1);
+      expect(mocks.clients[0]?.init).toHaveBeenCalledWith(API_KEY, EXPECTED_INIT_OPTIONS);
+      expect(mocks.clients[0]?.register).toHaveBeenCalledWith({ platform: 'extension' });
+      expect(mocks.clients[0]?.identify).toHaveBeenCalledWith(EMAIL, { email: EMAIL });
+    });
+  });
+
+  it('returns false and builds no client when opted out', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      await expect(initAnalytics(createStorage(true), EMAIL)).resolves.toBe(false);
+      expect(mocks.clients).toHaveLength(0);
+    });
+  });
+
+  it('returns false with no email', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      await expect(initAnalytics(createStorage(false), '')).resolves.toBe(false);
+      expect(mocks.clients).toHaveLength(0);
+    });
+  });
+
+  it('returns false in dev mode even with a key', async () => {
+    await resetModule();
+    await withEnv({ ...productionEnv, DEV: true }, async () => {
+      await expect(initAnalytics(createStorage(false), EMAIL)).resolves.toBe(false);
+      expect(mocks.clients).toHaveLength(0);
+    });
+  });
+
+  it('returns false without a key and logs a single console.info', async () => {
+    await resetModule();
+    const info = vi.spyOn(console, 'info').mockReturnValue();
+
+    await withEnv({ DEV: false, VITE_POSTHOG_API_KEY: '' }, async () => {
+      await expect(initAnalytics(createStorage(false), EMAIL)).resolves.toBe(false);
+      expect(mocks.clients).toHaveLength(0);
+      // eslint-disable-next-line vitest/prefer-called-once
+      expect(info).toHaveBeenCalledTimes(1);
+      expect(String(info.mock.calls[0]?.[0])).toMatch(/VITE_POSTHOG_API_KEY/);
+    });
+
+    info.mockRestore();
+  });
+
+  it('returns false when Firefox usage data is not granted', async () => {
+    await resetModule();
+    __setFirefoxPermissionsReaderForTests(() => ({ data_collection: [] }));
+
+    await withEnv({ ...productionEnv, FIREFOX: 'true' }, async () => {
+      await expect(initAnalytics(createStorage(false), EMAIL)).resolves.toBe(false);
+      expect(mocks.clients).toHaveLength(0);
+    });
+  });
+
+  it('re-init with the same email is a no-op returning true', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      const storage = createStorage(false);
+      await expect(initAnalytics(storage, EMAIL)).resolves.toBe(true);
+      const clientsAfterFirst = mocks.clients.length;
+      const firstClient = mocks.clients[0]!;
+      const identifyCalls = firstClient.identify.mock.calls.length;
+      await expect(initAnalytics(storage, EMAIL)).resolves.toBe(true);
+      expect(mocks.clients).toHaveLength(clientsAfterFirst);
+      expect(firstClient.identify).toHaveBeenCalledTimes(identifyCalls);
+    });
+  });
+
+  it('re-init with a different email re-identifies on the same client', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      const storage = createStorage(false);
+      await expect(initAnalytics(storage, EMAIL)).resolves.toBe(true);
+      const clientsAfterFirst = mocks.clients.length;
+      await expect(initAnalytics(storage, 'other@kilo.ai')).resolves.toBe(true);
+      expect(mocks.clients).toHaveLength(clientsAfterFirst);
+      expect(mocks.clients[0]?.identify).toHaveBeenLastCalledWith('other@kilo.ai', {
+        email: 'other@kilo.ai',
+      });
+    });
+  });
+});
+
+describe('analytics opt-out storage', () => {
+  it('treats absent and invalid stored values as false', async () => {
+    await resetModule();
+    await expect(loadAnalyticsOptOut(createStorage())).resolves.toBe(false);
+    await expect(loadAnalyticsOptOut(createStorage('yes'))).resolves.toBe(false);
+    await expect(loadAnalyticsOptOut(createStorage(1))).resolves.toBe(false);
+    await expect(loadAnalyticsOptOut(createStorage(true))).resolves.toBe(true);
+    await expect(loadAnalyticsOptOut(createStorage(false))).resolves.toBe(false);
+  });
+
+  it('persists opt-out and drops an active client', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      const storage = createStorage(false);
+      await initAnalytics(storage, EMAIL);
+      expect(mocks.clients).toHaveLength(1);
+      const client = mocks.clients[0]!;
+      client.capture.mockClear();
+      client.reset.mockClear();
+
+      await setAnalyticsOptOut(storage, true);
+      expect(storage.value).toBe(true);
+      expect(client.reset).toHaveBeenCalledWith();
+      await expect(loadAnalyticsOptOut(storage)).resolves.toBe(true);
+
+      captureEvent('message_sent', { mode: 'safe' });
+      expect(client.capture).not.toHaveBeenCalled();
+    });
+  });
+
+  it('re-inits when opting back in with an identity', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      const storage = createStorage(true);
+      await setAnalyticsOptOut(storage, false, { email: EMAIL });
+      expect(storage.value).toBe(false);
+      expect(mocks.clients.length).toBeGreaterThan(0);
+      expect(mocks.clients.at(-1)?.identify).toHaveBeenCalledWith(EMAIL, { email: EMAIL });
+    });
+  });
+
+  it('only persists when opting back in without an identity', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      const storage = createStorage(true);
+      await setAnalyticsOptOut(storage, false);
+      expect(storage.value).toBe(false);
+      expect(mocks.clients).toHaveLength(0);
+    });
+  });
+});
+
+describe('analytics capture', () => {
+  it('is a no-op without an active client', async () => {
+    await resetModule();
+    captureEvent('message_sent', { mode: 'safe' });
+    expect(allCaptureCalls()).toHaveLength(0);
+  });
+
+  it('forwards send_instantly when sendInstantly is set', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      await initAnalytics(createStorage(false), EMAIL);
+      const client = mocks.clients[0]!;
+      client.capture.mockClear();
+
+      captureEvent(EXTENSION_SIGNED_OUT_EVENT, { reason: 'explicit' }, { sendInstantly: true });
+
+      expect(client.capture).toHaveBeenCalledWith(
+        EXTENSION_SIGNED_OUT_EVENT,
+        { reason: 'explicit' },
+        { send_instantly: true }
+      );
+      assertCapturedPropertiesAreEnums();
+    });
+  });
+});
+
+describe('analytics user reset', () => {
+  it('active + explicit: capture with send_instantly before reset', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      await initAnalytics(createStorage(false), EMAIL);
+      const client = mocks.clients[0]!;
+      client.capture.mockClear();
+      client.reset.mockClear();
+
+      await resetAnalyticsUser({ reason: 'explicit' });
+
+      expect(client.capture.mock.invocationCallOrder[0]).toBeLessThan(
+        client.reset.mock.invocationCallOrder[0]!
+      );
+      expect(client.capture).toHaveBeenCalledWith(
+        EXTENSION_SIGNED_OUT_EVENT,
+        { reason: 'explicit' },
+        { send_instantly: true }
+      );
+      assertCapturedPropertiesAreEnums();
+    });
+  });
+
+  it('active + expired: capture with expired reason before reset', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      await initAnalytics(createStorage(false), EMAIL);
+      const client = mocks.clients[0]!;
+      client.capture.mockClear();
+      client.reset.mockClear();
+
+      await resetAnalyticsUser({ reason: 'expired' });
+
+      expect(client.capture.mock.invocationCallOrder[0]).toBeLessThan(
+        client.reset.mock.invocationCallOrder[0]!
+      );
+      expect(client.capture).toHaveBeenCalledWith(
+        EXTENSION_SIGNED_OUT_EVENT,
+        { reason: 'expired' },
+        { send_instantly: true }
+      );
+      assertCapturedPropertiesAreEnums();
+    });
+  });
+
+  it('inactive: ephemeral scrub with zero capture and zero identify', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      mocks.clients.length = 0;
+
+      await resetAnalyticsUser({ reason: 'expired' });
+
+      expect(mocks.clients).toHaveLength(1);
+      const ephemeral = mocks.clients[0]!;
+      expect(ephemeral.init).toHaveBeenCalledWith(API_KEY, EXPECTED_INIT_OPTIONS);
+      expect(ephemeral.capture).not.toHaveBeenCalled();
+      expect(ephemeral.identify).not.toHaveBeenCalled();
+      // eslint-disable-next-line vitest/prefer-called-once
+      expect(ephemeral.reset).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  it('inactive without api key is a no-op', async () => {
+    await resetModule();
+    await withEnv({ DEV: false, VITE_POSTHOG_API_KEY: '' }, async () => {
+      mocks.clients.length = 0;
+      await resetAnalyticsUser({ reason: 'explicit' });
+      expect(mocks.clients).toHaveLength(0);
+    });
+  });
+});
+
+describe('analytics in-flight race guard', () => {
+  it('discards init when opt-out lands mid-flight', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      const storage = createDeferredStorage();
+      const initPromise = initAnalytics(storage, EMAIL);
+
+      await setAnalyticsOptOut(storage, true);
+      storage.resolveGet(true);
+
+      await expect(initPromise).resolves.toBe(false);
+      expect(mocks.clients.every(client => client.identify.mock.calls.length === 0)).toBe(true);
+
+      captureEvent('message_sent', { mode: 'safe' });
+      expect(allCaptureCalls()).toHaveLength(0);
+    });
+  });
+
+  it('discards init when reset lands mid-flight', async () => {
+    await resetModule();
+    await withEnv(productionEnv, async () => {
+      const storage = createDeferredStorage();
+      const initPromise = initAnalytics(storage, EMAIL);
+
+      await resetAnalyticsUser({ reason: 'explicit' });
+      // Reset may construct an ephemeral scrub client.
+      storage.resolveGet(false);
+
+      await expect(initPromise).resolves.toBe(false);
+      expect(mocks.clients.every(client => client.identify.mock.calls.length === 0)).toBe(true);
+      captureEvent('message_sent', { mode: 'safe' });
+      expect(allCaptureCalls()).toHaveLength(0);
+    });
+  });
+});

--- a/apps/extension/src/shared/analytics.ts
+++ b/apps/extension/src/shared/analytics.ts
@@ -1,0 +1,257 @@
+import { PostHog } from 'posthog-js/dist/module.no-external';
+import { z } from 'zod';
+
+export const EXTENSION_SIGNED_IN_EVENT = 'extension_signed_in';
+export const EXTENSION_SIGNED_OUT_EVENT = 'extension_signed_out';
+export const CONVERSATION_CREATED_EVENT = 'conversation_created';
+export const MESSAGE_SENT_EVENT = 'message_sent';
+
+export const ANALYTICS_OPT_OUT_STORAGE_KEY = 'sync:analyticsOptOut';
+
+type MaybePromise<Value> = Promise<Value> | Value;
+
+export interface AnalyticsStorageArea {
+  getItem(key: typeof ANALYTICS_OPT_OUT_STORAGE_KEY): MaybePromise<unknown>;
+  setItem(key: typeof ANALYTICS_OPT_OUT_STORAGE_KEY, value: boolean): MaybePromise<void>;
+}
+
+interface AnalyticsGateInput {
+  readonly firefoxUsageDataGranted: boolean;
+  readonly hasApiKey: boolean;
+  readonly hasEmail: boolean;
+  readonly isDev: boolean;
+  readonly optedOut: boolean;
+}
+
+interface CaptureEventOptions {
+  readonly sendInstantly?: boolean;
+}
+
+interface ResetAnalyticsUserOptions {
+  readonly reason: 'explicit' | 'expired';
+}
+
+interface ActiveAnalyticsIdentity {
+  readonly client: PostHog;
+  readonly email: string;
+}
+
+const POSTHOG_API_HOST = 'https://us.i.posthog.com';
+
+// Exact MV3-safe init option set from the plan (key order sorted for lint).
+const POSTHOG_INIT_OPTIONS = {
+  advanced_disable_flags: true,
+  api_host: POSTHOG_API_HOST,
+  autocapture: false,
+  capture_pageleave: false,
+  capture_pageview: false,
+  disable_external_dependency_loading: true,
+  disable_session_recording: true,
+  persistence: 'localStorage',
+} as const;
+
+const permissionsGetAllSchema = z
+  .object({
+    data_collection: z.array(z.string()).optional(),
+  })
+  .loose();
+
+// eslint-disable-next-line unicorn/no-useless-undefined -- explicit unset sentinel
+let activeIdentity: ActiveAnalyticsIdentity | undefined = undefined;
+let lifecycleEpoch = 0;
+
+const readApiKey = (): string | undefined => {
+  const key = import.meta.env.VITE_POSTHOG_API_KEY;
+  return typeof key === 'string' && key.trim().length > 0 ? key.trim() : undefined;
+};
+
+const createPostHogClient = (apiKey: string): PostHog => {
+  const client = new PostHog();
+  client.init(apiKey, { ...POSTHOG_INIT_OPTIONS });
+  return client;
+};
+
+const dropClient = (client: PostHog | undefined): void => {
+  client?.reset();
+};
+
+const publishIdentity = (client: PostHog, email: string): void => {
+  client.register({ platform: 'extension' });
+  client.identify(email, { email });
+  activeIdentity = { client, email };
+};
+
+export const shouldStartAnalytics = ({
+  firefoxUsageDataGranted,
+  hasApiKey,
+  hasEmail,
+  isDev,
+  optedOut,
+}: AnalyticsGateInput): boolean =>
+  !isDev && hasApiKey && hasEmail && !optedOut && firefoxUsageDataGranted;
+
+export const loadAnalyticsOptOut = async (storageArea: AnalyticsStorageArea): Promise<boolean> => {
+  const value = await storageArea.getItem(ANALYTICS_OPT_OUT_STORAGE_KEY);
+  return value === true;
+};
+
+type FirefoxPermissionsReader = () => MaybePromise<unknown>;
+
+// eslint-disable-next-line unicorn/no-useless-undefined -- explicit unset sentinel
+let firefoxPermissionsReader: FirefoxPermissionsReader | undefined = undefined;
+
+/** Test-only seam for Firefox permission reads under Vitest (node, no chrome global). */
+export const __setFirefoxPermissionsReaderForTests = (reader?: FirefoxPermissionsReader): void => {
+  firefoxPermissionsReader = reader;
+};
+
+const readFirefoxPermissions = async (): Promise<unknown> => {
+  if (firefoxPermissionsReader) {
+    return firefoxPermissionsReader();
+  }
+
+  const { browser } = await import('wxt/browser');
+  return browser.permissions.getAll();
+};
+
+const isTruthyEnvFlag = (value: unknown): boolean => value === true || value === 'true';
+
+// Vite injects DEV; WXT injects FIREFOX as a boolean. Vitest stubs non-DEV keys as strings.
+const isDevBuild = (): boolean => isTruthyEnvFlag(import.meta.env.DEV);
+
+const isFirefoxBuild = (): boolean => isTruthyEnvFlag(import.meta.env.FIREFOX);
+
+export const getFirefoxUsageDataGranted = async (): Promise<boolean> => {
+  if (!isFirefoxBuild()) {
+    return true;
+  }
+
+  const raw = await readFirefoxPermissions();
+  const parsed = permissionsGetAllSchema.safeParse(raw);
+  if (!parsed.success) {
+    return false;
+  }
+
+  const dataCollection = parsed.data.data_collection;
+  if (dataCollection === undefined) {
+    // Firefox < 140: no built-in data_collection consent surface.
+    return false;
+  }
+
+  return dataCollection.includes('technicalAndInteraction');
+};
+
+export const initAnalytics = async (
+  storageArea: AnalyticsStorageArea,
+  email: string
+): Promise<boolean> => {
+  const epochAtStart = ++lifecycleEpoch;
+
+  if (activeIdentity !== undefined) {
+    if (activeIdentity.email === email) {
+      return true;
+    }
+
+    // Re-identify without constructing a second client.
+    activeIdentity.client.identify(email, { email });
+    activeIdentity = { client: activeIdentity.client, email };
+    return true;
+  }
+
+  const apiKey = readApiKey();
+  const hasApiKey = apiKey !== undefined;
+  const hasEmail = email.trim().length > 0;
+
+  if (!hasApiKey) {
+    console.info('PostHog analytics disabled: VITE_POSTHOG_API_KEY is not set.');
+  }
+
+  const optedOut = await loadAnalyticsOptOut(storageArea);
+  const firefoxUsageDataGranted = await getFirefoxUsageDataGranted();
+
+  if (lifecycleEpoch !== epochAtStart) {
+    return false;
+  }
+
+  const canStart = shouldStartAnalytics({
+    firefoxUsageDataGranted,
+    hasApiKey,
+    hasEmail,
+    isDev: isDevBuild(),
+    optedOut,
+  });
+
+  if (!canStart || apiKey === undefined) {
+    return false;
+  }
+
+  const client = createPostHogClient(apiKey);
+
+  if (lifecycleEpoch !== epochAtStart) {
+    // Discard without identify — inert with flags/capture disabled.
+    dropClient(client);
+    return false;
+  }
+
+  publishIdentity(client, email);
+  return true;
+};
+
+export const captureEvent = (
+  name: string,
+  properties?: Record<string, string | number | boolean>,
+  options?: CaptureEventOptions
+): void => {
+  if (activeIdentity === undefined) {
+    return;
+  }
+
+  if (options?.sendInstantly === true) {
+    activeIdentity.client.capture(name, properties, { send_instantly: true });
+    return;
+  }
+
+  activeIdentity.client.capture(name, properties);
+};
+
+export const resetAnalyticsUser = ({ reason }: ResetAnalyticsUserOptions): Promise<void> => {
+  lifecycleEpoch += 1;
+  const current = activeIdentity;
+  activeIdentity = undefined;
+
+  if (current !== undefined) {
+    current.client.capture(EXTENSION_SIGNED_OUT_EVENT, { reason }, { send_instantly: true });
+    current.client.reset();
+    return Promise.resolve();
+  }
+
+  const apiKey = readApiKey();
+  if (apiKey === undefined) {
+    return Promise.resolve();
+  }
+
+  // Scrub stale ph_<token>_* localStorage identity from a prior session.
+  const ephemeral = createPostHogClient(apiKey);
+  ephemeral.reset();
+  return Promise.resolve();
+};
+
+export const setAnalyticsOptOut = async (
+  storageArea: AnalyticsStorageArea,
+  optedOut: boolean,
+  identity?: { readonly email: string }
+): Promise<void> => {
+  lifecycleEpoch += 1;
+  await storageArea.setItem(ANALYTICS_OPT_OUT_STORAGE_KEY, optedOut);
+
+  if (optedOut) {
+    const current = activeIdentity;
+    activeIdentity = undefined;
+    current?.client.reset();
+    return;
+  }
+
+  if (identity !== undefined) {
+    await initAnalytics(storageArea, identity.email);
+  }
+};

--- a/apps/extension/src/types/import-meta.d.ts
+++ b/apps/extension/src/types/import-meta.d.ts
@@ -1,3 +1,5 @@
 interface ImportMetaEnv {
+  readonly DEV?: boolean;
   readonly VITE_KILO_API_BASE_URL?: string;
+  readonly VITE_POSTHOG_API_KEY?: string;
 }

--- a/apps/extension/tests/e2e/analytics.test.ts
+++ b/apps/extension/tests/e2e/analytics.test.ts
@@ -1,0 +1,290 @@
+/* eslint-disable import/no-nodejs-modules */
+import { expect, test } from '@playwright/test';
+import type { BrowserContext, Page } from '@playwright/test';
+import { rm } from 'node:fs/promises';
+import {
+  launchExtensionContext,
+  readExtensionLocalStorage,
+  readExtensionSyncStorage,
+  seedExtensionAuth,
+  startFixtureServer,
+} from './extension-context-fixture';
+import { mockKiloApi } from './kilo-api-fixture';
+import { findCapturedEvent, findCapturedEvents } from './posthog-fixture';
+import type { NormalizedPosthogEvent } from './posthog-fixture';
+
+const ANALYTICS_OPT_OUT_KEY = 'analyticsOptOut';
+const SEEDED_EMAIL = 'user@kilo.ai';
+const PRODUCT_EVENTS = [
+  '$identify',
+  'extension_signed_in',
+  'extension_signed_out',
+  'message_sent',
+  'conversation_created',
+] as const;
+
+const openSignedInSidePanel = async (
+  context: BrowserContext,
+  extensionId: string
+): Promise<Page> => {
+  const sidePanel = await context.newPage();
+  await sidePanel.goto(`chrome-extension://${extensionId}/sidepanel.html`);
+  await seedExtensionAuth(sidePanel);
+  await sidePanel.reload();
+  await expect(sidePanel.getByLabel('Settings')).toBeVisible();
+  return sidePanel;
+};
+
+const waitForEvent = async (
+  posthogRequests: readonly NormalizedPosthogEvent[],
+  eventName: string
+): Promise<NormalizedPosthogEvent> => {
+  await expect
+    .poll(() => findCapturedEvent(posthogRequests, eventName), { timeout: 10_000 })
+    .toBeTruthy();
+  const event = findCapturedEvent(posthogRequests, eventName);
+  if (event === undefined) {
+    throw new Error(`Expected ${eventName} to be recorded.`);
+  }
+  return event;
+};
+
+const waitForIdentify = async (
+  posthogRequests: readonly NormalizedPosthogEvent[],
+  options?: { baseline?: number; email?: string }
+): Promise<NormalizedPosthogEvent> => {
+  const baseline = options?.baseline ?? 0;
+  const email = options?.email ?? SEEDED_EMAIL;
+  await expect
+    .poll(
+      () =>
+        posthogRequests
+          .slice(baseline)
+          .find(event => event.event === '$identify' && event.distinctId === email),
+      { timeout: 10_000 }
+    )
+    .toBeTruthy();
+  const event = posthogRequests
+    .slice(baseline)
+    .find(entry => entry.event === '$identify' && entry.distinctId === email);
+  if (event === undefined) {
+    throw new Error(`Expected $identify for ${email} after baseline ${baseline}.`);
+  }
+  return event;
+};
+
+const identifiedEventsIn = (events: readonly NormalizedPosthogEvent[]): NormalizedPosthogEvent[] =>
+  events.filter(event => typeof event.distinctId === 'string' && event.distinctId.length > 0);
+
+const productEventsIn = (events: readonly NormalizedPosthogEvent[]): NormalizedPosthogEvent[] =>
+  events.filter(event => (PRODUCT_EVENTS as readonly string[]).includes(event.event));
+
+const analyticsSwitch = (sidePanel: Page) =>
+  sidePanel.getByRole('switch', { name: 'Share usage analytics' });
+
+test('analytics identify and sign-in event fire on signed-in session start', async () => {
+  const { context, extensionId, posthogFlagsOrDecideHits, posthogRequests, userDataDir } =
+    await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context);
+    await openSignedInSidePanel(context, extensionId);
+
+    const identify = await waitForIdentify(posthogRequests);
+    expect(identify.distinctId).toBe(SEEDED_EMAIL);
+
+    const signedIn = await waitForEvent(posthogRequests, 'extension_signed_in');
+    expect(signedIn.properties).toMatchObject({
+      platform: 'extension',
+      source: 'stored_session',
+    });
+
+    expect(posthogFlagsOrDecideHits).toEqual([]);
+  } finally {
+    await context.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});
+
+test('analytics sign-out event fires before reset on sign out', async () => {
+  const { context, extensionId, posthogRequests, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context);
+    const sidePanel = await openSignedInSidePanel(context, extensionId);
+    await waitForIdentify(posthogRequests);
+    await waitForEvent(posthogRequests, 'extension_signed_in');
+
+    await sidePanel.getByLabel('Settings').click();
+    const baseline = posthogRequests.length;
+
+    await sidePanel.getByRole('button', { name: 'Sign out' }).click();
+
+    await expect
+      .poll(
+        () => findCapturedEvents(posthogRequests.slice(baseline), 'extension_signed_out').length,
+        { timeout: 10_000 }
+      )
+      .toBe(1);
+
+    const signedOut = findCapturedEvent(posthogRequests.slice(baseline), 'extension_signed_out');
+    expect(signedOut?.properties).toMatchObject({ reason: 'explicit' });
+
+    await expect(sidePanel.getByRole('button', { name: 'Sign in' })).toBeVisible();
+
+    const postBaselineIdentified = identifiedEventsIn(posthogRequests.slice(baseline));
+    expect(postBaselineIdentified).toHaveLength(1);
+    expect(postBaselineIdentified[0]?.event).toBe('extension_signed_out');
+  } finally {
+    await context.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});
+
+test('analytics opt-out toggle persists across side panel reloads', async () => {
+  const { context, extensionId, posthogRequests, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context);
+    const sidePanel = await openSignedInSidePanel(context, extensionId);
+    await waitForIdentify(posthogRequests);
+    await waitForEvent(posthogRequests, 'extension_signed_in');
+
+    await sidePanel.getByLabel('Settings').click();
+    await expect(analyticsSwitch(sidePanel)).toHaveAttribute('aria-checked', 'true');
+
+    await analyticsSwitch(sidePanel).click();
+    const optOutBaseline = posthogRequests.length;
+
+    await expect
+      .poll(() => readExtensionSyncStorage(sidePanel, ANALYTICS_OPT_OUT_KEY), { timeout: 5000 })
+      .toBe(true);
+    expect(productEventsIn(posthogRequests.slice(optOutBaseline))).toHaveLength(0);
+
+    const afterReloadBaseline = posthogRequests.length;
+    await sidePanel.reload();
+    await expect(sidePanel.getByLabel('Settings')).toBeVisible();
+    await sidePanel.getByLabel('Settings').click();
+    await expect(analyticsSwitch(sidePanel)).toHaveAttribute('aria-checked', 'false');
+    await expect
+      .poll(() => readExtensionSyncStorage(sidePanel, ANALYTICS_OPT_OUT_KEY), { timeout: 5000 })
+      .toBe(true);
+    expect(productEventsIn(posthogRequests.slice(afterReloadBaseline))).toHaveLength(0);
+
+    await sidePanel.getByRole('button', { name: 'Sign out' }).click();
+    await expect(sidePanel.getByRole('button', { name: 'Sign in' })).toBeVisible();
+    await expect
+      .poll(() => readExtensionLocalStorage(sidePanel, 'kiloAuth'), { timeout: 5000 })
+      .toBeUndefined();
+    await expect
+      .poll(() => readExtensionSyncStorage(sidePanel, ANALYTICS_OPT_OUT_KEY), { timeout: 5000 })
+      .toBe(true);
+
+    await seedExtensionAuth(sidePanel);
+    const reseedBaseline = posthogRequests.length;
+    await sidePanel.reload();
+    await expect(sidePanel.getByLabel('Settings')).toBeVisible();
+    await sidePanel.getByLabel('Settings').click();
+    await expect(analyticsSwitch(sidePanel)).toHaveAttribute('aria-checked', 'false');
+    await expect
+      .poll(() => readExtensionSyncStorage(sidePanel, ANALYTICS_OPT_OUT_KEY), { timeout: 5000 })
+      .toBe(true);
+    expect(productEventsIn(posthogRequests.slice(reseedBaseline))).toHaveLength(0);
+
+    const toggleOnBaseline = posthogRequests.length;
+    await analyticsSwitch(sidePanel).click();
+    await waitForIdentify(posthogRequests, { baseline: toggleOnBaseline, email: SEEDED_EMAIL });
+  } finally {
+    await context.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});
+
+test('analytics captures message sent and user-created conversation events', async () => {
+  const fixture = await startFixtureServer();
+  const { context, extensionId, posthogRequests, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context, {
+      firstCompletionEvents: [{ choices: [{ delta: { content: 'Analytics reply.' } }] }],
+      toolNames: ['get_page_snapshot', 'get_element_details', 'find_in_page'],
+    });
+
+    const page = await context.newPage();
+    await page.goto(fixture.url);
+
+    const sidePanel = await openSignedInSidePanel(context, extensionId);
+    await waitForIdentify(posthogRequests);
+
+    await expect(sidePanel.getByLabel('Target tab')).toContainText('Kilo extension fixture');
+    await expect(sidePanel.getByLabel('Model')).not.toContainText('Loading');
+
+    const conversationCreatedAtOpen = findCapturedEvents(
+      posthogRequests,
+      'conversation_created'
+    ).length;
+    expect(conversationCreatedAtOpen).toBe(0);
+
+    const messageInput = sidePanel.getByLabel('Message agent');
+    await messageInput.fill('Hello from analytics e2e');
+    await messageInput.press('Enter');
+
+    const messageSent = await waitForEvent(posthogRequests, 'message_sent');
+    expect(messageSent.properties).toMatchObject({ mode: 'safe' });
+
+    await sidePanel.getByLabel('New conversation').click();
+
+    await expect
+      .poll(() => findCapturedEvents(posthogRequests, 'conversation_created').length, {
+        timeout: 10_000,
+      })
+      .toBe(conversationCreatedAtOpen + 1);
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});
+
+test('analytics sign-out event fires with expired reason on mid-session expiry', async () => {
+  const { context, extensionId, posthogRequests, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context);
+    const sidePanel = await openSignedInSidePanel(context, extensionId);
+    await waitForIdentify(posthogRequests);
+    await waitForEvent(posthogRequests, 'extension_signed_in');
+
+    const baseline = posthogRequests.length;
+
+    // Registered after mockKiloApi so this handler takes precedence.
+    await context.route('https://app.kilo.ai/api/user', route =>
+      route.fulfill({
+        json: { error: 'unauthorized' },
+        status: 401,
+      })
+    );
+
+    await context.setOffline(true);
+    await context.setOffline(false);
+
+    await expect
+      .poll(
+        () => findCapturedEvents(posthogRequests.slice(baseline), 'extension_signed_out').length,
+        { timeout: 15_000 }
+      )
+      .toBe(1);
+
+    const signedOut = findCapturedEvent(posthogRequests.slice(baseline), 'extension_signed_out');
+    expect(signedOut?.properties).toMatchObject({ reason: 'expired' });
+
+    await expect(sidePanel.getByRole('button', { name: 'Sign in' })).toBeVisible();
+
+    const postBaselineIdentified = identifiedEventsIn(posthogRequests.slice(baseline));
+    expect(postBaselineIdentified).toHaveLength(1);
+    expect(postBaselineIdentified[0]?.event).toBe('extension_signed_out');
+  } finally {
+    await context.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});

--- a/apps/extension/tests/e2e/analytics.test.ts
+++ b/apps/extension/tests/e2e/analytics.test.ts
@@ -207,7 +207,13 @@ test('analytics captures message sent and user-created conversation events', asy
   try {
     await mockKiloApi(context, {
       firstCompletionEvents: [{ choices: [{ delta: { content: 'Analytics reply.' } }] }],
-      toolNames: ['get_page_snapshot', 'get_element_details', 'find_in_page'],
+      toolNames: [
+        'get_page_snapshot',
+        'get_element_details',
+        'find_in_page',
+        'search_memories',
+        'get_memory',
+      ],
     });
 
     const page = await context.newPage();

--- a/apps/extension/tests/e2e/extension-context-fixture.ts
+++ b/apps/extension/tests/e2e/extension-context-fixture.ts
@@ -1,10 +1,17 @@
-/* eslint-disable import/no-nodejs-modules, promise/avoid-new, promise/prefer-await-to-callbacks */
+/* eslint-disable import/no-nodejs-modules, max-lines, promise/avoid-new, promise/prefer-await-to-callbacks */
 import { chromium, expect } from '@playwright/test';
 import type { BrowserContext, Page } from '@playwright/test';
 import { access, mkdtemp } from 'node:fs/promises';
 import { createServer } from 'node:http';
 import { tmpdir } from 'node:os';
 import { join, resolve as resolvePath } from 'node:path';
+import {
+  applyPosthogE2eBrowserWorkarounds,
+  EXTENSION_E2E_LAUNCH_ARGS,
+  EXTENSION_E2E_USER_AGENT,
+  installPosthogStub,
+} from './posthog-fixture';
+import type { NormalizedPosthogEvent } from './posthog-fixture';
 
 export const extensionPath = resolvePath(import.meta.dirname, '../../.output/chrome-mv3');
 
@@ -62,6 +69,10 @@ export const startFixtureServer = async ({
 export const launchExtensionContext = async (): Promise<{
   context: BrowserContext;
   extensionId: string;
+  /** `/flags` and `/decide/` URLs that hit the stub (must stay empty with flags disabled). */
+  posthogFlagsOrDecideHits: string[];
+  /** Capture-class PostHog events (normalized). Additive; existing callers ignore it. */
+  posthogRequests: NormalizedPosthogEvent[];
   userDataDir: string;
 }> => {
   const userDataDir = await mkdtemp(join(tmpdir(), 'kilo-extension-e2e-'));
@@ -69,17 +80,31 @@ export const launchExtensionContext = async (): Promise<{
   const isHeaded = process.env['EXTENSION_E2E_HEADED'] === '1';
 
   const context = await chromium.launchPersistentContext(userDataDir, {
-    args: [`--disable-extensions-except=${extensionPath}`, `--load-extension=${extensionPath}`],
+    args: [
+      `--disable-extensions-except=${extensionPath}`,
+      `--load-extension=${extensionPath}`,
+      ...EXTENSION_E2E_LAUNCH_ARGS,
+    ],
     channel: 'chromium',
     headless: !isHeaded,
+    ignoreDefaultArgs: ['--enable-automation'],
+    userAgent: EXTENSION_E2E_USER_AGENT,
   });
+
+  await applyPosthogE2eBrowserWorkarounds(context);
+  const posthogRecorder = await installPosthogStub(context);
 
   const [existingServiceWorker] = context.serviceWorkers();
   const serviceWorker = existingServiceWorker ?? (await context.waitForEvent('serviceworker'));
-
   const extensionId = new URL(serviceWorker.url()).host;
 
-  return { context, extensionId, userDataDir };
+  return {
+    context,
+    extensionId,
+    posthogFlagsOrDecideHits: posthogRecorder.flagsOrDecideHits,
+    posthogRequests: posthogRecorder.events,
+    userDataDir,
+  };
 };
 
 export const setExtensionStorage = async (
@@ -127,6 +152,127 @@ export const setExtensionStorage = async (
 
 export const seedExtensionAuth = (page: Page): Promise<void> =>
   setExtensionStorage(page, { kiloAuth: { token: 'token-1', userEmail: 'user@kilo.ai' } });
+
+export const setExtensionSyncStorage = async (
+  page: Page,
+  items: Record<string, unknown>
+): Promise<void> => {
+  await page.evaluate(
+    storageItems =>
+      new Promise<void>((resolve, reject) => {
+        const chromeApi = (
+          globalThis as typeof globalThis & {
+            chrome?: {
+              runtime?: { lastError?: { message?: string } };
+              storage?: {
+                sync?: {
+                  set: (items: Record<string, unknown>, callback: () => void) => void;
+                };
+              };
+            };
+          }
+        ).chrome;
+
+        const runtime = chromeApi?.runtime;
+        const storage = chromeApi?.storage?.sync;
+
+        if (runtime === undefined || storage === undefined) {
+          reject(new Error('Extension sync storage is unavailable.'));
+          return;
+        }
+
+        storage.set(storageItems, () => {
+          const message = runtime.lastError?.message;
+
+          if (message !== undefined && message !== '') {
+            reject(new Error(message));
+            return;
+          }
+
+          resolve();
+        });
+      }),
+    items
+  );
+};
+
+export const readExtensionSyncStorage = (page: Page, key: string): Promise<unknown> =>
+  page.evaluate(
+    storageKey =>
+      new Promise<unknown>((resolve, reject) => {
+        const chromeApi = (
+          globalThis as typeof globalThis & {
+            chrome?: {
+              runtime?: { lastError?: { message?: string } };
+              storage?: {
+                sync?: {
+                  get: (keys: string[], callback: (items: Record<string, unknown>) => void) => void;
+                };
+              };
+            };
+          }
+        ).chrome;
+
+        const runtime = chromeApi?.runtime;
+        const storage = chromeApi?.storage?.sync;
+
+        if (runtime === undefined || storage === undefined) {
+          reject(new Error('Extension sync storage is unavailable.'));
+          return;
+        }
+
+        storage.get([storageKey], items => {
+          const message = runtime.lastError?.message;
+
+          if (message !== undefined && message !== '') {
+            reject(new Error(message));
+            return;
+          }
+
+          resolve(items[storageKey]);
+        });
+      }),
+    key
+  );
+
+export const readExtensionLocalStorage = (page: Page, key: string): Promise<unknown> =>
+  page.evaluate(
+    storageKey =>
+      new Promise<unknown>((resolve, reject) => {
+        const chromeApi = (
+          globalThis as typeof globalThis & {
+            chrome?: {
+              runtime?: { lastError?: { message?: string } };
+              storage?: {
+                local?: {
+                  get: (keys: string[], callback: (items: Record<string, unknown>) => void) => void;
+                };
+              };
+            };
+          }
+        ).chrome;
+
+        const runtime = chromeApi?.runtime;
+        const storage = chromeApi?.storage?.local;
+
+        if (runtime === undefined || storage === undefined) {
+          reject(new Error('Extension local storage is unavailable.'));
+          return;
+        }
+
+        storage.get([storageKey], items => {
+          const message = runtime.lastError?.message;
+
+          if (message !== undefined && message !== '') {
+            reject(new Error(message));
+            return;
+          }
+
+          resolve(items[storageKey]);
+        });
+      }),
+    key
+  );
 
 export const waitForStoredConversationText = async (page: Page, text: string): Promise<void> => {
   await expect

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -47,6 +47,7 @@ const chromeWorkflowNames = [
   'switching credit accounts clears the model while the next catalog loads',
   'stale organization model loads cannot overwrite the current catalog',
   'new conversation keeps the running request in its original tab',
+  'analytics opt-out toggle persists across side panel reloads',
 ] as const;
 
 interface ServerHandle {
@@ -517,6 +518,45 @@ const seedFirefoxAuth = async (driver: WebDriver): Promise<void> => {
   });
 
   assert.equal(result, 'ok');
+};
+
+const readFirefoxSyncStorage = async (driver: WebDriver, key: string): Promise<unknown> => {
+  const result = await driver.executeAsyncScript(
+    (storageKey: string, done: (value: unknown) => void) => {
+      const browserApi = (
+        globalThis as typeof globalThis & {
+          browser?: {
+            storage?: {
+              sync?: {
+                get: (keys: string[]) => Promise<Record<string, unknown>>;
+              };
+            };
+          };
+        }
+      ).browser;
+
+      browserApi?.storage?.sync
+        ?.get([storageKey])
+        .then(items => {
+          done({ ok: true, value: items[storageKey] });
+          return null;
+        })
+        .catch((error: unknown) => {
+          done({
+            error: error instanceof Error ? error.message : String(error),
+            ok: false,
+          });
+        });
+    },
+    key
+  );
+
+  assert.equal(
+    isRecord(result) && result['ok'],
+    true,
+    `readFirefoxSyncStorage failed: ${String(result)}`
+  );
+  return isRecord(result) ? result['value'] : undefined;
 };
 
 const seedFirefoxConversation = async (driver: WebDriver, events: unknown[]): Promise<void> => {
@@ -1888,6 +1928,60 @@ const scenarios: FirefoxScenario[] = [
         }
       );
     },
+  },
+  {
+    name: 'analytics opt-out toggle persists across side panel reloads',
+    run: context =>
+      withSession(context.api, {}, async session => {
+        await openAuthenticatedPanel(session);
+        await clickButtonByLabel(session.driver, 'Settings');
+
+        const switchSelector = 'button[role="switch"][aria-label="Share usage analytics"]';
+        await waitUntil(
+          session.driver,
+          async () => {
+            const elements = await session.driver.findElements(By.css(switchSelector));
+            return elements.length > 0;
+          },
+          'Timed out waiting for Share usage analytics switch'
+        );
+
+        const analyticsSwitch = await session.driver.findElement(By.css(switchSelector));
+        assert.equal(await analyticsSwitch.getAttribute('aria-checked'), 'true');
+
+        await analyticsSwitch.click();
+
+        await waitUntil(
+          session.driver,
+          async () => {
+            const element = await session.driver.findElement(By.css(switchSelector));
+            return (await element.getAttribute('aria-checked')) === 'false';
+          },
+          'Timed out waiting for analytics switch to turn off'
+        );
+
+        await waitUntil(
+          session.driver,
+          async () => (await readFirefoxSyncStorage(session.driver, 'analyticsOptOut')) === true,
+          'Timed out waiting for analyticsOptOut in browser.storage.sync'
+        );
+
+        await session.driver.navigate().refresh();
+        await waitForText(session.driver, 'Kilo');
+        await clickButtonByLabel(session.driver, 'Settings');
+
+        await waitUntil(
+          session.driver,
+          async () => {
+            const elements = await session.driver.findElements(By.css(switchSelector));
+            if (elements.length === 0) {
+              return false;
+            }
+            return (await elements[0]?.getAttribute('aria-checked')) === 'false';
+          },
+          'Timed out waiting for analytics switch to stay off after reload'
+        );
+      }),
   },
 ];
 

--- a/apps/extension/tests/e2e/posthog-fixture.ts
+++ b/apps/extension/tests/e2e/posthog-fixture.ts
@@ -1,0 +1,187 @@
+/* eslint-disable import/no-nodejs-modules, promise/avoid-new */
+import type { BrowserContext, Request } from '@playwright/test';
+import { gunzipSync } from 'node:zlib';
+
+export interface NormalizedPosthogEvent {
+  readonly distinctId: string | undefined;
+  readonly event: string;
+  readonly properties: Record<string, unknown>;
+}
+
+export interface PosthogRecorder {
+  readonly events: NormalizedPosthogEvent[];
+  readonly flagsOrDecideHits: string[];
+}
+
+/**
+ * PostHog drops capture when the UA contains `HeadlessChrome` or
+ * `navigator.webdriver` is truthy. Chrome E2E must look like a normal browser.
+ */
+export const EXTENSION_E2E_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/145.0.0.0 Safari/537.36';
+
+export const EXTENSION_E2E_LAUNCH_ARGS = ['--disable-blink-features=AutomationControlled'] as const;
+
+export const applyPosthogE2eBrowserWorkarounds = async (context: BrowserContext): Promise<void> => {
+  await context.addInitScript(() => {
+    Object.defineProperty(navigator, 'webdriver', {
+      configurable: true,
+      // eslint-disable-next-line unicorn/no-useless-undefined -- must be undefined, not false/null
+      get: () => undefined,
+    });
+  });
+};
+
+const isRecord = (value: unknown): value is Record<string, unknown> =>
+  typeof value === 'object' && value !== null && !Array.isArray(value);
+
+const readRequestBodyText = (request: Request): string | undefined => {
+  const buffer = request.postDataBuffer();
+  if (buffer === null || buffer.length === 0) {
+    return request.postData() ?? undefined;
+  }
+
+  const url = request.url();
+  // Gzip magic bytes 0x1F 0x8B
+  const isGzip = url.includes('compression=gzip') || (buffer[0] === 31 && buffer[1] === 139);
+
+  if (isGzip) {
+    return gunzipSync(buffer).toString('utf8');
+  }
+
+  return buffer.toString('utf8');
+};
+
+const coerceBodyEntries = (body: unknown): unknown[] => {
+  if (Array.isArray(body)) {
+    return body;
+  }
+
+  if (isRecord(body) && Array.isArray(body['batch'])) {
+    return body['batch'];
+  }
+
+  if (body === undefined || body === null) {
+    return [];
+  }
+
+  return [body];
+};
+
+/**
+ * Normalize a parsed PostHog request body into capture events.
+ *
+ * Observed `posthog-js@1.360.2` shapes (with `advanced_disable_flags: true`):
+ * - Single event object: `{ event, properties, $set?, ... }` (identify / send_instantly)
+ * - Top-level array of event objects (default request batching flush)
+ * - `{ batch: [...] }` envelope (defensive)
+ *
+ * Bodies may arrive gzip-compressed (`compression=gzip-js` query param) even when
+ * `/flags` is disabled — decompress before JSON.parse.
+ */
+export const normalizePosthogBody = (body: unknown): NormalizedPosthogEvent[] => {
+  const normalized: NormalizedPosthogEvent[] = [];
+
+  for (const entry of coerceBodyEntries(body)) {
+    if (isRecord(entry)) {
+      const eventName = entry['event'];
+      if (typeof eventName === 'string' && eventName.length > 0) {
+        const properties = isRecord(entry['properties']) ? entry['properties'] : {};
+        const distinctIdRaw = properties['distinct_id'];
+
+        normalized.push({
+          distinctId: typeof distinctIdRaw === 'string' ? distinctIdRaw : undefined,
+          event: eventName,
+          properties,
+        });
+      }
+    }
+  }
+
+  return normalized;
+};
+
+const asEventList = (
+  recorder: PosthogRecorder | readonly NormalizedPosthogEvent[]
+): readonly NormalizedPosthogEvent[] => {
+  if ('events' in recorder) {
+    return recorder.events;
+  }
+
+  return recorder;
+};
+
+export const findCapturedEvent = (
+  recorder: PosthogRecorder | readonly NormalizedPosthogEvent[],
+  eventName: string
+): NormalizedPosthogEvent | undefined =>
+  asEventList(recorder).find(event => event.event === eventName);
+
+export const findCapturedEvents = (
+  recorder: PosthogRecorder | readonly NormalizedPosthogEvent[],
+  eventName: string
+): NormalizedPosthogEvent[] => asEventList(recorder).filter(event => event.event === eventName);
+
+const flagsResponseBody = JSON.stringify({
+  errorsWhileComputingFlags: false,
+  featureFlagPayloads: {},
+  featureFlags: {},
+});
+
+const captureResponseBody = JSON.stringify({ status: 1 });
+
+const isFlagsOrDecidePath = (pathname: string): boolean =>
+  pathname.includes('/flags') || pathname.includes('/decide');
+
+const isCapturePath = (pathname: string): boolean =>
+  pathname.includes('/e') ||
+  pathname.includes('/batch') ||
+  pathname.includes('/capture') ||
+  pathname.includes('/engage');
+
+/**
+ * Route all PostHog host traffic, fulfill expected shapes, and record normalized
+ * capture events. Tracks `/flags` and legacy `/decide/` hits separately so tests
+ * can assert the SDK emits zero such traffic with `advanced_disable_flags: true`.
+ */
+export const installPosthogStub = async (context: BrowserContext): Promise<PosthogRecorder> => {
+  const events: NormalizedPosthogEvent[] = [];
+  const flagsOrDecideHits: string[] = [];
+  const recorder: PosthogRecorder = { events, flagsOrDecideHits };
+
+  await context.route('https://us.i.posthog.com/**', async route => {
+    const request = route.request();
+    const url = request.url();
+    const { pathname } = new URL(url);
+
+    if (isFlagsOrDecidePath(pathname)) {
+      flagsOrDecideHits.push(url);
+      await route.fulfill({
+        body: flagsResponseBody,
+        contentType: 'application/json',
+        status: 200,
+      });
+      return;
+    }
+
+    if (isCapturePath(pathname) || request.method() === 'POST') {
+      const text = readRequestBodyText(request);
+      if (text !== undefined && text.length > 0) {
+        try {
+          const parsed: unknown = JSON.parse(text);
+          events.push(...normalizePosthogBody(parsed));
+        } catch {
+          // Non-JSON bodies still fulfill so the SDK does not retry forever.
+        }
+      }
+    }
+
+    await route.fulfill({
+      body: captureResponseBody,
+      contentType: 'application/json',
+      status: 200,
+    });
+  });
+
+  return recorder;
+};

--- a/apps/extension/wxt.config.ts
+++ b/apps/extension/wxt.config.ts
@@ -1,6 +1,13 @@
 import { defineConfig } from 'wxt';
 import tailwindcss from '@tailwindcss/vite';
 
+const posthogApiKey = process.env['VITE_POSTHOG_API_KEY'];
+if (typeof posthogApiKey !== 'string' || posthogApiKey.trim().length === 0) {
+  console.warn(
+    'VITE_POSTHOG_API_KEY is not set; extension analytics will be disabled in this build.'
+  );
+}
+
 // See https://wxt.dev/api/config.html
 export default defineConfig({
   manifest: ({ browser }) => ({
@@ -10,7 +17,8 @@ export default defineConfig({
     browser_specific_settings: {
       gecko: {
         data_collection_permissions: {
-          required: ['none'],
+          optional: ['technicalAndInteraction'],
+          required: ['personallyIdentifyingInfo'],
         },
         id: 'browser-agent@kilo.ai',
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -200,6 +200,9 @@ importers:
       lucide-react:
         specifier: 0.552.0
         version: 0.552.0(react@19.2.6)
+      posthog-js:
+        specifier: 1.360.2
+        version: 1.360.2
       react:
         specifier: 19.2.6
         version: 19.2.6
@@ -19765,7 +19768,7 @@ snapshots:
       cjs-module-lexer: 1.2.3
       esbuild: 0.27.4
       miniflare: 4.20260603.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
-      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
+      vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.27.4)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       wrangler: 4.98.0(@cloudflare/workers-types@4.20260605.1)(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     transitivePeerDependencies:
@@ -22096,7 +22099,7 @@ snapshots:
 
   '@opentelemetry/api-logs@0.207.0':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api-logs@0.208.0':
     dependencies:
@@ -22104,11 +22107,11 @@ snapshots:
 
   '@opentelemetry/api-logs@0.211.0':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api-logs@0.212.0':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
 
   '@opentelemetry/api@1.9.0': {}
 
@@ -22122,9 +22125,9 @@ snapshots:
     dependencies:
       '@opentelemetry/api': 1.9.1
 
-  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/core@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0)':
@@ -22147,19 +22150,24 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
+  '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.0)':
+    dependencies:
+      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/semantic-conventions': 1.40.0
+
   '@opentelemetry/core@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/exporter-logs-otlp-http@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-exporter-base': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/instrumentation-amqplib@0.58.0(@opentelemetry/api@1.9.0)':
     dependencies:
@@ -22388,29 +22396,29 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/otlp-exporter-base@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer': 0.208.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/otlp-transformer@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-metrics': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-trace-base': 2.2.0(@opentelemetry/api@1.9.1)
       protobufjs: 7.6.4
 
   '@opentelemetry/redis-common@0.38.2': {}
 
-  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/resources@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/resources@2.5.1(@opentelemetry/api@1.9.1)':
@@ -22437,12 +22445,12 @@ snapshots:
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
-  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-logs@0.208.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-logs@0.212.0(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -22451,11 +22459,11 @@ snapshots:
       '@opentelemetry/core': 2.5.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.5.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-metrics@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/sdk-metrics@2.6.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -22463,11 +22471,11 @@ snapshots:
       '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.0)':
+  '@opentelemetry/sdk-trace-base@2.2.0(@opentelemetry/api@1.9.1)':
     dependencies:
-      '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/api': 1.9.1
+      '@opentelemetry/core': 2.2.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.2.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/semantic-conventions': 1.40.0
 
   '@opentelemetry/sdk-trace-base@2.6.0(@opentelemetry/api@1.9.0)':
@@ -22489,7 +22497,7 @@ snapshots:
   '@opentelemetry/sql-common@0.41.2(@opentelemetry/api@1.9.0)':
     dependencies:
       '@opentelemetry/api': 1.9.0
-      '@opentelemetry/core': 2.6.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/core': 2.6.1(@opentelemetry/api@1.9.0)
 
   '@oxc-parser/binding-android-arm-eabi@0.120.0':
     optional: true
@@ -33336,11 +33344,11 @@ snapshots:
 
   posthog-js@1.360.2:
     dependencies:
-      '@opentelemetry/api': 1.9.0
+      '@opentelemetry/api': 1.9.1
       '@opentelemetry/api-logs': 0.208.0
-      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/resources': 2.6.0(@opentelemetry/api@1.9.0)
-      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.0)
+      '@opentelemetry/exporter-logs-otlp-http': 0.208.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/resources': 2.6.1(@opentelemetry/api@1.9.1)
+      '@opentelemetry/sdk-logs': 0.208.0(@opentelemetry/api@1.9.1)
       '@posthog/core': 1.23.4
       '@posthog/types': 1.360.2
       core-js: 3.48.0


### PR DESCRIPTION
## Summary

Adds PostHog product analytics to the Kilo browser extension, mirroring the mobile app's integration (`apps/mobile/src/lib/analytics/posthog.ts`) against the shared PostHog project already used by web and mobile.

- **New module `src/shared/analytics.ts`** — MV3-safe `posthog-js` (`dist/module.no-external` + `disable_external_dependency_loading`, required by MV3 `script-src 'self'` and store policy), `advanced_disable_flags: true` (zero `/flags` traffic; feature flags are out of scope), all autocapture/pageview/pageleave/session-recording off. Every event carries super property `platform: 'extension'`; `identify(email)` uses the email as distinct ID, matching the hard web/mobile convention so the same person never double-counts across platforms.
- **Consent model: opt-out.** Analytics starts only when signed in with a known email (no anonymous capture, ever); nothing sends in dev builds or keyless builds. The Settings dialog gains a "Share usage analytics" switch (`role="switch"`), persisted in `chrome.storage.sync` so the preference survives sign-out (`clearStoredSession` wipes the `local` area) and follows browser sync. Flipping applies immediately — no reload.
- **Events (enum-only payloads, no free text, no PII beyond the email identity):** `extension_signed_in` (`source: stored_session | device_auth`), `extension_signed_out` (`reason: explicit | expired`, sent instantly before `reset()`), `conversation_created` (user-driven New conversation only — never bootstrap/fallback creation), `message_sent` (`mode: safe | dangerous`, at the run-commit point so aborted sends don't count).
- **Firefox data-collection honesty:** manifest declares `required: ['personallyIdentifyingInfo']`, `optional: ['technicalAndInteraction']`; at runtime, Firefox without the usage-data grant (declined, toggled off in `about:addons`, or Firefox < 140) gets zero analytics, and the Settings row shows a hint when Firefox is blocking collection. Chrome is unaffected.
- **E2E:** a PostHog network stub installed by default in the shared Chrome harness (no test can ever reach real PostHog) records normalized wire events; five new Chrome tests cover identify/sign-in, explicit sign-out ordering, opt-out persistence across reloads and sign-out/sign-in, message/conversation capture, and mid-session expiry. The opt-out persistence scenario is mirrored in the Firefox Selenium suite (UI + storage only — Selenium can't intercept network, so payload assertions stay Chrome-only). `ENVIRONMENT.md` documents `VITE_POSTHOG_API_KEY` as `[PUBLIC]`; no key material is committed (E2E uses the dummy literal `e2e-test-key`).

Not in scope: feature flags, background-service-worker analytics, session recording, autocapture, anonymous/pre-login capture.

## Verification

Automated only — no manual testing beyond scripted E2E:

- [x] `pnpm --filter kilo-extension verify` (typecheck, oxlint, oxfmt, 288 unit tests)
- [x] `pnpm --filter kilo-extension e2e:chrome` — full suite 57 passed with the dummy key baked in (the five new analytics tests included; zero `/flags` or `/decide/` traffic asserted)
- [x] `pnpm --filter kilo-extension e2e:firefox` — 26/26 scenarios including the mirrored opt-out toggle scenario; `validate:firefox` 0 errors
- [x] Grounding run confirmed the real `posthog-js@1.360.2` wire shape (gzip bodies, top-level array batches) and zero CSP violations on Chrome; the recorder/normalizer is pinned to the observed shape

## Visual Changes

Settings dialog gains one row between "Remote MCP servers" and "Sign out": a `role="switch"` toggle labeled **Share usage analytics** with the sub-line "Helps improve Kilo. No page content is collected." (on = default; on Firefox without the usage-data grant a one-line hint explains Firefox is blocking collection). The rendered contract is asserted in E2E. A locally captured screenshot of the dialog is available on request — the CLI can't attach images to the PR.

| Before | After |
|---|---|
| No analytics row | Share usage analytics switch row |

## Reviewer Notes

- Two small deliberate asymmetries, both documented in code and tests: Chrome collects by default with in-app opt-out while Firefox defaults to off until the user grants usage-data collection (Mozilla's model); Chrome E2E asserts wire payloads while Firefox E2E covers UI/persistence only (Selenium limitation).
- The retryable storage-failure state of the toggle (revert + "Couldn't save the setting. Try again.") is unit-covered; it is not E2E-reproduced because it can't be produced deterministically in a real browser without patching the storage API.
- A one-off keyed Firefox CSP smoke build was attempted locally; the headless Selenium install timed out, so no Firefox CSP evidence exists either way. Chrome showed no CSP violations. No manifest CSP change is made (evidence-conditional).
