### PR TITLE
Enable GPT-5.6 OpenRouter promotion

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
+import { OPENROUTER_GPT56_PROMO_MODEL_IDS } from '@/lib/ai-gateway/providers/openai';
 
 function makeRequest(model: string, models?: string[]): GatewayRequest {
   return {
@@ -51,6 +52,14 @@ describe('applyGatewayModelsFallback', () => {
 });
 
 describe('applyPreferredProvider', () => {
+  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('prefers OpenAI for promo model %s', model => {
+    const request = makeRequest(model);
+
+    applyPreferredProvider(model, request.body);
+
+    expect(request.body.provider).toEqual({ order: ['openai'] });
+  });
+
   it('does not set a provider order for Fable', () => {
     const request = makeRequest('anthropic/claude-fable-5');
 

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -38,8 +38,12 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
 import { isQwenExplicitCacheModel, isQwenModel } from '@/lib/ai-gateway/providers/qwen';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
+import { isOpenRouterGpt56PromoModel } from '@/lib/ai-gateway/providers/openai';
 
 export function getPreferredProviderOrder(requestedModel: string): string[] {
+  if (isOpenRouterGpt56PromoModel(requestedModel)) {
+    return [OpenRouterInferenceProviderIdSchema.enum.openai];
+  }
   if (isClaudeModel(requestedModel) && !isFableModel(requestedModel)) {
     // fable is not available on bedrock on vercel
     // and specifying bedrock breaks the opus fallback

--- a/apps/web/src/lib/ai-gateway/providers/openai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai.ts
@@ -17,6 +17,7 @@ export const GPT_MINI_CURRENT_MODEL_ID = 'openai/gpt-5.4-mini';
 
 export const GPT_MINI_CURRENT_VERCEL_MODEL_ID = GPT_MINI_CURRENT_MODEL_ID;
 
+// OpenRouter BYOK must be disabled for these models so requests use the discounted endpoint.
 export const ENABLE_OPENROUTER_GPT56_PROMO = true;
 
 export const OPENROUTER_GPT56_PROMO_MODEL_IDS = [

--- a/apps/web/src/lib/ai-gateway/providers/openai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai.ts
@@ -16,3 +16,18 @@ export const GPT_CURRENT_VERCEL_MODEL_ID = GPT_CURRENT_MODEL_ID;
 export const GPT_MINI_CURRENT_MODEL_ID = 'openai/gpt-5.4-mini';
 
 export const GPT_MINI_CURRENT_VERCEL_MODEL_ID = GPT_MINI_CURRENT_MODEL_ID;
+
+export const ENABLE_OPENROUTER_GPT56_PROMO = true;
+
+export const OPENROUTER_GPT56_PROMO_MODEL_IDS = [
+  'openai/gpt-5.6-terra',
+  'openai/gpt-5.6-terra-pro',
+  'openai/gpt-5.6-luna',
+  'openai/gpt-5.6-luna-pro',
+] as const;
+
+const openRouterGpt56PromoModels: ReadonlySet<string> = new Set(OPENROUTER_GPT56_PROMO_MODEL_IDS);
+
+export function isOpenRouterGpt56PromoModel(modelId: string): boolean {
+  return ENABLE_OPENROUTER_GPT56_PROMO && openRouterGpt56PromoModels.has(modelId);
+}

--- a/apps/web/src/lib/ai-gateway/providers/openai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai.ts
@@ -27,8 +27,9 @@ export const OPENROUTER_GPT56_PROMO_MODEL_IDS = [
   'openai/gpt-5.6-luna-pro',
 ] as const;
 
-const openRouterGpt56PromoModels: ReadonlySet<string> = new Set(OPENROUTER_GPT56_PROMO_MODEL_IDS);
-
 export function isOpenRouterGpt56PromoModel(modelId: string): boolean {
-  return ENABLE_OPENROUTER_GPT56_PROMO && openRouterGpt56PromoModels.has(modelId);
+  return (
+    ENABLE_OPENROUTER_GPT56_PROMO &&
+    OPENROUTER_GPT56_PROMO_MODEL_IDS.some(promoModelId => promoModelId === modelId)
+  );
 }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -213,11 +213,7 @@ describe('OpenRouter GPT-5.6 promotion', () => {
   };
 
   it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('preserves discounted pricing for %s', modelId => {
-    expect(getModelDisplayPricing(modelId, discountedPricing)).toEqual({
-      prompt: '0.000001',
-      completion: '0.000004',
-      input_cache_read: '0.0000001',
-    });
+    expect(getModelDisplayPricing(modelId, discountedPricing)).toBe(discountedPricing);
   });
 
   it('continues to undo endpoint discounts for other models', () => {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -153,9 +153,15 @@ describe('formatName', () => {
     expect(formatName(model, NOT_PREFERRED)).toBe('OpenRouter Test Model ($$$$)');
   });
 
-  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('labels %s as 50% off', modelId => {
-    const model = buildModel({ id: modelId, created: 0 });
-    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model (50% off)');
+  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('prefers the 50% off marker for %s', modelId => {
+    const recentlyCreated = Math.floor(Date.now() / 1000) - 24 * 3600;
+    const model = buildModel({
+      id: modelId,
+      created: recentlyCreated,
+      expiration_date: '2026-07-01',
+      pricing: { prompt: '0.00001', completion: '0' },
+    });
+    expect(formatName(model, 0)).toBe('Test Model (50% off)');
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -159,9 +159,17 @@ describe('formatName', () => {
       id: modelId,
       created: recentlyCreated,
       expiration_date: '2026-07-01',
-      pricing: { prompt: '0.00001', completion: '0' },
+      pricing: { prompt: '0.00001', completion: '0', discount: 0.5 },
     });
     expect(formatName(model, 0)).toBe('Test Model (50% off)');
+  });
+
+  it('takes the promo percentage from endpoint metadata', () => {
+    const model = buildModel({
+      id: OPENROUTER_GPT56_PROMO_MODEL_IDS[0],
+      pricing: { prompt: '0.00001', completion: '0', discount: 0.375 },
+    });
+    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model (37.5% off)');
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, jest } from '@jest/globals
 import {
   formatName,
   getEnhancedOpenRouterModels,
+  getModelDisplayPricing,
   getOpenRouterTranscriptionModels,
   shouldSuppressOpenRouterModel,
   undoPricingDiscount,
@@ -19,6 +20,7 @@ import {
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { isFableModel } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { KILO_AUTO_EFFICIENT_MODEL } from '@/lib/ai-gateway/auto-model';
+import { OPENROUTER_GPT56_PROMO_MODEL_IDS } from '@/lib/ai-gateway/providers/openai';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
   getOpenRouterModelsMetadataFromDatabase: jest.fn(() => Promise.resolve({})),
@@ -150,6 +152,11 @@ describe('formatName', () => {
     });
     expect(formatName(model, NOT_PREFERRED)).toBe('OpenRouter Test Model ($$$$)');
   });
+
+  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('labels %s as 50% off', modelId => {
+    const model = buildModel({ id: modelId, created: 0 });
+    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model (50% off)');
+  });
 });
 
 describe('undoPricingDiscount', () => {
@@ -188,6 +195,31 @@ describe('undoPricingDiscount', () => {
       discount: 1,
     });
     expect(result).toEqual({ prompt: '0.000001', completion: '0.000005' });
+  });
+});
+
+describe('OpenRouter GPT-5.6 promotion', () => {
+  const discountedPricing = {
+    prompt: '0.000001',
+    completion: '0.000004',
+    input_cache_read: '0.0000001',
+    discount: 0.5,
+  };
+
+  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('preserves discounted pricing for %s', modelId => {
+    expect(getModelDisplayPricing(modelId, discountedPricing)).toEqual({
+      prompt: '0.000001',
+      completion: '0.000004',
+      input_cache_read: '0.0000001',
+    });
+  });
+
+  it('continues to undo endpoint discounts for other models', () => {
+    expect(getModelDisplayPricing('openai/gpt-5.6-sol', discountedPricing)).toEqual({
+      prompt: '0.000002000000',
+      completion: '0.000008000000',
+      input_cache_read: '0.000000200000',
+    });
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -81,14 +81,14 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
     model.id.startsWith('openrouter/') && !model.name.includes('OpenRouter')
       ? 'OpenRouter ' + model.name
       : model.name;
+  if (isOpenRouterGpt56PromoModel(model.id)) return name + ' (50% off)';
   const promptPrice = Number.parseFloat(model.pricing.prompt);
   const isExpensive = Number.isFinite(promptPrice) && promptPrice >= 0.00001; // Opus 4.8 Fast price
-  const promoSuffix = isOpenRouterGpt56PromoModel(model.id) ? ' (50% off)' : '';
-  if (isExpensive) return name + ' ($$$$)' + promoSuffix;
-  if (name.endsWith(')')) return name + promoSuffix;
+  if (isExpensive) return name + ' ($$$$)';
+  if (name.endsWith(')')) return name;
   const ageDays = (Date.now() / 1_000 - model.created) / (24 * 3600);
   const isNew = preferredIndex >= 0 && ageDays >= 0 && ageDays < 7;
-  if (isNew) return name + ' (new)' + promoSuffix;
+  if (isNew) return name + ' (new)';
   if (model.expiration_date) {
     const expirationDate = new Date(model.expiration_date);
     if (expirationDate <= addMonths(new Date(), 1)) {
@@ -97,10 +97,10 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
         day: 'numeric',
         timeZone: 'UTC',
       });
-      return name + ' (retires ' + suffix + ')' + promoSuffix;
+      return name + ' (retires ' + suffix + ')';
     }
   }
-  return name + promoSuffix;
+  return name;
 }
 
 type EndpointPricing = NonNullable<StoredModel['endpoints'][number]['pricing']>;

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -28,6 +28,7 @@ import { getTerminalBenchSummaries, terminalBenchFor } from '@/lib/model-stats/t
 import { isFreeNemotronModel, NVIDIA_TRIAL_TOS } from '@/lib/ai-gateway/providers/nvidia';
 import { applyCustomPricingToModel } from '@/lib/ai-gateway/custom-pricing';
 import { addMonths } from 'date-fns';
+import { isOpenRouterGpt56PromoModel } from '@/lib/ai-gateway/providers/openai';
 
 // Re-export from shared module for backwards compatibility
 export { normalizeModelId } from '@/lib/ai-gateway/model-utils';
@@ -82,11 +83,12 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
       : model.name;
   const promptPrice = Number.parseFloat(model.pricing.prompt);
   const isExpensive = Number.isFinite(promptPrice) && promptPrice >= 0.00001; // Opus 4.8 Fast price
-  if (isExpensive) return name + ' ($$$$)';
-  if (name.endsWith(')')) return name;
+  const promoSuffix = isOpenRouterGpt56PromoModel(model.id) ? ' (50% off)' : '';
+  if (isExpensive) return name + ' ($$$$)' + promoSuffix;
+  if (name.endsWith(')')) return name + promoSuffix;
   const ageDays = (Date.now() / 1_000 - model.created) / (24 * 3600);
   const isNew = preferredIndex >= 0 && ageDays >= 0 && ageDays < 7;
-  if (isNew) return name + ' (new)';
+  if (isNew) return name + ' (new)' + promoSuffix;
   if (model.expiration_date) {
     const expirationDate = new Date(model.expiration_date);
     if (expirationDate <= addMonths(new Date(), 1)) {
@@ -95,10 +97,10 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
         day: 'numeric',
         timeZone: 'UTC',
       });
-      return name + ' (retires ' + suffix + ')';
+      return name + ' (retires ' + suffix + ')' + promoSuffix;
     }
   }
-  return name;
+  return name + promoSuffix;
 }
 
 type EndpointPricing = NonNullable<StoredModel['endpoints'][number]['pricing']>;
@@ -116,6 +118,22 @@ export function undoPricingDiscount(pricing: EndpointPricing): EndpointPricing {
     }
   }
   return result;
+}
+
+function preserveDiscountedPricing(pricing: EndpointPricing): EndpointPricing {
+  const prices = { ...pricing };
+  delete prices.discount;
+  return prices;
+}
+
+export function getModelDisplayPricing(
+  modelId: string,
+  pricing: EndpointPricing | undefined
+): EndpointPricing | undefined {
+  if (!pricing) return undefined;
+  return isOpenRouterGpt56PromoModel(modelId)
+    ? preserveDiscountedPricing(pricing)
+    : undoPricingDiscount(pricing);
 }
 
 export function shouldSuppressOpenRouterModel(model: KiloExclusiveModel): boolean {
@@ -151,7 +169,7 @@ async function enhancedModelList(models: OpenRouterModel[]) {
                 normalizeInferenceProviderId(e.tag) ===
                 normalizeInferenceProviderId(preferredProvider)
             )?.pricing);
-        const pricing = rawPricing ? undoPricingDiscount(rawPricing) : rawPricing;
+        const pricing = getModelDisplayPricing(model.id, rawPricing);
         const terminalBench = terminalBenchFor(summaries, model.id);
         return {
           ...model,

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -120,20 +120,12 @@ export function undoPricingDiscount(pricing: EndpointPricing): EndpointPricing {
   return result;
 }
 
-function preserveDiscountedPricing(pricing: EndpointPricing): EndpointPricing {
-  const prices = { ...pricing };
-  delete prices.discount;
-  return prices;
-}
-
 export function getModelDisplayPricing(
   modelId: string,
   pricing: EndpointPricing | undefined
 ): EndpointPricing | undefined {
   if (!pricing) return undefined;
-  return isOpenRouterGpt56PromoModel(modelId)
-    ? preserveDiscountedPricing(pricing)
-    : undoPricingDiscount(pricing);
+  return isOpenRouterGpt56PromoModel(modelId) ? pricing : undoPricingDiscount(pricing);
 }
 
 export function shouldSuppressOpenRouterModel(model: KiloExclusiveModel): boolean {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -81,7 +81,11 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
     model.id.startsWith('openrouter/') && !model.name.includes('OpenRouter')
       ? 'OpenRouter ' + model.name
       : model.name;
-  if (isOpenRouterGpt56PromoModel(model.id)) return name + ' (50% off)';
+  const discount = model.pricing.discount;
+  if (isOpenRouterGpt56PromoModel(model.id) && discount !== undefined && discount > 0) {
+    const percentage = Number((discount * 100).toFixed(2));
+    return `${name} (${percentage}% off)`;
+  }
   const promptPrice = Number.parseFloat(model.pricing.prompt);
   const isExpensive = Number.isFinite(promptPrice) && promptPrice >= 0.00001; // Opus 4.8 Fast price
   if (isExpensive) return name + ' ($$$$)';

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import {
   convertProviderOptions,
   getAnthropicProviderOptionsForVercel,
@@ -159,6 +159,7 @@ describe('passesVercelRoutingPercentage', () => {
 
 describe('OpenRouter GPT-5.6 promotion', () => {
   it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('does not route %s to Vercel', async model => {
+    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
     const request: GatewayRequest = {
       kind: 'chat_completions',
       body: {
@@ -168,5 +169,9 @@ describe('OpenRouter GPT-5.6 promotion', () => {
     };
 
     await expect(shouldRouteToVercel(model, request, 'promo-test')).resolves.toBe(false);
+    expect(debugSpy).toHaveBeenCalledWith(
+      `[shouldRouteToVercel] routing ${model} to OpenRouter for the GPT-5.6 promotion`
+    );
+    debugSpy.mockRestore();
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -5,9 +5,11 @@ import {
   getVercelInferenceProvidersExcludingIgnored,
   hasCompatibleVercelInferenceProvider,
   passesVercelRoutingPercentage,
+  shouldRouteToVercel,
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import { OPENROUTER_GPT56_PROMO_MODEL_IDS } from '@/lib/ai-gateway/providers/openai';
 
 describe('getAnthropicProviderOptionsForVercel', () => {
   it('maps chat completion verbosity to Anthropic effort', () => {
@@ -152,5 +154,19 @@ describe('passesVercelRoutingPercentage', () => {
 
     expect(seedsInFinalBucket.some(seed => passesVercelRoutingPercentage(seed, 99.9))).toBe(true);
     expect(seedsInFinalBucket.some(seed => !passesVercelRoutingPercentage(seed, 99.9))).toBe(true);
+  });
+});
+
+describe('OpenRouter GPT-5.6 promotion', () => {
+  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('does not route %s to Vercel', async model => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model,
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    };
+
+    await expect(shouldRouteToVercel(model, request, 'promo-test')).resolves.toBe(false);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -27,6 +27,7 @@ import {
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { isOpenRouterGpt56PromoModel } from '@/lib/ai-gateway/providers/openai';
 
 type VercelRoutingPercentages = {
   paid: number;
@@ -94,6 +95,10 @@ export async function shouldRouteToVercel(
   request: GatewayRequest,
   randomSeed: string
 ) {
+  if (isOpenRouterGpt56PromoModel(requestedModel)) {
+    return false;
+  }
+
   console.debug('[shouldRouteToVercel] randomizing user to either OpenRouter or Vercel');
   const percentages = await getVercelRoutingPercentages();
   const routingPercentage = (await isFreeModel(requestedModel))

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -96,6 +96,9 @@ export async function shouldRouteToVercel(
   randomSeed: string
 ) {
   if (isOpenRouterGpt56PromoModel(requestedModel)) {
+    console.debug(
+      `[shouldRouteToVercel] routing ${requestedModel} to OpenRouter for the GPT-5.6 promotion`
+    );
     return false;
   }
 

--- a/apps/web/src/lib/organizations/organization-types.ts
+++ b/apps/web/src/lib/organizations/organization-types.ts
@@ -315,6 +315,7 @@ const OpenRouterModelSchema = z.object({
     input_cache_write: z.string().optional(),
     web_search: z.string().optional(),
     internal_reasoning: z.string().optional(),
+    discount: z.number().optional(),
   }),
   context_length: z.number(),
   per_request_limits: z.record(z.string(), z.unknown()).nullable().optional(),


### PR DESCRIPTION
## Summary
- add an enabled AI gateway promotion flag for the four GPT-5.6 Terra/Luna variants
- keep funded requests for those models on OpenRouter and preserve discounted catalog pricing
- label promoted model names as 50% off

## Verification
- `pnpm --filter web exec jest --runInBand src/lib/ai-gateway/providers/openrouter/index.test.ts src/lib/ai-gateway/providers/vercel/index.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`