### PR TITLE
fix(exports): record why ready-notification callbacks fail (+ temp 5m throttle for testing)

### DIFF
--- a/apps/web/src/routers/user-exports-router.ts
+++ b/apps/web/src/routers/user-exports-router.ts
@@ -85,7 +85,8 @@ export const userExportsRouter = createTRPCRouter({
         FROM user_data_exports
         WHERE kilo_user_id = ${ctx.user.id}
           AND status <> 'failed'
-          AND requested_at > now() - interval '24 hours'
+          -- TEMPORARY: throttle lowered to 5 minutes for pre-launch testing; restore to 24 hours before going live.
+          AND requested_at > now() - interval '5 minutes'
         ORDER BY requested_at DESC
         LIMIT 1
       `);

--- a/services/user-data-export/src/observability.test.ts
+++ b/services/user-data-export/src/observability.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { logExportEvent, safeError } from './observability';
+import { classifyFetchFailure, logExportEvent, safeError } from './observability';
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -45,5 +45,40 @@ describe('export observability', () => {
     });
 
     expect(safeError(error)).toEqual({ errorName: 'Error' });
+  });
+});
+
+describe('classifyFetchFailure', () => {
+  it('distinguishes an AbortSignal timeout from a manual abort', () => {
+    expect(classifyFetchFailure(new DOMException('timed out', 'TimeoutError'))).toBe('timeout');
+    expect(classifyFetchFailure(new DOMException('aborted', 'AbortError'))).toBe('aborted');
+  });
+
+  it('recognizes a disallowed redirect thrown under redirect: error', () => {
+    expect(
+      classifyFetchFailure(new TypeError("Fetch API cannot follow a redirect in mode 'error'"))
+    ).toBe('redirect');
+  });
+
+  it('recognizes dropped connections and network failures', () => {
+    expect(classifyFetchFailure(new TypeError('Network connection lost.'))).toBe('connection');
+    expect(classifyFetchFailure(new TypeError('The connection was reset.'))).toBe('connection');
+    expect(classifyFetchFailure(new TypeError('fetch failed'))).toBe('connection');
+  });
+
+  it('falls back to unknown for unrecognized or non-error throws', () => {
+    expect(classifyFetchFailure(new TypeError('something unexpected'))).toBe('unknown');
+    expect(classifyFetchFailure({ message: 'redirect' })).toBe('unknown');
+    expect(classifyFetchFailure('redirect')).toBe('unknown');
+  });
+
+  it('never returns the original message text, only a fixed literal', () => {
+    const reason = classifyFetchFailure(
+      new TypeError('redirect to https://evil.example/?token=postgres://secret@host')
+    );
+    expect(reason).toBe('redirect');
+    expect(reason).not.toContain('secret');
+    expect(reason).not.toContain('token');
+    expect(reason).not.toContain('https');
   });
 });

--- a/services/user-data-export/src/observability.ts
+++ b/services/user-data-export/src/observability.ts
@@ -18,6 +18,36 @@ export function safeError(error: unknown): { errorName: string; errorCode?: stri
   };
 }
 
+export type FetchFailureReason = 'timeout' | 'aborted' | 'redirect' | 'connection' | 'unknown';
+
+/**
+ * Classify a thrown `fetch()` failure into a fixed, non-sensitive reason.
+ *
+ * Only enumerated literals are returned; the original error message (which can
+ * contain URLs, query text, or secrets) is never propagated. This lets us tell
+ * apart the common Worker subrequest failures — a disallowed redirect (`redirect:
+ * 'error'`), an `AbortSignal.timeout`, or a dropped connection — which
+ * `safeError` alone flattens into an indistinguishable `TypeError`.
+ */
+export function classifyFetchFailure(error: unknown): FetchFailureReason {
+  if (error instanceof DOMException) {
+    if (error.name === 'TimeoutError') return 'timeout';
+    if (error.name === 'AbortError') return 'aborted';
+  }
+  const message = error instanceof Error ? error.message.toLowerCase() : '';
+  if (message.includes('redirect')) return 'redirect';
+  if (
+    message.includes('network') ||
+    message.includes('connection') ||
+    message.includes('reset') ||
+    message.includes('fetch failed') ||
+    message.includes('failed to fetch')
+  ) {
+    return 'connection';
+  }
+  return 'unknown';
+}
+
 export function logExportEvent(level: LogLevel, event: string, fields: ExportLogFields = {}): void {
   const value = JSON.stringify({ event, service: 'user-data-export', ...fields });
   if (level === 'error') console.error(value);

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -8,7 +8,7 @@ import {
 import { uploadGzipStream } from './gzip';
 import { createSourceAdapters, type ExportRecord } from './source-adapters';
 import type { SourceAdapter } from './source-adapters';
-import { logExportEvent, safeError } from './observability';
+import { classifyFetchFailure, logExportEvent, safeError } from './observability';
 
 const PART_BYTES = 5 * 1024 * 1024;
 const MAX_UNCOMPRESSED_BYTES_PER_INVOCATION = 32 * 1024 * 1024;
@@ -585,8 +585,11 @@ async function dispatchReadyNotifications(
       });
     } catch (error) {
       // The database-backed email lease remains authoritative for later sweeps.
+      // reason distinguishes a disallowed redirect / timeout / dropped connection,
+      // which safeError alone flattens into an opaque TypeError.
       logExportEvent('warn', 'export_notification_callback_failed', {
         exportId: item.id,
+        reason: classifyFetchFailure(error),
         ...safeError(error),
       });
     }


### PR DESCRIPTION
## Summary

Two export-related changes:

1. **Diagnose ready-notification callback failures** (`fix`). The worker's ready-notification callback only logs `export_notification_callback_failed` with `errorName` via `safeError()`, which intentionally strips `error.message` (to avoid leaking DB connection strings / query text — see `observability.test.ts`). For a `fetch()` `TypeError` that flattens every failure mode into an indistinguishable `"TypeError"`, so we can't tell a disallowed redirect (`redirect: 'error'`) from an `AbortSignal.timeout` or a dropped connection.

   Adds `classifyFetchFailure()`, which maps a thrown fetch failure to a fixed, non-sensitive `reason` enum (`timeout | aborted | redirect | connection | unknown`) **without ever propagating the message text**, and includes it on the failure log. The existing redaction invariant is preserved and covered by a new test that asserts none of the input message leaks into the returned literal.

   Context: in production the reconcile cron logs `export_notification_callback_failed` / `TypeError` every 5 minutes for a ready export, and never logs `export_notification_callback_completed` — i.e. the `fetch` throws before any response. This field will finally say which failure mode it is on the next deploy.

2. **⚠️ TEMPORARY: lower export re-request throttle to 5 minutes** (revert before launch). Lets us request repeat exports during pre-launch testing without waiting a day. The user-facing `TOO_MANY_REQUESTS` message is intentionally left unchanged ("You can request one data export every 24 hours"). **Restore `interval '5 minutes'` → `interval '24 hours'` in `apps/web/src/routers/user-exports-router.ts` before going live.**

## Testing

- `services/user-data-export`: typecheck clean, lint clean, 49 unit tests + 4 workers tests pass (5 new classifier tests).
- `apps/web/src/routers/user-exports-router.test.ts`: 8 tests pass.
