### PR TITLE
chore(ai-gateway): stop writing unused model catalogs

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -407,8 +407,6 @@ async function syncProviders(
   return result;
 }
 
-const MODEL_METADATA_REDIS_TTL_SECONDS = 7 * 24 * 60 * 60;
-
 async function mirrorToRedis(values: {
   providers: NormalizedOpenRouterResponse;
   openrouter: Record<string, StoredModel>;
@@ -417,8 +415,6 @@ async function mirrorToRedis(values: {
 }): Promise<void> {
   const entries: [RedisKey, unknown][] = [
     [GATEWAY_METADATA_REDIS_KEYS.allProviders, values.providers],
-    [GATEWAY_METADATA_REDIS_KEYS.openrouterModels, values.openrouter],
-    [GATEWAY_METADATA_REDIS_KEYS.vercelModels, values.vercel],
     [GATEWAY_METADATA_REDIS_KEYS.openrouterModelIds, getLanguageModelIds(values.openrouter)],
     [GATEWAY_METADATA_REDIS_KEYS.vercelModelIds, getLanguageModelIds(values.vercel)],
   ];
@@ -428,12 +424,6 @@ async function mirrorToRedis(values: {
   await Promise.all([
     ...entries.map(([key, value]) => {
       const serializedValue = JSON.stringify(value);
-      if (
-        key === GATEWAY_METADATA_REDIS_KEYS.openrouterModels ||
-        key === GATEWAY_METADATA_REDIS_KEYS.vercelModels
-      ) {
-        return redisClient.set(key, serializedValue, { ex: MODEL_METADATA_REDIS_TTL_SECONDS });
-      }
       return redisClient.set(key, serializedValue);
     }),
     mirrorVercelInferenceProvidersToRedis(values.vercel),

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -21,11 +21,8 @@ export const VERCEL_ROUTING_REDIS_KEY = redisKey('ai-gateway:vercel-routing-perc
 
 export const GATEWAY_METADATA_REDIS_KEYS = {
   allProviders: redisKey('ai-gateway.metadata:all-providers'),
-  openrouterModels: redisKey('ai-gateway.metadata:openrouter-models'),
-  vercelModels: redisKey('ai-gateway.metadata:vercel-models'),
-  // Lightweight lists of language model ids, mirrored alongside the full
-  // catalogs above so existence checks don't need to load every model's
-  // metadata and endpoints.
+  // Lightweight lists of language model ids used for existence checks without
+  // loading every model's metadata and endpoints.
   openrouterModelIds: redisKey('ai-gateway.metadata:openrouter-model-ids'),
   vercelModelIds: redisKey('ai-gateway.metadata:vercel-model-ids'),
   openrouterProviders: redisKey('ai-gateway.metadata:openrouter-providers'),


### PR DESCRIPTION
The full OpenRouter and Vercel model catalog Redis keys are no longer read.

Changes:
- remove both unused Redis key definitions
- stop writing the full catalogs and their TTL branch
- preserve model ID, provider, and database snapshot synchronization

Validation:
- pnpm exec oxfmt --check apps/web/src/lib/redis-keys.ts apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
- pnpm --filter web exec jest --runInBand src/lib/redis-keys.test.ts
- pnpm --filter web run typecheck
- pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/redis-keys.ts apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
- git diff --check