### PR TITLE
fix(mobile): no keyboard on share, no needless Play device filtering

### DIFF
--- a/apps/mobile/plugins/withAndroidManifestFix.js
+++ b/apps/mobile/plugins/withAndroidManifestFix.js
@@ -1,19 +1,44 @@
 const { withAndroidManifest } = require('expo/config-plugins');
 
 /**
+ * Features Google Play treats as required because a permission implies them.
+ * The app declares CAMERA, RECORD_AUDIO, ACCESS_FINE/COARSE_LOCATION and
+ * ACCESS_WIFI_STATE, so Play hides the listing ("This app won't work for your
+ * device") on every device that lacks one. All five are optional to this app,
+ * so declare them with required="false".
+ * https://developer.android.com/guide/topics/manifest/uses-feature-element
+ */
+const OPTIONAL_FEATURES = [
+  'android.hardware.camera',
+  'android.hardware.camera.autofocus',
+  'android.hardware.microphone',
+  'android.hardware.location',
+  'android.hardware.wifi',
+];
+
+/**
  * Resolves manifest merger conflict between expo-secure-store and AppsFlyer SDK,
- * which both declare dataExtractionRules and fullBackupContent on <application>.
+ * which both declare dataExtractionRules and fullBackupContent on <application>,
+ * and stops Google Play from filtering devices on implied hardware features.
  */
 const withAndroidManifestFix = config => {
   return withAndroidManifest(config, config => {
-    const application = config.modResults.manifest.application?.[0];
+    const manifest = config.modResults.manifest;
+    const application = manifest.application?.[0];
     if (!application) return config;
 
     // Ensure tools namespace is declared
-    config.modResults.manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
+    manifest.$['xmlns:tools'] = 'http://schemas.android.com/tools';
 
     // Add tools:replace to resolve the conflicting attributes
     application.$['tools:replace'] = 'android:dataExtractionRules,android:fullBackupContent';
+
+    const features = (manifest['uses-feature'] ??= []);
+    const declared = new Set(features.map(feature => feature.$?.['android:name']));
+    for (const name of OPTIONAL_FEATURES) {
+      if (declared.has(name)) continue;
+      features.push({ $: { 'android:name': name, 'android:required': 'false' } });
+    }
 
     return config;
   });

--- a/apps/mobile/src/components/agents/new-session-prompt.tsx
+++ b/apps/mobile/src/components/agents/new-session-prompt.tsx
@@ -257,7 +257,9 @@ export function NewSessionPrompt({
           editable={control.inputEditable}
           maxLength={PROMPT_INPUT_MAX_CHARS}
           accessibilityState={{ disabled: control.inputAccessibilityDisabled }}
-          autoFocus
+          // A shared payload prefills this input, so raising the keyboard on
+          // arrival hides the attachment strip and the Start button.
+          autoFocus={shareId === undefined || shareId === ''}
         />
         <View className="flex-row items-center justify-between pb-2">
           <View className="flex-row items-center gap-1">


### PR DESCRIPTION
## Keyboard on share

`NewSessionPrompt` set `autoFocus` unconditionally. Sharing an image or text
into a new session prefilled the input and then raised the keyboard over the
attachment strip and the Start button. `autoFocus` now applies only when the
screen opens without a share payload.

Same effect on "continue in a new session", which also arrives with a seeded
prompt. That is intended: a prefilled input does not need the keyboard.

## Play device filtering

The shipped AAB (1.0.3, build 132) declares **no** `<uses-feature>`, so Google
Play derives required features from the permissions:

| Permission | Implied required feature |
| --- | --- |
| `CAMERA` | `android.hardware.camera`, `android.hardware.camera.autofocus` |
| `RECORD_AUDIO` | `android.hardware.microphone` |
| `ACCESS_FINE/COARSE_LOCATION` | `android.hardware.location` |
| `ACCESS_WIFI_STATE` | `android.hardware.wifi` |

Play hides the listing on every device that misses one, and shows "This app
won't work for your device". All five are optional to the app, so
`withAndroidManifestFix` now declares them with `required="false"`.

Verified with `expo prebuild -p android`: the five entries reach
`android/app/src/main/AndroidManifest.xml`. No library declares `uses-feature`,
so the merger cannot raise them back to `required="true"`.

## Rest of the AAB is clean

`minSdkVersion=24`, `targetSdkVersion=36`, four ABIs, every 64-bit `.so` is
16 KB page aligned, no `compatible-screens`, no required `uses-library`.