### PR TITLE
fix(web): prevent invalid Unicode in API request logs

### DIFF
--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -11,6 +11,7 @@ import { db } from '@/lib/drizzle';
 import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
 import { errorExceptInTest, logExceptInTest } from '@/lib/utils.server';
 import { withRequestId } from '@/lib/ai-gateway/request-id';
+import { sanitizeJsonbValue } from '@/lib/sanitize-jsonb';
 import type { EventSourceMessage } from 'eventsource-parser';
 import { createParser } from 'eventsource-parser';
 import { after, NextResponse } from 'next/server';
@@ -109,9 +110,9 @@ async function createRequestLogCapture(
           status_code: status,
           model,
           provider,
-          request: request.body,
+          request: sanitizeJsonbValue(request.body),
           response: responseText,
-          error,
+          error: sanitizeJsonbValue(error),
         })
         .returning({ id: api_request_log.id });
       logExceptInTest(

--- a/apps/web/src/lib/sanitize-jsonb.test.ts
+++ b/apps/web/src/lib/sanitize-jsonb.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, test } from '@jest/globals';
+import { sanitizeJsonbValue } from './sanitize-jsonb';
+
+describe('sanitizeJsonbValue', () => {
+  test('replaces lone surrogates in nested values and object keys', () => {
+    const value = {
+      [`bad\ud800key`]: ['before\udc00after', { text: 'still\ud800broken' }],
+    };
+
+    expect(sanitizeJsonbValue(value)).toEqual({
+      ['bad\ufffdkey']: ['before\ufffdafter', { text: 'still\ufffdbroken' }],
+    });
+  });
+
+  test('preserves valid surrogate pairs and does not mutate the input', () => {
+    const value = { text: 'hello 😀' };
+
+    const sanitized = sanitizeJsonbValue(value);
+
+    expect(sanitized).toEqual(value);
+    expect(sanitized).not.toBe(value);
+  });
+});

--- a/apps/web/src/lib/sanitize-jsonb.test.ts
+++ b/apps/web/src/lib/sanitize-jsonb.test.ts
@@ -2,13 +2,15 @@ import { describe, expect, test } from '@jest/globals';
 import { sanitizeJsonbValue } from './sanitize-jsonb';
 
 describe('sanitizeJsonbValue', () => {
-  test('replaces lone surrogates in nested values and object keys', () => {
+  test('replaces JSONB-incompatible characters in nested values and object keys', () => {
     const value = {
       [`bad\ud800key`]: ['before\udc00after', { text: 'still\ud800broken' }],
+      [`nul\0key`]: 'nul\0value',
     };
 
     expect(sanitizeJsonbValue(value)).toEqual({
       ['bad\ufffdkey']: ['before\ufffdafter', { text: 'still\ufffdbroken' }],
+      ['nul\ufffdkey']: 'nul\ufffdvalue',
     });
   });
 

--- a/apps/web/src/lib/sanitize-jsonb.ts
+++ b/apps/web/src/lib/sanitize-jsonb.ts
@@ -1,0 +1,51 @@
+/**
+ * PostgreSQL JSONB rejects JSON strings containing escaped lone UTF-16
+ * surrogates. JavaScript can receive those values from JSON.parse, so repair
+ * them before sending values to a JSONB column.
+ */
+function replaceUnpairedSurrogates(value: string): string {
+  let result = '';
+  let changed = false;
+
+  for (let index = 0; index < value.length; index++) {
+    const code = value.charCodeAt(index);
+    if (code >= 0xd800 && code <= 0xdbff) {
+      const nextCode = value.charCodeAt(index + 1);
+      if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
+        result += value[index] + value[index + 1];
+        index++;
+      } else {
+        result += '\ufffd';
+        changed = true;
+      }
+    } else if (code >= 0xdc00 && code <= 0xdfff) {
+      result += '\ufffd';
+      changed = true;
+    } else {
+      result += value[index];
+    }
+  }
+
+  return changed ? result : value;
+}
+
+export function sanitizeJsonbValue(value: unknown): unknown {
+  if (typeof value === 'string') {
+    return replaceUnpairedSurrogates(value);
+  }
+
+  if (Array.isArray(value)) {
+    return value.map(sanitizeJsonbValue);
+  }
+
+  if (value !== null && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value).map(([key, nestedValue]) => [
+        replaceUnpairedSurrogates(key),
+        sanitizeJsonbValue(nestedValue),
+      ])
+    );
+  }
+
+  return value;
+}

--- a/apps/web/src/lib/sanitize-jsonb.ts
+++ b/apps/web/src/lib/sanitize-jsonb.ts
@@ -1,37 +1,19 @@
 /**
- * PostgreSQL JSONB rejects JSON strings containing escaped lone UTF-16
- * surrogates. JavaScript can receive those values from JSON.parse, so repair
- * them before sending values to a JSONB column.
+ * PostgreSQL JSONB rejects escaped NUL characters and lone UTF-16 surrogates.
+ * JavaScript strings can contain both, so repair them before sending values to
+ * a JSONB column.
  */
-function replaceUnpairedSurrogates(value: string): string {
-  let result = '';
-  let changed = false;
-
-  for (let index = 0; index < value.length; index++) {
-    const code = value.charCodeAt(index);
-    if (code >= 0xd800 && code <= 0xdbff) {
-      const nextCode = value.charCodeAt(index + 1);
-      if (nextCode >= 0xdc00 && nextCode <= 0xdfff) {
-        result += value[index] + value[index + 1];
-        index++;
-      } else {
-        result += '\ufffd';
-        changed = true;
-      }
-    } else if (code >= 0xdc00 && code <= 0xdfff) {
-      result += '\ufffd';
-      changed = true;
-    } else {
-      result += value[index];
-    }
+function sanitizeJsonbString(value: string): string {
+  if (value.isWellFormed() && !value.includes('\0')) {
+    return value;
   }
 
-  return changed ? result : value;
+  return value.toWellFormed().replaceAll('\0', '\ufffd');
 }
 
 export function sanitizeJsonbValue(value: unknown): unknown {
   if (typeof value === 'string') {
-    return replaceUnpairedSurrogates(value);
+    return sanitizeJsonbString(value);
   }
 
   if (Array.isArray(value)) {
@@ -41,7 +23,7 @@ export function sanitizeJsonbValue(value: unknown): unknown {
   if (value !== null && typeof value === 'object') {
     return Object.fromEntries(
       Object.entries(value).map(([key, nestedValue]) => [
-        replaceUnpairedSurrogates(key),
+        sanitizeJsonbString(key),
         sanitizeJsonbValue(nestedValue),
       ])
     );


### PR DESCRIPTION
## Summary
- repair lone UTF-16 surrogates and NUL characters before inserting JSONB request-log fields
- use native `String.prototype.isWellFormed()` and `toWellFormed()` with an allocation-free clean-string path
- preserve valid surrogate pairs and sanitize nested values and keys
- add regression coverage for PostgreSQL-incompatible Unicode payloads

## Verification
- `pnpm --filter web exec jest src/lib/rewriteModelResponse.test.ts src/lib/sanitize-jsonb.test.ts --runInBand --forceExit`
- `pnpm --filter web run typecheck`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/sanitize-jsonb.ts apps/web/src/lib/sanitize-jsonb.test.ts apps/web/src/lib/rewriteModelResponse.ts`
- `pnpm format`
- `git diff --check`