### PR TITLE
feat(mobile): greet signed-in Home with "Good {period}, {name}"

### DIFF
--- a/apps/mobile/e2e/flows/login-assert-home.js
+++ b/apps/mobile/e2e/flows/login-assert-home.js
@@ -2,5 +2,5 @@
 module.exports = async function assertHome(ctx) {
   const { h } = ctx;
   await h.tapOn('HOME|Home, tab, 1 of 4');
-  await h.assertVisible(/Good (morning|afternoon|evening)/);
+  await h.assertVisible(/Good (morning|afternoon|evening)(, .+)?/);
 };

--- a/apps/mobile/src/components/home/greeting.test.ts
+++ b/apps/mobile/src/components/home/greeting.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+import { buildTimedGreeting } from '@/components/home/greeting';
+
+describe('buildTimedGreeting', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  describe('time-of-day buckets', () => {
+    test('09:00 → Good morning', () => {
+      vi.setSystemTime(new Date('2026-07-31T09:00:00'));
+      expect(buildTimedGreeting('Ada')).toBe('Good morning, Ada');
+      expect(buildTimedGreeting()).toBe('Good morning');
+    });
+
+    test('14:00 → Good afternoon', () => {
+      vi.setSystemTime(new Date('2026-07-31T14:00:00'));
+      expect(buildTimedGreeting('Ada')).toBe('Good afternoon, Ada');
+      expect(buildTimedGreeting()).toBe('Good afternoon');
+    });
+
+    test('20:00 → Good evening', () => {
+      vi.setSystemTime(new Date('2026-07-31T20:00:00'));
+      expect(buildTimedGreeting('Ada')).toBe('Good evening, Ada');
+      expect(buildTimedGreeting()).toBe('Good evening');
+    });
+  });
+
+  describe('name handling at 09:00', () => {
+    beforeEach(() => {
+      vi.setSystemTime(new Date('2026-07-31T09:00:00'));
+    });
+
+    test('first token only of a multi-word name', () => {
+      expect(buildTimedGreeting('Ada Lovelace')).toBe('Good morning, Ada');
+    });
+
+    test('single name is used as-is', () => {
+      expect(buildTimedGreeting('Ada')).toBe('Good morning, Ada');
+    });
+
+    test('no name → "Good morning" with no trailing comma/space', () => {
+      expect(buildTimedGreeting()).toBe('Good morning');
+      expect(buildTimedGreeting(null)).toBe('Good morning');
+      expect(buildTimedGreeting('')).toBe('Good morning');
+      expect(buildTimedGreeting('   ')).toBe('Good morning');
+    });
+  });
+});

--- a/apps/mobile/src/components/home/greeting.tsx
+++ b/apps/mobile/src/components/home/greeting.tsx
@@ -8,7 +8,8 @@ function timeOfDay(hour: number): 'morning' | 'afternoon' | 'evening' {
   return 'evening';
 }
 
-export function buildTimedGreeting(): string {
+export function buildTimedGreeting(displayName?: string | null): string {
   const period = timeOfDay(new Date().getHours());
-  return `Good ${period}`;
+  const firstName = displayName?.trim().split(/\s+/)[0] ?? '';
+  return firstName ? `Good ${period}, ${firstName}` : `Good ${period}`;
 }

--- a/apps/mobile/src/components/home/home-screen.tsx
+++ b/apps/mobile/src/components/home/home-screen.tsx
@@ -24,6 +24,7 @@ import { ScreenHeader } from '@/components/screen-header';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useAgentSessions } from '@/lib/hooks/use-agent-sessions';
 import { type ClawInstance, useAllKiloClawInstances } from '@/lib/hooks/use-instance-context';
+import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import { useUnreadCounts } from '@/lib/hooks/use-unread-counts';
 import { useOrganization } from '@/lib/organization-context';
 import { useTRPC } from '@/lib/trpc';
@@ -106,7 +107,8 @@ export function HomeScreen() {
   // stored + any active), so a CLI-only account shows the first-use promo
   // instead of an empty section + orphaned "New coding task" button.
   const hasAnySession = hasDisplayableAgentSessions(storedSessions, activeSessions);
-  const headerTitle = buildTimedGreeting();
+  const { displayName } = useCurrentUserId();
+  const headerTitle = buildTimedGreeting(displayName);
 
   const handleRefresh = useCallback(() => {
     void (async () => {

--- a/apps/mobile/src/lib/hooks/use-current-user-id.ts
+++ b/apps/mobile/src/lib/hooks/use-current-user-id.ts
@@ -9,6 +9,7 @@ type UseCurrentUserIdOptions = {
 export function useCurrentUserId(options: UseCurrentUserIdOptions = {}): {
   userId: string | undefined;
   email: string | undefined;
+  displayName: string | null | undefined;
   isLoading: boolean;
   isError: boolean;
   refetch: () => void;
@@ -22,6 +23,7 @@ export function useCurrentUserId(options: UseCurrentUserIdOptions = {}): {
   return {
     userId: data?.id,
     email: data?.email,
+    displayName: data?.displayName,
     isLoading,
     isError,
     refetch: () => {

--- a/apps/web/src/lib/user/display-name.test.ts
+++ b/apps/web/src/lib/user/display-name.test.ts
@@ -1,0 +1,29 @@
+import { describe, test, expect } from '@jest/globals';
+
+import { resolveDisplayName } from '@/lib/user/display-name';
+
+describe('resolveDisplayName', () => {
+  test('returns google_user_name when no providers are present', () => {
+    expect(resolveDisplayName([], 'Ada')).toBe('Ada');
+  });
+
+  test('returns google_user_name when every provider has a null display_name', () => {
+    const providers = [{ display_name: null }, { display_name: null }];
+    expect(resolveDisplayName(providers, 'Ada')).toBe('Ada');
+  });
+
+  test('returns the newest non-null provider display_name (providers ordered ASC)', () => {
+    const providers = [{ display_name: 'Old' }, { display_name: null }, { display_name: 'New' }];
+    expect(resolveDisplayName(providers, 'Ignored')).toBe('New');
+  });
+
+  test('a trailing null provider does not beat an older non-null one', () => {
+    const providers = [{ display_name: 'Ada' }, { display_name: null }];
+    expect(resolveDisplayName(providers, 'Fallback')).toBe('Ada');
+  });
+
+  test('empty-string provider display_name passes through; null google_user_name returns null', () => {
+    expect(resolveDisplayName([{ display_name: '' }], 'Google')).toBe('');
+    expect(resolveDisplayName([], null)).toBeNull();
+  });
+});

--- a/apps/web/src/lib/user/display-name.ts
+++ b/apps/web/src/lib/user/display-name.ts
@@ -1,0 +1,17 @@
+/**
+ * Single-user display-name resolution, mirroring kilo-chat's
+ * resolveUserDisplayInfo (services/kilo-chat/src/services/user-lookup.ts):
+ * the most recent auth-provider row with a non-null display_name wins;
+ * otherwise google_user_name; otherwise null.
+ *
+ * `providers` must be ordered by created_at ASC (getUserAuthProviders'
+ * existing order). Empty strings pass through unchanged (kilo-chat parity);
+ * the mobile greeting treats empty/whitespace as missing.
+ */
+export function resolveDisplayName(
+  providers: ReadonlyArray<{ display_name: string | null }>,
+  googleUserName: string | null
+): string | null {
+  const providerName = [...providers].reverse().find(p => p.display_name != null)?.display_name;
+  return providerName ?? googleUserName ?? null;
+}

--- a/apps/web/src/routers/user-router.ts
+++ b/apps/web/src/routers/user-router.ts
@@ -1,4 +1,5 @@
 import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { resolveDisplayName } from '@/lib/user/display-name';
 import { getUserAuthProviders, unlinkAuthProviderFromUser } from '@/lib/user';
 import {
   sendAccountDeletionConfirmationEmail,
@@ -334,7 +335,9 @@ async function enrichDeductionsWithInstanceNames(
 export const userRouter = createTRPCRouter({
   // Account linking routes
   getMe: baseProcedure.query(async ({ ctx }) => {
-    return successResult({ id: ctx.user.id, email: ctx.user.google_user_email });
+    const providers = await getUserAuthProviders(ctx.user.id);
+    const displayName = resolveDisplayName(providers, ctx.user.google_user_name);
+    return successResult({ id: ctx.user.id, email: ctx.user.google_user_email, displayName });
   }),
 
   getAuthProviders: baseProcedure.query(async ({ ctx }) => {


### PR DESCRIPTION
## Summary

Signed-in mobile Home header now greets by first name when one is available.

**What:** `user.getMe` returns a resolved `displayName` (newest non-null auth-provider `display_name`, else `google_user_name`). The mobile Home header uses the first whitespace token: `Good {morning|afternoon|evening}, {firstName}`. Missing/empty/whitespace name keeps the previous copy `Good {period}` with no trailing comma.

**Why:** Personalize the Home header without a profile-edit surface or email-derived names at greeting time.

**How:** Small pure helper next to the web user router (unit-tested); additive field on the existing mobile `useCurrentUserId` hook; greeting helper extracts the first token. No schema/migration, no new packages, no ScreenHeader redesign.

## Verification

- [x] Web unit: `pnpm --filter web test -- --testPathPattern user/display-name` (5/5)
- [x] Mobile: format, typecheck, lint, check:unused, test (2514/2514)
- [x] Root `pnpm typecheck` and `pnpm lint`
- [x] iOS E2E greeting gate: login → named header `Good afternoon, e2e-mobile-home-greeting-name-32f2-ios` (hierarchy + Appium); `login-assert-home.js` optional-`, Name` regex also FLOW OK

## Visual Changes

| Before | After |
|---|---|
| `Good {morning\|afternoon\|evening}` (exact header copy, no name) | ![ios-home-greeting-header.png](https://github.com/user-attachments/assets/9d73aa8b-ebfe-4e70-9d6c-ba27fbf8bc80) |

## Reviewer Notes

- `home-screen.test.ts` intentionally untouched: the suite never mounts `HomeScreen` (string-only), and the new hook import is side-effect-free.
- `login-assert-home.js` is an orphan flow (not wired into `login.sh`); the E2E gate runs it explicitly alongside the named-header artifact flow.
- Human reviewers requested from file history: `jeanduplessis`, `pandemicsyn`.
- E2E happy path uses the default worktree email user's real `google_user_name` (set by the native email sign-in path from the local part) — product data, not a fixture hack. No-name fallback is unit-covered.