### PR TITLE
feat(exports): require internal api key and user credential

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -23,7 +23,7 @@ Manage shared web env var additions and rotations with `pnpm web:env set <VARIAB
 - `APP_URL_OVERRIDE` - Optional base application URL override in any environment; used in `apps/web/src/lib/constants.ts` and `next.config.mjs`. When unset, Vercel's `staging` target uses `https://staging-app.kilo.ai`, production uses `https://app.kilo.ai`, and local development uses `PORT`. [SERVER]
 - `KILOCLAW_INSTANCE_URL_TEMPLATE` - URL template for KiloClaw instances; used in `apps/web/src/lib/config.server.ts`. [SERVER]
 - `NEXTAUTH_URL` - Base URL for NextAuth.js; used across many auth-related files. [SERVER]
-- `NEXTAUTH_SECRET` - Secret key for NextAuth.js session encryption; used across many auth-related files. `[SECRET]`
+- `NEXTAUTH_SECRET` - Secret key for NextAuth.js session encryption and five-minute, audience-bound user assertions verified by internal Workers such as user data export. `[SECRET]`
 - `DEBUG_SHOW_DEV_UI` - Enables dev-only UI elements (debug panels, admin buttons); checked in `apps/web/src/lib/constants.ts` and `apps/web/src/app/(app)/profile/page.tsx`. [SERVER]
 - `TRPC_TIMING_LOGGING` - Enables tRPC timing logs in development; checked in `apps/web/src/lib/trpc/init.ts`. [SERVER]
 - `JEST_MAX_WORKERS` - Limits max worker threads for Jest; read in `apps/web/jest.config.ts`. [SERVER]

--- a/apps/web/src/lib/user-data-export-worker-client.test.ts
+++ b/apps/web/src/lib/user-data-export-worker-client.test.ts
@@ -1,8 +1,10 @@
 jest.mock('@/lib/config.server', () => ({
   INTERNAL_API_SECRET: 'test-secret',
+  NEXTAUTH_SECRET: 'test-nextauth-secret',
   USER_DATA_EXPORT_WORKER_URL: 'http://127.0.0.1:8787',
 }));
 
+import jwt from 'jsonwebtoken';
 import { __test__ } from '@/lib/user-data-export-worker-client';
 
 describe('user data export Worker client', () => {
@@ -19,19 +21,29 @@ describe('user data export Worker client', () => {
     expect(__test__.exportWorkerUrl(value) !== null).toBe(allowed);
   });
 
-  it('uses the internal API secret, timeout, and refuses redirects', async () => {
+  it('uses the internal API secret plus a five-minute audience-bound user assertion', async () => {
     const fetchImpl = jest.fn().mockResolvedValue(new Response(null, { status: 202 }));
     const response = await __test__.postExportWorker(
       '/internal/exports/dispatch',
+      'user-id',
       { exportId: 'id' },
       fetchImpl
     );
 
+    const request = fetchImpl.mock.calls[0]?.[1] as RequestInit | undefined;
+    const authorization = new Headers(request?.headers).get('authorization');
+    expect(authorization).toMatch(/^Bearer /);
+    const decoded = jwt.decode(authorization?.slice(7) ?? '') as jwt.JwtPayload;
+    expect(decoded.kiloUserId).toBe('user-id');
+    expect(decoded.aud).toBe('user-data-export');
+    expect(decoded.exp! - decoded.iat!).toBe(300);
+    expect(JSON.parse(String(request?.body))).toEqual({ exportId: 'id' });
     expect(fetchImpl).toHaveBeenCalledWith(
       new URL('http://127.0.0.1:8787/internal/exports/dispatch'),
       expect.objectContaining({
         redirect: 'error',
         headers: expect.objectContaining({
+          authorization: expect.stringMatching(/^Bearer /),
           'x-internal-api-key': 'test-secret',
         }),
         signal: expect.any(AbortSignal),
@@ -43,6 +55,7 @@ describe('user data export Worker client', () => {
   it('returns an unavailable result when the Worker defers signing', async () => {
     const response = await __test__.postExportWorker(
       '/internal/exports/download',
+      'user-id',
       { exportId: 'id' },
       jest.fn().mockResolvedValue(new Response(null, { status: 501 }))
     );

--- a/apps/web/src/lib/user-data-export-worker-client.ts
+++ b/apps/web/src/lib/user-data-export-worker-client.ts
@@ -2,6 +2,11 @@ import 'server-only';
 
 import { z } from 'zod';
 import { INTERNAL_API_SECRET, USER_DATA_EXPORT_WORKER_URL } from '@/lib/config.server';
+import { generateInternalServiceToken } from '@/lib/tokens';
+import {
+  USER_DATA_EXPORT_ASSERTION_TTL_SECONDS,
+  USER_DATA_EXPORT_AUDIENCE,
+} from '@kilocode/worker-utils/internal-service-token-audiences';
 
 const LOCAL_EXPORT_WORKER_HOSTS = new Set(['localhost', '127.0.0.1', '[::1]']);
 const DEPLOYED_EXPORT_WORKER_HOSTS = new Set(['user-data-export.kilosessions.ai']);
@@ -34,6 +39,7 @@ function exportWorkerUrl(value: string | undefined): URL | null {
 
 async function postExportWorker(
   path: string,
+  kiloUserId: string,
   body: object,
   fetchImpl: typeof fetch = fetch
 ): Promise<Response | null> {
@@ -41,12 +47,17 @@ async function postExportWorker(
   if (!baseUrl || !INTERNAL_API_SECRET) return null;
 
   const url = new URL(path, baseUrl);
+  const userAssertion = generateInternalServiceToken(kiloUserId, {
+    expiresIn: USER_DATA_EXPORT_ASSERTION_TTL_SECONDS,
+    audience: USER_DATA_EXPORT_AUDIENCE,
+  });
   try {
     const response = await fetchImpl(url, {
       method: 'POST',
       redirect: 'error',
       headers: {
         'content-type': 'application/json',
+        authorization: `Bearer ${userAssertion}`,
         'x-internal-api-key': INTERNAL_API_SECRET,
       },
       body: JSON.stringify(body),
@@ -61,8 +72,9 @@ async function postExportWorker(
 export async function dispatchUserDataExport(input: {
   exportId: string;
   generation: number;
+  kiloUserId: string;
 }): Promise<DispatchWorkerResponse> {
-  const response = await postExportWorker('/internal/exports/dispatch', {
+  const response = await postExportWorker('/internal/exports/dispatch', input.kiloUserId, {
     version: 1,
     operation: 'generate',
     exportId: input.exportId,
@@ -80,7 +92,10 @@ export async function requestUserDataExportDownload(input: {
   exportId: string;
   kiloUserId: string;
 }): Promise<DownloadWorkerResponse> {
-  const response = await postExportWorker('/internal/exports/download', { version: 1, ...input });
+  const response = await postExportWorker('/internal/exports/download', input.kiloUserId, {
+    version: 1,
+    exportId: input.exportId,
+  });
   if (!response) return { kind: 'unavailable', reason: 'not_configured' };
   if (response.status === 501) return { kind: 'unavailable', reason: 'not_implemented' };
   if (!response.ok) return { kind: 'unavailable', reason: 'not_configured' };

--- a/apps/web/src/routers/user-exports-router.ts
+++ b/apps/web/src/routers/user-exports-router.ts
@@ -115,7 +115,11 @@ export const userExportsRouter = createTRPCRouter({
 
     // The outbox remains authoritative if the Worker is unavailable after commit.
     if (row.status === 'queued')
-      await dispatchUserDataExport({ exportId: row.id, generation: row.dispatch_generation });
+      await dispatchUserDataExport({
+        exportId: row.id,
+        generation: row.dispatch_generation,
+        kiloUserId: ctx.user.id,
+      });
     return serialize(row);
   }),
 

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -11,6 +11,7 @@
     "./internal-service-token-audiences": "./src/internal-service-token-audiences.ts",
     "./instance-id": "./src/instance-id.ts",
     "./kilo-token-auth": "./src/kilo-token-auth.ts",
+    "./kilo-token": "./src/kilo-token.ts",
     "./sandbox-id": "./src/sandbox-id.ts",
     "./hostname-label": "./src/hostname-label.ts",
     "./deployment-slug": "./src/deployment-slug.ts",

--- a/packages/worker-utils/src/internal-service-token-audiences.ts
+++ b/packages/worker-utils/src/internal-service-token-audiences.ts
@@ -7,3 +7,5 @@ export const BITBUCKET_CODE_REVIEW_WEBHOOK_DELETE_AUDIENCE =
   'git-token-service:bitbucket-code-review:webhook-delete';
 export const GITLAB_CREDENTIAL_BROKER_AUDIENCE = 'git-token-service:gitlab-credentials';
 export const GITHUB_USER_ACCESS_TOKEN_AUDIENCE = 'git-token-service:github-user-access-token';
+export const USER_DATA_EXPORT_AUDIENCE = 'user-data-export';
+export const USER_DATA_EXPORT_ASSERTION_TTL_SECONDS = 5 * 60;

--- a/services/user-data-export/.dev.vars.example
+++ b/services/user-data-export/.dev.vars.example
@@ -1,5 +1,7 @@
 # @from INTERNAL_API_SECRET
 INTERNAL_API_SECRET=
+# @from NEXTAUTH_SECRET
+NEXTAUTH_SECRET=
 
 # Local-only placeholders. Production uses standard Worker secrets set with
 # `wrangler secret put`; never put production values in this file.

--- a/services/user-data-export/src/contracts.test.ts
+++ b/services/user-data-export/src/contracts.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { ExportQueueMessageSchema, parseCursor } from './contracts';
+import { DownloadRequestSchema, ExportQueueMessageSchema, parseCursor } from './contracts';
 
 describe('ExportQueueMessageSchema', () => {
   it('accepts only a versioned durable generation reference', () => {
@@ -18,6 +18,24 @@ describe('ExportQueueMessageSchema', () => {
         exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
         generation: -1,
         prompt: 'must not be present',
+      }).success
+    ).toBe(false);
+  });
+});
+
+describe('DownloadRequestSchema', () => {
+  it('accepts only export identity and derives user scope from auth', () => {
+    expect(
+      DownloadRequestSchema.safeParse({
+        version: 1,
+        exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+      }).success
+    ).toBe(true);
+    expect(
+      DownloadRequestSchema.safeParse({
+        version: 1,
+        exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+        kiloUserId: 'other-user',
       }).success
     ).toBe(false);
   });

--- a/services/user-data-export/src/contracts.ts
+++ b/services/user-data-export/src/contracts.ts
@@ -19,7 +19,6 @@ export const DownloadRequestSchema = z
   .object({
     version: z.literal(EXPORT_SCHEMA_VERSION),
     exportId: z.string().uuid(),
-    kiloUserId: z.string().min(1),
   })
   .strict();
 

--- a/services/user-data-export/src/databases.ts
+++ b/services/user-data-export/src/databases.ts
@@ -188,6 +188,14 @@ export function createStateDb(binding: HyperdriveBinding) {
         WHERE export_id = ${exportId} AND generation = ${generation} AND operation = 'generate'
       `);
     },
+    async exportBelongsToUser(exportId: string, kiloUserId: string): Promise<boolean> {
+      const rows = await db.execute<{ id: string }>(sql`
+        SELECT id FROM user_data_exports
+        WHERE id = ${exportId} AND kilo_user_id = ${kiloUserId}
+        LIMIT 1
+      `);
+      return rows.rows.length > 0;
+    },
     async readyObject(exportId: string, kiloUserId: string): Promise<ReadyExportObject | null> {
       const rows = await db.execute<ReadyExportObject>(sql`
         SELECT r2_object_key, expires_at

--- a/services/user-data-export/src/index.test.ts
+++ b/services/user-data-export/src/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { __test__ } from './index';
 
 describe('download URL expiration', () => {
@@ -34,5 +34,46 @@ describe('internal request parsing', () => {
     } as RequestInit & { duplex: 'half' });
 
     await expect(__test__.readJson(request)).rejects.toThrow('Request body is too large');
+  });
+});
+
+describe('dispatch authorization', () => {
+  const message = {
+    version: 1,
+    operation: 'generate',
+    exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+    generation: 0,
+  } as const;
+
+  it("does not enqueue or acknowledge another user's export", async () => {
+    const state = {
+      exportBelongsToUser: vi.fn().mockResolvedValue(false),
+      markOutboxGenerationSent: vi.fn(),
+    };
+    const queue = { send: vi.fn() };
+
+    await expect(__test__.dispatchExport(message, 'other-user', state, queue)).resolves.toBe(
+      'not_found'
+    );
+    expect(state.exportBelongsToUser).toHaveBeenCalledWith(message.exportId, 'other-user');
+    expect(queue.send).not.toHaveBeenCalled();
+    expect(state.markOutboxGenerationSent).not.toHaveBeenCalled();
+  });
+
+  it('enqueues an owned export without putting the assertion in the message', async () => {
+    const state = {
+      exportBelongsToUser: vi.fn().mockResolvedValue(true),
+      markOutboxGenerationSent: vi.fn(),
+    };
+    const queue = { send: vi.fn() };
+
+    await expect(__test__.dispatchExport(message, 'owner-user', state, queue)).resolves.toBe(
+      'accepted'
+    );
+    expect(queue.send).toHaveBeenCalledWith(message);
+    expect(state.markOutboxGenerationSent).toHaveBeenCalledWith(
+      message.exportId,
+      message.generation
+    );
   });
 });

--- a/services/user-data-export/src/index.ts
+++ b/services/user-data-export/src/index.ts
@@ -1,6 +1,14 @@
 import { AdmitExportSchema, DownloadRequestSchema } from './contracts';
 import type { ExportEnv } from './worker';
+import type { ExportQueueMessage } from './contracts';
+import type { StateDb } from './databases';
 import { createR2Client } from '@kilocode/worker-utils/r2-client';
+import { verifyKiloToken } from '@kilocode/worker-utils/kilo-token';
+import { extractBearerToken } from '@kilocode/worker-utils';
+import {
+  USER_DATA_EXPORT_ASSERTION_TTL_SECONDS,
+  USER_DATA_EXPORT_AUDIENCE,
+} from '@kilocode/worker-utils/internal-service-token-audiences';
 
 const DOWNLOAD_EXPIRES_SECONDS = 300;
 const DOWNLOAD_CONTENT_DISPOSITION = 'attachment; filename="kilo-data-export.jsonl.gz"';
@@ -22,6 +30,41 @@ async function authorized(request: Request, expected: string): Promise<boolean> 
     crypto.subtle.digest('SHA-256', encoder.encode(expected)),
   ]);
   return left.byteLength === right.byteLength && crypto.subtle.timingSafeEqual(left, right);
+}
+
+async function authenticatedUserId(request: Request, env: ExportEnv): Promise<string | null> {
+  if (!(await authorized(request, env.INTERNAL_API_SECRET))) return null;
+  const token = extractBearerToken(request.headers.get('authorization'));
+  if (!token) return null;
+  try {
+    const payload = await verifyKiloToken(token, env.NEXTAUTH_SECRET, {
+      audience: USER_DATA_EXPORT_AUDIENCE,
+    });
+    const now = Math.floor(Date.now() / 1000);
+    if (
+      payload.iat === undefined ||
+      payload.exp === undefined ||
+      payload.iat > now + 30 ||
+      payload.exp - payload.iat > USER_DATA_EXPORT_ASSERTION_TTL_SECONDS
+    ) {
+      return null;
+    }
+    return payload.kiloUserId;
+  } catch {
+    return null;
+  }
+}
+
+async function dispatchExport(
+  message: ExportQueueMessage,
+  kiloUserId: string,
+  state: Pick<StateDb, 'exportBelongsToUser' | 'markOutboxGenerationSent'>,
+  queue: Pick<Queue<ExportQueueMessage>, 'send'>
+): Promise<'accepted' | 'not_found'> {
+  if (!(await state.exportBelongsToUser(message.exportId, kiloUserId))) return 'not_found';
+  await queue.send(message);
+  await state.markOutboxGenerationSent(message.exportId, message.generation);
+  return 'accepted';
 }
 
 async function readJson(request: Request): Promise<unknown> {
@@ -58,7 +101,8 @@ export default {
     if (request.method === 'GET' && url.pathname === '/health') {
       return Response.json({ ok: true, service: 'user-data-export' });
     }
-    if (!(await authorized(request, env.INTERNAL_API_SECRET))) {
+    const kiloUserId = await authenticatedUserId(request, env);
+    if (!kiloUserId) {
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
     try {
@@ -66,12 +110,13 @@ export default {
         const parsed = AdmitExportSchema.safeParse(await readJson(request));
         if (!parsed.success)
           return Response.json({ error: 'Invalid export dispatch' }, { status: 400 });
-        await env.EXPORT_QUEUE.send(parsed.data);
         const { createStateDb } = await import('./databases');
-        await createStateDb(env.PRIMARY_STATE_DB).markOutboxGenerationSent(
-          parsed.data.exportId,
-          parsed.data.generation
-        );
+        const state = createStateDb(env.PRIMARY_STATE_DB);
+        if (
+          (await dispatchExport(parsed.data, kiloUserId, state, env.EXPORT_QUEUE)) === 'not_found'
+        ) {
+          return Response.json({ error: 'Export not found' }, { status: 404 });
+        }
         return Response.json({ accepted: true }, { status: 202 });
       }
       if (request.method === 'POST' && url.pathname === '/internal/exports/download') {
@@ -81,7 +126,7 @@ export default {
         const { createStateDb } = await import('./databases');
         const object = await createStateDb(env.PRIMARY_STATE_DB).readyObject(
           parsed.data.exportId,
-          parsed.data.kiloUserId
+          kiloUserId
         );
         if (!object) return Response.json({ error: 'Export not found' }, { status: 404 });
         const expiration = downloadExpiration(object.expires_at);
@@ -118,4 +163,4 @@ export default {
   },
 } satisfies ExportedHandler<ExportEnv>;
 
-export const __test__ = { downloadExpiration, readJson };
+export const __test__ = { downloadExpiration, readJson, authenticatedUserId, dispatchExport };

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -20,6 +20,7 @@ export type ExportEnv = {
   EXPORT_BUCKET: R2Bucket;
   EXPORT_QUEUE: Queue<ExportQueueMessage>;
   INTERNAL_API_SECRET: string;
+  NEXTAUTH_SECRET: string;
   R2_ACCESS_KEY_ID: string;
   R2_SECRET_ACCESS_KEY: string;
   R2_ACCOUNT_ID: string;

--- a/services/user-data-export/test/worker.test.ts
+++ b/services/user-data-export/test/worker.test.ts
@@ -1,8 +1,22 @@
 import { env, SELF } from 'cloudflare:test';
 import { describe, expect, it } from 'vitest';
+import { USER_DATA_EXPORT_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
+import { signKiloToken } from '@kilocode/worker-utils/kilo-token';
 
 describe('user-data-export worker', () => {
   const internalApiKey = String(env.INTERNAL_API_SECRET);
+  const nextAuthSecret = String(env.NEXTAUTH_SECRET);
+
+  async function userAssertion(options?: { audience?: string; expiresIn?: number }) {
+    const result = await signKiloToken({
+      userId: 'user-id',
+      pepper: null,
+      secret: nextAuthSecret,
+      expiresInSeconds: options?.expiresIn ?? 300,
+      audience: options?.audience ?? USER_DATA_EXPORT_AUDIENCE,
+    });
+    return result.token;
+  }
 
   it('keeps health public and rejects missing or incorrect internal API keys', async () => {
     const health = await SELF.fetch('https://worker.local/health');
@@ -20,20 +34,59 @@ describe('user-data-export worker', () => {
     expect(incorrectKey.status).toBe(401);
   });
 
-  it('accepts the standard internal API key header', async () => {
-    const response = await SELF.fetch('https://worker.local/internal/exports/dispatch', {
+  it('requires both the internal API key and user assertion', async () => {
+    const assertion = await userAssertion();
+    const missingAssertion = await SELF.fetch('https://worker.local/internal/exports/dispatch', {
       method: 'POST',
       headers: { 'x-internal-api-key': internalApiKey },
+      body: '{}',
+    });
+    expect(missingAssertion.status).toBe(401);
+
+    const missingInternalKey = await SELF.fetch('https://worker.local/internal/exports/dispatch', {
+      method: 'POST',
+      headers: { authorization: `Bearer ${assertion}` },
+      body: '{}',
+    });
+    expect(missingInternalKey.status).toBe(401);
+
+    const response = await SELF.fetch('https://worker.local/internal/exports/dispatch', {
+      method: 'POST',
+      headers: {
+        authorization: `bearer ${assertion}`,
+        'x-internal-api-key': internalApiKey,
+      },
       body: '{}',
     });
 
     expect(response.status).toBe(400);
   });
 
+  it('rejects assertions with the wrong audience, expiration, or lifetime', async () => {
+    for (const assertion of [
+      await userAssertion({ audience: 'other-service' }),
+      await userAssertion({ expiresIn: -1 }),
+      await userAssertion({ expiresIn: 301 }),
+    ]) {
+      const response = await SELF.fetch('https://worker.local/internal/exports/dispatch', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${assertion}`,
+          'x-internal-api-key': internalApiKey,
+        },
+        body: '{}',
+      });
+      expect(response.status).toBe(401);
+    }
+  });
+
   it('rejects a chunked internal request body over 16 KiB', async () => {
     const response = await SELF.fetch('https://worker.local/internal/exports/dispatch', {
       method: 'POST',
-      headers: { 'x-internal-api-key': internalApiKey },
+      headers: {
+        authorization: `Bearer ${await userAssertion()}`,
+        'x-internal-api-key': internalApiKey,
+      },
       body: 'x'.repeat(16_385),
     });
 

--- a/services/user-data-export/wrangler.test.jsonc
+++ b/services/user-data-export/wrangler.test.jsonc
@@ -6,6 +6,7 @@
   "compatibility_flags": ["nodejs_compat", "service_binding_extra_handlers"],
   "vars": {
     "INTERNAL_API_SECRET": "test-token",
+    "NEXTAUTH_SECRET": "test-nextauth-secret",
     "R2_ACCESS_KEY_ID": "test-access-key",
     "R2_SECRET_ACCESS_KEY": "test-secret-key",
     "R2_ACCOUNT_ID": "test-account",


### PR DESCRIPTION
## Summary
- require both the internal API key and a five-minute, audience-bound user assertion (user kilo api token) for export Worker HTTP endpoints
- derive the export owner from the verified assertion and enforce ownership before dispatch or download
- keep user identity and JWTs out of HTTP request bodies and Queue messages
- reject missing, expired, wrong-audience, and overlong assertions

## Verification
- `pnpm --filter web typecheck`
- `pnpm --filter user-data-export typecheck`
- `pnpm --filter @kilocode/worker-utils typecheck`
- `pnpm --filter web test --runTestsByPath src/lib/user-data-export-worker-client.test.ts --runInBand`
- `pnpm --filter user-data-export test`
- `pnpm --filter user-data-export test:workers`
- targeted oxlint checks
- `git diff --check`

## Deployment note
The `user-data-export` Worker must have `NEXTAUTH_SECRET` configured as a standard Worker secret before deploying this change.