### PR TITLE
fix(code reviewed) status dispatch after

### DIFF
--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -101,12 +101,15 @@ jest.mock('next/server', () => {
   const actual = jest.requireActual<typeof nextServerModule>('next/server');
   return {
     ...actual,
-    // Route handlers here fire the dispatch off in the background via
-    // `after()`. Outside a real request scope `after()` throws, so invoke
-    // the callback immediately (without awaiting) to preserve the existing
-    // fire-and-forget semantics under test.
-    after: (fn: () => Promise<void> | void) => {
-      void fn();
+    // The route hands `after()` an already-started promise (dispatch is
+    // kicked off immediately, not deferred behind it) so it can keep the
+    // serverless invocation alive until the promise settles. Outside a real
+    // request scope `after()` throws, so just swallow the task here; the
+    // dispatch call itself already ran by the time this is invoked.
+    after: (task: Promise<unknown> | (() => Promise<void> | void)) => {
+      if (typeof task === 'function') {
+        void task();
+      }
     },
   };
 });

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, jest, beforeEach } from '@jest/globals';
 import type { NextRequest } from 'next/server';
+import type * as nextServerModule from 'next/server';
 import type * as codeReviewsDbModule from '@/lib/code-reviews/db/code-reviews';
 import type * as analyticsDbModule from '@/lib/code-reviews/analytics/db';
 import type * as platformIntegrationsModule from '@/lib/integrations/db/platform-integrations';
@@ -95,6 +96,20 @@ const mockDisableCodeReviewForActionRequiredFailure = jest.fn<any>();
 const mockDisableCodeReviewForRepeatedCloneTimeoutsToday = jest.fn<any>();
 
 // --- Module mocks ---
+
+jest.mock('next/server', () => {
+  const actual = jest.requireActual<typeof nextServerModule>('next/server');
+  return {
+    ...actual,
+    // Route handlers here fire the dispatch off in the background via
+    // `after()`. Outside a real request scope `after()` throws, so invoke
+    // the callback immediately (without awaiting) to preserve the existing
+    // fire-and-forget semantics under test.
+    after: (fn: () => Promise<void> | void) => {
+      void fn();
+    },
+  };
+});
 
 jest.mock('@/lib/config.server', () => ({
   CALLBACK_TOKEN_SECRET: 'test-callback-token-secret',

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -1654,13 +1654,14 @@ export async function POST(
     if (status === 'completed' || status === 'failed' || status === 'cancelled') {
       const ownerResolution = await getTerminalOwnerResolution();
       if (ownerResolution?.canDispatch) {
-        // Trigger dispatch in the background. `after()` keeps the serverless
-        // invocation alive for this work instead of leaving it as an
-        // unawaited promise that Vercel can freeze once the response is
-        // sent, which was causing spurious worker-call/status-probe
-        // timeouts (fetches stall while the function is suspended).
-        after(() =>
-          tryDispatchPendingReviews(ownerResolution.owner).catch(dispatchError => {
+        // Start dispatch immediately (don't wait behind the remaining
+        // provider work below), but hand the promise to `after()` so Vercel
+        // keeps the serverless invocation alive until it settles instead of
+        // freezing it once the response is sent. That freeze is what
+        // produced spurious worker-call/status-probe timeouts (in-flight
+        // fetches stall while the function is suspended).
+        const dispatchPromise = tryDispatchPendingReviews(ownerResolution.owner).catch(
+          dispatchError => {
             errorExceptInTest(
               '[code-review-status] Error dispatching pending reviews:',
               dispatchError
@@ -1669,8 +1670,9 @@ export async function POST(
               tags: { source: 'code-review-status-dispatch' },
               extra: { reviewId, owner: ownerResolution.owner },
             });
-          })
+          }
         );
+        after(dispatchPromise);
 
         logExceptInTest('[code-review-status] Triggered dispatch for pending reviews', {
           reviewId,

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -17,7 +17,7 @@
  */
 
 import type { NextRequest } from 'next/server';
-import { NextResponse } from 'next/server';
+import { NextResponse, after } from 'next/server';
 import * as z from 'zod';
 import {
   updateCodeReviewStatus,
@@ -1690,17 +1690,23 @@ export async function POST(
     if (status === 'completed' || status === 'failed' || status === 'cancelled') {
       const ownerResolution = await getTerminalOwnerResolution();
       if (ownerResolution?.canDispatch) {
-        // Trigger dispatch in background (don't await - fire and forget)
-        tryDispatchPendingReviews(ownerResolution.owner).catch(dispatchError => {
-          errorExceptInTest(
-            '[code-review-status] Error dispatching pending reviews:',
-            dispatchError
-          );
-          captureException(dispatchError, {
-            tags: { source: 'code-review-status-dispatch' },
-            extra: { reviewId, owner: ownerResolution.owner },
-          });
-        });
+        // Trigger dispatch in the background. `after()` keeps the serverless
+        // invocation alive for this work instead of leaving it as an
+        // unawaited promise that Vercel can freeze once the response is
+        // sent, which was causing spurious worker-call/status-probe
+        // timeouts (fetches stall while the function is suspended).
+        after(() =>
+          tryDispatchPendingReviews(ownerResolution.owner).catch(dispatchError => {
+            errorExceptInTest(
+              '[code-review-status] Error dispatching pending reviews:',
+              dispatchError
+            );
+            captureException(dispatchError, {
+              tags: { source: 'code-review-status-dispatch' },
+              extra: { reviewId, owner: ownerResolution.owner },
+            });
+          })
+        );
 
         logExceptInTest('[code-review-status] Triggered dispatch for pending reviews', {
           reviewId,


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

The code review status callback route triggered `tryDispatchPendingReviews()` as an unawaited promise right after processing a terminal status update, then continued running and eventually returned its response. Vercel can freeze a serverless invocation once nothing is holding it open, so the dispatch call's outbound fetches to the code review worker could stall mid-flight. This showed up in Sentry as spurious `Request timeout after 10000ms` errors on both the dispatch call and the follow-up status probe.

This PR wraps that dispatch promise in Next.js `after()`, the same pattern already used by the GitHub and bot webhook handlers, so the invocation stays alive until the dispatch settles. The dispatch is still kicked off immediately and not awaited inline, so it does not delay the route's own response or the GitHub/GitLab reaction and comment updates that follow it.

## Changes

- `route.ts`: import `after` from `next/server` and pass the already-started `tryDispatchPendingReviews(...).catch(...)` promise to it instead of leaving it as a bare unawaited promise.
- `route.test.ts`: mock `next/server`'s `after` so tests can run outside a real request scope (where the real `after()` throws), while preserving the existing fire-and-forget assertions on `tryDispatchPendingReviews`.

## Verification

- [ ] No manual testing performed. Verified via `NODE_ENV=test npx jest "src/app/api/internal/code-review-status"` (127/127 passing), `scripts/typecheck-all.sh --changes-only`, and `scripts/lint-all.sh --changes-only`, all clean.

## Visual Changes

N/A

## Reviewer Notes

Reviewer focus: confirm `after(dispatchPromise)` doesn't change response timing. It doesn't, since the promise is created and handed to `after()` before any subsequent `await` in the route, and `after()` itself only registers the promise with the platform's `waitUntil` rather than awaiting it.
