### PR TITLE
fix(web): clarify OpenRouter endpoint retention

### DIFF
--- a/apps/web/src/components/organizations/providers-and-models/ModelDetailsDialog.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/ModelDetailsDialog.tsx
@@ -20,6 +20,7 @@ import type {
   ModelRow,
   ProviderOffering,
 } from '@/components/organizations/providers-and-models/providersAndModels.types';
+import { ProviderAttribution } from '@/components/organizations/providers-and-models/ProviderAttribution';
 
 export function ModelDetailsDialog({
   open,
@@ -117,7 +118,7 @@ export function ModelDetailsDialog({
                 <TableHead>In</TableHead>
                 <TableHead>Out</TableHead>
                 <TableHead>Trains</TableHead>
-                <TableHead>Retains prompts</TableHead>
+                <TableHead>Endpoint retention</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -145,7 +146,10 @@ export function ModelDetailsDialog({
                             />
                           ) : null}
                         </div>
-                        <span>{offering.providerDisplayName}</span>
+                        <ProviderAttribution
+                          providerDisplayName={offering.providerDisplayName}
+                          routingProviderDisplayName={offering.routingProviderDisplayName}
+                        />
                       </div>
                     </TableCell>
                     <TableCell>{formatPriceCompact(offering.promptPrice)}</TableCell>
@@ -154,7 +158,11 @@ export function ModelDetailsDialog({
                       <PolicyPill value={offering.trains} variant="trains" />
                     </TableCell>
                     <TableCell>
-                      <PolicyPill value={offering.retainsPrompts} variant="retainsPrompts" />
+                      <PolicyPill
+                        value={offering.retainsPrompts}
+                        variant="retainsPrompts"
+                        retentionDays={offering.retentionDays}
+                      />
                     </TableCell>
                   </TableRow>
                 );

--- a/apps/web/src/components/organizations/providers-and-models/OrganizationProvidersAndModelsPage.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/OrganizationProvidersAndModelsPage.tsx
@@ -32,7 +32,9 @@ import {
 import { preferredModels } from '@/lib/ai-gateway/models';
 import { AutoRoutingModeCard } from '@/components/auto-routing/AutoRoutingModeCard';
 import {
+  modelProviderDisplayName,
   modelRetainsPrompts,
+  modelRetentionDays,
   modelTrains,
 } from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
 
@@ -271,10 +273,12 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
 
       offerings.push({
         providerSlug: provider.slug,
-        providerDisplayName: provider.displayName,
+        providerDisplayName: modelProviderDisplayName(model, provider.displayName),
+        routingProviderDisplayName: provider.displayName,
         providerIconUrl: provider.icon?.url ? normalizeProviderIconUrl(provider.icon.url) : null,
         trains: modelTrains(model, provider.dataPolicy.training),
         retainsPrompts: modelRetainsPrompts(model, provider.dataPolicy.retainsPrompts),
+        retentionDays: modelRetentionDays(model),
         promptPrice: model.endpoint.pricing.prompt,
         completionPrice: model.endpoint.pricing.completion,
       });
@@ -421,6 +425,11 @@ export function OrganizationProvidersAndModelsPage({ organizationId, role }: Pro
         completionPrice: model.endpoint.pricing.completion,
         trains: modelTrains(model, provider.dataPolicy.training),
         retainsPrompts: modelRetainsPrompts(model, provider.dataPolicy.retainsPrompts),
+        retentionDays: modelRetentionDays(model),
+        endpointProviderDisplayName:
+          model.endpoint.provider_display_name === provider.displayName
+            ? undefined
+            : model.endpoint.provider_display_name,
       });
     }
 

--- a/apps/web/src/components/organizations/providers-and-models/PolicyPills.test.ts
+++ b/apps/web/src/components/organizations/providers-and-models/PolicyPills.test.ts
@@ -1,0 +1,29 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, test } from '@jest/globals';
+import { ProviderAttribution } from '@/components/organizations/providers-and-models/ProviderAttribution';
+import { PolicyPill } from '@/components/organizations/providers-and-models/PolicyPills';
+
+describe('endpoint policy presentation', () => {
+  test('shows the endpoint provider, routing provider, and retention duration', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(
+        React.Fragment,
+        null,
+        React.createElement(ProviderAttribution, {
+          providerDisplayName: 'Claude Platform on AWS',
+          routingProviderDisplayName: 'Amazon Bedrock',
+        }),
+        React.createElement(PolicyPill, {
+          value: true,
+          variant: 'retainsPrompts',
+          retentionDays: 30,
+        })
+      )
+    );
+
+    expect(html).toContain('Claude Platform on AWS');
+    expect(html).toContain('via Amazon Bedrock');
+    expect(html).toContain('30 days');
+  });
+});

--- a/apps/web/src/components/organizations/providers-and-models/PolicyPills.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/PolicyPills.tsx
@@ -1,6 +1,15 @@
+import React from 'react';
 import type { PolicyPillVariant } from '@/components/organizations/providers-and-models/providersAndModels.types';
 
-export function PolicyPill({ value, variant }: { value: boolean; variant: PolicyPillVariant }) {
+export function PolicyPill({
+  value,
+  variant,
+  retentionDays,
+}: {
+  value: boolean;
+  variant: PolicyPillVariant;
+  retentionDays?: number;
+}) {
   const base =
     'inline-flex items-center rounded-full border px-2 py-0.5 text-[11px] font-medium leading-none';
 
@@ -13,7 +22,9 @@ export function PolicyPill({ value, variant }: { value: boolean; variant: Policy
   }
 
   return (
-    <span className={`${base} border-orange-500/30 bg-orange-500/15 text-orange-300`}>Yes</span>
+    <span className={`${base} border-orange-500/30 bg-orange-500/15 text-orange-300`}>
+      {retentionDays === undefined ? 'Yes' : `${retentionDays} days`}
+    </span>
   );
 }
 

--- a/apps/web/src/components/organizations/providers-and-models/ProviderAttribution.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/ProviderAttribution.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+
+export function ProviderAttribution({
+  providerDisplayName,
+  routingProviderDisplayName,
+}: {
+  providerDisplayName: string;
+  routingProviderDisplayName: string;
+}) {
+  return (
+    <div>
+      <div>{providerDisplayName}</div>
+      {providerDisplayName !== routingProviderDisplayName ? (
+        <div className="text-muted-foreground mt-0.5 text-xs font-normal">
+          via {routingProviderDisplayName}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/components/organizations/providers-and-models/ProviderDetailsDialog.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/ProviderDetailsDialog.tsx
@@ -121,7 +121,7 @@ export function ProviderDetailsDialog({
                 <TableHead>In</TableHead>
                 <TableHead>Out</TableHead>
                 <TableHead>Trains</TableHead>
-                <TableHead>Retains prompts</TableHead>
+                <TableHead>Endpoint retention</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
@@ -141,6 +141,11 @@ export function ProviderDetailsDialog({
                     <TableCell>
                       <div className="font-medium">{model.modelName}</div>
                       <div className="text-muted-foreground mt-0.5 text-xs">{model.modelId}</div>
+                      {model.endpointProviderDisplayName ? (
+                        <div className="text-muted-foreground mt-0.5 text-xs">
+                          Endpoint: {model.endpointProviderDisplayName}
+                        </div>
+                      ) : null}
                     </TableCell>
                     <TableCell>{formatPriceCompact(model.promptPrice)}</TableCell>
                     <TableCell>{formatPriceCompact(model.completionPrice)}</TableCell>
@@ -148,7 +153,11 @@ export function ProviderDetailsDialog({
                       <PolicyPill value={model.trains} variant="trains" />
                     </TableCell>
                     <TableCell>
-                      <PolicyPill value={model.retainsPrompts} variant="retainsPrompts" />
+                      <PolicyPill
+                        value={model.retainsPrompts}
+                        variant="retainsPrompts"
+                        retentionDays={model.retentionDays}
+                      />
                     </TableCell>
                   </TableRow>
                 );

--- a/apps/web/src/components/organizations/providers-and-models/providersAndModels.types.ts
+++ b/apps/web/src/components/organizations/providers-and-models/providersAndModels.types.ts
@@ -22,9 +22,11 @@ export type ProviderRow = {
 export type ProviderOffering = {
   providerSlug: string;
   providerDisplayName: string;
+  routingProviderDisplayName: string;
   providerIconUrl: string | null;
   trains: boolean;
   retainsPrompts: boolean;
+  retentionDays: number | undefined;
   promptPrice: string;
   completionPrice: string;
 };
@@ -38,4 +40,6 @@ export type ProviderModelRow = {
   completionPrice: string;
   trains: boolean;
   retainsPrompts: boolean;
+  retentionDays: number | undefined;
+  endpointProviderDisplayName: string | undefined;
 };

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, test } from '@jest/globals';
 import {
+  modelProviderDisplayName,
   modelRetainsPrompts,
+  modelRetentionDays,
   modelTrains,
 } from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
 import { OpenRouterSearchResponse } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
@@ -25,7 +27,8 @@ describe('model data policy', () => {
           {
             ...baseModel,
             endpoint: {
-              provider_display_name: 'Amazon Bedrock (BYOK Only)',
+              provider_display_name: 'Claude Platform on AWS',
+              provider_slug: 'amazon-bedrock/claude-on-aws',
               is_free: false,
               pricing: { prompt: '0.000005', completion: '0.000025' },
               data_policy: {
@@ -40,9 +43,17 @@ describe('model data policy', () => {
     });
 
     const model = response.data.models[0];
-    expect(model?.endpoint?.data_policy).toEqual({ training: false, retainsPrompts: true });
+    expect(model?.endpoint).toMatchObject({
+      provider_display_name: 'Claude Platform on AWS',
+      provider_slug: 'amazon-bedrock/claude-on-aws',
+      data_policy: { training: false, retainsPrompts: true, retentionDays: 30 },
+    });
     expect(model && modelTrains(model, true)).toBe(false);
     expect(model && modelRetainsPrompts(model, false)).toBe(true);
+    expect(model && modelRetentionDays(model)).toBe(30);
+    expect(model && modelProviderDisplayName(model, 'Amazon Bedrock')).toBe(
+      'Claude Platform on AWS'
+    );
   });
 
   test('falls back to the provider policy for snapshots without endpoint policy', () => {
@@ -64,5 +75,7 @@ describe('model data policy', () => {
     const model = response.data.models[0];
     expect(model && modelTrains(model, true)).toBe(true);
     expect(model && modelRetainsPrompts(model, true)).toBe(true);
+    expect(model && modelRetentionDays(model)).toBeUndefined();
+    expect(model && modelProviderDisplayName(model, 'Amazon Bedrock')).toBe('Amazon Bedrock');
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/model-data-policy.ts
@@ -10,3 +10,14 @@ export function modelRetainsPrompts(
 ): boolean {
   return model.endpoint?.data_policy?.retainsPrompts ?? providerRetainsPrompts;
 }
+
+export function modelRetentionDays(model: OpenRouterModel): number | undefined {
+  return model.endpoint?.data_policy?.retentionDays;
+}
+
+export function modelProviderDisplayName(
+  model: OpenRouterModel,
+  providerDisplayName: string
+): string {
+  return model.endpoint?.provider_display_name ?? providerDisplayName;
+}

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -218,6 +218,8 @@ function injectExtraProviderModels(
           endpoint: {
             ...model.endpoint,
             provider_display_name: providerData.provider.displayName,
+            provider_slug: providerData.provider.slug,
+            data_policy: undefined,
             is_free: !endpoint.pricing?.prompt,
             pricing: endpoint.pricing ?? { prompt: '0', completion: '0' },
           },

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1713,12 +1713,14 @@ export const OpenRouterBaseModel = z.object({
 export type OpenRouterEndpoint = z.infer<typeof OpenRouterEndpoint>;
 export const OpenRouterEndpoint = z.object({
   provider_display_name: z.string(),
+  provider_slug: z.string().optional(),
   is_free: z.boolean(),
   pricing: OpenRouterPricing,
   data_policy: z
     .object({
       training: z.boolean().optional(),
       retainsPrompts: z.boolean().optional(),
+      retentionDays: z.number().int().nonnegative().optional(),
     })
     .nullish(),
 });


### PR DESCRIPTION
## Summary

- preserve OpenRouter endpoint provider identity and retention duration during provider sync
- distinguish endpoint providers from routing providers in model and provider details
- show endpoint retention durations such as 30 days instead of a generic Yes
- prevent synthetic provider models from inheriting another endpoint's data policy

## Verification

- `pnpm --filter web exec jest --runInBand src/lib/ai-gateway/providers/openrouter/model-data-policy.test.ts src/components/organizations/providers-and-models/PolicyPills.test.ts`
- `scripts/typecheck-all.sh --changes-only`
- targeted `oxlint` on all changed files
- `git diff --check`