### PR TITLE
feat(code reviewer): report provider ownership on assistant failures

### DIFF
--- a/apps/web/src/lib/code-reviews/terminal-reason-from-failure.test.ts
+++ b/apps/web/src/lib/code-reviews/terminal-reason-from-failure.test.ts
@@ -1,4 +1,5 @@
 import {
+  CLOUD_AGENT_ASSISTANT_FAILURE_REASONS,
   CLOUD_AGENT_FAILURE_CODES,
   WORKSPACE_FAILURE_SUBTYPES,
 } from '@kilocode/worker-utils/cloud-agent-failure';
@@ -53,6 +54,42 @@ describe('terminalReasonFromCloudAgentFailure', () => {
     expect(terminalReasonFromCloudAgentFailure({ code: 'wrapper_error_after_activity' })).toBe(
       'wrapper_failed'
     );
+  });
+
+  it('splits rate limiting by whose key was throttled', () => {
+    const rateLimited = { code: 'assistant_error', assistantReason: 'rate_limited' } as const;
+
+    expect(terminalReasonFromCloudAgentFailure({ ...rateLimited, providerOwnership: 'byok' })).toBe(
+      'assistant_rate_limited_byok'
+    );
+    expect(
+      terminalReasonFromCloudAgentFailure({ ...rateLimited, providerOwnership: 'managed' })
+    ).toBe('assistant_rate_limited_managed');
+    expect(
+      terminalReasonFromCloudAgentFailure({ ...rateLimited, providerOwnership: 'unknown' })
+    ).toBe('assistant_rate_limited');
+    expect(terminalReasonFromCloudAgentFailure(rateLimited)).toBe('assistant_rate_limited');
+  });
+
+  it('prefers the structured assistant reason over the safe message', () => {
+    // A message that would map elsewhere via the legacy text path must not win.
+    expect(
+      terminalReasonFromCloudAgentFailure({
+        code: 'assistant_error',
+        assistantReason: 'provider_unavailable',
+        message: 'Assistant request was rate limited',
+      })
+    ).toBe('assistant_unavailable');
+  });
+
+  it('resolves every assistant reason to a valid terminal reason', () => {
+    const valid = new Set<string>(CODE_REVIEW_TERMINAL_REASONS);
+    const resolved = CLOUD_AGENT_ASSISTANT_FAILURE_REASONS.map(assistantReason => [
+      assistantReason,
+      terminalReasonFromCloudAgentFailure({ code: 'assistant_error', assistantReason }),
+    ]);
+
+    expect(resolved.filter(([, reason]) => !valid.has(reason as string))).toEqual([]);
   });
 
   it('splits assistant failures by their safe message', () => {

--- a/apps/web/src/lib/code-reviews/terminal-reason-from-failure.ts
+++ b/apps/web/src/lib/code-reviews/terminal-reason-from-failure.ts
@@ -16,7 +16,9 @@
  */
 
 import type {
+  CloudAgentAssistantFailureReason,
   CloudAgentFailureCode,
+  CloudAgentProviderOwnership,
   CloudAgentSafeFailure,
   WorkspaceFailureSubtype,
 } from '@kilocode/worker-utils/cloud-agent-failure';
@@ -73,16 +75,42 @@ const FAILURE_CODE_REASONS = {
 /**
  * `assistant_error` is a single code covering every provider-side failure, so on
  * its own it would collapse rate limiting (by far the largest bucket) into one
- * undifferentiated category. The finer reason lives only in the safe message.
+ * undifferentiated category.
+ *
+ * cloud-agent-next now reports the finer reason structurally on
+ * `failure.assistantReason`, so this is an enum-to-enum map with no text
+ * matching. `satisfies Record<...>` keeps it exhaustive: a new assistant reason
+ * upstream is a type error here rather than a silent fall back to generic.
+ */
+const ASSISTANT_REASON_REASONS = {
+  rate_limited: 'assistant_rate_limited',
+  provider_unavailable: 'assistant_unavailable',
+  timeout: 'assistant_timeout',
+  provider_authentication: 'assistant_unauthorized',
+  invalid_request: 'assistant_invalid_request',
+  insufficient_credits: 'billing',
+  model_unavailable: 'model_not_found',
+  unknown: 'assistant_failed',
+} as const satisfies Record<CloudAgentAssistantFailureReason, CodeReviewTerminalReason>;
+
+/**
+ * Rate limiting split by whose key was throttled. A customer's own key hitting
+ * its quota is not actionable for us; our managed key hitting ours is.
+ * Unknown ownership keeps the unqualified reason.
+ */
+const RATE_LIMITED_BY_OWNERSHIP = {
+  byok: 'assistant_rate_limited_byok',
+  managed: 'assistant_rate_limited_managed',
+  unknown: 'assistant_rate_limited',
+} as const satisfies Record<CloudAgentProviderOwnership, CodeReviewTerminalReason>;
+
+/**
+ * Fallback for payloads sent before cloud-agent-next reported `assistantReason`.
  *
  * These are exact, whole-string matches against the constants produced by
- * `classifyAssistantFailure` in
- * services/cloud-agent-next/src/session/safe-failure-projection.ts — not
- * substring heuristics. If a message there is reworded this map stops matching
- * and callers fall back to the generic `assistant_failed`, which is no worse
- * than the current behaviour.
- *
- * KEEP IN SYNC with classifyAssistantFailure's safeMessage values.
+ * `classifyAssistantFailure`, not substring heuristics. Retained only so that
+ * in-flight callbacks from an older sender still classify; new payloads take the
+ * structured path above and never reach this.
  *
  * A Map rather than an object literal: the key is caller-supplied free text (the
  * schema bounds only its length), and an object lookup for 'constructor' or
@@ -116,8 +144,16 @@ export function terminalReasonFromCloudAgentFailure(
   }
 
   if (failure.code === 'assistant_error') {
-    // The projection puts the safe message on the failure; fall back to the
-    // callback's errorMessage for payloads that only carry the flattened text.
+    // Structured reason wins. Rate limiting refines further by whose key was
+    // throttled, which is the difference between an actionable failure and one
+    // only the customer can resolve.
+    if (failure.assistantReason) {
+      return failure.assistantReason === 'rate_limited'
+        ? RATE_LIMITED_BY_OWNERSHIP[failure.providerOwnership ?? 'unknown']
+        : ASSISTANT_REASON_REASONS[failure.assistantReason];
+    }
+
+    // Older payloads carry only the flattened text.
     const message = (failure.message ?? errorMessage)?.trim();
     return (message ? ASSISTANT_MESSAGE_REASONS.get(message) : undefined) ?? 'assistant_failed';
   }

--- a/apps/web/src/routers/admin-code-reviews-router.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.ts
@@ -100,6 +100,8 @@ const TERMINAL_REASON_LABELS: Record<string, string> = {
   sandbox_connection: 'Sandbox Connection',
   container_shutdown: 'Container Shutdown',
   assistant_rate_limited: 'Rate Limited',
+  assistant_rate_limited_byok: 'Rate Limited (customer key)',
+  assistant_rate_limited_managed: 'Rate Limited (managed key)',
   assistant_unavailable: 'Assistant Unavailable',
   assistant_timeout: 'Assistant Timeout',
   assistant_unauthorized: 'Assistant Unauthorized',

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -2015,7 +2015,13 @@ export const CODE_REVIEW_TERMINAL_REASONS = [
   // pattern-matching the human-readable error_message in the admin router.
   // See apps/web/src/lib/code-reviews/terminal-reason-from-failure.ts.
   'assistant_failed',
+  // Rate limiting is the single largest failure bucket, and who was throttled
+  // decides whether it is actionable. Split by the provider ownership
+  // cloud-agent-next now reports; the unqualified value remains for payloads
+  // that carry no ownership.
   'assistant_rate_limited',
+  'assistant_rate_limited_byok',
+  'assistant_rate_limited_managed',
   'assistant_unavailable',
   'assistant_timeout',
   'assistant_unauthorized',
@@ -2061,6 +2067,13 @@ export const CODE_REVIEW_BENIGN_TERMINAL_REASONS = [
   // deliberately left as a system failure: under-alerting is how the Jul 2026
   // publish-rate collapse ran for three days unnoticed.
   'setup_command_failed',
+  // The customer's own provider key hit its own quota. Nothing on our side is
+  // broken and nothing on our side can fix it, so it must not page us.
+  // 'assistant_rate_limited_managed' is deliberately NOT benign: that is our
+  // key or our quota, and it is the case worth waking someone for. The
+  // unqualified 'assistant_rate_limited' also stays non-benign, since unknown
+  // ownership could be either.
+  'assistant_rate_limited_byok',
 ] as const satisfies readonly CodeReviewTerminalReason[];
 
 export type CodeReviewBenignTerminalReason = (typeof CODE_REVIEW_BENIGN_TERMINAL_REASONS)[number];

--- a/packages/worker-utils/src/cloud-agent-failure.ts
+++ b/packages/worker-utils/src/cloud-agent-failure.ts
@@ -257,6 +257,20 @@ export const CloudAgentSafeFailureSchema = z
     subtype: WorkspaceFailureSubtypeSchema.optional(),
     attempts: z.number().int().nonnegative().optional(),
     message: z.string().min(1).max(CLOUD_AGENT_SAFE_FAILURE_MESSAGE_MAX_LENGTH).optional(),
+    // `assistant_error` is a single code covering every provider-side failure,
+    // so on its own it cannot tell rate limiting apart from an outage, and it
+    // cannot say whose key was throttled. Both values are already computed by
+    // classifyAssistantFailure and persisted on the session message state; these
+    // fields carry them across the callback so receivers stop having to infer
+    // the reason from the safe message text.
+    //
+    // Deliberately not covered by a refine. This schema is `.strict()` and
+    // CloudAgentCallbackFailureSchema turns any parse failure into `undefined`,
+    // which discards the WHOLE failure object (stage, code, subtype, message),
+    // not just the offending field. Neither field carries an invariant worth
+    // that blast radius.
+    assistantReason: CloudAgentAssistantFailureReasonSchema.optional(),
+    providerOwnership: CloudAgentProviderOwnershipSchema.optional(),
   })
   .strict()
   .refine(failure => failure.subtype === undefined || failure.code === 'workspace_setup_failed', {

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -174,6 +174,8 @@ export const CLOUD_AGENT_TERMINAL_REASONS = [
   'workspace_capacity',
   'assistant_failed',
   'assistant_rate_limited',
+  'assistant_rate_limited_byok',
+  'assistant_rate_limited_managed',
   'assistant_unavailable',
   'assistant_timeout',
   'assistant_unauthorized',

--- a/services/cloud-agent-next/src/session/safe-failure-projection.test.ts
+++ b/services/cloud-agent-next/src/session/safe-failure-projection.test.ts
@@ -1,4 +1,9 @@
-import { CLOUD_AGENT_FAILURE_CODES } from '@kilocode/worker-utils/cloud-agent-failure';
+import {
+  CLOUD_AGENT_ASSISTANT_FAILURE_REASONS,
+  CLOUD_AGENT_FAILURE_CODES,
+  CLOUD_AGENT_PROVIDER_OWNERSHIPS,
+  CloudAgentSafeFailureSchema,
+} from '@kilocode/worker-utils/cloud-agent-failure';
 import { describe, expect, it } from 'vitest';
 import {
   SAFE_FAILURE_MESSAGE_MAX_LENGTH,
@@ -26,6 +31,59 @@ describe('projectSafeFailure', () => {
       message: 'Assistant request failed',
     });
   });
+
+  it('forwards the assistant reason and provider ownership', () => {
+    expect(
+      projectSafeFailure({
+        failureStage: 'agent_activity',
+        failureCode: 'assistant_error',
+        safeFailureMessage: 'Assistant request was rate limited',
+        assistantFailureReason: 'rate_limited',
+        providerOwnership: 'byok',
+      })
+    ).toStrictEqual({
+      stage: 'agent_activity',
+      code: 'assistant_error',
+      message: 'Assistant request was rate limited',
+      assistantReason: 'rate_limited',
+      providerOwnership: 'byok',
+    });
+  });
+
+  it('omits the new fields when the source has neither', () => {
+    const failure = projectSafeFailure({
+      failureStage: 'agent_activity',
+      failureCode: 'assistant_error',
+    });
+
+    expect(failure).not.toHaveProperty('assistantReason');
+    expect(failure).not.toHaveProperty('providerOwnership');
+  });
+
+  it('projects a failure carrying only the assistant classification', () => {
+    expect(
+      projectSafeFailure({ assistantFailureReason: 'rate_limited', providerOwnership: 'managed' })
+    ).toStrictEqual({ assistantReason: 'rate_limited', providerOwnership: 'managed' });
+  });
+
+  // The producer contract is .strict() and the callback wrapper turns any parse
+  // failure into undefined, discarding the entire failure object. Every shape
+  // the projection can emit must survive that parse.
+  it.each(CLOUD_AGENT_ASSISTANT_FAILURE_REASONS)(
+    'emits a payload the strict contract accepts for reason %s',
+    assistantFailureReason => {
+      for (const providerOwnership of CLOUD_AGENT_PROVIDER_OWNERSHIPS) {
+        const failure = projectSafeFailure({
+          failureStage: 'agent_activity',
+          failureCode: 'assistant_error',
+          assistantFailureReason,
+          providerOwnership,
+        });
+
+        expect(CloudAgentSafeFailureSchema.safeParse(failure).success).toBe(true);
+      }
+    }
+  );
 
   it.each(CLOUD_AGENT_FAILURE_CODES)('always derives a bounded message for %s', failureCode => {
     const failure = projectSafeFailure({ failureCode });

--- a/services/cloud-agent-next/src/session/safe-failure-projection.ts
+++ b/services/cloud-agent-next/src/session/safe-failure-projection.ts
@@ -22,6 +22,15 @@ export type SafeFailureProjectionSource = {
   failureSubtype?: WorkspaceFailureSubtype;
   attempts?: number;
   safeFailureMessage?: string;
+  /**
+   * Both are already resolved by classifyAssistantFailure and persisted on the
+   * session message state (providerOwnership via resolveTerminalProviderOwnership,
+   * which upgrades 'unknown' to 'managed' when the session used an admitted
+   * model). Forwarding them lets receivers classify assistant failures from
+   * structured values rather than matching the safe message text.
+   */
+  assistantFailureReason?: CloudAgentAssistantFailureReason;
+  providerOwnership?: CloudAgentProviderOwnership;
 };
 
 const GENERIC_FAILURE_MESSAGES = {
@@ -189,7 +198,9 @@ export function projectSafeFailure(
     source.failureCode === undefined &&
     subtype === undefined &&
     source.attempts === undefined &&
-    message === undefined
+    message === undefined &&
+    source.assistantFailureReason === undefined &&
+    source.providerOwnership === undefined
   ) {
     return undefined;
   }
@@ -200,5 +211,11 @@ export function projectSafeFailure(
     ...(subtype === undefined ? {} : { subtype }),
     ...(source.attempts === undefined ? {} : { attempts: source.attempts }),
     ...(message === undefined ? {} : { message }),
+    ...(source.assistantFailureReason === undefined
+      ? {}
+      : { assistantReason: source.assistantFailureReason }),
+    ...(source.providerOwnership === undefined
+      ? {}
+      : { providerOwnership: source.providerOwnership }),
   };
 }


### PR DESCRIPTION
## Summary

`assistant_error` is a single failure code covering every provider-side failure,
so a rate limit and a provider outage arrived as the same thing, and nothing
said whose API key was throttled. That matters because rate limiting is the
largest failure bucket in the admin Error Analysis, and a customer's own key
hitting their own quota is not something we can act on, while our managed key
hitting ours is.

`classifyAssistantFailure` already resolves both facts, and session message
state already persists them. They were dropped at one hop: the callback payload
had no field to carry them, so receivers had to infer the reason by matching the
human-readable safe message text.

This forwards both across the callback and consumes them on the code review
side. Rate limiting now splits by key ownership, and the byok case is treated as
benign for alerting.

## Changes

Sender:

- Add `assistantReason` and `providerOwnership` as optional fields on
  `CloudAgentSafeFailureSchema`, reusing the existing enums.
- Forward both in `projectSafeFailure`, and count them in the all-undefined
  early return so a failure carrying only the assistant classification still
  projects.
- No call site changes were needed. All four `projectSafeFailure` callers pass
  the session message state directly, and that state already holds both fields.

Receiver:

- Replace the safe-message text matching with `ASSISTANT_REASON_REASONS`, an
  enum to enum map guarded by `satisfies Record<CloudAgentAssistantFailureReason,
  CodeReviewTerminalReason>`, so a new assistant reason upstream is a type error
  here rather than a silent fall back to generic.
- Split rate limiting into `assistant_rate_limited_byok` and
  `assistant_rate_limited_managed`, keeping the unqualified reason when
  ownership is unknown.
- Keep the old exact-string map as a fallback for in-flight callbacks sent
  before the sender change lands.
- Add admin labels "Rate Limited (customer key)" and "Rate Limited (managed
  key)".

## Verification

No manual testing. Exercising this end to end needs a real provider rate limit
against both a customer key and a managed key, which is not something I can
trigger on demand. Covered by tests instead:

- [ ] `safe-failure-projection` suite, 53 tests, including a strict-contract
      round trip over every assistant reason and provider ownership pair the
      projection can emit
- [ ] `terminal-reason-from-failure` suite, 18 tests, including ownership
      splitting and structured reason winning over a conflicting safe message
- [ ] apps/web affected suites 466, cloud-agent-next 2373, worker-utils 326

## Visual Changes

N/A. No component or layout changes. Two new categories will appear in the admin
Error Analysis chart once failures arrive carrying ownership, but that needs
production data to screenshot.

## Reviewer Notes

- Sender and receiver ship together on purpose. `CloudAgentSafeFailureSchema` is
  `.strict()` and `CloudAgentCallbackFailureSchema` maps any parse failure to
  `undefined`, which discards the entire failure object rather than just the
  unknown field. A sender-first rollout would make older receivers drop stage,
  code, subtype and message as well, silently reverting classification to
  message pattern matching.
- For the same reason the two new fields have no `refine`. An over-tight
  invariant would not reject one field, it would drop the whole payload. The
  existing subtype refine is unchanged.
- There is still a short worker-first window inside a single deploy, since the
  worker and apps/web are separate artifacts and the worker went out about three
  minutes ahead of the app promotion on the last deploy. Failures in that window
  fall back to message-based classification and then recover.
- The alerting change is the part with real behavior impact.
  `assistant_rate_limited_byok` is benign, so it no longer counts toward error
  spike detection. `assistant_rate_limited_managed` and the unqualified value
  are not benign. Given rate limiting is roughly half of all failures, this
  changes what the detector sees.
- `providerOwnership` is resolved by `resolveTerminalProviderOwnership`, which
  upgrades unknown to managed when the session used an admitted model, so the
  unqualified bucket should be small in practice.

### Known gap, deliberately left for a follow-up

Treating the byok case as benign is correct for our alerting, since we cannot
fix a customer's quota. But today nothing tells the customer either. They get a
generic "Kilo Code Review failed" check run with the summary "Review failed:
Assistant request was rate limited", and the same text in the Code Reviews list.
No PR comment, and rate limiting is not in
`CODE_REVIEW_ACTION_REQUIRED_REASONS`, so there is no actionable copy, no email
and no auto-disable. Nothing anywhere says whose key was throttled.

That is inconsistent with `byok_invalid_key`, which is action required and gets
dedicated copy, an email and auto-disable. Both are customer owned and customer
fixable.

This PR is the prerequisite for closing that gap rather than the fix for it. The
ownership fact did not exist receiver-side before, so customer-facing copy was
not possible to write. Whether the byok rate limit case should be full action
required, or only get better copy without the email and auto-disable, is a
product decision to make separately.
