### PR TITLE
fix(auto-fix): skip Kilo bot-authored review comments (self thumbs-down)

### DIFF
--- a/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.test.ts
+++ b/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.test.ts
@@ -18,6 +18,9 @@ import type { PullRequestReviewCommentPayload } from '@/lib/integrations/platfor
 const mockGetAgentConfigForOwner = jest.fn();
 const mockFindExistingReviewCommentFixTicket = jest.fn();
 const mockParseFixCommand = jest.fn();
+const mockAddReactionToPRReviewComment = jest.fn().mockResolvedValue(undefined);
+const mockGetCollaboratorPermissionLevel = jest.fn();
+const mockIsLikelyKiloBotActor = jest.fn();
 
 jest.mock('@/lib/agent-config/db/agent-configs', () => ({
   getAgentConfigForOwner: (...args: unknown[]) => mockGetAgentConfigForOwner(...args),
@@ -39,8 +42,9 @@ jest.mock('@/lib/bot-users/bot-user-service', () => ({
 }));
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
-  addReactionToPRReviewComment: jest.fn().mockResolvedValue(undefined),
-  getCollaboratorPermissionLevel: jest.fn(),
+  addReactionToPRReviewComment: (...args: unknown[]) => mockAddReactionToPRReviewComment(...args),
+  getCollaboratorPermissionLevel: (...args: unknown[]) =>
+    mockGetCollaboratorPermissionLevel(...args),
 }));
 
 jest.mock('@sentry/nextjs', () => ({
@@ -49,6 +53,10 @@ jest.mock('@sentry/nextjs', () => ({
 
 jest.mock('@kilocode/app-shared/code-review', () => ({
   parseFixCommand: (text: string) => mockParseFixCommand(text),
+}));
+
+jest.mock('@/lib/code-reviews/review-memory/github-feedback', () => ({
+  isLikelyKiloBotActor: (...args: unknown[]) => mockIsLikelyKiloBotActor(...args),
 }));
 
 import { ReviewCommentWebhookProcessor } from './review-comment-webhook-processor';
@@ -102,6 +110,8 @@ describe('ReviewCommentWebhookProcessor admission', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    // Default: comments are authored by humans, so admission proceeds.
+    mockIsLikelyKiloBotActor.mockReturnValue(false);
     processor = new ReviewCommentWebhookProcessor();
   });
 
@@ -150,6 +160,30 @@ describe('ReviewCommentWebhookProcessor admission', () => {
     await processor.process(buildPayload(body), integration);
 
     expect(mockParseFixCommand).toHaveBeenCalledWith(body);
+    expect(mockGetAgentConfigForOwner).not.toHaveBeenCalled();
+  });
+
+  it('ignores a comment authored by Kilo itself before parsing (no self thumbs-down)', async () => {
+    // Regression: Kilo's own inline comments carry the advertised
+    // "Reply with `@kilocode-bot fix it` …" footer, which parseFixCommand
+    // would admit. The bot must never process its own comment — doing so
+    // previously produced a thumbs-down (-1) reaction on its own review
+    // comment because the author write-access check fails for the bot.
+    const body =
+      'Some finding.\n\n---\nReply with `@kilocode-bot fix it` to have Kilo Code address this issue.';
+    const payload = buildPayload(body);
+    payload.comment.user.login = 'kilo-code-bot[bot]';
+    // author_association from a GitHub App bot is NONE, but the guard must
+    // short-circuit before we ever reach the permission check or the parser.
+    payload.comment.author_association = 'NONE';
+    mockIsLikelyKiloBotActor.mockReturnValue(true);
+
+    await processor.process(payload, integration);
+
+    expect(mockIsLikelyKiloBotActor).toHaveBeenCalledWith('kilo-code-bot[bot]');
+    expect(mockParseFixCommand).not.toHaveBeenCalled();
+    expect(mockGetCollaboratorPermissionLevel).not.toHaveBeenCalled();
+    expect(mockAddReactionToPRReviewComment).not.toHaveBeenCalled();
     expect(mockGetAgentConfigForOwner).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.ts
+++ b/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.ts
@@ -31,6 +31,7 @@ import type {
   GitHubAuthorAssociation,
 } from '@/lib/integrations/platforms/github/webhook-schemas';
 import { parseFixCommand } from '@kilocode/app-shared/code-review';
+import { isLikelyKiloBotActor } from '@/lib/code-reviews/review-memory/github-feedback';
 
 /**
  * author_association values that imply write access.
@@ -60,6 +61,22 @@ export class ReviewCommentWebhookProcessor {
         '[ReviewCommentWebhookProcessor] Malformed repository.full_name, cannot proceed',
         { fullName: repository.full_name }
       );
+      return;
+    }
+
+    // 0. Ignore comments authored by Kilo itself.
+    //    Every inline review comment Kilo posts ends with the advertised
+    //    "Reply with `@kilocode-bot fix it` …" footer, which parseFixCommand
+    //    (below) admits as a fix request. Without this guard the bot processes
+    //    its own comment, fails the author write-access check (a GitHub App
+    //    bot is not a repo collaborator), and reacts with a thumbs-down (-1)
+    //    on its own review comment. The sibling review-memory consumer of this
+    //    same webhook guards identically (see github-feedback.ts).
+    if (isLikelyKiloBotActor(comment.user.login)) {
+      logExceptInTest('[ReviewCommentWebhookProcessor] Ignoring Kilo bot-authored comment', {
+        commentId: comment.id,
+        author: comment.user.login,
+      });
       return;
     }
 


### PR DESCRIPTION
## Problem

Users reported the Kilo review bot posting a 👎 (`-1`) reaction on its **own** inline review comments.

Root cause is in the **Auto Fix** review-comment webhook processor, not the review-generation code:

1. Every inline review comment Kilo posts ends with the advertised footer `Reply with `@kilocode-bot fix it` to have Kilo Code address this issue.` (`default-prompt-template.json`, `inlineCommentFooter`).
2. GitHub fires a `pull_request_review_comment` (`created`) webhook for the bot's own comment. The webhook router filters only on `action === 'created'` — no bot/self-author filter.
3. `ReviewCommentWebhookProcessor.process()` runs `parseFixCommand(comment.body)`, which admits because the footer contains `@kilocode-bot` + `fix`.
4. The author write-access check then fails, because the "author" is the GitHub App bot (not a repo `admin`/`write` collaborator), so the processor reacts with `-1` on the bot's own comment (`review-comment-webhook-processor.ts:106`).

The sibling review-memory consumer of the **same** webhook already guards against this (`github-feedback.ts` → `isLikelyKiloBotActor`); the Auto Fix processor was missing the equivalent guard.

## Fix

Add a self-author guard at the top of `ReviewCommentWebhookProcessor.process()` that short-circuits when the comment author is a Kilo bot, reusing the existing `isLikelyKiloBotActor` helper (single source of truth for Kilo bot logins). This runs before `parseFixCommand`, the permission check, and any reaction, so the bot never processes — or thumbs-downs — its own comment.

## Testing

- Added a regression test asserting a bot-authored comment is ignored before parsing/permission checks and never triggers a reaction.
- `pnpm --filter web exec jest review-comment-webhook-processor.test.ts` — 5 passed.
- `pnpm --filter web typecheck` — passes.
- `oxlint` + `oxfmt` on changed files — clean.
