### PR TITLE
fix(ai-gateway): forbid Tencent HY3 free model

### DIFF
--- a/apps/web/src/lib/ai-gateway/forbidden-free-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/forbidden-free-models.test.ts
@@ -7,6 +7,7 @@ import {
 describe('forbidden free models', () => {
   test('keeps exact matching for request rejection', () => {
     expect(isForbiddenFreeModel('openai/gpt-oss-20b:free')).toBe(true);
+    expect(isForbiddenFreeModel('tencent/hy3:free')).toBe(true);
     expect(isForbiddenFreeModel('openai/gpt-oss-20b')).toBe(false);
   });
 

--- a/apps/web/src/lib/ai-gateway/forbidden-free-models.ts
+++ b/apps/web/src/lib/ai-gateway/forbidden-free-models.ts
@@ -52,6 +52,7 @@ const forbiddenFreeModelIds: ReadonlySet<string> = new Set([
   'z-ai/glm-4.5-air:free',
   'z-ai/glm-4.7:free',
   'stepfun/step-3.5-flash:free',
+  'tencent/hy3:free',
   'z-ai/glm-5:free',
   claude_sonnet_clawsetup_model.public_id, // only usable through kilo-auto
 ]);


### PR DESCRIPTION
## Summary
- add `tencent/hy3:free` to the forbidden free-model set
- cover exact request rejection with a regression assertion

## Testing
- `pnpm --filter web test --runInBand src/lib/ai-gateway/forbidden-free-models.test.ts`
- `git diff --check`