### PR TITLE
feat(mobile): add connectivity feedback surfaces

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/[session-id].tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/[session-id].tsx
@@ -7,6 +7,7 @@ import {
   SessionDetailContent,
   SessionSkeletonMessages,
 } from '@/components/agents/session-detail-content';
+import { SessionConnectionIndicator } from '@/components/agents/session-connection-indicator';
 import { SessionContextMetrics } from '@/components/agents/session-context-metrics';
 import { AgentSessionProvider } from '@/components/agents/session-provider';
 import { QueryError } from '@/components/query-error';
@@ -95,6 +96,7 @@ export default function SessionDetailScreen() {
             />
           }
         />
+        <SessionConnectionIndicator />
         <SessionSkeletonMessages />
       </View>
     );
@@ -108,6 +110,7 @@ export default function SessionDetailScreen() {
     return (
       <View className="flex-1 bg-background">
         <ScreenHeader title="Session" />
+        <SessionConnectionIndicator />
         <View className="flex-1 items-center justify-center gap-3 px-6">
           <QueryError
             variant={notFound ? 'not-found' : 'server'}

--- a/apps/mobile/src/components/agents/markdown-palette.test.ts
+++ b/apps/mobile/src/components/agents/markdown-palette.test.ts
@@ -23,6 +23,7 @@ const colors = {
   accentSoftForeground: '#1A1A10',
   good: '#2F9A5F',
   warn: '#B27214',
+  warnForeground: '#FFFFFF',
   info: '#2563EB',
   agentYuki: '#6B4FD6',
   agentWorkclaw: '#4F5A10',

--- a/apps/mobile/src/components/agents/session-connection-indicator-state.test.ts
+++ b/apps/mobile/src/components/agents/session-connection-indicator-state.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveSessionConnectionState,
+  type SessionConnectionState,
+} from '@/components/agents/session-connection-indicator-state';
+
+type StatusType = 'idle' | 'autocommit' | 'error' | 'disconnected' | 'interrupted';
+
+const STATUSES: StatusType[] = ['idle', 'autocommit', 'error', 'disconnected', 'interrupted'];
+const CONNECTION_VALUES: boolean[] = [true, false];
+
+function resolve(input: {
+  activeSessionType: 'remote' | 'cloud-agent' | 'read-only' | null;
+  agentStatusType: StatusType;
+  userWebConnected: boolean;
+}): SessionConnectionState {
+  return resolveSessionConnectionState(input);
+}
+
+describe('resolveSessionConnectionState - remote', () => {
+  it('reports down for every status when the mobile user-web leg is down', () => {
+    for (const status of STATUSES) {
+      expect(
+        resolve({ activeSessionType: 'remote', agentStatusType: status, userWebConnected: false })
+      ).toBe('down');
+    }
+  });
+
+  it('reports down for a disconnected agent status even while the user-web leg is up', () => {
+    expect(
+      resolve({
+        activeSessionType: 'remote',
+        agentStatusType: 'disconnected',
+        userWebConnected: true,
+      })
+    ).toBe('down');
+  });
+
+  it('reports up for agent lifecycle statuses other than disconnected while connected', () => {
+    for (const status of STATUSES.filter(item => item !== 'disconnected')) {
+      expect(
+        resolve({ activeSessionType: 'remote', agentStatusType: status, userWebConnected: true })
+      ).toBe('up');
+    }
+  });
+});
+
+describe('resolveSessionConnectionState - cloud-agent', () => {
+  it('reports up for non-disconnected statuses without consulting the user-web leg', () => {
+    for (const status of STATUSES.filter(item => item !== 'disconnected')) {
+      for (const userWebConnected of CONNECTION_VALUES) {
+        expect(
+          resolve({ activeSessionType: 'cloud-agent', agentStatusType: status, userWebConnected })
+        ).toBe('up');
+      }
+    }
+  });
+
+  it('reports down for a disconnected agent status regardless of the user-web leg', () => {
+    for (const userWebConnected of CONNECTION_VALUES) {
+      expect(
+        resolve({
+          activeSessionType: 'cloud-agent',
+          agentStatusType: 'disconnected',
+          userWebConnected,
+        })
+      ).toBe('down');
+    }
+  });
+});
+
+describe('resolveSessionConnectionState - no transport', () => {
+  it('reports none for read-only sessions across every status and connection value', () => {
+    for (const status of STATUSES) {
+      for (const userWebConnected of CONNECTION_VALUES) {
+        expect(
+          resolve({ activeSessionType: 'read-only', agentStatusType: status, userWebConnected })
+        ).toBe('none');
+      }
+    }
+  });
+
+  it('reports none while the session type is unresolved across every status and connection value', () => {
+    for (const status of STATUSES) {
+      for (const userWebConnected of CONNECTION_VALUES) {
+        expect(
+          resolve({ activeSessionType: null, agentStatusType: status, userWebConnected })
+        ).toBe('none');
+      }
+    }
+  });
+});

--- a/apps/mobile/src/components/agents/session-connection-indicator-state.ts
+++ b/apps/mobile/src/components/agents/session-connection-indicator-state.ts
@@ -1,0 +1,17 @@
+import { type AgentStatus, type ResolvedSession } from '@kilocode/cloud-agent-sdk';
+
+export type SessionConnectionState = 'up' | 'down' | 'none';
+
+export function resolveSessionConnectionState(input: {
+  activeSessionType: ResolvedSession['type'] | null;
+  agentStatusType: AgentStatus['type'];
+  userWebConnected: boolean;
+}): SessionConnectionState {
+  if (input.activeSessionType === 'remote') {
+    return !input.userWebConnected || input.agentStatusType === 'disconnected' ? 'down' : 'up';
+  }
+  if (input.activeSessionType === 'cloud-agent') {
+    return input.agentStatusType === 'disconnected' ? 'down' : 'up';
+  }
+  return 'none';
+}

--- a/apps/mobile/src/components/agents/session-connection-indicator.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/session-connection-indicator.mounted.test.tsx
@@ -1,0 +1,149 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/test/render-with-providers.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { SessionConnectionIndicator } from './session-connection-indicator';
+
+const connection = vi.hoisted(() => ({ connected: true }));
+
+vi.mock('react-native', () => ({
+  View: 'View',
+}));
+vi.mock('lucide-react-native', () => ({
+  WifiOff: 'WifiOff',
+}));
+vi.mock('@/components/ui/text', () => ({
+  Text: 'Text',
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ mutedForeground: '#666666' }),
+}));
+vi.mock('@/lib/hooks/use-user-web-connection-state', () => ({
+  useUserWebConnectionState: () => connection.connected,
+}));
+
+type IndicatorProps = Parameters<typeof SessionConnectionIndicator>[0];
+
+async function mount(props: IndicatorProps): Promise<TestRenderer.ReactTestRenderer> {
+  const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+    current: undefined,
+  };
+  await act(async () => {
+    await Promise.resolve();
+    rendererRef.current = TestRenderer.create(createElement(SessionConnectionIndicator, props));
+  });
+  const renderer = rendererRef.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+async function update(
+  renderer: TestRenderer.ReactTestRenderer,
+  props: IndicatorProps
+): Promise<void> {
+  await act(() => {
+    renderer.update(createElement(SessionConnectionIndicator, props));
+  });
+}
+
+function findHost(
+  root: TestRenderer.ReactTestInstance,
+  type: string
+): TestRenderer.ReactTestInstance[] {
+  return root.findAll(node => node.type === type);
+}
+
+describe('SessionConnectionIndicator mounted', () => {
+  beforeEach(() => {
+    connection.connected = true;
+  });
+
+  it('renders a blank fixed row with no text for default (pending/error) props', async () => {
+    const renderer = await mount({});
+
+    const view = findHost(renderer.root, 'View')[0];
+    expect(view).toBeDefined();
+    if (!view) {
+      throw new Error('view not found');
+    }
+    expect(view.props.className).toContain('h-6');
+    expect(view.props.accessibilityElementsHidden).toBe(true);
+    expect(view.props.importantForAccessibility).toBe('no-hide-descendants');
+    expect(view.props.accessible).toBe(false);
+    expect(findHost(renderer.root, 'Text')).toHaveLength(0);
+    expect(findHost(renderer.root, 'WifiOff')).toHaveLength(0);
+  });
+
+  it('renders a blank fixed row while a remote session transport is up', async () => {
+    const renderer = await mount({ activeSessionType: 'remote', agentStatusType: 'idle' });
+
+    const view = findHost(renderer.root, 'View')[0];
+    expect(view).toBeDefined();
+    if (!view) {
+      throw new Error('view not found');
+    }
+    expect(view.props.className).toContain('h-6');
+    expect(view.props.accessibilityElementsHidden).toBe(true);
+    expect(findHost(renderer.root, 'Text')).toHaveLength(0);
+    expect(findHost(renderer.root, 'WifiOff')).toHaveLength(0);
+  });
+
+  it('reads Connecting for a remote session that starts down', async () => {
+    connection.connected = false;
+    const renderer = await mount({ activeSessionType: 'remote', agentStatusType: 'idle' });
+
+    const view = findHost(renderer.root, 'View')[0];
+    expect(view).toBeDefined();
+    if (!view) {
+      throw new Error('view not found');
+    }
+    expect(view.props.className).toContain('h-6');
+    expect(view.props.accessibilityElementsHidden).toBe(false);
+    expect(view.props.importantForAccessibility).toBe('auto');
+    expect(view.props.accessible).toBe(true);
+    expect(view.props.accessibilityLabel).toBe('Connecting…');
+    expect(findHost(renderer.root, 'WifiOff')).toHaveLength(1);
+    const texts = findHost(renderer.root, 'Text');
+    expect(texts.some(node => node.props.children === 'Connecting…')).toBe(true);
+  });
+
+  it('reads Reconnecting after a drop from a committed up state', async () => {
+    const renderer = await mount({ activeSessionType: 'remote', agentStatusType: 'idle' });
+    expect(findHost(renderer.root, 'Text')).toHaveLength(0);
+
+    connection.connected = false;
+    await update(renderer, { activeSessionType: 'remote', agentStatusType: 'idle' });
+
+    const view = findHost(renderer.root, 'View')[0];
+    expect(view).toBeDefined();
+    if (!view) {
+      throw new Error('view not found');
+    }
+    expect(view.props.accessibilityElementsHidden).toBe(false);
+    expect(view.props.accessibilityLabel).toBe('Reconnecting…');
+    expect(findHost(renderer.root, 'WifiOff')).toHaveLength(1);
+    const texts = findHost(renderer.root, 'Text');
+    expect(texts.some(node => node.props.children === 'Reconnecting…')).toBe(true);
+  });
+
+  it('renders a blank fixed row for a read-only session even while disconnected', async () => {
+    connection.connected = false;
+    const renderer = await mount({
+      activeSessionType: 'read-only',
+      agentStatusType: 'disconnected',
+    });
+
+    const view = findHost(renderer.root, 'View')[0];
+    expect(view).toBeDefined();
+    if (!view) {
+      throw new Error('view not found');
+    }
+    expect(view.props.className).toContain('h-6');
+    expect(view.props.accessibilityElementsHidden).toBe(true);
+    expect(findHost(renderer.root, 'Text')).toHaveLength(0);
+    expect(findHost(renderer.root, 'WifiOff')).toHaveLength(0);
+  });
+});

--- a/apps/mobile/src/components/agents/session-connection-indicator.tsx
+++ b/apps/mobile/src/components/agents/session-connection-indicator.tsx
@@ -1,0 +1,58 @@
+import { type AgentStatus, type ResolvedSession } from '@kilocode/cloud-agent-sdk';
+import { WifiOff } from 'lucide-react-native';
+import { useEffect, useRef } from 'react';
+import { View } from 'react-native';
+
+import { Text } from '@/components/ui/text';
+import { useUserWebConnectionState } from '@/lib/hooks/use-user-web-connection-state';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+
+import { resolveSessionConnectionState } from './session-connection-indicator-state';
+
+type SessionConnectionIndicatorProps = {
+  activeSessionType?: ResolvedSession['type'] | null;
+  agentStatusType?: AgentStatus['type'];
+};
+
+export function SessionConnectionIndicator({
+  activeSessionType = null,
+  agentStatusType = 'idle',
+}: Readonly<SessionConnectionIndicatorProps>) {
+  const userWebConnected = useUserWebConnectionState();
+  const colors = useThemeColors();
+  const state = resolveSessionConnectionState({
+    activeSessionType,
+    agentStatusType,
+    userWebConnected,
+  });
+  // "Ever up" is a committed-state ref (written in an effect), so a drop
+  // after the first committed up reads "Reconnecting…" while a cold start
+  // reads "Connecting…". Writing it during render would leak abandoned
+  // render state under concurrent React.
+  const wasUpRef = useRef(false);
+  useEffect(() => {
+    if (state === 'up') {
+      wasUpRef.current = true;
+    }
+  }, [state]);
+  let label: string | null = null;
+  if (state === 'down') {
+    label = wasUpRef.current ? 'Reconnecting…' : 'Connecting…';
+  }
+  return (
+    <View
+      className="h-6 flex-row items-center justify-center gap-1.5"
+      accessibilityElementsHidden={label === null}
+      importantForAccessibility={label === null ? 'no-hide-descendants' : 'auto'}
+      accessible={label !== null}
+      accessibilityLabel={label ?? undefined}
+    >
+      {label !== null ? (
+        <>
+          <WifiOff size={12} color={colors.mutedForeground} />
+          <Text className="text-xs text-muted-foreground">{label}</Text>
+        </>
+      ) : null}
+    </View>
+  );
+}

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -30,6 +30,7 @@ import {
   type ContextSheetIdentity,
   getContextSheetMountState,
 } from '@/components/agents/context-usage-display';
+import { SessionConnectionIndicator } from '@/components/agents/session-connection-indicator';
 import { SessionContextMetrics } from '@/components/agents/session-context-metrics';
 import { SessionContextSheet } from '@/components/agents/session-context-sheet';
 import { selectSessionCostInputs } from '@/components/agents/session-list-helpers';
@@ -801,6 +802,10 @@ export function SessionDetailContent({
                 onTitlePressAccessibilityLabel: `Rename session: ${rename.title}`,
               }
             : {})}
+        />
+        <SessionConnectionIndicator
+          activeSessionType={activeSessionType}
+          agentStatusType={agentStatus.type}
         />
         {keepScreenAwake ? <ActiveSessionKeepAwake sessionId={sessionId} /> : null}
 

--- a/apps/mobile/src/components/app-root-providers.tsx
+++ b/apps/mobile/src/components/app-root-providers.tsx
@@ -6,6 +6,7 @@ import { type ReactNode } from 'react';
 import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { Toaster } from 'sonner-native';
 
+import { OfflineBanner } from '@/components/offline-banner';
 import { AuthProvider } from '@/lib/auth/auth-context';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { OrganizationProvider } from '@/lib/organization-context';
@@ -26,6 +27,7 @@ export function AppRootProviders({ children }: { readonly children: ReactNode })
               <ActionSheetProvider>
                 <>
                   {children}
+                  <OfflineBanner />
                   <PortalHost />
                   {/*
                     Toaster mounts last so it renders above PortalHost overlays (sheets/dropdowns

--- a/apps/mobile/src/components/offline-banner.mounted.test.tsx
+++ b/apps/mobile/src/components/offline-banner.mounted.test.tsx
@@ -1,0 +1,126 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as fixed-part-row.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OfflineBanner } from './offline-banner';
+
+// ── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const state = vi.hoisted(() => ({ isOffline: false }));
+const announceForA11y = vi.hoisted(() => vi.fn());
+
+vi.mock('react-native', () => ({
+  View: 'View',
+}));
+vi.mock('react-native-reanimated', () => ({
+  default: { View: 'Animated.View' },
+  FadeIn: { duration: () => ({}) },
+  FadeOut: { duration: () => ({}) },
+}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 47, right: 0, bottom: 34, left: 0 }),
+}));
+vi.mock('lucide-react-native', () => ({
+  WifiOff: 'WifiOff',
+}));
+vi.mock('@/components/ui/text', () => ({
+  Text: 'Text',
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ warnForeground: '#FFFFFF' }),
+}));
+vi.mock('@/lib/a11y/announce', () => ({
+  announceForA11y,
+}));
+vi.mock('@/lib/hooks/use-offline-banner-state', () => ({
+  useOfflineBannerState: () => state.isOffline,
+}));
+
+// ── Helpers ────────────────────────────────────────────────────────────────
+
+async function mountBanner(): Promise<TestRenderer.ReactTestRenderer> {
+  const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+    current: undefined,
+  };
+  await act(async () => {
+    await Promise.resolve();
+    rendererRef.current = TestRenderer.create(createElement(OfflineBanner));
+  });
+  const renderer = rendererRef.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+function findHost(
+  root: TestRenderer.ReactTestInstance,
+  type: string
+): TestRenderer.ReactTestInstance[] {
+  return root.findAll(node => node.type === type);
+}
+
+describe('OfflineBanner mounted', () => {
+  beforeEach(() => {
+    state.isOffline = false;
+    announceForA11y.mockClear();
+  });
+
+  it('renders nothing while online and never announces', async () => {
+    const renderer = await mountBanner();
+
+    expect(renderer.toJSON()).toBeNull();
+    expect(announceForA11y).not.toHaveBeenCalled();
+  });
+
+  it('renders the banner on an offline mount without announcing the initial state', async () => {
+    state.isOffline = true;
+    const renderer = await mountBanner();
+
+    expect(findHost(renderer.root, 'Animated.View')).toHaveLength(1);
+    expect(findHost(renderer.root, 'Text')).toHaveLength(1);
+    expect(announceForA11y).not.toHaveBeenCalled();
+  });
+
+  it('shows the banner with touch transparency, safe-area top, alert semantics, and announces on the online→offline transition', async () => {
+    const renderer = await mountBanner();
+    state.isOffline = true;
+    await act(async () => {
+      renderer.update(createElement(OfflineBanner));
+      await Promise.resolve();
+    });
+
+    expect(findHost(renderer.root, 'Text')[0]?.props.children).toBe('No internet connection');
+    const outer = findHost(renderer.root, 'View')[0];
+    expect(outer?.props.pointerEvents).toBe('none');
+    expect(outer?.props.style).toEqual({ top: 47 });
+    const alert = findHost(renderer.root, 'Animated.View')[0];
+    expect(alert?.props.accessibilityRole).toBe('alert');
+    expect(alert?.props.accessibilityLabel).toBe('No internet connection');
+    expect(findHost(renderer.root, 'WifiOff')).toHaveLength(1);
+    expect(announceForA11y).toHaveBeenCalledTimes(1);
+    expect(announceForA11y).toHaveBeenCalledWith('No internet connection');
+  });
+
+  it('hides the banner and announces restoration on the offline→online transition', async () => {
+    const renderer = await mountBanner();
+    state.isOffline = true;
+    await act(async () => {
+      renderer.update(createElement(OfflineBanner));
+      await Promise.resolve();
+    });
+    expect(findHost(renderer.root, 'Animated.View')).toHaveLength(1);
+
+    state.isOffline = false;
+    await act(async () => {
+      renderer.update(createElement(OfflineBanner));
+      await Promise.resolve();
+    });
+
+    expect(renderer.toJSON()).toBeNull();
+    expect(announceForA11y).toHaveBeenCalledTimes(2);
+    expect(announceForA11y).toHaveBeenNthCalledWith(1, 'No internet connection');
+    expect(announceForA11y).toHaveBeenNthCalledWith(2, 'Internet connection restored');
+  });
+});

--- a/apps/mobile/src/components/offline-banner.tsx
+++ b/apps/mobile/src/components/offline-banner.tsx
@@ -1,0 +1,53 @@
+import { WifiOff } from 'lucide-react-native';
+import { useEffect, useRef } from 'react';
+import { View } from 'react-native';
+import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { Text } from '@/components/ui/text';
+import { announceForA11y } from '@/lib/a11y/announce';
+import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { useOfflineBannerState } from '@/lib/hooks/use-offline-banner-state';
+
+/**
+ * App-wide offline banner. Absolute overlay, so app content keeps its layout
+ * position; `pointerEvents="none"` passes every touch to the header below.
+ */
+export function OfflineBanner() {
+  const isOffline = useOfflineBannerState();
+  const insets = useSafeAreaInsets();
+  const colors = useThemeColors();
+  const prevRef = useRef<boolean | null>(null);
+
+  // Announce committed transitions only, never the initial state: the first
+  // run records the current value without announcing. A cold-start offline
+  // device announces once when the first NetInfo commit lands (~1 s in).
+  useEffect(() => {
+    if (prevRef.current !== null && prevRef.current !== isOffline) {
+      announceForA11y(isOffline ? 'No internet connection' : 'Internet connection restored');
+    }
+    prevRef.current = isOffline;
+  }, [isOffline]);
+
+  if (!isOffline) {
+    return null;
+  }
+
+  return (
+    // Dynamic safe-area values cannot be Tailwind classes; same inline-style
+    // exception as `ScreenHeader` (style={{ paddingTop }}).
+    <View pointerEvents="none" className="absolute inset-x-0" style={{ top: insets.top }}>
+      <Animated.View
+        entering={FadeIn.duration(200)}
+        exiting={FadeOut.duration(150)}
+        accessible
+        accessibilityRole="alert"
+        accessibilityLabel="No internet connection"
+        className="flex-row items-center justify-center gap-2 bg-warn px-4 py-2"
+      >
+        <WifiOff size={14} color={colors.warnForeground} />
+        <Text className="text-sm font-medium text-warn-foreground">No internet connection</Text>
+      </Animated.View>
+    </View>
+  );
+}

--- a/apps/mobile/src/lib/connectivity-online.test.ts
+++ b/apps/mobile/src/lib/connectivity-online.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+
+import { isOnline } from '@/lib/connectivity-online';
+
+describe('isOnline', () => {
+  it('lets isInternetReachable false win over isConnected true', () => {
+    expect(isOnline({ isConnected: true, isInternetReachable: false })).toBe(false);
+    expect(isOnline({ isConnected: false, isInternetReachable: false })).toBe(false);
+  });
+
+  it('prefers isInternetReachable true over isConnected false', () => {
+    expect(isOnline({ isConnected: false, isInternetReachable: true })).toBe(true);
+  });
+
+  it('falls back to isConnected when isInternetReachable is null', () => {
+    expect(isOnline({ isConnected: false, isInternetReachable: null })).toBe(false);
+    expect(isOnline({ isConnected: true, isInternetReachable: null })).toBe(true);
+  });
+
+  it('defaults to online when both values are null', () => {
+    expect(isOnline({ isConnected: null, isInternetReachable: null })).toBe(true);
+  });
+});

--- a/apps/mobile/src/lib/connectivity-online.ts
+++ b/apps/mobile/src/lib/connectivity-online.ts
@@ -1,0 +1,7 @@
+import { type NetInfoState } from '@react-native-community/netinfo';
+
+export type ConnectivityState = Pick<NetInfoState, 'isConnected' | 'isInternetReachable'>;
+
+export function isOnline(state: ConnectivityState): boolean {
+  return state.isInternetReachable ?? state.isConnected ?? true;
+}

--- a/apps/mobile/src/lib/hooks/use-offline-banner-state.mounted.test.tsx
+++ b/apps/mobile/src/lib/hooks/use-offline-banner-state.mounted.test.tsx
@@ -1,0 +1,121 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/components/agents/fixed-part-row.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { useOfflineBannerState } from '@/lib/hooks/use-offline-banner-state';
+
+type ConnectivityState = { isConnected: boolean | null; isInternetReachable: boolean | null };
+
+const netinfo = vi.hoisted(() => {
+  const listeners = new Set<(state: ConnectivityState) => void>();
+  return {
+    listeners,
+    addEventListener: (listener: (state: ConnectivityState) => void): (() => void) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    emit: (state: ConnectivityState): void => {
+      for (const listener of listeners) {
+        listener(state);
+      }
+    },
+  };
+});
+
+vi.mock('@react-native-community/netinfo', () => ({
+  addEventListener: netinfo.addEventListener,
+}));
+
+function Probe() {
+  const isOffline = useOfflineBannerState();
+  return createElement('ProbeText', null, String(isOffline));
+}
+
+function textChildren(renderer: TestRenderer.ReactTestRenderer): string[] | null {
+  const json = renderer.toJSON();
+  if (!json) {
+    return null;
+  }
+  if (Array.isArray(json)) {
+    return null;
+  }
+  return json.children?.filter((child): child is string => typeof child === 'string') ?? null;
+}
+
+async function renderProbe(): Promise<TestRenderer.ReactTestRenderer> {
+  const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+    current: undefined,
+  };
+  await act(async () => {
+    await Promise.resolve();
+    rendererRef.current = TestRenderer.create(createElement(Probe));
+  });
+  const renderer = rendererRef.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+describe('useOfflineBannerState mounted', () => {
+  beforeEach(() => {
+    // React 19 requires the act environment flag before `act` supports
+    // updates scheduled from effects and external stores.
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+  });
+  afterEach(() => {
+    netinfo.listeners.clear();
+    vi.useRealTimers();
+  });
+
+  it('subscribes once, flips after the debounce in both directions, and cleans up on unmount', async () => {
+    vi.useFakeTimers();
+
+    const renderer = await renderProbe();
+
+    expect(netinfo.listeners.size).toBe(1);
+    expect(textChildren(renderer)).toEqual(['false']);
+
+    act(() => {
+      netinfo.emit({ isConnected: false, isInternetReachable: false });
+    });
+    expect(textChildren(renderer)).toEqual(['false']);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(textChildren(renderer)).toEqual(['true']);
+
+    act(() => {
+      netinfo.emit({ isConnected: true, isInternetReachable: true });
+    });
+    expect(textChildren(renderer)).toEqual(['true']);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(textChildren(renderer)).toEqual(['false']);
+
+    const consoleErrorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    try {
+      act(() => {
+        renderer.unmount();
+      });
+
+      expect(netinfo.listeners.size).toBe(0);
+
+      act(() => {
+        netinfo.emit({ isConnected: false, isInternetReachable: false });
+        vi.advanceTimersByTime(1000);
+      });
+
+      expect(renderer.toJSON()).toBeNull();
+      expect(consoleErrorSpy).not.toHaveBeenCalled();
+    } finally {
+      consoleErrorSpy.mockRestore();
+    }
+  });
+});

--- a/apps/mobile/src/lib/hooks/use-offline-banner-state.ts
+++ b/apps/mobile/src/lib/hooks/use-offline-banner-state.ts
@@ -1,0 +1,41 @@
+import { addEventListener } from '@react-native-community/netinfo';
+import { useCallback, useEffect, useState, useSyncExternalStore } from 'react';
+
+import {
+  type ConnectivitySource,
+  createOfflineBannerStore,
+  type OfflineBannerStore,
+  type OfflineBannerTimer,
+} from '@/lib/offline-banner-state';
+
+const NOOP_SUBSCRIBE = (): (() => void) => () => {
+  // No store on the first render; the effect creates one and destroys it on unmount.
+};
+
+const netInfoSource: ConnectivitySource = {
+  subscribe: listener => addEventListener(listener),
+};
+
+const defaultTimer: OfflineBannerTimer = {
+  set(callback, delayMs) {
+    const handle = setTimeout(callback, delayMs);
+    return {
+      cancel: () => {
+        clearTimeout(handle);
+      },
+    };
+  },
+};
+
+export function useOfflineBannerState(): boolean {
+  const [store, setStore] = useState<OfflineBannerStore | null>(null);
+  useEffect(() => {
+    const created = createOfflineBannerStore({ source: netInfoSource, timer: defaultTimer });
+    setStore(created);
+    return () => {
+      created.destroy();
+    };
+  }, []);
+  const getSnapshot = useCallback(() => store?.isOffline() ?? false, [store]);
+  return useSyncExternalStore(store?.subscribe ?? NOOP_SUBSCRIBE, getSnapshot);
+}

--- a/apps/mobile/src/lib/hooks/use-theme-colors.contrast.test.ts
+++ b/apps/mobile/src/lib/hooks/use-theme-colors.contrast.test.ts
@@ -71,3 +71,17 @@ describe('muted-foreground token contrast (WCAG AA text)', () => {
     }
   });
 });
+
+describe('warn foreground token contrast (WCAG AA text)', () => {
+  it('light theme: warnForeground vs warn >= 4.5:1', () => {
+    // Precomputed ≈ 4.79:1 for #FFFFFF on #9F6612.
+    const ratio = contrastRatio(lightColors.warnForeground, lightColors.warn);
+    expect(ratio).toBeGreaterThanOrEqual(MIN_TEXT_RATIO);
+  });
+
+  it('dark theme: warnForeground vs warn >= 4.5:1', () => {
+    // Precomputed ≈ 9.29:1 for #1A1A10 on #F2B05F.
+    const ratio = contrastRatio(darkColors.warnForeground, darkColors.warn);
+    expect(ratio).toBeGreaterThanOrEqual(MIN_TEXT_RATIO);
+  });
+});

--- a/apps/mobile/src/lib/hooks/use-theme-colors.ts
+++ b/apps/mobile/src/lib/hooks/use-theme-colors.ts
@@ -26,6 +26,7 @@ export const lightColors = {
   accentSoftForeground: '#1A1A10',
   good: '#278150',
   warn: '#9F6612',
+  warnForeground: '#FFFFFF',
   info: '#2563EB',
 
   // Per-agent hues (full-opacity only — tile bg/border live in CSS tokens)
@@ -59,6 +60,7 @@ export const darkColors = {
   accentSoftForeground: '#1A1A10',
   good: '#5FCB8E',
   warn: '#F2B05F',
+  warnForeground: '#1A1A10',
   info: '#60A5FA',
 
   // Per-agent hues

--- a/apps/mobile/src/lib/offline-banner-state.test.ts
+++ b/apps/mobile/src/lib/offline-banner-state.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { type ConnectivityState } from '@/lib/connectivity-online';
+import {
+  type ConnectivitySource,
+  createOfflineBannerStore,
+  type OfflineBannerStore,
+  type OfflineBannerTimer,
+} from '@/lib/offline-banner-state';
+
+const offlineState: ConnectivityState = { isConnected: false, isInternetReachable: false };
+const onlineState: ConnectivityState = { isConnected: true, isInternetReachable: true };
+
+function createFakeSource() {
+  const listeners = new Set<(state: ConnectivityState) => void>();
+  const unsubscribe = vi.fn(() => undefined);
+  const source: ConnectivitySource = {
+    subscribe: listener => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+        unsubscribe();
+      };
+    },
+  };
+  return {
+    source,
+    emit(state: ConnectivityState): void {
+      for (const listener of listeners) {
+        listener(state);
+      }
+    },
+    unsubscribe,
+  };
+}
+
+type ScheduledEntry = { callback: () => void; cancelled: boolean };
+
+function createFakeTimer() {
+  const scheduled: ScheduledEntry[] = [];
+  const timer: OfflineBannerTimer = {
+    // oxlint-disable-next-line promise/prefer-await-to-callbacks -- the fake timer stores callbacks for manual firing
+    set(callback) {
+      const entry: ScheduledEntry = { callback, cancelled: false };
+      scheduled.push(entry);
+      return {
+        cancel() {
+          entry.cancelled = true;
+        },
+      };
+    },
+  };
+  return {
+    timer,
+    scheduled,
+    firePending(): void {
+      while (scheduled.length > 0) {
+        const entry = scheduled.shift();
+        if (!entry) {
+          return;
+        }
+        if (!entry.cancelled) {
+          entry.callback();
+          return;
+        }
+      }
+    },
+  };
+}
+
+function createStore(
+  source = createFakeSource(),
+  timer = createFakeTimer()
+): {
+  store: OfflineBannerStore;
+  source: ReturnType<typeof createFakeSource>;
+  timer: ReturnType<typeof createFakeTimer>;
+} {
+  return {
+    store: createOfflineBannerStore({ source: source.source, timer: timer.timer }),
+    source,
+    timer,
+  };
+}
+
+describe('createOfflineBannerStore', () => {
+  it('starts online', () => {
+    const { store } = createStore();
+
+    expect(store.isOffline()).toBe(false);
+  });
+
+  it('commits offline only after the debounce and notifies once', () => {
+    const { store, source, timer } = createStore();
+    const listener = vi.fn(() => undefined);
+    store.subscribe(listener);
+
+    source.emit(offlineState);
+
+    expect(store.isOffline()).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+
+    timer.firePending();
+
+    expect(store.isOffline()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('never commits when the state returns online inside the window', () => {
+    const { store, source, timer } = createStore();
+    const listener = vi.fn(() => undefined);
+    store.subscribe(listener);
+
+    source.emit(offlineState);
+    source.emit(onlineState);
+
+    timer.firePending();
+
+    expect(store.isOffline()).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+  });
+
+  it('stays offline until the debounce after a committed offline, then notifies once', () => {
+    const { store, source, timer } = createStore();
+    const listener = vi.fn(() => undefined);
+    store.subscribe(listener);
+
+    source.emit(offlineState);
+    timer.firePending();
+    expect(store.isOffline()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    source.emit(onlineState);
+    expect(store.isOffline()).toBe(true);
+
+    timer.firePending();
+
+    expect(store.isOffline()).toBe(false);
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it('commits exactly once for rapid alternation, matching the final quiet state', () => {
+    const { store, source, timer } = createStore();
+    const listener = vi.fn(() => undefined);
+    store.subscribe(listener);
+
+    source.emit(offlineState);
+    source.emit(onlineState);
+    source.emit(offlineState);
+    source.emit(onlineState);
+    source.emit(offlineState);
+
+    timer.firePending();
+
+    expect(store.isOffline()).toBe(true);
+    expect(listener).toHaveBeenCalledTimes(1);
+  });
+
+  it('destroy with a pending commit cancels the timer and unsubscribes the source', () => {
+    const { store, source, timer } = createStore();
+    const listener = vi.fn(() => undefined);
+    store.subscribe(listener);
+
+    source.emit(offlineState);
+    store.destroy();
+
+    timer.firePending();
+    source.emit(onlineState);
+
+    expect(store.isOffline()).toBe(false);
+    expect(listener).not.toHaveBeenCalled();
+    expect(source.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not notify after destroy when the source emits', () => {
+    const { store, source, timer } = createStore();
+    const listener = vi.fn(() => undefined);
+    store.subscribe(listener);
+
+    store.destroy();
+    source.emit(offlineState);
+    timer.firePending();
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(source.unsubscribe).toHaveBeenCalledTimes(1);
+  });
+
+  it('unsubscribes a removed listener', () => {
+    const { store, source } = createStore();
+    const listener = vi.fn(() => undefined);
+    const remove = store.subscribe(listener);
+
+    remove();
+    source.emit(offlineState);
+
+    expect(listener).not.toHaveBeenCalled();
+  });
+});

--- a/apps/mobile/src/lib/offline-banner-state.test.ts
+++ b/apps/mobile/src/lib/offline-banner-state.test.ts
@@ -4,6 +4,7 @@ import { type ConnectivityState } from '@/lib/connectivity-online';
 import {
   type ConnectivitySource,
   createOfflineBannerStore,
+  OFFLINE_BANNER_DEBOUNCE_MS,
   type OfflineBannerStore,
   type OfflineBannerTimer,
 } from '@/lib/offline-banner-state';
@@ -34,14 +35,14 @@ function createFakeSource() {
   };
 }
 
-type ScheduledEntry = { callback: () => void; cancelled: boolean };
+type ScheduledEntry = { callback: () => void; cancelled: boolean; delayMs: number };
 
 function createFakeTimer() {
   const scheduled: ScheduledEntry[] = [];
   const timer: OfflineBannerTimer = {
     // oxlint-disable-next-line promise/prefer-await-to-callbacks -- the fake timer stores callbacks for manual firing
-    set(callback) {
-      const entry: ScheduledEntry = { callback, cancelled: false };
+    set(callback, delayMs) {
+      const entry: ScheduledEntry = { callback, cancelled: false, delayMs };
       scheduled.push(entry);
       return {
         cancel() {
@@ -99,6 +100,8 @@ describe('createOfflineBannerStore', () => {
 
     expect(store.isOffline()).toBe(false);
     expect(listener).not.toHaveBeenCalled();
+
+    expect(timer.scheduled[0]?.delayMs).toBe(OFFLINE_BANNER_DEBOUNCE_MS);
 
     timer.firePending();
 

--- a/apps/mobile/src/lib/offline-banner-state.ts
+++ b/apps/mobile/src/lib/offline-banner-state.ts
@@ -1,0 +1,80 @@
+import { type ConnectivityState, isOnline } from '@/lib/connectivity-online';
+
+export const OFFLINE_BANNER_DEBOUNCE_MS = 1000;
+
+export type OfflineBannerTimer = {
+  set(callback: () => void, delayMs: number): { cancel(): void };
+};
+
+export type ConnectivitySource = {
+  subscribe(listener: (state: ConnectivityState) => void): () => void;
+};
+
+export type OfflineBannerStore = {
+  subscribe: (listener: () => void) => () => void;
+  isOffline: () => boolean;
+  destroy: () => void;
+};
+
+export function createOfflineBannerStore(options: {
+  source: ConnectivitySource;
+  timer: OfflineBannerTimer;
+  debounceMs?: number;
+}): OfflineBannerStore {
+  const { source, timer } = options;
+  const debounceMs = options.debounceMs ?? OFFLINE_BANNER_DEBOUNCE_MS;
+
+  let committedOnline = true;
+  let pending: { cancel(): void } | null = null;
+  const listeners = new Set<() => void>();
+
+  function cancelPending(): void {
+    pending?.cancel();
+    pending = null;
+  }
+
+  function commit(online: boolean): void {
+    committedOnline = online;
+    for (const listener of listeners) {
+      listener();
+    }
+  }
+
+  function schedule(online: boolean): void {
+    cancelPending();
+    pending = timer.set(() => {
+      pending = null;
+      commit(online);
+    }, debounceMs);
+  }
+
+  function handleSourceState(state: ConnectivityState): void {
+    const online = isOnline(state);
+    if (online === committedOnline) {
+      cancelPending();
+      return;
+    }
+    schedule(online);
+  }
+
+  const unsubscribeSource = source.subscribe(handleSourceState);
+
+  // Pre-bound closures: callers pass `subscribe` and `isOffline` as stable
+  // references without losing `this` (they close over internal state).
+  const subscribe = (listener: () => void): (() => void) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+
+  const isOffline = (): boolean => !committedOnline;
+
+  const destroy = (): void => {
+    cancelPending();
+    unsubscribeSource();
+    listeners.clear();
+  };
+
+  return { subscribe, isOffline, destroy };
+}

--- a/apps/mobile/src/lib/query-client-lifecycle.tsx
+++ b/apps/mobile/src/lib/query-client-lifecycle.tsx
@@ -1,9 +1,9 @@
-import { addEventListener, type NetInfoState } from '@react-native-community/netinfo';
+import { addEventListener } from '@react-native-community/netinfo';
 import { focusManager, onlineManager } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { AppState, type AppStateStatus } from 'react-native';
 
-type ConnectivityState = Pick<NetInfoState, 'isConnected' | 'isInternetReachable'>;
+import { type ConnectivityState, isOnline } from '@/lib/connectivity-online';
 
 type QueryClientLifecycleSources = {
   getAppState: () => AppStateStatus;
@@ -36,10 +36,6 @@ const defaultManagers: QueryClientLifecycleManagers = {
   focus: focusManager,
   online: onlineManager,
 };
-
-function isOnline(state: ConnectivityState): boolean {
-  return state.isInternetReachable ?? state.isConnected ?? true;
-}
 
 export function installQueryClientNativeLifecycle({
   sources = nativeLifecycleSources,

--- a/apps/mobile/src/lib/user-web-connection-lifecycle.ts
+++ b/apps/mobile/src/lib/user-web-connection-lifecycle.ts
@@ -1,8 +1,8 @@
-import { AppState, type AppStateStatus } from 'react-native';
-import { addEventListener, type NetInfoState } from '@react-native-community/netinfo';
 import { type ConnectionLifecycleHooks } from '@kilocode/cloud-agent-sdk';
+import { addEventListener } from '@react-native-community/netinfo';
+import { AppState, type AppStateStatus } from 'react-native';
 
-type ConnectivityState = Pick<NetInfoState, 'isConnected' | 'isInternetReachable'>;
+import { type ConnectivityState, isOnline } from '@/lib/connectivity-online';
 
 type NativeLifecycleSources = {
   getAppState: () => AppStateStatus;
@@ -20,10 +20,6 @@ const nativeLifecycleSources: NativeLifecycleSources = {
   },
   onConnectivityChange: listener => addEventListener(listener),
 };
-
-function isOnline(state: ConnectivityState): boolean {
-  return state.isInternetReachable ?? state.isConnected ?? true;
-}
 
 export function createNativeUserWebConnectionLifecycleHooks(
   sources: NativeLifecycleSources = nativeLifecycleSources


### PR DESCRIPTION
User: The mobile app now shows a debounced offline banner without moving screen content and shows session transport loss with Connecting or Reconnecting text.

Product manager: Users receive clear app-wide network feedback and a fixed-height session transport indicator for remote and cloud-agent sessions.

Maintainer: Shared NetInfo online semantics feed an effect-owned trailing-debounce store. The banner uses safe-area overlay rendering and accessibility announcements. The session indicator maps remote and cloud-agent transport signals without changing SDK behavior.

Human steps: No steps are needed before or after merge.

Visual Changes: N/A — this mobile change requires simulator verification and has no uploaded PR screenshots.

E2E: bot-e2e — iOS and Android scenarios verify session transport loss, offline recovery, fixed layout bounds, accessibility, and tap-through behavior.
