### PR TITLE
feat(ai-gateway): add Laguna S to auto free

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -40,6 +40,7 @@ export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 export const autoFreeModels = [
   stepfun_37_flash_free_model.status === 'public' ? stepfun_37_flash_free_model.public_id : null,
   'inclusionai/ling-3.0-flash:free',
+  'poolside/laguna-s-2.1:free',
 ].filter(m => m !== null);
 
 export const preferredModels = [


### PR DESCRIPTION
## Summary
- add `poolside/laguna-s-2.1:free` to the auto-free model pool
- retain live OpenRouter catalog gating for candidate availability

## Testing
- `pnpm exec oxfmt --check apps/web/src/lib/ai-gateway/models.ts`
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/models.test.ts`
- `git diff --check`