### PR TITLE
fix(coding-plans): harden BytePlus inventory validation

### DIFF
--- a/apps/web/src/lib/coding-plans/byteplus-control-plane.test.ts
+++ b/apps/web/src/lib/coding-plans/byteplus-control-plane.test.ts
@@ -27,6 +27,7 @@ function listPayload(overrides: Record<string, unknown> = {}) {
         {
           SeatID: 'seat-123',
           UserName: 'seat-user',
+          IdentityDetail: 'seat-user',
           BizInfo: 'lite',
           SeatStatus: '2',
           BillingStatus: 2,
@@ -93,6 +94,50 @@ describe('BytePlus control-plane client', () => {
         },
       })
     );
+  });
+
+  it('post-filters all returned seats by the plain-text IdentityDetail username', async () => {
+    jest.spyOn(global, 'fetch').mockResolvedValue(
+      jsonResponse({
+        Result: {
+          Data: [
+            {
+              SeatID: 'seat-one',
+              IdentityDetail: 'other-user',
+              ProjectName: 'default',
+              BizInfo: 'Lite',
+              SeatStatus: 2,
+              BillingStatus: 2,
+              ApiKey: 'other-key',
+            },
+            {
+              SeatID: 'seat-target',
+              IdentityDetail: 'assigned-user',
+              ProjectName: 'default',
+              BizInfo: 'Lite',
+              SeatStatus: 2,
+              BillingStatus: 2,
+              ApiKey: 'target-key',
+            },
+          ],
+          Total: 2,
+        },
+      })
+    );
+
+    const result = await listBytePlusSeatsByUsername('assigned-user', 'Lite');
+
+    expect(result).toEqual([
+      {
+        seatId: 'seat-target',
+        bizInfo: 'Lite',
+        seatStatus: 2,
+        billingStatus: 2,
+        apiKey: 'target-key',
+      },
+    ]);
+    expect(JSON.stringify(result)).not.toContain('assigned-user');
+    expect(JSON.stringify(result)).not.toContain('other-user');
   });
 
   it('uses exact seat filters and field-picks the live ListSeatInfos response', async () => {

--- a/apps/web/src/lib/coding-plans/byteplus-control-plane.ts
+++ b/apps/web/src/lib/coding-plans/byteplus-control-plane.ts
@@ -64,6 +64,7 @@ const BytePlusSeatIdSchema = z.string().trim().min(1).max(256);
 const BytePlusSeatSchema = z.object({
   SeatID: z.string().trim().min(1).max(256),
   UserName: z.string().trim().min(1).max(256).optional(),
+  IdentityDetail: z.string().trim().min(1).max(256),
   ProjectName: z.string().trim().min(1).max(128).optional(),
   BizInfo: BytePlusScalarSchema,
   SeatStatus: BytePlusScalarSchema,
@@ -365,17 +366,17 @@ async function callBytePlusControlPlane(
   return parsed;
 }
 
-function parseBytePlusSeat(value: z.infer<typeof BytePlusSeatSchema>): BytePlusSeat & {
-  userName?: string;
-  projectName?: string;
-} {
+function parseBytePlusSeat(
+  value: z.infer<typeof BytePlusSeatSchema>,
+  username: string
+): BytePlusSeat & { usernameMatches: boolean; projectName?: string } {
   return {
     seatId: value.SeatID,
     bizInfo: normalizeTier(value.BizInfo),
     seatStatus: normalizeSeatStatus(value.SeatStatus),
     billingStatus: normalizeBillingStatus(value.BillingStatus),
     ...(value.ApiKey ? { apiKey: value.ApiKey } : {}),
-    ...(value.UserName ? { userName: value.UserName } : {}),
+    usernameMatches: value.IdentityDetail === username || value.UserName === username,
     ...(value.ProjectName ? { projectName: value.ProjectName } : {}),
   };
 }
@@ -392,19 +393,19 @@ export async function listBytePlusSeatsByUsername(
     throw new BytePlusControlPlaneError('invalid_response');
   }
 
-  const parsed = BytePlusListResponseSchema.safeParse(
-    await callBytePlusControlPlane('ListSeatInfos', {
-      Filter: {
-        BizInfo: bizInfo,
-        UserName: username,
-        SeatStatus: 2,
-        BillingStatus: [2],
-      },
-      PageNum: 1,
-      PageSize: BYTEPLUS_LIST_SEATS_PAGE_SIZE,
-      ProjectName: BYTEPLUS_CONTROL_PLANE_PROJECT,
-    })
-  );
+  const rawResponse = await callBytePlusControlPlane('ListSeatInfos', {
+    Filter: {
+      BizInfo: bizInfo,
+      UserName: username,
+      SeatStatus: 2,
+      BillingStatus: [2],
+    },
+    PageNum: 1,
+    PageSize: BYTEPLUS_LIST_SEATS_PAGE_SIZE,
+    ProjectName: BYTEPLUS_CONTROL_PLANE_PROJECT,
+  });
+
+  const parsed = BytePlusListResponseSchema.safeParse(rawResponse);
   if (!parsed.success) {
     throw new BytePlusControlPlaneError('invalid_response');
   }
@@ -417,18 +418,21 @@ export async function listBytePlusSeatsByUsername(
   }
 
   try {
-    return parsed.data.Result.Data.map(parseBytePlusSeat).map(seat => {
-      // UserName and ProjectName are optional in some API responses. When
-      // present, they must still agree with the exact filter supplied by Kilo.
-      if (
-        (seat.userName !== undefined && seat.userName !== username) ||
-        (seat.projectName !== undefined && seat.projectName !== BYTEPLUS_CONTROL_PLANE_PROJECT)
-      ) {
-        throw new BytePlusControlPlaneError('invalid_response');
-      }
-      const { userName: _userName, projectName: _projectName, ...fieldPickedSeat } = seat;
-      return fieldPickedSeat;
-    });
+    const matchingSeats = parsed.data.Result.Data.map(seat => parseBytePlusSeat(seat, username))
+      .filter(
+        seat =>
+          seat.usernameMatches &&
+          (seat.projectName === undefined || seat.projectName === BYTEPLUS_CONTROL_PLANE_PROJECT)
+      )
+      .map(seat => {
+        const {
+          usernameMatches: _usernameMatches,
+          projectName: _projectName,
+          ...fieldPickedSeat
+        } = seat;
+        return fieldPickedSeat;
+      });
+    return matchingSeats;
   } catch (error) {
     throw new BytePlusControlPlaneError(safeBytePlusErrorCode(error));
   }

--- a/apps/web/src/lib/coding-plans/index.ts
+++ b/apps/web/src/lib/coding-plans/index.ts
@@ -30,6 +30,24 @@ import {
 const logInfo = sentryLogger('coding-plans', 'info');
 const logError = sentryLogger('coding-plans', 'error');
 
+export class CodingPlanInventoryUploadError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CodingPlanInventoryUploadError';
+  }
+}
+
+function databaseConstraint(error: unknown): string | null {
+  let current: unknown = error;
+  for (let depth = 0; depth < 5 && current && typeof current === 'object'; depth++) {
+    if ('constraint' in current && typeof current.constraint === 'string') {
+      return current.constraint;
+    }
+    current = 'cause' in current ? current.cause : null;
+  }
+  return null;
+}
+
 // Credential validation calls the live provider API per key. Bound the fan-out so
 // large inventory uploads finish within the request budget without overwhelming
 // the upstream provider with one unbounded burst of requests.
@@ -515,16 +533,18 @@ export async function uploadKeysToInventory(
       return insertedCount;
     });
   } catch (error) {
-    const constraint =
-      typeof error === 'object' && error !== null && 'constraint' in error
-        ? String(error.constraint)
-        : typeof error === 'object' && error !== null && 'cause' in error
-          ? String((error as { cause?: { constraint?: unknown } }).cause?.constraint ?? '')
-          : '';
-    if (constraint === 'UQ_coding_plan_key_inv_provider_usage_id') {
-      throw new Error('One or more BytePlus seats are already attached to inventory.');
+    if (error instanceof CodingPlanInventoryUploadError) throw error;
+    if (error instanceof Error && error.message.includes('already present in inventory')) {
+      throw new CodingPlanInventoryUploadError(error.message);
     }
-    throw error;
+    if (databaseConstraint(error) === 'UQ_coding_plan_key_inv_provider_usage_id') {
+      throw new CodingPlanInventoryUploadError(
+        'One or more BytePlus seats are already attached to inventory.'
+      );
+    }
+    throw new CodingPlanInventoryUploadError(
+      'Unable to store Coding Plan inventory due to a database error.'
+    );
   }
 
   logInfo('Validated managed credentials uploaded to coding plan inventory', {

--- a/apps/web/src/lib/coding-plans/inventory-validation.test.ts
+++ b/apps/web/src/lib/coding-plans/inventory-validation.test.ts
@@ -32,6 +32,10 @@ jest.mock('@/lib/utils.server', () => ({
 
 const mockedGenerateText = jest.mocked(generateText);
 const mockedListBytePlusSeatsByUsername = jest.mocked(listBytePlusSeatsByUsername);
+const mockedSentryLogger = jest.mocked(
+  jest.requireMock('@/lib/utils.server').sentryLogger as () => jest.Mock
+);
+const mockLogWarning = mockedSentryLogger.mock.results[0]?.value as jest.Mock;
 
 beforeEach(() => {
   mockedListBytePlusSeatsByUsername.mockResolvedValue([
@@ -182,6 +186,58 @@ describe('validateCodingPlanCredential', () => {
     });
   });
 
+  it.each([
+    [[], 'no_matching_seat', 0],
+    [
+      [
+        {
+          seatId: 'seat-one',
+          bizInfo: 'Lite' as const,
+          seatStatus: 2 as const,
+          billingStatus: 2 as const,
+          apiKey: 'byteplus-inventory-key',
+        },
+        {
+          seatId: 'seat-two',
+          bizInfo: 'Lite' as const,
+          seatStatus: 2 as const,
+          billingStatus: 2 as const,
+          apiKey: 'byteplus-inventory-key',
+        },
+      ],
+      'multiple_matching_seats',
+      2,
+    ],
+  ])('logs a safe %s seat-count diagnostic', async (seats, reason, returnedSeatCount) => {
+    mockedGenerateText.mockResolvedValueOnce({ finishReason: 'stop' } as never);
+    mockedListBytePlusSeatsByUsername.mockResolvedValueOnce(seats);
+
+    await expect(
+      validateCodingPlanCredential({
+        apiKey: 'byteplus-inventory-key',
+        planId: 'byteplus-coding-plan-team-lite',
+        providerId: 'byteplus-coding',
+        upstreamPlanId: 'byteplus-plan-123',
+      })
+    ).resolves.toEqual({ valid: false });
+
+    expect(mockLogWarning).toHaveBeenCalledWith(
+      'BytePlus coding plan inventory validation failed',
+      {
+        providerId: 'byteplus-coding',
+        stage: 'seat_match',
+        reason,
+        expectedTier: 'Lite',
+        returnedSeatCount,
+      }
+    );
+    const serializedLog = JSON.stringify(mockLogWarning.mock.calls);
+    expect(serializedLog).not.toContain('byteplus-inventory-key');
+    expect(serializedLog).not.toContain('byteplus-plan-123');
+    expect(serializedLog).not.toContain('seat-one');
+    expect(serializedLog).not.toContain('seat-two');
+  });
+
   it('rejects a BytePlus seat without a verifiable matching inference key', async () => {
     mockedGenerateText.mockResolvedValueOnce({ finishReason: 'stop' } as never);
     mockedListBytePlusSeatsByUsername.mockResolvedValueOnce([
@@ -202,5 +258,19 @@ describe('validateCodingPlanCredential', () => {
         upstreamPlanId: 'byteplus-plan-123',
       })
     ).resolves.toEqual({ valid: false });
+
+    expect(mockLogWarning).toHaveBeenCalledWith(
+      'BytePlus coding plan inventory validation failed',
+      {
+        providerId: 'byteplus-coding',
+        stage: 'seat_match',
+        reason: 'seat_api_key_mismatch',
+      }
+    );
+    const serializedLog = JSON.stringify(mockLogWarning.mock.calls);
+    expect(serializedLog).not.toContain('byteplus-inventory-key');
+    expect(serializedLog).not.toContain('different-key');
+    expect(serializedLog).not.toContain('seat-mismatch');
+    expect(serializedLog).not.toContain('byteplus-plan-123');
   });
 });

--- a/apps/web/src/lib/coding-plans/inventory-validation.ts
+++ b/apps/web/src/lib/coding-plans/inventory-validation.ts
@@ -25,6 +25,32 @@ import { sentryLogger } from '@/lib/utils.server';
 const logWarning = sentryLogger('coding-plans-inventory-validation', 'warning');
 const MINIMAX_PROVIDER_ID = 'minimax';
 
+type BytePlusValidationStage = 'configuration' | 'inference' | 'seat_lookup' | 'seat_match';
+type BytePlusValidationReason =
+  | 'missing_management_credentials'
+  | 'inference_request_failed'
+  | 'unexpected_finish_reason'
+  | 'seat_lookup_failed'
+  | 'unsupported_plan'
+  | 'no_matching_seat'
+  | 'multiple_matching_seats'
+  | 'seat_attributes_mismatch'
+  | 'seat_api_key_missing'
+  | 'seat_api_key_mismatch';
+
+function logBytePlusValidationFailure(
+  stage: BytePlusValidationStage,
+  reason: BytePlusValidationReason,
+  details: { code?: string; expectedTier?: 'Lite' | 'Pro'; returnedSeatCount?: number } = {}
+): void {
+  logWarning('BytePlus coding plan inventory validation failed', {
+    providerId: 'byteplus-coding',
+    stage,
+    reason,
+    ...details,
+  });
+}
+
 export type CodingPlanCredentialValidationInput = {
   apiKey: string;
   planId: CodingPlanId;
@@ -70,24 +96,42 @@ async function validateBytePlusCodingPlanCredential(
   upstreamUsername: string
 ): Promise<CodingPlanCredentialValidationResult> {
   if (!BYTEPLUS_CODING_PLAN_ACCESS_KEY_ID || !BYTEPLUS_CODING_PLAN_SECRET_ACCESS_KEY) {
-    throw new BytePlusControlPlaneError('configuration');
-  }
-
-  const output = await generateText({
-    model: createAiSdkProvider(byteplusCoding, apiKey)('bytedance-seed-code'),
-    prompt: 'Say hi',
-    maxOutputTokens: 1,
-  });
-
-  if (output.finishReason !== 'stop' && output.finishReason !== 'length') {
+    logBytePlusValidationFailure('configuration', 'missing_management_credentials', {
+      code: 'configuration',
+    });
     return { valid: false };
   }
 
-  const upstreamUsageId = await resolveBytePlusSeatId({
-    apiKey,
-    planId,
-    upstreamUsername,
-  });
+  let output: Awaited<ReturnType<typeof generateText>>;
+  try {
+    output = await generateText({
+      model: createAiSdkProvider(byteplusCoding, apiKey)('bytedance-seed-code'),
+      prompt: 'Say hi',
+      maxOutputTokens: 1,
+    });
+  } catch {
+    logBytePlusValidationFailure('inference', 'inference_request_failed');
+    return { valid: false };
+  }
+
+  if (output.finishReason !== 'stop' && output.finishReason !== 'length') {
+    logBytePlusValidationFailure('inference', 'unexpected_finish_reason');
+    return { valid: false };
+  }
+
+  let upstreamUsageId: string | null;
+  try {
+    upstreamUsageId = await resolveBytePlusSeatId({
+      apiKey,
+      planId,
+      upstreamUsername,
+    });
+  } catch (error) {
+    logBytePlusValidationFailure('seat_lookup', 'seat_lookup_failed', {
+      code: error instanceof BytePlusControlPlaneError ? error.code : 'unexpected',
+    });
+    return { valid: false };
+  }
   return upstreamUsageId ? { valid: true, upstreamUsageId } : { valid: false };
 }
 
@@ -97,23 +141,47 @@ export async function resolveBytePlusSeatId(input: {
   upstreamUsername: string;
 }): Promise<string | null> {
   const expectedTier = getBytePlusPlanTier(input.planId);
-  if (!expectedTier) return null;
+  if (!expectedTier) {
+    logBytePlusValidationFailure('seat_match', 'unsupported_plan');
+    return null;
+  }
 
   const seats = await listBytePlusSeatsByUsername({
     username: input.upstreamUsername,
     bizInfo: expectedTier,
   });
-  if (seats.length !== 1) return null;
+  if (seats.length === 0) {
+    logBytePlusValidationFailure('seat_match', 'no_matching_seat', {
+      expectedTier,
+      returnedSeatCount: 0,
+    });
+    return null;
+  }
+  if (seats.length > 1) {
+    logBytePlusValidationFailure('seat_match', 'multiple_matching_seats', {
+      expectedTier,
+      returnedSeatCount: seats.length,
+    });
+    return null;
+  }
 
   const [seat] = seats;
   if (seat.bizInfo !== expectedTier || seat.seatStatus !== 2 || seat.billingStatus !== 2) {
+    logBytePlusValidationFailure('seat_match', 'seat_attributes_mismatch');
     return null;
   }
 
   // A missing or masked provider key cannot prove that the uploaded inference
   // key belongs to this seat. Fail closed until BytePlus exposes a safe key
   // identity that can be supplied with inventory instead.
-  if (!seat.apiKey || !constantTimeEqual(seat.apiKey, input.apiKey)) return null;
+  if (!seat.apiKey) {
+    logBytePlusValidationFailure('seat_match', 'seat_api_key_missing');
+    return null;
+  }
+  if (!constantTimeEqual(seat.apiKey, input.apiKey)) {
+    logBytePlusValidationFailure('seat_match', 'seat_api_key_mismatch');
+    return null;
+  }
 
   return seat.seatId;
 }

--- a/apps/web/src/routers/coding-plans-router.ts
+++ b/apps/web/src/routers/coding-plans-router.ts
@@ -4,6 +4,7 @@ import * as z from 'zod';
 
 import {
   cancelCodingPlanSubscription,
+  CodingPlanInventoryUploadError,
   getAvailableCodingPlanIds,
   getCodingPlanAvailabilityIntentCounts,
   getCodingPlanAvailabilityIntentPlanIds,
@@ -387,7 +388,11 @@ export const codingPlansRouter = createTRPCRouter({
         ) {
           throw new TRPCError({ code: 'BAD_REQUEST', message });
         }
-        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+        const safeMessage =
+          error instanceof CodingPlanInventoryUploadError
+            ? error.message
+            : 'Unable to upload Coding Plan inventory.';
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message: safeMessage });
       }
     }),
 


### PR DESCRIPTION
## Summary

Harden BytePlus inventory validation and prevent sensitive provider or database details from reaching API responses.

### Why this change is needed

BytePlus seat lookup responses can contain multiple or mismatched records, and inventory failures must remain diagnosable without exposing credentials, seat identifiers, or database details.

### How this is addressed

- Post-filter BytePlus seats using the returned identity and project fields.
- Require exactly one matching seat with the expected tier, status, billing state, and inference key.
- Add structured, sanitized diagnostics for each validation failure stage.
- Convert inventory constraint and database failures into safe domain errors before returning them through tRPC.
- Add coverage for ambiguous seats, mismatched keys, and sensitive logging.

## Human Verification

- 21 focused BytePlus control-plane and inventory-validation tests passed.

## Reviewer Notes

### Human Reviewer Flags

No notable items for human review beyond what the summary covers.

### Code Reviewer Agent

<details>
<summary>Code Reviewer Notes</summary>

- Web typecheck and lint passed.
- Failure diagnostics intentionally exclude API keys, usernames, seat IDs, and upstream plan identifiers.

</details>
