### PR TITLE
chore(ai-gateway): remove OpenRouter GPT-5.6 promo code

### DIFF
--- a/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
+++ b/apps/web/src/app/api/openrouter/models/[provider]/[model]/endpoints/route.ts
@@ -36,7 +36,7 @@ export async function GET(
         ...storedModel,
         endpoints: storedModel.endpoints.map(endpoint => {
           if (!endpoint.pricing) return endpoint;
-          const displayPricing = getModelDisplayPricing(storedModel.id, endpoint.pricing);
+          const displayPricing = getModelDisplayPricing(endpoint.pricing);
           return {
             ...endpoint,
             pricing: applyCustomPricingToPricing(

--- a/apps/web/src/lib/ai-gateway/providers/openai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openai.ts
@@ -16,20 +16,3 @@ export const GPT_CURRENT_VERCEL_MODEL_ID = GPT_CURRENT_MODEL_ID;
 export const GPT_MINI_CURRENT_MODEL_ID = 'openai/gpt-5.4-mini';
 
 export const GPT_MINI_CURRENT_VERCEL_MODEL_ID = GPT_MINI_CURRENT_MODEL_ID;
-
-// OpenAI BYOK must be disabled on the OpenRouter website before enabling this flag.
-export const ENABLE_OPENROUTER_GPT56_PROMO = false;
-
-export const OPENROUTER_GPT56_PROMO_MODEL_IDS = [
-  'openai/gpt-5.6-terra',
-  'openai/gpt-5.6-terra-pro',
-  'openai/gpt-5.6-luna',
-  'openai/gpt-5.6-luna-pro',
-] as const;
-
-export function isOpenRouterGpt56PromoModel(modelId: string): boolean {
-  return (
-    ENABLE_OPENROUTER_GPT56_PROMO &&
-    OPENROUTER_GPT56_PROMO_MODEL_IDS.some(promoModelId => promoModelId === modelId)
-  );
-}

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/display-pricing.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/display-pricing.test.ts
@@ -1,5 +1,4 @@
 import { describe, expect, it } from '@jest/globals';
-import { OPENROUTER_GPT56_PROMO_MODEL_IDS } from '@/lib/ai-gateway/providers/openai';
 import {
   getModelDisplayPricing,
   undoPricingDiscount,
@@ -44,30 +43,23 @@ describe('undoPricingDiscount', () => {
   });
 });
 
-describe('OpenRouter GPT-5.6 promotion', () => {
-  const discountedPricing = {
-    prompt: '0.000001',
-    completion: '0.000004',
-    input_cache_read: '0.0000001',
-    discount: 0.5,
-  };
-
-  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)(
-    'undoes discounted pricing while the promotion is disabled for %s',
-    modelId => {
-      expect(getModelDisplayPricing(modelId, discountedPricing)).toEqual({
-        prompt: '0.000002000000',
-        completion: '0.000008000000',
-        input_cache_read: '0.000000200000',
-      });
-    }
-  );
-
-  it('continues to undo endpoint discounts for other models', () => {
-    expect(getModelDisplayPricing('openai/gpt-5.6-sol', discountedPricing)).toEqual({
+describe('getModelDisplayPricing', () => {
+  it('undoes endpoint discounts', () => {
+    expect(
+      getModelDisplayPricing({
+        prompt: '0.000001',
+        completion: '0.000004',
+        input_cache_read: '0.0000001',
+        discount: 0.5,
+      })
+    ).toEqual({
       prompt: '0.000002000000',
       completion: '0.000008000000',
       input_cache_read: '0.000000200000',
     });
+  });
+
+  it('returns undefined when there is no pricing', () => {
+    expect(getModelDisplayPricing(undefined)).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/display-pricing.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/display-pricing.ts
@@ -1,5 +1,4 @@
 import type { StoredModel } from '@kilocode/db';
-import { isOpenRouterGpt56PromoModel } from '@/lib/ai-gateway/providers/openai';
 
 export type EndpointPricing = NonNullable<StoredModel['endpoints'][number]['pricing']>;
 
@@ -19,9 +18,8 @@ export function undoPricingDiscount(pricing: EndpointPricing): EndpointPricing {
 }
 
 export function getModelDisplayPricing(
-  modelId: string,
   pricing: EndpointPricing | undefined
 ): EndpointPricing | undefined {
   if (!pricing) return undefined;
-  return isOpenRouterGpt56PromoModel(modelId) ? pricing : undoPricingDiscount(pricing);
+  return undoPricingDiscount(pricing);
 }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -17,7 +17,6 @@ import {
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { isFableModel } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { KILO_AUTO_EFFICIENT_MODEL } from '@/lib/ai-gateway/auto-model';
-import { OPENROUTER_GPT56_PROMO_MODEL_IDS } from '@/lib/ai-gateway/providers/openai';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
   getOpenRouterModelsMetadataFromDatabase: jest.fn(() => Promise.resolve({})),
@@ -157,25 +156,6 @@ describe('formatName', () => {
       pricing: { prompt: '0.00001', completion: '0' },
     });
     expect(formatName(model, NOT_PREFERRED)).toBe('OpenRouter Test Model ($$$$)');
-  });
-
-  it.each(OPENROUTER_GPT56_PROMO_MODEL_IDS)('does not show the disabled promo for %s', modelId => {
-    const recentlyCreated = Math.floor(Date.now() / 1000) - 24 * 3600;
-    const model = buildModel({
-      id: modelId,
-      created: recentlyCreated,
-      expiration_date: '2026-07-01',
-      pricing: { prompt: '0.00001', completion: '0', discount: 0.5 },
-    });
-    expect(formatName(model, 0)).toBe('Test Model ($$$$)');
-  });
-
-  it('does not show the disabled promo percentage from endpoint metadata', () => {
-    const model = buildModel({
-      id: OPENROUTER_GPT56_PROMO_MODEL_IDS[0],
-      pricing: { prompt: '0.00001', completion: '0', discount: 0.375 },
-    });
-    expect(formatName(model, NOT_PREFERRED)).toBe('Test Model ($$$$)');
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -27,7 +27,6 @@ import { getTerminalBenchSummaries, terminalBenchFor } from '@/lib/model-stats/t
 import { isFreeNemotronModel, NVIDIA_TRIAL_TOS } from '@/lib/ai-gateway/providers/nvidia';
 import { applyCustomPricingToModel } from '@/lib/ai-gateway/custom-pricing';
 import { addMonths } from 'date-fns';
-import { isOpenRouterGpt56PromoModel } from '@/lib/ai-gateway/providers/openai';
 import { getModelDisplayPricing } from '@/lib/ai-gateway/providers/openrouter/display-pricing';
 
 // Re-export from shared module for backwards compatibility
@@ -86,11 +85,6 @@ export function formatName(model: OpenRouterModel, preferredIndex: number) {
     model.id.startsWith('openrouter/') && !model.name.includes('OpenRouter')
       ? 'OpenRouter ' + model.name
       : model.name;
-  const discount = model.pricing.discount;
-  if (isOpenRouterGpt56PromoModel(model.id) && discount !== undefined && discount > 0) {
-    const percentage = Number((discount * 100).toFixed(2));
-    return `${name} (${percentage}% off)`;
-  }
   const promptPrice = Number.parseFloat(model.pricing.prompt);
   const isExpensive = Number.isFinite(promptPrice) && promptPrice >= 0.00001; // Opus 4.8 Fast price
   if (isExpensive) return name + ' ($$$$)';
@@ -146,7 +140,7 @@ async function enhancedModelList(models: OpenRouterModel[]) {
                 normalizeInferenceProviderId(e.tag) ===
                 normalizeInferenceProviderId(preferredProvider)
             )?.pricing);
-        const pricing = getModelDisplayPricing(model.id, rawPricing);
+        const pricing = getModelDisplayPricing(rawPricing);
         const terminalBench = terminalBenchFor(summaries, model.id);
         return {
           ...model,

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -27,7 +27,6 @@ import {
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { isOpenRouterGpt56PromoModel } from '@/lib/ai-gateway/providers/openai';
 
 type VercelRoutingPercentages = {
   paid: number;
@@ -97,13 +96,6 @@ export async function shouldRouteToVercel(
 ) {
   // BYOK in the Vercel AI Gateway was not working for Laguna models.
   if (requestedModel.includes('laguna')) {
-    return false;
-  }
-
-  if (isOpenRouterGpt56PromoModel(requestedModel)) {
-    console.debug(
-      `[shouldRouteToVercel] routing ${requestedModel} to OpenRouter for the GPT-5.6 promotion`
-    );
     return false;
   }
 


### PR DESCRIPTION
Removes the disabled OpenRouter GPT-5.6 promotion code:

- Drop `ENABLE_OPENROUTER_GPT56_PROMO`, `OPENROUTER_GPT56_PROMO_MODEL_IDS`, and `isOpenRouterGpt56PromoModel` from `providers/openai.ts`
- Remove the "(X% off)" promo label branch from `formatName` in the OpenRouter model list
- Remove the promo exception from `getModelDisplayPricing` (its now-unused `modelId` parameter is dropped; all endpoint discounts are undone uniformly)
- Remove the promo routing override in `shouldRouteToVercel`
- Update the affected tests

Verified with the ai-gateway Jest suites (60 tests) and web typecheck + oxlint.