### PR TITLE
fix(mobile): keep colocated tests out of the Metro bundle

### DIFF
--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -17,6 +17,14 @@ config.resolver.nodeModulesPaths = [
   path.resolve(monorepoRoot, 'node_modules'),
 ];
 
+// Keep colocated tests out of the app bundle. Expo Router's require.context matches
+// every `.tsx` under `src/app`, so a `*.test.tsx` next to a route registers as a route
+// and drags vitest (and vite) into the bundle, which Metro cannot transform.
+config.resolver.blockList = [
+  ...config.resolver.blockList,
+  /[\\/]apps[\\/]mobile[\\/]src[\\/].*\.test\.[jt]sx?$/,
+];
+
 // Drop the unused Material Symbols font chain from the bundle.
 //
 // `expo-router`'s <Tabs> statically pulls `expo-symbols` (via withLayoutContext ->

--- a/apps/mobile/metro.config.js
+++ b/apps/mobile/metro.config.js
@@ -21,7 +21,7 @@ config.resolver.nodeModulesPaths = [
 // every `.tsx` under `src/app`, so a `*.test.tsx` next to a route registers as a route
 // and drags vitest (and vite) into the bundle, which Metro cannot transform.
 config.resolver.blockList = [
-  ...config.resolver.blockList,
+  ...(config.resolver.blockList || []),
   /[\\/]apps[\\/]mobile[\\/]src[\\/].*\.test\.[jt]sx?$/,
 ];
 


### PR DESCRIPTION
## Problem

The iOS EAS build fails at bundle time:

```
vite/dist/node/module-runner.js: Invalid call at line 1009: import(filepath)
pnpm expo export:embed --eager --platform ios --dev false exited with non-zero code: 1
```

## Cause

`apps/mobile/src/app/(app)/(tabs)/(2_agents)/index.mounted.test.tsx` lives inside the router root. Expo Router's `require.context` matches every `.tsx` under `src/app`, so the test file registered as a route. That pulled `vitest` into the bundle, which imports `vite/module-runner`, which Metro cannot transform.

## Fix

Block `*.test.*` under `apps/mobile/src` in the Metro resolver. This also covers any future colocated test.

## Verification

- `pnpm expo export:embed --eager --platform ios --dev false` exits 0 (5776 modules; failed before the fix).
- `pnpm test`: 362 files, 3548 tests pass. Vitest uses its own resolver, so the block list does not affect it.