### PR TITLE
feat(bitbucket) blobless wrapper

### DIFF
--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -266,6 +266,52 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     // blob could never be lazily fetched — it keeps a normal full clone.
     const cloneCall = gitCalls.find(args => args[0] === 'clone');
     expect(cloneCall).not.toContain('--filter=blob:none');
+    // The raw-token origin is stripped to a credential-free URL.
+    expect(gitCalls.some(args => args[0] === 'remote' && args[1] === 'set-url')).toBe(true);
+  });
+
+  it('uses a blobless clone and keeps the capability origin for a contained Bitbucket review session', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+    request.repo = {
+      kind: 'git',
+      url: 'https://bitbucket.org/acme/repo.git',
+      token: 'kbb1.opaque-capability',
+      platform: 'bitbucket',
+    };
+    request.workspace.branchName = 'feature/login';
+
+    const gitCalls: string[][] = [];
+    await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          gitCalls.push(args);
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    // A capability origin stays authenticated through the outbound interceptor,
+    // so the clone is blobless and the origin is NOT stripped.
+    expect(gitCalls.find(args => args[0] === 'clone')).toContain('--filter=blob:none');
+    expect(gitCalls.some(args => args[0] === 'remote' && args[1] === 'set-url')).toBe(false);
   });
 
   it('uses a blobless partial clone for GitLab review sessions', async () => {

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -345,14 +345,30 @@ function isBitbucketReviewSession(
   return isCodeReviewSession(request) && repo?.kind === 'git' && repo.platform === 'bitbucket';
 }
 
+// Wire-format prefix of a Bitbucket outbound session capability (see the
+// git-token-service BitbucketSessionCapabilityCodec). A capability in the origin
+// stays authenticated through the outbound interceptor, unlike a raw token which
+// is stripped after bootstrap.
+const BITBUCKET_CAPABILITY_PREFIX = 'kbb1.';
+
+function hasBitbucketReviewCapability(request: WrapperSessionReadyRequest): boolean {
+  return (
+    isBitbucketReviewSession(request) &&
+    typeof request.repo.token === 'string' &&
+    request.repo.token.startsWith(BITBUCKET_CAPABILITY_PREFIX)
+  );
+}
+
 function isBloblessReviewCloneEligible(request: WrapperSessionReadyRequest): boolean {
   if (!isCodeReviewSession(request)) return false;
   const repo = request.repo;
-  // Only GitHub and GitLab: their session origin keeps working credentials via
-  // outbound injection, so blobs deferred by a partial clone can be fetched
-  // lazily during the review. Bitbucket's origin is credential-stripped, and
-  // other/unknown git remotes have no such guarantee, so they keep a full clone.
-  return repo?.kind === 'github' || (repo?.kind === 'git' && repo.platform === 'gitlab');
+  // GitHub/GitLab keep working credentials via outbound injection. Bitbucket
+  // keeps them only when the session uses an outbound capability (a raw-token
+  // origin is credential-stripped after bootstrap). Other/unknown git remotes
+  // have no such guarantee, so they keep a full clone.
+  if (repo?.kind === 'github') return true;
+  if (repo?.kind === 'git' && repo.platform === 'gitlab') return true;
+  return hasBitbucketReviewCapability(request);
 }
 
 async function cloneRepository(
@@ -539,11 +555,19 @@ async function sanitizeBitbucketCodeReviewRemote(
   request: WrapperSessionReadyRequest,
   runGit: GitRunner
 ): Promise<boolean> {
-  // Single source of truth with the blobless-skip check in cloneRepository: the
-  // filter is skipped for exactly this session type because this function strips
-  // origin credentials, which would break a partial clone's later blob fetches.
   if (!isBitbucketReviewSession(request)) {
     return false;
+  }
+  // A capability origin stays authenticated through the outbound interceptor and
+  // is safe to expose (scoped to one repo, useless outside this container), so it
+  // must stay in place for a blobless clone's later lazy blob fetches. Only a raw
+  // workspace token needs stripping. Either way this is a handled code-review
+  // remote (return true), so callers do not refresh a token over it.
+  if (
+    typeof request.repo.token === 'string' &&
+    request.repo.token.startsWith(BITBUCKET_CAPABILITY_PREFIX)
+  ) {
+    return true;
   }
   const canonicalUrl = new URL(request.repo.url);
   canonicalUrl.username = '';

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -563,10 +563,7 @@ async function sanitizeBitbucketCodeReviewRemote(
   // must stay in place for a blobless clone's later lazy blob fetches. Only a raw
   // workspace token needs stripping. Either way this is a handled code-review
   // remote (return true), so callers do not refresh a token over it.
-  if (
-    typeof request.repo.token === 'string' &&
-    request.repo.token.startsWith(BITBUCKET_CAPABILITY_PREFIX)
-  ) {
+  if (hasBitbucketReviewCapability(request)) {
     return true;
   }
   const canonicalUrl = new URL(request.repo.url);

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -385,14 +385,14 @@ async function cloneRepository(
   const gitUrl = repo.kind === 'github' ? `https://github.com/${repo.repo}.git` : repo.url;
   const platform = repo.kind === 'git' ? repo.platform : 'github';
   const repoUrl = authenticatedUrl(gitUrl, repo.token, platform);
-  // GitHub/GitLab code review reads changed files from the working tree and gets
-  // the PR diff from the provider API or a local `git diff <prev>..HEAD`. It needs
-  // the full commit graph but not every historical file blob, so a blobless
-  // partial clone keeps the clone bounded by the current working tree (git fetches
-  // blobs lazily on demand) instead of full history, which on large repositories
-  // otherwise exceeds the clone timeout. Full history is retained, so incremental
-  // diffs and merge-base still work. See isBloblessReviewCloneEligible for why
-  // only GitHub/GitLab qualify.
+  // Code review reads changed files from the working tree and gets the PR diff
+  // from the provider API or a local `git diff <prev>..HEAD`. It needs the full
+  // commit graph but not every historical file blob, so a blobless partial clone
+  // fetches blobs lazily on demand instead of downloading every historical blob,
+  // which on large repositories otherwise exceeds the clone timeout. Full history
+  // is retained, so incremental diffs and merge-base still work. See
+  // isBloblessReviewCloneEligible for which sessions qualify (GitHub, GitLab, and
+  // capability-backed Bitbucket, whose origin stays authenticated for lazy fetch).
   const useBlobless = isBloblessReviewCloneEligible(request);
 
   const runClone = async (blobless: boolean): Promise<ExecResult> => {


### PR DESCRIPTION
  ## Summary

  Completes blobless partial clone support for Bitbucket code review in the wrapper. GitHub and GitLab already use a blobless clone to stay under the clone timeout on large repositories. This extends the same treatment to Bitbucket, but only when the session origin carries an outbound capability (the `kbb1.` prefix), because a capability origin stays authenticated through the outbound interceptor and can serve the lazy blob fetches a partial clone defers. A raw-token Bitbucket origin is credential-stripped after bootstrap, so it still gets a full clone.

  This pairs with the Bitbucket outbound credential injection in #4868 (already merged), which mints those capabilities.

  ## Changes

  - `isBloblessReviewCloneEligible` now returns true for a Bitbucket review session when the origin token is a `kbb1.` capability, in addition to the existing GitHub and GitLab cases.
  - Added `hasBitbucketReviewCapability` and the `BITBUCKET_CAPABILITY_PREFIX` (`kbb1.`) constant.
  - `sanitizeBitbucketCodeReviewRemote` skips stripping the origin when it holds a capability, so the credential stays available for the partial clone's later lazy blob fetches. A raw workspace token is still stripped as before.
  - Test coverage for the contained Bitbucket path (blobless clone used, capability origin kept).
  - Corrected the `useBlobless` comment, which previously said only GitHub/GitLab qualify and described history retention incorrectly.

  ## Verification

  Manually confirmed that Bitbucket Cloud (`bitbucket.org`) honors `git clone --filter=blob:none`: a partial clone of a public bitbucket.org repo showed the server withholding blobs (promised objects, fetched lazily), with no "filtering not recognized by server" warning. This was the load-bearing assumption for the change.

  No end-to-end contained-session run yet. The path is dormant until the `BITBUCKET_TOKEN_CONTAINMENT_ORG_IDS` allow-list enables an org, so a live Bitbucket review will be smoke-tested after enabling post-deploy. Automated coverage: 49 wrapper session-bootstrap tests pass, including the new capability blobless case.

  - [ ] Live Bitbucket review after enabling the allow-list (post-deploy)

  ## Visual Changes

  N/A

  ## Reviewer Notes

  - Bitbucket blobless is intentionally gated on the `kbb1.` capability. Without a capability, the origin is credential-stripped and a partial clone's lazy fetches would fail, so those sessions keep a full clone.
  - The capability origin is deliberately left in place by `sanitizeBitbucketCodeReviewRemote` (it is scoped to one repo and useless outside the container), so blob fetches during the review authenticate through the outbound interceptor.
  - Fallback: if a server rejects `--filter` outright, the clone retries once as a full clone, so a review is never lost to the optimization.
