### PR TITLE
fix(mobile): route create_session ids through the SDK runtime shim

### DIFF
--- a/packages/cloud-agent-sdk/src/cli-live-transport.test.ts
+++ b/packages/cloud-agent-sdk/src/cli-live-transport.test.ts
@@ -7,6 +7,7 @@ import type {
   RemoteModelState,
 } from './remote-model-catalog';
 import type { RemoteCommandState } from './remote-command-catalog';
+import { configureCloudAgentSdkRuntime, resetCloudAgentSdkRuntime } from './runtime';
 import {
   CommandDeliveredError,
   UserWebCommandError,
@@ -2687,6 +2688,37 @@ describe('CliLiveTransport createSession', () => {
     expect(secondMutationId).toBeDefined();
     expect(secondMutationId).not.toBe(firstMutationId);
     transport.destroy();
+  });
+
+  it('takes the mutationId from the configured runtime, not the global crypto', async () => {
+    // Hermes (React Native) has no global `crypto` binding, so a bare
+    // `crypto.randomUUID()` throws "Property crypto does not exist" and /new
+    // fails. Every id in this package must go through the runtime shim.
+    configureCloudAgentSdkRuntime({ randomUUID: () => 'runtime-uuid' });
+    try {
+      const connection = createConnection();
+      jest
+        .mocked(connection.sendCommand)
+        .mockResolvedValue({ protocolVersion: 1, sessionID: NEW_KILO_SESSION_ID });
+      const { transport, userWebConnection } = createTransportWithSinks({ connection });
+
+      transport.connect();
+      emitOwner(connection);
+      await Promise.resolve();
+      await Promise.resolve();
+      await Promise.resolve();
+
+      jest.mocked(userWebConnection.sendCommand).mockClear();
+      await transport.createSession?.();
+
+      const createCall = jest
+        .mocked(userWebConnection.sendCommand)
+        .mock.calls.find(([, command]) => command === 'create_session');
+      expect(createCall?.[4]).toBe('runtime-uuid');
+      transport.destroy();
+    } finally {
+      resetCloudAgentSdkRuntime();
+    }
   });
 });
 

--- a/packages/cloud-agent-sdk/src/cli-live-transport.ts
+++ b/packages/cloud-agent-sdk/src/cli-live-transport.ts
@@ -5,6 +5,7 @@
 import { normalizeCliEvent, isChatEvent } from './normalizer';
 import { parseRemoteCommandCatalog, type RemoteCommandState } from './remote-command-catalog';
 import { parseCreateSessionResponse } from './create-session';
+import { cloudAgentSdkRuntime } from './runtime';
 import { parseExitSessionResponse } from './exit-session';
 import {
   cliConnectionDataSchema,
@@ -875,7 +876,7 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
         // snapshotted before the await and SESSION_OWNER_CHANGED is handled.
         // Extended fields degrade via a single bare retry on the exact
         // old-CLI delivered error; other failures are hard rejects.
-        const mutationId = input?.mutationId ?? crypto.randomUUID();
+        const mutationId = input?.mutationId ?? cloudAgentSdkRuntime.randomUUID();
         const wireData = buildCreateSessionWireData(input);
         const hasExtendedFields =
           wireData.agent !== undefined ||
@@ -895,7 +896,7 @@ function createCliLiveTransport(config: CliLiveTransportConfig): TransportFactor
             result = await sendCommand(
               'create_session',
               { protocolVersion: 1 },
-              crypto.randomUUID()
+              cloudAgentSdkRuntime.randomUUID()
             );
           } else {
             throw error;


### PR DESCRIPTION
## Problem

`/new` in a remote CLI session on mobile fails with **"Property crypto does not exist"**.

Hermes has no global `crypto` binding. `createSession` in `@kilocode/cloud-agent-sdk` called `crypto.randomUUID()` directly, so the call threw before the command reached the CLI.

## Fix

The package already owns a runtime shim (`packages/cloud-agent-sdk/src/runtime.ts`) for exactly this. The mobile app configures it with `expo-crypto` in `apps/mobile/src/lib/cloud-agent-runtime.ts`.

`cli-live-transport.ts:879` and `:899` were the only two call sites in the package that bypassed the shim. Both now use `cloudAgentSdkRuntime.randomUUID()`.

## Test

New case in `cli-live-transport.test.ts` configures the runtime and asserts the `create_session` mutationId comes from it. Verified the test fails on the old code and passes on the new code.

## Checks

- `pnpm test` (cloud-agent-sdk): 107 passed
- `pnpm typecheck` (cloud-agent-sdk): clean
- `pnpm lint`: 0 warnings, 0 errors