### PR TITLE
fix(session-ingest): treat creation default title as placeholder for agent-generated titles

### DIFF
--- a/services/session-ingest/src/ingest/default-session-title.ts
+++ b/services/session-ingest/src/ingest/default-session-title.ts
@@ -1,0 +1,15 @@
+// Duplicated from kilocode packages/opencode/src/session/session.ts:55-62
+// (isDefaultTitle). Keep in sync when the CLI default-title pattern changes.
+export const DEFAULT_SESSION_TITLE_PATTERN =
+  /^(New session - |Child session - )\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
+
+/**
+ * A session title counts as the creation placeholder when it is still NULL or when it
+ * holds the default title stamped at creation time (e.g. cloud-agent-next inserts
+ * `New session - <ISO timestamp>` via createSessionForCloudAgent). Agent-generated
+ * titles may promote a placeholder title but must never overwrite a user-chosen one.
+ */
+export function isDefaultSessionTitle(title: string | null | undefined): boolean {
+  if (title == null) return true;
+  return DEFAULT_SESSION_TITLE_PATTERN.test(title);
+}

--- a/services/session-ingest/src/ingest/metadata.test.ts
+++ b/services/session-ingest/src/ingest/metadata.test.ts
@@ -685,6 +685,24 @@ describe('applyMetadataChanges', () => {
       );
     });
 
+    it('applies the agent-generated title over the default title stamped at creation (cloud-agent-next)', async () => {
+      // cloud-agent-next creates rows with a non-null default title
+      // (`New session - <ISO timestamp>`) via createSessionForCloudAgent; that title is
+      // still the creation placeholder and must not block the agent-generated title.
+      const db = createApplyMetadataDb({ initialTitle: 'New session - 2026-08-04T10:00:00.000Z' });
+      vi.mocked(getWorkerDb).mockReturnValue(db as never);
+
+      await applyMetadataChanges(env, 'usr_1', 'ses_1', new Map([['title', 'Agent title']]));
+
+      expect(db.updateSets).toEqual([expect.objectContaining({ title: 'Agent title' })]);
+      expect(notifyUserSessionEvent).toHaveBeenCalledWith(
+        env,
+        'usr_1',
+        expect.objectContaining({ type: 'session.updated' }),
+        undefined
+      );
+    });
+
     it('skips the agent-generated title write when the user already renamed the session', async () => {
       const db = createApplyMetadataDb({ initialTitle: 'User chosen title' });
       vi.mocked(getWorkerDb).mockReturnValue(db as never);

--- a/services/session-ingest/src/ingest/metadata.ts
+++ b/services/session-ingest/src/ingest/metadata.ts
@@ -8,6 +8,7 @@ import { getSessionAccessCacheDO } from '../dos/SessionAccessCacheDO';
 import { isNeedsInputStatus } from '../dos/session-ingest-attention';
 import { mapSessionEventRow, notifyUserSessionEvent } from '../session-events';
 import { SessionStatusSchema } from '../types/user-connection-protocol';
+import { isDefaultSessionTitle } from './default-session-title';
 
 /** Stored status written when a CLI disconnects while the session is waiting on input. */
 export const CLI_DISCONNECT_ATTENTION_RESET_STATUS = 'retry' as const;
@@ -131,12 +132,13 @@ export async function applyMetadataChanges(
           })();
 
     // Agent-generated titles arrive asynchronously and can race a user rename. A session's
-    // title starts out NULL (the placeholder set at row creation); only promote it from that
-    // placeholder here. Once the title is non-null — whether from a user rename or an earlier
-    // agent-generated write — leave it alone so a later user rename can never be clobbered by
-    // an in-flight ingest.
+    // title starts out as a creation placeholder — NULL, or the default title stamped at
+    // creation (e.g. cloud-agent-next inserts `New session - <ISO timestamp>`); only promote
+    // it from that placeholder here. Once the title holds anything else — whether from a user
+    // rename or an earlier agent-generated write — leave it alone so a later user rename can
+    // never be clobbered by an in-flight ingest.
     if (mergedChanges.has('title')) {
-      if (currentRow.title === null) {
+      if (isDefaultSessionTitle(currentRow.title)) {
         titleWriteApplied = true;
       } else {
         console.warn('Skipping agent-generated title write; title is no longer the placeholder', {

--- a/services/session-ingest/src/routes/api.ts
+++ b/services/session-ingest/src/routes/api.ts
@@ -18,6 +18,7 @@ import { getUserConnectionDO } from '../dos/UserConnectionDO';
 import { getSessionExport } from '../services/session-export';
 import { mapSessionEventRow, notifyUserSessionEvent } from '../session-events';
 import { handleDirectIngestRequest } from '../ingest/direct-ingest';
+import { isDefaultSessionTitle } from '../ingest/default-session-title';
 import { resolveAccessibleKiloSession } from '../services/session-access';
 
 export type ApiContext = {
@@ -524,16 +525,6 @@ api.post('/session/:sessionId/unshare', async c => {
 
   return c.json({ success: true }, 200);
 });
-
-// Duplicated from kilocode packages/opencode/src/session/session.ts:55-62
-// (isDefaultTitle). Keep in sync when the CLI default-title pattern changes.
-const DEFAULT_SESSION_TITLE_PATTERN =
-  /^(New session - |Child session - )\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d{3}Z$/;
-
-function isDefaultSessionTitle(title: string | null | undefined): boolean {
-  if (title == null) return true;
-  return DEFAULT_SESSION_TITLE_PATTERN.test(title);
-}
 
 const reportSessionTitleSchema = z.object({
   title: z.string().trim().min(1).max(200),


### PR DESCRIPTION
## Problem

#4852 stopped agent-generated titles from clobbering user renames by only promoting the title away from the creation placeholder, which it assumed was always `title IS NULL`. That assumption is wrong for cloud-agent-next: `session-registration.ts` stamps every new row with a default title (`New session - <ISO timestamp>`) via `createSessionForCloudAgent`, so the row is never NULL and the auto-generated title arriving through the ingest pipeline (`applyMetadataChanges`) is always dropped with `Skipping agent-generated title write; title is no longer the placeholder`. Cloud Agent sessions keep their `New session - ...` title forever unless the user manually renames them.

## Fix

The correct placeholder definition already existed in this service: `POST /session/:sessionId/title` treats both NULL and the CLI default-title pattern (`New session - ...` / `Child session - ...`, duplicated from kilocode's `isDefaultTitle`) as the placeholder, with a CAS at write time.

- Extract `DEFAULT_SESSION_TITLE_PATTERN` / `isDefaultSessionTitle` from `routes/api.ts` into `ingest/default-session-title.ts` (no behavior change there).
- `applyMetadataChanges` now gates the agent-generated title write on `isDefaultSessionTitle(currentRow.title)` instead of `currentRow.title === null`. User-renamed titles and earlier agent-generated titles are still never overwritten; the rest of the metadata batch is unaffected.

## Tests

- `metadata.test.ts`: new case — agent-generated title is applied over the default title stamped at creation (the cloud-agent-next shape). Existing cases (NULL placeholder applied, user-renamed skipped, rest-of-batch still applied) unchanged.
- The extracted helper remains covered by the existing `POST /session/:sessionId/title` tests in `api.test.ts` (NULL, default-pattern, and user-title cases).

## Verification

Not run locally (per request); relying on CI.