### PR TITLE
fix(cloud-agent-next): increase tool cgroup reserve to 2GB

### DIFF
--- a/services/cloud-agent-next/wrangler.jsonc
+++ b/services/cloud-agent-next/wrangler.jsonc
@@ -59,7 +59,7 @@
     "KILO_SESSION_INGEST_URL": "https://ingest.kilosessions.ai",
     "TOOL_CGROUP_ORG_IDS": "*",
     "TOOL_CGROUP_MODE": "enforce",
-    "TOOL_CGROUP_RESERVE_MB": "1024",
+    "TOOL_CGROUP_RESERVE_MB": "2048",
     "TOOL_CGROUP_CPU_WEIGHT": "50",
   },
   "placement": { "mode": "smart" },


### PR DESCRIPTION
## Summary
- Bump `TOOL_CGROUP_RESERVE_MB` from `1024` to `2048` in cloud-agent-next wrangler config
- Leaves more memory reserved outside the tool cgroup under enforce mode

## Test plan
- [ ] Confirm wrangler vars show `TOOL_CGROUP_RESERVE_MB=2048` after deploy
- [ ] Spot-check a session with tool cgroup enabled still starts and enforces limits