### PR TITLE
fix(ai-gateway): fall back from Fable and Opus 5 to Opus 4.8

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
@@ -5,6 +5,7 @@ import type {
 
 export const CLAUDE_SONNET_CURRENT_MODEL_ID = 'anthropic/claude-sonnet-5';
 export const CLAUDE_OPUS_CURRENT_MODEL_ID = 'anthropic/claude-opus-5';
+export const CLAUDE_OPUS_FALLBACK_MODEL_ID = 'anthropic/claude-opus-4.8';
 export const CLAUDE_HAIKU_CURRENT_MODEL_ID = 'anthropic/claude-haiku-4.5';
 export const CLAUDE_FABLE_CURRENT_MODEL_ID = 'anthropic/claude-fable-5';
 export const CLAUDE_OPUS_4_8_STEALTH_MODEL_ID = 'stealth/claude-opus-4.8';

--- a/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts
@@ -123,3 +123,7 @@ export function isClaudeModel(requestedModel: string) {
 export function isFableModel(requestedModel: string) {
   return requestedModel.includes('claude-fable');
 }
+
+export function isOpus5Model(requestedModel: string) {
+  return requestedModel.includes('claude-opus-5');
+}

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from '@jest/globals';
-import { CLAUDE_OPUS_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/anthropic.constants';
+import {
+  CLAUDE_OPUS_CURRENT_MODEL_ID,
+  CLAUDE_OPUS_FALLBACK_MODEL_ID,
+} from '@/lib/ai-gateway/providers/anthropic.constants';
 import {
   applyGatewayModelsFallback,
   applyPreferredProvider,
@@ -19,27 +22,32 @@ function makeRequest(model: string, models?: string[]): GatewayRequest {
 }
 
 describe('applyGatewayModelsFallback', () => {
-  it.each<ProviderId>(['openrouter', 'vercel'])(
-    'sets Opus as the Fable fallback for the %s provider',
-    async providerId => {
-      const request = makeRequest('anthropic/claude-fable-5', ['caller/fallback']);
+  it.each([
+    ['openrouter', 'anthropic/claude-fable-5'],
+    ['vercel', 'anthropic/claude-fable-5'],
+    ['openrouter', CLAUDE_OPUS_CURRENT_MODEL_ID],
+    ['vercel', CLAUDE_OPUS_CURRENT_MODEL_ID],
+  ] satisfies [ProviderId, string][])(
+    'sets Opus 4.8 as the fallback for %s requests to %s',
+    async (providerId, requestedModel) => {
+      const request = makeRequest(requestedModel, ['caller/fallback']);
 
-      await applyGatewayModelsFallback(providerId, 'anthropic/claude-fable-5', request);
+      await applyGatewayModelsFallback(providerId, requestedModel, request);
 
-      expect(request.body.models).toEqual([
-        'anthropic/claude-fable-5',
-        CLAUDE_OPUS_CURRENT_MODEL_ID,
-      ]);
+      expect(request.body.models).toEqual([requestedModel, CLAUDE_OPUS_FALLBACK_MODEL_ID]);
     }
   );
 
-  it('removes caller-provided fallbacks for Fable on other providers', async () => {
-    const request = makeRequest('anthropic/claude-fable-5', ['caller/fallback']);
+  it.each(['anthropic/claude-fable-5', CLAUDE_OPUS_CURRENT_MODEL_ID])(
+    'removes caller-provided fallbacks for %s on other providers',
+    async requestedModel => {
+      const request = makeRequest(requestedModel, ['caller/fallback']);
 
-    await applyGatewayModelsFallback('martian', 'anthropic/claude-fable-5', request);
+      await applyGatewayModelsFallback('martian', requestedModel, request);
 
-    expect(request.body.models).toBeUndefined();
-  });
+      expect(request.body.models).toBeUndefined();
+    }
+  );
 
   it('removes caller-provided fallbacks for other models', async () => {
     const request = makeRequest('openai/gpt-4o', ['caller/fallback']);

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -1,8 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import {
-  CLAUDE_OPUS_CURRENT_MODEL_ID,
-  CLAUDE_OPUS_FALLBACK_MODEL_ID,
-} from '@/lib/ai-gateway/providers/anthropic.constants';
+import { CLAUDE_OPUS_FALLBACK_MODEL_ID } from '@/lib/ai-gateway/providers/anthropic.constants';
 import {
   applyGatewayModelsFallback,
   applyPreferredProvider,
@@ -25,8 +22,8 @@ describe('applyGatewayModelsFallback', () => {
   it.each([
     ['openrouter', 'anthropic/claude-fable-5'],
     ['vercel', 'anthropic/claude-fable-5'],
-    ['openrouter', CLAUDE_OPUS_CURRENT_MODEL_ID],
-    ['vercel', CLAUDE_OPUS_CURRENT_MODEL_ID],
+    ['openrouter', 'anthropic/claude-opus-5'],
+    ['vercel', 'anthropic/claude-opus-5'],
   ] satisfies [ProviderId, string][])(
     'sets Opus 4.8 as the fallback for %s requests to %s',
     async (providerId, requestedModel) => {
@@ -38,7 +35,7 @@ describe('applyGatewayModelsFallback', () => {
     }
   );
 
-  it.each(['anthropic/claude-fable-5', CLAUDE_OPUS_CURRENT_MODEL_ID])(
+  it.each(['anthropic/claude-fable-5', 'anthropic/claude-opus-5'])(
     'removes caller-provided fallbacks for %s on other providers',
     async requestedModel => {
       const request = makeRequest(requestedModel, ['caller/fallback']);
@@ -49,13 +46,16 @@ describe('applyGatewayModelsFallback', () => {
     }
   );
 
-  it('removes caller-provided fallbacks for other models', async () => {
-    const request = makeRequest('openai/gpt-4o', ['caller/fallback']);
+  it.each(['anthropic/claude-opus-4.8', 'anthropic/claude-opus-6', 'openai/gpt-4o'])(
+    'removes caller-provided fallbacks for other model %s',
+    async requestedModel => {
+      const request = makeRequest(requestedModel, ['caller/fallback']);
 
-    await applyGatewayModelsFallback('openrouter', 'openai/gpt-4o', request);
+      await applyGatewayModelsFallback('openrouter', requestedModel, request);
 
-    expect(request.body.models).toBeUndefined();
-  });
+      expect(request.body.models).toBeUndefined();
+    }
+  );
 });
 
 describe('applyPreferredProvider', () => {

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -10,10 +10,10 @@ import { findKiloExclusiveModel } from '@/lib/ai-gateway/models';
 import { applyKiloExclusiveModelSettings } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { applyAnthropicModelSettings } from '@/lib/ai-gateway/providers/anthropic';
 import {
-  CLAUDE_OPUS_CURRENT_MODEL_ID,
   CLAUDE_OPUS_FALLBACK_MODEL_ID,
   isClaudeModel,
   isFableModel,
+  isOpus5Model,
 } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { OpenRouterInferenceProviderIdSchema } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { applyMoonshotModelSettings, isKimiModel } from '@/lib/ai-gateway/providers/moonshotai';
@@ -104,7 +104,7 @@ export async function applyGatewayModelsFallback(
 ) {
   if (
     !(await isFreeModel(requestedModel)) &&
-    (isFableModel(requestedModel) || requestedModel === CLAUDE_OPUS_CURRENT_MODEL_ID) &&
+    (isFableModel(requestedModel) || isOpus5Model(requestedModel)) &&
     (providerId === 'openrouter' || providerId === 'vercel')
   ) {
     requestToMutate.body.models = [requestedModel, CLAUDE_OPUS_FALLBACK_MODEL_ID];

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -11,6 +11,7 @@ import { applyKiloExclusiveModelSettings } from '@/lib/ai-gateway/providers/kilo
 import { applyAnthropicModelSettings } from '@/lib/ai-gateway/providers/anthropic';
 import {
   CLAUDE_OPUS_CURRENT_MODEL_ID,
+  CLAUDE_OPUS_FALLBACK_MODEL_ID,
   isClaudeModel,
   isFableModel,
 } from '@/lib/ai-gateway/providers/anthropic.constants';
@@ -103,10 +104,10 @@ export async function applyGatewayModelsFallback(
 ) {
   if (
     !(await isFreeModel(requestedModel)) &&
-    isFableModel(requestedModel) &&
+    (isFableModel(requestedModel) || requestedModel === CLAUDE_OPUS_CURRENT_MODEL_ID) &&
     (providerId === 'openrouter' || providerId === 'vercel')
   ) {
-    requestToMutate.body.models = [requestedModel, CLAUDE_OPUS_CURRENT_MODEL_ID];
+    requestToMutate.body.models = [requestedModel, CLAUDE_OPUS_FALLBACK_MODEL_ID];
     return;
   }
 


### PR DESCRIPTION
## Summary
- pin the Fable fallback to Claude Opus 4.8 instead of the mutable current-Opus model
- make Claude Opus 5 fall back to Claude Opus 4.8 on OpenRouter and Vercel
- detect Opus 5 explicitly so future current Opus versions do not inherit this fallback automatically

## Testing
- `pnpm --filter web exec jest --runInBand src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts`
- `pnpm --filter web run typecheck`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/anthropic.constants.ts apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts`