### PR TITLE
feat(admin): track and display full sync completion timestamp in Redis

### DIFF
--- a/apps/web/src/app/admin/sync-providers/SyncProvidersContent.tsx
+++ b/apps/web/src/app/admin/sync-providers/SyncProvidersContent.tsx
@@ -12,6 +12,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/com
 type SyncResult = {
   id: number;
   generated_at: string;
+  completed_at?: string;
   total_providers: number;
   total_models: number;
   direct_byok_model_counts: Record<string, number>;
@@ -54,13 +55,31 @@ export function SyncProvidersContent() {
       </p>
 
       {lastSync && (
-        <p className="text-muted-foreground text-sm">
-          Last successful sync{' '}
-          <span title={new Date(lastSync.generated_at).toLocaleString()}>
-            {formatDistanceToNow(new Date(lastSync.generated_at), { addSuffix: true })}
-          </span>{' '}
-          — {lastSync.total_providers} providers, {lastSync.total_models} models.
-        </p>
+        <div className="text-muted-foreground flex flex-col gap-1 text-sm">
+          {lastSync.completed_at ? (
+            <p>
+              Last full sync completed{' '}
+              <span
+                className="font-medium text-foreground"
+                title={new Date(lastSync.completed_at).toLocaleString()}
+              >
+                {formatDistanceToNow(new Date(lastSync.completed_at), { addSuffix: true })}
+              </span>{' '}
+              ({new Date(lastSync.completed_at).toLocaleString()})
+            </p>
+          ) : (
+            <p className="text-amber-500">No completed full run timestamp recorded in Redis yet.</p>
+          )}
+          {lastSync.generated_at && (
+            <p>
+              Database snapshot generated{' '}
+              <span title={new Date(lastSync.generated_at).toLocaleString()}>
+                {formatDistanceToNow(new Date(lastSync.generated_at), { addSuffix: true })}
+              </span>{' '}
+              — {lastSync.total_providers} providers, {lastSync.total_models} models.
+            </p>
+          )}
+        </div>
       )}
 
       <Card>
@@ -89,7 +108,15 @@ export function SyncProvidersContent() {
               <p className="font-medium">Last sync result</p>
               <ul className="text-muted-foreground mt-2 space-y-1">
                 <li>Row ID: {lastResult.id}</li>
-                <li>Generated at: {new Date(lastResult.generated_at).toLocaleString()}</li>
+                <li>
+                  Database snapshot generated at:{' '}
+                  {new Date(lastResult.generated_at).toLocaleString()}
+                </li>
+                {lastResult.completed_at && (
+                  <li>
+                    Full sync completed at: {new Date(lastResult.completed_at).toLocaleString()}
+                  </li>
+                )}
                 <li>Providers: {lastResult.total_providers}</li>
                 <li>Models: {lastResult.total_models}</li>
                 {Object.entries(lastResult.direct_byok_model_counts).map(([provider, count]) => (

--- a/apps/web/src/app/api/cron/sync-providers/route.test.ts
+++ b/apps/web/src/app/api/cron/sync-providers/route.test.ts
@@ -26,6 +26,7 @@ describe('GET /api/cron/sync-providers', () => {
     jest.mocked(syncAndStoreProviders).mockResolvedValue({
       id: 1,
       generated_at: '2026-07-20T00:00:00.000Z',
+      completed_at: '2026-07-20T00:05:00.000Z',
       total_models: 42,
       total_providers: 12,
       direct_byok_model_counts: {},

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -28,6 +28,7 @@ import { redisClient } from '@/lib/redis';
 import {
   GATEWAY_METADATA_REDIS_KEYS,
   type RedisKey,
+  SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY,
   vercelInferenceProvidersRedisKey,
 } from '@/lib/redis-keys';
 import {
@@ -545,9 +546,13 @@ export async function syncAndStoreProviders() {
   const direct_byok_model_counts = await syncDirectByokModels();
   console.log('[syncAndStoreProviders] direct-byok model counts:', direct_byok_model_counts);
 
+  const completed_at = new Date().toISOString();
+  await redisClient.set(SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY, completed_at);
+
   return {
     id: result.id,
     generated_at: result.data.generated_at,
+    completed_at,
     total_models: result.data.total_models,
     total_providers: result.data.total_providers,
     direct_byok_model_counts,

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -19,6 +19,10 @@ export const BLACKLIST_DOMAINS_REDIS_KEY = redisKey('admin:blacklisted-domains')
 
 export const VERCEL_ROUTING_REDIS_KEY = redisKey('ai-gateway:vercel-routing-percentage');
 
+export const SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY = redisKey(
+  'ai-gateway:sync-providers:last-completed-at'
+);
+
 export const GATEWAY_METADATA_REDIS_KEYS = {
   allProviders: redisKey('ai-gateway.metadata:all-providers'),
   // Lightweight lists of language model ids used for existence checks without

--- a/apps/web/src/routers/admin-router.ts
+++ b/apps/web/src/routers/admin-router.ts
@@ -33,6 +33,8 @@ import { isNewSession } from '@/lib/cloud-agent/session-type';
 import { fetchSessionSnapshot } from '@/lib/session-ingest-client';
 import { sortSessionMessagesForDisplay } from '@/lib/cloud-agent-next/message-ordering';
 import { syncAndStoreProviders } from '@/lib/ai-gateway/providers/openrouter/sync-providers';
+import { redisClient } from '@/lib/redis';
+import { SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY } from '@/lib/redis-keys';
 import { adminAppBuilderRouter } from '@/routers/admin-app-builder-router';
 import { adminDeploymentsRouter } from '@/routers/admin-deployments-router';
 import { adminKiloclawInstancesRouter } from '@/routers/admin-kiloclaw-instances-router';
@@ -2076,17 +2078,21 @@ export const adminRouter = createTRPCRouter({
       return result;
     }),
     getLastSync: adminProcedure.query(async () => {
-      const [latest] = await db
-        .select({ id: modelsByProvider.id, data: modelsByProvider.data })
-        .from(modelsByProvider)
-        .orderBy(desc(modelsByProvider.id))
-        .limit(1);
-      if (!latest) return null;
+      const [[latest], lastCompletedAt] = await Promise.all([
+        db
+          .select({ id: modelsByProvider.id, data: modelsByProvider.data })
+          .from(modelsByProvider)
+          .orderBy(desc(modelsByProvider.id))
+          .limit(1),
+        redisClient.get<string>(SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY),
+      ]);
+      if (!latest && !lastCompletedAt) return null;
       return {
-        id: latest.id,
-        generated_at: latest.data.generated_at,
-        total_providers: latest.data.total_providers,
-        total_models: latest.data.total_models,
+        id: latest?.id ?? null,
+        generated_at: latest?.data.generated_at ?? null,
+        completed_at: lastCompletedAt ?? null,
+        total_providers: latest?.data.total_providers ?? 0,
+        total_models: latest?.data.total_models ?? 0,
       };
     }),
   }),


### PR DESCRIPTION
## Summary
Records the completion timestamp in Redis at the very end of `syncAndStoreProviders()` (after all database transactions, Redis metadata mirroring, and direct BYOK sync steps have completed) and surfaces both the database snapshot timestamp and full sync completion timestamp in the Admin UI.

### Context
Previously, the Admin UI only inspected the latest database snapshot row in `modelsByProvider`. If downstream sync steps (such as direct BYOK sync) timed out or failed after the DB snapshot transaction committed, the UI gave the false impression that the entire sync job had succeeded recently.

### Changes
- Added `SYNC_PROVIDERS_LAST_COMPLETED_AT_REDIS_KEY` to `redis-keys.ts`.
- Updated `syncAndStoreProviders()` to set this Redis key and return `completed_at` when the entire sync finishes.
- Updated `adminRouter.syncProviders.getLastSync` to query both the database snapshot and the Redis completion timestamp.
- Updated `SyncProvidersContent.tsx` in the admin page to clearly display both the database snapshot generation timestamp and the full sync completion timestamp.