### PR TITLE
fix(migrations) - Make migration idempotent

### DIFF
--- a/packages/db/src/migrations/0204_drop_cost_insight_tables.sql
+++ b/packages/db/src/migrations/0204_drop_cost_insight_tables.sql
@@ -1,12 +1,12 @@
-DROP TABLE "cost_insight_active_suggestions" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_evaluation_dirty_owners" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_events" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_hourly_sweep_checkpoints" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_notification_deliveries" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_owner_configs" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_owner_hour_driver_buckets" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_owner_hour_totals" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_owner_states" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_rollup_coverage" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_rollup_degraded_intervals" CASCADE;--> statement-breakpoint
-DROP TABLE "cost_insight_rollup_repairs" CASCADE;
+DROP TABLE IF EXISTS "cost_insight_active_suggestions" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_evaluation_dirty_owners" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_events" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_hourly_sweep_checkpoints" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_notification_deliveries" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_owner_configs" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_owner_hour_driver_buckets" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_owner_hour_totals" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_owner_states" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_rollup_coverage" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_rollup_degraded_intervals" CASCADE;--> statement-breakpoint
+DROP TABLE IF EXISTS "cost_insight_rollup_repairs" CASCADE;


### PR DESCRIPTION
I had to manually run the migration with a bunch of retries to go around the deadlocks, so the tables are now gone, but the migration  still shows up as failing, so this should fix that.
