### PR TITLE
fix(ai-gateway): make Sakana Fugu Ultra available

### DIFF
--- a/apps/web/src/lib/ai-gateway/unavailable-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/unavailable-models.test.ts
@@ -7,7 +7,7 @@ import {
 describe('unavailable models', () => {
   test('keeps exact matching for request rejection', () => {
     expect(isUnavailableModel('openai/gpt-oss-20b:free')).toBe(true);
-    expect(isUnavailableModel('sakana/fugu-ultra')).toBe(true);
+    expect(isUnavailableModel('sakana/fugu-ultra')).toBe(false);
     expect(isUnavailableModel('byteplus-coding/glm-4.7')).toBe(true);
     expect(isUnavailableModel('openai/gpt-oss-20b')).toBe(false);
   });
@@ -19,7 +19,6 @@ describe('unavailable models', () => {
   });
 
   test('ignores families of unavailable models that are not free', () => {
-    expect(familyHasUnavailableFreeModel('sakana/fugu-ultra')).toBe(false);
     expect(familyHasUnavailableFreeModel('giga-potato')).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai-gateway/unavailable-models.ts
+++ b/apps/web/src/lib/ai-gateway/unavailable-models.ts
@@ -47,7 +47,6 @@ const unavailableModelIds: ReadonlySet<string> = new Set([
   'qwen/qwen3.6-plus-preview:free',
   'qwen/qwen3.6-plus:free',
   'qwen/qwen3.7-plus:free',
-  'sakana/fugu-ultra', // this model is not available in the EU
   'upstage/solar-pro-3:free',
   'x-ai/grok-code-fast-1:optimized:free',
   'xiaomi/mimo-v2-omni:free',


### PR DESCRIPTION
## Summary\n- remove Sakana Fugu Ultra from the unavailable model list\n- update the focused unavailable-model regression test\n\n## Validation\n- pnpm --filter web exec jest src/lib/ai-gateway/unavailable-models.test.ts --runInBand