### PR TITLE
fix(ai-gateway): always rewrite proxied model responses

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -57,9 +57,12 @@ jest.mock('@/lib/ai-gateway/o11y/api-metrics.server', () => ({
 }));
 jest.mock('@/lib/rewriteModelResponse', () => {
   const actual = jest.requireActual('@/lib/rewriteModelResponse');
+  const { wrapInSafeNextResponse } = jest.requireActual('@/lib/ai-gateway/llm-proxy-helpers');
   return {
     ...actual,
-    rewriteModelResponse: jest.fn(async () => null),
+    // Mirror the production passthrough; these tests exercise the route, not
+    // the response rewrite.
+    rewriteModelResponse: jest.fn(async (response: Response) => wrapInSafeNextResponse(response)),
   };
 });
 jest.mock('@/lib/ai-gateway/llm-proxy-helpers', () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -47,7 +47,6 @@ import {
   organizationAutoConfigurationResponse,
   temporarilyUnavailableResponse,
   usageLimitExceededResponse,
-  wrapInSafeNextResponse,
   forbiddenFreeModelResponse,
   storeAndPreviousResponseIdIsNotSupported,
   apiKindNotSupportedResponse,
@@ -997,16 +996,11 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     }
   }
 
-  const rewrittenResponse = await rewriteModelResponse(
+  return await rewriteModelResponse(
     response,
     effectiveModelIdLowerCased,
     effectiveProviderContext.provider.id,
     requestBodyParsed.kind,
     requestLogging
   );
-  if (rewrittenResponse) {
-    return rewrittenResponse;
-  }
-
-  return wrapInSafeNextResponse(response);
 }

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -582,16 +582,29 @@ describe('rewriteModelResponse', () => {
     });
   });
 
-  test('does not rewrite paid-model traffic for other organizations', async () => {
+  test('rewrites paid-model traffic for other organizations without stripping cost', async () => {
     const result = await rewriteModelResponse(
-      jsonResponse({ model: 'openai/gpt-5' }),
+      jsonResponse({
+        model: 'openai/gpt-5',
+        usage: {
+          cost: 0.5,
+          cost_details: { upstream_inference_cost: 0.4 },
+          is_byok: false,
+        },
+      }),
       'openai/gpt-5',
       'openrouter',
       'chat_completions',
       makeLogging({ organization_id: '00000000-0000-0000-0000-000000000000' })
     );
 
-    expect(result).toBeNull();
+    expect(await result.json()).toMatchObject({
+      usage: {
+        cost: 0.5,
+        cost_details: { upstream_inference_cost: 0.4 },
+        is_byok: false,
+      },
+    });
   });
 
   test('continues stripping cost for free models outside the Kilo organization', async () => {
@@ -613,7 +626,7 @@ describe('rewriteModelResponse', () => {
     });
   });
 
-  test('processes responses it would normally skip when request logging is enabled', async () => {
+  test('processes paid-model responses when request logging is enabled', async () => {
     mockedOptIn.mockResolvedValueOnce(true);
     const result = await rewriteModelResponse(
       jsonResponse({ model: 'openai/gpt-5' }),

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -740,18 +740,10 @@ export async function rewriteModelResponse(
   providerId: ProviderId,
   kind: GatewayRequest['kind'],
   logging: RequestLoggingParams
-): Promise<NextResponse | null> {
+): Promise<NextResponse> {
   const capture = await createRequestLogCapture(response, model, providerId, logging);
   const isFreeModelRequiringCostRemoval =
     (providerId === 'openrouter' || providerId === 'vercel') && isKiloExclusiveFreeModel(model);
-
-  // When request logging is enabled the response has to be processed anyway
-  // so the body can be captured for the request log in a single pass, so the
-  // rewrite is not skipped in that case.
-  if (!isFreeModelRequiringCostRemoval && !capture) {
-    console.debug('[rewriteModelResponse] skipping rewrite for %s', model);
-    return null;
-  }
 
   console.debug('[rewriteModelResponse] rewriting response for %s', model);
   const { vercel_request_id: vercelRequestId } = logging;
@@ -780,7 +772,7 @@ export async function rewriteModelResponse(
     );
   }
 
-  console.error('[rewriteModelResponse] implementation error: unrecognized API kind %s', kind);
-  capture?.setReadError(new Error('response was not processed'));
-  return null;
+  const error = new Error(`implementation error: unrecognized API kind ${kind}`);
+  capture?.setReadError(error);
+  throw error;
 }


### PR DESCRIPTION
## Summary

Removes the passthrough shortcut in `rewriteModelResponse` so every proxied model response goes through the processing pipeline (previously only Kilo-exclusive free models and request-logged traffic did).

## Why

Stream errors (upstream timeouts/disconnects) are common, and for the traffic that skipped the rewrite — paid models without request logging — they were undebuggable: the raw stream was passed through untouched, so mid-stream failures surfaced only as connection errors with no captured context. Processing the full stream is the only way to surface and log them.

Performance is not a concern here: token generation is inherently slow, and ~50% of traffic (free models + internal traffic with logging enabled) already goes through the rewrite.

## Changes

- `rewriteModelResponse` now always returns a `NextResponse` (never `null`); the route returns its result directly instead of falling back to `wrapInSafeNextResponse`.
- The unrecognized-API-kind branch now throws (fail loud on an implementation error) instead of silently passing the response through.
- Tests updated for the new contract: the route mock passes responses through via `wrapInSafeNextResponse`, and the removed skip-behavior test now asserts paid-model traffic is rewritten with cost preserved.

## Verification

- `rewriteModelResponse.test.ts`: 58/58 pass
- `openrouter/[...path]/route.test.ts`: 20/20 pass
- `tsgo --noEmit` (web): clean
- `oxlint` on the 4 changed files: 0 warnings, 0 errors
- `pnpm format:changed` applied; `git diff --check` clean