### PR TITLE
fix(ai-gateway): order reasoning variants ascending

### DIFF
--- a/apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.test.ts
@@ -4,7 +4,7 @@ import { orderOpenCodeSettings, orderOpenCodeVariants } from './order-opencode-v
 const variant = { reasoning: { enabled: true } };
 
 describe('orderOpenCodeVariants', () => {
-  it('orders reasoning effort variants from most to least intensive', () => {
+  it('orders reasoning effort variants from least to most intensive', () => {
     const variants = {
       max: variant,
       medium: variant,
@@ -16,13 +16,13 @@ describe('orderOpenCodeVariants', () => {
     };
 
     expect(Object.keys(orderOpenCodeVariants(variants))).toEqual([
-      'max',
-      'xhigh',
-      'high',
-      'medium',
-      'low',
-      'minimal',
       'none',
+      'minimal',
+      'low',
+      'medium',
+      'high',
+      'xhigh',
+      'max',
     ]);
     expect(Object.keys(variants)).toEqual([
       'max',
@@ -47,7 +47,7 @@ describe('orderOpenCodeVariants', () => {
       Object.keys(
         orderOpenCodeVariants({ high: variant, medium: variant, instant: variant, low: variant })
       )
-    ).toEqual(['instant', 'high', 'medium', 'low']);
+    ).toEqual(['instant', 'low', 'medium', 'high']);
   });
 
   it('orders arbitrary and mixed variant names alphabetically', () => {

--- a/apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/order-opencode-variants.ts
@@ -1,9 +1,9 @@
 import type { OpenCodeSettings } from '@kilocode/db/schema-types';
 
 const VARIANT_ORDERS = [
-  ['max', 'xhigh', 'high', 'medium', 'low', 'minimal', 'none'],
+  ['none', 'minimal', 'low', 'medium', 'high', 'xhigh', 'max'],
   ['instant', 'thinking'],
-  ['instant', 'high', 'medium', 'low'],
+  ['instant', 'low', 'medium', 'high'],
 ] as const;
 
 function compareNames(a: string, b: string): number {

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -207,10 +207,10 @@ describe('parseModelsDevProviderModels', () => {
     );
 
     expect(models[0].variants).toEqual({
-      high: { reasoning: { enabled: true, effort: 'high' }, verbosity: 'high' },
-      medium: { reasoning: { enabled: true, effort: 'medium' }, verbosity: 'medium' },
-      low: { reasoning: { enabled: true, effort: 'low' }, verbosity: 'low' },
       minimal: { reasoning: { enabled: true, effort: 'minimal' } },
+      low: { reasoning: { enabled: true, effort: 'low' }, verbosity: 'low' },
+      medium: { reasoning: { enabled: true, effort: 'medium' }, verbosity: 'medium' },
+      high: { reasoning: { enabled: true, effort: 'high' }, verbosity: 'high' },
       xhigh: { reasoning: { enabled: true, effort: 'xhigh' }, verbosity: 'xhigh' },
     });
   });

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, jest, test } from '@jest/globals';
+import type { ReasoningEffort } from '@kilocode/db/schema-types';
+
+describe('getOpenRouterDerivedModelVariants', () => {
+  test('reverses OpenRouter efforts and places none first', async () => {
+    const supportedEfforts: ReasoningEffort[] = ['max', 'high', 'medium', 'low', 'minimal'];
+    jest.resetModules();
+    jest.doMock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
+      getOpenRouterModelsMetadataFromDatabase: jest.fn(async () => ({
+        'vendor/model': {
+          id: 'vendor/model',
+          name: 'Model',
+          endpoints: [],
+          reasoning: { mandatory: false, supported_efforts: supportedEfforts },
+        },
+      })),
+    }));
+    const { getOpenRouterDerivedModelVariants } =
+      await import('@/lib/ai-gateway/providers/model-settings');
+
+    const variants = await getOpenRouterDerivedModelVariants('vendor/model');
+
+    expect(Object.keys(variants ?? {})).toEqual([
+      'none',
+      'minimal',
+      'low',
+      'medium',
+      'high',
+      'max',
+    ]);
+    expect(supportedEfforts).toEqual(['max', 'high', 'medium', 'low', 'minimal']);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -32,15 +32,17 @@ export async function getOpenRouterDerivedModelVariants(
     return reasoning.mandatory ? REASONING_VARIANTS_THINKING_ONLY : REASONING_VARIANTS_BINARY;
   }
   const useAnthropicProvider = getAiSdkProvider(model, null) === 'anthropic';
-  const variants: [string, OpenCodeVariant][] = reasoning.supported_efforts.map(effort => [
-    effort,
-    {
-      reasoning: { enabled: true, effort },
-      verbosity: useAnthropicProvider ? VerbositySchema.safeParse(effort).data : undefined,
-    },
-  ]);
-  if (!reasoning.mandatory) {
-    variants.push(['none', { reasoning: { enabled: false, effort: 'none' } }]);
+  const variants: [string, OpenCodeVariant][] = reasoning.supported_efforts
+    .toReversed()
+    .map(effort => [
+      effort,
+      {
+        reasoning: { enabled: effort !== 'none', effort },
+        verbosity: useAnthropicProvider ? VerbositySchema.safeParse(effort).data : undefined,
+      },
+    ]);
+  if (!reasoning.mandatory && !variants.some(([effort]) => effort === 'none')) {
+    variants.unshift(['none', { reasoning: { enabled: false, effort: 'none' } }]);
   }
   return Object.fromEntries(variants);
 }

--- a/apps/web/src/lib/ai-gateway/providers/variants.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/variants.test.ts
@@ -27,14 +27,20 @@ describe('getFallbackModelVariants', () => {
     });
   });
 
-  test('orders OpenAI variants from most to least intensive', () => {
-    expect(Object.keys(getFallbackModelVariants('openai/gpt-5.6-sol') ?? {})).toEqual([
-      'max',
-      'xhigh',
-      'high',
-      'medium',
-      'low',
-      'none',
-    ]);
+  test.each([
+    ['anthropic/claude-opus-5', ['none', 'low', 'medium', 'high', 'xhigh', 'max']],
+    ['deepseek/deepseek-v4', ['none', 'low', 'high', 'max']],
+    ['google/gemini-3.1-pro-preview', ['minimal', 'low', 'medium', 'high']],
+    ['z-ai/glm-5.2', ['none', 'high', 'xhigh']],
+    ['xai/grok-4.5', ['low', 'medium', 'high']],
+    ['moonshotai/kimi-k3', ['none', 'low', 'high', 'max']],
+    ['inception/mercury-2', ['instant', 'low', 'medium', 'high']],
+    ['meta/muse-1', ['none', 'minimal', 'low', 'medium', 'high', 'xhigh']],
+    ['nvidia/nemotron-3-super-120b-a12b:free', ['none', 'medium', 'high']],
+    ['openai/gpt-5.6-sol', ['none', 'low', 'medium', 'high', 'xhigh', 'max']],
+    ['qwen/qwen3.8', ['minimal', 'low', 'medium', 'high', 'xhigh']],
+    ['stepfun/step-3.7-flash', ['low', 'medium', 'high']],
+  ])('orders fallback variants from least to most intensive for %s', (model, expected) => {
+    expect(Object.keys(getFallbackModelVariants(model) ?? {})).toEqual(expected);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/variants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/variants.ts
@@ -22,75 +22,68 @@ export const REASONING_VARIANTS_BINARY = {
 } as const;
 
 export const REASONING_VARIANTS_LOW_MEDIUM_HIGH = {
-  high: { reasoning: { enabled: true, effort: 'high' } },
-  medium: { reasoning: { enabled: true, effort: 'medium' } },
   low: { reasoning: { enabled: true, effort: 'low' } },
+  medium: { reasoning: { enabled: true, effort: 'medium' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
 } as const;
 
-export const REASONING_VARIANTS_MAX_HIGH_LOW_NONE = {
-  max: { reasoning: { enabled: true, effort: 'max' } },
-  high: { reasoning: { enabled: true, effort: 'high' } },
-  low: { reasoning: { enabled: true, effort: 'low' } },
-  none: { reasoning: { enabled: false, effort: 'none' } },
-} as const;
-
-export const REASONING_VARIANTS_XHIGH_HIGH_MEDIUM_LOW_MINIMAL = {
-  xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
-  high: { reasoning: { enabled: true, effort: 'high' } },
-  medium: { reasoning: { enabled: true, effort: 'medium' } },
-  low: { reasoning: { enabled: true, effort: 'low' } },
+export const REASONING_VARIANTS_MINIMAL_LOW_MEDIUM_HIGH_XHIGH = {
   minimal: { reasoning: { enabled: true, effort: 'minimal' } },
+  low: { reasoning: { enabled: true, effort: 'low' } },
+  medium: { reasoning: { enabled: true, effort: 'medium' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
+  xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
 } as const;
 
 export const REASONING_VARIANTS_MINIMAL_LOW_MEDIUM_HIGH = {
-  high: { reasoning: { enabled: true, effort: 'high' } },
-  medium: { reasoning: { enabled: true, effort: 'medium' } },
-  low: { reasoning: { enabled: true, effort: 'low' } },
   minimal: { reasoning: { enabled: true, effort: 'minimal' } },
+  low: { reasoning: { enabled: true, effort: 'low' } },
+  medium: { reasoning: { enabled: true, effort: 'medium' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
 } as const;
 
 export const REASONING_VARIANTS_NONE_MINIMAL_LOW_MEDIUM_HIGH_XHIGH = {
-  xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
-  high: { reasoning: { enabled: true, effort: 'high' } },
-  medium: { reasoning: { enabled: true, effort: 'medium' } },
-  low: { reasoning: { enabled: true, effort: 'low' } },
-  minimal: { reasoning: { enabled: true, effort: 'minimal' } },
   none: { reasoning: { enabled: false, effort: 'none' } },
+  minimal: { reasoning: { enabled: true, effort: 'minimal' } },
+  low: { reasoning: { enabled: true, effort: 'low' } },
+  medium: { reasoning: { enabled: true, effort: 'medium' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
+  xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
 } as const;
 
 export const REASONING_VARIANTS_NONE_HIGH_XHIGH = {
-  xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
-  high: { reasoning: { enabled: true, effort: 'high' } },
   none: { reasoning: { enabled: false, effort: 'none' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
+  xhigh: { reasoning: { enabled: true, effort: 'xhigh' } },
 } as const;
 
 export const REASONING_VARIANTS_NONE_MEDIUM_HIGH = {
-  high: { reasoning: { enabled: true, effort: 'high' } },
-  medium: { reasoning: { enabled: true, effort: 'medium' } },
   none: { reasoning: { enabled: false, effort: 'none' } },
+  medium: { reasoning: { enabled: true, effort: 'medium' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
 } as const;
 
 export const REASONING_VARIANTS_NONE_LOW_HIGH_MAX = {
-  max: { reasoning: { enabled: true, effort: 'max' } },
-  high: { reasoning: { enabled: true, effort: 'high' } },
-  low: { reasoning: { enabled: true, effort: 'low' } },
   none: { reasoning: { enabled: false, effort: 'none' } },
+  low: { reasoning: { enabled: true, effort: 'low' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
+  max: { reasoning: { enabled: true, effort: 'max' } },
 } as const;
 
 const REASONING_VARIANTS_CLAUDE = {
-  max: { reasoning: { enabled: true, effort: 'max' }, verbosity: 'max' },
-  xhigh: { reasoning: { enabled: true, effort: 'xhigh' }, verbosity: 'xhigh' },
-  high: { reasoning: { enabled: true, effort: 'high' }, verbosity: 'high' },
-  medium: { reasoning: { enabled: true, effort: 'medium' }, verbosity: 'medium' },
-  low: { reasoning: { enabled: true, effort: 'low' }, verbosity: 'low' },
   none: { reasoning: { enabled: false, effort: 'none' } },
+  low: { reasoning: { enabled: true, effort: 'low' }, verbosity: 'low' },
+  medium: { reasoning: { enabled: true, effort: 'medium' }, verbosity: 'medium' },
+  high: { reasoning: { enabled: true, effort: 'high' }, verbosity: 'high' },
+  xhigh: { reasoning: { enabled: true, effort: 'xhigh' }, verbosity: 'xhigh' },
+  max: { reasoning: { enabled: true, effort: 'max' }, verbosity: 'max' },
 } as const;
 
 export const REASONING_VARIANTS_INSTANT_LOW_MEDIUM_HIGH = {
   instant: { reasoning: { enabled: false, effort: 'none' } },
-  high: { reasoning: { enabled: true, effort: 'high' } },
-  medium: { reasoning: { enabled: true, effort: 'medium' } },
   low: { reasoning: { enabled: true, effort: 'low' } },
+  medium: { reasoning: { enabled: true, effort: 'medium' } },
+  high: { reasoning: { enabled: true, effort: 'high' } },
 } as const;
 
 export function getFallbackModelVariants(model: string): OpenCodeSettings['variants'] {
@@ -113,7 +106,7 @@ export function getFallbackModelVariants(model: string): OpenCodeSettings['varia
     return REASONING_VARIANTS_LOW_MEDIUM_HIGH;
   }
   if (isKimiModel(model)) {
-    return REASONING_VARIANTS_MAX_HIGH_LOW_NONE;
+    return REASONING_VARIANTS_NONE_LOW_HIGH_MAX;
   }
   if (model.includes('laguna')) {
     return REASONING_VARIANTS_BINARY;
@@ -143,12 +136,11 @@ export function getFallbackModelVariants(model: string): OpenCodeSettings['varia
     return Object.fromEntries(
       ReasoningEffortSchema.options
         .filter(e => e !== 'minimal')
-        .reverse()
         .map(effort => [effort, { reasoning: { enabled: effort !== 'none', effort } }])
     );
   }
   if (isQwenModel(model)) {
-    return REASONING_VARIANTS_XHIGH_HIGH_MEDIUM_LOW_MINIMAL;
+    return REASONING_VARIANTS_MINIMAL_LOW_MEDIUM_HIGH_XHIGH;
   }
   if (isStepModel(model)) {
     return REASONING_VARIANTS_LOW_MEDIUM_HIGH;


### PR DESCRIPTION
## Summary
- order fallback reasoning variants from `none` / `minimal` through `max`
- reverse OpenRouter-reported reasoning efforts and keep `none` first for optional reasoning
- align custom OpenCode variant ordering with Kilo clients and OpenCode
- add focused coverage for fallback and OpenRouter-derived ordering

## Validation
- `pnpm --filter web test --runInBand src/lib/ai-gateway/providers/variants.test.ts src/lib/ai-gateway/providers/model-settings.test.ts src/lib/ai-gateway/custom-llm/order-opencode-variants.test.ts src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts`
- `pnpm --filter web run typecheck`
- `pnpm exec oxlint --config .oxlintrc.json <changed files>`
- `pnpm format`
- `pnpm exec oxfmt --list-different <changed files>`
- `git diff --check`

All pnpm commands emitted the existing engine warning because the local runtime is Node 26 while the repository requires Node 24.