### PR TITLE
refactor(cloud-agent): reduce cgroup stats interval to 15 seconds

### DIFF
--- a/services/cloud-agent-next/wrapper/src/tool-cgroup.ts
+++ b/services/cloud-agent-next/wrapper/src/tool-cgroup.ts
@@ -110,7 +110,7 @@ const DEFAULT_CPU_WEIGHT = 100;
 const MAX_CPU_WEIGHT = 10000;
 const DEFAULT_SWEEP_INTERVAL_MS = 1000;
 const MIN_SWEEP_INTERVAL_MS = 200;
-const DEFAULT_STATS_INTERVAL_MS = 10 * 1000;
+const DEFAULT_STATS_INTERVAL_MS = 15 * 1000;
 /** Below this cap the box is too small to meaningfully partition; stay uncapped. */
 const MIN_CAP_BYTES = 1024 * 1024 * 1024;
 /** §2.2 budget check: server cap + this headroom must fit under the tool reserve. */

--- a/services/cloud-agent-next/wrapper/src/tool-cgroup.ts
+++ b/services/cloud-agent-next/wrapper/src/tool-cgroup.ts
@@ -110,7 +110,7 @@ const DEFAULT_CPU_WEIGHT = 100;
 const MAX_CPU_WEIGHT = 10000;
 const DEFAULT_SWEEP_INTERVAL_MS = 1000;
 const MIN_SWEEP_INTERVAL_MS = 200;
-const DEFAULT_STATS_INTERVAL_MS = 5 * 60 * 1000;
+const DEFAULT_STATS_INTERVAL_MS = 10 * 1000;
 /** Below this cap the box is too small to meaningfully partition; stay uncapped. */
 const MIN_CAP_BYTES = 1024 * 1024 * 1024;
 /** §2.2 budget check: server cap + this headroom must fit under the tool reserve. */


### PR DESCRIPTION
Updates `DEFAULT_STATS_INTERVAL_MS` in `services/cloud-agent-next/wrapper/src/tool-cgroup.ts` from 5 minutes to 15 seconds so `tool_cgroup_stats` log lines (memory current/peak + CPU usage for the `kilo-tools` and `kilo-server` slices) are emitted far more often, making memory-pressure and OOM events easier to correlate in wrapper logs.

The operation is cheap: each tick performs 6 synchronous reads of tiny cgroupfs virtual files (`memory.current`, `memory.peak`, `cpu.stat` per slice), served from kernel memory with no disk I/O — negligible next to the 1s membership sweep that already walks all of `/proc`.

Note: per request, no checks were run on the final 15s value (wrapper unit tests + typecheck passed on the intermediate 10s version of this same one-line change).