### PR TITLE
fix(ai-gateway): expose Sakana Fugu Ultra

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -295,20 +295,6 @@ describe('auto models', () => {
     expect(models.data.some(model => model.id === 'vendor/model')).toBe(true);
     expect(models.data.some(model => model.id === 'vendor/model:batch')).toBe(false);
   });
-
-  it('includes Sakana Fugu Ultra in the public model list', async () => {
-    global.fetch = jest.fn(() =>
-      Promise.resolve(
-        createMockResponse({
-          jsonData: { data: [buildModel({ id: 'sakana/fugu' })] },
-        })
-      )
-    ) as unknown as typeof fetch;
-
-    const models = await getEnhancedOpenRouterModels();
-
-    expect(models.data.some(model => model.id === 'sakana/fugu')).toBe(true);
-  });
 });
 
 describe('disabled paid Kilo-exclusive model fallback', () => {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -295,6 +295,20 @@ describe('auto models', () => {
     expect(models.data.some(model => model.id === 'vendor/model')).toBe(true);
     expect(models.data.some(model => model.id === 'vendor/model:batch')).toBe(false);
   });
+
+  it('includes Sakana Fugu Ultra in the public model list', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        createMockResponse({
+          jsonData: { data: [buildModel({ id: 'sakana/fugu' })] },
+        })
+      )
+    ) as unknown as typeof fetch;
+
+    const models = await getEnhancedOpenRouterModels();
+
+    expect(models.data.some(model => model.id === 'sakana/fugu')).toBe(true);
+  });
 });
 
 describe('disabled paid Kilo-exclusive model fallback', () => {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -136,10 +136,6 @@ export function shouldSuppressOpenRouterModel(model: KiloExclusiveModel): boolea
   return model.status !== 'disabled' || model.pricing === null;
 }
 
-const unavailableModels = [
-  'sakana/fugu', // this model is not available in the EU
-];
-
 async function enhancedModelList(models: OpenRouterModel[]) {
   const autoModels = buildAutoModels();
   const endpointsMetadata = await getOpenRouterModelsMetadataFromDatabase();
@@ -152,8 +148,7 @@ async function enhancedModelList(models: OpenRouterModel[]) {
             m => m.public_id === model.id && shouldSuppressOpenRouterModel(m)
           ) &&
           !isForbiddenFreeModel(model.id) &&
-          !model.id.endsWith(':batch') &&
-          !unavailableModels.some(unavailableId => model.id.includes(unavailableId))
+          !model.id.endsWith(':batch')
       )
       .map(model => {
         const preferredProvider = getPreferredProviderOrder(model.id).at(0);


### PR DESCRIPTION
## Summary
- remove the hard-coded OpenRouter filter for `sakana/fugu`

## Verification
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/openrouter/index.ts apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts`
- `git diff --check`