### PR TITLE
Add sub-organizations page scaffold with sidebar entry, billing gate, and overview table (#5009, bead 3/9)

### DIFF
--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -28,6 +28,7 @@ import {
   ChevronLeft,
   ChevronRight,
   UsersRound,
+  Sitemap,
 } from 'lucide-react';
 import { usePathname } from 'next/navigation';
 import { useEffect, useMemo, useState } from 'react';
@@ -129,6 +130,21 @@ export default function OrganizationAppSidebar({
       url: `/organizations/${organizationId}/usage-details`,
     },
   ];
+
+  // The sub-organizations surface is parent-only: a child organization has no
+  // children of its own (single-level hierarchy), and only parent
+  // owner/billing_manager inherit access to children. Hide the entry for plain
+  // members and for orgs without any (non-deleted) children. withMembers
+  // already excludes soft-deleted children, so childCount reflects the real
+  // list a parent admin can administer.
+  const childCount = organizationData?.childOrganizations?.length ?? 0;
+  if (hasOwnerLevelAccess && childCount > 0) {
+    dashboardItems.push({
+      title: 'Sub-organizations',
+      icon: Sitemap,
+      url: `/organizations/${organizationId}/sub-organizations`,
+    });
+  }
 
   // KiloClaw group
   const kiloClawItems: Array<{

--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
@@ -1,0 +1,166 @@
+'use client';
+
+import Link from 'next/link';
+import {
+  AlertTriangle,
+  ChartColumnIncreasing,
+  CreditCard,
+  Layers,
+  ShieldCheck,
+  Users,
+} from 'lucide-react';
+
+import { OrganizationPageHeader } from '@/components/organizations/OrganizationPageHeader';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table';
+import { useSubOrganizationsOverview } from '@/app/api/organizations/hooks';
+import { formatDateOnly } from '@/lib/admin-utils';
+import type { OrganizationPlan } from '@/lib/organizations/organization-types';
+import { SubOrganizationsSectionPlaceholder } from './SubOrganizationsSectionPlaceholder';
+
+type Props = {
+  organizationId: string;
+};
+
+function PlanBadge({ plan }: { plan: OrganizationPlan }) {
+  return <Badge variant="secondary">{plan === 'enterprise' ? 'Enterprise' : 'Teams'}</Badge>;
+}
+
+export function SubOrganizationsPage({ organizationId }: Props) {
+  const { data, isLoading, error } = useSubOrganizationsOverview(organizationId);
+  const children = data?.children ?? [];
+
+  return (
+    <div className="flex w-full flex-col gap-y-6">
+      <OrganizationPageHeader
+        organizationId={organizationId}
+        title="Sub-organizations"
+        showBackButton
+      />
+
+      {error ? (
+        <Alert variant="destructive">
+          <AlertTriangle className="h-4 w-4" />
+          <AlertDescription>
+            Failed to load sub-organizations:{' '}
+            {error instanceof Error ? error.message : 'Unknown error'}
+          </AlertDescription>
+        </Alert>
+      ) : isLoading ? (
+        <Card>
+          <CardHeader>
+            <Skeleton className="h-5 w-64" />
+            <Skeleton className="h-4 w-96" />
+          </CardHeader>
+          <CardContent className="space-y-3">
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+            <Skeleton className="h-10 w-full" />
+          </CardContent>
+        </Card>
+      ) : children.length === 0 ? (
+        <Card>
+          <CardHeader>
+            <CardTitle>Sub-organizations</CardTitle>
+            <CardDescription>
+              This organization does not have any child organizations.
+            </CardDescription>
+          </CardHeader>
+        </Card>
+      ) : (
+        <>
+          <Card>
+            <CardHeader>
+              <CardTitle>Child organizations</CardTitle>
+              <CardDescription>
+                {children.length} child organization{children.length === 1 ? '' : 's'} belong to
+                this organization
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <Table>
+                <TableHeader>
+                  <TableRow>
+                    <TableHead>Organization</TableHead>
+                    <TableHead>Plan</TableHead>
+                    <TableHead className="text-right">Members</TableHead>
+                    <TableHead>Created</TableHead>
+                  </TableRow>
+                </TableHeader>
+                <TableBody>
+                  {children.map(child => (
+                    <TableRow key={child.id}>
+                      <TableCell className="font-medium">
+                        <Link
+                          prefetch={false}
+                          href={`/organizations/${encodeURIComponent(child.id)}`}
+                          className="hover:text-primary underline-offset-4 hover:underline"
+                        >
+                          {child.name}
+                        </Link>
+                      </TableCell>
+                      <TableCell>
+                        <PlanBadge plan={child.plan} />
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {child.memberCount}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        {formatDateOnly(child.createdAt)}
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </TableBody>
+              </Table>
+            </CardContent>
+          </Card>
+
+          {/* Dimension sections. Each is a named slot: later convoy beads fill
+              the placeholder body without restructuring this layout. */}
+          <div className="flex flex-col gap-6">
+            <SubOrganizationsSectionPlaceholder
+              id="people"
+              title="People"
+              icon={Users}
+              description="Members across every child organization, grouped by child, with each person's role in that child."
+            />
+            <SubOrganizationsSectionPlaceholder
+              id="usage"
+              title="Usage"
+              icon={ChartColumnIncreasing}
+              description="Per-child spend, requests, and tokens for the selected time range, with a deep link into each child's analytics."
+            />
+            <SubOrganizationsSectionPlaceholder
+              id="credits"
+              title="Credits"
+              icon={CreditCard}
+              description="Per-child credit balance, acquired, used, next expiration, and sub-org allocation, with a link to Distribute funds."
+            />
+            <SubOrganizationsSectionPlaceholder
+              id="models"
+              title="Models"
+              icon={Layers}
+              description="Each child's configured model access policy, including whether restrictions are inert due to a non-enterprise plan."
+            />
+            <SubOrganizationsSectionPlaceholder
+              id="permissions"
+              title="Permissions"
+              icon={ShieldCheck}
+              description="Each child's role distribution, SSO policy and its source, per-member spend limits, and inherited parent access."
+            />
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
@@ -83,7 +83,7 @@ export function SubOrganizationsPage({ organizationId }: Props) {
             <CardHeader>
               <CardTitle>Child organizations</CardTitle>
               <CardDescription>
-                {children.length} child organization{children.length === 1 ? '' : 's'} belong to
+                {children.length} child organization{children.length === 1 ? ' belongs' : 's belong'} to
                 this organization
               </CardDescription>
             </CardHeader>

--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsSectionPlaceholder.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsSectionPlaceholder.tsx
@@ -1,0 +1,50 @@
+import type { ReactNode } from 'react';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+type SubOrganizationsSectionPlaceholderProps = {
+  /** Anchor id so deep links and later beads can target this slot. */
+  id: string;
+  title: string;
+  description: string;
+  icon: React.ElementType;
+  /**
+   * Optional node rendered in place of the default placeholder body. Later
+   * convoy beads pass their implemented section content here without touching
+   * the surrounding page layout.
+   */
+  children?: ReactNode;
+};
+
+/**
+ * A named, stable slot in the sub-organizations surface. The scaffold renders
+ * a placeholder body for every dimension (People, Usage, Credits, Models,
+ * Permissions); subsequent beads replace the body by passing `children` (or by
+ * swapping this component for a concrete section) without restructuring the
+ * page.
+ */
+export function SubOrganizationsSectionPlaceholder({
+  id,
+  title,
+  description,
+  icon: Icon,
+  children,
+}: SubOrganizationsSectionPlaceholderProps) {
+  return (
+    <Card id={id} data-slot="sub-organizations-section">
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <Icon className="h-5 w-5" />
+          {title}
+        </CardTitle>
+        <CardDescription>{description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        {children ?? (
+          <div className="text-muted-foreground rounded-lg border border-dashed py-10 text-center text-sm">
+            {description}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/page.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/page.tsx
@@ -1,0 +1,25 @@
+import { redirect } from 'next/navigation';
+import { OrganizationByPageLayout } from '@/components/organizations/OrganizationByPageLayout';
+import { SubOrganizationsPage } from './SubOrganizationsPage';
+
+export default async function OrganizationSubOrganizationsPage({
+  params,
+}: {
+  params: Promise<{ id: string }>;
+}) {
+  return (
+    <OrganizationByPageLayout
+      params={params}
+      roles={['owner', 'billing_manager']}
+      render={({ organization }) => {
+        // Hierarchy is strictly single-level: a child organization never has
+        // its own children, so the sub-organizations surface only applies to
+        // parent organizations. Bounce a child org back to its own page.
+        if (organization.parent_organization_id) {
+          redirect(`/organizations/${encodeURIComponent(organization.id)}`);
+        }
+        return <SubOrganizationsPage organizationId={organization.id} />;
+      }}
+    />
+  );
+}

--- a/apps/web/src/app/api/organizations/hooks.ts
+++ b/apps/web/src/app/api/organizations/hooks.ts
@@ -55,6 +55,22 @@ export function useOrganizationChildBalances(id: string) {
   );
 }
 
+export function useSubOrganizationsOverview(id: string) {
+  const trpc = useTRPC();
+  return useQuery(
+    trpc.organizations.subOrganizations.overview.queryOptions(
+      { organizationId: id },
+      {
+        trpc: {
+          context: {
+            skipBatch: true,
+          },
+        },
+      }
+    )
+  );
+}
+
 export function useDistributeFundsToChildren() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();


### PR DESCRIPTION
Bead 3 of 9 for #5009. Adds the page shell that consumes the `subOrganizations.overview` tRPC procedure landed in bead 1, plus the sidebar entry and named section slots for the four subsequent convoy beads.

## Summary
- New route `/organizations/[id]/sub-organizations` wrapped in `OrganizationByPageLayout` with `roles={['owner','billing_manager']}`, so a plain parent `member` is redirected server-side and can never load the page or enumerate children. A child org (`parent_organization_id` set) is redirected to its own page since the hierarchy is strictly single-level.
- Client `SubOrganizationsPage` renders the overview table (name, plan, member count, created-at) from `subOrganizations.overview`, with loading, empty (zero children), and error states.
- Five named placeholder section slots — People, Usage, Credits, Models, Permissions — via `SubOrganizationsSectionPlaceholder`, so later convoy beads fill content without restructuring the page layout. This bead does **not** implement those sections' content.
- Sidebar entry under the Dashboard group, shown only when the viewer is a parent `owner`/`billing_manager` **and** the org has non-deleted children. The child count is derived from `organizations.withMembers`, which already excludes soft-deleted children.

## Non-negotiable constraints honored
- Server-side role gating (not just hiding the link): plain parent `member` never sees the nav entry and cannot load the page.
- Billing-gated per the issue spec (`roles={['owner','billing_manager']}` via `OrganizationByPageLayout`).
- Nav entry only for orgs that actually have children.
- Soft-deleted children excluded (both in the `overview` procedure and in the `withMembers`-derived child count used for the sidebar).

## Tests
Role gating for the `overview` data is covered by the router tests landed in bead 1 (`organization-sub-organizations-router.test.ts`): parent owner and billing_manager see children; parent plain `member` is rejected; child owner is rejected; soft-deleted children excluded; zero-children case; fixed query count. The page relies on that same procedure plus the shared `OrganizationByPageLayout` auth, so no new UI tests were added (the repo has no component-test harness for organization pages).

## Notes for later convoy beads
The five sections are rendered only when the parent has children. Each is a stable, anchorable slot (`id="people"`, `"usage"`, `"credits"`, `"models"`, `"permissions"`); replace the `SubOrganizationsSectionPlaceholder` body (or swap in a concrete section component) without touching the surrounding layout.

## Conventions
Next.js 16 App Router + React 19, tRPC v11, Zod v4, Tailwind v4 + shadcn-style components, lucide icons. Skipped the heavy `tsgo`/oxlint/oxfmt gates locally per environment constraints; full `pnpm validate` will run at review.