### PR TITLE
feat(code reviewer) use blobless clone for github and gitlab

### DIFF
--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -186,6 +186,110 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     expect(authFile).not.toContain('wrapper-dispatch-ticket');
   });
 
+  it('shallow-clones and fetches only the reviewed branch for code review sessions', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+    request.repo = {
+      kind: 'git',
+      url: 'https://bitbucket.org/acme/repo.git',
+      token: 'bb-token',
+      platform: 'bitbucket',
+    };
+    request.workspace.branchName = 'feature/login';
+
+    const gitCalls: Array<{ args: string[]; opts?: { hardTimeoutMs?: number } }> = [];
+    await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async (args, opts) => {
+          gitCalls.push({ args, opts: opts as { hardTimeoutMs?: number } });
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    const cloneCall = gitCalls.find(call => call.args[0] === 'clone');
+    expect(cloneCall?.args).toEqual([
+      'clone',
+      '--progress',
+      '--depth',
+      '1',
+      'https://x-token-auth:bb-token@bitbucket.org/acme/repo.git',
+      request.workspace.workspacePath,
+    ]);
+    expect(cloneCall?.opts?.hardTimeoutMs).toBe(600_000);
+    expect(
+      gitCalls.some(
+        call => call.args.join(' ') === 'fetch --progress --depth 1 origin feature/login'
+      )
+    ).toBe(true);
+    // The all-refs, full-history fetch must not run for a review session.
+    expect(gitCalls.some(call => call.args.join(' ') === 'fetch --progress origin')).toBe(false);
+  });
+
+  it('falls back to a full clone when the shallow clone fails', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+    request.repo = {
+      kind: 'git',
+      url: 'https://bitbucket.org/acme/repo.git',
+      token: 'bb-token',
+      platform: 'bitbucket',
+    };
+    request.workspace.branchName = 'feature/login';
+
+    const cloneArgs: string[][] = [];
+    await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          if (args[0] === 'clone') {
+            cloneArgs.push(args);
+            if (args.includes('--depth')) {
+              return { stdout: '', stderr: 'shallow not supported', exitCode: 1 };
+            }
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+            return { stdout: '', stderr: '', exitCode: 0 };
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    expect(cloneArgs.length).toBe(2);
+    expect(cloneArgs[0]).toContain('--depth');
+    expect(cloneArgs[1]).not.toContain('--depth');
+  });
+
   it('uses activity watchdogs and reports sanitized progress for long git operations', async () => {
     const request = makeRequest(tmpDir);
     request.materialized.setupCommands = [];

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -186,108 +186,22 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     expect(authFile).not.toContain('wrapper-dispatch-ticket');
   });
 
-  it('shallow-clones and fetches only the reviewed branch for code review sessions', async () => {
+  it('uses a blobless partial clone for GitHub/GitLab code review sessions', async () => {
     const request = makeRequest(tmpDir);
     request.materialized.env.KILO_PLATFORM = 'code-review';
     request.materialized.setupCommands = [];
-    request.repo = {
-      kind: 'git',
-      url: 'https://bitbucket.org/acme/repo.git',
-      token: 'bb-token',
-      platform: 'bitbucket',
-    };
-    request.workspace.branchName = 'feature/login';
 
-    const gitCalls: Array<{ args: string[]; opts?: { hardTimeoutMs?: number } }> = [];
-    await prepareWrapperBootstrapWorkspace(
-      request,
-      mock(() => {}),
-      {
-        git: async (args, opts) => {
-          gitCalls.push({ args, opts: opts as { hardTimeoutMs?: number } });
-          if (args[0] === 'clone') {
-            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
-              recursive: true,
-            });
-          }
-          if (args[0] === 'rev-parse') {
-            // The targeted fetch populates the remote-tracking ref for the
-            // reviewed branch; the local branch does not exist yet.
-            return {
-              stdout: '',
-              stderr: '',
-              exitCode: args.includes('origin/feature/login') ? 0 : 1,
-            };
-          }
-          return { stdout: '', stderr: '', exitCode: 0 };
-        },
-        restoreSession: async () => ({
-          ok: true,
-          downloaded: false,
-          imported: true,
-          diffs: { applied: 0, skipped: 0, total: 0 },
-        }),
-      }
-    );
-
-    const cloneCall = gitCalls.find(call => call.args[0] === 'clone');
-    expect(cloneCall?.args).toEqual([
-      'clone',
-      '--progress',
-      '--depth',
-      '1',
-      'https://x-token-auth:bb-token@bitbucket.org/acme/repo.git',
-      request.workspace.workspacePath,
-    ]);
-    expect(cloneCall?.opts?.hardTimeoutMs).toBe(600_000);
-    // A shallow clone is single-branch, so the fetch must use an explicit
-    // refspec to create refs/remotes/origin/<branch>; a bare fetch would only
-    // update FETCH_HEAD and the reviewed tree would never be checked out.
-    expect(
-      gitCalls.some(
-        call =>
-          call.args.join(' ') ===
-          'fetch --progress --depth 1 origin +feature/login:refs/remotes/origin/feature/login'
-      )
-    ).toBe(true);
-    // The reviewed tree is checked out from the fetched remote-tracking ref, not
-    // created off the default branch.
-    expect(
-      gitCalls.some(
-        call => call.args.join(' ') === 'checkout --progress -B feature/login origin/feature/login'
-      )
-    ).toBe(true);
-    // The all-refs, full-history fetch must not run for a review session.
-    expect(gitCalls.some(call => call.args.join(' ') === 'fetch --progress origin')).toBe(false);
-  });
-
-  it('falls back to a full clone when the shallow clone fails', async () => {
-    const request = makeRequest(tmpDir);
-    request.materialized.env.KILO_PLATFORM = 'code-review';
-    request.materialized.setupCommands = [];
-    request.repo = {
-      kind: 'git',
-      url: 'https://bitbucket.org/acme/repo.git',
-      token: 'bb-token',
-      platform: 'bitbucket',
-    };
-    request.workspace.branchName = 'feature/login';
-
-    const cloneArgs: string[][] = [];
+    const gitCalls: string[][] = [];
     await prepareWrapperBootstrapWorkspace(
       request,
       mock(() => {}),
       {
         git: async args => {
+          gitCalls.push(args);
           if (args[0] === 'clone') {
-            cloneArgs.push(args);
-            if (args.includes('--depth')) {
-              return { stdout: '', stderr: 'shallow not supported', exitCode: 1 };
-            }
             await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
               recursive: true,
             });
-            return { stdout: '', stderr: '', exitCode: 0 };
           }
           if (args[0] === 'rev-parse') {
             return { stdout: '', stderr: '', exitCode: 1 };
@@ -303,9 +217,55 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       }
     );
 
-    expect(cloneArgs.length).toBe(2);
-    expect(cloneArgs[0]).toContain('--depth');
-    expect(cloneArgs[1]).not.toContain('--depth');
+    // Full history is retained (no --depth); only file blobs are deferred, so
+    // incremental `git diff` and merge-base keep working.
+    const cloneCall = gitCalls.find(args => args[0] === 'clone');
+    expect(cloneCall).toContain('--filter=blob:none');
+    expect(cloneCall).not.toContain('--depth');
+  });
+
+  it('keeps a full clone (no blobless filter) for Bitbucket review sessions', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+    request.repo = {
+      kind: 'git',
+      url: 'https://bitbucket.org/acme/repo.git',
+      token: 'bb-token',
+      platform: 'bitbucket',
+    };
+    request.workspace.branchName = 'feature/login';
+
+    const gitCalls: string[][] = [];
+    await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          gitCalls.push(args);
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    // Bitbucket's origin is credential-stripped after bootstrap, so a deferred
+    // blob could never be lazily fetched — it keeps a normal full clone.
+    const cloneCall = gitCalls.find(args => args[0] === 'clone');
+    expect(cloneCall).not.toContain('--filter=blob:none');
   });
 
   it('uses activity watchdogs and reports sanitized progress for long git operations', async () => {

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -211,7 +211,13 @@ describe('prepareWrapperBootstrapWorkspace', () => {
             });
           }
           if (args[0] === 'rev-parse') {
-            return { stdout: '', stderr: '', exitCode: 1 };
+            // The targeted fetch populates the remote-tracking ref for the
+            // reviewed branch; the local branch does not exist yet.
+            return {
+              stdout: '',
+              stderr: '',
+              exitCode: args.includes('origin/feature/login') ? 0 : 1,
+            };
           }
           return { stdout: '', stderr: '', exitCode: 0 };
         },
@@ -234,9 +240,21 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       request.workspace.workspacePath,
     ]);
     expect(cloneCall?.opts?.hardTimeoutMs).toBe(600_000);
+    // A shallow clone is single-branch, so the fetch must use an explicit
+    // refspec to create refs/remotes/origin/<branch>; a bare fetch would only
+    // update FETCH_HEAD and the reviewed tree would never be checked out.
     expect(
       gitCalls.some(
-        call => call.args.join(' ') === 'fetch --progress --depth 1 origin feature/login'
+        call =>
+          call.args.join(' ') ===
+          'fetch --progress --depth 1 origin +feature/login:refs/remotes/origin/feature/login'
+      )
+    ).toBe(true);
+    // The reviewed tree is checked out from the fetched remote-tracking ref, not
+    // created off the default branch.
+    expect(
+      gitCalls.some(
+        call => call.args.join(' ') === 'checkout --progress -B feature/login origin/feature/login'
       )
     ).toBe(true);
     // The all-refs, full-history fetch must not run for a review session.

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -268,6 +268,127 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     expect(cloneCall).not.toContain('--filter=blob:none');
   });
 
+  it('uses a blobless partial clone for GitLab review sessions', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+    request.repo = {
+      kind: 'git',
+      url: 'https://gitlab.com/acme/repo.git',
+      token: 'gl-token',
+      platform: 'gitlab',
+    };
+    request.workspace.branchName = 'feature/login';
+
+    const gitCalls: string[][] = [];
+    await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          gitCalls.push(args);
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    expect(gitCalls.find(args => args[0] === 'clone')).toContain('--filter=blob:none');
+  });
+
+  it('keeps a full clone for review sessions on an unrecognized git platform', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+    // A `git` source with no recognized platform has no lazy-fetch credential
+    // guarantee, so it must not use a partial clone.
+    request.repo = { kind: 'git', url: 'https://git.example.com/acme/repo.git', token: 't' };
+    request.workspace.branchName = 'feature/login';
+
+    const gitCalls: string[][] = [];
+    await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          gitCalls.push(args);
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    expect(gitCalls.find(args => args[0] === 'clone')).not.toContain('--filter=blob:none');
+  });
+
+  it('retries a full clone when the server rejects the blobless filter', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+
+    const cloneArgs: string[][] = [];
+    await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          if (args[0] === 'clone') {
+            cloneArgs.push(args);
+            // Simulate a server that rejects the filter outright (not the
+            // warn-and-continue degradation).
+            if (args.includes('--filter=blob:none')) {
+              return { stdout: '', stderr: 'fatal: filter blob:none not supported', exitCode: 128 };
+            }
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+            return { stdout: '', stderr: '', exitCode: 0 };
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    expect(cloneArgs.length).toBe(2);
+    expect(cloneArgs[0]).toContain('--filter=blob:none');
+    expect(cloneArgs[1]).not.toContain('--filter=blob:none');
+  });
+
   it('uses activity watchdogs and reports sanitized progress for long git operations', async () => {
     const request = makeRequest(tmpDir);
     request.materialized.setupCommands = [];

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -345,6 +345,16 @@ function isBitbucketReviewSession(
   return isCodeReviewSession(request) && repo?.kind === 'git' && repo.platform === 'bitbucket';
 }
 
+function isBloblessReviewCloneEligible(request: WrapperSessionReadyRequest): boolean {
+  if (!isCodeReviewSession(request)) return false;
+  const repo = request.repo;
+  // Only GitHub and GitLab: their session origin keeps working credentials via
+  // outbound injection, so blobs deferred by a partial clone can be fetched
+  // lazily during the review. Bitbucket's origin is credential-stripped, and
+  // other/unknown git remotes have no such guarantee, so they keep a full clone.
+  return repo?.kind === 'github' || (repo?.kind === 'git' && repo.platform === 'gitlab');
+}
+
 async function cloneRepository(
   request: WrapperSessionReadyRequest,
   runGit: GitRunner,
@@ -359,30 +369,44 @@ async function cloneRepository(
   const gitUrl = repo.kind === 'github' ? `https://github.com/${repo.repo}.git` : repo.url;
   const platform = repo.kind === 'git' ? repo.platform : 'github';
   const repoUrl = authenticatedUrl(gitUrl, repo.token, platform);
-  const args = ['clone', '--progress'];
-  if (repo.shallow) {
-    args.push('--depth', '1');
-  }
   // GitHub/GitLab code review reads changed files from the working tree and gets
   // the PR diff from the provider API or a local `git diff <prev>..HEAD`. It needs
   // the full commit graph but not every historical file blob, so a blobless
   // partial clone keeps the clone bounded by the current working tree (git fetches
   // blobs lazily on demand) instead of full history, which on large repositories
   // otherwise exceeds the clone timeout. Full history is retained, so incremental
-  // diffs and merge-base still work; remotes without partial-clone support ignore
-  // the filter and perform a normal full clone, so no fallback is needed.
-  // Bitbucket is excluded: its origin is credential-stripped after bootstrap (no
-  // outbound credential injection), so a deferred blob could never be fetched. It
-  // keeps a normal full clone.
-  if (isCodeReviewSession(request) && !isBitbucketReviewSession(request)) {
-    args.push('--filter=blob:none');
+  // diffs and merge-base still work. See isBloblessReviewCloneEligible for why
+  // only GitHub/GitLab qualify.
+  const useBlobless = isBloblessReviewCloneEligible(request);
+
+  const runClone = async (blobless: boolean): Promise<ExecResult> => {
+    await removePath(request.workspace.workspacePath, signal);
+    await fs.mkdir(path.dirname(request.workspace.workspacePath), { recursive: true });
+    const args = ['clone', '--progress'];
+    if (repo.shallow) {
+      args.push('--depth', '1');
+    }
+    if (blobless) {
+      args.push('--filter=blob:none');
+    }
+    args.push(repoUrl, request.workspace.workspacePath);
+    return runGit(args, longGitOptions(progress, 'cloning', 'Cloning repository...'));
+  };
+
+  // Most servers without partial-clone support ignore the filter and full-clone,
+  // but some reject it outright. If the blobless attempt failed with a filter
+  // error, retry once as a full clone so a review is never lost to the optimization.
+  let result = await runClone(useBlobless);
+  if (
+    useBlobless &&
+    result.exitCode !== 0 &&
+    /filter/i.test(`${result.stderr}\n${result.stdout}`)
+  ) {
+    logToFile(
+      `bootstrap blobless clone rejected; retrying full clone kiloSessionId=${request.kiloSessionId}`
+    );
+    result = await runClone(false);
   }
-  args.push(repoUrl, request.workspace.workspacePath);
-
-  await removePath(request.workspace.workspacePath, signal);
-  await fs.mkdir(path.dirname(request.workspace.workspacePath), { recursive: true });
-
-  const result = await runGit(args, longGitOptions(progress, 'cloning', 'Cloning repository...'));
   if (result.exitCode !== 0) {
     throw gitOperationError(result, 'clone');
   }

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -468,23 +468,31 @@ async function prepareBranch(
   const reviewSession = isCodeReviewSession(request);
   const hardTimeoutMs = reviewSession ? REVIEW_GIT_HARD_TIMEOUT_MS : LONG_COMMAND_HARD_TIMEOUT_MS;
 
-  // Cloud code review only needs the reviewed branch checked out, so fetch just
-  // that branch at depth 1 instead of every ref with full history. Fall back to
-  // a full fetch on any failure so a review is never lost to the optimization.
-  let fetchResult: ExecResult | undefined;
+  // Cloud code review only needs the reviewed branch, so fetch just that branch
+  // instead of every ref with full history. A shallow clone is single-branch
+  // (`--depth 1` implies `--single-branch`), so its configured refspec covers
+  // only the default branch; an explicit `+<branch>:refs/remotes/origin/<branch>`
+  // refspec is required to populate the remote-tracking ref the checkout below
+  // relies on, since a bare `git fetch origin <branch>` would only update
+  // FETCH_HEAD. Fall back to a full-depth fetch of the same branch on failure so
+  // a review is never lost to the optimization.
+  let fetchResult: ExecResult;
   if (reviewSession || request.repo?.shallow === true) {
+    const branchRefspec = `+${branchName}:refs/remotes/origin/${branchName}`;
     fetchResult = await runGit(
-      ['fetch', '--progress', '--depth', '1', 'origin', branchName],
+      ['fetch', '--progress', '--depth', '1', 'origin', branchRefspec],
       longGitOptions(progress, 'branch', 'Fetching branch...', workspacePath, hardTimeoutMs)
     );
     if (fetchResult.exitCode !== 0) {
       logToFile(
         `bootstrap shallow branch fetch failed; retrying full fetch kiloSessionId=${request.kiloSessionId}`
       );
-      fetchResult = undefined;
+      fetchResult = await runGit(
+        ['fetch', '--progress', 'origin', branchRefspec],
+        longGitOptions(progress, 'branch', 'Fetching branch...', workspacePath, hardTimeoutMs)
+      );
     }
-  }
-  if (!fetchResult) {
+  } else {
     fetchResult = await runGit(
       ['fetch', '--progress', 'origin'],
       longGitOptions(progress, 'branch', 'Fetching repository...', workspacePath, hardTimeoutMs)

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -25,6 +25,9 @@ import { WrapperBootstrapError, workspaceBootstrapError } from './bootstrap-erro
 
 const LONG_COMMAND_INACTIVITY_TIMEOUT_MS = 120_000;
 const LONG_COMMAND_HARD_TIMEOUT_MS = 300_000;
+// Cloud code-review clones may fall back to a full clone on large repositories;
+// give the git clone/fetch steps extra headroom in review sessions only.
+const REVIEW_GIT_HARD_TIMEOUT_MS = 10 * 60_000;
 // Setup commands may legitimately stay silent for minutes (piped tools often
 // buffer), unlike git commands which run with --progress, so they get a more
 // lenient silence watchdog.
@@ -245,12 +248,13 @@ function longGitOptions(
   progress: BootstrapProgress | undefined,
   step: 'cloning' | 'branch',
   progressPrefix: string,
-  cwd?: string
+  cwd?: string,
+  hardTimeoutMs: number = LONG_COMMAND_HARD_TIMEOUT_MS
 ): ProcessOptions {
   return {
     cwd,
     inactivityTimeoutMs: LONG_COMMAND_INACTIVITY_TIMEOUT_MS,
-    hardTimeoutMs: LONG_COMMAND_HARD_TIMEOUT_MS,
+    hardTimeoutMs,
     onOutput: gitProgressReporter(progress, step, progressPrefix),
   };
 }
@@ -332,6 +336,10 @@ async function cleanupWorkspace(request: WrapperSessionReadyRequest): Promise<vo
   ]);
 }
 
+function isCodeReviewSession(request: WrapperSessionReadyRequest): boolean {
+  return request.materialized.env.KILO_PLATFORM === 'code-review';
+}
+
 async function cloneRepository(
   request: WrapperSessionReadyRequest,
   runGit: GitRunner,
@@ -346,16 +354,37 @@ async function cloneRepository(
   const gitUrl = repo.kind === 'github' ? `https://github.com/${repo.repo}.git` : repo.url;
   const platform = repo.kind === 'git' ? repo.platform : 'github';
   const repoUrl = authenticatedUrl(gitUrl, repo.token, platform);
-  const args = ['clone', '--progress'];
-  if (repo.shallow) {
-    args.push('--depth', '1');
+
+  // Cloud code review reads the diff from the provider API (bb/gh pr diff) and
+  // only needs the head working tree, never git history. A shallow clone keeps
+  // clone time bounded by the working tree instead of full history, which on
+  // large repositories otherwise exceeds the clone hard timeout. Any failure
+  // retries a full clone so a review is never lost to the optimization.
+  const reviewSession = isCodeReviewSession(request);
+  const shallow = reviewSession || repo.shallow === true;
+  const hardTimeoutMs = reviewSession ? REVIEW_GIT_HARD_TIMEOUT_MS : LONG_COMMAND_HARD_TIMEOUT_MS;
+
+  const runClone = async (useShallow: boolean): Promise<ExecResult> => {
+    await removePath(request.workspace.workspacePath, signal);
+    await fs.mkdir(path.dirname(request.workspace.workspacePath), { recursive: true });
+    const args = ['clone', '--progress'];
+    if (useShallow) {
+      args.push('--depth', '1');
+    }
+    args.push(repoUrl, request.workspace.workspacePath);
+    return runGit(
+      args,
+      longGitOptions(progress, 'cloning', 'Cloning repository...', undefined, hardTimeoutMs)
+    );
+  };
+
+  let result = await runClone(shallow);
+  if (result.exitCode !== 0 && shallow) {
+    logToFile(
+      `bootstrap shallow clone failed; retrying full clone kiloSessionId=${request.kiloSessionId}`
+    );
+    result = await runClone(false);
   }
-  args.push(repoUrl, request.workspace.workspacePath);
-
-  await removePath(request.workspace.workspacePath, signal);
-  await fs.mkdir(path.dirname(request.workspace.workspacePath), { recursive: true });
-
-  const result = await runGit(args, longGitOptions(progress, 'cloning', 'Cloning repository...'));
   if (result.exitCode !== 0) {
     throw gitOperationError(result, 'clone');
   }
@@ -436,10 +465,31 @@ async function prepareBranch(
     return;
   }
 
-  const fetchResult = await runGit(
-    ['fetch', '--progress', 'origin'],
-    longGitOptions(progress, 'branch', 'Fetching repository...', workspacePath)
-  );
+  const reviewSession = isCodeReviewSession(request);
+  const hardTimeoutMs = reviewSession ? REVIEW_GIT_HARD_TIMEOUT_MS : LONG_COMMAND_HARD_TIMEOUT_MS;
+
+  // Cloud code review only needs the reviewed branch checked out, so fetch just
+  // that branch at depth 1 instead of every ref with full history. Fall back to
+  // a full fetch on any failure so a review is never lost to the optimization.
+  let fetchResult: ExecResult | undefined;
+  if (reviewSession || request.repo?.shallow === true) {
+    fetchResult = await runGit(
+      ['fetch', '--progress', '--depth', '1', 'origin', branchName],
+      longGitOptions(progress, 'branch', 'Fetching branch...', workspacePath, hardTimeoutMs)
+    );
+    if (fetchResult.exitCode !== 0) {
+      logToFile(
+        `bootstrap shallow branch fetch failed; retrying full fetch kiloSessionId=${request.kiloSessionId}`
+      );
+      fetchResult = undefined;
+    }
+  }
+  if (!fetchResult) {
+    fetchResult = await runGit(
+      ['fetch', '--progress', 'origin'],
+      longGitOptions(progress, 'branch', 'Fetching repository...', workspacePath, hardTimeoutMs)
+    );
+  }
   if (fetchResult.exitCode !== 0) {
     throw gitOperationError(fetchResult, 'checkout');
   }

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -25,9 +25,6 @@ import { WrapperBootstrapError, workspaceBootstrapError } from './bootstrap-erro
 
 const LONG_COMMAND_INACTIVITY_TIMEOUT_MS = 120_000;
 const LONG_COMMAND_HARD_TIMEOUT_MS = 300_000;
-// Cloud code-review clones may fall back to a full clone on large repositories;
-// give the git clone/fetch steps extra headroom in review sessions only.
-const REVIEW_GIT_HARD_TIMEOUT_MS = 10 * 60_000;
 // Setup commands may legitimately stay silent for minutes (piped tools often
 // buffer), unlike git commands which run with --progress, so they get a more
 // lenient silence watchdog.
@@ -248,13 +245,12 @@ function longGitOptions(
   progress: BootstrapProgress | undefined,
   step: 'cloning' | 'branch',
   progressPrefix: string,
-  cwd?: string,
-  hardTimeoutMs: number = LONG_COMMAND_HARD_TIMEOUT_MS
+  cwd?: string
 ): ProcessOptions {
   return {
     cwd,
     inactivityTimeoutMs: LONG_COMMAND_INACTIVITY_TIMEOUT_MS,
-    hardTimeoutMs,
+    hardTimeoutMs: LONG_COMMAND_HARD_TIMEOUT_MS,
     onOutput: gitProgressReporter(progress, step, progressPrefix),
   };
 }
@@ -340,6 +336,15 @@ function isCodeReviewSession(request: WrapperSessionReadyRequest): boolean {
   return request.materialized.env.KILO_PLATFORM === 'code-review';
 }
 
+function isBitbucketReviewSession(
+  request: WrapperSessionReadyRequest
+): request is WrapperSessionReadyRequest & {
+  repo: Extract<NonNullable<WrapperSessionReadyRequest['repo']>, { kind: 'git' }>;
+} {
+  const repo = request.repo;
+  return isCodeReviewSession(request) && repo?.kind === 'git' && repo.platform === 'bitbucket';
+}
+
 async function cloneRepository(
   request: WrapperSessionReadyRequest,
   runGit: GitRunner,
@@ -354,37 +359,30 @@ async function cloneRepository(
   const gitUrl = repo.kind === 'github' ? `https://github.com/${repo.repo}.git` : repo.url;
   const platform = repo.kind === 'git' ? repo.platform : 'github';
   const repoUrl = authenticatedUrl(gitUrl, repo.token, platform);
-
-  // Cloud code review reads the diff from the provider API (bb/gh pr diff) and
-  // only needs the head working tree, never git history. A shallow clone keeps
-  // clone time bounded by the working tree instead of full history, which on
-  // large repositories otherwise exceeds the clone hard timeout. Any failure
-  // retries a full clone so a review is never lost to the optimization.
-  const reviewSession = isCodeReviewSession(request);
-  const shallow = reviewSession || repo.shallow === true;
-  const hardTimeoutMs = reviewSession ? REVIEW_GIT_HARD_TIMEOUT_MS : LONG_COMMAND_HARD_TIMEOUT_MS;
-
-  const runClone = async (useShallow: boolean): Promise<ExecResult> => {
-    await removePath(request.workspace.workspacePath, signal);
-    await fs.mkdir(path.dirname(request.workspace.workspacePath), { recursive: true });
-    const args = ['clone', '--progress'];
-    if (useShallow) {
-      args.push('--depth', '1');
-    }
-    args.push(repoUrl, request.workspace.workspacePath);
-    return runGit(
-      args,
-      longGitOptions(progress, 'cloning', 'Cloning repository...', undefined, hardTimeoutMs)
-    );
-  };
-
-  let result = await runClone(shallow);
-  if (result.exitCode !== 0 && shallow) {
-    logToFile(
-      `bootstrap shallow clone failed; retrying full clone kiloSessionId=${request.kiloSessionId}`
-    );
-    result = await runClone(false);
+  const args = ['clone', '--progress'];
+  if (repo.shallow) {
+    args.push('--depth', '1');
   }
+  // GitHub/GitLab code review reads changed files from the working tree and gets
+  // the PR diff from the provider API or a local `git diff <prev>..HEAD`. It needs
+  // the full commit graph but not every historical file blob, so a blobless
+  // partial clone keeps the clone bounded by the current working tree (git fetches
+  // blobs lazily on demand) instead of full history, which on large repositories
+  // otherwise exceeds the clone timeout. Full history is retained, so incremental
+  // diffs and merge-base still work; remotes without partial-clone support ignore
+  // the filter and perform a normal full clone, so no fallback is needed.
+  // Bitbucket is excluded: its origin is credential-stripped after bootstrap (no
+  // outbound credential injection), so a deferred blob could never be fetched. It
+  // keeps a normal full clone.
+  if (isCodeReviewSession(request) && !isBitbucketReviewSession(request)) {
+    args.push('--filter=blob:none');
+  }
+  args.push(repoUrl, request.workspace.workspacePath);
+
+  await removePath(request.workspace.workspacePath, signal);
+  await fs.mkdir(path.dirname(request.workspace.workspacePath), { recursive: true });
+
+  const result = await runGit(args, longGitOptions(progress, 'cloning', 'Cloning repository...'));
   if (result.exitCode !== 0) {
     throw gitOperationError(result, 'clone');
   }
@@ -465,39 +463,10 @@ async function prepareBranch(
     return;
   }
 
-  const reviewSession = isCodeReviewSession(request);
-  const hardTimeoutMs = reviewSession ? REVIEW_GIT_HARD_TIMEOUT_MS : LONG_COMMAND_HARD_TIMEOUT_MS;
-
-  // Cloud code review only needs the reviewed branch, so fetch just that branch
-  // instead of every ref with full history. A shallow clone is single-branch
-  // (`--depth 1` implies `--single-branch`), so its configured refspec covers
-  // only the default branch; an explicit `+<branch>:refs/remotes/origin/<branch>`
-  // refspec is required to populate the remote-tracking ref the checkout below
-  // relies on, since a bare `git fetch origin <branch>` would only update
-  // FETCH_HEAD. Fall back to a full-depth fetch of the same branch on failure so
-  // a review is never lost to the optimization.
-  let fetchResult: ExecResult;
-  if (reviewSession || request.repo?.shallow === true) {
-    const branchRefspec = `+${branchName}:refs/remotes/origin/${branchName}`;
-    fetchResult = await runGit(
-      ['fetch', '--progress', '--depth', '1', 'origin', branchRefspec],
-      longGitOptions(progress, 'branch', 'Fetching branch...', workspacePath, hardTimeoutMs)
-    );
-    if (fetchResult.exitCode !== 0) {
-      logToFile(
-        `bootstrap shallow branch fetch failed; retrying full fetch kiloSessionId=${request.kiloSessionId}`
-      );
-      fetchResult = await runGit(
-        ['fetch', '--progress', 'origin', branchRefspec],
-        longGitOptions(progress, 'branch', 'Fetching branch...', workspacePath, hardTimeoutMs)
-      );
-    }
-  } else {
-    fetchResult = await runGit(
-      ['fetch', '--progress', 'origin'],
-      longGitOptions(progress, 'branch', 'Fetching repository...', workspacePath, hardTimeoutMs)
-    );
-  }
+  const fetchResult = await runGit(
+    ['fetch', '--progress', 'origin'],
+    longGitOptions(progress, 'branch', 'Fetching repository...', workspacePath)
+  );
   if (fetchResult.exitCode !== 0) {
     throw gitOperationError(fetchResult, 'checkout');
   }
@@ -546,15 +515,13 @@ async function sanitizeBitbucketCodeReviewRemote(
   request: WrapperSessionReadyRequest,
   runGit: GitRunner
 ): Promise<boolean> {
-  const repo = request.repo;
-  if (
-    repo?.kind !== 'git' ||
-    repo.platform !== 'bitbucket' ||
-    request.materialized.env.KILO_PLATFORM !== 'code-review'
-  ) {
+  // Single source of truth with the blobless-skip check in cloneRepository: the
+  // filter is skipped for exactly this session type because this function strips
+  // origin credentials, which would break a partial clone's later blob fetches.
+  if (!isBitbucketReviewSession(request)) {
     return false;
   }
-  const canonicalUrl = new URL(repo.url);
+  const canonicalUrl = new URL(request.repo.url);
   canonicalUrl.username = '';
   canonicalUrl.password = '';
   const result = await runGit(['remote', 'set-url', 'origin', canonicalUrl.toString()], {


### PR DESCRIPTION
## Summary

Cloud code review sessions now use a blobless partial clone (`git clone --filter=blob:none`) for GitHub and GitLab repositories, instead of a full clone. This keeps the initial clone bounded by the current working tree rather than full repository history, avoiding clone timeouts on large repos, while still fetching the full commit graph so incremental diffs and merge-base checks keep working (blobs are fetched lazily on demand).

Bitbucket review sessions, and any other/unrecognized `git` remote, keep a normal full clone.

## Changes

- Added `isCodeReviewSession`, `isBitbucketReviewSession`, and `isBloblessReviewCloneEligible` helpers in `session-bootstrap.ts` to gate the clone strategy by session platform and repo provider.
- `cloneRepository` now clones with `--filter=blob:none` only for GitHub/GitLab code review sessions; if the server rejects the filter outright (rather than silently ignoring it), it retries once with a normal full clone so a review is never lost to the optimization.
- `sanitizeBitbucketCodeReviewRemote` now reuses `isBitbucketReviewSession` instead of duplicating the same platform check inline.
- Added tests covering: blobless clone for GitHub and GitLab, full clone for Bitbucket, full clone for an unrecognized git platform, and the retry-on-filter-rejection fallback.

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes

N/A

## Reviewer Notes

Bitbucket keeps a full clone as a deliberate tradeoff: enabling the blobless clone there would require adding outbound credential injection for Bitbucket to the sandbox's outbound proxy, which today only supports GitHub and GitLab. That's out of scope for this change.
