### PR TITLE
fix(ai-gateway): normalize model ids for variants

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -18,12 +18,13 @@ import {
   REASONING_VARIANTS_THINKING_ONLY,
   REASONING_VARIANTS_BINARY,
 } from '@/lib/ai-gateway/providers/variants';
+import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 
 export async function getOpenRouterDerivedModelVariants(
   model: string
 ): Promise<OpenCodeSettings['variants']> {
   const models = await getOpenRouterModelsMetadataFromDatabase();
-  const reasoning = models[model]?.reasoning;
+  const reasoning = (models[model] ?? models[normalizeModelId(model)])?.reasoning;
   if (!reasoning) {
     return undefined;
   }


### PR DESCRIPTION
## Summary
- fall back to the normalized OpenRouter model ID when deriving reasoning variants
- preserve exact model metadata lookup precedence

## Validation
- `pnpm --filter web run typecheck` passed
- `pnpm exec oxfmt --list-different apps/web/src/lib/ai-gateway/providers/model-settings.ts` passed
- `git diff --check` passed
- targeted Jest suites were attempted but could not run because the local test PostgreSQL and Redis services are unavailable

Untracked `.kilo/design/` tooling files were intentionally excluded.