### PR TITLE
feat(code reviewer): record process failure outcomes in the PR summary comment

### DIFF
--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -3460,7 +3460,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
       expect(mockCaptureException).toHaveBeenCalledWith(
         expect.any(Error),
         expect.objectContaining({
-          tags: { source: 'code-review-status-model-not-found-summary' },
+          tags: { source: 'code-review-status-failure-summary' },
         })
       );
     });
@@ -3749,6 +3749,141 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         reviewGuidance: { used: false, ref: null, truncated: false },
       });
       expect(mockUpdateKiloReviewComment).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('failure summary comment', () => {
+    // `cloudAgentSessionId` is what gates structured failure parsing on the
+    // route, so a payload without it never resolves a terminal reason.
+    const byokRateLimitRequest = {
+      cloudAgentSessionId: 'agent_1',
+      status: 'failed',
+      failure: {
+        code: 'assistant_error',
+        assistantReason: 'rate_limited',
+        providerOwnership: 'byok',
+      },
+    };
+
+    it('replaces the GitHub summary with the authored notice and collapses history', async () => {
+      const review = makeReview({
+        previous_summary_body: '<!-- kilo-review -->\n## Code Review Summary\n\nOld findings',
+        previous_summary_head_sha: 'previous-head-sha',
+      });
+      mockGetCodeReviewById.mockResolvedValue(review);
+      mockAppendPreviousReviewSummaryHistory.mockReturnValue('notice with history');
+
+      await POST(makeRequest(byokRateLimitRequest), makeParams(REVIEW_ID));
+
+      expect(mockAppendPreviousReviewSummaryHistory).toHaveBeenCalledWith(
+        expect.stringContaining('<!-- kilo-review -->'),
+        review.previous_summary_body,
+        'previous-head-sha',
+        { maxBodyCharacters: 65_536 }
+      );
+      expect(mockUpdateKiloReviewComment).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        99,
+        'notice with history',
+        'standard'
+      );
+    });
+
+    it('creates the summary comment when the pull request has none yet', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+      mockFindKiloReviewComment.mockResolvedValue(null);
+      mockAppendPreviousReviewSummaryHistory.mockReturnValue('notice only');
+
+      await POST(makeRequest(byokRateLimitRequest), makeParams(REVIEW_ID));
+
+      expect(mockCreatePRComment).toHaveBeenCalledWith(
+        'inst-1',
+        'owner',
+        'repo',
+        1,
+        'notice only',
+        'standard'
+      );
+    });
+
+    it('replaces the GitLab note with the authored notice', async () => {
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ platform: 'gitlab', platform_project_id: 42, check_run_id: null })
+      );
+      mockAppendPreviousReviewSummaryHistory.mockReturnValue('notice with history');
+
+      await POST(makeRequest(byokRateLimitRequest), makeParams(REVIEW_ID));
+
+      expect(mockUpdateKiloReviewNote).toHaveBeenCalledWith(
+        'mock-token',
+        'owner/repo',
+        1,
+        88,
+        'notice with history',
+        'https://gitlab.com'
+      );
+    });
+
+    // The notice is published to a pull request that may be public, so only
+    // reasons with reviewed copy are allowed to write one. Everything else must
+    // stay in the checks tab rather than leak an internal error string.
+    it('writes nothing for a failure without authored copy', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+
+      await POST(
+        makeRequest({
+          cloudAgentSessionId: 'agent_1',
+          status: 'failed',
+          failure: { stage: 'agent_activity', code: 'wrapper_error_after_activity' },
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockUpdateKiloReviewComment).not.toHaveBeenCalled();
+      expect(mockCreatePRComment).not.toHaveBeenCalled();
+    });
+
+    // A managed-key rate limit is Kilo's own quota. Telling the customer to
+    // check their provider key would be wrong.
+    it('writes nothing for a managed key rate limit', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+
+      await POST(
+        makeRequest({
+          cloudAgentSessionId: 'agent_1',
+          status: 'failed',
+          failure: {
+            code: 'assistant_error',
+            assistantReason: 'rate_limited',
+            providerOwnership: 'managed',
+          },
+        }),
+        makeParams(REVIEW_ID)
+      );
+
+      expect(mockUpdateKiloReviewComment).not.toHaveBeenCalled();
+      expect(mockCreatePRComment).not.toHaveBeenCalled();
+    });
+
+    it('writes nothing on a successful review', async () => {
+      mockGetCodeReviewById.mockResolvedValue(makeReview());
+
+      await POST(makeRequest({ status: 'completed' }), makeParams(REVIEW_ID));
+
+      expect(mockCreatePRComment).not.toHaveBeenCalled();
+    });
+
+    it('leaves Bitbucket untouched', async () => {
+      mockGetCodeReviewById.mockResolvedValue(
+        makeReview({ platform: 'bitbucket', check_run_id: null })
+      );
+
+      await POST(makeRequest(byokRateLimitRequest), makeParams(REVIEW_ID));
+
+      expect(mockUpdateKiloReviewComment).not.toHaveBeenCalled();
+      expect(mockCreatePRComment).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -895,13 +895,36 @@ function getGitLabStatusDescription(
   return undefined;
 }
 
-async function upsertModelNotFoundSummary(
+/**
+ * Replace the PR summary comment with an outcome notice, collapsing whatever it
+ * held into the review history block first.
+ *
+ * A run that fails never reaches the agent's own comment update, so without this
+ * the thread still shows the previous run's summary as though it were current.
+ * Composing through `appendPreviousReviewSummaryHistory` keeps the same
+ * accumulating history the success path builds: each run's summary, review or
+ * failure notice, is pushed into the collapsed block rather than discarded.
+ *
+ * `notice` is trusted, pre-authored markdown. Never pass a raw `error_message`:
+ * this is published to the pull request, which may be public.
+ */
+async function upsertFailureSummaryComment(
   review: CloudAgentCodeReview,
   integration: PlatformIntegration,
+  notice: string,
   gitlabAccessToken?: string
 ): Promise<void> {
   const platform = parseCodeReviewPlatform(review.platform);
   if (platform === PLATFORM.BITBUCKET) return;
+
+  // `previous_summary_body` is snapshotted at dispatch, before the agent runs,
+  // so it is already populated by the time a failure lands here.
+  const body = appendPreviousReviewSummaryHistory(
+    notice,
+    review.previous_summary_body,
+    review.previous_summary_head_sha,
+    { maxBodyCharacters: GITHUB_COMMENT_MAX_CHARACTERS }
+  );
 
   if (platform === PLATFORM.GITHUB && integration.platform_installation_id) {
     const [repoOwner, repoName] = review.repo_full_name.split('/');
@@ -920,7 +943,7 @@ async function upsertModelNotFoundSummary(
         repoOwner,
         repoName,
         existing.commentId,
-        MODEL_NOT_FOUND_SUMMARY_BODY,
+        body,
         appType
       );
     } else {
@@ -929,13 +952,13 @@ async function upsertModelNotFoundSummary(
         repoOwner,
         repoName,
         review.pr_number,
-        MODEL_NOT_FOUND_SUMMARY_BODY,
+        body,
         appType
       );
     }
 
     logExceptInTest(
-      `[code-review-status] Upserted model unavailable summary on ${review.repo_full_name}#${review.pr_number}`
+      `[code-review-status] Upserted failure summary on ${review.repo_full_name}#${review.pr_number}`
     );
     return;
   }
@@ -958,21 +981,15 @@ async function upsertModelNotFoundSummary(
         review.repo_full_name,
         review.pr_number,
         existing.noteId,
-        MODEL_NOT_FOUND_SUMMARY_BODY,
+        body,
         instanceUrl
       );
     } else {
-      await createMRNote(
-        accessToken,
-        review.repo_full_name,
-        review.pr_number,
-        MODEL_NOT_FOUND_SUMMARY_BODY,
-        instanceUrl
-      );
+      await createMRNote(accessToken, review.repo_full_name, review.pr_number, body, instanceUrl);
     }
 
     logExceptInTest(
-      `[code-review-status] Upserted model unavailable summary on GitLab MR ${review.repo_full_name}!${review.pr_number}`
+      `[code-review-status] Upserted failure summary on GitLab MR ${review.repo_full_name}!${review.pr_number}`
     );
   }
 }
@@ -1631,17 +1648,32 @@ export async function POST(
       }
     }
 
-    if (integration && isModelNotFoundCancellation) {
+    // Outcome notice for the PR thread. Only reasons with authored copy qualify:
+    // the notice is published to a possibly public repository, so raw error
+    // messages are deliberately never surfaced here. Billing and action-required
+    // failures are excluded because they own separate comment paths that also
+    // disable Code Reviewer, and posting both would double up on the thread.
+    const failureSummaryNotice = isModelNotFoundCancellation
+      ? MODEL_NOT_FOUND_SUMMARY_BODY
+      : status === 'failed' &&
+          !getActionRequiredTerminalReason(terminalReason, errorMessage) &&
+          !isBillingCodeReviewTerminalReason(terminalReason, errorMessage)
+        ? (getCodeReviewTerminalReasonCopy(terminalReason)?.summaryBody ?? null)
+        : null;
+
+    if (integration && failureSummaryNotice) {
       try {
-        await upsertModelNotFoundSummary(review, integration, gitlabAccessToken);
-      } catch (summaryError) {
-        logExceptInTest(
-          '[code-review-status] Failed to upsert model unavailable summary:',
-          summaryError
+        await upsertFailureSummaryComment(
+          review,
+          integration,
+          failureSummaryNotice,
+          gitlabAccessToken
         );
+      } catch (summaryError) {
+        logExceptInTest('[code-review-status] Failed to upsert failure summary:', summaryError);
         captureException(summaryError, {
-          tags: { source: 'code-review-status-model-not-found-summary' },
-          extra: { reviewId, platform: reviewPlatform },
+          tags: { source: 'code-review-status-failure-summary' },
+          extra: { reviewId, platform: reviewPlatform, terminalReason: terminalReason ?? null },
         });
       }
     }

--- a/apps/web/src/lib/code-reviews/terminal-reason-copy.test.ts
+++ b/apps/web/src/lib/code-reviews/terminal-reason-copy.test.ts
@@ -1,5 +1,14 @@
+import { CODE_REVIEW_TERMINAL_REASONS } from '@kilocode/db/schema-types';
 import { CODE_REVIEW_ACTION_REQUIRED_REASONS } from './action-required-shared';
 import { getCodeReviewTerminalReasonCopy } from './terminal-reason-copy';
+
+/**
+ * Derived rather than hardcoded so the invariants below automatically cover any
+ * reason added to the copy map later.
+ */
+const REASONS_WITH_COPY = CODE_REVIEW_TERMINAL_REASONS.filter(reason =>
+  getCodeReviewTerminalReasonCopy(reason)
+);
 
 describe('getCodeReviewTerminalReasonCopy', () => {
   it('returns null for reasons without customer-facing copy', () => {
@@ -10,12 +19,43 @@ describe('getCodeReviewTerminalReasonCopy', () => {
   });
 
   it('names the customer key for a byok rate limit', () => {
-    expect(getCodeReviewTerminalReasonCopy('assistant_rate_limited_byok')).toEqual({
+    expect(getCodeReviewTerminalReasonCopy('assistant_rate_limited_byok')).toMatchObject({
       label: 'Rate limited',
       message: 'Your provider API key hit its rate limit.',
       checkTitle: 'Kilo Code Review rate limited',
       checkSummary: 'Your provider API key hit its rate limit.',
     });
+  });
+
+  // The summary body replaces the PR comment in place. Losing the marker would
+  // orphan the existing comment and post a duplicate on the next run, because
+  // that marker is how the comment is found.
+  it('starts every summary body with the kilo-review marker', () => {
+    for (const reason of REASONS_WITH_COPY) {
+      const copy = getCodeReviewTerminalReasonCopy(reason);
+      expect(copy?.summaryBody.startsWith('<!-- kilo-review -->')).toBe(true);
+    }
+  });
+
+  // This copy is published to the pull request, which may be a public
+  // repository, so it must read as finished prose rather than a stub.
+  it('gives every summary body real content', () => {
+    for (const reason of REASONS_WITH_COPY) {
+      const copy = getCodeReviewTerminalReasonCopy(reason);
+      expect(copy?.summaryBody.replace('<!-- kilo-review -->', '').trim().length).toBeGreaterThan(
+        40
+      );
+    }
+  });
+
+  it('explains that the byok rate limit is not retried', () => {
+    const copy = getCodeReviewTerminalReasonCopy('assistant_rate_limited_byok');
+
+    expect(copy?.summaryBody).toContain('did not run');
+    expect(copy?.summaryBody).toContain('does not retry automatically');
+    // Inline comments are deliberately left in place, so the summary has to say
+    // they are stale rather than let them read as current findings.
+    expect(copy?.summaryBody).toContain('inline comments');
   });
 
   // 'managed' means the request used Kilo's credentials, which currently

--- a/apps/web/src/lib/code-reviews/terminal-reason-copy.test.ts
+++ b/apps/web/src/lib/code-reviews/terminal-reason-copy.test.ts
@@ -50,12 +50,15 @@ describe('getCodeReviewTerminalReasonCopy', () => {
 
   it('explains that the byok rate limit is not retried', () => {
     const copy = getCodeReviewTerminalReasonCopy('assistant_rate_limited_byok');
+    // Source line wrapping is not meaningful: markdown collapses single
+    // newlines, so assert on the rendered wording rather than the layout.
+    const wording = copy?.summaryBody.replace(/\s+/g, ' ');
 
-    expect(copy?.summaryBody).toContain('did not run');
-    expect(copy?.summaryBody).toContain('does not retry automatically');
+    expect(wording).toContain('did not run');
+    expect(wording).toContain('does not retry automatically');
     // Inline comments are deliberately left in place, so the summary has to say
     // they are stale rather than let them read as current findings.
-    expect(copy?.summaryBody).toContain('inline comments');
+    expect(wording).toContain('inline comments');
   });
 
   // 'managed' means the request used Kilo's credentials, which currently

--- a/apps/web/src/lib/code-reviews/terminal-reason-copy.ts
+++ b/apps/web/src/lib/code-reviews/terminal-reason-copy.ts
@@ -63,14 +63,9 @@ const COPY_BY_TERMINAL_REASON = new Map<CodeReviewTerminalReason, CodeReviewTerm
 ## Code Review Summary
 
 **This review did not run.** Your provider API key hit its rate limit, so the
-request was rejected before the review started.
-
-Kilo does not retry automatically, because the quota is held by your provider
-and a retry would hit the same limit. Push a new commit once the limit resets to
-run the review again.
-
-Any inline comments on this pull request are from an earlier review and have not
-been re-checked against the latest commit.`,
+request was rejected before the review started. Kilo does not retry
+automatically, because the quota is your provider's; push a new commit once it
+resets. Any inline comments below are from an earlier review.`,
     },
   ],
 ]);

--- a/apps/web/src/lib/code-reviews/terminal-reason-copy.ts
+++ b/apps/web/src/lib/code-reviews/terminal-reason-copy.ts
@@ -26,7 +26,23 @@ export type CodeReviewTerminalReasonCopy = {
   checkTitle: string;
   /** GitHub check run summary and the GitLab commit status description. */
   checkSummary: string;
+  /**
+   * Markdown written into the PR summary comment in place of a review, so the
+   * run's outcome is recorded in the thread rather than only in the checks tab.
+   *
+   * MUST start with the `<!-- kilo-review -->` marker: that is how the summary
+   * comment is located for update, and writing a body without it would orphan
+   * the existing comment and create a duplicate on the next run.
+   *
+   * Because this is published to the pull request, which may be a public
+   * repository, it must never interpolate a raw `error_message`. Each entry is
+   * a deliberate, reviewed sentence.
+   */
+  summaryBody: string;
 };
+
+/** Identifies the Kilo summary comment for in-place updates. */
+const KILO_REVIEW_MARKER = '<!-- kilo-review -->';
 
 /**
  * A Map rather than an object literal. Callers pass the raw `terminal_reason`
@@ -43,6 +59,18 @@ const COPY_BY_TERMINAL_REASON = new Map<CodeReviewTerminalReason, CodeReviewTerm
       message: 'Your provider API key hit its rate limit.',
       checkTitle: 'Kilo Code Review rate limited',
       checkSummary: 'Your provider API key hit its rate limit.',
+      summaryBody: `${KILO_REVIEW_MARKER}
+## Code Review Summary
+
+**This review did not run.** Your provider API key hit its rate limit, so the
+request was rejected before the review started.
+
+Kilo does not retry automatically, because the quota is held by your provider
+and a retry would hit the same limit. Push a new commit once the limit resets to
+run the review again.
+
+Any inline comments on this pull request are from an earlier review and have not
+been re-checked against the latest commit.`,
     },
   ],
 ]);


### PR DESCRIPTION
## Summary

When a code review run fails it never reaches the point where the agent updates its
summary comment. The pull request thread therefore keeps showing the previous run's
summary as though it were current, and the only signal that anything went wrong is a
red check.

This routes failures that have authored copy through the existing summary comment
path. The notice replaces the current summary, and whatever was there is collapsed
into the review history block that re-runs already build, so the thread accumulates a
record of every run instead of losing them.

- Generalizes `upsertModelNotFoundSummary` into `upsertFailureSummaryComment`, which
  takes the notice body as a parameter and composes it through
  `appendPreviousReviewSummaryHistory` before writing.
- Adds a `summaryBody` field to `CodeReviewTerminalReasonCopy`. Only terminal reasons
  with an entry in that map produce a comment.
- Adds the BYOK rate limit notice, which states that the run did not start, that Kilo
  does not retry against a quota held by the customer's provider, and that any inline
  comments on the pull request are from an earlier review.
- Fixes model-not-found discarding history. It previously wrote its body flat into the
  summary comment, which dropped the prior review from the thread. It now collapses
  like every other run.

Failures without authored copy write nothing. The notice is published to a pull request
that may be in a public repository, so raw `error_message` values are never surfaced.
Billing and action-required failures keep their existing separate comment paths.

## Verification

- [x] Posted a rate limited status callback to a local instance backed by a real GitHub
      App installation on a private test repository. The summary comment was replaced
      with the notice, and the previous summary collapsed into the history block.
- [x] Repeated with a second failing run, using the first run's comment as the snapshot.
      History accumulated to two entries inside a single comment, and no duplicate
      comment was created.
- [ ] Not exercised against a real provider rate limit. The failure was simulated at the
      callback boundary, so the upstream classification in `safe-failure-projection.ts`
      is covered by unit tests only.

## Visual Changes

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- The Sentry tag changed from `code-review-status-model-not-found-summary` to
  `code-review-status-failure-summary`. Saved searches or alerts on the old string will
  stop matching. The terminal reason is now included in `extra.terminalReason`.
- `previous_summary_body` is snapshotted by `prepareReviewPayload` at dispatch, before
  the agent runs, so it is already populated by the time a failure reaches this path.
- The `<!-- kilo-review -->` marker at the start of each `summaryBody` is required. It is
  how the existing comment is located for update, and a body without it would orphan
  that comment and post a duplicate on the next run. A test asserts every entry starts
  with it.
- Bitbucket behavior is unchanged. Both the status update and the comment path already
  return early for it.
