### PR TITLE
fix(mobile): remove session history transition jank

### DIFF
--- a/apps/mobile/src/components/agents/active-now-section.test.ts
+++ b/apps/mobile/src/components/agents/active-now-section.test.ts
@@ -11,14 +11,6 @@ import { type ActiveSession } from '@/lib/hooks/use-agent-sessions';
 vi.mock('react-native', () => ({
   View: 'View',
 }));
-vi.mock('react-native-reanimated', () => ({
-  __esModule: true,
-  default: { View: 'Animated.View' },
-  FadeIn: { duration: () => ({}) },
-  FadeOut: { duration: () => ({}) },
-  LinearTransition: { duration: () => ({}) },
-  useReducedMotion: () => true,
-}));
 vi.mock('@/components/agents/remote-session-row', () => ({
   RemoteSessionRow: 'RemoteSessionRow',
 }));
@@ -89,13 +81,15 @@ function collectElements(node: unknown): React.ReactElement[] {
 
 describe('ActiveNowSection rows', () => {
   it('renders one row per pinned session, with no cap', async () => {
-    // Rows are `AnimatedRow` elements; their own children are not evaluated
-    // without a renderer, so the elements carrying a `session` prop are the
-    // row count.
+    // Rows are `RemoteSessionRow` elements rendered directly by the section;
+    // their own children are not evaluated without a renderer, so the elements
+    // carrying a `session` prop are the row count.
     const rows = collectElements(await renderSection(pinnedSessions())).filter(element =>
       Object.hasOwn(elementProps(element), 'session')
     );
     expect(rows).toHaveLength(PINNED_IDS.length);
+    const ids = rows.map(element => (elementProps(element).session as ActiveSession).id);
+    expect(ids).toEqual(PINNED_IDS);
   });
 
   it('renders no expander control', async () => {
@@ -111,21 +105,23 @@ describe('ActiveNowSection rows', () => {
   });
 });
 
-describe('ActiveNowSection reduced motion', () => {
-  it('loads the module under useReducedMotion() => true without throwing', async () => {
-    const mod = await import('./active-now-section');
-    expect(typeof mod.ActiveNowSection).toBe('function');
+describe('ActiveNowSection atomic swap', () => {
+  it('mounts the tray and rows atomically — no entering, exiting, or layout props', async () => {
+    const animated = collectElements(await renderSection(pinnedSessions())).filter(element => {
+      const props = elementProps(element);
+      return (
+        Object.hasOwn(props, 'entering') ||
+        Object.hasOwn(props, 'exiting') ||
+        Object.hasOwn(props, 'layout')
+      );
+    });
+    expect(animated).toEqual([]);
   });
 
-  it('suppresses LinearTransition on the tray under reduced motion', async () => {
-    // The gate is `layout={reducedMotion ? undefined : LinearTransition}`, so
-    // every element that carries a `layout` prop must pass `undefined`.
-    const layoutElements = collectElements(await renderSection(pinnedSessions())).filter(element =>
-      Object.hasOwn(elementProps(element), 'layout')
+  it('scopes the tray surface with the agents-active-now-section test id', async () => {
+    const containers = collectElements(await renderSection(pinnedSessions())).filter(
+      element => elementProps(element).testID === 'agents-active-now-section'
     );
-    expect(layoutElements.length).toBeGreaterThan(0);
-    for (const element of layoutElements) {
-      expect(elementProps(element).layout).toBeUndefined();
-    }
+    expect(containers).toHaveLength(1);
   });
 });

--- a/apps/mobile/src/components/agents/active-now-section.tsx
+++ b/apps/mobile/src/components/agents/active-now-section.tsx
@@ -1,10 +1,4 @@
 import { View } from 'react-native';
-import Animated, {
-  FadeIn,
-  FadeOut,
-  LinearTransition,
-  useReducedMotion,
-} from 'react-native-reanimated';
 
 import { RemoteSessionRow } from '@/components/agents/remote-session-row';
 import { SessionListSectionHeader } from '@/components/agents/session-list-section-header';
@@ -26,9 +20,15 @@ type ActiveNowSectionProps = {
  * Pinned "Active now" tray for the Agents session list. Rendered as the
  * history `SectionList`'s `ListHeaderComponent`, so it scrolls with the
  * session history in one continuous gesture (search/filter chrome stays
- * pinned above the list). `ListHeaderComponent` is not a virtualized cell,
- * so Reanimated `FadeIn`/`FadeOut`/`LinearTransition` wrappers on the tray
- * and its rows keep working.
+ * pinned above the list).
+ *
+ * The tray and its rows mount and unmount atomically: there are no entering,
+ * exiting, or layout animations. A session moving between history and the
+ * tray therefore swaps in the same commit its twin is excluded or
+ * reinserted — no fade overlap against the instant virtualized-row removal,
+ * and no ~120 ms exiting native node that would duplicate the reinserted
+ * history row for screen readers. `maintainVisibleContentPosition` on the
+ * SectionList keeps the remaining rows anchored.
  *
  * The tray renders one row per pinned session. There is no cap and no
  * expander: the user asked for the full list.
@@ -38,58 +38,22 @@ export function ActiveNowSection({
   organizationIdBySessionId,
   onSessionPress,
 }: Readonly<ActiveNowSectionProps>) {
-  const reducedMotion = useReducedMotion();
-
   if (pinned.length === 0) {
     return null;
   }
 
   return (
-    <Animated.View
-      entering={FadeIn.duration(180)}
-      exiting={FadeOut.duration(120)}
-      layout={reducedMotion ? undefined : LinearTransition}
-      className="bg-background"
-    >
+    <View testID="agents-active-now-section" className="bg-background">
       <SessionListSectionHeader title="Active now" count={pinned.length} />
       {pinned.map(session => (
-        <AnimatedRow
+        <RemoteSessionRow
           key={session.id}
-          reducedMotion={reducedMotion}
           session={session}
           onPress={() => {
             onSessionPress(session.id, organizationIdBySessionId.get(session.id));
           }}
         />
       ))}
-    </Animated.View>
-  );
-}
-
-/**
- * Per-row wrapper that fades individual rows in/out while the tray is
- * animating. Under `useReducedMotion()` the entering/exiting row animations
- * are suppressed so rows appear instantly.
- */
-function AnimatedRow({
-  reducedMotion,
-  session,
-  onPress,
-}: Readonly<{
-  reducedMotion: boolean | null;
-  session: ActiveSession;
-  onPress: () => void;
-}>) {
-  if (reducedMotion) {
-    return (
-      <View>
-        <RemoteSessionRow session={session} onPress={onPress} />
-      </View>
-    );
-  }
-  return (
-    <Animated.View entering={FadeIn.duration(120)} exiting={FadeOut.duration(120)}>
-      <RemoteSessionRow session={session} onPress={onPress} />
-    </Animated.View>
+    </View>
   );
 }

--- a/apps/mobile/src/components/agents/session-list-active-set.test.ts
+++ b/apps/mobile/src/components/agents/session-list-active-set.test.ts
@@ -1,12 +1,32 @@
 import { describe, expect, it } from 'vitest';
 
 import { type AgentSessionDateGroup, groupAgentSessionsByDate } from '@/lib/agent-session-groups';
-import { excludeActiveFromGroups } from '@/components/agents/session-list-helpers';
+import {
+  filterActiveSessionsByOrganization,
+  selectActiveExclusionIds,
+} from '@/lib/active-sessions-live';
+import {
+  excludeActiveFromGroups,
+  selectPinnedActiveSessions,
+} from '@/components/agents/session-list-helpers';
 import { type AgentSessionSortBy } from '@/lib/agent-session-sort';
 
 // ── Helpers ───────────────────────────────────────────────────────────
 
 type Row = { session_id: string; created_at: string; updated_at: string };
+
+/** Minimal `ActiveSession`-shaped row; `organizationId` is set only after enrichment. */
+type ActiveRow = {
+  id: string;
+  status: string;
+  title: string;
+  connectionId: string;
+  organizationId?: string | null;
+};
+
+function makeActive(id: string, over: { organizationId?: string | null } = {}): ActiveRow {
+  return { id, status: 'running', title: `Session ${id}`, connectionId: 'c1', ...over };
+}
 
 function makeSessions(ids: string[], baseTimestamp: string): Row[] {
   return ids.map((id, i) => ({
@@ -99,5 +119,122 @@ describe('active-set order regression', () => {
     const sections = activeAwareSections(groups, allIds);
 
     expect(sections).toEqual([]);
+  });
+});
+
+// ── first-history-then-active sequence ────────────────────────────────
+
+describe('first-history-then-active sequence', () => {
+  // `x` is the only stored row; the sequence below moves it between history
+  // and the tray as the live cache fills, enriches, and drops it.
+  const baseDate = '2026-01-01T12:00:00Z';
+  const sortBy: AgentSessionSortBy = 'updated_at';
+  const groups = groupAgentSessionsByDate(
+    makeSessions(['x'], baseDate),
+    sortBy,
+    new Date('2026-08-01T12:00:00Z')
+  );
+
+  /**
+   * Same composition as `useAgentSessionListData`: the tray side runs the
+   * org-filtered rows through `selectPinnedActiveSessions`; the history side
+   * drops ids in the chosen exclusion set from the stored groups. `narrowing`
+   * replicates the `sections` memo's switch — a committed search
+   * (`isSearching`, including the pending first-fetch window where the
+   * effective query is still `''`) or a platform/project filter selects the
+   * org-filtered set; none of the three selects the unfiltered cache set.
+   */
+  function reconcile(
+    cache: ActiveRow[],
+    narrowing: { isSearching?: boolean; platformFilter?: string[]; projectFilter?: string[] } = {}
+  ) {
+    const { isSearching = false, platformFilter = [], projectFilter = [] } = narrowing;
+    const trayRows = filterActiveSessionsByOrganization(cache, 'org-1');
+    const pinned = selectPinnedActiveSessions({
+      activeSessions: trayRows,
+      projectFilter: [],
+      platformFilter: [],
+      searchQuery: '',
+    });
+    const activeSessionIds = new Set(trayRows.map(s => s.id));
+    const activeExclusionIds = selectActiveExclusionIds(cache);
+    const narrowed = isSearching || platformFilter.length > 0 || projectFilter.length > 0;
+    const exclusionIds = narrowed ? activeSessionIds : activeExclusionIds;
+    return {
+      pinned: pinned.map(s => s.id),
+      history: rowOrder(excludeActiveFromGroups(groups, exclusionIds)),
+      exclusionIds,
+    };
+  }
+
+  it('moves a session from history to the tray through the unenriched window without duplicates', () => {
+    // 1. Live cache empty → `x` renders in history; the tray is empty.
+    let cache: ActiveRow[] = [];
+    let result = reconcile(cache);
+    expect(result.history).toEqual(['x']);
+    expect(result.pinned).toEqual([]);
+    expect(result.pinned.every(id => result.exclusionIds.has(id))).toBe(true);
+
+    // 2. WS write lands UNENRICHED (no `organizationId`): the org filter
+    //    hides it from the tray, and the unfiltered exclusion set drops it
+    //    from history — the direct-move window renders it in neither surface.
+    cache = [makeActive('x')];
+    result = reconcile(cache);
+    expect(filterActiveSessionsByOrganization(cache, 'org-1')).toEqual([]);
+    expect(result.pinned).toEqual([]);
+    expect(result.history).toEqual([]);
+    expect(result.pinned.every(id => result.exclusionIds.has(id))).toBe(true);
+
+    // 3. Enrichment attributes the row to org-1 → pinned in the tray, still
+    //    excluded from history.
+    cache = [makeActive('x', { organizationId: 'org-1' })];
+    result = reconcile(cache);
+    expect(result.pinned).toEqual(['x']);
+    expect(result.history).toEqual([]);
+    expect(result.pinned.every(id => result.exclusionIds.has(id))).toBe(true);
+
+    // 4. Departure drops the row from the cache → history re-renders it at
+    //    its original position; the tray is empty again.
+    cache = [];
+    result = reconcile(cache);
+    expect(result.pinned).toEqual([]);
+    expect(result.history).toEqual(['x']);
+    expect(result.pinned.every(id => result.exclusionIds.has(id))).toBe(true);
+  });
+
+  describe('narrowing matrix', () => {
+    it('full view excludes the unenriched row; every narrowed view keeps it in history', () => {
+      const cache = [makeActive('x')];
+
+      // None of the three narrowing inputs active → unfiltered cache set.
+      expect(reconcile(cache).history).toEqual([]);
+
+      // Committed search text — including the pending first-fetch window
+      // where the effective query is still `''` — keeps the org-filtered set.
+      expect(reconcile(cache, { isSearching: true }).history).toEqual(['x']);
+
+      // Platform filter.
+      expect(reconcile(cache, { platformFilter: ['cli'] }).history).toEqual(['x']);
+
+      // Project filter.
+      expect(reconcile(cache, { projectFilter: ['https://example.com/r'] }).history).toEqual(['x']);
+    });
+
+    it('narrowed views still exclude an org-attributed row (the org-filtered set covers it)', () => {
+      const cache = [makeActive('x', { organizationId: 'org-1' })];
+      expect(reconcile(cache, { isSearching: true }).history).toEqual([]);
+      expect(reconcile(cache, { platformFilter: ['cli'] }).history).toEqual([]);
+    });
+
+    it('keeps exclusivity in both modes: pinned is always a subset of the exclusion set', () => {
+      const unenriched = [makeActive('x')];
+      expect(
+        reconcile(unenriched).pinned.every(id => reconcile(unenriched).exclusionIds.has(id))
+      ).toBe(true);
+      const enriched = [makeActive('x', { organizationId: 'org-1' })];
+      expect(reconcile(enriched).pinned.every(id => reconcile(enriched).exclusionIds.has(id))).toBe(
+        true
+      );
+    });
   });
 });

--- a/apps/mobile/src/components/agents/session-list-backfill.test.ts
+++ b/apps/mobile/src/components/agents/session-list-backfill.test.ts
@@ -11,6 +11,7 @@ function params(
   return {
     hasHistoryContent: false,
     hasStoredSessions: true,
+    hasPinnedActive: true,
     hasMoreHistory: true,
     isFetchingNextPage: false,
     isFetching: false,
@@ -30,6 +31,7 @@ describe('shouldBackfillHistoryAfterActiveExclusion', () => {
   it.each([
     ['history content is visible', { hasHistoryContent: true }],
     ['no stored rows are loaded', { hasStoredSessions: false }],
+    ['the tray is empty (unenriched window)', { hasPinnedActive: false }],
     ['no further history page exists', { hasMoreHistory: false }],
     ['the next page is already fetching', { isFetchingNextPage: true }],
     ['any stored fetch is in flight', { isFetching: true }],

--- a/apps/mobile/src/components/agents/session-list-backfill.ts
+++ b/apps/mobile/src/components/agents/session-list-backfill.ts
@@ -5,6 +5,9 @@
  * keeps the list rendered instead of claiming the history is exhausted. This
  * selector decides whether the caller should fetch the next stored page
  * automatically. Every gate must be green:
+ *  - `hasPinnedActive` is the populated-tray gate: the backfill exists to
+ *    fill history below a viewport-filling tray, so an empty tray (the
+ *    unenriched window, covered by the `all-active` body) blocks it.
  *  - `hasHistoryContent` is false when no rendered section survives the
  *    active-set exclusion.
  *  - `hasMoreHistory` is the stored pagination `hasNextPage`.
@@ -27,6 +30,7 @@ export const MAX_HISTORY_AUTOLOAD_PAGES = 3;
 export function shouldBackfillHistoryAfterActiveExclusion(params: {
   hasHistoryContent: boolean;
   hasStoredSessions: boolean;
+  hasPinnedActive: boolean;
   hasMoreHistory: boolean | undefined;
   isFetchingNextPage: boolean;
   isFetching: boolean;
@@ -36,6 +40,7 @@ export function shouldBackfillHistoryAfterActiveExclusion(params: {
   loadedPageCount: number;
 }): boolean {
   return (
+    params.hasPinnedActive &&
     !params.hasHistoryContent &&
     params.hasStoredSessions &&
     params.hasMoreHistory === true &&

--- a/apps/mobile/src/components/agents/session-list-body-empty.tsx
+++ b/apps/mobile/src/components/agents/session-list-body-empty.tsx
@@ -67,10 +67,11 @@ export function BodyEmpty({
     );
   }
   if (kind === 'all-active') {
-    // Every loaded stored session is currently active and pinned above, so
-    // the body is empty only because the active set consumed the history.
-    // No creation CTA: the tray, the FAB, and the header action already
-    // offer creation.
+    // Every loaded stored session is excluded by the live active set, so the
+    // body is empty only because the active set consumed the history. In the
+    // full view the exclusion set also covers WS-written rows awaiting org
+    // attribution, so the tray can be momentarily empty here. No creation
+    // CTA: the tray, the FAB, and the header action already offer creation.
     return (
       <View className="items-center justify-center pt-12">
         <EmptyState

--- a/apps/mobile/src/components/agents/session-list-body-model.test.ts
+++ b/apps/mobile/src/components/agents/session-list-body-model.test.ts
@@ -1,3 +1,4 @@
+// oxlint-disable max-lines -- one coherent decision-tree suite; every branch maps to a feature-state row in the model's doc comment
 import { describe, expect, it } from 'vitest';
 
 import { selectSessionListBodyModel } from './session-list-body-model';
@@ -140,6 +141,72 @@ describe('selectSessionListBodyModel', () => {
         primaryAction: 'retry',
         secondaryAction: 'clear-search',
         showInlineError: true,
+      });
+    });
+  });
+
+  describe('stored rows do not widen inline errors into query states', () => {
+    it('does not add an inline error to a stored-row search error with an empty tray', () => {
+      expect(
+        model({
+          hasHistoryContent: false,
+          hasStoredSessions: true,
+          hasActiveQuery: true,
+          isSearching: true,
+          isError: true,
+        })
+      ).toEqual({
+        kind: 'query-error-empty',
+        primaryAction: 'retry',
+        secondaryAction: 'clear-search',
+        showInlineError: false,
+      });
+    });
+
+    it('does not add an inline error to a stored-row filter error with an empty tray', () => {
+      expect(
+        model({
+          hasHistoryContent: false,
+          hasStoredSessions: true,
+          hasActiveQuery: true,
+          isError: true,
+        })
+      ).toEqual({
+        kind: 'query-error-empty',
+        primaryAction: 'retry',
+        secondaryAction: 'clear-filters',
+        showInlineError: false,
+      });
+    });
+
+    it('does not add an inline error to a stored-row search with an active-poll failure and empty tray', () => {
+      expect(
+        model({
+          hasHistoryContent: false,
+          hasStoredSessions: true,
+          hasActiveQuery: true,
+          isSearching: true,
+          activeIsError: true,
+        })
+      ).toEqual({
+        kind: 'filtered-empty',
+        primaryAction: 'clear-search',
+        showInlineError: false,
+      });
+    });
+
+    it('does not add an inline error to a stored-row filter with an active-poll failure and empty tray', () => {
+      expect(
+        model({
+          hasHistoryContent: false,
+          hasStoredSessions: true,
+          hasActiveQuery: true,
+          activeIsError: true,
+        })
+      ).toEqual({
+        kind: 'filtered-empty',
+        primaryAction: 'clear-filters',
+        showInlineError: false,
       });
     });
   });

--- a/apps/mobile/src/components/agents/session-list-body-model.test.ts
+++ b/apps/mobile/src/components/agents/session-list-body-model.test.ts
@@ -226,6 +226,48 @@ describe('selectSessionListBodyModel', () => {
     });
   });
 
+  describe('all-active while the tray is empty (full-view exclusion window)', () => {
+    it('returns all-active with no CTA when stored rows load and every one is excluded before enrichment', () => {
+      expect(
+        model({
+          hasStoredSessions: true,
+        })
+      ).toEqual({ kind: 'all-active', primaryAction: 'none', showInlineError: false });
+    });
+
+    it('keeps all-active while more history pages exist but the tray is empty (render-list keeps its tray conjunct)', () => {
+      expect(
+        model({
+          hasStoredSessions: true,
+          hasMoreHistory: true,
+        })
+      ).toEqual({ kind: 'all-active', primaryAction: 'none', showInlineError: false });
+    });
+
+    it('shows the inline error when the active poll failed during the all-excluded window', () => {
+      expect(
+        model({
+          hasStoredSessions: true,
+          activeIsError: true,
+        })
+      ).toEqual({ kind: 'all-active', primaryAction: 'none', showInlineError: true });
+    });
+
+    it('keeps query-error precedence when the stored query itself errored', () => {
+      expect(
+        model({
+          hasStoredSessions: true,
+          isError: true,
+        })
+      ).toEqual({
+        kind: 'query-error-empty',
+        primaryAction: 'retry',
+        secondaryAction: 'none',
+        showInlineError: true,
+      });
+    });
+  });
+
   describe('inline error / staleness surfacing', () => {
     it('shows the inline error when only the active poll failed and the tray is present', () => {
       expect(

--- a/apps/mobile/src/components/agents/session-list-body-model.ts
+++ b/apps/mobile/src/components/agents/session-list-body-model.ts
@@ -24,16 +24,24 @@
  *         "Clear filters"), while a no-query error shows only Retry.
  *      2. No query, error → retry-capable error empty state.
  *      3. No query, no error → compact "No past sessions" + New coding
- *         task CTA. When stored rows ARE loaded but the active set
+ *         task CTA. When stored rows ARE loaded but the live active set
  *         excludes every one, the honest "All sessions are active" body
  *         (`all-active`, no CTA) replaces the false "No past sessions";
- *         while more history pages remain the body stays `render-list` so
- *         it never claims the history is exhausted (the bounded backfill
- *         is in flight or its bound is reached).
+ *         while more history pages remain and the tray is populated the
+ *         body stays `render-list` so it never claims the history is
+ *         exhausted (the bounded backfill is in flight or its bound is
+ *         reached). An empty section list with stored rows loaded can
+ *         only arise from active-set exclusion, which in the full view
+ *         also covers live rows awaiting org attribution — so `all-active`
+ *         can render while the tray is momentarily empty, and never the
+ *         false "No past sessions".
  *  - `showInlineError` mirrors the prior inline header ("Couldn't refresh.
  *    Pull down to try again.") and is ADDITIONALLY driven by the
  *    active-only failure flag (`activeIsError`) so the tray's non-blocking
- *    staleness surface is rendered whenever there is visible content.
+ *    staleness surface is rendered whenever there is visible content —
+ *    including the all-excluded window (stored rows loaded, nothing
+ *    rendered, tray empty), where the widened term treats the `all-active`
+ *    body as visible content.
  */
 
 export type SessionListBodyModel =
@@ -121,7 +129,8 @@ export function selectSessionListBodyModel(
     activeIsError,
   } = inputs;
 
-  const showInlineError = (isError || activeIsError) && (hasHistoryContent || hasPinnedActive);
+  const showInlineError =
+    (isError || activeIsError) && (hasHistoryContent || hasPinnedActive || hasStoredSessions);
 
   // History has rows — nothing to decide at the body level.
   if (hasHistoryContent) {
@@ -177,10 +186,13 @@ export function selectSessionListBodyModel(
     return { kind: 'render-list', primaryAction: 'none', showInlineError };
   }
 
-  // Honest all-pinned body, distinct from "No past sessions": sessions DO
-  // exist — every one is pinned above. No creation CTA: the screen already
-  // offers creation through the tray, the FAB, and the header action.
-  if (hasPinnedActive && hasStoredSessions) {
+  // Honest all-active body, distinct from "No past sessions": sessions DO
+  // exist — every loaded stored row is excluded by the live active set. In
+  // the full view that set covers WS-written rows awaiting org attribution,
+  // so this branch can render while the tray is momentarily empty. No
+  // creation CTA: the screen already offers creation through the tray, the
+  // FAB, and the header action.
+  if (hasStoredSessions) {
     return { kind: 'all-active', primaryAction: 'none', showInlineError };
   }
 

--- a/apps/mobile/src/components/agents/session-list-body-model.ts
+++ b/apps/mobile/src/components/agents/session-list-body-model.ts
@@ -41,7 +41,10 @@
  *    staleness surface is rendered whenever there is visible content —
  *    including the all-excluded window (stored rows loaded, nothing
  *    rendered, tray empty), where the widened term treats the `all-active`
- *    body as visible content.
+ *    body as visible content. That widened stored-rows term is gated on
+ *    there being no active query: an empty search or filter state keeps
+ *    only its own body-level error surface and never gains a second
+ *    inline error from stored rows alone.
  */
 
 export type SessionListBodyModel =
@@ -129,8 +132,14 @@ export function selectSessionListBodyModel(
     activeIsError,
   } = inputs;
 
+  // The stored-rows term only widens inline-error visibility in the
+  // no-query full-view all-excluded window (the `all-active` body below).
+  // Search and filter states already surface their own body-level error
+  // (`query-error-empty`) or filtered-empty body, so they never get a
+  // second inline error from stored rows alone.
   const showInlineError =
-    (isError || activeIsError) && (hasHistoryContent || hasPinnedActive || hasStoredSessions);
+    (isError || activeIsError) &&
+    (hasHistoryContent || hasPinnedActive || (!hasActiveQuery && hasStoredSessions));
 
   // History has rows — nothing to decide at the body level.
   if (hasHistoryContent) {

--- a/apps/mobile/src/components/agents/session-list-content.tsx
+++ b/apps/mobile/src/components/agents/session-list-content.tsx
@@ -80,8 +80,9 @@ type AgentSessionListContentProps = {
   sortBy: AgentSessionSortBy;
   /**
    * Pinned "Active now" tray rendered as `ListHeaderComponent` so it scrolls
-   * with history in one continuous gesture. Not a virtualized cell — Reanimated
-   * layout transitions on the tray keep working. Pass `null` when empty.
+   * with history in one continuous gesture. The tray and its rows are fully
+   * atomic — no entering, exiting, or layout animations — so a session moving
+   * between history and the tray swaps in one commit. Pass `null` when empty.
    */
   activeNowSection: ReactElement | null;
 };
@@ -314,9 +315,10 @@ export function AgentSessionListContent({
   }
 
   // Single SectionList render site: tray stays in ListHeaderComponent across
-  // loading → rows so ActiveNowSection's local expanded state is not reset.
-  // While loading, sections are empty and skeletons fill ListEmptyComponent
-  // under the tray (active query may already have resolved).
+  // loading → rows, so the atomic tray never remounts while the body toggles
+  // between skeletons and rows. While loading, sections are empty and
+  // skeletons fill ListEmptyComponent under the tray (active query may
+  // already have resolved).
   let emptyComponent: ReactNode = null;
   if (surface.listEmpty === 'loading-skeletons') {
     emptyComponent = (

--- a/apps/mobile/src/components/agents/use-agent-session-list-data.ts
+++ b/apps/mobile/src/components/agents/use-agent-session-list-data.ts
@@ -39,6 +39,7 @@ export function useAgentSessionListData(options: {
     dateGroups,
     activeSessions,
     activeSessionIds,
+    activeExclusionIds,
     activeIsError,
     isLoading,
     storedIsError,
@@ -136,24 +137,48 @@ export function useAgentSessionListData(options: {
       }),
     [activeSessions, effectiveSearchQuery, platformFilter, projectFilter]
   );
+  // History/active exclusivity. The full history view excludes by the
+  // UNFILTERED active cache id set: a session leaves history the moment its
+  // live state arrives (WS write or poll), before the org-attributed row can
+  // pin it in the tray — the direct move. A narrowed view keeps the
+  // org-filtered set instead: an unenriched live row cannot yet prove it
+  // matches the narrowing, so hiding its stored twin would flash a false
+  // "No sessions match" — the transition there stays atomic via the
+  // animation-free tray. `isSearching` (committed query non-empty), NOT
+  // `effectiveSearchQuery`, drives the search half: once a search is
+  // committed the pre-existing exclusion semantics stay in force for the
+  // stored groups that remain rendered until results land. Pinned ⊆ exclusion holds
+  // at every commit in both modes, so a session never renders in both places.
   const sections = useMemo<SessionSection[]>(() => {
     const storedGroups = effectiveSearchQuery ? search.dateGroups : dateGroups;
-    return excludeActiveFromGroups(storedGroups, activeSessionIds).map(group => ({
+    const narrowed = isSearching || platformFilter.length > 0 || projectFilter.length > 0;
+    const exclusionIds = narrowed ? activeSessionIds : activeExclusionIds;
+    return excludeActiveFromGroups(storedGroups, exclusionIds).map(group => ({
       title: group.label,
       data: group.sessions,
     }));
-  }, [activeSessionIds, dateGroups, effectiveSearchQuery, search.dateGroups]);
+  }, [
+    activeExclusionIds,
+    activeSessionIds,
+    dateGroups,
+    effectiveSearchQuery,
+    isSearching,
+    platformFilter,
+    projectFilter,
+    search.dateGroups,
+  ]);
   // Bounded automatic backfill: when active-set exclusion empties every
   // rendered stored page and no gate (search, loading, error, in-flight
-  // stored fetch, page bound) blocks, fetch the next stored page so history
-  // still surfaces below a viewport-filling tray. `paging` selects the search
-  // vs stored pagination; the `isSearching` gate keeps the stored fetch from
-  // ever firing during committed search mode.
+  // stored fetch, page bound, empty tray) blocks, fetch the next stored page
+  // so history still surfaces below a viewport-filling tray. `paging` selects
+  // the search vs stored pagination; the `isSearching` gate keeps the stored
+  // fetch from ever firing during committed search mode.
   const shouldBackfill = useMemo(
     () =>
       shouldBackfillHistoryAfterActiveExclusion({
         hasHistoryContent: sections.length > 0,
         hasStoredSessions: storedSessions.length > 0,
+        hasPinnedActive: pinnedActive.length > 0,
         hasMoreHistory: paging.hasNextPage,
         isFetchingNextPage: paging.isFetchingNextPage,
         isFetching: storedIsFetching,
@@ -168,6 +193,7 @@ export function useAgentSessionListData(options: {
       isSearching,
       paging.hasNextPage,
       paging.isFetchingNextPage,
+      pinnedActive,
       sections,
       storedIsFetching,
       storedLoadedPageCount,

--- a/apps/mobile/src/components/agents/use-history-backfill.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/use-history-backfill.mounted.test.tsx
@@ -18,6 +18,7 @@ function greenInputs(overrides: Partial<SelectorInputs> = {}): SelectorInputs {
   return {
     hasHistoryContent: false,
     hasStoredSessions: true,
+    hasPinnedActive: true,
     hasMoreHistory: true,
     isFetchingNextPage: false,
     isFetching: false,
@@ -131,6 +132,19 @@ describe('useHistoryBackfill mounted', () => {
       greenInputs({ loadedPageCount: MAX_HISTORY_AUTOLOAD_PAGES })
     );
     expect(fetchNextPage).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not backfill while the tray is empty and opens exactly once when it populates', async () => {
+    const fetchNextPage = vi.fn();
+
+    // Empty tray (the unenriched window, covered by the `all-active` body):
+    // no automatic fetch even with every other gate green.
+    const renderer = await mountProbe(fetchNextPage, greenInputs({ hasPinnedActive: false }));
+    expect(fetchNextPage).not.toHaveBeenCalled();
+
+    // The tray populates: the false-to-true transition fetches exactly once.
+    await updateProbe(renderer, fetchNextPage, greenInputs());
+    expect(fetchNextPage).toHaveBeenCalledTimes(1);
   });
 
   it('does not backfill while a stored fetch is in flight', async () => {

--- a/apps/mobile/src/lib/active-sessions-live.exclusion.test.ts
+++ b/apps/mobile/src/lib/active-sessions-live.exclusion.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectActiveExclusionIds } from '@/lib/active-sessions-live';
+
+type Row = { id: string; organizationId?: string | null };
+
+describe('selectActiveExclusionIds', () => {
+  it('includes every row id regardless of org attribution', () => {
+    const rows: Row[] = [
+      { id: 'a' },
+      { id: 'b', organizationId: null },
+      { id: 'c', organizationId: 'org-1' },
+    ];
+    const ids = selectActiveExclusionIds(rows);
+    expect([...ids].toSorted()).toEqual(['a', 'b', 'c']);
+  });
+
+  it('collapses duplicate ids into one set entry', () => {
+    const ids = selectActiveExclusionIds([{ id: 'x' }, { id: 'x' }, { id: 'y' }]);
+    expect(ids.size).toBe(2);
+    expect([...ids].toSorted()).toEqual(['x', 'y']);
+  });
+
+  it('returns an empty set for an empty cache', () => {
+    expect(selectActiveExclusionIds([]).size).toBe(0);
+  });
+});

--- a/apps/mobile/src/lib/active-sessions-live.ts
+++ b/apps/mobile/src/lib/active-sessions-live.ts
@@ -355,6 +355,18 @@ export function filterActiveSessionsByOrganization<T extends { organizationId?: 
 }
 
 /**
+ * Ids of every row in the active-sessions cache, WITHOUT the org-context
+ * filter. Used to exclude active sessions from stored history the moment the
+ * live state exists in the cache — including WS-written rows not yet
+ * org-attributed — so a live session never renders as a stored-history twin
+ * while it waits for enrichment. The pinned tray itself stays org-filtered,
+ * so the pinned set is always a subset of this exclusion set.
+ */
+export function selectActiveExclusionIds(sessions: readonly { id: string }[]): Set<string> {
+  return new Set(sessions.map(s => s.id));
+}
+
+/**
  * Drop rows for a disconnected CLI connection. No cloud-sentinel special
  * case needed: CLI disconnect ids never equal `CLOUD_AGENT_CONNECTION_ID`.
  */

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.ts
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.ts
@@ -7,6 +7,7 @@ import { sortActiveSessionsByCreatedAt } from '@/lib/active-session-order';
 import {
   buildActiveSessionsTrayInput,
   filterActiveSessionsByOrganization,
+  selectActiveExclusionIds,
 } from '@/lib/active-sessions-live';
 import { refreshActiveSessionsNow } from '@/lib/active-sessions-live-sync';
 import {
@@ -242,6 +243,18 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
 
   const activeSessionIds = useMemo(() => new Set(activeSessions.map(s => s.id)), [activeSessions]);
 
+  // Unfiltered cache ids for history exclusion. Differs from
+  // `activeSessionIds` (org-filtered, tray-oriented) by also covering live
+  // rows the org filter hides until enrichment — the Agents list excludes
+  // those from history immediately (direct move into the tray at enrichment).
+  // The departure-refetch effect below intentionally keeps diffing the
+  // filtered set: an unenriched row that disappears re-renders from the
+  // already-loaded stored pages as soon as the exclusion lifts.
+  const activeExclusionIds = useMemo(
+    () => selectActiveExclusionIds(active.data?.sessions ?? []),
+    [active.data]
+  );
+
   const dateGroups = useMemo(
     () => groupAgentSessionsByDate(storedSessions, sortBy),
     [storedSessions, sortBy]
@@ -281,6 +294,7 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
     storedSessions,
     activeSessions,
     activeSessionIds,
+    activeExclusionIds,
     dateGroups,
     isLoading: stored.isLoading || active.isLoading,
     isError: stored.isError || active.isError,


### PR DESCRIPTION
User: A live remote session leaves history without a fade overlap or duplicate row, then appears in Active now when enrichment completes.

Product manager: Full history moves live sessions directly out of history; filtered views use an atomic tray swap with stable surrounding rows.

Maintainer: The list excludes full-view ids from the unfiltered active cache, keeps narrowed views org-filtered, widens the all-active state, gates backfill on tray content, and renders the tray without Reanimated transitions. Focused selector, body, backfill, and tray tests cover the sequence.

Human steps: No step is needed before or after merge.

E2E: bot-e2e — iOS bundle verification passed both direct-move and filtered history-first scenarios.

Visual Changes: N/A.