### PR TITLE
feat(ai-gateway): allow Responses API for OpenCode Go

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts
@@ -1,4 +1,9 @@
 import { getAiSdkProvider } from '../model-settings';
+import openCodeGo from './opencode-go';
+
+test('allows the Responses API for OpenCode Go', () => {
+  expect(openCodeGo.supported_chat_apis).toContain('responses');
+});
 
 describe('getAiSdkProvider', () => {
   test.each(['opencode-go/minimax-m3', 'opencode-go/qwen3.7-plus'])(

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.ts
@@ -4,7 +4,7 @@ import type { DirectByokProvider } from '@/lib/ai-gateway/providers/direct-byok/
 export default {
   id: 'opencode-go',
   base_url: 'https://opencode.ai/zen/go/v1',
-  supported_chat_apis: ['chat_completions', 'messages'],
+  supported_chat_apis: ['chat_completions', 'messages', 'responses'],
   default_ai_sdk_provider: 'openai-compatible',
   transformRequest(context) {
     if (context.request.kind === 'messages') {


### PR DESCRIPTION
## Summary\n- allow the Responses API for the OpenCode Go direct BYOK provider\n- add a regression test for the provider capability\n\n## Verification\n- pnpm --filter web test -- src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts --runInBand\n- pnpm --filter web typecheck\n- pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.ts apps/web/src/lib/ai-gateway/providers/direct-byok/opencode-go.test.ts