### PR TITLE
fix(mobile): hide session header context pill on empty sessions

### DIFF
--- a/.kilo_workflow/learnings/mobile-e2e-agents-tab-new-session-entry-zero-sessions.md
+++ b/.kilo_workflow/learnings/mobile-e2e-agents-tab-new-session-entry-zero-sessions.md
@@ -1,0 +1,15 @@
+# mobile e2e: Agents tab "New session" header button is hidden on zero-session accounts — tap "New coding task"
+
+Symptom: flows that `tapOn('New session')` after switching to the Agents tab
+time out on fresh e2e accounts.
+
+Cause: `SessionListHeaderActions` gets `showNewSession={hasAnySessions}` —
+with zero sessions the header Plus button is not rendered and the list's
+empty-state CTA button `New coding task` (text match) is the only creation
+affordance. After a first session exists, both paths can appear.
+
+Fix: poll for either entry point (`New session` OR `New coding task`) and tap
+whichever appears. Also note when detecting a session detail's loaded-empty
+state: the header title text (`<instance> · <project>`) is NOT transcript
+content — exclude it; `No messages yet` remains the only definitive text
+signal for an idle remote session.

--- a/.kilo_workflow/learnings/mobile-e2e-android-logbox-badge-intercepts-tab-taps.md
+++ b/.kilo_workflow/learnings/mobile-e2e-android-logbox-badge-intercepts-tab-taps.md
@@ -1,0 +1,21 @@
+# mobile e2e Android: RN LogBox badge intercepts tab-bar taps — dismiss the EXPANDED overlay, not just the badge
+
+Symptom: `tapOn('Agents, tab, 3 of 4')` throws nothing, but the tab never
+switches; the next wait times out. A hierarchy dump then shows an expanded
+LogBox (`Component Stack`, `Copy`, `Dismiss`, `Minimize`,
+`qualified-entry.js:20`).
+
+Cause: a dev-mode RN warning (here "Can't perform a React state update...")
+surfaces as a collapsed LogBox badge floating over the tab bar. UiAutomator2
+`elementClick` resolves to a coordinate tap at the element's center; the badge
+overlay intercepts the coordinates and EXPANDS the LogBox instead. Tapping
+`Minimize` in a prior run is not enough — the collapsed badge persists and
+keeps swallowing taps (a truncated grep of the dump can hide it: the badge's
+content-desc is the full warning text, longer than typical head -20/60-char
+filters).
+
+Fix: loop until the dump is clean — if `Component Stack|Minimize` present tap
+`Dismiss` (removes the notification permanently for the app session); else if
+the warning text desc is present tap it to expand, then `Dismiss`. Verify with
+`grep -c LogBox` == 0 before driving tabs. Dismissal survives across appium
+sessions (same app process); it re-fires only on a fresh JS reload.

--- a/.kilo_workflow/learnings/mobile-e2e-android-uiautomator-screenshot-crash-adb-fallback.md
+++ b/.kilo_workflow/learnings/mobile-e2e-android-uiautomator-screenshot-crash-adb-fallback.md
@@ -1,0 +1,17 @@
+# mobile e2e Android: UiAutomator2 instrumentation dies at takeScreenshot under parallel-emulator load — ADB screencap fallback
+
+Symptom: mid-flow `WebDriverError: 'GET /screenshot' cannot be proxied to
+UiAutomator2 server because the instrumentation process is not running
+(probably crashed)`. Seen twice in one round with three emulators + an iOS
+simulator running; hierarchy dumps and taps worked minutes before and after.
+
+Cause: the UiAutomator2 instrumentation process is killed/crashes under host
+load. The APP is unaffected — screen state, navigation, and the relay survive;
+a new appium session (next `appium.sh test`) respawns instrumentation.
+
+Fix: keep time-critical captures on `driver.takeScreenshot()` (tight timing
+after a transcript poll), but on a crash do NOT re-drive the flow blind —
+inspect with a fresh session, then fall back to
+`pnpm dev:mobile:android adb -s <serial> exec-out screencap -p > out.png` for
+static states (sheet open, post-dismiss). Same 1080x2424 pixel space as the
+uiautomator bounds, so geometry analysis stays valid across both sources.

--- a/.kilo_workflow/learnings/mobile-e2e-header-crop-sips-offset-broken-use-pil.md
+++ b/.kilo_workflow/learnings/mobile-e2e-header-crop-sips-offset-broken-use-pil.md
@@ -1,0 +1,12 @@
+# mobile e2e evidence: sips --cropOffset is unreliable for header crops — use PIL
+
+Symptom: cropping the header strip out of a 1206x2622 simctl screenshot with
+`sips -c 340 1206 --cropOffset 0 0 in.png --out out.png` returns a center-crop
+(ignores the offset) or an all-black image (offset overshoots).
+
+Cause: sips `-c` crops centered; `--cropOffset` semantics are unclear/buggy on
+current macOS (observed July 2026).
+
+Fix: `python3 -c` with PIL (`import PIL` works on this machine's python3):
+`Image.open(p).crop((0,0,w,340)).save(out)`. Deterministic, exact pixel regions,
+and cheap downscales (`resize((w//2, h//2))`) keep evidence small for reports.

--- a/.kilo_workflow/learnings/mobile-e2e-remote-cli-model-pin-relaunch.md
+++ b/.kilo_workflow/learnings/mobile-e2e-remote-cli-model-pin-relaunch.md
@@ -1,0 +1,28 @@
+# mobile e2e: remote CLI TUI keeps a stale model — send-keys lands in the TUI, relaunch the tmux session with `-m`
+
+Symptom: `apps/mobile/e2e/remote-cli.sh start <email>` launches the kilo TUI with whatever model
+the CLI last used (e.g. "MoonshotAI: Kimi K3"), not the E2E-required `kilo/kilo-auto/efficient`.
+Trying to fix it by `tmux send-keys "/model kilo/kilo-auto/efficient" Enter` makes it worse: the
+keystrokes land **inside the TUI app**, the text is submitted as a user prompt, and a junk
+session (titled e.g. "Kilo model configuration review") appears in the account's session list —
+the mobile app's Agents tab will show it.
+
+Cause: `remote-cli.sh start` accepts only `<email> [--reinstall]` and launches plain `kilo`; it
+has no model flag. A TUI is not a shell — send-keys text goes to the app's input, not to a
+command line.
+
+Fix: don't patch the TUI in place. Delete the junk session, kill the tmux session, and relaunch
+it pinned:
+
+```bash
+apps/mobile/e2e/remote-cli.sh exec session delete <junkSessionID>
+tmux kill-session -t kilo-e2e-cli-<worktree-slug>
+tmux new-session -d -s kilo-e2e-cli-<worktree-slug> -c "<repo>/dev/.dev-logs/remote-cli/<worktree-slug>" -x 220 -y 50
+tmux send-keys -t kilo-e2e-cli-context...:0 "source '<...>/.cli-env' && clear && kilo -m kilo/kilo-auto/efficient" Enter
+# then recreate the relay window and confirm:
+tmux new-window -t kilo-e2e-cli-<worktree-slug> -n relay
+# in it: apps/mobile/e2e/remote-cli.sh exec remote  → "Remote connection enabled."
+```
+
+Verify the model in the TUI header (`Auto Efficient Kilo Gateway`) — `exec models` only lists
+available models and never shows the current selection.

--- a/.kilo_workflow/learnings/mobile-e2e-tapon-prefix-matches-static-section-label.md
+++ b/.kilo_workflow/learnings/mobile-e2e-tapon-prefix-matches-static-section-label.md
@@ -1,0 +1,14 @@
+# mobile e2e: tapOn prefix regex matches the static section label above the real button
+
+Symptom: `tapOn(/^Run on: /)` on the new-session screen silently taps nothing; the
+follow-up wait times out. No product defect.
+
+Cause: `tapOn` sorts matches topmost-first (y, then x) and taps index 0. The form's
+static section header Text (`Run on`, y=322) sorts ABOVE the interactive row button
+(`Run on: Cloud Agent`, y=347) and matches the same prefix pattern, so the tap lands
+on the non-interactive label.
+
+Fix: always match the control's FULL exact accessibility label
+(`tapOn(/^Run on: Cloud Agent$/)`), never a prefix that also fits a sibling heading.
+When a tap "does nothing", dump the hierarchy and compare every match's rect before
+blaming the app — the topmost match wins, not the most interactive one.

--- a/.kilo_workflow/learnings/mobile-vitest-pure-tsx-include-globs.md
+++ b/.kilo_workflow/learnings/mobile-vitest-pure-tsx-include-globs.md
@@ -1,0 +1,20 @@
+# mobile: a `src/components/agents/*.test.tsx` matches no vitest project — coverage guard fails
+
+Symptom: after adding a component test named `*.test.tsx` under
+`apps/mobile/src/components/agents/` (or any `src/components/` subtree outside
+`pr-review/`/`kiloclaw/`), `pnpm test` fails in `src/lib/vitest-project-coverage.test.ts` with
+"Test files matched by no vitest project include — they never run", listing the new file.
+
+Cause: `apps/mobile/vitest.pure.config.ts` includes `src/components/**/*.test.ts` but
+`*.test.tsx` **only** under `src/components/pr-review/**` and `src/components/kiloclaw/**`;
+`apps/mobile/vitest.mounted.config.ts` includes only `src/**/*.mounted.test.tsx`. A plain
+`.test.tsx` elsewhere is an orphan, and the committed coverage guard (which evaluates both
+configs' real include arrays against every test-looking file under `src/`) fails the run
+loudly instead of letting the file sit idle.
+
+Fix: name the test `*.test.ts` and follow the `message-bubble.test.ts` direct-call convention
+(mock `react-native` with string host components, call the component as a function, walk the
+returned element tree — works for hook-free components), or name it `*.mounted.test.tsx` and
+use the `src/test/render-with-providers.tsx` harness. Only widen
+`vitest.pure.config.ts`'s include list when a whole new `.tsx` test directory is being
+introduced deliberately.

--- a/.kilo_workflow/learnings/pi-planner-trust-prompt-needs-approve-flag.md
+++ b/.kilo_workflow/learnings/pi-planner-trust-prompt-needs-approve-flag.md
@@ -1,0 +1,14 @@
+# pi planner wedges on "Trust project folder?" at launch
+
+**Symptom:** A pi-harness planner/orchestrator launched via `launch-interactive.sh` shows an interactive `Trust project folder?` dialog and never starts working.
+
+**Cause:** Fresh worktrees are untrusted; pi blocks on its trust prompt before loading project resources, and the tmux launch cannot answer it.
+
+**Fix:** Pass `--approve` in the pi command line (per-run trust; does not mutate pi settings):
+
+```bash
+.kilo_workflow/launch-interactive.sh <section>-planner <worktree> --log "$SCRATCH/planner.log" \
+  pi --approve --model kilocode/kilo-internal/kimi-k3 --thinking high "<planner role message>" "@$SCRATCH/brief.md"
+```
+
+Do not resolve it by pressing Enter on the persisted `Trust` option — that silently writes the worktree path into the user's pi settings.

--- a/apps/mobile/src/components/agents/session-context-metrics.test.ts
+++ b/apps/mobile/src/components/agents/session-context-metrics.test.ts
@@ -1,0 +1,227 @@
+import * as React from 'react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { type SessionContextInfo } from '@/lib/session-context-info';
+
+import { SessionContextMetrics } from './session-context-metrics';
+
+vi.mock('react-native', () => ({ Pressable: 'Pressable', View: 'View' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('./context-usage-ring', () => ({ ContextUsageRing: 'ContextUsageRing' }));
+
+function info(partial: Partial<SessionContextInfo> = {}): SessionContextInfo {
+  return {
+    contextTokens: 32_418,
+    providerID: 'kilo',
+    modelID: 'anthropic/claude-sonnet-4',
+    contextWindow: 200_000,
+    percentage: 16,
+    ...partial,
+  };
+}
+
+function render(props: React.ComponentProps<typeof SessionContextMetrics>): React.ReactElement {
+  // eslint-disable-next-line new-cap
+  return SessionContextMetrics(props) as React.ReactElement;
+}
+
+function findAll(
+  node: unknown,
+  predicate: (el: React.ReactElement) => boolean
+): React.ReactElement[] {
+  const matches: React.ReactElement[] = [];
+
+  function walk(value: unknown): void {
+    if (value == null || typeof value === 'string' || typeof value === 'number') {
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        walk(child);
+      }
+      return;
+    }
+    if (React.isValidElement(value)) {
+      if (predicate(value)) {
+        matches.push(value);
+      }
+      const props = value.props as { children?: unknown };
+      walk(props.children);
+    }
+  }
+
+  walk(node);
+  return matches;
+}
+
+const PILL_LAYOUT_TOKENS = [
+  'h-[44px]',
+  'flex-row',
+  'items-center',
+  'gap-2',
+  'rounded-full',
+  'border',
+  'border-border',
+  'bg-secondary',
+  'px-3',
+] as const;
+
+function expectHiddenReservedBox(root: React.ReactElement): void {
+  expect(root.type).toBe('View');
+  const className = (root.props as { className?: string }).className ?? '';
+  expect(className).toContain('opacity-0');
+  for (const token of PILL_LAYOUT_TOKENS) {
+    expect(className).toContain(token);
+  }
+  expect(findAll(root, el => el.type === 'ContextUsageRing').length).toBeGreaterThan(0);
+  const props = root.props as {
+    accessibilityElementsHidden?: boolean;
+    importantForAccessibility?: string;
+  };
+  expect(props.accessibilityElementsHidden).toBe(true);
+  expect(props.importantForAccessibility).toBe('no');
+}
+
+describe('SessionContextMetrics', () => {
+  it('empty session is invisible and a11y-hidden', () => {
+    const root = render({
+      info: undefined,
+      totalCostMicrodollars: null,
+      hasMessages: false,
+    });
+    expectHiddenReservedBox(root);
+  });
+
+  it('empty session with a cost stays fully hidden', () => {
+    const root = render({
+      info: undefined,
+      totalCostMicrodollars: 150_000,
+      hasMessages: false,
+    });
+    expectHiddenReservedBox(root);
+  });
+
+  it('loading keeps the reserved invisible box', () => {
+    const root = render({
+      loading: true,
+      hasMessages: true,
+      info: undefined,
+      totalCostMicrodollars: null,
+    });
+    expectHiddenReservedBox(root);
+  });
+
+  it('loading wins over missing messages', () => {
+    const root = render({
+      loading: true,
+      hasMessages: false,
+      info: undefined,
+      totalCostMicrodollars: null,
+    });
+    expectHiddenReservedBox(root);
+  });
+
+  it('first message with cost but no context info shows a visible, non-pressable pill', () => {
+    const root = render({
+      hasMessages: true,
+      info: undefined,
+      totalCostMicrodollars: 150_000,
+    });
+    expect(root.type).toBe('View');
+    const className = (root.props as { className?: string }).className ?? '';
+    expect(className).not.toContain('opacity-0');
+    expect(
+      (root.props as { accessibilityElementsHidden?: boolean }).accessibilityElementsHidden
+    ).toBeUndefined();
+    const texts = findAll(root, el => el.type === 'Text');
+    expect(
+      texts.some(el => {
+        const children = (el.props as { children?: unknown }).children;
+        return children === '$0.15';
+      })
+    ).toBe(true);
+    expect(root.type).not.toBe('Pressable');
+  });
+
+  it('context info with onPress renders the pressable pill', () => {
+    const onPress = vi.fn(() => undefined);
+    const root = render({
+      hasMessages: true,
+      info: info(),
+      totalCostMicrodollars: 150_000,
+      onPress,
+    });
+    expect(root.type).toBe('Pressable');
+    const props = root.props as {
+      accessibilityRole?: string;
+      accessibilityLabel?: string;
+      className?: string;
+      onPress?: () => void;
+    };
+    expect(props.accessibilityRole).toBe('button');
+    expect(props.accessibilityLabel).toContain('Tap to view context details.');
+    expect(props.className ?? '').not.toContain('opacity-0');
+    props.onPress?.();
+    expect(onPress).toHaveBeenCalledOnce();
+    const ring = findAll(root, el => el.type === 'ContextUsageRing')[0];
+    expect(ring).toBeDefined();
+    if (ring == null) {
+      throw new Error('expected ContextUsageRing');
+    }
+    const ringProps = ring.props as { arcFraction?: number; tone?: string };
+    expect(ringProps.arcFraction).toBe(0.16);
+    expect(ringProps.tone).toBe('primary');
+  });
+
+  it('context info without onPress stays a plain visible view', () => {
+    const root = render({
+      hasMessages: true,
+      info: info(),
+      totalCostMicrodollars: 150_000,
+    });
+    expect(root.type).toBe('View');
+    const className = (root.props as { className?: string }).className ?? '';
+    expect(className).not.toContain('opacity-0');
+    const label = (root.props as { accessibilityLabel?: string }).accessibilityLabel ?? '';
+    expect(label).not.toContain('Tap to view');
+  });
+
+  it('messages with neither info nor cost show a visible track-only ring', () => {
+    const root = render({
+      hasMessages: true,
+      info: undefined,
+      totalCostMicrodollars: null,
+    });
+    expect(root.type).toBe('View');
+    const className = (root.props as { className?: string }).className ?? '';
+    expect(className).not.toContain('opacity-0');
+    expect(
+      (root.props as { accessibilityElementsHidden?: boolean }).accessibilityElementsHidden
+    ).toBeUndefined();
+    expect(findAll(root, el => el.type === 'Text')).toHaveLength(0);
+    const ring = findAll(root, el => el.type === 'ContextUsageRing')[0];
+    expect(ring).toBeDefined();
+    if (ring == null) {
+      throw new Error('expected ContextUsageRing');
+    }
+    expect((ring.props as { arcFraction?: number }).arcFraction).toBe(0);
+  });
+
+  it('empty session with interactive info and onPress stays a hidden reserved view', () => {
+    const onPress = vi.fn(() => undefined);
+    const root = render({
+      hasMessages: false,
+      info: info(),
+      totalCostMicrodollars: 150_000,
+      onPress,
+    });
+    expectHiddenReservedBox(root);
+    const props = root.props as {
+      onPress?: () => void;
+      accessibilityRole?: string;
+    };
+    expect(props.onPress).toBeUndefined();
+    expect(props.accessibilityRole).not.toBe('button');
+  });
+});

--- a/apps/mobile/src/components/agents/session-context-metrics.tsx
+++ b/apps/mobile/src/components/agents/session-context-metrics.tsx
@@ -14,6 +14,7 @@ import {
 type SessionContextMetricsProps = {
   info: SessionContextInfo | undefined;
   totalCostMicrodollars: number | null;
+  /** When false (empty session), the pill stays hidden — an empty session has no usage or cost to show. */
   hasMessages: boolean;
   onPress?: () => void;
   /**
@@ -45,9 +46,14 @@ export function SessionContextMetrics({
   loading = false,
 }: Readonly<SessionContextMetricsProps>) {
   const content = getHeaderPillContent({ info, totalCostMicrodollars, hasMessages });
+  // A session with no messages has neither context usage nor cost to show. Keep
+  // the pill's layout box reserved (same mechanism as `loading`) so the header
+  // does not shift when the first message lands, but keep it invisible and out
+  // of the accessibility tree.
+  const hidden = loading || !hasMessages;
   // Single source for element kind and a11y affordance wording so a future
   // caller with interactive content but no onPress cannot advertise a tap.
-  const pressable = !loading && content.interactive && onPress != null;
+  const pressable = !hidden && content.interactive && onPress != null;
   const accessibilityLabel = getMetricsAccessibilityLabel({
     info,
     totalCostMicrodollars,
@@ -105,10 +111,10 @@ export function SessionContextMetrics({
   return (
     <View
       accessibilityLabel={accessibilityLabel || undefined}
-      {...(loading
+      {...(hidden
         ? { accessibilityElementsHidden: true, importantForAccessibility: 'no' as const }
         : {})}
-      className={cn(pillClassName, loading && 'opacity-0')}
+      className={cn(pillClassName, hidden && 'opacity-0')}
       testID="session-context-metrics"
     >
       {body}


### PR DESCRIPTION
## Summary

**What:** the mobile agent-session header's context/cost pill (`SessionContextMetrics`) no longer renders visibly when a session has zero messages.

**Why:** a messageless session has neither context usage nor cost, yet the header drew a neutral zero-arc ring — a meaningless artifact on every freshly spawned (e.g. remote-CLI) session.

**How:** one derived boolean, `hidden = loading || !hasMessages`, reuses the existing `loading` invisibility mechanism (`opacity-0` + `accessibilityElementsHidden` / `importantForAccessibility="no"`) everywhere `loading` previously gated visibility. The 44px layout box stays reserved, so the header does not shift when the first message lands (render-null was rejected: `ScreenHeader` keeps its `ml-3 shrink-0` wrapper for any truthy `headerRight` element, so a null render would collapse the reserved width and reflow the title). With ≥1 message the pill's content and interaction are byte-for-byte today's behavior.

Coverage: a new 9-case pure vitest suite (`session-context-metrics.test.ts`, direct-call convention like `message-bubble.test.ts` — a `.test.tsx` at this path would match no vitest project include and the committed coverage guard would fail `pnpm test`). The cases pin empty/loading/visible/pressable states, the reserved box's full width+height class set plus mounted ring, and the `!hidden` pressable gate (mutation-inversion demonstrated during review).

Also includes workflow learnings (process docs under `.kilo_workflow/learnings/`).

## Verification

- [x] E2E device verification, both platforms, real LLM (`kilo/kilo-auto/efficient`), remote-CLI spawned empty sessions (fresh E2E accounts, seeded credits):
  - **iOS** (simulator, iOS 26.5): AC1 empty → no pill drawn + `session-context-metrics` absent from the a11y tree; AC2 post-reply pill `1% $0.05`, full-label whole-string match, tap → Context usage sheet → dismiss; AC3 empty→first-message header chrome **pixel-identical (0 diff pixels)** outside the reserved box.
  - **Android** (emulator, API 35): AC1 empty → pill region 100% uniform page background, 0 off-dominant pixels; AC2 post-reply pill + Context usage sheet (token breakdown, total cost) → dismiss; AC3 decisive geometry — 2,482 changed pixels **100% inside the reserved box, 0 outside**; back button and title bounds byte-identical.
  - **Before-state capture** (guarded single revert of the one owned file on the Android emulator, restored immediately; restore patch saved): the pre-fix empty header draws the zero-arc ring (81.6% off-background pixels in the pill region vs 0% post-fix) — see Visual Changes.
- [x] Automated (all green in `apps/mobile`): `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused && pnpm test` (288 files / 2467 tests, new suite 9/9 under `mobile-pure`), `git diff --check`.

## Visual Changes

Empty session header (the change): pre-fix draws a zero-arc ring; post-fix draws nothing (layout box reserved, invisible).

| Before (Android, reverted) | After (Android) | After (iOS) |
|---|---|---|
| ![before-empty-hdr.png](https://github.com/user-attachments/assets/cf10388a-0e31-4796-8caa-2ce05f7c0064) | ![ev-header-step3.png](https://github.com/user-attachments/assets/37a1c5f5-c441-4df7-86b0-2752fac2df15) | ![ac1-loaded-empty-hdr420.png](https://github.com/user-attachments/assets/56133b22-34aa-4ac3-87a0-893db0fc7bcc) |

Unchanged behavior once the session has messages: the ring appears inside the reserved box at the first message (no header movement — geometry evidence above), and the pill opens the context sheet.

| First message (Android) | First message (iOS) | Context sheet (iOS) |
|---|---|---|
| ![ev-header-step4.png](https://github.com/user-attachments/assets/3060476e-e18c-44aa-b2f5-c3ddd060a692) | ![ac3-first-message-hdr420.png](https://github.com/user-attachments/assets/4bffe1cc-21cb-4ed5-9db1-b66e0035bb55) | ![ac2-sheet.png](https://github.com/user-attachments/assets/c4b486ea-aadc-4189-b825-d178c688e67e) |

## Reviewer Notes

- AC "every theme": the hide is `opacity-0` + a11y flags only — no color/token path is touched, so no theme-dependent behavior exists to verify; one screenshot per platform in the device theme is the evidence above.
- `hasMessages === false` with defined `info` is unreachable in practice (usage derives from messages); the hide is unconditional on `hasMessages` per the requirement, and test case 9 pins the pressable gate for that state anyway.
- Pill width growth when cost/% text first resolves mid-session is pre-existing behavior (already happens today) and out of scope; the layout files are owned by sibling sections.
- E2E note: the Android shard recovered two UiAutomator2 instrumentation crashes under parallel-emulator load (environment, not product — learning committed); the before-capture was driven over raw ADB for the same reason.
