### PR TITLE
fix(ai-gateway): standardize stream error payloads

### DIFF
--- a/apps/web/src/lib/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/rewriteModelResponse.test.ts
@@ -137,7 +137,7 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
     });
   });
 
-  test('includes the vercel request id in the JSON read error', async () => {
+  test('includes the vercel request id only in the JSON read error message', async () => {
     const result = await rewrite(
       failingResponse('application/json', 'ResponseAborted'),
       true,
@@ -152,11 +152,10 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
       error_type: 'upstream_disconnect',
       message:
         'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)',
-      vercel_request_id: 'iad1::iad1::request-id',
     });
   });
 
-  test('includes the vercel request id in the emitted stream error event', async () => {
+  test('includes the vercel request id only in the stream error message', async () => {
     const result = await rewrite(
       failingResponse('text/event-stream', 'ResponseAborted'),
       true,
@@ -164,14 +163,14 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
       'iad1::iad1::request-id'
     );
     const events = dataObjects(await readOutputStream(result)) as {
-      error: { message: string; vercel_request_id?: string };
+      error: { message: string };
     }[];
 
     expect(events).toHaveLength(1);
     expect(events[0].error.message).toBe(
       'The upstream provider disconnected while sending the response. (request id: iad1::iad1::request-id)'
     );
-    expect(events[0].error.vercel_request_id).toBe('iad1::iad1::request-id');
+    expect(events[0].error).not.toHaveProperty('vercel_request_id');
   });
 
   test('omits the request id suffix when no vercel request id is available', async () => {
@@ -182,13 +181,12 @@ describe.each(rewriters)('%s response read errors', (_name, rewrite) => {
       null
     );
     const events = dataObjects(await readOutputStream(result)) as {
-      error: { message: string; vercel_request_id?: string };
+      error: { message: string };
     }[];
 
     expect(events[0].error.message).toBe(
       'The upstream provider disconnected while sending the response.'
     );
-    expect(events[0].error.vercel_request_id).toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/rewriteModelResponse.ts
+++ b/apps/web/src/lib/rewriteModelResponse.ts
@@ -160,7 +160,6 @@ type ResponseReadError = {
   errorType: 'timeout' | 'upstream_disconnect';
   /** Already carries the request id suffix when one is available. */
   message: string;
-  vercelRequestId?: string;
 };
 
 const STREAM_PROGRESS_LOG_INTERVAL_MS = 30_000;
@@ -212,7 +211,6 @@ function getResponseReadError(
         'The upstream provider disconnected while sending the response.',
         vercelRequestId
       ),
-      vercelRequestId: vercelRequestId ?? undefined,
     };
   }
 
@@ -223,7 +221,6 @@ function getResponseReadError(
         'The upstream provider timed out while sending the response.',
         vercelRequestId
       ),
-      vercelRequestId: vercelRequestId ?? undefined,
     };
   }
 
@@ -254,9 +251,6 @@ async function readResponseText(
           error: responseReadError.message,
           error_type: responseReadError.errorType,
           message: responseReadError.message,
-          ...(responseReadError.vercelRequestId && {
-            vercel_request_id: responseReadError.vercelRequestId,
-          }),
         },
         { status: 503, headers }
       ),
@@ -482,9 +476,6 @@ export async function rewriteModelResponse_ChatCompletions(
               code: 503,
               message: responseReadError.message,
               type: responseReadError.errorType,
-              ...(responseReadError.vercelRequestId && {
-                vercel_request_id: responseReadError.vercelRequestId,
-              }),
             },
           }) +
           '\n\n',
@@ -665,9 +656,6 @@ export async function rewriteModelResponse_Messages(
               type: 'api_error',
               message: responseReadError.message,
               error_type: responseReadError.errorType,
-              ...(responseReadError.vercelRequestId && {
-                vercel_request_id: responseReadError.vercelRequestId,
-              }),
             },
           }) +
           '\n\n',
@@ -819,9 +807,6 @@ export async function rewriteModelResponse_Responses(
               type: responseReadError.errorType,
               code: responseReadError.errorType === 'timeout' ? '504' : '503',
               message: responseReadError.message,
-              ...(responseReadError.vercelRequestId && {
-                vercel_request_id: responseReadError.vercelRequestId,
-              }),
             },
           }) +
           '\n\n',


### PR DESCRIPTION
## Summary

- remove the non-standard `vercel_request_id` property from JSON response-read errors
- remove the same property from Chat Completions, Messages, and Responses SSE error objects
- retain the request ID suffix in each human-readable error message and retain internal request-ID logging
- update focused assertions to require that streamed error objects omit the custom field

## Compatibility

Vercel AI SDK v6 parses protocol-native error shapes:

- OpenAI-compatible errors use `error.message` with optional `type`, `param`, and `code`
- Anthropic Messages error events use `error.type` and `error.message`
- OpenAI Responses error events use their standard `type`, `code`, and `message` fields

The custom `vercel_request_id` member is unnecessary for correlation because the same value remains embedded in `message`, and omitting it keeps the emitted objects within those protocol shapes.

Reference: https://github.com/vercel/ai/tree/release-v6.0

## Verification

- `pnpm --filter web exec jest --runInBand --forceExit src/lib/rewriteModelResponse.test.ts` (72 tests passed)
- `pnpm exec oxfmt --list-different apps/web/src/lib/rewriteModelResponse.ts apps/web/src/lib/rewriteModelResponse.test.ts`
- `git diff --check`