### PR TITLE
feat(seed): add app:github-integration topic

### DIFF
--- a/dev/seed/app/github-integration.ts
+++ b/dev/seed/app/github-integration.ts
@@ -43,8 +43,14 @@ type GitHubIntegrationOptions = {
 };
 
 function takeFlagValue(args: string[], index: number, flag: string): string {
-  const inline = args[index].slice(flag.length + 1).trim();
-  if (inline) return inline;
+  const arg = args[index];
+  if (arg.length > flag.length && arg[flag.length] === '=') {
+    const inline = arg.slice(flag.length + 1).trim();
+    if (!inline) {
+      throw new Error(`${flag} requires a value`);
+    }
+    return inline;
+  }
 
   const next = args[index + 1];
   if (next === undefined || next.startsWith('--')) {

--- a/dev/seed/app/github-integration.ts
+++ b/dev/seed/app/github-integration.ts
@@ -1,0 +1,283 @@
+import { kilocode_users, platform_integrations } from '@kilocode/db/schema';
+import { and, eq } from 'drizzle-orm';
+
+import { getSeedDb } from '../lib/db';
+import {
+  fetchSeedGitHubInstallationDetails,
+  fetchSeedGitHubRepositories,
+  type SeedGitHubAppType,
+} from '../lib/github-app';
+import type { SeedResult } from '../index';
+
+export const usage =
+  '<user-id> --installation-id=<id> [--repository=<owner/repo>] [--app-type=standard|lite]';
+
+function printUsage(): void {
+  console.log(`Usage: pnpm dev:seed app:github-integration ${usage}`);
+  console.log('');
+  console.log('Connects a local development user to an existing GitHub App installation by');
+  console.log('upserting an active user-owned platform_integrations row. The installation and');
+  console.log('the optional repository are validated against GitHub with the configured app');
+  console.log('credentials (GITHUB_APP_ID/GITHUB_APP_PRIVATE_KEY, or the GITHUB_LITE_APP_* pair).');
+  console.log('No private keys or tokens are printed or stored; git-token-service mints the');
+  console.log('installation token at runtime.');
+  console.log('');
+  console.log('Options:');
+  console.log('  --installation-id=<id>     GitHub App installation id (required)');
+  console.log(
+    '  --repository=<owner/repo>  Repository that must be accessible to the installation'
+  );
+  console.log('  --app-type=standard|lite   GitHub App to validate against (default: standard)');
+  console.log('');
+  console.log('Examples:');
+  console.log('  pnpm dev:seed app:github-integration <user-id> --installation-id 107732005 \\');
+  console.log('    --repository na2-org/hi-how-are-you');
+  console.log('  pnpm dev:seed app:github-integration <user-id> --installation-id=107732005');
+}
+
+type GitHubIntegrationOptions = {
+  userId: string;
+  installationId: string;
+  repository: string | null;
+  appType: SeedGitHubAppType;
+};
+
+function takeFlagValue(args: string[], index: number, flag: string): string {
+  const inline = args[index].slice(flag.length + 1).trim();
+  if (inline) return inline;
+
+  const next = args[index + 1];
+  if (next === undefined || next.startsWith('--')) {
+    throw new Error(`${flag} requires a value`);
+  }
+  return next.trim();
+}
+
+function parseArgs(args: string[]): GitHubIntegrationOptions {
+  let userId: string | null = null;
+  let installationId: string | null = null;
+  let repository: string | null = null;
+  let appType: SeedGitHubAppType = 'standard';
+
+  const VALUE_FLAGS = ['--installation-id', '--repository', '--app-type'];
+
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index];
+    const flag = VALUE_FLAGS.find(name => arg === name || arg.startsWith(`${name}=`));
+
+    if (flag) {
+      const value = takeFlagValue(args, index, flag);
+      if (!value) {
+        throw new Error(`${flag} requires a value`);
+      }
+      if (arg === flag) index++; // value came from the next argv slot
+
+      if (flag === '--installation-id') {
+        if (!/^\d+$/.test(value)) {
+          throw new Error('--installation-id must be a numeric GitHub installation id');
+        }
+        installationId = value;
+      } else if (flag === '--repository') {
+        if (!/^[^\s/]+\/[^\s/]+$/.test(value)) {
+          throw new Error('--repository must look like owner/repo');
+        }
+        repository = value;
+      } else {
+        if (value !== 'standard' && value !== 'lite') {
+          throw new Error('--app-type must be standard or lite');
+        }
+        appType = value;
+      }
+      continue;
+    }
+
+    if (arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+
+    if (userId !== null) {
+      throw new Error(`Unexpected positional argument: ${arg}`);
+    }
+    userId = arg.trim();
+  }
+
+  if (!userId) {
+    printUsage();
+    throw new Error('user-id is required');
+  }
+  if (!installationId) {
+    printUsage();
+    throw new Error('--installation-id is required');
+  }
+
+  return { userId, installationId, repository, appType };
+}
+
+export async function run(...args: string[]): Promise<SeedResult | void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const options = parseArgs(args);
+  const db = getSeedDb();
+
+  const [user] = await db
+    .select({ id: kilocode_users.id, email: kilocode_users.google_user_email })
+    .from(kilocode_users)
+    .where(eq(kilocode_users.id, options.userId))
+    .limit(1);
+
+  if (!user) {
+    throw new Error(
+      `User ${options.userId} was not found. Create one first: ` +
+        `pnpm dev:seed app:create-user "Cloud Agent Test" cloud-agent-test@example.com`
+    );
+  }
+
+  // Validate against GitHub before writing anything, mirroring the dev-only
+  // devAddInstallation flow in apps/web/src/routers/github-apps-router.ts.
+  const details = await fetchSeedGitHubInstallationDetails(options.installationId, options.appType);
+  const repositories = await fetchSeedGitHubRepositories(options.installationId, options.appType);
+
+  let canonicalRepository: string | null = null;
+  if (options.repository) {
+    const requested = options.repository.toLowerCase();
+    const match = repositories.find(repo => repo.full_name.toLowerCase() === requested);
+    if (!match) {
+      const sample = repositories
+        .slice(0, 5)
+        .map(repo => repo.full_name)
+        .join(', ');
+      throw new Error(
+        `Repository ${options.repository} is not accessible to installation ${options.installationId} ` +
+          `(${details.accountLogin}, repository access: ${details.repositorySelection}, ` +
+          `${repositories.length} repositories${sample ? `: ${sample}${repositories.length > 5 ? ', …' : ''}` : ''}). ` +
+          `Grant the app access to the repository on GitHub first.`
+      );
+    }
+    canonicalRepository = match.full_name;
+  }
+
+  // Upsert replicating upsertPlatformIntegrationForOwner from
+  // apps/web/src/lib/integrations/db/platform-integrations.ts (GitHub two-step
+  // pattern): insert against the global (platform, github_app_type,
+  // platform_installation_id) unique index, then re-read on conflict to allow a
+  // same-owner refresh and refuse cross-owner claims.
+  const nowIso = new Date().toISOString();
+  const values = {
+    owned_by_user_id: user.id,
+    owned_by_organization_id: null,
+    platform: 'github',
+    integration_type: 'app',
+    platform_installation_id: options.installationId,
+    platform_account_id: String(details.accountId),
+    platform_account_login: details.accountLogin,
+    permissions: details.permissions,
+    scopes: details.events,
+    repository_access: details.repositorySelection,
+    integration_status: 'active',
+    repositories,
+    installed_at: details.createdAt,
+    github_app_type: options.appType,
+    repositories_synced_at: nowIso,
+  } satisfies typeof platform_integrations.$inferInsert;
+
+  const inserted = await db
+    .insert(platform_integrations)
+    .values(values)
+    .onConflictDoNothing()
+    .returning({ id: platform_integrations.id });
+
+  let integrationId: string;
+  let wasInserted: boolean;
+
+  if (inserted.length > 0) {
+    const [row] = inserted;
+    integrationId = row.id;
+    wasInserted = true;
+  } else {
+    const [existing] = await db
+      .select({
+        id: platform_integrations.id,
+        ownedByUserId: platform_integrations.owned_by_user_id,
+        ownedByOrganizationId: platform_integrations.owned_by_organization_id,
+      })
+      .from(platform_integrations)
+      .where(
+        and(
+          eq(platform_integrations.platform, 'github'),
+          eq(platform_integrations.github_app_type, options.appType),
+          eq(platform_integrations.platform_installation_id, options.installationId)
+        )
+      )
+      .limit(1);
+
+    if (!existing) {
+      // Edge case: a concurrent delete blocked the insert without leaving a row
+      // to re-read. Retry so the database enforces uniqueness (or throws).
+      const [retried] = await db
+        .insert(platform_integrations)
+        .values(values)
+        .returning({ id: platform_integrations.id });
+      integrationId = retried.id;
+      wasInserted = true;
+    } else if (existing.ownedByUserId === user.id && existing.ownedByOrganizationId === null) {
+      await db
+        .update(platform_integrations)
+        .set({
+          platform_account_id: values.platform_account_id,
+          platform_account_login: values.platform_account_login,
+          permissions: values.permissions,
+          scopes: values.scopes,
+          repository_access: values.repository_access,
+          integration_status: 'active',
+          repositories: values.repositories,
+          github_app_type: options.appType,
+          auth_invalid_at: null,
+          auth_invalid_reason: null,
+          repositories_synced_at: nowIso,
+          updated_at: nowIso,
+        })
+        .where(eq(platform_integrations.id, existing.id));
+      integrationId = existing.id;
+      wasInserted = false;
+    } else {
+      const ownerHint = existing.ownedByUserId
+        ? `user ${existing.ownedByUserId}`
+        : `organization ${existing.ownedByOrganizationId ?? 'unknown'}`;
+      throw new Error(
+        `This GitHub installation is already claimed by another account (${ownerHint}). ` +
+          `Delete that platform_integrations row first, or seed the integration for the owning account.`
+      );
+    }
+  }
+
+  console.log('');
+  console.log(
+    'This fixture represents: a user-owned GitHub App integration (platform_integrations row)'
+  );
+  console.log('for local Cloud Agent web testing.');
+  console.log(
+    'Note: no keys or tokens were stored; git-token-service mints the installation token at runtime.'
+  );
+  if (canonicalRepository) {
+    console.log(
+      `Suggested next step: start a Cloud Agent session against ${canonicalRepository} from the web app.`
+    );
+  }
+
+  return {
+    userId: user.id,
+    userEmail: user.email,
+    integrationId,
+    inserted: wasInserted,
+    installationId: options.installationId,
+    appType: options.appType,
+    accountLogin: details.accountLogin,
+    accountId: String(details.accountId),
+    repositoryAccess: details.repositorySelection,
+    repositoryCount: repositories.length,
+    repository: canonicalRepository,
+  };
+}

--- a/dev/seed/lib/github-app.ts
+++ b/dev/seed/lib/github-app.ts
@@ -1,0 +1,154 @@
+/**
+ * Minimal GitHub App validation helpers for dev seeds.
+ *
+ * Replicates the two read-only calls the web app makes in
+ * apps/web/src/lib/integrations/platforms/github/adapter.ts
+ * (`fetchGitHubInstallationDetails` / `fetchGitHubRepositories`) so a seed can
+ * confirm an installation exists and which repositories it can access before
+ * writing a `platform_integrations` row. Seed topics must not import from
+ * `apps/web/src`, so keep this file self-contained.
+ *
+ * Credentials come from the same env vars the web app uses
+ * (`GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY`, or the `GITHUB_LITE_APP_*` pair),
+ * loaded via `apps/web/src/lib/load-env` through `lib/db.ts`. The private key
+ * and the installation token minted below never leave this process: they are
+ * not logged, returned, or persisted.
+ */
+import { createAppAuth } from '@octokit/auth-app';
+import { Octokit } from '@octokit/rest';
+
+export type SeedGitHubAppType = 'standard' | 'lite';
+
+export type SeedGitHubInstallationDetails = {
+  accountId: number;
+  accountLogin: string;
+  repositorySelection: string;
+  permissions: Record<string, string>;
+  events: string[];
+  createdAt: string;
+};
+
+export type SeedGitHubRepository = {
+  id: number;
+  name: string;
+  full_name: string;
+  private: boolean;
+};
+
+function getSeedGitHubAppCredentials(appType: SeedGitHubAppType): {
+  appId: string;
+  privateKey: string;
+} {
+  const idVar = appType === 'lite' ? 'GITHUB_LITE_APP_ID' : 'GITHUB_APP_ID';
+  const keyVar = appType === 'lite' ? 'GITHUB_LITE_APP_PRIVATE_KEY' : 'GITHUB_APP_PRIVATE_KEY';
+  const appId = process.env[idVar] ?? '';
+  const privateKey = process.env[keyVar] ?? '';
+
+  if (!appId || !privateKey) {
+    throw new Error(
+      `${idVar} and ${keyVar} must both be set. Copy .env.local from the main worktree ` +
+        `(or run scripts/worktree-prepare.sh) so dev seeds can validate installations with GitHub.`
+    );
+  }
+
+  return { appId, privateKey };
+}
+
+function getErrorStatus(error: unknown): number | null {
+  if (typeof error !== 'object' || error === null || !('status' in error)) {
+    return null;
+  }
+  const { status } = error;
+  return typeof status === 'number' ? status : null;
+}
+
+/**
+ * Fetches installation details using app-level auth.
+ * Throws a clear error when the installation does not exist for the configured app.
+ */
+export async function fetchSeedGitHubInstallationDetails(
+  installationId: string,
+  appType: SeedGitHubAppType
+): Promise<SeedGitHubInstallationDetails> {
+  const { appId, privateKey } = getSeedGitHubAppCredentials(appType);
+  const auth = createAppAuth({ appId, privateKey });
+  const { token } = await auth({ type: 'app' });
+  const octokit = new Octokit({ auth: token });
+
+  let data;
+  try {
+    ({ data } = await octokit.apps.getInstallation({
+      installation_id: Number.parseInt(installationId, 10),
+    }));
+  } catch (error) {
+    if (getErrorStatus(error) === 404) {
+      throw new Error(
+        `GitHub installation ${installationId} was not found for the configured ${appType} app. ` +
+          `Check --installation-id and make sure the installation belongs to the app from ${appType === 'lite' ? 'GITHUB_LITE_APP_ID' : 'GITHUB_APP_ID'}.`
+      );
+    }
+    throw error;
+  }
+
+  const account = data.account ?? null;
+  const accountId = account && typeof account.id === 'number' ? account.id : 0;
+  const accountLogin =
+    account && 'login' in account && typeof account.login === 'string' ? account.login : '';
+
+  if (!accountId || !accountLogin) {
+    throw new Error(
+      `GitHub installation ${installationId} has no usable account identity; refusing to seed it.`
+    );
+  }
+
+  return {
+    accountId,
+    accountLogin,
+    repositorySelection: data.repository_selection ?? 'all',
+    permissions: data.permissions ?? {},
+    events: data.events ?? [],
+    createdAt: data.created_at,
+  };
+}
+
+/**
+ * Lists non-archived repositories accessible to the installation.
+ * Mints an installation access token in memory; the token is used only for
+ * this call and is never logged or stored.
+ */
+export async function fetchSeedGitHubRepositories(
+  installationId: string,
+  appType: SeedGitHubAppType
+): Promise<SeedGitHubRepository[]> {
+  const { appId, privateKey } = getSeedGitHubAppCredentials(appType);
+  const auth = createAppAuth({ appId, privateKey, installationId });
+  const { token } = await auth({ type: 'installation' });
+  const octokit = new Octokit({ auth: token });
+
+  const repositories: SeedGitHubRepository[] = [];
+  const perPage = 100;
+  let page = 1;
+
+  while (true) {
+    const { data } = await octokit.apps.listReposAccessibleToInstallation({
+      per_page: perPage,
+      page,
+    });
+
+    repositories.push(
+      ...data.repositories
+        .filter(repo => !repo.archived)
+        .map(repo => ({
+          id: repo.id,
+          name: repo.name,
+          full_name: repo.full_name,
+          private: repo.private,
+        }))
+    );
+
+    if (data.repositories.length < perPage) break;
+    page++;
+  }
+
+  return repositories;
+}


### PR DESCRIPTION
## Summary

Adds an `app:github-integration` topic to the `pnpm dev:seed` runner so a fresh worktree can create and fund a test user, then connect it to an existing GitHub App installation for local Cloud Agent web testing:

```bash
pnpm dev:seed app:create-user "Cloud Agent Test" cloud-agent-test@example.com
pnpm dev:seed app:add-credits <USER_ID> 25 --category=dev-seed:cloud-agent-test --idempotent
pnpm dev:seed app:github-integration <USER_ID> \
  --installation-id <INSTALLATION_ID> \
  --repository <OWNER/REPO>
```

- New `dev/seed/lib/github-app.ts`: self-contained GitHub App validation helpers replicating the web adapter's installation-details/repository fetches (seed topics must not import `apps/web/src`). Credentials come from the same `GITHUB_APP_ID`/`GITHUB_APP_PRIVATE_KEY` (or `GITHUB_LITE_APP_*`) env vars the web app uses; the minted installation token never leaves the process.
- New `dev/seed/app/github-integration.ts`: validates the target user exists, validates the installation and optional `--repository` against GitHub, then upserts an active user-owned `platform_integrations` row using the same two-step conflict pattern as `upsertPlatformIntegrationForOwner` (same-owner refresh, cross-owner claim refused with an actionable error).
- The resulting row matches what `git-token-service`'s managed installation lookup requires (active status, installation id, account login, `selected` repository access with the repository cached), so the token service can mint installation tokens at runtime for the seeded user.

## Verification

- Ran the full flow on a fresh worktree DB (migrated): user created, funded, integration seeded against a live GitHub App installation with `selected` repository access; read-only `psql` confirmed the row shape.
- Idempotent rerun returns `inserted: false` with the same `integrationId`.
- Failure paths produce clear errors: unknown user, repository not accessible to the installation, cross-owner claim refusal.
- Verified `--help`, topic listing, and `--json` output; `oxfmt`/`oxlint` clean on the new files.