### PR TITLE
fix(web): preserve browser OAuth callbacks

### DIFF
--- a/apps/web/src/app/account-verification/page.tsx
+++ b/apps/web/src/app/account-verification/page.tsx
@@ -6,6 +6,7 @@ import { AccountCreationScreen } from '@/components/auth/AccountCreationScreen';
 import { getUserFromAuthOrRedirect } from '@/lib/user/server';
 import { getStytchStatus, handleSignupPromotion, type SignupSource } from '@/lib/stytch';
 import { isValidCallbackPath } from '@/lib/getSignInCallbackUrl';
+import { browserLandingPath } from '@/lib/app-link-safe-redirect';
 import { maybeInterceptWithSurvey } from '@/lib/survey-redirect';
 import { isOpenclawAdvisorCallback } from '@/lib/signup-source';
 import { isCreditCampaignCallback, lookupCampaignBySlug } from '@/lib/credit-campaigns';
@@ -62,7 +63,10 @@ export default async function AccountVerificationPage({ searchParams }: AppPageP
         if (isFirstValidation) {
           const campaign = await lookupCampaignBySlug(campaignMatch.slug);
           if (campaign) {
-            signupSource = { kind: 'credit-campaign', slug: campaignMatch.slug };
+            signupSource = {
+              kind: 'credit-campaign',
+              slug: campaignMatch.slug,
+            };
           }
         }
       }
@@ -74,7 +78,7 @@ export default async function AccountVerificationPage({ searchParams }: AppPageP
   if (stytchStatus !== null) {
     const hasUsableCallback = isValidCallback && !stripCreditCampaignCallback;
     const finalDestination = hasUsableCallback ? callbackStr : '/get-started';
-    redirect(maybeInterceptWithSurvey(user, finalDestination));
+    redirect(browserLandingPath(maybeInterceptWithSurvey(user, finalDestination)));
   }
 
   return (

--- a/apps/web/src/app/auth/signin/route.ts
+++ b/apps/web/src/app/auth/signin/route.ts
@@ -1,9 +1,10 @@
 import { APP_URL } from '@/lib/constants';
+import { browserLandingPath } from '@/lib/app-link-safe-redirect';
 import { type NextRequest, NextResponse } from 'next/server';
 
 export async function GET(request: NextRequest): Promise<NextResponse<unknown>> {
   const searchParams = request.nextUrl.searchParams;
   const source = searchParams.get('source');
-  const redirectUrl = `${APP_URL}/profile${source ? `?source=${source}` : ''}`;
-  return NextResponse.redirect(redirectUrl);
+  const path = `/profile${source ? `?source=${source}` : ''}`;
+  return NextResponse.redirect(new URL(browserLandingPath(path), APP_URL));
 }

--- a/apps/web/src/app/get-started/page.tsx
+++ b/apps/web/src/app/get-started/page.tsx
@@ -1,10 +1,14 @@
 import { buildLandingRedirectUrl } from '@/lib/landing-redirect';
+import { browserLandingPath } from '@/lib/app-link-safe-redirect';
 import { maybeInterceptWithSurvey } from '@/lib/survey-redirect';
 import { getProfileRedirectPath, getUserFromAuth } from '@/lib/user/server';
 import { redirect } from 'next/navigation';
 
 export default async function GetStartedPage({ searchParams }: AppPageProps) {
-  const { user } = await getUserFromAuth({ adminOnly: false, DANGEROUS_allowBlockedUsers: true });
+  const { user } = await getUserFromAuth({
+    adminOnly: false,
+    DANGEROUS_allowBlockedUsers: true,
+  });
 
   if (!user) {
     redirect(buildLandingRedirectUrl('/install', await searchParams));
@@ -18,5 +22,5 @@ export default async function GetStartedPage({ searchParams }: AppPageProps) {
     redirect('/account-verification');
   }
 
-  redirect(maybeInterceptWithSurvey(user, await getProfileRedirectPath(user)));
+  redirect(browserLandingPath(maybeInterceptWithSurvey(user, await getProfileRedirectPath(user))));
 }

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,4 +1,5 @@
 import { getProfileRedirectPath, getUserFromAuth } from '@/lib/user/server';
+import { browserLandingPath } from '@/lib/app-link-safe-redirect';
 import { redirect } from 'next/navigation';
 
 export default async function Home() {
@@ -6,5 +7,5 @@ export default async function Home() {
   if (!user) {
     redirect('/users/sign_in');
   }
-  redirect(await getProfileRedirectPath(user));
+  redirect(browserLandingPath(await getProfileRedirectPath(user)));
 }

--- a/apps/web/src/app/users/after-sign-in/route.test.ts
+++ b/apps/web/src/app/users/after-sign-in/route.test.ts
@@ -5,7 +5,7 @@ jest.mock('@/lib/constants', () => ({
 }));
 
 jest.mock('@/lib/user/server', () => ({
-  getProfileRedirectPath: jest.fn(async () => '/users/profile'),
+  getProfileRedirectPath: jest.fn(async () => '/profile'),
   getUserFromAuth: jest.fn(),
 }));
 
@@ -47,7 +47,7 @@ import {
   recordImpactAffiliateTouch,
   recordImpactReferralTouch,
 } from '@/lib/impact/referral';
-import { getUserFromAuth } from '@/lib/user/server';
+import { getUserFromAuth, getProfileRedirectPath } from '@/lib/user/server';
 import { GET } from './route';
 
 const mockGetAffiliateAttribution = jest.mocked(getAffiliateAttribution);
@@ -59,6 +59,7 @@ const mockQueueImpactAdvocateParticipantRegistration = jest.mocked(
   queueImpactAdvocateParticipantRegistration
 );
 const mockRecordImpactAffiliateTouch = jest.mocked(recordImpactAffiliateTouch);
+const mockGetProfileRedirectPath = jest.mocked(getProfileRedirectPath);
 const mockRecordImpactReferralTouch = jest.mocked(recordImpactReferralTouch);
 
 describe('GET /users/after-sign-in', () => {
@@ -158,7 +159,9 @@ describe('GET /users/after-sign-in', () => {
     );
 
     expect(response.status).toBe(307);
-    expect(response.headers.get('location')).toBe('http://localhost:3000/users/profile');
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/users/continue?to=%2Fprofile'
+    );
     expect(mockRecordAffiliateAttributionAndQueueParentEvent).not.toHaveBeenCalled();
     expect(consoleError).toHaveBeenCalledWith(
       '[after-sign-in] failed to persist affiliate attribution',
@@ -168,5 +171,98 @@ describe('GET /users/after-sign-in', () => {
       })
     );
     consoleError.mockRestore();
+  });
+
+  it('routes default landing through the interstitial', async () => {
+    const response = await GET(new NextRequest('http://localhost:3000/users/after-sign-in'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/users/continue?to=%2Fprofile'
+    );
+  });
+
+  it('routes callbackPath=/claw through the interstitial', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/users/after-sign-in?callbackPath=%2Fclaw')
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe(
+      'http://localhost:3000/users/continue?to=%2Fclaw'
+    );
+  });
+
+  it('routes callbackPath=/cloud/sessions through the interstitial', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/users/after-sign-in?callbackPath=%2Fcloud%2Fsessions')
+    );
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get('location') ?? '');
+    expect(location.pathname).toBe('/users/continue');
+    expect(location.searchParams.get('to')).toBe('/cloud/sessions');
+  });
+
+  it('does not route single-org /organizations/<id> through the interstitial', async () => {
+    mockGetProfileRedirectPath.mockResolvedValueOnce('/organizations/org-1');
+
+    const response = await GET(new NextRequest('http://localhost:3000/users/after-sign-in'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost:3000/organizations/org-1');
+  });
+
+  it('does not route /account-verification through the interstitial', async () => {
+    mockGetUserFromAuth.mockResolvedValueOnce({
+      user: {
+        id: 'user-after-sign-in',
+        google_user_email: 'after-sign-in@example.com',
+        blocked_reason: null,
+        has_validation_stytch: null,
+      },
+    } as Awaited<ReturnType<typeof getUserFromAuth>>);
+
+    const response = await GET(new NextRequest('http://localhost:3000/users/after-sign-in'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost:3000/account-verification');
+  });
+
+  it('does not route /sign-in-to-editor through the interstitial', async () => {
+    const response = await GET(
+      new NextRequest('http://localhost:3000/users/after-sign-in?source=code-oss')
+    );
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost:3000/sign-in-to-editor');
+  });
+
+  it('does not route /account-blocked through the interstitial', async () => {
+    mockGetUserFromAuth.mockResolvedValueOnce({
+      user: {
+        id: 'user-after-sign-in',
+        google_user_email: 'after-sign-in@example.com',
+        blocked_reason: 'payment',
+        has_validation_stytch: true,
+      },
+    } as Awaited<ReturnType<typeof getUserFromAuth>>);
+
+    const response = await GET(new NextRequest('http://localhost:3000/users/after-sign-in'));
+
+    expect(response.status).toBe(307);
+    expect(response.headers.get('location')).toBe('http://localhost:3000/account-blocked');
+  });
+
+  it('does not route unauthenticated /users/sign_in through the interstitial', async () => {
+    mockGetUserFromAuth.mockResolvedValueOnce({ user: null } as Awaited<
+      ReturnType<typeof getUserFromAuth>
+    >);
+
+    const response = await GET(new NextRequest('http://localhost:3000/users/after-sign-in'));
+
+    expect(response.status).toBe(307);
+    const location = new URL(response.headers.get('location') ?? '');
+    expect(location.pathname).toBe('/users/sign_in');
   });
 });

--- a/apps/web/src/app/users/after-sign-in/route.tsx
+++ b/apps/web/src/app/users/after-sign-in/route.tsx
@@ -25,6 +25,7 @@ import {
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { APP_URL } from '@/lib/constants';
+import { browserLandingPath } from '@/lib/app-link-safe-redirect';
 import { isOpenclawAdvisorCallback } from '@/lib/signup-source';
 import { isCreditCampaignCallback, lookupCampaignBySlug } from '@/lib/credit-campaigns';
 
@@ -281,7 +282,7 @@ export async function GET(request: NextRequest) {
     }
   }
 
-  const response = NextResponse.redirect(new URL(responsePath, APP_URL));
+  const response = NextResponse.redirect(new URL(browserLandingPath(responsePath), APP_URL));
 
   // Only set the marker after we've confirmed a user is present and the
   // cookie-based attribution path has been processed (recorded or skipped

--- a/apps/web/src/app/users/continue/ContinueClient.tsx
+++ b/apps/web/src/app/users/continue/ContinueClient.tsx
@@ -13,7 +13,7 @@ export function ContinueClient({ to }: { to: string }) {
 
   return (
     <div className="flex min-h-screen flex-col items-center justify-center gap-12">
-      <BigLoader title="Signing you in" />
+      <BigLoader title="Continuing" />
       <noscript>
         <a href={to} className="underline">
           Continue

--- a/apps/web/src/app/users/continue/ContinueClient.tsx
+++ b/apps/web/src/app/users/continue/ContinueClient.tsx
@@ -1,0 +1,24 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import BigLoader from '@/components/BigLoader';
+
+export function ContinueClient({ to }: { to: string }) {
+  const router = useRouter();
+
+  useEffect(() => {
+    router.replace(to);
+  }, [router, to]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-12">
+      <BigLoader title="Signing you in" />
+      <noscript>
+        <a href={to} className="underline">
+          Continue
+        </a>
+      </noscript>
+    </div>
+  );
+}

--- a/apps/web/src/app/users/continue/page.tsx
+++ b/apps/web/src/app/users/continue/page.tsx
@@ -1,0 +1,7 @@
+import { resolveHandoffDestination } from '@/lib/app-link-safe-redirect';
+import { ContinueClient } from './ContinueClient';
+
+export default async function ContinuePage({ searchParams }: AppPageProps) {
+  const to = resolveHandoffDestination((await searchParams).to);
+  return <ContinueClient to={to} />;
+}

--- a/apps/web/src/lib/app-link-safe-redirect.test.ts
+++ b/apps/web/src/lib/app-link-safe-redirect.test.ts
@@ -1,0 +1,156 @@
+import { UNIVERSAL_LINK_ROUTES } from '@kilocode/app-shared/universal-links';
+import {
+  APP_LINK_HANDOFF_FALLBACK,
+  APP_LINK_HANDOFF_PATH,
+  browserLandingPath,
+  isAppLinkClaimed,
+  resolveHandoffDestination,
+} from './app-link-safe-redirect';
+
+describe('browserLandingPath', () => {
+  it('routes /profile through the interstitial', () => {
+    expect(browserLandingPath('/profile')).toBe('/users/continue?to=%2Fprofile');
+  });
+
+  it('routes /profile with query through the interstitial, preserving query', () => {
+    expect(browserLandingPath('/profile?auto_topup_setup=success')).toBe(
+      '/users/continue?to=%2Fprofile%3Fauto_topup_setup%3Dsuccess'
+    );
+  });
+
+  it('passes unclaimed paths through unchanged', () => {
+    const unclaimed = [
+      '/organizations/abc123',
+      '/account-verification',
+      '/sign-in-to-editor',
+      '/users/accept-invite/x',
+      '/c/promo',
+      '/',
+    ];
+    for (const path of unclaimed) {
+      expect(browserLandingPath(path)).toBe(path);
+    }
+  });
+
+  it('routes every literal webPath from UNIVERSAL_LINK_ROUTES through the interstitial', () => {
+    const literals = UNIVERSAL_LINK_ROUTES.map(r => r.webPath).filter(p => !p.includes('*'));
+    for (const path of literals) {
+      expect(browserLandingPath(path)).toBe(
+        `${APP_LINK_HANDOFF_PATH}?to=${encodeURIComponent(path)}`
+      );
+    }
+  });
+
+  describe('wildcard row instantiations (criterion-4 regression guard)', () => {
+    const wildcardInstantiations: Record<string, string> = {
+      '/code-reviews/*': '/code-reviews/abc',
+      '/organizations/*/security-agent': '/organizations/o1/security-agent',
+      '/organizations/*/security-agent/findings': '/organizations/o1/security-agent/findings',
+      '/organizations/*/code-reviews': '/organizations/o1/code-reviews',
+      '/organizations/*/code-reviews/*': '/organizations/o1/code-reviews/r2',
+    };
+
+    for (const [pattern, concrete] of Object.entries(wildcardInstantiations)) {
+      it(`routes wildcard ${pattern} instantiation ${concrete} through the interstitial`, () => {
+        expect(browserLandingPath(concrete)).toBe(
+          `${APP_LINK_HANDOFF_PATH}?to=${encodeURIComponent(concrete)}`
+        );
+      });
+    }
+  });
+
+  it('passes excluded row through unchanged', () => {
+    expect(browserLandingPath('/code-reviews/review-md')).toBe('/code-reviews/review-md');
+  });
+});
+
+describe('isAppLinkClaimed', () => {
+  it('rejects absolute URLs with foreign hosts', () => {
+    expect(isAppLinkClaimed('https://evil.com/profile')).toBe(false);
+  });
+
+  it('rejects protocol-relative URLs', () => {
+    expect(isAppLinkClaimed('//evil.com/profile')).toBe(false);
+  });
+
+  it('rejects paths with backslash', () => {
+    expect(isAppLinkClaimed(String.raw`/\evil`)).toBe(false);
+  });
+
+  it('rejects javascript: pseudo-URLs', () => {
+    expect(isAppLinkClaimed('javascript:alert(1)')).toBe(false);
+  });
+
+  it('rejects paths without leading slash', () => {
+    expect(isAppLinkClaimed('profile')).toBe(false);
+  });
+
+  it('accepts claimed paths', () => {
+    expect(isAppLinkClaimed('/profile')).toBe(true);
+    expect(isAppLinkClaimed('/claw')).toBe(true);
+    expect(isAppLinkClaimed('/cloud/sessions')).toBe(true);
+  });
+
+  it('rejects unclaimed paths', () => {
+    expect(isAppLinkClaimed('/organizations/abc123')).toBe(false);
+    expect(isAppLinkClaimed('/account-verification')).toBe(false);
+  });
+});
+
+describe('resolveHandoffDestination', () => {
+  it('returns claimed destinations as-is', () => {
+    expect(resolveHandoffDestination('/profile')).toBe('/profile');
+    expect(resolveHandoffDestination('/claw')).toBe('/claw');
+  });
+
+  it('falls back to /profile for undefined', () => {
+    expect(resolveHandoffDestination(undefined)).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for empty string', () => {
+    expect(resolveHandoffDestination('')).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for array form (Next can produce array params)', () => {
+    expect(resolveHandoffDestination(['/profile'])).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for absolute URLs', () => {
+    expect(resolveHandoffDestination('https://evil.com')).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for protocol-relative URLs', () => {
+    expect(resolveHandoffDestination('//evil.com')).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for multiple slashes prefix', () => {
+    expect(resolveHandoffDestination('///evil.com')).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for backslash paths', () => {
+    expect(resolveHandoffDestination(String.raw`/\\evil`)).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for javascript: pseudo-URLs', () => {
+    expect(resolveHandoffDestination('javascript:alert(1)')).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for full http URLs to our domain', () => {
+    expect(resolveHandoffDestination('http://app.kilo.ai/profile')).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  it('falls back to /profile for unclaimed valid paths', () => {
+    expect(resolveHandoffDestination('/account-verification')).toBe(APP_LINK_HANDOFF_FALLBACK);
+  });
+
+  describe('round-trip for every literal claimed webPath', () => {
+    const literals = UNIVERSAL_LINK_ROUTES.map(r => r.webPath).filter(p => !p.includes('*'));
+
+    for (const path of literals) {
+      it(`round-trips ${path}`, () => {
+        const search = new URLSearchParams(browserLandingPath(path).split('?')[1]);
+        expect(resolveHandoffDestination(search.get('to') ?? undefined)).toBe(path);
+      });
+    }
+  });
+});

--- a/apps/web/src/lib/app-link-safe-redirect.ts
+++ b/apps/web/src/lib/app-link-safe-redirect.ts
@@ -1,0 +1,43 @@
+import { webPathToAppPath } from '@kilocode/app-shared/universal-links';
+
+/** Unclaimed interstitial that finishes the hop client-side. Never add to UNIVERSAL_LINK_ROUTES. */
+export const APP_LINK_HANDOFF_PATH = '/users/continue';
+
+/** Default when `to` is absent or fails validation. */
+export const APP_LINK_HANDOFF_FALLBACK = '/profile';
+
+/**
+ * Universal Links / App Links match on path only. A server redirect that lands the
+ * browser on a claimed path gets routed into the native app, which breaks web login
+ * (see /users/continue). Route those destinations through the unclaimed interstitial;
+ * pass everything else through untouched.
+ */
+export function browserLandingPath(destination: string): string {
+  if (!isAppLinkClaimed(destination)) {
+    return destination;
+  }
+  return `${APP_LINK_HANDOFF_PATH}?to=${encodeURIComponent(destination)}`;
+}
+
+/** True when `destination` (path, optionally with query/fragment) is claimed by the app. */
+export function isAppLinkClaimed(destination: string): boolean {
+  const pathname = destination.split('?')[0]?.split('#')[0] ?? '';
+  if (!pathname.startsWith('/') || pathname.startsWith('//') || pathname.includes('\\')) {
+    return false;
+  }
+  const normalised =
+    pathname.length > 1 && pathname.endsWith('/') ? pathname.slice(0, -1) : pathname;
+  return webPathToAppPath(normalised) !== null;
+}
+
+/**
+ * Resolve the `to` query param of /users/continue to a safe destination.
+ * Only table-claimed same-origin paths are accepted — that is the tight allowlist
+ * that keeps this route from becoming an open redirect. Anything else falls back.
+ */
+export function resolveHandoffDestination(to: string | string[] | undefined): string {
+  if (typeof to !== 'string' || !isAppLinkClaimed(to)) {
+    return APP_LINK_HANDOFF_FALLBACK;
+  }
+  return to;
+}

--- a/apps/web/src/tests/account-verification-redirect.test.ts
+++ b/apps/web/src/tests/account-verification-redirect.test.ts
@@ -306,7 +306,9 @@ describe('account-verification redirect logic', () => {
       mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
       mockGetStytchStatus.mockResolvedValue(true);
 
-      await renderPage({ callbackPath: '/openclaw-advisor-fake?code=ABCD-1234' });
+      await renderPage({
+        callbackPath: '/openclaw-advisor-fake?code=ABCD-1234',
+      });
 
       expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
     });
@@ -368,7 +370,9 @@ describe('account-verification redirect logic', () => {
 
       // 17 ASCII alphanumerics — within the charset but longer than the
       // device-auth generator ever produces. Rejected by the format guard.
-      await renderPage({ callbackPath: '/openclaw-advisor?code=ABCDEFGHIJKLMNOPQ' });
+      await renderPage({
+        callbackPath: '/openclaw-advisor?code=ABCDEFGHIJKLMNOPQ',
+      });
 
       expect(mockHandleSignupPromotion).toHaveBeenCalledWith(user, true, null);
     });
@@ -393,7 +397,10 @@ describe('account-verification redirect logic', () => {
       // granted, sending the user back to /c/<slug> just shows them the
       // "for new accounts" message. Always strip the callback so they
       // land on /get-started like any other new signup.
-      const user = makeUser({ has_validation_stytch: null, customer_source: 'Reddit' });
+      const user = makeUser({
+        has_validation_stytch: null,
+        customer_source: 'Reddit',
+      });
       mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
       mockGetStytchStatus.mockResolvedValue(true);
 
@@ -425,7 +432,10 @@ describe('account-verification redirect logic', () => {
       // fires on the callback so signup lands on /get-started instead of
       // the dead /c/<slug> URL.
       mockLookupCampaignBySlug.mockResolvedValue(null);
-      const user = makeUser({ has_validation_stytch: null, customer_source: 'Reddit' });
+      const user = makeUser({
+        has_validation_stytch: null,
+        customer_source: 'Reddit',
+      });
       mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
       mockGetStytchStatus.mockResolvedValue(true);
 
@@ -442,7 +452,10 @@ describe('account-verification redirect logic', () => {
       // /c/Summit (uppercase) or /c/xx (short) would pass the callback
       // whitelist but skip the strip, and the user would be redirected
       // to the malformed URL post-signup.
-      const user = makeUser({ has_validation_stytch: null, customer_source: 'Reddit' });
+      const user = makeUser({
+        has_validation_stytch: null,
+        customer_source: 'Reddit',
+      });
       mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
       mockGetStytchStatus.mockResolvedValue(true);
 
@@ -458,7 +471,10 @@ describe('account-verification redirect logic', () => {
       // second pass `has_validation_stytch` is no longer null. The strip
       // decision runs independently of `isFirstValidation` so the redirect
       // still routes to /get-started, not the (now-useless) /c/<slug>.
-      const user = makeUser({ has_validation_stytch: true, customer_source: 'Reddit' });
+      const user = makeUser({
+        has_validation_stytch: true,
+        customer_source: 'Reddit',
+      });
       mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
       mockGetStytchStatus.mockResolvedValue(true);
 
@@ -554,6 +570,33 @@ describe('account-verification redirect logic', () => {
       expect(mockRedirect).toHaveBeenCalledTimes(1);
       // Invalid callbackPath dropped — go to /get-started
       expect(mockRedirect).toHaveBeenCalledWith('/get-started');
+    });
+  });
+
+  // ---------------------------------------------------------------
+  // App-link-safe-redirect interstitial: claimed callback paths
+  // ---------------------------------------------------------------
+  describe('app-link-safe-redirect interstitial', () => {
+    it('routes callbackPath=/claw through the interstitial', async () => {
+      const user = makeUser({ customer_source: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      await renderPage({ callbackPath: '/claw' });
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).toHaveBeenCalledWith('/users/continue?to=%2Fclaw');
+    });
+
+    it('routes callbackPath=/profile through the interstitial', async () => {
+      const user = makeUser({ customer_source: null });
+      mockGetUserFromAuthOrRedirect.mockResolvedValue(user);
+      mockGetStytchStatus.mockResolvedValue(true);
+
+      await renderPage({ callbackPath: '/profile' });
+
+      expect(mockRedirect).toHaveBeenCalledTimes(1);
+      expect(mockRedirect).toHaveBeenCalledWith('/users/continue?to=%2Fprofile');
     });
   });
 });


### PR DESCRIPTION
## Summary

### What
Route browser OAuth and signup completion redirects that land on app-claimed paths through a new `/users/continue` interstitial.

### Why
iOS Universal Links and Android App Links can hand a browser document navigation to the installed app. A mobile-browser OAuth return ending at `/profile` (or another claimed callback path) therefore prevents web login from completing in that browser.

### How
- Add a table-derived `browserLandingPath` guard backed by `UNIVERSAL_LINK_ROUTES`.
- Add `/users/continue`, which validates the target then uses client-side `router.replace` for the final hop.
- Apply the guard only to the five authentication redirect sites and add table-driven, open-redirect, login, and signup coverage.

## Verification
- `pnpm typecheck` — passed
- `pnpm lint` — passed
- `pnpm run format:changed` — passed
- `cd apps/web && pnpm test` — 694 suites passed; one pre-existing unrelated timeout failed in `src/lib/kiloclaw/subscription-schema.test.ts` during database cleanup
- Focused redirect tests — 79 tests passed
- Cumulative implementation review — no findings
- iOS E2E verifier — passed. It confirmed default and `/claw` auth server redirects target the handoff, hostile `to` values stay local, `kiloapp://profile` preserves profile deep-link resolution, and a fresh single-org user redirects directly to its organization without a handoff.
- Latest-head E2E verifier — passed. It captured the neutral `Continuing` loading state after the copy repair.

## E2E limitation
Native OS-level universal-link interception (Safari handing a claimed URL to the installed app) cannot be reproduced in a simulator: the local dev build does not have an App-Store-signed production AASA association or a real cross-domain OAuth return. The E2E verifier did not claim to verify or refute that OS behavior. The unit tests are the authoritative proof that auth server redirects route claimed targets through the interstitial.

## Universal-link scope
The shared universal-link table and both `.well-known` files are deliberately unchanged. Mobile files are unchanged as well, preserving existing deep-link and Smart App Banner behavior.

## Deferred Stripe/payment returns
These audited same-class defects are deliberately out of scope for this authentication-only PR:

| Site | Lands on |
|---|---|
| `apps/web/src/lib/stripe/index.ts:1418` | `/profile?auto_topup_setup=cancelled` |
| `apps/web/src/routers/kilo-pass-router.ts:1755` | `/profile` (billing-portal `return_url`) |
| `apps/web/src/routers/kilo-pass-router.ts:2375` | `/profile?kilo_pass_checkout=cancelled` |
| `apps/web/src/routers/kiloclaw-router.ts:5900` | `/claw?checkout=cancelled` |
| `apps/web/src/routers/kiloclaw-router.ts:6344` | `/claw` (billing-portal `return_url`) |
| `apps/web/src/lib/stripe/index.ts:1489,1613`; `kiloclaw-router.ts:5504` | via `cancelUrl` variables — trace before fixing |
| `apps/web/src/app/payments/auto-topup/success/route.ts:8` | `/profile?auto_topup_setup=success` |

## Visual Changes
![users-continue-loading.png](https://github.com/user-attachments/assets/7689c8ef-186f-4f2e-b73e-db6c1b3cacb1)
