### PR TITLE
fix(web): add web search CLI config schema

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -76,10 +76,9 @@ export const kiloExtras = {
       type: 'boolean',
     },
     web_search: {
-      description:
-        'Make web search available to models from all providers (default: true). Set to false to limit it to managed providers.',
+      description: 'Make web search available to models from all providers (default: false)',
       type: 'boolean',
-      default: true,
+      default: false,
     },
     commit_message: {
       description: 'Configuration for AI-generated commit messages',

--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -75,6 +75,12 @@ export const kiloExtras = {
       description: 'Hide Kilo Gateway models that may train on your prompts from model listings',
       type: 'boolean',
     },
+    web_search: {
+      description:
+        'Make web search available to models from all providers (default: true). Set to false to limit it to managed providers.',
+      type: 'boolean',
+      default: true,
+    },
     commit_message: {
       description: 'Configuration for AI-generated commit messages',
       type: 'object',

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -51,7 +51,7 @@ describe('kilo config.json schema merge', () => {
     expect(props.terminal_command_display).toBeDefined();
     expect(props.code_edit_display).toBeDefined();
     expect(props.hide_prompt_training_models).toBeDefined();
-    expect(props.web_search).toEqual(expect.objectContaining({ type: 'boolean', default: true }));
+    expect(props.web_search).toEqual(expect.objectContaining({ type: 'boolean', default: false }));
   });
 
   test('auto_collapse_reasoning is a boolean', () => {

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -51,6 +51,7 @@ describe('kilo config.json schema merge', () => {
     expect(props.terminal_command_display).toBeDefined();
     expect(props.code_edit_display).toBeDefined();
     expect(props.hide_prompt_training_models).toBeDefined();
+    expect(props.web_search).toEqual(expect.objectContaining({ type: 'boolean', default: true }));
   });
 
   test('auto_collapse_reasoning is a boolean', () => {


### PR DESCRIPTION
Adds the top-level `web_search` option to the public Kilo CLI JSON Schema served from `app.kilo.ai/config.json`. It defaults to `false`, matching the existing managed-provider-only behavior; users opt in to third-party-provider search with `web_search: true`.

This endpoint is an editor-validation schema overlay, not a Cloud settings surface. Without this entry, users configuring the option introduced by Kilo-Org/kilocode#12369 receive a false unknown-property warning from `$schema` validation.

Companion to https://github.com/Kilo-Org/kilocode/pull/12369