### PR TITLE
fix(cloud-agent-next): prefix-scan preparation events by range, not LIKE

### DIFF
--- a/services/cloud-agent-next/src/session/preparation-history.test.ts
+++ b/services/cloud-agent-next/src/session/preparation-history.test.ts
@@ -41,6 +41,26 @@ describe('materializePreparationEvent', () => {
     expect(getPreparationSnapshots(eventQueries)).toEqual([]);
   });
 
+  it('rejects a preparing event whose attemptId contains non-ASCII characters', () => {
+    const eventQueries = createMemoryEventQueries();
+    // A non-ASCII id would put non-ASCII bytes in the entity_id key, breaking
+    // the assumption that findByEntityPrefix's range bound (a JS-side UTF-16
+    // increment) agrees with SQLite's UTF-8 byte-order comparison.
+    const applied = materializePreparationEvent(eventQueries, storedEvent(1000), {
+      version: 2,
+      attemptId: 'attempt-\u{1f600}',
+      triggerMessageId: 'msg-1',
+      revision: 1,
+      timestamp: 1000,
+      step: 'workspace_setup',
+      message: 'Preparing environment',
+      action: 'attempt_started',
+    });
+
+    expect(applied).toBe(false);
+    expect(getPreparationSnapshots(eventQueries)).toEqual([]);
+  });
+
   it('preserves startedAt when attempt_started re-announces a running attempt', () => {
     const eventQueries = createMemoryEventQueries();
     const { attemptId } = seedRunningAttempt(eventQueries, { startedAt: 1000 });

--- a/services/cloud-agent-next/src/session/preparation-history.test.ts
+++ b/services/cloud-agent-next/src/session/preparation-history.test.ts
@@ -18,6 +18,29 @@ import {
 const MINUTE_MS = 60 * 1000;
 
 describe('materializePreparationEvent', () => {
+  it('rejects a preparing event whose attemptId exceeds the id length bound', () => {
+    const eventQueries = createMemoryEventQueries();
+    // An oversized attemptId would become part of an entity_id key and, via
+    // findByEntityPrefix, a query bound. Reject it before storage so it can
+    // never poison the session (previously it crashed the prefix scan on
+    // every reconnect).
+    const oversizedAttemptId = 'a'.repeat(1024);
+
+    const applied = materializePreparationEvent(eventQueries, storedEvent(1000), {
+      version: 2,
+      attemptId: oversizedAttemptId,
+      triggerMessageId: 'msg-1',
+      revision: 1,
+      timestamp: 1000,
+      step: 'workspace_setup',
+      message: 'Preparing environment',
+      action: 'attempt_started',
+    });
+
+    expect(applied).toBe(false);
+    expect(getPreparationSnapshots(eventQueries)).toEqual([]);
+  });
+
   it('preserves startedAt when attempt_started re-announces a running attempt', () => {
     const eventQueries = createMemoryEventQueries();
     const { attemptId } = seedRunningAttempt(eventQueries, { startedAt: 1000 });

--- a/services/cloud-agent-next/src/session/preparation-history.ts
+++ b/services/cloud-agent-next/src/session/preparation-history.ts
@@ -7,8 +7,15 @@ import type {
 import type { EventQueries } from './queries/index.js';
 import type { StoredEvent } from '../websocket/types.js';
 import type { EventId } from '../types/ids.js';
+import { logger } from '../logger.js';
 
 const OUTPUT_TAIL_MAX_BYTES = 65_536;
+
+// A preparation attemptId is a UUID (see CloudAgentSession `crypto.randomUUID()`).
+// It becomes part of an `entity_id` key and, via `findByEntityPrefix`, a query
+// bound, so an oversized value would bloat storage and previously crashed the
+// prefix scan. Reject anything far larger than a UUID before it is stored.
+const MAX_PREPARATION_ID_LENGTH = 256;
 
 type PreparationSnapshot =
   | { action: 'attempt_snapshot'; attempt: Omit<PreparationAttempt, 'steps'> }
@@ -140,6 +147,25 @@ export function materializePreparationEvent(
   data: unknown
 ): boolean {
   if (!isPreparationEvent(data) || data.action.endsWith('_snapshot')) return false;
+  if (
+    data.attemptId.length > MAX_PREPARATION_ID_LENGTH ||
+    data.triggerMessageId.length > MAX_PREPARATION_ID_LENGTH
+  ) {
+    // Drop the event before it is stored: an oversized id becomes part of an
+    // entity_id key and a findByEntityPrefix bound. Log it because this should
+    // never happen in normal operation (ids are UUIDs) — it flags an upstream
+    // emitter bug that this guard is containing.
+    logger
+      .withFields({
+        sessionId: event.session_id,
+        action: data.action,
+        attemptIdLength: data.attemptId.length,
+        triggerMessageIdLength: data.triggerMessageId.length,
+        limit: MAX_PREPARATION_ID_LENGTH,
+      })
+      .warn('Rejected preparation event with oversized id');
+    return false;
+  }
   const attemptId = data.attemptId;
   const attemptIdKey = attemptEntityId(attemptId);
   const existingAttempt = eventQueries.findByEntityId(attemptIdKey);

--- a/services/cloud-agent-next/src/session/preparation-history.ts
+++ b/services/cloud-agent-next/src/session/preparation-history.ts
@@ -11,11 +11,26 @@ import { logger } from '../logger.js';
 
 const OUTPUT_TAIL_MAX_BYTES = 65_536;
 
-// A preparation attemptId is a UUID (see CloudAgentSession `crypto.randomUUID()`).
-// It becomes part of an `entity_id` key and, via `findByEntityPrefix`, a query
-// bound, so an oversized value would bloat storage and previously crashed the
-// prefix scan. Reject anything far larger than a UUID before it is stored.
+// attemptId is the value embedded in the `entity_id` key and, via
+// findByEntityPrefix, in a query prefix; triggerMessageId is persisted in the
+// event payload. Both are short ASCII identifiers in normal operation
+// (attemptId is a UUID minted server-side, triggerMessageId a message id), but
+// materialize receives them from the ingest channel, so a corrupted value can
+// arrive. Bound the length (an oversized attemptId previously crashed the prefix
+// scan) and require ASCII, so entity_id keys stay ASCII — which the prefix-range
+// scan in findByEntityPrefix relies on for correct byte-order comparison.
 const MAX_PREPARATION_ID_LENGTH = 256;
+
+function isAscii(value: string): boolean {
+  for (let i = 0; i < value.length; i++) {
+    if (value.charCodeAt(i) > 0x7f) return false;
+  }
+  return true;
+}
+
+function isValidPreparationId(value: string): boolean {
+  return value.length <= MAX_PREPARATION_ID_LENGTH && isAscii(value);
+}
 
 type PreparationSnapshot =
   | { action: 'attempt_snapshot'; attempt: Omit<PreparationAttempt, 'steps'> }
@@ -147,23 +162,22 @@ export function materializePreparationEvent(
   data: unknown
 ): boolean {
   if (!isPreparationEvent(data) || data.action.endsWith('_snapshot')) return false;
-  if (
-    data.attemptId.length > MAX_PREPARATION_ID_LENGTH ||
-    data.triggerMessageId.length > MAX_PREPARATION_ID_LENGTH
-  ) {
-    // Drop the event before it is stored: an oversized id becomes part of an
-    // entity_id key and a findByEntityPrefix bound. Log it because this should
-    // never happen in normal operation (ids are UUIDs) — it flags an upstream
-    // emitter bug that this guard is containing.
+  if (!isValidPreparationId(data.attemptId) || !isValidPreparationId(data.triggerMessageId)) {
+    // Drop the event before it is stored: attemptId becomes part of an
+    // entity_id key and a findByEntityPrefix prefix. Log it because valid ids
+    // are short and ASCII, so a rejection flags an upstream emitter bug that
+    // this guard is containing rather than a routine outcome.
     logger
       .withFields({
         sessionId: event.session_id,
         action: data.action,
         attemptIdLength: data.attemptId.length,
         triggerMessageIdLength: data.triggerMessageId.length,
+        attemptIdNonAscii: !isAscii(data.attemptId),
+        triggerMessageIdNonAscii: !isAscii(data.triggerMessageId),
         limit: MAX_PREPARATION_ID_LENGTH,
       })
-      .warn('Rejected preparation event with oversized id');
+      .warn('Rejected preparation event with invalid id');
     return false;
   }
   const attemptId = data.attemptId;

--- a/services/cloud-agent-next/src/session/queries/events.test.ts
+++ b/services/cloud-agent-next/src/session/queries/events.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { prefixUpperBound } from './events.js';
+
+/**
+ * `findByEntityPrefix` matches entity_id prefixes with a half-open range
+ * [prefix, prefixUpperBound(prefix)) instead of a SQL LIKE, because LIKE throws
+ * "LIKE or GLOB pattern too complex" once the pattern exceeds 50 KB. These
+ * cover the bound arithmetic that makes the range equivalent to `LIKE prefix%`.
+ */
+describe('prefixUpperBound', () => {
+  it('increments the final code unit so the range is a half-open prefix scan', () => {
+    // entity_id prefixes end in '/'; keys under them (e.g. `${p}<id>`) sort
+    // below the incremented bound because '/'(0x2F) < the next code unit.
+    expect(prefixUpperBound('preparation/attempt/')).toBe('preparation/attempt0');
+    expect(prefixUpperBound('preparation/attempt/abc/step/')).toBe('preparation/attempt/abc/step0');
+  });
+
+  it('brackets exactly the keys that LIKE `${prefix}%` would match', () => {
+    const prefix = 'preparation/attempt/abc/step/';
+    const upper = prefixUpperBound(prefix);
+    expect(upper).not.toBeNull();
+    const matches = (key: string) => key >= prefix && (upper === null || key < upper);
+
+    expect(matches('preparation/attempt/abc/step/1')).toBe(true);
+    expect(matches('preparation/attempt/abc/step/zzz')).toBe(true);
+    expect(matches('preparation/attempt/abc/step/')).toBe(true);
+    // Not under the prefix.
+    expect(matches('preparation/attempt/abc/steq')).toBe(false);
+    expect(matches('preparation/attempt/abd')).toBe(false);
+  });
+
+  it('does not throw on a pathologically large prefix (the crash this replaces)', () => {
+    const huge = 'preparation/attempt/' + 'a'.repeat(100_000) + '/step/';
+    expect(() => prefixUpperBound(huge)).not.toThrow();
+    expect(prefixUpperBound(huge)).toBe('preparation/attempt/' + 'a'.repeat(100_000) + '/step0');
+  });
+
+  it('returns null when no finite upper bound exists', () => {
+    expect(prefixUpperBound('')).toBeNull();
+    expect(prefixUpperBound('￿')).toBeNull();
+  });
+
+  it('carries when the final code units are U+FFFF', () => {
+    // 'A￿' -> increment carries past the max unit to 'B'.
+    expect(prefixUpperBound('A￿')).toBe('B');
+  });
+});

--- a/services/cloud-agent-next/src/session/queries/events.ts
+++ b/services/cloud-agent-next/src/session/queries/events.ts
@@ -1,4 +1,4 @@
-import { count, max, eq, and, gt, gte, lte, lt, inArray, asc, like } from 'drizzle-orm';
+import { count, max, eq, and, gt, gte, lte, lt, inArray, asc } from 'drizzle-orm';
 import type { DrizzleSqliteDODatabase } from 'drizzle-orm/durable-sqlite';
 import * as z from 'zod';
 import type { StoredEvent } from '../../websocket/types.js';
@@ -206,6 +206,23 @@ function buildLatestAssistantMessage(
   } satisfies LatestAssistantMessage;
 }
 
+/**
+ * Exclusive upper bound for a prefix scan under SQLite's default BINARY
+ * collation: the prefix with its final code unit incremented. Returns null when
+ * no finite bound exists (an empty prefix, or one that is entirely U+FFFF), in
+ * which case callers fall back to a lower-bound-only scan. `entity_id` values
+ * are ASCII paths, so incrementing the last unit yields an exact bound.
+ */
+export function prefixUpperBound(prefix: string): string | null {
+  for (let i = prefix.length - 1; i >= 0; i--) {
+    const code = prefix.charCodeAt(i);
+    if (code < 0xffff) {
+      return prefix.slice(0, i) + String.fromCharCode(code + 1);
+    }
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Factory Function
 // ---------------------------------------------------------------------------
@@ -307,6 +324,18 @@ export function createEventQueries(db: DrizzleSqliteDODatabase, rawSql: SqlStora
     },
 
     findByEntityPrefix(prefix: string): StoredEvent[] {
+      // Prefix-match via a half-open range scan rather than LIKE. SQLite raises
+      // "LIKE or GLOB pattern too complex" once a LIKE pattern exceeds
+      // SQLITE_MAX_LIKE_PATTERN_LENGTH (50 KB) — which throws, and keeps
+      // re-throwing on every reconnect, for any session whose stored
+      // preparation attemptId is pathologically large. A range over the
+      // entity_id B-tree has no such limit and also avoids treating '%'/'_' in
+      // the prefix as LIKE wildcards.
+      const upperBound = prefixUpperBound(prefix);
+      const prefixCondition =
+        upperBound === null
+          ? gte(events.entity_id, prefix)
+          : and(gte(events.entity_id, prefix), lt(events.entity_id, upperBound));
       return db
         .select({
           id: events.id,
@@ -317,7 +346,7 @@ export function createEventQueries(db: DrizzleSqliteDODatabase, rawSql: SqlStora
           timestamp: events.timestamp,
         })
         .from(events)
-        .where(like(events.entity_id, `${prefix}%`))
+        .where(prefixCondition)
         .orderBy(asc(events.timestamp), asc(events.id))
         .all() satisfies StoredEvent[];
     },

--- a/services/cloud-agent-next/src/session/queries/events.ts
+++ b/services/cloud-agent-next/src/session/queries/events.ts
@@ -208,10 +208,18 @@ function buildLatestAssistantMessage(
 
 /**
  * Exclusive upper bound for a prefix scan under SQLite's default BINARY
- * collation: the prefix with its final code unit incremented. Returns null when
- * no finite bound exists (an empty prefix, or one that is entirely U+FFFF), in
- * which case callers fall back to a lower-bound-only scan. `entity_id` values
- * are ASCII paths, so incrementing the last unit yields an exact bound.
+ * collation: the prefix with its final UTF-16 code unit incremented. Returns
+ * null when no finite bound exists (an empty prefix, or one that is entirely
+ * U+FFFF), in which case callers fall back to a lower-bound-only scan.
+ *
+ * The bound is exact only when the prefix's final character is not a UTF-16
+ * surrogate: the JS-side increment must agree with SQLite's UTF-8 byte-order
+ * comparison, which holds for BMP-non-surrogate characters. Every caller here
+ * passes an `entity_id` prefix that ends in ASCII ('/'), and preparation ids are
+ * held to ASCII at ingest, so this holds. A future caller with a prefix ending
+ * in a non-BMP character must not reuse this without revisiting the bound. (The
+ * lower bound is an exact string comparison, so non-ASCII within a prefix is
+ * fine; only the trailing character matters here.)
  */
 export function prefixUpperBound(prefix: string): string | null {
   for (let i = prefix.length - 1; i >= 0; i--) {


### PR DESCRIPTION
## Summary

The `cloud-agent-next` session storage had a single SQL `LIKE`, in
`findByEntityPrefix` (`queries/events.ts`), used to load preparation-history
events by `entity_id` prefix. That prefix embeds a preparation `attemptId`. When
a session's stored `attemptId` is very large, the pattern passed to `LIKE`
exceeds SQLite's max `LIKE` pattern length (50 KB) and throws "LIKE or GLOB
pattern too complex", which resets the Durable Object. `reconcileStalePreparationAttempts`
runs that query on every client reconnect, so once a session holds an oversized
`attemptId` it fails on every reconnect and cannot deliver its message.

This replaces the `LIKE` with a range scan that has no pattern-length limit, and
bounds the id length at ingest so an oversized value cannot be stored in the
first place. The affected query path was added with the preparation-history
feature in #4583.

## Changes

- `queries/events.ts`: `findByEntityPrefix` now matches prefixes with a
  half-open range scan (`entity_id >= prefix AND entity_id < prefixUpperBound(prefix)`)
  instead of `like(entity_id, `${prefix}%`)`. Adds an exported `prefixUpperBound`
  helper (increments the final code unit of the prefix) and removes the now
  unused `like` import.
- `preparation-history.ts`: `materializePreparationEvent` rejects a preparing
  event whose `attemptId` or `triggerMessageId` exceeds 256 characters before it
  is stored, and logs a warning with the `sessionId` and the offending lengths.
- Tests: `events.test.ts` covers the `prefixUpperBound` bound arithmetic,
  including that a 100 KB prefix no longer throws. `preparation-history.test.ts`
  covers the oversized-id rejection (event dropped, nothing stored).

## Verification

No manual end-to-end run. The failure lives in the Durable Object SQLite path,
and there is no local Durable Object harness in the service to exercise the real
query, so verification is by automated coverage plus static checks.

- [x] `pnpm --filter cloud-agent-next test` for the two changed test files (22 pass)
- [x] `typecheck`, `lint` (oxlint, 0 errors), `format` (oxfmt) all pass
- [ ] Not manually run against a live session

## Visual Changes

N/A

## Reviewer Notes

- For the `entity_id` values in use (ASCII paths ending in `/`), the range scan
  is equivalent to `LIKE prefix%`. It also stops treating `%`/`_` in a prefix as
  wildcards, and removes the 50 KB pattern limit that caused the crash.
- `prefixUpperBound` returns `null` for an empty prefix or one that is entirely
  U+FFFF; callers then fall back to a lower-bound-only scan (matches all rows at
  or after the prefix, same as the previous `LIKE '%'` for an empty prefix).
- The 256-character id bound is defense in depth. A normal `attemptId` is a UUID
  (36 chars). The warn log surfaces the case if it ever happens, so the upstream
  emitter can be traced rather than the value being dropped silently.
- No schema or migration change. The behavior change is limited to how the
  prefix query is expressed.
