### PR TITLE
fix(admin): extend request log export timeout

### DIFF
--- a/apps/web/src/app/admin/api/api-request-log/download/route.ts
+++ b/apps/web/src/app/admin/api/api-request-log/download/route.ts
@@ -10,7 +10,7 @@ import { Readable } from 'node:stream';
 // maxDuration the Vercel function was killed mid-stream, producing a ZIP
 // without a central directory record. macOS Archive Utility then refused to
 // extract it ("Error 79 - Inappropriate file type or format").
-export const maxDuration = 300;
+export const maxDuration = 800;
 
 const BATCH_SIZE = 100;
 


### PR DESCRIPTION
## Summary

- increase the API request log download route duration from 300 to 800 seconds
- give large streamed archives more time to write their ZIP central directory before Vercel terminates the function

This is intentionally separate from #5089.

## Verification

- `pnpm --filter web typecheck`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/app/admin/api/api-request-log/download/route.ts`
- `pnpm exec oxfmt apps/web/src/app/admin/api/api-request-log/download/route.ts`
- `git diff --check`

## Visual Changes

None. Server route configuration only.