### PR TITLE
Fix(kiloclaw) cancel notification scope on scheduled admin tasks

### DIFF
--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -2876,6 +2876,63 @@ describe('admin.kiloclawInstances scheduled actions', () => {
         );
       expect(appliedTarget.status).toBe('applied');
     });
+
+    it('still notifies a target claimed by the apply pass but resolved as non-applied', async () => {
+      // Race window: the DO's apply pass can claim a target (pending ->
+      // running) moments before this cancel transaction runs. The
+      // cancel's own UPDATE only touches 'pending' rows, so a 'running'
+      // target is untouched here and resolves later via a completely
+      // separate outcome (e.g. skipped:pinned) that has nothing to do
+      // with this cancel. The notification gate must still fire for it
+      // — the user never got the announced change.
+      const caller = await createCallerForUser(adminUser.id);
+      const created = await caller.admin.kiloclawInstances.scheduleAction({
+        actionType: 'scheduled_restart',
+        instanceIds: [testInstanceId],
+        scheduledAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+      });
+
+      await db
+        .update(kiloclaw_scheduled_action_notifications)
+        .set({ status: 'sent', sent_at: new Date().toISOString() })
+        .where(eq(kiloclaw_scheduled_action_notifications.kind, 'notice'));
+
+      // Simulate the apply pass having claimed the target, then resolved
+      // it for a reason unrelated to any cancel (e.g. version pin).
+      await db
+        .update(kiloclaw_scheduled_action_targets)
+        .set({ status: 'skipped', skip_reason: 'pinned' })
+        .where(eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id));
+
+      await caller.admin.kiloclawInstances.cancelScheduledAction({ id: created.id });
+
+      const cancellationRows = await db
+        .select()
+        .from(kiloclaw_scheduled_action_notifications)
+        .innerJoin(
+          kiloclaw_scheduled_action_targets,
+          eq(
+            kiloclaw_scheduled_action_targets.id,
+            kiloclaw_scheduled_action_notifications.target_id
+          )
+        )
+        .where(
+          and(
+            eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id),
+            eq(kiloclaw_scheduled_action_notifications.kind, 'cancelled')
+          )
+        );
+
+      expect(cancellationRows.length).toBeGreaterThan(0);
+
+      // The pre-existing skip is not clobbered by cancel.
+      const [target] = await db
+        .select()
+        .from(kiloclaw_scheduled_action_targets)
+        .where(eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id));
+      expect(target.status).toBe('skipped');
+      expect(target.skip_reason).toBe('pinned');
+    });
   });
 
   describe('cancelScheduledActionTarget', () => {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -2801,6 +2801,81 @@ describe('admin.kiloclawInstances scheduled actions', () => {
         noticeRows.every(n => n.error_message === 'action cancelled before notice was dispatched')
       ).toBe(true);
     });
+
+    it('queues cancellation notices only for targets the cancel actually took away', async () => {
+      // Fleet-wide reality: some targets already applied by the time an
+      // admin cancels the rest (typically to unblock scheduling a new
+      // action while unresponsive instances hold the parent open).
+      // Users whose instance already upgraded must not be told their
+      // upgrade was cancelled.
+      const secondUser = await insertTestUser();
+      const [secondInstance] = await db
+        .insert(kiloclaw_instances)
+        .values({
+          user_id: secondUser.id,
+          sandbox_id: `test-cancel-applied-${Date.now()}`,
+        })
+        .returning({ id: kiloclaw_instances.id });
+
+      const caller = await createCallerForUser(adminUser.id);
+      const created = await caller.admin.kiloclawInstances.scheduleAction({
+        actionType: 'scheduled_restart',
+        instanceIds: [testInstanceId, secondInstance.id],
+        scheduledAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+      });
+
+      // Both users received their heads-up notices.
+      await db
+        .update(kiloclaw_scheduled_action_notifications)
+        .set({ status: 'sent', sent_at: new Date().toISOString() })
+        .where(eq(kiloclaw_scheduled_action_notifications.kind, 'notice'));
+
+      // First instance upgraded successfully; the second never reported.
+      await db
+        .update(kiloclaw_scheduled_action_targets)
+        .set({ status: 'applied', applied_at: new Date().toISOString() })
+        .where(
+          and(
+            eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id),
+            eq(kiloclaw_scheduled_action_targets.instance_id, testInstanceId)
+          )
+        );
+
+      await caller.admin.kiloclawInstances.cancelScheduledAction({ id: created.id });
+
+      const cancellationRows = await db
+        .select({ instance_id: kiloclaw_scheduled_action_targets.instance_id })
+        .from(kiloclaw_scheduled_action_notifications)
+        .innerJoin(
+          kiloclaw_scheduled_action_targets,
+          eq(
+            kiloclaw_scheduled_action_targets.id,
+            kiloclaw_scheduled_action_notifications.target_id
+          )
+        )
+        .where(
+          and(
+            eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id),
+            eq(kiloclaw_scheduled_action_notifications.kind, 'cancelled')
+          )
+        );
+
+      expect(cancellationRows.length).toBeGreaterThan(0);
+      expect(cancellationRows.every(r => r.instance_id === secondInstance.id)).toBe(true);
+      expect(cancellationRows.some(r => r.instance_id === testInstanceId)).toBe(false);
+
+      // The applied target keeps its outcome — cancel must not rewrite it.
+      const [appliedTarget] = await db
+        .select({ status: kiloclaw_scheduled_action_targets.status })
+        .from(kiloclaw_scheduled_action_targets)
+        .where(
+          and(
+            eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id),
+            eq(kiloclaw_scheduled_action_targets.instance_id, testInstanceId)
+          )
+        );
+      expect(appliedTarget.status).toBe('applied');
+    });
   });
 
   describe('cancelScheduledActionTarget', () => {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.test.ts
@@ -2933,6 +2933,91 @@ describe('admin.kiloclawInstances scheduled actions', () => {
       expect(target.status).toBe('skipped');
       expect(target.skip_reason).toBe('pinned');
     });
+
+    it('defers on a target still running at cancel time and does not notify if it later applies', async () => {
+      // The most likely real-world timing: an admin cancels while the
+      // DO's apply pass is mid-dispatch on a target it just claimed
+      // (pending -> running, via claimScheduledActionTarget). This
+      // cancel mutation's own UPDATE only touches 'pending' rows, so
+      // the running target is untouched — it is genuinely unresolved
+      // at the instant this mutation decides who to notify. Deciding
+      // eagerly from that snapshot is wrong: if the target goes on to
+      // apply, a "cancelled" notification would be sent for a change
+      // that actually happened.
+      const caller = await createCallerForUser(adminUser.id);
+      const created = await caller.admin.kiloclawInstances.scheduleAction({
+        actionType: 'scheduled_restart',
+        instanceIds: [testInstanceId],
+        scheduledAt: new Date(Date.now() + 60 * 60_000).toISOString(),
+      });
+
+      await db
+        .update(kiloclaw_scheduled_action_notifications)
+        .set({ status: 'sent', sent_at: new Date().toISOString() })
+        .where(eq(kiloclaw_scheduled_action_notifications.kind, 'notice'));
+
+      // Simulate claimScheduledActionTarget having just claimed the
+      // target (pending -> running) before this cancel runs.
+      await db
+        .update(kiloclaw_scheduled_action_targets)
+        .set({ status: 'running' })
+        .where(eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id));
+
+      await caller.admin.kiloclawInstances.cancelScheduledAction({ id: created.id });
+
+      // At this point the cancel mutation must NOT have queued a
+      // cancellation notification for the still-unresolved target.
+      const afterCancel = await db
+        .select()
+        .from(kiloclaw_scheduled_action_notifications)
+        .innerJoin(
+          kiloclaw_scheduled_action_targets,
+          eq(
+            kiloclaw_scheduled_action_targets.id,
+            kiloclaw_scheduled_action_notifications.target_id
+          )
+        )
+        .where(
+          and(
+            eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id),
+            eq(kiloclaw_scheduled_action_notifications.kind, 'cancelled')
+          )
+        );
+      expect(afterCancel).toHaveLength(0);
+
+      // The target was left untouched by cancel (still 'running').
+      const [stillRunning] = await db
+        .select()
+        .from(kiloclaw_scheduled_action_targets)
+        .where(eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id));
+      expect(stillRunning.status).toBe('running');
+
+      // Now the target resolves 'applied' — the outcome the eager old
+      // logic could not know about yet. No cancellation notification
+      // must exist for it, before or after this resolution.
+      await db
+        .update(kiloclaw_scheduled_action_targets)
+        .set({ status: 'applied', applied_at: new Date().toISOString() })
+        .where(eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id));
+
+      const afterResolve = await db
+        .select()
+        .from(kiloclaw_scheduled_action_notifications)
+        .innerJoin(
+          kiloclaw_scheduled_action_targets,
+          eq(
+            kiloclaw_scheduled_action_targets.id,
+            kiloclaw_scheduled_action_notifications.target_id
+          )
+        )
+        .where(
+          and(
+            eq(kiloclaw_scheduled_action_targets.scheduled_action_id, created.id),
+            eq(kiloclaw_scheduled_action_notifications.kind, 'cancelled')
+          )
+        );
+      expect(afterResolve).toHaveLength(0);
+    });
   });
 
   describe('cancelScheduledActionTarget', () => {

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -3062,37 +3062,51 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         // cancellation either. ON CONFLICT DO NOTHING keeps repeat
         // cancels idempotent.
         //
-        // Gated on `t.status <> 'applied'`, not on this cancel's own
-        // skip_reason='cancelled' write. A target claimed by the DO's
-        // apply pass (pending → running) moments before this cancel
-        // transaction runs is untouched by the UPDATE above — it's
-        // still 'running' here and resolves later via
-        // recordScheduledActionTargetOutcome with an outcome/skip_reason
-        // that has nothing to do with this cancel (applied, or
-        // skipped:pinned, skipped:pin_changed_in_flight, or failed).
-        // Scoping on the literal string 'cancelled' would silently drop
-        // the notification for every one of those non-applied outcomes
-        // even though the user never got the announced change. `status
-        // <> 'applied'` is the actual invariant we care about — "did
-        // this target get the change we told the user about" — and it
-        // stays correct regardless of which code path produced the
-        // terminal status. It also still excludes rows that legitimately
-        // applied before this cancel landed. The dispatch side can't
-        // filter this out either: selectDueNotifications lets
-        // kind='cancelled' rows through with no target-status gate (by
-        // design — a cancellation must not be blocked by parent/target
-        // state), so the scoping has to happen here at insert time.
-        // Mirrored in services/kiloclaw/src/scheduled/scheduled-action-notices.ts
-        // markSent — keep both in sync if this invariant changes.
+        // Gated on `t.status NOT IN ('applied', 'running')`, not on this
+        // cancel's own skip_reason='cancelled' write.
+        //
+        // Excluding 'applied' handles the easy case: a target that
+        // already got the announced change must not be told it was
+        // cancelled.
+        //
+        // Excluding 'running' handles a race this mutation cannot
+        // resolve on its own: claimScheduledActionTarget flips a target
+        // pending → running *before* the DO's apply pass dispatches the
+        // side effect. This cancel's own UPDATE above only touches
+        // 'pending' targets, so a target claimed moments earlier is
+        // still 'running' right now — genuinely unresolved. It may go
+        // on to resolve 'applied' (no notification should exist) or to
+        // something else (a notification is owed). We can't know yet,
+        // so we don't decide here. The deferred decision is made in
+        // recordScheduledActionTargetOutcome (services/kiloclaw/src/db/index.ts)
+        // once the real outcome is known: if it's not 'applied' and the
+        // parent is by then 'cancelled', that function queues the same
+        // cancellation-notification insert itself. ON CONFLICT on both
+        // sides keeps this idempotent regardless of which writer gets
+        // there first.
+        //
+        // For non-running, non-applied targets (already skipped/failed
+        // before this cancel ran, or freshly skipped by the UPDATE
+        // above), `status <> 'applied'` is the actual invariant we care
+        // about — "did this target get the change we told the user
+        // about" — and it stays correct regardless of which code path
+        // produced the terminal status. The dispatch side can't filter
+        // this out either: selectDueNotifications lets kind='cancelled'
+        // rows through with no target-status gate (by design — a
+        // cancellation must not be blocked by parent/target state), so
+        // the scoping has to happen here at insert time. Mirrored in
+        // services/kiloclaw/src/scheduled/scheduled-action-notices.ts
+        // markSent — keep all three call sites in sync if this
+        // invariant changes.
         //
         // The race between this cancel and an in-flight 'sending'
         // notice is closed in the sweep's markSent: when markSent
         // moves a row from 'sending' to 'sent' AND the parent action
         // is already in 'cancelled', it inserts a cancellation row in
-        // the same step (subject to the same status <> 'applied' gate).
-        // That makes the cancellation creation contingent on the notice
-        // actually reaching the user; a dispatch failure leaves no
-        // orphan cancellation pending.
+        // the same step (subject to the same gate). That makes the
+        // cancellation creation contingent on the notice actually
+        // reaching the user; a dispatch failure leaves no orphan
+        // cancellation pending.
         await tx.execute(sql`
           INSERT INTO kiloclaw_scheduled_action_notifications
             (target_id, channel, kind, status)
@@ -3103,7 +3117,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
           WHERE t.scheduled_action_id = ${input.id}
             AND n.kind = 'notice'
             AND n.status = 'sent'
-            AND t.status <> 'applied'
+            AND t.status NOT IN ('applied', 'running')
           ON CONFLICT (target_id, kind, channel) DO NOTHING
         `);
 

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -3043,7 +3043,12 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             )
           );
 
-        await tx
+        // Capture the target rows this cancel actually took away from
+        // the user. Everything else under this parent has already
+        // resolved (applied / failed / previously skipped) and must NOT
+        // be told "your upgrade was cancelled" — see the notification
+        // scoping below.
+        const cancelledTargets = await tx
           .update(kiloclaw_scheduled_action_targets)
           .set({
             status: 'skipped',
@@ -3054,13 +3059,25 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
               eq(kiloclaw_scheduled_action_targets.scheduled_action_id, input.id),
               eq(kiloclaw_scheduled_action_targets.status, 'pending')
             )
-          );
+          )
+          .returning({ id: kiloclaw_scheduled_action_targets.id });
 
         // Queue cancellation notifications for (target, channel) pairs
         // that already had a 'notice' row in 'sent' status. If the
         // user never received a heads-up we do not surface a
         // cancellation either. ON CONFLICT DO NOTHING keeps repeat
         // cancels idempotent.
+        //
+        // Scoped to the targets this cancel just moved pending →
+        // skipped, NOT to every target under the parent. A fleet-wide
+        // action routinely has targets that already applied (or failed)
+        // by the time an admin cancels the remainder; telling those
+        // users their upgrade was cancelled is factually wrong — their
+        // instance is already on the new version. The dispatch side
+        // can't filter this out either: selectDueNotifications lets
+        // kind='cancelled' rows through with no target-status gate (by
+        // design — a cancellation must not be blocked by parent/target
+        // state), so the scoping has to happen here at insert time.
         //
         // The race between this cancel and an in-flight 'sending'
         // notice is closed in the sweep's markSent: when markSent
@@ -3069,18 +3086,22 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         // the same step. That makes the cancellation creation
         // contingent on the notice actually reaching the user; a
         // dispatch failure leaves no orphan cancellation pending.
-        await tx.execute(sql`
-          INSERT INTO kiloclaw_scheduled_action_notifications
-            (target_id, channel, kind, status)
-          SELECT n.target_id, n.channel, 'cancelled', 'pending'
-          FROM kiloclaw_scheduled_action_notifications n
-          INNER JOIN kiloclaw_scheduled_action_targets t
-            ON t.id = n.target_id
-          WHERE t.scheduled_action_id = ${input.id}
-            AND n.kind = 'notice'
-            AND n.status = 'sent'
-          ON CONFLICT (target_id, kind, channel) DO NOTHING
-        `);
+        if (cancelledTargets.length > 0) {
+          const cancelledTargetIds = sql.join(
+            cancelledTargets.map(t => sql`${t.id}`),
+            sql`, `
+          );
+          await tx.execute(sql`
+            INSERT INTO kiloclaw_scheduled_action_notifications
+              (target_id, channel, kind, status)
+            SELECT n.target_id, n.channel, 'cancelled', 'pending'
+            FROM kiloclaw_scheduled_action_notifications n
+            WHERE n.target_id IN (${cancelledTargetIds})
+              AND n.kind = 'notice'
+              AND n.status = 'sent'
+            ON CONFLICT (target_id, kind, channel) DO NOTHING
+          `);
+        }
 
         // Void any pending notice rows so the sweep doesn't deliver a
         // notice for a now-cancelled action. The sweep's selectDue

--- a/apps/web/src/routers/admin-kiloclaw-instances-router.ts
+++ b/apps/web/src/routers/admin-kiloclaw-instances-router.ts
@@ -3043,12 +3043,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
             )
           );
 
-        // Capture the target rows this cancel actually took away from
-        // the user. Everything else under this parent has already
-        // resolved (applied / failed / previously skipped) and must NOT
-        // be told "your upgrade was cancelled" — see the notification
-        // scoping below.
-        const cancelledTargets = await tx
+        await tx
           .update(kiloclaw_scheduled_action_targets)
           .set({
             status: 'skipped',
@@ -3059,8 +3054,7 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
               eq(kiloclaw_scheduled_action_targets.scheduled_action_id, input.id),
               eq(kiloclaw_scheduled_action_targets.status, 'pending')
             )
-          )
-          .returning({ id: kiloclaw_scheduled_action_targets.id });
+          );
 
         // Queue cancellation notifications for (target, channel) pairs
         // that already had a 'notice' row in 'sent' status. If the
@@ -3068,40 +3062,50 @@ export const adminKiloclawInstancesRouter = createTRPCRouter({
         // cancellation either. ON CONFLICT DO NOTHING keeps repeat
         // cancels idempotent.
         //
-        // Scoped to the targets this cancel just moved pending →
-        // skipped, NOT to every target under the parent. A fleet-wide
-        // action routinely has targets that already applied (or failed)
-        // by the time an admin cancels the remainder; telling those
-        // users their upgrade was cancelled is factually wrong — their
-        // instance is already on the new version. The dispatch side
-        // can't filter this out either: selectDueNotifications lets
+        // Gated on `t.status <> 'applied'`, not on this cancel's own
+        // skip_reason='cancelled' write. A target claimed by the DO's
+        // apply pass (pending → running) moments before this cancel
+        // transaction runs is untouched by the UPDATE above — it's
+        // still 'running' here and resolves later via
+        // recordScheduledActionTargetOutcome with an outcome/skip_reason
+        // that has nothing to do with this cancel (applied, or
+        // skipped:pinned, skipped:pin_changed_in_flight, or failed).
+        // Scoping on the literal string 'cancelled' would silently drop
+        // the notification for every one of those non-applied outcomes
+        // even though the user never got the announced change. `status
+        // <> 'applied'` is the actual invariant we care about — "did
+        // this target get the change we told the user about" — and it
+        // stays correct regardless of which code path produced the
+        // terminal status. It also still excludes rows that legitimately
+        // applied before this cancel landed. The dispatch side can't
+        // filter this out either: selectDueNotifications lets
         // kind='cancelled' rows through with no target-status gate (by
         // design — a cancellation must not be blocked by parent/target
         // state), so the scoping has to happen here at insert time.
+        // Mirrored in services/kiloclaw/src/scheduled/scheduled-action-notices.ts
+        // markSent — keep both in sync if this invariant changes.
         //
         // The race between this cancel and an in-flight 'sending'
         // notice is closed in the sweep's markSent: when markSent
         // moves a row from 'sending' to 'sent' AND the parent action
         // is already in 'cancelled', it inserts a cancellation row in
-        // the same step. That makes the cancellation creation
-        // contingent on the notice actually reaching the user; a
-        // dispatch failure leaves no orphan cancellation pending.
-        if (cancelledTargets.length > 0) {
-          const cancelledTargetIds = sql.join(
-            cancelledTargets.map(t => sql`${t.id}`),
-            sql`, `
-          );
-          await tx.execute(sql`
-            INSERT INTO kiloclaw_scheduled_action_notifications
-              (target_id, channel, kind, status)
-            SELECT n.target_id, n.channel, 'cancelled', 'pending'
-            FROM kiloclaw_scheduled_action_notifications n
-            WHERE n.target_id IN (${cancelledTargetIds})
-              AND n.kind = 'notice'
-              AND n.status = 'sent'
-            ON CONFLICT (target_id, kind, channel) DO NOTHING
-          `);
-        }
+        // the same step (subject to the same status <> 'applied' gate).
+        // That makes the cancellation creation contingent on the notice
+        // actually reaching the user; a dispatch failure leaves no
+        // orphan cancellation pending.
+        await tx.execute(sql`
+          INSERT INTO kiloclaw_scheduled_action_notifications
+            (target_id, channel, kind, status)
+          SELECT n.target_id, n.channel, 'cancelled', 'pending'
+          FROM kiloclaw_scheduled_action_notifications n
+          INNER JOIN kiloclaw_scheduled_action_targets t
+            ON t.id = n.target_id
+          WHERE t.scheduled_action_id = ${input.id}
+            AND n.kind = 'notice'
+            AND n.status = 'sent'
+            AND t.status <> 'applied'
+          ON CONFLICT (target_id, kind, channel) DO NOTHING
+        `);
 
         // Void any pending notice rows so the sweep doesn't deliver a
         // notice for a now-cancelled action. The sweep's selectDue

--- a/services/kiloclaw/src/db/index.test.ts
+++ b/services/kiloclaw/src/db/index.test.ts
@@ -1,0 +1,103 @@
+import { describe, it, expect, vi } from 'vitest';
+import { recordScheduledActionTargetOutcome } from './index';
+import type { WorkerDb } from '@kilocode/db/client';
+
+/**
+ * Unit coverage for the deferred-resolution half of the cancel/claim
+ * handoff (see the doc comment on recordScheduledActionTargetOutcome).
+ * A target claimed by the DO's apply pass (pending -> running) is
+ * untouched by the admin cancel mutation's own UPDATE, which only
+ * touches 'pending' rows. When this function later resolves that
+ * target's real outcome, it must queue the cancellation-notification
+ * insert itself if the outcome isn't 'applied' — that's the exact
+ * invariant under test here.
+ *
+ * No real Postgres connection: services/kiloclaw's `pnpm test` runs in
+ * CI's workspace-tests matrix job, which has no Postgres service
+ * container (unlike the root `test` job). A real-DB integration test
+ * for this function would pass locally and fail in CI. Instead this
+ * fakes the WorkerDb transaction surface just enough to observe the
+ * control flow: does the notification INSERT (`tx.execute`) fire, and
+ * how many times.
+ *
+ * The target/stage/parent UPDATE calls in the real function chain
+ * `.update().set().where()` (and `.returning()` for the target row
+ * only) — the fake chain below supports exactly that shape and nothing
+ * more. It is not a drizzle behavior simulation; it only lets the real
+ * function's branching logic run to completion so the `tx.execute`
+ * call count reflects the real guard (`args.outcome !== 'applied'`).
+ */
+function makeFakeTx(opts: { claimed: boolean }) {
+  const chain = {
+    set: () => chain,
+    where: () => chain,
+    returning: async () => (opts.claimed ? [{ id: 'target-1' }] : []),
+    then: (resolve: (value: undefined) => void) => resolve(undefined),
+  };
+  const execute = vi.fn(async () => ({ rows: [] }));
+  const tx = {
+    update: () => chain,
+    execute,
+  };
+  return { tx, execute };
+}
+
+function makeFakeDb(tx: unknown): WorkerDb {
+  return {
+    transaction: async (cb: (tx: unknown) => Promise<void>) => cb(tx),
+  } as unknown as WorkerDb;
+}
+
+describe('recordScheduledActionTargetOutcome', () => {
+  const baseArgs = {
+    target_id: 'target-1',
+    scheduled_action_id: 'action-1',
+    stage_id: 'stage-1',
+  };
+
+  it('does not queue a cancellation notification when the outcome is applied', async () => {
+    const { tx, execute } = makeFakeTx({ claimed: true });
+    const db = makeFakeDb(tx);
+
+    await recordScheduledActionTargetOutcome(db, { ...baseArgs, outcome: 'applied' });
+
+    expect(execute).not.toHaveBeenCalled();
+  });
+
+  it('queues a cancellation notification when a claimed target resolves skipped', async () => {
+    const { tx, execute } = makeFakeTx({ claimed: true });
+    const db = makeFakeDb(tx);
+
+    await recordScheduledActionTargetOutcome(db, {
+      ...baseArgs,
+      outcome: 'skipped',
+      skip_reason: 'pinned',
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('queues a cancellation notification when a claimed target resolves failed', async () => {
+    const { tx, execute } = makeFakeTx({ claimed: true });
+    const db = makeFakeDb(tx);
+
+    await recordScheduledActionTargetOutcome(db, {
+      ...baseArgs,
+      outcome: 'failed',
+      error_message: 'restart failed',
+    });
+
+    expect(execute).toHaveBeenCalledTimes(1);
+  });
+
+  it('does nothing when the CAS misses (another pass already claimed the target)', async () => {
+    const { tx, execute } = makeFakeTx({ claimed: false });
+    const db = makeFakeDb(tx);
+
+    await recordScheduledActionTargetOutcome(db, { ...baseArgs, outcome: 'skipped' });
+
+    // The function returns early once `updated.length === 0` — the
+    // notification insert (and the counter bumps) must not run.
+    expect(execute).not.toHaveBeenCalled();
+  });
+});

--- a/services/kiloclaw/src/db/index.ts
+++ b/services/kiloclaw/src/db/index.ts
@@ -531,6 +531,16 @@ export async function claimScheduledActionTarget(
  * just records the per-target outcome and increments counters. A
  * follow-up sweep (or the next apply call when no targets remain) can
  * promote stage/parent statuses if their pending counts hit zero.
+ *
+ * Also the resolving half of the cancel/claim race: the admin cancel
+ * mutation defers its cancellation-notification decision for any target
+ * still 'running' at cancel time (unresolved — it doesn't yet know
+ * whether this call will land on 'applied' or something else). Once the
+ * real outcome is known, if it isn't 'applied' and the parent has since
+ * been marked 'cancelled', this function queues that target's
+ * cancellation notification itself. See the matching comment in
+ * apps/web/src/routers/admin-kiloclaw-instances-router.ts
+ * (cancelScheduledAction) for the other half of this handoff.
  */
 export async function recordScheduledActionTargetOutcome(
   db: WorkerDb,
@@ -607,6 +617,38 @@ export async function recordScheduledActionTargetOutcome(
         started_at: sql`COALESCE(${kiloclaw_scheduled_actions.started_at}, ${now})`,
       })
       .where(eq(kiloclaw_scheduled_actions.id, args.scheduled_action_id));
+
+    // Close the claim/dispatch race with the admin cancel mutation.
+    // claimScheduledActionTarget flips pending -> running *before* this
+    // function runs (dispatch happens in between). The cancel mutation's
+    // own UPDATE only touches 'pending' targets, so a target that was
+    // already claimed is left untouched by cancel — at the moment the
+    // cancel mutation decides who to notify, this target is still
+    // 'running', a genuinely unresolved state. Deciding "notify" or
+    // "don't notify" from that snapshot is wrong either way: the target
+    // might still resolve to 'applied' (no notification should exist)
+    // or to something else (a notification is owed). So the cancel
+    // mutation (and the sweep's markSent) both defer on 'running' targets
+    // — they exclude 'running' from their cancellation-notification
+    // insert, not just 'applied'. This is the other half: once we know
+    // the *actual* outcome, if it's not 'applied' and the parent is
+    // already 'cancelled' by now, queue the cancellation notice here.
+    // ON CONFLICT keeps this idempotent against an insert the cancel
+    // mutation or markSent already made for this (target, channel).
+    if (args.outcome !== 'applied') {
+      await tx.execute(sql`
+        INSERT INTO kiloclaw_scheduled_action_notifications
+          (target_id, channel, kind, status)
+        SELECT n.target_id, n.channel, 'cancelled', 'pending'
+        FROM kiloclaw_scheduled_action_notifications n
+        INNER JOIN kiloclaw_scheduled_actions a ON a.id = ${args.scheduled_action_id}
+        WHERE n.target_id = ${args.target_id}
+          AND n.kind = 'notice'
+          AND n.status = 'sent'
+          AND a.status = 'cancelled'
+        ON CONFLICT (target_id, kind, channel) DO NOTHING
+      `);
+    }
   });
 }
 

--- a/services/kiloclaw/src/scheduled/scheduled-action-notices.ts
+++ b/services/kiloclaw/src/scheduled/scheduled-action-notices.ts
@@ -637,16 +637,19 @@ async function markSent(db: WorkerDb, row: DueNotificationRow): Promise<void> {
   //      exists when the user actually received the original notice.
   //      The target-status gate mirrors the cancel mutation's scoping
   //      (apps/web/src/routers/admin-kiloclaw-instances-router.ts,
-  //      cancelScheduledAction): `status <> 'applied'`, not a literal
-  //      skip_reason='cancelled' check. A target the apply pass claimed
-  //      (pending -> running) can resolve to skipped:pinned,
-  //      skipped:pin_changed_in_flight, or failed with no relation to
-  //      this cancel at all — none of those write skip_reason='cancelled',
-  //      so gating on that literal would silently drop the notification
-  //      for a user who never got the announced change. `status <>
-  //      'applied'` is the real invariant: only a target that actually
-  //      received the change is excluded. Keep both call sites in sync
-  //      if this invariant changes.
+  //      cancelScheduledAction): `status NOT IN ('applied', 'running')`,
+  //      not a literal skip_reason='cancelled' check. A target the
+  //      apply pass claimed (pending -> running) can resolve to
+  //      applied, skipped:pinned, skipped:pin_changed_in_flight, or
+  //      failed with no relation to this cancel at all. Excluding
+  //      'running' here defers the decision for a target still
+  //      unresolved at this instant — the same unresolved-status race
+  //      the cancel mutation defers on — rather than guessing from a
+  //      snapshot that might flip to 'applied' moments later. The
+  //      deferred decision is made in recordScheduledActionTargetOutcome
+  //      (services/kiloclaw/src/db/index.ts) once the real outcome is
+  //      known. Keep all three call sites in sync if this invariant
+  //      changes.
   // ON CONFLICT keeps the insert idempotent against a separate cancel
   // transaction that already queued the cancellation from a 'sent' row.
   await db.execute(sql`
@@ -665,7 +668,7 @@ async function markSent(db: WorkerDb, row: DueNotificationRow): Promise<void> {
     INNER JOIN kiloclaw_scheduled_actions a ON a.id = t.scheduled_action_id
     WHERE f.kind = 'notice'
       AND a.status = 'cancelled'
-      AND t.status <> 'applied'
+      AND t.status NOT IN ('applied', 'running')
     ON CONFLICT (target_id, kind, channel) DO NOTHING
   `);
 }

--- a/services/kiloclaw/src/scheduled/scheduled-action-notices.ts
+++ b/services/kiloclaw/src/scheduled/scheduled-action-notices.ts
@@ -635,6 +635,14 @@ async function markSent(db: WorkerDb, row: DueNotificationRow): Promise<void> {
   //      creation to a successful markSent means a dispatch failure
   //      leaves no orphan cancellation; the cancellation row only
   //      exists when the user actually received the original notice.
+  //      The target-status gate mirrors the cancel mutation's scoping:
+  //      only a target the cancel actually took away (skipped with
+  //      skip_reason='cancelled') gets told it was cancelled. A target
+  //      that applied in the window between claim and markSent is
+  //      already on the new version, so a cancellation notice would be
+  //      wrong. Safe to read here: markSent only reaches this branch
+  //      once the cancel transaction has committed, and that
+  //      transaction resolves pending targets before committing.
   // ON CONFLICT keeps the insert idempotent against a separate cancel
   // transaction that already queued the cancellation from a 'sent' row.
   await db.execute(sql`
@@ -653,6 +661,8 @@ async function markSent(db: WorkerDb, row: DueNotificationRow): Promise<void> {
     INNER JOIN kiloclaw_scheduled_actions a ON a.id = t.scheduled_action_id
     WHERE f.kind = 'notice'
       AND a.status = 'cancelled'
+      AND t.status = 'skipped'
+      AND t.skip_reason = 'cancelled'
     ON CONFLICT (target_id, kind, channel) DO NOTHING
   `);
 }

--- a/services/kiloclaw/src/scheduled/scheduled-action-notices.ts
+++ b/services/kiloclaw/src/scheduled/scheduled-action-notices.ts
@@ -635,14 +635,18 @@ async function markSent(db: WorkerDb, row: DueNotificationRow): Promise<void> {
   //      creation to a successful markSent means a dispatch failure
   //      leaves no orphan cancellation; the cancellation row only
   //      exists when the user actually received the original notice.
-  //      The target-status gate mirrors the cancel mutation's scoping:
-  //      only a target the cancel actually took away (skipped with
-  //      skip_reason='cancelled') gets told it was cancelled. A target
-  //      that applied in the window between claim and markSent is
-  //      already on the new version, so a cancellation notice would be
-  //      wrong. Safe to read here: markSent only reaches this branch
-  //      once the cancel transaction has committed, and that
-  //      transaction resolves pending targets before committing.
+  //      The target-status gate mirrors the cancel mutation's scoping
+  //      (apps/web/src/routers/admin-kiloclaw-instances-router.ts,
+  //      cancelScheduledAction): `status <> 'applied'`, not a literal
+  //      skip_reason='cancelled' check. A target the apply pass claimed
+  //      (pending -> running) can resolve to skipped:pinned,
+  //      skipped:pin_changed_in_flight, or failed with no relation to
+  //      this cancel at all — none of those write skip_reason='cancelled',
+  //      so gating on that literal would silently drop the notification
+  //      for a user who never got the announced change. `status <>
+  //      'applied'` is the real invariant: only a target that actually
+  //      received the change is excluded. Keep both call sites in sync
+  //      if this invariant changes.
   // ON CONFLICT keeps the insert idempotent against a separate cancel
   // transaction that already queued the cancellation from a 'sent' row.
   await db.execute(sql`
@@ -661,8 +665,7 @@ async function markSent(db: WorkerDb, row: DueNotificationRow): Promise<void> {
     INNER JOIN kiloclaw_scheduled_actions a ON a.id = t.scheduled_action_id
     WHERE f.kind = 'notice'
       AND a.status = 'cancelled'
-      AND t.status = 'skipped'
-      AND t.skip_reason = 'cancelled'
+      AND t.status <> 'applied'
     ON CONFLICT (target_id, kind, channel) DO NOTHING
   `);
 }


### PR DESCRIPTION
## Summary

Cancelling a fleet-wide scheduled action (e.g. an OpenClaw version upgrade) notified every user who had received the original heads-up, even if their instance had already applied the change or was still mid-dispatch. Users whose upgrade succeeded, or hadn't resolved yet, would get a "the previously scheduled upgrade has been cancelled" message that was factually wrong.

This scopes the cancellation notification to only the targets that actually didn't get the announced change, and closes a race where a target claimed by the apply pass right before cancel (status `running`, not yet resolved) could be judged too early.

## Changes

- `cancelScheduledAction` (admin router) and the notice sweep's `markSent` late-cancel path now gate the cancellation-notification insert on `status NOT IN ('applied', 'running')` instead of the previous unscoped insert (which matched every target with a sent notice) and instead of a later attempt gated on the literal `skip_reason = 'cancelled'` (which missed targets that resolved for unrelated reasons, like a version pin).
- `running` targets are deliberately excluded rather than judged: a target claimed by the DO's apply pass (pending -> running) right before an admin cancels is unresolved at that instant, so `recordScheduledActionTargetOutcome` in `services/kiloclaw/src/db/index.ts` now queues the cancellation notification itself once the real outcome is known, if it isn't `applied` and the parent action is by then cancelled.
- Added regression tests in `admin-kiloclaw-instances-router.test.ts` covering: an already-applied target is excluded, a target skipped for an unrelated reason (pinned) before cancel is still notified, and a target still `running` at cancel time is deferred and correctly not notified even after it later resolves to `applied`.

## Notes

Checked production for pre-existing bad rows from the old unscoped logic (pending `cancelled` notifications queued for already-`applied` targets) and found zero, so no backfill was needed.
