### PR TITLE
fix(mobile): stop search indicator CLS and group preferences

### DIFF
--- a/apps/mobile/src/components/agents/session-list-search-busy.ts
+++ b/apps/mobile/src/components/agents/session-list-search-busy.ts
@@ -17,7 +17,7 @@ export function selectAwaitingCommit(params: {
 }
 
 /**
- * True when the "Searching…" indicator should be visible.
+ * True when the in-field search spinner should replace the search icon.
  *
  * Covers three windows:
  * - debounce window (typed text not yet committed) — `awaitingCommit`

--- a/apps/mobile/src/components/agents/session-list-search-header.tsx
+++ b/apps/mobile/src/components/agents/session-list-search-header.tsx
@@ -28,7 +28,18 @@ export function SessionListSearchHeader({
   return (
     <View>
       <View className="mx-[22px] mb-[14px] mt-3 flex-row items-center gap-2 rounded-[10px] border border-border bg-card px-4 py-1.5">
-        <Search size={18} color={colors.mutedForeground} />
+        {/* Fixed-size slot: the spinner swaps in for the icon, so the row never reflows. */}
+        <View className="h-[18px] w-[18px] items-center justify-center">
+          {showSearchBusy ? (
+            <ActivityIndicator
+              size="small"
+              color={colors.mutedForeground}
+              accessibilityLabel="Searching"
+            />
+          ) : (
+            <Search size={18} color={colors.mutedForeground} />
+          )}
+        </View>
         <TextInput
           ref={inputRef}
           className="min-h-6 flex-1 py-1 text-[15px] leading-6 text-foreground"
@@ -51,14 +62,6 @@ export function SessionListSearchHeader({
           </Pressable>
         ) : null}
       </View>
-      {showSearchBusy ? (
-        <View className="mx-[22px] mb-[14px] flex-row items-center gap-2">
-          <ActivityIndicator size="small" color={colors.mutedForeground} />
-          <Text variant="muted" className="text-xs">
-            Searching…
-          </Text>
-        </View>
-      ) : null}
       {showInlineError ? (
         <Text variant="muted" className="mx-[22px] mb-[14px] text-xs">
           Couldn't refresh. Pull down to try again.

--- a/apps/mobile/src/components/preferences-screen.tsx
+++ b/apps/mobile/src/components/preferences-screen.tsx
@@ -1,12 +1,20 @@
-import { Brain, type LucideIcon, Smartphone } from 'lucide-react-native';
+import { type Href, useRouter } from 'expo-router';
+import { Bell, Brain, type LucideIcon, Smartphone } from 'lucide-react-native';
 import { Switch, View } from 'react-native';
 
 import { ScreenHeader } from '@/components/screen-header';
 import { TabScreenScrollView } from '@/components/tab-screen';
+import { ConfigureRow } from '@/components/ui/configure-row';
+import { SegmentedControl } from '@/components/ui/segmented-control';
 import { Text } from '@/components/ui/text';
 import { useKeepScreenOnPreference } from '@/lib/hooks/use-keep-screen-on-preference';
 import { useReasoningPreference } from '@/lib/hooks/use-reasoning-preference';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import {
+  setThemePreference,
+  type ThemePreference,
+  useThemePreference,
+} from '@/lib/hooks/use-theme-preference';
 
 type PreferenceRowProps = Readonly<{
   icon: LucideIcon;
@@ -50,6 +58,8 @@ function PreferenceRow({
 }
 
 export function PreferencesScreen() {
+  const router = useRouter();
+  const { preference: themePreference } = useThemePreference();
   const {
     defaultExpanded,
     hasLoaded: reasoningLoaded,
@@ -85,6 +95,40 @@ export function PreferencesScreen() {
           disabled={!keepScreenOnLoaded}
           onValueChange={setKeepScreenOn}
         />
+
+        {/* Appearance */}
+        <View className="mt-3 gap-3">
+          <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+            Appearance
+          </Text>
+          <SegmentedControl<ThemePreference>
+            accessibilityLabel="Appearance"
+            options={[
+              { value: 'system', label: 'System' },
+              { value: 'light', label: 'Light' },
+              { value: 'dark', label: 'Dark' },
+            ]}
+            value={themePreference}
+            onChange={setThemePreference}
+          />
+        </View>
+
+        {/* Notifications */}
+        <View className="mt-3 gap-3">
+          <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
+            Notifications
+          </Text>
+          <ConfigureRow
+            icon={Bell}
+            title="Notifications"
+            subtitle="Push preferences"
+            className="rounded-lg bg-secondary px-3"
+            last
+            onPress={() => {
+              router.push('/(app)/(tabs)/(3_profile)/notifications' as Href);
+            }}
+          />
+        </View>
       </TabScreenScrollView>
     </View>
   );

--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -1,9 +1,8 @@
-/* eslint-disable max-lines -- The profile screen composes Credits, Agents, Reviews, Organization, Linked accounts, Notifications, Restore Purchases, and Actions; each section is a small rendered surface that mirrors the shared ConfigureRow/Text-header pattern. Splitting would re-encode the same hooks. */
+/* eslint-disable max-lines -- The profile screen composes Credits, Agents, Reviews, Organization, Linked accounts, App, Restore Purchases, and Actions; each section is a small rendered surface that mirrors the shared ConfigureRow/Text-header pattern. Splitting would re-encode the same hooks. */
 import { useMutation, useQuery } from '@tanstack/react-query';
 import * as Application from 'expo-application';
 import { type Href, useRouter } from 'expo-router';
 import {
-  Bell,
   Building2,
   GitMerge,
   GitPullRequest,
@@ -26,7 +25,6 @@ import { QueryError } from '@/components/query-error';
 import { ScreenHeader } from '@/components/screen-header';
 import { TabScreenScrollView } from '@/components/tab-screen';
 import { ConfigureRow } from '@/components/ui/configure-row';
-import { SegmentedControl } from '@/components/ui/segmented-control';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { FEATURE_FLAG_PR_REVIEW, useFeatureFlag } from '@/lib/analytics/posthog';
@@ -34,11 +32,6 @@ import { useAuth } from '@/lib/auth/auth-context';
 import { showFeedbackPrompt } from '@/lib/feedback';
 import { useCurrentUserId } from '@/lib/hooks/use-current-user-id';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
-import {
-  setThemePreference,
-  type ThemePreference,
-  useThemePreference,
-} from '@/lib/hooks/use-theme-preference';
 import { useOrganization } from '@/lib/organization-context';
 import {
   getCodeReviewerProfilePath,
@@ -57,7 +50,6 @@ export function ProfileScreen() {
   const router = useRouter();
   const trpc = useTRPC();
   const colors = useThemeColors();
-  const { preference: themePreference } = useThemePreference();
   const { organizationId, isLoaded: organizationContextLoaded } = useOrganization();
   const isAuthenticated = token != null;
   const prReviewEnabled = useFeatureFlag(FEATURE_FLAG_PR_REVIEW, true);
@@ -275,23 +267,6 @@ export function ProfileScreen() {
           </View>
         )}
 
-        {/* Appearance */}
-        <View className="mt-6 gap-3">
-          <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
-            Appearance
-          </Text>
-          <SegmentedControl<ThemePreference>
-            accessibilityLabel="Appearance"
-            options={[
-              { value: 'system', label: 'System' },
-              { value: 'light', label: 'Light' },
-              { value: 'dark', label: 'Dark' },
-            ]}
-            value={themePreference}
-            onChange={setThemePreference}
-          />
-        </View>
-
         {/* App */}
         <View className="mt-6 gap-3">
           <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
@@ -300,28 +275,11 @@ export function ProfileScreen() {
           <ConfigureRow
             icon={SlidersHorizontal}
             title="Preferences"
-            subtitle="Thinking and screen behavior"
+            subtitle="Appearance, notifications, thinking, and screen behavior"
             className="rounded-lg bg-secondary px-3"
             last
             onPress={() => {
               router.push('/(app)/(tabs)/(3_profile)/preferences' as Href);
-            }}
-          />
-        </View>
-
-        {/* Notifications */}
-        <View className="mt-6 gap-3">
-          <Text variant="small" className="uppercase tracking-wide text-muted-foreground">
-            Notifications
-          </Text>
-          <ConfigureRow
-            icon={Bell}
-            title="Notifications"
-            subtitle="Push preferences"
-            className="rounded-lg bg-secondary px-3"
-            last
-            onPress={() => {
-              router.push('/(app)/(tabs)/(3_profile)/notifications' as Href);
             }}
           />
         </View>


### PR DESCRIPTION
## Summary

Two small mobile UI changes.

**Session list search indicator**
- The "Searching…" row rendered below the search input and pushed the list down. That caused cumulative layout shift (CLS).
- The spinner now replaces the search icon inside the input, in a fixed-size 18px slot. The row never reflows.

**Profile preferences**
- Moved the Appearance segmented control and the Notifications row from the Profile screen into the Preferences screen.
- Updated the Profile "Preferences" subtitle to name the four groups.

## Test

`pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused && pnpm test` pass in `apps/mobile`. 3695 tests pass.