### PR TITLE
fix(ai-gateway): gate fallback reasoning variants

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -244,7 +244,7 @@ async function resolveEfficientDecisionModel(
   // `variant` is only on the benchmark decision branch of the discriminated
   // union; coding-plan defaults never carry it.
   if ('variant' in decision && decision.variant != null) {
-    const variants = await getModelVariants(decision.model);
+    const variants = await getModelVariants(decision.model, true);
     const variantSettings: OpenCodeVariant | undefined = variants?.[decision.variant];
     if (!variantSettings) {
       return null;

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.test.ts
@@ -124,7 +124,7 @@ describe('getDirectByokModel', () => {
     });
   });
 
-  test('falls back to model-name variants when synced variants are unavailable', async () => {
+  test('does not fall back to model-name variants when reasoning is unsupported', async () => {
     const { getDirectByokModelsForUser } = await loadDirectByokModule();
     const { getBYOKforUser } = await import('@/lib/ai-gateway/byok');
     const { getFallbackModelVariants } = await import('@/lib/ai-gateway/providers/variants');
@@ -139,8 +139,7 @@ describe('getDirectByokModel', () => {
     expect(models[0].opencode.variants).toEqual({
       high: { reasoning: { enabled: true, effort: 'high' } },
     });
-    expect(models[1].opencode.variants).toBe(fallback);
-    expect(getFallbackModelVariants).toHaveBeenCalledTimes(1);
-    expect(getFallbackModelVariants).toHaveBeenCalledWith('chutes-byok/non-reasoning-model');
+    expect(models[1].opencode.variants).toBeUndefined();
+    expect(getFallbackModelVariants).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/index.ts
@@ -63,7 +63,9 @@ function convertModel(
     hasUserByokAvailable: true,
     opencode: {
       ai_sdk_provider: getAiSdkProvider(id, provider.id) ?? provider.default_ai_sdk_provider,
-      variants: model.variants ?? getFallbackModelVariants(id),
+      variants:
+        model.variants ??
+        (model.flags?.includes('reasoning') ? getFallbackModelVariants(id) : undefined),
     } satisfies OpenCodeSettings,
   };
 }

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts
@@ -80,7 +80,7 @@ describe('parseModelsDevProviderModels', () => {
             reasoning_options: [{ type: 'toggle' }],
           },
           beta: {
-            id: 'beta',
+            id: 'claude-beta',
             status: 'beta',
             reasoning: false,
           },
@@ -130,7 +130,7 @@ describe('parseModelsDevProviderModels', () => {
         },
       },
       {
-        id: 'beta',
+        id: 'claude-beta',
         name: undefined,
         context_length: undefined,
         max_completion_tokens: undefined,

--- a/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
+++ b/apps/web/src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.ts
@@ -196,7 +196,7 @@ export function parseModelsDevProviderModels(
       const aiSdkProvider = getAiSdkProvider(modelId, providerId);
       const variants =
         modelsDevReasoningOptionsToVariants(model.reasoning_options ?? []) ??
-        getFallbackModelVariants(modelId);
+        (model.reasoning ? getFallbackModelVariants(modelId) : undefined);
       return {
         id: model.id,
         name: shortenDisplayName(model.name),

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -45,8 +45,14 @@ export async function getOpenRouterDerivedModelVariants(
   return Object.fromEntries(variants);
 }
 
-export async function getModelVariants(model: string): Promise<OpenCodeSettings['variants']> {
-  return (await getOpenRouterDerivedModelVariants(model)) ?? getFallbackModelVariants(model);
+export async function getModelVariants(
+  model: string,
+  allowFallbackVariants = true
+): Promise<OpenCodeSettings['variants']> {
+  return (
+    (await getOpenRouterDerivedModelVariants(model)) ??
+    (allowFallbackVariants ? getFallbackModelVariants(model) : undefined)
+  );
 }
 
 export function getAiSdkProvider(
@@ -81,10 +87,11 @@ function getOpenCodePrompt(model: string): OpenCodePrompt | undefined {
 }
 
 export async function getGatewayOpenCodeSettings(
-  model: string
+  model: string,
+  allowFallbackVariants = true
 ): Promise<OpenCodeSettings | undefined> {
   const ai_sdk_provider = getAiSdkProvider(model, null);
-  const variants = await getModelVariants(model);
+  const variants = await getModelVariants(model, allowFallbackVariants);
   const prompt = getOpenCodePrompt(model);
   return { ai_sdk_provider, variants, prompt };
 }

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -47,7 +47,7 @@ export async function getOpenRouterDerivedModelVariants(
 
 export async function getModelVariants(
   model: string,
-  allowFallbackVariants = true
+  allowFallbackVariants: boolean
 ): Promise<OpenCodeSettings['variants']> {
   return (
     (await getOpenRouterDerivedModelVariants(model)) ??
@@ -88,7 +88,7 @@ function getOpenCodePrompt(model: string): OpenCodePrompt | undefined {
 
 export async function getGatewayOpenCodeSettings(
   model: string,
-  allowFallbackVariants = true
+  allowFallbackVariants: boolean
 ): Promise<OpenCodeSettings | undefined> {
   const ai_sdk_provider = getAiSdkProvider(model, null);
   const variants = await getModelVariants(model, allowFallbackVariants);

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -223,6 +223,42 @@ describe('auto models', () => {
   });
 });
 
+describe('reasoning variants', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('only adds fallback variants when reasoning is supported', async () => {
+    const unsupportedId = 'anthropic/claude-without-reasoning';
+    const supportedId = 'anthropic/claude-with-reasoning';
+    global.fetch = jest.fn(() =>
+      Promise.resolve(
+        createMockResponse({
+          jsonData: {
+            data: [
+              buildModel({
+                id: unsupportedId,
+                supported_parameters: ['max_tokens', 'tools'],
+              }),
+              buildModel({
+                id: supportedId,
+                supported_parameters: ['max_tokens', 'tools', 'reasoning'],
+              }),
+            ],
+          },
+        })
+      )
+    ) as unknown as typeof fetch;
+
+    const models = await getEnhancedOpenRouterModels();
+
+    expect(
+      models.data.find(model => model.id === unsupportedId)?.opencode?.variants
+    ).toBeUndefined();
+    expect(models.data.find(model => model.id === supportedId)?.opencode?.variants).toBeDefined();
+  });
+});
+
 describe('disabled paid Kilo-exclusive model fallback', () => {
   beforeEach(() => {
     kiloExclusiveModels.push(disabledPaidModel);

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -165,7 +165,12 @@ async function enhancedModelList(models: OpenRouterModel[]) {
           preferredIndex: preferredIndex >= 0 ? preferredIndex : undefined,
           isFree: model.isFree ?? isFree,
           mayTrainOnYourPrompts: model.mayTrainOnYourPrompts ?? isFree,
-          opencode: model.opencode ?? (await getGatewayOpenCodeSettings(model.id)),
+          opencode:
+            model.opencode ??
+            (await getGatewayOpenCodeSettings(
+              model.id,
+              model.supported_parameters?.includes('reasoning') ?? false
+            )),
           architecture: addPdf
             ? {
                 ...model.architecture,


### PR DESCRIPTION
## Summary
- only infer OpenRouter fallback variants when `reasoning` is advertised in `supported_parameters`
- preserve variants derived from OpenRouter metadata
- apply the same fallback guard to direct-BYOK model conversion and models.dev synchronization

## Verification
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/providers/openrouter/index.test.ts src/lib/ai-gateway/providers/direct-byok/index.test.ts src/lib/ai-gateway/providers/direct-byok/sync-direct-byok.test.ts`
- `pnpm --filter web typecheck`
- targeted `oxlint`, `oxfmt --check`, and `git diff --check`