### PR TITLE
fix(ai-gateway): harden response rewrite pipeline

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -275,7 +275,8 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
       expect.anything(),
       expect.anything(),
       expect.anything(),
-      expect.objectContaining({ vercel_request_id: 'iad1::iad1::request-id' })
+      expect.objectContaining({ vercel_request_id: 'iad1::iad1::request-id' }),
+      expect.anything()
     );
   });
 
@@ -829,6 +830,24 @@ describe('upstream request failure and unrewritten response logging', () => {
     );
     expect(mockedLogUnrewrittenResponse).not.toHaveBeenCalled();
     expect(mockedRewriteModelResponse).not.toHaveBeenCalled();
+  });
+
+  it('preserves status 499 so request logging classifies a client disconnect', async () => {
+    mockedUpstreamRequest.mockResolvedValue({
+      type: 'error',
+      response: new Response(null, { status: 499 }) as never,
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('openai/gpt-4o')) as never);
+
+    expect(response.status).toBe(499);
+    expect(mockedLogUpstreamRequestFailure).toHaveBeenCalledWith(
+      499,
+      'openai/gpt-4o',
+      'openrouter',
+      expect.anything()
+    );
   });
 
   it('logs non-BYOK upstream 402 via logUnrewrittenResponse before returning service unavailable', async () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -14,7 +14,11 @@ import { fetchEfficientAutoDecision } from '@/lib/ai-gateway/auto-routing-decisi
 import { logMicrodollarUsage } from '@/lib/ai-gateway/processUsage';
 import { applyResolvedAutoModel } from '@/lib/ai-gateway/auto-model/resolution';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
-import { rewriteModelResponse } from '@/lib/rewriteModelResponse';
+import {
+  logUnrewrittenResponse,
+  logUpstreamRequestFailure,
+  rewriteModelResponse,
+} from '@/lib/rewriteModelResponse';
 
 jest.mock('next/server', () => {
   return {
@@ -63,6 +67,8 @@ jest.mock('@/lib/rewriteModelResponse', () => {
     // Mirror the production passthrough; these tests exercise the route, not
     // the response rewrite.
     rewriteModelResponse: jest.fn(async (response: Response) => wrapInSafeNextResponse(response)),
+    logUpstreamRequestFailure: jest.fn(),
+    logUnrewrittenResponse: jest.fn(),
   };
 });
 jest.mock('@/lib/ai-gateway/llm-proxy-helpers', () => {
@@ -104,6 +110,8 @@ const mockedLogMicrodollarUsage = jest.mocked(logMicrodollarUsage);
 const mockedApplyResolvedAutoModel = jest.mocked(applyResolvedAutoModel);
 const mockedGetDirectByokModel = jest.mocked(getDirectByokModel);
 const mockedRewriteModelResponse = jest.mocked(rewriteModelResponse);
+const mockedLogUpstreamRequestFailure = jest.mocked(logUpstreamRequestFailure);
+const mockedLogUnrewrittenResponse = jest.mocked(logUnrewrittenResponse);
 
 const provider = {
   id: 'openrouter',
@@ -762,5 +770,105 @@ describe('auto-routing shadow classifier', () => {
     expect(response.status).toBe(200);
     expect(mockedUpstreamRequest).toHaveBeenCalledTimes(1);
     expect(mockedAfter).not.toHaveBeenCalled();
+  });
+});
+
+describe('upstream request failure and unrewritten response logging', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    setUserAuth();
+    mockedGetProvider.mockResolvedValue({
+      kind: 'provider',
+      provider,
+      userByok: null,
+      bypassAccessCheck: false,
+    });
+    mockedClassifyAbuse.mockResolvedValue(classifyResult(null));
+    mockedRedisGet.mockResolvedValue(null);
+    mockedRedisSet.mockResolvedValue('OK');
+    mockedGetOpenRouterModels.mockResolvedValue(new Set());
+    mockedEmitApiMetricsForResponse.mockReturnValue(undefined);
+    mockedAccountForMicrodollarUsage.mockReturnValue(undefined);
+    mockedLogUpstreamRequestFailure.mockResolvedValue(undefined);
+    mockedLogUnrewrittenResponse.mockResolvedValue(undefined);
+  });
+
+  it('logs upstreamRequest type:error failures with status, model, provider, and logging context', async () => {
+    const errorResponse = new Response(
+      JSON.stringify({
+        error: 'upstream failed',
+        error_type: 'upstream_disconnect',
+      }),
+      { status: 503, headers: { 'content-type': 'application/json' } }
+    );
+    mockedUpstreamRequest.mockResolvedValue({
+      type: 'error',
+      response: errorResponse as never,
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(
+      makeRequest(makeBody('openai/gpt-4o'), { 'x-vercel-id': 'iad1::req-upstream-fail' }) as never
+    );
+
+    expect(response.status).toBe(503);
+    expect(mockedLogUpstreamRequestFailure).toHaveBeenCalledTimes(1);
+    expect(mockedLogUpstreamRequestFailure).toHaveBeenCalledWith(
+      503,
+      'openai/gpt-4o',
+      'openrouter',
+      expect.objectContaining({
+        user: expect.objectContaining({ id: 'user-123' }),
+        organization_id: null,
+        session_id: null,
+        vercel_request_id: 'iad1::req-upstream-fail',
+        request: expect.objectContaining({
+          body: expect.objectContaining({ model: 'openai/gpt-4o' }),
+        }),
+      })
+    );
+    expect(mockedLogUnrewrittenResponse).not.toHaveBeenCalled();
+    expect(mockedRewriteModelResponse).not.toHaveBeenCalled();
+  });
+
+  it('logs non-BYOK upstream 402 via logUnrewrittenResponse before returning service unavailable', async () => {
+    const paymentRequiredBody = { error: { message: 'Payment Required', code: 402 } };
+    const upstream402 = new Response(JSON.stringify(paymentRequiredBody), {
+      status: 402,
+      headers: { 'content-type': 'application/json', 'request-id': 'or-req-402' },
+    });
+    mockedUpstreamRequest.mockResolvedValue({
+      type: 'success',
+      response: upstream402,
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(
+      makeRequest(makeBody(), { 'x-vercel-id': 'iad1::req-402' }) as never
+    );
+
+    expect(response.status).toBe(503);
+    expect(await response.json()).toMatchObject({
+      error: 'Service Unavailable',
+      error_type: 'temporarily_unavailable',
+      message: 'The service is temporarily unavailable. Please try again later.',
+    });
+    expect(mockedLogUnrewrittenResponse).toHaveBeenCalledTimes(1);
+    expect(mockedLogUnrewrittenResponse).toHaveBeenCalledWith(
+      upstream402,
+      'openai/gpt-4o',
+      'openrouter',
+      expect.objectContaining({
+        user: expect.objectContaining({ id: 'user-123' }),
+        organization_id: null,
+        session_id: null,
+        vercel_request_id: 'iad1::req-402',
+        request: expect.objectContaining({
+          body: expect.objectContaining({ model: 'openai/gpt-4o' }),
+        }),
+      })
+    );
+    expect(mockedLogUpstreamRequestFailure).not.toHaveBeenCalled();
+    expect(mockedRewriteModelResponse).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -55,7 +55,11 @@ import {
 import { ProxyErrorType } from '@/lib/proxy-error-types';
 import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage';
 import { isDataCollectionExplicitlyDisallowed } from '@/lib/ai-gateway/providers/openrouter/types';
-import { rewriteModelResponse, logUnrewrittenResponse } from '@/lib/rewriteModelResponse';
+import {
+  rewriteModelResponse,
+  logUnrewrittenResponse,
+  logUpstreamRequestFailure,
+} from '@/lib/rewriteModelResponse';
 import {
   createAnonymousContext,
   isAnonymousContext,
@@ -877,6 +881,14 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     await sleepForRulesEngineAction(rulesEngineDecision.delayMs);
   }
 
+  const requestLogging = {
+    user: maybeUser,
+    organization_id: organizationId || null,
+    session_id: usageContext.session_id,
+    vercel_request_id: vercelRequestId,
+    request: requestBodyParsed,
+  };
+
   const upstreamResult = await upstreamRequest({
     path,
     search: url.search,
@@ -888,6 +900,12 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     vercelRequestId,
   });
   if (upstreamResult.type === 'error') {
+    await logUpstreamRequestFailure(
+      upstreamResult.response.status,
+      effectiveModelIdLowerCased,
+      effectiveProviderContext.provider.id,
+      requestLogging
+    );
     return upstreamResult.response;
   }
   const response = upstreamResult.response;
@@ -935,6 +953,13 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       trackInSentry: true,
     });
 
+    await logUnrewrittenResponse(
+      response,
+      effectiveModelIdLowerCased,
+      effectiveProviderContext.provider.id,
+      requestLogging
+    );
+
     // Return a service unavailable error instead of the 402
     return temporarilyUnavailableResponse();
   }
@@ -968,14 +993,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   }
 
   accountForMicrodollarUsage(clonedReponse, usageContext, openrouterRequestSpan);
-
-  const requestLogging = {
-    user: maybeUser,
-    organization_id: organizationId || null,
-    session_id: usageContext.session_id,
-    vercel_request_id: vercelRequestId,
-    request: requestBodyParsed,
-  };
 
   {
     const errorResponse = await makeErrorReadable({

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -1018,6 +1018,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     effectiveModelIdLowerCased,
     effectiveProviderContext.provider.id,
     requestBodyParsed.kind,
-    requestLogging
+    requestLogging,
+    request.signal
   );
 }

--- a/apps/web/src/lib/ai-gateway/api-request-log-errors.ts
+++ b/apps/web/src/lib/ai-gateway/api-request-log-errors.ts
@@ -25,7 +25,14 @@ export const toolCallArgumentErrorSchema = z.discriminatedUnion('kind', [
 ]);
 
 export const apiRequestLogErrorSchema = z.object({
-  invalid_tool_call_arguments: z.array(toolCallArgumentErrorSchema),
+  invalid_tool_call_arguments: z.array(toolCallArgumentErrorSchema).optional(),
+  response_body_read_error: z.string().optional(),
+  upstream_stream_error: z.object({ event_type: z.string() }).optional(),
+  gateway_stream_error: z
+    .object({ error_type: z.enum(['timeout', 'upstream_disconnect', 'invalid_response']) })
+    .optional(),
+  upstream_request_error: z.enum(['fetch_failed']).optional(),
+  client_disconnected: z.literal(true).optional(),
 });
 
 export type ApiRequestLogError = z.infer<typeof apiRequestLogErrorSchema>;

--- a/apps/web/src/lib/ai-gateway/api-request-log-errors.ts
+++ b/apps/web/src/lib/ai-gateway/api-request-log-errors.ts
@@ -33,6 +33,7 @@ export const apiRequestLogErrorSchema = z.object({
     .optional(),
   upstream_request_error: z.enum(['fetch_failed']).optional(),
   client_disconnected: z.literal(true).optional(),
+  client_stalled: z.literal(true).optional(),
 });
 
 export type ApiRequestLogError = z.infer<typeof apiRequestLogErrorSchema>;

--- a/apps/web/src/lib/ai-gateway/processUsage.responses.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.responses.test.ts
@@ -195,6 +195,33 @@ describe('parseMicrodollarUsageFromStream approval tests', () => {
     expect(result.responseContent).toBe('Hello world');
     expect(result.hasError).toBe(true);
   });
+
+  test('marks hasError for standard OpenAI Responses type:error SSE events', async () => {
+    const errorEvent = `data: ${JSON.stringify({
+      type: 'error',
+      code: 'server_error',
+      message: 'The server had an error while processing your request.',
+      param: null,
+      sequence_number: 3,
+    })}\n\n`;
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(errorEvent));
+        controller.close();
+      },
+    });
+
+    const result = await parseResponsesMicrodollarUsageFromStream(
+      stream,
+      'fake-user-id',
+      undefined,
+      'openrouter',
+      200
+    );
+
+    expect(result.hasError).toBe(true);
+  });
 });
 
 describe('parseMicrodollarUsageFromString approval tests', () => {

--- a/apps/web/src/lib/ai-gateway/processUsage.responses.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.responses.ts
@@ -44,6 +44,9 @@ type ResponsesApiStreamEvent = {
   delta?: string;
   response?: ResponsesApiResponse;
   error?: { message: string; code: string };
+  code?: string | null;
+  message?: string;
+  param?: string | null;
 };
 
 export function processResponsesApiUsage(
@@ -154,9 +157,10 @@ export async function parseResponsesMicrodollarUsageFromStream(
         return;
       }
 
-      if ('error' in json && json.error) {
+      const streamError = json.type === 'error' ? json : json.error;
+      if (streamError) {
         reportedError = true;
-        captureException(new Error(`Responses API error: ${json.error.message}`), {
+        captureException(new Error(`Responses API error: ${streamError.message ?? 'unknown'}`), {
           tags: { source: 'responses_sse_processing' },
           extra: { json, event },
         });

--- a/apps/web/src/lib/ai-gateway/processUsage.shared.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.shared.ts
@@ -134,7 +134,12 @@ export async function drainSseStream(
   try {
     while (true) {
       const { done, value } = await reader.read();
-      if (done) break;
+      if (done) {
+        const trailingText = decoder.decode();
+        if (trailingText) onTextChunk(trailingText);
+        onTextChunk('\n\n');
+        break;
+      }
       onTextChunk(decoder.decode(value, { stream: true }));
     }
   } catch (error) {

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -297,6 +297,33 @@ describe('parseMicrodollarUsageFromStream approval tests', () => {
     expect(result.status_code).toBe(502);
   });
 
+  test('does not treat Chat Completions SSE chunk with error: null as an error', async () => {
+    const sse = [
+      'data: {"id":"gen-null-err","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{"content":"hi"},"finish_reason":null}],"error":null}',
+      'data: {"id":"gen-null-err","object":"chat.completion.chunk","created":1,"model":"test-model","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":1,"total_tokens":2,"cost":0.001,"is_byok":false,"prompt_tokens_details":{"cached_tokens":0},"cost_details":{"upstream_inference_cost":null},"completion_tokens_details":{"reasoning_tokens":0}}}',
+      'data: [DONE]',
+      '',
+    ].join('\n\n');
+
+    const stream = new ReadableStream<Uint8Array>({
+      start(controller) {
+        controller.enqueue(new TextEncoder().encode(sse));
+        controller.close();
+      },
+    });
+
+    await expect(
+      parseMicrodollarUsageFromStream(stream, 'fake-user-id', undefined, 'openrouter', 200)
+    ).resolves.toMatchObject({
+      hasError: false,
+      messageId: 'gen-null-err',
+      model: 'test-model',
+      responseContent: 'hi',
+      cost_mUsd: 1000,
+      status_code: 200,
+    });
+  });
+
   test('records the Vercel upstream provider request id as upstream_id', async () => {
     const chunk = `data: {"id":"gen_01KYMFY57BAFKZGK45197SCRGD","object":"chat.completion.chunk","created":1785246720,"model":"moonshotai/kimi-k3-fast","choices":[{"index":0,"delta":{"provider_metadata":{"fireworks":{},"gateway":{"routing":{"originalModelId":"moonshotai/kimi-k3-fast","resolvedProvider":"fireworks","fallbacksAvailable":[],"canonicalSlug":"moonshotai/kimi-k3-fast","finalProvider":"fireworks","speed":"fast","modelAttemptCount":1,"modelAttempts":[{"canonicalSlug":"moonshotai/kimi-k3-fast","success":true,"providerAttemptCount":1,"providerAttempts":[{"provider":"fireworks","credentialType":"system","success":true,"startTime":1785246717210,"endTime":1785246721497,"providerRequestId":"chatcmpl-ccebc94c526d4f8797cfe00023478a9a","statusCode":200,"providerResponseId":"chatcmpl-ccebc94c526d4f8797cfe00023478a9a"}]}],"totalProviderAttemptCount":1},"cost":"0.0474822","marketCost":"0.0474822","generationId":"gen_01KYMFY57BAFKZGK45197SCRGD"}}},"logprobs":null,"finish_reason":"tool_calls"}],"usage":{"prompt_tokens":91904,"completion_tokens":134,"total_tokens":92038,"cost":0.0474822,"is_byok":false,"prompt_tokens_details":{"cached_tokens":91136},"cost_details":{"upstream_inference_cost":null},"completion_tokens_details":{"reasoning_tokens":0}},"generationId":"gen_01KYMFY57BAFKZGK45197SCRGD"}\n\ndata: [DONE]\n\n`;
 

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -1065,7 +1065,7 @@ export async function parseMicrodollarUsageFromStream(
         return;
       }
 
-      if ('error' in json) {
+      if ('error' in json && json.error != null) {
         const error = json.error as OpenRouterError;
         reportedError = true;
         if (typeof error.code === 'number') {

--- a/apps/web/src/lib/ai-gateway/request-logging-opt-ins.test.ts
+++ b/apps/web/src/lib/ai-gateway/request-logging-opt-ins.test.ts
@@ -1,9 +1,23 @@
-import { describe, expect, test } from '@jest/globals';
+import { beforeEach, describe, expect, test } from '@jest/globals';
 import {
   hasMatchingRequestLoggingOptIn,
+  isDynamicallyOptedIntoRequestLogging,
   RequestLoggingOptInsSchema,
   type RequestLoggingOptIn,
 } from './request-logging-opt-ins';
+import { redisClient } from '@/lib/redis';
+import { errorExceptInTest } from '@/lib/utils.server';
+
+jest.mock('@/lib/redis', () => ({
+  redisClient: { get: jest.fn() },
+}));
+
+jest.mock('@/lib/utils.server', () => ({
+  errorExceptInTest: jest.fn(),
+}));
+
+const mockedRedisGet = jest.mocked(redisClient.get);
+const mockedError = jest.mocked(errorExceptInTest);
 
 const optIns: RequestLoggingOptIn[] = [
   {
@@ -25,6 +39,11 @@ const optIns: RequestLoggingOptIn[] = [
 ];
 
 describe('request logging opt-ins', () => {
+  beforeEach(() => {
+    mockedRedisGet.mockReset();
+    mockedError.mockReset();
+  });
+
   test('matches account and organization IDs by type', () => {
     expect(
       hasMatchingRequestLoggingOptIn(optIns, {
@@ -57,5 +76,17 @@ describe('request logging opt-ins', () => {
         },
       ])
     ).toThrow();
+  });
+
+  test('logs refresh failures while safely disabling dynamic request logging', async () => {
+    mockedRedisGet.mockRejectedValueOnce(new TypeError('Redis unavailable'));
+
+    await expect(
+      isDynamicallyOptedIntoRequestLogging({ accountId: 'account-1', organizationId: null })
+    ).resolves.toBe(false);
+    expect(mockedError).toHaveBeenCalledWith(
+      '[requestLogging] failed to refresh dynamic logging opt-ins',
+      { errorName: 'TypeError' }
+    );
   });
 });

--- a/apps/web/src/lib/ai-gateway/request-logging-opt-ins.ts
+++ b/apps/web/src/lib/ai-gateway/request-logging-opt-ins.ts
@@ -2,6 +2,7 @@ import * as z from 'zod';
 import { createCachedFetch } from '@/lib/cached-fetch';
 import { redisClient } from '@/lib/redis';
 import { REQUEST_LOGGING_OPT_INS_REDIS_KEY } from '@/lib/redis-keys';
+import { errorExceptInTest } from '@/lib/utils.server';
 
 export const RequestLoggingOptInSchema = z.object({
   id: z.string().uuid(),
@@ -74,8 +75,19 @@ export async function getRequestLoggingOptIns(): Promise<RequestLoggingOptIn[]> 
   return RequestLoggingOptInsSchema.parse(JSON.parse(raw));
 }
 
+async function getRequestLoggingOptInsWithDiagnostics(): Promise<RequestLoggingOptIn[]> {
+  try {
+    return await getRequestLoggingOptIns();
+  } catch (error) {
+    errorExceptInTest('[requestLogging] failed to refresh dynamic logging opt-ins', {
+      errorName: error instanceof Error ? error.name : typeof error,
+    });
+    throw error;
+  }
+}
+
 const getCachedRequestLoggingOptIns = createCachedFetch<RequestLoggingOptIn[]>(
-  getRequestLoggingOptIns,
+  getRequestLoggingOptInsWithDiagnostics,
   REQUEST_LOGGING_OPT_INS_CACHE_TTL_MS,
   []
 );

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -5,12 +5,15 @@ import {
   rewriteModelResponse_Responses,
   rewriteModelResponse,
   logUnrewrittenResponse,
+  logUpstreamRequestFailure,
   type RequestLoggingParams,
 } from './rewriteModelResponse';
 import { isDynamicallyOptedIntoRequestLogging } from '@/lib/ai-gateway/request-logging-opt-ins';
 import { QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/custom-pricing';
 import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
 import { logExceptInTest } from '@/lib/utils.server';
+import { after } from 'next/server';
+import { db } from '@/lib/drizzle';
 
 jest.mock('next/server', () => ({
   ...(jest.requireActual('next/server') as Record<string, unknown>),
@@ -21,6 +24,10 @@ jest.mock('@/lib/ai-gateway/request-logging-opt-ins', () => ({
   isDynamicallyOptedIntoRequestLogging: jest.fn(async () => false),
 }));
 
+jest.mock('@/lib/drizzle', () => ({
+  db: { insert: jest.fn() },
+}));
+
 jest.mock('@/lib/utils.server', () => ({
   ...(jest.requireActual('@/lib/utils.server') as Record<string, unknown>),
   logExceptInTest: jest.fn(),
@@ -28,10 +35,21 @@ jest.mock('@/lib/utils.server', () => ({
 
 const mockedOptIn = jest.mocked(isDynamicallyOptedIntoRequestLogging);
 const mockedLog = jest.mocked(logExceptInTest);
+const mockedAfter = jest.mocked(after);
+const mockedInsert = jest.mocked(db.insert);
+const mockedValues = jest.fn();
+const mockedReturning = jest.fn();
 
 beforeEach(() => {
   mockedOptIn.mockClear();
   mockedLog.mockClear();
+  mockedAfter.mockClear();
+  mockedInsert.mockReset();
+  mockedValues.mockReset();
+  mockedReturning.mockReset();
+  mockedInsert.mockReturnValue({ values: mockedValues } as never);
+  mockedValues.mockReturnValue({ returning: mockedReturning } as never);
+  mockedReturning.mockResolvedValue([{ id: 'request-log-id' }]);
 });
 
 function jsonResponse(body: unknown, status = 200): Response {
@@ -139,7 +157,12 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
     const result = await rewrite(failingResponse('application/json', errorName), true, null, null);
 
     expect(result.status).toBe(503);
-    const details = streamErrorDetails(await result.json());
+    const errorResponse = await result.json();
+    expect(errorResponse).toMatchObject({
+      error_type: errorType,
+      message: expect.stringContaining(messageFragment),
+    });
+    const details = streamErrorDetails(errorResponse);
     expect(details).toMatchObject({
       message: expect.stringContaining(messageFragment),
     });
@@ -155,7 +178,14 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
     );
 
     expect(result.status).toBe(503);
-    expect(streamErrorDetails(await result.json())).toMatchObject({
+    const errorResponse = await result.json();
+    expect(errorResponse).toMatchObject({
+      error_type: 'upstream_disconnect',
+      vercel_request_id: 'iad1::iad1::request-id',
+      message:
+        'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
+    });
+    expect(streamErrorDetails(errorResponse)).toMatchObject({
       message:
         'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
     });
@@ -171,6 +201,10 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
     const events = dataObjects(await readOutputStream(result));
 
     expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      error_type: 'upstream_disconnect',
+      vercel_request_id: 'iad1::iad1::request-id',
+    });
     expect(streamErrorDetails(events[0]).message).toBe(
       'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)'
     );
@@ -342,6 +376,31 @@ describe('rewriteModelResponse_ChatCompletions', () => {
       expect(dataPayloads(sse)).toContain('[DONE]');
     });
 
+    test('rewrites a successful SSE stream with a non-standard content type', async () => {
+      const upstream = new Response(
+        'data: {"id":"gen-chat","choices":[],"usage":{"cost":0.5,"is_byok":false,"prompt_tokens_details":{}}}\n\n' +
+          'data: [DONE]\n\n',
+        { headers: { 'content-type': 'text/plain' } }
+      );
+
+      const result = await rewriteModelResponse_ChatCompletions(upstream, true, null, null);
+      const [chunk] = dataObjects(await readOutputStream(result)) as Array<{
+        usage: {
+          cost?: number;
+          is_byok?: boolean;
+          prompt_tokens_details: { cached_tokens?: number };
+        };
+      }>;
+
+      expect(chunk.usage.cost).toBeUndefined();
+      expect(chunk.usage.is_byok).toBeUndefined();
+      expect(chunk.usage.prompt_tokens_details.cached_tokens).toBe(0);
+      expect(mockedLog).toHaveBeenCalledWith(
+        '[rewriteModelResponse] rewriting successful response with unexpected content type',
+        { status: 200, contentType: 'text/plain' }
+      );
+    });
+
     test('forwards a final event without a trailing blank line', async () => {
       const upstream = sseResponse(
         'data: {"id":"gen-chat","choices":[{"delta":{"content":"final €"}}]}'
@@ -379,6 +438,95 @@ describe('rewriteModelResponse_ChatCompletions', () => {
       expect(pullCount).toBeLessThan(10);
       await reader?.cancel();
       expect(cancel).toHaveBeenCalledTimes(1);
+    });
+
+    test('settles a stalled stream when the incoming request is aborted', async () => {
+      const capture = makeCapture();
+      const requestController = new AbortController();
+      const cancel = jest.fn();
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          start() {},
+          cancel,
+        }),
+        { headers: { 'content-type': 'text/event-stream' } }
+      );
+
+      const result = await rewriteModelResponse_ChatCompletions(
+        upstream,
+        true,
+        capture,
+        null,
+        requestController.signal
+      );
+      const pendingRead = result.body?.getReader().read();
+      requestController.abort();
+
+      await expect(pendingRead).rejects.toBeDefined();
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), undefined, {
+        client_disconnected: true,
+      });
+    });
+
+    test('settles a stream when output remains buffered for an idle consumer', async () => {
+      jest.useFakeTimers();
+      try {
+        const capture = makeCapture();
+        const { response: upstream, cancel } = hangingSseResponse(
+          'data: {"id":"gen-chat","choices":[]}\n\n'
+        );
+
+        const result = await rewriteModelResponse_ChatCompletions(upstream, true, capture, null);
+        await Promise.resolve();
+        await jest.advanceTimersByTimeAsync(15 * 60 * 1000);
+
+        await expect(result.body?.getReader().read()).rejects.toThrow(
+          'response consumer remained idle'
+        );
+        expect(cancel).toHaveBeenCalledTimes(1);
+        expect(capture.setReadError).toHaveBeenCalledWith(
+          expect.objectContaining({ message: 'response consumer remained idle' }),
+          'data: {"id":"gen-chat","choices":[]}\n\n',
+          { client_stalled: true }
+        );
+      } finally {
+        jest.useRealTimers();
+      }
+    });
+
+    test('does not classify a slow upstream read as a stalled consumer', async () => {
+      jest.useFakeTimers();
+      try {
+        const capture = makeCapture();
+        const requestController = new AbortController();
+        const cancel = jest.fn();
+        const upstream = new Response(
+          new ReadableStream<Uint8Array>({
+            start() {},
+            cancel,
+          }),
+          { headers: { 'content-type': 'text/event-stream' } }
+        );
+
+        const result = await rewriteModelResponse_ChatCompletions(
+          upstream,
+          true,
+          capture,
+          null,
+          requestController.signal
+        );
+        const pendingRead = result.body?.getReader().read();
+        await jest.advanceTimersByTimeAsync(15 * 60 * 1000);
+
+        expect(cancel).not.toHaveBeenCalled();
+        expect(capture.setReadError).not.toHaveBeenCalled();
+
+        requestController.abort();
+        await expect(pendingRead).rejects.toBeDefined();
+      } finally {
+        jest.useRealTimers();
+      }
     });
 
     test('cancels upstream and closes immediately after [DONE]', async () => {
@@ -490,6 +638,8 @@ describe('rewriteModelResponse_Messages', () => {
       {
         id: 'gen-message',
         type: 'error',
+        error_type: errorType,
+        message: expect.any(String),
         error: {
           type: 'api_error',
           message: expect.any(String),
@@ -647,6 +797,7 @@ describe('rewriteModelResponse_Responses', () => {
       {
         type: 'error',
         sequence_number: 5,
+        error_type: errorType,
         code: errorType,
         message: expect.any(String),
         param: null,
@@ -830,7 +981,7 @@ describe.each(rewriters)('%s response compatibility', (_name, rewrite) => {
         },
         cancel,
       }),
-      { headers: { 'content-type': 'text/plain' } }
+      { status: 502, headers: { 'content-type': 'text/plain' } }
     );
 
     const result = await rewrite(upstream, true, capture, null);
@@ -852,7 +1003,7 @@ describe.each(rewriters)('%s response compatibility', (_name, rewrite) => {
         start() {},
         cancel,
       }),
-      { headers: { 'content-type': 'text/plain' } }
+      { status: 502, headers: { 'content-type': 'text/plain' } }
     );
 
     const result = await rewrite(upstream, true, capture, null);
@@ -1007,6 +1158,91 @@ function makeCapture() {
 }
 
 describe('request log capture', () => {
+  test.each([
+    [499, { client_disconnected: true }],
+    [503, { upstream_request_error: 'fetch_failed' }],
+  ] as const)(
+    'classifies an upstream request status %i in error metadata',
+    async (status, error) => {
+      mockedOptIn.mockResolvedValueOnce(true);
+
+      await logUpstreamRequestFailure(status, 'openai/gpt-5', 'openrouter', makeLogging());
+      const callback = mockedAfter.mock.calls[0]?.[0] as () => Promise<void>;
+      await callback();
+
+      expect(mockedValues).toHaveBeenCalledWith(
+        expect.objectContaining({
+          status_code: status,
+          response: undefined,
+          error,
+        })
+      );
+    }
+  );
+
+  test('settles a captured passthrough response when the request is aborted', async () => {
+    const capture = makeCapture();
+    const requestController = new AbortController();
+    const cancel = jest.fn();
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start() {},
+        cancel,
+      }),
+      { status: 502, headers: { 'content-type': 'text/plain' } }
+    );
+
+    const result = await rewriteModelResponse_ChatCompletions(
+      upstream,
+      true,
+      capture,
+      null,
+      requestController.signal
+    );
+    const pendingRead = result.body?.getReader().read();
+    requestController.abort();
+
+    await expect(pendingRead).rejects.toBeDefined();
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), undefined, {
+      client_disconnected: true,
+    });
+  });
+
+  test('settles a captured passthrough response when its consumer stalls', async () => {
+    jest.useFakeTimers();
+    try {
+      const capture = makeCapture();
+      const cancel = jest.fn();
+      const rawBody = 'buffered upstream body';
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.enqueue(new TextEncoder().encode(rawBody));
+          },
+          cancel,
+        }),
+        { status: 502, headers: { 'content-type': 'text/plain' } }
+      );
+
+      const result = await rewriteModelResponse_ChatCompletions(upstream, true, capture, null);
+      await Promise.resolve();
+      await jest.advanceTimersByTimeAsync(15 * 60 * 1000);
+
+      await expect(result.body?.getReader().read()).rejects.toThrow(
+        'response consumer remained idle'
+      );
+      expect(cancel).toHaveBeenCalledTimes(1);
+      expect(capture.setReadError).toHaveBeenCalledWith(
+        expect.objectContaining({ message: 'response consumer remained idle' }),
+        rawBody,
+        { client_stalled: true }
+      );
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
   test('starts unrewritten response capture without blocking the client response', async () => {
     mockedOptIn.mockResolvedValueOnce(true);
     let upstreamController: ReadableStreamDefaultController<Uint8Array> | undefined;

--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -4,6 +4,7 @@ import {
   rewriteModelResponse_Messages,
   rewriteModelResponse_Responses,
   rewriteModelResponse,
+  logUnrewrittenResponse,
   type RequestLoggingParams,
 } from './rewriteModelResponse';
 import { isDynamicallyOptedIntoRequestLogging } from '@/lib/ai-gateway/request-logging-opt-ins';
@@ -116,6 +117,14 @@ function dataObjects(sse: string): unknown[] {
     .map(payload => JSON.parse(payload));
 }
 
+function streamErrorDetails(event: unknown): Record<string, unknown> {
+  if (typeof event !== 'object' || event === null) return {};
+  if ('error' in event && typeof event.error === 'object' && event.error !== null) {
+    return event.error as Record<string, unknown>;
+  }
+  return event as Record<string, unknown>;
+}
+
 const rewriters = [
   ['Chat Completions', rewriteModelResponse_ChatCompletions],
   ['Messages', rewriteModelResponse_Messages],
@@ -130,11 +139,11 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
     const result = await rewrite(failingResponse('application/json', errorName), true, null, null);
 
     expect(result.status).toBe(503);
-    expect(await result.json()).toEqual({
-      error: expect.stringContaining(messageFragment),
-      error_type: errorType,
+    const details = streamErrorDetails(await result.json());
+    expect(details).toMatchObject({
       message: expect.stringContaining(messageFragment),
     });
+    expect(Object.values(details)).toContain(errorType);
   });
 
   test('includes the vercel request id in the JSON read error', async () => {
@@ -146,13 +155,9 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
     );
 
     expect(result.status).toBe(503);
-    expect(await result.json()).toEqual({
-      error:
-        'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
-      error_type: 'upstream_disconnect',
+    expect(streamErrorDetails(await result.json())).toMatchObject({
       message:
         'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
-      vercel_request_id: 'iad1::iad1::request-id',
     });
   });
 
@@ -163,15 +168,12 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
       null,
       'iad1::iad1::request-id'
     );
-    const events = dataObjects(await readOutputStream(result)) as {
-      error: { message: string; vercel_request_id?: string };
-    }[];
+    const events = dataObjects(await readOutputStream(result));
 
     expect(events).toHaveLength(1);
-    expect(events[0].error.message).toBe(
+    expect(streamErrorDetails(events[0]).message).toBe(
       'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)'
     );
-    expect(events[0].error.vercel_request_id).toBe('iad1::iad1::request-id');
   });
 
   test('omits the request id suffix when no vercel request id is available', async () => {
@@ -181,14 +183,11 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
       null,
       null
     );
-    const events = dataObjects(await readOutputStream(result)) as {
-      error: { message: string; vercel_request_id?: string };
-    }[];
+    const events = dataObjects(await readOutputStream(result));
 
-    expect(events[0].error.message).toBe(
+    expect(streamErrorDetails(events[0]).message).toBe(
       'The upstream provider disconnected while sending the response.'
     );
-    expect(events[0].error.vercel_request_id).toBeUndefined();
   });
 });
 
@@ -303,7 +302,10 @@ describe('rewriteModelResponse_ChatCompletions', () => {
 
       expect(events[0]).toMatchObject({ model: 'upstream-model' });
       expect(events[1]).toMatchObject({ id: 'gen-chat' });
-      expect(events[1]?.error).toMatchObject({ code: 503, type: errorType });
+      expect(events[1]?.error).toMatchObject({
+        code: 503,
+        type: errorType,
+      });
       expect(dataPayloads(sse)).not.toContain('[DONE]');
     });
 
@@ -338,6 +340,45 @@ describe('rewriteModelResponse_ChatCompletions', () => {
 
       expect(sse).toContain('still streaming');
       expect(dataPayloads(sse)).toContain('[DONE]');
+    });
+
+    test('forwards a final event without a trailing blank line', async () => {
+      const upstream = sseResponse(
+        'data: {"id":"gen-chat","choices":[{"delta":{"content":"final €"}}]}'
+      );
+
+      const result = await rewriteModelResponse_ChatCompletions(upstream, true, null, null);
+
+      expect(await readOutputStream(result)).toContain('final €');
+    });
+
+    test('does not eagerly drain upstream while the client is idle', async () => {
+      const encoder = new TextEncoder();
+      let pullCount = 0;
+      const cancel = jest.fn();
+      const upstream = new Response(
+        new ReadableStream<Uint8Array>({
+          pull(controller) {
+            pullCount += 1;
+            controller.enqueue(
+              encoder.encode(
+                `data: {"id":"gen-chat","choices":[{"delta":{"content":"${pullCount}"}}]}\n\n`
+              )
+            );
+          },
+          cancel,
+        }),
+        { headers: { 'content-type': 'text/event-stream' } }
+      );
+
+      const result = await rewriteModelResponse_ChatCompletions(upstream, true, null, null);
+      const reader = result.body?.getReader();
+      await reader?.read();
+      await Promise.resolve();
+
+      expect(pullCount).toBeLessThan(10);
+      await reader?.cancel();
+      expect(cancel).toHaveBeenCalledTimes(1);
     });
 
     test('cancels upstream and closes immediately after [DONE]', async () => {
@@ -604,14 +645,11 @@ describe('rewriteModelResponse_Responses', () => {
         response: { id: 'gen-response' },
       },
       {
-        id: 'gen-response',
         type: 'error',
         sequence_number: 5,
-        error: {
-          type: errorType,
-          code: errorType === 'timeout' ? '504' : '503',
-          message: expect.any(String),
-        },
+        code: errorType,
+        message: expect.any(String),
+        param: null,
       },
     ]);
   });
@@ -682,7 +720,13 @@ describe('rewriteModelResponse_Responses', () => {
 
       expect(dataObjects(sse)).toEqual([{ type }]);
       expect(cancel).toHaveBeenCalledTimes(1);
-      expect(capture.setBody).toHaveBeenCalledWith(body);
+      if (type === 'response.completed') {
+        expect(capture.setBody).toHaveBeenCalledWith(body);
+      } else {
+        expect(capture.setBody).toHaveBeenCalledWith(body, {
+          upstream_stream_error: { event_type: type },
+        });
+      }
       expect(capture.setReadError).not.toHaveBeenCalled();
       expect(mockedLog).toHaveBeenCalledWith(
         '[rewriteModelResponse] received terminal stream event',
@@ -736,7 +780,9 @@ describe.each([
       expect(sse).toContain('rate limited');
       expect(sse).not.toContain('ignored');
       expect(cancel).toHaveBeenCalledTimes(1);
-      expect(capture.setBody).toHaveBeenCalledWith(body);
+      expect(capture.setBody).toHaveBeenCalledWith(body, {
+        upstream_stream_error: { event_type: 'error' },
+      });
       expect(capture.setReadError).not.toHaveBeenCalled();
       expect(mockedLog).toHaveBeenCalledWith(
         '[rewriteModelResponse] received terminal stream event',
@@ -750,6 +796,95 @@ describe.each([
     });
   }
 );
+
+describe.each(rewriters)('%s response compatibility', (_name, rewrite) => {
+  test.each(['application/problem+json', 'text/plain', null])(
+    'passes through non-SSE content type %s',
+    async contentType => {
+      const capture = makeCapture();
+      const body = '{"upstream":"error details"}';
+      const headers = contentType ? { 'content-type': contentType } : undefined;
+      const upstream = new Response(contentType === null ? new TextEncoder().encode(body) : body, {
+        status: 502,
+        headers,
+      });
+
+      const result = await rewrite(upstream, true, capture, null);
+
+      expect(result.status).toBe(502);
+      expect(await result.text()).toBe(body);
+      if (contentType) expect(result.headers.get('content-type')).toBe(contentType);
+      await Promise.resolve();
+      expect(capture.setBody).toHaveBeenCalledWith(body);
+    }
+  );
+
+  test('cancels a non-SSE upstream and captures its raw partial body', async () => {
+    const capture = makeCapture();
+    const cancel = jest.fn();
+    const rawBody = 'partial upstream body';
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          controller.enqueue(new TextEncoder().encode(rawBody));
+        },
+        cancel,
+      }),
+      { headers: { 'content-type': 'text/plain' } }
+    );
+
+    const result = await rewrite(upstream, true, capture, null);
+    const reader = result.body?.getReader();
+    await reader?.read();
+    await reader?.cancel();
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), rawBody, {
+      client_disconnected: true,
+    });
+  });
+
+  test('cancels a non-SSE upstream while its first read is pending', async () => {
+    const capture = makeCapture();
+    const cancel = jest.fn();
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start() {},
+        cancel,
+      }),
+      { headers: { 'content-type': 'text/plain' } }
+    );
+
+    const result = await rewrite(upstream, true, capture, null);
+    const reader = result.body?.getReader();
+    const pendingRead = reader?.read();
+    await Promise.resolve();
+    await reader?.cancel();
+    await pendingRead;
+
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(capture.setReadError).toHaveBeenCalledTimes(1);
+    expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), undefined, {
+      client_disconnected: true,
+    });
+    expect(capture.setBody).not.toHaveBeenCalled();
+  });
+
+  test('turns malformed SSE JSON into a protocol error and cancels upstream', async () => {
+    const capture = makeCapture();
+    const rawBody = 'data: not-json\n\n';
+    const { response: upstream, cancel } = hangingSseResponse(rawBody);
+
+    const result = await rewrite(upstream, true, capture, null);
+    const events = dataObjects(await readOutputStream(result));
+
+    expect(streamErrorDetails(events[0]).message).toContain('invalid response');
+    expect(cancel).toHaveBeenCalledTimes(1);
+    expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), rawBody, {
+      gateway_stream_error: { error_type: 'invalid_response' },
+    });
+  });
+});
 
 function makeLogging(overrides?: Partial<RequestLoggingParams>): RequestLoggingParams {
   return {
@@ -868,10 +1003,28 @@ describe('rewriteModelResponse', () => {
 });
 
 function makeCapture() {
-  return { setBody: jest.fn(), setReadError: jest.fn() };
+  return { setBody: jest.fn(), setReadError: jest.fn(), setError: jest.fn() };
 }
 
 describe('request log capture', () => {
+  test('starts unrewritten response capture without blocking the client response', async () => {
+    mockedOptIn.mockResolvedValueOnce(true);
+    let upstreamController: ReadableStreamDefaultController<Uint8Array> | undefined;
+    const response = new Response(
+      new ReadableStream<Uint8Array>({
+        start(controller) {
+          upstreamController = controller;
+        },
+      })
+    );
+
+    await expect(
+      logUnrewrittenResponse(response, 'openai/gpt-5', 'openrouter', makeLogging())
+    ).resolves.toBeUndefined();
+
+    upstreamController?.close();
+  });
+
   test.each(rewriters)('%s: captures the raw JSON body', async (_name, rewrite) => {
     const capture = makeCapture();
     const body = { model: 'upstream-model' };
@@ -882,6 +1035,31 @@ describe('request log capture', () => {
     expect(capture.setBody).toHaveBeenCalledTimes(1);
     expect(capture.setBody).toHaveBeenCalledWith(JSON.stringify(body));
     expect(capture.setReadError).not.toHaveBeenCalled();
+  });
+
+  test('keeps the raw upstream JSON when the client response is rewritten', async () => {
+    const capture = makeCapture();
+    const body = {
+      model: 'upstream-model',
+      usage: {
+        cost: 0.5,
+        is_byok: false,
+        prompt_tokens: 1,
+        completion_tokens: 1,
+        total_tokens: 2,
+        prompt_tokens_details: {},
+      },
+    };
+
+    const result = await rewriteModelResponse_ChatCompletions(
+      jsonResponse(body),
+      true,
+      capture,
+      null
+    );
+
+    expect((await result.json()).usage.cost).toBeUndefined();
+    expect(capture.setBody).toHaveBeenCalledWith(JSON.stringify(body));
   });
 
   test.each(rewriters)('%s: captures the raw event stream', async (_name, rewrite) => {
@@ -930,7 +1108,9 @@ describe('request log capture', () => {
       await readOutputStream(result);
 
       expect(capture.setReadError).toHaveBeenCalledTimes(1);
-      expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), receivedChunks);
+      expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), receivedChunks, {
+        gateway_stream_error: { error_type: 'upstream_disconnect' },
+      });
       expect(capture.setBody).not.toHaveBeenCalled();
     }
   );
@@ -949,7 +1129,9 @@ describe('request log capture', () => {
       await readOutputStream(result);
 
       expect(capture.setReadError).toHaveBeenCalledTimes(1);
-      expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), undefined);
+      expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), undefined, {
+        gateway_stream_error: { error_type: 'upstream_disconnect' },
+      });
       expect(capture.setBody).not.toHaveBeenCalled();
     }
   );
@@ -974,16 +1156,58 @@ describe('request log capture', () => {
 
   test('records a read error when the response stream is cancelled', async () => {
     const capture = makeCapture();
-    const upstream = new Response(new ReadableStream<Uint8Array>({ start() {} }), {
-      headers: { 'content-type': 'text/event-stream' },
-    });
+    const cancel = jest.fn();
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start() {},
+        cancel,
+      }),
+      { headers: { 'content-type': 'text/event-stream' } }
+    );
 
     const result = await rewriteModelResponse_ChatCompletions(upstream, true, capture, null);
     const reader = result.body?.getReader();
     await reader?.cancel();
 
-    expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), undefined);
+    expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), undefined, {
+      client_disconnected: true,
+    });
     expect(capture.setBody).not.toHaveBeenCalled();
+    expect(cancel).toHaveBeenCalledTimes(1);
+  });
+
+  test('does not wait for a hanging upstream cancellation', async () => {
+    const upstream = new Response(
+      new ReadableStream<Uint8Array>({
+        start() {},
+        cancel: () => new Promise<void>(() => {}),
+      }),
+      { headers: { 'content-type': 'text/event-stream' } }
+    );
+
+    const result = await rewriteModelResponse_ChatCompletions(upstream, true, makeCapture(), null);
+
+    await expect(result.body?.getReader().cancel()).resolves.toBeUndefined();
+  });
+
+  test('settles capture when the upstream response body is already locked', async () => {
+    const capture = makeCapture();
+    const upstream = sseResponse('data: {"choices":[]}\n\n');
+    const upstreamReader = upstream.body?.getReader();
+
+    try {
+      const result = await rewriteModelResponse_ChatCompletions(upstream, true, capture, null);
+      const events = dataObjects(await readOutputStream(result));
+
+      expect(streamErrorDetails(events[0]).message).toContain('invalid response');
+      expect(capture.setReadError).toHaveBeenCalledWith(
+        expect.objectContaining({ name: 'TypeError' }),
+        undefined,
+        { gateway_stream_error: { error_type: 'invalid_response' } }
+      );
+    } finally {
+      upstreamReader?.releaseLock();
+    }
   });
 
   test.each(rewriters)(
@@ -991,7 +1215,7 @@ describe('request log capture', () => {
     async (_name, rewrite) => {
       const capture = makeCapture();
       const receivedChunks = 'data: {"id":"gen-1","choices":[]}\n\n';
-      const { response: upstream } = hangingSseResponse(receivedChunks);
+      const { response: upstream, cancel } = hangingSseResponse(receivedChunks);
 
       const result = await rewrite(upstream, true, capture, null);
       const reader = result.body?.getReader();
@@ -999,8 +1223,11 @@ describe('request log capture', () => {
       await reader?.cancel();
 
       expect(capture.setReadError).toHaveBeenCalledTimes(1);
-      expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), receivedChunks);
+      expect(capture.setReadError).toHaveBeenCalledWith(expect.any(Error), receivedChunks, {
+        client_disconnected: true,
+      });
       expect(capture.setBody).not.toHaveBeenCalled();
+      expect(cancel).toHaveBeenCalledTimes(1);
     }
   );
 });

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -1,7 +1,10 @@
 import { api_request_log, type User } from '@kilocode/db/schema';
 import { isKiloExclusiveFreeModel } from '@/lib/ai-gateway/models';
 import { getCustomPricing } from '@/lib/ai-gateway/custom-pricing';
-import { detectToolCallArgumentErrors } from '@/lib/ai-gateway/api-request-log-errors';
+import {
+  detectToolCallArgumentErrors,
+  type ApiRequestLogError,
+} from '@/lib/ai-gateway/api-request-log-errors';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 import { getOutputHeaders } from '@/lib/ai-gateway/llm-proxy-helpers';
@@ -24,8 +27,9 @@ import type Anthropic from '@anthropic-ai/sdk';
  * logging and once for rewriting.
  */
 export type RequestLogCapture = {
-  setBody(text: string): void;
-  setReadError(error: unknown, partialBody?: string): void;
+  setBody(text: string, error?: RequestLogError): void;
+  setReadError(error: unknown, partialBody?: string, details?: RequestLogError): void;
+  setError(error: RequestLogError): void;
 };
 
 export type RequestLoggingParams = {
@@ -36,9 +40,16 @@ export type RequestLoggingParams = {
   request: GatewayRequest;
 };
 
-type CapturedResponseBody =
-  | { text: string; readError?: never }
-  | { readError: string; text?: string };
+type RequestLogError = Omit<
+  ApiRequestLogError,
+  'invalid_tool_call_arguments' | 'response_body_read_error'
+>;
+
+type CapturedResponseBody = {
+  text?: string;
+  readError?: string;
+  error?: RequestLogError;
+};
 
 async function isLoggingEnabledForUser(
   user: User | null,
@@ -54,7 +65,7 @@ async function isLoggingEnabledForUser(
 }
 
 async function createRequestLogCapture(
-  response: Response,
+  status: number,
   model: string,
   provider: string,
   logging: RequestLoggingParams
@@ -63,8 +74,6 @@ async function createRequestLogCapture(
   if (!(await isLoggingEnabledForUser(user, organization_id))) {
     return null;
   }
-  const status = response.status;
-
   let resolveCaptured: (result: CapturedResponseBody) => void = () => {};
   const captured = new Promise<CapturedResponseBody>(resolve => {
     resolveCaptured = resolve;
@@ -90,15 +99,18 @@ async function createRequestLogCapture(
       );
     }
     try {
-      const error =
-        responseText !== undefined
-          ? responseReadError !== undefined
-            ? {
-                ...(detectToolCallArgumentErrors(responseText, request) ?? {}),
-                response_body_read_error: responseReadError,
-              }
-            : detectToolCallArgumentErrors(responseText, request)
-          : { response_body_read_error: responseReadError };
+      const detectedToolCallErrors =
+        responseText !== undefined && responseReadError === undefined
+          ? detectToolCallArgumentErrors(responseText, request)
+          : null;
+      const errorDetails = {
+        ...(detectedToolCallErrors ?? {}),
+        ...(result.error ?? {}),
+        ...(responseReadError !== undefined && {
+          response_body_read_error: responseReadError,
+        }),
+      };
+      const error = Object.keys(errorDetails).length > 0 ? errorDetails : undefined;
       const apiRequestLogId = await db
         .insert(api_request_log)
         .values({
@@ -127,13 +139,14 @@ async function createRequestLogCapture(
   });
 
   return {
-    setBody: text => settleOnce({ text }),
-    setReadError: (error, partialBody) =>
+    setBody: (text, error) => settleOnce({ text, error }),
+    setReadError: (error, partialBody, details) =>
       settleOnce(
         partialBody !== undefined && partialBody.length > 0
-          ? { text: partialBody, readError: String(error).substring(0, 4000) }
-          : { readError: String(error).substring(0, 4000) }
+          ? { text: partialBody, readError: String(error).substring(0, 4000), error: details }
+          : { readError: String(error).substring(0, 4000), error: details }
       ),
+    setError: error => settleOnce({ error }),
   };
 }
 
@@ -144,10 +157,17 @@ export async function logUnrewrittenResponse(
   providerId: ProviderId,
   logging: RequestLoggingParams
 ): Promise<void> {
-  const capture = await createRequestLogCapture(response, model, providerId, logging);
+  const capture = await createRequestLogCapture(response.status, model, providerId, logging);
   if (!capture) {
     return;
   }
+  void captureUnrewrittenResponse(response, capture);
+}
+
+async function captureUnrewrittenResponse(
+  response: Response,
+  capture: RequestLogCapture
+): Promise<void> {
   try {
     capture.setBody(await response.text());
   } catch (error) {
@@ -155,8 +175,18 @@ export async function logUnrewrittenResponse(
   }
 }
 
+export async function logUpstreamRequestFailure(
+  status: number,
+  model: string,
+  providerId: ProviderId,
+  logging: RequestLoggingParams
+): Promise<void> {
+  const capture = await createRequestLogCapture(status, model, providerId, logging);
+  capture?.setError({ upstream_request_error: 'fetch_failed' });
+}
+
 type ResponseReadError = {
-  errorType: 'timeout' | 'upstream_disconnect';
+  errorType: 'timeout' | 'upstream_disconnect' | 'invalid_response';
   /** Already carries the request id suffix when one is available. */
   message: string;
   vercelRequestId?: string;
@@ -229,118 +259,324 @@ function getResponseReadError(
   return null;
 }
 
+function invalidResponseReadError(vercelRequestId: string | null | undefined): ResponseReadError {
+  return {
+    errorType: 'invalid_response',
+    message: withRequestId('The upstream provider returned an invalid response.', vercelRequestId),
+    vercelRequestId: vercelRequestId ?? undefined,
+  };
+}
+
 async function readResponseText(
   response: Response,
-  headers: Headers,
-  vercelRequestId: string | null | undefined,
-  capture: RequestLogCapture | null
-): Promise<{ text: string } | { error: unknown; errorResponse: NextResponse }> {
+  vercelRequestId: string | null | undefined
+): Promise<{ text: string } | { error: unknown; responseReadError: ResponseReadError }> {
   try {
     return { text: await response.text() };
   } catch (error) {
-    const responseReadError = getResponseReadError(error, vercelRequestId);
-    if (!responseReadError) {
-      // Settle the capture so the after() callback awaiting it does not hang
-      // and the request is still logged (without a response body).
-      capture?.setReadError(error);
-      throw error;
-    }
-
     return {
       error,
-      errorResponse: NextResponse.json(
-        {
-          error: responseReadError.message,
-          error_type: responseReadError.errorType,
-          message: responseReadError.message,
-          ...(responseReadError.vercelRequestId && {
-            vercel_request_id: responseReadError.vercelRequestId,
-          }),
-        },
-        { status: 503, headers }
-      ),
+      responseReadError:
+        getResponseReadError(error, vercelRequestId) ?? invalidResponseReadError(vercelRequestId),
     };
   }
+}
+
+function isJsonContentType(contentType: string | null): boolean {
+  const mediaType = contentType?.split(';', 1)[0].trim().toLowerCase();
+  return mediaType === 'application/json';
+}
+
+function isEventStreamContentType(contentType: string | null): boolean {
+  return contentType?.split(';', 1)[0].trim().toLowerCase() === 'text/event-stream';
+}
+
+function isJsonObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function passThroughResponse(
+  response: Response,
+  headers: Headers,
+  capture: RequestLogCapture | null
+): NextResponse {
+  let body = response.body;
+  if (!body) {
+    capture?.setBody('');
+  } else if (capture) {
+    body = createCapturedPassThroughBody(body, capture);
+  }
+  return new NextResponse(body, {
+    status: response.status,
+    statusText: response.statusText,
+    headers,
+  });
+}
+
+function createCapturedPassThroughBody(
+  upstreamBody: ReadableStream<Uint8Array<ArrayBuffer>>,
+  capture: RequestLogCapture
+): ReadableStream<Uint8Array<ArrayBuffer>> {
+  let reader: ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>> | null = null;
+  const decoder = new TextDecoder();
+  const capturedChunks: string[] = [];
+  let finalized = false;
+
+  const flushCapture = () => {
+    if (finalized) return;
+    finalized = true;
+    const trailingText = decoder.decode();
+    if (trailingText) capturedChunks.push(trailingText);
+  };
+  const releaseReader = (activeReader: ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>>) => {
+    try {
+      activeReader.releaseLock();
+    } catch (error) {
+      errorExceptInTest('[rewriteModelResponse] failed to release passthrough reader', error);
+    }
+  };
+  const cancelReader = (reason: unknown) => {
+    const activeReader = reader;
+    reader = null;
+    if (!activeReader) return;
+    let cancellation: Promise<void>;
+    try {
+      cancellation = activeReader.cancel(reason);
+    } catch (error) {
+      errorExceptInTest('[rewriteModelResponse] failed to cancel passthrough stream', error);
+      releaseReader(activeReader);
+      return;
+    }
+    queueMicrotask(() => releaseReader(activeReader));
+    void cancellation.catch(error => {
+      errorExceptInTest('[rewriteModelResponse] failed to cancel passthrough stream', error);
+    });
+  };
+
+  return new ReadableStream<Uint8Array<ArrayBuffer>>({
+    start(controller) {
+      try {
+        reader = upstreamBody.getReader();
+      } catch (error) {
+        flushCapture();
+        capture.setReadError(error);
+        controller.error(error);
+      }
+    },
+    async pull(controller) {
+      const activeReader = reader;
+      if (!activeReader || finalized) return;
+      try {
+        const { done, value } = await activeReader.read();
+        if (finalized) return;
+        if (done) {
+          flushCapture();
+          capture.setBody(capturedChunks.join(''));
+          reader = null;
+          releaseReader(activeReader);
+          controller.close();
+          return;
+        }
+        capturedChunks.push(decoder.decode(value, { stream: true }));
+        controller.enqueue(value);
+      } catch (error) {
+        if (finalized) return;
+        flushCapture();
+        capture.setReadError(error, partialCapturedBody(capturedChunks));
+        reader = null;
+        releaseReader(activeReader);
+        controller.error(error);
+      }
+    },
+    cancel(reason) {
+      flushCapture();
+      capture.setReadError(
+        new Error('response stream was cancelled'),
+        partialCapturedBody(capturedChunks),
+        { client_disconnected: true }
+      );
+      cancelReader(reason);
+    },
+  });
 }
 
 function partialCapturedBody(capturedChunks: string[] | null): string | undefined {
   return capturedChunks && capturedChunks.length > 0 ? capturedChunks.join('') : undefined;
 }
 
-async function rewriteSseStream(
-  reader: ReadableStreamDefaultReader<Uint8Array>,
-  parser: ReturnType<typeof createParser>,
-  controller: ReadableStreamDefaultController<string>,
-  doneReceived: () => boolean,
-  terminalEventReceived: () => boolean,
-  serializeError: (error: ResponseReadError) => string,
-  onFinally: () => void,
-  vercelRequestId: string | null | undefined,
-  capture: RequestLogCapture | null,
-  capturedChunks: string[] | null
-) {
+type TerminalStreamEvent = {
+  eventType: string;
+  isError: boolean;
+};
+
+function createRewrittenSseStream({
+  response,
+  createEventParser,
+  doneReceived,
+  getTerminalEvent,
+  serializeError,
+  onFinally,
+  vercelRequestId,
+  capture,
+  capturedChunks,
+}: {
+  response: Response;
+  createEventParser: (
+    controller: ReadableStreamDefaultController<string>
+  ) => ReturnType<typeof createParser>;
+  doneReceived: () => boolean;
+  getTerminalEvent: () => TerminalStreamEvent | null;
+  serializeError: (error: ResponseReadError) => string;
+  onFinally: () => void;
+  vercelRequestId: string | null | undefined;
+  capture: RequestLogCapture | null;
+  capturedChunks: string[] | null;
+}): ReadableStream<string> {
+  let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
+  let parser: ReturnType<typeof createParser> | null = null;
   const decoder = new TextDecoder();
-  const settleReadError = (error: unknown) =>
-    capture?.setReadError(error, partialCapturedBody(capturedChunks));
-  const settleBody = () => {
+  let decoderFlushed = false;
+  let finalized = false;
+
+  const flushDecoder = () => {
+    if (decoderFlushed) return '';
+    decoderFlushed = true;
+    const trailingText = decoder.decode();
+    if (trailingText) capturedChunks?.push(trailingText);
+    return trailingText;
+  };
+  const settleReadError = (error: unknown, responseReadError: ResponseReadError) => {
+    flushDecoder();
+    capture?.setReadError(error, partialCapturedBody(capturedChunks), {
+      gateway_stream_error: { error_type: responseReadError.errorType },
+    });
+  };
+  const settleBody = (terminalEvent: TerminalStreamEvent | null) => {
+    flushDecoder();
     if (capturedChunks) {
-      capturedChunks.push(decoder.decode());
-      capture?.setBody(capturedChunks.join(''));
+      const text = capturedChunks.join('');
+      if (terminalEvent?.isError) {
+        capture?.setBody(text, {
+          upstream_stream_error: { event_type: terminalEvent.eventType },
+        });
+      } else {
+        capture?.setBody(text);
+      }
     }
   };
-  try {
-    while (true) {
-      const { done, value } = await reader.read();
-      if (done) {
-        // Flush any event left buffered when the stream ends without a
-        // trailing blank line, so its data isn't silently dropped.
-        parser.reset({ consume: true });
-        if (doneReceived()) {
-          controller.enqueue('data: [DONE]\n\n');
-        }
-        controller.close();
-        settleBody();
-        return;
-      }
-      const chunk = decoder.decode(value, { stream: true });
-      capturedChunks?.push(chunk);
-      parser.feed(chunk);
-      if (terminalEventReceived()) {
-        if (doneReceived()) {
-          controller.enqueue('data: [DONE]\n\n');
-        }
-        const cancellation = reader.cancel();
-        controller.close();
-        settleBody();
-        try {
-          await cancellation;
-        } catch (error) {
-          errorExceptInTest(
-            '[rewriteModelResponse] failed to cancel terminal upstream stream',
-            error
-          );
-        }
-        return;
-      }
+
+  const releaseReader = (activeReader: ReadableStreamDefaultReader<Uint8Array>) => {
+    try {
+      activeReader.releaseLock();
+    } catch (error) {
+      errorExceptInTest('[rewriteModelResponse] failed to release upstream stream reader', error);
     }
-  } catch (error) {
-    const responseReadError = getResponseReadError(error, vercelRequestId);
-    if (!responseReadError) {
-      settleReadError(error);
-      throw error;
+  };
+  const finalize = (activeReader?: ReadableStreamDefaultReader<Uint8Array>) => {
+    if (finalized) return;
+    finalized = true;
+    onFinally();
+    if (activeReader) releaseReader(activeReader);
+  };
+  const cancelUpstream = (reason: unknown) => {
+    const activeReader = reader;
+    reader = null;
+    if (!activeReader) {
+      finalize();
+      return;
     }
 
+    let cancellation: Promise<void>;
+    try {
+      cancellation = activeReader.cancel(reason);
+    } catch (error) {
+      errorExceptInTest('[rewriteModelResponse] failed to cancel upstream stream', error);
+      finalize(activeReader);
+      return;
+    }
+
+    finalize();
+    queueMicrotask(() => releaseReader(activeReader));
+    void cancellation.catch(error => {
+      errorExceptInTest('[rewriteModelResponse] failed to cancel upstream stream', error);
+    });
+  };
+  const emitReadError = (controller: ReadableStreamDefaultController<string>, error: unknown) => {
+    const responseReadError =
+      getResponseReadError(error, vercelRequestId) ?? invalidResponseReadError(vercelRequestId);
     errorExceptInTest('[rewriteModelResponse] emitting stream error event', {
       ...responseReadError,
       vercelRequestId: vercelRequestId ?? '<none>',
     });
-    settleReadError(error);
+    settleReadError(error, responseReadError);
     controller.enqueue(serializeError(responseReadError));
     controller.close();
-  } finally {
-    onFinally();
-    reader.releaseLock();
-  }
+    cancelUpstream(error);
+  };
+
+  return new ReadableStream<string>({
+    start(controller) {
+      try {
+        reader = response.body?.getReader() ?? null;
+        if (!reader) {
+          controller.close();
+          capture?.setBody('');
+          finalize();
+          return;
+        }
+        parser = createEventParser(controller);
+      } catch (error) {
+        emitReadError(controller, error);
+      }
+    },
+    async pull(controller) {
+      const activeReader = reader;
+      const activeParser = parser;
+      if (finalized || !activeReader || !activeParser) return;
+
+      try {
+        const { done, value } = await activeReader.read();
+        if (finalized) return;
+        if (done) {
+          const trailingText = flushDecoder();
+          if (trailingText) activeParser.feed(trailingText);
+          // Complete the final SSE record even when upstream omitted its blank line.
+          activeParser.feed('\n\n');
+          if (doneReceived()) {
+            controller.enqueue('data: [DONE]\n\n');
+          }
+          controller.close();
+          settleBody(getTerminalEvent());
+          reader = null;
+          finalize(activeReader);
+          return;
+        }
+
+        const chunk = decoder.decode(value, { stream: true });
+        capturedChunks?.push(chunk);
+        activeParser.feed(chunk);
+        const terminalEvent = getTerminalEvent();
+        if (!terminalEvent) return;
+        if (doneReceived()) {
+          controller.enqueue('data: [DONE]\n\n');
+        }
+        controller.close();
+        settleBody(terminalEvent);
+        cancelUpstream('terminal stream event received');
+      } catch (error) {
+        if (!finalized) emitReadError(controller, error);
+      }
+    },
+    cancel(reason) {
+      flushDecoder();
+      capture?.setReadError(
+        new Error('response stream was cancelled'),
+        partialCapturedBody(capturedChunks),
+        { client_disconnected: true }
+      );
+      cancelUpstream(reason);
+    },
+  });
 }
 
 function rewriteUsage(usage: OpenRouterUsage, removeCost: boolean) {
@@ -363,20 +599,37 @@ export async function rewriteModelResponse_ChatCompletions(
   vercelRequestId: string | null
 ) {
   const headers = getOutputHeaders(response);
+  const contentType = response.headers.get('content-type');
 
-  if (headers.get('content-type')?.includes('application/json')) {
+  if (isJsonContentType(contentType)) {
     // Read the body text once to avoid "Response body object should not be
     // disturbed or locked" errors that occur when `.clone().json()` fails.
-    const textResult = await readResponseText(response, headers, vercelRequestId, capture);
-    if ('errorResponse' in textResult) {
-      capture?.setReadError(textResult.error);
-      return textResult.errorResponse;
+    const textResult = await readResponseText(response, vercelRequestId);
+    if ('responseReadError' in textResult) {
+      capture?.setReadError(textResult.error, undefined, {
+        gateway_stream_error: { error_type: textResult.responseReadError.errorType },
+      });
+      return NextResponse.json(
+        {
+          error: {
+            code: 503,
+            message: textResult.responseReadError.message,
+            type: textResult.responseReadError.errorType,
+            param: null,
+            ...(textResult.responseReadError.vercelRequestId && {
+              vercel_request_id: textResult.responseReadError.vercelRequestId,
+            }),
+          },
+        },
+        { status: 503, headers }
+      );
     }
     capture?.setBody(textResult.text);
     const { text } = textResult;
     let json: OpenAI.ChatCompletion;
     try {
       json = JSON.parse(text) as OpenAI.ChatCompletion;
+      if (!isJsonObject(json)) throw new TypeError('Expected a JSON object');
     } catch {
       // Upstream returned invalid/empty JSON body — pass through as-is
       return new NextResponse(text, {
@@ -397,33 +650,32 @@ export async function rewriteModelResponse_ChatCompletions(
     });
   }
 
+  if (!isEventStreamContentType(contentType)) {
+    return passThroughResponse(response, headers, capture);
+  }
+
   // Accumulate the raw upstream text for request logging while the stream is
   // being processed anyway, so it doesn't have to be processed a second time.
   // Shared with the stream's cancel() callback so a client disconnect still
   // logs the partially received response body.
   const capturedChunks: string[] | null = capture ? [] : null;
-  const stream = new ReadableStream({
-    async start(controller) {
-      const reader = response.body?.getReader();
-      if (!reader) {
-        controller.close();
-        capture?.setBody('');
-        return;
-      }
-
-      let doneReceived = false;
-      let terminalEventReceived = false;
-      let generationId: string | undefined;
-      const progress = createStreamProgressLogger();
-      const parser = createParser({
+  let doneReceived = false;
+  let terminalEvent: TerminalStreamEvent | null = null;
+  let generationId: string | undefined;
+  const progress = createStreamProgressLogger();
+  const stream = createRewrittenSseStream({
+    response,
+    createEventParser(controller) {
+      return createParser({
         onEvent(event: EventSourceMessage) {
-          if (doneReceived || terminalEventReceived) {
+          if (terminalEvent) {
             return;
           }
           progress.eventProcessed();
           if (event.data === '[DONE]') {
             logTerminalStreamEvent('chat_completions', event.data, generationId, vercelRequestId);
             doneReceived = true;
+            terminalEvent = { eventType: event.data, isError: false };
             return;
           }
           const json = JSON.parse(event.data) as ChatCompletionChunk;
@@ -454,51 +706,39 @@ export async function rewriteModelResponse_ChatCompletions(
 
           const eventLine = event.event ? 'event: ' + event.event + '\n' : '';
           controller.enqueue(eventLine + 'data: ' + JSON.stringify(json) + '\n\n');
-          terminalEventReceived = 'error' in json && json.error != null;
-          if (terminalEventReceived) {
+          if ('error' in json && json.error != null) {
+            terminalEvent = { eventType: 'error', isError: true };
             logTerminalStreamEvent('chat_completions', 'error', generationId, vercelRequestId);
           }
         },
         onComment() {
-          if (doneReceived || terminalEventReceived) {
+          if (terminalEvent) {
             return;
           }
           controller.enqueue(': KILO PROCESSING\n\n');
         },
       });
-
-      await rewriteSseStream(
-        reader,
-        parser,
-        controller,
-        () => doneReceived,
-        () => doneReceived || terminalEventReceived,
-        responseReadError =>
-          'data: ' +
-          JSON.stringify({
-            ...(generationId ? { id: generationId } : {}),
-            error: {
-              code: 503,
-              message: responseReadError.message,
-              type: responseReadError.errorType,
-              ...(responseReadError.vercelRequestId && {
-                vercel_request_id: responseReadError.vercelRequestId,
-              }),
-            },
-          }) +
-          '\n\n',
-        progress.stop,
-        vercelRequestId,
-        capture,
-        capturedChunks
-      );
     },
-    cancel() {
-      capture?.setReadError(
-        new Error('response stream was cancelled'),
-        partialCapturedBody(capturedChunks)
-      );
-    },
+    doneReceived: () => doneReceived,
+    getTerminalEvent: () => terminalEvent,
+    serializeError: responseReadError =>
+      'data: ' +
+      JSON.stringify({
+        ...(generationId ? { id: generationId } : {}),
+        error: {
+          code: responseReadError.errorType === 'invalid_response' ? 502 : 503,
+          message: responseReadError.message,
+          type: responseReadError.errorType,
+          ...(responseReadError.vercelRequestId && {
+            vercel_request_id: responseReadError.vercelRequestId,
+          }),
+        },
+      }) +
+      '\n\n',
+    onFinally: progress.stop,
+    vercelRequestId,
+    capture,
+    capturedChunks,
   });
 
   return new NextResponse(stream, {
@@ -545,12 +785,25 @@ export async function rewriteModelResponse_Messages(
   vercelRequestId: string | null
 ) {
   const headers = getOutputHeaders(response);
+  const contentType = response.headers.get('content-type');
 
-  if (headers.get('content-type')?.includes('application/json')) {
-    const textResult = await readResponseText(response, headers, vercelRequestId, capture);
-    if ('errorResponse' in textResult) {
-      capture?.setReadError(textResult.error);
-      return textResult.errorResponse;
+  if (isJsonContentType(contentType)) {
+    const textResult = await readResponseText(response, vercelRequestId);
+    if ('responseReadError' in textResult) {
+      capture?.setReadError(textResult.error, undefined, {
+        gateway_stream_error: { error_type: textResult.responseReadError.errorType },
+      });
+      return NextResponse.json(
+        {
+          type: 'error',
+          error: {
+            type: 'api_error',
+            message: textResult.responseReadError.message,
+            error_type: textResult.responseReadError.errorType,
+          },
+        },
+        { status: 503, headers }
+      );
     }
     capture?.setBody(textResult.text);
     const { text } = textResult;
@@ -559,6 +812,7 @@ export async function rewriteModelResponse_Messages(
       json = JSON.parse(text) as Anthropic.Messages.Message & {
         usage?: MessagesApiUsage;
       };
+      if (!isJsonObject(json)) throw new TypeError('Expected a JSON object');
     } catch {
       // Upstream returned invalid/empty JSON body — pass through as-is
       return new NextResponse(text, {
@@ -577,33 +831,32 @@ export async function rewriteModelResponse_Messages(
     });
   }
 
+  if (!isEventStreamContentType(contentType)) {
+    return passThroughResponse(response, headers, capture);
+  }
+
   // Accumulate the raw upstream text for request logging while the stream is
   // being processed anyway, so it doesn't have to be processed a second time.
   // Shared with the stream's cancel() callback so a client disconnect still
   // logs the partially received response body.
   const capturedChunks: string[] | null = capture ? [] : null;
-  const stream = new ReadableStream({
-    async start(controller) {
-      const reader = response.body?.getReader();
-      if (!reader) {
-        controller.close();
-        capture?.setBody('');
-        return;
-      }
-
-      let doneReceived = false;
-      let terminalEventReceived = false;
-      let generationId: string | undefined;
-      const progress = createStreamProgressLogger();
-      const parser = createParser({
+  let doneReceived = false;
+  let terminalEvent: TerminalStreamEvent | null = null;
+  let generationId: string | undefined;
+  const progress = createStreamProgressLogger();
+  const stream = createRewrittenSseStream({
+    response,
+    createEventParser(controller) {
+      return createParser({
         onEvent(event: EventSourceMessage) {
-          if (doneReceived || terminalEventReceived) {
+          if (terminalEvent) {
             return;
           }
           progress.eventProcessed();
           if (event.data === '[DONE]') {
             logTerminalStreamEvent('messages', event.data, generationId, vercelRequestId);
             doneReceived = true;
+            terminalEvent = { eventType: event.data, isError: false };
             return;
           }
           const json = JSON.parse(event.data) as
@@ -635,53 +888,41 @@ export async function rewriteModelResponse_Messages(
 
           const eventLine = event.event ? 'event: ' + event.event + '\n' : '';
           controller.enqueue(eventLine + 'data: ' + JSON.stringify(json) + '\n\n');
-          terminalEventReceived = json.type === 'message_stop' || json.type === 'error';
-          if (terminalEventReceived) {
+          if (json.type === 'message_stop' || json.type === 'error') {
+            terminalEvent = { eventType: json.type, isError: json.type === 'error' };
             logTerminalStreamEvent('messages', json.type, generationId, vercelRequestId);
           }
         },
         onComment() {
-          if (doneReceived || terminalEventReceived) {
+          if (terminalEvent) {
             return;
           }
           controller.enqueue(': KILO PROCESSING\n\n');
         },
       });
-
-      await rewriteSseStream(
-        reader,
-        parser,
-        controller,
-        () => doneReceived,
-        () => doneReceived || terminalEventReceived,
-        responseReadError =>
-          'event: error\n' +
-          'data: ' +
-          JSON.stringify({
-            ...(generationId ? { id: generationId } : {}),
-            type: 'error',
-            error: {
-              type: 'api_error',
-              message: responseReadError.message,
-              error_type: responseReadError.errorType,
-              ...(responseReadError.vercelRequestId && {
-                vercel_request_id: responseReadError.vercelRequestId,
-              }),
-            },
-          }) +
-          '\n\n',
-        progress.stop,
-        vercelRequestId,
-        capture,
-        capturedChunks
-      );
     },
-    cancel() {
-      capture?.setReadError(
-        new Error('response stream was cancelled'),
-        partialCapturedBody(capturedChunks)
-      );
-    },
+    doneReceived: () => doneReceived,
+    getTerminalEvent: () => terminalEvent,
+    serializeError: responseReadError =>
+      'event: error\n' +
+      'data: ' +
+      JSON.stringify({
+        ...(generationId ? { id: generationId } : {}),
+        type: 'error',
+        error: {
+          type: 'api_error',
+          message: responseReadError.message,
+          error_type: responseReadError.errorType,
+          ...(responseReadError.vercelRequestId && {
+            vercel_request_id: responseReadError.vercelRequestId,
+          }),
+        },
+      }) +
+      '\n\n',
+    onFinally: progress.stop,
+    vercelRequestId,
+    capture,
+    capturedChunks,
   });
 
   return new NextResponse(stream, {
@@ -704,12 +945,25 @@ export async function rewriteModelResponse_Responses(
   vercelRequestId: string | null
 ) {
   const headers = getOutputHeaders(response);
+  const contentType = response.headers.get('content-type');
 
-  if (headers.get('content-type')?.includes('application/json')) {
-    const textResult = await readResponseText(response, headers, vercelRequestId, capture);
-    if ('errorResponse' in textResult) {
-      capture?.setReadError(textResult.error);
-      return textResult.errorResponse;
+  if (isJsonContentType(contentType)) {
+    const textResult = await readResponseText(response, vercelRequestId);
+    if ('responseReadError' in textResult) {
+      capture?.setReadError(textResult.error, undefined, {
+        gateway_stream_error: { error_type: textResult.responseReadError.errorType },
+      });
+      return NextResponse.json(
+        {
+          error: {
+            code: textResult.responseReadError.errorType,
+            message: textResult.responseReadError.message,
+            param: null,
+            type: textResult.responseReadError.errorType,
+          },
+        },
+        { status: 503, headers }
+      );
     }
     capture?.setBody(textResult.text);
     const { text } = textResult;
@@ -718,6 +972,7 @@ export async function rewriteModelResponse_Responses(
       json = JSON.parse(text) as OpenAI.Responses.Response & {
         usage?: OpenRouterUsage | null;
       };
+      if (!isJsonObject(json)) throw new TypeError('Expected a JSON object');
     } catch {
       // Upstream returned invalid/empty JSON body — pass through as-is
       return new NextResponse(text, {
@@ -736,34 +991,33 @@ export async function rewriteModelResponse_Responses(
     });
   }
 
+  if (!isEventStreamContentType(contentType)) {
+    return passThroughResponse(response, headers, capture);
+  }
+
   // Accumulate the raw upstream text for request logging while the stream is
   // being processed anyway, so it doesn't have to be processed a second time.
   // Shared with the stream's cancel() callback so a client disconnect still
   // logs the partially received response body.
   const capturedChunks: string[] | null = capture ? [] : null;
-  const stream = new ReadableStream({
-    async start(controller) {
-      const reader = response.body?.getReader();
-      if (!reader) {
-        controller.close();
-        capture?.setBody('');
-        return;
-      }
-
-      let doneReceived = false;
-      let terminalEventReceived = false;
-      let generationId: string | undefined;
-      let nextSequenceNumber = 0;
-      const progress = createStreamProgressLogger();
-      const parser = createParser({
+  let doneReceived = false;
+  let terminalEvent: TerminalStreamEvent | null = null;
+  let generationId: string | undefined;
+  let nextSequenceNumber = 0;
+  const progress = createStreamProgressLogger();
+  const stream = createRewrittenSseStream({
+    response,
+    createEventParser(controller) {
+      return createParser({
         onEvent(event: EventSourceMessage) {
-          if (doneReceived || terminalEventReceived) {
+          if (terminalEvent) {
             return;
           }
           progress.eventProcessed();
           if (event.data === '[DONE]') {
             logTerminalStreamEvent('responses', event.data, generationId, vercelRequestId);
             doneReceived = true;
+            terminalEvent = { eventType: event.data, isError: false };
             return;
           }
           const json = JSON.parse(event.data) as ResponsesApiEvent;
@@ -784,58 +1038,44 @@ export async function rewriteModelResponse_Responses(
           }
           const eventLine = event.event ? 'event: ' + event.event + '\n' : '';
           controller.enqueue(eventLine + 'data: ' + JSON.stringify(json) + '\n\n');
-          terminalEventReceived =
+          if (
             json.type === 'response.completed' ||
             json.type === 'response.incomplete' ||
             json.type === 'response.failed' ||
-            json.type === 'error';
-          if (terminalEventReceived) {
+            json.type === 'error'
+          ) {
+            terminalEvent = {
+              eventType: json.type,
+              isError: json.type !== 'response.completed',
+            };
             logTerminalStreamEvent('responses', json.type, generationId, vercelRequestId);
           }
         },
         onComment() {
-          if (doneReceived || terminalEventReceived) {
+          if (terminalEvent) {
             return;
           }
           controller.enqueue(': KILO PROCESSING\n\n');
         },
       });
-
-      await rewriteSseStream(
-        reader,
-        parser,
-        controller,
-        () => doneReceived,
-        () => doneReceived || terminalEventReceived,
-        responseReadError =>
-          'event: error\n' +
-          'data: ' +
-          JSON.stringify({
-            ...(generationId ? { id: generationId } : {}),
-            type: 'error',
-            sequence_number: nextSequenceNumber,
-            error: {
-              type: responseReadError.errorType,
-              code: responseReadError.errorType === 'timeout' ? '504' : '503',
-              message: responseReadError.message,
-              ...(responseReadError.vercelRequestId && {
-                vercel_request_id: responseReadError.vercelRequestId,
-              }),
-            },
-          }) +
-          '\n\n',
-        progress.stop,
-        vercelRequestId,
-        capture,
-        capturedChunks
-      );
     },
-    cancel() {
-      capture?.setReadError(
-        new Error('response stream was cancelled'),
-        partialCapturedBody(capturedChunks)
-      );
-    },
+    doneReceived: () => doneReceived,
+    getTerminalEvent: () => terminalEvent,
+    serializeError: responseReadError =>
+      'event: error\n' +
+      'data: ' +
+      JSON.stringify({
+        type: 'error',
+        sequence_number: nextSequenceNumber,
+        code: responseReadError.errorType,
+        message: responseReadError.message,
+        param: null,
+      }) +
+      '\n\n',
+    onFinally: progress.stop,
+    vercelRequestId,
+    capture,
+    capturedChunks,
   });
 
   return new NextResponse(stream, {
@@ -852,7 +1092,7 @@ export async function rewriteModelResponse(
   kind: GatewayRequest['kind'],
   logging: RequestLoggingParams
 ): Promise<NextResponse> {
-  const capture = await createRequestLogCapture(response, model, providerId, logging);
+  const capture = await createRequestLogCapture(response.status, model, providerId, logging);
   const requiresCostRemoval =
     (providerId === 'openrouter' || providerId === 'vercel') &&
     (isKiloExclusiveFreeModel(model) || getCustomPricing(model) !== undefined);

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -182,7 +182,9 @@ export async function logUpstreamRequestFailure(
   logging: RequestLoggingParams
 ): Promise<void> {
   const capture = await createRequestLogCapture(status, model, providerId, logging);
-  capture?.setError({ upstream_request_error: 'fetch_failed' });
+  capture?.setError(
+    status === 499 ? { client_disconnected: true } : { upstream_request_error: 'fetch_failed' }
+  );
 }
 
 type ResponseReadError = {
@@ -193,6 +195,7 @@ type ResponseReadError = {
 };
 
 const STREAM_PROGRESS_LOG_INTERVAL_MS = 30_000;
+const STREAM_CONSUMER_IDLE_TIMEOUT_MS = 15 * 60 * 1000;
 
 function createStreamProgressLogger() {
   let eventCount = 0;
@@ -267,6 +270,14 @@ function invalidResponseReadError(vercelRequestId: string | null | undefined): R
   };
 }
 
+function legacyGatewayErrorFields(error: ResponseReadError) {
+  return {
+    error_type: error.errorType,
+    message: error.message,
+    ...(error.vercelRequestId && { vercel_request_id: error.vercelRequestId }),
+  };
+}
+
 async function readResponseText(
   response: Response,
   vercelRequestId: string | null | undefined
@@ -291,6 +302,19 @@ function isEventStreamContentType(contentType: string | null): boolean {
   return contentType?.split(';', 1)[0].trim().toLowerCase() === 'text/event-stream';
 }
 
+function shouldRewriteAsEventStream(response: Response, contentType: string | null): boolean {
+  if (isEventStreamContentType(contentType)) return true;
+  if (!response.ok) return false;
+  logExceptInTest(
+    '[rewriteModelResponse] rewriting successful response with unexpected content type',
+    {
+      status: response.status,
+      contentType: contentType ?? '<none>',
+    }
+  );
+  return true;
+}
+
 function isJsonObject(value: unknown): value is Record<string, unknown> {
   return typeof value === 'object' && value !== null && !Array.isArray(value);
 }
@@ -298,13 +322,14 @@ function isJsonObject(value: unknown): value is Record<string, unknown> {
 function passThroughResponse(
   response: Response,
   headers: Headers,
-  capture: RequestLogCapture | null
+  capture: RequestLogCapture | null,
+  signal?: AbortSignal
 ): NextResponse {
   let body = response.body;
   if (!body) {
     capture?.setBody('');
   } else if (capture) {
-    body = createCapturedPassThroughBody(body, capture);
+    body = createCapturedPassThroughBody(body, capture, signal);
   }
   return new NextResponse(body, {
     status: response.status,
@@ -315,16 +340,21 @@ function passThroughResponse(
 
 function createCapturedPassThroughBody(
   upstreamBody: ReadableStream<Uint8Array<ArrayBuffer>>,
-  capture: RequestLogCapture
+  capture: RequestLogCapture,
+  signal?: AbortSignal
 ): ReadableStream<Uint8Array<ArrayBuffer>> {
   let reader: ReadableStreamDefaultReader<Uint8Array<ArrayBuffer>> | null = null;
   const decoder = new TextDecoder();
   const capturedChunks: string[] = [];
   let finalized = false;
+  let streamController: ReadableStreamDefaultController<Uint8Array<ArrayBuffer>> | null = null;
+  let consumerIdleTimeout: ReturnType<typeof setTimeout> | null = null;
 
   const flushCapture = () => {
     if (finalized) return;
     finalized = true;
+    if (consumerIdleTimeout) clearTimeout(consumerIdleTimeout);
+    signal?.removeEventListener('abort', handleRequestAbort);
     const trailingText = decoder.decode();
     if (trailingText) capturedChunks.push(trailingText);
   };
@@ -352,11 +382,45 @@ function createCapturedPassThroughBody(
       errorExceptInTest('[rewriteModelResponse] failed to cancel passthrough stream', error);
     });
   };
+  const clearConsumerIdleTimeout = () => {
+    if (consumerIdleTimeout) clearTimeout(consumerIdleTimeout);
+    consumerIdleTimeout = null;
+  };
+  const armConsumerIdleTimeout = () => {
+    clearConsumerIdleTimeout();
+    if (finalized) return;
+    consumerIdleTimeout = setTimeout(() => {
+      if (finalized) return;
+      const timeoutError = new Error('response consumer remained idle');
+      flushCapture();
+      capture.setReadError(timeoutError, partialCapturedBody(capturedChunks), {
+        client_stalled: true,
+      });
+      streamController?.error(timeoutError);
+      cancelReader(timeoutError);
+    }, STREAM_CONSUMER_IDLE_TIMEOUT_MS);
+  };
+  function handleRequestAbort() {
+    if (finalized) return;
+    const abortError = new Error('request was aborted by the client');
+    flushCapture();
+    capture.setReadError(abortError, partialCapturedBody(capturedChunks), {
+      client_disconnected: true,
+    });
+    streamController?.error(signal?.reason ?? abortError);
+    cancelReader(signal?.reason);
+  }
 
   return new ReadableStream<Uint8Array<ArrayBuffer>>({
     start(controller) {
+      streamController = controller;
       try {
         reader = upstreamBody.getReader();
+        if (signal?.aborted) {
+          handleRequestAbort();
+          return;
+        }
+        signal?.addEventListener('abort', handleRequestAbort, { once: true });
       } catch (error) {
         flushCapture();
         capture.setReadError(error);
@@ -366,6 +430,7 @@ function createCapturedPassThroughBody(
     async pull(controller) {
       const activeReader = reader;
       if (!activeReader || finalized) return;
+      clearConsumerIdleTimeout();
       try {
         const { done, value } = await activeReader.read();
         if (finalized) return;
@@ -379,6 +444,7 @@ function createCapturedPassThroughBody(
         }
         capturedChunks.push(decoder.decode(value, { stream: true }));
         controller.enqueue(value);
+        armConsumerIdleTimeout();
       } catch (error) {
         if (finalized) return;
         flushCapture();
@@ -419,6 +485,7 @@ function createRewrittenSseStream({
   vercelRequestId,
   capture,
   capturedChunks,
+  signal,
 }: {
   response: Response;
   createEventParser: (
@@ -431,12 +498,15 @@ function createRewrittenSseStream({
   vercelRequestId: string | null | undefined;
   capture: RequestLogCapture | null;
   capturedChunks: string[] | null;
+  signal?: AbortSignal;
 }): ReadableStream<string> {
   let reader: ReadableStreamDefaultReader<Uint8Array> | null = null;
   let parser: ReturnType<typeof createParser> | null = null;
   const decoder = new TextDecoder();
   let decoderFlushed = false;
   let finalized = false;
+  let streamController: ReadableStreamDefaultController<string> | null = null;
+  let consumerIdleTimeout: ReturnType<typeof setTimeout> | null = null;
 
   const flushDecoder = () => {
     if (decoderFlushed) return '';
@@ -475,6 +545,8 @@ function createRewrittenSseStream({
   const finalize = (activeReader?: ReadableStreamDefaultReader<Uint8Array>) => {
     if (finalized) return;
     finalized = true;
+    if (consumerIdleTimeout) clearTimeout(consumerIdleTimeout);
+    signal?.removeEventListener('abort', handleRequestAbort);
     onFinally();
     if (activeReader) releaseReader(activeReader);
   };
@@ -513,9 +585,39 @@ function createRewrittenSseStream({
     controller.close();
     cancelUpstream(error);
   };
+  const clearConsumerIdleTimeout = () => {
+    if (consumerIdleTimeout) clearTimeout(consumerIdleTimeout);
+    consumerIdleTimeout = null;
+  };
+  const armConsumerIdleTimeout = () => {
+    clearConsumerIdleTimeout();
+    if (finalized) return;
+    consumerIdleTimeout = setTimeout(() => {
+      if (finalized) return;
+      const timeoutError = new Error('response consumer remained idle');
+      flushDecoder();
+      capture?.setReadError(timeoutError, partialCapturedBody(capturedChunks), {
+        client_stalled: true,
+      });
+      streamController?.error(timeoutError);
+      cancelUpstream(timeoutError);
+    }, STREAM_CONSUMER_IDLE_TIMEOUT_MS);
+  };
+  function handleRequestAbort() {
+    if (finalized) return;
+    flushDecoder();
+    capture?.setReadError(
+      new Error('request was aborted by the client'),
+      partialCapturedBody(capturedChunks),
+      { client_disconnected: true }
+    );
+    streamController?.error(signal?.reason ?? new Error('request was aborted by the client'));
+    cancelUpstream(signal?.reason);
+  }
 
   return new ReadableStream<string>({
     start(controller) {
+      streamController = controller;
       try {
         reader = response.body?.getReader() ?? null;
         if (!reader) {
@@ -525,6 +627,11 @@ function createRewrittenSseStream({
           return;
         }
         parser = createEventParser(controller);
+        if (signal?.aborted) {
+          handleRequestAbort();
+          return;
+        }
+        signal?.addEventListener('abort', handleRequestAbort, { once: true });
       } catch (error) {
         emitReadError(controller, error);
       }
@@ -533,6 +640,7 @@ function createRewrittenSseStream({
       const activeReader = reader;
       const activeParser = parser;
       if (finalized || !activeReader || !activeParser) return;
+      clearConsumerIdleTimeout();
 
       try {
         const { done, value } = await activeReader.read();
@@ -556,7 +664,10 @@ function createRewrittenSseStream({
         capturedChunks?.push(chunk);
         activeParser.feed(chunk);
         const terminalEvent = getTerminalEvent();
-        if (!terminalEvent) return;
+        if (!terminalEvent) {
+          armConsumerIdleTimeout();
+          return;
+        }
         if (doneReceived()) {
           controller.enqueue('data: [DONE]\n\n');
         }
@@ -596,7 +707,8 @@ export async function rewriteModelResponse_ChatCompletions(
   response: Response,
   removeCost: boolean,
   capture: RequestLogCapture | null,
-  vercelRequestId: string | null
+  vercelRequestId: string | null,
+  signal?: AbortSignal
 ) {
   const headers = getOutputHeaders(response);
   const contentType = response.headers.get('content-type');
@@ -611,6 +723,7 @@ export async function rewriteModelResponse_ChatCompletions(
       });
       return NextResponse.json(
         {
+          ...legacyGatewayErrorFields(textResult.responseReadError),
           error: {
             code: 503,
             message: textResult.responseReadError.message,
@@ -650,8 +763,8 @@ export async function rewriteModelResponse_ChatCompletions(
     });
   }
 
-  if (!isEventStreamContentType(contentType)) {
-    return passThroughResponse(response, headers, capture);
+  if (!shouldRewriteAsEventStream(response, contentType)) {
+    return passThroughResponse(response, headers, capture, signal);
   }
 
   // Accumulate the raw upstream text for request logging while the stream is
@@ -725,6 +838,7 @@ export async function rewriteModelResponse_ChatCompletions(
       'data: ' +
       JSON.stringify({
         ...(generationId ? { id: generationId } : {}),
+        ...legacyGatewayErrorFields(responseReadError),
         error: {
           code: responseReadError.errorType === 'invalid_response' ? 502 : 503,
           message: responseReadError.message,
@@ -739,6 +853,7 @@ export async function rewriteModelResponse_ChatCompletions(
     vercelRequestId,
     capture,
     capturedChunks,
+    signal,
   });
 
   return new NextResponse(stream, {
@@ -782,7 +897,8 @@ export async function rewriteModelResponse_Messages(
   response: Response,
   removeCost: boolean,
   capture: RequestLogCapture | null,
-  vercelRequestId: string | null
+  vercelRequestId: string | null,
+  signal?: AbortSignal
 ) {
   const headers = getOutputHeaders(response);
   const contentType = response.headers.get('content-type');
@@ -795,6 +911,7 @@ export async function rewriteModelResponse_Messages(
       });
       return NextResponse.json(
         {
+          ...legacyGatewayErrorFields(textResult.responseReadError),
           type: 'error',
           error: {
             type: 'api_error',
@@ -831,8 +948,8 @@ export async function rewriteModelResponse_Messages(
     });
   }
 
-  if (!isEventStreamContentType(contentType)) {
-    return passThroughResponse(response, headers, capture);
+  if (!shouldRewriteAsEventStream(response, contentType)) {
+    return passThroughResponse(response, headers, capture, signal);
   }
 
   // Accumulate the raw upstream text for request logging while the stream is
@@ -908,6 +1025,7 @@ export async function rewriteModelResponse_Messages(
       'data: ' +
       JSON.stringify({
         ...(generationId ? { id: generationId } : {}),
+        ...legacyGatewayErrorFields(responseReadError),
         type: 'error',
         error: {
           type: 'api_error',
@@ -923,6 +1041,7 @@ export async function rewriteModelResponse_Messages(
     vercelRequestId,
     capture,
     capturedChunks,
+    signal,
   });
 
   return new NextResponse(stream, {
@@ -942,7 +1061,8 @@ export async function rewriteModelResponse_Responses(
   response: Response,
   removeCost: boolean,
   capture: RequestLogCapture | null,
-  vercelRequestId: string | null
+  vercelRequestId: string | null,
+  signal?: AbortSignal
 ) {
   const headers = getOutputHeaders(response);
   const contentType = response.headers.get('content-type');
@@ -955,6 +1075,7 @@ export async function rewriteModelResponse_Responses(
       });
       return NextResponse.json(
         {
+          ...legacyGatewayErrorFields(textResult.responseReadError),
           error: {
             code: textResult.responseReadError.errorType,
             message: textResult.responseReadError.message,
@@ -991,8 +1112,8 @@ export async function rewriteModelResponse_Responses(
     });
   }
 
-  if (!isEventStreamContentType(contentType)) {
-    return passThroughResponse(response, headers, capture);
+  if (!shouldRewriteAsEventStream(response, contentType)) {
+    return passThroughResponse(response, headers, capture, signal);
   }
 
   // Accumulate the raw upstream text for request logging while the stream is
@@ -1067,8 +1188,8 @@ export async function rewriteModelResponse_Responses(
       JSON.stringify({
         type: 'error',
         sequence_number: nextSequenceNumber,
+        ...legacyGatewayErrorFields(responseReadError),
         code: responseReadError.errorType,
-        message: responseReadError.message,
         param: null,
       }) +
       '\n\n',
@@ -1076,6 +1197,7 @@ export async function rewriteModelResponse_Responses(
     vercelRequestId,
     capture,
     capturedChunks,
+    signal,
   });
 
   return new NextResponse(stream, {
@@ -1090,7 +1212,8 @@ export async function rewriteModelResponse(
   model: string,
   providerId: ProviderId,
   kind: GatewayRequest['kind'],
-  logging: RequestLoggingParams
+  logging: RequestLoggingParams,
+  signal?: AbortSignal
 ): Promise<NextResponse> {
   const capture = await createRequestLogCapture(response.status, model, providerId, logging);
   const requiresCostRemoval =
@@ -1104,14 +1227,27 @@ export async function rewriteModelResponse(
       response,
       requiresCostRemoval,
       capture,
-      vercelRequestId
+      vercelRequestId,
+      signal
     );
   }
   if (kind === 'responses') {
-    return rewriteModelResponse_Responses(response, requiresCostRemoval, capture, vercelRequestId);
+    return rewriteModelResponse_Responses(
+      response,
+      requiresCostRemoval,
+      capture,
+      vercelRequestId,
+      signal
+    );
   }
   if (kind === 'messages') {
-    return rewriteModelResponse_Messages(response, requiresCostRemoval, capture, vercelRequestId);
+    return rewriteModelResponse_Messages(
+      response,
+      requiresCostRemoval,
+      capture,
+      vercelRequestId,
+      signal
+    );
   }
 
   const error = new Error(`implementation error: unrecognized API kind ${kind}`);


### PR DESCRIPTION
## Summary

- make rewritten SSE and captured non-SSE bodies pull-driven so downstream backpressure controls upstream reads
- propagate downstream cancellation to upstream readers, release locks/timers without waiting for hanging cancellation promises, and guard cancellation races
- flush decoder and unterminated SSE records at EOF, convert malformed or locked streams into protocol-compatible errors, and preserve non-SSE bodies byte-for-byte
- keep `api_request_log.response` strictly raw upstream content while recording terminal upstream errors, gateway-generated stream failures, fetch failures, and client disconnects in structured `error` metadata
- avoid tool-call validation on partial failed bodies and make unrewritten-response capture non-blocking
- emit standard OpenAI Responses error events and align Chat/Responses usage accounting with rewritten error classification
- log upstream fetch failures and converted non-BYOK 402 responses, and surface dynamic request-logging opt-in refresh failures

## Request log semantics

Gateway-generated client error events are intentionally not appended to `api_request_log.response`. The column contains only upstream response bytes. Generated and terminal failures are queryable through `api_request_log.error`, so HTTP 200 streams with terminal error events are included by the existing errors-only filter.

## Verification

- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `NODE_ENV=test pnpm --filter web exec jest --runTestsByPath src/lib/rewriteModelResponse.test.ts src/lib/ai-gateway/processUsage.test.ts src/lib/ai-gateway/processUsage.responses.test.ts src/lib/ai-gateway/request-logging-opt-ins.test.ts "src/app/api/openrouter/[...path]/route.test.ts" --runInBand`
- 5 suites passed, 183 tests passed
- independent implementation review: no findings