### PR TITLE
fix(ai-gateway): shed usage writes when the pool is full

### DIFF
--- a/apps/web/src/app/api/internal/usage/record/route.ts
+++ b/apps/web/src/app/api/internal/usage/record/route.ts
@@ -11,6 +11,7 @@ import {
 import {
   createPhaseTimer,
   emitUsageRecordTiming,
+  isPrimaryPoolSaturated,
   readPoolGauges,
   shouldEmitUsageRecordTiming,
 } from '@/lib/ai-gateway/usage-record-diagnostics';
@@ -46,6 +47,14 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
   // the pre-check gets confirmed.
   const timer = createPhaseTimer();
   const poolBefore = readPoolGauges();
+  if (isPrimaryPoolSaturated(poolBefore)) {
+    // Do not join an unbounded pg-pool queue. A 503 proves no write started, so
+    // the caller can safely retry this delivery without creating a duplicate.
+    return NextResponse.json(
+      { error: 'Usage record sink busy' },
+      { status: 503, headers: { 'retry-after': '1' } }
+    );
+  }
   let poolWaitingPeak = poolBefore.waiting;
   const samplePool = () => {
     const gauges = readPoolGauges();

--- a/apps/web/src/lib/ai-gateway/usage-record-diagnostics.test.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-diagnostics.test.ts
@@ -7,6 +7,7 @@ import { describe, expect, test } from '@jest/globals';
 import {
   createPhaseTimer,
   describeDatabaseError,
+  isPrimaryPoolSaturated,
   isUsageRowConflict,
   readPoolGauges,
   shouldEmitUsageRecordTiming,
@@ -249,6 +250,20 @@ describe('createPhaseTimer', () => {
 describe('readPoolGauges', () => {
   test('reports the in-process pool counters, not Supavisor stats', () => {
     expect(readPoolGauges()).toEqual({ total: 4, idle: 1, waiting: 0 });
+  });
+});
+
+describe('isPrimaryPoolSaturated', () => {
+  test('rejects work when every configured connection is checked out', () => {
+    expect(isPrimaryPoolSaturated({ total: 10, idle: 0, waiting: 245 })).toBe(true);
+  });
+
+  test('accepts work when an idle connection is available', () => {
+    expect(isPrimaryPoolSaturated({ total: 10, idle: 1, waiting: 0 })).toBe(false);
+  });
+
+  test('accepts work when the pool can still open a connection', () => {
+    expect(isPrimaryPoolSaturated({ total: 9, idle: 0, waiting: 0 })).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/usage-record-diagnostics.ts
+++ b/apps/web/src/lib/ai-gateway/usage-record-diagnostics.ts
@@ -78,6 +78,16 @@ export function readPoolGauges(): PoolGauges {
   };
 }
 
+/**
+ * Whether a new request would have to queue for the primary pool.
+ *
+ * Fail open if the pool implementation does not expose its configured maximum.
+ */
+export function isPrimaryPoolSaturated(gauges: PoolGauges): boolean {
+  const max = poolMax();
+  return max !== null && gauges.idle === 0 && gauges.total >= max;
+}
+
 function eventLoopLagMs() {
   return {
     mean_ms: Math.round(eventLoopDelay.mean / 1e6),


### PR DESCRIPTION
## Summary

Follow-up to #5034, #5098, and #5105. The shared Sentry event for `insertUsageRecord failed (code=unknown constraint=none)` shows the failure originates at `pg-pool` acquisition inside Drizzle, before `BEGIN` or any usage SQL. The paired `usage record handoff to primary region failed` event is the caller reporting that failed Frankfurt delivery.

Production diagnostics already show the local pool at `idle=0` on 96-98% of sampled requests, with as many as 245 waiters against `max=10`. Letting every handoff join that queue causes connection-acquisition timeouts and keeps unrelated work on the same Fluid instance under pressure.

This change adds admission control to `POST /api/internal/usage/record`: after authentication, it returns a retryable 503 before reading the body or starting a write when the primary pool has no idle connection and is already at its configured maximum. The existing client retries 503 because this response proves no write began, preserving idempotency. Requests are still admitted when an idle connection exists or the pool can grow. If the pool maximum is unavailable, the check fails open.

The third linked event, `TRPCError: Usage data temporarily unavailable`, is a separate Snowflake query exceeding its 5-second timeout. Its stack does not touch this PostgreSQL path, so this PR does not claim to fix it.

## Verification

- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/usage-record-diagnostics.test.ts src/lib/ai-gateway/usage-record-client.test.ts` (53 tests passed)
- `pnpm --filter web typecheck`
- `pnpm --filter web lint` (0 warnings, 0 errors)
- `pnpm format`
- `git diff --check`

## Visual Changes

N/A