### PR TITLE
fix(ai-gateway): fit generation routes within Vercel timeout

### DIFF
--- a/apps/web/src/app/api/gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/gateway/[...path]/route.ts
@@ -1,3 +1,3 @@
 export { POST } from '@/app/api/openrouter/[...path]/route';
 
-export const maxDuration = 600;
+export const maxDuration = 800;

--- a/apps/web/src/app/api/gateway/[...path]/route.ts
+++ b/apps/web/src/app/api/gateway/[...path]/route.ts
@@ -1,3 +1,3 @@
 export { POST } from '@/app/api/openrouter/[...path]/route';
 
-export const maxDuration = 1800;
+export const maxDuration = 600;

--- a/apps/web/src/app/api/gateway/audio/transcriptions/route.ts
+++ b/apps/web/src/app/api/gateway/audio/transcriptions/route.ts
@@ -1,3 +1,3 @@
 export { POST } from '@/app/api/openrouter/audio/transcriptions/route';
 
-export const maxDuration = 1800;
+export const maxDuration = 800;

--- a/apps/web/src/app/api/gateway/v1/audio/transcriptions/route.ts
+++ b/apps/web/src/app/api/gateway/v1/audio/transcriptions/route.ts
@@ -1,3 +1,3 @@
 export { POST } from '@/app/api/openrouter/audio/transcriptions/route';
 
-export const maxDuration = 1800;
+export const maxDuration = 800;

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -107,7 +107,7 @@ import {
 import { redactProviderHints } from '@kilocode/auto-routing-contracts';
 import { logExceptInTest } from '@/lib/utils.server';
 
-export const maxDuration = 1800;
+export const maxDuration = 600;
 
 const MAX_TOKENS_LIMIT = 99999999999; // GPT4.1 default is ~32k
 
@@ -621,7 +621,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // previously blocking/quarantine decision wait for a fresh abuse-service result.
   const shouldBlockOnClassify = isRulesEngineBlockingAction(cachedRulesEngineAction);
 
-  // Large responses may run longer than the 1800s serverless function timeout.
+  // Large responses may run longer than the 600s serverless function timeout.
   const requestMaxTokens = getMaxTokens(requestBodyParsed);
   if (requestMaxTokens && requestMaxTokens > MAX_TOKENS_LIMIT) {
     console.warn(`SECURITY: Max tokens limit exceeded: ${user.id}`, {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -107,7 +107,7 @@ import {
 import { redactProviderHints } from '@kilocode/auto-routing-contracts';
 import { logExceptInTest } from '@/lib/utils.server';
 
-export const maxDuration = 600;
+export const maxDuration = 800;
 
 const MAX_TOKENS_LIMIT = 99999999999; // GPT4.1 default is ~32k
 
@@ -621,7 +621,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // previously blocking/quarantine decision wait for a fresh abuse-service result.
   const shouldBlockOnClassify = isRulesEngineBlockingAction(cachedRulesEngineAction);
 
-  // Large responses may run longer than the 600s serverless function timeout.
+  // Large responses may run longer than the 800s serverless function timeout.
   const requestMaxTokens = getMaxTokens(requestBodyParsed);
   if (requestMaxTokens && requestMaxTokens > MAX_TOKENS_LIMIT) {
     console.warn(`SECURITY: Max tokens limit exceeded: ${user.id}`, {

--- a/apps/web/src/app/api/openrouter/audio/transcriptions/route.test.ts
+++ b/apps/web/src/app/api/openrouter/audio/transcriptions/route.test.ts
@@ -85,7 +85,7 @@ describe('POST /api/gateway/v1/audio/transcriptions', () => {
       import('@/app/api/gateway/v1/audio/transcriptions/route'),
     ]);
 
-    expect(routes.map(route => route.maxDuration)).toEqual([1800, 1800, 1800, 1800]);
+    expect(routes.map(route => route.maxDuration)).toEqual([800, 800, 800, 800]);
   });
 
   it('proxies transcription requests to OpenRouter', async () => {

--- a/apps/web/src/app/api/openrouter/audio/transcriptions/route.ts
+++ b/apps/web/src/app/api/openrouter/audio/transcriptions/route.ts
@@ -31,7 +31,7 @@ import {
 } from '@/lib/ai-gateway/transcriptions/transcription-request';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
 
-export const maxDuration = 1800;
+export const maxDuration = 800;
 
 const PAID_MODEL_AUTH_REQUIRED = 'PAID_MODEL_AUTH_REQUIRED';
 

--- a/apps/web/src/app/api/openrouter/v1/audio/transcriptions/route.ts
+++ b/apps/web/src/app/api/openrouter/v1/audio/transcriptions/route.ts
@@ -1,3 +1,3 @@
 export { POST } from '@/app/api/openrouter/audio/transcriptions/route';
 
-export const maxDuration = 1800;
+export const maxDuration = 800;

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.generation.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.generation.test.ts
@@ -36,7 +36,7 @@ describe('fetchGeneration', () => {
     jest.useRealTimers();
   });
 
-  it('uses a longer, slower retry window', async () => {
+  it('limits generation polling to about one minute', async () => {
     mockFetchWithBackoff.mockResolvedValue(
       new Response(JSON.stringify({ id: 'generation-id' }), {
         status: 200,
@@ -56,7 +56,7 @@ describe('fetchGeneration', () => {
       },
       expect.objectContaining({
         baseDelayMs: 5_000,
-        maxDelayMs: 5 * 60 * 1_000,
+        maxDelayMs: 60 * 1_000,
       })
     );
 

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.generation.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.generation.test.ts
@@ -56,7 +56,7 @@ describe('fetchGeneration', () => {
       },
       expect.objectContaining({
         baseDelayMs: 5_000,
-        maxDelayMs: 60 * 1_000,
+        maxDelayMs: 75 * 1_000,
       })
     );
 

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -23,9 +23,10 @@ type UpstreamFetchFailureFamily =
   | 'abort'
   | 'unknown';
 
-// Longer than Vercel AI Gateway's 13min timeout, shorter than Vercel Function's 30min timeout.
-const TIMEOUT_MS = 15 * 60 * 1000;
-const GENERATION_FETCH_MAX_DELAY_MS = 60 * 1000;
+// Leave 200s of the Vercel function budget for post-stream work.
+const TIMEOUT_MS = 10 * 60 * 1000;
+// fetchWithBackoff reserves the next delay before retrying, so 75s yields about one minute.
+const GENERATION_FETCH_MAX_DELAY_MS = 75 * 1000;
 
 function getProviderTargetHost(apiUrl: string): string {
   try {

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -25,7 +25,7 @@ type UpstreamFetchFailureFamily =
 
 // Longer than Vercel AI Gateway's 13min timeout, shorter than Vercel Function's 30min timeout.
 const TIMEOUT_MS = 15 * 60 * 1000;
-const GENERATION_FETCH_MAX_DELAY_MS = 5 * 60 * 1000;
+const GENERATION_FETCH_MAX_DELAY_MS = 60 * 1000;
 
 function getProviderTargetHost(apiUrl: string): string {
   try {


### PR DESCRIPTION
## Summary

- cap the OpenRouter and Gateway chat/messages/responses routes at the non-extended 800s Vercel limit
- cap all four OpenRouter and Gateway transcription route aliases at the same 800s limit
- reduce the upstream generation and transcription request timeout from 900s to 600s, leaving 200s for post-stream work
- configure `fetchGeneration` with a 75s backoff budget, which yields roughly one minute of polling with the helper's next-delay reservation
- update the focused generation polling expectation, transcription route-duration expectation, and timeout comments

## Slow-path concerns

- `maxDuration` covers the full invocation, including request processing and `after()` work. The 600s upstream timeout leaves 200s for usage persistence, metrics, generation polling, and other post-response work.
- the generation polling window is approximate rather than a hard wall-clock timeout because individual fetch attempts have no abort timeout.
- the shorter `fetchGeneration` budget is shared by transcription usage processing as requested; this reduces the five-minute polling window introduced in #4818 and may miss unusually delayed OpenRouter generation records.
- post-response usage, metrics, auto-top-up, experiment attribution, request logging, and notification operations share the invocation budget, and some downstream database/network calls have no hard timeout.
- unrelated tRPC, chat webhook, and Discord route exports remain configured at 1,800s and may need separate changes for a strict non-extended 800s environment.

## Verification

- formatted the changed files with `oxfmt`
- `git diff --check`
- tests and automated review left to CI