### PR TITLE
feat(web): add Qwen 3.8 Max model

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -9,6 +9,7 @@ import {
   claude_opus_4_6_stealth_model,
 } from './providers/anthropic.constants';
 import { gpt_5_6_sol_stealth_model } from './providers/openai-exclusive';
+import { qwen38_max_model } from './providers/qwen';
 import { tencent_hy3_free_model } from './providers/tencent';
 
 describe('isFreeModel', () => {
@@ -55,6 +56,24 @@ describe('isFreeModel', () => {
     test('does not register discounted OpenRouter Qwen models as Kilo exclusive', () => {
       expect(findKiloExclusiveModel('qwen/qwen3.7-max')).toBeNull();
       expect(findKiloExclusiveModel('qwen/qwen3.7-plus')).toBeNull();
+    });
+
+    test('registers Qwen 3.8 Max as a priced unrestricted Vercel model', () => {
+      expect(findKiloExclusiveModel('qwen/qwen-3.8-max')).toBe(qwen38_max_model);
+      expect(qwen38_max_model.internal_id).toBe('alibaba/qwen3.8-max');
+      expect(qwen38_max_model.gateway).toBe('vercel');
+      expect(qwen38_max_model.inference_provider_restriction).toEqual([]);
+      expect(qwen38_max_model.pricing).toEqual([
+        {
+          start_context_length: 0,
+          pricing: {
+            prompt_per_million: 2,
+            completion_per_million: 6,
+            input_cache_read_per_million: 0.25,
+            input_cache_write_per_million: 2.5,
+          },
+        },
+      ]);
     });
 
     test('registers Tencent Hy3 as free without adding it to Auto Free', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -22,7 +22,11 @@ import { isMuseModel } from '@/lib/ai-gateway/providers/meta';
 import { MINIMAX_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/minimax';
 import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import { gemma_4_26b_a4b_it_free_model, isGeminiModel } from '@/lib/ai-gateway/providers/google';
-import { QWEN37_PLUS_MODEL_ID, qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
+import {
+  QWEN37_PLUS_MODEL_ID,
+  qwen36_plus_stealth_model,
+  qwen38_max_model,
+} from '@/lib/ai-gateway/providers/qwen';
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { tencent_hy3_free_model } from '@/lib/ai-gateway/providers/tencent';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
@@ -89,6 +93,7 @@ export const kiloExclusiveModels = [
   gemma_4_26b_a4b_it_free_model,
   ...deepseekDiscountedModels,
   qwen36_plus_stealth_model,
+  qwen38_max_model,
   gpt_5_6_sol_stealth_model,
   claude_sonnet_clawsetup_model,
   claude_opus_4_8_stealth_model,

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -7,7 +7,7 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter';
 import { createMockResponse, mockOpenRouterModels } from '@/tests/helpers/openrouter-models.helper';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
-import { qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
+import { qwen36_plus_stealth_model, qwen38_max_model } from '@/lib/ai-gateway/providers/qwen';
 import { gemma_4_26b_a4b_it_free_model } from '@/lib/ai-gateway/providers/google';
 import {
   findKiloExclusiveModel,
@@ -220,6 +220,30 @@ describe('auto models', () => {
 
     expect(models.data.some(model => model.id === 'vendor/model')).toBe(true);
     expect(models.data.some(model => model.id === 'vendor/model:batch')).toBe(false);
+  });
+
+  it('replaces the conventional OpenRouter Qwen 3.8 ID with the requested Kilo alias', async () => {
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        createMockResponse({
+          jsonData: {
+            data: [buildModel({ id: 'qwen/qwen3.8-max', name: 'OpenRouter Qwen 3.8 Max' })],
+          },
+        })
+      )
+    ) as unknown as typeof fetch;
+
+    const models = await getEnhancedOpenRouterModels();
+
+    expect(models.data.filter(model => model.id === 'qwen/qwen3.8-max')).toHaveLength(0);
+    expect(models.data.filter(model => model.id === qwen38_max_model.public_id)).toHaveLength(1);
+    expect(models.data.find(model => model.id === qwen38_max_model.public_id)).toMatchObject({
+      name: qwen38_max_model.display_name,
+      pricing: {
+        prompt: '0.000002000000',
+        completion: '0.000006000000',
+      },
+    });
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -114,6 +114,10 @@ const unavailableModels = [
   'sakana/fugu', // this model is not available in the EU
 ];
 
+const replacedOpenRouterModelIds = new Set([
+  'qwen/qwen3.8-max', // Replaced by the Kilo-exclusive qwen/qwen-3.8-max alias.
+]);
+
 async function enhancedModelList(models: OpenRouterModel[]) {
   const autoModels = buildAutoModels();
   const endpointsMetadata = await getOpenRouterModelsMetadataFromDatabase();
@@ -127,6 +131,7 @@ async function enhancedModelList(models: OpenRouterModel[]) {
           ) &&
           !isForbiddenFreeModel(model.id) &&
           !model.id.endsWith(':batch') &&
+          !replacedOpenRouterModelIds.has(model.id) &&
           !unavailableModels.some(unavailableId => model.id.includes(unavailableId))
       )
       .map(model => {

--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -47,6 +47,32 @@ const TOKENS_256K = 256 * 1024;
 
 export const QWEN37_MAX_MODEL_ID = 'qwen/qwen3.7-max';
 export const QWEN37_PLUS_MODEL_ID = 'qwen/qwen3.7-plus';
+export const QWEN38_MAX_MODEL_ID = 'qwen/qwen-3.8-max';
+
+export const qwen38_max_model: KiloExclusiveModel = {
+  public_id: QWEN38_MAX_MODEL_ID,
+  display_name: 'Qwen: Qwen 3.8 Max',
+  description:
+    'Qwen 3.8 Max is a 2.4-trillion-parameter mixture-of-experts model for long-horizon coding, professional work, and visual document analysis.',
+  context_length: 1_000_000,
+  max_completion_tokens: 128_000,
+  status: 'public',
+  flags: ['reasoning', 'vision'],
+  gateway: 'vercel',
+  internal_id: 'alibaba/qwen3.8-max',
+  pricing: [
+    {
+      start_context_length: 0,
+      pricing: {
+        prompt_per_million: 2,
+        completion_per_million: 6,
+        input_cache_read_per_million: 0.25,
+        input_cache_write_per_million: 2.5,
+      },
+    },
+  ],
+  inference_provider_restriction: [],
+};
 
 export const qwen36_plus_stealth_model: KiloExclusiveModel = {
   public_id: 'stealth/qwen3.6-plus',
@@ -91,7 +117,10 @@ export function isQwenModel(model: string) {
 
 export function isQwenExplicitCacheModel(model: string) {
   return (
-    (model.includes('qwen3.7') || model.includes('qwen3.6')) &&
+    (model.includes('qwen-3.8') ||
+      model.includes('qwen3.8') ||
+      model.includes('qwen3.7') ||
+      model.includes('qwen3.6')) &&
     (model.includes('max') || model.includes('plus'))
   );
 }

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -104,6 +104,10 @@ describe('mapModelIdToVercel', () => {
   });
 
   describe('kilo-exclusive models', () => {
+    it('maps Qwen 3.8 Max to its Vercel model id', () => {
+      expect(mapModelIdToVercel('qwen/qwen-3.8-max')).toBe('alibaba/qwen3.8-max');
+    });
+
     it('maps an exclusive flagged with vercel-routing to its internal id', () => {
       // google/gemma-4-26b-a4b-it:free is registered in kiloExclusiveModels
       // with the 'vercel-routing' flag and internal_id 'google/gemma-4-26b-a4b-it'.


### PR DESCRIPTION
## Summary
- add the priced Kilo-exclusive `qwen/qwen-3.8-max` alias backed by Vercel AI Gateway model `alibaba/qwen3.8-max`
- use live gateway pricing and capabilities, including cache read/write pricing
- leave inference providers unrestricted
- cover catalog registration and Vercel model ID mapping

## Verification
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/models.test.ts src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm -w exec oxfmt --list-different apps/web/src/lib/ai-gateway/providers/qwen.ts apps/web/src/lib/ai-gateway/models.ts apps/web/src/lib/ai-gateway/models.test.ts apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts`
- `git diff --check`