### PR TITLE
feat(security-agent): warn about disabled Dependabot alerts

### DIFF
--- a/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
+++ b/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
@@ -20,12 +20,14 @@ export type RepositoryMultiSelectProps<TId extends RepositoryId = number> = {
   repositories: Repository<TId>[];
   selectedIds: TId[];
   onSelectionChange: (selectedIds: TId[]) => void;
+  renderRepositoryAccessory?: (repository: Repository<TId>) => React.ReactNode;
 };
 
 export function RepositoryMultiSelect<TId extends RepositoryId = number>({
   repositories,
   selectedIds,
   onSelectionChange,
+  renderRepositoryAccessory,
 }: RepositoryMultiSelectProps<TId>) {
   const [searchQuery, setSearchQuery] = useState('');
 
@@ -116,7 +118,7 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
                   />
                   <label
                     htmlFor={`repo-${repo.id}`}
-                    className="flex flex-1 cursor-pointer items-center gap-2 text-sm"
+                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-sm"
                   >
                     {repo.private ? (
                       <Lock className="text-primary h-3.5 w-3.5 shrink-0" />
@@ -124,6 +126,7 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
                       <Unlock className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
                     )}
                     <span className="truncate font-mono">{repo.full_name}</span>
+                    {renderRepositoryAccessory?.(repo)}
                   </label>
                 </div>
               );

--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -14,6 +14,7 @@ import type { SecurityFinding } from '@kilocode/db/schema';
 import type { SecurityRemediationAdmissionRejectionReason } from '@kilocode/worker-utils/security-remediation-policy';
 import { getSecurityCommandFailureMessage } from '@kilocode/app-shared/security-agent';
 import type { SecurityAgentUiInteraction } from '@/lib/security-agent/core/schemas';
+import type { DependabotAlertsAvailability } from '@/lib/security-agent/core/types';
 import { isGitHubIntegrationError } from '@/lib/security-agent/core/error-display';
 import type { DismissReason } from './DismissFindingDialog';
 import { getRemediationUnavailableCopy } from './remediation-unavailable-copy';
@@ -81,14 +82,14 @@ type SecurityAgentContextValue = {
     fullName: string;
     name: string;
     private: boolean;
-    dependabotAlerts: 'enabled' | 'disabled' | 'unknown';
+    dependabotAlerts: DependabotAlertsAvailability;
   }>;
   filteredRepositories: Array<{
     id: number;
     fullName: string;
     name: string;
     private: boolean;
-    dependabotAlerts: 'enabled' | 'disabled' | 'unknown';
+    dependabotAlerts: DependabotAlertsAvailability;
   }>;
 
   // Mutation handlers
@@ -180,6 +181,7 @@ function getOptionalStringField(source: unknown, key: string): string | undefine
 }
 
 const COMMAND_POLL_INTERVAL_MS = 3000;
+const REPOSITORY_AVAILABILITY_STALE_TIME_MS = 30 * 60_000;
 const EMPTY_REPOSITORIES: SecurityAgentContextValue['allRepositories'] = [];
 const EMPTY_REPOSITORY_IDS: number[] = [];
 const EMPTY_ORPHANED_REPOSITORIES: SecurityAgentContextValue['orphanedRepositories'] = [];
@@ -629,8 +631,13 @@ function useSecurityAgentProviderValue(
   // Repositories query
   const { data: reposData } = useQuery(
     isOrg
-      ? trpc.organizations.securityAgent.getRepositories.queryOptions({ organizationId })
-      : trpc.securityAgent.getRepositories.queryOptions()
+      ? trpc.organizations.securityAgent.getRepositories.queryOptions(
+          { organizationId },
+          { staleTime: REPOSITORY_AVAILABILITY_STALE_TIME_MS }
+        )
+      : trpc.securityAgent.getRepositories.queryOptions(undefined, {
+          staleTime: REPOSITORY_AVAILABILITY_STALE_TIME_MS,
+        })
   );
 
   // Orphaned repositories query

--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -181,7 +181,6 @@ function getOptionalStringField(source: unknown, key: string): string | undefine
 }
 
 const COMMAND_POLL_INTERVAL_MS = 3000;
-const REPOSITORY_AVAILABILITY_STALE_TIME_MS = 30 * 60_000;
 const EMPTY_REPOSITORIES: SecurityAgentContextValue['allRepositories'] = [];
 const EMPTY_REPOSITORY_IDS: number[] = [];
 const EMPTY_ORPHANED_REPOSITORIES: SecurityAgentContextValue['orphanedRepositories'] = [];
@@ -631,13 +630,8 @@ function useSecurityAgentProviderValue(
   // Repositories query
   const { data: reposData } = useQuery(
     isOrg
-      ? trpc.organizations.securityAgent.getRepositories.queryOptions(
-          { organizationId },
-          { staleTime: REPOSITORY_AVAILABILITY_STALE_TIME_MS }
-        )
-      : trpc.securityAgent.getRepositories.queryOptions(undefined, {
-          staleTime: REPOSITORY_AVAILABILITY_STALE_TIME_MS,
-        })
+      ? trpc.organizations.securityAgent.getRepositories.queryOptions({ organizationId })
+      : trpc.securityAgent.getRepositories.queryOptions()
   );
 
   // Orphaned repositories query

--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -76,8 +76,20 @@ type SecurityAgentContextValue = {
   refetchConfig: () => Promise<unknown>;
 
   // Repositories
-  allRepositories: Array<{ id: number; fullName: string; name: string; private: boolean }>;
-  filteredRepositories: Array<{ id: number; fullName: string; name: string; private: boolean }>;
+  allRepositories: Array<{
+    id: number;
+    fullName: string;
+    name: string;
+    private: boolean;
+    dependabotAlerts: 'enabled' | 'disabled' | 'unknown';
+  }>;
+  filteredRepositories: Array<{
+    id: number;
+    fullName: string;
+    name: string;
+    private: boolean;
+    dependabotAlerts: 'enabled' | 'disabled' | 'unknown';
+  }>;
 
   // Mutation handlers
   trackUiInteraction: (interaction: SecurityAgentUiInteraction) => void;

--- a/apps/web/src/components/security-agent/SecurityConfigSections.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigSections.tsx
@@ -14,6 +14,8 @@ import {
 } from 'lucide-react';
 import { RepositoryMultiSelect } from '@/components/code-reviews/RepositoryMultiSelect';
 import { ModelCombobox } from '@/components/shared/ModelCombobox';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
@@ -334,6 +336,18 @@ export function RepositorySection({
   repositories: SecurityRepository[];
   isLoading?: boolean;
 }) {
+  const dependabotAlertsByRepositoryId = new Map(
+    repositories.map(repository => [repository.id, repository.dependabotAlerts])
+  );
+  const disabledRepositories = repositories.filter(
+    repository => repository.dependabotAlerts === 'disabled'
+  );
+  const selectedRepositoryIds = new Set(state.selectedRepositoryIds);
+  const selectedDisabledRepositories =
+    state.repositorySelectionMode === 'all'
+      ? disabledRepositories
+      : disabledRepositories.filter(repository => selectedRepositoryIds.has(repository.id));
+
   return (
     <Card>
       <SectionHeader
@@ -375,6 +389,24 @@ export function RepositorySection({
                 </Label>
               </div>
             </RadioGroup>
+            {selectedDisabledRepositories.length > 0 && (
+              <Alert variant="warning">
+                <AlertTriangle aria-hidden="true" />
+                <AlertTitle>
+                  Dependabot alerts disabled for {selectedDisabledRepositories.length}{' '}
+                  {selectedDisabledRepositories.length === 1 ? 'repository' : 'repositories'}
+                </AlertTitle>
+                <AlertDescription>
+                  <p>
+                    Security Agent cannot import findings from{' '}
+                    {selectedDisabledRepositories.length === 1
+                      ? selectedDisabledRepositories[0]?.fullName
+                      : 'these repositories'}{' '}
+                    until Dependabot alerts are enabled in GitHub repository settings.
+                  </p>
+                </AlertDescription>
+              </Alert>
+            )}
             {state.repositorySelectionMode === 'selected' && (
               <div className="space-y-2">
                 <Label>Repositories</Label>
@@ -384,6 +416,20 @@ export function RepositorySection({
                   onSelectionChange={selectedRepositoryIds =>
                     setState(current => ({ ...current, selectedRepositoryIds }))
                   }
+                  renderRepositoryAccessory={repository => {
+                    if (dependabotAlertsByRepositoryId.get(repository.id) !== 'disabled') {
+                      return null;
+                    }
+
+                    return (
+                      <Badge
+                        variant="outline"
+                        className="border-status-warning-border bg-status-warning-surface text-status-warning ml-auto shrink-0"
+                      >
+                        Dependabot alerts off
+                      </Badge>
+                    );
+                  }}
                 />
               </div>
             )}

--- a/apps/web/src/components/security-agent/SecurityConfigSections.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigSections.tsx
@@ -347,6 +347,9 @@ export function RepositorySection({
     state.repositorySelectionMode === 'all'
       ? disabledRepositories
       : disabledRepositories.filter(repository => selectedRepositoryIds.has(repository.id));
+  const displayedDisabledRepositories = selectedDisabledRepositories.slice(0, 5);
+  const additionalDisabledRepositoryCount =
+    selectedDisabledRepositories.length - displayedDisabledRepositories.length;
 
   return (
     <Card>
@@ -399,9 +402,12 @@ export function RepositorySection({
                 <AlertDescription>
                   <p>
                     Security Agent cannot import findings from{' '}
-                    {selectedDisabledRepositories.length === 1
-                      ? selectedDisabledRepositories[0]?.fullName
-                      : 'these repositories'}{' '}
+                    {displayedDisabledRepositories
+                      .map(repository => repository.fullName)
+                      .join(', ')}
+                    {additionalDisabledRepositoryCount > 0
+                      ? `, and ${additionalDisabledRepositoryCount} more`
+                      : ''}{' '}
                     until Dependabot alerts are enabled in GitHub repository settings.
                   </p>
                 </AlertDescription>

--- a/apps/web/src/components/security-agent/security-config-types.ts
+++ b/apps/web/src/components/security-agent/security-config-types.ts
@@ -14,11 +14,14 @@ export type AutoRemediationMinSeverity = 'critical' | 'high' | 'medium' | 'all';
 export type NotificationMinSeverity = 'critical' | 'high' | 'medium' | 'low';
 export type RepositorySelectionMode = 'all' | 'selected';
 
+export type DependabotAlertsAvailability = 'enabled' | 'disabled' | 'unknown';
+
 export type SecurityRepository = {
   id: number;
   fullName: string;
   name: string;
   private: boolean;
+  dependabotAlerts: DependabotAlertsAvailability;
 };
 
 export type SecurityConfigFormState = {

--- a/apps/web/src/components/security-agent/security-config-types.ts
+++ b/apps/web/src/components/security-agent/security-config-types.ts
@@ -1,4 +1,5 @@
 import type { Repository } from '@/components/code-reviews/RepositoryMultiSelect';
+import type { DependabotAlertsAvailability } from '@/lib/security-agent/core/types';
 
 export type SlaConfig = {
   critical: number;
@@ -13,8 +14,6 @@ export type AutoAnalysisMinSeverity = 'critical' | 'high' | 'medium' | 'all';
 export type AutoRemediationMinSeverity = 'critical' | 'high' | 'medium' | 'all';
 export type NotificationMinSeverity = 'critical' | 'high' | 'medium' | 'low';
 export type RepositorySelectionMode = 'all' | 'selected';
-
-export type DependabotAlertsAvailability = 'enabled' | 'disabled' | 'unknown';
 
 export type SecurityRepository = {
   id: number;

--- a/apps/web/src/lib/security-agent/core/types.ts
+++ b/apps/web/src/lib/security-agent/core/types.ts
@@ -46,6 +46,7 @@ export type SecurityFindingAnalysisStatus =
   (typeof SecurityFindingAnalysisStatus)[keyof typeof SecurityFindingAnalysisStatus];
 
 export type AnalysisMode = 'auto' | 'shallow' | 'deep';
+export type DependabotAlertsAvailability = 'enabled' | 'disabled' | 'unknown';
 
 export type AutoAnalysisMinSeverity = 'critical' | 'high' | 'medium' | 'all';
 export type AutoRemediationMinSeverity = 'critical' | 'high' | 'medium' | 'all';

--- a/apps/web/src/lib/security-agent/github/dependabot-api.test.ts
+++ b/apps/web/src/lib/security-agent/github/dependabot-api.test.ts
@@ -97,12 +97,30 @@ describe('dependabot-api', () => {
     });
   });
 
+  it('reuses a recent repository result without another GitHub request', async () => {
+    const { checkDependabotAlertsAvailability } = await import('./dependabot-api');
+    mockListAlertsForRepo.mockResolvedValue({ data: [] });
+    const repositories = [{ id: 1, fullName: 'cache-test/widgets' }];
+
+    await expect(
+      checkDependabotAlertsAvailability('cache-installation', 'standard', repositories)
+    ).resolves.toEqual([{ id: 1, status: 'enabled' }]);
+    await expect(
+      checkDependabotAlertsAvailability('cache-installation', 'standard', repositories)
+    ).resolves.toEqual([{ id: 1, status: 'enabled' }]);
+
+    expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledTimes(1);
+    expect(mockListAlertsForRepo).toHaveBeenCalledTimes(1);
+  });
+
   it('keeps every repository unknown when GitHub authentication fails', async () => {
     const { checkDependabotAlertsAvailability } = await import('./dependabot-api');
     mockGenerateGitHubInstallationToken.mockRejectedValueOnce(new Error('auth unavailable'));
 
     await expect(
-      checkDependabotAlertsAvailability('inst-1', 'standard', [{ id: 1, fullName: 'acme/widgets' }])
+      checkDependabotAlertsAvailability('auth-failure-installation', 'standard', [
+        { id: 1, fullName: 'auth-failure/widgets' },
+      ])
     ).resolves.toEqual([{ id: 1, status: 'unknown' }]);
 
     expect(mockListAlertsForRepo).not.toHaveBeenCalled();

--- a/apps/web/src/lib/security-agent/github/dependabot-api.test.ts
+++ b/apps/web/src/lib/security-agent/github/dependabot-api.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 
 const mockPaginate = jest.fn() as jest.MockedFunction<(...args: unknown[]) => Promise<unknown[]>>;
+const mockListAlertsForRepo = jest.fn() as jest.MockedFunction<
+  (...args: unknown[]) => Promise<unknown>
+>;
+const mockGenerateGitHubInstallationToken = jest.fn(async () => ({ token: 'token' }));
 const mockWarnExceptInTest = jest.fn();
 const mockErrorExceptInTest = jest.fn();
 const mockSentryLog = jest.fn();
@@ -11,14 +15,14 @@ jest.mock('@octokit/rest', () => ({
     paginate: mockPaginate,
     rest: {
       dependabot: {
-        listAlertsForRepo: jest.fn(),
+        listAlertsForRepo: mockListAlertsForRepo,
       },
     },
   })),
 }));
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
-  generateGitHubInstallationToken: jest.fn(async () => ({ token: 'token' })),
+  generateGitHubInstallationToken: mockGenerateGitHubInstallationToken,
 }));
 
 jest.mock('@/lib/utils.server', () => ({
@@ -62,5 +66,45 @@ describe('dependabot-api', () => {
       installationId: 'inst-1',
     });
     expect(mockSentryLog).toHaveBeenCalledTimes(1);
+  });
+
+  it('reports enabled only when the Dependabot alerts endpoint succeeds', async () => {
+    const { checkDependabotAlertsAvailability } = await import('./dependabot-api');
+    mockListAlertsForRepo.mockResolvedValueOnce({ data: [] });
+    mockListAlertsForRepo.mockRejectedValueOnce({
+      status: 422,
+      message: 'Dependabot alerts are disabled for this repository',
+    });
+    mockListAlertsForRepo.mockRejectedValueOnce({ status: 403, message: 'Forbidden' });
+
+    await expect(
+      checkDependabotAlertsAvailability('inst-1', 'standard', [
+        { id: 1, fullName: 'acme/enabled' },
+        { id: 2, fullName: 'acme/disabled' },
+        { id: 3, fullName: 'acme/unknown' },
+      ])
+    ).resolves.toEqual([
+      { id: 1, status: 'enabled' },
+      { id: 2, status: 'disabled' },
+      { id: 3, status: 'unknown' },
+    ]);
+
+    expect(mockListAlertsForRepo).toHaveBeenCalledWith({
+      owner: 'acme',
+      repo: 'enabled',
+      state: 'open',
+      per_page: 1,
+    });
+  });
+
+  it('keeps every repository unknown when GitHub authentication fails', async () => {
+    const { checkDependabotAlertsAvailability } = await import('./dependabot-api');
+    mockGenerateGitHubInstallationToken.mockRejectedValueOnce(new Error('auth unavailable'));
+
+    await expect(
+      checkDependabotAlertsAvailability('inst-1', 'standard', [{ id: 1, fullName: 'acme/widgets' }])
+    ).resolves.toEqual([{ id: 1, status: 'unknown' }]);
+
+    expect(mockListAlertsForRepo).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/security-agent/github/dependabot-api.test.ts
+++ b/apps/web/src/lib/security-agent/github/dependabot-api.test.ts
@@ -125,4 +125,19 @@ describe('dependabot-api', () => {
 
     expect(mockListAlertsForRepo).not.toHaveBeenCalled();
   });
+
+  it('isolates malformed repository names instead of failing the whole check', async () => {
+    const { checkDependabotAlertsAvailability } = await import('./dependabot-api');
+    mockListAlertsForRepo.mockResolvedValueOnce({ data: [] });
+
+    await expect(
+      checkDependabotAlertsAvailability('malformed-installation', 'standard', [
+        { id: 1, fullName: undefined as never },
+        { id: 2, fullName: 'acme/valid' },
+      ])
+    ).resolves.toEqual([
+      { id: 1, status: 'unknown' },
+      { id: 2, status: 'enabled' },
+    ]);
+  });
 });

--- a/apps/web/src/lib/security-agent/github/dependabot-api.ts
+++ b/apps/web/src/lib/security-agent/github/dependabot-api.ts
@@ -5,7 +5,11 @@
  */
 
 import { Octokit } from '@octokit/rest';
-import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
+import pLimit from 'p-limit';
+import {
+  generateGitHubInstallationToken,
+  type GitHubAppType,
+} from '@/lib/integrations/platforms/github/adapter';
 import type { DependabotAlertRaw, DependabotAlertState } from '../core/types';
 import { errorExceptInTest, sentryLogger, warnExceptInTest } from '@/lib/utils.server';
 
@@ -117,6 +121,13 @@ type FetchAlertsSkipStatus =
   | 'access_blocked'
   | 'auth_invalid';
 
+export type DependabotAlertsAvailability = 'enabled' | 'disabled' | 'unknown';
+
+export type RepositoryDependabotAlertsAvailability = {
+  id: number;
+  status: DependabotAlertsAvailability;
+};
+
 // Permanent repo-level settings — safe to skip without blocking freshness.
 const DEPENDABOT_DISABLED_HINTS = [
   'dependabot alerts are disabled',
@@ -167,6 +178,69 @@ export function classifyFetchAlertsError(
   }
 
   return null;
+}
+
+/**
+ * Checks whether GitHub's Dependabot alerts API is available for each repository.
+ * A successful request is enough to prove alerts are enabled, even when no alerts exist.
+ * Ambiguous permission, authentication, and transient failures remain unknown so the UI
+ * never labels a repository as disabled without a definitive GitHub response.
+ */
+export async function checkDependabotAlertsAvailability(
+  installationId: string,
+  appType: GitHubAppType,
+  repositories: ReadonlyArray<{ id: number; fullName: string }>
+): Promise<RepositoryDependabotAlertsAvailability[]> {
+  if (repositories.length === 0) return [];
+
+  let token: string;
+  try {
+    token = (await generateGitHubInstallationToken(installationId, appType)).token;
+  } catch {
+    warnExceptInTest('Unable to authenticate while checking Dependabot alerts availability');
+    return repositories.map(repository => ({ id: repository.id, status: 'unknown' }));
+  }
+
+  const octokit = new Octokit({ auth: token });
+  const limit = pLimit(5);
+
+  const results = await Promise.all(
+    repositories.map(repository =>
+      limit(async (): Promise<RepositoryDependabotAlertsAvailability> => {
+        const [owner, repo, ...extraParts] = repository.fullName.split('/');
+        if (!owner || !repo || extraParts.length > 0) {
+          return { id: repository.id, status: 'unknown' };
+        }
+
+        try {
+          await octokit.rest.dependabot.listAlertsForRepo({
+            owner,
+            repo,
+            state: 'open',
+            per_page: 1,
+          });
+          return { id: repository.id, status: 'enabled' };
+        } catch (error) {
+          const httpStatus = (error as { status?: number }).status;
+          const message = (error as { message?: string }).message;
+          if (classifyFetchAlertsError(httpStatus, message) === 'alerts_disabled') {
+            return { id: repository.id, status: 'disabled' };
+          }
+
+          return { id: repository.id, status: 'unknown' };
+        }
+      })
+    )
+  );
+
+  const unknownCount = results.filter(result => result.status === 'unknown').length;
+  if (unknownCount > 0) {
+    warnExceptInTest('Unable to determine Dependabot alerts availability for some repositories', {
+      repositoryCount: unknownCount,
+    });
+  }
+
+  return results;
 }
 
 /**

--- a/apps/web/src/lib/security-agent/github/dependabot-api.ts
+++ b/apps/web/src/lib/security-agent/github/dependabot-api.ts
@@ -10,7 +10,11 @@ import {
   generateGitHubInstallationToken,
   type GitHubAppType,
 } from '@/lib/integrations/platforms/github/adapter';
-import type { DependabotAlertRaw, DependabotAlertState } from '../core/types';
+import type {
+  DependabotAlertRaw,
+  DependabotAlertsAvailability,
+  DependabotAlertState,
+} from '../core/types';
 import { errorExceptInTest, sentryLogger, warnExceptInTest } from '@/lib/utils.server';
 
 const log = sentryLogger('security-agent:dependabot-api', 'info');
@@ -121,8 +125,6 @@ type FetchAlertsSkipStatus =
   | 'access_blocked'
   | 'auth_invalid';
 
-export type DependabotAlertsAvailability = 'enabled' | 'disabled' | 'unknown';
-
 export type RepositoryDependabotAlertsAvailability = {
   id: number;
   status: DependabotAlertsAvailability;
@@ -139,6 +141,13 @@ const DEPENDABOT_DISABLED_HINTS = [
 // The repo exists but our app can't read it — should block freshness
 // advancement so the owner doesn't look fully synced.
 const ACCESS_BLOCKED_HINTS = ['repository access blocked'] as const;
+
+const DEPENDABOT_AVAILABILITY_CACHE_TTL_MS = 30 * 60_000;
+const dependabotAvailabilityCache = new Map<
+  string,
+  { status: DependabotAlertsAvailability; expiresAtMs: number }
+>();
+const dependabotAvailabilityInFlight = new Map<string, Promise<DependabotAlertsAvailability>>();
 
 function normalizeErrorMessage(message?: string): string {
   return (message ?? '').toLowerCase();
@@ -193,45 +202,58 @@ export async function checkDependabotAlertsAvailability(
 ): Promise<RepositoryDependabotAlertsAvailability[]> {
   if (repositories.length === 0) return [];
 
+  const now = Date.now();
+  const cachedResults = new Map<number, DependabotAlertsAvailability>();
+  const repositoriesToCheck = repositories.filter(repository => {
+    const cacheKey = dependabotAvailabilityCacheKey(installationId, appType, repository.fullName);
+    const cached = dependabotAvailabilityCache.get(cacheKey);
+    if (!cached) return true;
+    if (cached.expiresAtMs <= now) {
+      dependabotAvailabilityCache.delete(cacheKey);
+      return true;
+    }
+    cachedResults.set(repository.id, cached.status);
+    return false;
+  });
+
+  if (repositoriesToCheck.length === 0) {
+    return repositories.map(repository => ({
+      id: repository.id,
+      status: cachedResults.get(repository.id) ?? 'unknown',
+    }));
+  }
+
   let token: string;
   try {
     token = (await generateGitHubInstallationToken(installationId, appType)).token;
   } catch {
     warnExceptInTest('Unable to authenticate while checking Dependabot alerts availability');
-    return repositories.map(repository => ({ id: repository.id, status: 'unknown' }));
+    return repositories.map(repository => ({
+      id: repository.id,
+      status: cachedResults.get(repository.id) ?? 'unknown',
+    }));
   }
 
   const octokit = new Octokit({ auth: token });
   const limit = pLimit(5);
-
-  const results = await Promise.all(
-    repositories.map(repository =>
+  const checkedResults = await Promise.all(
+    repositoriesToCheck.map(repository =>
       limit(async (): Promise<RepositoryDependabotAlertsAvailability> => {
-        const [owner, repo, ...extraParts] = repository.fullName.split('/');
-        if (!owner || !repo || extraParts.length > 0) {
-          return { id: repository.id, status: 'unknown' };
-        }
-
-        try {
-          await octokit.rest.dependabot.listAlertsForRepo({
-            owner,
-            repo,
-            state: 'open',
-            per_page: 1,
-          });
-          return { id: repository.id, status: 'enabled' };
-        } catch (error) {
-          const httpStatus = (error as { status?: number }).status;
-          const message = (error as { message?: string }).message;
-          if (classifyFetchAlertsError(httpStatus, message) === 'alerts_disabled') {
-            return { id: repository.id, status: 'disabled' };
-          }
-
-          return { id: repository.id, status: 'unknown' };
-        }
+        const status = await checkRepositoryDependabotAlertsAvailability({
+          installationId,
+          appType,
+          repositoryFullName: repository.fullName,
+          octokit,
+        });
+        return { id: repository.id, status };
       })
     )
   );
+  const checkedResultsById = new Map(checkedResults.map(result => [result.id, result.status]));
+  const results = repositories.map(repository => ({
+    id: repository.id,
+    status: cachedResults.get(repository.id) ?? checkedResultsById.get(repository.id) ?? 'unknown',
+  }));
 
   const unknownCount = results.filter(result => result.status === 'unknown').length;
   if (unknownCount > 0) {
@@ -241,6 +263,76 @@ export async function checkDependabotAlertsAvailability(
   }
 
   return results;
+}
+
+async function checkRepositoryDependabotAlertsAvailability(input: {
+  installationId: string;
+  appType: GitHubAppType;
+  repositoryFullName: string;
+  octokit: Octokit;
+}): Promise<DependabotAlertsAvailability> {
+  const cacheKey = dependabotAvailabilityCacheKey(
+    input.installationId,
+    input.appType,
+    input.repositoryFullName
+  );
+  const inFlight = dependabotAvailabilityInFlight.get(cacheKey);
+  if (inFlight) return await inFlight;
+
+  const promise = fetchRepositoryDependabotAlertsAvailability(
+    input.repositoryFullName,
+    input.octokit
+  );
+  dependabotAvailabilityInFlight.set(cacheKey, promise);
+
+  try {
+    const status = await promise;
+    if (status !== 'unknown') {
+      dependabotAvailabilityCache.set(cacheKey, {
+        status,
+        expiresAtMs: Date.now() + DEPENDABOT_AVAILABILITY_CACHE_TTL_MS,
+      });
+    }
+    return status;
+  } finally {
+    dependabotAvailabilityInFlight.delete(cacheKey);
+  }
+}
+
+async function fetchRepositoryDependabotAlertsAvailability(
+  repositoryFullName: string,
+  octokit: Octokit
+): Promise<DependabotAlertsAvailability> {
+  const [owner, repo, ...extraParts] = repositoryFullName.split('/');
+  if (!owner || !repo || extraParts.length > 0) return 'unknown';
+
+  try {
+    await octokit.rest.dependabot.listAlertsForRepo({
+      owner,
+      repo,
+      state: 'open',
+      per_page: 1,
+    });
+    return 'enabled';
+  } catch (error) {
+    const httpStatus = (error as { status?: number }).status;
+    const message = (error as { message?: string }).message;
+    return classifyFetchAlertsError(httpStatus, message) === 'alerts_disabled'
+      ? 'disabled'
+      : 'unknown';
+  }
+}
+
+function dependabotAvailabilityCacheKey(
+  installationId: string,
+  appType: GitHubAppType,
+  repositoryFullName: string
+): string {
+  return JSON.stringify([
+    installationId.trim().toLowerCase(),
+    appType,
+    repositoryFullName.trim().toLowerCase(),
+  ]);
 }
 
 /**

--- a/apps/web/src/lib/security-agent/github/dependabot-api.ts
+++ b/apps/web/src/lib/security-agent/github/dependabot-api.ts
@@ -143,6 +143,7 @@ const DEPENDABOT_DISABLED_HINTS = [
 const ACCESS_BLOCKED_HINTS = ['repository access blocked'] as const;
 
 const DEPENDABOT_AVAILABILITY_CACHE_TTL_MS = 30 * 60_000;
+const DEPENDABOT_AVAILABILITY_CACHE_MAX_ENTRIES = 10_000;
 const dependabotAvailabilityCache = new Map<
   string,
   { status: DependabotAlertsAvailability; expiresAtMs: number }
@@ -203,15 +204,13 @@ export async function checkDependabotAlertsAvailability(
   if (repositories.length === 0) return [];
 
   const now = Date.now();
+  sweepDependabotAvailabilityCache(now);
   const cachedResults = new Map<number, DependabotAlertsAvailability>();
   const repositoriesToCheck = repositories.filter(repository => {
     const cacheKey = dependabotAvailabilityCacheKey(installationId, appType, repository.fullName);
+    if (!cacheKey) return true;
     const cached = dependabotAvailabilityCache.get(cacheKey);
     if (!cached) return true;
-    if (cached.expiresAtMs <= now) {
-      dependabotAvailabilityCache.delete(cacheKey);
-      return true;
-    }
     cachedResults.set(repository.id, cached.status);
     return false;
   });
@@ -239,13 +238,17 @@ export async function checkDependabotAlertsAvailability(
   const checkedResults = await Promise.all(
     repositoriesToCheck.map(repository =>
       limit(async (): Promise<RepositoryDependabotAlertsAvailability> => {
-        const status = await checkRepositoryDependabotAlertsAvailability({
-          installationId,
-          appType,
-          repositoryFullName: repository.fullName,
-          octokit,
-        });
-        return { id: repository.id, status };
+        try {
+          const status = await checkRepositoryDependabotAlertsAvailability({
+            installationId,
+            appType,
+            repositoryFullName: repository.fullName,
+            octokit,
+          });
+          return { id: repository.id, status };
+        } catch {
+          return { id: repository.id, status: 'unknown' };
+        }
       })
     )
   );
@@ -276,6 +279,7 @@ async function checkRepositoryDependabotAlertsAvailability(input: {
     input.appType,
     input.repositoryFullName
   );
+  if (!cacheKey) return 'unknown';
   const inFlight = dependabotAvailabilityInFlight.get(cacheKey);
   if (inFlight) return await inFlight;
 
@@ -292,6 +296,7 @@ async function checkRepositoryDependabotAlertsAvailability(input: {
         status,
         expiresAtMs: Date.now() + DEPENDABOT_AVAILABILITY_CACHE_TTL_MS,
       });
+      sweepDependabotAvailabilityCache(Date.now());
     }
     return status;
   } finally {
@@ -326,13 +331,28 @@ async function fetchRepositoryDependabotAlertsAvailability(
 function dependabotAvailabilityCacheKey(
   installationId: string,
   appType: GitHubAppType,
-  repositoryFullName: string
-): string {
+  repositoryFullName: unknown
+): string | null {
+  if (typeof repositoryFullName !== 'string') return null;
+  const normalizedRepositoryFullName = repositoryFullName.trim().toLowerCase();
+  if (!normalizedRepositoryFullName) return null;
   return JSON.stringify([
     installationId.trim().toLowerCase(),
     appType,
-    repositoryFullName.trim().toLowerCase(),
+    normalizedRepositoryFullName,
   ]);
+}
+
+function sweepDependabotAvailabilityCache(now: number): void {
+  for (const [key, cached] of dependabotAvailabilityCache) {
+    if (cached.expiresAtMs <= now) dependabotAvailabilityCache.delete(key);
+  }
+
+  while (dependabotAvailabilityCache.size > DEPENDABOT_AVAILABILITY_CACHE_MAX_ENTRIES) {
+    const oldestKey = dependabotAvailabilityCache.keys().next().value;
+    if (typeof oldestKey !== 'string') break;
+    dependabotAvailabilityCache.delete(oldestKey);
+  }
 }
 
 /**

--- a/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
@@ -40,6 +40,10 @@ const mockLogSecurityAudit = jest.fn();
 const mockCreateSecurityAuditLog = jest.fn();
 const mockUpsertSecurityAgentConfig = jest.fn();
 const mockSetSecurityAgentEnabled = jest.fn();
+const mockCheckDependabotAlertsAvailability =
+  jest.fn<
+    (installationId: string, appType: string, repositories: unknown[]) => Promise<unknown[]>
+  >();
 const mockAutoDismissEligibleFindings =
   jest.fn<
     (
@@ -65,6 +69,9 @@ jest.mock('../services/manual-remediation-client', () => ({
 jest.mock('../github/permissions', () => ({
   hasSecurityReviewPermissions: () => true,
   getReauthorizeUrl: jest.fn(),
+}));
+jest.mock('../github/dependabot-api', () => ({
+  checkDependabotAlertsAvailability: mockCheckDependabotAlertsAvailability,
 }));
 jest.mock('../posthog-tracking', () => ({
   trackSecurityAgentEnabled: jest.fn(),
@@ -134,6 +141,7 @@ beforeEach(() => {
   mockGetSecurityAgentConfigWithStatus.mockResolvedValue(null);
   mockGetRemediationAttemptHistory.mockResolvedValue([]);
   mockEnqueueBacklogFindings.mockResolvedValue(0);
+  mockCheckDependabotAlertsAvailability.mockResolvedValue([]);
 });
 
 function createHandlers() {
@@ -151,7 +159,7 @@ function createHandlers() {
         id: 'integration-123',
         integration_status: 'active',
         platform_installation_id: 'installation-123',
-        repositories: [{ id: 1, full_name: 'kilo/repo' }],
+        repositories: [{ id: 1, full_name: 'kilo/repo', name: 'repo', private: true }],
       }) as never,
     trackingExtras: () => ({}),
   });
@@ -257,6 +265,43 @@ describe('trackUiInteraction', () => {
     expect(mockSetSecurityAgentEnabled).not.toHaveBeenCalled();
     expect(mockCreateSecurityAuditLog).not.toHaveBeenCalled();
     expect(mockLogSecurityAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe('getRepositories', () => {
+  it('includes Dependabot alerts availability for each repository', async () => {
+    mockCheckDependabotAlertsAvailability.mockResolvedValueOnce([{ id: 1, status: 'disabled' }]);
+
+    await expect(createHandlers().getRepositories({ ctx: context, input: {} })).resolves.toEqual([
+      {
+        id: 1,
+        fullName: 'kilo/repo',
+        name: 'repo',
+        private: true,
+        dependabotAlerts: 'disabled',
+      },
+    ]);
+
+    expect(mockCheckDependabotAlertsAvailability).toHaveBeenCalledWith(
+      'installation-123',
+      'standard',
+      [
+        {
+          id: 1,
+          fullName: 'kilo/repo',
+          name: 'repo',
+          private: true,
+        },
+      ]
+    );
+  });
+
+  it('keeps repository selection available when the availability check fails', async () => {
+    mockCheckDependabotAlertsAvailability.mockRejectedValueOnce(new Error('GitHub unavailable'));
+
+    await expect(createHandlers().getRepositories({ ctx: context, input: {} })).resolves.toEqual([
+      expect.objectContaining({ id: 1, dependabotAlerts: 'unknown' }),
+    ]);
   });
 });
 

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -46,6 +46,7 @@ import {
   hasSecurityReviewPermissions,
   getReauthorizeUrl,
 } from '@/lib/security-agent/github/permissions';
+import { checkDependabotAlertsAvailability } from '@/lib/security-agent/github/dependabot-api';
 import { submitManualSecuritySync } from '@/lib/security-agent/services/manual-sync-client';
 import { submitManualFindingDismissal } from '@/lib/security-agent/services/manual-dismiss-client';
 import { submitManualAnalysisStart } from '@/lib/security-agent/services/manual-analysis-client';
@@ -846,11 +847,42 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         repos = fetchedRepos;
       }
 
-      return repos.map(repo => ({
+      const repositoryDetails = repos.map(repo => ({
         id: repo.id,
         fullName: repo.full_name,
         name: repo.name,
         private: repo.private,
+      }));
+      const installationId = integration.platform_installation_id;
+      if (!installationId || !hasSecurityReviewPermissions(integration)) {
+        return repositoryDetails.map(repository => ({
+          ...repository,
+          dependabotAlerts: 'unknown' as const,
+        }));
+      }
+
+      const appType = integration.github_app_type || 'standard';
+      let availability: Awaited<ReturnType<typeof checkDependabotAlertsAvailability>>;
+      try {
+        availability = await checkDependabotAlertsAvailability(
+          installationId,
+          appType,
+          repositoryDetails
+        );
+      } catch (error) {
+        console.error('Failed to check Dependabot alerts availability', {
+          error: error instanceof Error ? error.message : String(error),
+        });
+        return repositoryDetails.map(repository => ({
+          ...repository,
+          dependabotAlerts: 'unknown' as const,
+        }));
+      }
+      const availabilityById = new Map(availability.map(result => [result.id, result.status]));
+
+      return repositoryDetails.map(repository => ({
+        ...repository,
+        dependabotAlerts: availabilityById.get(repository.id) ?? ('unknown' as const),
       }));
     },
 


### PR DESCRIPTION
## Summary

Warn users when selected repositories cannot supply Security Agent findings because Dependabot alerts are disabled.

### Why this change is needed

Security Agent relies on GitHub Dependabot alerts. Repositories without alerts enabled can currently be selected without any indication that findings cannot be imported, which can give users a false sense of coverage.

### How this is addressed

- Check Dependabot alert availability for repositories shown in Security Agent settings and reuse recent results for 30 minutes.
- Mark affected repositories with a "Dependabot alerts off" badge.
- Show a warning when the current selection includes affected repositories.
- Treat authentication, permission, and transient failures as unknown rather than incorrectly reporting alerts as disabled.
- Keep repository selection available if GitHub availability checks fail.

## Verification

<img width="2328" height="1766" alt="CleanShot X 2026-07-30 21 45 17" src="https://github.com/user-attachments/assets/c837c71e-8e69-45d6-84b8-3854d697bc2b" />
<img width="2292" height="1970" alt="CleanShot X 2026-07-30 21 45 18" src="https://github.com/user-attachments/assets/4543b802-ebb6-4da6-8999-81a8a2a1bbe3" />

## Reviewer Notes

### Human Reviewer Flags

- Repository availability is checked with bounded concurrency and cached for 30 minutes per installation and repository. The cache sweeps expired entries and is capped at 10,000 entries; transient or unknown results are not cached.
- Only definitive GitHub responses produce a disabled warning. Ambiguous failures remain unknown to avoid false warnings.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- The repository response now carries an `enabled`, `disabled`, or `unknown` Dependabot status.
- Checks use the existing GitHub App installation token and request one open alert, which proves API availability even when the result is empty. Server-side caching and in-flight deduplication limit repeated GitHub requests.
- The shared repository picker gained an optional accessory renderer so Security Agent can add status UI without affecting its other consumers.
- Failure handling preserves the existing repository list and does not block configuration.

</details>


