### PR TITLE
fix(web-env): select kilocode 1Password account

### DIFF
--- a/scripts/web-env/index.ts
+++ b/scripts/web-env/index.ts
@@ -167,7 +167,7 @@ async function main(): Promise<void> {
   try {
     console.log('Checking Vercel and 1Password access...');
     const contexts = resolveVercelContexts(tempDirectory);
-    const vaultId = sensitive ? resolveVault() : undefined;
+    const vault = sensitive ? resolveVault() : undefined;
     const values = await collectValues(options);
     const defaults = await collectDefaults(repoRoot, options.name);
     if (defaults.size === 0) warnAboutMissingTrackedDefault(options.name);
@@ -202,9 +202,9 @@ async function main(): Promise<void> {
         setVariable(context, environment, options.name, values[environment], sensitive);
       }
     }
-    if (vaultId) {
+    if (vault) {
       console.log('Updating 1Password Production copy...');
-      await setVaultValue(vaultId, options.name, values.production);
+      await setVaultValue(vault, options.name, values.production);
     }
 
     console.log('\nDone. Rerun the same command if a provider failed partway through.');

--- a/scripts/web-env/shared.test.ts
+++ b/scripts/web-env/shared.test.ts
@@ -24,7 +24,13 @@ try {
 } catch {}
 const stdin = fs.readFileSync(0, 'utf8');
 fs.appendFileSync(process.env.FAKE_OP_LOG, JSON.stringify({ args, stdin, templateInput }) + '\\n');
-if (args[0] === 'item' && args[1] === 'list') {
+if (args[0] === 'account' && args[1] === 'list') {
+  process.stdout.write(JSON.stringify([
+    { url: 'kilocode.1password.com', account_uuid: 'kilocode-account-id' }
+  ]));
+} else if (args[0] === 'vault' && args[1] === 'get') {
+  process.stdout.write(JSON.stringify({ id: 'vault-id' }));
+} else if (args[0] === 'item' && args[1] === 'list') {
   const items = process.env.FAKE_OP_EXISTING
     ? [{ id: 'existing-id', title: 'TEST_SECRET' }]
     : [];
@@ -71,7 +77,11 @@ async function captureOpInvocations(existing: boolean): Promise<Invocation[]> {
   else delete process.env.FAKE_OP_EXISTING;
 
   try {
-    await setVaultValue('vault-id', 'TEST_SECRET', 'secret-value');
+    await setVaultValue(
+      { accountId: 'account-id', vaultId: 'vault-id' },
+      'TEST_SECRET',
+      'secret-value'
+    );
     return readFileSync(logFile, 'utf8')
       .trim()
       .split('\n')
@@ -97,6 +107,8 @@ void test('setVaultValue creates an item from a template without sending the sec
     '--template=/dev/fd/3',
     '--vault',
     'vault-id',
+    '--account',
+    'account-id',
     '--format=json',
   ]);
   assert.equal(create.stdin, '');
@@ -116,12 +128,47 @@ void test('setVaultValue updates an item from a template without sending the sec
     '--template=/dev/fd/3',
     '--vault',
     'vault-id',
+    '--account',
+    'account-id',
     '--format=json',
   ]);
   assert.equal(edit.stdin, '');
   const item = JSON.parse(edit.templateInput) as { title?: string; fields?: unknown[] };
   assert.equal(item.title, 'TEST_SECRET');
   assert.ok(item.fields?.some(field => JSON.stringify(field).includes('secret-value')));
+});
+
+void test('resolveVault selects the kilocode account before resolving the vault', () => {
+  const directory = mkdtempSync(path.join(os.tmpdir(), 'web-env-op-test-'));
+  const logFile = path.join(directory, 'op.jsonl');
+  writeFileSync(path.join(directory, 'op'), FAKE_OP, { mode: 0o700 });
+  const originalPath = process.env.PATH;
+  const originalLog = process.env.FAKE_OP_LOG;
+  process.env.PATH = `${directory}:${originalPath ?? ''}`;
+  process.env.FAKE_OP_LOG = logFile;
+
+  try {
+    assert.deepEqual(resolveVault(), { accountId: 'kilocode-account-id', vaultId: 'vault-id' });
+    const invocations = readFileSync(logFile, 'utf8')
+      .trim()
+      .split('\n')
+      .map(line => JSON.parse(line) as Invocation);
+    assert.deepEqual(invocations[0]?.args, ['account', 'list', '--format=json']);
+    assert.deepEqual(invocations[1]?.args, [
+      'vault',
+      'get',
+      'Kilo Web ENV Production',
+      '--account',
+      'kilocode-account-id',
+      '--format=json',
+    ]);
+  } finally {
+    if (originalPath === undefined) delete process.env.PATH;
+    else process.env.PATH = originalPath;
+    if (originalLog === undefined) delete process.env.FAKE_OP_LOG;
+    else process.env.FAKE_OP_LOG = originalLog;
+    rmSync(directory, { recursive: true, force: true });
+  }
 });
 
 void test(
@@ -140,7 +187,10 @@ void test(
           error.message.includes('brew install 1password-cli') &&
           error.message.includes('/cli/get-started') &&
           error.message.includes('op signin') &&
-          error.message.includes('op vault get "Kilo Web ENV Production" --format=json')
+          error.message.includes('op account list --format=json') &&
+          error.message.includes(
+            'op vault get "Kilo Web ENV Production" --account kilocode.1password.com --format=json'
+          )
       );
     } finally {
       if (originalPath === undefined) delete process.env.PATH;
@@ -211,7 +261,10 @@ void test(
           error.message.includes('brew install 1password-cli') &&
           error.message.includes('/cli/get-started') &&
           error.message.includes('op signin') &&
-          error.message.includes('op vault get "Kilo Web ENV Production" --format=json') &&
+          error.message.includes('op account list --format=json') &&
+          error.message.includes(
+            'op vault get "Kilo Web ENV Production" --account kilocode.1password.com --format=json'
+          ) &&
           error.message.includes('not currently signed in')
       );
     } finally {

--- a/scripts/web-env/shared.ts
+++ b/scripts/web-env/shared.ts
@@ -8,6 +8,7 @@ import { Writable } from 'node:stream';
 export const PROJECTS = ['kilocode-app', 'kilocode-global-app'] as const;
 export const ENVIRONMENTS = ['development', 'staging', 'production'] as const;
 export const VAULT = 'Kilo Web ENV Production';
+const ONE_PASSWORD_ACCOUNT_URL = 'kilocode.1password.com';
 const VERCEL_PACKAGE = 'vercel@53.3.1';
 const VERCEL_COMMAND = `pnpm dlx ${VERCEL_PACKAGE}`;
 const ONE_PASSWORD_CLI_DOCS = 'https://www.1password.dev/cli/get-started';
@@ -19,6 +20,10 @@ export type VercelContext = {
   project: Project;
   orgId: string;
   cwd: string;
+};
+export type OnePasswordContext = {
+  accountId: string;
+  vaultId: string;
 };
 
 type JsonRecord = Record<string, unknown>;
@@ -62,7 +67,7 @@ function missingCommandMessage(command: string, args: string[]): string | undefi
     return [
       '1Password CLI (`op`) is not installed or is not on PATH.',
       ...onePasswordInstallInstructions(),
-      `Verify access with \`op vault get "${VAULT}" --format=json\`.`,
+      `Verify access with \`op account list --format=json\`, then \`op vault get "${VAULT}" --account ${ONE_PASSWORD_ACCOUNT_URL} --format=json\`.`,
     ].join('\n');
   }
 
@@ -171,7 +176,7 @@ function onePasswordAccessError(error: unknown): Error {
     [
       `Could not verify 1Password access to the ${VAULT} vault.`,
       ...onePasswordInstallInstructions(),
-      `Verify access with \`op vault get "${VAULT}" --format=json\`.`,
+      `Verify access with \`op account list --format=json\`, then \`op vault get "${VAULT}" --account ${ONE_PASSWORD_ACCOUNT_URL} --format=json\`.`,
       'If verification says the vault is missing or forbidden, ask for access to that vault.',
       details ? `1Password reported:\n${details}` : undefined,
     ]
@@ -235,11 +240,31 @@ function assertSecureTemplateSupported(): void {
   }
 }
 
-export function resolveVault(): string {
+export function resolveVault(): OnePasswordContext {
   assertSecureTemplateSupported();
+  let accounts: JsonRecord[];
+  try {
+    accounts = records(JSON.parse(run('op', ['account', 'list', '--format=json'])) as unknown);
+  } catch (error) {
+    if (error instanceof MissingCommandError) throw error;
+    throw onePasswordAccessError(error);
+  }
+  const account = accounts.find(
+    account => stringValue(account, 'url') === ONE_PASSWORD_ACCOUNT_URL
+  );
+  const accountId = account ? stringValue(account, 'account_uuid') : undefined;
+  if (!accountId) {
+    throw onePasswordAccessError(
+      new Error(`Could not find the 1Password account ${ONE_PASSWORD_ACCOUNT_URL}.`)
+    );
+  }
+
   let vault: JsonRecord;
   try {
-    vault = parseJson(run('op', ['vault', 'get', VAULT, '--format=json']), 'Resolve vault');
+    vault = parseJson(
+      run('op', ['vault', 'get', VAULT, '--account', accountId, '--format=json']),
+      'Resolve vault'
+    );
   } catch (error) {
     if (error instanceof MissingCommandError) throw error;
     throw onePasswordAccessError(error);
@@ -248,7 +273,7 @@ export function resolveVault(): string {
   if (!vaultId) {
     throw onePasswordAccessError(new Error(`Could not resolve 1Password vault ${VAULT}.`));
   }
-  return vaultId;
+  return { accountId, vaultId };
 }
 
 function runOpWithTemplate(args: string[], template: string): Promise<string> {
@@ -312,9 +337,17 @@ function runOpWithTemplate(args: string[], template: string): Promise<string> {
   });
 }
 
-function findVaultItem(vaultId: string, name: string): JsonRecord | undefined {
+function findVaultItem(context: OnePasswordContext, name: string): JsonRecord | undefined {
   const items = JSON.parse(
-    run('op', ['item', 'list', '--vault', vaultId, '--format=json'])
+    run('op', [
+      'item',
+      'list',
+      '--vault',
+      context.vaultId,
+      '--account',
+      context.accountId,
+      '--format=json',
+    ])
   ) as unknown;
   const matches = records(items).filter(item => item.title === name);
   if (matches.length > 1) throw new Error(`More than one 1Password item is named ${name}.`);
@@ -350,9 +383,13 @@ function setAuditNote(item: JsonRecord, note: string): void {
   notes.value = preserved ? `${preserved}\n${note}` : note;
 }
 
-export async function setVaultValue(vaultId: string, name: string, value: string): Promise<void> {
+export async function setVaultValue(
+  context: OnePasswordContext,
+  name: string,
+  value: string
+): Promise<void> {
   const note = auditNote();
-  const existing = findVaultItem(vaultId, name);
+  const existing = findVaultItem(context, name);
   if (!existing) {
     const item = {
       title: name,
@@ -377,7 +414,16 @@ export async function setVaultValue(vaultId: string, name: string, value: string
     };
     const created = parseJson(
       await runOpWithTemplate(
-        ['item', 'create', '--template=/dev/fd/3', '--vault', vaultId, '--format=json'],
+        [
+          'item',
+          'create',
+          '--template=/dev/fd/3',
+          '--vault',
+          context.vaultId,
+          '--account',
+          context.accountId,
+          '--format=json',
+        ],
         JSON.stringify(item)
       ),
       `Create ${name}`
@@ -393,7 +439,16 @@ export async function setVaultValue(vaultId: string, name: string, value: string
   const id = stringValue(existing, 'id');
   if (!id) throw new Error(`1Password item ${name} has no ID.`);
   const item = parseJson(
-    run('op', ['item', 'get', id, '--vault', vaultId, '--format=json']),
+    run('op', [
+      'item',
+      'get',
+      id,
+      '--vault',
+      context.vaultId,
+      '--account',
+      context.accountId,
+      '--format=json',
+    ]),
     `Read ${name}`
   );
   const password = records(item.fields).find(field => field.id === 'password');
@@ -408,7 +463,17 @@ export async function setVaultValue(vaultId: string, name: string, value: string
   );
   const updated = parseJson(
     await runOpWithTemplate(
-      ['item', 'edit', id, '--template=/dev/fd/3', '--vault', vaultId, '--format=json'],
+      [
+        'item',
+        'edit',
+        id,
+        '--template=/dev/fd/3',
+        '--vault',
+        context.vaultId,
+        '--account',
+        context.accountId,
+        '--format=json',
+      ],
       JSON.stringify(item)
     ),
     `Update ${name}`


### PR DESCRIPTION
## Summary

- Resolve the `kilocode.1password.com` account before looking up `Kilo Web ENV Production`, avoiding whichever 1Password account the CLI selected by default.
- Carry the resolved account UUID through all 1Password vault item reads and writes via `--account`.
- Add coverage for explicit account selection and account-aware vault mutations. No architectural changes.

## Verification

- [x] Manually ran `pnpm web:env set`
- [ ] Additional manual verification details:

## Visual Changes

N/A

## Reviewer Notes

- The account is selected by its stable `kilocode.1password.com` URL, then the CLI-provided account UUID is used for every operation.