### PR TITLE
feat(ai-gateway): derive BYOK variants from models.dev

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
@@ -31,6 +31,9 @@ jest.mock('./direct-byok-definitions', () => ({
           flags: ['reasoning'],
           context_length: 4096,
           max_completion_tokens: 1024,
+          variants: {
+            high: { reasoning: { enabled: true, effort: 'high' } },
+          },
         },
         {
           id: 'non-reasoning-model',
@@ -113,5 +116,28 @@ describe('getDirectByokModel', () => {
     ]);
     expect(models[1].supported_parameters).toEqual(['max_tokens', 'temperature', 'tools']);
     expect(models.flatMap(model => model.supported_parameters)).not.toContain('include_reasoning');
+    expect(models[0].opencode.variants).toEqual({
+      high: { reasoning: { enabled: true, effort: 'high' } },
+    });
+  });
+
+  test('falls back to model-name variants when synced variants are unavailable', async () => {
+    const { getDirectByokModelsForUser } = await loadDirectByokModule();
+    const { getBYOKforUser } = await import('@/lib/ai-gateway/byok');
+    const { getModelVariants } = await import('@/lib/ai-gateway/providers/model-settings');
+    const fallback = { thinking: { reasoning: { enabled: true, effort: 'high' as const } } };
+    jest.mocked(getBYOKforUser).mockResolvedValueOnce([
+      { providerId: 'chutes-byok', decryptedAPIKey: 'test-key' },
+    ]);
+    jest.mocked(getModelVariants).mockReturnValue(fallback);
+
+    const models = await getDirectByokModelsForUser('user-id');
+
+    expect(models[0].opencode.variants).toEqual({
+      high: { reasoning: { enabled: true, effort: 'high' } },
+    });
+    expect(models[1].opencode.variants).toBe(fallback);
+    expect(getModelVariants).toHaveBeenCalledTimes(1);
+    expect(getModelVariants).toHaveBeenCalledWith('chutes-byok/non-reasoning-model');
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
@@ -126,9 +126,9 @@ describe('getDirectByokModel', () => {
     const { getBYOKforUser } = await import('@/lib/ai-gateway/byok');
     const { getModelVariants } = await import('@/lib/ai-gateway/providers/model-settings');
     const fallback = { thinking: { reasoning: { enabled: true, effort: 'high' as const } } };
-    jest.mocked(getBYOKforUser).mockResolvedValueOnce([
-      { providerId: 'chutes-byok', decryptedAPIKey: 'test-key' },
-    ]);
+    jest
+      .mocked(getBYOKforUser)
+      .mockResolvedValueOnce([{ providerId: 'chutes-byok', decryptedAPIKey: 'test-key' }]);
     jest.mocked(getModelVariants).mockReturnValue(fallback);
 
     const models = await getDirectByokModelsForUser('user-id');

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
@@ -62,7 +62,7 @@ function convertModel(
     hasUserByokAvailable: true,
     opencode: {
       ai_sdk_provider: getAiSdkProvider(id, provider.id) ?? provider.default_ai_sdk_provider,
-      variants: getModelVariants(id),
+      variants: model.variants ?? getModelVariants(id),
     } satisfies OpenCodeSettings,
   };
 }

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/model-list.ts
@@ -6,7 +6,6 @@ import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/provide
 import { createCachedFetch } from '@/lib/cached-fetch';
 import { redisClient } from '@/lib/redis';
 import { directByokModelsRedisKey } from '@/lib/redis-keys';
-import type { OpenCodeVariant } from '@kilocode/db/schema-types';
 
 type CachedEnhancedModelListOptions = {
   providerId: DirectUserByokInferenceProviderId;
@@ -36,9 +35,9 @@ function enhanceDirectByokModelList({
 }: {
   recommendedModels: ReadonlyArray<DirectByokModel>;
   remainingModels: ReadonlyArray<DirectByokModel>;
-  variants?: Record<string, OpenCodeVariant>;
 }): ReadonlyArray<DirectByokModel> {
   const seenIds = new Set<string>();
+  const syncedModels = new Map(remainingModels.map(model => [model.id, model]));
   return [...recommendedModels, ...remainingModels]
     .filter(model => (seenIds.has(model.id) ? false : (seenIds.add(model.id), true)))
     .map(model => {
@@ -47,6 +46,7 @@ function enhanceDirectByokModelList({
       return {
         ...model,
         flags: flags.size > 0 ? [...flags] : undefined,
+        variants: model.variants ?? syncedModels.get(model.id)?.variants,
       };
     });
 }

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -68,7 +68,6 @@ describe('parseModelsDevProviderModels', () => {
           reasoning_options: [
             { type: 'toggle' },
             { type: 'effort', values: ['high', 'max', 'default', null] },
-            { type: 'budget_tokens', min: 0, max: 32_000 },
           ],
           limit: { context: 128_000, output: 32_000 },
           modalities: { input: ['text', 'image'], output: ['text'] },
@@ -146,6 +145,24 @@ describe('parseModelsDevProviderModels', () => {
         variants: {},
       },
     ]);
+  });
+
+  test('ignores reasoning option types that are not supported locally', () => {
+    const models = parseModelsDevProviderModels({
+      models: {
+        futureControl: {
+          id: 'future-control',
+          reasoning: true,
+          reasoning_options: [{ type: 'budget_tokens', min: 0, max: 32_000 }],
+        },
+      },
+    });
+
+    expect(models[0]).toMatchObject({
+      id: 'future-control',
+      flags: ['reasoning'],
+      variants: {},
+    });
   });
 
   test('excludes models missing from the provider model list', () => {

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -134,7 +134,7 @@ describe('parseModelsDevProviderModels', () => {
         max_completion_tokens: undefined,
         input_modalities: undefined,
         flags: undefined,
-        variants: undefined,
+        variants: {},
       },
       {
         id: 'unknown-status',
@@ -143,7 +143,7 @@ describe('parseModelsDevProviderModels', () => {
         max_completion_tokens: undefined,
         input_modalities: undefined,
         flags: undefined,
-        variants: undefined,
+        variants: {},
       },
     ]);
   });

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -133,7 +133,7 @@ describe('parseModelsDevProviderModels', () => {
         max_completion_tokens: undefined,
         input_modalities: undefined,
         flags: undefined,
-        variants: {},
+        variants: undefined,
       },
       {
         id: 'unknown-status',
@@ -142,7 +142,7 @@ describe('parseModelsDevProviderModels', () => {
         max_completion_tokens: undefined,
         input_modalities: undefined,
         flags: undefined,
-        variants: {},
+        variants: undefined,
       },
     ]);
   });
@@ -161,8 +161,8 @@ describe('parseModelsDevProviderModels', () => {
     expect(models[0]).toMatchObject({
       id: 'future-control',
       flags: ['reasoning'],
-      variants: {},
     });
+    expect(models[0].variants).toBeUndefined();
   });
 
   test('excludes models missing from the provider model list', () => {

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -59,46 +59,49 @@ describe('parseOpenAICompatibleProviderModels', () => {
 
 describe('parseModelsDevProviderModels', () => {
   test('excludes deprecated and non-text-output models while retaining other statuses', () => {
-    const models = parseModelsDevProviderModels({
-      models: {
-        stable: {
-          id: 'stable',
-          name: 'provider/stable',
-          reasoning: true,
-          reasoning_options: [
-            { type: 'toggle' },
-            { type: 'effort', values: ['high', 'max', 'default', null] },
-          ],
-          limit: { context: 128_000, output: 32_000 },
-          modalities: { input: ['text', 'image'], output: ['text'] },
-        },
-        alpha: {
-          id: 'alpha',
-          status: 'alpha',
-          reasoning: true,
-          reasoning_options: [{ type: 'toggle' }],
-        },
-        beta: {
-          id: 'beta',
-          status: 'beta',
-          reasoning: false,
-        },
-        unknownStatus: {
-          id: 'unknown-status',
-          status: 'active',
-        },
-        deprecated: {
-          id: 'mimo-v2-omni',
-          name: 'MiMo V2 Omni',
-          status: 'deprecated',
-        },
-        imageOnly: {
-          id: 'wan2.7-image',
-          name: 'Wan2.7 Image',
-          modalities: { input: ['text'], output: ['image'] },
+    const models = parseModelsDevProviderModels(
+      {
+        models: {
+          stable: {
+            id: 'stable',
+            name: 'provider/stable',
+            reasoning: true,
+            reasoning_options: [
+              { type: 'toggle' },
+              { type: 'effort', values: ['high', 'max', 'default', null] },
+            ],
+            limit: { context: 128_000, output: 32_000 },
+            modalities: { input: ['text', 'image'], output: ['text'] },
+          },
+          alpha: {
+            id: 'alpha',
+            status: 'alpha',
+            reasoning: true,
+            reasoning_options: [{ type: 'toggle' }],
+          },
+          beta: {
+            id: 'beta',
+            status: 'beta',
+            reasoning: false,
+          },
+          unknownStatus: {
+            id: 'unknown-status',
+            status: 'active',
+          },
+          deprecated: {
+            id: 'mimo-v2-omni',
+            name: 'MiMo V2 Omni',
+            status: 'deprecated',
+          },
+          imageOnly: {
+            id: 'wan2.7-image',
+            name: 'Wan2.7 Image',
+            modalities: { input: ['text'], output: ['image'] },
+          },
         },
       },
-    });
+      'alibaba-token-plan'
+    );
 
     expect(models).toEqual([
       {
@@ -148,21 +151,65 @@ describe('parseModelsDevProviderModels', () => {
   });
 
   test('ignores reasoning option types that are not supported locally', () => {
-    const models = parseModelsDevProviderModels({
-      models: {
-        futureControl: {
-          id: 'future-control',
-          reasoning: true,
-          reasoning_options: [{ type: 'budget_tokens', min: 0, max: 32_000 }],
+    const models = parseModelsDevProviderModels(
+      {
+        models: {
+          futureControl: {
+            id: 'future-control',
+            reasoning: true,
+            reasoning_options: [{ type: 'budget_tokens', min: 0, max: 32_000 }],
+          },
         },
       },
-    });
+      'alibaba-token-plan'
+    );
 
     expect(models[0]).toMatchObject({
       id: 'future-control',
       flags: ['reasoning'],
     });
     expect(models[0].variants).toBeUndefined();
+  });
+
+  test('sets verbosity from effort for Anthropic-backed models', () => {
+    const models = parseModelsDevProviderModels(
+      {
+        models: {
+          qwen: {
+            id: 'qwen-test',
+            reasoning: true,
+            reasoning_options: [{ type: 'toggle' }, { type: 'effort', values: ['low', 'high'] }],
+          },
+        },
+      },
+      'opencode-go'
+    );
+
+    expect(models[0].variants).toEqual({
+      none: { reasoning: { enabled: false, effort: 'none' } },
+      low: { reasoning: { enabled: true, effort: 'low' }, verbosity: 'low' },
+      high: { reasoning: { enabled: true, effort: 'high' }, verbosity: 'high' },
+    });
+  });
+
+  test('sets verbosity on fallback variants for Anthropic-backed models', () => {
+    const models = parseModelsDevProviderModels(
+      {
+        models: {
+          qwen: {
+            id: 'qwen-test',
+            reasoning: true,
+            reasoning_options: [{ type: 'toggle' }, { type: 'budget_tokens', max: 32_000 }],
+          },
+        },
+      },
+      'opencode-go'
+    );
+
+    expect(models[0].variants).toEqual({
+      instant: { reasoning: { enabled: false, effort: 'none' } },
+      thinking: { reasoning: { enabled: true, effort: 'high' }, verbosity: 'high' },
+    });
   });
 
   test('excludes models missing from the provider model list', () => {
@@ -173,6 +220,7 @@ describe('parseModelsDevProviderModels', () => {
           removed: { id: 'removed', limit: { context: 64_000 } },
         },
       },
+      'alibaba-token-plan',
       new Set(['available', 'provider-only'])
     );
 

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -65,12 +65,19 @@ describe('parseModelsDevProviderModels', () => {
           id: 'stable',
           name: 'provider/stable',
           reasoning: true,
+          reasoning_options: [
+            { type: 'toggle' },
+            { type: 'effort', values: ['high', 'max', 'default', null] },
+            { type: 'budget_tokens', min: 0, max: 32_000 },
+          ],
           limit: { context: 128_000, output: 32_000 },
           modalities: { input: ['text', 'image'], output: ['text'] },
         },
         alpha: {
           id: 'alpha',
           status: 'alpha',
+          reasoning: true,
+          reasoning_options: [{ type: 'toggle' }],
         },
         beta: {
           id: 'beta',
@@ -102,6 +109,11 @@ describe('parseModelsDevProviderModels', () => {
         max_completion_tokens: 32_000,
         input_modalities: ['text', 'image'],
         flags: ['reasoning'],
+        variants: {
+          none: { reasoning: { enabled: false, effort: 'none' } },
+          high: { reasoning: { enabled: true, effort: 'high' } },
+          max: { reasoning: { enabled: true, effort: 'max' } },
+        },
       },
       {
         id: 'alpha',
@@ -109,7 +121,11 @@ describe('parseModelsDevProviderModels', () => {
         context_length: undefined,
         max_completion_tokens: undefined,
         input_modalities: undefined,
-        flags: undefined,
+        flags: ['reasoning'],
+        variants: {
+          instant: { reasoning: { enabled: false, effort: 'none' } },
+          thinking: { reasoning: { enabled: true, effort: 'high' } },
+        },
       },
       {
         id: 'beta',
@@ -118,6 +134,7 @@ describe('parseModelsDevProviderModels', () => {
         max_completion_tokens: undefined,
         input_modalities: undefined,
         flags: undefined,
+        variants: undefined,
       },
       {
         id: 'unknown-status',
@@ -126,6 +143,7 @@ describe('parseModelsDevProviderModels', () => {
         max_completion_tokens: undefined,
         input_modalities: undefined,
         flags: undefined,
+        variants: undefined,
       },
     ]);
   });

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -36,18 +36,13 @@ const ModelsDevReasoningOptionSchema = z.discriminatedUnion('type', [
     type: z.literal('effort'),
     values: z.array(z.union([z.null(), ReasoningEffortSchema, z.literal('default')])),
   }),
-  z.object({
-    type: z.literal('budget_tokens'),
-    min: z.number().optional(),
-    max: z.number().optional(),
-  }),
 ]);
 
 const ModelsDevModelSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
   reasoning: z.boolean().optional(),
-  reasoning_options: z.array(ModelsDevReasoningOptionSchema).optional(),
+  reasoning_options: z.array(ModelsDevReasoningOptionSchema).optional().catch(undefined),
   status: z.enum(['alpha', 'beta', 'deprecated']).optional().catch(undefined),
   limit: z
     .object({
@@ -132,11 +127,11 @@ export function parseOpenAICompatibleProviderModels(entry: unknown): RawModel[] 
 }
 
 function modelsDevReasoningOptionsToVariants(
-  options: ReadonlyArray<z.infer<typeof ModelsDevReasoningOptionSchema>> | undefined
+  options: ReadonlyArray<z.infer<typeof ModelsDevReasoningOptionSchema>>
 ): NonNullable<OpenCodeSettings['variants']> {
-  const hasToggle = options?.some(option => option.type === 'toggle') ?? false;
+  const hasToggle = options.some(option => option.type === 'toggle');
   const effortVariants: NonNullable<OpenCodeSettings['variants']> = {};
-  for (const option of options ?? []) {
+  for (const option of options) {
     if (option.type !== 'effort') continue;
     for (const value of option.values) {
       const effort = ReasoningEffortSchema.safeParse(value);
@@ -177,7 +172,7 @@ export function parseModelsDevProviderModels(
       max_completion_tokens: model.limit?.output,
       input_modalities: model.modalities?.input,
       flags: model.reasoning ? ['reasoning'] : undefined,
-      variants: modelsDevReasoningOptionsToVariants(model.reasoning_options),
+      variants: modelsDevReasoningOptionsToVariants(model.reasoning_options ?? []),
     }));
 }
 

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -132,12 +132,10 @@ export function parseOpenAICompatibleProviderModels(entry: unknown): RawModel[] 
 
 function modelsDevReasoningOptionsToVariants(
   options: ReadonlyArray<z.infer<typeof ModelsDevReasoningOptionSchema>> | undefined
-): OpenCodeSettings['variants'] {
-  if (!options) return undefined;
-
-  const hasToggle = options.some(option => option.type === 'toggle');
+): NonNullable<OpenCodeSettings['variants']> {
+  const hasToggle = options?.some(option => option.type === 'toggle') ?? false;
   const effortVariants: NonNullable<OpenCodeSettings['variants']> = {};
-  for (const option of options) {
+  for (const option of options ?? []) {
     if (option.type !== 'effort') continue;
     for (const value of option.values) {
       const effort = ReasoningEffortSchema.safeParse(value);
@@ -159,7 +157,7 @@ function modelsDevReasoningOptionsToVariants(
       thinking: { reasoning: { enabled: true, effort: 'high' } },
     };
   }
-  return undefined;
+  return {};
 }
 
 export function parseModelsDevProviderModels(

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -7,6 +7,7 @@ import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/provide
 import { redisClient } from '@/lib/redis';
 import { directByokModelsRedisKey } from '@/lib/redis-keys';
 import { ReasoningEffortSchema, type OpenCodeSettings } from '@kilocode/db/schema-types';
+import { REASONING_VARIANTS_BINARY } from '@/lib/ai-gateway/providers/model-settings';
 
 const DEFAULT_CONTENT_LENGTH = 200_000;
 const DEFAULT_MAX_COMPLETION_TOKENS = 32_000;
@@ -152,10 +153,7 @@ function modelsDevReasoningOptionsToVariants(
       : effortVariants;
   }
   if (hasToggle) {
-    return {
-      instant: { reasoning: { enabled: false, effort: 'none' } },
-      thinking: { reasoning: { enabled: true, effort: 'high' } },
-    };
+    return REASONING_VARIANTS_BINARY;
   }
   return {};
 }

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -6,6 +6,7 @@ import {
 import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { redisClient } from '@/lib/redis';
 import { directByokModelsRedisKey } from '@/lib/redis-keys';
+import { ReasoningEffortSchema, type OpenCodeSettings } from '@kilocode/db/schema-types';
 
 const DEFAULT_CONTENT_LENGTH = 200_000;
 const DEFAULT_MAX_COMPLETION_TOKENS = 32_000;
@@ -28,10 +29,24 @@ const OpenAICompatibleModelsResponseSchema = z.object({
   ),
 });
 
+const ModelsDevReasoningOptionSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('toggle') }),
+  z.object({
+    type: z.literal('effort'),
+    values: z.array(z.union([z.null(), ReasoningEffortSchema, z.literal('default')])),
+  }),
+  z.object({
+    type: z.literal('budget_tokens'),
+    min: z.number().optional(),
+    max: z.number().optional(),
+  }),
+]);
+
 const ModelsDevModelSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
   reasoning: z.boolean().optional(),
+  reasoning_options: z.array(ModelsDevReasoningOptionSchema).optional(),
   status: z.enum(['alpha', 'beta', 'deprecated']).optional().catch(undefined),
   limit: z
     .object({
@@ -62,6 +77,7 @@ type RawModel = {
   max_completion_tokens?: number;
   input_modalities?: ReadonlyArray<z.infer<typeof ModalitySchema>>;
   flags?: ReadonlyArray<DirectByokModelFlag>;
+  variants?: OpenCodeSettings['variants'];
 };
 
 type SyncContext = {
@@ -114,6 +130,38 @@ export function parseOpenAICompatibleProviderModels(entry: unknown): RawModel[] 
     }));
 }
 
+function modelsDevReasoningOptionsToVariants(
+  options: ReadonlyArray<z.infer<typeof ModelsDevReasoningOptionSchema>> | undefined
+): OpenCodeSettings['variants'] {
+  if (!options) return undefined;
+
+  const hasToggle = options.some(option => option.type === 'toggle');
+  const effortVariants: NonNullable<OpenCodeSettings['variants']> = {};
+  for (const option of options) {
+    if (option.type !== 'effort') continue;
+    for (const value of option.values) {
+      const effort = ReasoningEffortSchema.safeParse(value);
+      if (!effort.success) continue;
+      effortVariants[effort.data] = {
+        reasoning: { enabled: effort.data !== 'none', effort: effort.data },
+      };
+    }
+  }
+
+  if (Object.keys(effortVariants).length > 0) {
+    return hasToggle && !effortVariants.none
+      ? { none: { reasoning: { enabled: false, effort: 'none' } }, ...effortVariants }
+      : effortVariants;
+  }
+  if (hasToggle) {
+    return {
+      instant: { reasoning: { enabled: false, effort: 'none' } },
+      thinking: { reasoning: { enabled: true, effort: 'high' } },
+    };
+  }
+  return undefined;
+}
+
 export function parseModelsDevProviderModels(
   entry: unknown,
   availableModelIds?: ReadonlySet<string>
@@ -133,6 +181,7 @@ export function parseModelsDevProviderModels(
       max_completion_tokens: model.limit?.output,
       input_modalities: model.modalities?.input,
       flags: model.reasoning ? ['reasoning'] : undefined,
+      variants: modelsDevReasoningOptionsToVariants(model.reasoning_options),
     }));
 }
 
@@ -246,6 +295,7 @@ async function syncProvider(fetcher: ProviderFetcher, ctx: SyncContext): Promise
       flags: flags.size > 0 ? [...flags] : undefined,
       context_length,
       max_completion_tokens,
+      variants: raw.variants,
     });
   }
 

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -6,8 +6,16 @@ import {
 import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { redisClient } from '@/lib/redis';
 import { directByokModelsRedisKey } from '@/lib/redis-keys';
-import { ReasoningEffortSchema, type OpenCodeSettings } from '@kilocode/db/schema-types';
-import { REASONING_VARIANTS_BINARY } from '@/lib/ai-gateway/providers/model-settings';
+import {
+  ReasoningEffortSchema,
+  VerbositySchema,
+  type OpenCodeSettings,
+} from '@kilocode/db/schema-types';
+import {
+  getAiSdkProvider,
+  getModelVariants,
+  REASONING_VARIANTS_BINARY,
+} from '@/lib/ai-gateway/providers/model-settings';
 
 const DEFAULT_CONTENT_LENGTH = 200_000;
 const DEFAULT_MAX_COMPLETION_TOKENS = 32_000;
@@ -153,8 +161,23 @@ function modelsDevReasoningOptionsToVariants(
   return undefined;
 }
 
+function addAnthropicVariantVerbosity(
+  variants: OpenCodeSettings['variants'],
+  aiSdkProvider: OpenCodeSettings['ai_sdk_provider']
+): OpenCodeSettings['variants'] {
+  if (aiSdkProvider !== 'anthropic' || !variants) return variants;
+
+  return Object.fromEntries(
+    Object.entries(variants).map(([name, variant]) => {
+      const verbosity = VerbositySchema.safeParse(variant.reasoning?.effort);
+      return [name, verbosity.success ? { ...variant, verbosity: verbosity.data } : variant];
+    })
+  );
+}
+
 export function parseModelsDevProviderModels(
   entry: unknown,
+  providerId: DirectUserByokInferenceProviderId,
   availableModelIds?: ReadonlySet<string>
 ): RawModel[] {
   const provider = ModelsDevProviderSchema.parse(entry);
@@ -165,15 +188,22 @@ export function parseModelsDevProviderModels(
         (!model.modalities?.output || model.modalities.output.includes('text')) &&
         (!availableModelIds || availableModelIds.has(model.id))
     )
-    .map(model => ({
-      id: model.id,
-      name: shortenDisplayName(model.name),
-      context_length: model.limit?.context,
-      max_completion_tokens: model.limit?.output,
-      input_modalities: model.modalities?.input,
-      flags: model.reasoning ? ['reasoning'] : undefined,
-      variants: modelsDevReasoningOptionsToVariants(model.reasoning_options ?? []),
-    }));
+    .map(model => {
+      const modelId = `${providerId}/${model.id}`.toLowerCase();
+      const aiSdkProvider = getAiSdkProvider(modelId, providerId);
+      const variants =
+        modelsDevReasoningOptionsToVariants(model.reasoning_options ?? []) ??
+        getModelVariants(modelId);
+      return {
+        id: model.id,
+        name: shortenDisplayName(model.name),
+        context_length: model.limit?.context,
+        max_completion_tokens: model.limit?.output,
+        input_modalities: model.modalities?.input,
+        flags: model.reasoning ? ['reasoning'] : undefined,
+        variants: addAnthropicVariantVerbosity(variants, aiSdkProvider),
+      };
+    });
 }
 
 function modelsDevFetcher(
@@ -190,7 +220,7 @@ function modelsDevFetcher(
         throw new Error(`models.dev catalog missing ${catalogKey} entry`);
       }
       if (!availableModelsUrl) {
-        return parseModelsDevProviderModels(entry);
+        return parseModelsDevProviderModels(entry, providerId);
       }
       const response = await fetch(availableModelsUrl);
       if (!response.ok) {
@@ -203,7 +233,7 @@ function modelsDevFetcher(
           model => model.id
         )
       );
-      return parseModelsDevProviderModels(entry, availableModelIds);
+      return parseModelsDevProviderModels(entry, providerId, availableModelIds);
     },
   };
 }

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -128,7 +128,7 @@ export function parseOpenAICompatibleProviderModels(entry: unknown): RawModel[] 
 
 function modelsDevReasoningOptionsToVariants(
   options: ReadonlyArray<z.infer<typeof ModelsDevReasoningOptionSchema>>
-): NonNullable<OpenCodeSettings['variants']> {
+): OpenCodeSettings['variants'] {
   const hasToggle = options.some(option => option.type === 'toggle');
   const effortVariants: NonNullable<OpenCodeSettings['variants']> = {};
   for (const option of options) {
@@ -150,7 +150,7 @@ function modelsDevReasoningOptionsToVariants(
   if (hasToggle) {
     return REASONING_VARIANTS_BINARY;
   }
-  return {};
+  return undefined;
 }
 
 export function parseModelsDevProviderModels(

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/types.ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 import type { DirectByokProviderMetaId } from '@/lib/ai-gateway/providers/direct-byok/direct-byok-meta';
 import type { GatewayChatApiKind, TransformRequestContext } from '@/lib/ai-gateway/providers/types';
 import type { CustomLlmProvider } from '@kilocode/db';
+import { OpenCodeVariantSchema } from '@kilocode/db/schema-types';
 
 export const DirectByokModelFlagSchema = z.enum(['recommended', 'vision', 'reasoning']);
 
@@ -13,6 +14,7 @@ export const DirectByokModelSchema = z.object({
   flags: z.array(DirectByokModelFlagSchema).readonly().optional(),
   context_length: z.number(),
   max_completion_tokens: z.number(),
+  variants: z.record(z.string(), OpenCodeVariantSchema).optional(),
 });
 
 export const DirectByokModelArraySchema = z.array(DirectByokModelSchema);

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -105,12 +105,7 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
   if (isKimiModel(model)) {
     return REASONING_VARIANTS_MAX_HIGH_LOW;
   }
-  if (
-    isMinimaxModel(model) ||
-    isGrok42Model(model) ||
-    isQwenModel(model) ||
-    isGemmaModel(model)
-  ) {
+  if (isMinimaxModel(model) || isGrok42Model(model) || isQwenModel(model) || isGemmaModel(model)) {
     return REASONING_VARIANTS_BINARY;
   }
   if (model === seed_20_code_free_model.public_id) {

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -105,7 +105,13 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
   if (isKimiModel(model)) {
     return REASONING_VARIANTS_MAX_HIGH_LOW;
   }
-  if (isMinimaxModel(model) || isGrok42Model(model) || isQwenModel(model) || isGemmaModel(model)) {
+  if (
+    isMinimaxModel(model) ||
+    isGrok42Model(model) ||
+    isQwenModel(model) ||
+    isGemmaModel(model) ||
+    model.includes('mimo')
+  ) {
     return REASONING_VARIANTS_BINARY;
   }
   if (model === seed_20_code_free_model.public_id) {

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -50,11 +50,6 @@ export const REASONING_VARIANTS_NONE_MINIMAL_LOW_MEDIUM_HIGH = {
   ...REASONING_VARIANTS_MINIMAL_LOW_MEDIUM_HIGH,
 } as const;
 
-export const REASONING_VARIANTS_NONE_LOW_MEDIUM_HIGH = {
-  none: { reasoning: { enabled: false, effort: 'none' } },
-  ...REASONING_VARIANTS_LOW_MEDIUM_HIGH,
-} as const;
-
 export const REASONING_VARIANTS_NONE_HIGH_XHIGH = {
   none: { reasoning: { enabled: false, effort: 'none' } },
   high: { reasoning: { enabled: true, effort: 'high' } },
@@ -114,8 +109,7 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
     isMinimaxModel(model) ||
     isGrok42Model(model) ||
     isQwenModel(model) ||
-    isGemmaModel(model) ||
-    model.includes('mimo')
+    isGemmaModel(model)
   ) {
     return REASONING_VARIANTS_BINARY;
   }


### PR DESCRIPTION
## Summary
- derive OpenCode reasoning variants for models.dev-backed direct BYOK models from provider-specific `reasoning_options`
- translate supported `toggle` and `effort` controls, reusing the shared binary `instant`/`thinking` variants for toggle-only models
- resolve the AI SDK provider during models.dev sync and set Anthropic variant verbosity to the corresponding supported reasoning effort
- apply model-family fallback during sync when models.dev controls are absent or unsupported, including Anthropic verbosity on fallback variants
- persist variants on `DirectByokModel` and carry synced variants onto overlapping recommended model entries
- tolerate unsupported or future reasoning option types without failing sync
- keep OpenAI-compatible fetched models and OpenRouter models on the existing conversion-time model-family fallback path
- remove the now-unused `REASONING_VARIANTS_NONE_LOW_MEDIUM_HIGH` constant

## Examples

`zai-coding/glm-5.2` exposes the catalog-provided `high` and `max` efforts:

```json
{
  "high": { "reasoning": { "enabled": true, "effort": "high" } },
  "max": { "reasoning": { "enabled": true, "effort": "max" } }
}
```

`opencode-go/minimax-m3` uses the Anthropic SDK and a catalog `toggle`, so its enabled variant also gets matching verbosity:

```json
{
  "instant": { "reasoning": { "enabled": false, "effort": "none" } },
  "thinking": {
    "reasoning": { "enabled": true, "effort": "high" },
    "verbosity": "high"
  }
}
```

`opencode-go/qwen3.7-plus` includes unsupported `budget_tokens`, so it falls back to the Qwen binary variants and still receives Anthropic verbosity:

```json
{
  "instant": { "reasoning": { "enabled": false, "effort": "none" } },
  "thinking": {
    "reasoning": { "enabled": true, "effort": "high" },
    "verbosity": "high"
  }
}
```

The disabled variants omit verbosity because `none` is not a valid `VerbositySchema` value.

## Verification
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts src/lib/ai-gateway/providers/direct-byok/index.test.ts` (11 tests passed)
- `pnpm --filter web typecheck`
- targeted `oxlint` on all changed files
- formatting and `git diff --check`