### PR TITLE
fix(mobile): allow submitting a PR review with no comments

### DIFF
--- a/apps/mobile/src/components/pr-review/pr-review-overview.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-overview.tsx
@@ -1,8 +1,9 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
-import { GitPullRequest } from 'lucide-react-native';
+import { type Href, useRouter } from 'expo-router';
+import * as WebBrowser from 'expo-web-browser';
+import { CheckCheck, GitPullRequest } from 'lucide-react-native';
 import { useCallback } from 'react';
 import { View } from 'react-native';
-import * as WebBrowser from 'expo-web-browser';
 
 import { EmptyState } from '@/components/empty-state';
 import { QueryError } from '@/components/query-error';
@@ -20,9 +21,12 @@ import {
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { getGitHubIntegrationUrl } from '@/lib/agent-github-integration';
-import { classifyPrReviewQueryState } from '@/lib/pr-review/classify-pr-review-query-state';
 import { WEB_BASE_URL } from '@/lib/config';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { classifyPrReviewQueryState } from '@/lib/pr-review/classify-pr-review-query-state';
 import { useTRPC } from '@/lib/trpc';
+
+const REVIEW_SUBMIT_PATH = '/(app)/pr-review/[owner]/[repo]/[number]/review-submit' as const;
 
 type PrReviewOverviewProps = {
   readonly owner: string;
@@ -67,8 +71,18 @@ export function PrReviewOverview({
 }: PrReviewOverviewProps) {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
+  const router = useRouter();
+  const colors = useThemeColors();
 
   const pr = useQuery(trpc.githubPrReview.getPullRequest.queryOptions({ owner, repo, number }));
+
+  const handleOpenReviewSubmit = useCallback(() => {
+    const href: Href = {
+      pathname: REVIEW_SUBMIT_PATH,
+      params: { owner, repo, number },
+    };
+    router.push(href);
+  }, [owner, repo, number, router]);
 
   const handleReconnect = useCallback(() => {
     // A PRECONDITION_FAILED here means the gate's authorization is no
@@ -201,6 +215,18 @@ export function PrReviewOverview({
       </View>
 
       <PrReviewChecksSection owner={owner} repo={repo} number={number} headSha={data.headSha} />
+
+      <View className="gap-2">
+        <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+          Review
+        </Text>
+        <Button onPress={handleOpenReviewSubmit} accessibilityLabel="Review pull request">
+          <View className="flex-row items-center gap-2">
+            <CheckCheck size={14} color={colors.primaryForeground} />
+            <Text>Review</Text>
+          </View>
+        </Button>
+      </View>
 
       <PrMergeSection
         owner={owner}

--- a/apps/mobile/src/components/pr-review/pr-review-submit.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-submit.tsx
@@ -8,7 +8,7 @@
 
 import * as Haptics from 'expo-haptics';
 import { type Href, useRouter } from 'expo-router';
-import { useEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useRef, useState } from 'react';
 import { Alert, Keyboard, Pressable, ScrollView, type TextInput, View } from 'react-native';
 
 import {
@@ -26,6 +26,7 @@ import {
 import {
   buildSubmitReviewInput,
   type ReviewEvent,
+  reviewSubmitBlockReason,
 } from '@/lib/pr-review/build-submit-review-input';
 import { PrReviewReconnectNotice } from '@/components/pr-review/pr-review-reconnect-notice';
 import { classifyPrReviewMutationError } from '@/lib/pr-review/classify-pr-review-query-state';
@@ -59,6 +60,7 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
   const submitReview = useSubmitReviewMutation({ owner, repo, number });
 
   const [event, setEvent] = useState<ReviewEvent>('COMMENT');
+  const [hasSummary, setHasSummary] = useState(false);
   const [inlineError, setInlineError] = useState<string | null>(null);
   const [inlineErrorKind, setInlineErrorKind] = useState<
     'retryable' | 'bad-request' | 'forbidden' | 'reconnect' | null
@@ -71,6 +73,11 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
   const isSubmitting = submitReview.isPending;
   const queuedCount = pending.items.length;
   const hasStaleItems = pending.items.some(item => item.commitSha !== headSha);
+  const blockReason = reviewSubmitBlockReason({
+    event,
+    hasSummary,
+    commentCount: queuedCount,
+  });
 
   useEffect(() => {
     if (submitReview.error) {
@@ -156,6 +163,7 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
 
   const submitDisabled =
     isSubmitting ||
+    blockReason !== null ||
     inlineErrorKind === 'bad-request' ||
     inlineErrorKind === 'forbidden' ||
     inlineErrorKind === 'reconnect';
@@ -164,6 +172,20 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
   // Keyboard-open viewport is tight; keep count, hide per-item rows so
   // Submit + Cancel stay above the keyboard at scroll offset 0.
   const showPendingRows = !keyboardVisible;
+
+  // Hint only when empty/stale — skips the long happy-path line that
+  // pushed footer CTAs below half-detent. blockReason replaces
+  // PendingQueueHint so empty-queue + COMMENT is not contradictory.
+  let queueHint: ReactNode = null;
+  if (blockReason !== null) {
+    queueHint = (
+      <Text variant="muted" className="text-xs">
+        {blockReason}
+      </Text>
+    );
+  } else if (!keyboardVisible && (queuedCount === 0 || hasStaleItems)) {
+    queueHint = <PendingQueueHint queuedCount={queuedCount} hasStaleItems={hasStaleItems} />;
+  }
 
   // PickerSheet invariant: [header, ScrollView]; footer is trailing content.
   return (
@@ -192,7 +214,10 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
               bodyRef={bodyRef}
               inputRef={bodyInputRef}
               isDisabled={isSubmitting}
-              onChange={clearRecoverableError}
+              onChange={() => {
+                setHasSummary(bodyRef.current.trim().length > 0);
+                clearRecoverableError();
+              }}
             />
           </View>
 
@@ -200,11 +225,7 @@ export function PrReviewSubmit(props: PrReviewSubmitProps) {
             <Text className="text-sm font-medium text-foreground">
               {queuedCount} pending {queuedCount === 1 ? 'comment' : 'comments'}
             </Text>
-            {/* Hint only when empty/stale — skips the long happy-path line that
-                pushed footer CTAs below half-detent. */}
-            {!keyboardVisible && (queuedCount === 0 || hasStaleItems) ? (
-              <PendingQueueHint queuedCount={queuedCount} hasStaleItems={hasStaleItems} />
-            ) : null}
+            {queueHint}
             {showPendingRows
               ? pending.items.map(item => (
                   <PrReviewPendingCommentRow

--- a/apps/mobile/src/lib/pr-review/build-submit-review-input.test.ts
+++ b/apps/mobile/src/lib/pr-review/build-submit-review-input.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, it } from 'vitest';
 
-import { buildSubmitReviewInput } from '@/lib/pr-review/build-submit-review-input';
+import {
+  buildSubmitReviewInput,
+  reviewSubmitBlockReason,
+} from '@/lib/pr-review/build-submit-review-input';
 import { type PendingReviewItem } from '@/lib/pr-review/pending-review-provider';
 
 function makeItem(overrides: Partial<PendingReviewItem> = {}): PendingReviewItem {
@@ -140,5 +143,76 @@ describe('buildSubmitReviewInput', () => {
     // queue is retained because the input is built from the current items
     // without mutating them.
     expect(items).toHaveLength(2);
+  });
+});
+
+describe('reviewSubmitBlockReason', () => {
+  it('allows APPROVE with neither summary nor comments', () => {
+    expect(
+      reviewSubmitBlockReason({ event: 'APPROVE', hasSummary: false, commentCount: 0 })
+    ).toBeNull();
+  });
+
+  it('allows APPROVE with a summary and no comments', () => {
+    expect(
+      reviewSubmitBlockReason({ event: 'APPROVE', hasSummary: true, commentCount: 0 })
+    ).toBeNull();
+  });
+
+  it('blocks REQUEST_CHANGES with neither summary nor comments', () => {
+    const reason = reviewSubmitBlockReason({
+      event: 'REQUEST_CHANGES',
+      hasSummary: false,
+      commentCount: 0,
+    });
+    expect(reason).toBe('Add a summary or at least one comment to request changes.');
+  });
+
+  it('allows REQUEST_CHANGES with a summary and no comments', () => {
+    expect(
+      reviewSubmitBlockReason({
+        event: 'REQUEST_CHANGES',
+        hasSummary: true,
+        commentCount: 0,
+      })
+    ).toBeNull();
+  });
+
+  it('allows REQUEST_CHANGES with a comment and no summary', () => {
+    expect(
+      reviewSubmitBlockReason({
+        event: 'REQUEST_CHANGES',
+        hasSummary: false,
+        commentCount: 1,
+      })
+    ).toBeNull();
+  });
+
+  it('blocks COMMENT with neither summary nor comments, with distinct wording', () => {
+    const reason = reviewSubmitBlockReason({
+      event: 'COMMENT',
+      hasSummary: false,
+      commentCount: 0,
+    });
+    expect(reason).toBe('Add a summary or at least one comment to post a comment review.');
+    expect(reason).not.toBe(
+      reviewSubmitBlockReason({
+        event: 'REQUEST_CHANGES',
+        hasSummary: false,
+        commentCount: 0,
+      })
+    );
+  });
+
+  it('allows COMMENT with a summary and no comments', () => {
+    expect(
+      reviewSubmitBlockReason({ event: 'COMMENT', hasSummary: true, commentCount: 0 })
+    ).toBeNull();
+  });
+
+  it('allows COMMENT with a comment and no summary', () => {
+    expect(
+      reviewSubmitBlockReason({ event: 'COMMENT', hasSummary: false, commentCount: 1 })
+    ).toBeNull();
   });
 });

--- a/apps/mobile/src/lib/pr-review/build-submit-review-input.ts
+++ b/apps/mobile/src/lib/pr-review/build-submit-review-input.ts
@@ -5,6 +5,29 @@ import {
 
 export type ReviewEvent = 'APPROVE' | 'REQUEST_CHANGES' | 'COMMENT';
 
+/**
+ * GitHub rejects REQUEST_CHANGES and COMMENT reviews that carry neither a
+ * summary nor at least one comment; APPROVE has no such requirement. Mirrored
+ * client-side so the sheet can explain the requirement instead of round-
+ * tripping to a 422.
+ */
+export function reviewSubmitBlockReason(args: {
+  event: ReviewEvent;
+  hasSummary: boolean;
+  commentCount: number;
+}): string | null {
+  if (args.event === 'APPROVE') {
+    return null;
+  }
+  if (args.hasSummary || args.commentCount > 0) {
+    return null;
+  }
+  if (args.event === 'REQUEST_CHANGES') {
+    return 'Add a summary or at least one comment to request changes.';
+  }
+  return 'Add a summary or at least one comment to post a comment review.';
+}
+
 type BuildSubmitReviewInputArgs = {
   owner: string;
   repo: string;


### PR DESCRIPTION
## Problem

On the mobile PR-review surface a user could not submit a review carrying no comments, so approving a PR outright was impossible. The gate was unreachability, not validation: the review-submit sheet's only entrance was the floating `Finish review` button over the Files-tab diff, rendered only when the pending-comment queue was non-empty. The sheet, the input mapper, the tRPC schema/procedure, and the GitHub params builder all already permitted an empty body and zero comments.

## Fix

- **Overview `Review` entry point.** The Overview tab now has a `Review` section (a11y `Review pull request`) above the merge section that opens the review-submit sheet unconditionally, mirroring the merge CTA idiom. The Files-tab `Finish review` shortcut is unchanged.
- **Client-side mirror of GitHub's body rule.** `APPROVE` submits with an empty summary and zero comments. `REQUEST_CHANGES`/`COMMENT` with neither a summary nor a comment now disables the submit CTA and explains the requirement in place — in the existing hint slot, replacing the empty-queue hint so the two never contradict — instead of round-tripping to a GitHub 422. Typing a summary or queuing a comment re-enables it.

No backend change: all three backend layers already permit an empty body and zero comments.

## Testing

- Eight new unit cases for `reviewSubmitBlockReason` covering both blockable events on both allow paths.
- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` and full `pnpm test` pass in `apps/mobile`.
- E2E on iOS against a hermetic GitHub stub: approve with empty summary and zero comments succeeds end to end (wire-level `200 APPROVED`); blocked state shows the hint and disabled CTA; the pre-existing queued-comment `Finish review` path is unchanged; retryable (stub down) and non-retryable (403) failure states behave per the existing classification.
