### PR TITLE
perf(ai-gateway): read provider index from replica

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/models-by-provider-index.server.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/models-by-provider-index.server.ts
@@ -1,5 +1,5 @@
 import { modelsByProvider } from '@kilocode/db/schema';
-import { db } from '@/lib/drizzle';
+import { readDb } from '@/lib/drizzle';
 import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 import type { NormalizedOpenRouterResponse } from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
 import { desc } from 'drizzle-orm';
@@ -88,7 +88,7 @@ export function createModelsByProviderIndexLoader(options: ProviderIndexLoaderOp
 export async function fetchLatestModelsByProviderSnapshotFromDb(): Promise<
   NormalizedOpenRouterResponse | undefined
 > {
-  const result = await db
+  const result = await readDb
     .select({ data: modelsByProvider.data })
     .from(modelsByProvider)
     .orderBy(desc(modelsByProvider.id))


### PR DESCRIPTION
## Summary
- read the cached models-by-provider snapshot from `readDb` instead of the primary
- keep strongly consistent gateway reads, including balances, rate limits, BYOK credentials, and experiment routing, on the writer

## Rationale
The provider index already has a 30-second in-process cache and has no read-after-write dependency, so it can tolerate normal replica lag while reducing primary traffic before OpenRouter requests.

## Validation
- `pnpm exec oxfmt apps/web/src/lib/ai-gateway/providers/openrouter/models-by-provider-index.server.ts`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/openrouter/models-by-provider-index.server.ts`
- `pnpm --filter web test --runInBand src/app/api/organizations/[id]/defaults/route.test.ts src/routers/model-preferences-router.test.ts src/routers/organizations/organization-settings-router.test.ts`
- `pnpm --filter web typecheck`
- `git diff --check`