### PR TITLE
fix(ai-gateway): measure generation time

### DIFF
--- a/apps/web/src/app/api/dev/consume-credits/route.ts
+++ b/apps/web/src/app/api/dev/consume-credits/route.ts
@@ -98,7 +98,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     };
 
     // Use the existing countAndStoreUsage function
-    await countAndStoreUsage(mockResponse, usageContext, undefined);
+    await countAndStoreUsage(mockResponse, usageContext, undefined, null);
 
     // Reset the balance cache using the proper function
     await forceImmediateExpirationRecomputation(kiloUserId);

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -898,7 +898,8 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     usageContext.session_id || '<none>'
   );
 
-  const ttfbMs = Math.max(0, Math.round(performance.now() - requestStartedAt));
+  const upstreamResponseReceivedAt = performance.now();
+  const ttfbMs = Math.max(0, Math.round(upstreamResponseReceivedAt - requestStartedAt));
   usageContext.ttfb_ms = ttfbMs;
 
   emitApiMetricsForResponse(
@@ -967,7 +968,12 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     usageContext.abuse_request_id = classifyResult.request_id;
   }
 
-  accountForMicrodollarUsage(clonedReponse, usageContext, openrouterRequestSpan);
+  accountForMicrodollarUsage(
+    clonedReponse,
+    usageContext,
+    openrouterRequestSpan,
+    upstreamResponseReceivedAt
+  );
 
   const requestLogging = {
     user: maybeUser,

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -372,34 +372,38 @@ export function wrapInSafeNextResponse(response: Response) {
 export function accountForMicrodollarUsage(
   clonedReponse: Response,
   usageContext: MicrodollarUsageContext,
-  openrouterRequestSpan: Span | undefined
+  openrouterRequestSpan: Span | undefined,
+  generationStartedAtMs: number
 ) {
   const logFileExtension = usageContext.isStreaming ? '.log.resp.sse' : '.log.resp.json';
   debugSaveProxyResponseStream(clonedReponse, logFileExtension);
   after(
-    countAndStoreUsage(clonedReponse, usageContext, openrouterRequestSpan).then(
-      async usageIdentity => {
-        // Chain the experiment-attribution write after the microdollar
-        // write. This is best-effort analytics: failures here MUST NOT
-        // roll back the billing write, which has already succeeded by
-        // the time we reach here. `persistExperimentAttribution`
-        // swallows errors internally.
-        if (
-          usageIdentity &&
-          usageContext.modelExperimentVariantVersionId &&
-          usageContext.modelExperimentAllocationSubject
-        ) {
-          await persistExperimentAttribution({
-            usageId: usageIdentity.usageId,
-            createdAt: usageIdentity.createdAt,
-            variantVersionId: usageContext.modelExperimentVariantVersionId,
-            allocationSubject: usageContext.modelExperimentAllocationSubject,
-            clientRequestId: usageContext.clientRequestId ?? null,
-            capture: usageContext.experimentPromptCapture ?? null,
-          });
-        }
+    countAndStoreUsage(
+      clonedReponse,
+      usageContext,
+      openrouterRequestSpan,
+      generationStartedAtMs
+    ).then(async usageIdentity => {
+      // Chain the experiment-attribution write after the microdollar
+      // write. This is best-effort analytics: failures here MUST NOT
+      // roll back the billing write, which has already succeeded by
+      // the time we reach here. `persistExperimentAttribution`
+      // swallows errors internally.
+      if (
+        usageIdentity &&
+        usageContext.modelExperimentVariantVersionId &&
+        usageContext.modelExperimentAllocationSubject
+      ) {
+        await persistExperimentAttribution({
+          usageId: usageIdentity.usageId,
+          createdAt: usageIdentity.createdAt,
+          variantVersionId: usageContext.modelExperimentVariantVersionId,
+          allocationSubject: usageContext.modelExperimentAllocationSubject,
+          clientRequestId: usageContext.clientRequestId ?? null,
+          capture: usageContext.experimentPromptCapture ?? null,
+        });
       }
-    )
+    })
   );
 }
 

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -13,6 +13,7 @@ import {
   stripNulBytesInPlace,
   toInsertableDbUsageRecord,
   usageTransactionIdleTimeoutQuery,
+  withGenerationTimeFallback,
 } from './processUsage';
 import type { OpenRouterGeneration } from '@/lib/ai-gateway/providers/openrouter/types';
 import { verifyApproval } from '../../tests/helpers/approval.helper';
@@ -99,6 +100,58 @@ describe('processOpenRouterUsage', () => {
 
     expect(result.cost_mUsd).toBe(20000);
     expect(result.is_byok).toBe(true);
+  });
+});
+
+describe('withGenerationTimeFallback', () => {
+  const usageStats: MicrodollarUsageStats = {
+    messageId: 'test-message-id',
+    model: 'test-model',
+    responseContent: 'test-response',
+    hasError: false,
+    inference_provider: 'test-provider',
+    upstream_id: null,
+    finish_reason: 'stop',
+    latency: null,
+    moderation_latency: null,
+    generation_time: null,
+    streamed: true,
+    cancelled: null,
+    status_code: 200,
+    cost_mUsd: 1,
+    inputTokens: 1,
+    outputTokens: 1,
+    cacheWriteTokens: 0,
+    cacheHitTokens: 0,
+    is_byok: false,
+  };
+
+  test('measures generation time in milliseconds', () => {
+    const result = withGenerationTimeFallback(usageStats, 1_000, 3_500.4);
+
+    expect(result?.generation_time).toBe(2_500);
+  });
+
+  test('preserves provider-reported generation time', () => {
+    const result = withGenerationTimeFallback(
+      { ...usageStats, generation_time: 1_234 },
+      1_000,
+      3_500
+    );
+
+    expect(result?.generation_time).toBe(1_234);
+  });
+
+  test('leaves generation time absent without a start time', () => {
+    const result = withGenerationTimeFallback(usageStats, null, 3_500);
+
+    expect(result?.generation_time).toBeNull();
+  });
+
+  test('clamps generation time when the monotonic clock moves backwards', () => {
+    const result = withGenerationTimeFallback(usageStats, 3_500, 1_000);
+
+    expect(result?.generation_time).toBe(0);
   });
 });
 
@@ -270,7 +323,8 @@ describe('parseMicrodollarUsageFromStream approval tests', () => {
           api_kind: apiKind,
           isStreaming: false,
         } as MicrodollarUsageContext,
-        undefined
+        undefined,
+        performance.now()
       )
     ).resolves.toBeNull();
   });

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -127,14 +127,21 @@ describe('withGenerationTimeFallback', () => {
   };
 
   test('measures generation time in milliseconds', () => {
-    const result = withGenerationTimeFallback(usageStats, 1_000, 3_500.4);
+    const result = withGenerationTimeFallback(usageStats, true, 1_000, 3_500.4);
 
     expect(result?.generation_time).toBe(2_500);
+  });
+
+  test('leaves generation time absent for non-streaming responses', () => {
+    const result = withGenerationTimeFallback(usageStats, false, 1_000, 3_500);
+
+    expect(result?.generation_time).toBeNull();
   });
 
   test('preserves provider-reported generation time', () => {
     const result = withGenerationTimeFallback(
       { ...usageStats, generation_time: 1_234 },
+      true,
       1_000,
       3_500
     );
@@ -143,13 +150,13 @@ describe('withGenerationTimeFallback', () => {
   });
 
   test('leaves generation time absent without a start time', () => {
-    const result = withGenerationTimeFallback(usageStats, null, 3_500);
+    const result = withGenerationTimeFallback(usageStats, true, null, 3_500);
 
     expect(result?.generation_time).toBeNull();
   });
 
   test('clamps generation time when the monotonic clock moves backwards', () => {
-    const result = withGenerationTimeFallback(usageStats, 3_500, 1_000);
+    const result = withGenerationTimeFallback(usageStats, true, 3_500, 1_000);
 
     expect(result?.generation_time).toBe(0);
   });

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -926,7 +926,8 @@ async function insertUsageAndMetadataWithBalanceUpdate(
 export function countAndStoreUsage(
   clonedReponse: Response,
   usageContext: MicrodollarUsageContext,
-  openrouterRequestSpan: Span | undefined
+  openrouterRequestSpan: Span | undefined,
+  generationStartedAtMs: number | null
 ) {
   let usageStatsPromise: Promise<MicrodollarUsageStats | null> = Promise.resolve(null);
 
@@ -983,7 +984,28 @@ export function countAndStoreUsage(
     }
   }
 
-  return usageStatsPromise.then(usageStats => processTokenData(usageStats, usageContext));
+  return usageStatsPromise.then(usageStats =>
+    processTokenData(
+      withGenerationTimeFallback(usageStats, generationStartedAtMs, performance.now()),
+      usageContext
+    )
+  );
+}
+
+/** Uses response-body duration when provider generation metadata has no timing. */
+export function withGenerationTimeFallback(
+  usageStats: MicrodollarUsageStats | null,
+  generationStartedAtMs: number | null,
+  generationCompletedAtMs: number
+): MicrodollarUsageStats | null {
+  if (!usageStats || usageStats.generation_time !== null || generationStartedAtMs === null) {
+    return usageStats;
+  }
+
+  return {
+    ...usageStats,
+    generation_time: Math.max(0, Math.round(generationCompletedAtMs - generationStartedAtMs)),
+  };
 }
 
 export function processOpenRouterUsage(
@@ -1249,6 +1271,7 @@ export async function processTokenData(
 
     genStats.model = usageStats.model; // openrouter bug?
     genStats.upstream_id ??= usageStats.upstream_id; // keep the id the response already reported
+    genStats.generation_time ??= usageStats.generation_time;
     genStats.hasError = usageStats.hasError; // retain by choice
     genStats.status_code = usageStats.status_code; // retain by choice
     genStats.streamed ??= usageContext.isStreaming;

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -986,19 +986,30 @@ export function countAndStoreUsage(
 
   return usageStatsPromise.then(usageStats =>
     processTokenData(
-      withGenerationTimeFallback(usageStats, generationStartedAtMs, performance.now()),
+      withGenerationTimeFallback(
+        usageStats,
+        usageContext.isStreaming,
+        generationStartedAtMs,
+        performance.now()
+      ),
       usageContext
     )
   );
 }
 
-/** Uses response-body duration when provider generation metadata has no timing. */
+/** Uses streamed response-body duration when provider generation metadata has no timing. */
 export function withGenerationTimeFallback(
   usageStats: MicrodollarUsageStats | null,
+  isStreaming: boolean,
   generationStartedAtMs: number | null,
   generationCompletedAtMs: number
 ): MicrodollarUsageStats | null {
-  if (!usageStats || usageStats.generation_time !== null || generationStartedAtMs === null) {
+  if (
+    !usageStats ||
+    !isStreaming ||
+    usageStats.generation_time !== null ||
+    generationStartedAtMs === null
+  ) {
     return usageStats;
   }
 


### PR DESCRIPTION
## Summary
- measure generation duration from upstream response headers through response-body completion
- store the measured milliseconds in `microdollar_usage_metadata.generation_time` when provider metadata does not supply a value
- keep provider generation lookup timing authoritative and exclude synthetic dev credit consumption

## Verification
- `pnpm test --runInBand --runTestsByPath src/lib/ai-gateway/processUsage.test.ts --testNamePattern withGenerationTimeFallback`
- `pnpm test --runInBand --runTestsByPath src/app/api/openrouter/[...path]/route.test.ts`
- `pnpm typecheck` (apps/web)
- changed-file `oxlint`, `oxfmt --list-different`, and `git diff --check`