### PR TITLE
fix(mobile): new-session composer spacing and session bottom-inset surface

### DIFF
--- a/apps/mobile/src/components/agents/new-session-prompt.tsx
+++ b/apps/mobile/src/components/agents/new-session-prompt.tsx
@@ -191,7 +191,7 @@ export function NewSessionPrompt({
           accessibilityState={{ disabled: control.inputAccessibilityDisabled }}
           autoFocus
         />
-        <View className="flex-row items-center justify-between pb-1">
+        <View className="flex-row items-center justify-between pb-2">
           <Pressable
             onPress={handlePaperclipPress}
             disabled={paperclipDisabled}
@@ -207,6 +207,11 @@ export function NewSessionPrompt({
             <Paperclip size={18} color={colors.mutedForeground} />
           </Pressable>
           {voiceInput.available ? (
+            <View className="h-9 flex-1 items-center justify-center overflow-hidden px-2">
+              <VoiceInputStatus status={voiceInput.status} />
+            </View>
+          ) : null}
+          {voiceInput.available ? (
             <VoiceInputButton
               disabled={control.voiceDisabled}
               size="md"
@@ -216,11 +221,6 @@ export function NewSessionPrompt({
           ) : null}
         </View>
       </View>
-      {voiceInput.available ? (
-        <View className="min-h-[20px] px-3 pb-1">
-          <VoiceInputStatus status={voiceInput.status} />
-        </View>
-      ) : null}
       {isModelsError && modelOptions.length === 0 ? (
         <QueryError
           placement="top"

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -64,6 +64,7 @@ import { PartRenderer } from '@/components/agents/part-renderer';
 import { QueryError } from '@/components/query-error';
 import { RenameModal } from '@/components/rename-modal';
 import { ScreenHeader } from '@/components/screen-header';
+import { BlurBar } from '@/components/ui/blur-bar';
 import { Button } from '@/components/ui/button';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
@@ -482,6 +483,8 @@ export function SessionDetailContent({
   const requiresModel = Boolean(fetchedData?.cloudAgentSessionId);
   const blockingInteraction = getBlockingInteraction({ activeQuestion, activePermission });
   const hasBlockingInteraction = blockingInteraction !== 'none';
+  const isComposerMounted = !isReadOnly || messages.length === 0;
+  const isComposerVisible = isComposerMounted && !hasBlockingInteraction;
   const isComposerDisabled =
     isReadOnly ||
     !canSend ||
@@ -645,7 +648,13 @@ export function SessionDetailContent({
         </KeyboardAvoidingView>
       )}
 
-      <View style={{ height: bottom }} className="bg-background" />
+      {isComposerVisible ? (
+        <BlurBar className="border-t-0">
+          <View style={{ height: bottom }} />
+        </BlurBar>
+      ) : (
+        <View style={{ height: bottom }} className="bg-background" />
+      )}
 
       {sheetMountState.mounted ? (
         <SessionContextSheet
@@ -756,7 +765,7 @@ export function SessionDetailContent({
           </View>
         ) : null}
 
-        {!isReadOnly || messages.length === 0 ? (
+        {isComposerMounted ? (
           <View
             className={cn(hasBlockingInteraction && 'hidden')}
             accessibilityElementsHidden={hasBlockingInteraction}


### PR DESCRIPTION
## What

Two iOS-visible fixes on the Agents surfaces.

### New session screen — dead space under the attachment/microphone row

The prompt card reserved 24pt of permanently empty space between the action row and the model/mode toolbar: a `min-h-[20px]` wrapper around `VoiceInputStatus`, which renders `null` in every status except `listening` (the reservation was introduced in 863d6ffb so toggling voice input could not shift the composer layout).

The "Listening…" caption now renders inline as the middle child of the action row, inside a height-pinned `h-9` wrapper (the same 36pt as the flanking paperclip/microphone controls) with `overflow-hidden`, so the row height is set by the controls and cannot change when the caption appears — at any Dynamic Type scale. The reserved block is deleted and the row's bottom padding becomes `pb-2`, matching the card's existing `pt-2` top inset.

### Session screen — bottom safe-area strip matches the composer surface

The strip below the composer was a solid `bg-background` view while the composer above it is a `BlurBar` (`expo-blur`, intensity 40). A tinted blur over `bg-background` does not resolve to `bg-background` — measured delta (−4,−4,−4) per channel in dark theme.

When the composer is the bottom-most visible element, the strip now renders the same `BlurBar` surface (`border-t-0`, verified to merge away the hairline via `twMerge`). The solid `bg-background` strip stays for the blocking question/permission cards, and the strip's placement after the `KeyboardAvoidingView` — which keeps the composer flush on the open keyboard — is unchanged. Android is unaffected (`BlurBar` already resolves to `bg-background` there).

Deliberately out of scope: the read-only-session banner (`bg-secondary`) also sits above a `bg-background` strip; that surface is unchanged.

## Verification

- From `apps/mobile/`: `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused && pnpm test` (1871/1871 passing) and `git diff --check`.
- On-device E2E (iPhone 17 / iOS 26.5): action-row→toolbar spacing measurement, voice-toggle no-layout-shift check, and composer/strip pixel sampling in light and dark themes — evidence follows in a comment.
