### PR TITLE
feat(web): skip customer-source survey for SSO and invite joins

### DIFF
--- a/apps/web/src/lib/organizations/organizations.test.ts
+++ b/apps/web/src/lib/organizations/organizations.test.ts
@@ -1704,6 +1704,48 @@ describe('Organizations', () => {
         expect(updatedInvitee?.personal_account_disabled).toBe(false);
       });
 
+      test('skips the customer-source survey when a user joins via invitation', async () => {
+        const owner = await insertTestUser();
+        const invitee = await insertTestUser({ customer_source: null });
+        const organization = await createOrganization('Test Org', owner.id);
+
+        const invitation = await inviteUserToOrganization(
+          organization.id,
+          owner.id,
+          invitee.google_user_email,
+          'member'
+        );
+
+        const result = await acceptOrganizationInvite(invitee.id, invitation.token);
+        expect(result.success).toBe(true);
+
+        const updatedInvitee = await db.query.kilocode_users.findFirst({
+          where: eq(kilocode_users.id, invitee.id),
+        });
+        expect(updatedInvitee?.customer_source).toBe('');
+      });
+
+      test('does not overwrite an existing customer-source answer when accepting an invite', async () => {
+        const owner = await insertTestUser();
+        const invitee = await insertTestUser({ customer_source: 'GitHub' });
+        const organization = await createOrganization('Test Org', owner.id);
+
+        const invitation = await inviteUserToOrganization(
+          organization.id,
+          owner.id,
+          invitee.google_user_email,
+          'member'
+        );
+
+        const result = await acceptOrganizationInvite(invitee.id, invitation.token);
+        expect(result.success).toBe(true);
+
+        const updatedInvitee = await db.query.kilocode_users.findFirst({
+          where: eq(kilocode_users.id, invitee.id),
+        });
+        expect(updatedInvitee?.customer_source).toBe('GitHub');
+      });
+
       test('rejects accepting a pre-existing invitation into a child organization', async () => {
         const owner = await insertTestUser();
         const invitee = await insertTestUser({ google_user_email: 'legacy@example.com' });

--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -297,6 +297,23 @@ export async function createOrganization(
   return organization;
 }
 
+/**
+ * When a user joins an organization through SSO or an invitation we should not
+ * ask them how they heard about Kilo. Mark the customer-source survey as
+ * dismissed by setting `customer_source` to an empty string, but only when they
+ * have not already answered or dismissed it (`customer_source IS NULL`) so an
+ * existing answer is never overwritten.
+ */
+export async function skipCustomerSourceSurveyForOrgJoin(
+  userId: User['id'],
+  txn?: DrizzleTransaction
+): Promise<void> {
+  await (txn || db)
+    .update(kilocode_users)
+    .set({ customer_source: '' })
+    .where(and(eq(kilocode_users.id, userId), isNull(kilocode_users.customer_source)));
+}
+
 export async function addUserToOrganization(
   organizationId: Organization['id'],
   userId: User['id'],
@@ -825,6 +842,10 @@ export async function acceptOrganizationInvite(
         role: invitation.role,
         invited_by: invitation.invited_by,
       });
+
+      // Users who join through an invitation should not be asked how they
+      // heard about Kilo.
+      await skipCustomerSourceSurveyForOrgJoin(userId, tx);
 
       // If the invitation predates the account, the account was created after
       // (i.e. because of) a pending invite: this is a brand-new user joining an

--- a/apps/web/src/lib/user/sso.test.ts
+++ b/apps/web/src/lib/user/sso.test.ts
@@ -23,6 +23,7 @@ jest.mock('@/lib/organizations/organizations', () => ({
   addSsoUserToOrganization: jest.fn(async () => false),
   getOrganizationById: jest.fn(async () => ({ id: 'org-local' })),
   getOrganizationMembers: jest.fn(async () => []),
+  skipCustomerSourceSurveyForOrgJoin: jest.fn(async () => {}),
 }));
 
 jest.mock('@/lib/organizations/organization-sso-policy', () => ({
@@ -46,11 +47,15 @@ jest.mock('@sentry/nextjs', () => ({
 }));
 
 import { createOrUpdateUser } from '@/lib/user';
-import { addSsoUserToOrganization } from '@/lib/organizations/organizations';
+import {
+  addSsoUserToOrganization,
+  skipCustomerSourceSurveyForOrgJoin,
+} from '@/lib/organizations/organizations';
 import { processSSOUserLogin } from './sso';
 
 const mockCreateOrUpdateUser = jest.mocked(createOrUpdateUser);
 const mockAddSsoUserToOrganization = jest.mocked(addSsoUserToOrganization);
+const mockSkipCustomerSourceSurveyForOrgJoin = jest.mocked(skipCustomerSourceSurveyForOrgJoin);
 const { mockWorkOSInstance } = jest.requireMock('@workos-inc/node') as {
   mockWorkOSInstance: { organizations: { listOrganizations: jest.Mock } };
 };
@@ -109,5 +114,37 @@ describe('processSSOUserLogin', () => {
     expect(mockAddSsoUserToOrganization).toHaveBeenCalledWith('org-local', 'user-workos', {
       isNewUser: true,
     });
+  });
+
+  it('skips the customer-source survey when the user joins the org via SSO', async () => {
+    mockAddSsoUserToOrganization.mockResolvedValueOnce(true);
+    const accountInfo = {
+      google_user_email: 'new-user@example.com',
+      google_user_name: 'New User',
+      google_user_image_url: 'https://example.com/avatar.png',
+      hosted_domain: 'example.com',
+      provider: 'workos' as const,
+      provider_account_id: 'workos-user-123',
+    };
+
+    await expect(processSSOUserLogin(accountInfo)).resolves.toBe(true);
+
+    expect(mockSkipCustomerSourceSurveyForOrgJoin).toHaveBeenCalledWith('user-workos');
+  });
+
+  it('does not touch the customer-source survey when the user is already a member', async () => {
+    mockAddSsoUserToOrganization.mockResolvedValueOnce(false);
+    const accountInfo = {
+      google_user_email: 'new-user@example.com',
+      google_user_name: 'New User',
+      google_user_image_url: 'https://example.com/avatar.png',
+      hosted_domain: 'example.com',
+      provider: 'workos' as const,
+      provider_account_id: 'workos-user-123',
+    };
+
+    await expect(processSSOUserLogin(accountInfo)).resolves.toBe(true);
+
+    expect(mockSkipCustomerSourceSurveyForOrgJoin).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/user/sso.ts
+++ b/apps/web/src/lib/user/sso.ts
@@ -8,6 +8,7 @@ import {
   addSsoUserToOrganization,
   getOrganizationById,
   getOrganizationMembers,
+  skipCustomerSourceSurveyForOrgJoin,
 } from '@/lib/organizations/organizations';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import { sendOrgSSOUserJoinedEmail } from '@/lib/email';
@@ -85,6 +86,9 @@ async function processSSOInternal(
     isNewUser: res.isNew,
   });
   if (added) {
+    // Users who join through SSO should not be asked how they heard about Kilo.
+    await skipCustomerSourceSurveyForOrgJoin(savedUser.id);
+
     // get all owners for org
     const members = await getOrganizationMembers(kiloOrg.id);
     const owners = members.filter(m => m.role === 'owner');


### PR DESCRIPTION
## Summary

When a user joins an organization through **SSO** or an **invitation**, we should not ask them how they heard about Kilo.

The `CustomerSourceSurvey` floating card renders only when `customer_source === null` (`null` = never asked, `''` = dismissed, string = answered). Rather than gating in the frontend — which doesn't know how a user joined — this marks the survey as dismissed at the two server-side join points.

## Changes

- **`apps/web/src/lib/organizations/organizations.ts`**: added `skipCustomerSourceSurveyForOrgJoin(userId, txn?)`, which sets `customer_source = ''` only `WHERE customer_source IS NULL` (never overwrites an existing answer; accepts an optional transaction). Called inside `acceptOrganizationInvite`'s transaction right after the new membership is inserted.
- **`apps/web/src/lib/user/sso.ts`**: calls the helper inside the `if (added)` block, so it fires only when the SSO user actually joins the org (not on every re-login).

## Tests

- `sso.test.ts`: helper added to the module mock; asserts it's called when the user joins via SSO and not called for an existing member.
- `organizations.test.ts`: asserts accepting an invite sets `customer_source` to `''`, and that an existing answer (`'GitHub'`) is preserved.

## Notes / assumptions

- Targets only the actual "join" events (membership inserted / SSO auto-provision). Re-logins and already-a-member accept flows are not re-marked; pre-existing members with a `null` source are not retroactively marked.
- The `IS NULL` guard makes both call sites idempotent and safe against overwriting real answers.

## Validation

- `pnpm --filter web run typecheck` (exit 0), `lint` (0 warnings/errors), targeted `jest` suites pass.