### PR TITLE
docs(mobile): make the e2e device slot mandatory, not conditional

### DIFF
--- a/apps/mobile/.kilo/MOBILE_WORKFLOW.md
+++ b/apps/mobile/.kilo/MOBILE_WORKFLOW.md
@@ -110,7 +110,7 @@ Plan the simplest viable shape of every item — feature-wise as much as code-wi
 
 ### Bug Reproduction Gate
 
-For defect work, dispatch a fresh `mobile-e2e-verifier` in repro mode on the unmodified baseline in the dedicated worktree before writing the draft plan. Its assignment: reproduce the reported issue — fix nothing — and return exact reproduction steps, evidence, and a failure classification. It claims iOS with `--phase prewarm`. The claimed device and warmed services carry into the planner handoff as resources to preserve; the final verifier later reclaims the same device with `--phase verify`.
+For defect work, dispatch a fresh `mobile-e2e-verifier` in repro mode on the unmodified baseline in the dedicated worktree before writing the draft plan. Its assignment: reproduce the reported issue — fix nothing — and return exact reproduction steps, evidence, and a failure classification. It acquires a device slot first, then claims iOS with `--phase prewarm`. The claimed device and warmed services carry into the planner handoff as resources to preserve; the final verifier later reclaims the same device with `--phase verify`.
 
 A confirmed reproduction feeds the plan: the steps and classification inform the root-cause hypothesis, and the confirmed repro flow passing becomes an acceptance criterion the final verifier must rerun.
 
@@ -182,7 +182,21 @@ Start and inspect the local stack, simulator, login, and E2E flows per [e2e/AGEN
 
 Env sync between the app bundle, Metro, and this worktree is validated by `apps/mobile/e2e/preflight.sh` (run by `login.sh`). Trust its failure output instead of re-checking URLs by hand.
 
-When several workflows run on one machine, device-bound work is capped by the slot semaphore [`e2e-slot.sh`](e2e-slot.sh) (default 3 slots, machine-global). Run `e2e-slot.sh acquire <tmux-session>` before any phase that drives a simulator, emulator, local backend stack, or native build — the repro gate, prewarm, and every E2E round — and `e2e-slot.sh release <tmux-session>` the moment that phase ends. Planning, implementation, review, checks, and CI waits are uncapped; never hold a slot through them. Slots are owned by tmux session name and reclaimed automatically when the session dies, so a crashed run cannot wedge the queue. `e2e-slot.sh status` shows holders.
+### Device Slots Are Mandatory
+
+The machine is shared by parallel workflows, and unslotted device work overloads it. Every phase that drives a simulator, emulator, local backend stack, or native build — the repro gate, prewarm, and every E2E round — runs inside a slot from the semaphore [`e2e-slot.sh`](e2e-slot.sh) (default 3, machine-global):
+
+```bash
+.kilo/e2e-slot.sh acquire <tmux-session>   # blocks until a slot frees
+.kilo/e2e-slot.sh status                   # current holders
+.kilo/e2e-slot.sh release <tmux-session>   # the moment the device phase ends
+```
+
+- This holds on every run, not only when another workflow is visibly active. "No one else seems to be running" is not an exemption, and neither is a stack that is already up.
+- `acquire` blocking is correct behavior, never a wedge to route around and never a reason to start device work unslotted. A blocked acquire is not a stuck state for the escalation ladder.
+- Release immediately when the device phase ends. Planning, implementation, review, checks, and CI waits are uncapped; never hold a slot through them.
+- Slots are owned by tmux session name and reclaimed automatically when the session dies, so a crashed run cannot wedge the queue.
+- The orchestrator is accountable for this: every device-phase handoff states the slot rule, and a role agent that reports device work with no acquire gets re-dispatched.
 
 ## Execution Ledger
 
@@ -204,7 +218,7 @@ Two slices are parallel-safe only when all of these hold: their write sets do no
 3. When the whole wave has returned, synchronize: inspect each result, ownership adherence, and the combined diff; resolve integration and architecture decisions yourself; run shared mutating commands and shared checks once. If one slice failed, preserve the successful ones.
 4. Dispatch one fresh `mobile-reviewer` over the wave diff. Triage findings yourself: route valid findings through a bounded repair wave; record rejected findings with a short rationale. Loop repair wave → fresh reviewer, steering each round per the escalation ladder, until a fresh reviewer reports no valid actionable findings. Running this loop is the orchestrator's primary job, not a preamble to doing the work itself.
 5. After checks and review pass, create the commits at the ledger's per-slice boundaries. If a slice exhausts its implementer budget, split it or re-dispatch it with a sharper handoff; take over only per the escalation ladder.
-6. When device E2E is likely, prewarm concurrently with implementation: stable services, a claimed and labeled device, a baseline native build (only when unaffected by active slices), the exact Metro URL, and login state. Record a resource manifest for the final verifier. Do not judge acceptance behavior while implementation is still changing.
+6. When device E2E is likely, prewarm concurrently with implementation, inside an acquired device slot: stable services, a claimed and labeled device, a baseline native build (only when unaffected by active slices), the exact Metro URL, and login state. Record a resource manifest for the final verifier. Do not judge acceptance behavior while implementation is still changing.
 7. After review passes, perform the final full-diff review yourself, push the reviewed head, create the PR — its description records any simpler-shape decision from the handoff — and assign it to the requesting human — before starting E2E, so CI and Kilobot run concurrently with the E2E run. Do not read or triage any review comment yet (step 9).
 8. Dispatch a fresh final `mobile-e2e-verifier` with the resource manifest. Loop triage → repair wave → fresh reviewer → fresh verifier, steering each round per the escalation ladder, until a fresh verifier passes every applicable feature state. You may reproduce a failure once to triage it; the repair itself — with your diagnosis and acceptance criteria attached — goes through the implementer-reviewer loop. Never sit in an edit-run-verify loop yourself. Review the full diff of any E2E-driven repair, commit it at the right boundary, and push.
 
@@ -234,6 +248,7 @@ Every dispatch to a role agent must include:
 - The dedicated worktree path for every repository in scope, including sibling repositories
 - Existing uncommitted changes that must be preserved
 - The exact checks or user flows expected for that stage
+- For any device phase: the mandatory `e2e-slot.sh acquire`/`release` rule with the tmux session name to own the slot (see Device Slots Are Mandatory)
 - Prior findings being addressed, including rejected findings that must not reopen without new evidence
 - The intended commit boundary for the assigned slice
 - Priority order, minimum complete outcome, optional work to drop, and a clean stopping rule before budget exhaustion

--- a/apps/mobile/.kilo/agent/mobile-e2e-verifier.md
+++ b/apps/mobile/.kilo/agent/mobile-e2e-verifier.md
@@ -21,10 +21,11 @@ Your 100-step limit is a hard ceiling. The handoff defines your priority order, 
 
 Before testing:
 
-1. Read `apps/mobile/e2e/AGENTS.md` and follow it exactly for services, device claiming, builds, login, Maestro, prompts, and cleanup. Claim iOS with `pnpm dev:mobile:simulator claim [udid] --phase verify`. Never bypass the helper scripts' preflight, install unvalidated builds, or guess selectors.
-2. Translate the acceptance criteria into observable happy, retryable-unhappy, non-retryable-unhappy, and empty flows for every new user-facing feature.
-3. Record pre-existing services, listeners, simulators, and tmux sessions so cleanup removes only resources you created. Never use a device claimed by another worktree.
-4. Before any temporary edit, snapshot a baseline outside every repository: `git status --porcelain=v2 -z --untracked-files=all`, binary worktree and index diffs, and the byte hash, file mode, and symlink target of every untracked path. Copy the original bytes and mode of every tracked file you plan to edit. Temporary edits may touch only paths that are clean and tracked at baseline, or brand-new paths — never a pre-existing modified, staged, or untracked path.
+1. Acquire a machine device slot with `apps/mobile/.kilo/e2e-slot.sh acquire <your-tmux-session>` before starting a stack, booting a simulator or emulator, or running a native build. This is mandatory on every run, not only when you can see another workflow: the machine is shared and unslotted device work overloads it. The command blocks until a slot frees — blocking is correct behavior, never a wedge to work around, and never a reason to proceed unslotted. Release it with `e2e-slot.sh release <your-tmux-session>` the moment your device phase ends, before you write your report.
+2. Read `apps/mobile/e2e/AGENTS.md` and follow it exactly for services, device claiming, builds, login, Maestro, prompts, and cleanup. Claim iOS with `pnpm dev:mobile:simulator claim [udid] --phase verify`. Never bypass the helper scripts' preflight, install unvalidated builds, or guess selectors.
+3. Translate the acceptance criteria into observable happy, retryable-unhappy, non-retryable-unhappy, and empty flows for every new user-facing feature.
+4. Record pre-existing services, listeners, simulators, and tmux sessions so cleanup removes only resources you created. Never use a device claimed by another worktree.
+5. Before any temporary edit, snapshot a baseline outside every repository: `git status --porcelain=v2 -z --untracked-files=all`, binary worktree and index diffs, and the byte hash, file mode, and symlink target of every untracked path. Copy the original bytes and mode of every tracked file you plan to edit. Temporary edits may touch only paths that are clean and tracked at baseline, or brand-new paths — never a pre-existing modified, staged, or untracked path.
 
 During verification:
 

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -2,6 +2,21 @@
 
 Interactive verification against a local backend. Run commands from the repository root unless a step says otherwise. Long-lived services live in a worktree-specific tmux session owned by the repository dev runner; use it, never loose background processes.
 
+## Device Slot: Required First Step
+
+This machine is shared by parallel workflows. Before starting a stack, booting a simulator or emulator, or running a native build — on every run, whether or not you can see another workflow active — acquire a slot:
+
+```bash
+apps/mobile/.kilo/e2e-slot.sh acquire <your-tmux-session>   # blocks until a slot frees
+apps/mobile/.kilo/e2e-slot.sh status                        # current holders
+apps/mobile/.kilo/e2e-slot.sh release <your-tmux-session>   # the moment the device phase ends
+```
+
+- Default 3 slots, machine-global, owned by tmux session name; a dead session's slot is reclaimed automatically, so a crash cannot wedge the queue.
+- `acquire` blocking is correct behavior, not a hang and not a wedge. Wait for it. Never start device work unslotted because the queue was busy, because your phase looks small, or because a stack is already up.
+- Acquiring is idempotent per session; every device phase (repro gate, prewarm, each E2E round) needs a slot.
+- Release as soon as the device phase ends. Planning, implementation, review, checks, and CI waits are uncapped — never hold a slot through them.
+
 ## Fresh Worktree Quickstart
 
 If dependencies or local env files are missing, run once (authorizes both worktree `.envrc` files and copies local env files from the primary checkout):
@@ -21,9 +36,7 @@ xcrun simctl list devices booted
 
 If a complete stack is already running for this worktree, reuse it. Never start a competing stack or stop an unrelated `kilo-dev-*` session.
 
-When other workflows may be running on this machine, acquire a device slot before starting a stack, simulator, or native build, and release it when the device phase ends: `apps/mobile/.kilo/e2e-slot.sh acquire|release <tmux-session>` (see the Local Tooling section of [.kilo/MOBILE_WORKFLOW.md](../.kilo/MOBILE_WORKFLOW.md)).
-
-If this worktree has no stack, start the complete mobile flow:
+If this worktree has no stack, start the complete mobile flow — after acquiring a device slot (see above):
 
 ```bash
 pnpm dev:env -y cloudflare-session-ingest
@@ -211,7 +224,7 @@ Use the wrappers for all Android tooling, including the Expo/Gradle build, so th
 Two launch attempts total, then a test-environment blocker with the tail of `$EMULATOR_LOG`. Attempt 1 uses `-gpu host` (Mac GPU; fastest; software rendering competes for the CPU under parallel-workflow load). Keep `-no-snapshot-save -no-boot-anim` on every launch. Attempt 2 switches GPU only on an observed process-death signal (`pgrep -f "qemu.*<avd-name>"` empty, or the log shows the emulator exiting/erroring — the pane mirrors it live but dies with the session) → `-gpu swiftshader_indirect`. If the process is still alive but the boot envelope expired → repeat `-gpu host`. Never a third launch.
 
 ```bash
-# After e2e-slot acquire (see Fresh Worktree Quickstart)
+# After e2e-slot acquire (see Device Slot: Required First Step)
 ANDROID_SESSION="kilo-e2e-android-$(basename "$PWD")"
 EMULATOR_LOG="/tmp/${ANDROID_SESSION}.log"
 GPU_FLAG=host   # attempt 2: swiftshader_indirect only after process death; else host again
@@ -293,7 +306,7 @@ pnpm dev:stop                                # only if you started this worktree
 xcrun simctl shutdown <udid>                 # only if you booted it
 pnpm dev:mobile:simulator release <udid>     # every simulator you claimed
 pnpm dev:mobile:android release <serial>     # every Android device you claimed
-apps/mobile/.kilo/e2e-slot.sh release <tmux-session>   # if you acquired a device slot
+apps/mobile/.kilo/e2e-slot.sh release <tmux-session>   # always, as soon as the device phase ends
 ```
 
 Also stop recorders, log followers, and emulator processes you created. Never use `tmux kill-server`, kill an unrelated `kilo-dev-*` session, shut down a simulator that was already booted, or use `pnpm dev:stop --force` while sibling worktrees are active.


### PR DESCRIPTION
Agents were skipping `.kilo/e2e-slot.sh` and overloading the machine with parallel device work.

The rule was there, but easy to rationalize away: it lived in two *conditional* prose paragraphs ("when other workflows may be running", "when several workflows run on one machine"), both mid-document, and it was absent from `mobile-e2e-verifier.md` — the one agent definition that actually drives simulators, emulators, stacks, and native builds.

## Changes

- **`e2e/AGENTS.md`** — new "Device Slot: Required First Step" section, placed before the Fresh Worktree Quickstart. Unconditional, with the usual rationalizations named explicitly: `acquire` blocking is correct behavior, and a busy queue, a small-looking phase, or an already-running stack are not exemptions. Cleanup entry changed from "if you acquired a device slot" to "always".
- **`.kilo/agent/mobile-e2e-verifier.md`** — acquire is now step 1, ahead of reading the runbook, and a blocked acquire is explicitly not a wedge to route around.
- **`.kilo/MOBILE_WORKFLOW.md`** — section rewritten unconditional; added to Handoff Requirements so every device-phase dispatch states the rule, and to the repro gate and prewarm steps. The orchestrator re-dispatches a role agent that reports device work with no acquire.

Documentation only; no behavior or script changes.

## Not done

Auto-acquiring inside `pnpm dev:mobile:simulator claim` / `dev:start` would be the version that can't be ignored, but those scripts can't know when a device *phase* ends, so they would acquire and never release. Worth doing if the doc fix still gets skipped, together with an explicit release contract.