### PR TITLE
fix(ai-gateway): route Laguna through Vercel

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -94,11 +94,6 @@ export async function shouldRouteToVercel(
   request: GatewayRequest,
   randomSeed: string
 ) {
-  // BYOK in the Vercel AI Gateway was not working for Laguna models.
-  if (requestedModel.includes('laguna')) {
-    return false;
-  }
-
   console.debug('[shouldRouteToVercel] randomizing user to either OpenRouter or Vercel');
   const percentages = await getVercelRoutingPercentages();
   const routingPercentage = (await isFreeModel(requestedModel))

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -55,6 +55,7 @@ describe('mapModelIdToVercel', () => {
       ['mistralai/mistral-medium-3-5', 'mistral/mistral-medium-3.5'],
       ['mistralai/mistral-small-2603', 'mistral/mistral-small'],
       ['mistralai/pixtral-large-2411', 'mistral/pixtral-large'],
+      ['poolside/laguna-s-2.1:free', 'poolside/laguna-s-2.1-free'],
       ['qwen/qwen3-14b', 'alibaba/qwen-3-14b'],
       ['qwen/qwen3-235b-a22b', 'alibaba/qwen-3-235b'],
       ['qwen/qwen3-30b-a3b', 'alibaba/qwen-3-30b'],
@@ -88,10 +89,6 @@ describe('mapModelIdToVercel', () => {
 
     it('leaves gpt-oss models unchanged', () => {
       expect(mapModelIdToVercel('openai/gpt-oss-20b')).toBe('openai/gpt-oss-20b');
-    });
-
-    it('leaves the OpenRouter-only Poolside model unchanged', () => {
-      expect(mapModelIdToVercel('poolside/laguna-s-2.1:free')).toBe('poolside/laguna-s-2.1:free');
     });
 
     it('leaves a model with an unknown provider prefix unchanged', () => {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -41,6 +41,7 @@ const vercelModelIdMapping: Record<string, string | undefined> = {
   'mistralai/mistral-medium-3-5': 'mistral/mistral-medium-3.5',
   'mistralai/mistral-small-2603': 'mistral/mistral-small',
   'mistralai/pixtral-large-2411': 'mistral/pixtral-large',
+  'poolside/laguna-s-2.1:free': 'poolside/laguna-s-2.1-free',
   'qwen/qwen3-14b': 'alibaba/qwen-3-14b',
   'qwen/qwen3-235b-a22b': 'alibaba/qwen-3-235b',
   'qwen/qwen3-30b-a3b': 'alibaba/qwen-3-30b',


### PR DESCRIPTION
## Summary
- remove the Laguna-specific Vercel routing exclusion
- map the public Laguna model ID to the Vercel AI Gateway model ID
- update the model mapping unit coverage

## Verification
- `pnpm --filter web test --runInBand src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts src/lib/ai-gateway/providers/vercel/index.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`