### PR TITLE
feat(ai-gateway): include the vercel request id in upstream failure errors

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -255,6 +255,10 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // non-kilocode clients). `taskId` still wins when both are present.
   const sessionHeader = extractHeaderAndLimitLength(request, 'x-kilo-session');
   const machineIdHeader = extractHeaderAndLimitLength(request, 'x-kilocode-machineid');
+  // Vercel's per-invocation request id. Logged on the disconnect and upstream
+  // failure paths so a client disconnect can be correlated with the upstream
+  // error it causes, and with the platform logs for the same invocation.
+  const vercelRequestId = extractHeaderAndLimitLength(request, 'x-vercel-id');
 
   const logClientDisconnect = () => {
     // The request signal is forwarded to the upstream fetch and to the response
@@ -269,6 +273,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
         elapsed_ms: Math.round(performance.now() - requestStartedAt),
         client_request_id: clientRequestId,
         session_id: taskId ?? sessionHeader,
+        vercel_request_id: vercelRequestId,
       }
     );
   };
@@ -881,6 +886,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     extraHeaders,
     provider: effectiveProviderContext.provider,
     signal: request.signal,
+    vercelRequestId,
   });
   if (upstreamResult.type === 'error') {
     return upstreamResult.response;
@@ -968,7 +974,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     user: maybeUser,
     organization_id: organizationId || null,
     session_id: usageContext.session_id,
-    vercel_request_id: extractHeaderAndLimitLength(request, 'x-vercel-id'),
+    vercel_request_id: vercelRequestId,
     request: requestBodyParsed,
   };
 

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -140,38 +140,55 @@ function classifyUpstreamFetchFailure({
 }
 
 /**
+ * The Vercel request id makes a reported error traceable to the invocation that
+ * produced it, so it is appended to the message when the platform provided one.
+ */
+function withRequestId(message: string, vercelRequestId: string | null | undefined): string {
+  return vercelRequestId ? `${message} (request id: ${vercelRequestId})` : message;
+}
+
+/**
  * The client going away also aborts our upstream fetch, so the abort has to be
  * attributed to the client rather than reported as an upstream fault. The body
  * is mostly for logs and observability: the client that would read it is gone.
  * 499 mirrors the nginx convention so these cancellations do not show up as
  * upstream 5xx failures.
  */
-function clientDisconnectResponse() {
-  const error =
-    'The client disconnected before the upstream provider responded, so the request was cancelled. The upstream provider did not fail.';
+function clientDisconnectResponse(vercelRequestId: string | null | undefined) {
+  const error = withRequestId(
+    'The client disconnected before the upstream provider responded, so the request was cancelled. The upstream provider did not fail.',
+    vercelRequestId
+  );
   return NextResponse.json(
     {
       error,
       error_type: ProxyErrorType.client_disconnect,
       message: error,
+      ...(vercelRequestId && { vercel_request_id: vercelRequestId }),
     },
     { status: 499 }
   );
 }
 
-function upstreamFetchFailureResponse(failureFamily: UpstreamFetchFailureFamily) {
-  const error =
+function upstreamFetchFailureResponse(
+  failureFamily: UpstreamFetchFailureFamily,
+  vercelRequestId: string | null | undefined
+) {
+  const error = withRequestId(
     failureFamily === 'request_timeout' ||
-    failureFamily === 'headers_timeout' ||
-    failureFamily === 'connect_timeout' ||
-    failureFamily === 'read_timeout'
+      failureFamily === 'headers_timeout' ||
+      failureFamily === 'connect_timeout' ||
+      failureFamily === 'read_timeout'
       ? 'The upstream provider did not send response headers before the gateway timeout.'
-      : 'The upstream provider closed the connection before sending a response.';
+      : 'The upstream provider closed the connection before sending a response.',
+    vercelRequestId
+  );
   return NextResponse.json(
     {
       error,
       error_type: ProxyErrorType.upstream_disconnect,
       message: error,
+      ...(vercelRequestId && { vercel_request_id: vercelRequestId }),
     },
     { status: 503 }
   );
@@ -185,6 +202,7 @@ export async function upstreamRequest({
   extraHeaders,
   provider,
   signal,
+  vercelRequestId,
 }: {
   path: string;
   search: string;
@@ -193,6 +211,8 @@ export async function upstreamRequest({
   extraHeaders: Record<string, string>;
   provider: Provider;
   signal?: AbortSignal;
+  /** Incoming `x-vercel-id`, used to correlate failures with the platform logs. */
+  vercelRequestId?: string | null;
 }): Promise<{ type: 'success'; response: Response } | { type: 'error'; response: NextResponse }> {
   const headers = new Headers();
   for (const [key, value] of Object.entries(ATTRIBUTION_HEADERS)) {
@@ -210,7 +230,8 @@ export async function upstreamRequest({
   const timeoutSignal = AbortSignal.timeout(TIMEOUT_MS);
   const onTimeoutAbort = () => {
     errorExceptInTest(
-      `[upstreamRequest] gateway timeout after ${TIMEOUT_MS}ms waiting for upstream response headers`
+      `[upstreamRequest] gateway timeout after ${TIMEOUT_MS}ms waiting for upstream response headers`,
+      { vercelRequestId: vercelRequestId ?? '<none>' }
     );
   };
   timeoutSignal.addEventListener('abort', onTimeoutAbort);
@@ -253,6 +274,7 @@ export async function upstreamRequest({
         failureFamily,
         errorName,
         errorMessage,
+        ...(vercelRequestId && { vercelRequestId }),
         ...(causeCode && { causeCode }),
         ...(causeName && { causeName }),
         ...(causeMessage && { causeMessage }),
@@ -280,8 +302,8 @@ export async function upstreamRequest({
     return {
       type: 'error',
       response: causedByClientDisconnect
-        ? clientDisconnectResponse()
-        : upstreamFetchFailureResponse(failureFamily ?? 'unknown'),
+        ? clientDisconnectResponse(vercelRequestId)
+        : upstreamFetchFailureResponse(failureFamily ?? 'unknown', vercelRequestId),
     };
   }
 }

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -117,6 +117,70 @@ describe('upstreamRequest timeout', () => {
     });
   });
 
+  it('includes the vercel request id in the error message and failure metadata', async () => {
+    const resetCause = Object.assign(new Error('socket hang up'), { code: 'ECONNRESET' });
+    global.fetch = jest
+      .fn()
+      .mockRejectedValue(new TypeError('fetch failed', { cause: resetCause }));
+
+    const result = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+      vercelRequestId: 'iad1::iad1::request-id',
+    });
+
+    expect(result.type).toBe('error');
+    if (result.type !== 'error') throw new Error('expected an error result');
+    await expect(result.response.json()).resolves.toEqual({
+      error:
+        'The upstream provider closed the connection before sending a response. (request id: iad1::iad1::request-id)',
+      error_type: 'upstream_disconnect',
+      message:
+        'The upstream provider closed the connection before sending a response. (request id: iad1::iad1::request-id)',
+      vercel_request_id: 'iad1::iad1::request-id',
+    });
+    expect(mockCaptureException).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({
+        extra: expect.objectContaining({ vercelRequestId: 'iad1::iad1::request-id' }),
+      })
+    );
+  });
+
+  it('includes the vercel request id when the client disconnects', async () => {
+    const controller = new AbortController();
+    controller.abort();
+
+    const result = await upstreamRequest({
+      path: '/chat/completions',
+      search: '',
+      method: 'POST',
+      body: {
+        model: 'test-model',
+        messages: [{ role: 'user', content: 'test' }],
+      },
+      extraHeaders: {},
+      provider: PROVIDERS.OPENROUTER,
+      signal: controller.signal,
+      vercelRequestId: 'iad1::iad1::request-id',
+    });
+
+    expect(result.type).toBe('error');
+    if (result.type !== 'error') throw new Error('expected an error result');
+    expect(result.response.status).toBe(499);
+    await expect(result.response.json()).resolves.toMatchObject({
+      error_type: 'client_disconnect',
+      vercel_request_id: 'iad1::iad1::request-id',
+    });
+  });
+
   it('classifies request timeout aborts separately', async () => {
     const timeoutError = new DOMException(
       'The operation was aborted due to timeout',


### PR DESCRIPTION
## Why

Follow-up to #4795. The client-disconnect and upstream-failure messages now say *what* happened, but a reported error still can't be tied to the invocation that produced it. The incoming `x-vercel-id` is the id shown in Vercel logs, so including it makes those errors traceable.

## Changes

- `upstreamRequest` takes an optional `vercelRequestId`. When present:
  - the client-disconnect (499) and upstream-failure (503) bodies append `(request id: <id>)` to `error`/`message` and add a `vercel_request_id` field;
  - the Sentry/console upstream fetch failure metadata includes `vercelRequestId`;
  - the gateway timeout log includes it (`<none>` when absent).
- `route.ts` resolves `x-vercel-id` once into `vercelRequestId`, passes it to `upstreamRequest`, adds `vercel_request_id` to the client-disconnect log, and reuses the same value for the existing request-log field.

Behaviour is unchanged when the header is absent (local dev, tests): no `(request id: …)` suffix and no extra field.

## Verification

- `pnpm --filter web test -- src/tests/openrouterApi.timeout.test.ts` (two new cases covering the id in the upstream-failure body/metadata and in the client-disconnect body)
- `pnpm --filter web test -- src/app/api/openrouter`
- `pnpm --filter web typecheck`, `pnpm --filter web lint`, `pnpm format`