### PR TITLE
fix(ai-gateway): log partial response body when client disconnects mid-stream

### DIFF
--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -914,7 +914,25 @@ describe('request log capture', () => {
     const reader = result.body?.getReader();
     await reader?.cancel();
 
-    expect(capture.setReadError).toHaveBeenCalled();
+    expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), undefined);
     expect(capture.setBody).not.toHaveBeenCalled();
   });
+
+  test.each(rewriters)(
+    '%s: records the chunks received before the response stream is cancelled',
+    async (_name, rewrite) => {
+      const capture = makeCapture();
+      const receivedChunks = 'data: {"id":"gen-1","choices":[]}\n\n';
+      const { response: upstream } = hangingSseResponse(receivedChunks);
+
+      const result = await rewrite(upstream, true, capture, null);
+      const reader = result.body?.getReader();
+      await reader?.read();
+      await reader?.cancel();
+
+      expect(capture.setReadError).toHaveBeenCalledTimes(1);
+      expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), receivedChunks);
+      expect(capture.setBody).not.toHaveBeenCalled();
+    }
+  );
 });

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -263,6 +263,10 @@ async function readResponseText(
   }
 }
 
+function partialCapturedBody(capturedChunks: string[] | null): string | undefined {
+  return capturedChunks && capturedChunks.length > 0 ? capturedChunks.join('') : undefined;
+}
+
 async function rewriteSseStream(
   reader: ReadableStreamDefaultReader<Uint8Array>,
   parser: ReturnType<typeof createParser>,
@@ -272,17 +276,12 @@ async function rewriteSseStream(
   serializeError: (error: ResponseReadError) => string,
   onFinally: () => void,
   vercelRequestId: string | null | undefined,
-  capture: RequestLogCapture | null
+  capture: RequestLogCapture | null,
+  capturedChunks: string[] | null
 ) {
   const decoder = new TextDecoder();
-  // Accumulate the raw upstream text for request logging while the stream is
-  // being processed anyway, so it doesn't have to be processed a second time.
-  const capturedChunks: string[] | null = capture ? [] : null;
   const settleReadError = (error: unknown) =>
-    capture?.setReadError(
-      error,
-      capturedChunks && capturedChunks.length > 0 ? capturedChunks.join('') : undefined
-    );
+    capture?.setReadError(error, partialCapturedBody(capturedChunks));
   const settleBody = () => {
     if (capturedChunks) {
       capturedChunks.push(decoder.decode());
@@ -398,6 +397,11 @@ export async function rewriteModelResponse_ChatCompletions(
     });
   }
 
+  // Accumulate the raw upstream text for request logging while the stream is
+  // being processed anyway, so it doesn't have to be processed a second time.
+  // Shared with the stream's cancel() callback so a client disconnect still
+  // logs the partially received response body.
+  const capturedChunks: string[] | null = capture ? [] : null;
   const stream = new ReadableStream({
     async start(controller) {
       const reader = response.body?.getReader();
@@ -480,11 +484,15 @@ export async function rewriteModelResponse_ChatCompletions(
           '\n\n',
         progress.stop,
         vercelRequestId,
-        capture
+        capture,
+        capturedChunks
       );
     },
     cancel() {
-      capture?.setReadError(new Error('response stream was cancelled'));
+      capture?.setReadError(
+        new Error('response stream was cancelled'),
+        partialCapturedBody(capturedChunks)
+      );
     },
   });
 
@@ -559,6 +567,11 @@ export async function rewriteModelResponse_Messages(
     });
   }
 
+  // Accumulate the raw upstream text for request logging while the stream is
+  // being processed anyway, so it doesn't have to be processed a second time.
+  // Shared with the stream's cancel() callback so a client disconnect still
+  // logs the partially received response body.
+  const capturedChunks: string[] | null = capture ? [] : null;
   const stream = new ReadableStream({
     async start(controller) {
       const reader = response.body?.getReader();
@@ -648,11 +661,15 @@ export async function rewriteModelResponse_Messages(
           '\n\n',
         progress.stop,
         vercelRequestId,
-        capture
+        capture,
+        capturedChunks
       );
     },
     cancel() {
-      capture?.setReadError(new Error('response stream was cancelled'));
+      capture?.setReadError(
+        new Error('response stream was cancelled'),
+        partialCapturedBody(capturedChunks)
+      );
     },
   });
 
@@ -708,6 +725,11 @@ export async function rewriteModelResponse_Responses(
     });
   }
 
+  // Accumulate the raw upstream text for request logging while the stream is
+  // being processed anyway, so it doesn't have to be processed a second time.
+  // Shared with the stream's cancel() callback so a client disconnect still
+  // logs the partially received response body.
+  const capturedChunks: string[] | null = capture ? [] : null;
   const stream = new ReadableStream({
     async start(controller) {
       const reader = response.body?.getReader();
@@ -792,11 +814,15 @@ export async function rewriteModelResponse_Responses(
           '\n\n',
         progress.stop,
         vercelRequestId,
-        capture
+        capture,
+        capturedChunks
       );
     },
     cancel() {
-      capture?.setReadError(new Error('response stream was cancelled'));
+      capture?.setReadError(
+        new Error('response stream was cancelled'),
+        partialCapturedBody(capturedChunks)
+      );
     },
   });
 


### PR DESCRIPTION
## Problem

When a client disconnects mid-stream (e.g. it gives up the moment an error event arrives), the response pipeline's `cancel()` callback settled the request-log capture with `'response stream was cancelled'` and **no response body** — even though `rewriteSseStream` had already accumulated the raw upstream chunks (including the error event) in `capturedChunks`. The accumulated text lived in a closure the `cancel()` callback couldn't reach, and `settleOnce` made the empty settlement win, so the `api_request_log` row ended up with `response = NULL` and only a `response_body_read_error`.

This mostly hits non-terminal error events (`{"error": ...}` chunks on chat_completions, `type: 'error'` events on messages), where the upstream keeps the stream open briefly after the error and the client disconnects first. Terminal events (`[DONE]`, `message_stop`, `response.completed/incomplete/failed`) were already captured because `settleBody()` runs synchronously in the same macrotask as the final `enqueue`, before `cancel()` can interleave.

## Fix

Hoist the `capturedChunks` buffer out of `rewriteSseStream` into the scope shared by the stream's `start()` and `cancel()` callbacks (one line of plumbing per API kind), so `cancel()` can settle with the partial body received so far — same as the existing upstream timeout/disconnect paths already do via `settleReadError`. The buffer stays `null` when request logging is disabled, so non-logged traffic still accumulates nothing.

## Not covered (intentionally)

If the client disconnects *before any bytes arrive* (e.g. client-side timeout while the upstream is still rate-limiting), there is still nothing to log, and an error event that arrives after the disconnect is dropped — capturing it would require keeping the upstream stream alive purely for logging after the client is gone.

## Tests

- New: each API kind records the chunks received before the response stream is cancelled.
- Tightened the existing cancel test to assert a `undefined` partial body when nothing was streamed.

Note: `pnpm format:check`/`lint`/`typecheck --changes-only` passed via the pre-push hook; the jest run for this file was not completed locally.