### PR TITLE
fix(ai-gateway): stop redacting custom model errors

### DIFF
--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -971,6 +971,69 @@ describe('makeErrorReadable', () => {
       ).resolves.toBeUndefined();
     }
   });
+
+  it('does not redact errors for custom model provider', async () => {
+    const response = Response.json(
+      { error: { message: 'Custom endpoint failure details' } },
+      { status: 500 }
+    );
+
+    const result = await makeErrorReadable({
+      providerId: 'custom',
+      requestedModel: 'kilo-internal/custom-endpoint',
+      request,
+      response,
+      isUserByok: false,
+    });
+
+    expect(result).toBeUndefined();
+  });
+
+  it('redacts errors for experiment provider', async () => {
+    const response = Response.json(
+      { error: { message: 'Internal experiment failure' } },
+      { status: 500 }
+    );
+
+    const result = await makeErrorReadable({
+      providerId: 'experiment',
+      requestedModel: 'experiment/test-model',
+      request,
+      response,
+      isUserByok: false,
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.status).toBe(500);
+    await expect(result?.json()).resolves.toEqual({
+      error: 'The upstream provider was unable to process the request',
+      error_type: 'upstream_error',
+      message: 'The upstream provider was unable to process the request',
+    });
+  });
+
+  it('redacts errors for stealth models', async () => {
+    const response = Response.json(
+      { error: { message: 'Upstream vendor secret error' } },
+      { status: 502 }
+    );
+
+    const result = await makeErrorReadable({
+      providerId: 'openrouter',
+      requestedModel: 'stealth/claude-opus-4.7',
+      request,
+      response,
+      isUserByok: false,
+    });
+
+    expect(result).toBeDefined();
+    expect(result?.status).toBe(502);
+    await expect(result?.json()).resolves.toEqual({
+      error: 'The upstream provider was unable to process the request',
+      error_type: 'upstream_error',
+      message: 'The upstream provider was unable to process the request',
+    });
+  });
 });
 
 describe('extractHeaderAndLimitLength', () => {

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -5,6 +5,8 @@ import {
   isKiloExclusiveRateLimitedModel,
   kiloExclusiveModels,
   selectAutoFreeCandidate,
+  shouldRedactErrorResponse,
+  shouldRedactModelNameInMicrodollarUsage,
 } from './models';
 import { hasBestEffortGuessDataCollectionRequirement, isFreeModel } from './is-free-model';
 import { getInferenceProvider } from './providers/kilo-exclusive-model';
@@ -292,5 +294,47 @@ describe('hasBestEffortGuessDataCollectionRequirement', () => {
     expect(await hasBestEffortGuessDataCollectionRequirement('anthropic/claude-sonnet-4')).toBe(
       false
     );
+  });
+});
+
+describe('shouldRedactErrorResponse', () => {
+  test('does not redact errors for custom models', () => {
+    expect(shouldRedactErrorResponse('custom', 'kilo-internal/my-custom-model')).toBe(false);
+  });
+
+  test('redacts errors for experiment provider', () => {
+    expect(shouldRedactErrorResponse('experiment', 'some-experiment-model')).toBe(true);
+  });
+
+  test('redacts errors for stealth models regardless of provider', () => {
+    expect(shouldRedactErrorResponse('openrouter', claude_opus_4_7_stealth_model.public_id)).toBe(
+      true
+    );
+    expect(shouldRedactErrorResponse('martian', gpt_5_6_sol_stealth_model.public_id)).toBe(true);
+  });
+
+  test('does not redact errors for regular models and providers', () => {
+    expect(shouldRedactErrorResponse('openrouter', 'anthropic/claude-3.5-sonnet')).toBe(false);
+    expect(shouldRedactErrorResponse('vercel', 'openai/gpt-4o')).toBe(false);
+  });
+});
+
+describe('shouldRedactModelNameInMicrodollarUsage', () => {
+  test('redacts model name for custom provider', () => {
+    expect(shouldRedactModelNameInMicrodollarUsage('custom', 'kilo-internal/my-custom-model')).toBe(
+      true
+    );
+  });
+
+  test('redacts model name for experiment provider', () => {
+    expect(shouldRedactModelNameInMicrodollarUsage('experiment', 'some-experiment-model')).toBe(
+      true
+    );
+  });
+
+  test('redacts model name for stealth models', () => {
+    expect(
+      shouldRedactModelNameInMicrodollarUsage('openrouter', claude_opus_4_7_stealth_model.public_id)
+    ).toBe(true);
   });
 });

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -151,7 +151,7 @@ export function shouldRedactModelNameInMicrodollarUsage(
 }
 
 export function shouldRedactErrorResponse(provider: ProviderId, model: string): boolean {
-  return provider === 'custom' || provider === 'experiment' || isKiloStealthModel(model);
+  return provider === 'experiment' || isKiloStealthModel(model);
 }
 
 export function isDeadFreeModel(model: string): boolean {


### PR DESCRIPTION
Stops redacting upstream error responses for custom LLM models (`provider === 'custom'`), allowing raw provider error details through to clients while maintaining redaction for experiment and stealth models.