### PR TITLE
feat(ai-gateway): cache system and developer prompts

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -225,13 +225,12 @@ export function addCacheBreakpoints(request: GatewayRequest) {
   } else if (
     request.kind === 'messages' &&
     request.body.messages.length > 1 &&
-    !containsCacheControl(request.body.messages) &&
-    !containsCacheControl(request.body.system)
+    !containsCacheControl(request.body.messages)
   ) {
     const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
     delete request.body.cache_control;
 
-    if (request.body.system) {
+    if (request.body.system && !containsCacheControl(request.body.system)) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on messages system prompt');
       request.body.system = setCacheControlOnMessagesSystem(request.body.system, cacheControl);
     }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -101,6 +101,30 @@ function setCacheControlOnMessagesMessage(
   }
 }
 
+function setCacheControlOnMessagesSystem(
+  system: string | Anthropic.TextBlockParam[],
+  cacheControl: Anthropic.CacheControlEphemeral
+): Anthropic.TextBlockParam[] {
+  if (typeof system === 'string') {
+    return [
+      {
+        type: 'text',
+        text: system,
+        cache_control: cacheControl,
+      },
+    ];
+  }
+  const lastBlock = system.at(-1);
+  if (lastBlock) {
+    lastBlock.cache_control = cacheControl;
+  }
+  return system;
+}
+
+function isSystemOrDeveloperRole(role: string): boolean {
+  return role === 'system' || role === 'developer';
+}
+
 function isCacheableMessagesContentBlock(
   item: Anthropic.ContentBlockParam
 ): item is Exclude<
@@ -158,10 +182,10 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     request.body.messages.length > 1 &&
     !containsCacheControl(request.body.messages)
   ) {
-    const systemMessage = request.body.messages.find(msg => msg.role === 'system');
+    const systemMessage = request.body.messages.find(msg => isSystemOrDeveloperRole(msg.role));
     if (systemMessage) {
       console.debug(
-        '[addCacheBreakpoints] setting cache breakpoint on system chat completions message'
+        `[addCacheBreakpoints] setting cache breakpoint on ${systemMessage.role} chat completions message`
       );
       setCacheControlOnChatCompletionsMessage(systemMessage);
     }
@@ -181,10 +205,12 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     !containsCacheControl(request.body.input)
   ) {
     const systemMessage = request.body.input.find(
-      msg => msg.type === 'message' && msg.role === 'system'
+      msg => msg.type === 'message' && isSystemOrDeveloperRole(msg.role)
     );
-    if (systemMessage) {
-      console.debug('[addCacheBreakpoints] setting cache breakpoint on system responses message');
+    if (systemMessage && systemMessage.type === 'message') {
+      console.debug(
+        `[addCacheBreakpoints] setting cache breakpoint on ${systemMessage.role} responses message`
+      );
       setCacheControlOnResponsesMessage(systemMessage);
     }
     const lastMessage = request.body.input.findLast(
@@ -199,14 +225,21 @@ export function addCacheBreakpoints(request: GatewayRequest) {
   } else if (
     request.kind === 'messages' &&
     request.body.messages.length > 1 &&
-    !containsCacheControl(request.body.messages)
+    !containsCacheControl(request.body.messages) &&
+    !containsCacheControl(request.body.system)
   ) {
+    const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
+    delete request.body.cache_control;
+
+    if (request.body.system) {
+      console.debug('[addCacheBreakpoints] setting cache breakpoint on messages system prompt');
+      request.body.system = setCacheControlOnMessagesSystem(request.body.system, cacheControl);
+    }
+
     const lastMessage = request.body.messages.findLast(hasCacheableMessagesContent);
     if (lastMessage) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on last messages message');
       // Vercel AI Gateway does not honor top-level cache_control on Messages API requests.
-      const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
-      delete request.body.cache_control;
       setCacheControlOnMessagesMessage(lastMessage, cacheControl);
     }
   }
@@ -222,6 +255,9 @@ export function removeCacheBreakpoints(request: GatewayRequest) {
   } else if (request.kind === 'messages') {
     console.debug('[removeCacheBreakpoints] removing cache breakpoints from messages request');
     delete request.body.cache_control;
+    if (request.body.system) {
+      deleteCacheControl(request.body.system);
+    }
     deleteCacheControl(request.body.messages);
   }
 }

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -48,6 +48,30 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
+  test('adds a cache breakpoint to a developer message in chat completions', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'test-model',
+        messages: [
+          { role: 'developer', content: 'Developer guidelines.' },
+          { role: 'user', content: 'Hello' },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    const developerContent = request.body.messages.at(0)?.content;
+    expect(developerContent).toEqual([
+      {
+        type: 'text',
+        text: 'Developer guidelines.',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
   test('adds a cache breakpoint to the last eligible chat completions message when there is no system message', () => {
     const request: GatewayRequest = {
       kind: 'chat_completions',
@@ -165,6 +189,33 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
+  test('adds a cache breakpoint to a developer message in responses', () => {
+    const request: GatewayRequest = {
+      kind: 'responses',
+      body: {
+        model: 'test-model',
+        input: [
+          { type: 'message', role: 'developer', content: 'Developer instructions.' },
+          { type: 'message', role: 'user', content: [{ type: 'input_text', text: 'Hello' }] },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
+    const developerMessage = request.body.input.at(0);
+    expect(developerMessage).toMatchObject({ type: 'message', role: 'developer' });
+    if (!developerMessage || developerMessage.type !== 'message') return;
+    expect(developerMessage.content).toEqual([
+      {
+        type: 'input_text',
+        text: 'Developer instructions.',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
+
   test('does nothing for responses requests when any cache_control is already present', () => {
     const request: GatewayRequest = {
       kind: 'responses',
@@ -205,6 +256,66 @@ describe('addCacheBreakpoints', () => {
         { type: 'input_text', text: 'Tool detail' },
       ],
     });
+  });
+
+  test('adds cache_control to the system prompt and last message of a messages request', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        system: 'System instructions',
+        messages: [
+          { role: 'user', content: 'First prompt' },
+          { role: 'assistant', content: 'First response' },
+          { role: 'user', content: 'Latest prompt' },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.cache_control).toBeUndefined();
+    expect(request.body.system).toEqual([
+      {
+        type: 'text',
+        text: 'System instructions',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+    expect(request.body.messages.at(-1)?.content).toEqual([
+      { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
+    ]);
+  });
+
+  test('adds cache_control to the last system block of a messages request', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        system: [
+          { type: 'text', text: 'Stable instructions' },
+          { type: 'text', text: 'Additional context' },
+        ],
+        messages: [
+          { role: 'user', content: 'First prompt' },
+          { role: 'assistant', content: 'First response' },
+          { role: 'user', content: 'Latest prompt' },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.system).toEqual([
+      { type: 'text', text: 'Stable instructions' },
+      {
+        type: 'text',
+        text: 'Additional context',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
   });
 
   test('adds cache_control to the last content block of a messages request', () => {
@@ -388,6 +499,13 @@ describe('removeCacheBreakpoints', () => {
         model: 'anthropic/claude-sonnet-4-5',
         max_tokens: 1024,
         cache_control: { type: 'ephemeral' },
+        system: [
+          {
+            type: 'text',
+            text: 'System instructions',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
         messages: [
           {
             role: 'user',
@@ -408,6 +526,7 @@ describe('removeCacheBreakpoints', () => {
     removeCacheBreakpoints(request);
 
     expect(request.body.cache_control).toBeUndefined();
+    expect(containsCacheControlDeep(request.body.system)).toBe(false);
     expect(containsCacheControlDeep(request.body.messages)).toBe(false);
   });
 });

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -340,6 +340,47 @@ describe('addCacheBreakpoints', () => {
     ]);
   });
 
+  test('migrates top-level cache_control onto the last message when system already has cache_control', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        cache_control: { type: 'ephemeral', ttl: '1h' },
+        system: [
+          {
+            type: 'text',
+            text: 'System instructions',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+        messages: [
+          { role: 'user', content: 'First prompt' },
+          { role: 'assistant', content: 'First response' },
+          { role: 'user', content: 'Latest prompt' },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.cache_control).toBeUndefined();
+    expect(request.body.system).toEqual([
+      {
+        type: 'text',
+        text: 'System instructions',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+    expect(request.body.messages.at(-1)?.content).toEqual([
+      {
+        type: 'text',
+        text: 'Latest prompt',
+        cache_control: { type: 'ephemeral', ttl: '1h' },
+      },
+    ]);
+  });
+
   test('adds nested cache_control when an unhonored top-level value is present', () => {
     const request: GatewayRequest = {
       kind: 'messages',


### PR DESCRIPTION
## Summary

- Set a cache breakpoint on `system` and `developer` chat/responses messages in `addCacheBreakpoints`.
- Set a cache breakpoint on the Anthropic Messages API top-level `system` prompt, in addition to the last eligible message.
- Clear `system` cache control in `removeCacheBreakpoints`.

This lets prompt caching reuse the stable instruction prefix instead of only the last user/tool turn.

## Verification

- [ ] No manual test. Unit coverage was added in `openrouter-request-helpers.test.ts`; CI should run the web Jest suite.

## Visual Changes

N/A