### PR TITLE
feat(coding-plans): add waitlist stats to Slack summary

### DIFF
--- a/apps/web/src/app/api/cron/coding-plans-inventory-summary/route.test.ts
+++ b/apps/web/src/app/api/cron/coding-plans-inventory-summary/route.test.ts
@@ -35,6 +35,7 @@ describe('GET /api/cron/coding-plans-inventory-summary', () => {
       loaded: 263,
       assigned: 156,
       available: 83,
+      waitlist: 13,
       revocationPending: 5,
       revocationFailed: 0,
       revoked: 19,

--- a/apps/web/src/lib/coding-plans/index.ts
+++ b/apps/web/src/lib/coding-plans/index.ts
@@ -490,6 +490,26 @@ export async function getCodingPlanAvailabilityIntentPlanIds(userId: string): Pr
   return rows.map(row => row.planId);
 }
 
+export async function getCodingPlanAvailabilityIntentCounts(): Promise<
+  Array<{ planId: string; count: number }>
+> {
+  const { rows } = await db.execute<{ plan_id: string; count: string }>(sql`
+    SELECT intents.plan_id, COUNT(DISTINCT intents.user_id) AS count
+    FROM coding_plan_availability_intents AS intents
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM coding_plan_terms AS terms
+      WHERE terms.user_id = intents.user_id
+        AND terms.plan_id = intents.plan_id
+        AND terms.kind = 'activation'
+        AND terms.created_at >= intents.created_at
+    )
+    GROUP BY intents.plan_id
+    ORDER BY intents.plan_id
+  `);
+  return rows.map(row => ({ planId: row.plan_id, count: Number.parseInt(row.count, 10) }));
+}
+
 export async function requestCodingPlanAvailabilityNotification(
   userId: string,
   planId: CodingPlanId

--- a/apps/web/src/lib/coding-plans/inventory-slack-summary.test.ts
+++ b/apps/web/src/lib/coding-plans/inventory-slack-summary.test.ts
@@ -23,6 +23,11 @@ const CURRENT_COUNTS: CodingPlanInventoryCount[] = [
   { providerId: 'minimax', planId: 'minimax-token-plan-ultra', status: 'available', count: 1 },
 ];
 
+const CURRENT_WAITLIST_COUNTS = [
+  { planId: 'minimax-token-plan-max', count: 4 },
+  { planId: 'minimax-token-plan-plus', count: 9 },
+];
+
 function blockText(notification: ReturnType<typeof buildCodingPlanInventorySlackNotification>) {
   return JSON.stringify(notification.notification.blocks);
 }
@@ -31,6 +36,7 @@ describe('buildCodingPlanInventorySlackNotification', () => {
   it('formats the current inventory into a compact Slack summary', () => {
     const result = buildCodingPlanInventorySlackNotification(
       CURRENT_COUNTS,
+      [],
       new Date('2026-07-30T12:00:00.000Z')
     );
 
@@ -38,12 +44,13 @@ describe('buildCodingPlanInventorySlackNotification', () => {
       loaded: 263,
       assigned: 156,
       available: 83,
+      waitlist: 0,
       revocationPending: 5,
       revocationFailed: 0,
       revoked: 19,
     });
     expect(result.notification.text).toBe(
-      'Coding Plans inventory: `83` available, `156` assigned, `263` loaded. `5` pending revocation. MiniMax Token Plan Plus: `79` available, `148` assigned, `251` loaded. MiniMax Token Plan Max: `3` available, `7` assigned, `10` loaded. MiniMax Token Plan Ultra: `1` available, `1` assigned, `2` loaded.'
+      'Coding Plans inventory: `83` available, `156` assigned, `263` loaded, `0` waitlisted. `5` pending revocation. MiniMax Token Plan Plus: `79` available, `148` assigned, `251` loaded, `0` waitlist. MiniMax Token Plan Max: `3` available, `7` assigned, `10` loaded, `0` waitlist. MiniMax Token Plan Ultra: `1` available, `1` assigned, `2` loaded, `0` waitlist.'
     );
 
     const rendered = blockText(result);
@@ -117,23 +124,70 @@ describe('buildCodingPlanInventorySlackNotification', () => {
     expect(result.notification.text).toContain('No inventory recorded');
     expect(blockText(result)).toContain('No Coding Plans inventory is currently recorded.');
   });
+
+  it('includes the total and per-plan waitlist counts', () => {
+    const result = buildCodingPlanInventorySlackNotification(
+      CURRENT_COUNTS,
+      CURRENT_WAITLIST_COUNTS
+    );
+
+    expect(result.totals).toMatchObject({ waitlist: 13 });
+    expect(result.notification.text).toContain('`13` waitlisted');
+
+    const rendered = blockText(result);
+    expect(rendered).toContain('Token Plan Plus');
+    expect(rendered).toContain('Waitlist `9`');
+    expect(rendered).toContain('Token Plan Max');
+    expect(rendered).toContain('Waitlist `4`');
+  });
+
+  it('defaults missing per-plan waitlist counts to zero', () => {
+    const result = buildCodingPlanInventorySlackNotification(CURRENT_COUNTS, [
+      { planId: 'minimax-token-plan-plus', count: 9 },
+    ]);
+
+    expect(result.totals).toMatchObject({ waitlist: 9 });
+    const rendered = blockText(result);
+    expect(rendered).toContain('Token Plan Plus ·');
+    expect(rendered).toContain('Waitlist `9`');
+    expect(rendered).toContain('Token Plan Max ·');
+    expect(rendered).toContain('Waitlist `0`');
+  });
+
+  it('represents a waitlist when no inventory is recorded', () => {
+    const result = buildCodingPlanInventorySlackNotification(
+      [],
+      [{ planId: 'minimax-token-plan-plus', count: 6 }]
+    );
+
+    expect(result.totals).toMatchObject({ loaded: 0, waitlist: 6 });
+    const rendered = blockText(result);
+    expect(rendered).toContain('No Coding Plans inventory is currently recorded.');
+    expect(rendered).toContain('Token Plan Plus');
+    expect(rendered).toContain('Waitlist `6`');
+  });
 });
 
 describe('sendCodingPlanInventorySlackSummary', () => {
   it('queries current counts and sends the generated notification', async () => {
     const getCounts = jest.fn(async () => CURRENT_COUNTS);
+    const getWaitlistCounts = jest.fn(async () => CURRENT_WAITLIST_COUNTS);
     const sendNotification = jest.fn(async (_notification: AdminSlackNotification) => undefined);
 
     await expect(
-      sendCodingPlanInventorySlackSummary({ getCounts, sendNotification })
+      sendCodingPlanInventorySlackSummary({ getCounts, getWaitlistCounts, sendNotification })
     ).resolves.toMatchObject({
       available: 83,
       loaded: 263,
+      waitlist: 13,
     });
 
     expect(getCounts).toHaveBeenCalledWith();
+    expect(getWaitlistCounts).toHaveBeenCalledWith();
     expect(sendNotification).toHaveBeenCalledWith(
-      expect.objectContaining({ text: expect.stringContaining('`83` available') })
+      expect.objectContaining({
+        text: expect.stringContaining('`13` waitlisted'),
+      })
     );
   });
 });

--- a/apps/web/src/lib/coding-plans/inventory-slack-summary.ts
+++ b/apps/web/src/lib/coding-plans/inventory-slack-summary.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import { APP_URL } from '@/lib/constants';
-import { getKeyInventoryCounts } from '@/lib/coding-plans';
+import { getCodingPlanAvailabilityIntentCounts, getKeyInventoryCounts } from '@/lib/coding-plans';
 import { getCodingPlanCatalog } from '@/lib/coding-plans/pricing';
 import {
   sendAdminSlackNotification,
@@ -15,12 +15,18 @@ export type CodingPlanInventoryCount = {
   count: number;
 };
 
+export type CodingPlanWaitlistCount = {
+  planId: string;
+  count: number;
+};
+
 type InventoryPlanSummary = {
   providerId: string;
   providerName: string;
   planId: string;
   displayName: string;
   loaded: number;
+  waitlist: number;
   statusCounts: Record<string, number>;
 };
 
@@ -28,6 +34,7 @@ export type CodingPlanInventoryTotals = {
   loaded: number;
   assigned: number;
   available: number;
+  waitlist: number;
   revocationPending: number;
   revocationFailed: number;
   revoked: number;
@@ -79,6 +86,7 @@ function summarizeInventory(counts: CodingPlanInventoryCount[]): InventoryPlanSu
       planId: item.planId,
       displayName: catalogPlan?.name ?? item.planId,
       loaded: 0,
+      waitlist: 0,
       statusCounts: {},
     };
 
@@ -98,12 +106,47 @@ function summarizeInventory(counts: CodingPlanInventoryCount[]): InventoryPlanSu
   });
 }
 
+function addWaitlistCounts(
+  summaries: InventoryPlanSummary[],
+  counts: CodingPlanWaitlistCount[]
+): InventoryPlanSummary[] {
+  const catalog = getCodingPlanCatalog();
+  const catalogByPlanId = new Map<string, (typeof catalog)[number]>(
+    catalog.map(plan => [plan.planId, plan])
+  );
+  const summariesByPlanId = new Map(summaries.map(summary => [summary.planId, summary]));
+
+  for (const item of counts) {
+    const existing = summariesByPlanId.get(item.planId);
+    if (existing) {
+      existing.waitlist = item.count;
+      continue;
+    }
+
+    const catalogPlan = catalogByPlanId.get(item.planId);
+    const summary: InventoryPlanSummary = {
+      providerId: catalogPlan?.providerId ?? 'unknown',
+      providerName: catalogPlan?.providerName ?? 'Unknown provider',
+      planId: item.planId,
+      displayName: catalogPlan?.name ?? item.planId,
+      loaded: 0,
+      waitlist: item.count,
+      statusCounts: {},
+    };
+    summariesByPlanId.set(item.planId, summary);
+    summaries.push(summary);
+  }
+
+  return summaries;
+}
+
 function inventoryTotals(summaries: InventoryPlanSummary[]): CodingPlanInventoryTotals {
   return summaries.reduce<CodingPlanInventoryTotals>(
     (totals, summary) => ({
       loaded: totals.loaded + summary.loaded,
       assigned: totals.assigned + statusCount(summary, 'assigned'),
       available: totals.available + statusCount(summary, 'available'),
+      waitlist: totals.waitlist + summary.waitlist,
       revocationPending: totals.revocationPending + statusCount(summary, 'revocation_pending'),
       revocationFailed: totals.revocationFailed + statusCount(summary, 'revocation_failed'),
       revoked: totals.revoked + statusCount(summary, 'revoked'),
@@ -112,6 +155,7 @@ function inventoryTotals(summaries: InventoryPlanSummary[]): CodingPlanInventory
       loaded: 0,
       assigned: 0,
       available: 0,
+      waitlist: 0,
       revocationPending: 0,
       revocationFailed: 0,
       revoked: 0,
@@ -120,7 +164,7 @@ function inventoryTotals(summaries: InventoryPlanSummary[]): CodingPlanInventory
 }
 
 function formatInventoryTotals(totals: CodingPlanInventoryTotals): string {
-  return `*Total* · Available ${formatCount(totals.available)} · Assigned ${formatCount(totals.assigned)} · Loaded ${formatCount(totals.loaded)}`;
+  return `*Total* · Available ${formatCount(totals.available)} · Assigned ${formatCount(totals.assigned)} · Loaded ${formatCount(totals.loaded)} · Waitlist ${formatCount(totals.waitlist)}`;
 }
 
 function groupSummariesByProvider(
@@ -140,7 +184,7 @@ function groupSummariesByProvider(
 function formatProviderSummary(providerName: string, summaries: InventoryPlanSummary[]): string {
   const planLines = summaries.map(
     summary =>
-      `${escapeSlackLabel(summary.displayName)} · Available ${formatCount(statusCount(summary, 'available'))} · Assigned ${formatCount(statusCount(summary, 'assigned'))} · Loaded ${formatCount(summary.loaded)}`
+      `${escapeSlackLabel(summary.displayName)} · Available ${formatCount(statusCount(summary, 'available'))} · Assigned ${formatCount(statusCount(summary, 'assigned'))} · Loaded ${formatCount(summary.loaded)} · Waitlist ${formatCount(summary.waitlist)}`
   );
 
   return [`*${escapeSlackLabel(providerName)}*`, ...planLines].join('\n');
@@ -182,9 +226,10 @@ function formatSnapshotTime(timestamp: Date): string {
 
 export function buildCodingPlanInventorySlackNotification(
   counts: CodingPlanInventoryCount[],
+  waitlistCounts: CodingPlanWaitlistCount[] = [],
   timestamp = new Date()
 ): { notification: AdminSlackNotification; totals: CodingPlanInventoryTotals } {
-  const summaries = summarizeInventory(counts);
+  const summaries = addWaitlistCounts(summarizeInventory(counts), waitlistCounts);
   const totals = inventoryTotals(summaries);
   const needsAttention = totals.revocationFailed + totals.revocationPending;
   const providerNames = Array.from(new Set(summaries.map(summary => summary.providerName)));
@@ -192,7 +237,7 @@ export function buildCodingPlanInventorySlackNotification(
   const planAvailability = summaries
     .map(
       summary =>
-        `${summary.providerName} ${summary.displayName}: ${formatCount(statusCount(summary, 'available'))} available, ${formatCount(statusCount(summary, 'assigned'))} assigned, ${formatCount(summary.loaded)} loaded`
+        `${summary.providerName} ${summary.displayName}: ${formatCount(statusCount(summary, 'available'))} available, ${formatCount(statusCount(summary, 'assigned'))} assigned, ${formatCount(summary.loaded)} loaded, ${formatCount(summary.waitlist)} waitlist`
     )
     .join('. ');
   const attentionFallback = [
@@ -206,7 +251,7 @@ export function buildCodingPlanInventorySlackNotification(
     .filter((value): value is string => value !== null)
     .join(', ');
   const text = [
-    `Coding Plans inventory: ${formatCount(totals.available)} available, ${formatCount(totals.assigned)} assigned, ${formatCount(totals.loaded)} loaded`,
+    `Coding Plans inventory: ${formatCount(totals.available)} available, ${formatCount(totals.assigned)} assigned, ${formatCount(totals.loaded)} loaded, ${formatCount(totals.waitlist)} waitlisted`,
     attentionFallback || null,
     planAvailability || 'No inventory recorded',
   ]
@@ -226,12 +271,14 @@ export function buildCodingPlanInventorySlackNotification(
     { type: 'divider' },
   ];
 
-  if (summaries.length === 0) {
+  if (counts.length === 0) {
     blocks.push({
       type: 'section',
       text: { type: 'mrkdwn', text: 'No Coding Plans inventory is currently recorded.' },
     });
-  } else {
+  }
+
+  if (summaries.length > 0) {
     blocks.push({
       type: 'section',
       text: { type: 'mrkdwn', text: formatInventoryTotals(totals) },
@@ -278,15 +325,20 @@ export function buildCodingPlanInventorySlackNotification(
 
 type InventorySummaryDependencies = {
   getCounts?: typeof getKeyInventoryCounts;
+  getWaitlistCounts?: typeof getCodingPlanAvailabilityIntentCounts;
   sendNotification?: typeof sendAdminSlackNotification;
 };
 
 export async function sendCodingPlanInventorySlackSummary({
   getCounts = getKeyInventoryCounts,
+  getWaitlistCounts = getCodingPlanAvailabilityIntentCounts,
   sendNotification = sendAdminSlackNotification,
 }: InventorySummaryDependencies = {}): Promise<CodingPlanInventoryTotals> {
-  const counts = await getCounts();
-  const { notification, totals } = buildCodingPlanInventorySlackNotification(counts);
+  const [counts, waitlistCounts] = await Promise.all([getCounts(), getWaitlistCounts()]);
+  const { notification, totals } = buildCodingPlanInventorySlackNotification(
+    counts,
+    waitlistCounts
+  );
   await sendNotification(notification);
   return totals;
 }

--- a/apps/web/src/routers/coding-plans-router.ts
+++ b/apps/web/src/routers/coding-plans-router.ts
@@ -1,10 +1,11 @@
-import { and, count, desc, eq } from 'drizzle-orm';
+import { and, desc, eq } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 
 import {
   cancelCodingPlanSubscription,
   getAvailableCodingPlanIds,
+  getCodingPlanAvailabilityIntentCounts,
   getCodingPlanAvailabilityIntentPlanIds,
   getKeyInventoryCounts,
   requestCodingPlanAvailabilityNotification,
@@ -37,7 +38,6 @@ import { UserByokProviderIdSchema } from '@/lib/ai-gateway/providers/openrouter/
 import { billingHistoryResponseSchema } from '@/lib/subscriptions/subscription-center';
 import { baseProcedure, adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import {
-  coding_plan_availability_intents,
   coding_plan_subscriptions,
   coding_plan_terms,
   credit_transactions,
@@ -201,13 +201,7 @@ export const codingPlansRouter = createTRPCRouter({
   }),
 
   adminAvailabilityIntentCounts: adminProcedure.input(z.object({})).query(async () => {
-    return db
-      .select({
-        planId: coding_plan_availability_intents.plan_id,
-        count: count(),
-      })
-      .from(coding_plan_availability_intents)
-      .groupBy(coding_plan_availability_intents.plan_id);
+    return getCodingPlanAvailabilityIntentCounts();
   }),
 
   getSubscriptionDetail: baseProcedure


### PR DESCRIPTION
## Summary
Add outstanding Coding Plan waitlist demand to the daily admin Slack inventory summary.

### Why this change is needed
Inventory availability alone does not show how much unmet demand exists for sold-out Coding Plans. Admins need the number of users still waiting for each plan, excluding users who later activated that plan.

### How this is addressed
- Count distinct users with an outstanding availability-notification intent per plan.
- Exclude intents followed by an activation for the same user and plan, regardless of the subscription's later status.
- Show total and per-plan waitlist counts in the Slack summary, including plans with demand but no inventory.
- Reuse the same count for the existing admin Coding Plans view.

## Human Verification
- Slack inventory summary tests passed: 8/8.
- Coding Plans inventory cron route tests passed: 3/3.
- Confirmed the count follows the Coding Plans requirement that successful activation clears the user's plan-specific intent.

## Reviewer Notes
### Human Reviewer Flags
- The query includes a defensive activation-term exclusion in addition to the normal transactional deletion of availability intents. This prevents stale or legacy intent rows from inflating current demand.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Activation terms, rather than current subscription status, determine exclusion so users who later canceled remain excluded.
- Inventory and waitlist counts are fetched concurrently.
- Waitlist-only plans are included in Slack even when no inventory rows exist.

</details>
