### PR TITLE
perf(organizations): read group policy from replica

### DIFF
--- a/apps/web/src/lib/organizations/organization-group-policy-context.server.test.ts
+++ b/apps/web/src/lib/organizations/organization-group-policy-context.server.test.ts
@@ -1,0 +1,31 @@
+import { db, readDb } from '@/lib/drizzle';
+
+jest.mock('@/lib/drizzle', () => ({
+  db: { transaction: jest.fn() },
+  readDb: { transaction: jest.fn() },
+}));
+
+import { getOrganizationGroupPolicyContext } from './organization-group-policy-context.server';
+
+const mockedPrimaryTransaction = jest.mocked(db.transaction);
+const mockedReplicaTransaction = jest.mocked(readDb.transaction);
+
+describe('getOrganizationGroupPolicyContext', () => {
+  it('opens its repeatable-read snapshot on the read replica', async () => {
+    const transactionError = new Error('stop after selecting the transaction client');
+    mockedReplicaTransaction.mockRejectedValueOnce(transactionError);
+
+    await expect(
+      getOrganizationGroupPolicyContext({
+        organizationId: '00000000-0000-0000-0000-000000000001',
+        subject: { type: 'defaultAccess' },
+      })
+    ).rejects.toBe(transactionError);
+
+    expect(mockedReplicaTransaction).toHaveBeenCalledWith(expect.any(Function), {
+      isolationLevel: 'repeatable read',
+      accessMode: 'read only',
+    });
+    expect(mockedPrimaryTransaction).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/organizations/organization-group-policy-context.server.ts
+++ b/apps/web/src/lib/organizations/organization-group-policy-context.server.ts
@@ -15,7 +15,7 @@ import {
 import { and, eq, isNull } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import { captureException } from '@sentry/nextjs';
-import { db, type DrizzleTransaction } from '@/lib/drizzle';
+import { readDb, type DrizzleTransaction } from '@/lib/drizzle';
 
 export type OrganizationPolicySubject =
   | {
@@ -70,7 +70,7 @@ function parsePolicies(
  * that could disagree with it.
  */
 async function resolveOrganization(
-  client: typeof db | DrizzleTransaction,
+  client: DrizzleTransaction,
   params: { organizationId: string; organization?: Organization }
 ): Promise<Organization> {
   if (params.organization) {
@@ -105,12 +105,12 @@ export async function getOrganizationGroupPolicyContext(params: {
   tx?: DrizzleTransaction;
 }): Promise<OrganizationGroupPolicyContext> {
   if (!params.tx) {
-    return await db.transaction(
+    return await readDb.transaction(
       async tx => await getOrganizationGroupPolicyContext({ ...params, tx }),
       { isolationLevel: 'repeatable read', accessMode: 'read only' }
     );
   }
-  const client = params.tx ?? db;
+  const client = params.tx;
   const organization = await resolveOrganization(client, params);
 
   let isDirectMember = false;


### PR DESCRIPTION
## Summary
- run organization group-policy snapshots through `readDb` instead of the primary client
- preserve the existing repeatable-read, read-only transaction semantics
- keep explicit caller-supplied transactions authoritative
- add regression coverage for replica selection and transaction options

## Tradeoff
Policy reads can observe normal replica lag while remaining internally consistent within the repeatable-read snapshot. `readDb` falls back to primary where no replica is configured.

## Validation
- `pnpm --filter web typecheck`
- focused Jest suites: 3 passed, 35 tests
- changed-file `oxlint`: 0 warnings, 0 errors
- `pnpm format`
- `git diff --check`