### PR TITLE
feat(ai-gateway): support Qwen3.8 reasoning

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -38,6 +38,12 @@ export const REASONING_VARIANTS_MAX_HIGH_LOW = {
   low: { reasoning: { enabled: true, effort: 'low' } },
 } as const;
 
+export const REASONING_VARIANTS_XHIGH_MEDIUM_LOW = {
+  xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
+  medium: { reasoning: { enabled: true, effort: 'medium' } },
+  low: { reasoning: { enabled: true, effort: 'low' } },
+} as const;
+
 export const REASONING_VARIANTS_MINIMAL_LOW_MEDIUM_HIGH = {
   minimal: { reasoning: { enabled: true, effort: 'minimal' } },
   ...REASONING_VARIANTS_LOW_MEDIUM_HIGH,
@@ -97,6 +103,9 @@ export function getModelVariants(model: string): OpenCodeSettings['variants'] {
   }
   if (isKimiModel(model)) {
     return REASONING_VARIANTS_MAX_HIGH_LOW;
+  }
+  if (model.includes('qwen3.8') && (model.includes('plus') || model.includes('max'))) {
+    return REASONING_VARIANTS_XHIGH_MEDIUM_LOW;
   }
   if (
     isMinimaxModel(model) ||

--- a/apps/web/src/lib/ai-gateway/providers/qwen.ts
+++ b/apps/web/src/lib/ai-gateway/providers/qwen.ts
@@ -91,7 +91,7 @@ export function isQwenModel(model: string) {
 
 export function isQwenExplicitCacheModel(model: string) {
   return (
-    (model.includes('qwen3.7') || model.includes('qwen3.6')) &&
+    (model.includes('qwen3.8') || model.includes('qwen3.7') || model.includes('qwen3.6')) &&
     (model.includes('max') || model.includes('plus'))
   );
 }


### PR DESCRIPTION
## Summary
- add xhigh, medium, and low reasoning variants for Qwen3.8 Plus and Max models
- enable explicit prompt caching for Qwen3.8 Plus and Max models

## Reference
https://qwen.ai/blog?id=qwen3.8

## Validation
- pnpm --filter web run typecheck
- pnpm --filter web run lint
- pnpm --filter web test -- --runInBand apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts