### PR TITLE
fix(ai-gateway): increase non-Laguna Auto Free weights

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -160,6 +160,17 @@ describe('isFreeModel', () => {
       }
     });
 
+    test('weights non-Laguna auto-free models higher than Laguna', () => {
+      const lagunaModel = autoFreeModels.find(({ model }) => model.includes('laguna'));
+      expect(lagunaModel?.weight).toBe(1);
+
+      for (const candidate of autoFreeModels) {
+        if (!candidate.model.includes('laguna')) {
+          expect(candidate.weight).toBe(2);
+        }
+      }
+    });
+
     test('uses autoFreeModels weights when selecting a model', () => {
       const candidates = [
         { model: 'preferred/model', weight: 3 },

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -43,9 +43,9 @@ export type AutoFreeModel = { model: string; weight: number };
 
 export const autoFreeModels = [
   ...(stepfun_37_flash_free_model.status === 'public'
-    ? [{ model: stepfun_37_flash_free_model.public_id, weight: 1 }]
+    ? [{ model: stepfun_37_flash_free_model.public_id, weight: 2 }]
     : []),
-  { model: 'inclusionai/ling-3.0-flash:free', weight: 1 },
+  { model: 'inclusionai/ling-3.0-flash:free', weight: 2 },
   { model: 'poolside/laguna-s-2.1:free', weight: 1 },
 ] satisfies ReadonlyArray<AutoFreeModel>;
 


### PR DESCRIPTION
## Summary
- increase non-Laguna Auto Free model weights from 1 to 2
- keep Laguna at weight 1
- add regression coverage for the weighting split

## Validation
- `pnpm --filter web exec jest src/lib/ai-gateway/models.test.ts --runInBand`
- `pnpm --filter web run lint`
- `pnpm --filter web run typecheck`
- `pnpm exec oxfmt --check apps/web/src/lib/ai-gateway/models.ts apps/web/src/lib/ai-gateway/models.test.ts`