### PR TITLE
refactor(ai-gateway): move free model limits to Redis

### DIFF
--- a/apps/web/src/app/admin/components/RateLimitTesting.tsx
+++ b/apps/web/src/app/admin/components/RateLimitTesting.tsx
@@ -22,7 +22,7 @@ export function RateLimitTesting() {
           });
         } else {
           toast.success(
-            `Inserted ${data.rowsInserted} rows for IP ${data.ipAddress}. New total: ${data.newTotal}.`
+            `Added ${data.requestsAdded} requests for IP ${data.ipAddress}. New total: ${data.newTotal}.`
           );
         }
         void queryClient.invalidateQueries({
@@ -42,7 +42,7 @@ export function RateLimitTesting() {
       <CardHeader>
         <CardTitle>Rate Limit Testing</CardTitle>
         <CardDescription>
-          Insert enough requests to trigger the free model rate limit for your current IP address.
+          Add enough requests to trigger the free model rate limit for your current IP address.
         </CardDescription>
       </CardHeader>
       <CardContent className="space-y-4">
@@ -85,10 +85,10 @@ export function RateLimitTesting() {
               variant={data.isRateLimited ? 'outline' : 'default'}
             >
               {rateLimitMutation.isPending
-                ? 'Inserting rows...'
+                ? 'Adding requests...'
                 : data.isRateLimited
                   ? 'Already Rate Limited'
-                  : `Rate Limit My IP (insert ${data.limit - data.currentUsage} rows)`}
+                  : `Rate Limit My IP (add ${data.limit - data.currentUsage} requests)`}
             </Button>
           </>
         )}

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -22,7 +22,7 @@ import { buildExperimentPromptCapture } from '@/lib/ai-gateway/experiments/persi
 import { isPublicIdExperimented } from '@/lib/ai-gateway/experiments/membership';
 import { upstreamRequest } from '@/lib/ai-gateway/providers/upstream-request';
 import { debugSaveProxyRequest } from '@/lib/debugUtils';
-import { setTag, startInactiveSpan } from '@sentry/nextjs';
+import { captureException, setTag, startInactiveSpan } from '@sentry/nextjs';
 import { getUserFromAuth } from '@/lib/user/server';
 import { sentryRootSpan } from '@/lib/getRootSpan';
 import { isDeadFreeModel, isKiloExclusiveFreeModel } from '@/lib/ai-gateway/models';
@@ -66,6 +66,7 @@ import {
   consumeFreeModelRateLimitByUser,
   consumePromotionLimit,
 } from '@/lib/free-model-rate-limiter';
+import { logFreeModelUsage } from '@/lib/free-model-usage';
 import { PROMOTION_MAX_REQUESTS, PROMOTION_WINDOW_HOURS } from '@/lib/constants';
 import {
   classifyAbuse,
@@ -544,6 +545,20 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     (requestBodyParsed.body.store || requestBodyParsed.body.previous_response_id)
   ) {
     return storeAndPreviousResponseIdIsNotSupported();
+  }
+
+  if (isRateLimitedFreeModelRequest) {
+    after(async () => {
+      try {
+        await logFreeModelUsage(
+          ipAddress,
+          effectiveModelIdLowerCased,
+          isAnonymousContext(user) ? undefined : user.id
+        );
+      } catch (error) {
+        captureException(error, { tags: { source: 'free_model_usage' } });
+      }
+    });
   }
 
   // Resolve the initial provider before abuse enforcement because abuse needs

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -3,12 +3,7 @@ import { type NextRequest } from 'next/server';
 import { stripRequiredPrefix, toMicrodollars } from '@/lib/utils';
 import { extractPromptInfo } from '@/lib/ai-gateway/extractPromptInfo';
 import { determineFallbackFeature } from '@/lib/ai-gateway/determineFallbackFeature';
-import {
-  validateFeatureHeader,
-  FEATURE_HEADER,
-  isUserRateLimitedFeature,
-  type FeatureValue,
-} from '@/lib/feature-detection';
+import { validateFeatureHeader, FEATURE_HEADER } from '@/lib/feature-detection';
 import type {
   OpenRouterChatCompletionRequest,
   GatewayResponsesRequest,
@@ -22,7 +17,7 @@ import { buildExperimentPromptCapture } from '@/lib/ai-gateway/experiments/persi
 import { isPublicIdExperimented } from '@/lib/ai-gateway/experiments/membership';
 import { upstreamRequest } from '@/lib/ai-gateway/providers/upstream-request';
 import { debugSaveProxyRequest } from '@/lib/debugUtils';
-import { captureException, setTag, startInactiveSpan } from '@sentry/nextjs';
+import { setTag, startInactiveSpan } from '@sentry/nextjs';
 import { getUserFromAuth } from '@/lib/user/server';
 import { sentryRootSpan } from '@/lib/getRootSpan';
 import { isDeadFreeModel, isKiloExclusiveFreeModel } from '@/lib/ai-gateway/models';
@@ -61,15 +56,8 @@ import {
   isAnonymousContext,
   type AnonymousUserContext,
 } from '@/lib/anonymous';
-import {
-  checkPromotionLimit,
-  consumeAnonymousFreeModelRateLimits,
-  consumeFreeModelRateLimit,
-  consumeFreeModelRateLimitByUser,
-  type RateLimitResult,
-} from '@/lib/free-model-rate-limiter';
-import { logFreeModelUsage } from '@/lib/free-model-usage';
-import { PROMOTION_MAX_REQUESTS, PROMOTION_WINDOW_HOURS } from '@/lib/constants';
+import { enforceFreeModelRateLimits } from '@/lib/ai-gateway/free-model-rate-limit-enforcement';
+import { scheduleFreeModelUsageLog } from '@/lib/free-model-usage';
 import {
   classifyAbuse,
   awaitClassifyAbuse,
@@ -88,7 +76,6 @@ import {
 } from '@/lib/ai-gateway/o11y/api-metrics.server';
 import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 import { isForbiddenFreeModel } from '@/lib/ai-gateway/forbidden-free-models';
-import { isCloudflareIP } from '@/lib/cloudflare-ip';
 import {
   isKiloAutoModel,
   KILO_AUTO_FREE_MODEL,
@@ -114,7 +101,6 @@ export const maxDuration = 1800;
 const MAX_TOKENS_LIMIT = 99999999999; // GPT4.1 default is ~32k
 
 const PAID_MODEL_AUTH_REQUIRED = 'PAID_MODEL_AUTH_REQUIRED';
-const PROMOTION_MODEL_LIMIT_REACHED = 'PROMOTION_MODEL_LIMIT_REACHED';
 
 function validatePath(
   url: URL
@@ -135,36 +121,6 @@ function validatePath(
     return { path: pathSuffix };
   }
   return { errorResponse: invalidPathResponse() };
-}
-
-async function resolveRateLimit(
-  feature: FeatureValue | null,
-  ipAddress: string,
-  authPromise: Promise<{ user: { id: string } | null }>
-): Promise<
-  | NextResponseType<unknown>
-  | { result: { allowed: boolean; requestCount: number }; subject: string }
-> {
-  if (isUserRateLimitedFeature(feature) && isCloudflareIP(ipAddress)) {
-    const { user } = await authPromise;
-    if (!user) {
-      return NextResponse.json(
-        {
-          error: 'Authentication required for this feature',
-          error_type: ProxyErrorType.authentication_required,
-        },
-        { status: 401 }
-      );
-    }
-    return {
-      result: await consumeFreeModelRateLimitByUser(user.id),
-      subject: `user: ${user.id}`,
-    };
-  }
-  return {
-    result: await consumeFreeModelRateLimit(ipAddress),
-    subject: `ip address: ${ipAddress}`,
-  };
 }
 
 export async function POST(request: NextRequest): Promise<NextResponseType<unknown>> {
@@ -503,76 +459,21 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     return storeAndPreviousResponseIdIsNotSupported();
   }
 
-  let freeModelRateLimit: { result: RateLimitResult; subject: string } | null = null;
-  let promotionLimit: RateLimitResult | null = null;
-
-  if (
-    isRateLimitedFreeModelRequest &&
-    (!isAnonymousContext(user) || (isUserRateLimitedFeature(feature) && isCloudflareIP(ipAddress)))
-  ) {
-    const rateLimit = await resolveRateLimit(feature, ipAddress, authPromise);
-    if (rateLimit instanceof NextResponse) return rateLimit;
-    freeModelRateLimit = rateLimit;
-  } else if (isAnonymousContext(user)) {
-    if (isRateLimitedFreeModelRequest) {
-      const anonymousLimits = await consumeAnonymousFreeModelRateLimits(ipAddress);
-      freeModelRateLimit = {
-        result: anonymousLimits.freeModel,
-        subject: `ip address: ${ipAddress}`,
-      };
-      promotionLimit = anonymousLimits.promotion;
-    } else {
-      promotionLimit = await checkPromotionLimit(ipAddress);
-    }
-  }
-
-  if (freeModelRateLimit && !freeModelRateLimit.result.allowed) {
-    console.warn(
-      `Free model rate limit exceeded, ${freeModelRateLimit.subject}, model: ${effectiveModelIdLowerCased}, request count: ${freeModelRateLimit.result.requestCount}`
-    );
-    return NextResponse.json(
-      {
-        error: 'Rate limit exceeded',
-        error_type: ProxyErrorType.rate_limit_exceeded,
-        message:
-          'Free model usage limit reached. Please try again later or upgrade to a paid model.',
-      },
-      { status: 429 }
-    );
-  }
-
-  if (promotionLimit && !promotionLimit.allowed) {
-    console.warn(
-      `Promotion model limit exceeded, ip: ${ipAddress}, ` +
-        `model: ${effectiveModelIdLowerCased}, ` +
-        `requests: ${promotionLimit.requestCount}/${PROMOTION_MAX_REQUESTS} ` +
-        `in ${PROMOTION_WINDOW_HOURS}h window`
-    );
-
-    return NextResponse.json(
-      {
-        error: {
-          code: PROMOTION_MODEL_LIMIT_REACHED,
-          message:
-            'Sign up for free to continue and explore 500 other models. ' +
-            'Takes 2 minutes, no credit card required. Or come back later.',
-        },
-        error_type: ProxyErrorType.promotion_limit_reached,
-      },
-      { status: 401 } // TODO: Change to 429 once the extension supports it (see kilocode errorUtils.ts)
-    );
-  }
+  const freeModelRateLimitResponse = await enforceFreeModelRateLimits({
+    feature,
+    ipAddress,
+    isRateLimitedFreeModel: isRateLimitedFreeModelRequest,
+    model: effectiveModelIdLowerCased,
+    user,
+  });
+  if (freeModelRateLimitResponse) return freeModelRateLimitResponse;
 
   if (isRateLimitedFreeModelRequest) {
-    const loggedModelId = effectiveModelIdLowerCased;
-    const loggedKiloUserId = isAnonymousContext(user) ? undefined : user.id;
-    after(async () => {
-      try {
-        await logFreeModelUsage(ipAddress, loggedModelId, loggedKiloUserId);
-      } catch (error) {
-        captureException(error, { tags: { source: 'free_model_usage' } });
-      }
-    });
+    scheduleFreeModelUsageLog(
+      ipAddress,
+      effectiveModelIdLowerCased,
+      isAnonymousContext(user) ? undefined : user.id
+    );
   }
 
   // Resolve the initial provider before abuse enforcement because abuse needs

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -62,10 +62,9 @@ import {
   type AnonymousUserContext,
 } from '@/lib/anonymous';
 import {
-  checkFreeModelRateLimit,
-  checkFreeModelRateLimitByUser,
-  logFreeModelRequest,
-  checkPromotionLimit,
+  consumeFreeModelRateLimit,
+  consumeFreeModelRateLimitByUser,
+  consumePromotionLimit,
 } from '@/lib/free-model-rate-limiter';
 import { PROMOTION_MAX_REQUESTS, PROMOTION_WINDOW_HOURS } from '@/lib/constants';
 import {
@@ -155,12 +154,12 @@ async function resolveRateLimit(
       );
     }
     return {
-      result: await checkFreeModelRateLimitByUser(user.id),
+      result: await consumeFreeModelRateLimitByUser(user.id),
       subject: `user: ${user.id}`,
     };
   }
   return {
-    result: await checkFreeModelRateLimit(ipAddress),
+    result: await consumeFreeModelRateLimit(ipAddress),
     subject: `ip address: ${ipAddress}`,
   };
 }
@@ -422,7 +421,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       );
     }
 
-    const promotionLimit = await checkPromotionLimit(ipAddress);
+    const promotionLimit = await consumePromotionLimit(ipAddress);
 
     if (!promotionLimit.allowed) {
       console.warn(
@@ -545,15 +544,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     (requestBodyParsed.body.store || requestBodyParsed.body.previous_response_id)
   ) {
     return storeAndPreviousResponseIdIsNotSupported();
-  }
-
-  // Log to free_model_usage for rate limiting (at request start, before processing)
-  if (isRateLimitedFreeModelRequest) {
-    await logFreeModelRequest(
-      ipAddress,
-      effectiveModelIdLowerCased,
-      isAnonymousContext(user) ? undefined : user.id
-    );
   }
 
   // Resolve the initial provider before abuse enforcement because abuse needs

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -62,9 +62,11 @@ import {
   type AnonymousUserContext,
 } from '@/lib/anonymous';
 import {
+  checkPromotionLimit,
+  consumeAnonymousFreeModelRateLimits,
   consumeFreeModelRateLimit,
   consumeFreeModelRateLimitByUser,
-  consumePromotionLimit,
+  type RateLimitResult,
 } from '@/lib/free-model-rate-limiter';
 import { logFreeModelUsage } from '@/lib/free-model-usage';
 import { PROMOTION_MAX_REQUESTS, PROMOTION_WINDOW_HOURS } from '@/lib/constants';
@@ -361,35 +363,13 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     );
   }
 
-  // For FREE models: check rate limit, log at start.
-  // Server-side products (cloud-agent, code-review, app-builder) rate-limit
-  // per user when the request comes from Cloudflare IPs (Kilo infrastructure).
-  // All other products rate-limit per IP (fast pre-auth path).
+  // Server-side products (cloud-agent, code-review, app-builder) rate-limit per
+  // user when the request comes from Cloudflare IPs. All other products use IPs.
   const isRateLimitedFreeModelRequest =
     isKiloExclusiveFreeModel(effectiveModelIdLowerCased) ||
     autoModel === KILO_AUTO_FREE_MODEL.id ||
     routingTarget === KILO_AUTO_FREE_MODEL.id ||
     (await isPublicIdExperimented(effectiveModelIdLowerCased));
-  if (isRateLimitedFreeModelRequest) {
-    const rateLimit = await resolveRateLimit(feature, ipAddress, authPromise);
-    if (rateLimit instanceof NextResponse) return rateLimit;
-
-    if (!rateLimit.result.allowed) {
-      console.warn(
-        `Free model rate limit exceeded, ${rateLimit.subject}, model: ${effectiveModelIdLowerCased}, request count: ${rateLimit.result.requestCount}`
-      );
-      return NextResponse.json(
-        {
-          error: 'Rate limit exceeded',
-          error_type: ProxyErrorType.rate_limit_exceeded,
-          message:
-            'Free model usage limit reached. Please try again later or upgrade to a paid model.',
-        },
-        { status: 429 }
-      );
-    }
-  }
-
   // Now check auth
   const authSpan = startInactiveSpan({ name: 'auth-check' });
   const {
@@ -422,31 +402,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       );
     }
 
-    const promotionLimit = await consumePromotionLimit(ipAddress);
-
-    if (!promotionLimit.allowed) {
-      console.warn(
-        `Promotion model limit exceeded, ip: ${ipAddress}, ` +
-          `model: ${effectiveModelIdLowerCased}, ` +
-          `requests: ${promotionLimit.requestCount}/${PROMOTION_MAX_REQUESTS} ` +
-          `in ${PROMOTION_WINDOW_HOURS}h window`
-      );
-
-      return NextResponse.json(
-        {
-          error: {
-            code: PROMOTION_MODEL_LIMIT_REACHED,
-            message:
-              'Sign up for free to continue and explore 500 other models. ' +
-              'Takes 2 minutes, no credit card required. Or come back later.',
-          },
-          error_type: ProxyErrorType.promotion_limit_reached,
-        },
-        { status: 401 } // TODO: Change to 429 once the extension supports it (see kilocode errorUtils.ts)
-      );
-    }
-
-    // Anonymous access for free model (already rate-limited above)
+    // Anonymous access for free models is rate-limited after request validation.
     user = createAnonymousContext(ipAddress);
     organizationId = undefined;
     botId = undefined;
@@ -547,14 +503,72 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     return storeAndPreviousResponseIdIsNotSupported();
   }
 
+  let freeModelRateLimit: { result: RateLimitResult; subject: string } | null = null;
+  let promotionLimit: RateLimitResult | null = null;
+
+  if (
+    isRateLimitedFreeModelRequest &&
+    (!isAnonymousContext(user) || (isUserRateLimitedFeature(feature) && isCloudflareIP(ipAddress)))
+  ) {
+    const rateLimit = await resolveRateLimit(feature, ipAddress, authPromise);
+    if (rateLimit instanceof NextResponse) return rateLimit;
+    freeModelRateLimit = rateLimit;
+  } else if (isAnonymousContext(user)) {
+    if (isRateLimitedFreeModelRequest) {
+      const anonymousLimits = await consumeAnonymousFreeModelRateLimits(ipAddress);
+      freeModelRateLimit = {
+        result: anonymousLimits.freeModel,
+        subject: `ip address: ${ipAddress}`,
+      };
+      promotionLimit = anonymousLimits.promotion;
+    } else {
+      promotionLimit = await checkPromotionLimit(ipAddress);
+    }
+  }
+
+  if (freeModelRateLimit && !freeModelRateLimit.result.allowed) {
+    console.warn(
+      `Free model rate limit exceeded, ${freeModelRateLimit.subject}, model: ${effectiveModelIdLowerCased}, request count: ${freeModelRateLimit.result.requestCount}`
+    );
+    return NextResponse.json(
+      {
+        error: 'Rate limit exceeded',
+        error_type: ProxyErrorType.rate_limit_exceeded,
+        message:
+          'Free model usage limit reached. Please try again later or upgrade to a paid model.',
+      },
+      { status: 429 }
+    );
+  }
+
+  if (promotionLimit && !promotionLimit.allowed) {
+    console.warn(
+      `Promotion model limit exceeded, ip: ${ipAddress}, ` +
+        `model: ${effectiveModelIdLowerCased}, ` +
+        `requests: ${promotionLimit.requestCount}/${PROMOTION_MAX_REQUESTS} ` +
+        `in ${PROMOTION_WINDOW_HOURS}h window`
+    );
+
+    return NextResponse.json(
+      {
+        error: {
+          code: PROMOTION_MODEL_LIMIT_REACHED,
+          message:
+            'Sign up for free to continue and explore 500 other models. ' +
+            'Takes 2 minutes, no credit card required. Or come back later.',
+        },
+        error_type: ProxyErrorType.promotion_limit_reached,
+      },
+      { status: 401 } // TODO: Change to 429 once the extension supports it (see kilocode errorUtils.ts)
+    );
+  }
+
   if (isRateLimitedFreeModelRequest) {
+    const loggedModelId = effectiveModelIdLowerCased;
+    const loggedKiloUserId = isAnonymousContext(user) ? undefined : user.id;
     after(async () => {
       try {
-        await logFreeModelUsage(
-          ipAddress,
-          effectiveModelIdLowerCased,
-          isAnonymousContext(user) ? undefined : user.id
-        );
+        await logFreeModelUsage(ipAddress, loggedModelId, loggedKiloUserId);
       } catch (error) {
         captureException(error, { tags: { source: 'free_model_usage' } });
       }

--- a/apps/web/src/lib/ai-gateway/free-model-rate-limit-enforcement.test.ts
+++ b/apps/web/src/lib/ai-gateway/free-model-rate-limit-enforcement.test.ts
@@ -1,0 +1,154 @@
+import { afterAll, beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import { createAnonymousContext } from '@/lib/anonymous';
+import type * as EnforcementModule from './free-model-rate-limit-enforcement';
+
+type RateLimitResult = { allowed: boolean; requestCount: number };
+type ConsumeRateLimit = (subject: string) => Promise<RateLimitResult>;
+type ConsumeAnonymousRateLimits = (ipAddress: string) => Promise<{
+  freeModel: RateLimitResult;
+  promotion: RateLimitResult;
+}>;
+
+const mockCheckPromotionLimit = jest.fn<ConsumeRateLimit>();
+const mockConsumeAnonymousRateLimits = jest.fn<ConsumeAnonymousRateLimits>();
+const mockConsumeIpRateLimit = jest.fn<ConsumeRateLimit>();
+const mockConsumeUserRateLimit = jest.fn<ConsumeRateLimit>();
+const mockIsCloudflareIp = jest.fn<(ipAddress: string) => boolean>();
+
+jest.mock('@/lib/free-model-rate-limiter', () => ({
+  checkPromotionLimit: mockCheckPromotionLimit,
+  consumeAnonymousFreeModelRateLimits: mockConsumeAnonymousRateLimits,
+  consumeFreeModelRateLimit: mockConsumeIpRateLimit,
+  consumeFreeModelRateLimitByUser: mockConsumeUserRateLimit,
+}));
+
+jest.mock('@/lib/cloudflare-ip', () => ({
+  isCloudflareIP: mockIsCloudflareIp,
+}));
+
+let enforceFreeModelRateLimits: typeof EnforcementModule.enforceFreeModelRateLimits;
+const consoleWarnSpy = jest.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+describe('free model rate limit enforcement', () => {
+  beforeAll(async () => {
+    ({ enforceFreeModelRateLimits } = await import('./free-model-rate-limit-enforcement'));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockIsCloudflareIp.mockReturnValue(false);
+    mockCheckPromotionLimit.mockResolvedValue({ allowed: true, requestCount: 0 });
+    mockConsumeAnonymousRateLimits.mockResolvedValue({
+      freeModel: { allowed: true, requestCount: 1 },
+      promotion: { allowed: true, requestCount: 1 },
+    });
+    mockConsumeIpRateLimit.mockResolvedValue({ allowed: true, requestCount: 1 });
+    mockConsumeUserRateLimit.mockResolvedValue({ allowed: true, requestCount: 1 });
+  });
+
+  afterAll(() => {
+    consoleWarnSpy.mockRestore();
+  });
+
+  it('consumes both limits for an anonymous Kilo free-model request', async () => {
+    const response = await enforceFreeModelRateLimits({
+      feature: 'vscode-extension',
+      ipAddress: '192.0.2.1',
+      isRateLimitedFreeModel: true,
+      model: 'kilo/free-model',
+      user: createAnonymousContext('192.0.2.1'),
+    });
+
+    expect(response).toBeNull();
+    expect(mockConsumeAnonymousRateLimits).toHaveBeenCalledWith('192.0.2.1');
+    expect(mockCheckPromotionLimit).not.toHaveBeenCalled();
+  });
+
+  it('only checks promotion usage for an anonymous third-party free model', async () => {
+    const response = await enforceFreeModelRateLimits({
+      feature: 'vscode-extension',
+      ipAddress: '192.0.2.1',
+      isRateLimitedFreeModel: false,
+      model: 'provider/free-model',
+      user: createAnonymousContext('192.0.2.1'),
+    });
+
+    expect(response).toBeNull();
+    expect(mockCheckPromotionLimit).toHaveBeenCalledWith('192.0.2.1');
+    expect(mockConsumeAnonymousRateLimits).not.toHaveBeenCalled();
+  });
+
+  it('requires authentication for user-limited infrastructure requests', async () => {
+    mockIsCloudflareIp.mockReturnValue(true);
+
+    const response = await enforceFreeModelRateLimits({
+      feature: 'cloud-agent',
+      ipAddress: '192.0.2.1',
+      isRateLimitedFreeModel: true,
+      model: 'kilo/free-model',
+      user: createAnonymousContext('192.0.2.1'),
+    });
+
+    expect(response?.status).toBe(401);
+    if (!response) throw new Error('Expected an authentication response');
+    await expect(response.json()).resolves.toEqual({
+      error: 'Authentication required for this feature',
+      error_type: 'authentication_required',
+    });
+    expect(mockConsumeAnonymousRateLimits).not.toHaveBeenCalled();
+  });
+
+  it('uses a user limit for authenticated infrastructure requests', async () => {
+    mockIsCloudflareIp.mockReturnValue(true);
+
+    const response = await enforceFreeModelRateLimits({
+      feature: 'cloud-agent',
+      ipAddress: '192.0.2.1',
+      isRateLimitedFreeModel: true,
+      model: 'kilo/free-model',
+      user: { id: 'user-123' },
+    });
+
+    expect(response).toBeNull();
+    expect(mockConsumeUserRateLimit).toHaveBeenCalledWith('user-123');
+    expect(mockConsumeIpRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('returns the free-model limit response when the IP limit is exhausted', async () => {
+    mockConsumeIpRateLimit.mockResolvedValue({ allowed: false, requestCount: 200 });
+
+    const response = await enforceFreeModelRateLimits({
+      feature: 'vscode-extension',
+      ipAddress: '192.0.2.1',
+      isRateLimitedFreeModel: true,
+      model: 'kilo/free-model',
+      user: { id: 'user-123' },
+    });
+
+    expect(response?.status).toBe(429);
+    if (!response) throw new Error('Expected a rate-limit response');
+    await expect(response.json()).resolves.toMatchObject({
+      error: 'Rate limit exceeded',
+      error_type: 'rate_limit_exceeded',
+    });
+  });
+
+  it('returns the promotion response when anonymous usage is exhausted', async () => {
+    mockCheckPromotionLimit.mockResolvedValue({ allowed: false, requestCount: 10_000 });
+
+    const response = await enforceFreeModelRateLimits({
+      feature: 'vscode-extension',
+      ipAddress: '192.0.2.1',
+      isRateLimitedFreeModel: false,
+      model: 'provider/free-model',
+      user: createAnonymousContext('192.0.2.1'),
+    });
+
+    expect(response?.status).toBe(401);
+    if (!response) throw new Error('Expected a promotion-limit response');
+    await expect(response.json()).resolves.toMatchObject({
+      error: { code: 'PROMOTION_MODEL_LIMIT_REACHED' },
+      error_type: 'promotion_limit_reached',
+    });
+  });
+});

--- a/apps/web/src/lib/ai-gateway/free-model-rate-limit-enforcement.ts
+++ b/apps/web/src/lib/ai-gateway/free-model-rate-limit-enforcement.ts
@@ -1,0 +1,77 @@
+import type { NextResponse } from 'next/server';
+import { isAnonymousContext, type AnonymousUserContext } from '@/lib/anonymous';
+import { isCloudflareIP } from '@/lib/cloudflare-ip';
+import { isUserRateLimitedFeature, type FeatureValue } from '@/lib/feature-detection';
+import {
+  checkPromotionLimit,
+  consumeAnonymousFreeModelRateLimits,
+  consumeFreeModelRateLimit,
+  consumeFreeModelRateLimitByUser,
+  type RateLimitResult,
+} from '@/lib/free-model-rate-limiter';
+import {
+  freeModelFeatureAuthenticationRequiredResponse,
+  freeModelRateLimitExceededResponse,
+  promotionLimitExceededResponse,
+} from './free-model-rate-limit-responses';
+
+type RateLimitUser = { id: string } | AnonymousUserContext;
+
+type EnforceFreeModelRateLimitsInput = {
+  feature: FeatureValue | null;
+  ipAddress: string;
+  isRateLimitedFreeModel: boolean;
+  model: string;
+  user: RateLimitUser;
+};
+
+export async function enforceFreeModelRateLimits({
+  feature,
+  ipAddress,
+  isRateLimitedFreeModel,
+  model,
+  user,
+}: EnforceFreeModelRateLimitsInput): Promise<NextResponse<unknown> | null> {
+  let freeModelRateLimit: { result: RateLimitResult; subject: string } | null = null;
+  let promotionLimit: RateLimitResult | null = null;
+
+  if (isRateLimitedFreeModel && isUserRateLimitedFeature(feature) && isCloudflareIP(ipAddress)) {
+    if (isAnonymousContext(user)) {
+      return freeModelFeatureAuthenticationRequiredResponse();
+    }
+    freeModelRateLimit = {
+      result: await consumeFreeModelRateLimitByUser(user.id),
+      subject: `user: ${user.id}`,
+    };
+  } else if (isAnonymousContext(user)) {
+    if (isRateLimitedFreeModel) {
+      const anonymousLimits = await consumeAnonymousFreeModelRateLimits(ipAddress);
+      freeModelRateLimit = {
+        result: anonymousLimits.freeModel,
+        subject: `ip address: ${ipAddress}`,
+      };
+      promotionLimit = anonymousLimits.promotion;
+    } else {
+      promotionLimit = await checkPromotionLimit(ipAddress);
+    }
+  } else if (isRateLimitedFreeModel) {
+    freeModelRateLimit = {
+      result: await consumeFreeModelRateLimit(ipAddress),
+      subject: `ip address: ${ipAddress}`,
+    };
+  }
+
+  if (freeModelRateLimit && !freeModelRateLimit.result.allowed) {
+    return freeModelRateLimitExceededResponse(
+      freeModelRateLimit.subject,
+      model,
+      freeModelRateLimit.result.requestCount
+    );
+  }
+
+  if (promotionLimit && !promotionLimit.allowed) {
+    return promotionLimitExceededResponse(ipAddress, model, promotionLimit.requestCount);
+  }
+
+  return null;
+}

--- a/apps/web/src/lib/ai-gateway/free-model-rate-limit-responses.ts
+++ b/apps/web/src/lib/ai-gateway/free-model-rate-limit-responses.ts
@@ -1,0 +1,57 @@
+import { NextResponse } from 'next/server';
+import { PROMOTION_MAX_REQUESTS, PROMOTION_WINDOW_HOURS } from '@/lib/constants';
+import { ProxyErrorType } from '@/lib/proxy-error-types';
+
+export function freeModelFeatureAuthenticationRequiredResponse(): NextResponse<unknown> {
+  return NextResponse.json(
+    {
+      error: 'Authentication required for this feature',
+      error_type: ProxyErrorType.authentication_required,
+    },
+    { status: 401 }
+  );
+}
+
+export function freeModelRateLimitExceededResponse(
+  subject: string,
+  model: string,
+  requestCount: number
+): NextResponse<unknown> {
+  console.warn(
+    `Free model rate limit exceeded, ${subject}, model: ${model}, request count: ${requestCount}`
+  );
+  return NextResponse.json(
+    {
+      error: 'Rate limit exceeded',
+      error_type: ProxyErrorType.rate_limit_exceeded,
+      message: 'Free model usage limit reached. Please try again later or upgrade to a paid model.',
+    },
+    { status: 429 }
+  );
+}
+
+export function promotionLimitExceededResponse(
+  ipAddress: string,
+  model: string,
+  requestCount: number
+): NextResponse<unknown> {
+  console.warn(
+    `Promotion model limit exceeded, ip: ${ipAddress}, ` +
+      `model: ${model}, ` +
+      `requests: ${requestCount}/${PROMOTION_MAX_REQUESTS} ` +
+      `in ${PROMOTION_WINDOW_HOURS}h window`
+  );
+
+  return NextResponse.json(
+    {
+      error: {
+        code: 'PROMOTION_MODEL_LIMIT_REACHED',
+        message:
+          'Sign up for free to continue and explore 500 other models. ' +
+          'Takes 2 minutes, no credit card required. Or come back later.',
+      },
+      error_type: ProxyErrorType.promotion_limit_reached,
+    },
+    { status: 401 } // TODO: Change to 429 once the extension supports it (see kilocode errorUtils.ts)
+  );
+}

--- a/apps/web/src/lib/free-model-rate-limiter.test.ts
+++ b/apps/web/src/lib/free-model-rate-limiter.test.ts
@@ -7,7 +7,9 @@ import {
   getFreeModelRateLimitUsage,
 } from './free-model-rate-limiter';
 
-const mockRedisEval = jest.fn();
+type MockRedisEval = (script: string, keys: string[], args: unknown[]) => Promise<unknown>;
+
+const mockRedisEval = jest.fn<MockRedisEval>();
 
 jest.mock('@/lib/redis', () => ({
   redisClient: {

--- a/apps/web/src/lib/free-model-rate-limiter.test.ts
+++ b/apps/web/src/lib/free-model-rate-limiter.test.ts
@@ -1,11 +1,5 @@
-import { beforeEach, describe, expect, it, jest } from '@jest/globals';
-import {
-  consumeFreeModelRateLimit,
-  consumeFreeModelRateLimitByUser,
-  consumePromotionLimit,
-  fillFreeModelRateLimit,
-  getFreeModelRateLimitUsage,
-} from './free-model-rate-limiter';
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type * as FreeModelRateLimiter from './free-model-rate-limiter';
 
 type MockRedisEval = (script: string, keys: string[], args: unknown[]) => Promise<unknown>;
 
@@ -17,7 +11,13 @@ jest.mock('@/lib/redis', () => ({
   },
 }));
 
+let rateLimiter: typeof FreeModelRateLimiter;
+
 describe('free model rate limiter', () => {
+  beforeAll(async () => {
+    rateLimiter = await import('./free-model-rate-limiter');
+  });
+
   beforeEach(() => {
     mockRedisEval.mockReset();
   });
@@ -25,7 +25,7 @@ describe('free model rate limiter', () => {
   it('atomically consumes an IP request from the rolling window', async () => {
     mockRedisEval.mockResolvedValueOnce([1, 1]);
 
-    await expect(consumeFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
+    await expect(rateLimiter.consumeFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
       allowed: true,
       requestCount: 1,
     });
@@ -39,7 +39,7 @@ describe('free model rate limiter', () => {
   it('returns the current count when a user has reached the limit', async () => {
     mockRedisEval.mockResolvedValueOnce([0, 200]);
 
-    await expect(consumeFreeModelRateLimitByUser('user-123')).resolves.toEqual({
+    await expect(rateLimiter.consumeFreeModelRateLimitByUser('user-123')).resolves.toEqual({
       allowed: false,
       requestCount: 200,
     });
@@ -53,7 +53,7 @@ describe('free model rate limiter', () => {
   it('uses a separate 24-hour window for anonymous promotion requests', async () => {
     mockRedisEval.mockResolvedValueOnce([1, 42]);
 
-    await expect(consumePromotionLimit('192.0.2.1')).resolves.toEqual({
+    await expect(rateLimiter.consumePromotionLimit('192.0.2.1')).resolves.toEqual({
       allowed: true,
       requestCount: 42,
     });
@@ -67,7 +67,7 @@ describe('free model rate limiter', () => {
   it('fails open when Redis is unavailable', async () => {
     mockRedisEval.mockRejectedValueOnce(new Error('Redis unavailable'));
 
-    await expect(consumeFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
+    await expect(rateLimiter.consumeFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
       allowed: true,
       requestCount: 0,
     });
@@ -76,8 +76,8 @@ describe('free model rate limiter', () => {
   it('reads and fills the same IP limit for the admin controls', async () => {
     mockRedisEval.mockResolvedValueOnce(12).mockResolvedValueOnce([188, 200]);
 
-    await expect(getFreeModelRateLimitUsage('192.0.2.1')).resolves.toBe(12);
-    await expect(fillFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
+    await expect(rateLimiter.getFreeModelRateLimitUsage('192.0.2.1')).resolves.toBe(12);
+    await expect(rateLimiter.fillFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
       requestsAdded: 188,
       requestCount: 200,
     });

--- a/apps/web/src/lib/free-model-rate-limiter.test.ts
+++ b/apps/web/src/lib/free-model-rate-limiter.test.ts
@@ -1,0 +1,90 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import {
+  consumeFreeModelRateLimit,
+  consumeFreeModelRateLimitByUser,
+  consumePromotionLimit,
+  fillFreeModelRateLimit,
+  getFreeModelRateLimitUsage,
+} from './free-model-rate-limiter';
+
+const mockRedisEval = jest.fn();
+
+jest.mock('@/lib/redis', () => ({
+  redisClient: {
+    eval: mockRedisEval,
+  },
+}));
+
+describe('free model rate limiter', () => {
+  beforeEach(() => {
+    mockRedisEval.mockReset();
+  });
+
+  it('atomically consumes an IP request from the rolling window', async () => {
+    mockRedisEval.mockResolvedValueOnce([1, 1]);
+
+    await expect(consumeFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
+      allowed: true,
+      requestCount: 1,
+    });
+    expect(mockRedisEval).toHaveBeenCalledWith(
+      expect.stringContaining("redis.call('ZADD'"),
+      ['ai-gateway.free-model-rate-limit:ip:192.0.2.1'],
+      [3_600_000, 200, 3_600, expect.any(String)]
+    );
+  });
+
+  it('returns the current count when a user has reached the limit', async () => {
+    mockRedisEval.mockResolvedValueOnce([0, 200]);
+
+    await expect(consumeFreeModelRateLimitByUser('user-123')).resolves.toEqual({
+      allowed: false,
+      requestCount: 200,
+    });
+    expect(mockRedisEval).toHaveBeenCalledWith(
+      expect.any(String),
+      ['ai-gateway.free-model-rate-limit:user:user-123'],
+      [3_600_000, 200, 3_600, expect.any(String)]
+    );
+  });
+
+  it('uses a separate 24-hour window for anonymous promotion requests', async () => {
+    mockRedisEval.mockResolvedValueOnce([1, 42]);
+
+    await expect(consumePromotionLimit('192.0.2.1')).resolves.toEqual({
+      allowed: true,
+      requestCount: 42,
+    });
+    expect(mockRedisEval).toHaveBeenCalledWith(
+      expect.any(String),
+      ['ai-gateway.promotion-rate-limit:ip:192.0.2.1'],
+      [86_400_000, 10_000, 86_400, expect.any(String)]
+    );
+  });
+
+  it('fails open when Redis is unavailable', async () => {
+    mockRedisEval.mockRejectedValueOnce(new Error('Redis unavailable'));
+
+    await expect(consumeFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
+      allowed: true,
+      requestCount: 0,
+    });
+  });
+
+  it('reads and fills the same IP limit for the admin controls', async () => {
+    mockRedisEval.mockResolvedValueOnce(12).mockResolvedValueOnce([188, 200]);
+
+    await expect(getFreeModelRateLimitUsage('192.0.2.1')).resolves.toBe(12);
+    await expect(fillFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
+      requestsAdded: 188,
+      requestCount: 200,
+    });
+
+    expect(mockRedisEval.mock.calls[0]?.[1]).toEqual([
+      'ai-gateway.free-model-rate-limit:ip:192.0.2.1',
+    ]);
+    expect(mockRedisEval.mock.calls[1]?.[1]).toEqual([
+      'ai-gateway.free-model-rate-limit:ip:192.0.2.1',
+    ]);
+  });
+});

--- a/apps/web/src/lib/free-model-rate-limiter.test.ts
+++ b/apps/web/src/lib/free-model-rate-limiter.test.ts
@@ -56,17 +56,34 @@ describe('free model rate limiter', () => {
     );
   });
 
-  it('uses a separate 24-hour window for anonymous promotion requests', async () => {
-    mockRedisEval.mockResolvedValueOnce([1, 42]);
+  it('atomically consumes both anonymous rate limits', async () => {
+    mockRedisEval.mockResolvedValueOnce([2, 1, 42]);
 
-    await expect(rateLimiter.consumePromotionLimit('192.0.2.1')).resolves.toEqual({
-      allowed: true,
-      requestCount: 42,
+    await expect(rateLimiter.consumeAnonymousFreeModelRateLimits('192.0.2.1')).resolves.toEqual({
+      freeModel: { allowed: true, requestCount: 1 },
+      promotion: { allowed: true, requestCount: 42 },
     });
     expect(mockRedisEval).toHaveBeenCalledWith(
       expect.any(String),
+      [
+        'ai-gateway.free-model-rate-limit:ip:192.0.2.1',
+        'ai-gateway.promotion-rate-limit:ip:192.0.2.1',
+      ],
+      [3_600_000, 200, 3_600, 86_400_000, 10_000, 86_400, expect.any(String)]
+    );
+  });
+
+  it('checks the promotion limit without consuming it', async () => {
+    mockRedisEval.mockResolvedValueOnce(10_000);
+
+    await expect(rateLimiter.checkPromotionLimit('192.0.2.1')).resolves.toEqual({
+      allowed: false,
+      requestCount: 10_000,
+    });
+    expect(mockRedisEval).toHaveBeenCalledWith(
+      expect.not.stringContaining("redis.call('ZADD'"),
       ['ai-gateway.promotion-rate-limit:ip:192.0.2.1'],
-      [86_400_000, 10_000, 86_400, expect.any(String)]
+      [86_400_000]
     );
   });
 

--- a/apps/web/src/lib/free-model-rate-limiter.test.ts
+++ b/apps/web/src/lib/free-model-rate-limiter.test.ts
@@ -4,11 +4,16 @@ import type * as FreeModelRateLimiter from './free-model-rate-limiter';
 type MockRedisEval = (script: string, keys: string[], args: unknown[]) => Promise<unknown>;
 
 const mockRedisEval = jest.fn<MockRedisEval>();
+const mockCaptureException = jest.fn();
 
 jest.mock('@/lib/redis', () => ({
   redisClient: {
     eval: mockRedisEval,
   },
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: mockCaptureException,
 }));
 
 let rateLimiter: typeof FreeModelRateLimiter;
@@ -20,6 +25,7 @@ describe('free model rate limiter', () => {
 
   beforeEach(() => {
     mockRedisEval.mockReset();
+    mockCaptureException.mockReset();
   });
 
   it('atomically consumes an IP request from the rolling window', async () => {
@@ -70,6 +76,9 @@ describe('free model rate limiter', () => {
     await expect(rateLimiter.consumeFreeModelRateLimit('192.0.2.1')).resolves.toEqual({
       allowed: true,
       requestCount: 0,
+    });
+    expect(mockCaptureException).toHaveBeenCalledWith(expect.any(Error), {
+      tags: { source: 'free_model_rate_limiter' },
     });
   });
 

--- a/apps/web/src/lib/free-model-rate-limiter.ts
+++ b/apps/web/src/lib/free-model-rate-limiter.ts
@@ -34,6 +34,35 @@ redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
 return { 1, request_count + 1 }
 `;
 
+const CONSUME_ANONYMOUS_RATE_LIMITS_SCRIPT = `
+local time = redis.call('TIME')
+local now = time[1] * 1000 + math.floor(time[2] / 1000)
+
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', now - tonumber(ARGV[1]))
+redis.call('ZREMRANGEBYSCORE', KEYS[2], '-inf', now - tonumber(ARGV[4]))
+
+local free_model_count = redis.call('ZCARD', KEYS[1])
+local promotion_count = redis.call('ZCARD', KEYS[2])
+
+if free_model_count >= tonumber(ARGV[2]) then
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+  redis.call('EXPIRE', KEYS[2], tonumber(ARGV[6]))
+  return { 0, free_model_count, promotion_count }
+end
+
+if promotion_count >= tonumber(ARGV[5]) then
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+  redis.call('EXPIRE', KEYS[2], tonumber(ARGV[6]))
+  return { 1, free_model_count, promotion_count }
+end
+
+redis.call('ZADD', KEYS[1], now, ARGV[7])
+redis.call('ZADD', KEYS[2], now, ARGV[7])
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+redis.call('EXPIRE', KEYS[2], tonumber(ARGV[6]))
+return { 2, free_model_count + 1, promotion_count + 1 }
+`;
+
 const GET_RATE_LIMIT_USAGE_SCRIPT = `
 local time = redis.call('TIME')
 local now = time[1] * 1000 + math.floor(time[2] / 1000)
@@ -66,6 +95,11 @@ return { requests_to_add, request_count + requests_to_add }
 export type RateLimitResult = {
   allowed: boolean;
   requestCount: number;
+};
+
+export type AnonymousFreeModelRateLimits = {
+  freeModel: RateLimitResult;
+  promotion: RateLimitResult;
 };
 
 type FillRateLimitResult = {
@@ -153,15 +187,64 @@ export function consumeFreeModelRateLimitByUser(kiloUserId: string): Promise<Rat
 }
 
 /**
- * Consume one request from an IP address's anonymous promotion limit.
- * Applies to free model requests without authentication.
+ * Atomically consume the hourly IP and daily promotion limits for an anonymous
+ * Kilo free-model request. Neither limit is consumed when either is exhausted.
  */
-export function consumePromotionLimit(ipAddress: string): Promise<RateLimitResult> {
-  return consumeRateLimit(
-    promotionRateLimitIpRedisKey(ipAddress),
-    PROMOTION_WINDOW_HOURS,
-    PROMOTION_MAX_REQUESTS
-  );
+export async function consumeAnonymousFreeModelRateLimits(
+  ipAddress: string
+): Promise<AnonymousFreeModelRateLimits> {
+  try {
+    const [outcome, freeModelCount, promotionCount] = await redisClient.eval<
+      [number, number, number, number, number, number, string],
+      [number, number, number]
+    >(
+      CONSUME_ANONYMOUS_RATE_LIMITS_SCRIPT,
+      [freeModelRateLimitIpRedisKey(ipAddress), promotionRateLimitIpRedisKey(ipAddress)],
+      [
+        FREE_MODEL_RATE_LIMIT_WINDOW_HOURS * MILLISECONDS_PER_HOUR,
+        FREE_MODEL_MAX_REQUESTS_PER_WINDOW,
+        FREE_MODEL_RATE_LIMIT_WINDOW_HOURS * 60 * 60,
+        PROMOTION_WINDOW_HOURS * MILLISECONDS_PER_HOUR,
+        PROMOTION_MAX_REQUESTS,
+        PROMOTION_WINDOW_HOURS * 60 * 60,
+        randomUUID(),
+      ]
+    );
+
+    return {
+      freeModel: {
+        allowed: outcome !== 0,
+        requestCount: freeModelCount,
+      },
+      promotion: {
+        allowed: outcome === 2 || (outcome === 0 && promotionCount < PROMOTION_MAX_REQUESTS),
+        requestCount: promotionCount,
+      },
+    };
+  } catch (error) {
+    captureException(error, { tags: { source: 'free_model_rate_limiter' } });
+    return {
+      freeModel: { allowed: true, requestCount: 0 },
+      promotion: { allowed: true, requestCount: 0 },
+    };
+  }
+}
+
+/**
+ * Check the anonymous promotion limit without consuming it. Third-party free
+ * models historically shared the cap but did not add to its request count.
+ */
+export async function checkPromotionLimit(ipAddress: string): Promise<RateLimitResult> {
+  try {
+    const requestCount = await getRateLimitUsage(
+      promotionRateLimitIpRedisKey(ipAddress),
+      PROMOTION_WINDOW_HOURS
+    );
+    return { allowed: requestCount < PROMOTION_MAX_REQUESTS, requestCount };
+  } catch (error) {
+    captureException(error, { tags: { source: 'free_model_rate_limiter' } });
+    return { allowed: true, requestCount: 0 };
+  }
 }
 
 export function getFreeModelRateLimitUsage(ipAddress: string): Promise<number> {

--- a/apps/web/src/lib/free-model-rate-limiter.ts
+++ b/apps/web/src/lib/free-model-rate-limiter.ts
@@ -1,115 +1,178 @@
-import { db } from '@/lib/drizzle';
-import { free_model_usage } from '@kilocode/db/schema';
-import { and, count, eq, gte, sql } from 'drizzle-orm';
+import { randomUUID } from 'node:crypto';
 import {
   FREE_MODEL_RATE_LIMIT_WINDOW_HOURS,
   FREE_MODEL_MAX_REQUESTS_PER_WINDOW,
   PROMOTION_WINDOW_HOURS,
   PROMOTION_MAX_REQUESTS,
 } from '@/lib/constants';
+import { redisClient } from '@/lib/redis';
+import {
+  freeModelRateLimitIpRedisKey,
+  freeModelRateLimitUserRedisKey,
+  promotionRateLimitIpRedisKey,
+  type RedisKey,
+} from '@/lib/redis-keys';
+
+const MILLISECONDS_PER_HOUR = 60 * 60 * 1000;
+
+const CONSUME_RATE_LIMIT_SCRIPT = `
+local time = redis.call('TIME')
+local now = time[1] * 1000 + math.floor(time[2] / 1000)
+local cutoff = now - tonumber(ARGV[1])
+
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', cutoff)
+
+local request_count = redis.call('ZCARD', KEYS[1])
+if request_count >= tonumber(ARGV[2]) then
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+  return { 0, request_count }
+end
+
+redis.call('ZADD', KEYS[1], now, ARGV[4])
+redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+return { 1, request_count + 1 }
+`;
+
+const GET_RATE_LIMIT_USAGE_SCRIPT = `
+local time = redis.call('TIME')
+local now = time[1] * 1000 + math.floor(time[2] / 1000)
+local cutoff = now - tonumber(ARGV[1])
+
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', cutoff)
+return redis.call('ZCARD', KEYS[1])
+`;
+
+const FILL_RATE_LIMIT_SCRIPT = `
+local time = redis.call('TIME')
+local now = time[1] * 1000 + math.floor(time[2] / 1000)
+local cutoff = now - tonumber(ARGV[1])
+
+redis.call('ZREMRANGEBYSCORE', KEYS[1], '-inf', cutoff)
+
+local request_count = redis.call('ZCARD', KEYS[1])
+local requests_to_add = math.max(0, tonumber(ARGV[2]) - request_count)
+for index = 1, requests_to_add do
+  redis.call('ZADD', KEYS[1], now, ARGV[4] .. ':' .. index)
+end
+
+if requests_to_add > 0 then
+  redis.call('EXPIRE', KEYS[1], tonumber(ARGV[3]))
+end
+
+return { requests_to_add, request_count + requests_to_add }
+`;
 
 export type RateLimitResult = {
   allowed: boolean;
   requestCount: number;
 };
 
-async function getModelUsageSinceTime(
-  windowStart: Date,
-  ipAddress: string,
-  anonymousOnly = false
-): Promise<number> {
-  const conditions = [
-    sql`${free_model_usage.ip_address} = ${ipAddress}`,
-    gte(free_model_usage.created_at, windowStart.toISOString()),
-  ];
+type FillRateLimitResult = {
+  requestsAdded: number;
+  requestCount: number;
+};
 
-  if (anonymousOnly) {
-    conditions.push(sql`${free_model_usage.kilo_user_id} IS NULL`);
-  }
+async function consumeRateLimit(
+  key: RedisKey,
+  windowHours: number,
+  maxRequests: number
+): Promise<RateLimitResult> {
+  const windowMilliseconds = windowHours * MILLISECONDS_PER_HOUR;
+  const windowSeconds = windowHours * 60 * 60;
 
-  const usage = await db
-    .select({ totalRequests: count() })
-    .from(free_model_usage)
-    .where(and(...conditions));
-
-  return Number(usage[0]?.totalRequests ?? 0);
-}
-
-async function getModelUsageSinceTimeByUser(
-  windowStart: Date,
-  kiloUserId: string
-): Promise<number> {
-  const usage = await db
-    .select({ totalRequests: count() })
-    .from(free_model_usage)
-    .where(
-      and(
-        eq(free_model_usage.kilo_user_id, kiloUserId),
-        gte(free_model_usage.created_at, windowStart.toISOString())
-      )
+  try {
+    const [allowed, requestCount] = await redisClient.eval<
+      [number, number, number, string],
+      [number, number]
+    >(
+      CONSUME_RATE_LIMIT_SCRIPT,
+      [key],
+      [windowMilliseconds, maxRequests, windowSeconds, randomUUID()]
     );
 
-  return Number(usage[0]?.totalRequests ?? 0);
+    return {
+      allowed: allowed === 1,
+      requestCount,
+    };
+  } catch {
+    // Redis is an availability optimization; do not block inference when it is unavailable.
+    return { allowed: true, requestCount: 0 };
+  }
+}
+
+async function getRateLimitUsage(key: RedisKey, windowHours: number): Promise<number> {
+  return redisClient.eval<[number], number>(
+    GET_RATE_LIMIT_USAGE_SCRIPT,
+    [key],
+    [windowHours * MILLISECONDS_PER_HOUR]
+  );
+}
+
+async function fillRateLimit(
+  key: RedisKey,
+  windowHours: number,
+  maxRequests: number
+): Promise<FillRateLimitResult> {
+  const [requestsAdded, requestCount] = await redisClient.eval<
+    [number, number, number, string],
+    [number, number]
+  >(
+    FILL_RATE_LIMIT_SCRIPT,
+    [key],
+    [windowHours * MILLISECONDS_PER_HOUR, maxRequests, windowHours * 60 * 60, randomUUID()]
+  );
+
+  return { requestsAdded, requestCount };
 }
 
 /**
- * Check if an IP address is within the free model rate limit.
+ * Consume one request from an IP address's free model rate limit.
  * This applies to ALL free model requests, both anonymous and authenticated.
  */
-export async function checkFreeModelRateLimit(ipAddress: string): Promise<RateLimitResult> {
-  const windowStart = new Date(Date.now() - FREE_MODEL_RATE_LIMIT_WINDOW_HOURS * 60 * 60 * 1000);
-
-  const requestCount = await getModelUsageSinceTime(windowStart, ipAddress);
-
-  return {
-    allowed: requestCount < FREE_MODEL_MAX_REQUESTS_PER_WINDOW,
-    requestCount,
-  };
+export function consumeFreeModelRateLimit(ipAddress: string): Promise<RateLimitResult> {
+  return consumeRateLimit(
+    freeModelRateLimitIpRedisKey(ipAddress),
+    FREE_MODEL_RATE_LIMIT_WINDOW_HOURS,
+    FREE_MODEL_MAX_REQUESTS_PER_WINDOW
+  );
 }
 
 /**
- * Check if a user is within the free model rate limit.
+ * Consume one request from a user's free model rate limit.
  * Used for server-side products (cloud-agent, code-review, app-builder)
  * where all requests share infrastructure IPs.
  */
-export async function checkFreeModelRateLimitByUser(kiloUserId: string): Promise<RateLimitResult> {
-  const windowStart = new Date(Date.now() - FREE_MODEL_RATE_LIMIT_WINDOW_HOURS * 60 * 60 * 1000);
-
-  const requestCount = await getModelUsageSinceTimeByUser(windowStart, kiloUserId);
-
-  return {
-    allowed: requestCount < FREE_MODEL_MAX_REQUESTS_PER_WINDOW,
-    requestCount,
-  };
+export function consumeFreeModelRateLimitByUser(kiloUserId: string): Promise<RateLimitResult> {
+  return consumeRateLimit(
+    freeModelRateLimitUserRedisKey(kiloUserId),
+    FREE_MODEL_RATE_LIMIT_WINDOW_HOURS,
+    FREE_MODEL_MAX_REQUESTS_PER_WINDOW
+  );
 }
 
 /**
- * Check if an IP address is within the promotion limit.
+ * Consume one request from an IP address's anonymous promotion limit.
  * Applies to free model requests without authentication.
  */
-export async function checkPromotionLimit(ipAddress: string): Promise<RateLimitResult> {
-  const windowStart = new Date(Date.now() - PROMOTION_WINDOW_HOURS * 60 * 60 * 1000);
-
-  const requestCount = await getModelUsageSinceTime(windowStart, ipAddress, true);
-
-  return {
-    allowed: requestCount < PROMOTION_MAX_REQUESTS,
-    requestCount,
-  };
+export function consumePromotionLimit(ipAddress: string): Promise<RateLimitResult> {
+  return consumeRateLimit(
+    promotionRateLimitIpRedisKey(ipAddress),
+    PROMOTION_WINDOW_HOURS,
+    PROMOTION_MAX_REQUESTS
+  );
 }
 
-/**
- * Log a free model request for rate limiting purposes.
- * This should be called at the START of the request, before processing.
- */
-export async function logFreeModelRequest(
-  ipAddress: string,
-  model: string,
-  kiloUserId?: string
-): Promise<void> {
-  await db.insert(free_model_usage).values({
-    ip_address: ipAddress,
-    model,
-    kilo_user_id: kiloUserId,
-  });
+export function getFreeModelRateLimitUsage(ipAddress: string): Promise<number> {
+  return getRateLimitUsage(
+    freeModelRateLimitIpRedisKey(ipAddress),
+    FREE_MODEL_RATE_LIMIT_WINDOW_HOURS
+  );
+}
+
+export function fillFreeModelRateLimit(ipAddress: string): Promise<FillRateLimitResult> {
+  return fillRateLimit(
+    freeModelRateLimitIpRedisKey(ipAddress),
+    FREE_MODEL_RATE_LIMIT_WINDOW_HOURS,
+    FREE_MODEL_MAX_REQUESTS_PER_WINDOW
+  );
 }

--- a/apps/web/src/lib/free-model-rate-limiter.ts
+++ b/apps/web/src/lib/free-model-rate-limiter.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from 'node:crypto';
+import { captureException } from '@sentry/nextjs';
 import {
   FREE_MODEL_RATE_LIMIT_WINDOW_HOURS,
   FREE_MODEL_MAX_REQUESTS_PER_WINDOW,
@@ -94,7 +95,8 @@ async function consumeRateLimit(
       allowed: allowed === 1,
       requestCount,
     };
-  } catch {
+  } catch (error) {
+    captureException(error, { tags: { source: 'free_model_rate_limiter' } });
     // Redis is an availability optimization; do not block inference when it is unavailable.
     return { allowed: true, requestCount: 0 };
   }

--- a/apps/web/src/lib/free-model-usage.ts
+++ b/apps/web/src/lib/free-model-usage.ts
@@ -1,7 +1,9 @@
+import { captureException } from '@sentry/nextjs';
+import { after } from 'next/server';
 import { db } from '@/lib/drizzle';
 import { free_model_usage } from '@kilocode/db/schema';
 
-export async function logFreeModelUsage(
+async function logFreeModelUsage(
   ipAddress: string,
   model: string,
   kiloUserId?: string
@@ -10,5 +12,19 @@ export async function logFreeModelUsage(
     ip_address: ipAddress,
     model,
     kilo_user_id: kiloUserId,
+  });
+}
+
+export function scheduleFreeModelUsageLog(
+  ipAddress: string,
+  model: string,
+  kiloUserId?: string
+): void {
+  after(async () => {
+    try {
+      await logFreeModelUsage(ipAddress, model, kiloUserId);
+    } catch (error) {
+      captureException(error, { tags: { source: 'free_model_usage' } });
+    }
   });
 }

--- a/apps/web/src/lib/free-model-usage.ts
+++ b/apps/web/src/lib/free-model-usage.ts
@@ -1,0 +1,14 @@
+import { db } from '@/lib/drizzle';
+import { free_model_usage } from '@kilocode/db/schema';
+
+export async function logFreeModelUsage(
+  ipAddress: string,
+  model: string,
+  kiloUserId?: string
+): Promise<void> {
+  await db.insert(free_model_usage).values({
+    ip_address: ipAddress,
+    model,
+    kilo_user_id: kiloUserId,
+  });
+}

--- a/apps/web/src/lib/redis-keys.test.ts
+++ b/apps/web/src/lib/redis-keys.test.ts
@@ -1,6 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
 import {
+  freeModelRateLimitIpRedisKey,
+  freeModelRateLimitUserRedisKey,
   gitLabOAuthCredentialsRedisKey,
+  promotionRateLimitIpRedisKey,
   REQUEST_LOGGING_OPT_INS_REDIS_KEY,
   vercelInferenceProvidersRedisKey,
 } from './redis-keys';
@@ -18,5 +21,17 @@ describe('Redis key namespaces', () => {
 
   test('uses one key for the request logging opt-in array', () => {
     expect(REQUEST_LOGGING_OPT_INS_REDIS_KEY).toBe('ai-gateway:request-logging-opt-ins');
+  });
+
+  test('separates free model rate limits by subject and limit', () => {
+    expect(freeModelRateLimitIpRedisKey('192.0.2.1')).toBe(
+      'ai-gateway.free-model-rate-limit:ip:192.0.2.1'
+    );
+    expect(freeModelRateLimitUserRedisKey('user-123')).toBe(
+      'ai-gateway.free-model-rate-limit:user:user-123'
+    );
+    expect(promotionRateLimitIpRedisKey('192.0.2.1')).toBe(
+      'ai-gateway.promotion-rate-limit:ip:192.0.2.1'
+    );
   });
 });

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -59,6 +59,15 @@ export const REQUEST_LOGGING_OPT_INS_REDIS_KEY = redisKey('ai-gateway:request-lo
 export const abuseRulesClassificationRedisKey = (identityKey: string) =>
   redisKey(`ai-gateway.abuse-rules:last-classification:${identityKey}`);
 
+export const freeModelRateLimitIpRedisKey = (ipAddress: string) =>
+  redisKey(`ai-gateway.free-model-rate-limit:ip:${ipAddress}`);
+
+export const freeModelRateLimitUserRedisKey = (kiloUserId: string) =>
+  redisKey(`ai-gateway.free-model-rate-limit:user:${kiloUserId}`);
+
+export const promotionRateLimitIpRedisKey = (ipAddress: string) =>
+  redisKey(`ai-gateway.promotion-rate-limit:ip:${ipAddress}`);
+
 export const botIdentityRedisKey = (platform: string, teamId: string, userId: string) =>
   redisKey(`identity:${platform}:${teamId}:${userId}`);
 

--- a/apps/web/src/routers/admin/free-model-usage-router.ts
+++ b/apps/web/src/routers/admin/free-model-usage-router.ts
@@ -1,21 +1,13 @@
 import 'server-only';
 
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
-import { db } from '@/lib/drizzle';
-import { free_model_usage } from '@kilocode/db/schema';
-import { and, count, gte } from 'drizzle-orm';
 import { headers } from 'next/headers';
 import { TRPCError } from '@trpc/server';
 import {
   FREE_MODEL_RATE_LIMIT_WINDOW_HOURS,
   FREE_MODEL_MAX_REQUESTS_PER_WINDOW,
-  ADMIN_RATE_LIMIT_TEST_MODEL,
 } from '@/lib/constants';
-import { sql } from 'drizzle-orm';
-
-function getWindowStart(): Date {
-  return new Date(Date.now() - FREE_MODEL_RATE_LIMIT_WINDOW_HOURS * 60 * 60 * 1000);
-}
+import { fillFreeModelRateLimit, getFreeModelRateLimitUsage } from '@/lib/free-model-rate-limiter';
 
 async function getCallerIp(): Promise<string> {
   const headersList = await headers();
@@ -30,24 +22,10 @@ async function getCallerIp(): Promise<string> {
   return ip;
 }
 
-async function countUsageForIp(ipAddress: string): Promise<number> {
-  const windowStart = getWindowStart();
-  const usage = await db
-    .select({ totalRequests: count() })
-    .from(free_model_usage)
-    .where(
-      and(
-        sql`${free_model_usage.ip_address} = ${ipAddress}`,
-        gte(free_model_usage.created_at, windowStart.toISOString())
-      )
-    );
-  return Number(usage[0]?.totalRequests ?? 0);
-}
-
 export const adminFreeModelUsageRouter = createTRPCRouter({
   getMyIpUsage: adminProcedure.query(async () => {
     const ipAddress = await getCallerIp();
-    const currentUsage = await countUsageForIp(ipAddress);
+    const currentUsage = await getFreeModelRateLimitUsage(ipAddress);
     return {
       ipAddress,
       currentUsage,
@@ -59,30 +37,13 @@ export const adminFreeModelUsageRouter = createTRPCRouter({
 
   rateLimitMyIp: adminProcedure.mutation(async () => {
     const ipAddress = await getCallerIp();
-    const currentUsage = await countUsageForIp(ipAddress);
-    const rowsNeeded = FREE_MODEL_MAX_REQUESTS_PER_WINDOW - currentUsage;
-
-    if (rowsNeeded <= 0) {
-      return {
-        ipAddress,
-        rowsInserted: 0,
-        newTotal: currentUsage,
-        alreadyRateLimited: true,
-      };
-    }
-
-    const rows = Array.from({ length: rowsNeeded }, () => ({
-      ip_address: ipAddress,
-      model: ADMIN_RATE_LIMIT_TEST_MODEL,
-    }));
-
-    await db.insert(free_model_usage).values(rows);
+    const { requestsAdded, requestCount } = await fillFreeModelRateLimit(ipAddress);
 
     return {
       ipAddress,
-      rowsInserted: rowsNeeded,
-      newTotal: FREE_MODEL_MAX_REQUESTS_PER_WINDOW,
-      alreadyRateLimited: false,
+      requestsAdded,
+      newTotal: requestCount,
+      alreadyRateLimited: requestsAdded === 0,
     };
   }),
 });


### PR DESCRIPTION
## Summary
- replace PostgreSQL free-model usage counts with atomic Redis rolling-window limits
- keep separate IP, user, and anonymous promotion limits with expiring keys and fail-open behavior
- update the admin self-limit control to use Redis while retaining the existing database table and historical reporting paths

## Testing
- Added unit coverage for Redis keys, limit consumption, fail-open behavior, and admin controls
- Local test suites intentionally not run; CI will perform validation