### PR TITLE
feat(mobile): render tool input diffs

### DIFF
--- a/apps/mobile/src/components/agents/part-renderer.test.ts
+++ b/apps/mobile/src/components/agents/part-renderer.test.ts
@@ -61,6 +61,13 @@ describe('PartRenderer', () => {
     expect(result).toBeNull();
   });
 
+  it('does not mount a streaming empty reasoning part', () => {
+    const part = makeReasoningPart('', false);
+    // eslint-disable-next-line new-cap
+    const result = PartRenderer({ part, isStreaming: true });
+    expect(result).toBeNull();
+  });
+
   it('renders completed meaningful reasoning through the renderer seam', () => {
     const part = makeReasoningPart('Meaningful reasoning text', true);
     // eslint-disable-next-line new-cap

--- a/apps/mobile/src/components/agents/part-types.test.ts
+++ b/apps/mobile/src/components/agents/part-types.test.ts
@@ -67,16 +67,16 @@ describe('shouldRenderReasoningPart', () => {
     expect(shouldRenderReasoningPart(part, false)).toBe(true);
   });
 
-  it('renders a reasoning part that is empty while effectively streaming', () => {
+  it('does not render a reasoning part that is empty while effectively streaming', () => {
     const part = makeReasoningPart('', false);
     expect(isPartStreaming(part)).toBe(true);
-    expect(shouldRenderReasoningPart(part, true)).toBe(true);
+    expect(shouldRenderReasoningPart(part, true)).toBe(false);
   });
 
-  it('renders a whitespace-only unfinished reasoning part while the parent is streaming', () => {
+  it('does not render a whitespace-only unfinished reasoning part while the parent is streaming', () => {
     const part = makeReasoningPart('   \n\t  ', false);
     expect(isPartStreaming(part)).toBe(true);
-    expect(shouldRenderReasoningPart(part, true)).toBe(true);
+    expect(shouldRenderReasoningPart(part, true)).toBe(false);
   });
 
   it('does not render a non-reasoning part', () => {

--- a/apps/mobile/src/components/agents/part-types.ts
+++ b/apps/mobile/src/components/agents/part-types.ts
@@ -45,12 +45,9 @@ export function isPartStreaming(part: Part): boolean {
   return false;
 }
 
-export function shouldRenderReasoningPart(part: Part, isStreaming: boolean): boolean {
+export function shouldRenderReasoningPart(part: Part, _isStreaming: boolean): boolean {
   if (!isReasoningPart(part)) {
     return false;
   }
-  if (part.text.trim() !== '') {
-    return true;
-  }
-  return isStreaming && isPartStreaming(part);
+  return part.text.trim() !== '';
 }

--- a/apps/mobile/src/components/agents/reasoning-part-renderer.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/reasoning-part-renderer.mounted.test.tsx
@@ -1,0 +1,180 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/test/render-with-providers.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ReasoningPartRenderer } from './reasoning-part-renderer';
+
+vi.mock('react-native', () => ({
+  Pressable: 'Pressable',
+  View: 'View',
+}));
+vi.mock('lucide-react-native', () => ({
+  ChevronDown: 'ChevronDown',
+  ChevronRight: 'ChevronRight',
+}));
+vi.mock('@/components/ui/eyebrow', () => ({
+  Eyebrow: 'Eyebrow',
+}));
+vi.mock('@/components/ui/text', () => ({
+  Text: 'Text',
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ mutedSoft: '#999999' }),
+}));
+vi.mock('./bubble-text-selection-context', () => ({
+  useTranscriptTextSelectable: () => false,
+}));
+
+/** Find the body element that contains the reasoning text (View right after the Pressable). */
+function findTextElement(
+  root: TestRenderer.ReactTestInstance
+): TestRenderer.ReactTestInstance | undefined {
+  return root.find(
+    node =>
+      typeof node.type === 'string' &&
+      (node.type as string) === 'Text' &&
+      typeof node.props.children === 'string'
+  );
+}
+
+describe('ReasoningPartRenderer mounted', () => {
+  it('shows text without entering animation on first mount', async () => {
+    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      rendererRef.current = TestRenderer.create(
+        createElement(ReasoningPartRenderer, {
+          text: 'First reasoning step',
+          isStreaming: false,
+          defaultExpanded: true,
+        })
+      );
+    });
+    const renderer = rendererRef.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+
+    const textEl = findTextElement(renderer.root);
+    expect(textEl).toBeDefined();
+    expect(textEl?.props.children).toBe('First reasoning step');
+
+    // The body element must not have an entering prop (animation removed).
+    // After the fix, the body is a plain View, not an Animated.View.
+    /* eslint-disable typescript-eslint/no-unsafe-member-access */
+    const bodyViews = renderer.root.findAll(
+      node =>
+        typeof node.type === 'string' &&
+        (node.type as string) === 'View' &&
+        node.props.className === 'mt-2'
+    );
+    expect(bodyViews.length).toBe(1);
+    expect(bodyViews[0]?.props.entering).toBeUndefined();
+    /* eslint-enable typescript-eslint/no-unsafe-member-access */
+  });
+
+  it('shows text without entering animation on recycled mount', async () => {
+    const firstRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      firstRef.current = TestRenderer.create(
+        createElement(ReasoningPartRenderer, {
+          text: 'Recycled reasoning',
+          isStreaming: false,
+          defaultExpanded: true,
+        })
+      );
+    });
+    const firstRenderer = firstRef.current;
+    if (!firstRenderer) {
+      throw new Error('first renderer was not created');
+    }
+    // Unmount
+    await act(async () => {
+      await Promise.resolve();
+      firstRenderer.unmount();
+    });
+
+    // Second mount (recycled)
+    const secondRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      secondRef.current = TestRenderer.create(
+        createElement(ReasoningPartRenderer, {
+          text: 'Recycled reasoning',
+          isStreaming: false,
+          defaultExpanded: true,
+        })
+      );
+    });
+    const secondRenderer = secondRef.current;
+    if (!secondRenderer) {
+      throw new Error('second renderer was not created');
+    }
+
+    const textEl = findTextElement(secondRenderer.root);
+    expect(textEl).toBeDefined();
+    expect(textEl?.props.children).toBe('Recycled reasoning');
+
+    /* eslint-disable typescript-eslint/no-unsafe-member-access */
+    const bodyViews = secondRenderer.root.findAll(
+      node =>
+        typeof node.type === 'string' &&
+        (node.type as string) === 'View' &&
+        node.props.className === 'mt-2'
+    );
+    expect(bodyViews.length).toBe(1);
+    expect(bodyViews[0]?.props.entering).toBeUndefined();
+    /* eslint-enable typescript-eslint/no-unsafe-member-access */
+  });
+
+  it('returns null for blank (empty string) text', async () => {
+    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      rendererRef.current = TestRenderer.create(
+        createElement(ReasoningPartRenderer, {
+          text: '',
+          isStreaming: false,
+          defaultExpanded: true,
+        })
+      );
+    });
+    const renderer = rendererRef.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+    // The renderer returns null, so the tree should have no children.
+    expect(renderer.root.children).toHaveLength(0);
+  });
+
+  it('returns null for whitespace-only text', async () => {
+    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      rendererRef.current = TestRenderer.create(
+        createElement(ReasoningPartRenderer, {
+          text: '   \n\t  ',
+          isStreaming: false,
+          defaultExpanded: true,
+        })
+      );
+    });
+    const renderer = rendererRef.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+    expect(renderer.root.children).toHaveLength(0);
+  });
+});

--- a/apps/mobile/src/components/agents/reasoning-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/reasoning-part-renderer.tsx
@@ -1,7 +1,6 @@
 import { ChevronDown, ChevronRight } from 'lucide-react-native';
 import { useState } from 'react';
 import { Pressable, View } from 'react-native';
-import Animated, { FadeIn } from 'react-native-reanimated';
 
 import { Eyebrow } from '@/components/ui/eyebrow';
 import { Text } from '@/components/ui/text';
@@ -24,6 +23,10 @@ export function ReasoningPartRenderer({
   const colors = useThemeColors();
   const textSelectable = useTranscriptTextSelectable();
 
+  if (text.trim() === '') {
+    return null;
+  }
+
   return (
     <View className="rounded-xl border-[1.5px] border-dashed border-border p-3">
       <Pressable
@@ -44,12 +47,12 @@ export function ReasoningPartRenderer({
         )}
       </Pressable>
 
-      {isExpanded && text ? (
-        <Animated.View entering={FadeIn.duration(200)} className="mt-2">
+      {isExpanded ? (
+        <View className="mt-2">
           <Text selectable={textSelectable} className="text-sm leading-5 text-muted-foreground">
             {text}
           </Text>
-        </Animated.View>
+        </View>
       ) : null}
     </View>
   );

--- a/apps/mobile/src/components/agents/tool-cards/edit-tool-card.test.ts
+++ b/apps/mobile/src/components/agents/tool-cards/edit-tool-card.test.ts
@@ -1,0 +1,233 @@
+import { type ToolPart } from '@kilocode/cloud-agent-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ToolDiffModel } from '../tool-diff-model';
+import { EditToolCard } from './edit-tool-card';
+import * as React from 'react';
+
+vi.mock('react-native', () => ({ View: 'View' }));
+vi.mock('lucide-react-native', () => ({ Pencil: 'Pencil' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('../bubble-text-selection-context', () => ({
+  useTranscriptTextSelectable: () => true,
+}));
+vi.mock('../mono-scroll-block', () => ({ MonoScrollBlock: 'MonoScrollBlock' }));
+vi.mock('../tool-card-shell', () => ({ ToolCardShell: 'ToolCardShell' }));
+vi.mock('../tool-card-utils', () => ({
+  getFilename: (p: string) => p.split('/').pop() ?? p,
+}));
+vi.mock('../tool-diff-preview', () => ({ ToolDiffPreview: 'ToolDiffPreview' }));
+vi.mock('react', async importOriginal => {
+  const actual = await importOriginal<typeof React>();
+  return {
+    default: actual,
+    ...actual,
+    useMemo: <T>(fn: () => T): T => fn(),
+  };
+});
+
+const { buildToolDiffModel } = vi.hoisted(() => ({
+  buildToolDiffModel: vi.fn(),
+}));
+vi.mock('../tool-diff-model', () => ({ buildToolDiffModel }));
+
+function makeCompletedState(overrides: {
+  filePath: string;
+  oldString: string;
+  newString: string;
+}): Extract<ToolPart['state'], { status: 'completed' }> {
+  return {
+    status: 'completed',
+    input: {
+      filePath: overrides.filePath,
+      oldString: overrides.oldString,
+      newString: overrides.newString,
+    },
+    output: '',
+    title: 'edit',
+    metadata: {},
+    time: { start: 0, end: 1 },
+  };
+}
+
+function makeErrorState(overrides: {
+  filePath: string;
+  oldString: string;
+  newString: string;
+  error: string;
+}): Extract<ToolPart['state'], { status: 'error' }> {
+  return {
+    status: 'error',
+    input: {
+      filePath: overrides.filePath,
+      oldString: overrides.oldString,
+      newString: overrides.newString,
+    },
+    error: overrides.error,
+    time: { start: 0, end: 1 },
+  };
+}
+
+function makeEditPart(overrides: {
+  oldString?: string;
+  newString?: string;
+  filePath?: string;
+  status?: string;
+  error?: string;
+}): ToolPart {
+  const filePath = overrides.filePath ?? 'src/app.tsx';
+  const oldString = overrides.oldString ?? 'old';
+  const newString = overrides.newString ?? 'new';
+
+  const state: ToolPart['state'] =
+    overrides.status === 'error'
+      ? makeErrorState({
+          filePath,
+          oldString,
+          newString,
+          error: overrides.error ?? 'failed',
+        })
+      : makeCompletedState({ filePath, oldString, newString });
+
+  return {
+    id: 'edit-1',
+    sessionID: 'session-1',
+    messageID: 'message-1',
+    type: 'tool',
+    callID: 'call-1',
+    tool: 'edit',
+    state,
+  };
+}
+
+function makeModel(): ToolDiffModel {
+  return {
+    lines: [
+      { type: 'del', oldLine: 1, text: 'old', noNewlineAtEndOfFile: false },
+      { type: 'add', newLine: 1, text: 'new', noNewlineAtEndOfFile: false },
+    ],
+    filePath: 'src/app.tsx',
+    language: 'typescript',
+    truncated: false,
+    tool: 'edit',
+  };
+}
+
+function findAll(
+  node: unknown,
+  predicate: (el: React.ReactElement) => boolean
+): React.ReactElement[] {
+  const matches: React.ReactElement[] = [];
+  function walk(value: unknown): void {
+    if (value == null || typeof value === 'string' || typeof value === 'number') {
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        walk(child);
+      }
+      return;
+    }
+    if (React.isValidElement(value)) {
+      if (predicate(value)) {
+        matches.push(value);
+      }
+      const props = value.props as Record<string, unknown>;
+      // Walk the rendered output of function components so their
+      // children are visible to predicate matching.
+      if (typeof value.type === 'function') {
+        walk((value.type as React.FunctionComponent<unknown>)(props));
+      }
+      walk(props.children);
+    }
+  }
+  walk(node);
+  return matches;
+}
+
+function findByType(root: React.ReactElement, type: string): React.ReactElement[] {
+  return findAll(root, el => el.type === type);
+}
+
+describe('EditToolCard — diff preview routing', () => {
+  beforeEach(() => {
+    buildToolDiffModel.mockReset();
+  });
+
+  it('renders ToolDiffPreview when the model exists', () => {
+    const model = makeModel();
+    buildToolDiffModel.mockReturnValue(model);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = EditToolCard({ part: makeEditPart({}) }) as unknown as React.ReactElement;
+    const previews = findByType(root, 'ToolDiffPreview');
+    expect(previews).toHaveLength(1);
+  });
+
+  it('passes the model and partId to ToolDiffPreview', () => {
+    const model = makeModel();
+    buildToolDiffModel.mockReturnValue(model);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = EditToolCard({ part: makeEditPart({}) }) as unknown as React.ReactElement;
+    const preview = findByType(root, 'ToolDiffPreview')[0];
+    expect(preview).toBeDefined();
+    if (!preview) {
+      throw new Error('preview not found');
+    }
+    expect((preview.props as { model: unknown }).model).toBe(model);
+    expect((preview.props as { partId: unknown }).partId).toBe('edit-1');
+  });
+
+  it('renders MonoScrollBlock fallback when the model does not exist', () => {
+    buildToolDiffModel.mockReturnValue(null);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = EditToolCard({
+      part: makeEditPart({ oldString: 'old', newString: 'new' }),
+    }) as unknown as React.ReactElement;
+    expect(findByType(root, 'ToolDiffPreview')).toHaveLength(0);
+    expect(findByType(root, 'MonoScrollBlock')).toHaveLength(2);
+  });
+
+  it('renders no body when the model does not exist and strings are empty', () => {
+    buildToolDiffModel.mockReturnValue(null);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = EditToolCard({
+      part: makeEditPart({ oldString: '', newString: '' }),
+    }) as unknown as React.ReactElement;
+    expect(findByType(root, 'ToolDiffPreview')).toHaveLength(0);
+    expect(findByType(root, 'MonoScrollBlock')).toHaveLength(0);
+  });
+
+  it('preserves the error block when the model exists', () => {
+    const model = makeModel();
+    buildToolDiffModel.mockReturnValue(model);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = EditToolCard({
+      part: makeEditPart({ status: 'error', error: 'something went wrong' }),
+    }) as unknown as React.ReactElement;
+    const texts = findAll(
+      root,
+      el =>
+        el.type === 'Text' &&
+        (el.props as { children?: string }).children === 'something went wrong'
+    );
+    expect(texts).toHaveLength(1);
+  });
+
+  it('preserves the error block when the model does not exist', () => {
+    buildToolDiffModel.mockReturnValue(null);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = EditToolCard({
+      part: makeEditPart({
+        oldString: 'old',
+        newString: 'new',
+        status: 'error',
+        error: 'edit failed',
+      }),
+    }) as unknown as React.ReactElement;
+    const texts = findAll(
+      root,
+      el => el.type === 'Text' && (el.props as { children?: string }).children === 'edit failed'
+    );
+    expect(texts).toHaveLength(1);
+  });
+});

--- a/apps/mobile/src/components/agents/tool-cards/edit-tool-card.tsx
+++ b/apps/mobile/src/components/agents/tool-cards/edit-tool-card.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { View } from 'react-native';
 import { Pencil } from 'lucide-react-native';
 import { type ToolPart } from '@kilocode/cloud-agent-sdk';
@@ -8,6 +9,34 @@ import { useTranscriptTextSelectable } from '../bubble-text-selection-context';
 import { MonoScrollBlock } from '../mono-scroll-block';
 import { ToolCardShell } from '../tool-card-shell';
 import { getFilename } from '../tool-card-utils';
+import { buildToolDiffModel } from '../tool-diff-model';
+import { ToolDiffPreview } from '../tool-diff-preview';
+
+function EditFallbackBody({
+  oldString,
+  newString,
+}: Readonly<{ oldString: string; newString: string }>) {
+  return (
+    <View className="gap-2">
+      {oldString.length > 0 ? (
+        <MonoScrollBlock
+          content={oldString}
+          maxLength={1000}
+          containerClassName="rounded bg-red-50 px-2 py-1 dark:bg-red-950"
+          textClassName="text-red-700 dark:text-red-400"
+        />
+      ) : null}
+      {newString.length > 0 ? (
+        <MonoScrollBlock
+          content={newString}
+          maxLength={1000}
+          containerClassName="rounded bg-green-50 px-2 py-1 dark:bg-green-950"
+          textClassName="text-green-700 dark:text-green-400"
+        />
+      ) : null}
+    </View>
+  );
+}
 
 export function EditToolCard({ part }: Readonly<{ part: ToolPart }>) {
   const textSelectable = useTranscriptTextSelectable();
@@ -21,28 +50,18 @@ export function EditToolCard({ part }: Readonly<{ part: ToolPart }>) {
 
   const hasChanges = oldString.length > 0 || newString.length > 0;
 
+  const diffModel = useMemo(() => buildToolDiffModel(part), [part]);
+
+  let body: React.ReactNode = null;
+  if (diffModel) {
+    body = <ToolDiffPreview model={diffModel} partId={part.id} />;
+  } else if (hasChanges) {
+    body = <EditFallbackBody oldString={oldString} newString={newString} />;
+  }
+
   return (
     <ToolCardShell icon={Pencil} title="edit" subtitle={subtitle} status={part.state.status}>
-      {hasChanges ? (
-        <View className="gap-2">
-          {oldString.length > 0 ? (
-            <MonoScrollBlock
-              content={oldString}
-              maxLength={1000}
-              containerClassName="rounded bg-red-50 px-2 py-1 dark:bg-red-950"
-              textClassName="text-red-700 dark:text-red-400"
-            />
-          ) : null}
-          {newString.length > 0 ? (
-            <MonoScrollBlock
-              content={newString}
-              maxLength={1000}
-              containerClassName="rounded bg-green-50 px-2 py-1 dark:bg-green-950"
-              textClassName="text-green-700 dark:text-green-400"
-            />
-          ) : null}
-        </View>
-      ) : null}
+      {body}
       {error ? (
         <Text selectable={textSelectable} className="text-xs text-destructive">
           {error}

--- a/apps/mobile/src/components/agents/tool-cards/write-tool-card.test.ts
+++ b/apps/mobile/src/components/agents/tool-cards/write-tool-card.test.ts
@@ -1,0 +1,211 @@
+import { type ToolPart } from '@kilocode/cloud-agent-sdk';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ToolDiffModel } from '../tool-diff-model';
+import { WriteToolCard } from './write-tool-card';
+import * as React from 'react';
+
+vi.mock('react-native', () => ({ View: 'View' }));
+vi.mock('lucide-react-native', () => ({ FilePlus: 'FilePlus' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('../bubble-text-selection-context', () => ({
+  useTranscriptTextSelectable: () => true,
+}));
+vi.mock('../mono-scroll-block', () => ({ MonoScrollBlock: 'MonoScrollBlock' }));
+vi.mock('../tool-card-shell', () => ({ ToolCardShell: 'ToolCardShell' }));
+vi.mock('../tool-card-utils', () => ({
+  getFilename: (p: string) => p.split('/').pop() ?? p,
+}));
+vi.mock('../tool-diff-preview', () => ({ ToolDiffPreview: 'ToolDiffPreview' }));
+vi.mock('react', async importOriginal => {
+  const actual = await importOriginal<typeof React>();
+  return {
+    default: actual,
+    ...actual,
+    useMemo: <T>(fn: () => T): T => fn(),
+  };
+});
+
+const { buildToolDiffModel } = vi.hoisted(() => ({
+  buildToolDiffModel: vi.fn(),
+}));
+vi.mock('../tool-diff-model', () => ({ buildToolDiffModel }));
+
+function makeCompletedState(overrides: {
+  filePath: string;
+  content: string;
+}): Extract<ToolPart['state'], { status: 'completed' }> {
+  return {
+    status: 'completed',
+    input: {
+      filePath: overrides.filePath,
+      content: overrides.content,
+    },
+    output: '',
+    title: 'write',
+    metadata: {},
+    time: { start: 0, end: 1 },
+  };
+}
+
+function makeErrorState(overrides: {
+  filePath: string;
+  content: string;
+  error: string;
+}): Extract<ToolPart['state'], { status: 'error' }> {
+  return {
+    status: 'error',
+    input: {
+      filePath: overrides.filePath,
+      content: overrides.content,
+    },
+    error: overrides.error,
+    time: { start: 0, end: 1 },
+  };
+}
+
+function makeWritePart(overrides: {
+  content?: string;
+  filePath?: string;
+  status?: string;
+  error?: string;
+}): ToolPart {
+  const filePath = overrides.filePath ?? 'src/new.ts';
+  const content = overrides.content ?? 'hello world';
+
+  const state: ToolPart['state'] =
+    overrides.status === 'error'
+      ? makeErrorState({
+          filePath,
+          content,
+          error: overrides.error ?? 'failed',
+        })
+      : makeCompletedState({ filePath, content });
+
+  return {
+    id: 'write-1',
+    sessionID: 'session-1',
+    messageID: 'message-1',
+    type: 'tool',
+    callID: 'call-1',
+    tool: 'write',
+    state,
+  };
+}
+
+function makeModel(): ToolDiffModel {
+  return {
+    lines: [{ type: 'add', newLine: 1, text: 'hello world', noNewlineAtEndOfFile: false }],
+    filePath: 'src/new.ts',
+    language: 'typescript',
+    truncated: false,
+    tool: 'write',
+  };
+}
+
+function findAll(
+  node: unknown,
+  predicate: (el: React.ReactElement) => boolean
+): React.ReactElement[] {
+  const matches: React.ReactElement[] = [];
+  function walk(value: unknown): void {
+    if (value == null || typeof value === 'string' || typeof value === 'number') {
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        walk(child);
+      }
+      return;
+    }
+    if (React.isValidElement(value)) {
+      if (predicate(value)) {
+        matches.push(value);
+      }
+      const props = value.props as { children?: unknown };
+      walk(props.children);
+    }
+  }
+  walk(node);
+  return matches;
+}
+
+function findByType(root: React.ReactElement, type: string): React.ReactElement[] {
+  return findAll(root, el => el.type === type);
+}
+
+describe('WriteToolCard — diff preview routing', () => {
+  beforeEach(() => {
+    buildToolDiffModel.mockReset();
+  });
+
+  it('renders ToolDiffPreview when the model exists', () => {
+    const model = makeModel();
+    buildToolDiffModel.mockReturnValue(model);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCard({ part: makeWritePart({}) }) as unknown as React.ReactElement;
+    const previews = findByType(root, 'ToolDiffPreview');
+    expect(previews).toHaveLength(1);
+  });
+
+  it('passes the model and partId to ToolDiffPreview', () => {
+    const model = makeModel();
+    buildToolDiffModel.mockReturnValue(model);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCard({ part: makeWritePart({}) }) as unknown as React.ReactElement;
+    const preview = findByType(root, 'ToolDiffPreview')[0];
+    expect(preview).toBeDefined();
+    if (!preview) {
+      throw new Error('preview not found');
+    }
+    expect((preview.props as { model: unknown }).model).toBe(model);
+    expect((preview.props as { partId: unknown }).partId).toBe('write-1');
+  });
+
+  it('renders MonoScrollBlock fallback when the model does not exist', () => {
+    buildToolDiffModel.mockReturnValue(null);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCard({
+      part: makeWritePart({ content: 'hello' }),
+    }) as unknown as React.ReactElement;
+    expect(findByType(root, 'ToolDiffPreview')).toHaveLength(0);
+    expect(findByType(root, 'MonoScrollBlock')).toHaveLength(1);
+  });
+
+  it('renders no body when the model does not exist and content is empty', () => {
+    buildToolDiffModel.mockReturnValue(null);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCard({
+      part: makeWritePart({ content: '' }),
+    }) as unknown as React.ReactElement;
+    expect(findByType(root, 'ToolDiffPreview')).toHaveLength(0);
+    expect(findByType(root, 'MonoScrollBlock')).toHaveLength(0);
+  });
+
+  it('preserves the error block when the model exists', () => {
+    const model = makeModel();
+    buildToolDiffModel.mockReturnValue(model);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCard({
+      part: makeWritePart({ status: 'error', error: 'write failed' }),
+    }) as unknown as React.ReactElement;
+    const texts = findAll(
+      root,
+      el => el.type === 'Text' && (el.props as { children?: string }).children === 'write failed'
+    );
+    expect(texts).toHaveLength(1);
+  });
+
+  it('preserves the error block when the model does not exist', () => {
+    buildToolDiffModel.mockReturnValue(null);
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCard({
+      part: makeWritePart({ content: 'hello', status: 'error', error: 'write error' }),
+    }) as unknown as React.ReactElement;
+    const texts = findAll(
+      root,
+      el => el.type === 'Text' && (el.props as { children?: string }).children === 'write error'
+    );
+    expect(texts).toHaveLength(1);
+  });
+});

--- a/apps/mobile/src/components/agents/tool-cards/write-tool-card.tsx
+++ b/apps/mobile/src/components/agents/tool-cards/write-tool-card.tsx
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { FilePlus } from 'lucide-react-native';
 import { type ToolPart } from '@kilocode/cloud-agent-sdk';
 
@@ -7,6 +8,8 @@ import { useTranscriptTextSelectable } from '../bubble-text-selection-context';
 import { MonoScrollBlock } from '../mono-scroll-block';
 import { ToolCardShell } from '../tool-card-shell';
 import { getFilename } from '../tool-card-utils';
+import { buildToolDiffModel } from '../tool-diff-model';
+import { ToolDiffPreview } from '../tool-diff-preview';
 
 export function WriteToolCard({ part }: Readonly<{ part: ToolPart }>) {
   const textSelectable = useTranscriptTextSelectable();
@@ -17,11 +20,18 @@ export function WriteToolCard({ part }: Readonly<{ part: ToolPart }>) {
   const subtitle = filePath ? getFilename(filePath) : 'write';
   const error = part.state.status === 'error' ? part.state.error : undefined;
 
+  const diffModel = useMemo(() => buildToolDiffModel(part), [part]);
+
+  let body: React.ReactNode = null;
+  if (diffModel) {
+    body = <ToolDiffPreview model={diffModel} partId={part.id} />;
+  } else if (content.length > 0) {
+    body = <MonoScrollBlock content={content} maxLength={2000} textClassName="text-foreground" />;
+  }
+
   return (
     <ToolCardShell icon={FilePlus} title="write" subtitle={subtitle} status={part.state.status}>
-      {content.length > 0 ? (
-        <MonoScrollBlock content={content} maxLength={2000} textClassName="text-foreground" />
-      ) : null}
+      {body}
       {error ? (
         <Text selectable={textSelectable} className="text-xs text-destructive">
           {error}

--- a/apps/mobile/src/components/agents/tool-diff-model.test.ts
+++ b/apps/mobile/src/components/agents/tool-diff-model.test.ts
@@ -1,0 +1,311 @@
+import { type ToolPart } from '@kilocode/cloud-agent-sdk';
+import { describe, expect, it } from 'vitest';
+
+import { buildToolDiffModel } from './tool-diff-model';
+
+function mustBe<T>(value: T | null, message: string): NonNullable<T> {
+  if (value == null) {
+    throw new Error(message);
+  }
+  return value;
+}
+
+function makeEditToolPart(overrides: {
+  filePath?: string;
+  oldString?: string;
+  newString?: string;
+}): ToolPart {
+  const input: Record<string, unknown> = {
+    filePath: overrides.filePath ?? 'src/app.tsx',
+    oldString: overrides.oldString ?? '',
+    newString: overrides.newString ?? '',
+  };
+  return {
+    id: 'edit-1',
+    sessionID: 'session-1',
+    messageID: 'message-1',
+    type: 'tool',
+    callID: 'call-1',
+    tool: 'edit',
+    state: {
+      status: 'completed',
+      input,
+      output: '',
+      title: 'edit',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    },
+  };
+}
+
+function makeWriteToolPart(overrides: { filePath?: string; content?: string }): ToolPart {
+  const input: Record<string, unknown> = {
+    filePath: overrides.filePath ?? 'src/new.ts',
+    content: overrides.content ?? '',
+  };
+  return {
+    id: 'write-1',
+    sessionID: 'session-1',
+    messageID: 'message-1',
+    type: 'tool' as const,
+    callID: 'call-1',
+    tool: 'write',
+    state: {
+      status: 'completed',
+      input,
+      output: '',
+      title: 'write',
+      metadata: {},
+      time: { start: 0, end: 1 },
+    },
+  };
+}
+
+describe('buildToolDiffModel — edit tool', () => {
+  it('returns deleted and added numbered DiffLine rows for a valid edit', () => {
+    const part = makeEditToolPart({
+      oldString: 'line1\nline2',
+      newString: 'new1\nnew2\nnew3',
+    });
+    const model = mustBe(buildToolDiffModel(part), 'edit model');
+    expect(model.tool).toBe('edit');
+    expect(model.language).toBe('typescript');
+    expect(model.truncated).toBe(false);
+
+    const { lines } = model;
+    expect(lines).toHaveLength(5);
+
+    // Deleted rows
+    expect(lines[0]).toEqual({
+      type: 'del',
+      oldLine: 1,
+      text: 'line1',
+      noNewlineAtEndOfFile: false,
+    });
+    expect(lines[1]).toEqual({
+      type: 'del',
+      oldLine: 2,
+      text: 'line2',
+      noNewlineAtEndOfFile: false,
+    });
+
+    // Added rows — independently numbered from 1
+    expect(lines[2]).toEqual({
+      type: 'add',
+      newLine: 1,
+      text: 'new1',
+      noNewlineAtEndOfFile: false,
+    });
+    expect(lines[3]).toEqual({
+      type: 'add',
+      newLine: 2,
+      text: 'new2',
+      noNewlineAtEndOfFile: false,
+    });
+    expect(lines[4]).toEqual({
+      type: 'add',
+      newLine: 3,
+      text: 'new3',
+      noNewlineAtEndOfFile: false,
+    });
+  });
+
+  it('returns added rows only when oldString is empty', () => {
+    const part = makeEditToolPart({ oldString: '', newString: 'a\nb' });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.lines).toHaveLength(2);
+    expect(model.lines[0]).toEqual({
+      type: 'add',
+      newLine: 1,
+      text: 'a',
+      noNewlineAtEndOfFile: false,
+    });
+    expect(model.lines[1]).toEqual({
+      type: 'add',
+      newLine: 2,
+      text: 'b',
+      noNewlineAtEndOfFile: false,
+    });
+  });
+
+  it('returns deleted rows only when newString is empty', () => {
+    const part = makeEditToolPart({ oldString: 'x\ny', newString: '' });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.lines).toHaveLength(2);
+    expect(model.lines[0]).toEqual({
+      type: 'del',
+      oldLine: 1,
+      text: 'x',
+      noNewlineAtEndOfFile: false,
+    });
+    expect(model.lines[1]).toEqual({
+      type: 'del',
+      oldLine: 2,
+      text: 'y',
+      noNewlineAtEndOfFile: false,
+    });
+  });
+
+  it('returns null when both oldString and newString are empty', () => {
+    const part = makeEditToolPart({ oldString: '', newString: '' });
+    expect(buildToolDiffModel(part)).toBeNull();
+  });
+
+  it('returns a valid model when filePath is empty but content exists', () => {
+    const part = makeEditToolPart({ filePath: '', oldString: 'x', newString: 'y' });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.filePath).toBe('');
+    expect(model.language).toBeNull();
+  });
+
+  it('truncates oldString and newString at the character cap', () => {
+    const longOld = 'a'.repeat(EDIT_CHAR_CAP + 50);
+    const longNew = 'b'.repeat(EDIT_CHAR_CAP + 10);
+    const part = makeEditToolPart({ oldString: longOld, newString: longNew });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.truncated).toBe(true);
+
+    // Each side capped: no line exceeds EDIT_CHAR_CAP combined.
+    const oldLines = model.lines.filter(l => l.type === 'del');
+    const newLines = model.lines.filter(l => l.type === 'add');
+    const oldChars = oldLines.reduce((sum, l) => sum + l.text.length, 0);
+    const newChars = newLines.reduce((sum, l) => sum + l.text.length, 0);
+    expect(oldChars).toBeLessThanOrEqual(EDIT_CHAR_CAP);
+    expect(newChars).toBeLessThanOrEqual(EDIT_CHAR_CAP);
+  });
+
+  it('truncates at the line cap', () => {
+    const manyLines = Array.from({ length: EDIT_LINE_CAP + 10 }, (_, i) => `line${i}`).join('\n');
+    const part = makeEditToolPart({ oldString: manyLines, newString: 'y' });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.truncated).toBe(true);
+    const oldLines = model.lines.filter(l => l.type === 'del');
+    expect(oldLines).toHaveLength(EDIT_LINE_CAP);
+  });
+});
+
+describe('buildToolDiffModel — write tool', () => {
+  it('returns added numbered DiffLine rows for a valid write', () => {
+    const part = makeWriteToolPart({ content: 'line1\nline2\nline3' });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.tool).toBe('write');
+    expect(model.truncated).toBe(false);
+
+    const { lines } = model;
+    expect(lines).toHaveLength(3);
+    expect(lines[0]).toEqual({
+      type: 'add',
+      newLine: 1,
+      text: 'line1',
+      noNewlineAtEndOfFile: false,
+    });
+    expect(lines[1]).toEqual({
+      type: 'add',
+      newLine: 2,
+      text: 'line2',
+      noNewlineAtEndOfFile: false,
+    });
+    expect(lines[2]).toEqual({
+      type: 'add',
+      newLine: 3,
+      text: 'line3',
+      noNewlineAtEndOfFile: false,
+    });
+  });
+
+  it('resolves language for .js files to javascript', () => {
+    const part = makeWriteToolPart({ filePath: 'src/foo.js', content: 'x' });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.language).toBe('javascript');
+  });
+
+  it('resolves language to null for unknown extensions', () => {
+    const part = makeWriteToolPart({ filePath: 'Makefile', content: 'x' });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.language).toBeNull();
+  });
+
+  it('returns null when content is empty', () => {
+    const part = makeWriteToolPart({ content: '' });
+    expect(buildToolDiffModel(part)).toBeNull();
+  });
+
+  it('returns a valid model for whitespace-only content (blank lines)', () => {
+    const part = makeWriteToolPart({ content: '\n\n' });
+    // splitTrimTrailingEmpty removes the final empty, but keeps \n lines.
+    const model = buildToolDiffModel(part);
+    // Two non-empty entries from ["", ""] after trailing pop.
+    expect(model).not.toBeNull();
+  });
+
+  it('returns null when content is missing (undefined treated as empty)', () => {
+    const part = makeWriteToolPart({ content: undefined });
+    expect(buildToolDiffModel(part)).toBeNull();
+  });
+
+  it('truncates content at the character cap', () => {
+    const longContent = 'x'.repeat(WRITE_CHAR_CAP + 100);
+    const part = makeWriteToolPart({ content: longContent });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.truncated).toBe(true);
+    const totalChars =
+      model.lines.reduce((sum, l) => sum + l.text.length, 0) + (model.lines.length - 1);
+    expect(totalChars).toBeLessThanOrEqual(WRITE_CHAR_CAP);
+  });
+
+  it('truncates at the line cap', () => {
+    const manyLines = Array.from({ length: WRITE_LINE_CAP + 10 }, (_, i) => `line${i}`).join('\n');
+    const part = makeWriteToolPart({ content: manyLines });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.truncated).toBe(true);
+    expect(model.lines).toHaveLength(WRITE_LINE_CAP);
+  });
+});
+
+describe('buildToolDiffModel — non-diff tools', () => {
+  it('returns null for a bash tool part', () => {
+    const part: ToolPart = {
+      id: 'bash-1',
+      sessionID: 'session-1',
+      messageID: 'message-1',
+      type: 'tool',
+      callID: 'call-1',
+      tool: 'bash',
+      state: {
+        status: 'completed',
+        input: { command: 'ls' },
+        output: 'done',
+        title: 'bash',
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    };
+    expect(buildToolDiffModel(part)).toBeNull();
+  });
+
+  it('returns null for an unknown tool name', () => {
+    const part: ToolPart = {
+      id: 'x-1',
+      sessionID: 'session-1',
+      messageID: 'message-1',
+      type: 'tool',
+      callID: 'call-1',
+      tool: 'unknown-tool',
+      state: {
+        status: 'completed',
+        input: {},
+        output: '',
+        title: '',
+        metadata: {},
+        time: { start: 0, end: 1 },
+      },
+    };
+    expect(buildToolDiffModel(part)).toBeNull();
+  });
+});
+
+// Constants from the model, duplicated here for focused assertion.
+const EDIT_CHAR_CAP = 1000;
+const EDIT_LINE_CAP = 100;
+const WRITE_CHAR_CAP = 2000;
+const WRITE_LINE_CAP = 200;

--- a/apps/mobile/src/components/agents/tool-diff-model.test.ts
+++ b/apps/mobile/src/components/agents/tool-diff-model.test.ts
@@ -1,3 +1,4 @@
+// oxlint-disable max-lines
 import { type ToolPart } from '@kilocode/cloud-agent-sdk';
 import { describe, expect, it } from 'vitest';
 
@@ -182,6 +183,30 @@ describe('buildToolDiffModel — edit tool', () => {
     const oldLines = model.lines.filter(l => l.type === 'del');
     expect(oldLines).toHaveLength(EDIT_LINE_CAP);
   });
+
+  it('strips CR from CRLF and bare-CR edit input', () => {
+    const part = makeEditToolPart({
+      oldString: 'alpha\r\nbeta',
+      newString: 'gamma\r\ndelta\r\nepsilon',
+    });
+    const model = mustBe(buildToolDiffModel(part), 'model');
+    expect(model.lines).toHaveLength(5);
+    expect(model.lines[0]).toMatchObject({ type: 'del', oldLine: 1, text: 'alpha' });
+    expect(model.lines[1]).toMatchObject({ type: 'del', oldLine: 2, text: 'beta' });
+    expect(model.lines[2]).toMatchObject({ type: 'add', newLine: 1, text: 'gamma' });
+    expect(model.lines[3]).toMatchObject({ type: 'add', newLine: 2, text: 'delta' });
+    expect(model.lines[4]).toMatchObject({ type: 'add', newLine: 3, text: 'epsilon' });
+
+    const barePart = makeEditToolPart({
+      oldString: 'one\rtwo',
+      newString: 'three\rfour',
+    });
+    const bareModel = mustBe(buildToolDiffModel(barePart), 'model');
+    expect(bareModel.lines[0]).toMatchObject({ type: 'del', oldLine: 1, text: 'one' });
+    expect(bareModel.lines[1]).toMatchObject({ type: 'del', oldLine: 2, text: 'two' });
+    expect(bareModel.lines[2]).toMatchObject({ type: 'add', newLine: 1, text: 'three' });
+    expect(bareModel.lines[3]).toMatchObject({ type: 'add', newLine: 2, text: 'four' });
+  });
 });
 
 describe('buildToolDiffModel — write tool', () => {
@@ -259,6 +284,28 @@ describe('buildToolDiffModel — write tool', () => {
     const model = mustBe(buildToolDiffModel(part), 'model');
     expect(model.truncated).toBe(true);
     expect(model.lines).toHaveLength(WRITE_LINE_CAP);
+  });
+
+  it('strips CR from CRLF, bare-CR, and mixed write content', () => {
+    const crlfPart = makeWriteToolPart({ content: 'alpha\r\nbeta\r\ncharlie' });
+    const crlfModel = mustBe(buildToolDiffModel(crlfPart), 'model');
+    expect(crlfModel.lines).toHaveLength(3);
+    expect(crlfModel.lines[0]).toMatchObject({ type: 'add', newLine: 1, text: 'alpha' });
+    expect(crlfModel.lines[1]).toMatchObject({ type: 'add', newLine: 2, text: 'beta' });
+    expect(crlfModel.lines[2]).toMatchObject({ type: 'add', newLine: 3, text: 'charlie' });
+
+    const barePart = makeWriteToolPart({ content: 'one\rtwo' });
+    const bareModel = mustBe(buildToolDiffModel(barePart), 'model');
+    expect(bareModel.lines).toHaveLength(2);
+    expect(bareModel.lines[0]).toMatchObject({ type: 'add', newLine: 1, text: 'one' });
+    expect(bareModel.lines[1]).toMatchObject({ type: 'add', newLine: 2, text: 'two' });
+
+    const mixedPart = makeWriteToolPart({ content: 'line1\nline2\r\nline3' });
+    const mixedModel = mustBe(buildToolDiffModel(mixedPart), 'model');
+    expect(mixedModel.lines).toHaveLength(3);
+    expect(mixedModel.lines[0]).toMatchObject({ type: 'add', newLine: 1, text: 'line1' });
+    expect(mixedModel.lines[1]).toMatchObject({ type: 'add', newLine: 2, text: 'line2' });
+    expect(mixedModel.lines[2]).toMatchObject({ type: 'add', newLine: 3, text: 'line3' });
   });
 });
 

--- a/apps/mobile/src/components/agents/tool-diff-model.ts
+++ b/apps/mobile/src/components/agents/tool-diff-model.ts
@@ -1,0 +1,143 @@
+// Pure model that converts edit and write tool inputs into
+// `ParsedDiffLine` rows for the shared tool diff preview.
+//
+// Edit: builds deleted rows from `oldString` and added rows from
+// `newString`, numbered independently from one.
+// Write: builds added rows from `content`, numbered from one.
+//
+// Character and line caps bound output size. The model is null when
+// the input is absent, invalid, or carries no diff content.
+//
+// Reuses the existing `ParsedDiffLine` type and `languageForPath` from
+// the pull request diff surface. Does not use `parsePatch` because the
+// tool inputs are not unified patches.
+
+import { type ToolPart } from '@kilocode/cloud-agent-sdk';
+import { type ParsedDiffLine } from '@/lib/pr-review/diff/parse-patch';
+import { languageForPath } from '@/lib/pr-review/diff/highlight';
+
+const EDIT_CHARACTER_CAP = 1000;
+const EDIT_LINE_CAP = 100;
+const WRITE_CHARACTER_CAP = 2000;
+const WRITE_LINE_CAP = 200;
+
+export type ToolDiffModel = {
+  lines: readonly ParsedDiffLine[];
+  filePath: string;
+  /** File-extension language for syntax highlighting. null = plain text. */
+  language: string | null;
+  truncated: boolean;
+  tool: string;
+};
+
+/**
+ * Convert an edit or write tool part into a diff model.
+ * Returns null when the tool is neither edit nor write, the input is
+ * absent or invalid, or the diff content is empty.
+ */
+export function buildToolDiffModel(part: ToolPart): ToolDiffModel | null {
+  const tool = part.tool;
+  const input = part.state.input as Record<string, unknown>;
+
+  if (tool === 'edit') {
+    const filePath = typeof input.filePath === 'string' ? input.filePath : '';
+    const oldString = typeof input.oldString === 'string' ? input.oldString : '';
+    const newString = typeof input.newString === 'string' ? input.newString : '';
+
+    const slicedOld = oldString.slice(0, EDIT_CHARACTER_CAP);
+    const slicedNew = newString.slice(0, EDIT_CHARACTER_CAP);
+
+    const delLines = oldString ? splitTrimTrailingEmpty(slicedOld) : [];
+    const addLines = newString ? splitTrimTrailingEmpty(slicedNew) : [];
+
+    if (delLines.length === 0 && addLines.length === 0) {
+      return null;
+    }
+
+    const oldCapHit = oldString.length > EDIT_CHARACTER_CAP;
+    const newCapHit = newString.length > EDIT_CHARACTER_CAP;
+    const truncated =
+      oldCapHit || newCapHit || delLines.length > EDIT_LINE_CAP || addLines.length > EDIT_LINE_CAP;
+
+    const cappedDel = delLines.slice(0, EDIT_LINE_CAP);
+    const cappedAdd = addLines.slice(0, EDIT_LINE_CAP);
+
+    const lines: ParsedDiffLine[] = [
+      ...cappedDel.map(
+        (text, i): ParsedDiffLine => ({
+          type: 'del',
+          oldLine: i + 1,
+          text,
+          noNewlineAtEndOfFile: false,
+        })
+      ),
+      ...cappedAdd.map(
+        (text, i): ParsedDiffLine => ({
+          type: 'add',
+          newLine: i + 1,
+          text,
+          noNewlineAtEndOfFile: false,
+        })
+      ),
+    ];
+
+    return {
+      lines,
+      filePath,
+      language: languageForPath(filePath),
+      truncated,
+      tool,
+    };
+  }
+
+  if (tool === 'write') {
+    const filePath = typeof input.filePath === 'string' ? input.filePath : '';
+    const content = typeof input.content === 'string' ? input.content : '';
+
+    if (!content) {
+      return null;
+    }
+
+    const sliced = content.slice(0, WRITE_CHARACTER_CAP);
+    const textLines = splitTrimTrailingEmpty(sliced);
+
+    if (textLines.length === 0) {
+      return null;
+    }
+
+    const truncated = content.length > WRITE_CHARACTER_CAP || textLines.length > WRITE_LINE_CAP;
+
+    const cappedLines = textLines.slice(0, WRITE_LINE_CAP);
+
+    const lines: ParsedDiffLine[] = cappedLines.map(
+      (text, i): ParsedDiffLine => ({
+        type: 'add',
+        newLine: i + 1,
+        text,
+        noNewlineAtEndOfFile: false,
+      })
+    );
+
+    return {
+      lines,
+      filePath,
+      language: languageForPath(filePath),
+      truncated,
+      tool,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Split text on newlines. Drop a single trailing empty string produced
+ * when the input ends with a newline because it is not a content line.
+ */
+function splitTrimTrailingEmpty(text: string): string[] {
+  const parts = text.split('\n');
+  if (parts.length > 1 && parts.at(-1) === '') {
+    parts.pop();
+  }
+  return parts;
+}

--- a/apps/mobile/src/components/agents/tool-diff-model.ts
+++ b/apps/mobile/src/components/agents/tool-diff-model.ts
@@ -135,7 +135,8 @@ export function buildToolDiffModel(part: ToolPart): ToolDiffModel | null {
  * when the input ends with a newline because it is not a content line.
  */
 function splitTrimTrailingEmpty(text: string): string[] {
-  const parts = text.split('\n');
+  const normalized = text.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+  const parts = normalized.split('\n');
   if (parts.length > 1 && parts.at(-1) === '') {
     parts.pop();
   }

--- a/apps/mobile/src/components/agents/tool-diff-preview.test.ts
+++ b/apps/mobile/src/components/agents/tool-diff-preview.test.ts
@@ -1,0 +1,143 @@
+import * as React from 'react';
+
+import { describe, expect, it, vi } from 'vitest';
+
+import { ToolDiffPreview } from './tool-diff-preview';
+import { type ToolDiffModel } from './tool-diff-model';
+
+vi.mock('react-native', () => ({ View: 'View' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/components/pr-review/diff/diff-line', () => ({ DiffLine: 'DiffLine' }));
+
+function makeModel(overrides: Partial<ToolDiffModel> = {}): ToolDiffModel {
+  return {
+    lines: [
+      { type: 'del', oldLine: 1, text: 'old', noNewlineAtEndOfFile: false },
+      { type: 'add', newLine: 1, text: 'new', noNewlineAtEndOfFile: false },
+    ],
+    filePath: 'src/app.tsx',
+    language: 'typescript',
+    truncated: false,
+    tool: 'edit',
+    ...overrides,
+  };
+}
+
+function render(m: ToolDiffModel, partId = 'part-1'): React.ReactElement {
+  // eslint-disable-next-line new-cap
+  return ToolDiffPreview({ model: m, partId }) as React.ReactElement;
+}
+
+function findAll(
+  node: unknown,
+  predicate: (el: React.ReactElement) => boolean
+): React.ReactElement[] {
+  const matches: React.ReactElement[] = [];
+
+  function walk(value: unknown): void {
+    if (value == null || typeof value === 'string' || typeof value === 'number') {
+      return;
+    }
+    if (Array.isArray(value)) {
+      for (const child of value) {
+        walk(child);
+      }
+      return;
+    }
+    if (React.isValidElement(value)) {
+      if (predicate(value)) {
+        matches.push(value);
+      }
+      const props = value.props as { children?: unknown };
+      walk(props.children);
+    }
+  }
+
+  walk(node);
+  return matches;
+}
+
+function findByType(root: React.ReactElement, type: string): React.ReactElement[] {
+  return findAll(root, el => el.type === type);
+}
+
+function rootElement(node: React.ReactElement | null): React.ReactElement {
+  if (!node) {
+    throw new Error('expected a root element');
+  }
+  return node;
+}
+
+describe('ToolDiffPreview', () => {
+  it('renders a DiffLine for every model line', () => {
+    const root = rootElement(render(makeModel({ language: null })));
+    const diffLines = findByType(root, 'DiffLine');
+    expect(diffLines).toHaveLength(2);
+  });
+
+  it('passes the language prop to every DiffLine', () => {
+    const root = rootElement(render(makeModel({ language: 'python' })));
+    const diffLines = findByType(root, 'DiffLine');
+    for (const el of diffLines) {
+      expect((el.props as { language: unknown }).language).toBe('python');
+    }
+  });
+
+  it('passes keyId with partId and index', () => {
+    const root = rootElement(render(makeModel({ language: null }), 'xyz'));
+    const diffLines = findByType(root, 'DiffLine');
+    expect(diffLines[0]).not.toBeUndefined();
+    expect(diffLines[1]).not.toBeUndefined();
+    const line0 = diffLines[0];
+    const line1 = diffLines[1];
+    if (!line0 || !line1) {
+      throw new Error('diffLines entries missing');
+    }
+    expect((line0.props as { keyId: unknown }).keyId).toBe('xyz:0');
+    expect((line1.props as { keyId: unknown }).keyId).toBe('xyz:1');
+  });
+
+  it('omits onTap from every DiffLine (read-only preview)', () => {
+    const root = rootElement(render(makeModel({ language: null })));
+    const diffLines = findByType(root, 'DiffLine');
+    for (const el of diffLines) {
+      expect((el.props as { onTap?: unknown }).onTap).toBeUndefined();
+    }
+  });
+
+  it('omits isSelected from every DiffLine', () => {
+    const root = rootElement(render(makeModel({ language: null })));
+    const diffLines = findByType(root, 'DiffLine');
+    for (const el of diffLines) {
+      expect((el.props as { isSelected?: unknown }).isSelected).toBeUndefined();
+    }
+  });
+
+  it('shows the Truncated label when the model is truncated', () => {
+    const root = rootElement(render(makeModel({ truncated: true, language: null })));
+    const texts = findByType(root, 'Text');
+    const truncatedLabel = texts.find(
+      el => (el.props as { accessibilityLabel?: string }).accessibilityLabel === 'Content truncated'
+    );
+    expect(truncatedLabel).toBeDefined();
+    if (!truncatedLabel) {
+      throw new Error('truncatedLabel not found');
+    }
+    expect((truncatedLabel.props as { children?: string }).children).toBe('Truncated');
+  });
+
+  it('does not show the Truncated label when the model is not truncated', () => {
+    const root = rootElement(render(makeModel({ truncated: false, language: null })));
+    const texts = findByType(root, 'Text');
+    const truncatedLabel = texts.find(
+      el => (el.props as { accessibilityLabel?: string }).accessibilityLabel === 'Content truncated'
+    );
+    expect(truncatedLabel).toBeUndefined();
+  });
+
+  it('renders an empty container when the model has no lines', () => {
+    const root = rootElement(render(makeModel({ lines: [], language: null, truncated: false })));
+    const diffLines = findByType(root, 'DiffLine');
+    expect(diffLines).toHaveLength(0);
+  });
+});

--- a/apps/mobile/src/components/agents/tool-diff-preview.tsx
+++ b/apps/mobile/src/components/agents/tool-diff-preview.tsx
@@ -1,0 +1,39 @@
+// Read-only diff preview for edit and write tool cards.
+// Renders every `ParsedDiffLine` from the model through the shared
+// `DiffLine` component with syntax highlighting.
+//
+// Does not use `parsePatch` because the tool inputs are not unified
+// patches. No hunk headers, no selection handlers, no scroll view —
+// the transcript `FlashList` owns all vertical scrolling.
+
+import { View } from 'react-native';
+
+import { Text } from '@/components/ui/text';
+import { DiffLine } from '@/components/pr-review/diff/diff-line';
+
+import { type ToolDiffModel } from './tool-diff-model';
+
+type ToolDiffPreviewProps = {
+  model: ToolDiffModel;
+  partId: string;
+};
+
+export function ToolDiffPreview({ model, partId }: Readonly<ToolDiffPreviewProps>) {
+  return (
+    <View className="gap-0">
+      {model.lines.map((line, index) => (
+        <DiffLine
+          key={`${partId}:${index}`}
+          keyId={`${partId}:${index}`}
+          line={line}
+          language={model.language}
+        />
+      ))}
+      {model.truncated ? (
+        <Text accessibilityLabel="Content truncated" className="mt-1 text-xs text-muted-foreground">
+          Truncated
+        </Text>
+      ) : null}
+    </View>
+  );
+}


### PR DESCRIPTION
## Summary

- Render bounded, read-only shared diff rows for mobile edit and write tool cards.
- Keep the existing code preview when the tool input is missing or invalid.
- Remove the thought body entering animation and omit blank reasoning blocks.
- Normalize CRLF and bare-CR tool input before diff row rendering.

## Why

- Tool cards now show clear added and removed lines with syntax highlighting.
- Recycled expanded thought rows keep their text visible.
- Windows line endings no longer appear as stray characters in diff rows.

## How

- Build tool input rows with the current `ParsedDiffLine`, `DiffLine`, and `languageForPath` contracts.
- Bound edit and write previews with the existing character limits and explicit row limits.
- Add routing, model, mounted-renderer, shared diff, and CRLF tests.

## Validation

- `pnpm exec vitest run` for the 10 changed and shared focused test files: 92 passed.
- `pnpm exec vitest run src/components/agents/tool-diff-model.test.ts`: 19 passed after the CRLF repair.
- `pnpm typecheck`: passed.
- `pnpm lint`: passed.
- `pnpm check:unused`: passed.
- `pnpm format` and `git diff --check`: passed.
- iOS bot E2E passed on the latest head: remote edit and write previews, CRLF row inspection, and no fallback.
- The earlier iOS round passed recycled thought and long-write scroll checks.
- Cloud session behavior uses the same shared `ToolPartRenderer` path; deterministic routing tests cover the shared code.

## Visual Changes

Visual Changes: Yes.

**Latest edit tool preview**

![edit-card.png](https://github.com/user-attachments/assets/9603553f-bdc2-4ebe-88a1-979f2048aa78)

**Latest write tool preview**

![write-card.png](https://github.com/user-attachments/assets/8561af06-c6c0-4b53-86ab-a86f7c806aab)

**Recycled thought row**

![recycled-thought.png](https://github.com/user-attachments/assets/2936a796-2547-4250-85c4-f99583769340)

E2E: bot-e2e — iOS verification passed on `3269d1701`.