### PR TITLE
feat(kiloclaw): close new subscriptions

### DIFF
--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -32,7 +32,7 @@ Updated 2026-05-12 -- retired current Standard first-month discount.
 Updated 2026-05-18 -- organization hard-expiry suspension and recovery contract.
 Updated 2026-05-28 -- exceptional personal Stripe EFW cancellation and suspension contract.
 Updated 2026-06-05 -- retirement of new and renewing Commit subscriptions.
-Updated 2026-08-05 -- closed fresh personal subscription signup.
+Updated 2026-08-05 -- closed fresh KiloClaw instance provisioning.
 
 ## Conventions
 
@@ -146,11 +146,13 @@ Current organization-managed bootstrap rows remain a temporary
 managed-active funding carveout, but their compute lifecycle is still
 subordinate to organization trial and seat entitlement.
 
-Fresh personal KiloClaw signup is closed. A user without an existing
-canonical personal KiloClaw subscription MUST NOT provision a personal
-instance or receive a new trial subscription. Existing canonical personal
-subscription rows retain their current trial conversion, renewal,
-reactivation, management, and safe reprovision behavior. Legacy
+Fresh KiloClaw instance provisioning is closed in personal and organization
+contexts. A current access-granting subscription in the requested ownership
+context is REQUIRED before replacement infrastructure may be provisioned.
+Canceled, expired, unpaid, suspended, or purely historical subscription rows
+MUST NOT authorize a new instance. Existing live instances and current
+subscription rows retain their management, renewal, and reconfiguration
+behavior. Legacy
 `kiloclaw_earlybird_purchases` rows without canonical subscription rows
 MUST NOT mint fresh trial access and instead require manual
 remediation. Canonical earlybird subscription rows continue to grant
@@ -206,26 +208,28 @@ lapses, with email notifications at each stage.
     price increase. Larger-machine and tiered-pricing selection require
     a future spec change.
 
-### Fresh Personal Subscription Closure
+### Fresh Instance Provisioning Closure
 
-1. A user without an existing canonical personal KiloClaw subscription
-   MUST NOT provision a personal KiloClaw instance or create a fresh trial
-   subscription.
-2. Personal KiloClaw surfaces MUST NOT show onboarding, checkout, or
-   enrollment actions to a user without an existing canonical personal
-   subscription. They MUST instead state that new subscriptions are
-   unavailable. Navigation and product-promotion surfaces MUST omit KiloClaw
-   entirely for those users; a directly opened KiloClaw route MAY show the
-   unavailable state.
-3. Existing canonical personal subscriptions MUST retain their current
-   access, conversion, renewal, reactivation, cancellation, management,
-   and safe reprovision behavior.
-4. Provisioning services and post-checkout fulfillment paths MUST enforce
-   the same canonical-subscription boundary before creating personal
-   infrastructure or subscription state, including stale or already-completed
-   checkout sessions.
-5. This closure does not change organization-managed KiloClaw provisioning
-   or entitlement behavior.
+1. A current access-granting KiloClaw subscription in the requested personal
+   or organization context is REQUIRED before provisioning a replacement
+   KiloClaw instance.
+2. Canceled, expired, unpaid, suspended, transferred-out, or purely historical
+   subscription rows MUST NOT authorize provisioning. Subscription history
+   alone is insufficient.
+3. KiloClaw surfaces MUST NOT show onboarding, checkout, or enrollment actions
+   when the requested context has no current subscription. They MUST instead
+   state that a current subscription is required. Navigation and product-promotion
+   surfaces MUST omit KiloClaw entirely for those contexts; a directly opened
+   KiloClaw route MAY show the unavailable state.
+4. Existing live instances and current subscriptions MUST retain their access,
+   conversion, renewal, reactivation, cancellation, management, and
+   configuration-update behavior.
+5. Provisioning services and post-checkout fulfillment paths MUST enforce the
+   same current-subscription boundary before creating infrastructure or
+   subscription state, including stale or already-completed checkout sessions.
+6. Provisioning MUST preserve the existing current subscription context; it
+   MUST NOT create a new trial or managed-active subscription from canceled or
+   historical rows.
 
 ### Pricing Versions and Legacy Lineages
 
@@ -266,12 +270,11 @@ lapses, with email notifications at each stage.
    receive a fresh current-price subscription row, not a renewed legacy
    lineage.
 10. Price and display calculations MUST use the subscription row's
-    price version, or the intended price version for a checkout or
+    price version, or the intended price version for an eligible checkout or
     enrollment that has not created a row yet. Existing live legacy
-    subscriptions MUST show legacy prices and legacy instance
-    entitlement; fresh current signups MUST show current prices and
-    current instance entitlement. Canceled history MUST NOT cause fresh
-    subscribe surfaces to show legacy pricing.
+    subscriptions MUST show legacy prices and legacy instance entitlement.
+    Canceled history MUST NOT cause subscription surfaces to show legacy
+    pricing or expose replacement-instance actions.
 11. Self-service default instance size and maximum self-service size
     MUST come from the active or intended price version. Existing
     running instances MUST NOT be actively resized solely because of
@@ -522,18 +525,18 @@ rules resolve conflicts.
    manually subscribe to regain access.
 6. The system MUST deny access and return a forbidden error when none of
    the above conditions are met.
-7. All instance lifecycle operations (start, stop, destroy, provision,
-   configuration changes) MUST be gated behind the access check, except
-   for provisioning which uses the trial-bootstrap flow.
+7. Instance lifecycle operations that create infrastructure MUST require a
+   current paid, locally settled subscription. Existing-instance start, stop,
+   destroy, and configuration changes remain governed by their existing access
+   and entitlement checks.
 
 ### Subscription Checkout (Stripe)
 
 1. The system MUST reject a checkout request if the user already has a
    subscription in active, past-due, or unpaid status.
-2. The system MUST allow checkout when the existing subscription status
-   is trialing or canceled. Checkout from a trialing live lineage MUST
-   use that lineage's price version. Checkout after canceled history
-   MUST create a fresh current-price subscription row.
+2. Checkout MUST NOT create a new KiloClaw instance. Any checkout action
+   shown for an existing live instance MUST remain anchored to that instance;
+   canceled history MUST NOT authorize replacement infrastructure.
 3. The system MUST verify with the payment provider that no subscription
    in active or trialing (delayed-billing) status already exists for the
    customer before creating a new checkout session, to guard against
@@ -592,11 +595,9 @@ rules resolve conflicts.
 1. The system MUST reject a credit enrollment request if the user
    already has a subscription in active, past-due, or unpaid status.
    This is the same guard as Subscription Checkout rule 1.
-2. The system MUST allow credit enrollment when the existing
-   subscription status is trialing or canceled. Enrollment from a
-   trialing live lineage MUST use that lineage's price version.
-   Enrollment after canceled history MUST create a fresh current-price
-   subscription row.
+2. Credit enrollment MUST NOT provision replacement infrastructure.
+   Enrollment may update billing for an existing live instance, but canceled
+   history MUST NOT authorize a new instance or successor row.
 3. The system MUST NOT apply a built-in first-paid-month Standard
    discount for fresh current-price credit enrollment. It MUST apply a
    first-paid-month discounted Standard price only when enrolling an
@@ -1524,10 +1525,11 @@ rows renew.
 
 ### Changelog
 
-#### 2026-08-05 -- Close fresh personal subscription signup
+#### 2026-08-05 -- Close fresh KiloClaw instance provisioning
 
-- Blocked personal provisioning and trial creation for users without an existing canonical personal KiloClaw subscription.
-- Removed personal onboarding and enrollment actions for those users while preserving existing subscription lifecycle and organization-managed behavior.
+- Required a current access-granting subscription in the requested personal or organization context before replacement instance provisioning.
+- Blocked canceled and historical rows from authorizing new infrastructure or subscription bootstrap.
+- Removed onboarding and enrollment actions from ineligible contexts while preserving existing live instances and current subscription management.
 
 #### 2026-06-05 -- Retire new and renewing Commit subscriptions
 

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -1486,10 +1486,12 @@ rows renew.
 10. The billing status MUST include instance data (whether an
     undestroyed instance exists, suspension timestamp, destruction
     deadline, and destroyed flag) when any instance record exists.
-11. The billing status MUST indicate whether the user has any existing
-    canonical personal KiloClaw subscription row so personal surfaces can
-    enforce the fresh-subscription closure without treating organization-owned
-    subscriptions as personal history.
+11. The billing status MUST distinguish any existing canonical personal
+    KiloClaw subscription history from a current personal subscription that may
+    authorize replacement provisioning. Personal surfaces MUST use current,
+    context-scoped eligibility for onboarding, navigation, enrollment, and
+    recovery actions without treating organization-owned or purely historical
+    subscriptions as authorization.
 
 ### Billing Portal
 

--- a/.specs/kiloclaw-billing.md
+++ b/.specs/kiloclaw-billing.md
@@ -32,6 +32,7 @@ Updated 2026-05-12 -- retired current Standard first-month discount.
 Updated 2026-05-18 -- organization hard-expiry suspension and recovery contract.
 Updated 2026-05-28 -- exceptional personal Stripe EFW cancellation and suspension contract.
 Updated 2026-06-05 -- retirement of new and renewing Commit subscriptions.
+Updated 2026-08-05 -- closed fresh personal subscription signup.
 
 ## Conventions
 
@@ -145,9 +146,11 @@ Current organization-managed bootstrap rows remain a temporary
 managed-active funding carveout, but their compute lifecycle is still
 subordinate to organization trial and seat entitlement.
 
-New users who provision an instance without subscribing first
-automatically receive a free trial whose duration is determined by the
-subscription row's price version. Legacy
+Fresh personal KiloClaw signup is closed. A user without an existing
+canonical personal KiloClaw subscription MUST NOT provision a personal
+instance or receive a new trial subscription. Existing canonical personal
+subscription rows retain their current trial conversion, renewal,
+reactivation, management, and safe reprovision behavior. Legacy
 `kiloclaw_earlybird_purchases` rows without canonical subscription rows
 MUST NOT mint fresh trial access and instead require manual
 remediation. Canonical earlybird subscription rows continue to grant
@@ -202,6 +205,27 @@ lapses, with email notifications at each stage.
     tiers or instance-size-based paid plans as part of the current
     price increase. Larger-machine and tiered-pricing selection require
     a future spec change.
+
+### Fresh Personal Subscription Closure
+
+1. A user without an existing canonical personal KiloClaw subscription
+   MUST NOT provision a personal KiloClaw instance or create a fresh trial
+   subscription.
+2. Personal KiloClaw surfaces MUST NOT show onboarding, checkout, or
+   enrollment actions to a user without an existing canonical personal
+   subscription. They MUST instead state that new subscriptions are
+   unavailable. Navigation and product-promotion surfaces MUST omit KiloClaw
+   entirely for those users; a directly opened KiloClaw route MAY show the
+   unavailable state.
+3. Existing canonical personal subscriptions MUST retain their current
+   access, conversion, renewal, reactivation, cancellation, management,
+   and safe reprovision behavior.
+4. Provisioning services and post-checkout fulfillment paths MUST enforce
+   the same canonical-subscription boundary before creating personal
+   infrastructure or subscription state, including stale or already-completed
+   checkout sessions.
+5. This closure does not change organization-managed KiloClaw provisioning
+   or entitlement behavior.
 
 ### Pricing Versions and Legacy Lineages
 
@@ -1461,6 +1485,10 @@ rows renew.
 10. The billing status MUST include instance data (whether an
     undestroyed instance exists, suspension timestamp, destruction
     deadline, and destroyed flag) when any instance record exists.
+11. The billing status MUST indicate whether the user has any existing
+    canonical personal KiloClaw subscription row so personal surfaces can
+    enforce the fresh-subscription closure without treating organization-owned
+    subscriptions as personal history.
 
 ### Billing Portal
 
@@ -1495,6 +1523,11 @@ rows renew.
    requirements on credit transaction records.
 
 ### Changelog
+
+#### 2026-08-05 -- Close fresh personal subscription signup
+
+- Blocked personal provisioning and trial creation for users without an existing canonical personal KiloClaw subscription.
+- Removed personal onboarding and enrollment actions for those users while preserving existing subscription lifecycle and organization-managed behavior.
 
 #### 2026-06-05 -- Retire new and renewing Commit subscriptions
 

--- a/.specs/subscription-center.md
+++ b/.specs/subscription-center.md
@@ -29,7 +29,7 @@ Updated 2026-06-19 -- Current Coding Plan quota presentation and routing indepen
 Updated 2026-07-01 -- Coding Plans installed-key deletion blocked in BYOK.
 Updated 2026-06-26 -- MiniMax token plan tiers and provider-level Coding Plan exclusivity.
 Updated 2026-08-05 -- BytePlus Coding Plan Pro catalog requirements.
-Updated 2026-08-05 -- closed fresh personal KiloClaw signup surfaces.
+Updated 2026-08-05 -- closed fresh KiloClaw instance provisioning surfaces.
 
 ## Conventions
 
@@ -500,10 +500,11 @@ not yet enforced in the current codebase:
 
 ## Changelog
 
-### 2026-08-05 -- Close fresh personal KiloClaw signup surfaces
+### 2026-08-05 -- Close fresh KiloClaw instance provisioning surfaces
 
-- Replaced KiloClaw signup offers with an unavailable notice for users without canonical personal subscription history.
-- Preserved enrollment, recovery, and management surfaces for existing personal subscription history.
+- Replaced KiloClaw signup offers with an unavailable notice when the requested personal or organization context lacks a current access-granting subscription.
+- Prevented canceled and historical subscription rows from presenting replacement-instance actions.
+- Preserved management surfaces for existing live instances and current subscriptions.
 
 ### 2026-07-14 -- Coding Plans installed keys made read-only
 

--- a/.specs/subscription-center.md
+++ b/.specs/subscription-center.md
@@ -265,12 +265,13 @@ the change completes. Every final Commit summary card and detail view MUST
 state that hosting ends on the final date unless the customer continues
 month-to-month, and MUST expose the continuation action directly. When retirement state cannot be derived safely, the surface MUST hide unsafe billing actions, preserve only access supported by canonical state, and show a generic temporary billing-state error without exposing internal reason codes.
 
-When the user has no canonical personal KiloClaw subscription history, the
-KiloClaw group MUST state that new subscriptions are unavailable and MUST NOT
-show a signup or enrollment action. Users with existing canonical personal
-subscription history retain the applicable enrollment, recovery, and management
-surfaces. Canceled KiloClaw history MUST NOT cause Commit, an earlier price, or
-an earlier entitlement to appear as the available offer. Stripe-funded
+When the user has no current personal KiloClaw subscription, the KiloClaw group
+MUST state that new instances are unavailable and MUST NOT show a signup,
+enrollment, or recovery action. Users with a current personal subscription or an
+existing live instance retain the applicable enrollment, recovery, and
+management surfaces. Canceled, expired, suspended, transferred-out, and purely
+historical KiloClaw rows MUST NOT cause an available offer, Commit, an earlier
+price, or an earlier entitlement to appear. Stripe-funded
 enrollment awaiting invoice settlement MUST be presented as pending rather
 than active. Active and terminal history MUST continue to show historical
 Commit names, prices, invoices, and credit deductions.

--- a/.specs/subscription-center.md
+++ b/.specs/subscription-center.md
@@ -29,6 +29,7 @@ Updated 2026-06-19 -- Current Coding Plan quota presentation and routing indepen
 Updated 2026-07-01 -- Coding Plans installed-key deletion blocked in BYOK.
 Updated 2026-06-26 -- MiniMax token plan tiers and provider-level Coding Plan exclusivity.
 Updated 2026-08-05 -- BytePlus Coding Plan Pro catalog requirements.
+Updated 2026-08-05 -- closed fresh personal KiloClaw signup surfaces.
 
 ## Conventions
 
@@ -264,13 +265,15 @@ the change completes. Every final Commit summary card and detail view MUST
 state that hosting ends on the final date unless the customer continues
 month-to-month, and MUST expose the continuation action directly. When retirement state cannot be derived safely, the surface MUST hide unsafe billing actions, preserve only access supported by canonical state, and show a generic temporary billing-state error without exposing internal reason codes.
 
-When the user has no non-terminal KiloClaw subscription, the enrollment
-view MUST display Standard as the only currently available offer after the
-Commit sales cutoff. Canceled KiloClaw history MUST NOT cause Commit, an
-earlier price, or an earlier entitlement to appear as the available offer.
-Stripe-funded enrollment awaiting invoice settlement MUST be presented as
-pending rather than active. Active and terminal history MUST continue to show
-historical Commit names, prices, invoices, and credit deductions.
+When the user has no canonical personal KiloClaw subscription history, the
+KiloClaw group MUST state that new subscriptions are unavailable and MUST NOT
+show a signup or enrollment action. Users with existing canonical personal
+subscription history retain the applicable enrollment, recovery, and management
+surfaces. Canceled KiloClaw history MUST NOT cause Commit, an earlier price, or
+an earlier entitlement to appear as the available offer. Stripe-funded
+enrollment awaiting invoice settlement MUST be presented as pending rather
+than active. Active and terminal history MUST continue to show historical
+Commit names, prices, invoices, and credit deductions.
 
 ### Coding Plans Subscriptions (Personal Route)
 
@@ -496,6 +499,11 @@ not yet enforced in the current codebase:
    the current plan and seat count without management actions.
 
 ## Changelog
+
+### 2026-08-05 -- Close fresh personal KiloClaw signup surfaces
+
+- Replaced KiloClaw signup offers with an unavailable notice for users without canonical personal subscription history.
+- Preserved enrollment, recovery, and management surfaces for existing personal subscription history.
 
 ### 2026-07-14 -- Coding Plans installed keys made read-only
 

--- a/apps/mobile/src/components/kiloclaw/empty-state-content.tsx
+++ b/apps/mobile/src/components/kiloclaw/empty-state-content.tsx
@@ -53,8 +53,8 @@ export function EmptyStateContent({
     return (
       <EmptyState
         icon={Server}
-        title="New KiloClaw subscriptions are unavailable"
-        description="KiloClaw is no longer accepting new subscriptions. Existing subscribers can continue managing their service."
+        title="New KiloClaw instances are unavailable"
+        description="A current KiloClaw subscription is required to provision an instance. Existing instances and subscriptions continue as normal."
       />
     );
   }

--- a/apps/mobile/src/components/kiloclaw/empty-state-content.tsx
+++ b/apps/mobile/src/components/kiloclaw/empty-state-content.tsx
@@ -28,9 +28,9 @@ export function resolveAccessRequiredSubcase(
   ) {
     return state.state;
   }
-  // trial_eligible | has_access | pending_settlement — the `satisfies` guard forces
+  // signup_unavailable | has_access | pending_settlement — the `satisfies` guard forces
   // a typecheck failure if the server ever adds a new state kind we forgot to handle.
-  state.state satisfies 'trial_eligible' | 'has_access' | 'pending_settlement';
+  state.state satisfies 'signup_unavailable' | 'has_access' | 'pending_settlement';
   return null;
 }
 
@@ -45,6 +45,16 @@ export function EmptyStateContent({
         icon={Server}
         title="Finishing setup"
         description="Hang tight, we're finalizing your account. This usually takes a moment."
+      />
+    );
+  }
+
+  if (state.state === 'signup_unavailable') {
+    return (
+      <EmptyState
+        icon={Server}
+        title="New KiloClaw subscriptions are unavailable"
+        description="KiloClaw is no longer accepting new subscriptions. Existing subscribers can continue managing their service."
       />
     );
   }

--- a/apps/mobile/src/components/kiloclaw/onboarding-flow.tsx
+++ b/apps/mobile/src/components/kiloclaw/onboarding-flow.tsx
@@ -106,8 +106,7 @@ export function OnboardingFlow() {
     if (!data) {
       return;
     }
-    const kind = data.state;
-    const eligible = kind === 'trial_eligible' || kind === 'has_access';
+    const eligible = data.state === 'has_access';
     // pending_settlement means the subscription is activating; the instance
     // may already exist, in which case we should redirect rather than block.
     const hasAccessWithInstance =
@@ -378,6 +377,30 @@ export function OnboardingFlow() {
     const subcase = onboardingQuery.data
       ? resolveAccessRequiredSubcase(onboardingQuery.data)
       : null;
+    let unavailableContent: ReactNode = (
+      <View className="items-center gap-3 px-6">
+        <ActivityIndicator size="small" color={colors.mutedForeground} />
+        <Text variant="muted" className="text-center">
+          Finishing setup — hang tight while we finalize your account.
+        </Text>
+      </View>
+    );
+    if (onboardingQuery.data?.state === 'signup_unavailable') {
+      unavailableContent = (
+        <View className="items-center gap-2 px-6">
+          <Text className="text-center text-2xl font-semibold">
+            New KiloClaw subscriptions are unavailable
+          </Text>
+          <Text variant="muted" className="text-center text-base">
+            KiloClaw is no longer accepting new subscriptions. Existing subscribers can continue
+            managing their service.
+          </Text>
+        </View>
+      );
+    } else if (subcase) {
+      unavailableContent = <AccessRequiredScreen subcase={subcase} />;
+    }
+
     return (
       <View className="flex-1 bg-background">
         <ScreenHeader title="" modal showBackButton={false} headerRight={closeButton} />
@@ -385,19 +408,7 @@ export function OnboardingFlow() {
           entering={FadeIn.duration(200)}
           className="flex-1 items-center justify-center"
         >
-          {subcase ? (
-            <AccessRequiredScreen subcase={subcase} />
-          ) : (
-            // pending_settlement without an instance — the subscription is still
-            // activating server-side. `resolveAccessRequiredSubcase` returns null
-            // because this is neither an access-required nor a remediation case.
-            <View className="items-center gap-3 px-6">
-              <ActivityIndicator size="small" color={colors.mutedForeground} />
-              <Text variant="muted" className="text-center">
-                Finishing setup — hang tight while we finalize your account.
-              </Text>
-            </View>
-          )}
+          {unavailableContent}
         </Animated.View>
       </View>
     );

--- a/apps/mobile/src/components/kiloclaw/onboarding-flow.tsx
+++ b/apps/mobile/src/components/kiloclaw/onboarding-flow.tsx
@@ -389,11 +389,11 @@ export function OnboardingFlow() {
       unavailableContent = (
         <View className="items-center gap-2 px-6">
           <Text className="text-center text-2xl font-semibold">
-            New KiloClaw subscriptions are unavailable
+            New KiloClaw instances are unavailable
           </Text>
           <Text variant="muted" className="text-center text-base">
-            KiloClaw is no longer accepting new subscriptions. Existing subscribers can continue
-            managing their service.
+            A current KiloClaw subscription is required to provision an instance. Existing instances
+            and subscriptions continue as normal.
           </Text>
         </View>
       );

--- a/apps/mobile/src/lib/derive-mobile-onboarding-state.test.ts
+++ b/apps/mobile/src/lib/derive-mobile-onboarding-state.test.ts
@@ -144,6 +144,7 @@ function billingStatus(overrides: Partial<ClawBillingStatus> = {}): ClawBillingS
     hasAccess: false,
     hasActiveKiloPass: false,
     hasExistingPersonalSubscription: false,
+    hasCurrentPersonalSubscription: false,
     instance: null,
     intendedPriceVersion: '2026-05-10',
     intendedSelfServiceInstanceType: 'perf-1-3',
@@ -162,18 +163,15 @@ describe('deriveMobileOnboardingStateFromBilling', () => {
     });
   });
 
-  it('preserves existing subscriber recovery state', () => {
+  it('blocks recovery for historical subscribers without a current subscription', () => {
     expect(
       deriveMobileOnboardingStateFromBilling(
         billingStatus({
           hasExistingPersonalSubscription: true,
+          hasCurrentPersonalSubscription: false,
           trialEligible: false,
         })
       )
-    ).toEqual({
-      state: 'access_required',
-      reason: 'subscription_canceled',
-      instanceId: null,
-    });
+    ).toEqual({ state: 'signup_unavailable' });
   });
 });

--- a/apps/mobile/src/lib/derive-mobile-onboarding-state.test.ts
+++ b/apps/mobile/src/lib/derive-mobile-onboarding-state.test.ts
@@ -1,0 +1,179 @@
+import { describe, expect, it } from 'vitest';
+
+import { deriveMobileOnboardingStateFromBilling } from '@/lib/derive-mobile-onboarding-state';
+import { type ClawBillingStatus } from '@/lib/hooks/use-kiloclaw-billing';
+
+const emptyKiloPassUpsellPreview: ClawBillingStatus['kiloPassUpsellPreview'] = {
+  commit: {
+    monthly: {
+      '19': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+      '49': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+      '199': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+    },
+    yearly: {
+      '19': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+      '49': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+      '199': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+    },
+  },
+  standard: {
+    monthly: {
+      '19': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+      '49': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+      '199': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+    },
+    yearly: {
+      '19': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+      '49': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+      '199': {
+        costMicrodollars: 0,
+        eligible: false,
+        projectedKiloPassBaseMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        shortfallMicrodollars: 0,
+      },
+    },
+  },
+};
+
+function billingStatus(overrides: Partial<ClawBillingStatus> = {}): ClawBillingStatus {
+  return {
+    accessReason: null,
+    commitPlanAvailable: false,
+    creditBalanceMicrodollars: 0,
+    creditEnrollmentPreview: {
+      commit: {
+        costMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+      },
+      standard: {
+        costMicrodollars: 0,
+        effectiveBalanceMicrodollars: 0,
+        projectedKiloPassBonusMicrodollars: 0,
+      },
+    },
+    creditIntroEligible: false,
+    creditReprovisionRecovery: {
+      costMicrodollars: 0,
+      effectiveBalanceMicrodollars: 0,
+      eligible: false,
+      plan: 'standard',
+      projectedKiloPassBonusMicrodollars: 0,
+      shortfallMicrodollars: 0,
+    },
+    earlybird: null,
+    hasAccess: false,
+    hasActiveKiloPass: false,
+    hasExistingPersonalSubscription: false,
+    instance: null,
+    intendedPriceVersion: '2026-05-10',
+    intendedSelfServiceInstanceType: 'perf-1-3',
+    kiloPassUpsellPreview: emptyKiloPassUpsellPreview,
+    subscription: null,
+    trial: null,
+    trialEligible: true,
+    ...overrides,
+  };
+}
+
+describe('deriveMobileOnboardingStateFromBilling', () => {
+  it('closes fresh mobile signup even when the legacy trial flag is true', () => {
+    expect(deriveMobileOnboardingStateFromBilling(billingStatus())).toEqual({
+      state: 'signup_unavailable',
+    });
+  });
+
+  it('preserves existing subscriber recovery state', () => {
+    expect(
+      deriveMobileOnboardingStateFromBilling(
+        billingStatus({
+          hasExistingPersonalSubscription: true,
+          trialEligible: false,
+        })
+      )
+    ).toEqual({
+      state: 'access_required',
+      reason: 'subscription_canceled',
+      instanceId: null,
+    });
+  });
+});

--- a/apps/mobile/src/lib/derive-mobile-onboarding-state.ts
+++ b/apps/mobile/src/lib/derive-mobile-onboarding-state.ts
@@ -52,7 +52,7 @@ export function deriveMobileOnboardingStateFromBilling(
     return { state: 'quarantined', instanceId: liveInstanceId };
   }
 
-  if (!billing.hasExistingPersonalSubscription) {
+  if (!billing.hasCurrentPersonalSubscription) {
     return { state: 'signup_unavailable' };
   }
 

--- a/apps/mobile/src/lib/derive-mobile-onboarding-state.ts
+++ b/apps/mobile/src/lib/derive-mobile-onboarding-state.ts
@@ -13,7 +13,7 @@ import { type ClawBillingStatus } from '@/lib/hooks/use-kiloclaw-billing';
  */
 
 export type MobileOnboardingState =
-  | { state: 'trial_eligible' }
+  | { state: 'signup_unavailable' }
   | {
       state: 'has_access';
       accessReason: 'trial' | 'subscription' | 'earlybird';
@@ -52,8 +52,8 @@ export function deriveMobileOnboardingStateFromBilling(
     return { state: 'quarantined', instanceId: liveInstanceId };
   }
 
-  if (billing.trialEligible) {
-    return { state: 'trial_eligible' };
+  if (!billing.hasExistingPersonalSubscription) {
+    return { state: 'signup_unavailable' };
   }
 
   return {

--- a/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
@@ -79,7 +79,7 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
     return <>{children}</>;
   }
 
-  if (!billing.hasExistingPersonalSubscription) {
+  if (!billing.hasCurrentPersonalSubscription && !billing.instance?.exists) {
     return (
       <div className="flex w-full flex-1 items-center justify-center p-4 md:p-6">
         <KiloClawSignupUnavailable />

--- a/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
+++ b/apps/web/src/app/(app)/claw/components/billing/BillingWrapper.tsx
@@ -6,6 +6,7 @@ import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Button } from '@/components/ui/button';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
+import { KiloClawSignupUnavailable } from '@/components/subscriptions/kiloclaw/KiloClawSignupUnavailable';
 import { BillingBanner } from './BillingBanner';
 import { AccessLockedDialog } from './AccessLockedDialog';
 import { PlanSelectionDialog } from './PlanSelectionDialog';
@@ -58,7 +59,9 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
   const destroy = useMutation(
     trpc.kiloclaw.destroy.mutationOptions({
       onSuccess: () => {
-        void queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() });
+        void queryClient.invalidateQueries({
+          queryKey: trpc.kiloclaw.getStatus.queryKey(),
+        });
         void queryClient.invalidateQueries({
           queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
         });
@@ -74,6 +77,14 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
 
   if (!billing) {
     return <>{children}</>;
+  }
+
+  if (!billing.hasExistingPersonalSubscription) {
+    return (
+      <div className="flex w-full flex-1 items-center justify-center p-4 md:p-6">
+        <KiloClawSignupUnavailable />
+      </div>
+    );
   }
 
   const lockReason = deriveLockReason(billing);
@@ -100,10 +111,14 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
               queryKey: trpc.kiloclaw.listPersonalSubscriptions.queryKey(),
             }),
             queryClient.invalidateQueries({
-              queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({ instanceId }),
+              queryKey: trpc.kiloclaw.getSubscriptionDetail.queryKey({
+                instanceId,
+              }),
             }),
             queryClient.invalidateQueries({
-              queryKey: trpc.kiloclaw.getBillingHistory.queryKey({ instanceId }),
+              queryKey: trpc.kiloclaw.getBillingHistory.queryKey({
+                instanceId,
+              }),
             }),
           ]);
         },
@@ -130,7 +145,9 @@ export function BillingWrapper({ children, hideBanners }: BillingWrapperProps) {
       {
         onSuccess: result => {
           void Promise.all([
-            queryClient.invalidateQueries({ queryKey: trpc.kiloclaw.getStatus.queryKey() }),
+            queryClient.invalidateQueries({
+              queryKey: trpc.kiloclaw.getStatus.queryKey(),
+            }),
             queryClient.invalidateQueries({
               queryKey: trpc.kiloclaw.getActivePersonalBillingStatus.queryKey(),
             }),

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
@@ -37,6 +37,7 @@ function createBillingStatus(overrides?: BillingStatusOverrides): ClawBillingSta
   return {
     hasAccess: false,
     accessReason: null,
+    hasExistingPersonalSubscription: true,
     trialEligible: false,
     creditBalanceMicrodollars: 0,
     creditIntroEligible: false,
@@ -65,12 +66,28 @@ function createBillingStatus(overrides?: BillingStatusOverrides): ClawBillingSta
     },
     kiloPassUpsellPreview: {
       standard: {
-        monthly: { '19': emptyUpsellPreview, '49': emptyUpsellPreview, '199': emptyUpsellPreview },
-        yearly: { '19': emptyUpsellPreview, '49': emptyUpsellPreview, '199': emptyUpsellPreview },
+        monthly: {
+          '19': emptyUpsellPreview,
+          '49': emptyUpsellPreview,
+          '199': emptyUpsellPreview,
+        },
+        yearly: {
+          '19': emptyUpsellPreview,
+          '49': emptyUpsellPreview,
+          '199': emptyUpsellPreview,
+        },
       },
       commit: {
-        monthly: { '19': emptyUpsellPreview, '49': emptyUpsellPreview, '199': emptyUpsellPreview },
-        yearly: { '19': emptyUpsellPreview, '49': emptyUpsellPreview, '199': emptyUpsellPreview },
+        monthly: {
+          '19': emptyUpsellPreview,
+          '49': emptyUpsellPreview,
+          '199': emptyUpsellPreview,
+        },
+        yearly: {
+          '19': emptyUpsellPreview,
+          '49': emptyUpsellPreview,
+          '199': emptyUpsellPreview,
+        },
       },
     },
     trial: null,
@@ -181,6 +198,7 @@ describe('KiloClaw funding and recovery copy', () => {
     ['credits_not_settled', true, null, null],
     ['enrollment_failed', true, '/claw/subscription', 'Choose hosting plan'],
     ['requires_reprovision', false, null, null],
+    ['signup_unavailable', false, '/profile', 'Go to profile'],
     ['missing_instance', false, null, null],
     ['destroyed_instance', false, null, null],
     ['stale_intent', false, '/claw/subscription', 'Choose hosting plan'],
@@ -199,7 +217,10 @@ describe('KiloClaw funding and recovery copy', () => {
 
   it('distinguishes credit-funded hosting from a separate recurring Stripe subscription', () => {
     expect(
-      getKiloClawFundingChoiceCopy({ plan: 'standard', costMicrodollars: 55_000_000 })
+      getKiloClawFundingChoiceCopy({
+        plan: 'standard',
+        costMicrodollars: 55_000_000,
+      })
     ).toEqual({
       creditHeading: 'Credit-funded hosting',
       creditDescription:

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.test.ts
@@ -38,6 +38,7 @@ function createBillingStatus(overrides?: BillingStatusOverrides): ClawBillingSta
     hasAccess: false,
     accessReason: null,
     hasExistingPersonalSubscription: true,
+    hasCurrentPersonalSubscription: true,
     trialEligible: false,
     creditBalanceMicrodollars: 0,
     creditIntroEligible: false,

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
@@ -293,6 +293,7 @@ export type KiloPassHostingRecoveryReason =
   | 'credits_not_settled'
   | 'enrollment_failed'
   | 'requires_reprovision'
+  | 'signup_unavailable'
   | 'missing_instance'
   | 'destroyed_instance'
   | 'stale_intent'
@@ -339,6 +340,16 @@ export function getKiloPassHostingRecoveryCopy(reason: KiloPassHostingRecoveryRe
         destinationLabel: null,
         canRetry: false,
         showSupport: true,
+      };
+    case 'signup_unavailable':
+      return {
+        title: 'New KiloClaw subscriptions are unavailable',
+        description:
+          'Your Kilo Pass credits are ready, but this checkout cannot create a first KiloClaw subscription.',
+        destination: '/profile',
+        destinationLabel: 'Go to profile',
+        canRetry: false,
+        showSupport: false,
       };
     case 'missing_instance':
       return {
@@ -436,6 +447,8 @@ export function planPriceLabel(plan: ClawPlan, priceVersion?: string): string {
 export type ClawBillingStatus = {
   hasAccess: boolean;
   accessReason: 'trial' | 'subscription' | 'earlybird' | null;
+  /** Whether this user already has a canonical personal KiloClaw subscription row. */
+  hasExistingPersonalSubscription: boolean;
   trialEligible: boolean;
 
   /** User's credit balance in microdollars (null when not fetched). */

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
@@ -447,8 +447,10 @@ export function planPriceLabel(plan: ClawPlan, priceVersion?: string): string {
 export type ClawBillingStatus = {
   hasAccess: boolean;
   accessReason: 'trial' | 'subscription' | 'earlybird' | null;
-  /** Whether this user already has a canonical personal KiloClaw subscription row. */
+  /** Whether this user has any canonical personal KiloClaw subscription history. */
   hasExistingPersonalSubscription: boolean;
+  /** Whether this user has a current personal subscription that permits replacement provisioning. */
+  hasCurrentPersonalSubscription: boolean;
   trialEligible: boolean;
 
   /** User's credit balance in microdollars (null when not fetched). */

--- a/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
+++ b/apps/web/src/app/(app)/claw/components/billing/billing-types.ts
@@ -343,9 +343,9 @@ export function getKiloPassHostingRecoveryCopy(reason: KiloPassHostingRecoveryRe
       };
     case 'signup_unavailable':
       return {
-        title: 'New KiloClaw subscriptions are unavailable',
+        title: 'New KiloClaw instances are unavailable',
         description:
-          'Your Kilo Pass credits are ready, but this checkout cannot create a first KiloClaw subscription.',
+          'Your Kilo Pass credits are ready, but a current KiloClaw subscription is required to provision an instance.',
         destination: '/profile',
         destinationLabel: 'Go to profile',
         canRetry: false,

--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
@@ -127,7 +127,7 @@ function ClawNewLiveClient() {
 
   const billing = billingQuery.data;
 
-  if (billing && !billing.hasExistingPersonalSubscription) {
+  if (billing && !billing.hasCurrentPersonalSubscription) {
     return (
       <div
         className="container m-auto flex w-full max-w-[1140px] items-center justify-center p-4 md:p-6"

--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
@@ -13,7 +13,6 @@ import {
 } from '../components';
 import type { ClawOnboardingRenderStep } from '../components/ClawOnboardingFlow.state';
 import { ClawOnboardingFakeWalkthrough } from '../components/ClawOnboardingFakeWalkthrough';
-import { WelcomePage } from '../components/billing/WelcomePage';
 import { getClawNewStatusQueryForBoundary } from './ClawNewClient.state';
 
 const ClawOnboardingWithBoundary = withStatusQueryBoundary(ClawOnboardingFlow);
@@ -134,21 +133,6 @@ function ClawNewLiveClient() {
         style={{ minHeight: '50vh' }}
       >
         <KiloClawSignupUnavailable />
-      </div>
-    );
-  }
-
-  const isNewUser =
-    billing &&
-    !billing.hasAccess &&
-    billing.instance === null &&
-    !billing.earlybird &&
-    !billing.trial?.expired;
-
-  if (isNewUser && !billing.trialEligible) {
-    return (
-      <div className="container m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
-        <WelcomePage />
       </div>
     );
   }

--- a/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
+++ b/apps/web/src/app/(app)/claw/new/ClawNewClient.tsx
@@ -5,6 +5,7 @@ import { Loader2 } from 'lucide-react';
 import { useQuery } from '@tanstack/react-query';
 import { useKiloClawStatus } from '@/hooks/useKiloClaw';
 import { useTRPC } from '@/lib/trpc/utils';
+import { KiloClawSignupUnavailable } from '@/components/subscriptions/kiloclaw/KiloClawSignupUnavailable';
 import {
   ClawOnboardingFlow,
   type ClawOnboardingMode,
@@ -125,6 +126,18 @@ function ClawNewLiveClient() {
   }
 
   const billing = billingQuery.data;
+
+  if (billing && !billing.hasExistingPersonalSubscription) {
+    return (
+      <div
+        className="container m-auto flex w-full max-w-[1140px] items-center justify-center p-4 md:p-6"
+        style={{ minHeight: '50vh' }}
+      >
+        <KiloClawSignupUnavailable />
+      </div>
+    );
+  }
+
   const isNewUser =
     billing &&
     !billing.hasAccess &&

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -360,14 +360,7 @@ export default function OrganizationAppSidebar({
           suffixIcon: ChevronRight,
         },
       ]
-    : [
-        {
-          title: 'KiloClaw',
-          icon: MessageSquare,
-          url: kiloClawInstanceState === 'absent' ? `${kiloClawBaseUrl}/new` : kiloClawBaseUrl,
-          isActive: isKiloClawPath,
-        },
-      ];
+    : [];
 
   const backItems: Array<{
     title: string;
@@ -417,7 +410,9 @@ export default function OrganizationAppSidebar({
         ) : (
           <>
             <SidebarMenuList label="Dashboard" items={dashboardItems} allUrls={allUrls} />
-            <SidebarMenuList label={null} items={kiloClawEntryItems} allUrls={allUrls} />
+            {kiloClawEntryItems.length > 0 && (
+              <SidebarMenuList label={null} items={kiloClawEntryItems} allUrls={allUrls} />
+            )}
             {cloudItems.length > 0 && (
               <SidebarMenuList label="Cloud" items={cloudItems} allUrls={allUrls} />
             )}

--- a/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/OrganizationAppSidebar.tsx
@@ -334,6 +334,8 @@ export default function OrganizationAppSidebar({
       : 'absent'
     : 'unknown';
   const hasKiloClawInstance = kiloClawInstanceState === 'present';
+  const shouldShowKiloClaw =
+    kiloClawNavStateQuery.isSuccess && kiloClawNavStateQuery.data.hasCurrentSubscription;
   const isKiloClawPath = pathname === kiloClawBaseUrl || pathname.startsWith(kiloClawBaseUrl + '/');
   const [sidebarMenu, setSidebarMenu] = useState<'main' | 'kiloClaw'>(
     isKiloClawPath && hasKiloClawInstance ? 'kiloClaw' : 'main'
@@ -350,17 +352,18 @@ export default function OrganizationAppSidebar({
     onClick?: () => void;
     isActive: boolean;
     suffixIcon?: React.ElementType;
-  }> = hasKiloClawInstance
-    ? [
-        {
-          title: 'KiloClaw',
-          icon: MessageSquare,
-          onClick: () => setSidebarMenu('kiloClaw'),
-          isActive: isKiloClawPath,
-          suffixIcon: ChevronRight,
-        },
-      ]
-    : [];
+  }> =
+    shouldShowKiloClaw && hasKiloClawInstance
+      ? [
+          {
+            title: 'KiloClaw',
+            icon: MessageSquare,
+            onClick: () => setSidebarMenu('kiloClaw'),
+            isActive: isKiloClawPath,
+            suffixIcon: ChevronRight,
+          },
+        ]
+      : [];
 
   const backItems: Array<{
     title: string;

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -264,6 +264,8 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       : 'absent'
     : 'unknown';
   const hasKiloClawInstance = kiloClawInstanceState === 'present';
+  const shouldShowKiloClaw =
+    kiloClawNavStateQuery.isSuccess && kiloClawNavStateQuery.data.hasExistingPersonalSubscription;
   const isKiloClawPath = pathname === kiloClawBaseUrl || pathname.startsWith(kiloClawBaseUrl + '/');
   const [sidebarMenuOverride, setSidebarMenuOverride] = useState<{
     pathname: string;
@@ -283,24 +285,26 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     onClick?: () => void;
     isActive: boolean;
     suffixIcon?: React.ElementType;
-  }> = hasKiloClawInstance
-    ? [
-        {
-          title: 'KiloClaw',
-          icon: MessageSquare,
-          onClick: () => setSidebarMenuOverride({ pathname, menu: 'kiloClaw' }),
-          isActive: isKiloClawPath,
-          suffixIcon: ChevronRight,
-        },
-      ]
-    : [
-        {
-          title: 'KiloClaw',
-          icon: MessageSquare,
-          url: kiloClawInstanceState === 'absent' ? `${kiloClawBaseUrl}/new` : kiloClawBaseUrl,
-          isActive: isKiloClawPath,
-        },
-      ];
+  }> = !shouldShowKiloClaw
+    ? []
+    : hasKiloClawInstance
+      ? [
+          {
+            title: 'KiloClaw',
+            icon: MessageSquare,
+            onClick: () => setSidebarMenuOverride({ pathname, menu: 'kiloClaw' }),
+            isActive: isKiloClawPath,
+            suffixIcon: ChevronRight,
+          },
+        ]
+      : [
+          {
+            title: 'KiloClaw',
+            icon: MessageSquare,
+            url: `${kiloClawBaseUrl}/new`,
+            isActive: isKiloClawPath,
+          },
+        ];
 
   const backItems: Array<{
     title: string;
@@ -344,7 +348,9 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
         ) : (
           <>
             <SidebarMenuList label="Dashboard" items={dashboardItems} allUrls={allUrls} />
-            <SidebarMenuList label={null} items={kiloClawEntryItems} allUrls={allUrls} />
+            {kiloClawEntryItems.length > 0 && (
+              <SidebarMenuList label={null} items={kiloClawEntryItems} allUrls={allUrls} />
+            )}
             {cloudItems.length > 0 && (
               <SidebarMenuList label="Cloud" items={cloudItems} allUrls={allUrls} />
             )}

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -265,7 +265,9 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
     : 'unknown';
   const hasKiloClawInstance = kiloClawInstanceState === 'present';
   const shouldShowKiloClaw =
-    kiloClawNavStateQuery.isSuccess && kiloClawNavStateQuery.data.hasExistingPersonalSubscription;
+    kiloClawNavStateQuery.isSuccess &&
+    (kiloClawNavStateQuery.data.hasActiveInstance ||
+      kiloClawNavStateQuery.data.hasCurrentPersonalSubscription);
   const isKiloClawPath = pathname === kiloClawBaseUrl || pathname.startsWith(kiloClawBaseUrl + '/');
   const [sidebarMenuOverride, setSidebarMenuOverride] = useState<{
     pathname: string;

--- a/apps/web/src/app/(app)/organizations/[id]/claw/new/OrgClawNewClient.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/claw/new/OrgClawNewClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useCallback, useEffect, useState } from 'react';
-import { useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
+import { useOrgKiloClawNavState, useOrgKiloClawStatus } from '@/hooks/useOrgKiloClaw';
+import { KiloClawSignupUnavailable } from '@/components/subscriptions/kiloclaw/KiloClawSignupUnavailable';
 import {
   ClawOnboardingFlow,
   type ClawOnboardingMode,
@@ -33,6 +34,7 @@ export function OrgClawNewClient({
 
 function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
   const statusQuery = useOrgKiloClawStatus(organizationId);
+  const navStateQuery = useOrgKiloClawNavState(organizationId);
   const [createFlowStartedAt, setCreateFlowStartedAt] = useState<number | null>(null);
   const [setupFailed, setSetupFailed] = useState(false);
   const [hasSettledStatus, setHasSettledStatus] = useState(false);
@@ -50,6 +52,38 @@ function OrgClawNewLiveClient({ organizationId }: { organizationId: string }) {
       setHasSettledStatus(true);
     }
   }, [statusQuery.data, statusQuery.error, statusQuery.isFetching]);
+
+  if (navStateQuery.isLoading) {
+    return (
+      <ClawOnboardingWithBoundary
+        statusQuery={{ data: undefined, isLoading: true, error: null }}
+        mode="post-provisioning"
+        organizationId={organizationId}
+        createFlowStarted={false}
+        setupFailed={false}
+        onCreateFlowStarted={onCreateFlowStarted}
+        onCreateFlowFailed={onCreateFlowFailed}
+      />
+    );
+  }
+
+  if (navStateQuery.isError) {
+    return (
+      <div className="container m-auto flex min-h-[50vh] w-full max-w-[1140px] items-center justify-center p-4 md:p-6">
+        <p className="text-destructive text-sm">
+          Unable to load KiloClaw eligibility. Please refresh the page or try again later.
+        </p>
+      </div>
+    );
+  }
+
+  if (navStateQuery.data?.hasCurrentSubscription !== true) {
+    return (
+      <div className="container m-auto flex min-h-[50vh] w-full max-w-[1140px] items-center justify-center p-4 md:p-6">
+        <KiloClawSignupUnavailable />
+      </div>
+    );
+  }
 
   if (createFlowStartedAt !== null) {
     const createStatus =

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
@@ -21,6 +21,7 @@ import { useInvalidateKiloClawBilling } from './useKiloClawBillingQueries';
 import KiloCrabIcon from '@/components/KiloCrabIcon';
 import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
 import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
+import { KiloClawSignupUnavailable } from './KiloClawSignupUnavailable';
 import { KiloClawSubscribeCard } from './KiloClawSubscribeCard';
 import {
   formatDateLabel,
@@ -195,6 +196,8 @@ export function KiloClawGroup({
             );
           })}
         </div>
+      ) : subscriptions.length === 0 ? (
+        <KiloClawSignupUnavailable />
       ) : nonTerminalSubscriptions.length === 0 ? (
         <KiloClawSubscribeCard
           standardCostMicrodollars={

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
@@ -58,8 +58,7 @@ export function KiloClawGroup({
   const subscriptions = query.data?.subscriptions ?? [];
   const commitPlanAvailable =
     query.data?.commitPlanAvailable ?? summaryQuery.data?.commitPlanAvailable ?? false;
-  const hasExistingPersonalSubscription =
-    summaryQuery.data?.hasExistingPersonalSubscription === true;
+  const hasCurrentPersonalSubscription = summaryQuery.data?.hasCurrentPersonalSubscription === true;
   const isLoading = query.isLoading || summaryQuery.isLoading;
   const isError = query.isError || summaryQuery.isError;
   const error = query.error ?? summaryQuery.error;
@@ -203,7 +202,7 @@ export function KiloClawGroup({
             );
           })}
         </div>
-      ) : subscriptions.length === 0 && !hasExistingPersonalSubscription ? (
+      ) : subscriptions.length === 0 && !hasCurrentPersonalSubscription ? (
         <KiloClawSignupUnavailable />
       ) : subscriptions.length === 0 || nonTerminalSubscriptions.length === 0 ? (
         <KiloClawSubscribeCard

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawGroup.tsx
@@ -58,6 +58,11 @@ export function KiloClawGroup({
   const subscriptions = query.data?.subscriptions ?? [];
   const commitPlanAvailable =
     query.data?.commitPlanAvailable ?? summaryQuery.data?.commitPlanAvailable ?? false;
+  const hasExistingPersonalSubscription =
+    summaryQuery.data?.hasExistingPersonalSubscription === true;
+  const isLoading = query.isLoading || summaryQuery.isLoading;
+  const isError = query.isError || summaryQuery.isError;
+  const error = query.error ?? summaryQuery.error;
 
   const visibleSubscriptions = subscriptions.filter(
     subscription => !isKiloclawTerminal(subscription.status) || showTerminal
@@ -100,10 +105,12 @@ export function KiloClawGroup({
       title="KiloClaw"
       description="View hosting subscriptions for your personal KiloClaw instances."
       headerIcon={<KiloCrabIcon className="size-5" />}
-      isLoading={query.isLoading}
-      isError={query.isError}
-      error={query.error}
-      onRetry={() => void query.refetch()}
+      isLoading={isLoading}
+      isError={isError}
+      error={error}
+      onRetry={() => {
+        void Promise.all([query.refetch(), summaryQuery.refetch()]);
+      }}
       accordionValue={accordionValue}
       hideHeader={hideHeader}
       unframed={hideHeader}
@@ -196,9 +203,9 @@ export function KiloClawGroup({
             );
           })}
         </div>
-      ) : subscriptions.length === 0 ? (
+      ) : subscriptions.length === 0 && !hasExistingPersonalSubscription ? (
         <KiloClawSignupUnavailable />
-      ) : nonTerminalSubscriptions.length === 0 ? (
+      ) : subscriptions.length === 0 || nonTerminalSubscriptions.length === 0 ? (
         <KiloClawSubscribeCard
           standardCostMicrodollars={
             summaryQuery.data?.creditEnrollmentPreview.standard.costMicrodollars

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawSignupUnavailable.test.ts
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawSignupUnavailable.test.ts
@@ -7,8 +7,9 @@ describe('KiloClawSignupUnavailable', () => {
   it('explains the closure without rendering a signup action', () => {
     const markup = renderToStaticMarkup(React.createElement(KiloClawSignupUnavailable));
 
-    expect(markup).toContain('New KiloClaw subscriptions are unavailable');
-    expect(markup).toContain('Existing subscriptions continue as normal.');
+    expect(markup).toContain('New KiloClaw instances are unavailable');
+    expect(markup).toContain('A current KiloClaw subscription is required');
+    expect(markup).toContain('Existing instances and subscriptions continue as normal.');
     expect(markup).not.toContain('<button');
     expect(markup).not.toContain('<a');
   });

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawSignupUnavailable.test.ts
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawSignupUnavailable.test.ts
@@ -1,0 +1,15 @@
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { describe, expect, it } from '@jest/globals';
+import { KiloClawSignupUnavailable } from './KiloClawSignupUnavailable';
+
+describe('KiloClawSignupUnavailable', () => {
+  it('explains the closure without rendering a signup action', () => {
+    const markup = renderToStaticMarkup(React.createElement(KiloClawSignupUnavailable));
+
+    expect(markup).toContain('New KiloClaw subscriptions are unavailable');
+    expect(markup).toContain('Existing subscriptions continue as normal.');
+    expect(markup).not.toContain('<button');
+    expect(markup).not.toContain('<a');
+  });
+});

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawSignupUnavailable.tsx
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawSignupUnavailable.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { CircleOff } from 'lucide-react';
+import { Card, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+
+export function KiloClawSignupUnavailable() {
+  return (
+    <Card className="mx-auto w-full max-w-lg">
+      <CardHeader className="items-center text-center">
+        <div className="bg-muted text-muted-foreground flex size-10 items-center justify-center rounded-full">
+          <CircleOff aria-hidden="true" className="size-5" />
+        </div>
+        <CardTitle>New KiloClaw subscriptions are unavailable</CardTitle>
+        <CardDescription>
+          KiloClaw is no longer accepting new subscriptions. Existing subscriptions continue as
+          normal.
+        </CardDescription>
+      </CardHeader>
+    </Card>
+  );
+}

--- a/apps/web/src/components/subscriptions/kiloclaw/KiloClawSignupUnavailable.tsx
+++ b/apps/web/src/components/subscriptions/kiloclaw/KiloClawSignupUnavailable.tsx
@@ -9,10 +9,10 @@ export function KiloClawSignupUnavailable() {
         <div className="bg-muted text-muted-foreground flex size-10 items-center justify-center rounded-full">
           <CircleOff aria-hidden="true" className="size-5" />
         </div>
-        <CardTitle>New KiloClaw subscriptions are unavailable</CardTitle>
+        <CardTitle>New KiloClaw instances are unavailable</CardTitle>
         <CardDescription>
-          KiloClaw is no longer accepting new subscriptions. Existing subscriptions continue as
-          normal.
+          A current KiloClaw subscription is required to provision an instance. Existing instances
+          and subscriptions continue as normal.
         </CardDescription>
       </CardHeader>
     </Card>

--- a/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
+++ b/apps/web/src/lib/kiloclaw/personal-subscription-destroy-collapse.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, jest } from '@jest/globals';
 import {
-  CURRENT_KILOCLAW_PRICE_VERSION,
   LEGACY_KILOCLAW_PRICE_VERSION,
   type KiloClawPriceVersion,
   collapseOrphanPersonalSubscriptionsOnDestroy,
@@ -1220,7 +1219,7 @@ describe('personal subscription destroy collapse', () => {
     await expectCurrentHead({ subscriptionId: successor.id, userId: user.id });
   });
 
-  it('expired trial row + destroyed instance creates a fresh current trial', async () => {
+  it('rejects replacement provisioning for an expired trial on a destroyed instance', async () => {
     const user = await insertTestUser({
       google_user_email: 'destroy-expired-trial-blocks-provision@example.com',
     });
@@ -1251,24 +1250,16 @@ describe('personal subscription destroy collapse', () => {
       trialEndsAt: '2026-04-08T00:00:00.000Z',
     });
 
-    const created = await bootstrapProvisionSubscriptionWithDb({
-      db,
-      input: { userId: user.id, instanceId: newInstanceId, orgId: null },
-      actor: TEST_ACTOR,
-    });
-
-    expect(created).toEqual(
-      expect.objectContaining({
-        user_id: user.id,
-        instance_id: newInstanceId,
-        plan: 'trial',
-        status: 'trialing',
-        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    await expect(
+      bootstrapProvisionSubscriptionWithDb({
+        db,
+        input: { userId: user.id, instanceId: newInstanceId, orgId: null },
+        actor: TEST_ACTOR,
       })
-    );
+    ).rejects.toThrow('A current KiloClaw subscription is required to provision an instance.');
   });
 
-  it('past-due suspended row creates a fresh current trial', async () => {
+  it('rejects replacement provisioning for a suspended past-due row', async () => {
     const user = await insertTestUser({
       google_user_email: 'destroy-past-due-suspended-blocks-provision@example.com',
     });
@@ -1298,21 +1289,13 @@ describe('personal subscription destroy collapse', () => {
       suspendedAt: '2026-04-08T00:00:00.000Z',
     });
 
-    const created = await bootstrapProvisionSubscriptionWithDb({
-      db,
-      input: { userId: user.id, instanceId: newInstanceId, orgId: null },
-      actor: TEST_ACTOR,
-    });
-
-    expect(created).toEqual(
-      expect.objectContaining({
-        user_id: user.id,
-        instance_id: newInstanceId,
-        plan: 'trial',
-        status: 'trialing',
-        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    await expect(
+      bootstrapProvisionSubscriptionWithDb({
+        db,
+        input: { userId: user.id, instanceId: newInstanceId, orgId: null },
+        actor: TEST_ACTOR,
       })
-    );
+    ).rejects.toThrow('A current KiloClaw subscription is required to provision an instance.');
   });
 
   it('refuses collapse when multiple alive current funded personal rows exist', async () => {

--- a/apps/web/src/lib/kiloclaw/provision-bootstrap-shared-org.test.ts
+++ b/apps/web/src/lib/kiloclaw/provision-bootstrap-shared-org.test.ts
@@ -11,7 +11,10 @@ import {
   organization_seats_purchases,
   organizations,
 } from '@kilocode/db/schema';
-import { bootstrapProvisionSubscriptionWithDb } from '../../../../../services/kiloclaw-billing/src/provision-bootstrap-shared';
+import {
+  bootstrapProvisionSubscriptionWithDb,
+  KiloClawProvisioningUnavailableError,
+} from '../../../../../services/kiloclaw-billing/src/provision-bootstrap-shared';
 
 const BOOTSTRAP_ACTOR = {
   actorType: 'system',
@@ -59,7 +62,7 @@ describe('bootstrapProvisionSubscriptionWithDb organization replacement', () => 
     expect(logs).toHaveLength(0);
   });
 
-  it('keeps managed bootstrap for hard-expired organizations with a non-ended seat purchase', async () => {
+  it('rejects managed bootstrap without a current org subscription despite seat entitlement', async () => {
     const user = await insertTestUser({
       google_user_email: 'org-bootstrap-paid-hard-expired@example.com',
     });
@@ -86,23 +89,16 @@ describe('bootstrapProvisionSubscriptionWithDb organization replacement', () => 
       sandbox_id: `ki_${instanceId.replaceAll('-', '')}`,
     });
 
-    const subscription = await bootstrapProvisionSubscriptionWithDb({
-      db,
-      input: { userId: user.id, instanceId, orgId: organization.id },
-      actor: BOOTSTRAP_ACTOR,
-    });
-
-    expect(subscription).toEqual(
-      expect.objectContaining({
-        instance_id: instanceId,
-        payment_source: 'credits',
-        plan: 'standard',
-        status: 'active',
+    await expect(
+      bootstrapProvisionSubscriptionWithDb({
+        db,
+        input: { userId: user.id, instanceId, orgId: organization.id },
+        actor: BOOTSTRAP_ACTOR,
       })
-    );
+    ).rejects.toBeInstanceOf(KiloClawProvisioningUnavailableError);
   });
 
-  it('keeps managed bootstrap for hard-expired organizations with trial enforcement disabled', async () => {
+  it('rejects managed bootstrap without a current org subscription despite trial exemption', async () => {
     const user = await insertTestUser({
       google_user_email: 'org-bootstrap-exempt-hard-expired@example.com',
     });
@@ -126,20 +122,13 @@ describe('bootstrapProvisionSubscriptionWithDb organization replacement', () => 
       sandbox_id: `ki_${instanceId.replaceAll('-', '')}`,
     });
 
-    const subscription = await bootstrapProvisionSubscriptionWithDb({
-      db,
-      input: { userId: user.id, instanceId, orgId: organization.id },
-      actor: BOOTSTRAP_ACTOR,
-    });
-
-    expect(subscription).toEqual(
-      expect.objectContaining({
-        instance_id: instanceId,
-        payment_source: 'credits',
-        plan: 'standard',
-        status: 'active',
+    await expect(
+      bootstrapProvisionSubscriptionWithDb({
+        db,
+        input: { userId: user.id, instanceId, orgId: organization.id },
+        actor: BOOTSTRAP_ACTOR,
       })
-    );
+    ).rejects.toBeInstanceOf(KiloClawProvisioningUnavailableError);
   });
 
   it('transfers destroyed org predecessors to the new live row without touching personal or other-org rows', async () => {
@@ -307,6 +296,8 @@ describe('bootstrapProvisionSubscriptionWithDb organization replacement', () => 
     const oldestDestroyedInstanceId = crypto.randomUUID();
     const newestDestroyedInstanceId = crypto.randomUUID();
     const liveInstanceId = crypto.randomUUID();
+    const oldestDestroyedSubscriptionId = crypto.randomUUID();
+    const newestDestroyedSubscriptionId = crypto.randomUUID();
 
     await db.insert(kiloclaw_instances).values([
       {
@@ -338,16 +329,19 @@ describe('bootstrapProvisionSubscriptionWithDb organization replacement', () => 
       .insert(kiloclaw_subscriptions)
       .values([
         {
+          id: oldestDestroyedSubscriptionId,
           user_id: user.id,
           instance_id: oldestDestroyedInstanceId,
           plan: 'standard',
-          status: 'active',
+          status: 'canceled',
           payment_source: 'credits',
           cancel_at_period_end: false,
+          transferred_to_subscription_id: newestDestroyedSubscriptionId,
           created_at: '2026-02-01T00:00:00.000Z',
           updated_at: '2026-02-01T00:00:00.000Z',
         },
         {
+          id: newestDestroyedSubscriptionId,
           user_id: user.id,
           instance_id: newestDestroyedInstanceId,
           plan: 'standard',

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -167,7 +167,9 @@ type KiloPassCaller = {
     } | null;
     isEligibleForFirstMonthPromo: boolean;
   }>;
-  getAverageMonthlyUsageLast3Months: () => Promise<{ averageMonthlyUsageUsd: number }>;
+  getAverageMonthlyUsageLast3Months: () => Promise<{
+    averageMonthlyUsageUsd: number;
+  }>;
   getCheckoutReturnState: (input: { sessionId: string }) => Promise<{
     subscription: {
       stripeSubscriptionId: string | null;
@@ -199,6 +201,7 @@ type KiloPassCaller = {
           | 'missing_instance'
           | 'destroyed_instance'
           | 'requires_reprovision'
+          | 'signup_unavailable'
           | 'insufficient_credits'
           | 'expired_commit'
           | 'unexpected_error';
@@ -661,7 +664,9 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
 
       await expect(
-        caller.kiloPass.completeAppStorePurchase({ signedTransactionJws: 'signed-jws' })
+        caller.kiloPass.completeAppStorePurchase({
+          signedTransactionJws: 'signed-jws',
+        })
       ).rejects.toThrow('We could not verify this App Store purchase. Please try again.');
       expect(sentryMock.captureException).toHaveBeenCalledTimes(1);
     });
@@ -720,7 +725,9 @@ describe('kiloPassRouter', () => {
       const trackingMock = getPosthogTrackingMock();
       const user = await insertTestUser();
       verifierMock.verifyAppleKiloPassTransactionJws.mockResolvedValue(
-        appStorePurchaseFixture({ appAccountToken: user.app_store_account_token })
+        appStorePurchaseFixture({
+          appAccountToken: user.app_store_account_token,
+        })
       );
       completionMock.completeStoreKiloPassPurchase.mockResolvedValue({
         subscriptionId: 'sub-test-id',
@@ -753,7 +760,9 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
 
       await expect(
-        caller.kiloPass.completeAppStorePurchase({ signedTransactionJws: 'signed-jws' })
+        caller.kiloPass.completeAppStorePurchase({
+          signedTransactionJws: 'signed-jws',
+        })
       ).rejects.toThrow('App Store purchase account token does not match the signed-in user.');
       expect(completionMock.completeStoreKiloPassPurchase).not.toHaveBeenCalled();
       expect(sentryMock.captureException).not.toHaveBeenCalled();
@@ -771,7 +780,9 @@ describe('kiloPassRouter', () => {
       const caller = await createCallerForUser(user.id);
 
       await expect(
-        caller.kiloPass.completeAppStorePurchase({ signedTransactionJws: 'signed-jws' })
+        caller.kiloPass.completeAppStorePurchase({
+          signedTransactionJws: 'signed-jws',
+        })
       ).rejects.toThrow(
         "This App Store purchase isn't linked to your Kilo account. Make sure you're signed in to the Apple ID that made the purchase, then try again."
       );
@@ -798,17 +809,23 @@ describe('kiloPassRouter', () => {
       const sentryMock = getSentryMock();
       const user = await insertTestUser();
       verifierMock.verifyAppleKiloPassTransactionJws.mockResolvedValue(
-        appStorePurchaseFixture({ appAccountToken: user.app_store_account_token })
+        appStorePurchaseFixture({
+          appAccountToken: user.app_store_account_token,
+        })
       );
       completionMock.completeStoreKiloPassPurchase.mockRejectedValue(new Error(internalMessage));
 
       const caller = await createCallerForUser(user.id);
 
       await expect(
-        caller.kiloPass.completeAppStorePurchase({ signedTransactionJws: 'signed-jws' })
+        caller.kiloPass.completeAppStorePurchase({
+          signedTransactionJws: 'signed-jws',
+        })
       ).rejects.toThrow(safeMessage);
       await expect(
-        caller.kiloPass.completeAppStorePurchase({ signedTransactionJws: 'signed-jws' })
+        caller.kiloPass.completeAppStorePurchase({
+          signedTransactionJws: 'signed-jws',
+        })
       ).rejects.not.toThrow(internalMessage);
       expect(sentryMock.captureException).toHaveBeenCalled();
     });
@@ -2338,7 +2355,9 @@ describe('kiloPassRouter', () => {
       });
 
       const caller = await createCallerForUser(user.id);
-      const result = await caller.kiloPass.getCheckoutReturnState({ sessionId: 'cs_no_credits' });
+      const result = await caller.kiloPass.getCheckoutReturnState({
+        sessionId: 'cs_no_credits',
+      });
 
       expect(result.creditsAwarded).toBe(false);
       expect(result.welcomePromoIneligibleDueToReusedFingerprint).toBe(false);
@@ -2422,7 +2441,9 @@ describe('kiloPassRouter', () => {
       });
 
       const caller = await createCallerForUser(user.id);
-      const result = await caller.kiloPass.getCheckoutReturnState({ sessionId: 'cs_credits' });
+      const result = await caller.kiloPass.getCheckoutReturnState({
+        sessionId: 'cs_credits',
+      });
 
       expect(result.creditsAwarded).toBe(true);
       expect(result.welcomePromoIneligibleDueToReusedFingerprint).toBe(false);
@@ -2455,7 +2476,9 @@ describe('kiloPassRouter', () => {
       });
 
       const caller = await createCallerForUser(user.id);
-      const result = await caller.kiloPass.getCheckoutReturnState({ sessionId: 'cs_reused_card' });
+      const result = await caller.kiloPass.getCheckoutReturnState({
+        sessionId: 'cs_reused_card',
+      });
 
       expect(stripeMock.checkout.sessions.retrieve).toHaveBeenCalledWith('cs_reused_card');
       expect(result.creditsAwarded).toBe(true);
@@ -2464,6 +2487,64 @@ describe('kiloPassRouter', () => {
   });
 
   describe('activateCheckoutHosting', () => {
+    it('does not let a completed stale checkout create a first KiloClaw subscription', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-stale-first-kiloclaw@example.com',
+        total_microdollars_acquired: 199_000_000,
+      });
+      const instanceId = crypto.randomUUID();
+      await db.insert(kiloclaw_instances).values({
+        id: instanceId,
+        user_id: user.id,
+        sandbox_id: `test-${instanceId}`,
+      });
+      const { id: kiloPassSubscriptionId } = await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_stale_first_kiloclaw',
+        tier: KiloPassTier.Tier199,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+      });
+      await insertBaseCreditsIssuance({
+        subscriptionId: kiloPassSubscriptionId,
+        kiloUserId: user.id,
+      });
+
+      const stripeMock = getStripeMock();
+      stripeMock.checkout.sessions.retrieve.mockResolvedValue({
+        status: 'complete',
+        subscription: 'sub_stale_first_kiloclaw',
+        metadata: {
+          type: 'kilo-pass',
+          kiloUserId: user.id,
+          kiloclawHostingPlan: 'standard',
+          kiloclawInstanceId: instanceId,
+          kiloclawPriceVersion: '2026-05-10',
+        },
+      });
+      stripeMock.subscriptions.retrieve.mockResolvedValue({
+        id: 'sub_stale_first_kiloclaw',
+        created: Math.floor(new Date('2026-06-10T15:00:00.000Z').getTime() / 1000),
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_stale_first_kiloclaw',
+        })
+      ).resolves.toEqual({
+        outcome: 'action_required',
+        hostingIntent: 'standard',
+        reason: 'signup_unavailable',
+      });
+
+      const hostingRows = await db
+        .select()
+        .from(kiloclaw_subscriptions)
+        .where(eq(kiloclaw_subscriptions.user_id, user.id));
+      expect(hostingRows).toHaveLength(0);
+    });
+
     it('preserves canceled legacy lineage and requires reprovision after Kilo Pass credits settle', async () => {
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-canceled-legacy-hosting@example.com',
@@ -2748,7 +2829,9 @@ describe('kiloPassRouter', () => {
 
       const caller = await createCallerForUser(user.id);
       await expect(
-        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_stale_hosting_intent' })
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_stale_hosting_intent',
+        })
       ).resolves.toEqual({
         outcome: 'action_required',
         hostingIntent: 'standard',
@@ -2786,7 +2869,9 @@ describe('kiloPassRouter', () => {
 
       const caller = await createCallerForUser(user.id);
       await expect(
-        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_invalid_hosting_price_version' })
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_invalid_hosting_price_version',
+        })
       ).resolves.toEqual({
         outcome: 'action_required',
         hostingIntent: 'standard',
@@ -2829,7 +2914,9 @@ describe('kiloPassRouter', () => {
 
       const caller = await createCallerForUser(user.id);
       await expect(
-        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_missing_hosting_instance' })
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_missing_hosting_instance',
+        })
       ).resolves.toEqual({
         outcome: 'action_required',
         hostingIntent: 'standard',
@@ -2887,7 +2974,9 @@ describe('kiloPassRouter', () => {
 
       const caller = await createCallerForUser(user.id);
       await expect(
-        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_destroyed_hosting_anchor' })
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_destroyed_hosting_anchor',
+        })
       ).resolves.toEqual({
         outcome: 'action_required',
         hostingIntent: 'standard',
@@ -2951,7 +3040,9 @@ describe('kiloPassRouter', () => {
 
       const caller = await createCallerForUser(user.id);
       await expect(
-        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_qualified_commit_hosting' })
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_qualified_commit_hosting',
+        })
       ).resolves.toEqual({ outcome: 'activated', hostingIntent: 'commit' });
 
       const [hosting] = await db
@@ -2987,7 +3078,9 @@ describe('kiloPassRouter', () => {
 
       const caller = await createCallerForUser(user.id);
       await expect(
-        caller.kiloPass.activateCheckoutHosting({ sessionId: 'cs_expired_commit_hosting' })
+        caller.kiloPass.activateCheckoutHosting({
+          sessionId: 'cs_expired_commit_hosting',
+        })
       ).resolves.toEqual({
         outcome: 'action_required',
         hostingIntent: 'expired_commit',
@@ -3479,7 +3572,9 @@ describe('kiloPassRouter', () => {
     it('keeps an overdue change pending while the Stripe schedule remains active', async () => {
       freezeKiloPassClock('2026-07-14T12:00:00.000Z');
       const stripeMock = getStripeMock();
-      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({ status: 'active' });
+      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+        status: 'active',
+      });
       const { user, scheduleId, scheduledChangeId } = await insertPendingScheduledChange({
         email: 'kilo-pass-scheduled-read-active@example.com',
         effectiveAt: '2026-07-14T11:00:00.000Z',
@@ -3502,7 +3597,9 @@ describe('kiloPassRouter', () => {
       KiloPassScheduledChangeStatus.Completed,
     ])('reconciles an overdue change when Stripe reports %s', async providerStatus => {
       freezeKiloPassClock('2026-07-14T12:00:00.000Z');
-      getStripeMock().subscriptionSchedules.retrieve.mockResolvedValue({ status: providerStatus });
+      getStripeMock().subscriptionSchedules.retrieve.mockResolvedValue({
+        status: providerStatus,
+      });
       const { user, scheduledChangeId } = await insertPendingScheduledChange({
         email: `kilo-pass-scheduled-read-${providerStatus}@example.com`,
         effectiveAt: '2026-07-14T11:00:00.000Z',
@@ -4008,7 +4105,9 @@ describe('kiloPassRouter', () => {
       stripeMock.subscriptionSchedules.release.mockRejectedValue(
         new Error('The subscription schedule is already released')
       );
-      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({ status: 'released' });
+      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+        status: 'released',
+      });
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-cancel-already-released@example.com',
       });
@@ -4049,7 +4148,9 @@ describe('kiloPassRouter', () => {
     it('restores the pending row when release fails and Stripe remains active', async () => {
       const stripeMock = getStripeMock();
       stripeMock.subscriptionSchedules.release.mockRejectedValue(new Error('Stripe unavailable'));
-      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({ status: 'active' });
+      stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
+        status: 'active',
+      });
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-cancel-still-active@example.com',
       });
@@ -4391,10 +4492,16 @@ describe('kiloPassRouter', () => {
         'Kilo Pass base credits (tier_19, monthly)',
       ]);
       expect(
-        result.entries.map(entry => ({ amountUsd: entry.amountUsd, kind: entry.kind }))
+        result.entries.map(entry => ({
+          amountUsd: entry.amountUsd,
+          kind: entry.kind,
+        }))
       ).toEqual([
         { amountUsd: 49, kind: KiloPassIssuanceItemKind.Base },
-        { amountUsd: -4.75, kind: KiloPassIssuanceItemKind.PromoFirstMonth50Pct },
+        {
+          amountUsd: -4.75,
+          kind: KiloPassIssuanceItemKind.PromoFirstMonth50Pct,
+        },
         { amountUsd: -9.5, kind: KiloPassIssuanceItemKind.Bonus },
         { amountUsd: -9.5, kind: KiloPassIssuanceItemKind.Base },
         { amountUsd: 19, kind: KiloPassIssuanceItemKind.Base },

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -874,6 +874,7 @@ const ActivateCheckoutHostingOutputSchema = z.discriminatedUnion('outcome', [
       'missing_instance',
       'destroyed_instance',
       'requires_reprovision',
+      'signup_unavailable',
       'insufficient_credits',
       'expired_commit',
       'unexpected_error',
@@ -1075,7 +1076,10 @@ export const kiloPassRouter = createTRPCRouter({
           appAccountToken: purchase.appAccountToken,
           userAppStoreAccountToken: ctx.user.app_store_account_token,
         });
-        const result = await completeStoreKiloPassPurchase({ user: ctx.user, purchase });
+        const result = await completeStoreKiloPassPurchase({
+          user: ctx.user,
+          purchase,
+        });
         if (!result.alreadyProcessed) {
           trackKiloPassPurchaseCompleted({
             channel: 'app_store',
@@ -1132,7 +1136,9 @@ export const kiloPassRouter = createTRPCRouter({
     .output(SidebarPromoEligibilityOutputSchema)
     .query(async ({ ctx }) => {
       const subscription = await getKiloPassStateForUser(readDb, ctx.user.id);
-      return { showPromoBanner: !subscription || isStripeSubscriptionEnded(subscription.status) };
+      return {
+        showPromoBanner: !subscription || isStripeSubscriptionEnded(subscription.status),
+      };
     }),
 
   getReferralRewardSummary: baseProcedure
@@ -1229,7 +1235,10 @@ export const kiloPassRouter = createTRPCRouter({
   getState: baseProcedure.output(GetStateOutputSchema).query(async ({ ctx }) => {
     const subscriptionBase = await getKiloPassStateForUser(db, ctx.user.id);
     if (!subscriptionBase) {
-      return { subscription: null, isEligibleForFirstMonthPromo: isTwoMonthPromoOfferActive() };
+      return {
+        subscription: null,
+        isEligibleForFirstMonthPromo: isTwoMonthPromoOfferActive(),
+      };
     }
 
     if (subscriptionBase.paymentProvider !== KiloPassPaymentProvider.Stripe) {
@@ -1278,7 +1287,10 @@ export const kiloPassRouter = createTRPCRouter({
 
     const stripeCustomerId = ctx.user.stripe_customer_id;
     if (!stripeCustomerId) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Missing Stripe customer for user.',
+      });
     }
 
     const stripeSubscription = await stripe.subscriptions.retrieve(
@@ -1565,6 +1577,21 @@ export const kiloPassRouter = createTRPCRouter({
           )
         )
         .limit(1);
+      if (!existingSubscription) {
+        logHostingActivationWarning('Kilo Pass hosting activation failed', {
+          user_id: ctx.user.id,
+          checkout_session_id: input.sessionId,
+          instance_id: instance.id,
+          reason: 'signup_unavailable',
+          intended_price_version: priceVersion,
+          duration_ms: Date.now() - startedAt,
+        });
+        return {
+          outcome: 'action_required',
+          hostingIntent: hostingPlan,
+          reason: 'signup_unavailable',
+        };
+      }
       const settledSubscription = await getSettledKiloPassCheckoutSubscription({
         userId: ctx.user.id,
         stripeSubscriptionId,
@@ -1670,7 +1697,10 @@ export const kiloPassRouter = createTRPCRouter({
           actor: { actorType: 'user', actorId: ctx.user.id },
           commitQualification:
             hostingPlan === 'commit'
-              ? { source: 'checkout_confirmed_before_cutoff', qualifiedAt: checkoutConfirmedAt }
+              ? {
+                  source: 'checkout_confirmed_before_cutoff',
+                  qualifiedAt: checkoutConfirmedAt,
+                }
               : undefined,
         });
       } catch (error) {
@@ -1742,7 +1772,10 @@ export const kiloPassRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Missing Stripe customer for user.',
+        });
       }
 
       const subscription = await getKiloPassStateForUser(db, ctx.user.id);
@@ -1763,12 +1796,18 @@ export const kiloPassRouter = createTRPCRouter({
     .mutation(async ({ ctx }) => {
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Missing Stripe customer for user.',
+        });
       }
 
       const subscription = await getKiloPassStateForUser(db, ctx.user.id);
       if (!subscription) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Kilo Pass subscription found.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No Kilo Pass subscription found.',
+        });
       }
       assertStripeManagedSubscription(subscription);
 
@@ -1828,12 +1867,18 @@ export const kiloPassRouter = createTRPCRouter({
     .mutation(async ({ ctx }) => {
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Missing Stripe customer for user.',
+        });
       }
 
       const subscription = await getKiloPassStateForUser(db, ctx.user.id);
       if (!subscription) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Kilo Pass subscription found.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No Kilo Pass subscription found.',
+        });
       }
       assertStripeManagedSubscription(subscription);
 
@@ -1878,12 +1923,18 @@ export const kiloPassRouter = createTRPCRouter({
     .mutation(async ({ ctx }) => {
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Missing Stripe customer for user.',
+        });
       }
 
       const subscription = await getKiloPassStateForUser(db, ctx.user.id);
       if (!subscription) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Kilo Pass subscription found.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No Kilo Pass subscription found.',
+        });
       }
       assertStripeManagedSubscription(subscription);
 
@@ -1994,7 +2045,10 @@ export const kiloPassRouter = createTRPCRouter({
           });
         } catch (error) {
           captureException(error, {
-            tags: { source: 'kilo_pass_scheduled_change', stage: 'overdue_read_reconciliation' },
+            tags: {
+              source: 'kilo_pass_scheduled_change',
+              stage: 'overdue_read_reconciliation',
+            },
             extra: {
               scheduledChangeId: scheduledChange.id,
               scheduleId: scheduledChange.stripe_schedule_id,
@@ -2025,7 +2079,10 @@ export const kiloPassRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const subscription = await getKiloPassStateForUser(db, ctx.user.id);
       if (!subscription) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Kilo Pass subscription found.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No Kilo Pass subscription found.',
+        });
       }
       assertStripeManagedSubscription(subscription);
 
@@ -2110,8 +2167,14 @@ export const kiloPassRouter = createTRPCRouter({
       });
 
       // Stripe schedule creation (two-phase schedule; switch price at effectiveAt).
-      const currentPriceId = getStripePriceIdForKiloPass({ tier: fromTier, cadence: fromCadence });
-      const targetPriceId = getStripePriceIdForKiloPass({ tier: toTier, cadence: toCadence });
+      const currentPriceId = getStripePriceIdForKiloPass({
+        tier: fromTier,
+        cadence: fromCadence,
+      });
+      const targetPriceId = getStripePriceIdForKiloPass({
+        tier: toTier,
+        cadence: toCadence,
+      });
 
       const scheduledChangeId = crypto.randomUUID();
       const metadata = {
@@ -2226,7 +2289,10 @@ export const kiloPassRouter = createTRPCRouter({
     .mutation(async ({ ctx }) => {
       const subscription = await getKiloPassStateForUser(db, ctx.user.id);
       if (!subscription) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Kilo Pass subscription found.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No Kilo Pass subscription found.',
+        });
       }
       assertStripeManagedSubscription(subscription);
 
@@ -2290,7 +2356,10 @@ export const kiloPassRouter = createTRPCRouter({
     .query(async ({ ctx, input }) => {
       const subscription = await getKiloPassStateForUser(db, ctx.user.id);
       if (!subscription) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Kilo Pass subscription found.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No Kilo Pass subscription found.',
+        });
       }
 
       const offset = parseOffsetCursor(input.cursor);
@@ -2392,7 +2461,10 @@ export const kiloPassRouter = createTRPCRouter({
 
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Missing Stripe customer for user.',
+        });
       }
 
       return {

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -8564,6 +8564,23 @@ describe('getBillingStatus with credits', () => {
     expect(result.hasActiveKiloPass).toBe(true);
   });
 
+  it('includes detached canonical history in the personal billing summary', async () => {
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: null,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    });
+
+    const caller = await createCallerForUser(user.id);
+    const result = await caller.kiloclaw.getPersonalBillingSummary();
+
+    expect(result.hasExistingPersonalSubscription).toBe(true);
+    expect(result.hasActiveInstance).toBe(false);
+  });
+
   it('reports legacy recurring Standard upsell cost when prior paid history removes intro eligibility', async () => {
     const trialInstance = await createKiloclawInstance(user.id);
     const canceledPaidInstance = await createKiloclawInstance(user.id, '2026-04-01T00:00:00.000Z');

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -23,26 +23,18 @@ import {
   kiloclaw_subscription_change_log,
   kilocode_users,
   credit_transactions,
-  kilo_pass_issuance_items,
-  kilo_pass_issuances,
   kilo_pass_store_purchases,
   kilo_pass_subscriptions,
   user_affiliate_attributions,
   user_affiliate_events,
 } from '@kilocode/db/schema';
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import { sandboxIdFromUserId } from '@/lib/kiloclaw/sandbox-id';
 import { createOrganization } from '@/lib/organizations/organizations';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 import type Stripe from 'stripe';
-import {
-  KiloPassTier,
-  KiloPassCadence,
-  KiloPassPaymentProvider,
-  KiloPassIssuanceItemKind,
-  KiloPassIssuanceSource,
-} from '@/lib/kilo-pass/enums';
+import { KiloPassTier, KiloPassCadence, KiloPassPaymentProvider } from '@/lib/kilo-pass/enums';
 import { differenceInCalendarMonths } from 'date-fns';
 import { CURRENT_KILOCLAW_PRICE_VERSION, LEGACY_KILOCLAW_PRICE_VERSION } from '@kilocode/db';
 (kiloclaw_subscriptions.kiloclaw_price_version as { defaultFn: () => string }).defaultFn = () =>
@@ -840,7 +832,7 @@ describe('provision detached personal billing recovery', () => {
 
       await expect(caller.kiloclaw[procedure]({})).rejects.toMatchObject({
         code: 'FORBIDDEN',
-        message: 'New KiloClaw subscriptions are unavailable.',
+        message: 'A current KiloClaw subscription is required to provision an instance.',
       });
       expect(kiloclawInternalClientMock.__provisionMock).not.toHaveBeenCalled();
     }
@@ -852,7 +844,7 @@ describe('provision detached personal billing recovery', () => {
     const caller = await createCallerForUser(user.id);
     await expect(caller.kiloclaw.provision({})).rejects.toMatchObject({
       code: 'FORBIDDEN',
-      message: 'New KiloClaw subscriptions are unavailable.',
+      message: 'A current KiloClaw subscription is required to provision an instance.',
     });
 
     expect(kiloclawInternalClientMock.__provisionMock).not.toHaveBeenCalled();
@@ -2525,7 +2517,7 @@ describe('createSubscriptionCheckout', () => {
 
     const caller = await createCallerForUser(user.id);
     await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
-      'New KiloClaw subscriptions are unavailable.'
+      'A current KiloClaw subscription is required to provision an instance.'
     );
 
     expect(stripeMock.subscriptions.list).not.toHaveBeenCalled();
@@ -2828,7 +2820,7 @@ describe('createKiloPassUpsellCheckout', () => {
         cadence: 'yearly',
         hostingPlan: 'standard',
       })
-    ).rejects.toThrow('New KiloClaw subscriptions are unavailable.');
+    ).rejects.toThrow('A current KiloClaw subscription is required to provision an instance.');
 
     expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
   });
@@ -7181,67 +7173,6 @@ describe('enrollWithCredits', () => {
     return instance;
   }
 
-  async function createActiveYearlyTier49KiloPassWithBaseIssuance(userId: string) {
-    const providerSubscriptionId = `kp-recovery-${crypto.randomUUID()}`;
-    const [subscription] = await db
-      .insert(kilo_pass_subscriptions)
-      .values({
-        kilo_user_id: userId,
-        provider_subscription_id: providerSubscriptionId,
-        stripe_subscription_id: providerSubscriptionId,
-        tier: KiloPassTier.Tier49,
-        cadence: KiloPassCadence.Yearly,
-        status: 'active',
-        cancel_at_period_end: false,
-        started_at: '2026-07-01T00:00:00.000Z',
-        current_streak_months: 1,
-        next_yearly_issue_at: '2026-08-01T00:00:00.000Z',
-      })
-      .returning();
-
-    if (!subscription) {
-      throw new Error('Failed to insert Kilo Pass subscription');
-    }
-
-    const [baseCreditTransaction] = await db
-      .insert(credit_transactions)
-      .values({
-        kilo_user_id: userId,
-        amount_microdollars: 49_000_000,
-        is_free: false,
-        description: 'Kilo Pass Pro yearly base credits',
-        credit_category: `kilo-pass-base:${providerSubscriptionId}:2026-07`,
-        check_category_uniqueness: true,
-      })
-      .returning();
-
-    if (!baseCreditTransaction) {
-      throw new Error('Failed to insert Kilo Pass base credit transaction');
-    }
-
-    const [issuance] = await db
-      .insert(kilo_pass_issuances)
-      .values({
-        kilo_pass_subscription_id: subscription.id,
-        issue_month: '2026-07-01',
-        source: KiloPassIssuanceSource.Cron,
-      })
-      .returning();
-
-    if (!issuance) {
-      throw new Error('Failed to insert Kilo Pass issuance');
-    }
-
-    await db.insert(kilo_pass_issuance_items).values({
-      kilo_pass_issuance_id: issuance.id,
-      kind: KiloPassIssuanceItemKind.Base,
-      credit_transaction_id: baseCreditTransaction.id,
-      amount_usd: 49,
-    });
-
-    return { subscription, issuance };
-  }
-
   it('clears destruction fields and records resume retry state when credit enrollment activates a suspended trial', async () => {
     const instance = await createInstance(user.id);
     await giveUserCredits(user.id, 60_000_000);
@@ -7544,7 +7475,7 @@ describe('enrollWithCredits', () => {
         plan: 'standard',
         instanceId: instance.id,
       })
-    ).rejects.toThrow('New KiloClaw subscriptions are unavailable.');
+    ).rejects.toThrow('A current KiloClaw subscription is required to provision an instance.');
 
     const subscriptions = await db
       .select()
@@ -7764,357 +7695,12 @@ describe('enrollWithCredits', () => {
     );
   });
 
-  it('reprovisions a destroyed canceled Standard subscription and activates with Kilo Pass projected bonus credits', async () => {
-    setTestSystemTime('2026-07-01T12:00:00.000Z');
+  it('does not reprovision a destroyed canceled Standard subscription', async () => {
     const destroyedInstance = await createInstance(user.id);
     await db
       .update(kiloclaw_instances)
       .set({ destroyed_at: '2026-06-30T00:00:00.000Z' })
       .where(eq(kiloclaw_instances.id, destroyedInstance.id));
-    await db
-      .update(kilocode_users)
-      .set({
-        total_microdollars_acquired: 43_710_000,
-        microdollars_used: 0,
-        kilo_pass_threshold: 49_000_000,
-      })
-      .where(eq(kilocode_users.id, user.id));
-    const { issuance } = await createActiveYearlyTier49KiloPassWithBaseIssuance(user.id);
-    const [oldSubscription] = await db
-      .insert(kiloclaw_subscriptions)
-      .values({
-        user_id: user.id,
-        instance_id: destroyedInstance.id,
-        payment_source: 'credits',
-        plan: 'standard',
-        status: 'canceled',
-        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
-        current_period_start: '2026-05-30T00:00:00.000Z',
-        current_period_end: '2026-06-30T00:00:00.000Z',
-        credit_renewal_at: '2026-06-30T00:00:00.000Z',
-      })
-      .returning();
-    const freshInstance = {
-      id: crypto.randomUUID(),
-      sandboxId: `ki_${crypto.randomUUID()}`,
-    };
-    kiloclawInternalClientMock.__provisionMock.mockImplementationOnce(async () => {
-      await db.insert(kiloclaw_instances).values({
-        id: freshInstance.id,
-        user_id: user.id,
-        sandbox_id: freshInstance.sandboxId,
-      });
-      return {
-        instanceId: freshInstance.id,
-        sandboxId: freshInstance.sandboxId,
-      };
-    });
-
-    const caller = await createCallerForUser(user.id);
-    const beforeStatus = await caller.kiloclaw.getBillingStatus();
-    expect(beforeStatus.creditReprovisionRecovery).toEqual({
-      eligible: true,
-      plan: 'standard',
-      costMicrodollars: 55_000_000,
-      projectedKiloPassBonusMicrodollars: 24_500_000,
-      effectiveBalanceMicrodollars: 68_210_000,
-      shortfallMicrodollars: 0,
-    });
-
-    const result = await caller.kiloclaw.reprovisionAndEnrollWithCredits({
-      plan: 'standard',
-    });
-
-    expect(result).toEqual({
-      success: true,
-      status: 'activated',
-      instanceId: freshInstance.id,
-    });
-
-    const subscriptions = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, user.id));
-    const predecessor = subscriptions.find(subscription => subscription.id === oldSubscription?.id);
-    const successor = subscriptions.find(
-      subscription => subscription.instance_id === freshInstance.id
-    );
-
-    expect(successor).toEqual(
-      expect.objectContaining({
-        status: 'active',
-        payment_source: 'credits',
-        plan: 'standard',
-        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
-        credit_renewal_at: expect.any(String),
-      })
-    );
-    expect(predecessor?.transferred_to_subscription_id).toBe(successor?.id);
-
-    const [updatedUser] = await db
-      .select({
-        acquired: kilocode_users.total_microdollars_acquired,
-        used: kilocode_users.microdollars_used,
-        threshold: kilocode_users.kilo_pass_threshold,
-      })
-      .from(kilocode_users)
-      .where(eq(kilocode_users.id, user.id))
-      .limit(1);
-    expect(updatedUser).toEqual({
-      acquired: 68_210_000,
-      used: 55_000_000,
-      threshold: null,
-    });
-
-    const bonusItem = await db.query.kilo_pass_issuance_items.findFirst({
-      where: and(
-        eq(kilo_pass_issuance_items.kilo_pass_issuance_id, issuance.id),
-        eq(kilo_pass_issuance_items.kind, KiloPassIssuanceItemKind.Bonus)
-      ),
-      columns: {
-        kind: true,
-        amount_usd: true,
-        bonus_percent_applied: true,
-      },
-    });
-    expect(bonusItem).toEqual(
-      expect.objectContaining({
-        kind: KiloPassIssuanceItemKind.Bonus,
-        amount_usd: 24.5,
-        bonus_percent_applied: 0.5,
-      })
-    );
-
-    const deductions = await db
-      .select({ amountMicrodollars: credit_transactions.amount_microdollars })
-      .from(credit_transactions)
-      .where(eq(credit_transactions.kilo_user_id, user.id));
-    expect(deductions.map(row => row.amountMicrodollars)).toContain(-55_000_000);
-  });
-
-  it('rolls back a duplicate fresh provision when another recovery activates first', async () => {
-    setTestSystemTime('2026-07-01T12:00:00.000Z');
-    const destroyedInstance = await createInstance(user.id);
-    await db
-      .update(kiloclaw_instances)
-      .set({ destroyed_at: '2026-06-30T00:00:00.000Z' })
-      .where(eq(kiloclaw_instances.id, destroyedInstance.id));
-    await db
-      .update(kilocode_users)
-      .set({
-        total_microdollars_acquired: 120_000_000,
-        microdollars_used: 0,
-        kilo_pass_threshold: null,
-      })
-      .where(eq(kilocode_users.id, user.id));
-    const [oldSubscription] = await db
-      .insert(kiloclaw_subscriptions)
-      .values({
-        user_id: user.id,
-        instance_id: destroyedInstance.id,
-        payment_source: 'credits',
-        plan: 'standard',
-        status: 'canceled',
-        kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
-        current_period_start: '2026-05-30T00:00:00.000Z',
-        current_period_end: '2026-06-30T00:00:00.000Z',
-        credit_renewal_at: '2026-06-30T00:00:00.000Z',
-      })
-      .returning();
-    const oldSubscriptionId = oldSubscription?.id;
-    if (!oldSubscriptionId) throw new Error('Expected old subscription fixture');
-    const winningInstance = {
-      id: crypto.randomUUID(),
-      sandboxId: `ki_${crypto.randomUUID()}`,
-    };
-    const freshInstance = {
-      id: crypto.randomUUID(),
-      sandboxId: `ki_${crypto.randomUUID()}`,
-    };
-    kiloclawInternalClientMock.__provisionMock.mockImplementationOnce(async () => {
-      await db.insert(kiloclaw_instances).values({
-        id: winningInstance.id,
-        user_id: user.id,
-        sandbox_id: winningInstance.sandboxId,
-      });
-      const [winningSubscription] = await db
-        .insert(kiloclaw_subscriptions)
-        .values({
-          user_id: user.id,
-          instance_id: winningInstance.id,
-          payment_source: 'credits',
-          plan: 'standard',
-          status: 'active',
-          kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
-          current_period_start: '2026-07-01T12:00:00.000Z',
-          current_period_end: '2026-08-01T12:00:00.000Z',
-          credit_renewal_at: '2026-08-01T12:00:00.000Z',
-        })
-        .returning();
-      const winningSubscriptionId = winningSubscription?.id;
-      if (!winningSubscriptionId) throw new Error('Expected winning subscription fixture');
-      await db
-        .update(kiloclaw_subscriptions)
-        .set({ transferred_to_subscription_id: winningSubscriptionId })
-        .where(eq(kiloclaw_subscriptions.id, oldSubscriptionId));
-      await db.insert(kiloclaw_instances).values({
-        id: freshInstance.id,
-        user_id: user.id,
-        sandbox_id: freshInstance.sandboxId,
-      });
-      return {
-        instanceId: freshInstance.id,
-        sandboxId: freshInstance.sandboxId,
-      };
-    });
-
-    const caller = await createCallerForUser(user.id);
-    await expect(
-      caller.kiloclaw.reprovisionAndEnrollWithCredits({ plan: 'standard' })
-    ).resolves.toEqual({
-      success: true,
-      status: 'activated',
-      instanceId: winningInstance.id,
-    });
-
-    expect(kiloclawInternalClientMock.__provisionMock).toHaveBeenCalledTimes(1);
-
-    const [freshRow] = await db
-      .select({ destroyedAt: kiloclaw_instances.destroyed_at })
-      .from(kiloclaw_instances)
-      .where(eq(kiloclaw_instances.id, freshInstance.id))
-      .limit(1);
-    expect(freshRow?.destroyedAt).toEqual(expect.any(String));
-
-    const freshSubscriptions = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.instance_id, freshInstance.id));
-    expect(freshSubscriptions).toEqual([]);
-    expect(kiloclawInternalClientMock.__destroyMock).toHaveBeenCalledWith(
-      user.id,
-      freshInstance.id,
-      { reason: 'stale_provision_cleanup' }
-    );
-
-    const [predecessor] = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.id, oldSubscriptionId))
-      .limit(1);
-    expect(predecessor).toEqual(
-      expect.objectContaining({
-        transferred_to_subscription_id: expect.any(String),
-      })
-    );
-  });
-
-  it('rolls back the fresh instance when destroyed-subscription credit recovery enrollment fails', async () => {
-    setTestSystemTime('2026-07-01T12:00:00.000Z');
-    const destroyedInstance = await createInstance(user.id);
-    await db
-      .update(kiloclaw_instances)
-      .set({ destroyed_at: '2026-06-30T00:00:00.000Z' })
-      .where(eq(kiloclaw_instances.id, destroyedInstance.id));
-    await db
-      .update(kilocode_users)
-      .set({
-        total_microdollars_acquired: 60_000_000,
-        microdollars_used: 0,
-        kilo_pass_threshold: null,
-      })
-      .where(eq(kilocode_users.id, user.id));
-    await db.insert(kiloclaw_subscriptions).values({
-      user_id: user.id,
-      instance_id: destroyedInstance.id,
-      payment_source: 'credits',
-      plan: 'standard',
-      status: 'canceled',
-      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
-    });
-    const freshInstance = {
-      id: crypto.randomUUID(),
-      sandboxId: `ki_${crypto.randomUUID()}`,
-    };
-    kiloclawInternalClientMock.__provisionMock.mockImplementationOnce(async () => {
-      await db.insert(kiloclaw_instances).values({
-        id: freshInstance.id,
-        user_id: user.id,
-        sandbox_id: freshInstance.sandboxId,
-      });
-      await db.insert(credit_transactions).values({
-        kilo_user_id: user.id,
-        amount_microdollars: -55_000_000,
-        is_free: false,
-        description: 'Duplicate KiloClaw enrollment deduction',
-        credit_category: `kiloclaw-subscription:${freshInstance.id}:2026-07`,
-        check_category_uniqueness: true,
-      });
-      return {
-        instanceId: freshInstance.id,
-        sandboxId: freshInstance.sandboxId,
-      };
-    });
-
-    const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.getBillingStatus()).resolves.toMatchObject({
-      creditReprovisionRecovery: {
-        eligible: true,
-        effectiveBalanceMicrodollars: 60_000_000,
-        shortfallMicrodollars: 0,
-      },
-    });
-
-    const result = await caller.kiloclaw.reprovisionAndEnrollWithCredits({
-      plan: 'standard',
-    });
-
-    expect(result).toEqual({
-      success: false,
-      status: 'action_required',
-      instanceId: null,
-      message:
-        'Credit activation did not finish, so the new KiloClaw was rolled back. Retry activation or contact support.',
-    });
-    const [rolledBackInstance] = await db
-      .select({ destroyedAt: kiloclaw_instances.destroyed_at })
-      .from(kiloclaw_instances)
-      .where(eq(kiloclaw_instances.id, freshInstance.id))
-      .limit(1);
-    expect(rolledBackInstance?.destroyedAt).toEqual(expect.any(String));
-    const freshSubscriptions = await db
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.instance_id, freshInstance.id));
-    expect(freshSubscriptions).toEqual([]);
-    await expect(caller.kiloclaw.getBillingStatus()).resolves.toMatchObject({
-      creditReprovisionRecovery: {
-        eligible: true,
-        effectiveBalanceMicrodollars: 60_000_000,
-        shortfallMicrodollars: 0,
-      },
-    });
-    expect(kiloclawInternalClientMock.__destroyMock).toHaveBeenCalledWith(
-      user.id,
-      freshInstance.id,
-      { reason: 'stale_provision_cleanup' }
-    );
-  });
-
-  it('does not offer or run destroyed-subscription credit recovery when effective balance is insufficient', async () => {
-    const destroyedInstance = await createInstance(user.id);
-    await db
-      .update(kiloclaw_instances)
-      .set({ destroyed_at: '2026-06-30T00:00:00.000Z' })
-      .where(eq(kiloclaw_instances.id, destroyedInstance.id));
-    await db
-      .update(kilocode_users)
-      .set({
-        total_microdollars_acquired: 43_710_000,
-        microdollars_used: 0,
-        kilo_pass_threshold: null,
-      })
-      .where(eq(kilocode_users.id, user.id));
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: destroyedInstance.id,
@@ -8125,18 +7711,12 @@ describe('enrollWithCredits', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const status = await caller.kiloclaw.getBillingStatus();
-    expect(status.creditReprovisionRecovery).toEqual({
-      eligible: false,
-      plan: 'standard',
-      costMicrodollars: 55_000_000,
-      projectedKiloPassBonusMicrodollars: 0,
-      effectiveBalanceMicrodollars: 43_710_000,
-      shortfallMicrodollars: 11_290_000,
+    await expect(caller.kiloclaw.getBillingStatus()).resolves.toMatchObject({
+      creditReprovisionRecovery: { eligible: false },
     });
     await expect(
       caller.kiloclaw.reprovisionAndEnrollWithCredits({ plan: 'standard' })
-    ).rejects.toThrow('Effective credit balance is insufficient');
+    ).rejects.toThrow('Credit-funded reprovision recovery is not available');
     expect(kiloclawInternalClientMock.__provisionMock).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -617,6 +617,7 @@ describe('getBillingStatus', () => {
     expect(result).not.toBeNull();
     expect(result.trialEligible).toBe(false);
     expect(result.hasExistingPersonalSubscription).toBe(true);
+    expect(result.hasCurrentPersonalSubscription).toBe(false);
   });
 
   it('returns trialEligible false when user only has an org-backed subscription', async () => {
@@ -8578,6 +8579,7 @@ describe('getBillingStatus with credits', () => {
     const result = await caller.kiloclaw.getPersonalBillingSummary();
 
     expect(result.hasExistingPersonalSubscription).toBe(true);
+    expect(result.hasCurrentPersonalSubscription).toBe(true);
     expect(result.hasActiveInstance).toBe(false);
   });
 

--- a/apps/web/src/routers/kiloclaw-billing-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-billing-router.test.ts
@@ -72,7 +72,9 @@ jest.mock('@/lib/stripe-client', () => {
       release: jest.fn(),
       retrieve: jest.fn(),
     },
-    checkout: { sessions: { create: jest.fn(), list: jest.fn(), expire: jest.fn() } },
+    checkout: {
+      sessions: { create: jest.fn(), list: jest.fn(), expire: jest.fn() },
+    },
     billingPortal: { sessions: { create: jest.fn() } },
     invoices: { list: jest.fn() },
     errors,
@@ -179,7 +181,12 @@ type StripeMockShape = {
   checkout: { sessions: { create: AnyMock; list: AnyMock; expire: AnyMock } };
   billingPortal: { sessions: { create: AnyMock } };
   subscriptions: { retrieve: AnyMock; update: AnyMock; list: AnyMock };
-  subscriptionSchedules: { create: AnyMock; update: AnyMock; release: AnyMock; retrieve: AnyMock };
+  subscriptionSchedules: {
+    create: AnyMock;
+    update: AnyMock;
+    release: AnyMock;
+    retrieve: AnyMock;
+  };
   invoices: { list: AnyMock };
   errors: Stripe['errors'];
 };
@@ -247,19 +254,39 @@ beforeEach(async () => {
   stripePriceIdsMock.getStripePriceIdMetadata.mockReset();
   stripePriceIdsMock.getStripePriceIdMetadata.mockImplementation((priceId: string) => {
     if (priceId === 'price_commit') {
-      return { plan: 'commit', priceVersion: LEGACY_KILOCLAW_PRICE_VERSION, isIntro: false };
+      return {
+        plan: 'commit',
+        priceVersion: LEGACY_KILOCLAW_PRICE_VERSION,
+        isIntro: false,
+      };
     }
     if (priceId === 'price_standard') {
-      return { plan: 'standard', priceVersion: LEGACY_KILOCLAW_PRICE_VERSION, isIntro: false };
+      return {
+        plan: 'standard',
+        priceVersion: LEGACY_KILOCLAW_PRICE_VERSION,
+        isIntro: false,
+      };
     }
     if (priceId === 'price_standard_intro') {
-      return { plan: 'standard', priceVersion: LEGACY_KILOCLAW_PRICE_VERSION, isIntro: true };
+      return {
+        plan: 'standard',
+        priceVersion: LEGACY_KILOCLAW_PRICE_VERSION,
+        isIntro: true,
+      };
     }
     if (priceId === 'price_current_commit') {
-      return { plan: 'commit', priceVersion: CURRENT_KILOCLAW_PRICE_VERSION, isIntro: false };
+      return {
+        plan: 'commit',
+        priceVersion: CURRENT_KILOCLAW_PRICE_VERSION,
+        isIntro: false,
+      };
     }
     if (priceId === 'price_current_standard') {
-      return { plan: 'standard', priceVersion: CURRENT_KILOCLAW_PRICE_VERSION, isIntro: false };
+      return {
+        plan: 'standard',
+        priceVersion: CURRENT_KILOCLAW_PRICE_VERSION,
+        isIntro: false,
+      };
     }
     return null;
   });
@@ -552,6 +579,7 @@ describe('getBillingStatus', () => {
 
     expect(result).not.toBeNull();
     expect(result.trialEligible).toBe(true);
+    expect(result.hasExistingPersonalSubscription).toBe(false);
   });
 
   it('returns trialEligible false when user only has a destroyed personal instance row', async () => {
@@ -566,6 +594,7 @@ describe('getBillingStatus', () => {
 
     expect(result).not.toBeNull();
     expect(result.trialEligible).toBe(false);
+    expect(result.hasExistingPersonalSubscription).toBe(false);
   });
 
   it('returns trialEligible false when user has an active personal instance row', async () => {
@@ -579,6 +608,7 @@ describe('getBillingStatus', () => {
 
     expect(result).not.toBeNull();
     expect(result.trialEligible).toBe(false);
+    expect(result.hasExistingPersonalSubscription).toBe(false);
   });
 
   it('returns trialEligible false when user has a canceled subscription but no instance', async () => {
@@ -594,6 +624,7 @@ describe('getBillingStatus', () => {
 
     expect(result).not.toBeNull();
     expect(result.trialEligible).toBe(false);
+    expect(result.hasExistingPersonalSubscription).toBe(true);
   });
 
   it('returns trialEligible false when user only has an org-backed subscription', async () => {
@@ -622,6 +653,7 @@ describe('getBillingStatus', () => {
     // Must be false — ensureProvisionAccess checks ALL subscriptions (including
     // org) and would block trial creation, so trialEligible must agree.
     expect(result.trialEligible).toBe(false);
+    expect(result.hasExistingPersonalSubscription).toBe(false);
   });
 
   it('prefers an active subscription over an older canceled row', async () => {
@@ -801,65 +833,29 @@ describe('provision detached personal billing recovery', () => {
     );
   });
 
-  it('bootstraps a fresh trial onto an active orphan instance with zero subscription rows', async () => {
-    const activeInstance = await createKiloclawInstance(user.id);
-    kiloclawInternalClientMock.__provisionMock.mockImplementationOnce(async () => {
-      await db.insert(kiloclaw_subscriptions).values({
-        user_id: user.id,
-        instance_id: activeInstance.id,
-        plan: 'trial',
-        status: 'trialing',
-        trial_started_at: '2026-04-20T10:00:00.000Z',
-        trial_ends_at: '2026-04-27T10:00:00.000Z',
-      });
+  it.each(['provision', 'updateConfig'] as const)(
+    'rejects new personal subscriptions from kiloclaw.%s',
+    async procedure => {
+      const caller = await createCallerForUser(user.id);
 
-      return {
-        sandboxId: activeInstance.sandbox_id,
-        instanceId: activeInstance.id,
-      };
-    });
+      await expect(caller.kiloclaw[procedure]({})).rejects.toMatchObject({
+        code: 'FORBIDDEN',
+        message: 'New KiloClaw subscriptions are unavailable.',
+      });
+      expect(kiloclawInternalClientMock.__provisionMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not bootstrap a fresh trial onto an active orphan instance', async () => {
+    await createKiloclawInstance(user.id);
 
     const caller = await createCallerForUser(user.id);
-    await expect(caller.kiloclaw.provision({})).resolves.toEqual({
-      sandboxId: activeInstance.sandbox_id,
-      instanceId: activeInstance.id,
+    await expect(caller.kiloclaw.provision({})).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'New KiloClaw subscriptions are unavailable.',
     });
 
-    expect(kiloclawInternalClientMock.__provisionMock).toHaveBeenCalledWith(
-      user.id,
-      expect.any(Object),
-      {
-        instanceId: activeInstance.id,
-        bootstrapSubscription: true,
-      }
-    );
-    expect(posthogCaptureMock).toHaveBeenCalledWith({
-      distinctId: user.google_user_email,
-      event: 'claw_trial_started',
-      properties: expect.objectContaining({
-        user_id: user.id,
-        plan: 'trial',
-      }),
-    });
-
-    const [trialSubscription] = await db
-      .select({
-        trialEndsAt: kiloclaw_subscriptions.trial_ends_at,
-      })
-      .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.instance_id, activeInstance.id))
-      .limit(1);
-
-    expect(trialSubscription).toBeDefined();
-    expect(posthogCaptureMock).toHaveBeenCalledWith({
-      distinctId: user.google_user_email,
-      event: 'claw_trial_started',
-      properties: {
-        user_id: user.id,
-        plan: 'trial',
-        trial_ends_at: trialSubscription?.trialEndsAt,
-      },
-    });
+    expect(kiloclawInternalClientMock.__provisionMock).not.toHaveBeenCalled();
   });
 
   it('rejects reprovision for legacy earlybird purchase without canonical subscription row', async () => {
@@ -880,6 +876,16 @@ describe('provision detached personal billing recovery', () => {
   it.each(['provision', 'updateConfig'] as const)(
     'maps Worker admission conflicts from kiloclaw.%s',
     async procedure => {
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: null,
+        stripe_subscription_id: `sub_admission_conflict_${procedure}`,
+        payment_source: 'stripe',
+        plan: 'standard',
+        status: 'active',
+        current_period_start: '2026-04-01T00:00:00.000Z',
+        current_period_end: '2026-05-01T00:00:00.000Z',
+      });
       kiloclawInternalClientMock.__provisionMock.mockRejectedValueOnce(
         new MockKiloClawApiError(
           409,
@@ -902,10 +908,23 @@ describe('provision detached personal billing recovery', () => {
   it.each(['provision', 'updateConfig'] as const)(
     'maps missing Worker instances from kiloclaw.%s',
     async procedure => {
+      await db.insert(kiloclaw_subscriptions).values({
+        user_id: user.id,
+        instance_id: null,
+        stripe_subscription_id: `sub_missing_instance_${procedure}`,
+        payment_source: 'stripe',
+        plan: 'standard',
+        status: 'active',
+        current_period_start: '2026-04-01T00:00:00.000Z',
+        current_period_end: '2026-05-01T00:00:00.000Z',
+      });
       kiloclawInternalClientMock.__provisionMock.mockRejectedValueOnce(
         new MockKiloClawApiError(
           404,
-          JSON.stringify({ error: 'Active instance not found', code: 'instance_not_found' })
+          JSON.stringify({
+            error: 'Active instance not found',
+            code: 'instance_not_found',
+          })
         )
       );
 
@@ -1132,7 +1151,9 @@ describe('subscription center procedures', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.getSubscriptionDetail({ instanceId: instance.id });
+    const result = await caller.kiloclaw.getSubscriptionDetail({
+      instanceId: instance.id,
+    });
 
     expect(result).toMatchObject({
       instanceId: instance.id,
@@ -1226,7 +1247,9 @@ describe('subscription center procedures', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.getSubscriptionDetail({ instanceId: instance.id });
+    const result = await caller.kiloclaw.getSubscriptionDetail({
+      instanceId: instance.id,
+    });
 
     expect(result).toMatchObject({
       instanceId: instance.id,
@@ -1256,7 +1279,9 @@ describe('subscription center procedures', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.getSubscriptionDetail({ instanceId: instance.id });
+    const result = await caller.kiloclaw.getSubscriptionDetail({
+      instanceId: instance.id,
+    });
 
     expect(result).toMatchObject({
       instanceId: instance.id,
@@ -1307,7 +1332,10 @@ describe('subscription center procedures', () => {
       has_more: false,
     });
 
-    const instance = await createInstanceRow({ userId: user.id, name: 'Stripe Instance' });
+    const instance = await createInstanceRow({
+      userId: user.id,
+      name: 'Stripe Instance',
+    });
     await insertSubscriptionRow({
       userId: user.id,
       instanceId: instance.id,
@@ -1317,7 +1345,9 @@ describe('subscription center procedures', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.getBillingHistory({ instanceId: instance.id });
+    const result = await caller.kiloclaw.getBillingHistory({
+      instanceId: instance.id,
+    });
 
     expect(stripeMock.invoices.list).toHaveBeenCalledWith({
       subscription: 'sub_kiloclaw_stripe',
@@ -1355,7 +1385,10 @@ describe('subscription center procedures', () => {
       name: 'Credits Instance',
       sandboxId,
     });
-    const otherInstance = await createInstanceRow({ userId: user.id, name: 'Other Instance' });
+    const otherInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Other Instance',
+    });
 
     await insertSubscriptionRow({
       userId: user.id,
@@ -1397,7 +1430,9 @@ describe('subscription center procedures', () => {
     ]);
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.getBillingHistory({ instanceId: instance.id });
+    const result = await caller.kiloclaw.getBillingHistory({
+      instanceId: instance.id,
+    });
 
     expect(result).toEqual({
       entries: [
@@ -1426,7 +1461,10 @@ describe('subscription center procedures', () => {
       url: 'https://stripe.example.test/kiloclaw-portal',
     });
 
-    const instance = await createInstanceRow({ userId: user.id, name: 'Portal Instance' });
+    const instance = await createInstanceRow({
+      userId: user.id,
+      name: 'Portal Instance',
+    });
     await insertSubscriptionRow({
       userId: user.id,
       instanceId: instance.id,
@@ -1441,7 +1479,9 @@ describe('subscription center procedures', () => {
       returnUrl: 'https://example.test/subscriptions/kiloclaw',
     });
 
-    expect(result).toEqual({ url: 'https://stripe.example.test/kiloclaw-portal' });
+    expect(result).toEqual({
+      url: 'https://stripe.example.test/kiloclaw-portal',
+    });
     expect(stripeMock.billingPortal.sessions.create).toHaveBeenCalledWith({
       customer: user.stripe_customer_id,
       return_url: 'https://example.test/subscriptions/kiloclaw',
@@ -1452,8 +1492,14 @@ describe('subscription center procedures', () => {
     stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
     stripeMock.subscriptions.update.mockResolvedValue({});
 
-    const targetInstance = await createInstanceRow({ userId: user.id, name: 'Target Instance' });
-    const otherInstance = await createInstanceRow({ userId: user.id, name: 'Other Instance' });
+    const targetInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Target Instance',
+    });
+    const otherInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Other Instance',
+    });
 
     await insertSubscriptionRow({
       userId: user.id,
@@ -1548,7 +1594,10 @@ describe('subscription center procedures', () => {
     );
     stripeMock.subscriptions.retrieve
       .mockResolvedValueOnce(liveSubscription)
-      .mockResolvedValueOnce({ ...liveSubscription, cancel_at_period_end: true });
+      .mockResolvedValueOnce({
+        ...liveSubscription,
+        cancel_at_period_end: true,
+      });
     stripeMock.subscriptions.update.mockResolvedValue({});
     const { enforceKiloClawCommitRetirementGuard } =
       await import('@/lib/kiloclaw/commit-retirement');
@@ -1581,7 +1630,9 @@ describe('subscription center procedures', () => {
       const result =
         mutationPath === 'legacy'
           ? await caller.kiloclaw.reactivateSubscription()
-          : await caller.kiloclaw.reactivateSubscriptionAtInstance({ instanceId: instance.id });
+          : await caller.kiloclaw.reactivateSubscriptionAtInstance({
+              instanceId: instance.id,
+            });
 
       expect(result).toEqual({ success: true });
       expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
@@ -1617,7 +1668,9 @@ describe('subscription center procedures', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    await caller.kiloclaw.reactivateSubscriptionAtInstance({ instanceId: instance.id });
+    await caller.kiloclaw.reactivateSubscriptionAtInstance({
+      instanceId: instance.id,
+    });
 
     const [row] = await db
       .select()
@@ -1653,7 +1706,9 @@ describe('subscription center procedures', () => {
 
     const caller = await createCallerForUser(user.id);
     await expect(
-      caller.kiloclaw.reactivateSubscriptionAtInstance({ instanceId: instance.id })
+      caller.kiloclaw.reactivateSubscriptionAtInstance({
+        instanceId: instance.id,
+      })
     ).rejects.toThrow('Commit retirement state requires support review.');
 
     const [row] = await db
@@ -1671,8 +1726,14 @@ describe('subscription center procedures', () => {
       items: { data: [{ price: { id: 'price_standard' } }] },
     });
 
-    const targetInstance = await createInstanceRow({ userId: user.id, name: 'Target Instance' });
-    const otherInstance = await createInstanceRow({ userId: user.id, name: 'Other Instance' });
+    const targetInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Target Instance',
+    });
+    const otherInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Other Instance',
+    });
 
     await db.insert(kiloclaw_subscriptions).values([
       {
@@ -1762,7 +1823,11 @@ describe('subscription center procedures', () => {
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sched_final_continuation',
       phases: [
-        { items: [{ price: 'price_commit' }], start_date: 1_767_225_600, end_date: 1_783_478_400 },
+        {
+          items: [{ price: 'price_commit' }],
+          start_date: 1_767_225_600,
+          end_date: 1_783_478_400,
+        },
       ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
@@ -1786,7 +1851,9 @@ describe('subscription center procedures', () => {
           expect.objectContaining({
             end_date: Math.floor(new Date(FINAL_COMMIT_END).getTime() / 1000),
           }),
-          expect.objectContaining({ items: [{ price: 'price_test_kiloclaw' }] }),
+          expect.objectContaining({
+            items: [{ price: 'price_test_kiloclaw' }],
+          }),
         ],
       })
     );
@@ -1835,14 +1902,20 @@ describe('subscription center procedures', () => {
       stripeMock.subscriptions.retrieve
         .mockResolvedValueOnce(liveSubscription)
         .mockResolvedValueOnce(liveSubscription)
-        .mockResolvedValueOnce({ ...liveSubscription, schedule: null, cancel_at_period_end: true });
+        .mockResolvedValueOnce({
+          ...liveSubscription,
+          schedule: null,
+          cancel_at_period_end: true,
+        });
       stripeMock.subscriptions.update.mockResolvedValue({});
 
       const caller = await createCallerForUser(user.id);
       const result =
         mutationPath === 'legacy'
           ? await caller.kiloclaw.acceptConversion()
-          : await caller.kiloclaw.acceptConversionAtInstance({ instanceId: instance.id });
+          : await caller.kiloclaw.acceptConversionAtInstance({
+              instanceId: instance.id,
+            });
 
       expect(result).toEqual({ success: true });
       const [row] = await db
@@ -1863,8 +1936,14 @@ describe('subscription center procedures', () => {
     stripeMock.subscriptions.retrieve.mockResolvedValue({ schedule: null });
     stripeMock.subscriptions.update.mockResolvedValue({});
 
-    const targetInstance = await createInstanceRow({ userId: user.id, name: 'Target Instance' });
-    const otherInstance = await createInstanceRow({ userId: user.id, name: 'Other Instance' });
+    const targetInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Target Instance',
+    });
+    const otherInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Other Instance',
+    });
 
     await db.insert(kiloclaw_subscriptions).values([
       {
@@ -1971,7 +2050,10 @@ describe('subscription center procedures', () => {
       .mockResolvedValueOnce({ cancel_at_period_end: false });
     stripeMock.subscriptions.update.mockRejectedValue(new Error('Stripe update failed'));
 
-    const targetInstance = await createInstanceRow({ userId: user.id, name: 'Target Instance' });
+    const targetInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Target Instance',
+    });
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: targetInstance.id,
@@ -1995,7 +2077,9 @@ describe('subscription center procedures', () => {
 
     const caller = await createCallerForUser(user.id);
     await expect(
-      caller.kiloclaw.acceptConversionAtInstance({ instanceId: targetInstance.id })
+      caller.kiloclaw.acceptConversionAtInstance({
+        instanceId: targetInstance.id,
+      })
     ).rejects.toThrow('Failed to schedule Stripe cancellation. Please try again.');
 
     const [targetRow] = await db
@@ -2026,12 +2110,24 @@ describe('subscription center procedures', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sched_target_switch',
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
-    const targetInstance = await createInstanceRow({ userId: user.id, name: 'Target Instance' });
-    const otherInstance = await createInstanceRow({ userId: user.id, name: 'Other Instance' });
+    const targetInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Target Instance',
+    });
+    const otherInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Other Instance',
+    });
 
     await db.insert(kiloclaw_subscriptions).values([
       {
@@ -2116,11 +2212,20 @@ describe('subscription center procedures', () => {
     );
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sched_target_switch_recreated',
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
-    const targetInstance = await createInstanceRow({ userId: user.id, name: 'Target Instance' });
+    const targetInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Target Instance',
+    });
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: targetInstance.id,
@@ -2208,7 +2313,9 @@ describe('subscription center procedures', () => {
       const result =
         mutationPath === 'legacy'
           ? await caller.kiloclaw.cancelPlanSwitch()
-          : await caller.kiloclaw.cancelPlanSwitchAtInstance({ instanceId: instance.id });
+          : await caller.kiloclaw.cancelPlanSwitchAtInstance({
+              instanceId: instance.id,
+            });
 
       expect(result).toEqual({ success: true });
       const [row] = await db
@@ -2241,7 +2348,9 @@ describe('subscription center procedures', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    await caller.kiloclaw.cancelPlanSwitchAtInstance({ instanceId: instance.id });
+    await caller.kiloclaw.cancelPlanSwitchAtInstance({
+      instanceId: instance.id,
+    });
 
     const [row] = await db
       .select()
@@ -2262,8 +2371,14 @@ describe('subscription center procedures', () => {
       items: { data: [{ price: { id: 'price_standard' } }] },
     });
 
-    const targetInstance = await createInstanceRow({ userId: user.id, name: 'Target Instance' });
-    const otherInstance = await createInstanceRow({ userId: user.id, name: 'Other Instance' });
+    const targetInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Target Instance',
+    });
+    const otherInstance = await createInstanceRow({
+      userId: user.id,
+      name: 'Other Instance',
+    });
 
     await db.insert(kiloclaw_subscriptions).values([
       {
@@ -2371,7 +2486,10 @@ describe('createSubscriptionCheckout', () => {
     const caller = await createCallerForUser(user.id);
 
     await expect(
-      caller.kiloclaw.enrollWithCredits({ plan: 'commit', instanceId: enrollmentInstance.id })
+      caller.kiloclaw.enrollWithCredits({
+        plan: 'commit',
+        instanceId: enrollmentInstance.id,
+      })
     ).rejects.toThrow('Commit is no longer available');
 
     const switchInstance = await createKiloclawInstance(user.id);
@@ -2389,7 +2507,10 @@ describe('createSubscriptionCheckout', () => {
       'Commit is no longer available'
     );
     await expect(
-      caller.kiloclaw.switchPlanAtInstance({ instanceId: switchInstance.id, toPlan: 'commit' })
+      caller.kiloclaw.switchPlanAtInstance({
+        instanceId: switchInstance.id,
+        toPlan: 'commit',
+      })
     ).rejects.toThrow('Commit is no longer available');
 
     const [row] = await db
@@ -2404,7 +2525,7 @@ describe('createSubscriptionCheckout', () => {
 
     const caller = await createCallerForUser(user.id);
     await expect(caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' })).rejects.toThrow(
-      'Reprovision KiloClaw before starting a new Stripe subscription.'
+      'New KiloClaw subscriptions are unavailable.'
     );
 
     expect(stripeMock.subscriptions.list).not.toHaveBeenCalled();
@@ -2696,8 +2817,31 @@ describe('createKiloPassUpsellCheckout', () => {
     expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
   });
 
+  it('rejects Kilo Pass hosting activation without an existing personal subscription', async () => {
+    const instance = await createKiloclawInstance(user.id);
+    const caller = await createCallerForUser(user.id);
+
+    await expect(
+      caller.kiloclaw.createKiloPassUpsellCheckout({
+        instanceId: instance.id,
+        tier: '199',
+        cadence: 'yearly',
+        hostingPlan: 'standard',
+      })
+    ).rejects.toThrow('New KiloClaw subscriptions are unavailable.');
+
+    expect(stripeMock.checkout.sessions.create).not.toHaveBeenCalled();
+  });
+
   it('rejects current Standard hosting when the selected Kilo Pass tier cannot cover the first charge', async () => {
     const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'trialing',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    });
     const caller = await createCallerForUser(user.id);
 
     await expect(
@@ -2717,6 +2861,12 @@ describe('createKiloPassUpsellCheckout', () => {
   it('rejects commit hosting for monthly tier 19', async () => {
     setTestSystemTime(PRE_COMMIT_CUTOFF_TIME);
     const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'trialing',
+    });
     const caller = await createCallerForUser(user.id);
 
     await expect(
@@ -2736,6 +2886,12 @@ describe('createKiloPassUpsellCheckout', () => {
   it('rejects commit hosting for yearly tier 19 when monthly effective credits cannot cover the charge', async () => {
     setTestSystemTime(PRE_COMMIT_CUTOFF_TIME);
     const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'trialing',
+    });
     const caller = await createCallerForUser(user.id);
 
     await expect(
@@ -2935,6 +3091,13 @@ describe('createKiloPassUpsellCheckout', () => {
 
   it('allows current Standard hosting when balance plus selected tier projection covers the first charge', async () => {
     const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'trialing',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    });
     await db
       .update(kilocode_users)
       .set({ total_microdollars_acquired: 4_000_000 })
@@ -2988,6 +3151,13 @@ describe('createKiloPassUpsellCheckout', () => {
   it('allows current Commit hosting only when balance plus selected tier projection covers the six-month charge', async () => {
     setTestSystemTime(PRE_COMMIT_CUTOFF_TIME);
     const instance = await createKiloclawInstance(user.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instance.id,
+      plan: 'trial',
+      status: 'trialing',
+      kiloclaw_price_version: CURRENT_KILOCLAW_PRICE_VERSION,
+    });
     await db
       .update(kilocode_users)
       .set({ total_microdollars_acquired: 8_000_000 })
@@ -3278,8 +3448,16 @@ describe('handleKiloClawSubscriptionUpdated', () => {
       priceId: 'price_commit',
     });
     stripeMock.subscriptions.retrieve
-      .mockResolvedValueOnce({ ...subscription, schedule: null, cancel_at_period_end: false })
-      .mockResolvedValueOnce({ ...subscription, schedule: null, cancel_at_period_end: true });
+      .mockResolvedValueOnce({
+        ...subscription,
+        schedule: null,
+        cancel_at_period_end: false,
+      })
+      .mockResolvedValueOnce({
+        ...subscription,
+        schedule: null,
+        cancel_at_period_end: true,
+      });
     stripeMock.subscriptions.update.mockResolvedValue({});
 
     await handleKiloClawSubscriptionUpdated({
@@ -3313,8 +3491,16 @@ describe('handleKiloClawSubscriptionUpdated', () => {
       priceId: 'price_commit',
     });
     stripeMock.subscriptions.retrieve
-      .mockResolvedValueOnce({ ...subscription, schedule: null, cancel_at_period_end: false })
-      .mockResolvedValueOnce({ ...subscription, schedule: null, cancel_at_period_end: true });
+      .mockResolvedValueOnce({
+        ...subscription,
+        schedule: null,
+        cancel_at_period_end: false,
+      })
+      .mockResolvedValueOnce({
+        ...subscription,
+        schedule: null,
+        cancel_at_period_end: true,
+      });
     stripeMock.subscriptions.update.mockResolvedValue({});
 
     await handleKiloClawSubscriptionUpdated({
@@ -3396,7 +3582,12 @@ describe('handleKiloClawSubscriptionDeleted', () => {
     if (!existing) throw new Error('Failed to insert ambiguous deleted fixture');
     const subscription = makeStripeSubscription({
       id: 'sub_deleted_manual_review',
-      metadata: { type: 'kiloclaw', plan: 'commit', kiloUserId: user.id, instanceId: instance.id },
+      metadata: {
+        type: 'kiloclaw',
+        plan: 'commit',
+        kiloUserId: user.id,
+        instanceId: instance.id,
+      },
       status: 'canceled',
       cancel_at_period_end: true,
       priceId: 'price_commit',
@@ -3655,8 +3846,16 @@ describe('handleKiloClawSubscriptionCreated', () => {
       created: Math.floor(new Date('2026-06-05T23:59:59.000Z').getTime() / 1000),
     });
     stripeMock.subscriptions.retrieve
-      .mockResolvedValueOnce({ ...subscription, schedule: null, cancel_at_period_end: false })
-      .mockResolvedValueOnce({ ...subscription, schedule: null, cancel_at_period_end: true });
+      .mockResolvedValueOnce({
+        ...subscription,
+        schedule: null,
+        cancel_at_period_end: false,
+      })
+      .mockResolvedValueOnce({
+        ...subscription,
+        schedule: null,
+        cancel_at_period_end: true,
+      });
     stripeMock.subscriptions.update.mockResolvedValue({});
 
     await handleKiloClawSubscriptionCreated({
@@ -3720,7 +3919,10 @@ describe('handleKiloClawSubscriptionCreated', () => {
   });
 
   it('does not mutate a canceled legacy row when current checkout points at it', async () => {
-    const instance = await createWebhookAnchor({ plan: 'standard', status: 'canceled' });
+    const instance = await createWebhookAnchor({
+      plan: 'standard',
+      status: 'canceled',
+    });
 
     const subscription = makeStripeSubscription({
       id: 'sub_current_after_legacy_cancel',
@@ -3952,8 +4154,16 @@ describe('handleKiloClawSubscriptionCreated', () => {
       priceId: 'price_commit',
     });
     stripeMock.subscriptions.retrieve
-      .mockResolvedValueOnce({ ...staleSubscription, schedule: null, cancel_at_period_end: false })
-      .mockResolvedValueOnce({ ...staleSubscription, schedule: null, cancel_at_period_end: true });
+      .mockResolvedValueOnce({
+        ...staleSubscription,
+        schedule: null,
+        cancel_at_period_end: false,
+      })
+      .mockResolvedValueOnce({
+        ...staleSubscription,
+        schedule: null,
+        cancel_at_period_end: true,
+      });
     stripeMock.subscriptions.update.mockResolvedValue({});
 
     await handleKiloClawSubscriptionCreated({
@@ -3981,7 +4191,13 @@ describe('handleKiloClawSubscriptionCreated', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_auto',
-      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard_intro' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -4030,7 +4246,13 @@ describe('handleKiloClawSubscriptionCreated', () => {
       id: 'sched_half',
       metadata: { origin: 'auto-intro' },
       // Only 1 phase — the 2-phase rewrite never completed
-      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard_intro' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
       status: 'active',
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
@@ -4083,7 +4305,11 @@ describe('handleKiloClawSubscriptionCreated', () => {
     );
     stripePriceIdsMock.getStripePriceIdMetadata.mockImplementation((priceId: string) =>
       priceId === 'price_legacy_standard_intro'
-        ? { plan: 'standard', priceVersion: LEGACY_KILOCLAW_PRICE_VERSION, isIntro: true }
+        ? {
+            plan: 'standard',
+            priceVersion: LEGACY_KILOCLAW_PRICE_VERSION,
+            isIntro: true,
+          }
         : null
     );
     stripePriceIdsMock.getStripePriceIdForClawPlan.mockImplementation(
@@ -4131,7 +4357,9 @@ describe('handleKiloClawSubscriptionCreated', () => {
       'sched_legacy_half',
       expect.objectContaining({
         phases: expect.arrayContaining([
-          expect.objectContaining({ items: [{ price: 'price_legacy_standard_intro' }] }),
+          expect.objectContaining({
+            items: [{ price: 'price_legacy_standard_intro' }],
+          }),
           expect.objectContaining({
             items: [{ price: `${LEGACY_KILOCLAW_PRICE_VERSION}_standard` }],
           }),
@@ -4355,9 +4583,15 @@ describe('current-price canceled Stripe checkout webhook ordering', () => {
           eventId: `evt_created_${orderKey}`,
           subscription,
         });
-        await handleKiloClawInvoicePaid({ eventId: `evt_invoice_${orderKey}`, invoice });
+        await handleKiloClawInvoicePaid({
+          eventId: `evt_invoice_${orderKey}`,
+          invoice,
+        });
       } else {
-        await handleKiloClawInvoicePaid({ eventId: `evt_invoice_${orderKey}`, invoice });
+        await handleKiloClawInvoicePaid({
+          eventId: `evt_invoice_${orderKey}`,
+          invoice,
+        });
         await handleKiloClawSubscriptionCreated({
           eventId: `evt_created_${orderKey}`,
           subscription,
@@ -4711,7 +4945,9 @@ describe('handleKiloClawInvoicePaid affiliate events', () => {
           amount_paid: 30_600,
           currency: 'usd',
           charge: 'ch_rowless_paid_commit_provider_failure',
-          parent: { subscription_details: { subscription: stripeSubscriptionId } },
+          parent: {
+            subscription_details: { subscription: stripeSubscriptionId },
+          },
           lines: {
             data: [
               {
@@ -5216,7 +5452,13 @@ describe('reactivateSubscription', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_restored',
-      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard_intro' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -5311,7 +5553,13 @@ describe('switchPlan', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_new',
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -5379,7 +5627,13 @@ describe('switchPlan', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_legacy_family',
-      phases: [{ items: [{ price: 'price_legacy_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_legacy_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -5390,7 +5644,9 @@ describe('switchPlan', () => {
       'sub_sched_legacy_family',
       expect.objectContaining({
         phases: [
-          expect.objectContaining({ items: [{ price: 'price_legacy_standard' }] }),
+          expect.objectContaining({
+            items: [{ price: 'price_legacy_standard' }],
+          }),
           { items: [{ price: `${LEGACY_KILOCLAW_PRICE_VERSION}_commit` }] },
         ],
       })
@@ -5409,7 +5665,13 @@ describe('switchPlan', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_effective',
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -5472,7 +5734,13 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
       id: 'sched_auto',
       metadata: { origin: 'auto-intro' },
-      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard_intro' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
       status: 'active',
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
@@ -5515,7 +5783,13 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
       id: 'sched_hidden_auto',
       metadata: { origin: 'auto-intro' },
-      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard_intro' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
       status: 'active',
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
@@ -5549,13 +5823,25 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
       id: 'sched_hidden_user',
       metadata: {},
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
       status: 'active',
     });
     stripeMock.subscriptionSchedules.release.mockResolvedValue({});
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sched_fresh',
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -5594,7 +5880,13 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.retrieve.mockResolvedValue({
       id: 'sched_hidden_transient',
       metadata: {},
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
       status: 'active',
     });
     // Transient error — not "not active" or "released" or "canceled"
@@ -5622,7 +5914,13 @@ describe('switchPlan', () => {
     // which has already rolled over to the regular price
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sched_fresh_price',
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -5636,7 +5934,9 @@ describe('switchPlan', () => {
       string,
       unknown
     >;
-    const phases = updateArgs.phases as Array<{ items: Array<{ price: string }> }>;
+    const phases = updateArgs.phases as Array<{
+      items: Array<{ price: string }>;
+    }>;
     expect(phases[0].items[0].price).toBe('price_standard');
   });
 });
@@ -5756,7 +6056,13 @@ describe('cancelPlanSwitch', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sched_auto_restored',
-      phases: [{ items: [{ price: 'price_standard_intro' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard_intro' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -5833,7 +6139,12 @@ describe('createSubscriptionCheckout — concurrent checkout guard', () => {
 
     stripeMock.subscriptions.list.mockResolvedValue({ data: [] });
     stripeMock.checkout.sessions.list.mockResolvedValue({
-      data: [{ id: 'cs_existing', metadata: { type: 'kiloclaw', instanceId: instance.id } }],
+      data: [
+        {
+          id: 'cs_existing',
+          metadata: { type: 'kiloclaw', instanceId: instance.id },
+        },
+      ],
     });
     stripeMock.checkout.sessions.create.mockResolvedValue({
       id: 'cs_new',
@@ -5841,7 +6152,9 @@ describe('createSubscriptionCheckout — concurrent checkout guard', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' });
+    const result = await caller.kiloclaw.createSubscriptionCheckout({
+      plan: 'standard',
+    });
 
     expect(stripeMock.checkout.sessions.expire).toHaveBeenCalledWith('cs_existing');
     expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
@@ -5861,7 +6174,12 @@ describe('createSubscriptionCheckout — concurrent checkout guard', () => {
 
     stripeMock.subscriptions.list.mockResolvedValue({ data: [] });
     stripeMock.checkout.sessions.list.mockResolvedValue({
-      data: [{ id: 'cs_gone', metadata: { type: 'kiloclaw', instanceId: instance.id } }],
+      data: [
+        {
+          id: 'cs_gone',
+          metadata: { type: 'kiloclaw', instanceId: instance.id },
+        },
+      ],
     });
     stripeMock.checkout.sessions.expire.mockRejectedValue(new Error('session no longer open'));
     stripeMock.checkout.sessions.create.mockResolvedValue({
@@ -5870,7 +6188,9 @@ describe('createSubscriptionCheckout — concurrent checkout guard', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' });
+    const result = await caller.kiloclaw.createSubscriptionCheckout({
+      plan: 'standard',
+    });
 
     expect(stripeMock.checkout.sessions.expire).toHaveBeenCalledWith('cs_gone');
     expect(result).toEqual({ url: 'https://checkout.stripe.com/new' });
@@ -5990,7 +6310,9 @@ describe('createSubscriptionCheckout — concurrent checkout guard', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.createSubscriptionCheckout({ plan: 'standard' });
+    const result = await caller.kiloclaw.createSubscriptionCheckout({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ url: 'https://checkout.stripe.com/personal' });
     expect(stripeMock.checkout.sessions.create).toHaveBeenCalled();
@@ -6048,7 +6370,12 @@ describe('personal billing mutations do not affect org subscriptions', () => {
       })
       .returning();
 
-    return { orgInstance, personalInstance, orgSub: orgSub!, personalSub: personalSub! };
+    return {
+      orgInstance,
+      personalInstance,
+      orgSub: orgSub!,
+      personalSub: personalSub!,
+    };
   }
 
   it('cancelSubscription targets the personal subscription, not the org one', async () => {
@@ -6116,7 +6443,13 @@ describe('personal billing mutations do not affect org subscriptions', () => {
     });
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_personal',
-      phases: [{ items: [{ price: 'price_standard' }], start_date: 1000, end_date: 2000 }],
+      phases: [
+        {
+          items: [{ price: 'price_standard' }],
+          start_date: 1000,
+          end_date: 2000,
+        },
+      ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({});
 
@@ -6192,7 +6525,11 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_new',
       phases: [
-        { start_date: now, end_date: now + 86400 * 30, items: [{ price: 'price_test_kiloclaw' }] },
+        {
+          start_date: now,
+          end_date: now + 86400 * 30,
+          items: [{ price: 'price_test_kiloclaw' }],
+        },
       ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({
@@ -6322,7 +6659,11 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_new',
       phases: [
-        { start_date: now, end_date: now + 86400 * 30, items: [{ price: 'price_test_kiloclaw' }] },
+        {
+          start_date: now,
+          end_date: now + 86400 * 30,
+          items: [{ price: 'price_test_kiloclaw' }],
+        },
       ],
     });
     stripeMock.subscriptionSchedules.update.mockResolvedValue({
@@ -6347,7 +6688,11 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_orphan',
       phases: [
-        { start_date: now, end_date: now + 86400 * 30, items: [{ price: 'price_test_kiloclaw' }] },
+        {
+          start_date: now,
+          end_date: now + 86400 * 30,
+          items: [{ price: 'price_test_kiloclaw' }],
+        },
       ],
     });
     stripeMock.subscriptionSchedules.update.mockRejectedValue(new Error('Stripe update failed'));
@@ -6381,7 +6726,11 @@ describe('switchPlan', () => {
     stripeMock.subscriptionSchedules.create.mockResolvedValue({
       id: 'sub_sched_race',
       phases: [
-        { start_date: now, end_date: now + 86400 * 30, items: [{ price: 'price_test_kiloclaw' }] },
+        {
+          start_date: now,
+          end_date: now + 86400 * 30,
+          items: [{ price: 'price_test_kiloclaw' }],
+        },
       ],
     });
     // Simulate a concurrent request writing a schedule to the DB while our
@@ -6913,7 +7262,9 @@ describe('enrollWithCredits', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.enrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -6973,7 +7324,9 @@ describe('enrollWithCredits', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.enrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -7012,7 +7365,9 @@ describe('enrollWithCredits', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.enrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -7100,7 +7455,9 @@ describe('enrollWithCredits', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.enrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -7154,7 +7511,9 @@ describe('enrollWithCredits', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.enrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -7175,31 +7534,29 @@ describe('enrollWithCredits', () => {
     expect(deduction?.amount_microdollars).toBe(-55_000_000);
   });
 
-  it('charges current standard pricing for fresh enrollment with no subscription row', async () => {
+  it('rejects credit enrollment without an existing personal subscription', async () => {
     const instance = await createInstance(user.id);
     await giveUserCredits(user.id, 60_000_000);
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({
-      plan: 'standard',
-      instanceId: instance.id,
-    });
+    await expect(
+      caller.kiloclaw.enrollWithCredits({
+        plan: 'standard',
+        instanceId: instance.id,
+      })
+    ).rejects.toThrow('New KiloClaw subscriptions are unavailable.');
 
-    expect(result).toEqual({ success: true });
-
-    const [sub] = await db
+    const subscriptions = await db
       .select()
       .from(kiloclaw_subscriptions)
-      .where(eq(kiloclaw_subscriptions.user_id, user.id))
-      .limit(1);
-    expect(sub.kiloclaw_price_version).toBe(CURRENT_KILOCLAW_PRICE_VERSION);
+      .where(eq(kiloclaw_subscriptions.user_id, user.id));
+    expect(subscriptions).toHaveLength(0);
 
-    const txns = await db
+    const transactions = await db
       .select()
       .from(credit_transactions)
       .where(eq(credit_transactions.kilo_user_id, user.id));
-    const deduction = txns.find(t => t.amount_microdollars < 0);
-    expect(deduction?.amount_microdollars).toBe(-55_000_000);
+    expect(transactions).toHaveLength(0);
   });
 
   it('rejects current standard enrollment when balance only covers legacy pricing', async () => {
@@ -7464,7 +7821,9 @@ describe('enrollWithCredits', () => {
       shortfallMicrodollars: 0,
     });
 
-    const result = await caller.kiloclaw.reprovisionAndEnrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.reprovisionAndEnrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({
       success: true,
@@ -7706,7 +8065,9 @@ describe('enrollWithCredits', () => {
       },
     });
 
-    const result = await caller.kiloclaw.reprovisionAndEnrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.reprovisionAndEnrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({
       success: false,
@@ -7846,7 +8207,9 @@ describe('enrollWithCredits', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.enrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -7982,7 +8345,9 @@ describe('enrollWithCredits', () => {
     });
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.enrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -8007,7 +8372,9 @@ describe('enrollWithCredits', () => {
     await giveUserCredits(user.id, 5_000_000); // $5 — enough for $4 intro, not enough for $9
 
     const caller = await createCallerForUser(user.id);
-    const result = await caller.kiloclaw.enrollWithCredits({ plan: 'standard' });
+    const result = await caller.kiloclaw.enrollWithCredits({
+      plan: 'standard',
+    });
 
     expect(result).toEqual({ success: true });
 
@@ -8466,7 +8833,9 @@ describe('getBillingStatus with credits', () => {
 
     const caller = await createCallerForUser(user.id);
     const status = await caller.kiloclaw.getBillingStatus();
-    const portal = await caller.kiloclaw.getCustomerPortalUrl({ instanceId: instance.id });
+    const portal = await caller.kiloclaw.getCustomerPortalUrl({
+      instanceId: instance.id,
+    });
 
     expect(status.subscription).toMatchObject({
       paymentSource: 'credits',
@@ -8476,7 +8845,9 @@ describe('getBillingStatus with credits', () => {
       renewalCostMicrodollars: 55_000_000,
       renewalCostSource: 'stripe_approximation',
     });
-    expect(portal).toEqual({ url: 'https://stripe.example.test/hybrid-portal' });
+    expect(portal).toEqual({
+      url: 'https://stripe.example.test/hybrid-portal',
+    });
   });
 
   it('reports creditIntroEligible=true for new user with no subscription', async () => {
@@ -9118,7 +9489,9 @@ describe('acceptConversion', () => {
     stripeMock.subscriptions.retrieve.mockResolvedValueOnce({ schedule: null });
     stripeMock.subscriptions.update.mockRejectedValue(new Error('Stripe API error'));
     // Re-fetch confirms Stripe did NOT apply cancel_at_period_end
-    stripeMock.subscriptions.retrieve.mockResolvedValueOnce({ cancel_at_period_end: false });
+    stripeMock.subscriptions.retrieve.mockResolvedValueOnce({
+      cancel_at_period_end: false,
+    });
 
     const caller = await createCallerForUser(user.id);
     await expect(caller.kiloclaw.acceptConversion()).rejects.toThrow(
@@ -9153,7 +9526,9 @@ describe('acceptConversion', () => {
     stripeMock.subscriptions.retrieve.mockResolvedValueOnce({ schedule: null });
     stripeMock.subscriptions.update.mockRejectedValue(new Error('Stripe timeout'));
     // Re-fetch confirms Stripe DID apply cancel_at_period_end (timeout-after-commit)
-    stripeMock.subscriptions.retrieve.mockResolvedValueOnce({ cancel_at_period_end: true });
+    stripeMock.subscriptions.retrieve.mockResolvedValueOnce({
+      cancel_at_period_end: true,
+    });
 
     const caller = await createCallerForUser(user.id);
     const result = await caller.kiloclaw.acceptConversion();

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -646,7 +646,7 @@ describe('kiloclawRouter getNavState', () => {
 
     expect(result).toEqual({
       hasActiveInstance: false,
-      hasExistingPersonalSubscription: false,
+      hasCurrentPersonalSubscription: false,
     });
     expect(kiloclawClientMock.KiloClawInternalClient).not.toHaveBeenCalled();
     expect(kiloclawClientMock.__getStatusMock).not.toHaveBeenCalled();
@@ -665,8 +665,9 @@ describe('kiloclawRouter getNavState', () => {
     await db.insert(kiloclaw_subscriptions).values({
       user_id: user.id,
       instance_id: instanceId,
-      plan: 'trial',
-      status: 'trialing',
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
     });
     const caller = createCaller({ user });
 
@@ -674,7 +675,7 @@ describe('kiloclawRouter getNavState', () => {
 
     expect(result).toEqual({
       hasActiveInstance: true,
-      hasExistingPersonalSubscription: true,
+      hasCurrentPersonalSubscription: true,
     });
     expect(kiloclawClientMock.KiloClawInternalClient).not.toHaveBeenCalled();
     expect(kiloclawClientMock.__getStatusMock).not.toHaveBeenCalled();
@@ -697,11 +698,11 @@ describe('kiloclawRouter getNavState', () => {
 
     expect(result).toEqual({
       hasActiveInstance: false,
-      hasExistingPersonalSubscription: false,
+      hasCurrentPersonalSubscription: false,
     });
   });
 
-  it('keeps KiloClaw navigation available for canceled personal subscription history', async () => {
+  it('does not expose KiloClaw navigation for canceled personal subscription history', async () => {
     const user = await insertTestUser({
       google_user_email: `kiloclaw-nav-canceled-${Math.random()}@example.com`,
     });
@@ -725,7 +726,7 @@ describe('kiloclawRouter getNavState', () => {
 
     expect(result).toEqual({
       hasActiveInstance: false,
-      hasExistingPersonalSubscription: true,
+      hasCurrentPersonalSubscription: false,
     });
   });
 });

--- a/apps/web/src/routers/kiloclaw-router.test.ts
+++ b/apps/web/src/routers/kiloclaw-router.test.ts
@@ -59,7 +59,9 @@ jest.mock('@/lib/stripe-client', () => {
       release: jest.fn(),
       retrieve: jest.fn(),
     },
-    checkout: { sessions: { create: jest.fn(), list: jest.fn(), expire: jest.fn() } },
+    checkout: {
+      sessions: { create: jest.fn(), list: jest.fn(), expire: jest.fn() },
+    },
     billingPortal: { sessions: { create: jest.fn() } },
     invoices: { list: jest.fn() },
   };
@@ -149,7 +151,10 @@ jest.mock('@/lib/kiloclaw/kiloclaw-internal-client', () => {
 // fetch/verify/kilo-chat path (covered by install-dispatch.test.ts).
 jest.mock('@/lib/kiloclaw/install-dispatch', () => {
   const dispatchInstallFromSource = jest.fn();
-  return { dispatchInstallFromSource, __dispatchInstallFromSource: dispatchInstallFromSource };
+  return {
+    dispatchInstallFromSource,
+    __dispatchInstallFromSource: dispatchInstallFromSource,
+  };
 });
 
 let createCaller: (ctx: { user: Awaited<ReturnType<typeof insertTestUser>> }) => {
@@ -227,12 +232,13 @@ let createCaller: (ctx: { user: Awaited<ReturnType<typeof insertTestUser>> }) =>
   // Method syntax (bivariant params) so the real caller's narrower
   // `source: 'byte'` input stays assignable while tests can pass an arbitrary
   // string for the input-validation case.
-  installFromSource(input: {
-    source: string;
-    slug: string;
-    signature: string;
-  }): Promise<
-    | { ok: true; conversationId: string; messageId: string; conversationCreated: boolean }
+  installFromSource(input: { source: string; slug: string; signature: string }): Promise<
+    | {
+        ok: true;
+        conversationId: string;
+        messageId: string;
+        conversationCreated: boolean;
+      }
     | { ok: false; code: 'no_instance' }
   >;
 };
@@ -256,7 +262,10 @@ async function createActivePersonalInstance(userId: string): Promise<string> {
 }
 
 function wttrFormat3Response(text: string, status = 200): Response {
-  return new Response(text, { status, headers: { 'Content-Type': 'text/plain' } });
+  return new Response(text, {
+    status,
+    headers: { 'Content-Type': 'text/plain' },
+  });
 }
 
 const WTTR_SERVICE_UNAVAILABLE_MESSAGE =
@@ -308,7 +317,9 @@ describe('kiloclawRouter validateWeatherLocation', () => {
       );
     const caller = createCaller({ user });
 
-    const result = await caller.validateWeatherLocation({ location: ' Amsterdam ' });
+    const result = await caller.validateWeatherLocation({
+      location: ' Amsterdam ',
+    });
 
     expect(fetchSpy).toHaveBeenCalledTimes(2);
     expect(fetchSpy).toHaveBeenNthCalledWith(
@@ -349,7 +360,9 @@ describe('kiloclawRouter validateWeatherLocation', () => {
       );
     const caller = createCaller({ user });
 
-    const result = await caller.validateWeatherLocation({ location: '53.2167,6.5667' });
+    const result = await caller.validateWeatherLocation({
+      location: '53.2167,6.5667',
+    });
 
     expect(fetchSpy).toHaveBeenNthCalledWith(
       2,
@@ -396,7 +409,9 @@ describe('kiloclawRouter validateWeatherLocation', () => {
     const user = await insertTestUser({
       google_user_email: `kiloclaw-weather-timeout-test-${Math.random()}@example.com`,
     });
-    const timeoutError = Object.assign(new Error('timeout'), { name: 'TimeoutError' });
+    const timeoutError = Object.assign(new Error('timeout'), {
+      name: 'TimeoutError',
+    });
     fetchSpy.mockRejectedValue(timeoutError);
     const caller = createCaller({ user });
 
@@ -574,7 +589,9 @@ describe('kiloclawRouter latestVersion', () => {
     });
 
     const caller = createCaller({ user });
-    const result = await caller.latestVersion({ currentImageTag: 'current-tag' });
+    const result = await caller.latestVersion({
+      currentImageTag: 'current-tag',
+    });
 
     expect(result).toEqual({ imageTag: 'anonymous-tag' });
     expect(kiloclawClientMock.__getLatestVersionMock).toHaveBeenCalledWith();
@@ -627,12 +644,15 @@ describe('kiloclawRouter getNavState', () => {
 
     const result = await caller.getNavState();
 
-    expect(result).toEqual({ hasActiveInstance: false });
+    expect(result).toEqual({
+      hasActiveInstance: false,
+      hasExistingPersonalSubscription: false,
+    });
     expect(kiloclawClientMock.KiloClawInternalClient).not.toHaveBeenCalled();
     expect(kiloclawClientMock.__getStatusMock).not.toHaveBeenCalled();
   });
 
-  it('returns active personal instance presence without requiring subscription access', async () => {
+  it('returns active personal instance and canonical subscription presence without worker access', async () => {
     const user = await insertTestUser({
       google_user_email: `kiloclaw-nav-present-${Math.random()}@example.com`,
     });
@@ -642,16 +662,25 @@ describe('kiloclawRouter getNavState', () => {
       user_id: user.id,
       sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
     });
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instanceId,
+      plan: 'trial',
+      status: 'trialing',
+    });
     const caller = createCaller({ user });
 
     const result = await caller.getNavState();
 
-    expect(result).toEqual({ hasActiveInstance: true });
+    expect(result).toEqual({
+      hasActiveInstance: true,
+      hasExistingPersonalSubscription: true,
+    });
     expect(kiloclawClientMock.KiloClawInternalClient).not.toHaveBeenCalled();
     expect(kiloclawClientMock.__getStatusMock).not.toHaveBeenCalled();
   });
 
-  it('ignores destroyed personal instances', async () => {
+  it('ignores destroyed personal instances without subscription history', async () => {
     const user = await insertTestUser({
       google_user_email: `kiloclaw-nav-destroyed-${Math.random()}@example.com`,
     });
@@ -666,7 +695,38 @@ describe('kiloclawRouter getNavState', () => {
 
     const result = await caller.getNavState();
 
-    expect(result).toEqual({ hasActiveInstance: false });
+    expect(result).toEqual({
+      hasActiveInstance: false,
+      hasExistingPersonalSubscription: false,
+    });
+  });
+
+  it('keeps KiloClaw navigation available for canceled personal subscription history', async () => {
+    const user = await insertTestUser({
+      google_user_email: `kiloclaw-nav-canceled-${Math.random()}@example.com`,
+    });
+    const instanceId = crypto.randomUUID();
+    await db.insert(kiloclaw_instances).values({
+      id: instanceId,
+      user_id: user.id,
+      sandbox_id: `ki_${instanceId.replace(/-/g, '')}`,
+      destroyed_at: '2026-05-29T00:00:00.000Z',
+    });
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instanceId,
+      plan: 'standard',
+      status: 'canceled',
+      payment_source: 'credits',
+    });
+    const caller = createCaller({ user });
+
+    const result = await caller.getNavState();
+
+    expect(result).toEqual({
+      hasActiveInstance: false,
+      hasExistingPersonalSubscription: true,
+    });
   });
 });
 
@@ -799,9 +859,15 @@ describe('kiloclawRouter getActivePersonalBillingStatus referral rewards', () =>
         current_period_end: '2026-06-01T00:00:00.000Z',
         credit_renewal_at: '2026-06-01T00:00:00.000Z',
       })
-      .returning({ id: kiloclaw_subscriptions.id, instanceId: kiloclaw_subscriptions.instance_id });
+      .returning({
+        id: kiloclaw_subscriptions.id,
+        instanceId: kiloclaw_subscriptions.instance_id,
+      });
 
-    return { subscriptionId: subscription.id, instanceId: subscription.instanceId ?? instanceId };
+    return {
+      subscriptionId: subscription.id,
+      instanceId: subscription.instanceId ?? instanceId,
+    };
   }
 
   async function insertAppliedReferralReward(params: {
@@ -870,7 +936,9 @@ describe('kiloclawRouter getActivePersonalBillingStatus referral rewards', () =>
       sourcePaymentId: `kiloclaw-subscription:${instanceId}:2026-04`,
     });
 
-    const billing = await createCaller({ user }).getActivePersonalBillingStatus();
+    const billing = await createCaller({
+      user,
+    }).getActivePersonalBillingStatus();
 
     expect(billing.subscription?.referralRewards).toEqual({
       totalAppliedMonths: 1,
@@ -901,7 +969,9 @@ describe('kiloclawRouter getActivePersonalBillingStatus referral rewards', () =>
       sourcePaymentId: `kiloclaw-subscription:${instanceId}:other-user`,
     });
 
-    const billing = await createCaller({ user }).getActivePersonalBillingStatus();
+    const billing = await createCaller({
+      user,
+    }).getActivePersonalBillingStatus();
 
     expect(billing.subscription?.referralRewards).toEqual({
       totalAppliedMonths: 0,
@@ -921,7 +991,9 @@ describe('kiloclawRouter getActivePersonalBillingStatus referral rewards', () =>
       sourcePaymentId: `kiloclaw-subscription:${instanceId}:detail`,
     });
 
-    const detail = await createCaller({ user }).getSubscriptionDetail({ instanceId });
+    const detail = await createCaller({ user }).getSubscriptionDetail({
+      instanceId,
+    });
 
     expect(detail.referralRewards).toEqual({
       totalAppliedMonths: 1,
@@ -1321,9 +1393,9 @@ describe('kiloclawRouter destroy', () => {
 });
 
 describe('kiloclawRouter installFromSource', () => {
-  const installDispatchMock = jest.requireMock<{ __dispatchInstallFromSource: AnyMock }>(
-    '@/lib/kiloclaw/install-dispatch'
-  );
+  const installDispatchMock = jest.requireMock<{
+    __dispatchInstallFromSource: AnyMock;
+  }>('@/lib/kiloclaw/install-dispatch');
 
   beforeEach(async () => {
     await cleanupDbForTest();
@@ -1355,7 +1427,11 @@ describe('kiloclawRouter installFromSource', () => {
     const caller = createCaller({ user });
 
     await expect(
-      caller.installFromSource({ source: 'byte', slug: 'deep-research', signature: 'sig' })
+      caller.installFromSource({
+        source: 'byte',
+        slug: 'deep-research',
+        signature: 'sig',
+      })
     ).rejects.toMatchObject({ code: 'FORBIDDEN' });
     expect(installDispatchMock.__dispatchInstallFromSource).not.toHaveBeenCalled();
   });
@@ -1421,7 +1497,11 @@ describe('kiloclawRouter installFromSource', () => {
     const caller = createCaller({ user });
 
     await expect(
-      caller.installFromSource({ source: 'hacker', slug: 'deep-research', signature: 'sig' })
+      caller.installFromSource({
+        source: 'hacker',
+        slug: 'deep-research',
+        signature: 'sig',
+      })
     ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
     expect(installDispatchMock.__dispatchInstallFromSource).not.toHaveBeenCalled();
   });

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -100,10 +100,6 @@ import {
 import { client as stripe } from '@/lib/stripe-client';
 import { APP_URL } from '@/lib/constants';
 import { getAffiliateAttribution } from '@/lib/affiliate-attribution';
-import {
-  buildAffiliateEventDedupeKey,
-  enqueueAffiliateEventForUser,
-} from '@/lib/impact/affiliate-events';
 import { clawAccessProcedure } from '@/lib/kiloclaw/access-gate';
 import { dispatchInstallFromSource } from '@/lib/kiloclaw/install-dispatch';
 import { INSTALL_SOURCE_KEYS } from '@/lib/kiloclaw/install-sources';
@@ -148,7 +144,6 @@ import {
 import type { ClawBillingStatus } from '@/app/(app)/claw/components/billing/billing-types';
 import PostHogClient from '@/lib/posthog';
 import { CHANGELOG_ENTRIES } from '@/app/(app)/claw/components/changelog-data';
-import { IMPACT_ORDER_ID_MACRO } from '@/lib/impact';
 
 /**
  * Error codes whose messages may contain raw internal details (e.g. filesystem
@@ -352,21 +347,45 @@ type CreditEnrollmentRouterErrorDisposition = {
 };
 
 const CREDIT_ENROLLMENT_ROUTER_ERROR_DISPOSITIONS = {
-  commit_unavailable: { code: 'BAD_REQUEST', failureReason: 'precondition_failed' },
+  commit_unavailable: {
+    code: 'BAD_REQUEST',
+    failureReason: 'precondition_failed',
+  },
   user_not_found: { code: 'NOT_FOUND', failureReason: 'user_not_found' },
   instance_not_found: { code: 'NOT_FOUND', failureReason: 'no_instance' },
-  instance_destroyed: { code: 'CONFLICT', failureReason: 'precondition_failed' },
+  instance_destroyed: {
+    code: 'CONFLICT',
+    failureReason: 'precondition_failed',
+  },
   active_subscription_exists: {
     code: 'CONFLICT',
     failureReason: 'active_subscription_exists',
   },
-  unknown_price_version: { code: 'CONFLICT', failureReason: 'precondition_failed' },
-  price_version_mismatch: { code: 'CONFLICT', failureReason: 'precondition_failed' },
-  insufficient_credits: { code: 'BAD_REQUEST', failureReason: 'insufficient_credits' },
-  target_unavailable: { code: 'CONFLICT', failureReason: 'precondition_failed' },
+  unknown_price_version: {
+    code: 'CONFLICT',
+    failureReason: 'precondition_failed',
+  },
+  price_version_mismatch: {
+    code: 'CONFLICT',
+    failureReason: 'precondition_failed',
+  },
+  insufficient_credits: {
+    code: 'BAD_REQUEST',
+    failureReason: 'insufficient_credits',
+  },
+  target_unavailable: {
+    code: 'CONFLICT',
+    failureReason: 'precondition_failed',
+  },
   target_changed: { code: 'CONFLICT', failureReason: 'precondition_failed' },
-  requires_reprovision: { code: 'CONFLICT', failureReason: 'precondition_failed' },
-  duplicate_enrollment: { code: 'CONFLICT', failureReason: 'duplicate_enrollment' },
+  requires_reprovision: {
+    code: 'CONFLICT',
+    failureReason: 'precondition_failed',
+  },
+  duplicate_enrollment: {
+    code: 'CONFLICT',
+    failureReason: 'duplicate_enrollment',
+  },
 } satisfies Record<CreditEnrollmentErrorReason, CreditEnrollmentRouterErrorDisposition>;
 
 function classifyEnrollWithCreditsError(error: unknown):
@@ -610,7 +629,10 @@ function handleFileOperationError(err: unknown, operation: string): never {
   });
 }
 
-function getKiloClawApiErrorPayload(err: KiloClawApiError): { message?: string; code?: string } {
+function getKiloClawApiErrorPayload(err: KiloClawApiError): {
+  message?: string;
+  code?: string;
+} {
   if (!err.responseBody) return {};
 
   try {
@@ -1197,67 +1219,6 @@ async function provisionInstance(
   }
 }
 
-async function emitProvisionTrialStartSideEffects(params: {
-  userId: string;
-  userEmail: string;
-  instanceId: string;
-}) {
-  try {
-    const [subscription] = await db
-      .select({
-        id: kiloclaw_subscriptions.id,
-        createdAt: kiloclaw_subscriptions.created_at,
-        plan: kiloclaw_subscriptions.plan,
-        status: kiloclaw_subscriptions.status,
-        trialStartedAt: kiloclaw_subscriptions.trial_started_at,
-        trialEndsAt: kiloclaw_subscriptions.trial_ends_at,
-        accessOrigin: kiloclaw_subscriptions.access_origin,
-      })
-      .from(kiloclaw_subscriptions)
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.user_id, params.userId),
-          eq(kiloclaw_subscriptions.instance_id, params.instanceId)
-        )
-      )
-      .limit(1);
-
-    if (!subscription) return;
-    if (subscription.plan !== 'trial' || subscription.status !== 'trialing') return;
-    if (subscription.accessOrigin === 'earlybird') return;
-
-    PostHogClient().capture({
-      distinctId: params.userEmail,
-      event: 'claw_trial_started',
-      properties: {
-        user_id: params.userId,
-        plan: 'trial',
-        trial_ends_at: subscription.trialEndsAt,
-      },
-    });
-
-    const eventDate = new Date(subscription.trialStartedAt ?? subscription.createdAt);
-    await enqueueAffiliateEventForUser({
-      userId: params.userId,
-      provider: 'impact',
-      eventType: 'trial_start',
-      dedupeKey: buildAffiliateEventDedupeKey({
-        provider: 'impact',
-        eventType: 'trial_start',
-        entityId: subscription.id,
-      }),
-      eventDate,
-      orderId: IMPACT_ORDER_ID_MACRO,
-    });
-  } catch (error) {
-    sentryLogger('kiloclaw-billing', 'warning')('Provision trial start side effects failed', {
-      user_id: params.userId,
-      instance_id: params.instanceId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-}
-
 async function patchConfig(
   user: Parameters<typeof generateApiToken>[0],
   input: z.infer<typeof updateKiloCodeConfigSchema>
@@ -1365,8 +1326,11 @@ async function fetchKiloClawServiceDegraded(): Promise<boolean> {
     });
     if (!response.ok) return false;
     const data = await response.json();
-    const included: Array<{ id: string; type: string; attributes?: { status?: string } }> =
-      data.included ?? [];
+    const included: Array<{
+      id: string;
+      type: string;
+      attributes?: { status?: string };
+    }> = data.included ?? [];
     const resource = included.find(
       entry =>
         entry.type === 'status_page_resource' && entry.id === KILOCLAW_STATUS_PAGE_RESOURCE_ID
@@ -1383,6 +1347,13 @@ async function fetchKiloClawServiceDegraded(): Promise<boolean> {
   }
 }
 
+function throwNewKiloClawSubscriptionsUnavailable(): never {
+  throw new TRPCError({
+    code: 'FORBIDDEN',
+    message: 'New KiloClaw subscriptions are unavailable.',
+  });
+}
+
 /**
  * Ensure user has billing access for provisioning.
  * Returns active instance when access is bound to one, otherwise null when
@@ -1390,12 +1361,10 @@ async function fetchKiloClawServiceDegraded(): Promise<boolean> {
  */
 async function ensureProvisionAccess(
   userId: string,
-  _userEmail: string,
   executor: typeof db | DrizzleTransaction = db
 ): Promise<{
   instanceId: string | null;
   bootstrapSubscription: boolean;
-  shouldEnqueueTrialStartAffiliate: boolean;
 }> {
   const now = new Date();
   const activeInstance = await getActiveInstance(userId, executor);
@@ -1433,12 +1402,8 @@ async function ensureProvisionAccess(
     });
   }
 
-  if (activeInstance && !currentRow && !detachedAccessGrantingSubscription && !anySubscription) {
-    return {
-      instanceId: activeInstance.id,
-      bootstrapSubscription: true,
-      shouldEnqueueTrialStartAffiliate: true,
-    };
+  if (!anySubscription) {
+    throwNewKiloClawSubscriptionsUnavailable();
   }
 
   if (activeInstance && !currentRow && !detachedAccessGrantingSubscription) {
@@ -1459,7 +1424,6 @@ async function ensureProvisionAccess(
     return {
       instanceId: activeInstance?.id ?? null,
       bootstrapSubscription: false,
-      shouldEnqueueTrialStartAffiliate: false,
     };
   }
 
@@ -1467,15 +1431,6 @@ async function ensureProvisionAccess(
     return {
       instanceId: activeInstance?.id ?? null,
       bootstrapSubscription: activeInstance !== null,
-      shouldEnqueueTrialStartAffiliate: false,
-    };
-  }
-
-  if (!anySubscription) {
-    return {
-      instanceId: activeInstance?.id ?? null,
-      bootstrapSubscription: activeInstance !== null,
-      shouldEnqueueTrialStartAffiliate: true,
     };
   }
 
@@ -1488,7 +1443,9 @@ async function ensureProvisionAccess(
 // ── Personal subscription management schemas ──────────────────────────
 
 const KiloclawInstanceInputSchema = z.object({ instanceId: z.string().uuid() });
-const KiloclawOptionalInstanceInputSchema = z.object({ instanceId: z.string().uuid().optional() });
+const KiloclawOptionalInstanceInputSchema = z.object({
+  instanceId: z.string().uuid().optional(),
+});
 const KiloclawInstanceSwitchPlanInputSchema = z.object({
   instanceId: z.string().uuid(),
   toPlan: z.enum(['commit', 'standard']),
@@ -1672,7 +1629,10 @@ function assertKiloClawCommitAdmission(
       requested_plan: plan,
       cutoff_decision_at: now.toISOString(),
     });
-    throw new TRPCError({ code: 'BAD_REQUEST', message: COMMIT_ADMISSION_ERROR_MESSAGE });
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: COMMIT_ADMISSION_ERROR_MESSAGE,
+    });
   }
 }
 
@@ -1803,7 +1763,10 @@ async function getKiloPassUpsellActivationPreview(params: {
     microdollarsUsed: params.microdollarsUsed,
     kiloPassThreshold: params.microdollarsUsed + projectedKiloPassBaseMicrodollars,
     costMicrodollars: params.costMicrodollars,
-    subscription: buildPendingKiloPassState({ tier: params.tier, cadence: params.cadence }),
+    subscription: buildPendingKiloPassState({
+      tier: params.tier,
+      cadence: params.cadence,
+    }),
   });
   const shortfallMicrodollars = Math.max(
     0,
@@ -1981,7 +1944,10 @@ async function getPersonalBillingStatus(user: {
             ? 'credits'
             : (sub.payment_source ?? null),
         needsSupportReview: subscriptionCommitRetirementState === 'manual_review',
-        referralRewards: referralRewards ?? { totalAppliedMonths: 0, applications: [] },
+        referralRewards: referralRewards ?? {
+          totalAppliedMonths: 0,
+          applications: [],
+        },
       }
     : null;
 
@@ -2013,11 +1979,26 @@ async function getPersonalBillingStatus(user: {
     };
   }
 
-  const [anySubscription, anyPersonalInstanceHistory] = await Promise.all([
+  const [anySubscription, anyPersonalSubscription, anyPersonalInstanceHistory] = await Promise.all([
     db
       .select({ id: kiloclaw_subscriptions.id })
       .from(kiloclaw_subscriptions)
       .where(eq(kiloclaw_subscriptions.user_id, user.id))
+      .limit(1)
+      .then(rows => rows[0] ?? null),
+    db
+      .select({ id: kiloclaw_subscriptions.id })
+      .from(kiloclaw_subscriptions)
+      .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.user_id, user.id),
+          or(
+            isNull(kiloclaw_subscriptions.instance_id),
+            and(eq(kiloclaw_instances.user_id, user.id), isNull(kiloclaw_instances.organization_id))
+          )
+        )
+      )
       .limit(1)
       .then(rows => rows[0] ?? null),
     db
@@ -2092,6 +2073,7 @@ async function getPersonalBillingStatus(user: {
   return {
     hasAccess,
     accessReason,
+    hasExistingPersonalSubscription: anyPersonalSubscription !== null,
     commitPlanAvailable: maySelectKiloClawCommit(now),
     trialEligible: !anyPersonalInstanceHistory && !anySubscription,
     creditBalanceMicrodollars,
@@ -2449,7 +2431,10 @@ function summarizePersonalBillingStatus(billing: ClawBillingStatus) {
 async function hasEligiblePersonalSubscriptionForReferralReward(userId: string): Promise<boolean> {
   let currentRow: Awaited<ReturnType<typeof resolveCurrentPersonalSubscriptionRow>>;
   try {
-    currentRow = await resolveCurrentPersonalSubscriptionRow({ userId, dbOrTx: db });
+    currentRow = await resolveCurrentPersonalSubscriptionRow({
+      userId,
+      dbOrTx: db,
+    });
   } catch (error) {
     mapCurrentSubscriptionResolutionError(error);
   }
@@ -2742,7 +2727,10 @@ async function getKiloclawPersonalSubscriptionRow(params: {
     .limit(1);
 
   if (!row) {
-    throw new TRPCError({ code: 'NOT_FOUND', message: 'Subscription not found.' });
+    throw new TRPCError({
+      code: 'NOT_FOUND',
+      message: 'Subscription not found.',
+    });
   }
 
   return row;
@@ -2755,7 +2743,10 @@ async function cancelKiloclawSubscriptionForRow(params: {
   const { subscription, userId } = params;
 
   if (subscription.status !== 'active') {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to cancel.' });
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No active subscription to cancel.',
+    });
   }
 
   if (subscription.cancel_at_period_end) {
@@ -2799,7 +2790,11 @@ async function cancelKiloclawSubscriptionForRow(params: {
           .set({
             cancel_at_period_end: true,
             ...(scheduleIdToRelease
-              ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
+              ? {
+                  stripe_schedule_id: null,
+                  scheduled_plan: null,
+                  scheduled_by: null,
+                }
               : {}),
           })
           .where(eq(kiloclaw_subscriptions.id, subscription.id))
@@ -2848,7 +2843,10 @@ async function acceptKiloclawConversionForRow(params: {
   const { subscription, userId } = params;
 
   if (subscription.status !== 'active') {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to convert.' });
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No active subscription to convert.',
+    });
   }
 
   if (!subscription.stripe_subscription_id) {
@@ -2916,7 +2914,11 @@ async function acceptKiloclawConversionForRow(params: {
         .set({
           pending_conversion: true,
           ...(scheduleIdToRelease
-            ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
+            ? {
+                stripe_schedule_id: null,
+                scheduled_plan: null,
+                scheduled_by: null,
+              }
             : {}),
         })
         .where(eq(kiloclaw_subscriptions.id, subscription.id))
@@ -3097,15 +3099,24 @@ async function switchKiloclawPlanForRow(params: {
   assertKiloClawCommitAdmission(toPlan, 'switch_plan_for_row', requestedAt);
 
   if (subscription.status !== 'active') {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to switch.' });
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No active subscription to switch.',
+    });
   }
 
   if (subscription.plan === toPlan) {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Already on this plan.' });
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Already on this plan.',
+    });
   }
 
   if (subscription.plan !== 'commit' && subscription.plan !== 'standard') {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot switch from a trial plan.' });
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Cannot switch from a trial plan.',
+    });
   }
 
   if (subscription.stripe_subscription_id) {
@@ -3213,7 +3224,11 @@ async function switchKiloclawPlanForRow(params: {
 
             const [after] = await tx
               .update(kiloclaw_subscriptions)
-              .set({ stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null })
+              .set({
+                stripe_schedule_id: null,
+                scheduled_plan: null,
+                scheduled_by: null,
+              })
               .where(eq(kiloclaw_subscriptions.id, subscription.id))
               .returning();
 
@@ -3440,7 +3455,11 @@ function mapCommitRetirementMutationError(error: unknown): TRPCError {
   if (error instanceof TRPCError) return error;
   const message = error instanceof Error ? error.message : 'Unable to update Commit retirement.';
   const isConflict = message.includes('changed') || message.includes('support review');
-  return new TRPCError({ code: isConflict ? 'CONFLICT' : 'BAD_REQUEST', message, cause: error });
+  return new TRPCError({
+    code: isConflict ? 'CONFLICT' : 'BAD_REQUEST',
+    message,
+    cause: error,
+  });
 }
 
 async function cancelKiloclawPlanSwitchForRow(params: {
@@ -3450,7 +3469,10 @@ async function cancelKiloclawPlanSwitchForRow(params: {
   const { subscription, userId } = params;
 
   if (!subscription.scheduled_plan) {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'No pending plan switch to cancel.' });
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'No pending plan switch to cancel.',
+    });
   }
 
   if (subscription.scheduled_by !== 'user') {
@@ -3679,9 +3701,30 @@ export const kiloclawRouter = createTRPCRouter({
   }),
 
   getNavState: baseProcedure.query(async ({ ctx }) => {
-    const instance = await getActiveInstance(ctx.user.id);
+    const [instance, personalSubscription] = await Promise.all([
+      getActiveInstance(ctx.user.id),
+      db
+        .select({ id: kiloclaw_subscriptions.id })
+        .from(kiloclaw_subscriptions)
+        .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+        .where(
+          and(
+            eq(kiloclaw_subscriptions.user_id, ctx.user.id),
+            or(
+              isNull(kiloclaw_subscriptions.instance_id),
+              and(
+                eq(kiloclaw_instances.user_id, ctx.user.id),
+                isNull(kiloclaw_instances.organization_id)
+              )
+            )
+          )
+        )
+        .limit(1)
+        .then(rows => rows[0] ?? null),
+    ]);
     return {
       hasActiveInstance: instance !== null,
+      hasExistingPersonalSubscription: personalSubscription !== null,
     };
   }),
 
@@ -3693,7 +3736,10 @@ export const kiloclawRouter = createTRPCRouter({
     try {
       return await queryDiskUsage(instance.sandboxId);
     } catch (error) {
-      logDiskUsageError('Failed to fetch disk usage', { error, sandboxId: instance.sandboxId });
+      logDiskUsageError('Failed to fetch disk usage', {
+        error,
+        sandboxId: instance.sandboxId,
+      });
       throw new TRPCError({
         code: 'INTERNAL_SERVER_ERROR',
         message: 'Failed to fetch disk usage',
@@ -3999,20 +4045,11 @@ export const kiloclawRouter = createTRPCRouter({
 
   // Explicit lifecycle APIs
   provision: baseProcedure.input(updateConfigSchema).mutation(async ({ ctx, input }) => {
-    const { instanceId, bootstrapSubscription, shouldEnqueueTrialStartAffiliate } =
-      await ensureProvisionAccess(ctx.user.id, ctx.user.google_user_email);
-    const result = await provisionInstance(ctx.user, input, {
+    const { instanceId, bootstrapSubscription } = await ensureProvisionAccess(ctx.user.id);
+    return await provisionInstance(ctx.user, input, {
       instanceId,
       bootstrapSubscription,
     });
-    if (shouldEnqueueTrialStartAffiliate) {
-      await emitProvisionTrialStartSideEffects({
-        userId: ctx.user.id,
-        userEmail: ctx.user.google_user_email,
-        instanceId: result.instanceId,
-      });
-    }
-    return result;
   }),
 
   patchConfig: clawAccessProcedure
@@ -4021,23 +4058,13 @@ export const kiloclawRouter = createTRPCRouter({
       return patchConfig(ctx.user, input);
     }),
 
-  // Backward-compatible alias — uses the same trial-bootstrap flow as provision
-  // so first-time callers can create a trial row (clawAccessProcedure would reject them).
+  // Backward-compatible alias — uses the same subscription admission rules as provision.
   updateConfig: baseProcedure.input(updateConfigSchema).mutation(async ({ ctx, input }) => {
-    const { instanceId, bootstrapSubscription, shouldEnqueueTrialStartAffiliate } =
-      await ensureProvisionAccess(ctx.user.id, ctx.user.google_user_email);
-    const result = await provisionInstance(ctx.user, input, {
+    const { instanceId, bootstrapSubscription } = await ensureProvisionAccess(ctx.user.id);
+    return await provisionInstance(ctx.user, input, {
       instanceId,
       bootstrapSubscription,
     });
-    if (shouldEnqueueTrialStartAffiliate) {
-      await emitProvisionTrialStartSideEffects({
-        userId: ctx.user.id,
-        userEmail: ctx.user.google_user_email,
-        instanceId: result.instanceId,
-      });
-    }
-    return result;
   }),
 
   updateKiloCodeConfig: clawAccessProcedure
@@ -4188,15 +4215,22 @@ export const kiloclawRouter = createTRPCRouter({
   getConfig: baseProcedure.query(async ({ ctx }) => {
     const instance = await getActiveInstance(ctx.user.id);
     const client = new KiloClawUserClient(
-      generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
+      generateApiToken(ctx.user, undefined, {
+        expiresIn: TOKEN_EXPIRY.fiveMinutes,
+      })
     );
-    return client.getConfig({ userId: ctx.user.id, instanceId: workerInstanceId(instance) });
+    return client.getConfig({
+      userId: ctx.user.id,
+      instanceId: workerInstanceId(instance),
+    });
   }),
 
   getChannelCatalog: baseProcedure.query(async ({ ctx }) => {
     const instance = await getActiveInstance(ctx.user.id);
     const client = new KiloClawUserClient(
-      generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
+      generateApiToken(ctx.user, undefined, {
+        expiresIn: TOKEN_EXPIRY.fiveMinutes,
+      })
     );
     const config = await client.getConfig({
       userId: ctx.user.id,
@@ -4227,7 +4261,9 @@ export const kiloclawRouter = createTRPCRouter({
   getSecretCatalog: baseProcedure.query(async ({ ctx }) => {
     const instance = await getActiveInstance(ctx.user.id);
     const client = new KiloClawUserClient(
-      generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
+      generateApiToken(ctx.user, undefined, {
+        expiresIn: TOKEN_EXPIRY.fiveMinutes,
+      })
     );
     const config = await client.getConfig({
       userId: ctx.user.id,
@@ -4279,7 +4315,10 @@ export const kiloclawRouter = createTRPCRouter({
     .mutation(async ({ ctx, input }) => {
       const instance = await getActiveInstance(ctx.user.id);
       if (!instance) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'No active KiloClaw instance found' });
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'No active KiloClaw instance found',
+        });
       }
 
       // Pin consent gate: when the caller is asking for a specific image
@@ -4360,7 +4399,9 @@ export const kiloclawRouter = createTRPCRouter({
       }
 
       const client = new KiloClawUserClient(
-        generateApiToken(ctx.user, undefined, { expiresIn: TOKEN_EXPIRY.fiveMinutes })
+        generateApiToken(ctx.user, undefined, {
+          expiresIn: TOKEN_EXPIRY.fiveMinutes,
+        })
       );
       const result = await client
         .restartMachine(input?.imageTag ? { imageTag: input.imageTag } : undefined, {
@@ -4795,7 +4836,10 @@ export const kiloclawRouter = createTRPCRouter({
     .mutation(async ({ input, ctx }) => {
       const instance = await getActiveInstance(ctx.user.id);
       if (!instance) {
-        throw new TRPCError({ code: 'NOT_FOUND', message: 'No active KiloClaw instance found' });
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'No active KiloClaw instance found',
+        });
       }
 
       // Verify the version exists and is available
@@ -4860,7 +4904,10 @@ export const kiloclawRouter = createTRPCRouter({
       }
 
       if (!result) {
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: 'Failed to create pin' });
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Failed to create pin',
+        });
       }
 
       const workerSync = await pushPinToWorker(ctx.user.id, instance.id, input.imageTag);
@@ -4871,7 +4918,10 @@ export const kiloclawRouter = createTRPCRouter({
   removeMyPin: clawAccessProcedure.mutation(async ({ ctx }) => {
     const instance = await getActiveInstance(ctx.user.id);
     if (!instance) {
-      throw new TRPCError({ code: 'NOT_FOUND', message: 'No active KiloClaw instance found' });
+      throw new TRPCError({
+        code: 'NOT_FOUND',
+        message: 'No active KiloClaw instance found',
+      });
     }
 
     // Pins are advisory consent metadata — either the user or an admin
@@ -5158,7 +5208,10 @@ export const kiloclawRouter = createTRPCRouter({
     .output(KiloclawPersonalSubscriptionSchema)
     .query(async ({ ctx, input }) => {
       const [row, hasActiveKiloPass] = await Promise.all([
-        getKiloclawPersonalSubscriptionRow({ userId: ctx.user.id, instanceId: input.instanceId }),
+        getKiloclawPersonalSubscriptionRow({
+          userId: ctx.user.id,
+          instanceId: input.instanceId,
+        }),
         getHasActiveKiloPassForUser(ctx.user.id),
       ]);
 
@@ -5259,7 +5312,10 @@ export const kiloclawRouter = createTRPCRouter({
 
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Missing Stripe customer.',
+        });
       }
 
       const session = await stripe.billingPortal.sessions.create({
@@ -5373,12 +5429,19 @@ export const kiloclawRouter = createTRPCRouter({
     }),
 
   createSubscriptionCheckout: baseProcedure
-    .input(KiloclawOptionalInstanceInputSchema.extend({ plan: z.enum(['commit', 'standard']) }))
+    .input(
+      KiloclawOptionalInstanceInputSchema.extend({
+        plan: z.enum(['commit', 'standard']),
+      })
+    )
     .mutation(async ({ ctx, input }) => {
       assertKiloClawCommitAdmission(input.plan, 'create_subscription_checkout');
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Missing Stripe customer for user.',
+        });
       }
 
       const { anchorInstance, currentRow } = await resolvePersonalBillingAnchor({
@@ -5390,6 +5453,9 @@ export const kiloclawRouter = createTRPCRouter({
           code: 'BAD_REQUEST',
           message: 'Provision KiloClaw first before starting paid hosting checkout.',
         });
+      }
+      if (!currentRow) {
+        throwNewKiloClawSubscriptionsUnavailable();
       }
 
       const hasBlockingSubscription = await hasBlockingPersonalKiloclawSubscriptionAtInstance({
@@ -5403,11 +5469,11 @@ export const kiloclawRouter = createTRPCRouter({
         });
       }
 
-      if (anchorInstance.destroyed_at || !currentRow) {
+      if (anchorInstance.destroyed_at) {
         logBillingWarning('KiloClaw direct checkout rejected before provider access', {
           user_id: ctx.user.id,
           instance_id: anchorInstance.id,
-          reason: anchorInstance.destroyed_at ? 'destroyed_billing_anchor' : 'missing_billing_row',
+          reason: 'destroyed_billing_anchor',
         });
         throw new TRPCError({
           code: 'CONFLICT',
@@ -5441,9 +5507,21 @@ export const kiloclawRouter = createTRPCRouter({
       // Guard against duplicate Stripe subscriptions: the DB check above exempts
       // trialing rows, so also verify against live Stripe state.
       const [activeSubs, trialingSubs, openSessions] = await Promise.all([
-        stripe.subscriptions.list({ customer: stripeCustomerId, status: 'active', limit: 10 }),
-        stripe.subscriptions.list({ customer: stripeCustomerId, status: 'trialing', limit: 10 }),
-        stripe.checkout.sessions.list({ customer: stripeCustomerId, status: 'open', limit: 10 }),
+        stripe.subscriptions.list({
+          customer: stripeCustomerId,
+          status: 'active',
+          limit: 10,
+        }),
+        stripe.subscriptions.list({
+          customer: stripeCustomerId,
+          status: 'trialing',
+          limit: 10,
+        }),
+        stripe.checkout.sessions.list({
+          customer: stripeCustomerId,
+          status: 'open',
+          limit: 10,
+        }),
       ]);
       const hasActiveKiloClawSub = [...activeSubs.data, ...trialingSubs.data].some(
         s =>
@@ -5476,8 +5554,12 @@ export const kiloclawRouter = createTRPCRouter({
         intendedPricing.standardIntroMicrodollars !== undefined &&
         !hadPaidSubscription;
       const priceId = useStandardIntro
-        ? getStripePriceIdForClawPlanIntro('standard', { priceVersion: intendedPriceVersion })
-        : getStripePriceIdForClawPlan(input.plan, { priceVersion: intendedPriceVersion });
+        ? getStripePriceIdForClawPlanIntro('standard', {
+            priceVersion: intendedPriceVersion,
+          })
+        : getStripePriceIdForClawPlan(input.plan, {
+            priceVersion: intendedPriceVersion,
+          });
 
       const attribution = await getAffiliateAttribution(ctx.user.id, 'impact');
       const sessionMetadata = {
@@ -5532,7 +5614,7 @@ export const kiloclawRouter = createTRPCRouter({
       let resolvedInstanceId: string | undefined = input.instanceId;
 
       try {
-        const { anchorInstance } = await resolvePersonalBillingAnchor({
+        const { anchorInstance, currentRow } = await resolvePersonalBillingAnchor({
           userId: ctx.user.id,
           instanceId: input.instanceId,
         });
@@ -5541,6 +5623,9 @@ export const kiloclawRouter = createTRPCRouter({
             code: 'BAD_REQUEST',
             message: 'Provision KiloClaw first before enrolling hosting with credits.',
           });
+        }
+        if (!currentRow) {
+          throwNewKiloClawSubscriptionsUnavailable();
         }
         if (anchorInstance.destroyed_at) {
           throw new TRPCError({
@@ -5770,7 +5855,10 @@ export const kiloclawRouter = createTRPCRouter({
       assertKiloClawCommitAdmission(input.hostingPlan, 'create_kilo_pass_upsell_checkout');
       const stripeCustomerId = ctx.user.stripe_customer_id;
       if (!stripeCustomerId) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer for user.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Missing Stripe customer for user.',
+        });
       }
 
       const { anchorInstance, currentRow } = await resolvePersonalBillingAnchor({
@@ -5782,6 +5870,9 @@ export const kiloclawRouter = createTRPCRouter({
           code: 'BAD_REQUEST',
           message: 'Provision KiloClaw first before starting Kilo Pass hosting activation.',
         });
+      }
+      if (!currentRow) {
+        throwNewKiloClawSubscriptionsUnavailable();
       }
       if (anchorInstance.destroyed_at) {
         throw new TRPCError({
@@ -5913,7 +6004,10 @@ export const kiloclawRouter = createTRPCRouter({
     });
 
     if (!sub || sub.status !== 'active') {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to cancel.' });
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'No active subscription to cancel.',
+      });
     }
 
     if (sub.cancel_at_period_end) {
@@ -5960,7 +6054,11 @@ export const kiloclawRouter = createTRPCRouter({
           .set({
             cancel_at_period_end: true,
             ...(scheduleIdToRelease
-              ? { stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null }
+              ? {
+                  stripe_schedule_id: null,
+                  scheduled_plan: null,
+                  scheduled_by: null,
+                }
               : {}),
           })
           .where(eq(kiloclaw_subscriptions.id, sub.id))
@@ -6034,7 +6132,10 @@ export const kiloclawRouter = createTRPCRouter({
       userId: ctx.user.id,
     });
     if (!subscription) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to convert.' });
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'No active subscription to convert.',
+      });
     }
     if (
       classifyKiloClawCommitTerm(await getCommitRetirementEvidence(subscription)) === 'final_term'
@@ -6045,7 +6146,10 @@ export const kiloclawRouter = createTRPCRouter({
         convertToCredits: true,
       });
     } else {
-      await acceptKiloclawConversionForRow({ subscription, userId: ctx.user.id });
+      await acceptKiloclawConversionForRow({
+        subscription,
+        userId: ctx.user.id,
+      });
     }
     return { success: true };
   }),
@@ -6060,7 +6164,10 @@ export const kiloclawRouter = createTRPCRouter({
         message: 'No pending cancellation to reactivate.',
       });
     }
-    await reactivateKiloclawSubscriptionForRow({ subscription, userId: ctx.user.id });
+    await reactivateKiloclawSubscriptionForRow({
+      subscription,
+      userId: ctx.user.id,
+    });
     return { success: true };
   }),
 
@@ -6074,15 +6181,24 @@ export const kiloclawRouter = createTRPCRouter({
       });
 
       if (!sub || sub.status !== 'active') {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'No active subscription to switch.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'No active subscription to switch.',
+        });
       }
 
       if (sub.plan === input.toPlan) {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Already on this plan.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Already on this plan.',
+        });
       }
 
       if (sub.plan !== 'commit' && sub.plan !== 'standard') {
-        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Cannot switch from a trial plan.' });
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Cannot switch from a trial plan.',
+        });
       }
 
       if (sub.stripe_subscription_id) {
@@ -6179,7 +6295,11 @@ export const kiloclawRouter = createTRPCRouter({
 
             await db
               .update(kiloclaw_subscriptions)
-              .set({ stripe_schedule_id: null, scheduled_plan: null, scheduled_by: null })
+              .set({
+                stripe_schedule_id: null,
+                scheduled_plan: null,
+                scheduled_by: null,
+              })
               .where(eq(kiloclaw_subscriptions.id, sub.id));
           }
         }
@@ -6327,7 +6447,10 @@ export const kiloclawRouter = createTRPCRouter({
       userId: ctx.user.id,
     });
     if (!subscription) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'No pending plan switch to cancel.' });
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'No pending plan switch to cancel.',
+      });
     }
     await cancelKiloclawPlanSwitchForRow({ subscription, userId: ctx.user.id });
     return { success: true };
@@ -6336,7 +6459,10 @@ export const kiloclawRouter = createTRPCRouter({
   createBillingPortalSession: baseProcedure.mutation(async ({ ctx }) => {
     const stripeCustomerId = ctx.user.stripe_customer_id;
     if (!stripeCustomerId) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'Missing Stripe customer.' });
+      throw new TRPCError({
+        code: 'BAD_REQUEST',
+        message: 'Missing Stripe customer.',
+      });
     }
 
     const session = await stripe.billingPortal.sessions.create({

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -2173,6 +2173,7 @@ function summarizePersonalBillingStatus(billing: ClawBillingStatus) {
   return {
     hasActiveInstance,
     activeInstanceHasAccess: hasActiveInstance && billing.hasAccess,
+    hasExistingPersonalSubscription: billing.hasExistingPersonalSubscription,
     activeInstanceId,
     creditBalanceMicrodollars: billing.creditBalanceMicrodollars,
     creditIntroEligible: billing.creditIntroEligible,

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -42,7 +42,6 @@ import {
   resolveKiloClawEnrollmentPriceVersion,
   maySelectKiloClawCommit,
   PersonalSubscriptionCollapseUQConflictError,
-  type KiloClawPriceVersion,
 } from '@kilocode/db';
 import {
   kiloclaw_version_pins,
@@ -1350,7 +1349,7 @@ async function fetchKiloClawServiceDegraded(): Promise<boolean> {
 function throwNewKiloClawSubscriptionsUnavailable(): never {
   throw new TRPCError({
     code: 'FORBIDDEN',
-    message: 'New KiloClaw subscriptions are unavailable.',
+    message: 'A current KiloClaw subscription is required to provision an instance.',
   });
 }
 
@@ -1436,7 +1435,7 @@ async function ensureProvisionAccess(
 
   throw new TRPCError({
     code: 'FORBIDDEN',
-    message: 'Your trial has expired. Please subscribe to continue using KiloClaw.',
+    message: 'A current KiloClaw subscription is required to provision an instance.',
   });
 }
 
@@ -1596,21 +1595,10 @@ type CreditReprovisionRecoveryPreview = {
   shortfallMicrodollars: number;
 };
 
-type CreditReprovisionRecoveryEligibility =
-  | (CreditReprovisionRecoveryPreview & {
-      eligible: true;
-      subscription: typeof kiloclaw_subscriptions.$inferSelect;
-      priceVersion: KiloClawPriceVersion;
-    })
-  | (CreditReprovisionRecoveryPreview & {
-      eligible: false;
-      reason:
-        | 'no_current_subscription'
-        | 'subscription_not_canceled'
-        | 'instance_not_destroyed'
-        | 'active_instance_exists'
-        | 'insufficient_credits';
-    });
+type CreditReprovisionRecoveryEligibility = CreditReprovisionRecoveryPreview & {
+  eligible: false;
+  reason: 'no_current_subscription' | 'subscription_not_current';
+};
 
 // ── Personal subscription helpers ──────────────────────────────────────
 
@@ -2155,247 +2143,14 @@ async function getCreditReprovisionRecoveryEligibility(params: {
   if (!params.currentRow) {
     return { ...base, eligible: false, reason: 'no_current_subscription' };
   }
-  if (params.currentRow.subscription.status !== 'canceled') {
-    return { ...base, eligible: false, reason: 'subscription_not_canceled' };
-  }
-  if (!params.currentRow.instance?.destroyedAt) {
-    return { ...base, eligible: false, reason: 'instance_not_destroyed' };
-  }
-  if (params.activeInstance) {
-    return { ...base, eligible: false, reason: 'active_instance_exists' };
-  }
-  if (preview.effectiveBalanceMicrodollars < costMicrodollars) {
-    return { ...base, eligible: false, reason: 'insufficient_credits' };
-  }
-
-  return {
-    ...base,
-    eligible: true,
-    subscription: params.currentRow.subscription,
-    priceVersion,
-  };
+  return { ...base, eligible: false, reason: 'subscription_not_current' };
 }
 
-function getCreditReprovisionRecoveryUnavailableMessage(
-  eligibility: Exclude<CreditReprovisionRecoveryEligibility, { eligible: true }>
-) {
-  return eligibility.reason === 'insufficient_credits'
-    ? 'Effective credit balance is insufficient to activate Standard hosting.'
-    : 'Credit-funded reprovision recovery is not available for this KiloClaw state.';
-}
-
-function throwCreditReprovisionRecoveryUnavailable(
-  eligibility: Exclude<CreditReprovisionRecoveryEligibility, { eligible: true }>
-): never {
-  const message = getCreditReprovisionRecoveryUnavailableMessage(eligibility);
+function throwCreditReprovisionRecoveryUnavailable(): never {
   throw new TRPCError({
-    code: eligibility.reason === 'insufficient_credits' ? 'BAD_REQUEST' : 'CONFLICT',
-    message,
+    code: 'CONFLICT',
+    message: 'Credit-funded reprovision recovery is not available for this KiloClaw state.',
   });
-}
-
-async function linkDestroyedSubscriptionToCreditRecoverySuccessor(params: {
-  userId: string;
-  predecessorSubscriptionId: string;
-  successorInstanceId: string;
-}) {
-  await db.transaction(async tx => {
-    const [predecessor] = await tx
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.id, params.predecessorSubscriptionId),
-          eq(kiloclaw_subscriptions.user_id, params.userId)
-        )
-      )
-      .for('update')
-      .limit(1);
-
-    if (!predecessor) {
-      throw new TRPCError({
-        code: 'CONFLICT',
-        message: 'Previous KiloClaw billing state changed before recovery could finish.',
-      });
-    }
-    if (predecessor.transferred_to_subscription_id) {
-      return;
-    }
-
-    const [successor] = await tx
-      .select()
-      .from(kiloclaw_subscriptions)
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.user_id, params.userId),
-          eq(kiloclaw_subscriptions.instance_id, params.successorInstanceId),
-          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-        )
-      )
-      .for('update')
-      .limit(1);
-
-    if (!successor || successor.status !== 'active' || successor.payment_source !== 'credits') {
-      throw new TRPCError({
-        code: 'CONFLICT',
-        message: 'Credit activation finished but the new billing row could not be linked.',
-      });
-    }
-
-    const [after] = await tx
-      .update(kiloclaw_subscriptions)
-      .set({ transferred_to_subscription_id: successor.id })
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.id, predecessor.id),
-          isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-        )
-      )
-      .returning();
-
-    if (!after) {
-      throw new TRPCError({
-        code: 'CONFLICT',
-        message: 'Previous KiloClaw billing state changed before recovery could finish.',
-      });
-    }
-
-    await insertKiloClawSubscriptionChangeLog(tx, {
-      subscriptionId: predecessor.id,
-      actor: {
-        actorType: 'user',
-        actorId: params.userId,
-      },
-      action: 'reassigned',
-      reason: 'credit_reprovision_recovery',
-      before: predecessor,
-      after,
-    });
-  });
-}
-
-async function tryLinkDestroyedSubscriptionToCreditRecoverySuccessor(params: {
-  userId: string;
-  predecessorSubscriptionId: string;
-  successorInstanceId: string;
-  context: 'post_activation_recovery' | 'post_enrollment_success';
-}) {
-  try {
-    await linkDestroyedSubscriptionToCreditRecoverySuccessor(params);
-    return true;
-  } catch (error) {
-    logBillingWarning('KiloClaw credit reprovision successor linking failed after activation', {
-      user_id: params.userId,
-      predecessor_subscription_id: params.predecessorSubscriptionId,
-      successor_instance_id: params.successorInstanceId,
-      context: params.context,
-      error: error instanceof Error ? error.message : String(error),
-    });
-    return false;
-  }
-}
-
-async function getActivatedCreditRecoverySuccessor(params: { userId: string; instanceId: string }) {
-  const [successor] = await db
-    .select()
-    .from(kiloclaw_subscriptions)
-    .where(
-      and(
-        eq(kiloclaw_subscriptions.user_id, params.userId),
-        eq(kiloclaw_subscriptions.instance_id, params.instanceId),
-        eq(kiloclaw_subscriptions.status, 'active'),
-        eq(kiloclaw_subscriptions.payment_source, 'credits'),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id)
-      )
-    )
-    .limit(1);
-
-  return successor ?? null;
-}
-
-async function getCompetingCreditRecoveryActivation(params: {
-  userId: string;
-  instanceId: string;
-}): Promise<
-  { status: 'activated'; instanceId: string } | { status: 'in_progress'; instanceId: string } | null
-> {
-  const [activeSuccessor] = await db
-    .select({ instanceId: kiloclaw_subscriptions.instance_id })
-    .from(kiloclaw_subscriptions)
-    .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
-    .where(
-      and(
-        eq(kiloclaw_subscriptions.user_id, params.userId),
-        ne(kiloclaw_subscriptions.instance_id, params.instanceId),
-        eq(kiloclaw_subscriptions.status, 'active'),
-        eq(kiloclaw_subscriptions.payment_source, 'credits'),
-        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
-        isNull(kiloclaw_instances.organization_id),
-        isNull(kiloclaw_instances.destroyed_at)
-      )
-    )
-    .limit(1);
-
-  if (activeSuccessor?.instanceId) {
-    return { status: 'activated', instanceId: activeSuccessor.instanceId };
-  }
-
-  const [activeInstance] = await db
-    .select({ id: kiloclaw_instances.id })
-    .from(kiloclaw_instances)
-    .where(
-      and(
-        eq(kiloclaw_instances.user_id, params.userId),
-        ne(kiloclaw_instances.id, params.instanceId),
-        isNull(kiloclaw_instances.organization_id),
-        isNull(kiloclaw_instances.destroyed_at)
-      )
-    )
-    .limit(1);
-
-  return activeInstance ? { status: 'in_progress', instanceId: activeInstance.id } : null;
-}
-
-async function cleanupFailedCreditRecoveryProvision(params: {
-  userId: string;
-  instanceId: string;
-  sandboxId: string;
-}) {
-  const [destroyed] = await db
-    .update(kiloclaw_instances)
-    .set({ destroyed_at: new Date().toISOString() })
-    .where(
-      and(
-        eq(kiloclaw_instances.id, params.instanceId),
-        eq(kiloclaw_instances.user_id, params.userId),
-        isNull(kiloclaw_instances.organization_id),
-        isNull(kiloclaw_instances.destroyed_at)
-      )
-    )
-    .returning({ id: kiloclaw_instances.id });
-
-  if (!destroyed) {
-    return false;
-  }
-
-  try {
-    const client = new KiloClawInternalClient();
-    await client.destroy(
-      params.userId,
-      workerInstanceId({ id: params.instanceId, sandboxId: params.sandboxId }),
-      {
-        reason: 'stale_provision_cleanup',
-      }
-    );
-  } catch (error) {
-    logBillingWarning('KiloClaw credit reprovision cleanup failed after DB quarantine', {
-      user_id: params.userId,
-      instance_id: params.instanceId,
-      error: error instanceof Error ? error.message : String(error),
-    });
-  }
-
-  return true;
 }
 
 function maskCustomerEmail(email: string | null): string | null {
@@ -5695,151 +5450,8 @@ export const kiloclawRouter = createTRPCRouter({
   reprovisionAndEnrollWithCredits: baseProcedure
     .input(z.object({ plan: z.literal('standard').optional() }).optional())
     .output(KiloclawReprovisionCreditEnrollmentResultSchema)
-    .mutation(async ({ ctx, input }) => {
-      const plan = input?.plan ?? 'standard';
-      const currentRow = await (async () => {
-        try {
-          return await resolveCurrentPersonalSubscriptionRow({
-            userId: ctx.user.id,
-            dbOrTx: db,
-          });
-        } catch (error) {
-          mapCurrentSubscriptionResolutionError(error);
-        }
-      })();
-      const [activeInstance, kiloPassState] = await Promise.all([
-        getActiveInstance(ctx.user.id),
-        getKiloPassStateForUser(db, ctx.user.id),
-      ]);
-      const eligibility = await getCreditReprovisionRecoveryEligibility({
-        user: ctx.user,
-        currentRow,
-        activeInstance,
-        kiloPassState,
-      });
-
-      if (!eligibility.eligible) {
-        throwCreditReprovisionRecoveryUnavailable(eligibility);
-      }
-
-      const provisioned = await provisionInstance(
-        ctx.user,
-        {},
-        {
-          instanceId: null,
-          bootstrapSubscription: false,
-        }
-      );
-
-      const competingRecovery = await getCompetingCreditRecoveryActivation({
-        userId: ctx.user.id,
-        instanceId: provisioned.instanceId,
-      });
-      if (competingRecovery) {
-        const cleanedUp = await cleanupFailedCreditRecoveryProvision({
-          userId: ctx.user.id,
-          instanceId: provisioned.instanceId,
-          sandboxId: provisioned.sandboxId,
-        });
-        logBillingWarning('KiloClaw credit reprovision skipped duplicate concurrent provision', {
-          user_id: ctx.user.id,
-          instance_id: provisioned.instanceId,
-          competing_instance_id: competingRecovery.instanceId,
-          competing_status: competingRecovery.status,
-          cleanup: cleanedUp ? 'destroyed' : 'not_needed_or_already_destroyed',
-        });
-        if (competingRecovery.status === 'activated') {
-          return {
-            success: true,
-            status: 'activated',
-            instanceId: competingRecovery.instanceId,
-          };
-        }
-        throw new TRPCError({
-          code: 'CONFLICT',
-          message: 'KiloClaw credit-funded reprovision recovery is already in progress.',
-        });
-      }
-
-      try {
-        await enrollWithCreditsImpl({
-          userId: ctx.user.id,
-          instanceId: provisioned.instanceId,
-          plan,
-          hadPaidSubscription: true,
-          expectedPriceVersion: eligibility.priceVersion,
-          actor: {
-            actorType: 'user',
-            actorId: ctx.user.id,
-          },
-        });
-      } catch (error) {
-        const message =
-          error instanceof Error
-            ? error.message
-            : 'KiloClaw was reprovisioned, but credit activation did not finish.';
-        const activatedSuccessor = await getActivatedCreditRecoverySuccessor({
-          userId: ctx.user.id,
-          instanceId: provisioned.instanceId,
-        });
-        if (activatedSuccessor) {
-          const linked = await tryLinkDestroyedSubscriptionToCreditRecoverySuccessor({
-            userId: ctx.user.id,
-            predecessorSubscriptionId: eligibility.subscription.id,
-            successorInstanceId: provisioned.instanceId,
-            context: 'post_activation_recovery',
-          });
-          logBillingWarning(
-            'KiloClaw credit reprovision enrollment threw after activation; returning activated state',
-            {
-              user_id: ctx.user.id,
-              instance_id: provisioned.instanceId,
-              subscription_id: eligibility.subscription.id,
-              successor_subscription_id: activatedSuccessor.id,
-              successor_linked: linked,
-              error: message,
-            }
-          );
-          return {
-            success: true,
-            status: 'activated',
-            instanceId: provisioned.instanceId,
-          };
-        }
-
-        const cleanedUp = await cleanupFailedCreditRecoveryProvision({
-          userId: ctx.user.id,
-          instanceId: provisioned.instanceId,
-          sandboxId: provisioned.sandboxId,
-        });
-        logBillingWarning('KiloClaw credit reprovision enrollment failed after provisioning', {
-          user_id: ctx.user.id,
-          instance_id: provisioned.instanceId,
-          subscription_id: eligibility.subscription.id,
-          error: message,
-          cleanup: cleanedUp ? 'destroyed' : 'not_needed_or_already_destroyed',
-        });
-        return {
-          success: false,
-          status: 'action_required',
-          instanceId: null,
-          message:
-            'Credit activation did not finish, so the new KiloClaw was rolled back. Retry activation or contact support.',
-        };
-      }
-
-      await tryLinkDestroyedSubscriptionToCreditRecoverySuccessor({
-        userId: ctx.user.id,
-        predecessorSubscriptionId: eligibility.subscription.id,
-        successorInstanceId: provisioned.instanceId,
-        context: 'post_enrollment_success',
-      });
-
-      return {
-        success: true,
-        status: 'activated',
-        instanceId: provisioned.instanceId,
-      };
+    .mutation(() => {
+      throwCreditReprovisionRecoveryUnavailable();
     }),
 
   createKiloPassUpsellCheckout: baseProcedure

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -1967,7 +1967,12 @@ async function getPersonalBillingStatus(user: {
     };
   }
 
-  const [anySubscription, anyPersonalSubscription, anyPersonalInstanceHistory] = await Promise.all([
+  const [
+    anySubscription,
+    anyPersonalSubscription,
+    currentPersonalProvisioningSubscription,
+    anyPersonalInstanceHistory,
+  ] = await Promise.all([
     db
       .select({ id: kiloclaw_subscriptions.id })
       .from(kiloclaw_subscriptions)
@@ -1981,6 +1986,24 @@ async function getPersonalBillingStatus(user: {
       .where(
         and(
           eq(kiloclaw_subscriptions.user_id, user.id),
+          or(
+            isNull(kiloclaw_subscriptions.instance_id),
+            and(eq(kiloclaw_instances.user_id, user.id), isNull(kiloclaw_instances.organization_id))
+          )
+        )
+      )
+      .limit(1)
+      .then(rows => rows[0] ?? null),
+    db
+      .select({ id: kiloclaw_subscriptions.id })
+      .from(kiloclaw_subscriptions)
+      .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+      .where(
+        and(
+          eq(kiloclaw_subscriptions.user_id, user.id),
+          eq(kiloclaw_subscriptions.status, 'active'),
+          isNull(kiloclaw_subscriptions.suspended_at),
+          isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
           or(
             isNull(kiloclaw_subscriptions.instance_id),
             and(eq(kiloclaw_instances.user_id, user.id), isNull(kiloclaw_instances.organization_id))
@@ -2062,6 +2085,7 @@ async function getPersonalBillingStatus(user: {
     hasAccess,
     accessReason,
     hasExistingPersonalSubscription: anyPersonalSubscription !== null,
+    hasCurrentPersonalSubscription: currentPersonalProvisioningSubscription !== null,
     commitPlanAvailable: maySelectKiloClawCommit(now),
     trialEligible: !anyPersonalInstanceHistory && !anySubscription,
     creditBalanceMicrodollars,
@@ -2174,6 +2198,7 @@ function summarizePersonalBillingStatus(billing: ClawBillingStatus) {
     hasActiveInstance,
     activeInstanceHasAccess: hasActiveInstance && billing.hasAccess,
     hasExistingPersonalSubscription: billing.hasExistingPersonalSubscription,
+    hasCurrentPersonalSubscription: billing.hasCurrentPersonalSubscription,
     activeInstanceId,
     creditBalanceMicrodollars: billing.creditBalanceMicrodollars,
     creditIntroEligible: billing.creditIntroEligible,
@@ -3457,7 +3482,7 @@ export const kiloclawRouter = createTRPCRouter({
   }),
 
   getNavState: baseProcedure.query(async ({ ctx }) => {
-    const [instance, personalSubscription] = await Promise.all([
+    const [instance, currentPersonalSubscription] = await Promise.all([
       getActiveInstance(ctx.user.id),
       db
         .select({ id: kiloclaw_subscriptions.id })
@@ -3466,6 +3491,9 @@ export const kiloclawRouter = createTRPCRouter({
         .where(
           and(
             eq(kiloclaw_subscriptions.user_id, ctx.user.id),
+            eq(kiloclaw_subscriptions.status, 'active'),
+            isNull(kiloclaw_subscriptions.suspended_at),
+            isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
             or(
               isNull(kiloclaw_subscriptions.instance_id),
               and(
@@ -3480,7 +3508,7 @@ export const kiloclawRouter = createTRPCRouter({
     ]);
     return {
       hasActiveInstance: instance !== null,
-      hasExistingPersonalSubscription: personalSubscription !== null,
+      hasCurrentPersonalSubscription: currentPersonalSubscription !== null,
     };
   }),
 

--- a/apps/web/src/routers/kiloclaw-router.ts
+++ b/apps/web/src/routers/kiloclaw-router.ts
@@ -1967,50 +1967,16 @@ async function getPersonalBillingStatus(user: {
     };
   }
 
-  const [
-    anySubscription,
-    anyPersonalSubscription,
-    currentPersonalProvisioningSubscription,
-    anyPersonalInstanceHistory,
-  ] = await Promise.all([
+  const [subscriptionPresence, anyPersonalInstanceHistory] = await Promise.all([
     db
-      .select({ id: kiloclaw_subscriptions.id })
+      .select({
+        hasAnySubscription: sql<boolean>`bool_or(true)`,
+        hasAnyPersonalSubscription: sql<boolean>`coalesce(bool_or(${kiloclaw_subscriptions.instance_id} is null or (${kiloclaw_instances.user_id} = ${user.id} and ${kiloclaw_instances.organization_id} is null)), false)`,
+        hasCurrentPersonalSubscription: sql<boolean>`coalesce(bool_or((${kiloclaw_subscriptions.instance_id} is null or (${kiloclaw_instances.user_id} = ${user.id} and ${kiloclaw_instances.organization_id} is null)) and ${kiloclaw_subscriptions.status} = 'active' and ${kiloclaw_subscriptions.suspended_at} is null and ${kiloclaw_subscriptions.transferred_to_subscription_id} is null), false)`,
+      })
       .from(kiloclaw_subscriptions)
+      .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
       .where(eq(kiloclaw_subscriptions.user_id, user.id))
-      .limit(1)
-      .then(rows => rows[0] ?? null),
-    db
-      .select({ id: kiloclaw_subscriptions.id })
-      .from(kiloclaw_subscriptions)
-      .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.user_id, user.id),
-          or(
-            isNull(kiloclaw_subscriptions.instance_id),
-            and(eq(kiloclaw_instances.user_id, user.id), isNull(kiloclaw_instances.organization_id))
-          )
-        )
-      )
-      .limit(1)
-      .then(rows => rows[0] ?? null),
-    db
-      .select({ id: kiloclaw_subscriptions.id })
-      .from(kiloclaw_subscriptions)
-      .leftJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
-      .where(
-        and(
-          eq(kiloclaw_subscriptions.user_id, user.id),
-          eq(kiloclaw_subscriptions.status, 'active'),
-          isNull(kiloclaw_subscriptions.suspended_at),
-          isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
-          or(
-            isNull(kiloclaw_subscriptions.instance_id),
-            and(eq(kiloclaw_instances.user_id, user.id), isNull(kiloclaw_instances.organization_id))
-          )
-        )
-      )
-      .limit(1)
       .then(rows => rows[0] ?? null),
     db
       .select({ id: kiloclaw_instances.id })
@@ -2084,10 +2050,10 @@ async function getPersonalBillingStatus(user: {
   return {
     hasAccess,
     accessReason,
-    hasExistingPersonalSubscription: anyPersonalSubscription !== null,
-    hasCurrentPersonalSubscription: currentPersonalProvisioningSubscription !== null,
+    hasExistingPersonalSubscription: subscriptionPresence?.hasAnyPersonalSubscription === true,
+    hasCurrentPersonalSubscription: subscriptionPresence?.hasCurrentPersonalSubscription === true,
     commitPlanAvailable: maySelectKiloClawCommit(now),
-    trialEligible: !anyPersonalInstanceHistory && !anySubscription,
+    trialEligible: !anyPersonalInstanceHistory && subscriptionPresence?.hasAnySubscription !== true,
     creditBalanceMicrodollars,
     creditIntroEligible,
     hasActiveKiloPass,

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -330,6 +330,29 @@ describe('organizations.kiloclaw.getNavState', () => {
     expect(result).toEqual({ hasActiveInstance: true, hasCurrentSubscription: true });
   });
 
+  it('treats an active Stripe-funded organization subscription as current', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-kiloclaw-nav-stripe-${Math.random()}@example.com`,
+    });
+    const organization = await createOrganization('Org KiloClaw Nav Stripe Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instanceId,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'stripe',
+      stripe_subscription_id: `sub_${crypto.randomUUID()}`,
+    });
+    const caller = await createCallerForUser(user.id);
+
+    const result = await caller.organizations.kiloclaw.getNavState({
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual({ hasActiveInstance: true, hasCurrentSubscription: true });
+  });
+
   it('does not leak a personal instance into organization nav state', async () => {
     const user = await insertTestUser({
       google_user_email: `org-kiloclaw-nav-personal-${Math.random()}@example.com`,

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.test.ts
@@ -305,22 +305,29 @@ describe('organizations.kiloclaw.getNavState', () => {
       organizationId: organization.id,
     });
 
-    expect(result).toEqual({ hasActiveInstance: false });
+    expect(result).toEqual({ hasActiveInstance: false, hasCurrentSubscription: false });
   });
 
-  it('returns active organization instance presence', async () => {
+  it('returns active organization instance and subscription presence', async () => {
     const user = await insertTestUser({
       google_user_email: `org-kiloclaw-nav-present-${Math.random()}@example.com`,
     });
     const organization = await createOrganization('Org KiloClaw Nav Present Test', user.id);
-    await createActiveOrgInstance(user.id, organization.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instanceId,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
+    });
     const caller = await createCallerForUser(user.id);
 
     const result = await caller.organizations.kiloclaw.getNavState({
       organizationId: organization.id,
     });
 
-    expect(result).toEqual({ hasActiveInstance: true });
+    expect(result).toEqual({ hasActiveInstance: true, hasCurrentSubscription: true });
   });
 
   it('does not leak a personal instance into organization nav state', async () => {
@@ -340,15 +347,22 @@ describe('organizations.kiloclaw.getNavState', () => {
       organizationId: organization.id,
     });
 
-    expect(result).toEqual({ hasActiveInstance: false });
+    expect(result).toEqual({ hasActiveInstance: false, hasCurrentSubscription: false });
   });
 
-  it('ignores destroyed organization instances', async () => {
+  it('does not treat canceled destroyed organization history as current', async () => {
     const user = await insertTestUser({
       google_user_email: `org-kiloclaw-nav-destroyed-${Math.random()}@example.com`,
     });
     const organization = await createOrganization('Org KiloClaw Nav Destroyed Test', user.id);
     const instanceId = await createActiveOrgInstance(user.id, organization.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instanceId,
+      plan: 'standard',
+      status: 'canceled',
+      payment_source: 'credits',
+    });
     await db
       .update(kiloclaw_instances)
       .set({ destroyed_at: '2026-05-29T00:00:00.000Z' })
@@ -359,7 +373,7 @@ describe('organizations.kiloclaw.getNavState', () => {
       organizationId: organization.id,
     });
 
-    expect(result).toEqual({ hasActiveInstance: false });
+    expect(result).toEqual({ hasActiveInstance: false, hasCurrentSubscription: false });
   });
 });
 
@@ -444,6 +458,58 @@ describe('organization kiloclaw destroy', () => {
 describe('organizations.kiloclaw.provision trial entitlement gate', () => {
   beforeEach(async () => {
     await cleanupDbForTest();
+  });
+
+  it('rejects organizations without a current KiloClaw subscription before provisioning', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-kiloclaw-provision-no-subscription-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization(
+      'Org KiloClaw Provision No Subscription Test',
+      user.id
+    );
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.provision({
+        organizationId: organization.id,
+      })
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'A current KiloClaw subscription is required to provision an instance.',
+    });
+    expect(kiloclawClientMock.__provisionMock).not.toHaveBeenCalled();
+  });
+
+  it('rejects canceled organization subscription history before provisioning', async () => {
+    const user = await insertTestUser({
+      google_user_email: `org-kiloclaw-provision-canceled-${crypto.randomUUID()}@example.com`,
+    });
+    const organization = await createOrganization(
+      'Org KiloClaw Provision Canceled Subscription Test',
+      user.id
+    );
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instanceId,
+      plan: 'standard',
+      status: 'canceled',
+      payment_source: 'credits',
+    });
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: '2026-05-29T00:00:00.000Z' })
+      .where(eq(kiloclaw_instances.id, instanceId));
+
+    const caller = await createCallerForUser(user.id);
+    await expect(
+      caller.organizations.kiloclaw.provision({ organizationId: organization.id })
+    ).rejects.toMatchObject({
+      code: 'FORBIDDEN',
+      message: 'A current KiloClaw subscription is required to provision an instance.',
+    });
+    expect(kiloclawClientMock.__provisionMock).not.toHaveBeenCalled();
   });
 
   it('rejects hard-expired unentitled organizations before provisioning', async () => {
@@ -538,6 +604,18 @@ describe('organizations.kiloclaw.provision trial entitlement gate', () => {
       google_user_email: `org-kiloclaw-provision-conflict-${crypto.randomUUID()}@example.com`,
     });
     const organization = await createOrganization('Org KiloClaw Provision Conflict Test', user.id);
+    const instanceId = await createActiveOrgInstance(user.id, organization.id);
+    await db.insert(kiloclaw_subscriptions).values({
+      user_id: user.id,
+      instance_id: instanceId,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
+    });
+    await db
+      .update(kiloclaw_instances)
+      .set({ destroyed_at: '2026-05-29T00:00:00.000Z' })
+      .where(eq(kiloclaw_instances.id, instanceId));
     kiloclawClientMock.__provisionMock.mockRejectedValueOnce(
       new MockKiloClawApiError(
         409,

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -172,6 +172,35 @@ async function requireOrgInstance(userId: string, orgId: string) {
   return instance;
 }
 
+async function hasCurrentOrganizationKiloClawSubscription(userId: string, orgId: string) {
+  const rows = await db
+    .select({ subscription: kiloclaw_subscriptions })
+    .from(kiloclaw_subscriptions)
+    .innerJoin(kiloclaw_instances, eq(kiloclaw_instances.id, kiloclaw_subscriptions.instance_id))
+    .where(
+      and(
+        eq(kiloclaw_subscriptions.user_id, userId),
+        isNull(kiloclaw_subscriptions.transferred_to_subscription_id),
+        eq(kiloclaw_instances.user_id, userId),
+        eq(kiloclaw_instances.organization_id, orgId)
+      )
+    );
+
+  return rows.some(
+    row =>
+      row.subscription.status === 'active' &&
+      row.subscription.suspended_at === null &&
+      row.subscription.payment_source !== 'stripe'
+  );
+}
+
+function throwKiloClawProvisioningUnavailable(): never {
+  throw new TRPCError({
+    code: 'FORBIDDEN',
+    message: 'A current KiloClaw subscription is required to provision an instance.',
+  });
+}
+
 // ── Input schemas ──────────────────────────────────────────────────
 
 const kilocodeDefaultModelSchema = z
@@ -430,9 +459,13 @@ export const organizationKiloclawRouter = createTRPCRouter({
   }),
 
   getNavState: organizationMemberProcedure.query(async ({ ctx, input }) => {
-    const instance = await getActiveOrgInstance(ctx.user.id, input.organizationId);
+    const [instance, hasCurrentSubscription] = await Promise.all([
+      getActiveOrgInstance(ctx.user.id, input.organizationId),
+      hasCurrentOrganizationKiloClawSubscription(ctx.user.id, input.organizationId),
+    ]);
     return {
       hasActiveInstance: instance !== null,
+      hasCurrentSubscription,
     };
   }),
 
@@ -498,6 +531,10 @@ export const organizationKiloclawRouter = createTRPCRouter({
           code: 'CONFLICT',
           message: 'You already have an active KiloClaw instance in this organization',
         });
+      }
+
+      if (!(await hasCurrentOrganizationKiloClawSubscription(ctx.user.id, input.organizationId))) {
+        throwKiloClawProvisioningUnavailable();
       }
 
       const encryptedSecrets = encryptProvisionSecretsForWorker(input.secrets);

--- a/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
+++ b/apps/web/src/routers/organizations/organization-kiloclaw-router.ts
@@ -187,10 +187,7 @@ async function hasCurrentOrganizationKiloClawSubscription(userId: string, orgId:
     );
 
   return rows.some(
-    row =>
-      row.subscription.status === 'active' &&
-      row.subscription.suspended_at === null &&
-      row.subscription.payment_source !== 'stripe'
+    row => row.subscription.status === 'active' && row.subscription.suspended_at === null
   );
 }
 

--- a/services/kiloclaw-billing/src/bootstrap.test.ts
+++ b/services/kiloclaw-billing/src/bootstrap.test.ts
@@ -1009,66 +1009,43 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
     }
   });
 
-  it('personal fresh-insert creates a current-version one-day trial', async () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-05-12T00:00:00.000Z'));
-    const createdRow = {
-      id: 'sub-current-trial',
-      user_id: 'user-1',
-      instance_id: 'instance-new',
-      plan: 'trial',
-      status: 'trialing',
-      kiloclaw_price_version: '2026-05-10',
-      access_origin: null,
-      payment_source: null,
-      cancel_at_period_end: false,
-      trial_started_at: '2026-05-12T00:00:00.000Z',
-      trial_ends_at: '2026-05-13T00:00:00.000Z',
-      stripe_subscription_id: null,
-      stripe_schedule_id: null,
-      transferred_to_subscription_id: null,
-      scheduled_plan: null,
-      scheduled_by: null,
-      pending_conversion: false,
-      current_period_start: null,
-      current_period_end: null,
-      credit_renewal_at: null,
-      commit_ends_at: null,
-      past_due_since: null,
-      suspended_at: null,
-      destruction_deadline: null,
-      auto_resume_requested_at: null,
-      auto_resume_retry_after: null,
-      auto_resume_attempt_count: 0,
-      auto_top_up_triggered_for_period: null,
-      created_at: '2026-05-12T00:00:00.000Z',
-      updated_at: '2026-05-12T00:00:00.000Z',
-    };
+  it('rejects fresh personal provisioning without canonical subscription history', async () => {
     const { db, insertValues } = createFreshInsertDb({
       selectRows: [[], [], [{ id: 'instance-new', destroyedAt: null, organizationId: null }], []],
-      insertFirstReturningRows: [createdRow],
+      insertFirstReturningRows: [],
       reselectAfterConflictRows: [],
     });
     mockGetWorkerDb.mockReturnValue(db);
 
-    try {
-      const result = await bootstrapProvisionSubscription(createEnv(), {
+    await expect(
+      bootstrapProvisionSubscription(createEnv(), {
         userId: 'user-1',
         instanceId: 'instance-new',
         orgId: null,
-      });
+      })
+    ).rejects.toMatchObject({
+      code: 'new_kiloclaw_subscriptions_unavailable',
+      status: 403,
+      message: 'New KiloClaw subscriptions are unavailable.',
+    });
+    expect(insertValues).toHaveLength(0);
+  });
 
-      expect(result).toEqual(createdRow);
-      expect(insertValues[0]).toEqual(
-        expect.objectContaining({
-          kiloclaw_price_version: '2026-05-10',
-          trial_started_at: '2026-05-12T00:00:00.000Z',
-          trial_ends_at: '2026-05-13T00:00:00.000Z',
-        })
-      );
-    } finally {
-      vi.useRealTimers();
-    }
+  it('rejects personal provision entitlement without canonical subscription history', async () => {
+    const { db } = createFreshInsertDb({
+      selectRows: [[], [], []],
+      insertFirstReturningRows: [],
+      reselectAfterConflictRows: [],
+    });
+    mockGetWorkerDb.mockReturnValue(db);
+
+    await expect(
+      resolveProvisionEntitlement(createEnv(), { userId: 'user-1', orgId: null })
+    ).rejects.toMatchObject({
+      code: 'new_kiloclaw_subscriptions_unavailable',
+      status: 403,
+      message: 'New KiloClaw subscriptions are unavailable.',
+    });
   });
 
   it('personal fresh-insert after canceled legacy history creates a current-version trial', async () => {
@@ -1155,65 +1132,31 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
     }
   });
 
-  it('personal fresh-insert: loser of insert race returns winner row instead of throwing', async () => {
-    const winnerRow = {
-      id: 'sub-winner',
-      user_id: 'user-1',
-      instance_id: 'instance-new',
-      plan: 'trial',
-      status: 'trialing',
-      access_origin: null,
-      payment_source: null,
-      cancel_at_period_end: false,
-      trial_started_at: '2026-04-16T00:00:00.000Z',
-      trial_ends_at: '2026-04-23T00:00:00.000Z',
-      stripe_subscription_id: null,
-      stripe_schedule_id: null,
-      transferred_to_subscription_id: null,
-      scheduled_plan: null,
-      scheduled_by: null,
-      pending_conversion: false,
-      current_period_start: null,
-      current_period_end: null,
-      credit_renewal_at: null,
-      commit_ends_at: null,
-      past_due_since: null,
-      suspended_at: null,
-      destruction_deadline: null,
-      auto_resume_requested_at: null,
-      auto_resume_retry_after: null,
-      auto_resume_attempt_count: 0,
-      auto_top_up_triggered_for_period: null,
-      created_at: '2026-04-16T00:00:00.000Z',
-      updated_at: '2026-04-16T00:00:00.000Z',
-    };
+  it('personal fresh-insert race still fails closed without prior subscription history', async () => {
     const { db, insertValues } = createFreshInsertDb({
       selectRows: [
-        [], // existingForInstance (none seen yet — TOCTOU window)
+        [], // existingForInstance
         [], // subscriptions for user
         [], // instances for user
         [], // legacy earlybird purchase
-        [winnerRow], // reselect after conflict
       ],
-      insertFirstReturningRows: [], // onConflictDoNothing swallowed our insert
-      reselectAfterConflictRows: [winnerRow],
+      insertFirstReturningRows: [],
+      reselectAfterConflictRows: [],
     });
     mockGetWorkerDb.mockReturnValue(db);
 
-    const result = await bootstrapProvisionSubscription(createEnv(), {
-      userId: 'user-1',
-      instanceId: 'instance-new',
-      orgId: null,
+    await expect(
+      bootstrapProvisionSubscription(createEnv(), {
+        userId: 'user-1',
+        instanceId: 'instance-new',
+        orgId: null,
+      })
+    ).rejects.toMatchObject({
+      code: 'new_kiloclaw_subscriptions_unavailable',
+      status: 403,
     });
 
-    expect(result).toEqual(winnerRow);
-    expect(insertValues).toHaveLength(1);
-    expect(insertValues[0]).toEqual(
-      expect.objectContaining({
-        instance_id: 'instance-new',
-      })
-    );
-    // Race loser must not write a change-log row (winner already logged it).
+    expect(insertValues).toHaveLength(0);
     expect(mockInsertKiloClawSubscriptionChangeLog).not.toHaveBeenCalled();
   });
 

--- a/services/kiloclaw-billing/src/bootstrap.test.ts
+++ b/services/kiloclaw-billing/src/bootstrap.test.ts
@@ -906,7 +906,7 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
     });
   });
 
-  it('resolves org provisioning entitlement for a hard-expired org with paid seat state', async () => {
+  it('rejects org provisioning entitlement without a current KiloClaw subscription', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-18T12:00:00.000Z'));
     const { db } = createFreshInsertDb({
@@ -920,6 +920,52 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
           },
         ],
         [{ subscriptionStatus: 'past_due' }],
+        [],
+      ],
+      insertFirstReturningRows: [],
+      reselectAfterConflictRows: [],
+    });
+    mockGetWorkerDb.mockReturnValue(db);
+
+    try {
+      await expect(
+        resolveProvisionEntitlement(createEnv(), {
+          userId: 'user-1',
+          orgId: '22222222-2222-4222-8222-222222222222',
+        })
+      ).rejects.toMatchObject({
+        code: 'new_kiloclaw_instances_unavailable',
+        status: 403,
+      });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('resolves org provisioning entitlement for a current destroyed KiloClaw subscription', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-05-18T12:00:00.000Z'));
+    const { db } = createFreshInsertDb({
+      selectRows: [
+        [
+          {
+            created_at: '2026-04-01T00:00:00.000Z',
+            free_trial_end_at: '2026-05-01T00:00:00.000Z',
+            require_seats: true,
+            settings: {},
+          },
+        ],
+        [{ subscriptionStatus: 'past_due' }],
+        [
+          {
+            subscription: createTransferSource({
+              instance_id: 'instance-old-org',
+              stripe_subscription_id: null,
+              stripe_schedule_id: null,
+            }),
+            instance: { id: 'instance-old-org', destroyedAt: '2026-05-12T00:00:00.000Z' },
+          },
+        ],
       ],
       insertFirstReturningRows: [],
       reselectAfterConflictRows: [],
@@ -1024,9 +1070,9 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
         orgId: null,
       })
     ).rejects.toMatchObject({
-      code: 'new_kiloclaw_subscriptions_unavailable',
+      code: 'new_kiloclaw_instances_unavailable',
       status: 403,
-      message: 'New KiloClaw subscriptions are unavailable.',
+      message: 'A current KiloClaw subscription is required to provision an instance.',
     });
     expect(insertValues).toHaveLength(0);
   });
@@ -1042,13 +1088,13 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
     await expect(
       resolveProvisionEntitlement(createEnv(), { userId: 'user-1', orgId: null })
     ).rejects.toMatchObject({
-      code: 'new_kiloclaw_subscriptions_unavailable',
+      code: 'new_kiloclaw_instances_unavailable',
       status: 403,
-      message: 'New KiloClaw subscriptions are unavailable.',
+      message: 'A current KiloClaw subscription is required to provision an instance.',
     });
   });
 
-  it('personal fresh-insert after canceled legacy history creates a current-version trial', async () => {
+  it('rejects personal provisioning after canceled subscription history', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(new Date('2026-05-12T00:00:00.000Z'));
     const canceledLegacyRow = {
@@ -1083,21 +1129,6 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
       created_at: '2026-04-01T00:00:00.000Z',
       updated_at: '2026-05-01T00:00:00.000Z',
     };
-    const createdRow = {
-      ...canceledLegacyRow,
-      id: 'sub-current-trial',
-      instance_id: 'instance-new',
-      plan: 'trial',
-      status: 'trialing',
-      kiloclaw_price_version: '2026-05-10',
-      payment_source: null,
-      current_period_start: null,
-      current_period_end: null,
-      trial_started_at: '2026-05-12T00:00:00.000Z',
-      trial_ends_at: '2026-05-13T00:00:00.000Z',
-      created_at: '2026-05-12T00:00:00.000Z',
-      updated_at: '2026-05-12T00:00:00.000Z',
-    };
     const { db, insertValues } = createFreshInsertDb({
       selectRows: [
         [],
@@ -1108,25 +1139,23 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
         ],
         [],
       ],
-      insertFirstReturningRows: [createdRow],
+      insertFirstReturningRows: [],
       reselectAfterConflictRows: [],
     });
     mockGetWorkerDb.mockReturnValue(db);
 
     try {
-      const result = await bootstrapProvisionSubscription(createEnv(), {
-        userId: 'user-1',
-        instanceId: 'instance-new',
-        orgId: null,
-      });
-
-      expect(result).toEqual(createdRow);
-      expect(insertValues[0]).toEqual(
-        expect.objectContaining({
-          kiloclaw_price_version: '2026-05-10',
-          trial_ends_at: '2026-05-13T00:00:00.000Z',
+      await expect(
+        bootstrapProvisionSubscription(createEnv(), {
+          userId: 'user-1',
+          instanceId: 'instance-new',
+          orgId: null,
         })
-      );
+      ).rejects.toMatchObject({
+        code: 'new_kiloclaw_instances_unavailable',
+        status: 403,
+      });
+      expect(insertValues).toHaveLength(0);
     } finally {
       vi.useRealTimers();
     }
@@ -1152,7 +1181,7 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
         orgId: null,
       })
     ).rejects.toMatchObject({
-      code: 'new_kiloclaw_subscriptions_unavailable',
+      code: 'new_kiloclaw_instances_unavailable',
       status: 403,
     });
 
@@ -1205,6 +1234,16 @@ describe('bootstrapProvisionSubscription concurrent insert race', () => {
           },
         ],
         [],
+        [
+          {
+            subscription: createTransferSource({
+              instance_id: 'instance-old-org',
+              stripe_subscription_id: null,
+              stripe_schedule_id: null,
+            }),
+            instance: { id: 'instance-old-org', destroyedAt: '2026-04-15T00:00:00.000Z' },
+          },
+        ],
         [winnerRow],
         [
           {

--- a/services/kiloclaw-billing/src/provision-bootstrap-shared.ts
+++ b/services/kiloclaw-billing/src/provision-bootstrap-shared.ts
@@ -1,6 +1,5 @@
 import { and, desc, eq, isNotNull, isNull } from 'drizzle-orm';
 import {
-  CURRENT_KILOCLAW_PRICE_VERSION,
   LEGACY_KILOCLAW_PRICE_VERSION,
   classifyKiloClawCommitTerm,
   findLatestPreCutoffUserCommitSwitchQualification,
@@ -22,8 +21,6 @@ import {
 } from '@kilocode/db';
 import { classifyOrganizationEntitlement } from '@kilocode/organization-entitlement';
 
-const ORGANIZATION_TRIAL_DURATION_DAYS = 14;
-
 export class OrganizationKiloClawProvisionEntitlementError extends Error {
   readonly status = 403;
   readonly code = 'organization_kiloclaw_entitlement_expired';
@@ -34,13 +31,13 @@ export class OrganizationKiloClawProvisionEntitlementError extends Error {
   }
 }
 
-export class PersonalKiloClawProvisioningUnavailableError extends Error {
+export class KiloClawProvisioningUnavailableError extends Error {
   readonly status = 403;
-  readonly code = 'new_kiloclaw_subscriptions_unavailable';
+  readonly code = 'new_kiloclaw_instances_unavailable';
 
   constructor() {
-    super('New KiloClaw subscriptions are unavailable.');
-    this.name = 'PersonalKiloClawProvisioningUnavailableError';
+    super('A current KiloClaw subscription is required to provision an instance.');
+    this.name = 'KiloClawProvisioningUnavailableError';
   }
 }
 
@@ -94,34 +91,6 @@ async function insertSubscriptionIdempotent(
   return { row: existing, created: false };
 }
 
-async function writeBootstrapChangeLogBestEffort(params: {
-  db: WorkerDb;
-  actor: KiloClawSubscriptionChangeActor;
-  subscriptionId: string;
-  action: 'created';
-  reason: string;
-  after: KiloClawSubscription;
-  onError?: (params: ChangeLogErrorParams) => void;
-}) {
-  try {
-    await insertKiloClawSubscriptionChangeLog(params.db, {
-      subscriptionId: params.subscriptionId,
-      actor: params.actor,
-      action: params.action,
-      reason: params.reason,
-      before: null,
-      after: params.after,
-    });
-  } catch (error) {
-    params.onError?.({
-      subscriptionId: params.subscriptionId,
-      action: params.action,
-      reason: params.reason,
-      error,
-    });
-  }
-}
-
 function isAccessGrantingSubscription(
   subscription: Pick<KiloClawSubscription, 'status' | 'suspended_at' | 'trial_ends_at'>,
   now: Date
@@ -138,8 +107,10 @@ function isAccessGrantingSubscription(
   return false;
 }
 
-function getTrialEndsAt(startedAt: Date, trialDurationDays: number): string {
-  return new Date(startedAt.getTime() + trialDurationDays * 24 * 60 * 60 * 1000).toISOString();
+function isCurrentProvisioningSubscription(
+  subscription: Pick<KiloClawSubscription, 'status' | 'suspended_at'>
+): boolean {
+  return subscription.status === 'active' && subscription.suspended_at === null;
 }
 
 type ProvisionEntitlement = {
@@ -276,6 +247,24 @@ function buildTransferUpdates(subscriptions: KiloClawSubscription[]): TransferUp
 
 function currentOrganizationSubscriptionRows(rows: OrgSubscriptionRow[]): OrgSubscriptionRow[] {
   return rows.filter(row => row.subscription.transferred_to_subscription_id === null);
+}
+
+function resolveOrganizationProvisionSource(rows: OrgSubscriptionRow[]): KiloClawSubscription {
+  const currentRows = currentOrganizationSubscriptionRows(rows);
+  const accessGrantingRows = currentRows.filter(
+    row => row.instance.destroyedAt !== null && isCurrentProvisioningSubscription(row.subscription)
+  );
+  if (accessGrantingRows.length === 0) {
+    throw new KiloClawProvisioningUnavailableError();
+  }
+  if (accessGrantingRows.length > 1) {
+    throw new Error('Multiple current organization subscription rows found during provisioning');
+  }
+  const source = accessGrantingRows[0];
+  if (!source) {
+    throw new KiloClawProvisioningUnavailableError();
+  }
+  return source.subscription;
 }
 
 function transferredToUnchangedWhere(subscription: KiloClawSubscription) {
@@ -432,46 +421,36 @@ async function bootstrapOrganizationSubscription(params: BootstrapProvisionWithD
       throw new Error('Cannot bootstrap organization subscription on destroyed instance');
     }
 
-    const { organization } = await requireOrganizationProvisionEntitlement({
+    await requireOrganizationProvisionEntitlement({
       executor: tx,
       missingOrganizationMessage: 'Organization not found during subscription bootstrap',
       now,
       orgId,
     });
 
-    const hasManagedActiveAccess = true;
-    const trialEndsAt =
-      organization.free_trial_end_at ??
-      new Date(
-        new Date(organization.created_at).getTime() +
-          ORGANIZATION_TRIAL_DURATION_DAYS * 24 * 60 * 60 * 1000
-      ).toISOString();
-
-    const { row: created, created: wasInserted } = await insertSubscriptionIdempotent(
-      tx,
-      hasManagedActiveAccess
-        ? {
-            user_id: input.userId,
-            instance_id: input.instanceId,
-            plan: 'standard',
-            status: 'active',
-            payment_source: 'credits',
-            kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
-            cancel_at_period_end: false,
-          }
-        : {
-            user_id: input.userId,
-            instance_id: input.instanceId,
-            plan: 'trial',
-            status: new Date(trialEndsAt).getTime() > now.getTime() ? 'trialing' : 'canceled',
-            kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
-            access_origin: null,
-            payment_source: null,
-            cancel_at_period_end: false,
-            trial_started_at: organization.created_at,
-            trial_ends_at: trialEndsAt,
-          }
+    const existingRows = await listOrganizationSubscriptionRowsForTransfer(tx, input.userId, orgId);
+    const existingTarget = existingRows.find(
+      row => row.subscription.instance_id === input.instanceId
     );
+    if (existingTarget) {
+      assertExpectedPriceVersion({
+        actual: existingTarget.subscription.kiloclaw_price_version,
+        expected: input.expectedPriceVersion,
+        context: 'organization provision bootstrap idempotency',
+      });
+      return existingTarget.subscription;
+    }
+    resolveOrganizationProvisionSource(existingRows);
+
+    const { row: created, created: wasInserted } = await insertSubscriptionIdempotent(tx, {
+      user_id: input.userId,
+      instance_id: input.instanceId,
+      plan: 'standard',
+      status: 'active',
+      payment_source: 'credits',
+      kiloclaw_price_version: LEGACY_KILOCLAW_PRICE_VERSION,
+      cancel_at_period_end: false,
+    });
     assertExpectedPriceVersion({
       actual: created.kiloclaw_price_version,
       expected: input.expectedPriceVersion,
@@ -483,7 +462,7 @@ async function bootstrapOrganizationSubscription(params: BootstrapProvisionWithD
         subscriptionId: created.id,
         actor: params.actor,
         action: 'created',
-        reason: hasManagedActiveAccess ? 'org_provision_managed' : 'org_provision_trial',
+        reason: 'org_provision_managed',
         before: null,
         after: created,
       });
@@ -902,7 +881,7 @@ function resolvePersonalProvisionEntitlementFromContext(params: {
       : null;
     if (
       currentInstance?.destroyedAt &&
-      isAccessGrantingSubscription(currentPersonalSubscription, params.now)
+      isCurrentProvisioningSubscription(currentPersonalSubscription)
     ) {
       return getProvisionEntitlementForPriceVersion(
         currentPersonalSubscription.kiloclaw_price_version
@@ -920,7 +899,10 @@ function resolvePersonalProvisionEntitlementFromContext(params: {
     params.personalSubscriptions,
     params.now
   );
-  if (detachedAccessGrantingSubscription) {
+  if (
+    detachedAccessGrantingSubscription &&
+    isCurrentProvisioningSubscription(detachedAccessGrantingSubscription)
+  ) {
     return getProvisionEntitlementForPriceVersion(
       detachedAccessGrantingSubscription.kiloclaw_price_version
     );
@@ -932,11 +914,7 @@ function resolvePersonalProvisionEntitlementFromContext(params: {
     );
   }
 
-  if (params.personalSubscriptions.length === 0) {
-    throw new PersonalKiloClawProvisioningUnavailableError();
-  }
-
-  return getProvisionEntitlementForPriceVersion(CURRENT_KILOCLAW_PRICE_VERSION);
+  throw new KiloClawProvisioningUnavailableError();
 }
 
 export async function resolveProvisionEntitlementWithDb(params: {
@@ -944,12 +922,19 @@ export async function resolveProvisionEntitlementWithDb(params: {
   input: { userId: string; orgId: string | null };
 }): Promise<ProvisionEntitlement> {
   if (params.input.orgId) {
+    const now = new Date();
     await requireOrganizationProvisionEntitlement({
       executor: params.db,
       missingOrganizationMessage: 'Organization not found during provision entitlement resolution',
-      now: new Date(),
+      now,
       orgId: params.input.orgId,
     });
+    const rows = await listOrganizationSubscriptionRowsForTransfer(
+      params.db,
+      params.input.userId,
+      params.input.orgId
+    );
+    resolveOrganizationProvisionSource(rows);
     return getProvisionEntitlementForPriceVersion(LEGACY_KILOCLAW_PRICE_VERSION);
   }
 
@@ -1006,7 +991,7 @@ async function bootstrapPersonalSubscription(params: BootstrapProvisionWithDbPar
       : null;
     if (
       currentInstance?.destroyedAt &&
-      isAccessGrantingSubscription(currentPersonalSubscription, now)
+      isCurrentProvisioningSubscription(currentPersonalSubscription)
     ) {
       assertExpectedPriceVersion({
         actual: currentPersonalSubscription.kiloclaw_price_version,
@@ -1024,7 +1009,10 @@ async function bootstrapPersonalSubscription(params: BootstrapProvisionWithDbPar
     context.personalSubscriptions,
     now
   );
-  if (detachedAccessGrantingSubscription) {
+  if (
+    detachedAccessGrantingSubscription &&
+    isCurrentProvisioningSubscription(detachedAccessGrantingSubscription)
+  ) {
     assertExpectedPriceVersion({
       actual: detachedAccessGrantingSubscription.kiloclaw_price_version,
       expected: input.expectedPriceVersion,
@@ -1042,44 +1030,7 @@ async function bootstrapPersonalSubscription(params: BootstrapProvisionWithDbPar
     );
   }
 
-  if (context.personalSubscriptions.length === 0) {
-    throw new PersonalKiloClawProvisioningUnavailableError();
-  }
-
-  const currentCatalogEntry = getKiloClawPricingCatalogEntry(CURRENT_KILOCLAW_PRICE_VERSION);
-  assertExpectedPriceVersion({
-    actual: currentCatalogEntry.priceVersion,
-    expected: input.expectedPriceVersion,
-    context: 'personal fresh trial bootstrap',
-  });
-  const { row: created, created: wasInserted } = await insertSubscriptionIdempotent(db, {
-    user_id: input.userId,
-    instance_id: input.instanceId,
-    plan: 'trial',
-    status: 'trialing',
-    kiloclaw_price_version: currentCatalogEntry.priceVersion,
-    access_origin: null,
-    payment_source: null,
-    cancel_at_period_end: false,
-    trial_started_at: now.toISOString(),
-    trial_ends_at: getTrialEndsAt(now, currentCatalogEntry.trialDurationDays),
-  });
-
-  if (!wasInserted) {
-    return created;
-  }
-
-  await writeBootstrapChangeLogBestEffort({
-    db,
-    actor: params.actor,
-    subscriptionId: created.id,
-    action: 'created',
-    reason: 'personal_provision_trial',
-    after: created,
-    onError: params.onChangeLogError,
-  });
-
-  return created;
+  throw new KiloClawProvisioningUnavailableError();
 }
 
 export async function bootstrapProvisionSubscriptionWithDb(params: BootstrapProvisionWithDbParams) {

--- a/services/kiloclaw-billing/src/provision-bootstrap-shared.ts
+++ b/services/kiloclaw-billing/src/provision-bootstrap-shared.ts
@@ -34,6 +34,16 @@ export class OrganizationKiloClawProvisionEntitlementError extends Error {
   }
 }
 
+export class PersonalKiloClawProvisioningUnavailableError extends Error {
+  readonly status = 403;
+  readonly code = 'new_kiloclaw_subscriptions_unavailable';
+
+  constructor() {
+    super('New KiloClaw subscriptions are unavailable.');
+    this.name = 'PersonalKiloClawProvisioningUnavailableError';
+  }
+}
+
 export type BootstrapProvisionInput = {
   userId: string;
   instanceId: string;
@@ -922,6 +932,10 @@ function resolvePersonalProvisionEntitlementFromContext(params: {
     );
   }
 
+  if (params.personalSubscriptions.length === 0) {
+    throw new PersonalKiloClawProvisioningUnavailableError();
+  }
+
   return getProvisionEntitlementForPriceVersion(CURRENT_KILOCLAW_PRICE_VERSION);
 }
 
@@ -1026,6 +1040,10 @@ async function bootstrapPersonalSubscription(params: BootstrapProvisionWithDbPar
     throw new Error(
       'Cannot bootstrap personal subscription for legacy earlybird purchase without canonical row'
     );
+  }
+
+  if (context.personalSubscriptions.length === 0) {
+    throw new PersonalKiloClawProvisioningUnavailableError();
   }
 
   const currentCatalogEntry = getKiloClawPricingCatalogEntry(CURRENT_KILOCLAW_PRICE_VERSION);

--- a/services/kiloclaw/src/routes/platform-provision-bootstrap.test.ts
+++ b/services/kiloclaw/src/routes/platform-provision-bootstrap.test.ts
@@ -326,6 +326,33 @@ describe('platform provision bootstrap quarantine', () => {
     });
   });
 
+  it('rejects fresh personal provisioning when billing reports signup is unavailable', async () => {
+    const { env, provision, beginFreshProvision } = makeEnv();
+    mockGetWorkerDb.mockReturnValue(createWorkerDb());
+    mockResolveProvisionEntitlementWithFallback.mockRejectedValueOnce(
+      Object.assign(new Error('New KiloClaw subscriptions are unavailable.'), {
+        status: 403,
+        code: 'new_kiloclaw_subscriptions_unavailable',
+      })
+    );
+
+    const response = await platform.request(
+      '/provision',
+      {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ userId: 'user-1', provider: 'fly' }),
+      },
+      env
+    );
+
+    expect(response.status).toBe(403);
+    await expect(response.json()).resolves.toEqual({ error: 'provision failed' });
+    expect(beginFreshProvision).not.toHaveBeenCalled();
+    expect(provision).not.toHaveBeenCalled();
+    expect(mockBootstrapProvisionedSubscriptionWithFallback).not.toHaveBeenCalled();
+  });
+
   it('forwards user location to the instance provision config', async () => {
     const { env, provision } = makeEnv();
     const workerDb = createWorkerDb();

--- a/services/kiloclaw/src/routes/platform-provision-bootstrap.test.ts
+++ b/services/kiloclaw/src/routes/platform-provision-bootstrap.test.ts
@@ -330,10 +330,13 @@ describe('platform provision bootstrap quarantine', () => {
     const { env, provision, beginFreshProvision } = makeEnv();
     mockGetWorkerDb.mockReturnValue(createWorkerDb());
     mockResolveProvisionEntitlementWithFallback.mockRejectedValueOnce(
-      Object.assign(new Error('New KiloClaw subscriptions are unavailable.'), {
-        status: 403,
-        code: 'new_kiloclaw_subscriptions_unavailable',
-      })
+      Object.assign(
+        new Error('A current KiloClaw subscription is required to provision an instance.'),
+        {
+          status: 403,
+          code: 'new_kiloclaw_instances_unavailable',
+        }
+      )
     );
 
     const response = await platform.request(

--- a/services/kiloclaw/src/routes/platform.ts
+++ b/services/kiloclaw/src/routes/platform.ts
@@ -505,6 +505,36 @@ async function hasCanonicalProvisionSubscription(
   return await hasSubscriptionForInstance(getWorkerDb(connectionString), instanceId);
 }
 
+async function resolveCanonicalProvisionEntitlement(params: {
+  env: AppEnv['Bindings'];
+  userId: string;
+  orgId: string | null;
+}): Promise<{
+  priceVersion: KiloClawPriceVersion;
+  selfServiceInstanceType: InstanceTierKey;
+}> {
+  const resolvedEntitlement = await resolveProvisionEntitlementWithFallback({
+    env: params.env,
+    input: { userId: params.userId, orgId: params.orgId },
+  });
+  if (!isKiloClawPriceVersion(resolvedEntitlement.priceVersion)) {
+    throw new Error(`Unknown KiloClaw price version: ${resolvedEntitlement.priceVersion}`);
+  }
+  const pricing = getKiloClawPricingCatalogEntry(resolvedEntitlement.priceVersion);
+  const resolvedSelfServiceInstanceType = InstanceTierKeySchema.parse(
+    resolvedEntitlement.selfServiceInstanceType
+  );
+  if (resolvedSelfServiceInstanceType !== pricing.selfServiceInstanceType) {
+    throw new Error(
+      `KiloClaw entitlement tier drift during provision: price version ${pricing.priceVersion} resolved ${resolvedSelfServiceInstanceType}, catalog expects ${pricing.selfServiceInstanceType}`
+    );
+  }
+  return {
+    priceVersion: pricing.priceVersion,
+    selfServiceInstanceType: pricing.selfServiceInstanceType,
+  };
+}
+
 function isWithinSelfServiceEntitlement(
   requestedTier: InstanceTierKey,
   entitlementTier: InstanceTierKey
@@ -1350,6 +1380,11 @@ platform.post('/provision', async c => {
         }
       } else if (bootstrapSubscription === true) {
         explicitInstanceRequiresSubscriptionBootstrap = true;
+        provisionEntitlement = await resolveCanonicalProvisionEntitlement({
+          env: c.env,
+          userId,
+          orgId: orgId ?? null,
+        });
       } else {
         return jsonError(
           'Provisioning completed but subscription finalization is pending',
@@ -1362,26 +1397,11 @@ platform.post('/provision', async c => {
       assertAvailableProvider(c.env, selectedProvider);
     }
     if (shouldInsertInstanceRecord) {
-      const resolvedEntitlement = await resolveProvisionEntitlementWithFallback({
+      provisionEntitlement = await resolveCanonicalProvisionEntitlement({
         env: c.env,
-        input: { userId, orgId: orgId ?? null },
+        userId,
+        orgId: orgId ?? null,
       });
-      if (!isKiloClawPriceVersion(resolvedEntitlement.priceVersion)) {
-        throw new Error(`Unknown KiloClaw price version: ${resolvedEntitlement.priceVersion}`);
-      }
-      const pricing = getKiloClawPricingCatalogEntry(resolvedEntitlement.priceVersion);
-      const resolvedSelfServiceInstanceType = InstanceTierKeySchema.parse(
-        resolvedEntitlement.selfServiceInstanceType
-      );
-      if (resolvedSelfServiceInstanceType !== pricing.selfServiceInstanceType) {
-        throw new Error(
-          `KiloClaw entitlement tier drift during provision: price version ${pricing.priceVersion} resolved ${resolvedSelfServiceInstanceType}, catalog expects ${pricing.selfServiceInstanceType}`
-        );
-      }
-      provisionEntitlement = {
-        priceVersion: pricing.priceVersion,
-        selfServiceInstanceType: pricing.selfServiceInstanceType,
-      };
       if (
         requestedInstanceType &&
         !isWithinSelfServiceEntitlement(


### PR DESCRIPTION
## Summary

Close new KiloClaw instance provisioning in personal and organization contexts unless the requested context already has a current subscription.

### Why this change is needed

KiloClaw is no longer accepting new instance creation without an existing current subscription. The closure must apply consistently across personal and organization flows, web and mobile surfaces, provisioning services, checkout fulfillment, and navigation so stale or historical state cannot create replacement infrastructure.

Existing live instances and current subscriptions must continue to support normal access, billing management, and configuration updates.

### How this is addressed

- Require a current active, unsuspended KiloClaw subscription in the exact personal or organization context before provisioning replacement infrastructure.
- Prevent canceled, expired, suspended, transferred-out, or purely historical subscription rows from authorizing new instances.
- Enforce the same boundary in the web routers, KiloClaw billing service, KiloClaw provisioning service, and local service fallback.
- Prevent completed or stale Kilo Pass checkouts from creating a first KiloClaw subscription.
- Disable credit-funded reprovision recovery from canceled personal subscription history.
- Replace ineligible personal and organization onboarding actions with a no-action unavailable state.
- Hide KiloClaw navigation and promotional surfaces when the current context is ineligible.
- Preserve existing live-instance access, billing management, and configuration behavior.

## Human Verification

- Targeted mobile tests passed for closed-signup state derivation and Home behavior.
- KiloClaw platform provisioning tests passed: 26 tests.
- KiloClaw billing bootstrap tests passed: 19 tests.
- Targeted web tests passed for:
  - personal and organization provisioning rejection
  - current organization subscription navigation state
  - Kilo Pass post-checkout enforcement
  - disabled canceled-subscription reprovision recovery
  - unavailable-state copy and hosting recovery behavior

## Reviewer Notes

### Human Reviewer Flags

- `.specs/kiloclaw-billing.md` and `.specs/subscription-center.md` now define a current subscription in the requested ownership context as the provisioning boundary.
- Subscription history alone is intentionally insufficient: canceled and historical rows cannot authorize replacement infrastructure.
- Existing live instances remain manageable; the restriction applies to infrastructure creation rather than ordinary instance configuration and lifecycle management.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- The shared billing bootstrap guard is used by both the billing Worker RPC and the KiloClaw Worker's local fallback, preventing behavior drift when the service binding fails.
- Provision entitlement is checked before durable admission reservation or provider work.
- Organization eligibility is scoped by organization and assigned user; personal subscription state cannot authorize an organization instance.
- Explicit orphan-instance bootstrap attempts are checked before provisioning can mutate infrastructure.
- Kilo Pass fulfillment requires an existing subscription row on the checkout's personal instance before credit enrollment.
- Web and mobile navigation use server-backed context eligibility rather than the legacy trial-eligibility flag.

</details>
