### PR TITLE
fix(ai-gateway): honor direct BYOK reasoning flags

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
@@ -28,6 +28,13 @@ jest.mock('./direct-byok-definitions', () => ({
         {
           id: 'supported-model',
           name: 'Supported Model',
+          flags: ['reasoning'],
+          context_length: 4096,
+          max_completion_tokens: 1024,
+        },
+        {
+          id: 'non-reasoning-model',
+          name: 'Non-reasoning Model',
           context_length: 4096,
           max_completion_tokens: 1024,
         },
@@ -56,9 +63,9 @@ jest.mock('./direct-byok-definitions', () => ({
 
 async function loadDirectByokModule() {
   const directByokProviders = (await import('./direct-byok-definitions')).default;
-  const { getDirectByokModel } = await import('.');
+  const { getDirectByokModel, getDirectByokModelsForUser } = await import('.');
 
-  return { directByokProviders, getDirectByokModel };
+  return { directByokProviders, getDirectByokModel, getDirectByokModelsForUser };
 }
 
 describe('getDirectByokModel', () => {
@@ -87,5 +94,24 @@ describe('getDirectByokModel', () => {
     expect(result.provider?.id).toBe('chutes-byok');
     expect(directByokProviders[0].models).toHaveBeenCalledTimes(1);
     expect(directByokProviders[1].models).not.toHaveBeenCalled();
+  });
+
+  test('advertises only the reasoning parameter for reasoning models', async () => {
+    const { getDirectByokModelsForUser } = await loadDirectByokModule();
+    const { getBYOKforUser } = await import('@/lib/ai-gateway/byok');
+    jest
+      .mocked(getBYOKforUser)
+      .mockResolvedValueOnce([{ providerId: 'chutes-byok', decryptedAPIKey: 'test-key' }]);
+
+    const models = await getDirectByokModelsForUser('user-id');
+
+    expect(models[0].supported_parameters).toEqual([
+      'max_tokens',
+      'temperature',
+      'tools',
+      'reasoning',
+    ]);
+    expect(models[1].supported_parameters).toEqual(['max_tokens', 'temperature', 'tools']);
+    expect(models.flatMap(model => model.supported_parameters)).not.toContain('include_reasoning');
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
@@ -54,7 +54,9 @@ function convertModel(
       is_moderated: false,
     },
     per_request_limits: null,
-    supported_parameters: ['max_tokens', 'temperature', 'tools', 'reasoning', 'include_reasoning'],
+    supported_parameters: ['max_tokens', 'temperature', 'tools'].concat(
+      model.flags?.includes('reasoning') ? ['reasoning'] : []
+    ),
     default_parameters: {},
     preferredIndex: model.flags?.includes('recommended') ? preferredIndex : undefined,
     hasUserByokAvailable: true,


### PR DESCRIPTION
## Summary
- advertise the `reasoning` supported parameter only for Direct BYOK models carrying the reasoning flag
- remove `include_reasoning` from all Direct BYOK model metadata
- cover reasoning and non-reasoning catalog entries

## Tests
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/providers/direct-byok/index.test.ts`
- `pnpm --filter web typecheck`
- targeted `oxlint` and `oxfmt --list-different` checks