### PR TITLE
feat(ai-gateway): map custom LLM thought signatures

### DIFF
--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
@@ -1,0 +1,134 @@
+import { describe, expect, it } from '@jest/globals';
+import { CustomLlmApiConfigSchema } from '@kilocode/db';
+import { EmptyFraudDetectionHeaders } from '@/lib/utils';
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import { buildDirectProvider } from './build-direct-provider';
+
+type ChatCompletionRequest = Extract<GatewayRequest, { kind: 'chat_completions' }>;
+
+async function transformRequest(request: GatewayRequest, thought_signature_mapping?: string) {
+  const provider = buildDirectProvider('custom', ['chat_completions'], {
+    internal_id: 'upstream-model',
+    base_url: 'https://llm.example.com/v1',
+    api_key: 'test-key',
+    thought_signature_mapping,
+  });
+
+  await provider.transformRequest({
+    provider,
+    model: 'public-model',
+    request,
+    originalHeaders: EmptyFraudDetectionHeaders,
+    extraHeaders: {},
+    userByok: null,
+    kilo_user_id: 'user-1',
+    organization_id: null,
+    session_id: null,
+  });
+}
+
+function makeRequest(): ChatCompletionRequest {
+  const toolCall = {
+    id: 'call-1',
+    type: 'function' as const,
+    function: { name: 'lookup', arguments: '{}' },
+  };
+  const toolMessage = {
+    role: 'tool' as const,
+    content: 'result',
+    tool_call_id: 'call-1',
+  };
+  const request: ChatCompletionRequest = {
+    kind: 'chat_completions',
+    body: {
+      model: 'public-model',
+      stream: false,
+      messages: [
+        {
+          role: 'assistant',
+          content: null,
+          tool_calls: [toolCall],
+        },
+        toolMessage,
+      ],
+    },
+  };
+
+  Object.assign(toolCall, {
+    thoughtSignature: 'assistant-signature',
+    extra_content: { trace_id: 'trace-1' },
+  });
+  Object.assign(toolMessage, { thoughtSignature: 'tool-signature' });
+
+  return request;
+}
+
+describe('custom LLM thought signature mapping configuration', () => {
+  const config = {
+    internal_id: 'upstream-model',
+    base_url: 'https://llm.example.com/v1',
+  };
+
+  it('accepts a dot-separated property path', () => {
+    expect(
+      CustomLlmApiConfigSchema.safeParse({
+        ...config,
+        thought_signature_mapping: 'extra_content.provider.thought_signature',
+      }).success
+    ).toBe(true);
+  });
+
+  it.each(['', 'extra_content..thought_signature', '__proto__.thought_signature'])(
+    'rejects unsafe property path %p',
+    thought_signature_mapping => {
+      expect(
+        CustomLlmApiConfigSchema.safeParse({ ...config, thought_signature_mapping }).success
+      ).toBe(false);
+    }
+  );
+});
+
+describe('buildDirectProvider thought signature mapping', () => {
+  it('maps assistant tool-call signatures and removes camel-case transport fields', async () => {
+    const request = makeRequest();
+
+    await transformRequest(request, 'extra_content.provider.thought_signature');
+
+    expect(request.body.model).toBe('upstream-model');
+    expect(request.body.messages).toEqual([
+      {
+        role: 'assistant',
+        content: null,
+        tool_calls: [
+          {
+            id: 'call-1',
+            type: 'function',
+            function: { name: 'lookup', arguments: '{}' },
+            extra_content: {
+              trace_id: 'trace-1',
+              provider: { thought_signature: 'assistant-signature' },
+            },
+          },
+        ],
+      },
+      {
+        role: 'tool',
+        content: 'result',
+        tool_call_id: 'call-1',
+      },
+    ]);
+  });
+
+  it('preserves signatures when no mapping is configured', async () => {
+    const request = makeRequest();
+
+    await transformRequest(request);
+
+    expect(request.body.messages).toMatchObject([
+      {
+        tool_calls: [{ thoughtSignature: 'assistant-signature' }],
+      },
+      { thoughtSignature: 'tool-signature' },
+    ]);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
@@ -30,6 +30,64 @@ import { db } from '@/lib/drizzle';
  */
 export type ResolvedExperimentUpstream = CustomLlmApiConfig & { api_key: string };
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function setPropertyPath(target: Record<string, unknown>, path: string, value: string) {
+  const segments = path.split('.');
+  const finalSegment = segments.at(-1);
+  if (!finalSegment) {
+    return;
+  }
+
+  let current = target;
+
+  for (const segment of segments.slice(0, -1)) {
+    const existing = current[segment];
+    if (isRecord(existing)) {
+      current = existing;
+      continue;
+    }
+
+    const nested: Record<string, unknown> = {};
+    current[segment] = nested;
+    current = nested;
+  }
+
+  current[finalSegment] = value;
+}
+
+function mapThoughtSignatures(context: TransformRequestContext, path: string) {
+  if (context.request.kind !== 'chat_completions') {
+    return;
+  }
+
+  for (const message of context.request.body.messages) {
+    if (!isRecord(message)) {
+      continue;
+    }
+
+    delete message.thoughtSignature;
+
+    if (!Array.isArray(message.tool_calls)) {
+      continue;
+    }
+
+    for (const toolCall of message.tool_calls) {
+      if (!isRecord(toolCall)) {
+        continue;
+      }
+
+      const signature = toolCall.thoughtSignature;
+      delete toolCall.thoughtSignature;
+      if (typeof signature === 'string') {
+        setPropertyPath(toolCall, path, signature);
+      }
+    }
+  }
+}
+
 async function compressWithHeadroom(
   context: TransformRequestContext,
   compression: CustomLlmCompression
@@ -119,6 +177,9 @@ export function buildDirectProvider(
         } else {
           context.request.body.messages = messages as OpenRouterChatCompletionRequest['messages'];
         }
+      }
+      if (upstream.thought_signature_mapping) {
+        mapThoughtSignatures(context, upstream.thought_signature_mapping);
       }
     },
   };

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1924,6 +1924,20 @@ export const CustomLlmCompressionSchema = z.object({
 
 export type CustomLlmCompression = z.infer<typeof CustomLlmCompressionSchema>;
 
+const CustomLlmPropertyPathSchema = z
+  .string()
+  .min(1)
+  .refine(
+    path =>
+      path
+        .split('.')
+        .every(
+          segment =>
+            segment.length > 0 && !['__proto__', 'constructor', 'prototype'].includes(segment)
+        ),
+    'Must be a dot-separated property path'
+  );
+
 export const CustomLlmApiConfigSchema = z.object({
   internal_id: z.string().min(1),
   base_url: z.url(),
@@ -1934,6 +1948,7 @@ export const CustomLlmApiConfigSchema = z.object({
   extra_body: CustomLlmExtraBodySchema.optional(),
   remove_from_body: z.array(z.string()).optional(),
   compression: CustomLlmCompressionSchema.optional(),
+  thought_signature_mapping: CustomLlmPropertyPathSchema.optional(),
 });
 
 export type CustomLlmApiConfig = z.infer<typeof CustomLlmApiConfigSchema>;


### PR DESCRIPTION
## Summary
- add a validated destination path to custom LLM configurations
- map camel-case tool-call signatures into the configured nested upstream payload
- remove transport-only signature fields from mapped chat-completion messages

## Testing
- `pnpm --filter web exec jest --runInBand --runTestsByPath "src/lib/ai-gateway/experiments/build-direct-provider.test.ts"`
- `pnpm --filter @kilocode/db typecheck`
- `pnpm --filter web typecheck`
- `pnpm --filter @kilocode/db lint`
- `pnpm --filter web lint`