### PR TITLE
fix(sessions): disable shared session access

### DIFF
--- a/apps/web/src/app/s/[sessionId]/page.tsx
+++ b/apps/web/src/app/s/[sessionId]/page.tsx
@@ -10,13 +10,15 @@ import { OpenInCliButton } from '@/app/share/[shareId]/open-in-cli-button';
 import { OpenInEditorButton } from '@/app/share/[shareId]/open-in-editor-button';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 
-export const revalidate = 86400;
+export const dynamic = 'force-dynamic';
 
 export default async function SharedSessionPage({
   params,
 }: {
   params: Promise<{ sessionId: string }>;
 }) {
+  notFound();
+
   const { sessionId } = await params;
 
   // Validate sessionId is a valid UUID before querying the database

--- a/apps/web/src/app/share/[shareId]/page.tsx
+++ b/apps/web/src/app/share/[shareId]/page.tsx
@@ -27,7 +27,7 @@ import { cookies } from 'next/headers';
 import { getExtensionUrl } from '@/components/auth/getExtensionUrl';
 import { validate as isValidUUID } from 'uuid';
 
-export const revalidate = 86400;
+export const dynamic = 'force-dynamic';
 
 /**
  * Extracts text content from a blob message based on its type.
@@ -85,6 +85,8 @@ export default async function SharePage({
   params: Promise<{ shareId: string }>;
   searchParams: Promise<NextAppSearchParams>;
 }) {
+  notFound();
+
   const { shareId } = await params;
   const resolvedSearchParams = await searchParams;
   const cookieStore = await cookies();

--- a/services/session-ingest/src/app.ts
+++ b/services/session-ingest/src/app.ts
@@ -16,6 +16,7 @@ import { getSessionExport } from './services/session-export';
 import { withDORetry } from '@kilocode/worker-utils';
 
 const sessionIdSchema = z.string().startsWith('ses_').length(30);
+const publicSessionAccessEnabled: boolean = false;
 const invalidateSessionAccessSchema = z.object({
   kiloUserId: z.string().min(1),
   organizationId: z.uuid(),
@@ -78,6 +79,10 @@ app.get('/session/:sessionId', async c => {
       { success: false, error: 'Invalid sessionId', issues: parsedSessionId.error.issues },
       400
     );
+  }
+
+  if (!publicSessionAccessEnabled) {
+    return c.json({ success: false, error: 'session_not_found' }, 404);
   }
 
   const db = getWorkerDb(c.env.HYPERDRIVE.connectionString);

--- a/services/session-ingest/src/index.test.ts
+++ b/services/session-ingest/src/index.test.ts
@@ -32,7 +32,6 @@ vi.mock('./dos/SessionAccessCacheDO', () => ({
 
 import { app } from './index';
 import { getWorkerDb } from '@kilocode/db/client';
-import { getSessionIngestDO } from './dos/SessionIngestDO';
 import { getSessionAccessCacheDO } from './dos/SessionAccessCacheDO';
 
 type TestBindings = {
@@ -169,37 +168,13 @@ describe('public session route', () => {
     expect(res.status).toBe(400);
   });
 
-  it('returns 404 when public_id not found', async () => {
+  it('returns 404 without looking up the public_id', async () => {
     const { db, selectResult } = makeDbFakes();
     vi.mocked(getWorkerDb).mockReturnValue(db as never);
-    selectResult.mockResolvedValueOnce([]);
 
     const res = await app.request('/session/11111111-1111-4111-8111-111111111111', {}, defaultEnv);
 
     expect(res.status).toBe(404);
-  });
-
-  it('returns DO snapshot json with content-type', async () => {
-    const { db, selectResult } = makeDbFakes();
-    vi.mocked(getWorkerDb).mockReturnValue(db as never);
-    selectResult.mockResolvedValueOnce([
-      {
-        session_id: 'ses_12345678901234567890123456',
-        kilo_user_id: 'usr_123',
-      },
-    ]);
-
-    const stub = {
-      getAllStream: vi.fn(async () => new Response('{"ok":true}').body!),
-    };
-    vi.mocked(getSessionIngestDO).mockReturnValue(
-      stub as unknown as ReturnType<typeof getSessionIngestDO>
-    );
-
-    const res = await app.request('/session/11111111-1111-4111-8111-111111111111', {}, defaultEnv);
-
-    expect(res.status).toBe(200);
-    expect(res.headers.get('content-type')).toBe('application/json; charset=utf-8');
-    expect(await res.text()).toBe('{"ok":true}');
+    expect(selectResult).not.toHaveBeenCalled();
   });
 });


### PR DESCRIPTION
## Summary
- return 404 from legacy and current shared-session pages
- return 404 from the public session-ingest endpoint without loading session data
- keep authenticated session access and sharing APIs unchanged

## Verification
- `pnpm --filter web typecheck`
- `pnpm --filter cloudflare-session-ingest typecheck`
- `pnpm --filter cloudflare-session-ingest lint`
- `pnpm --filter cloudflare-session-ingest test -- src/index.test.ts`
- targeted `oxfmt --check` and `git diff --check`