### PR TITLE
fix(web): stop replication probe from sending statement_timeout via pooler

### DIFF
--- a/apps/web/src/lib/replication-health.test.ts
+++ b/apps/web/src/lib/replication-health.test.ts
@@ -9,6 +9,7 @@ jest.mock('@/lib/drizzle', () => ({
 import {
   classifyReplicaRow,
   collectReplicationHealth,
+  PROBE_POOL_CONFIG,
   probeReplica,
   REPLICA_LAG_ALERT_SECONDS,
   type ReplicaHealth,
@@ -69,6 +70,14 @@ describe('probeReplica', () => {
 
     expect(health).toMatchObject({ name: 'us-west', status: 'unreachable' });
     expect(health.error).toBeTruthy();
+  });
+
+  it('does not send statement_timeout, which Supabase Supavisor rejects at startup', () => {
+    // Regression guard: statement_timeout travels in the Postgres startup packet
+    // and the pooler refuses connections carrying it, so every probe failed.
+    expect(PROBE_POOL_CONFIG).not.toHaveProperty('statement_timeout');
+    expect(PROBE_POOL_CONFIG.query_timeout).toBe(5_000);
+    expect(PROBE_POOL_CONFIG.connectionTimeoutMillis).toBe(5_000);
   });
 });
 
@@ -234,6 +243,25 @@ describe('collectReplicationHealth', () => {
     expect(report.walSenders).toHaveLength(1);
     expect(report.slots).toHaveLength(1);
     expect(report.healthy).toBe(false);
+  });
+
+  it('surfaces the underlying driver cause when a probe error wraps one', async () => {
+    mockPrimary([walSenderRow()], [slotRow()]);
+
+    const report = await collectReplicationHealth({
+      targets: [{ name: 'us-west', url: 'postgres://replica' }],
+      probe: async () => {
+        // Shape of a drizzle failure: generic wrapper message + real driver cause.
+        throw Object.assign(new Error('Failed query: SELECT ...'), {
+          cause: new Error('db error: connection terminated'),
+        });
+      },
+    });
+
+    expect(report.replicas[0]).toMatchObject({
+      status: 'unreachable',
+      error: 'db error: connection terminated',
+    });
   });
 
   it('captures primary query failures without blanking the report', async () => {

--- a/apps/web/src/lib/replication-health.ts
+++ b/apps/web/src/lib/replication-health.ts
@@ -1,4 +1,4 @@
-import { createDrizzleClient, type DrizzleClient } from '@kilocode/db/client';
+import { createDrizzleClient, type DrizzleClient, type pg } from '@kilocode/db/client';
 import { sql } from 'drizzle-orm';
 
 import { getEnvVariable } from '@/lib/dotenvx';
@@ -64,6 +64,24 @@ const AT_RISK_WAL_STATUSES = new Set(['unreserved', 'lost']);
 
 const PROBE_TIMEOUT_MS = 5_000;
 
+/**
+ * Connection config for a single probe.
+ *
+ * IMPORTANT: do not set `statement_timeout` here. node-postgres transmits
+ * `statement_timeout` in the Postgres startup packet (pg `getStartupConf`), and
+ * Supabase's Supavisor pooler — which the POSTGRES_REPLICA_* URLs connect
+ * through — rejects connections that carry it, so the probe would never
+ * establish a session (it silently failed on every EU replica this way). Bound
+ * the probe with the client-side `query_timeout` and `connectionTimeoutMillis`
+ * instead, matching the app's own replica pool in lib/drizzle.ts.
+ */
+export const PROBE_POOL_CONFIG = {
+  max: 1,
+  application_name: 'kilocode-web-replication-health',
+  connectionTimeoutMillis: PROBE_TIMEOUT_MS,
+  query_timeout: PROBE_TIMEOUT_MS,
+} satisfies Partial<pg.PoolConfig>;
+
 export type ReplicaHealthStatus = 'ok' | 'lagging' | 'not_in_recovery' | 'unreachable';
 
 export type ReplicaHealth = {
@@ -112,7 +130,13 @@ export type ReplicationHealthReport = {
 };
 
 function errorMessage(error: unknown): string {
-  return error instanceof Error ? error.message : String(error);
+  if (!(error instanceof Error)) return String(error);
+  // drizzle wraps DB failures as `Error('Failed query: <sql>')` and attaches the
+  // real driver error (e.g. the connection/pooler rejection) as `cause`. Prefer
+  // that cause so alerts show why a probe failed instead of the SQL text.
+  const cause = error.cause;
+  if (cause instanceof Error && cause.message) return cause.message;
+  return error.message;
 }
 
 /** Pure status derivation, split out so it can be unit-tested without a database. */
@@ -139,13 +163,7 @@ export async function probeReplica(target: ReplicaTarget): Promise<ReplicaHealth
   try {
     client = createDrizzleClient({
       connectionString: target.url,
-      poolConfig: {
-        max: 1,
-        application_name: 'kilocode-web-replication-health',
-        connectionTimeoutMillis: PROBE_TIMEOUT_MS,
-        statement_timeout: PROBE_TIMEOUT_MS,
-        query_timeout: PROBE_TIMEOUT_MS,
-      },
+      poolConfig: PROBE_POOL_CONFIG,
     });
 
     // A pg.Pool emits 'error' when an idle/checked-out client's connection drops


### PR DESCRIPTION
## Problem

The new `db-replication-health` cron paged (Sentry KILOCODE-WEB-27GZ) with `replica eu-central-1: unreachable` / `eu-central-2: unreachable (Failed query…)`. The replicas were **not** down.

## Confirmation (Supabase + Axiom)

- **Primary `pg_stat_replication`** (2026-07-31 09:19 UTC): both EU `main` walsenders streaming at ~2 ms lag; a rebuilt US replica also streaming at 0.15 s; Snowflake main slot reserved. All healthy.
- **Axiom `supabase-production`**: **zero** connections for `application_name = 'kilocode-web-replication-health'` on either EU replica, while the app's own `kilocode-web-replica` pool had 6 successful connections each on the same hosts (`cdhuu`, `zoxpu`). The probe never established a session.

## Root cause

`probeReplica` set `statement_timeout` in the pg pool config. node-postgres transmits `statement_timeout` in the **Postgres startup packet** (`pg/lib/client.js` `getStartupConf`). The `POSTGRES_REPLICA_*` URLs connect through Supabase's **Supavisor** pooler, which **rejects connections carrying that startup parameter** — so the connection is refused before any Postgres session exists (hence no replica-side logs, and drizzle only surfaces its generic `Failed query: <sql>` wrapper). The app's replica pool works because it does **not** set `statement_timeout`.

## Fix

- Drop `statement_timeout` from the probe pool config; keep the client-side `query_timeout` and `connectionTimeoutMillis` to bound the probe. Extracted as `PROBE_POOL_CONFIG` with a regression test asserting `statement_timeout` is absent.
- `errorMessage` now prefers `error.cause` (the real driver error) over drizzle's `Failed query: <sql>` wrapper, so future probe failures are diagnosable in Sentry.

## Testing
- `replication-health.test.ts` (incl. new pool-config regression + error-cause tests), both route tests — 20/20 pass. oxlint 0/0, `tsgo --noEmit` clean, formatted.

## Not in this PR (ops follow-ups to fully clear the alert)
- `POSTGRES_REPLICA_US_URL` is unset in production (`"only 2 configured"`) even though the US-west replica is back and streaming — set it via `pnpm web:env set POSTGRES_REPLICA_US_URL`.
- `snowflake_connector_gfqyzuertw` slot is `lost` (pre-existing abandoned slot from July) — the monitor correctly flags it; drop the slot to resolve. Both are real signals, not regressions from this change.