### PR TITLE
chore(ci): temporarily disable automatic CodeQL runs

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,14 +1,6 @@
 name: CodeQL
 
 on:
-  push:
-    branches:
-      - main
-  pull_request:
-    branches:
-      - main
-  schedule:
-    - cron: '24 3 * * 1'
   workflow_dispatch:
 
 concurrency:


### PR DESCRIPTION
## Summary

- stop CodeQL from running automatically on pushes and pull requests
- remove the weekly scheduled scan
- retain `workflow_dispatch` so CodeQL remains available for manual runs

## Validation

- `git diff --check origin/main...HEAD`