### PR TITLE
feat(api): expose cached model endpoints

### DIFF
--- a/apps/web/src/app/api/gateway/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/gateway/models/[provider]/[model]/endpoints/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/openrouter/models/[provider]/[model]/endpoints/route';

--- a/apps/web/src/app/api/gateway/v1/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/gateway/v1/models/[provider]/[model]/endpoints/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/openrouter/models/[provider]/[model]/endpoints/route';

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
@@ -3,6 +3,8 @@ import { NextRequest } from 'next/server';
 import { getOpenRouterModelsMetadataFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { QWEN37_MAX_MODEL_ID } from '@/lib/ai-gateway/custom-pricing';
 import { GET } from './route';
+import { GET as openRouterV1GET } from '@/app/api/openrouter/v1/models/[provider]/[model]/endpoints/route';
+import { GET as gatewayV1GET } from '@/app/api/gateway/v1/models/[provider]/[model]/endpoints/route';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
   getOpenRouterModelsMetadataFromDatabase: jest.fn(),
@@ -17,6 +19,11 @@ function request(modelId: string) {
 }
 
 describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
+  test('uses the canonical handler for versioned routes', () => {
+    expect(openRouterV1GET).toBe(GET);
+    expect(gatewayV1GET).toBe(GET);
+  });
+
   test('undoes discounts for every priced endpoint without adding missing fields', async () => {
     const model = {
       id: 'deepseek/deepseek-v4-pro',
@@ -41,6 +48,9 @@ describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
     });
 
     expect(response.status).toBe(200);
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=0, s-maxage=60, stale-while-revalidate=60'
+    );
     await expect(response.json()).resolves.toEqual({
       data: {
         id: model.id,
@@ -69,6 +79,9 @@ describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
     });
 
     expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=0, s-maxage=60, stale-while-revalidate=60'
+    );
     await expect(response.json()).resolves.toEqual({
       error: { message: 'Not Found', code: 404 },
     });
@@ -83,6 +96,9 @@ describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
     });
 
     expect(response.status).toBe(404);
+    expect(response.headers.get('cache-control')).toBe(
+      'public, max-age=0, s-maxage=60, stale-while-revalidate=60'
+    );
     await expect(response.json()).resolves.toEqual({
       error: { message: 'Not Found', code: 404 },
     });

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, test } from '@jest/globals';
 import { NextRequest } from 'next/server';
 import { getOpenRouterModelsMetadataFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import { QWEN37_MAX_MODEL_ID } from '@/lib/ai-gateway/custom-pricing';
 import { GET } from './route';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
@@ -71,5 +72,53 @@ describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
     await expect(response.json()).resolves.toEqual({
       error: { message: 'Not Found', code: 404 },
     });
+  });
+
+  test('applies custom pricing to every priced endpoint', async () => {
+    const model = {
+      id: QWEN37_MAX_MODEL_ID,
+      name: 'Qwen: Qwen3.7 Max',
+      endpoints: [
+        {
+          provider_name: 'Alibaba',
+          pricing: { prompt: '0.000001', completion: '0.000002' },
+        },
+        {
+          provider_name: 'Another provider',
+          pricing: { prompt: '0.000003', completion: '0.000004' },
+        },
+        { provider_name: 'Unpriced' },
+      ],
+    };
+    mockedGetOpenRouterModelsMetadataFromDatabase.mockResolvedValue({ [model.id]: model });
+    const [provider, modelName] = model.id.split('/');
+
+    const response = await GET(request(model.id), {
+      params: Promise.resolve({ provider, model: modelName }),
+    });
+
+    expect(response.status).toBe(200);
+    const data = (await response.json()).data;
+    expect(data.endpoints).toEqual([
+      {
+        provider_name: 'Alibaba',
+        pricing: {
+          prompt: '0.000001250000',
+          completion: '0.000003750000',
+          input_cache_read: '0.000000125000',
+          input_cache_write: '0.000001562500',
+        },
+      },
+      {
+        provider_name: 'Another provider',
+        pricing: {
+          prompt: '0.000001250000',
+          completion: '0.000003750000',
+          input_cache_read: '0.000000125000',
+          input_cache_write: '0.000001562500',
+        },
+      },
+      { provider_name: 'Unpriced' },
+    ]);
   });
 });

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
@@ -74,6 +74,21 @@ describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
     });
   });
 
+  test('returns 404 for forbidden free models without reading cached metadata', async () => {
+    mockedGetOpenRouterModelsMetadataFromDatabase.mockClear();
+    const modelId = 'openai/gpt-oss-20b:free';
+
+    const response = await GET(request(modelId), {
+      params: Promise.resolve({ provider: 'openai', model: 'gpt-oss-20b:free' }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: { message: 'Not Found', code: 404 },
+    });
+    expect(mockedGetOpenRouterModelsMetadataFromDatabase).not.toHaveBeenCalled();
+  });
+
   test('applies custom pricing to every priced endpoint', async () => {
     const model = {
       id: QWEN37_MAX_MODEL_ID,

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from '@jest/globals';
+import { NextRequest } from 'next/server';
+import { getOpenRouterModelsMetadataFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import { GET } from './route';
+
+jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
+  getOpenRouterModelsMetadataFromDatabase: jest.fn(),
+}));
+
+const mockedGetOpenRouterModelsMetadataFromDatabase = jest.mocked(
+  getOpenRouterModelsMetadataFromDatabase
+);
+
+function request(modelId: string) {
+  return new NextRequest(`http://localhost:3000/api/openrouter/models/${modelId}/endpoints`);
+}
+
+describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
+  test('returns the cached model without adding missing fields', async () => {
+    const model = {
+      id: 'deepseek/deepseek-v4-pro',
+      name: 'DeepSeek: DeepSeek V4 Pro',
+      endpoints: [
+        {
+          provider_name: 'DeepSeek',
+          context_length: 1_048_576,
+          pricing: { prompt: '0.000000435', completion: '0.00000087' },
+        },
+      ],
+    };
+    mockedGetOpenRouterModelsMetadataFromDatabase.mockResolvedValue({ [model.id]: model });
+
+    const response = await GET(request(model.id), {
+      params: Promise.resolve({ provider: 'deepseek', model: 'deepseek-v4-pro' }),
+    });
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({ data: model });
+  });
+
+  test('returns 404 when the model is absent from the cache', async () => {
+    mockedGetOpenRouterModelsMetadataFromDatabase.mockResolvedValue({});
+
+    const response = await GET(request('missing/model'), {
+      params: Promise.resolve({ provider: 'missing', model: 'model' }),
+    });
+
+    expect(response.status).toBe(404);
+    await expect(response.json()).resolves.toEqual({
+      error: { message: 'Not Found', code: 404 },
+    });
+  });
+});

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.test.ts
@@ -16,7 +16,7 @@ function request(modelId: string) {
 }
 
 describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
-  test('returns the cached model without adding missing fields', async () => {
+  test('undoes discounts for every priced endpoint without adding missing fields', async () => {
     const model = {
       id: 'deepseek/deepseek-v4-pro',
       name: 'DeepSeek: DeepSeek V4 Pro',
@@ -24,8 +24,13 @@ describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
         {
           provider_name: 'DeepSeek',
           context_length: 1_048_576,
-          pricing: { prompt: '0.000000435', completion: '0.00000087' },
+          pricing: { prompt: '0.000000435', completion: '0.00000087', discount: 0.5 },
         },
+        {
+          provider_name: 'Baidu',
+          pricing: { prompt: '0.0000006253', completion: '0.0000012506', discount: 0.63 },
+        },
+        { provider_name: 'Unpriced' },
       ],
     };
     mockedGetOpenRouterModelsMetadataFromDatabase.mockResolvedValue({ [model.id]: model });
@@ -35,7 +40,24 @@ describe('GET /api/openrouter/models/[provider]/[model]/endpoints', () => {
     });
 
     expect(response.status).toBe(200);
-    await expect(response.json()).resolves.toEqual({ data: model });
+    await expect(response.json()).resolves.toEqual({
+      data: {
+        id: model.id,
+        name: model.name,
+        endpoints: [
+          {
+            provider_name: 'DeepSeek',
+            context_length: 1_048_576,
+            pricing: { prompt: '0.000000870000', completion: '0.000001740000' },
+          },
+          {
+            provider_name: 'Baidu',
+            pricing: { prompt: '0.000001690000', completion: '0.000003380000' },
+          },
+          { provider_name: 'Unpriced' },
+        ],
+      },
+    });
   });
 
   test('returns 404 when the model is absent from the cache', async () => {

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
@@ -3,14 +3,20 @@ import { NextResponse } from 'next/server';
 import { getOpenRouterModelsMetadataFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { getModelDisplayPricing } from '@/lib/ai-gateway/providers/openrouter';
 import { applyCustomPricingToPricing } from '@/lib/ai-gateway/custom-pricing';
+import { isForbiddenFreeModel } from '@/lib/ai-gateway/forbidden-free-models';
 
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ provider: string; model: string }> }
 ) {
   const { provider, model } = await params;
+  const modelId = `${provider}/${model}`;
+  if (isForbiddenFreeModel(modelId)) {
+    return NextResponse.json({ error: { message: 'Not Found', code: 404 } }, { status: 404 });
+  }
+
   const models = await getOpenRouterModelsMetadataFromDatabase();
-  const storedModel = models[`${provider}/${model}`];
+  const storedModel = models[modelId];
 
   if (!storedModel) {
     return NextResponse.json({ error: { message: 'Not Found', code: 404 } }, { status: 404 });

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
@@ -2,6 +2,7 @@ import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getOpenRouterModelsMetadataFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { getModelDisplayPricing } from '@/lib/ai-gateway/providers/openrouter';
+import { applyCustomPricingToPricing } from '@/lib/ai-gateway/custom-pricing';
 
 export async function GET(
   _request: NextRequest,
@@ -18,14 +19,14 @@ export async function GET(
   return NextResponse.json({
     data: {
       ...storedModel,
-      endpoints: storedModel.endpoints.map(endpoint =>
-        endpoint.pricing
-          ? {
-              ...endpoint,
-              pricing: getModelDisplayPricing(storedModel.id, endpoint.pricing),
-            }
-          : endpoint
-      ),
+      endpoints: storedModel.endpoints.map(endpoint => {
+        if (!endpoint.pricing) return endpoint;
+        const displayPricing = getModelDisplayPricing(storedModel.id, endpoint.pricing);
+        return {
+          ...endpoint,
+          pricing: applyCustomPricingToPricing(storedModel.id, displayPricing ?? endpoint.pricing),
+        };
+      }),
     },
   });
 }

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
@@ -1,6 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getOpenRouterModelsMetadataFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import { getModelDisplayPricing } from '@/lib/ai-gateway/providers/openrouter';
 
 export async function GET(
   _request: NextRequest,
@@ -14,5 +15,17 @@ export async function GET(
     return NextResponse.json({ error: { message: 'Not Found', code: 404 } }, { status: 404 });
   }
 
-  return NextResponse.json({ data: storedModel });
+  return NextResponse.json({
+    data: {
+      ...storedModel,
+      endpoints: storedModel.endpoints.map(endpoint =>
+        endpoint.pricing
+          ? {
+              ...endpoint,
+              pricing: getModelDisplayPricing(storedModel.id, endpoint.pricing),
+            }
+          : endpoint
+      ),
+    },
+  });
 }

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
@@ -1,0 +1,18 @@
+import type { NextRequest } from 'next/server';
+import { NextResponse } from 'next/server';
+import { getOpenRouterModelsMetadataFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ provider: string; model: string }> }
+) {
+  const { provider, model } = await params;
+  const models = await getOpenRouterModelsMetadataFromDatabase();
+  const storedModel = models[`${provider}/${model}`];
+
+  if (!storedModel) {
+    return NextResponse.json({ error: { message: 'Not Found', code: 404 } }, { status: 404 });
+  }
+
+  return NextResponse.json({ data: storedModel });
+}

--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
@@ -5,6 +5,8 @@ import { getModelDisplayPricing } from '@/lib/ai-gateway/providers/openrouter';
 import { applyCustomPricingToPricing } from '@/lib/ai-gateway/custom-pricing';
 import { isForbiddenFreeModel } from '@/lib/ai-gateway/forbidden-free-models';
 
+const CACHE_CONTROL = 'public, max-age=0, s-maxage=60, stale-while-revalidate=60';
+
 export async function GET(
   _request: NextRequest,
   { params }: { params: Promise<{ provider: string; model: string }> }
@@ -12,27 +14,39 @@ export async function GET(
   const { provider, model } = await params;
   const modelId = `${provider}/${model}`;
   if (isForbiddenFreeModel(modelId)) {
-    return NextResponse.json({ error: { message: 'Not Found', code: 404 } }, { status: 404 });
+    return NextResponse.json(
+      { error: { message: 'Not Found', code: 404 } },
+      { status: 404, headers: { 'Cache-Control': CACHE_CONTROL } }
+    );
   }
 
   const models = await getOpenRouterModelsMetadataFromDatabase();
   const storedModel = models[modelId];
 
   if (!storedModel) {
-    return NextResponse.json({ error: { message: 'Not Found', code: 404 } }, { status: 404 });
+    return NextResponse.json(
+      { error: { message: 'Not Found', code: 404 } },
+      { status: 404, headers: { 'Cache-Control': CACHE_CONTROL } }
+    );
   }
 
-  return NextResponse.json({
-    data: {
-      ...storedModel,
-      endpoints: storedModel.endpoints.map(endpoint => {
-        if (!endpoint.pricing) return endpoint;
-        const displayPricing = getModelDisplayPricing(storedModel.id, endpoint.pricing);
-        return {
-          ...endpoint,
-          pricing: applyCustomPricingToPricing(storedModel.id, displayPricing ?? endpoint.pricing),
-        };
-      }),
+  return NextResponse.json(
+    {
+      data: {
+        ...storedModel,
+        endpoints: storedModel.endpoints.map(endpoint => {
+          if (!endpoint.pricing) return endpoint;
+          const displayPricing = getModelDisplayPricing(storedModel.id, endpoint.pricing);
+          return {
+            ...endpoint,
+            pricing: applyCustomPricingToPricing(
+              storedModel.id,
+              displayPricing ?? endpoint.pricing
+            ),
+          };
+        }),
+      },
     },
-  });
+    { headers: { 'Cache-Control': CACHE_CONTROL } }
+  );
 }

--- a/apps/web/src/app/api/openrouter/v1/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/openrouter/v1/models/[provider]/[model]/endpoints/route.ts
@@ -1,0 +1,1 @@
+export { GET } from '@/app/api/openrouter/models/[provider]/[model]/endpoints/route';

--- a/apps/web/src/lib/ai-gateway/custom-pricing.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.ts
@@ -84,6 +84,14 @@ function applyPricing(pricing: OpenRouterModel['pricing'], customPricing: Pricin
   };
 }
 
+export function applyCustomPricingToPricing(
+  modelId: string,
+  pricing: OpenRouterModel['pricing']
+): OpenRouterModel['pricing'] {
+  const customPricing = getCustomPricing(modelId);
+  return customPricing ? applyPricing(pricing, customPricing.pricing[0].pricing) : pricing;
+}
+
 export function applyCustomPricingToModel(model: OpenRouterModel): OpenRouterModel {
   const customPricing = getCustomPricing(model.id);
   if (!customPricing) return model;


### PR DESCRIPTION
## Summary
- add OpenRouter-compatible per-model endpoints metadata routes, including /v1 aliases for OpenRouter and gateway
- serve endpoint metadata from the cached models_by_provider.openrouter snapshot
- normalize ordinary OpenRouter discounts and apply Kilo custom pricing to every cached endpoint using the same pricing precedence as /models
- return OpenRouter-shaped 404s for absent and forbidden free models
- add 60-second CDN caching with 60-second stale-while-revalidate for successful and 404 responses

## Testing
- focused Jest route, alias, cache-header, and custom-pricing tests
- focused oxlint
- web typecheck