### PR TITLE
refactor(user): filter account linking errors in Sentry

### DIFF
--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -817,18 +817,22 @@ export async function linkAccountToExistingUser(
   });
 
   if (!linkResult.success) {
-    captureException(new Error(`Account linking failed: ${linkResult.error}`), {
-      tags: {
-        operation: 'account_linking',
-        provider: authProviderData.provider,
-      },
-      extra: {
-        existing_user_id: existingKiloUserId,
-        provider_email: authProviderData.google_user_email,
-        provider_account_id: authProviderData.provider_account_id,
-        error_code: linkResult.error,
-      },
-    });
+    // ACCOUNT-ALREADY-LINKED and PROVIDER-ALREADY-LINKED are expected user
+    // errors; only LINKING-FAILED indicates a system failure worth Sentry.
+    if (linkResult.error === 'LINKING-FAILED') {
+      captureException(new Error(`Account linking failed: ${linkResult.error}`), {
+        tags: {
+          operation: 'account_linking',
+          provider: authProviderData.provider,
+        },
+        extra: {
+          existing_user_id: existingKiloUserId,
+          provider_email: authProviderData.google_user_email,
+          provider_account_id: authProviderData.provider_account_id,
+          error_code: linkResult.error,
+        },
+      });
+    }
 
     return linkResult;
   }


### PR DESCRIPTION
## Summary

`linkAccountToExistingUser` reported every account-linking failure to Sentry via `captureException`, including expected user errors like `ACCOUNT-ALREADY-LINKED` (user tried to link a provider account already attached to another Kilo user) and `PROVIDER-ALREADY-LINKED`. This produced noisy Sentry issues such as `GET /api/auth/callback/githubAccount linking failed: ACCOUNT-ALREADY-LINKED`.

The NextAuth `signIn` handler in `server.ts` already treats these codes as expected and skips Sentry, but the capture in `linkAccountToExistingUser` fired unconditionally before that check. This PR guards the `captureException` so only `LINKING-FAILED` (a genuine system error — the DB insert returned nothing) is reported. Expected errors still return normally and redirect the user to the appropriate error page.

## Verification

- [ ] No manual testing performed — change is a conditional guard around an existing Sentry call; `oxlint` passes (0 warnings, 0 errors) and existing `multi-auth.test.ts` coverage of `linkAuthProviderToUser` error codes is unaffected. Full web typecheck could not complete within the CI-agent sandbox time limit.

## Visual Changes

N/A

## Reviewer Notes

`linkAuthProviderToUser` returns exactly three failure codes (`ACCOUNT-ALREADY-LINKED`, `PROVIDER-ALREADY-LINKED`, `LINKING-FAILED`), so the `=== 'LINKING-FAILED'` guard covers all unexpected cases.