### PR TITLE
fix(ai-gateway): disable GPT-5.6 promotion

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -6,7 +6,6 @@ import {
 } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
-import { OPENROUTER_GPT56_PROMO_MODEL_IDS } from '@/lib/ai-gateway/providers/openai';
 
 function makeRequest(model: string, models?: string[]): GatewayRequest {
   return {
@@ -60,12 +59,24 @@ describe('applyGatewayModelsFallback', () => {
 });
 
 describe('applyPreferredProvider', () => {
-  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('prefers OpenAI for promo model %s', model => {
+  it.each(['openai/gpt-5.6-terra', 'openai/o3', 'gpt-5.5'])(
+    'prefers OpenAI for OpenAI model %s',
+    model => {
+      const request = makeRequest(model);
+
+      applyPreferredProvider(model, request.body);
+
+      expect(request.body.provider).toEqual({ order: ['openai'] });
+    }
+  );
+
+  it('does not set a provider order for GPT-OSS', () => {
+    const model = 'openai/gpt-oss-120b';
     const request = makeRequest(model);
 
     applyPreferredProvider(model, request.body);
 
-    expect(request.body.provider).toEqual({ order: ['openai'] });
+    expect(request.body.provider).toBeUndefined();
   });
 
   it('does not set a provider order for Fable', () => {

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -39,10 +39,10 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
 import { isQwenExplicitCacheModel, isQwenModel } from '@/lib/ai-gateway/providers/qwen';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
-import { isOpenRouterGpt56PromoModel } from '@/lib/ai-gateway/providers/openai';
+import { isOpenAiModel } from '@/lib/ai-gateway/providers/openai';
 
 export function getPreferredProviderOrder(requestedModel: string): string[] {
-  if (isOpenRouterGpt56PromoModel(requestedModel)) {
+  if (isOpenAiModel(requestedModel)) {
     return [OpenRouterInferenceProviderIdSchema.enum.openai];
   }
   if (isClaudeModel(requestedModel) && !isFableModel(requestedModel)) {

--- a/apps/web/src/lib/ai-gateway/providers/openai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai.ts
@@ -17,8 +17,8 @@ export const GPT_MINI_CURRENT_MODEL_ID = 'openai/gpt-5.4-mini';
 
 export const GPT_MINI_CURRENT_VERCEL_MODEL_ID = GPT_MINI_CURRENT_MODEL_ID;
 
-// OpenRouter BYOK must be disabled for these models so requests use the discounted endpoint.
-export const ENABLE_OPENROUTER_GPT56_PROMO = true;
+// When enabled, OpenRouter BYOK is disabled for these models so requests use the discounted endpoint.
+export const ENABLE_OPENROUTER_GPT56_PROMO = false;
 
 export const OPENROUTER_GPT56_PROMO_MODEL_IDS = [
   'openai/gpt-5.6-terra',

--- a/apps/web/src/lib/ai-gateway/providers/openai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai.ts
@@ -17,7 +17,7 @@ export const GPT_MINI_CURRENT_MODEL_ID = 'openai/gpt-5.4-mini';
 
 export const GPT_MINI_CURRENT_VERCEL_MODEL_ID = GPT_MINI_CURRENT_MODEL_ID;
 
-// When enabled, OpenRouter BYOK is disabled for these models so requests use the discounted endpoint.
+// OpenAI BYOK must be disabled on the OpenRouter website before enabling this flag.
 export const ENABLE_OPENROUTER_GPT56_PROMO = false;
 
 export const OPENROUTER_GPT56_PROMO_MODEL_IDS = [

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/display-pricing.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/display-pricing.test.ts
@@ -52,9 +52,16 @@ describe('OpenRouter GPT-5.6 promotion', () => {
     discount: 0.5,
   };
 
-  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('preserves discounted pricing for %s', modelId => {
-    expect(getModelDisplayPricing(modelId, discountedPricing)).toBe(discountedPricing);
-  });
+  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)(
+    'undoes discounted pricing while the promotion is disabled for %s',
+    modelId => {
+      expect(getModelDisplayPricing(modelId, discountedPricing)).toEqual({
+        prompt: '0.000002000000',
+        completion: '0.000008000000',
+        input_cache_read: '0.000000200000',
+      });
+    }
+  );
 
   it('continues to undo endpoint discounts for other models', () => {
     expect(getModelDisplayPricing('openai/gpt-5.6-sol', discountedPricing)).toEqual({

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -159,7 +159,7 @@ describe('formatName', () => {
     expect(formatName(model, NOT_PREFERRED)).toBe('OpenRouter Test Model ($$$$)');
   });
 
-  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('prefers the 50% off marker for %s', modelId => {
+  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('does not show the disabled promo for %s', modelId => {
     const recentlyCreated = Math.floor(Date.now() / 1000) - 24 * 3600;
     const model = buildModel({
       id: modelId,
@@ -167,15 +167,15 @@ describe('formatName', () => {
       expiration_date: '2026-07-01',
       pricing: { prompt: '0.00001', completion: '0', discount: 0.5 },
     });
-    expect(formatName(model, 0)).toBe('Test Model (50% off)');
+    expect(formatName(model, 0)).toBe('Test Model ($$$$)');
   });
 
-  it('takes the promo percentage from endpoint metadata', () => {
+  it('does not show the disabled promo percentage from endpoint metadata', () => {
     const model = buildModel({
       id: OPENROUTER_GPT56_PROMO_MODEL_IDS[0],
       pricing: { prompt: '0.00001', completion: '0', discount: 0.375 },
     });
-    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model (37.5% off)');
+    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model ($$$$)');
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -1,15 +1,13 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 import {
   convertProviderOptions,
   getAnthropicProviderOptionsForVercel,
   getVercelInferenceProvidersExcludingIgnored,
   hasCompatibleVercelInferenceProvider,
   passesVercelRoutingPercentage,
-  shouldRouteToVercel,
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
-import { OPENROUTER_GPT56_PROMO_MODEL_IDS } from '@/lib/ai-gateway/providers/openai';
 
 describe('getAnthropicProviderOptionsForVercel', () => {
   it('maps chat completion verbosity to Anthropic effort', () => {
@@ -154,24 +152,5 @@ describe('passesVercelRoutingPercentage', () => {
 
     expect(seedsInFinalBucket.some(seed => passesVercelRoutingPercentage(seed, 99.9))).toBe(true);
     expect(seedsInFinalBucket.some(seed => !passesVercelRoutingPercentage(seed, 99.9))).toBe(true);
-  });
-});
-
-describe('OpenRouter GPT-5.6 promotion', () => {
-  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('does not route %s to Vercel', async model => {
-    const debugSpy = jest.spyOn(console, 'debug').mockImplementation(() => {});
-    const request: GatewayRequest = {
-      kind: 'chat_completions',
-      body: {
-        model,
-        messages: [{ role: 'user', content: 'hello' }],
-      },
-    };
-
-    await expect(shouldRouteToVercel(model, request, 'promo-test')).resolves.toBe(false);
-    expect(debugSpy).toHaveBeenCalledWith(
-      `[shouldRouteToVercel] routing ${model} to OpenRouter for the GPT-5.6 promotion`
-    );
-    debugSpy.mockRestore();
   });
 });


### PR DESCRIPTION
## Summary
- disable the OpenRouter GPT-5.6 promotion
- prefer the `openai` inference provider for OpenAI GPT models independently of the promo flag
- update promo and provider-routing expectations for the disabled state

## Testing
- not run locally; CI will validate the change