### PR TITLE
feat(code reviewer) reap stale code reviews

### DIFF
--- a/apps/web/src/app/api/cron/reap-stale-code-reviews/route.ts
+++ b/apps/web/src/app/api/cron/reap-stale-code-reviews/route.ts
@@ -1,0 +1,43 @@
+import { NextResponse } from 'next/server';
+
+import { CRON_SECRET } from '@/lib/config.server';
+import { reapStaleCodeReviews } from '@/lib/code-reviews/reap-stale-reviews';
+import { sentryLogger } from '@/lib/utils.server';
+
+if (!CRON_SECRET) {
+  throw new Error('CRON_SECRET is not configured in environment variables');
+}
+
+/**
+ * A batch walks up to REAP_DEFAULT_BATCH_SIZE rows sequentially, each with a
+ * potential provider call. Backlog rows in particular reference suspended or
+ * uninstalled integrations whose calls fail slowly, so the default budget is
+ * not enough. Matches the other batch crons in this directory.
+ */
+export const maxDuration = 300;
+
+export async function GET(request: Request) {
+  const authHeader = request.headers.get('authorization');
+  const expectedAuth = `Bearer ${CRON_SECRET}`;
+  if (authHeader !== expectedAuth) {
+    sentryLogger(
+      'cron',
+      'warning'
+    )(
+      'SECURITY: Invalid CRON job authorization attempt: ' +
+        (authHeader ? 'Invalid authorization header' : 'Missing authorization header')
+    );
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const summary = await reapStaleCodeReviews();
+
+  return NextResponse.json(
+    {
+      success: true,
+      summary,
+      timestamp: new Date().toISOString(),
+    },
+    { status: 200 }
+  );
+}

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -52,15 +52,15 @@ import {
 } from '@/lib/integrations/platforms/gitlab/adapter';
 import type { GitLabCommitStatusState } from '@/lib/integrations/platforms/gitlab/adapter';
 import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
-import {
-  getValidGitLabProjectAccessToken,
-  getValidGitLabToken,
-} from '@/lib/integrations/gitlab-service';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { CALLBACK_TOKEN_SECRET } from '@/lib/config.server';
 import { verifyCallbackToken } from '@kilocode/worker-utils/callback-token';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { appendPreviousReviewSummaryHistory } from '@/lib/code-reviews/summary/history';
+import {
+  getGitLabInstanceUrl,
+  resolveGitLabAccessToken,
+} from '@/lib/code-reviews/platform/gitlab-access';
 import { terminalReasonFromCloudAgentFailure } from '@/lib/code-reviews/terminal-reason-from-failure';
 import { getCodeReviewTerminalReasonCopy } from '@/lib/code-reviews/terminal-reason-copy';
 import {
@@ -992,42 +992,6 @@ async function upsertFailureSummaryComment(
       `[code-review-status] Upserted failure summary on GitLab MR ${review.repo_full_name}!${review.pr_number}`
     );
   }
-}
-
-/**
- * Resolves a GitLab access token for a review's project.
- * Uses the exact project credential when a project ID is present.
- */
-async function resolveGitLabAccessToken(
-  integration: PlatformIntegration,
-  projectId: number | null
-): Promise<string> {
-  let userId: string;
-  let organizationId: string | undefined;
-  if (integration.owned_by_organization_id) {
-    organizationId = integration.owned_by_organization_id;
-    const botUserId = await getBotUserId(organizationId, 'code-review');
-    if (!botUserId) throw new Error('GitLab organization has no configured acting user');
-    userId = botUserId;
-  } else if (integration.owned_by_user_id) {
-    userId = integration.owned_by_user_id;
-  } else {
-    throw new Error('GitLab integration has no owner');
-  }
-  const actor = { userId, ...(organizationId ? { organizationId } : {}) };
-  return projectId
-    ? await getValidGitLabProjectAccessToken(integration, projectId, actor)
-    : await getValidGitLabToken(integration, actor);
-}
-
-/**
- * Extracts the GitLab instance URL from an integration's metadata.
- */
-function getGitLabInstanceUrl(integration: PlatformIntegration): string {
-  const metadata = integration.metadata as {
-    gitlab_instance_url?: string;
-  } | null;
-  return metadata?.gitlab_instance_url || 'https://gitlab.com';
 }
 
 /**

--- a/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.test.ts
@@ -196,6 +196,35 @@ describe('code review alert detectors', () => {
     });
   });
 
+  // A reaped review that never started has no started_at, so its effective
+  // start collapses to the reap-stamped updated_at. Without the CTE exclusion,
+  // each reaper run would inject days-old rows into the live window as fresh
+  // starts, diluting the rate below threshold and masking a real spike.
+  it('excludes reaped reviews from the error-spike denominator', async () => {
+    await insertReviews([
+      // A genuine 20% spike: 1 failure among 5 recent starts.
+      reviewValues({ status: 'failed', terminal_reason: 'timeout' }),
+      ...Array.from({ length: 4 }, () => reviewValues()),
+      // Five reaped rows, shaped like the reaper leaves them: never started,
+      // terminalized just now. Counting these would dilute the rate to 1/10.
+      ...Array.from({ length: 5 }, () =>
+        reviewValues({
+          status: 'failed',
+          terminal_reason: 'abandoned',
+          started_at: null,
+          created_at: minutesAgo(72 * 60),
+          updated_at: minutesAgo(0),
+          completed_at: minutesAgo(0),
+        })
+      ),
+    ]);
+
+    await expect(evaluateErrorSpike(db)).resolves.toMatchObject({
+      tripped: true,
+      details: { rate: 0.2, startedCount: 5, errorCount: 1 },
+    });
+  });
+
   it('does not trip error-spike alerts with no recent errors', async () => {
     await insertReviews(Array.from({ length: 20 }, () => reviewValues()));
 

--- a/apps/web/src/lib/code-reviews/alerting/detectors.ts
+++ b/apps/web/src/lib/code-reviews/alerting/detectors.ts
@@ -73,6 +73,13 @@ const startedReviewsCteSql = sql`
       COALESCE(completed_at, updated_at) AS completed_at_effective
     FROM ${cloud_agent_code_reviews}
     WHERE status NOT IN ('pending', 'queued')
+      -- Reaped reviews that never started have no started_at, so the COALESCE
+      -- above would resolve to the reap-stamped updated_at and place a days-old
+      -- row inside the live windows. The benign-reason filter already keeps
+      -- 'abandoned' out of both numerators, so counting it in started_count
+      -- would only dilute the rates and mask a real spike for the window right
+      -- after each reaper run.
+      AND COALESCE(terminal_reason, '') <> 'abandoned'
   )
 `;
 

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-constants.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-constants.ts
@@ -6,6 +6,17 @@ export const MAX_CONCURRENT_CODE_REVIEWS_PER_FUNDED_USER = 3;
 export const MAX_CONCURRENT_CODE_REVIEWS_PER_DEFAULT_USER = 1;
 export const FUNDED_CODE_REVIEW_BALANCE_THRESHOLD_MICRODOLLARS = 5_000_000;
 
+/**
+ * Statuses a review can hold while it still has work outstanding.
+ *
+ * Anything not listed here has reached a terminal state and will never move
+ * again. Callers that select or guard on "still in flight" should reference this
+ * rather than repeat the literals, so adding or renaming a status is a single
+ * edit. Several older call sites still inline the same array; they predate this
+ * constant and can adopt it as they are touched.
+ */
+export const NON_TERMINAL_CODE_REVIEW_STATUSES = ['pending', 'queued', 'running'] as const;
+
 export const STALE_QUEUED_CODE_REVIEW_MINUTES = 5;
 export const STALE_RUNNING_CODE_REVIEW_MINUTES = 90;
 export const CRON_PENDING_CODE_REVIEW_MIN_AGE_MINUTES = 60;

--- a/apps/web/src/lib/code-reviews/platform/gitlab-access.ts
+++ b/apps/web/src/lib/code-reviews/platform/gitlab-access.ts
@@ -1,0 +1,43 @@
+import type { PlatformIntegration } from '@kilocode/db/schema';
+
+import { getBotUserId } from '@/lib/bot-users/bot-user-service';
+import {
+  getValidGitLabProjectAccessToken,
+  getValidGitLabToken,
+} from '@/lib/integrations/gitlab-service';
+
+/**
+ * Resolves a GitLab access token for a review's project.
+ * Uses the exact project credential when a project ID is present.
+ */
+export async function resolveGitLabAccessToken(
+  integration: PlatformIntegration,
+  projectId: number | null
+): Promise<string> {
+  let userId: string;
+  let organizationId: string | undefined;
+  if (integration.owned_by_organization_id) {
+    organizationId = integration.owned_by_organization_id;
+    const botUserId = await getBotUserId(organizationId, 'code-review');
+    if (!botUserId) throw new Error('GitLab organization has no configured acting user');
+    userId = botUserId;
+  } else if (integration.owned_by_user_id) {
+    userId = integration.owned_by_user_id;
+  } else {
+    throw new Error('GitLab integration has no owner');
+  }
+  const actor = { userId, ...(organizationId ? { organizationId } : {}) };
+  return projectId
+    ? await getValidGitLabProjectAccessToken(integration, projectId, actor)
+    : await getValidGitLabToken(integration, actor);
+}
+
+/**
+ * Extracts the GitLab instance URL from an integration's metadata.
+ */
+export function getGitLabInstanceUrl(integration: PlatformIntegration): string {
+  const metadata = integration.metadata as {
+    gitlab_instance_url?: string;
+  } | null;
+  return metadata?.gitlab_instance_url || 'https://gitlab.com';
+}

--- a/apps/web/src/lib/code-reviews/reap-stale-reviews.integration.test.ts
+++ b/apps/web/src/lib/code-reviews/reap-stale-reviews.integration.test.ts
@@ -85,6 +85,9 @@ describe('reapStaleCodeReviews against the database', () => {
     expect(freshRow.terminal_reason).toBeNull();
 
     expect(summary.terminalized).toBeGreaterThanOrEqual(1);
+    // The fresh row is under the threshold, so it must not appear in the
+    // remaining-depth count either.
+    expect(summary.remaining).toBe(0);
   });
 
   it('closes the review’s own non-terminal attempts with it', async () => {

--- a/apps/web/src/lib/code-reviews/reap-stale-reviews.integration.test.ts
+++ b/apps/web/src/lib/code-reviews/reap-stale-reviews.integration.test.ts
@@ -1,0 +1,124 @@
+import { db } from '@/lib/drizzle';
+import {
+  cloud_agent_code_review_attempts,
+  cloud_agent_code_reviews,
+  type User,
+} from '@kilocode/db/schema';
+import { eq, inArray, sql } from 'drizzle-orm';
+
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { reapStaleCodeReviews } from './reap-stale-reviews';
+
+const REPO = `test-org/reap-stale-${Date.now()}`;
+
+/**
+ * Runs the reaper against the real test database, unlike the unit suite, whose
+ * drizzle mock swallows the WHERE clauses. This is what pins the parts only the
+ * database can prove: the staleness predicate, and that the optimistic-lock
+ * claim matches a microsecond-precision `updated_at` written by DB-side now()
+ * after a select/bind round trip. If a driver or ORM upgrade ever changes
+ * timestamp parsing precision, this suite fails instead of every reap silently
+ * claiming nothing.
+ */
+describe('reapStaleCodeReviews against the database', () => {
+  let user: User;
+  const createdReviewIds: string[] = [];
+
+  beforeAll(async () => {
+    user = await insertTestUser();
+  });
+
+  afterAll(async () => {
+    if (createdReviewIds.length > 0) {
+      await db
+        .delete(cloud_agent_code_reviews)
+        .where(inArray(cloud_agent_code_reviews.id, createdReviewIds));
+    }
+  });
+
+  async function insertReview(params: { status: string; hoursOld: number }): Promise<string> {
+    // Timestamps come from DB-side now() so they carry microsecond precision,
+    // like every defaultNow()/`$onUpdateFn` row in production. App-side ISO
+    // strings would only exercise the easy millisecond case.
+    const age = sql.raw(`now() - interval '${params.hoursOld} hours'`);
+    const [row] = await db
+      .insert(cloud_agent_code_reviews)
+      .values({
+        owned_by_user_id: user.id,
+        repo_full_name: REPO,
+        pr_number: Math.floor(Math.random() * 1_000_000),
+        pr_url: 'https://github.com/test-org/reap-stale/pull/1',
+        pr_title: 'Reap integration fixture',
+        pr_author: 'test-author',
+        base_ref: 'main',
+        head_ref: 'feature',
+        head_sha: 'a'.repeat(40),
+        platform: 'github',
+        status: params.status,
+        created_at: age as never,
+        updated_at: age as never,
+      })
+      .returning({ id: cloud_agent_code_reviews.id });
+    createdReviewIds.push(row.id);
+    return row.id;
+  }
+
+  it('claims a stale pending review and leaves a fresh one alone', async () => {
+    const staleId = await insertReview({ status: 'pending', hoursOld: 72 });
+    const freshId = await insertReview({ status: 'pending', hoursOld: 1 });
+
+    const summary = await reapStaleCodeReviews(500);
+
+    const [staleRow] = await db
+      .select()
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.id, staleId));
+    expect(staleRow.status).toBe('failed');
+    expect(staleRow.terminal_reason).toBe('abandoned');
+    expect(staleRow.completed_at).not.toBeNull();
+
+    const [freshRow] = await db
+      .select()
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.id, freshId));
+    expect(freshRow.status).toBe('pending');
+    expect(freshRow.terminal_reason).toBeNull();
+
+    expect(summary.terminalized).toBeGreaterThanOrEqual(1);
+  });
+
+  it('closes the review’s own non-terminal attempts with it', async () => {
+    const reviewId = await insertReview({ status: 'running', hoursOld: 72 });
+    await db.insert(cloud_agent_code_review_attempts).values({
+      code_review_id: reviewId,
+      attempt_number: 1,
+      status: 'running',
+    });
+
+    await reapStaleCodeReviews(500);
+
+    const attempts = await db
+      .select()
+      .from(cloud_agent_code_review_attempts)
+      .where(eq(cloud_agent_code_review_attempts.code_review_id, reviewId));
+    expect(attempts).toHaveLength(1);
+    expect(attempts[0].status).toBe('failed');
+    expect(attempts[0].terminal_reason).toBe('abandoned');
+  });
+
+  it('does not reselect rows it already terminalized', async () => {
+    const reviewId = await insertReview({ status: 'queued', hoursOld: 72 });
+
+    await reapStaleCodeReviews(500);
+    const secondRun = await reapStaleCodeReviews(500);
+
+    const [row] = await db
+      .select()
+      .from(cloud_agent_code_reviews)
+      .where(eq(cloud_agent_code_reviews.id, reviewId));
+    expect(row.status).toBe('failed');
+    // The second run may pick up other suites' fixtures, but not this row: its
+    // status is terminal, so the selection predicate excludes it structurally.
+    expect(secondRun.selected).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/apps/web/src/lib/code-reviews/reap-stale-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/reap-stale-reviews.test.ts
@@ -42,6 +42,21 @@ jest.mock('@/lib/drizzle', () => ({
         },
       }),
     }),
+    // The claim runs inside a transaction; the callback receives a tx with the
+    // same update chain as the db object above.
+    transaction: async (fn: (tx: unknown) => Promise<unknown>) =>
+      fn({
+        update: () => ({
+          set: () => ({
+            where: () => {
+              const thenable = Object.assign(Promise.resolve([] as unknown[]), {
+                returning: () => mockClaim(),
+              });
+              return thenable;
+            },
+          }),
+        }),
+      }),
   },
 }));
 

--- a/apps/web/src/lib/code-reviews/reap-stale-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/reap-stale-reviews.test.ts
@@ -1,0 +1,287 @@
+import type { CloudAgentCodeReview } from '@kilocode/db/schema';
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+// Loosely typed on purpose: these stand in for modules with wide signatures and
+// the assertions here are about call shape, not argument types.
+const mockSelectStale = jest.fn() as jest.MockedFunction<(limit: number) => Promise<any[]>>;
+const mockClaim = jest.fn() as jest.MockedFunction<() => Promise<unknown[]>>;
+const mockGetIntegrationById = jest.fn() as jest.MockedFunction<(id: string) => Promise<any>>;
+const mockUpdateCheckRun = jest.fn() as jest.MockedFunction<(...args: any[]) => Promise<void>>;
+const mockSetCommitStatus = jest.fn() as jest.MockedFunction<(...args: any[]) => Promise<void>>;
+const mockResolveGitLabAccessToken = jest.fn() as jest.MockedFunction<
+  (...args: any[]) => Promise<string>
+>;
+
+// The real SQL (selection predicate, optimistic lock, attempt terminalization)
+// is exercised against the database in reap-stale-reviews.integration.test.ts;
+// this mock swallows the WHERE clauses so the per-row branching can be asserted
+// directly. The update chain is shared by the review claim (awaits .returning())
+// and the attempts close (awaits the .where() thenable itself).
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    select: () => ({
+      from: () => ({
+        where: () => ({
+          orderBy: () => ({
+            limit: (n: number) => mockSelectStale(n),
+          }),
+        }),
+      }),
+    }),
+    update: () => ({
+      set: () => ({
+        where: () => {
+          const thenable = Object.assign(Promise.resolve([] as unknown[]), {
+            returning: () => mockClaim(),
+          });
+          return thenable;
+        },
+      }),
+    }),
+  },
+}));
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationById: (id: string) => mockGetIntegrationById(id),
+}));
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  updateCheckRun: (...args: unknown[]) => mockUpdateCheckRun(...args),
+}));
+
+jest.mock('@/lib/integrations/platforms/gitlab/adapter', () => ({
+  setCommitStatus: (...args: unknown[]) => mockSetCommitStatus(...args),
+}));
+
+jest.mock('@/lib/code-reviews/platform/gitlab-access', () => ({
+  resolveGitLabAccessToken: (...args: unknown[]) => mockResolveGitLabAccessToken(...args),
+  getGitLabInstanceUrl: () => 'https://gitlab.com',
+}));
+
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+
+import { reapStaleCodeReviews, REAP_DEFAULT_BATCH_SIZE } from './reap-stale-reviews';
+
+function makeReview(overrides: Partial<CloudAgentCodeReview> = {}): CloudAgentCodeReview {
+  return {
+    id: '00000000-0000-0000-0000-0000000000aa',
+    owned_by_organization_id: null,
+    owned_by_user_id: 'user-1',
+    platform_integration_id: 'int-1',
+    repo_full_name: 'owner/repo',
+    pr_number: 7,
+    pr_url: 'https://github.com/owner/repo/pull/7',
+    pr_title: 'Test',
+    pr_author: 'author',
+    pr_author_github_id: null,
+    base_ref: 'main',
+    head_ref: 'feature',
+    head_sha: 'abc123',
+    platform: 'github',
+    platform_project_id: null,
+    session_id: null,
+    cli_session_id: null,
+    status: 'running',
+    dispatch_reservation_id: null,
+    error_message: null,
+    terminal_reason: null,
+    agent_version: 'v2',
+    check_run_id: 555,
+    repository_review_instructions_used: false,
+    repository_review_instructions_ref: null,
+    repository_review_instructions_truncated: false,
+    previous_summary_body: null,
+    previous_summary_head_sha: null,
+    manual_config: null,
+    review_type: 'standard',
+    trigger_source: 'webhook',
+    council_result: null,
+    model: null,
+    total_tokens_in: null,
+    total_tokens_out: null,
+    total_cost_musd: null,
+    started_at: '2025-01-01T00:00:00Z',
+    completed_at: null,
+    created_at: '2025-01-01T00:00:00Z',
+    updated_at: '2025-01-01T00:00:00Z',
+    ...overrides,
+  } as CloudAgentCodeReview;
+}
+
+/**
+ * `manual_config` is parsed by a strict zod schema, so a partial literal is
+ * rejected at read time rather than simply ignored.
+ */
+function manualConfig(outputMode: 'provider' | 'kilo') {
+  return {
+    agentConfig: {
+      review_style: 'balanced',
+      focus_areas: [],
+      model_slug: 'anthropic/claude-sonnet-4.6',
+    },
+    instructions: null,
+    outputMode,
+  };
+}
+
+const githubIntegration = {
+  id: 'int-1',
+  platform_installation_id: 'inst-1',
+  github_app_type: 'standard',
+  metadata: null,
+  owned_by_user_id: 'user-1',
+  owned_by_organization_id: null,
+};
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  mockClaim.mockResolvedValue([{ id: 'claimed' }]);
+  mockGetIntegrationById.mockResolvedValue(githubIntegration);
+  mockUpdateCheckRun.mockResolvedValue(undefined);
+  mockSetCommitStatus.mockResolvedValue(undefined);
+  mockResolveGitLabAccessToken.mockResolvedValue('gl-token');
+});
+
+describe('reapStaleCodeReviews', () => {
+  it('uses the default batch size as the selection limit', async () => {
+    mockSelectStale.mockResolvedValue([]);
+
+    await reapStaleCodeReviews();
+
+    expect(mockSelectStale).toHaveBeenCalledWith(REAP_DEFAULT_BATCH_SIZE);
+  });
+
+  it('honours an explicit batch size', async () => {
+    mockSelectStale.mockResolvedValue([]);
+
+    await reapStaleCodeReviews(5);
+
+    expect(mockSelectStale).toHaveBeenCalledWith(5);
+  });
+
+  it('closes the GitHub check run as timed out', async () => {
+    mockSelectStale.mockResolvedValue([makeReview()]);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(mockUpdateCheckRun).toHaveBeenCalledWith(
+      'inst-1',
+      'owner',
+      'repo',
+      555,
+      expect.objectContaining({ status: 'completed', conclusion: 'timed_out' }),
+      'standard'
+    );
+    expect(summary).toMatchObject({ terminalized: 1, checksClosed: 1, providerFailures: 0 });
+  });
+
+  it('cancels the commit status for a GitLab review', async () => {
+    mockSelectStale.mockResolvedValue([
+      makeReview({ platform: 'gitlab', platform_project_id: 42, check_run_id: null }),
+    ]);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(mockSetCommitStatus).toHaveBeenCalledWith(
+      'gl-token',
+      42,
+      'abc123',
+      'canceled',
+      expect.any(Object),
+      'https://gitlab.com'
+    );
+    expect(summary).toMatchObject({ checksClosed: 1 });
+  });
+
+  // A terminal callback arriving mid-batch wins: the guarded UPDATE claims
+  // nothing and the reaper must not then touch the provider.
+  it('skips provider work when the row was already claimed elsewhere', async () => {
+    mockSelectStale.mockResolvedValue([makeReview()]);
+    mockClaim.mockResolvedValue([]);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(mockUpdateCheckRun).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ selected: 1, terminalized: 0 });
+  });
+
+  // A dashboard-only manual review never published anything to the pull
+  // request, so nothing may be created for it now either.
+  it('terminalizes a dashboard-only review without touching the provider', async () => {
+    mockSelectStale.mockResolvedValue([
+      makeReview({ manual_config: manualConfig('kilo') as never }),
+    ]);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(mockGetIntegrationById).not.toHaveBeenCalled();
+    expect(mockUpdateCheckRun).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ terminalized: 1, checksClosed: 0 });
+  });
+
+  it('still closes the gate for a manual review configured for the provider', async () => {
+    mockSelectStale.mockResolvedValue([
+      makeReview({ manual_config: manualConfig('provider') as never }),
+    ]);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(summary).toMatchObject({ terminalized: 1, checksClosed: 1 });
+  });
+
+  // The strict manual_config schema throws on malformed legacy rows. One poison
+  // row must cost only its own provider work, never the rest of the batch.
+  it('continues the batch past a review whose manual_config no longer parses', async () => {
+    mockSelectStale.mockResolvedValue([
+      makeReview({ id: 'poison', manual_config: { outputMode: 'kilo' } as never }),
+      makeReview({ id: 'healthy', check_run_id: 777 }),
+    ]);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(summary).toMatchObject({
+      terminalized: 2,
+      checksClosed: 1,
+      providerFailures: 1,
+    });
+    expect(mockUpdateCheckRun).toHaveBeenCalledTimes(1);
+  });
+
+  // A suspended or uninstalled integration cannot mint a token, so its gate is
+  // unclosable. Expected for part of the backlog; counted, not retried.
+  it('continues the batch when a check run cannot be closed', async () => {
+    mockSelectStale.mockResolvedValue([
+      makeReview({ id: 'a', check_run_id: 111 }),
+      makeReview({ id: 'b', check_run_id: 222 }),
+    ]);
+    mockUpdateCheckRun.mockRejectedValueOnce(new Error('installation suspended'));
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(summary).toMatchObject({
+      terminalized: 2,
+      checksClosed: 1,
+      providerFailures: 1,
+    });
+  });
+
+  it('leaves Bitbucket reviews untouched on the provider side', async () => {
+    mockSelectStale.mockResolvedValue([makeReview({ platform: 'bitbucket', check_run_id: null })]);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(mockUpdateCheckRun).not.toHaveBeenCalled();
+    expect(mockSetCommitStatus).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ terminalized: 1, checksClosed: 0 });
+  });
+
+  it('terminalizes a review with no integration row without provider calls', async () => {
+    mockSelectStale.mockResolvedValue([makeReview({ platform_integration_id: null })]);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(mockGetIntegrationById).not.toHaveBeenCalled();
+    expect(mockUpdateCheckRun).not.toHaveBeenCalled();
+    expect(summary).toMatchObject({ terminalized: 1, checksClosed: 0, providerFailures: 0 });
+  });
+});

--- a/apps/web/src/lib/code-reviews/reap-stale-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/reap-stale-reviews.test.ts
@@ -5,6 +5,7 @@ import type { CloudAgentCodeReview } from '@kilocode/db/schema';
 // the assertions here are about call shape, not argument types.
 const mockSelectStale = jest.fn() as jest.MockedFunction<(limit: number) => Promise<any[]>>;
 const mockClaim = jest.fn() as jest.MockedFunction<() => Promise<unknown[]>>;
+const mockRemaining = jest.fn() as jest.MockedFunction<() => number>;
 const mockGetIntegrationById = jest.fn() as jest.MockedFunction<(id: string) => Promise<any>>;
 const mockUpdateCheckRun = jest.fn() as jest.MockedFunction<(...args: any[]) => Promise<void>>;
 const mockSetCommitStatus = jest.fn() as jest.MockedFunction<(...args: any[]) => Promise<void>>;
@@ -21,11 +22,14 @@ jest.mock('@/lib/drizzle', () => ({
   db: {
     select: () => ({
       from: () => ({
-        where: () => ({
-          orderBy: () => ({
-            limit: (n: number) => mockSelectStale(n),
+        // Awaited directly by the remaining-depth count, chained through
+        // orderBy/limit by the batch selection.
+        where: () =>
+          Object.assign(Promise.resolve([{ remaining: mockRemaining() }]), {
+            orderBy: () => ({
+              limit: (n: number) => mockSelectStale(n),
+            }),
           }),
-        }),
       }),
     }),
     update: () => ({
@@ -136,6 +140,7 @@ const githubIntegration = {
 beforeEach(() => {
   jest.clearAllMocks();
   mockClaim.mockResolvedValue([{ id: 'claimed' }]);
+  mockRemaining.mockReturnValue(0);
   mockGetIntegrationById.mockResolvedValue(githubIntegration);
   mockUpdateCheckRun.mockResolvedValue(undefined);
   mockSetCommitStatus.mockResolvedValue(undefined);
@@ -173,6 +178,17 @@ describe('reapStaleCodeReviews', () => {
       'standard'
     );
     expect(summary).toMatchObject({ terminalized: 1, checksClosed: 1, providerFailures: 0 });
+  });
+
+  // A saturated batch alone says nothing about depth; the summary must carry
+  // how much is still waiting so the drain is observable.
+  it('reports the remaining stale backlog after the run', async () => {
+    mockSelectStale.mockResolvedValue([makeReview()]);
+    mockRemaining.mockReturnValue(1575);
+
+    const summary = await reapStaleCodeReviews();
+
+    expect(summary.remaining).toBe(1575);
   });
 
   it('cancels the commit status for a GitLab review', async () => {

--- a/apps/web/src/lib/code-reviews/reap-stale-reviews.ts
+++ b/apps/web/src/lib/code-reviews/reap-stale-reviews.ts
@@ -1,0 +1,243 @@
+import {
+  cloud_agent_code_review_attempts,
+  cloud_agent_code_reviews,
+  type CloudAgentCodeReview,
+} from '@kilocode/db/schema';
+import { and, asc, eq, inArray, sql } from 'drizzle-orm';
+import { captureException } from '@sentry/nextjs';
+
+import { db } from '@/lib/drizzle';
+import { APP_URL } from '@/lib/constants';
+import { CodeReviewPlatformSchema } from '@/lib/code-reviews/core/schemas';
+import { NON_TERMINAL_CODE_REVIEW_STATUSES } from '@/lib/code-reviews/dispatch/dispatch-constants';
+import { shouldPublishCodeReviewToProvider } from '@/lib/code-reviews/manual-config';
+import {
+  getGitLabInstanceUrl,
+  resolveGitLabAccessToken,
+} from '@/lib/code-reviews/platform/gitlab-access';
+import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import { updateCheckRun } from '@/lib/integrations/platforms/github/adapter';
+import { setCommitStatus } from '@/lib/integrations/platforms/gitlab/adapter';
+import { logExceptInTest } from '@/lib/utils.server';
+
+/**
+ * How long a review may sit in a non-terminal state before the reaper closes it.
+ *
+ * Far past anything legitimate: capacity waits resolve in minutes to hours, and
+ * the cron drain already stops reconsidering pending work after 75 minutes.
+ */
+export const REAP_STALE_REVIEW_HOURS = 48;
+
+/**
+ * Upper bound on rows closed per invocation.
+ *
+ * Needed for two independent reasons. Each reaped review can cost a platform
+ * API call against a per-installation rate limit. And the alerting detector
+ * measures failure rate in a 30 minute window keyed on completion time, so an
+ * uncapped first drain would register thousands of failures at once and read
+ * as an incident.
+ */
+export const REAP_DEFAULT_BATCH_SIZE = 25;
+
+const REAP_TERMINAL_REASON = 'abandoned';
+const REAP_ERROR_MESSAGE = 'Stopped by Kilo after the review never reached a terminal state';
+const REAP_CHECK_TITLE = 'Kilo Code Review stopped';
+const REAP_CHECK_SUMMARY = 'This review did not finish and was closed by Kilo.';
+
+export type ReapStaleReviewsSummary = {
+  selected: number;
+  terminalized: number;
+  checksClosed: number;
+  providerFailures: number;
+};
+
+/**
+ * Reviews whose last sign of life is older than the reap threshold.
+ *
+ * The COALESCE mirrors the one the dispatcher uses for staleness, so a row that
+ * was updated recently is not reaped purely because it was created long ago.
+ *
+ * Oldest first: with no notification attached to a reap, there is no freshness
+ * window to protect, and the rows that have been spinning a provider-side check
+ * the longest are the most useful ones to close first.
+ */
+function selectStaleReviews(limit: number) {
+  return db
+    .select()
+    .from(cloud_agent_code_reviews)
+    .where(
+      and(
+        inArray(cloud_agent_code_reviews.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES]),
+        sql`COALESCE(
+          ${cloud_agent_code_reviews.started_at},
+          ${cloud_agent_code_reviews.updated_at},
+          ${cloud_agent_code_reviews.created_at}
+        ) < now() - interval '${sql.raw(String(REAP_STALE_REVIEW_HOURS))} hours'`
+      )
+    )
+    .orderBy(asc(cloud_agent_code_reviews.created_at))
+    .limit(limit);
+}
+
+/**
+ * Claim a review terminally, but only if nothing has touched it since selection.
+ *
+ * The whole batch is selected up front and then walked with provider calls in
+ * between, so minutes can pass before a given row is claimed. A status check on
+ * its own is not enough: the inline dispatch path has no age bound, so an owner
+ * becoming active mid-batch can legitimately re-dispatch one of these very rows,
+ * and the reaper would then kill a live review and null the reservation the real
+ * callback depends on.
+ *
+ * Matching on the snapshot's `updated_at` makes the claim an optimistic lock:
+ * every write to this table refreshes that column, so any intervening dispatch,
+ * callback, or supersede invalidates the claim and the row is skipped this run.
+ *
+ * On a successful claim the review's own non-terminal attempts are closed with
+ * it, the same way the supersede path closes both tables together. Left open,
+ * they would count as in-progress work forever in every attempt-level query.
+ */
+async function terminalizeReview(review: CloudAgentCodeReview): Promise<boolean> {
+  const now = new Date().toISOString();
+  const claimed = await db
+    .update(cloud_agent_code_reviews)
+    .set({
+      status: 'failed',
+      terminal_reason: REAP_TERMINAL_REASON,
+      error_message: REAP_ERROR_MESSAGE,
+      dispatch_reservation_id: null,
+      completed_at: now,
+      updated_at: now,
+    })
+    .where(
+      and(
+        eq(cloud_agent_code_reviews.id, review.id),
+        inArray(cloud_agent_code_reviews.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES]),
+        eq(cloud_agent_code_reviews.updated_at, review.updated_at)
+      )
+    )
+    .returning({ id: cloud_agent_code_reviews.id });
+
+  if (claimed.length === 0) return false;
+
+  await db
+    .update(cloud_agent_code_review_attempts)
+    .set({
+      status: 'failed',
+      terminal_reason: REAP_TERMINAL_REASON,
+      error_message: REAP_ERROR_MESSAGE,
+      completed_at: now,
+      updated_at: now,
+    })
+    .where(
+      and(
+        eq(cloud_agent_code_review_attempts.code_review_id, review.id),
+        inArray(cloud_agent_code_review_attempts.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES])
+      )
+    );
+
+  return true;
+}
+
+/**
+ * Close the provider-side gate so the pull request stops showing a check that
+ * will never finish. Runs regardless of whether the pull request is still open:
+ * a spinning check on a closed pull request is still wrong.
+ */
+async function closeProviderGate(review: CloudAgentCodeReview): Promise<boolean> {
+  // A manual review configured as dashboard-only never published anything to the
+  // pull request, so there is nothing to close and nothing may be created now.
+  // Every other provider-publish site gates on this; the reaper is no exception.
+  if (!shouldPublishCodeReviewToProvider(review)) return false;
+
+  const platform = CodeReviewPlatformSchema.parse(review.platform);
+  if (platform === PLATFORM.BITBUCKET) return false;
+
+  if (!review.platform_integration_id) return false;
+  const integration = await getIntegrationById(review.platform_integration_id);
+  if (!integration) return false;
+
+  const detailsUrl = `${APP_URL}/code-reviews/${review.id}`;
+
+  if (platform === PLATFORM.GITHUB) {
+    if (!review.check_run_id || !integration.platform_installation_id) return false;
+    const [repoOwner, repoName] = review.repo_full_name.split('/');
+    await updateCheckRun(
+      integration.platform_installation_id,
+      repoOwner,
+      repoName,
+      review.check_run_id,
+      {
+        status: 'completed',
+        conclusion: 'timed_out',
+        detailsUrl,
+        output: { title: REAP_CHECK_TITLE, summary: REAP_CHECK_SUMMARY },
+      },
+      integration.github_app_type ?? 'standard'
+    );
+    return true;
+  }
+
+  const accessToken = await resolveGitLabAccessToken(integration, review.platform_project_id);
+  await setCommitStatus(
+    accessToken,
+    review.platform_project_id ?? review.repo_full_name,
+    review.head_sha,
+    'canceled',
+    { targetUrl: detailsUrl, description: REAP_CHECK_SUMMARY },
+    getGitLabInstanceUrl(integration)
+  );
+  return true;
+}
+
+/**
+ * Close out reviews that have sat in a non-terminal state past the threshold.
+ *
+ * Deliberately janitorial: it does not diagnose why a review stranded, only
+ * that nothing is going to finish it. All provider work runs inside a per-row
+ * catch, so one unreachable installation, malformed legacy row, or suspended
+ * integration cannot stall the rest of the batch. Those failures are expected
+ * for part of the backlog and are counted rather than retried; the row is
+ * already terminal by then either way.
+ */
+export async function reapStaleCodeReviews(
+  batchSize: number = REAP_DEFAULT_BATCH_SIZE
+): Promise<ReapStaleReviewsSummary> {
+  const stale = await selectStaleReviews(batchSize);
+  const summary: ReapStaleReviewsSummary = {
+    selected: stale.length,
+    terminalized: 0,
+    checksClosed: 0,
+    providerFailures: 0,
+  };
+
+  for (const review of stale) {
+    // Claim first. Everything after this is best-effort cleanup, and a provider
+    // call that fails must not leave the row selectable forever.
+    if (!(await terminalizeReview(review))) continue;
+    summary.terminalized += 1;
+
+    try {
+      if (await closeProviderGate(review)) summary.checksClosed += 1;
+    } catch (error) {
+      summary.providerFailures += 1;
+      logExceptInTest('[reap-stale-reviews] Failed to close provider gate', {
+        reviewId: review.id,
+        repo: review.repo_full_name,
+        error: error instanceof Error ? error.message : String(error),
+      });
+    }
+  }
+
+  if (summary.providerFailures > 0) {
+    captureException(new Error('Stale code review reap completed with provider failures'), {
+      level: 'info',
+      tags: { operation: 'reap-stale-code-reviews' },
+      extra: { ...summary },
+    });
+  }
+
+  logExceptInTest('[reap-stale-reviews] Completed', summary);
+  return summary;
+}

--- a/apps/web/src/lib/code-reviews/reap-stale-reviews.ts
+++ b/apps/web/src/lib/code-reviews/reap-stale-reviews.ts
@@ -3,7 +3,7 @@ import {
   cloud_agent_code_reviews,
   type CloudAgentCodeReview,
 } from '@kilocode/db/schema';
-import { and, asc, eq, inArray, sql } from 'drizzle-orm';
+import { and, asc, count, eq, inArray, sql } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 
 import { db } from '@/lib/drizzle';
@@ -50,6 +50,13 @@ export type ReapStaleReviewsSummary = {
   terminalized: number;
   checksClosed: number;
   providerFailures: number;
+  /**
+   * Stale rows still waiting after this run. A saturated batch alone cannot
+   * distinguish a backlog of dozens from one of thousands; this is the number
+   * to watch while the initial drain runs (visible in the Completed log line
+   * and the cron response).
+   */
+  remaining: number;
 };
 
 /**
@@ -62,22 +69,33 @@ export type ReapStaleReviewsSummary = {
  * window to protect, and the rows that have been spinning a provider-side check
  * the longest are the most useful ones to close first.
  */
+function staleReviewCondition() {
+  return and(
+    inArray(cloud_agent_code_reviews.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES]),
+    sql`COALESCE(
+      ${cloud_agent_code_reviews.started_at},
+      ${cloud_agent_code_reviews.updated_at},
+      ${cloud_agent_code_reviews.created_at}
+    ) < now() - interval '${sql.raw(String(REAP_STALE_REVIEW_HOURS))} hours'`
+  );
+}
+
 function selectStaleReviews(limit: number) {
   return db
     .select()
     .from(cloud_agent_code_reviews)
-    .where(
-      and(
-        inArray(cloud_agent_code_reviews.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES]),
-        sql`COALESCE(
-          ${cloud_agent_code_reviews.started_at},
-          ${cloud_agent_code_reviews.updated_at},
-          ${cloud_agent_code_reviews.created_at}
-        ) < now() - interval '${sql.raw(String(REAP_STALE_REVIEW_HOURS))} hours'`
-      )
-    )
+    .where(staleReviewCondition())
     .orderBy(asc(cloud_agent_code_reviews.created_at))
     .limit(limit);
+}
+
+/** Shares the selection predicate so the depth count cannot drift from it. */
+async function countRemainingStaleReviews(): Promise<number> {
+  const [row] = await db
+    .select({ remaining: count() })
+    .from(cloud_agent_code_reviews)
+    .where(staleReviewCondition());
+  return Number(row?.remaining) || 0;
 }
 
 /**
@@ -210,6 +228,7 @@ export async function reapStaleCodeReviews(
     terminalized: 0,
     checksClosed: 0,
     providerFailures: 0,
+    remaining: 0,
   };
 
   for (const review of stale) {
@@ -229,6 +248,8 @@ export async function reapStaleCodeReviews(
       });
     }
   }
+
+  summary.remaining = await countRemainingStaleReviews();
 
   if (summary.providerFailures > 0) {
     captureException(new Error('Stale code review reap completed with provider failures'), {

--- a/apps/web/src/lib/code-reviews/reap-stale-reviews.ts
+++ b/apps/web/src/lib/code-reviews/reap-stale-reviews.ts
@@ -118,44 +118,49 @@ async function countRemainingStaleReviews(): Promise<number> {
  */
 async function terminalizeReview(review: CloudAgentCodeReview): Promise<boolean> {
   const now = new Date().toISOString();
-  const claimed = await db
-    .update(cloud_agent_code_reviews)
-    .set({
-      status: 'failed',
-      terminal_reason: REAP_TERMINAL_REASON,
-      error_message: REAP_ERROR_MESSAGE,
-      dispatch_reservation_id: null,
-      completed_at: now,
-      updated_at: now,
-    })
-    .where(
-      and(
-        eq(cloud_agent_code_reviews.id, review.id),
-        inArray(cloud_agent_code_reviews.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES]),
-        eq(cloud_agent_code_reviews.updated_at, review.updated_at)
+  // One transaction: a crash between the two writes would otherwise leave the
+  // review terminal with its attempts still running, permanently, because the
+  // parent is no longer selectable so nothing would ever revisit them.
+  return await db.transaction(async tx => {
+    const claimed = await tx
+      .update(cloud_agent_code_reviews)
+      .set({
+        status: 'failed',
+        terminal_reason: REAP_TERMINAL_REASON,
+        error_message: REAP_ERROR_MESSAGE,
+        dispatch_reservation_id: null,
+        completed_at: now,
+        updated_at: now,
+      })
+      .where(
+        and(
+          eq(cloud_agent_code_reviews.id, review.id),
+          inArray(cloud_agent_code_reviews.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES]),
+          eq(cloud_agent_code_reviews.updated_at, review.updated_at)
+        )
       )
-    )
-    .returning({ id: cloud_agent_code_reviews.id });
+      .returning({ id: cloud_agent_code_reviews.id });
 
-  if (claimed.length === 0) return false;
+    if (claimed.length === 0) return false;
 
-  await db
-    .update(cloud_agent_code_review_attempts)
-    .set({
-      status: 'failed',
-      terminal_reason: REAP_TERMINAL_REASON,
-      error_message: REAP_ERROR_MESSAGE,
-      completed_at: now,
-      updated_at: now,
-    })
-    .where(
-      and(
-        eq(cloud_agent_code_review_attempts.code_review_id, review.id),
-        inArray(cloud_agent_code_review_attempts.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES])
-      )
-    );
+    await tx
+      .update(cloud_agent_code_review_attempts)
+      .set({
+        status: 'failed',
+        terminal_reason: REAP_TERMINAL_REASON,
+        error_message: REAP_ERROR_MESSAGE,
+        completed_at: now,
+        updated_at: now,
+      })
+      .where(
+        and(
+          eq(cloud_agent_code_review_attempts.code_review_id, review.id),
+          inArray(cloud_agent_code_review_attempts.status, [...NON_TERMINAL_CODE_REVIEW_STATUSES])
+        )
+      );
 
-  return true;
+    return true;
+  });
 }
 
 /**

--- a/apps/web/src/routers/admin-code-reviews-router.ts
+++ b/apps/web/src/routers/admin-code-reviews-router.ts
@@ -99,6 +99,7 @@ const TERMINAL_REASON_LABELS: Record<string, string> = {
   workspace_capacity: 'Sandbox Capacity',
   sandbox_connection: 'Sandbox Connection',
   container_shutdown: 'Container Shutdown',
+  abandoned: 'Abandoned (reaped)',
   assistant_rate_limited: 'Rate Limited',
   // Named by owner rather than by the internal `providerOwnership` value.
   // "managed key" required knowing that 'managed' means Kilo's own credential,
@@ -436,7 +437,10 @@ export const adminCodeReviewsRouter = createTRPCRouter({
         cancelled_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'cancelled' OR (${statusTable.status} = 'failed' AND ${modelUnavailable}))`,
         interrupted_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} = 'interrupted')`,
         in_progress_count: sql<number>`COUNT(*) FILTER (WHERE ${statusTable.status} IN ('pending', 'queued', 'running'))`,
-        avg_duration_seconds: sql<number>`AVG(EXTRACT(EPOCH FROM (${durationCompletedAt}::timestamp - ${durationStartedAt}::timestamp))) FILTER (WHERE ${durationCompletedAt} IS NOT NULL AND ${durationStartedAt} IS NOT NULL)`,
+        // Reaped reviews get completed_at stamped at reap time, ~48h+ after they
+        // started, so a handful of them would dominate an average built from
+        // minutes-long real runs. They are closures, not measurements.
+        avg_duration_seconds: sql<number>`AVG(EXTRACT(EPOCH FROM (${durationCompletedAt}::timestamp - ${durationStartedAt}::timestamp))) FILTER (WHERE ${durationCompletedAt} IS NOT NULL AND ${durationStartedAt} IS NOT NULL AND COALESCE(${statusTable.terminal_reason}, '') <> 'abandoned')`,
         wait_started_count: sql<number>`COUNT(*) FILTER (WHERE ${waitCondition})`,
         avg_wait_seconds: sql<number>`AVG(${waitSeconds}) FILTER (WHERE ${waitCondition})`,
         p95_wait_seconds: sql<number>`percentile_cont(0.95) WITHIN GROUP (ORDER BY ${waitSeconds}) FILTER (WHERE ${waitCondition})`,

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -81,6 +81,10 @@
       "schedule": "*/10 * * * *"
     },
     {
+      "path": "/api/cron/reap-stale-code-reviews",
+      "schedule": "0 * * * *"
+    },
+    {
       "path": "/api/cron/exa-partition-maintenance",
       "schedule": "0 0 1 * *"
     },

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -2130,6 +2130,10 @@ export const CODE_REVIEW_TERMINAL_REASONS = [
   'session_import_failed',
   'setup_command_failed',
   'container_shutdown',
+  // Closed out by the stale review reaper because it sat in a non-terminal state
+  // past the reap threshold. Distinct from 'timeout', which means the agent
+  // itself timed out; this one means nothing ever reported back at all.
+  'abandoned',
   'unknown',
 ] as const;
 
@@ -2166,6 +2170,14 @@ export const CODE_REVIEW_BENIGN_TERMINAL_REASONS = [
   // unqualified 'assistant_rate_limited' also stays non-benign, since unknown
   // ownership could be either.
   'assistant_rate_limited_byok',
+  // Set only by the stale review reaper, which measures cleanup rather than the
+  // fault that stranded the review, so alerting on it would count janitorial work
+  // as incidents. Every stranded pending review measured on 2026-08-04 traced to
+  // customer-side state: Code Reviewer disabled, the platform integration
+  // suspended, or an action-required disable. The signal for genuinely stuck work
+  // is the live "Running > 90m" queue health counter, which is unaffected by this
+  // and does not depend on a review having been reaped yet.
+  'abandoned',
 ] as const satisfies readonly CodeReviewTerminalReason[];
 
 export type CodeReviewBenignTerminalReason = (typeof CODE_REVIEW_BENIGN_TERMINAL_REASONS)[number];

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -192,6 +192,11 @@ export const CLOUD_AGENT_TERMINAL_REASONS = [
   'session_import_failed',
   'setup_command_failed',
   'container_shutdown',
+  // Written only by the stale review reaper on the app side, never sent by the
+  // orchestrator. It is listed here because this enum and the db one are kept
+  // identical: the callback allowlist is built from this list, so an omission
+  // would reject the reason if it ever did arrive on a callback.
+  'abandoned',
   'unknown',
 ] as const;
 


### PR DESCRIPTION
## Summary

Reviews stranded in `pending`, `queued`, or `running` were never closed out.
Nothing on any schedule terminalizes them: the 90 minute staleness cutoff only
stops stale runs counting toward owner capacity, it never fails them. A stranded
review can leave an `in_progress` GitHub check run spinning on its pull request
indefinitely, and on any repo that requires the Kilo Code Review check, that
blocks merging.

This adds an hourly reaper cron that closes any review whose last sign of life
(`COALESCE(started_at, updated_at, created_at)`) is older than 48 hours:

- Marks the review failed with a new `abandoned` terminal reason and closes its
  own non-terminal attempts with it, the same way the supersede path closes both
  tables together.
- Completes the provider-side gate: GitHub check run as `timed_out`, GitLab
  commit status as `canceled`. Bitbucket has no status path and is skipped.
- The claim is an optimistic lock on the selected row's `updated_at`, so a
  re-dispatch or late callback arriving mid-batch wins the race instead of
  being overwritten.
- All provider work runs inside a per-row catch: suspended installations and
  malformed legacy rows are counted in the summary, not fatal to the batch.
- Dashboard-only manual reviews (`outputMode: 'kilo'`) publish nothing.
- Each run reports `remaining`, the count of still-stale rows using the same
  predicate as selection, so the backlog drain is observable from the log line.

Reaped rows are deliberately kept out of health metrics, in both directions:

- `abandoned` joins `CODE_REVIEW_BENIGN_TERMINAL_REASONS`, so the reaper's
  cleanup does not read as an error spike. The live queue health counters
  remain the signal for stuck work.
- The alerting detectors' shared CTE also excludes it. A reaped review that
  never started has no `started_at`, so its effective start collapsed to the
  reap timestamp and would have inflated `started_count`, diluting the
  error-spike and slow-review rates and masking a real incident.
- The admin `avg_duration_seconds` excludes it: a reap timestamp is a closure,
  not a duration measurement.

Supporting changes: `resolveGitLabAccessToken`/`getGitLabInstanceUrl` moved
out of the status-callback route into `lib/code-reviews/platform/gitlab-access`
(pure move, the reaper needs them too), and the repeated
`['pending','queued','running']` literal became `NON_TERMINAL_CODE_REVIEW_STATUSES`
in dispatch-constants. No migration: `terminal_reason` is an unconstrained text
column, and the db/worker-utils enum parity test covers the new value.

## Verification

- [ ] Not manually tested against a live pull request yet. The check-run close
      path is covered by unit tests only; the integration suite runs the
      selection, claim, and attempt-close SQL against a real database,
      including the microsecond `updated_at` round trip the optimistic lock
      depends on. Suggested first manual test: run the cron with a small batch
      and confirm a known stuck check run flips to `timed_out`.

## Visual Changes

N/A (the admin Error Analysis table gains an "Abandoned (reaped)" row label
once such rows exist; no layout changes).

## Reviewer Notes

- Deliberate scope cut: the reaper posts no PR comment. Closing the check run
  is visible on the PR already, and a notification can be layered on later
  without touching this design.
- The benign-list entry is an exception to the non-benign default documented in
  `schema-types.ts`; the reasoning is in a comment at the entry itself.
- During the initial drain expect nonzero `providerFailures`: part of the
  backlog references suspended or uninstalled integrations whose check runs
  cannot be closed. The row still terminalizes; the failure is counted, not
  retried.
- The drain runs oldest first at the capped batch rate; `remaining` in the
  summary log line tracks progress until it reaches zero.
