### PR TITLE
fix(mobile): PR sheet chrome + session UX defect batch; sandbox CLI 7.3.63 for routed-model stamps

### DIFF
--- a/apps/mobile/src/components/agents/message-bubble.test.ts
+++ b/apps/mobile/src/components/agents/message-bubble.test.ts
@@ -179,3 +179,75 @@ describe('MessageBubble regressions', () => {
     expect(findText(dequeuedTree, t => t === 'Queued')).toBe(false);
   });
 });
+
+function pressableProps(node: unknown): Record<string, unknown> | null {
+  if (node == null || typeof node !== 'object') {
+    return null;
+  }
+  const element = node as { type?: unknown; props?: Record<string, unknown> };
+  if (element.type === 'Pressable' && element.props) {
+    return element.props;
+  }
+  const children = element.props?.children;
+  if (Array.isArray(children)) {
+    for (const child of children) {
+      const found = pressableProps(child);
+      if (found) {
+        return found;
+      }
+    }
+  } else if (children && typeof children === 'object') {
+    return pressableProps(children);
+  }
+  return null;
+}
+
+describe('MessageBubble long-press details', () => {
+  it('uses the details accessibility hint on user messages', async () => {
+    const tree = await renderBubble(userMessage('m-hint-user'));
+    const props = pressableProps(tree);
+    expect(props?.accessibilityHint).toBe('Long press for message details');
+    expect(props?.accessibilityActions).toEqual([{ name: 'copy', label: 'Copy message' }]);
+  });
+
+  it('uses the details accessibility hint on assistant messages', async () => {
+    const base = userMessage('m-hint-asst');
+    const assistant: StoredMessage = {
+      info: {
+        id: base.info.id,
+        sessionID: base.info.sessionID,
+        role: 'assistant',
+        time: { created: base.info.time.created },
+        parentID: 'm0',
+        modelID: 'anthropic/claude-sonnet-4',
+        providerID: 'kilo',
+        mode: 'code',
+        agent: 'build',
+        path: { cwd: '/', root: '/' },
+        cost: 0,
+        tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+      },
+      parts: [],
+    };
+    const tree = await renderBubble(assistant);
+    const props = pressableProps(tree);
+    expect(props?.accessibilityHint).toBe('Long press for message details');
+  });
+
+  it('invokes onLongPressDetails on long-press, not copyMessage', async () => {
+    const onLongPressDetails = vi.fn((..._args: unknown[]) => {
+      // void-returning callback matching MessageBubble's prop type
+    });
+    const { MessageBubble } = await import('./message-bubble');
+    const message = userMessage('m-long');
+    // eslint-disable-next-line new-cap
+    const tree = MessageBubble({ message, onLongPressDetails });
+    const props = pressableProps(tree);
+    expect(props).not.toBeNull();
+    const handler = props === null ? undefined : props.onLongPress;
+    expect(typeof handler).toBe('function');
+    const invoke = handler as (() => void) | undefined;
+    invoke?.();
+    expect(onLongPressDetails).toHaveBeenCalledWith(message);
+  });
+});

--- a/apps/mobile/src/components/agents/message-bubble.tsx
+++ b/apps/mobile/src/components/agents/message-bubble.tsx
@@ -24,13 +24,6 @@ type MessageBubbleProps = {
   onOpenChildSession?: OpenChildSession;
   /** Per-user-message delivery state. v1 surfaces only a "Queued" badge. */
   deliveryState?: MessageDeliveryState;
-  /**
-   * Subtle model label for an assistant message, precomputed by the parent
-   * via `computeMessageModelLabels`. Only the assistant branch renders it
-   * (and only when truthy); the user branch and the unlabelled
-   * same-model follow-ups render nothing.
-   */
-  modelLabel?: string;
 };
 
 export function MessageBubble({
@@ -41,7 +34,6 @@ export function MessageBubble({
   defaultReasoningExpanded,
   onOpenChildSession,
   deliveryState,
-  modelLabel,
 }: Readonly<MessageBubbleProps>) {
   const isUser = message.info.role === 'user';
   const { copyMessage } = useMessageCopy();
@@ -139,15 +131,6 @@ export function MessageBubble({
             onOpenChildSession={onOpenChildSession}
           />
         ))}
-        {modelLabel ? (
-          <Text
-            className="text-xs text-muted-foreground"
-            accessibilityRole="text"
-            accessibilityLabel={`Model: ${modelLabel}`}
-          >
-            {modelLabel}
-          </Text>
-        ) : null}
       </View>
     </Pressable>
   );

--- a/apps/mobile/src/components/agents/message-bubble.tsx
+++ b/apps/mobile/src/components/agents/message-bubble.tsx
@@ -24,7 +24,11 @@ type MessageBubbleProps = {
   onOpenChildSession?: OpenChildSession;
   /** Per-user-message delivery state. v1 surfaces only a "Queued" badge. */
   deliveryState?: MessageDeliveryState;
+  /** Opens the message-details sheet; long-press never triggers the copy ActionSheet. */
+  onLongPressDetails?: (message: StoredMessage) => void;
 };
+
+const DETAILS_HINT = 'Long press for message details';
 
 export function MessageBubble({
   message,
@@ -34,18 +38,18 @@ export function MessageBubble({
   defaultReasoningExpanded,
   onOpenChildSession,
   deliveryState,
+  onLongPressDetails,
 }: Readonly<MessageBubbleProps>) {
   const isUser = message.info.role === 'user';
   const { copyMessage } = useMessageCopy();
   const colors = useThemeColors();
 
   const handleLongPress = () => {
-    void copyMessage(message);
+    onLongPressDetails?.(message);
   };
 
-  // Long-press is an accelerator; expose the same "copy" action to
-  // accessibility tooling (VoiceOver/TalkBack rotor) since a long-press
-  // gesture isn't reliably discoverable there.
+  // Long-press opens details; keep the VoiceOver/TalkBack rotor "copy" action
+  // on the bubble so a11y tooling still reaches the existing ActionSheet path.
   const copyAccessibilityActions = [{ name: 'copy', label: 'Copy message' }];
   const handleAccessibilityAction = (event: AccessibilityActionEvent) => {
     if (event.nativeEvent.actionName === 'copy') {
@@ -77,7 +81,7 @@ export function MessageBubble({
         className="px-4 py-1"
         accessibilityRole="text"
         accessibilityLabel="User message"
-        accessibilityHint="Long press to copy message text"
+        accessibilityHint={DETAILS_HINT}
         accessibilityActions={copyAccessibilityActions}
         onAccessibilityAction={handleAccessibilityAction}
       >
@@ -116,7 +120,7 @@ export function MessageBubble({
       onLongPress={handleLongPress}
       accessibilityRole="text"
       accessibilityLabel="Assistant message"
-      accessibilityHint="Long press to copy message text"
+      accessibilityHint={DETAILS_HINT}
       accessibilityActions={copyAccessibilityActions}
       onAccessibilityAction={handleAccessibilityAction}
     >

--- a/apps/mobile/src/components/agents/message-details-content.ts
+++ b/apps/mobile/src/components/agents/message-details-content.ts
@@ -1,0 +1,129 @@
+import { type StoredMessage } from 'cloud-agent-sdk';
+
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
+import { collectCopyableText } from './collect-copyable-text';
+import { formatCost } from './context-usage-display';
+import { resolveMessageDisplayModel } from './message-model-label';
+import { friendlyModelName } from './session-model-display';
+
+type MessageDetailsTokenRow = {
+  label: string;
+  value: number;
+};
+
+type MessageDetailsContent = {
+  roleLabel: string;
+  sentTimeLabel: string | null;
+  modelLabel: string | null;
+  costLabel: string | null;
+  tokenRows: MessageDetailsTokenRow[] | null;
+  copyableText: string | null;
+};
+
+const SENT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
+  dateStyle: 'medium',
+  timeStyle: 'short',
+});
+
+/**
+ * Pure projection of a StoredMessage into the details-sheet fields.
+ * Unit-tested for happy / empty visibility rules; the sheet component
+ * only renders this shape.
+ */
+export function getMessageDetailsContent(
+  message: StoredMessage,
+  modelOptions: SessionModelOption[]
+): MessageDetailsContent {
+  const roleLabel = message.info.role === 'user' ? 'User' : 'Assistant';
+  const sentTimeLabel = formatMessageSentTime(message.info.time.created);
+  const copyable = collectCopyableText(message);
+  const copyableText = copyable.length > 0 ? copyable : null;
+
+  if (message.info.role !== 'assistant') {
+    return {
+      roleLabel,
+      sentTimeLabel,
+      modelLabel: null,
+      costLabel: null,
+      tokenRows: null,
+      copyableText,
+    };
+  }
+
+  const resolved = resolveMessageDisplayModel(message);
+  const modelLabel = resolved
+    ? friendlyModelName(resolved.providerID, resolved.modelID, modelOptions)
+    : null;
+
+  const usage = getAssistantUsage(message);
+  const showUsage = usage !== null && !isZeroUsage(usage);
+
+  return {
+    roleLabel,
+    sentTimeLabel,
+    modelLabel,
+    costLabel: showUsage ? formatCost(usage.cost) : null,
+    tokenRows: showUsage
+      ? [
+          { label: 'Input', value: usage.input },
+          { label: 'Output', value: usage.output },
+          { label: 'Reasoning', value: usage.reasoning },
+          { label: 'Cache read', value: usage.cacheRead },
+          { label: 'Cache write', value: usage.cacheWrite },
+          { label: 'Total', value: usage.total },
+        ]
+      : null,
+    copyableText,
+  };
+}
+
+type AssistantUsage = {
+  cost: number;
+  input: number;
+  output: number;
+  reasoning: number;
+  cacheRead: number;
+  cacheWrite: number;
+  total: number;
+};
+
+function getAssistantUsage(message: StoredMessage): AssistantUsage | null {
+  if (message.info.role !== 'assistant') {
+    return null;
+  }
+  const { cost, tokens } = message.info;
+  const input = tokens.input;
+  const output = tokens.output;
+  const reasoning = tokens.reasoning;
+  const cacheRead = tokens.cache.read;
+  const cacheWrite = tokens.cache.write;
+  return {
+    cost,
+    input,
+    output,
+    reasoning,
+    cacheRead,
+    cacheWrite,
+    total: input + output + reasoning + cacheRead + cacheWrite,
+  };
+}
+
+function isZeroUsage(usage: AssistantUsage): boolean {
+  return (
+    usage.cost === 0 &&
+    usage.input === 0 &&
+    usage.output === 0 &&
+    usage.reasoning === 0 &&
+    usage.cacheRead === 0 &&
+    usage.cacheWrite === 0
+  );
+}
+
+/** Format an epoch-ms created timestamp; null when absent/invalid. */
+export function formatMessageSentTime(created: number | undefined | null): string | null {
+  if (created === undefined || created === null || !Number.isFinite(created) || created <= 0) {
+    return null;
+  }
+  return SENT_TIME_FORMATTER.format(new Date(created));
+}

--- a/apps/mobile/src/components/agents/message-details-copy.ts
+++ b/apps/mobile/src/components/agents/message-details-copy.ts
@@ -1,0 +1,12 @@
+import { performCopy } from './use-message-copy';
+
+/**
+ * Details-sheet Copy path: immediate shared `performCopy`, no ActionSheet.
+ * Kept free of RN UI so unit tests can pin the wiring.
+ */
+export function handleMessageDetailsCopy(copyableText: string | null | undefined): void {
+  if (!copyableText) {
+    return;
+  }
+  void performCopy(copyableText);
+}

--- a/apps/mobile/src/components/agents/message-details-sheet.test.ts
+++ b/apps/mobile/src/components/agents/message-details-sheet.test.ts
@@ -1,0 +1,290 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import {
+  type AssistantMessage,
+  type Part,
+  type StepFinishPart,
+  type StoredMessage,
+  type UserMessage,
+} from 'cloud-agent-sdk';
+
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
+import { formatMessageSentTime, getMessageDetailsContent } from './message-details-content';
+
+const performCopyMock = vi.fn().mockResolvedValue(undefined);
+const showActionSheetWithOptions = vi.fn();
+
+vi.mock('./use-message-copy', () => ({
+  performCopy: (...args: unknown[]) => performCopyMock(...args),
+}));
+
+vi.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  ActionSheetIOS: {
+    showActionSheetWithOptions: (...args: unknown[]) => showActionSheetWithOptions(...args),
+  },
+}));
+
+function assistantInfo(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    id: 'msg-1',
+    sessionID: 'ses-1',
+    role: 'assistant',
+    time: { created: 1_700_000_000_000 },
+    parentID: 'msg-0',
+    modelID: 'claude-sonnet-4',
+    providerID: 'kilo',
+    mode: 'code',
+    agent: 'test',
+    path: { cwd: '/', root: '/' },
+    cost: 0.0123,
+    tokens: {
+      input: 100,
+      output: 50,
+      reasoning: 10,
+      cache: { read: 5, write: 2 },
+    },
+    ...overrides,
+  };
+}
+
+function userInfo(overrides: Partial<UserMessage> = {}): UserMessage {
+  return {
+    id: 'u-1',
+    sessionID: 'ses-1',
+    role: 'user',
+    time: { created: 1_700_000_000_000 },
+    agent: 'test',
+    model: { providerID: 'kilo', modelID: 'claude-sonnet-4' },
+    ...overrides,
+  };
+}
+
+function textPart(text: string, id = 'p-text'): Part {
+  return {
+    id,
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'text',
+    text,
+  };
+}
+
+function stepFinish(overrides: Partial<StepFinishPart> = {}): StepFinishPart {
+  return {
+    id: 'p-finish',
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'step-finish',
+    reason: 'stop',
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    ...overrides,
+  };
+}
+
+function stepFinishWithRouted(
+  routed: { providerID: string; modelID: string },
+  overrides: Partial<StepFinishPart> = {}
+): StepFinishPart {
+  return Object.assign(stepFinish(overrides), { model: routed }) as StepFinishPart;
+}
+
+function storedMessage(info: AssistantMessage | UserMessage, parts: Part[] = []): StoredMessage {
+  return { info, parts };
+}
+
+const catalogOptions: SessionModelOption[] = [
+  {
+    id: 'anthropic/claude-sonnet-4',
+    name: 'Claude Sonnet 4',
+    displayId: 'anthropic/claude-sonnet-4',
+    variants: [],
+    isPreferred: false,
+    showGatewayMetadata: false,
+    modelRef: { providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4' },
+    provider: { id: 'kilo', name: 'Kilo' },
+  },
+  {
+    id: 'kilo-auto/efficient',
+    name: 'Auto Efficient',
+    displayId: 'kilo-auto/efficient',
+    variants: [],
+    isPreferred: false,
+    showGatewayMetadata: true,
+    provider: { id: 'kilo', name: 'Kilo' },
+  },
+];
+
+describe('formatMessageSentTime', () => {
+  it('formats a finite positive epoch ms timestamp', () => {
+    const label = formatMessageSentTime(1_700_000_000_000);
+    expect(label).not.toBeNull();
+    expect(typeof label).toBe('string');
+    expect((label ?? '').length).toBeGreaterThan(0);
+  });
+
+  it('returns null when the timestamp is absent or invalid', () => {
+    expect(formatMessageSentTime(undefined)).toBeNull();
+    expect(formatMessageSentTime(null)).toBeNull();
+    expect(formatMessageSentTime(0)).toBeNull();
+    expect(formatMessageSentTime(Number.NaN)).toBeNull();
+    expect(formatMessageSentTime(-1)).toBeNull();
+  });
+});
+
+describe('getMessageDetailsContent — happy', () => {
+  it('projects a user message with role, sent time, and copy text (no model/cost)', () => {
+    const message = storedMessage(userInfo(), [textPart('hello world')]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+
+    expect(content.roleLabel).toBe('User');
+    expect(content.sentTimeLabel).not.toBeNull();
+    expect(content.copyableText).toBe('hello world');
+    expect(content.modelLabel).toBeNull();
+    expect(content.costLabel).toBeNull();
+    expect(content.tokenRows).toBeNull();
+  });
+
+  it('projects an assistant message with model, cost, and token rows', () => {
+    const info = assistantInfo({
+      providerID: 'kilo',
+      modelID: 'kilo-auto/efficient',
+      cost: 0.0123,
+      tokens: {
+        input: 100,
+        output: 50,
+        reasoning: 10,
+        cache: { read: 5, write: 2 },
+      },
+    });
+    const routed = stepFinishWithRouted({
+      providerID: 'kilo',
+      modelID: 'anthropic/claude-sonnet-4',
+    });
+    const message = storedMessage(info, [textPart('assistant reply'), routed]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+
+    expect(content.roleLabel).toBe('Assistant');
+    expect(content.sentTimeLabel).not.toBeNull();
+    expect(content.copyableText).toBe('assistant reply');
+    // Routed stamp preferred; catalog-friendly name.
+    expect(content.modelLabel).toBe('Claude Sonnet 4');
+    expect(content.costLabel).toBe('$0.0123');
+    expect(content.tokenRows).toEqual([
+      { label: 'Input', value: 100 },
+      { label: 'Output', value: 50 },
+      { label: 'Reasoning', value: 10 },
+      { label: 'Cache read', value: 5 },
+      { label: 'Cache write', value: 2 },
+      { label: 'Total', value: 167 },
+    ]);
+  });
+
+  it('shows the info-level auto model when no routed stamp exists (explicit detail)', () => {
+    const info = assistantInfo({
+      providerID: 'kilo',
+      modelID: 'kilo-auto/efficient',
+      cost: 0.001,
+      tokens: {
+        input: 1,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    });
+    const message = storedMessage(info, [textPart('hi')]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.modelLabel).toBe('Auto Efficient');
+  });
+});
+
+describe('getMessageDetailsContent — empty', () => {
+  it('omits the model row when the assistant model is unresolvable', () => {
+    const info = assistantInfo({
+      providerID: '',
+      modelID: '',
+      cost: 0.01,
+      tokens: {
+        input: 10,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    });
+    const message = storedMessage(info, [textPart('no model')]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.roleLabel).toBe('Assistant');
+    expect(content.modelLabel).toBeNull();
+    expect(content.costLabel).not.toBeNull();
+    expect(content.tokenRows).not.toBeNull();
+  });
+
+  it('omits the cost/tokens block when cost and all five token values are zero', () => {
+    const info = assistantInfo({
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    });
+    const message = storedMessage(info, [textPart('aborted')]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.roleLabel).toBe('Assistant');
+    expect(content.modelLabel).toBe('claude-sonnet-4');
+    expect(content.costLabel).toBeNull();
+    expect(content.tokenRows).toBeNull();
+    expect(content.copyableText).toBe('aborted');
+  });
+
+  it('hides Copy when there is no copyable text', () => {
+    const message = storedMessage(userInfo(), []);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).toBeNull();
+    expect(content.roleLabel).toBe('User');
+  });
+
+  it('hides Sent when the created timestamp is missing', () => {
+    const info = userInfo({
+      time: { created: 0 },
+    });
+    const message = storedMessage(info, [textPart('x')]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.sentTimeLabel).toBeNull();
+  });
+});
+
+describe('MessageDetailsSheet copy button wiring (retryable unhappy)', () => {
+  beforeEach(() => {
+    performCopyMock.mockReset().mockResolvedValue(undefined);
+    showActionSheetWithOptions.mockReset();
+  });
+
+  it('forwards copyable text to shared performCopy (no ActionSheet)', async () => {
+    // Contract: details Copy uses handleMessageDetailsCopy → shared performCopy.
+    // No ActionSheet (that path is for long-press message copy on iOS).
+    // Sheet onPress wires to this handler (see message-details-sheet.tsx).
+    const message = storedMessage(userInfo(), [textPart('copy me')]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).toBe('copy me');
+
+    const { handleMessageDetailsCopy } = await import('./message-details-copy');
+    handleMessageDetailsCopy(content.copyableText);
+
+    expect(performCopyMock).toHaveBeenCalledWith('copy me');
+    expect(performCopyMock).toHaveBeenCalledTimes(1);
+    expect(showActionSheetWithOptions).not.toHaveBeenCalled();
+  });
+
+  it('no-ops when copyable text is absent', async () => {
+    const { handleMessageDetailsCopy } = await import('./message-details-copy');
+    handleMessageDetailsCopy(null);
+    handleMessageDetailsCopy(undefined);
+    handleMessageDetailsCopy('');
+    expect(performCopyMock).not.toHaveBeenCalled();
+    expect(showActionSheetWithOptions).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/components/agents/message-details-sheet.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.tsx
@@ -1,0 +1,127 @@
+import { type StoredMessage } from 'cloud-agent-sdk';
+import { useMemo } from 'react';
+import { Modal, Pressable, ScrollView, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { SheetHeader } from '@/components/sheet-header';
+import { Text } from '@/components/ui/text';
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
+import { formatExactTokens } from './context-usage-display';
+import { handleMessageDetailsCopy } from './message-details-copy';
+import { getMessageDetailsContent } from './message-details-content';
+
+type MessageDetailsSheetProps = {
+  visible: boolean;
+  message: StoredMessage | null;
+  modelOptions: SessionModelOption[];
+  onClose: () => void;
+};
+
+export function MessageDetailsSheet({
+  visible,
+  message,
+  modelOptions,
+  onClose,
+}: Readonly<MessageDetailsSheetProps>) {
+  const insets = useSafeAreaInsets();
+  const content = useMemo(
+    () => (message ? getMessageDetailsContent(message, modelOptions) : null),
+    [message, modelOptions]
+  );
+
+  const handleCopy = () => {
+    handleMessageDetailsCopy(content?.copyableText);
+  };
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title="Message details" onDone={onClose} doneLabel="Done" />
+
+        {content ? (
+          <ScrollView contentContainerClassName="px-6 pb-6 pt-2">
+            {content.copyableText ? (
+              <Pressable
+                onPress={handleCopy}
+                accessibilityRole="button"
+                accessibilityLabel="Copy message"
+                className="mb-6 rounded-md border border-border px-4 py-3 active:opacity-70"
+                testID="message-details-copy"
+              >
+                <Text className="text-center text-base font-medium text-foreground">
+                  Copy message
+                </Text>
+              </Pressable>
+            ) : null}
+
+            <View className="gap-4">
+              <Row label="Role">
+                <Text className="text-base font-medium text-foreground">{content.roleLabel}</Text>
+              </Row>
+
+              {content.sentTimeLabel ? (
+                <Row label="Sent">
+                  <Text className="text-base font-medium text-foreground tabular-nums">
+                    {content.sentTimeLabel}
+                  </Text>
+                </Row>
+              ) : null}
+
+              {content.modelLabel ? (
+                <Row label="Model">
+                  <Text className="text-base font-medium text-foreground">
+                    {content.modelLabel}
+                  </Text>
+                </Row>
+              ) : null}
+            </View>
+
+            {content.costLabel && content.tokenRows ? (
+              <View className="mt-8 gap-4">
+                <Text className="text-sm font-semibold text-foreground">Cost & tokens</Text>
+                <Row label="Cost">
+                  <Text className="text-base font-medium text-foreground tabular-nums">
+                    {content.costLabel}
+                  </Text>
+                </Row>
+                <View className="gap-3">
+                  {content.tokenRows.map(row => (
+                    <TokenRow key={row.label} label={row.label} value={row.value} />
+                  ))}
+                </View>
+              </View>
+            ) : null}
+          </ScrollView>
+        ) : null}
+
+        <View style={{ height: insets.bottom }} className="bg-background" />
+      </View>
+    </Modal>
+  );
+}
+
+function Row({ label, children }: Readonly<{ label: string; children: React.ReactNode }>) {
+  return (
+    <View className="gap-1">
+      <Text className="text-xs uppercase tracking-wide text-muted-foreground">{label}</Text>
+      {children}
+    </View>
+  );
+}
+
+function TokenRow({ label, value }: Readonly<{ label: string; value: number }>) {
+  return (
+    <View className="flex-row items-center justify-between">
+      <Text className="text-sm text-muted-foreground">{label}</Text>
+      <Text className="text-sm font-medium text-foreground tabular-nums">
+        {formatExactTokens(value)}
+      </Text>
+    </View>
+  );
+}

--- a/apps/mobile/src/components/agents/message-model-label.test.ts
+++ b/apps/mobile/src/components/agents/message-model-label.test.ts
@@ -8,22 +8,15 @@ import {
   type UserMessage,
 } from 'cloud-agent-sdk';
 
-import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
-
-import { computeMessageModelLabels, resolveMessageDisplayModel } from './message-model-label';
+import { resolveMessageDisplayModel } from './message-model-label';
 
 /**
- * F3 — per-message model label helpers.
+ * Routed-first model resolution for assistant messages (message details sheet).
  *
  * Contract:
- *  - `resolveMessageDisplayModel` prefers the LAST routed-model step-finish
- *    part over `info.providerID/modelID`, falls back to info, and returns
- *    null for user messages and when no model info is resolvable.
- *  - `computeMessageModelLabels` labels the FIRST assistant message and
- *    every subsequent assistant message whose resolved model DIFFERS from
- *    the previous assistant's. Same-model follow-ups stay unlabelled; a
- *    user message between two same-model assistants must not break the
- *    gating; the label string is `friendlyModelName(providerID, modelID, options)`.
+ *  - prefers the LAST routed-model step-finish part over info.providerID/modelID
+ *  - falls back to info when no routed part is present
+ *  - returns null for user messages and when no model info is resolvable
  */
 
 function assistantInfo(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
@@ -82,29 +75,6 @@ function stepFinishWithRouted(
 ): StepFinishPart {
   return Object.assign(stepFinish(overrides), { model: routed }) as StepFinishPart;
 }
-
-const catalogOption: SessionModelOption = {
-  id: 'anthropic/claude-sonnet-4',
-  name: 'Claude Sonnet 4',
-  displayId: 'claude-sonnet-4',
-  variants: [],
-  isPreferred: false,
-  showGatewayMetadata: false,
-  provider: { id: 'anthropic', name: 'Anthropic' },
-  modelRef: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
-};
-
-const kiloAutoOption: SessionModelOption = {
-  id: 'kilo-auto/efficient',
-  name: 'Kilo Auto (efficient)',
-  displayId: 'kilo-auto/efficient',
-  variants: [],
-  isPreferred: true,
-  showGatewayMetadata: true,
-  provider: { id: 'kilo', name: 'Kilo' },
-};
-
-const options: SessionModelOption[] = [catalogOption, kiloAutoOption];
 
 describe('resolveMessageDisplayModel', () => {
   it('returns null for a user message', () => {
@@ -176,132 +146,5 @@ describe('resolveMessageDisplayModel', () => {
     const info = assistantInfo({ providerID: 'kilo', modelID: '' });
     const message = storedMessage(info);
     expect(resolveMessageDisplayModel(message)).toBeNull();
-  });
-});
-
-describe('computeMessageModelLabels', () => {
-  it('labels the first assistant message even when later assistants share the model', () => {
-    const m1 = storedMessage(
-      assistantInfo({ id: 'a1', providerID: 'kilo', modelID: 'kilo-auto/efficient' })
-    );
-    const m2 = storedMessage(
-      assistantInfo({ id: 'a2', providerID: 'kilo', modelID: 'kilo-auto/efficient' })
-    );
-    const labels = computeMessageModelLabels([m1, m2], options);
-    expect(labels.get('a1')).toBe('Kilo Auto (efficient)');
-    // m2 is the same model as m1 → no label.
-    expect(labels.has('a2')).toBe(false);
-  });
-
-  it('does NOT label a same-model follow-up assistant message', () => {
-    const m1 = storedMessage(
-      assistantInfo({ id: 'a1', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
-    );
-    const m2 = storedMessage(
-      assistantInfo({ id: 'a2', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
-    );
-    const labels = computeMessageModelLabels([m1, m2], options);
-    expect(labels.size).toBe(1);
-    expect(labels.get('a1')).toBe('Claude Sonnet 4');
-    expect(labels.has('a2')).toBe(false);
-  });
-
-  it('labels a follow-up assistant message when its model DIFFERS from the previous', () => {
-    const m1 = storedMessage(
-      assistantInfo({ id: 'a1', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
-    );
-    const m2 = storedMessage(
-      assistantInfo({ id: 'a2', providerID: 'kilo', modelID: 'kilo-auto/efficient' })
-    );
-    const labels = computeMessageModelLabels([m1, m2], options);
-    expect(labels.get('a1')).toBe('Claude Sonnet 4');
-    expect(labels.get('a2')).toBe('Kilo Auto (efficient)');
-  });
-
-  it('does NOT spuriously label when a user message sits between two same-model assistants', () => {
-    const user = storedMessage(userInfo({ id: 'u-mid' }));
-    const a1 = storedMessage(
-      assistantInfo({ id: 'a1', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
-    );
-    const a2 = storedMessage(
-      assistantInfo({ id: 'a2', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
-    );
-    const labels = computeMessageModelLabels([a1, user, a2], options);
-    expect(labels.size).toBe(1);
-    expect(labels.get('a1')).toBe('Claude Sonnet 4');
-    expect(labels.has('a2')).toBe(false);
-  });
-
-  it('returns an empty map when there are no assistant messages', () => {
-    const user1 = storedMessage(userInfo({ id: 'u-1' }));
-    const user2 = storedMessage(userInfo({ id: 'u-2' }));
-    expect(computeMessageModelLabels([user1, user2], options)).toEqual(new Map());
-  });
-
-  it('returns an empty map when no assistant message resolves a model', () => {
-    const a1 = storedMessage(assistantInfo({ id: 'a1', providerID: '', modelID: '' }));
-    const a2 = storedMessage(assistantInfo({ id: 'a2', providerID: '', modelID: '' }));
-    expect(computeMessageModelLabels([a1, a2], options)).toEqual(new Map());
-  });
-
-  it('treats an unresolvable assistant as transparent: a following resolvable assistant compares against the LAST resolved model, not against null', () => {
-    const a1 = storedMessage(
-      assistantInfo({ id: 'a1', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
-    );
-    const aUnresolvable = storedMessage(assistantInfo({ id: 'a2', providerID: '', modelID: '' }));
-    const a3 = storedMessage(
-      assistantInfo({ id: 'a3', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
-    );
-    const labels = computeMessageModelLabels([a1, aUnresolvable, a3], options);
-    // a1 is labelled (first); a3 shares a1's model and must NOT be labelled.
-    expect(labels.size).toBe(1);
-    expect(labels.get('a1')).toBe('Claude Sonnet 4');
-    expect(labels.has('a3')).toBe(false);
-  });
-
-  it('uses the friendlyModelName catalog hit when the resolved model is in the catalog', () => {
-    const a1 = storedMessage(
-      assistantInfo({ id: 'a1', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
-    );
-    const labels = computeMessageModelLabels([a1], options);
-    expect(labels.get('a1')).toBe('Claude Sonnet 4');
-  });
-
-  it('falls back to the cleaned raw modelID via friendlyModelName when the resolved model is NOT in the catalog', () => {
-    // Unresolvable id (no catalog hit) → cleaned raw id, with the trailing
-    // -YYYYMMDD date suffix stripped. Exercises the "Empty" branch of F3
-    // (unresolvable id → never blank).
-    const a1 = storedMessage(
-      assistantInfo({ id: 'a1', providerID: 'kilo', modelID: 'claude-sonnet-4-20260101' })
-    );
-    const labels = computeMessageModelLabels([a1], options);
-    expect(labels.get('a1')).toBe('claude-sonnet-4');
-  });
-
-  it('prefers the LAST routed step-finish model when computing the gate key', () => {
-    // m1 used kilo-auto/efficient info, but the LAST routed step-finish
-    // ran on anthropic/claude-sonnet-4. m2 is the SAME routed model, so
-    // it must NOT be labelled.
-    const m1 = storedMessage(
-      assistantInfo({ id: 'm1', providerID: 'kilo', modelID: 'kilo-auto/efficient' }),
-      [
-        stepFinishWithRouted(
-          { providerID: 'kilo', modelID: 'kilo-auto/efficient' },
-          { id: 'sf-a' }
-        ),
-        stepFinishWithRouted(
-          { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
-          { id: 'sf-b' }
-        ),
-      ]
-    );
-    const m2 = storedMessage(
-      assistantInfo({ id: 'm2', providerID: 'anthropic', modelID: 'claude-sonnet-4' }),
-      []
-    );
-    const labels = computeMessageModelLabels([m1, m2], options);
-    expect(labels.get('m1')).toBe('Claude Sonnet 4');
-    // m2's resolved model === m1's LAST routed model → no label.
-    expect(labels.has('m2')).toBe(false);
   });
 });

--- a/apps/mobile/src/components/agents/message-model-label.ts
+++ b/apps/mobile/src/components/agents/message-model-label.ts
@@ -2,28 +2,13 @@ import { getStepFinishRoutedModel } from 'cloud-agent-sdk/part-utils';
 
 import { type StoredMessage } from 'cloud-agent-sdk';
 
-import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
-
-import { friendlyModelName } from './session-model-display';
-
 /**
- * F3 — per-message model label helpers.
+ * Resolve the concrete (providerID, modelID) for one assistant message.
  *
- * The assistant transcript can use a different model from message to
- * message: the user switches mid-session, the CLI auto-routes a kilo-auto
- * turn to a different upstream provider, etc. We want a subtle, dimmed
- * "Claude Sonnet 4" / "Kilo Auto (efficient)" label to appear under the
- * FIRST assistant message and whenever the resolved model CHANGES relative
- * to the previous assistant message. Same-model follow-ups stay unlabelled
- * (a quiet "the model hasn't changed" signal).
- *
- * Two layers of pure functions:
- *  - {@link resolveMessageDisplayModel}: pick the concrete (providerID,
- *    modelID) for ONE assistant message, preferring the routed model on
- *    the LAST step-finish part that carries one.
- *  - {@link computeMessageModelLabels}: walk the transcript in order and
- *    produce the map of messageId -> display label for exactly the
- *    assistant messages that should render a label.
+ * Prefers the routed model on the LAST step-finish part that carries one
+ * (kilo-auto and mid-session switches), then falls back to info-level
+ * provider/model. Used by message details (long-press sheet); the transcript
+ * no longer renders a per-message model label.
  */
 
 type ResolvedModel = { providerID: string; modelID: string };
@@ -67,47 +52,4 @@ export function resolveMessageDisplayModel(message: StoredMessage): ResolvedMode
     return { providerID, modelID };
   }
   return null;
-}
-
-/**
- * Walk the ordered transcript and return the subset of assistant message
- * ids that should render a model label, mapped to their display string.
- *
- * Gating rule: the FIRST assistant message always shows its label (its
- * "previous model" is `undefined`, so the key always differs); every
- * following assistant message shows the label only when its resolved model
- * differs from the previous assistant message's resolved model. User
- * messages and other non-assistant messages are skipped and do NOT reset
- * the running key.
- */
-export function computeMessageModelLabels(
-  messages: readonly StoredMessage[],
-  options: SessionModelOption[]
-): Map<string, string> {
-  const labels = new Map<string, string>();
-  let previousKey: string | undefined = undefined;
-
-  // Filter to assistant messages first so the inner loop stays straight-line
-  // (no `continue`, which the lint rules forbid) while preserving order.
-  const assistantMessages = messages.filter(message => message.info.role === 'assistant');
-
-  for (const message of assistantMessages) {
-    const resolved = resolveMessageDisplayModel(message);
-    // Unresolvable assistant message: never labelled, and do NOT update
-    // `previousKey` so the next assistant is still compared against the
-    // last successfully-resolved model. This matches the F3 "Empty"
-    // state (unresolvable id → no label rather than a wrong label).
-    if (resolved) {
-      const key = `${resolved.providerID}:${resolved.modelID}`;
-      if (key !== previousKey) {
-        labels.set(
-          message.info.id,
-          friendlyModelName(resolved.providerID, resolved.modelID, options)
-        );
-        previousKey = key;
-      }
-    }
-  }
-
-  return labels;
 }

--- a/apps/mobile/src/components/agents/new-session-prompt.tsx
+++ b/apps/mobile/src/components/agents/new-session-prompt.tsx
@@ -65,14 +65,14 @@ type NewSessionPromptProps = {
 };
 
 /**
- * New-session prompt surface: attachment strip, paperclip + multiline text
- * input + voice toggle row, and the model/mode toolbar. Owns the prompt
- * ref (for voice input to read), the height-measuring TextInput machinery,
- * and the `useVoiceInput` hook. The route listens to `onChangeText` so the
- * create handler can read the live prompt value after
- * `settleVoiceInputBeforeSubmit` resolves; the attachment, repository, and
- * create flows stay in the route so navigation and tRPC mutations stay
- * colocated.
+ * New-session prompt surface: attachment strip, full-width multiline text
+ * input, bottom action row (paperclip leading, voice toggle trailing), and
+ * the model/mode toolbar. Owns the prompt ref (for voice input to read), the
+ * height-measuring TextInput machinery, and the `useVoiceInput` hook. The
+ * route listens to `onChangeText` so the create handler can read the live
+ * prompt value after `settleVoiceInputBeforeSubmit` resolves; the attachment,
+ * repository, and create flows stay in the route so navigation and tRPC
+ * mutations stay colocated.
  */
 export function NewSessionPrompt({
   attachments,
@@ -165,29 +165,15 @@ export function NewSessionPrompt({
         onRemove={onRemoveAttachment}
         onRetry={onRetryAttachment}
       />
-      <View className="flex-row items-end px-2 pt-2">
+      <View className="px-2 pt-2">
         {promptMeasure.measureElement}
-        <Pressable
-          onPress={handlePaperclipPress}
-          disabled={paperclipDisabled}
-          hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
-          className={cn(
-            'mb-1 h-9 w-9 items-center justify-center rounded-full active:opacity-70',
-            paperclipDisabled && 'opacity-50'
-          )}
-          accessibilityRole="button"
-          accessibilityLabel="Add attachment"
-          accessibilityState={{ disabled: paperclipDisabled }}
-        >
-          <Paperclip size={18} color={colors.mutedForeground} />
-        </Pressable>
         <RNTextInput
           ref={promptInputRef}
           placeholder="What would you like to work on?"
           placeholderTextColor={colors.mutedForeground}
           multiline
           className={cn(
-            'flex-1 px-2 py-2 text-base leading-6 text-foreground',
+            'w-full px-2 py-2 text-base leading-6 text-foreground',
             isCreating && 'opacity-50'
           )}
           style={[
@@ -205,16 +191,30 @@ export function NewSessionPrompt({
           accessibilityState={{ disabled: control.inputAccessibilityDisabled }}
           autoFocus
         />
-        {voiceInput.available ? (
-          <View className="ml-1">
+        <View className="flex-row items-center justify-between pb-1">
+          <Pressable
+            onPress={handlePaperclipPress}
+            disabled={paperclipDisabled}
+            hitSlop={{ top: 8, bottom: 8, left: 8, right: 8 }}
+            className={cn(
+              'h-9 w-9 items-center justify-center rounded-full active:opacity-70',
+              paperclipDisabled && 'opacity-50'
+            )}
+            accessibilityRole="button"
+            accessibilityLabel="Add attachment"
+            accessibilityState={{ disabled: paperclipDisabled }}
+          >
+            <Paperclip size={18} color={colors.mutedForeground} />
+          </Pressable>
+          {voiceInput.available ? (
             <VoiceInputButton
               disabled={control.voiceDisabled}
               size="md"
               status={voiceInput.status}
               onPress={handleVoiceToggle}
             />
-          </View>
-        ) : null}
+          ) : null}
+        </View>
       </View>
       {voiceInput.available ? (
         <View className="min-h-[20px] px-3 pb-1">

--- a/apps/mobile/src/components/agents/session-context-sheet.tsx
+++ b/apps/mobile/src/components/agents/session-context-sheet.tsx
@@ -21,7 +21,9 @@ import {
   getContextTone,
 } from './context-usage-display';
 import {
+  getModelsSectionCount,
   getSessionCostBreakdown,
+  getVisibleSessionCostModels,
   type SessionCostBreakdown,
   type SessionCostBreakdownModel,
 } from './session-cost-breakdown';
@@ -70,7 +72,12 @@ export function SessionContextSheet({
     () => getSessionCostBreakdown(messages, totalCost),
     [messages, totalCost]
   );
-  const modelsSectionCount = breakdown.models.length + (breakdown.subagentCostUsd > 0 ? 1 : 0);
+  // Render-only filter: totals/subagent residual still use the full breakdown.
+  const visibleModels = useMemo(
+    () => getVisibleSessionCostModels(breakdown.models),
+    [breakdown.models]
+  );
+  const modelsSectionCount = getModelsSectionCount(breakdown.models, breakdown.subagentCostUsd);
 
   return (
     <Modal
@@ -176,7 +183,7 @@ export function SessionContextSheet({
                 Models ({modelsSectionCount})
               </Text>
               <View className="gap-2">
-                {breakdown.models.map(model => (
+                {visibleModels.map(model => (
                   <ModelRow
                     key={`${model.providerID}:${model.modelID}`}
                     model={model}

--- a/apps/mobile/src/components/agents/session-cost-breakdown-models-filter.test.ts
+++ b/apps/mobile/src/components/agents/session-cost-breakdown-models-filter.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getModelsSectionCount,
+  getSessionCostBreakdown,
+  getVisibleSessionCostModels,
+  isHiddenAutoModelRow,
+  type SessionCostBreakdownModel,
+} from './session-cost-breakdown';
+import {
+  type AssistantMessage,
+  type Part,
+  type StepFinishPart,
+  type StoredMessage,
+} from 'cloud-agent-sdk';
+
+/**
+ * R8 / AC8 — Models section display filter.
+ *
+ * Predicate + count derivation are pure and unit-tested here. Filtering is
+ * render-only: getSessionCostBreakdown still attributes auto rows so totals
+ * and the subagent residual stay correct.
+ */
+
+function assistantInfo(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    id: 'msg-1',
+    sessionID: 'ses-1',
+    role: 'assistant',
+    time: { created: 1 },
+    parentID: 'msg-0',
+    modelID: 'claude-sonnet-4',
+    providerID: 'kilo',
+    mode: 'code',
+    agent: 'test',
+    path: { cwd: '/', root: '/' },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    ...overrides,
+  };
+}
+
+function stepFinish(overrides: Partial<StepFinishPart> = {}): StepFinishPart {
+  return {
+    id: 'p-finish',
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'step-finish',
+    reason: 'stop',
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    ...overrides,
+  };
+}
+
+function stepFinishWithModel(
+  model: { providerID: string; modelID: string },
+  overrides: Partial<StepFinishPart> = {}
+): StepFinishPart {
+  return Object.assign(stepFinish(overrides), { model }) as StepFinishPart;
+}
+
+function storedMessage(info: AssistantMessage, parts: Part[] = []): StoredMessage {
+  return { info, parts };
+}
+
+function modelRow(
+  overrides: Partial<SessionCostBreakdownModel> &
+    Pick<SessionCostBreakdownModel, 'providerID' | 'modelID'>
+): SessionCostBreakdownModel {
+  return {
+    steps: 1,
+    costUsd: 0.01,
+    tokens: {
+      input: 1,
+      output: 1,
+      reasoning: 0,
+      cacheRead: 0,
+      cacheWrite: 0,
+      total: 2,
+    },
+    ...overrides,
+  };
+}
+
+const oneOneTokens = { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } };
+
+describe('isHiddenAutoModelRow', () => {
+  it('hides kilo provider rows whose modelID starts with kilo-auto/', () => {
+    expect(isHiddenAutoModelRow({ providerID: 'kilo', modelID: 'kilo-auto/efficient' })).toBe(true);
+    expect(isHiddenAutoModelRow({ providerID: 'kilo', modelID: 'kilo-auto/frontier' })).toBe(true);
+    expect(isHiddenAutoModelRow({ providerID: 'kilo', modelID: 'kilo-auto/balanced' })).toBe(true);
+  });
+
+  it('keeps routed concrete models on the kilo provider', () => {
+    expect(isHiddenAutoModelRow({ providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4' })).toBe(
+      false
+    );
+    expect(isHiddenAutoModelRow({ providerID: 'kilo', modelID: 'claude-sonnet-4' })).toBe(false);
+    expect(isHiddenAutoModelRow({ providerID: 'kilo', modelID: 'openai/gpt-4o' })).toBe(false);
+  });
+
+  it('does not hide auto-prefixed ids on non-kilo providers', () => {
+    expect(isHiddenAutoModelRow({ providerID: 'openrouter', modelID: 'kilo-auto/efficient' })).toBe(
+      false
+    );
+    expect(isHiddenAutoModelRow({ providerID: 'anthropic', modelID: 'kilo-auto/efficient' })).toBe(
+      false
+    );
+  });
+
+  it('does not hide non-auto kilo models that merely contain kilo-auto elsewhere', () => {
+    expect(
+      isHiddenAutoModelRow({ providerID: 'kilo', modelID: 'prefix-kilo-auto/efficient' })
+    ).toBe(false);
+  });
+});
+
+describe('getVisibleSessionCostModels / getModelsSectionCount', () => {
+  it('filters auto rows and keeps routed + non-kilo rows', () => {
+    const models = [
+      modelRow({ providerID: 'kilo', modelID: 'kilo-auto/efficient', steps: 4 }),
+      modelRow({ providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4', steps: 2 }),
+      modelRow({ providerID: 'openai', modelID: 'gpt-4o', steps: 1 }),
+    ];
+    const visible = getVisibleSessionCostModels(models);
+    expect(visible).toHaveLength(2);
+    expect(visible.map(m => m.modelID)).toEqual(['anthropic/claude-sonnet-4', 'gpt-4o']);
+  });
+
+  it('derives Models (N) from filtered rows + residual, never unfiltered length', () => {
+    const autoOnly = [modelRow({ providerID: 'kilo', modelID: 'kilo-auto/efficient' })];
+    // Auto-only, no residual → section hidden (count 0)
+    expect(getModelsSectionCount(autoOnly, 0)).toBe(0);
+    // Auto-only + residual → count is residual only (1), not 2
+    expect(getModelsSectionCount(autoOnly, 0.02)).toBe(1);
+
+    const mixed = [
+      modelRow({ providerID: 'kilo', modelID: 'kilo-auto/efficient' }),
+      modelRow({ providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4' }),
+    ];
+    // Filtered list (1) + residual → 2, not unfiltered 2 + residual = 3
+    expect(getModelsSectionCount(mixed, 0.02)).toBe(2);
+    // Filtered list only → 1
+    expect(getModelsSectionCount(mixed, 0)).toBe(1);
+  });
+
+  it('returns zero when there are no models and no residual', () => {
+    expect(getModelsSectionCount([], 0)).toBe(0);
+  });
+
+  it('counts residual alone when models list is empty', () => {
+    expect(getModelsSectionCount([], 0.05)).toBe(1);
+  });
+});
+
+describe('getSessionCostBreakdown (filter is render-only)', () => {
+  it('keeps auto-model rows in breakdown totals and residual', () => {
+    const messages: StoredMessage[] = [
+      storedMessage(
+        assistantInfo({
+          id: 'm1',
+          providerID: 'kilo',
+          modelID: 'kilo-auto/efficient',
+          cost: 0.04,
+        }),
+        [
+          stepFinishWithModel(
+            { providerID: 'kilo', modelID: 'kilo-auto/efficient' },
+            { id: 'sf-1', cost: 0.04, tokens: oneOneTokens }
+          ),
+        ]
+      ),
+    ];
+    const result = getSessionCostBreakdown(messages, 0.06);
+    expect(result.models).toHaveLength(1);
+    expect(result.models[0]?.modelID).toBe('kilo-auto/efficient');
+    expect(result.attributedCostUsd).toBeCloseTo(0.04, 6);
+    expect(result.subagentCostUsd).toBeCloseTo(0.02, 6);
+    expect(result.totals.input).toBe(1);
+    expect(result.totals.output).toBe(1);
+    // Display layer would hide the auto row and show residual only
+    expect(getModelsSectionCount(result.models, result.subagentCostUsd)).toBe(1);
+    expect(getVisibleSessionCostModels(result.models)).toEqual([]);
+  });
+});

--- a/apps/mobile/src/components/agents/session-cost-breakdown.ts
+++ b/apps/mobile/src/components/agents/session-cost-breakdown.ts
@@ -168,6 +168,38 @@ export function getSessionCostBreakdown(
   return { totals, models, attributedCostUsd, subagentCostUsd };
 }
 
+/**
+ * Models-section display filter (R8): hide the session's selected auto model
+ * so the list only shows concrete routed models. Render-only — never applied
+ * when computing totals or the subagent residual.
+ *
+ * Hidden iff provider is `kilo` and modelID starts with `kilo-auto/`.
+ * Routed rows (`providerID: 'kilo'`, concrete `modelID` e.g. `anthropic/...`)
+ * always pass. Info-fallback steps that resolve only to an auto id are hidden
+ * by the same rule.
+ */
+export function isHiddenAutoModelRow(model: { providerID: string; modelID: string }): boolean {
+  return model.providerID === 'kilo' && model.modelID.startsWith('kilo-auto/');
+}
+
+/** Models rows that should render in the context-sheet Models section. */
+export function getVisibleSessionCostModels(
+  models: SessionCostBreakdownModel[]
+): SessionCostBreakdownModel[] {
+  return models.filter(model => !isHiddenAutoModelRow(model));
+}
+
+/**
+ * Section title count and visibility source: filtered model rows + optional
+ * Subagents residual. Never derived from the unfiltered list.
+ */
+export function getModelsSectionCount(
+  models: SessionCostBreakdownModel[],
+  subagentCostUsd: number
+): number {
+  return getVisibleSessionCostModels(models).length + (subagentCostUsd > 0 ? 1 : 0);
+}
+
 function collectStepFinishParts(parts: Part[]): StepFinishPart[] {
   const out: StepFinishPart[] = [];
   for (const part of parts) {

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable max-lines -- Session orchestration and its render paths are kept together. */
-import { type CloudStatus, type KiloSessionId } from 'cloud-agent-sdk';
+import { type CloudStatus, type KiloSessionId, type StoredMessage } from 'cloud-agent-sdk';
 import { type Href, useRouter } from 'expo-router';
 import { useAtomValue } from 'jotai';
 import { MessageSquare } from 'lucide-react-native';
@@ -15,6 +15,7 @@ import { createAndNavigateAgentSession } from '@/components/agents/create-and-na
 import { exitRemoteSessionWithFeedback } from '@/components/agents/exit-remote-session-with-feedback';
 import { ConnectivityBanner } from '@/components/agents/connectivity-banner';
 import { MessageBubble } from '@/components/agents/message-bubble';
+import { MessageDetailsSheet } from '@/components/agents/message-details-sheet';
 import { ModelPickerSelectionScopeProvider } from '@/components/agents/model-selector';
 import { PermissionCard } from '@/components/agents/permission-card';
 import { QuestionCard } from '@/components/agents/question-card';
@@ -144,6 +145,7 @@ export function SessionDetailContent({
   const olderMessagesOmittedItemCount = useAtomValue(manager.atoms.olderMessagesOmittedItemCount);
   const [openContextSheetIdentity, setOpenContextSheetIdentity] =
     useState<ContextSheetIdentity | null>(null);
+  const [detailsMessage, setDetailsMessage] = useState<StoredMessage | null>(null);
 
   const { isConnected } = useAppLifecycle();
   const { bottom } = useSafeAreaInsets();
@@ -366,6 +368,7 @@ export function SessionDetailContent({
           defaultReasoningExpanded={reasoningDefaultExpanded}
           onOpenChildSession={handleOpenChildSession}
           deliveryState={deliveryState}
+          onLongPressDetails={setDetailsMessage}
         />
       );
     },
@@ -651,6 +654,15 @@ export function SessionDetailContent({
           }}
         />
       ) : null}
+
+      <MessageDetailsSheet
+        visible={detailsMessage !== null}
+        message={detailsMessage}
+        modelOptions={modelOptions}
+        onClose={() => {
+          setDetailsMessage(null);
+        }}
+      />
 
       {childSession ? (
         <ChildSessionSheet

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -15,7 +15,6 @@ import { createAndNavigateAgentSession } from '@/components/agents/create-and-na
 import { exitRemoteSessionWithFeedback } from '@/components/agents/exit-remote-session-with-feedback';
 import { ConnectivityBanner } from '@/components/agents/connectivity-banner';
 import { MessageBubble } from '@/components/agents/message-bubble';
-import { computeMessageModelLabels } from '@/components/agents/message-model-label';
 import { ModelPickerSelectionScopeProvider } from '@/components/agents/model-selector';
 import { PermissionCard } from '@/components/agents/permission-card';
 import { QuestionCard } from '@/components/agents/question-card';
@@ -40,6 +39,7 @@ import { PreparationGroup } from '@/components/agents/preparation-group';
 import {
   shouldShowAgentWorkingIndicator,
   shouldShowFooterWorkingIndicator,
+  shouldShowSessionFooterRow,
 } from '@/components/agents/session-working-state';
 import { EmptyState } from '@/components/empty-state';
 import { AppAwareKeyboardPaddingView } from '@/components/kilo-chat/app-aware-keyboard-padding';
@@ -333,16 +333,6 @@ export function SessionDetailContent({
     return null;
   }, [messages]);
 
-  // Per-message model label gating: the first assistant message is always
-  // labelled, and every subsequent assistant message is labelled only when
-  // its resolved model differs from the previous assistant's. Walked over
-  // the ordered transcript here so each `<MessageBubble>` only needs to
-  // consult a Map lookup, not re-derive the answer from the whole list.
-  const messageModelLabels = useMemo(
-    () => computeMessageModelLabels(messages, modelOptions),
-    [messages, modelOptions]
-  );
-
   const handleOpenChildSession = useCallback(
     (childSessionId: KiloSessionId, childTitle: string) => {
       setChildSession({ sessionId: childSessionId, title: childTitle });
@@ -376,11 +366,6 @@ export function SessionDetailContent({
           defaultReasoningExpanded={reasoningDefaultExpanded}
           onOpenChildSession={handleOpenChildSession}
           deliveryState={deliveryState}
-          modelLabel={
-            item.message.info.role === 'assistant'
-              ? messageModelLabels.get(item.message.info.id)
-              : undefined
-          }
         />
       );
     },
@@ -391,7 +376,6 @@ export function SessionDetailContent({
       reasoningDefaultExpanded,
       handleOpenChildSession,
       pendingMessages,
-      messageModelLabels,
     ]
   );
 
@@ -452,10 +436,25 @@ export function SessionDetailContent({
     isStreaming,
     pendingMessageCount: pendingMessages.size,
   });
+  const hasFooterStatusIndicator =
+    statusIndicator !== null || (cloudStatus !== null && cloudStatus.type !== 'ready');
   const shouldShowFooterWorking = shouldShowFooterWorkingIndicator({
     isAgentWorking: shouldShowWorkingIndicator,
-    hasStatusIndicator:
-      statusIndicator !== null || (cloudStatus !== null && cloudStatus.type !== 'ready'),
+    hasStatusIndicator: hasFooterStatusIndicator,
+  });
+  // Only a live PreparationGroup duplicates footer progress. Completed groups
+  // stay in the transcript after cold starts and must not suppress a later
+  // recycle re-prepare footer (Setting up environment…).
+  const hasInProgressTranscriptPreparation = useMemo(
+    () => transcript.some(item => item.type === 'preparation' && item.attempt.status === 'running'),
+    [transcript]
+  );
+  const showSessionFooterRow = shouldShowSessionFooterRow({
+    cloudStatusType: cloudStatus?.type,
+    hasInProgressTranscriptPreparation,
+    shouldShowFooterWorking,
+    hasStatusIndicator: statusIndicator !== null,
+    messageCount: messages.length,
   });
 
   const emptyStateText = statusIndicator ? null : 'No messages yet';
@@ -692,8 +691,9 @@ export function SessionDetailContent({
             content-size changes during streaming cannot reposition it.
             Gated on has-messages so the empty/connecting path (which
             renders the centered status indicator inside `renderContent`)
-            does not double-render. */}
-        {messages.length > 0 && (shouldShowFooterWorking || statusIndicator) ? (
+            does not double-render. While preparing, suppressed when the
+            transcript already shows PreparationGroup (no duplicate). */}
+        {showSessionFooterRow ? (
           <Animated.View
             entering={FadeIn.duration(200)}
             exiting={FadeOut.duration(150)}

--- a/apps/mobile/src/components/agents/session-working-state.test.ts
+++ b/apps/mobile/src/components/agents/session-working-state.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it } from 'vitest';
 import {
   shouldShowAgentWorkingIndicator,
   shouldShowFooterWorkingIndicator,
+  shouldShowSessionFooterRow,
 } from '@/components/agents/session-working-state';
 
 describe('shouldShowAgentWorkingIndicator', () => {
@@ -58,6 +59,120 @@ describe('shouldShowFooterWorkingIndicator', () => {
       shouldShowFooterWorkingIndicator({
         isAgentWorking: false,
         hasStatusIndicator: false,
+      })
+    ).toBe(false);
+  });
+});
+
+describe('shouldShowSessionFooterRow', () => {
+  const base = {
+    shouldShowFooterWorking: false,
+    hasStatusIndicator: true,
+    messageCount: 1,
+  };
+
+  it('hides while preparing when the transcript shows an in-progress preparation', () => {
+    expect(
+      shouldShowSessionFooterRow({
+        ...base,
+        cloudStatusType: 'preparing',
+        hasInProgressTranscriptPreparation: true,
+      })
+    ).toBe(false);
+  });
+
+  it('shows while preparing when the transcript has no live preparation surface', () => {
+    expect(
+      shouldShowSessionFooterRow({
+        ...base,
+        cloudStatusType: 'preparing',
+        hasInProgressTranscriptPreparation: false,
+      })
+    ).toBe(true);
+  });
+
+  it('shows while preparing when only a completed (stale) preparation is in the transcript', () => {
+    // Recycle re-prepare: prior non-no-op completed group remains rendered, but
+    // the new running attempt is not merged yet — footer must stay visible.
+    expect(
+      shouldShowSessionFooterRow({
+        ...base,
+        cloudStatusType: 'preparing',
+        hasInProgressTranscriptPreparation: false,
+      })
+    ).toBe(true);
+  });
+
+  it('hides while preparing when a running non-no-op preparation is in the transcript', () => {
+    expect(
+      shouldShowSessionFooterRow({
+        ...base,
+        cloudStatusType: 'preparing',
+        hasInProgressTranscriptPreparation: true,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps non-preparing behavior: shows when status or footer working is set', () => {
+    expect(
+      shouldShowSessionFooterRow({
+        ...base,
+        cloudStatusType: 'ready',
+        hasInProgressTranscriptPreparation: true,
+        hasStatusIndicator: true,
+        shouldShowFooterWorking: false,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowSessionFooterRow({
+        ...base,
+        cloudStatusType: null,
+        hasInProgressTranscriptPreparation: false,
+        hasStatusIndicator: false,
+        shouldShowFooterWorking: true,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowSessionFooterRow({
+        ...base,
+        cloudStatusType: 'ready',
+        hasInProgressTranscriptPreparation: false,
+        hasStatusIndicator: false,
+        shouldShowFooterWorking: false,
+      })
+    ).toBe(false);
+  });
+
+  it('keeps footer-working rules and hides the row when there are no messages', () => {
+    expect(
+      shouldShowSessionFooterRow({
+        cloudStatusType: null,
+        hasInProgressTranscriptPreparation: false,
+        shouldShowFooterWorking: true,
+        hasStatusIndicator: false,
+        messageCount: 3,
+      })
+    ).toBe(true);
+
+    expect(
+      shouldShowSessionFooterRow({
+        cloudStatusType: 'preparing',
+        hasInProgressTranscriptPreparation: false,
+        shouldShowFooterWorking: false,
+        hasStatusIndicator: true,
+        messageCount: 0,
+      })
+    ).toBe(false);
+
+    expect(
+      shouldShowSessionFooterRow({
+        cloudStatusType: null,
+        hasInProgressTranscriptPreparation: false,
+        shouldShowFooterWorking: true,
+        hasStatusIndicator: false,
+        messageCount: 0,
       })
     ).toBe(false);
   });

--- a/apps/mobile/src/components/agents/session-working-state.ts
+++ b/apps/mobile/src/components/agents/session-working-state.ts
@@ -8,6 +8,15 @@ type FooterWorkingIndicatorInput = {
   hasStatusIndicator: boolean;
 };
 
+type SessionFooterRowInput = {
+  cloudStatusType: string | null | undefined;
+  /** True only when the transcript shows a live (running) PreparationGroup. */
+  hasInProgressTranscriptPreparation: boolean;
+  shouldShowFooterWorking: boolean;
+  hasStatusIndicator: boolean;
+  messageCount: number;
+};
+
 export function shouldShowAgentWorkingIndicator({
   isStreaming,
   pendingMessageCount,
@@ -20,4 +29,28 @@ export function shouldShowFooterWorkingIndicator({
   hasStatusIndicator,
 }: FooterWorkingIndicatorInput): boolean {
   return isAgentWorking && !hasStatusIndicator;
+}
+
+/**
+ * Fixed footer row above the composer (working spinner and/or cloud status).
+ * While cloud-agent preparation is in flight AND the transcript already shows
+ * a live PreparationGroup, hide the footer so progress is not duplicated.
+ * Stale completed/failed groups must not suppress the footer — otherwise a
+ * recycle re-prepare can leave a blank progress window until the new running
+ * attempt merges. Zero-message empty state is handled elsewhere.
+ */
+export function shouldShowSessionFooterRow({
+  cloudStatusType,
+  hasInProgressTranscriptPreparation,
+  shouldShowFooterWorking,
+  hasStatusIndicator,
+  messageCount,
+}: SessionFooterRowInput): boolean {
+  if (messageCount === 0) {
+    return false;
+  }
+  if (cloudStatusType === 'preparing' && hasInProgressTranscriptPreparation) {
+    return false;
+  }
+  return shouldShowFooterWorking || hasStatusIndicator;
 }

--- a/apps/mobile/src/components/agents/use-message-copy.test.ts
+++ b/apps/mobile/src/components/agents/use-message-copy.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const setStringAsync = vi.fn();
+const notificationAsync = vi.fn();
+const toastSuccess = vi.fn();
+const toastError = vi.fn();
+const showActionSheetWithOptions = vi.fn();
+
+vi.mock('expo-clipboard', () => ({
+  setStringAsync: (...args: unknown[]) => setStringAsync(...args),
+}));
+vi.mock('expo-haptics', () => ({
+  notificationAsync: (...args: unknown[]) => notificationAsync(...args),
+  NotificationFeedbackType: { Success: 'success' },
+}));
+vi.mock('sonner-native', () => ({
+  toast: {
+    success: (...args: unknown[]) => toastSuccess(...args),
+    error: (...args: unknown[]) => toastError(...args),
+  },
+}));
+vi.mock('react-native', () => ({
+  Platform: { OS: 'android' },
+  ActionSheetIOS: {
+    showActionSheetWithOptions: (...args: unknown[]) => showActionSheetWithOptions(...args),
+  },
+}));
+
+describe('performCopy', () => {
+  beforeEach(() => {
+    setStringAsync.mockReset();
+    notificationAsync.mockReset();
+    toastSuccess.mockReset();
+    toastError.mockReset();
+    showActionSheetWithOptions.mockReset();
+  });
+
+  it('writes to the clipboard, fires success haptic, and toasts success', async () => {
+    setStringAsync.mockResolvedValue(undefined);
+    const { performCopy } = await import('./use-message-copy');
+    await performCopy('hello');
+    expect(setStringAsync).toHaveBeenCalledWith('hello');
+    expect(notificationAsync).toHaveBeenCalledWith('success');
+    expect(toastSuccess).toHaveBeenCalledWith('Copied to clipboard');
+    expect(toastError).not.toHaveBeenCalled();
+  });
+
+  it('toasts an error on clipboard failure and does not throw (sheet stays open)', async () => {
+    setStringAsync.mockRejectedValue(new Error('denied'));
+    const { performCopy } = await import('./use-message-copy');
+    await expect(performCopy('hello')).resolves.toBeUndefined();
+    expect(toastError).toHaveBeenCalledWith('Could not copy to clipboard');
+    expect(toastSuccess).not.toHaveBeenCalled();
+    expect(notificationAsync).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/components/agents/use-message-copy.ts
+++ b/apps/mobile/src/components/agents/use-message-copy.ts
@@ -32,7 +32,12 @@ export function useMessageCopy() {
   return { copyMessage };
 }
 
-async function performCopy(text: string) {
+/**
+ * Immediate clipboard write used by the message-details sheet and by the
+ * a11y/ActionSheet copy path after the user confirms. Success haptic + toast;
+ * failure → error toast (caller keeps its UI open).
+ */
+export async function performCopy(text: string): Promise<void> {
   try {
     await Clipboard.setStringAsync(text);
     void Haptics.notificationAsync(Haptics.NotificationFeedbackType.Success);

--- a/apps/mobile/src/components/pr-review/diff/pr-diff-navigator-file-row.tsx
+++ b/apps/mobile/src/components/pr-review/diff/pr-diff-navigator-file-row.tsx
@@ -33,19 +33,19 @@ export function NavigatorFileRow({
   const colors = useThemeColors();
   const { dir, basename } = splitPath(file.path);
   return (
-    <View className="flex-row items-center border-b border-hair-soft bg-card px-4 py-2.5">
+    <View className="flex-row items-center gap-3 border-b border-hair-soft bg-card px-4 py-2.5">
       <Pressable
         onPress={onSelect}
         accessibilityRole="button"
         accessibilityLabel={`Open ${file.path}${viewed ? ' (viewed)' : ''}`}
-        className="min-h-11 flex-1 flex-row items-center active:opacity-70"
+        className="min-h-11 min-w-0 flex-1 flex-row items-center active:opacity-70"
       >
-        <View className="flex-1 pr-3">
-          <View className="flex-row items-baseline">
+        <View className="min-w-0 flex-1">
+          <View className="min-w-0 flex-row items-baseline">
             {dir.length > 0 ? (
               <Text
                 variant="muted"
-                className="text-sm"
+                className="min-w-0 shrink text-sm"
                 // eslint-disable-next-line react-native/no-inline-styles, react-native/no-color-literals -- dynamic muted color
                 style={{ color: colors.mutedForeground }}
                 numberOfLines={1}
@@ -53,7 +53,7 @@ export function NavigatorFileRow({
                 {dir}
               </Text>
             ) : null}
-            <Text className="text-sm font-medium text-foreground" numberOfLines={1}>
+            <Text className="shrink-0 text-sm font-medium text-foreground" numberOfLines={1}>
               {basename}
             </Text>
           </View>
@@ -72,7 +72,9 @@ export function NavigatorFileRow({
           </View>
         </View>
       </Pressable>
-      <MarkViewedToggle path={file.path} viewed={viewed} onToggle={onToggleViewed} />
+      <View className="shrink-0">
+        <MarkViewedToggle path={file.path} viewed={viewed} onToggle={onToggleViewed} />
+      </View>
     </View>
   );
 }

--- a/apps/mobile/src/components/pr-review/merge/pr-merge-sheet-parts.tsx
+++ b/apps/mobile/src/components/pr-review/merge/pr-merge-sheet-parts.tsx
@@ -1,10 +1,15 @@
 // Form sub-components for the S8 merge sheet. Extracted out of
 // `pr-merge-sheet.tsx` to keep that file under the repo's 300-line limit.
 
-import { type RefObject } from 'react';
-import { Switch, TextInput, View } from 'react-native';
+import { type ReactNode, type RefObject } from 'react';
+import { Pressable, Switch, TextInput, View } from 'react-native';
+import * as Haptics from 'expo-haptics';
 
-import { PillGroup } from '@/components/security-agent/settings-pill-group';
+import {
+  PrFormSheetFooter,
+  useFormSheetKeyboardVisible,
+} from '@/components/pr-review/pr-form-sheet-chrome';
+import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { cn } from '@/lib/utils';
@@ -13,8 +18,19 @@ import {
   PR_MERGE_DESCRIPTIONS,
 } from '@/lib/pr-review/merge/merge-blocked-reasons';
 import { type MergeMethodOption } from '@/components/pr-review/merge/pr-merge-icons';
+import { PrReviewReconnectNotice } from '@/components/pr-review/pr-review-reconnect-notice';
 
-export function MethodPicker({
+function shortMethodChipLabel(value: AllowedMergeMethod): string {
+  if (value === 'merge') {
+    return 'Merge';
+  }
+  if (value === 'squash') {
+    return 'Squash';
+  }
+  return 'Rebase';
+}
+
+function MethodPicker({
   methodOptions,
   method,
   isDisabled,
@@ -26,27 +42,50 @@ export function MethodPicker({
   onChange: (next: AllowedMergeMethod) => void;
 }>) {
   return (
-    <View className="gap-2">
-      <Text variant="eyebrow" className="uppercase tracking-wide text-muted-foreground">
+    <View className="gap-0.5">
+      <Text className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
         Method
       </Text>
-      <PillGroup
-        label="Merge method"
-        options={methodOptions.map(o => ({ value: o.value, label: o.label }))}
-        value={method}
-        disabled={isDisabled}
-        onChange={value => {
-          onChange(value);
-        }}
-      />
-      <Text variant="muted" className="text-sm">
-        {PR_MERGE_DESCRIPTIONS[method]}
-      </Text>
+      <View className="flex-row flex-wrap gap-1">
+        {methodOptions.map(option => {
+          const active = method === option.value;
+          // Long labels stay readable via accessibilityLabel; chip shows short text.
+          const shortLabel = shortMethodChipLabel(option.value);
+          return (
+            <Pressable
+              key={option.value}
+              disabled={isDisabled}
+              onPress={() => {
+                void Haptics.selectionAsync();
+                onChange(option.value);
+              }}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: active, disabled: isDisabled }}
+              accessibilityLabel={option.label}
+              accessibilityHint={PR_MERGE_DESCRIPTIONS[option.value]}
+              className={cn(
+                'min-h-8 items-center justify-center rounded-full border px-2.5 py-1 active:opacity-70',
+                active ? 'border-primary bg-primary' : 'border-border bg-secondary',
+                isDisabled && 'opacity-50'
+              )}
+            >
+              <Text
+                className={cn(
+                  'text-xs font-medium',
+                  active ? 'text-primary-foreground' : 'text-foreground'
+                )}
+              >
+                {shortLabel}
+              </Text>
+            </Pressable>
+          );
+        })}
+      </View>
     </View>
   );
 }
 
-export function CommitTitleField({
+function CommitTitleField({
   titleRef,
   inputRef,
   placeholder,
@@ -59,8 +98,8 @@ export function CommitTitleField({
 }>) {
   const colors = useThemeColors();
   return (
-    <View className="gap-2">
-      <Text className="text-sm font-medium text-foreground">Commit title</Text>
+    <View className="gap-0.5">
+      <Text className="text-xs font-medium text-foreground">Commit title</Text>
       <TextInput
         ref={inputRef}
         defaultValue={titleRef.current}
@@ -72,7 +111,7 @@ export function CommitTitleField({
           titleRef.current = value;
         }}
         className={cn(
-          'rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground',
+          'min-h-9 max-h-12 rounded-md border border-input bg-background px-3 py-1 text-sm leading-5 text-foreground',
           'focus:border-ring'
         )}
         multiline
@@ -81,19 +120,24 @@ export function CommitTitleField({
   );
 }
 
-export function CommitMessageField({
+function CommitMessageField({
   messageRef,
   inputRef,
   isDisabled,
+  /** Half-detent / keyboard-open: keep a single-line-ish field so footer CTAs fit. */
+  compact = false,
 }: Readonly<{
   messageRef: RefObject<string>;
   inputRef: RefObject<TextInput | null>;
   isDisabled: boolean;
+  compact?: boolean;
 }>) {
   const colors = useThemeColors();
+  const keyboardVisible = useFormSheetKeyboardVisible();
+  const tight = compact || keyboardVisible;
   return (
-    <View className="gap-2">
-      <Text className="text-sm font-medium text-foreground">Commit message</Text>
+    <View className="gap-0.5">
+      <Text className="text-xs font-medium text-foreground">Commit message</Text>
       <TextInput
         ref={inputRef}
         defaultValue={messageRef.current}
@@ -105,8 +149,9 @@ export function CommitMessageField({
           messageRef.current = value;
         }}
         className={cn(
-          'min-h-24 rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground',
-          'focus:border-ring'
+          'rounded-md border border-input bg-background px-3 py-1 text-sm leading-5 text-foreground',
+          'focus:border-ring',
+          tight ? 'max-h-12 min-h-9' : 'min-h-11 max-h-16'
         )}
         multiline
         textAlignVertical="top"
@@ -115,23 +160,25 @@ export function CommitMessageField({
   );
 }
 
-export function DeleteBranchToggle({
+function DeleteBranchToggle({
   value,
   onChange,
   isDisabled,
+  /** Hidden on half-detent and while the keyboard is open (footer room). */
+  hidden = false,
 }: Readonly<{
   value: boolean;
   onChange: (next: boolean) => void;
   isDisabled: boolean;
+  hidden?: boolean;
 }>) {
+  const keyboardVisible = useFormSheetKeyboardVisible();
+  if (hidden || keyboardVisible) {
+    return null;
+  }
   return (
-    <View className="flex-row items-center justify-between rounded-lg bg-secondary p-4">
-      <View className="flex-1 pr-3">
-        <Text className="text-sm font-medium">Delete branch</Text>
-        <Text variant="muted" className="text-xs">
-          Delete the head branch after the merge succeeds.
-        </Text>
-      </View>
+    <View className="flex-row items-center justify-between rounded-lg bg-secondary px-3 py-1.5">
+      <Text className="flex-1 pr-3 text-sm font-medium">Delete branch</Text>
       <Switch
         accessibilityLabel="Delete branch after merge"
         value={value}
@@ -139,5 +186,127 @@ export function DeleteBranchToggle({
         onValueChange={onChange}
       />
     </View>
+  );
+}
+
+/** Compact form body + footer for half-detent CTA fit. */
+export function MergeSheetFormBody(props: {
+  noMethodsAllowed: boolean;
+  methodOptions: MergeMethodOption[];
+  method: AllowedMergeMethod;
+  isMutating: boolean;
+  onMethodChange: (next: AllowedMergeMethod) => void;
+  titleRef: RefObject<string>;
+  titleInputRef: RefObject<TextInput | null>;
+  titlePlaceholder: string;
+  messageRef: RefObject<string>;
+  messageInputRef: RefObject<TextInput | null>;
+  isHalfDetent: boolean;
+  showDeleteBranchToggle: boolean;
+  deleteBranch: boolean;
+  onDeleteBranchChange: (next: boolean) => void;
+  inlineError: string | null;
+  inlineErrorKind: 'retryable' | 'non-retryable' | 'reconnect' | null;
+  submitLabel: string;
+  onConfirm: () => void;
+  onDismiss: () => void;
+}): ReactNode {
+  const {
+    noMethodsAllowed,
+    methodOptions,
+    method,
+    isMutating,
+    onMethodChange,
+    titleRef,
+    titleInputRef,
+    titlePlaceholder,
+    messageRef,
+    messageInputRef,
+    isHalfDetent,
+    showDeleteBranchToggle,
+    deleteBranch,
+    onDeleteBranchChange,
+    inlineError,
+    inlineErrorKind,
+    submitLabel,
+    onConfirm,
+    onDismiss,
+  } = props;
+
+  return (
+    <>
+      <View className="gap-1.5 px-6 pt-1.5">
+        {noMethodsAllowed ? (
+          <View className="rounded-md border border-border bg-secondary p-3">
+            <Text className="text-sm text-muted-foreground">
+              This repository has no enabled merge methods. Ask a repository admin to enable merge,
+              squash, or rebase merging.
+            </Text>
+          </View>
+        ) : (
+          <MethodPicker
+            methodOptions={methodOptions}
+            method={method}
+            isDisabled={isMutating}
+            onChange={onMethodChange}
+          />
+        )}
+        <CommitTitleField
+          titleRef={titleRef}
+          inputRef={titleInputRef}
+          placeholder={titlePlaceholder}
+          isDisabled={isMutating}
+        />
+        <CommitMessageField
+          messageRef={messageRef}
+          inputRef={messageInputRef}
+          isDisabled={isMutating}
+          compact={isHalfDetent}
+        />
+        {showDeleteBranchToggle ? (
+          <DeleteBranchToggle
+            value={deleteBranch}
+            onChange={onDeleteBranchChange}
+            isDisabled={isMutating}
+            hidden={isHalfDetent}
+          />
+        ) : null}
+        {inlineError && inlineErrorKind !== 'reconnect' ? (
+          <View
+            className="rounded-md border border-destructive bg-red-50 dark:bg-red-950 px-2.5 py-1.5"
+            accessibilityLiveRegion="polite"
+          >
+            <Text className="text-xs text-destructive">{inlineError}</Text>
+          </View>
+        ) : null}
+        {inlineErrorKind === 'reconnect' ? <PrReviewReconnectNotice /> : null}
+      </View>
+
+      <PrFormSheetFooter className="pb-1 pt-1">
+        <Button
+          size="sm"
+          onPress={onConfirm}
+          loading={isMutating}
+          disabled={
+            noMethodsAllowed ||
+            inlineErrorKind === 'non-retryable' ||
+            inlineErrorKind === 'reconnect'
+          }
+          accessibilityLabel={submitLabel}
+        >
+          <Text>{submitLabel}</Text>
+        </Button>
+        <Button
+          size="sm"
+          variant="ghost"
+          onPress={onDismiss}
+          disabled={isMutating}
+          className="mt-0.5"
+          accessibilityLabel="Cancel"
+        >
+          <Text>Cancel</Text>
+        </Button>
+      </PrFormSheetFooter>
+    </>
   );
 }

--- a/apps/mobile/src/components/pr-review/merge/pr-merge-sheet.tsx
+++ b/apps/mobile/src/components/pr-review/merge/pr-merge-sheet.tsx
@@ -13,11 +13,10 @@
 // dismisses (cancel) or the mutation succeeds (auto-dismiss).
 
 import * as Haptics from 'expo-haptics';
-import { Alert, ScrollView, type TextInput, View } from 'react-native';
+import { Alert, Keyboard, ScrollView, type TextInput, useWindowDimensions } from 'react-native';
 import { useEffect, useMemo, useRef, useState } from 'react';
 
-import { Button } from '@/components/ui/button';
-import { Text } from '@/components/ui/text';
+import { PrFormSheetHeader } from '@/components/pr-review/pr-form-sheet-chrome';
 import {
   type AllowedMergeMethod,
   type PrMergeMethod,
@@ -27,18 +26,12 @@ import {
   useEnableAutoMergeMutation,
   useMergePullRequestMutation,
 } from '@/lib/pr-review/merge/use-pr-merge-mutations';
-import { PrReviewReconnectNotice } from '@/components/pr-review/pr-review-reconnect-notice';
 import { classifyPrReviewMutationError } from '@/lib/pr-review/classify-pr-review-query-state';
 import {
   defaultMergeMethodOptionFor,
   mergeMethodOptionsFor,
 } from '@/components/pr-review/merge/pr-merge-icons';
-import {
-  CommitMessageField,
-  CommitTitleField,
-  DeleteBranchToggle,
-  MethodPicker,
-} from '@/components/pr-review/merge/pr-merge-sheet-parts';
+import { MergeSheetFormBody } from '@/components/pr-review/merge/pr-merge-sheet-parts';
 import {
   defaultCommitMessage,
   defaultCommitTitle,
@@ -61,6 +54,8 @@ type PrMergeSheetProps = Readonly<{
   repo: PrOverviewRepoSettings;
   initialMethod: PrMergeMethod;
   mode: PrMergeSheetMode;
+  sheetTitle: string;
+  eyebrow: string;
   /** Called after a successful merge / auto-merge enable so the orchestrator can refetch. */
   onRefetch: () => Promise<void>;
   /** Called when the user cancels or after a successful submit. */
@@ -104,6 +99,8 @@ export function PrMergeSheet(props: PrMergeSheetProps) {
     repo: repoSettings,
     initialMethod,
     mode,
+    sheetTitle,
+    eyebrow,
     onRefetch,
     onDismiss,
   } = props;
@@ -125,8 +122,14 @@ export function PrMergeSheet(props: PrMergeSheetProps) {
   // read the ref on submit. `defaultValue` is for the first commit only.
   const titleInputRef = useRef<TextInput>(null);
   const messageInputRef = useRef<TextInput>(null);
+  const scrollRef = useRef<ScrollView | null>(null);
   const titleRef = useRef(defaultCommitTitle(title, number));
   const messageRef = useRef(defaultCommitMessage(bodyMarkdown));
+  const { height: windowHeight } = useWindowDimensions();
+  // Half detent (~0.5) vs full: hide delete-branch + tighten message so
+  // Merge/Cancel stay above the closed-sheet limit without scrolling.
+  const [scrollViewportHeight, setScrollViewportHeight] = useState(0);
+  const isHalfDetent = scrollViewportHeight > 0 && scrollViewportHeight < windowHeight * 0.65;
 
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [inlineErrorKind, setInlineErrorKind] = useState<
@@ -167,6 +170,17 @@ export function PrMergeSheet(props: PrMergeSheetProps) {
       }
     }
   }, [lastError]);
+
+  useEffect(() => {
+    const sub = Keyboard.addListener('keyboardDidShow', () => {
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ y: 0, animated: false });
+      });
+    });
+    return () => {
+      sub.remove();
+    };
+  }, []);
 
   function resetForNewMethod(next: AllowedMergeMethod) {
     setMethod(next);
@@ -264,82 +278,43 @@ export function PrMergeSheet(props: PrMergeSheetProps) {
   // rather than sending a method the repo does not allow.
   const noMethodsAllowed = methodOptions.length === 0;
 
+  // PickerSheet invariant: [header, ScrollView]; footer is trailing content.
   return (
-    <View className="flex-1 bg-background">
+    <>
+      <PrFormSheetHeader title={sheetTitle} eyebrow={eyebrow} onBack={onDismiss} />
       <ScrollView
-        className="flex-1"
-        contentContainerClassName="gap-5 px-6 pb-10 pt-2"
+        ref={scrollRef}
+        className="flex-1 bg-background"
+        contentContainerClassName="pb-1"
         keyboardShouldPersistTaps="handled"
         automaticallyAdjustKeyboardInsets
         keyboardDismissMode="interactive"
+        onLayout={event => {
+          setScrollViewportHeight(event.nativeEvent.layout.height);
+        }}
       >
-        {noMethodsAllowed ? (
-          <View className="rounded-md border border-border bg-secondary p-3">
-            <Text className="text-sm text-muted-foreground">
-              This repository has no enabled merge methods. Ask a repository admin to enable merge,
-              squash, or rebase merging.
-            </Text>
-          </View>
-        ) : (
-          <MethodPicker
-            methodOptions={methodOptions}
-            method={method}
-            isDisabled={isMutating}
-            onChange={resetForNewMethod}
-          />
-        )}
-        <CommitTitleField
+        <MergeSheetFormBody
+          noMethodsAllowed={noMethodsAllowed}
+          methodOptions={methodOptions}
+          method={method}
+          isMutating={isMutating}
+          onMethodChange={resetForNewMethod}
           titleRef={titleRef}
-          inputRef={titleInputRef}
-          placeholder={defaultCommitTitle(title, number)}
-          isDisabled={isMutating}
-        />
-        <CommitMessageField
+          titleInputRef={titleInputRef}
+          titlePlaceholder={defaultCommitTitle(title, number)}
           messageRef={messageRef}
-          inputRef={messageInputRef}
-          isDisabled={isMutating}
+          messageInputRef={messageInputRef}
+          isHalfDetent={isHalfDetent}
+          showDeleteBranchToggle={showDeleteBranchToggle}
+          deleteBranch={deleteBranch}
+          onDeleteBranchChange={setDeleteBranch}
+          inlineError={inlineError}
+          inlineErrorKind={inlineErrorKind}
+          submitLabel={submitLabel}
+          onConfirm={handleConfirmPress}
+          onDismiss={onDismiss}
         />
-        {showDeleteBranchToggle ? (
-          <DeleteBranchToggle
-            value={deleteBranch}
-            onChange={setDeleteBranch}
-            isDisabled={isMutating}
-          />
-        ) : null}
-        {inlineError && inlineErrorKind !== 'reconnect' ? (
-          <View
-            className="rounded-md border border-destructive bg-red-50 dark:bg-red-950 p-3"
-            accessibilityLiveRegion="polite"
-          >
-            <Text className="text-sm text-destructive">{inlineError}</Text>
-          </View>
-        ) : null}
-        {inlineErrorKind === 'reconnect' ? <PrReviewReconnectNotice /> : null}
       </ScrollView>
-
-      <View className="border-t-[0.5px] border-hair-soft bg-background px-6 pb-6 pt-3">
-        <Button
-          onPress={handleConfirmPress}
-          loading={isMutating}
-          disabled={
-            noMethodsAllowed ||
-            inlineErrorKind === 'non-retryable' ||
-            inlineErrorKind === 'reconnect'
-          }
-          accessibilityLabel={submitLabel}
-        >
-          <Text>{submitLabel}</Text>
-        </Button>
-        <Button
-          variant="ghost"
-          onPress={onDismiss}
-          disabled={isMutating}
-          className="mt-2"
-          accessibilityLabel="Cancel"
-        >
-          <Text>Cancel</Text>
-        </Button>
-      </View>
-    </View>
+    </>
   );
 }

--- a/apps/mobile/src/components/pr-review/pr-form-sheet-chrome.tsx
+++ b/apps/mobile/src/components/pr-review/pr-form-sheet-chrome.tsx
@@ -1,0 +1,77 @@
+// Shared formSheet chrome for PR review sheets.
+//
+// react-native-screens formSheet only honors a pinned header when the screen
+// content's direct children are [header, scroll view] (see picker-sheet.tsx).
+// An extra wrapper, or a third sticky-footer sibling, makes RNS pin the
+// ScrollView full-bleed and overpaint the header. Footer CTAs therefore live
+// as trailing ScrollView content, not as a sticky sibling. Header must stay
+// OUTSIDE the ScrollView so keyboard focus does not scroll the title off-screen.
+//
+// collapsable={false}: keep a stable native subview at index 0 (SheetHeader
+// pattern). No `modal` top inset: the formSheet grabber already clears the
+// top edge; the modal 32pt pad left a transparent band content showed through
+// (that band + parent PR "Go back" is the stray ‹ root cause).
+//
+// Keyboard: ScrollView uses automaticallyAdjustKeyboardInsets. Footers must
+// NOT re-apply the full keyboard height (AppAwareKeyboardPaddingView double-
+// counted and pushed CTAs under the keyboard until the user scrolled). Body
+// fields cap their height while the keyboard is open so the trailing footer
+// still fits in the inset viewport at scroll offset 0.
+
+import { type ReactNode, useEffect, useState } from 'react';
+import { Keyboard, Platform, View } from 'react-native';
+
+import { ScreenHeader } from '@/components/screen-header';
+import { cn } from '@/lib/utils';
+
+export function useFormSheetKeyboardVisible(): boolean {
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const showEvent = Platform.OS === 'ios' ? 'keyboardWillShow' : 'keyboardDidShow';
+    const hideEvent = Platform.OS === 'ios' ? 'keyboardWillHide' : 'keyboardDidHide';
+    const show = Keyboard.addListener(showEvent, () => {
+      setVisible(true);
+    });
+    const hide = Keyboard.addListener(hideEvent, () => {
+      setVisible(false);
+    });
+    return () => {
+      show.remove();
+      hide.remove();
+    };
+  }, []);
+
+  return visible;
+}
+
+export function PrFormSheetHeader(props: { title: string; eyebrow: string; onBack: () => void }) {
+  return (
+    <View collapsable={false} className="border-b border-border bg-background">
+      <ScreenHeader
+        title={props.title}
+        eyebrow={props.eyebrow}
+        onBack={props.onBack}
+        backIcon="close"
+        className="pt-3"
+      />
+    </View>
+  );
+}
+
+/**
+ * Trailing ScrollView footer for formSheets. No keyboard-height padding —
+ * parent ScrollView automaticallyAdjustKeyboardInsets owns that.
+ */
+export function PrFormSheetFooter(props: { children: ReactNode; className?: string }) {
+  return (
+    <View
+      className={cn(
+        'mt-0.5 border-t-[0.5px] border-hair-soft bg-background px-6 pb-1.5 pt-1',
+        props.className
+      )}
+    >
+      {props.children}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/pr-review/pr-review-comment-composer-parts.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-comment-composer-parts.tsx
@@ -5,6 +5,10 @@
 import { type ReactNode, type RefObject } from 'react';
 import { TextInput, View } from 'react-native';
 
+import {
+  PrFormSheetFooter,
+  useFormSheetKeyboardVisible,
+} from '@/components/pr-review/pr-form-sheet-chrome';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
@@ -25,6 +29,7 @@ export function CommentBodyField({
   onChangeText: (value: string) => void;
 }) {
   const colors = useThemeColors();
+  const keyboardVisible = useFormSheetKeyboardVisible();
   return (
     <TextInput
       ref={inputRef}
@@ -37,9 +42,12 @@ export function CommentBodyField({
       multiline
       textAlignVertical="top"
       // Explicit line-height (no `text-center` per the repo's iOS rule).
+      // Compact min-height so half-detent + keyboard-open both keep footer
+      // CTAs on-screen at scroll offset 0; multiline still grows on type.
       className={cn(
-        'min-h-32 rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground',
-        'focus:border-ring'
+        'rounded-md border border-input bg-background px-3 py-1.5 text-sm leading-5 text-foreground',
+        'focus:border-ring',
+        keyboardVisible ? 'max-h-16 min-h-12' : 'min-h-14 max-h-28'
       )}
     />
   );
@@ -63,14 +71,18 @@ export function ComposerFooter({
   onCancel: () => void;
 }): ReactNode {
   return (
-    <View className="border-t-[0.5px] border-hair-soft bg-background px-6 pb-6 pt-3">
+    // Lives inside the formSheet ScrollView (not a sticky sibling).
+    // size=sm + tight footer: half-detent + empty-body error must keep Cancel
+    // above the closed-sheet limit (~874) without scrolling.
+    <PrFormSheetFooter className="pb-1 pt-1">
       {isEdit ? (
-        <Button onPress={onSave} disabled={primaryDisabled} accessibilityLabel="Save">
+        <Button size="sm" onPress={onSave} disabled={primaryDisabled} accessibilityLabel="Save">
           <Text>Save</Text>
         </Button>
       ) : (
         <>
           <Button
+            size="sm"
             onPress={onCommentNow}
             loading={isSubmitting}
             disabled={primaryDisabled}
@@ -79,10 +91,11 @@ export function ComposerFooter({
             <Text>Comment now</Text>
           </Button>
           <Button
+            size="sm"
             variant="secondary"
             onPress={onAddToReview}
             disabled={isSubmitting}
-            className="mt-2"
+            className="mt-0.5"
             accessibilityLabel="Add to review"
           >
             <Text>Add to review</Text>
@@ -90,15 +103,16 @@ export function ComposerFooter({
         </>
       )}
       <Button
+        size="sm"
         variant="ghost"
         onPress={onCancel}
         disabled={isSubmitting}
-        className="mt-2"
+        className="mt-0.5"
         accessibilityLabel="Cancel"
       >
         <Text>Cancel</Text>
       </Button>
-    </View>
+    </PrFormSheetFooter>
   );
 }
 
@@ -123,20 +137,17 @@ export function ContextPreview({
       ? fallbackLineLabel
       : composerRangeLabel(selection.line, selection.startLine);
   const previewText = preferFallback ? '' : (selection?.selectedText ?? '');
+  // Single-line context keeps half-detent + keyboard-open room for CTAs.
   return (
-    <View className="gap-2 rounded-lg border border-hair-soft bg-secondary p-3">
+    <View className="gap-0.5 rounded-lg border border-hair-soft bg-secondary px-3 py-1.5">
       <Text className="font-mono-medium text-[11px] text-muted-foreground" numberOfLines={1}>
         {path} {side} {lineLabel}
       </Text>
       {previewText.length > 0 ? (
-        <Text className="font-mono-medium text-[12px] leading-5 text-foreground" numberOfLines={6}>
+        <Text className="font-mono-medium text-[12px] leading-4 text-foreground" numberOfLines={1}>
           {previewText}
         </Text>
-      ) : (
-        <Text variant="muted" className="text-xs">
-          {preferFallback ? 'Editing a queued comment.' : 'Selected line context will appear here.'}
-        </Text>
-      )}
+      ) : null}
     </View>
   );
 }

--- a/apps/mobile/src/components/pr-review/pr-review-comment-composer-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-comment-composer-screen.tsx
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/react-query';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { type ReactNode, useEffect, useRef } from 'react';
-import { ActivityIndicator, Alert, View } from 'react-native';
+import { ActivityIndicator, Alert, ScrollView, View } from 'react-native';
 
+import { PrFormSheetHeader } from '@/components/pr-review/pr-form-sheet-chrome';
 import { PrReviewCommentComposer } from '@/components/pr-review/pr-review-comment-composer';
 import { QueryError } from '@/components/query-error';
 import { InvalidRouteState } from '@/components/invalid-route-state';
-import { ScreenHeader } from '@/components/screen-header';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { parseComposerParams } from '@/lib/pr-review/comment-composer-params';
 import { usePendingReview } from '@/lib/pr-review/pending-review-provider';
@@ -33,6 +33,8 @@ export function PrReviewCommentComposerScreen() {
   const pendingId = parsed?.pendingId;
   const isEdit = pendingId !== undefined;
   const pendingItem = isEdit ? pending.items.find(item => item.id === pendingId) : undefined;
+  const title = isEdit ? 'Edit comment' : 'Add comment';
+  const eyebrow = parsed ? `${parsed.owner}/${parsed.repo}#${parsed.number}` : '';
 
   // Edit mode is local-only: do not fire getPullRequest and do not gate on it.
   const trpc = useTRPC();
@@ -64,11 +66,9 @@ export function PrReviewCommentComposerScreen() {
     router.back();
   };
 
-  let content: ReactNode = null;
-  if (!parsed) {
-    content = <InvalidRouteState backTo="/(app)/pr-review" />;
-  } else if (isEdit) {
-    content = pendingItem ? (
+  // Happy path: content ScrollView owns the in-scroll header.
+  if (parsed && isEdit && pendingItem) {
+    return (
       <PrReviewCommentComposer
         key={`edit:${pendingItem.id}`}
         owner={parsed.owner}
@@ -80,31 +80,16 @@ export function PrReviewCommentComposerScreen() {
         line={parsed.line}
         startLine={parsed.startLine}
         initialBody={pendingItem.body}
+        title={title}
+        eyebrow={eyebrow}
         onDismiss={dismiss}
       />
-    ) : null;
-  } else if (pr.isLoading) {
-    content = (
-      <View className="flex-1 items-center justify-center">
-        <ActivityIndicator size="small" color={colors.mutedForeground} />
-      </View>
     );
-  } else if (pr.isError || !pr.data) {
-    content = (
-      <View className="flex-1">
-        <QueryError
-          variant="server"
-          title="Couldn't load the comment composer"
-          onRetry={() => {
-            void pr.refetch();
-          }}
-          isRetrying={pr.isFetching}
-        />
-      </View>
-    );
-  } else {
+  }
+
+  if (parsed && !isEdit && pr.data) {
     const createKey = [parsed.path, parsed.line, parsed.side, parsed.startLine ?? ''].join(':');
-    content = (
+    return (
       <PrReviewCommentComposer
         key={`create:${createKey}`}
         owner={parsed.owner}
@@ -115,20 +100,43 @@ export function PrReviewCommentComposerScreen() {
         side={parsed.side}
         line={parsed.line}
         startLine={parsed.startLine}
+        title={title}
+        eyebrow={eyebrow}
         onDismiss={dismiss}
       />
     );
   }
 
-  return (
-    <View className="flex-1 bg-background">
-      <ScreenHeader
-        title={isEdit ? 'Edit comment' : 'Add comment'}
-        eyebrow={parsed ? `${parsed.owner}/${parsed.repo}#${parsed.number}` : ''}
-        modal
-        onBack={dismiss}
+  let body: ReactNode = null;
+  if (!parsed) {
+    body = <InvalidRouteState backTo="/(app)/pr-review" />;
+  } else if (isEdit) {
+    body = null;
+  } else if (pr.isLoading) {
+    body = (
+      <View className="flex-1 items-center justify-center py-16">
+        <ActivityIndicator size="small" color={colors.mutedForeground} />
+      </View>
+    );
+  } else {
+    body = (
+      <QueryError
+        variant="server"
+        title="Couldn't load the comment composer"
+        onRetry={() => {
+          void pr.refetch();
+        }}
+        isRetrying={pr.isFetching}
       />
-      {content}
-    </View>
+    );
+  }
+
+  return (
+    <>
+      <PrFormSheetHeader title={title} eyebrow={eyebrow} onBack={dismiss} />
+      <ScrollView className="flex-1 bg-background" contentContainerClassName="grow">
+        {body}
+      </ScrollView>
+    </>
   );
 }

--- a/apps/mobile/src/components/pr-review/pr-review-comment-composer.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-comment-composer.tsx
@@ -7,8 +7,12 @@
 import * as Crypto from 'expo-crypto';
 import * as Haptics from 'expo-haptics';
 import { useEffect, useRef, useState } from 'react';
-import { Alert, ScrollView, type TextInput, View } from 'react-native';
+import { Alert, Keyboard, ScrollView, type TextInput, View } from 'react-native';
 
+import {
+  PrFormSheetHeader,
+  useFormSheetKeyboardVisible,
+} from '@/components/pr-review/pr-form-sheet-chrome';
 import {
   CommentBodyField,
   ComposerFooter,
@@ -40,6 +44,8 @@ type PrReviewCommentComposerProps = Readonly<{
   startLine?: number;
   /** Seeded body (edit) / empty (create). Also the dirty-check baseline. */
   initialBody?: string;
+  title: string;
+  eyebrow: string;
   onDismiss: () => void;
 }>;
 
@@ -54,6 +60,8 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
     line,
     startLine,
     initialBody = '',
+    title,
+    eyebrow,
     onDismiss,
   } = props;
   const pending = usePendingReview();
@@ -67,6 +75,7 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
   const bodyRef = useRef<string>(initialBody);
   const bodyBaselineRef = useRef<string>(initialBody);
   const bodyInputRef = useRef<TextInput | null>(null);
+  const scrollRef = useRef<ScrollView | null>(null);
   const [hasBody, setHasBody] = useState(() => initialBody.trim().length > 0);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [inlineErrorKind, setInlineErrorKind] = useState<
@@ -85,6 +94,20 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
     setInlineError(display.message);
     setInlineErrorKind(display.kind);
   }, [createComment.error, isEdit]);
+
+  // automaticallyAdjustKeyboardInsets can scroll the focused field under the
+  // pinned header. Compact kb layout fits at offset 0 — snap back so body +
+  // footer CTAs stay in the inset viewport together.
+  useEffect(() => {
+    const sub = Keyboard.addListener('keyboardDidShow', () => {
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ y: 0, animated: false });
+      });
+    });
+    return () => {
+      sub.remove();
+    };
+  }, []);
 
   function clearBadRequestOnBodyEdit() {
     // bad-request clears on body change; forbidden stays for the session.
@@ -203,6 +226,7 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
     bodyInputRef.current?.focus();
   }
 
+  const keyboardVisible = useFormSheetKeyboardVisible();
   const suggestionAvailable = !isEdit && side === 'RIGHT' && Boolean(selection?.selectedText);
   let suggestionDisabledReason: string | null = null;
   if (!isEdit) {
@@ -212,6 +236,9 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
       suggestionDisabledReason = 'Tap a diff line to enable suggestions.';
     }
   }
+  // Half-detent needs every row for footer CTAs; surface Insert only once the
+  // keyboard has expanded the sheet and compacted the body field.
+  const showInsertSuggestion = suggestionAvailable && keyboardVisible;
 
   const primaryDisabled =
     isSubmitting ||
@@ -220,66 +247,73 @@ export function PrReviewCommentComposer(props: PrReviewCommentComposerProps) {
     (!isEdit && inlineErrorKind === 'bad-request') ||
     (isEdit && !hasBody);
 
+  // PickerSheet invariant: [header, ScrollView] as direct children (no
+  // wrapper View, no sticky-footer sibling). Footer is trailing scroll
+  // content so keyboard insets + AppAwareKeyboardPaddingView keep CTAs
+  // tappable without overpainting the pinned header.
   return (
-    <View className="flex-1 bg-background">
+    <>
+      <PrFormSheetHeader title={title} eyebrow={eyebrow} onBack={onDismiss} />
       <ScrollView
-        className="flex-1"
-        contentContainerClassName="gap-4 px-6 pb-8 pt-2"
+        ref={scrollRef}
+        className="flex-1 bg-background"
+        contentContainerClassName="pb-1"
         keyboardShouldPersistTaps="handled"
         automaticallyAdjustKeyboardInsets
         keyboardDismissMode="interactive"
       >
-        <ContextPreview
-          selection={selection}
-          fallbackPath={path}
-          fallbackLineLabel={lineRangeLabel}
-          fallbackSide={side}
-          preferFallback={isEdit}
-        />
-        <View className="gap-2">
-          <Text className="text-sm font-medium text-foreground">Comment</Text>
-          <CommentBodyField
-            inputRef={bodyInputRef}
-            isDisabled={isSubmitting}
-            defaultValue={initialBody}
-            onChangeText={handleBodyChange}
+        <View className="gap-1.5 px-6 pt-1.5">
+          <ContextPreview
+            selection={selection}
+            fallbackPath={path}
+            fallbackLineLabel={lineRangeLabel}
+            fallbackSide={side}
+            preferFallback={isEdit}
           />
-          {!isEdit ? (
-            <Button
-              variant="ghost"
-              size="sm"
-              onPress={handleInsertSuggestion}
-              disabled={!suggestionAvailable}
-              accessibilityLabel="Insert a code suggestion"
-              accessibilityHint={suggestionDisabledReason ?? undefined}
-              className="self-start"
-            >
-              <Text>Insert suggestion</Text>
-            </Button>
-          ) : null}
-        </View>
-        {inlineError && inlineErrorKind !== 'reconnect' ? (
-          <View
-            className="rounded-md border border-destructive bg-red-50 dark:bg-red-950 p-3"
-            accessibilityLiveRegion="polite"
-          >
-            <Text className="text-sm text-destructive">{inlineError}</Text>
+          <View className="gap-1">
+            <Text className="text-xs font-medium text-foreground">Comment</Text>
+            <CommentBodyField
+              inputRef={bodyInputRef}
+              isDisabled={isSubmitting}
+              defaultValue={initialBody}
+              onChangeText={handleBodyChange}
+            />
+            {showInsertSuggestion ? (
+              <Button
+                variant="ghost"
+                size="sm"
+                onPress={handleInsertSuggestion}
+                accessibilityLabel="Insert a code suggestion"
+                accessibilityHint={suggestionDisabledReason ?? undefined}
+                className="self-start"
+              >
+                <Text>Insert suggestion</Text>
+              </Button>
+            ) : null}
           </View>
-        ) : null}
-        {inlineErrorKind === 'reconnect' ? <PrReviewReconnectNotice /> : null}
-      </ScrollView>
+          {inlineError && inlineErrorKind !== 'reconnect' ? (
+            <View
+              className="rounded-md border border-destructive bg-red-50 dark:bg-red-950 px-2.5 py-1.5"
+              accessibilityLiveRegion="polite"
+            >
+              <Text className="text-xs text-destructive">{inlineError}</Text>
+            </View>
+          ) : null}
+          {inlineErrorKind === 'reconnect' ? <PrReviewReconnectNotice /> : null}
+        </View>
 
-      <ComposerFooter
-        isEdit={isEdit}
-        isSubmitting={isSubmitting}
-        primaryDisabled={primaryDisabled}
-        onSave={handleSave}
-        onCommentNow={() => {
-          void handleCommentNow();
-        }}
-        onAddToReview={handleAddToReview}
-        onCancel={handleCancel}
-      />
-    </View>
+        <ComposerFooter
+          isEdit={isEdit}
+          isSubmitting={isSubmitting}
+          primaryDisabled={primaryDisabled}
+          onSave={handleSave}
+          onCommentNow={() => {
+            void handleCommentNow();
+          }}
+          onAddToReview={handleAddToReview}
+          onCancel={handleCancel}
+        />
+      </ScrollView>
+    </>
   );
 }

--- a/apps/mobile/src/components/pr-review/pr-review-entry-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-entry-screen.tsx
@@ -121,7 +121,6 @@ export function PrReviewEntryScreen() {
   };
 
   const slotState = selectPrLinkHelperSlotState({
-    hasInput,
     message: helperMessage,
   });
   const isInvalid = helperMessage === 'invalid';
@@ -133,12 +132,6 @@ export function PrReviewEntryScreen() {
     helperContent = (
       <Text variant="muted" className="text-sm">
         {PR_LINK_HELPER_CLIPBOARD_EMPTY_COPY}
-      </Text>
-    );
-  } else if (slotState === 'hint') {
-    helperContent = (
-      <Text variant="muted" className="text-sm">
-        Paste a link like {URL_PLACEHOLDER}
       </Text>
     );
   }

--- a/apps/mobile/src/components/pr-review/pr-review-merge-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-merge-screen.tsx
@@ -1,10 +1,10 @@
 import { useQuery } from '@tanstack/react-query';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { type ReactNode } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
 
+import { PrFormSheetHeader } from '@/components/pr-review/pr-form-sheet-chrome';
 import { QueryError } from '@/components/query-error';
-import { ScreenHeader } from '@/components/screen-header';
 import { PrMergeSheet } from '@/components/pr-review/merge/pr-merge-sheet';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { type PrMergeMethod } from '@/lib/pr-review/merge/merge-blocked-reasons';
@@ -38,6 +38,11 @@ export function PrReviewMergeScreen() {
   const method: PrMergeMethod = MERGE_METHODS.has(params.method as PrMergeMethod)
     ? (params.method as PrMergeMethod)
     : 'merge';
+  const sheetTitle = mode === 'enable-auto-merge' ? 'Enable auto-merge' : 'Merge pull request';
+  const eyebrow = `${owner}/${repo}#${rawNumber}`;
+  const dismiss = () => {
+    router.back();
+  };
 
   const trpc = useTRPC();
   const pr = useQuery(
@@ -47,28 +52,8 @@ export function PrReviewMergeScreen() {
     )
   );
 
-  let content: ReactNode = null;
-  if (pr.isLoading) {
-    content = (
-      <View className="flex-1 items-center justify-center">
-        <ActivityIndicator size="small" color={colors.mutedForeground} />
-      </View>
-    );
-  } else if (pr.isError || !pr.data) {
-    content = (
-      <View className="flex-1">
-        <QueryError
-          variant="server"
-          title="Couldn't load merge options"
-          onRetry={() => {
-            void pr.refetch();
-          }}
-          isRetrying={pr.isFetching}
-        />
-      </View>
-    );
-  } else {
-    content = (
+  if (pr.data) {
+    return (
       <PrMergeSheet
         owner={owner}
         repoName={repo}
@@ -83,27 +68,37 @@ export function PrReviewMergeScreen() {
         repo={pr.data.repo}
         initialMethod={method}
         mode={mode}
+        sheetTitle={sheetTitle}
+        eyebrow={eyebrow}
         onRefetch={async () => {
           await pr.refetch();
         }}
-        onDismiss={() => {
-          router.back();
-        }}
+        onDismiss={dismiss}
       />
     );
   }
 
-  return (
-    <View className="flex-1 bg-background">
-      <ScreenHeader
-        title={mode === 'enable-auto-merge' ? 'Enable auto-merge' : 'Merge pull request'}
-        eyebrow={`${owner}/${repo}#${rawNumber}`}
-        modal
-        onBack={() => {
-          router.back();
-        }}
-      />
-      {content}
+  const body: ReactNode = pr.isLoading ? (
+    <View className="flex-1 items-center justify-center py-16">
+      <ActivityIndicator size="small" color={colors.mutedForeground} />
     </View>
+  ) : (
+    <QueryError
+      variant="server"
+      title="Couldn't load merge options"
+      onRetry={() => {
+        void pr.refetch();
+      }}
+      isRetrying={pr.isFetching}
+    />
+  );
+
+  return (
+    <>
+      <PrFormSheetHeader title={sheetTitle} eyebrow={eyebrow} onBack={dismiss} />
+      <ScrollView className="flex-1 bg-background" contentContainerClassName="grow">
+        {body}
+      </ScrollView>
+    </>
   );
 }

--- a/apps/mobile/src/components/pr-review/pr-review-pending-comment-row.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-pending-comment-row.tsx
@@ -6,6 +6,7 @@ import { type RefObject } from 'react';
 import { Trash2 } from 'lucide-react-native';
 import { Pressable, TextInput, View } from 'react-native';
 
+import { useFormSheetKeyboardVisible } from '@/components/pr-review/pr-form-sheet-chrome';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { type PendingReviewItem } from '@/lib/pr-review/pending-review-provider';
@@ -28,18 +29,18 @@ export function PrReviewPendingCommentRow({
   const location = pendingCommentLocationLabel(item);
 
   return (
-    <View className="flex-row items-start gap-2 border-t border-hair-soft pt-3">
+    <View className="flex-row items-center gap-2 border-t border-hair-soft pt-2">
       <Pressable
         onPress={onPress}
         disabled={disabled}
         accessibilityRole="button"
         accessibilityLabel={`Edit pending comment on ${location}`}
-        className="min-h-11 flex-1 gap-1 active:opacity-70"
+        className="min-h-9 flex-1 gap-0.5 active:opacity-70"
       >
         <Text className="font-mono-medium text-[11px] text-muted-foreground" numberOfLines={1}>
           {location}
         </Text>
-        <Text className="text-sm leading-5 text-foreground" numberOfLines={2}>
+        <Text className="text-xs leading-4 text-foreground" numberOfLines={1}>
           {item.body.trim().length > 0 ? item.body : '(empty)'}
         </Text>
       </Pressable>
@@ -49,9 +50,9 @@ export function PrReviewPendingCommentRow({
         hitSlop={8}
         accessibilityRole="button"
         accessibilityLabel={`Delete pending comment on ${location}`}
-        className="h-9 w-9 items-center justify-center rounded-md active:opacity-60"
+        className="h-8 w-8 items-center justify-center rounded-md active:opacity-60"
       >
-        <Trash2 size={16} color={colors.mutedForeground} />
+        <Trash2 size={14} color={colors.mutedForeground} />
       </Pressable>
     </View>
   );
@@ -104,6 +105,7 @@ export function ReviewSummaryField({
   onChange: () => void;
 }) {
   const colors = useThemeColors();
+  const keyboardVisible = useFormSheetKeyboardVisible();
   return (
     <TextInput
       ref={inputRef}
@@ -118,9 +120,11 @@ export function ReviewSummaryField({
       }}
       multiline
       textAlignVertical="top"
+      // Compact so half-detent and keyboard-open keep footer CTAs at y=0.
       className={cn(
-        'min-h-24 rounded-md border border-input bg-background px-3 py-2.5 text-sm leading-5 text-foreground',
-        'focus:border-ring'
+        'rounded-md border border-input bg-background px-3 py-2 text-sm leading-5 text-foreground',
+        'focus:border-ring',
+        keyboardVisible ? 'max-h-16 min-h-12' : 'min-h-14 max-h-24'
       )}
     />
   );

--- a/apps/mobile/src/components/pr-review/pr-review-review-submit-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-review-submit-screen.tsx
@@ -1,11 +1,11 @@
 import { useQuery } from '@tanstack/react-query';
 import { useLocalSearchParams, useRouter } from 'expo-router';
 import { type ReactNode } from 'react';
-import { ActivityIndicator, View } from 'react-native';
+import { ActivityIndicator, ScrollView, View } from 'react-native';
 
+import { PrFormSheetHeader } from '@/components/pr-review/pr-form-sheet-chrome';
 import { PrReviewSubmit } from '@/components/pr-review/pr-review-submit';
 import { QueryError } from '@/components/query-error';
-import { ScreenHeader } from '@/components/screen-header';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { parseParam } from '@/lib/route-params';
 import { useTRPC } from '@/lib/trpc';
@@ -24,6 +24,11 @@ export function PrReviewReviewSubmitScreen() {
   const repo = parseParam(params.repo) ?? '';
   const rawNumber = parseParam(params.number) ?? '';
   const number = Number.parseInt(rawNumber, 10);
+  const title = 'Submit review';
+  const eyebrow = `${owner}/${repo}#${rawNumber}`;
+  const dismiss = () => {
+    router.back();
+  };
 
   const trpc = useTRPC();
   const pr = useQuery(
@@ -33,51 +38,41 @@ export function PrReviewReviewSubmitScreen() {
     )
   );
 
-  let content: ReactNode = null;
-  if (pr.isLoading) {
-    content = (
-      <View className="flex-1 items-center justify-center">
-        <ActivityIndicator size="small" color={colors.mutedForeground} />
-      </View>
-    );
-  } else if (pr.isError || !pr.data) {
-    content = (
-      <View className="flex-1">
-        <QueryError
-          variant="server"
-          title="Couldn't load review submission"
-          onRetry={() => {
-            void pr.refetch();
-          }}
-          isRetrying={pr.isFetching}
-        />
-      </View>
-    );
-  } else {
-    content = (
+  if (pr.data) {
+    return (
       <PrReviewSubmit
         owner={owner}
         repo={repo}
         number={number}
         headSha={pr.data.headSha}
-        onDismiss={() => {
-          router.back();
-        }}
+        title={title}
+        eyebrow={eyebrow}
+        onDismiss={dismiss}
       />
     );
   }
 
-  return (
-    <View className="flex-1 bg-background">
-      <ScreenHeader
-        title="Submit review"
-        eyebrow={`${owner}/${repo}#${rawNumber}`}
-        modal
-        onBack={() => {
-          router.back();
-        }}
-      />
-      {content}
+  const body: ReactNode = pr.isLoading ? (
+    <View className="flex-1 items-center justify-center py-16">
+      <ActivityIndicator size="small" color={colors.mutedForeground} />
     </View>
+  ) : (
+    <QueryError
+      variant="server"
+      title="Couldn't load review submission"
+      onRetry={() => {
+        void pr.refetch();
+      }}
+      isRetrying={pr.isFetching}
+    />
+  );
+
+  return (
+    <>
+      <PrFormSheetHeader title={title} eyebrow={eyebrow} onBack={dismiss} />
+      <ScrollView className="flex-1 bg-background" contentContainerClassName="grow">
+        {body}
+      </ScrollView>
+    </>
   );
 }

--- a/apps/mobile/src/components/pr-review/pr-review-submit.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-submit.tsx
@@ -9,10 +9,14 @@
 import * as Haptics from 'expo-haptics';
 import { type Href, useRouter } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
-import { Alert, ScrollView, type TextInput, View } from 'react-native';
+import { Alert, Keyboard, Pressable, ScrollView, type TextInput, View } from 'react-native';
 
+import {
+  PrFormSheetFooter,
+  PrFormSheetHeader,
+  useFormSheetKeyboardVisible,
+} from '@/components/pr-review/pr-form-sheet-chrome';
 import { Button } from '@/components/ui/button';
-import { PillGroup } from '@/components/security-agent/settings-pill-group';
 import { Text } from '@/components/ui/text';
 import {
   PendingQueueHint,
@@ -28,6 +32,7 @@ import { classifyPrReviewMutationError } from '@/lib/pr-review/classify-pr-revie
 import { mutationErrorDisplay } from '@/lib/pr-review/mutation-error-display';
 import { type PendingReviewItem, usePendingReview } from '@/lib/pr-review/pending-review-provider';
 import { useSubmitReviewMutation } from '@/lib/pr-review/use-pr-review-mutations';
+import { cn } from '@/lib/utils';
 
 const COMMENT_COMPOSER_PATH = '/(app)/pr-review/[owner]/[repo]/[number]/comment-composer' as const;
 
@@ -36,6 +41,8 @@ type PrReviewSubmitProps = Readonly<{
   repo: string;
   number: number;
   headSha: string;
+  title: string;
+  eyebrow: string;
   onDismiss: () => void;
 }>;
 
@@ -46,7 +53,7 @@ const EVENT_OPTIONS: readonly { value: ReviewEvent; label: string }[] = [
 ];
 
 export function PrReviewSubmit(props: PrReviewSubmitProps) {
-  const { owner, repo, number, headSha, onDismiss } = props;
+  const { owner, repo, number, headSha, title, eyebrow, onDismiss } = props;
   const router = useRouter();
   const pending = usePendingReview();
   const submitReview = useSubmitReviewMutation({ owner, repo, number });
@@ -59,6 +66,7 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
 
   const bodyRef = useRef<string>('');
   const bodyInputRef = useRef<TextInput | null>(null);
+  const scrollRef = useRef<ScrollView | null>(null);
 
   const isSubmitting = submitReview.isPending;
   const queuedCount = pending.items.length;
@@ -72,6 +80,17 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
       setInlineErrorKind(display.kind);
     }
   }, [submitReview.error]);
+
+  useEffect(() => {
+    const sub = Keyboard.addListener('keyboardDidShow', () => {
+      requestAnimationFrame(() => {
+        scrollRef.current?.scrollTo({ y: 0, animated: false });
+      });
+    });
+    return () => {
+      sub.remove();
+    };
+  }, []);
 
   function clearRecoverableError() {
     // bad-request / retryable clear on edit; forbidden stays for the session.
@@ -141,90 +160,151 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
     inlineErrorKind === 'forbidden' ||
     inlineErrorKind === 'reconnect';
 
+  const keyboardVisible = useFormSheetKeyboardVisible();
+  // Keyboard-open viewport is tight; keep count, hide per-item rows so
+  // Submit + Cancel stay above the keyboard at scroll offset 0.
+  const showPendingRows = !keyboardVisible;
+
+  // PickerSheet invariant: [header, ScrollView]; footer is trailing content.
   return (
-    <View className="flex-1 bg-background">
+    <>
+      <PrFormSheetHeader title={title} eyebrow={eyebrow} onBack={onDismiss} />
       <ScrollView
-        className="flex-1"
-        contentContainerClassName="gap-4 px-6 pb-8 pt-2"
+        ref={scrollRef}
+        className="flex-1 bg-background"
+        contentContainerClassName="pb-2"
         keyboardShouldPersistTaps="handled"
         automaticallyAdjustKeyboardInsets
         keyboardDismissMode="interactive"
       >
-        <PillGroup
-          label="Review event"
-          options={EVENT_OPTIONS}
-          value={event}
-          disabled={isSubmitting}
-          onChange={next => {
-            setEvent(next);
-            clearRecoverableError();
-          }}
-        />
-        <View className="gap-2">
-          <Text className="text-sm font-medium text-foreground">Summary (optional)</Text>
-          <ReviewSummaryField
-            bodyRef={bodyRef}
-            inputRef={bodyInputRef}
-            isDisabled={isSubmitting}
-            onChange={clearRecoverableError}
+        <View className="gap-2 px-6 pt-2">
+          <ReviewEventChips
+            value={event}
+            disabled={isSubmitting}
+            onChange={next => {
+              setEvent(next);
+              clearRecoverableError();
+            }}
           />
-        </View>
-
-        <View className="gap-2 rounded-lg border border-hair-soft bg-secondary p-3">
-          <Text className="text-sm font-medium text-foreground">
-            {queuedCount} pending {queuedCount === 1 ? 'comment' : 'comments'}
-          </Text>
-          <PendingQueueHint queuedCount={queuedCount} hasStaleItems={hasStaleItems} />
-          {pending.items.map(item => (
-            <PrReviewPendingCommentRow
-              key={item.id}
-              item={item}
-              disabled={isSubmitting}
-              onPress={() => {
-                openEditComposer(item);
-              }}
-              onDelete={() => {
-                confirmDelete(item);
-              }}
+          <View className="gap-1.5">
+            <Text className="text-sm font-medium text-foreground">Summary (optional)</Text>
+            <ReviewSummaryField
+              bodyRef={bodyRef}
+              inputRef={bodyInputRef}
+              isDisabled={isSubmitting}
+              onChange={clearRecoverableError}
             />
-          ))}
+          </View>
+
+          <View className="gap-1 rounded-lg border border-hair-soft bg-secondary px-3 py-1.5">
+            <Text className="text-sm font-medium text-foreground">
+              {queuedCount} pending {queuedCount === 1 ? 'comment' : 'comments'}
+            </Text>
+            {/* Hint only when empty/stale — skips the long happy-path line that
+                pushed footer CTAs below half-detent. */}
+            {!keyboardVisible && (queuedCount === 0 || hasStaleItems) ? (
+              <PendingQueueHint queuedCount={queuedCount} hasStaleItems={hasStaleItems} />
+            ) : null}
+            {showPendingRows
+              ? pending.items.map(item => (
+                  <PrReviewPendingCommentRow
+                    key={item.id}
+                    item={item}
+                    disabled={isSubmitting}
+                    onPress={() => {
+                      openEditComposer(item);
+                    }}
+                    onDelete={() => {
+                      confirmDelete(item);
+                    }}
+                  />
+                ))
+              : null}
+          </View>
+
+          {inlineError && inlineErrorKind !== 'reconnect' ? (
+            <View
+              className="rounded-md border border-destructive bg-red-50 dark:bg-red-950 px-2.5 py-2"
+              accessibilityLiveRegion="polite"
+            >
+              <Text className="text-xs text-destructive">{inlineError}</Text>
+            </View>
+          ) : null}
+          {inlineErrorKind === 'reconnect' ? <PrReviewReconnectNotice /> : null}
         </View>
 
-        {inlineError && inlineErrorKind !== 'reconnect' ? (
-          <View
-            className="rounded-md border border-destructive bg-red-50 dark:bg-red-950 p-3"
-            accessibilityLiveRegion="polite"
+        <PrFormSheetFooter>
+          <Button
+            onPress={() => {
+              void handleSubmit();
+            }}
+            loading={isSubmitting}
+            disabled={submitDisabled}
+            accessibilityLabel="Submit review"
           >
-            <Text className="text-sm text-destructive">{inlineError}</Text>
-          </View>
-        ) : null}
-        {inlineErrorKind === 'reconnect' ? <PrReviewReconnectNotice /> : null}
+            <Text>Submit review</Text>
+          </Button>
+          <Button
+            variant="ghost"
+            onPress={() => {
+              if (!isSubmitting) {
+                onDismiss();
+              }
+            }}
+            disabled={isSubmitting}
+            className="mt-1"
+            accessibilityLabel="Cancel"
+          >
+            <Text>Cancel</Text>
+          </Button>
+        </PrFormSheetFooter>
       </ScrollView>
+    </>
+  );
+}
 
-      <View className="border-t-[0.5px] border-hair-soft bg-background px-6 pb-6 pt-3">
-        <Button
-          onPress={() => {
-            void handleSubmit();
-          }}
-          loading={isSubmitting}
-          disabled={submitDisabled}
-          accessibilityLabel="Submit review"
-        >
-          <Text>Submit review</Text>
-        </Button>
-        <Button
-          variant="ghost"
-          onPress={() => {
-            if (!isSubmitting) {
-              onDismiss();
-            }
-          }}
-          disabled={isSubmitting}
-          className="mt-2"
-          accessibilityLabel="Cancel"
-        >
-          <Text>Cancel</Text>
-        </Button>
+/** Horizontal event chips — vertical PillGroup is too tall for half-detent. */
+function ReviewEventChips(props: {
+  value: ReviewEvent;
+  disabled: boolean;
+  onChange: (next: ReviewEvent) => void;
+}) {
+  return (
+    <View className="gap-1.5">
+      <Text className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+        Review event
+      </Text>
+      <View className="flex-row flex-wrap gap-1.5">
+        {EVENT_OPTIONS.map(option => {
+          const active = props.value === option.value;
+          return (
+            <Pressable
+              key={option.value}
+              disabled={props.disabled}
+              onPress={() => {
+                void Haptics.selectionAsync();
+                props.onChange(option.value);
+              }}
+              accessibilityRole="radio"
+              accessibilityState={{ selected: active, disabled: props.disabled }}
+              accessibilityLabel={option.label}
+              className={cn(
+                'min-h-9 items-center justify-center rounded-full border px-3 py-1.5 active:opacity-70',
+                active ? 'border-primary bg-primary' : 'border-border bg-secondary',
+                props.disabled && 'opacity-50'
+              )}
+            >
+              <Text
+                className={cn(
+                  'text-xs font-medium',
+                  active ? 'text-primary-foreground' : 'text-foreground'
+                )}
+              >
+                {option.label}
+              </Text>
+            </Pressable>
+          );
+        })}
       </View>
     </View>
   );

--- a/apps/mobile/src/lib/pr-review/pr-link-helper-slot.test.ts
+++ b/apps/mobile/src/lib/pr-review/pr-link-helper-slot.test.ts
@@ -7,34 +7,22 @@ import {
 } from './pr-link-helper-slot';
 
 describe('selectPrLinkHelperSlotState', () => {
-  it('returns hint when the field is empty and no message is active', () => {
-    expect(selectPrLinkHelperSlotState({ hasInput: false, message: null })).toBe('hint');
+  it('returns none when no message is active', () => {
+    expect(selectPrLinkHelperSlotState({ message: null })).toBe('none');
   });
 
-  it('returns none when the field has text and no message is active', () => {
-    expect(selectPrLinkHelperSlotState({ hasInput: true, message: null })).toBe('none');
+  it('returns invalid when the invalid message is active', () => {
+    expect(selectPrLinkHelperSlotState({ message: 'invalid' })).toBe('invalid');
   });
 
-  it('returns invalid when the invalid message is active, regardless of input', () => {
-    expect(selectPrLinkHelperSlotState({ hasInput: false, message: 'invalid' })).toBe('invalid');
-    expect(selectPrLinkHelperSlotState({ hasInput: true, message: 'invalid' })).toBe('invalid');
+  it('returns clipboard-empty when that message is active', () => {
+    expect(selectPrLinkHelperSlotState({ message: 'clipboard-empty' })).toBe('clipboard-empty');
   });
 
-  it('returns clipboard-empty when that message is active, regardless of input', () => {
-    expect(selectPrLinkHelperSlotState({ hasInput: false, message: 'clipboard-empty' })).toBe(
-      'clipboard-empty'
-    );
-    expect(selectPrLinkHelperSlotState({ hasInput: true, message: 'clipboard-empty' })).toBe(
-      'clipboard-empty'
-    );
-  });
-
-  it('gives messages priority over hint and none (last-set wins at the call site)', () => {
+  it('gives messages priority over none (last-set wins at the call site)', () => {
     // Single message field — whichever the UI last set is what we select.
-    expect(selectPrLinkHelperSlotState({ hasInput: false, message: 'invalid' })).toBe('invalid');
-    expect(selectPrLinkHelperSlotState({ hasInput: false, message: 'clipboard-empty' })).toBe(
-      'clipboard-empty'
-    );
+    expect(selectPrLinkHelperSlotState({ message: 'invalid' })).toBe('invalid');
+    expect(selectPrLinkHelperSlotState({ message: 'clipboard-empty' })).toBe('clipboard-empty');
   });
 
   it('exports the pinned helper copy strings', () => {

--- a/apps/mobile/src/lib/pr-review/pr-link-helper-slot.ts
+++ b/apps/mobile/src/lib/pr-review/pr-link-helper-slot.ts
@@ -1,10 +1,8 @@
 export type PrLinkHelperMessage = 'invalid' | 'clipboard-empty';
 
-type PrLinkHelperSlotState = 'invalid' | 'clipboard-empty' | 'hint' | 'none';
+type PrLinkHelperSlotState = 'invalid' | 'clipboard-empty' | 'none';
 
 type PrLinkHelperSlotInput = {
-  /** Whether the PR-link field currently has any text. */
-  readonly hasInput: boolean;
   /**
    * Active transient message. `invalid` and `clipboard-empty` are mutually
    * exclusive at the call site (last-set wins); `null` means no message.
@@ -15,10 +13,10 @@ type PrLinkHelperSlotInput = {
 /**
  * Select the reserved-height helper-slot content for the PR-link entry field.
  *
- * Priority: active message (invalid / clipboard-empty) wins over hint/none.
- * Hint only when the field is empty and no message is active; none when the
- * field has text and no message is active. The slot always keeps fixed height
- * in the UI regardless of which state is selected.
+ * Priority: active message (invalid / clipboard-empty) wins over none.
+ * No active message selects none — the input placeholder already shows the
+ * example URL. The slot always keeps fixed height in the UI regardless of
+ * which state is selected.
  */
 export function selectPrLinkHelperSlotState(input: PrLinkHelperSlotInput): PrLinkHelperSlotState {
   if (input.message === 'invalid') {
@@ -26,9 +24,6 @@ export function selectPrLinkHelperSlotState(input: PrLinkHelperSlotInput): PrLin
   }
   if (input.message === 'clipboard-empty') {
     return 'clipboard-empty';
-  }
-  if (!input.hasInput) {
-    return 'hint';
   }
   return 'none';
 }

--- a/services/cloud-agent-next/Dockerfile
+++ b/services/cloud-agent-next/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/cloudflare/sandbox:0.12.1
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.54"
+ARG KILOCODE_CLI_VERSION="7.3.63"
 
 # Install latest stable git + git-lfs from the git-core PPA, GitHub CLI, and supporting tools.
 # The default Ubuntu git (2.34.1 on 22.04) is outdated; the git-core PPA ships the latest

--- a/services/cloud-agent-next/Dockerfile.dev
+++ b/services/cloud-agent-next/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM docker.io/cloudflare/sandbox:0.12.1
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.54"
+ARG KILOCODE_CLI_VERSION="7.3.63"
 
 # Build the kilo binary:
 #   cd ~/projects/kilocode-backend/cloud-agent

--- a/services/cloud-agent-next/Dockerfile.dind
+++ b/services/cloud-agent-next/Dockerfile.dind
@@ -9,7 +9,7 @@ USER root
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.54"
+ARG KILOCODE_CLI_VERSION="7.3.63"
 
 # Cloudflare Containers run without root privileges, so Docker must run in
 # rootless mode. The Sandbox SDK server is copied into this image so the

--- a/services/cloud-agent-next/src/kilo/devcontainer.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.ts
@@ -148,7 +148,7 @@ function buildDevContainerTrustEnv(sessionHome: string): Record<string, string> 
  * `wrangler.jsonc#image_vars` so the kilo running in the dev container
  * matches the one we use on the outer sandbox.
  */
-export const KILO_CLI_VERSION = '7.3.54';
+export const KILO_CLI_VERSION = '7.3.63';
 
 const DEVCONTAINER_RUNTIME_BUN_VERSION = '1.3.14';
 const DEVCONTAINER_RUNTIME_BOOTSTRAP_TIMEOUT_MS = 10 * 60 * 1000;

--- a/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
+++ b/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
@@ -17,7 +17,7 @@ export type SlashCommandInfo = {
  *
  * Regenerate with `pnpm --filter cloud-agent-next update-default-slash-commands`.
  */
-export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.54';
+export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.63';
 
 /**
  * Default slash command catalog used when no live wrapper-reported catalog is

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -161,7 +161,7 @@
         "disk_mb": 20000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.3.63",
       },
       "max_instances": 200,
       "rollout_active_grace_period": 1800,
@@ -175,7 +175,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.3.63",
       },
       "max_instances": 150,
       "rollout_active_grace_period": 1800,
@@ -189,7 +189,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.3.63",
       },
       "max_instances": 20,
       "rollout_active_grace_period": 1800,
@@ -203,7 +203,7 @@
         "disk_mb": 8000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.3.63",
       },
       "max_instances": 500,
       "rollout_active_grace_period": 1800,
@@ -217,7 +217,7 @@
         "disk_mb": 20000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.3.63",
       },
       "max_instances": 750,
       "rollout_active_grace_period": 1800,
@@ -231,7 +231,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.3.63",
       },
       "max_instances": 300,
       "rollout_active_grace_period": 1800,
@@ -245,7 +245,7 @@
         "disk_mb": 8000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.3.63",
       },
       "max_instances": 1500,
       "rollout_active_grace_period": 1800,
@@ -456,7 +456,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.3.63",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -466,7 +466,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.3.63",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -476,7 +476,7 @@
           "image": "./Dockerfile.dind",
           "instance_type": "standard-3",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.3.63",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -490,7 +490,7 @@
             "disk_mb": 8000,
           },
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.3.63",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -500,7 +500,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.3.63",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -510,7 +510,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.3.63",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -524,7 +524,7 @@
             "disk_mb": 8000,
           },
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.3.63",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,


### PR DESCRIPTION
## Summary

Mobile UX defect batch (7 reproduced defects) + GitHub rate-limit investigation (report-only).

- **R1/R2 — PR formSheets**: the comment-composer, review-submit, and merge sheets did not paint their (already-existing) headers; a stray leading-edge `‹` floated over content; with the keyboard open the CTA footer rendered fully behind the keyboard. Root cause (device-backed): react-native-screens formSheet only honors a pinned header when the screen content's direct children are `[header, ScrollView]` — the old `View → ScrollView + sticky footer` tree made the ScrollView full-bleed over the header; the stray `‹` was the parent PR screen's "Go back" showing through a transparent top band. Fix: shared pinned `PrFormSheetHeader` outside the ScrollView, footer CTAs as trailing scroll content with `automaticallyAdjustKeyboardInsets` + `AppAwareKeyboardPaddingView`, plus density passes so all CTAs sit above the keyboard at both detents without scrolling.
- **R4 — file navigator**: long paths overlapped the viewed toggle. Fix: `min-w-0` chain, truncating shrinkable directory segment, non-shrinking basename, non-shrinking toggle with a guaranteed gap.
- **"Paste a link" hint**: removed the redundant helper state (the input placeholder already shows the example URL); dead slot state pruned.
- **R5 — new-session composer**: paperclip + mic rendered mid-height flanking the input. Fix: full-width input on top, one bottom action row (paperclip leading, voice trailing; voice-unavailable shows paperclip only).
- **R6 — cloud-agent preparation**: the fixed `Importing session…` footer row duplicated the in-transcript PreparationGroup. Fix: `shouldShowSessionFooterRow` gate — while `preparing`, suppress the footer only when the merged transcript carries a visible (non-no-op) preparation item; otherwise the footer keeps rendering (never a blank progress window).
- **R7 — per-message model label**: removed entirely; message info is now on long-tap via a new message-details sheet (Copy with immediate clipboard write, role, sent time, model row, cost/tokens block; VoiceOver/TalkBack rotor copy action unchanged).
- **R8 — auto model in Models section**: display layer — the context sheet's Models section never renders `kilo/kilo-auto/*` rows (render-only filter; totals/residual untouched; count derives from filtered rows). Data path — root cause was the sandbox-pinned CLI `7.3.54` predating the routed-model stamp feature (first released in `7.3.63`); bumped the pin in lockstep (Dockerfiles, wrangler `image_vars`, `KILO_CLI_VERSION`) and re-proved live: fresh `kilo-auto/efficient` sessions now stamp `step-finish.model` with the concrete routed id (e.g. `qwen/qwen3.7-plus`) at the ingest boundary and in the app-facing payload.

R3 (file-navigator missing header) was dropped: could not be reproduced — already fixed on baseline.

## GitHub rate-limit investigation (report only — no code changes)

| Claim | Evidence |
|---|---|
| All PR-review GitHub calls use per-user GitHub App user access tokens: the token response schema requires `expires_in` + `refresh_token` and refresh uses `grant_type: 'refresh_token'` — the GitHub App user-to-server pattern; each call builds an Octokit with the fetched per-user token; all 16 procedures wrap `withGitHubUserTokenRetry`, so the rate-limit bucket is per user and scales with user count; no installation-token/shared-bucket path exists in this feature | token schema + exchange `apps/web/src/lib/integrations/platforms/github/user-authorization.ts:13-18,72-93`; refresh grant `services/git-token-service/src/github-user-authorization-service.ts:502-511`; per-call fetch+Octokit `apps/web/src/lib/github-pr-review/retry.ts:63-70` + `client.ts:14-19`; 16 call sites `github-pr-review-router.ts:509-956` |
| GitHub-documented primary limits for user-to-server tokens: 5,000 REST req/h + 5,000 GraphQL points/h per user (EXTERNAL doc figure, not in-repo) | https://docs.github.com/en/rest/rate-limit + https://docs.github.com/en/graphql/overview/rate-limits-and-node-limits-for-the-graphql-api |
| Unbounded concurrent GraphQL burst: thread-comment follow-ups for up to 50 threads fire in one `Promise.all` | `github-pr-review-router.ts:653-673` + loop `399-429` |
| Tight pagination with no pacing | `apps/mobile/src/lib/pr-review/diff/pr-review-file-list-state.ts:197-204`; `octokit.paginate` in `listChecks` (`apps/web/src/routers/github-pr-review-router.ts:570-581`); `onEndReached` auto-pagination (`apps/mobile/src/components/pr-review/diff/pr-diff-file-list.tsx:343-347`) |
| Mergeability poller: each 3s tick = 1 tRPC overview refetch = 3 GitHub API requests server-side (pulls.get + repos.get + GraphQL), up to 10 ticks | `apps/mobile/src/components/pr-review/merge/pr-merge-section.tsx:49-50,131-142`; fan-out `apps/web/src/routers/github-pr-review-router.ts:515-537` |
| Invalidation multiplier per mutation family: comment/submit → overview + ALL loaded thread pages; merge/update/auto-merge → overview + checks + ALL loaded file pages; reply/resolve/reactions → thread pages only | `apps/mobile/src/lib/pr-review/use-pr-review-mutations.ts:34-41`; `apps/mobile/src/lib/pr-review/merge/use-pr-merge-mutations.ts:31-40`; `apps/mobile/src/lib/pr-review/discussion/use-review-discussion-mutations.ts:55-60` |
| Mobile auto-retries `TOO_MANY_REQUESTS` 2× against an exhausted bucket | `apps/mobile/src/lib/query-client.ts:7-26` (permanent-code set omits it) |
| Headerless 403 secondary limit misclassified as terminal `FORBIDDEN` | `apps/web/src/lib/github-pr-review/errors.ts:49-53,163-171` |
| `retryAfterEpochMs` dropped at the tRPC boundary | `apps/web/src/lib/github-pr-review/retry.ts:22-27` |
| No conditional requests/ETag; rate-limit headers read only after failure | `apps/web/src/lib/github-pr-review/errors.ts:146`; repo-wide grep confirms no If-None-Match in GitHub paths |
| `getFileLines` downloads whole raw file per 500-line window, no cache | `apps/web/src/routers/github-pr-review-router.ts:611-637`; `apps/mobile/src/lib/pr-review/diff/use-pr-diff-context-loader.ts:61-68` |

**Recommendations (no code in this PR):** bound GraphQL follow-up concurrency + pace pagination; plumb `retryAfter` to the client and suppress auto-retry on 429; classify headerless 403 secondary limits as retryable `TOO_MANY_REQUESTS`; consider ETag caching for overview/files.

## Notes

- The sandbox CLI pin bump (7.3.63) takes effect for new sandboxes; production images pick it up on the next image build/publish. Existing sandboxes stay on 7.3.54 until recycled.
- `default-slash-commands.generated.ts`: source marker bumped for the lockstep test; the catalog body was not regenerated (the generator's `kilo serve` step hung locally with 7.3.63) — content drift vs 7.3.63 is possible and tracked as follow-up.
- `providerMetadata.kilocode.routedModelID` is not emitted by the 7.3.63 stamp path; consumers read `part.model` (`{providerID, modelID}`), which `cloud-agent-sdk/part-utils#getStepFinishRoutedModel` already does.
