### PR TITLE
feat(auth): log admin login audit event

### DIFF
--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -553,7 +553,8 @@ type ExtendedProfile = Profile & {
 
 const posthogClient = PostHogClient();
 const logger: LoggerInstance = {
-  debug: logExceptInTest,
+  // NextAuth debug payloads can include OAuth credentials; never ship them to logs.
+  debug: () => {},
   warn: sentryLogger('NEXTAUTH', 'warning'),
   error: sentryLogger('NEXTAUTH', 'error'),
 };
@@ -939,6 +940,19 @@ export const authOptions: NextAuthOptions = {
           // mutate the profile to track if its new (only for new user registrations)
           extendedProfile.isNewUser = 'isNew' in result ? result.isNew : false; // Add isNewUser to the profile
         }
+
+        if (result.user.is_admin) {
+          // Keep this event free of OAuth tokens and PII; Vercel ships it to Axiom.
+          logExceptInTest(
+            JSON.stringify({
+              event: 'admin_login_succeeded',
+              kiloUserId: result.user.id,
+              provider: accountInfo.provider,
+              isSuperAdmin: result.user.is_super_admin,
+            })
+          );
+        }
+
         return true;
       } catch (error) {
         const operation = isAccountLinking ? 'account_linking' : 'user_creation';
@@ -1035,7 +1049,7 @@ export const authOptions: NextAuthOptions = {
     signIn: '/users/sign_in',
     error: '/users/sign_in',
   },
-  debug: !!getEnvVariable('DEBUG_AUTH'),
+  debug: false,
 };
 
 export const nextAuthHttpHandler = NextAuth(authOptions);

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -994,19 +994,6 @@ export const authOptions: NextAuthOptions = {
         token.authenticatedAt = token.iat;
         delete token.ssoSourceOrganizationId;
 
-        if (existingUser.is_admin) {
-          // Admin audit trail: identify which Kilocode admin authenticated.
-          logExceptInTest(
-            JSON.stringify({
-              event: 'admin_login_succeeded',
-              kiloUserId: existingUser.id,
-              email: existingUser.google_user_email,
-              provider: accountInfo.provider,
-              adminTier: existingUser.is_super_admin ? 'super_admin' : 'platform_admin',
-            })
-          );
-        }
-
         if (accountInfo.provider === 'workos') {
           const domain = getLowerDomainFromEmail(existingUser.google_user_email);
           assert(domain, 'WorkOS user must have a valid primary email domain');
@@ -1016,6 +1003,20 @@ export const authOptions: NextAuthOptions = {
             `WorkOS user does not have one active SSO authority for ${domain}`
           );
           token.ssoSourceOrganizationId = ssoAuthority.sourceOrganizationId;
+        }
+
+        if (existingUser.is_admin) {
+          // Admin audit trail: identify which Kilocode admin authenticated.
+          // Emitted only after JWT creation is guaranteed to succeed.
+          logExceptInTest(
+            JSON.stringify({
+              event: 'admin_login_succeeded',
+              kiloUserId: existingUser.id,
+              email: existingUser.google_user_email,
+              provider: accountInfo.provider,
+              adminTier: existingUser.is_super_admin ? 'super_admin' : 'platform_admin',
+            })
+          );
         }
       } catch (error) {
         captureException(error, {

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -553,8 +553,7 @@ type ExtendedProfile = Profile & {
 
 const posthogClient = PostHogClient();
 const logger: LoggerInstance = {
-  // NextAuth debug payloads can include OAuth credentials; never ship them to logs.
-  debug: () => {},
+  debug: logExceptInTest,
   warn: sentryLogger('NEXTAUTH', 'warning'),
   error: sentryLogger('NEXTAUTH', 'error'),
 };
@@ -940,19 +939,6 @@ export const authOptions: NextAuthOptions = {
           // mutate the profile to track if its new (only for new user registrations)
           extendedProfile.isNewUser = 'isNew' in result ? result.isNew : false; // Add isNewUser to the profile
         }
-
-        if (result.user.is_admin) {
-          // Keep this event free of OAuth tokens and PII; Vercel ships it to Axiom.
-          logExceptInTest(
-            JSON.stringify({
-              event: 'admin_login_succeeded',
-              kiloUserId: result.user.id,
-              provider: accountInfo.provider,
-              isSuperAdmin: result.user.is_super_admin,
-            })
-          );
-        }
-
         return true;
       } catch (error) {
         const operation = isAccountLinking ? 'account_linking' : 'user_creation';
@@ -1049,7 +1035,7 @@ export const authOptions: NextAuthOptions = {
     signIn: '/users/sign_in',
     error: '/users/sign_in',
   },
-  debug: false,
+  debug: !!getEnvVariable('DEBUG_AUTH'),
 };
 
 export const nextAuthHttpHandler = NextAuth(authOptions);

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -994,6 +994,19 @@ export const authOptions: NextAuthOptions = {
         token.authenticatedAt = token.iat;
         delete token.ssoSourceOrganizationId;
 
+        if (existingUser.is_admin) {
+          // Admin audit trail: identify which Kilocode admin authenticated.
+          logExceptInTest(
+            JSON.stringify({
+              event: 'admin_login_succeeded',
+              kiloUserId: existingUser.id,
+              email: existingUser.google_user_email,
+              provider: accountInfo.provider,
+              adminTier: existingUser.is_super_admin ? 'super_admin' : 'platform_admin',
+            })
+          );
+        }
+
         if (accountInfo.provider === 'workos') {
           const domain = getLowerDomainFromEmail(existingUser.google_user_email);
           assert(domain, 'WorkOS user must have a valid primary email domain');


### PR DESCRIPTION
## Summary
- emit a structured `admin_login_succeeded` log event when a Kilocode admin authenticates
- record the admin user ID, email, provider, and admin tier for the Axiom-backed admin audit trail
- admin-only; no change to NextAuth `DEBUG_AUTH` behavior and no new schema

## Notes
- The event is emitted via stdout and shipped to the `vercel` dataset in Axiom, powering the Admin Access Security dashboard login panels.

## Validation
- pnpm --filter web lint
- pnpm --filter web typecheck
- git diff --check