### PR TITLE
feat(mobile): force efficient model as the dev default

### DIFF
--- a/apps/mobile/src/lib/hooks/auto-select-model.test.ts
+++ b/apps/mobile/src/lib/hooks/auto-select-model.test.ts
@@ -1,0 +1,121 @@
+import { describe, expect, it } from 'vitest';
+
+import { type AutoSelectInput, pickAutoSelectedModel } from './auto-select-model';
+
+const efficient = {
+  id: 'kilo-auto/efficient',
+  name: 'Auto Efficient',
+  variants: [],
+  isPreferred: false,
+};
+const claude = {
+  id: 'anthropic/claude',
+  name: 'Claude',
+  variants: ['thinking'],
+  isPreferred: true,
+};
+const gpt = { id: 'openai/gpt', name: 'GPT', variants: [], isPreferred: false };
+
+const base: AutoSelectInput = {
+  models: [],
+  lastSelected: null,
+  stored: {},
+  organizationId: undefined,
+  orgDefaultModel: undefined,
+  isDev: true,
+};
+
+describe('pickAutoSelectedModel', () => {
+  it('dev, no overrides, efficient in catalog → selects efficient', () => {
+    expect(pickAutoSelectedModel({ ...base, models: [claude, efficient, gpt] })).toEqual({
+      model: 'kilo-auto/efficient',
+      variant: '',
+    });
+  });
+
+  it('dev, efficient absent → falls back to models[0]', () => {
+    expect(pickAutoSelectedModel({ ...base, models: [claude, gpt] })).toEqual({
+      model: 'anthropic/claude',
+      variant: 'thinking',
+    });
+  });
+
+  it('dev, matching org default wins over efficient', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        models: [claude, efficient],
+        orgDefaultModel: 'anthropic/claude',
+      })
+    ).toEqual({ model: 'anthropic/claude', variant: 'thinking' });
+  });
+
+  it('dev, org default not in catalog → efficient', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        models: [claude, efficient],
+        orgDefaultModel: 'gone/model',
+      })
+    ).toEqual({ model: 'kilo-auto/efficient', variant: '' });
+  });
+
+  it('dev, server lastSelected wins over efficient', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        models: [claude, efficient],
+        lastSelected: { model: 'anthropic/claude', variant: 'thinking' },
+      })
+    ).toEqual({ model: 'anthropic/claude', variant: 'thinking' });
+  });
+
+  it('dev, local persisted preference wins over efficient', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        models: [gpt, efficient],
+        stored: { personal: { model: 'openai/gpt', variant: '' } },
+      })
+    ).toEqual({ model: 'openai/gpt', variant: '' });
+  });
+
+  it('release, efficient in catalog → keeps production fallback models[0]', () => {
+    expect(pickAutoSelectedModel({ ...base, isDev: false, models: [claude, efficient] })).toEqual({
+      model: 'anthropic/claude',
+      variant: 'thinking',
+    });
+  });
+
+  it('release, matching org default → org default', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        isDev: false,
+        models: [claude, efficient],
+        orgDefaultModel: 'anthropic/claude',
+      })
+    ).toEqual({ model: 'anthropic/claude', variant: 'thinking' });
+  });
+
+  it('release, org default not in catalog → models[0]', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        isDev: false,
+        models: [claude, efficient],
+        orgDefaultModel: 'gone/model',
+      })
+    ).toEqual({ model: 'anthropic/claude', variant: 'thinking' });
+  });
+
+  it('empty catalog → null', () => {
+    expect(pickAutoSelectedModel({ ...base, models: [] })).toBeNull();
+  });
+
+  it('dev, efficient absent, matching org default → org default wins', () => {
+    expect(
+      pickAutoSelectedModel({ ...base, models: [claude, gpt], orgDefaultModel: 'openai/gpt' })
+    ).toEqual({ model: 'openai/gpt', variant: '' });
+  });
+});

--- a/apps/mobile/src/lib/hooks/auto-select-model.test.ts
+++ b/apps/mobile/src/lib/hooks/auto-select-model.test.ts
@@ -40,14 +40,14 @@ describe('pickAutoSelectedModel', () => {
     });
   });
 
-  it('dev, matching org default wins over efficient', () => {
+  it('dev, efficient wins over a matching org default', () => {
     expect(
       pickAutoSelectedModel({
         ...base,
         models: [claude, efficient],
         orgDefaultModel: 'anthropic/claude',
       })
-    ).toEqual({ model: 'anthropic/claude', variant: 'thinking' });
+    ).toEqual({ model: 'kilo-auto/efficient', variant: '' });
   });
 
   it('dev, org default not in catalog → efficient', () => {
@@ -60,22 +60,32 @@ describe('pickAutoSelectedModel', () => {
     ).toEqual({ model: 'kilo-auto/efficient', variant: '' });
   });
 
-  it('dev, server lastSelected wins over efficient', () => {
+  it('dev, efficient wins over server lastSelected', () => {
     expect(
       pickAutoSelectedModel({
         ...base,
         models: [claude, efficient],
         lastSelected: { model: 'anthropic/claude', variant: 'thinking' },
       })
-    ).toEqual({ model: 'anthropic/claude', variant: 'thinking' });
+    ).toEqual({ model: 'kilo-auto/efficient', variant: '' });
   });
 
-  it('dev, local persisted preference wins over efficient', () => {
+  it('dev, efficient wins over a local persisted preference', () => {
     expect(
       pickAutoSelectedModel({
         ...base,
         models: [gpt, efficient],
         stored: { personal: { model: 'openai/gpt', variant: '' } },
+      })
+    ).toEqual({ model: 'kilo-auto/efficient', variant: '' });
+  });
+
+  it('dev, efficient absent → server lastSelected still wins', () => {
+    expect(
+      pickAutoSelectedModel({
+        ...base,
+        models: [claude, gpt],
+        lastSelected: { model: 'openai/gpt' },
       })
     ).toEqual({ model: 'openai/gpt', variant: '' });
   });

--- a/apps/mobile/src/lib/hooks/auto-select-model.ts
+++ b/apps/mobile/src/lib/hooks/auto-select-model.ts
@@ -1,0 +1,50 @@
+import {
+  contextKey,
+  resolveModelForContext,
+  type StoredModelPreference,
+} from '@/lib/hooks/agent-model-preference';
+import { type ModelOption } from '@/lib/hooks/use-available-models';
+
+const DEV_DEFAULT_MODEL_ID = 'kilo-auto/efficient';
+
+function pickVariant(model: ModelOption, preferredVariant: string | undefined): string {
+  if (preferredVariant && model.variants.includes(preferredVariant)) {
+    return preferredVariant;
+  }
+  return model.variants[0] ?? '';
+}
+
+export type AutoSelectInput = {
+  models: ModelOption[];
+  lastSelected: { model: string; variant?: string } | null;
+  stored: StoredModelPreference;
+  organizationId: string | undefined;
+  orgDefaultModel: string | undefined;
+  isDev: boolean;
+};
+
+/**
+ * Pick the new-session model. Override priority: server lastSelected, then local
+ * persisted preference, then org default. In dev builds only, `kilo-auto/efficient`
+ * slots in above the bare catalog fallback (never above an explicit override).
+ */
+export function pickAutoSelectedModel(
+  input: AutoSelectInput
+): { model: string; variant: string } | null {
+  const { models, lastSelected, stored, organizationId, orgDefaultModel, isDev } = input;
+  const serverMatch = lastSelected ? models.find(m => m.id === lastSelected.model) : undefined;
+  const localEntry = resolveModelForContext(stored, contextKey(organizationId), models);
+  const orgDefaultMatch = orgDefaultModel ? models.find(m => m.id === orgDefaultModel) : undefined;
+  const devDefaultMatch = isDev ? models.find(m => m.id === DEV_DEFAULT_MODEL_ID) : undefined;
+  const fallback = orgDefaultMatch ?? devDefaultMatch ?? models[0];
+  if (serverMatch) {
+    return { model: serverMatch.id, variant: pickVariant(serverMatch, lastSelected?.variant) };
+  }
+  if (localEntry) {
+    return localEntry;
+  }
+  if (fallback) {
+    return { model: fallback.id, variant: pickVariant(fallback, undefined) };
+  }
+  return null;
+}

--- a/apps/mobile/src/lib/hooks/auto-select-model.ts
+++ b/apps/mobile/src/lib/hooks/auto-select-model.ts
@@ -24,19 +24,22 @@ export type AutoSelectInput = {
 };
 
 /**
- * Pick the new-session model. Override priority: server lastSelected, then local
- * persisted preference, then org default. In dev builds only, `kilo-auto/efficient`
- * slots in above the bare catalog fallback (never above an explicit override).
+ * Pick the new-session model. In dev builds, `kilo-auto/efficient` wins over every
+ * override when the catalog holds it. Otherwise the priority is server lastSelected,
+ * then local persisted preference, then org default, then the first catalog entry.
  */
 export function pickAutoSelectedModel(
   input: AutoSelectInput
 ): { model: string; variant: string } | null {
   const { models, lastSelected, stored, organizationId, orgDefaultModel, isDev } = input;
+  const devDefaultMatch = isDev ? models.find(m => m.id === DEV_DEFAULT_MODEL_ID) : undefined;
+  if (devDefaultMatch) {
+    return { model: devDefaultMatch.id, variant: pickVariant(devDefaultMatch, undefined) };
+  }
   const serverMatch = lastSelected ? models.find(m => m.id === lastSelected.model) : undefined;
   const localEntry = resolveModelForContext(stored, contextKey(organizationId), models);
   const orgDefaultMatch = orgDefaultModel ? models.find(m => m.id === orgDefaultModel) : undefined;
-  const devDefaultMatch = isDev ? models.find(m => m.id === DEV_DEFAULT_MODEL_ID) : undefined;
-  const fallback = orgDefaultMatch ?? devDefaultMatch ?? models[0];
+  const fallback = orgDefaultMatch ?? models[0];
   if (serverMatch) {
     return { model: serverMatch.id, variant: pickVariant(serverMatch, lastSelected?.variant) };
   }

--- a/apps/mobile/src/lib/hooks/use-auto-select-model.ts
+++ b/apps/mobile/src/lib/hooks/use-auto-select-model.ts
@@ -1,16 +1,9 @@
 import { useRef } from 'react';
 
-import { contextKey, resolveModelForContext } from '@/lib/hooks/agent-model-preference';
+import { pickAutoSelectedModel } from '@/lib/hooks/auto-select-model';
 import { type ModelOption, useOrgDefaultModel } from '@/lib/hooks/use-available-models';
 import { useModelPreferences } from '@/lib/hooks/use-model-preferences';
 import { usePersistedAgentModel } from '@/lib/hooks/use-persisted-agent-model';
-
-function pickVariant(model: ModelOption, preferredVariant: string | undefined): string {
-  if (preferredVariant && model.variants.includes(preferredVariant)) {
-    return preferredVariant;
-  }
-  return model.variants[0] ?? '';
-}
 
 const NO_SELECTION = { model: '', variant: '' };
 
@@ -32,21 +25,17 @@ export function useAutoSelectModel(
   if (isLoading || orgDefaultIsLoading || !hasLoaded || models.length === 0) {
     return NO_SELECTION;
   }
-  const serverMatch = lastSelected ? models.find(m => m.id === lastSelected.model) : undefined;
-  const localEntry = resolveModelForContext(stored, contextKey(organizationId), models);
-  const orgDefaultMatch = orgDefaultModel ? models.find(m => m.id === orgDefaultModel) : undefined;
-  const fallback = orgDefaultMatch ?? models[0];
-  if (serverMatch) {
-    chosenRef.current = {
-      model: serverMatch.id,
-      variant: pickVariant(serverMatch, lastSelected?.variant),
-    };
-  } else if (localEntry) {
-    chosenRef.current = localEntry;
-  } else if (fallback) {
-    chosenRef.current = { model: fallback.id, variant: pickVariant(fallback, undefined) };
-  } else {
+  const picked = pickAutoSelectedModel({
+    models,
+    lastSelected,
+    stored,
+    organizationId,
+    orgDefaultModel,
+    isDev: __DEV__,
+  });
+  if (!picked) {
     return NO_SELECTION;
   }
+  chosenRef.current = picked;
   return chosenRef.current;
 }


### PR DESCRIPTION
## Summary

- In development builds, always select `kilo-auto/efficient` for a new mobile session.
- The dev default wins over the server preference, the local preference, and the organization default.
- Release builds keep the current selection priority.
- Add pure unit coverage for the full selection priority.

## Why

Development sessions need one stable efficient model. A stale preference from an earlier
session must not change the dev default. Release builds must not change at all.

## How

- Extract the selection priority into a pure function, `pickAutoSelectedModel`.
- Return `kilo-auto/efficient` first when `__DEV__` is true and the catalog holds the model.
- If the catalog does not hold the model, fall back to the release priority: server
  `lastSelected`, then the local persisted preference, then the organization default, then
  the first catalog entry.
- Keep the existing hook loading gate and selection latch.

## Verification

- `pnpm test` from `apps/mobile` — passed, 330 files and 3041 tests.
- `pnpm typecheck` from `apps/mobile` — passed.
- `pnpm lint` from `apps/mobile` — passed.

## E2E

Bot E2E verification uses an iOS development build and checks the fresh new-session picker.

## Visual Changes

N/A — this change alters the selected model, not the picker layout.
