### PR TITLE
feat(ai-gateway): sanitize custom LLM JSON refs

### DIFF
--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
@@ -6,12 +6,15 @@ import { buildDirectProvider } from './build-direct-provider';
 
 type ChatCompletionRequest = Extract<GatewayRequest, { kind: 'chat_completions' }>;
 
-async function transformRequest(request: GatewayRequest, thought_signature_mapping?: string) {
+async function transformRequest(
+  request: GatewayRequest,
+  options: { sanitize_ref_fields?: boolean; thought_signature_mapping?: string } = {}
+) {
   const provider = buildDirectProvider('custom', ['chat_completions'], {
     internal_id: 'upstream-model',
     base_url: 'https://llm.example.com/v1',
     api_key: 'test-key',
-    thought_signature_mapping,
+    ...options,
   });
 
   await provider.transformRequest({
@@ -92,7 +95,9 @@ describe('buildDirectProvider thought signature mapping', () => {
   it('maps assistant tool-call signatures and removes camel-case transport fields', async () => {
     const request = makeRequest();
 
-    await transformRequest(request, 'extra_content.provider.thought_signature');
+    await transformRequest(request, {
+      thought_signature_mapping: 'extra_content.provider.thought_signature',
+    });
 
     expect(request.body.model).toBe('upstream-model');
     expect(request.body.messages).toEqual([
@@ -130,5 +135,103 @@ describe('buildDirectProvider thought signature mapping', () => {
       },
       { thoughtSignature: 'tool-signature' },
     ]);
+  });
+});
+
+describe('buildDirectProvider JSON ref field sanitization', () => {
+  it('accepts the sanitization option', () => {
+    expect(
+      CustomLlmApiConfigSchema.safeParse({
+        internal_id: 'upstream-model',
+        base_url: 'https://llm.example.com/v1',
+        sanitize_ref_fields: true,
+      }).success
+    ).toBe(true);
+  });
+
+  it('recursively renames $ref properties in JSON chat completion tool results', async () => {
+    const content = JSON.stringify({
+      $ref: '#/$defs/root',
+      nested: { $ref: '#/$defs/nested' },
+      items: [{ $ref: '#/$defs/item' }],
+    });
+    const request: ChatCompletionRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'public-model',
+        messages: [
+          { role: 'user', content },
+          { role: 'tool', tool_call_id: 'call-1', content },
+        ],
+      },
+    };
+
+    await transformRequest(request, { sanitize_ref_fields: true });
+
+    expect(request.body.messages[0].content).toBe(content);
+    expect(JSON.parse(request.body.messages[1].content as string)).toEqual({
+      _ref: '#/$defs/root',
+      nested: { _ref: '#/$defs/nested' },
+      items: [{ _ref: '#/$defs/item' }],
+    });
+  });
+
+  it.each([
+    ['the option is disabled', false, '{ "$ref": "keep" }'],
+    ['the tool result is not valid JSON', true, '{ "$ref": "keep"'],
+    ['valid JSON has no $ref properties', true, '{ "value": "keep" }'],
+  ])('preserves content when %s', async (_description, sanitize_ref_fields, content) => {
+    const request: ChatCompletionRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'public-model',
+        messages: [{ role: 'tool', tool_call_id: 'call-1', content }],
+      },
+    };
+
+    await transformRequest(request, { sanitize_ref_fields });
+
+    expect(request.body.messages[0].content).toBe(content);
+  });
+
+  it('sanitizes JSON in chat completion tool result text parts', async () => {
+    const request: ChatCompletionRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'public-model',
+        messages: [
+          {
+            role: 'tool',
+            tool_call_id: 'call-1',
+            content: [{ type: 'text', text: '{"$ref":"rename"}' }],
+          },
+        ],
+      },
+    };
+
+    await transformRequest(request, { sanitize_ref_fields: true });
+
+    expect(request.body.messages[0].content).toEqual([{ type: 'text', text: '{"_ref":"rename"}' }]);
+  });
+
+  it('does not sanitize Messages API tool results', async () => {
+    const content = '{"$ref":"keep"}';
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'public-model',
+        max_tokens: 100,
+        messages: [
+          {
+            role: 'user',
+            content: [{ type: 'tool_result', tool_use_id: 'call-1', content }],
+          },
+        ],
+      },
+    };
+
+    await transformRequest(request, { sanitize_ref_fields: true });
+
+    expect(request.body.messages[0].content[0]).toMatchObject({ content });
   });
 });

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
@@ -88,6 +88,61 @@ function mapThoughtSignatures(context: TransformRequestContext, path: string) {
   }
 }
 
+function renameJsonRefProperties(value: unknown): boolean {
+  if (Array.isArray(value)) {
+    return value.reduce<boolean>(
+      (changed, item) => renameJsonRefProperties(item) || changed,
+      false
+    );
+  }
+
+  if (!isRecord(value)) {
+    return false;
+  }
+
+  let changed = false;
+  for (const [key, nestedValue] of Object.entries(value)) {
+    changed = renameJsonRefProperties(nestedValue) || changed;
+    if (key === '$ref') {
+      delete value.$ref;
+      value._ref = nestedValue;
+      changed = true;
+    }
+  }
+  return changed;
+}
+
+function sanitizeJsonRefContent(content: string): string {
+  try {
+    const result: unknown = JSON.parse(content);
+    return renameJsonRefProperties(result) ? JSON.stringify(result) : content;
+  } catch {
+    return content;
+  }
+}
+
+function sanitizeJsonRefToolResults(context: TransformRequestContext) {
+  if (context.request.kind !== 'chat_completions') {
+    return;
+  }
+
+  for (const message of context.request.body.messages) {
+    if (message.role !== 'tool') {
+      continue;
+    }
+
+    if (typeof message.content === 'string') {
+      message.content = sanitizeJsonRefContent(message.content);
+    } else {
+      for (const part of message.content) {
+        if (part.type === 'text') {
+          part.text = sanitizeJsonRefContent(part.text);
+        }
+      }
+    }
+  }
+}
+
 async function compressWithHeadroom(
   context: TransformRequestContext,
   compression: CustomLlmCompression
@@ -180,6 +235,9 @@ export function buildDirectProvider(
       }
       if (upstream.thought_signature_mapping) {
         mapThoughtSignatures(context, upstream.thought_signature_mapping);
+      }
+      if (upstream.sanitize_ref_fields) {
+        sanitizeJsonRefToolResults(context);
       }
     },
   };

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1944,6 +1944,7 @@ export const CustomLlmApiConfigSchema = z.object({
   add_cache_breakpoints: z.boolean().optional(),
   remove_cache_breakpoints: z.boolean().optional(),
   inject_reasoning_into_content: z.boolean().optional(),
+  sanitize_ref_fields: z.boolean().optional(),
   extra_headers: CustomLlmExtraHeadersSchema.optional(),
   extra_body: CustomLlmExtraBodySchema.optional(),
   remove_from_body: z.array(z.string()).optional(),


### PR DESCRIPTION
## Summary
- add an optional `sanitize_ref_fields` custom LLM upstream setting
- recursively rename `$ref` keys to `_ref` in valid JSON Chat Completions tool results
- preserve invalid/non-matching JSON and leave Messages/Responses requests unchanged

## Testing
- `pnpm --filter web exec jest src/lib/ai-gateway/experiments/build-direct-provider.test.ts --runInBand`
- `pnpm --filter web run typecheck`
- `pnpm --filter web run lint`
- `pnpm --filter @kilocode/db run typecheck`
- `pnpm --filter @kilocode/db run lint`
- `pnpm format`
- `git diff --check`