### PR TITLE
fix(ai-gateway): close terminal stream errors

### DIFF
--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -326,6 +326,20 @@ describe('rewriteModelResponse_ChatCompletions', () => {
       expect(dataPayloads(sse)).toContain('[DONE]');
     });
 
+    test('does not treat a null error field as terminal', async () => {
+      const upstream = sseResponse(
+        'data: {"id":"gen-chat","error":null,"choices":[]}\n\n' +
+          'data: {"id":"gen-chat","choices":[{"delta":{"content":"still streaming"}}]}\n\n' +
+          'data: [DONE]\n\n'
+      );
+
+      const result = await rewriteModelResponse_ChatCompletions(upstream, true, null, null);
+      const sse = await readOutputStream(result);
+
+      expect(sse).toContain('still streaming');
+      expect(dataPayloads(sse)).toContain('[DONE]');
+    });
+
     test('cancels upstream and closes immediately after [DONE]', async () => {
       const capture = makeCapture();
       const body =

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -683,6 +683,60 @@ describe('rewriteModelResponse_Responses', () => {
   );
 });
 
+describe.each([
+  [
+    'Chat Completions',
+    'chat_completions',
+    rewriteModelResponse_ChatCompletions,
+    'data: {"id":"gen-chat","choices":[]}\n\n',
+    'data: {"error":{"code":429,"message":"rate limited"}}\n\n',
+    'gen-chat',
+  ],
+  [
+    'Messages',
+    'messages',
+    rewriteModelResponse_Messages,
+    'event: message_start\ndata: {"type":"message_start","message":{"id":"gen-message","usage":{"input_tokens":1,"output_tokens":0}}}\n\n',
+    'event: error\ndata: {"type":"error","error":{"type":"api_error","message":"rate limited"}}\n\n',
+    'gen-message',
+  ],
+  [
+    'Responses',
+    'responses',
+    rewriteModelResponse_Responses,
+    'event: response.created\ndata: {"type":"response.created","response":{"id":"gen-response"}}\n\n',
+    'event: error\ndata: {"type":"error","error":{"type":"server_error","message":"rate limited"}}\n\n',
+    'gen-response',
+  ],
+] as const)(
+  '%s terminal stream errors',
+  (_name, kind, rewrite, initialEvent, errorEvent, generationId) => {
+    test('logs the error event and closes without waiting for EOF', async () => {
+      const capture = makeCapture();
+      const body = initialEvent + errorEvent + 'data: {"ignored":true}\n\n';
+      const { response: upstream, cancel } = hangingSseResponse(body);
+
+      const result = await rewrite(upstream, true, capture, 'iad1::error-request');
+      const sse = await readOutputStream(result);
+
+      expect(sse).toContain('rate limited');
+      expect(sse).not.toContain('ignored');
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(capture.setBody).toHaveBeenCalledWith(body);
+      expect(capture.setReadError).not.toHaveBeenCalled();
+      expect(mockedLog).toHaveBeenCalledWith(
+        '[rewriteModelResponse] received terminal stream event',
+        {
+          kind,
+          eventType: 'error',
+          generationId,
+          vercelRequestId: 'iad1::error-request',
+        }
+      );
+    });
+  }
+);
+
 function makeLogging(overrides?: Partial<RequestLoggingParams>): RequestLoggingParams {
   return {
     user: null,

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -454,7 +454,7 @@ export async function rewriteModelResponse_ChatCompletions(
 
           const eventLine = event.event ? 'event: ' + event.event + '\n' : '';
           controller.enqueue(eventLine + 'data: ' + JSON.stringify(json) + '\n\n');
-          terminalEventReceived = 'error' in json;
+          terminalEventReceived = 'error' in json && json.error != null;
           if (terminalEventReceived) {
             logTerminalStreamEvent('chat_completions', 'error', generationId, vercelRequestId);
           }

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -412,11 +412,12 @@ export async function rewriteModelResponse_ChatCompletions(
       }
 
       let doneReceived = false;
+      let terminalEventReceived = false;
       let generationId: string | undefined;
       const progress = createStreamProgressLogger();
       const parser = createParser({
         onEvent(event: EventSourceMessage) {
-          if (doneReceived) {
+          if (doneReceived || terminalEventReceived) {
             return;
           }
           progress.eventProcessed();
@@ -453,9 +454,13 @@ export async function rewriteModelResponse_ChatCompletions(
 
           const eventLine = event.event ? 'event: ' + event.event + '\n' : '';
           controller.enqueue(eventLine + 'data: ' + JSON.stringify(json) + '\n\n');
+          terminalEventReceived = 'error' in json;
+          if (terminalEventReceived) {
+            logTerminalStreamEvent('chat_completions', 'error', generationId, vercelRequestId);
+          }
         },
         onComment() {
-          if (doneReceived) {
+          if (doneReceived || terminalEventReceived) {
             return;
           }
           controller.enqueue(': KILO PROCESSING\n\n');
@@ -467,7 +472,7 @@ export async function rewriteModelResponse_ChatCompletions(
         parser,
         controller,
         () => doneReceived,
-        () => doneReceived,
+        () => doneReceived || terminalEventReceived,
         responseReadError =>
           'data: ' +
           JSON.stringify({
@@ -518,6 +523,11 @@ type MessagesApiMessageDelta = {
   type: 'message_delta';
   usage: MessagesApiUsage;
   delta: Anthropic.Messages.MessageDeltaEvent['delta'];
+};
+
+type MessagesApiError = {
+  type: 'error';
+  error: unknown;
 };
 
 function rewriteMessagesUsage(usage: MessagesApiUsage, removeCost: boolean) {
@@ -599,6 +609,7 @@ export async function rewriteModelResponse_Messages(
           const json = JSON.parse(event.data) as
             | MessagesApiMessageStart
             | MessagesApiMessageDelta
+            | MessagesApiError
             | Anthropic.Messages.MessageStreamEvent;
 
           if (json.type === 'message_start') {
@@ -624,7 +635,7 @@ export async function rewriteModelResponse_Messages(
 
           const eventLine = event.event ? 'event: ' + event.event + '\n' : '';
           controller.enqueue(eventLine + 'data: ' + JSON.stringify(json) + '\n\n');
-          terminalEventReceived = json.type === 'message_stop';
+          terminalEventReceived = json.type === 'message_stop' || json.type === 'error';
           if (terminalEventReceived) {
             logTerminalStreamEvent('messages', json.type, generationId, vercelRequestId);
           }
@@ -776,7 +787,8 @@ export async function rewriteModelResponse_Responses(
           terminalEventReceived =
             json.type === 'response.completed' ||
             json.type === 'response.incomplete' ||
-            json.type === 'response.failed';
+            json.type === 'response.failed' ||
+            json.type === 'error';
           if (terminalEventReceived) {
             logTerminalStreamEvent('responses', json.type, generationId, vercelRequestId);
           }


### PR DESCRIPTION
## Problem

Provider-sent SSE error events were forwarded to clients but were not treated as terminal events. When the client disconnected in response, logs showed the cancellation without the terminal event that triggered it, and the stream stayed open until that cancellation or upstream EOF.

## Fix

- treat Chat Completions `{error: ...}`, Messages `type: "error"`, and Responses `type: "error"` events as terminal
- log them through the existing `received terminal stream event` logger
- close the downstream stream and cancel upstream immediately after forwarding the error
- add regression coverage for logging, closure, cancellation, and raw response capture across all three API kinds

## Testing

CI will validate the change.