### PR TITLE
feat(ai-gateway): support Google service account auth

### DIFF
--- a/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
+++ b/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
@@ -151,7 +151,8 @@ export function CustomLlmsContent() {
       <p className="text-muted-foreground">
         Manage custom LLM definitions stored in the <code>custom_llm2</code> table. Each entry has a{' '}
         <code>public_id</code> and a JSON <code>definition</code> that is validated against{' '}
-        <code>CustomLlmDefinitionSchema</code>.
+        <code>CustomLlmDefinitionSchema</code>. Authentication requires either <code>api_key</code>{' '}
+        or a standard Google Cloud service-account JSON key in <code>google_service_account</code>.
       </p>
 
       {isLoading ? (

--- a/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts
@@ -1,0 +1,99 @@
+import { GoogleAuth } from 'google-auth-library';
+import { CustomLlmDefinitionSchema, type GoogleServiceAccountKey } from '@kilocode/db/schema-types';
+import { getGoogleServiceAccountAccessToken } from './google-service-account';
+
+jest.mock('google-auth-library');
+
+const mockGoogleAuth = jest.mocked(GoogleAuth);
+
+function serviceAccount(privateKey: string): GoogleServiceAccountKey {
+  return {
+    type: 'service_account',
+    project_id: 'example-project',
+    private_key_id: 'key-id',
+    private_key: privateKey,
+    client_email: 'custom-llm@example-project.iam.gserviceaccount.com',
+    client_id: '1234567890',
+    auth_uri: 'https://accounts.google.com/o/oauth2/auth',
+    token_uri: 'https://oauth2.googleapis.com/token',
+    auth_provider_x509_cert_url: 'https://www.googleapis.com/oauth2/v1/certs',
+    client_x509_cert_url:
+      'https://www.googleapis.com/robot/v1/metadata/x509/custom-llm%40example-project.iam.gserviceaccount.com',
+  };
+}
+
+const baseDefinition = {
+  internal_id: 'gemini-2.5-pro',
+  display_name: 'Vertex Gemini',
+  context_length: 1_000_000,
+  max_completion_tokens: 65_536,
+  base_url: 'https://us-central1-aiplatform.googleapis.com/v1',
+  organization_ids: ['org-1'],
+};
+
+describe('CustomLlmDefinitionSchema authentication', () => {
+  it('accepts legacy API key authentication', () => {
+    expect(
+      CustomLlmDefinitionSchema.safeParse({ ...baseDefinition, api_key: 'partner-token' }).success
+    ).toBe(true);
+  });
+
+  it('accepts Google Cloud service account authentication', () => {
+    expect(
+      CustomLlmDefinitionSchema.safeParse({
+        ...baseDefinition,
+        google_service_account: serviceAccount('private-key'),
+      }).success
+    ).toBe(true);
+  });
+
+  it('requires exactly one authentication method', () => {
+    expect(CustomLlmDefinitionSchema.safeParse(baseDefinition).success).toBe(false);
+    expect(
+      CustomLlmDefinitionSchema.safeParse({
+        ...baseDefinition,
+        api_key: 'partner-token',
+        google_service_account: serviceAccount('private-key'),
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('getGoogleServiceAccountAccessToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('requests a cloud-platform access token with the supplied credentials', async () => {
+    const getAccessToken = jest.fn(async () => 'gcp-token');
+    mockGoogleAuth.mockImplementation(() => ({ getAccessToken }) as unknown as GoogleAuth);
+    const credentials = serviceAccount('private-key-one');
+
+    await expect(getGoogleServiceAccountAccessToken(credentials)).resolves.toBe('gcp-token');
+    expect(mockGoogleAuth).toHaveBeenCalledWith({
+      credentials,
+      scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    });
+  });
+
+  it('reuses the Google auth client so its access token cache remains effective', async () => {
+    const getAccessToken = jest.fn(async () => 'cached-token');
+    mockGoogleAuth.mockImplementation(() => ({ getAccessToken }) as unknown as GoogleAuth);
+    const credentials = serviceAccount('private-key-two');
+
+    await getGoogleServiceAccountAccessToken(credentials);
+    await getGoogleServiceAccountAccessToken(credentials);
+
+    expect(mockGoogleAuth).toHaveBeenCalledTimes(1);
+    expect(getAccessToken).toHaveBeenCalledTimes(2);
+  });
+
+  it('fails when Google returns no access token', async () => {
+    const getAccessToken = jest.fn(async () => null);
+    mockGoogleAuth.mockImplementation(() => ({ getAccessToken }) as unknown as GoogleAuth);
+
+    await expect(
+      getGoogleServiceAccountAccessToken(serviceAccount('private-key-three'))
+    ).rejects.toThrow('Google service account authentication returned no access token');
+  });
+});

--- a/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.ts
@@ -1,0 +1,35 @@
+import 'server-only';
+
+import type { GoogleServiceAccountKey } from '@kilocode/db/schema-types';
+import { createHash } from 'node:crypto';
+import { GoogleAuth } from 'google-auth-library';
+
+const GOOGLE_CLOUD_PLATFORM_SCOPE = 'https://www.googleapis.com/auth/cloud-platform';
+const authClients = new Map<string, GoogleAuth>();
+
+function getAuthClient(serviceAccount: GoogleServiceAccountKey): GoogleAuth {
+  const cacheKey = createHash('sha256')
+    .update(serviceAccount.client_email)
+    .update('\0')
+    .update(serviceAccount.private_key)
+    .digest('base64url');
+  const cached = authClients.get(cacheKey);
+  if (cached) return cached;
+
+  const auth = new GoogleAuth({
+    credentials: serviceAccount,
+    scopes: [GOOGLE_CLOUD_PLATFORM_SCOPE],
+  });
+  authClients.set(cacheKey, auth);
+  return auth;
+}
+
+export async function getGoogleServiceAccountAccessToken(
+  serviceAccount: GoogleServiceAccountKey
+): Promise<string> {
+  const accessToken = await getAuthClient(serviceAccount).getAccessToken();
+  if (!accessToken) {
+    throw new Error('Google service account authentication returned no access token');
+  }
+  return accessToken;
+}

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -22,6 +22,7 @@ import {
   pickModelExperimentVariant,
   type AllocationSubject,
 } from '@/lib/ai-gateway/experiments/pick-variant';
+import { getGoogleServiceAccountAccessToken } from '@/lib/ai-gateway/custom-llm/google-service-account';
 
 /**
  * Metadata about the experiment that resolved this provider, attached when
@@ -105,6 +106,14 @@ async function checkCustomLlm(
   if (!customLlm || !customLlm.organization_ids.includes(organizationId)) {
     return null;
   }
+  const resolvedCustomLlm =
+    typeof customLlm.api_key === 'string'
+      ? customLlm
+      : {
+          ...customLlm,
+          google_service_account: undefined,
+          api_key: await getGoogleServiceAccountAccessToken(customLlm.google_service_account),
+        };
   return {
     kind: 'provider',
     provider: buildDirectProvider(
@@ -116,7 +125,7 @@ async function checkCustomLlm(
             ? 'responses'
             : 'chat_completions',
       ],
-      customLlm
+      resolvedCustomLlm
     ),
     userByok: null,
     bypassAccessCheck: true,

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1938,15 +1938,40 @@ export const CustomLlmApiConfigSchema = z.object({
 
 export type CustomLlmApiConfig = z.infer<typeof CustomLlmApiConfigSchema>;
 
-export const CustomLlmDefinitionSchema = z
-  .object({
-    display_name: z.string(),
+export const GoogleServiceAccountKeySchema = z.object({
+  type: z.literal('service_account'),
+  project_id: z.string().min(1),
+  private_key_id: z.string().min(1),
+  private_key: z.string().min(1),
+  client_email: z.email(),
+  client_id: z.string().min(1),
+  auth_uri: z.url(),
+  token_uri: z.url(),
+  auth_provider_x509_cert_url: z.url(),
+  client_x509_cert_url: z.url(),
+  universe_domain: z.string().min(1).optional(),
+});
+
+export type GoogleServiceAccountKey = z.infer<typeof GoogleServiceAccountKeySchema>;
+
+const CustomLlmDefinitionBaseSchema = z.object({
+  ...CustomLlmMetadataSchema.shape,
+  ...CustomLlmApiConfigSchema.shape,
+  display_name: z.string(),
+  organization_ids: z.array(z.string()),
+  pricing: CustomLlmPricingSchema.optional(),
+});
+
+export const CustomLlmDefinitionSchema = z.union([
+  CustomLlmDefinitionBaseSchema.extend({
     api_key: z.string(),
-    organization_ids: z.array(z.string()),
-    pricing: CustomLlmPricingSchema.optional(),
-  })
-  .and(CustomLlmMetadataSchema)
-  .and(CustomLlmApiConfigSchema);
+    google_service_account: z.never().optional(),
+  }),
+  CustomLlmDefinitionBaseSchema.extend({
+    api_key: z.never().optional(),
+    google_service_account: GoogleServiceAccountKeySchema,
+  }),
+]);
 
 export type CustomLlmDefinition = z.infer<typeof CustomLlmDefinitionSchema>;
 


### PR DESCRIPTION
## Summary
- allow custom LLM definitions to authenticate with either an API key or a Google Cloud service-account JSON key
- mint and cache cloud-platform OAuth access tokens for service-account-backed providers
- document the new option in the admin editor and cover schema validation and token resolution

## Validation
- pnpm --filter web exec jest --runInBand --runTestsByPath src/lib/ai-gateway/custom-llm/google-service-account.test.ts
- pnpm --filter web typecheck
- pnpm --filter @kilocode/db typecheck
- pnpm --filter web lint
- pnpm --filter @kilocode/db lint
- formatting check and git diff --check