### PR TITLE
fix(cloud-agent-next): preserve bitbucket capability origin in worker sanitize

### DIFF
--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -47,6 +47,7 @@ vi.mock('./workspace.js', () => ({
 const tokenMocks = vi.hoisted(() => ({
   issueCloudAgentGitHubSessionCapability: vi.fn(),
   issueCloudAgentGitLabSessionCapability: vi.fn(),
+  issueCloudAgentBitbucketSessionCapability: vi.fn(),
   resolveCloudAgentGitHubAuthForRepo: vi.fn(),
   resolveManagedBitbucketToken: vi.fn(),
   resolveManagedGitLabToken: vi.fn(),
@@ -452,7 +453,8 @@ function createGitLabCodeReviewMetadata(): CloudAgentSessionState {
 
 function createBitbucketMetadata(
   isCodeReview: boolean,
-  orgId: string | null = '123e4567-e89b-12d3-a456-426614174030'
+  orgId: string | null = '123e4567-e89b-12d3-a456-426614174030',
+  credentialContainment?: CredentialContainment
 ): CloudAgentSessionState {
   return parseSessionMetadata({
     metadataSchemaVersion: 2,
@@ -462,6 +464,7 @@ function createBitbucketMetadata(
       ...(orgId ? { orgId } : {}),
       createdOnPlatform: isCodeReview ? 'code-review' : 'cloud-agent-web',
     },
+    ...(credentialContainment ? { workspace: { credentialContainment } } : {}),
     auth: {
       kilocodeToken: 'kilo-token',
       kiloSessionId: 'kilo-session',
@@ -755,6 +758,41 @@ describe('SessionService.prepareWorkspace', () => {
     expect(workspaceMocks.updateGitRemoteUrl.mock.invocationCallOrder[0]).toBeLessThan(
       session.exec.mock.invocationCallOrder[restoreCallIndex] ?? 0
     );
+  });
+
+  it('preserves the capability origin (no strip) for a contained cold Bitbucket review', async () => {
+    const session = createSession(false);
+    const sandbox = createSandbox(session);
+    const metadata = createBitbucketMetadata(true, '123e4567-e89b-12d3-a456-426614174030', {
+      github: false,
+      gitlab: false,
+      bitbucket: true,
+      kilocode: false,
+    });
+    tokenMocks.issueCloudAgentBitbucketSessionCapability.mockResolvedValue({
+      success: true,
+      value: {
+        capability: 'kbb1.opaque-capability',
+        gitUrl: 'https://bitbucket.org/acme-team/widgets.git',
+      },
+    });
+
+    await new SessionService().prepareWorkspace({
+      sandbox,
+      sandboxId: 'usr-abcdef',
+      orgId: '123e4567-e89b-12d3-a456-426614174030',
+      userId: 'user_test',
+      sessionId: 'agent_test' as SessionId,
+      env: createEnv(),
+      metadata,
+      kilocodeModel: 'test-model',
+    });
+
+    expect(tokenMocks.issueCloudAgentBitbucketSessionCapability).toHaveBeenCalled();
+    expect(tokenMocks.resolveManagedBitbucketToken).not.toHaveBeenCalled();
+    // A kbb1. capability origin stays authenticated through the outbound
+    // interceptor, so it must NOT be stripped (unlike a raw-token session).
+    expect(workspaceMocks.updateGitRemoteUrl).not.toHaveBeenCalled();
   });
 
   it('writes the opaque Kilo capability to the sandbox auth file, never the raw token', async () => {
@@ -1142,6 +1180,41 @@ describe('SessionService.prepareWorkspace', () => {
       '/workspace/user/sessions/agent_test',
       'https://bitbucket.org/acme-team/widgets.git'
     );
+  });
+
+  it('preserves the capability origin (no strip, no refresh) for a contained warm Bitbucket review', async () => {
+    const session = createSession(true);
+    const sandbox = createSandbox(session, true);
+    const metadata = createBitbucketMetadata(true, '123e4567-e89b-12d3-a456-426614174030', {
+      github: false,
+      gitlab: false,
+      bitbucket: true,
+      kilocode: false,
+    });
+    tokenMocks.issueCloudAgentBitbucketSessionCapability.mockResolvedValue({
+      success: true,
+      value: {
+        capability: 'kbb1.opaque-capability',
+        gitUrl: 'https://bitbucket.org/acme-team/widgets.git',
+      },
+    });
+
+    await new SessionService().prepareWorkspace({
+      sandbox,
+      sandboxId: 'usr-abcdef',
+      orgId: '123e4567-e89b-12d3-a456-426614174030',
+      userId: 'user_test',
+      sessionId: 'agent_test' as SessionId,
+      env: createEnv(),
+      metadata,
+      kilocodeModel: 'test-model',
+    });
+
+    expect(workspaceMocks.cloneGitRepo).not.toHaveBeenCalled();
+    // A capability origin is preserved: no strip, and the warm-resume token
+    // refresh is skipped because sanitize reports the remote as handled.
+    expect(workspaceMocks.updateGitRemoteUrl).not.toHaveBeenCalled();
+    expect(workspaceMocks.updateGitRemoteToken).not.toHaveBeenCalled();
   });
 
   it('refreshes prepared GitHub workspace metadata with a managed capability', async () => {

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -2674,6 +2674,13 @@ export class SessionService {
     if (metadata.identity.createdOnPlatform !== 'code-review' || git?.type !== 'bitbucket') {
       return false;
     }
+    // A contained session's origin carries a kbb1. capability that stays
+    // authenticated through the outbound interceptor, so it must stay in place for
+    // a blobless clone's later lazy blob fetches (mirrors the wrapper's
+    // sanitizeBitbucketCodeReviewRemote). Only a raw workspace token is stripped.
+    if (getEffectiveCredentialContainment(metadata).bitbucket) {
+      return true;
+    }
     await updateGitRemoteUrl(session, workspacePath, git.url);
     return true;
   }


### PR DESCRIPTION
## Summary

The worker-side `sanitizeBitbucketCodeReviewRemote` in `session-service.ts`
unconditionally stripped the credential from a Bitbucket code-review origin. For
a credential-contained session, that origin holds a `kbb1.` outbound capability
that must stay in place so a blobless clone's lazy blob fetches can authenticate
through the outbound interceptor. This adds a guard that skips the strip when the
session is contained, mirroring the wrapper's `sanitizeBitbucketCodeReviewRemote`.
Follows up on a review comment on #4872.

## Changes

- `session-service.ts`: in `sanitizeBitbucketCodeReviewRemote`, return early and
  leave the origin untouched when `getEffectiveCredentialContainment(metadata).bitbucket`
  is true. A non-contained (raw-token) session is still stripped as before.
- `session-service.test.ts`: added cold and warm `prepareWorkspace` tests for a
  contained Bitbucket review, asserting the origin is not stripped
  (`updateGitRemoteUrl` not called) and, on warm resume, the token refresh is
  skipped (`updateGitRemoteToken` not called). Added an
  `issueCloudAgentBitbucketSessionCapability` mock and a containment override to
  the `createBitbucketMetadata` helper to support them.

## Verification

No manual run. This is an internal credential-handling guard, covered by unit
tests. Full `session-service.test.ts` passes (94 tests), and I confirmed the new
tests actually cover the guard: with the guard removed, both contained-path tests
fail because the strip runs (`updateGitRemoteUrl` called once). Typecheck, lint,
and format clean.

- [ ] No manual testing performed (unit-tested internal guard)

## Visual Changes

N/A

## Reviewer Notes

- Addresses pandemicsyn's follow-up comment on #4872: the worker-side sanitize
  had no capability check, unlike the wrapper's version.
- The guard keys off the containment flag rather than the token because the
  function only receives `metadata`. When `credentialContainment.bitbucket` is
  true a capability was issued, so the origin is safe to keep.
- Non-contained Bitbucket sessions are unchanged (still stripped).
