### PR TITLE
fix(ai-gateway): route Laguna S through OpenRouter only

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -54,7 +54,6 @@ describe('mapModelIdToVercel', () => {
       ['mistralai/mistral-medium-3-5', 'mistral/mistral-medium-3.5'],
       ['mistralai/mistral-small-2603', 'mistral/mistral-small'],
       ['mistralai/pixtral-large-2411', 'mistral/pixtral-large'],
-      ['poolside/laguna-s-2.1:free', 'poolside/laguna-s-2.1-free'],
       ['qwen/qwen3-14b', 'alibaba/qwen-3-14b'],
       ['qwen/qwen3-235b-a22b', 'alibaba/qwen-3-235b'],
       ['qwen/qwen3-30b-a3b', 'alibaba/qwen-3-30b'],
@@ -88,6 +87,10 @@ describe('mapModelIdToVercel', () => {
 
     it('leaves gpt-oss models unchanged', () => {
       expect(mapModelIdToVercel('openai/gpt-oss-20b')).toBe('openai/gpt-oss-20b');
+    });
+
+    it('leaves the OpenRouter-only Poolside model unchanged', () => {
+      expect(mapModelIdToVercel('poolside/laguna-s-2.1:free')).toBe('poolside/laguna-s-2.1:free');
     });
 
     it('leaves a model with an unknown provider prefix unchanged', () => {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -40,7 +40,6 @@ const vercelModelIdMapping: Record<string, string | undefined> = {
   'mistralai/mistral-medium-3-5': 'mistral/mistral-medium-3.5',
   'mistralai/mistral-small-2603': 'mistral/mistral-small',
   'mistralai/pixtral-large-2411': 'mistral/pixtral-large',
-  'poolside/laguna-s-2.1:free': 'poolside/laguna-s-2.1-free',
   'qwen/qwen3-14b': 'alibaba/qwen-3-14b',
   'qwen/qwen3-235b-a22b': 'alibaba/qwen-3-235b',
   'qwen/qwen3-30b-a3b': 'alibaba/qwen-3-30b',


### PR DESCRIPTION
## Summary
- remove the Vercel model ID mapping for `poolside/laguna-s-2.1:free`
- keep the OpenRouter ID unchanged so it no longer matches the Vercel `-free` model entry
- add a regression assertion for the OpenRouter-only routing behavior

## Verification
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `git diff --check`

Verification ran successfully with Node 26.5.0; the repository declares Node >=24 <25.