### PR TITLE
feat(shell-security): return EOL notice instead of security report

### DIFF
--- a/apps/web/src/app/api/shell-security/analyze/route.test.ts
+++ b/apps/web/src/app/api/shell-security/analyze/route.test.ts
@@ -8,7 +8,6 @@ import {
   recordShellSecurityScan,
 } from '@/lib/shell-security/rate-limiter';
 import { trackShellSecurityScanCompleted } from '@/lib/shell-security/posthog-tracking';
-import { getShellSecurityContent } from '@/lib/shell-security/content-loader';
 import { RATE_LIMIT_PER_DAY } from '@/lib/shell-security/schemas';
 
 // Capture after() callbacks so we can flush them in tests
@@ -30,78 +29,10 @@ jest.mock('@sentry/nextjs', () => ({
   captureException: jest.fn(),
 }));
 
-// The real content-loader queries the DB. In CI, workerSetup.ts runs
-// `cleanupDbForTest()` after migrations, which truncates every table —
-// including our seeded content. Mock the loader here so the route tests
-// exercise deterministic content that mirrors the migration seed, without
-// depending on whether the cleanup happened to preserve the seed rows.
-// Fixture is installed per-test in beforeEach (resetAllMocks wipes it).
-jest.mock('@/lib/shell-security/content-loader', () => {
-  const actual = jest.requireActual('@/lib/shell-security/content-loader');
-  return {
-    ...actual,
-    getShellSecurityContent: jest.fn(),
-  };
-});
-
 const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
 const mockedCheckRateLimit = jest.mocked(checkShellSecurityRateLimit);
 const mockedRecordScan = jest.mocked(recordShellSecurityScan);
 const mockedTrackScan = jest.mocked(trackShellSecurityScanCompleted);
-const mockedGetContent = jest.mocked(getShellSecurityContent);
-
-// Seed-equivalent content used by the route-level tests. `jest.resetAllMocks`
-// in beforeEach clears mock return values; setShellSecurityContentFixture()
-// re-installs this value before each test.
-const TEST_CONTENT = {
-  checkCatalog: new Map([
-    [
-      'fs.config.perms_world_readable',
-      {
-        severity: 'critical' as const,
-        explanation: 'The OpenClaw configuration file is readable by all users.',
-        risk: 'Any process can read your secrets.',
-      },
-    ],
-    [
-      'summary.attack_surface',
-      {
-        severity: 'info' as const,
-        explanation: 'Summary of the attack surface.',
-        risk: 'More entry points mean more risk.',
-      },
-    ],
-  ]),
-  kiloclawCoverage: [
-    {
-      area: 'config_permissions',
-      summary: 'Config files are restricted to owner only access',
-      detail: 'KiloClaw provisions strict file permissions.',
-      matchCheckIds: ['fs.config.perms_world_readable', 'fs.config.perms_group_readable'],
-    },
-    {
-      area: 'gateway_exposure',
-      summary: 'Gateway bound to localhost only',
-      detail: 'Reverse proxy handles external access.',
-      matchCheckIds: ['summary.attack_surface'],
-    },
-  ],
-  content: new Map([
-    ['framing.openclaw', '**How KiloClaw handles this:** {summary}. {detail}'],
-    [
-      'framing.kiloclaw',
-      '**KiloClaw default:** {summary}. Your instance has diverged from this default configuration.',
-    ],
-    ['fallback.risk', 'Review this finding: {detail}'],
-    ['fallback.recommendation_action', 'Address finding: {title} ({checkId})'],
-    ['section.next_step', '## Next step: try KiloClaw free'],
-    ['cta.body', '**Start a free trial at [kilo.ai/kiloclaw](https://kilo.ai/kiloclaw).**'],
-  ]),
-};
-
-function setShellSecurityContentFixture() {
-  mockedGetContent.mockResolvedValue(TEST_CONTENT);
-}
 
 function setUserAuth(id = 'user-123') {
   mockedGetUserFromAuth.mockResolvedValue({
@@ -167,7 +98,6 @@ describe('POST /api/shell-security/analyze', () => {
     jest.resetAllMocks();
     afterCallbacks = [];
     mockedRecordScan.mockResolvedValue(undefined);
-    setShellSecurityContentFixture();
   });
 
   it('returns 401 when not authenticated', async () => {
@@ -245,7 +175,7 @@ describe('POST /api/shell-security/analyze', () => {
     expect(data.error.message.length).toBeGreaterThan(30);
   });
 
-  it('returns 200 with structured report for valid request', async () => {
+  it('returns 200 with the discontinuation notice for valid request', async () => {
     setUserAuth();
     setRateLimitAllowed();
     const { POST } = await import('./route');
@@ -256,32 +186,18 @@ describe('POST /api/shell-security/analyze', () => {
     const data = await response.json();
     expect(data.apiVersion).toBe('2026-04-01');
     expect(data.status).toBe('success');
-    expect(data.report.markdown).toContain('# Security Audit Report');
-    expect(data.report.summary.critical).toBe(1);
-    expect(data.report.findings).toHaveLength(2);
-    expect(data.report.recommendations.length).toBeGreaterThan(0);
-    // Grade fields are populated in both structured + markdown form.
-    expect(['A', 'B', 'C', 'D', 'F']).toContain(data.report.grade);
-    expect(data.report.score).toBeGreaterThanOrEqual(0);
-    expect(data.report.score).toBeLessThanOrEqual(100);
-    expect(data.report.markdown).toContain('## Security Grade:');
+    // The plugin renders report.markdown verbatim, so the notice must land there.
+    expect(data.report.markdown).toContain('discontinued');
+    expect(data.report.markdown).toContain('openclaw plugins uninstall shell-security');
+    // No analysis is performed anymore — structured fields are benign stubs.
+    expect(data.report.summary).toEqual({ critical: 0, warn: 0, info: 0, passed: 0 });
+    expect(data.report.findings).toEqual([]);
+    expect(data.report.recommendations).toEqual([]);
+    expect(data.report.grade).toBe('A');
+    expect(data.report.score).toBe(100);
   });
 
-  it('includes sales comparison for openclaw source', async () => {
-    setUserAuth();
-    setRateLimitAllowed();
-    const { POST } = await import('./route');
-
-    const response = await POST(makeRequest() as never);
-    const data = await response.json();
-
-    const configFinding = data.report.findings.find(
-      (f: { checkId: string }) => f.checkId === 'fs.config.perms_world_readable'
-    );
-    expect(configFinding.kiloClawComparison).toContain('How KiloClaw handles this');
-  });
-
-  it('includes divergence warning for kiloclaw source', async () => {
+  it('returns the same discontinuation notice for kiloclaw source', async () => {
     setUserAuth();
     setRateLimitAllowed();
     const { POST } = await import('./route');
@@ -291,17 +207,11 @@ describe('POST /api/shell-security/analyze', () => {
       source: { platform: 'kiloclaw', method: 'plugin', pluginVersion: '1.0.0' },
     };
     const response = await POST(makeRequest(kiloClawBody) as never);
-    const data = await response.json();
+    expect(response.status).toBe(200);
 
-    // Probe summary.attack_surface rather than fs.config.perms_world_readable:
-    // the latter is in KILOCLAW_MITIGATED_CHECKS and gets filtered out of
-    // rendered findings on KiloClaw. summary.attack_surface is not mitigated
-    // and still matches gateway_exposure coverage in the test fixture, so
-    // the divergence framing should attach to it on KiloClaw.
-    const attackSurface = data.report.findings.find(
-      (f: { checkId: string }) => f.checkId === 'summary.attack_surface'
-    );
-    expect(attackSurface.kiloClawComparison).toContain('diverged');
+    const data = await response.json();
+    expect(data.report.markdown).toContain('discontinued');
+    expect(data.report.findings).toEqual([]);
   });
 
   it('returns 429 when rate limit exceeded', async () => {
@@ -353,7 +263,10 @@ describe('POST /api/shell-security/analyze', () => {
         userId: 'user-123',
         organizationId: 'org-456',
         sourcePlatform: 'openclaw',
-        findingsCritical: 1,
+        // Stub report values — no analysis runs anymore.
+        findingsCritical: 0,
+        grade: 'A',
+        score: 100,
       })
     );
   });

--- a/apps/web/src/app/api/shell-security/analyze/route.ts
+++ b/apps/web/src/app/api/shell-security/analyze/route.ts
@@ -11,13 +11,43 @@ import {
   type ShellSecurityError,
   type ShellSecurityResponse,
 } from '@/lib/shell-security/schemas';
-import { generateSecurityReport } from '@/lib/shell-security/report-generator';
-import { getShellSecurityContent } from '@/lib/shell-security/content-loader';
 import {
   checkShellSecurityRateLimit,
   recordShellSecurityScan,
 } from '@/lib/shell-security/rate-limiter';
 import { trackShellSecurityScanCompleted } from '@/lib/shell-security/posthog-tracking';
+
+// The shell-security plugin is end of life. Every published plugin version
+// renders `report.markdown` verbatim in chat, so this endpoint now returns a
+// static discontinuation notice instead of a generated report. It must stay a
+// 200 success response: the plugin wraps error responses in "Security checkup
+// failed unexpectedly" boilerplate, while the success path renders cleanly.
+// Old plugin versions can never be forced to upgrade, so this endpoint (and
+// its legacy /api/security-advisor/analyze alias) stays up indefinitely.
+const EOL_MARKDOWN = `## The Kilo shell security checkup has been discontinued
+
+This plugin no longer performs security analysis and will not receive updates.
+
+You can remove it with:
+
+\`\`\`
+openclaw plugins uninstall shell-security
+\`\`\`
+
+For a managed OpenClaw environment that is secure by default, see [KiloClaw](https://kilo.ai/kiloclaw).
+`;
+
+// Zero findings maps to a clean grade in the old report generator, so A/100
+// with empty findings is the most internally consistent stub for any non-plugin
+// consumer that reads the structured fields.
+const EOL_REPORT: ShellSecurityResponse['report'] = {
+  markdown: EOL_MARKDOWN,
+  grade: 'A',
+  score: 100,
+  summary: { critical: 0, warn: 0, info: 0, passed: 0 },
+  findings: [],
+  recommendations: [],
+};
 
 function errorResponse(
   code: ShellSecurityError['error']['code'],
@@ -95,21 +125,15 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  // 6. Generate report
-  const isKiloClaw = payload.source.platform === 'kiloclaw';
-  const content = await getShellSecurityContent();
-  const report = generateSecurityReport({
-    audit: payload.audit,
-    publicIp: payload.publicIp,
-    isKiloClaw,
-    content,
-  });
-
-  // 7. Record scan in DB (synchronous — must complete before response
-  // so the rate limit counter is accurate under concurrent requests)
+  // 6. Record scan in DB (synchronous — must complete before response
+  // so the rate limit counter is accurate under concurrent requests).
+  // Scan rows are also how we measure remaining traffic before removing
+  // the rest of the feature.
   await recordShellSecurityScan(user.id, organizationId ?? undefined, payload);
 
-  // 8. Fire PostHog event (non-blocking — analytics don't need to block the response)
+  // 7. Fire PostHog event (non-blocking — analytics don't need to block the
+  // response). Kept so scan-volume dashboards keep working through the EOL
+  // wind-down; finding counts reflect the stub report, not a real analysis.
   after(() => {
     try {
       trackShellSecurityScanCompleted({
@@ -120,11 +144,11 @@ export async function POST(request: NextRequest) {
         sourceMethod: payload.source.method,
         pluginVersion: payload.source.pluginVersion,
         openclawVersion: payload.source.openclawVersion,
-        findingsCritical: report.summary.critical,
-        findingsWarn: report.summary.warn,
-        findingsInfo: report.summary.info,
-        grade: report.grade,
-        score: report.score,
+        findingsCritical: EOL_REPORT.summary.critical,
+        findingsWarn: EOL_REPORT.summary.warn,
+        findingsInfo: EOL_REPORT.summary.info,
+        grade: EOL_REPORT.grade,
+        score: EOL_REPORT.score,
         publicIp: payload.publicIp,
       });
     } catch (err) {
@@ -132,18 +156,11 @@ export async function POST(request: NextRequest) {
     }
   });
 
-  // 9. Return structured response
+  // 8. Return the static discontinuation notice
   const response: ShellSecurityResponse = {
     apiVersion: API_VERSION,
     status: 'success',
-    report: {
-      markdown: report.markdown,
-      grade: report.grade,
-      score: report.score,
-      summary: report.summary,
-      findings: report.findings,
-      recommendations: report.recommendations,
-    },
+    report: EOL_REPORT,
   };
 
   return NextResponse.json(response);


### PR DESCRIPTION
## Summary

First step in ending life for the `@kilocode/shell-security` plugin. The analyze
endpoint no longer generates a security report. Every valid request now gets a
static 200 response whose `report.markdown` contains a discontinuation notice
with uninstall instructions. All published plugin versions render that field
verbatim in chat, and the legacy `/api/security-advisor/analyze` alias
re-exports this handler, so older 0.1.x clients receive the notice too.

Auth, request validation, rate limiting, scan recording, and the PostHog event
are unchanged, so remaining traffic stays measurable ahead of further cleanup.

## Verification

- [ ] Not manually tested against a running instance. The change replaces the
      generated report with a static response body; the updated route tests
      cover the success path for both `openclaw` and `kiloclaw` sources plus
      the unchanged auth, validation, and rate limit paths.

## Visual Changes

N/A

## Reviewer Notes

- The response stays a 200 success on purpose: the plugin wraps error
  responses in "Security checkup failed unexpectedly" boilerplate, while the
  success path renders the notice cleanly.
- The structured fields are benign stubs (empty findings and recommendations,
  grade A, score 100), consistent with what the old generator produced for
  zero findings.
- `report-generator.ts` and `content-loader.ts` are no longer imported by the
  route but are intentionally left in place. Removing them, the admin content
  tab, and the content tables is deferred to a later PR, once scan volume
  confirms the notice has reached remaining callers.
- Deprecating the npm package itself happens separately.
