### PR TITLE
fix(kilo-pass): hide unreachable bonus progress

### DIFF
--- a/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.logic.ts
+++ b/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.logic.ts
@@ -30,6 +30,7 @@ export type KiloPassActiveSubscriptionCardLogicSubscription = Pick<
   | 'currentPeriodUsageUsd'
   | 'currentPeriodBonusCreditsUsd'
   | 'isBonusUnlocked'
+  | 'isBonusAvailableToUnlock'
 >;
 
 export type RenewInfoRowModel =
@@ -236,6 +237,7 @@ export function computeUsageProgressModel(params: {
   usageUsd: number | null | undefined;
   bonusUsd: number | null | undefined;
   isBonusUnlocked: boolean | null | undefined;
+  isBonusAvailableToUnlock: boolean | null | undefined;
 }): UsageProgressModel | null {
   const baseUsd = params.baseUsd;
   const usageUsd = params.usageUsd ?? 0;
@@ -243,6 +245,7 @@ export function computeUsageProgressModel(params: {
 
   if (typeof baseUsd !== 'number' || baseUsd <= 0) return null;
   if (typeof bonusUsd !== 'number' || bonusUsd <= 0) return null;
+  if (!params.isBonusUnlocked && !params.isBonusAvailableToUnlock) return null;
 
   const totalAvailableUsd = baseUsd + bonusUsd;
   const nonNegativeUsageUsd = Math.max(0, usageUsd);

--- a/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.test.ts
+++ b/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.test.ts
@@ -28,6 +28,7 @@ function buildSubscription(
     currentPeriodUsageUsd: 0,
     currentPeriodBonusCreditsUsd: 0,
     isBonusUnlocked: false,
+    isBonusAvailableToUnlock: false,
     ...overrides,
   };
 }
@@ -314,13 +315,37 @@ describe('KiloPassActiveSubscriptionCard.logic', () => {
   describe('computeUsageProgressModel()', () => {
     test('returns null when baseUsd is not positive', () => {
       expect(
-        computeUsageProgressModel({ baseUsd: 0, bonusUsd: 10, usageUsd: 5, isBonusUnlocked: false })
+        computeUsageProgressModel({
+          baseUsd: 0,
+          bonusUsd: 10,
+          usageUsd: 5,
+          isBonusUnlocked: false,
+          isBonusAvailableToUnlock: true,
+        })
       ).toBeNull();
     });
 
     test('returns null when bonusUsd is not positive', () => {
       expect(
-        computeUsageProgressModel({ baseUsd: 10, bonusUsd: 0, usageUsd: 5, isBonusUnlocked: false })
+        computeUsageProgressModel({
+          baseUsd: 10,
+          bonusUsd: 0,
+          usageUsd: 5,
+          isBonusUnlocked: false,
+          isBonusAvailableToUnlock: true,
+        })
+      ).toBeNull();
+    });
+
+    test('returns null when no bonus is unlocked or available to unlock', () => {
+      expect(
+        computeUsageProgressModel({
+          baseUsd: 20,
+          bonusUsd: 10,
+          usageUsd: 5,
+          isBonusUnlocked: false,
+          isBonusAvailableToUnlock: false,
+        })
       ).toBeNull();
     });
 
@@ -330,6 +355,7 @@ describe('KiloPassActiveSubscriptionCard.logic', () => {
         bonusUsd: 10,
         usageUsd: 5,
         isBonusUnlocked: false,
+        isBonusAvailableToUnlock: true,
       });
 
       expect(model).not.toBeNull();
@@ -345,6 +371,7 @@ describe('KiloPassActiveSubscriptionCard.logic', () => {
         bonusUsd: 10,
         usageUsd: 31,
         isBonusUnlocked: true,
+        isBonusAvailableToUnlock: false,
       });
 
       expect(model).not.toBeNull();
@@ -358,6 +385,7 @@ describe('KiloPassActiveSubscriptionCard.logic', () => {
         bonusUsd: 10,
         usageUsd: 25,
         isBonusUnlocked: true,
+        isBonusAvailableToUnlock: false,
       });
 
       expect(model).not.toBeNull();

--- a/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.tsx
+++ b/apps/web/src/components/profile/kilo-pass/KiloPassActiveSubscriptionCard.tsx
@@ -224,6 +224,7 @@ function UsageProgressOrBonusUnlocked() {
     usageUsd,
     bonusUsd,
     isBonusUnlocked: subscription.isBonusUnlocked,
+    isBonusAvailableToUnlock: subscription.isBonusAvailableToUnlock,
   });
   if (!model) return null;
 
@@ -377,6 +378,8 @@ function BottomClarification() {
       </div>
     );
   }
+
+  if (!subscription.isBonusUnlocked && !subscription.isBonusAvailableToUnlock) return null;
 
   return (
     <div className="text-muted-foreground text-xs">

--- a/apps/web/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
+++ b/apps/web/src/components/subscriptions/kilo-pass/KiloPassDetail.tsx
@@ -485,6 +485,7 @@ function BonusStreakContent({
     usageUsd: subscription.currentPeriodUsageUsd,
     bonusUsd: subscription.currentPeriodBonusCreditsUsd,
     isBonusUnlocked: subscription.isBonusUnlocked,
+    isBonusAvailableToUnlock: subscription.isBonusAvailableToUnlock,
   });
 
   const renewRows = computeRenewInfoRowModel({
@@ -637,13 +638,13 @@ function BonusStreakContent({
             Free bonus credits are not renewed while your subscription is paused; monthly credits
             resume when the subscription resumes.
           </div>
-        ) : (
+        ) : subscription.isBonusUnlocked || subscription.isBonusAvailableToUnlock ? (
           <div className="text-muted-foreground text-xs">
             Free bonus credits are earned after using the month&apos;s paid credits. Unused free
             bonus credits do not roll over
             {expiresAtLabel ? ` and will expire on ${expiresAtLabel}.` : '.'}
           </div>
-        )
+        ) : null
       ) : null}
     </div>
   );

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -153,6 +153,7 @@ type KiloPassCaller = {
       currentPeriodHostingCostUsd: number;
       currentPeriodBonusCreditsUsd: number | null;
       isBonusUnlocked: boolean;
+      isBonusAvailableToUnlock: boolean;
       refillAt: string | null;
     } | null;
     isEligibleForFirstMonthPromo: boolean;
@@ -428,6 +429,11 @@ async function insertBaseCreditsIssuance(params: {
   stripeInvoiceId?: string;
   createdAt?: string;
   usageBaselineMicrodollars?: number | null;
+  kiloPassThreshold?: number | null;
+  bonusKind?:
+    | KiloPassIssuanceItemKind.Bonus
+    | KiloPassIssuanceItemKind.PromoFirstMonth50Pct
+    | KiloPassIssuanceItemKind.ReferralBonus;
 }): Promise<void> {
   const issuedMonth = new Date().toISOString().slice(0, 7);
   const issueMonth = params.issueMonth ?? `${issuedMonth}-01`;
@@ -480,6 +486,41 @@ async function insertBaseCreditsIssuance(params: {
   if (!issuanceItem) {
     throw new Error('Failed to insert kilo_pass_issuance_items row for test');
   }
+
+  if (params.bonusKind) {
+    const [bonusCreditTxn] = await db
+      .insert(credit_transactions)
+      .values({
+        id: crypto.randomUUID(),
+        kilo_user_id: params.kiloUserId,
+        amount_microdollars: 500_000,
+        is_free: true,
+        description: `kilo-pass-bonus-test-${Date.now()}`,
+        created_at: params.createdAt,
+      })
+      .returning({ id: credit_transactions.id });
+
+    if (!bonusCreditTxn) {
+      throw new Error('Failed to insert bonus credit transaction for test');
+    }
+
+    await db.insert(kilo_pass_issuance_items).values({
+      kilo_pass_issuance_id: issuance.id,
+      kind: params.bonusKind,
+      credit_transaction_id: bonusCreditTxn.id,
+      amount_usd: 5,
+      bonus_percent_applied: 0.5,
+      created_at: params.createdAt,
+    });
+  }
+
+  await db
+    .update(kilocode_users)
+    .set({
+      kilo_pass_threshold:
+        params.kiloPassThreshold === undefined ? 19_000_000 : params.kiloPassThreshold,
+    })
+    .where(eq(kilocode_users.id, params.kiloUserId));
 }
 
 async function insertKiloPassReferralReward(params: {
@@ -758,6 +799,7 @@ describe('kiloPassRouter', () => {
 
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-get-state-yearly@example.com',
+        kilo_pass_threshold: 49_000_000,
       });
       const nextYearlyIssueAt = new Date('2030-01-01T00:00:00.000Z').toISOString();
       await insertSubscription({
@@ -891,7 +933,98 @@ describe('kiloPassRouter', () => {
       expect(result.subscription?.currentPeriodBaseCreditsUsd).toBe(baseAmountUsd);
       expect(result.subscription?.currentPeriodUsageUsd).toBe(0);
       expect(result.subscription?.isBonusUnlocked).toBe(false);
+      expect(result.subscription?.isBonusAvailableToUnlock).toBe(true);
       expect(result.subscription?.refillAt).toBe(expectedNextBillingAt);
+    });
+
+    it('does not project a reachable current bonus when the threshold is null', async () => {
+      const stripeMock = getStripeMock();
+      const currentPeriodEndSeconds = 1_700_123_456;
+      const currentPeriodStartSeconds = currentPeriodEndSeconds - 2_592_000;
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_test_monthly_no_threshold',
+        status: 'active',
+        items: {
+          data: [
+            {
+              current_period_end: currentPeriodEndSeconds,
+              current_period_start: currentPeriodStartSeconds,
+            },
+          ],
+        },
+      });
+
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-get-state-no-threshold@example.com',
+      });
+      const { id: subscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_test_monthly_no_threshold',
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+        currentStreakMonths: 1,
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId,
+        kiloUserId: user.id,
+        kiloPassThreshold: null,
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.kiloPass.getState();
+
+      expect(result.subscription).toEqual(
+        expect.objectContaining({
+          status: 'active',
+          currentPeriodBonusCreditsUsd: null,
+          isBonusUnlocked: false,
+          isBonusAvailableToUnlock: false,
+        })
+      );
+    });
+
+    it('keeps unlocked state when a bonus-like item exists and the threshold is null', async () => {
+      const stripeMock = getStripeMock();
+      const currentPeriodEndSeconds = 1_700_123_456;
+      const currentPeriodStartSeconds = currentPeriodEndSeconds - 2_592_000;
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_test_monthly_bonus_issued',
+        status: 'active',
+        items: {
+          data: [
+            {
+              current_period_end: currentPeriodEndSeconds,
+              current_period_start: currentPeriodStartSeconds,
+            },
+          ],
+        },
+      });
+
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-get-state-bonus-issued@example.com',
+      });
+      const { id: subscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_test_monthly_bonus_issued',
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+        currentStreakMonths: 1,
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId,
+        kiloUserId: user.id,
+        kiloPassThreshold: null,
+        bonusKind: KiloPassIssuanceItemKind.Bonus,
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.kiloPass.getState();
+
+      expect(result.subscription?.currentPeriodBonusCreditsUsd).toBeGreaterThan(0);
+      expect(result.subscription?.isBonusUnlocked).toBe(true);
+      expect(result.subscription?.isBonusAvailableToUnlock).toBe(false);
     });
 
     it('keeps first-month current bonus visible for first-time subscribers with a new card', async () => {
@@ -1139,7 +1272,7 @@ describe('kiloPassRouter', () => {
 
       await db
         .update(kilocode_users)
-        .set({ microdollars_used: 19_250_000 })
+        .set({ microdollars_used: 19_250_000, kilo_pass_threshold: 19_000_000 })
         .where(eq(kilocode_users.id, user.id));
 
       const caller = await createCallerForUser(user.id);
@@ -1454,6 +1587,11 @@ describe('kiloPassRouter', () => {
           raw_payload_json: {},
         },
       ]);
+
+      await db
+        .update(kilocode_users)
+        .set({ kilo_pass_threshold: 19_000_000 })
+        .where(eq(kilocode_users.id, user.id));
 
       const caller = await createCallerForUser(user.id);
       const result = await caller.kiloPass.getState();

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -167,6 +167,7 @@ const KiloPassSubscriptionStateSchema = KiloPassSubscriptionStateBaseSchema.exte
   currentPeriodHostingCostUsd: z.number(),
   currentPeriodBonusCreditsUsd: z.number().nullable(),
   isBonusUnlocked: z.boolean(),
+  isBonusAvailableToUnlock: z.boolean(),
   refillAt: z.string().nullable(),
 });
 
@@ -460,6 +461,15 @@ async function getIsBonusUnlockedForSubscriptionId(subscriptionId: string): Prom
   return Boolean(unlockedItem);
 }
 
+async function getHasKiloPassThreshold(kiloUserId: string): Promise<boolean> {
+  const user = await db.query.kilocode_users.findFirst({
+    columns: { kilo_pass_threshold: true },
+    where: eq(kilocode_users.id, kiloUserId),
+  });
+
+  return user?.kilo_pass_threshold != null;
+}
+
 /**
  * Get the credit transaction for the most recent base issuance of a subscription.
  *
@@ -737,17 +747,25 @@ async function buildActiveKiloPassSubscriptionState(params: {
   nowUtc: ReturnType<typeof dayjs>;
 }): Promise<KiloPassSubscriptionStateResponse> {
   const baseAmountUsd = getMonthlyPriceUsd(params.subscription.tier);
-  const isFirstTimeSubscriberEver = await getIsFirstTimeSubscriberEver({
-    kiloUserId: params.kiloUserId,
-    subscriptionId: params.subscription.subscriptionId,
-  });
-  const [isBonusUnlocked, latestBaseCredits, initialWelcomePromoContext] = await Promise.all([
+  const [
+    isFirstTimeSubscriberEver,
+    isBonusUnlocked,
+    hasKiloPassThreshold,
+    latestBaseCredits,
+    initialWelcomePromoContext,
+  ] = await Promise.all([
+    getIsFirstTimeSubscriberEver({
+      kiloUserId: params.kiloUserId,
+      subscriptionId: params.subscription.subscriptionId,
+    }),
     getIsBonusUnlockedForSubscriptionId(params.subscription.subscriptionId),
+    getHasKiloPassThreshold(params.kiloUserId),
     getLatestBaseCreditsForSubscription(params.subscription.subscriptionId),
     getInitialWelcomePromoContextForSubscription(db, {
       subscriptionId: params.subscription.subscriptionId,
     }),
   ]);
+  const isBonusAvailableToUnlock = hasKiloPassThreshold && !isBonusUnlocked;
   const welcomePromoPolicy = getKiloPassWelcomePromoPolicy({
     paymentProvider: params.subscription.paymentProvider,
     initialIssuanceCreatedAt: initialWelcomePromoContext?.createdAt ?? null,
@@ -779,13 +797,17 @@ async function buildActiveKiloPassSubscriptionState(params: {
     currentPeriodBaseCreditsUsd: baseAmountUsd,
     currentPeriodUsageUsd,
     currentPeriodHostingCostUsd,
-    currentPeriodBonusCreditsUsd: getCurrentKiloPassBonusCreditsUsd({
-      subscription: params.subscription,
-      isFirstTimeSubscriberEver,
-      welcomePromoPolicy,
-      welcomePromoEligibilityReason,
-    }),
+    currentPeriodBonusCreditsUsd:
+      isBonusUnlocked || isBonusAvailableToUnlock
+        ? getCurrentKiloPassBonusCreditsUsd({
+            subscription: params.subscription,
+            isFirstTimeSubscriberEver,
+            welcomePromoPolicy,
+            welcomePromoEligibilityReason,
+          })
+        : null,
     isBonusUnlocked,
+    isBonusAvailableToUnlock,
     refillAt:
       params.subscription.cadence === KiloPassCadence.Yearly
         ? (params.subscription.nextYearlyIssueAt ?? params.nextBillingAt)
@@ -815,6 +837,7 @@ async function buildEndedKiloPassSubscriptionState(params: {
     currentPeriodHostingCostUsd: 0,
     currentPeriodBonusCreditsUsd: null,
     isBonusUnlocked: false,
+    isBonusAvailableToUnlock: false,
     refillAt: null,
   };
 }


### PR DESCRIPTION
## Summary
Prevent Kilo Pass from showing progress toward a usage-triggered bonus when the persisted threshold has already been cleared.

### Why this change is needed
A subscription can resume after its usage threshold was consumed while inactive. The current state projection still derives a prospective bonus from the latest base issuance, even though no threshold remains to trigger that bonus. This leaves customers seeing progress toward a reward that cannot unlock.

### How this is addressed
- Treat the persisted threshold and current issuance items as authoritative for current-period bonus availability.
- Distinguish an already unlocked bonus from a bonus that remains available to unlock.
- Return no current-period bonus projection when neither a threshold nor a bonus-like issuance item exists.
- Suppress progress and explanatory copy in both Kilo Pass UI surfaces for that unavailable state.
- Preserve threshold-present progress, unlocked bonuses, renewal projections, and paused or ended subscription rendering.

## Human Verification
- Focused Kilo Pass router and component logic suites passed: 118 tests.
- Local code review passed all eight quality focuses with no findings.
- React Doctor reported no issues with a 93/100 score.

## Reviewer Notes

### Human Reviewer Flags
- The persisted user-global threshold remains the authority for whether the current bonus can still unlock.
- This intentionally does not change paused-subscription threshold consumption or add deferred eligibility state.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The API exposes a derived `isBonusAvailableToUnlock` boolean rather than the raw cumulative threshold.
- `isBonusUnlocked` remains based on bonus-like issuance items and is semantically separate from current unlock availability.
- Next-period bonus projections are unchanged.

</details>
