### PR TITLE
fix(auto-routing): keep session incumbents inside the benchmark noise band

### DIFF
--- a/apps/mobile/.kilo/WORKFLOW_LEARNINGS.md
+++ b/apps/mobile/.kilo/WORKFLOW_LEARNINGS.md
@@ -30,3 +30,17 @@ Then wait event-driven with an `until grep -q EXITCODE= "$LOG"` loop that also b
 **Fix.** A round that produced no explicit verdict line is **void, never a pass**. Re-dispatch a fresh agent — the review gate wants a fresh session per round anyway, so nothing is lost. Detect it by requiring the verdict text itself (`No findings.` or a numbered list), not by exit code. If several consecutive rounds die at the same point, shrink the handoff rather than retrying unchanged.
 
 ## Orchestrator
+
+### Waiting on the EXITCODE marker false-triggers mid-run
+
+**Symptom.** An `until grep -q EXITCODE= "$LOG"` wait loop (Planner section, first entry) reports the role agent finished while it is still running: the string `EXITCODE=` already appears in the log because the agent read `WORKFLOW_LEARNINGS.md` or a handoff that documents the pattern, and the TUI echoes it into the capture.
+
+**Cause.** The wait pattern greps for a marker that is no longer unique to the wrapper's final append.
+
+**Fix.** Treat the run as done only when the tmux session is gone **or** the marker is the last line of the log (`tail -1 "$LOG" | grep -q '^EXITCODE=[0-9]'`). The plain `grep -q EXITCODE=` form is only safe if neither the handoff nor anything the agent is likely to read mentions the pattern — which this file does, so prefer the last-line check.
+
+### Reading Kilobot's no-findings state (post #4765)
+
+**Symptom.** The completion gate wants "Kilobot has reviewed the latest head", but the review no longer arrives as inline threads: with the bot skip/permit config (#4765) on main, a clean review produces a green `Kilo Code Review` check plus exactly one issue comment from `kilo-code-bot[bot]` headed `Status: No Issues Found | Recommendation: Merge`.
+
+**Fix.** That combination — green check on the current head, the no-issues summary comment, zero review threads (`gh api repos/.../pulls/<n>/comments` empty) — *is* the reviewed-with-no-findings state. There is nothing to reply to or resolve; the gate is met. A `BLOCKED`/`REVIEW_REQUIRED` merge state at that point only means the requested human review is pending.

--- a/apps/mobile/.kilo/WORKFLOW_LEARNINGS.md
+++ b/apps/mobile/.kilo/WORKFLOW_LEARNINGS.md
@@ -4,4 +4,29 @@ Environment blockers and their fixes, recorded by the planner or orchestrator fo
 
 ## Planner
 
+### Dispatching role agents from a non-kilo harness (tmux, exit codes, void rounds)
+
+**Symptom.** A `kilo run --agent <role>` dispatched from a harness whose Bash tool has a 10-minute timeout gets killed mid-review. Worse, a run that is piped (`kilo run ... | tee log`) records the exit status of `tee`, not of kilo, so a crashed agent reports `EXITCODE=0` and reads as a clean pass.
+
+**Cause.** Two independent traps: the harness command timeout, and `$?` after a pipeline referring to the last stage.
+
+**Fix.** Run the agent inside a tmux window from a small wrapper script, redirect rather than pipe, and append the exit code of the redirected command:
+
+```bash
+cd "$WORKTREE/apps/mobile"   # .kilo/agent/ must be discoverable from the cwd
+kilo run "$(cat msg.txt)" --model kilo/x-ai/grok-4.5 --variant high \
+  --agent mobile-plan-reviewer --file "$PLAN" > "$LOG" 2>&1
+echo "EXITCODE=$?" >> "$LOG"
+```
+
+Then wait event-driven with an `until grep -q EXITCODE= "$LOG"` loop that also breaks when the tmux session disappears. Keep the message positional **before** the flags: `--file` takes multiple values and swallows a trailing message as a path.
+
+### A kilo role agent can exit mid-run with no verdict — treat it as a void round
+
+**Symptom.** The agent's log ends on an ordinary progress line ("Checking how decider scores are assigned…"), the tmux window is gone, and no findings list was ever printed. With a piped exit code this is indistinguishable from a pass.
+
+**Cause.** Long kilo runs die on provider stream stalls, typically 10–15 minutes in. Nothing about the plan or the repository is wrong.
+
+**Fix.** A round that produced no explicit verdict line is **void, never a pass**. Re-dispatch a fresh agent — the review gate wants a fresh session per round anyway, so nothing is lost. Detect it by requiring the verdict text itself (`No findings.` or a numbered list), not by exit code. If several consecutive rounds die at the same point, shrink the handoff rather than retrying unchanged.
+
 ## Orchestrator

--- a/services/auto-routing/src/decision-engine.test.ts
+++ b/services/auto-routing/src/decision-engine.test.ts
@@ -316,6 +316,212 @@ describe('computeDecision', () => {
     });
   });
 
+  describe('benchmark noise band', () => {
+    // Every fixture below is taken verbatim from the live routing table
+    // (decider-2026-07-22T10-51-06-305Z, minAccuracy 0.95): accuracies are the
+    // published k/30 roundings and costs the published avgCostUsd. In
+    // cost_per_accuracy mode the fresh pick is candidates[0] after filtering,
+    // so each route array lists the named fresh pick first.
+    const liveClassification = (
+      taskType: ClassifierOutput['taskType'],
+      subtaskType: ClassifierOutput['subtaskType']
+    ): ClassifierOutput => ({ ...classification, taskType, subtaskType });
+
+    it('keeps the incumbent on a zero-passer route when it sits inside the band', () => {
+      // investigation/codebase_understanding has no threshold-meeting
+      // candidate. kimi-k2.7-code is less accurate AND ~1.16x more expensive
+      // per benchmark case than the fresh pick, yet it is kept: 0.8667 clears
+      // the 0.85 band floor, and 0.01094 * 3 is not less than 0.01272, so the
+      // cost condition does not fire either.
+      const zeroPasserTable: RoutingTable = {
+        ...table,
+        minAccuracy: 0.95,
+        routes: {
+          'investigation/codebase_understanding': [
+            {
+              model: 'moonshotai/kimi-k3',
+              accuracy: 0.9333,
+              avgCostUsd: 0.01094,
+              meetsThreshold: false,
+            },
+            {
+              model: 'moonshotai/kimi-k2.7-code',
+              accuracy: 0.8667,
+              avgCostUsd: 0.01272,
+              meetsThreshold: false,
+            },
+          ],
+        },
+      };
+      const decision = computeDecision(
+        liveClassification('investigation', 'codebase_understanding'),
+        zeroPasserTable,
+        'moonshotai/kimi-k2.7-code'
+      );
+      expect(decision).toMatchObject({
+        model: 'moonshotai/kimi-k2.7-code',
+        sticky: true,
+        switchReason: null,
+      });
+    });
+
+    it('keeps an in-band incumbent when the route’s sole passer is far more expensive', () => {
+      // planning_design/technical_planning has exactly one passer,
+      // claude-sonnet-5 at $0.0394/case. Keeping inkling (0.9333, $0.0061)
+      // gives up +0.033 accuracy — one graded case out of thirty — and the
+      // cost escape cannot help here: 0.0394 * 3 = 0.1182 is not less than
+      // 0.0061, so the band is the only thing preventing the switch onto a
+      // model 6.5x more expensive.
+      const solePasserTable: RoutingTable = {
+        ...table,
+        minAccuracy: 0.95,
+        routes: {
+          'planning_design/technical_planning': [
+            {
+              model: 'anthropic/claude-sonnet-5',
+              accuracy: 0.9667,
+              avgCostUsd: 0.0394,
+              meetsThreshold: true,
+            },
+            {
+              model: 'thinkingmachines/inkling',
+              accuracy: 0.9333,
+              avgCostUsd: 0.0061,
+              meetsThreshold: false,
+            },
+          ],
+        },
+      };
+      const decision = computeDecision(
+        liveClassification('planning_design', 'technical_planning'),
+        solePasserTable,
+        'thinkingmachines/inkling'
+      );
+      expect(decision).toMatchObject({
+        model: 'thinkingmachines/inkling',
+        sticky: true,
+        switchReason: null,
+      });
+    });
+
+    it('keeps a below-bar incumbent over a threshold-clearing fresh pick when the gap is 2/30 graded cases', () => {
+      // debugging/root_cause_analysis, the modal live case: the fresh pick
+      // clears the bar and costs the same to four decimal places
+      // ($0.00274548 vs $0.00274055), so the entire benefit of keeping
+      // kimi-k2.7-code is prompt-cache continuity. At n=10 distinct graded
+      // cases, 27/30 vs 29/30 is a difference the benchmark cannot resolve.
+      const modalTable: RoutingTable = {
+        ...table,
+        minAccuracy: 0.95,
+        routes: {
+          'debugging/root_cause_analysis': [
+            {
+              model: 'minimax/minimax-m3',
+              accuracy: 0.9667,
+              avgCostUsd: 0.00275,
+              meetsThreshold: true,
+            },
+            {
+              model: 'moonshotai/kimi-k2.7-code',
+              accuracy: 0.9,
+              avgCostUsd: 0.00274,
+              meetsThreshold: false,
+            },
+          ],
+        },
+      };
+      const decision = computeDecision(
+        liveClassification('debugging', 'root_cause_analysis'),
+        modalTable,
+        'moonshotai/kimi-k2.7-code'
+      );
+      expect(decision).toMatchObject({
+        model: 'moonshotai/kimi-k2.7-code',
+        sticky: true,
+        switchReason: null,
+      });
+    });
+
+    it("labels an in-band incumbent's cost-driven ejection as switchReason 'cost', not 'threshold'", () => {
+      // planning_design/architecture_design: the incumbent is inside the
+      // band, so the old code would have ejected it as 'threshold'; the band
+      // makes it eligible, and the ejection is then caused by the unchanged
+      // cost condition: 0.00660620 * 3 = 0.01981860 < 0.03943792. Telemetry
+      // must therefore read 'cost' — otherwise the before/after measurement
+      // of this change reads its own relabels backwards.
+      const relabelTable: RoutingTable = {
+        ...table,
+        minAccuracy: 0.95,
+        routes: {
+          'planning_design/architecture_design': [
+            {
+              model: 'thinkingmachines/inkling',
+              accuracy: 0.9,
+              avgCostUsd: 0.0066062,
+              meetsThreshold: false,
+            },
+            {
+              model: 'anthropic/claude-sonnet-5',
+              accuracy: 0.9,
+              avgCostUsd: 0.03943792,
+              meetsThreshold: false,
+            },
+          ],
+        },
+      };
+      const decision = computeDecision(
+        liveClassification('planning_design', 'architecture_design'),
+        relabelTable,
+        'anthropic/claude-sonnet-5'
+      );
+      expect(decision).toMatchObject({
+        model: 'thinkingmachines/inkling',
+        sticky: false,
+        switchReason: 'cost',
+      });
+    });
+
+    it('best_accuracy mode still ejects an in-band incumbent below the threshold', () => {
+      // Same route and incumbent as the sole-passer keep case above, with
+      // the mode flipped and the outcome inverted: the accuracy gap is
+      // 0.0334, below the 0.05 bestAccuracySwitchThreshold, so the gap
+      // condition alone would keep inkling — only best_accuracy still
+      // requiring meetsThreshold can eject it.
+      const solePasserTable: RoutingTable = {
+        ...table,
+        minAccuracy: 0.95,
+        routes: {
+          'planning_design/technical_planning': [
+            {
+              model: 'anthropic/claude-sonnet-5',
+              accuracy: 0.9667,
+              avgCostUsd: 0.0394,
+              meetsThreshold: true,
+            },
+            {
+              model: 'thinkingmachines/inkling',
+              accuracy: 0.9333,
+              avgCostUsd: 0.0061,
+              meetsThreshold: false,
+            },
+          ],
+        },
+      };
+      const decision = computeDecision(
+        liveClassification('planning_design', 'technical_planning'),
+        solePasserTable,
+        'thinkingmachines/inkling',
+        new Set(),
+        'best_accuracy'
+      );
+      expect(decision).toMatchObject({
+        model: 'anthropic/claude-sonnet-5',
+        sticky: false,
+        switchReason: 'threshold',
+      });
+    });
+  });
+
   describe('capability filters', () => {
     const visionTable: RoutingTable = {
       ...table,

--- a/services/auto-routing/src/decision-engine.ts
+++ b/services/auto-routing/src/decision-engine.ts
@@ -150,6 +150,23 @@ function applyCapabilityFilters(
   return { filtered: maxContextFallback, reason: 'ok' };
 }
 
+// A route's accuracy is graded on 10 distinct benchmark cases
+// (datasets/decider-cases.ts, >=10 per taxonomy route; repetitions re-run the
+// same prompts and add no independent tasks). At n=10 the one-sided 95% Wilson
+// upper bound only drops below a 0.95 bar at an observed accuracy of ~0.837, so
+// pass/fail at 0.95 flips on binomial noise — and each flip ejects every session
+// parked on that model, paying a full prompt-cache rebuild for a difference the
+// benchmark cannot resolve. Keep a cost-mode incumbent inside the band instead.
+// This is a fixed band, not a per-route interval: replace it with a published
+// Wilson bound once the routing table carries per-route case counts. 0.10 is
+// deliberately inside the [0.0833, 0.1167) plateau where behaviour is identical
+// on the current table, and stricter than the n=10 boundary (~0.113), so it never
+// keeps a model a real interval would eject. Do not nudge it toward either edge:
+// published accuracies are toFixed(4) roundings of k/30, so 0.083 rounds the floor
+// above 26/30 and silently drops that entire tier of retained incumbents (not
+// the single largest group, which sits at 27/30 and is unaffected).
+const STICKY_ACCURACY_TOLERANCE = 0.1;
+
 export function computeDecision(
   classification: ClassifierOutput,
   table: RoutingTable | null,
@@ -190,9 +207,17 @@ export function computeDecision(
   // by a fresh pick from the eligible set, not kept.
   const incumbent =
     incumbentModel === null ? undefined : candidates.find(c => c.model === incumbentModel);
+  // Sticky eligibility, shared by the keep decision and the switchReason
+  // telemetry below so the two can never disagree. best_accuracy keeps the
+  // strict bar (that mode exists to buy accuracy); cost_per_accuracy keeps
+  // any incumbent inside the benchmark noise band.
+  const incumbentStickyEligible = (candidate: RankedCandidate): boolean =>
+    mode === 'best_accuracy'
+      ? candidate.meetsThreshold
+      : candidate.accuracy >= table.minAccuracy - STICKY_ACCURACY_TOLERANCE;
   const stickyIncumbent =
     incumbent &&
-    incumbent.meetsThreshold &&
+    incumbentStickyEligible(incumbent) &&
     incumbent.model !== freshPick.model &&
     ((mode === 'cost_per_accuracy' &&
       !(freshPick.avgCostUsd * table.switchCostFactor < incumbent.avgCostUsd)) ||
@@ -224,11 +249,11 @@ export function computeDecision(
     // 'cost': the incumbent was eligible but the mode's switch condition
     // (cost factor / accuracy gap) made the fresh pick worth it;
     // 'capability': the modality/context filters ejected it from the route;
-    // 'threshold': it is denied, off the route, or below the accuracy bar.
+    // 'threshold': it is denied, off the route, or outside the accuracy band.
     switchReason: !switched
       ? null
       : incumbent
-        ? incumbent.meetsThreshold
+        ? incumbentStickyEligible(incumbent)
           ? 'cost'
           : 'threshold'
         : routeCandidates.some(c => c.model === incumbentModel)


### PR DESCRIPTION
## Summary

In `cost_per_accuracy` mode, `computeDecision` kept a session's incumbent model only when the incumbent cleared the route's `minAccuracy` bar (0.95). That bar is a point estimate over **10 distinct benchmark cases per route** (repetitions re-run the same prompts and add no independent tasks), so pass/fail flips on binomial noise — and every flip ejects every session parked on that model, discarding a warm prompt cache at ~72k median context.

The change replaces the `meetsThreshold` requirement on the sticky path with a tolerance band: keep a cost-mode incumbent whose route accuracy is within **0.10** of `minAccuracy`. `best_accuracy` mode still requires `meetsThreshold`, and the existing cost escape (fresh pick cheaper by more than `switchCostFactor`) still fires. `switchReason` telemetry now derives from the same predicate as the keep decision, so a band-eligible incumbent that is cost-switched is labelled `cost`, not `threshold`.

Measured against the live routing table (`decider-2026-07-22T10-51-06-305Z`) and a pinned 24-hour telemetry window (2026-07-26T12:00Z – 2026-07-27T12:00Z, Axiom `cloudflare-logpush`):

| Measure | Baseline | Predicted after deploy |
|---|---|---|
| Real model switches/day | 109 (threshold 91, cost 16, capability 2) | threshold **~42**, cost **~22**, capability 2 |
| Sessions with ≥1 switch/day | 54 (23 multi-switch, one with 11) | should fall materially |

The band makes 49 of the 91 threshold-forced incumbents eligible to stay; 6 of those still fail the unchanged cost condition and are **relabelled** `threshold → cost` rather than prevented — hence the predicted `cost` rise, which is expected behaviour, not a regression. Net effect: **43 of 91 daily forced switches (47 %) disappear**, including 9 of the 14 daily punts onto `claude-sonnet-5` in `planning_design/technical_planning` (its sole passer, at 6.2–14.2× the incumbents' benchmark-case cost). The split is discriminating: the largest remaining ejection (`minimax-m3` leaving `debugging/bug_fixing` at 24/30) is genuinely weak there and still fires.

**Correction to the source document.** The source doc's diagnosis is confirmed (83 % of switches are threshold-forced; 98 % follow a route change, concentrated in sessions oscillating between semantically adjacent routes). Its **magnitude is wrong by ~53×**: it modelled 22.6 switches per 100 turns by assuming a 50 % route-change probability per turn; the measured rate is 0.43 per 100 decisions, because the classifier cache hits 95 % of the time within a conversation. The modelled "$300–400/day of forced-switch cache rebuilds" is really **$2–25/day**. The justification for shipping is therefore not the line item but the 54 sessions/day that get a model swapped mid-conversation — a visible latency and behaviour event — 83 % of them decided by a gate the benchmark cannot resolve.

**Honest disclosure — what the band retains.** Classifying all 43 net retentions: **A1** (19/day) keeps an incumbent that is materially cheaper (0.07–0.86×) than a threshold-clearing fresh pick; **A2** (11/day) declines a *qualified upgrade* for cache continuity alone — the modal case keeps `kimi-k2.7-code` (27/30) over `minimax-m3` (29/30, clears the bar) at a $0.000005 cost difference, i.e. it acts on a difference of 2 graded cases out of 30 that n = 10 cannot resolve (the one-sided Wilson upper bound for 0.9000 is 0.977, above the bar); **B** (13/day) chooses between two models that both miss the bar on a zero-passer route. A2 is the class a reviewer should challenge: this change forgoes ~11 qualified upgrades/day by design. A dominance guard that would cut the 10/day strictly-dominated retentions was considered and rejected — it acts on `avgCostUsd` margins (1.16–1.26×) that are not trustworthy at that size, and it barely touches A2 (11 → 10/day) because in the modal case the fresh pick costs fractionally *more*. Re-examine both if the routing table ever carries a real per-turn cost signal (cache-read price rather than benchmark-case average).

**Simpler-shape decision (recorded per workflow).** The source doc asked for a Wilson lower bound / publish-time hysteresis on `meetsThreshold` (Step 2) *and* an ε band on the sticky condition (Step 3). Implementing both separately means publishing per-candidate case counts or interval bounds through `RankedCandidateSchema` → the table builder → a new D1 column → `rowsToRoutingTable`, then computing an interval at serve time. At the live dataset size that machinery is inert: with n = 10 the Wilson boundary sits at an observed accuracy of ≈ 0.837, a 0.10 band keeps everything ≥ 0.85, and the two rules differ only on accuracies in [0.837, 0.85) — of which the live table contains none (every published accuracy is a multiple of 1/30). On the data actually served the two rules select identical models, so this PR ships the constant, calibrated against the measured identical-behaviour plateau **[0.0833, 0.1167)** ("keep ≥ 26/30, eject ≤ 25/30"), with the upgrade path marked in a code comment.

**Rollback:** revert-and-redeploy; the change takes effect on the next `auto-routing` worker deploy. Deliberately no kill-switch knob — adding one would mean the same contract/migration surface this PR avoids.

**Deferred, with re-entry criteria (not silently dropped):**

- **(a) Adding benchmark cases to hot routes** (source Step 2's first move). New decider cases need a full benchmark run to validate, and a poorly specified case shifts the very thresholds this change makes robust. Re-entry: its own change, acceptance = a published benchmark run, once the per-route case results in the benchmark D1 are readable.
- **(b) Route-flip debounce** (source Step 4). The phenomenon is real and dominant (100 % of switches follow a route change; multi-switch sessions visibly alternate adjacent routes), but the band breaks those cycles at the source, and whatever it does not catch is where keeping the model costs the most accuracy — where a debounce is least defensible. Debounce also needs new Durable Object state and one turn of delayed adaptation. Re-entry: on ≥ 3 days of post-deploy data, if switch volume has not fallen materially and multi-switch sessions still alternate, build it.
- **(c) "Within ε of the *best* candidate" arm / stickiness on empty passing sets** (source Step 3's second arm). Deferred as a genuinely different policy with a worse failure mode: relative-to-best keeps an incumbent where *nothing* is good (on `codebase_understanding` the field spans 16/30–28/30; "within ε of best" could retain a 0.53 model under a 0.60 best). Note the shipped absolute band already fires on zero-passer routes — `investigation/codebase_understanding` has 0 passers but 9 of 14 candidates in band — so the arm is not needed to reach the degenerate routes. Re-entry: a route with meaningful traffic that keeps switching **and** has no in-band candidates at all gets its own change and review.
- **(d) Cost-relative override** (keep a below-band incumbent when the only passer is dramatically more expensive). Deferred as a second, uncalibrated policy; the band plus the existing cost condition covers the common case.

**Post-deploy validation (not a gate on this PR):** re-run the pinned-window Axiom query on ≥ 3 days of data. Primary signal: `threshold` switches ~91/day → ~42/day (falsifiable prediction; a materially different outcome means the mechanism model is wrong), `cost` 16 → ~22 (relabels), `capability` unchanged at 2. A `cost` count materially above ~22 is the real warning sign — it would mean in-band incumbents are kept and then cost-switched a turn later, churn the band was supposed to remove rather than relocate. Guardrail: watch per-route `decidedModel` mix for drift toward the expensive end, since an in-band incumbent can now sit at up to 3× the cheapest eligible model's cost on every subsequent turn — the main product risk against the one-time rebuild saving. The prediction is void if a new routing table publishes before measurement.

## Verification

No manual device or UI testing: the change alters which model a server-side routing decision returns inside a worker with no UI, no new failure mode, and no user-facing surface — the feature-state matrix is structurally not applicable, and no mobile/web client renders anything derived from `sticky` or `switchReason`.

- [x] `pnpm vitest run src/decision-engine.test.ts` — 38/38, including 5 new fixtures taken verbatim from the live routing table (zero-passer keep, sole-expensive-passer keep, qualified-upgrade-declined keep, in-band cost relabel, `best_accuracy` still ejects)
- [x] `pnpm test` in `services/auto-routing` (143/143) and `packages/auto-routing-contracts` (84/84) — every pre-existing test passes **unedited** (no existing test encodes "below threshold ⇒ always switch"; the one candidate, `weak/chat` at 0.5 vs a 0.6 band floor, was pre-verified)
- [x] Root `pnpm typecheck`, `pnpm lint`, `git diff --check` clean
- [x] Independent reviewer pass: **No findings** (residual risks noted below)

## Visual Changes

N/A

## Reviewer Notes

- Everything hangs on one predicate, `incumbentStickyEligible`, which is shared by the keep decision and the `switchReason` derivation so the two cannot disagree — the one way this change could silently corrupt its own before/after measurement was keying `switchReason` to `meetsThreshold` while keeping on the band. Test 5d (`planning_design/architecture_design`, `inkling` $0.00660620 vs incumbent `claude-sonnet-5` $0.03943792, both below bar but in band → must read `cost`) exists specifically to catch that; test 5e (same route as 5b, mode flipped to `best_accuracy`, accuracy gap 0.0334 < the 0.05 switch threshold) exists to catch the band leaking into `best_accuracy`.
- Fixture arrays list the named fresh pick first because `pickFreshCandidate` returns `candidates[0]` in cost mode — a fixture listing the incumbent first would silently test a different scenario.
- Residual testing risks from the independent review: no unit case pins the exact band floor (live fixtures sit strictly above it); 5d/5e discrimination was verified by fixture arithmetic and control-flow reading rather than by breaking the predicate; the post-deploy Axiom checks above remain the real production gate.
- The second commit (`docs(mobile): record planner workflow learnings`) is a required workflow deliverable, unrelated to the behavioural change.
