### PR TITLE
fix(ai-gateway): forbid poolside/laguna-m.1:free

### DIFF
--- a/apps/web/src/lib/ai-gateway/forbidden-free-models.ts
+++ b/apps/web/src/lib/ai-gateway/forbidden-free-models.ts
@@ -39,6 +39,7 @@ const forbiddenFreeModelIds: ReadonlySet<string> = new Set([
   'nvidia/nemotron-nano-9b-v2:free',
   'openai/gpt-oss-120b:free',
   'openai/gpt-oss-20b:free',
+  'poolside/laguna-m.1:free',
   'qwen/qwen3-4b:free',
   'qwen/qwen3-coder:free',
   'qwen/qwen3-next-80b-a3b-instruct:free',


### PR DESCRIPTION
Adds `poolside/laguna-m.1:free` to `forbiddenFreeModelIds` so the removed free model is rejected with the appropriate error message for stale clients.