### PR TITLE
fix(ai-gateway): stop copying source data policy onto injected providers

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/inject-extra-provider-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/inject-extra-provider-models.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, test } from '@jest/globals';
+import { injectExtraProviderModels } from '@/lib/ai-gateway/providers/openrouter/inject-extra-provider-models';
+import {
+  modelRetainsPrompts,
+  modelTrains,
+} from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
+import type {
+  OpenRouterModel,
+  OpenRouterProvider,
+} from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import type { StoredModel } from '@kilocode/db/schema-types';
+
+const MODEL_SLUG = 'nvidia/nemotron-3-super-120b-a12b';
+
+function provider(
+  slug: string,
+  displayName: string,
+  dataPolicy: OpenRouterProvider['dataPolicy']
+): OpenRouterProvider {
+  return {
+    name: displayName,
+    displayName,
+    slug,
+    dataPolicy,
+  };
+}
+
+function nvidiaModel(): OpenRouterModel {
+  return {
+    slug: MODEL_SLUG,
+    name: 'NVIDIA: Nemotron 3 Super',
+    author: 'nvidia',
+    description: '',
+    context_length: 256_000,
+    input_modalities: ['text'],
+    output_modalities: ['text'],
+    group: 'Nemotron',
+    updated_at: '2026-08-09T00:00:00.000Z',
+    endpoint: {
+      provider_display_name: 'NVIDIA',
+      is_free: true,
+      pricing: { prompt: '0', completion: '0' },
+      data_policy: { training: true, retainsPrompts: true },
+    },
+  };
+}
+
+describe('injectExtraProviderModels', () => {
+  test('does not copy the source provider data policy onto injected offerings', () => {
+    const nvidia = nvidiaModel();
+    const providerModelData = [
+      {
+        provider: provider('nvidia', 'NVIDIA', {
+          training: true,
+          retainsPrompts: true,
+          canPublish: false,
+        }),
+        models: [nvidia],
+      },
+      {
+        provider: provider('amazon-bedrock', 'Amazon Bedrock', {
+          training: false,
+          retainsPrompts: false,
+          canPublish: false,
+        }),
+        models: [] as OpenRouterModel[],
+      },
+    ];
+    const vercelModels: Record<string, StoredModel> = {
+      [MODEL_SLUG]: {
+        id: MODEL_SLUG,
+        name: 'NVIDIA Nemotron 3 Super',
+        endpoints: [
+          {
+            provider_name: 'nvidia',
+            pricing: { prompt: '0', completion: '0' },
+          },
+          {
+            provider_name: 'bedrock',
+            context_length: 256_000,
+            pricing: { prompt: '0.15', completion: '0.65' },
+          },
+        ],
+      },
+    };
+
+    injectExtraProviderModels(vercelModels, providerModelData);
+
+    const injected = providerModelData[1]?.models[0];
+    expect(injected?.slug).toBe(MODEL_SLUG);
+    expect(injected?.endpoint).toEqual({
+      provider_display_name: 'Amazon Bedrock',
+      is_free: false,
+      pricing: { prompt: '0.15', completion: '0.65' },
+    });
+    expect(injected && modelTrains(injected, false)).toBe(false);
+    expect(injected && modelRetainsPrompts(injected, false)).toBe(false);
+    expect(nvidia.endpoint?.data_policy).toEqual({ training: true, retainsPrompts: true });
+    expect(modelTrains(nvidia, true)).toBe(true);
+    expect(modelRetainsPrompts(nvidia, true)).toBe(true);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/inject-extra-provider-models.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/inject-extra-provider-models.ts
@@ -1,0 +1,66 @@
+import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
+import {
+  openRouterToVercelInferenceProviderId,
+  VercelInferenceProviderIdSchema,
+} from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
+import type {
+  OpenRouterModel,
+  OpenRouterProvider,
+} from '@/lib/ai-gateway/providers/openrouter/openrouter-types';
+import type { StoredModel } from '@kilocode/db/schema-types';
+
+export function injectExtraProviderModels(
+  vercelModels: Record<string, StoredModel>,
+  providerModelData: Array<{ provider: OpenRouterProvider; models: OpenRouterModel[] }>
+) {
+  const openRouterModels = new Map<string, OpenRouterModel>();
+  for (const { models } of providerModelData) {
+    for (const model of models) {
+      openRouterModels.set(model.slug, model);
+    }
+  }
+  for (const model of openRouterModels.values()) {
+    const vercelModel = vercelModels[mapModelIdToVercel(model.slug)];
+    if (!vercelModel) continue;
+
+    const vercelInferenceProviders = new Set(
+      vercelModel.endpoints
+        .map(
+          endpoint =>
+            VercelInferenceProviderIdSchema.safeParse(endpoint.provider_name ?? endpoint.tag).data
+        )
+        .filter(p => p !== undefined)
+    );
+
+    for (const providerData of providerModelData) {
+      const vercelProviderId = VercelInferenceProviderIdSchema.safeParse(
+        openRouterToVercelInferenceProviderId(providerData.provider.slug)
+      ).data;
+      const endpoint = vercelModel.endpoints.find(e => e.provider_name === vercelProviderId);
+      if (
+        vercelProviderId &&
+        endpoint &&
+        vercelInferenceProviders.has(vercelProviderId) &&
+        !providerData.models.some(m => m.slug === model.slug)
+      ) {
+        const freeSuffixIndex = model.name.indexOf(' (free)');
+        const m = {
+          ...model,
+          name: freeSuffixIndex >= 0 ? model.name.substring(0, freeSuffixIndex) : model.name,
+          context_length: endpoint.context_length ?? model.context_length,
+          endpoint: {
+            provider_display_name: providerData.provider.displayName,
+            is_free: !endpoint.pricing?.prompt,
+            pricing: endpoint.pricing ?? { prompt: '0', completion: '0' },
+          },
+        };
+        console.warn(
+          '[injectExtraProviderModels] Adding missing model to provider %s: %s',
+          providerData.provider.name,
+          m.name
+        );
+        providerData.models.push(m);
+      }
+    }
+  }
+}

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -36,15 +36,11 @@ import {
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { syncDirectByokModels } from '@/lib/ai-gateway/providers/direct-byok/sync-direct-byok';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
-import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
-import {
-  openRouterToVercelInferenceProviderId,
-  VercelInferenceProviderIdSchema,
-} from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import {
   applyFreeEndpointDataPolicy,
   getOpenRouterFreeEndpoints,
 } from '@/lib/ai-gateway/providers/openrouter/free-endpoint-data-policy';
+import { injectExtraProviderModels } from '@/lib/ai-gateway/providers/openrouter/inject-extra-provider-models';
 import { withWorstProviderDataPolicy } from '@/lib/ai-gateway/providers/openrouter/model-data-policy';
 import { isUnavailableModel } from '@/lib/ai-gateway/unavailable-models';
 import { injectSupportedFimModels } from '@/lib/ai-gateway/supported-fim-models';
@@ -190,63 +186,6 @@ async function fetchModelsForProvider(provider: OpenRouterProvider): Promise<Ope
   // Note: Models still contain redundant provider info in endpoint.provider_info, etc.
   // This is now available in the comprehensive providers array, but we keep it for compatibility
   return data.data.models;
-}
-
-function injectExtraProviderModels(
-  vercelModels: Record<string, StoredModel>,
-  providerModelData: Array<{ provider: OpenRouterProvider; models: OpenRouterModel[] }>
-) {
-  const openRouterModels = new Map<string, OpenRouterModel>();
-  for (const { models } of providerModelData) {
-    for (const model of models) {
-      openRouterModels.set(model.slug, model);
-    }
-  }
-  for (const model of openRouterModels.values()) {
-    const vercelModel = vercelModels[mapModelIdToVercel(model.slug)];
-    if (!vercelModel) continue;
-
-    const vercelInferenceProviders = new Set(
-      vercelModel.endpoints
-        .map(
-          endpoint =>
-            VercelInferenceProviderIdSchema.safeParse(endpoint.provider_name ?? endpoint.tag).data
-        )
-        .filter(p => p !== undefined)
-    );
-
-    for (const providerData of providerModelData) {
-      const vercelProviderId = VercelInferenceProviderIdSchema.safeParse(
-        openRouterToVercelInferenceProviderId(providerData.provider.slug)
-      ).data;
-      const endpoint = vercelModel.endpoints.find(e => e.provider_name === vercelProviderId);
-      if (
-        vercelProviderId &&
-        endpoint &&
-        vercelInferenceProviders.has(vercelProviderId) &&
-        !providerData.models.some(m => m.slug === model.slug)
-      ) {
-        const freeSuffixIndex = model.name.indexOf(' (free)');
-        const m = {
-          ...model,
-          name: freeSuffixIndex >= 0 ? model.name.substring(0, freeSuffixIndex) : model.name,
-          context_length: endpoint.context_length ?? model.context_length,
-          endpoint: {
-            ...model.endpoint,
-            provider_display_name: providerData.provider.displayName,
-            is_free: !endpoint.pricing?.prompt,
-            pricing: endpoint.pricing ?? { prompt: '0', completion: '0' },
-          },
-        };
-        console.warn(
-          '[injectExtraProviderModels] Adding missing model to provider %s: %s',
-          providerData.provider.name,
-          m.name
-        );
-        providerData.models.push(m);
-      }
-    }
-  }
 }
 
 async function syncProviders(


### PR DESCRIPTION
## Summary

`injectExtraProviderModels` adds Vercel-only routes (for example Amazon Bedrock on `nvidia/nemotron-3-super-120b-a12b`) by cloning an OpenRouter offering from another provider. It also copied that source endpoint's `data_policy`, so Trains/Retains on the injected row showed NVIDIA's Yes/Yes instead of Bedrock's provider default.

Injected endpoints now only carry display name, pricing, and freeness. Missing `data_policy` makes the model details UI fall back to the target provider default.

## Verification

- [ ] Did not run tests locally per request; waiting on CI.

## Visual Changes

N/A

## Reviewer Notes

After the next provider sync, Bedrock (and any other injected extra provider) should show its own Trains/Retains defaults rather than the source offering's policy.