### PR TITLE
fix(git-token-service): resolve Bitbucket repo cache for workspaces

### DIFF
--- a/services/git-token-service/src/bitbucket-runtime-token-resolver.test.ts
+++ b/services/git-token-service/src/bitbucket-runtime-token-resolver.test.ts
@@ -3,6 +3,7 @@ import { BitbucketApiError, type BitbucketRepository } from './bitbucket-api.js'
 import {
   listBitbucketRepositories,
   resolveBitbucketToken,
+  selectCachedBitbucketRepository,
 } from './bitbucket-runtime-token-resolver.js';
 import {
   BITBUCKET_CLOUD_AGENT_MINIMUM_VALIDITY_MS,
@@ -255,5 +256,63 @@ describe('Bitbucket runtime token resolver', () => {
       reason: 'repository_mismatch',
     });
     expect(deps.authorizationService.invalidateAuthorization).not.toHaveBeenCalled();
+  });
+});
+
+describe('selectCachedBitbucketRepository', () => {
+  const cachedTarget = {
+    id: repositoryUuid,
+    name: 'Widgets',
+    full_name: 'acme/widgets',
+    private: true,
+    default_branch: 'main',
+  };
+
+  it('resolves the target repository even when the cache holds more than 500 repositories', () => {
+    // Filler entries deliberately use non-UUID ids and are never validated: only
+    // the matched target must be well-formed. A workspace this size previously
+    // failed the whole-array `.max(500)` parse and returned temporarily_unavailable.
+    const filler = Array.from({ length: 2091 }, (_, index) => ({
+      id: `filler-${index}`,
+      name: `repo-${index}`,
+      full_name: `acme/repo-${index}`,
+      private: false,
+    }));
+
+    expect(
+      selectCachedBitbucketRepository([...filler, cachedTarget], {
+        workspaceUuid,
+        repositoryUuid,
+      })
+    ).toEqual({
+      status: 'available',
+      repository: {
+        id: repositoryUuid,
+        workspaceUuid,
+        name: 'Widgets',
+        fullName: 'acme/widgets',
+        private: true,
+        defaultBranch: 'main',
+      },
+    });
+  });
+
+  it('returns repository_not_found when the target repository is absent from the cache', () => {
+    expect(selectCachedBitbucketRepository([], { workspaceUuid, repositoryUuid }).status).toBe(
+      'repository_not_found'
+    );
+  });
+
+  it('returns repository_not_found when the matched cache entry is malformed', () => {
+    const malformed = [{ id: repositoryUuid, name: '', full_name: 'x', private: 'nope' }];
+    expect(
+      selectCachedBitbucketRepository(malformed, { workspaceUuid, repositoryUuid }).status
+    ).toBe('repository_not_found');
+  });
+
+  it('returns temporarily_unavailable when the cached value is not an array', () => {
+    expect(selectCachedBitbucketRepository(null, { workspaceUuid, repositoryUuid }).status).toBe(
+      'temporarily_unavailable'
+    );
   });
 });

--- a/services/git-token-service/src/bitbucket-runtime-token-resolver.ts
+++ b/services/git-token-service/src/bitbucket-runtime-token-resolver.ts
@@ -105,6 +105,39 @@ export type BitbucketRuntimeTokenResolverDependencies = {
   }): Promise<CachedRepositoryLookupResult>;
 };
 
+// Select a single repository from the cached workspace repository list by UUID.
+// The resolver only ever needs the one repository under review, so we look it up
+// directly and validate just that entry. Validating the whole array (and capping
+// its length) would reject the cache for any workspace larger than the cap even
+// though the target repository is present and well-formed.
+export function selectCachedBitbucketRepository(
+  repositoriesValue: unknown,
+  input: { workspaceUuid: string; repositoryUuid: string }
+): CachedRepositoryLookupResult {
+  if (!Array.isArray(repositoriesValue)) return { status: 'temporarily_unavailable' };
+  const entries = repositoriesValue as unknown[];
+  const match = entries.find(
+    candidate =>
+      typeof candidate === 'object' &&
+      candidate !== null &&
+      (candidate as { id?: unknown }).id === input.repositoryUuid
+  );
+  const parsed = CachedRepositorySchema.safeParse(match);
+  if (!parsed.success) return { status: 'repository_not_found' };
+  const repository = parsed.data;
+  return {
+    status: 'available',
+    repository: {
+      id: repository.id,
+      workspaceUuid: input.workspaceUuid,
+      name: repository.name,
+      fullName: repository.full_name,
+      private: repository.private,
+      ...(repository.default_branch ? { defaultBranch: repository.default_branch } : {}),
+    },
+  };
+}
+
 async function findCachedBitbucketRepository(
   env: CloudflareEnv,
   input: {
@@ -146,24 +179,10 @@ async function findCachedBitbucketRepository(
       return { status: 'temporarily_unavailable' };
     }
 
-    const repositories = z
-      .array(CachedRepositorySchema)
-      .max(500)
-      .safeParse(integration.repositories);
-    if (!repositories.success) return { status: 'temporarily_unavailable' };
-    const repository = repositories.data.find(candidate => candidate.id === input.repositoryUuid);
-    if (!repository) return { status: 'repository_not_found' };
-    return {
-      status: 'available',
-      repository: {
-        id: repository.id,
-        workspaceUuid: input.workspace.uuid,
-        name: repository.name,
-        fullName: repository.full_name,
-        private: repository.private,
-        ...(repository.default_branch ? { defaultBranch: repository.default_branch } : {}),
-      },
-    };
+    return selectCachedBitbucketRepository(integration.repositories, {
+      workspaceUuid: input.workspace.uuid,
+      repositoryUuid: input.repositoryUuid,
+    });
   } catch {
     return { status: 'temporarily_unavailable' };
   }


### PR DESCRIPTION
## Summary

Bitbucket code review sessions failed for any workspace with more than 500 repositories. When resolving a Bitbucket token, `findCachedBitbucketRepository` validated the entire cached repository list with `z.array(CachedRepositorySchema).max(500)`. A workspace over that size failed the parse and returned `temporarily_unavailable`, which the caller surfaces as a retryable 503 (`prepareSession failed (503): Bitbucket repository authorization failed (temporarily_unavailable)`) on every review. The repository cache is written with no size cap, so the reader could never read back what the writer had stored. This was seen on a production workspace with more than 2000 repositories.

The resolver only needs the single repository under review, so it now looks that repository up by UUID and validates only that one entry, which removes the dependency on total workspace size.

- Add `selectCachedBitbucketRepository`, which finds the target repository by UUID in the cached list and validates only that entry. It returns `repository_not_found` when the target is missing or its cache entry is malformed, and `temporarily_unavailable` when the cached value is not an array.
- Change `findCachedBitbucketRepository` to delegate to the new helper and drop the `z.array(...).max(500)` whole-list parse.
- Add unit tests for a cache holding more than 500 repositories, an absent target, a malformed matched entry, and a value that is not an array.

## Verification

No manual testing performed. Reproducing the live failure needs a deployed git-token-service and a Bitbucket workspace with more than 500 repositories, which is not reproducible in local development. The change is covered by unit tests added here in `bitbucket-runtime-token-resolver.test.ts`, including the case of a cache with more than 500 repositories. The git-token-service test suite, typecheck, lint, and formatter pass.

## Visual Changes

N/A

## Reviewer Notes

- Behavior changes worth a look: a cached list longer than 500 no longer fails and now resolves the target repository. A malformed matched entry now returns `repository_not_found` rather than `temporarily_unavailable`. The absent-target and non-array outcomes are unchanged.
- Not addressed here: the `repositories === null` / never-synced branch still returns the retryable `temporarily_unavailable`. That is a separate concern and out of scope for this fix.
