### PR TITLE
feat(ai-gateway): include the vercel request id in stream read errors

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -12,6 +12,7 @@ import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attri
 import type { Provider } from '@/lib/ai-gateway/providers/types';
 import { after, NextResponse } from 'next/server';
 import { ProxyErrorType } from '@/lib/proxy-error-types';
+import { withRequestId } from '@/lib/ai-gateway/request-id';
 
 type UpstreamFetchFailureFamily =
   | 'request_timeout'
@@ -137,14 +138,6 @@ function classifyUpstreamFetchFailure({
     default:
       return 'unknown';
   }
-}
-
-/**
- * The Vercel request id makes a reported error traceable to the invocation that
- * produced it, so it is appended to the message when the platform provided one.
- */
-function withRequestId(message: string, vercelRequestId: string | null | undefined): string {
-  return vercelRequestId ? `${message} (request id: ${vercelRequestId})` : message;
 }
 
 /**

--- a/apps/web/src/lib/ai-gateway/request-id.ts
+++ b/apps/web/src/lib/ai-gateway/request-id.ts
@@ -1,0 +1,8 @@
+/**
+ * The Vercel request id makes a reported error traceable to the invocation that
+ * produced it, so it is appended to gateway error messages when the platform
+ * provided one.
+ */
+export function withRequestId(message: string, vercelRequestId: string | null | undefined): string {
+  return vercelRequestId ? `${message} (request id: ${vercelRequestId})` : message;
+}

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -111,6 +111,55 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
       message: expect.stringContaining(messageFragment),
     });
   });
+
+  test('includes the vercel request id in the JSON read error', async () => {
+    const result = await rewrite(
+      failingResponse('application/json', 'ResponseAborted'),
+      true,
+      null,
+      'iad1::iad1::request-id'
+    );
+
+    expect(result.status).toBe(503);
+    expect(await result.json()).toEqual({
+      error:
+        'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
+      error_type: 'upstream_disconnect',
+      message:
+        'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
+      vercel_request_id: 'iad1::iad1::request-id',
+    });
+  });
+
+  test('includes the vercel request id in the emitted stream error event', async () => {
+    const result = await rewrite(
+      failingResponse('text/event-stream', 'ResponseAborted'),
+      true,
+      null,
+      'iad1::iad1::request-id'
+    );
+    const events = dataObjects(await readOutputStream(result)) as {
+      error: { message: string; vercel_request_id?: string };
+    }[];
+
+    expect(events).toHaveLength(1);
+    expect(events[0].error.message).toBe(
+      'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)'
+    );
+    expect(events[0].error.vercel_request_id).toBe('iad1::iad1::request-id');
+  });
+
+  test('omits the request id suffix when no vercel request id is available', async () => {
+    const result = await rewrite(failingResponse('text/event-stream', 'ResponseAborted'));
+    const events = dataObjects(await readOutputStream(result)) as {
+      error: { message: string; vercel_request_id?: string };
+    }[];
+
+    expect(events[0].error.message).toBe(
+      'The upstream provider disconnected while sending the response.'
+    );
+    expect(events[0].error.vercel_request_id).toBeUndefined();
+  });
 });
 
 describe('rewriteModelResponse_ChatCompletions', () => {

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -9,6 +9,7 @@ import { isDynamicallyOptedIntoRequestLogging } from '@/lib/ai-gateway/request-l
 import { db } from '@/lib/drizzle';
 import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
 import { errorExceptInTest, logExceptInTest } from '@/lib/utils.server';
+import { withRequestId } from '@/lib/ai-gateway/request-id';
 import type { EventSourceMessage } from 'eventsource-parser';
 import { createParser } from 'eventsource-parser';
 import { after, NextResponse } from 'next/server';
@@ -155,7 +156,9 @@ export async function logUnrewrittenResponse(
 
 type ResponseReadError = {
   errorType: 'timeout' | 'upstream_disconnect';
+  /** Already carries the request id suffix when one is available. */
   message: string;
+  vercelRequestId?: string;
 };
 
 const STREAM_PROGRESS_LOG_INTERVAL_MS = 30_000;
@@ -178,7 +181,10 @@ function createStreamProgressLogger() {
   };
 }
 
-function getResponseReadError(error: unknown): ResponseReadError | null {
+function getResponseReadError(
+  error: unknown,
+  vercelRequestId: string | null | undefined
+): ResponseReadError | null {
   if (typeof error !== 'object' || error === null || !('name' in error)) {
     return null;
   }
@@ -186,14 +192,22 @@ function getResponseReadError(error: unknown): ResponseReadError | null {
   if (error.name === 'ResponseAborted') {
     return {
       errorType: 'upstream_disconnect',
-      message: 'The upstream provider disconnected while sending the response.',
+      message: withRequestId(
+        'The upstream provider disconnected while sending the response.',
+        vercelRequestId
+      ),
+      vercelRequestId: vercelRequestId ?? undefined,
     };
   }
 
   if (error.name === 'TimeoutError') {
     return {
       errorType: 'timeout',
-      message: 'The upstream provider timed out while sending the response.',
+      message: withRequestId(
+        'The upstream provider timed out while sending the response.',
+        vercelRequestId
+      ),
+      vercelRequestId: vercelRequestId ?? undefined,
     };
   }
 
@@ -203,12 +217,13 @@ function getResponseReadError(error: unknown): ResponseReadError | null {
 async function readResponseText(
   response: Response,
   headers: Headers,
+  vercelRequestId: string | null | undefined,
   capture?: RequestLogCapture | null
 ): Promise<{ text: string } | { error: unknown; errorResponse: NextResponse }> {
   try {
     return { text: await response.text() };
   } catch (error) {
-    const responseReadError = getResponseReadError(error);
+    const responseReadError = getResponseReadError(error, vercelRequestId);
     if (!responseReadError) {
       // Settle the capture so the after() callback awaiting it does not hang
       // and the request is still logged (without a response body).
@@ -223,6 +238,9 @@ async function readResponseText(
           error: responseReadError.message,
           error_type: responseReadError.errorType,
           message: responseReadError.message,
+          ...(responseReadError.vercelRequestId && {
+            vercel_request_id: responseReadError.vercelRequestId,
+          }),
         },
         { status: 503, headers }
       ),
@@ -237,6 +255,7 @@ async function rewriteSseStream(
   doneReceived: () => boolean,
   serializeError: (error: ResponseReadError) => string,
   onFinally: () => void,
+  vercelRequestId: string | null | undefined,
   capture?: RequestLogCapture | null
 ) {
   const decoder = new TextDecoder();
@@ -270,13 +289,16 @@ async function rewriteSseStream(
       parser.feed(chunk);
     }
   } catch (error) {
-    const responseReadError = getResponseReadError(error);
+    const responseReadError = getResponseReadError(error, vercelRequestId);
     if (!responseReadError) {
       settleReadError(error);
       throw error;
     }
 
-    errorExceptInTest('[rewriteModelResponse] emitting stream error event', responseReadError);
+    errorExceptInTest('[rewriteModelResponse] emitting stream error event', {
+      ...responseReadError,
+      vercelRequestId: vercelRequestId ?? '<none>',
+    });
     settleReadError(error);
     controller.enqueue(serializeError(responseReadError));
     controller.close();
@@ -302,14 +324,15 @@ function rewriteUsage(usage: OpenRouterUsage, removeCost: boolean) {
 export async function rewriteModelResponse_ChatCompletions(
   response: Response,
   removeCost = true,
-  capture?: RequestLogCapture | null
+  capture?: RequestLogCapture | null,
+  vercelRequestId?: string | null
 ) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
     // Read the body text once to avoid "Response body object should not be
     // disturbed or locked" errors that occur when `.clone().json()` fails.
-    const textResult = await readResponseText(response, headers, capture);
+    const textResult = await readResponseText(response, headers, vercelRequestId, capture);
     if ('errorResponse' in textResult) {
       capture?.setReadError(textResult.error);
       return textResult.errorResponse;
@@ -405,10 +428,14 @@ export async function rewriteModelResponse_ChatCompletions(
               code: 503,
               message: responseReadError.message,
               type: responseReadError.errorType,
+              ...(responseReadError.vercelRequestId && {
+                vercel_request_id: responseReadError.vercelRequestId,
+              }),
             },
           }) +
           '\n\n',
         progress.stop,
+        vercelRequestId,
         capture
       );
     },
@@ -452,12 +479,13 @@ function rewriteMessagesUsage(usage: MessagesApiUsage, removeCost: boolean) {
 export async function rewriteModelResponse_Messages(
   response: Response,
   removeCost = true,
-  capture?: RequestLogCapture | null
+  capture?: RequestLogCapture | null,
+  vercelRequestId?: string | null
 ) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
-    const textResult = await readResponseText(response, headers, capture);
+    const textResult = await readResponseText(response, headers, vercelRequestId, capture);
     if ('errorResponse' in textResult) {
       capture?.setReadError(textResult.error);
       return textResult.errorResponse;
@@ -555,10 +583,14 @@ export async function rewriteModelResponse_Messages(
               type: 'api_error',
               message: responseReadError.message,
               error_type: responseReadError.errorType,
+              ...(responseReadError.vercelRequestId && {
+                vercel_request_id: responseReadError.vercelRequestId,
+              }),
             },
           }) +
           '\n\n',
         progress.stop,
+        vercelRequestId,
         capture
       );
     },
@@ -583,12 +615,13 @@ type ResponsesApiEvent = {
 export async function rewriteModelResponse_Responses(
   response: Response,
   removeCost = true,
-  capture?: RequestLogCapture | null
+  capture?: RequestLogCapture | null,
+  vercelRequestId?: string | null
 ) {
   const headers = getOutputHeaders(response);
 
   if (headers.get('content-type')?.includes('application/json')) {
-    const textResult = await readResponseText(response, headers, capture);
+    const textResult = await readResponseText(response, headers, vercelRequestId, capture);
     if ('errorResponse' in textResult) {
       capture?.setReadError(textResult.error);
       return textResult.errorResponse;
@@ -678,10 +711,14 @@ export async function rewriteModelResponse_Responses(
               type: responseReadError.errorType,
               code: responseReadError.errorType === 'timeout' ? '504' : '503',
               message: responseReadError.message,
+              ...(responseReadError.vercelRequestId && {
+                vercel_request_id: responseReadError.vercelRequestId,
+              }),
             },
           }) +
           '\n\n',
         progress.stop,
+        vercelRequestId,
         capture
       );
     },
@@ -717,14 +754,30 @@ export async function rewriteModelResponse(
   }
 
   console.debug('[rewriteModelResponse] rewriting response for %s', model);
+  const { vercel_request_id: vercelRequestId } = logging;
   if (kind === 'chat_completions') {
-    return rewriteModelResponse_ChatCompletions(response, isFreeModelRequiringCostRemoval, capture);
+    return rewriteModelResponse_ChatCompletions(
+      response,
+      isFreeModelRequiringCostRemoval,
+      capture,
+      vercelRequestId
+    );
   }
   if (kind === 'responses') {
-    return rewriteModelResponse_Responses(response, isFreeModelRequiringCostRemoval, capture);
+    return rewriteModelResponse_Responses(
+      response,
+      isFreeModelRequiringCostRemoval,
+      capture,
+      vercelRequestId
+    );
   }
   if (kind === 'messages') {
-    return rewriteModelResponse_Messages(response, isFreeModelRequiringCostRemoval, capture);
+    return rewriteModelResponse_Messages(
+      response,
+      isFreeModelRequiringCostRemoval,
+      capture,
+      vercelRequestId
+    );
   }
 
   console.error('[rewriteModelResponse] implementation error: unrecognized API kind %s', kind);


### PR DESCRIPTION
## Why

Follow-up to #4795 and #4796. Those covered failures that happen *before* the upstream responds. The errors `rewriteModelResponse` emits when the upstream disconnects or times out *while streaming* still had no request id, so a user report of "The upstream provider disconnected while sending the response." could not be tied to an invocation.

## Changes

- `rewriteModelResponse` passes `logging.vercel_request_id` into all three rewriters (`_ChatCompletions`, `_Messages`, `_Responses`) as a new optional trailing argument.
- `getResponseReadError` appends `(request id: <id>)` to the message and carries the id, so:
  - the in-stream SSE error events (all three shapes) include the suffixed message and a `vercel_request_id` field inside the error object;
  - the non-streaming 503 read-error JSON response includes the suffixed message and a `vercel_request_id` field;
  - the `[rewriteModelResponse] emitting stream error event` log includes `vercelRequestId` (`<none>` when absent).
- The message suffix helper moved to `apps/web/src/lib/ai-gateway/request-id.ts` and is now shared with `upstream-request.ts` instead of being duplicated.

Behaviour is unchanged when no `x-vercel-id` is present: no suffix, no extra field.

## Verification

- `pnpm exec jest src/lib/rewriteModelResponse.test.ts` — 58 passed, including three new cases per rewriter (JSON read error, in-stream error event, and the no-id case). Note: this suite already does not let jest exit on `main` (pre-existing open handle), unrelated to this change.
- `pnpm exec jest src/tests/openrouterApi.timeout.test.ts src/app/api/openrouter` — 45 passed
- `pnpm --filter web typecheck`, `pnpm --filter web lint`, `pnpm format`