### PR TITLE
Align Enterprise SSO with other sign-in options and make Install Kilo Code more distinct

### DIFF
--- a/apps/web/src/components/auth/SignInForm.tsx
+++ b/apps/web/src/components/auth/SignInForm.tsx
@@ -335,14 +335,14 @@ export function SignInForm({
             <div className="border-border mt-8 flex flex-col items-center gap-3 border-t pt-6">
               <Link
                 href="/users/sign_in?sso=true"
-                className="text-muted-foreground hover:text-foreground inline-flex items-center gap-2 text-sm transition-colors"
+                className="w-full flex items-center justify-center gap-2 rounded-md border border-border bg-card px-4 py-2.5 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
               >
                 <SquareUserRound className="size-4" />
                 Enterprise SSO
               </Link>
               <Link
                 href="/get-started"
-                className="text-brand-primary text-sm font-medium underline-offset-4 hover:underline"
+                className="w-full mt-4 justify-center text-brand-primary text-sm font-medium underline-offset-4 hover:underline"
               >
                 Install Kilo Code
               </Link>

--- a/apps/web/src/components/auth/SignInForm.tsx
+++ b/apps/web/src/components/auth/SignInForm.tsx
@@ -335,14 +335,14 @@ export function SignInForm({
             <div className="border-border mt-8 flex flex-col items-center gap-3 border-t pt-6">
               <Link
                 href="/users/sign_in?sso=true"
-                className="w-full flex items-center justify-center gap-2 rounded-md border border-border bg-card px-4 py-2.5 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors"
+                className="w-full flex h-10 items-center justify-center rounded-md border border-border bg-card px-4 py-2.5 text-sm font-medium text-foreground hover:bg-accent hover:text-accent-foreground transition-colors focus-visible:ring-ring focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-offset-background focus-visible:outline-none [&_svg]:size-4 [&_svg]:shrink-0"
               >
                 <SquareUserRound className="size-4" />
                 Enterprise SSO
               </Link>
               <Link
                 href="/get-started"
-                className="w-full mt-4 justify-center text-brand-primary text-sm font-medium underline-offset-4 hover:underline"
+                className="mt-4 text-center text-brand-primary text-sm font-medium underline-offset-4 hover:underline"
               >
                 Install Kilo Code
               </Link>


### PR DESCRIPTION
Visual fix so that the Enterprise SSO option is more closely aligned with the other sign in options, and the 'Install Kilo Code' option is more distinct.

| Before | After |
|--------|--------|
| <img width="822" height="1522" alt="CleanShot 2026-07-31 at 11 41 15@2x" src="https://github.com/user-attachments/assets/64e8fd33-b36f-4976-9c25-6e6410ee4c90" /> | <img width="876" height="1630" alt="CleanShot 2026-07-31 at 11 40 35@2x" src="https://github.com/user-attachments/assets/81b098b9-f832-41c5-8728-ba9dc5df9939" /> | 