### PR TITLE
fix(dev): update mobile accessibility label guard

### DIFF
--- a/dev/local/mobile-workflow.test.ts
+++ b/dev/local/mobile-workflow.test.ts
@@ -2,17 +2,23 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import test from 'node:test';
 
-test('tab layout exposes the exact documented accessibility labels', () => {
+test('tab layout derives accessibility labels from the visible tab count', () => {
   const layout = fs.readFileSync('apps/mobile/src/app/(app)/(tabs)/_layout.tsx', 'utf8');
 
-  for (const label of [
-    'Home, tab, 1 of 4',
-    'KiloClaw, tab, 2 of 4',
-    'Agents, tab, 3 of 4',
-    'Profile, tab, 4 of 4',
-  ]) {
-    assert.match(layout, new RegExp(`tabBarAccessibilityLabel: '${label}'`));
-  }
+  assert.match(layout, /const tabCount = showKiloClawTab \? 4 : 3;/);
+  assert.match(layout, /tabBarAccessibilityLabel: tabAccessibilityLabel\('Home', 1, tabCount\)/);
+  assert.match(
+    layout,
+    /tabBarAccessibilityLabel: tabAccessibilityLabel\('KiloClaw', 2, tabCount\)/
+  );
+  assert.match(
+    layout,
+    /tabBarAccessibilityLabel: tabAccessibilityLabel\(\s*'Agents',\s*showKiloClawTab \? 3 : 2,\s*tabCount\s*\)/
+  );
+  assert.match(
+    layout,
+    /tabBarAccessibilityLabel: tabAccessibilityLabel\(\s*'Profile',\s*showKiloClawTab \? 4 : 3,\s*tabCount\s*\)/
+  );
 });
 
 test('Android tooling is resolved independently of the agent PATH', async () => {


### PR DESCRIPTION
## Summary

- Update the local-development workflow guard after the KiloClaw tab became conditionally visible.
- Verify the mobile tab layout derives accessibility labels from the visible three- or four-tab count and reindexes Agents and Profile accordingly.

## Verification

- No manual UI verification was performed because this changes only a source-level development test; mobile runtime behavior is unchanged.
- [ ] Additional manual verification:

## Visual Changes

N/A

## Reviewer Notes

- Main commit `791a3bd4c` replaced hard-coded four-tab labels with `tabAccessibilityLabel(...)`, but `dev/local/mobile-workflow.test.ts` still searched for the old literals. Exact helper output is already covered in `apps/mobile/src/lib/tab-bar-layout.test.ts`.