### PR TITLE
fix(ai-gateway): increase weight of Vercel-routable auto free models

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -176,7 +176,7 @@ describe('isFreeModel', () => {
 
       for (const candidate of autoFreeModels) {
         if (!candidate.model.includes('laguna')) {
-          expect(candidate.weight).toBe(2);
+          expect(candidate.weight).toBe(3);
         }
       }
     });

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -50,14 +50,14 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
     ? [
         {
           model: stepfun_37_flash_free_model.public_id,
-          weight: 2,
+          weight: 3,
           reasoning: { enabled: true, effort: 'high' },
         } satisfies AutoFreeModel,
       ]
     : []),
   {
     model: 'inclusionai/ling-3.0-flash:free',
-    weight: 2,
+    weight: 3,
     reasoning: { enabled: true, effort: 'high' },
   } satisfies AutoFreeModel,
   {


### PR DESCRIPTION
## Summary
- increase non-Laguna Auto Free model weights from 2 to 3
- keep Laguna at weight 1 and update the routing invariant test

## Verification
- `./node_modules/.bin/jest src/lib/ai-gateway/models.test.ts --runInBand`
- `./node_modules/.bin/oxfmt --check apps/web/src/lib/ai-gateway/models.ts apps/web/src/lib/ai-gateway/models.test.ts`
- `./node_modules/.bin/tsgo --noEmit -p tsconfig.json`
- `git diff --check`