### PR TITLE
fix(ai-gateway): preserve client-supplied prompt_cache_key and session_id

### DIFF
--- a/apps/web/src/lib/ai-gateway/providerHash.test.ts
+++ b/apps/web/src/lib/ai-gateway/providerHash.test.ts
@@ -1,5 +1,11 @@
 import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import type {
+  GatewayMessagesRequest,
+  GatewayRequest,
+  GatewayResponsesRequest,
+} from '@/lib/ai-gateway/providers/openrouter/types';
 import {
+  applyTrackingIds,
   generateOpenRouterDownstreamSafetyIdentifier,
   generateProviderSpecificHash,
   generateVercelDownstreamSafetyIdentifier,
@@ -50,5 +56,76 @@ describe('downstream safety identifiers', () => {
     expect(generateOpenRouterDownstreamSafetyIdentifier(testUserId)).not.toBe(
       generateVercelDownstreamSafetyIdentifier(testUserId)
     );
+  });
+});
+
+describe('applyTrackingIds', () => {
+  const userId = 'user-123';
+  const taskId = 'task-456';
+  const taskHash = generateProviderSpecificHash(`${userId}-${taskId}`, PROVIDERS.OPENROUTER);
+
+  function responsesRequest(body: Partial<GatewayResponsesRequest> = {}) {
+    const fullBody: GatewayResponsesRequest = {
+      model: 'openai/gpt-5.4',
+      input: 'hi',
+      ...body,
+    };
+    const request: GatewayRequest = { kind: 'responses', body: fullBody };
+    return { request, body: fullBody };
+  }
+
+  function messagesRequest(body: Partial<GatewayMessagesRequest> = {}) {
+    const fullBody: GatewayMessagesRequest = {
+      model: 'anthropic/claude-sonnet-4.5',
+      max_tokens: 1024,
+      messages: [],
+      ...body,
+    };
+    const request: GatewayRequest = { kind: 'messages', body: fullBody };
+    return { request, body: fullBody };
+  }
+
+  it('sets prompt_cache_key to the task hash when the client did not set one', () => {
+    const { request, body } = responsesRequest();
+    applyTrackingIds(request, PROVIDERS.OPENROUTER, userId, taskId);
+    expect(body.prompt_cache_key).toBe(taskHash);
+  });
+
+  it('does not overwrite a client-supplied prompt_cache_key', () => {
+    const clientKey = '019fb418-bf88-70cc-bb8c-f595c82173b3';
+    const { request, body } = responsesRequest({ prompt_cache_key: clientKey });
+    applyTrackingIds(request, PROVIDERS.OPENROUTER, userId, taskId);
+    expect(body.prompt_cache_key).toBe(clientKey);
+  });
+
+  it('does not overwrite a client-supplied prompt_cache_key on chat completions', () => {
+    const clientKey = 'client-cache-key';
+    const body = {
+      model: 'openai/gpt-5.4',
+      messages: [],
+      prompt_cache_key: clientKey,
+    };
+    const request: GatewayRequest = { kind: 'chat_completions', body };
+    applyTrackingIds(request, PROVIDERS.OPENROUTER, userId, taskId);
+    expect(body.prompt_cache_key).toBe(clientKey);
+  });
+
+  it('leaves prompt_cache_key unset when there is no task id', () => {
+    const { request, body } = responsesRequest();
+    applyTrackingIds(request, PROVIDERS.OPENROUTER, userId, null);
+    expect(body.prompt_cache_key).toBeUndefined();
+  });
+
+  it('sets session_id to the task hash when the client did not set one', () => {
+    const { request, body } = messagesRequest();
+    applyTrackingIds(request, PROVIDERS.OPENROUTER, userId, taskId);
+    expect(body.session_id).toBe(taskHash);
+  });
+
+  it('does not overwrite a client-supplied session_id', () => {
+    const clientSessionId = 'client-session-id';
+    const { request, body } = messagesRequest({ session_id: clientSessionId });
+    applyTrackingIds(request, PROVIDERS.OPENROUTER, userId, taskId);
+    expect(body.session_id).toBe(clientSessionId);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providerHash.ts
+++ b/apps/web/src/lib/ai-gateway/providerHash.ts
@@ -60,12 +60,14 @@ export function applyTrackingIds(
     if (provider.id === 'openrouter') {
       request.body.user = userHash;
       if (taskHash) {
-        request.body.session_id = taskHash;
+        // Keep a client-supplied session id (e.g. from non-KiloCode clients).
+        request.body.session_id ??= taskHash;
       }
     }
   } else {
     if (taskHash) {
-      request.body.prompt_cache_key = taskHash;
+      // Keep a client-supplied cache key (e.g. Codex sends its session UUID).
+      request.body.prompt_cache_key ??= taskHash;
     }
     request.body.safety_identifier = userHash;
     request.body.user = userHash; // deprecated, but this is what OpenRouter uses


### PR DESCRIPTION
## Problem

`applyTrackingIds` unconditionally overwrote `prompt_cache_key` (responses / chat completions) and `session_id` (messages, OpenRouter) with the gateway's base64 task hash whenever an `x-kilocode-taskid` header was present.

Non-KiloCode clients (e.g. Codex) send their own `prompt_cache_key` — typically a session/conversation UUID — for prompt-cache affinity. Clobbering it breaks that affinity, and it made `api_request_log` entries confusing to reason about: a logged request can show a client UUID (when no taskid header was sent, or for messages-kind requests where the key is never set) while identical requests from sessions with a task id show the hash instead.

## Change

Only fill in the tracking hash when the client left the field unset (`??=`). Client-supplied values always win.

Out of scope: `user`, `safety_identifier`, and `metadata.user_id` are still always overwritten, as before.

## Verification

- Added 6 tests to `providerHash.test.ts` covering set-when-unset, preserve-when-set (responses, chat completions, messages), and no-taskid behavior — all 12 tests pass
- `pnpm --filter web typecheck` passes
- oxlint and oxfmt clean on changed files