### PR TITLE
fix(ai-gateway): set maxDuration on /api/gateway/[...path] route

### DIFF
--- a/apps/web/src/app/api/gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/gateway/[...path]/route.ts
@@ -1,5 +1,3 @@
 export { POST } from '@/app/api/openrouter/[...path]/route';
 
-// Route segment config is not inherited through a handler re-export,
-// so this must match maxDuration in '@/app/api/openrouter/[...path]/route'.
 export const maxDuration = 1800;

--- a/apps/web/src/app/api/gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/gateway/[...path]/route.ts
@@ -1,1 +1,5 @@
 export { POST } from '@/app/api/openrouter/[...path]/route';
+
+// Route segment config is not inherited through a handler re-export,
+// so this must match maxDuration in '@/app/api/openrouter/[...path]/route'.
+export const maxDuration = 1800;


### PR DESCRIPTION
## Summary

`api/gateway/[...path]/route.ts` re-exports `POST` from the openrouter catch-all route, but Next.js route segment config is not inherited through a handler re-export — it must be exported from the route's own file. Without its own `maxDuration` export, `/api/gateway/*` fell back to the Vercel plan default (60s Hobby / 300s Pro) instead of the 1800s that the identical `/api/openrouter/*` handler gets, so long-running streaming requests through `/api/gateway` timed out early.

The fix adds `export const maxDuration = 1800;` to the gateway route file, matching `api/openrouter/[...path]/route.ts`.

## Why not re-export `maxDuration` too?

`export { POST, maxDuration } from '...'` does not work for route segment config. Next.js extracts segment config at build time via static SWC analysis (`extractExportedConstValue` in `next/dist/build/analysis/extract-const-value.js`), which only matches an `ExportDeclaration` containing a `const` variable with a literal initializer — i.e. `export const maxDuration = 1800` written directly in the route file itself. A re-export parses as an `ExportNamedDeclaration`, which the extractor skips, so the value is silently ignored. Vercel then derives the function timeout from Next.js's build-time functions config manifest, so a re-export that is perfectly valid at runtime never reaches the deployed function configuration and the route falls back to the plan default. Verified against the installed Next.js 16.2.6.

## Verification

- [ ] Not manually tested — one-line config export; relying on CI and Vercel deployment behavior. The openrouter route's `validatePath` already accepts both `/api/gateway` and `/api/openrouter` prefixes, confirming these paths are intended aliases of the same handler.

## Visual Changes

N/A