### PR TITLE
fix(gateway): tolerate malformed tools in api metrics

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -903,8 +903,15 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     taskId ?? null
   );
 
-  const toolsAvailable = getToolsAvailable(requestBodyParsed);
-  const toolsUsed = getToolsUsed(requestBodyParsed);
+  let toolsAvailable: string[] = [];
+  let toolsUsed: string[] = [];
+  try {
+    toolsAvailable = getToolsAvailable(requestBodyParsed);
+    toolsUsed = getToolsUsed(requestBodyParsed);
+  } catch {
+    toolsAvailable = [];
+    toolsUsed = [];
+  }
 
   // Capture the bounded prompt for experimented requests AFTER provider
   // transforms have produced the canonical upstream body. Stored on the

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -903,15 +903,8 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     taskId ?? null
   );
 
-  let toolsAvailable: string[] = [];
-  let toolsUsed: string[] = [];
-  try {
-    toolsAvailable = getToolsAvailable(requestBodyParsed);
-    toolsUsed = getToolsUsed(requestBodyParsed);
-  } catch {
-    toolsAvailable = [];
-    toolsUsed = [];
-  }
+  const toolsAvailable = getToolsAvailable(requestBodyParsed);
+  const toolsUsed = getToolsUsed(requestBodyParsed);
 
   // Capture the bounded prompt for experimented requests AFTER provider
   // transforms have produced the canonical upstream body. Stored on the

--- a/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.test.ts
+++ b/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.test.ts
@@ -137,6 +137,22 @@ describe('getToolsUsed', () => {
     ).toEqual(['function:search', 'custom:browser']);
   });
 
+  test('ignores non-array chat completion tool_calls', () => {
+    expect(
+      getToolsUsed(
+        chatRequest({
+          messages: [
+            {
+              role: 'assistant',
+              content: null,
+              tool_calls: { id: '1', type: 'function' } as never,
+            },
+          ],
+        })
+      )
+    ).toEqual([]);
+  });
+
   test('tolerates responses tool calls with missing names', () => {
     expect(
       getToolsUsed(

--- a/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.test.ts
+++ b/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.test.ts
@@ -1,0 +1,158 @@
+import { describe, expect, test } from '@jest/globals';
+import type {
+  GatewayMessagesRequest,
+  GatewayRequest,
+  GatewayResponsesRequest,
+  OpenRouterChatCompletionRequest,
+} from '@/lib/ai-gateway/providers/openrouter/types';
+import { getToolsAvailable, getToolsUsed } from './api-metrics.server';
+
+jest.mock('next/server', () => ({
+  ...(jest.requireActual('next/server') as Record<string, unknown>),
+  after: jest.fn(),
+}));
+
+function chatRequest(overrides: Partial<OpenRouterChatCompletionRequest> = {}): GatewayRequest {
+  return {
+    kind: 'chat_completions',
+    body: {
+      model: 'test-model',
+      messages: [],
+      ...overrides,
+    },
+  };
+}
+
+function responsesRequest(overrides: Partial<GatewayResponsesRequest> = {}): GatewayRequest {
+  return {
+    kind: 'responses',
+    body: {
+      model: 'test-model',
+      input: [],
+      ...overrides,
+    },
+  };
+}
+
+function messagesRequest(overrides: Partial<GatewayMessagesRequest> = {}): GatewayRequest {
+  return {
+    kind: 'messages',
+    body: {
+      model: 'test-model',
+      max_tokens: 16,
+      messages: [],
+      ...overrides,
+    },
+  };
+}
+
+describe('getToolsAvailable', () => {
+  test('returns empty when tools is missing', () => {
+    expect(getToolsAvailable(chatRequest())).toEqual([]);
+  });
+
+  test('returns empty when tools is not an array', () => {
+    expect(
+      getToolsAvailable(
+        chatRequest({
+          tools: { type: 'function', function: { name: 'search' } } as never,
+        })
+      )
+    ).toEqual([]);
+    expect(getToolsAvailable(chatRequest({ tools: 'search' as never }))).toEqual([]);
+  });
+
+  test('labels chat completion function and custom tools', () => {
+    expect(
+      getToolsAvailable(
+        chatRequest({
+          tools: [
+            { type: 'function', function: { name: '  search  ' } },
+            { type: 'custom', custom: { name: 'browser' } },
+            { type: 'function', function: {} },
+          ],
+        })
+      )
+    ).toEqual(['function:search', 'custom:browser', 'function:unknown']);
+  });
+
+  test('labels responses tools and tolerates missing mcp server_label', () => {
+    expect(
+      getToolsAvailable(
+        responsesRequest({
+          tools: [
+            { type: 'function', name: 'lookup' },
+            { type: 'custom', name: 'browser' },
+            { type: 'mcp' },
+            { type: 'web_search_preview' },
+          ] as GatewayResponsesRequest['tools'],
+        })
+      )
+    ).toEqual(['function:lookup', 'custom:browser', 'mcp:unknown', 'web_search_preview']);
+  });
+
+  test('labels messages tools', () => {
+    expect(
+      getToolsAvailable(
+        messagesRequest({
+          tools: [{ name: 'read_file', input_schema: { type: 'object' } }],
+        })
+      )
+    ).toEqual(['function:read_file']);
+  });
+});
+
+describe('getToolsUsed', () => {
+  test('returns empty when chat messages are missing', () => {
+    expect(getToolsUsed(chatRequest({ messages: undefined as never }))).toEqual([]);
+  });
+
+  test('labels chat completion tool calls', () => {
+    expect(
+      getToolsUsed(
+        chatRequest({
+          messages: [
+            {
+              role: 'assistant',
+              content: null,
+              tool_calls: [
+                { id: '1', type: 'function', function: { name: 'search', arguments: '{}' } },
+                { id: '2', type: 'custom', custom: { name: 'browser', input: '{}' } },
+              ],
+            },
+          ],
+        })
+      )
+    ).toEqual(['function:search', 'custom:browser']);
+  });
+
+  test('tolerates responses tool calls with missing names', () => {
+    expect(
+      getToolsUsed(
+        responsesRequest({
+          input: [
+            { type: 'function_call', call_id: '1', name: 'search', arguments: '{}' },
+            { type: 'function_call', call_id: '2' },
+            { type: 'custom_tool_call', call_id: '3', name: 'browser', input: '{}' },
+            { type: 'custom_tool_call', call_id: '4' },
+          ] as GatewayResponsesRequest['input'],
+        })
+      )
+    ).toEqual(['function:search', 'function:unknown', 'custom:browser', 'custom:unknown']);
+  });
+
+  test('labels messages tool_use blocks', () => {
+    expect(
+      getToolsUsed(
+        messagesRequest({
+          messages: [
+            {
+              role: 'assistant',
+              content: [{ type: 'tool_use', id: '1', name: 'read_file', input: {} }],
+            },
+          ],
+        })
+      )
+    ).toEqual(['function:read_file']);
+  });
+});

--- a/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.test.ts
+++ b/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.test.ts
@@ -69,7 +69,7 @@ describe('getToolsAvailable', () => {
           tools: [
             { type: 'function', function: { name: '  search  ' } },
             { type: 'custom', custom: { name: 'browser' } },
-            { type: 'function', function: {} },
+            { type: 'function', function: { name: '' } },
           ],
         })
       )

--- a/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.test.ts
+++ b/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.test.ts
@@ -67,6 +67,7 @@ describe('getToolsAvailable', () => {
       getToolsAvailable(
         chatRequest({
           tools: [
+            null as never,
             { type: 'function', function: { name: '  search  ' } },
             { type: 'custom', custom: { name: 'browser' } },
             { type: 'function', function: { name: '' } },
@@ -76,19 +77,29 @@ describe('getToolsAvailable', () => {
     ).toEqual(['function:search', 'custom:browser', 'function:unknown']);
   });
 
-  test('labels responses tools and tolerates missing mcp server_label', () => {
+  test('labels responses tools and skips malformed entries', () => {
     expect(
       getToolsAvailable(
         responsesRequest({
           tools: [
+            null,
             { type: 'function', name: 'lookup' },
             { type: 'custom', name: 'browser' },
             { type: 'mcp' },
             { type: 'web_search_preview' },
+            {},
+            { type: 123 },
           ] as GatewayResponsesRequest['tools'],
         })
       )
-    ).toEqual(['function:lookup', 'custom:browser', 'mcp:unknown', 'web_search_preview']);
+    ).toEqual([
+      'function:lookup',
+      'custom:browser',
+      'mcp:unknown',
+      'web_search_preview',
+      'unknown:unknown',
+      'unknown:unknown',
+    ]);
   });
 
   test('labels messages tools', () => {

--- a/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.ts
+++ b/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.ts
@@ -66,26 +66,34 @@ function labeledTool(kind: string, name: unknown): string {
   return trimmed ? `${kind}:${trimmed}` : `${kind}:unknown`;
 }
 
+function isObjectEntry<T>(value: T): value is T & object {
+  return typeof value === 'object' && value !== null;
+}
+
 export function getToolsAvailable(request: GatewayRequest): string[] {
   if (!Array.isArray(request.body.tools)) return [];
 
   if (request.kind === 'responses') {
-    return request.body.tools.map((tool): string => {
-      if (tool.type === 'function') return labeledTool('function', tool.name);
-      if (tool.type === 'custom') return labeledTool('custom', tool.name);
-      if (tool.type === 'mcp') return labeledTool('mcp', tool.server_label);
-      return tool.type;
+    return request.body.tools.flatMap((tool): string[] => {
+      if (!isObjectEntry(tool)) return [];
+      if (tool.type === 'function') return [labeledTool('function', tool.name)];
+      if (tool.type === 'custom') return [labeledTool('custom', tool.name)];
+      if (tool.type === 'mcp') return [labeledTool('mcp', tool.server_label)];
+      return typeof tool.type === 'string' && tool.type ? [tool.type] : ['unknown:unknown'];
     });
   }
 
   if (request.kind === 'messages') {
-    return request.body.tools.map((tool): string => labeledTool('function', tool.name));
+    return request.body.tools.flatMap((tool): string[] =>
+      isObjectEntry(tool) ? [labeledTool('function', tool.name)] : []
+    );
   }
 
-  return request.body.tools.map((tool): string => {
-    if (tool.type === 'function') return labeledTool('function', tool.function?.name);
-    if (tool.type === 'custom') return labeledTool('custom', tool.custom?.name);
-    return 'unknown:unknown';
+  return request.body.tools.flatMap((tool): string[] => {
+    if (!isObjectEntry(tool)) return [];
+    if (tool.type === 'function') return [labeledTool('function', tool.function?.name)];
+    if (tool.type === 'custom') return [labeledTool('custom', tool.custom?.name)];
+    return ['unknown:unknown'];
   });
 }
 

--- a/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.ts
+++ b/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.ts
@@ -57,49 +57,43 @@ export function getTokensFromCompletionUsage(
   return hasAny ? tokens : undefined;
 }
 
+function trimString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function labeledTool(kind: string, name: unknown): string {
+  const trimmed = trimString(name);
+  return trimmed ? `${kind}:${trimmed}` : `${kind}:unknown`;
+}
+
 export function getToolsAvailable(request: GatewayRequest): string[] {
-  if (!request.body.tools) return [];
+  const tools = request.body.tools;
+  if (!Array.isArray(tools)) return [];
 
   if (request.kind === 'responses') {
-    return request.body.tools.map((tool): string => {
-      if (tool.type === 'function') {
-        const name = typeof tool.name === 'string' ? tool.name.trim() : '';
-        return name ? `function:${name}` : 'function:unknown';
-      }
+    return tools.flatMap((tool): string[] => {
+      if (!tool || typeof tool !== 'object') return [];
 
-      if (tool.type === 'custom') {
-        const name = typeof tool.name === 'string' ? tool.name.trim() : '';
-        return name ? `custom:${name}` : 'custom:unknown';
-      }
-
-      if (tool.type === 'mcp') {
-        const label = tool.server_label.trim();
-        return label ? `mcp:${label}` : 'mcp:unknown';
-      }
-
-      return tool.type;
+      if (tool.type === 'function') return [labeledTool('function', tool.name)];
+      if (tool.type === 'custom') return [labeledTool('custom', tool.name)];
+      if (tool.type === 'mcp') return [labeledTool('mcp', tool.server_label)];
+      return typeof tool.type === 'string' && tool.type ? [tool.type] : [];
     });
   }
 
   if (request.kind === 'messages') {
-    return request.body.tools.map((tool): string => {
-      const name = typeof tool.name === 'string' ? tool.name.trim() : '';
-      return name ? `function:${name}` : 'function:unknown';
+    return tools.flatMap((tool): string[] => {
+      if (!tool || typeof tool !== 'object') return [];
+      return [labeledTool('function', tool.name)];
     });
   }
 
-  return request.body.tools.map((tool): string => {
-    if (tool.type === 'function') {
-      const toolName = typeof tool.function?.name === 'string' ? tool.function.name.trim() : '';
-      return toolName ? `function:${toolName}` : 'function:unknown';
-    }
+  return tools.flatMap((tool): string[] => {
+    if (!tool || typeof tool !== 'object') return [];
 
-    if (tool.type === 'custom') {
-      const toolName = typeof tool.custom?.name === 'string' ? tool.custom.name.trim() : '';
-      return toolName ? `custom:${toolName}` : 'custom:unknown';
-    }
-
-    return 'unknown:unknown';
+    if (tool.type === 'function') return [labeledTool('function', tool.function?.name)];
+    if (tool.type === 'custom') return [labeledTool('custom', tool.custom?.name)];
+    return ['unknown:unknown'];
   });
 }
 
@@ -111,12 +105,11 @@ export function getToolsUsed(request: GatewayRequest): string[] {
     const used = new Array<string>();
 
     for (const item of input) {
+      if (!item || typeof item !== 'object') continue;
       if (item.type === 'function_call') {
-        const name = item.name.trim();
-        used.push(name ? `function:${name}` : 'function:unknown');
+        used.push(labeledTool('function', item.name));
       } else if (item.type === 'custom_tool_call') {
-        const name = item.name.trim();
-        used.push(name ? `custom:${name}` : 'custom:unknown');
+        used.push(labeledTool('custom', item.name));
       }
     }
 
@@ -125,13 +118,15 @@ export function getToolsUsed(request: GatewayRequest): string[] {
 
   if (request.kind === 'messages') {
     const used = new Array<string>();
+    if (!Array.isArray(request.body.messages)) return used;
     for (const message of request.body.messages) {
+      if (!message || typeof message !== 'object') continue;
       if (message.role !== 'assistant') continue;
       const content = Array.isArray(message.content) ? message.content : [];
       for (const block of content) {
+        if (!block || typeof block !== 'object') continue;
         if (block.type === 'tool_use') {
-          const name = typeof block.name === 'string' ? block.name.trim() : '';
-          used.push(name ? `function:${name}` : 'function:unknown');
+          used.push(labeledTool('function', block.name));
         }
       }
     }
@@ -143,20 +138,18 @@ export function getToolsUsed(request: GatewayRequest): string[] {
   const used = new Array<string>();
 
   for (const message of request.body.messages) {
+    if (!message || typeof message !== 'object') continue;
     if (message.role !== 'assistant') continue;
 
     for (const toolCall of message.tool_calls ?? []) {
+      if (!toolCall || typeof toolCall !== 'object') continue;
       if (toolCall.type === 'function') {
-        const toolName =
-          typeof toolCall.function?.name === 'string' ? toolCall.function.name.trim() : '';
-        used.push(toolName ? `function:${toolName}` : 'function:unknown');
+        used.push(labeledTool('function', toolCall.function?.name));
         continue;
       }
 
       if (toolCall.type === 'custom') {
-        const toolName =
-          typeof toolCall.custom?.name === 'string' ? toolCall.custom.name.trim() : '';
-        used.push(toolName ? `custom:${toolName}` : 'custom:unknown');
+        used.push(labeledTool('custom', toolCall.custom?.name));
         continue;
       }
 

--- a/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.ts
+++ b/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.ts
@@ -141,7 +141,9 @@ export function getToolsUsed(request: GatewayRequest): string[] {
     if (!message || typeof message !== 'object') continue;
     if (message.role !== 'assistant') continue;
 
-    for (const toolCall of message.tool_calls ?? []) {
+    if (!Array.isArray(message.tool_calls)) continue;
+
+    for (const toolCall of message.tool_calls) {
       if (!toolCall || typeof toolCall !== 'object') continue;
       if (toolCall.type === 'function') {
         used.push(labeledTool('function', toolCall.function?.name));

--- a/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.ts
+++ b/apps/web/src/lib/ai-gateway/o11y/api-metrics.server.ts
@@ -67,33 +67,25 @@ function labeledTool(kind: string, name: unknown): string {
 }
 
 export function getToolsAvailable(request: GatewayRequest): string[] {
-  const tools = request.body.tools;
-  if (!Array.isArray(tools)) return [];
+  if (!Array.isArray(request.body.tools)) return [];
 
   if (request.kind === 'responses') {
-    return tools.flatMap((tool): string[] => {
-      if (!tool || typeof tool !== 'object') return [];
-
-      if (tool.type === 'function') return [labeledTool('function', tool.name)];
-      if (tool.type === 'custom') return [labeledTool('custom', tool.name)];
-      if (tool.type === 'mcp') return [labeledTool('mcp', tool.server_label)];
-      return typeof tool.type === 'string' && tool.type ? [tool.type] : [];
+    return request.body.tools.map((tool): string => {
+      if (tool.type === 'function') return labeledTool('function', tool.name);
+      if (tool.type === 'custom') return labeledTool('custom', tool.name);
+      if (tool.type === 'mcp') return labeledTool('mcp', tool.server_label);
+      return tool.type;
     });
   }
 
   if (request.kind === 'messages') {
-    return tools.flatMap((tool): string[] => {
-      if (!tool || typeof tool !== 'object') return [];
-      return [labeledTool('function', tool.name)];
-    });
+    return request.body.tools.map((tool): string => labeledTool('function', tool.name));
   }
 
-  return tools.flatMap((tool): string[] => {
-    if (!tool || typeof tool !== 'object') return [];
-
-    if (tool.type === 'function') return [labeledTool('function', tool.function?.name)];
-    if (tool.type === 'custom') return [labeledTool('custom', tool.custom?.name)];
-    return ['unknown:unknown'];
+  return request.body.tools.map((tool): string => {
+    if (tool.type === 'function') return labeledTool('function', tool.function?.name);
+    if (tool.type === 'custom') return labeledTool('custom', tool.custom?.name);
+    return 'unknown:unknown';
   });
 }
 


### PR DESCRIPTION
## Summary

Malformed chat/completions bodies were 500ing the shared `/api/gateway` and `/api/openrouter` proxy during o11y tool extraction:

- `tools.map is not a function` when `tools` is present but not an array
- `Cannot read properties of undefined (reading 'trim')` when an MCP `server_label` or responses tool-call `name` is missing

Tool extraction now treats those fields as optional and skips malformed entries.

## Verification

- [ ] No manual test; CI unit tests cover the malformed `tools` / missing-name / non-array `tool_calls` cases

## Visual Changes

N/A

## Reviewer Notes

Sentry: KILOCODE-WEB-27NX and the sibling `e.body.tools.map is not a function` on `POST /api/openrouter/[...path]`.