### PR TITLE
fix(auto-model): update frontier to Opus 5

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
@@ -4,7 +4,7 @@ import type {
 } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 
 export const CLAUDE_SONNET_CURRENT_MODEL_ID = 'anthropic/claude-sonnet-5';
-export const CLAUDE_OPUS_CURRENT_MODEL_ID = 'anthropic/claude-opus-4.8';
+export const CLAUDE_OPUS_CURRENT_MODEL_ID = 'anthropic/claude-opus-5';
 export const CLAUDE_HAIKU_CURRENT_MODEL_ID = 'anthropic/claude-haiku-4.5';
 export const CLAUDE_FABLE_CURRENT_MODEL_ID = 'anthropic/claude-fable-5';
 export const CLAUDE_OPUS_4_8_STEALTH_MODEL_ID = 'stealth/claude-opus-4.8';


### PR DESCRIPTION
## Summary
- update the current Claude Opus model ID from `anthropic/claude-opus-4.8` to `anthropic/claude-opus-5`
- route Auto Frontier Opus modes and other current-Opus consumers to Opus 5
- preserve the separate Opus 4.8 stealth model ID

## Validation
- `pnpm --filter web test -- --runInBand src/tests/openrouter-models-config.test.ts src/lib/ai-gateway/auto-model/resolution.test.ts` (19 tests passed)
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts`
- `pnpm exec oxfmt --list-different apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts`
- `git diff --check`

## Note
- Validation ran with Node 26; the repository specifies Node 24.