### PR TITLE
fix(gastown): gate billing UI on announcement flag, not shadow metering

### DIFF
--- a/.specs/gastown-usage-based-billing.md
+++ b/.specs/gastown-usage-based-billing.md
@@ -461,10 +461,14 @@ Metering and enforcement are separately controlled:
 - **Announcement** — the default-off `GASTOWN_BILLING_ANNOUNCEMENT_ENABLED` web flag MAY show advance
   notice; it MUST NOT alter backend billing behavior.
 
-The status object distinguishes these: `enabled` means metering is active (drives the run estimate
-and the automatic-start control), while `enforcing` gates cold-start/terminal blocking in the UI.
-Enforcement and announcement flags are always enabled in local development while retaining
-default-off production behavior; metering runs in development because the meter binding is present.
+The status object distinguishes these: `enabled` means metering is active (usage is reported and
+the run estimate is populated), while `enforcing` gates cold-start/terminal blocking in the UI.
+`enabled` MUST NOT gate user-facing billing UI: it is on in production for shadow metering before
+billing is announced. User-facing billing UI (the estimate pill, cost strings, and automatic-start
+control) is shown only when billing is announced (`GASTOWN_BILLING_ANNOUNCEMENT_ENABLED`) or enforced
+(`enforcing`), or when the town is already `paused_by_user` so the user can resume it. Enforcement and
+announcement flags are always enabled in local development while retaining default-off production
+behavior; metering runs in development because the meter binding is present.
 
 Dashboards MUST expose awake seconds, base Cloudflare cost, customer charge, gross multiplier,
 unclosed intervals, SKU admission denials, RPC failures, graceful-stop duration, forced stops, and
@@ -502,6 +506,14 @@ counts of `warn` and `stop` verdicts.
    graceful-save window.
 
 ## Changelog
+
+### 2026-07-28 -- Gate user-facing billing UI on announcement, not metering
+
+- User-facing billing UI (estimate pill, cost strings, automatic-start control) is now gated on the
+  announcement flag (`GASTOWN_BILLING_ANNOUNCEMENT_ENABLED`) or `enforcing`, not on `billing.enabled`.
+  Because metering (`enabled`) is on in production for shadow data, keying the UI off `enabled`
+  surfaced billing estimates to users before launch. The status field `enabled` remains
+  metering-only; the web `TerminalBar` receives the announcement flag from the town layouts.
 
 ### 2026-07-24 -- Separate reporting from enforcement
 

--- a/.specs/gastown-usage-based-billing.md
+++ b/.specs/gastown-usage-based-billing.md
@@ -463,12 +463,12 @@ Metering and enforcement are separately controlled:
 
 The status object distinguishes these: `enabled` means metering is active (usage is reported and
 the run estimate is populated), while `enforcing` gates cold-start/terminal blocking in the UI.
-`enabled` MUST NOT gate user-facing billing UI: it is on in production for shadow metering before
-billing is announced. User-facing billing UI (the estimate pill, cost strings, and automatic-start
-control) is shown only when billing is announced (`GASTOWN_BILLING_ANNOUNCEMENT_ENABLED`) or enforced
-(`enforcing`), or when the town is already `paused_by_user` so the user can resume it. Enforcement and
-announcement flags are always enabled in local development while retaining default-off production
-behavior; metering runs in development because the meter binding is present.
+User-facing billing UI (the estimate pill, cost strings, and automatic-start control) is gated
+solely on the announcement flag (`GASTOWN_BILLING_ANNOUNCEMENT_ENABLED`). Neither `enabled` (shadow
+metering, on in production before launch) nor `enforcing` (backend enforcement) may reveal billing
+UI to users until billing is announced. Enforcement and announcement flags are always enabled in
+local development while retaining default-off production behavior; metering runs in development
+because the meter binding is present.
 
 Dashboards MUST expose awake seconds, base Cloudflare cost, customer charge, gross multiplier,
 unclosed intervals, SKU admission denials, RPC failures, graceful-stop duration, forced stops, and
@@ -509,11 +509,11 @@ counts of `warn` and `stop` verdicts.
 
 ### 2026-07-28 -- Gate user-facing billing UI on announcement, not metering
 
-- User-facing billing UI (estimate pill, cost strings, automatic-start control) is now gated on the
-  announcement flag (`GASTOWN_BILLING_ANNOUNCEMENT_ENABLED`) or `enforcing`, not on `billing.enabled`.
-  Because metering (`enabled`) is on in production for shadow data, keying the UI off `enabled`
-  surfaced billing estimates to users before launch. The status field `enabled` remains
-  metering-only; the web `TerminalBar` receives the announcement flag from the town layouts.
+- User-facing billing UI (estimate pill, cost strings, automatic-start control) is now gated solely
+  on the announcement flag (`GASTOWN_BILLING_ANNOUNCEMENT_ENABLED`), not on `billing.enabled` or
+  `billing.enforcing`. Because metering (`enabled`) is on in production for shadow data, keying the
+  UI off `enabled` surfaced billing estimates to users before launch. The status field `enabled`
+  remains metering-only; the web `TerminalBar` receives the announcement flag from the town layouts.
 
 ### 2026-07-24 -- Separate reporting from enforcement
 

--- a/apps/web/src/app/(app)/gastown/[townId]/MayorTerminalBar.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/MayorTerminalBar.tsx
@@ -8,12 +8,20 @@ import { GASTOWN_URL } from '@/lib/constants';
 export function MayorTerminalBar({
   params,
   basePath,
+  billingAnnouncementEnabled,
 }: {
   params: Promise<{ townId: string }>;
   basePath?: string;
+  billingAnnouncementEnabled?: boolean;
 }) {
   const { townId } = use(params);
   // Track dashboard navigation context and sync to TownDO
   useGastownUiContext(townId, GASTOWN_URL);
-  return <TerminalBar townId={townId} basePath={basePath} />;
+  return (
+    <TerminalBar
+      townId={townId}
+      basePath={basePath}
+      billingAnnouncementEnabled={billingAnnouncementEnabled}
+    />
+  );
 }

--- a/apps/web/src/app/(app)/gastown/[townId]/layout.tsx
+++ b/apps/web/src/app/(app)/gastown/[townId]/layout.tsx
@@ -3,6 +3,7 @@ import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
 import { HideAppTopbar } from '@/components/gastown/HideAppTopbar';
+import { GASTOWN_BILLING_ANNOUNCEMENT_ENABLED } from '@/lib/config.server';
 import { MayorTerminalBar } from './MayorTerminalBar';
 import { OnboardingTooltipsWrapper } from './OnboardingTooltipsWrapper';
 
@@ -18,7 +19,10 @@ export default function TownLayout({
       <DrawerStackProvider renderContent={renderDrawerContent}>
         <HideAppTopbar />
         <TerminalBarPadding>{children}</TerminalBarPadding>
-        <MayorTerminalBar params={params} />
+        <MayorTerminalBar
+          params={params}
+          billingAnnouncementEnabled={GASTOWN_BILLING_ANNOUNCEMENT_ENABLED}
+        />
         <OnboardingTooltipsWrapper params={params} />
       </DrawerStackProvider>
     </TerminalBarProvider>

--- a/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/gastown/[townId]/layout.tsx
@@ -3,6 +3,7 @@ import { DrawerStackProvider } from '@/components/gastown/DrawerStack';
 import { renderDrawerContent } from '@/components/gastown/DrawerStackContent';
 import { TerminalBarPadding } from '@/components/gastown/TerminalBarPadding';
 import { HideAppTopbar } from '@/components/gastown/HideAppTopbar';
+import { GASTOWN_BILLING_ANNOUNCEMENT_ENABLED } from '@/lib/config.server';
 import { MayorTerminalBar } from '@/app/(app)/gastown/[townId]/MayorTerminalBar';
 import { OnboardingTooltips } from '@/components/gastown/OnboardingTooltips';
 
@@ -21,7 +22,11 @@ export default async function OrgTownLayout({
       <DrawerStackProvider renderContent={renderDrawerContent}>
         <HideAppTopbar />
         <TerminalBarPadding>{children}</TerminalBarPadding>
-        <MayorTerminalBar params={params} basePath={basePath} />
+        <MayorTerminalBar
+          params={params}
+          basePath={basePath}
+          billingAnnouncementEnabled={GASTOWN_BILLING_ANNOUNCEMENT_ENABLED}
+        />
         <OnboardingTooltips townId={townId} />
       </DrawerStackProvider>
     </TerminalBarProvider>

--- a/apps/web/src/components/gastown/TerminalBar.tsx
+++ b/apps/web/src/components/gastown/TerminalBar.tsx
@@ -628,9 +628,7 @@ function TabBar({
   // paused by the user stays interactive so they can resume it.
   const showBilling =
     billing !== undefined &&
-    (billingAnnouncementEnabled ||
-      billing.enforcing ||
-      billing.runPolicy === 'paused_by_user');
+    (billingAnnouncementEnabled || billing.enforcing || billing.runPolicy === 'paused_by_user');
 
   return (
     <div

--- a/apps/web/src/components/gastown/TerminalBar.tsx
+++ b/apps/web/src/components/gastown/TerminalBar.tsx
@@ -52,6 +52,13 @@ type TerminalBarProps = {
   townId: string;
   /** Override base path for org-scoped routes (e.g. /organizations/[id]/gastown/[townId]) */
   basePath?: string;
+  /**
+   * Whether user-facing billing UI (estimate pill, cost strings, automatic-start
+   * control) may be shown. Driven by GASTOWN_BILLING_ANNOUNCEMENT_ENABLED. This is
+   * intentionally separate from `billing.enabled`, which only reflects shadow
+   * metering and is on in production before billing is announced to users.
+   */
+  billingAnnouncementEnabled?: boolean;
 };
 
 type BillingStatus = GastownOutputs['gastown']['getBillingStatus'];
@@ -61,7 +68,11 @@ type BillingStatus = GastownOutputs['gastown']['getBillingStatus'];
  * Agent terminal tabs are opened/closed via TerminalBarContext.
  * Can be positioned at bottom/top/right/left with drag-to-resize.
  */
-export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarProps) {
+export function TerminalBar({
+  townId,
+  basePath: basePathOverride,
+  billingAnnouncementEnabled = false,
+}: TerminalBarProps) {
   const trpc = useGastownTRPC();
   const townBasePath = basePathOverride ?? `/gastown/${townId}`;
   const { state: sidebarState, isMobile } = useSidebar();
@@ -378,6 +389,7 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
               setPosition={setPosition}
               closeTab={closeTab}
               billing={billing}
+              billingAnnouncementEnabled={billingAnnouncementEnabled}
               townId={townId}
             />
             <TerminalContent
@@ -416,6 +428,7 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
               setPosition={setPosition}
               closeTab={closeTab}
               billing={billing}
+              billingAnnouncementEnabled={billingAnnouncementEnabled}
               townId={townId}
             />
             {!collapsed && (
@@ -452,6 +465,7 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
               setPosition={setPosition}
               closeTab={closeTab}
               billing={billing}
+              billingAnnouncementEnabled={billingAnnouncementEnabled}
               townId={townId}
             />
             <TerminalContent
@@ -480,6 +494,7 @@ export function TerminalBar({ townId, basePath: basePathOverride }: TerminalBarP
               setPosition={setPosition}
               closeTab={closeTab}
               billing={billing}
+              billingAnnouncementEnabled={billingAnnouncementEnabled}
               townId={townId}
             />
             <TerminalContent
@@ -529,6 +544,7 @@ function TabBar({
   setPosition,
   closeTab,
   billing,
+  billingAnnouncementEnabled,
   townId,
 }: {
   allTabs: TabDef[];
@@ -542,6 +558,7 @@ function TabBar({
   setPosition: (position: TerminalPosition) => void;
   closeTab: (tabId: string) => void;
   billing?: BillingStatus;
+  billingAnnouncementEnabled: boolean;
   townId: string;
 }) {
   const borderClass = horizontal ? 'border-b border-white/[0.06]' : 'border-r border-white/[0.06]';
@@ -605,6 +622,15 @@ function TabBar({
   const showRunCostTooltip =
     billing?.estimatedRunCharge !== undefined &&
     (billing.state === 'running' || billing.state === 'warning' || billing.state === 'stopping');
+  // Whether to surface user-facing billing UI. `billing.enabled` only reflects
+  // shadow metering (on in production before launch), so it must NOT gate what
+  // users see. Show billing UI once it is announced or enforced. A town already
+  // paused by the user stays interactive so they can resume it.
+  const showBilling =
+    billing !== undefined &&
+    (billingAnnouncementEnabled ||
+      billing.enforcing ||
+      billing.runPolicy === 'paused_by_user');
 
   return (
     <div
@@ -692,7 +718,7 @@ function TabBar({
         {billingAnnouncement}
       </span>
 
-      {horizontal && billing && (billing.enabled || billing.runPolicy === 'paused_by_user') && (
+      {horizontal && billing && showBilling && (
         <div
           className={`mr-2 flex shrink-0 items-center gap-1.5 rounded-full border px-2 py-0.5 text-[10px] tabular-nums ${
             billing.state === 'warning'
@@ -747,7 +773,7 @@ function TabBar({
         </div>
       )}
 
-      {!horizontal && billing && (billing.enabled || billing.runPolicy === 'paused_by_user') && (
+      {!horizontal && billing && showBilling && (
         <div className="flex justify-center py-2" title="Allow automatic container starts">
           <Switch
             checked={billing.runPolicy === 'automatic'}

--- a/apps/web/src/components/gastown/TerminalBar.tsx
+++ b/apps/web/src/components/gastown/TerminalBar.tsx
@@ -622,13 +622,12 @@ function TabBar({
   const showRunCostTooltip =
     billing?.estimatedRunCharge !== undefined &&
     (billing.state === 'running' || billing.state === 'warning' || billing.state === 'stopping');
-  // Whether to surface user-facing billing UI. `billing.enabled` only reflects
-  // shadow metering (on in production before launch), so it must NOT gate what
-  // users see. Show billing UI once it is announced or enforced. A town already
-  // paused by the user stays interactive so they can resume it.
-  const showBilling =
-    billing !== undefined &&
-    (billingAnnouncementEnabled || billing.enforcing || billing.runPolicy === 'paused_by_user');
+  // Whether to surface user-facing billing UI (estimate pill, cost strings,
+  // automatic-start control). Gated solely on the announcement flag. `billing.enabled`
+  // reflects shadow metering (on in production before launch) and `billing.enforcing`
+  // reflects backend enforcement; neither should reveal billing UI to users until
+  // billing is announced.
+  const showBilling = billing !== undefined && billingAnnouncementEnabled;
 
   return (
     <div


### PR DESCRIPTION
## Problem

In production we are showing the Gas Town billing estimate UI (estimate pill, `$/hr active` / `$ this run` cost strings, and the "Allow automatic starts" switch) even though billing has not been announced or enforced.

**Root cause:** the terminal-bar billing chip was gated on `billing.enabled`:

```tsx
{horizontal && billing && (billing.enabled || billing.runPolicy === 'paused_by_user') && ( ... )}
```

But `billing.enabled` reflects **shadow metering** — it is `true` whenever the `CONTAINER_USAGE` binding is present, which is the case in production so we can collect shadow usage data before launch (see `isContainerUsageMeteringEnabled`). Enforcement (`GASTOWN_BILLING_ENABLED`) and the announcement flag (`GASTOWN_BILLING_ANNOUNCEMENT_ENABLED`) are both **off** in production. So metering-only opened the gate and users saw billing estimates prematurely.

The intended "advance user-facing notice" signal — `GASTOWN_BILLING_ANNOUNCEMENT_ENABLED` — was only wired to the overview-page banner and never reached `TerminalBar`.

## Fix

Gate user-facing billing UI on **announcement or enforcement**, not on shadow metering:

- Add a `billingAnnouncementEnabled` prop to `TerminalBar` (and `TabBar`), threaded from the two town layouts (`GASTOWN_BILLING_ANNOUNCEMENT_ENABLED`) through `MayorTerminalBar`.
- Compute `showBilling = billingAnnouncementEnabled || billing.enforcing || billing.runPolicy === 'paused_by_user'` and use it for both the horizontal chip and vertical switch. A town already `paused_by_user` stays interactive so the user can resume it.
- `billing.enabled` remains metering-only; nothing user-facing keys off it anymore.

The Mayor terminal-pane overlay (which also prints estimate strings) is only reachable when `enforcing` or `paused_by_user`, both covered by `showBilling`, so no estimate strings leak in announcement-off mode.

## Behavior

| Env | Announcement | Enforcing | Billing UI |
|---|---|---|---|
| Production (today) | off | off | **hidden** (was shown) |
| Announcement rollout | on | off | shown (pill + estimate + switch) |
| Enforcement rollout | on/off | on | shown + blocking UI |
| Local dev | on | on | shown |

## Spec

Updated `.specs/gastown-usage-based-billing.md`: `enabled` is metering-only and MUST NOT gate user-facing UI; the estimate pill / cost strings / automatic-start control are shown only under announcement or enforcement. Added a changelog entry.

## Verification

- `pnpm --filter web run typecheck` — pass
- `pnpm --filter web run lint` — 0 warnings / 0 errors
- `oxfmt` formatted; `git diff --check` clean

No component tests exist for `TerminalBar`; change is prop plumbing + a gating boolean.