### PR TITLE
refactor(ai-gateway): clarify usage/generation cost mismatch warning

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -1253,11 +1253,19 @@ export async function processTokenData(
     genStats.status_code = usageStats.status_code; // retain by choice
     genStats.streamed ??= usageContext.isStreaming;
     if (genStats.cost_mUsd !== usageStats.cost_mUsd) {
+      // The provider's generation lookup and the response's own usage payload should
+      // yield the same cost. A mismatch means inconsistent token or pricing data from
+      // the provider; the generation lookup values win (see assignment below).
       console.warn(
-        `DEV ODDITY / WARNING: Usage stats do not match generation data:`,
-        genStats.model,
-        [genStats.cost_mUsd, usageStats.cost_mUsd],
-        [genStats.cacheDiscount_mUsd, usageStats.cacheDiscount_mUsd]
+        'Cost from provider generation lookup differs from cost computed from response usage data:',
+        {
+          model: genStats.model,
+          cost_mUsd: { generation: genStats.cost_mUsd, response: usageStats.cost_mUsd },
+          cacheDiscount_mUsd: {
+            generation: genStats.cacheDiscount_mUsd,
+            response: usageStats.cacheDiscount_mUsd,
+          },
+        }
       );
     }
     usageStats = genStats;


### PR DESCRIPTION
Rewords the dev-only warning in `processTokenData` that fires when the provider's generation lookup yields a different `cost_mUsd` than the response's own usage payload:

- Before: `DEV ODDITY / WARNING: Usage stats do not match generation data:` followed by two unlabeled `[a, b]` arrays.
- After: an explicit message stating what is being compared, with labeled values (`generation` vs `response`) for `cost_mUsd` and `cacheDiscount_mUsd`, plus a comment noting the generation lookup values win.

No behavior change; warning text and structure only.