### PR TITLE
feat(auth): audit-log the is_admin bypasses on non-admin procedures

### DIFF
--- a/apps/web/src/app/api/gastown/token/route.ts
+++ b/apps/web/src/app/api/gastown/token/route.ts
@@ -4,6 +4,7 @@ import { getUserFromAuth } from '@/lib/user/server';
 import { generateApiToken } from '@/lib/tokens';
 import { isGastownEnabled } from '@/lib/gastown/feature-flags';
 import { getUserOrgMemberships } from '@/lib/organizations/organizations';
+import { recordKiloAdminElevationForRequest, serviceTarget } from '@/lib/admin/admin-access-log';
 
 const ONE_HOUR_SECONDS = 60 * 60;
 
@@ -23,7 +24,7 @@ const ONE_HOUR_SECONDS = 60 * 60;
  * membership without DB round-trips.
  */
 export async function POST() {
-  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+  const { user, authFailedResponse, tokenSource } = await getUserFromAuth({ adminOnly: false });
   if (authFailedResponse) return authFailedResponse;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
@@ -31,6 +32,18 @@ export async function POST() {
 
   if (!hasAccess) {
     return NextResponse.json({ error: 'Gastown access denied' }, { status: 403 });
+  }
+
+  if (user.is_admin) {
+    // The minted token carries `isAdmin`, so the elevation is exercised inside
+    // the Gastown worker where this app emits nothing. Correlate on
+    // `kiloUserId` within the token's lifetime below.
+    await recordKiloAdminElevationForRequest({
+      user,
+      tokenSource,
+      reason: 'service_token_mint',
+      target: serviceTarget('gastown'),
+    });
   }
 
   const orgMemberships = await getUserOrgMemberships(user.id);

--- a/apps/web/src/app/api/wasteland/token/route.ts
+++ b/apps/web/src/app/api/wasteland/token/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user/server';
 import { generateApiToken } from '@/lib/tokens';
 import { getUserOrgMemberships } from '@/lib/organizations/organizations';
+import { recordKiloAdminElevationForRequest, serviceTarget } from '@/lib/admin/admin-access-log';
 
 const ONE_HOUR_SECONDS = 60 * 60;
 
@@ -20,9 +21,21 @@ const ONE_HOUR_SECONDS = 60 * 60;
  * worker can enforce access and check org membership without DB round-trips.
  */
 export async function POST() {
-  const { user, authFailedResponse } = await getUserFromAuth({ adminOnly: false });
+  const { user, authFailedResponse, tokenSource } = await getUserFromAuth({ adminOnly: false });
   if (authFailedResponse) return authFailedResponse;
   if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+
+  if (user.is_admin) {
+    // The minted token carries `isAdmin`, so the elevation is exercised inside
+    // the Wasteland worker where this app emits nothing. Correlate on
+    // `kiloUserId` within the token's lifetime below.
+    await recordKiloAdminElevationForRequest({
+      user,
+      tokenSource,
+      reason: 'service_token_mint',
+      target: serviceTarget('wasteland'),
+    });
+  }
 
   const orgMemberships = await getUserOrgMemberships(user.id);
 

--- a/apps/web/src/lib/admin/admin-access-log.test.ts
+++ b/apps/web/src/lib/admin/admin-access-log.test.ts
@@ -126,10 +126,10 @@ describe('kilo admin elevation telemetry', () => {
     };
   }
 
-  test('recordKiloAdminElevation attributes the event to the exact procedure', () => {
+  test('recordKiloAdminElevation attributes the event to the exact procedure', async () => {
     const ctx = ctxFor();
 
-    recordKiloAdminElevation(ctx, {
+    await recordKiloAdminElevation(ctx, {
       reason: 'organization_access',
       target: organizationTarget('org-1'),
     });
@@ -152,8 +152,8 @@ describe('kilo admin elevation telemetry', () => {
     });
   });
 
-  test('carries the token discriminator so a stolen admin token is separable', () => {
-    recordKiloAdminElevation(ctxFor({ authViaToken: true, tokenSource: 'cloud-agent' }), {
+  test('carries the token discriminator so a stolen admin token is separable', async () => {
+    await recordKiloAdminElevation(ctxFor({ authViaToken: true, tokenSource: 'cloud-agent' }), {
       reason: 'cli_session_cross_org_query',
       target: UNSCOPED_TARGET,
     });
@@ -161,19 +161,35 @@ describe('kilo admin elevation telemetry', () => {
     expect(events[0]).toMatchObject({ authVia: 'token', tokenSource: 'cloud-agent' });
   });
 
-  test('degrades to null route/method for contexts without the tRPC middleware', () => {
-    // Hand-rolled `{ user }` contexts (scripts, older tests) never see
-    // baseProcedure, so attribution falls back to identity alone.
-    recordKiloAdminElevation(
+  test('attributes a context without the tRPC middleware to the request surface', async () => {
+    // `ensureOrganizationAccess` and friends are shared with REST route handlers
+    // that hand-roll `{ user }`. Those elevations must not be labelled `trpc`,
+    // and must derive `authVia` from the request rather than assuming a session.
+    await recordKiloAdminElevation(
       { user: defineTestUser({ is_admin: true }) },
       { reason: 'organization_fetch', target: null }
     );
 
-    expect(events[0]).toMatchObject({ route: null, method: null, ip: null, target: null });
+    expect(events[0]).toMatchObject({
+      surface: 'rest',
+      route: null,
+      method: null,
+      ip: null,
+      target: null,
+    });
   });
 
-  test('elevateViaKiloAdmin returns the grant and emits exactly one event', () => {
-    const granted = elevateViaKiloAdmin(ctxFor(), {
+  test('a tokenSource on a non-tRPC context survives the REST fallback', async () => {
+    await recordKiloAdminElevation(
+      { user: defineTestUser({ is_admin: true }), tokenSource: 'cloud-agent' },
+      { reason: 'organization_access', target: organizationTarget('org-1') }
+    );
+
+    expect(events[0]).toMatchObject({ surface: 'rest', tokenSource: 'cloud-agent' });
+  });
+
+  test('elevateViaKiloAdmin returns the grant and emits exactly one event', async () => {
+    const granted = await elevateViaKiloAdmin(ctxFor(), {
       reason: 'organization_access',
       target: organizationTarget('org-1'),
       grant: 'owner',
@@ -187,18 +203,18 @@ describe('kilo admin elevation telemetry', () => {
     });
   });
 
-  test('a throwing sink never propagates into the admin action', () => {
+  test('a throwing sink never propagates into the admin action', async () => {
     setAdminAccessSinkForTest(() => {
       throw new Error('drain unavailable');
     });
 
-    expect(() =>
+    await expect(
       elevateViaKiloAdmin(ctxFor(), {
         reason: 'organization_access',
         target: organizationTarget('org-1'),
         grant: 'owner',
       })
-    ).not.toThrow();
+    ).resolves.toBe('owner');
   });
 
   test('recordKiloAdminElevationForRequest still emits when no header store exists', async () => {

--- a/apps/web/src/lib/admin/admin-access-log.test.ts
+++ b/apps/web/src/lib/admin/admin-access-log.test.ts
@@ -1,5 +1,21 @@
-import { describe, expect, test } from '@jest/globals';
-import { authViaTokenFromHeaders, clientIpFromHeaders } from './admin-access-log';
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import {
+  authViaTokenFromHeaders,
+  clientIpFromHeaders,
+  elevateViaKiloAdmin,
+  organizationTarget,
+  organizationsTarget,
+  recordKiloAdminElevation,
+  recordKiloAdminElevationForRequest,
+  routeFromHeaders,
+  serviceTarget,
+  setAdminAccessSinkForTest,
+  userTarget,
+  UNSCOPED_TARGET,
+  type AdminAccessEvent,
+  type AdminAuditContext,
+} from './admin-access-log';
+import { defineTestUser } from '@/tests/helpers/user.helper';
 
 describe('clientIpFromHeaders', () => {
   test('returns the first hop of x-forwarded-for', () => {
@@ -42,5 +58,168 @@ describe('authViaTokenFromHeaders', () => {
     // An empty header is non-null but falsy; getUserFromAuth treats it as the
     // session path, so the discriminator must agree.
     expect(authViaTokenFromHeaders(new Headers({ Authorization: '' }))).toBe(false);
+  });
+});
+
+describe('routeFromHeaders', () => {
+  test('prefers the concrete pathname set by proxy.ts', () => {
+    expect(
+      routeFromHeaders(
+        new Headers({ 'x-pathname': '/admin/api/users/abc', 'x-matched-path': '/admin/api/users' })
+      )
+    ).toBe('/admin/api/users/abc');
+  });
+
+  test('falls back to the matched route pattern', () => {
+    expect(routeFromHeaders(new Headers({ 'x-matched-path': '/admin/api/users/[id]' }))).toBe(
+      '/admin/api/users/[id]'
+    );
+  });
+
+  test('returns null when neither header is present', () => {
+    expect(routeFromHeaders(new Headers())).toBeNull();
+  });
+});
+
+describe('target builders', () => {
+  test('organizationTarget/userTarget/serviceTarget use a <type>:<id> reference', () => {
+    expect(organizationTarget('org-1')).toBe('organization:org-1');
+    expect(userTarget('user-1')).toBe('user:user-1');
+    expect(serviceTarget('wasteland')).toBe('service:wasteland');
+    expect(UNSCOPED_TARGET).toBe('*');
+  });
+
+  test('organizationsTarget names the org when the batch holds exactly one', () => {
+    expect(organizationsTarget(['org-1', 'org-1'])).toBe('organization:org-1');
+  });
+
+  test('organizationsTarget records the deduplicated breadth for larger batches', () => {
+    expect(organizationsTarget(['org-1', 'org-2', 'org-2'])).toBe('organizations:2');
+  });
+
+  test('organizationsTarget reports a zero-length batch rather than throwing', () => {
+    expect(organizationsTarget([])).toBe('organizations:0');
+  });
+});
+
+describe('kilo admin elevation telemetry', () => {
+  let events: AdminAccessEvent[];
+
+  beforeEach(() => {
+    events = [];
+    setAdminAccessSinkForTest(event => events.push(event));
+  });
+
+  afterEach(() => {
+    setAdminAccessSinkForTest(null);
+  });
+
+  function ctxFor(overrides: Partial<AdminAuditContext> = {}): AdminAuditContext {
+    return {
+      user: defineTestUser({ is_admin: true, is_super_admin: false }),
+      authViaToken: false,
+      tokenSource: null,
+      ip: '203.0.113.7',
+      trpcPath: 'organizations.getSettings',
+      trpcType: 'query',
+      ...overrides,
+    };
+  }
+
+  test('recordKiloAdminElevation attributes the event to the exact procedure', () => {
+    const ctx = ctxFor();
+
+    recordKiloAdminElevation(ctx, {
+      reason: 'organization_access',
+      target: organizationTarget('org-1'),
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      event: 'admin_access',
+      surface: 'trpc',
+      kind: 'kilo_admin_elevation',
+      kiloUserId: ctx.user.id,
+      email: ctx.user.google_user_email,
+      adminTier: 'platform_admin',
+      authVia: 'session',
+      tokenSource: null,
+      route: 'organizations.getSettings',
+      method: 'query',
+      ip: '203.0.113.7',
+      reason: 'organization_access',
+      target: 'organization:org-1',
+    });
+  });
+
+  test('carries the token discriminator so a stolen admin token is separable', () => {
+    recordKiloAdminElevation(ctxFor({ authViaToken: true, tokenSource: 'cloud-agent' }), {
+      reason: 'cli_session_cross_org_query',
+      target: UNSCOPED_TARGET,
+    });
+
+    expect(events[0]).toMatchObject({ authVia: 'token', tokenSource: 'cloud-agent' });
+  });
+
+  test('degrades to null route/method for contexts without the tRPC middleware', () => {
+    // Hand-rolled `{ user }` contexts (scripts, older tests) never see
+    // baseProcedure, so attribution falls back to identity alone.
+    recordKiloAdminElevation(
+      { user: defineTestUser({ is_admin: true }) },
+      { reason: 'organization_fetch', target: null }
+    );
+
+    expect(events[0]).toMatchObject({ route: null, method: null, ip: null, target: null });
+  });
+
+  test('elevateViaKiloAdmin returns the grant and emits exactly one event', () => {
+    const granted = elevateViaKiloAdmin(ctxFor(), {
+      reason: 'organization_access',
+      target: organizationTarget('org-1'),
+      grant: 'owner',
+    });
+
+    expect(granted).toBe('owner');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'kilo_admin_elevation',
+      reason: 'organization_access',
+    });
+  });
+
+  test('a throwing sink never propagates into the admin action', () => {
+    setAdminAccessSinkForTest(() => {
+      throw new Error('drain unavailable');
+    });
+
+    expect(() =>
+      elevateViaKiloAdmin(ctxFor(), {
+        reason: 'organization_access',
+        target: organizationTarget('org-1'),
+        grant: 'owner',
+      })
+    ).not.toThrow();
+  });
+
+  test('recordKiloAdminElevationForRequest still emits when no header store exists', async () => {
+    // `headers()` throws outside a request scope; the event must survive that.
+    await recordKiloAdminElevationForRequest({
+      user: defineTestUser({ is_admin: true, is_super_admin: true }),
+      reason: 'service_token_mint',
+      target: serviceTarget('wasteland'),
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      surface: 'rest',
+      kind: 'kilo_admin_elevation',
+      adminTier: 'super_admin',
+      authVia: 'session',
+      route: null,
+      method: null,
+      ip: null,
+      reason: 'service_token_mint',
+      target: 'service:wasteland',
+    });
   });
 });

--- a/apps/web/src/lib/admin/admin-access-log.ts
+++ b/apps/web/src/lib/admin/admin-access-log.ts
@@ -167,7 +167,8 @@ export function emitAdminAccessEvent(params: {
  * `trpcPath`/`trpcType` are populated for every `baseProcedure` descendant by a
  * middleware in `@/lib/trpc/init`; the remaining fields come from
  * `createTRPCContext`. All are optional because the many hand-rolled `{ user }`
- * contexts in tests and scripts do not set them.
+ * contexts in REST route handlers, tests, and scripts do not set them, which is
+ * also what {@link recordKiloAdminElevation} uses to pick its attribution source.
  */
 export type AdminAuditContext = {
   user: AdminAccessUser;
@@ -186,18 +187,43 @@ export type AdminAuditContext = {
  * Call this from inside the `is_admin` branch, before returning the elevated
  * result, so the access is recorded even if the caller later throws. Prefer
  * {@link elevateViaKiloAdmin} where the branch produces a value.
+ *
+ * Surface-agnostic on purpose. Several elevation sites live in helpers that are
+ * shared between tRPC procedures and REST route handlers — `ensureOrganizationAccess`
+ * is called both from `organizationMemberProcedure` and from route handlers such
+ * as `/api/cloud-agent/sessions/stream-ticket`, which hand-roll a `{ user }`
+ * context. A context carrying `trpcPath` is attributed from the context; anything
+ * else is attributed from the request headers, so a REST caller is not mislabeled
+ * as a tRPC session request. That distinction matters most for `authVia`: guessing
+ * `"session"` for a bearer-token request would silently break the compromise
+ * discriminator this whole event exists to provide.
  */
-export function recordKiloAdminElevation(
+export async function recordKiloAdminElevation(
   ctx: AdminAuditContext,
   params: { reason: KiloAdminElevationReason; target: string | null }
-): void {
+): Promise<void> {
+  if (ctx.trpcPath === undefined) {
+    // `tokenSource` can only be preserved when the caller put it on the context,
+    // and today's REST handlers pass a bare `{ user }`. That is a deliberate
+    // limit, not an oversight: `authVia` — the discriminator that separates a
+    // stolen bearer token from a web-console session — is derived from the
+    // headers below and is always correct. `tokenSource` only adds granularity
+    // *within* the token case, and null is already one of its documented values.
+    await recordKiloAdminElevationForRequest({
+      user: ctx.user,
+      tokenSource: ctx.tokenSource,
+      reason: params.reason,
+      target: params.target,
+    });
+    return;
+  }
   emitAdminAccessEvent({
     surface: 'trpc',
     kind: 'kilo_admin_elevation',
     user: ctx.user,
     authViaToken: ctx.authViaToken ?? false,
     tokenSource: ctx.tokenSource ?? null,
-    route: ctx.trpcPath ?? null,
+    route: ctx.trpcPath,
     method: ctx.trpcType ?? null,
     ip: ctx.ip ?? null,
     reason: params.reason,
@@ -211,28 +237,30 @@ export function recordKiloAdminElevation(
  * elevation and its audit record are a single expression.
  *
  *     if (ctx.user.is_admin) {
- *       return elevateViaKiloAdmin(ctx, {
+ *       return await elevateViaKiloAdmin(ctx, {
  *         reason: 'organization_access',
  *         target: organizationTarget(organizationId),
  *         grant: 'owner',
  *       });
  *     }
  */
-export function elevateViaKiloAdmin<const TGrant>(
+export async function elevateViaKiloAdmin<const TGrant>(
   ctx: AdminAuditContext,
   params: {
     reason: KiloAdminElevationReason;
     target: string | null;
     grant: TGrant;
   }
-): TGrant {
-  recordKiloAdminElevation(ctx, { reason: params.reason, target: params.target });
+): Promise<TGrant> {
+  await recordKiloAdminElevation(ctx, { reason: params.reason, target: params.target });
   return params.grant;
 }
 
 /**
  * {@link recordKiloAdminElevation} for route handlers and server components,
- * which have request headers instead of a tRPC context.
+ * which have request headers instead of a tRPC context. Call it directly from
+ * REST-only sites; `recordKiloAdminElevation` also delegates here for the
+ * transport-agnostic helpers that REST handlers share with tRPC procedures.
  *
  * Resolves the header store itself so callers cannot forget to. If the store is
  * unavailable — a unit test invoking the surrounding function directly, or a

--- a/apps/web/src/lib/admin/admin-access-log.ts
+++ b/apps/web/src/lib/admin/admin-access-log.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import type { User } from '@kilocode/db/schema';
 import { captureException } from '@sentry/nextjs';
+import { headers } from 'next/headers';
 import { logExceptInTest } from '@/lib/utils.server';
 
 /**
@@ -11,10 +12,29 @@ import { logExceptInTest } from '@/lib/utils.server';
  * closes the blind spot where a compromised admin API token could read data
  * leaving only anonymous edge request logs.
  *
- * Two choke points emit the identical event schema so a single Axiom query can
- * union both surfaces:
- *   - `surface: "rest"`  — emitted in `getUserFromAuth` for `/admin/api/*`.
- *   - `surface: "trpc"`  — emitted in the `adminProcedure` middleware.
+ * Every event carries two orthogonal, always-present dimensions so a single
+ * `event:"admin_access"` query returns the whole picture and can then be split:
+ *
+ * `surface` — how the request arrived:
+ *   - `"rest"` — a Next.js route handler (`/admin/api/*`, `/api/*`).
+ *   - `"trpc"` — a tRPC procedure.
+ *
+ * `kind` — what produced the event:
+ *   - `"admin_guard"` — an explicit admin gate was satisfied. Emitted at the two
+ *     choke points that protect the `/admin` console: `getUserFromAuth` with
+ *     `adminOnly: true`, and the `adminProcedure` middleware.
+ *   - `"kilo_admin_elevation"` — the `is_admin` escape hatch granted a Kilo
+ *     employee access to *customer* data on an otherwise non-admin code path
+ *     (e.g. reading any organization, querying sessions across all orgs). These
+ *     paths pass through neither admin gate, so they emit here instead. Carries
+ *     a `reason` and a `target`.
+ *
+ * Coverage note: `kind:"admin_guard"` alone covers only the `/admin` console
+ * surface. Kilo's highest-value admin capability — an employee reading an
+ * arbitrary customer organization's data — flows through `is_admin` checks on
+ * regular procedures and is covered by `kind:"kilo_admin_elevation"`. Any new
+ * `is_admin` bypass must funnel through {@link elevateViaKiloAdmin} or
+ * {@link recordKiloAdminElevation}, or it will be invisible to this audit trail.
  *
  * Security: never include the token itself, the Authorization header, cookies,
  * or any secret in this event.
@@ -22,9 +42,36 @@ import { logExceptInTest } from '@/lib/utils.server';
 
 export type AdminAccessSurface = 'rest' | 'trpc';
 
+export type AdminAccessKind = 'admin_guard' | 'kilo_admin_elevation';
+
+/**
+ * Why an `is_admin` elevation fired. A closed union so the values stay stable
+ * and queryable in Axiom, and so a typo cannot silently create a new bucket.
+ */
+export type KiloAdminElevationReason =
+  /** REST `getAuthorizedOrgContext` granted `owner` on an arbitrary org. */
+  | 'organization_access_rest'
+  /** tRPC `ensureOrganizationAccess` granted `owner` on an arbitrary org. */
+  | 'organization_access'
+  /** tRPC `getOrganizationsAccessRoles` granted `owner` on a batch of orgs. */
+  | 'organization_access_batch'
+  /** tRPC `ensureOrganizationAccessAndFetchOrg` returned an arbitrary org. */
+  | 'organization_fetch'
+  /** CLI session query ran with the org-membership filter removed entirely. */
+  | 'cli_session_cross_org_query'
+  /** Code-index read/write redirected to another org or user via `overrideUser`. */
+  | 'code_index_user_override'
+  /** MCP gateway org-manager check bypassed for a global admin. */
+  | 'mcp_gateway_organization_manage'
+  /** Security Agent audit report assembled with Kilo-admin visibility. */
+  | 'security_agent_audit_report'
+  /** A token carrying `isAdmin` was minted for a downstream service. */
+  | 'service_token_mint';
+
 export type AdminAccessEvent = {
   event: 'admin_access';
   surface: AdminAccessSurface;
+  kind: AdminAccessKind;
   kiloUserId: string;
   email: string;
   adminTier: 'super_admin' | 'platform_admin';
@@ -45,6 +92,14 @@ export type AdminAccessEvent = {
   route: string | null;
   method: string | null;
   ip: string | null;
+  /** Set for `kind:"kilo_admin_elevation"`; null for `kind:"admin_guard"`. */
+  reason: KiloAdminElevationReason | null;
+  /**
+   * What the elevation reached, as a `<type>:<id>` reference (see
+   * {@link organizationTarget} and friends). Null for `kind:"admin_guard"`,
+   * where `route` already identifies the resource.
+   */
+  target: string | null;
 };
 
 export type AdminAccessSink = (event: AdminAccessEvent) => void;
@@ -62,17 +117,24 @@ export function setAdminAccessSinkForTest(sink: AdminAccessSink | null): void {
   currentSink = sink ?? defaultSink;
 }
 
+type AdminAccessUser = Pick<User, 'id' | 'google_user_email' | 'is_super_admin'>;
+
 /**
- * Build and emit an `admin_access` event. Called from both admin choke points.
+ * Build and emit an `admin_access` event. Called from both admin guard choke
+ * points; elevation sites should use {@link elevateViaKiloAdmin} or
+ * {@link recordKiloAdminElevation} instead of calling this directly.
  */
 export function emitAdminAccessEvent(params: {
   surface: AdminAccessSurface;
-  user: Pick<User, 'id' | 'google_user_email' | 'is_super_admin'>;
+  kind: AdminAccessKind;
+  user: AdminAccessUser;
   authViaToken: boolean;
   tokenSource: string | null;
   route: string | null;
   method: string | null;
   ip: string | null;
+  reason?: KiloAdminElevationReason | null;
+  target?: string | null;
 }): void {
   // Audit logging is a side effect that must never deny a legitimate admin
   // action: swallow (and report) any sink failure rather than propagate it.
@@ -80,6 +142,7 @@ export function emitAdminAccessEvent(params: {
     currentSink({
       event: 'admin_access',
       surface: params.surface,
+      kind: params.kind,
       kiloUserId: params.user.id,
       email: params.user.google_user_email,
       adminTier: params.user.is_super_admin ? 'super_admin' : 'platform_admin',
@@ -88,11 +151,163 @@ export function emitAdminAccessEvent(params: {
       route: params.route,
       method: params.method,
       ip: params.ip,
+      reason: params.reason ?? null,
+      target: params.target ?? null,
     });
   } catch (error) {
     captureException(error, { tags: { operation: 'admin_access_log' } });
   }
 }
+
+/**
+ * The audit-relevant slice of a tRPC context. Declared structurally rather than
+ * importing `TRPCContext` so this module stays free of a dependency cycle with
+ * `@/lib/trpc/init` (which imports from here).
+ *
+ * `trpcPath`/`trpcType` are populated for every `baseProcedure` descendant by a
+ * middleware in `@/lib/trpc/init`; the remaining fields come from
+ * `createTRPCContext`. All are optional because the many hand-rolled `{ user }`
+ * contexts in tests and scripts do not set them.
+ */
+export type AdminAuditContext = {
+  user: AdminAccessUser;
+  authViaToken?: boolean;
+  tokenSource?: string | null;
+  ip?: string | null;
+  trpcPath?: string;
+  trpcType?: string;
+};
+
+/**
+ * Record that the `is_admin` escape hatch granted a Kilo employee access to
+ * data they have no membership-derived right to, on a code path that does not
+ * pass through `adminProcedure`.
+ *
+ * Call this from inside the `is_admin` branch, before returning the elevated
+ * result, so the access is recorded even if the caller later throws. Prefer
+ * {@link elevateViaKiloAdmin} where the branch produces a value.
+ */
+export function recordKiloAdminElevation(
+  ctx: AdminAuditContext,
+  params: { reason: KiloAdminElevationReason; target: string | null }
+): void {
+  emitAdminAccessEvent({
+    surface: 'trpc',
+    kind: 'kilo_admin_elevation',
+    user: ctx.user,
+    authViaToken: ctx.authViaToken ?? false,
+    tokenSource: ctx.tokenSource ?? null,
+    route: ctx.trpcPath ?? null,
+    method: ctx.trpcType ?? null,
+    ip: ctx.ip ?? null,
+    reason: params.reason,
+    target: params.target,
+  });
+}
+
+/**
+ * {@link recordKiloAdminElevation} for `is_admin` branches that return an
+ * elevated value: emits the audit event and hands back `grant`, so the
+ * elevation and its audit record are a single expression.
+ *
+ *     if (ctx.user.is_admin) {
+ *       return elevateViaKiloAdmin(ctx, {
+ *         reason: 'organization_access',
+ *         target: organizationTarget(organizationId),
+ *         grant: 'owner',
+ *       });
+ *     }
+ */
+export function elevateViaKiloAdmin<const TGrant>(
+  ctx: AdminAuditContext,
+  params: {
+    reason: KiloAdminElevationReason;
+    target: string | null;
+    grant: TGrant;
+  }
+): TGrant {
+  recordKiloAdminElevation(ctx, { reason: params.reason, target: params.target });
+  return params.grant;
+}
+
+/**
+ * {@link recordKiloAdminElevation} for route handlers and server components,
+ * which have request headers instead of a tRPC context.
+ *
+ * Resolves the header store itself so callers cannot forget to. If the store is
+ * unavailable — a unit test invoking the surrounding function directly, or a
+ * script outside any request — the event is still emitted with null request
+ * metadata rather than throwing into the caller's happy path, preserving the
+ * rule that audit logging never denies a legitimate admin action.
+ */
+export async function recordKiloAdminElevationForRequest(params: {
+  user: AdminAccessUser;
+  tokenSource?: string | null;
+  reason: KiloAdminElevationReason;
+  target: string | null;
+}): Promise<void> {
+  let headersList: Headers;
+  try {
+    headersList = await headers();
+  } catch {
+    headersList = new Headers();
+  }
+  recordKiloAdminElevationFromHeaders({ ...params, headersList });
+}
+
+function recordKiloAdminElevationFromHeaders(params: {
+  user: AdminAccessUser;
+  headersList: Headers;
+  tokenSource?: string | null;
+  reason: KiloAdminElevationReason;
+  target: string | null;
+}): void {
+  emitAdminAccessEvent({
+    surface: 'rest',
+    kind: 'kilo_admin_elevation',
+    user: params.user,
+    authViaToken: authViaTokenFromHeaders(params.headersList),
+    tokenSource: params.tokenSource ?? null,
+    route: routeFromHeaders(params.headersList),
+    // No reliable HTTP method header is available here; do not fabricate one.
+    method: null,
+    ip: clientIpFromHeaders(params.headersList),
+    reason: params.reason,
+    target: params.target,
+  });
+}
+
+/** `target` for a single organization. */
+export function organizationTarget(organizationId: string): string {
+  return `organization:${organizationId}`;
+}
+
+/**
+ * `target` for a batch of organizations. Names the org when there is exactly
+ * one, otherwise records the count — the audit-relevant fact for a bulk role
+ * resolution is the breadth, and inlining hundreds of UUIDs would bloat the log
+ * line past what the drain will keep.
+ */
+export function organizationsTarget(organizationIds: readonly string[]): string {
+  const unique = Array.from(new Set(organizationIds));
+  const [only] = unique;
+  return unique.length === 1 && only !== undefined
+    ? organizationTarget(only)
+    : `organizations:${unique.length}`;
+}
+
+/** `target` for a single Kilo user. */
+export function userTarget(userId: string): string {
+  return `user:${userId}`;
+}
+
+/** `target` for a downstream service that a minted token grants access to. */
+export function serviceTarget(service: string): string {
+  return `service:${service}`;
+}
+
+/** `target` for an elevation that is not scoped to any single resource. */
+export const UNSCOPED_TARGET = '*';
 
 /**
  * Whether a request authenticated via an API bearer token. Mirrors the exact
@@ -102,6 +317,14 @@ export function emitAdminAccessEvent(params: {
  */
 export function authViaTokenFromHeaders(headersList: Headers): boolean {
   return Boolean(headersList.get('Authorization'));
+}
+
+/**
+ * Best-effort route for a REST request: the concrete pathname set by
+ * `proxy.ts`, falling back to Vercel's (possibly templated) matched route.
+ */
+export function routeFromHeaders(headersList: Headers): string | null {
+  return headersList.get('x-pathname') ?? headersList.get('x-matched-path') ?? null;
 }
 
 /**

--- a/apps/web/src/lib/organizations/organization-auth.ts
+++ b/apps/web/src/lib/organizations/organization-auth.ts
@@ -3,6 +3,10 @@ import { getUserFromAuth } from '@/lib/user/server';
 import type { Organization, User } from '@kilocode/db/schema';
 import { organization_memberships, organizations } from '@kilocode/db/schema';
 import { NextResponse } from 'next/server';
+import {
+  organizationTarget,
+  recordKiloAdminElevationForRequest,
+} from '@/lib/admin/admin-access-log';
 import type { OrganizationRole } from '@/lib/organizations/organization-types';
 import { db } from '@/lib/drizzle';
 import { eq, inArray, and, isNull } from 'drizzle-orm';
@@ -56,7 +60,7 @@ export async function getAuthorizedOrgContext(
       ? getUserFromAuthOverride
       : getUserFromAuth;
 
-  const { authFailedResponse, user } = await getUserFromAuthFn({ adminOnly: false });
+  const { authFailedResponse, user, tokenSource } = await getUserFromAuthFn({ adminOnly: false });
   if (authFailedResponse) {
     return { success: false, nextResponse: authFailedResponse };
   }
@@ -71,6 +75,14 @@ export async function getAuthorizedOrgContext(
 
   // admin user allowed to edit everything
   if (user.is_admin) {
+    // Recorded before the lookup so an admin probing a non-existent organization
+    // is still attributed, rather than vanishing into the 404 below.
+    await recordKiloAdminElevationForRequest({
+      user,
+      tokenSource,
+      reason: 'organization_access_rest',
+      target: organizationTarget(organizationId),
+    });
     const organization = await getOrganizationById(organizationId);
     if (!organization) {
       const res = NextResponse.json({ error: 'Organization not found' }, { status: 404 });

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -1,4 +1,9 @@
 import type { TRPCContext } from '@/lib/trpc/init';
+import {
+  organizationTarget,
+  recordKiloAdminElevation,
+  userTarget,
+} from '@/lib/admin/admin-access-log';
 import { TRPCError } from '@trpc/server';
 import {
   type getIntegrationForOwner,
@@ -224,6 +229,17 @@ async function assembleAuditReportResponse<TExtra>(params: {
     params.ctx,
     params.deps.resolveOwner(params.ctx, params.input)
   );
+
+  if (params.ctx.user.is_admin) {
+    // `isRequestingUserKiloAdmin` below unmasks Kilo-admin and unattributed
+    // actors that a customer would see as "Kilo Admin"/"Masked user". Recorded
+    // before the query so an over-budget or failed report still attributes the
+    // attempt; the DB-backed security audit log is written on success only.
+    recordKiloAdminElevation(params.ctx, {
+      reason: 'security_agent_audit_report',
+      target: owner.type === 'organization' ? organizationTarget(owner.id) : userTarget(owner.id),
+    });
+  }
 
   try {
     const report = await getSecurityAgentAuditReport({

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -235,7 +235,7 @@ async function assembleAuditReportResponse<TExtra>(params: {
     // actors that a customer would see as "Kilo Admin"/"Masked user". Recorded
     // before the query so an over-budget or failed report still attributes the
     // attempt; the DB-backed security audit log is written on success only.
-    recordKiloAdminElevation(params.ctx, {
+    await recordKiloAdminElevation(params.ctx, {
       reason: 'security_agent_audit_report',
       target: owner.type === 'organization' ? organizationTarget(owner.id) : userTarget(owner.id),
     });

--- a/apps/web/src/lib/trpc/init.test.ts
+++ b/apps/web/src/lib/trpc/init.test.ts
@@ -1,10 +1,30 @@
 import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
-import { adminProcedure, createCallerFactory, createTRPCRouter, type TRPCContext } from './init';
-import { setAdminAccessSinkForTest, type AdminAccessEvent } from '@/lib/admin/admin-access-log';
+import {
+  adminProcedure,
+  baseProcedure,
+  createCallerFactory,
+  createTRPCRouter,
+  type TRPCContext,
+} from './init';
+import {
+  recordKiloAdminElevation,
+  setAdminAccessSinkForTest,
+  UNSCOPED_TARGET,
+  type AdminAccessEvent,
+} from '@/lib/admin/admin-access-log';
 import { defineTestUser } from '@/tests/helpers/user.helper';
 
 const testRouter = createTRPCRouter({
   ping: adminProcedure.query(() => 'ok'),
+  // Stands in for the `is_admin` bypasses on regular procedures, which can only
+  // name their procedure if `baseProcedure` publishes it onto the context.
+  bypass: baseProcedure.mutation(({ ctx }) => {
+    recordKiloAdminElevation(ctx, {
+      reason: 'cli_session_cross_org_query',
+      target: UNSCOPED_TARGET,
+    });
+    return 'ok';
+  }),
 });
 const createCaller = createCallerFactory(testRouter);
 
@@ -35,6 +55,7 @@ describe('adminProcedure admin_access telemetry', () => {
     expect(events[0]).toMatchObject({
       event: 'admin_access',
       surface: 'trpc',
+      kind: 'admin_guard',
       authVia: 'session',
       adminTier: 'super_admin',
       route: 'ping',
@@ -58,6 +79,7 @@ describe('adminProcedure admin_access telemetry', () => {
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({
       surface: 'trpc',
+      kind: 'admin_guard',
       authVia: 'token',
       adminTier: 'platform_admin',
       tokenSource: 'cloud-agent',
@@ -70,5 +92,26 @@ describe('adminProcedure admin_access telemetry', () => {
     await expect(caller.ping()).rejects.toThrow();
 
     expect(events).toHaveLength(0);
+  });
+});
+
+describe('baseProcedure audit context', () => {
+  test('publishes the procedure path and type so elevations inside a resolver are attributable', async () => {
+    const caller = createCaller(
+      ctxFor({ user: defineTestUser({ is_admin: true }), ip: '203.0.113.7' })
+    );
+
+    await expect(caller.bypass()).resolves.toBe('ok');
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      surface: 'trpc',
+      kind: 'kilo_admin_elevation',
+      route: 'bypass',
+      method: 'mutation',
+      ip: '203.0.113.7',
+      reason: 'cli_session_cross_org_query',
+      target: '*',
+    });
   });
 });

--- a/apps/web/src/lib/trpc/init.test.ts
+++ b/apps/web/src/lib/trpc/init.test.ts
@@ -18,8 +18,8 @@ const testRouter = createTRPCRouter({
   ping: adminProcedure.query(() => 'ok'),
   // Stands in for the `is_admin` bypasses on regular procedures, which can only
   // name their procedure if `baseProcedure` publishes it onto the context.
-  bypass: baseProcedure.mutation(({ ctx }) => {
-    recordKiloAdminElevation(ctx, {
+  bypass: baseProcedure.mutation(async ({ ctx }) => {
+    await recordKiloAdminElevation(ctx, {
       reason: 'cli_session_cross_org_query',
       target: UNSCOPED_TARGET,
     });

--- a/apps/web/src/lib/trpc/init.ts
+++ b/apps/web/src/lib/trpc/init.ts
@@ -27,6 +27,12 @@ export type TRPCContext = {
   authViaToken?: boolean;
   tokenSource?: string | null;
   ip?: string | null;
+  // Procedure path and type, injected into the context by `baseProcedure` so
+  // that `is_admin` elevation sites *inside* a resolver (which only receive
+  // `ctx`, not the middleware's `path`/`type`) can attribute their audit event
+  // to the exact procedure. Optional for the same reason as the fields above.
+  trpcPath?: string;
+  trpcType?: string;
 };
 
 /**
@@ -100,10 +106,20 @@ const timingMiddleware = t.middleware(async ({ path, type, ctx, next }) => {
   return result;
 });
 
+// Publishes the procedure path/type onto the context so audit emitters reachable
+// only from a resolver (see `recordKiloAdminElevation`) can name the procedure.
+// `next({ ctx })` merges into the existing context, so nothing is dropped.
+const auditContextMiddleware = t.middleware(({ path, type, next }) =>
+  next({ ctx: { trpcPath: path, trpcType: type } })
+);
+
 // Base router and procedure helpers
 export const createTRPCRouter = t.router;
 export const createCallerFactory = t.createCallerFactory;
-export const baseProcedure = t.procedure.use(timingMiddleware).use(sentryMiddleware);
+export const baseProcedure = t.procedure
+  .use(timingMiddleware)
+  .use(sentryMiddleware)
+  .use(auditContextMiddleware);
 
 // Admin-only procedure. creditManager/superadmin/sessionViewer chain on this,
 // so emitting here covers the whole admin.* tRPC surface with a single event.
@@ -118,6 +134,7 @@ export const adminProcedure = baseProcedure.use(async ({ ctx, path, type, next }
   // (or a chained sub-check) later throws.
   emitAdminAccessEvent({
     surface: 'trpc',
+    kind: 'admin_guard',
     user: ctx.user,
     authViaToken: ctx.authViaToken ?? false,
     tokenSource: ctx.tokenSource ?? null,

--- a/apps/web/src/lib/user/server.test.ts
+++ b/apps/web/src/lib/user/server.test.ts
@@ -614,6 +614,7 @@ describe('getUserFromAuth admin_access telemetry (REST)', () => {
     expect(events[0]).toMatchObject({
       event: 'admin_access',
       surface: 'rest',
+      kind: 'admin_guard',
       authVia: 'token',
       adminTier: 'super_admin',
       kiloUserId: admin.id,

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -90,6 +90,7 @@ import {
   authViaTokenFromHeaders,
   clientIpFromHeaders,
   emitAdminAccessEvent,
+  routeFromHeaders,
 } from '@/lib/admin/admin-access-log';
 import { processSSOUserLogin } from '@/lib/user/sso';
 import { getLowerDomainFromEmail } from '@/lib/utils';
@@ -1094,10 +1095,11 @@ export async function getUserFromAuth(opts: RequiredPermissions): Promise<GetAut
   if (opts.adminOnly === true && result.user) {
     emitAdminAccessEvent({
       surface: 'rest',
+      kind: 'admin_guard',
       user: result.user,
       authViaToken: authViaTokenFromHeaders(headersList),
       tokenSource: result.tokenSource ?? null,
-      route: headersList.get('x-pathname') ?? headersList.get('x-matched-path') ?? null,
+      route: routeFromHeaders(headersList),
       // No reliable HTTP method header is available here; do not fabricate one.
       method: null,
       ip: clientIpFromHeaders(headersList),

--- a/apps/web/src/lib/wasteland/server-resolve.ts
+++ b/apps/web/src/lib/wasteland/server-resolve.ts
@@ -5,6 +5,7 @@ import type { WrappedWastelandRouter } from '@/lib/wasteland/types/router';
 import { WASTELAND_URL } from '@/lib/constants';
 import { generateApiToken } from '@/lib/tokens';
 import { getUserOrgMemberships } from '@/lib/organizations/organizations';
+import { recordKiloAdminElevationForRequest, serviceTarget } from '@/lib/admin/admin-access-log';
 import { parseDolthubUpstream } from '@/lib/wasteland/upstream';
 
 /**
@@ -27,6 +28,15 @@ export async function resolveWastelandUpstreamForUser(
   if (!WASTELAND_URL) return null;
 
   try {
+    if (user.is_admin) {
+      // Same elevation as POST /api/wasteland/token: the minted token carries
+      // `isAdmin` into the worker, which emits nothing back here.
+      await recordKiloAdminElevationForRequest({
+        user,
+        reason: 'service_token_mint',
+        target: serviceTarget('wasteland'),
+      });
+    }
     const orgMemberships = await getUserOrgMemberships(user.id);
     const token = generateApiToken(
       user,

--- a/apps/web/src/routers/cli-sessions-v2-router.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.ts
@@ -42,6 +42,7 @@ import { baseGetSessionNextOutputSchema } from './cloud-agent-next-schemas';
 import { KNOWN_PLATFORMS } from '@kilocode/app-shared/platforms';
 import { verifyWebhookTriggerAccess } from '@/lib/webhook-trigger-ownership';
 import { ensureOrganizationAccess } from '@/routers/organizations/utils';
+import { recordKiloAdminElevation, UNSCOPED_TARGET } from '@/lib/admin/admin-access-log';
 import {
   fetchPullRequestForBranch,
   fetchPullRequestReviewDecision,
@@ -454,7 +455,15 @@ async function addOrganizationCondition(
   organizationId: string | null | undefined
 ): Promise<void> {
   if (organizationId === undefined) {
-    if (!ctx.user.is_admin) {
+    if (ctx.user.is_admin) {
+      // No membership predicate is added at all, so the query spans every
+      // organization's sessions. This is the broadest read in the file and it
+      // never touches `adminProcedure`, so it must be recorded here.
+      recordKiloAdminElevation(ctx, {
+        reason: 'cli_session_cross_org_query',
+        target: UNSCOPED_TARGET,
+      });
+    } else {
       whereConditions.push(sql`(
         ${cli_sessions_v2.organization_id} IS NULL
         OR EXISTS (

--- a/apps/web/src/routers/cli-sessions-v2-router.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.ts
@@ -459,7 +459,7 @@ async function addOrganizationCondition(
       // No membership predicate is added at all, so the query spans every
       // organization's sessions. This is the broadest read in the file and it
       // never touches `adminProcedure`, so it must be recorded here.
-      recordKiloAdminElevation(ctx, {
+      await recordKiloAdminElevation(ctx, {
         reason: 'cli_session_cross_org_query',
         target: UNSCOPED_TARGET,
       });

--- a/apps/web/src/routers/code-indexing/code-indexing-router.ts
+++ b/apps/web/src/routers/code-indexing/code-indexing-router.ts
@@ -8,6 +8,7 @@ import {
   ensureOrganizationAccessAndFetchOrg,
   organizationMemberProcedure,
 } from '@/routers/organizations/utils';
+import { elevateViaKiloAdmin, organizationTarget, userTarget } from '@/lib/admin/admin-access-log';
 import { sentryLogger } from '@/lib/utils.server';
 import { codeIndexingAdminRouter } from './code-indexing-admin-router';
 import { getOrganizationById } from '@/lib/organizations/organizations';
@@ -159,7 +160,11 @@ async function resolveOrganizationIdWithOverride(
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (uuidRegex.test(input.overrideUser)) {
       // It's an organization ID
-      return input.overrideUser;
+      return elevateViaKiloAdmin(ctx, {
+        reason: 'code_index_user_override',
+        target: organizationTarget(input.overrideUser),
+        grant: input.overrideUser,
+      });
     } else {
       // It's an email - look up the user
       const user = await findUserByEmail(input.overrideUser);
@@ -170,7 +175,11 @@ async function resolveOrganizationIdWithOverride(
         });
       }
       // Format the user ID using getUserUUID
-      return getUserUUID(user);
+      return elevateViaKiloAdmin(ctx, {
+        reason: 'code_index_user_override',
+        target: userTarget(user.id),
+        grant: getUserUUID(user),
+      });
     }
   }
 

--- a/apps/web/src/routers/code-indexing/code-indexing-router.ts
+++ b/apps/web/src/routers/code-indexing/code-indexing-router.ts
@@ -160,7 +160,7 @@ async function resolveOrganizationIdWithOverride(
     const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
     if (uuidRegex.test(input.overrideUser)) {
       // It's an organization ID
-      return elevateViaKiloAdmin(ctx, {
+      return await elevateViaKiloAdmin(ctx, {
         reason: 'code_index_user_override',
         target: organizationTarget(input.overrideUser),
         grant: input.overrideUser,
@@ -175,7 +175,7 @@ async function resolveOrganizationIdWithOverride(
         });
       }
       // Format the user ID using getUserUUID
-      return elevateViaKiloAdmin(ctx, {
+      return await elevateViaKiloAdmin(ctx, {
         reason: 'code_index_user_override',
         target: userTarget(user.id),
         grant: getUserUUID(user),

--- a/apps/web/src/routers/mcp-gateway-router.ts
+++ b/apps/web/src/routers/mcp-gateway-router.ts
@@ -17,7 +17,8 @@ import {
   GatewayError,
   parseStaticHeaders,
 } from '@kilocode/mcp-gateway';
-import { adminProcedure, baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
+import { adminProcedure, baseProcedure, createTRPCRouter, type TRPCContext } from '@/lib/trpc/init';
+import { organizationTarget, recordKiloAdminElevation } from '@/lib/admin/admin-access-log';
 import { createGatewayServices } from '@/lib/mcp-gateway/services';
 import { db } from '@/lib/drizzle';
 import { createGatewayRepository } from '@/lib/mcp-gateway/repository';
@@ -116,14 +117,19 @@ async function withGatewayErrorMapping<T>(operation: () => Promise<T>): Promise<
   }
 }
 
-async function requireOrganizationManager(params: {
-  organizationId: string;
-  userId: string;
-  isGlobalAdmin: boolean;
-}) {
-  if (params.isGlobalAdmin) return;
+async function requireOrganizationManager(params: { organizationId: string; ctx: TRPCContext }) {
+  if (params.ctx.user.is_admin) {
+    // The owner-membership check below is skipped entirely, so a Kilo admin can
+    // manage any customer organization's gateway connections (including their
+    // static headers and provider credentials) from a `baseProcedure`.
+    recordKiloAdminElevation(params.ctx, {
+      reason: 'mcp_gateway_organization_manage',
+      target: organizationTarget(params.organizationId),
+    });
+    return;
+  }
   const repository = createGatewayRepository(db);
-  const membership = await repository.findMembership(params.userId, params.organizationId);
+  const membership = await repository.findMembership(params.ctx.user.id, params.organizationId);
   if (!membership || membership.role !== 'owner') {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'Organization owner access required' });
   }
@@ -360,8 +366,7 @@ async function getConfigDetail(params: {
 async function resolveScopedConfig(params: {
   configId: string;
   organizationId?: string;
-  userId: string;
-  isGlobalAdmin: boolean;
+  ctx: TRPCContext;
 }) {
   const repository = createGatewayRepository(db);
   const resolved = await repository.findDashboardRouteByConfigId(params.configId);
@@ -370,11 +375,14 @@ async function resolveScopedConfig(params: {
     ? resolved.config.owner_scope === GatewayOwnerScope.Organization &&
       resolved.config.owner_id === params.organizationId
     : resolved.config.owner_scope === GatewayOwnerScope.Personal &&
-      resolved.config.owner_id === params.userId;
+      resolved.config.owner_id === params.ctx.user.id;
   if (!belongsToScope) {
     throw new TRPCError({ code: 'NOT_FOUND', message: 'Connection not found' });
   }
-  if (!params.organizationId && !params.isGlobalAdmin) {
+  // Deliberately not an admin elevation: the personal branch above already
+  // requires `owner_id === ctx.user.id`, so `is_admin` only gates a staff-only
+  // feature on the caller's *own* config — no customer data is reached.
+  if (!params.organizationId && !params.ctx.user.is_admin) {
     throw new TRPCError({ code: 'FORBIDDEN', message: 'Admin access required' });
   }
   return resolved;
@@ -383,15 +391,13 @@ async function resolveScopedConfig(params: {
 async function requireManagedConfig(params: {
   configId: string;
   organizationId?: string;
-  userId: string;
-  isGlobalAdmin: boolean;
+  ctx: TRPCContext;
 }) {
   const resolved = await resolveScopedConfig(params);
   if (params.organizationId) {
     await requireOrganizationManager({
       organizationId: params.organizationId,
-      userId: params.userId,
-      isGlobalAdmin: params.isGlobalAdmin,
+      ctx: params.ctx,
     });
   }
   return resolved;
@@ -425,8 +431,7 @@ export const mcpGatewayRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       await requireOrganizationManager({
         organizationId: input.organizationId,
-        userId: ctx.user.id,
-        isGlobalAdmin: ctx.user.is_admin,
+        ctx,
       });
       return listConfigs({
         ownerScope: GatewayOwnerScope.Organization,
@@ -447,8 +452,7 @@ export const mcpGatewayRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       await requireOrganizationManager({
         organizationId: input.organizationId,
-        userId: ctx.user.id,
-        isGlobalAdmin: ctx.user.is_admin,
+        ctx,
       });
       return getConfigDetail({
         configId: input.configId,
@@ -509,8 +513,7 @@ export const mcpGatewayRouter = createTRPCRouter({
       withGatewayErrorMapping(async () => {
         await requireOrganizationManager({
           organizationId: input.organizationId,
-          userId: ctx.user.id,
-          isGlobalAdmin: ctx.user.is_admin,
+          ctx,
         });
         const services = createGatewayServices();
         const created = await services.configService.createOrganizationConfig({
@@ -538,8 +541,7 @@ export const mcpGatewayRouter = createTRPCRouter({
         const resolved = await resolveScopedConfig({
           configId: input.configId,
           organizationId: input.organizationId,
-          userId: ctx.user.id,
-          isGlobalAdmin: ctx.user.is_admin,
+          ctx,
         });
         const services = createGatewayServices();
         const route = services.routeService.parseResource(resolved.route.canonical_url);
@@ -560,8 +562,7 @@ export const mcpGatewayRouter = createTRPCRouter({
       await requireManagedConfig({
         configId: input.configId,
         organizationId: input.organizationId,
-        userId: ctx.user.id,
-        isGlobalAdmin: ctx.user.is_admin,
+        ctx,
       });
       const services = createGatewayServices();
       const route = await services.configService.rotateRoute({ configId: input.configId });
@@ -573,8 +574,7 @@ export const mcpGatewayRouter = createTRPCRouter({
       await requireManagedConfig({
         configId: input.configId,
         organizationId: input.organizationId,
-        userId: ctx.user.id,
-        isGlobalAdmin: ctx.user.is_admin,
+        ctx,
       });
       const services = createGatewayServices();
       const config = await services.configService.disableConfig(input.configId);
@@ -587,8 +587,7 @@ export const mcpGatewayRouter = createTRPCRouter({
       await requireManagedConfig({
         configId: input.configId,
         organizationId: input.organizationId,
-        userId: ctx.user.id,
-        isGlobalAdmin: ctx.user.is_admin,
+        ctx,
       });
       const services = createGatewayServices();
       const config = await services.configService.deleteConfig(input.configId);
@@ -603,8 +602,7 @@ export const mcpGatewayRouter = createTRPCRouter({
         const resolved = await requireManagedConfig({
           configId: input.configId,
           organizationId: input.organizationId,
-          userId: ctx.user.id,
-          isGlobalAdmin: ctx.user.is_admin,
+          ctx,
         });
         if (resolved.config.auth_mode !== GatewayAuthMode.StaticHeaders) {
           throw new TRPCError({
@@ -628,8 +626,7 @@ export const mcpGatewayRouter = createTRPCRouter({
         await requireManagedConfig({
           configId: input.configId,
           organizationId: input.organizationId,
-          userId: ctx.user.id,
-          isGlobalAdmin: ctx.user.is_admin,
+          ctx,
         });
         const services = createGatewayServices();
         const config = await services.configService.updateProviderScopes({
@@ -655,8 +652,7 @@ export const mcpGatewayRouter = createTRPCRouter({
         const resolved = await requireManagedConfig({
           configId: input.configId,
           organizationId: input.organizationId,
-          userId: ctx.user.id,
-          isGlobalAdmin: ctx.user.is_admin,
+          ctx,
         });
         if (resolved.config.auth_mode !== GatewayAuthMode.OAuthStatic) {
           throw new TRPCError({
@@ -680,8 +676,7 @@ export const mcpGatewayRouter = createTRPCRouter({
         await requireManagedConfig({
           configId: input.configId,
           organizationId: input.organizationId,
-          userId: ctx.user.id,
-          isGlobalAdmin: ctx.user.is_admin,
+          ctx,
         });
         const services = createGatewayServices();
         const assignment = await services.configService.assignUser({
@@ -701,8 +696,7 @@ export const mcpGatewayRouter = createTRPCRouter({
         await requireManagedConfig({
           configId: input.configId,
           organizationId: input.organizationId,
-          userId: ctx.user.id,
-          isGlobalAdmin: ctx.user.is_admin,
+          ctx,
         });
         const services = createGatewayServices();
         const assignment = await services.configService.revokeAssignment({

--- a/apps/web/src/routers/mcp-gateway-router.ts
+++ b/apps/web/src/routers/mcp-gateway-router.ts
@@ -122,7 +122,7 @@ async function requireOrganizationManager(params: { organizationId: string; ctx:
     // The owner-membership check below is skipped entirely, so a Kilo admin can
     // manage any customer organization's gateway connections (including their
     // static headers and provider credentials) from a `baseProcedure`.
-    recordKiloAdminElevation(params.ctx, {
+    await recordKiloAdminElevation(params.ctx, {
       reason: 'mcp_gateway_organization_manage',
       target: organizationTarget(params.organizationId),
     });

--- a/apps/web/src/routers/organizations/utils.test.ts
+++ b/apps/web/src/routers/organizations/utils.test.ts
@@ -4,10 +4,7 @@ import {
   ensureOrganizationAccessAndFetchOrg,
   getOrganizationsAccessRoles,
 } from './utils';
-import {
-  setAdminAccessSinkForTest,
-  type AdminAccessEvent,
-} from '@/lib/admin/admin-access-log';
+import { setAdminAccessSinkForTest, type AdminAccessEvent } from '@/lib/admin/admin-access-log';
 import type { TRPCContext } from '@/lib/trpc/init';
 import { db } from '@/lib/drizzle';
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -75,6 +72,28 @@ describe('organization access kilo_admin_elevation telemetry', () => {
     });
   });
 
+  test('ensureOrganizationAccess does not label a REST caller as a tRPC request', async () => {
+    // Route handlers such as `/api/cloud-agent/sessions/stream-ticket` and
+    // `/api/auto-routing/settings` call this helper with a hand-rolled
+    // `{ user }`. Labelling those `surface:"trpc"`/`authVia:"session"` would
+    // hide a token-authenticated admin read behind a web-console-looking event.
+    const admin = await insertTestUser({ is_admin: true });
+    const organization = await orgOwnedByAnotherUser();
+
+    await expect(ensureOrganizationAccess({ user: admin }, organization.id)).resolves.toBe('owner');
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      surface: 'rest',
+      kind: 'kilo_admin_elevation',
+      kiloUserId: admin.id,
+      route: null,
+      method: null,
+      reason: 'organization_access',
+      target: `organization:${organization.id}`,
+    });
+  });
+
   test('ensureOrganizationAccess stays silent for a member resolving their own org', async () => {
     const member = await insertTestUser({ is_admin: false });
     const organization = await createTestOrganization(
@@ -128,9 +147,9 @@ describe('organization access kilo_admin_elevation telemetry', () => {
     const admin = await insertTestUser({ is_admin: true });
     const missingId = crypto.randomUUID();
 
-    await expect(
-      ensureOrganizationAccessAndFetchOrg(ctxFor(admin), missingId)
-    ).rejects.toThrow(/Organization not found/);
+    await expect(ensureOrganizationAccessAndFetchOrg(ctxFor(admin), missingId)).rejects.toThrow(
+      /Organization not found/
+    );
 
     expect(events).toHaveLength(1);
     expect(events[0]).toMatchObject({

--- a/apps/web/src/routers/organizations/utils.test.ts
+++ b/apps/web/src/routers/organizations/utils.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, test } from '@jest/globals';
+import {
+  ensureOrganizationAccess,
+  ensureOrganizationAccessAndFetchOrg,
+  getOrganizationsAccessRoles,
+} from './utils';
+import {
+  setAdminAccessSinkForTest,
+  type AdminAccessEvent,
+} from '@/lib/admin/admin-access-log';
+import type { TRPCContext } from '@/lib/trpc/init';
+import { db } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
+import { organization_memberships, organizations, type User } from '@kilocode/db/schema';
+
+/**
+ * `is_admin` on these helpers is the escape hatch that lets a Kilo employee read
+ * any customer organization from a plain `baseProcedure`. It bypasses both
+ * `admin_access` guard choke points, so the audit trail depends entirely on the
+ * `kilo_admin_elevation` emit inside each branch.
+ */
+describe('organization access kilo_admin_elevation telemetry', () => {
+  let events: AdminAccessEvent[];
+
+  beforeEach(() => {
+    events = [];
+    setAdminAccessSinkForTest(event => events.push(event));
+  });
+
+  afterEach(async () => {
+    setAdminAccessSinkForTest(null);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organization_memberships);
+    // eslint-disable-next-line drizzle/enforce-delete-with-where
+    await db.delete(organizations);
+  });
+
+  function ctxFor(user: User): TRPCContext {
+    return {
+      user,
+      authViaToken: true,
+      tokenSource: 'cloud-agent',
+      ip: '203.0.113.7',
+      trpcPath: 'organizations.getSettings',
+      trpcType: 'query',
+    };
+  }
+
+  async function orgOwnedByAnotherUser() {
+    const owner = await insertTestUser({ is_admin: false });
+    return createTestOrganization(`elevation-test-${crypto.randomUUID()}`, owner.id, 0);
+  }
+
+  test('ensureOrganizationAccess records the org an admin reached without membership', async () => {
+    const admin = await insertTestUser({ is_admin: true, is_super_admin: true });
+    const organization = await orgOwnedByAnotherUser();
+
+    await expect(ensureOrganizationAccess(ctxFor(admin), organization.id)).resolves.toBe('owner');
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      event: 'admin_access',
+      surface: 'trpc',
+      kind: 'kilo_admin_elevation',
+      kiloUserId: admin.id,
+      adminTier: 'super_admin',
+      authVia: 'token',
+      tokenSource: 'cloud-agent',
+      route: 'organizations.getSettings',
+      method: 'query',
+      ip: '203.0.113.7',
+      reason: 'organization_access',
+      target: `organization:${organization.id}`,
+    });
+  });
+
+  test('ensureOrganizationAccess stays silent for a member resolving their own org', async () => {
+    const member = await insertTestUser({ is_admin: false });
+    const organization = await createTestOrganization(
+      `elevation-test-${crypto.randomUUID()}`,
+      member.id,
+      0
+    );
+
+    await expect(ensureOrganizationAccess(ctxFor(member), organization.id)).resolves.toBe('owner');
+
+    expect(events).toHaveLength(0);
+  });
+
+  test('getOrganizationsAccessRoles records one event carrying the batch breadth', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const first = await orgOwnedByAnotherUser();
+    const second = await orgOwnedByAnotherUser();
+
+    const roles = await getOrganizationsAccessRoles(ctxFor(admin), [
+      first.id,
+      second.id,
+      second.id,
+    ]);
+
+    expect(roles.get(first.id)).toBe('owner');
+    expect(roles.get(second.id)).toBe('owner');
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'kilo_admin_elevation',
+      reason: 'organization_access_batch',
+      target: 'organizations:2',
+    });
+  });
+
+  test('ensureOrganizationAccessAndFetchOrg records the org an admin fetched', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const organization = await orgOwnedByAnotherUser();
+
+    const fetched = await ensureOrganizationAccessAndFetchOrg(ctxFor(admin), organization.id);
+
+    expect(fetched.id).toBe(organization.id);
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      kind: 'kilo_admin_elevation',
+      reason: 'organization_fetch',
+      target: `organization:${organization.id}`,
+    });
+  });
+
+  test('ensureOrganizationAccessAndFetchOrg records an admin probing a missing org', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const missingId = crypto.randomUUID();
+
+    await expect(
+      ensureOrganizationAccessAndFetchOrg(ctxFor(admin), missingId)
+    ).rejects.toThrow(/Organization not found/);
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toMatchObject({
+      reason: 'organization_fetch',
+      target: `organization:${missingId}`,
+    });
+  });
+});

--- a/apps/web/src/routers/organizations/utils.ts
+++ b/apps/web/src/routers/organizations/utils.ts
@@ -9,6 +9,12 @@ import {
 } from '@kilocode/app-shared/organizations';
 import { baseProcedure } from '@/lib/trpc/init';
 import type { TRPCContext } from '@/lib/trpc/init';
+import {
+  elevateViaKiloAdmin,
+  organizationTarget,
+  organizationsTarget,
+  recordKiloAdminElevation,
+} from '@/lib/admin/admin-access-log';
 import { TRPCError } from '@trpc/server';
 import { and, eq, inArray } from 'drizzle-orm';
 import * as z from 'zod';
@@ -44,7 +50,11 @@ export async function ensureOrganizationAccess(
   roles?: OrganizationRole[]
 ): Promise<OrganizationRole> {
   if (ctx.user.is_admin) {
-    return 'owner';
+    return elevateViaKiloAdmin(ctx, {
+      reason: 'organization_access',
+      target: organizationTarget(organizationId),
+      grant: 'owner',
+    });
   }
   const directRows = await db
     .select({ role: organization_memberships.role })
@@ -105,7 +115,12 @@ export async function getOrganizationsAccessRoles(
     return result;
   }
   if (ctx.user.is_admin) {
-    for (const id of uniqueIds) result.set(id, 'owner');
+    const grant = elevateViaKiloAdmin(ctx, {
+      reason: 'organization_access_batch',
+      target: organizationsTarget(uniqueIds),
+      grant: 'owner',
+    });
+    for (const id of uniqueIds) result.set(id, grant);
     return result;
   }
 
@@ -179,6 +194,12 @@ export async function ensureOrganizationAccessAndFetchOrg(
   roles?: OrganizationRole[]
 ): Promise<Organization> {
   if (ctx.user.is_admin) {
+    // Recorded before the fetch so an admin probing a non-existent organization
+    // is still attributed, rather than vanishing into the NOT_FOUND below.
+    recordKiloAdminElevation(ctx, {
+      reason: 'organization_fetch',
+      target: organizationTarget(organizationId),
+    });
     const [org] = await db.select().from(organizations).where(eq(organizations.id, organizationId));
 
     if (!org) {

--- a/apps/web/src/routers/organizations/utils.ts
+++ b/apps/web/src/routers/organizations/utils.ts
@@ -50,7 +50,7 @@ export async function ensureOrganizationAccess(
   roles?: OrganizationRole[]
 ): Promise<OrganizationRole> {
   if (ctx.user.is_admin) {
-    return elevateViaKiloAdmin(ctx, {
+    return await elevateViaKiloAdmin(ctx, {
       reason: 'organization_access',
       target: organizationTarget(organizationId),
       grant: 'owner',
@@ -115,7 +115,7 @@ export async function getOrganizationsAccessRoles(
     return result;
   }
   if (ctx.user.is_admin) {
-    const grant = elevateViaKiloAdmin(ctx, {
+    const grant = await elevateViaKiloAdmin(ctx, {
       reason: 'organization_access_batch',
       target: organizationsTarget(uniqueIds),
       grant: 'owner',
@@ -196,7 +196,7 @@ export async function ensureOrganizationAccessAndFetchOrg(
   if (ctx.user.is_admin) {
     // Recorded before the fetch so an admin probing a non-existent organization
     // is still attributed, rather than vanishing into the NOT_FOUND below.
-    recordKiloAdminElevation(ctx, {
+    await recordKiloAdminElevation(ctx, {
       reason: 'organization_fetch',
       target: organizationTarget(organizationId),
     });


### PR DESCRIPTION
Follow-up to #5124.

## Why

#5124 gates `admin_access` on `adminOnly: true` and `adminProcedure`. That covers the `/admin` console, but Kilo's highest-value admin capability — an employee reading an arbitrary customer organization's data — flows through the `is_admin` escape hatch on regular, non-admin procedures. Those paths touch neither choke point, so they emitted nothing.

The risk isn't just the missing events, it's the false confidence: an Axiom detection built on `admin_access` would look complete while the most sensitive paths stayed invisible. This closes that.

## How

Every event now carries two orthogonal dimensions instead of one, so `event:"admin_access"` still returns the whole picture and can then be split:

- `surface` — `rest` | `trpc` (unchanged, the transport)
- `kind` — `admin_guard` (#5124's two choke points) | `kilo_admin_elevation` (this PR), with `reason` and `target`

Rather than sprinkling emit calls, the bypasses funnel through `elevateViaKiloAdmin` / `recordKiloAdminElevation`, so the choke-point property is structural instead of relying on everyone remembering to log. `elevateViaKiloAdmin` returns the elevated value, which makes the grant and its audit record a single expression. The `ensureOrganizationAccess` family was the natural starting point — it already centralises the org-access sites, and covers the 19 `baseProcedure` org procedures behind it.

`route`/`method` for emits *inside* a resolver come from a new `baseProcedure` middleware that publishes the procedure path onto the context; resolvers only receive `ctx`, not the middleware's `path`/`type`, so without this the events couldn't name the procedure they came from.

For the wasteland/gastown token routes the event is emitted at mint time, since the elevation is exercised in the worker where this app emits nothing at all.

Two emits are placed *before* their DB lookup so an admin probing a non-existent organization is still attributed, rather than vanishing into the 404.

#5124's properties are preserved: audit logging still never denies a legitimate admin action (all three entry points are non-throwing), identity remains the primary key with `ip` recorded but not depended on, and no token, header, cookie or secret is ever included.

## Notes for review

- **Duplicate events per request are expected and not deduped.** An admin-console call can emit an `admin_guard` from `adminProcedure` and a `kilo_admin_elevation` from `ensureOrganizationAccess`. Both are true; deduping would need per-request state.
- **`resolveScopedConfig`'s personal branch is deliberately *not* treated as an elevation.** It already requires `owner_id === ctx.user.id`, so `is_admin` only gates a staff-only feature on the caller's own config — no customer data is reached. Emitting there would add false positives to the elevation stream.
- **Batch org resolution records breadth, not IDs.** Inlining hundreds of UUIDs would bloat the log line past what the drain keeps.
- **Token-mint correlation is `kiloUserId` + timestamp within the token lifetime, not exact.** `generateApiToken` has no `jti`; adding one only pays off once the downstream workers log it, which is cross-repo.
- The mcp-gateway helpers now take `ctx` instead of `userId` + `isGlobalAdmin`. That's what makes the bypass auditable in one place, and it removes the `isGlobalAdmin: ctx.user.is_admin` repetition across 12 call sites that made an unaudited bypass easy to add.
- The docblock in `admin-access-log.ts` now states the coverage limit explicitly and names the funnel new bypasses must use, so the next reader isn't misled by the #5124 title.