### PR TITLE
fix(web): add Play app signing certificate to Android assetlinks

### DIFF
--- a/apps/web/public/.well-known/assetlinks.json
+++ b/apps/web/public/.well-known/assetlinks.json
@@ -5,7 +5,8 @@
       "namespace": "android_app",
       "package_name": "com.kilocode.kiloapp",
       "sha256_cert_fingerprints": [
-        "39:87:0D:39:0E:45:88:4F:B8:B0:2D:A5:0C:E4:97:9B:EC:67:B2:CF:5F:69:D9:A8:84:79:5E:65:FD:B8:85:E7"
+        "39:87:0D:39:0E:45:88:4F:B8:B0:2D:A5:0C:E4:97:9B:EC:67:B2:CF:5F:69:D9:A8:84:79:5E:65:FD:B8:85:E7",
+        "89:8E:D2:CA:DA:01:0D:76:D1:CE:B4:98:A1:40:0D:E4:51:42:D3:E0:47:07:0C:CE:B6:0E:CB:E7:73:38:9D:6B"
       ]
     }
   }

--- a/apps/web/src/lib/app-site-association.test.ts
+++ b/apps/web/src/lib/app-site-association.test.ts
@@ -5,8 +5,12 @@ import { aasaComponents } from '@kilocode/app-shared/universal-links';
 
 const wellKnownDir = join(__dirname, '../../public/.well-known');
 
+// EAS upload certificate: covers internal-distribution and dev-client builds.
 const ANDROID_UPLOAD_CERT_FINGERPRINT =
   '39:87:0D:39:0E:45:88:4F:B8:B0:2D:A5:0C:E4:97:9B:EC:67:B2:CF:5F:69:D9:A8:84:79:5E:65:FD:B8:85:E7';
+// Google Play app signing certificate: covers everything installed from the store.
+const ANDROID_PLAY_SIGNING_CERT_FINGERPRINT =
+  '89:8E:D2:CA:DA:01:0D:76:D1:CE:B4:98:A1:40:0D:E4:51:42:D3:E0:47:07:0C:CE:B6:0E:CB:E7:73:38:9D:6B';
 
 describe('apple-app-site-association', () => {
   const raw = readFileSync(join(wellKnownDir, 'apple-app-site-association'), 'utf8');
@@ -59,7 +63,10 @@ describe('assetlinks.json', () => {
     expect(entry?.target.package_name).toBe('com.kilocode.kiloapp');
   });
 
-  it('lists only the verified EAS upload-certificate fingerprint', () => {
-    expect(parsed[0]?.target.sha256_cert_fingerprints).toEqual([ANDROID_UPLOAD_CERT_FINGERPRINT]);
+  it('lists the upload and Play app signing certificate fingerprints', () => {
+    expect(parsed[0]?.target.sha256_cert_fingerprints).toEqual([
+      ANDROID_UPLOAD_CERT_FINGERPRINT,
+      ANDROID_PLAY_SIGNING_CERT_FINGERPRINT,
+    ]);
   });
 });


### PR DESCRIPTION
Follow-up to #4783.

`assetlinks.json` listed only the **EAS upload certificate**, which covers internal-distribution and dev-client builds. Google Play re-signs uploads with the **app signing key**, so Play-installed builds present a different certificate and App Links verification fails — links open in the browser instead of the app.

Adds the Play app signing SHA-256 (from Play Console → Test and release → App integrity → App signing) alongside the existing upload fingerprint, so both build channels verify.

## Verification

- `assetlinks.json` parses; both entries are well-formed 32-byte uppercase colon-separated SHA-256, no duplicates.
- `apps/web/src/lib/app-site-association.test.ts` updated to expect both fingerprints. The jest suite needs a local Postgres (global setup calls `cleanupDbForTest`), which is not running here, so it was not executed locally — CI covers it.
- Post-deploy, on a Play internal-track install: `adb shell pm get-app-links com.kilocode.kiloapp` should report `verified` for `app.kilo.ai`.