### PR TITLE
fix(cloud-agent): bump CLI to 7.4.20 and default bash timeout to 4m

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1290,7 +1290,7 @@ importers:
         version: 7.0.0-dev.20260514.1
       jest:
         specifier: 30.3.0
-        version: 30.3.0(@types/node@24.12.4)(node-notifier@10.0.1)
+        version: 30.3.0(@types/node@25.5.2)(node-notifier@10.0.1)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
@@ -1942,8 +1942,8 @@ importers:
         specifier: 'catalog:'
         version: 0.16.13(@cloudflare/workers-types@4.20260605.1)(@types/node@24.12.4)(@vitest/runner@4.1.6)(@vitest/snapshot@4.1.6)(bufferutil@4.1.0)(utf-8-validate@6.0.6)(vitest@4.1.6)
       '@kilocode/sdk':
-        specifier: 7.3.54
-        version: 7.3.54
+        specifier: 7.4.20
+        version: 7.4.20
       '@types/jsonwebtoken':
         specifier: 'catalog:'
         version: 9.0.10
@@ -1981,8 +1981,8 @@ importers:
   services/cloud-agent-next/wrapper:
     dependencies:
       '@kilocode/sdk':
-        specifier: 7.3.54
-        version: 7.3.54
+        specifier: 7.4.20
+        version: 7.4.20
       fuzzysort:
         specifier: 3.1.0
         version: 3.1.0
@@ -4657,11 +4657,11 @@ packages:
 
   '@esbuild-kit/core-utils@3.3.2':
     resolution: {integrity: sha512-sPRAnw9CdSsRmEtnsl2WXWdyquogVpB3yZ3dgwJfe8zrOzTsV7cJvmwrKVa+0ma5BoiGJ+BoqkMvawbayKUsqQ==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild-kit/esm-loader@2.6.5':
     resolution: {integrity: sha512-FxEMIkJKnodyA1OaCUoEvbYRkoZlLZ4d/eXFu9Fh8CbBBgP5EmZxrfTRyN0qpXZ4vOvqnE5YdRdcrmUUXuU+dA==}
-    deprecated: 'Merged into tsx: https://tsx.hirok.io'
+    deprecated: 'Merged into tsx: https://tsx.is'
 
   '@esbuild/aix-ppc64@0.28.1':
     resolution: {integrity: sha512-Svl7tq8k/08+p6CXPpRjQ1fKX+1odH/BQbb48fV6fj3CWHhsoIOoY87w1oHXm0qEpkIK3ZfVgp0hed3XBXzXMQ==}
@@ -5586,8 +5586,8 @@ packages:
   '@kilocode/sdk@7.2.52':
     resolution: {integrity: sha512-j8w6ewvo7dyu/qxjJAg0bcjHGUGGvIZ4F2f5tJnpMwLzPTAu26DJoO/08aoxf1BhfuZLzNS9tA2q+ZPdzPT8Jg==}
 
-  '@kilocode/sdk@7.3.54':
-    resolution: {integrity: sha512-A+g744DVuAHXSU3pu6BLe2AoxEh4fq7NdrYvlET3+waXSS0tG41Blr3ItCKSMLJH5M6C4rK2ZXi7plzkPNbdmA==}
+  '@kilocode/sdk@7.4.20':
+    resolution: {integrity: sha512-Dl1gBNAtZ3z8FWl4+Q08d7iP+mr8Rg2tqqn6kU9NJLlhuVtKUlp6PyIXqutam2zn+hu5xdRfbHwNauy4yHufmw==}
 
   '@lexical/clipboard@0.35.0':
     resolution: {integrity: sha512-ko7xSIIiayvDiqjNDX6fgH9RlcM6r9vrrvJYTcfGVBor5httx16lhIi0QJZ4+RNPvGtTjyFv4bwRmsixRRwImg==}
@@ -22109,7 +22109,7 @@ snapshots:
     dependencies:
       cross-spawn: 7.0.6
 
-  '@kilocode/sdk@7.3.54':
+  '@kilocode/sdk@7.4.20':
     dependencies:
       cross-spawn: 7.0.6
 

--- a/services/cloud-agent-next/Dockerfile
+++ b/services/cloud-agent-next/Dockerfile
@@ -3,7 +3,7 @@ FROM docker.io/cloudflare/sandbox:0.12.1
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.54"
+ARG KILOCODE_CLI_VERSION="7.4.20"
 
 # Install latest stable git + git-lfs from the git-core PPA, GitHub CLI, and supporting tools.
 # The default Ubuntu git (2.34.1 on 22.04) is outdated; the git-core PPA ships the latest

--- a/services/cloud-agent-next/Dockerfile.dev
+++ b/services/cloud-agent-next/Dockerfile.dev
@@ -3,7 +3,7 @@ FROM docker.io/cloudflare/sandbox:0.12.1
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.54"
+ARG KILOCODE_CLI_VERSION="7.4.20"
 
 # Build the kilo binary:
 #   cd ~/projects/kilocode-backend/cloud-agent

--- a/services/cloud-agent-next/Dockerfile.dind
+++ b/services/cloud-agent-next/Dockerfile.dind
@@ -9,7 +9,7 @@ USER root
 # Build arguments for metadata (all optional with defaults)
 ARG BUILD_DATE=""
 ARG VCS_REF=""
-ARG KILOCODE_CLI_VERSION="7.3.54"
+ARG KILOCODE_CLI_VERSION="7.4.20"
 
 # Cloudflare Containers run without root privileges, so Docker must run in
 # rootless mode. The Sandbox SDK server is copied into this image so the

--- a/services/cloud-agent-next/package.json
+++ b/services/cloud-agent-next/package.json
@@ -51,7 +51,7 @@
   "devDependencies": {
     "@cloudflare/containers": "0.3.7",
     "@cloudflare/vitest-pool-workers": "catalog:",
-    "@kilocode/sdk": "7.3.54",
+    "@kilocode/sdk": "7.4.20",
     "@types/jsonwebtoken": "catalog:",
     "@types/node": "catalog:",
     "@types/ws": "^8.5.12",

--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.test.ts
@@ -368,6 +368,35 @@ describe('CloudflareAgentSandbox', () => {
     ensureBootstrapWrapper.mockRestore();
   });
 
+  it('passes kiloServerEnv through when KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS is set', async () => {
+    const bootstrapSession = {};
+    const createSession = vi.fn().mockResolvedValue(bootstrapSession);
+    const ensureBootstrapWrapper = vi
+      .spyOn(WrapperClient, 'ensureBootstrapWrapper')
+      .mockResolvedValueOnce({ client: {} as WrapperClient });
+    const sandbox = new CloudflareAgentSandbox(
+      { KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: '120000' } as unknown as Env,
+      metadata(),
+      {
+        resolveSandbox: () =>
+          ({
+            exec: vi.fn().mockResolvedValue({ exitCode: 0, stdout: 'exists\n', stderr: '' }),
+            createSession,
+          }) as unknown as SandboxInstance,
+      }
+    );
+
+    await expect(sandbox.ensureWrapper(ensureRequest())).resolves.toMatchObject({
+      status: 'wrapper-running',
+    });
+    expect(ensureBootstrapWrapper).toHaveBeenCalledWith(expect.anything(), bootstrapSession, {
+      agentSessionId: 'agent_cloudflare',
+      userId: 'user_cloudflare',
+      kiloServerEnv: { KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: '120000' },
+    });
+    ensureBootstrapWrapper.mockRestore();
+  });
+
   it('activates containment before probing a sandbox with Kilo-only containment', async () => {
     const bootstrapSession = {};
     const setOutboundHandler = vi.fn().mockResolvedValue(undefined);

--- a/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/cloudflare/cloudflare-agent-sandbox.ts
@@ -70,6 +70,7 @@ import {
   WorkspaceCapacityAdmissionRejectedError,
   WorkspaceFilesystemPreparationError,
 } from '../../workspace-errors.js';
+import { KILO_SERVER_ENV_KEYS, type KiloServerEnv } from '../../shared/kilo-server-env.js';
 import { TOOL_CGROUP_ENV_KEYS, type ToolCgroupEnv } from '../../shared/tool-cgroup-env.js';
 import {
   buildSandboxBillingInput,
@@ -112,6 +113,21 @@ function buildToolCgroupEnv(env: Env, orgId: string | undefined): ToolCgroupEnv 
     if (value) vars[key] = value;
   }
   return vars;
+}
+
+/**
+ * Worker-owned `KILO_*` knobs to pass through to the wrapper (and from there
+ * to the Kilo server), e.g. the experimental bash default timeout. Not
+ * org-gated: presence of the Worker var is the rollout control. Undefined
+ * when no passthrough keys are set.
+ */
+function buildKiloServerEnv(env: Env): KiloServerEnv | undefined {
+  const vars: KiloServerEnv = {};
+  for (const key of KILO_SERVER_ENV_KEYS) {
+    const value = env[key];
+    if (value) vars[key] = value;
+  }
+  return Object.keys(vars).length > 0 ? vars : undefined;
 }
 
 function reportWorkspaceBackupProgress(
@@ -614,6 +630,7 @@ export class CloudflareAgentSandbox implements AgentSandbox {
         );
       }
       const toolCgroupEnv = buildToolCgroupEnv(this.env, orgId);
+      const kiloServerEnv = buildKiloServerEnv(this.env);
       let wrapper: Awaited<ReturnType<typeof WrapperClient.ensureWrapper>>;
       try {
         wrapper = await WrapperClient.ensureWrapper(sandbox, preparedWorkspace.session, {
@@ -626,6 +643,7 @@ export class CloudflareAgentSandbox implements AgentSandbox {
           fixedPort: preparedWorkspace.ready.devcontainer.wrapperPort,
           ...(request.leasedInstance ? { leasedInstance: request.leasedInstance } : {}),
           ...(toolCgroupEnv ? { toolCgroupEnv } : {}),
+          ...(kiloServerEnv ? { kiloServerEnv } : {}),
         });
       } catch (error) {
         throw ExecutionError.wrapperStartFailed(
@@ -674,11 +692,13 @@ export class CloudflareAgentSandbox implements AgentSandbox {
       cwd: '/',
     });
     const bootstrapToolCgroupEnv = buildToolCgroupEnv(this.env, orgId);
+    const bootstrapKiloServerEnv = buildKiloServerEnv(this.env);
     const wrapper = await WrapperClient.ensureBootstrapWrapper(sandbox, bootstrapSession, {
       agentSessionId: sessionId,
       userId,
       ...(request.leasedInstance ? { leasedInstance: request.leasedInstance } : {}),
       ...(bootstrapToolCgroupEnv ? { toolCgroupEnv: bootstrapToolCgroupEnv } : {}),
+      ...(bootstrapKiloServerEnv ? { kiloServerEnv: bootstrapKiloServerEnv } : {}),
     });
     if (!prepared.readyRequest) {
       return { status: 'wrapper-running' as const, client: wrapper.client };

--- a/services/cloud-agent-next/src/kilo/devcontainer.ts
+++ b/services/cloud-agent-next/src/kilo/devcontainer.ts
@@ -148,7 +148,7 @@ function buildDevContainerTrustEnv(sessionHome: string): Record<string, string> 
  * `wrangler.jsonc#image_vars` so the kilo running in the dev container
  * matches the one we use on the outer sandbox.
  */
-export const KILO_CLI_VERSION = '7.3.54';
+export const KILO_CLI_VERSION = '7.4.20';
 
 const DEVCONTAINER_RUNTIME_BUN_VERSION = '1.3.14';
 const DEVCONTAINER_RUNTIME_BOOTSTRAP_TIMEOUT_MS = 10 * 60 * 1000;

--- a/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.test.ts
@@ -1121,6 +1121,98 @@ describe('WrapperClient', () => {
       expect(options.env).not.toHaveProperty('BAD;touch /tmp/pwned');
     });
 
+    it('defaults KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS to 240000 without kiloServerEnv', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        agentSessionId: 'test-session',
+        userId: 'test-user',
+        workspacePath: '/workspace/test',
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      const command = startProcessCall[0] as string;
+      const options = startProcessCall[1] as { env?: Record<string, string> };
+      expect(command).toContain('KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=240000');
+      expect(options.env).toEqual(
+        expect.objectContaining({
+          KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: '240000',
+        })
+      );
+    });
+
+    it('passes kiloServerEnv through to both the process env and the inlined command env', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+
+      await client.ensureRunning({
+        agentSessionId: 'test-session',
+        userId: 'test-user',
+        workspacePath: '/workspace/test',
+        kiloServerEnv: { KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: '120000' },
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      const command = startProcessCall[0] as string;
+      const options = startProcessCall[1] as { env?: Record<string, string> };
+      expect(command).toContain('KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=');
+      expect(options.env).toEqual(
+        expect.objectContaining({
+          KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: '120000',
+        })
+      );
+    });
+
+    it('filters invalid kiloServerEnv keys before shell interpolation', async () => {
+      const session = createMockSession(createCurlError(7, 'Connection refused'));
+      (session.startProcess as ReturnType<typeof vi.fn>).mockResolvedValue({
+        id: 'mock-process-id',
+        waitForPort: vi.fn().mockResolvedValue(undefined),
+        getLogs: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      });
+
+      const client = new WrapperClient({ session, port: defaultPort });
+      const kiloServerEnv: Record<string, string> = {
+        KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: '120000',
+        PATH: '/tmp/pwned',
+        'BAD;touch /tmp/pwned': 'x',
+      };
+
+      await client.ensureRunning({
+        agentSessionId: 'test-session',
+        userId: 'test-user',
+        workspacePath: '/workspace/test',
+        kiloServerEnv,
+      });
+
+      const startProcessCall = (session.startProcess as ReturnType<typeof vi.fn>).mock.calls[0];
+      const command = startProcessCall[0] as string;
+      const options = startProcessCall[1] as { env?: Record<string, string> };
+      expect(command).toContain('KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=');
+      expect(command).not.toContain('/tmp/pwned');
+      expect(command).not.toContain('BAD;touch');
+      expect(options.env).toEqual(
+        expect.objectContaining({
+          KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: '120000',
+        })
+      );
+      expect(options.env).not.toHaveProperty('PATH');
+      expect(options.env).not.toHaveProperty('BAD;touch /tmp/pwned');
+    });
+
     it('throws WrapperNotReadyError after exhausting all retry attempts', async () => {
       // Health check fails (not running)
       const session = createMockSession(createCurlError(7, 'Connection refused'));
@@ -1544,7 +1636,7 @@ describe('WrapperClient', () => {
 
       expect(session.startProcess).toHaveBeenCalledWith(
         expect.stringMatching(
-          /^WRAPPER_PORT=5000 WORKSPACE_PATH=\/workspace\/test WRAPPER_LOG_PATH=\/tmp\/kilocode-wrapper-test-session-\d+\.log KILO_SESSION_RETRY_LIMIT=5 KILO_CLOUD_AGENT=1 DOCKER_HOST=unix:\/\/\/var\/run\/docker\.sock bun run '\.\/wrapper'\\''s folder\/wrapper\.js; touch \/tmp\/pwned' --agent-session test-session --user-id 'test-user'$/
+          /^WRAPPER_PORT=5000 WORKSPACE_PATH=\/workspace\/test WRAPPER_LOG_PATH=\/tmp\/kilocode-wrapper-test-session-\d+\.log KILO_SESSION_RETRY_LIMIT=5 KILO_CLOUD_AGENT=1 KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=240000 DOCKER_HOST=unix:\/\/\/var\/run\/docker\.sock bun run '\.\/wrapper'\\''s folder\/wrapper\.js; touch \/tmp\/pwned' --agent-session test-session --user-id 'test-user'$/
         ),
         expect.objectContaining({ cwd: '/workspace' })
       );

--- a/services/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -32,6 +32,7 @@ import {
   type WrapperSessionReadyRequest,
   type WrapperSessionReadySuccessResponse,
 } from '../shared/wrapper-bootstrap.js';
+import { KILO_SERVER_ENV_KEYS, type KiloServerEnv } from '../shared/kilo-server-env.js';
 import { TOOL_CGROUP_ENV_KEYS, type ToolCgroupEnv } from '../shared/tool-cgroup-env.js';
 import { parseWrapperSessionReadyErrorResponse } from './wrapper-ready-error.js';
 
@@ -82,6 +83,12 @@ export type EnsureRunningOptions = {
    * included — see MEMORY_CGROUPS_PLAN.md (W4).
    */
   toolCgroupEnv?: ToolCgroupEnv;
+  /**
+   * Worker-owned `KILO_*` knobs (e.g. the experimental bash default timeout)
+   * forwarded into the wrapper process env so the Kilo server inherits them.
+   * Not org-gated — only keys set in the Worker environment are included.
+   */
+  kiloServerEnv?: KiloServerEnv;
 };
 
 export type EnsureWrapperOptions = {
@@ -96,6 +103,8 @@ export type EnsureWrapperOptions = {
   devcontainer?: DevContainerHandle;
   /** See {@link EnsureRunningOptions.toolCgroupEnv}. */
   toolCgroupEnv?: ToolCgroupEnv;
+  /** See {@link EnsureRunningOptions.kiloServerEnv}. */
+  kiloServerEnv?: KiloServerEnv;
   /**
    * Force the wrapper to listen on this exact port instead of a random one.
    * Used by the devcontainer flow because the port has to be chosen *before*
@@ -113,6 +122,8 @@ export type EnsureBootstrapWrapperOptions = {
   leasedInstance?: WrapperInstanceLease;
   /** See {@link EnsureRunningOptions.toolCgroupEnv}. */
   toolCgroupEnv?: ToolCgroupEnv;
+  /** See {@link EnsureRunningOptions.kiloServerEnv}. */
+  kiloServerEnv?: KiloServerEnv;
 };
 
 export type SessionBinding = {
@@ -252,6 +263,13 @@ const ERROR_STATUS_CODES: Record<string, number> = {
 /** Max attempts for port allocation in ensureWrapper (retry with new random port on failure) */
 const MAX_PORT_ATTEMPTS = 3;
 const TOOL_CGROUP_ENV_KEY_SET = new Set<string>(TOOL_CGROUP_ENV_KEYS);
+const KILO_SERVER_ENV_KEY_SET = new Set<string>(KILO_SERVER_ENV_KEYS);
+/**
+ * Default shell-tool timeout (ms) for the Kilo server in cloud-agent
+ * sandboxes. Keeps stalled commands well inside the 330 s wrapper no-output
+ * liveness deadline; the `kiloServerEnv` passthrough overrides it when set.
+ */
+const KILO_BASH_DEFAULT_TIMEOUT_MS = '240000';
 
 function healthMatchesLease(
   health: WrapperHealthResponse,
@@ -621,6 +639,7 @@ export class WrapperClient {
       runtimeEnv,
       devcontainer,
       toolCgroupEnv,
+      kiloServerEnv,
     } = options;
 
     // First, try to check health
@@ -656,12 +675,17 @@ export class WrapperClient {
     const validToolCgroupEnv = validShellEnvEntries(toolCgroupEnv ?? {}).filter(([key]) =>
       TOOL_CGROUP_ENV_KEY_SET.has(key)
     );
+    const validKiloServerEnv = validShellEnvEntries(kiloServerEnv ?? {}).filter(([key]) =>
+      KILO_SERVER_ENV_KEY_SET.has(key)
+    );
     const wrapperEnv: Record<string, string | undefined> = {
       WRAPPER_PORT: String(this.port),
       WORKSPACE_PATH: innerWorkspacePath,
       WRAPPER_LOG_PATH: wrapperLogPath,
       KILO_SESSION_RETRY_LIMIT: '5',
       KILO_CLOUD_AGENT: '1',
+      // Later spreads (toolCgroupEnv, kiloServerEnv) override this default.
+      KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS: KILO_BASH_DEFAULT_TIMEOUT_MS,
       ...(leasedInstance
         ? {
             WRAPPER_INSTANCE_ID: leasedInstance.instanceId,
@@ -669,6 +693,7 @@ export class WrapperClient {
           }
         : {}),
       ...Object.fromEntries(validToolCgroupEnv),
+      ...Object.fromEntries(validKiloServerEnv),
     };
     const commandEnvParts = [
       `WRAPPER_PORT=${this.port}`,
@@ -676,6 +701,8 @@ export class WrapperClient {
       `WRAPPER_LOG_PATH=${wrapperLogPath}`,
       `KILO_SESSION_RETRY_LIMIT=5`,
       `KILO_CLOUD_AGENT=1`,
+      // Later entries (toolCgroupEnv, kiloServerEnv) override this default.
+      `KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS=${KILO_BASH_DEFAULT_TIMEOUT_MS}`,
       // Environment markers let pre-lease wrapper bundles launch during a rolling deploy.
       ...(leasedInstance
         ? [
@@ -684,6 +711,7 @@ export class WrapperClient {
           ]
         : []),
       ...validToolCgroupEnv.map(([key, value]) => `${key}=${shellQuote(value)}`),
+      ...validKiloServerEnv.map(([key, value]) => `${key}=${shellQuote(value)}`),
       ...dockerEnvParts,
     ];
     const devContainerSessionHome =

--- a/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
+++ b/services/cloud-agent-next/src/shared/default-slash-commands.generated.ts
@@ -17,7 +17,7 @@ export type SlashCommandInfo = {
  *
  * Regenerate with `pnpm --filter cloud-agent-next update-default-slash-commands`.
  */
-export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.3.54';
+export const DEFAULT_SLASH_COMMANDS_SOURCE = 'kilo@7.4.20';
 
 /**
  * Default slash command catalog used when no live wrapper-reported catalog is
@@ -32,19 +32,17 @@ export const DEFAULT_SLASH_COMMANDS = [
   },
   {
     name: 'local-review',
-    description: 'local review (current branch, optional base or instructions)',
-    hints: ['$ARGUMENTS'],
+    description: 'deprecated; use /review branch',
+    hints: [],
   },
   {
     name: 'local-review-uncommitted',
-    description: 'local review (uncommitted changes)',
-    hints: ['$ARGUMENTS'],
+    description: 'deprecated; use /review uncommitted',
+    hints: [],
   },
   {
     name: 'review',
-    description: 'review changes [commit|branch|pr], defaults to uncommitted',
-    source: 'command',
-    subtask: true,
+    description: 'review changes [uncommitted|commit|branch|pr]',
     hints: ['$ARGUMENTS'],
   },
 ] satisfies SlashCommandInfo[];

--- a/services/cloud-agent-next/src/shared/kilo-server-env.ts
+++ b/services/cloud-agent-next/src/shared/kilo-server-env.ts
@@ -1,0 +1,14 @@
+export const KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS_ENV =
+  'KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS';
+
+/**
+ * Worker-owned env keys forwarded to the wrapper process so the Kilo server
+ * inherits them (e.g. the experimental bash default timeout). Unlike
+ * `TOOL_CGROUP_*` these are not org-gated: a key is forwarded only when it is
+ * set in the Worker environment, so presence in the deployed config is the
+ * rollout control.
+ */
+export const KILO_SERVER_ENV_KEYS = [KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS_ENV] as const;
+
+export type KiloServerEnvKey = (typeof KILO_SERVER_ENV_KEYS)[number];
+export type KiloServerEnv = Partial<Record<KiloServerEnvKey, string>>;

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -547,6 +547,8 @@ export type Env = {
   KILO_OPENROUTER_BASE?: string;
   /** Kilocode CLI timeout override (seconds) */
   CLI_TIMEOUT_SECONDS?: string;
+  /** Experimental default shell-tool timeout (ms) forwarded to the Kilo server */
+  KILO_EXPERIMENTAL_BASH_DEFAULT_TIMEOUT_MS?: string;
   /** Reaper interval override (ms) */
   REAPER_INTERVAL_MS?: string;
   /** Kilo server idle timeout override (ms) - defaults to 15 minutes */

--- a/services/cloud-agent-next/test/e2e/README.md
+++ b/services/cloud-agent-next/test/e2e/README.md
@@ -78,7 +78,7 @@ containment flags.
 > driver silently hits the wrong Worker/fake-LLM and every scenario fails
 > at connection. See the env-var table below for the full list.
 
-Official SDK basic-chat acceptance (pinned `@kilocode/sdk/v2` `7.3.54`):
+Official SDK basic-chat acceptance (pinned `@kilocode/sdk/v2` `7.4.20`):
 
 ```bash
 pnpm --filter cloud-agent-next exec tsx test/e2e/sdk-basic-chat.ts

--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -166,7 +166,7 @@
         "disk_mb": 20000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.4.20",
       },
       "max_instances": 200,
       "rollout_active_grace_period": 1800,
@@ -180,7 +180,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.4.20",
       },
       "max_instances": 150,
       "rollout_active_grace_period": 1800,
@@ -194,7 +194,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.4.20",
       },
       "max_instances": 20,
       "rollout_active_grace_period": 1800,
@@ -208,7 +208,7 @@
         "disk_mb": 8000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.4.20",
       },
       "max_instances": 500,
       "rollout_active_grace_period": 1800,
@@ -222,7 +222,7 @@
         "disk_mb": 20000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.4.20",
       },
       "max_instances": 750,
       "rollout_active_grace_period": 1800,
@@ -236,7 +236,7 @@
         "disk_mb": 10000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.4.20",
       },
       "max_instances": 300,
       "rollout_active_grace_period": 1800,
@@ -250,7 +250,7 @@
         "disk_mb": 8000,
       },
       "image_vars": {
-        "KILOCODE_CLI_VERSION": "7.3.54",
+        "KILOCODE_CLI_VERSION": "7.4.20",
       },
       "max_instances": 1500,
       "rollout_active_grace_period": 1800,
@@ -467,7 +467,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.4.20",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -477,7 +477,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.4.20",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -487,7 +487,7 @@
           "image": "./Dockerfile.dind",
           "instance_type": "standard-3",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.4.20",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -501,7 +501,7 @@
             "disk_mb": 8000,
           },
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.4.20",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -511,7 +511,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.4.20",
           },
           "max_instances": 10,
           "rollout_active_grace_period": 60,
@@ -521,7 +521,7 @@
           "image": "./Dockerfile.dev",
           "instance_type": "standard-4",
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.4.20",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,
@@ -535,7 +535,7 @@
             "disk_mb": 8000,
           },
           "image_vars": {
-            "KILOCODE_CLI_VERSION": "7.3.54",
+            "KILOCODE_CLI_VERSION": "7.4.20",
           },
           "max_instances": 2,
           "rollout_active_grace_period": 60,

--- a/services/cloud-agent-next/wrapper/package.json
+++ b/services/cloud-agent-next/wrapper/package.json
@@ -8,7 +8,7 @@
     "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
-    "@kilocode/sdk": "7.3.54",
+    "@kilocode/sdk": "7.4.20",
     "fuzzysort": "3.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary

Cloud Agent sessions were dying during heavy commands (like `pnpm typecheck`) with a generic wrapper failure, even though the sandbox was still alive.

This PR fixes two things that caused that:

1. **Upgrade Kilo CLI to 7.4.20** — when a command is killed (OOM, SIGKILL, etc.), the agent now gets the exit code immediately and can continue, instead of hanging.
2. **Default shell timeout of 4 minutes** — if a command stalls with no output (e.g. thrashing at a memory limit), it is stopped before the 5.5-minute session liveness deadline, so the agent can recover instead of the whole session failing.

Also adds a small env passthrough so the default timeout can be overridden from Worker config if needed.

## What we found

We reproduced the failure on a test Worker with a clean checkout of this monorepo:

| Setup | Result |
|---|---|
| 6 GB sandbox | Session dies during install/typecheck |
| 12 GB sandbox | Session stays healthy; typecheck can finish |
| Command killed by signal (on 7.3.x) | Agent could hang waiting for exit |
| Same kill on **7.4.20** | Exit 137 right away; agent continues |
| Long timeout + memory pressure | Process stays alive but stuck; session times out after ~5.5 min |
| **Short timeout** under same pressure | Command fails cleanly; agent runs a follow-up and finishes normally |

So there were two separate issues:

- **Killed process not reported** → fixed by CLI 7.4.20  
- **Stuck-but-alive process** → fixed by a 4-minute default shell timeout (under the 5.5-minute liveness limit)

This does **not** make a full monorepo typecheck fit in 6 GB — that still needs more memory. It makes failures **visible and recoverable** instead of taking down the session.

## Test plan

- [x] Unit tests for timeout default, override, and env filtering
- [x] Deployed to Cloudflare test Worker (`cloud-agent-next-evgeny-test`)
- [x] Confirmed `kilo --version` is 7.4.20 on that deployment
- [x] Signal kill (`kill -KILL $$`) returns exit 137 immediately; agent runs a follow-up command
- [x] Heavy stalled command with a short shell timeout fails cleanly; agent recovers and session completes normally
- [x] Same heavy workload with a long timeout still hits the stuck-but-alive path (confirms why the default timeout is needed)