### PR TITLE
fix(kilo-pass): emit kilo_pass_purchase_completed server-side, once per sale

### DIFF
--- a/.kilo_workflow/learnings/prettier-churn-cannot-be-undone-by-oxfmt.md
+++ b/.kilo_workflow/learnings/prettier-churn-cannot-be-undone-by-oxfmt.md
@@ -1,0 +1,29 @@
+# Prettier churn cannot be undone by running oxfmt afterwards
+
+**Symptom.** A role agent's diff on its owned files is far larger than the planned
+change (thousands of lines across untouched regions): single quotes flipped to double
+quotes, object literals rewrapped multi-line. The agent ran Prettier (defaults or its
+own config) on repo files.
+
+**Cause.** This repository's formatter is **oxfmt** (root `pnpm format`, config
+`.oxfmtrc.json`: `singleQuote`, `printWidth: 100`). Prettier with defaults
+(`printWidth: 80`, double quotes) reformats whole files. The trap: running oxfmt
+afterwards does NOT restore the original. Prettier expands object literals to one
+property per line, and oxfmt (like Prettier) preserves object literals that are
+already expanded in the source — so the double-quote churn reverts but the object
+expansion stays. Both states are formatter fixed points; the original single-line
+form is unrecoverable by formatting.
+
+**Fix.**
+
+- Recovery: `git checkout HEAD -- <files>` and re-apply the functional edits. Do not
+  attempt formatter-based repair.
+- Prevention (dispatchers): every implementer handoff that touches files pins —
+  never run `prettier`/`npx prettier`; the repo formatter is oxfmt
+  (`pnpm -w exec oxfmt <file>`); before finishing, run
+  `git diff HEAD --stat -- <owned paths>` and confirm the diff is limited to the
+  functional edits.
+- Detection (orchestrator): compare the emitted slice diff size against the planned
+  change size BEFORE dispatching the reviewer. A diff many times larger than the
+  plan's edit description is churn — revert and redo the round; do not send churn to
+  the reviewer and do not commit it.

--- a/.kilo_workflow/learnings/web-jest-full-suite-local-workers-and-collisions.md
+++ b/.kilo_workflow/learnings/web-jest-full-suite-local-workers-and-collisions.md
@@ -1,0 +1,33 @@
+# Running the full web jest suite locally: workers, timeouts, and run collisions
+
+**Symptom 1 — mass per-test 5s timeouts and 60s `beforeAll` hook timeouts across
+unrelated suites when running `pnpm --filter web test` locally.** The failures name
+`workerSetup.ts` `beforeAll` or `cleanupDbForTest` in `beforeEach`, in suites far from
+whatever you changed.
+
+**Cause.** `apps/web/jest.config.ts` defaults to `maxWorkers: '50%'`. Every worker's
+first suite cold-starts a per-worker database
+(`DROP DATABASE … WITH (FORCE)` + `CREATE DATABASE` + full drizzle migrate + partition
+provisioning, `apps/web/src/tests/setup/workerSetup.ts`). On a laptop docker postgres,
+N parallel cold starts exceed the hardcoded 60s hook timeout; the setup flag file is
+only written after success, so every subsequent suite re-runs the full setup and times
+out again — the whole run is poisoned from the start. Even after setup, 200-table
+`TRUNCATE` cleanup per test can exceed the 5s default test timeout under load.
+
+**Fix.** Run the full suite as `JEST_MAX_WORKERS=1 pnpm --filter web test` with nothing
+else DB-heavy on the machine, and expect it to take hours (~680 suites). Per-file
+(`pnpm --filter web test -- <file>`) runs are fine with default workers. If a full-run
+failure is in a suite your diff does not touch, re-run that suite alone before
+believing it.
+
+**Symptom 2 — a second concurrent DB-test run crashes with `ERR_UNHANDLED_ERROR` /
+`Connection terminated unexpectedly`, and both runs produce garbage results.**
+
+**Cause.** With `JEST_MAX_WORKERS=1` (or any equal worker count), both runs use the
+same `JEST_WORKER_ID`s and therefore the SAME `postgres-<workerId>` databases: each
+run's setup `DROP DATABASE … WITH (FORCE)` terminates the other run's connections
+mid-flight.
+
+**Fix.** Never run two web jest invocations (or anything else using the shared
+docker postgres test setup) concurrently on one worktree. One DB-test run at a time,
+machine-wide.

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
@@ -5,6 +5,12 @@ import { type Purchase } from 'expo-iap';
 import { toast } from 'sonner-native';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import {
+  captureEvent,
+  KILO_PASS_PURCHASE_COMPLETED_EVENT,
+  KILO_PASS_PURCHASE_FAILED_EVENT,
+  KILO_PASS_PURCHASE_STARTED_EVENT,
+} from '@/lib/analytics/posthog';
+import {
   createAppStoreKiloPassPurchaseActions,
   resetInlinePurchaseErrorOwnership,
   resetPurchaseErrorToastDedup,
@@ -900,6 +906,26 @@ describe('StoreKiloPassPurchaseProvider', () => {
     expect(releasedValue.isPending).toBe(false);
     await releasedValue.purchase(product);
     expect(mockedIap.requestPurchase).toHaveBeenCalledTimes(2);
+  });
+
+  it('emits started and failed client events but not purchase_completed', async () => {
+    const provider = renderStoreKiloPassPurchaseProvider();
+    const initialValue = provider.render();
+
+    await initialValue.purchase(product, { onCompleted: noop });
+    expect(captureEvent).toHaveBeenCalledWith(KILO_PASS_PURCHASE_STARTED_EVENT);
+
+    mockedIap.handlers?.onPurchaseSuccess(createPurchase());
+    await flushPromises();
+
+    expect(captureEvent).not.toHaveBeenCalledWith(KILO_PASS_PURCHASE_COMPLETED_EVENT);
+
+    const afterSuccess = provider.render();
+    await afterSuccess.purchase(product);
+    mockedIap.handlers?.onPurchaseError(new Error('StoreKit failed'));
+
+    expect(captureEvent).toHaveBeenCalledWith(KILO_PASS_PURCHASE_FAILED_EVENT);
+    expect(captureEvent).not.toHaveBeenCalledWith(KILO_PASS_PURCHASE_COMPLETED_EVENT);
   });
 
   it('toasts a purchase error when no screen owns inline feedback', async () => {

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
@@ -912,12 +912,20 @@ describe('StoreKiloPassPurchaseProvider', () => {
     const provider = renderStoreKiloPassPurchaseProvider();
     const initialValue = provider.render();
 
-    await initialValue.purchase(product, { onCompleted: noop });
+    const completedSpy = vi.fn();
+    await initialValue.purchase(product, {
+      onCompleted: () => {
+        completedSpy();
+      },
+    });
     expect(captureEvent).toHaveBeenCalledWith(KILO_PASS_PURCHASE_STARTED_EVENT);
 
     mockedIap.handlers?.onPurchaseSuccess(createPurchase());
     await flushPromises();
 
+    // Anchor: proves the completion callback (where the client capture used to
+    // live) actually ran, so the negative assertion below is not vacuous.
+    expect(completedSpy).toHaveBeenCalledTimes(1);
     expect(captureEvent).not.toHaveBeenCalledWith(KILO_PASS_PURCHASE_COMPLETED_EVENT);
 
     const afterSuccess = provider.render();

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
@@ -24,7 +24,6 @@ import { z } from 'zod';
 
 import {
   captureEvent,
-  KILO_PASS_PURCHASE_COMPLETED_EVENT,
   KILO_PASS_PURCHASE_FAILED_EVENT,
   KILO_PASS_PURCHASE_STARTED_EVENT,
 } from '@/lib/analytics/posthog';
@@ -498,9 +497,8 @@ function IosStoreKiloPassPurchaseProvider({ children }: { children: ReactNode })
         finishTransaction,
         invalidateAfterCompletion,
         onPurchaseCompleted: () => {
-          // Only user-initiated purchases reach here — recovery and restore
-          // flows pass notifyCompletion: false.
-          captureEvent(KILO_PASS_PURCHASE_COMPLETED_EVENT);
+          // Completed is emitted server-side by completeAppStorePurchase — do not
+          // re-add a client capture (double counting).
           setErrorMessage(null);
           const onCompleted = pendingPurchaseCompletedCallbackRef.current;
           pendingPurchaseCompletedCallbackRef.current = null;

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
@@ -27,10 +27,8 @@ import {
   KiloPassPaymentProvider,
   KiloPassTier,
 } from './enums';
-import type {
-  AppleStoreDecodedNotification,
-  processAppStoreKiloPassNotification as ProcessAppStoreKiloPassNotificationFn,
-} from './apple-store-notifications';
+import type * as AppleStoreNotifications from './apple-store-notifications';
+import type { AppleStoreDecodedNotification } from './apple-store-notifications';
 import type { AppleStoreDecodedTransaction } from './apple-store-verifier';
 import { toMicrodollars } from '@/lib/utils';
 
@@ -52,7 +50,7 @@ function getPosthogTrackingMock(): PosthogTrackingMock {
   return jest.requireMock('@/lib/kilo-pass/posthog-tracking') as PosthogTrackingMock;
 }
 
-let processAppStoreKiloPassNotification: ProcessAppStoreKiloPassNotificationFn;
+let processAppStoreKiloPassNotification: typeof AppleStoreNotifications.processAppStoreKiloPassNotification;
 
 const APP_STORE_NOTIFICATION_TEST_NOW_MS = Date.parse('2026-05-15T00:00:00.000Z');
 
@@ -318,17 +316,15 @@ describe('processAppStoreKiloPassNotification', () => {
 
       expect(result).toEqual({ processed: true });
       expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
-      const trackCall = trackingMock.trackKiloPassPurchaseCompleted.mock.calls[0]?.[0] as {
-        purchaseKind: string;
-      };
-      expect(trackCall.purchaseKind).toBeDefined();
-      expect(['initial', 'renewal', 'upgrade']).toContain(trackCall.purchaseKind);
+      // tier19 → tier49 within the previous purchase's period classifies as a
+      // same-period upgrade in completeStoreKiloPassPurchase (pinned in slice 1);
+      // this asserts the kind is forwarded through the ASSN path.
       expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith(
         expect.objectContaining({
           channel: 'app_store',
           distinctId: user.google_user_email,
           userId: user.id,
-          purchaseKind: trackCall.purchaseKind,
+          purchaseKind: 'upgrade',
           providerTransactionId: upgradeTransaction.transactionId,
           productId: upgradeTransaction.productId,
           environment: upgradeTransaction.environment,

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
@@ -27,7 +27,10 @@ import {
   KiloPassPaymentProvider,
   KiloPassTier,
 } from './enums';
-import type { AppleStoreDecodedNotification } from './apple-store-notifications';
+import type {
+  AppleStoreDecodedNotification,
+  processAppStoreKiloPassNotification as ProcessAppStoreKiloPassNotificationFn,
+} from './apple-store-notifications';
 import type { AppleStoreDecodedTransaction } from './apple-store-verifier';
 import { toMicrodollars } from '@/lib/utils';
 
@@ -49,7 +52,7 @@ function getPosthogTrackingMock(): PosthogTrackingMock {
   return jest.requireMock('@/lib/kilo-pass/posthog-tracking') as PosthogTrackingMock;
 }
 
-let processAppStoreKiloPassNotification: typeof import('./apple-store-notifications').processAppStoreKiloPassNotification;
+let processAppStoreKiloPassNotification: ProcessAppStoreKiloPassNotificationFn;
 
 const APP_STORE_NOTIFICATION_TEST_NOW_MS = Date.parse('2026-05-15T00:00:00.000Z');
 

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
@@ -1,4 +1,4 @@
-import { afterAll, beforeAll, describe, expect, it, jest } from '@jest/globals';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
   DeliveryStatus,
   NotificationTypeV2,
@@ -27,10 +27,29 @@ import {
   KiloPassPaymentProvider,
   KiloPassTier,
 } from './enums';
-import { processAppStoreKiloPassNotification } from './apple-store-notifications';
 import type { AppleStoreDecodedNotification } from './apple-store-notifications';
 import type { AppleStoreDecodedTransaction } from './apple-store-verifier';
 import { toMicrodollars } from '@/lib/utils';
+
+// SWC + static ESM imports do not see jest.mock replacements on the same module id.
+// Dynamic-import the SUT after the mock (same pattern as stripe-handlers-invoice-paid.test.ts).
+jest.mock('@/lib/kilo-pass/posthog-tracking', () => ({
+  runAfterResponse: async (work: () => Promise<void>) => {
+    await work();
+  },
+  trackKiloPassPurchaseCompleted: jest.fn(),
+}));
+
+type PosthogTrackingMock = {
+  trackKiloPassPurchaseCompleted: jest.Mock;
+  runAfterResponse: (work: () => Promise<void>) => Promise<void>;
+};
+
+function getPosthogTrackingMock(): PosthogTrackingMock {
+  return jest.requireMock('@/lib/kilo-pass/posthog-tracking') as PosthogTrackingMock;
+}
+
+let processAppStoreKiloPassNotification: typeof import('./apple-store-notifications').processAppStoreKiloPassNotification;
 
 const APP_STORE_NOTIFICATION_TEST_NOW_MS = Date.parse('2026-05-15T00:00:00.000Z');
 
@@ -99,12 +118,220 @@ async function insertProviderScopedSubscriptionRows(providerSubscriptionId: stri
 describe('processAppStoreKiloPassNotification', () => {
   let dateNowSpy: jest.SpiedFunction<typeof Date.now>;
 
-  beforeAll(() => {
+  beforeAll(async () => {
     dateNowSpy = jest.spyOn(Date, 'now').mockReturnValue(APP_STORE_NOTIFICATION_TEST_NOW_MS);
+    ({ processAppStoreKiloPassNotification } = await import('./apple-store-notifications'));
   });
 
   afterAll(() => {
     dateNowSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    getPosthogTrackingMock().trackKiloPassPurchaseCompleted.mockClear();
+  });
+
+  describe('kilo_pass_purchase_completed tracking', () => {
+    it('does not track when the notification UUID was already processed', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const user = await insertTestUser();
+      const decodedNotification = notification();
+      const decodedTransaction = transaction({
+        appAccountToken: user.app_store_account_token,
+      });
+      const params = {
+        signedPayload: 'payload',
+        decodeNotification: async () => decodedNotification,
+        decodeTransaction: async () => decodedTransaction,
+      };
+
+      await processAppStoreKiloPassNotification(params);
+      trackingMock.trackKiloPassPurchaseCompleted.mockClear();
+
+      const replay = await processAppStoreKiloPassNotification(params);
+      expect(replay).toEqual({ processed: true, status: 'already_processed' });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).not.toHaveBeenCalled();
+    });
+
+    it('does not track when the provider transaction was already recorded by the app', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const user = await insertTestUser();
+      const providerSubscriptionId = `orig-${crypto.randomUUID()}`;
+      const providerTransactionId = `tx-${crypto.randomUUID()}`;
+      const decodedTransaction = transaction({
+        originalTransactionId: providerSubscriptionId,
+        transactionId: providerTransactionId,
+        appAccountToken: user.app_store_account_token,
+      });
+
+      // App path records the purchase first (same provider transaction id).
+      await processAppStoreKiloPassNotification({
+        signedPayload: 'app-first-initial',
+        decodeNotification: async () =>
+          notification({
+            notificationUUID: `note-${crypto.randomUUID()}`,
+            notificationType: NotificationTypeV2.SUBSCRIBED,
+            subtype: Subtype.INITIAL_BUY,
+          }),
+        decodeTransaction: async () => decodedTransaction,
+      });
+      trackingMock.trackKiloPassPurchaseCompleted.mockClear();
+
+      const result = await processAppStoreKiloPassNotification({
+        signedPayload: 'assn-same-tx',
+        decodeNotification: async () =>
+          notification({
+            notificationUUID: `note-${crypto.randomUUID()}`,
+            notificationType: NotificationTypeV2.DID_RENEW,
+          }),
+        decodeTransaction: async () => decodedTransaction,
+      });
+
+      expect(result).toEqual({ processed: true });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).not.toHaveBeenCalled();
+    });
+
+    it('tracks DID_RENEW with a new transaction as renewal', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const user = await insertTestUser();
+      const providerSubscriptionId = `orig-${crypto.randomUUID()}`;
+
+      await processAppStoreKiloPassNotification({
+        signedPayload: 'renewal-initial',
+        decodeNotification: async () =>
+          notification({
+            notificationUUID: `note-${crypto.randomUUID()}`,
+            notificationType: NotificationTypeV2.SUBSCRIBED,
+            subtype: Subtype.INITIAL_BUY,
+          }),
+        decodeTransaction: async () =>
+          transaction({
+            originalTransactionId: providerSubscriptionId,
+            appAccountToken: user.app_store_account_token,
+          }),
+      });
+      trackingMock.trackKiloPassPurchaseCompleted.mockClear();
+
+      const renewalTransaction = transaction({
+        originalTransactionId: providerSubscriptionId,
+        transactionId: `tx-${crypto.randomUUID()}`,
+        appAccountToken: user.app_store_account_token,
+      });
+      const result = await processAppStoreKiloPassNotification({
+        signedPayload: 'renewal',
+        decodeNotification: async () =>
+          notification({
+            notificationUUID: `note-${crypto.randomUUID()}`,
+            notificationType: NotificationTypeV2.DID_RENEW,
+          }),
+        decodeTransaction: async () => renewalTransaction,
+      });
+
+      expect(result).toEqual({ processed: true });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'app_store',
+          distinctId: user.google_user_email,
+          userId: user.id,
+          purchaseKind: 'renewal',
+          providerTransactionId: renewalTransaction.transactionId,
+          productId: renewalTransaction.productId,
+          environment: renewalTransaction.environment,
+        })
+      );
+    });
+
+    it('tracks SUBSCRIBED with a resolved user and new transaction as initial', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const user = await insertTestUser();
+      const decodedTransaction = transaction({
+        appAccountToken: user.app_store_account_token,
+      });
+
+      const result = await processAppStoreKiloPassNotification({
+        signedPayload: 'subscribed-initial',
+        decodeNotification: async () =>
+          notification({
+            notificationUUID: `note-${crypto.randomUUID()}`,
+            notificationType: NotificationTypeV2.SUBSCRIBED,
+            subtype: Subtype.INITIAL_BUY,
+          }),
+        decodeTransaction: async () => decodedTransaction,
+      });
+
+      expect(result).toEqual({ processed: true });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'app_store',
+          distinctId: user.google_user_email,
+          userId: user.id,
+          purchaseKind: 'initial',
+          providerTransactionId: decodedTransaction.transactionId,
+          productId: decodedTransaction.productId,
+          environment: decodedTransaction.environment,
+        })
+      );
+    });
+
+    it('forwards purchaseKind from completion on DID_CHANGE_RENEWAL_PREF UPGRADE', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const user = await insertTestUser();
+      const providerSubscriptionId = `orig-${crypto.randomUUID()}`;
+
+      await processAppStoreKiloPassNotification({
+        signedPayload: 'upgrade-initial',
+        decodeNotification: async () =>
+          notification({
+            notificationUUID: `note-${crypto.randomUUID()}`,
+            notificationType: NotificationTypeV2.SUBSCRIBED,
+            subtype: Subtype.INITIAL_BUY,
+          }),
+        decodeTransaction: async () =>
+          transaction({
+            originalTransactionId: providerSubscriptionId,
+            appAccountToken: user.app_store_account_token,
+          }),
+      });
+      trackingMock.trackKiloPassPurchaseCompleted.mockClear();
+
+      const upgradeTransaction = transaction({
+        originalTransactionId: providerSubscriptionId,
+        transactionId: `tx-${crypto.randomUUID()}`,
+        productId: 'kilopass.tier49.monthly.v1',
+        appAccountToken: user.app_store_account_token,
+      });
+      const result = await processAppStoreKiloPassNotification({
+        signedPayload: 'upgrade-pref',
+        decodeNotification: async () =>
+          notification({
+            notificationUUID: `note-${crypto.randomUUID()}`,
+            notificationType: NotificationTypeV2.DID_CHANGE_RENEWAL_PREF,
+            subtype: Subtype.UPGRADE,
+          }),
+        decodeTransaction: async () => upgradeTransaction,
+      });
+
+      expect(result).toEqual({ processed: true });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      const trackCall = trackingMock.trackKiloPassPurchaseCompleted.mock.calls[0]?.[0] as {
+        purchaseKind: string;
+      };
+      expect(trackCall.purchaseKind).toBeDefined();
+      expect(['initial', 'renewal', 'upgrade']).toContain(trackCall.purchaseKind);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          channel: 'app_store',
+          distinctId: user.google_user_email,
+          userId: user.id,
+          purchaseKind: trackCall.purchaseKind,
+          providerTransactionId: upgradeTransaction.transactionId,
+          productId: upgradeTransaction.productId,
+          environment: upgradeTransaction.environment,
+        })
+      );
+    });
   });
 
   it('records a renewal notification and completes the subscription once', async () => {

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.ts
@@ -34,7 +34,14 @@ import {
   createAppleStoreServerApiClient,
   createAppleStoreSignedDataVerifier,
 } from './apple-store-sdk';
-import { completeStoreKiloPassPurchase } from './store-subscription-completion';
+import {
+  completeStoreKiloPassPurchase,
+  type CompleteStoreKiloPassPurchaseResult,
+} from './store-subscription-completion';
+import {
+  runAfterResponse,
+  trackKiloPassPurchaseCompleted,
+} from '@/lib/kilo-pass/posthog-tracking';
 import { redactStoreAccountLinkedJson } from './store-payload-redaction';
 import { dayjs } from './dayjs';
 
@@ -722,8 +729,9 @@ export async function processAppStoreKiloPassNotification(params: {
         );
       }
     } else {
+      let completionResult: CompleteStoreKiloPassPurchaseResult | null = null;
       await db.transaction(async tx => {
-        await completeStoreKiloPassPurchase({ dbOrTx: tx, user, purchase });
+        completionResult = await completeStoreKiloPassPurchase({ dbOrTx: tx, user, purchase });
         await appendKiloPassAuditLog(tx, {
           action: KiloPassAuditLogAction.StoreSubscriptionRenewed,
           result: KiloPassAuditLogResult.Success,
@@ -743,6 +751,23 @@ export async function processAppStoreKiloPassNotification(params: {
             )
           );
       });
+      // Post-commit only — never capture inside the transaction.
+      const trackedResult = completionResult;
+      if (trackedResult && !trackedResult.alreadyProcessed) {
+        await runAfterResponse(async () => {
+          trackKiloPassPurchaseCompleted({
+            channel: 'app_store',
+            distinctId: user.google_user_email,
+            userId: user.id,
+            tier: trackedResult.tier,
+            cadence: trackedResult.cadence,
+            purchaseKind: trackedResult.purchaseKind,
+            providerTransactionId: purchase.providerTransactionId,
+            productId: purchase.productId,
+            environment: purchase.environment,
+          });
+        });
+      }
       return { processed: true };
     }
   }

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.ts
@@ -752,7 +752,7 @@ export async function processAppStoreKiloPassNotification(params: {
           );
       });
       // Post-commit only — never capture inside the transaction.
-      const trackedResult = completionResult;
+      const trackedResult = completionResult as CompleteStoreKiloPassPurchaseResult | null;
       if (trackedResult && !trackedResult.alreadyProcessed) {
         await runAfterResponse(async () => {
           trackKiloPassPurchaseCompleted({

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.ts
@@ -38,10 +38,7 @@ import {
   completeStoreKiloPassPurchase,
   type CompleteStoreKiloPassPurchaseResult,
 } from './store-subscription-completion';
-import {
-  runAfterResponse,
-  trackKiloPassPurchaseCompleted,
-} from '@/lib/kilo-pass/posthog-tracking';
+import { runAfterResponse, trackKiloPassPurchaseCompleted } from '@/lib/kilo-pass/posthog-tracking';
 import { redactStoreAccountLinkedJson } from './store-payload-redaction';
 import { dayjs } from './dayjs';
 

--- a/apps/web/src/lib/kilo-pass/posthog-tracking.test.ts
+++ b/apps/web/src/lib/kilo-pass/posthog-tracking.test.ts
@@ -1,0 +1,143 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { trackKiloPassPurchaseCompleted as trackKiloPassPurchaseCompletedType } from './posthog-tracking';
+import { KiloPassCadence, KiloPassTier } from './enums';
+
+jest.mock('@/lib/posthog', () => {
+  const mockCapture = jest.fn();
+  return {
+    __esModule: true,
+    default: jest.fn(() => ({ capture: mockCapture })),
+    mockCapture,
+  };
+});
+
+jest.mock('@sentry/nextjs', () => {
+  const mockCaptureException = jest.fn();
+  return {
+    captureException: mockCaptureException,
+    mockCaptureException,
+  };
+});
+
+jest.mock('next/server', () => ({
+  after: jest.fn(),
+}));
+
+jest.mock('@/lib/config.server', () => ({
+  IS_IN_AUTOMATED_TEST: true,
+}));
+
+let trackKiloPassPurchaseCompleted: typeof trackKiloPassPurchaseCompletedType;
+
+const posthogMock: { mockCapture: jest.Mock } = jest.requireMock('@/lib/posthog');
+const sentryMock: { mockCaptureException: jest.Mock } = jest.requireMock('@sentry/nextjs');
+const { mockCapture } = posthogMock;
+const { mockCaptureException } = sentryMock;
+
+beforeAll(async () => {
+  ({ trackKiloPassPurchaseCompleted } = await import('./posthog-tracking'));
+});
+
+describe('Kilo Pass PostHog tracking', () => {
+  beforeEach(() => {
+    mockCapture.mockReset();
+    mockCaptureException.mockReset();
+  });
+
+  it('captures app_store purchase completed with snake_case wire properties', () => {
+    trackKiloPassPurchaseCompleted({
+      channel: 'app_store',
+      distinctId: 'user@example.com',
+      userId: 'user-123',
+      tier: KiloPassTier.Tier49,
+      cadence: KiloPassCadence.Monthly,
+      purchaseKind: 'initial',
+      providerTransactionId: 'tx-abc',
+      productId: 'kilopass.tier49.monthly.v1',
+      environment: 'Sandbox',
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith({
+      distinctId: 'user@example.com',
+      event: 'kilo_pass_purchase_completed',
+      properties: {
+        channel: 'app_store',
+        tier: KiloPassTier.Tier49,
+        cadence: KiloPassCadence.Monthly,
+        purchase_kind: 'initial',
+        user_id: 'user-123',
+        provider_transaction_id: 'tx-abc',
+        product_id: 'kilopass.tier49.monthly.v1',
+        environment: 'Sandbox',
+      },
+    });
+  });
+
+  it('captures stripe purchase completed with snake_case wire properties', () => {
+    trackKiloPassPurchaseCompleted({
+      channel: 'stripe',
+      distinctId: 'user@example.com',
+      userId: 'user-456',
+      tier: KiloPassTier.Tier19,
+      cadence: KiloPassCadence.Yearly,
+      purchaseKind: 'renewal',
+      stripeInvoiceId: 'in_abc',
+      amountPaidUsd: 19,
+      currency: 'usd',
+      livemode: true,
+    });
+
+    expect(mockCapture).toHaveBeenCalledWith({
+      distinctId: 'user@example.com',
+      event: 'kilo_pass_purchase_completed',
+      properties: {
+        channel: 'stripe',
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Yearly,
+        purchase_kind: 'renewal',
+        user_id: 'user-456',
+        stripe_invoice_id: 'in_abc',
+        amount_paid_usd: 19,
+        currency: 'usd',
+        livemode: true,
+      },
+    });
+  });
+
+  it('reports capture failures without throwing', () => {
+    const error = new Error('capture failed');
+    mockCapture.mockImplementation(() => {
+      throw error;
+    });
+
+    expect(() =>
+      trackKiloPassPurchaseCompleted({
+        channel: 'app_store',
+        distinctId: 'user@example.com',
+        userId: 'user-123',
+        tier: KiloPassTier.Tier49,
+        cadence: KiloPassCadence.Monthly,
+        purchaseKind: 'upgrade',
+        providerTransactionId: 'tx-abc',
+        productId: 'kilopass.tier49.monthly.v1',
+        environment: 'Production',
+      })
+    ).not.toThrow();
+
+    expect(mockCaptureException).toHaveBeenCalledWith(error, {
+      tags: { source: 'posthog_kilo_pass_purchase_completed' },
+      extra: {
+        properties: {
+          channel: 'app_store',
+          tier: KiloPassTier.Tier49,
+          cadence: KiloPassCadence.Monthly,
+          purchase_kind: 'upgrade',
+          user_id: 'user-123',
+          provider_transaction_id: 'tx-abc',
+          product_id: 'kilopass.tier49.monthly.v1',
+          environment: 'Production',
+        },
+      },
+    });
+  });
+});

--- a/apps/web/src/lib/kilo-pass/posthog-tracking.ts
+++ b/apps/web/src/lib/kilo-pass/posthog-tracking.ts
@@ -1,0 +1,95 @@
+/**
+ * Server-side PostHog tracking for Kilo Pass purchase completion.
+ *
+ * Future store-purchase completion call sites (e.g. Google Play) must call
+ * `trackKiloPassPurchaseCompleted` post-commit — there is no automatic hook
+ * inside `completeStoreKiloPassPurchase`.
+ */
+import 'server-only';
+
+import { after } from 'next/server';
+import { captureException } from '@sentry/nextjs';
+
+import { IS_IN_AUTOMATED_TEST } from '@/lib/config.server';
+import PostHogClient from '@/lib/posthog';
+import type { KiloPassCadence, KiloPassTier } from './enums';
+
+export type KiloPassPurchaseKind = 'initial' | 'renewal' | 'upgrade' | 'unknown';
+
+type TrackKiloPassPurchaseCompletedBase = {
+  distinctId: string;
+  userId: string;
+  tier: KiloPassTier;
+  cadence: KiloPassCadence;
+  purchaseKind: KiloPassPurchaseKind;
+};
+
+export type TrackKiloPassPurchaseCompletedParams =
+  | (TrackKiloPassPurchaseCompletedBase & {
+      channel: 'app_store';
+      providerTransactionId: string;
+      productId: string;
+      environment: string;
+    })
+  | (TrackKiloPassPurchaseCompletedBase & {
+      channel: 'stripe';
+      stripeInvoiceId: string;
+      amountPaidUsd: number;
+      currency: string;
+      livemode: boolean;
+    });
+
+const posthogClient = PostHogClient();
+
+/**
+ * Copied from apps/web/src/lib/kiloclaw/stripe-handlers.ts:426.
+ * Keeps the serverless function alive until the capture is enqueued on
+ * provider-webhook paths.
+ */
+export async function runAfterResponse(work: () => Promise<void>): Promise<void> {
+  if (IS_IN_AUTOMATED_TEST) {
+    await work();
+    return;
+  }
+
+  after(work);
+}
+
+export function trackKiloPassPurchaseCompleted(params: TrackKiloPassPurchaseCompletedParams): void {
+  const baseProperties = {
+    channel: params.channel,
+    tier: params.tier,
+    cadence: params.cadence,
+    purchase_kind: params.purchaseKind,
+    user_id: params.userId,
+  };
+
+  const properties =
+    params.channel === 'app_store'
+      ? {
+          ...baseProperties,
+          provider_transaction_id: params.providerTransactionId,
+          product_id: params.productId,
+          environment: params.environment,
+        }
+      : {
+          ...baseProperties,
+          stripe_invoice_id: params.stripeInvoiceId,
+          amount_paid_usd: params.amountPaidUsd,
+          currency: params.currency,
+          livemode: params.livemode,
+        };
+
+  try {
+    posthogClient.capture({
+      distinctId: params.distinctId,
+      event: 'kilo_pass_purchase_completed',
+      properties,
+    });
+  } catch (error) {
+    captureException(error, {
+      tags: { source: 'posthog_kilo_pass_purchase_completed' },
+      extra: { properties },
+    });
+  }
+}

--- a/apps/web/src/lib/kilo-pass/store-subscription-completion.test.ts
+++ b/apps/web/src/lib/kilo-pass/store-subscription-completion.test.ts
@@ -53,6 +53,7 @@ describe('completeStoreKiloPassPurchase', () => {
       tier: KiloPassTier.Tier49,
       cadence: KiloPassCadence.Monthly,
       alreadyProcessed: false,
+      purchaseKind: 'initial',
     });
 
     const subscriptions = await db
@@ -126,7 +127,8 @@ describe('completeStoreKiloPassPurchase', () => {
     const first = await completeStoreKiloPassPurchase({ user, purchase });
     const replay = await completeStoreKiloPassPurchase({ user, purchase });
 
-    expect(replay).toEqual({ ...first, alreadyProcessed: true });
+    const { purchaseKind: _purchaseKind, ...firstWithoutKind } = first;
+    expect(replay).toEqual({ ...firstWithoutKind, alreadyProcessed: true });
 
     const storePurchases = await db
       .select()
@@ -283,7 +285,9 @@ describe('completeStoreKiloPassPurchase', () => {
         purchasedAtIso: '2026-01-05T12:00:00.000Z',
       }),
     });
-    await completeStoreKiloPassPurchase({
+    expect(first).toMatchObject({ alreadyProcessed: false, purchaseKind: 'initial' });
+
+    const renewal = await completeStoreKiloPassPurchase({
       user,
       purchase: applePurchase({
         providerSubscriptionId,
@@ -292,6 +296,7 @@ describe('completeStoreKiloPassPurchase', () => {
         purchasedAtIso: '2026-02-05T12:00:00.000Z',
       }),
     });
+    expect(renewal).toMatchObject({ alreadyProcessed: false, purchaseKind: 'renewal' });
 
     const subscription = await db.query.kilo_pass_subscriptions.findFirst({
       where: eq(kilo_pass_subscriptions.id, first.subscriptionId),
@@ -363,7 +368,7 @@ describe('completeStoreKiloPassPurchase', () => {
       }),
     });
 
-    await completeStoreKiloPassPurchase({
+    const upgrade = await completeStoreKiloPassPurchase({
       user,
       purchase: applePurchase({
         productId: 'kilopass.tier49.monthly.v1',
@@ -375,6 +380,7 @@ describe('completeStoreKiloPassPurchase', () => {
         tier: KiloPassTier.Tier49,
       }),
     });
+    expect(upgrade).toMatchObject({ alreadyProcessed: false, purchaseKind: 'upgrade' });
 
     const subscription = await db.query.kilo_pass_subscriptions.findFirst({
       where: eq(kilo_pass_subscriptions.provider_subscription_id, providerSubscriptionId),

--- a/apps/web/src/lib/kilo-pass/store-subscription-completion.test.ts
+++ b/apps/web/src/lib/kilo-pass/store-subscription-completion.test.ts
@@ -127,8 +127,12 @@ describe('completeStoreKiloPassPurchase', () => {
     const first = await completeStoreKiloPassPurchase({ user, purchase });
     const replay = await completeStoreKiloPassPurchase({ user, purchase });
 
-    const { purchaseKind: _purchaseKind, ...firstWithoutKind } = first;
-    expect(replay).toEqual({ ...firstWithoutKind, alreadyProcessed: true });
+    expect(replay).toEqual({
+      subscriptionId: first.subscriptionId,
+      tier: first.tier,
+      cadence: first.cadence,
+      alreadyProcessed: true,
+    });
 
     const storePurchases = await db
       .select()

--- a/apps/web/src/lib/kilo-pass/store-subscription-completion.ts
+++ b/apps/web/src/lib/kilo-pass/store-subscription-completion.ts
@@ -51,12 +51,20 @@ export type ValidatedStoreKiloPassPurchase = {
   rawPayload: Record<string, unknown>;
 };
 
-export type CompleteStoreKiloPassPurchaseResult = {
-  subscriptionId: string;
-  tier: KiloPassTier;
-  cadence: KiloPassCadence;
-  alreadyProcessed: boolean;
-};
+export type CompleteStoreKiloPassPurchaseResult =
+  | {
+      subscriptionId: string;
+      tier: KiloPassTier;
+      cadence: KiloPassCadence;
+      alreadyProcessed: true;
+    }
+  | {
+      subscriptionId: string;
+      tier: KiloPassTier;
+      cadence: KiloPassCadence;
+      alreadyProcessed: false;
+      purchaseKind: 'initial' | 'renewal' | 'upgrade';
+    };
 
 function getIssuanceSource(
   paymentProvider: ValidatedStoreKiloPassPurchase['paymentProvider']
@@ -660,11 +668,26 @@ export async function completeStoreKiloPassPurchase(params: {
       },
     });
 
+    // purchaseKind labeling (analytics-only; not on the tRPC output schema):
+    // - Resubscribe on an existing provider subscription row → renewal (any non-first
+    //   transaction on the subscription).
+    // - Upgrade landing after the previous period ended → renewal; the event's tier
+    //   property carries the new tier, so no information is lost.
+    // - "Subscription row exists but no prior purchase row" is structurally impossible
+    //   for App Store (subscription + purchase insert in the same transaction), so
+    //   renewal always means a real prior transaction.
+    const purchaseKind = isAppStoreSamePeriodUpgrade
+      ? ('upgrade' as const)
+      : existingProviderSubscription != null
+        ? ('renewal' as const)
+        : ('initial' as const);
+
     return {
       subscriptionId,
       tier: purchase.tier,
       cadence: purchase.cadence,
       alreadyProcessed: false,
+      purchaseKind,
     };
   };
 

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.test.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.test.ts
@@ -33,6 +33,22 @@ import type * as affiliateEventsModule from '@/lib/impact/affiliate-events';
 import { randomUUID } from 'node:crypto';
 import { digestCardFingerprint } from '@/lib/kilo-pass/card-fingerprint-gate';
 
+jest.mock('@/lib/kilo-pass/posthog-tracking', () => ({
+  runAfterResponse: async (work: () => Promise<void>) => {
+    await work();
+  },
+  trackKiloPassPurchaseCompleted: jest.fn(),
+}));
+
+type PosthogTrackingMock = {
+  trackKiloPassPurchaseCompleted: jest.Mock;
+  runAfterResponse: (work: () => Promise<void>) => Promise<void>;
+};
+
+function getPosthogTrackingMock(): PosthogTrackingMock {
+  return jest.requireMock('@/lib/kilo-pass/posthog-tracking') as PosthogTrackingMock;
+}
+
 function ensureKiloPassStripePriceIdEnv(): void {
   // These env vars are required at module-load time by [`getKnownStripePriceIdsForKiloPass()`](src/lib/kilo-pass/stripe-price-ids.server.ts:24).
   // If the host env already provides them, don't overwrite.
@@ -105,6 +121,7 @@ function makeStripeInvoice(params: {
     amount_paid: params.amount_paid_cents,
     billing_reason: params.billingReason ?? null,
     currency: params.currency ?? 'usd',
+    livemode: false,
     period_start: params.period_start_seconds,
     created: params.created_seconds,
     status_transitions:
@@ -333,10 +350,412 @@ function makeInvoicesListMock(params: {
 
 beforeEach(async () => {
   ensureKiloPassStripePriceIdEnv();
+  getPosthogTrackingMock().trackKiloPassPurchaseCompleted.mockClear();
   await cleanupDbForTest();
 });
 
 describe('handleKiloPassInvoicePaid', () => {
+  describe('kilo_pass_purchase_completed tracking', () => {
+    test('first invoice.paid emits one track call with stripe properties', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const { handleKiloPassInvoicePaid } =
+        await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
+
+      const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });
+      const stripeSubId = `sub_track_first_${Math.random()}`;
+      const invoiceId = `inv_track_first_${Math.random()}`;
+      const meta = kiloPassMetadata({
+        kiloUserId: user.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      const subscription = makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_735_689_600,
+        metadata: meta,
+      });
+      const priceId = await getKiloPassPriceId({
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_first_${Math.random()}`,
+        invoice: makeStripeInvoice({
+          id: invoiceId,
+          amount_paid_cents: 1900,
+          created_seconds: 1_735_689_600,
+          priceId,
+          subscriptionIdOrExpanded: stripeSubId,
+          metadata: meta,
+          billingReason: 'subscription_create',
+        }),
+        stripe: {
+          subscriptions: { retrieve: jest.fn(async () => subscription) },
+        } as unknown as Stripe,
+      });
+
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith({
+        channel: 'stripe',
+        distinctId: user.google_user_email,
+        userId: user.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        purchaseKind: 'initial',
+        stripeInvoiceId: invoiceId,
+        amountPaidUsd: 19,
+        currency: 'usd',
+        livemode: false,
+      });
+    });
+
+    test('sequentially redelivered webhook does not track again', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const { handleKiloPassInvoicePaid } =
+        await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
+
+      const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });
+      const stripeSubId = `sub_track_redeliver_${Math.random()}`;
+      const invoiceId = `inv_track_redeliver_${Math.random()}`;
+      const meta = kiloPassMetadata({
+        kiloUserId: user.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      const subscription = makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_735_689_600,
+        metadata: meta,
+      });
+      const priceId = await getKiloPassPriceId({
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      const invoice = makeStripeInvoice({
+        id: invoiceId,
+        amount_paid_cents: 1900,
+        created_seconds: 1_735_689_600,
+        priceId,
+        subscriptionIdOrExpanded: stripeSubId,
+        metadata: meta,
+        billingReason: 'subscription_create',
+      });
+      const stripe = {
+        subscriptions: { retrieve: jest.fn(async () => subscription) },
+      } as unknown as Stripe;
+
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_redeliver_a_${Math.random()}`,
+        invoice,
+        stripe,
+      });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+
+      trackingMock.trackKiloPassPurchaseCompleted.mockClear();
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_redeliver_b_${Math.random()}`,
+        invoice,
+        stripe,
+      });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(0);
+    });
+
+    test('second paid invoice in the same issue month still emits once', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const { handleKiloPassInvoicePaid } =
+        await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
+
+      const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });
+      const stripeSubId = `sub_track_same_month_${Math.random()}`;
+      const meta = kiloPassMetadata({
+        kiloUserId: user.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      const subscription = makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_735_689_600,
+        metadata: meta,
+      });
+      const priceId = await getKiloPassPriceId({
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      const stripe = {
+        subscriptions: { retrieve: jest.fn(async () => subscription) },
+      } as unknown as Stripe;
+
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_same_month_a_${Math.random()}`,
+        invoice: makeStripeInvoice({
+          id: `inv_track_same_month_a_${Math.random()}`,
+          amount_paid_cents: 1900,
+          created_seconds: 1_735_689_600,
+          priceId,
+          subscriptionIdOrExpanded: stripeSubId,
+          metadata: meta,
+          billingReason: 'subscription_create',
+        }),
+        stripe,
+      });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+
+      trackingMock.trackKiloPassPurchaseCompleted.mockClear();
+      const secondInvoiceId = `inv_track_same_month_b_${Math.random()}`;
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_same_month_b_${Math.random()}`,
+        invoice: makeStripeInvoice({
+          id: secondInvoiceId,
+          amount_paid_cents: 3000,
+          created_seconds: 1_735_689_600,
+          priceId,
+          subscriptionIdOrExpanded: stripeSubId,
+          metadata: meta,
+          billingReason: 'subscription_update',
+        }),
+        stripe,
+      });
+
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stripeInvoiceId: secondInvoiceId,
+          purchaseKind: 'upgrade',
+          amountPaidUsd: 30,
+        })
+      );
+    });
+
+    test('$0 invoice still emits once', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const { handleKiloPassInvoicePaid } =
+        await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
+
+      const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });
+      const stripeSubId = `sub_track_zero_${Math.random()}`;
+      const invoiceId = `inv_track_zero_${Math.random()}`;
+      const meta = kiloPassMetadata({
+        kiloUserId: user.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      const subscription = makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_735_689_600,
+        metadata: meta,
+      });
+      const priceId = await getKiloPassPriceId({
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_zero_${Math.random()}`,
+        invoice: makeStripeInvoice({
+          id: invoiceId,
+          amount_paid_cents: 0,
+          created_seconds: 1_735_689_600,
+          priceId,
+          subscriptionIdOrExpanded: stripeSubId,
+          metadata: meta,
+          billingReason: 'subscription_create',
+        }),
+        stripe: {
+          subscriptions: { retrieve: jest.fn(async () => subscription) },
+        } as unknown as Stripe,
+      });
+
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          stripeInvoiceId: invoiceId,
+          amountPaidUsd: 0,
+          purchaseKind: 'initial',
+        })
+      );
+    });
+
+    test('blocked duplicate-card purchase does not track', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const { handleKiloPassInvoicePaid } =
+        await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
+
+      const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });
+      const firstClaimant = await insertTestUser();
+      const fingerprint = `fp_track_blocked_${Math.random()}`;
+      const winnerSubId = `sub_track_winner_${Math.random()}`;
+      const winnerInvoiceId = `in_track_winner_${Math.random()}`;
+      const [firstClaimantSubscription] = await db
+        .insert(kilo_pass_subscriptions)
+        .values({
+          kilo_user_id: firstClaimant.id,
+          payment_provider: KiloPassPaymentProvider.Stripe,
+          provider_subscription_id: winnerSubId,
+          stripe_subscription_id: winnerSubId,
+          tier: KiloPassTier.Tier19,
+          cadence: KiloPassCadence.Monthly,
+          status: 'active',
+        })
+        .returning({ id: kilo_pass_subscriptions.id });
+      await db.insert(kilo_pass_issuances).values({
+        kilo_pass_subscription_id: firstClaimantSubscription.id,
+        issue_month: '2026-06-01',
+        source: KiloPassIssuanceSource.StripeInvoice,
+        stripe_invoice_id: winnerInvoiceId,
+      });
+      await db.insert(kilo_pass_welcome_promo_payment_fingerprint_claims).values({
+        stripe_payment_method_type: KiloPassWelcomePromoPaymentFingerprintType.Card,
+        stripe_fingerprint: fingerprint,
+        source_stripe_invoice_id: winnerInvoiceId,
+      });
+
+      const stripeSubscriptionId = `sub_track_blocked_${Math.random()}`;
+      const stripeInvoiceId = `in_track_blocked_${Math.random()}`;
+      const metadata = kiloPassMetadata({
+        kiloUserId: user.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      const priceId = await getKiloPassPriceId({
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_blocked_${Math.random()}`,
+        invoice: makeStripeInvoice({
+          id: stripeInvoiceId,
+          amount_paid_cents: 1900,
+          created_seconds: 1_780_272_000,
+          paid_seconds: 1_780_272_000,
+          priceId,
+          subscriptionIdOrExpanded: stripeSubscriptionId,
+          metadata,
+          invoicePaymentId: `inpay_track_blocked_${Math.random()}`,
+          invoicePayment: {
+            type: 'charge',
+            charge: makeFingerprintCharge(`ch_track_blocked_${Math.random()}`, 'card', fingerprint),
+          },
+          billingReason: 'subscription_create',
+        }),
+        stripe: {
+          subscriptions: {
+            retrieve: jest.fn(async () =>
+              makeStripeSubscription({
+                id: stripeSubscriptionId,
+                start_date_seconds: 1_780_272_000,
+                metadata,
+              })
+            ),
+            cancel: jest.fn(async () => ({ id: stripeSubscriptionId })),
+          },
+          refunds: { create: jest.fn(async () => ({ id: 're_track_blocked' })) },
+        } as unknown as Stripe,
+      });
+
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(0);
+    });
+
+    test('billing_reason subscription_create with pre-existing subscription row maps to initial', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const { handleKiloPassInvoicePaid } =
+        await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
+
+      const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });
+      const stripeSubId = `sub_track_preexist_${Math.random()}`;
+      const meta = kiloPassMetadata({
+        kiloUserId: user.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      await db.insert(kilo_pass_subscriptions).values({
+        kilo_user_id: user.id,
+        payment_provider: KiloPassPaymentProvider.Stripe,
+        provider_subscription_id: stripeSubId,
+        stripe_subscription_id: stripeSubId,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+        started_at: '2026-01-01T00:00:00.000Z',
+      });
+      const subscription = makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_735_689_600,
+        metadata: meta,
+      });
+      const priceId = await getKiloPassPriceId({
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_preexist_${Math.random()}`,
+        invoice: makeStripeInvoice({
+          id: `inv_track_preexist_${Math.random()}`,
+          amount_paid_cents: 1900,
+          created_seconds: 1_735_689_600,
+          priceId,
+          subscriptionIdOrExpanded: stripeSubId,
+          metadata: meta,
+          billingReason: 'subscription_create',
+        }),
+        stripe: {
+          subscriptions: { retrieve: jest.fn(async () => subscription) },
+        } as unknown as Stripe,
+      });
+
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({ purchaseKind: 'initial' })
+      );
+    });
+
+    test('null billing_reason maps to unknown and still emits', async () => {
+      const trackingMock = getPosthogTrackingMock();
+      const { handleKiloPassInvoicePaid } =
+        await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');
+
+      const user = await insertTestUser({ total_microdollars_acquired: 0, microdollars_used: 0 });
+      const stripeSubId = `sub_track_unknown_${Math.random()}`;
+      const meta = kiloPassMetadata({
+        kiloUserId: user.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+      const subscription = makeStripeSubscription({
+        id: stripeSubId,
+        start_date_seconds: 1_735_689_600,
+        metadata: meta,
+      });
+      const priceId = await getKiloPassPriceId({
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+      });
+
+      await handleKiloPassInvoicePaid({
+        eventId: `evt_track_unknown_${Math.random()}`,
+        invoice: makeStripeInvoice({
+          id: `inv_track_unknown_${Math.random()}`,
+          amount_paid_cents: 1900,
+          created_seconds: 1_735_689_600,
+          priceId,
+          subscriptionIdOrExpanded: stripeSubId,
+          metadata: meta,
+          billingReason: null,
+        }),
+        stripe: {
+          subscriptions: { retrieve: jest.fn(async () => subscription) },
+        } as unknown as Stripe,
+      });
+
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith(
+        expect.objectContaining({ purchaseKind: 'unknown' })
+      );
+    });
+  });
+
   test('returns early when invoice does not look like Kilo Pass (no DB side effects)', async () => {
     const { handleKiloPassInvoicePaid } =
       await import('@/lib/kilo-pass/stripe-handlers-invoice-paid');

--- a/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
+++ b/apps/web/src/lib/kilo-pass/stripe-handlers-invoice-paid.ts
@@ -72,6 +72,12 @@ import {
   type KiloPassAffiliateSaleContext,
 } from '@/lib/kilo-pass/affiliate-sale';
 import { processPersonalKiloPassStripePaidConversion } from '@/lib/impact/kilo-pass-referrals';
+import {
+  runAfterResponse,
+  trackKiloPassPurchaseCompleted,
+  type KiloPassPurchaseKind,
+} from '@/lib/kilo-pass/posthog-tracking';
+
 type DuplicateCardEnforcement = {
   kiloUserId: string;
   stripeInvoiceId: string;
@@ -394,6 +400,43 @@ async function maybeIssueYearlyRemainingCredits(params: {
   return true;
 }
 
+/**
+ * Whether this invoice already has a successful KiloPassInvoicePaidHandled audit row.
+ *
+ * HARD INVARIANT: MUST be called after the `kilo_pass_subscriptions` upsert (whose
+ * row lock serializes same-subscription webhook concurrency) and before this run's
+ * own Success-row append — moving it reopens a double-emit race.
+ */
+async function hasHandledKiloPassInvoicePaid(
+  tx: DrizzleTransaction,
+  stripeInvoiceId: string
+): Promise<boolean> {
+  const existing = await tx.query.kilo_pass_audit_log.findFirst({
+    columns: { id: true },
+    where: and(
+      eq(kilo_pass_audit_log.action, KiloPassAuditLogAction.KiloPassInvoicePaidHandled),
+      eq(kilo_pass_audit_log.result, KiloPassAuditLogResult.Success),
+      eq(kilo_pass_audit_log.stripe_invoice_id, stripeInvoiceId)
+    ),
+  });
+  return existing !== undefined;
+}
+
+function purchaseKindFromBillingReason(
+  billingReason: Stripe.Invoice['billing_reason']
+): KiloPassPurchaseKind {
+  switch (billingReason) {
+    case 'subscription_create':
+      return 'initial';
+    case 'subscription_cycle':
+      return 'renewal';
+    case 'subscription_update':
+      return 'upgrade';
+    default:
+      return 'unknown';
+  }
+}
+
 export async function handleKiloPassInvoicePaid(params: {
   eventId: string;
   invoice: Stripe.Invoice;
@@ -435,6 +478,7 @@ export async function handleKiloPassInvoicePaid(params: {
   // Track context for failure audit logging
   let kiloUserIdForAudit: string | null = null;
   let stripeSubscriptionIdForAudit: string | null = null;
+  let shouldTrackPurchase = false;
 
   let duplicateCardEnforcement: DuplicateCardEnforcement | null = null;
 
@@ -700,6 +744,11 @@ export async function handleKiloPassInvoicePaid(params: {
             })
           : null;
 
+      // Emit order: blocked early-return → subscription upsert (row lock) →
+      // hasHandledKiloPassInvoicePaid check → append this run's Success row →
+      // commit → emit via after().
+      shouldTrackPurchase = !(await hasHandledKiloPassInvoicePaid(tx, invoice.id));
+
       await appendKiloPassAuditLog(tx, {
         action: KiloPassAuditLogAction.KiloPassInvoicePaidHandled,
         result: KiloPassAuditLogResult.Success,
@@ -825,6 +874,56 @@ export async function handleKiloPassInvoicePaid(params: {
     }
 
     throw error;
+  }
+
+  if (shouldTrackPurchase) {
+    await runAfterResponse(async () => {
+      if (!kiloUserIdForAudit) {
+        captureException(
+          new Error('kilo_pass_purchase_completed skipped: missing purchaser or state'),
+          {
+            tags: { source: 'kilo_pass_purchase_tracking' },
+            extra: { stripeInvoiceId: invoice.id },
+          }
+        );
+        return;
+      }
+
+      const [purchaser] = await db
+        .select({ email: kilocode_users.google_user_email })
+        .from(kilocode_users)
+        .where(eq(kilocode_users.id, kiloUserIdForAudit))
+        .limit(1);
+
+      if (
+        !purchaser?.email ||
+        !referralConversionState.userId ||
+        !referralConversionState.tier ||
+        !referralConversionState.cadence
+      ) {
+        captureException(
+          new Error('kilo_pass_purchase_completed skipped: missing purchaser or state'),
+          {
+            tags: { source: 'kilo_pass_purchase_tracking' },
+            extra: { stripeInvoiceId: invoice.id },
+          }
+        );
+        return;
+      }
+
+      trackKiloPassPurchaseCompleted({
+        channel: 'stripe',
+        distinctId: purchaser.email,
+        userId: referralConversionState.userId,
+        tier: referralConversionState.tier,
+        cadence: referralConversionState.cadence,
+        purchaseKind: purchaseKindFromBillingReason(invoice.billing_reason),
+        stripeInvoiceId: invoice.id,
+        amountPaidUsd: invoice.amount_paid / 100,
+        currency: (invoice.currency ?? 'usd').toLowerCase(),
+        livemode: invoice.livemode,
+      });
+    });
   }
 
   if (duplicateCardEnforcement) {

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -100,6 +100,11 @@ type StoreCompletionMock = {
   completeStoreKiloPassPurchase: ReturnType<typeof jest.fn>;
 };
 
+type PosthogTrackingMock = {
+  trackKiloPassPurchaseCompleted: ReturnType<typeof jest.fn>;
+  runAfterResponse: (work: () => Promise<void>) => Promise<void>;
+};
+
 type SentryMock = {
   captureException: ReturnType<typeof jest.fn>;
 };
@@ -115,6 +120,10 @@ function getAppStoreVerifierMock(): AppStoreVerifierMock {
 
 function getStoreCompletionMock(): StoreCompletionMock {
   return jest.requireMock('@/lib/kilo-pass/store-subscription-completion') as StoreCompletionMock;
+}
+
+function getPosthogTrackingMock(): PosthogTrackingMock {
+  return jest.requireMock('@/lib/kilo-pass/posthog-tracking') as PosthogTrackingMock;
 }
 
 function getSentryMock(): SentryMock {
@@ -335,6 +344,13 @@ jest.mock('@/lib/kilo-pass/apple-store-verifier', () => ({
 
 jest.mock('@/lib/kilo-pass/store-subscription-completion', () => ({
   completeStoreKiloPassPurchase: jest.fn(),
+}));
+
+jest.mock('@/lib/kilo-pass/posthog-tracking', () => ({
+  runAfterResponse: async (work: () => Promise<void>) => {
+    await work();
+  },
+  trackKiloPassPurchaseCompleted: jest.fn(),
 }));
 
 async function insertSubscription(params: {
@@ -572,6 +588,7 @@ describe('kiloPassRouter', () => {
     stripeMock.invoices.list.mockReset();
     getAppStoreVerifierMock().verifyAppleKiloPassTransactionJws.mockReset();
     getStoreCompletionMock().completeStoreKiloPassPurchase.mockReset();
+    getPosthogTrackingMock().trackKiloPassPurchaseCompleted.mockReset();
     getSentryMock().captureException.mockReset();
   });
 
@@ -611,27 +628,78 @@ describe('kiloPassRouter', () => {
     it('succeeds when the transaction appAccountToken matches the signed-in user', async () => {
       const verifierMock = getAppStoreVerifierMock();
       const completionMock = getStoreCompletionMock();
+      const trackingMock = getPosthogTrackingMock();
       const sentryMock = getSentryMock();
       const user = await insertTestUser();
-      verifierMock.verifyAppleKiloPassTransactionJws.mockResolvedValue(
-        appStorePurchaseFixture({ appAccountToken: user.app_store_account_token })
-      );
-      const expectedResult = {
+      const purchase = appStorePurchaseFixture({
+        appAccountToken: user.app_store_account_token,
+      });
+      verifierMock.verifyAppleKiloPassTransactionJws.mockResolvedValue(purchase);
+      // Completion mock includes purchaseKind (server internal); tRPC output strips it.
+      const completionResult = {
         subscriptionId: 'sub-test-id',
         tier: KiloPassTier.Tier19,
         cadence: KiloPassCadence.Monthly,
+        alreadyProcessed: false as const,
+        purchaseKind: 'initial' as const,
+      };
+      const expectedClientResult = {
+        subscriptionId: completionResult.subscriptionId,
+        tier: completionResult.tier,
+        cadence: completionResult.cadence,
         alreadyProcessed: false,
       };
-      completionMock.completeStoreKiloPassPurchase.mockResolvedValue(expectedResult);
+      completionMock.completeStoreKiloPassPurchase.mockResolvedValue(completionResult);
 
       const caller = await createCallerForUser(user.id);
       const result = await caller.kiloPass.completeAppStorePurchase({
         signedTransactionJws: 'signed-jws',
       });
 
-      expect(result).toEqual(expectedResult);
+      expect(result).toEqual(expectedClientResult);
       expect(completionMock.completeStoreKiloPassPurchase).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledTimes(1);
+      expect(trackingMock.trackKiloPassPurchaseCompleted).toHaveBeenCalledWith({
+        channel: 'app_store',
+        distinctId: user.google_user_email,
+        userId: user.id,
+        tier: completionResult.tier,
+        cadence: completionResult.cadence,
+        purchaseKind: 'initial',
+        providerTransactionId: purchase.providerTransactionId,
+        productId: purchase.productId,
+        environment: purchase.environment,
+      });
       expect(sentryMock.captureException).not.toHaveBeenCalled();
+    });
+
+    it('does not track when completeStoreKiloPassPurchase reports alreadyProcessed', async () => {
+      const verifierMock = getAppStoreVerifierMock();
+      const completionMock = getStoreCompletionMock();
+      const trackingMock = getPosthogTrackingMock();
+      const user = await insertTestUser();
+      verifierMock.verifyAppleKiloPassTransactionJws.mockResolvedValue(
+        appStorePurchaseFixture({ appAccountToken: user.app_store_account_token })
+      );
+      completionMock.completeStoreKiloPassPurchase.mockResolvedValue({
+        subscriptionId: 'sub-test-id',
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        alreadyProcessed: true,
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.kiloPass.completeAppStorePurchase({
+        signedTransactionJws: 'signed-jws',
+      });
+
+      expect(result).toEqual({
+        subscriptionId: 'sub-test-id',
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        alreadyProcessed: true,
+      });
+      expect(trackingMock.trackKiloPassPurchaseCompleted).not.toHaveBeenCalled();
     });
 
     it('keeps account mismatch copy stable and does not log it as an internal failure', async () => {

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -81,6 +81,7 @@ import { closePauseEvent } from '@/lib/kilo-pass/pause-events';
 import { getAllMobileStoreKiloPassProducts } from '@/lib/kilo-pass/mobile-store-products';
 import { verifyAppleKiloPassTransactionJws } from '@/lib/kilo-pass/apple-store-verifier';
 import { completeStoreKiloPassPurchase } from '@/lib/kilo-pass/store-subscription-completion';
+import { trackKiloPassPurchaseCompleted } from '@/lib/kilo-pass/posthog-tracking';
 import {
   getInitialWelcomePromoContextForSubscription,
   getKiloPassWelcomePromoPolicy,
@@ -1051,7 +1052,21 @@ export const kiloPassRouter = createTRPCRouter({
           appAccountToken: purchase.appAccountToken,
           userAppStoreAccountToken: ctx.user.app_store_account_token,
         });
-        return await completeStoreKiloPassPurchase({ user: ctx.user, purchase });
+        const result = await completeStoreKiloPassPurchase({ user: ctx.user, purchase });
+        if (!result.alreadyProcessed) {
+          trackKiloPassPurchaseCompleted({
+            channel: 'app_store',
+            distinctId: ctx.user.google_user_email,
+            userId: ctx.user.id,
+            tier: result.tier,
+            cadence: result.cadence,
+            purchaseKind: result.purchaseKind,
+            providerTransactionId: purchase.providerTransactionId,
+            productId: purchase.productId,
+            environment: purchase.environment,
+          });
+        }
+        return result;
       } catch (error) {
         throw mapAppStoreCompletionError(error, ctx.user.id);
       }


### PR DESCRIPTION
## Summary

**What:** `kilo_pass_purchase_completed` is now emitted **server-side, at most once per completed sale**, at exactly three call sites — tRPC `completeAppStorePurchase`, Apple App Store Server Notifications completion, and Stripe `handleKiloPassInvoicePaid` — and the mobile client stops emitting it. New `purchase_kind` / `channel` (and per-channel) properties make the series filterable.

**Why:** the event undercounted actual Kilo Pass sales. The data team flagged that the PostHog count sits below real sales; the investigation found four root causes (below). The count stepping up to the true number is the fix, not an anomaly.

## Investigation narrative (root causes, with evidence)

Sales are recorded on the server across two channels and five code paths; the event was emitted only on one lossy client-side path.

- **RC1 — recovery/restore App Store completions never emitted (systematic).** The event fired only in `onPurchaseCompleted` (`apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts:503`), reachable only when `onPurchaseSuccess` matched `activePurchaseRequestRef.current?.sku === purchase.productId`. That ref is in-memory: if the app was backgrounded/killed/restarted between Apple's payment sheet succeeding and JS handling the success, the purchase completed later via the `availablePurchases` recovery effect (`:577`) or `recoverPurchases` — both pass `notifyCompletion: false`, so the backend recorded the sale and no event fired.
- **RC2 — Stripe web purchases never emitted at all (systematic).** Web checkout (`KiloPassSubscribeCard.tsx`) and the Stripe webhook flow (`stripe-handlers-invoice-paid.ts`) contained no PostHog emission at all. Both channels feed `kilo_pass_subscriptions`, so "passes sold" excluding Stripe was guaranteed to undercount.
- **RC3 — client-side capture was lossy (statistical).** `captureEvent` (`apps/mobile/src/lib/analytics/posthog.ts`) enqueues in memory; an app suspend right after capture lost the queued event (and capture is disabled in dev builds).
- **RC4 — semantic mismatch (definition).** Renewals never emitted (recovery/ASSN paths pass `notifyCompletion: false`), and TestFlight/sandbox purchases DID emit with no property to filter them out. The event as defined could never equal any backend-derived "passes sold" number.

## How (design)

**Server is the sole emitter, once per completed sale.** The single choke point for App Store sales is `completeStoreKiloPassPurchase` (inserts one `kilo_pass_store_purchases` row per provider transaction id, unique constraint on `(payment_provider, provider_transaction_id)`, returns `alreadyProcessed`). Emission gates on `alreadyProcessed === false`, so recovery replays, ASSN/app races, and tRPC retries collapse to one event. For Stripe, the anchor is the absence of a prior `kilo_pass_audit_log` row with `action = KiloPassInvoicePaidHandled`, `result = Success` for the invoice id — checked in-transaction **after** the `kilo_pass_subscriptions` upsert (whose row lock serializes same-subscription webhook concurrency) and **before** this run's own Success-row append. `baseCreditsResult.wasIssued` was considered and rejected: issuance is unique per `(subscription, issue_month)`, not per invoice, so second paid invoices in one month (upgrades, prorations) would silently never emit.

**Delivery guarantee: at most once, best-effort after commit.** The hard requirement is *no double counting*; emission happens only after the recording transaction commits (fire-and-forget on the user-facing tRPC mutation, Next.js `after()` on both provider webhooks so the serverless function stays alive). A crash between commit and capture loses that one event — accepted residual. Concurrent same-invoice Stripe redelivery is covered by the upsert row-lock reasoning above, not a DB uniqueness constraint — accepted residual; sequential redelivery is the tested bar. A full at-least-once outbox is out of scope (possible follow-up).

**Semantics (deliberate change, documented for the data team):**

- Event name unchanged — dashboards keep working.
- Per-transaction semantics: initial purchases, renewals, and upgrades each emit once, distinguished by `purchase_kind` (`initial` | `renewal` | `upgrade` | `unknown`). Rationale: under-delivery of events is unrecoverable downstream; over-delivery with a filter property is self-serve fixable. A renewal is a completed purchase (money moved); the DB records one row per charge. `purchase_kind` is a `billing_reason`/store-flow proxy, not a tier diff — proration/cadence-change invoices can read `upgrade`; a resubscribe on an existing provider subscription reads `renewal`; Stripe null/unmapped `billing_reason` reads `unknown` (never guessed from subscription-row presence, because `customer.subscription.created` can create the row before the first `invoice.paid` arrives — guessing would mislabel true first purchases).
- `$0` invoices (100% promo/trial first months) DO emit — a pass was granted and the subscription started; `amount_paid_usd: 0` makes them filterable.
- Wire properties (snake_case, matching `claw_trial_started` convention): both channels send `channel`, `tier`, `cadence`, `purchase_kind`, `user_id`; App Store adds `provider_transaction_id`, `product_id`, `environment`; Stripe adds `stripe_invoice_id`, `amount_paid_usd`, `currency`, `livemode`. `distinctId` is the user email, matching the web/mobile `identify(email)` convention so funnels stay joined.
- **Transition window:** old app versions keep emitting client-side until users update. Those events carry **no `channel` property** — filter them out with `channel IS SET`. PostHog cannot dedupe a client event against a server event for the same purchase, which is why the client emission is removed rather than kept.
- Blocked duplicate-card Stripe purchases return before the Success audit row is written and never emit; blocked/refunded purchases stay uncounted.

## Data-team guidance

- **Trustworthy series:** filter `kilo_pass_purchase_completed` to `channel IS SET`. Events without `channel` are the old lossy client series (transition window).
- **Unfiltered count** (with `channel IS SET`) counts **transactions** (initial + renewal + upgrade), not conversions.
- **Funnel analysis** (`kilo_pass_purchase_started` → completed): filter completed to `channel = 'app_store' AND purchase_kind IN ('initial', 'upgrade')` to approximate the old user-initiated funnel. Resubscribes read `renewal` and Stripe null/legacy `billing_reason` reads `unknown`; both are excluded from that funnel view — intentional. `unknown` should be ~zero in production.
- **Sandbox/TestFlight:** filter via `environment`. **$0 promos:** filter via `amount_paid_usd` (and `currency` for correctness; Kilo Pass bills USD today).
- **Historical data:** client-lost events are unrecoverable, but the full sale history exists in `kilo_pass_store_purchases` / Stripe invoices — a one-off PostHog bulk backfill is possible as a follow-up if wanted (not in this PR).

## Verification

No manual testing: **E2E is environment-limited** — real App Store purchases cannot run in the simulator/E2E stack and PostHog capture is disabled in dev builds, so no E2E slot was taken. Verification is automated:

- [ ] Tracking-module unit tests (event name, distinctId, exact snake_case wire properties per channel, capture-throw swallowed + Sentry).
- [ ] `purchaseKind` classification unit tests (initial / renewal / upgrade) + idempotent-replay shape.
- [ ] At-most-once tests at all three call sites: App Store tRPC (first → 1, replay → 0), ASSN (duplicate claim → 0; app-beat-ASSN → 0; DID_RENEW → 1 `renewal`; SUBSCRIBED → 1 `initial`; DID_CHANGE_RENEWAL_PREF+UPGRADE → 1), Stripe (first invoice → 1; sequential redelivery → 0; second invoice same month → 1; $0 invoice → 1; blocked duplicate-card → 0; `subscription_create` with pre-existing row → `initial`; null `billing_reason` → `unknown`).
- [ ] Mobile test: successful purchase does NOT capture completed, still captures started; error still captures failed.
- [ ] Full suites: mobile vitest 287 files / 2459 tests pass; web jest — slice suites pass (tracking module, completion, router, ASSN 33, Stripe handler 50); full web suite is CI-verified (locally it requires `JEST_MAX_WORKERS=1` and hours — see the committed learning; failures there are pre-existing per-test 5s timeouts under docker postgres load, in suites this diff does not touch).

## Visual Changes

N/A

## Reviewer Notes

- The load-bearing invariants: the Stripe audit-anchor **ordering** (after the subscription upsert, before this run's own Success append — moving it reopens a double-emit race), the discriminated-union result type (`purchaseKind` exists only when `alreadyProcessed === false` — no `??` fallbacks), and the snake_case wire map.
- `CompleteStorePurchaseOutputSchema` is unchanged: `purchaseKind` is internal, Zod strips it from the tRPC response; the mobile contract is untouched.
- Emission tests `jest.mock` the tracking module with a factory that keeps `runAfterResponse` working inline — a bare automock would no-op it and the emit callback would never run.
- Two `.kilo_workflow/learnings/` entries ride along (workflow metadata, not product code).
- The mobile analytics constant `KILO_PASS_PURCHASE_COMPLETED_EVENT` remains exported in `apps/mobile/src/lib/analytics/posthog.ts` (owned by a parallel section); the negative test imports it, keeping knip green.
