### PR TITLE
fix(mobile): session header pill spacing, centering, hide on load

### DIFF
--- a/.kilo_workflow/learnings/mobile-remote-cli-model-id-prefix.md
+++ b/.kilo_workflow/learnings/mobile-remote-cli-model-id-prefix.md
@@ -1,0 +1,18 @@
+# mobile: remote-cli.sh exec run -m kilo-auto/efficient fails ProviderModelNotFoundError — CLI ids need the kilo/ prefix
+
+Symptom: `apps/mobile/e2e/remote-cli.sh exec run -m kilo-auto/efficient --auto "<prompt>"` fails
+with `ProviderModelNotFoundError` / `Model not found: kilo-auto/efficient`, and the run still
+creates an empty session row in the mobile Agents list.
+
+Cause: the handoff/workflow "kilo-auto/efficient" id is the IN-APP id. The CLI's provider/model
+format needs the provider prefix: `kilo/kilo-auto/efficient` (WORKFLOW.md's "kilo/kilo-auto/* are
+the same models as CLI ids" is the only place this is stated, and it is easy to read past).
+
+Fix: run `apps/mobile/e2e/remote-cli.sh exec models` first and copy the exact id
+(`kilo/kilo-auto/efficient`); never guess from the in-app id. Side effect to expect: each failed
+run leaves an empty `New session - <ts>` row in the session list — harmless, but do not confuse
+it with the content session when picking rows to tap.
+
+Bonus: a fresh E2E account starts with $0 credit; `kilo/kilo-auto/efficient` then fails with
+"Add credits to continue". Seed first:
+`pnpm dev:seed app:user-id <email>` then `pnpm dev:seed app:add-credits <user-id> 10`.

--- a/apps/mobile/src/app/(app)/agent-chat/[session-id].tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/[session-id].tsx
@@ -88,6 +88,7 @@ export default function SessionDetailScreen() {
               info={undefined}
               totalCostMicrodollars={null}
               hasMessages={false}
+              loading
             />
           }
         />

--- a/apps/mobile/src/components/agents/session-context-metrics.tsx
+++ b/apps/mobile/src/components/agents/session-context-metrics.tsx
@@ -16,6 +16,11 @@ type SessionContextMetricsProps = {
   totalCostMicrodollars: number | null;
   hasMessages: boolean;
   onPress?: () => void;
+  /**
+   * Hide the pill while the session page loads; the layout box stays reserved so the header does not
+   * shift.
+   */
+  loading?: boolean;
 };
 
 const RING_SIZE = 28;
@@ -37,11 +42,12 @@ export function SessionContextMetrics({
   totalCostMicrodollars,
   hasMessages,
   onPress,
+  loading = false,
 }: Readonly<SessionContextMetricsProps>) {
   const content = getHeaderPillContent({ info, totalCostMicrodollars, hasMessages });
   // Single source for element kind and a11y affordance wording so a future
   // caller with interactive content but no onPress cannot advertise a tap.
-  const pressable = content.interactive && onPress != null;
+  const pressable = !loading && content.interactive && onPress != null;
   const accessibilityLabel = getMetricsAccessibilityLabel({
     info,
     totalCostMicrodollars,
@@ -52,20 +58,16 @@ export function SessionContextMetrics({
   // NativeWind 5 preview (rem ≈ 14px here), so an arbitrary px value is required
   // for the 44pt minimum touch target; height is identical in every pill state.
   const pillClassName =
-    'h-[44px] flex-row items-center gap-1.5 rounded-full border border-border bg-secondary px-2.5';
+    'h-[44px] flex-row items-center gap-2 rounded-full border border-border bg-secondary px-3';
 
   const body = (
     <>
-      <View className="h-7 w-7 items-center justify-center">
-        <View className="absolute inset-0">
-          <ContextUsageRing
-            size={RING_SIZE}
-            strokeWidth={RING_STROKE}
-            arcFraction={content.arcFraction}
-            tone={content.tone}
-          />
-        </View>
-      </View>
+      <ContextUsageRing
+        size={RING_SIZE}
+        strokeWidth={RING_STROKE}
+        arcFraction={content.arcFraction}
+        tone={content.tone}
+      />
       {content.primary != null ? (
         <View className="flex-row items-baseline gap-1">
           <Text className={cn('text-xs font-semibold tabular-nums', toneTextClass(content.tone))}>
@@ -103,7 +105,10 @@ export function SessionContextMetrics({
   return (
     <View
       accessibilityLabel={accessibilityLabel || undefined}
-      className={pillClassName}
+      {...(loading
+        ? { accessibilityElementsHidden: true, importantForAccessibility: 'no' as const }
+        : {})}
+      className={cn(pillClassName, loading && 'opacity-0')}
       testID="session-context-metrics"
     >
       {body}

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -483,6 +483,7 @@ export function SessionDetailContent({
       info={contextInfo}
       totalCostMicrodollars={totalMicrodollars}
       hasMessages={messages.length > 0}
+      loading={shouldShowLoading}
       onPress={
         contextInfo
           ? () => {


### PR DESCRIPTION
## Summary

Three visual fixes to the session page header pill (`SessionContextMetrics`, the element holding the context ring + percentage + session cost):

1. **Horizontal breathing room** — the ring read cramped against the pill's left edge and the text (`gap-1.5`→`gap-2`, `px-2.5`→`px-3`).
2. **Vertical centering** — the ring is a 28×28 raw-pixel SVG that sat in an `h-7 w-7` wrapper (≈24.5px at NativeWind's rem≈14px in this app). The SVG drew from the wrapper's top-left origin and overflowed 3.5px right/bottom, so its visible center sat ~1.75px low. The wrapper Views are deleted and `ContextUsageRing` now renders directly as a flex child; the pill's existing `items-center` centers its explicit 28px layout box exactly.
3. **Hidden while loading, no CLS** — a new `loading?: boolean` prop renders the pill with `opacity-0` (layout box reserved, non-pressable, hidden from accessibility) while the session page loads. Both call sites pass it: the route-level `sessionQuery.isPending` branch in `[session-id].tsx` and `session-detail-content.tsx` (`loading={shouldShowLoading}`).

**Why:** the pill was optically off-center and cramped, and during loading it showed a meaningless track-only ring that popped into real content on load.

**How:** one mechanism in the component — `loading` gates `pressable` and applies `opacity-0` + a11y-hiding props on the existing non-pressable `View` return. No third return branch, no call-site divergence.

**Simpler-shape decision (recorded from plan review):** a pure `getHeaderPillRenderState` helper + unit tests was considered and rejected — the loading state is one boolean gate on an RN component the node test harness cannot render, so the helper was API surface without product value. Consequently there are **no test changes**: the new behavior is visual-only, covered by the E2E evidence below. The pinned test "keeps a fixed non-interactive pill when context usage is unresolved" is deliberately untouched — it pins *unresolved-but-loaded* behavior, which is preserved; loading is a component prop, not a `getHeaderPillContent` input.

**CLS contract (precise, not overclaimed):** the hidden loading pill reserves its content-sized box (route path: ring-only ~45px; in-content path may include outgoing cost text). Guaranteed: header **height** and the **anchor positions (x/y origins) of the back button and title** are identical loading → loaded. Explicitly not claimed: pill-width or title-width equality — the pill is content-sized and the title text changes at load; that is accepted, documented behavior, not a regression. A guessed fixed-width reservation was considered and rejected as redesign.

## Verification

- [x] `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused && pnpm test` from `apps/mobile/` — all green (283 files / 2434 tests, no suite changes)
- [x] E2E (iPhone 17 Pro simulator, iOS 26.5, real `kilo-auto/efficient` session content — no mocking): loaded pill shows ring + percentage + cost; tap opens the context sheet (interactivity regression check passed)
- [x] E2E: route-level loading state (`kill -STOP` nextjs suspend protocol, strictly scoped) — header title + skeleton visible, pill region pixel-uniform (0 drawn pixels), pill absent from the a11y tree
- [x] E2E: in-content loading state captured on the first attempt — skeleton + composer, hidden pill (same pixel/a11y checks)
- [x] E2E CLS (Maestro `hierarchy`, loading vs loaded): **identical in all three states** — back button `[10,80][34,104]`, title origin `(41,79)`, header container `[0,0][402,124]`. Single-line-title precondition met (session renamed to "T"; loaded title 25pt tall = 1 line). Width equality not asserted per the CLS contract.

Objective pill measurements (3x screenshot pixel analysis): ring annulus exactly 28.0×28.0pt; ring y-center −0.17pt off pill center (sub-pixel — optically centered); ring→text visual gap 8.0pt (`gap-2`); ring 12.3pt from pill left edge, text 11.3pt from right edge (`px-3`).

## Visual Changes

After-only evidence per the brief (the before state is the one described in the user request; reproducing it would need a second stack on a baseline worktree — disproportionate for a spacing change).

| Before | After |
|---|---|
| Ring cramped/off-center; track-only ring pill visible during loading | **Loaded** — ring clear of text and edges, optically centered: ![03-loaded-T-full.png](https://github.com/user-attachments/assets/555793ec-63ad-4b6f-a91d-5dee410d1bf1) |
|  | **Loaded, header close-up**: ![03-loaded-T-header.png](https://github.com/user-attachments/assets/a77c9cbb-ef37-4df0-806a-6c8d9a9ea19d) |
|  | **Route-level loading** — no pill, no header shift: ![04-route-loading-full.png](https://github.com/user-attachments/assets/8298f89a-6e47-4f6d-87ff-235625735395) |
|  | **In-content loading** — no pill, skeleton + composer: ![05-incontent-loading-full.png](https://github.com/user-attachments/assets/5a11e1bd-039f-448a-b712-349e94941e74) |
|  | **Tap opens context sheet** (interactivity unchanged): ![02-context-sheet.png](https://github.com/user-attachments/assets/b97a1932-9866-4a08-a1f6-323367dd4347) |

## Reviewer Notes

- `loading` hidden-wins semantics: if `shouldShowLoading` is true while `contextInfo` already exists, the pill hides — consistent with the loading definition.
- The 44px touch target and pill fixed height are unchanged in every state.
- No Android-specific work; the change is shared RN code. E2E evidence is iOS-only.
- Includes one workflow learning from the E2E run (`.kilo_workflow/learnings/mobile-remote-cli-model-id-prefix.md`): `remote-cli.sh` needs the CLI id `kilo/kilo-auto/efficient`, not the in-app id; fresh E2E accounts need seeded credits.
