### PR TITLE
fix(admin): detail custom LLM validation errors

### DIFF
--- a/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
+++ b/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
@@ -28,6 +28,7 @@ import {
 import { CustomLlmDefinitionSchema } from '@kilocode/db/schema-types';
 import type { CustomLlmDefinition } from '@kilocode/db/schema-types';
 import { deepStrict } from '@/lib/zod/deep-strict';
+import { formatZodError } from '@/lib/zod/format-zod-error';
 import { CUSTOM_LLM_PREFIX } from '@/lib/ai-gateway/model-utils';
 import { toast } from 'sonner';
 import { Plus, Pencil } from 'lucide-react';
@@ -92,8 +93,17 @@ export function CustomLlmsContent() {
   }, []);
 
   const handleSave = useCallback(async () => {
-    if (!editor.publicId.trim()) {
+    const trimmedPublicId = editor.publicId.trim();
+    if (!trimmedPublicId) {
       setEditor(prev => ({ ...prev, validationError: 'public_id is required' }));
+      return;
+    }
+
+    if (!trimmedPublicId.startsWith(CUSTOM_LLM_PREFIX)) {
+      setEditor(prev => ({
+        ...prev,
+        validationError: `public_id must start with "${CUSTOM_LLM_PREFIX}"`,
+      }));
       return;
     }
 
@@ -107,22 +117,19 @@ export function CustomLlmsContent() {
 
     const result = StrictCustomLlmDefinitionSchema.safeParse(parsed);
     if (!result.success) {
-      const messages = result.error.issues
-        .map(issue => `${issue.path.join('.')}: ${issue.message}`)
-        .join('\n');
-      setEditor(prev => ({ ...prev, validationError: messages }));
+      setEditor(prev => ({ ...prev, validationError: formatZodError(result.error) }));
       return;
     }
 
     try {
       await upsertMutation.mutateAsync({
-        public_id: editor.publicId,
+        public_id: trimmedPublicId,
         definition: result.data,
       });
       toast.success(editor.mode === 'create' ? 'Custom LLM created' : 'Custom LLM updated');
       closeEditor();
     } catch (error) {
-      toast.error(error instanceof Error ? error.message : 'Failed to save');
+      toast.error(formatZodError(error));
     }
   }, [editor, upsertMutation, closeEditor]);
 
@@ -132,7 +139,7 @@ export function CustomLlmsContent() {
         await deleteMutation.mutateAsync({ public_id: publicId });
         toast.success('Custom LLM deleted');
       } catch (error) {
-        toast.error(error instanceof Error ? error.message : 'Failed to delete');
+        toast.error(formatZodError(error));
       }
     },
     [deleteMutation]

--- a/apps/web/src/lib/zod/format-zod-error.test.ts
+++ b/apps/web/src/lib/zod/format-zod-error.test.ts
@@ -1,0 +1,207 @@
+import { describe, expect, test } from '@jest/globals';
+import { z } from 'zod';
+import { formatZodIssue, formatZodIssues, formatZodError } from './format-zod-error';
+import { deepStrict } from './deep-strict';
+import { CustomLlmDefinitionSchema } from '@kilocode/db/schema-types';
+
+describe('formatZodIssue', () => {
+  test('formats issue with path', () => {
+    const formatted = formatZodIssue({
+      code: 'invalid_type',
+      path: ['internal_id'],
+      message: 'Too small',
+    });
+    expect(formatted).toBe('internal_id: Too small');
+  });
+
+  test('formats issue with empty path without leading colon', () => {
+    const formatted = formatZodIssue({
+      code: 'custom',
+      path: [],
+      message: 'Invalid configuration',
+    });
+    expect(formatted).toBe('Invalid configuration');
+  });
+
+  test('formats unrecognized_keys at top level', () => {
+    const formatted = formatZodIssue({
+      code: 'unrecognized_keys',
+      path: [],
+      keys: ['dispaly_name'],
+    });
+    expect(formatted).toBe('Unrecognized key: "dispaly_name"');
+  });
+
+  test('formats multiple unrecognized_keys with nested path', () => {
+    const formatted = formatZodIssue({
+      code: 'unrecognized_keys',
+      path: ['pricing'],
+      keys: ['extra1', 'extra2'],
+    });
+    expect(formatted).toBe('pricing: Unrecognized keys: "extra1", "extra2"');
+  });
+});
+
+describe('formatZodIssues with unions', () => {
+  const schema = deepStrict(CustomLlmDefinitionSchema);
+
+  test('formats initial definition errors cleanly without ": Invalid input"', () => {
+    const initialDefinition = {
+      internal_id: '',
+      display_name: '',
+      context_length: 0,
+      max_completion_tokens: 0,
+      base_url: '',
+      api_key: '',
+      organization_ids: [],
+    };
+
+    const result = schema.safeParse(initialDefinition);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = formatZodIssues(result.error.issues);
+      expect(messages).not.toContain(': Invalid input');
+      expect(messages).not.toContain('Invalid input');
+      expect(messages).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('internal_id'),
+          expect.stringContaining('base_url'),
+        ])
+      );
+    }
+  });
+
+  test('picks the API key branch when api_key is present and fields have typos', () => {
+    const typoInput = {
+      internal_id: 'model-1',
+      dispaly_name: 'Typo Name',
+      context_length: 1000,
+      max_completion_tokens: 100,
+      base_url: 'https://example.com',
+      api_key: 'secret',
+      organization_ids: [],
+    };
+
+    const result = schema.safeParse(typoInput);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = formatZodIssues(result.error.issues);
+      expect(messages).not.toContain(': Invalid input');
+      expect(messages).toContain('Unrecognized key: "dispaly_name"');
+      expect(messages.some(m => m.includes('display_name'))).toBe(true);
+      expect(messages.some(m => m.includes('google_service_account'))).toBe(false);
+    }
+  });
+
+  test('picks the Google service account branch when google_service_account is present', () => {
+    const gsaInput = {
+      internal_id: 'model-1',
+      display_name: 'Vertex Gemini',
+      context_length: 1000,
+      max_completion_tokens: 100,
+      base_url: 'https://example.com',
+      organization_ids: [],
+      google_service_account: {
+        type: 'service_account',
+        project_id: 'proj',
+        private_key_id: 'key-id',
+        private_key: 'pk',
+        client_email: 'invalid-email',
+        client_id: '123',
+        auth_uri: 'https://accounts.google.com',
+        token_uri: 'https://oauth2.googleapis.com',
+        auth_provider_x509_cert_url: 'https://example.com',
+        client_x509_cert_url: 'https://example.com',
+      },
+    };
+
+    const result = schema.safeParse(gsaInput);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = formatZodIssues(result.error.issues);
+      expect(messages).not.toContain(': Invalid input');
+      expect(messages.some(m => m.includes('google_service_account.client_email'))).toBe(true);
+      expect(messages.some(m => m.includes('api_key'))).toBe(false);
+    }
+  });
+
+  test('shows both authentication options when neither is provided', () => {
+    const noAuthInput = {
+      internal_id: 'model-1',
+      display_name: 'Model 1',
+      context_length: 1000,
+      max_completion_tokens: 100,
+      base_url: 'https://example.com',
+      organization_ids: [],
+    };
+
+    const result = schema.safeParse(noAuthInput);
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = formatZodIssues(result.error.issues);
+      expect(messages).not.toContain(': Invalid input');
+      expect(messages.some(m => m.includes('api_key'))).toBe(true);
+      expect(messages.some(m => m.includes('google_service_account'))).toBe(true);
+    }
+  });
+
+  test('handles nested unions with path prefixes', () => {
+    const nestedSchema = z.object({
+      config: z.union([
+        z.object({ mode: z.literal('a'), aValue: z.string() }),
+        z.object({ mode: z.literal('b'), bValue: z.number() }),
+      ]),
+    });
+
+    const result = nestedSchema.safeParse({ config: { mode: 'a', aValue: 123 } });
+    expect(result.success).toBe(false);
+    if (!result.success) {
+      const messages = formatZodIssues(result.error.issues);
+      expect(messages).toEqual(['config.aValue: Invalid input: expected string, received number']);
+    }
+  });
+});
+
+describe('formatZodError', () => {
+  test('formats ZodError instance', () => {
+    const schema = z.object({ name: z.string() });
+    const result = schema.safeParse({ name: 123 });
+    if (!result.success) {
+      const formatted = formatZodError(result.error);
+      expect(formatted).toBe('name: Invalid input: expected string, received number');
+    }
+  });
+
+  test('formats JSON-encoded TRPC issues string', () => {
+    const jsonError = JSON.stringify([
+      {
+        code: 'custom',
+        message: 'public_id must start with "custom-llm/"',
+        path: ['public_id'],
+      },
+    ]);
+    const formatted = formatZodError(new Error(jsonError));
+    expect(formatted).toBe('public_id: public_id must start with "custom-llm/"');
+  });
+
+  test('formats TRPC data.zodError shape', () => {
+    const trpcError = {
+      message: 'BAD_REQUEST',
+      data: {
+        zodError: {
+          formErrors: [],
+          fieldErrors: {
+            public_id: ['public_id is required'],
+          },
+        },
+      },
+    };
+    const formatted = formatZodError(trpcError);
+    expect(formatted).toBe('public_id: public_id is required');
+  });
+
+  test('falls back to plain Error message', () => {
+    const formatted = formatZodError(new Error('Network error'));
+    expect(formatted).toBe('Network error');
+  });
+});

--- a/apps/web/src/lib/zod/format-zod-error.ts
+++ b/apps/web/src/lib/zod/format-zod-error.ts
@@ -1,0 +1,126 @@
+import { z } from 'zod';
+
+export type ZodIssueLike =
+  | z.core.$ZodIssue
+  | {
+      code: string;
+      message?: string;
+      path?: readonly PropertyKey[];
+      keys?: string[];
+      errors?: readonly (readonly ZodIssueLike[])[];
+    };
+
+export function formatZodIssue(
+  issue: ZodIssueLike,
+  parentPath: readonly (string | number | symbol)[] = []
+): string {
+  const fullPath = [...parentPath, ...(issue.path ?? [])];
+  const pathStr = fullPath.length > 0 ? fullPath.map(String).join('.') : '';
+
+  if (issue.code === 'unrecognized_keys' && Array.isArray(issue.keys) && issue.keys.length > 0) {
+    const keysStr = issue.keys.map(k => `"${k}"`).join(', ');
+    const label = issue.keys.length === 1 ? 'Unrecognized key' : 'Unrecognized keys';
+    return pathStr ? `${pathStr}: ${label}: ${keysStr}` : `${label}: ${keysStr}`;
+  }
+
+  const message = issue.message || 'Invalid input';
+  return pathStr ? `${pathStr}: ${message}` : message;
+}
+
+export function formatZodIssues(
+  issues: readonly ZodIssueLike[],
+  parentPath: readonly (string | number | symbol)[] = []
+): string[] {
+  const messages: string[] = [];
+
+  for (const issue of issues) {
+    const currentPath = [...parentPath, ...(issue.path ?? [])];
+
+    if (issue.code === 'invalid_union' && Array.isArray(issue.errors) && issue.errors.length > 0) {
+      const branchIssueLists = issue.errors;
+      const minErrors = Math.min(...branchIssueLists.map(list => list.length));
+      const candidateBranches = branchIssueLists.filter(list => list.length === minErrors);
+
+      if (candidateBranches.length === 1) {
+        messages.push(...formatZodIssues(candidateBranches[0], currentPath));
+      } else {
+        const branchMessages = new Set<string>();
+        for (const branch of candidateBranches) {
+          for (const msg of formatZodIssues(branch, currentPath)) {
+            branchMessages.add(msg);
+          }
+        }
+        messages.push(...Array.from(branchMessages));
+      }
+      continue;
+    }
+
+    messages.push(formatZodIssue(issue, parentPath));
+  }
+
+  return messages;
+}
+
+export function formatZodError(error: unknown): string {
+  if (error instanceof z.ZodError) {
+    const lines = formatZodIssues(error.issues as ZodIssueLike[]);
+    return lines.length > 0 ? lines.join('\n') : error.message;
+  }
+
+  if (
+    typeof error === 'object' &&
+    error !== null &&
+    'data' in error &&
+    typeof (error as { data?: unknown }).data === 'object' &&
+    (error as { data?: { zodError?: unknown } }).data?.zodError
+  ) {
+    const zodError = (
+      error as {
+        data: {
+          zodError: { formErrors?: string[]; fieldErrors?: Record<string, string[]> };
+        };
+      }
+    ).data.zodError;
+
+    const messages: string[] = [];
+    if (Array.isArray(zodError.formErrors)) {
+      for (const msg of zodError.formErrors) {
+        if (msg && msg !== 'Invalid input') messages.push(msg);
+      }
+    }
+    if (zodError.fieldErrors && typeof zodError.fieldErrors === 'object') {
+      for (const [field, fieldMessages] of Object.entries(zodError.fieldErrors)) {
+        if (Array.isArray(fieldMessages)) {
+          for (const msg of fieldMessages) {
+            messages.push(`${field}: ${msg}`);
+          }
+        }
+      }
+    }
+    if (messages.length > 0) {
+      return messages.join('\n');
+    }
+  }
+
+  if (typeof error === 'string') {
+    const trimmed = error.trim();
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed);
+        if (Array.isArray(parsed) && parsed.length > 0 && parsed[0]?.code) {
+          const lines = formatZodIssues(parsed as ZodIssueLike[]);
+          if (lines.length > 0) return lines.join('\n');
+        }
+      } catch {
+        // Not JSON
+      }
+    }
+    return error;
+  }
+
+  if (error instanceof Error) {
+    return formatZodError(error.message);
+  }
+
+  return 'Validation failed';
+}


### PR DESCRIPTION
### Summary
- Introduce `formatZodError` / `formatZodIssues` to unwrap and format Zod validation issues, including `invalid_union` branches and `unrecognized_keys`.
- Fix the Custom LLM editor so validation failures on union schemas (such as API key vs Google service account auth) surface actionable field-level error messages instead of `: Invalid input`.
- Validate `public_id` prefix client-side before submission for immediate feedback.