### PR TITLE
feat(ai-gateway): store model reasoning metadata

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -98,8 +98,17 @@ async function fetchGatewayModels(gateway: Provider) {
           );
         }
         const endpoints = EndpointsSchema.parse(await endpointsResponse.json());
+        const { reasoning, ...modelMetadata } = model;
         result[model.id] = {
-          ...model,
+          ...modelMetadata,
+          ...(reasoning && {
+            reasoning: {
+              mandatory: reasoning.mandatory,
+              ...(reasoning.supported_efforts && {
+                supported_efforts: reasoning.supported_efforts,
+              }),
+            },
+          }),
           endpoints: endpoints.data.endpoints,
         };
       })

--- a/packages/db/src/schema-types.test.ts
+++ b/packages/db/src/schema-types.test.ts
@@ -3,7 +3,9 @@ import {
   CodeReviewCouncilConfigSchema,
   ModelsSchema,
   OrganizationSettingsSchema,
+  StoredModelSchema,
 } from './schema-types';
+import type { StoredModel } from './schema-types';
 
 describe('CodeReviewCouncilConfigSchema', () => {
   const specialist = (id: string) => ({
@@ -106,5 +108,38 @@ describe('ModelsSchema', () => {
     });
 
     expect(result.data[0].reasoning).toEqual({ mandatory: true });
+  });
+
+  it('drops invalid reasoning metadata', () => {
+    const result = ModelsSchema.parse({
+      data: [
+        {
+          id: 'example/future-effort',
+          name: 'Future Effort',
+          reasoning: {
+            mandatory: false,
+            supported_efforts: ['future'],
+          },
+        },
+      ],
+    });
+
+    expect(result.data[0].reasoning).toBeUndefined();
+  });
+});
+
+describe('StoredModelSchema', () => {
+  it('includes model reasoning metadata', () => {
+    const storedModel: StoredModel = {
+      id: 'openai/gpt-5.2',
+      name: 'OpenAI: GPT-5.2',
+      reasoning: {
+        mandatory: false,
+        supported_efforts: ['high', 'medium', 'low', 'none'],
+      },
+      endpoints: [],
+    };
+
+    expect(StoredModelSchema.parse(storedModel).reasoning).toEqual(storedModel.reasoning);
   });
 });

--- a/packages/db/src/schema-types.test.ts
+++ b/packages/db/src/schema-types.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from '@jest/globals';
-import { CodeReviewCouncilConfigSchema, OrganizationSettingsSchema } from './schema-types';
+import {
+  CodeReviewCouncilConfigSchema,
+  ModelsSchema,
+  OrganizationSettingsSchema,
+} from './schema-types';
 
 describe('CodeReviewCouncilConfigSchema', () => {
   const specialist = (id: string) => ({
@@ -64,5 +68,43 @@ describe('OrganizationSettingsSchema org_auto_model', () => {
     });
 
     expect(result.success).toBe(false);
+  });
+});
+
+describe('ModelsSchema', () => {
+  it('preserves only supported reasoning metadata', () => {
+    const result = ModelsSchema.parse({
+      data: [
+        {
+          id: 'openai/gpt-5.2',
+          name: 'OpenAI: GPT-5.2',
+          reasoning: {
+            mandatory: false,
+            supported_efforts: ['high', 'medium', 'low', 'none'],
+            default_enabled: true,
+            default_effort: 'medium',
+          },
+        },
+      ],
+    });
+
+    expect(result.data[0].reasoning).toEqual({
+      mandatory: false,
+      supported_efforts: ['high', 'medium', 'low', 'none'],
+    });
+  });
+
+  it('allows reasoning metadata without supported efforts', () => {
+    const result = ModelsSchema.parse({
+      data: [
+        {
+          id: 'google/gemini-2.5-pro',
+          name: 'Google: Gemini 2.5 Pro',
+          reasoning: { mandatory: true },
+        },
+      ],
+    });
+
+    expect(result.data[0].reasoning).toEqual({ mandatory: true });
   });
 });

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -2025,6 +2025,12 @@ export const ModelSchema = z.object({
   id: z.string(),
   name: z.string(),
   type: z.enum(['language', 'embedding', 'image']).optional().catch(undefined),
+  reasoning: z
+    .object({
+      mandatory: z.boolean(),
+      supported_efforts: z.array(z.string()).optional(),
+    })
+    .optional(),
 });
 
 export const ModelsSchema = z.object({ data: z.array(ModelSchema) });

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -2028,9 +2028,10 @@ export const ModelSchema = z.object({
   reasoning: z
     .object({
       mandatory: z.boolean(),
-      supported_efforts: z.array(z.string()).optional(),
+      supported_efforts: z.array(ReasoningEffortSchema).optional(),
     })
-    .optional(),
+    .optional()
+    .catch(undefined),
 });
 
 export const ModelsSchema = z.object({ data: z.array(ModelSchema) });


### PR DESCRIPTION
## Summary
- preserve OpenRouter model reasoning metadata during gateway model sync
- store only `mandatory` and optional `supported_efforts`, stripping unsupported response fields
- cover models with and without supported effort lists

## Validation
- `scripts/typecheck-all.sh --changes-only`
- `pnpm --filter @kilocode/db lint`
- `pnpm exec oxfmt --check packages/db/src/schema-types.ts packages/db/src/schema-types.test.ts`
- direct TypeScript parsing assertion against representative OpenRouter model data

## Testing note
- focused Jest execution was blocked because the web Jest config does not discover external `packages/db` tests from the Agent Manager worktree path