### PR TITLE
fix(ai-gateway): map DeepSeek V4 Flash to Vercel

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -43,7 +43,7 @@ describe('mapModelIdToVercel', () => {
 
   describe('hardcoded OpenRouter → Vercel mapping', () => {
     it.each([
-      ['deepseek/deepseek-v4-flash-latest', 'deepseek/deepseek-v4-flash'],
+      ['deepseek/deepseek-v4-flash-latest', 'deepseek/deepseek-v4-flash-0731'],
       ['mistralai/codestral-2508', 'mistral/codestral'],
       ['mistralai/devstral-2512', 'mistral/devstral-2'],
       ['mistralai/mistral-embed-2312', 'mistral/mistral-embed'],

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -43,6 +43,7 @@ describe('mapModelIdToVercel', () => {
 
   describe('hardcoded OpenRouter → Vercel mapping', () => {
     it.each([
+      ['deepseek/deepseek-v4-flash-latest', 'deepseek/deepseek-v4-flash'],
       ['mistralai/codestral-2508', 'mistral/codestral'],
       ['mistralai/devstral-2512', 'mistral/devstral-2'],
       ['mistralai/mistral-embed-2312', 'mistral/mistral-embed'],

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -28,6 +28,7 @@ const vercelModelIdMapping: Record<string, string | undefined> = {
   '~google/gemini-pro-latest': GEMINI_PRO_CURRENT_VERCEL_MODEL_ID,
   '~google/gemini-flash-latest': GEMINI_FLASH_CURRENT_VERCEL_MODEL_ID,
   '~x-ai/grok-latest': GROK_CURRENT_VERCEL_MODEL_ID,
+  'deepseek/deepseek-v4-flash-latest': 'deepseek/deepseek-v4-flash',
   'inclusionai/ling-3.0-flash:free': 'inclusionai/ling-3.0-flash-free',
   'mistralai/codestral-2508': 'mistral/codestral',
   'mistralai/devstral-2512': 'mistral/devstral-2',

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -28,7 +28,7 @@ const vercelModelIdMapping: Record<string, string | undefined> = {
   '~google/gemini-pro-latest': GEMINI_PRO_CURRENT_VERCEL_MODEL_ID,
   '~google/gemini-flash-latest': GEMINI_FLASH_CURRENT_VERCEL_MODEL_ID,
   '~x-ai/grok-latest': GROK_CURRENT_VERCEL_MODEL_ID,
-  'deepseek/deepseek-v4-flash-latest': 'deepseek/deepseek-v4-flash',
+  'deepseek/deepseek-v4-flash-latest': 'deepseek/deepseek-v4-flash-0731',
   'inclusionai/ling-3.0-flash:free': 'inclusionai/ling-3.0-flash-free',
   'mistralai/codestral-2508': 'mistral/codestral',
   'mistralai/devstral-2512': 'mistral/devstral-2',


### PR DESCRIPTION
## Summary
- map the OpenRouter `deepseek/deepseek-v4-flash-latest` model ID to Vercel's dated `deepseek/deepseek-v4-flash-0731` ID
- add regression coverage to the existing mapping test table

## Testing
- focused mapping Jest suite (39 tests passed)
- focused `oxlint` on both changed files
- `git diff --check`