### PR TITLE
feat(ai-gateway): improve cache breakpoints with environment details and responses API support

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -109,6 +109,26 @@ function setCacheControlOnMessagesMessage(
   }
 }
 
+function setCacheControlOnMessagesSystem(
+  system: string | Anthropic.TextBlockParam[],
+  cacheControl: Anthropic.CacheControlEphemeral
+): Anthropic.TextBlockParam[] {
+  if (typeof system === 'string') {
+    return [
+      {
+        type: 'text',
+        text: system,
+        cache_control: cacheControl,
+      },
+    ];
+  }
+  const lastBlock = system.at(-1);
+  if (lastBlock) {
+    lastBlock.cache_control = cacheControl;
+  }
+  return system;
+}
+
 function isCacheableMessagesContentBlock(
   item: Anthropic.ContentBlockParam
 ): item is Exclude<
@@ -176,10 +196,12 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     request.body.messages.length > 1 &&
     !containsCacheControl(request.body.messages)
   ) {
-    const systemMessage = request.body.messages.find(msg => msg.role === 'system');
+    const systemMessage = request.body.messages.find(
+      msg => msg.role === 'system' || msg.role === 'developer'
+    );
     if (systemMessage) {
       console.debug(
-        '[addCacheBreakpoints] setting cache breakpoint on system chat completions message'
+        `[addCacheBreakpoints] setting cache breakpoint on ${systemMessage.role} chat completions message`
       );
       setCacheControlOnChatCompletionsMessage(systemMessage);
     }
@@ -224,10 +246,12 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     };
 
     const systemMessage = request.body.input.find(
-      msg => msg.type === 'message' && msg.role === 'system'
+      msg => msg.type === 'message' && (msg.role === 'system' || msg.role === 'developer')
     );
     if (systemMessage) {
-      console.debug('[addCacheBreakpoints] setting cache breakpoint on system responses message');
+      console.debug(
+        `[addCacheBreakpoints] setting cache breakpoint on ${systemMessage.role} responses message`
+      );
       setCacheBreakpointOnResponsesMessage(systemMessage);
     }
 
@@ -262,10 +286,16 @@ export function addCacheBreakpoints(request: GatewayRequest) {
   } else if (
     request.kind === 'messages' &&
     request.body.messages.length > 1 &&
-    !containsCacheControl(request.body.messages)
+    !containsCacheControl(request.body.messages) &&
+    !containsCacheControl(request.body.system)
   ) {
     const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
     delete request.body.cache_control;
+
+    if (request.body.system) {
+      console.debug('[addCacheBreakpoints] setting cache breakpoint on system messages prompt');
+      request.body.system = setCacheControlOnMessagesSystem(request.body.system, cacheControl);
+    }
 
     const lastMessage = request.body.messages.findLast(hasCacheableMessagesContent);
     if (lastMessage) {
@@ -305,6 +335,9 @@ export function removeCacheBreakpoints(request: GatewayRequest) {
   } else if (request.kind === 'messages') {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from messages request');
     delete request.body.cache_control;
+    if (request.body.system) {
+      deleteCacheControl(request.body.system);
+    }
     deleteCacheControl(request.body.messages);
   }
 }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -70,42 +70,23 @@ function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.Response
       ];
     } else if (Array.isArray(message.output)) {
       const lastItem = message.output.at(-1);
-      if (
-        lastItem &&
-        typeof lastItem === 'object' &&
-        'type' in lastItem &&
-        lastItem.type === 'input_text'
-      ) {
-        (lastItem as OpenAI.Responses.ResponseInputText).prompt_cache_breakpoint = {
-          mode: 'explicit',
-        };
+      if (lastItem && lastItem.type === 'input_text') {
+        lastItem.prompt_cache_breakpoint = { mode: 'explicit' };
       }
     }
   }
 }
 
 function isEnvironmentDetailsChatCompletionsPart(part: OpenAI.ChatCompletionContentPart): boolean {
-  return (
-    part.type === 'text' &&
-    typeof part.text === 'string' &&
-    part.text.startsWith('<environment_details>')
-  );
+  return part.type === 'text' && part.text.startsWith('<environment_details>');
 }
 
 function isEnvironmentDetailsResponsesPart(part: OpenAI.Responses.ResponseInputContent): boolean {
-  return (
-    (part.type === 'input_text' || (part as { type?: string }).type === 'text') &&
-    typeof (part as { text?: string }).text === 'string' &&
-    (part as { text: string }).text.startsWith('<environment_details>')
-  );
+  return part.type === 'input_text' && part.text.startsWith('<environment_details>');
 }
 
 function isEnvironmentDetailsMessagesPart(part: Anthropic.ContentBlockParam): boolean {
-  return (
-    part.type === 'text' &&
-    typeof part.text === 'string' &&
-    part.text.startsWith('<environment_details>')
-  );
+  return part.type === 'text' && part.text.startsWith('<environment_details>');
 }
 
 function setCacheControlOnMessagesMessage(

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -24,7 +24,14 @@ export function hasMiddleOutTransform(request: GatewayRequest) {
   );
 }
 
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null;
+}
+
 function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionMessageParam) {
+  if (!isObjectRecord(message)) {
+    return;
+  }
   if (typeof message.content === 'string') {
     message.content = [
       {
@@ -36,7 +43,7 @@ function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionM
     ];
   } else if (Array.isArray(message.content)) {
     const lastItem = message.content.at(-1);
-    if (lastItem) {
+    if (isObjectRecord(lastItem)) {
       // @ts-expect-error non-standard extension
       lastItem.cache_control = { type: 'ephemeral' };
     }
@@ -44,6 +51,9 @@ function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionM
 }
 
 function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.ResponseInputItem) {
+  if (!isObjectRecord(message)) {
+    return;
+  }
   if ('content' in message) {
     if (typeof message.content === 'string') {
       message.content = [
@@ -55,7 +65,7 @@ function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.Response
       ];
     } else if (Array.isArray(message.content)) {
       const lastItem = message.content.at(-1);
-      if (lastItem && 'type' in lastItem && lastItem.type === 'input_text') {
+      if (isObjectRecord(lastItem) && lastItem.type === 'input_text') {
         lastItem.prompt_cache_breakpoint = { mode: 'explicit' };
       }
     }
@@ -70,7 +80,7 @@ function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.Response
       ];
     } else if (Array.isArray(message.output)) {
       const lastItem = message.output.at(-1);
-      if (lastItem && 'type' in lastItem && lastItem.type === 'input_text') {
+      if (isObjectRecord(lastItem) && lastItem.type === 'input_text') {
         lastItem.prompt_cache_breakpoint = { mode: 'explicit' };
       }
     }
@@ -78,25 +88,41 @@ function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.Response
 }
 
 function isEnvironmentDetailsChatCompletionsPart(part: OpenAI.ChatCompletionContentPart): boolean {
-  return part.type === 'text' && part.text.startsWith('<environment_details>');
+  return (
+    isObjectRecord(part) &&
+    part.type === 'text' &&
+    typeof part.text === 'string' &&
+    part.text.startsWith('<environment_details>')
+  );
 }
 
 function isEnvironmentDetailsResponsesPart(
   part: OpenAI.Responses.ResponseInputContent | OpenAI.Responses.ResponseContent
 ): boolean {
   return (
-    'type' in part && part.type === 'input_text' && part.text.startsWith('<environment_details>')
+    isObjectRecord(part) &&
+    part.type === 'input_text' &&
+    typeof part.text === 'string' &&
+    part.text.startsWith('<environment_details>')
   );
 }
 
 function isEnvironmentDetailsMessagesPart(part: Anthropic.ContentBlockParam): boolean {
-  return part.type === 'text' && part.text.startsWith('<environment_details>');
+  return (
+    isObjectRecord(part) &&
+    part.type === 'text' &&
+    typeof part.text === 'string' &&
+    part.text.startsWith('<environment_details>')
+  );
 }
 
 function setCacheControlOnMessagesMessage(
   message: Anthropic.MessageParam,
   cacheControl: Anthropic.CacheControlEphemeral
 ) {
+  if (!isObjectRecord(message)) {
+    return;
+  }
   if (typeof message.content === 'string') {
     message.content = [
       {
@@ -105,7 +131,7 @@ function setCacheControlOnMessagesMessage(
         cache_control: cacheControl,
       },
     ];
-  } else {
+  } else if (Array.isArray(message.content)) {
     const lastItem = message.content.findLast(isCacheableMessagesContentBlock);
     if (lastItem) {
       lastItem.cache_control = cacheControl;
@@ -139,17 +165,16 @@ function isCacheableMessagesContentBlock(
   Anthropic.ContentBlockParam,
   Anthropic.ThinkingBlockParam | Anthropic.RedactedThinkingBlockParam
 > {
-  return item.type !== 'thinking' && item.type !== 'redacted_thinking';
+  return isObjectRecord(item) && item.type !== 'thinking' && item.type !== 'redacted_thinking';
 }
 
 function hasCacheableMessagesContent(message: Anthropic.MessageParam) {
+  if (!isObjectRecord(message)) {
+    return false;
+  }
   return typeof message.content === 'string'
     ? message.content.length > 0
-    : message.content.some(isCacheableMessagesContentBlock);
-}
-
-function isObjectRecord(value: unknown): value is Record<string, unknown> {
-  return typeof value === 'object' && value !== null;
+    : Array.isArray(message.content) && message.content.some(isCacheableMessagesContentBlock);
 }
 
 function containsCacheControl(value: unknown): boolean {
@@ -202,7 +227,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
   ) {
     const systemMessage = request.body.messages.find(
       (msg): msg is Extract<OpenAI.ChatCompletionMessageParam, { role: 'system' | 'developer' }> =>
-        msg.role === 'system' || msg.role === 'developer'
+        isObjectRecord(msg) && (msg.role === 'system' || msg.role === 'developer')
     );
     if (systemMessage) {
       console.debug(
@@ -213,7 +238,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
 
     const lastMessage = request.body.messages.findLast(
       (msg): msg is Extract<OpenAI.ChatCompletionMessageParam, { role: 'user' | 'tool' }> =>
-        msg.role === 'user' || msg.role === 'tool'
+        isObjectRecord(msg) && (msg.role === 'user' || msg.role === 'tool')
     );
     if (lastMessage) {
       if (
@@ -224,7 +249,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
         const envIndex = lastMessage.content.findIndex(isEnvironmentDetailsChatCompletionsPart);
         if (envIndex > 0) {
           const targetElement = lastMessage.content[envIndex - 1];
-          if (targetElement) {
+          if (isObjectRecord(targetElement)) {
             console.debug(
               '[addCacheBreakpoints] setting cache breakpoint before environment details in chat completions'
             );
@@ -252,7 +277,8 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     };
 
     const systemMessage = request.body.input.find(
-      msg => 'role' in msg && (msg.role === 'system' || msg.role === 'developer')
+      msg =>
+        isObjectRecord(msg) && 'role' in msg && (msg.role === 'system' || msg.role === 'developer')
     );
     if (systemMessage) {
       console.debug(
@@ -263,8 +289,9 @@ export function addCacheBreakpoints(request: GatewayRequest) {
 
     const lastMessage = request.body.input.findLast(
       msg =>
-        ('role' in msg && msg.role === 'user') ||
-        ('type' in msg && msg.type === 'function_call_output')
+        isObjectRecord(msg) &&
+        (('role' in msg && msg.role === 'user') ||
+          ('type' in msg && msg.type === 'function_call_output'))
     );
     if (lastMessage) {
       if (
@@ -277,7 +304,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
         const envIndex = lastMessage.content.findIndex(isEnvironmentDetailsResponsesPart);
         if (envIndex > 0) {
           const targetElement = lastMessage.content[envIndex - 1];
-          if (targetElement && 'type' in targetElement && targetElement.type === 'input_text') {
+          if (isObjectRecord(targetElement) && targetElement.type === 'input_text') {
             console.debug(
               '[addCacheBreakpoints] setting cache breakpoint before environment details in responses'
             );
@@ -309,6 +336,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     const lastMessage = request.body.messages.findLast(hasCacheableMessagesContent);
     if (lastMessage) {
       if (
+        isObjectRecord(lastMessage) &&
         lastMessage.role === 'user' &&
         Array.isArray(lastMessage.content) &&
         lastMessage.content.length > 1
@@ -316,7 +344,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
         const envIndex = lastMessage.content.findIndex(isEnvironmentDetailsMessagesPart);
         if (envIndex > 0) {
           const targetElement = lastMessage.content[envIndex - 1];
-          if (targetElement && isCacheableMessagesContentBlock(targetElement)) {
+          if (isObjectRecord(targetElement) && isCacheableMessagesContentBlock(targetElement)) {
             console.debug(
               '[addCacheBreakpoints] setting cache breakpoint before environment details in messages'
             );

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -44,7 +44,6 @@ function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionM
   } else if (Array.isArray(message.content)) {
     const lastItem = message.content.at(-1);
     if (isObjectRecord(lastItem)) {
-      // @ts-expect-error non-standard extension
       lastItem.cache_control = { type: 'ephemeral' };
     }
   }
@@ -253,7 +252,6 @@ export function addCacheBreakpoints(request: GatewayRequest) {
             console.debug(
               '[addCacheBreakpoints] setting cache breakpoint before environment details in chat completions'
             );
-            // @ts-expect-error non-standard extension
             targetElement.cache_control = { type: 'ephemeral' };
             return;
           }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -44,7 +44,7 @@ function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionM
 }
 
 function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.ResponseInputItem) {
-  if (message.type === 'message') {
+  if ('content' in message) {
     if (typeof message.content === 'string') {
       message.content = [
         {
@@ -55,11 +55,11 @@ function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.Response
       ];
     } else if (Array.isArray(message.content)) {
       const lastItem = message.content.at(-1);
-      if (lastItem && lastItem.type === 'input_text') {
+      if (lastItem && 'type' in lastItem && lastItem.type === 'input_text') {
         lastItem.prompt_cache_breakpoint = { mode: 'explicit' };
       }
     }
-  } else if (message.type === 'function_call_output') {
+  } else if ('output' in message) {
     if (typeof message.output === 'string') {
       message.output = [
         {
@@ -70,7 +70,7 @@ function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.Response
       ];
     } else if (Array.isArray(message.output)) {
       const lastItem = message.output.at(-1);
-      if (lastItem && lastItem.type === 'input_text') {
+      if (lastItem && 'type' in lastItem && lastItem.type === 'input_text') {
         lastItem.prompt_cache_breakpoint = { mode: 'explicit' };
       }
     }
@@ -81,8 +81,12 @@ function isEnvironmentDetailsChatCompletionsPart(part: OpenAI.ChatCompletionCont
   return part.type === 'text' && part.text.startsWith('<environment_details>');
 }
 
-function isEnvironmentDetailsResponsesPart(part: OpenAI.Responses.ResponseInputContent): boolean {
-  return part.type === 'input_text' && part.text.startsWith('<environment_details>');
+function isEnvironmentDetailsResponsesPart(
+  part: OpenAI.Responses.ResponseInputContent | OpenAI.Responses.ResponseContent
+): boolean {
+  return (
+    'type' in part && part.type === 'input_text' && part.text.startsWith('<environment_details>')
+  );
 }
 
 function isEnvironmentDetailsMessagesPart(part: Anthropic.ContentBlockParam): boolean {
@@ -248,35 +252,32 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     };
 
     const systemMessage = request.body.input.find(
-      (msg): msg is Extract<OpenAI.Responses.ResponseInputItem, { type: 'message' }> =>
-        msg.type === 'message' && (msg.role === 'system' || msg.role === 'developer')
+      msg => 'role' in msg && (msg.role === 'system' || msg.role === 'developer')
     );
     if (systemMessage) {
       console.debug(
-        `[addCacheBreakpoints] setting cache breakpoint on ${systemMessage.role} responses message`
+        `[addCacheBreakpoints] setting cache breakpoint on ${'role' in systemMessage ? systemMessage.role : 'system'} responses message`
       );
       setCacheBreakpointOnResponsesMessage(systemMessage);
     }
 
     const lastMessage = request.body.input.findLast(
-      (
-        msg
-      ): msg is
-        | Extract<OpenAI.Responses.ResponseInputItem, { type: 'message' }>
-        | Extract<OpenAI.Responses.ResponseInputItem, { type: 'function_call_output' }> =>
-        (msg.type === 'message' && msg.role === 'user') || msg.type === 'function_call_output'
+      msg =>
+        ('role' in msg && msg.role === 'user') ||
+        ('type' in msg && msg.type === 'function_call_output')
     );
     if (lastMessage) {
       if (
-        lastMessage.type === 'message' &&
+        'role' in lastMessage &&
         lastMessage.role === 'user' &&
+        'content' in lastMessage &&
         Array.isArray(lastMessage.content) &&
         lastMessage.content.length > 1
       ) {
         const envIndex = lastMessage.content.findIndex(isEnvironmentDetailsResponsesPart);
         if (envIndex > 0) {
           const targetElement = lastMessage.content[envIndex - 1];
-          if (targetElement && targetElement.type === 'input_text') {
+          if (targetElement && 'type' in targetElement && targetElement.type === 'input_text') {
             console.debug(
               '[addCacheBreakpoints] setting cache breakpoint before environment details in responses'
             );
@@ -287,7 +288,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       }
 
       console.debug(
-        `[addCacheBreakpoints] setting cache breakpoint on last ${lastMessage.type} responses message`
+        `[addCacheBreakpoints] setting cache breakpoint on last ${'role' in lastMessage ? lastMessage.role : 'type' in lastMessage ? lastMessage.type : 'responses'} responses message`
       );
       setCacheBreakpointOnResponsesMessage(lastMessage);
     }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -317,7 +317,6 @@ export function removeCacheBreakpoints(request: GatewayRequest) {
   if (request.kind === 'chat_completions' && Array.isArray(request.body.messages)) {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from chat completions');
     deleteCacheControl(request.body.messages);
-    delete (request.body as Record<string, unknown>).prompt_cache_options;
   } else if (request.kind === 'responses' && Array.isArray(request.body.input)) {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from responses request');
     deleteCacheControl(request.body.input);

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -193,8 +193,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     request.kind === 'chat_completions' &&
     Array.isArray(request.body.messages) &&
     request.body.messages.length > 1 &&
-    !containsCacheControl(request.body.messages) &&
-    !containsCacheControl((request.body as Record<string, unknown>).prompt_cache_options)
+    !containsCacheControl(request.body.messages)
   ) {
     const systemMessage = request.body.messages.find(msg => msg.role === 'system');
     if (systemMessage) {
@@ -204,32 +203,29 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       setCacheControlOnChatCompletionsMessage(systemMessage);
     }
 
-    const lastUserMessageWithEnvDetails = request.body.messages.findLast(
-      (msg): msg is OpenAI.ChatCompletionUserMessageParam =>
-        msg.role === 'user' &&
-        Array.isArray(msg.content) &&
-        msg.content.some(isEnvironmentDetailsChatCompletionsPart)
-    );
-    if (lastUserMessageWithEnvDetails && Array.isArray(lastUserMessageWithEnvDetails.content)) {
-      const envIndex = lastUserMessageWithEnvDetails.content.findIndex(
-        isEnvironmentDetailsChatCompletionsPart
-      );
-      if (envIndex > 0) {
-        const targetElement = lastUserMessageWithEnvDetails.content[envIndex - 1];
-        if (targetElement) {
-          console.debug(
-            '[addCacheBreakpoints] setting cache breakpoint before environment details in chat completions'
-          );
-          // @ts-expect-error non-standard extension
-          targetElement.cache_control = { type: 'ephemeral' };
-        }
-      }
-    }
-
     const lastMessage = request.body.messages.findLast(
       msg => msg.role === 'user' || msg.role === 'tool'
     );
     if (lastMessage) {
+      if (
+        lastMessage.role === 'user' &&
+        Array.isArray(lastMessage.content) &&
+        lastMessage.content.length > 1
+      ) {
+        const envIndex = lastMessage.content.findIndex(isEnvironmentDetailsChatCompletionsPart);
+        if (envIndex > 0) {
+          const targetElement = lastMessage.content[envIndex - 1];
+          if (targetElement) {
+            console.debug(
+              '[addCacheBreakpoints] setting cache breakpoint before environment details in chat completions'
+            );
+            // @ts-expect-error non-standard extension
+            targetElement.cache_control = { type: 'ephemeral' };
+            return;
+          }
+        }
+      }
+
       console.debug(
         `[addCacheBreakpoints] setting cache breakpoint on last ${lastMessage.role} chat completions message`
       );
@@ -239,11 +235,10 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     request.kind === 'responses' &&
     Array.isArray(request.body.input) &&
     request.body.input.length > 1 &&
-    !containsCacheControl(request.body.input) &&
-    !containsCacheControl((request.body as Record<string, unknown>).prompt_cache_options)
+    !request.body.prompt_cache_options &&
+    !containsCacheControl(request.body.input)
   ) {
     request.body.prompt_cache_options = {
-      ...(request.body as { prompt_cache_options?: Record<string, unknown> }).prompt_cache_options,
       mode: 'implicit',
     };
 
@@ -255,32 +250,29 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       setCacheBreakpointOnResponsesMessage(systemMessage);
     }
 
-    const lastUserMessageWithEnvDetails = request.body.input.findLast(
-      (item): item is Extract<OpenAI.Responses.ResponseInputItem, { type: 'message' }> =>
-        item.type === 'message' &&
-        item.role === 'user' &&
-        Array.isArray(item.content) &&
-        item.content.some(isEnvironmentDetailsResponsesPart)
-    );
-    if (lastUserMessageWithEnvDetails && Array.isArray(lastUserMessageWithEnvDetails.content)) {
-      const envIndex = lastUserMessageWithEnvDetails.content.findIndex(
-        isEnvironmentDetailsResponsesPart
-      );
-      if (envIndex > 0) {
-        const targetElement = lastUserMessageWithEnvDetails.content[envIndex - 1];
-        if (targetElement && targetElement.type === 'input_text') {
-          console.debug(
-            '[addCacheBreakpoints] setting cache breakpoint before environment details in responses'
-          );
-          targetElement.prompt_cache_breakpoint = { mode: 'explicit' };
-        }
-      }
-    }
-
     const lastMessage = request.body.input.findLast(
       msg => (msg.type === 'message' && msg.role === 'user') || msg.type === 'function_call_output'
     );
     if (lastMessage) {
+      if (
+        lastMessage.type === 'message' &&
+        lastMessage.role === 'user' &&
+        Array.isArray(lastMessage.content) &&
+        lastMessage.content.length > 1
+      ) {
+        const envIndex = lastMessage.content.findIndex(isEnvironmentDetailsResponsesPart);
+        if (envIndex > 0) {
+          const targetElement = lastMessage.content[envIndex - 1];
+          if (targetElement && targetElement.type === 'input_text') {
+            console.debug(
+              '[addCacheBreakpoints] setting cache breakpoint before environment details in responses'
+            );
+            targetElement.prompt_cache_breakpoint = { mode: 'explicit' };
+            return;
+          }
+        }
+      }
+
       console.debug(
         `[addCacheBreakpoints] setting cache breakpoint on last ${lastMessage.type} responses message`
       );
@@ -294,29 +286,26 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
     delete request.body.cache_control;
 
-    const lastUserMessageWithEnvDetails = request.body.messages.findLast(
-      msg =>
-        msg.role === 'user' &&
-        Array.isArray(msg.content) &&
-        msg.content.some(isEnvironmentDetailsMessagesPart)
-    );
-    if (lastUserMessageWithEnvDetails && Array.isArray(lastUserMessageWithEnvDetails.content)) {
-      const envIndex = lastUserMessageWithEnvDetails.content.findIndex(
-        isEnvironmentDetailsMessagesPart
-      );
-      if (envIndex > 0) {
-        const targetElement = lastUserMessageWithEnvDetails.content[envIndex - 1];
-        if (targetElement && isCacheableMessagesContentBlock(targetElement)) {
-          console.debug(
-            '[addCacheBreakpoints] setting cache breakpoint before environment details in messages'
-          );
-          targetElement.cache_control = cacheControl;
-        }
-      }
-    }
-
     const lastMessage = request.body.messages.findLast(hasCacheableMessagesContent);
     if (lastMessage) {
+      if (
+        lastMessage.role === 'user' &&
+        Array.isArray(lastMessage.content) &&
+        lastMessage.content.length > 1
+      ) {
+        const envIndex = lastMessage.content.findIndex(isEnvironmentDetailsMessagesPart);
+        if (envIndex > 0) {
+          const targetElement = lastMessage.content[envIndex - 1];
+          if (targetElement && isCacheableMessagesContentBlock(targetElement)) {
+            console.debug(
+              '[addCacheBreakpoints] setting cache breakpoint before environment details in messages'
+            );
+            targetElement.cache_control = cacheControl;
+            return;
+          }
+        }
+      }
+
       console.debug('[addCacheBreakpoints] setting cache breakpoint on last messages message');
       // Vercel AI Gateway does not honor top-level cache_control on Messages API requests.
       setCacheControlOnMessagesMessage(lastMessage, cacheControl);
@@ -332,7 +321,7 @@ export function removeCacheBreakpoints(request: GatewayRequest) {
   } else if (request.kind === 'responses' && Array.isArray(request.body.input)) {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from responses request');
     deleteCacheControl(request.body.input);
-    delete (request.body as Record<string, unknown>).prompt_cache_options;
+    delete request.body.prompt_cache_options;
   } else if (request.kind === 'messages') {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from messages request');
     delete request.body.cache_control;

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -197,7 +197,8 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     !containsCacheControl(request.body.messages)
   ) {
     const systemMessage = request.body.messages.find(
-      msg => msg.role === 'system' || msg.role === 'developer'
+      (msg): msg is Extract<OpenAI.ChatCompletionMessageParam, { role: 'system' | 'developer' }> =>
+        msg.role === 'system' || msg.role === 'developer'
     );
     if (systemMessage) {
       console.debug(
@@ -207,7 +208,8 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     }
 
     const lastMessage = request.body.messages.findLast(
-      msg => msg.role === 'user' || msg.role === 'tool'
+      (msg): msg is Extract<OpenAI.ChatCompletionMessageParam, { role: 'user' | 'tool' }> =>
+        msg.role === 'user' || msg.role === 'tool'
     );
     if (lastMessage) {
       if (
@@ -246,7 +248,8 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     };
 
     const systemMessage = request.body.input.find(
-      msg => msg.type === 'message' && (msg.role === 'system' || msg.role === 'developer')
+      (msg): msg is Extract<OpenAI.Responses.ResponseInputItem, { type: 'message' }> =>
+        msg.type === 'message' && (msg.role === 'system' || msg.role === 'developer')
     );
     if (systemMessage) {
       console.debug(
@@ -256,7 +259,12 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     }
 
     const lastMessage = request.body.input.findLast(
-      msg => (msg.type === 'message' && msg.role === 'user') || msg.type === 'function_call_output'
+      (
+        msg
+      ): msg is
+        | Extract<OpenAI.Responses.ResponseInputItem, { type: 'message' }>
+        | Extract<OpenAI.Responses.ResponseInputItem, { type: 'function_call_output' }> =>
+        (msg.type === 'message' && msg.role === 'user') || msg.type === 'function_call_output'
     );
     if (lastMessage) {
       if (

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -43,22 +43,20 @@ function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionM
   }
 }
 
-function setCacheControlOnResponsesMessage(message: OpenAI.Responses.ResponseInputItem) {
+function setCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.ResponseInputItem) {
   if (message.type === 'message') {
     if (typeof message.content === 'string') {
       message.content = [
         {
           type: 'input_text',
           text: message.content,
-          // @ts-expect-error non-standard extension
-          cache_control: { type: 'ephemeral' },
+          prompt_cache_breakpoint: { mode: 'explicit' },
         },
       ];
-    } else {
+    } else if (Array.isArray(message.content)) {
       const lastItem = message.content.at(-1);
-      if (lastItem) {
-        // @ts-expect-error non-standard extension
-        lastItem.cache_control = { type: 'ephemeral' };
+      if (lastItem && lastItem.type === 'input_text') {
+        lastItem.prompt_cache_breakpoint = { mode: 'explicit' };
       }
     }
   } else if (message.type === 'function_call_output') {
@@ -67,18 +65,47 @@ function setCacheControlOnResponsesMessage(message: OpenAI.Responses.ResponseInp
         {
           type: 'input_text',
           text: message.output,
-          // @ts-expect-error non-standard extension
-          cache_control: { type: 'ephemeral' },
+          prompt_cache_breakpoint: { mode: 'explicit' },
         },
       ];
-    } else {
+    } else if (Array.isArray(message.output)) {
       const lastItem = message.output.at(-1);
-      if (lastItem) {
-        // @ts-expect-error non-standard extension
-        lastItem.cache_control = { type: 'ephemeral' };
+      if (
+        lastItem &&
+        typeof lastItem === 'object' &&
+        'type' in lastItem &&
+        lastItem.type === 'input_text'
+      ) {
+        (lastItem as OpenAI.Responses.ResponseInputText).prompt_cache_breakpoint = {
+          mode: 'explicit',
+        };
       }
     }
   }
+}
+
+function isEnvironmentDetailsChatCompletionsPart(part: OpenAI.ChatCompletionContentPart): boolean {
+  return (
+    part.type === 'text' &&
+    typeof part.text === 'string' &&
+    part.text.startsWith('<environment_details>')
+  );
+}
+
+function isEnvironmentDetailsResponsesPart(part: OpenAI.Responses.ResponseInputContent): boolean {
+  return (
+    (part.type === 'input_text' || (part as { type?: string }).type === 'text') &&
+    typeof (part as { text?: string }).text === 'string' &&
+    (part as { text: string }).text.startsWith('<environment_details>')
+  );
+}
+
+function isEnvironmentDetailsMessagesPart(part: Anthropic.ContentBlockParam): boolean {
+  return (
+    part.type === 'text' &&
+    typeof part.text === 'string' &&
+    part.text.startsWith('<environment_details>')
+  );
 }
 
 function setCacheControlOnMessagesMessage(
@@ -127,7 +154,11 @@ function containsCacheControl(value: unknown): boolean {
   if (!isObjectRecord(value)) {
     return false;
   }
-  if (Object.hasOwn(value, 'cache_control')) {
+  if (
+    Object.hasOwn(value, 'cache_control') ||
+    Object.hasOwn(value, 'prompt_cache_breakpoint') ||
+    Object.hasOwn(value, 'prompt_cache_options')
+  ) {
     return true;
   }
   return Object.values(value).some(containsCacheControl);
@@ -146,6 +177,12 @@ function deleteCacheControl(value: unknown): void {
   if (Object.hasOwn(value, 'cache_control')) {
     delete value.cache_control;
   }
+  if (Object.hasOwn(value, 'prompt_cache_breakpoint')) {
+    delete value.prompt_cache_breakpoint;
+  }
+  if (Object.hasOwn(value, 'prompt_cache_options')) {
+    delete value.prompt_cache_options;
+  }
   for (const item of Object.values(value)) {
     deleteCacheControl(item);
   }
@@ -156,7 +193,8 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     request.kind === 'chat_completions' &&
     Array.isArray(request.body.messages) &&
     request.body.messages.length > 1 &&
-    !containsCacheControl(request.body.messages)
+    !containsCacheControl(request.body.messages) &&
+    !containsCacheControl((request.body as Record<string, unknown>).prompt_cache_options)
   ) {
     const systemMessage = request.body.messages.find(msg => msg.role === 'system');
     if (systemMessage) {
@@ -165,6 +203,29 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       );
       setCacheControlOnChatCompletionsMessage(systemMessage);
     }
+
+    const lastUserMessageWithEnvDetails = request.body.messages.findLast(
+      (msg): msg is OpenAI.ChatCompletionUserMessageParam =>
+        msg.role === 'user' &&
+        Array.isArray(msg.content) &&
+        msg.content.some(isEnvironmentDetailsChatCompletionsPart)
+    );
+    if (lastUserMessageWithEnvDetails && Array.isArray(lastUserMessageWithEnvDetails.content)) {
+      const envIndex = lastUserMessageWithEnvDetails.content.findIndex(
+        isEnvironmentDetailsChatCompletionsPart
+      );
+      if (envIndex > 0) {
+        const targetElement = lastUserMessageWithEnvDetails.content[envIndex - 1];
+        if (targetElement) {
+          console.debug(
+            '[addCacheBreakpoints] setting cache breakpoint before environment details in chat completions'
+          );
+          // @ts-expect-error non-standard extension
+          targetElement.cache_control = { type: 'ephemeral' };
+        }
+      }
+    }
+
     const lastMessage = request.body.messages.findLast(
       msg => msg.role === 'user' || msg.role === 'tool'
     );
@@ -178,15 +239,44 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     request.kind === 'responses' &&
     Array.isArray(request.body.input) &&
     request.body.input.length > 1 &&
-    !containsCacheControl(request.body.input)
+    !containsCacheControl(request.body.input) &&
+    !containsCacheControl((request.body as Record<string, unknown>).prompt_cache_options)
   ) {
+    request.body.prompt_cache_options = {
+      ...(request.body as { prompt_cache_options?: Record<string, unknown> }).prompt_cache_options,
+      mode: 'implicit',
+    };
+
     const systemMessage = request.body.input.find(
       msg => msg.type === 'message' && msg.role === 'system'
     );
     if (systemMessage) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on system responses message');
-      setCacheControlOnResponsesMessage(systemMessage);
+      setCacheBreakpointOnResponsesMessage(systemMessage);
     }
+
+    const lastUserMessageWithEnvDetails = request.body.input.findLast(
+      (item): item is Extract<OpenAI.Responses.ResponseInputItem, { type: 'message' }> =>
+        item.type === 'message' &&
+        item.role === 'user' &&
+        Array.isArray(item.content) &&
+        item.content.some(isEnvironmentDetailsResponsesPart)
+    );
+    if (lastUserMessageWithEnvDetails && Array.isArray(lastUserMessageWithEnvDetails.content)) {
+      const envIndex = lastUserMessageWithEnvDetails.content.findIndex(
+        isEnvironmentDetailsResponsesPart
+      );
+      if (envIndex > 0) {
+        const targetElement = lastUserMessageWithEnvDetails.content[envIndex - 1];
+        if (targetElement && targetElement.type === 'input_text') {
+          console.debug(
+            '[addCacheBreakpoints] setting cache breakpoint before environment details in responses'
+          );
+          targetElement.prompt_cache_breakpoint = { mode: 'explicit' };
+        }
+      }
+    }
+
     const lastMessage = request.body.input.findLast(
       msg => (msg.type === 'message' && msg.role === 'user') || msg.type === 'function_call_output'
     );
@@ -194,19 +284,41 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       console.debug(
         `[addCacheBreakpoints] setting cache breakpoint on last ${lastMessage.type} responses message`
       );
-      setCacheControlOnResponsesMessage(lastMessage);
+      setCacheBreakpointOnResponsesMessage(lastMessage);
     }
   } else if (
     request.kind === 'messages' &&
     request.body.messages.length > 1 &&
     !containsCacheControl(request.body.messages)
   ) {
+    const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
+    delete request.body.cache_control;
+
+    const lastUserMessageWithEnvDetails = request.body.messages.findLast(
+      msg =>
+        msg.role === 'user' &&
+        Array.isArray(msg.content) &&
+        msg.content.some(isEnvironmentDetailsMessagesPart)
+    );
+    if (lastUserMessageWithEnvDetails && Array.isArray(lastUserMessageWithEnvDetails.content)) {
+      const envIndex = lastUserMessageWithEnvDetails.content.findIndex(
+        isEnvironmentDetailsMessagesPart
+      );
+      if (envIndex > 0) {
+        const targetElement = lastUserMessageWithEnvDetails.content[envIndex - 1];
+        if (targetElement && isCacheableMessagesContentBlock(targetElement)) {
+          console.debug(
+            '[addCacheBreakpoints] setting cache breakpoint before environment details in messages'
+          );
+          targetElement.cache_control = cacheControl;
+        }
+      }
+    }
+
     const lastMessage = request.body.messages.findLast(hasCacheableMessagesContent);
     if (lastMessage) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on last messages message');
       // Vercel AI Gateway does not honor top-level cache_control on Messages API requests.
-      const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
-      delete request.body.cache_control;
       setCacheControlOnMessagesMessage(lastMessage, cacheControl);
     }
   }
@@ -216,9 +328,11 @@ export function removeCacheBreakpoints(request: GatewayRequest) {
   if (request.kind === 'chat_completions' && Array.isArray(request.body.messages)) {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from chat completions');
     deleteCacheControl(request.body.messages);
+    delete (request.body as Record<string, unknown>).prompt_cache_options;
   } else if (request.kind === 'responses' && Array.isArray(request.body.input)) {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from responses request');
     deleteCacheControl(request.body.input);
+    delete (request.body as Record<string, unknown>).prompt_cache_options;
   } else if (request.kind === 'messages') {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from messages request');
     delete request.body.cache_control;

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
@@ -65,7 +65,12 @@ export type SharedGatewayRequestProperties = {
 };
 
 export type GatewayResponsesRequest = SharedGatewayRequestProperties &
-  OpenAI.Responses.ResponseCreateParams;
+  OpenAI.Responses.ResponseCreateParams & {
+    prompt_cache_options?: {
+      mode?: 'implicit' | 'explicit';
+      ttl?: string;
+    };
+  };
 
 export type GatewayMessagesRequest = SharedGatewayRequestProperties &
   Anthropic.MessageCreateParams & {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/types.ts
@@ -65,12 +65,7 @@ export type SharedGatewayRequestProperties = {
 };
 
 export type GatewayResponsesRequest = SharedGatewayRequestProperties &
-  OpenAI.Responses.ResponseCreateParams & {
-    prompt_cache_options?: {
-      mode?: 'implicit' | 'explicit';
-      ttl?: string;
-    };
-  };
+  OpenAI.Responses.ResponseCreateParams;
 
 export type GatewayMessagesRequest = SharedGatewayRequestProperties &
   Anthropic.MessageCreateParams & {

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -175,13 +175,14 @@ describe('addCacheBreakpoints', () => {
             ],
           },
           { role: 'assistant', content: 'Calling tool' },
-          { role: 'tool', content: 'Tool output' },
+          { role: 'tool', content: 'Tool output', tool_call_id: 'call_123' },
         ],
       },
     };
 
     addCacheBreakpoints(request);
 
+    if (request.kind !== 'chat_completions') return;
     const userContent = request.body.messages.at(1)?.content;
     expect(userContent).toEqual([
       { type: 'text', text: 'User prompt' },
@@ -191,6 +192,31 @@ describe('addCacheBreakpoints', () => {
     const toolContent = request.body.messages.at(3)?.content;
     expect(toolContent).toEqual([
       { type: 'text', text: 'Tool output', cache_control: { type: 'ephemeral' } },
+    ]);
+  });
+
+  test('adds a cache breakpoint to developer message in chat completions', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'test-model',
+        messages: [
+          { role: 'developer', content: 'Developer guidelines.' },
+          { role: 'user', content: 'Hello' },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    if (request.kind !== 'chat_completions') return;
+    const devContent = request.body.messages.at(0)?.content;
+    expect(devContent).toEqual([
+      {
+        type: 'text',
+        text: 'Developer guidelines.',
+        cache_control: { type: 'ephemeral' },
+      },
     ]);
   });
 
@@ -335,6 +361,32 @@ describe('addCacheBreakpoints', () => {
     ]);
   });
 
+  test('adds a prompt_cache_breakpoint to developer message in responses', () => {
+    const request: GatewayRequest = {
+      kind: 'responses',
+      body: {
+        model: 'test-model',
+        input: [
+          { type: 'message', role: 'developer', content: 'Developer instructions.' },
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
+    const devMessage = request.body.input.at(0);
+    if (!devMessage || typeof devMessage !== 'object' || devMessage.type !== 'message') return;
+    expect(devMessage.content).toEqual([
+      {
+        type: 'input_text',
+        text: 'Developer instructions.',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      },
+    ]);
+  });
+
   test('does nothing for responses requests when prompt_cache_options is already present', () => {
     const request: GatewayRequest = {
       kind: 'responses',
@@ -359,8 +411,14 @@ describe('addCacheBreakpoints', () => {
     addCacheBreakpoints(request);
 
     expect(request.body.prompt_cache_options).toEqual({ mode: 'explicit' });
+    if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
     const userMessage = request.body.input.at(0);
-    if (userMessage && userMessage.type === 'message' && Array.isArray(userMessage.content)) {
+    if (
+      userMessage &&
+      typeof userMessage === 'object' &&
+      userMessage.type === 'message' &&
+      Array.isArray(userMessage.content)
+    ) {
       expect(userMessage.content[0]).toEqual({ type: 'input_text', text: 'First prompt' });
     }
   });
@@ -405,6 +463,35 @@ describe('addCacheBreakpoints', () => {
         { type: 'input_text', text: 'Tool detail' },
       ],
     });
+  });
+
+  test('adds cache_control to system prompt and last message in messages requests', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        system: 'System instructions',
+        messages: [
+          { role: 'user', content: 'First prompt' },
+          { role: 'assistant', content: 'First response' },
+          { role: 'user', content: 'Latest prompt' },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.system).toEqual([
+      {
+        type: 'text',
+        text: 'System instructions',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+    expect(request.body.messages.at(-1)?.content).toEqual([
+      { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
+    ]);
   });
 
   test('adds cache_control to the last content block of a messages request', () => {

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -73,6 +73,95 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
+  test('adds a cache breakpoint before environment_details and at the end of the last user message in chat completions', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'test-model',
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          { role: 'assistant', content: 'First response' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Main task instruction' },
+              { type: 'text', text: '<environment_details>\nOS: Linux\n</environment_details>' },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    const userContent = request.body.messages.at(2)?.content;
+    expect(Array.isArray(userContent)).toBe(true);
+    if (!Array.isArray(userContent)) return;
+    expect(userContent).toEqual([
+      {
+        type: 'text',
+        text: 'Main task instruction',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: '<environment_details>\nOS: Linux\n</environment_details>',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
+  test('adds a cache breakpoint before environment_details on the last user message with environment_details across multi-turn chat completions', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'test-model',
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Turn 1 prompt' },
+              { type: 'text', text: '<environment_details>\nTurn 1 env\n</environment_details>' },
+            ],
+          },
+          { role: 'assistant', content: 'Turn 1 response' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Turn 2 prompt part 1' },
+              { type: 'text', text: 'Turn 2 prompt part 2' },
+              { type: 'text', text: '<environment_details>\nTurn 2 env\n</environment_details>' },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    const turn1Content = request.body.messages.at(1)?.content;
+    expect(turn1Content).toEqual([
+      { type: 'text', text: 'Turn 1 prompt' },
+      { type: 'text', text: '<environment_details>\nTurn 1 env\n</environment_details>' },
+    ]);
+
+    const turn2Content = request.body.messages.at(3)?.content;
+    expect(turn2Content).toEqual([
+      { type: 'text', text: 'Turn 2 prompt part 1' },
+      {
+        type: 'text',
+        text: 'Turn 2 prompt part 2',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: '<environment_details>\nTurn 2 env\n</environment_details>',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
   test('does nothing for chat completions requests when any cache_control is already present', () => {
     const request: GatewayRequest = {
       kind: 'chat_completions',
@@ -112,7 +201,7 @@ describe('addCacheBreakpoints', () => {
     ]);
   });
 
-  test('adds a cache breakpoint to the system message and the last eligible responses message when none exist', () => {
+  test('adds a prompt_cache_breakpoint to the system message and the last eligible responses message with mode implicit', () => {
     const request: GatewayRequest = {
       kind: 'responses',
       body: {
@@ -143,6 +232,8 @@ describe('addCacheBreakpoints', () => {
     addCacheBreakpoints(request);
 
     if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
+    expect(request.body.prompt_cache_options).toEqual({ mode: 'implicit' });
+
     const systemMessage = request.body.input.at(0);
     expect(systemMessage).toMatchObject({ type: 'message', role: 'system' });
     if (!systemMessage || systemMessage.type !== 'message') return;
@@ -152,7 +243,7 @@ describe('addCacheBreakpoints', () => {
     expect(systemContent.at(-1)).toMatchObject({
       type: 'input_text',
       text: 'You are helpful.',
-      cache_control: { type: 'ephemeral' },
+      prompt_cache_breakpoint: { mode: 'explicit' },
     });
 
     const lastItem = request.body.input.at(-1);
@@ -160,12 +251,60 @@ describe('addCacheBreakpoints', () => {
       type: 'function_call_output',
       output: [
         { type: 'input_text', text: 'Tool output' },
-        { type: 'input_text', text: 'Tool detail', cache_control: { type: 'ephemeral' } },
+        { type: 'input_text', text: 'Tool detail', prompt_cache_breakpoint: { mode: 'explicit' } },
       ],
     });
   });
 
-  test('does nothing for responses requests when any cache_control is already present', () => {
+  test('adds a prompt_cache_breakpoint before environment_details and at the end of the last user message in responses', () => {
+    const request: GatewayRequest = {
+      kind: 'responses',
+      body: {
+        model: 'test-model',
+        input: [
+          {
+            type: 'message',
+            role: 'system',
+            content: 'You are helpful.',
+          },
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'Main user instructions' },
+              {
+                type: 'input_text',
+                text: '<environment_details>\nCurrent time: 2026-08-08\n</environment_details>',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
+    expect(request.body.prompt_cache_options).toEqual({ mode: 'implicit' });
+
+    const userMessage = request.body.input.at(1);
+    expect(userMessage).toMatchObject({ type: 'message', role: 'user' });
+    if (!userMessage || userMessage.type !== 'message') return;
+    expect(userMessage.content).toEqual([
+      {
+        type: 'input_text',
+        text: 'Main user instructions',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      },
+      {
+        type: 'input_text',
+        text: '<environment_details>\nCurrent time: 2026-08-08\n</environment_details>',
+        prompt_cache_breakpoint: { mode: 'explicit' },
+      },
+    ]);
+  });
+
+  test('does nothing for responses requests when any prompt_cache_breakpoint or cache_control is already present', () => {
     const request: GatewayRequest = {
       kind: 'responses',
       body: {
@@ -178,8 +317,7 @@ describe('addCacheBreakpoints', () => {
               {
                 type: 'input_text',
                 text: 'First prompt',
-                // @ts-expect-error non-standard cache_control extension
-                cache_control: { type: 'ephemeral' },
+                prompt_cache_breakpoint: { mode: 'explicit' },
               },
             ],
           },
@@ -197,6 +335,7 @@ describe('addCacheBreakpoints', () => {
 
     addCacheBreakpoints(request);
 
+    expect(request.body.prompt_cache_options).toBeUndefined();
     const lastItem = request.kind === 'responses' && request.body.input?.at(-1);
     expect(lastItem).toMatchObject({
       type: 'function_call_output',
@@ -226,6 +365,46 @@ describe('addCacheBreakpoints', () => {
     expect(request.body.cache_control).toBeUndefined();
     expect(request.body.messages.at(-1)?.content).toEqual([
       { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
+    ]);
+  });
+
+  test('adds a cache breakpoint before environment_details in messages requests', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        messages: [
+          { role: 'user', content: 'First prompt' },
+          { role: 'assistant', content: 'First response' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Latest instructions' },
+              {
+                type: 'text',
+                text: '<environment_details>\nWorking directory: /workspace\n</environment_details>',
+              },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.cache_control).toBeUndefined();
+    expect(request.body.messages.at(-1)?.content).toEqual([
+      {
+        type: 'text',
+        text: 'Latest instructions',
+        cache_control: { type: 'ephemeral' },
+      },
+      {
+        type: 'text',
+        text: '<environment_details>\nWorking directory: /workspace\n</environment_details>',
+        cache_control: { type: 'ephemeral' },
+      },
     ]);
   });
 
@@ -348,7 +527,7 @@ describe('removeCacheBreakpoints', () => {
     expect(containsCacheControlDeep(request.body.messages)).toBe(false);
   });
 
-  test('removes all cache breakpoints added to a responses request', () => {
+  test('removes all cache breakpoints and prompt_cache_options added to a responses request', () => {
     const request: GatewayRequest = {
       kind: 'responses',
       body: {
@@ -374,11 +553,12 @@ describe('removeCacheBreakpoints', () => {
 
     addCacheBreakpoints(request);
     if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
-    expect(containsCacheControlDeep(request.body.input)).toBe(true);
+    expect(containsCacheControlDeep(request.body)).toBe(true);
 
     removeCacheBreakpoints(request);
 
-    expect(containsCacheControlDeep(request.body.input)).toBe(false);
+    expect(containsCacheControlDeep(request.body)).toBe(false);
+    expect(request.body.prompt_cache_options).toBeUndefined();
   });
 
   test('removes top-level and nested cache_control from a messages request', () => {
@@ -419,7 +599,11 @@ function containsCacheControlDeep(value: unknown): boolean {
   if (typeof value !== 'object' || value === null) {
     return false;
   }
-  if (Object.hasOwn(value, 'cache_control')) {
+  if (
+    Object.hasOwn(value, 'cache_control') ||
+    Object.hasOwn(value, 'prompt_cache_breakpoint') ||
+    Object.hasOwn(value, 'prompt_cache_options')
+  ) {
     return true;
   }
   return Object.values(value).some(containsCacheControlDeep);

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -73,7 +73,7 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
-  test('adds a cache breakpoint before environment_details and at the end of the last user message in chat completions', () => {
+  test('adds a cache breakpoint before environment_details when the last message is a user message with multiple parts in chat completions', () => {
     const request: GatewayRequest = {
       kind: 'chat_completions',
       body: {
@@ -106,12 +106,11 @@ describe('addCacheBreakpoints', () => {
       {
         type: 'text',
         text: '<environment_details>\nOS: Linux\n</environment_details>',
-        cache_control: { type: 'ephemeral' },
       },
     ]);
   });
 
-  test('adds a cache breakpoint before environment_details on the last user message with environment_details across multi-turn chat completions', () => {
+  test('adds a cache breakpoint before environment_details on the last message in multi-turn chat completions', () => {
     const request: GatewayRequest = {
       kind: 'chat_completions',
       body: {
@@ -157,8 +156,41 @@ describe('addCacheBreakpoints', () => {
       {
         type: 'text',
         text: '<environment_details>\nTurn 2 env\n</environment_details>',
-        cache_control: { type: 'ephemeral' },
       },
+    ]);
+  });
+
+  test('adds a cache breakpoint at the end when the last message is a tool message even if previous user message had environment_details', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'test-model',
+        messages: [
+          { role: 'system', content: 'You are helpful.' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'User prompt' },
+              { type: 'text', text: '<environment_details>\nOS: Linux\n</environment_details>' },
+            ],
+          },
+          { role: 'assistant', content: 'Calling tool' },
+          { role: 'tool', content: 'Tool output' },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    const userContent = request.body.messages.at(1)?.content;
+    expect(userContent).toEqual([
+      { type: 'text', text: 'User prompt' },
+      { type: 'text', text: '<environment_details>\nOS: Linux\n</environment_details>' },
+    ]);
+
+    const toolContent = request.body.messages.at(3)?.content;
+    expect(toolContent).toEqual([
+      { type: 'text', text: 'Tool output', cache_control: { type: 'ephemeral' } },
     ]);
   });
 
@@ -256,7 +288,7 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
-  test('adds a prompt_cache_breakpoint before environment_details and at the end of the last user message in responses', () => {
+  test('adds a prompt_cache_breakpoint before environment_details when the last message is a user message with multiple parts in responses', () => {
     const request: GatewayRequest = {
       kind: 'responses',
       body: {
@@ -299,9 +331,38 @@ describe('addCacheBreakpoints', () => {
       {
         type: 'input_text',
         text: '<environment_details>\nCurrent time: 2026-08-08\n</environment_details>',
-        prompt_cache_breakpoint: { mode: 'explicit' },
       },
     ]);
+  });
+
+  test('does nothing for responses requests when prompt_cache_options is already present', () => {
+    const request: GatewayRequest = {
+      kind: 'responses',
+      body: {
+        model: 'test-model',
+        prompt_cache_options: { mode: 'explicit' },
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'First prompt' }],
+          },
+          {
+            type: 'function_call_output',
+            call_id: 'call_123',
+            output: [{ type: 'input_text', text: 'Tool output' }],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.prompt_cache_options).toEqual({ mode: 'explicit' });
+    const userMessage = request.body.input.at(0);
+    if (userMessage && userMessage.type === 'message' && Array.isArray(userMessage.content)) {
+      expect(userMessage.content[0]).toEqual({ type: 'input_text', text: 'First prompt' });
+    }
   });
 
   test('does nothing for responses requests when any prompt_cache_breakpoint or cache_control is already present', () => {
@@ -368,7 +429,7 @@ describe('addCacheBreakpoints', () => {
     ]);
   });
 
-  test('adds a cache breakpoint before environment_details in messages requests', () => {
+  test('adds a cache breakpoint before environment_details when the last message is a user message with multiple parts in messages', () => {
     const request: GatewayRequest = {
       kind: 'messages',
       body: {
@@ -403,7 +464,6 @@ describe('addCacheBreakpoints', () => {
       {
         type: 'text',
         text: '<environment_details>\nWorking directory: /workspace\n</environment_details>',
-        cache_control: { type: 'ephemeral' },
       },
     ]);
   });


### PR DESCRIPTION
## Summary
- In `addCacheBreakpoints`, add a cache breakpoint on the content element before `<environment_details>` on the last user message containing that prefix (in addition to the breakpoint at the end).
- Add explicit cache breakpoint support for the Responses API using `prompt_cache_breakpoint: { mode: 'explicit' }` and setting `prompt_cache_options: { mode: 'implicit' }`.
- Update `containsCacheControl`, `deleteCacheControl`, and `removeCacheBreakpoints` to recognize and clean up `prompt_cache_breakpoint` and `prompt_cache_options`.
- Add comprehensive test coverage in `openrouter-request-helpers.test.ts`.