### PR TITLE
fix(ai-gateway): log Responses cache writes

### DIFF
--- a/apps/web/src/lib/ai-gateway/processUsage.responses.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.responses.test.ts
@@ -74,7 +74,7 @@ describe('processResponsesApiUsage', () => {
       input_tokens: 2425,
       output_tokens: 5,
       total_tokens: 2430,
-      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 0 },
+      input_tokens_details: { cached_tokens: 0, cache_write_tokens: 15374 },
       output_tokens_details: { reasoning_tokens: 0 },
     };
     const providerMetadata = {
@@ -87,6 +87,7 @@ describe('processResponsesApiUsage', () => {
     expect(result.is_byok).toBeNull();
     expect(result.inputTokens).toBe(2425);
     expect(result.outputTokens).toBe(5);
+    expect(result.cacheWriteTokens).toBe(15374);
   });
 
   test('returns zero cost when no usage or metadata is provided', () => {

--- a/apps/web/src/lib/ai-gateway/processUsage.responses.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.responses.test.ts
@@ -69,25 +69,26 @@ describe('processResponsesApiUsage', () => {
     expect(result.is_byok).toBe(true);
   });
 
-  test('correctly processes Vercel usage with marketCost', () => {
+  test('correctly processes Vercel usage with cache writes included in input tokens', () => {
     const usage = {
-      input_tokens: 2425,
-      output_tokens: 5,
-      total_tokens: 2430,
+      input_tokens: 15377,
+      output_tokens: 6,
+      total_tokens: 15383,
       input_tokens_details: { cached_tokens: 0, cache_write_tokens: 15374 },
       output_tokens_details: { reasoning_tokens: 0 },
     };
     const providerMetadata = {
-      gateway: { routing: { finalProvider: 'openai' }, cost: '0', marketCost: '0.0061375' },
+      gateway: { routing: { finalProvider: 'openai' }, cost: '0', marketCost: '0.0962825' },
     };
 
     const result = processResponsesApiUsage(usage, providerMetadata, coreProps);
 
-    expect(result.cost_mUsd).toBe(6138); // toMicrodollars(0.0061375)
+    expect(result.cost_mUsd).toBe(96283); // toMicrodollars(0.0962825)
     expect(result.is_byok).toBeNull();
-    expect(result.inputTokens).toBe(2425);
-    expect(result.outputTokens).toBe(5);
+    expect(result.inputTokens).toBe(15377);
+    expect(result.outputTokens).toBe(6);
     expect(result.cacheWriteTokens).toBe(15374);
+    expect(result.inputTokens - result.cacheWriteTokens).toBe(3);
   });
 
   test('returns zero cost when no usage or metadata is provided', () => {

--- a/apps/web/src/lib/ai-gateway/processUsage.responses.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.responses.ts
@@ -23,7 +23,10 @@ import { isErrorFinishReason } from '@/lib/ai-gateway/finishReason';
 
 // OpenRouter adds cost fields to the standard Responses API usage object.
 // ref: https://openrouter.ai/docs/use-cases/usage-accounting#response-format
-type ResponsesApiUsage = OpenAI.Responses.ResponseUsage & {
+type ResponsesApiUsage = Omit<OpenAI.Responses.ResponseUsage, 'input_tokens_details'> & {
+  input_tokens_details: OpenAI.Responses.ResponseUsage['input_tokens_details'] & {
+    cache_write_tokens?: number;
+  };
   cost?: number;
   is_byok?: boolean | null;
   cost_details?: { upstream_inference_cost: number };
@@ -54,6 +57,7 @@ export function processResponsesApiUsage(
   const inputTokens = usage?.input_tokens ?? 0;
   const outputTokens = usage?.output_tokens ?? 0;
   const cacheHitTokens = usage?.input_tokens_details?.cached_tokens ?? 0;
+  const cacheWriteTokens = usage?.input_tokens_details?.cache_write_tokens ?? 0;
 
   // OpenRouter path: cost fields are present directly in usage
   if (usage?.cost != null || usage?.is_byok != null) {
@@ -62,7 +66,7 @@ export function processResponsesApiUsage(
       coreProps,
       'responses_sse_processing'
     );
-    return { inputTokens, outputTokens, cacheHitTokens, cacheWriteTokens: 0, cost_mUsd, is_byok };
+    return { inputTokens, outputTokens, cacheHitTokens, cacheWriteTokens, cost_mUsd, is_byok };
   }
 
   // Vercel path: cost is in provider_metadata.gateway
@@ -73,7 +77,7 @@ export function processResponsesApiUsage(
       inputTokens,
       outputTokens,
       cacheHitTokens,
-      cacheWriteTokens: 0,
+      cacheWriteTokens,
       cost_mUsd,
       is_byok: extractVercelIsByok(vercelGateway),
     };
@@ -84,7 +88,7 @@ export function processResponsesApiUsage(
     inputTokens,
     outputTokens,
     cacheHitTokens,
-    cacheWriteTokens: 0,
+    cacheWriteTokens,
     cost_mUsd: 0,
     is_byok: null,
   };

--- a/apps/web/src/lib/ai-gateway/processUsage.responses.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.responses.ts
@@ -51,6 +51,7 @@ export function processResponsesApiUsage(
   providerMetadata: VercelProviderMetaData | null | undefined,
   coreProps: NotYetCostedUsageStats
 ): JustTheCostsUsageStats {
+  // OpenAI-style input_tokens already includes cached and cache-write tokens.
   const inputTokens = usage?.input_tokens ?? 0;
   const outputTokens = usage?.output_tokens ?? 0;
   const cacheHitTokens = usage?.input_tokens_details?.cached_tokens ?? 0;

--- a/apps/web/src/lib/ai-gateway/processUsage.responses.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.responses.ts
@@ -23,10 +23,7 @@ import { isErrorFinishReason } from '@/lib/ai-gateway/finishReason';
 
 // OpenRouter adds cost fields to the standard Responses API usage object.
 // ref: https://openrouter.ai/docs/use-cases/usage-accounting#response-format
-type ResponsesApiUsage = Omit<OpenAI.Responses.ResponseUsage, 'input_tokens_details'> & {
-  input_tokens_details: OpenAI.Responses.ResponseUsage['input_tokens_details'] & {
-    cache_write_tokens?: number;
-  };
+type ResponsesApiUsage = OpenAI.Responses.ResponseUsage & {
   cost?: number;
   is_byok?: boolean | null;
   cost_details?: { upstream_inference_cost: number };


### PR DESCRIPTION
## Summary
- read `cache_write_tokens` from Responses API input token details
- persist cache-write usage through every Responses cost path
- add regression coverage for Vercel Responses usage

## Verification
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/processUsage.responses.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm exec oxfmt --check apps/web/src/lib/ai-gateway/processUsage.responses.ts apps/web/src/lib/ai-gateway/processUsage.responses.test.ts`
- `git diff --check`