### PR TITLE
feat(mobile): share pull request from the PR review header

### DIFF
--- a/apps/mobile/src/components/pr-review/pr-review-screen.test.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-screen.test.tsx
@@ -19,6 +19,7 @@ import { type PendingReviewItem } from '@/lib/pr-review/pending-review-provider'
 const routerPush = vi.fn();
 const routerBack = vi.fn();
 const routerCanGoBack = vi.fn(() => true);
+const shareMock = vi.hoisted(() => vi.fn(() => ({ action: 'sharedAction' })));
 
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof React>('react');
@@ -46,19 +47,29 @@ vi.mock('expo-router', () => ({
 }));
 
 vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
   RefreshControl: 'RefreshControl',
   ScrollView: 'ScrollView',
+  Share: { share: shareMock },
   View: 'View',
   Platform: { OS: 'ios' },
 }));
 
+let prQueryResult: { data: unknown; isLoading: boolean; isError: boolean; isFetching: boolean } = {
+  data: undefined,
+  isLoading: true,
+  isError: false,
+  isFetching: false,
+};
+
 vi.mock('@tanstack/react-query', () => ({
-  useQuery: () => ({ data: undefined, isLoading: true, isError: false, isFetching: false }),
+  useQuery: () => prQueryResult,
   useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
 
 vi.mock('lucide-react-native', () => ({
   Check: () => null,
+  Share: () => null,
 }));
 
 vi.mock('@/lib/hooks/use-theme-colors', () => ({
@@ -226,6 +237,78 @@ describe('PrReviewScreen Submit review reachability (P1-F-46b)', () => {
     expect(routerPush).toHaveBeenCalledWith({
       pathname: '/(app)/pr-review/[owner]/[repo]/[number]/review-submit',
       params: { owner: 'octocat', repo: 'hello', number: 7 },
+    });
+  });
+});
+
+describe('PrReviewScreen share action', () => {
+  beforeEach(() => {
+    prQueryResult = {
+      data: undefined,
+      isLoading: true,
+      isError: false,
+      isFetching: false,
+    };
+    shareMock.mockClear();
+  });
+
+  it('renders the Share affordance in the header', () => {
+    // eslint-disable-next-line new-cap
+    const element = PrReviewScreen({ owner: 'octocat', repo: 'hello', number: 7 });
+    const shareButton = findElement({
+      node: element,
+      type: 'Pressable',
+      prop: 'accessibilityLabel',
+      value: 'Share pull request',
+    });
+    expect(shareButton).not.toBeNull();
+  });
+
+  it('shares the URL only when no PR data is loaded yet', () => {
+    // eslint-disable-next-line new-cap
+    const element = PrReviewScreen({ owner: 'octocat', repo: 'hello', number: 7 });
+    const shareButton = findElement({
+      node: element,
+      type: 'Pressable',
+      prop: 'accessibilityLabel',
+      value: 'Share pull request',
+    });
+    if (!shareButton) {
+      throw new Error('Share button not found');
+    }
+    const onPress = (shareButton.props as { onPress?: () => void }).onPress;
+    onPress?.();
+
+    expect(shareMock).toHaveBeenCalledTimes(1);
+    expect(shareMock).toHaveBeenCalledWith({
+      message: 'https://github.com/octocat/hello/pull/7',
+    });
+  });
+
+  it('shares the title and URL when the PR title is loaded', () => {
+    prQueryResult = {
+      data: { title: 'Fix the thing' },
+      isLoading: false,
+      isError: false,
+      isFetching: false,
+    };
+    // eslint-disable-next-line new-cap
+    const element = PrReviewScreen({ owner: 'octocat', repo: 'hello', number: 7 });
+    const shareButton = findElement({
+      node: element,
+      type: 'Pressable',
+      prop: 'accessibilityLabel',
+      value: 'Share pull request',
+    });
+    if (!shareButton) {
+      throw new Error('Share button not found');
+    }
+    const onPress = (shareButton.props as { onPress?: () => void }).onPress;
+    onPress?.();
+
+    expect(shareMock).toHaveBeenCalledTimes(1);
+    expect(shareMock).toHaveBeenCalledWith({
+      message: 'Fix the thing\nhttps://github.com/octocat/hello/pull/7',
     });
   });
 });

--- a/apps/mobile/src/components/pr-review/pr-review-screen.tsx
+++ b/apps/mobile/src/components/pr-review/pr-review-screen.tsx
@@ -1,8 +1,8 @@
 import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { type Href, useFocusEffect, useRouter } from 'expo-router';
-import { Check } from 'lucide-react-native';
+import { Check, Share as ShareIcon } from 'lucide-react-native';
 import { type ReactNode, useCallback, useEffect, useState } from 'react';
-import { RefreshControl, ScrollView, View } from 'react-native';
+import { Pressable, RefreshControl, ScrollView, Share, View } from 'react-native';
 
 import { PrMergePartialSuccessBanner } from '@/components/pr-review/merge/pr-merge-partial-success-banner';
 import { PrReviewDiscussionTab } from '@/components/pr-review/pr-review-discussion-tab';
@@ -101,6 +101,17 @@ export function PrReviewScreen({ owner, repo, number }: PrReviewScreenProps) {
     });
   }, [pr.data, owner, repo, number]);
 
+  // Share the PR's public GitHub URL via the native share sheet. The URL comes
+  // from the route params, so this works before the PR query resolves; the title
+  // is added once it is known. Fire-and-forget, like the invite-link share in
+  // `invited-member-row.tsx` — cancelling resolves with `dismissedAction`, and a
+  // sheet the platform refuses to present has no actionable recovery.
+  const sharePullRequest = useCallback(() => {
+    const url = `https://github.com/${owner}/${repo}/pull/${number}`;
+    const title = pr.data?.title;
+    void Share.share({ message: title ? `${title}\n${url}` : url });
+  }, [owner, repo, number, pr.data?.title]);
+
   const handleRefresh = useCallback(() => {
     void (async () => {
       setRefreshing(true);
@@ -178,21 +189,31 @@ export function PrReviewScreen({ owner, repo, number }: PrReviewScreenProps) {
         title={`#${number}`}
         eyebrow={`${owner}/${repo}`}
         headerRight={
-          // P1-F-46b: the Submit-review affordance is reachable from the
-          // Overview tab (header right) and the Files tab (floating
-          // action bar). The Discussion tab is intentionally left without
-          // a submit affordance — comment threads there are read-only.
-          tab === 'overview' ? (
-            <Button
-              size="sm"
-              onPress={openReviewSubmit}
-              accessibilityLabel="Submit review"
-              className={cn('px-3')}
+          <View className="flex-row items-center gap-1">
+            <Pressable
+              onPress={sharePullRequest}
+              accessibilityRole="button"
+              accessibilityLabel="Share pull request"
+              className="h-10 w-10 items-center justify-center rounded-full active:bg-muted"
             >
-              <Check size={14} color={colors.primaryForeground} />
-              <Text>Submit review</Text>
-            </Button>
-          ) : null
+              <ShareIcon size={18} color={colors.foreground} />
+            </Pressable>
+            {/* P1-F-46b: the Submit-review affordance is reachable from the
+                Overview tab (header right) and the Files tab (floating
+                action bar). The Discussion tab is intentionally left without
+                a submit affordance — comment threads there are read-only. */}
+            {tab === 'overview' ? (
+              <Button
+                size="sm"
+                onPress={openReviewSubmit}
+                accessibilityLabel="Submit review"
+                className={cn('px-3')}
+              >
+                <Check size={14} color={colors.primaryForeground} />
+                <Text>Submit review</Text>
+              </Button>
+            ) : null}
+          </View>
         }
       />
       <View className="px-4 pb-2 pt-3">


### PR DESCRIPTION
## What

Adds an icon-only **Share pull request** action to the mobile PR review header.

## Why

Lets reviewers send the public GitHub pull-request link without leaving the app.

## How

- Uses the native React Native share sheet on every PR-review tab.
- Shares `https://github.com/<owner>/<repo>/pull/<number>` immediately; adds the PR title above it when loaded.
- Keeps the existing overview-only Submit review action unchanged.
- Covers URL-only and title-plus-URL payloads with unit tests.

## Verification

- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:unused`
- `pnpm test` — 296 files, 2581 tests passed
- `git diff --check`
- Fresh implementation review: no findings.
- iOS bot E2E: **VERIFICATION PASSED.**
  - Share sheet includes `Mixed discussion fixture` and `https://github.com/kilo-stub/discussion-mixed/pull/1`.
  - Dismissal preserves the Overview screen with no error toast.
  - Share control remains on Files and Discussion while header Submit review stays absent there.

## Visual Changes

Native iOS share sheet (title and public GitHub URL):

![ios-share-sheet-r3.png](https://github.com/user-attachments/assets/5551f4a5-8368-4366-8fb7-162064c1bf8a)

PR review header after dismissal (share icon visible):

![ios-share-header-r3.png](https://github.com/user-attachments/assets/ce5c0819-2530-4443-8c96-9ca093c50772)
