### PR TITLE
feat(web): route chat completions and AI gateway calls to global app

### DIFF
--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -65,6 +65,14 @@ const nextConfig = {
               destination: 'https://global-api.kilo.ai/api/edit/completions',
             },
             {
+              source: '/api/gateway/:path*',
+              destination: 'https://global-api.kilo.ai/api/gateway/:path*',
+            },
+            {
+              source: '/api/openrouter/:path*',
+              destination: 'https://global-api.kilo.ai/api/openrouter/:path*',
+            },
+            {
               source: '/api/exa/:path*',
               destination: 'https://global-api.kilo.ai/api/exa/:path*',
             },


### PR DESCRIPTION
## Summary
Extends the existing global-app rewrite rules in `apps/web/next.config.mjs` to also cover chat completions and AI gateway traffic, so these requests are proxied to `global-api.kilo.ai` when running in production and not on the global backend (same condition as the existing `/api/fim/completions` rewrite).

## Changes
- Added `/api/gateway/:path*` -> `https://global-api.kilo.ai/api/gateway/:path*`
- Added `/api/openrouter/:path*` -> `https://global-api.kilo.ai/api/openrouter/:path*`

Both routes are handled by the same catch-all handler (`apps/web/src/app/api/openrouter/[...path]/route.ts`, re-exported at `apps/web/src/app/api/gateway/[...path]/route.ts`), which serves chat completions at `/api/gateway/v1/chat/completions` (and the legacy alias `/api/openrouter/v1/chat/completions`), as well as `/responses` and `/messages`. Adding both prefixes as `:path*` rewrites covers chat completions and all other AI gateway calls, following the same structure/convention as the existing `fim/completions` and `edit/completions` rewrites (same `beforeFiles` placement, same `global-api.kilo.ai` destination base URL, same env-var gating).

## Testing
- Verified formatting with `oxfmt --list-different apps/web/next.config.mjs` (no diff).

---
Built for [Remon Oldenbeuving](https://kilo-code.slack.com/archives/D0A0KQSRCBV/p1785843380860459?thread_ts=1785843345.572829&cid=D0A0KQSRCBV) by [Kilo for Slack](https://kilo.ai/slack)