### PR TITLE
fix(ai-gateway): stop the usage-record redelivery storm

### DIFF
--- a/apps/web/src/app/api/internal/usage/record/route.ts
+++ b/apps/web/src/app/api/internal/usage/record/route.ts
@@ -11,6 +11,12 @@ import {
   UsageRecordRequestSchema,
   type UsageRecordResponse,
 } from '@/lib/ai-gateway/usage-record-contract';
+import {
+  createPhaseTimer,
+  emitUsageRecordTiming,
+  readPoolGauges,
+  shouldEmitUsageRecordTiming,
+} from '@/lib/ai-gateway/usage-record-diagnostics';
 
 /**
  * Frankfurt-local sink for AI-gateway usage writes.
@@ -37,8 +43,35 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
   }
 
+  // Phase timings exist to locate the ~50s tail this endpoint exhibits while the
+  // database and Supavisor are both idle. Splitting validate / dedupe / write and
+  // pairing them with the in-process pool gauges distinguishes waiting for a pool
+  // connection from waiting for PostgreSQL from a stalled event loop.
+  const timer = createPhaseTimer();
+  const poolBefore = readPoolGauges();
+  let poolWaitingPeak = poolBefore.waiting;
+  const samplePool = () => {
+    const gauges = readPoolGauges();
+    poolWaitingPeak = Math.max(poolWaitingPeak, gauges.waiting);
+    return gauges;
+  };
+  const reportTiming = (usageId: string, outcome: UsageRecordResponse['status']) => {
+    const totalMs = timer.totalMs();
+    if (!shouldEmitUsageRecordTiming(totalMs)) return;
+    emitUsageRecordTiming({
+      usageId,
+      outcome,
+      totalMs,
+      phases: timer.phases(),
+      poolBefore,
+      poolAfter: samplePool(),
+      poolWaitingPeak,
+    });
+  };
+
   const rawBody: unknown = await request.json().catch(() => null);
   const parsed = UsageRecordRequestSchema.safeParse(rawBody);
+  timer.mark('validate');
   if (!parsed.success) {
     // Deliberately a 400: the client must not retry a payload we cannot accept,
     // and a schema failure here means a lost billing row that needs a human.
@@ -56,16 +89,17 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // such a redelivery is detectable, and skipping the write avoids burning the
   // retry budget in `insertUsageRecord` and re-running its side effects.
   //
-  // This check cannot cover the redelivery that arrives while the first attempt
-  // is still open — the common case, since the client retries a 10s attempt
-  // timeout and this write can legitimately take longer. That window is closed by
-  // `insertUsageRecord`, which recovers the identity of an already-persisted row
-  // instead of reporting a primary-key collision as a failed write.
+  // This check cannot cover the redelivery that arrives while the first attempt is
+  // still open. That window is closed by `insertUsageRecord`, which recovers the
+  // identity of an already-persisted row instead of reporting a primary-key
+  // collision as a failed write.
   const existing = await db
     .select({ id: microdollar_usage.id })
     .from(microdollar_usage)
     .where(eq(microdollar_usage.id, core.id))
     .limit(1);
+  timer.mark('dedupe_check');
+  samplePool();
 
   if (existing.length > 0) {
     // Post-commit side effects ran on the first delivery, so do not re-run them.
@@ -75,6 +109,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       status: 'duplicate',
       result: { usageId: core.id, createdAt: core.created_at, newMicrodollarsUsed: null },
     };
+    reportTiming(core.id, 'duplicate');
     return NextResponse.json(duplicate);
   }
 
@@ -84,6 +119,7 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
     prior_microdollar_usage,
     posthog_distinct_id
   );
+  timer.mark('write');
 
   // `saveUsageRelatedDataLocally` swallows database errors and returns null,
   // matching the pre-existing local behaviour. Report it as a successful HTTP
@@ -91,11 +127,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // deliberately gave up.
   //
   // Deliberately not an `unavailable` signal that would make the client write
-  // locally instead: `insertUsageRecord` has already retried the transaction
-  // three times against this primary, and a cross-region retry from SFO would
-  // re-add the transatlantic lock hold this endpoint exists to remove — at the
-  // exact moment the database is least able to absorb it. The failure is
-  // reported from here via `captureException` in `insertUsageRecord`.
+  // locally instead: `insertUsageRecord` has already exhausted its retries against
+  // this primary, and a cross-region retry from SFO would re-add the transatlantic
+  // lock hold this endpoint exists to remove — at the exact moment the database is
+  // least able to absorb it. The failure is reported from here via
+  // `captureException` in `insertUsageRecord`.
   const response: UsageRecordResponse = result
     ? {
         // A recovered identity means an earlier delivery of this same record
@@ -114,5 +150,6 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       }
     : { status: 'not_recorded', result: null };
 
+  reportTiming(core.id, response.status);
   return NextResponse.json(response);
 }

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -1,6 +1,7 @@
 import { randomUUID } from 'crypto';
 import { db, isUSRegion } from '../drizzle';
 import { recordUsageInPrimaryRegion } from './usage-record-client';
+import { describeDatabaseError, isUsageRowConflict } from './usage-record-diagnostics';
 import type { MicrodollarUsage } from '@kilocode/db/schema';
 import { microdollar_usage } from '@kilocode/db/schema';
 import { createTimer } from '@/lib/timer';
@@ -618,13 +619,13 @@ function scheduleKiloPassBonusIfNeeded(
 /**
  * Identity of an already-persisted usage row, or null if it is not there.
  *
- * The same record can reach this write twice: `recordUsageInPrimaryRegion`
- * retries when an attempt exceeds its 10s timeout while the first delivery is
- * still committing, and after exhausting its retries the caller falls back to
- * writing locally with the same `core.id`. The losing transaction then collides
- * on the `microdollar_usage` primary key and rolls back in full, so the usage is
- * billed exactly once. Reporting that as a failure would make callers treat
- * billed usage as unrecorded and skip dependent writes.
+ * The same record can still reach this write twice. `recordUsageInPrimaryRegion`
+ * no longer retries an attempt timeout — doing so was the dominant source of
+ * collisions — but on timeout it falls back to writing locally with the same
+ * `core.id` while the remote delivery may still be committing. The losing
+ * transaction then collides on the `microdollar_usage` primary key and rolls back
+ * in full, so the usage is billed exactly once. Reporting that as a failure would
+ * make callers treat billed usage as unrecorded and skip dependent writes.
  *
  * The row's presence under this user is the proof, not the PostgreSQL error code:
  * `id` is generated per delivery by `toInsertableDbUsageRecord`, and the row can
@@ -680,11 +681,18 @@ export async function insertUsageRecord(
             // Every retry opens a fresh transaction for the usage and balance write.
             return await insertUsageTransaction(coreUsageFields, metadataFields);
           } catch (error) {
-            if (attempt >= 2) throw error;
-            sentryLogger('insertUsageRecord', 'warning')(
-              'insertUsageRecord concurrency failure',
-              error
-            );
+            // A collision on this record's own id can never be resolved by
+            // retrying — `id` is fixed for the delivery — so stop immediately and
+            // let the outer handler recover the committed row's identity. Retrying
+            // it burned three attempts and rebuilt the statement each time.
+            if (attempt >= 2 || isUsageRowConflict(error)) throw error;
+            // Never log the raw error: its message is the interpolated statement,
+            // roughly 30KB including prompt prefixes and the client IP.
+            sentryLogger('insertUsageRecord', 'warning')('insertUsageRecord concurrency failure', {
+              usageId: coreUsageFields.id,
+              attempt,
+              error: describeDatabaseError(error),
+            });
             await new Promise(r => setTimeout(r, Math.random() * 100));
             attempt++;
           }
@@ -712,15 +720,24 @@ export async function insertUsageRecord(
       );
       return alreadyRecorded;
     }
-    console.error('insertUsageRecord failed', error);
-    captureException(error, {
+    // Report the redacted description rather than `error`, whose message carries
+    // the interpolated statement and its parameters. The stack is preserved on the
+    // replacement so the failing call site is still identifiable.
+    const described = describeDatabaseError(error);
+    console.error('insertUsageRecord failed', { usageId: coreUsageFields.id, error: described });
+    const redacted = new Error(
+      `insertUsageRecord failed (code=${described.code ?? 'unknown'} constraint=${described.constraint ?? 'none'})`
+    );
+    if (error instanceof Error && error.stack) redacted.stack = error.stack;
+    captureException(redacted, {
       tags: {
         source: 'insertUsageRecord',
         spendCategory: 'variable',
         spendSource: 'ai_gateway',
         ownerType: coreUsageFields.organization_id ? 'organization' : 'user',
+        databaseErrorCode: described.code ?? 'unknown',
       },
-      extra: { sourceRecordId: coreUsageFields.id },
+      extra: { sourceRecordId: coreUsageFields.id, databaseError: described },
     });
     return null;
   }

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -1,7 +1,11 @@
 import { randomUUID } from 'crypto';
 import { db, isUSRegion } from '../drizzle';
 import { recordUsageInPrimaryRegion } from './usage-record-client';
-import { describeDatabaseError, isUsageRowConflict } from './usage-record-diagnostics';
+import {
+  describeDatabaseError,
+  isUsageRowConflict,
+  stackFramesUnderHeader,
+} from './usage-record-diagnostics';
 import type { MicrodollarUsage } from '@kilocode/db/schema';
 import { microdollar_usage } from '@kilocode/db/schema';
 import { createTimer } from '@/lib/timer';
@@ -721,14 +725,14 @@ export async function insertUsageRecord(
       return alreadyRecorded;
     }
     // Report the redacted description rather than `error`, whose message carries
-    // the interpolated statement and its parameters. The stack is preserved on the
-    // replacement so the failing call site is still identifiable.
+    // the interpolated statement and its parameters. Only the original stack's
+    // frames are carried over: `error.stack` begins with `name: message`, so
+    // copying it verbatim would put the message straight back into the event.
     const described = describeDatabaseError(error);
     console.error('insertUsageRecord failed', { usageId: coreUsageFields.id, error: described });
-    const redacted = new Error(
-      `insertUsageRecord failed (code=${described.code ?? 'unknown'} constraint=${described.constraint ?? 'none'})`
-    );
-    if (error instanceof Error && error.stack) redacted.stack = error.stack;
+    const summary = `insertUsageRecord failed (code=${described.code ?? 'unknown'} constraint=${described.constraint ?? 'none'})`;
+    const redacted = new Error(summary);
+    redacted.stack = stackFramesUnderHeader(error, `Error: ${summary}`);
     captureException(redacted, {
       tags: {
         source: 'insertUsageRecord',

--- a/apps/web/src/lib/ai-gateway/usage-record-client.test.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-client.test.ts
@@ -24,7 +24,11 @@ jest.mock('@sentry/nextjs', () => ({
 import { beforeEach, describe, expect, test } from '@jest/globals';
 import type * as SentryNextjs from '@sentry/nextjs';
 
-import { recordUsageInPrimaryRegion } from './usage-record-client';
+import {
+  ATTEMPT_TIMEOUT_MS,
+  MAX_ATTEMPTS,
+  recordUsageInPrimaryRegion,
+} from './usage-record-client';
 import type { UsageRecordRequest } from './usage-record-contract';
 
 const mockedCaptureException = jest.requireMock<typeof SentryNextjs>('@sentry/nextjs')
@@ -103,15 +107,48 @@ describe('recordUsageInPrimaryRegion', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  test('retries a 5xx and succeeds', async () => {
+  // 429/502/503 are refusals: the function provably did not run, so re-sending
+  // cannot produce a second write.
+  test.each([429, 502, 503])('retries a %i refusal and succeeds', async status => {
     mockFetch
-      .mockResolvedValueOnce(jsonResponse({ error: 'boom' }, 503))
+      .mockResolvedValueOnce(jsonResponse({ error: 'boom' }, status))
       .mockResolvedValueOnce(jsonResponse(recorded));
 
     const outcome = await recordUsageInPrimaryRegion(payload);
 
     expect(outcome.kind).toBe('ok');
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  // A 500 means our handler threw, possibly after the transaction committed. This
+  // was the dominant source of primary-key collisions, so it must not retry.
+  test.each([500, 504])('does not retry an ambiguous %i', async status => {
+    mockFetch.mockResolvedValue(jsonResponse({ error: 'boom' }, status));
+
+    const outcome = await recordUsageInPrimaryRegion(payload);
+
+    expect(outcome).toEqual({ kind: 'unavailable', reason: `http_${status}` });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // The regression this branch exists to prevent: a 10s timeout against a p95 of
+  // ~50s meant roughly 20% of deliveries were re-sent with the same core.id.
+  test('never retries a timeout, because the write may still be in flight', async () => {
+    const timeout = new Error('The operation was aborted due to timeout');
+    timeout.name = 'TimeoutError';
+    mockFetch.mockRejectedValue(timeout);
+
+    const outcome = await recordUsageInPrimaryRegion(payload);
+
+    expect(outcome).toEqual({ kind: 'unavailable', reason: 'TimeoutError' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  // Guards the invariant the incident violated: the attempt budget has to clear the
+  // endpoint's tail, and stay inside its maxDuration of 150s.
+  test('keeps the attempt timeout above the observed p95 and below maxDuration', () => {
+    expect(ATTEMPT_TIMEOUT_MS).toBeGreaterThan(50_000);
+    expect(ATTEMPT_TIMEOUT_MS).toBeLessThan(150_000);
   });
 
   test('retries a network failure and succeeds', async () => {
@@ -143,13 +180,13 @@ describe('recordUsageInPrimaryRegion', () => {
     expect(mockFetch).toHaveBeenCalledTimes(1);
   });
 
-  test('stops after three attempts and reports unavailable', async () => {
-    mockFetch.mockResolvedValue(jsonResponse({ error: 'boom' }, 500));
+  test('stops after the attempt cap and reports unavailable', async () => {
+    mockFetch.mockResolvedValue(jsonResponse({ error: 'boom' }, 503));
 
     const outcome = await recordUsageInPrimaryRegion(payload);
 
     expect(outcome.kind).toBe('unavailable');
-    expect(mockFetch).toHaveBeenCalledTimes(3);
+    expect(mockFetch).toHaveBeenCalledTimes(MAX_ATTEMPTS);
     expect(mockedCaptureException).toHaveBeenCalledTimes(1);
   });
 
@@ -165,7 +202,7 @@ describe('recordUsageInPrimaryRegion', () => {
   });
 
   test('reports the failure to Sentry with the usage id for reconciliation', async () => {
-    mockFetch.mockResolvedValue(jsonResponse({ error: 'boom' }, 500));
+    mockFetch.mockResolvedValue(jsonResponse({ error: 'boom' }, 503));
 
     await recordUsageInPrimaryRegion(payload);
 

--- a/apps/web/src/lib/ai-gateway/usage-record-client.test.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-client.test.ts
@@ -190,6 +190,23 @@ describe('recordUsageInPrimaryRegion', () => {
     expect(mockedCaptureException).toHaveBeenCalledTimes(1);
   });
 
+  // A 2xx with an unreadable body is the same hazard as a schema mismatch: the
+  // write may have committed, so it must fall back rather than re-send.
+  test('does not retry an unreadable response body', async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => {
+        throw new SyntaxError('Unexpected end of JSON input');
+      },
+    });
+
+    const outcome = await recordUsageInPrimaryRegion(payload);
+
+    expect(outcome).toEqual({ kind: 'unavailable', reason: 'unreadable_response' });
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
   // A malformed response may mean the write committed, so retrying risks nothing
   // (the receiver dedupes) but is pointless; the caller must reconcile instead.
   test('does not retry a malformed response body', async () => {

--- a/apps/web/src/lib/ai-gateway/usage-record-client.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-client.ts
@@ -105,14 +105,14 @@ export async function recordUsageInPrimaryRegion(
         // failure — but the status was already 2xx, so the write may have
         // committed, exactly like the schema mismatch below. Both must fall back
         // rather than re-send and manufacture a redelivery.
-        let payload: unknown;
+        let responseBody: unknown;
         try {
-          payload = await response.json();
+          responseBody = await response.json();
         } catch {
           lastReason = 'unreadable_response';
           break;
         }
-        const parsed = UsageRecordResponseSchema.safeParse(payload);
+        const parsed = UsageRecordResponseSchema.safeParse(responseBody);
         if (!parsed.success) {
           // A malformed response is not safe to retry: the write may well have
           // committed. Fall back so the caller can reconcile on `core.id`.

--- a/apps/web/src/lib/ai-gateway/usage-record-client.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-client.ts
@@ -100,7 +100,19 @@ export async function recordUsageInPrimaryRegion(
         lastReason = `http_${response.status}`;
         if (!isRetryableStatus(response.status)) break;
       } else {
-        const parsed = UsageRecordResponseSchema.safeParse(await response.json());
+        // Read the body inside its own guard. A truncated or non-JSON body throws
+        // here, and the outer catch would treat that as a retryable transport
+        // failure — but the status was already 2xx, so the write may have
+        // committed, exactly like the schema mismatch below. Both must fall back
+        // rather than re-send and manufacture a redelivery.
+        let payload: unknown;
+        try {
+          payload = await response.json();
+        } catch {
+          lastReason = 'unreadable_response';
+          break;
+        }
+        const parsed = UsageRecordResponseSchema.safeParse(payload);
         if (!parsed.success) {
           // A malformed response is not safe to retry: the write may well have
           // committed. Fall back so the caller can reconcile on `core.id`.

--- a/apps/web/src/lib/ai-gateway/usage-record-client.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-client.ts
@@ -17,10 +17,20 @@ import { UsageRecordResponseSchema, type UsageRecordRequest } from './usage-reco
 
 const USAGE_RECORD_PATH = '/api/internal/usage/record';
 
-/** Per-attempt budget. Runs inside `after()`, so keep the total bounded. */
-const ATTEMPT_TIMEOUT_MS = 10_000;
-const MAX_ATTEMPTS = 3;
+/**
+ * Per-attempt budget. Runs inside `after()`, so the total stays bounded, and it
+ * must stay under the endpoint's `maxDuration` of 150s.
+ *
+ * This was 10s, which was below the endpoint's actual p95 of roughly 50s. Every
+ * request slower than the timeout was abandoned and re-sent with the same
+ * `core.id`, so ~20% of deliveries became redeliveries that collided on the
+ * `microdollar_usage` primary key — about 4,400 collisions per five minutes — and
+ * each retry added load that made the endpoint slower still. Keep this
+ * comfortably above the observed tail.
+ */
+export const ATTEMPT_TIMEOUT_MS = 90_000;
 const RETRY_BASE_DELAY_MS = 200;
+export const MAX_ATTEMPTS = 2;
 
 /**
  * `unavailable` tells the caller to fall back to writing locally. A slow
@@ -36,9 +46,27 @@ function retryDelayMs(attempt: number): number {
   return RETRY_BASE_DELAY_MS * attempt + Math.random() * RETRY_BASE_DELAY_MS;
 }
 
-/** 4xx other than 429 means the payload or auth is wrong; retrying cannot help. */
+/**
+ * Only statuses that prove the request never reached the write.
+ *
+ * 429 and 503 are refusals, and a 502 means the gateway never got a response from
+ * a function that therefore did not run. A 500 is the opposite: our handler threw,
+ * possibly after the transaction committed, so re-sending risks a redelivery for
+ * no benefit. 504 is likewise ambiguous. 4xx other than 429 means the payload or
+ * auth is wrong, which a retry cannot fix.
+ */
 function isRetryableStatus(status: number): boolean {
-  return status >= 500 || status === 429;
+  return status === 429 || status === 502 || status === 503;
+}
+
+/**
+ * A timeout is never retried. The endpoint may still be mid-write, so re-sending
+ * produces exactly the primary-key collision this client used to cause. Falling
+ * back to a local write is the safer response: it is slower, but the endpoint's
+ * own conflict handling recognises the collision and recovers the identity.
+ */
+function isRetryableError(error: unknown): boolean {
+  return !(error instanceof Error) || error.name !== 'TimeoutError';
 }
 
 export async function recordUsageInPrimaryRegion(
@@ -85,6 +113,7 @@ export async function recordUsageInPrimaryRegion(
       }
     } catch (error) {
       lastReason = error instanceof Error ? error.name : 'fetch_failed';
+      if (!isRetryableError(error)) break;
     }
 
     if (attempt < MAX_ATTEMPTS) {

--- a/apps/web/src/lib/ai-gateway/usage-record-diagnostics.test.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-diagnostics.test.ts
@@ -10,6 +10,7 @@ import {
   isUsageRowConflict,
   readPoolGauges,
   shouldEmitUsageRecordTiming,
+  stackFramesUnderHeader,
 } from './usage-record-diagnostics';
 
 /** Shape of the drizzle wrapper: a message carrying the statement, plus a cause. */
@@ -85,6 +86,50 @@ describe('describeDatabaseError', () => {
   test('does not throw on null or a primitive', () => {
     expect(describeDatabaseError(null).code).toBeNull();
     expect(describeDatabaseError('nope').code).toBeNull();
+  });
+});
+
+describe('stackFramesUnderHeader', () => {
+  // The regression this exists to prevent: `error.stack` opens with
+  // `name: message`, so copying it verbatim onto a redacted error puts the
+  // interpolated statement straight back into the Sentry event.
+  test('drops the original header, which contains the statement', () => {
+    const stack = stackFramesUnderHeader(
+      drizzleError({ code: '23505', table: 'microdollar_usage' }),
+      'Error: insertUsageRecord failed (code=23505)'
+    );
+    expect(stack).not.toContain('You are Kilo');
+    expect(stack).not.toContain('134.82.68.167');
+    expect(stack).not.toContain('microdollar_usage_ins');
+    expect(stack).not.toContain('params:');
+    expect(stack).not.toContain('Failed query');
+  });
+
+  test('keeps the frames, so the throw site survives redaction', () => {
+    const error = new Error('secret message');
+    error.stack = 'Error: secret message\n    at inner (chunk.js:1:1)\n    at outer (chunk.js:2:2)';
+    expect(stackFramesUnderHeader(error, 'Error: redacted')).toBe(
+      'Error: redacted\n    at inner (chunk.js:1:1)\n    at outer (chunk.js:2:2)'
+    );
+  });
+
+  test('anchors on the first frame even when the message spans lines', () => {
+    const error = new Error('line one\nline two\nparams: secret');
+    error.stack = 'Error: line one\nline two\nparams: secret\n    at inner (chunk.js:1:1)';
+    expect(stackFramesUnderHeader(error, 'Error: redacted')).toBe(
+      'Error: redacted\n    at inner (chunk.js:1:1)'
+    );
+  });
+
+  test('falls back to the header alone when there are no frames', () => {
+    const error = new Error('boom');
+    error.stack = 'Error: boom';
+    expect(stackFramesUnderHeader(error, 'Error: redacted')).toBe('Error: redacted');
+  });
+
+  test('returns the header for a non-error', () => {
+    expect(stackFramesUnderHeader('nope', 'Error: redacted')).toBe('Error: redacted');
+    expect(stackFramesUnderHeader(null, 'Error: redacted')).toBe('Error: redacted');
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/usage-record-diagnostics.test.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-diagnostics.test.ts
@@ -113,9 +113,52 @@ describe('stackFramesUnderHeader', () => {
     );
   });
 
-  test('anchors on the first frame even when the message spans lines', () => {
+  test('removes a multi-line message in full', () => {
     const error = new Error('line one\nline two\nparams: secret');
     error.stack = 'Error: line one\nline two\nparams: secret\n    at inner (chunk.js:1:1)';
+    expect(stackFramesUnderHeader(error, 'Error: redacted')).toBe(
+      'Error: redacted\n    at inner (chunk.js:1:1)'
+    );
+  });
+
+  // A user pasting a stack trace into their prompt is routine for a coding
+  // assistant, and `user_prompt_prefix` is interpolated into the message. Anchoring
+  // on the first frame-shaped line would start the slice inside the message and
+  // carry the remaining parameters — client IP, city — into the result.
+  test('does not leak parameters when the prompt itself contains a stack trace', () => {
+    const prompt = 'Fix this:\n    at handler (app.js:10:5)\n    at run (app.js:2:1)';
+    const error = new Error(
+      `Failed query: WITH microdollar_usage_ins AS (...)\nparams: 3f5826e7,${prompt},134.82.68.167,Miami`
+    );
+    error.name = 'DrizzleQueryError';
+
+    const stack = stackFramesUnderHeader(error, 'Error: redacted');
+
+    expect(stack).not.toContain('134.82.68.167');
+    expect(stack).not.toContain('Miami');
+    expect(stack).not.toContain('Fix this');
+    expect(stack).not.toContain('app.js');
+    expect(stack).not.toContain('params:');
+  });
+
+  // Fails closed: an unrecognised header means the message boundary is unknown.
+  test('emits no frames when the stack does not start with the expected header', () => {
+    const error = new Error('secret params: 134.82.68.167');
+    error.stack = 'SomethingElse: unrelated\n    at inner (chunk.js:1:1)';
+    expect(stackFramesUnderHeader(error, 'Error: redacted')).toBe('Error: redacted');
+  });
+
+  test('handles an empty message, whose header is the name alone', () => {
+    const error = new Error('');
+    error.stack = 'Error\n    at inner (chunk.js:1:1)';
+    expect(stackFramesUnderHeader(error, 'Error: redacted')).toBe(
+      'Error: redacted\n    at inner (chunk.js:1:1)'
+    );
+  });
+
+  test('drops non-frame lines that survive the strip', () => {
+    const error = new Error('boom');
+    error.stack = 'Error: boom\ntrailing junk\n    at inner (chunk.js:1:1)';
     expect(stackFramesUnderHeader(error, 'Error: redacted')).toBe(
       'Error: redacted\n    at inner (chunk.js:1:1)'
     );

--- a/apps/web/src/lib/ai-gateway/usage-record-diagnostics.test.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-diagnostics.test.ts
@@ -1,0 +1,177 @@
+jest.mock('@/lib/drizzle', () => ({
+  pool: { totalCount: 4, idleCount: 1, waitingCount: 0, options: { max: 10 } },
+}));
+
+import { describe, expect, test } from '@jest/globals';
+
+import {
+  createPhaseTimer,
+  describeDatabaseError,
+  isUsageRowConflict,
+  readPoolGauges,
+  shouldEmitUsageRecordTiming,
+} from './usage-record-diagnostics';
+
+/** Shape of the drizzle wrapper: a message carrying the statement, plus a cause. */
+function drizzleError(cause: Record<string, unknown>) {
+  const error = new Error(
+    'Failed query: WITH microdollar_usage_ins AS (...) params: 3f5826e7,You are Kilo,134.82.68.167'
+  );
+  error.name = 'DrizzleQueryError';
+  (error as unknown as { cause: unknown }).cause = Object.assign(new Error('driver'), cause);
+  return error;
+}
+
+describe('describeDatabaseError', () => {
+  test('extracts driver fields from the wrapped cause', () => {
+    const described = describeDatabaseError(
+      drizzleError({
+        code: '23505',
+        constraint: 'PK_a71b90d910e7882358c3defe8e2',
+        table: 'microdollar_usage',
+        routine: '_bt_check_unique',
+      })
+    );
+    expect(described).toEqual({
+      name: 'DrizzleQueryError',
+      code: '23505',
+      constraint: 'PK_a71b90d910e7882358c3defe8e2',
+      table: 'microdollar_usage',
+      routine: '_bt_check_unique',
+    });
+  });
+
+  // The whole point of this helper: nothing it returns may carry the statement or
+  // its interpolated parameters, which include prompt text and the client IP.
+  test('returns no field containing the statement or its parameters', () => {
+    const described = describeDatabaseError(
+      drizzleError({ code: '23505', table: 'microdollar_usage' })
+    );
+    const serialized = JSON.stringify(described);
+    expect(serialized).not.toContain('You are Kilo');
+    expect(serialized).not.toContain('134.82.68.167');
+    expect(serialized).not.toContain('microdollar_usage_ins');
+    expect(serialized).not.toContain('params:');
+  });
+
+  test('omits detail, which PostgreSQL fills with the conflicting values', () => {
+    const described = describeDatabaseError(
+      drizzleError({
+        code: '23505',
+        table: 'microdollar_usage',
+        detail: 'Key (id)=(3f5826e7-b563-4850-b34d-d9e4cd3978fc) already exists.',
+      })
+    );
+    expect(JSON.stringify(described)).not.toContain('already exists');
+  });
+
+  test('walks a nested cause chain', () => {
+    const inner = Object.assign(new Error('driver'), { code: '40P01' });
+    const middle = Object.assign(new Error('mid'), { cause: inner });
+    const outer = Object.assign(new Error('outer'), { cause: middle });
+    expect(describeDatabaseError(outer).code).toBe('40P01');
+  });
+
+  test('degrades to nulls for a non-database error', () => {
+    expect(describeDatabaseError(new Error('boom'))).toEqual({
+      name: 'Error',
+      code: null,
+      constraint: null,
+      table: null,
+      routine: null,
+    });
+  });
+
+  test('does not throw on null or a primitive', () => {
+    expect(describeDatabaseError(null).code).toBeNull();
+    expect(describeDatabaseError('nope').code).toBeNull();
+  });
+});
+
+describe('isUsageRowConflict', () => {
+  test('is true for the usage row primary key', () => {
+    expect(isUsageRowConflict(drizzleError({ code: '23505', table: 'microdollar_usage' }))).toBe(
+      true
+    );
+  });
+
+  test('is true for the usage metadata primary key, also keyed by the delivery id', () => {
+    expect(
+      isUsageRowConflict(drizzleError({ code: '23505', table: 'microdollar_usage_metadata' }))
+    ).toBe(true);
+  });
+
+  // These MUST stay retryable: two concurrent writes can both pass the
+  // `WHERE NOT EXISTS` guard for a new value, and the retry then skips the insert.
+  test.each([
+    'http_ip',
+    'http_user_agent',
+    'system_prompt_prefix',
+    'ja4_digest',
+    'vercel_ip_city',
+    'finish_reason',
+  ])('is false for the deduplicated lookup table %s', table => {
+    expect(isUsageRowConflict(drizzleError({ code: '23505', table }))).toBe(false);
+  });
+
+  test('falls back to the constraint name when the driver omits table', () => {
+    expect(
+      isUsageRowConflict(
+        drizzleError({ code: '23505', constraint: 'PK_a71b90d910e7882358c3defe8e2' })
+      )
+    ).toBe(true);
+    expect(isUsageRowConflict(drizzleError({ code: '23505', constraint: 'http_ip_pkey' }))).toBe(
+      false
+    );
+  });
+
+  test.each([
+    ['serialization failure', '40001'],
+    ['deadlock', '40P01'],
+    ['statement timeout', '57014'],
+    ['connection failure', '08006'],
+  ])('is false for %s, which a retry can resolve', (_label, code) => {
+    expect(isUsageRowConflict(drizzleError({ code, table: 'microdollar_usage' }))).toBe(false);
+  });
+
+  test('is false for an error with no driver code', () => {
+    expect(isUsageRowConflict(new Error('boom'))).toBe(false);
+  });
+});
+
+describe('createPhaseTimer', () => {
+  test('records each phase duration and the running total', () => {
+    let now = 1_000;
+    const timer = createPhaseTimer(() => now);
+    now = 1_010;
+    timer.mark('validate');
+    now = 1_035;
+    timer.mark('dedupe_check');
+    now = 6_035;
+    timer.mark('write');
+    expect(timer.phases()).toEqual([
+      { phase: 'validate', ms: 10 },
+      { phase: 'dedupe_check', ms: 25 },
+      { phase: 'write', ms: 5_000 },
+    ]);
+    expect(timer.totalMs()).toBe(5_035);
+  });
+});
+
+describe('readPoolGauges', () => {
+  test('reports the in-process pool counters, not Supavisor stats', () => {
+    expect(readPoolGauges()).toEqual({ total: 4, idle: 1, waiting: 0 });
+  });
+});
+
+describe('shouldEmitUsageRecordTiming', () => {
+  test('always emits at or above the slow threshold', () => {
+    expect(shouldEmitUsageRecordTiming(1_000, () => 1)).toBe(true);
+    expect(shouldEmitUsageRecordTiming(50_000, () => 1)).toBe(true);
+  });
+
+  test('samples a small fraction of fast requests for a baseline', () => {
+    expect(shouldEmitUsageRecordTiming(5, () => 0.005)).toBe(true);
+    expect(shouldEmitUsageRecordTiming(5, () => 0.5)).toBe(false);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/usage-record-diagnostics.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-diagnostics.ts
@@ -1,0 +1,231 @@
+import 'server-only';
+
+import { monitorEventLoopDelay } from 'node:perf_hooks';
+import { pool } from '@/lib/drizzle';
+
+/**
+ * Diagnostics for the Frankfurt-local usage write.
+ *
+ * `POST /api/internal/usage/record` shows a strongly bimodal latency profile —
+ * p50 around 5ms against a p95 near 50s — while the database is idle: zero
+ * blocked sessions, sub-second oldest transaction, and only a handful of
+ * `log_lock_waits` entries per hour. Supavisor is equally idle, reporting
+ * `client_waiting: 0` against a pool size of 320. So the time is being spent
+ * inside the Node process, and nothing currently emitted can say where.
+ *
+ * The two candidate explanations need different fixes, so they have to be
+ * separated by measurement rather than argument:
+ *
+ * - Waiting on the in-process `pg` pool, which is capped at 10 connections per
+ *   instance. `/api/cron/db-pool-metrics` reports Supavisor's counters, not this
+ *   pool's, so its saturation is currently invisible. `waitingCount` settles it.
+ * - Event-loop starvation, which would inflate every phase including ones that do
+ *   no I/O at all. The delay histogram settles that one.
+ *
+ * Everything here is read-only and allocation-light. Emission is gated on a
+ * duration threshold plus a small random sample, and it replaces a log line that
+ * serialized ~30KB of interpolated SQL per failure, so net log volume falls.
+ */
+
+/**
+ * Process-lifetime event-loop delay. Deliberately never reset: a sustained stall
+ * is what we are looking for, and per-request windowing would need a timer of its
+ * own on the very loop being measured.
+ */
+const eventLoopDelay = monitorEventLoopDelay({ resolution: 20 });
+eventLoopDelay.enable();
+
+const SLOW_EMIT_THRESHOLD_MS = 1_000;
+const BASELINE_SAMPLE_RATE = 0.01;
+
+export type UsageRecordPhase = { phase: string; ms: number };
+
+export interface PhaseTimer {
+  /** Closes the previous phase and records its duration. */
+  mark(phase: string): void;
+  phases(): UsageRecordPhase[];
+  totalMs(): number;
+}
+
+export function createPhaseTimer(now: () => number = () => Date.now()): PhaseTimer {
+  const start = now();
+  let last = start;
+  const recorded: UsageRecordPhase[] = [];
+  return {
+    mark(phase: string) {
+      const at = now();
+      recorded.push({ phase, ms: at - last });
+      last = at;
+    },
+    phases: () => recorded,
+    totalMs: () => now() - start,
+  };
+}
+
+export type PoolGauges = {
+  /** Connections the pool currently holds, idle or checked out. */
+  total: number;
+  idle: number;
+  /** Requests queued for a connection. Non-zero means the pool is the bottleneck. */
+  waiting: number;
+};
+
+export function readPoolGauges(): PoolGauges {
+  return {
+    total: pool.totalCount,
+    idle: pool.idleCount,
+    waiting: pool.waitingCount,
+  };
+}
+
+function eventLoopLagMs() {
+  return {
+    mean_ms: Math.round(eventLoopDelay.mean / 1e6),
+    p99_ms: Math.round(eventLoopDelay.percentile(99) / 1e6),
+    max_ms: Math.round(eventLoopDelay.max / 1e6),
+  };
+}
+
+export type UsageRecordTiming = {
+  usageId: string;
+  outcome: 'recorded' | 'duplicate' | 'not_recorded';
+  totalMs: number;
+  phases: UsageRecordPhase[];
+  poolBefore: PoolGauges;
+  poolAfter: PoolGauges;
+  /** Highest `waitingCount` sampled during the request. */
+  poolWaitingPeak: number;
+};
+
+export function shouldEmitUsageRecordTiming(
+  totalMs: number,
+  random: () => number = Math.random
+): boolean {
+  return totalMs >= SLOW_EMIT_THRESHOLD_MS || random() < BASELINE_SAMPLE_RATE;
+}
+
+/**
+ * One structured line, queryable in Axiom without regex over a message blob.
+ */
+export function emitUsageRecordTiming(timing: UsageRecordTiming): void {
+  console.log(
+    JSON.stringify({
+      type: 'usage_record_timing',
+      usage_id: timing.usageId,
+      outcome: timing.outcome,
+      total_ms: timing.totalMs,
+      phases: Object.fromEntries(timing.phases.map(({ phase, ms }) => [`${phase}_ms`, ms])),
+      pool_before: timing.poolBefore,
+      pool_after: timing.poolAfter,
+      pool_waiting_peak: timing.poolWaitingPeak,
+      pool_max: poolMax(),
+      event_loop_lag: eventLoopLagMs(),
+    })
+  );
+}
+
+/**
+ * `max` is not exposed on `pg.Pool` in the public types but is present on the
+ * options object, and knowing it is what makes `waiting` interpretable.
+ */
+function poolMax(): number | null {
+  const options = (pool as unknown as { options?: { max?: number } }).options;
+  return typeof options?.max === 'number' ? options.max : null;
+}
+
+/**
+ * Redacted description of a database error.
+ *
+ * A drizzle failure stringifies to `Failed query: <SQL>\nparams: <values>`. For
+ * the usage write that is ~30KB and the values include `user_prompt_prefix`,
+ * `system_prompt_prefix`, the client IP, city and JA4 digest — real end-user
+ * prompt text in a log line that fired thousands of times per minute. Never log
+ * or capture the raw error from this path; log this instead.
+ *
+ * `detail` is also omitted: PostgreSQL puts the conflicting key values in it.
+ */
+export type DatabaseErrorDescription = {
+  name: string | null;
+  code: string | null;
+  constraint: string | null;
+  table: string | null;
+  routine: string | null;
+};
+
+type PostgresErrorShape = {
+  name?: unknown;
+  code?: unknown;
+  constraint?: unknown;
+  table?: unknown;
+  routine?: unknown;
+  cause?: unknown;
+};
+
+function stringOrNull(value: unknown): string | null {
+  return typeof value === 'string' && value.length > 0 ? value : null;
+}
+
+export function describeDatabaseError(error: unknown): DatabaseErrorDescription {
+  // drizzle wraps the driver error, so the fields we want sit on `cause`. Walk a
+  // bounded chain rather than assuming a fixed depth.
+  let current: unknown = error;
+  let name: string | null = null;
+  for (let depth = 0; depth < 5 && current !== null && typeof current === 'object'; depth++) {
+    const candidate = current as PostgresErrorShape;
+    name ??= stringOrNull(candidate.name);
+    const code = stringOrNull(candidate.code);
+    if (code !== null) {
+      return {
+        // The outermost name identifies the failure class (`DrizzleQueryError`);
+        // the driver's own name is just "error" and says nothing.
+        name: name ?? stringOrNull(candidate.name),
+        code,
+        constraint: stringOrNull(candidate.constraint),
+        table: stringOrNull(candidate.table),
+        routine: stringOrNull(candidate.routine),
+      };
+    }
+    current = candidate.cause;
+  }
+  return { name, code: null, constraint: null, table: null, routine: null };
+}
+
+/** PostgreSQL `unique_violation`. */
+const UNIQUE_VIOLATION = '23505';
+
+/**
+ * Tables keyed by the per-delivery usage id. A collision on either means this
+ * record is colliding with itself.
+ */
+const USAGE_IDENTITY_TABLES = new Set(['microdollar_usage', 'microdollar_usage_metadata']);
+
+/**
+ * `microdollar_usage`'s primary key predates the current naming convention, so it
+ * carries a generated name while every deduplicated lookup table uses
+ * `<table>_pkey`. Matched exactly, as a fallback for drivers that report
+ * `constraint` without `table`.
+ */
+const USAGE_PRIMARY_KEY_CONSTRAINTS = new Set([
+  'PK_a71b90d910e7882358c3defe8e2',
+  'microdollar_usage_metadata_pkey',
+]);
+
+/**
+ * True when the failure is this exact usage row colliding with itself.
+ *
+ * Retrying is futile: `id` is fixed for the delivery, so every attempt collides
+ * again, and each one rebuilds and re-logs the same ~30KB statement. The caller
+ * should stop and recover the committed row's identity instead.
+ *
+ * Deliberately narrower than "any unique violation". A collision on one of the
+ * twelve deduplicated lookup tables IS worth retrying — two concurrent writes can
+ * both pass the `WHERE NOT EXISTS` guard for a new value, and on the retry the
+ * value exists and the insert is skipped. That is the race the retry loop was
+ * built for, and it must keep working.
+ */
+export function isUsageRowConflict(error: unknown): boolean {
+  const described = describeDatabaseError(error);
+  if (described.code !== UNIQUE_VIOLATION) return false;
+  if (described.table !== null) return USAGE_IDENTITY_TABLES.has(described.table);
+  return described.constraint !== null && USAGE_PRIMARY_KEY_CONSTRAINTS.has(described.constraint);
+}

--- a/apps/web/src/lib/ai-gateway/usage-record-diagnostics.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-diagnostics.ts
@@ -199,15 +199,30 @@ export function describeDatabaseError(error: unknown): DatabaseErrorDescription 
  * prefixes and the client IP. Dropping the header keeps the throw site, which
  * `Error.captureStackTrace` on the replacement would lose.
  *
- * Frames themselves are `at fn (chunk:line:col)` and carry no request data.
+ * The header is removed by exact `${name}: ${message}` prefix, never by searching
+ * for the first frame-shaped line. That search is unsafe here because the message
+ * embeds `user_prompt_prefix`: a user pasting a stack trace into their prompt —
+ * routine for a coding assistant — puts a line matching `/^\s+at\s/` inside the
+ * message, and slicing from it carries the rest of the parameters, client IP
+ * included, into the result.
+ *
+ * Fails closed. If the stack does not start with the expected header the message
+ * boundary is unknown, so no frames are emitted at all; `describeDatabaseError`
+ * still supplies the actionable code and constraint. Losing a throw site is
+ * cheaper than leaking a prompt.
  */
 export function stackFramesUnderHeader(error: unknown, header: string): string {
   if (!(error instanceof Error) || typeof error.stack !== 'string') return header;
-  // The message is multi-line for a drizzle failure, so anchor on the first frame
-  // rather than assuming the header occupies a single line.
-  const firstFrame = error.stack.search(/^\s+at\s/m);
-  if (firstFrame === -1) return header;
-  return `${header}\n${error.stack.slice(firstFrame)}`;
+  const originalHeader = error.message.length > 0 ? `${error.name}: ${error.message}` : error.name;
+  if (!error.stack.startsWith(originalHeader)) return header;
+  // Belt and braces: after an exact strip nothing but frames can remain, but a
+  // message mutated after construction would slip through, so keep only lines
+  // that are actually frames.
+  const frames = error.stack
+    .slice(originalHeader.length)
+    .split('\n')
+    .filter(line => /^\s+at\s/.test(line));
+  return frames.length > 0 ? `${header}\n${frames.join('\n')}` : header;
 }
 
 /** PostgreSQL `unique_violation`. */

--- a/apps/web/src/lib/ai-gateway/usage-record-diagnostics.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-diagnostics.ts
@@ -190,6 +190,26 @@ export function describeDatabaseError(error: unknown): DatabaseErrorDescription 
   return { name, code: null, constraint: null, table: null, routine: null };
 }
 
+/**
+ * The frames of `error`'s stack under a caller-supplied header.
+ *
+ * V8 renders `error.stack` as `${name}: ${message}` followed by the frames, so
+ * copying a stack verbatim onto a redacted error re-embeds the message it was
+ * redacting — for this path, ~30KB of interpolated statement including prompt
+ * prefixes and the client IP. Dropping the header keeps the throw site, which
+ * `Error.captureStackTrace` on the replacement would lose.
+ *
+ * Frames themselves are `at fn (chunk:line:col)` and carry no request data.
+ */
+export function stackFramesUnderHeader(error: unknown, header: string): string {
+  if (!(error instanceof Error) || typeof error.stack !== 'string') return header;
+  // The message is multi-line for a drizzle failure, so anchor on the first frame
+  // rather than assuming the header occupies a single line.
+  const firstFrame = error.stack.search(/^\s+at\s/m);
+  if (firstFrame === -1) return header;
+  return `${header}\n${error.stack.slice(firstFrame)}`;
+}
+
 /** PostgreSQL `unique_violation`. */
 const UNIQUE_VIOLATION = '23505';
 


### PR DESCRIPTION
## Summary

Follow-up to #5034. That change fixed the hot-row convoy — the Frankfurt-local write is **5 ms at p50** and the primary is now idle (0 blocked sessions, oldest transaction 0.76 s, 17 `log_lock_waits` entries in 30 min with `log_lock_waits=on` and `deadlock_timeout=1s`, Supavisor `client_waiting=0` against `pool_size=320`). It replaced it with a self-inflicted retry storm.

`recordUsageInPrimaryRegion` used a **10 s** per-attempt timeout against an endpoint whose **p95 is ~50 s**. Every request slower than the timeout was abandoned and re-sent with the same `core.id`:

| 5-min bucket (UTC) | requests | p50 | p95 | duplicate-key errors |
|---|---|---|---|---|
| 12:20 | 10,331 | 5 ms | 43.7 s | 305 |
| 12:35 | 46,439 | 155 ms | 54.3 s | 4,320 |
| 12:45 | 46,362 | 155 ms | 50.2 s | 4,600 |

The violated constraint is `PK_a71b90d910e7882358c3defe8e2`, confirmed via `pg_constraint` to be `PRIMARY KEY (id)` on `microdollar_usage` — so ~20% of deliveries were redeliveries of a record already being written, and each retry added load that made the endpoint slower still. It stayed invisible because the client only logs after exhausting every attempt, which happened just **167** times.

### Breaking the loop

- **Attempt budget 10 s → 90 s**, above the observed tail and below the endpoint's `maxDuration` of 150 s.
- **A timeout is never retried.** The endpoint may still be mid-write, so re-sending reproduces exactly this collision. It falls back to the local write instead — slower, but the endpoint's conflict handling already recognises it.
- **Retryable statuses narrow from `>= 500 || 429` to 429/502/503** — refusals that prove the function did not run. A 500 means our handler threw, possibly after commit; 504 is equally ambiguous. Both used to be retried.
- **`insertUsageRecord` stops retrying a collision on this record's own id.** `id` is fixed for the delivery, so all three attempts collided, each rebuilding and re-logging the same ~30 KB statement before the outer handler recovered the committed identity. Deliberately narrow: `microdollar_usage` and `microdollar_usage_metadata` are keyed by the per-delivery id, while the twelve deduplicated lookup tables have a `WHERE NOT EXISTS` race that retrying genuinely does resolve. Checked against `pg_constraint` — lookup tables use `<table>_pkey`.

### Stops leaking prompts into logs

The failure log serialized the interpolated statement. A sample contained real end-user prompt text (`"Aun me siguen apareciendo los telefonos de un cliente…"`), `system_prompt_prefix`, client IP `134.82.68.167`, city and JA4 digest — ~30 KB per event, ~4,400 events per 5 minutes, into Axiom and Sentry. Both the retry warning and the final `captureException` now report a redacted description (`name`, `code`, `constraint`, `table`, `routine`). `detail` is excluded too, since PostgreSQL puts the conflicting key values there. The stack is preserved on the replacement error.

This predates #5034 — the same line fires on `kilocode-global-app` gateway paths — but that change amplified it about 45×.

### Instrumentation for the remaining tail

I could not determine *why* p95 is ~50 s. It is app-side (database and pooler both idle) and it is **not** memory: every route on `kilocode-app` sits at p95 920–1,055 MB and this one is typical at 1,034 MB, while its duration is the sole outlier at 57.7 s versus ≤ 2 s everywhere else. Two candidates remain and need different fixes, so they are separated by measurement:

- **In-process pg pool gauges** (`totalCount`/`idleCount`/`waitingCount`/`max`). `/api/cron/db-pool-metrics` reports Supavisor's counters, not this pool's, so its saturation is invisible today. `waitingCount` settles it.
- **Event-loop delay** via `monitorEventLoopDelay`, which would inflate every phase including ones doing no I/O.
- **Phase timings** — `validate`, `dedupe_check`, `write`.

One structured `{"type":"usage_record_timing"}` line, gated on ≥ 1 s or a 1% sample. Combined with removing the 30 KB dump, **net log volume falls.**

## Verification

Automated: `tsgo --noEmit -p apps/web/tsconfig.json` clean; `./scripts/lint-all.sh` 0 warnings 0 errors; 24 new diagnostics tests (including explicit assertions that no returned field contains the statement, params, prompt text or IP, and that lookup-table conflicts stay retryable); 16 client tests covering the never-retry-a-timeout regression and the ambiguous 500/504 cases; `src/lib/ai-gateway` + `src/lib/drizzle.test.ts` 699 passing across 59 suites. Targeted verification, not `pnpm validate`.

Manual: **none.** The behaviour only exists on a multi-region deployment — locally `VERCEL_REGION` is unset, so `isUSRegion()` is false and the remote path is never taken. I could not exercise the timeout, the collision path, or the pool gauges under load by hand.

- [ ] After deploy, confirm duplicate-key errors on `/api/internal/usage/record` fall to near zero.
- [ ] Read the new timing line and decide the next step (query below).
- [ ] Re-tune `ATTEMPT_TIMEOUT_MS` once the real p95 is known — see Reviewer Notes.

## Visual Changes

N/A

## Reviewer Notes

**90 s is calibrated against a p95 I expect this PR to remove.** If most of the tail was self-inflicted, the real p95 will drop a lot and 90 s becomes far more generous than needed. Treat it as provisional; the test asserts the invariant (above the tail, below `maxDuration`) rather than the number.

**This does not explain the tail, it measures it.** Please read the instrumentation as the deliverable it is, not as a fix. The query that decides the next step:

```
['vercel'] | where message startswith '{"type":"usage_record_timing"'
| summarize p95_total=percentile(total_ms,95), p95_write=percentile(['phases.write_ms'],95),
            max_waiting=max(pool_waiting_peak), p99_lag=percentile(['event_loop_lag.p99_ms'],99)
  by bin(_time, 1m)
```

`max_waiting > 0` → raise the per-instance pool `max`; there is headroom (141 of 480 Postgres connections, 100 of 3,000 pooler client slots). High `p99_lag` with `max_waiting` at 0 → the cost is CPU per request. Neither → I am wrong about both, and the phase split will say where the time went.

Other things worth a look:

- **Not retrying a timeout trades one failure mode for another.** A genuine transient timeout now goes straight to a local SFO write, re-adding the transatlantic lock hold #5034 removed. I judged that better than manufacturing collisions, but it is a deliberate trade.
- **`monitorEventLoopDelay` is never reset**, so values are process-lifetime. Per-request windowing would need a timer on the loop being measured. Sustained starvation is what we are looking for, so this is sufficient — but it will not show a single isolated stall.
- **`poolMax()` reads `pool.options.max`**, which is not in `pg`'s public types. Casted, and null-safe.
- I left the `pg_stat_statements` snapshot out of `/api/cron/db-pool-metrics` deliberately, to keep this diff reviewable while production is degraded. It would remove the cumulative-stats blind spot that made this hard to diagnose, and is worth a follow-up.
