### PR TITLE
fix(ai-gateway): retire inclusionai/ling-3.0-flash:free

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -165,7 +165,6 @@ describe('isFreeModel', () => {
         Object.fromEntries(autoFreeModels.map(({ model, reasoning }) => [model, reasoning]))
       ).toEqual({
         'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
-        'inclusionai/ling-3.0-flash:free': { enabled: true, effort: 'high' },
         'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
       });
     });

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -56,11 +56,6 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
       ]
     : []),
   {
-    model: 'inclusionai/ling-3.0-flash:free',
-    weight: 3,
-    reasoning: { enabled: true, effort: 'high' },
-  } satisfies AutoFreeModel,
-  {
     model: 'poolside/laguna-s-2.1:free',
     weight: 1,
     reasoning: { enabled: true, effort: 'high' },

--- a/apps/web/src/lib/ai-gateway/providers/variants.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/variants.test.ts
@@ -7,13 +7,12 @@ import {
 } from '@/lib/ai-gateway/providers/variants';
 
 describe('getFallbackModelVariants', () => {
-  test.each([
-    'google/gemma-4-26b-a4b-it',
-    'poolside/laguna-s-2.1:free',
-    'inclusionai/ling-3.0-flash:free',
-  ])('returns binary variants for %s', model => {
-    expect(getFallbackModelVariants(model)).toBe(REASONING_VARIANTS_BINARY);
-  });
+  test.each(['google/gemma-4-26b-a4b-it', 'poolside/laguna-s-2.1:free'])(
+    'returns binary variants for %s',
+    model => {
+      expect(getFallbackModelVariants(model)).toBe(REASONING_VARIANTS_BINARY);
+    }
+  );
 
   test('returns the latest Nemotron family variants', () => {
     expect(getFallbackModelVariants('nvidia/nemotron-3-super-120b-a12b:free')).toBe(

--- a/apps/web/src/lib/ai-gateway/unavailable-models.ts
+++ b/apps/web/src/lib/ai-gateway/unavailable-models.ts
@@ -21,6 +21,7 @@ const unavailableModelIds: ReadonlySet<string> = new Set([
   'google/gemma-3n-e4b-it:free',
   'google/gemma-4-26b-a4b-it:free', // usable through kilo-auto
   'google/gemma-4-31b-it:free',
+  'inclusionai/ling-3.0-flash:free',
   'kilo/auto-free', // discontinued variant of kilo-auto/free
   'kwaipilot/kat-coder-pro-v2.5:free',
   'liquid/lfm-2.5-1.2b-instruct:free',


### PR DESCRIPTION
## Summary

- Upstream removed free tier for `inclusionai/ling-3.0-flash:free` (OpenRouter 404 “unavailable for free”; Novita/Vercel “model not found”), which zeroed successful traffic and kept BetterStack `/api/models/up` unhealthy.
- Remove the model from `autoFreeModels` so `kilo-auto/free` and preferred/monitor lists no longer include it.
- Add it to `unavailableModelIds` so direct requests get a clean unavailable-model error.
- Update unit test expectations.

## Test plan

- [ ] CI: `models.test.ts`, `unavailable-models.test.ts`, `variants.test.ts`
- [ ] After deploy: `curl -s 'https://api.kilo.ai/api/models/up?key=kilo-models-health-check' | jq '.healthy, .models["inclusionai/ling-3.0-flash:free"]'` — overall healthy; free Ling absent or not monitored
- [ ] Confirm BetterStack models/up monitor recovers
- [ ] Spot-check `kilo-auto/free` still resolves to remaining candidates (stepfun / laguna)