### PR TITLE
fix(mobile): route snapshot-init progress to the working indicator row

### DIFF
--- a/apps/mobile/src/components/agents/collect-copyable-text.ts
+++ b/apps/mobile/src/components/agents/collect-copyable-text.ts
@@ -1,4 +1,4 @@
-type TextPartLike = { type: string; text: string };
+type TextPartLike = { type: string; text: string; synthetic?: boolean };
 type CopyablePart = TextPartLike | { type: string };
 
 type CopyableMessage = {
@@ -9,9 +9,14 @@ function isTextPartLike(part: CopyablePart): part is TextPartLike {
   return part.type === 'text' && typeof (part as TextPartLike).text === 'string';
 }
 
+function isSnapshotProgressText(part: TextPartLike): boolean {
+  return part.synthetic === true && part.text.includes('Initializing snapshot');
+}
+
 export function collectCopyableText(message: CopyableMessage): string {
   return message.parts
     .filter(isTextPartLike)
+    .filter(part => !isSnapshotProgressText(part))
     .map(part => part.text)
     .join('\n\n');
 }

--- a/apps/mobile/src/components/agents/compute-status.test.ts
+++ b/apps/mobile/src/components/agents/compute-status.test.ts
@@ -1,0 +1,71 @@
+import { type ReasoningPart, type TextPart, type ToolPart } from 'cloud-agent-sdk';
+import { describe, expect, it } from 'vitest';
+
+import { computeStatus, SNAPSHOT_PROGRESS_STATUS } from './compute-status';
+
+function makeTextPart(text: string, synthetic?: boolean): TextPart {
+  const part: TextPart = {
+    id: 't1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'text',
+    text,
+    time: { start: 1, end: 2 },
+  };
+  if (synthetic !== undefined) {
+    part.synthetic = synthetic;
+  }
+  return part;
+}
+
+function makeReasoningPart(): ReasoningPart {
+  return {
+    id: 'r1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'reasoning',
+    text: 'thinking',
+    time: { start: 1, end: 2 },
+  };
+}
+
+function makeToolPart(tool: string): ToolPart {
+  return {
+    id: 'tool1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'tool',
+    callID: 'c1',
+    tool,
+    state: {
+      status: 'running',
+      input: {},
+      time: { start: 1 },
+    },
+  };
+}
+
+describe('computeStatus', () => {
+  it('maps snapshot-progress text parts to SNAPSHOT_PROGRESS_STATUS', () => {
+    const part = makeTextPart('⠋ Initializing snapshot…', true);
+    expect(computeStatus(part)).toBe(SNAPSHOT_PROGRESS_STATUS);
+    expect(SNAPSHOT_PROGRESS_STATUS).toBe('Initializing snapshot…');
+  });
+
+  it('maps plain text parts to Writing response', () => {
+    expect(computeStatus(makeTextPart('Hello'))).toBe('Writing response');
+  });
+
+  it('maps reasoning parts to Thinking', () => {
+    expect(computeStatus(makeReasoningPart())).toBe('Thinking');
+  });
+
+  it('maps known tool parts via the tool status map', () => {
+    expect(computeStatus(makeToolPart('bash'))).toBe('Running commands');
+    expect(computeStatus(makeToolPart('read'))).toBe('Exploring');
+  });
+
+  it('maps unknown tool parts to Considering next steps', () => {
+    expect(computeStatus(makeToolPart('unknown-tool'))).toBe('Considering next steps');
+  });
+});

--- a/apps/mobile/src/components/agents/compute-status.ts
+++ b/apps/mobile/src/components/agents/compute-status.ts
@@ -1,5 +1,7 @@
 import { type Part } from 'cloud-agent-sdk';
 
+import { isSnapshotProgressPart } from './part-types';
+
 const toolStatusMap: Record<string, string> = {
   read: 'Exploring',
   grep: 'Searching the codebase',
@@ -17,6 +19,9 @@ const toolStatusMap: Record<string, string> = {
   question: 'Asking a question',
 };
 
+/** Matches CLI PROGRESS_INITIALIZING typography (U+2026 ellipsis). */
+export const SNAPSHOT_PROGRESS_STATUS = 'Initializing snapshot…';
+
 export function computeStatus(part: Part): string {
   if (part.type === 'tool') {
     return toolStatusMap[part.tool] ?? 'Considering next steps';
@@ -25,6 +30,9 @@ export function computeStatus(part: Part): string {
     return 'Thinking';
   }
   if (part.type === 'text') {
+    if (isSnapshotProgressPart(part)) {
+      return SNAPSHOT_PROGRESS_STATUS;
+    }
     return 'Writing response';
   }
   return 'Considering next steps';

--- a/apps/mobile/src/components/agents/message-copy-text.test.ts
+++ b/apps/mobile/src/components/agents/message-copy-text.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 import { collectCopyableText } from './collect-copyable-text';
 
 type TestMessage = {
-  parts: { type: string; text?: string; url?: string }[];
+  parts: { type: string; text?: string; url?: string; synthetic?: boolean }[];
 };
 
 describe('collectCopyableText', () => {
@@ -23,5 +23,29 @@ describe('collectCopyableText', () => {
       parts: [{ type: 'file', url: 'x' }],
     };
     expect(collectCopyableText(message)).toBe('');
+  });
+
+  it('excludes synthetic snapshot-progress text parts from copy', () => {
+    const message: TestMessage = {
+      parts: [
+        { type: 'text', text: '⠋ Initializing snapshot…', synthetic: true },
+        { type: 'text', text: 'Real answer' },
+      ],
+    };
+    expect(collectCopyableText(message)).toBe('Real answer');
+  });
+
+  it('keeps non-synthetic text that mentions Initializing snapshot', () => {
+    const message: TestMessage = {
+      parts: [{ type: 'text', text: 'Note: Initializing snapshot can take a while' }],
+    };
+    expect(collectCopyableText(message)).toBe('Note: Initializing snapshot can take a while');
+  });
+
+  it('keeps synthetic user optimistic text parts', () => {
+    const message: TestMessage = {
+      parts: [{ type: 'text', text: 'User typed this', synthetic: true }],
+    };
+    expect(collectCopyableText(message)).toBe('User typed this');
   });
 });

--- a/apps/mobile/src/components/agents/part-renderer.test.ts
+++ b/apps/mobile/src/components/agents/part-renderer.test.ts
@@ -1,8 +1,9 @@
-import { type ReasoningPart } from 'cloud-agent-sdk';
+import { type ReasoningPart, type TextPart } from 'cloud-agent-sdk';
 import { describe, expect, it, vi } from 'vitest';
 
 import { PartRenderer } from './part-renderer';
 import { ReasoningPartRenderer } from './reasoning-part-renderer';
+import { TextPartRenderer } from './text-part-renderer';
 
 vi.mock('./child-session-section', () => ({}));
 vi.mock('./compaction-separator', () => ({
@@ -35,6 +36,21 @@ function makeReasoningPart(text: string, ended = true): ReasoningPart {
   };
 }
 
+function makeTextPart(text: string, synthetic?: boolean, ended = true): TextPart {
+  const part: TextPart = {
+    id: 't1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'text',
+    text,
+    time: { start: 1, end: ended ? 2 : undefined },
+  };
+  if (synthetic !== undefined) {
+    part.synthetic = synthetic;
+  }
+  return part;
+}
+
 describe('PartRenderer', () => {
   it('does not mount a completed empty reasoning part', () => {
     const part = makeReasoningPart('', true);
@@ -60,5 +76,33 @@ describe('PartRenderer', () => {
       text: 'Meaningful reasoning text',
       isStreaming: false,
     });
+  });
+
+  it('returns null for snapshot-progress parts while streaming', () => {
+    const part = makeTextPart('⠋ Initializing snapshot…', true, false);
+    // eslint-disable-next-line new-cap
+    const result = PartRenderer({ part, isStreaming: true });
+    expect(result).toBeNull();
+  });
+
+  it('returns null for snapshot-progress parts when not streaming', () => {
+    const part = makeTextPart('⠋ Initializing snapshot…', true, true);
+    // eslint-disable-next-line new-cap
+    const result = PartRenderer({ part, isStreaming: false });
+    expect(result).toBeNull();
+  });
+
+  it('routes normal text parts to TextPartRenderer', () => {
+    const part = makeTextPart('Hello world');
+    // eslint-disable-next-line new-cap
+    const result = PartRenderer({ part, isStreaming: true });
+    expect(result).not.toBeNull();
+    const textElement = (
+      result as unknown as {
+        props: { children: { type: unknown; props: Record<string, unknown> } };
+      }
+    ).props.children;
+    expect(textElement.type).toBe(TextPartRenderer);
+    expect(textElement.props).toMatchObject({ text: 'Hello world' });
   });
 });

--- a/apps/mobile/src/components/agents/part-renderer.tsx
+++ b/apps/mobile/src/components/agents/part-renderer.tsx
@@ -8,6 +8,7 @@ import {
   isFilePart,
   isPartStreaming,
   isReasoningPart,
+  isSnapshotProgressPart,
   isTextPart,
   isToolPart,
   shouldRenderReasoningPart,
@@ -33,6 +34,11 @@ export function PartRenderer({
   onOpenChildSession,
 }: Readonly<PartRendererProps>) {
   if (isTextPart(part)) {
+    // Snapshot-init progress is shown only in the fixed WorkingIndicator row.
+    // Hide unconditionally so a persisted part never lingers in the transcript.
+    if (isSnapshotProgressPart(part)) {
+      return null;
+    }
     return (
       <MessageErrorBoundary>
         <TextPartRenderer text={part.text} />

--- a/apps/mobile/src/components/agents/part-types.test.ts
+++ b/apps/mobile/src/components/agents/part-types.test.ts
@@ -1,7 +1,7 @@
-import { type Part, type ReasoningPart } from 'cloud-agent-sdk';
+import { type ReasoningPart, type TextPart } from 'cloud-agent-sdk';
 import { describe, expect, it } from 'vitest';
 
-import { isPartStreaming, shouldRenderReasoningPart } from './part-types';
+import { isPartStreaming, isSnapshotProgressPart, shouldRenderReasoningPart } from './part-types';
 
 function makeReasoningPart(text: string, ended = true): ReasoningPart {
   return {
@@ -14,8 +14,8 @@ function makeReasoningPart(text: string, ended = true): ReasoningPart {
   };
 }
 
-function makeTextPart(text: string): Part {
-  return {
+function makeTextPart(text: string, synthetic?: boolean): TextPart {
+  const part: TextPart = {
     id: 't1',
     sessionID: 's1',
     messageID: 'm1',
@@ -23,7 +23,33 @@ function makeTextPart(text: string): Part {
     text,
     time: { start: 1, end: 2 },
   };
+  if (synthetic !== undefined) {
+    part.synthetic = synthetic;
+  }
+  return part;
 }
+
+describe('isSnapshotProgressPart', () => {
+  it('is true for a synthetic text part whose text includes Initializing snapshot', () => {
+    const part = makeTextPart('⠋ Initializing snapshot…', true);
+    expect(isSnapshotProgressPart(part)).toBe(true);
+  });
+
+  it('is false for the same text when not synthetic', () => {
+    const part = makeTextPart('⠋ Initializing snapshot…', false);
+    expect(isSnapshotProgressPart(part)).toBe(false);
+  });
+
+  it('is false for a synthetic text part with other content', () => {
+    const part = makeTextPart('Hello from the agent', true);
+    expect(isSnapshotProgressPart(part)).toBe(false);
+  });
+
+  it('is false for non-text parts', () => {
+    const part = makeReasoningPart('thinking');
+    expect(isSnapshotProgressPart(part)).toBe(false);
+  });
+});
 
 describe('shouldRenderReasoningPart', () => {
   it('does not render a completed reasoning part with empty text', () => {

--- a/apps/mobile/src/components/agents/part-types.ts
+++ b/apps/mobile/src/components/agents/part-types.ts
@@ -11,6 +11,11 @@ export function isTextPart(part: Part): part is TextPart {
   return part.type === 'text';
 }
 
+/** CLI snapshot-init progress injected as a synthetic text part (matches kilo-vscode). */
+export function isSnapshotProgressPart(part: Part): boolean {
+  return isTextPart(part) && part.synthetic === true && part.text.includes('Initializing snapshot');
+}
+
 export function isToolPart(part: Part): part is ToolPart {
   return part.type === 'tool';
 }


### PR DESCRIPTION
## Problem

At the start of a live agent chat turn, while the CLI initializes its git snapshot baseline (cold track > ~500 ms), the CLI injects a synthetic text part (`synthetic: true`, text `⠋ Initializing snapshot…`) into the live assistant message. Mobile rendered it as an inline line in the message list while the fixed status row above the composer simultaneously showed the generic `Writing response · Ns` — two stacked, mismatched spinner lines. The line could also linger in the finished transcript.

Baseline on-device evidence (E2E, forced cold-snapshot window): inline `Initializing snapshot...` line under the user bubble + fixed row `Writing response · Ns` at the same time, and the inline line persisted in the finished transcript after close/reopen.

## Fix

Mirror the VS Code extension's special case with the narrowest change:

- `part-types.ts`: new `isSnapshotProgressPart` guard (text part + `synthetic === true` + text includes `Initializing snapshot`; same match rule as kilo-vscode `snapshotProgress()`).
- `compute-status.ts`: new `SNAPSHOT_PROGRESS_STATUS = 'Initializing snapshot…'` (U+2026, matching the CLI's own typography); the fixed working-indicator row now reads `Initializing snapshot… · Ns` during snapshot init instead of `Writing response · Ns`.
- `part-renderer.tsx`: snapshot-progress parts render `null`, unconditionally — no inline duplicate while streaming, and a persisted part (long/killed turn) never lingers in the transcript.
- `collect-copyable-text.ts`: the same narrow signature is excluded from long-press copy; synthetic **user** optimistic parts stay copyable.

Everything else (user optimistic messages, all other part routing, copy, status mappings) is byte-identical. Degrades gracefully if CLI wording changes: the part would render as before, no crash.

## Test plan

- [x] New/updated unit tests: `part-types`, `compute-status` (new), `part-renderer`, `message-copy-text` (27 tests in the touched files)
- [x] Full mobile suite: 220 files / 1820 tests pass
- [x] `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` clean; `git diff --check` clean
- [x] Baseline E2E (repro): dual-indicator facet + transcript linger demonstrated on the unmodified app
- [x] Acceptance E2E on this branch (iOS simulator, forced cold-snapshot window on a 100k-file scratch repo):
  - No inline `Initializing snapshot` line in any frame during the window, after completion, or after close/reopen (the baseline run's lingering line is gone on the fixed build)
  - Fixed row reads `Initializing snapshot… · Ns` throughout the cold window (frame series, 5s→43s)
  - Row flips to the normal computed status when the turn proceeds (`Considering next steps · 45s` → `Thinking · 49s`), elapsed timer continues; row clears at completion
  - Regressions: session reopen, Home, Agents list unchanged
- [x] Long-press copy exclusion (unit-gated; on-device copy automation not operationalized)

Note: during E2E a `TypeError: isSnapshotProgressPart is not a function` appeared once in Metro logs with a "3 earlier items could not be displayed" banner. Triaged to a Metro fast-refresh module-skew artifact caused by switching branches under a running app: after a cold app start on a consistent bundle, the same session renders correctly with no banner and no new errors. Not a defect in this change.