### PR TITLE
feat(web): add Qwen 3.8 Max model

### DIFF
--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -53,6 +53,7 @@ import * as z from 'zod';
 // clause forces new entries here whenever a provider is added to
 // VercelUserByokInferenceProviderIdSchema.
 const VERCEL_BYOK_PROVIDER_NAMES = {
+  alibaba: 'Alibaba Cloud',
   anthropic: 'Anthropic',
   bedrock: 'AWS Bedrock',
   deepseek: 'DeepSeek',

--- a/apps/web/src/lib/ai-gateway/byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/byok/index.ts
@@ -14,7 +14,7 @@ import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelId
 import type { BYOKResult } from '@/lib/ai-gateway/providers/types';
 import { getVercelModelsMetadataFromDatabase } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
-import { isKiloExclusiveModel } from '@/lib/ai-gateway/models';
+import { isEligibleForVercelUserByok } from '@/lib/ai-gateway/models';
 
 export async function getModelUserByokProviders(modelId: string): Promise<UserByokProviderId[]> {
   const vercelModelMetadata = await getVercelModelsMetadataFromDatabase();
@@ -71,7 +71,7 @@ export async function addUserByokAvailability(
   return Promise.all(
     models.map(async model => {
       const hasUserByokAvailable =
-        !isKiloExclusiveModel(model.id) &&
+        isEligibleForVercelUserByok(model.id) &&
         (await getModelUserByokProviders(model.id)).some(provider =>
           enabledProviders.has(provider)
         );

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -9,6 +9,7 @@ import {
   claude_opus_4_6_stealth_model,
 } from './providers/anthropic.constants';
 import { gpt_5_6_sol_stealth_model } from './providers/openai-exclusive';
+import { qwen38_max_model } from './providers/qwen';
 import { tencent_hy3_free_model } from './providers/tencent';
 
 describe('isFreeModel', () => {
@@ -55,6 +56,23 @@ describe('isFreeModel', () => {
     test('does not register discounted OpenRouter Qwen models as Kilo exclusive', () => {
       expect(findKiloExclusiveModel('qwen/qwen3.7-max')).toBeNull();
       expect(findKiloExclusiveModel('qwen/qwen3.7-plus')).toBeNull();
+    });
+
+    test('registers Qwen 3.8 Max as a priced Vercel model', () => {
+      expect(findKiloExclusiveModel('qwen/qwen-3.8-max')).toBe(qwen38_max_model);
+      expect(qwen38_max_model.internal_id).toBe('alibaba/qwen3.8-max');
+      expect(qwen38_max_model.gateway).toBe('vercel');
+      expect(qwen38_max_model.pricing).toEqual([
+        {
+          start_context_length: 0,
+          pricing: {
+            prompt_per_million: 2,
+            completion_per_million: 6,
+            input_cache_read_per_million: 0.25,
+            input_cache_write_per_million: 2.5,
+          },
+        },
+      ]);
     });
 
     test('registers Tencent Hy3 as free without adding it to Auto Free', () => {

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from '@jest/globals';
-import { autoFreeModels, findKiloExclusiveModel, kiloExclusiveModels } from './models';
+import {
+  autoFreeModels,
+  findKiloExclusiveModel,
+  isEligibleForVercelUserByok,
+  kiloExclusiveModels,
+} from './models';
 import { hasBestEffortGuessDataCollectionRequirement, isFreeModel } from './is-free-model';
 import { getInferenceProvider } from './providers/kilo-exclusive-model';
 import { getAiSdkProvider } from './providers/model-settings';
@@ -73,6 +78,13 @@ describe('isFreeModel', () => {
           },
         },
       ]);
+    });
+
+    test('allows Vercel-compatible exclusives to use Vercel user BYOK', () => {
+      expect(isEligibleForVercelUserByok('qwen/qwen-3.8-max')).toBe(true);
+      expect(isEligibleForVercelUserByok('google/gemma-4-26b-a4b-it:free')).toBe(true);
+      expect(isEligibleForVercelUserByok('stealth/qwen3.6-plus')).toBe(false);
+      expect(isEligibleForVercelUserByok('anthropic/claude-sonnet-4')).toBe(true);
     });
 
     test('registers Tencent Hy3 as free without adding it to Auto Free', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -128,3 +128,12 @@ export function isDeadFreeModel(model: string): boolean {
 export function findKiloExclusiveModel(model: string): KiloExclusiveModel | null {
   return kiloExclusiveModels.find(m => m.public_id === model && m.status !== 'disabled') ?? null;
 }
+
+export function isEligibleForVercelUserByok(model: string): boolean {
+  const exclusiveModel = findKiloExclusiveModel(model);
+  return (
+    exclusiveModel === null ||
+    exclusiveModel.gateway === 'vercel' ||
+    exclusiveModel.flags.includes('vercel-routing')
+  );
+}

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -22,7 +22,11 @@ import { isMuseModel } from '@/lib/ai-gateway/providers/meta';
 import { MINIMAX_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/minimax';
 import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import { gemma_4_26b_a4b_it_free_model, isGeminiModel } from '@/lib/ai-gateway/providers/google';
-import { QWEN37_PLUS_MODEL_ID, qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
+import {
+  QWEN37_PLUS_MODEL_ID,
+  qwen36_plus_stealth_model,
+  qwen38_max_model,
+} from '@/lib/ai-gateway/providers/qwen';
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { tencent_hy3_free_model } from '@/lib/ai-gateway/providers/tencent';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
@@ -89,6 +93,7 @@ export const kiloExclusiveModels = [
   gemma_4_26b_a4b_it_free_model,
   ...deepseekDiscountedModels,
   qwen36_plus_stealth_model,
+  qwen38_max_model,
   gpt_5_6_sol_stealth_model,
   claude_sonnet_clawsetup_model,
   claude_opus_4_8_stealth_model,

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -10,6 +10,7 @@ import {
   logMicrodollarUsage,
   insertUsageRecord,
   processOpenRouterUsage,
+  processTokenData,
   stripNulBytesInPlace,
   toInsertableDbUsageRecord,
   usageTransactionIdleTimeoutQuery,
@@ -754,6 +755,45 @@ describe('logMicrodollarUsage', () => {
       .from(cost_insight_owner_hour_totals)
       .where(eq(cost_insight_owner_hour_totals.owned_by_user_id, user.id));
     expect(totals).toHaveLength(0);
+  });
+
+  test('does not charge Kilo balance for a Vercel user-BYOK exclusive model', async () => {
+    const user = await insertTestUser({
+      id: 'test-vercel-exclusive-byok',
+      microdollars_used: 2000,
+      google_user_email: 'vercel-exclusive-byok@example.com',
+    });
+    const usageStats: MicrodollarUsageStats = {
+      ...BASE_USAGE_STATS,
+      messageId: 'test-vercel-exclusive-byok-msg',
+      cost_mUsd: 500,
+      outputTokens: 0,
+      model: 'alibaba/qwen3.8-max',
+      inference_provider: 'alibaba',
+      status_code: 400,
+    };
+    const usageContext: MicrodollarUsageContext = {
+      ...createBaseUsageContext(user),
+      provider: 'vercel',
+      requested_model: 'qwen/qwen-3.8-max',
+      user_byok: true,
+      status_code: 400,
+    };
+
+    await processTokenData(usageStats, usageContext);
+
+    const updatedUser = await findUserById(user.id);
+    expect(updatedUser?.microdollars_used).toBe(2000);
+
+    const metadataRecord = await db.query.microdollar_usage_metadata.findFirst({
+      where: eq(microdollar_usage_metadata.message_id, 'test-vercel-exclusive-byok-msg'),
+    });
+    const usageRecord = await db.query.microdollar_usage.findFirst({
+      where: eq(microdollar_usage.id, metadataRecord!.id),
+    });
+    expect(usageRecord?.cost).toBe(0);
+    expect(metadataRecord?.market_cost).toBe(500);
+    expect(metadataRecord?.is_user_byok).toBe(true);
   });
 
   test('keeps AI source rows when legacy usage owner does not exist', async () => {

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -1,6 +1,6 @@
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import { shouldRouteToVercel } from '@/lib/ai-gateway/providers/vercel';
-import { findKiloExclusiveModel, isKiloExclusiveModel } from '@/lib/ai-gateway/models';
+import { findKiloExclusiveModel, isEligibleForVercelUserByok } from '@/lib/ai-gateway/models';
 import { CUSTOM_LLM_PREFIX } from '@/lib/ai-gateway/model-utils';
 import {
   getBYOKforOrganization,
@@ -129,13 +129,10 @@ async function checkVercelBYOK(
   organizationId: string | undefined
 ): Promise<BYOKResult[] | null> {
   if (isAnonymousContext(user)) return null;
-  // Kilo-exclusive models are not routable through Vercel BYOK. Reasoning in particular
-  // breaks: the Vercel AI Gateway normalizes reasoning to each provider's upstream-native
-  // shape, whereas our Kilo-exclusive models are served through generic OpenAI-compatible
-  // endpoints (Martian, direct Alibaba, etc.) where that normalization doesn't apply and the
-  // response ends up corrupted. Skip the Vercel BYOK lookup entirely and let the caller fall
-  // through to the model's declared gateway.
-  if (isKiloExclusiveModel(requestedModel)) return null;
+  // Exclusives served by Vercel, or explicitly allowed to route there, can safely use
+  // Vercel BYOK. Other exclusives must use their declared gateway because Vercel's
+  // provider-native request normalization may not match their upstream endpoint.
+  if (!isEligibleForVercelUserByok(requestedModel)) return null;
   const modelProviders = await getModelUserByokProviders(requestedModel);
   if (modelProviders.length === 0) return null;
   return organizationId

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/inference-provider-id.ts
@@ -81,6 +81,7 @@ export const OpenRouterInferenceProviderIdSchema = z.enum([
 ]);
 
 export const VercelUserByokInferenceProviderIdSchema = z.enum([
+  'alibaba',
   'anthropic',
   'bedrock',
   'deepseek',
@@ -134,6 +135,7 @@ export const UserByokProviderIdSchema = VercelUserByokInferenceProviderIdSchema.
 export type UserByokProviderId = z.infer<typeof UserByokProviderIdSchema>;
 
 export const UserByokTestModels = {
+  [VercelUserByokInferenceProviderIdSchema.enum.alibaba]: 'alibaba/qwen3.8-max',
   [VercelUserByokInferenceProviderIdSchema.enum.anthropic]: 'anthropic/claude-haiku-4.5',
   [VercelUserByokInferenceProviderIdSchema.enum.bedrock]: 'anthropic/claude-haiku-4.5',
   [VercelUserByokInferenceProviderIdSchema.enum.deepseek]: 'deepseek/deepseek-v3.2',

--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -47,6 +47,32 @@ const TOKENS_256K = 256 * 1024;
 
 export const QWEN37_MAX_MODEL_ID = 'qwen/qwen3.7-max';
 export const QWEN37_PLUS_MODEL_ID = 'qwen/qwen3.7-plus';
+export const QWEN38_MAX_MODEL_ID = 'qwen/qwen-3.8-max';
+
+export const qwen38_max_model: KiloExclusiveModel = {
+  public_id: QWEN38_MAX_MODEL_ID,
+  display_name: 'Qwen: Qwen 3.8 Max',
+  description:
+    'Qwen 3.8 Max is a 2.4-trillion-parameter mixture-of-experts model for long-horizon coding, professional work, and visual document analysis.',
+  context_length: 1_000_000,
+  max_completion_tokens: 128_000,
+  status: 'public',
+  flags: ['reasoning', 'vision'],
+  gateway: 'vercel',
+  internal_id: 'alibaba/qwen3.8-max',
+  pricing: [
+    {
+      start_context_length: 0,
+      pricing: {
+        prompt_per_million: 2,
+        completion_per_million: 6,
+        input_cache_read_per_million: 0.25,
+        input_cache_write_per_million: 2.5,
+      },
+    },
+  ],
+  inference_provider_restriction: ['alibaba'],
+};
 
 export const qwen36_plus_stealth_model: KiloExclusiveModel = {
   public_id: 'stealth/qwen3.6-plus',
@@ -91,7 +117,10 @@ export function isQwenModel(model: string) {
 
 export function isQwenExplicitCacheModel(model: string) {
   return (
-    (model.includes('qwen3.7') || model.includes('qwen3.6')) &&
+    (model.includes('qwen-3.8') ||
+      model.includes('qwen3.8') ||
+      model.includes('qwen3.7') ||
+      model.includes('qwen3.6')) &&
     (model.includes('max') || model.includes('plus'))
   );
 }

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from '@jest/globals';
 import {
   convertProviderOptions,
+  applyVercelSettings,
   getAnthropicProviderOptionsForVercel,
   getVercelInferenceProvidersExcludingIgnored,
   hasCompatibleVercelInferenceProvider,
@@ -125,6 +126,31 @@ describe('convertProviderOptions', () => {
 
     expect(providerOptions.gateway?.only).toEqual(['anthropic']);
     expect(provider?.only).toEqual(['anthropic', 'amazon-bedrock']);
+  });
+});
+
+describe('applyVercelSettings', () => {
+  it('pins an exclusive model request to the user BYOK provider', async () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'qwen/qwen-3.8-max',
+        messages: [{ role: 'user', content: 'hello' }],
+        provider: { only: ['openai'] },
+      },
+    };
+
+    await applyVercelSettings('qwen/qwen-3.8-max', request, [
+      { providerId: 'alibaba', decryptedAPIKey: 'user-key' },
+    ]);
+
+    expect(request.body.model).toBe('alibaba/qwen3.8-max');
+    expect(request.body.providerOptions?.gateway).toEqual({
+      only: ['alibaba'],
+      byok: { alibaba: [{ apiKey: 'user-key' }] },
+      models: undefined,
+    });
+    expect(request.body.provider).toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -104,6 +104,10 @@ describe('mapModelIdToVercel', () => {
   });
 
   describe('kilo-exclusive models', () => {
+    it('maps Qwen 3.8 Max to its Vercel model id', () => {
+      expect(mapModelIdToVercel('qwen/qwen-3.8-max')).toBe('alibaba/qwen3.8-max');
+    });
+
     it('maps an exclusive flagged with vercel-routing to its internal id', () => {
       // google/gemma-4-26b-a4b-it:free is registered in kiloExclusiveModels
       // with the 'vercel-routing' flag and internal_id 'google/gemma-4-26b-a4b-it'.

--- a/apps/web/src/lib/cloud-agent-next/balance-check-eligibility.test.ts
+++ b/apps/web/src/lib/cloud-agent-next/balance-check-eligibility.test.ts
@@ -16,7 +16,8 @@ jest.mock('@/lib/ai-gateway/byok', () => ({
 
 import { computeCloudAgentNextBalanceCheckEligibility } from './balance-check-eligibility';
 
-const KILO_EXCLUSIVE_MODEL = 'deepseek/deepseek-v4-pro:discounted';
+const KILO_EXCLUSIVE_MODEL = 'stealth/qwen3.6-plus';
+const VERCEL_EXCLUSIVE_MODEL = 'qwen/qwen-3.8-max';
 const NON_EXCLUSIVE_MODEL = 'anthropic/claude-sonnet-4';
 
 const fakeDb = {} as never;
@@ -84,6 +85,19 @@ describe('computeCloudAgentNextBalanceCheckEligibility', () => {
     expect(result).toEqual({ isFree: false, hasUserByokAvailable: false });
     expect(mockGetModelUserByokProviders).not.toHaveBeenCalled();
     expect(mockGetOrganizationByokProviderIds).not.toHaveBeenCalled();
+  });
+
+  it('allows a Vercel exclusive model to bypass the balance check with matching user BYOK', async () => {
+    mockGetModelUserByokProviders.mockResolvedValueOnce(['alibaba']);
+    mockGetUserByokProviderIds.mockResolvedValueOnce(['alibaba']);
+
+    const result = await computeCloudAgentNextBalanceCheckEligibility({
+      fromDb: fakeDb,
+      user: fakeUser,
+      modelId: VERCEL_EXCLUSIVE_MODEL,
+    });
+
+    expect(result).toEqual({ isFree: false, hasUserByokAvailable: true });
   });
 
   it('returns hasUserByokAvailable: true for a non-Kilo-exclusive paid model with a matching enabled user BYOK provider', async () => {

--- a/apps/web/src/lib/cloud-agent-next/balance-check-eligibility.ts
+++ b/apps/web/src/lib/cloud-agent-next/balance-check-eligibility.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 import { type db } from '@/lib/drizzle';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
-import { isKiloExclusiveModel } from '@/lib/ai-gateway/models';
+import { isEligibleForVercelUserByok } from '@/lib/ai-gateway/models';
 import {
   getModelUserByokProviders,
   getOrganizationByokProviderIds,
@@ -20,21 +20,13 @@ export type BalanceCheckModelEligibility = {
  *
  * Skips the check when either:
  * - the model is Kilo-funded (free for the user), or
- * - the model is not Kilo-exclusive AND the user has a BYOK provider
+ * - the model is eligible for Vercel user BYOK AND the user has a provider
  *   configured that can serve it, so the session is billed against the
  *   user's own key rather than their balance.
  *
- * Kilo-exclusive models (e.g. `deepseek/deepseek-v4-pro:discounted`) are
- * always excluded from the BYOK bypass: they are Kilo-funded and platform
- * billed, so even when `getModelUserByokProviders` reports a provider that
- * can route the model, they must still go through the worker-side balance
- * check and cannot be legitimately served via a user's own BYOK key.
- *
- * The resulting predicate is a strict subset of the
- * `isFree || hasUserByokAvailable` predicate used by the NewSessionPanel
- * model picker to filter `hasLimitedAccess` users: this router additionally
- * forces Kilo-exclusive models through the balance check, so the picker
- * may offer a model as free while the router still requires a balance.
+ * Kilo-exclusive models are eligible only when their gateway is Vercel or
+ * they explicitly allow Vercel routing. Other exclusives remain platform
+ * billed and must go through the worker-side balance check.
  */
 export async function computeCloudAgentNextBalanceCheckEligibility(params: {
   fromDb: typeof db;
@@ -47,7 +39,7 @@ export async function computeCloudAgentNextBalanceCheckEligibility(params: {
     return { isFree: true, hasUserByokAvailable: false };
   }
 
-  if (isKiloExclusiveModel(params.modelId)) {
+  if (!isEligibleForVercelUserByok(params.modelId)) {
     return { isFree: false, hasUserByokAvailable: false };
   }
 

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -34,7 +34,7 @@ import { getVercelInferenceProviderConfigForUserByok } from '@/lib/ai-gateway/pr
 import { decryptByokRow } from '@/lib/ai-gateway/byok';
 import type { GatewayProviderOptions } from '@ai-sdk/gateway';
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
-import { isKiloExclusiveModel } from '@/lib/ai-gateway/models';
+import { isEligibleForVercelUserByok } from '@/lib/ai-gateway/models';
 import DIRECT_BYOK_PROVIDERS from '@/lib/ai-gateway/providers/direct-byok/direct-byok-definitions';
 import {
   createAiSdkProvider,
@@ -81,7 +81,7 @@ async function fetchSupportedModels(): Promise<Record<string, string[]>> {
   result['codestral'] = ['Codestral (mistralai/codestral-2508)'];
 
   for (const openRouterModel of Object.values(openRouterModelMetadata)) {
-    if (isKiloExclusiveModel(openRouterModel.id)) continue;
+    if (!isEligibleForVercelUserByok(openRouterModel.id)) continue;
     const vercelModel = vercelModelMetadata[mapModelIdToVercel(openRouterModel.id)];
     if (!vercelModel) continue;
     if (vercelModel.type !== 'language') continue;


### PR DESCRIPTION
## Summary
- add the priced Kilo-exclusive `qwen/qwen-3.8-max` model and route it to Vercel AI Gateway's `alibaba/qwen3.8-max`
- allow Kilo-exclusive models to use Vercel user BYOK when their gateway is Vercel or they carry the `vercel-routing` flag
- add Alibaba as a Vercel BYOK provider and keep non-Vercel-compatible exclusives excluded
- pin BYOK requests to the supplied provider credential and verify Kilo billing remains zero while market cost is retained

## Validation
- focused model, balance eligibility, Vercel routing, and BYOK transform tests: 91 passed
- `src/lib/ai-gateway/processUsage.test.ts`: 52 passed, including database-backed zero-charge verification
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`