### PR TITLE
fix(web): filter AI usage-limit 402 errors out of Sentry

### DIFF
--- a/apps/web/sentry.server.config.ts
+++ b/apps/web/sentry.server.config.ts
@@ -79,6 +79,24 @@ function isTRPC4xxError(error: unknown): boolean {
   );
 }
 
+// The AI gateway returns 402 when the caller's own credit balance is exhausted
+// (`usage_limit_exceeded`, "Add credits to continue, or switch to a free
+// model"), and the AI SDK surfaces that as AI_APICallError with statusCode 402
+// (e.g. Kilo Bot calling the gateway on behalf of a user who is out of
+// credits). That is expected per-user billing state, not an application bug.
+// Upstream provider 402s (our provider account) never reach callers: the
+// gateway converts them to a 503 and reports them itself via
+// captureProxyError. Duck-typed like isTRPC4xxError to keep the `ai` package
+// out of the Sentry init bundle.
+export function isAIUsageLimitError(error: unknown): boolean {
+  return (
+    error instanceof Error &&
+    error.name === 'AI_APICallError' &&
+    'statusCode' in error &&
+    error.statusCode === 402
+  );
+}
+
 // The GitHub OAuth callback uses `state` as a short-lived bearer token, and the
 // mobile app handoff carries a C1 bearer in `installState`. Sentry's automatic
 // request-data integration can capture either in the request URL or query
@@ -196,7 +214,7 @@ if (process.env.NODE_ENV !== 'development') {
 
     beforeSend(event, hint) {
       const error = hint.originalException;
-      if (isTRPC4xxError(error)) {
+      if (isTRPC4xxError(error) || isAIUsageLimitError(error)) {
         return null;
       }
 

--- a/apps/web/src/sentry.server.config.test.ts
+++ b/apps/web/src/sentry.server.config.test.ts
@@ -1,6 +1,7 @@
 import { describe, test, expect } from '@jest/globals';
 import type { Event } from '@sentry/nextjs';
-import { sanitizeSentryRequestData } from '../sentry.server.config';
+import { APICallError } from 'ai';
+import { isAIUsageLimitError, sanitizeSentryRequestData } from '../sentry.server.config';
 
 describe('sanitizeSentryRequestData', () => {
   test('removes the GitHub OAuth state token from request URL and query string', () => {
@@ -274,5 +275,47 @@ describe('sanitizeSentryRequestData', () => {
     const event: Event = { message: 'no request data' };
 
     expect(sanitizeSentryRequestData(event)).toBe(event);
+  });
+});
+
+describe('isAIUsageLimitError', () => {
+  function apiCallError(statusCode: number): APICallError {
+    return new APICallError({
+      message: 'Add credits to continue, or switch to a free model',
+      url: 'https://app.kilo.sh/api/openrouter/chat/completions',
+      requestBodyValues: {},
+      statusCode,
+    });
+  }
+
+  test('matches a real AI SDK APICallError with statusCode 402', () => {
+    expect(isAIUsageLimitError(apiCallError(402))).toBe(true);
+  });
+
+  test('does not match AI SDK call failures with other statuses', () => {
+    expect(isAIUsageLimitError(apiCallError(429))).toBe(false);
+    expect(isAIUsageLimitError(apiCallError(500))).toBe(false);
+  });
+
+  test('does not match an AI SDK call failure without a status', () => {
+    const error = new APICallError({
+      message: 'network failure',
+      url: 'https://app.kilo.sh/api/openrouter/chat/completions',
+      requestBodyValues: {},
+    });
+
+    expect(isAIUsageLimitError(error)).toBe(false);
+  });
+
+  test('does not match a 402 error that is not an AI SDK call error', () => {
+    const error = Object.assign(new Error('payment required'), { statusCode: 402 });
+
+    expect(isAIUsageLimitError(error)).toBe(false);
+  });
+
+  test('does not match plain errors or non-error values', () => {
+    expect(isAIUsageLimitError(new Error('Add credits to continue'))).toBe(false);
+    expect(isAIUsageLimitError({ name: 'AI_APICallError', statusCode: 402 })).toBe(false);
+    expect(isAIUsageLimitError(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

Filters `AI_APICallError` with `statusCode: 402` out of Sentry in `beforeSend`, alongside the existing tRPC 4xx filter.

## Why

The AI gateway returns 402 (`usage_limit_exceeded` — "Add credits to continue, or switch to a free model", `llm-proxy-helpers.ts`) when the **caller's own** credit balance is exhausted. Server-side callers acting on behalf of a user — e.g. Kilo Bot processing `/api/internal/bot-session-callback` — surface this as an unhandled `AI_APICallError` (statusCode 402), which `captureException` then reports. Each event just means "a user ran out of credits mid-workflow": expected per-user billing state, not an application bug, and it scales with free/low-credit usage.

This is safe to filter globally because upstream provider 402s (our provider account) never reach AI SDK callers: the gateway converts them to a 503 and reports them itself via `captureProxyError({ trackInSentry: true })` in `app/api/openrouter/[...path]/route.ts`, so that failure mode stays visible.

## Changes

- `apps/web/sentry.server.config.ts`: add exported `isAIUsageLimitError` predicate (duck-typed like the existing `isTRPC4xxError`, so the `ai` package stays out of the Sentry init bundle) and apply it in `beforeSend`.
- `apps/web/src/sentry.server.config.test.ts`: tests for the predicate, including one built from the real `APICallError` class to pin the duck-type contract.

## Verification

- `jest src/sentry.server.config.test.ts`: **24/24 pass** (run with a scratch config identical to `jest.config.ts` minus the DB-backed global setup — this sandbox has no Docker/Postgres; the standard config's setup requires it. The suite itself has no DB dependency, so CI should behave the same).
- `oxlint` on the changed test file: clean.
- `oxfmt` applied to both files.
- Scoped `tsgo` typecheck of both changed files: clean. Full `apps/web` typecheck not run (its `@kilocode/trpc` build prerequisite exceeded the sandbox time limit).