### PR TITLE
feat(ai-gateway): weight auto-free model routing

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -39,23 +39,21 @@ const sampleDecision: AutoRoutingDecision = {
 };
 
 describe('selectAutoFreeCandidate', () => {
-  it('follows the configured routing percentages', () => {
-    const selectionCounts = new Map(autoFreeModelRoutes.map(route => [route.model, 0]));
-    const sampleSize = 10_000;
-
-    for (let seed = 0; seed < sampleSize; seed++) {
-      const selected = selectAutoFreeCandidate(
-        autoFreeModelRoutes.map(route => route.model),
-        String(seed)
-      );
-      if (selected) selectionCounts.set(selected, (selectionCounts.get(selected) ?? 0) + 1);
-    }
-
+  it('maps the configured percentage boundaries to each model', () => {
+    const candidates = autoFreeModelRoutes.map(route => route.model);
+    const totalPercentage = autoFreeModelRoutes.reduce(
+      (total, route) => total + route.percentage,
+      0
+    );
+    let cumulativePercentage = 0;
     for (const route of autoFreeModelRoutes) {
-      expect((selectionCounts.get(route.model) ?? 0) / sampleSize).toBeCloseTo(
-        route.percentage / 100,
-        1
-      );
+      const firstBucket = Math.ceil((cumulativePercentage * 10_000) / totalPercentage);
+      const lastBucket =
+        Math.ceil(((cumulativePercentage + route.percentage) * 10_000) / totalPercentage) - 1;
+
+      expect(selectAutoFreeCandidate(candidates, 'seed', () => firstBucket)).toBe(route.model);
+      expect(selectAutoFreeCandidate(candidates, 'seed', () => lastBucket)).toBe(route.model);
+      cumulativePercentage += route.percentage;
     }
   });
 

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -8,7 +8,7 @@ jest.mock('@/lib/kiloclaw/setup-promo', () => ({
   userIsWithinFirstKiloClawInstanceWindow: jest.fn(async () => false),
 }));
 
-import { resolveAutoModel } from './resolution';
+import { resolveAutoModel, selectAutoFreeCandidate } from './resolution';
 import {
   BALANCED_QWEN_MODEL,
   FRONTIER_MODE_TO_MODEL,
@@ -16,6 +16,7 @@ import {
   ORG_AUTO_MODEL,
 } from '@/lib/ai-gateway/auto-model';
 import type { AutoRoutingDecision } from '@kilocode/auto-routing-contracts';
+import { autoFreeModelRoutes } from '@/lib/ai-gateway/models';
 
 const baseParams = {
   model: KILO_AUTO_EFFICIENT_MODEL.id,
@@ -36,6 +37,41 @@ const sampleDecision: AutoRoutingDecision = {
   tableVersion: 'v1',
   sticky: false,
 };
+
+describe('selectAutoFreeCandidate', () => {
+  it('follows the configured routing percentages', () => {
+    const selectionCounts = new Map(autoFreeModelRoutes.map(route => [route.model, 0]));
+    const sampleSize = 10_000;
+
+    for (let seed = 0; seed < sampleSize; seed++) {
+      const selected = selectAutoFreeCandidate(
+        autoFreeModelRoutes.map(route => route.model),
+        String(seed)
+      );
+      if (selected) selectionCounts.set(selected, (selectionCounts.get(selected) ?? 0) + 1);
+    }
+
+    for (const route of autoFreeModelRoutes) {
+      expect((selectionCounts.get(route.model) ?? 0) / sampleSize).toBeCloseTo(
+        route.percentage / 100,
+        1
+      );
+    }
+  });
+
+  it('only selects from available candidates', () => {
+    const model = autoFreeModelRoutes[1]?.model;
+    expect(model).toBeDefined();
+
+    for (let seed = 0; seed < 100; seed++) {
+      expect(selectAutoFreeCandidate(model ? [model] : [], String(seed))).toBe(model);
+    }
+  });
+
+  it('returns null when no configured candidates are available', () => {
+    expect(selectAutoFreeCandidate([], 'seed')).toBeNull();
+  });
+});
 
 describe('resolveAutoModel — kilo-auto/efficient branch', () => {
   it('resolves to decision.model when the thunk returns a decision', async () => {

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -31,6 +31,7 @@ import {
 import { userIsWithinFirstKiloClawInstanceWindow } from '@/lib/kiloclaw/setup-promo';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import {
+  autoFreeModelRoutes,
   autoFreeModels,
   findKiloExclusiveModel,
   isKiloExclusiveFreeModel,
@@ -101,6 +102,26 @@ function gatewaySupportsApiKind(
   if (apiKind === null) return true;
   const provider = Object.values(PROVIDERS).find(p => p.id === gateway);
   return provider?.supportedChatApis.some(k => k === apiKind) ?? false;
+}
+
+export function selectAutoFreeCandidate(
+  candidates: ReadonlyArray<string>,
+  randomSeed: string
+): string | null {
+  const availableCandidates = new Set(candidates);
+  const routes = autoFreeModelRoutes.filter(route => availableCandidates.has(route.model));
+  const totalPercentage = routes.reduce((total, route) => total + route.percentage, 0);
+  if (totalPercentage <= 0) return null;
+
+  const percentageBucket =
+    (getRandomNumber('free_routing_' + randomSeed, 10_000) / 10_000) * totalPercentage;
+  let cumulativePercentage = 0;
+  for (const route of routes) {
+    cumulativePercentage += route.percentage;
+    if (percentageBucket < cumulativePercentage) return route.model;
+  }
+
+  return routes.at(-1)?.model ?? null;
 }
 
 type OrganizationAutoContext = {
@@ -242,14 +263,12 @@ export async function resolveAutoModel(
   }
   if (model === KILO_AUTO_FREE_MODEL.id) {
     const candidates = await getAutoFreeCandidates(apiKind);
-    if (candidates.length === 0) {
+    const randomSeed = sessionId ?? (await userPromise)?.id ?? clientIp;
+    const candidate = selectAutoFreeCandidate(candidates, String(randomSeed));
+    if (!candidate) {
       return { kind: 'no_free_models_available' };
     }
-    const randomNumber = getRandomNumber(
-      'free_routing_' + (sessionId ?? (await userPromise)?.id ?? clientIp),
-      candidates.length
-    );
-    return { kind: 'ok', resolved: { model: candidates[randomNumber] } };
+    return { kind: 'ok', resolved: { model: candidate } };
   }
   if (model === KILO_AUTO_SMALL_MODEL.id) {
     return {

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -106,7 +106,8 @@ function gatewaySupportsApiKind(
 
 export function selectAutoFreeCandidate(
   candidates: ReadonlyArray<string>,
-  randomSeed: string
+  randomSeed: string,
+  randomNumber: typeof getRandomNumber = getRandomNumber
 ): string | null {
   const availableCandidates = new Set(candidates);
   const routes = autoFreeModelRoutes.filter(route => availableCandidates.has(route.model));
@@ -114,7 +115,7 @@ export function selectAutoFreeCandidate(
   if (totalPercentage <= 0) return null;
 
   const percentageBucket =
-    (getRandomNumber('free_routing_' + randomSeed, 10_000) / 10_000) * totalPercentage;
+    (randomNumber('free_routing_' + randomSeed, 10_000) / 10_000) * totalPercentage;
   let cumulativePercentage = 0;
   for (const route of routes) {
     cumulativePercentage += route.percentage;

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from '@jest/globals';
-import { autoFreeModels, findKiloExclusiveModel, kiloExclusiveModels } from './models';
+import {
+  autoFreeModelRoutes,
+  autoFreeModels,
+  findKiloExclusiveModel,
+  kiloExclusiveModels,
+} from './models';
 import { hasBestEffortGuessDataCollectionRequirement, isFreeModel } from './is-free-model';
 import { getInferenceProvider } from './providers/kilo-exclusive-model';
 import { getAiSdkProvider } from './providers/model-settings';
@@ -129,6 +134,11 @@ describe('isFreeModel', () => {
       expect(autoFreeModels.length).toBeGreaterThan(0);
       const providers = new Set(autoFreeModels.map(model => getAiSdkProvider(model, null)));
       expect(providers.size).toBe(1);
+    });
+
+    test('auto-free routing percentages should total 100', () => {
+      expect(autoFreeModelRoutes.every(route => route.percentage > 0)).toBe(true);
+      expect(autoFreeModelRoutes.reduce((total, route) => total + route.percentage, 0)).toBe(100);
     });
 
     test('should return true for disabled Kilo exclusive models that end with :free', async () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -38,14 +38,18 @@ import { type ProviderId } from '@/lib/ai-gateway/providers/types';
 export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
 export const autoFreeModelRoutes = [
-  ...(stepfun_37_flash_free_model.status === 'public'
-    ? [{ model: stepfun_37_flash_free_model.public_id, percentage: 34 }]
-    : []),
+  { model: stepfun_37_flash_free_model.public_id, percentage: 34 },
   { model: 'inclusionai/ling-3.0-flash:free', percentage: 33 },
   { model: 'poolside/laguna-s-2.1:free', percentage: 33 },
 ] satisfies ReadonlyArray<{ model: string; percentage: number }>;
 
-export const autoFreeModels = autoFreeModelRoutes.map(route => route.model);
+export const autoFreeModels = autoFreeModelRoutes
+  .filter(
+    route =>
+      route.model !== stepfun_37_flash_free_model.public_id ||
+      stepfun_37_flash_free_model.status === 'public'
+  )
+  .map(route => route.model);
 
 export const preferredModels = [
   KILO_AUTO_FRONTIER_MODEL.id,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -37,11 +37,15 @@ import { type ProviderId } from '@/lib/ai-gateway/providers/types';
 
 export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
-export const autoFreeModels = [
-  stepfun_37_flash_free_model.status === 'public' ? stepfun_37_flash_free_model.public_id : null,
-  'inclusionai/ling-3.0-flash:free',
-  'poolside/laguna-s-2.1:free',
-].filter(m => m !== null);
+export const autoFreeModelRoutes = [
+  ...(stepfun_37_flash_free_model.status === 'public'
+    ? [{ model: stepfun_37_flash_free_model.public_id, percentage: 34 }]
+    : []),
+  { model: 'inclusionai/ling-3.0-flash:free', percentage: 33 },
+  { model: 'poolside/laguna-s-2.1:free', percentage: 33 },
+] satisfies ReadonlyArray<{ model: string; percentage: number }>;
+
+export const autoFreeModels = autoFreeModelRoutes.map(route => route.model);
 
 export const preferredModels = [
   KILO_AUTO_FRONTIER_MODEL.id,


### PR DESCRIPTION
## Summary
- configure an explicit percentage for each auto-free model in code
- route sticky cohorts according to the configured percentages
- renormalize percentages across models that are currently available
- retain the existing string model list for catalog and policy consumers

## Testing
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/models.test.ts src/lib/ai-gateway/auto-model/resolution.test.ts`
- `pnpm --filter web lint`
- `pnpm --filter web typecheck`
- `pnpm format`
- `git diff --check`

## Notes
- Initial routing remains approximately even at 34% / 33% / 33%.
- Commands passed under Node 26.5.0 with an engine warning because the repository declares Node >=24 <25.