### PR TITLE
feat(mobile): add pinch zoom to table viewer

### DIFF
--- a/apps/mobile/e2e/github-api-stub/server.mjs
+++ b/apps/mobile/e2e/github-api-stub/server.mjs
@@ -141,7 +141,16 @@ function buildMixedFixture(idSuffix) {
 
   return {
     title: 'Mixed discussion fixture',
-    body: 'PR body for mixed fixture.',
+    body: [
+      'PR body for mixed fixture.',
+      '',
+      '| ColAlpha | ColBeta | ColGamma | ColDelta | ColEpsilon |',
+      '| --- | --- | --- | --- | --- |',
+      '| ZoomCellA1 | ZoomCellB1 | ZoomCellC1 | ZoomCellD1 | ZoomCellE1 |',
+      '| ZoomCellA2 | ZoomCellB2 | ZoomCellC2 | ZoomCellD2 | ZoomCellE2 |',
+      '| ZoomCellA3 | ZoomCellB3 | ZoomCellC3 | ZoomCellD3 | ZoomCellE3 |',
+      '| ZoomCellA4 | ZoomCellB4 | ZoomCellC4 | ZoomCellD4 | ZoomCellE4 |',
+    ].join('\n'),
     files: stubFiles(),
     threads: [
       {

--- a/apps/mobile/e2e/github-api-stub/server.mjs
+++ b/apps/mobile/e2e/github-api-stub/server.mjs
@@ -141,16 +141,7 @@ function buildMixedFixture(idSuffix) {
 
   return {
     title: 'Mixed discussion fixture',
-    body: [
-      'PR body for mixed fixture.',
-      '',
-      '| ColAlpha | ColBeta | ColGamma | ColDelta | ColEpsilon |',
-      '| --- | --- | --- | --- | --- |',
-      '| ZoomCellA1 | ZoomCellB1 | ZoomCellC1 | ZoomCellD1 | ZoomCellE1 |',
-      '| ZoomCellA2 | ZoomCellB2 | ZoomCellC2 | ZoomCellD2 | ZoomCellE2 |',
-      '| ZoomCellA3 | ZoomCellB3 | ZoomCellC3 | ZoomCellD3 | ZoomCellE3 |',
-      '| ZoomCellA4 | ZoomCellB4 | ZoomCellC4 | ZoomCellD4 | ZoomCellE4 |',
-    ].join('\n'),
+    body: 'PR body for mixed fixture.',
     files: stubFiles(),
     threads: [
       {

--- a/apps/mobile/src/components/agents/markdown-table.tsx
+++ b/apps/mobile/src/components/agents/markdown-table.tsx
@@ -128,9 +128,6 @@ export function MarkdownTable({ palette, header, rows }: Readonly<MarkdownTableP
       ? undefined
       : { width: natural.width * zoom, height: natural.height * zoom };
 
-  const clamp = (value: number) =>
-    Number.isFinite(value) ? Math.min(Math.max(value, ZOOM_MIN), ZOOM_MAX) : ZOOM_DEFAULT;
-
   // eslint-disable-next-line new-cap -- RNGH's gesture builder API is Gesture.Pinch().
   const pinch = Gesture.Pinch()
     .simultaneousWithExternalGesture(...scrollGestureRefs)
@@ -139,14 +136,19 @@ export function MarkdownTable({ palette, header, rows }: Readonly<MarkdownTableP
     })
     .onUpdate(e => {
       if (gestureSession.value === session.value) {
-        scale.value = clamp(savedScale.value * e.scale);
+        const next = savedScale.value * e.scale;
+        scale.value = Number.isFinite(next)
+          ? Math.min(Math.max(next, ZOOM_MIN), ZOOM_MAX)
+          : ZOOM_DEFAULT;
       }
     })
     .onEnd(() => {
       if (gestureSession.value !== session.value) {
         return;
       }
-      const next = clamp(scale.value);
+      const next = Number.isFinite(scale.value)
+        ? Math.min(Math.max(scale.value, ZOOM_MIN), ZOOM_MAX)
+        : ZOOM_DEFAULT;
       scale.value = next;
       savedScale.value = next;
       scheduleOnRN(applyZoom, next, gestureSession.value);

--- a/apps/mobile/src/components/agents/markdown-table.tsx
+++ b/apps/mobile/src/components/agents/markdown-table.tsx
@@ -1,7 +1,32 @@
+/* eslint-disable max-lines -- modal zoom keeps its gesture and table layout coupled in one component */
 import { Table2, X } from 'lucide-react-native';
-import { type ReactNode, useState } from 'react';
-import { Modal, Pressable, ScrollView, Text, useWindowDimensions, View } from 'react-native';
+import {
+  type ComponentRef,
+  type ComponentType,
+  type ReactNode,
+  type RefObject,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react';
+import {
+  type LayoutChangeEvent,
+  Modal,
+  Pressable,
+  Text,
+  useWindowDimensions,
+  View,
+} from 'react-native';
+import {
+  Gesture,
+  GestureDetector,
+  GestureHandlerRootView,
+  ScrollView,
+} from 'react-native-gesture-handler';
+import Animated, { useAnimatedStyle, useSharedValue } from 'react-native-reanimated';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
+import { scheduleOnRN } from 'react-native-worklets';
 
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 
@@ -9,6 +34,10 @@ import { type MarkdownPalette } from './markdown-palette';
 
 const MODAL_COLUMN_MIN_WIDTH = 148;
 const MODAL_HORIZONTAL_PADDING = 16;
+
+const ZOOM_MIN = 0.4;
+const ZOOM_MAX = 3;
+const ZOOM_DEFAULT = 1;
 
 type MarkdownTableProps = {
   palette: MarkdownPalette;
@@ -49,6 +78,103 @@ export function MarkdownTable({ palette, header, rows }: Readonly<MarkdownTableP
     Math.floor((windowWidth - MODAL_HORIZONTAL_PADDING * 2) / Math.max(columnCount, 1))
   );
 
+  const [zoom, setZoom] = useState(ZOOM_DEFAULT);
+  const [natural, setNatural] = useState<{ width: number; height: number } | undefined>(undefined);
+  const scale = useSharedValue(ZOOM_DEFAULT);
+  const savedScale = useSharedValue(ZOOM_DEFAULT);
+  const session = useSharedValue(0);
+  const gestureSession = useSharedValue(0);
+  const verticalRef = useRef<ComponentRef<typeof ScrollView>>(null);
+  const horizontalRef = useRef<ComponentRef<typeof ScrollView>>(null);
+
+  // RNGH types an external gesture ref as RefObject<ComponentType> (see
+  // node_modules/react-native-gesture-handler/lib/typescript/handlers/gestures/gesture.d.ts:5),
+  // which a host-instance ref does not satisfy, while at runtime it only reads
+  // `handlerTag` off the ref object. One cast, here, is the whole workaround.
+  const scrollGestureRefs = [verticalRef, horizontalRef] as unknown as RefObject<ComponentType>[];
+
+  const applyZoom = useCallback(
+    (next: number, gestureGeneration: number) => {
+      if (gestureGeneration === session.value) {
+        setZoom(next);
+      }
+    },
+    [session]
+  );
+
+  useEffect(() => {
+    if (!open) {
+      setZoom(ZOOM_DEFAULT);
+      scale.value = ZOOM_DEFAULT;
+      savedScale.value = ZOOM_DEFAULT;
+    }
+  }, [open, savedScale, scale, session]);
+
+  // Natural (unscaled) table size — a transform does not change layout, so this
+  // measurement stays valid at every zoom level. Epsilon guard stops a re-render loop.
+  const handleTableLayout = useCallback((event: LayoutChangeEvent) => {
+    const { width, height } = event.nativeEvent.layout;
+    setNatural(prev =>
+      prev !== undefined &&
+      Math.abs(prev.width - width) < 0.5 &&
+      Math.abs(prev.height - height) < 0.5
+        ? prev
+        : { width, height }
+    );
+  }, []);
+
+  const sizerStyle =
+    natural === undefined || natural.width <= 0 || natural.height <= 0
+      ? undefined
+      : { width: natural.width * zoom, height: natural.height * zoom };
+
+  const clamp = (value: number) =>
+    Number.isFinite(value) ? Math.min(Math.max(value, ZOOM_MIN), ZOOM_MAX) : ZOOM_DEFAULT;
+
+  // eslint-disable-next-line new-cap -- RNGH's gesture builder API is Gesture.Pinch().
+  const pinch = Gesture.Pinch()
+    .simultaneousWithExternalGesture(...scrollGestureRefs)
+    .onBegin(() => {
+      gestureSession.value = session.value;
+    })
+    .onUpdate(e => {
+      if (gestureSession.value === session.value) {
+        scale.value = clamp(savedScale.value * e.scale);
+      }
+    })
+    .onEnd(() => {
+      if (gestureSession.value !== session.value) {
+        return;
+      }
+      const next = clamp(scale.value);
+      scale.value = next;
+      savedScale.value = next;
+      scheduleOnRN(applyZoom, next, gestureSession.value);
+    });
+
+  // eslint-disable-next-line new-cap -- RNGH's gesture builder API is Gesture.Tap().
+  const doubleTap = Gesture.Tap()
+    .numberOfTaps(2)
+    .simultaneousWithExternalGesture(...scrollGestureRefs)
+    .onBegin(() => {
+      gestureSession.value = session.value;
+    })
+    .onEnd(() => {
+      if (gestureSession.value !== session.value) {
+        return;
+      }
+      scale.value = ZOOM_DEFAULT;
+      savedScale.value = ZOOM_DEFAULT;
+      scheduleOnRN(applyZoom, ZOOM_DEFAULT, gestureSession.value);
+    });
+
+  // eslint-disable-next-line new-cap -- RNGH's gesture builder API is Gesture.Race().
+  const zoomGesture = Gesture.Race(doubleTap, pinch);
+
+  const tableStyle = useAnimatedStyle(() => ({
+    transform: [{ scale: scale.value }],
+  }));
+
   return (
     <>
       <Pressable
@@ -78,6 +204,7 @@ export function MarkdownTable({ palette, header, rows }: Readonly<MarkdownTableP
         visible={open}
         animationType="slide"
         onRequestClose={() => {
+          session.value += 1;
           setOpen(false);
         }}
       >
@@ -89,6 +216,7 @@ export function MarkdownTable({ palette, header, rows }: Readonly<MarkdownTableP
             <Text className="text-lg font-semibold text-foreground">Table</Text>
             <Pressable
               onPress={() => {
+                session.value += 1;
                 setOpen(false);
               }}
               className="h-10 w-10 items-center justify-center rounded-md bg-secondary active:opacity-70"
@@ -98,38 +226,59 @@ export function MarkdownTable({ palette, header, rows }: Readonly<MarkdownTableP
               <X size={20} color={colors.foreground} />
             </Pressable>
           </View>
-          <ScrollView
-            className="flex-1"
-            contentContainerClassName="p-4"
-            contentContainerStyle={{ paddingBottom: insets.bottom + 16 }}
-          >
-            <ScrollView horizontal showsHorizontalScrollIndicator>
-              <View
-                className="self-start overflow-hidden rounded-md border"
-                // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant colors
-                style={{ borderColor: palette.borderColor, backgroundColor: palette.surfaceColor }}
-              >
-                <TableRow
-                  palette={palette}
-                  cells={header}
-                  columnCount={columnCount}
-                  columnWidth={columnWidth}
-                  isHeader
-                  isLastRow={rows.length === 0}
-                />
-                {rows.map((row, rowIdx) => (
-                  <TableRow
-                    key={rowIdx}
-                    palette={palette}
-                    cells={row}
-                    columnCount={columnCount}
-                    columnWidth={columnWidth}
-                    isLastRow={rows.length - 1 === rowIdx}
-                  />
-                ))}
-              </View>
+          {/* RNGH gestures need their own root inside an RN Modal — see image-viewer-modal.tsx. */}
+          <GestureHandlerRootView className="flex-1">
+            <ScrollView
+              ref={verticalRef}
+              className="flex-1"
+              // eslint-disable-next-line react-native/no-inline-styles -- padding must be combined after contentContainerClassName removal
+              contentContainerStyle={{ padding: 16, paddingBottom: insets.bottom + 16 }}
+            >
+              <ScrollView ref={horizontalRef} horizontal showsHorizontalScrollIndicator>
+                <GestureDetector gesture={zoomGesture}>
+                  {/* Sizer: gives both scrollers the zoomed extent. The table keeps its
+                      natural layout size (self-start) and is scaled from its top-left. */}
+                  {/* eslint-disable-next-line react-native/no-inline-styles -- dynamic measured sizer dimensions */}
+                  <View style={sizerStyle}>
+                    <Animated.View
+                      className="self-start"
+                      onLayout={handleTableLayout}
+                      // eslint-disable-next-line react-native/no-inline-styles -- animated transform + transformOrigin
+                      style={[tableStyle, { transformOrigin: 'top left' }]}
+                    >
+                      <View
+                        className="self-start overflow-hidden rounded-md border"
+                        // eslint-disable-next-line react-native/no-inline-styles -- dynamic per-variant colors
+                        style={{
+                          borderColor: palette.borderColor,
+                          backgroundColor: palette.surfaceColor,
+                        }}
+                      >
+                        <TableRow
+                          palette={palette}
+                          cells={header}
+                          columnCount={columnCount}
+                          columnWidth={columnWidth}
+                          isHeader
+                          isLastRow={rows.length === 0}
+                        />
+                        {rows.map((row, rowIdx) => (
+                          <TableRow
+                            key={rowIdx}
+                            palette={palette}
+                            cells={row}
+                            columnCount={columnCount}
+                            columnWidth={columnWidth}
+                            isLastRow={rows.length - 1 === rowIdx}
+                          />
+                        ))}
+                      </View>
+                    </Animated.View>
+                  </View>
+                </GestureDetector>
+              </ScrollView>
             </ScrollView>
-          </ScrollView>
+          </GestureHandlerRootView>
         </View>
       </Modal>
     </>


### PR DESCRIPTION
## Summary

### What
- Adds pinch zoom from 0.4× to 3× and double-tap reset to the mobile full-screen markdown table viewer.
- Keeps existing two-axis scrolling and updates scroll extent from the measured table size after each completed gesture.
- Adds a wide five-column PR-review stub fixture for device verification.

### Why
Wide markdown tables could only be horizontally scrolled at a fixed size. Zoom-out makes more columns readable at once; zoom-in supports small text.

### How
- Uses React Native Gesture Handler scroll views with simultaneous pinch/double-tap gestures.
- Uses Reanimated for smooth gesture scale and commits the final zoom to a sizer view so both scroll axes match scaled content.
- Uses session guards to discard gesture completions from a closed viewer.

## Verification
- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:unused`
- `pnpm test` — 296 files / 2578 tests
- `git diff --check`
- `pnpm run format:changed`
- Impl-reviewer: no findings on final cumulative diff.
- iOS E2E: `VERIFICATION PASSED.` for T1–T5. T6 (chat) is carried: chat and PR review use the unchanged same `MarkdownTable` modal subtree, while PR review exercised the changed component.

No unit test was added by design: the mobile Vitest setup cannot mount React Native components, and the behavior is gesture/layout-dependent. The remaining arithmetic is inlined clamps and a multiply; device E2E is the coverage for this change.

E2E observation model: post-gesture frames decide zoom/reset, and swipe reachability decides scroll extent; accessibility hierarchy presence is corroboration only.

T6 chat regression is carried with the shared-component rationale above; no chat E2E pass is claimed.

Fallback: none — the existing scroll views remain.

## Visual Changes

100% baseline (unchanged appearance)

![ios-table-zoom-100.png](https://github.com/user-attachments/assets/98a9ade0-bace-46e2-b1a0-413edb14a4b2)

Zoomed out

![ios-table-zoom-out.png](https://github.com/user-attachments/assets/43749b5a-3806-45cb-8f79-1ff656336de7)

Zoomed in

![ios-table-zoom-in.png](https://github.com/user-attachments/assets/99894f1f-a787-4dc1-91e5-70f1b500be04)



---

> **Reviewer note:** This PR temporarily contained changes from #4960 to unblock e2e. Those changes are removed. #4960 lands the e2e harness.
