### PR TITLE
fix(ai-gateway): hide OpenRouter batch models

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -278,6 +278,23 @@ describe('auto models', () => {
 
     expect(models.data.some(model => model.id === KILO_AUTO_EFFICIENT_MODEL.id)).toBe(true);
   });
+
+  it('excludes OpenRouter batch variants from the public model list', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        createMockResponse({
+          jsonData: {
+            data: [buildModel(), buildModel({ id: 'vendor/model:batch' })],
+          },
+        })
+      )
+    ) as unknown as typeof fetch;
+
+    const models = await getEnhancedOpenRouterModels();
+
+    expect(models.data.some(model => model.id === 'vendor/model')).toBe(true);
+    expect(models.data.some(model => model.id === 'vendor/model:batch')).toBe(false);
+  });
 });
 
 describe('disabled paid Kilo-exclusive model fallback', () => {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -152,6 +152,7 @@ async function enhancedModelList(models: OpenRouterModel[]) {
             m => m.public_id === model.id && shouldSuppressOpenRouterModel(m)
           ) &&
           !isForbiddenFreeModel(model.id) &&
+          !model.id.endsWith(':batch') &&
           !unavailableModels.some(unavailableId => model.id.includes(unavailableId))
       )
       .map(model => {


### PR DESCRIPTION
## Summary
- exclude OpenRouter model IDs ending in `:batch` from the public enhanced model catalog
- preserve raw OpenRouter model data used by metadata synchronization
- add focused regression coverage

## Testing
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/providers/openrouter/index.test.ts` (36 passed)
- `pnpm --filter web exec jest --runInBand src/app/api/openrouter/models/route.test.ts` (4 passed)
- `pnpm --filter web typecheck`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/openrouter/index.ts apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts`
- `pnpm exec oxfmt --list-different apps/web/src/lib/ai-gateway/providers/openrouter/index.ts apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts`
- `git diff --check HEAD^ HEAD`