### PR TITLE
fix(cloud-agent-next): retry git rate-limited workspace setup

### DIFF
--- a/apps/web/src/lib/code-reviews/terminal-reason-from-failure.ts
+++ b/apps/web/src/lib/code-reviews/terminal-reason-from-failure.ts
@@ -32,6 +32,7 @@ const WORKSPACE_SUBTYPE_REASONS = {
   sandbox_storage_full: 'workspace_capacity',
   git_clone_timeout: 'repository_clone_failed',
   git_checkout_timeout: 'repository_clone_failed',
+  git_rate_limited: 'repository_clone_failed',
   git_network_failed: 'repository_clone_failed',
   git_authentication_failed: 'repository_auth_failed',
   git_pack_corrupt: 'repository_checkout_failed',

--- a/packages/worker-utils/src/cloud-agent-failure.ts
+++ b/packages/worker-utils/src/cloud-agent-failure.ts
@@ -41,6 +41,7 @@ export const WORKSPACE_FAILURE_SUBTYPES = [
   'git_clone_timeout',
   'git_checkout_timeout',
   'git_authentication_failed',
+  'git_rate_limited',
   'git_network_failed',
   'git_pack_corrupt',
   'git_checkout_conflict',
@@ -155,6 +156,8 @@ function classifyWorkspaceFailure(
       return classified('user', 'setup_command');
     case 'sandbox_storage_full':
       return classified('platform', 'sandbox_capacity');
+    case 'git_rate_limited':
+      return classified('platform', 'rate_limited');
     case 'git_clone_timeout':
     case 'git_checkout_timeout':
     case 'git_network_failed':

--- a/services/cloud-agent-next/src/session/pending-messages.test.ts
+++ b/services/cloud-agent-next/src/session/pending-messages.test.ts
@@ -403,6 +403,119 @@ describe('recordPendingFlushFailure', () => {
     expect(delays).toEqual([10_000, 30_000, 60_000, undefined]);
   });
 
+  it('gives a git rate-limited workspace failure a backed-off retry budget', async () => {
+    const storage = createMemoryStorage();
+    let message = makeMessage();
+    await storePendingSessionMessage(storage, message);
+
+    const delays: (number | undefined)[] = [];
+    const now = 100_000;
+
+    // A workspace_setup_failed with the git_rate_limited subtype is transient
+    // GitHub throttling that typically clears within well under a minute: two
+    // backed-off retries, then exhaustion (unlike a plain workspace failure's
+    // single warm-followup retry above).
+    for (let i = 0; i < 3; i++) {
+      const result = await recordPendingFlushFailure(
+        storage,
+        message,
+        'The requested URL returned error: 429',
+        now,
+        {
+          policy: 'warm-followup',
+          code: 'WORKSPACE_SETUP_FAILED',
+          subtype: 'git_rate_limited',
+        }
+      );
+      delays.push(
+        result.nextFlushAttemptAt !== undefined ? result.nextFlushAttemptAt - now : undefined
+      );
+      message = result.message;
+    }
+
+    expect(delays).toEqual([15_000, 45_000, undefined]);
+  });
+
+  it('starts the git rate-limit retry budget fresh after a different earlier failure', async () => {
+    const storage = createMemoryStorage();
+    const message = makeMessage({
+      createdAt: 1,
+      flushAttempts: 2,
+      lastFlushFailureCode: 'WRAPPER_START_FAILED',
+    });
+    await storePendingSessionMessage(storage, message);
+
+    const result = await recordPendingFlushFailure(
+      storage,
+      message,
+      'The requested URL returned error: 429',
+      100_000,
+      {
+        policy: 'warm-followup',
+        code: 'WORKSPACE_SETUP_FAILED',
+        subtype: 'git_rate_limited',
+      }
+    );
+
+    // Reset to attempt 1 so the full 15s/45s budget applies, not truncated
+    // by the two earlier non-rate-limit attempts.
+    expect(result.attempts).toBe(1);
+    expect(result.exhausted).toBe(false);
+    expect(result.nextFlushAttemptAt).toBe(115_000);
+  });
+
+  it('bounds retries when failures alternate between storage-full and rate-limit modes', async () => {
+    const storage = createMemoryStorage();
+    let message = makeMessage();
+    await storePendingSessionMessage(storage, message);
+    const now = 100_000;
+
+    // Fresh storage-full failure resets to attempt 1.
+    let result = await recordPendingFlushFailure(storage, message, 'sandbox storage full', now, {
+      policy: 'warm-followup',
+      code: 'WORKSPACE_SETUP_FAILED',
+      subtype: 'sandbox_storage_full',
+    });
+    expect(result.attempts).toBe(1);
+    expect(result.exhausted).toBe(false);
+    message = result.message;
+
+    // Switching to rate-limit (both modes reset-eligible) does NOT reset;
+    // attempts accumulate and the shorter rate-limit budget applies.
+    result = await recordPendingFlushFailure(
+      storage,
+      message,
+      'The requested URL returned error: 429',
+      now,
+      {
+        policy: 'warm-followup',
+        code: 'WORKSPACE_SETUP_FAILED',
+        subtype: 'git_rate_limited',
+      }
+    );
+    expect(result.attempts).toBe(2);
+    expect(result.exhausted).toBe(false);
+    expect(result.nextFlushAttemptAt).toBe(now + 45_000);
+    message = result.message;
+
+    // Continuing to alternate keeps accumulating and exceeds the rate-limit
+    // budget, so the flapping message exhausts instead of resetting forever.
+    result = await recordPendingFlushFailure(
+      storage,
+      message,
+      'The requested URL returned error: 429',
+      now,
+      {
+        policy: 'warm-followup',
+        code: 'WORKSPACE_SETUP_FAILED',
+        subtype: 'git_rate_limited',
+      }
+    );
+    expect(result.attempts).toBe(3);
+    expect(result.exhausted).toBe(true);
+    expect(result.nextFlushAttemptAt).toBeUndefined();
+  });
+
   it('starts the capacity retry budget fresh after a different earlier failure', async () => {
     const storage = createMemoryStorage();
     const message = makeMessage({

--- a/services/cloud-agent-next/src/session/pending-messages.ts
+++ b/services/cloud-agent-next/src/session/pending-messages.ts
@@ -24,6 +24,11 @@ const SANDBOX_CONNECT_RETRY_DELAYS_MS = [5_000] as const;
 // longer, backed-off retry budget instead of failing the delivery after a
 // single redelivery.
 const WORKSPACE_CAPACITY_RETRY_DELAYS_MS = [10_000, 30_000, 60_000] as const;
+// GitHub's ref-discovery/clone endpoint returns 429 under concurrent-clone or
+// secondary-abuse throttling, which typically clears within well under a
+// minute — give it a short backed-off budget instead of one generic
+// redelivery.
+const GIT_RATE_LIMIT_RETRY_DELAYS_MS = [15_000, 45_000] as const;
 // Other pending delivery failures currently get one redelivery after the initial failed attempt.
 const WARM_FOLLOWUP_RETRY_DELAYS_MS = [PENDING_FLUSH_RETRY_BASE_DELAY_MS] as const;
 const COLD_INIT_RETRY_DELAYS_MS = [PENDING_FLUSH_RETRY_BASE_DELAY_MS] as const;
@@ -492,9 +497,10 @@ export function shouldSkipPendingFlush(message: PendingSessionMessage, now: numb
 
 /**
  * Reset-eligible modes each start a fresh retry budget on entry (sandbox-connect
- * has a short reconnect budget; sandbox-capacity has a longer backed-off budget
- * for transient disk pressure). Alternating between them must NOT keep resetting,
- * so callers only reset when entering one of these from a non-reset-eligible state.
+ * has a short reconnect budget; sandbox-capacity and git-rate-limit each have a
+ * longer backed-off budget for transient, self-clearing conditions).
+ * Alternating between them must NOT keep resetting, so callers only reset when
+ * entering one of these from a non-reset-eligible state.
  */
 function isResetEligibleFailure(
   code: PendingFlushFailureCode | undefined,
@@ -502,7 +508,8 @@ function isResetEligibleFailure(
 ): boolean {
   return (
     code === 'SANDBOX_CONNECT_FAILED' ||
-    (code === 'WORKSPACE_SETUP_FAILED' && subtype === 'sandbox_storage_full')
+    (code === 'WORKSPACE_SETUP_FAILED' &&
+      (subtype === 'sandbox_storage_full' || subtype === 'git_rate_limited'))
   );
 }
 
@@ -557,11 +564,11 @@ export async function recordPendingFlushFailure(
       ? options.safeFailureMessage
       : undefined;
   // Reset the attempt counter only when a message ENTERS a reset-eligible
-  // transient mode (sandbox-connect or sandbox-capacity) from a state that is
-  // not itself reset-eligible, so each fresh sequence gets its full backoff
-  // budget. When failures alternate between the two reset-eligible modes the
-  // counter is NOT reset, so attempts accumulate and the message still exhausts
-  // instead of flapping between modes forever.
+  // transient mode (sandbox-connect, sandbox-capacity, or git-rate-limit) from a
+  // state that is not itself reset-eligible, so each fresh sequence gets its
+  // full backoff budget. When failures alternate between reset-eligible modes
+  // the counter is NOT reset, so attempts accumulate and the message still
+  // exhausts instead of flapping between modes forever.
   const attempts =
     isResetEligibleFailure(flushFailureCode, failureSubtype) &&
     !isResetEligibleFailure(message.lastFlushFailureCode, message.lastFlushFailureSubtype)
@@ -572,9 +579,11 @@ export async function recordPendingFlushFailure(
       ? SANDBOX_CONNECT_RETRY_DELAYS_MS
       : flushFailureCode === 'WORKSPACE_SETUP_FAILED' && failureSubtype === 'sandbox_storage_full'
         ? WORKSPACE_CAPACITY_RETRY_DELAYS_MS
-        : options.policy === 'cold-init'
-          ? COLD_INIT_RETRY_DELAYS_MS
-          : WARM_FOLLOWUP_RETRY_DELAYS_MS;
+        : flushFailureCode === 'WORKSPACE_SETUP_FAILED' && failureSubtype === 'git_rate_limited'
+          ? GIT_RATE_LIMIT_RETRY_DELAYS_MS
+          : options.policy === 'cold-init'
+            ? COLD_INIT_RETRY_DELAYS_MS
+            : WARM_FOLLOWUP_RETRY_DELAYS_MS;
   const retryable = options.retryable ?? isRetryableFlushCode(flushFailureCode);
   const exhausted = !retryable || attempts > retryDelays.length;
   const retryDelay = retryDelays[attempts - 1];

--- a/services/cloud-agent-next/src/session/safe-failure-projection.ts
+++ b/services/cloud-agent-next/src/session/safe-failure-projection.ts
@@ -60,6 +60,7 @@ const WORKSPACE_FAILURE_MESSAGES = {
   git_clone_timeout: 'Repository clone timed out',
   git_checkout_timeout: 'Repository checkout timed out',
   git_authentication_failed: 'Repository authentication failed',
+  git_rate_limited: 'Repository request was rate limited',
   git_network_failed: 'Repository network request failed',
   git_pack_corrupt: 'Repository data is corrupt',
   git_checkout_conflict: 'Repository checkout conflict',

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -1052,6 +1052,19 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       subtype: 'git_network_failed',
     },
     {
+      name: 'clone network failure with progress object counts is not rate limited',
+      stage: 'clone',
+      result: {
+        stdout: '',
+        stderr:
+          'remote: Enumerating objects: 429, done.\n' +
+          'remote: Total 429 (delta 12), reused 100 (delta 30), pack-reused 0\n' +
+          'fatal: the remote end hung up unexpectedly',
+        exitCode: 128,
+      },
+      subtype: 'git_network_failed',
+    },
+    {
       name: 'clone corrupt pack',
       stage: 'clone',
       result: { stdout: '', stderr: 'fatal: pack has bad object at offset', exitCode: 128 },

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -1025,6 +1025,27 @@ describe('prepareWrapperBootstrapWorkspace', () => {
       subtype: 'git_authentication_failed',
     },
     {
+      name: 'clone HTTP 429 rate limit',
+      stage: 'clone',
+      result: {
+        stdout: '',
+        stderr:
+          "fatal: unable to access 'https://github.com/org/repo.git/': The requested URL returned error: 429",
+        exitCode: 128,
+      },
+      subtype: 'git_rate_limited',
+    },
+    {
+      name: 'clone too many requests rate limit',
+      stage: 'clone',
+      result: {
+        stdout: '',
+        stderr: 'fatal: unable to access repository: too many requests',
+        exitCode: 128,
+      },
+      subtype: 'git_rate_limited',
+    },
+    {
       name: 'clone network failure',
       stage: 'clone',
       result: { stdout: '', stderr: 'fatal: the remote end hung up unexpectedly', exitCode: 128 },

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -179,7 +179,9 @@ const GIT_FAILURE_PATTERNS = [
   },
   {
     subtype: 'git_rate_limited',
-    pattern: /\b429\b|too many requests|rate limit(?:ed)?/i,
+    // Anchor 429 to an HTTP-error context: clones run with --progress, so a bare
+    // 429 also matches object counts (e.g. "remote: Total 429 (delta 12)").
+    pattern: /(?:error|http|status(?:\s+code)?)\s*:?\s*429\b|too many requests|rate limit(?:ed)?/i,
   },
   {
     subtype: 'git_network_failed',

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -178,6 +178,10 @@ const GIT_FAILURE_PATTERNS = [
     pattern: /authentication failed|could not read username|http 401|http 403/i,
   },
   {
+    subtype: 'git_rate_limited',
+    pattern: /\b429\b|too many requests|rate limit(?:ed)?/i,
+  },
+  {
     subtype: 'git_network_failed',
     pattern:
       /remote end hung up|connection (?:reset|timed out)|could not resolve host|failed to connect/i,


### PR DESCRIPTION
## Summary

### Why

Cold Cloud Agent workspace bootstrap can fail when GitHub throttles clone/ref discovery with HTTP 429 (or equivalent “too many requests” / rate-limit text). Those failures were previously unclassified (`workspace_setup_unknown`) and only got a single generic pending-message redelivery, so concurrent or bursty clone traffic could fail sessions that would succeed moments later.

### What was done

- Classify wrapper git clone/checkout stderr matching `\b429\b`, `too many requests`, or `rate limit(ed)` as workspace subtype `git_rate_limited` (after auth patterns so 401/403 still win).
- Map the subtype through shared failure classification as platform `rate_limited`, project the safe user message “Repository request was rate limited”, and map code-review terminal reason to existing `repository_clone_failed` (no new DB enum).
- Give pending flush a dedicated short backoff budget (`15s`, `45s` — two retries / three total attempts) for `WORKSPACE_SETUP_FAILED` + `git_rate_limited`, reusing the full cold bootstrap path instead of adding an inner clone retry loop.
- Treat git rate-limit as reset-eligible alongside sandbox storage-full (fresh budget on entry from a non-reset-eligible failure; alternating reset-eligible modes still accumulate and exhaust).

### High-level architecture

```mermaid
sequenceDiagram
  participant DO as Session DO
  participant Pending as Pending flush
  participant Wrapper as Sandbox wrapper
  participant GitHub as Git remote

  DO->>Pending: Drain queued cold-start message
  Pending->>Wrapper: Prepare workspace (clone/checkout)
  Wrapper->>GitHub: git clone / fetch
  GitHub-->>Wrapper: 429 / rate limited
  Wrapper-->>Pending: WORKSPACE_SETUP_FAILED git_rate_limited
  Note over Pending: Schedule retry at +15s then +45s<br/>(reset-eligible budget)
  Pending->>Wrapper: Retry full cold bootstrap
  alt Throttle cleared
    Wrapper->>GitHub: clone succeeds
    Wrapper-->>DO: Workspace ready
  else Budget exhausted
    Pending-->>DO: Terminal safe failure projection
  end
```

### Architecture decision

**Decision:** Detect git rate limits at wrapper classification and retry via the existing pending-flush mechanism with a dedicated short backoff budget, rather than adding an inner retry loop inside `cloneRepository`.

**Context:** Pending flush already owns durable redelivery of cold bootstrap, and other transient workspace conditions (e.g. sandbox storage full) already use subtype-specific reset-eligible budgets. Clone 429s are short-lived platform throttling that clear without a new product path.

**Rationale:** Reusing pending flush keeps retry durability, attempt accounting, and terminalization in one place, mirrors the storage-full pattern, and avoids duplicating bootstrap side effects inside the wrapper.

**Alternatives considered:**

- **Inner clone retry in the wrapper.** Would hide durability from the DO and risk partial workspace state on repeated in-process attempts; not chosen.
- **Treat as generic warm/cold single redelivery.** Too little budget for throttling that often needs tens of seconds to clear; not chosen.

**Consequences:** Sessions survive brief GitHub clone throttling with clearer diagnostics and platform ownership. Detection remains best-effort regex on sanitized process output (no captured production 429 stderr sample in-repo); permanent or long throttles still exhaust after two backed-off retries.

