### PR TITLE
fix(ai-gateway): increase sync-providers cron timeout to 8 minutes

### DIFF
--- a/apps/web/src/app/api/cron/sync-providers/route.test.ts
+++ b/apps/web/src/app/api/cron/sync-providers/route.test.ts
@@ -15,12 +15,16 @@ jest.mock('@/lib/ai-gateway/providers/openrouter/sync-providers', () => ({
 
 import { syncAndStoreProviders } from '@/lib/ai-gateway/providers/openrouter/sync-providers';
 import { emitScheduledJobEvent } from '@kilocode/worker-utils/scheduled-job-observability';
-import { GET } from './route';
+import { GET, maxDuration } from './route';
 
 const mockEmitScheduledJobEvent = jest.mocked(emitScheduledJobEvent);
 
 describe('GET /api/cron/sync-providers', () => {
   beforeEach(() => jest.clearAllMocks());
+
+  it('exports maxDuration of 8 minutes (480 seconds)', () => {
+    expect(maxDuration).toBe(480);
+  });
 
   it('emits one event at the cron boundary with aggregate provider counts', async () => {
     jest.mocked(syncAndStoreProviders).mockResolvedValue({

--- a/apps/web/src/app/api/cron/sync-providers/route.ts
+++ b/apps/web/src/app/api/cron/sync-providers/route.ts
@@ -9,6 +9,10 @@ import {
 import { CRON_SECRET } from '@/lib/config.server';
 import { syncAndStoreProviders } from '@/lib/ai-gateway/providers/openrouter/sync-providers';
 
+// The cron job runs every 10 minutes, so if increasing the timeout beyond 8 minutes
+// becomes necessary, the cron schedule in vercel.json should probably be adjusted as well.
+export const maxDuration = 480;
+
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');
   if (!CRON_SECRET || authHeader !== `Bearer ${CRON_SECRET}`) {


### PR DESCRIPTION
## Summary
Increases `maxDuration` for the `/api/cron/sync-providers` serverless function to 8 minutes (480 seconds) to prevent `TimeoutError` aborts.

The provider sync job fetches models and endpoints from 60+ OpenRouter providers and multiple direct BYOK upstreams before persisting snapshots and syncing Redis. Without an explicit `maxDuration`, the function timed out at the default ~30s limit, aborting mid-execution and preventing downstream direct BYOK models (including newly added models such as `ollama-cloud/deepseek-v4-flash:0731`) from syncing to Redis.

A comment has also been added noting that the cron job runs every 10 minutes, so if increasing the timeout beyond 8 minutes becomes necessary in the future, the schedule in `vercel.json` should be adjusted accordingly.