### PR TITLE
fix(web): discard stale SSO sign-in hint after a failed sign-in

### DIFF
--- a/apps/web/src/hooks/useSignInFlow.ts
+++ b/apps/web/src/hooks/useSignInFlow.ts
@@ -8,6 +8,7 @@ import { ProdNonSSOAuthProviders } from '@/lib/auth/provider-metadata';
 import { useSignInHint, type SignInHint } from '@/hooks/useSignInHint';
 import { emailSchema, validateMagicLinkSignupEmail } from '@/lib/schemas/email';
 import { sendMagicLink } from '@/lib/auth/send-magic-link';
+import { shouldDiscardSsoHintOnError } from '@/lib/auth/sign-in-hint-recovery';
 import type { SSOOrganizationsResponse } from '@/lib/schemas/sso-organizations';
 
 export type FlowState = 'landing' | 'provider-select' | 'magic-link-sent' | 'redirecting';
@@ -161,6 +162,34 @@ export function useSignInFlow({
   const [showEmailInput, setShowEmailInput] = useState(
     storybookInitialState?.showEmailInput ?? (ssoMode || initialError === 'DIFFERENT-OAUTH')
   );
+
+  // Recover from a stale SSO hint. A hint pointing at a WorkOS organization that
+  // no longer resolves renders an "Enterprise SSO" button that can only ever fail,
+  // and that screen has no alternative method, so retries loop forever. Dropping
+  // the hint falls back to the email prompt, which re-runs the server-side
+  // organization lookup. See shouldDiscardSsoHintOnError for the full reasoning.
+  //
+  // One-shot: only the hint the user arrived with is inspected, so a hint saved
+  // later in this session (just before signIn redirects) is never clobbered.
+  const hintRecoveryCheckedRef = useRef(false);
+  useEffect(() => {
+    if (storybookInitialState || !isHintLoaded || hintRecoveryCheckedRef.current) {
+      return;
+    }
+    hintRecoveryCheckedRef.current = true;
+
+    if (!shouldDiscardSsoHintOnError(hint, initialError)) {
+      return;
+    }
+
+    const rememberedEmail = hint?.lastEmail;
+    clearHint();
+    // Keep the address so recovery is a single click instead of a retype.
+    if (rememberedEmail) {
+      setEmailState(rememberedEmail);
+    }
+    setShowEmailInput(true);
+  }, [isHintLoaded, hint, initialError, clearHint, storybookInitialState]);
 
   // Store pending SSO orgId in ref instead of window object
   const pendingSSOOrgIdRef = useRef<string | null>(null);

--- a/apps/web/src/lib/auth/sign-in-hint-recovery.test.ts
+++ b/apps/web/src/lib/auth/sign-in-hint-recovery.test.ts
@@ -1,0 +1,49 @@
+import { shouldDiscardSsoHintOnError } from '@/lib/auth/sign-in-hint-recovery';
+
+const ssoHint = { lastAuthMethod: 'workos', orgId: 'org_01KY7Q7B3W99QKBKYGWYK6SFK1' } as const;
+
+describe('shouldDiscardSsoHintOnError', () => {
+  it('discards an SSO hint when NextAuth rejects the WorkOS redirect', () => {
+    // WorkOS answers `error=organization_invalid` for an organization with no
+    // connection, which NextAuth surfaces as `Callback`.
+    expect(shouldDiscardSsoHintOnError(ssoHint, 'Callback')).toBe(true);
+  });
+
+  it('discards an SSO hint for any other error code that lands on sign-in', () => {
+    for (const error of [
+      'OAuthCallback',
+      'OAuthSignin',
+      'AccessDenied',
+      'OAUTH_ERROR',
+      'DIFFERENT-OAUTH',
+      'UNKNOWN-ERROR',
+      'some unmapped thrown message',
+    ]) {
+      expect(shouldDiscardSsoHintOnError(ssoHint, error)).toBe(true);
+    }
+  });
+
+  it('keeps the SSO hint when the page is not showing an error', () => {
+    expect(shouldDiscardSsoHintOnError(ssoHint, undefined)).toBe(false);
+    expect(shouldDiscardSsoHintOnError(ssoHint, null)).toBe(false);
+    expect(shouldDiscardSsoHintOnError(ssoHint, '')).toBe(false);
+  });
+
+  it('keeps non-SSO hints, which always have a working escape hatch', () => {
+    expect(shouldDiscardSsoHintOnError({ lastAuthMethod: 'google' }, 'Callback')).toBe(false);
+    expect(shouldDiscardSsoHintOnError({ lastAuthMethod: 'email' }, 'Callback')).toBe(false);
+    expect(shouldDiscardSsoHintOnError({ lastAuthMethod: 'github' }, 'OAuthCallback')).toBe(false);
+  });
+
+  it('keeps a workos hint that carries no organization id, since nothing is stale', () => {
+    expect(shouldDiscardSsoHintOnError({ lastAuthMethod: 'workos' }, 'Callback')).toBe(false);
+    expect(shouldDiscardSsoHintOnError({ lastAuthMethod: 'workos', orgId: '' }, 'Callback')).toBe(
+      false
+    );
+  });
+
+  it('tolerates a missing hint', () => {
+    expect(shouldDiscardSsoHintOnError(null, 'Callback')).toBe(false);
+    expect(shouldDiscardSsoHintOnError(undefined, 'Callback')).toBe(false);
+  });
+});

--- a/apps/web/src/lib/auth/sign-in-hint-recovery.ts
+++ b/apps/web/src/lib/auth/sign-in-hint-recovery.ts
@@ -1,0 +1,35 @@
+import type { SignInHint } from '@/hooks/useSignInHint';
+
+type SsoHintFields = Pick<SignInHint, 'lastAuthMethod' | 'orgId'>;
+
+/**
+ * Decides whether a stored sign-in hint must be discarded after a failed sign-in.
+ *
+ * An SSO hint is the only hint that pins the browser to a specific WorkOS
+ * organization id, and the returning-user screen intentionally offers no
+ * alternative method for it (other methods genuinely cannot work for a domain
+ * where SSO is required). That combination makes a stale SSO hint unrecoverable:
+ * if the organization stops resolving - deleted in WorkOS, its connection
+ * detached, or `organizations.sso_domain` cleared - the redirect fails, the user
+ * is bounced back here with an `error`, and the same failing button is rendered
+ * again. Every retry reproduces the failure.
+ *
+ * Discarding the hint returns the user to the email prompt, which re-runs the
+ * server-side `/api/sso/organizations` lookup and resolves the organization that
+ * is live right now.
+ *
+ * Any error is treated as disqualifying rather than an allowlist of codes. No
+ * error code means "the SSO redirect succeeded", the set of codes that can land
+ * on the sign-in page is large and drifts (NextAuth internals plus our own), and
+ * the outcomes are wildly asymmetric: a false positive costs one retyped email
+ * address, while a missed case leaves an account permanently unable to sign in.
+ */
+export function shouldDiscardSsoHintOnError(
+  hint: SsoHintFields | null | undefined,
+  error: string | null | undefined
+): boolean {
+  if (!error) {
+    return false;
+  }
+  return hint?.lastAuthMethod === 'workos' && !!hint.orgId;
+}


### PR DESCRIPTION
## Problem

The `signin_hint` entry in `localStorage` pins a returning SSO user to one WorkOS organization id, and the returning-user screen intentionally offers no alternative method for it (other methods genuinely cannot work for a domain where SSO is required).

That combination makes a stale SSO hint unrecoverable. If the organization stops resolving — deleted in WorkOS, its connection detached, or `organizations.sso_domain` cleared — the redirect fails, NextAuth bounces the user back to `/users/sign_in` with an `error`, and `SignInForm` renders the same failing **Sign in with Enterprise SSO** button from the same hint. Every retry reproduces the failure. Affected accounts cannot sign in at all until they manually clear site data, which no user will think to do.

### Observed in production

`anaconda.com` users holding a hint for an earlier WorkOS organization got:

```
GET /api/auth/callback/workos
  ?error=organization_invalid
  &error_description=No Connection associated with Organization 'org_01KY7Q7B3W99QKBKYGWYK6SFK1'
→ /api/auth/error?error=Callback
→ /users/sign_in?...&error=Callback     (renders the same broken button)
```

Meanwhile users who re-entered their email resolved the current organization and signed in fine — every redirect *preceded* by a `/api/sso/organizations` lookup succeeded; every redirect to the dead org had **no** preceding lookup. 133 such error callbacks over four days across 5 client IPs.

This class of failure emits **no** Sentry event (NextAuth aborts before our `signIn` callback) and **no** log line containing the user's email, so it is invisible to the usual searches.

## Change

Discard the hint when we arrive on the sign-in page with an error *and* the stored hint is an SSO hint. The user falls back to the email prompt, which re-runs the server-side `/api/sso/organizations` lookup and resolves the organization that is live right now. The remembered address is restored into the field so recovery is a single submit rather than a retype.

- **`apps/web/src/lib/auth/sign-in-hint-recovery.ts`** (new) — pure predicate `shouldDiscardSsoHintOnError(hint, error)`.
- **`apps/web/src/hooks/useSignInFlow.ts`** — one-shot effect that runs once the hint has loaded, calls the existing `clearHint()`, restores the email, and opens the email input.
- **`apps/web/src/lib/auth/sign-in-hint-recovery.test.ts`** (new) — 6 cases.

### Two decisions worth reviewing

**Any error disqualifies the hint, rather than an allowlist of codes.** No error code means "the SSO redirect succeeded"; the set of codes that can reach this page is large and already drifts across four places (the `AuthErrorType` union, the emitters, `AuthErrorNotification`'s switch, and NextAuth internals); and the outcomes are asymmetric — a false positive costs one prefilled submit, a missed case leaves an account permanently locked out. Non-SSO hints are untouched, since they already render an escape hatch.

**The check is one-shot on arrival.** Only the hint the user arrived with is inspected. Without the latch, the hint saved moments before `signIn()` redirects would be wiped while `initialError` was still in props.

The decision lives in a separate plain module because `apps/web` jest runs `testEnvironment: 'node'` with no jsdom or testing-library, and `testMatch` excludes `.test.tsx`, so the hook itself is not unit-testable today.

## Verification

Reproduced the production state against local dev in an isolated browser session, seeding `signin_hint` with the real dead org id:

| Scenario | Result |
|---|---|
| SSO hint, no `error` | Hint kept, SSO button still rendered — happy path intact |
| SSO hint + `?error=Callback` | `signin_hint` → `null`, SSO button gone, email prefilled and focused |
| Google hint + `?error=Callback` | Hint kept, "Continue with Google" + "or see other sign-in methods" — no regression |

Checks run:

- `npx tsgo --noEmit` in `apps/web` — exit 0
- `oxlint` on the three files — 0 warnings, 0 errors
- Full `apps/web` jest suite — 690 suites, 8796 passed, 3 skipped
- `oxfmt` applied; `git diff --check` clean

## Scope

Fixes recovery, not the cause. The WorkOS organization behind the production incident is already deleted, so re-attaching a connection is no longer an option — shipping this is the path for the remaining affected users.

Deliberately **not** included: an escape hatch on the SSO branch of `SignInForm.tsx`. For a domain where SSO is required, other methods cannot work, so offering them would mislead. Note that screen does already render "Not you? Use a different account" when the hint carries an email; the hard dead-end is a hint with `orgId` but no `lastEmail`.

Worth a separate PR: `OAUTH_ERROR` is still absent from `AuthErrorType`, and every NextAuth code (`Callback`, `OAuthCallback`, …) falls through to the generic "Oops! Something went wrong trying to log in." A message like "We couldn't reach your organization's SSO provider — enter your email to try again" would make this class of failure self-explanatory.
