### PR TITLE
fix(permission): support interactive skill shell replies

### DIFF
--- a/apps/mobile/src/components/agents/permission-card.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/permission-card.mounted.test.tsx
@@ -1,0 +1,89 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as reasoning-part-renderer.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { PermissionCard } from './permission-card';
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  ScrollView: 'ScrollView',
+  View: 'View',
+}));
+vi.mock('expo-haptics', () => ({
+  impactAsync: vi.fn(),
+  ImpactFeedbackStyle: { Light: 'light' },
+}));
+vi.mock('@/components/ui/button', () => ({
+  Button: 'Button',
+}));
+vi.mock('@/components/ui/text', () => ({
+  Text: 'Text',
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({}),
+}));
+vi.mock('@/lib/a11y/announce', () => ({
+  announceForA11y: vi.fn(),
+  moveA11yFocus: vi.fn(),
+}));
+
+function findByAccessibilityLabel(
+  root: TestRenderer.ReactTestInstance,
+  label: string
+): TestRenderer.ReactTestInstance[] {
+  return root.findAll(node => node.props.accessibilityLabel === label);
+}
+
+async function renderCard(metadata: Record<string, unknown> | undefined) {
+  const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+    current: undefined,
+  };
+  await act(async () => {
+    await Promise.resolve();
+    rendererRef.current = TestRenderer.create(
+      createElement(PermissionCard, {
+        permission: 'bash',
+        patterns: [],
+        metadata,
+        onRespond: () => undefined,
+        requestId: 'perm-req-1',
+      })
+    );
+  });
+  const renderer = rendererRef.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+describe('PermissionCard mounted', () => {
+  it('hides Always allow for a skillShell request and keeps Allow once and Deny', async () => {
+    const renderer = await renderCard({
+      skillShell: true,
+      skill: 'e2e',
+      commands: ['echo hi'],
+    });
+
+    expect(findByAccessibilityLabel(renderer.root, 'Always allow')).toHaveLength(0);
+    expect(findByAccessibilityLabel(renderer.root, 'Allow once')).toHaveLength(1);
+    expect(findByAccessibilityLabel(renderer.root, 'Deny permission')).toHaveLength(1);
+  });
+
+  it('keeps Always allow when metadata is undefined', async () => {
+    const renderer = await renderCard(undefined);
+
+    expect(findByAccessibilityLabel(renderer.root, 'Always allow')).toHaveLength(1);
+    expect(findByAccessibilityLabel(renderer.root, 'Allow once')).toHaveLength(1);
+    expect(findByAccessibilityLabel(renderer.root, 'Deny permission')).toHaveLength(1);
+  });
+
+  it('keeps Always allow when metadata is empty', async () => {
+    const renderer = await renderCard({});
+
+    expect(findByAccessibilityLabel(renderer.root, 'Always allow')).toHaveLength(1);
+    expect(findByAccessibilityLabel(renderer.root, 'Allow once')).toHaveLength(1);
+    expect(findByAccessibilityLabel(renderer.root, 'Deny permission')).toHaveLength(1);
+  });
+});

--- a/apps/mobile/src/components/agents/permission-card.tsx
+++ b/apps/mobile/src/components/agents/permission-card.tsx
@@ -91,6 +91,10 @@ export function PermissionCard({
   const title = formatBlockingCardTitle('Permission required', pendingCount);
   const isInert = presentation.state === 'non-retryable';
 
+  // Skill-shell batches accept only once/reject (CLI/TUI show no persist option);
+  // never offer Always Allow for them.
+  const isSkillShell = metadata?.skillShell === true;
+
   return (
     <View className="mx-4 my-2 shrink overflow-hidden rounded-xl border border-border bg-card">
       <View className="border-b border-border bg-secondary px-4 py-3">
@@ -179,29 +183,31 @@ export function PermissionCard({
                   </Text>
                 )}
               </Button>
-              <Button
-                size="sm"
-                className="flex-1"
-                onPress={() => {
-                  handleRespond('always');
-                }}
-                disabled={isSubmitting || isInert}
-                accessibilityRole="button"
-                accessibilityLabel="Always allow"
-              >
-                {activeResponse === 'always' && isSubmitting ? (
-                  <ActivityIndicator size="small" color={colors.primaryForeground} />
-                ) : (
-                  <Text
-                    className={cn(
-                      'text-xs text-primary-foreground',
-                      activeResponse === 'always' && 'font-medium'
-                    )}
-                  >
-                    Always Allow
-                  </Text>
-                )}
-              </Button>
+              {!isSkillShell ? (
+                <Button
+                  size="sm"
+                  className="flex-1"
+                  onPress={() => {
+                    handleRespond('always');
+                  }}
+                  disabled={isSubmitting || isInert}
+                  accessibilityRole="button"
+                  accessibilityLabel="Always allow"
+                >
+                  {activeResponse === 'always' && isSubmitting ? (
+                    <ActivityIndicator size="small" color={colors.primaryForeground} />
+                  ) : (
+                    <Text
+                      className={cn(
+                        'text-xs text-primary-foreground',
+                        activeResponse === 'always' && 'font-medium'
+                      )}
+                    >
+                      Always Allow
+                    </Text>
+                  )}
+                </Button>
+              ) : null}
             </>
           ) : null}
           {presentation.hasRetryCta ? (

--- a/packages/cloud-agent-sdk/src/cli-live-transport.test.ts
+++ b/packages/cloud-agent-sdk/src/cli-live-transport.test.ts
@@ -1240,7 +1240,19 @@ describe('CliLiveTransport unified user web connection', () => {
       'respondToPermission',
       () => ({ requestId: 'p-1', response: 'always' }),
       'permission_respond',
-      { requestID: 'p-1', reply: 'always' },
+      { requestID: 'p-1', reply: 'always', interactive: true },
+    ],
+    [
+      'respondToPermission',
+      () => ({ requestId: 'p-2', response: 'once' }),
+      'permission_respond',
+      { requestID: 'p-2', reply: 'once', interactive: true },
+    ],
+    [
+      'respondToPermission',
+      () => ({ requestId: 'p-3', response: 'reject' }),
+      'permission_respond',
+      { requestID: 'p-3', reply: 'reject', interactive: true },
     ],
     [
       'acceptSuggestion',

--- a/packages/cloud-agent-sdk/src/cli-live-transport.ts
+++ b/packages/cloud-agent-sdk/src/cli-live-transport.ts
@@ -977,10 +977,14 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         sendCommand('question_reject', {
           requestID: payload.requestId,
         }),
+      // Human reply from the app UI: mark it interactive so the CLI's skill-shell
+      // gate accepts approvals (VS Code does the same for every human reply).
+      // Old CLIs zod-strip the unknown key, so this is safe for every CLI version.
       respondToPermission: payload =>
         sendCommand('permission_respond', {
           requestID: payload.requestId,
           reply: payload.response,
+          interactive: true,
         }),
       acceptSuggestion: payload =>
         sendCommand('suggestion_accept', {

--- a/services/cloud-agent-next/test/unit/wrapper/server.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/server.test.ts
@@ -245,7 +245,87 @@ describe('createAnswerPermissionHandler', () => {
 
     expect(response.status).toBe(200);
     expect(data).toEqual({ status: 'answered', success: true });
-    expect(deps.kiloClient.answerPermission).toHaveBeenCalledWith('perm_1', 'always');
+    expect(deps.kiloClient.answerPermission).toHaveBeenCalledWith(
+      'perm_1',
+      'always',
+      undefined,
+      true
+    );
+  });
+
+  it('forwards the response with no message as interactive', async () => {
+    const state = new WrapperState();
+    state.bindSession({
+      kiloSessionId: 'kilo_sess_1',
+      ingestUrl: 'wss://ingest.example.com',
+      ingestToken: 'token',
+      workerAuthToken: 'auth',
+    });
+    const deps = createMockDeps(state);
+    const handler = createAnswerPermissionHandler(deps);
+
+    const response = await handler(jsonRequest({ permissionId: 'perm_2', response: 'once' }));
+    const data = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ status: 'answered', success: true });
+    expect(deps.kiloClient.answerPermission).toHaveBeenCalledWith(
+      'perm_2',
+      'once',
+      undefined,
+      true
+    );
+  });
+
+  it('threads an optional rejection message through the interactive reply', async () => {
+    const state = new WrapperState();
+    state.bindSession({
+      kiloSessionId: 'kilo_sess_1',
+      ingestUrl: 'wss://ingest.example.com',
+      ingestToken: 'token',
+      workerAuthToken: 'auth',
+    });
+    const deps = createMockDeps(state);
+    const handler = createAnswerPermissionHandler(deps);
+
+    const response = await handler(
+      jsonRequest({ permissionId: 'perm_3', response: 'reject', message: 'no' })
+    );
+    const data = await readJson(response);
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ status: 'answered', success: true });
+    expect(deps.kiloClient.answerPermission).toHaveBeenCalledWith('perm_3', 'reject', 'no', true);
+  });
+
+  it('returns PERMISSION_ERROR when the kilo reply fails', async () => {
+    const state = new WrapperState();
+    state.bindSession({
+      kiloSessionId: 'kilo_sess_1',
+      ingestUrl: 'wss://ingest.example.com',
+      ingestToken: 'token',
+      workerAuthToken: 'auth',
+    });
+    const deps = createMockDeps(state);
+    deps.kiloClient.answerPermission = vi
+      .fn()
+      .mockRejectedValue(new Error('Permission reply perm_4 failed: HTTP 500'));
+    const handler = createAnswerPermissionHandler(deps);
+
+    const response = await handler(jsonRequest({ permissionId: 'perm_4', response: 'once' }));
+    const data = await readJson(response);
+
+    expect(response.status).toBe(500);
+    expect(data).toEqual({
+      error: 'PERMISSION_ERROR',
+      message: 'Failed to answer permission: Permission reply perm_4 failed: HTTP 500',
+    });
+    expect(deps.kiloClient.answerPermission).toHaveBeenCalledWith(
+      'perm_4',
+      'once',
+      undefined,
+      true
+    );
   });
 });
 

--- a/services/cloud-agent-next/wrapper/src/kilo-api.test.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.test.ts
@@ -1,5 +1,6 @@
-import { describe, expect, it } from 'bun:test';
-import { isKiloServerUnreachableError } from './kilo-api';
+import { afterEach, describe, expect, it } from 'bun:test';
+import type { KiloClient as SDKClient } from '@kilocode/sdk';
+import { createWrapperKiloClient, isKiloServerUnreachableError } from './kilo-api';
 
 describe('isKiloServerUnreachableError', () => {
   it('matches a raw ECONNREFUSED error', () => {
@@ -92,5 +93,98 @@ describe('isKiloServerUnreachableError', () => {
     expect(isKiloServerUnreachableError('ECONNREFUSED')).toBe(false);
     expect(isKiloServerUnreachableError(undefined)).toBe(false);
     expect(isKiloServerUnreachableError(null)).toBe(false);
+  });
+});
+
+describe('createWrapperKiloClient().answerPermission', () => {
+  type RecordedRequest = {
+    method: string;
+    pathname: string;
+    body: Record<string, unknown>;
+  };
+
+  const startedServers: ReturnType<typeof Bun.serve>[] = [];
+
+  afterEach(async () => {
+    await Promise.all(startedServers.splice(0).map(server => server.stop()));
+  });
+
+  async function startStub(status: number): Promise<{ url: string; requests: RecordedRequest[] }> {
+    const requests: RecordedRequest[] = [];
+    const server = Bun.serve({
+      port: 0,
+      fetch: async req => {
+        const url = new URL(req.url);
+        requests.push({
+          method: req.method,
+          pathname: url.pathname,
+          body: (await req.json()) as Record<string, unknown>,
+        });
+        return new Response('{}', { status });
+      },
+    });
+    startedServers.push(server);
+    // Bun 1.3.14 exposes `server.url` as a URL object; normalize to a string.
+    return { url: server.url.toString(), requests };
+  }
+
+  function createClient(serverUrl: string) {
+    return createWrapperKiloClient({} as SDKClient, serverUrl, '/workspace');
+  }
+
+  it('POSTs an interactive reply to /permission/<id>/reply on a trailing-slash URL', async () => {
+    const stub = await startStub(200);
+    const client = createClient(stub.url);
+
+    const result = await client.answerPermission('perm_1', 'once', undefined, true);
+    expect(result).toBe(true);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].method).toBe('POST');
+    expect(stub.requests[0].pathname).toBe('/permission/perm_1/reply');
+    expect(stub.requests[0].body).toEqual({ reply: 'once', interactive: true });
+  });
+
+  it('omits interactive and message for the non-interactive auto-approve shape', async () => {
+    const stub = await startStub(200);
+    const client = createClient(stub.url);
+
+    const result = await client.answerPermission('perm_2', 'always');
+    expect(result).toBe(true);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].method).toBe('POST');
+    expect(stub.requests[0].pathname).toBe('/permission/perm_2/reply');
+    expect(stub.requests[0].body).toEqual({ reply: 'always' });
+  });
+
+  it('threads the message through an interactive reply on a stripped URL', async () => {
+    const stub = await startStub(200);
+    const client = createClient(stub.url.replace(/\/+$/, ''));
+
+    const result = await client.answerPermission('perm_3', 'reject', 'continue read-only', true);
+    expect(result).toBe(true);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].method).toBe('POST');
+    expect(stub.requests[0].pathname).toBe('/permission/perm_3/reply');
+    expect(stub.requests[0].body).toEqual({
+      reply: 'reject',
+      message: 'continue read-only',
+      interactive: true,
+    });
+  });
+
+  it('throws on a non-2xx reply', async () => {
+    const stub = await startStub(500);
+    const client = createClient(stub.url.replace(/\/+$/, ''));
+
+    let caught: Error | undefined;
+    try {
+      await client.answerPermission('perm_4', 'once', undefined, true);
+    } catch (error) {
+      caught = error as Error;
+    }
+    expect(caught?.message).toMatch(/Permission reply perm_4 failed/);
+    expect(stub.requests).toHaveLength(1);
+    expect(stub.requests[0].method).toBe('POST');
+    expect(stub.requests[0].pathname).toBe('/permission/perm_4/reply');
   });
 });

--- a/services/cloud-agent-next/wrapper/src/kilo-api.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.ts
@@ -3,10 +3,11 @@
  *
  * Provides a stable `WrapperKiloClient` interface that all wrapper modules use.
  * Session methods use the v1 SDK client (passed in from main.ts, which uses
- * createKilo() from the root @kilocode/sdk). Global event subscription and
- * methods only available in the v2 API (permission reply, question
- * reply/reject, commit message) use a v2 client created internally from the
- * same server URL.
+ * createKilo() from the root @kilocode/sdk). Global event subscription,
+ * question reply/reject, and commit message use a v2 client created
+ * internally from the same server URL. Permission reply POSTs
+ * /permission/{id}/reply directly so it can carry `interactive` — the pinned
+ * SDK client strips unknown body keys.
  *
  * The raw SDK client is not exposed on the returned interface — all access
  * goes through named methods.
@@ -260,7 +261,8 @@ export type WrapperKiloClient = {
   answerPermission: (
     permissionId: string,
     response: PermissionResponse,
-    message?: string
+    message?: string,
+    interactive?: boolean
   ) => Promise<boolean>;
   answerQuestion: (questionId: string, answers: string[][]) => Promise<boolean>;
   rejectQuestion: (questionId: string) => Promise<boolean>;
@@ -442,8 +444,28 @@ export function createWrapperKiloClient(
       return commands;
     },
 
-    answerPermission: async (permissionId, response, message) => {
-      await v2Client.permission.reply({ requestID: permissionId, reply: response, message });
+    answerPermission: async (permissionId, response, message, interactive) => {
+      // The pinned @kilocode/sdk 7.3.54 client whitelists body keys at runtime and
+      // would silently drop `interactive` (needs SDK >= 7.4.19). POST directly: old
+      // kilo servers ignore the unknown body key; >= 7.4.18 requires it to accept a
+      // human skill-shell approval.
+      const res = await fetch(
+        // `serverUrl` is passed through from the bootstrap; strip trailing slashes so
+        // both `http://host:port` and `http://host:port/` join to the same path.
+        `${serverUrl.replace(/\/+$/, '')}/permission/${encodeURIComponent(permissionId)}/reply`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            reply: response,
+            ...(message !== undefined ? { message } : {}),
+            ...(interactive === true ? { interactive: true } : {}),
+          }),
+        }
+      );
+      if (!res.ok) {
+        throw new Error(`Permission reply ${permissionId} failed: HTTP ${res.status}`);
+      }
       return true;
     },
 

--- a/services/cloud-agent-next/wrapper/src/server.ts
+++ b/services/cloud-agent-next/wrapper/src/server.ts
@@ -696,10 +696,15 @@ export function createAnswerPermissionHandler(deps: ServerDependencies) {
     }
 
     try {
-      const success =
-        body.message === undefined
-          ? await kiloClient.answerPermission(body.permissionId, body.response)
-          : await kiloClient.answerPermission(body.permissionId, body.response, body.message);
+      // Every caller of this endpoint is a human tap in a client UI, so the reply is
+      // always interactive (skill-shell approvals require it). The wrapper's own
+      // auto-approve path calls kiloClient.answerPermission directly and omits the flag.
+      const success = await kiloClient.answerPermission(
+        body.permissionId,
+        body.response,
+        body.message,
+        true
+      );
       state.updateActivity();
       logToFile(
         `job/answer-permission: permissionId=${body.permissionId} response=${body.response}`


### PR DESCRIPTION
## Summary

- Mark remote CLI permission replies as interactive so skill-shell approvals resolve.
- Send wrapper permission replies directly and forward the interactive marker for human UI replies.
- Hide Always Allow for mobile skill-shell permission cards.

## Why

The skill-shell server gate rejects approval replies without `interactive: true`. The pinned wrapper SDK strips that field, and mobile offered an unsupported Always Allow action.

## How

- Add the marker to the cloud-agent SDK wire command.
- Post wrapper replies to the permission endpoint and surface non-2xx responses.
- Pass the marker from the human permission endpoint while preserving automated callers.
- Add SDK, wrapper, service, and mobile tests.

## Verification

- Cloud-agent SDK tests and typecheck passed.
- Cloud-agent service tests, wrapper tests, typecheck, and lint passed.
- Mobile focused tests, typecheck, lint, and unused checks passed.
- Bot E2E ran on iOS and verified the live skill-shell card omitted `Always allow` after the trusted fixture was loaded. The final marker execution was blocked by the local shell permission rule after an external-directory recovery; no product edit was made from that environment evidence.

## E2E

Bot E2E ran on iOS. The cloud-agent wrapper path has no live E2E because its sandbox CLI is pinned at 7.3.54 and predates the skill-shell gate; Changes 3–5 have unit coverage.

## Visual Changes

N/A.
