### PR TITLE
fix(organizations): disable personal account for new SSO signups

### DIFF
--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -507,6 +507,36 @@ describe('Organizations', () => {
       expect(added).toBe(false);
       expect(await getUserOrganizationsWithSeats(member.id)).toHaveLength(0);
     });
+
+    test('disables the personal account for a brand-new user provisioned via SSO', async () => {
+      const owner = await insertTestUser();
+      const member = await insertTestUser();
+      const organization = await createOrganization('SSO Org', owner.id);
+
+      const added = await addSsoUserToOrganization(organization.id, member.id, {
+        isNewUser: true,
+      });
+
+      expect(added).toBe(true);
+      const updatedMember = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, member.id),
+      });
+      expect(updatedMember?.personal_account_disabled).toBe(true);
+    });
+
+    test('leaves the personal account untouched for an existing user authenticating via SSO', async () => {
+      const owner = await insertTestUser();
+      const member = await insertTestUser();
+      const organization = await createOrganization('SSO Org', owner.id);
+
+      const added = await addSsoUserToOrganization(organization.id, member.id);
+
+      expect(added).toBe(true);
+      const updatedMember = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, member.id),
+      });
+      expect(updatedMember?.personal_account_disabled).toBe(false);
+    });
   });
 
   describe('updateUserRoleInOrganization', () => {

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -338,7 +338,8 @@ async function lockOrganizationMembershipMutation(
 
 export async function addSsoUserToOrganization(
   organizationId: Organization['id'],
-  userId: User['id']
+  userId: User['id'],
+  options?: { isNewUser?: boolean }
 ): Promise<boolean> {
   return db.transaction(async tx => {
     await lockOrganizationMembershipMutation(tx, organizationId, userId);
@@ -354,7 +355,20 @@ export async function addSsoUserToOrganization(
       .limit(1);
 
     if (removal) return false;
-    return addUserToOrganization(organizationId, userId, 'member', tx);
+    const added = await addUserToOrganization(organizationId, userId, 'member', tx);
+
+    // A brand-new account provisioned through SSO exists only because of the
+    // organization, so it has no standalone personal account. Mirror the
+    // invite-driven signup behavior (acceptOrganizationInvite) and disable it.
+    // Existing users who authenticate through SSO keep their current value.
+    if (added && options?.isNewUser) {
+      await tx
+        .update(kilocode_users)
+        .set({ personal_account_disabled: true })
+        .where(eq(kilocode_users.id, userId));
+    }
+
+    return added;
   });
 }
 

--- a/apps/web/src/lib/user/sso.test.ts
+++ b/apps/web/src/lib/user/sso.test.ts
@@ -106,6 +106,8 @@ describe('processSSOUserLogin', () => {
       'impact-click-123',
       trackingContext
     );
-    expect(mockAddSsoUserToOrganization).toHaveBeenCalledWith('org-local', 'user-workos');
+    expect(mockAddSsoUserToOrganization).toHaveBeenCalledWith('org-local', 'user-workos', {
+      isNewUser: true,
+    });
   });
 });

--- a/apps/web/src/lib/user/sso.ts
+++ b/apps/web/src/lib/user/sso.ts
@@ -81,7 +81,9 @@ async function processSSOInternal(
 
   const savedUser = res.user;
   // add user to organization since its been fully created
-  const added = await addSsoUserToOrganization(kiloOrg.id, savedUser.id);
+  const added = await addSsoUserToOrganization(kiloOrg.id, savedUser.id, {
+    isNewUser: res.isNew,
+  });
   if (added) {
     // get all owners for org
     const members = await getOrganizationMembers(kiloOrg.id);


### PR DESCRIPTION
## Problem

Signing up through SSO created an account with `personal_account_disabled=false` when it should be `true`.

The feature that disables the personal account for accounts created specifically to join an org was only ever implemented for the **invitation** flow (#4447, `acceptOrganizationInvite`). The **SSO JIT provisioning** path (`processSSOUserLogin` → `createOrUpdateUser` → `addSsoUserToOrganization`) never touched the flag, so brand-new SSO accounts kept the schema default of `false`.

## Fix

Mirror the invite-flow behavior for SSO, atomically within the membership-insert transaction:

- `addSsoUserToOrganization` now accepts an optional `{ isNewUser }`. When the membership is actually inserted **and** the account is brand-new, it sets `personal_account_disabled: true` in the same transaction.
- `sso.ts` passes `isNewUser: res.isNew` (from `createOrUpdateUser`).
- Existing users who authenticate through SSO keep their current value, matching the invite semantics ("account created *because of* the org").

The disabling is gated on `added && isNewUser`. A brand-new user can't have a removal tombstone (so `added` is always true here), but gating on `added` keeps the flag from being flipped for a non-member if the tombstone guard ever short-circuits, matching how the invite flow only disables within a successful-insert path.

## Tests

- Added two cases in `organizations.test.ts`: new SSO user → `personal_account_disabled=true`; existing SSO user → stays `false`.
- Updated `sso.test.ts` call-args assertion for the new `{ isNewUser: true }` argument.
- Typecheck passes; targeted SSO and personal-account suites pass; formatted.

## Note

This only affects accounts created going forward. Accounts already provisioned via SSO with `false` need a manual correction (e.g. the admin toggle) if desired.