### PR TITLE
feat(cloud-agent-next) add cloud agent clone telemetry / logs

### DIFF
--- a/services/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -1094,10 +1094,16 @@ export class WrapperClient {
       request
     );
     // Single choke point for both callers (execution orchestrator and the sandbox
-    // ready path), so the metric is emitted exactly once per bootstrap. Only the
-    // wrapper's `telemetry` object is logged: `workspaceReady` carries `gitToken`.
-    // Older wrappers omit `telemetry` entirely, hence the guard.
-    if (response.telemetry) {
+    // ready path), so a given `ensureSessionReady` call logs its outcome exactly
+    // once. This does NOT mean once per session lifetime: `ensureSessionReady` is
+    // called on every dispatch to a sandbox that isn't already `session-ready`,
+    // including ordinary warm follow-up turns. Skip logging those to keep the
+    // "bootstrap" metric scoped to calls that actually did bootstrap work (a cold
+    // clone, or a backup restore even when the marker makes the workspace look
+    // warm). Only the wrapper's `telemetry` object is logged: `workspaceReady`
+    // carries `gitToken`. Older wrappers omit `telemetry` entirely, hence the guard.
+    const telemetry = response.telemetry;
+    if (telemetry && (!telemetry.workspaceWasWarm || telemetry.restoredFromBackup)) {
       logger.info('Cloud agent workspace bootstrap', {
         metric: 'cloud_agent_workspace_bootstrap',
         count: 1,
@@ -1106,8 +1112,12 @@ export class WrapperClient {
         // guard log carries `createdOnPlatform` but no session id, which makes
         // code-review sessions impossible to isolate without trace-row guesswork.
         platform: request.materialized.env.KILO_PLATFORM ?? '(none)',
-        workspaceWasWarm: response.telemetry.workspaceWasWarm,
-        ...(response.telemetry.clone ?? {}),
+        workspaceWasWarm: telemetry.workspaceWasWarm,
+        restoredFromBackup: telemetry.restoredFromBackup,
+        // Nested rather than spread: `clone` comes from the wrapper's response
+        // body, which is parsed without runtime schema validation, so an
+        // unexpected key must not be able to overwrite the trusted fields above.
+        clone: telemetry.clone,
       });
     }
     return response;

--- a/services/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -1088,7 +1088,29 @@ export class WrapperClient {
   async ensureSessionReady(
     request: WrapperSessionReadyRequest
   ): Promise<WrapperSessionReadySuccessResponse> {
-    return this.request<WrapperSessionReadySuccessResponse>('POST', '/session/ready', request);
+    const response = await this.request<WrapperSessionReadySuccessResponse>(
+      'POST',
+      '/session/ready',
+      request
+    );
+    // Single choke point for both callers (execution orchestrator and the sandbox
+    // ready path), so the metric is emitted exactly once per bootstrap. Only the
+    // wrapper's `telemetry` object is logged: `workspaceReady` carries `gitToken`.
+    // Older wrappers omit `telemetry` entirely, hence the guard.
+    if (response.telemetry) {
+      logger.info('Cloud agent workspace bootstrap', {
+        metric: 'cloud_agent_workspace_bootstrap',
+        count: 1,
+        sessionId: request.agentSessionId,
+        // Attaches the platform to a session-scoped event. The read-only command
+        // guard log carries `createdOnPlatform` but no session id, which makes
+        // code-review sessions impossible to isolate without trace-row guesswork.
+        platform: request.materialized.env.KILO_PLATFORM ?? '(none)',
+        workspaceWasWarm: response.telemetry.workspaceWasWarm,
+        ...(response.telemetry.clone ?? {}),
+      });
+    }
+    return response;
   }
 
   async updateRuntimeEnvironment(env: Record<string, string>): Promise<void> {

--- a/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
+++ b/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
@@ -151,8 +151,11 @@ export type WrapperWorkspaceReady = {
 
 /**
  * How the repository clone was performed.
- * - `full`: ordinary clone (no partial-clone filter requested)
- * - `blobless`: `--filter=blob:none` clone succeeded
+ * - `full`: ordinary clone (no partial-clone filter requested), or a blobless
+ *   attempt that the remote silently ignored (no rejection, but the filter
+ *   never took effect, e.g. no promisor remote configured after clone)
+ * - `blobless`: `--filter=blob:none` clone succeeded and was confirmed active
+ *   (the remote registered as a promisor remote)
  * - `blobless_fallback`: blobless was rejected by the remote, retried as a full clone
  */
 export type WrapperCloneMode = 'full' | 'blobless' | 'blobless_fallback';
@@ -185,6 +188,15 @@ export type WrapperCloneTelemetry = {
  */
 export type WrapperBootstrapTelemetry = {
   workspaceWasWarm: boolean;
+  /**
+   * True when the workspace was populated from an R2 backup rather than
+   * genuinely reused from a prior bootstrap. A restored workspace still
+   * reports `workspaceWasWarm: true` (the bootstrap marker is included in
+   * the backup archive), so this disambiguates "reused as-is" from
+   * "restored over the network," which otherwise inflates apparent
+   * sandbox-reuse rates.
+   */
+  restoredFromBackup: boolean;
   clone?: WrapperCloneTelemetry;
 };
 

--- a/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
+++ b/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
@@ -149,10 +149,51 @@ export type WrapperWorkspaceReady = {
   devcontainer?: WrapperDevContainerMetadata;
 };
 
+/**
+ * How the repository clone was performed.
+ * - `full`: ordinary clone (no partial-clone filter requested)
+ * - `blobless`: `--filter=blob:none` clone succeeded
+ * - `blobless_fallback`: blobless was rejected by the remote, retried as a full clone
+ */
+export type WrapperCloneMode = 'full' | 'blobless' | 'blobless_fallback';
+
+export type WrapperCloneTelemetry = {
+  mode: WrapperCloneMode;
+  /** Clone invocations issued (2 when a blobless attempt fell back). */
+  attempts: number;
+  /**
+   * Whether the blobless attempt's output matched the filter-rejection predicate
+   * that triggers the full-clone retry. A blobless clone that fails for a reason
+   * the predicate does not recognize reports `false` and gets no retry, so this
+   * distinguishes "remote refused the filter" from "clone failed for other reasons".
+   */
+  filterRejected: boolean;
+  durationMs: number;
+  repoKind: 'github' | 'git';
+  /** `unknown` for a generic git remote that declared no platform. */
+  repoPlatform: 'github' | 'gitlab' | 'bitbucket' | 'unknown';
+  shallow: boolean;
+  /** Size proxies parsed from git's own progress output; absent if git did not report them. */
+  totalObjects?: number;
+  receivedBytes?: number;
+};
+
+/**
+ * Non-sensitive bootstrap diagnostics, kept as a sibling of `workspaceReady` rather
+ * than a member of it: `workspaceReady` carries `gitToken`, so nesting telemetry there
+ * would make the object unsafe to log wholesale. Everything here is safe to log.
+ */
+export type WrapperBootstrapTelemetry = {
+  workspaceWasWarm: boolean;
+  clone?: WrapperCloneTelemetry;
+};
+
 export type WrapperSessionReadySuccessResponse = {
   status: 'ready';
   kiloSessionId: string;
   workspaceReady: WrapperWorkspaceReady;
+  /** Optional: wrappers older than this field's introduction do not send it. */
+  telemetry?: WrapperBootstrapTelemetry;
 };
 
 export const WRAPPER_READY_ERROR_MESSAGE_MAX_LENGTH = 4_096;

--- a/services/cloud-agent-next/wrapper/src/main.ts
+++ b/services/cloud-agent-next/wrapper/src/main.ts
@@ -788,8 +788,9 @@ async function main() {
         workspaceBootstrapController.signal
       );
       activeWorkspaceBootstraps.add(workspaceBootstrap);
+      let bootstrapResult: Awaited<typeof workspaceBootstrap>;
       try {
-        await workspaceBootstrap;
+        bootstrapResult = await workspaceBootstrap;
       } finally {
         activeWorkspaceBootstraps.delete(workspaceBootstrap);
       }
@@ -850,6 +851,10 @@ async function main() {
           sessionHome: request.workspace.sessionHome,
           branchName: request.workspace.branchName,
           kiloSessionId: request.kiloSessionId,
+        },
+        telemetry: {
+          workspaceWasWarm: bootstrapResult.workspaceWasWarm,
+          ...(bootstrapResult.clone ? { clone: bootstrapResult.clone } : {}),
         },
       };
     } catch (error) {

--- a/services/cloud-agent-next/wrapper/src/main.ts
+++ b/services/cloud-agent-next/wrapper/src/main.ts
@@ -852,10 +852,11 @@ async function main() {
           branchName: request.workspace.branchName,
           kiloSessionId: request.kiloSessionId,
         },
-        telemetry: {
-          workspaceWasWarm: bootstrapResult.workspaceWasWarm,
-          ...(bootstrapResult.clone ? { clone: bootstrapResult.clone } : {}),
-        },
+        // Forward the bootstrap result as-is: `WrapperBootstrapResult` and
+        // `WrapperBootstrapTelemetry` are kept structurally identical on
+        // purpose so this can't silently drop a field one type gains but the
+        // other doesn't.
+        telemetry: bootstrapResult,
       };
     } catch (error) {
       if (request.preparation) {

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -389,6 +389,139 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     expect(cloneArgs[1]).not.toContain('--filter=blob:none');
   });
 
+  it('reports blobless clone telemetry with size proxies parsed from git progress', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+
+    const result = await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+            return {
+              stdout: '',
+              stderr: [
+                'remote: Enumerating objects: 1234, done.',
+                'remote: Total 1234 (delta 456), reused 1000 (delta 300), pack-reused 0',
+                'Receiving objects: 100% (1234/1234), 1.50 MiB | 12.34 MiB/s, done.',
+              ].join('\n'),
+              exitCode: 0,
+            };
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    expect(result.clone?.mode).toBe('blobless');
+    expect(result.clone?.attempts).toBe(1);
+    expect(result.clone?.filterRejected).toBe(false);
+    expect(result.clone?.repoKind).toBe('github');
+    expect(result.clone?.repoPlatform).toBe('github');
+    expect(result.clone?.shallow).toBe(false);
+    expect(result.clone?.totalObjects).toBe(1234);
+    expect(result.clone?.receivedBytes).toBe(1.5 * 1024 * 1024);
+  });
+
+  it('reports blobless_fallback telemetry when the server rejects the filter', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+
+    const result = await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          if (args[0] === 'clone') {
+            if (args.includes('--filter=blob:none')) {
+              return { stdout: '', stderr: 'fatal: filter blob:none not supported', exitCode: 128 };
+            }
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+            return { stdout: '', stderr: '', exitCode: 0 };
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    expect(result.clone?.mode).toBe('blobless_fallback');
+    expect(result.clone?.attempts).toBe(2);
+    expect(result.clone?.filterRejected).toBe(true);
+  });
+
+  it('reports full clone telemetry for sessions that are not blobless eligible', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+    request.repo = {
+      kind: 'git',
+      url: 'https://bitbucket.org/acme/repo.git',
+      token: 'bb-token',
+      platform: 'bitbucket',
+    };
+    request.workspace.branchName = 'feature/login';
+
+    const result = await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    expect(result.clone?.mode).toBe('full');
+    expect(result.clone?.attempts).toBe(1);
+    expect(result.clone?.filterRejected).toBe(false);
+    expect(result.clone?.repoKind).toBe('git');
+    expect(result.clone?.repoPlatform).toBe('bitbucket');
+    // git reported no progress counters, so the size proxies stay absent
+    // rather than defaulting to a misleading zero.
+    expect(result.clone?.totalObjects).toBeUndefined();
+    expect(result.clone?.receivedBytes).toBeUndefined();
+  });
+
   it('uses activity watchdogs and reports sanitized progress for long git operations', async () => {
     const request = makeRequest(tmpDir);
     request.materialized.setupCommands = [];

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -416,6 +416,9 @@ describe('prepareWrapperBootstrapWorkspace', () => {
           if (args[0] === 'rev-parse') {
             return { stdout: '', stderr: '', exitCode: 1 };
           }
+          if (args[0] === 'config' && args.includes('remote.origin.promisor')) {
+            return { stdout: 'true\n', stderr: '', exitCode: 0 };
+          }
           return { stdout: '', stderr: '', exitCode: 0 };
         },
         restoreSession: async () => ({
@@ -435,6 +438,45 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     expect(result.clone?.shallow).toBe(false);
     expect(result.clone?.totalObjects).toBe(1234);
     expect(result.clone?.receivedBytes).toBe(1.5 * 1024 * 1024);
+  });
+
+  it('downgrades to full mode when a blobless clone succeeds but the server silently ignored the filter', async () => {
+    const request = makeRequest(tmpDir);
+    request.materialized.env.KILO_PLATFORM = 'code-review';
+    request.materialized.setupCommands = [];
+
+    const result = await prepareWrapperBootstrapWorkspace(
+      request,
+      mock(() => {}),
+      {
+        git: async args => {
+          if (args[0] === 'clone') {
+            await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), {
+              recursive: true,
+            });
+            return { stdout: '', stderr: '', exitCode: 0 };
+          }
+          if (args[0] === 'rev-parse') {
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          if (args[0] === 'config' && args.includes('remote.origin.promisor')) {
+            // Server ignored --filter=blob:none: no promisor remote was configured.
+            return { stdout: '', stderr: '', exitCode: 1 };
+          }
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        restoreSession: async () => ({
+          ok: true,
+          downloaded: false,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        }),
+      }
+    );
+
+    expect(result.clone?.mode).toBe('full');
+    expect(result.clone?.attempts).toBe(1);
+    expect(result.clone?.filterRejected).toBe(false);
   });
 
   it('reports blobless_fallback telemetry when the server rejects the filter', async () => {

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -2,6 +2,7 @@ import fs from 'node:fs/promises';
 import path from 'node:path';
 import {
   type WrapperBootstrapAttachment,
+  type WrapperCloneTelemetry,
   type WrapperPromptRequest,
   type WrapperPromptPart,
   type WrapperSessionReadyRequest,
@@ -151,6 +152,8 @@ export type BootstrapProgress = {
 
 export type WrapperBootstrapResult = {
   workspaceWasWarm: boolean;
+  /** Absent when the workspace was warm and no clone ran. */
+  clone?: WrapperCloneTelemetry;
 };
 
 type GitRunner = (args: string[], opts?: ProcessOptions) => Promise<ExecResult>;
@@ -213,6 +216,43 @@ function gitOperationError(
 
 const GIT_PROGRESS_PATTERN =
   /\b(Receiving objects|Resolving deltas|Updating files|Checking out files|Compressing objects):\s+(\d+)%/g;
+
+// Size proxies straight out of git's own progress output, so measuring clone size
+// costs no extra subprocess:
+//   remote: Total 1234 (delta 456), reused 1000 (delta 300), pack-reused 0
+//   Receiving objects: 100% (1234/1234), 45.67 MiB | 12.34 MiB/s, done.
+const GIT_TOTAL_OBJECTS_PATTERN = /\bTotal\s+(\d+)\b/;
+const GIT_RECEIVED_SIZE_PATTERN =
+  /Receiving objects:\s+100%\s+\([^)]*\),\s+([\d.]+)\s+(bytes|KiB|MiB|GiB)/;
+const BYTE_UNIT_MULTIPLIERS: Record<string, number> = {
+  bytes: 1,
+  KiB: 1024,
+  MiB: 1024 * 1024,
+  GiB: 1024 * 1024 * 1024,
+};
+
+function parseCloneSizeProxies(output: string): {
+  totalObjects?: number;
+  receivedBytes?: number;
+} {
+  // git writes progress with carriage returns and may colorize it.
+  const text = stripAnsi(output).replace(/\r/g, '\n');
+  const proxies: { totalObjects?: number; receivedBytes?: number } = {};
+  const objects = GIT_TOTAL_OBJECTS_PATTERN.exec(text);
+  if (objects) {
+    const parsed = Number.parseInt(objects[1], 10);
+    if (Number.isFinite(parsed)) proxies.totalObjects = parsed;
+  }
+  const size = GIT_RECEIVED_SIZE_PATTERN.exec(text);
+  if (size) {
+    const amount = Number.parseFloat(size[1]);
+    const multiplier = BYTE_UNIT_MULTIPLIERS[size[2]];
+    if (Number.isFinite(amount) && multiplier !== undefined) {
+      proxies.receivedBytes = Math.round(amount * multiplier);
+    }
+  }
+  return proxies;
+}
 
 function gitProgressReporter(
   progress: BootstrapProgress | undefined,
@@ -360,7 +400,7 @@ async function cloneRepository(
   runGit: GitRunner,
   progress: BootstrapProgress | undefined,
   signal: AbortSignal
-): Promise<void> {
+): Promise<WrapperCloneTelemetry> {
   const repo = request.repo;
   if (!repo) {
     throw new Error('Session metadata is missing a repository source');
@@ -396,20 +436,38 @@ async function cloneRepository(
   // Most servers without partial-clone support ignore the filter and full-clone,
   // but some reject it outright. If the blobless attempt failed with a filter
   // error, retry once as a full clone so a review is never lost to the optimization.
+  const startedAt = Date.now();
+  let attempts = 1;
+  let filterRejected = false;
   let result = await runClone(useBlobless);
   if (
     useBlobless &&
     result.exitCode !== 0 &&
     /filter/i.test(`${result.stderr}\n${result.stdout}`)
   ) {
+    filterRejected = true;
     logToFile(
       `bootstrap blobless clone rejected; retrying full clone kiloSessionId=${request.kiloSessionId}`
     );
     result = await runClone(false);
+    attempts = 2;
   }
   if (result.exitCode !== 0) {
     throw gitOperationError(result, 'clone');
   }
+  const cloneTelemetry: WrapperCloneTelemetry = {
+    mode: !useBlobless ? 'full' : filterRejected ? 'blobless_fallback' : 'blobless',
+    attempts,
+    filterRejected,
+    durationMs: Date.now() - startedAt,
+    repoKind: repo.kind,
+    repoPlatform: platform ?? 'unknown',
+    shallow: repo.shallow === true,
+    ...parseCloneSizeProxies(`${result.stderr}\n${result.stdout}`),
+  };
+  logToFile(
+    `bootstrap clone complete kiloSessionId=${request.kiloSessionId} mode=${cloneTelemetry.mode} attempts=${attempts} durationMs=${cloneTelemetry.durationMs} totalObjects=${cloneTelemetry.totalObjects ?? '(unknown)'} receivedBytes=${cloneTelemetry.receivedBytes ?? '(unknown)'}`
+  );
 
   const authorName =
     repo.kind === 'github' ? (repo.gitAuthor?.name ?? 'Kilo Code Cloud') : 'Kilo Code Cloud';
@@ -426,6 +484,7 @@ async function cloneRepository(
   if (authorNameResult.exitCode !== 0 || authorEmailResult.exitCode !== 0) {
     throw new Error('Failed to configure git author identity');
   }
+  return cloneTelemetry;
 }
 
 async function branchExists(
@@ -1070,6 +1129,7 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
 
   let workspaceWasWarm = false;
   let workspaceNeedsBootstrap = true;
+  let cloneTelemetry: WrapperCloneTelemetry | undefined;
   const restoredFromBackup = request.workspace.restoredFromBackup === true;
 
   try {
@@ -1105,7 +1165,7 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
       logToFile(
         `bootstrap cold workspace cloning repository kiloSessionId=${request.kiloSessionId}`
       );
-      await cloneRepository(request, runGit, progress, signal);
+      cloneTelemetry = await cloneRepository(request, runGit, progress, signal);
       logToFile(`bootstrap cold workspace clone ready kiloSessionId=${request.kiloSessionId}`);
     }
 
@@ -1155,7 +1215,7 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
       `bootstrap workspace ready kiloSessionId=${request.kiloSessionId} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap}`
     );
     progress?.('kilo_server', 'Starting Kilo...');
-    return { workspaceWasWarm };
+    return { workspaceWasWarm, ...(cloneTelemetry ? { clone: cloneTelemetry } : {}) };
   } catch (error) {
     if (error instanceof RestoredWorkspaceReconciliationError) {
       if (workspaceNeedsBootstrap) {

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -152,6 +152,7 @@ export type BootstrapProgress = {
 
 export type WrapperBootstrapResult = {
   workspaceWasWarm: boolean;
+  restoredFromBackup: boolean;
   /** Absent when the workspace was warm and no clone ran. */
   clone?: WrapperCloneTelemetry;
 };
@@ -455,8 +456,28 @@ async function cloneRepository(
   if (result.exitCode !== 0) {
     throw gitOperationError(result, 'clone');
   }
+  // A server without partial-clone support commonly ignores `--filter=blob:none`
+  // outright (exit 0, full clone) rather than rejecting it, so a successful
+  // blobless attempt does not guarantee the filter took effect. git records an
+  // accepted filter by marking the remote as a promisor remote; confirm that
+  // before reporting `mode: 'blobless'` so silently-full clones aren't
+  // misclassified as partial.
+  let filterHonored = false;
+  if (useBlobless && !filterRejected) {
+    const promisorCheck = await runGit(['config', '--get', 'remote.origin.promisor'], {
+      cwd: request.workspace.workspacePath,
+      timeoutMs: SHORT_GIT_COMMAND_TIMEOUT_MS,
+    });
+    filterHonored = promisorCheck.exitCode === 0 && promisorCheck.stdout.trim() === 'true';
+  }
   const cloneTelemetry: WrapperCloneTelemetry = {
-    mode: !useBlobless ? 'full' : filterRejected ? 'blobless_fallback' : 'blobless',
+    mode: !useBlobless
+      ? 'full'
+      : filterRejected
+        ? 'blobless_fallback'
+        : filterHonored
+          ? 'blobless'
+          : 'full',
     attempts,
     filterRejected,
     durationMs: Date.now() - startedAt,
@@ -1215,7 +1236,11 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
       `bootstrap workspace ready kiloSessionId=${request.kiloSessionId} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap}`
     );
     progress?.('kilo_server', 'Starting Kilo...');
-    return { workspaceWasWarm, ...(cloneTelemetry ? { clone: cloneTelemetry } : {}) };
+    return {
+      workspaceWasWarm,
+      restoredFromBackup,
+      ...(cloneTelemetry ? { clone: cloneTelemetry } : {}),
+    };
   } catch (error) {
     if (error instanceof RestoredWorkspaceReconciliationError) {
       if (workspaceNeedsBootstrap) {


### PR DESCRIPTION
## Summary

Adds structured telemetry for cloud agent workspace bootstraps, emitted to Axiom via a single `cloud_agent_workspace_bootstrap` log event in `WrapperClient.ensureSessionReady`.

The wrapper now collects and returns a `WrapperBootstrapTelemetry` object on `/session/ready` responses, containing:

- `workspaceWasWarm` and `restoredFromBackup` to distinguish genuinely reused sandboxes from backup-restored ones (both previously looked identical from the outside)
- Clone details when a cold clone ran: `mode`, `attempts`, `filterRejected`, `durationMs`, `repoKind`, `repoPlatform`, `shallow`, and size proxies (`totalObjects`, `receivedBytes`) parsed directly from git's progress output at no extra cost

The `mode` field distinguishes three outcomes: `full` (no partial-clone filter used, or the filter was silently ignored by the remote), `blobless` (filter confirmed active via promisor remote config), and `blobless_fallback` (filter rejected by the remote, retried as a full clone). Previously, a server that silently ignored `--filter=blob:none` would have been misreported as a genuine blobless clone; this is now detected by checking `remote.origin.promisor` after the clone.

The metric is only emitted when actual bootstrap work happened (cold clone or backup restore). Ordinary warm follow-up turns on an already-running sandbox are skipped, so the count stays scoped to real bootstrap events. The `telemetry` field on the response is optional, so old wrapper images that don't send it degrade gracefully.

The `clone` data is kept nested in the log payload rather than spread flat, so a future wrapper-side field cannot silently overwrite the trusted `sessionId`/`platform`/`metric` fields. `WrapperBootstrapResult` and `WrapperBootstrapTelemetry` are kept structurally identical and `main.ts` forwards the result directly, so a field added to one type can't be silently dropped from the wire response.

## Verification

- [ ] Manual: no visual changes; this is a backend telemetry change only. Verified via Axiom once deployed.

## Visual Changes

N/A

## Reviewer Notes

- The promisor remote check (`git config --get remote.origin.promisor`) is the git-native way to confirm a partial clone filter was accepted. A server that did a full clone silently will not have set this config, so `mode` correctly downgrades to `full`.
- `restoredFromBackup` was needed because a backup archive includes the bootstrap marker file, so `workspaceWasWarm` alone could not distinguish "reused as-is" from "just restored from R2." Both flags are now logged.
- `telemetry` is optional on `WrapperSessionReadySuccessResponse` for backward compat with pre-existing sandbox images that don't send it.
