### PR TITLE
fix(mobile): keep the sign-in submit button clear of the iOS keyboard

### DIFF
--- a/.kilo_workflow/learnings/maestro-tap-swallowed-by-ios-keyboard.md
+++ b/.kilo_workflow/learnings/maestro-tap-swallowed-by-ios-keyboard.md
@@ -1,0 +1,19 @@
+# mobile: Maestro reports a tap COMPLETED that the iOS keyboard swallowed
+
+Symptom: a flow taps a button, Maestro logs `Tap on "<label>"... COMPLETED`, and nothing happens — the next `assertVisible` times out with Maestro's generic "this could be a real regression" advice, sending the reader after a product bug that does not exist. Typing into the field above the button worked, so the screen looks healthy in the failure screenshot.
+
+Cause: Maestro taps an element's **centre**, and iOS delivers any touch inside `UIRemoteKeyboardWindow` to the keyboard, not to the app. A control that is only partly covered by the keyboard therefore looks tappable and is not: the keyboard window's frame starts a few points above the visible keys, so a centre that clears the keys by a couple of points still lands in it. Maestro cannot see this — it gets no hit-test result back.
+
+Verify it in two commands, both cheap:
+
+```bash
+maestro --device <udid> hierarchy        # control centre vs the keyboard window's top bound
+grep -E "Tapping [0-9]" ~/.maestro/tests/<run>/<flow>/logs/device-xctest.log
+grep -A2 "Sending UIEvent" ~/.maestro/tests/<run>/<flow>/logs/device-simulator.log
+```
+
+The simulator log names the receiving window verbatim — `to window: <UIRemoteKeyboardWindow: 0x…>` is proof the app never saw the touch, `<UIWindow…>` (the app's) means look elsewhere.
+
+Because the margin is a handful of points on a centred layout, this is device-model dependent: the same flow passes on a taller simulator and fails on a shorter one, which reads as "it used to work" when the pool hands out a different iPhone.
+
+Fix: keep the control clear of the keyboard in the product (a root `KeyboardAvoidingView` on iOS, not `automaticallyAdjustKeyboardInsets` — that only makes the ScrollView scrollable, it never scrolls, and iOS auto-reveals only the focused field). Do not work around it in the flow with pasteboard tricks or coordinate taps; assert the reachable state instead, and never read a swallowed tap as a product regression.

--- a/apps/mobile/e2e/AGENTS.md
+++ b/apps/mobile/e2e/AGENTS.md
@@ -127,7 +127,7 @@ apps/mobile/e2e/logout.sh <udid>
 
 The default email is `e2e-mobile-<worktree-basename>@example.com`, derived deterministically from the worktree directory name. Hyphens are preserved by `normalizeEmail`, so each worktree signs into a distinct backend user. Pass an explicit email only when a test needs a specific account.
 
-Login requests an email OTP, waits up to 30 seconds for the worktree-local outbox, verifies the code, accepts first-account consent, and asserts Home. It retries the known dev-client launch boundary once. `flows/settle-app.yaml` handles late tracking and Expo developer-menu prompts without restarting the app; `flows/open-app.yaml` is the standalone cold-launch flow.
+Login requests an email OTP, waits up to 30 seconds for the worktree-local outbox, verifies the code, accepts first-account consent, and asserts Home. If the request half fails it cold-relaunches through `flows/open-app.yaml` and retries once — that clears both a half-started dev client and an email field left dirty by an earlier run — and if the retry fails too it says which half broke: no outbox email means the app never reached `POST /api/auth/native/otp`, a new outbox email means the request worked and only the code screen was never reached. `flows/settle-app.yaml` handles late tracking and Expo developer-menu prompts without restarting the app; `flows/open-app.yaml` is the standalone cold-launch flow.
 
 Native prompts are states in the flow, not errors to tap through blindly:
 
@@ -149,6 +149,8 @@ When editing the flows, preserve these device-tested constraints:
 - Tap the Kilo home-screen icon; Maestro `launchApp` can bounce the Expo dev client to SpringBoard.
 - Pass `EMAIL` and `OTP` with `-e`; flow-level defaults override `-e` values in the installed Maestro version.
 - Target the email field by its placeholder `you@example.com`, and tap `Verify code` without trying to dismiss the number pad.
+- The email field is uncontrolled, so a login page left on screen by an earlier run still holds its address, and `inputText` inserts at the caret the tap just dropped mid-string. Erase the field first and assert the typed address before submitting; without that, two attempts interleave into one malformed address and the flow dies 15s later on a missing `Verify code`.
+- Keep every control a flow taps clear of the keyboard. Maestro taps an element's centre, and iOS hands a touch inside `UIRemoteKeyboardWindow` to the keyboard while Maestro still logs the tap `COMPLETED` — a silent no-op. Verify with `maestro --device <udid> hierarchy`: the control's centre must be above the keyboard window's top bound. See `.kilo_workflow/learnings/maestro-tap-swallowed-by-ios-keyboard.md`.
 - The native sign-out confirmation is the first case-insensitive `Sign Out` match (`index: 0`).
 
 Seed only when needed. `pnpm dev:seed` with no arguments lists every topic and its usage:

--- a/apps/mobile/e2e/flows/login-request-code.yaml
+++ b/apps/mobile/e2e/flows/login-request-code.yaml
@@ -18,7 +18,14 @@ appId: com.kilocode.kiloapp
 # Tap the input via its placeholder — the "Email address" label shares the
 # field's accessibility text and would match the (non-focusable) label.
 - tapOn: 'you@example.com'
+# The field is uncontrolled, so a login page left on screen by an earlier run
+# still holds its address, and `inputText` inserts at the caret the tap just
+# dropped mid-string — two attempts interleave into a malformed address.
+- eraseText: 100
 - inputText: ${EMAIL}
+# Fail here, immediately and legibly, instead of 15s later on a missing
+# "Verify code": a mismatch means typing landed in a field that was not empty.
+- assertVisible: ${EMAIL}
 - tapOn: 'Send sign-in code'
 # Wait for the code screen — sending is a network round-trip.
 - extendedWaitUntil:

--- a/apps/mobile/e2e/login.sh
+++ b/apps/mobile/e2e/login.sh
@@ -47,10 +47,30 @@ latest_email() {
 
 before="$(latest_email)"
 
-echo "==> signing out and requesting sign-in code for $EMAIL"
-if ! maestro --device "$DEVICE" test -e "EMAIL=$EMAIL" "$SCRIPT_DIR/flows/login-request-code.yaml"; then
-  echo "==> retrying launch and sign-in request once after a dev-client startup failure"
+request_code() {
   maestro --device "$DEVICE" test -e "EMAIL=$EMAIL" "$SCRIPT_DIR/flows/login-request-code.yaml"
+}
+
+# Say which half broke, so nobody reads Maestro's generic "could be a real
+# regression" advice as a product-bug lead.
+diagnose_request() {
+  local now
+  now="$(latest_email)"
+  if [ -n "$now" ] && [ "$now" != "$before" ]; then
+    echo "==> the backend DID email a code: the request worked, the app never reached the code screen" >&2
+  else
+    echo "==> no code email for $EMAIL in $OUTBOX: the app never reached POST /api/auth/native/otp," >&2
+    echo "    so the submit press did not fire (preflight already proved the backend is up)" >&2
+  fi
+}
+
+echo "==> signing out and requesting sign-in code for $EMAIL"
+if ! request_code; then
+  # One cold relaunch clears both known first-attempt failures: a half-started
+  # dev client, and an email field left dirty by an earlier run.
+  echo "==> retrying launch and sign-in request once after a cold relaunch"
+  maestro --device "$DEVICE" test "$SCRIPT_DIR/flows/open-app.yaml" || true
+  request_code || { diagnose_request; exit 1; }
 fi
 
 # Wait for a newer outbox email than we had before (the send is async).
@@ -65,7 +85,7 @@ for _ in $(seq 1 120); do
 done
 
 if [ -z "$code" ]; then
-  echo "==> no new sign-in code received" >&2
+  echo "==> reached the code screen, but no new code email for $EMAIL landed in $OUTBOX within 30s" >&2
   exit 1
 fi
 

--- a/apps/mobile/src/components/login-screen.tsx
+++ b/apps/mobile/src/components/login-screen.tsx
@@ -86,13 +86,23 @@ export function LoginScreen() {
     // does not push the form up. Placing the KeyboardAvoidingView at the root
     // gives it a window-relative frame (y ~ 0, height ~ screen height), so
     // behavior="height" computes a non-zero shrink and resizes the ScrollView so
-    // the form stays above the IME. iOS is disabled because the ScrollView's
-    // automaticallyAdjustKeyboardInsets already handles the offset.
-    <KeyboardAvoidingView behavior="height" enabled={Platform.OS === 'android'} className="flex-1">
+    // the form stays above the IME.
+    //
+    // iOS needs it too: automaticallyAdjustKeyboardInsets only made the
+    // ScrollView scrollable, it never scrolls, and iOS only auto-reveals the
+    // focused field — so the centered form kept "Send code" under the keyboard
+    // on shorter devices (verified: iPhone 17 Pro, button centre 568pt vs
+    // keyboard window top 566pt, taps swallowed by UIRemoteKeyboardWindow).
+    // "padding" shrinks the ScrollView instead, so the whole form re-centres in
+    // the space above the keyboard; that replaces the inset, stacking both
+    // pushes the form off the top of the screen.
+    <KeyboardAvoidingView
+      behavior={Platform.OS === 'ios' ? 'padding' : 'height'}
+      className="flex-1"
+    >
       <ScrollView
         className="flex-1 bg-background"
         contentContainerClassName="flex-grow items-center justify-center gap-6 px-6 py-8"
-        automaticallyAdjustKeyboardInsets
         keyboardShouldPersistTaps="handled"
       >
         <View className="w-full max-w-sm items-center gap-2">


### PR DESCRIPTION
## What was broken

`apps/mobile/e2e/login.sh` stopped being able to sign in: every attempt died at
`Assert that "Verify code" is visible... FAILED` after the 15s wait, behind Maestro's
generic *"This could be a real regression that needs to be addressed"* — which sent an
agent hunting a product bug for four rounds.

It is not a backend problem and not a typing problem. The email lands in the field
correctly; the **submit tap is swallowed by the keyboard**.

## Root cause

The login form is vertically centred in a ScrollView, so the "Send code" button sits a
few points from the keyboard's top edge. On an iPhone 17 Pro:

| element | bounds (pt) | centre |
| --- | --- | --- |
| email field | 506–538 | 522 |
| **Send code** | **549–588** | **568** |
| keyboard window | 566–874 | — |

Maestro taps an element's **centre**, and iOS delivers any touch inside
`UIRemoteKeyboardWindow` to the keyboard. From the failing run's own device log:

```
Tapping 201.0, 568.0
Sending UIEvent type: 0; subtype: 0; to window: <UIRemoteKeyboardWindow: 0x159a5b200>
```

The app never saw the touch. `requestEmailCode` never ran, no `POST /api/auth/native/otp`
was sent (the outbox directory did not even exist), and Maestro reported the tap
`COMPLETED` because it gets no hit-test result back. The garbled field content seen in
later rounds (`-cli-69f6@example.com@ee2e-mobile-…`) is a downstream artefact of retries
typing into a field that was never cleared, not the cause.

`automaticallyAdjustKeyboardInsets` did not save it: it only makes the ScrollView
scrollable, it never scrolls, and iOS auto-reveals only the *focused field* — which was
already visible.

## On the regression hunt

**Not** caused by `304b31e3d` (Mobile Audit W1-B). I checked out that commit's parent
versions of `login-screen.tsx` + `idle-auth.tsx` on the device and measured again:
identical geometry — field 506–538, submit 549–588, more-options 598–637, submit still
under the keyboard. Screenshot of the pre-commit build shows "Send code" cut off by the
keyboard exactly as HEAD does. That commit only *mitigated* the Android half of this
same defect (`returnKeyType="go"` + `onSubmitEditing`).

The defect is older than the sign-in screen's last few changes: the margin at the
submit button's centre was ~2pt, and it is a function of screen height minus keyboard
height, so the same flow passes on a taller simulator and fails on a shorter one. The
simulator pool here spans iPhone SE through 17 Pro Max, and `dev:mobile:simulator claim`
takes whichever iPhone is free — that is the "this used to work". I did not re-run
history on the other models, so which model the earlier green runs used is unproven;
the geometry above is measured, the model-dependence is arithmetic from it.

## The fix

**Product** (`login-screen.tsx`, the real user-visible half): the root
`KeyboardAvoidingView` now runs on iOS too, with `behavior="padding"`. It shrinks the
ScrollView so the whole form re-centres above the keyboard. The now-redundant
`automaticallyAdjustKeyboardInsets` is removed — stacking both pushes the form off the
top of the screen (observed, then fixed). After the change, submit centre 414 vs
keyboard top 566: clear by 152pt, with the logo, field, submit and "More sign-in
options" all visible.

No unit test: the change is a platform-conditional prop, there is no extractable logic
to assert. It is covered by the device runs below.

**Harness**:
- `login-request-code.yaml` erases the field before typing (it is uncontrolled, so a
  login page left on screen still holds its address and `inputText` inserts at the caret
  the tap dropped mid-string) and asserts the typed address before submitting — a
  mismatch now fails instantly and legibly instead of 15s later on `Verify code`.
- `login.sh` cold-relaunches through `open-app.yaml` before its single retry, and if that
  fails too it names which half broke: no new outbox email means the request never
  reached the backend; a new email means the request worked and only the code screen was
  never reached.
- `e2e/AGENTS.md` records both constraints; the swallowed-tap diagnosis (including the
  two log greps that prove which window got the touch) is in
  `.kilo_workflow/learnings/maestro-tap-swallowed-by-ios-keyboard.md`.

## Verification

iPhone 17 Pro simulator (iOS 26.5), this worktree's own stack and Metro.

Reproduced at HEAD first: `login.sh` exit 1, both attempts dying on `Verify code`, live
`maestro hierarchy` confirming submit centre 568 inside the keyboard window at 566.

With the fix, `apps/mobile/e2e/login.sh <udid>` reached Home from all three starting
states, first attempt each time, no retry needed:

| start state | result |
| --- | --- |
| signed out with a full-length address already in the field | exit 0 — `Erase 100 characters` → `Assert that "${EMAIL}" is visible... COMPLETED` → Home |
| already signed in | exit 0 — signed out, re-requested, verified, Home |
| cold app (process terminated) | exit 0 — deep link relaunch, signed out, verified, Home |

The OTP screen shares the same container and was re-checked with the number pad up:
`Verify code` 238–276, `Resend code` 287–325, `Back` 336–374, all above the keyboard
window at 566.

Checks from `apps/mobile`: `pnpm format`, `pnpm typecheck`, `pnpm lint` (0 errors),
`pnpm check:unused`, `pnpm test` (2337 passed). `git diff --check` clean,
`bash -n login.sh` and `maestro check-syntax` OK.

## What remains unexplained

Which simulator model the historical green runs used — the fix makes it moot (there is
now 152pt of clearance instead of 2), but the "used to work" timeline is inferred from
geometry, not from a recovered passing run. The OTP screen now has both this
KeyboardAvoidingView and its own keyboard-padding listener; both were verified working
together, and collapsing that duplication was out of scope here.