### PR TITLE
fix(mobile): define PODS_ROOT for ShareExtension so ccache wrapper resolves

### DIFF
--- a/apps/mobile/plugins/withExpoShareIntent.js
+++ b/apps/mobile/plugins/withExpoShareIntent.js
@@ -2,7 +2,7 @@ const fs = require('fs');
 const Module = require('module');
 const path = require('path');
 
-const { withFinalizedMod } = require('expo/config-plugins');
+const { withFinalizedMod, withXcodeProject } = require('expo/config-plugins');
 
 // expo-share-intent@6.1.1 requires @expo/plist without declaring it. Under pnpm's
 // isolated linker the nested plugin cannot resolve that package from its own
@@ -44,6 +44,52 @@ const withExpoShareIntentUpstream = loadUpstreamPlugin();
 const SHARE_EXTENSION_TARGET = 'ShareExtension';
 const SHARE_SHEET_DISPLAY_NAME = 'Kilo';
 
+// React Native's react_native_post_install writes CC/CXX/LD/LDPLUSPLUS pointing at
+// $(REACT_NATIVE_PATH)/scripts/xcode/ccache-*.sh at the *project* level whenever
+// ccache is installed on the builder (EAS images ship it) and apple.ccacheEnabled
+// is set. REACT_NATIVE_PATH expands through ${PODS_ROOT}, which CocoaPods only
+// defines for pod-integrated targets. ShareExtension links no pods, so PODS_ROOT
+// expanded empty and CC became /../../../../node_modules/... — "unable to spawn
+// process" killed the iOS build on EAS. Define PODS_ROOT the way CocoaPods would
+// so the inherited compiler wrapper path resolves.
+function withShareExtensionPodsRoot(config) {
+  return withXcodeProject(config, config => {
+    const project = config.modResults;
+    // The stored target name is quoted ('"ShareExtension"') and upstream's
+    // addTarget leaves no comment entry for pbxTargetByName to match, so
+    // compare raw names with quotes tolerated.
+    const unquote = value => (typeof value === 'string' ? value.replace(/^"|"$/g, '') : value);
+    const target = Object.values(project.pbxNativeTargetSection()).find(
+      entry => entry && unquote(entry.name) === SHARE_EXTENSION_TARGET
+    );
+    if (!target) {
+      throw new Error(
+        `Expected Xcode target "${SHARE_EXTENSION_TARGET}" so PODS_ROOT can be set, but it was not found`
+      );
+    }
+    const configurationList = project.pbxXCConfigurationList()[target.buildConfigurationList];
+    if (!configurationList) {
+      throw new Error(
+        `Expected build configuration list for Xcode target "${SHARE_EXTENSION_TARGET}", but it was not found`
+      );
+    }
+    const configurations = project.pbxXCBuildConfigurationSection();
+    for (const { value } of configurationList.buildConfigurations) {
+      const buildConfiguration = configurations[value];
+      if (
+        buildConfiguration &&
+        buildConfiguration.buildSettings &&
+        !buildConfiguration.buildSettings.PODS_ROOT
+      ) {
+        // Quoted: '(' and ')' are array delimiters in pbxproj syntax, so the
+        // xcode package's verbatim write would corrupt the project unquoted.
+        buildConfiguration.buildSettings.PODS_ROOT = '"$(SRCROOT)/Pods"';
+      }
+    }
+    return config;
+  });
+}
+
 function withKiloShareSheetDisplayName(config) {
   // finalized runs after dangerous mods that write ShareExtension-Info.plist.
   return withFinalizedMod(config, [
@@ -82,6 +128,11 @@ module.exports = function withExpoShareIntent(config, props = {}) {
     // Distinct from the main "Kilo" app target (see collision note above).
     iosShareExtensionName: SHARE_EXTENSION_TARGET,
   };
+  // withXcodeProject mods execute in reverse registration order (each mod runs
+  // its action, then delegates to the previously registered one). Register
+  // withShareExtensionPodsRoot first so it runs after upstream's target-creation
+  // mod, when the ShareExtension target exists.
+  config = withShareExtensionPodsRoot(config);
   config = withExpoShareIntentUpstream(config, parameters);
   config = withKiloShareSheetDisplayName(config);
   return config;


### PR DESCRIPTION
## Summary

Fixes the failing iOS build in [kilo-app Release run 30430285185](https://github.com/Kilo-Org/cloud/actions/runs/30430285185/job/90506026881): `unable to spawn process '/../../../../node_modules/.pnpm/react-native@0.86.0_.../node_modules/react-native/scripts/xcode/ccache-clang.sh' (No such file or directory) (in target 'ShareExtension' from project 'Kilo')`.

## Root cause

- `ios.ccacheEnabled: true` (app.config.ts) → `react_native_post_install(:ccache_enabled => true)` writes `CC/CXX/LD/LDPLUSPLUS = $(REACT_NATIVE_PATH)/scripts/xcode/ccache-*.sh` **project-wide** on `Kilo.xcodeproj` when ccache exists on the builder.
- `REACT_NATIVE_PATH` is `${PODS_ROOT}/../../../..`, and CocoaPods only defines `PODS_ROOT` for pod-integrated targets.
- The `ShareExtension` target (created by expo-share-intent, no Podfile integration) has no Pods xcconfig → `PODS_ROOT` empty → `CC` expands to `/../../../../node_modules/...` → spawn fails.
- The main Kilo target gets `PODS_ROOT` from its Pods xcconfig, which is why only the extension failed.
- Repo inputs were identical to yesterday's green build; the EAS default iOS image gained ccache, which activated this latent breakage.

## Fix

Define `PODS_ROOT = $(SRCROOT)/Pods` on the ShareExtension target build configs — exactly what CocoaPods would set if the target were pod-integrated — in the existing local plugin wrapper `apps/mobile/plugins/withExpoShareIntent.js`. One build setting; ccache keeps working everywhere.

Gotchas handled: `withXcodeProject` mods run in reverse registration order (ours registers before upstream so it runs after target creation); the stored target name is quoted with no comment entry (raw-name match with quote tolerance); the value is written quoted because `(` and `)` are array delimiters in pbxproj syntax.

## Verification

Reproduced and fixed locally (macOS + ccache + CocoaPods, same as EAS builders):

- **Before:** `xcodebuild -showBuildSettings -target ShareExtension` showed `CC = /../../../../node_modules/.pnpm/...` — byte-identical to the EAS error.
- **After:** `CC/LD/CXX/LDPLUSPLUS` resolve to the real `node_modules/.pnpm/react-native@0.86.0_.../scripts/xcode/ccache-*.sh` (verified the file exists and is executable).
- **End to end:** `xcodebuild -scheme ShareExtension build` spawns `ccache-clang.sh` (as the link driver) and produces `ShareExtension.appex` successfully. (Residual failures in that isolated invocation are the host app target's pod module maps, an artifact of building the extension scheme without building pods first — not related.)
- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` (apps/mobile) + root `pnpm format` + `git diff --check` all clean.

EAS re-verification happens automatically on merge — the release job is gated to `refs/heads/main`, so it can't be exercised from this branch.