### PR TITLE
feat(ai-gateway): prefer Tencent Hy3 free model

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -51,7 +51,7 @@ export const preferredModels = [
   KILO_AUTO_FREE_MODEL.id,
 
   ...autoFreeModels,
-  tencent_hy3_free_model.public_id,
+  ...(tencent_hy3_free_model.status === 'public' ? [tencent_hy3_free_model.public_id] : []),
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -51,6 +51,7 @@ export const preferredModels = [
   KILO_AUTO_FREE_MODEL.id,
 
   ...autoFreeModels,
+  tencent_hy3_free_model.public_id,
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -8,6 +8,7 @@ import { deepseek_v4_pro_discounted_model } from '@/lib/ai-gateway/providers/dee
 import { GPT_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/openai';
 import { gpt_5_6_sol_stealth_model } from '@/lib/ai-gateway/providers/openai-exclusive';
 import { QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
+import { tencent_hy3_free_model } from '@/lib/ai-gateway/providers/tencent';
 
 describe('OpenRouter Models Config', () => {
   test('preferred models should contain expected models', () => {
@@ -20,6 +21,7 @@ describe('OpenRouter Models Config', () => {
         : 'deepseek/deepseek-v4-pro',
       QWEN37_PLUS_MODEL_ID,
       'z-ai/glm-5.2',
+      tencent_hy3_free_model.public_id,
     ];
 
     expectedModels.forEach(model => {


### PR DESCRIPTION
## Summary

- Add `tencent/hy3:free` to preferred models immediately below `autoFreeModels`.
- Cover the preferred-model configuration with an assertion.

## Validation

- `git diff --check`
- `oxfmt --check apps/web/src/lib/ai-gateway/models.ts apps/web/src/tests/openrouter-models-config.test.ts`
- Jest was blocked by the current Node 26 environment and pnpm patch-application failures for existing Expo/React Native dependencies.