### PR TITLE
fix(cloud-agent-next): pin sandbox CLI back to 7.3.54

### DIFF
--- a/services/cloud-agent-next/Dockerfile
+++ b/services/cloud-agent-next/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/cloudflare/sandbox:0.12.1
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.63"
+ARG KILOCODE_CLI_VERSION="7.3.54"
 
 # Install latest stable git + git-lfs from the git-core PPA, GitHub CLI, and supporting tools.
 # The default Ubuntu git (2.34.1 on 22.04) is outdated; the git-core PPA ships the latest

--- a/services/cloud-agent-next/Dockerfile.dev
+++ b/services/cloud-agent-next/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM docker.io/cloudflare/sandbox:0.12.1
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.63"
+ARG KILOCODE_CLI_VERSION="7.3.54"
 
 # Build the kilo binary:
 #   cd ~/projects/kilocode-backend/cloud-agent

--- a/services/cloud-agent-next/Dockerfile.dind
+++ b/services/cloud-agent-next/Dockerfile.dind
@@ -9,7 +9,7 @@ USER root
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.63"
+ARG KILOCODE_CLI_VERSION="7.3.54"
 
 # Cloudflare Containers run without root privileges, so Docker must run in
 # rootless mode. The Sandbox SDK server is copied into this image so the

--- a/services/cloud-agent-next/src/kilo/devcontainer.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.ts
@@ -148,7 +148,7 @@ function buildDevContainerTrustEnv(sessionHome: string): Record<string, string> 
  * `wrangler.jsonc#image_vars` so the kilo running in the dev container
  * matches the one we use on the outer sandbox.
  */
-export const KILO_CLI_VERSION = '7.3.63';
+export const KILO_CLI_VERSION = '7.3.54';
 
 const DEVCONTAINER_RUNTIME_BUN_VERSION = '1.3.14';
 const DEVCONTAINER_RUNTIME_BOOTSTRAP_TIMEOUT_MS = 10 * 60 * 1000;

--- a/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
+++ b/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
@@ -17,7 +17,7 @@ export type SlashCommandInfo = {
  *
  * Regenerate with `pnpm --filter cloud-agent-next update-default-slash-commands`.
  */
-export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.63';
+export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.54';
 
 /**
  * Default slash command catalog used when no live wrapper-reported catalog is

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -161,7 +161,7 @@
         "disk_mb": 20000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.63",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 200,
       "rollout_active_grace_period": 1800,
@@ -175,7 +175,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.63",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 150,
       "rollout_active_grace_period": 1800,
@@ -189,7 +189,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.63",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 20,
       "rollout_active_grace_period": 1800,
@@ -203,7 +203,7 @@
         "disk_mb": 8000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.63",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 500,
       "rollout_active_grace_period": 1800,
@@ -217,7 +217,7 @@
         "disk_mb": 20000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.63",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 750,
       "rollout_active_grace_period": 1800,
@@ -231,7 +231,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.63",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 300,
       "rollout_active_grace_period": 1800,
@@ -245,7 +245,7 @@
         "disk_mb": 8000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.63",
+        "KILOCODE_CLI_VERSION": "7.3.54",
       },
       "max_instances": 1500,
       "rollout_active_grace_period": 1800,
@@ -456,7 +456,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.63",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -466,7 +466,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.63",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -476,7 +476,7 @@
           "image": "./Dockerfile.dind",
           "instance_type": "standard-3",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.63",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -490,7 +490,7 @@
             "disk_mb": 8000,
           },
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.63",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -500,7 +500,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.63",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -510,7 +510,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.63",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -524,7 +524,7 @@
             "disk_mb": 8000,
           },
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.63",
+            "KILOCODE_CLI_VERSION": "7.3.54",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary
Reverts pin sandbox CLI back to 7.3.54
<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
