### PR TITLE
fix(ai-gateway): scope model rate limits by flag

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -16,6 +16,14 @@ import { applyResolvedAutoModel } from '@/lib/ai-gateway/auto-model/resolution';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
 import { rewriteModelResponse } from '@/lib/rewriteModelResponse';
 import { readDb } from '@/lib/drizzle';
+import {
+  checkFreeModelRateLimit,
+  checkFreeModelRateLimitByUser,
+  checkPromotionLimit,
+  logFreeModelRequest,
+} from '@/lib/free-model-rate-limiter';
+import { gemma_4_26b_a4b_it_free_model } from '@/lib/ai-gateway/providers/google';
+import { tencent_hy3_free_model } from '@/lib/ai-gateway/providers/tencent';
 
 jest.mock('next/server', () => {
   return {
@@ -36,6 +44,7 @@ jest.mock('@sentry/nextjs', () => ({
 jest.mock('@/lib/user/server');
 jest.mock('@/lib/organizations/organization-usage');
 jest.mock('@/lib/drizzle', () => ({ readDb: {} }));
+jest.mock('@/lib/free-model-rate-limiter');
 jest.mock('@/lib/organizations/organization-group-policy-context.server', () => ({
   getOrganizationGroupPolicyContext: jest.fn().mockResolvedValue({}),
 }));
@@ -113,6 +122,10 @@ const mockedLogMicrodollarUsage = jest.mocked(logMicrodollarUsage);
 const mockedApplyResolvedAutoModel = jest.mocked(applyResolvedAutoModel);
 const mockedGetDirectByokModel = jest.mocked(getDirectByokModel);
 const mockedRewriteModelResponse = jest.mocked(rewriteModelResponse);
+const mockedCheckFreeModelRateLimit = jest.mocked(checkFreeModelRateLimit);
+const mockedCheckFreeModelRateLimitByUser = jest.mocked(checkFreeModelRateLimitByUser);
+const mockedCheckPromotionLimit = jest.mocked(checkPromotionLimit);
+const mockedLogFreeModelRequest = jest.mocked(logFreeModelRequest);
 
 const provider = {
   id: 'openrouter',
@@ -303,6 +316,43 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
       message: 'Rate limit exceeded. Please try again later.',
     });
     expect(mockedUpstreamRequest).not.toHaveBeenCalled();
+  });
+
+  it('applies free-model rate limiting to flagged Kilo-exclusive models', async () => {
+    mockedCheckFreeModelRateLimit.mockResolvedValue({ allowed: false, requestCount: 200 });
+
+    const { POST } = await import('./route');
+    const response = await POST(
+      makeRequest(makeBody(gemma_4_26b_a4b_it_free_model.public_id)) as never
+    );
+
+    expect(response.status).toBe(429);
+    expect(await response.json()).toMatchObject({
+      error_type: 'rate_limit_exceeded',
+      message: 'Model usage limit reached. Please try again later.',
+    });
+    expect(mockedCheckFreeModelRateLimit).toHaveBeenCalledWith('127.0.0.1');
+    expect(mockedCheckFreeModelRateLimitByUser).not.toHaveBeenCalled();
+    expect(mockedLogFreeModelRequest).not.toHaveBeenCalled();
+    expect(mockedUpstreamRequest).not.toHaveBeenCalled();
+  });
+
+  it('does not apply free-model rate limiting to unflagged free models', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: null,
+      authFailedResponse: new Response('unauthorized', { status: 401 }),
+      organizationId: undefined,
+    } as unknown as Awaited<ReturnType<typeof getUserFromAuth>>);
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody(tencent_hy3_free_model.public_id)) as never);
+
+    expect(response.status).toBe(200);
+    expect(mockedCheckFreeModelRateLimit).not.toHaveBeenCalled();
+    expect(mockedCheckFreeModelRateLimitByUser).not.toHaveBeenCalled();
+    expect(mockedCheckPromotionLimit).not.toHaveBeenCalled();
+    expect(mockedLogFreeModelRequest).not.toHaveBeenCalled();
+    expect(mockedUpstreamRequest).toHaveBeenCalledTimes(1);
   });
 
   it('adds latency and rewrites quarantine-3 non-BYOK requests to a free model', async () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -19,13 +19,12 @@ import { applyProviderSpecificLogic } from '@/lib/ai-gateway/providers/apply-pro
 import { getProvider } from '@/lib/ai-gateway/providers/get-provider';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
 import { buildExperimentPromptCapture } from '@/lib/ai-gateway/experiments/persist';
-import { isPublicIdExperimented } from '@/lib/ai-gateway/experiments/membership';
 import { upstreamRequest } from '@/lib/ai-gateway/providers/upstream-request';
 import { debugSaveProxyRequest } from '@/lib/debugUtils';
 import { setTag, startInactiveSpan } from '@sentry/nextjs';
 import { getUserFromAuth } from '@/lib/user/server';
 import { sentryRootSpan } from '@/lib/getRootSpan';
-import { isDeadFreeModel, isKiloExclusiveFreeModel } from '@/lib/ai-gateway/models';
+import { isDeadFreeModel, isKiloExclusiveRateLimitedModel } from '@/lib/ai-gateway/models';
 import {
   hasBestEffortGuessDataCollectionRequirement,
   isFreeModel,
@@ -89,7 +88,6 @@ import { isUnavailableModel } from '@/lib/ai-gateway/unavailable-models';
 import { isCloudflareIP } from '@/lib/cloudflare-ip';
 import {
   isKiloAutoModel,
-  KILO_AUTO_FREE_MODEL,
   KILO_AUTO_EFFICIENT_MODEL,
   ORG_AUTO_MODEL,
 } from '@/lib/ai-gateway/auto-model';
@@ -290,8 +288,8 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   let autoModel: string | null = null;
   // Organization Auto can resolve through an intermediate route target before
-  // reaching a concrete model. Keep that target for nested free-tier rate
-  // limiting and direct-BYOK ownership validation after resolution.
+  // reaching a concrete model. Keep that target for direct-BYOK ownership
+  // validation after resolution.
   let routingTarget: string | null = null;
   let classifierCostUsd = 0;
   if (isKiloAutoModel(requestedModelLowerCased)) {
@@ -367,29 +365,24 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     );
   }
 
-  // For FREE models: check rate limit, log at start.
+  // For rate-limited Kilo-exclusive models: check the limit and log at start.
   // Server-side products (cloud-agent, code-review, app-builder) rate-limit
   // per user when the request comes from Cloudflare IPs (Kilo infrastructure).
   // All other products rate-limit per IP (fast pre-auth path).
-  const isRateLimitedFreeModelRequest =
-    isKiloExclusiveFreeModel(effectiveModelIdLowerCased) ||
-    autoModel === KILO_AUTO_FREE_MODEL.id ||
-    routingTarget === KILO_AUTO_FREE_MODEL.id ||
-    (await isPublicIdExperimented(effectiveModelIdLowerCased));
-  if (isRateLimitedFreeModelRequest) {
+  const isRateLimitedModelRequest = isKiloExclusiveRateLimitedModel(effectiveModelIdLowerCased);
+  if (isRateLimitedModelRequest) {
     const rateLimit = await resolveRateLimit(feature, ipAddress, authPromise);
     if (rateLimit instanceof NextResponse) return rateLimit;
 
     if (!rateLimit.result.allowed) {
       console.warn(
-        `Free model rate limit exceeded, ${rateLimit.subject}, model: ${effectiveModelIdLowerCased}, request count: ${rateLimit.result.requestCount}`
+        `Model rate limit exceeded, ${rateLimit.subject}, model: ${effectiveModelIdLowerCased}, request count: ${rateLimit.result.requestCount}`
       );
       return NextResponse.json(
         {
           error: 'Rate limit exceeded',
           error_type: ProxyErrorType.rate_limit_exceeded,
-          message:
-            'Free model usage limit reached. Please try again later or upgrade to a paid model.',
+          message: 'Model usage limit reached. Please try again later.',
         },
         { status: 429 }
       );
@@ -428,31 +421,33 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       );
     }
 
-    const promotionLimit = await checkPromotionLimit(ipAddress);
+    if (isRateLimitedModelRequest) {
+      const promotionLimit = await checkPromotionLimit(ipAddress);
 
-    if (!promotionLimit.allowed) {
-      console.warn(
-        `Promotion model limit exceeded, ip: ${ipAddress}, ` +
-          `model: ${effectiveModelIdLowerCased}, ` +
-          `requests: ${promotionLimit.requestCount}/${PROMOTION_MAX_REQUESTS} ` +
-          `in ${PROMOTION_WINDOW_HOURS}h window`
-      );
+      if (!promotionLimit.allowed) {
+        console.warn(
+          `Promotion model limit exceeded, ip: ${ipAddress}, ` +
+            `model: ${effectiveModelIdLowerCased}, ` +
+            `requests: ${promotionLimit.requestCount}/${PROMOTION_MAX_REQUESTS} ` +
+            `in ${PROMOTION_WINDOW_HOURS}h window`
+        );
 
-      return NextResponse.json(
-        {
-          error: {
-            code: PROMOTION_MODEL_LIMIT_REACHED,
-            message:
-              'Sign up for free to continue and explore 500 other models. ' +
-              'Takes 2 minutes, no credit card required. Or come back later.',
+        return NextResponse.json(
+          {
+            error: {
+              code: PROMOTION_MODEL_LIMIT_REACHED,
+              message:
+                'Sign up for free to continue and explore 500 other models. ' +
+                'Takes 2 minutes, no credit card required. Or come back later.',
+            },
+            error_type: ProxyErrorType.promotion_limit_reached,
           },
-          error_type: ProxyErrorType.promotion_limit_reached,
-        },
-        { status: 401 } // TODO: Change to 429 once the extension supports it (see kilocode errorUtils.ts)
-      );
+          { status: 401 } // TODO: Change to 429 once the extension supports it (see kilocode errorUtils.ts)
+        );
+      }
     }
 
-    // Anonymous access for free model (already rate-limited above)
+    // Anonymous access for free model (rate-limited above when configured)
     user = createAnonymousContext(ipAddress);
     organizationId = undefined;
     botId = undefined;
@@ -573,7 +568,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   }
 
   // Log to free_model_usage for rate limiting (at request start, before processing)
-  if (isRateLimitedFreeModelRequest) {
+  if (isRateLimitedModelRequest) {
     await logFreeModelRequest(
       ipAddress,
       effectiveModelIdLowerCased,

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -1,5 +1,10 @@
 import { describe, test, expect } from '@jest/globals';
-import { autoFreeModels, findKiloExclusiveModel, kiloExclusiveModels } from './models';
+import {
+  autoFreeModels,
+  findKiloExclusiveModel,
+  isKiloExclusiveRateLimitedModel,
+  kiloExclusiveModels,
+} from './models';
 import { hasBestEffortGuessDataCollectionRequirement, isFreeModel } from './is-free-model';
 import { getInferenceProvider } from './providers/kilo-exclusive-model';
 import { getAiSdkProvider } from './providers/model-settings';
@@ -10,6 +15,17 @@ import {
 } from './providers/anthropic.constants';
 import { gpt_5_6_sol_stealth_model } from './providers/openai-exclusive';
 import { tencent_hy3_free_model } from './providers/tencent';
+import { gemma_4_26b_a4b_it_free_model } from './providers/google';
+
+describe('rate-limited Kilo-exclusive models', () => {
+  test('only includes free Gemma', () => {
+    expect(kiloExclusiveModels.filter(model => model.flags.includes('rate-limited'))).toEqual([
+      gemma_4_26b_a4b_it_free_model,
+    ]);
+    expect(isKiloExclusiveRateLimitedModel(gemma_4_26b_a4b_it_free_model.public_id)).toBe(true);
+    expect(isKiloExclusiveRateLimitedModel(tencent_hy3_free_model.public_id)).toBe(false);
+  });
+});
 
 describe('isFreeModel', () => {
   describe('free models', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -85,6 +85,12 @@ export function isKiloExclusiveModel(model: string): boolean {
   return kiloExclusiveModels.some(m => m.public_id === model && m.status !== 'disabled');
 }
 
+export function isKiloExclusiveRateLimitedModel(model: string): boolean {
+  return kiloExclusiveModels.some(
+    m => m.public_id === model && m.status !== 'disabled' && m.flags.includes('rate-limited')
+  );
+}
+
 export const kiloExclusiveModels = [
   gemma_4_26b_a4b_it_free_model,
   ...deepseekDiscountedModels,

--- a/apps/web/src/lib/ai-gateway/providers/google.ts
+++ b/apps/web/src/lib/ai-gateway/providers/google.ts
@@ -14,7 +14,7 @@ export const gemma_4_26b_a4b_it_free_model: KiloExclusiveModel = {
   context_length: 262144,
   max_completion_tokens: 32768,
   status: 'hidden', // usable through kilo-auto
-  flags: ['vision', 'vercel-routing'],
+  flags: ['vision', 'vercel-routing', 'rate-limited'],
   gateway: 'openrouter',
   internal_id: GEMMA_4_26B_A4B_IT_ID,
   pricing: null,

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -13,6 +13,7 @@ export type KiloExclusiveModelFlag =
   | 'vision'
   | 'stealth'
   | 'vercel-routing'
+  | 'rate-limited'
   | 'requires-data-collection';
 
 export type Usage = {


### PR DESCRIPTION
## Summary
- add a `rate-limited` Kilo-exclusive model flag
- apply request and anonymous promotion limits only to flagged models, regardless of pricing
- mark only the free Gemma model as rate-limited

## Verification
- `NODE_ENV=test pnpm --filter web exec jest --runInBand --runTestsByPath "src/lib/ai-gateway/models.test.ts" "src/app/api/openrouter/[...path]/route.test.ts"`
- `pnpm --filter web typecheck`
- `pnpm exec oxlint --config .oxlintrc.json <changed files>`
- `pnpm exec oxfmt --check <changed files>`
- `git diff --check`