### PR TITLE
fix(workflow): stop e2e-slot mangling the stack session name

### DIFF
--- a/.kilo_workflow/e2e-slot.sh
+++ b/.kilo_workflow/e2e-slot.sh
@@ -37,7 +37,10 @@ SELF_WORKTREE=$(git -C "$(dirname "$0")" rev-parse --show-toplevel 2>/dev/null |
 # started by hand in a personal worktree is reported, never stopped.
 is_section_slug() { [[ "$1" =~ -[0-9a-f]{4}$ ]]; }
 
-stack_session() { echo "kilo-dev-$(basename "$1" | tr -c 'A-Za-z0-9_-' '_')"; }
+# `\n` stays in the preserved set on purpose: without it `tr` rewrites the
+# trailing newline `basename` emits into `_`, which `$(...)` can no longer
+# strip, and every session name comes back with a spurious trailing underscore.
+stack_session() { echo "kilo-dev-$(basename "$1" | tr -c 'A-Za-z0-9_-\n' '_')"; }
 
 # Is any held slot entitled to this stack session? The recorded worktree is the
 # real answer; the owner-name prefix is a fallback so slots written before


### PR DESCRIPTION
## Problem

`stack_session()` sanitises a worktree basename with `tr -c 'A-Za-z0-9_-' '_'`. `basename` emits a trailing newline, the newline is outside the preserved set, so `tr` rewrites it to `_` — and `$(...)` can no longer strip it. Every session name came back with a spurious trailing underscore:

```
$ basename /Users/igor/Projects/.worktrees/mobile-ui-ddc7 | tr -c 'A-Za-z0-9_-' '_'
mobile-ui-ddc7_          # wanted: mobile-ui-ddc7
```

## Why it matters

The slot/stack unification promises that `release` frees the slot **and** stops the worktree's stack, so a stack can never outlive the slot that entitled it. That guarantee was not holding. Three silent failures:

1. **`release` never stopped the dev stack.** `stop_stack` looked up `kilo-dev-<name>_`, `tmux has-session` failed, and it returned early treating the stack as already gone. Stacks outlived their slots — the exact over-subscription the cap exists to prevent.
2. **`status` always reported `stack=none`**, even with the stack plainly up.
3. **`stack_is_covered` never matched on the recorded worktree**, so coverage worked only via the owner-name-prefix fallback. A slot whose owner name does not begin with the worktree basename would make a live stack look uncovered — and `stacks --reap` would then `pnpm dev:stop` a running E2E.

Observed on a live host: `slot-1 … [/Users/igor/Projects/.worktrees/mobile-ui-ddc7 stack=none]` while `tmux has-session -t kilo-dev-mobile-ui-ddc7` exited 0.

## Fix

Keep `\n` in the preserved set so `tr` leaves the newline alone for `$(...)` to strip. Other unsafe characters are still replaced (`weird.name/x` → `weird_name_x`).

## Verification

Against live slot state, before and after:

```
before: slot-1: … [/Users/igor/Projects/.worktrees/mobile-ui-ddc7 stack=none]
after:  slot-1: … [/Users/igor/Projects/.worktrees/mobile-ui-ddc7 stack=up]
```

`bash -n` clean. `stacks` still reports every running stack as covered, now on the worktree path rather than by accident of the fallback.

Found while enforcing the new slot rules across running dev stacks after #4826.
