### PR TITLE
fix(web): ignore transferred subscriptions during soft delete

### DIFF
--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -3870,6 +3870,46 @@ describe('User', () => {
       expect(retainedLogs[0].organization_id).toBe(orgId);
     });
 
+    it('should allow soft-delete when a transferred past-due KiloClaw predecessor has a canceled current successor', async () => {
+      const user = await insertTestUser();
+      const successorId = randomUUID();
+      await db.insert(kiloclaw_subscriptions).values({
+        id: successorId,
+        user_id: user.id,
+        plan: 'standard',
+        status: 'canceled',
+      });
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        plan: 'standard',
+        status: 'past_due',
+        transferred_to_subscription_id: successorId,
+      });
+
+      await expect(assertUserCanBeSoftDeleted(user.id)).resolves.toBeUndefined();
+      await expect(softDeleteUser(user.id)).resolves.toBeUndefined();
+
+      const softDeleted = await findUserById(user.id);
+      expect(softDeleted!.blocked_reason).toMatch(/^soft-deleted at \d{4}-\d{2}-\d{2}T/);
+    });
+
+    it('should throw SoftDeletePreconditionError for a current past-due KiloClaw subscription', async () => {
+      const user = await insertTestUser();
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        plan: 'standard',
+        status: 'past_due',
+        transferred_to_subscription_id: null,
+      });
+
+      await expect(assertUserCanBeSoftDeleted(user.id)).rejects.toThrow(
+        SoftDeletePreconditionError
+      );
+      await expect(softDeleteUser(user.id)).rejects.toThrow(SoftDeletePreconditionError);
+      const userAfter = await findUserById(user.id);
+      expect(userAfter!.google_user_email).toBe(user.google_user_email);
+    });
+
     it('should throw SoftDeletePreconditionError for active KiloClaw subscription', async () => {
       const user = await insertTestUser();
       await db.insert(kiloclaw_subscriptions).values({

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -836,7 +836,7 @@ async function assertNoLiveSubscriptionsForSoftDelete(
     );
   }
 
-  // Block soft-delete for any live KiloClaw subscription. This includes
+  // Block soft-delete for any current live KiloClaw subscription. This includes
   // trialing — the user may have a running Fly instance, and deleting the
   // row without destroying the instance would orphan it.
   const liveClawSubscriptions = await executor
@@ -848,6 +848,7 @@ async function assertNoLiveSubscriptionsForSoftDelete(
     .where(
       and(
         eq(kiloclaw_subscriptions.user_id, userId),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
         inArray(kiloclaw_subscriptions.status, ['active', 'past_due', 'unpaid', 'trialing'])
       )
     );
@@ -874,7 +875,7 @@ export async function assertUserCanBeSoftDeleted(userId: string): Promise<void> 
  *
  * Preconditions (will throw SoftDeletePreconditionError if violated):
  * - User must not have an active, non-cancelling Kilo Pass subscription
- * - User must not have a live KiloClaw subscription (active, past_due, unpaid, or trialing)
+ * - User must not have a current live KiloClaw subscription (active, past_due, unpaid, or trialing)
  *
  * What is kept:
  * - The kilocode_users row (anonymized)


### PR DESCRIPTION
## Summary
Allow GDPR soft deletion when the only live-status KiloClaw subscription is a superseded lineage row.

### Why this change is needed
Transferred KiloClaw subscription rows are retained as billing history but no longer represent current entitlement. Treating a transferred `past_due` predecessor as live incorrectly prevents deletion when its current successor is canceled.

### How this is addressed
- Restrict the KiloClaw soft-delete guard to current subscription rows whose `transferred_to_subscription_id` is null.
- Continue blocking current `active`, `past_due`, `unpaid`, and `trialing` subscriptions.
- Preserve historical subscription rows and the existing active-instance guard.
- Add regression coverage for transferred and current `past_due` rows.

## Human Verification
- `pnpm --filter web test --runInBand src/lib/user/index.test.ts` — passed, 95 tests.

## Reviewer Notes

### Human Reviewer Flags
No notable items for human review beyond what the summary covers.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- The guard now follows the existing KiloClaw convention that current subscription rows have `transferred_to_subscription_id IS NULL`.
- Existing active and trialing tests remain unchanged and pass.
- No migration or production-data rewrite is included.

</details>
