### PR TITLE
fix(web): rename xAI display labels to SpaceXAI

### DIFF
--- a/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
+++ b/apps/web/src/components/organizations/byok/BYOKKeysManager.tsx
@@ -66,7 +66,7 @@ const VERCEL_BYOK_PROVIDER_NAMES = {
   moonshotai: 'Moonshot AI',
   novita: 'Novita',
   perplexity: 'Perplexity',
-  xai: 'xAI',
+  xai: 'SpaceXAI',
   xiaomi: 'Xiaomi (pay as you go)',
   zai: 'Z.ai (pay as you go)',
 } satisfies Record<VercelUserByokInferenceProviderId, string>;

--- a/apps/web/src/docs/network-compliance-diagram.md
+++ b/apps/web/src/docs/network-compliance-diagram.md
@@ -86,7 +86,7 @@ graph TB
         OPENROUTER[OpenRouter<br/>AI Model Gateway]
         ANTHROPIC[Anthropic<br/>Claude Models]
         OPENAI[OpenAI<br/>GPT Models]
-        XAI[xAI/Grok<br/>AI Models]
+        XAI[SpaceXAI/Grok<br/>AI Models]
     end
 
     subgraph "Payment & Billing"

--- a/apps/web/src/lib/notifications/byok-provider-cache.ts
+++ b/apps/web/src/lib/notifications/byok-provider-cache.ts
@@ -68,7 +68,7 @@ export const BYOK_PROVIDER_NOTIFICATION_LABELS: Record<string, string> = {
   novita: 'Novita AI API Key',
 
   // xAI
-  xai: 'xAI API Key',
+  xai: 'SpaceXAI API Key',
 
   // Z.ai / Zhipu (GLM)
   zai: 'GLM Coding Plan',

--- a/apps/web/src/lib/public-inference-provider.ts
+++ b/apps/web/src/lib/public-inference-provider.ts
@@ -48,7 +48,7 @@ const PROVIDER_NAMES: Record<string, string> = {
   together: 'Together AI',
   unknown: 'Unknown',
   wandb: 'Weights & Biases',
-  xai: 'xAI',
+  xai: 'SpaceXAI',
   zai: 'Z.ai',
 };
 


### PR DESCRIPTION
## Summary
- rename xAI user-facing provider labels to SpaceXAI
- keep provider IDs, model IDs, environment variables, and protocol values unchanged
- update the network compliance diagram label

## Validation
- pnpm --filter web run lint
- pnpm --filter web run typecheck
- pnpm --filter web exec jest src/lib/notifications/byok-provider-cache.test.ts --runInBand
- pnpm exec oxfmt on changed TypeScript files
- git diff --check