### PR TITLE
perf(web): use read replica for gateway balance checks

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -15,6 +15,7 @@ import { logMicrodollarUsage } from '@/lib/ai-gateway/processUsage';
 import { applyResolvedAutoModel } from '@/lib/ai-gateway/auto-model/resolution';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
 import { rewriteModelResponse } from '@/lib/rewriteModelResponse';
+import { readDb } from '@/lib/drizzle';
 
 jest.mock('next/server', () => {
   return {
@@ -34,6 +35,7 @@ jest.mock('@sentry/nextjs', () => ({
 
 jest.mock('@/lib/user/server');
 jest.mock('@/lib/organizations/organization-usage');
+jest.mock('@/lib/drizzle', () => ({ readDb: {} }));
 jest.mock('@/lib/ai-gateway/abuse-service', () => {
   const actual = jest.requireActual('@/lib/ai-gateway/abuse-service');
   return {
@@ -269,6 +271,16 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
       expect.anything(),
       expect.objectContaining({ vercel_request_id: 'iad1::iad1::request-id' })
     );
+  });
+
+  it('uses the read replica for balance and organization settings', async () => {
+    const { POST } = await import('./route');
+
+    const response = await POST(makeRequest(makeBody()) as never);
+
+    expect(response.status).toBe(200);
+    expect(mockedGetBalanceAndOrgSettings).toHaveBeenCalledTimes(1);
+    expect(mockedGetBalanceAndOrgSettings.mock.calls[0]?.[2]).toBe(readDb);
   });
 
   it('rate limits rules-engine rate-limit actions before upstream', async () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -106,6 +106,7 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
 import { redactProviderHints } from '@kilocode/auto-routing-contracts';
 import { logExceptInTest } from '@/lib/utils.server';
+import { readDb } from '@/lib/drizzle';
 
 export const maxDuration = 800;
 
@@ -231,7 +232,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   const balanceAndSettingsPromise = authPromise.then(res =>
     res.user
-      ? getBalanceAndOrgSettings(res.organizationId, res.user)
+      ? getBalanceAndOrgSettings(res.organizationId, res.user, readDb)
       : { balance: 0, settings: undefined, plan: undefined }
   );
   const organizationContextPromise = Promise.all([authPromise, balanceAndSettingsPromise]).then(


### PR DESCRIPTION
## Summary

- pass the region-aware `readDb` into the OpenRouter gateway balance and organization settings lookup
- add route coverage that verifies the lookup receives `readDb`

## Consequences

This moves a high-volume, read-only gateway query off the primary PostgreSQL instance. In US regions it avoids the cross-region read to the Frankfurt primary and should reduce balance-check latency; in EU regions it distributes reads across replicas, reducing primary connection and query load. If no replica is configured, `readDb` falls back to the primary, so behavior is unchanged.

The tradeoff is eventual consistency. Replica lag is normally slight (typically under 100 ms), but immediately after a write the gateway can briefly observe stale organization balances, per-user usage or limits, membership, settings, plan, seat requirements, auto-top-up state, or credit-expiration metadata. Depending on which value changed, a request may be briefly accepted or rejected using the prior state, or use the prior organization routing/data-collection policy. No writes are redirected: expiry processing, auto-top-up, usage accounting, and all other mutations continue to use the primary database.

## Verification

- `pnpm --filter web exec jest --runInBand --runTestsByPath 'src/app/api/openrouter/[...path]/route.test.ts'` (21 tests)
- `scripts/typecheck-all.sh --changes-only`
- `pnpm -w exec oxlint --config .oxlintrc.json 'apps/web/src/app/api/openrouter/[...path]/route.ts' 'apps/web/src/app/api/openrouter/[...path]/route.test.ts'`
- `pnpm -w exec oxfmt --write 'apps/web/src/app/api/openrouter/[...path]/route.ts' 'apps/web/src/app/api/openrouter/[...path]/route.test.ts'`
- `git diff --check`