### PR TITLE
fix(cloud-agent-next) skip container wake on idle stop

### DIFF
--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
@@ -1656,6 +1656,76 @@ describe('CloudflareAgentSandbox', () => {
     ).resolves.toMatchObject({ status: 'still-present' });
   });
 
+  it('confirms absence for an idle-timeout stop without waking a stopped container', async () => {
+    const listProcesses = vi.fn().mockResolvedValue([]);
+    const isContainerRunning = vi.fn().mockResolvedValue(false);
+    const sandbox = new CloudflareAgentSandbox({} as Env, metadata(), {
+      resolveSandbox: () => ({ listProcesses, isContainerRunning }) as unknown as SandboxInstance,
+    });
+
+    await expect(
+      sandbox.stopWrappers({
+        target: { kind: 'session' },
+        attemptId: 'attempt_idle',
+        reason: 'idle-timeout',
+      })
+    ).resolves.toEqual({ status: 'absent' });
+    // The whole point: no container fetch, so a sleeping container stays asleep.
+    expect(listProcesses).not.toHaveBeenCalled();
+  });
+
+  it('still inspects an idle-timeout stop while the container is running', async () => {
+    const listProcesses = vi.fn().mockResolvedValue([]);
+    const isContainerRunning = vi.fn().mockResolvedValue(true);
+    const sandbox = new CloudflareAgentSandbox({} as Env, metadata(), {
+      resolveSandbox: () => ({ listProcesses, isContainerRunning }) as unknown as SandboxInstance,
+    });
+
+    await expect(
+      sandbox.stopWrappers({
+        target: { kind: 'session' },
+        attemptId: 'attempt_idle_running',
+        reason: 'idle-timeout',
+      })
+    ).resolves.toEqual({ status: 'absent' });
+    expect(listProcesses).toHaveBeenCalled();
+  });
+
+  it('inspects a stopped container for stop reasons other than idle-timeout', async () => {
+    const listProcesses = vi.fn().mockResolvedValue([]);
+    const isContainerRunning = vi.fn().mockResolvedValue(false);
+    const sandbox = new CloudflareAgentSandbox({} as Env, metadata(), {
+      resolveSandbox: () => ({ listProcesses, isContainerRunning }) as unknown as SandboxInstance,
+    });
+
+    await expect(
+      sandbox.stopWrappers({
+        target: { kind: 'session' },
+        attemptId: 'attempt_delete',
+        reason: 'session-delete',
+      })
+    ).resolves.toEqual({ status: 'absent' });
+    expect(listProcesses).toHaveBeenCalled();
+    expect(isContainerRunning).not.toHaveBeenCalled();
+  });
+
+  it('falls back to inspection when the sandbox cannot report container state', async () => {
+    const listProcesses = vi.fn().mockResolvedValue([]);
+    const sandbox = new CloudflareAgentSandbox({} as Env, metadata(), {
+      // No isContainerRunning: an unknown state must not be treated as "stopped".
+      resolveSandbox: () => ({ listProcesses }) as unknown as SandboxInstance,
+    });
+
+    await expect(
+      sandbox.stopWrappers({
+        target: { kind: 'session' },
+        attemptId: 'attempt_unknown',
+        reason: 'idle-timeout',
+      })
+    ).resolves.toEqual({ status: 'absent' });
+    expect(listProcesses).toHaveBeenCalled();
+  });
+
   it('returns inspection-failed from stop when post-stop inspection cannot prove absence', async () => {
     const listProcesses = vi
       .fn()

--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
@@ -74,6 +74,7 @@ import { TOOL_CGROUP_ENV_KEYS, type ToolCgroupEnv } from '../../shared/tool-cgro
 import {
   buildSandboxBillingInput,
   configureSandboxBillingInput,
+  isSandboxContainerRunning,
   type SandboxBillingInput,
 } from '../../container-usage-context.js';
 
@@ -751,16 +752,38 @@ export class CloudflareAgentSandbox implements AgentSandbox {
     reason: WrapperStopReason;
   }): Promise<StopWrappersResult> {
     const sandbox = await this.getSandbox();
+    const stopInspectionLogger = logger.withTags({
+      logTag: 'wrapper_stop_inspection',
+      sessionId: this.metadata.identity.sessionId,
+      sandboxId: await this.resolveSandboxId(),
+    });
+
+    // Inspecting is a container fetch, so it boots a sleeping container. A wrapper is a
+    // process, and a process cannot outlive its container (activity expiry SIGTERMs the
+    // whole container), so a stopped container cannot be hiding a leaked wrapper.
+    //
+    // Scoped to idle-timeout: that sweep already established via DO state that no wrapper
+    // runtime or pending work remains, and it is the path that was waking cold containers
+    // for nothing. Every other stop reason keeps inspecting, which preserves the leaked
+    // wrapper recovery those paths were built for.
+    if (request.reason === 'idle-timeout') {
+      const containerRunning = await isSandboxContainerRunning(sandbox);
+      if (containerRunning === false) {
+        stopInspectionLogger
+          .withFields({
+            reason: request.reason,
+            attemptId: request.attemptId,
+            target: request.target.kind,
+            observation: 'absent-no-container',
+            observedWrapperCount: 0,
+          })
+          .info('Wrapper stop inspection completed');
+        return { status: 'absent' };
+      }
+    }
+
     const initial = await this.observeTarget(request.target);
-    // Inspection is a container fetch, so it wakes a sleeping container. An `absent`
-    // result therefore means we booted a container only to learn nothing was running
-    // in it — the signal for how much idle container time this path is creating.
-    logger
-      .withTags({
-        logTag: 'wrapper_stop_inspection',
-        sessionId: this.metadata.identity.sessionId,
-        sandboxId: await this.resolveSandboxId(),
-      })
+    stopInspectionLogger
       .withFields({
         reason: request.reason,
         attemptId: request.attemptId,

--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
@@ -81,6 +81,16 @@ import {
 const PREPARE_WORKSPACE_TIMEOUT_MS = 10 * 60 * 1000;
 const DEFAULT_STOP_OBSERVATION_DELAYS_MS = [100, 500, 1_000];
 
+/**
+ * Outcome of a wrapper stop inspection, as reported by the `wrapper_stop_inspection` log.
+ *
+ * Extends `WrapperObservation` with `absent-no-container`: absence established from
+ * container state rather than by inspecting, so the log can distinguish a confirmed-empty
+ * container from one we booted in order to look. Not a `WrapperObservation` status,
+ * because nothing was observed.
+ */
+type StopInspection = WrapperObservation | { status: 'absent-no-container' };
+
 function shellQuote(value: string): string {
   return `'${value.replaceAll("'", `'"'"'`)}'`;
 }
@@ -752,11 +762,6 @@ export class CloudflareAgentSandbox implements AgentSandbox {
     reason: WrapperStopReason;
   }): Promise<StopWrappersResult> {
     const sandbox = await this.getSandbox();
-    const stopInspectionLogger = logger.withTags({
-      logTag: 'wrapper_stop_inspection',
-      sessionId: this.metadata.identity.sessionId,
-      sandboxId: await this.resolveSandboxId(),
-    });
 
     // Inspecting is a container fetch, so it boots a sleeping container. A wrapper is a
     // process, and a process cannot outlive its container (activity expiry SIGTERMs the
@@ -766,24 +771,20 @@ export class CloudflareAgentSandbox implements AgentSandbox {
     // runtime or pending work remains, and it is the path that was waking cold containers
     // for nothing. Every other stop reason keeps inspecting, which preserves the leaked
     // wrapper recovery those paths were built for.
-    if (request.reason === 'idle-timeout') {
-      const containerRunning = await isSandboxContainerRunning(sandbox);
-      if (containerRunning === false) {
-        stopInspectionLogger
-          .withFields({
-            reason: request.reason,
-            attemptId: request.attemptId,
-            target: request.target.kind,
-            observation: 'absent-no-container',
-            observedWrapperCount: 0,
-          })
-          .info('Wrapper stop inspection completed');
-        return { status: 'absent' };
-      }
-    }
+    const skipsInspection =
+      request.reason === 'idle-timeout' && (await isSandboxContainerRunning(sandbox)) === false;
+    const initial: StopInspection = skipsInspection
+      ? { status: 'absent-no-container' }
+      : await this.observeTarget(request.target);
 
-    const initial = await this.observeTarget(request.target);
-    stopInspectionLogger
+    // Single emission for every outcome. `wrapper_stop_inspection` is how container wake
+    // behaviour is measured, so the field set is defined once here rather than per branch.
+    logger
+      .withTags({
+        logTag: 'wrapper_stop_inspection',
+        sessionId: this.metadata.identity.sessionId,
+        sandboxId: await this.resolveSandboxId(),
+      })
       .withFields({
         reason: request.reason,
         attemptId: request.attemptId,
@@ -792,6 +793,8 @@ export class CloudflareAgentSandbox implements AgentSandbox {
         observedWrapperCount: initial.status === 'present' ? initial.observed.length : 0,
       })
       .info('Wrapper stop inspection completed');
+
+    if (initial.status === 'absent-no-container') return { status: 'absent' };
     if (initial.status !== 'present') return initial;
 
     try {

--- a/services/cloud-agent-next/src/container-usage-context.ts
+++ b/services/cloud-agent-next/src/container-usage-context.ts
@@ -25,6 +25,7 @@ export type SandboxBillingInput = Omit<UsageContext, 'service' | 'instanceId' | 
 };
 export type MeteredSandboxInstance = SandboxInstance & {
   configureBilling(input: unknown): Promise<void>;
+  isContainerRunning(): Promise<boolean>;
 };
 
 const sandboxBillingInputEnvelopeSchema = z
@@ -166,6 +167,31 @@ export async function configureSandboxBilling(
   sandboxId: SandboxId
 ): Promise<void> {
   await configureSandboxBillingInput(sandbox, buildSandboxBillingInput(metadata, sandboxId));
+}
+
+/**
+ * Whether the sandbox's container is currently running, read over Durable Object RPC.
+ *
+ * This deliberately avoids any container fetch (`exec`, `listProcesses`, …), because
+ * those boot a sleeping container. Callers use it to answer "is there anything running
+ * in there?" without paying for a wake-up.
+ *
+ * Returns `undefined` when the sandbox does not expose the method, so callers can fall
+ * back to their existing behaviour rather than treating an unknown state as "stopped".
+ */
+export async function isSandboxContainerRunning(
+  sandbox: SandboxInstance
+): Promise<boolean | undefined> {
+  const isContainerRunning = (sandbox as Partial<MeteredSandboxInstance>).isContainerRunning;
+  if (typeof isContainerRunning !== 'function') return undefined;
+  try {
+    return await (sandbox as MeteredSandboxInstance).isContainerRunning();
+  } catch (error) {
+    logger
+      .withFields({ error: error instanceof Error ? error.message : String(error) })
+      .warn('Container running probe failed');
+    return undefined;
+  }
 }
 
 export async function configureSandboxBillingInput(

--- a/services/cloud-agent-next/src/container-usage.ts
+++ b/services/cloud-agent-next/src/container-usage.ts
@@ -100,6 +100,17 @@ export abstract class MeteredSandbox extends StockSandbox<Env> {
     });
   }
 
+  /**
+   * Whether this sandbox's container is currently running.
+   *
+   * Reads Durable Object state only. Calling this over RPC does not boot a sleeping
+   * container, unlike any container fetch, so callers can confirm "nothing is running
+   * in there" without paying for a wake-up.
+   */
+  async isContainerRunning(): Promise<boolean> {
+    return this.ctx.container?.running === true;
+  }
+
   async configureBilling(input: unknown): Promise<void> {
     const parsed = parseSandboxBillingInput(input);
     assertSandboxBillingAllocation(this.sandboxClassName, parsed);


### PR DESCRIPTION
## Summary

`stopWrappers` inspects the sandbox by calling `listProcesses`, which is a
container fetch and therefore boots a sleeping container. On the idle timeout
path that boot is wasted work: `cleanupIdleKiloServer` only requests a stop
after `hasWrapperRuntimeOrPendingWork()` has already confirmed from Durable
Object state that no wrapper runtime and no pending work remain. The inspection
then wakes a stopped container to re-derive that same fact, and the woken
container sits idle until the 900s `sleepAfter` expires it.

In 90 minutes of production logs, `reason=idle-timeout` produced 233 stop
inspections. Every one returned `absent`. None returned `present`.

This confirms absence from container state instead, when the container is
stopped. A wrapper is a process, and a process cannot outlive its container
(activity expiry SIGTERMs the container, exit code 143), so a stopped container
cannot be hiding a leaked wrapper.

## Changes

- `container-usage.ts`: adds `MeteredSandbox.isContainerRunning()`, returning
  `this.ctx.container?.running === true`. It reads Durable Object state only, so
  calling it over RPC does not boot the container.
- `container-usage-context.ts`: adds the method to `MeteredSandboxInstance` and
  adds `isSandboxContainerRunning()`, using the same runtime guarded cast as
  `configureSandboxBillingInput`. It returns `boolean | undefined`, yielding
  `undefined` when the method is missing or throws, so an unknown state is never
  read as stopped.
- `cloudflare-agent-sandbox.ts`: in `stopWrappers`, when the reason is
  `idle-timeout` and the container is confirmed not running, return
  `{ status: 'absent' }` without inspecting. Every other stop reason is
  unchanged.
- `cloudflare-agent-sandbox.ts`: the `wrapper_stop_inspection` log is now emitted
  once for all outcomes rather than once per branch, with a local
  `StopInspection` type adding an `absent-no-container` status for the new case.

## Verification

- [ ] No manual testing of the fix. Reproducing it needs a sandbox container that
      has already gone to sleep plus a Durable Object alarm firing the idle sweep,
      which is not reproducible locally. The problem itself was measured from
      production logs (233 idle timeout inspections, all `absent`).

## Visual Changes

N/A

## Reviewer Notes

- The narrow scope is deliberate. The `stopWrappers` inspection was added by
  #3555 ("recover leaked sandbox wrappers safely") to catch wrapper processes the
  Durable Object lease does not track, including duplicates in shared sandboxes.
  That recovery is preserved: it can only apply when a container is running, and
  in that case this change falls through to the existing inspection untouched.
  Only `idle-timeout` short circuits.
- `isSandboxContainerRunning` sits behind a `&&` on the reason check, so the probe
  does not run at all for other stop reasons. There is a test asserting this.
- Returning bare `{ status: 'absent' }` drops `stoppedInstanceIds`. That field is
  optional on `StopWrappersResult` and has no readers anywhere in the codebase
  (produced in `stopWrappers`, never consumed).
- Residual risk worth a look: this trades a container fetch for trusting
  `ctx.container.running`. If that flag were ever stale and reported false while a
  container was up, a legitimate leak check would be skipped. The same flag
  already gates billing adoption in `configureBilling`.
- Four tests cover the branch matrix: idle timeout with a stopped container
  (asserts `listProcesses` is never called), idle timeout with a running
  container, a non idle timeout reason with a stopped container, and a sandbox
  that does not expose `isContainerRunning`.
- Effect is checkable after deploy with existing logging: `reason=idle-timeout`
  should report `observation=absent-no-container`, and `container_stopped` with
  `reason=activity_expired` should fall relative to `reason=exit`.
