### PR TITLE
feat(exports): add workload observability and allow early re-enque

### DIFF
--- a/apps/web/src/routers/user-exports-router.test.ts
+++ b/apps/web/src/routers/user-exports-router.test.ts
@@ -98,6 +98,34 @@ describe('user exports router guards and serialization', () => {
     expect(new Date(row.snapshotAt).toISOString()).toBe('2026-08-03T00:00:00.000Z');
   });
 
+  it('allows an immediate fresh request after a failed export', async () => {
+    const [failed] = await db
+      .insert(user_data_exports)
+      .values({
+        kilo_user_id: owner.id,
+        snapshot_at: new Date().toISOString(),
+        status: 'failed',
+        failure_code: 'queue_delivery_exhausted',
+        last_error_redacted: 'The export could not be completed after multiple attempts.',
+      })
+      .returning({ id: user_data_exports.id });
+
+    const requested = await (await createCallerForUser(owner.id)).userExports.request();
+
+    expect(requested.id).not.toBe(failed.id);
+    expect(requested.status).toBe('queued');
+    const rows = await db
+      .select({ id: user_data_exports.id, status: user_data_exports.status })
+      .from(user_data_exports)
+      .where(eq(user_data_exports.kilo_user_id, owner.id));
+    expect(rows).toEqual(
+      expect.arrayContaining([
+        { id: failed.id, status: 'failed' },
+        { id: requested.id, status: 'queued' },
+      ])
+    );
+  });
+
   it('does not authorize another user or an expired export for download', async () => {
     const [ready] = await db
       .insert(user_data_exports)

--- a/apps/web/src/routers/user-exports-router.ts
+++ b/apps/web/src/routers/user-exports-router.ts
@@ -84,6 +84,7 @@ export const userExportsRouter = createTRPCRouter({
         SELECT requested_at
         FROM user_data_exports
         WHERE kilo_user_id = ${ctx.user.id}
+          AND status <> 'failed'
           AND requested_at > now() - interval '24 hours'
         ORDER BY requested_at DESC
         LIMIT 1

--- a/services/user-data-export/src/index.ts
+++ b/services/user-data-export/src/index.ts
@@ -9,6 +9,7 @@ import {
   USER_DATA_EXPORT_ASSERTION_TTL_SECONDS,
   USER_DATA_EXPORT_AUDIENCE,
 } from '@kilocode/worker-utils/internal-service-token-audiences';
+import { logExportEvent, safeError } from './observability';
 
 const DOWNLOAD_EXPIRES_SECONDS = 300;
 const DOWNLOAD_CONTENT_DISPOSITION = 'attachment; filename="kilo-data-export.jsonl.gz"';
@@ -103,34 +104,62 @@ export default {
     }
     const kiloUserId = await authenticatedUserId(request, env);
     if (!kiloUserId) {
+      logExportEvent('warn', 'export_http_unauthorized', {
+        method: request.method,
+        path: url.pathname,
+      });
       return Response.json({ error: 'Unauthorized' }, { status: 401 });
     }
     try {
       if (request.method === 'POST' && url.pathname === '/internal/exports/dispatch') {
         const parsed = AdmitExportSchema.safeParse(await readJson(request));
-        if (!parsed.success)
+        if (!parsed.success) {
+          logExportEvent('warn', 'export_http_invalid_request', {
+            operation: 'dispatch',
+            validationIssueCount: parsed.error.issues.length,
+          });
           return Response.json({ error: 'Invalid export dispatch' }, { status: 400 });
+        }
         const { createStateDb } = await import('./databases');
         const state = createStateDb(env.PRIMARY_STATE_DB);
         if (
           (await dispatchExport(parsed.data, kiloUserId, state, env.EXPORT_QUEUE)) === 'not_found'
         ) {
+          logExportEvent('warn', 'export_dispatch_not_found', {
+            exportId: parsed.data.exportId,
+            generation: parsed.data.generation,
+          });
           return Response.json({ error: 'Export not found' }, { status: 404 });
         }
+        logExportEvent('info', 'export_dispatch_accepted', {
+          exportId: parsed.data.exportId,
+          generation: parsed.data.generation,
+        });
         return Response.json({ accepted: true }, { status: 202 });
       }
       if (request.method === 'POST' && url.pathname === '/internal/exports/download') {
         const parsed = DownloadRequestSchema.safeParse(await readJson(request));
-        if (!parsed.success)
+        if (!parsed.success) {
+          logExportEvent('warn', 'export_http_invalid_request', {
+            operation: 'download',
+            validationIssueCount: parsed.error.issues.length,
+          });
           return Response.json({ error: 'Invalid download request' }, { status: 400 });
+        }
         const { createStateDb } = await import('./databases');
         const object = await createStateDb(env.PRIMARY_STATE_DB).readyObject(
           parsed.data.exportId,
           kiloUserId
         );
-        if (!object) return Response.json({ error: 'Export not found' }, { status: 404 });
+        if (!object) {
+          logExportEvent('warn', 'export_download_not_found', { exportId: parsed.data.exportId });
+          return Response.json({ error: 'Export not found' }, { status: 404 });
+        }
         const expiration = downloadExpiration(object.expires_at);
-        if (!expiration) return Response.json({ error: 'Export not found' }, { status: 404 });
+        if (!expiration) {
+          logExportEvent('warn', 'export_download_expired', { exportId: parsed.data.exportId });
+          return Response.json({ error: 'Export not found' }, { status: 404 });
+        }
         const signer = createR2Client({
           accessKeyId: env.R2_ACCESS_KEY_ID,
           secretAccessKey: env.R2_SECRET_ACCESS_KEY,
@@ -142,13 +171,22 @@ export default {
           expiration.expiresIn,
           { responseContentDisposition: DOWNLOAD_CONTENT_DISPOSITION }
         );
+        logExportEvent('info', 'export_download_signed', {
+          exportId: parsed.data.exportId,
+          expiresInSeconds: expiration.expiresIn,
+        });
         return Response.json(
           { downloadUrl, expiresAt: expiration.expiresAt },
           { headers: { 'cache-control': 'private, no-store' } }
         );
       }
       return Response.json({ error: 'Not found' }, { status: 404 });
-    } catch {
+    } catch (error) {
+      logExportEvent('error', 'export_http_failed', {
+        method: request.method,
+        path: url.pathname,
+        ...safeError(error),
+      });
       return Response.json({ error: 'Invalid request' }, { status: 400 });
     }
   },
@@ -159,7 +197,20 @@ export default {
   },
   async scheduled(_controller: ScheduledController, env: ExportEnv): Promise<void> {
     const { reconcile } = await import('./worker');
-    await reconcile(env);
+    const startedAt = Date.now();
+    logExportEvent('info', 'export_reconcile_started');
+    try {
+      await reconcile(env);
+      logExportEvent('info', 'export_reconcile_completed', {
+        durationMs: Date.now() - startedAt,
+      });
+    } catch (error) {
+      logExportEvent('error', 'export_reconcile_failed', {
+        durationMs: Date.now() - startedAt,
+        ...safeError(error),
+      });
+      throw error;
+    }
   },
 } satisfies ExportedHandler<ExportEnv>;
 

--- a/services/user-data-export/src/observability.test.ts
+++ b/services/user-data-export/src/observability.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { logExportEvent, safeError } from './observability';
+
+afterEach(() => vi.restoreAllMocks());
+
+describe('export observability', () => {
+  it('logs structured fields with a stable service name', () => {
+    const info = vi.spyOn(console, 'log').mockImplementation(() => undefined);
+
+    logExportEvent('info', 'export_test_event', {
+      exportId: 'export-id',
+      generation: 2,
+      source: null,
+    });
+
+    expect(JSON.parse(String(info.mock.calls[0]?.[0]))).toEqual({
+      event: 'export_test_event',
+      service: 'user-data-export',
+      exportId: 'export-id',
+      generation: 2,
+      source: null,
+    });
+  });
+
+  it('classifies errors without exposing messages or stacks', () => {
+    const error = Object.assign(new Error('postgres://secret@host private query text'), {
+      code: 'ECONNRESET',
+    });
+
+    expect(safeError(error)).toEqual({ errorName: 'Error', errorCode: 'ECONNRESET' });
+    expect(JSON.stringify(safeError(error))).not.toContain('secret');
+    expect(JSON.stringify(safeError(error))).not.toContain('query');
+  });
+
+  it('does not copy properties from non-error throws', () => {
+    expect(safeError({ token: 'secret-token', message: 'private' })).toEqual({
+      errorName: 'NonErrorThrow',
+    });
+  });
+
+  it('drops nonstandard names and codes that could contain sensitive text', () => {
+    const error = Object.assign(new Error('private'), {
+      name: 'Database secret leaked',
+      code: 'secret-token',
+    });
+
+    expect(safeError(error)).toEqual({ errorName: 'Error' });
+  });
+});

--- a/services/user-data-export/src/observability.ts
+++ b/services/user-data-export/src/observability.ts
@@ -1,0 +1,26 @@
+type LogLevel = 'info' | 'warn' | 'error';
+
+type ExportLogFields = Record<string, boolean | number | string | null | undefined>;
+
+export function safeError(error: unknown): { errorName: string; errorCode?: string | number } {
+  if (!(error instanceof Error)) return { errorName: 'NonErrorThrow' };
+  const code = (error as Error & { code?: unknown }).code;
+  const errorName = /^[A-Za-z][A-Za-z0-9]{0,63}$/.test(error.name) ? error.name : 'Error';
+  const errorCode =
+    typeof code === 'number'
+      ? code
+      : typeof code === 'string' && /^[A-Z0-9_]{1,32}$/.test(code)
+        ? code
+        : undefined;
+  return {
+    errorName,
+    ...(errorCode === undefined ? {} : { errorCode }),
+  };
+}
+
+export function logExportEvent(level: LogLevel, event: string, fields: ExportLogFields = {}): void {
+  const value = JSON.stringify({ event, service: 'user-data-export', ...fields });
+  if (level === 'error') console.error(value);
+  else if (level === 'warn') console.warn(value);
+  else console.log(value);
+}

--- a/services/user-data-export/src/worker.test.ts
+++ b/services/user-data-export/src/worker.test.ts
@@ -1,7 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   attachNewMultipartUpload,
   consumeDeadLetterBatch,
+  consumeExportBatch,
   deletePendingObjects,
   dispatchContinuation,
   exportHeader,
@@ -11,13 +12,69 @@ import {
 } from './worker';
 import type { ExportJob } from './databases';
 
+afterEach(() => vi.restoreAllMocks());
+
 function queueMessage(body: unknown) {
   return {
     body,
+    attempts: 3,
     ack: vi.fn(),
     retry: vi.fn(),
   };
 }
+
+function parsedLog(spy: ReturnType<typeof vi.spyOn>, index = 0): Record<string, unknown> {
+  return JSON.parse(String(spy.mock.calls[index]?.[0])) as Record<string, unknown>;
+}
+
+describe('queue observability', () => {
+  it('logs safe retry context and keeps exception messages out of logs', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const message = queueMessage({
+      version: 1,
+      operation: 'generate',
+      exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+      generation: 3,
+    });
+
+    await consumeExportBatch(
+      { messages: [message] } as unknown as MessageBatch<unknown>,
+      {} as ExportEnv,
+      vi.fn().mockRejectedValue(new Error('database secret and row contents'))
+    );
+
+    expect(parsedLog(warn)).toEqual({
+      event: 'export_queue_retry_requested',
+      service: 'user-data-export',
+      exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+      generation: 3,
+      attempt: 3,
+      errorName: 'Error',
+    });
+    expect(warn.mock.calls[0]?.[0]).not.toContain('database secret');
+    expect(message.retry).toHaveBeenCalledWith({ delaySeconds: 60 });
+    expect(message.ack).not.toHaveBeenCalled();
+  });
+
+  it('logs malformed messages without serializing their payload', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const message = queueMessage({ token: 'secret-token', rows: ['private'] });
+
+    await consumeExportBatch(
+      { messages: [message] } as unknown as MessageBatch<unknown>,
+      {} as ExportEnv,
+      vi.fn()
+    );
+
+    expect(parsedLog(warn)).toEqual({
+      event: 'export_queue_message_invalid',
+      service: 'user-data-export',
+      validationIssueCount: expect.any(Number),
+    });
+    expect(warn.mock.calls[0]?.[0]).not.toContain('secret-token');
+    expect(message.ack).toHaveBeenCalledOnce();
+  });
+});
 
 describe('dead-letter queue consumption', () => {
   it('generation-fences terminal failure and acknowledges the message', async () => {
@@ -194,10 +251,13 @@ describe('account-deletion object cleanup', () => {
   });
 
   it('retains the tombstone and records a failed R2 deletion attempt', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const exportId = 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c';
+    const objectKey = `exports/${exportId}/kilo-data-export.jsonl.gz`;
     const state = {
       pendingObjectDeletions: vi
         .fn()
-        .mockResolvedValue([{ object_key: 'exports/id/file.gz', multipart_upload_id: null }]),
+        .mockResolvedValue([{ object_key: objectKey, multipart_upload_id: null }]),
       completeObjectDeletion: vi.fn(),
       recordObjectDeletionFailure: vi.fn(),
     };
@@ -209,7 +269,15 @@ describe('account-deletion object cleanup', () => {
     await deletePendingObjects(bucket, state);
 
     expect(state.completeObjectDeletion).not.toHaveBeenCalled();
-    expect(state.recordObjectDeletionFailure).toHaveBeenCalledWith('exports/id/file.gz');
+    expect(state.recordObjectDeletionFailure).toHaveBeenCalledWith(objectKey);
+    expect(parsedLog(warn)).toEqual({
+      event: 'account_export_object_cleanup_failed',
+      service: 'user-data-export',
+      exportId,
+      stage: 'r2_delete',
+      errorName: 'Error',
+    });
+    expect(warn.mock.calls[0]?.[0]).not.toContain(objectKey);
   });
 
   it('aborts an in-flight multipart upload before deleting its key', async () => {

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -8,6 +8,7 @@ import {
 import { uploadGzipStream } from './gzip';
 import { createSourceAdapters, type ExportRecord } from './source-adapters';
 import type { SourceAdapter } from './source-adapters';
+import { logExportEvent, safeError } from './observability';
 
 const PART_BYTES = 5 * 1024 * 1024;
 const MAX_UNCOMPRESSED_BYTES_PER_INVOCATION = 32 * 1024 * 1024;
@@ -30,6 +31,12 @@ export type ExportEnv = {
 
 function objectKey(exportId: string): string {
   return `exports/${exportId}/kilo-data-export.jsonl.gz`;
+}
+
+function exportIdFromObjectKey(value: string): string | undefined {
+  return /^exports\/([0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12})\/kilo-data-export\.jsonl\.gz$/i.exec(
+    value
+  )?.[1];
 }
 
 export const exportArtifact = {
@@ -101,8 +108,17 @@ export async function dispatchContinuation(input: {
       generation: input.generation,
     });
     await input.markSent(input.exportId, input.generation);
-  } catch {
+    logExportEvent('info', 'export_continuation_dispatched', {
+      exportId: input.exportId,
+      generation: input.generation,
+    });
+  } catch (error) {
     // The transactional outbox remains available for scheduled recovery.
+    logExportEvent('warn', 'export_continuation_deferred', {
+      exportId: input.exportId,
+      generation: input.generation,
+      ...safeError(error),
+    });
   }
 }
 
@@ -138,14 +154,29 @@ export async function processGenerateMessage(
   const state = createStateDb(env.PRIMARY_STATE_DB);
   const leaseToken = crypto.randomUUID();
   const job = await state.claim(message.exportId, message.generation, leaseToken);
-  if (!job) return;
+  if (!job) {
+    logExportEvent('info', 'export_generation_skipped', {
+      exportId: message.exportId,
+      generation: message.generation,
+      reason: 'not_claimable',
+    });
+    return;
+  }
   let writer: WritableStreamDefaultWriter<Uint8Array> | undefined;
   let uploadParts:
     | Promise<Array<{ partNumber: number; etag: string; sizeBytes: number }>>
     | undefined;
+  let phase = 'claim';
+  let activeSource = job.current_source;
 
   try {
     if (job.current_source === null && job.multipart_upload_id) {
+      phase = 'finalization';
+      logExportEvent('info', 'export_finalization_started', {
+        exportId: job.id,
+        generation: job.dispatch_generation,
+        nextPartNumber: job.next_part_number,
+      });
       await finalizeExport(env, state, job, leaseToken);
       return;
     }
@@ -155,11 +186,20 @@ export async function processGenerateMessage(
     if (!adapter || !adapter.readPage) {
       throw new Error('Export job has an invalid current source');
     }
+    activeSource = adapter.name;
 
     const key = objectKey(job.id);
+    phase = 'multipart';
     let upload: R2MultipartUpload;
     if (job.multipart_upload_id) {
       upload = env.EXPORT_BUCKET.resumeMultipartUpload(key, job.multipart_upload_id);
+      logExportEvent('info', 'export_generation_attempt_started', {
+        exportId: job.id,
+        generation: job.dispatch_generation,
+        source: adapter.name,
+        uploadMode: 'resumed',
+        nextPartNumber: job.next_part_number,
+      });
     } else {
       upload = await env.EXPORT_BUCKET.createMultipartUpload(key, {
         httpMetadata: {
@@ -174,7 +214,21 @@ export async function processGenerateMessage(
         leaseToken,
         attach: input => state.attachMultipartUpload(input),
       });
-      if (attachResult !== 'attached') return;
+      if (attachResult !== 'attached') {
+        logExportEvent('info', 'export_generation_skipped', {
+          exportId: job.id,
+          generation: job.dispatch_generation,
+          reason: attachResult,
+        });
+        return;
+      }
+      logExportEvent('info', 'export_generation_attempt_started', {
+        exportId: job.id,
+        generation: job.dispatch_generation,
+        source: adapter.name,
+        uploadMode: 'created',
+        nextPartNumber: job.next_part_number,
+      });
     }
     const encoder = new TextEncoder();
     const compressor = new CompressionStream('gzip');
@@ -205,6 +259,8 @@ export async function processGenerateMessage(
     ) {
       const readPage = adapter.readPage;
       if (!readPage) throw new Error('Export job has an invalid current source');
+      phase = 'source_read';
+      activeSource = adapter.name;
       const page = await readPage({
         kiloUserId: job.kilo_user_id,
         snapshotAt: job.snapshot_at,
@@ -234,9 +290,11 @@ export async function processGenerateMessage(
       nextSource = adapter.name;
     }
     isFinal = nextSource === null;
+    phase = 'compression_finalize';
     await writer.close();
     const parts = await uploadParts;
     if (parts.length === 0) throw new Error('Compressed export produced no multipart data');
+    phase = 'checkpoint';
     const checkpointed = await state.checkpoint({
       exportId: job.id,
       leaseToken,
@@ -247,7 +305,25 @@ export async function processGenerateMessage(
       nextGeneration: job.dispatch_generation + 1,
       multipartUploadId: upload.uploadId,
     });
-    if (!checkpointed) return;
+    if (!checkpointed) {
+      logExportEvent('warn', 'export_checkpoint_rejected', {
+        exportId: job.id,
+        generation: job.dispatch_generation,
+      });
+      return;
+    }
+
+    logExportEvent('info', 'export_generation_checkpointed', {
+      exportId: job.id,
+      generation: job.dispatch_generation,
+      nextGeneration: job.dispatch_generation + 1,
+      source: adapter.name,
+      nextSource,
+      pageCount,
+      rowCount: recordCount,
+      partCount: parts.length,
+      uncompressedBytes: uncompressedSize,
+    });
 
     await dispatchContinuation({
       queue: env.EXPORT_QUEUE,
@@ -263,6 +339,13 @@ export async function processGenerateMessage(
     await writer?.abort(error).catch(() => undefined);
     await uploadParts?.catch(() => undefined);
     await state.releaseForRetry(job.id, job.dispatch_generation, leaseToken);
+    logExportEvent('error', 'export_generation_failed', {
+      exportId: job.id,
+      generation: job.dispatch_generation,
+      phase,
+      source: activeSource,
+      ...safeError(error),
+    });
     throw error;
   }
 }
@@ -284,29 +367,55 @@ async function finalizeExport(
     verified = await env.EXPORT_BUCKET.head(key);
   }
   if (!verified) throw new Error('Completed export object was not found');
-  await state.complete({
+  const completed = await state.complete({
     exportId: job.id,
     leaseToken,
     objectKey: key,
     etag: verified.etag,
     sizeBytes: verified.size,
   });
+  if (!completed) {
+    logExportEvent('warn', 'export_completion_fenced', {
+      exportId: job.id,
+      generation: job.dispatch_generation,
+      reason: 'lost_lease_or_terminal_state',
+    });
+    return;
+  }
+  logExportEvent('info', 'export_completed', {
+    exportId: job.id,
+    generation: job.dispatch_generation,
+    sizeBytes: verified.size,
+  });
 }
 
 export async function consumeExportBatch(
   batch: MessageBatch<unknown>,
-  env: ExportEnv
+  env: ExportEnv,
+  processMessage: (
+    env: ExportEnv,
+    message: ExportQueueMessage
+  ) => Promise<void> = processGenerateMessage
 ): Promise<void> {
   for (const message of batch.messages) {
     const parsed = ExportQueueMessageSchema.safeParse(message.body);
     if (!parsed.success) {
+      logExportEvent('warn', 'export_queue_message_invalid', {
+        validationIssueCount: parsed.error.issues.length,
+      });
       message.ack();
       continue;
     }
     try {
-      await processGenerateMessage(env, parsed.data);
+      await processMessage(env, parsed.data);
       message.ack();
-    } catch {
+    } catch (error) {
+      logExportEvent('warn', 'export_queue_retry_requested', {
+        exportId: parsed.data.exportId,
+        generation: parsed.data.generation,
+        attempt: message.attempts,
+        ...safeError(error),
+      });
       message.retry({ delaySeconds: 60 });
     }
   }
@@ -321,6 +430,14 @@ export async function consumeDeadLetterBatch(
     const parsed = ExportQueueMessageSchema.safeParse(message.body);
     if (parsed.success) {
       await state.markFailed(parsed.data.exportId, parsed.data.generation);
+      logExportEvent('error', 'export_message_dead_lettered', {
+        exportId: parsed.data.exportId,
+        generation: parsed.data.generation,
+      });
+    } else {
+      logExportEvent('error', 'export_dead_letter_message_invalid', {
+        validationIssueCount: parsed.error.issues.length,
+      });
     }
     message.ack();
   }
@@ -351,22 +468,34 @@ export async function processScheduledExportWork(
   >
 ): Promise<void> {
   for (const item of await state.expiredObjects()) {
+    let stage = 'r2_delete';
     try {
       await env.EXPORT_BUCKET.delete(item.r2_object_key);
+      stage = 'state_update';
       await state.markExpired(item.id);
-    } catch {
-      console.warn(JSON.stringify({ event: 'export_expiry_cleanup_failed', exportId: item.id }));
+      logExportEvent('info', 'export_expired_object_deleted', { exportId: item.id });
+    } catch (error) {
+      logExportEvent('warn', 'export_expiry_cleanup_failed', {
+        exportId: item.id,
+        stage,
+        ...safeError(error),
+      });
     }
   }
   for (const item of await state.failedMultipartUploads()) {
+    let stage = 'multipart_abort';
     try {
       const key = objectKey(item.id);
       await env.EXPORT_BUCKET.resumeMultipartUpload(key, item.multipart_upload_id).abort();
+      stage = 'state_update';
       await state.clearMultipartUpload(item.id);
-    } catch {
-      console.warn(
-        JSON.stringify({ event: 'failed_export_multipart_cleanup_failed', exportId: item.id })
-      );
+      logExportEvent('info', 'failed_export_multipart_deleted', { exportId: item.id });
+    } catch (error) {
+      logExportEvent('warn', 'failed_export_multipart_cleanup_failed', {
+        exportId: item.id,
+        stage,
+        ...safeError(error),
+      });
     }
   }
   for (const item of await state.pendingOutbox()) {
@@ -378,15 +507,17 @@ export async function processScheduledExportWork(
         generation: item.generation,
       });
       await state.markOutboxSent(item.id);
-    } catch {
+      logExportEvent('info', 'export_outbox_dispatched', {
+        exportId: item.export_id,
+        generation: item.generation,
+      });
+    } catch (error) {
       await state.recordOutboxFailure(item.id);
-      console.warn(
-        JSON.stringify({
-          event: 'export_outbox_dispatch_failed',
-          exportId: item.export_id,
-          generation: item.generation,
-        })
-      );
+      logExportEvent('warn', 'export_outbox_dispatch_failed', {
+        exportId: item.export_id,
+        generation: item.generation,
+        ...safeError(error),
+      });
     }
   }
 }
@@ -399,6 +530,8 @@ export async function deletePendingObjects(
   >
 ): Promise<void> {
   for (const item of await state.pendingObjectDeletions()) {
+    const exportId = exportIdFromObjectKey(item.object_key);
+    let stage = item.multipart_upload_id ? 'multipart_abort' : 'r2_delete';
     try {
       if (item.multipart_upload_id) {
         try {
@@ -408,16 +541,18 @@ export async function deletePendingObjects(
           if (value.code !== 10024 && value.name !== 'NoSuchUpload') throw error;
         }
       }
+      stage = 'r2_delete';
       await bucket.delete(item.object_key);
+      stage = 'state_update';
       await state.completeObjectDeletion(item.object_key);
-    } catch {
+      logExportEvent('info', 'account_export_object_deleted', { exportId });
+    } catch (error) {
       await state.recordObjectDeletionFailure(item.object_key);
-      console.warn(
-        JSON.stringify({
-          event: 'account_export_object_cleanup_failed',
-          objectKey: item.object_key,
-        })
-      );
+      logExportEvent('warn', 'account_export_object_cleanup_failed', {
+        exportId,
+        stage,
+        ...safeError(error),
+      });
     }
   }
 }
@@ -428,13 +563,13 @@ async function dispatchReadyNotifications(
 ): Promise<void> {
   if (!env.USER_DATA_EXPORT_WEB_URL) return;
   if (!isAllowedWebCallbackUrl(env.USER_DATA_EXPORT_WEB_URL)) {
-    console.warn(JSON.stringify({ event: 'export_notification_callback_url_invalid' }));
+    logExportEvent('warn', 'export_notification_callback_url_invalid');
     return;
   }
   const baseUrl = new URL(env.USER_DATA_EXPORT_WEB_URL);
   for (const item of await state.pendingNotifications()) {
     try {
-      await fetch(new URL('/api/internal/user-data-exports/ready', baseUrl), {
+      const response = await fetch(new URL('/api/internal/user-data-exports/ready', baseUrl), {
         method: 'POST',
         redirect: 'error',
         headers: {
@@ -444,8 +579,16 @@ async function dispatchReadyNotifications(
         body: JSON.stringify({ exportId: item.id }),
         signal: AbortSignal.timeout(10_000),
       });
-    } catch {
+      logExportEvent(response.ok ? 'info' : 'warn', 'export_notification_callback_completed', {
+        exportId: item.id,
+        status: response.status,
+      });
+    } catch (error) {
       // The database-backed email lease remains authoritative for later sweeps.
+      logExportEvent('warn', 'export_notification_callback_failed', {
+        exportId: item.id,
+        ...safeError(error),
+      });
     }
   }
 }

--- a/services/user-data-export/wrangler.jsonc
+++ b/services/user-data-export/wrangler.jsonc
@@ -22,6 +22,7 @@
       "head_sampling_rate": 1,
     },
   },
+  "logpush": true,
   "routes": [
     {
       "pattern": "user-data-export.kilosessions.ai",


### PR DESCRIPTION
## Summary
- add structured events across export HTTP admission, Queue processing, checkpoints, finalization, DLQ handling, scheduled reconciliation, R2 cleanup, outbox recovery, and notification callbacks
- include stable operational context such as export ID, generation, attempt, phase, source, counts, sizes, status, and cleanup stage
- centralize safe error classification while excluding exception messages, stacks, user identity, credentials, exported content, cursor values, and R2 object paths
- add regression coverage for Queue retry context and log redaction
- actually allow re-requesting export on failure

## Verification
- `pnpm --filter user-data-export typecheck`
- `pnpm --filter user-data-export test` (44 tests)
- `pnpm --filter user-data-export test:workers` (4 tests)
- `pnpm --filter user-data-export lint`
- `git diff --check`

