### PR TITLE
feat(extension): agents tab UX and functionality pass

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agents-composer.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-composer.tsx
@@ -41,14 +41,16 @@ export const AgentsComposer = ({
 
   const handleKeyDown = useCallback(
     (event: KeyboardEvent<HTMLTextAreaElement>): void => {
+      if (event.nativeEvent.isComposing) {
+        return;
+      }
       if (event.key === 'Enter' && !event.shiftKey) {
         event.preventDefault();
-        if (!isStreaming) {
-          submit();
-        }
+        // Sending stays available while the agent runs — the message queues.
+        submit();
       }
     },
-    [isStreaming, submit]
+    [submit]
   );
 
   if (isReadOnly) {

--- a/apps/extension/entrypoints/sidepanel/agents-format.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-format.test.ts
@@ -18,6 +18,10 @@ describe('displayRepoName()', () => {
     expect(displayRepoName('ssh://git@github.com/org/repo.git')).toBe('org/repo');
   });
 
+  it('drops an explicit ssh port along with the host', () => {
+    expect(displayRepoName('ssh://git@gitlab.example.com:2222/org/repo.git')).toBe('org/repo');
+  });
+
   it('keeps nested groups on a non-github host', () => {
     expect(displayRepoName('https://gitlab.com/group/sub/repo.git')).toBe('group/sub/repo');
   });

--- a/apps/extension/entrypoints/sidepanel/agents-format.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-format.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest';
+import { displayRepoName, relativeTime } from './agents-format';
+
+describe('displayRepoName()', () => {
+  it('strips the github host from a bare cloud-session gitUrl', () => {
+    expect(displayRepoName('github.com/org/repo')).toBe('org/repo');
+  });
+
+  it('strips scheme and .git from an https remote', () => {
+    expect(displayRepoName('https://github.com/org/repo.git')).toBe('org/repo');
+  });
+
+  it('handles a scp-style ssh remote from the CLI heartbeat', () => {
+    expect(displayRepoName('git@github.com:org/repo.git')).toBe('org/repo');
+  });
+
+  it('handles an ssh:// remote with a user', () => {
+    expect(displayRepoName('ssh://git@github.com/org/repo.git')).toBe('org/repo');
+  });
+
+  it('keeps nested groups on a non-github host', () => {
+    expect(displayRepoName('https://gitlab.com/group/sub/repo.git')).toBe('group/sub/repo');
+  });
+
+  it('passes through a value that is already owner/repo', () => {
+    expect(displayRepoName('org/repo')).toBe('org/repo');
+  });
+
+  it('returns an empty string unchanged', () => {
+    expect(displayRepoName('')).toBe('');
+  });
+});
+
+describe('relativeTime()', () => {
+  it('reports sub-minute ages as Just now', () => {
+    expect(relativeTime(new Date(Date.now() - 5000).toISOString())).toBe('Just now');
+  });
+
+  it('reports minutes, hours, days, and months', () => {
+    expect(relativeTime(new Date(Date.now() - 5 * 60_000).toISOString())).toBe('5m ago');
+    expect(relativeTime(new Date(Date.now() - 3 * 3_600_000).toISOString())).toBe('3h ago');
+    expect(relativeTime(new Date(Date.now() - 2 * 86_400_000).toISOString())).toBe('2d ago');
+    expect(relativeTime(new Date(Date.now() - 70 * 86_400_000).toISOString())).toBe('2mo ago');
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/agents-format.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-format.ts
@@ -1,0 +1,30 @@
+/**
+ * Display helpers shared by the agents session list and session view.
+ */
+
+/** Strip the host prefix from a stored git URL: "github.com/org/repo" → "org/repo". */
+export const displayRepoName = (gitUrl: string): string =>
+  gitUrl.replace(/^(?:https?:\/\/)?(?:www\.)?github\.com\//, '');
+
+export const relativeTime = (dateStr: string): string => {
+  const date = new Date(dateStr);
+  const now = new Date();
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) {
+    return 'Just now';
+  }
+  if (diffMin < 60) {
+    return `${diffMin}m ago`;
+  }
+  const diffHours = Math.floor(diffMin / 60);
+  if (diffHours < 24) {
+    return `${diffHours}h ago`;
+  }
+  const diffDays = Math.floor(diffHours / 24);
+  if (diffDays < 30) {
+    return `${diffDays}d ago`;
+  }
+  const diffMonths = Math.floor(diffDays / 30);
+  return `${diffMonths}mo ago`;
+};

--- a/apps/extension/entrypoints/sidepanel/agents-format.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-format.ts
@@ -14,8 +14,8 @@ export const displayRepoName = (gitUrl: string): string => {
   const withoutScheme = gitUrl.trim().replace(/^[a-z][a-z\d+.-]*:\/\//i, '');
   const withoutUser = withoutScheme.replace(/^[^@/]+@/, '');
   // Strip the leading segment only when it looks like a host (contains a dot),
-  // So a plain `owner/repo` keeps its owner.
-  const withoutHost = withoutUser.replace(/^[^/:]*\.[^/:]*[:/]+/, '');
+  // So a plain `owner/repo` keeps its owner. An explicit port goes with it.
+  const withoutHost = withoutUser.replace(/^[^/:]*\.[^/:]*(?::\d+)?[:/]+/, '');
   return withoutHost.replace(/\.git$/i, '');
 };
 

--- a/apps/extension/entrypoints/sidepanel/agents-format.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-format.ts
@@ -2,9 +2,22 @@
  * Display helpers shared by the agents session list and session view.
  */
 
-/** Strip the host prefix from a stored git URL: "github.com/org/repo" → "org/repo". */
-export const displayRepoName = (gitUrl: string): string =>
-  gitUrl.replace(/^(?:https?:\/\/)?(?:www\.)?github\.com\//, '');
+/**
+ * Reduce a git remote to `owner/repo` for display.
+ *
+ * Handles every form the wire carries: bare `github.com/org/repo` from cloud
+ * sessions, and the CLI heartbeat's raw remote — `https://host/org/repo.git`,
+ * `ssh://git@host/org/repo.git`, or scp-style `git@host:org/repo.git`. A value
+ * that already looks like `owner/repo` (no host segment) passes through.
+ */
+export const displayRepoName = (gitUrl: string): string => {
+  const withoutScheme = gitUrl.trim().replace(/^[a-z][a-z\d+.-]*:\/\//i, '');
+  const withoutUser = withoutScheme.replace(/^[^@/]+@/, '');
+  // Strip the leading segment only when it looks like a host (contains a dot),
+  // So a plain `owner/repo` keeps its owner.
+  const withoutHost = withoutUser.replace(/^[^/:]*\.[^/:]*[:/]+/, '');
+  return withoutHost.replace(/\.git$/i, '');
+};
 
 export const relativeTime = (dateStr: string): string => {
   const date = new Date(dateStr);

--- a/apps/extension/entrypoints/sidepanel/agents-message-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-message-list.tsx
@@ -1,7 +1,12 @@
+import { useCallback, useLayoutEffect, useRef } from 'react';
 import type { JSX } from 'react';
 import ReactMarkdown from 'react-markdown';
 import remarkGfm from 'remark-gfm';
+import { Loader2 } from 'lucide-react';
 import type { StoredMessage, Part } from '@kilocode/cloud-agent-sdk';
+
+/** Distance from the bottom (px) still treated as "at the bottom". */
+const BOTTOM_PIN_THRESHOLD_PX = 32;
 
 const remarkPlugins = [remarkGfm];
 
@@ -36,8 +41,12 @@ const toolStatusColor = (status: string): string => {
 
 const ToolPartRow = ({ part }: { part: Extract<Part, { type: 'tool' }> }): JSX.Element => {
   const { status } = part.state;
+  const isActive = status === 'running' || status === 'pending';
   return (
     <div className="flex items-center gap-1.5 text-xs">
+      {isActive ? (
+        <Loader2 aria-hidden="true" className="size-3 animate-spin text-foreground-muted" />
+      ) : null}
       <span className="text-foreground-muted">{part.tool}</span>
       <span className={toolStatusColor(status)}>{toolStatusLabel(status)}</span>
     </div>
@@ -74,8 +83,6 @@ const MessageRow = ({ message }: { message: StoredMessage }): JSX.Element => {
     message.info.role === 'assistant' &&
     message.info.time.completed === undefined &&
     !message.info.error;
-  const textParts = message.parts.filter(part => part.type === 'text');
-  const nonTextParts = message.parts.filter(part => part.type !== 'text');
   const hasContent = message.parts.length > 0;
 
   return (
@@ -89,10 +96,8 @@ const MessageRow = ({ message }: { message: StoredMessage }): JSX.Element => {
       >
         {hasContent ? (
           <div className="space-y-1">
-            {textParts.map(part => (
-              <PartRow key={part.id} part={part} />
-            ))}
-            {nonTextParts.map(part => (
+            {/* Parts render in stored order: reasoning and tools come before the text they produced. */}
+            {message.parts.map(part => (
               <PartRow key={part.id} part={part} />
             ))}
           </div>
@@ -109,8 +114,63 @@ const MessageRow = ({ message }: { message: StoredMessage }): JSX.Element => {
   );
 };
 
-export const AgentsMessageList = ({ messages }: { messages: StoredMessage[] }): JSX.Element => {
-  if (messages.length === 0) {
+/**
+ * True when the agent is running but the newest message shows no live
+ * assistant output — the gap between sending a prompt and the first
+ * assistant token. The indicator fills that gap.
+ */
+export const shouldShowWorkingIndicator = (
+  isStreaming: boolean,
+  messages: StoredMessage[]
+): boolean => {
+  if (!isStreaming) {
+    return false;
+  }
+  const last = messages.at(-1);
+  if (last === undefined) {
+    return true;
+  }
+  return last.info.role !== 'assistant' || last.info.time.completed !== undefined;
+};
+
+const WorkingIndicatorRow = (): JSX.Element => (
+  <div className="flex justify-start">
+    <div className="flex items-center gap-1.5 px-3 py-2 text-xs text-foreground-muted">
+      <span className="inline-block size-1.5 animate-pulse rounded-full bg-foreground-muted" />
+      Working…
+    </div>
+  </div>
+);
+
+export const AgentsMessageList = ({
+  messages,
+  isStreaming = false,
+}: {
+  messages: StoredMessage[];
+  isStreaming?: boolean;
+}): JSX.Element => {
+  const showWorking = shouldShowWorkingIndicator(isStreaming, messages);
+  const scrollRef = useRef<HTMLDivElement>(null);
+  // Follow the bottom until the user scrolls up; re-arm when they return.
+  const pinnedRef = useRef(true);
+
+  const handleScroll = useCallback(() => {
+    const element = scrollRef.current;
+    if (!element) {
+      return;
+    }
+    pinnedRef.current =
+      element.scrollTop + element.clientHeight >= element.scrollHeight - BOTTOM_PIN_THRESHOLD_PX;
+  }, []);
+
+  useLayoutEffect(() => {
+    const element = scrollRef.current;
+    if (element && pinnedRef.current) {
+      element.scrollTop = element.scrollHeight;
+    }
+  });
+
+  if (messages.length === 0 && !showWorking) {
     return (
       <div className="flex flex-1 items-center justify-center px-4 py-6">
         <p className="type-body text-foreground-muted">No messages yet</p>
@@ -119,11 +179,16 @@ export const AgentsMessageList = ({ messages }: { messages: StoredMessage[] }): 
   }
 
   return (
-    <div className="agent-conversation-scrollbar min-h-0 flex-1 overflow-y-auto px-4 py-4">
+    <div
+      className="agent-conversation-scrollbar min-h-0 flex-1 overflow-y-auto px-4 py-4"
+      onScroll={handleScroll}
+      ref={scrollRef}
+    >
       <div className="space-y-3">
         {messages.map(message => (
           <MessageRow key={message.info.id} message={message} />
         ))}
+        {showWorking ? <WorkingIndicatorRow /> : null}
       </div>
     </div>
   );

--- a/apps/extension/entrypoints/sidepanel/agents-message-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-message-list.tsx
@@ -77,13 +77,28 @@ const PartRow = ({ part }: { part: Part }): JSX.Element | null => {
   return null;
 };
 
+/**
+ * Real transcripts carry a reasoning part before nearly every step. Keep a
+ * single reasoning row only while the message still streams; a completed
+ * message shows its tools and text without the noise.
+ */
+export const visibleParts = (parts: Part[], isStreaming: boolean): Part[] => {
+  if (isStreaming) {
+    return parts.filter(
+      (part, index) => part.type !== 'reasoning' || parts[index + 1] === undefined
+    );
+  }
+  return parts.filter(part => part.type !== 'reasoning');
+};
+
 const MessageRow = ({ message }: { message: StoredMessage }): JSX.Element => {
   const isUser = message.info.role === 'user';
   const isStreaming =
     message.info.role === 'assistant' &&
     message.info.time.completed === undefined &&
     !message.info.error;
-  const hasContent = message.parts.length > 0;
+  const parts = visibleParts(message.parts, isStreaming);
+  const hasContent = parts.length > 0;
 
   return (
     <div className={isUser ? 'flex justify-end' : 'flex justify-start'}>
@@ -96,8 +111,8 @@ const MessageRow = ({ message }: { message: StoredMessage }): JSX.Element => {
       >
         {hasContent ? (
           <div className="space-y-1">
-            {/* Parts render in stored order: reasoning and tools come before the text they produced. */}
-            {message.parts.map(part => (
+            {/* Parts render in stored order: tools come before the text they produced. */}
+            {parts.map(part => (
               <PartRow key={part.id} part={part} />
             ))}
           </div>

--- a/apps/extension/entrypoints/sidepanel/agents-message-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-message-list.tsx
@@ -39,16 +39,53 @@ const toolStatusColor = (status: string): string => {
   return 'text-foreground-muted';
 };
 
+/** Longest tool error rendered inline; the rest would swamp the transcript. */
+const TOOL_ERROR_MAX_LENGTH = 200;
+
+/**
+ * First meaningful line of a tool error, clamped. Tool failures arrive as
+ * anything from one line to a stack trace, and the transcript must stay
+ * readable in a narrow panel.
+ */
+export const toolErrorSummary = (error: string): string => {
+  const firstLine = error
+    .split('\n')
+    .map(line => line.trim())
+    .find(line => line !== '');
+  if (firstLine === undefined) {
+    return '';
+  }
+  return firstLine.length > TOOL_ERROR_MAX_LENGTH
+    ? `${firstLine.slice(0, TOOL_ERROR_MAX_LENGTH)}…`
+    : firstLine;
+};
+
 const ToolPartRow = ({ part }: { part: Extract<Part, { type: 'tool' }> }): JSX.Element => {
-  const { status } = part.state;
+  const { state } = part;
+  const { status } = state;
   const isActive = status === 'running' || status === 'pending';
+  // The tool's own summary of the call — a path, a command. Absent while pending.
+  const title = 'title' in state ? state.title : undefined;
+  const errorSummary = state.status === 'error' ? toolErrorSummary(state.error) : '';
+
   return (
-    <div className="flex items-center gap-1.5 text-xs">
-      {isActive ? (
-        <Loader2 aria-hidden="true" className="size-3 animate-spin text-foreground-muted" />
-      ) : null}
-      <span className="text-foreground-muted">{part.tool}</span>
-      <span className={toolStatusColor(status)}>{toolStatusLabel(status)}</span>
+    <div className="text-xs">
+      <div className="flex items-center gap-1.5">
+        {isActive ? (
+          <Loader2
+            aria-hidden="true"
+            className="size-3 shrink-0 animate-spin text-foreground-muted"
+          />
+        ) : null}
+        <span className="shrink-0 text-foreground-muted">{part.tool}</span>
+        {title === undefined || title === '' ? null : (
+          <span className="min-w-0 flex-1 truncate text-foreground-subtle">{title}</span>
+        )}
+        <span className={`shrink-0 ${toolStatusColor(status)}`}>{toolStatusLabel(status)}</span>
+      </div>
+      {errorSummary === '' ? null : (
+        <p className="mt-0.5 break-words text-status-red-400">{errorSummary}</p>
+      )}
     </div>
   );
 };

--- a/apps/extension/entrypoints/sidepanel/agents-mode.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-mode.tsx
@@ -4,7 +4,10 @@ import { AgentsSessionList } from './agents-session-list';
 import { AgentsSessionView } from './agents-session-view';
 import { AgentsNewSession } from './agents-new-session';
 
-type AgentsView = { kind: 'list' } | { kind: 'session'; kiloSessionId: string } | { kind: 'new' };
+type AgentsView =
+  | { kind: 'list' }
+  | { kind: 'session'; kiloSessionId: string; initialPrompt?: string }
+  | { kind: 'new' };
 
 export const AgentsMode = (): JSX.Element => {
   const [view, setView] = useState<AgentsView>({ kind: 'list' });
@@ -12,6 +15,7 @@ export const AgentsMode = (): JSX.Element => {
   if (view.kind === 'session') {
     return (
       <AgentsSessionView
+        initialPrompt={view.initialPrompt}
         kiloSessionId={view.kiloSessionId}
         onBack={() => {
           setView({ kind: 'list' });
@@ -26,8 +30,12 @@ export const AgentsMode = (): JSX.Element => {
         onCancel={() => {
           setView({ kind: 'list' });
         }}
-        onCreated={(kiloSessionId: string) => {
-          setView({ kiloSessionId, kind: 'session' });
+        onCreated={(kiloSessionId: string, initialPrompt?: string) => {
+          setView({
+            kiloSessionId,
+            kind: 'session',
+            ...(initialPrompt === undefined ? {} : { initialPrompt }),
+          });
         }}
       />
     );

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
@@ -183,6 +183,7 @@ describe('submitBlockedReason helper', () => {
     hasModels: true,
     integrationInstalled: true,
     isCloudTarget: true,
+    isLoading: false,
     isPromptValid: true,
     repoCount: 1,
     selectedRepo: 'org/repo',
@@ -204,6 +205,19 @@ describe('submitBlockedReason helper', () => {
         hasModels: false,
         integrationInstalled: false,
         isCloudTarget: false,
+        repoCount: 0,
+        selectedRepo: '',
+      })
+    ).toBeNull();
+  });
+
+  it('names no blocker while the repo and model lists are still loading', () => {
+    // An empty list mid-load means "not yet", not "none available".
+    expect(
+      submitBlockedReason({
+        ...base,
+        hasModels: false,
+        isLoading: true,
         repoCount: 0,
         selectedRepo: '',
       })

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
@@ -7,6 +7,7 @@ import {
   MODE,
   PROMPT_MAX_LENGTH,
   PROMPT_MIN_LENGTH,
+  submitBlockedReason,
 } from './agents-new-session';
 
 /* eslint-disable jest/no-untyped-mock-factory, vitest/prefer-import-in-mock -- WXT virtual module has no importable runtime type in Vitest. */
@@ -174,5 +175,56 @@ describe('buildPrepareSessionInput helper', () => {
     const copy = { ...baseInput };
     buildPrepareSessionInput('org-1', baseInput);
     expect(baseInput).toStrictEqual(copy);
+  });
+});
+
+describe('submitBlockedReason helper', () => {
+  const base = {
+    hasModels: true,
+    integrationInstalled: true,
+    isCloudTarget: true,
+    isPromptValid: true,
+    repoCount: 1,
+    selectedRepo: 'org/repo',
+  };
+
+  it('returns null when the cloud form is submittable', () => {
+    expect(submitBlockedReason(base)).toBeNull();
+  });
+
+  it('stays silent while the prompt is still too short', () => {
+    // The textarea already reports the length requirement.
+    expect(submitBlockedReason({ ...base, isPromptValid: false, selectedRepo: '' })).toBeNull();
+  });
+
+  it('stays silent for a CLI target, which needs no repo or model', () => {
+    expect(
+      submitBlockedReason({
+        ...base,
+        hasModels: false,
+        integrationInstalled: false,
+        isCloudTarget: false,
+        repoCount: 0,
+        selectedRepo: '',
+      })
+    ).toBeNull();
+  });
+
+  it('reports connect-github before anything else', () => {
+    expect(
+      submitBlockedReason({ ...base, integrationInstalled: false, repoCount: 0, selectedRepo: '' })
+    ).toBe('connect-github');
+  });
+
+  it('reports no-repos when the integration is installed but empty', () => {
+    expect(submitBlockedReason({ ...base, repoCount: 0, selectedRepo: '' })).toBe('no-repos');
+  });
+
+  it('reports no-models when models failed to load', () => {
+    expect(submitBlockedReason({ ...base, hasModels: false })).toBe('no-models');
+  });
+
+  it('reports pick-repo when repositories exist but none is chosen', () => {
+    expect(submitBlockedReason({ ...base, selectedRepo: '' })).toBe('pick-repo');
   });
 });

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
@@ -25,6 +25,8 @@ import {
 import { generateMessageId } from '@kilocode/cloud-agent-sdk/message-id';
 import type { StoredAuth } from '@/src/shared/auth';
 import { getKiloApiBaseUrl, loadStoredAuth } from '@/src/shared/auth';
+import { fetchModelPreferences } from '@/src/shared/model-preferences-client';
+import { getModelPreferencesQueryKey } from '@/src/shared/side-panel-query-options';
 import { thinkingEffortLabel } from '@/src/shared/kilo-api-client';
 import { useExtensionAgents } from './agents-provider';
 import { activeSessionsQueryKey, sessionHistoryQueryKey } from './agents-session-list';
@@ -124,6 +126,45 @@ export const buildSubmitInput = ({
   ...(selectedVariant ? { variant: selectedVariant } : {}),
 });
 
+/**
+ * One line saying why Start session is unavailable. A disabled button with no
+ * reason is a dead end — most often no GitHub integration, so a cloud session
+ * can never get a repository.
+ */
+export const submitBlockedReason = ({
+  hasModels,
+  integrationInstalled,
+  isCloudTarget,
+  isPromptValid,
+  repoCount,
+  selectedRepo,
+}: {
+  hasModels: boolean;
+  integrationInstalled: boolean;
+  isCloudTarget: boolean;
+  isPromptValid: boolean;
+  repoCount: number;
+  selectedRepo: string;
+}): 'connect-github' | 'no-repos' | 'pick-repo' | 'no-models' | null => {
+  if (!isPromptValid || !isCloudTarget) {
+    // The textarea already reports a short prompt; a CLI target needs nothing else.
+    return null;
+  }
+  if (!integrationInstalled) {
+    return 'connect-github';
+  }
+  if (repoCount === 0) {
+    return 'no-repos';
+  }
+  if (!hasModels) {
+    return 'no-models';
+  }
+  if (selectedRepo === '') {
+    return 'pick-repo';
+  }
+  return null;
+};
+
 const isModelPreferencesGetResult = (
   value: unknown
 ): value is { favorites: string[]; lastSelected: LastSelected | null } =>
@@ -165,14 +206,22 @@ export const AgentsNewSession = ({
   });
 
   // ---- Model preferences (lastSelected) ----
+  // Same key and fetcher as the embedded ModelPicker's `useModelPreferences`,
+  // So favorites and lastSelected arrive on one request.
   const { data: modelPrefsData } = useQuery({
     enabled: auth !== undefined && auth.token !== '',
-    queryFn: () => {
-      const input = organizationId === null ? undefined : { organizationId };
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- tRPC query input union
-      return trpcClient.modelPreferences.get.query(input as never);
-    },
-    queryKey: ['agents-new-session', 'model-preferences', organizationId],
+    queryFn: ({ signal }) =>
+      fetchModelPreferences({
+        apiBaseUrl: getKiloApiBaseUrl(),
+        fetch: (input, init) => fetch(input, init),
+        organizationId: organizationId ?? undefined,
+        signal,
+        token: auth?.token ?? '',
+      }),
+    queryKey: getModelPreferencesQueryKey({
+      organizationId: organizationId ?? undefined,
+      token: auth?.token ?? '',
+    }),
   });
 
   const lastSelected: LastSelected | null = useMemo(() => {
@@ -343,6 +392,15 @@ export const AgentsNewSession = ({
         repo.name.toLowerCase().includes(normalized)
     );
   }, [repos, repoSearch]);
+
+  const blockedReason = submitBlockedReason({
+    hasModels: modelOptions.length > 0,
+    integrationInstalled,
+    isCloudTarget,
+    isPromptValid,
+    repoCount: repos.length,
+    selectedRepo,
+  });
 
   const isCreditsError = submitError?.toLowerCase().includes('insufficient credits') ?? false;
 
@@ -593,16 +651,21 @@ export const AgentsNewSession = ({
 
         {/* Toolbar: model + variant + repo */}
         <div className="flex flex-wrap items-center gap-2">
-          {/* Model picker (cloud target only) — same component as the browser tab */}
+          {/* Model picker (cloud target only) — same component as the browser tab.
+              The wrapper's min width stops the flexible trigger collapsing to a
+              sliver once the repo and Run-on pickers share the row; the row
+              wraps instead. */}
           {isCloudTarget && auth !== undefined ? (
-            <ModelPicker
-              auth={auth}
-              disabled={isSubmitting || modelOptions.length === 0}
-              model={selectedModel}
-              modelOptions={modelOptions}
-              onModelChange={handleModelSelect}
-              organizationId={organizationId ?? undefined}
-            />
+            <div className="flex min-w-36 flex-1">
+              <ModelPicker
+                auth={auth}
+                disabled={isSubmitting || modelOptions.length === 0}
+                model={selectedModel}
+                modelOptions={modelOptions}
+                onModelChange={handleModelSelect}
+                organizationId={organizationId ?? undefined}
+              />
+            </div>
           ) : null}
           {isCloudTarget
             ? (() => {
@@ -848,6 +911,28 @@ export const AgentsNewSession = ({
         {isCloudTarget || selectedInstance === undefined ? null : (
           <p className="type-label -mt-2 text-foreground-muted">
             Runs in {selectedInstance.projectName} with the repository and model of the CLI.
+          </p>
+        )}
+
+        {/* Why Start session is unavailable */}
+        {blockedReason === null ? null : (
+          <p className="type-label -mt-2 text-foreground-muted">
+            {blockedReason === 'connect-github' ? (
+              <>
+                <a
+                  className="text-link hover:text-link-hover underline underline-offset-4"
+                  href={`${getKiloApiBaseUrl().replace(/\/+$/, '')}${organizationId === null ? '/integrations' : `/organizations/${organizationId}/integrations`}`}
+                  rel="noreferrer"
+                  target="_blank"
+                >
+                  Connect GitHub
+                </a>{' '}
+                to start a cloud session, or pick a connected CLI instance.
+              </>
+            ) : null}
+            {blockedReason === 'no-repos' ? 'No repositories available on this account.' : null}
+            {blockedReason === 'no-models' ? 'No models available. Retry above.' : null}
+            {blockedReason === 'pick-repo' ? 'Choose a repository to start.' : null}
           </p>
         )}
 

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
@@ -9,14 +9,19 @@ import {
   ArrowLeft,
   Check,
   ChevronDown,
+  Cloud,
   FolderGit2,
   Loader2,
   Lock,
   RefreshCw,
   Search,
-  Send,
+  TerminalSquare,
 } from 'lucide-react';
-import { formatSessionError } from '@kilocode/cloud-agent-sdk';
+import {
+  createRemoteSessionOnConnection,
+  formatSessionError,
+  parseCreateSessionResponse,
+} from '@kilocode/cloud-agent-sdk';
 import { generateMessageId } from '@kilocode/cloud-agent-sdk/message-id';
 import type { StoredAuth } from '@/src/shared/auth';
 import { getKiloApiBaseUrl, loadStoredAuth } from '@/src/shared/auth';
@@ -139,10 +144,10 @@ export const AgentsNewSession = ({
   onCreated,
   onCancel,
 }: {
-  onCreated: (kiloSessionId: string) => void;
+  onCreated: (kiloSessionId: string, initialPrompt?: string) => void;
   onCancel: () => void;
 }): JSX.Element => {
-  const { organizationId, trpcClient } = useExtensionAgents();
+  const { organizationId, trpcClient, userWebConnection } = useExtensionAgents();
   const queryClient = useQueryClient();
 
   // ---- Auth (for gateway models) ----
@@ -217,11 +222,23 @@ export const AgentsNewSession = ({
     return raw?.integrationInstalled ?? true;
   }, [repoData]);
 
+  // ---- Connected CLI instances (spawn targets) ----
+  // A failed query degrades to cloud-only; the form never blocks on this.
+  const { data: instancesData } = useQuery({
+    enabled: auth !== undefined && auth.token !== '',
+    queryFn: () => trpcClient.activeSessions.listInstances.query(),
+    queryKey: ['agents-new-session', 'instances'],
+    retry: 1,
+  });
+  const instances = useMemo(() => instancesData?.instances ?? [], [instancesData]);
+
   // ---- Form state ----
   const [prompt, setPrompt] = useState('');
   const [selectedRepo, setSelectedRepo] = useState('');
   const [selectedModel, setSelectedModel] = useState('');
   const [selectedVariant, setSelectedVariant] = useState('');
+  /** 'cloud' or a CLI instance connectionId. */
+  const [runTarget, setRunTarget] = useState('cloud');
   const [isModelUserSelected, setIsModelUserSelected] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
@@ -231,6 +248,19 @@ export const AgentsNewSession = ({
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const repoDropdownRef = useRef<HTMLDivElement>(null);
   const modelDropdownRef = useRef<HTMLDivElement>(null);
+
+  const isCloudTarget = runTarget === 'cloud';
+  const selectedInstance = useMemo(
+    () => instances.find(instance => instance.connectionId === runTarget),
+    [instances, runTarget]
+  );
+
+  // A picked instance that disconnects falls back to cloud.
+  useEffect(() => {
+    if (!isCloudTarget && selectedInstance === undefined) {
+      setRunTarget('cloud');
+    }
+  }, [isCloudTarget, selectedInstance]);
 
   // ---- Close dropdowns on outside click ----
   useEffect(() => {
@@ -293,7 +323,10 @@ export const AgentsNewSession = ({
   // ---- Derived state ----
   const trimmed = trimValue(prompt);
   const isPromptValid = trimmed.length >= PROMPT_MIN_LENGTH && trimmed.length <= PROMPT_MAX_LENGTH;
-  const isFormValid = isPromptValid && selectedModel !== '' && selectedRepo !== '';
+  // A CLI instance inherits repo and model from the CLI; cloud needs both.
+  const isFormValid = isCloudTarget
+    ? isPromptValid && selectedModel !== '' && selectedRepo !== ''
+    : isPromptValid;
   const repoStatus = (() => {
     if (isRepoLoading) {
       return 'loading';
@@ -348,6 +381,32 @@ export const AgentsNewSession = ({
     setSubmitError(null);
     setIsSubmitting(true);
 
+    // ---- CLI instance target: spawn over the user-web socket ----
+    if (!isCloudTarget) {
+      try {
+        const raw = await createRemoteSessionOnConnection(
+          userWebConnection,
+          runTarget,
+          organizationId === null ? undefined : { orgId: organizationId }
+        );
+        const parsed = parseCreateSessionResponse(raw);
+        if (!parsed.ok) {
+          setSubmitError('The CLI did not return a session id. Update the Kilo CLI and retry.');
+          setIsSubmitting(false);
+          return;
+        }
+        void queryClient.invalidateQueries({
+          queryKey: activeSessionsQueryKey(organizationId),
+        });
+        setIsSubmitting(false);
+        onCreated(parsed.kiloSessionId, trimmed);
+      } catch (error) {
+        setSubmitError(error instanceof Error ? error.message : 'Failed to start the session.');
+        setIsSubmitting(false);
+      }
+      return;
+    }
+
     const messageId = generateMessageId();
     const input = buildSubmitInput({
       initialMessageId: messageId,
@@ -397,6 +456,9 @@ export const AgentsNewSession = ({
   }, [
     isFormValid,
     isSubmitting,
+    isCloudTarget,
+    runTarget,
+    userWebConnection,
     trimmed,
     selectedModel,
     selectedVariant,
@@ -475,7 +537,7 @@ export const AgentsNewSession = ({
         >
           <ArrowLeft className="size-4" />
         </button>
-        <span className="type-label text-foreground">New Cloud Session</span>
+        <span className="type-label text-foreground">New session</span>
       </div>
 
       {/* Error banner */}
@@ -529,7 +591,7 @@ export const AgentsNewSession = ({
             value={prompt}
           />
           {prompt.length > 0 && prompt.length < PROMPT_MIN_LENGTH ? (
-            <p className="mt-1 type-label text-status-red-400">
+            <p className="mt-1 type-label text-foreground-muted">
               Enter at least {PROMPT_MIN_LENGTH} characters
             </p>
           ) : null}
@@ -537,118 +599,124 @@ export const AgentsNewSession = ({
 
         {/* Toolbar: model + variant + repo */}
         <div className="flex flex-wrap items-center gap-2">
-          {/* Model picker */}
-          <div ref={modelDropdownRef} className="relative">
-            <button
-              aria-label="Select model"
-              className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-overlay px-2 type-label text-foreground-on-secondary transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={isSubmitting || modelOptions.length === 0}
-              onClick={() => {
-                setModelDropdownOpen(prev => !prev);
-              }}
-              type="button"
-            >
-              <span className="max-w-[140px] truncate">
-                {selectedModelOption?.name ?? 'Select model'}
-              </span>
-              <ChevronDown className="size-3.5 shrink-0" />
-            </button>
-            {modelDropdownOpen ? (
-              <div className="absolute left-0 top-full z-20 mt-1 max-h-56 w-56 overflow-y-auto rounded-lg border border-border bg-surface-overlay py-1 shadow-lg">
-                {(() => {
-                  if (modelLoadError !== undefined) {
-                    return (
-                      <div className="px-3 py-2">
-                        <p className="type-label text-status-red-400">{modelLoadError}</p>
-                        <button
-                          className="mt-1 type-label text-link hover:text-link-hover underline underline-offset-4"
-                          onClick={() => {
-                            void refetchModels();
-                          }}
-                          type="button"
-                        >
-                          Retry
-                        </button>
-                      </div>
-                    );
-                  }
-                  if (isModelsLoading) {
-                    return (
-                      <p className="px-3 py-2 type-label text-foreground-muted">Loading models…</p>
-                    );
-                  }
-                  if (modelOptions.length === 0) {
-                    return (
-                      <p className="px-3 py-2 type-label text-foreground-muted">
-                        No models available
-                      </p>
-                    );
-                  }
-                  return modelOptions.map(model => (
-                    <button
-                      className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
-                      key={model.id}
-                      onClick={() => {
-                        handleModelSelect(model);
-                        setModelDropdownOpen(false);
-                      }}
-                      type="button"
-                    >
-                      <span className="truncate flex-1">{model.name}</span>
-                      {model.id === selectedModel ? (
-                        <Check className="size-3.5 shrink-0 text-brand-primary" />
-                      ) : null}
-                    </button>
-                  ));
-                })()}
-              </div>
-            ) : null}
-          </div>
-          {(() => {
-            if (modelDropdownOpen) {
-              return null;
-            }
-            if (modelLoadError !== undefined) {
-              return (
-                <div className="flex items-center gap-1.5">
-                  <AlertTriangle className="size-3.5 shrink-0 text-status-red-400" />
-                  <span className="type-label text-status-red-400">{modelLoadError}</span>
-                  <button
-                    className="type-label text-link hover:text-link-hover underline underline-offset-4"
-                    onClick={() => {
-                      void refetchModels();
-                    }}
-                    type="button"
-                  >
-                    Retry
-                  </button>
+          {/* Model picker (cloud target only) */}
+          {isCloudTarget ? (
+            <div ref={modelDropdownRef} className="relative">
+              <button
+                aria-label="Select model"
+                className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-overlay px-2 type-label text-foreground-on-secondary transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={isSubmitting || modelOptions.length === 0}
+                onClick={() => {
+                  setModelDropdownOpen(prev => !prev);
+                }}
+                type="button"
+              >
+                <span className="max-w-[140px] truncate">
+                  {selectedModelOption?.name ?? 'Select model'}
+                </span>
+                <ChevronDown className="size-3.5 shrink-0" />
+              </button>
+              {modelDropdownOpen ? (
+                <div className="absolute left-0 top-full z-20 mt-1 max-h-56 w-56 overflow-y-auto rounded-lg border border-border bg-surface-overlay py-1 shadow-lg">
+                  {(() => {
+                    if (modelLoadError !== undefined) {
+                      return (
+                        <div className="px-3 py-2">
+                          <p className="type-label text-status-red-400">{modelLoadError}</p>
+                          <button
+                            className="mt-1 type-label text-link hover:text-link-hover underline underline-offset-4"
+                            onClick={() => {
+                              void refetchModels();
+                            }}
+                            type="button"
+                          >
+                            Retry
+                          </button>
+                        </div>
+                      );
+                    }
+                    if (isModelsLoading) {
+                      return (
+                        <p className="px-3 py-2 type-label text-foreground-muted">
+                          Loading models…
+                        </p>
+                      );
+                    }
+                    if (modelOptions.length === 0) {
+                      return (
+                        <p className="px-3 py-2 type-label text-foreground-muted">
+                          No models available
+                        </p>
+                      );
+                    }
+                    return modelOptions.map(model => (
+                      <button
+                        className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
+                        key={model.id}
+                        onClick={() => {
+                          handleModelSelect(model);
+                          setModelDropdownOpen(false);
+                        }}
+                        type="button"
+                      >
+                        <span className="truncate flex-1">{model.name}</span>
+                        {model.id === selectedModel ? (
+                          <Check className="size-3.5 shrink-0 text-brand-primary" />
+                        ) : null}
+                      </button>
+                    ));
+                  })()}
                 </div>
-              );
-            }
-            if (isModelsLoading) {
-              return <span className="type-label text-foreground-muted">Loading models…</span>;
-            }
-            if (modelOptions.length === 0) {
-              return (
-                <div className="flex items-center gap-1.5">
-                  <span className="type-label text-foreground-muted">No models available</span>
-                  <button
-                    className="type-label text-link hover:text-link-hover underline underline-offset-4"
-                    onClick={() => {
-                      void refetchModels();
-                    }}
-                    type="button"
-                  >
-                    Retry
-                  </button>
-                </div>
-              );
-            }
-            return null;
-          })()}
+              ) : null}
+            </div>
+          ) : null}
+          {isCloudTarget
+            ? (() => {
+                if (modelDropdownOpen) {
+                  return null;
+                }
+                if (modelLoadError !== undefined) {
+                  return (
+                    <div className="flex items-center gap-1.5">
+                      <AlertTriangle className="size-3.5 shrink-0 text-status-red-400" />
+                      <span className="type-label text-status-red-400">{modelLoadError}</span>
+                      <button
+                        className="type-label text-link hover:text-link-hover underline underline-offset-4"
+                        onClick={() => {
+                          void refetchModels();
+                        }}
+                        type="button"
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  );
+                }
+                if (isModelsLoading) {
+                  return <span className="type-label text-foreground-muted">Loading models…</span>;
+                }
+                if (modelOptions.length === 0) {
+                  return (
+                    <div className="flex items-center gap-1.5">
+                      <span className="type-label text-foreground-muted">No models available</span>
+                      <button
+                        className="type-label text-link hover:text-link-hover underline underline-offset-4"
+                        onClick={() => {
+                          void refetchModels();
+                        }}
+                        type="button"
+                      >
+                        Retry
+                      </button>
+                    </div>
+                  );
+                }
+                return null;
+              })()
+            : null}
 
-          {/* Variant picker */}
-          {availableVariants.length > 0 ? (
+          {/* Variant picker (cloud target only) */}
+          {isCloudTarget && availableVariants.length > 0 ? (
             <div className="relative">
               <div className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-overlay px-2 type-label text-foreground-on-secondary transition hover:bg-surface-hover outline-none focus-within:ring-2 focus-within:ring-brand-primary-ring">
                 <select
@@ -670,163 +738,204 @@ export const AgentsNewSession = ({
                     </option>
                   ))}
                 </select>
+                <ChevronDown aria-hidden="true" className="pointer-events-none size-3.5 shrink-0" />
               </div>
             </div>
           ) : null}
 
-          <div className="flex-1" />
-
-          {/* Repo picker */}
-          <div ref={repoDropdownRef} className="relative">
-            <button
-              aria-label="Select repository"
-              className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-overlay px-2 type-label transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring disabled:cursor-not-allowed disabled:opacity-50"
-              disabled={isSubmitting || repoStatus === 'loading'}
-              onClick={() => {
-                setRepoDropdownOpen(prev => !prev);
-              }}
-              type="button"
-            >
-              <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
-              <span
-                className={`max-w-[120px] truncate ${selectedRepo ? 'text-foreground' : 'text-foreground-muted'}`}
+          {/* Repo picker (cloud target only) */}
+          {isCloudTarget ? (
+            <div ref={repoDropdownRef} className="relative">
+              <button
+                aria-label="Select repository"
+                className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-overlay px-2 type-label transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring disabled:cursor-not-allowed disabled:opacity-50"
+                disabled={isSubmitting || repoStatus === 'loading'}
+                onClick={() => {
+                  setRepoDropdownOpen(prev => !prev);
+                }}
+                type="button"
               >
-                {selectedRepo || 'Repository'}
-              </span>
-              {repoStatus === 'loading' ? (
-                <Loader2 className="size-3.5 shrink-0 animate-spin" />
-              ) : (
-                <ChevronDown className="size-3.5 shrink-0" />
-              )}
-            </button>
-            {repoDropdownOpen ? (
-              <div className="absolute right-0 top-full z-20 mt-1 max-h-64 w-64 overflow-y-auto rounded-lg border border-border bg-surface-overlay py-1 shadow-lg">
-                {(() => {
-                  if (repoStatus === 'loading') {
-                    return (
-                      <p className="px-3 py-2 type-label text-foreground-muted">
-                        Loading repositories...
-                      </p>
-                    );
-                  }
-                  if (repoStatus === 'error') {
-                    return (
-                      <div className="px-3 py-2">
-                        <p className="type-label text-status-red-400">
-                          Failed to load repositories
-                        </p>
-                        <button
-                          className="mt-1 flex items-center gap-1 type-label text-link hover:text-link-hover underline underline-offset-4"
-                          disabled={isRepoRefetching}
-                          onClick={() => {
-                            void refetchRepos();
-                          }}
-                          type="button"
-                        >
-                          <RefreshCw
-                            className={`size-3 ${isRepoRefetching ? 'animate-spin' : ''}`}
-                          />
-                          {isRepoRefetching ? 'Retrying...' : 'Retry'}
-                        </button>
-                      </div>
-                    );
-                  }
-                  if (!integrationInstalled) {
-                    return (
-                      <div className="px-3 py-2 text-center">
-                        <p className="type-label text-foreground-muted">
-                          GitHub integration not connected
-                        </p>
-                        <p className="mt-1 type-label text-foreground-muted">
-                          <a
-                            className="text-link hover:text-link-hover underline underline-offset-4"
-                            href={`${getKiloApiBaseUrl().replace(/\/+$/, '')}${organizationId === null ? '/integrations' : `/organizations/${organizationId}/integrations`}`}
-                            rel="noreferrer"
-                            target="_blank"
-                          >
-                            Connect GitHub
-                          </a>{' '}
-                          to start a session
-                        </p>
-                      </div>
-                    );
-                  }
-                  if (repos.length === 0) {
-                    return (
-                      <div className="px-3 py-2 text-center">
-                        <p className="type-label text-foreground-muted">No repositories found</p>
-                      </div>
-                    );
-                  }
-                  return (
-                    <>
-                      {/* Repo search */}
-                      <div className="sticky top-0 z-10 border-b border-border bg-surface-overlay px-2 py-1.5">
-                        <div className="flex items-center gap-1.5 rounded-md border border-border bg-input-bg px-2 py-1">
-                          <Search className="size-3 shrink-0 text-foreground-muted" />
-                          <input
-                            aria-label="Search repositories"
-                            className="w-full bg-transparent type-label text-foreground placeholder:text-foreground-muted outline-none"
-                            onChange={changeEvent => {
-                              setRepoSearch(changeEvent.target.value);
-                            }}
-                            placeholder="Search repositories..."
-                            type="text"
-                            value={repoSearch}
-                          />
-                        </div>
-                      </div>
-                      {filteredRepos.length === 0 ? (
+                <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
+                <span
+                  className={`max-w-[120px] truncate ${selectedRepo ? 'text-foreground' : 'text-foreground-muted'}`}
+                >
+                  {selectedRepo || 'Repository'}
+                </span>
+                {repoStatus === 'loading' ? (
+                  <Loader2 className="size-3.5 shrink-0 animate-spin" />
+                ) : (
+                  <ChevronDown className="size-3.5 shrink-0" />
+                )}
+              </button>
+              {repoDropdownOpen ? (
+                <div className="absolute right-0 top-full z-20 mt-1 max-h-64 w-64 overflow-y-auto rounded-lg border border-border bg-surface-overlay py-1 shadow-lg">
+                  {(() => {
+                    if (repoStatus === 'loading') {
+                      return (
                         <p className="px-3 py-2 type-label text-foreground-muted">
-                          No repositories match your search
+                          Loading repositories...
                         </p>
-                      ) : (
-                        filteredRepos.map(repo => (
+                      );
+                    }
+                    if (repoStatus === 'error') {
+                      return (
+                        <div className="px-3 py-2">
+                          <p className="type-label text-status-red-400">
+                            Failed to load repositories
+                          </p>
                           <button
-                            className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
-                            key={repo.id}
+                            className="mt-1 flex items-center gap-1 type-label text-link hover:text-link-hover underline underline-offset-4"
+                            disabled={isRepoRefetching}
                             onClick={() => {
-                              setSelectedRepo(repo.fullName);
-                              setRepoDropdownOpen(false);
-                              setRepoSearch('');
+                              void refetchRepos();
                             }}
                             type="button"
                           >
-                            <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
-                            <span className="truncate flex-1">{repo.fullName}</span>
-                            {repo.private ? (
-                              <Lock className="size-3 shrink-0 text-foreground-muted" />
-                            ) : null}
-                            {repo.fullName === selectedRepo ? (
-                              <Check className="size-3.5 shrink-0 text-brand-primary" />
-                            ) : null}
+                            <RefreshCw
+                              className={`size-3 ${isRepoRefetching ? 'animate-spin' : ''}`}
+                            />
+                            {isRepoRefetching ? 'Retrying...' : 'Retry'}
                           </button>
-                        ))
-                      )}
-                    </>
-                  );
-                })()}
-              </div>
-            ) : null}
-          </div>
+                        </div>
+                      );
+                    }
+                    if (!integrationInstalled) {
+                      return (
+                        <div className="px-3 py-2 text-center">
+                          <p className="type-label text-foreground-muted">
+                            GitHub integration not connected
+                          </p>
+                          <p className="mt-1 type-label text-foreground-muted">
+                            <a
+                              className="text-link hover:text-link-hover underline underline-offset-4"
+                              href={`${getKiloApiBaseUrl().replace(/\/+$/, '')}${organizationId === null ? '/integrations' : `/organizations/${organizationId}/integrations`}`}
+                              rel="noreferrer"
+                              target="_blank"
+                            >
+                              Connect GitHub
+                            </a>{' '}
+                            to start a session
+                          </p>
+                        </div>
+                      );
+                    }
+                    if (repos.length === 0) {
+                      return (
+                        <div className="px-3 py-2 text-center">
+                          <p className="type-label text-foreground-muted">No repositories found</p>
+                        </div>
+                      );
+                    }
+                    return (
+                      <>
+                        {/* Repo search */}
+                        <div className="sticky top-0 z-10 border-b border-border bg-surface-overlay px-2 py-1.5">
+                          <div className="flex items-center gap-1.5 rounded-md border border-border bg-input-bg px-2 py-1">
+                            <Search className="size-3 shrink-0 text-foreground-muted" />
+                            <input
+                              aria-label="Search repositories"
+                              className="w-full bg-transparent type-label text-foreground placeholder:text-foreground-muted outline-none"
+                              onChange={changeEvent => {
+                                setRepoSearch(changeEvent.target.value);
+                              }}
+                              placeholder="Search repositories..."
+                              type="text"
+                              value={repoSearch}
+                            />
+                          </div>
+                        </div>
+                        {filteredRepos.length === 0 ? (
+                          <p className="px-3 py-2 type-label text-foreground-muted">
+                            No repositories match your search
+                          </p>
+                        ) : (
+                          filteredRepos.map(repo => (
+                            <button
+                              className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
+                              key={repo.id}
+                              onClick={() => {
+                                setSelectedRepo(repo.fullName);
+                                setRepoDropdownOpen(false);
+                                setRepoSearch('');
+                              }}
+                              type="button"
+                            >
+                              <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
+                              <span className="truncate flex-1">{repo.fullName}</span>
+                              {repo.private ? (
+                                <Lock className="size-3 shrink-0 text-foreground-muted" />
+                              ) : null}
+                              {repo.fullName === selectedRepo ? (
+                                <Check className="size-3.5 shrink-0 text-brand-primary" />
+                              ) : null}
+                            </button>
+                          ))
+                        )}
+                      </>
+                    );
+                  })()}
+                </div>
+              ) : null}
+            </div>
+          ) : null}
 
-          {/* Submit */}
-          <button
-            aria-label="Start session"
-            className="flex size-8 shrink-0 items-center justify-center rounded-md bg-brand-primary text-brand-primary-foreground transition hover:bg-brand-primary-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring disabled:cursor-not-allowed disabled:opacity-50"
-            disabled={!isFormValid || isSubmitting}
-            onClick={() => {
-              void handleSubmit();
-            }}
-            type="button"
-          >
-            {isSubmitting ? (
-              <Loader2 className="size-4 animate-spin" />
-            ) : (
-              <Send className="size-4" />
-            )}
-          </button>
+          {/* Run-on picker — visible only when a CLI instance is connected */}
+          {instances.length > 0 ? (
+            <div className="relative">
+              <div className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-overlay px-2 type-label text-foreground-on-secondary transition hover:bg-surface-hover outline-none focus-within:ring-2 focus-within:ring-brand-primary-ring">
+                {isCloudTarget ? (
+                  <Cloud aria-hidden="true" className="size-3.5 shrink-0 text-foreground-muted" />
+                ) : (
+                  <TerminalSquare
+                    aria-hidden="true"
+                    className="size-3.5 shrink-0 text-foreground-muted"
+                  />
+                )}
+                <select
+                  aria-label="Run on"
+                  className="max-w-40 appearance-none truncate bg-transparent outline-none disabled:cursor-not-allowed disabled:opacity-50"
+                  disabled={isSubmitting}
+                  onFocus={() => {
+                    setModelDropdownOpen(false);
+                    setRepoDropdownOpen(false);
+                  }}
+                  onChange={changeEvent => {
+                    setRunTarget(changeEvent.target.value);
+                  }}
+                  value={runTarget}
+                >
+                  <option value="cloud">Cloud agent</option>
+                  {instances.map(instance => (
+                    <option key={instance.connectionId} value={instance.connectionId}>
+                      {instance.name} · {instance.projectName}
+                    </option>
+                  ))}
+                </select>
+                <ChevronDown aria-hidden="true" className="pointer-events-none size-3.5 shrink-0" />
+              </div>
+            </div>
+          ) : null}
         </div>
+
+        {/* CLI target hint */}
+        {isCloudTarget || selectedInstance === undefined ? null : (
+          <p className="type-label -mt-2 text-foreground-muted">
+            Runs in {selectedInstance.projectName} with the repository and model of the CLI.
+          </p>
+        )}
+
+        {/* Submit */}
+        <button
+          className="flex h-10 w-full shrink-0 items-center justify-center gap-2 rounded-md bg-brand-primary type-label font-medium text-brand-primary-foreground transition hover:bg-brand-primary-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring ring-offset-2 ring-offset-surface-background disabled:cursor-not-allowed disabled:bg-surface-selected disabled:text-foreground-subtle"
+          disabled={!isFormValid || isSubmitting}
+          onClick={() => {
+            void handleSubmit();
+          }}
+          type="button"
+        >
+          {isSubmitting ? <Loader2 className="size-4 animate-spin" /> : null}
+          {isSubmitting ? 'Starting…' : 'Start session'}
+        </button>
       </div>
     </div>
   );

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
@@ -135,6 +135,7 @@ export const submitBlockedReason = ({
   hasModels,
   integrationInstalled,
   isCloudTarget,
+  isLoading,
   isPromptValid,
   repoCount,
   selectedRepo,
@@ -142,12 +143,18 @@ export const submitBlockedReason = ({
   hasModels: boolean;
   integrationInstalled: boolean;
   isCloudTarget: boolean;
+  /** Repositories or models still in flight; an empty list means nothing yet. */
+  isLoading: boolean;
   isPromptValid: boolean;
   repoCount: number;
   selectedRepo: string;
 }): 'connect-github' | 'no-repos' | 'pick-repo' | 'no-models' | null => {
   if (!isPromptValid || !isCloudTarget) {
     // The textarea already reports a short prompt; a CLI target needs nothing else.
+    return null;
+  }
+  if (isLoading) {
+    // Naming a blocker mid-load would name the wrong one.
     return null;
   }
   if (!integrationInstalled) {
@@ -397,6 +404,7 @@ export const AgentsNewSession = ({
     hasModels: modelOptions.length > 0,
     integrationInstalled,
     isCloudTarget,
+    isLoading: isRepoLoading || isModelsLoading,
     isPromptValid,
     repoCount: repos.length,
     selectedRepo,

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
@@ -25,10 +25,10 @@ import {
 import { generateMessageId } from '@kilocode/cloud-agent-sdk/message-id';
 import type { StoredAuth } from '@/src/shared/auth';
 import { getKiloApiBaseUrl, loadStoredAuth } from '@/src/shared/auth';
-import type { KiloGatewayModelOption } from '@/src/shared/kilo-api-client';
 import { thinkingEffortLabel } from '@/src/shared/kilo-api-client';
 import { useExtensionAgents } from './agents-provider';
 import { activeSessionsQueryKey, sessionHistoryQueryKey } from './agents-session-list';
+import { ModelPicker } from './model-picker';
 import { useGatewayModels } from './use-gateway-models';
 
 // ---------------------------------------------------------------------------
@@ -243,11 +243,9 @@ export const AgentsNewSession = ({
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [repoDropdownOpen, setRepoDropdownOpen] = useState(false);
-  const [modelDropdownOpen, setModelDropdownOpen] = useState(false);
   const [repoSearch, setRepoSearch] = useState('');
   const textareaRef = useRef<HTMLTextAreaElement>(null);
   const repoDropdownRef = useRef<HTMLDivElement>(null);
-  const modelDropdownRef = useRef<HTMLDivElement>(null);
 
   const isCloudTarget = runTarget === 'cloud';
   const selectedInstance = useMemo(
@@ -262,17 +260,13 @@ export const AgentsNewSession = ({
     }
   }, [isCloudTarget, selectedInstance]);
 
-  // ---- Close dropdowns on outside click ----
+  // ---- Close the repo dropdown on outside click ----
   useEffect(() => {
     const handler = (evt: MouseEvent): void => {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- browser DOM event target
       if (repoDropdownRef.current && !repoDropdownRef.current.contains(evt.target as Node)) {
         setRepoDropdownOpen(false);
         setRepoSearch('');
-      }
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- browser DOM event target
-      if (modelDropdownRef.current && !modelDropdownRef.current.contains(evt.target as Node)) {
-        setModelDropdownOpen(false);
       }
     };
     document.addEventListener('mousedown', handler);
@@ -354,11 +348,11 @@ export const AgentsNewSession = ({
 
   // ---- Handlers ----
   const handleModelSelect = useCallback(
-    (model: KiloGatewayModelOption) => {
-      setSelectedModel(model.id);
+    (modelId: string) => {
+      setSelectedModel(modelId);
       setIsModelUserSelected(true);
       setSelectedVariant('');
-      setLastSelectedMutation.mutate({ model: model.id });
+      setLastSelectedMutation.mutate({ model: modelId });
     },
     [setLastSelectedMutation]
   );
@@ -599,82 +593,19 @@ export const AgentsNewSession = ({
 
         {/* Toolbar: model + variant + repo */}
         <div className="flex flex-wrap items-center gap-2">
-          {/* Model picker (cloud target only) */}
-          {isCloudTarget ? (
-            <div ref={modelDropdownRef} className="relative">
-              <button
-                aria-label="Select model"
-                className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-overlay px-2 type-label text-foreground-on-secondary transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring disabled:cursor-not-allowed disabled:opacity-50"
-                disabled={isSubmitting || modelOptions.length === 0}
-                onClick={() => {
-                  setModelDropdownOpen(prev => !prev);
-                }}
-                type="button"
-              >
-                <span className="max-w-[140px] truncate">
-                  {selectedModelOption?.name ?? 'Select model'}
-                </span>
-                <ChevronDown className="size-3.5 shrink-0" />
-              </button>
-              {modelDropdownOpen ? (
-                <div className="absolute left-0 top-full z-20 mt-1 max-h-56 w-56 overflow-y-auto rounded-lg border border-border bg-surface-overlay py-1 shadow-lg">
-                  {(() => {
-                    if (modelLoadError !== undefined) {
-                      return (
-                        <div className="px-3 py-2">
-                          <p className="type-label text-status-red-400">{modelLoadError}</p>
-                          <button
-                            className="mt-1 type-label text-link hover:text-link-hover underline underline-offset-4"
-                            onClick={() => {
-                              void refetchModels();
-                            }}
-                            type="button"
-                          >
-                            Retry
-                          </button>
-                        </div>
-                      );
-                    }
-                    if (isModelsLoading) {
-                      return (
-                        <p className="px-3 py-2 type-label text-foreground-muted">
-                          Loading models…
-                        </p>
-                      );
-                    }
-                    if (modelOptions.length === 0) {
-                      return (
-                        <p className="px-3 py-2 type-label text-foreground-muted">
-                          No models available
-                        </p>
-                      );
-                    }
-                    return modelOptions.map(model => (
-                      <button
-                        className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
-                        key={model.id}
-                        onClick={() => {
-                          handleModelSelect(model);
-                          setModelDropdownOpen(false);
-                        }}
-                        type="button"
-                      >
-                        <span className="truncate flex-1">{model.name}</span>
-                        {model.id === selectedModel ? (
-                          <Check className="size-3.5 shrink-0 text-brand-primary" />
-                        ) : null}
-                      </button>
-                    ));
-                  })()}
-                </div>
-              ) : null}
-            </div>
+          {/* Model picker (cloud target only) — same component as the browser tab */}
+          {isCloudTarget && auth !== undefined ? (
+            <ModelPicker
+              auth={auth}
+              disabled={isSubmitting || modelOptions.length === 0}
+              model={selectedModel}
+              modelOptions={modelOptions}
+              onModelChange={handleModelSelect}
+              organizationId={organizationId ?? undefined}
+            />
           ) : null}
           {isCloudTarget
             ? (() => {
-                if (modelDropdownOpen) {
-                  return null;
-                }
                 if (modelLoadError !== undefined) {
                   return (
                     <div className="flex items-center gap-1.5">
@@ -693,7 +624,7 @@ export const AgentsNewSession = ({
                   );
                 }
                 if (isModelsLoading) {
-                  return <span className="type-label text-foreground-muted">Loading models…</span>;
+                  return null;
                 }
                 if (modelOptions.length === 0) {
                   return (
@@ -723,9 +654,6 @@ export const AgentsNewSession = ({
                   aria-label="Thinking effort"
                   className="appearance-none bg-transparent outline-none disabled:cursor-not-allowed disabled:opacity-50"
                   disabled={isSubmitting}
-                  onFocus={() => {
-                    setModelDropdownOpen(false);
-                  }}
                   onChange={changeEvent => {
                     handleVariantSelect(changeEvent.target.value);
                   }}
@@ -896,7 +824,6 @@ export const AgentsNewSession = ({
                   className="max-w-40 appearance-none truncate bg-transparent outline-none disabled:cursor-not-allowed disabled:opacity-50"
                   disabled={isSubmitting}
                   onFocus={() => {
-                    setModelDropdownOpen(false);
                     setRepoDropdownOpen(false);
                   }}
                   onChange={changeEvent => {

--- a/apps/extension/entrypoints/sidepanel/agents-session-list.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-session-list.test.ts
@@ -39,6 +39,16 @@ describe('sessionStatusBadge()', () => {
     expect(badge!.label).toBe('Running');
   });
 
+  it("maps the cloud agent's busy status onto the Running label", () => {
+    const badge = sessionStatusBadge('busy');
+    expect(badge!.label).toBe('Running');
+    expect(badge!.className).toContain('bg-status-green');
+  });
+
+  it('maps retry onto a Retrying label', () => {
+    expect(sessionStatusBadge('retry')!.label).toBe('Retrying');
+  });
+
   it('returns "Running" for uppercase RUNNING', () => {
     const badge = sessionStatusBadge('RUNNING');
     expect(badge).not.toBeNull();

--- a/apps/extension/entrypoints/sidepanel/agents-session-list.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-session-list.test.ts
@@ -45,10 +45,10 @@ describe('sessionStatusBadge()', () => {
     expect(badge!.label).toBe('Running');
   });
 
-  it('passes through unrecognized status as label', () => {
+  it('capitalizes an unrecognized status label', () => {
     const badge = sessionStatusBadge('idle');
     expect(badge).not.toBeNull();
-    expect(badge!.label).toBe('idle');
+    expect(badge!.label).toBe('Idle');
   });
 
   it('returns "Needs input" with yellow styling for question', () => {
@@ -69,14 +69,9 @@ describe('sessionStatusBadge()', () => {
     expect(badge!.className).toContain('text-foreground-muted');
   });
 
-  // Proves the actual undefined-status path: a cloud-agent session with an
-  // Empty-string status falls through to the fallback label (the empty string
-  // Itself), not to the null branch.
-  it('returns fallback badge for empty string status', () => {
-    const badge = sessionStatusBadge('');
-    expect(badge).not.toBeNull();
-    expect(badge!.label).toBe('');
-    expect(badge!.className).toContain('text-foreground-muted');
+  // An empty-string status renders no badge — an empty pill carries no signal.
+  it('returns null for empty string status', () => {
+    expect(sessionStatusBadge('')).toBeNull();
   });
 });
 

--- a/apps/extension/entrypoints/sidepanel/agents-session-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-session-list.tsx
@@ -32,6 +32,18 @@ const sessionSearchQueryKey = (organizationId: string | null, query: string) =>
 // Exported for focused test coverage.
 export { activeSessionsQueryKey, sessionHistoryQueryKey, sessionSearchQueryKey };
 
+/**
+ * Input for `activeSessions.list`. Both the Active section and the History
+ * section observe this query; an identical key plus input means React Query
+ * serves them from one request.
+ */
+const activeSessionsListInput = (
+  organizationId: string | null
+): { organizationId: string | null; includeCloudAgentSessions: boolean } => ({
+  includeCloudAgentSessions: true,
+  organizationId,
+});
+
 const HISTORY_PAGE_LIMIT = 30;
 const SEARCH_LIMIT = 50;
 const MIN_SEARCH_LENGTH = 2;
@@ -103,6 +115,11 @@ export function mapHistorySessionRow(params: {
 // Status badge classifier
 // ---------------------------------------------------------------------------
 
+/**
+ * Map a wire status to one badge vocabulary. The wire carries `busy` for a
+ * cloud agent and `running` for a CLI session; both mean the same thing to a
+ * reader, so they render the same label.
+ */
 export const sessionStatusBadge = (
   status: string | null
 ): { label: string; className: string } | null => {
@@ -113,8 +130,11 @@ export const sessionStatusBadge = (
   if (lowerStatus === 'question' || lowerStatus === 'permission') {
     return { className: 'bg-status-yellow-500/15 text-status-yellow-500', label: 'Needs input' };
   }
-  if (lowerStatus === 'running') {
+  if (lowerStatus === 'running' || lowerStatus === 'busy') {
     return { className: 'bg-status-green-500/15 text-status-green-500', label: 'Running' };
+  }
+  if (lowerStatus === 'retry') {
+    return { className: 'bg-status-yellow-500/15 text-status-yellow-500', label: 'Retrying' };
   }
   return {
     className: 'bg-surface-selected text-foreground-muted',
@@ -181,17 +201,8 @@ const ActiveSessionsSection = ({
     };
   }, [userWebConnection, queryClient, organizationId]);
 
-  const listInput = useMemo(
-    () =>
-      ({
-        includeCloudAgentSessions: true,
-        organizationId,
-      }) satisfies { organizationId: string | null; includeCloudAgentSessions: boolean },
-    [organizationId]
-  );
-
   const { data, error, isError, isLoading, refetch, isRefetching } = useQuery({
-    queryFn: () => trpcClient.activeSessions.list.query(listInput),
+    queryFn: () => trpcClient.activeSessions.list.query(activeSessionsListInput(organizationId)),
     queryKey: activeSessionsQueryKey(organizationId),
     refetchInterval: connected ? ACTIVE_POLL_CONNECTED_MS : ACTIVE_POLL_DISCONNECTED_MS,
   });
@@ -344,6 +355,18 @@ const HistorySessionsSection = ({
   const [inputValue, setInputValue] = useState('');
   const [searchQuery, setSearchQuery] = useState('');
 
+  // Live sessions already have a row in the Active section. Observing the same
+  // Query (identical key + input) costs no extra request and keeps the two
+  // Sections consistent on every refetch.
+  const { data: activeData } = useQuery({
+    queryFn: () => trpcClient.activeSessions.list.query(activeSessionsListInput(organizationId)),
+    queryKey: activeSessionsQueryKey(organizationId),
+  });
+  const activeIds = useMemo(
+    () => new Set((activeData?.sessions ?? []).map(session => session.id)),
+    [activeData]
+  );
+
   // Debounce search input so we don't request on every keystroke.
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -437,7 +460,7 @@ const HistorySessionsSection = ({
     }
   };
   const isRefetching = isSearching ? isSearchRefetching : isHistoryRefetching;
-  const rows = isSearching ? searchRows : allHistoryRows;
+  const rows = isSearching ? searchRows : allHistoryRows.filter(row => !activeIds.has(row.id));
   const hasNoResults = !isLoading && !hasError && rows.length === 0;
   // Hide the search box when there is nothing to search and no query typed.
   const showSearch = inputValue !== '' || isLoading || hasError || rows.length > 0;

--- a/apps/extension/entrypoints/sidepanel/agents-session-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-session-list.tsx
@@ -3,7 +3,17 @@
 import { useQuery, useQueryClient, useInfiniteQuery } from '@tanstack/react-query';
 import { useEffect, useMemo, useState } from 'react';
 import type { JSX } from 'react';
-import { AlertTriangle, Bot, History, Plus, Search, WifiOff } from 'lucide-react';
+import {
+  AlertTriangle,
+  Bot,
+  Cloud,
+  History,
+  Plus,
+  Search,
+  TerminalSquare,
+  WifiOff,
+} from 'lucide-react';
+import { displayRepoName, relativeTime } from './agents-format';
 import { useExtensionAgents } from './agents-provider';
 
 // ---------------------------------------------------------------------------
@@ -27,6 +37,8 @@ const SEARCH_LIMIT = 50;
 const MIN_SEARCH_LENGTH = 2;
 const ACTIVE_POLL_CONNECTED_MS = 30_000;
 const ACTIVE_POLL_DISCONNECTED_MS = 10_000;
+/** Suppress the Offline pill during the initial dial and transient blips. */
+const OFFLINE_PILL_GRACE_MS = 5000;
 
 // ---------------------------------------------------------------------------
 // Types
@@ -94,7 +106,7 @@ export function mapHistorySessionRow(params: {
 export const sessionStatusBadge = (
   status: string | null
 ): { label: string; className: string } | null => {
-  if (status === null) {
+  if (status === null || status === '') {
     return null;
   }
   const lowerStatus = status.toLowerCase();
@@ -104,7 +116,10 @@ export const sessionStatusBadge = (
   if (lowerStatus === 'running') {
     return { className: 'bg-status-green-500/15 text-status-green-500', label: 'Running' };
   }
-  return { className: 'bg-surface-selected text-foreground-muted', label: status };
+  return {
+    className: 'bg-surface-selected text-foreground-muted',
+    label: lowerStatus.charAt(0).toUpperCase() + lowerStatus.slice(1),
+  };
 };
 
 // ---------------------------------------------------------------------------
@@ -121,6 +136,7 @@ const ActiveSessionsSection = ({
   const { trpcClient, userWebConnection } = useExtensionAgents();
   const queryClient = useQueryClient();
   const [connected, setConnected] = useState(() => userWebConnection.isConnected());
+  const [showOffline, setShowOffline] = useState(false);
 
   useEffect(() => {
     const unsubscribe = userWebConnection.onConnectionChange((connectedStatus: boolean) => {
@@ -128,6 +144,20 @@ const ActiveSessionsSection = ({
     });
     return unsubscribe;
   }, [userWebConnection]);
+
+  // Show the pill only after the connection stays down past the grace period.
+  useEffect(() => {
+    if (connected) {
+      setShowOffline(false);
+      return;
+    }
+    const timer = setTimeout(() => {
+      setShowOffline(true);
+    }, OFFLINE_PILL_GRACE_MS);
+    return () => {
+      clearTimeout(timer);
+    };
+  }, [connected]);
 
   // Subscribe UserWeb events → invalidate active list
   useEffect(() => {
@@ -218,12 +248,12 @@ const ActiveSessionsSection = ({
       <div className="flex items-center gap-2">
         <Bot className="size-4 text-foreground-muted" />
         <span className="type-label text-foreground-muted">Active</span>
-        {connected ? null : (
+        {showOffline ? (
           <span className="flex items-center gap-1 rounded-full bg-surface-selected px-1.5 py-0.5 type-label text-foreground-muted">
             <WifiOff className="size-3" />
             Offline
           </span>
-        )}
+        ) : null}
       </div>
       {isError ? (
         <div className="flex items-center gap-2 rounded-lg border border-border bg-surface-raised p-2">
@@ -247,6 +277,14 @@ const ActiveSessionsSection = ({
         <div className="space-y-0.5">
           {sessions.map(session => {
             const badge = sessionStatusBadge(session.status);
+            const PlatformIcon = session.isCloudAgent ? Cloud : TerminalSquare;
+            const platformLabel = session.isCloudAgent ? 'Cloud agent' : 'CLI';
+            const repoLine = [
+              session.repository === null ? null : displayRepoName(session.repository),
+              session.gitBranch,
+            ]
+              .filter(Boolean)
+              .join(' · ');
             return (
               <button
                 className="w-full rounded-md px-2 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring"
@@ -257,8 +295,17 @@ const ActiveSessionsSection = ({
                 type="button"
               >
                 <div className="flex items-center justify-between gap-2">
-                  <span className="truncate text-foreground">
-                    {session.title ?? 'Unnamed session'}
+                  <span className="flex min-w-0 items-center gap-1.5">
+                    <PlatformIcon
+                      aria-label={platformLabel}
+                      className="size-3.5 shrink-0 text-foreground-muted"
+                      role="img"
+                    >
+                      <title>{platformLabel}</title>
+                    </PlatformIcon>
+                    <span className="truncate text-foreground">
+                      {session.title ?? 'Untitled session'}
+                    </span>
                   </span>
                   {badge ? (
                     <span
@@ -268,19 +315,11 @@ const ActiveSessionsSection = ({
                     </span>
                   ) : null}
                 </div>
-                {session.repository === null && session.gitBranch === null ? null : (
-                  <div className="mt-0.5 flex items-center gap-1.5 truncate type-label text-foreground-muted">
-                    {session.repository === null ? null : <span>{session.repository}</span>}
-                    {session.gitBranch === null ? null : <span>{session.gitBranch}</span>}
-                  </div>
+                {repoLine === '' ? null : (
+                  <p className="mt-0.5 truncate pl-5 type-label text-foreground-muted">
+                    {repoLine}
+                  </p>
                 )}
-                {session.isCloudAgent ? (
-                  <div className="mt-0.5">
-                    <span className="rounded-full bg-surface-selected px-1.5 py-0.5 type-label text-foreground-muted">
-                      Cloud
-                    </span>
-                  </div>
-                ) : null}
               </button>
             );
           })}
@@ -293,29 +332,6 @@ const ActiveSessionsSection = ({
 // ---------------------------------------------------------------------------
 // History sessions section
 // ---------------------------------------------------------------------------
-
-const relativeTime = (dateStr: string): string => {
-  const date = new Date(dateStr);
-  const now = new Date();
-  const diffMs = now.getTime() - date.getTime();
-  const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1) {
-    return 'Just now';
-  }
-  if (diffMin < 60) {
-    return `${diffMin}m ago`;
-  }
-  const diffHours = Math.floor(diffMin / 60);
-  if (diffHours < 24) {
-    return `${diffHours}h ago`;
-  }
-  const diffDays = Math.floor(diffHours / 24);
-  if (diffDays < 30) {
-    return `${diffDays}d ago`;
-  }
-  const diffMonths = Math.floor(diffDays / 30);
-  return `${diffMonths}mo ago`;
-};
 
 const HistorySessionsSection = ({
   onOpenSession,
@@ -423,6 +439,8 @@ const HistorySessionsSection = ({
   const isRefetching = isSearching ? isSearchRefetching : isHistoryRefetching;
   const rows = isSearching ? searchRows : allHistoryRows;
   const hasNoResults = !isLoading && !hasError && rows.length === 0;
+  // Hide the search box when there is nothing to search and no query typed.
+  const showSearch = inputValue !== '' || isLoading || hasError || rows.length > 0;
 
   return (
     <div className="space-y-2 px-4 py-3">
@@ -432,19 +450,21 @@ const HistorySessionsSection = ({
       </div>
 
       {/* Search box */}
-      <div className="relative">
-        <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-foreground-muted" />
-        <input
-          aria-label="Search sessions"
-          className="h-8 w-full rounded-md border border-border bg-input-bg pl-7.5 pr-2 type-body text-foreground placeholder:text-foreground-muted outline-none transition focus-visible:ring-2 focus-visible:ring-brand-primary-ring"
-          onChange={changeEvent => {
-            setInputValue(changeEvent.currentTarget.value);
-          }}
-          placeholder="Search sessions…"
-          type="search"
-          value={inputValue}
-        />
-      </div>
+      {showSearch ? (
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 size-3.5 -translate-y-1/2 text-foreground-muted" />
+          <input
+            aria-label="Search sessions"
+            className="h-8 w-full rounded-md border border-border bg-input-bg pl-7.5 pr-2 type-body text-foreground placeholder:text-foreground-muted outline-none transition focus-visible:ring-2 focus-visible:ring-brand-primary-ring"
+            onChange={changeEvent => {
+              setInputValue(changeEvent.currentTarget.value);
+            }}
+            placeholder="Search sessions…"
+            type="search"
+            value={inputValue}
+          />
+        </div>
+      ) : null}
 
       {/* Error state */}
       {hasError ? (
@@ -452,7 +472,10 @@ const HistorySessionsSection = ({
           <div className="flex items-start gap-2">
             <AlertTriangle className="mt-0.5 size-4 shrink-0 text-status-red-400" />
             <div className="min-w-0 flex-1">
-              <p className="type-label text-status-red-400">{errorMessage}</p>
+              <p className="type-label text-status-red-400">
+                {isSearching ? 'Search failed' : 'Failed to load sessions'}
+              </p>
+              <p className="type-label mt-0.5 break-words text-foreground-muted">{errorMessage}</p>
             </div>
             <button
               className="h-8 shrink-0 rounded-md border border-border bg-surface-overlay px-3 type-label text-foreground-on-secondary transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring"
@@ -484,7 +507,7 @@ const HistorySessionsSection = ({
           <p className="type-body text-foreground-muted">
             {isSearching
               ? 'No sessions match your search.'
-              : 'No sessions yet. Create your first cloud session!'}
+              : 'No sessions yet. Start your first session above.'}
           </p>
         </div>
       ) : null}
@@ -502,7 +525,11 @@ const HistorySessionsSection = ({
               type="button"
             >
               <div className="flex items-center justify-between gap-2">
-                <span className="truncate text-foreground">{session.title ?? 'New session'}</span>
+                <span
+                  className={`truncate ${session.title === null ? 'text-foreground-muted' : 'text-foreground'}`}
+                >
+                  {session.title ?? 'Untitled session'}
+                </span>
                 <span className="shrink-0 type-label text-foreground-muted">
                   {relativeTime(session.updatedAt)}
                 </span>

--- a/apps/extension/entrypoints/sidepanel/agents-session-view.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-session-view.test.ts
@@ -127,38 +127,45 @@ describe('agents message list rendering', () => {
     expect(container.textContent).toContain('completed');
   });
 
-  it('renders reasoning parts as muted label', () => {
-    const messages: StoredMessage[] = [
+  it('hides reasoning parts on a completed message and shows the tail while streaming', () => {
+    const completedInfo = {
+      id: 'msg-4',
+      sessionID: 'ses-1',
+      role: 'assistant',
+      time: { created: 4000, completed: 4000 },
+      parentID: 'msg-3',
+      modelID: 'test',
+      providerID: 'kilo',
+      mode: 'code',
+      agent: '',
+      path: { cwd: '/', root: '/' },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    } satisfies AssistantMessage;
+    const reasoningParts = [
       {
-        info: {
-          id: 'msg-4',
-          sessionID: 'ses-1',
-          role: 'assistant',
-          time: { created: 4000, completed: 4000 },
-          parentID: 'msg-3',
-          modelID: 'test',
-          providerID: 'kilo',
-          mode: 'code',
-          agent: '',
-          path: { cwd: '/', root: '/' },
-          cost: 0,
-          tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
-        } satisfies AssistantMessage,
-        parts: [
-          {
-            id: 'p-4',
-            sessionID: 'ses-1',
-            messageID: 'msg-4',
-            type: 'reasoning' as const,
-            text: 'Let me think...',
-            time: { start: 4000, end: 4100 },
-          },
-        ],
+        id: 'p-4',
+        sessionID: 'ses-1',
+        messageID: 'msg-4',
+        type: 'reasoning' as const,
+        text: 'Let me think...',
+        time: { start: 4000, end: 4100 },
       },
     ];
+    const messages: StoredMessage[] = [{ info: completedInfo, parts: reasoningParts }];
 
+    // Completed message: reasoning is noise and stays hidden.
     const { container } = render(h(AgentsMessageList, { messages }));
-    expect(container.textContent).toContain('Reasoning');
+    expect(container.textContent).not.toContain('Reasoning');
+
+    // Streaming message: the trailing reasoning part renders as a live label.
+    const streamingInfo = {
+      ...completedInfo,
+      time: { created: 4000 },
+    } satisfies AssistantMessage;
+    const streaming: StoredMessage[] = [{ info: streamingInfo, parts: reasoningParts }];
+    const { container: streamingContainer } = render(h(AgentsMessageList, { messages: streaming }));
+    expect(streamingContainer.textContent).toContain('Reasoning');
   });
 });
 

--- a/apps/extension/entrypoints/sidepanel/agents-session-view.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-session-view.test.ts
@@ -13,7 +13,7 @@ import type {
 } from '@kilocode/cloud-agent-sdk';
 import { AgentsBlockingCards } from './agents-blocking-cards';
 import { AgentsComposer } from './agents-composer';
-import { AgentsMessageList } from './agents-message-list';
+import { AgentsMessageList, toolErrorSummary } from './agents-message-list';
 
 // ---- AgentsMessageList rendering ----
 
@@ -125,6 +125,68 @@ describe('agents message list rendering', () => {
     const { container } = render(h(AgentsMessageList, { messages }));
     expect(container.textContent).toContain('read_file');
     expect(container.textContent).toContain('completed');
+  });
+
+  it("shows the tool's own title and surfaces a failed tool's reason", () => {
+    const info = {
+      id: 'msg-tool',
+      sessionID: 'ses-1',
+      role: 'assistant',
+      time: { created: 3000, completed: 3200 },
+      parentID: 'msg-2',
+      modelID: 'test',
+      providerID: 'kilo',
+      mode: 'code',
+      agent: '',
+      path: { cwd: '/', root: '/' },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    } satisfies AssistantMessage;
+    const messages: StoredMessage[] = [
+      {
+        info,
+        parts: [
+          {
+            id: 'p-ok',
+            sessionID: 'ses-1',
+            messageID: 'msg-tool',
+            type: 'tool' as const,
+            callID: 'call-ok',
+            tool: 'read',
+            state: {
+              status: 'completed' as const,
+              input: {},
+              output: 'contents',
+              title: 'README.md',
+              metadata: {},
+              time: { start: 3000, end: 3100 },
+            },
+          },
+          {
+            id: 'p-err',
+            sessionID: 'ses-1',
+            messageID: 'msg-tool',
+            type: 'tool' as const,
+            callID: 'call-err',
+            tool: 'read',
+            state: {
+              status: 'error' as const,
+              input: {},
+              error: 'ENOENT: no such file or directory\n    at open (fs.js:1)',
+              time: { start: 3100, end: 3150 },
+            },
+          },
+        ],
+      },
+    ];
+
+    const { container } = render(h(AgentsMessageList, { messages }));
+    // The title says which file, so the row is not just "read completed".
+    expect(container.textContent).toContain('README.md');
+    // A failed tool states its reason instead of a bare "error".
+    expect(container.textContent).toContain('ENOENT: no such file or directory');
+    // The stack frame is dropped.
+    expect(container.textContent).not.toContain('at open (fs.js:1)');
   });
 
   it('hides reasoning parts on a completed message and shows the tail while streaming', () => {
@@ -1082,6 +1144,46 @@ describe('agents session view integration', () => {
     });
   });
 
+  it('shows Working while a send is in flight, before the stream starts', async () => {
+    storedAtomValues['sessionConfig'] = { mode: 'code', model: 'gpt-4' };
+    storedAtomValues['canSend'] = true;
+    storedAtomValues['isStreaming'] = false;
+
+    const { container } = await renderView();
+    expect(container.textContent).not.toContain('Working');
+
+    const textarea = container.querySelector('textarea');
+    fireEvent.change(textarea!, { target: { value: 'run the tests' } });
+    const sendBtn = [...container.querySelectorAll('button')].find(
+      b => b.textContent === 'Send message'
+    );
+    fireEvent.click(sendBtn!);
+
+    // The agent has the prompt but has not streamed yet: say so rather than
+    // Leaving a dead composer and an unchanged transcript.
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Working');
+    });
+  });
+
+  it('stops claiming work when the send fails', async () => {
+    mockManager.send.mockResolvedValue(false);
+    storedAtomValues['sessionConfig'] = { mode: 'code', model: 'gpt-4' };
+    storedAtomValues['canSend'] = true;
+    storedAtomValues['isStreaming'] = false;
+
+    const { container } = await renderView();
+    const textarea = container.querySelector('textarea');
+    fireEvent.change(textarea!, { target: { value: 'run the tests' } });
+    fireEvent.click(
+      [...container.querySelectorAll('button')].find(b => b.textContent === 'Send message')!
+    );
+
+    await vi.waitFor(() => {
+      expect(container.textContent).not.toContain('Working');
+    });
+  });
+
   it('keeps failed-prompt banner when composer send returns false', async () => {
     mockManager.send.mockResolvedValue(false);
 
@@ -1499,5 +1601,25 @@ describe('agents session view integration', () => {
     expect(mockManager.destroy).toHaveBeenCalledOnce();
 
     vi.useRealTimers();
+  });
+});
+
+describe('toolErrorSummary helper', () => {
+  it('returns a short single-line error unchanged', () => {
+    expect(toolErrorSummary('ENOENT: no such file')).toBe('ENOENT: no such file');
+  });
+
+  it('keeps only the first meaningful line of a stack trace', () => {
+    expect(toolErrorSummary('\n  Error: boom\n    at foo (bar.ts:1)\n')).toBe('Error: boom');
+  });
+
+  it('clamps a very long line so the transcript stays readable', () => {
+    const summary = toolErrorSummary('x'.repeat(500));
+    expect(summary).toHaveLength(201);
+    expect(summary.endsWith('…')).toBe(true);
+  });
+
+  it('returns an empty string for whitespace-only errors', () => {
+    expect(toolErrorSummary('   \n  ')).toBe('');
   });
 });

--- a/apps/extension/entrypoints/sidepanel/agents-session-view.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-session-view.tsx
@@ -57,6 +57,11 @@ export const AgentsSessionView = ({
   const [retryingPrompt, setRetryingPrompt] = useState(false);
   const [retryingSwitch, setRetryingSwitch] = useState(false);
   const [retrySucceeded, setRetrySucceeded] = useState(false);
+  /*
+   * A sent prompt reaches the agent before `isStreaming` flips. Without this
+   * the composer just goes dead and the transcript shows nothing happening.
+   */
+  const [isSending, setIsSending] = useState(false);
 
   // When a new failedPrompt appears, reset the retry-succeeded flag.
   useEffect(() => {
@@ -95,9 +100,17 @@ export const AgentsSessionView = ({
     };
   }, [kiloSessionId, manager]);
 
+  // The agent picked the prompt up, or it failed: stop claiming work.
+  useEffect(() => {
+    if (isStreaming || error !== null) {
+      setIsSending(false);
+    }
+  }, [isStreaming, error]);
+
   const handleSend = useCallback(
     async (text: string) => {
       setRetrySucceeded(false);
+      setIsSending(true);
       const rawMode = sessionConfig?.mode ?? '';
       const rawModel = sessionConfig?.model ?? '';
       const mode = rawMode === '' ? 'code' : rawMode;
@@ -115,9 +128,12 @@ export const AgentsSessionView = ({
         });
         if (ok) {
           setRetrySucceeded(true);
+        } else {
+          setIsSending(false);
         }
       } catch {
         // Keep failedPrompt row visible — the SDK sets error atom, caller retains card.
+        setIsSending(false);
       }
     },
     [manager, sessionConfig]
@@ -449,7 +465,7 @@ export const AgentsSessionView = ({
         </div>
       ) : (
         <>
-          <AgentsMessageList isStreaming={isStreaming} messages={messages} />
+          <AgentsMessageList isStreaming={isStreaming || isSending} messages={messages} />
           <AgentsComposer
             canSend={canSend}
             canInterrupt={canInterrupt}

--- a/apps/extension/entrypoints/sidepanel/agents-session-view.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-session-view.tsx
@@ -3,8 +3,9 @@ import { useAtomValue } from 'jotai';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import type { JSX } from 'react';
 import type { KiloSessionId } from '@kilocode/cloud-agent-sdk';
-import { AlertTriangle, ArrowLeft } from 'lucide-react';
+import { AlertTriangle, ArrowLeft, GitPullRequest } from 'lucide-react';
 import { getKiloApiBaseUrl } from '@/src/shared/auth';
+import { displayRepoName } from './agents-format';
 import { useExtensionAgents } from './agents-provider';
 import { AgentsMessageList } from './agents-message-list';
 import { AgentsComposer } from './agents-composer';
@@ -27,9 +28,12 @@ const statusIndicatorClass = (type: string): string => {
 export const AgentsSessionView = ({
   kiloSessionId,
   onBack,
+  initialPrompt,
 }: {
   kiloSessionId: string;
   onBack: () => void;
+  /** Prompt to auto-send once the session accepts messages (CLI spawn flow). */
+  initialPrompt?: string | undefined;
 }): JSX.Element => {
   const { manager, organizationId } = useExtensionAgents();
   const { atoms } = manager;
@@ -123,6 +127,19 @@ export const AgentsSessionView = ({
     void manager.interrupt();
   }, [manager]);
 
+  // CLI spawn flow: send the initial prompt once the transport accepts sends.
+  const initialPromptSentRef = useRef(false);
+  useEffect(() => {
+    if (initialPrompt === undefined || initialPromptSentRef.current) {
+      return;
+    }
+    if (isLoading || !canSend) {
+      return;
+    }
+    initialPromptSentRef.current = true;
+    void handleSend(initialPrompt);
+  }, [initialPrompt, isLoading, canSend, handleSend]);
+
   const handleRetryFailedPrompt = useCallback(async () => {
     if (failedPrompt === null) {
       return;
@@ -201,9 +218,14 @@ export const AgentsSessionView = ({
 
   const rawTitle = fetchedSessionData?.title ?? '';
   const title = rawTitle === '' ? 'Session' : rawTitle;
-  const repository = fetchedSessionData?.repository ?? fetchedSessionData?.gitUrl;
+  const rawRepository = fetchedSessionData?.repository ?? fetchedSessionData?.gitUrl;
+  const repository =
+    rawRepository === null || rawRepository === undefined || rawRepository === ''
+      ? null
+      : displayRepoName(rawRepository);
   const gitBranch = fetchedSessionData?.gitBranch;
   const hasRepoInfo = (repository ?? '') !== '' || (gitBranch ?? '') !== '';
+  const associatedPr = fetchedSessionData?.associatedPr ?? null;
 
   return (
     <div className="flex min-h-0 flex-1 flex-col">
@@ -226,6 +248,19 @@ export const AgentsSessionView = ({
               </p>
             ) : null}
           </div>
+          {associatedPr === null ? null : (
+            <a
+              aria-label={`Open pull request #${associatedPr.number}`}
+              className="flex h-7 shrink-0 items-center gap-1 rounded-md border border-border bg-surface-overlay px-2 type-label text-foreground-on-secondary transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring"
+              href={associatedPr.url}
+              rel="noopener noreferrer"
+              target="_blank"
+              title={associatedPr.title ?? undefined}
+            >
+              <GitPullRequest aria-hidden="true" className="size-3.5" />
+              <span>#{associatedPr.number}</span>
+            </a>
+          )}
         </div>
       </div>
 
@@ -234,8 +269,8 @@ export const AgentsSessionView = ({
         <div
           className={`shrink-0 border-b px-4 py-2 type-label ${statusIndicatorClass(statusIndicator.type)}`}
         >
-          <div className="flex items-center justify-between gap-2">
-            <span className="min-w-0 truncate">{statusIndicator.message}</span>
+          <div className="flex items-start justify-between gap-2">
+            <span className="min-w-0 break-words">{statusIndicator.message}</span>
             {(() => {
               if (statusIndicator.type === 'error' && !isCreditsStatus) {
                 return (
@@ -414,7 +449,7 @@ export const AgentsSessionView = ({
         </div>
       ) : (
         <>
-          <AgentsMessageList messages={messages} />
+          <AgentsMessageList isStreaming={isStreaming} messages={messages} />
           <AgentsComposer
             canSend={canSend}
             canInterrupt={canInterrupt}

--- a/apps/extension/src/shared/model-preferences-client.test.ts
+++ b/apps/extension/src/shared/model-preferences-client.test.ts
@@ -95,7 +95,10 @@ describe('model preferences client', () => {
     const { fetch, seen } = captureFetch(() => favoritesEnvelope(['anthropic/claude-sonnet-4']));
     await expect(
       fetchModelPreferences({ apiBaseUrl: 'https://app.kilo.ai/', fetch, token: 'token-1' })
-    ).resolves.toStrictEqual({ favorites: ['anthropic/claude-sonnet-4'] });
+    ).resolves.toStrictEqual({
+      favorites: ['anthropic/claude-sonnet-4'],
+      lastSelected: null,
+    });
     const request = firstRequest(seen);
     expect(request.input).toBe('https://app.kilo.ai/api/trpc/modelPreferences.get');
     expect(request.input).not.toContain('batch');
@@ -128,8 +131,11 @@ describe('model preferences client', () => {
         },
       })
     );
+    // The lastSelected value passes through so the new-session form can reuse
+    // This request instead of issuing its own.
     await expect(fetchModelPreferences(clientOpts(fetch))).resolves.toStrictEqual({
       favorites: ['model-a'],
+      lastSelected: { model: 'model-a', variant: 'high' },
     });
   });
 

--- a/apps/extension/src/shared/model-preferences-client.ts
+++ b/apps/extension/src/shared/model-preferences-client.ts
@@ -229,7 +229,10 @@ export const fetchModelPreferences = async ({
   organizationId,
   signal,
   token,
-}: ModelPreferencesClientOptions): Promise<{ favorites: string[] }> => {
+}: ModelPreferencesClientOptions): Promise<{
+  favorites: string[];
+  lastSelected: unknown;
+}> => {
   const data = await requestModelPreferences({
     apiBaseUrl,
     dataSchema: favoritesDataSchema,
@@ -241,7 +244,7 @@ export const fetchModelPreferences = async ({
     ...(signal === undefined ? {} : { signal }),
   });
 
-  return { favorites: data.favorites };
+  return { favorites: data.favorites, lastSelected: data.lastSelected };
 };
 
 export const addModelFavorite = async ({

--- a/apps/extension/tests/e2e/agents-fixture.ts
+++ b/apps/extension/tests/e2e/agents-fixture.ts
@@ -67,16 +67,50 @@ export interface HistorySessionSeed {
   updatedAt: string;
 }
 
+export interface ConnectedInstanceSeed {
+  connectionId: string;
+  name: string;
+  projectName: string;
+}
+
+export const DEFAULT_INSTANCE: ConnectedInstanceSeed = {
+  connectionId: 'cli-connection-42',
+  name: 'igor-mbp',
+  projectName: 'cloud',
+};
+
+export const SPAWNED_SESSION_ID = 'ses_spawnedcli0000000000000001';
+
+export interface AssociatedPrSeed {
+  headSha: string | null;
+  lastSyncedAt: string;
+  number: number;
+  state: string;
+  title: string | null;
+  url: string;
+}
+
 export interface AgentsFixtureOptions {
   activeListFailuresBeforeSuccess?: number;
   activeSessions?: (CloudAgentSessionSeed | RemoteSessionSeed)[];
   cloudAgentWsEvents?: unknown[];
+  /** PR returned on `cliSessionsV2.getWithRuntimeState` for cloud sessions. */
+  cloudSessionAssociatedPr?: AssociatedPrSeed;
   getSessionFailuresBeforeSuccess?: number;
   historyListFailuresBeforeSuccess?: number;
   historySessions?: HistorySessionSeed[];
+  /** Connected CLI instances returned by `activeSessions.listInstances`. */
+  instances?: ConnectedInstanceSeed[];
+  /** Keep the mocked ingest relay silent — the connection never reports
+   * connected (simulates an outage; default false). */
+  ingestSilent?: boolean;
+  /** GitHub integration state for the repository pickers (default true). */
+  integrationInstalled?: boolean;
   onCloudAgentClientMessage?: (message: unknown) => void;
   onIngestClientMessage?: (message: unknown) => void;
   prepareSessionError?: Record<string, unknown>;
+  /** Fail `prepareSession` with 500 this many times, then succeed. */
+  prepareSessionFailuresBeforeSuccess?: number;
   prepareSessionStatusCode?: number;
 }
 
@@ -208,7 +242,10 @@ export const mockAgentsApi = async (
   let activeListFailures = options.activeListFailuresBeforeSuccess ?? 0;
   let historyListFailures = options.historyListFailuresBeforeSuccess ?? 0;
   let getSessionFailures = options.getSessionFailuresBeforeSuccess ?? 0;
+  let prepareSessionFailures = options.prepareSessionFailuresBeforeSuccess ?? 0;
   let preparedKiloSessionId: string | null = null;
+  /** Set when a `create_session` command spawns a session on a CLI instance. */
+  let spawnedKiloSessionId: string | null = null;
 
   // ---- /api/user ----
   await context.route('https://app.kilo.ai/api/user', route =>
@@ -264,7 +301,21 @@ export const mockAgentsApi = async (
             ? activeSessionFromCloudAgent(session)
             : activeSessionFromRemote(session)
         );
+        if (spawnedKiloSessionId !== null) {
+          sessions.push({
+            connectionId: options.instances?.[0]?.connectionId ?? 'cli-connection-42',
+            gitBranch: 'main',
+            gitUrl: 'github.com/org/repo',
+            id: spawnedKiloSessionId,
+            status: 'idle',
+            title: 'Spawned session',
+          });
+        }
         return { result: { data: { sessions } } };
+      }
+
+      if (proc === 'activeSessions.listInstances') {
+        return { result: { data: { instances: options.instances ?? [] } } };
       }
 
       if (proc === 'cliSessionsV2.list') {
@@ -367,6 +418,9 @@ export const mockAgentsApi = async (
         return {
           result: {
             data: {
+              ...(cloudSession && options.cloudSessionAssociatedPr
+                ? { associatedPr: options.cloudSessionAssociatedPr }
+                : {}),
               cloud_agent_session_id: cloudSession?.cloudAgentSessionId ?? null,
               git_branch: cloudSession?.gitBranch ?? null,
               git_url: cloudSession?.gitUrl ?? null,
@@ -374,7 +428,10 @@ export const mockAgentsApi = async (
               parent_session_id: null,
               runtimeState,
               session_id: requestedId,
-              title: cloudSession?.title ?? 'Test Session',
+              title:
+                requestedId === spawnedKiloSessionId
+                  ? 'Spawned session'
+                  : (cloudSession?.title ?? 'Test Session'),
               total_cost_microdollars: 0,
             },
           },
@@ -416,11 +473,14 @@ export const mockAgentsApi = async (
         proc === 'cloudAgentNext.listGitHubRepositories' ||
         proc === 'organizations.cloudAgentNext.listGitHubRepositories'
       ) {
+        const integrationInstalled = options.integrationInstalled ?? true;
         return {
           result: {
             data: {
-              integrationInstalled: true,
-              repositories: [{ fullName: 'org/repo', id: 1, name: 'repo', private: false }],
+              integrationInstalled,
+              repositories: integrationInstalled
+                ? [{ fullName: 'org/repo', id: 1, name: 'repo', private: false }]
+                : [],
             },
           },
         };
@@ -475,6 +535,20 @@ export const mockAgentsApi = async (
           proc === 'organizations.cloudAgentNext.prepareSession'
         ) {
           calledProcedures.push({ input: inputs[0], proc });
+          if (prepareSessionFailures > 0) {
+            prepareSessionFailures -= 1;
+            await route.fulfill({
+              json: {
+                error: {
+                  code: -32_603,
+                  data: { code: 'INTERNAL_SERVER_ERROR', httpStatus: 500 },
+                  message: 'Server error',
+                },
+              },
+              status: 500,
+            });
+            return;
+          }
           const statusCode = options.prepareSessionStatusCode;
           if (statusCode !== undefined) {
             const errorBody = options.prepareSessionError ?? {
@@ -546,17 +620,44 @@ export const mockAgentsApi = async (
   });
 
   // ---- WebSocket: session ingest ----
-  await context.routeWebSocket('wss://ingest.kilosessions.ai/api/user/web', ws => {
+  // Glob with a wildcard — the client appends ?token=…&connectionId=… and a
+  // Bare-string pattern silently never matches (auth then fails).
+  await context.routeWebSocket('wss://ingest.kilosessions.ai/api/user/web**', ws => {
+    // A healthy relay speaks first; one parsed message marks the SDK
+    // Connection as connected. `ingestSilent` simulates an outage instead.
+    if (options.ingestSilent !== true) {
+      ws.send(JSON.stringify({ data: {}, event: 'connected', type: 'system' }));
+    }
     ws.onMessage(message => {
       const parsed = parseJsonMessage(message);
       ingestClientMessages.push(parsed);
       options.onIngestClientMessage?.(parsed);
+      if (isRecordObject(parsed) && parsed['type'] === 'ping') {
+        // Answer liveness pings so the SDK keeps the socket alive.
+        if (options.ingestSilent !== true) {
+          ws.send(JSON.stringify({ nonce: parsed['nonce'], type: 'pong' }));
+        }
+        return;
+      }
       if (
         isRecordObject(parsed) &&
         typeof parsed['type'] === 'string' &&
         parsed['type'] === 'command'
       ) {
         const cmdId = typeof parsed['id'] === 'string' ? parsed['id'] : '';
+        // Spawn commands answer with the strict v1 envelope so the
+        // Extension's CLI spawn flow can navigate to the new session.
+        if (parsed['command'] === 'create_session') {
+          spawnedKiloSessionId = SPAWNED_SESSION_ID;
+          ws.send(
+            JSON.stringify({
+              id: cmdId,
+              result: { protocolVersion: 1, sessionID: SPAWNED_SESSION_ID },
+              type: 'response',
+            })
+          );
+          return;
+        }
         ws.send(JSON.stringify({ id: cmdId, result: {}, type: 'response' }));
       }
     });

--- a/apps/extension/tests/e2e/agents-fixture.ts
+++ b/apps/extension/tests/e2e/agents-fixture.ts
@@ -75,8 +75,8 @@ export interface ConnectedInstanceSeed {
 
 export const DEFAULT_INSTANCE: ConnectedInstanceSeed = {
   connectionId: 'cli-connection-42',
-  name: 'igor-mbp',
-  projectName: 'cloud',
+  name: 'dev-laptop',
+  projectName: 'checkout-service',
 };
 
 export const SPAWNED_SESSION_ID = 'ses_spawnedcli0000000000000001';
@@ -85,6 +85,9 @@ export interface AssociatedPrSeed {
   headSha: string | null;
   lastSyncedAt: string;
   number: number;
+  /** Server always sends these two; keep the seed shape faithful. */
+  reviewDecision: 'approved' | 'changes_requested' | 'review_required' | null;
+  reviewDecisionPending: boolean;
   state: string;
   title: string | null;
   url: string;

--- a/apps/extension/tests/e2e/agents-mode-live.test.ts
+++ b/apps/extension/tests/e2e/agents-mode-live.test.ts
@@ -104,52 +104,18 @@ test('live local backend: open remote CLI session, send, assert reply, send long
     });
 
     // Wait for active sessions to load. Sessions poll every ~30s; bound to 60s.
-    // Must find at least one non-Cloud active session row.
-    const sessionRows = sidePanel.locator('button:has(> div:has(> span.truncate))');
+    // CLI rows carry the "CLI" platform icon (cloud rows carry "Cloud agent").
+    const remoteRows = sidePanel.locator('button', {
+      has: sidePanel.locator('svg[aria-label="CLI"]'),
+    });
     await expect
-      .poll(
-        async () => {
-          const count = await sessionRows.count();
-          for (let idx = 0; idx < count; idx += 1) {
-            const hasCloudBadge = await sessionRows
-              .nth(idx)
-              .locator('text=Cloud')
-              .isVisible()
-              .catch(() => false);
-            if (!hasCloudBadge) {
-              return true;
-            }
-          }
-          return false;
-        },
-        {
-          message: 'No non-Cloud active sessions found — expected at least one remote CLI session',
-          timeout: 60_000,
-        }
-      )
-      .toBe(true);
+      .poll(() => remoteRows.count(), {
+        message: 'No remote CLI sessions found — expected at least one active CLI session',
+        timeout: 60_000,
+      })
+      .toBeGreaterThan(0);
 
-    // Find a non-Cloud active session. The session buttons are nested <button>
-    // Elements with a truncate span showing the title. Cloud sessions have a
-    // "Cloud" badge. Filter to rows without the Cloud badge.
-    let remoteRow: ReturnType<typeof sessionRows.nth> | null = null;
-    const rowCount = await sessionRows.count();
-    for (let rowIdx = 0; rowIdx < rowCount; rowIdx++) {
-      const row = sessionRows.nth(rowIdx);
-      const hasCloudBadge = await row
-        .locator('text=Cloud')
-        .isVisible()
-        .catch(() => false);
-      if (!hasCloudBadge) {
-        remoteRow = row;
-        break;
-      }
-    }
-    if (!remoteRow) {
-      throw new Error('No remote CLI sessions found — all active sessions are Cloud sessions');
-    }
-
-    await remoteRow.click();
+    await remoteRows.first().click();
     await expect(sidePanel.getByLabel('Back to sessions')).toBeVisible({ timeout: 15_000 });
 
     // Wait for the initial transcript to replace the session-loading skeleton.

--- a/apps/extension/tests/e2e/agents-mode.test.ts
+++ b/apps/extension/tests/e2e/agents-mode.test.ts
@@ -11,6 +11,7 @@ import {
   buildQuestionCloudAgentStream,
   buildRunningCloudAgentStream,
   DEFAULT_CLOUD_SESSION,
+  DEFAULT_HISTORY_SESSION_1,
   DEFAULT_INSTANCE,
   DEFAULT_REMOTE_SESSION,
   mockAgentsApi,
@@ -563,7 +564,7 @@ test('Agents new session spawns onto a connected CLI instance', async () => {
     // Cloud-only pickers leave the form; the CLI hint appears.
     await expect(sidePanel.getByLabel('Model', { exact: true })).toBeHidden();
     await expect(sidePanel.getByLabel('Select repository')).toBeHidden();
-    await expect(sidePanel.getByText(/Runs in cloud/)).toBeVisible();
+    await expect(sidePanel.getByText(/Runs in checkout-service/)).toBeVisible();
 
     await sidePanel.getByRole('button', { name: 'Start session' }).click();
 
@@ -591,6 +592,8 @@ test('Agents session header links the associated PR', async () => {
       headSha: 'abc123',
       lastSyncedAt: new Date().toISOString(),
       number: 512,
+      reviewDecision: 'review_required',
+      reviewDecisionPending: false,
       state: 'open',
       title: 'Fix login bug',
       url: 'https://github.com/org/repo/pull/512',
@@ -735,10 +738,22 @@ test('Agents offline pill waits out the connect grace period', async () => {
     const sidePanel = await getSidePanel();
     await navigateToAgentsMode(sidePanel);
 
-    // The mocked ingest socket never completes the connected handshake, so
-    // The pill must stay hidden through the grace period and appear after.
-    await expect(sidePanel.getByText('Offline')).toBeHidden();
-    await expect(sidePanel.getByText('Offline')).toBeVisible({ timeout: 10_000 });
+    // The mocked ingest socket never completes the connected handshake. The
+    // Pill must stay hidden for the whole grace period, then appear.
+    const offlinePill = sidePanel.getByText('Offline');
+    const startedAt = Date.now();
+    await expect(offlinePill).toBeHidden();
+    // Sample across the first 3s — one check could miss an immediate render.
+    const samples = await Promise.all(
+      [0, 500, 1000, 1500, 2000, 2500, 3000].map(async delayMs => {
+        await sidePanel.waitForTimeout(delayMs);
+        return offlinePill.isVisible().catch(() => false);
+      })
+    );
+    expect(samples).not.toContain(true);
+    await expect(offlinePill).toBeVisible({ timeout: 15_000 });
+    // It appeared only after the grace period, never before.
+    expect(Date.now() - startedAt).toBeGreaterThanOrEqual(4500);
   } finally {
     await cleanup();
   }
@@ -756,7 +771,93 @@ test('Agents new session repo picker shows Connect GitHub when not installed', a
     await expect(sidePanel.getByText('GitHub integration not connected')).toBeVisible({
       timeout: 10_000,
     });
-    await expect(sidePanel.getByRole('link', { name: 'Connect GitHub' })).toBeVisible();
+    await expect(sidePanel.getByRole('link', { name: 'Connect GitHub' }).first()).toBeVisible();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents new session explains why Start session is unavailable', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({
+    instances: [DEFAULT_INSTANCE],
+    integrationInstalled: false,
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+    await sidePanel.getByRole('button', { exact: true, name: 'New session' }).click();
+
+    const startButton = sidePanel.getByRole('button', { name: 'Start session' });
+    await sidePanel.getByLabel('What would you like to do?').fill('Fix the flaky login test');
+
+    // Cloud target with no GitHub integration can never get a repository, so
+    // The form says so instead of leaving a dead button.
+    await expect(startButton).toBeDisabled();
+    await expect(
+      sidePanel.getByText(/to start a cloud session, or pick a connected CLI instance/)
+    ).toBeVisible({ timeout: 10_000 });
+
+    // Switching to the connected CLI instance clears the block.
+    await sidePanel.getByLabel('Run on').selectOption(DEFAULT_INSTANCE.connectionId);
+    await expect(startButton).toBeEnabled();
+    await expect(
+      sidePanel.getByText(/to start a cloud session, or pick a connected CLI instance/)
+    ).toBeHidden();
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents list shows a live session once, not in both Active and History', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({
+    activeSessions: [DEFAULT_CLOUD_SESSION],
+    // The same session is also a history row — the wire returns it in both.
+    historySessions: [
+      {
+        sessionId: DEFAULT_CLOUD_SESSION.kiloSessionId,
+        title: DEFAULT_CLOUD_SESSION.title,
+        updatedAt: new Date(Date.now() - 600_000).toISOString(),
+      },
+      DEFAULT_HISTORY_SESSION_1,
+    ],
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+
+    // Exactly one row for the live session; the plain history row still shows.
+    await expect(sidePanel.getByText(DEFAULT_CLOUD_SESSION.title)).toHaveCount(1);
+    await expect(sidePanel.getByText('Refactor auth module')).toBeVisible();
+
+    // Search stays complete so a live session is still findable by name.
+    await sidePanel.getByLabel('Search sessions').fill('Fix login');
+    await expect(sidePanel.getByText(DEFAULT_CLOUD_SESSION.title)).toHaveCount(2);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents new session toolbar stays usable at the narrowest panel width', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({ instances: [DEFAULT_INSTANCE] });
+  try {
+    const sidePanel = await getSidePanel();
+    await sidePanel.setViewportSize({ height: 700, width: 320 });
+    await navigateToAgentsMode(sidePanel);
+    await sidePanel.getByRole('button', { exact: true, name: 'New session' }).click();
+    await sidePanel.getByLabel('What would you like to do?').fill('Fix the flaky login test');
+
+    // The flexible model trigger must keep its label instead of collapsing to a
+    // Sliver once the repo and Run-on pickers share the row.
+    const modelTrigger = sidePanel.getByLabel('Model', { exact: true });
+    await expect(modelTrigger).toBeVisible({ timeout: 10_000 });
+    const box = await modelTrigger.boundingBox();
+    expect(box?.width ?? 0).toBeGreaterThan(100);
+
+    // The fixed side panel must never scroll horizontally.
+    const overflow = await sidePanel.evaluate(
+      () => document.documentElement.scrollWidth - window.innerWidth
+    );
+    expect(overflow).toBeLessThanOrEqual(0);
   } finally {
     await cleanup();
   }

--- a/apps/extension/tests/e2e/agents-mode.test.ts
+++ b/apps/extension/tests/e2e/agents-mode.test.ts
@@ -11,6 +11,7 @@ import {
   buildQuestionCloudAgentStream,
   buildRunningCloudAgentStream,
   DEFAULT_CLOUD_SESSION,
+  DEFAULT_INSTANCE,
   DEFAULT_REMOTE_SESSION,
   mockAgentsApi,
   navigateToAgentsMode,
@@ -471,6 +472,291 @@ test('Agents new session shows credits error (402) with Add credits CTA', async 
     await expect(sidePanel.getByRole('link', { name: 'Add credits' })).toBeVisible({
       timeout: 5000,
     });
+  } finally {
+    await cleanup();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// 6. Feature matrix — history errors, session-load retry, prepare retry, CLI
+//    Spawn, PR link, working indicator, queued send, auto-scroll, offline
+//    Grace, GitHub not connected
+// ---------------------------------------------------------------------------
+
+test('Agents history list shows retryable error and recovers', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({
+    historyListFailuresBeforeSuccess: 1,
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+
+    await expect(sidePanel.getByText('Failed to load sessions')).toBeVisible({ timeout: 10_000 });
+    await sidePanel.getByRole('button', { name: 'Retry' }).click();
+    await expect(sidePanel.getByText('Refactor auth module')).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents session view load failure shows Retry and recovers', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({
+    getSessionFailuresBeforeSuccess: 1,
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+    await sidePanel.getByText('Fix login bug').click();
+
+    const retryButton = sidePanel.getByRole('button', { name: 'Retry' });
+    await expect(retryButton).toBeVisible({ timeout: 15_000 });
+    await retryButton.click();
+
+    // Recovered: transcript streams from the mocked cloud-agent socket.
+    await expect(sidePanel.getByText('I found the issue.')).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents new session retries a failed prepare and succeeds', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({
+    prepareSessionFailuresBeforeSuccess: 1,
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+
+    await sidePanel.getByRole('button', { exact: true, name: 'New session' }).click();
+    await sidePanel.getByLabel('What would you like to do?').fill('Fix the login page');
+    await sidePanel.waitForTimeout(500);
+    await sidePanel.getByRole('button', { name: 'Start session' }).click();
+
+    // Retryable failure shows the banner with a Retry CTA.
+    const retryButton = sidePanel.getByRole('button', { name: 'Retry' });
+    await expect(retryButton).toBeVisible({ timeout: 10_000 });
+    await retryButton.click();
+
+    // Second attempt succeeds and navigates into the session.
+    await expect(sidePanel.getByLabel('Back to sessions')).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents new session spawns onto a connected CLI instance', async () => {
+  const { cleanup, getSidePanel, mockResult } = await setupAgentsTest({
+    instances: [DEFAULT_INSTANCE],
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+
+    await sidePanel.getByRole('button', { exact: true, name: 'New session' }).click();
+    await sidePanel.getByLabel('What would you like to do?').fill('Run the test suite');
+
+    // Pick the CLI instance as the run target.
+    const runOn = sidePanel.getByLabel('Run on');
+    await expect(runOn).toBeVisible({ timeout: 10_000 });
+    await runOn.selectOption(DEFAULT_INSTANCE.connectionId);
+
+    // Cloud-only pickers leave the form; the CLI hint appears.
+    await expect(sidePanel.getByLabel('Select model')).toBeHidden();
+    await expect(sidePanel.getByLabel('Select repository')).toBeHidden();
+    await expect(sidePanel.getByText(/Runs in cloud/)).toBeVisible();
+
+    await sidePanel.getByRole('button', { name: 'Start session' }).click();
+
+    // The spawn command goes out on the user-web socket and the view
+    // Navigates to the spawned session.
+    await expect(sidePanel.getByLabel('Back to sessions')).toBeVisible({ timeout: 15_000 });
+    const spawnCommands = mockResult.ingestClientMessages.filter(
+      message =>
+        typeof message === 'object' &&
+        message !== null &&
+        (message as { command?: string }).command === 'create_session'
+    );
+    expect(spawnCommands.length).toBeGreaterThan(0);
+    await expect(sidePanel.getByRole('heading', { name: 'Spawned session' })).toBeVisible({
+      timeout: 15_000,
+    });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents session header links the associated PR', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({
+    cloudSessionAssociatedPr: {
+      headSha: 'abc123',
+      lastSyncedAt: new Date().toISOString(),
+      number: 512,
+      state: 'open',
+      title: 'Fix login bug',
+      url: 'https://github.com/org/repo/pull/512',
+    },
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+    await sidePanel.getByText('Fix login bug').click();
+
+    const prLink = sidePanel.getByLabel('Open pull request #512');
+    await expect(prLink).toBeVisible({ timeout: 15_000 });
+    await expect(prLink).toHaveAttribute('href', 'https://github.com/org/repo/pull/512');
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents session shows a working indicator while the agent runs without output', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({
+    cloudAgentWsEvents: buildRunningCloudAgentStream(),
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+    await sidePanel.getByText('Fix login bug').click();
+
+    await expect(sidePanel.getByText('Working…')).toBeVisible({ timeout: 15_000 });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents composer queues a send while the agent runs', async () => {
+  const { cleanup, getSidePanel, mockResult } = await setupAgentsTest({
+    cloudAgentWsEvents: buildRunningCloudAgentStream(),
+  });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+    await sidePanel.getByText('Fix login bug').click();
+
+    const composer = sidePanel.getByLabel('Message agent');
+    await expect(composer).toBeVisible({ timeout: 15_000 });
+    // The run is live: the Stop control is present while we queue a send.
+    await expect(sidePanel.getByRole('button', { name: 'Stop' })).toBeVisible({
+      timeout: 15_000,
+    });
+    await composer.fill('Also update the changelog');
+    await composer.press('Enter');
+
+    // The draft clears and the send reaches the API despite the run.
+    await expect(composer).toHaveValue('', { timeout: 10_000 });
+    await expect
+      .poll(
+        () => mockResult.calledProcedures.filter(call => call.proc.includes('sendMessage')).length,
+        { timeout: 10_000 }
+      )
+      .toBeGreaterThan(0);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents session transcript opens pinned to the bottom', async () => {
+  const sessionId = 'ses_cloudsession00000000001';
+  let eventCounter = 0;
+  const ev = (streamEventType: string, data: unknown): Record<string, unknown> => ({
+    data,
+    eventId: ++eventCounter,
+    executionId: 'exec-scroll',
+    sessionId,
+    streamEventType,
+    timestamp: new Date().toISOString(),
+  });
+  const kilocode = (type: string, properties: unknown): Record<string, unknown> =>
+    ev('kilocode', { properties, type });
+  const events: Record<string, unknown>[] = [
+    kilocode('session.created', { info: { id: sessionId } }),
+  ];
+  for (let index = 1; index <= 12; index++) {
+    events.push(
+      kilocode('message.updated', {
+        info: {
+          agent: 'build',
+          cost: 0,
+          id: `msg-${String(index).padStart(3, '0')}`,
+          mode: 'code',
+          modelID: 'm',
+          path: { cwd: '/', root: '/' },
+          providerID: 'p',
+          role: 'assistant',
+          sessionID: sessionId,
+          time: { completed: Date.now(), created: Date.now() },
+          tokens: { cache: { read: 0, write: 0 }, input: 0, output: 0, reasoning: 0 },
+        },
+      }),
+      kilocode('message.part.updated', {
+        part: {
+          id: `part-${String(index).padStart(3, '0')}`,
+          messageID: `msg-${String(index).padStart(3, '0')}`,
+          sessionID: sessionId,
+          text: `Long transcript row ${index}: this line wraps across the panel and consumes vertical space so the list must scroll.`,
+          type: 'text',
+        },
+      })
+    );
+  }
+  events.push(ev('complete', { currentBranch: 'main' }));
+
+  const { cleanup, getSidePanel } = await setupAgentsTest({ cloudAgentWsEvents: events });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+    await sidePanel.getByText('Fix login bug').click();
+    await expect(sidePanel.getByText('Long transcript row 12', { exact: false })).toBeVisible({
+      timeout: 15_000,
+    });
+
+    const scrollState = await sidePanel.evaluate(() => {
+      const panes = document.querySelectorAll('.agent-conversation-scrollbar');
+      const pane = [...panes].at(-1);
+      if (!(pane instanceof HTMLElement)) {
+        return null;
+      }
+      return {
+        atBottom: pane.scrollTop + pane.clientHeight >= pane.scrollHeight - 48,
+        scrollable: pane.scrollHeight > pane.clientHeight,
+      };
+    });
+    expect(scrollState).not.toBeNull();
+    expect(scrollState!.scrollable).toBe(true);
+    expect(scrollState!.atBottom).toBe(true);
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents offline pill waits out the connect grace period', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({ ingestSilent: true });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+
+    // The mocked ingest socket never completes the connected handshake, so
+    // The pill must stay hidden through the grace period and appear after.
+    await expect(sidePanel.getByText('Offline')).toBeHidden();
+    await expect(sidePanel.getByText('Offline')).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanup();
+  }
+});
+
+test('Agents new session repo picker shows Connect GitHub when not installed', async () => {
+  const { cleanup, getSidePanel } = await setupAgentsTest({ integrationInstalled: false });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+
+    await sidePanel.getByRole('button', { exact: true, name: 'New session' }).click();
+    await sidePanel.getByLabel('Select repository').click();
+
+    await expect(sidePanel.getByText('GitHub integration not connected')).toBeVisible({
+      timeout: 10_000,
+    });
+    await expect(sidePanel.getByRole('link', { name: 'Connect GitHub' })).toBeVisible();
   } finally {
     await cleanup();
   }

--- a/apps/extension/tests/e2e/agents-mode.test.ts
+++ b/apps/extension/tests/e2e/agents-mode.test.ts
@@ -116,8 +116,10 @@ test('Agents list shows empty state when no sessions exist', async () => {
 
     await expect(sidePanel.getByText('No active sessions')).toBeVisible();
     await expect(
-      sidePanel.getByText('No sessions yet. Create your first cloud session!')
+      sidePanel.getByText('No sessions yet. Start your first session above.')
     ).toBeVisible();
+    // With zero sessions and no query there is nothing to search.
+    await expect(sidePanel.getByLabel('Search sessions')).toBeHidden();
   } finally {
     await cleanup();
   }
@@ -132,13 +134,20 @@ test('Agents list shows populated active and history sessions', async () => {
     // Active section
     await expect(sidePanel.getByText('Fix login bug')).toBeVisible();
     await expect(sidePanel.getByText('Running')).toBeVisible();
-    await expect(sidePanel.getByText('Cloud')).toBeVisible();
+    // Platform markers: cloud icon on the cloud row, terminal icon on the CLI row.
+    await expect(sidePanel.getByLabel('Cloud agent')).toBeVisible();
+    await expect(sidePanel.getByLabel('CLI')).toBeVisible();
+    // The CLI row's raw status renders capitalized.
+    await expect(sidePanel.getByText('Idle')).toBeVisible();
+    // Repo and branch join with a separator, host prefix stripped.
+    await expect(sidePanel.getByText('org/repo · fix/login')).toBeVisible();
 
     // History section
     await expect(sidePanel.getByText('Refactor auth module')).toBeVisible();
-    // The null-title history session renders "New session" as the row title.
-    // Use the button accessible name which includes the relative time.
-    await expect(sidePanel.getByRole('button', { name: /New session \d+d ago/ })).toBeVisible();
+    // The null-title history session renders a muted "Untitled session" title.
+    await expect(
+      sidePanel.getByRole('button', { name: /Untitled session \d+d ago/ })
+    ).toBeVisible();
   } finally {
     await cleanup();
   }
@@ -382,7 +391,9 @@ test('Agents new session shows the create form and navigates to the new session 
 
     // Click "New session"
     await sidePanel.getByRole('button', { exact: true, name: 'New session' }).click();
-    await expect(sidePanel.getByText('New Cloud Session')).toBeVisible({ timeout: 10_000 });
+    await expect(sidePanel.getByText('New session', { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
 
     // Fill the form
     const promptArea = sidePanel.getByLabel('What would you like to do?');
@@ -425,7 +436,9 @@ test('Agents new session shows credits error (402) with Add credits CTA', async 
     await navigateToAgentsMode(sidePanel);
 
     await sidePanel.getByRole('button', { exact: true, name: 'New session' }).click();
-    await expect(sidePanel.getByText('New Cloud Session')).toBeVisible({ timeout: 10_000 });
+    await expect(sidePanel.getByText('New session', { exact: true })).toBeVisible({
+      timeout: 10_000,
+    });
 
     const promptArea = sidePanel.getByLabel('What would you like to do?');
     await promptArea.fill('Fix the login page');

--- a/apps/extension/tests/e2e/agents-mode.test.ts
+++ b/apps/extension/tests/e2e/agents-mode.test.ts
@@ -561,7 +561,7 @@ test('Agents new session spawns onto a connected CLI instance', async () => {
     await runOn.selectOption(DEFAULT_INSTANCE.connectionId);
 
     // Cloud-only pickers leave the form; the CLI hint appears.
-    await expect(sidePanel.getByLabel('Select model')).toBeHidden();
+    await expect(sidePanel.getByLabel('Model', { exact: true })).toBeHidden();
     await expect(sidePanel.getByLabel('Select repository')).toBeHidden();
     await expect(sidePanel.getByText(/Runs in cloud/)).toBeVisible();
 

--- a/packages/cloud-agent-sdk/src/index.ts
+++ b/packages/cloud-agent-sdk/src/index.ts
@@ -81,7 +81,7 @@ export type {
   UserWebSystemEvent,
 } from './user-web-connection';
 
-export { createRemoteSessionOnConnection } from './create-session';
+export { createRemoteSessionOnConnection, parseCreateSessionResponse } from './create-session';
 
 export {
   REMOTE_MODEL_IDENTITY_MAX_LENGTH,


### PR DESCRIPTION
UX and functionality pass of the extension agents tab: cloud agent sessions and remote CLI sessions. Every state verified twice — mocked Playwright e2e for the full feature matrix (27 tests), and a live pass against the local stack with a real CLI instance (`kilo` 7.4.20) and a real cloud-agent session: real model replies, spawn onto the CLI, follow-up sends, interrupt.

## Functionality

- **Start a session on a connected CLI instance.** The new-session form gets a "Run on" picker (visible only when an instance is connected). Spawn goes over the user-web socket (`create_session` v1); the initial prompt auto-sends once the session accepts messages. Cloud path unchanged.
- **Send while the agent runs.** Enter queues the message instead of silently dropping it.
- **Dead Start button fixed.** With no GitHub integration the cloud form could never get a repository, so Start session sat disabled with nothing explaining why — found by driving the real backend. The form now names the blocker (Connect GitHub / no repositories / no models / pick a repository) and points at the CLI-instance alternative.
- **A live session no longer appears twice.** It was rendering in both Active and History. History now drops rows already shown above; search stays complete so a live session is still findable by name.
- **Associated PR link** in the session header (was fetched, never shown).
- **Transcript pins to the bottom** and follows streaming until the user scrolls up; re-arms when they return.
- **Message parts render in stored order** — tools before the text they produced.
- **A failed tool now says why.** Tool rows showed only name + status, so a failure read "read error" with no reason even though `state.error` was available. Rows now carry the tool's own title (the file, the command) and a failed tool states its reason, clamped to the first line.
- **A sent prompt no longer looks ignored.** The prompt reaches the agent before the SDK reports streaming, so the composer went dead with an unchanged transcript; the Working row now appears on send and gives way to the assistant's output. A failed send clears it rather than claiming work that is not happening.
- `displayRepoName` handles the CLI heartbeat's real remotes (scp-style `git@host:org/repo.git`, `ssh://`, trailing `.git`) instead of showing them raw.

## UX

- Session list: platform icon per row (cloud / CLI); one status vocabulary — `busy` and `running` both read as **Running**, `retry` as **Retrying**; `org/repo · branch` with the host stripped; muted "Untitled session"; Offline pill only after 5s of sustained disconnect; search box hidden when there is nothing to search.
- Session view: Working indicator between a sent prompt and the first token; spinner on running tool rows; reasoning rows hidden on completed messages (real transcripts carry one before nearly every step — they drowned the content); status banners wrap instead of truncating.
- New session: full-width "Start session" button; the form reuses the browser tab's ModelPicker (search + favorites) so model UX matches the Browser tab; the model trigger keeps a min width instead of collapsing to a sliver when the repo and Run-on pickers share the row (caught at 320px).

## Tests

- `agents-mode.test.ts`: **27 green**, 13 new — retry recovery for history/session-load/prepare, CLI spawn end to end, PR link, working indicator, queued send, bottom pinning, offline grace period, Connect GitHub state, blocked-reason line, duplicate-row regression, and a 320px layout check with a no-horizontal-overflow assertion.
- Unit: **917 green**, including new coverage for `displayRepoName`, `submitBlockedReason`, and the status mapping.
- Fixture fix worth flagging: the ingest WebSocket route pattern never matched the real URL (query string), so every mocked run silently exercised a dead user-web connection. The mock relay now speaks the minimal protocol (hello, pong, `create_session` envelope).
- Live (not in CI): device-auth sign-in, real cloud session open + follow-up, working indicator, GitHub-not-connected state, spawn onto a real CLI instance, real reply, interrupt — all through the extension UI. Five of the bugs above were invisible to the mocked suite and only surfaced by driving the real backend.

All five Kilobot findings from the first review round are addressed.

## Skipped / follow-ups

- Firefox e2e not run (both builds verified); Chrome e2e + verify green locally and in CI.
- Session delete/rename from the list — mobile has it, extension doesn't yet.
- Not done deliberately, each being a new feature rather than a defect: history date grouping, a tool-detail sheet (the inline error covers the common need), a scroll-to-bottom button, cost in the session header.
- Local-stack note: UI-created cloud sessions still hang locally (`cloud-agent-web` snapshot-wait, pre-existing) — the live pass created its cloud session worker-direct per the known recipe.
