### PR TITLE
fix(workflow): stop e2e-slot release from stopping another section's stack

### DIFF
--- a/.kilo_workflow/e2e-slot.sh
+++ b/.kilo_workflow/e2e-slot.sh
@@ -46,7 +46,11 @@ stack_session() { echo "kilo-dev-$(basename "$1" | tr -c 'A-Za-z0-9_-\n' '_')"; 
 # real answer; the owner-name prefix is a fallback so slots written before
 # worktrees were recorded never make a live stack look abandoned.
 stack_is_covered() {
-  sess=$1
+  # Every name here is local: this function loops over slots reassigning `wt`,
+  # and its caller `stop_stack` still needs its own `wt` afterwards to know
+  # which worktree to stop. Without `local` the caller's value is clobbered and
+  # the wrong section's stack gets stopped.
+  local sess=$1 s wt owner
   for s in "$DIR"/slot-*; do
     [ -d "$s" ] || continue
     wt=$(cat "$s/worktree" 2>/dev/null || echo)
@@ -60,7 +64,7 @@ stack_is_covered() {
 # Stop a worktree's stack, but only once no remaining slot covers it — a section
 # can hold a second slot for a concurrent phase.
 stop_stack() {
-  wt=$1
+  local wt=$1 sess
   [ -n "$wt" ] && [ -d "$wt" ] || return 0
   sess=$(stack_session "$wt")
   stack_is_covered "$sess" && return 0
@@ -73,6 +77,7 @@ reap() {
   # If tmux cannot answer (missing binary, no server, socket error), liveness
   # cannot be judged — keep every slot rather than wipe live ones. Acquirers
   # always run inside tmux, so the server is up whenever reaping matters.
+  local alive now s owner mtime age wt
   alive=$(tmux list-sessions -F '#{session_name}' 2>/dev/null) || return 0
   now=$(date +%s)
   for s in "$DIR"/slot-*; do

--- a/.kilo_workflow/learnings/e2e-slot-release-stopped-another-sections-stack.md
+++ b/.kilo_workflow/learnings/e2e-slot-release-stopped-another-sections-stack.md
@@ -1,0 +1,37 @@
+# `e2e-slot.sh release` stopped a different section's dev stack
+
+Symptom: releasing `file-preview-2975`'s slot printed
+`Killed tmux session kilo-dev-hermes-mem-c716` and left
+`kilo-dev-file-preview-2975` running. Another section's E2E verifier was
+mid-round and carried on driving a device against a stack that no longer
+existed, which surfaces as an inexplicable product failure in *that* section.
+
+Cause: shell variable shadowing. `stop_stack` set `wt=$1`, computed
+`sess=$(stack_session "$wt")`, then called `stack_is_covered "$sess"` — whose
+loop reassigns the **same global** `wt` once per slot directory. On return `wt`
+held the *last* slot's worktree, so the final `(cd "$wt" && pnpm dev:stop)`
+stopped whichever section happened to sort last. `sess` stayed correct, so the
+`tmux has-session` guard confirmed *our* stack was up and then stopped
+*theirs*. `reap()` had the same exposure on its own `s` loop variable.
+
+`dev:stop` is not at fault: it resolves its target purely from
+`git rev-parse --show-toplevel` in the process cwd. It was handed the wrong cwd.
+
+This was latent until the trailing-underscore fix (#4836). Before it,
+`stack_session` returned a mangled name, `tmux has-session` always failed, and
+`stop_stack` returned early — never reaching the `cd`. Fixing the name made the
+guard pass and exposed the shadowing. A dormant bug behind a broken guard
+becomes a live bug the moment the guard starts working; when repairing a
+predicate, read what runs *after* it, not just the predicate.
+
+Fix: declare `local` in every helper that a loop-bearing caller depends on —
+`stack_is_covered`, `stop_stack`, `reap`. Bash functions share global scope by
+default, so a helper called from inside a loop silently corrupts its caller's
+iteration state.
+
+Operational note: a slot must be acquired under the **verifier's own tmux
+session name**. This incident began because the orchestrator acquired a slot in
+a `slot-acq` window under a proxy `<section>-e2e-seed` session and parked a
+`sleep` to hold it. That both violates the E2E-loop rule and creates a
+self-deadlock: the verifier polls for a free slot that its own section's
+sleeper holds, and neither side can progress.


### PR DESCRIPTION
## What happened

Releasing `file-preview-2975`'s slot printed:

```
Killed tmux session kilo-dev-hermes-mem-c716
Leaving Docker infrastructure running (other sessions active: kilo-dev-file-preview-2975, ...)
```

It stopped **another section's** dev stack and left its own running. That section's E2E verifier was mid-round and carried on driving a device against a stack that no longer existed — which surfaces there as an inexplicable product failure.

## Cause: shell variable shadowing

`stop_stack` sets a global `wt=$1`, computes `sess` from it, then calls `stack_is_covered "$sess"` — whose loop reassigns **the same global `wt`** once per slot directory. On return, `wt` holds the *last* slot's worktree:

```
sess (correct)      = kilo-dev-some-other-section
wt at cd time       = /wt/hermes-mem-c716   <-- clobbered by stack_is_covered
```

`sess` stays correct, so `tmux has-session` confirms *our* stack is up — and then `(cd "$wt" && pnpm dev:stop)` stops *theirs*. `reap()` had the same exposure on its own `s` loop variable.

**`dev:stop` is not at fault.** It resolves its target purely from `git rev-parse --show-toplevel` in the process cwd. It was handed the wrong cwd.

## Why it appeared only now

Latent until #4836. Previously `stack_session` returned a name with a spurious trailing underscore, so `tmux has-session` always failed and `stop_stack` returned before ever reaching the `cd`. Fixing the name made the guard pass and exposed the shadowing underneath.

Generalisable: a dormant bug behind a broken guard becomes live the moment the guard starts working. When repairing a predicate, read what runs *after* it.

## Fix

`local` in `stack_is_covered`, `stop_stack` and `reap`. Bash functions share global scope, so a helper called from inside a loop silently corrupts its caller's iteration state.

## Verification

Reduced repro before: `wt at cd time = /wt/hermes-mem-c716`. After: `wt at cd time = /wt/some-other-section`. `bash -n` clean; `status` and `stacks` still correct against live slot state.

Also adds `learnings/e2e-slot-release-stopped-another-sections-stack.md`, including the operational note that a slot must be acquired under the verifier's **own** tmux session name — acquiring under a proxy `<section>-e2e-seed` session and parking a `sleep` both violates the E2E-loop rule and self-deadlocks the verifier against its own section's sleeper.
