### PR TITLE
fix(auto-routing-benchmark): isolate dead-lettered lanes so one model cannot wedge a run

### DIFF
--- a/services/auto-routing-benchmark/README.md
+++ b/services/auto-routing-benchmark/README.md
@@ -84,9 +84,10 @@ pending → running → ready
 - **running**: set when a profile run claims the entries at `startRun`.
 - **ready**: set when that profile run completes successfully (`run_id`
   provenance points at the measuring run).
-- **failed**: set when the run fails (enqueue, timeout sweep, etc.). Only rows
-  still pointing at that `run_id` transition — a newer pending/ready row is
-  never clobbered.
+- **failed**: set when the run fails (enqueue, timeout sweep, etc.) — or, at
+  profile-run completion, per entry whose lane dead-lettered while the run's
+  other entries become `ready`. Only rows still pointing at that `run_id`
+  transition — a newer pending/ready row is never clobbered.
 
 Currency: a profile is current only when `engine_identity`, `repetitions`, and
 exact variant match the live decider engine. Stale rows are never returned as
@@ -204,24 +205,37 @@ sqlite3 /tmp/<file>.sqlite 'select id, kind, status from benchmark_runs;'
   unless the dev runner pins the arm64 manifest digest
   (`MINIFLARE_CONTAINER_EGRESS_IMAGE`) — already handled by the dev runner.
 
-## Debugging the DLQ
+## Dead-letter handling (lane failure)
 
 Failed queue messages land in `auto-routing-benchmark-dlq` after `max_retries`
 (6) on `auto-routing-benchmark-jobs`. A decider message is one
-(model, repetition, shard, chunk) job, so a DLQ'd message means that chunk never
-produced results; its model's summaries for the affected route(s) will be
-missing or incomplete and `finalizeRunIfComplete` will mark the run accordingly.
+(model, repetition, shard, chunk) job, and later chunks are chained from it —
+so a DLQ'd message kills its lane's remaining cases.
 
-To inspect / handle:
+The worker consumes the DLQ itself: each dead message is recorded in
+`run_lane_failures`, and run finalization is lane-aware. A run completes once
+every (model, variant, rep) lane has either all its case rows or a recorded
+lane death — a single dead model can no longer wedge the whole run.
 
-- **Prod**: read the DLQ from the Cloudflare dashboard (Workers → Queues →
-  `auto-routing-benchmark-dlq`) or `wrangler queues` tooling; the message body is
-  the JSON job (`runId`, `model`, `rep`, `shard`, `shardCount`, `chunk`, case ids).
-- **Replay**: re-run the affected model with the admin `force` toggle once the
-  underlying cause (OpenRouter outage, container image, bad case) is fixed —
-  carried summaries mean only the re-triggered model is re-benchmarked.
-- **Declare failed**: a run with a wedged/dead `running` row is swept to `failed`
-  on the next `GET /admin/runs`, freeing the one-active-run-per-kind slot.
+- **Profile runs** complete per-entry: entries whose lanes all finished go
+  `ready`; entries with a dead lane go `failed` ("Benchmark lane
+  dead-lettered…"; the owner's Retry re-admits them, quota-charged).
+- **Platform runs** fail fast with the dead lane named in the run error —
+  publishing a partial routing table would silently drop a candidate from
+  routing decisions, so the previous table stays live.
+- **Backstop**: the 6h stale sweep still fails wedged `running` rows on the
+  next `GET /admin/runs` / run start / scheduled sync, for failures that never
+  reach the DLQ (e.g. a throwing consumer).
+
+To inspect:
+
+- **Prod**: Cloudflare dashboard (Workers → Queues →
+  `auto-routing-benchmark-dlq`); the message body is the JSON job (`runId`,
+  `model`, `rep`, `shard`, `chunk`, case ids). Recorded lane deaths are
+  queryable: `SELECT * FROM run_lane_failures WHERE run_id = '…'`.
+- **Replay**: failed profile entries re-admit via the owner's Retry; platform
+  candidates re-measure on the next run (carried summaries mean only models
+  without current results re-run).
 
 ## Commands
 

--- a/services/auto-routing-benchmark/migrations/0008_easy_doctor_faustus.sql
+++ b/services/auto-routing-benchmark/migrations/0008_easy_doctor_faustus.sql
@@ -1,0 +1,10 @@
+CREATE TABLE `run_lane_failures` (
+	`run_id` text NOT NULL,
+	`model` text NOT NULL,
+	`variant` text DEFAULT '' NOT NULL,
+	`rep` integer DEFAULT 0 NOT NULL,
+	`chunk` integer DEFAULT 0 NOT NULL,
+	`shard` integer DEFAULT 0 NOT NULL,
+	`failed_at` text NOT NULL,
+	PRIMARY KEY(`run_id`, `model`, `variant`, `rep`, `chunk`, `shard`)
+);

--- a/services/auto-routing-benchmark/migrations/meta/0008_snapshot.json
+++ b/services/auto-routing-benchmark/migrations/meta/0008_snapshot.json
@@ -1,0 +1,1060 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "c0afe0b5-ea9a-4206-a099-34099ac02ee9",
+  "prevId": "d374401e-a36e-48bc-8a5a-6d98690c356b",
+  "tables": {
+    "benchmark_config": {
+      "name": "benchmark_config",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_accuracy": {
+          "name": "min_accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "switch_cost_factor": {
+          "name": "switch_cost_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "best_accuracy_switch_threshold": {
+          "name": "best_accuracy_switch_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "benchmark_user_id": {
+          "name": "benchmark_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "benchmark_org_id": {
+          "name": "benchmark_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "classifier_repetitions": {
+          "name": "classifier_repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "decider_repetitions": {
+          "name": "decider_repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "classifier_max_p95_latency_ms": {
+          "name": "classifier_max_p95_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_decider_min_cost_usd": {
+          "name": "auto_decider_min_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 15
+        },
+        "auto_decider_max_cost_usd": {
+          "name": "auto_decider_max_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 25
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_by": {
+          "name": "updated_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "benchmark_profiles": {
+      "name": "benchmark_profiles",
+      "columns": {
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "engine_identity": {
+          "name": "engine_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "failure_reason": {
+          "name": "failure_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "requested_at": {
+          "name": "requested_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "benchmark_profiles_model_variant_engine_identity_repetitions_pk": {
+          "columns": [
+            "model",
+            "variant",
+            "engine_identity",
+            "repetitions"
+          ],
+          "name": "benchmark_profiles_model_variant_engine_identity_repetitions_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "benchmark_runs": {
+      "name": "benchmark_runs",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "kind": {
+          "name": "kind",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "min_accuracy": {
+          "name": "min_accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "switch_cost_factor": {
+          "name": "switch_cost_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "best_accuracy_switch_threshold": {
+          "name": "best_accuracy_switch_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "max_concurrency": {
+          "name": "max_concurrency",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "benchmark_user_id": {
+          "name": "benchmark_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "benchmark_org_id": {
+          "name": "benchmark_org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "classifier_max_p95_latency_ms": {
+          "name": "classifier_max_p95_latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "engine_identity": {
+          "name": "engine_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "purpose": {
+          "name": "purpose",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'platform'"
+        }
+      },
+      "indexes": {
+        "UQ_benchmark_runs_one_running_per_kind": {
+          "name": "UQ_benchmark_runs_one_running_per_kind",
+          "columns": [
+            "kind"
+          ],
+          "isUnique": true,
+          "where": "\"benchmark_runs\".\"status\" = 'running'"
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "case_results": {
+      "name": "case_results",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "case_id": {
+          "name": "case_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "route_key": {
+          "name": "route_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "score": {
+          "name": "score",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "latency_ms": {
+          "name": "latency_ms",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "cost_usd": {
+          "name": "cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "fallback_reason": {
+          "name": "fallback_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "retried": {
+          "name": "retried",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "exit_code": {
+          "name": "exit_code",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "output_prefix": {
+          "name": "output_prefix",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "event_count": {
+          "name": "event_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "last_event_types": {
+          "name": "last_event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "rep": {
+          "name": "rep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "timed_out": {
+          "name": "timed_out",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "case_results_run_id_model_variant_case_id_rep_pk": {
+          "columns": [
+            "run_id",
+            "model",
+            "variant",
+            "case_id",
+            "rep"
+          ],
+          "name": "case_results_run_id_model_variant_case_id_rep_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_auto_decider_exclusions": {
+      "name": "config_auto_decider_exclusions",
+      "columns": {
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_auto_decider_models": {
+      "name": "config_auto_decider_models",
+      "columns": {
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_attempt_cost_usd": {
+          "name": "avg_attempt_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "synced_at": {
+          "name": "synced_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_classifier_models": {
+      "name": "config_classifier_models",
+      "columns": {
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "config_decider_models": {
+      "name": "config_decider_models",
+      "columns": {
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "model_summaries": {
+      "name": "model_summaries",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "route_key": {
+          "name": "route_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avg_cost_usd": {
+          "name": "avg_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "avg_latency_ms": {
+          "name": "avg_latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p50_latency_ms": {
+          "name": "p50_latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cases": {
+          "name": "cases",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "errors": {
+          "name": "errors",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "p95_latency_ms": {
+          "name": "p95_latency_ms",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "timeouts": {
+          "name": "timeouts",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "carried": {
+          "name": "carried",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "model_summaries_run_id_model_variant_route_key_pk": {
+          "columns": [
+            "run_id",
+            "model",
+            "variant",
+            "route_key"
+          ],
+          "name": "model_summaries_run_id_model_variant_route_key_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "profile_request_events": {
+      "name": "profile_request_events",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": true
+        },
+        "owner_type": {
+          "name": "owner_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "engine_identity": {
+          "name": "engine_identity",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "repetitions": {
+          "name": "repetitions",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "admitted_at": {
+          "name": "admitted_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {
+        "IDX_profile_request_events_owner_admitted": {
+          "name": "IDX_profile_request_events_owner_admitted",
+          "columns": [
+            "owner_type",
+            "owner_id",
+            "admitted_at"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routing_table_candidates": {
+      "name": "routing_table_candidates",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "route_key": {
+          "name": "route_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "rank": {
+          "name": "rank",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "accuracy": {
+          "name": "accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "avg_cost_usd": {
+          "name": "avg_cost_usd",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "meets_threshold": {
+          "name": "meets_threshold",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "routing_table_candidates_run_id_route_key_rank_pk": {
+          "columns": [
+            "run_id",
+            "route_key",
+            "rank"
+          ],
+          "name": "routing_table_candidates_run_id_route_key_rank_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "routing_tables": {
+      "name": "routing_tables",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "published_at": {
+          "name": "published_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "generated_at": {
+          "name": "generated_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "min_accuracy": {
+          "name": "min_accuracy",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "switch_cost_factor": {
+          "name": "switch_cost_factor",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "best_accuracy_switch_threshold": {
+          "name": "best_accuracy_switch_threshold",
+          "type": "real",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0.05
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_lane_failures": {
+      "name": "run_lane_failures",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "rep": {
+          "name": "rep",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "chunk": {
+          "name": "chunk",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "shard": {
+          "name": "shard",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 0
+        },
+        "failed_at": {
+          "name": "failed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "run_lane_failures_run_id_model_variant_rep_chunk_shard_pk": {
+          "columns": [
+            "run_id",
+            "model",
+            "variant",
+            "rep",
+            "chunk",
+            "shard"
+          ],
+          "name": "run_lane_failures_run_id_model_variant_rep_chunk_shard_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    },
+    "run_models": {
+      "name": "run_models",
+      "columns": {
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "''"
+        },
+        "enqueued": {
+          "name": "enqueued",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "reasoning_effort": {
+          "name": "reasoning_effort",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {
+        "run_models_run_id_model_variant_pk": {
+          "columns": [
+            "run_id",
+            "model",
+            "variant"
+          ],
+          "name": "run_models_run_id_model_variant_pk"
+        }
+      },
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {}
+  }
+}

--- a/services/auto-routing-benchmark/migrations/meta/_journal.json
+++ b/services/auto-routing-benchmark/migrations/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1785260908640,
       "tag": "0007_complex_makkari",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "6",
+      "when": 1786106641954,
+      "tag": "0008_easy_doctor_faustus",
+      "breakpoints": true
     }
   ]
 }

--- a/services/auto-routing-benchmark/src/db-schema.ts
+++ b/services/auto-routing-benchmark/src/db-schema.ts
@@ -249,3 +249,28 @@ export const profileRequestEvents = sqliteTable(
     ),
   ]
 );
+
+/**
+ * Lane-death ledger: one row per benchmark queue message that exhausted its
+ * retries and dead-lettered. Written by the DLQ consumer; read by run
+ * finalization so a dead lane no longer wedges its run — profile runs complete
+ * per-entry, platform runs fail fast instead of waiting for the stale sweep.
+ */
+export const runLaneFailures = sqliteTable(
+  'run_lane_failures',
+  {
+    run_id: text('run_id').notNull(),
+    model: text('model').notNull(),
+    // Canonical variant key at the D1 boundary. '' means null/default variant.
+    variant: text('variant').notNull().default(''),
+    rep: integer('rep').notNull().default(0),
+    chunk: integer('chunk').notNull().default(0),
+    shard: integer('shard').notNull().default(0),
+    failed_at: text('failed_at').notNull(),
+  },
+  table => [
+    primaryKey({
+      columns: [table.run_id, table.model, table.variant, table.rep, table.chunk, table.shard],
+    }),
+  ]
+);

--- a/services/auto-routing-benchmark/src/db.ts
+++ b/services/auto-routing-benchmark/src/db.ts
@@ -652,6 +652,12 @@ export function markProfilesFailedForEntriesStatement(
   failureReason: string,
   nowIso: string
 ) {
+  // or(...[]) evaluates to undefined and the WHERE would degrade to run_id +
+  // status='running', failing every running entry of the run. Refuse the
+  // destructive form at the boundary instead of relying on caller guards.
+  if (entries.length === 0) {
+    throw new Error('markProfilesFailedForEntriesStatement requires at least one entry');
+  }
   return orm
     .update(benchmarkProfiles)
     .set({

--- a/services/auto-routing-benchmark/src/db.ts
+++ b/services/auto-routing-benchmark/src/db.ts
@@ -24,6 +24,7 @@ import {
   modelSummaries,
   routingTableCandidates,
   routingTables,
+  runLaneFailures,
   runModels,
 } from './db-schema';
 import { pickClassifierWinner } from './winner';
@@ -327,13 +328,23 @@ export async function upsertCaseResult(db: D1Database, row: CaseResultRow): Prom
     });
 }
 
-export async function countCaseResults(db: D1Database, runId: string): Promise<number> {
-  const row = await drizzle(db)
-    .select({ n: count() })
+export type LaneCaseCount = { model: string; variant: string; rep: number; n: number };
+
+/** Per-lane case counts for run-completion accounting. Variant is storage form. */
+export async function countCaseResultsByLane(
+  db: D1Database,
+  runId: string
+): Promise<LaneCaseCount[]> {
+  return drizzle(db)
+    .select({
+      model: caseResults.model,
+      variant: caseResults.variant,
+      rep: caseResults.rep,
+      n: count(),
+    })
     .from(caseResults)
     .where(eq(caseResults.run_id, runId))
-    .get();
-  return row?.n ?? 0;
+    .groupBy(caseResults.model, caseResults.variant, caseResults.rep);
 }
 
 export async function getCaseResults(db: D1Database, runId: string): Promise<CaseResultRow[]> {
@@ -626,6 +637,118 @@ export async function markProfilesFailedForRun(
   nowIso: string = new Date().toISOString()
 ): Promise<void> {
   await markProfilesFailedForRunStatement(drizzle(db), runId, failureReason, nowIso);
+}
+
+/**
+ * Production UPDATE for the per-entry failed transition at profile-run
+ * completion. Same run_id + status='running' no-clobber guard as the
+ * whole-run variants. Exported for honest SQLite tests.
+ */
+export function markProfilesFailedForEntriesStatement(
+  orm: ReturnType<typeof drizzle>,
+  runId: string,
+  /** Storage-form variant keys ('' = default variant). */
+  entries: readonly { model: string; variant: string }[],
+  failureReason: string,
+  nowIso: string
+) {
+  return orm
+    .update(benchmarkProfiles)
+    .set({
+      status: 'failed',
+      failure_reason: boundProfileFailureReason(failureReason),
+      updated_at: nowIso,
+      completed_at: nowIso,
+    })
+    .where(
+      and(
+        eq(benchmarkProfiles.run_id, runId),
+        eq(benchmarkProfiles.status, 'running'),
+        or(
+          ...entries.map(e =>
+            and(eq(benchmarkProfiles.model, e.model), eq(benchmarkProfiles.variant, e.variant))
+          )
+        )
+      )
+    );
+}
+
+/**
+ * Transition the given entries claimed by this run to failed. Only rows still
+ * pointing at this run_id and still running are updated.
+ */
+export async function markProfilesFailedForEntries(
+  db: D1Database,
+  runId: string,
+  entries: readonly { model: string; variant: string }[],
+  failureReason: string,
+  nowIso: string = new Date().toISOString()
+): Promise<void> {
+  if (entries.length === 0) return;
+  await markProfilesFailedForEntriesStatement(drizzle(db), runId, entries, failureReason, nowIso);
+}
+
+// ---------------------------------------------------------------------------
+// Lane failures (dead-lettered queue messages)
+// ---------------------------------------------------------------------------
+
+export type RunLaneFailureRow = typeof runLaneFailures.$inferSelect;
+
+/**
+ * Production INSERT for lane-death records. ON CONFLICT DO NOTHING so DLQ
+ * redelivery or several dead chunks of one lane never throw. Exported for
+ * honest SQLite tests.
+ */
+export function recordLaneFailureStatement(
+  orm: ReturnType<typeof drizzle>,
+  row: {
+    runId: string;
+    model: string;
+    /** Storage form ('' = default variant). */
+    variant: string;
+    rep: number;
+    chunk: number;
+    shard: number;
+    failedAtIso: string;
+  }
+) {
+  return orm
+    .insert(runLaneFailures)
+    .values({
+      run_id: row.runId,
+      model: row.model,
+      variant: row.variant,
+      rep: row.rep,
+      chunk: row.chunk,
+      shard: row.shard,
+      failed_at: row.failedAtIso,
+    })
+    .onConflictDoNothing();
+}
+
+/** Record that a run's lane chunk dead-lettered. Variant in storage form. */
+export async function recordLaneFailure(
+  db: D1Database,
+  row: {
+    runId: string;
+    model: string;
+    /** Storage form ('' = default variant). */
+    variant: string;
+    rep: number;
+    chunk: number;
+    shard: number;
+  },
+  failedAtIso: string = new Date().toISOString()
+): Promise<void> {
+  await recordLaneFailureStatement(drizzle(db), { ...row, failedAtIso });
+}
+
+/** Lane-death records of a run, at (model, variant, rep, chunk, shard) granularity. */
+export async function listLaneFailures(
+  db: D1Database,
+  runId: string
+): Promise<RunLaneFailureRow[]> {
+  return drizzle(db).select().from(runLaneFailures).where(eq(runLaneFailures.run_id, runId));
 }
 
 /**

--- a/services/auto-routing-benchmark/src/index-queue.test.ts
+++ b/services/auto-routing-benchmark/src/index-queue.test.ts
@@ -1,0 +1,79 @@
+/**
+ * Queue-handler retry contract. DLQ messages must propagate processDeadLetter
+ * errors (no ack) so the queue retries them: a lane death recorded without a
+ * completed finalization has to be re-attempted, or the run wedges until the
+ * stale sweep fails it wholesale.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as RunModule from './run';
+
+vi.mock('./run', async importOriginal => {
+  const actual = await importOriginal<typeof RunModule>();
+  return {
+    ...actual,
+    processDeadLetter: vi.fn(),
+    processJob: vi.fn(),
+  };
+});
+
+import { processDeadLetter, processJob, type BenchmarkJobMessage } from './run';
+import worker from './index';
+
+const env = {} as unknown as Env;
+
+function fakeBatch(queue: string, bodies: unknown[]) {
+  const messages = bodies.map(body => ({ id: 'm', timestamp: 0, body, ack: vi.fn() }));
+  return {
+    batch: { queue, messages } as unknown as MessageBatch<BenchmarkJobMessage>,
+    messages,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(processDeadLetter).mockResolvedValue(undefined);
+  vi.mocked(processJob).mockResolvedValue(undefined);
+});
+
+describe('queue handler — DLQ branch', () => {
+  it('acks dead-lettered messages after processDeadLetter succeeds', async () => {
+    const { batch, messages } = fakeBatch('auto-routing-benchmark-dlq', [{ runId: 'r1' }]);
+
+    await worker.queue(batch, env);
+
+    expect(processDeadLetter).toHaveBeenCalledWith(env, { runId: 'r1' });
+    expect(messages[0].ack).toHaveBeenCalled();
+  });
+
+  it('propagates processDeadLetter errors without ack so the queue retries', async () => {
+    vi.mocked(processDeadLetter).mockRejectedValueOnce(new Error('D1 transient'));
+    const { batch, messages } = fakeBatch('auto-routing-benchmark-dlq', [{ runId: 'r1' }]);
+
+    await expect(worker.queue(batch, env)).rejects.toThrow('D1 transient');
+
+    expect(messages[0].ack).not.toHaveBeenCalled();
+  });
+});
+
+describe('queue handler — jobs branch', () => {
+  it('acks jobs after processJob succeeds and propagates failures without ack', async () => {
+    const { batch, messages } = fakeBatch('auto-routing-benchmark-jobs', [
+      { runId: 'r1', kind: 'decider', model: 'm/x' },
+    ]);
+
+    await worker.queue(batch, env);
+
+    expect(processJob).toHaveBeenCalledWith(env, {
+      runId: 'r1',
+      kind: 'decider',
+      model: 'm/x',
+    });
+    expect(messages[0].ack).toHaveBeenCalled();
+
+    vi.mocked(processJob).mockRejectedValueOnce(new Error('container capacity'));
+    const retry = fakeBatch('auto-routing-benchmark-jobs', [{ runId: 'r1' }]);
+
+    await expect(worker.queue(retry.batch, env)).rejects.toThrow('container capacity');
+    expect(retry.messages[0].ack).not.toHaveBeenCalled();
+  });
+});

--- a/services/auto-routing-benchmark/src/index.ts
+++ b/services/auto-routing-benchmark/src/index.ts
@@ -1,5 +1,5 @@
 import { Hono } from 'hono';
-import { createErrorHandler, createNotFoundHandler, formatError } from '@kilocode/worker-utils';
+import { createErrorHandler, createNotFoundHandler } from '@kilocode/worker-utils';
 import { registerAdminRoutes } from './admin';
 import { authMiddleware } from './auth';
 import { syncAutoDeciderModels } from './auto-decider-sync';
@@ -35,18 +35,14 @@ export default {
   },
   async queue(batch: MessageBatch<BenchmarkJobMessage>, env: Env): Promise<void> {
     // Dead-lettered messages: record the lane death and try to finalize the
-    // run. Never throw — a poison DLQ message retrying forever would wedge the
-    // run again; the stale sweep remains the backstop.
+    // run. Same retry contract as the jobs branch: a throw (transient D1
+    // failure after the death was recorded) skips the ack so the message
+    // retries and finalization is re-attempted. A message still failing after
+    // max_retries is dropped (the DLQ has no DLQ); the stale sweep remains
+    // the backstop for runs that never finalize.
     if (batch.queue === DLQ_NAME) {
       for (const message of batch.messages) {
-        await processDeadLetter(env, message.body).catch(error => {
-          console.warn(
-            JSON.stringify({
-              event: 'benchmark_deadletter_handler_error',
-              ...formatError(error),
-            })
-          );
-        });
+        await processDeadLetter(env, message.body);
         message.ack();
       }
       return;

--- a/services/auto-routing-benchmark/src/index.ts
+++ b/services/auto-routing-benchmark/src/index.ts
@@ -1,10 +1,13 @@
 import { Hono } from 'hono';
-import { createErrorHandler, createNotFoundHandler } from '@kilocode/worker-utils';
+import { createErrorHandler, createNotFoundHandler, formatError } from '@kilocode/worker-utils';
 import { registerAdminRoutes } from './admin';
 import { authMiddleware } from './auth';
 import { syncAutoDeciderModels } from './auto-decider-sync';
 import type { HonoEnv } from './hono-env';
-import { processJob, type BenchmarkJobMessage } from './run';
+import { processDeadLetter, processJob, type BenchmarkJobMessage } from './run';
+
+// Queue name of the dead-letter queue, matched against batch.queue.
+const DLQ_NAME = 'auto-routing-benchmark-dlq';
 
 // Re-exported so the Durable Object class binding (BENCH_RUNNER) can find it.
 export { BenchRunnerContainer } from './bench-runner-container';
@@ -31,6 +34,23 @@ export default {
     );
   },
   async queue(batch: MessageBatch<BenchmarkJobMessage>, env: Env): Promise<void> {
+    // Dead-lettered messages: record the lane death and try to finalize the
+    // run. Never throw — a poison DLQ message retrying forever would wedge the
+    // run again; the stale sweep remains the backstop.
+    if (batch.queue === DLQ_NAME) {
+      for (const message of batch.messages) {
+        await processDeadLetter(env, message.body).catch(error => {
+          console.warn(
+            JSON.stringify({
+              event: 'benchmark_deadletter_handler_error',
+              ...formatError(error),
+            })
+          );
+        });
+        message.ack();
+      }
+      return;
+    }
     for (const message of batch.messages) {
       // Deliberately no try/catch: a throw from processJob (transient token,
       // D1 or container failures) must skip the ack so the queue retries the

--- a/services/auto-routing-benchmark/src/lane-failure-sql.test.ts
+++ b/services/auto-routing-benchmark/src/lane-failure-sql.test.ts
@@ -233,6 +233,14 @@ describe('markProfilesFailedForEntriesStatement (real SQLite)', () => {
     ]);
   });
 
+  it('throws on empty entries instead of degrading to the whole-run form', () => {
+    // or(...[]) would drop the entry filter and fail every running row of the
+    // run; the builder must refuse before any statement exists.
+    expect(() => markProfilesFailedForEntriesStatement(orm, 'run-1', [], 'lane dead', now)).toThrow(
+      /at least one entry/
+    );
+  });
+
   it('matches entries on the exact (model, variant) pair', () => {
     insertProfile(db, { model: 'm/x', variant: 'high', status: 'running', run_id: 'run-1' });
     insertProfile(db, { model: 'm/x', variant: 'low', status: 'running', run_id: 'run-1' });

--- a/services/auto-routing-benchmark/src/lane-failure-sql.test.ts
+++ b/services/auto-routing-benchmark/src/lane-failure-sql.test.ts
@@ -1,0 +1,270 @@
+/**
+ * Real SQLite execution of production lane-failure SQL. Intentionally does NOT
+ * mock drizzle — these tests fail if the idempotent insert or the run_id +
+ * status='running' no-clobber guard is missing or weakened.
+ */
+import { DatabaseSync } from 'node:sqlite';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { drizzle } from 'drizzle-orm/d1';
+import { markProfilesFailedForEntriesStatement, recordLaneFailureStatement } from './db';
+
+const SCHEMA_SQL = `
+  CREATE TABLE run_lane_failures (
+    run_id TEXT NOT NULL,
+    model TEXT NOT NULL,
+    variant TEXT NOT NULL DEFAULT '',
+    rep INTEGER NOT NULL DEFAULT 0,
+    chunk INTEGER NOT NULL DEFAULT 0,
+    shard INTEGER NOT NULL DEFAULT 0,
+    failed_at TEXT NOT NULL,
+    PRIMARY KEY (run_id, model, variant, rep, chunk, shard)
+  );
+  CREATE TABLE benchmark_profiles (
+    model TEXT NOT NULL,
+    variant TEXT NOT NULL DEFAULT '',
+    engine_identity TEXT NOT NULL,
+    repetitions INTEGER NOT NULL,
+    status TEXT NOT NULL,
+    run_id TEXT,
+    failure_reason TEXT,
+    requested_at TEXT NOT NULL,
+    updated_at TEXT NOT NULL,
+    completed_at TEXT,
+    PRIMARY KEY (model, variant, engine_identity, repetitions)
+  );
+`;
+
+type SqlQuery = { sql: string; params: unknown[] };
+
+function toSql(stmt: { toSQL: () => SqlQuery }): SqlQuery {
+  return stmt.toSQL();
+}
+
+/** node:sqlite Statement.run overloads confuse TS with mixed string/number args. */
+function execSql(db: DatabaseSync, sqlText: string, params: readonly unknown[] = []): void {
+  db.prepare(sqlText).run(...(params as never[]));
+}
+
+function runQuery(db: DatabaseSync, q: SqlQuery): void {
+  execSql(db, q.sql, q.params);
+}
+
+function insertProfile(
+  db: DatabaseSync,
+  row: {
+    model: string;
+    variant?: string;
+    status: string;
+    run_id: string | null;
+    failure_reason?: string | null;
+  }
+): void {
+  execSql(
+    db,
+    `INSERT INTO benchmark_profiles
+      (model, variant, engine_identity, repetitions, status, run_id, failure_reason, requested_at, updated_at, completed_at)
+     VALUES (?, ?, 'v-test:engine', 1, ?, ?, ?, '2026-08-07T09:00:00.000Z', '2026-08-07T09:00:00.000Z', NULL)`,
+    [row.model, row.variant ?? '', row.status, row.run_id, row.failure_reason ?? null]
+  );
+}
+
+type ProfileRow = {
+  model: string;
+  status: string;
+  run_id: string | null;
+  failure_reason: string | null;
+  completed_at: string | null;
+};
+
+function allProfiles(db: DatabaseSync): ProfileRow[] {
+  return db
+    .prepare(
+      'SELECT model, status, run_id, failure_reason, completed_at FROM benchmark_profiles ORDER BY model, variant'
+    )
+    .all() as ProfileRow[];
+}
+
+const orm = drizzle({} as D1Database);
+const now = '2026-08-07T12:00:00.000Z';
+
+describe('recordLaneFailureStatement (real SQLite)', () => {
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    db.exec(SCHEMA_SQL);
+  });
+
+  it('inserts the lane-death record', () => {
+    runQuery(
+      db,
+      toSql(
+        recordLaneFailureStatement(orm, {
+          runId: 'run-1',
+          model: 'cohere/north-mini-code:free',
+          variant: '',
+          rep: 0,
+          chunk: 27,
+          shard: 0,
+          failedAtIso: now,
+        })
+      )
+    );
+
+    const rows = db.prepare('SELECT * FROM run_lane_failures').all();
+    expect(rows).toEqual([
+      {
+        run_id: 'run-1',
+        model: 'cohere/north-mini-code:free',
+        variant: '',
+        rep: 0,
+        chunk: 27,
+        shard: 0,
+        failed_at: now,
+      },
+    ]);
+  });
+
+  it('ignores duplicate records (DLQ redelivery must not throw)', () => {
+    const row = {
+      runId: 'run-1',
+      model: 'm/x',
+      variant: 'high',
+      rep: 1,
+      chunk: 3,
+      shard: 2,
+      failedAtIso: now,
+    };
+    runQuery(db, toSql(recordLaneFailureStatement(orm, row)));
+    runQuery(db, toSql(recordLaneFailureStatement(orm, row)));
+
+    const count = db.prepare('SELECT COUNT(*) AS n FROM run_lane_failures').get() as { n: number };
+    expect(count.n).toBe(1);
+  });
+});
+
+describe('markProfilesFailedForEntriesStatement (real SQLite)', () => {
+  let db: DatabaseSync;
+
+  beforeEach(() => {
+    db = new DatabaseSync(':memory:');
+    db.exec(SCHEMA_SQL);
+  });
+
+  it('fails only the listed entries claimed by this run', () => {
+    insertProfile(db, { model: 'a/ok', status: 'running', run_id: 'run-1' });
+    insertProfile(db, { model: 'b/dead', status: 'running', run_id: 'run-1' });
+
+    runQuery(
+      db,
+      toSql(
+        markProfilesFailedForEntriesStatement(
+          orm,
+          'run-1',
+          [{ model: 'b/dead', variant: '' }],
+          'lane dead',
+          now
+        )
+      )
+    );
+
+    expect(allProfiles(db)).toEqual([
+      {
+        model: 'a/ok',
+        status: 'running',
+        run_id: 'run-1',
+        failure_reason: null,
+        completed_at: null,
+      },
+      {
+        model: 'b/dead',
+        status: 'failed',
+        run_id: 'run-1',
+        failure_reason: 'lane dead',
+        completed_at: now,
+      },
+    ]);
+  });
+
+  it('does not touch rows claimed by a different run or already transitioned', () => {
+    insertProfile(db, { model: 'a/other-run', status: 'running', run_id: 'run-2' });
+    insertProfile(db, { model: 'b/ready', status: 'ready', run_id: 'run-1' });
+    insertProfile(db, { model: 'c/pending', status: 'pending', run_id: null });
+
+    runQuery(
+      db,
+      toSql(
+        markProfilesFailedForEntriesStatement(
+          orm,
+          'run-1',
+          [
+            { model: 'a/other-run', variant: '' },
+            { model: 'b/ready', variant: '' },
+            { model: 'c/pending', variant: '' },
+          ],
+          'lane dead',
+          now
+        )
+      )
+    );
+
+    expect(allProfiles(db)).toEqual([
+      {
+        model: 'a/other-run',
+        status: 'running',
+        run_id: 'run-2',
+        failure_reason: null,
+        completed_at: null,
+      },
+      {
+        model: 'b/ready',
+        status: 'ready',
+        run_id: 'run-1',
+        failure_reason: null,
+        completed_at: null,
+      },
+      {
+        model: 'c/pending',
+        status: 'pending',
+        run_id: null,
+        failure_reason: null,
+        completed_at: null,
+      },
+    ]);
+  });
+
+  it('matches entries on the exact (model, variant) pair', () => {
+    insertProfile(db, { model: 'm/x', variant: 'high', status: 'running', run_id: 'run-1' });
+    insertProfile(db, { model: 'm/x', variant: 'low', status: 'running', run_id: 'run-1' });
+
+    runQuery(
+      db,
+      toSql(
+        markProfilesFailedForEntriesStatement(
+          orm,
+          'run-1',
+          [{ model: 'm/x', variant: 'high' }],
+          'lane dead',
+          now
+        )
+      )
+    );
+
+    expect(allProfiles(db)).toEqual([
+      {
+        model: 'm/x',
+        status: 'failed',
+        run_id: 'run-1',
+        failure_reason: 'lane dead',
+        completed_at: now,
+      },
+      {
+        model: 'm/x',
+        status: 'running',
+        run_id: 'run-1',
+        failure_reason: null,
+        completed_at: null,
+      },
+    ]);
+  });
+});

--- a/services/auto-routing-benchmark/src/profile-runs.test.ts
+++ b/services/auto-routing-benchmark/src/profile-runs.test.ts
@@ -23,12 +23,14 @@ vi.mock('./db', async importOriginal => {
     markStaleRunsFailed: vi.fn(),
     listStaleRunningDeciderRunIds: vi.fn(),
     listPendingCurrentProfiles: vi.fn(),
+    markProfilesFailedForEntries: vi.fn(),
     markProfilesFailedForRun: vi.fn(),
     markProfilesReadyForRun: vi.fn(),
     markProfilesRunningForRun: vi.fn(),
     markRunCompleted: vi.fn(),
     markRunFailed: vi.fn(),
-    countCaseResults: vi.fn(),
+    countCaseResultsByLane: vi.fn(),
+    listLaneFailures: vi.fn(),
     getCaseResults: vi.fn(),
     getExistingCaseResultIds: vi.fn(),
     getSummaries: vi.fn(),
@@ -40,7 +42,7 @@ vi.mock('./db', async importOriginal => {
 });
 
 import {
-  countCaseResults,
+  countCaseResultsByLane,
   existsNewerCompletedRun,
   getCaseResults,
   getConfigRows,
@@ -50,8 +52,10 @@ import {
   getRunWithModels,
   getSummaries,
   insertRun,
+  listLaneFailures,
   listPendingCurrentProfiles,
   listStaleRunningDeciderRunIds,
+  markProfilesFailedForEntries,
   markProfilesFailedForRun,
   markProfilesReadyForRun,
   markProfilesRunningForRun,
@@ -123,10 +127,12 @@ beforeEach(() => {
   vi.mocked(listPendingCurrentProfiles).mockResolvedValue([]);
   vi.mocked(markProfilesRunningForRun).mockResolvedValue(undefined);
   vi.mocked(markProfilesReadyForRun).mockResolvedValue(undefined);
+  vi.mocked(markProfilesFailedForEntries).mockResolvedValue(undefined);
   vi.mocked(markProfilesFailedForRun).mockResolvedValue(undefined);
   vi.mocked(markRunCompleted).mockResolvedValue(undefined);
   vi.mocked(markRunFailed).mockResolvedValue(undefined);
-  vi.mocked(countCaseResults).mockResolvedValue(0);
+  vi.mocked(countCaseResultsByLane).mockResolvedValue([]);
+  vi.mocked(listLaneFailures).mockResolvedValue([]);
   vi.mocked(existsNewerCompletedRun).mockResolvedValue(false);
   vi.mocked(replaceModelSummaries).mockResolvedValue(undefined);
   vi.mocked(saveRoutingTable).mockResolvedValue(undefined);
@@ -250,7 +256,9 @@ describe('profile completion transitions', () => {
     const runId = 'profile-complete-1';
     mockProfileRunState(runId);
     const { DECIDER_CASES } = await import('./datasets/decider-cases');
-    vi.mocked(countCaseResults).mockResolvedValue(DECIDER_CASES.length);
+    vi.mocked(countCaseResultsByLane).mockResolvedValue([
+      { model: 'vendor/m', variant: 'xhigh', rep: 0, n: DECIDER_CASES.length },
+    ]);
     vi.mocked(getCaseResults).mockResolvedValue(
       DECIDER_CASES.map(c => ({
         run_id: runId,
@@ -464,7 +472,9 @@ describe('platform run completion still publishes', () => {
         },
       ],
     });
-    vi.mocked(countCaseResults).mockResolvedValue(DECIDER_CASES.length);
+    vi.mocked(countCaseResultsByLane).mockResolvedValue([
+      { model: 'platform/a', variant: '', rep: 0, n: DECIDER_CASES.length },
+    ]);
     vi.mocked(getCaseResults).mockResolvedValue(
       DECIDER_CASES.map(c => ({
         run_id: runId,

--- a/services/auto-routing-benchmark/src/run-dead-letter.test.ts
+++ b/services/auto-routing-benchmark/src/run-dead-letter.test.ts
@@ -224,6 +224,39 @@ describe('processDeadLetter', () => {
     expect(markProfilesFailedForEntries).not.toHaveBeenCalled();
   });
 
+  it('keeps entries distinct when delimiter-joined keys would collide', async () => {
+    // Space-join would collapse these two entries to the same key ('a b c');
+    // only the dead one may fail.
+    mockRunState([
+      { model: 'a b', variant: 'c' },
+      { model: 'a', variant: 'b c' },
+    ]);
+    vi.mocked(countCaseResultsByLane).mockResolvedValue([
+      { model: 'a', variant: 'b c', rep: 0, n: DECIDER_CASES.length },
+    ]);
+    vi.mocked(listLaneFailures).mockResolvedValue([
+      {
+        run_id: runId,
+        model: 'a b',
+        variant: 'c',
+        rep: 0,
+        chunk: 27,
+        shard: 0,
+        failed_at: '2026-08-07T12:00:00.000Z',
+      },
+    ]);
+
+    await processDeadLetter(env, deadLetterMessage({ model: 'a b', variant: 'c' }));
+
+    expect(markProfilesFailedForEntries).toHaveBeenCalledWith(
+      env.BENCH_DB,
+      runId,
+      [{ model: 'a b', variant: 'c' }],
+      PROFILE_LANE_DEAD_FAILURE_REASON
+    );
+    expect(markProfilesReadyForRun).toHaveBeenCalledWith(env.BENCH_DB, runId);
+  });
+
   it('lets written rows win over a failure record (message died after writes)', async () => {
     mockRunState([{ model: 'b/dead', variant: 'high' }]);
     vi.mocked(countCaseResultsByLane).mockResolvedValue([

--- a/services/auto-routing-benchmark/src/run-dead-letter.test.ts
+++ b/services/auto-routing-benchmark/src/run-dead-letter.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Dead-letter handling: a queue message that exhausted retries must record its
+ * lane death and finalize the run — profile runs complete per-entry, platform
+ * runs fail fast. Mocks the db module; SQL guards are covered honestly in
+ * lane-failure-sql.test.ts.
+ */
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type * as DbModule from './db';
+import { DECIDER_CASES } from './datasets/decider-cases';
+
+vi.mock('./db', async importOriginal => {
+  const actual = await importOriginal<typeof DbModule>();
+  return {
+    ...actual,
+    countCaseResultsByLane: vi.fn(),
+    existsNewerCompletedRun: vi.fn(),
+    getCaseResults: vi.fn(),
+    getRunningRun: vi.fn(),
+    getRunWithModels: vi.fn(),
+    getSummaries: vi.fn(),
+    listLaneFailures: vi.fn(),
+    listPendingCurrentProfiles: vi.fn(),
+    markProfilesFailedForEntries: vi.fn(),
+    markProfilesFailedForRun: vi.fn(),
+    markProfilesReadyForRun: vi.fn(),
+    markRunCompleted: vi.fn(),
+    markRunFailed: vi.fn(),
+    recordLaneFailure: vi.fn(),
+    replaceModelSummaries: vi.fn(),
+    saveRoutingTable: vi.fn(),
+  };
+});
+
+import {
+  countCaseResultsByLane,
+  getCaseResults,
+  getRunningRun,
+  getRunWithModels,
+  getSummaries,
+  listLaneFailures,
+  listPendingCurrentProfiles,
+  markProfilesFailedForEntries,
+  markProfilesReadyForRun,
+  markRunCompleted,
+  markRunFailed,
+  recordLaneFailure,
+  replaceModelSummaries,
+  saveRoutingTable,
+} from './db';
+import { processDeadLetter, PROFILE_LANE_DEAD_FAILURE_REASON } from './run';
+
+const queueSendBatch = vi.fn();
+const kvDelete = vi.fn();
+const runId = 'profile-dead-1';
+
+const env = {
+  BENCH_DB: {} as D1Database,
+  BENCH_QUEUE: { sendBatch: queueSendBatch },
+  AUTO_ROUTING_CONFIG: { delete: kvDelete },
+  INTERNAL_API_SECRET_PROD: { get: async () => 'secret' },
+  KILO_WEB_API_BASE_URL: 'https://app.test',
+  KILO_CLI_API_URL: 'https://api.test',
+} as unknown as Env;
+
+function mockRunState(
+  models: { model: string; variant: string }[],
+  purpose: 'platform' | 'profile' = 'profile',
+  status: 'running' | 'failed' = 'running'
+): void {
+  vi.mocked(getRunWithModels).mockResolvedValue({
+    run: {
+      id: runId,
+      kind: 'decider',
+      status,
+      started_at: '2026-08-07T09:00:00.000Z',
+      completed_at: null,
+      error: null,
+      min_accuracy: 0.7,
+      switch_cost_factor: 3,
+      best_accuracy_switch_threshold: 0.05,
+      max_concurrency: 4,
+      benchmark_user_id: 'user-1',
+      benchmark_org_id: null,
+      repetitions: 1,
+      classifier_max_p95_latency_ms: null,
+      engine_identity: 'v1:test',
+      purpose,
+    },
+    models: models.map(m => ({
+      run_id: runId,
+      model: m.model,
+      variant: m.variant,
+      enqueued: true,
+      reasoning_effort: null,
+    })),
+  } as never);
+}
+
+function deadLetterMessage(overrides: Record<string, unknown> = {}) {
+  return {
+    runId,
+    kind: 'decider' as const,
+    model: 'b/dead',
+    variant: 'high',
+    chunk: 27,
+    shard: 0,
+    rep: 0,
+    caseIds: DECIDER_CASES.slice(135, 140).map(c => c.id),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.mocked(countCaseResultsByLane).mockResolvedValue([]);
+  vi.mocked(listLaneFailures).mockResolvedValue([]);
+  vi.mocked(recordLaneFailure).mockResolvedValue(undefined);
+  vi.mocked(getCaseResults).mockResolvedValue([]);
+  vi.mocked(getSummaries).mockResolvedValue([]);
+  vi.mocked(replaceModelSummaries).mockResolvedValue(undefined);
+  vi.mocked(markRunCompleted).mockResolvedValue(undefined);
+  vi.mocked(markRunFailed).mockResolvedValue(undefined);
+  vi.mocked(markProfilesFailedForEntries).mockResolvedValue(undefined);
+  vi.mocked(markProfilesReadyForRun).mockResolvedValue(undefined);
+  vi.mocked(getRunningRun).mockResolvedValue(undefined);
+  vi.mocked(listPendingCurrentProfiles).mockResolvedValue([]);
+  queueSendBatch.mockResolvedValue(undefined);
+});
+
+describe('processDeadLetter', () => {
+  it('records the lane death and completes a profile run per-entry', async () => {
+    mockRunState([
+      { model: 'a/ok', variant: '' },
+      { model: 'b/dead', variant: 'high' },
+    ]);
+    vi.mocked(countCaseResultsByLane).mockResolvedValue([
+      { model: 'a/ok', variant: '', rep: 0, n: DECIDER_CASES.length },
+    ]);
+    // The post-record read already sees the failure.
+    vi.mocked(listLaneFailures).mockResolvedValue([
+      {
+        run_id: runId,
+        model: 'b/dead',
+        variant: 'high',
+        rep: 0,
+        chunk: 27,
+        shard: 0,
+        failed_at: '2026-08-07T12:00:00.000Z',
+      },
+    ]);
+
+    await processDeadLetter(env, deadLetterMessage());
+
+    expect(recordLaneFailure).toHaveBeenCalledWith(env.BENCH_DB, {
+      runId,
+      model: 'b/dead',
+      variant: 'high',
+      rep: 0,
+      chunk: 27,
+      shard: 0,
+    });
+    expect(markRunCompleted).toHaveBeenCalledWith(env.BENCH_DB, runId);
+    // Only the dead entry fails; the completed entry still goes ready.
+    expect(markProfilesFailedForEntries).toHaveBeenCalledWith(
+      env.BENCH_DB,
+      runId,
+      [{ model: 'b/dead', variant: 'high' }],
+      PROFILE_LANE_DEAD_FAILURE_REASON
+    );
+    expect(markProfilesReadyForRun).toHaveBeenCalledWith(env.BENCH_DB, runId);
+    // Profile runs never publish platform artifacts.
+    expect(saveRoutingTable).not.toHaveBeenCalled();
+    expect(kvDelete).not.toHaveBeenCalled();
+  });
+
+  it('fails a platform run fast when a lane is dead, without publishing', async () => {
+    mockRunState([{ model: 'b/dead', variant: 'high' }], 'platform');
+    vi.mocked(listLaneFailures).mockResolvedValue([
+      {
+        run_id: runId,
+        model: 'b/dead',
+        variant: 'high',
+        rep: 0,
+        chunk: 27,
+        shard: 0,
+        failed_at: '2026-08-07T12:00:00.000Z',
+      },
+    ]);
+
+    await processDeadLetter(env, deadLetterMessage());
+
+    expect(markRunFailed).toHaveBeenCalledWith(
+      env.BENCH_DB,
+      runId,
+      expect.stringContaining('lane dead-lettered: b/dead variant high rep 0')
+    );
+    expect(markRunCompleted).not.toHaveBeenCalled();
+    expect(saveRoutingTable).not.toHaveBeenCalled();
+  });
+
+  it('does not finalize while another lane is still pending', async () => {
+    mockRunState([
+      { model: 'a/pending', variant: '' },
+      { model: 'b/dead', variant: 'high' },
+    ]);
+    // a/pending has no rows and no failure record yet.
+    vi.mocked(listLaneFailures).mockResolvedValue([
+      {
+        run_id: runId,
+        model: 'b/dead',
+        variant: 'high',
+        rep: 0,
+        chunk: 27,
+        shard: 0,
+        failed_at: '2026-08-07T12:00:00.000Z',
+      },
+    ]);
+
+    await processDeadLetter(env, deadLetterMessage());
+
+    expect(recordLaneFailure).toHaveBeenCalled();
+    expect(markRunCompleted).not.toHaveBeenCalled();
+    expect(markRunFailed).not.toHaveBeenCalled();
+    expect(markProfilesFailedForEntries).not.toHaveBeenCalled();
+  });
+
+  it('lets written rows win over a failure record (message died after writes)', async () => {
+    mockRunState([{ model: 'b/dead', variant: 'high' }]);
+    vi.mocked(countCaseResultsByLane).mockResolvedValue([
+      { model: 'b/dead', variant: 'high', rep: 0, n: DECIDER_CASES.length },
+    ]);
+    vi.mocked(listLaneFailures).mockResolvedValue([
+      {
+        run_id: runId,
+        model: 'b/dead',
+        variant: 'high',
+        rep: 0,
+        chunk: 27,
+        shard: 0,
+        failed_at: '2026-08-07T12:00:00.000Z',
+      },
+    ]);
+
+    await processDeadLetter(env, deadLetterMessage());
+
+    expect(markRunCompleted).toHaveBeenCalledWith(env.BENCH_DB, runId);
+    expect(markProfilesFailedForEntries).not.toHaveBeenCalled();
+    expect(markProfilesReadyForRun).toHaveBeenCalledWith(env.BENCH_DB, runId);
+  });
+
+  it('ignores messages for a run that is no longer running', async () => {
+    mockRunState([{ model: 'b/dead', variant: 'high' }], 'profile', 'failed');
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await processDeadLetter(env, deadLetterMessage());
+
+    expect(recordLaneFailure).not.toHaveBeenCalled();
+    expect(markRunCompleted).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('benchmark_deadletter_run_not_running')
+    );
+    warn.mockRestore();
+  });
+
+  it('drops malformed messages without recording', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {});
+
+    await processDeadLetter(env, { nope: true });
+
+    expect(recordLaneFailure).not.toHaveBeenCalled();
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining('benchmark_deadletter_invalid_message')
+    );
+    warn.mockRestore();
+  });
+
+  it('resolves the sole snapshot row variant for legacy variant-less messages', async () => {
+    mockRunState([{ model: 'b/dead', variant: 'high' }]);
+    const message = deadLetterMessage();
+    delete (message as { variant?: unknown }).variant;
+
+    await processDeadLetter(env, message);
+
+    expect(recordLaneFailure).toHaveBeenCalledWith(
+      env.BENCH_DB,
+      expect.objectContaining({ model: 'b/dead', variant: 'high' })
+    );
+  });
+});

--- a/services/auto-routing-benchmark/src/run-process-job.test.ts
+++ b/services/auto-routing-benchmark/src/run-process-job.test.ts
@@ -7,7 +7,9 @@ vi.mock('./db', async importOriginal => {
   const actual = await importOriginal<typeof DbModule>();
   return {
     ...actual,
-    countCaseResults: vi.fn(),
+    countCaseResultsByLane: vi.fn(),
+    listLaneFailures: vi.fn(),
+    recordLaneFailure: vi.fn(),
     existsNewerCompletedRun: vi.fn(),
     getCaseResults: vi.fn(),
     getExistingCaseResultIds: vi.fn(),
@@ -45,9 +47,11 @@ import {
   type CliRunResult,
 } from './cli-runner';
 import {
-  countCaseResults,
+  countCaseResultsByLane,
   getExistingCaseResultIds,
   getRunWithModels,
+  listLaneFailures,
+  recordLaneFailure,
   upsertCaseResult,
 } from './db';
 import { processJob } from './run';
@@ -129,7 +133,9 @@ beforeEach(() => {
     )
   );
   mockRunSnapshot();
-  vi.mocked(countCaseResults).mockResolvedValue(0);
+  vi.mocked(countCaseResultsByLane).mockResolvedValue([]);
+  vi.mocked(listLaneFailures).mockResolvedValue([]);
+  vi.mocked(recordLaneFailure).mockResolvedValue(undefined);
   vi.mocked(getExistingCaseResultIds).mockResolvedValue(new Set());
   vi.mocked(destroyDeciderCliContainer).mockResolvedValue(undefined);
   vi.mocked(warmUpCliContainer).mockResolvedValue(undefined);
@@ -243,7 +249,7 @@ describe('processJob — decider container availability failures', () => {
     await expect(processJob(env, deciderMessage())).rejects.toThrow(message);
 
     expect(upsertCaseResult).not.toHaveBeenCalled();
-    expect(countCaseResults).not.toHaveBeenCalled();
+    expect(countCaseResultsByLane).not.toHaveBeenCalled();
   });
 
   it('lets the queue retry warmup capacity failures before running cases', async () => {
@@ -255,7 +261,7 @@ describe('processJob — decider container availability failures', () => {
 
     expect(runDeciderCaseViaCli).not.toHaveBeenCalled();
     expect(upsertCaseResult).not.toHaveBeenCalled();
-    expect(countCaseResults).not.toHaveBeenCalled();
+    expect(countCaseResultsByLane).not.toHaveBeenCalled();
   });
 });
 
@@ -301,7 +307,7 @@ describe('processJob — decider chunk chaining', () => {
         },
       },
     ]);
-    expect(countCaseResults).not.toHaveBeenCalled();
+    expect(countCaseResultsByLane).not.toHaveBeenCalled();
   });
 
   it('enqueues the next chunk assigned to the same shard lane', async () => {
@@ -339,7 +345,7 @@ describe('processJob — decider chunk chaining', () => {
         },
       },
     ]);
-    expect(countCaseResults).not.toHaveBeenCalled();
+    expect(countCaseResultsByLane).not.toHaveBeenCalled();
   });
 
   it('does not rerun completed chunk cases or enqueue a fully completed next chunk', async () => {
@@ -402,7 +408,7 @@ describe('processJob — decider chunk chaining', () => {
     expect(destroyDeciderCliContainer).toHaveBeenCalledWith(env, {
       instanceName: `${runId}:${model}::0:3`,
     });
-    expect(countCaseResults).toHaveBeenCalled();
+    expect(countCaseResultsByLane).toHaveBeenCalled();
   });
 
   it('finalizes terminal chunks even when best-effort container destroy fails', async () => {
@@ -425,7 +431,7 @@ describe('processJob — decider chunk chaining', () => {
     expect(warn).toHaveBeenCalledWith(
       expect.stringContaining('benchmark_container_destroy_failed')
     );
-    expect(countCaseResults).toHaveBeenCalled();
+    expect(countCaseResultsByLane).toHaveBeenCalled();
     warn.mockRestore();
   });
 });

--- a/services/auto-routing-benchmark/src/run.ts
+++ b/services/auto-routing-benchmark/src/run.ts
@@ -13,9 +13,9 @@ import * as z from 'zod';
 import { getBenchmarkConfig } from './config';
 import { CLASSIFIER_CASES } from './datasets/classifier-cases';
 import { DECIDER_CASES } from './datasets/decider-cases';
-import type { RunModelRow } from './db';
+import type { RunModelRow, RunRow } from './db';
 import {
-  countCaseResults,
+  countCaseResultsByLane,
   exactPairKey,
   existsNewerCompletedRun,
   getCaseResults,
@@ -25,14 +25,17 @@ import {
   getRunWithModels,
   getSummaries,
   insertRun,
+  listLaneFailures,
   listPendingCurrentProfiles,
   listStaleRunningDeciderRunIds,
+  markProfilesFailedForEntries,
   markProfilesFailedForRun,
   markProfilesReadyForRun,
   markProfilesRunningForRun,
   markRunCompleted,
   markRunFailed,
   markStaleRunsFailed,
+  recordLaneFailure,
   replaceModelSummaries,
   saveRoutingTable,
   upsertCaseResult,
@@ -582,6 +585,7 @@ export async function startRun(
     // take effect without re-running any model. The state mirrors the rows
     // insertRun just wrote, so no re-read is needed.
     await finalizeRunIfComplete(env, runId, kind, {
+      status: 'running',
       maxConcurrency: config.maxConcurrency,
       minAccuracy: config.minAccuracy,
       switchCostFactor: config.switchCostFactor,
@@ -793,7 +797,69 @@ export async function processJob(env: Env, rawMessage: unknown): Promise<void> {
   }
 }
 
+/**
+ * Handle a dead-lettered benchmark job: record the lane death, then attempt
+ * finalization so a single dead lane cannot wedge its run. The queue handler
+ * must not let this throw — a poison DLQ message retrying forever would wedge
+ * the run again; the stale sweep remains the backstop.
+ */
+export async function processDeadLetter(env: Env, rawMessage: unknown): Promise<void> {
+  const parsed = BenchmarkJobMessageSchema.safeParse(rawMessage);
+  if (!parsed.success) {
+    console.warn(
+      JSON.stringify({
+        event: 'benchmark_deadletter_invalid_message',
+        error: parsed.error.message,
+        raw: JSON.stringify(rawMessage).slice(0, 200),
+      })
+    );
+    return;
+  }
+
+  const message = parsed.data;
+  const state = await getRunState(env, message.runId).catch(() => undefined);
+  if (!state || state.status !== 'running') {
+    // Run already completed/failed/swept — its lane accounting is settled.
+    console.warn(
+      JSON.stringify({ event: 'benchmark_deadletter_run_not_running', runId: message.runId })
+    );
+    return;
+  }
+
+  // Resolve the exact-pair variant like processDeciderJob does: an explicit
+  // message variant wins; a legacy variant-less message maps to the model's
+  // sole snapshot row.
+  const rowsForModel = state.models.filter(m => m.model === message.model);
+  const soleVariant = rowsForModel.length === 1 ? rowsForModel[0]?.variant : undefined;
+  const storedVariant =
+    message.variant !== undefined
+      ? variantToStorage(message.variant)
+      : (soleVariant ?? variantToStorage(null));
+
+  await recordLaneFailure(env.BENCH_DB, {
+    runId: message.runId,
+    model: message.model,
+    variant: storedVariant,
+    rep: message.rep ?? 0,
+    chunk: message.chunk ?? 0,
+    shard: message.shard ?? 0,
+  });
+  console.warn(
+    JSON.stringify({
+      event: 'benchmark_lane_dead',
+      runId: message.runId,
+      kind: message.kind,
+      model: message.model,
+      variant: variantFromStorage(storedVariant),
+      rep: message.rep ?? 0,
+      chunk: message.chunk ?? 0,
+    })
+  );
+  await finalizeRunIfComplete(env, message.runId, message.kind, state);
+}
+
 type RunState = {
+  status: RunRow['status'];
   maxConcurrency: number;
   minAccuracy: number;
   switchCostFactor: number;
@@ -813,6 +879,7 @@ async function getRunState(env: Env, runId: string): Promise<RunState> {
   if (!result) throw new Error(`unknown run ${runId}`);
   const { run, models } = result;
   return {
+    status: run.status,
     maxConcurrency: run.max_concurrency,
     minAccuracy: run.min_accuracy,
     switchCostFactor: run.switch_cost_factor,
@@ -1149,23 +1216,68 @@ export async function runCasesWithConcurrency<T>(
   await Promise.all(workers);
 }
 
+// Lane identity for completion accounting: one (model, variant, rep) chain of
+// chunk messages. All keys use storage-form variant ('' = default).
+function laneKey(model: string, variant: string, rep: number): string {
+  return `${model} ${variant} ${rep}`;
+}
+
+/** Failure reason written to profile entries whose lane dead-lettered. */
+export const PROFILE_LANE_DEAD_FAILURE_REASON =
+  'Benchmark lane dead-lettered (queue retries exhausted); retry to re-measure.';
+
 async function finalizeRunIfComplete(
   env: Env,
   runId: string,
   kind: BenchmarkKind,
-  // Run snapshot already loaded by the caller (startRun / processJob).
+  // Run snapshot already loaded by the caller (startRun / processJob / processDeadLetter).
   state: RunState
 ): Promise<void> {
   const enqueuedModels = state.models.filter(m => m.enqueued);
   const caseCount = kind === 'classifier' ? CLASSIFIER_CASES.length : DECIDER_CASES.length;
-  const expected = enqueuedModels.length * caseCount * state.repetitions;
-  const actual = await countCaseResults(env.BENCH_DB, runId);
 
-  if (actual < expected) return;
+  // Lane accounting: a lane is done when all its case rows exist, dead when
+  // one of its chunk messages dead-lettered (rows win — a message can die
+  // after its writes landed). The run finalizes once every lane is accounted
+  // for, so one dead lane no longer wedges the run until the stale sweep.
+  const [laneCounts, laneFailures] = await Promise.all([
+    countCaseResultsByLane(env.BENCH_DB, runId),
+    listLaneFailures(env.BENCH_DB, runId),
+  ]);
+  const countByLane = new Map(laneCounts.map(r => [laneKey(r.model, r.variant, r.rep), r.n]));
+  const deadLaneKeys = new Set(laneFailures.map(f => laneKey(f.model, f.variant, f.rep)));
+  const lanes = enqueuedModels.flatMap(m =>
+    Array.from({ length: state.repetitions }, (_, rep) => ({
+      model: m.model,
+      variant: m.variant,
+      rep,
+    }))
+  );
+  const isDone = (lane: { model: string; variant: string; rep: number }) =>
+    (countByLane.get(laneKey(lane.model, lane.variant, lane.rep)) ?? 0) >= caseCount;
+  const deadLanes = lanes.filter(lane => !isDone(lane));
+  if (deadLanes.some(lane => !deadLaneKeys.has(laneKey(lane.model, lane.variant, lane.rep)))) {
+    return;
+  }
+
+  // A platform run publishes one comparable artifact; a missing candidate
+  // would silently drop it from routing. Fail fast instead of publishing
+  // partial results or wedging until the 6h stale sweep.
+  if (deadLanes.length > 0 && state.purpose !== 'profile') {
+    const [first, ...rest] = deadLanes;
+    await failRunAndDrain(
+      env,
+      runId,
+      `lane dead-lettered: ${first.model} variant ${variantFromStorage(first.variant) ?? 'default'} rep ${first.rep}` +
+        (rest.length > 0 ? ` (+${rest.length} more)` : '')
+    );
+    return;
+  }
 
   // Two consumers may both see completion and both aggregate — harmless:
   // identical deterministic inputs → identical summaries; replaceModelSummaries
-  // is a batched delete+insert; markRunCompleted guards on status='running'.
+  // is a batched delete+insert; markRunCompleted and the per-entry profile
+  // transitions guard on status='running'.
   const rows = await getCaseResults(env.BENCH_DB, runId);
   // Fresh results (enqueued models). Carried summaries (skipped models) stay in
   // model_summaries with carried=true and are included via getSummaries below.
@@ -1176,7 +1288,23 @@ async function finalizeRunIfComplete(
   // Profile runs update the registry only — never publish platform artifacts,
   // never touch the classifier winner, never clear platform KV keys.
   if (state.purpose === 'profile') {
+    // Entries whose lanes all completed become ready; entries with a dead lane
+    // fail (retry re-admits them) without taking down the whole run. Fail
+    // first so the ready sweep only catches survivors; both statements keep
+    // the run_id + status='running' no-clobber guard.
+    const failedEntryKeys = new Set(deadLanes.map(l => `${l.model} ${l.variant}`));
+    const failedEntries = enqueuedModels
+      .filter(m => failedEntryKeys.has(`${m.model} ${m.variant}`))
+      .map(m => ({ model: m.model, variant: m.variant }));
     try {
+      if (failedEntries.length > 0) {
+        await markProfilesFailedForEntries(
+          env.BENCH_DB,
+          runId,
+          failedEntries,
+          PROFILE_LANE_DEAD_FAILURE_REASON
+        );
+      }
       await markProfilesReadyForRun(env.BENCH_DB, runId);
     } catch (error) {
       console.warn(
@@ -1193,6 +1321,7 @@ async function finalizeRunIfComplete(
         runId,
         kind,
         purpose: state.purpose,
+        failedEntries: failedEntries.length,
       })
     );
     try {

--- a/services/auto-routing-benchmark/src/run.ts
+++ b/services/auto-routing-benchmark/src/run.ts
@@ -1218,9 +1218,10 @@ export async function runCasesWithConcurrency<T>(
 }
 
 // Lane identity for completion accounting: one (model, variant, rep) chain of
-// chunk messages. All keys use storage-form variant ('' = default).
+// chunk messages. JSON tuple keys (storage-form variant) so model/variant
+// values can never collide across concatenation.
 function laneKey(model: string, variant: string, rep: number): string {
-  return `${model} ${variant} ${rep}`;
+  return JSON.stringify([model, variant, rep]);
 }
 
 /** Failure reason written to profile entries whose lane dead-lettered. */
@@ -1293,9 +1294,9 @@ async function finalizeRunIfComplete(
     // fail (retry re-admits them) without taking down the whole run. Fail
     // first so the ready sweep only catches survivors; both statements keep
     // the run_id + status='running' no-clobber guard.
-    const failedEntryKeys = new Set(deadLanes.map(l => `${l.model} ${l.variant}`));
+    const failedEntryKeys = new Set(deadLanes.map(l => JSON.stringify([l.model, l.variant])));
     const failedEntries = enqueuedModels
-      .filter(m => failedEntryKeys.has(`${m.model} ${m.variant}`))
+      .filter(m => failedEntryKeys.has(JSON.stringify([m.model, m.variant])))
       .map(m => ({ model: m.model, variant: m.variant }));
     try {
       if (failedEntries.length > 0) {

--- a/services/auto-routing-benchmark/src/run.ts
+++ b/services/auto-routing-benchmark/src/run.ts
@@ -799,9 +799,10 @@ export async function processJob(env: Env, rawMessage: unknown): Promise<void> {
 
 /**
  * Handle a dead-lettered benchmark job: record the lane death, then attempt
- * finalization so a single dead lane cannot wedge its run. The queue handler
- * must not let this throw — a poison DLQ message retrying forever would wedge
- * the run again; the stale sweep remains the backstop.
+ * finalization so a single dead lane cannot wedge its run. Malformed messages
+ * and terminal runs are settled cases and return normally; transient failures
+ * (e.g. D1) throw so the DLQ consumer retries — a death recorded without a
+ * completed finalization must be re-attempted, not acked away.
  */
 export async function processDeadLetter(env: Env, rawMessage: unknown): Promise<void> {
   const parsed = BenchmarkJobMessageSchema.safeParse(rawMessage);

--- a/services/auto-routing-benchmark/wrangler.jsonc
+++ b/services/auto-routing-benchmark/wrangler.jsonc
@@ -60,10 +60,12 @@
         "dead_letter_queue": "auto-routing-benchmark-dlq",
       },
       {
-        // Lane-death signal: a message here exhausted its retries. The handler
-        // records the lane failure and finalizes the run (profile runs complete
-        // per-entry; platform runs fail fast). Handler never throws, so retries
-        // only cover transient D1 reads; the stale sweep is the backstop.
+        // Lane-death signal: a message here exhausted its job retries. The
+        // handler records the lane failure and finalizes the run (profile runs
+        // complete per-entry; platform runs fail fast). A throw retries the
+        // message so a transient failure after recording still finalizes; a
+        // message still failing after max_retries is dropped (the DLQ has no
+        // DLQ) and the stale sweep is the backstop.
         "queue": "auto-routing-benchmark-dlq",
         "max_batch_size": 1,
         "max_retries": 2,

--- a/services/auto-routing-benchmark/wrangler.jsonc
+++ b/services/auto-routing-benchmark/wrangler.jsonc
@@ -59,6 +59,17 @@
         "max_concurrency": 100,
         "dead_letter_queue": "auto-routing-benchmark-dlq",
       },
+      {
+        // Lane-death signal: a message here exhausted its retries. The handler
+        // records the lane failure and finalizes the run (profile runs complete
+        // per-entry; platform runs fail fast). Handler never throws, so retries
+        // only cover transient D1 reads; the stale sweep is the backstop.
+        "queue": "auto-routing-benchmark-dlq",
+        "max_batch_size": 1,
+        "max_retries": 2,
+        "retry_delay": 60,
+        "max_concurrency": 5,
+      },
     ],
   },
   "kv_namespaces": [


### PR DESCRIPTION
## Summary

Today a decider run wedges when a queue message exhausts its 6 retries and dead-letters: the lane's chunk chain is gone, `finalizeRunIfComplete` waits forever for rows that can never exist, and the 6h stale sweep then fails the **entire** run — including every cleanly measured model. Observed in prod: profile run `profile-2026-08-07T09-24-27-661Z` stuck for hours with 32/33 entries fully measured; only `cohere/north-mini-code:free` dead-lettered.

The worker now consumes `auto-routing-benchmark-dlq` itself. Each dead message is recorded in a new `run_lane_failures` table, and run finalization becomes lane-aware: a run completes once every (model, variant, rep) lane has either all its case rows **or** a recorded lane death.

- **Profile runs** complete per-entry: finished entries go `ready`; entries with a dead lane go `failed` (owner Retry re-admits, quota-charged). One failing model no longer fails the other owners' entries.
- **Platform runs** fail fast with the dead lane named in the run error. No partial publish — a silently missing candidate would drop it from routing decisions; the previous routing table stays live.
- The 6h stale sweep stays as backstop for deaths that never reach the DLQ (e.g. a throwing consumer); the DLQ handler never throws and always acks.

## Verification

- [x] Automated only: 21 files / 249 tests pass, incl. new honest-SQLite tests for the idempotent insert and per-entry no-clobber guard, and dead-letter flow tests (per-entry profile completion, platform fail-fast, rows-win-over-failure-record, terminal-run skip).
- [ ] Not manually tested against a live queue (requires a deploy); risk is contained to the new DLQ consumer and finalize accounting.

## Visual Changes

N/A

## Reviewer Notes

- Deploy applies migration `0008_easy_doctor_faustus.sql` via `predeploy`.
- On deploy, the DLQ consumer will drain the current incident's 3 dead cohere messages (still in the DLQ, 4-day retention): the wedged profile run will then complete automatically with 32 entries ready and cohere failed.
- Dead-lane resurrection (re-enqueue once before declaring death) was deliberately deferred to keep this change tight.