### PR TITLE
Strengthen final-week Kilo Code V5 EOL warning

### DIFF
--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -65,7 +65,7 @@ const normalUnconditionalNotifications: KiloNotification[] = [
     id: 'legacy-upgrade-final-week-july-2026',
     title: 'Final Week: Kilo Code 5.x Support Ends July 31',
     message:
-      'This is the final week to upgrade. Support for Kilo Code extension version 5.x ends July 31, 2026. After that date, there will be no updates, bug fixes, security patches, compatibility fixes, or marketplace releases. Upgrade now to stay on a supported version.',
+      'Kilo Code strongly recommends updating to version 7.x this week. Support for Kilo Code extension version 5.x ends July 31, 2026. After that date, there will be no updates, bug fixes, security patches, compatibility fixes, or marketplace releases. Upgrade now to stay on a supported version.',
     action: {
       actionText: 'Upgrade Before July 31',
       actionURL: 'https://github.com/Kilo-Org/kilocode-legacy#legacy-ide-extensions-end-of-life',

--- a/apps/web/src/lib/notifications.ts
+++ b/apps/web/src/lib/notifications.ts
@@ -62,15 +62,16 @@ const normalUnconditionalNotifications: KiloNotification[] = [
     expiresAt: '2026-07-24T16:00:00Z',
   },
   {
-    id: 'legacy-upgrade-june-2026',
-    title: 'Kilo Code 5.x: End of Life July 31, 2026',
+    id: 'legacy-upgrade-final-week-july-2026',
+    title: 'Final Week: Kilo Code 5.x Support Ends July 31',
     message:
-      'Kilo Code extension version 5.x reaches end of life on July 31, 2026. After that date, it will no longer receive updates, bug fixes, or security patches. Upgrade to the latest version for continued support.',
+      'This is the final week to upgrade. Support for Kilo Code extension version 5.x ends July 31, 2026. After that date, there will be no updates, bug fixes, security patches, compatibility fixes, or marketplace releases. Upgrade now to stay on a supported version.',
     action: {
-      actionText: 'See End of Life Notice',
+      actionText: 'Upgrade Before July 31',
       actionURL: 'https://github.com/Kilo-Org/kilocode-legacy#legacy-ide-extensions-end-of-life',
     },
     showIn: ['extension'],
+    expiresAt: '2026-08-01T04:00:00Z',
     showOnlyOnLegacyExtension: true,
   },
   {


### PR DESCRIPTION
## Summary
- replace the existing Kilo Code 5.x EOL notification with a final-week reminder
- use a new notification ID so users who dismissed the prior notice see the replacement
- add stronger upgrade language and expire the notice after July 31

## Validation
- `pnpm --filter web exec jest src/lib/notifications.test.ts --runInBand`
- `oxlint apps/web/src/lib/notifications.ts`
- `oxfmt --list-different apps/web/src/lib/notifications.ts`
- `git diff --check`