### PR TITLE
fix(web): preserve organization welcome spacing

### DIFF
--- a/apps/web/src/components/organizations/OrganizationWelcomeHeader.tsx
+++ b/apps/web/src/components/organizations/OrganizationWelcomeHeader.tsx
@@ -41,8 +41,8 @@ export function OrganizationWelcomeHeader({
               Welcome to {organizationName}!
             </h3>
             <p className="mb-4 text-blue-200">
-              You&apos;ve been added to the <strong>{organizationName}</strong>{' '}organization. Click
-              &apos;Open in vscode&apos; to get started with Kilo Code.
+              You&apos;ve been added to the <strong>{organizationName}</strong>
+              {' organization'}. Click &apos;Open in vscode&apos; to get started with Kilo Code.
             </p>
             <div className="flex flex-col gap-3 sm:flex-row">
               <span className="bg-background">

--- a/apps/web/src/components/organizations/OrganizationWelcomeHeader.tsx
+++ b/apps/web/src/components/organizations/OrganizationWelcomeHeader.tsx
@@ -41,7 +41,7 @@ export function OrganizationWelcomeHeader({
               Welcome to {organizationName}!
             </h3>
             <p className="mb-4 text-blue-200">
-              You&apos;ve been added to the <strong>{organizationName}</strong> organization. Click
+              You&apos;ve been added to the <strong>{organizationName}</strong>{' '}organization. Click
               &apos;Open in vscode&apos; to get started with Kilo Code.
             </p>
             <div className="flex flex-col gap-3 sm:flex-row">


### PR DESCRIPTION
## Summary
- Preserve the space between the organization name and `organization` in the welcome banner.

## Verification
- `pnpm --filter web exec oxlint --config ../../.oxlintrc.json apps/web/src/components/organizations/OrganizationWelcomeHeader.tsx`
- `git diff --check`