### PR TITLE
fix(ai-gateway): exclude Laguna from Vercel routing

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -5,9 +5,27 @@ import {
   getVercelInferenceProvidersExcludingIgnored,
   hasCompatibleVercelInferenceProvider,
   passesVercelRoutingPercentage,
+  shouldRouteToVercel,
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+
+describe('shouldRouteToVercel', () => {
+  it.each(['poolside/laguna-s-2.1', 'poolside/laguna-s-2.1:free'])(
+    'does not randomly route %s to Vercel',
+    async model => {
+      const request: GatewayRequest = {
+        kind: 'chat_completions',
+        body: {
+          model,
+          messages: [{ role: 'user', content: 'hello' }],
+        },
+      };
+
+      await expect(shouldRouteToVercel(model, request, 'seed')).resolves.toBe(false);
+    }
+  );
+});
 
 describe('getAnthropicProviderOptionsForVercel', () => {
   it('maps chat completion verbosity to Anthropic effort', () => {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -5,27 +5,9 @@ import {
   getVercelInferenceProvidersExcludingIgnored,
   hasCompatibleVercelInferenceProvider,
   passesVercelRoutingPercentage,
-  shouldRouteToVercel,
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
-
-describe('shouldRouteToVercel', () => {
-  it.each(['poolside/laguna-s-2.1', 'poolside/laguna-s-2.1:free'])(
-    'does not randomly route %s to Vercel',
-    async model => {
-      const request: GatewayRequest = {
-        kind: 'chat_completions',
-        body: {
-          model,
-          messages: [{ role: 'user', content: 'hello' }],
-        },
-      };
-
-      await expect(shouldRouteToVercel(model, request, 'seed')).resolves.toBe(false);
-    }
-  );
-});
 
 describe('getAnthropicProviderOptionsForVercel', () => {
   it('maps chat completion verbosity to Anthropic effort', () => {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -95,6 +95,11 @@ export async function shouldRouteToVercel(
   request: GatewayRequest,
   randomSeed: string
 ) {
+  // BYOK in the Vercel AI Gateway was not working for Laguna models.
+  if (requestedModel.startsWith('poolside/laguna-')) {
+    return false;
+  }
+
   if (isOpenRouterGpt56PromoModel(requestedModel)) {
     console.debug(
       `[shouldRouteToVercel] routing ${requestedModel} to OpenRouter for the GPT-5.6 promotion`

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -96,7 +96,7 @@ export async function shouldRouteToVercel(
   randomSeed: string
 ) {
   // BYOK in the Vercel AI Gateway was not working for Laguna models.
-  if (requestedModel.startsWith('poolside/laguna-')) {
+  if (requestedModel.includes('laguna')) {
     return false;
   }
 


### PR DESCRIPTION
## Summary
- keep models containing `laguna` out of random Vercel AI Gateway routing
- document the Vercel BYOK compatibility issue

## Verification
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/vercel/index.ts apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts`
- `git diff --check`