### PR TITLE
fix(session-ingest): stop agent-generated titles from clobbering user renames

### DIFF
--- a/apps/web/src/routers/cli-sessions-v2-router.test.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.test.ts
@@ -857,6 +857,36 @@ describe('cli-sessions-v2-router', () => {
       expect(result.title).toBe('renamed by current member');
     });
 
+    it('rename always overwrites the title, whether it is still the creation placeholder or an existing (e.g. agent-generated) title', async () => {
+      const caller = await createCallerForUser(regularUser.id);
+
+      // Session starts with title NULL (the creation placeholder) — rename must succeed.
+      const [beforeAnyTitle] = await db
+        .select({ title: cli_sessions_v2.title })
+        .from(cli_sessions_v2)
+        .where(eq(cli_sessions_v2.session_id, organizationSessionId));
+      expect(beforeAnyTitle?.title).toBeNull();
+
+      const firstRename = await caller.cliSessionsV2.rename({
+        session_id: organizationSessionId,
+        title: 'agent-generated title',
+      });
+      expect(firstRename.title).toBe('agent-generated title');
+
+      // A subsequent user rename must overwrite an already non-null (agent-generated) title too.
+      const secondRename = await caller.cliSessionsV2.rename({
+        session_id: organizationSessionId,
+        title: 'user renamed title',
+      });
+      expect(secondRename.title).toBe('user renamed title');
+
+      const [persisted] = await db
+        .select({ title: cli_sessions_v2.title })
+        .from(cli_sessions_v2)
+        .where(eq(cli_sessions_v2.session_id, organizationSessionId));
+      expect(persisted?.title).toBe('user renamed title');
+    });
+
     it('rename rejects an organization session after its creator loses membership', async () => {
       const originalTitle = 'organization session title';
       await db

--- a/services/session-ingest/src/ingest/metadata.test.ts
+++ b/services/session-ingest/src/ingest/metadata.test.ts
@@ -119,6 +119,8 @@ type ApplyMetadataDbOptions = {
   parentSessionId?: string | null;
   createsCycle?: boolean;
   scopeRootMissing?: boolean;
+  /** Title stored on the row before applyMetadataChanges runs. Defaults to the creation placeholder (NULL). */
+  initialTitle?: string | null;
 };
 
 /**
@@ -148,6 +150,7 @@ function createApplyMetadataDb(options: ApplyMetadataDbOptions = {}) {
 
   function currentSessionState() {
     return {
+      title: options.initialTitle ?? null,
       status: options.initialStatus ?? 'idle',
       parentSessionId: options.parentSessionId ?? null,
       cloudAgentSessionScopeId: options.cloudAgentSessionScopeId ?? null,
@@ -664,6 +667,65 @@ describe('applyMetadataChanges', () => {
     expect(db.execute).toHaveBeenCalledTimes(1);
     expect(db.updateSets).toEqual([]);
     expect(notifyUserSessionEvent).not.toHaveBeenCalled();
+  });
+
+  describe('agent-generated title vs. user rename race', () => {
+    it('applies the agent-generated title when the row still has the creation placeholder (NULL)', async () => {
+      const db = createApplyMetadataDb({ initialTitle: null });
+      vi.mocked(getWorkerDb).mockReturnValue(db as never);
+
+      await applyMetadataChanges(env, 'usr_1', 'ses_1', new Map([['title', 'Agent title']]));
+
+      expect(db.updateSets).toEqual([expect.objectContaining({ title: 'Agent title' })]);
+      expect(notifyUserSessionEvent).toHaveBeenCalledWith(
+        env,
+        'usr_1',
+        expect.objectContaining({ type: 'session.updated' }),
+        undefined
+      );
+    });
+
+    it('skips the agent-generated title write when the user already renamed the session', async () => {
+      const db = createApplyMetadataDb({ initialTitle: 'User chosen title' });
+      vi.mocked(getWorkerDb).mockReturnValue(db as never);
+      const warnSpy = vi.mocked(console.warn);
+
+      await applyMetadataChanges(env, 'usr_1', 'ses_1', new Map([['title', 'Agent title']]));
+
+      // Title write is dropped entirely; no update statement is issued for a title-only batch.
+      expect(db.applyUpdate).not.toHaveBeenCalled();
+      expect(db.updateSets).toEqual([]);
+      expect(notifyUserSessionEvent).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        'Skipping agent-generated title write; title is no longer the placeholder',
+        expect.objectContaining({ kiloUserId: 'usr_1', sessionId: 'ses_1' })
+      );
+    });
+
+    it('still applies other metadata fields when the title write is skipped due to a prior user rename', async () => {
+      const db = createApplyMetadataDb({ initialTitle: 'User chosen title' });
+      vi.mocked(getWorkerDb).mockReturnValue(db as never);
+
+      await applyMetadataChanges(
+        env,
+        'usr_1',
+        'ses_1',
+        new Map([
+          ['title', 'Agent title'],
+          ['platform', 'cli'],
+          ['status', 'busy'],
+        ])
+      );
+
+      expect(db.updateSets).toEqual([
+        expect.objectContaining({
+          created_on_platform: 'cli',
+          status: 'busy',
+        }),
+      ]);
+      const written = db.updateSets[0] as Record<string, unknown>;
+      expect(written).not.toHaveProperty('title');
+    });
   });
 
   it('logs when a session scope root is missing during reparent', async () => {

--- a/services/session-ingest/src/ingest/metadata.ts
+++ b/services/session-ingest/src/ingest/metadata.ts
@@ -68,10 +68,14 @@ export async function applyMetadataChanges(
   /** True only when an organization_id write was actually applied (authorized claim or explicit null clear). */
   let organizationIdWriteApplied = false;
 
+  /** True only when an agent-generated title write was actually applied (placeholder was still unset). */
+  let titleWriteApplied = false;
+
   const notification = await db.transaction(async tx => {
     const selectCurrentRow = () =>
       tx
         .select({
+          title: cli_sessions_v2.title,
           status: cli_sessions_v2.status,
           parentSessionId: cli_sessions_v2.parent_session_id,
           cloudAgentSessionId: cli_sessions_v2.cloud_agent_session_id,
@@ -125,6 +129,23 @@ export async function applyMetadataChanges(
             const previousStatus = SessionStatusSchema.nullable().parse(currentRow.status);
             return { changed: status !== previousStatus, previousStatus };
           })();
+
+    // Agent-generated titles arrive asynchronously and can race a user rename. A session's
+    // title starts out NULL (the placeholder set at row creation); only promote it from that
+    // placeholder here. Once the title is non-null — whether from a user rename or an earlier
+    // agent-generated write — leave it alone so a later user rename can never be clobbered by
+    // an in-flight ingest.
+    if (mergedChanges.has('title')) {
+      if (currentRow.title === null) {
+        titleWriteApplied = true;
+      } else {
+        console.warn('Skipping agent-generated title write; title is no longer the placeholder', {
+          kiloUserId,
+          sessionId,
+        });
+        delete updates.title;
+      }
+    }
 
     // Membership check only for non-null org claims; run on the same tx as the UPDATE.
     // Residual: SessionIngestDO.writeIngestMetaIfChanged records the claimed orgId in DO
@@ -281,9 +302,9 @@ export async function applyMetadataChanges(
       }
     }
 
-    // Refused org/parent claims must not emit phantom session.updated events.
+    // Refused org/parent/title claims must not emit phantom session.updated events.
     const changedNonStatus =
-      mergedChanges.has('title') ||
+      titleWriteApplied ||
       mergedChanges.has('platform') ||
       organizationIdWriteApplied ||
       mergedChanges.has('gitUrl') ||


### PR DESCRIPTION
## Problem

`cli_sessions_v2.title` is a single unqualified column with no provenance flag, so two independent write paths race:

- **User rename** (`cliSessionsV2.rename` in `apps/web/src/routers/cli-sessions-v2-router.ts`): a direct, unconditional `UPDATE title = $newTitle`.
- **Agent-generated title** (async, arrives via the sandbox agent → `SessionIngestDO` → queue consumer → `applyMetadataChanges` in `services/session-ingest/src/ingest/metadata.ts`): also an unconditional `UPDATE title = $newTitle`.

Whichever write lands last wins. If the agent-generated title arrives after a user renamed the session, it silently clobbers the user's chosen title.

## Fix (no schema/migration changes)

Sessions are created with `title = NULL` — there's no default placeholder string; the column is nullable with no default (`packages/db/src/schema.ts`), and both insert sites (`services/session-ingest/src/routes/api.ts`, `services/session-ingest/src/session-ingest-rpc.ts`) simply omit `title` unless explicitly provided.

`applyMetadataChanges` now treats `NULL` as the "still unset" placeholder and only promotes the title away from it:

- Inside the existing `SELECT ... FOR UPDATE` row lock (already used to serialize this metadata update), it reads the current `title`.
- If `title IS NULL`, the agent-generated title is applied as before (folded into the same batched `UPDATE`).
- If `title` is no longer `NULL` — because a user already renamed the session, or an earlier agent-generated write already landed — the title write is dropped from the batch (`delete updates.title`) and a warning is logged. The rest of the metadata batch (org, git url/branch, platform, status, parent) is unaffected.

`cliSessionsV2.rename` is unchanged: it remains an unconditional `UPDATE`, so a user can always overwrite the title regardless of its current value (placeholder or agent-generated).

This mirrors the existing conditional-write pattern already used in this file for `organization_id` (membership-gated) and `parent_session_id` (`IS DISTINCT FROM` re-check), just gated on "is this still the creation placeholder" instead.

## Tests

- `services/session-ingest/src/ingest/metadata.test.ts`:
  - Agent-generated title is applied when the row is still at the `NULL` placeholder.
  - Agent-generated title write is skipped (with the rest of the batch still applied) when the user already renamed the session.
  - Warning is logged when the title write is skipped.
- `apps/web/src/routers/cli-sessions-v2-router.test.ts`:
  - `rename` overwrites the title both when it's still the `NULL` placeholder and when it already holds a previously-written (e.g. agent-generated) title.

## Verification

- `npx vitest run src/ingest/metadata.test.ts src/queue-consumer.test.ts` (services/session-ingest) — all passing.
- `npx oxlint` on changed files — clean.
- `npx tsc --noEmit` (services/session-ingest) — clean.
- `npx tsc --noEmit` (apps/web) — no errors in the changed test file.
- Could not run the `apps/web` Jest integration suite for `cli-sessions-v2-router.test.ts` in this sandbox (no local/reachable Postgres or Docker); it should be run in CI or with `pnpm test:db` locally.

---

Built for [Jean Du Plessis](https://anaconda.slack.com/archives/C0BJWJB1WBT/p1785316730468229?thread_ts=1785314971.821899&cid=C0BJWJB1WBT) by [Kilo for Slack](https://kilo.ai/slack)