### PR TITLE
fix(mobile): force refresh active sessions

### DIFF
--- a/apps/mobile/src/lib/active-sessions-live-sync.manual-refresh.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.manual-refresh.test.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it } from 'vitest';
+
+import {
+  ActiveSessionsLiveSync,
+  makeCached,
+  makeConnection,
+  makeFakeQueryClient,
+  makeQueryFn,
+  QUERY_KEY,
+  setupTimers,
+  type SystemEvent,
+} from '@/lib/active-sessions-live-sync.test-helpers';
+import { refreshActiveSessionsNow } from '@/lib/active-sessions-live-sync';
+
+setupTimers();
+
+let sync: ActiveSessionsLiveSync | null = null;
+
+afterEach(() => {
+  if (sync) {
+    sync.detach();
+    sync = null;
+  }
+});
+
+describe('ActiveSessionsLiveSync — manual refresh', () => {
+  it('recovers a tray wedged by a missed reconnect signal', async () => {
+    const conn = makeConnection();
+    conn.__setConnected(true);
+    const qc = makeFakeQueryClient({ sessions: [] });
+    const queryFn = makeQueryFn();
+    sync = new ActiveSessionsLiveSync({
+      connection: conn,
+      queryClient: qc,
+      queryKey: QUERY_KEY,
+      queryFn,
+    });
+    sync.attach();
+
+    const pending = refreshActiveSessionsNow();
+    await sync.getFetchQueue();
+    expect(qc.__hasPendingFetch()).toBe(true);
+    expect(qc.fetchQueryCalls).toBe(1);
+
+    qc.__triggerFetchResolve({ sessions: [makeCached({ createdOnPlatform: 'cli' })] });
+    const result = await pending;
+    expect(result).toBe(true);
+    expect(qc.__getCached()?.sessions[0]?.id).toBe('a1');
+  });
+
+  it('does not resolve before the forced fetch settles', async () => {
+    const conn = makeConnection();
+    const qc = makeFakeQueryClient();
+    const queryFn = makeQueryFn();
+    sync = new ActiveSessionsLiveSync({
+      connection: conn,
+      queryClient: qc,
+      queryKey: QUERY_KEY,
+      queryFn,
+    });
+    sync.attach();
+
+    let settled = false;
+    const pending = refreshActiveSessionsNow();
+    // eslint-disable-next-line promise/prefer-await-to-then, promise/always-return
+    void pending.then(() => {
+      settled = true;
+    });
+
+    await sync.getFetchQueue();
+    expect(qc.__hasPendingFetch()).toBe(true);
+    expect(settled).toBe(false);
+
+    qc.__triggerFetchResolve({ sessions: [] });
+    await pending;
+    expect(settled).toBe(true);
+  });
+
+  it('stays pending across a write that cancels the manual fetch', async () => {
+    const conn = makeConnection();
+    const qc = makeFakeQueryClient();
+    const queryFn = makeQueryFn();
+    sync = new ActiveSessionsLiveSync({
+      connection: conn,
+      queryClient: qc,
+      queryKey: QUERY_KEY,
+      queryFn,
+    });
+    sync.attach();
+
+    const settledFlag = { value: false };
+    const pending = refreshActiveSessionsNow();
+    // eslint-disable-next-line promise/prefer-await-to-then, promise/always-return
+    void pending.then(() => {
+      settledFlag.value = true;
+    });
+    await sync.getFetchQueue();
+    expect(qc.fetchQueryCalls).toBe(1);
+
+    const disconnected: SystemEvent = {
+      event: 'cli.disconnected',
+      data: { connectionId: 'c1' },
+    };
+    conn.__fireSystem(disconnected);
+    await sync.getWriteQueue();
+    await sync.getFetchQueue();
+
+    expect(qc.fetchQueryCalls).toBe(2);
+    expect(qc.__hasPendingFetch()).toBe(true);
+    expect(settledFlag.value).toBe(false);
+
+    qc.__triggerFetchResolve({ sessions: [makeCached({ createdOnPlatform: 'cli' })] });
+    await pending;
+    expect(settledFlag.value).toBe(true);
+    expect(qc.__getCached()?.sessions[0]?.id).toBe('a1');
+  });
+
+  it('refetches after a failed refresh left a reason pending', async () => {
+    const conn = makeConnection();
+    const qc = makeFakeQueryClient();
+    const queryFn = makeQueryFn();
+    sync = new ActiveSessionsLiveSync({
+      connection: conn,
+      queryClient: qc,
+      queryKey: QUERY_KEY,
+      queryFn,
+    });
+    sync.attach();
+
+    // Build the D1 stuck state: a cli.disconnected refresh fails and is not re-kicked.
+    const disconnected: SystemEvent = {
+      event: 'cli.disconnected',
+      data: { connectionId: 'c1' },
+    };
+    conn.__fireSystem(disconnected);
+    await sync.getWriteQueue();
+    await sync.getFetchQueue();
+    qc.__triggerFetchReject(new Error('offline'));
+    await sync.getFetchCompletion();
+
+    // Owner is stuck with a pending reason and no in-flight fetch.
+    expect(sync.getPendingReasons().has('cli-disconnected')).toBe(true);
+    expect(qc.__hasPendingFetch()).toBe(false);
+
+    // Manual refresh kicks a new fetch that clears the stuck reason.
+    const previousCalls = qc.fetchQueryCalls;
+    const pending = refreshActiveSessionsNow();
+    await sync.getFetchQueue();
+    expect(qc.fetchQueryCalls).toBe(previousCalls + 1);
+    expect(qc.__hasPendingFetch()).toBe(true);
+
+    qc.__triggerFetchResolve({ sessions: [makeCached({ createdOnPlatform: 'cli' })] });
+    const result = await pending;
+    expect(result).toBe(true);
+    expect(qc.__getCached()?.sessions[0]?.id).toBe('a1');
+  });
+
+  it('returns false and fetches nothing when no owner is attached', async () => {
+    const conn = makeConnection();
+    const qc = makeFakeQueryClient();
+    const queryFn = makeQueryFn();
+    sync = new ActiveSessionsLiveSync({
+      connection: conn,
+      queryClient: qc,
+      queryKey: QUERY_KEY,
+      queryFn,
+    });
+    sync.attach();
+    sync.detach();
+
+    const prevCalls = qc.fetchQueryCalls;
+    const result = await refreshActiveSessionsNow();
+    expect(result).toBe(false);
+    expect(qc.fetchQueryCalls).toBe(prevCalls);
+  });
+});

--- a/apps/mobile/src/lib/active-sessions-live-sync.ts
+++ b/apps/mobile/src/lib/active-sessions-live-sync.ts
@@ -19,7 +19,7 @@ import { type UserWebConnection, type UserWebSystemEvent } from '@kilocode/cloud
 
 const ENRICHMENT_RETRY_MIN_INTERVAL_MS = 10_000;
 
-type RefreshReason = 'enrichment' | 'cli-connected' | 'cli-disconnected' | 'reconnect';
+type RefreshReason = 'enrichment' | 'cli-connected' | 'cli-disconnected' | 'reconnect' | 'manual';
 
 type SystemEvent = UserWebSystemEvent;
 
@@ -92,6 +92,8 @@ export class ActiveSessionsLiveSync {
     this.attachmentEpoch += 1;
     this.lastConnectedState = this.connection.isConnected();
     this.releaseRetain = this.connection.retain();
+    // eslint-disable-next-line typescript-eslint/no-this-alias, unicorn/no-this-assignment
+    attachedSync = this;
     this.systemListenerUnsubscribe = this.connection.onSystemEvent(event => {
       this.handleSystemEvent(event);
     });
@@ -112,6 +114,9 @@ export class ActiveSessionsLiveSync {
     this.systemListenerUnsubscribe = null;
     this.connectionListenerUnsubscribe = null;
     this.releaseRetain = null;
+    if (attachedSync === this) {
+      attachedSync = null;
+    }
     void this.queryClient.cancelQueries({ queryKey: this.queryKey });
   }
 
@@ -121,6 +126,36 @@ export class ActiveSessionsLiveSync {
     }
     this.pendingReasons.add(reason);
     this.kickFetch();
+  }
+
+  /**
+   * Manual (pull-to-refresh) resync. Runs through the same serialized fetch
+   * queue as WS-driven refreshes, so it can neither be cancelled by nor race
+   * with this owner's own writes, and it retries a refresh that an earlier
+   * failure left pending. Resolves when the forced fetch settles — it never
+   * rejects (`processFetchQueue` swallows fetch failures), so a caller's
+   * pull-to-refresh spinner always stops. Returns false when detached, so the
+   * caller can fall back to a plain query refetch.
+   */
+  async refreshNow(): Promise<boolean> {
+    if (this.releaseRetain === null) {
+      return false;
+    }
+    this.scheduleRefresh('manual');
+    // A write landing mid-fetch cancels that fetch and re-kicks the queue, so
+    // awaiting a single hop can return while the replacement fetch is still in
+    // flight. Follow the chain until the manual refresh is done (a successful
+    // fetch clears the reason) or nothing new was scheduled.
+    /* eslint-disable no-await-in-loop */
+    while (this.pendingReasons.has('manual')) {
+      const queue = this.fetchQueue;
+      await queue;
+      if (this.fetchQueue === queue) {
+        break;
+      }
+    }
+    /* eslint-enable no-await-in-loop */
+    return true;
   }
 
   async getWriteQueue(): Promise<void> {
@@ -317,4 +352,19 @@ export class ActiveSessionsLiveSync {
   private readInFlightFetchCanceled(): boolean {
     return this.inFlightFetchCanceled;
   }
+}
+
+/**
+ * The currently attached owner. One `<ActiveSessionsLiveSyncMount />` in
+ * `app/(app)/_layout.tsx` owns the live tray app-wide, so a module-scoped
+ * reference is the whole registry this needs.
+ */
+let attachedSync: ActiveSessionsLiveSync | null = null;
+
+/**
+ * Pull-to-refresh entry point for the live tray. Returns false when no owner
+ * is attached, so the caller falls back to a plain query refetch.
+ */
+export async function refreshActiveSessionsNow(): Promise<boolean> {
+  return (await attachedSync?.refreshNow()) ?? false;
 }

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.ts
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.ts
@@ -7,6 +7,7 @@ import {
   buildActiveSessionsTrayInput,
   filterActiveSessionsByOrganization,
 } from '@/lib/active-sessions-live';
+import { refreshActiveSessionsNow } from '@/lib/active-sessions-live-sync';
 import {
   buildAgentSessionListInput,
   buildAgentSessionSearchInput,
@@ -254,7 +255,19 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
     isFetchingNextPage: stored.isFetchingNextPage,
     fetchNextPage: stored.fetchNextPage,
     refetch: async () => {
-      await Promise.all([stored.refetch(), active.refetch()]);
+      await Promise.all([
+        stored.refetch(),
+        (async () => {
+          // The live-sync owner writes and cancels this same query key, so a
+          // plain refetch alone can be swallowed by it. Drive the owner when
+          // one is attached — it is keyed to the same organization context
+          // this hook is given — and fall back to the plain refetch otherwise.
+          if (await refreshActiveSessionsNow()) {
+            return;
+          }
+          await active.refetch();
+        })(),
+      ]);
     },
   };
 }


### PR DESCRIPTION
## Summary

### What
- Route session-list manual refresh through the active-sessions live-sync owner when attached.
- Add focused coverage for missed reconnect, cancelled/re-kicked fetches, stuck failed reasons, and no-owner fallback.

### Why
After a long background suspension, a missed connection transition can leave the Active now tray stale or empty. A plain query refetch can race with the live-sync owner and be cancelled.

### How
- Add a serialized manual refresh entry point and attached-owner registry.
- Make `useAgentSessions().refetch()` choose the owner path or the plain-query fallback, never both.
- Preserve existing polling, WebSocket handling, and UI states.

## Verification
- `apps/mobile: pnpm test` (297 files, 2583 tests)
- `apps/mobile: pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused`
- `pnpm typecheck`
- `git diff --check`
- iOS E2E: `VERIFICATION PASSED.` — live Active now tray, pull-to-refresh with a live tray, and pull-to-refresh with an empty tray.
- The long-background wedge is covered by unit tests because iOS simulator E2E cannot deterministically reproduce OS-coalesced reconnect events.

## Visual Changes

N/A — no UI change; this changes the manual-refresh code path only.