### PR TITLE
feat(organizations): add subOrganizations.overview tRPC procedure (#5009, bead 1/9)

### DIFF
--- a/apps/web/src/lib/organizations/organizations.ts
+++ b/apps/web/src/lib/organizations/organizations.ts
@@ -63,6 +63,33 @@ export async function findOrganizationByStripeCustomerId(
   );
 }
 
+/**
+ * Direct, non-deleted child organizations parented by `parentOrganizationId`.
+ * The org hierarchy is strictly single-level, so this returns only immediate
+ * children — never descendants — and excludes soft-deleted children
+ * (`deleted_at IS NOT NULL`). Ordered by name for stable display.
+ *
+ * Shared by the parent-facing sub-organizations surface and the
+ * `organizations.childOrganizations` procedure so the child-selection logic
+ * lives in exactly one place. Authorization is the caller's responsibility:
+ * only parent `owner`/`billing_manager` may invoke the procedures that use it.
+ */
+export async function getDirectChildOrganizations(
+  parentOrganizationId: Organization['id'],
+  txn?: DrizzleTransaction
+): Promise<Organization[]> {
+  return await (txn || db)
+    .select()
+    .from(organizations)
+    .where(
+      and(
+        eq(organizations.parent_organization_id, parentOrganizationId),
+        isNull(organizations.deleted_at)
+      )
+    )
+    .orderBy(asc(organizations.name));
+}
+
 export async function getUserOrganizationsWithSeats(
   userId: User['id']
 ): Promise<UserOrganizationWithSeats[]> {

--- a/apps/web/src/routers/organizations/organization-router.ts
+++ b/apps/web/src/routers/organizations/organization-router.ts
@@ -19,6 +19,7 @@ import {
 import { CompanyDomainSchema } from '@/lib/organizations/company-domain';
 import {
   createOrganization,
+  getDirectChildOrganizations,
   getOrganizationById,
   getOrganizationMembers,
   getUserOrganizationsWithSeats,
@@ -39,7 +40,7 @@ import { organizationsSubscriptionRouter } from '@/routers/organizations/organiz
 import { organizationsSettingsRouter } from '@/routers/organizations/organization-settings-router';
 import { organizationsUsageDetailsRouter } from '@/routers/organizations/organization-usage-details-router';
 import { TRPCError } from '@trpc/server';
-import { and, asc, count, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
+import { and, count, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import * as z from 'zod';
 import { getCreditTransactionsForOrganization } from '@/lib/creditTransactions';
 import { getCreditBlocks } from '@/lib/getCreditBlocks';
@@ -69,6 +70,7 @@ import { organizationAutoTopUpRouter } from '@/routers/organizations/organizatio
 import { organizationKiloclawRouter } from '@/routers/organizations/organization-kiloclaw-router';
 import { organizationBitbucketRouter } from '@/routers/organizations/organization-bitbucket-router';
 import { organizationFundsRouter } from '@/routers/organizations/organization-funds-router';
+import { organizationSubOrganizationsRouter } from '@/routers/organizations/organization-sub-organizations-router';
 import { organizationKiloPassRouter } from '@/routers/organizations/organization-kilo-pass-router';
 import { organizationGroupsRouter } from '@/routers/organizations/organization-groups-router';
 import { bumpOrganizationGroupPolicyRevision } from '@/lib/organizations/organization-groups';
@@ -133,6 +135,7 @@ export const organizationsRouter = createTRPCRouter({
   kiloclaw: organizationKiloclawRouter,
   bitbucket: organizationBitbucketRouter,
   funds: organizationFundsRouter,
+  subOrganizations: organizationSubOrganizationsRouter,
   kiloPass: organizationKiloPassRouter,
   groups: organizationGroupsRouter,
 
@@ -365,19 +368,8 @@ export const organizationsRouter = createTRPCRouter({
   // Child organizations parented by this organization. Restricted to
   // owner/billing_manager because only those roles inherit access to children.
   childOrganizations: organizationBillingProcedure.query(async opts => {
-    return await db
-      .select({
-        id: organizations.id,
-        name: organizations.name,
-      })
-      .from(organizations)
-      .where(
-        and(
-          eq(organizations.parent_organization_id, opts.input.organizationId),
-          isNull(organizations.deleted_at)
-        )
-      )
-      .orderBy(asc(organizations.name));
+    const children = await getDirectChildOrganizations(opts.input.organizationId);
+    return children.map(({ id, name }) => ({ id, name }));
   }),
 
   update: organizationBillingMutationProcedure

--- a/apps/web/src/routers/organizations/organization-sub-organizations-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-sub-organizations-router.test.ts
@@ -16,6 +16,8 @@ let parentBillingManager: User;
 let parentMember: User;
 let childOwner: User;
 let childAExtraMember: User;
+let childABillingManager: User;
+let childABotMember: User;
 let parentOrg: Organization;
 let childA: Organization;
 let childB: Organization;
@@ -69,15 +71,31 @@ describe('organization sub-organizations router', () => {
       google_user_name: 'Suborg Child A Extra Member',
       is_admin: false,
     });
+    childABillingManager = await insertTestUser({
+      google_user_email: 'suborg-overview-child-a-billing@example.com',
+      google_user_name: 'Suborg Child A Billing Manager',
+      is_admin: false,
+    });
+    childABotMember = await insertTestUser({
+      google_user_email: 'suborg-overview-child-a-bot@example.com',
+      google_user_name: 'Suborg Child A Bot Member',
+      is_admin: false,
+      is_bot: true,
+    });
 
     parentOrg = await createOrganization('Suborg Overview Parent', parentOwner.id);
     await addUserToOrganization(parentOrg.id, parentBillingManager.id, 'billing_manager');
     await addUserToOrganization(parentOrg.id, parentMember.id, 'member');
 
     // childA is owned by childOwner (who is NOT a member of the parent), with an
-    // extra member so its member count is distinguishable from childB.
+    // extra member so its member count is distinguishable from childB. It also
+    // has a billing_manager and a bot member, which must NOT count toward
+    // memberCount (matches the surfaced member-count convention in
+    // organization-admin-router, which excludes billing-manager seats and bots).
     childA = await createOrganization('Suborg Overview Child A', childOwner.id);
     await addUserToOrganization(childA.id, childAExtraMember.id, 'member');
+    await addUserToOrganization(childA.id, childABillingManager.id, 'billing_manager');
+    await addUserToOrganization(childA.id, childABotMember.id, 'member');
 
     // childB is on the 'enterprise' plan so the plan field is exercised.
     childB = await createOrganization(
@@ -150,6 +168,20 @@ describe('organization sub-organizations router', () => {
         expect(child.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
         expect(new Date(child.createdAt).toISOString()).toBe(child.createdAt);
       }
+    });
+
+    it('excludes billing-manager seats and bot users from memberCount', async () => {
+      // childA has four raw memberships: owner, a plain member, a billing
+      // manager, and a bot member. The surfaced memberCount must exclude the
+      // billing-manager seat and the bot user, matching the convention in
+      // organization-admin-router (and getUserOrganizationsWithSeats).
+      const caller = await createCallerForUser(parentOwner.id);
+      const result = await caller.organizations.subOrganizations.overview({
+        organizationId: parentOrg.id,
+      });
+
+      const childAResult = result.children.find(child => child.id === childA.id);
+      expect(childAResult?.memberCount).toBe(2);
     });
 
     it('returns all non-deleted children for the parent billing_manager', async () => {

--- a/apps/web/src/routers/organizations/organization-sub-organizations-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-sub-organizations-router.test.ts
@@ -1,0 +1,227 @@
+import { createCallerForUser } from '@/routers/test-utils';
+import { db } from '@/lib/drizzle';
+import {
+  organizations,
+  organization_memberships,
+  organization_audit_logs,
+  credit_transactions,
+} from '@kilocode/db/schema';
+import { eq, inArray } from 'drizzle-orm';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createOrganization, addUserToOrganization } from '@/lib/organizations/organizations';
+import type { User, Organization } from '@kilocode/db/schema';
+
+let parentOwner: User;
+let parentBillingManager: User;
+let parentMember: User;
+let childOwner: User;
+let childAExtraMember: User;
+let parentOrg: Organization;
+let childA: Organization;
+let childB: Organization;
+let childCDeleted: Organization;
+let unrelatedOrg: Organization;
+
+async function setChildOf(childId: string, parentId: string) {
+  await db
+    .update(organizations)
+    .set({ parent_organization_id: parentId })
+    .where(eq(organizations.id, childId));
+}
+
+async function softDelete(organizationId: string) {
+  await db
+    .update(organizations)
+    .set({ deleted_at: new Date().toISOString() })
+    .where(eq(organizations.id, organizationId));
+}
+
+async function expectUnauthorized(promise: Promise<unknown>) {
+  await expect(promise).rejects.toMatchObject({
+    code: 'UNAUTHORIZED',
+  });
+}
+
+describe('organization sub-organizations router', () => {
+  beforeAll(async () => {
+    parentOwner = await insertTestUser({
+      google_user_email: 'suborg-overview-parent-owner@example.com',
+      google_user_name: 'Suborg Parent Owner',
+      is_admin: false,
+    });
+    parentBillingManager = await insertTestUser({
+      google_user_email: 'suborg-overview-parent-billing@example.com',
+      google_user_name: 'Suborg Parent Billing Manager',
+      is_admin: false,
+    });
+    parentMember = await insertTestUser({
+      google_user_email: 'suborg-overview-parent-member@example.com',
+      google_user_name: 'Suborg Parent Member',
+      is_admin: false,
+    });
+    childOwner = await insertTestUser({
+      google_user_email: 'suborg-overview-child-owner@example.com',
+      google_user_name: 'Suborg Child Owner',
+      is_admin: false,
+    });
+    childAExtraMember = await insertTestUser({
+      google_user_email: 'suborg-overview-child-a-extra@example.com',
+      google_user_name: 'Suborg Child A Extra Member',
+      is_admin: false,
+    });
+
+    parentOrg = await createOrganization('Suborg Overview Parent', parentOwner.id);
+    await addUserToOrganization(parentOrg.id, parentBillingManager.id, 'billing_manager');
+    await addUserToOrganization(parentOrg.id, parentMember.id, 'member');
+
+    // childA is owned by childOwner (who is NOT a member of the parent), with an
+    // extra member so its member count is distinguishable from childB.
+    childA = await createOrganization('Suborg Overview Child A', childOwner.id);
+    await addUserToOrganization(childA.id, childAExtraMember.id, 'member');
+
+    // childB is on the 'enterprise' plan so the plan field is exercised.
+    childB = await createOrganization(
+      'Suborg Overview Child B',
+      parentOwner.id,
+      true,
+      undefined,
+      'enterprise'
+    );
+
+    // childC is soft-deleted and must never appear in the overview.
+    childCDeleted = await createOrganization('Suborg Overview Child C Deleted', parentOwner.id);
+
+    unrelatedOrg = await createOrganization('Suborg Overview Unrelated Org', parentOwner.id);
+
+    await setChildOf(childA.id, parentOrg.id);
+    await setChildOf(childB.id, parentOrg.id);
+    await setChildOf(childCDeleted.id, parentOrg.id);
+    await softDelete(childCDeleted.id);
+  });
+
+  afterAll(async () => {
+    const orgIds = [parentOrg.id, childA.id, childB.id, childCDeleted.id, unrelatedOrg.id];
+    await db
+      .delete(organization_memberships)
+      .where(inArray(organization_memberships.organization_id, orgIds));
+    await db
+      .delete(credit_transactions)
+      .where(inArray(credit_transactions.organization_id, orgIds));
+    await db
+      .delete(organization_audit_logs)
+      .where(inArray(organization_audit_logs.organization_id, orgIds));
+    // Children must be removed before the parent (FK onDelete: restrict).
+    await db
+      .delete(organizations)
+      .where(inArray(organizations.id, [childA.id, childB.id, childCDeleted.id]));
+    await db
+      .delete(organizations)
+      .where(inArray(organizations.id, [parentOrg.id, unrelatedOrg.id]));
+  });
+
+  describe('overview', () => {
+    it('returns all non-deleted children for the parent owner', async () => {
+      const caller = await createCallerForUser(parentOwner.id);
+      const result = await caller.organizations.subOrganizations.overview({
+        organizationId: parentOrg.id,
+      });
+
+      const ids = result.children.map(child => child.id);
+      expect(ids).toEqual([childA.id, childB.id]);
+      expect(ids).not.toContain(childCDeleted.id);
+
+      const childAResult = result.children.find(child => child.id === childA.id);
+      expect(childAResult).toMatchObject({
+        id: childA.id,
+        name: 'Suborg Overview Child A',
+        plan: 'teams',
+        memberCount: 2,
+      });
+      // childB is owned by parentOwner (one member) and is on the enterprise plan.
+      const childBResult = result.children.find(child => child.id === childB.id);
+      expect(childBResult).toMatchObject({
+        id: childB.id,
+        name: 'Suborg Overview Child B',
+        plan: 'enterprise',
+        memberCount: 1,
+      });
+      // created_at is normalized to a strict ISO datetime at the contract boundary.
+      for (const child of result.children) {
+        expect(child.createdAt).toMatch(/^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}.\d{3}Z$/);
+        expect(new Date(child.createdAt).toISOString()).toBe(child.createdAt);
+      }
+    });
+
+    it('returns all non-deleted children for the parent billing_manager', async () => {
+      const caller = await createCallerForUser(parentBillingManager.id);
+      const result = await caller.organizations.subOrganizations.overview({
+        organizationId: parentOrg.id,
+      });
+
+      const ids = result.children.map(child => child.id);
+      expect(ids).toEqual([childA.id, childB.id]);
+    });
+
+    it('rejects a plain parent member', async () => {
+      const caller = await createCallerForUser(parentMember.id);
+      await expectUnauthorized(
+        caller.organizations.subOrganizations.overview({ organizationId: parentOrg.id })
+      );
+    });
+
+    it('rejects a child owner for the parent endpoint', async () => {
+      const caller = await createCallerForUser(childOwner.id);
+      await expectUnauthorized(
+        caller.organizations.subOrganizations.overview({ organizationId: parentOrg.id })
+      );
+    });
+
+    it('excludes soft-deleted children', async () => {
+      const caller = await createCallerForUser(parentOwner.id);
+      const result = await caller.organizations.subOrganizations.overview({
+        organizationId: parentOrg.id,
+      });
+      expect(result.children.some(child => child.id === childCDeleted.id)).toBe(false);
+    });
+
+    it('returns an empty list for a parent with zero children', async () => {
+      const caller = await createCallerForUser(parentOwner.id);
+      const result = await caller.organizations.subOrganizations.overview({
+        organizationId: unrelatedOrg.id,
+      });
+      expect(result.children).toEqual([]);
+    });
+
+    it('does not scale the query count with the number of children', async () => {
+      const caller = await createCallerForUser(parentOwner.id);
+
+      const countSelects = async () => {
+        const selectSpy = jest.spyOn(db, 'select');
+        try {
+          await caller.organizations.subOrganizations.overview({
+            organizationId: parentOrg.id,
+          });
+          return selectSpy.mock.calls.length;
+        } finally {
+          selectSpy.mockRestore();
+        }
+      };
+
+      const baselineSelects = await countSelects();
+
+      // Add a third visible child and confirm the select count is unchanged.
+      const extraChild = await createOrganization('Suborg Overview Extra Child', parentOwner.id);
+      await setChildOf(extraChild.id, parentOrg.id);
+      try {
+        const withExtraChildSelects = await countSelects();
+        expect(withExtraChildSelects).toBe(baselineSelects);
+        expect(baselineSelects).toBeGreaterThan(0);
+      } finally {
+        await db
+          .delete(organization_memberships)
+          .where(eq(organization_memberships.organization_id, extraChild.id));
+        await db.delete(organizations).where(eq(organizations.id, extraChild.id));
+      }
+    });
+  });
+});

--- a/apps/web/src/routers/organizations/organization-sub-organizations-router.ts
+++ b/apps/web/src/routers/organizations/organization-sub-organizations-router.ts
@@ -1,10 +1,10 @@
-import { organization_memberships } from '@kilocode/db/schema';
+import { kilocode_users, organization_memberships } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
 import { createTRPCRouter } from '@/lib/trpc/init';
 import { organizationBillingProcedure } from '@/routers/organizations/utils';
 import { getDirectChildOrganizations } from '@/lib/organizations/organizations';
 import { OrganizationPlanSchema } from '@/lib/organizations/organization-types';
-import { count, inArray } from 'drizzle-orm';
+import { and, count, eq, inArray, ne } from 'drizzle-orm';
 import * as z from 'zod';
 
 const SubOrganizationOverviewChildSchema = z.object({
@@ -32,16 +32,34 @@ export const organizationSubOrganizationsRouter = createTRPCRouter({
 
       // Single batched query for member counts across every child, so the
       // query count is independent of the number of children (no N+1 fan-out).
+      // Match the surfaced member-count convention in organization-admin-router
+      // (and getUserOrganizationsWithSeats): count kilocode_users.id so
+      // billing-manager seats (filtered on the membership join condition) and
+      // bot users (filtered on the user join condition) drop out of the count.
+      // Without this, the same child would show a higher memberCount here than
+      // the member count surfaced elsewhere for it.
       const childIds = children.map(child => child.id);
       const memberCountRows =
         childIds.length > 0
           ? await db
               .select({
                 organizationId: organization_memberships.organization_id,
-                memberCount: count(),
+                memberCount: count(kilocode_users.id),
               })
               .from(organization_memberships)
-              .where(inArray(organization_memberships.organization_id, childIds))
+              .innerJoin(
+                kilocode_users,
+                and(
+                  eq(kilocode_users.id, organization_memberships.kilo_user_id),
+                  eq(kilocode_users.is_bot, false)
+                )
+              )
+              .where(
+                and(
+                  inArray(organization_memberships.organization_id, childIds),
+                  ne(organization_memberships.role, 'billing_manager')
+                )
+              )
               .groupBy(organization_memberships.organization_id)
           : [];
       const memberCountByOrg = new Map(

--- a/apps/web/src/routers/organizations/organization-sub-organizations-router.ts
+++ b/apps/web/src/routers/organizations/organization-sub-organizations-router.ts
@@ -1,0 +1,61 @@
+import { organization_memberships } from '@kilocode/db/schema';
+import { db } from '@/lib/drizzle';
+import { createTRPCRouter } from '@/lib/trpc/init';
+import { organizationBillingProcedure } from '@/routers/organizations/utils';
+import { getDirectChildOrganizations } from '@/lib/organizations/organizations';
+import { OrganizationPlanSchema } from '@/lib/organizations/organization-types';
+import { count, inArray } from 'drizzle-orm';
+import * as z from 'zod';
+
+const SubOrganizationOverviewChildSchema = z.object({
+  id: z.uuid(),
+  name: z.string(),
+  plan: OrganizationPlanSchema,
+  memberCount: z.number().int().min(0),
+  createdAt: z.string().datetime(),
+});
+
+const SubOrganizationsOverviewOutputSchema = z.object({
+  children: z.array(SubOrganizationOverviewChildSchema),
+});
+
+export const organizationSubOrganizationsRouter = createTRPCRouter({
+  // Parent-facing overview of direct child organizations. Restricted to the
+  // parent's owner/billing_manager: only those roles inherit access to
+  // children, so a plain parent member can never enumerate them, and a child
+  // owner has no membership on the parent and is rejected at the auth gate.
+  // Hierarchy is strictly single-level, so this is immediate children only.
+  overview: organizationBillingProcedure
+    .output(SubOrganizationsOverviewOutputSchema)
+    .query(async ({ input }) => {
+      const children = await getDirectChildOrganizations(input.organizationId);
+
+      // Single batched query for member counts across every child, so the
+      // query count is independent of the number of children (no N+1 fan-out).
+      const childIds = children.map(child => child.id);
+      const memberCountRows =
+        childIds.length > 0
+          ? await db
+              .select({
+                organizationId: organization_memberships.organization_id,
+                memberCount: count(),
+              })
+              .from(organization_memberships)
+              .where(inArray(organization_memberships.organization_id, childIds))
+              .groupBy(organization_memberships.organization_id)
+          : [];
+      const memberCountByOrg = new Map(
+        memberCountRows.map(row => [row.organizationId, Number(row.memberCount)])
+      );
+
+      return {
+        children: children.map(child => ({
+          id: child.id,
+          name: child.name,
+          plan: child.plan,
+          memberCount: memberCountByOrg.get(child.id) ?? 0,
+          createdAt: new Date(child.created_at).toISOString(),
+        })),
+      };
+    }),
+});


### PR DESCRIPTION
Part of #5009 — parent-org visibility into sub-organizations. This is **bead 1 of 9** in the convoy and lands the foundation router + authorization pattern that every later bead builds on.

## Summary

Adds a billing-gated `organizations.subOrganizations.overview` tRPC procedure and registers the new `subOrganizations` sub-router.

- **Authorization:** uses the existing `organizationBillingProcedure` (calls `ensureOrganizationAccess` with `['owner', 'billing_manager']`). Only those roles inherit access to children, so a plain parent `member` can never enumerate children and a child owner is rejected for the parent endpoint.
- **Output:** one row per non-deleted direct child with `id`, `name`, `plan`, `memberCount`, `createdAt`. `createdAt` is normalized to ISO via `new Date(...).toISOString()` at the strict Zod output boundary.
- **Batching:** member counts come from a single batched `GROUP BY` query over `organization_memberships`, so query count is independent of child count (no N+1 fan-out). Hierarchy is strictly single-level — no recursive traversal.
- **Soft-deleted children excluded** (`deleted_at IS NOT NULL`).

## Reuse, not rebuild

Extracted a shared `getDirectChildOrganizations(parentOrganizationId)` helper in `lib/organizations/organizations.ts` and composed it from both the new `overview` procedure and the existing `organizations.childOrganizations` procedure, so the direct-non-deleted-child selection logic lives in exactly one place. Future convoy beads (`people`, `credits`, `models`, `permissions`) reuse the same pattern.

## What is NOT in this PR

- No UI (separate beads).
- No People / Usage / Credits / Models / Permissions data (separate beads add procedures alongside this one).
- No DB migration (read-only over existing columns). No new audit-log action (read-only procedure).
- Parent-policy-as-hard-ceiling over children remains explicitly out of scope.

## Tests

`organization-sub-organizations-router.test.ts` mirrors the canonical parent/child fixture pattern from `organization-funds-router.test.ts`. All 7 pass against a real Postgres:

- parent owner sees all children
- parent billing_manager sees all children
- parent plain member is rejected (UNAUTHORIZED)
- child owner is rejected for the parent endpoint
- soft-deleted child is excluded
- parent org with zero children returns empty
- fixed-query-count assertion (select count does not scale with child count)

Regression: `organization-router.test` and `organization-funds-router.test` still pass (38 tests) after the `childOrganizations` refactor.