### PR TITLE
docs(workflow): require uploaded UI evidence

### DIFF
--- a/.kilo_workflow/WORKFLOW.md
+++ b/.kilo_workflow/WORKFLOW.md
@@ -214,7 +214,7 @@ The orchestrator drives the plan to completion. It is the expensive model steeri
 2. Segment the plan into slices with disjoint write sets so parallel implementers cannot collide — the plan proposes the tasks, the orchestrator owns the slicing. Always serialize: lockfile changes, dependency installs, migrations, generated clients, repository-wide formatters, and broad autofix commands. File separation is not enough when one slice changes a contract another consumes.
 3. Dispatch ready independent slices to parallel `implementer`s — as many in parallel as the segmentation safely allows; agent parallelism is never capped, only E2E device/stack phases are (see E2E Slots). Loop per slice, at most five rounds: implementer implements, then a fresh `impl-reviewer` reviews the slice diff — `git add -N -- <owned paths> && git diff HEAD -- <owned paths>` (the `add -N` makes new files visible to the diff; take the reviewer's pre-round snapshot **after** it, since it changes status output) written to a scratch file passed via `--file`, since parallel slices share the worktree; triage remarks (untrusted), route valid ones through a repair dispatch. Exit the loop when a fresh reviewer returns `No findings.`, or when its only remaining findings are already rejected in `$SCRATCH/decisions.md` and cite no evidence the rejection did not consider. At the round cap the remaining moves are takeover or BLOCKED (see Escalation).
 4. Create small logical commits at slice boundaries, staging only the slice's owned paths (`git add -- <owned paths>`, never `git add -A` while other slices are mid-flight). Once every slice has landed, run the synchronization point: the deferred project-wide checks (typecheck and each changed repository's own check commands) — then, and again after any later repair or direct orchestrator edit, dispatch one fresh `impl-reviewer` over the cumulative section diff (`git diff origin/main...HEAD`, plus any uncommitted changes), so integration seams, takeovers, and merge resolutions never ship unreviewed.
-5. Create the PR — use the repository's PR template when one exists, with the human-readable **what / why / how** narrative inside its summary section, and verification evidence (verifier screenshots and flow results, pulled from reports before scratch cleanup) where the template asks for it — assign it to the requesting human, and request reviews per repository convention (cloud: `eshurakov`, `jeanduplessis`; kilocode: additionally `marius-kilocode`, `chrarnoldus`). When the section spans multiple repositories, use the same branch name in each, open one PR per repository, cross-link them, and hold every one to the completion gate. CI and Kilobot start running concurrently with E2E.
+5. Create the PR — use the repository's PR template when one exists, with the human-readable **what / why / how** narrative inside its summary section, and verification evidence (verifier screenshots and flow results, pulled from reports before scratch cleanup) where the template asks for it. For work with a UI, upload the screenshots to the PR per GitHub Communication before scratch cleanup — local paths are not evidence. Assign the PR to the requesting human, and request reviews per repository convention (cloud: `eshurakov`, `jeanduplessis`; kilocode: additionally `marius-kilocode`, `chrarnoldus`). When the section spans multiple repositories, use the same branch name in each, open one PR per repository, cross-link them, and hold every one to the completion gate. CI and Kilobot start running concurrently with E2E.
 6. Run the E2E loop (below) when the work has verifiable runtime behavior; skip it for doc-only or equivalently inert changes, recording why in the PR description.
 7. Run the Kilobot loop (below).
 8. When both loops are clean, verify the completion gate, label the PR `human-ready` (`gh pr edit <n> --add-label human-ready`) as the last act before teardown, then shut the section down. The PR is the deliverable; everything else closes.
@@ -251,6 +251,7 @@ The work is complete only when every item holds:
 - A fresh E2E verifier returned `VERIFICATION PASSED.` for the plan's goals — or E2E was skipped as inert, with the rationale in the PR description
 - Changes are organized into small, coherent commits; format, typecheck, lint, and tests pass in every changed repository, using the check commands the nearest `AGENTS.md` or `package.json` defines for each changed package
 - The PR exists with what/why/how sections and is assigned to the requesting human
+- If any accepted task has a UI, the PR description renders screenshots of the final behavior from the latest head, uploaded to that repository as GitHub `user-attachments`; visual changes include before/after evidence when a meaningful before state exists. A non-UI PR records `Visual Changes: N/A`
 - Kilobot has posted an approving summary comment on the latest head and no actionable posted comment is unresolved — or Kilobot's absence after two retriggers is noted in a `(bot) ` PR comment
 - All expected CI checks on the latest head are green, and GitHub reports the head mergeable with no conflicts
 - No generated fixture remains, tracked or untracked; every verifier temporary edit is restored
@@ -327,3 +328,23 @@ Environment blockers and their fixes — broken local stacks, credential traps, 
 ## GitHub Communication
 
 Every GitHub issue comment, PR comment, review comment, review body, and thread reply written by this workflow begins exactly with `(bot) `, including replies to Kilobot and rejections of findings. Only the PR title and PR description carry no prefix.
+
+GitHub's public API and `gh pr comment` cannot upload attachments. Use the pinned
+[`gh-image`](https://github.com/drogers0/gh-image) extension, which performs the same
+repository-scoped upload as GitHub's comment box and prints ready-to-paste Markdown:
+
+```bash
+gh extension list | grep -q '^gh image' ||
+  gh extension install drogers0/gh-image --pin v1.2.0
+gh image "$SCREENSHOT" --repo <owner/repo>
+# ![screenshot.png](https://github.com/user-attachments/assets/<id>)
+```
+
+Put that Markdown in the PR's `Visual Changes` section (or a `(bot) ` comment when adding
+later), then fetch the PR body/comments with `gh` and verify the
+`github.com/user-attachments/` URL is present. `gh-image` uses an existing GitHub browser
+session because a normal `gh` API token cannot authorize this undocumented upload endpoint.
+It may trigger a one-time OS keychain approval; never print, pass on the command line, commit,
+or place its `user_session` cookie in a handoff. A missing browser session is a completion
+blocker for UI work, not a reason to commit screenshots into the product repository or use an
+unrelated public image host.

--- a/.kilo_workflow/WORKFLOW.md
+++ b/.kilo_workflow/WORKFLOW.md
@@ -329,14 +329,13 @@ Environment blockers and their fixes — broken local stacks, credential traps, 
 
 Every GitHub issue comment, PR comment, review comment, review body, and thread reply written by this workflow begins exactly with `(bot) `, including replies to Kilobot and rejections of findings. Only the PR title and PR description carry no prefix.
 
-GitHub's public API and `gh pr comment` cannot upload attachments. Use the pinned
-[`gh-image`](https://github.com/drogers0/gh-image) extension, which performs the same
+GitHub's public API and `gh pr comment` cannot upload attachments. Use the repository's
+checksum-pinned wrapper around the security-reviewed
+[`gh-image`](https://github.com/drogers0/gh-image) v1.2.0 binary. It performs the same
 repository-scoped upload as GitHub's comment box and prints ready-to-paste Markdown:
 
 ```bash
-gh extension list | grep -q '^gh image' ||
-  gh extension install drogers0/gh-image --pin v1.2.0
-gh image "$SCREENSHOT" --repo <owner/repo>
+.kilo_workflow/upload-pr-attachment.sh "$SCREENSHOT" --repo <owner/repo>
 # ![screenshot.png](https://github.com/user-attachments/assets/<id>)
 ```
 
@@ -345,6 +344,10 @@ later), then fetch the PR body/comments with `gh` and verify the
 `github.com/user-attachments/` URL is present. `gh-image` uses an existing GitHub browser
 session because a normal `gh` API token cannot authorize this undocumented upload endpoint.
 It may trigger a one-time OS keychain approval; never print, pass on the command line, commit,
-or place its `user_session` cookie in a handoff. A missing browser session is a completion
+or place its `user_session` cookie in a handoff; never invoke `gh-image` directly. The wrapper
+verifies the reviewed release digest before every execution and blocks every supported explicit
+token path. Its audit and residual risks are recorded in
+`learnings/gh-image-unverified-release-binary.md`. A missing browser session is a completion
 blocker for UI work, not a reason to commit screenshots into the product repository or use an
-unrelated public image host.
+unrelated public image host. Any version change requires a fresh security review and new committed
+digests.

--- a/.kilo_workflow/learnings/gh-image-unverified-release-binary.md
+++ b/.kilo_workflow/learnings/gh-image-unverified-release-binary.md
@@ -1,0 +1,43 @@
+# gh-image must be source-reviewed and checksum-pinned before cookie access
+
+Symptom: the screenshot-upload workflow installed a third-party release binary and then let it
+read a full-account GitHub `user_session` cookie. Pinning only the mutable release tag did not
+prove that agents would execute the code reviewed in this PR.
+
+Cause: GitHub has no public attachment-upload API. `gh-image` v1.2.0 implements GitHub's private
+web upload using browser authentication, but `gh extension install --pin` downloads and executes
+the upstream binary without a repository-owned integrity check.
+
+Fix: use `upload-pr-attachment.sh`. It permits only the reviewed v1.2.0 release assets whose
+SHA-256 digests are committed in the script, verifies the digest before first execution and on
+every cached execution, and discards `GH_SESSION_TOKEN`. Its interface accepts exactly one
+non-symlink PNG/JPEG/GIF/WebP under GitHub's 10 MB limit plus an explicit `owner/repo`, so the
+upstream token-export and arbitrary-file paths are unreachable.
+
+Security review, 2026-07-28:
+
+- Reviewed source tag `v1.2.0`, commit `44f4b93ecbbe22de6c45fa2f62f519aee564ca8c`,
+  including all non-test Go code, tests, the dependency manifest, release configuration, and
+  security policy.
+- Session-cookie values stay in memory and are attached only to hard-coded `https://github.com`
+  requests. The uploaded file goes separately to the presigned storage URL without GitHub cookies;
+  finalization is restricted to a root-relative GitHub path. No telemetry or unrelated network
+  destination exists in the reviewed source.
+- The binary can deliberately print the session through `extract-token` or accept it through
+  `--token`/`GH_SESSION_TOKEN`; the repository wrapper exposes none of those arguments and clears
+  the environment token.
+- The only direct external package is `browserutils/kooky` v0.2.10 (source commit
+  `0d54a50c33ecea7d703d4edda7571c3559dc485d`), used to read encrypted browser stores. Its reviewed
+  source performs local browser/keychain access and no network calls. The dependency manifest was
+  checked against GitHub's Advisory Database: current findings exist in `x/crypto` and `x/net`,
+  but the imported paths use only `hkdf`, `pbkdf2`, and `publicsuffix`, not the affected SSH or
+  HTML-parser code.
+- Upstream test, lint, and release jobs passed on the reviewed commit. The release workflow's
+  third-party actions use major-version tags rather than commit SHAs, so the build chain is not
+  independently reproducible; the committed release digests bind workflow execution to the exact
+  binaries exercised here. Any version bump requires a fresh source, dependency,
+  behavior, and digest review in a PR.
+- Residual risk: the tool necessarily gives a third-party binary a full-account session cookie and
+  relies on an undocumented GitHub endpoint. A compromised browser session or an undiscovered flaw
+  in the pinned binary retains that blast radius. Use only a logged-in account that needs write
+  access to the target repository; never use this in CI or persist a session token.

--- a/.kilo_workflow/upload-pr-attachment.sh
+++ b/.kilo_workflow/upload-pr-attachment.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+# Upload one screenshot with the security-reviewed gh-image v1.2.0 binary only
+# after verifying its release digest. See learnings/gh-image-unverified-release-binary.md.
+set -euo pipefail
+
+VERSION=v1.2.0
+[ "$#" -eq 1 ] && [ "$1" = "--version" ] && VERSION_ONLY=1 || VERSION_ONLY=0
+if [ "$VERSION_ONLY" -eq 0 ]; then
+  [ "$#" -eq 3 ] && [ "$2" = "--repo" ] || {
+    echo "usage: $0 <screenshot> --repo <owner/repo>" >&2
+    exit 1
+  }
+  SCREENSHOT=$1
+  REPO=$3
+  [ -f "$SCREENSHOT" ] && [ ! -L "$SCREENSHOT" ] || {
+    echo "screenshot must be a regular, non-symlink file" >&2
+    exit 1
+  }
+  [[ "$REPO" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] || {
+    echo "repository must be owner/repo" >&2
+    exit 1
+  }
+  case "$(file -b --mime-type "$SCREENSHOT")" in
+    image/png | image/jpeg | image/gif | image/webp) ;;
+    *) echo "only PNG, JPEG, GIF, or WebP screenshots are allowed" >&2; exit 1 ;;
+  esac
+  [ "$(wc -c < "$SCREENSHOT")" -le 10485760 ] || {
+    echo "screenshot exceeds GitHub's 10 MB image limit" >&2
+    exit 1
+  }
+fi
+
+case "$(uname -s)-$(uname -m)" in
+  Darwin-arm64) ASSET=darwin-arm64; EXPECTED=e0d7670f263dc495cca358b3676f049c51e3c1bafcab7836ba1d0557c099c15b ;;
+  Darwin-x86_64) ASSET=darwin-amd64; EXPECTED=08353182ec9f1af8b445d192b538741fb7421a16e12e2645f2152ac859c0958a ;;
+  Linux-aarch64 | Linux-arm64) ASSET=linux-arm64; EXPECTED=f36fd26e1920e217eb2bd1d5f7e0378c00f64214f3b011f5697d883943f0d1ee ;;
+  Linux-x86_64) ASSET=linux-amd64; EXPECTED=0505f8c46d63bd603a445fdbfdd6be45e75a80778d97f1edf3580697fa6b7919 ;;
+  *) echo "unsupported platform: $(uname -s)-$(uname -m)" >&2; exit 1 ;;
+esac
+
+unset GH_SESSION_TOKEN
+
+KILO_CACHE_ROOT=${XDG_CACHE_HOME:-${HOME:?}/.cache}
+BINARY="$KILO_CACHE_ROOT/kilo-workflow/gh-image/$VERSION/$ASSET"
+checksum() {
+  if command -v sha256sum >/dev/null; then
+    sha256sum "$1" | cut -d' ' -f1
+  else
+    shasum -a 256 "$1" | cut -d' ' -f1
+  fi
+}
+if [ -f "$BINARY" ]; then
+  ACTUAL=$(checksum "$BINARY")
+else
+  KILO_IMAGE_TMP=$(mktemp -d "${TMPDIR:-/tmp}/kilo-gh-image.XXXXXX")
+  trap 'rm -rf "$KILO_IMAGE_TMP"' EXIT
+  gh release download "$VERSION" --repo drogers0/gh-image --pattern "$ASSET" --output "$KILO_IMAGE_TMP/$ASSET"
+  ACTUAL=$(checksum "$KILO_IMAGE_TMP/$ASSET")
+  [ "$ACTUAL" = "$EXPECTED" ] || { echo "gh-image checksum mismatch" >&2; exit 1; }
+  mkdir -p "$(dirname "$BINARY")"
+  install -m 0755 "$KILO_IMAGE_TMP/$ASSET" "$BINARY"
+fi
+
+[ "$ACTUAL" = "$EXPECTED" ] || { echo "cached gh-image checksum mismatch" >&2; exit 1; }
+if [ "$VERSION_ONLY" -eq 1 ]; then
+  exec "$BINARY" --version
+fi
+exec "$BINARY" "$SCREENSHOT" --repo "$REPO"


### PR DESCRIPTION
## Summary

### What

Teach `.kilo_workflow` agents to upload screenshots as repository-scoped GitHub
`user-attachments` with the pinned `gh-image` extension.

### Why

Future UI work should leave visual evidence directly on the PR instead of local
paths, repository blobs, or claims that CLI uploads are impossible.

### How

The workflow now documents the upload command, session-cookie safety boundary,
and verification step. The completion gate requires latest-head screenshots for
UI-bearing work and an explicit non-UI exemption.

## Verification

- [x] `pnpm format:changed`
- [x] `git diff --check`
- [x] Audited `gh-image` v1.2.0 source, dependency paths, release workflow, and credential flow
- [x] Exercised the checksum-pinned wrapper against the authenticated Brave session
- [x] Uploaded the proof image and verified its PR attachment URL

E2E was skipped because this is workflow documentation only.

## Visual Changes

N/A — no product UI changed.

## Reviewer Notes

Repository-scoped attachment upload proof:

![A friendly robot weighing one kilo of glowing code](https://github.com/user-attachments/assets/d7c57499-0240-4cb0-a000-454919fa4694)

Security review: the supported wrapper pins the reviewed release's SHA-256 digests, verifies them
before every execution, accepts only one non-symlink image under 10 MB plus an explicit repository,
clears `GH_SESSION_TOKEN`, and exposes none of the upstream token-export options. The full review and
residual risks are committed in `.kilo_workflow/learnings/gh-image-unverified-release-binary.md`.
