### PR TITLE
feat(auth): audit-log all admin access (choke-point, IP-independent)

### DIFF
--- a/apps/web/src/lib/admin/admin-access-log.test.ts
+++ b/apps/web/src/lib/admin/admin-access-log.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, test } from '@jest/globals';
+import { authViaTokenFromHeaders, clientIpFromHeaders } from './admin-access-log';
+
+describe('clientIpFromHeaders', () => {
+  test('returns the first hop of x-forwarded-for', () => {
+    expect(clientIpFromHeaders(new Headers({ 'x-forwarded-for': '203.0.113.7, 10.0.0.1' }))).toBe(
+      '203.0.113.7'
+    );
+  });
+
+  test('trims surrounding whitespace', () => {
+    expect(
+      clientIpFromHeaders(new Headers({ 'x-forwarded-for': '  203.0.113.9 , 10.0.0.1' }))
+    ).toBe('203.0.113.9');
+  });
+
+  test('falls back to x-vercel-forwarded-for when x-forwarded-for is absent', () => {
+    expect(clientIpFromHeaders(new Headers({ 'x-vercel-forwarded-for': '198.51.100.5' }))).toBe(
+      '198.51.100.5'
+    );
+  });
+
+  test('returns null when no forwarding header is present', () => {
+    expect(clientIpFromHeaders(new Headers())).toBeNull();
+  });
+
+  test('returns null for an empty x-forwarded-for header', () => {
+    expect(clientIpFromHeaders(new Headers({ 'x-forwarded-for': '' }))).toBeNull();
+  });
+});
+
+describe('authViaTokenFromHeaders', () => {
+  test('is true when an Authorization header is present', () => {
+    expect(authViaTokenFromHeaders(new Headers({ Authorization: 'Bearer abc' }))).toBe(true);
+  });
+
+  test('is false when no Authorization header is present', () => {
+    expect(authViaTokenFromHeaders(new Headers())).toBe(false);
+  });
+
+  test('is false for an empty Authorization header (matches the session auth branch)', () => {
+    // An empty header is non-null but falsy; getUserFromAuth treats it as the
+    // session path, so the discriminator must agree.
+    expect(authViaTokenFromHeaders(new Headers({ Authorization: '' }))).toBe(false);
+  });
+});

--- a/apps/web/src/lib/admin/admin-access-log.ts
+++ b/apps/web/src/lib/admin/admin-access-log.ts
@@ -1,0 +1,91 @@
+import 'server-only';
+import type { User } from '@kilocode/db/schema';
+import { logExceptInTest } from '@/lib/utils.server';
+
+/**
+ * Per-request, identity-attributed audit telemetry for Kilocode admin access.
+ *
+ * This is structured-log telemetry (shipped to the Axiom `vercel` dataset via
+ * stdout, same mechanism as `admin_login_succeeded`), NOT a database table. It
+ * closes the blind spot where a compromised admin API token could read data
+ * leaving only anonymous edge request logs.
+ *
+ * Two choke points emit the identical event schema so a single Axiom query can
+ * union both surfaces:
+ *   - `surface: "rest"`  — emitted in `getUserFromAuth` for `/admin/api/*`.
+ *   - `surface: "trpc"`  — emitted in the `adminProcedure` middleware.
+ *
+ * Security: never include the token itself, the Authorization header, cookies,
+ * or any secret in this event.
+ */
+
+export type AdminAccessSurface = 'rest' | 'trpc';
+
+export type AdminAccessEvent = {
+  event: 'admin_access';
+  surface: AdminAccessSurface;
+  kiloUserId: string;
+  email: string;
+  adminTier: 'super_admin' | 'platform_admin';
+  /**
+   * `"token"` when the request authenticated via an API bearer token (any
+   * `Authorization` header), else `"session"` (web-console cookie). This is the
+   * compromise discriminator; `tokenSource` below adds finer granularity.
+   */
+  authVia: 'token' | 'session';
+  /** Set only for tokens that carry a source (e.g. `cloud-agent`); else null. */
+  tokenSource: string | null;
+  route: string | null;
+  method: string | null;
+  ip: string | null;
+};
+
+export type AdminAccessSink = (event: AdminAccessEvent) => void;
+
+const defaultSink: AdminAccessSink = event => logExceptInTest(JSON.stringify(event));
+
+let currentSink: AdminAccessSink = defaultSink;
+
+/**
+ * Test-only seam. `logExceptInTest` is a no-op in automated tests, so a test
+ * cannot observe the default sink. Override it to capture emitted events, and
+ * pass `null` to restore the production sink.
+ */
+export function setAdminAccessSinkForTest(sink: AdminAccessSink | null): void {
+  currentSink = sink ?? defaultSink;
+}
+
+/**
+ * Build and emit an `admin_access` event. Called from both admin choke points.
+ */
+export function emitAdminAccessEvent(params: {
+  surface: AdminAccessSurface;
+  user: Pick<User, 'id' | 'google_user_email' | 'is_super_admin'>;
+  authViaToken: boolean;
+  tokenSource: string | null;
+  route: string | null;
+  method: string | null;
+  ip: string | null;
+}): void {
+  currentSink({
+    event: 'admin_access',
+    surface: params.surface,
+    kiloUserId: params.user.id,
+    email: params.user.google_user_email,
+    adminTier: params.user.is_super_admin ? 'super_admin' : 'platform_admin',
+    authVia: params.authViaToken ? 'token' : 'session',
+    tokenSource: params.tokenSource,
+    route: params.route,
+    method: params.method,
+    ip: params.ip,
+  });
+}
+
+/**
+ * Extract the client IP from request headers. Prefers `x-forwarded-for`, with
+ * `x-vercel-forwarded-for` as a fallback; returns the first hop or null.
+ */
+export function clientIpFromHeaders(headersList: Headers): string | null {
+  const forwarded = headersList.get('x-forwarded-for') ?? headersList.get('x-vercel-forwarded-for');
+  return forwarded?.split(',')[0]?.trim() || null;
+}

--- a/apps/web/src/lib/admin/admin-access-log.ts
+++ b/apps/web/src/lib/admin/admin-access-log.ts
@@ -1,5 +1,6 @@
 import 'server-only';
 import type { User } from '@kilocode/db/schema';
+import { captureException } from '@sentry/nextjs';
 import { logExceptInTest } from '@/lib/utils.server';
 
 /**
@@ -35,6 +36,12 @@ export type AdminAccessEvent = {
   authVia: 'token' | 'session';
   /** Set only for tokens that carry a source (e.g. `cloud-agent`); else null. */
   tokenSource: string | null;
+  /**
+   * Best-effort route identifier. For tRPC this is the exact procedure path;
+   * for REST it is the concrete pathname (`x-pathname`) when available, falling
+   * back to Vercel's matched route pattern (`x-matched-path`), which may be
+   * templated (e.g. `/admin/api/users/[id]/...`).
+   */
   route: string | null;
   method: string | null;
   ip: string | null;
@@ -67,18 +74,34 @@ export function emitAdminAccessEvent(params: {
   method: string | null;
   ip: string | null;
 }): void {
-  currentSink({
-    event: 'admin_access',
-    surface: params.surface,
-    kiloUserId: params.user.id,
-    email: params.user.google_user_email,
-    adminTier: params.user.is_super_admin ? 'super_admin' : 'platform_admin',
-    authVia: params.authViaToken ? 'token' : 'session',
-    tokenSource: params.tokenSource,
-    route: params.route,
-    method: params.method,
-    ip: params.ip,
-  });
+  // Audit logging is a side effect that must never deny a legitimate admin
+  // action: swallow (and report) any sink failure rather than propagate it.
+  try {
+    currentSink({
+      event: 'admin_access',
+      surface: params.surface,
+      kiloUserId: params.user.id,
+      email: params.user.google_user_email,
+      adminTier: params.user.is_super_admin ? 'super_admin' : 'platform_admin',
+      authVia: params.authViaToken ? 'token' : 'session',
+      tokenSource: params.tokenSource,
+      route: params.route,
+      method: params.method,
+      ip: params.ip,
+    });
+  } catch (error) {
+    captureException(error, { tags: { operation: 'admin_access_log' } });
+  }
+}
+
+/**
+ * Whether a request authenticated via an API bearer token. Mirrors the exact
+ * branch condition in `getUserFromAuth` (truthiness of the `Authorization`
+ * header), so the emitted `authVia` label can never diverge from the auth path
+ * that was actually taken. This is the compromise discriminator.
+ */
+export function authViaTokenFromHeaders(headersList: Headers): boolean {
+  return Boolean(headersList.get('Authorization'));
 }
 
 /**

--- a/apps/web/src/lib/trpc/init.test.ts
+++ b/apps/web/src/lib/trpc/init.test.ts
@@ -1,0 +1,74 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import { adminProcedure, createCallerFactory, createTRPCRouter, type TRPCContext } from './init';
+import { setAdminAccessSinkForTest, type AdminAccessEvent } from '@/lib/admin/admin-access-log';
+import { defineTestUser } from '@/tests/helpers/user.helper';
+
+const testRouter = createTRPCRouter({
+  ping: adminProcedure.query(() => 'ok'),
+});
+const createCaller = createCallerFactory(testRouter);
+
+function ctxFor(overrides: Partial<TRPCContext> & Pick<TRPCContext, 'user'>): TRPCContext {
+  return { authViaToken: false, tokenSource: null, ip: null, ...overrides };
+}
+
+let events: AdminAccessEvent[];
+
+beforeEach(() => {
+  events = [];
+  setAdminAccessSinkForTest(event => events.push(event));
+});
+
+afterEach(() => {
+  setAdminAccessSinkForTest(null);
+});
+
+describe('adminProcedure admin_access telemetry', () => {
+  test('emits a trpc session event for a web-console admin', async () => {
+    const caller = createCaller(
+      ctxFor({ user: defineTestUser({ is_admin: true, is_super_admin: true }), ip: '9.9.9.9' })
+    );
+
+    await expect(caller.ping()).resolves.toBe('ok');
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: 'admin_access',
+      surface: 'trpc',
+      authVia: 'session',
+      adminTier: 'super_admin',
+      route: 'ping',
+      method: 'query',
+      ip: '9.9.9.9',
+      tokenSource: null,
+    });
+  });
+
+  test('emits authVia token when the caller authenticated via a bearer token', async () => {
+    const caller = createCaller(
+      ctxFor({
+        user: defineTestUser({ is_admin: true, is_super_admin: false }),
+        authViaToken: true,
+        tokenSource: 'cloud-agent',
+      })
+    );
+
+    await caller.ping();
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      surface: 'trpc',
+      authVia: 'token',
+      adminTier: 'platform_admin',
+      tokenSource: 'cloud-agent',
+    });
+  });
+
+  test('does not emit for a non-admin caller', async () => {
+    const caller = createCaller(ctxFor({ user: defineTestUser({ is_admin: false }) }));
+
+    await expect(caller.ping()).rejects.toThrow();
+
+    expect(events).toHaveLength(0);
+  });
+});

--- a/apps/web/src/lib/trpc/init.ts
+++ b/apps/web/src/lib/trpc/init.ts
@@ -3,7 +3,11 @@ import { headers } from 'next/headers';
 import { getUserFromAuth } from '@/lib/user/server';
 import { initTRPC, TRPCError } from '@trpc/server';
 import type { User } from '@kilocode/db/schema';
-import { clientIpFromHeaders, emitAdminAccessEvent } from '@/lib/admin/admin-access-log';
+import {
+  authViaTokenFromHeaders,
+  clientIpFromHeaders,
+  emitAdminAccessEvent,
+} from '@/lib/admin/admin-access-log';
 import { setTag, trpcMiddleware } from '@sentry/nextjs';
 import { userCanViewSessions, userIsSuperadmin } from '@/lib/admin/admin-permissions';
 import { userCanManageCredits } from '@/lib/admin/credit-management';
@@ -44,8 +48,7 @@ export const createTRPCContext = async (): Promise<TRPCContext> => {
   setTag('userId', user.id);
   return {
     user,
-    // The token path is selected iff an Authorization header is present.
-    authViaToken: headersList.get('Authorization') != null,
+    authViaToken: authViaTokenFromHeaders(headersList),
     tokenSource: tokenSource ?? null,
     ip: clientIpFromHeaders(headersList),
   };

--- a/apps/web/src/lib/trpc/init.ts
+++ b/apps/web/src/lib/trpc/init.ts
@@ -1,7 +1,9 @@
 import 'server-only';
+import { headers } from 'next/headers';
 import { getUserFromAuth } from '@/lib/user/server';
 import { initTRPC, TRPCError } from '@trpc/server';
 import type { User } from '@kilocode/db/schema';
+import { clientIpFromHeaders, emitAdminAccessEvent } from '@/lib/admin/admin-access-log';
 import { setTag, trpcMiddleware } from '@sentry/nextjs';
 import { userCanViewSessions, userIsSuperadmin } from '@/lib/admin/admin-permissions';
 import { userCanManageCredits } from '@/lib/admin/credit-management';
@@ -14,13 +16,21 @@ export { UpstreamApiError } from '@/lib/trpc/transport';
 // Define the context type
 export type TRPCContext = {
   user: User;
+  // Admin audit signals threaded from the auth layer so `adminProcedure` can
+  // emit IP-independent, identity-attributed access telemetry. Optional so the
+  // many existing `{ user }` context constructors (tests, scripts) keep working;
+  // production `createTRPCContext` always populates them.
+  authViaToken?: boolean;
+  tokenSource?: string | null;
+  ip?: string | null;
 };
 
 /**
  * @see: https://trpc.io/docs/server/context
  */
 export const createTRPCContext = async (): Promise<TRPCContext> => {
-  const { user } = await getUserFromAuth({ adminOnly: false });
+  const headersList = await headers();
+  const { user, tokenSource } = await getUserFromAuth({ adminOnly: false });
   if (!user) {
     throw new TRPCError({
       code: 'UNAUTHORIZED',
@@ -34,6 +44,10 @@ export const createTRPCContext = async (): Promise<TRPCContext> => {
   setTag('userId', user.id);
   return {
     user,
+    // The token path is selected iff an Authorization header is present.
+    authViaToken: headersList.get('Authorization') != null,
+    tokenSource: tokenSource ?? null,
+    ip: clientIpFromHeaders(headersList),
   };
 };
 
@@ -88,14 +102,26 @@ export const createTRPCRouter = t.router;
 export const createCallerFactory = t.createCallerFactory;
 export const baseProcedure = t.procedure.use(timingMiddleware).use(sentryMiddleware);
 
-// Admin-only procedure
-export const adminProcedure = baseProcedure.use(async ({ ctx, next }) => {
+// Admin-only procedure. creditManager/superadmin/sessionViewer chain on this,
+// so emitting here covers the whole admin.* tRPC surface with a single event.
+export const adminProcedure = baseProcedure.use(async ({ ctx, path, type, next }) => {
   if (!ctx.user.is_admin) {
     throw new TRPCError({
       code: 'FORBIDDEN',
       message: 'Admin access required',
     });
   }
+  // Emit before next() so the access attempt is recorded even if the handler
+  // (or a chained sub-check) later throws.
+  emitAdminAccessEvent({
+    surface: 'trpc',
+    user: ctx.user,
+    authViaToken: ctx.authViaToken ?? false,
+    tokenSource: ctx.tokenSource ?? null,
+    route: path,
+    method: type,
+    ip: ctx.ip ?? null,
+  });
   return next();
 });
 

--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -5,7 +5,7 @@ jest.mock('next/headers', () => ({
   cookies: jest.fn(),
 }));
 
-import { beforeAll, beforeEach, describe, test, expect } from '@jest/globals';
+import { afterEach, beforeAll, beforeEach, describe, test, expect } from '@jest/globals';
 import {
   isEmailBlacklistedByDomain,
   isBlockedTLD,
@@ -20,6 +20,7 @@ import {
   getUserFromAuth,
 } from './server';
 import { db } from '@/lib/drizzle';
+import { setAdminAccessSinkForTest, type AdminAccessEvent } from '@/lib/admin/admin-access-log';
 import { kilocode_users, organization_seats_purchases, organizations } from '@kilocode/db/schema';
 import type { Organization, User } from '@kilocode/db/schema';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
@@ -574,6 +575,82 @@ describe('getUserFromAuth', () => {
     const afterGrant = await getUserFromAuth({ adminOnly: true });
     expect(afterGrant.authFailedResponse).not.toBeNull();
     expect(afterGrant.user).toBeNull();
+  });
+});
+
+describe('getUserFromAuth admin_access telemetry (REST)', () => {
+  let events: AdminAccessEvent[];
+
+  beforeEach(() => {
+    events = [];
+    setAdminAccessSinkForTest(event => events.push(event));
+  });
+
+  afterEach(() => {
+    setAdminAccessSinkForTest(null);
+  });
+
+  test('emits one rest/token event for an authorized admin via API token', async () => {
+    const admin = await insertTestUser({
+      google_user_email: `rest-admin-${crypto.randomUUID()}@kilocode.ai`,
+      hosted_domain: 'kilocode.ai',
+      is_admin: true,
+      is_super_admin: true,
+      api_token_pepper: 'rest-admin-pepper',
+    });
+    const token = generateApiToken(admin);
+    mockHeaders.mockResolvedValue(
+      new Headers({
+        Authorization: `Bearer ${token}`,
+        'x-pathname': '/admin/api/safety-identifiers',
+        'x-forwarded-for': '203.0.113.7, 10.0.0.1',
+      })
+    );
+
+    const result = await getUserFromAuth({ adminOnly: true });
+
+    expect(result.user?.id).toBe(admin.id);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: 'admin_access',
+      surface: 'rest',
+      authVia: 'token',
+      adminTier: 'super_admin',
+      kiloUserId: admin.id,
+      email: admin.google_user_email,
+      route: '/admin/api/safety-identifiers',
+      method: null,
+      ip: '203.0.113.7',
+      tokenSource: null,
+    });
+  });
+
+  test('does not emit when a non-admin token hits an admin-only check', async () => {
+    const nonAdmin = await insertTestUser({
+      is_admin: false,
+      api_token_pepper: 'rest-nonadmin-pepper',
+    });
+    const token = generateApiToken(nonAdmin);
+    mockHeaders.mockResolvedValue(new Headers({ Authorization: `Bearer ${token}` }));
+
+    const result = await getUserFromAuth({ adminOnly: true });
+
+    expect(result.authFailedResponse).not.toBeNull();
+    expect(events).toHaveLength(0);
+  });
+
+  test('does not emit for adminOnly:false calls even for an admin', async () => {
+    const admin = await insertTestUser({
+      is_admin: true,
+      api_token_pepper: 'rest-admin-noemit-pepper',
+    });
+    const token = generateApiToken(admin);
+    mockHeaders.mockResolvedValue(new Headers({ Authorization: `Bearer ${token}` }));
+
+    const result = await getUserFromAuth({ adminOnly: false });
+
+    expect(result.user?.id).toBe(admin.id);
+    expect(events).toHaveLength(0);
   });
 });
 

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -86,6 +86,7 @@ import {
 import jwt from 'jsonwebtoken';
 import type { UUID } from 'node:crypto';
 import { logExceptInTest, sentryLogger } from '@/lib/utils.server';
+import { clientIpFromHeaders, emitAdminAccessEvent } from '@/lib/admin/admin-access-log';
 import { processSSOUserLogin } from '@/lib/user/sso';
 import { getLowerDomainFromEmail } from '@/lib/utils';
 import { z } from 'zod';
@@ -1081,7 +1082,32 @@ type GetAuthResponse =
 
 export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAuthResponse> {
   const headersList = await headers();
+  const result = await resolveUserFromAuth(opts, headersList);
 
+  // Admin audit trail: emit exactly one identity-attributed event per authorized
+  // admin request. Guarded strictly on adminOnly so the millions of
+  // adminOnly:false calls never log.
+  if (opts.adminOnly === true && result.user) {
+    emitAdminAccessEvent({
+      surface: 'rest',
+      user: result.user,
+      // The token path is selected iff an Authorization header is present.
+      authViaToken: headersList.get('Authorization') != null,
+      tokenSource: result.tokenSource ?? null,
+      route: headersList.get('x-pathname') ?? headersList.get('x-matched-path') ?? null,
+      // No reliable HTTP method header is available here; do not fabricate one.
+      method: null,
+      ip: clientIpFromHeaders(headersList),
+    });
+  }
+
+  return result;
+}
+
+async function resolveUserFromAuth(
+  opts: RequiredPermissions,
+  headersList: Awaited<ReturnType<typeof headers>>
+): Promise<GetAuthResponse> {
   // This path is executed for non-next-auth requests
   // all calls from the extension including the openrouter proxy call use this auth method
   // also val.town and other blessed API users who are given their own custom JWTs use this path

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -86,7 +86,11 @@ import {
 import jwt from 'jsonwebtoken';
 import type { UUID } from 'node:crypto';
 import { logExceptInTest, sentryLogger } from '@/lib/utils.server';
-import { clientIpFromHeaders, emitAdminAccessEvent } from '@/lib/admin/admin-access-log';
+import {
+  authViaTokenFromHeaders,
+  clientIpFromHeaders,
+  emitAdminAccessEvent,
+} from '@/lib/admin/admin-access-log';
 import { processSSOUserLogin } from '@/lib/user/sso';
 import { getLowerDomainFromEmail } from '@/lib/utils';
 import { z } from 'zod';
@@ -1091,8 +1095,7 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
     emitAdminAccessEvent({
       surface: 'rest',
       user: result.user,
-      // The token path is selected iff an Authorization header is present.
-      authViaToken: headersList.get('Authorization') != null,
+      authViaToken: authViaTokenFromHeaders(headersList),
       tokenSource: result.tokenSource ?? null,
       route: headersList.get('x-pathname') ?? headersList.get('x-matched-path') ?? null,
       // No reliable HTTP method header is available here; do not fabricate one.


### PR DESCRIPTION
## Goal

Per-request, identity-attributed audit logging for **all** Kilocode admin access, independent of source IP, with **API-token access flagged separately** from normal web-console sessions.

This closes a known blind spot: today a compromised admin API token that reads data leaves only anonymous edge request logs (IP/path/UA, no identity). Admin API-token success was not recorded anywhere at the application layer.

This is structured-log telemetry shipped to the Axiom `vercel` dataset (same mechanism as the existing `admin_login_succeeded` event). **No database table** is added; it complements the existing action-scoped audit tables.

## Two emit points (one shared schema)

`getUserFromAuth({ adminOnly: true })` guards the ~50 REST `/admin/api/*` handlers, but tRPC admin procedures build their context with `adminOnly: false` and enforce admin separately in `adminProcedure`. Covering the whole surface needs both:

- **Gate 1 — REST** (`/admin/api/*`): emitted in `getUserFromAuth` after admin authorization succeeds, guarded strictly on `opts.adminOnly === true`.
- **Gate 2 — tRPC** (`admin.*`): emitted in the `adminProcedure` middleware. Because `creditManagerProcedure`/`superadminProcedure`/`sessionViewerProcedure` chain on `adminProcedure`, a single emit covers all of them.

### Event schema (identical across surfaces)

```json
{
  "event": "admin_access",
  "surface": "rest" | "trpc",
  "kiloUserId": "...",
  "email": "...",
  "adminTier": "super_admin" | "platform_admin",
  "authVia": "token" | "session",
  "tokenSource": "..." | null,
  "route": "...",
  "method": "...",
  "ip": "..." | null
}
```

## Security

No tokens, cookies, `Authorization` headers, or secrets appear in any event (verified in code + tests). Follows the repo security baseline.

## Local evidence

Live tRPC admin traffic against a local admin session, showing one `admin_access` event per admin procedure (including the chained `organizations.admin.*` variants):

```
GET /admin/organizations 200 in 103ms (next.js: 70ms, proxy.ts: 3ms, application-code: 30ms)
{"event":"admin_access","surface":"trpc","kiloUserId":"3471dd68-e5d0-4afc-9248-5e0944d391b5","email":"test@admin.example.com","adminTier":"platform_admin","authVia":"session","tokenSource":null,"route":"admin.getPermissions","method":"query","ip":"127.0.0.1"}
{"event":"admin_access","surface":"trpc","kiloUserId":"3471dd68-e5d0-4afc-9248-5e0944d391b5","email":"test@admin.example.com","adminTier":"platform_admin","authVia":"session","tokenSource":null,"route":"admin.disputes.summary","method":"query","ip":"127.0.0.1"}
 GET /api/trpc/admin.getPermissions,admin.disputes.summary?batch=1&input=%7B%7D 200 in 29ms (next.js: 10ms, proxy.ts: 7ms, application-code: 12ms)
{"event":"admin_access","surface":"trpc","kiloUserId":"3471dd68-e5d0-4afc-9248-5e0944d391b5","email":"test@admin.example.com","adminTier":"platform_admin","authVia":"session","tokenSource":null,"route":"organizations.admin.getMetrics","method":"query","ip":"127.0.0.1"}
{"event":"admin_access","surface":"trpc","kiloUserId":"3471dd68-e5d0-4afc-9248-5e0944d391b5","email":"test@admin.example.com","adminTier":"platform_admin","authVia":"session","tokenSource":null,"route":"organizations.admin.list","method":"query","ip":"127.0.0.1"}
```

## Changes

- **New** `apps/web/src/lib/admin/admin-access-log.ts` — shared event type, `emitAdminAccessEvent(...)`, `clientIpFromHeaders(...)` (prefers `x-forwarded-for`, falls back to `x-vercel-forwarded-for`), and a test-only sink seam (`setAdminAccessSinkForTest`) so the emit is observable (the default `logExceptInTest` is silenced in tests).
- `apps/web/src/lib/user/server.ts` — split auth body into `resolveUserFromAuth`; `getUserFromAuth` emits once (`surface: "rest"`). `route` = `x-pathname` (fallback `x-matched-path`); `method: null` (no reliable header — not fabricated).
- `apps/web/src/lib/trpc/init.ts` — `TRPCContext` gains optional `authViaToken`/`tokenSource`/`ip` (optional to avoid churn in existing `{ user }` context constructors; production `createTRPCContext` always sets them); `adminProcedure` emits `surface: "trpc"` before `next()`.
- Basic tests in `init.test.ts` and `server.test.ts` (session-admin, token-admin, non-admin, `adminOnly:false`).
