### PR TITLE
Add models.dev reasoning variants to gateway models

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -6,23 +6,19 @@ import {
 import type { DirectUserByokInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { redisClient } from '@/lib/redis';
 import { directByokModelsRedisKey } from '@/lib/redis-keys';
+import { VerbositySchema, type OpenCodeSettings } from '@kilocode/db/schema-types';
+import { getAiSdkProvider, getModelVariants } from '@/lib/ai-gateway/providers/model-settings';
 import {
-  ReasoningEffortSchema,
-  VerbositySchema,
-  type OpenCodeSettings,
-} from '@kilocode/db/schema-types';
-import {
-  getAiSdkProvider,
-  getModelVariants,
-  REASONING_VARIANTS_BINARY,
-} from '@/lib/ai-gateway/providers/model-settings';
+  fetchModelsDevCatalog,
+  ModelsDevModalitySchema,
+  modelsDevReasoningOptionsToVariants,
+  parseModelsDevProvider,
+  type ModelsDevCatalog,
+  type ModelsDevModality,
+} from '@/lib/ai-gateway/providers/models-dev';
 
 const DEFAULT_CONTENT_LENGTH = 200_000;
 const DEFAULT_MAX_COMPLETION_TOKENS = 32_000;
-
-const ModalitySchema = z
-  .enum(['text', 'image', 'video', 'pdf', 'audio', 'unknown'])
-  .catch('unknown');
 
 const OpenAICompatibleModelsResponseSchema = z.object({
   data: z.array(
@@ -32,55 +28,18 @@ const OpenAICompatibleModelsResponseSchema = z.object({
       context_length: z.number().optional(),
       max_model_len: z.number().optional(),
       max_output_length: z.number().optional(),
-      input_modalities: z.array(ModalitySchema).optional(),
+      input_modalities: z.array(ModelsDevModalitySchema).optional(),
       supported_features: z.array(z.string()).optional(),
     })
   ),
 });
-
-const ModelsDevReasoningOptionSchema = z.discriminatedUnion('type', [
-  z.object({ type: z.literal('toggle') }),
-  z.object({
-    type: z.literal('effort'),
-    values: z.array(z.union([z.null(), ReasoningEffortSchema, z.literal('default')])),
-  }),
-]);
-
-const ModelsDevModelSchema = z.object({
-  id: z.string(),
-  name: z.string().optional(),
-  reasoning: z.boolean().optional(),
-  reasoning_options: z.array(ModelsDevReasoningOptionSchema).optional().catch(undefined),
-  status: z.enum(['alpha', 'beta', 'deprecated']).optional().catch(undefined),
-  limit: z
-    .object({
-      context: z.number().optional(),
-      output: z.number().optional(),
-    })
-    .optional(),
-  modalities: z
-    .object({
-      input: z.array(ModalitySchema).optional(),
-      output: z.array(ModalitySchema).optional(),
-    })
-    .optional(),
-  tool_call: z.boolean().optional(),
-});
-
-const ModelsDevProviderSchema = z.object({
-  models: z.record(z.string(), ModelsDevModelSchema),
-});
-
-const ModelsDevCatalogSchema = z.record(z.string(), z.unknown());
-
-type ModelsDevCatalog = z.infer<typeof ModelsDevCatalogSchema>;
 
 type RawModel = {
   id: string;
   name?: string;
   context_length?: number;
   max_completion_tokens?: number;
-  input_modalities?: ReadonlyArray<z.infer<typeof ModalitySchema>>;
+  input_modalities?: ReadonlyArray<ModelsDevModality>;
   flags?: ReadonlyArray<DirectByokModelFlag>;
   variants?: OpenCodeSettings['variants'];
 };
@@ -135,33 +94,6 @@ export function parseOpenAICompatibleProviderModels(entry: unknown): RawModel[] 
     }));
 }
 
-function modelsDevReasoningOptionsToVariants(
-  options: ReadonlyArray<z.infer<typeof ModelsDevReasoningOptionSchema>>
-): OpenCodeSettings['variants'] {
-  const hasToggle = options.some(option => option.type === 'toggle');
-  const effortVariants: NonNullable<OpenCodeSettings['variants']> = {};
-  for (const option of options) {
-    if (option.type !== 'effort') continue;
-    for (const value of option.values) {
-      const effort = ReasoningEffortSchema.safeParse(value);
-      if (!effort.success) continue;
-      effortVariants[effort.data] = {
-        reasoning: { enabled: effort.data !== 'none', effort: effort.data },
-      };
-    }
-  }
-
-  if (Object.keys(effortVariants).length > 0) {
-    return hasToggle && !effortVariants.none
-      ? { none: { reasoning: { enabled: false, effort: 'none' } }, ...effortVariants }
-      : effortVariants;
-  }
-  if (hasToggle) {
-    return REASONING_VARIANTS_BINARY;
-  }
-  return undefined;
-}
-
 function addAnthropicVariantVerbosity(
   variants: OpenCodeSettings['variants'],
   aiSdkProvider: OpenCodeSettings['ai_sdk_provider']
@@ -181,7 +113,7 @@ export function parseModelsDevProviderModels(
   providerId: DirectUserByokInferenceProviderId,
   availableModelIds?: ReadonlySet<string>
 ): RawModel[] {
-  const provider = ModelsDevProviderSchema.parse(entry);
+  const provider = parseModelsDevProvider(entry);
   return Object.values(provider.models)
     .filter(
       model =>
@@ -239,16 +171,6 @@ function modelsDevFetcher(
       return parseModelsDevProviderModels(entry, providerId, availableModelIds);
     },
   };
-}
-
-async function fetchModelsDevCatalog(): Promise<ModelsDevCatalog> {
-  const response = await fetch('https://models.dev/api.json');
-  if (!response.ok) {
-    throw new Error(
-      `Failed to fetch models.dev catalog: ${response.status} ${response.statusText}`
-    );
-  }
-  return ModelsDevCatalogSchema.parse(await response.json());
 }
 
 const FETCHERS: ReadonlyArray<ProviderFetcher> = [
@@ -328,10 +250,10 @@ async function syncProvider(fetcher: ProviderFetcher, ctx: SyncContext): Promise
   return models.length;
 }
 
-export async function syncDirectByokModels(): Promise<
-  Partial<Record<DirectUserByokInferenceProviderId, number>>
-> {
-  let catalogPromise: Promise<ModelsDevCatalog> | null = null;
+export async function syncDirectByokModels(
+  sharedModelsDevCatalog?: Promise<ModelsDevCatalog>
+): Promise<Partial<Record<DirectUserByokInferenceProviderId, number>>> {
+  let catalogPromise: Promise<ModelsDevCatalog> | null = sharedModelsDevCatalog ?? null;
   const ctx: SyncContext = {
     getModelsDevCatalog() {
       catalogPromise ??= fetchModelsDevCatalog();

--- a/apps/web/src/lib/ai-gateway/providers/models-dev.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/models-dev.test.ts
@@ -1,0 +1,69 @@
+import {
+  getModelsDevProvider,
+  modelsDevReasoningOptionsToVariants,
+} from '@/lib/ai-gateway/providers/models-dev';
+import { StoredModelSchema } from '@kilocode/db/schema-types';
+
+describe('models.dev metadata', () => {
+  test('uses provider-specific reasoning options for duplicate model ids', () => {
+    const catalog = {
+      openrouter: {
+        models: {
+          'provider/model': {
+            id: 'provider/model',
+            reasoning_options: [{ type: 'effort', values: ['high', 'xhigh'] }],
+          },
+        },
+      },
+      vercel: {
+        models: {
+          'provider/model': {
+            id: 'provider/model',
+            reasoning_options: [{ type: 'toggle' }, { type: 'effort', values: ['high', 'xhigh'] }],
+          },
+        },
+      },
+    };
+
+    const openRouterModel = getModelsDevProvider(catalog, 'openrouter').models['provider/model'];
+    const vercelModel = getModelsDevProvider(catalog, 'vercel').models['provider/model'];
+
+    expect(modelsDevReasoningOptionsToVariants(openRouterModel.reasoning_options ?? [])).toEqual({
+      high: { reasoning: { enabled: true, effort: 'high' } },
+      xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
+    });
+    expect(modelsDevReasoningOptionsToVariants(vercelModel.reasoning_options ?? [])).toEqual({
+      none: { reasoning: { enabled: false, effort: 'none' } },
+      high: { reasoning: { enabled: true, effort: 'high' } },
+      xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
+    });
+  });
+
+  test('ignores unsupported options without discarding supported options', () => {
+    expect(
+      modelsDevReasoningOptionsToVariants([
+        { type: 'toggle' },
+        { type: 'budget_tokens', min: 0, max: 32_000 },
+      ])
+    ).toEqual({
+      instant: { reasoning: { enabled: false, effort: 'none' } },
+      thinking: { reasoning: { enabled: true, effort: 'high' } },
+    });
+  });
+
+  test('keeps StoredModel variants optional and validates persisted variants', () => {
+    const model = {
+      id: 'provider/model',
+      name: 'Model',
+      endpoints: [],
+    };
+
+    expect(StoredModelSchema.parse(model)).toEqual(model);
+    expect(
+      StoredModelSchema.parse({
+        ...model,
+        variants: { high: { reasoning: { enabled: true, effort: 'high' } } },
+      }).variants
+    ).toEqual({ high: { reasoning: { enabled: true, effort: 'high' } } });
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/models-dev.ts
+++ b/apps/web/src/lib/ai-gateway/providers/models-dev.ts
@@ -1,0 +1,98 @@
+import { ReasoningEffortSchema, type OpenCodeSettings } from '@kilocode/db/schema-types';
+import * as z from 'zod';
+import { REASONING_VARIANTS_BINARY } from '@/lib/ai-gateway/providers/model-settings';
+
+export const ModelsDevModalitySchema = z
+  .enum(['text', 'image', 'video', 'pdf', 'audio', 'unknown'])
+  .catch('unknown');
+
+const ModelsDevReasoningOptionSchema = z.discriminatedUnion('type', [
+  z.object({ type: z.literal('toggle') }),
+  z.object({
+    type: z.literal('effort'),
+    values: z.array(z.union([z.null(), ReasoningEffortSchema, z.literal('default')])),
+  }),
+]);
+
+const ModelsDevModelSchema = z.object({
+  id: z.string(),
+  name: z.string().optional(),
+  reasoning: z.boolean().optional(),
+  reasoning_options: z.array(z.unknown()).optional().catch(undefined),
+  status: z.enum(['alpha', 'beta', 'deprecated']).optional().catch(undefined),
+  limit: z
+    .object({
+      context: z.number().optional(),
+      output: z.number().optional(),
+    })
+    .optional(),
+  modalities: z
+    .object({
+      input: z.array(ModelsDevModalitySchema).optional(),
+      output: z.array(ModelsDevModalitySchema).optional(),
+    })
+    .optional(),
+  tool_call: z.boolean().optional(),
+});
+
+const ModelsDevProviderSchema = z.object({
+  models: z.record(z.string(), ModelsDevModelSchema),
+});
+
+const ModelsDevCatalogSchema = z.record(z.string(), z.unknown());
+
+export type ModelsDevCatalog = z.infer<typeof ModelsDevCatalogSchema>;
+export type ModelsDevModality = z.infer<typeof ModelsDevModalitySchema>;
+
+export function parseModelsDevProvider(entry: unknown) {
+  return ModelsDevProviderSchema.parse(entry);
+}
+
+export function getModelsDevProvider(catalog: ModelsDevCatalog, providerId: string) {
+  const entry = catalog[providerId];
+  if (!entry) {
+    throw new Error(`models.dev catalog missing ${providerId} entry`);
+  }
+  return parseModelsDevProvider(entry);
+}
+
+export function modelsDevReasoningOptionsToVariants(
+  options: ReadonlyArray<unknown>
+): OpenCodeSettings['variants'] {
+  const parsedOptions = options.flatMap(option => {
+    const parsed = ModelsDevReasoningOptionSchema.safeParse(option);
+    return parsed.success ? [parsed.data] : [];
+  });
+  const hasToggle = parsedOptions.some(option => option.type === 'toggle');
+  const effortVariants: NonNullable<OpenCodeSettings['variants']> = {};
+  for (const option of parsedOptions) {
+    if (option.type !== 'effort') continue;
+    for (const value of option.values) {
+      const effort = ReasoningEffortSchema.safeParse(value);
+      if (!effort.success) continue;
+      effortVariants[effort.data] = {
+        reasoning: { enabled: effort.data !== 'none', effort: effort.data },
+      };
+    }
+  }
+
+  if (Object.keys(effortVariants).length > 0) {
+    return hasToggle && !effortVariants.none
+      ? { none: { reasoning: { enabled: false, effort: 'none' } }, ...effortVariants }
+      : effortVariants;
+  }
+  if (hasToggle) {
+    return REASONING_VARIANTS_BINARY;
+  }
+  return undefined;
+}
+
+export async function fetchModelsDevCatalog(): Promise<ModelsDevCatalog> {
+  const response = await fetch('https://models.dev/api.json');
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch models.dev catalog: ${response.status} ${response.statusText}`
+    );
+  }
+  return ModelsDevCatalogSchema.parse(await response.json());
+}

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -46,6 +46,12 @@ import {
   getOpenRouterFreeEndpoints,
 } from '@/lib/ai-gateway/providers/openrouter/free-endpoint-data-policy';
 import { isUnavailableModel } from '@/lib/ai-gateway/unavailable-models';
+import {
+  fetchModelsDevCatalog,
+  getModelsDevProvider,
+  modelsDevReasoningOptionsToVariants,
+  type ModelsDevCatalog,
+} from '@/lib/ai-gateway/providers/models-dev';
 
 /**
  * Advisory lock key hashed from a stable identifier. Serializes concurrent
@@ -68,20 +74,27 @@ async function mirrorVercelInferenceProvidersToRedis(vercelModels: Record<string
   await pipeline.exec();
 }
 
-async function fetchGatewayModels(gateway: Provider) {
+async function fetchGatewayModels(
+  gateway: Provider,
+  modelsDevCatalogPromise: Promise<ModelsDevCatalog> = fetchModelsDevCatalog()
+) {
   const headers = {
     ...ATTRIBUTION_HEADERS,
     authorization: `Bearer ${gateway.apiKey}`,
   };
 
-  const modelsResponse = await fetch(`${gateway.apiUrl}/models`, {
-    method: 'GET',
-    headers,
-  });
+  const [modelsResponse, modelsDevCatalog] = await Promise.all([
+    fetch(`${gateway.apiUrl}/models`, {
+      method: 'GET',
+      headers,
+    }),
+    modelsDevCatalogPromise,
+  ]);
   if (!modelsResponse.ok) {
     throw new Error(`Fetching models from ${gateway.id} failed: ${modelsResponse.status}`);
   }
   const models = ModelsSchema.parse(await modelsResponse.json());
+  const modelsDevProvider = getModelsDevProvider(modelsDevCatalog, gateway.id);
 
   const limit = pLimit(8);
   const result: Record<string, StoredModel> = {};
@@ -98,9 +111,13 @@ async function fetchGatewayModels(gateway: Provider) {
           );
         }
         const endpoints = EndpointsSchema.parse(await endpointsResponse.json());
+        const variants = modelsDevReasoningOptionsToVariants(
+          modelsDevProvider.models[model.id]?.reasoning_options ?? []
+        );
         result[model.id] = {
           ...model,
           endpoints: endpoints.data.endpoints,
+          ...(variants && { variants }),
         };
       })
     )
@@ -504,8 +521,11 @@ export async function applySnapshotChangesAndAudit(params: {
 export async function syncAndStoreProviders() {
   const startTime = performance.now();
 
-  const openrouter_data = await fetchGatewayModels(PROVIDERS.OPENROUTER);
-  const vercel_data = await fetchGatewayModels(PROVIDERS.VERCEL_AI_GATEWAY);
+  const modelsDevCatalogPromise = fetchModelsDevCatalog();
+  const [openrouter_data, vercel_data] = await Promise.all([
+    fetchGatewayModels(PROVIDERS.OPENROUTER, modelsDevCatalogPromise),
+    fetchGatewayModels(PROVIDERS.VERCEL_AI_GATEWAY, modelsDevCatalogPromise),
+  ]);
 
   const openrouterProviders = await fetchProviders();
   if (openrouterProviders.length < 10) {
@@ -537,7 +557,7 @@ export async function syncAndStoreProviders() {
     openrouterProviders,
   });
 
-  const direct_byok_model_counts = await syncDirectByokModels();
+  const direct_byok_model_counts = await syncDirectByokModels(modelsDevCatalogPromise);
   console.log('[syncAndStoreProviders] direct-byok model counts:', direct_byok_model_counts);
 
   return {

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -2057,6 +2057,7 @@ export const EndpointsSchema = z.object({
 export const StoredModelSchema = ModelSchema.and(
   z.object({
     endpoints: z.array(EndpointSchema),
+    variants: OpenCodeSettingsSchema.shape.variants,
   })
 );
 


### PR DESCRIPTION
## Summary
- share models.dev validation and reasoning-option conversion with direct BYOK syncs
- enrich OpenRouter and Vercel StoredModel snapshots with provider-specific variants
- preserve unsupported reasoning options individually and validate persisted variants

## Verification
- `pnpm --filter web test -- --runInBand apps/web/src/lib/ai-gateway/providers/models-dev.test.ts apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/models-dev.ts apps/web/src/lib/ai-gateway/providers/models-dev.test.ts apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts packages/db/src/schema-types.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter @kilocode/db typecheck`