### PR TITLE
feat(web): add public leaderboard provider race endpoint

### DIFF
--- a/apps/web/src/app/api/public/leaderboard-provider-race/route.test.ts
+++ b/apps/web/src/app/api/public/leaderboard-provider-race/route.test.ts
@@ -1,0 +1,109 @@
+import { describe, test, expect, jest } from '@jest/globals';
+import type * as SnowflakeModule from '@/lib/snowflake';
+import type { GET as RouteGet } from './route';
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+
+jest.mock('@/lib/redis', () => ({
+  redisClient: {
+    get: jest.fn<() => Promise<string | null>>().mockResolvedValue(null),
+    set: jest.fn().mockResolvedValue('OK'),
+  },
+}));
+
+jest.mock('@/lib/snowflake', () => ({
+  resolveSnowflakeConfig: jest.fn(),
+  executeSnowflakeStatement: jest.fn(),
+}));
+
+const FAKE_CONFIG = { accountHost: 'test.snowflakecomputing.com' };
+
+// The route builds a module-level in-process cache (1h TTL) at import time, so
+// each test loads it in an isolated module registry to keep that cache from
+// leaking between cases.
+async function loadGet(opts: {
+  config?: unknown;
+  rows?: string[][];
+  statementError?: Error;
+}): Promise<typeof RouteGet> {
+  let GET!: typeof RouteGet;
+  await jest.isolateModulesAsync(async () => {
+    const snowflake = (await import('@/lib/snowflake')) as SnowflakeModule;
+    const config = opts.config === undefined ? FAKE_CONFIG : opts.config;
+    jest
+      .mocked(snowflake.resolveSnowflakeConfig)
+      .mockReturnValue(config as ReturnType<SnowflakeModule['resolveSnowflakeConfig']>);
+    if (opts.statementError) {
+      jest.mocked(snowflake.executeSnowflakeStatement).mockRejectedValue(opts.statementError);
+    } else {
+      jest.mocked(snowflake.executeSnowflakeStatement).mockResolvedValue(opts.rows ?? []);
+    }
+    ({ GET } = await import('./route'));
+  });
+  return GET;
+}
+
+describe('GET /api/public/leaderboard-provider-race', () => {
+  test('returns 503 when Snowflake is not configured', async () => {
+    const GET = await loadGet({ config: null });
+
+    const response = await GET();
+
+    expect(response.status).toBe(503);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  test('returns 502 when the Snowflake query fails (e.g. is_open_weights backfill not landed)', async () => {
+    const GET = await loadGet({ statementError: new Error('invalid identifier IS_OPEN_WEIGHTS') });
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+  });
+
+  test('maps explicit is_open_weights to booleans and NULL/unknown to null', async () => {
+    const GET = await loadGet({
+      rows: [
+        ['2026-07-14', 'Anthropic', 'false', '12345'],
+        ['2026-07-14', 'Alibaba', 'true', '6789'],
+        // The SQL API returns NULL cells as null at runtime despite the
+        // string[] row type; unmapped models land here.
+        ['2026-07-14', 'other', null, '999'] as unknown as string[],
+        // A future model_dim mapping gap must not be silently bucketed as closed.
+        ['2026-07-14', 'Mystery', 'unexpected', '111'],
+      ],
+    });
+
+    const response = await GET();
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual([
+      { weekStart: '2026-07-14', provider: 'Anthropic', isOpenWeights: false, tokens: 12345 },
+      { weekStart: '2026-07-14', provider: 'Alibaba', isOpenWeights: true, tokens: 6789 },
+      { weekStart: '2026-07-14', provider: 'other', isOpenWeights: null, tokens: 999 },
+      { weekStart: '2026-07-14', provider: 'Mystery', isOpenWeights: null, tokens: 111 },
+    ]);
+    expect(response.headers.get('Cache-Control')).toContain('public');
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+  });
+
+  test('returns 502 when a row is malformed', async () => {
+    const GET = await loadGet({ rows: [['2026-07-14', 'Anthropic', 'true', 'not-a-number']] });
+
+    const response = await GET();
+
+    expect(response.status).toBe(502);
+  });
+});
+
+describe('OPTIONS /api/public/leaderboard-provider-race', () => {
+  test('returns 204 with CORS headers', async () => {
+    const { OPTIONS } = await import('./route');
+
+    const response = OPTIONS();
+
+    expect(response.status).toBe(204);
+    expect(response.headers.get('Access-Control-Allow-Origin')).toBe('*');
+    expect(response.headers.get('Access-Control-Allow-Methods')).toBe('GET');
+  });
+});

--- a/apps/web/src/app/api/public/leaderboard-provider-race/route.test.ts
+++ b/apps/web/src/app/api/public/leaderboard-provider-race/route.test.ts
@@ -1,5 +1,5 @@
 import { describe, test, expect, jest } from '@jest/globals';
-import type * as SnowflakeModule from '@/lib/snowflake';
+import type { resolveSnowflakeConfig } from '@/lib/snowflake';
 import type { GET as RouteGet } from './route';
 
 jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
@@ -7,7 +7,7 @@ jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
 jest.mock('@/lib/redis', () => ({
   redisClient: {
     get: jest.fn<() => Promise<string | null>>().mockResolvedValue(null),
-    set: jest.fn().mockResolvedValue('OK'),
+    set: jest.fn<() => Promise<string>>().mockResolvedValue('OK'),
   },
 }));
 
@@ -16,23 +16,23 @@ jest.mock('@/lib/snowflake', () => ({
   executeSnowflakeStatement: jest.fn(),
 }));
 
-const FAKE_CONFIG = { accountHost: 'test.snowflakecomputing.com' };
+type SnowflakeConfig = ReturnType<typeof resolveSnowflakeConfig>;
+
+const FAKE_CONFIG = { accountHost: 'test.snowflakecomputing.com' } as SnowflakeConfig;
 
 // The route builds a module-level in-process cache (1h TTL) at import time, so
 // each test loads it in an isolated module registry to keep that cache from
 // leaking between cases.
 async function loadGet(opts: {
-  config?: unknown;
+  config?: SnowflakeConfig;
   rows?: string[][];
   statementError?: Error;
 }): Promise<typeof RouteGet> {
   let GET!: typeof RouteGet;
   await jest.isolateModulesAsync(async () => {
-    const snowflake = (await import('@/lib/snowflake')) as SnowflakeModule;
+    const snowflake = await import('@/lib/snowflake');
     const config = opts.config === undefined ? FAKE_CONFIG : opts.config;
-    jest
-      .mocked(snowflake.resolveSnowflakeConfig)
-      .mockReturnValue(config as ReturnType<SnowflakeModule['resolveSnowflakeConfig']>);
+    jest.mocked(snowflake.resolveSnowflakeConfig).mockReturnValue(config);
     if (opts.statementError) {
       jest.mocked(snowflake.executeSnowflakeStatement).mockRejectedValue(opts.statementError);
     } else {

--- a/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
@@ -13,6 +13,12 @@ import { LEADERBOARD_PROVIDER_RACE_REDIS_KEY } from '@/lib/redis-keys';
 // is_open_weights are maintained in the dbt model_dim seed (kilocode-dbt), so
 // the lab mapping lives in one place rather than being re-derived here.
 // The partial current week is excluded so every returned week is complete.
+// Infrastructure-artifact BYOK model ids are excluded here (not in the base
+// dbt model, which stays complete): URI/path ids (s3://, gs://, ...), ckpt:
+// checkpoint refs, and HuggingFace class names (e.g. AtlasForCausalLM). These
+// are customers pointing Kilo at their own checkpoints/endpoints - single-org
+// noise that cannot be attributed to a model lab and would otherwise dominate
+// the "other" bucket.
 const LEADERBOARD_PROVIDER_RACE_QUERY = `
 select
     to_char(date_trunc('week', ud.usage_date), 'YYYY-MM-DD') as week_start
@@ -24,6 +30,11 @@ where
     ud.usage_date >= '2025-07-01'
     and date_trunc('week', ud.usage_date) < date_trunc('week', current_date())
     and ud.total_tokens > 0
+    and not (
+        ud.model like '%://%'
+        or ud.model ilike 'ckpt:%'
+        or ud.model ilike '%ForCausalLM'
+    )
 group by 1, 2, 3
 order by 1, 4 desc;
 `;

--- a/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
@@ -32,12 +32,23 @@ const providerRaceSchema = z.array(
   z.object({
     weekStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
     provider: z.string().min(1),
-    isOpenWeights: z.boolean(),
+    isOpenWeights: z.boolean().nullable(),
     tokens: z.number(),
   })
 );
 
 type ProviderRace = z.infer<typeof providerRaceSchema>;
+
+// is_open_weights is maintained in the dbt model_dim seed and is NULL for
+// unmapped models (the ones bucketed as provider = 'other'). Only the explicit
+// 'true'/'false' strings map to a boolean; anything else (NULL from the SQL API,
+// or a future mapping gap) becomes null so the client can distinguish "unknown"
+// from a confirmed closed-weight lab instead of silently bucketing gaps as closed.
+function parseOpenWeights(raw: string): boolean | null {
+  if (raw === 'true') return true;
+  if (raw === 'false') return false;
+  return null;
+}
 
 function parseProviderRace(rows: string[][]): ProviderRace {
   return rows.map(row => {
@@ -51,7 +62,7 @@ function parseProviderRace(rows: string[][]): ProviderRace {
     return providerRaceSchema.element.parse({
       weekStart,
       provider,
-      isOpenWeights: rawOpenWeights === 'true' || rawOpenWeights === true,
+      isOpenWeights: parseOpenWeights(rawOpenWeights),
       tokens,
     });
   });

--- a/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
@@ -7,11 +7,12 @@ import {
 import { LEADERBOARD_PROVIDER_RACE_REDIS_KEY } from '@/lib/redis-keys';
 
 // Weekly token volume per model lab, from a fixed start date through the most
-// recent complete day. Grouped at week x model_provider_company x
+// recent complete week. Grouped at week x model_provider_company x
 // is_open_weights so a single payload drives both the per-lab "race" view and
 // an open-weight vs proprietary toggle. model_provider_company and
 // is_open_weights are maintained in the dbt model_dim seed (kilocode-dbt), so
 // the lab mapping lives in one place rather than being re-derived here.
+// The partial current week is excluded so every returned week is complete.
 const LEADERBOARD_PROVIDER_RACE_QUERY = `
 select
     to_char(date_trunc('week', ud.usage_date), 'YYYY-MM-DD') as week_start
@@ -21,7 +22,7 @@ select
 from kilo_dw.dbt_prod.usage_daily as ud
 where
     ud.usage_date >= '2025-07-01'
-    and ud.usage_date < current_date()
+    and date_trunc('week', ud.usage_date) < date_trunc('week', current_date())
     and ud.total_tokens > 0
 group by 1, 2, 3
 order by 1, 4 desc;

--- a/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
+++ b/apps/web/src/app/api/public/leaderboard-provider-race/route.ts
@@ -1,0 +1,68 @@
+import { z } from 'zod';
+
+import {
+  createPublicSnowflakeReport,
+  publicSnowflakeReportOptions,
+} from '@/lib/public-snowflake-report';
+import { LEADERBOARD_PROVIDER_RACE_REDIS_KEY } from '@/lib/redis-keys';
+
+// Weekly token volume per model lab, from a fixed start date through the most
+// recent complete day. Grouped at week x model_provider_company x
+// is_open_weights so a single payload drives both the per-lab "race" view and
+// an open-weight vs proprietary toggle. model_provider_company and
+// is_open_weights are maintained in the dbt model_dim seed (kilocode-dbt), so
+// the lab mapping lives in one place rather than being re-derived here.
+const LEADERBOARD_PROVIDER_RACE_QUERY = `
+select
+    to_char(date_trunc('week', ud.usage_date), 'YYYY-MM-DD') as week_start
+    , ud.model_provider_company as provider
+    , ud.is_open_weights
+    , sum(ud.total_tokens) as tokens
+from kilo_dw.dbt_prod.usage_daily as ud
+where
+    ud.usage_date >= '2025-07-01'
+    and ud.usage_date < current_date()
+    and ud.total_tokens > 0
+group by 1, 2, 3
+order by 1, 4 desc;
+`;
+
+const providerRaceSchema = z.array(
+  z.object({
+    weekStart: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+    provider: z.string().min(1),
+    isOpenWeights: z.boolean(),
+    tokens: z.number(),
+  })
+);
+
+type ProviderRace = z.infer<typeof providerRaceSchema>;
+
+function parseProviderRace(rows: string[][]): ProviderRace {
+  return rows.map(row => {
+    const [weekStart, provider, rawOpenWeights, rawTokens] = row;
+    const tokens = Number(rawTokens);
+
+    if (!weekStart || !provider || !Number.isFinite(tokens)) {
+      throw new Error('Snowflake returned an invalid provider race row');
+    }
+
+    return providerRaceSchema.element.parse({
+      weekStart,
+      provider,
+      isOpenWeights: rawOpenWeights === 'true' || rawOpenWeights === true,
+      tokens,
+    });
+  });
+}
+
+export const GET = createPublicSnowflakeReport({
+  cacheKey: LEADERBOARD_PROVIDER_RACE_REDIS_KEY,
+  errorMessage: 'Failed to fetch leaderboard provider race',
+  parseRows: parseProviderRace,
+  query: LEADERBOARD_PROVIDER_RACE_QUERY,
+  schema: providerRaceSchema,
+  source: 'public-leaderboard-provider-race-api',
+});
+
+export const OPTIONS = publicSnowflakeReportOptions;

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -52,6 +52,7 @@ export const LEADERBOARD_MODEL_PROVIDER_USAGE_REDIS_KEY = redisKey(
   'public-api:leaderboard-model-provider-usage'
 );
 export const LEADERBOARD_MODEL_USAGE_REDIS_KEY = redisKey('public-api:leaderboard-model-usage');
+export const LEADERBOARD_PROVIDER_RACE_REDIS_KEY = redisKey('public-api:leaderboard-provider-race');
 
 export const REQUEST_LOGGING_OPT_INS_REDIS_KEY = redisKey('ai-gateway:request-logging-opt-ins');
 


### PR DESCRIPTION
## Summary

Adds a public Snowflake-backed endpoint `GET /api/public/leaderboard-provider-race` that serves weekly token volume per model lab for the [kilo.ai/leaderboard/race](https://kilo.ai/leaderboard/race) visualization. The race page currently hardcodes 53 weeks of data in the landing repo; this endpoint lets it load dynamically.

The query groups `kilo_dw.dbt_prod.usage_daily` at `week × model_provider_company × is_open_weights` (fixed start `2025-07-01` → most recent complete day). One payload drives both the per-lab race and an open-weight vs proprietary toggle. The lab mapping (`model_provider_company`, `is_open_weights`) comes from the dbt `model_dim` seed rather than being re-derived in SQL — this is the same gap the Omni dashboard's CASE workaround was papering over.

Follows the existing `createPublicSnowflakeReport` pattern (Redis-cached 1h, CORS, Sentry) used by `leaderboard-model-usage` and `leaderboard-model-provider-usage`.

## Verification

- [x] `oxlint` clean on both changed files (0 errors)
- [x] Route is a structural copy of the adjacent `leaderboard-model-usage/route.ts`; `tsgo` reports no errors on the new files (full-repo typecheck blocked locally by unbuilt workspace packages — pre-existing, unrelated)
- [x] **End-to-end with live Snowflake data** — validated locally against `kilo_dw.dbt_prod.usage_daily`

### Live data verification (2026-07-27)

Endpoint tested locally on `localhost:3000`:

```
GET /api/public/leaderboard-provider-race
HTTP 200 | 207,685 bytes | 9ms (Redis-cached)
2,361 rows | 56 weeks | 50 providers
First week: 2025-06-30
Last week:  2026-07-20  (current partial week correctly excluded)
```

Top 5 labs in latest complete week (Jul 20, 2026):

| Rank | Provider | Tokens | Open Weights |
|------|----------|--------|--------------|
| 1 | Other | 1.06T | — |
| 2 | StepFun | 1.56T | ✓ |
| 3 | DeepSeek | 942B | ✓ |
| 4 | Z.ai | 438B | ✓ |
| 5 | OpenAI | 381B | ✗ |

Total platform volume: **6.90T tokens** — matches the landing page headline.

Snowflake Query History confirms the query executed with status **Success** on warehouse `WH_DBT_BACKEND_SANDBOX` as `KILOCODE_USER_DEV`.

anding race page consuming this endpoint
<img width="1624" height="1061" alt="Screenshot 2026-07-27 at 11 01 58" src="https://github.com/user-attachments/assets/7889df25-358e-474d-93d8-5ebc26cd9bab" />

Snowflake query history (Success)
<img width="1624" height="1061" alt="Screenshot 2026-07-27 at 11 07 08" src="https://github.com/user-attachments/assets/352ed7be-955d-4d84-9a7c-5f0478696830" />

<img width="1624" height="1061" alt="Screenshot 2026-07-27 at 11 23 30" src="https://github.com/user-attachments/assets/83ff0f19-97a0-4df3-a0eb-753fa80481f4" />


No errors in server logs. To verify: in the cloud tmux dashboard, select the `nextjs` pane (arrow keys + Enter) — incoming requests log there with status codes. Alternatively, browser DevTools → Network tab shows the 200 response with full JSON body.

## Visual Changes

N/A



## Reviewer Notes

- **Deploy dependency:** the query reads `usage_daily.is_open_weights`, added by kilocode-dbt PR #480 + its backfill (`2026-07-25-backfill-is-open-weights.sql`). That backfill must run before this endpoint returns data; until then the query errors and the endpoint returns 502 (cached `null`).
- Response shape: `[{ weekStart: "YYYY-MM-DD", provider: string, isOpenWeights: boolean | null, tokens: number }]`. `isOpenWeights` is `null` for unmapped models (`is_open_weights` NULL in `model_dim`) so the client can distinguish "unknown" from a confirmed closed-weight lab; only explicit `'true'`/`'false'` become a boolean. `is_open_weights` is per-model in dbt, so a lab like Alibaba appears in both open and closed rows; the client sums across `isOpenWeights` for the lab race and across `provider` for the open/closed view.
- `model_provider_company = 'other'` (unmapped models) is included so the client can bucket it; drop here if we'd rather exclude upstream.
