### PR TITLE
feat(billing): add usage summary reporting

### DIFF
--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -368,8 +368,12 @@ export default function UsageRecordsContent() {
               if (unchanged) void results.refetch();
             }}
           >
-            {/* Primary bar: what to search for, and the actions that trigger it. */}
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+            {/* Primary bar: what to search for, and the actions that trigger it.
+                items-start (not items-end): every column below shares the same
+                label + gap + control rhythm, so their controls line up on the
+                same top edge regardless of any incidental height differences
+                inside a column (e.g. Radix Select's hidden native <select>). */}
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-start">
               <div className="w-full space-y-1.5 sm:w-40 sm:shrink-0">
                 <Label htmlFor="usage-search-kind">Search by</Label>
                 <Select value={kind} onValueChange={next => setKind(next as SearchKind)}>
@@ -394,32 +398,37 @@ export default function UsageRecordsContent() {
                   onChange={event => setValue(event.target.value)}
                 />
               </div>
-              <div className="grid grid-cols-2 gap-2 sm:flex sm:shrink-0">
-                <Button type="submit" disabled={results.isFetching || !value.trim()}>
-                  <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  onClick={() => {
-                    setValue('');
-                    setStatus('all');
-                    setCloseReason('all');
-                    setSkuId('all');
-                    setSummaryInputError(null);
-                    setSummaryRequest(null);
-                    setSubmitted({ kind: 'recent' });
-                    replaceCloseReasonParam(undefined);
-                    resetResultNavigation();
-                  }}
-                >
-                  Reset
-                </Button>
+              <div className="w-full space-y-1.5 sm:w-auto sm:shrink-0">
+                <Label className="invisible" aria-hidden="true">
+                  Actions
+                </Label>
+                <div className="grid grid-cols-2 gap-2 sm:flex">
+                  <Button type="submit" disabled={results.isFetching || !value.trim()}>
+                    <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    onClick={() => {
+                      setValue('');
+                      setStatus('all');
+                      setCloseReason('all');
+                      setSkuId('all');
+                      setSummaryInputError(null);
+                      setSummaryRequest(null);
+                      setSubmitted({ kind: 'recent' });
+                      replaceCloseReasonParam(undefined);
+                      resetResultNavigation();
+                    }}
+                  >
+                    Reset
+                  </Button>
+                </div>
               </div>
             </div>
 
             {/* Filters: narrow the search above. Wraps freely; never forces the actions off-card. */}
-            <div className="flex flex-wrap items-end gap-4 border-t border-border pt-4">
+            <div className="flex flex-wrap items-start gap-4 border-t border-border pt-4">
               <div className="w-36 space-y-1.5">
                 <Label htmlFor="usage-search-status">Status</Label>
                 <Select

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -297,7 +297,7 @@ export default function UsageRecordsContent() {
         </CardHeader>
         <CardContent>
           <form
-            className="grid gap-4 lg:grid-cols-3 lg:items-start xl:grid-cols-[9rem_minmax(12.5rem,1fr)_7rem_10rem_10rem_auto] xl:gap-3"
+            className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 lg:items-start xl:grid-cols-[8rem_minmax(11rem,1fr)_minmax(20rem,1.5fr)_7rem_9rem_9rem_auto] xl:gap-3"
             onSubmit={event => {
               event.preventDefault();
               const trimmed = value.trim();
@@ -382,10 +382,13 @@ export default function UsageRecordsContent() {
               </Select>
             </div>
             {(kind === 'user' || kind === 'org') && (
-              <div className="space-y-1.5 lg:col-span-3 xl:col-span-2">
-                <div className="grid gap-4 sm:grid-cols-2">
+              <div className="space-y-1.5 md:col-span-2 lg:col-span-2 xl:col-span-1">
+                <Label>Usage window</Label>
+                <div className="grid grid-cols-2 gap-2">
                   <div className="space-y-1.5">
-                    <Label htmlFor="usage-summary-start">Window start</Label>
+                    <Label htmlFor="usage-summary-start" className="sr-only">
+                      Window start
+                    </Label>
                     <Input
                       id="usage-summary-start"
                       type="datetime-local"
@@ -398,7 +401,9 @@ export default function UsageRecordsContent() {
                     />
                   </div>
                   <div className="space-y-1.5">
-                    <Label htmlFor="usage-summary-end">Window end</Label>
+                    <Label htmlFor="usage-summary-end" className="sr-only">
+                      Window end
+                    </Label>
                     <Input
                       id="usage-summary-end"
                       type="datetime-local"
@@ -523,17 +528,37 @@ export default function UsageRecordsContent() {
                 </SelectContent>
               </Select>
             </div>
-            <div className="space-y-1.5">
+            <div className="space-y-1.5 md:col-span-2 lg:col-span-1">
               <Label className="invisible" aria-hidden="true">
-                Action
+                Actions
               </Label>
-              <Button
-                type="submit"
-                className="w-full"
-                disabled={results.isFetching || !value.trim()}
-              >
-                <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
-              </Button>
+              <div className="grid grid-cols-2 gap-2 xl:flex">
+                <Button
+                  type="submit"
+                  className="w-full xl:w-auto"
+                  disabled={results.isFetching || !value.trim()}
+                >
+                  <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  className="w-full xl:w-auto"
+                  onClick={() => {
+                    setValue('');
+                    setStatus('all');
+                    setCloseReason('all');
+                    setSkuId('all');
+                    setSummaryInputError(null);
+                    setSummaryRequest(null);
+                    setSubmitted({ kind: 'recent' });
+                    replaceCloseReasonParam(undefined);
+                    resetResultNavigation();
+                  }}
+                >
+                  Reset
+                </Button>
+              </div>
             </div>
           </form>
         </CardContent>

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -381,52 +381,6 @@ export default function UsageRecordsContent() {
                 </SelectContent>
               </Select>
             </div>
-            {(kind === 'user' || kind === 'org') && (
-              <div className="space-y-1.5 md:col-span-2 lg:col-span-2 xl:col-span-1">
-                <Label>Usage window</Label>
-                <div className="grid grid-cols-2 gap-2">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="usage-summary-start" className="sr-only">
-                      Window start
-                    </Label>
-                    <Input
-                      id="usage-summary-start"
-                      type="datetime-local"
-                      value={summaryStart}
-                      max={summaryEnd}
-                      aria-describedby={
-                        summaryInputError ? 'usage-summary-window-error' : undefined
-                      }
-                      onChange={event => setSummaryStart(event.target.value)}
-                    />
-                  </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="usage-summary-end" className="sr-only">
-                      Window end
-                    </Label>
-                    <Input
-                      id="usage-summary-end"
-                      type="datetime-local"
-                      value={summaryEnd}
-                      min={summaryStart}
-                      aria-describedby={
-                        summaryInputError ? 'usage-summary-window-error' : undefined
-                      }
-                      onChange={event => setSummaryEnd(event.target.value)}
-                    />
-                  </div>
-                </div>
-                {summaryInputError && (
-                  <p
-                    id="usage-summary-window-error"
-                    className="text-destructive type-label"
-                    role="alert"
-                  >
-                    {summaryInputError}
-                  </p>
-                )}
-              </div>
-            )}
             <div className="space-y-1.5">
               <Label htmlFor="usage-search-value">Exact value</Label>
               <Input
@@ -528,6 +482,52 @@ export default function UsageRecordsContent() {
                 </SelectContent>
               </Select>
             </div>
+            {(kind === 'user' || kind === 'org') && (
+              <div className="space-y-1.5 md:col-span-2 lg:col-span-2 xl:col-span-1">
+                <Label>Usage window</Label>
+                <div className="grid grid-cols-2 gap-2">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="usage-summary-start" className="sr-only">
+                      Window start
+                    </Label>
+                    <Input
+                      id="usage-summary-start"
+                      type="datetime-local"
+                      value={summaryStart}
+                      max={summaryEnd}
+                      aria-describedby={
+                        summaryInputError ? 'usage-summary-window-error' : undefined
+                      }
+                      onChange={event => setSummaryStart(event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="usage-summary-end" className="sr-only">
+                      Window end
+                    </Label>
+                    <Input
+                      id="usage-summary-end"
+                      type="datetime-local"
+                      value={summaryEnd}
+                      min={summaryStart}
+                      aria-describedby={
+                        summaryInputError ? 'usage-summary-window-error' : undefined
+                      }
+                      onChange={event => setSummaryEnd(event.target.value)}
+                    />
+                  </div>
+                </div>
+                {summaryInputError && (
+                  <p
+                    id="usage-summary-window-error"
+                    className="text-destructive type-label"
+                    role="alert"
+                  >
+                    {summaryInputError}
+                  </p>
+                )}
+              </div>
+            )}
             <div className="space-y-1.5 md:col-span-2 lg:col-span-1">
               <Label className="invisible" aria-hidden="true">
                 Actions

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -44,16 +44,36 @@ type SearchRequest =
       skuId?: string;
     }
   | {
-      kind: SearchKind;
+      kind: 'interval';
       value: string;
       status?: 'open' | 'closed';
       closeReason?: CloseReason;
       skuId?: string;
+    }
+  | {
+      kind: 'user' | 'org';
+      value: string;
+      status?: 'open' | 'closed';
+      closeReason?: CloseReason;
+      skuId?: string;
+      summaryStart?: string;
+      summaryEnd?: string;
     };
 type Cursor = { startedAt: string; id: string };
+type UsageSummaryRequest = {
+  subjectType: 'user' | 'org';
+  subjectId: string;
+  start: string;
+  end: string;
+};
 
 function formatTimestamp(value: string | null): string {
   return value ? new Date(value).toLocaleString() : '—';
+}
+
+function toDateTimeLocalValue(value: Date): string {
+  const offset = value.getTimezoneOffset() * 60_000;
+  return new Date(value.getTime() - offset).toISOString().slice(0, 16);
 }
 
 function adminSubjectHref(type: 'user' | 'org', id: string): string {
@@ -200,6 +220,12 @@ export default function UsageRecordsContent() {
   const [cursor, setCursor] = useState<Cursor | undefined>();
   const [previousCursors, setPreviousCursors] = useState<Array<Cursor | undefined>>([]);
   const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [summaryStart, setSummaryStart] = useState(() =>
+    toDateTimeLocalValue(new Date(Date.now() - 24 * 60 * 60 * 1_000))
+  );
+  const [summaryEnd, setSummaryEnd] = useState(() => toDateTimeLocalValue(new Date()));
+  const [summaryRequest, setSummaryRequest] = useState<UsageSummaryRequest | null>(null);
+  const [summaryInputError, setSummaryInputError] = useState<string | null>(null);
 
   const input = {
     search:
@@ -211,6 +237,8 @@ export default function UsageRecordsContent() {
               kind: 'subject',
               subjectType: submitted.kind,
               subjectId: submitted.value,
+              start: submitted.summaryStart ?? '',
+              end: submitted.summaryEnd ?? '',
             } as const),
     status: submitted.status,
     closeReason: submitted.closeReason,
@@ -219,6 +247,17 @@ export default function UsageRecordsContent() {
     limit: submitted.kind === 'recent' ? 10 : 25,
   };
   const results = useQuery(trpc.admin.cloudBillingSkus.searchUsageIntervals.queryOptions(input));
+  const summary = useQuery({
+    ...trpc.admin.cloudBillingSkus.getUsageSummary.queryOptions(
+      summaryRequest ?? {
+        subjectType: 'user',
+        subjectId: 'not-submitted',
+        start: new Date(0).toISOString(),
+        end: new Date(1).toISOString(),
+      }
+    ),
+    enabled: summaryRequest !== null,
+  });
   const rows = results.data?.items ?? [];
 
   const resetResultNavigation = () => {
@@ -263,20 +302,67 @@ export default function UsageRecordsContent() {
               event.preventDefault();
               const trimmed = value.trim();
               if (!trimmed) return;
+              let summaryWindow: { summaryStart?: string; summaryEnd?: string } = {};
+              if (kind === 'user' || kind === 'org') {
+                const start = new Date(summaryStart);
+                const end = new Date(summaryEnd);
+                const windowMs = end.getTime() - start.getTime();
+                if (
+                  Number.isNaN(start.getTime()) ||
+                  Number.isNaN(end.getTime()) ||
+                  windowMs <= 0 ||
+                  windowMs > 31 * 24 * 60 * 60 * 1_000
+                ) {
+                  setSummaryInputError('Choose a valid window of no more than 31 days.');
+                  return;
+                }
+                summaryWindow = {
+                  summaryStart: start.toISOString(),
+                  summaryEnd: end.toISOString(),
+                };
+              }
               const next: SearchRequest = {
                 kind,
                 value: trimmed,
                 status: status === 'all' ? undefined : status,
                 closeReason: closeReason === 'all' ? undefined : closeReason,
                 skuId: skuId === 'all' ? undefined : skuId,
+                ...summaryWindow,
               };
+              const submittedValue = submitted.kind === 'recent' ? undefined : submitted.value;
+              const nextValue = next.kind === 'recent' ? undefined : next.value;
+              const nextSummaryStart =
+                next.kind === 'user' || next.kind === 'org' ? next.summaryStart : undefined;
+              const nextSummaryEnd =
+                next.kind === 'user' || next.kind === 'org' ? next.summaryEnd : undefined;
+              const submittedSummaryStart =
+                submitted.kind === 'user' || submitted.kind === 'org'
+                  ? submitted.summaryStart
+                  : undefined;
+              const submittedSummaryEnd =
+                submitted.kind === 'user' || submitted.kind === 'org'
+                  ? submitted.summaryEnd
+                  : undefined;
               const unchanged =
                 cursor === undefined &&
                 submitted.kind === next.kind &&
-                submitted.value === next.value &&
+                submittedValue === nextValue &&
                 submitted.status === next.status &&
                 submitted.closeReason === next.closeReason &&
-                submitted.skuId === next.skuId;
+                submitted.skuId === next.skuId &&
+                submittedSummaryStart === nextSummaryStart &&
+                submittedSummaryEnd === nextSummaryEnd;
+              setSummaryInputError(null);
+              setSummaryRequest(
+                next.kind === 'user' || next.kind === 'org'
+                  ? {
+                      subjectType: next.kind,
+                      subjectId: next.value,
+                      start: next.summaryStart ?? '',
+                      end: next.summaryEnd ?? '',
+                    }
+                  : null
+              );
               setSubmitted(next);
               resetResultNavigation();
               if (unchanged) void results.refetch();
@@ -295,6 +381,47 @@ export default function UsageRecordsContent() {
                 </SelectContent>
               </Select>
             </div>
+            {(kind === 'user' || kind === 'org') && (
+              <div className="space-y-1.5 lg:col-span-3 xl:col-span-2">
+                <div className="grid gap-4 sm:grid-cols-2">
+                  <div className="space-y-1.5">
+                    <Label htmlFor="usage-summary-start">Window start</Label>
+                    <Input
+                      id="usage-summary-start"
+                      type="datetime-local"
+                      value={summaryStart}
+                      max={summaryEnd}
+                      aria-describedby={
+                        summaryInputError ? 'usage-summary-window-error' : undefined
+                      }
+                      onChange={event => setSummaryStart(event.target.value)}
+                    />
+                  </div>
+                  <div className="space-y-1.5">
+                    <Label htmlFor="usage-summary-end">Window end</Label>
+                    <Input
+                      id="usage-summary-end"
+                      type="datetime-local"
+                      value={summaryEnd}
+                      min={summaryStart}
+                      aria-describedby={
+                        summaryInputError ? 'usage-summary-window-error' : undefined
+                      }
+                      onChange={event => setSummaryEnd(event.target.value)}
+                    />
+                  </div>
+                </div>
+                {summaryInputError && (
+                  <p
+                    id="usage-summary-window-error"
+                    className="text-destructive type-label"
+                    role="alert"
+                  >
+                    {summaryInputError}
+                  </p>
+                )}
+              </div>
+            )}
             <div className="space-y-1.5">
               <Label htmlFor="usage-search-value">Exact value</Label>
               <Input
@@ -411,6 +538,113 @@ export default function UsageRecordsContent() {
           </form>
         </CardContent>
       </Card>
+
+      {(submitted.kind === 'user' || submitted.kind === 'org') && (
+        <Card>
+          <CardHeader>
+            <CardTitle>Usage summary</CardTitle>
+            <CardDescription>
+              Accepted seconds and shadow estimated cents for this exact subject. This does not
+              debit credits.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {summaryRequest && (
+              <p className="text-muted-foreground break-all type-label">
+                {summaryRequest.subjectType} {summaryRequest.subjectId} ·{' '}
+                {formatTimestamp(summaryRequest.start)} to {formatTimestamp(summaryRequest.end)} ·
+                window is [start, end)
+              </p>
+            )}
+
+            {summary.isFetching && (
+              <p className="text-muted-foreground type-body" role="status" aria-live="polite">
+                Calculating usage summary...
+              </p>
+            )}
+
+            {summary.isError && (
+              <Alert variant="destructive">
+                <AlertTitle>Usage summary could not be calculated</AlertTitle>
+                <AlertDescription className="space-y-3">
+                  <p>{summary.error.message}</p>
+                  {summary.error.data?.code !== 'BAD_REQUEST' && (
+                    <Button variant="outline" size="sm" onClick={() => void summary.refetch()}>
+                      Retry
+                    </Button>
+                  )}
+                </AlertDescription>
+              </Alert>
+            )}
+
+            {summary.isSuccess && (
+              <div className="space-y-3" aria-live="polite">
+                <p className="text-muted-foreground type-label">
+                  {summary.data.acceptedSeconds.toLocaleString()} accepted seconds across{' '}
+                  {summary.data.items
+                    .reduce((total, item) => total + item.intervals, 0)
+                    .toLocaleString()}{' '}
+                  interval
+                  {summary.data.items.reduce((total, item) => total + item.intervals, 0) === 1
+                    ? ''
+                    : 's'}
+                </p>
+                {summary.data.items.length === 0 ? (
+                  <p className="text-muted-foreground type-body">
+                    No accepted usage was recorded in this window.
+                  </p>
+                ) : (
+                  <div className="overflow-x-auto rounded-lg border border-border">
+                    <Table>
+                      <caption className="sr-only">
+                        Usage summary for {summary.data.subjectType} {summary.data.subjectId} from{' '}
+                        {formatTimestamp(summary.data.start)} to {formatTimestamp(summary.data.end)}
+                      </caption>
+                      <TableHeader>
+                        <TableRow>
+                          <TableHead>SKU</TableHead>
+                          <TableHead>Accepted seconds</TableHead>
+                          <TableHead>Rate</TableHead>
+                          <TableHead>Estimated cents</TableHead>
+                        </TableRow>
+                      </TableHeader>
+                      <TableBody>
+                        {summary.data.items.map(item => (
+                          <TableRow key={item.skuId}>
+                            <TableCell>
+                              <code className="type-code">{item.skuId}</code>
+                              <p className="text-muted-foreground type-label">{item.skuName}</p>
+                            </TableCell>
+                            <TableCell className="tabular-nums type-code">
+                              {item.acceptedSeconds.toLocaleString()}s
+                            </TableCell>
+                            <TableCell className="tabular-nums type-code">
+                              {item.rateCentsPerSecond} cents/s
+                            </TableCell>
+                            <TableCell className="tabular-nums type-code">
+                              {item.estimatedCents} cents
+                            </TableCell>
+                          </TableRow>
+                        ))}
+                        <TableRow>
+                          <TableCell className="font-medium">Total</TableCell>
+                          <TableCell className="tabular-nums font-medium type-code">
+                            {summary.data.acceptedSeconds.toLocaleString()}s
+                          </TableCell>
+                          <TableCell />
+                          <TableCell className="tabular-nums font-medium type-code">
+                            {summary.data.estimatedCents} cents
+                          </TableCell>
+                        </TableRow>
+                      </TableBody>
+                    </Table>
+                  </div>
+                )}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
 
       {results.isError && (
         <Alert variant="destructive">

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -363,6 +363,10 @@ export default function UsageRecordsContent() {
                     }
                   : null
               );
+              // Sync the URL to the applied filter (not the draft dropdown value) so a
+              // submitted search can be bookmarked/deep-linked without re-triggering a
+              // search merely from changing the Close reason dropdown before submitting.
+              replaceCloseReasonParam(next.closeReason);
               setSubmitted(next);
               resetResultNavigation();
               if (unchanged) void results.refetch();

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -398,20 +398,10 @@ export default function UsageRecordsContent() {
                 value={status}
                 onValueChange={next => {
                   const selected = next as typeof status;
-                  const selectedStatus = selected === 'all' ? undefined : selected;
-                  const selectedCloseReason =
-                    selected === 'open' ? undefined : submitted.closeReason;
                   setStatus(selected);
                   if (selected === 'open' && closeReason !== 'all') {
                     setCloseReason('all');
-                    replaceCloseReasonParam(undefined);
                   }
-                  setSubmitted(current => ({
-                    ...current,
-                    status: selectedStatus,
-                    closeReason: selectedCloseReason,
-                  }));
-                  resetResultNavigation();
                 }}
               >
                 <SelectTrigger id="usage-search-status" className="w-full">
@@ -433,13 +423,6 @@ export default function UsageRecordsContent() {
                   const selectedReason = selected === 'all' ? undefined : selected;
                   if (selectedReason && status === 'open') setStatus('closed');
                   setCloseReason(selected);
-                  replaceCloseReasonParam(selectedReason);
-                  setSubmitted(current => ({
-                    ...current,
-                    status: selectedReason && current.status === 'open' ? 'closed' : current.status,
-                    closeReason: selectedReason,
-                  }));
-                  resetResultNavigation();
                 }}
               >
                 <SelectTrigger id="usage-search-close-reason" className="w-full">
@@ -462,11 +445,6 @@ export default function UsageRecordsContent() {
                 value={skuId}
                 onValueChange={selected => {
                   setSkuId(selected);
-                  setSubmitted(current => ({
-                    ...current,
-                    skuId: selected === 'all' ? undefined : selected,
-                  }));
-                  resetResultNavigation();
                 }}
               >
                 <SelectTrigger id="usage-search-sku" className="w-full">
@@ -483,83 +461,122 @@ export default function UsageRecordsContent() {
               </Select>
             </div>
             {(kind === 'user' || kind === 'org') && (
-              <div className="space-y-1.5 lg:col-span-2 xl:col-span-4 xl:col-start-1 xl:row-start-2">
-                <Label>Usage window</Label>
-                <div className="grid grid-cols-2 gap-2">
-                  <div className="space-y-1.5">
-                    <Label htmlFor="usage-summary-start" className="sr-only">
-                      Window start
-                    </Label>
-                    <Input
-                      id="usage-summary-start"
-                      type="datetime-local"
-                      value={summaryStart}
-                      max={summaryEnd}
-                      aria-describedby={
-                        summaryInputError ? 'usage-summary-window-error' : undefined
-                      }
-                      onChange={event => setSummaryStart(event.target.value)}
-                    />
+              <div className="lg:col-span-2 xl:col-span-5 xl:row-start-2">
+                <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-end">
+                  <div className="space-y-1.5 xl:w-84">
+                    <Label>Usage window</Label>
+                    <div className="grid grid-cols-2 gap-2">
+                      <div className="space-y-1.5">
+                        <Label htmlFor="usage-summary-start" className="sr-only">
+                          Window start
+                        </Label>
+                        <Input
+                          id="usage-summary-start"
+                          type="datetime-local"
+                          value={summaryStart}
+                          max={summaryEnd}
+                          aria-describedby={
+                            summaryInputError ? 'usage-summary-window-error' : undefined
+                          }
+                          onChange={event => setSummaryStart(event.target.value)}
+                        />
+                      </div>
+                      <div className="space-y-1.5">
+                        <Label htmlFor="usage-summary-end" className="sr-only">
+                          Window end
+                        </Label>
+                        <Input
+                          id="usage-summary-end"
+                          type="datetime-local"
+                          value={summaryEnd}
+                          min={summaryStart}
+                          aria-describedby={
+                            summaryInputError ? 'usage-summary-window-error' : undefined
+                          }
+                          onChange={event => setSummaryEnd(event.target.value)}
+                        />
+                      </div>
+                    </div>
+                    {summaryInputError && (
+                      <p
+                        id="usage-summary-window-error"
+                        className="text-destructive type-label"
+                        role="alert"
+                      >
+                        {summaryInputError}
+                      </p>
+                    )}
                   </div>
-                  <div className="space-y-1.5">
-                    <Label htmlFor="usage-summary-end" className="sr-only">
-                      Window end
+                  <div className="space-y-1.5 xl:w-44">
+                    <Label className="invisible" aria-hidden="true">
+                      Actions
                     </Label>
-                    <Input
-                      id="usage-summary-end"
-                      type="datetime-local"
-                      value={summaryEnd}
-                      min={summaryStart}
-                      aria-describedby={
-                        summaryInputError ? 'usage-summary-window-error' : undefined
-                      }
-                      onChange={event => setSummaryEnd(event.target.value)}
-                    />
+                    <div className="grid grid-cols-2 gap-2">
+                      <Button
+                        type="submit"
+                        className="w-full"
+                        disabled={results.isFetching || !value.trim()}
+                      >
+                        <Search className="size-4" />{' '}
+                        {results.isFetching ? 'Searching...' : 'Search'}
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="outline"
+                        className="w-full"
+                        onClick={() => {
+                          setValue('');
+                          setStatus('all');
+                          setCloseReason('all');
+                          setSkuId('all');
+                          setSummaryInputError(null);
+                          setSummaryRequest(null);
+                          setSubmitted({ kind: 'recent' });
+                          replaceCloseReasonParam(undefined);
+                          resetResultNavigation();
+                        }}
+                      >
+                        Reset
+                      </Button>
+                    </div>
                   </div>
                 </div>
-                {summaryInputError && (
-                  <p
-                    id="usage-summary-window-error"
-                    className="text-destructive type-label"
-                    role="alert"
-                  >
-                    {summaryInputError}
-                  </p>
-                )}
               </div>
             )}
-            <div className="space-y-1.5 lg:col-span-2 xl:col-span-1 xl:col-start-5 xl:row-start-2">
-              <Label className="invisible" aria-hidden="true">
-                Actions
-              </Label>
-              <div className="grid grid-cols-2 gap-2">
-                <Button
-                  type="submit"
-                  className="w-full"
-                  disabled={results.isFetching || !value.trim()}
-                >
-                  <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
-                </Button>
-                <Button
-                  type="button"
-                  variant="outline"
-                  className="w-full"
-                  onClick={() => {
-                    setValue('');
-                    setStatus('all');
-                    setCloseReason('all');
-                    setSkuId('all');
-                    setSummaryInputError(null);
-                    setSummaryRequest(null);
-                    setSubmitted({ kind: 'recent' });
-                    replaceCloseReasonParam(undefined);
-                    resetResultNavigation();
-                  }}
-                >
-                  Reset
-                </Button>
+            {kind === 'interval' && (
+              <div className="space-y-1.5 lg:col-span-2 xl:col-span-5 xl:row-start-2 xl:ml-auto xl:w-44">
+                <Label className="invisible" aria-hidden="true">
+                  Actions
+                </Label>
+                <div className="grid grid-cols-2 gap-2">
+                  <Button
+                    type="submit"
+                    className="w-full"
+                    disabled={results.isFetching || !value.trim()}
+                  >
+                    <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
+                  </Button>
+                  <Button
+                    type="button"
+                    variant="outline"
+                    className="w-full"
+                    onClick={() => {
+                      setValue('');
+                      setStatus('all');
+                      setCloseReason('all');
+                      setSkuId('all');
+                      setSummaryInputError(null);
+                      setSummaryRequest(null);
+                      setSubmitted({ kind: 'recent' });
+                      replaceCloseReasonParam(undefined);
+                      resetResultNavigation();
+                    }}
+                  >
+                    Reset
+                  </Button>
+                </div>
               </div>
-            </div>
+            )}
           </form>
         </CardContent>
       </Card>

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -297,7 +297,7 @@ export default function UsageRecordsContent() {
         </CardHeader>
         <CardContent>
           <form
-            className="grid gap-4 md:grid-cols-2 lg:grid-cols-4 lg:items-start xl:grid-cols-[8rem_minmax(11rem,1fr)_minmax(20rem,1.5fr)_7rem_9rem_9rem_auto] xl:gap-3"
+            className="grid gap-4 lg:grid-cols-2 xl:grid-cols-[8rem_minmax(16rem,1fr)_7rem_9rem_8rem] xl:items-start xl:gap-3"
             onSubmit={event => {
               event.preventDefault();
               const trimmed = value.trim();
@@ -368,7 +368,7 @@ export default function UsageRecordsContent() {
               if (unchanged) void results.refetch();
             }}
           >
-            <div className="space-y-1.5">
+            <div className="space-y-1.5 xl:col-start-1 xl:row-start-1">
               <Label htmlFor="usage-search-kind">Search by</Label>
               <Select value={kind} onValueChange={next => setKind(next as SearchKind)}>
                 <SelectTrigger id="usage-search-kind" className="w-full">
@@ -381,7 +381,7 @@ export default function UsageRecordsContent() {
                 </SelectContent>
               </Select>
             </div>
-            <div className="space-y-1.5">
+            <div className="space-y-1.5 lg:col-span-1 xl:col-start-2 xl:row-start-1">
               <Label htmlFor="usage-search-value">Exact value</Label>
               <Input
                 id="usage-search-value"
@@ -392,7 +392,7 @@ export default function UsageRecordsContent() {
                 onChange={event => setValue(event.target.value)}
               />
             </div>
-            <div className="space-y-1.5">
+            <div className="space-y-1.5 xl:col-start-3 xl:row-start-1">
               <Label htmlFor="usage-search-status">Status</Label>
               <Select
                 value={status}
@@ -424,7 +424,7 @@ export default function UsageRecordsContent() {
                 </SelectContent>
               </Select>
             </div>
-            <div className="space-y-1.5">
+            <div className="space-y-1.5 xl:col-start-4 xl:row-start-1">
               <Label htmlFor="usage-search-close-reason">Close reason</Label>
               <Select
                 value={closeReason}
@@ -456,7 +456,7 @@ export default function UsageRecordsContent() {
                 </SelectContent>
               </Select>
             </div>
-            <div className="space-y-1.5">
+            <div className="space-y-1.5 xl:col-start-5 xl:row-start-1">
               <Label htmlFor="usage-search-sku">SKU</Label>
               <Select
                 value={skuId}
@@ -483,7 +483,7 @@ export default function UsageRecordsContent() {
               </Select>
             </div>
             {(kind === 'user' || kind === 'org') && (
-              <div className="space-y-1.5 md:col-span-2 lg:col-span-2 xl:col-span-1">
+              <div className="space-y-1.5 lg:col-span-2 xl:col-span-4 xl:col-start-1 xl:row-start-2">
                 <Label>Usage window</Label>
                 <div className="grid grid-cols-2 gap-2">
                   <div className="space-y-1.5">
@@ -528,14 +528,14 @@ export default function UsageRecordsContent() {
                 )}
               </div>
             )}
-            <div className="space-y-1.5 md:col-span-2 lg:col-span-1">
+            <div className="space-y-1.5 lg:col-span-2 xl:col-span-1 xl:col-start-5 xl:row-start-2">
               <Label className="invisible" aria-hidden="true">
                 Actions
               </Label>
-              <div className="grid grid-cols-2 gap-2 xl:flex">
+              <div className="grid grid-cols-2 gap-2">
                 <Button
                   type="submit"
-                  className="w-full xl:w-auto"
+                  className="w-full"
                   disabled={results.isFetching || !value.trim()}
                 >
                   <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
@@ -543,7 +543,7 @@ export default function UsageRecordsContent() {
                 <Button
                   type="button"
                   variant="outline"
-                  className="w-full xl:w-auto"
+                  className="w-full"
                   onClick={() => {
                     setValue('');
                     setStatus('all');

--- a/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
+++ b/apps/web/src/app/admin/cloud-billing-skus/UsageRecordsContent.tsx
@@ -297,7 +297,7 @@ export default function UsageRecordsContent() {
         </CardHeader>
         <CardContent>
           <form
-            className="grid gap-4 lg:grid-cols-2 xl:grid-cols-[8rem_minmax(16rem,1fr)_7rem_9rem_8rem] xl:items-start xl:gap-3"
+            className="space-y-4"
             onSubmit={event => {
               event.preventDefault();
               const trimmed = value.trim();
@@ -368,215 +368,167 @@ export default function UsageRecordsContent() {
               if (unchanged) void results.refetch();
             }}
           >
-            <div className="space-y-1.5 xl:col-start-1 xl:row-start-1">
-              <Label htmlFor="usage-search-kind">Search by</Label>
-              <Select value={kind} onValueChange={next => setKind(next as SearchKind)}>
-                <SelectTrigger id="usage-search-kind" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="interval">Interval ID</SelectItem>
-                  <SelectItem value="user">User ID</SelectItem>
-                  <SelectItem value="org">Organization ID</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-1.5 lg:col-span-1 xl:col-start-2 xl:row-start-1">
-              <Label htmlFor="usage-search-value">Exact value</Label>
-              <Input
-                id="usage-search-value"
-                value={value}
-                required
-                maxLength={kind === 'interval' ? 512 : 256}
-                placeholder={kind === 'interval' ? 'service:instance:startEpochMs' : 'Exact ID'}
-                onChange={event => setValue(event.target.value)}
-              />
-            </div>
-            <div className="space-y-1.5 xl:col-start-3 xl:row-start-1">
-              <Label htmlFor="usage-search-status">Status</Label>
-              <Select
-                value={status}
-                onValueChange={next => {
-                  const selected = next as typeof status;
-                  setStatus(selected);
-                  if (selected === 'open' && closeReason !== 'all') {
+            {/* Primary bar: what to search for, and the actions that trigger it. */}
+            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+              <div className="w-full space-y-1.5 sm:w-40 sm:shrink-0">
+                <Label htmlFor="usage-search-kind">Search by</Label>
+                <Select value={kind} onValueChange={next => setKind(next as SearchKind)}>
+                  <SelectTrigger id="usage-search-kind" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="interval">Interval ID</SelectItem>
+                    <SelectItem value="user">User ID</SelectItem>
+                    <SelectItem value="org">Organization ID</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="w-full flex-1 space-y-1.5">
+                <Label htmlFor="usage-search-value">Exact value</Label>
+                <Input
+                  id="usage-search-value"
+                  value={value}
+                  required
+                  maxLength={kind === 'interval' ? 512 : 256}
+                  placeholder={kind === 'interval' ? 'service:instance:startEpochMs' : 'Exact ID'}
+                  onChange={event => setValue(event.target.value)}
+                />
+              </div>
+              <div className="grid grid-cols-2 gap-2 sm:flex sm:shrink-0">
+                <Button type="submit" disabled={results.isFetching || !value.trim()}>
+                  <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
+                </Button>
+                <Button
+                  type="button"
+                  variant="outline"
+                  onClick={() => {
+                    setValue('');
+                    setStatus('all');
                     setCloseReason('all');
-                  }
-                }}
-              >
-                <SelectTrigger id="usage-search-status" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Any status</SelectItem>
-                  <SelectItem value="open">Open</SelectItem>
-                  <SelectItem value="closed">Closed</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-1.5 xl:col-start-4 xl:row-start-1">
-              <Label htmlFor="usage-search-close-reason">Close reason</Label>
-              <Select
-                value={closeReason}
-                onValueChange={next => {
-                  const selected = next as typeof closeReason;
-                  const selectedReason = selected === 'all' ? undefined : selected;
-                  if (selectedReason && status === 'open') setStatus('closed');
-                  setCloseReason(selected);
-                }}
-              >
-                <SelectTrigger id="usage-search-close-reason" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Any reason</SelectItem>
-                  <SelectItem value="exit">Exit</SelectItem>
-                  <SelectItem value="runtime_signal">Runtime signal</SelectItem>
-                  <SelectItem value="activity_expired">Activity expired</SelectItem>
-                  <SelectItem value="unconfirmed">Unconfirmed (15m timeout)</SelectItem>
-                  <SelectItem value="superseded">Superseded</SelectItem>
-                  <SelectItem value="reconciled">Reconciled</SelectItem>
-                </SelectContent>
-              </Select>
-            </div>
-            <div className="space-y-1.5 xl:col-start-5 xl:row-start-1">
-              <Label htmlFor="usage-search-sku">SKU</Label>
-              <Select
-                value={skuId}
-                onValueChange={selected => {
-                  setSkuId(selected);
-                }}
-              >
-                <SelectTrigger id="usage-search-sku" className="w-full">
-                  <SelectValue />
-                </SelectTrigger>
-                <SelectContent>
-                  <SelectItem value="all">Any SKU</SelectItem>
-                  {(catalog.data ?? []).map(sku => (
-                    <SelectItem key={sku.id} value={sku.id}>
-                      {sku.id}
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            {(kind === 'user' || kind === 'org') && (
-              <div className="lg:col-span-2 xl:col-span-5 xl:row-start-2">
-                <div className="flex flex-col gap-4 xl:flex-row xl:items-end xl:justify-end">
-                  <div className="space-y-1.5 xl:w-84">
-                    <Label>Usage window</Label>
-                    <div className="grid grid-cols-2 gap-2">
-                      <div className="space-y-1.5">
-                        <Label htmlFor="usage-summary-start" className="sr-only">
-                          Window start
-                        </Label>
-                        <Input
-                          id="usage-summary-start"
-                          type="datetime-local"
-                          value={summaryStart}
-                          max={summaryEnd}
-                          aria-describedby={
-                            summaryInputError ? 'usage-summary-window-error' : undefined
-                          }
-                          onChange={event => setSummaryStart(event.target.value)}
-                        />
-                      </div>
-                      <div className="space-y-1.5">
-                        <Label htmlFor="usage-summary-end" className="sr-only">
-                          Window end
-                        </Label>
-                        <Input
-                          id="usage-summary-end"
-                          type="datetime-local"
-                          value={summaryEnd}
-                          min={summaryStart}
-                          aria-describedby={
-                            summaryInputError ? 'usage-summary-window-error' : undefined
-                          }
-                          onChange={event => setSummaryEnd(event.target.value)}
-                        />
-                      </div>
-                    </div>
-                    {summaryInputError && (
-                      <p
-                        id="usage-summary-window-error"
-                        className="text-destructive type-label"
-                        role="alert"
-                      >
-                        {summaryInputError}
-                      </p>
-                    )}
-                  </div>
-                  <div className="space-y-1.5 xl:w-44">
-                    <Label className="invisible" aria-hidden="true">
-                      Actions
-                    </Label>
-                    <div className="grid grid-cols-2 gap-2">
-                      <Button
-                        type="submit"
-                        className="w-full"
-                        disabled={results.isFetching || !value.trim()}
-                      >
-                        <Search className="size-4" />{' '}
-                        {results.isFetching ? 'Searching...' : 'Search'}
-                      </Button>
-                      <Button
-                        type="button"
-                        variant="outline"
-                        className="w-full"
-                        onClick={() => {
-                          setValue('');
-                          setStatus('all');
-                          setCloseReason('all');
-                          setSkuId('all');
-                          setSummaryInputError(null);
-                          setSummaryRequest(null);
-                          setSubmitted({ kind: 'recent' });
-                          replaceCloseReasonParam(undefined);
-                          resetResultNavigation();
-                        }}
-                      >
-                        Reset
-                      </Button>
-                    </div>
-                  </div>
-                </div>
+                    setSkuId('all');
+                    setSummaryInputError(null);
+                    setSummaryRequest(null);
+                    setSubmitted({ kind: 'recent' });
+                    replaceCloseReasonParam(undefined);
+                    resetResultNavigation();
+                  }}
+                >
+                  Reset
+                </Button>
               </div>
-            )}
-            {kind === 'interval' && (
-              <div className="space-y-1.5 lg:col-span-2 xl:col-span-5 xl:row-start-2 xl:ml-auto xl:w-44">
-                <Label className="invisible" aria-hidden="true">
-                  Actions
-                </Label>
-                <div className="grid grid-cols-2 gap-2">
-                  <Button
-                    type="submit"
-                    className="w-full"
-                    disabled={results.isFetching || !value.trim()}
-                  >
-                    <Search className="size-4" /> {results.isFetching ? 'Searching...' : 'Search'}
-                  </Button>
-                  <Button
-                    type="button"
-                    variant="outline"
-                    className="w-full"
-                    onClick={() => {
-                      setValue('');
-                      setStatus('all');
+            </div>
+
+            {/* Filters: narrow the search above. Wraps freely; never forces the actions off-card. */}
+            <div className="flex flex-wrap items-end gap-4 border-t border-border pt-4">
+              <div className="w-36 space-y-1.5">
+                <Label htmlFor="usage-search-status">Status</Label>
+                <Select
+                  value={status}
+                  onValueChange={next => {
+                    const selected = next as typeof status;
+                    setStatus(selected);
+                    if (selected === 'open' && closeReason !== 'all') {
                       setCloseReason('all');
-                      setSkuId('all');
-                      setSummaryInputError(null);
-                      setSummaryRequest(null);
-                      setSubmitted({ kind: 'recent' });
-                      replaceCloseReasonParam(undefined);
-                      resetResultNavigation();
-                    }}
-                  >
-                    Reset
-                  </Button>
-                </div>
+                    }
+                  }}
+                >
+                  <SelectTrigger id="usage-search-status" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Any status</SelectItem>
+                    <SelectItem value="open">Open</SelectItem>
+                    <SelectItem value="closed">Closed</SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
-            )}
+              <div className="w-44 space-y-1.5">
+                <Label htmlFor="usage-search-close-reason">Close reason</Label>
+                <Select
+                  value={closeReason}
+                  onValueChange={next => {
+                    const selected = next as typeof closeReason;
+                    const selectedReason = selected === 'all' ? undefined : selected;
+                    if (selectedReason && status === 'open') setStatus('closed');
+                    setCloseReason(selected);
+                  }}
+                >
+                  <SelectTrigger id="usage-search-close-reason" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Any reason</SelectItem>
+                    <SelectItem value="exit">Exit</SelectItem>
+                    <SelectItem value="runtime_signal">Runtime signal</SelectItem>
+                    <SelectItem value="activity_expired">Activity expired</SelectItem>
+                    <SelectItem value="unconfirmed">Unconfirmed (15m timeout)</SelectItem>
+                    <SelectItem value="superseded">Superseded</SelectItem>
+                    <SelectItem value="reconciled">Reconciled</SelectItem>
+                  </SelectContent>
+                </Select>
+              </div>
+              <div className="w-40 space-y-1.5">
+                <Label htmlFor="usage-search-sku">SKU</Label>
+                <Select
+                  value={skuId}
+                  onValueChange={selected => {
+                    setSkuId(selected);
+                  }}
+                >
+                  <SelectTrigger id="usage-search-sku" className="w-full">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="all">Any SKU</SelectItem>
+                    {(catalog.data ?? []).map(sku => (
+                      <SelectItem key={sku.id} value={sku.id}>
+                        {sku.id}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
+              </div>
+              {(kind === 'user' || kind === 'org') && (
+                <div className="w-full space-y-1.5 sm:w-auto">
+                  <Label>Usage window</Label>
+                  <div className="flex flex-col gap-2 sm:flex-row">
+                    <Input
+                      id="usage-summary-start"
+                      type="datetime-local"
+                      aria-label="Window start"
+                      value={summaryStart}
+                      max={summaryEnd}
+                      aria-describedby={
+                        summaryInputError ? 'usage-summary-window-error' : undefined
+                      }
+                      className="w-full sm:w-[9.5rem]"
+                      onChange={event => setSummaryStart(event.target.value)}
+                    />
+                    <Input
+                      id="usage-summary-end"
+                      type="datetime-local"
+                      aria-label="Window end"
+                      value={summaryEnd}
+                      min={summaryStart}
+                      aria-describedby={
+                        summaryInputError ? 'usage-summary-window-error' : undefined
+                      }
+                      className="w-full sm:w-[9.5rem]"
+                      onChange={event => setSummaryEnd(event.target.value)}
+                    />
+                  </div>
+                  {summaryInputError && (
+                    <p
+                      id="usage-summary-window-error"
+                      className="text-destructive type-label"
+                      role="alert"
+                    >
+                      {summaryInputError}
+                    </p>
+                  )}
+                </div>
+              )}
+            </div>
           </form>
         </CardContent>
       </Card>

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
@@ -211,18 +211,150 @@ describe('admin.cloudBillingSkus usage records', () => {
     await insertUsageInterval({ id: 'interval-other', subjectId: 'subject-2' });
     const caller = await createCallerForUser(admin.id);
     const first = await caller.admin.cloudBillingSkus.searchUsageIntervals({
-      search: { kind: 'subject', subjectType: 'user', subjectId: 'subject-1' },
+      search: {
+        kind: 'subject',
+        subjectType: 'user',
+        subjectId: 'subject-1',
+        start: '2026-07-22T09:00:00.000Z',
+        end: '2026-07-22T11:00:00.000Z',
+      },
       limit: 1,
     });
     expect(first.items.map(item => item.id)).toEqual(['interval-b']);
     expect(first.nextCursor).not.toBeNull();
     if (!first.nextCursor) throw new Error('Expected an interval cursor');
     const second = await caller.admin.cloudBillingSkus.searchUsageIntervals({
-      search: { kind: 'subject', subjectType: 'user', subjectId: 'subject-1' },
+      search: {
+        kind: 'subject',
+        subjectType: 'user',
+        subjectId: 'subject-1',
+        start: '2026-07-22T09:00:00.000Z',
+        end: '2026-07-22T11:00:00.000Z',
+      },
       limit: 1,
       cursor: first.nextCursor,
     });
     expect(second.items.map(item => item.id)).toEqual(['interval-a']);
+  });
+
+  it('summarizes only an exact subject and bounded activity window by SKU', async () => {
+    await db.insert(cloud_billing_sku).values({
+      ...validInput('usage-summary-sku'),
+      rate_cents_per_unit: '0.125',
+      created_by_user_id: admin.id,
+    });
+    await insertUsageInterval({
+      id: 'summary-in-window',
+      subjectId: 'summary-subject',
+      startedAt: '2026-07-22T10:00:00.000Z',
+    });
+    await db
+      .update(container_usage_interval)
+      .set({ cloud_billing_sku_id: 'usage-summary-sku', confirmed_seconds: 999 })
+      .where(eq(container_usage_interval.id, 'summary-in-window'));
+    await db.insert(container_usage_segment).values([
+      {
+        interval_id: 'summary-in-window',
+        seq: 1,
+        idempotency_key: 'summary-start-boundary',
+        reported_seconds: 12,
+        usage_seconds: 12,
+        received_at: '2026-07-22T09:00:00.000Z',
+      },
+      {
+        interval_id: 'summary-in-window',
+        seq: 2,
+        idempotency_key: 'summary-end-boundary',
+        reported_seconds: 100,
+        usage_seconds: 100,
+        received_at: '2026-07-22T11:00:00.000Z',
+      },
+    ]);
+    await insertUsageInterval({
+      id: 'summary-other-subject',
+      subjectId: 'other-subject',
+      startedAt: '2026-07-22T10:00:00.000Z',
+    });
+    await db
+      .update(container_usage_interval)
+      .set({ confirmed_seconds: 999 })
+      .where(eq(container_usage_interval.id, 'summary-other-subject'));
+    await db.insert(container_usage_segment).values({
+      interval_id: 'summary-other-subject',
+      seq: 1,
+      idempotency_key: 'summary-other-subject',
+      reported_seconds: 999,
+      usage_seconds: 999,
+      received_at: '2026-07-22T10:00:00.000Z',
+    });
+    await insertUsageInterval({
+      id: 'summary-outside-window',
+      subjectId: 'summary-subject',
+      startedAt: '2026-07-23T10:00:00.000Z',
+    });
+    await db
+      .update(container_usage_interval)
+      .set({ confirmed_seconds: 999 })
+      .where(eq(container_usage_interval.id, 'summary-outside-window'));
+    await db.insert(container_usage_segment).values({
+      interval_id: 'summary-outside-window',
+      seq: 1,
+      idempotency_key: 'summary-outside-window',
+      reported_seconds: 999,
+      usage_seconds: 999,
+      received_at: '2026-07-23T10:00:00.000Z',
+    });
+
+    const caller = await createCallerForUser(admin.id);
+    const summary = await caller.admin.cloudBillingSkus.getUsageSummary({
+      subjectType: 'user',
+      subjectId: 'summary-subject',
+      start: '2026-07-22T09:00:00.000Z',
+      end: '2026-07-22T11:00:00.000Z',
+    });
+
+    expect(summary).toMatchObject({
+      acceptedSeconds: 12,
+      estimatedCents: '1.5',
+      items: [
+        {
+          skuId: 'usage-summary-sku',
+          acceptedSeconds: 12,
+          estimatedCents: '1.5',
+          intervals: 1,
+        },
+      ],
+    });
+
+    const nonAdminCaller = await createCallerForUser(nonAdmin.id);
+    await expect(
+      nonAdminCaller.admin.cloudBillingSkus.getUsageSummary({
+        subjectType: 'user',
+        subjectId: 'summary-subject',
+        start: '2026-07-22T09:00:00.000Z',
+        end: '2026-07-22T11:00:00.000Z',
+      })
+    ).rejects.toMatchObject({ code: 'FORBIDDEN' });
+  });
+
+  it('rejects invalid and oversized usage summary windows', async () => {
+    const caller = await createCallerForUser(admin.id);
+    await expect(
+      caller.admin.cloudBillingSkus.getUsageSummary({
+        subjectType: 'user',
+        subjectId: 'summary-subject',
+        start: '2026-07-22T11:00:00.000Z',
+        end: '2026-07-22T10:00:00.000Z',
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    await expect(
+      caller.admin.cloudBillingSkus.getUsageSummary({
+        subjectType: 'user',
+        subjectId: 'summary-subject',
+        start: '2026-06-01T00:00:00.000Z',
+        end: '2026-07-03T00:00:00.000Z',
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
   });
 
   it('returns ordered, safe segment details and rejects unknown intervals', async () => {

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.test.ts
@@ -209,6 +209,32 @@ describe('admin.cloudBillingSkus usage records', () => {
     await insertUsageInterval({ id: 'interval-b', subjectId: 'subject-1' });
     await insertUsageInterval({ id: 'interval-a', subjectId: 'subject-1' });
     await insertUsageInterval({ id: 'interval-other', subjectId: 'subject-2' });
+    await db.insert(container_usage_segment).values([
+      {
+        interval_id: 'interval-b',
+        seq: 1,
+        idempotency_key: 'interval-b-segment',
+        reported_seconds: 1,
+        usage_seconds: 1,
+        received_at: '2026-07-22T10:01:00.000Z',
+      },
+      {
+        interval_id: 'interval-a',
+        seq: 1,
+        idempotency_key: 'interval-a-segment',
+        reported_seconds: 1,
+        usage_seconds: 1,
+        received_at: '2026-07-22T10:01:00.000Z',
+      },
+      {
+        interval_id: 'interval-other',
+        seq: 1,
+        idempotency_key: 'interval-other-segment',
+        reported_seconds: 1,
+        usage_seconds: 1,
+        received_at: '2026-07-22T10:01:00.000Z',
+      },
+    ]);
     const caller = await createCallerForUser(admin.id);
     const first = await caller.admin.cloudBillingSkus.searchUsageIntervals({
       search: {

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.ts
@@ -331,6 +331,12 @@ export const cloudBillingSkusRouter = createTRPCRouter({
           sql<string>`coalesce(sum(${container_usage_segment.usage_seconds}::numeric * ${cloud_billing_sku.rate_cents_per_unit}), 0)::text`.mapWith(
             String
           ),
+        totalAcceptedSeconds:
+          sql<number>`sum(sum(${container_usage_segment.usage_seconds})) over ()`.mapWith(Number),
+        totalEstimatedCents:
+          sql<string>`sum(sum(${container_usage_segment.usage_seconds}::numeric * ${cloud_billing_sku.rate_cents_per_unit})) over ()::text`.mapWith(
+            String
+          ),
       })
       .from(container_usage_segment)
       .innerJoin(
@@ -363,40 +369,15 @@ export const cloudBillingSkusRouter = createTRPCRouter({
       estimatedCents: normalizeCloudBillingSkuRate(row.estimatedCents),
       intervals: row.intervals,
     }));
-    const [totals] = await db
-      .select({
-        acceptedSeconds:
-          sql<number>`coalesce(sum(${container_usage_segment.usage_seconds}), 0)`.mapWith(Number),
-        estimatedCents:
-          sql<string>`coalesce(sum(${container_usage_segment.usage_seconds}::numeric * ${cloud_billing_sku.rate_cents_per_unit}), 0)::text`.mapWith(
-            String
-          ),
-      })
-      .from(container_usage_segment)
-      .innerJoin(
-        container_usage_interval,
-        eq(container_usage_segment.interval_id, container_usage_interval.id)
-      )
-      .innerJoin(
-        cloud_billing_sku,
-        eq(container_usage_interval.cloud_billing_sku_id, cloud_billing_sku.id)
-      )
-      .where(
-        and(
-          eq(container_usage_interval.subject_type, input.subjectType),
-          eq(container_usage_interval.subject_id, input.subjectId),
-          sql`${container_usage_segment.received_at} >= ${input.start}`,
-          lt(container_usage_segment.received_at, input.end)
-        )
-      );
+    const totals = rows[0];
     return {
       subjectType: input.subjectType,
       subjectId: input.subjectId,
       start: input.start,
       end: input.end,
       items,
-      acceptedSeconds: totals?.acceptedSeconds ?? 0,
-      estimatedCents: normalizeCloudBillingSkuRate(totals?.estimatedCents ?? '0'),
+      acceptedSeconds: totals?.totalAcceptedSeconds ?? 0,
+      estimatedCents: normalizeCloudBillingSkuRate(totals?.totalEstimatedCents ?? '0'),
     };
   }),
 

--- a/apps/web/src/routers/admin/cloud-billing-skus-router.ts
+++ b/apps/web/src/routers/admin/cloud-billing-skus-router.ts
@@ -38,6 +38,8 @@ const usageSearchSchema = z
         kind: z.literal('subject'),
         subjectType: z.enum(['user', 'org']),
         subjectId: z.string().trim().min(1).max(256),
+        start: z.iso.datetime(),
+        end: z.iso.datetime(),
       }),
     ]),
     status: z.enum(['open', 'closed']).optional(),
@@ -58,7 +60,11 @@ const usageSearchSchema = z
       .optional(),
     limit: z.number().int().min(1).max(100).default(25),
   })
-  .strict();
+  .strict()
+  .superRefine((input, context) => {
+    if (input.search.kind !== 'subject') return;
+    validateUsageWindow(input.search.start, input.search.end, context);
+  });
 
 const segmentSearchSchema = z
   .object({
@@ -68,6 +74,18 @@ const segmentSearchSchema = z
   })
   .strict();
 
+const usageSummarySchema = z
+  .object({
+    subjectType: z.enum(['user', 'org']),
+    subjectId: z.string().trim().min(1).max(256),
+    start: z.iso.datetime(),
+    end: z.iso.datetime(),
+  })
+  .strict()
+  .superRefine((input, context) => {
+    validateUsageWindow(input.start, input.end, context);
+  });
+
 const BILLING_HEALTH_WINDOW_MS = 24 * 60 * 60 * 1_000;
 const STALE_OPEN_INTERVAL_MS = 15 * 60 * 1_000;
 const usageMetadataSchema = z
@@ -76,6 +94,22 @@ const usageMetadataSchema = z
     metadata => Object.keys(metadata).length <= 16,
     'Metadata may contain at most 16 entries'
   );
+
+function validateUsageWindow(startValue: string, endValue: string, context: z.RefinementCtx): void {
+  const start = new Date(startValue).getTime();
+  const end = new Date(endValue).getTime();
+  if (end <= start) {
+    context.addIssue({ code: 'custom', path: ['end'], message: 'End must be after start' });
+    return;
+  }
+  if (end - start > 31 * 24 * 60 * 60 * 1_000) {
+    context.addIssue({
+      code: 'custom',
+      path: ['end'],
+      message: 'Usage windows may not exceed 31 days',
+    });
+  }
+}
 
 export type SerializedUsageInterval = Pick<
   ContainerUsageInterval,
@@ -212,7 +246,13 @@ export const cloudBillingSkusRouter = createTRPCRouter({
     } else {
       predicates.push(
         eq(container_usage_interval.subject_type, input.search.subjectType),
-        eq(container_usage_interval.subject_id, input.search.subjectId)
+        eq(container_usage_interval.subject_id, input.search.subjectId),
+        sql`exists (
+          select 1 from ${container_usage_segment}
+          where ${container_usage_segment.interval_id} = ${container_usage_interval.id}
+            and ${container_usage_segment.received_at} >= ${input.search.start}
+            and ${container_usage_segment.received_at} < ${input.search.end}
+        )`
       );
     }
     if (input.status) predicates.push(eq(container_usage_interval.status, input.status));
@@ -275,6 +315,88 @@ export const cloudBillingSkusRouter = createTRPCRouter({
       metadata: parseUsageMetadata(interval.metadata),
       items: page.map(serializeUsageSegment),
       nextCursor: hasMore ? (page.at(-1)?.seq ?? null) : null,
+    };
+  }),
+
+  getUsageSummary: adminProcedure.input(usageSummarySchema).query(async ({ input }) => {
+    const rows = await db
+      .select({
+        skuId: container_usage_interval.cloud_billing_sku_id,
+        skuName: cloud_billing_sku.name,
+        rateCentsPerSecond: cloud_billing_sku.rate_cents_per_unit,
+        acceptedSeconds:
+          sql<number>`coalesce(sum(${container_usage_segment.usage_seconds}), 0)`.mapWith(Number),
+        intervals: sql<number>`count(distinct ${container_usage_interval.id})`.mapWith(Number),
+        estimatedCents:
+          sql<string>`coalesce(sum(${container_usage_segment.usage_seconds}::numeric * ${cloud_billing_sku.rate_cents_per_unit}), 0)::text`.mapWith(
+            String
+          ),
+      })
+      .from(container_usage_segment)
+      .innerJoin(
+        container_usage_interval,
+        eq(container_usage_segment.interval_id, container_usage_interval.id)
+      )
+      .innerJoin(
+        cloud_billing_sku,
+        eq(container_usage_interval.cloud_billing_sku_id, cloud_billing_sku.id)
+      )
+      .where(
+        and(
+          eq(container_usage_interval.subject_type, input.subjectType),
+          eq(container_usage_interval.subject_id, input.subjectId),
+          sql`${container_usage_segment.received_at} >= ${input.start}`,
+          lt(container_usage_segment.received_at, input.end)
+        )
+      )
+      .groupBy(
+        container_usage_interval.cloud_billing_sku_id,
+        cloud_billing_sku.name,
+        cloud_billing_sku.rate_cents_per_unit
+      )
+      .orderBy(container_usage_interval.cloud_billing_sku_id);
+    const items = rows.map(row => ({
+      skuId: row.skuId,
+      skuName: row.skuName,
+      rateCentsPerSecond: normalizeCloudBillingSkuRate(row.rateCentsPerSecond),
+      acceptedSeconds: row.acceptedSeconds,
+      estimatedCents: normalizeCloudBillingSkuRate(row.estimatedCents),
+      intervals: row.intervals,
+    }));
+    const [totals] = await db
+      .select({
+        acceptedSeconds:
+          sql<number>`coalesce(sum(${container_usage_segment.usage_seconds}), 0)`.mapWith(Number),
+        estimatedCents:
+          sql<string>`coalesce(sum(${container_usage_segment.usage_seconds}::numeric * ${cloud_billing_sku.rate_cents_per_unit}), 0)::text`.mapWith(
+            String
+          ),
+      })
+      .from(container_usage_segment)
+      .innerJoin(
+        container_usage_interval,
+        eq(container_usage_segment.interval_id, container_usage_interval.id)
+      )
+      .innerJoin(
+        cloud_billing_sku,
+        eq(container_usage_interval.cloud_billing_sku_id, cloud_billing_sku.id)
+      )
+      .where(
+        and(
+          eq(container_usage_interval.subject_type, input.subjectType),
+          eq(container_usage_interval.subject_id, input.subjectId),
+          sql`${container_usage_segment.received_at} >= ${input.start}`,
+          lt(container_usage_segment.received_at, input.end)
+        )
+      );
+    return {
+      subjectType: input.subjectType,
+      subjectId: input.subjectId,
+      start: input.start,
+      end: input.end,
+      items,
+      acceptedSeconds: totals?.acceptedSeconds ?? 0,
+      estimatedCents: normalizeCloudBillingSkuRate(totals?.estimatedCents ?? '0'),
     };
   }),
 

--- a/services/container-usage-meter/src/meter.test.ts
+++ b/services/container-usage-meter/src/meter.test.ts
@@ -84,6 +84,7 @@ beforeEach(() => {
 
 describe('ContainerUsageMeter', () => {
   it('writes an admitted start directly to PostgreSQL', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     await expect(createMeter().recordStart(validStart())).resolves.toEqual({
       success: true,
       ack: { intervalId: 'cloud-agent-next:instance-1:123', durable: 'pg', dedup: false },
@@ -95,9 +96,20 @@ describe('ContainerUsageMeter', () => {
       expect.stringMatching(/^[a-f0-9]{64}$/),
       expect.any(Number)
     );
+    expect(log).toHaveBeenCalledWith(
+      JSON.stringify({
+        message: 'Container usage meter RPC completed',
+        event: 'container_usage_rpc',
+        operation: 'start',
+        service: 'cloud-agent-next',
+        outcome: 'accepted',
+        dedup: false,
+      })
+    );
   });
 
   it('returns permanent SKU admission failures', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(applyStart).mockResolvedValue({
       kind: 'rejected',
       code: 'sku_not_accepting_new_usage',
@@ -110,6 +122,9 @@ describe('ContainerUsageMeter', () => {
         message: 'Billing SKU is not accepting new usage',
       },
     });
+    expect(log).toHaveBeenCalledWith(
+      expect.stringContaining('"rejectionCode":"sku_not_accepting_new_usage"')
+    );
   });
 
   it('writes heartbeats directly and returns the shadow budget verdict', async () => {
@@ -132,9 +147,20 @@ describe('ContainerUsageMeter', () => {
   });
 
   it('propagates transient PostgreSQL failures for bounded client retry', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
     vi.mocked(applyHeartbeat).mockRejectedValue(new Error('postgres unavailable'));
     await expect(createMeter().recordHeartbeat(validHeartbeat())).rejects.toThrow(
       'postgres unavailable'
+    );
+    expect(log).toHaveBeenCalledWith(
+      JSON.stringify({
+        message: 'Container usage meter RPC completed',
+        event: 'container_usage_rpc',
+        operation: 'heartbeat',
+        service: 'cloud-agent-next',
+        outcome: 'failed',
+        errorName: 'Error',
+      })
     );
   });
 });

--- a/services/container-usage-meter/src/meter.ts
+++ b/services/container-usage-meter/src/meter.ts
@@ -45,6 +45,26 @@ function copyUsageContext(context: UsageContext): UsageContext {
   };
 }
 
+type MeterOperation = 'start' | 'heartbeat' | 'stop';
+
+function logRpcOutcome(
+  operation: MeterOperation,
+  service: string,
+  outcome: 'accepted' | 'rejected' | 'failed',
+  details: { dedup?: boolean; rejectionCode?: string; errorName?: string } = {}
+): void {
+  console.log(
+    JSON.stringify({
+      message: 'Container usage meter RPC completed',
+      event: 'container_usage_rpc',
+      operation,
+      service,
+      outcome,
+      ...details,
+    })
+  );
+}
+
 export class ContainerUsageMeter
   extends WorkerEntrypoint<Cloudflare.Env>
   implements ContainerUsageRpcMethods
@@ -57,17 +77,27 @@ export class ContainerUsageMeter
     );
     const context = copyUsageContext(parsed);
     const id = intervalId(parsed.service, parsed.instanceId, parsed.startEpochMs);
-    const result = await applyStart(
-      this.env,
-      parsed,
-      id,
-      await usageContextFingerprint(context),
-      Date.now()
-    );
+    let result: Awaited<ReturnType<typeof applyStart>>;
+    try {
+      result = await applyStart(
+        this.env,
+        parsed,
+        id,
+        await usageContextFingerprint(context),
+        Date.now()
+      );
+    } catch (error) {
+      logRpcOutcome('start', parsed.service, 'failed', {
+        errorName: error instanceof Error ? error.name : 'UnknownError',
+      });
+      throw error;
+    }
     switch (result.kind) {
       case 'rejected':
+        logRpcOutcome('start', parsed.service, 'rejected', { rejectionCode: result.code });
         return { success: false, error: { code: result.code, message: result.message } };
       case 'applied':
+        logRpcOutcome('start', parsed.service, 'accepted', { dedup: result.dedup });
         return {
           success: true,
           ack: { intervalId: id, durable: 'pg', dedup: result.dedup },
@@ -83,13 +113,22 @@ export class ContainerUsageMeter
       heartbeatIdempotencyKey(parsed.service, parsed.instanceId, parsed.startEpochMs, parsed.seq)
     );
     const id = intervalId(parsed.service, parsed.instanceId, parsed.startEpochMs);
-    const result = await applyHeartbeat(
-      this.env,
-      parsed,
-      id,
-      await usageContextFingerprint(parsed.context),
-      Date.now()
-    );
+    let result: Awaited<ReturnType<typeof applyHeartbeat>>;
+    try {
+      result = await applyHeartbeat(
+        this.env,
+        parsed,
+        id,
+        await usageContextFingerprint(parsed.context),
+        Date.now()
+      );
+    } catch (error) {
+      logRpcOutcome('heartbeat', parsed.service, 'failed', {
+        errorName: error instanceof Error ? error.name : 'UnknownError',
+      });
+      throw error;
+    }
+    logRpcOutcome('heartbeat', parsed.service, 'accepted', { dedup: result.dedup });
     return {
       intervalId: id,
       durable: 'pg',
@@ -106,13 +145,22 @@ export class ContainerUsageMeter
       stopIdempotencyKey(parsed.service, parsed.instanceId, parsed.startEpochMs)
     );
     const id = intervalId(parsed.service, parsed.instanceId, parsed.startEpochMs);
-    const result = await applyStop(
-      this.env,
-      parsed,
-      id,
-      await usageContextFingerprint(parsed.context),
-      Date.now()
-    );
+    let result: Awaited<ReturnType<typeof applyStop>>;
+    try {
+      result = await applyStop(
+        this.env,
+        parsed,
+        id,
+        await usageContextFingerprint(parsed.context),
+        Date.now()
+      );
+    } catch (error) {
+      logRpcOutcome('stop', parsed.service, 'failed', {
+        errorName: error instanceof Error ? error.name : 'UnknownError',
+      });
+      throw error;
+    }
+    logRpcOutcome('stop', parsed.service, 'accepted', { dedup: result.dedup });
     return { intervalId: id, durable: 'pg', dedup: result.dedup };
   }
 }

--- a/services/container-usage-meter/src/reconciliation.test.ts
+++ b/services/container-usage-meter/src/reconciliation.test.ts
@@ -1,0 +1,34 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./postgres', () => ({
+  reconcileStaleIntervals: vi.fn(),
+}));
+
+import { reconcileStaleIntervals } from './postgres';
+import { runReconciliation } from './reconciliation';
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('runReconciliation', () => {
+  it('logs completed runs and unconfirmed closes', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+    vi.mocked(reconcileStaleIntervals).mockResolvedValue(3);
+
+    await runReconciliation({} as Cloudflare.Env);
+
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('"outcome":"completed"'));
+    expect(log).toHaveBeenCalledWith(expect.stringContaining('"reconciledIntervals":3'));
+  });
+
+  it('logs and propagates failed runs', async () => {
+    const error = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(reconcileStaleIntervals).mockRejectedValue(new Error('postgres unavailable'));
+
+    await expect(runReconciliation({} as Cloudflare.Env)).rejects.toThrow('postgres unavailable');
+
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('"outcome":"failed"'));
+    expect(error).toHaveBeenCalledWith(expect.stringContaining('"errorName":"Error"'));
+  });
+});

--- a/services/container-usage-meter/src/reconciliation.ts
+++ b/services/container-usage-meter/src/reconciliation.ts
@@ -3,12 +3,28 @@ import { reconcileStaleIntervals } from './postgres';
 export const CONTAINER_USAGE_RECONCILIATION_CRON = '*/5 * * * *';
 
 export async function runReconciliation(env: Cloudflare.Env): Promise<void> {
-  const reconciledIntervals = await reconcileStaleIntervals(env);
-  console.log(
-    JSON.stringify({
-      message: 'Container usage reconciliation completed',
-      event: 'container_usage_reconciliation',
-      reconciledIntervals,
-    })
-  );
+  const startedAt = Date.now();
+  try {
+    const reconciledIntervals = await reconcileStaleIntervals(env);
+    console.log(
+      JSON.stringify({
+        message: 'Container usage reconciliation completed',
+        event: 'container_usage_reconciliation',
+        outcome: 'completed',
+        reconciledIntervals,
+        durationMs: Date.now() - startedAt,
+      })
+    );
+  } catch (error) {
+    console.error(
+      JSON.stringify({
+        message: 'Container usage reconciliation failed',
+        event: 'container_usage_reconciliation',
+        outcome: 'failed',
+        durationMs: Date.now() - startedAt,
+        errorName: error instanceof Error ? error.name : 'UnknownError',
+      })
+    );
+    throw error;
+  }
 }


### PR DESCRIPTION
## Summary

- Add an admin-only Usage Summary for an exact user or organization over a bounded, half-open `[start, end)` window.
- Aggregate accepted container seconds from metering segments, group results by immutable billing SKU, and calculate exact shadow estimated cents with PostgreSQL numeric arithmetic without debiting credits.
- Scope the interval list and summary to the same subject and window, with client/server validation, precise report context, and accessible loading and result states.
- Add structured, sanitized meter RPC and reconciliation outcome logs so the shadow-metering Axiom dashboard can track accepted, rejected, failed, deduplicated, and reconciled activity.

## Verification

## Visual Changes

<img width="1476" height="782" alt="SCR-20260728-meop" src="https://github.com/user-attachments/assets/77c53fb1-d974-4074-9f23-457213afebe9" />



## Reviewer Notes

- Review the segment-time `[start, end)` boundary and PostgreSQL numeric estimate calculation closely; these define the shadow billing report.
- Meter logs intentionally exclude subject IDs, instance IDs, metadata, and error messages. Existing producer logs remain the source for Cloud Agent delivery/retry failures.