### PR TITLE
feat(web): add Qwen 3.8 Max model

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -9,6 +9,7 @@ import {
   claude_opus_4_6_stealth_model,
 } from './providers/anthropic.constants';
 import { gpt_5_6_sol_stealth_model } from './providers/openai-exclusive';
+import { qwen38_max_model } from './providers/qwen';
 import { tencent_hy3_free_model } from './providers/tencent';
 
 describe('isFreeModel', () => {
@@ -55,6 +56,24 @@ describe('isFreeModel', () => {
     test('does not register discounted OpenRouter Qwen models as Kilo exclusive', () => {
       expect(findKiloExclusiveModel('qwen/qwen3.7-max')).toBeNull();
       expect(findKiloExclusiveModel('qwen/qwen3.7-plus')).toBeNull();
+    });
+
+    test('registers Qwen 3.8 Max as a priced unrestricted Vercel model', () => {
+      expect(findKiloExclusiveModel('qwen/qwen3.8-max')).toBe(qwen38_max_model);
+      expect(qwen38_max_model.internal_id).toBe('alibaba/qwen3.8-max');
+      expect(qwen38_max_model.gateway).toBe('vercel');
+      expect(qwen38_max_model.inference_provider_restriction).toEqual([]);
+      expect(qwen38_max_model.pricing).toEqual([
+        {
+          start_context_length: 0,
+          pricing: {
+            prompt_per_million: 2,
+            completion_per_million: 6,
+            input_cache_read_per_million: 0.25,
+            input_cache_write_per_million: 2.5,
+          },
+        },
+      ]);
     });
 
     test('registers Tencent Hy3 as free without adding it to Auto Free', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -22,7 +22,11 @@ import { isMuseModel } from '@/lib/ai-gateway/providers/meta';
 import { MINIMAX_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/minimax';
 import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import { gemma_4_26b_a4b_it_free_model, isGeminiModel } from '@/lib/ai-gateway/providers/google';
-import { QWEN37_PLUS_MODEL_ID, qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
+import {
+  QWEN37_PLUS_MODEL_ID,
+  qwen36_plus_stealth_model,
+  qwen38_max_model,
+} from '@/lib/ai-gateway/providers/qwen';
 import { stepfun_37_flash_free_model } from '@/lib/ai-gateway/providers/stepfun';
 import { tencent_hy3_free_model } from '@/lib/ai-gateway/providers/tencent';
 import { isGrokModel } from '@/lib/ai-gateway/providers/xai';
@@ -89,6 +93,7 @@ export const kiloExclusiveModels = [
   gemma_4_26b_a4b_it_free_model,
   ...deepseekDiscountedModels,
   qwen36_plus_stealth_model,
+  qwen38_max_model,
   gpt_5_6_sol_stealth_model,
   claude_sonnet_clawsetup_model,
   claude_opus_4_8_stealth_model,

--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -47,6 +47,32 @@ const TOKENS_256K = 256 * 1024;
 
 export const QWEN37_MAX_MODEL_ID = 'qwen/qwen3.7-max';
 export const QWEN37_PLUS_MODEL_ID = 'qwen/qwen3.7-plus';
+export const QWEN38_MAX_MODEL_ID = 'qwen/qwen3.8-max';
+
+export const qwen38_max_model: KiloExclusiveModel = {
+  public_id: QWEN38_MAX_MODEL_ID,
+  display_name: 'Qwen: Qwen 3.8 Max',
+  description:
+    'Qwen 3.8 Max is a 2.4-trillion-parameter mixture-of-experts model for long-horizon coding, professional work, and visual document analysis.',
+  context_length: 1_000_000,
+  max_completion_tokens: 128_000,
+  status: 'public',
+  flags: ['reasoning', 'vision'],
+  gateway: 'vercel',
+  internal_id: 'alibaba/qwen3.8-max',
+  pricing: [
+    {
+      start_context_length: 0,
+      pricing: {
+        prompt_per_million: 2,
+        completion_per_million: 6,
+        input_cache_read_per_million: 0.25,
+        input_cache_write_per_million: 2.5,
+      },
+    },
+  ],
+  inference_provider_restriction: [],
+};
 
 export const qwen36_plus_stealth_model: KiloExclusiveModel = {
   public_id: 'stealth/qwen3.6-plus',
@@ -91,7 +117,7 @@ export function isQwenModel(model: string) {
 
 export function isQwenExplicitCacheModel(model: string) {
   return (
-    (model.includes('qwen3.7') || model.includes('qwen3.6')) &&
+    (model.includes('qwen3.8') || model.includes('qwen3.7') || model.includes('qwen3.6')) &&
     (model.includes('max') || model.includes('plus'))
   );
 }

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -104,6 +104,10 @@ describe('mapModelIdToVercel', () => {
   });
 
   describe('kilo-exclusive models', () => {
+    it('maps Qwen 3.8 Max to its Vercel model id', () => {
+      expect(mapModelIdToVercel('qwen/qwen3.8-max')).toBe('alibaba/qwen3.8-max');
+    });
+
     it('maps an exclusive flagged with vercel-routing to its internal id', () => {
       // google/gemma-4-26b-a4b-it:free is registered in kiloExclusiveModels
       // with the 'vercel-routing' flag and internal_id 'google/gemma-4-26b-a4b-it'.


### PR DESCRIPTION
## Summary
- add the priced Kilo-exclusive model `qwen/qwen3.8-max`
- route it through Vercel as `alibaba/qwen3.8-max` with upstream pricing and model limits
- leave inference providers unrestricted
- cover catalog registration, pricing, explicit cache handling, and Vercel model mapping

## Validation
- `pnpm --filter web test -- --runInBand apps/web/src/lib/ai-gateway/models.test.ts apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts`
- `pnpm --filter web run typecheck`
- `pnpm --filter web run lint`
- `git diff --check`