### PR TITLE
perf(ai-gateway): read routing credentials from replicas

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -8,7 +8,7 @@ import {
   getModelUserByokProviders,
 } from '@/lib/ai-gateway/byok';
 import { custom_llm2, type User } from '@kilocode/db/schema';
-import { db } from '@/lib/drizzle';
+import { readDb } from '@/lib/drizzle';
 import { eq } from 'drizzle-orm';
 import type { AnonymousUserContext } from '@/lib/anonymous';
 import { isAnonymousContext } from '@/lib/anonymous';
@@ -67,8 +67,8 @@ async function checkDirectBYOK(
     return null;
   }
   const userByok = organizationId
-    ? await getBYOKforOrganization(db, organizationId, [directByok.id])
-    : await getBYOKforUser(db, user.id, [directByok.id]);
+    ? await getBYOKforOrganization(readDb, organizationId, [directByok.id])
+    : await getBYOKforUser(readDb, user.id, [directByok.id]);
   if (!userByok || userByok.length === 0) {
     return null;
   }
@@ -93,7 +93,7 @@ async function checkCustomLlm(
   requestedModel: string,
   organizationId: string
 ): Promise<GetProviderProviderResult | null> {
-  const [row] = await db
+  const [row] = await readDb
     .select()
     .from(custom_llm2)
     .where(eq(custom_llm2.public_id, requestedModel));
@@ -139,8 +139,8 @@ async function checkVercelBYOK(
   const modelProviders = await getModelUserByokProviders(requestedModel);
   if (modelProviders.length === 0) return null;
   return organizationId
-    ? getBYOKforOrganization(db, organizationId, modelProviders)
-    : getBYOKforUser(db, user.id, modelProviders);
+    ? getBYOKforOrganization(readDb, organizationId, modelProviders)
+    : getBYOKforUser(readDb, user.id, modelProviders);
 }
 
 export type GetProviderInput = {

--- a/apps/web/src/lib/ai-gateway/providers/getEmbeddingProvider.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/getEmbeddingProvider.test.ts
@@ -11,6 +11,7 @@ import {
   getBYOKforOrganization,
 } from '@/lib/ai-gateway/byok';
 import type { User } from '@kilocode/db/schema';
+import { readDb } from '@/lib/drizzle';
 
 jest.mock('@/lib/ai-gateway/byok');
 
@@ -63,6 +64,7 @@ describe('getEmbeddingProvider', () => {
     expect(result.provider.id).toBe('vercel');
     expect(result.provider).toBe(PROVIDERS.VERCEL_AI_GATEWAY);
     expect(result.userByok).toBe(mockByokResult);
+    expect(mockedGetBYOKforUser).toHaveBeenCalledWith(readDb, user.id, ['openai']);
   });
 
   it('should check organization BYOK when organizationId is provided', async () => {
@@ -76,9 +78,7 @@ describe('getEmbeddingProvider', () => {
 
     expect(result.provider.id).toBe('vercel');
     expect(result.userByok).toBe(mockByokResult);
-    expect(mockedGetBYOKforOrganization).toHaveBeenCalledWith(expect.anything(), 'org-123', [
-      'mistral',
-    ]);
+    expect(mockedGetBYOKforOrganization).toHaveBeenCalledWith(readDb, 'org-123', ['mistral']);
   });
 
   it('should skip BYOK check for anonymous users', async () => {

--- a/apps/web/src/lib/organizations/organization-auto-model.ts
+++ b/apps/web/src/lib/organizations/organization-auto-model.ts
@@ -11,7 +11,7 @@ import {
   getDirectByokModel,
 } from '@/lib/ai-gateway/providers/direct-byok';
 import { getBYOKforOrganization } from '@/lib/ai-gateway/byok';
-import { db, type DrizzleTransaction } from '@/lib/drizzle';
+import { readDb, type DrizzleTransaction } from '@/lib/drizzle';
 import { KILO_AUTO_BALANCED_MODEL, ORG_AUTO_MODEL } from '@/lib/ai-gateway/auto-model';
 import { isPublicIdExperimented } from '@/lib/ai-gateway/experiments/membership';
 import { isReleaseToggleEnabled } from '@/lib/posthog-feature-flags';
@@ -87,7 +87,7 @@ export async function validateOrganizationAutoTarget(
   targetModelId: string,
   options: {
     apiKind?: 'chat_completions' | 'responses' | 'messages';
-    dbClient?: typeof db | DrizzleTransaction;
+    dbClient?: typeof readDb | DrizzleTransaction;
   } = {}
 ): Promise<OrganizationAutoTargetValidationResult> {
   const rawModelId = targetModelId.trim().toLowerCase();
@@ -117,7 +117,7 @@ export async function validateOrganizationAutoTarget(
 
   const directByokTarget = await getDirectByokModel(rawModelId);
   if (directByokTarget.provider && directByokTarget.model) {
-    const byok = await getBYOKforOrganization(options.dbClient ?? db, organization.id, [
+    const byok = await getBYOKforOrganization(options.dbClient ?? readDb, organization.id, [
       directByokTarget.provider.id,
     ]);
     if (!byok || byok.length === 0) {


### PR DESCRIPTION
## Summary
- use `readDb` for direct and Vercel BYOK credential lookup during AI gateway provider resolution
- use `readDb` for custom LLM provider lookup
- use `readDb` for request-time Organization Auto BYOK validation while preserving explicitly supplied primary transactions for admin mutations
- assert that embedding BYOK resolution receives the readonly client

## Consistency
These request-time reads may briefly observe stale credential or configuration state during replica lag. Write paths and transaction-scoped Organization Auto validation remain on the primary.

## Validation
- `pnpm exec oxfmt --list-different apps/web/src/lib/ai-gateway/providers/get-provider.ts apps/web/src/lib/ai-gateway/providers/getEmbeddingProvider.test.ts apps/web/src/lib/organizations/organization-auto-model.ts`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/get-provider.ts apps/web/src/lib/ai-gateway/providers/getEmbeddingProvider.test.ts apps/web/src/lib/organizations/organization-auto-model.ts`
- `pnpm --filter web test --runInBand --runTestsByPath src/lib/ai-gateway/providers/getEmbeddingProvider.test.ts src/routers/organizations/organization-settings-router.test.ts src/routers/organizations/organization-modes-router.test.ts`
- `pnpm --filter web typecheck`
- `git diff --check`