### PR TITLE
fix(ai-gateway): maximize Auto Free reasoning

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.test.ts
@@ -419,7 +419,10 @@ describe('resolveAutoModel — kilo-auto/free branch', () => {
 
     expect(result).toEqual({
       kind: 'ok',
-      resolved: { model: 'stepfun/step-3.7-flash:free' },
+      resolved: {
+        model: 'stepfun/step-3.7-flash:free',
+        reasoning: { enabled: true, effort: 'high' },
+      },
     });
     expect(isAutoFreeCandidateAllowed).toHaveBeenCalledWith('stepfun/step-3.7-flash:free');
   });

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -30,7 +30,7 @@ import {
   autoFreeModels,
   findKiloExclusiveModel,
   isKiloExclusiveFreeModel,
-  selectAutoFreeModel,
+  selectAutoFreeCandidate,
 } from '@/lib/ai-gateway/models';
 import { getOpenRouterModelsFromRedis } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
@@ -292,14 +292,20 @@ export async function resolveAutoModel(
       return { kind: 'no_free_models_available' };
     }
     const candidateIds = new Set(candidates);
-    const selectedModel = selectAutoFreeModel(
+    const selectedCandidate = selectAutoFreeCandidate(
       autoFreeModels
         .filter(candidate => candidateIds.has(candidate.model))
         .toSorted((a, b) => a.model.localeCompare(b.model)),
       'free_routing_' + (sessionId ?? (await userPromise)?.id ?? clientIp)
     );
-    return selectedModel
-      ? { kind: 'ok', resolved: { model: selectedModel } }
+    return selectedCandidate
+      ? {
+          kind: 'ok',
+          resolved: {
+            model: selectedCandidate.model,
+            reasoning: { ...selectedCandidate.reasoning },
+          },
+        }
       : { kind: 'no_free_models_available' };
   }
   if (model === KILO_AUTO_SMALL_MODEL.id) {

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -4,7 +4,7 @@ import {
   findKiloExclusiveModel,
   isKiloExclusiveRateLimitedModel,
   kiloExclusiveModels,
-  selectAutoFreeModel,
+  selectAutoFreeCandidate,
 } from './models';
 import { hasBestEffortGuessDataCollectionRequirement, isFreeModel } from './is-free-model';
 import { getInferenceProvider } from './providers/kilo-exclusive-model';
@@ -160,6 +160,16 @@ describe('isFreeModel', () => {
       }
     });
 
+    test('hardcodes the most aggressive reasoning for every Auto Free model', () => {
+      expect(
+        Object.fromEntries(autoFreeModels.map(({ model, reasoning }) => [model, reasoning]))
+      ).toEqual({
+        'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
+        'inclusionai/ling-3.0-flash:free': { enabled: true, effort: 'high' },
+        'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
+      });
+    });
+
     test('weights non-Laguna auto-free models higher than Laguna', () => {
       const lagunaModel = autoFreeModels.find(({ model }) => model.includes('laguna'));
       expect(lagunaModel?.weight).toBe(1);
@@ -173,8 +183,8 @@ describe('isFreeModel', () => {
 
     test('uses autoFreeModels weights when selecting a model', () => {
       const candidates = [
-        { model: 'preferred/model', weight: 3 },
-        { model: 'other/model', weight: 1 },
+        { model: 'preferred/model', weight: 3, reasoning: { enabled: true } },
+        { model: 'other/model', weight: 1, reasoning: { enabled: true } },
       ];
       const randomSeed = Array.from({ length: 100 }, (_, index) => `weight-test-${index}`).find(
         seed => getRandomNumber(seed, 4) === 1
@@ -183,7 +193,7 @@ describe('isFreeModel', () => {
       if (!randomSeed) return;
 
       expect(getRandomNumber(randomSeed, 4)).toBe(1);
-      expect(selectAutoFreeModel(candidates, randomSeed)).toBe('preferred/model');
+      expect(selectAutoFreeCandidate(candidates, randomSeed)).toBe(candidates[0]);
     });
 
     test('all autoFreeModels should use the same AI SDK provider', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -34,21 +34,43 @@ import {
   deepseekDiscountedModels,
 } from '@/lib/ai-gateway/providers/deepseek';
 import { type ProviderId } from '@/lib/ai-gateway/providers/types';
+import type { OpenRouterReasoningConfig } from '@/lib/ai-gateway/providers/openrouter/types';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 
 export const PRIMARY_DEFAULT_MODEL = CLAUDE_SONNET_CURRENT_MODEL_ID;
 
-export type AutoFreeModel = { model: string; weight: number };
+export type AutoFreeModel = {
+  model: string;
+  weight: number;
+  reasoning: OpenRouterReasoningConfig;
+};
 
-export const autoFreeModels = [
+export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
   ...(stepfun_37_flash_free_model.status === 'public'
-    ? [{ model: stepfun_37_flash_free_model.public_id, weight: 2 }]
+    ? [
+        {
+          model: stepfun_37_flash_free_model.public_id,
+          weight: 2,
+          reasoning: { enabled: true, effort: 'high' },
+        } satisfies AutoFreeModel,
+      ]
     : []),
-  { model: 'inclusionai/ling-3.0-flash:free', weight: 2 },
-  { model: 'poolside/laguna-s-2.1:free', weight: 1 },
-] satisfies ReadonlyArray<AutoFreeModel>;
+  {
+    model: 'inclusionai/ling-3.0-flash:free',
+    weight: 2,
+    reasoning: { enabled: true, effort: 'high' },
+  } satisfies AutoFreeModel,
+  {
+    model: 'poolside/laguna-s-2.1:free',
+    weight: 1,
+    reasoning: { enabled: true, effort: 'high' },
+  } satisfies AutoFreeModel,
+];
 
-export function selectAutoFreeModel(candidates: ReadonlyArray<AutoFreeModel>, randomSeed: string) {
+export function selectAutoFreeCandidate(
+  candidates: ReadonlyArray<AutoFreeModel>,
+  randomSeed: string
+): AutoFreeModel | null {
   const totalWeight = candidates.reduce((total, candidate) => total + candidate.weight, 0);
   if (totalWeight === 0) return null;
 
@@ -56,7 +78,7 @@ export function selectAutoFreeModel(candidates: ReadonlyArray<AutoFreeModel>, ra
   let cumulativeWeight = 0;
   for (const candidate of candidates) {
     cumulativeWeight += candidate.weight;
-    if (bucket < cumulativeWeight) return candidate.model;
+    if (bucket < cumulativeWeight) return candidate;
   }
   return null;
 }


### PR DESCRIPTION
## Summary
- hardcode the strongest supported reasoning configuration for every Auto Free candidate
- carry candidate reasoning settings through weighted routing so client defaults cannot weaken them
- cover the full candidate map and resolved Auto Free result with unit tests

## Verification
- `pnpm format`
- web TypeScript check (`apps/web/node_modules/.bin/tsgo --noEmit -p apps/web/tsconfig.json`)
- targeted oxlint on the four changed files
- targeted Jest suites: 58 tests passed