### PR TITLE
fix(web): open Usage on AI usage tab

### DIFF
--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -126,7 +126,7 @@ export default function OrganizationAppSidebar({
     {
       title: 'Usage',
       icon: ChartColumnIncreasing,
-      url: `/organizations/${organizationId}/usage-details`,
+      url: `/organizations/${organizationId}/usage-details?view=ai-usage`,
     },
   ];
 

--- a/apps/web/src/app/(app)/components/SidebarMenuList.tsx
+++ b/apps/web/src/app/(app)/components/SidebarMenuList.tsx
@@ -31,13 +31,17 @@ type SidebarMenuListProps = {
   allUrls?: string[];
 };
 
+function pathnameForMatch(url: string): string {
+  return url.split(/[?#]/, 1)[0] || url;
+}
+
 export default function SidebarMenuList({
   items,
   label = 'Dashboard',
   allUrls,
 }: SidebarMenuListProps) {
   const pathname = usePathname();
-  const urlsToCheck = allUrls ?? items.flatMap(i => (i.url ? [i.url] : []));
+  const urlsToCheck = (allUrls ?? items.flatMap(i => (i.url ? [i.url] : []))).map(pathnameForMatch);
 
   return (
     <SidebarGroup>
@@ -48,17 +52,18 @@ export default function SidebarMenuList({
         <SidebarMenu>
           {items.map(item => {
             const itemUrl = item.url;
+            const itemPathname = itemUrl ? pathnameForMatch(itemUrl) : undefined;
             const isNumericBadge = item.badge ? /^\d[\d,]*$/.test(item.badge) : false;
-            const matchesPrefix = itemUrl
-              ? pathname === itemUrl || pathname.startsWith(itemUrl + '/')
+            const matchesPrefix = itemPathname
+              ? pathname === itemPathname || pathname.startsWith(itemPathname + '/')
               : false;
             const hasMoreSpecificMatch =
               matchesPrefix &&
-              itemUrl &&
+              itemPathname &&
               urlsToCheck.some(
                 url =>
-                  url !== itemUrl &&
-                  url.length > itemUrl.length &&
+                  url !== itemPathname &&
+                  url.length > itemPathname.length &&
                   (pathname === url || pathname.startsWith(url + '/'))
               );
             const isActive = item.isActive ?? (matchesPrefix && !hasMoreSpecificMatch);


### PR DESCRIPTION
## Summary
- Route the organization sidebar Usage item directly to the AI usage tab.
- Prevent enterprise users from landing on Feature Adoption through the default Usage route.

## Validation
- `pnpm --filter web lint`
- `pnpm -w exec oxfmt --check "apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx"`
- `git diff --check`

---
<img width="3936" height="2185" alt="SCR-20260805-liff" src="https://github.com/user-attachments/assets/0692d521-7c46-40db-af16-24503e011ab4" />



