### PR TITLE
fix(ai-gateway): clarify interrupted stream errors

### DIFF
--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -148,10 +148,10 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
     expect(result.status).toBe(503);
     expect(await result.json()).toEqual({
       error:
-        'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
+        'The upstream response was interrupted while streaming. The provider may have disconnected or the request may have timed out. (request id: iad1::iad1::request-id)',
       error_type: 'upstream_disconnect',
       message:
-        'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
+        'The upstream response was interrupted while streaming. The provider may have disconnected or the request may have timed out. (request id: iad1::iad1::request-id)',
       vercel_request_id: 'iad1::iad1::request-id',
     });
   });
@@ -169,7 +169,7 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
 
     expect(events).toHaveLength(1);
     expect(events[0].error.message).toBe(
-      'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)'
+      'The upstream response was interrupted while streaming. The provider may have disconnected or the request may have timed out. (request id: iad1::iad1::request-id)'
     );
     expect(events[0].error.vercel_request_id).toBe('iad1::iad1::request-id');
   });
@@ -186,7 +186,7 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
     }[];
 
     expect(events[0].error.message).toBe(
-      'The upstream provider disconnected while sending the response.'
+      'The upstream response was interrupted while streaming. The provider may have disconnected or the request may have timed out.'
     );
     expect(events[0].error.vercel_request_id).toBeUndefined();
   });

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -209,7 +209,7 @@ function getResponseReadError(
     return {
       errorType: 'upstream_disconnect',
       message: withRequestId(
-        'The upstream provider disconnected while sending the response.',
+        'The upstream response was interrupted while streaming. The provider may have disconnected or the request may have timed out.',
         vercelRequestId
       ),
       vercelRequestId: vercelRequestId ?? undefined,


### PR DESCRIPTION
## Summary

- clarify that a mid-stream `ResponseAborted` can indicate either a provider disconnect or a request timeout
- preserve the existing `upstream_disconnect` error type and distinct `TimeoutError` handling
- update exact JSON and SSE message assertions with and without a Vercel request id

## Why

The previous message said the provider disconnected, but `ResponseAborted` only establishes that the response stream was interrupted. A timeout at the provider, intermediary, or request layer can surface through the same read-error path, so the injected client message should not claim a single cause.

## Verification

- `pnpm --filter web exec jest --runInBand --forceExit src/lib/rewriteModelResponse.test.ts` (72 tests passed)
- `pnpm exec oxfmt --list-different apps/web/src/lib/rewriteModelResponse.ts apps/web/src/lib/rewriteModelResponse.test.ts`
- `git diff --check`