### PR TITLE
feat(web): observable read-replica and slot replication health

### DIFF
--- a/apps/web/src/app/api/cron/db-replication-health/route.test.ts
+++ b/apps/web/src/app/api/cron/db-replication-health/route.test.ts
@@ -1,0 +1,121 @@
+import { captureException } from '@sentry/nextjs';
+
+import { collectReplicationHealth, type ReplicationHealthReport } from '@/lib/replication-health';
+
+jest.mock('@/lib/config.server', () => ({
+  CRON_SECRET: 'cron-secret',
+}));
+
+jest.mock('@/lib/replication-health', () => ({
+  collectReplicationHealth: jest.fn(),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+}));
+
+import { GET } from './route';
+
+const mockCollect = jest.mocked(collectReplicationHealth);
+const mockCaptureException = jest.mocked(captureException);
+
+function report(overrides: Partial<ReplicationHealthReport> = {}): ReplicationHealthReport {
+  return {
+    healthy: true,
+    timestamp: '2026-07-30T09:39:06.000Z',
+    replicas: [],
+    walSenders: [],
+    slots: [],
+    errors: [],
+    ...overrides,
+  };
+}
+
+function createRequest(headers: Record<string, string> = {}) {
+  return new Request('http://localhost:3000/api/cron/db-replication-health', {
+    method: 'GET',
+    headers,
+  });
+}
+
+describe('GET /api/cron/db-replication-health', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockCollect.mockResolvedValue(report());
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('returns 401 with the wrong cron secret', async () => {
+    const response = await GET(createRequest({ authorization: 'Bearer wrong' }));
+
+    expect(response.status).toBe(401);
+    expect(mockCollect).not.toHaveBeenCalled();
+  });
+
+  it('does not alert when replication is healthy', async () => {
+    const response = await GET(createRequest({ authorization: 'Bearer cron-secret' }));
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ healthy: true, problems: [] })
+    );
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('alerts when a replica is lagging', async () => {
+    mockCollect.mockResolvedValue(
+      report({
+        healthy: false,
+        replicas: [
+          {
+            name: 'us-west',
+            status: 'lagging',
+            in_recovery: true,
+            replay_lsn: '1EE6/65035140',
+            last_xact_replay_timestamp: '2026-07-22 10:41:00+00',
+            replay_delay_seconds: 691200,
+            error: null,
+          },
+        ],
+      })
+    );
+
+    const response = await GET(createRequest({ authorization: 'Bearer cron-secret' }));
+
+    const body = await response.json();
+    expect(body.healthy).toBe(false);
+    expect(body.problems).toEqual([expect.stringContaining('replica us-west: lagging')]);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('alerts when a slot is at risk', async () => {
+    mockCollect.mockResolvedValue(
+      report({
+        healthy: false,
+        slots: [
+          {
+            slot_name: 'snowflake_connector_gfqyzuertw',
+            slot_type: 'logical',
+            active: false,
+            wal_status: 'lost',
+            retained_wal_bytes: '0',
+            at_risk: true,
+          },
+        ],
+      })
+    );
+
+    const response = await GET(createRequest({ authorization: 'Bearer cron-secret' }));
+
+    const body = await response.json();
+    expect(body.problems).toEqual([
+      expect.stringContaining('slot snowflake_connector_gfqyzuertw: wal_status=lost'),
+    ]);
+    expect(mockCaptureException).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/app/api/cron/db-replication-health/route.ts
+++ b/apps/web/src/app/api/cron/db-replication-health/route.ts
@@ -1,0 +1,71 @@
+import { captureException } from '@sentry/nextjs';
+import { NextResponse } from 'next/server';
+
+import { CRON_SECRET } from '@/lib/config.server';
+import { collectReplicationHealth } from '@/lib/replication-health';
+
+/**
+ * Emits replication health to Axiom (via the Vercel log drain) and alerts Sentry
+ * when a replica is lagging/unreachable or a slot is at risk of losing WAL.
+ *
+ * This intentionally uses the replica-side SQL probe from `collectReplicationHealth`
+ * rather than the Supabase Prometheus `physical_replication_lag_*` metric: that
+ * metric has a documented history of returning no data, and — like the primary's
+ * `pg_stat_replication` — cannot see a replica whose walreceiver has died. The
+ * per-replica probe is the authoritative signal.
+ */
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization');
+  if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const report = await collectReplicationHealth();
+
+  // Structured JSON → Vercel log drain → Axiom, one line per series.
+  for (const replica of report.replicas) {
+    console.log(
+      JSON.stringify({ type: 'db_replication_health', ...replica, timestamp: report.timestamp })
+    );
+  }
+  for (const slot of report.slots) {
+    console.log(
+      JSON.stringify({ type: 'db_replication_slot', ...slot, timestamp: report.timestamp })
+    );
+  }
+
+  const problems: string[] = [];
+  for (const replica of report.replicas) {
+    if (replica.status !== 'ok') {
+      problems.push(
+        `replica ${replica.name}: ${replica.status}` +
+          (replica.replay_delay_seconds !== null
+            ? ` (${Math.round(replica.replay_delay_seconds)}s behind)`
+            : replica.error
+              ? ` (${replica.error})`
+              : '')
+      );
+    }
+  }
+  for (const slot of report.slots) {
+    if (slot.at_risk) {
+      problems.push(`slot ${slot.slot_name}: wal_status=${slot.wal_status}, active=${slot.active}`);
+    }
+  }
+  for (const error of report.errors) {
+    problems.push(`primary query failed: ${error}`);
+  }
+
+  if (problems.length > 0) {
+    console.error(JSON.stringify({ type: 'db_replication_health_alert', problems }));
+    captureException(new Error(`Replication health degraded: ${problems.join('; ')}`));
+  }
+
+  return NextResponse.json({
+    healthy: report.healthy,
+    problems,
+    replicas: report.replicas.length,
+    slots: report.slots.length,
+    timestamp: report.timestamp,
+  });
+}

--- a/apps/web/src/app/api/internal/db/replication-lag/route.test.ts
+++ b/apps/web/src/app/api/internal/db/replication-lag/route.test.ts
@@ -1,27 +1,28 @@
 import { NextRequest } from 'next/server';
-import { db } from '@/lib/drizzle';
+
+import { collectReplicationHealth, type ReplicationHealthReport } from '@/lib/replication-health';
 
 jest.mock('@/lib/config.server', () => ({
   INTERNAL_API_SECRET: 'internal-secret',
 }));
 
-jest.mock('@/lib/drizzle', () => ({
-  db: {
-    execute: jest.fn(),
-  },
+jest.mock('@/lib/replication-health', () => ({
+  collectReplicationHealth: jest.fn(),
 }));
 
 import { GET } from './route';
 
-const mockExecute = jest.mocked(db.execute);
+const mockCollect = jest.mocked(collectReplicationHealth);
 
-function queryResult(rows: Record<string, unknown>[]) {
+function report(overrides: Partial<ReplicationHealthReport> = {}): ReplicationHealthReport {
   return {
-    command: 'SELECT',
-    rowCount: rows.length,
-    oid: 0,
-    fields: [],
-    rows,
+    healthy: true,
+    timestamp: '2026-07-30T09:39:06.000Z',
+    replicas: [],
+    walSenders: [],
+    slots: [],
+    errors: [],
+    ...overrides,
   };
 }
 
@@ -35,56 +36,43 @@ function createRequest(headers: Record<string, string> = {}) {
 describe('GET /api/internal/db/replication-lag', () => {
   beforeEach(() => {
     jest.clearAllMocks();
-    mockExecute.mockResolvedValue(queryResult([]));
+    mockCollect.mockResolvedValue(report());
   });
 
   it('returns 401 without the internal secret', async () => {
     const response = await GET(createRequest());
 
     expect(response.status).toBe(401);
-    expect(mockExecute).not.toHaveBeenCalled();
+    expect(mockCollect).not.toHaveBeenCalled();
   });
 
-  it('returns replication lag for every target reported by Postgres', async () => {
-    mockExecute.mockResolvedValue(
-      queryResult([
-        {
-          pid: 123,
-          application_name: 'walreceiver',
-          client_addr: '10.0.0.10',
-          client_hostname: null,
-          client_port: 5432,
-          state: 'streaming',
-          sync_state: 'async',
-          sent_lsn: '0/5000000',
-          write_lsn: '0/4FFFFF0',
-          flush_lsn: '0/4FFFFE0',
-          replay_lsn: '0/4FFFFD0',
-          sent_lag_bytes: '0',
-          write_lag_bytes: '16',
-          flush_lag_bytes: '32',
-          replay_lag_bytes: '48',
-          write_lag_seconds: 0.1,
-          flush_lag_seconds: 0.2,
-          replay_lag_seconds: 0.3,
-        },
-      ])
+  it('returns the replication health report with the secret', async () => {
+    mockCollect.mockResolvedValue(
+      report({
+        healthy: false,
+        replicas: [
+          {
+            name: 'us-west',
+            status: 'unreachable',
+            in_recovery: null,
+            replay_lsn: null,
+            last_xact_replay_timestamp: null,
+            replay_delay_seconds: null,
+            error: 'connection timeout',
+          },
+        ],
+      })
     );
 
     const response = await GET(createRequest({ 'X-Internal-Secret': 'internal-secret' }));
 
     expect(response.status).toBe(200);
-    expect(mockExecute).toHaveBeenCalledTimes(1);
-    await expect(response.json()).resolves.toEqual({
-      targets: [
-        expect.objectContaining({
-          application_name: 'walreceiver',
-          client_addr: '10.0.0.10',
-          replay_lag_bytes: '48',
-          replay_lag_seconds: 0.3,
-        }),
-      ],
-      timestamp: expect.any(String),
-    });
+    expect(mockCollect).toHaveBeenCalledTimes(1);
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({
+        healthy: false,
+        replicas: [expect.objectContaining({ name: 'us-west', status: 'unreachable' })],
+      })
+    );
   });
 });

--- a/apps/web/src/app/api/internal/db/replication-lag/route.ts
+++ b/apps/web/src/app/api/internal/db/replication-lag/route.ts
@@ -1,30 +1,8 @@
 import { timingSafeEqual } from 'crypto';
-import { sql } from 'drizzle-orm';
 import { NextResponse } from 'next/server';
 
 import { INTERNAL_API_SECRET } from '@/lib/config.server';
-import { db } from '@/lib/drizzle';
-
-type ReplicationLagRow = {
-  pid: number;
-  application_name: string;
-  client_addr: string | null;
-  client_hostname: string | null;
-  client_port: number | null;
-  state: string | null;
-  sync_state: string | null;
-  sent_lsn: string | null;
-  write_lsn: string | null;
-  flush_lsn: string | null;
-  replay_lsn: string | null;
-  sent_lag_bytes: string;
-  write_lag_bytes: string;
-  flush_lag_bytes: string;
-  replay_lag_bytes: string;
-  write_lag_seconds: number | null;
-  flush_lag_seconds: number | null;
-  replay_lag_seconds: number | null;
-};
+import { collectReplicationHealth } from '@/lib/replication-health';
 
 function secretMatches(provided: string | null, expected: string): boolean {
   if (!provided) return false;
@@ -42,29 +20,7 @@ export async function GET(request: Request) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
-  const { rows } = await db.execute<ReplicationLagRow>(sql`
-    SELECT
-      pid,
-      application_name,
-      client_addr::text,
-      client_hostname,
-      client_port,
-      state,
-      sync_state,
-      sent_lsn::text,
-      write_lsn::text,
-      flush_lsn::text,
-      replay_lsn::text,
-      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), sent_lsn), 0)::text AS sent_lag_bytes,
-      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), write_lsn), 0)::text AS write_lag_bytes,
-      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), flush_lsn), 0)::text AS flush_lag_bytes,
-      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), 0)::text AS replay_lag_bytes,
-      EXTRACT(EPOCH FROM write_lag)::double precision AS write_lag_seconds,
-      EXTRACT(EPOCH FROM flush_lag)::double precision AS flush_lag_seconds,
-      EXTRACT(EPOCH FROM replay_lag)::double precision AS replay_lag_seconds
-    FROM pg_stat_replication
-    ORDER BY application_name, client_addr, client_port
-  `);
+  const report = await collectReplicationHealth();
 
-  return NextResponse.json({ targets: rows, timestamp: new Date().toISOString() });
+  return NextResponse.json(report);
 }

--- a/apps/web/src/lib/replication-health.test.ts
+++ b/apps/web/src/lib/replication-health.test.ts
@@ -108,8 +108,57 @@ describe('classifyReplicaRow', () => {
 });
 
 describe('collectReplicationHealth', () => {
+  const originalVercelEnv = process.env.VERCEL_ENV;
+
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env.VERCEL_ENV = originalVercelEnv;
+  });
+
+  it('reports an error when fewer than the expected replicas are configured in production', async () => {
+    process.env.VERCEL_ENV = 'production';
+    mockPrimary([walSenderRow()], [slotRow()]);
+
+    const report = await collectReplicationHealth({
+      targets: [],
+      probe: async target => okProbe(target.name),
+    });
+
+    expect(report.healthy).toBe(false);
+    expect(report.errors).toEqual([expect.stringContaining('expected 3 read replicas but only 0')]);
+  });
+
+  it('does not flag a short inventory outside production', async () => {
+    process.env.VERCEL_ENV = 'preview';
+    mockPrimary([walSenderRow()], [slotRow()]);
+
+    const report = await collectReplicationHealth({
+      targets: [],
+      probe: async target => okProbe(target.name),
+    });
+
+    expect(report.errors).toEqual([]);
+    expect(report.healthy).toBe(true);
+  });
+
+  it('accepts the full replica inventory in production', async () => {
+    process.env.VERCEL_ENV = 'production';
+    mockPrimary([walSenderRow()], [slotRow()]);
+
+    const report = await collectReplicationHealth({
+      targets: [
+        { name: 'us-west', url: 'postgres://a' },
+        { name: 'eu-central-1', url: 'postgres://b' },
+        { name: 'eu-central-2', url: 'postgres://c' },
+      ],
+      probe: async target => okProbe(target.name),
+    });
+
+    expect(report.errors).toEqual([]);
+    expect(report.healthy).toBe(true);
   });
 
   it('is healthy when replicas are caught up and slots are safe', async () => {

--- a/apps/web/src/lib/replication-health.test.ts
+++ b/apps/web/src/lib/replication-health.test.ts
@@ -1,0 +1,176 @@
+import { db } from '@/lib/drizzle';
+
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    execute: jest.fn(),
+  },
+}));
+
+import {
+  classifyReplicaRow,
+  collectReplicationHealth,
+  REPLICA_LAG_ALERT_SECONDS,
+  type ReplicaHealth,
+} from './replication-health';
+
+const mockExecute = jest.mocked(db.execute);
+
+function queryResult(rows: Record<string, unknown>[]) {
+  return { command: 'SELECT', rowCount: rows.length, oid: 0, fields: [], rows };
+}
+
+function walSenderRow(overrides: Record<string, unknown> = {}) {
+  return {
+    application_name: 'main',
+    client_addr: '18.153.166.51/32',
+    state: 'streaming',
+    sync_state: 'async',
+    replay_lag_bytes: '0',
+    replay_lag_seconds: 0.002,
+    ...overrides,
+  };
+}
+
+function slotRow(overrides: Record<string, unknown> = {}) {
+  return {
+    slot_name: 'snowflake_backend_slot',
+    slot_type: 'logical',
+    active: true,
+    wal_status: 'reserved',
+    retained_wal_bytes: '1000',
+    ...overrides,
+  };
+}
+
+function okProbe(name: string): ReplicaHealth {
+  return {
+    name,
+    status: 'ok',
+    in_recovery: true,
+    replay_lsn: '2008/2F522000',
+    last_xact_replay_timestamp: '2026-07-30 09:39:06+00',
+    replay_delay_seconds: 0.1,
+    error: null,
+  };
+}
+
+// getWalSenders runs before getReplicationSlots, so the first db.execute call is
+// the walsender query and the second is the slots query.
+function mockPrimary(walSenders: Record<string, unknown>[], slots: Record<string, unknown>[]) {
+  mockExecute
+    .mockResolvedValueOnce(queryResult(walSenders))
+    .mockResolvedValueOnce(queryResult(slots));
+}
+
+describe('classifyReplicaRow', () => {
+  it('flags a replica that is not in recovery', () => {
+    expect(
+      classifyReplicaRow({
+        in_recovery: false,
+        replay_lsn: null,
+        last_xact_replay_timestamp: null,
+        replay_delay_seconds: 0,
+      })
+    ).toBe('not_in_recovery');
+  });
+
+  it('flags lag beyond the alert threshold', () => {
+    expect(
+      classifyReplicaRow({
+        in_recovery: true,
+        replay_lsn: '1/1',
+        last_xact_replay_timestamp: '2026-07-22 10:41:00+00',
+        replay_delay_seconds: REPLICA_LAG_ALERT_SECONDS + 1,
+      })
+    ).toBe('lagging');
+  });
+
+  it('treats a caught-up replica as ok', () => {
+    expect(
+      classifyReplicaRow({
+        in_recovery: true,
+        replay_lsn: '1/1',
+        last_xact_replay_timestamp: '2026-07-30 00:00:00+00',
+        replay_delay_seconds: 0.2,
+      })
+    ).toBe('ok');
+  });
+});
+
+describe('collectReplicationHealth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('is healthy when replicas are caught up and slots are safe', async () => {
+    mockPrimary([walSenderRow()], [slotRow()]);
+
+    const report = await collectReplicationHealth({
+      targets: [{ name: 'us-west', url: 'postgres://replica' }],
+      probe: async target => okProbe(target.name),
+    });
+
+    expect(report.healthy).toBe(true);
+    expect(report.errors).toEqual([]);
+    expect(report.replicas).toEqual([expect.objectContaining({ name: 'us-west', status: 'ok' })]);
+    expect(report.walSenders).toHaveLength(1);
+    expect(report.slots[0].at_risk).toBe(false);
+  });
+
+  it('is unhealthy when a replica is unreachable', async () => {
+    mockPrimary([walSenderRow()], [slotRow()]);
+
+    const report = await collectReplicationHealth({
+      targets: [{ name: 'us-west', url: 'postgres://replica' }],
+      probe: async target => ({
+        name: target.name,
+        status: 'unreachable',
+        in_recovery: null,
+        replay_lsn: null,
+        last_xact_replay_timestamp: null,
+        replay_delay_seconds: null,
+        error: 'connection timeout',
+      }),
+    });
+
+    expect(report.healthy).toBe(false);
+    expect(report.replicas[0]).toMatchObject({
+      status: 'unreachable',
+      error: 'connection timeout',
+    });
+  });
+
+  it('marks a lost slot as at risk and unhealthy', async () => {
+    mockPrimary(
+      [walSenderRow()],
+      [
+        slotRow(),
+        slotRow({ slot_name: 'snowflake_connector_gfqyzuertw', active: false, wal_status: 'lost' }),
+      ]
+    );
+
+    const report = await collectReplicationHealth({
+      targets: [{ name: 'us-west', url: 'postgres://replica' }],
+      probe: async target => okProbe(target.name),
+    });
+
+    expect(report.healthy).toBe(false);
+    const lost = report.slots.find(s => s.slot_name === 'snowflake_connector_gfqyzuertw');
+    expect(lost?.at_risk).toBe(true);
+  });
+
+  it('captures primary query failures without blanking the report', async () => {
+    mockExecute
+      .mockRejectedValueOnce(new Error('primary down'))
+      .mockResolvedValueOnce(queryResult([slotRow()]));
+
+    const report = await collectReplicationHealth({
+      targets: [{ name: 'us-west', url: 'postgres://replica' }],
+      probe: async target => okProbe(target.name),
+    });
+
+    expect(report.healthy).toBe(false);
+    expect(report.errors).toEqual([expect.stringContaining('pg_stat_replication: primary down')]);
+    expect(report.slots).toHaveLength(1);
+  });
+});

--- a/apps/web/src/lib/replication-health.test.ts
+++ b/apps/web/src/lib/replication-health.test.ts
@@ -9,6 +9,7 @@ jest.mock('@/lib/drizzle', () => ({
 import {
   classifyReplicaRow,
   collectReplicationHealth,
+  probeReplica,
   REPLICA_LAG_ALERT_SECONDS,
   type ReplicaHealth,
 } from './replication-health';
@@ -61,6 +62,15 @@ function mockPrimary(walSenders: Record<string, unknown>[], slots: Record<string
     .mockResolvedValueOnce(queryResult(walSenders))
     .mockResolvedValueOnce(queryResult(slots));
 }
+
+describe('probeReplica', () => {
+  it('maps a malformed connection string to unreachable instead of throwing', async () => {
+    const health = await probeReplica({ name: 'us-west', url: 'not-a-url' });
+
+    expect(health).toMatchObject({ name: 'us-west', status: 'unreachable' });
+    expect(health.error).toBeTruthy();
+  });
+});
 
 describe('classifyReplicaRow', () => {
   it('flags a replica that is not in recovery', () => {
@@ -157,6 +167,24 @@ describe('collectReplicationHealth', () => {
     expect(report.healthy).toBe(false);
     const lost = report.slots.find(s => s.slot_name === 'snowflake_connector_gfqyzuertw');
     expect(lost?.at_risk).toBe(true);
+  });
+
+  it('isolates a throwing probe as an unreachable replica without blanking primary data', async () => {
+    mockPrimary([walSenderRow()], [slotRow()]);
+
+    const report = await collectReplicationHealth({
+      targets: [{ name: 'us-west', url: 'postgres://replica' }],
+      probe: async () => {
+        throw new Error('boom');
+      },
+    });
+
+    expect(report.replicas).toEqual([
+      expect.objectContaining({ name: 'us-west', status: 'unreachable', error: 'boom' }),
+    ]);
+    expect(report.walSenders).toHaveLength(1);
+    expect(report.slots).toHaveLength(1);
+    expect(report.healthy).toBe(false);
   });
 
   it('captures primary query failures without blanking the report', async () => {

--- a/apps/web/src/lib/replication-health.ts
+++ b/apps/web/src/lib/replication-health.ts
@@ -48,6 +48,14 @@ export function getExpectedReplicaTargets(): ReplicaTarget[] {
 export const REPLICA_LAG_ALERT_SECONDS = 300;
 
 /**
+ * Number of read replicas we expect in production, one per POSTGRES_REPLICA_*
+ * connection string (US + two EU). If fewer are configured (env var dropped,
+ * renamed, or misspelled), the monitor would otherwise probe nothing and still
+ * report `healthy: true` — so we surface it as an error in production.
+ */
+export const EXPECTED_REPLICA_COUNT = 3;
+
+/**
  * `pg_replication_slots.wal_status` values that mean the slot is at, or past,
  * the point of losing WAL it still needs. 'lost' is unrecoverable; 'unreserved'
  * is imminent. 'reserved' and 'extended' are both still safe.
@@ -240,6 +248,18 @@ export async function collectReplicationHealth(options?: {
   const targets = options?.targets ?? getExpectedReplicaTargets();
   const probe = options?.probe ?? probeReplica;
   const errors: string[] = [];
+
+  // A monitor that silently checks zero replicas is itself an invisible failure.
+  // In production every replica URL should be set, so treat a short inventory as
+  // an error (which forces `healthy: false` and triggers the cron's alert).
+  // Preview/dev deployments legitimately run without replica URLs, so gate on
+  // VERCEL_ENV to avoid false alarms there.
+  if (process.env.VERCEL_ENV === 'production' && targets.length < EXPECTED_REPLICA_COUNT) {
+    errors.push(
+      `expected ${EXPECTED_REPLICA_COUNT} read replicas but only ${targets.length} configured; ` +
+        `check POSTGRES_REPLICA_* env vars`
+    );
+  }
 
   const [replicas, walSenders, slots] = await Promise.all([
     // Isolate each probe: `probeReplica` is contracted not to throw, but a

--- a/apps/web/src/lib/replication-health.ts
+++ b/apps/web/src/lib/replication-health.ts
@@ -1,4 +1,4 @@
-import { createDrizzleClient } from '@kilocode/db/client';
+import { createDrizzleClient, type DrizzleClient } from '@kilocode/db/client';
 import { sql } from 'drizzle-orm';
 
 import { getEnvVariable } from '@/lib/dotenvx';
@@ -122,18 +122,24 @@ export function classifyReplicaRow(row: ReplicaProbeRow): ReplicaHealthStatus {
  * which is itself the signal that the replica is down.
  */
 export async function probeReplica(target: ReplicaTarget): Promise<ReplicaHealth> {
-  const client = createDrizzleClient({
-    connectionString: target.url,
-    poolConfig: {
-      max: 1,
-      application_name: 'kilocode-web-replication-health',
-      connectionTimeoutMillis: PROBE_TIMEOUT_MS,
-      statement_timeout: PROBE_TIMEOUT_MS,
-      query_timeout: PROBE_TIMEOUT_MS,
-    },
-  });
+  // createDrizzleClient must stay inside the try: getDatabaseClientConfig runs
+  // `new URL(connectionString)`, which throws synchronously on a malformed
+  // POSTGRES_REPLICA_* value. Keeping it here preserves the "never throws"
+  // contract and maps such failures to `status: 'unreachable'`.
+  let client: DrizzleClient | undefined;
 
   try {
+    client = createDrizzleClient({
+      connectionString: target.url,
+      poolConfig: {
+        max: 1,
+        application_name: 'kilocode-web-replication-health',
+        connectionTimeoutMillis: PROBE_TIMEOUT_MS,
+        statement_timeout: PROBE_TIMEOUT_MS,
+        query_timeout: PROBE_TIMEOUT_MS,
+      },
+    });
+
     const { rows } = await client.db.execute<ReplicaProbeRow>(sql`
       SELECT
         pg_is_in_recovery() AS in_recovery,
@@ -176,7 +182,7 @@ export async function probeReplica(target: ReplicaTarget): Promise<ReplicaHealth
       error: errorMessage(error),
     };
   } finally {
-    await client.pool.end().catch(() => {});
+    await client?.pool.end().catch(() => {});
   }
 }
 
@@ -230,7 +236,24 @@ export async function collectReplicationHealth(options?: {
   const errors: string[] = [];
 
   const [replicas, walSenders, slots] = await Promise.all([
-    Promise.all(targets.map(target => probe(target))),
+    // Isolate each probe: `probeReplica` is contracted not to throw, but a
+    // custom/injected probe or an unexpected error must not reject the whole
+    // report and blank the walsender and slot data below.
+    Promise.all(
+      targets.map(target =>
+        probe(target).catch(
+          (error): ReplicaHealth => ({
+            name: target.name,
+            status: 'unreachable',
+            in_recovery: null,
+            replay_lsn: null,
+            last_xact_replay_timestamp: null,
+            replay_delay_seconds: null,
+            error: errorMessage(error),
+          })
+        )
+      )
+    ),
     getWalSenders().catch(error => {
       errors.push(`pg_stat_replication: ${errorMessage(error)}`);
       return [] as WalSender[];

--- a/apps/web/src/lib/replication-health.ts
+++ b/apps/web/src/lib/replication-health.ts
@@ -140,6 +140,12 @@ export async function probeReplica(target: ReplicaTarget): Promise<ReplicaHealth
       },
     });
 
+    // A pg.Pool emits 'error' when an idle/checked-out client's connection drops
+    // unexpectedly (likely here, since we probe replicas that may already be in a
+    // bad state). Without a listener Node treats it as unhandled and crashes the
+    // process, so attach a no-op like the long-lived pools in lib/drizzle.ts do.
+    client.pool.on('error', () => {});
+
     const { rows } = await client.db.execute<ReplicaProbeRow>(sql`
       SELECT
         pg_is_in_recovery() AS in_recovery,

--- a/apps/web/src/lib/replication-health.ts
+++ b/apps/web/src/lib/replication-health.ts
@@ -1,0 +1,257 @@
+import { createDrizzleClient } from '@kilocode/db/client';
+import { sql } from 'drizzle-orm';
+
+import { getEnvVariable } from '@/lib/dotenvx';
+import { db } from '@/lib/drizzle';
+
+/**
+ * Replication health for the primary's read replicas and logical (Snowflake)
+ * consumers.
+ *
+ * Why not just `pg_stat_replication`? That view only lists *currently connected*
+ * walsenders. A read replica whose walreceiver has died (e.g. it fell behind and
+ * the primary recycled the WAL it needed) simply has no row there, so it is
+ * invisible — which is exactly the failure we most want to catch. Logical slots
+ * disappear from that view the same way once their consumer disconnects.
+ *
+ * So the authoritative per-replica signal is measured *on each replica* via
+ * `pg_last_xact_replay_timestamp()`, and slot health is read from
+ * `pg_replication_slots` on the primary (which persists even when the consumer
+ * is gone). `pg_stat_replication` is still reported, but only as "who is
+ * streaming right now".
+ */
+
+/** A replica we expect to exist, resolved from its per-region connection string. */
+export type ReplicaTarget = {
+  name: string;
+  url: string;
+};
+
+/**
+ * Expected replicas, mirroring the replica URLs consumed in lib/drizzle.ts.
+ * Targets without a configured URL are omitted (nothing to probe).
+ */
+export function getExpectedReplicaTargets(): ReplicaTarget[] {
+  const entries: Array<[string, string]> = [
+    ['us-west', getEnvVariable('POSTGRES_REPLICA_US_URL')],
+    ['eu-central-1', getEnvVariable('POSTGRES_REPLICA_EU_URL')],
+    ['eu-central-2', getEnvVariable('POSTGRES_REPLICA_EU_URL_2')],
+  ];
+  return entries.filter(([, url]) => url.length > 0).map(([name, url]) => ({ name, url }));
+}
+
+/**
+ * A healthy read replica trails the primary by well under a second. Anything
+ * past this threshold is treated as an alertable lag (the stuck US-west replica
+ * sat days behind before this was noticed).
+ */
+export const REPLICA_LAG_ALERT_SECONDS = 300;
+
+/**
+ * `pg_replication_slots.wal_status` values that mean the slot is at, or past,
+ * the point of losing WAL it still needs. 'lost' is unrecoverable; 'unreserved'
+ * is imminent. 'reserved' and 'extended' are both still safe.
+ */
+const AT_RISK_WAL_STATUSES = new Set(['unreserved', 'lost']);
+
+const PROBE_TIMEOUT_MS = 5_000;
+
+export type ReplicaHealthStatus = 'ok' | 'lagging' | 'not_in_recovery' | 'unreachable';
+
+export type ReplicaHealth = {
+  name: string;
+  status: ReplicaHealthStatus;
+  in_recovery: boolean | null;
+  replay_lsn: string | null;
+  last_xact_replay_timestamp: string | null;
+  replay_delay_seconds: number | null;
+  error: string | null;
+};
+
+type ReplicaProbeRow = {
+  in_recovery: boolean;
+  replay_lsn: string | null;
+  last_xact_replay_timestamp: string | null;
+  replay_delay_seconds: number | null;
+};
+
+/** Currently-connected walsender, as seen on the primary. */
+export type WalSender = {
+  application_name: string | null;
+  client_addr: string | null;
+  state: string | null;
+  sync_state: string | null;
+  replay_lag_bytes: string;
+  replay_lag_seconds: number | null;
+};
+
+export type ReplicationSlot = {
+  slot_name: string;
+  slot_type: string | null;
+  active: boolean;
+  wal_status: string | null;
+  retained_wal_bytes: string;
+  at_risk: boolean;
+};
+
+export type ReplicationHealthReport = {
+  healthy: boolean;
+  timestamp: string;
+  replicas: ReplicaHealth[];
+  walSenders: WalSender[];
+  slots: ReplicationSlot[];
+  errors: string[];
+};
+
+function errorMessage(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+/** Pure status derivation, split out so it can be unit-tested without a database. */
+export function classifyReplicaRow(row: ReplicaProbeRow): ReplicaHealthStatus {
+  if (!row.in_recovery) return 'not_in_recovery';
+  if (row.replay_delay_seconds !== null && row.replay_delay_seconds > REPLICA_LAG_ALERT_SECONDS) {
+    return 'lagging';
+  }
+  return 'ok';
+}
+
+/**
+ * Connect directly to a single replica and ask it how far behind it is. Never
+ * throws: connection/timeout failures are reported as `status: 'unreachable'`,
+ * which is itself the signal that the replica is down.
+ */
+export async function probeReplica(target: ReplicaTarget): Promise<ReplicaHealth> {
+  const client = createDrizzleClient({
+    connectionString: target.url,
+    poolConfig: {
+      max: 1,
+      application_name: 'kilocode-web-replication-health',
+      connectionTimeoutMillis: PROBE_TIMEOUT_MS,
+      statement_timeout: PROBE_TIMEOUT_MS,
+      query_timeout: PROBE_TIMEOUT_MS,
+    },
+  });
+
+  try {
+    const { rows } = await client.db.execute<ReplicaProbeRow>(sql`
+      SELECT
+        pg_is_in_recovery() AS in_recovery,
+        pg_last_wal_replay_lsn()::text AS replay_lsn,
+        pg_last_xact_replay_timestamp()::text AS last_xact_replay_timestamp,
+        EXTRACT(EPOCH FROM (now() - pg_last_xact_replay_timestamp()))::double precision
+          AS replay_delay_seconds
+    `);
+
+    const row = rows[0];
+    if (!row) {
+      return {
+        name: target.name,
+        status: 'unreachable',
+        in_recovery: null,
+        replay_lsn: null,
+        last_xact_replay_timestamp: null,
+        replay_delay_seconds: null,
+        error: 'probe returned no rows',
+      };
+    }
+
+    return {
+      name: target.name,
+      status: classifyReplicaRow(row),
+      in_recovery: row.in_recovery,
+      replay_lsn: row.replay_lsn,
+      last_xact_replay_timestamp: row.last_xact_replay_timestamp,
+      replay_delay_seconds: row.replay_delay_seconds,
+      error: null,
+    };
+  } catch (error) {
+    return {
+      name: target.name,
+      status: 'unreachable',
+      in_recovery: null,
+      replay_lsn: null,
+      last_xact_replay_timestamp: null,
+      replay_delay_seconds: null,
+      error: errorMessage(error),
+    };
+  } finally {
+    await client.pool.end().catch(() => {});
+  }
+}
+
+async function getWalSenders(): Promise<WalSender[]> {
+  const { rows } = await db.execute<WalSender>(sql`
+    SELECT
+      application_name,
+      client_addr::text AS client_addr,
+      state,
+      sync_state,
+      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), replay_lsn), 0)::text AS replay_lag_bytes,
+      EXTRACT(EPOCH FROM replay_lag)::double precision AS replay_lag_seconds
+    FROM pg_stat_replication
+    ORDER BY application_name, client_addr
+  `);
+  return rows;
+}
+
+type ReplicationSlotRow = Omit<ReplicationSlot, 'at_risk'>;
+
+async function getReplicationSlots(): Promise<ReplicationSlot[]> {
+  const { rows } = await db.execute<ReplicationSlotRow>(sql`
+    SELECT
+      slot_name,
+      slot_type,
+      active,
+      wal_status,
+      COALESCE(pg_wal_lsn_diff(pg_current_wal_lsn(), restart_lsn), 0)::text AS retained_wal_bytes
+    FROM pg_replication_slots
+    ORDER BY slot_name
+  `);
+  return rows.map(row => ({
+    ...row,
+    at_risk: AT_RISK_WAL_STATUSES.has(row.wal_status ?? ''),
+  }));
+}
+
+/**
+ * Collect the full replication picture: per-replica lag (probed on each
+ * replica), connected walsenders, and slot health. Primary-side queries are
+ * isolated so one failing component does not blank the whole report.
+ *
+ * `probe` and `targets` are injectable for testing.
+ */
+export async function collectReplicationHealth(options?: {
+  probe?: (target: ReplicaTarget) => Promise<ReplicaHealth>;
+  targets?: ReplicaTarget[];
+}): Promise<ReplicationHealthReport> {
+  const targets = options?.targets ?? getExpectedReplicaTargets();
+  const probe = options?.probe ?? probeReplica;
+  const errors: string[] = [];
+
+  const [replicas, walSenders, slots] = await Promise.all([
+    Promise.all(targets.map(target => probe(target))),
+    getWalSenders().catch(error => {
+      errors.push(`pg_stat_replication: ${errorMessage(error)}`);
+      return [] as WalSender[];
+    }),
+    getReplicationSlots().catch(error => {
+      errors.push(`pg_replication_slots: ${errorMessage(error)}`);
+      return [] as ReplicationSlot[];
+    }),
+  ]);
+
+  const healthy =
+    errors.length === 0 &&
+    replicas.every(replica => replica.status === 'ok') &&
+    slots.every(slot => !slot.at_risk);
+
+  return {
+    healthy,
+    timestamp: new Date().toISOString(),
+    replicas,
+    walSenders,
+    slots,
+    errors,
+  };
+}

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -61,6 +61,10 @@
       "schedule": "* * * * *"
     },
     {
+      "path": "/api/cron/db-replication-health",
+      "schedule": "*/5 * * * *"
+    },
+    {
       "path": "/api/cron/dispatch-affiliate-events",
       "schedule": "* * * * *"
     },


### PR DESCRIPTION
## Why

We had a US-west read replica silently stuck ~8 days behind (its walreceiver crash-looped after the primary recycled WAL it still needed). The existing \`/api/internal/db/replication-lag\` endpoint queried \`pg_stat_replication\`, which **only lists currently-connected walsenders** — so a broken replica has no row and is invisible, exactly the failure we most want to catch. Logical (Snowflake) slots disappear from that view the same way once their consumer disconnects.

## What

New shared module \`apps/web/src/lib/replication-health.ts\` combining three signals:

- **Replica-side lag (authoritative).** Connects directly to each replica URL (\`POSTGRES_REPLICA_US_URL\`, \`POSTGRES_REPLICA_EU_URL\`, \`POSTGRES_REPLICA_EU_URL_2\`) and computes \`replay_delay_seconds\` from \`pg_last_xact_replay_timestamp()\` / \`pg_is_in_recovery()\`. Measured on the replica, so a stuck box reports days of delay (or \`unreachable\`) instead of vanishing. Short-lived \`max: 1\` pool with connect/statement/query timeouts; never throws.
- **Slot health (primary).** Reads \`pg_replication_slots\` for \`active\` / \`wal_status\` / retained WAL, flagging \`at_risk\` when \`wal_status ∈ {unreserved, lost}\` — catches lost Snowflake slots and slots approaching \`max_slot_wal_keep_size\`.
- **\`pg_stat_replication\`**, kept but reframed as "who is streaming right now".

\`collectReplicationHealth()\` isolates primary-query failures into \`errors[]\` and returns a single \`healthy\` boolean.

### Endpoint A — \`/api/internal/db/replication-lag\`
Returns the full report (\`healthy\`, \`replicas\`, \`walSenders\`, \`slots\`, \`errors\`, \`timestamp\`). Same \`X-Internal-Secret\` auth. **Response shape changed** (no other consumers).

### Cron B — \`/api/cron/db-replication-health\` (new, \`*/5 * * * *\`)
Reuses the module, emits per-replica/per-slot JSON to the Vercel→Axiom log drain, and \`captureException\`s to Sentry on lagging/unreachable replicas or at-risk slots.

**Design note:** I deliberately did *not* extend \`db-pool-metrics\`. That cron is a single-purpose Supabase Prometheus scraper, and the \`physical_replication_lag_*\` metric has a documented history of returning no data (and can share the same connected-only blind spot). A dedicated cron on the reliable replica-side SQL probe is cleaner and more trustworthy.

## Testing
- \`replication-health.test.ts\`, both route tests — **13/13 pass** (status classification, healthy/unreachable/lost-slot/primary-failure paths, auth).
- oxlint: 0 warnings/errors. \`pnpm format\` applied. \`tsgo --noEmit\` (apps/web) clean.

## Follow-ups (non-blocking)
- \`REPLICA_LAG_ALERT_SECONDS\` (300s) and the \`*/5\` cadence are easy-to-tune defaults.
- The module opens a fresh pool per probe — fine at this frequency; would want cached pools if ever used on a hot path.