### PR TITLE
fix(exports): keep generated artifacts useful and compact

### DIFF
--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -925,6 +925,36 @@ describe('User', () => {
       expect(tombstone).toMatchObject({ multipart_upload_id: null });
     });
 
+    it('delays deterministic object cleanup until an active export lease expires', async () => {
+      const user = await insertTestUser();
+      const leaseExpiresAt = new Date(Date.now() + 10 * 60 * 1000).toISOString();
+      const [exportJob] = await db
+        .insert(user_data_exports)
+        .values({
+          kilo_user_id: user.id,
+          snapshot_at: new Date().toISOString(),
+          status: 'processing',
+          lease_token: crypto.randomUUID(),
+          lease_expires_at: leaseExpiresAt,
+        })
+        .returning();
+
+      await softDeleteUser(user.id);
+
+      const [tombstone] = await db
+        .select()
+        .from(user_data_export_object_deletions)
+        .where(
+          eq(
+            user_data_export_object_deletions.object_key,
+            `exports/${exportJob.id}/kilo-data-export.jsonl.gz`
+          )
+        );
+      expect(new Date(tombstone?.available_at ?? '').toISOString()).toBe(
+        new Date(leaseExpiresAt).toISOString()
+      );
+    });
+
     it('anonymizes recommendation dismissal actor references', async () => {
       const organizationOwner = await insertTestUser();
       const dismissingUser = await insertTestUser();

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -1084,15 +1084,22 @@ export async function softDeleteUser(userId: string) {
     // ── 2. Hard-delete PII tables ────────────────────────────────────────
     await tx.delete(user_auth_provider).where(eq(user_auth_provider.kilo_user_id, userId));
     await tx.execute(sql`
-      INSERT INTO user_data_export_object_deletions (object_key, multipart_upload_id)
+      INSERT INTO user_data_export_object_deletions (object_key, multipart_upload_id, available_at)
       SELECT COALESCE(r2_object_key, 'exports/' || id::text || '/kilo-data-export.jsonl.gz'),
-        multipart_upload_id
+        multipart_upload_id,
+        CASE
+          WHEN lease_expires_at > now() THEN lease_expires_at
+          ELSE now()
+        END
       FROM user_data_exports
       WHERE kilo_user_id = ${userId}
       ON CONFLICT (object_key) DO UPDATE
       SET multipart_upload_id = COALESCE(
         EXCLUDED.multipart_upload_id,
         user_data_export_object_deletions.multipart_upload_id
+      ), available_at = GREATEST(
+        user_data_export_object_deletions.available_at,
+        EXCLUDED.available_at
       ), updated_at = now()
     `);
     await tx.delete(user_data_exports).where(eq(user_data_exports.kilo_user_id, userId));

--- a/services/user-data-export/src/databases.ts
+++ b/services/user-data-export/src/databases.ts
@@ -142,6 +142,22 @@ export function createStateDb(binding: HyperdriveBinding) {
       `);
       return rows.rows[0]?.matches ?? false;
     },
+    async scheduleTerminalObjectDeletion(input: {
+      exportId: string;
+      objectKey: string;
+    }): Promise<boolean> {
+      const rows = await db.execute<{ object_key: string }>(sql`
+        INSERT INTO user_data_export_object_deletions (object_key, available_at)
+        SELECT ${input.objectKey}, now()
+        FROM user_data_exports
+        WHERE id = ${input.exportId} AND status IN ('failed', 'expired')
+        ON CONFLICT (object_key) DO UPDATE
+        SET available_at = LEAST(user_data_export_object_deletions.available_at, now()),
+          updated_at = now()
+        RETURNING object_key
+      `);
+      return rows.rows.length > 0;
+    },
     async markFailed(
       exportId: string,
       generation: number,

--- a/services/user-data-export/src/databases.ts
+++ b/services/user-data-export/src/databases.ts
@@ -81,6 +81,22 @@ export function createStateDb(binding: HyperdriveBinding) {
       if (result?.attached) return 'attached';
       return result?.export_exists ? 'lost_lease' : 'deleted';
     },
+    async clearClaimedMultipartUpload(input: {
+      exportId: string;
+      generation: number;
+      leaseToken: string;
+      multipartUploadId: string;
+    }): Promise<boolean> {
+      const rows = await db.execute<{ id: string }>(sql`
+        UPDATE user_data_exports
+        SET status = 'processing', multipart_upload_id = NULL, updated_at = now()
+        WHERE id = ${input.exportId} AND dispatch_generation = ${input.generation}
+          AND lease_token = ${input.leaseToken}
+          AND multipart_upload_id = ${input.multipartUploadId}
+        RETURNING id
+      `);
+      return rows.rows.length > 0;
+    },
     async complete(input: {
       exportId: string;
       leaseToken: string;
@@ -179,8 +195,7 @@ export function createStateDb(binding: HyperdriveBinding) {
     async releaseForRetry(exportId: string, generation: number, leaseToken: string): Promise<void> {
       await db.execute(sql`
         UPDATE user_data_exports
-        SET status = 'queued', multipart_upload_id = NULL, lease_token = NULL,
-          lease_expires_at = NULL, updated_at = now()
+        SET status = 'queued', lease_token = NULL, lease_expires_at = NULL, updated_at = now()
         WHERE id = ${exportId} AND dispatch_generation = ${generation}
           AND status IN ('processing', 'finalizing') AND lease_token = ${leaseToken}
       `);

--- a/services/user-data-export/src/databases.ts
+++ b/services/user-data-export/src/databases.ts
@@ -1,6 +1,5 @@
 import { getWorkerDb, pg } from '@kilocode/db/client';
 import { sql } from 'drizzle-orm';
-import type { ExportCursor } from './contracts';
 import type { ReplicaQuery } from './source-adapters';
 
 export type HyperdriveBinding = { connectionString: string };
@@ -21,7 +20,6 @@ export type ExportJob = {
   r2_object_key: string | null;
 };
 
-type Part = { part_number: number; etag: string };
 type PendingNotification = { id: string };
 type StoredObject = { id: string; r2_object_key: string };
 type MultipartUpload = { id: string; multipart_upload_id: string };
@@ -42,7 +40,7 @@ export function createStateDb(binding: HyperdriveBinding) {
               WHEN current_source IS NULL AND multipart_upload_id IS NOT NULL THEN 'finalizing'
               ELSE 'processing'
             END,
-            lease_token = ${leaseToken}, lease_expires_at = now() + interval '14 minutes',
+            lease_token = ${leaseToken}, lease_expires_at = now() + interval '16 minutes',
             attempt_count = attempt_count + 1, started_at = COALESCE(started_at, now()), updated_at = now()
         WHERE id = ${exportId} AND dispatch_generation = ${generation}
           AND status IN ('queued', 'processing', 'finalizing')
@@ -66,9 +64,7 @@ export function createStateDb(binding: HyperdriveBinding) {
             AND lease_token = ${input.leaseToken} AND multipart_upload_id IS NULL
           RETURNING id
         ), existing AS (
-          SELECT EXISTS (
-            SELECT 1 FROM user_data_exports WHERE id = ${input.exportId}
-          ) AS export_exists
+          SELECT EXISTS (SELECT 1 FROM user_data_exports WHERE id = ${input.exportId}) AS export_exists
         ), cleanup AS (
           INSERT INTO user_data_export_object_deletions (object_key, multipart_upload_id)
           SELECT ${`exports/${input.exportId}/kilo-data-export.jsonl.gz`}, ${input.multipartUploadId}
@@ -85,63 +81,21 @@ export function createStateDb(binding: HyperdriveBinding) {
       if (result?.attached) return 'attached';
       return result?.export_exists ? 'lost_lease' : 'deleted';
     },
-    async checkpoint(input: {
-      exportId: string;
-      leaseToken: string;
-      parts: Array<{ partNumber: number; etag: string; sizeBytes: number }>;
-      rowCount: number;
-      cursor: ExportCursor | null;
-      nextSource: string | null;
-      nextGeneration: number;
-      multipartUploadId: string;
-    }): Promise<boolean> {
-      const nextPartNumber = input.parts.at(-1)?.partNumber;
-      if (nextPartNumber === undefined) throw new Error('Export checkpoint has no parts');
-      const rows = await db.execute<{ id: string }>(sql`
-        WITH candidate AS (
-          SELECT id
-          FROM user_data_exports
-          WHERE id = ${input.exportId} AND lease_token = ${input.leaseToken}
-          FOR UPDATE
-        ), input_parts AS (
-          SELECT * FROM jsonb_to_recordset(${JSON.stringify(input.parts)}::jsonb)
-            AS part("partNumber" integer, etag text, "sizeBytes" bigint)
-        ), inserted_parts AS (
-          INSERT INTO user_data_export_parts (export_id, part_number, etag, size_bytes)
-          SELECT candidate.id, part."partNumber", part.etag, part."sizeBytes"
-          FROM candidate CROSS JOIN input_parts AS part
-          RETURNING export_id
-        ), updated AS (
-          UPDATE user_data_exports AS exports
-          SET source_cursor = ${JSON.stringify(input.cursor)}::jsonb,
-            current_source = ${input.nextSource}, next_part_number = ${nextPartNumber + 1},
-            multipart_upload_id = ${input.multipartUploadId}, dispatch_generation = ${input.nextGeneration},
-            row_count = exports.row_count + ${input.rowCount}, attempt_count = 0,
-            lease_token = NULL, lease_expires_at = NULL, updated_at = now()
-          FROM (SELECT DISTINCT export_id FROM inserted_parts) AS inserted
-          WHERE exports.id = inserted.export_id AND exports.lease_token = ${input.leaseToken}
-          RETURNING exports.id
-        )
-        INSERT INTO user_data_export_outbox (export_id, generation, operation, available_at)
-        SELECT id, ${input.nextGeneration}, 'generate', now() FROM updated
-        ON CONFLICT (export_id, generation, operation) DO NOTHING
-        RETURNING export_id AS id
-      `);
-      return rows.rows.length > 0;
-    },
     async complete(input: {
       exportId: string;
       leaseToken: string;
       objectKey: string;
       etag: string;
       sizeBytes: number;
+      rowCount: number;
     }): Promise<boolean> {
       const rows = await db.execute<{ id: string }>(sql`
         UPDATE user_data_exports
         SET status = 'ready', r2_object_key = ${input.objectKey}, r2_etag = ${input.etag}, size_bytes = ${input.sizeBytes},
+          row_count = ${input.rowCount}, current_source = NULL, source_cursor = NULL,
           completed_at = now(), expires_at = now() + interval '7 days', multipart_upload_id = NULL,
           lease_token = NULL, lease_expires_at = NULL, updated_at = now()
-        WHERE id = ${input.exportId} AND status = 'finalizing' AND lease_token = ${input.leaseToken}
+        WHERE id = ${input.exportId} AND status = 'processing' AND lease_token = ${input.leaseToken}
         RETURNING id
       `);
       return rows.rows.length > 0;
@@ -149,14 +103,30 @@ export function createStateDb(binding: HyperdriveBinding) {
     async markFailed(
       exportId: string,
       generation: number,
-      failureCode = 'queue_delivery_exhausted'
+      failureCode = 'queue_delivery_exhausted',
+      redactedMessage = 'The export could not be completed after multiple attempts.'
     ): Promise<void> {
       await db.execute(sql`
         UPDATE user_data_exports SET status = 'failed', failure_code = ${failureCode},
-          last_error_redacted = 'The export could not be completed after multiple attempts.',
+          last_error_redacted = ${redactedMessage},
           lease_token = NULL, lease_expires_at = NULL, updated_at = now()
         WHERE id = ${exportId} AND dispatch_generation = ${generation}
           AND status IN ('queued', 'processing', 'finalizing')
+      `);
+    },
+    async markLeasedExportFailed(input: {
+      exportId: string;
+      generation: number;
+      leaseToken: string;
+      failureCode: string;
+      redactedMessage: string;
+    }): Promise<void> {
+      await db.execute(sql`
+        UPDATE user_data_exports SET status = 'failed', failure_code = ${input.failureCode},
+          last_error_redacted = ${input.redactedMessage}, lease_token = NULL,
+          lease_expires_at = NULL, updated_at = now()
+        WHERE id = ${input.exportId} AND dispatch_generation = ${input.generation}
+          AND status IN ('processing', 'finalizing') AND lease_token = ${input.leaseToken}
       `);
     },
     async pendingOutbox(): Promise<ExportQueueRow[]> {
@@ -209,7 +179,8 @@ export function createStateDb(binding: HyperdriveBinding) {
     async releaseForRetry(exportId: string, generation: number, leaseToken: string): Promise<void> {
       await db.execute(sql`
         UPDATE user_data_exports
-        SET status = 'queued', lease_token = NULL, lease_expires_at = NULL, updated_at = now()
+        SET status = 'queued', multipart_upload_id = NULL, lease_token = NULL,
+          lease_expires_at = NULL, updated_at = now()
         WHERE id = ${exportId} AND dispatch_generation = ${generation}
           AND status IN ('processing', 'finalizing') AND lease_token = ${leaseToken}
       `);
@@ -298,12 +269,6 @@ export function createStateDb(binding: HyperdriveBinding) {
           updated_at = now()
         WHERE object_key = ${objectKey}
       `);
-    },
-    async parts(exportId: string): Promise<Part[]> {
-      const rows = await db.execute<Part>(sql`
-        SELECT part_number, etag FROM user_data_export_parts WHERE export_id = ${exportId} ORDER BY part_number
-      `);
-      return rows.rows;
     },
     async pendingNotifications(): Promise<PendingNotification[]> {
       const rows = await db.execute<PendingNotification>(sql`

--- a/services/user-data-export/src/databases.ts
+++ b/services/user-data-export/src/databases.ts
@@ -23,6 +23,7 @@ export type ExportJob = {
 type PendingNotification = { id: string };
 type StoredObject = { id: string; r2_object_key: string };
 type MultipartUpload = { id: string; multipart_upload_id: string };
+export type ExportCompletionResult = 'completed' | 'already_completed' | 'fenced';
 type ReadyExportObject = { r2_object_key: string; expires_at: string };
 type ObjectDeletion = { object_key: string; multipart_upload_id: string | null };
 
@@ -104,17 +105,42 @@ export function createStateDb(binding: HyperdriveBinding) {
       etag: string;
       sizeBytes: number;
       rowCount: number;
-    }): Promise<boolean> {
-      const rows = await db.execute<{ id: string }>(sql`
-        UPDATE user_data_exports
-        SET status = 'ready', r2_object_key = ${input.objectKey}, r2_etag = ${input.etag}, size_bytes = ${input.sizeBytes},
-          row_count = ${input.rowCount}, current_source = NULL, source_cursor = NULL,
-          completed_at = now(), expires_at = now() + interval '7 days', multipart_upload_id = NULL,
-          lease_token = NULL, lease_expires_at = NULL, updated_at = now()
-        WHERE id = ${input.exportId} AND status = 'processing' AND lease_token = ${input.leaseToken}
-        RETURNING id
+    }): Promise<ExportCompletionResult> {
+      const rows = await db.execute<{ result: ExportCompletionResult }>(sql`
+        WITH completed AS (
+          UPDATE user_data_exports
+          SET status = 'ready', r2_object_key = ${input.objectKey}, r2_etag = ${input.etag}, size_bytes = ${input.sizeBytes},
+            row_count = ${input.rowCount}, current_source = NULL, source_cursor = NULL,
+            completed_at = now(), expires_at = now() + interval '7 days', multipart_upload_id = NULL,
+            lease_token = NULL, lease_expires_at = NULL, updated_at = now()
+          WHERE id = ${input.exportId} AND status = 'processing' AND lease_token = ${input.leaseToken}
+          RETURNING id
+        )
+        SELECT CASE
+          WHEN EXISTS (SELECT 1 FROM completed) THEN 'completed'
+          WHEN EXISTS (
+            SELECT 1 FROM user_data_exports
+            WHERE id = ${input.exportId} AND status = 'ready'
+              AND r2_object_key = ${input.objectKey} AND r2_etag = ${input.etag}
+          ) THEN 'already_completed'
+          ELSE 'fenced'
+        END AS result
       `);
-      return rows.rows.length > 0;
+      return rows.rows[0]?.result ?? 'fenced';
+    },
+    async completedObjectMatches(input: {
+      exportId: string;
+      objectKey: string;
+      etag: string;
+    }): Promise<boolean> {
+      const rows = await db.execute<{ matches: boolean }>(sql`
+        SELECT EXISTS (
+          SELECT 1 FROM user_data_exports
+          WHERE id = ${input.exportId} AND status = 'ready'
+            AND r2_object_key = ${input.objectKey} AND r2_etag = ${input.etag}
+        ) AS matches
+      `);
+      return rows.rows[0]?.matches ?? false;
     },
     async markFailed(
       exportId: string,

--- a/services/user-data-export/src/gzip.test.ts
+++ b/services/user-data-export/src/gzip.test.ts
@@ -1,17 +1,15 @@
 import { gunzipSync } from 'node:zlib';
 import { describe, expect, it } from 'vitest';
-import { gzipMember, gzipPaddingMember, uploadGzipStream } from './gzip';
+import { gzipMember, uploadGzipStream } from './gzip';
 import { exportArtifact, isAllowedWebCallbackUrl, redirectTargetHost } from './worker';
 
 describe('gzip export members', () => {
   it('concatenates independently compressed JSONL members into one gzip stream', async () => {
     const header = await gzipMember('{"type":"header"}\n');
     const record = await gzipMember('{"value":"hello"}\n');
-    const padding = await gzipPaddingMember(1024);
-    const archive = Buffer.concat([header, record, padding]);
+    const archive = Buffer.concat([header, record]);
 
     expect(gunzipSync(archive).toString()).toBe('{"type":"header"}\n{"value":"hello"}\n');
-    expect(padding.byteLength).toBe(1024);
   });
 
   it('streams a smaller final part without padding', async () => {
@@ -31,14 +29,30 @@ describe('gzip export members', () => {
     expect(parts[0]).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7]));
   });
 
-  it('pads non-final output to uniform parts without decoded bytes', async () => {
-    const payload = '{"value":"hello"}\n';
-    const compressed = await gzipMember(payload);
+  it('rejects a non-final stream that cannot form a legal multipart boundary', async () => {
     const parts: Uint8Array[] = [];
-    await uploadGzipStream({
-      stream: new Blob([compressed]).stream(),
-      partBytes: 64,
-      startPartNumber: 1,
+    await expect(
+      uploadGzipStream({
+        stream: new Blob([new Uint8Array([1, 2, 3, 4, 5, 6, 7])]).stream(),
+        partBytes: 8,
+        startPartNumber: 2,
+        isFinal: () => false,
+        uploadPart: async (_partNumber, value) => {
+          parts.push(value.slice());
+          return { etag: `etag-${parts.length}` };
+        },
+      })
+    ).rejects.toThrow('Non-final compressed export did not fill an R2 multipart part');
+
+    expect(parts).toEqual([]);
+  });
+
+  it('uploads full non-final parts without padding', async () => {
+    const parts: Uint8Array[] = [];
+    const uploaded = await uploadGzipStream({
+      stream: new Blob([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])]).stream(),
+      partBytes: 8,
+      startPartNumber: 2,
       isFinal: () => false,
       uploadPart: async (_partNumber, value) => {
         parts.push(value.slice());
@@ -46,8 +60,8 @@ describe('gzip export members', () => {
       },
     });
 
-    expect(parts.every(part => part.byteLength === 64)).toBe(true);
-    expect(gunzipSync(Buffer.concat(parts)).toString()).toBe(payload);
+    expect(uploaded).toEqual([{ partNumber: 2, etag: 'etag-1', sizeBytes: 8 }]);
+    expect(parts).toEqual([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])]);
   });
 
   it('stores a gzip archive without HTTP content encoding', () => {

--- a/services/user-data-export/src/gzip.test.ts
+++ b/services/user-data-export/src/gzip.test.ts
@@ -1,76 +1,29 @@
-import { gunzipSync } from 'node:zlib';
 import { describe, expect, it } from 'vitest';
-import { gzipMember, uploadGzipStream } from './gzip';
-import { exportArtifact, isAllowedWebCallbackUrl, redirectTargetHost } from './worker';
+import { uploadGzipStream } from './gzip';
+import { isAllowedWebCallbackUrl, redirectTargetHost } from './worker';
 
-describe('gzip export members', () => {
-  it('concatenates independently compressed JSONL members into one gzip stream', async () => {
-    const header = await gzipMember('{"type":"header"}\n');
-    const record = await gzipMember('{"value":"hello"}\n');
-    const archive = Buffer.concat([header, record]);
-
-    expect(gunzipSync(archive).toString()).toBe('{"type":"header"}\n{"value":"hello"}\n');
-  });
-
-  it('streams a smaller final part without padding', async () => {
-    const parts: Uint8Array[] = [];
-    const uploaded = await uploadGzipStream({
-      stream: new Blob([new Uint8Array([1, 2, 3, 4, 5, 6, 7])]).stream(),
-      partBytes: 8,
-      startPartNumber: 3,
-      isFinal: () => true,
+describe('uploadGzipStream', () => {
+  it('flushes full parts periodically and one short final part', async () => {
+    const values: Uint8Array[] = [];
+    const parts = await uploadGzipStream({
+      stream: new Blob([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8, 9])]).stream(),
+      partBytes: 4,
       uploadPart: async (_partNumber, value) => {
-        parts.push(value.slice());
-        return { etag: `etag-${parts.length}` };
+        values.push(value.slice());
+        return { etag: `etag-${values.length}` };
       },
     });
 
-    expect(uploaded).toEqual([{ partNumber: 3, etag: 'etag-1', sizeBytes: 7 }]);
-    expect(parts[0]).toEqual(new Uint8Array([1, 2, 3, 4, 5, 6, 7]));
-  });
-
-  it('rejects a non-final stream that cannot form a legal multipart boundary', async () => {
-    const parts: Uint8Array[] = [];
-    await expect(
-      uploadGzipStream({
-        stream: new Blob([new Uint8Array([1, 2, 3, 4, 5, 6, 7])]).stream(),
-        partBytes: 8,
-        startPartNumber: 2,
-        isFinal: () => false,
-        uploadPart: async (_partNumber, value) => {
-          parts.push(value.slice());
-          return { etag: `etag-${parts.length}` };
-        },
-      })
-    ).rejects.toThrow('Non-final compressed export did not fill an R2 multipart part');
-
-    expect(parts).toEqual([]);
-  });
-
-  it('uploads full non-final parts without padding', async () => {
-    const parts: Uint8Array[] = [];
-    const uploaded = await uploadGzipStream({
-      stream: new Blob([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])]).stream(),
-      partBytes: 8,
-      startPartNumber: 2,
-      isFinal: () => false,
-      uploadPart: async (_partNumber, value) => {
-        parts.push(value.slice());
-        return { etag: `etag-${parts.length}` };
-      },
-    });
-
-    expect(uploaded).toEqual([{ partNumber: 2, etag: 'etag-1', sizeBytes: 8 }]);
-    expect(parts).toEqual([new Uint8Array([1, 2, 3, 4, 5, 6, 7, 8])]);
-  });
-
-  it('stores a gzip archive without HTTP content encoding', () => {
-    expect(exportArtifact).toEqual({
-      contentDisposition: 'attachment; filename="kilo-data-export.jsonl.gz"',
-      contentType: 'application/gzip',
-      partBytes: 5 * 1024 * 1024,
-    });
-    expect(exportArtifact).not.toHaveProperty('contentEncoding');
+    expect(parts).toEqual([
+      { partNumber: 1, etag: 'etag-1', sizeBytes: 4 },
+      { partNumber: 2, etag: 'etag-2', sizeBytes: 4 },
+      { partNumber: 3, etag: 'etag-3', sizeBytes: 1 },
+    ]);
+    expect(values).toEqual([
+      new Uint8Array([1, 2, 3, 4]),
+      new Uint8Array([5, 6, 7, 8]),
+      new Uint8Array([9]),
+    ]);
   });
 
   it('allows HTTPS and loopback HTTP notification callbacks only', () => {

--- a/services/user-data-export/src/gzip.ts
+++ b/services/user-data-export/src/gzip.ts
@@ -1,34 +1,6 @@
-const GZIP_HEADER_BYTES = 10;
-
 export async function gzipMember(value: string): Promise<Uint8Array> {
   const compressed = new Blob([value]).stream().pipeThrough(new CompressionStream('gzip'));
   return new Uint8Array(await new Response(compressed).arrayBuffer());
-}
-
-export async function gzipPaddingMember(size: number): Promise<Uint8Array> {
-  const emptyMember = await gzipMember('');
-  if (
-    emptyMember.byteLength < GZIP_HEADER_BYTES + 8 ||
-    emptyMember[0] !== 0x1f ||
-    emptyMember[1] !== 0x8b ||
-    emptyMember[2] !== 0x08 ||
-    emptyMember[3] !== 0
-  ) {
-    throw new Error('Runtime produced an unsupported gzip header');
-  }
-  if (size < emptyMember.byteLength) {
-    throw new Error('Gzip padding is smaller than an empty gzip member');
-  }
-  if (size === emptyMember.byteLength) return emptyMember;
-
-  const commentLength = size - emptyMember.byteLength - 1;
-  const padded = new Uint8Array(size);
-  padded.set(emptyMember.subarray(0, GZIP_HEADER_BYTES));
-  padded[3] |= 0x08; // FCOMMENT
-  padded.fill(0x50, GZIP_HEADER_BYTES, GZIP_HEADER_BYTES + commentLength);
-  padded[GZIP_HEADER_BYTES + commentLength] = 0;
-  padded.set(emptyMember.subarray(GZIP_HEADER_BYTES), GZIP_HEADER_BYTES + commentLength + 1);
-  return padded;
 }
 
 export type UploadedGzipPart = { partNumber: number; etag: string; sizeBytes: number };
@@ -72,13 +44,12 @@ export async function uploadGzipStream(input: {
     await append(result.value);
   }
 
-  if (used > 0 && !input.isFinal()) {
-    const gap = input.partBytes - used;
-    const minimumPaddingSize = (await gzipMember('')).byteLength;
-    const paddingSize = gap >= minimumPaddingSize ? gap : gap + input.partBytes;
-    await append(await gzipPaddingMember(paddingSize));
+  if (used > 0) {
+    if (!input.isFinal()) {
+      throw new Error('Non-final compressed export did not fill an R2 multipart part');
+    }
+    await flush(used);
   }
-  if (used > 0) await flush(used);
 
   return uploaded;
 }

--- a/services/user-data-export/src/gzip.ts
+++ b/services/user-data-export/src/gzip.ts
@@ -1,20 +1,13 @@
-export async function gzipMember(value: string): Promise<Uint8Array> {
-  const compressed = new Blob([value]).stream().pipeThrough(new CompressionStream('gzip'));
-  return new Uint8Array(await new Response(compressed).arrayBuffer());
-}
-
 export type UploadedGzipPart = { partNumber: number; etag: string; sizeBytes: number };
 
 export async function uploadGzipStream(input: {
   stream: ReadableStream<Uint8Array>;
   partBytes: number;
-  startPartNumber: number;
-  isFinal: () => boolean;
   uploadPart: (partNumber: number, value: Uint8Array) => Promise<{ etag: string }>;
 }): Promise<UploadedGzipPart[]> {
   const reader = input.stream.getReader();
   const uploaded: UploadedGzipPart[] = [];
-  let partNumber = input.startPartNumber;
+  let partNumber = 1;
   let buffer = new Uint8Array(input.partBytes);
   let used = 0;
 
@@ -27,29 +20,19 @@ export async function uploadGzipStream(input: {
     used = 0;
   };
 
-  const append = async (chunk: Uint8Array) => {
+  while (true) {
+    const result = await reader.read();
+    if (result.done) break;
     let offset = 0;
-    while (offset < chunk.byteLength) {
-      const length = Math.min(input.partBytes - used, chunk.byteLength - offset);
-      buffer.set(chunk.subarray(offset, offset + length), used);
+    while (offset < result.value.byteLength) {
+      const length = Math.min(input.partBytes - used, result.value.byteLength - offset);
+      buffer.set(result.value.subarray(offset, offset + length), used);
       used += length;
       offset += length;
       if (used === input.partBytes) await flush(input.partBytes);
     }
-  };
-
-  while (true) {
-    const result = await reader.read();
-    if (result.done) break;
-    await append(result.value);
   }
 
-  if (used > 0) {
-    if (!input.isFinal()) {
-      throw new Error('Non-final compressed export did not fill an R2 multipart part');
-    }
-    await flush(used);
-  }
-
+  if (used > 0) await flush(used);
   return uploaded;
 }

--- a/services/user-data-export/src/source-adapters.test.ts
+++ b/services/user-data-export/src/source-adapters.test.ts
@@ -16,6 +16,8 @@ describe('source adapters', () => {
     expect(sourceQueries.projectQuery).not.toContain('created_by_user_id');
     expect(sourceQueries.promptQuery).toContain('FROM microdollar_usage AS mu');
     expect(sourceQueries.promptQuery).toContain('mu.kilo_user_id = $1');
+    expect(sourceQueries.promptQuery).toContain('meta.id AS metadata_id');
+    expect(sourceQueries.promptQuery).toContain('meta.created_at');
   });
 
   it('reports unresolved sources as disabled without querying them', () => {
@@ -101,8 +103,10 @@ describe('source adapters', () => {
         calls.push({ text, values });
         return [
           {
-            id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
-            created_at: '2026-08-08T12:00:00.000000Z',
+            usage_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            usage_created_at: '2026-08-08T12:00:00.000000Z',
+            metadata_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            metadata_created_at: '2026-08-08T12:00:01.000000Z',
             user_prompt_prefix: 'User prompt',
             system_prompt_prefix: 'System prompt',
           },
@@ -127,6 +131,8 @@ describe('source adapters', () => {
     expect(page?.records).toEqual([
       {
         source: 'microdollar_usage_metadata',
+        id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        createdAt: '2026-08-08T12:00:01.000Z',
         field: 'user_prompt_prefix',
         value: 'User prompt',
       },
@@ -136,6 +142,72 @@ describe('source adapters', () => {
         value: 'System prompt',
       },
     ]);
+  });
+
+  it('preserves a null metadata timestamp without attributing usage identity to the system lookup', async () => {
+    const prompts = requireAdapter(
+      createSourceAdapters(async () => [
+        {
+          usage_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          usage_created_at: '2026-08-08T12:00:00.000000Z',
+          metadata_id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+          metadata_created_at: null,
+          user_prompt_prefix: null,
+          system_prompt_prefix: null,
+        },
+      ]),
+      'microdollar_usage_prompts'
+    );
+
+    const page = await prompts.readPage?.({
+      kiloUserId: 'owner-user',
+      snapshotAt: '2026-08-08T13:00:00.000Z',
+      cursor: null,
+      limit: 100,
+    });
+
+    expect(page?.records).toEqual([
+      {
+        source: 'microdollar_usage_metadata',
+        id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        createdAt: null,
+        field: 'user_prompt_prefix',
+        value: null,
+      },
+      {
+        source: 'system_prompt_prefix',
+        field: 'system_prompt_prefix',
+        value: null,
+      },
+    ]);
+  });
+
+  it('paginates prompts by usage identity rather than metadata provenance', async () => {
+    const prompts = requireAdapter(
+      createSourceAdapters(async () => [
+        {
+          usage_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          usage_created_at: '2026-08-08T12:00:00.000000Z',
+          metadata_id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          metadata_created_at: '2026-08-08T12:05:00.000000Z',
+          user_prompt_prefix: null,
+          system_prompt_prefix: null,
+        },
+      ]),
+      'microdollar_usage_prompts'
+    );
+
+    const page = await prompts.readPage?.({
+      kiloUserId: 'owner-user',
+      snapshotAt: '2026-08-08T13:00:00.000Z',
+      cursor: null,
+      limit: 1,
+    });
+
+    expect(page?.nextCursor).toEqual({
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      createdAt: '2026-08-08T12:00:00.000000Z',
+    });
   });
 
   it('exports the matched Kilo user columns with their JSON value types', async () => {

--- a/services/user-data-export/src/source-adapters.ts
+++ b/services/user-data-export/src/source-adapters.ts
@@ -4,6 +4,8 @@ export type ExportRecord = {
   source: string;
   field: string;
   value: string | number | boolean | null;
+  id?: string;
+  createdAt?: string | null;
 };
 export type SourcePage = { records: ExportRecord[]; nextCursor: ExportCursor | null };
 
@@ -29,8 +31,10 @@ WHERE owned_by_user_id = $1
 ORDER BY created_at, id
 LIMIT $5`;
 
-const promptQuery = `SELECT mu.id,
-  to_char(mu.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS created_at,
+const promptQuery = `SELECT mu.id AS usage_id,
+  to_char(mu.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS usage_created_at,
+  meta.id AS metadata_id,
+  to_char(meta.created_at AT TIME ZONE 'UTC', 'YYYY-MM-DD"T"HH24:MI:SS.US"Z"') AS metadata_created_at,
   meta.user_prompt_prefix, spp.system_prompt_prefix
 FROM microdollar_usage AS mu
 JOIN microdollar_usage_metadata AS meta ON meta.id = mu.id
@@ -57,8 +61,10 @@ function cursorFor(row: Record<string, unknown>): ExportCursor {
 
 type ProjectRow = { id: string; title: string | null; created_at: string };
 type PromptRow = {
-  id: string;
-  created_at: string;
+  usage_id: string;
+  usage_created_at: string;
+  metadata_id: string;
+  metadata_created_at: string | null;
   user_prompt_prefix: string | null;
   system_prompt_prefix: string | null;
 };
@@ -213,8 +219,10 @@ export function createSourceAdapters(query: ReplicaQuery): SourceAdapter[] {
           input.limit,
         ]).then(result =>
           result.map(row => ({
-            id: requiredString(row.id, 'id'),
-            created_at: cursorTimestamp(row.created_at),
+            usage_id: requiredString(row.usage_id, 'usage_id'),
+            usage_created_at: cursorTimestamp(row.usage_created_at),
+            metadata_id: requiredString(row.metadata_id, 'metadata_id'),
+            metadata_created_at: nullableTimestamp(row.metadata_created_at, 'metadata_created_at'),
             user_prompt_prefix: nullableString(row.user_prompt_prefix, 'user_prompt_prefix'),
             system_prompt_prefix: nullableString(row.system_prompt_prefix, 'system_prompt_prefix'),
           }))
@@ -222,6 +230,8 @@ export function createSourceAdapters(query: ReplicaQuery): SourceAdapter[] {
         const records = rows.flatMap(row => [
           {
             source: 'microdollar_usage_metadata',
+            id: row.metadata_id,
+            createdAt: row.metadata_created_at,
             field: 'user_prompt_prefix',
             value: row.user_prompt_prefix == null ? null : String(row.user_prompt_prefix),
           },
@@ -234,7 +244,10 @@ export function createSourceAdapters(query: ReplicaQuery): SourceAdapter[] {
         const lastRow = rows.at(-1);
         return {
           records,
-          nextCursor: rows.length === input.limit && lastRow ? cursorFor(lastRow) : null,
+          nextCursor:
+            rows.length === input.limit && lastRow
+              ? { createdAt: lastRow.usage_created_at, id: lastRow.usage_id }
+              : null,
         };
       },
     },

--- a/services/user-data-export/src/worker.test.ts
+++ b/services/user-data-export/src/worker.test.ts
@@ -7,6 +7,7 @@ import {
   exportArtifact,
   handleGenerationFailure,
   processScheduledExportWork,
+  recoverInterruptedMultipartUpload,
   resolveSourceAdapter,
   TerminalExportError,
   type ExportEnv,
@@ -210,6 +211,46 @@ describe('generation failure handling', () => {
       2,
       'lease-token'
     );
+  });
+});
+
+describe('interrupted multipart recovery', () => {
+  it('aborts the orphan and clears its lease-fenced database reference', async () => {
+    const abort = vi.fn();
+    const clear = vi.fn().mockResolvedValue(true);
+
+    await expect(recoverInterruptedMultipartUpload({ upload: { abort }, clear })).resolves.toBe(
+      true
+    );
+
+    expect(abort).toHaveBeenCalledOnce();
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it('treats a missing orphan upload as already aborted', async () => {
+    const clear = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      recoverInterruptedMultipartUpload({
+        upload: { abort: vi.fn().mockRejectedValue({ code: 10024 }) },
+        clear,
+      })
+    ).resolves.toBe(true);
+
+    expect(clear).toHaveBeenCalledOnce();
+  });
+
+  it('does not clear the database reference when abort fails transiently', async () => {
+    const clear = vi.fn();
+
+    await expect(
+      recoverInterruptedMultipartUpload({
+        upload: { abort: vi.fn().mockRejectedValue(new Error('R2 unavailable')) },
+        clear,
+      })
+    ).rejects.toThrow('R2 unavailable');
+
+    expect(clear).not.toHaveBeenCalled();
   });
 });
 

--- a/services/user-data-export/src/worker.test.ts
+++ b/services/user-data-export/src/worker.test.ts
@@ -7,6 +7,7 @@ import {
   exportArtifact,
   handleGenerationFailure,
   processScheduledExportWork,
+  persistCompletedExport,
   recoverInterruptedMultipartUpload,
   resolveSourceAdapter,
   TerminalExportError,
@@ -254,6 +255,26 @@ describe('interrupted multipart recovery', () => {
   });
 });
 
+describe('completed export persistence', () => {
+  it('accepts a ready row after the completion response is lost', async () => {
+    await expect(
+      persistCompletedExport({
+        complete: vi.fn().mockRejectedValue(new Error('database response lost')),
+        completedObjectMatches: vi.fn().mockResolvedValue(true),
+      })
+    ).resolves.toBe('already_completed');
+  });
+
+  it('rethrows an ambiguous completion when the ready object does not match', async () => {
+    await expect(
+      persistCompletedExport({
+        complete: vi.fn().mockRejectedValue(new Error('database unavailable')),
+        completedObjectMatches: vi.fn().mockResolvedValue(false),
+      })
+    ).rejects.toThrow('database unavailable');
+  });
+});
+
 describe('account-deletion object cleanup', () => {
   it('removes a tombstone only after R2 deletion succeeds', async () => {
     const state = {
@@ -390,6 +411,33 @@ describe('scheduled export maintenance isolation', () => {
     expect(state.markOutboxSent).toHaveBeenCalledWith('outbox-id');
     expect(state.recordOutboxFailure).not.toHaveBeenCalled();
     warn.mockRestore();
+  });
+
+  it('clears a failed multipart reference when the upload is already missing', async () => {
+    const state = {
+      expiredObjects: vi.fn().mockResolvedValue([]),
+      markExpired: vi.fn(),
+      failedMultipartUploads: vi
+        .fn()
+        .mockResolvedValue([{ id: 'failed-id', multipart_upload_id: 'upload-id' }]),
+      clearMultipartUpload: vi.fn(),
+      pendingOutbox: vi.fn().mockResolvedValue([]),
+      markOutboxSent: vi.fn(),
+      recordOutboxFailure: vi.fn(),
+    };
+    const env = {
+      EXPORT_BUCKET: {
+        delete: vi.fn(),
+        resumeMultipartUpload: vi.fn().mockReturnValue({
+          abort: vi.fn().mockRejectedValue({ name: 'NoSuchUpload' }),
+        }),
+      },
+      EXPORT_QUEUE: { send: vi.fn() },
+    };
+
+    await processScheduledExportWork(env, state);
+
+    expect(state.clearMultipartUpload).toHaveBeenCalledWith('failed-id');
   });
 
   it('continues to outbox dispatch after a failed multipart abort', async () => {

--- a/services/user-data-export/src/worker.test.ts
+++ b/services/user-data-export/src/worker.test.ts
@@ -5,6 +5,7 @@ import {
   deletePendingObjects,
   exportHeader,
   exportArtifact,
+  handleFencedCompletion,
   handleGenerationFailure,
   processScheduledExportWork,
   persistCompletedExport,
@@ -272,6 +273,27 @@ describe('completed export persistence', () => {
         completedObjectMatches: vi.fn().mockResolvedValue(false),
       })
     ).rejects.toThrow('database unavailable');
+  });
+});
+
+describe('fenced completion cleanup', () => {
+  it('asks the database to schedule terminal object cleanup', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+    const scheduleObjectDeletion = vi.fn().mockResolvedValue(true);
+
+    await expect(
+      handleFencedCompletion({
+        exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+        generation: 0,
+        scheduleObjectDeletion,
+      })
+    ).resolves.toBe(true);
+
+    expect(scheduleObjectDeletion).toHaveBeenCalledOnce();
+    expect(parsedLog(warn)).toMatchObject({
+      event: 'export_completion_fenced',
+      cleanupScheduled: true,
+    });
   });
 });
 

--- a/services/user-data-export/src/worker.test.ts
+++ b/services/user-data-export/src/worker.test.ts
@@ -1,14 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
-  attachNewMultipartUpload,
   consumeDeadLetterBatch,
   consumeExportBatch,
   deletePendingObjects,
-  dispatchContinuation,
   exportHeader,
-  hasProcessingTimeRemaining,
+  exportArtifact,
+  handleGenerationFailure,
   processScheduledExportWork,
   resolveSourceAdapter,
+  TerminalExportError,
   type ExportEnv,
 } from './worker';
 import type { ExportJob } from './databases';
@@ -128,6 +128,16 @@ describe('export header timestamps', () => {
   });
 });
 
+describe('export artifact metadata', () => {
+  it('stores a downloadable gzip object without transparent content encoding', () => {
+    expect(exportArtifact).toEqual({
+      contentType: 'application/gzip',
+      contentDisposition: 'attachment; filename="kilo-data-export.jsonl.gz"',
+    });
+    expect(exportArtifact).not.toHaveProperty('contentEncoding');
+  });
+});
+
 describe('source resume keys', () => {
   const enabled = {
     name: 'enabled',
@@ -145,100 +155,61 @@ describe('source resume keys', () => {
   });
 });
 
-describe('generation processing budget', () => {
-  it('continues until the ten-minute safety budget is exhausted', () => {
-    const startedAt = Date.UTC(2026, 7, 9, 20, 0, 0);
-
-    expect(hasProcessingTimeRemaining(startedAt, startedAt + 10 * 60 * 1000 - 1)).toBe(true);
-    expect(hasProcessingTimeRemaining(startedAt, startedAt + 10 * 60 * 1000)).toBe(false);
-  });
-});
-
-describe('first multipart upload attachment', () => {
-  it('aborts a newly created upload when account deletion removes the export row', async () => {
-    const abort = vi.fn();
-    const attach = vi.fn().mockResolvedValue('deleted');
+describe('generation failure handling', () => {
+  it('marks terminal deadlines failed without releasing them for retry', async () => {
+    const markFailed = vi.fn();
+    const releaseForRetry = vi.fn();
 
     await expect(
-      attachNewMultipartUpload({
-        upload: { uploadId: 'upload-id', abort },
+      handleGenerationFailure({
+        error: new TerminalExportError(
+          'export_deadline_exceeded',
+          'The export was too large to complete within the processing limit.',
+          'deadline exceeded'
+        ),
         exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
-        generation: 0,
+        generation: 2,
         leaseToken: 'lease-token',
-        attach,
+        phase: 'compression_finalize',
+        source: 'microdollar_usage_prompts',
+        markFailed,
+        releaseForRetry,
       })
-    ).resolves.toBe('deleted');
+    ).resolves.toBe('failed');
 
-    expect(abort).toHaveBeenCalledOnce();
-  });
-
-  it('aborts its private upload without creating cleanup work when only the lease was lost', async () => {
-    const abort = vi.fn();
-
-    await expect(
-      attachNewMultipartUpload({
-        upload: { uploadId: 'upload-id', abort },
-        exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
-        generation: 0,
-        leaseToken: 'lease-token',
-        attach: vi.fn().mockResolvedValue('lost_lease'),
-      })
-    ).resolves.toBe('lost_lease');
-
-    expect(abort).toHaveBeenCalledOnce();
-  });
-
-  it('aborts a newly created upload when persisting its ID fails', async () => {
-    const abort = vi.fn().mockResolvedValue(undefined);
-    const attach = vi.fn().mockRejectedValue(new Error('database unavailable'));
-
-    await expect(
-      attachNewMultipartUpload({
-        upload: { uploadId: 'upload-id', abort },
-        exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
-        generation: 0,
-        leaseToken: 'lease-token',
-        attach,
-      })
-    ).rejects.toThrow('database unavailable');
-
-    expect(abort).toHaveBeenCalledOnce();
-  });
-});
-
-describe('continuation dispatch', () => {
-  it('sends the next generation and marks its outbox row sent', async () => {
-    const send = vi.fn();
-    const markSent = vi.fn();
-
-    await dispatchContinuation({
-      queue: { send },
+    expect(markFailed).toHaveBeenCalledWith({
       exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
-      generation: 4,
-      markSent,
+      generation: 2,
+      leaseToken: 'lease-token',
+      failureCode: 'export_deadline_exceeded',
+      redactedMessage: 'The export was too large to complete within the processing limit.',
     });
-
-    expect(send).toHaveBeenCalledWith({
-      version: 1,
-      operation: 'generate',
-      exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
-      generation: 4,
-    });
-    expect(markSent).toHaveBeenCalledWith('f6ba5ce5-9061-4f7f-9ec6-76f047573f1c', 4);
+    expect(releaseForRetry).not.toHaveBeenCalled();
   });
 
-  it('leaves the outbox unsent when immediate Queue publication fails', async () => {
-    const markSent = vi.fn();
+  it('keeps transient failures on the retry path', async () => {
+    const markFailed = vi.fn();
+    const releaseForRetry = vi.fn();
 
     await expect(
-      dispatchContinuation({
-        queue: { send: vi.fn().mockRejectedValue(new Error('Queue unavailable')) },
+      handleGenerationFailure({
+        error: new Error('temporary'),
         exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
-        generation: 4,
-        markSent,
+        generation: 2,
+        leaseToken: 'lease-token',
+        phase: 'source_read',
+        source: 'microdollar_usage_prompts',
+        markFailed,
+        releaseForRetry,
       })
-    ).resolves.toBeUndefined();
-    expect(markSent).not.toHaveBeenCalled();
+    ).resolves.toBe('retry');
+
+    expect(markFailed).not.toHaveBeenCalled();
+    expect(releaseForRetry).toHaveBeenCalledWith(
+      'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+      2,
+      'lease-token'
+    );
   });
 });
 

--- a/services/user-data-export/src/worker.test.ts
+++ b/services/user-data-export/src/worker.test.ts
@@ -6,6 +6,7 @@ import {
   deletePendingObjects,
   dispatchContinuation,
   exportHeader,
+  hasProcessingTimeRemaining,
   processScheduledExportWork,
   resolveSourceAdapter,
   type ExportEnv,
@@ -141,6 +142,15 @@ describe('source resume keys', () => {
 
   it('does not fall back when a persisted source key is unknown', () => {
     expect(resolveSourceAdapter([enabled], 'renamed-source')).toBeUndefined();
+  });
+});
+
+describe('generation processing budget', () => {
+  it('continues until the ten-minute safety budget is exhausted', () => {
+    const startedAt = Date.UTC(2026, 7, 9, 20, 0, 0);
+
+    expect(hasProcessingTimeRemaining(startedAt, startedAt + 10 * 60 * 1000 - 1)).toBe(true);
+    expect(hasProcessingTimeRemaining(startedAt, startedAt + 10 * 60 * 1000)).toBe(false);
   });
 });
 

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -105,6 +105,12 @@ function exportIdFromObjectKey(value: string): string | undefined {
   )?.[1];
 }
 
+function isMissingMultipartUpload(error: unknown): boolean {
+  if (typeof error !== 'object' || error === null) return false;
+  const value = error as { code?: unknown; name?: unknown };
+  return value.code === 10024 || value.name === 'NoSuchUpload';
+}
+
 export const exportArtifact = {
   contentDisposition: 'attachment; filename="kilo-data-export.jsonl.gz"',
   contentType: 'application/gzip',
@@ -157,6 +163,17 @@ export async function attachNewMultipartUpload(input: {
   }
 }
 
+export async function recoverInterruptedMultipartUpload(input: {
+  upload: Pick<R2MultipartUpload, 'abort'>;
+  clear: () => Promise<boolean>;
+}): Promise<boolean> {
+  try {
+    await input.upload.abort();
+  } catch (error) {
+    if (!isMissingMultipartUpload(error)) throw error;
+  }
+  return input.clear();
+}
 function jsonLine(record: ExportRecord): string {
   return `${JSON.stringify(record)}\n`;
 }
@@ -209,7 +226,6 @@ export async function processGenerateMessage(
 
   try {
     if (
-      job.multipart_upload_id ||
       job.dispatch_generation !== 0 ||
       job.current_source !== null ||
       job.source_cursor !== null
@@ -219,6 +235,31 @@ export async function processGenerateMessage(
         'This export was created by an older generator and must be requested again.',
         'Existing multipart export cannot be resumed by the one-shot generator'
       );
+    }
+
+    if (job.multipart_upload_id) {
+      const multipartUploadId = job.multipart_upload_id;
+      phase = 'orphan_cleanup';
+      const recovered = await recoverInterruptedMultipartUpload({
+        upload: env.EXPORT_BUCKET.resumeMultipartUpload(objectKey(job.id), multipartUploadId),
+        clear: () =>
+          state.clearClaimedMultipartUpload({
+            exportId: job.id,
+            generation: job.dispatch_generation,
+            leaseToken,
+            multipartUploadId,
+          }),
+      });
+      if (!recovered) {
+        logExportEvent('info', 'export_generation_skipped', {
+          exportId: job.id,
+          generation: job.dispatch_generation,
+          reason: 'lost_lease_during_orphan_cleanup',
+        });
+        return;
+      }
+      job.multipart_upload_id = null;
+      phase = 'claim';
     }
 
     const adapters = createSourceAdapters(createReplicaQuery(env.EXPORT_REPLICA_DB));
@@ -518,8 +559,7 @@ export async function deletePendingObjects(
         try {
           await bucket.resumeMultipartUpload(item.object_key, item.multipart_upload_id).abort();
         } catch (error) {
-          const value = error as { code?: number; name?: string };
-          if (value.code !== 10024 && value.name !== 'NoSuchUpload') throw error;
+          if (!isMissingMultipartUpload(error)) throw error;
         }
       }
       stage = 'r2_delete';

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -2,6 +2,7 @@ import { ExportQueueMessageSchema, type ExportQueueMessage } from './contracts';
 import {
   createReplicaQuery,
   createStateDb,
+  type ExportCompletionResult,
   type ExportJob,
   type HyperdriveBinding,
 } from './databases';
@@ -111,6 +112,14 @@ function isMissingMultipartUpload(error: unknown): boolean {
   return value.code === 10024 || value.name === 'NoSuchUpload';
 }
 
+async function abortMultipartUpload(upload: Pick<R2MultipartUpload, 'abort'>): Promise<void> {
+  try {
+    await upload.abort();
+  } catch (error) {
+    if (!isMissingMultipartUpload(error)) throw error;
+  }
+}
+
 export const exportArtifact = {
   contentDisposition: 'attachment; filename="kilo-data-export.jsonl.gz"',
   contentType: 'application/gzip',
@@ -167,12 +176,19 @@ export async function recoverInterruptedMultipartUpload(input: {
   upload: Pick<R2MultipartUpload, 'abort'>;
   clear: () => Promise<boolean>;
 }): Promise<boolean> {
-  try {
-    await input.upload.abort();
-  } catch (error) {
-    if (!isMissingMultipartUpload(error)) throw error;
-  }
+  await abortMultipartUpload(input.upload);
   return input.clear();
+}
+export async function persistCompletedExport(input: {
+  complete: () => Promise<ExportCompletionResult>;
+  completedObjectMatches: () => Promise<boolean>;
+}): Promise<ExportCompletionResult> {
+  try {
+    return await input.complete();
+  } catch (error) {
+    if (await input.completedObjectMatches()) return 'already_completed';
+    throw error;
+  }
 }
 function jsonLine(record: ExportRecord): string {
   return `${JSON.stringify(record)}\n`;
@@ -221,6 +237,7 @@ export async function processGenerateMessage(
   let upload: R2MultipartUpload | undefined;
   let deadline: ReturnType<typeof setTimeout> | undefined;
   let deadlineError: TerminalExportError | undefined;
+  let objectCompletionAttempted = false;
   let phase = 'claim';
   let activeSource = job.current_source;
 
@@ -356,22 +373,30 @@ export async function processGenerateMessage(
     const parts = await uploadParts;
     if (parts.length === 0) throw new Error('Compressed export produced no multipart data');
     if (deadlineError) throw deadlineError;
+    if (deadline) {
+      clearTimeout(deadline);
+      deadline = undefined;
+    }
     phase = 'object_finalize';
+    objectCompletionAttempted = true;
     const object = await upload.complete(
       parts.map(part => ({ partNumber: part.partNumber, etag: part.etag }))
     );
-    if (deadlineError) throw deadlineError;
     phase = 'state_update';
-    const completed = await state.complete({
-      exportId: job.id,
-      leaseToken,
-      rowCount: recordCount,
-      objectKey: key,
-      etag: object.etag,
-      sizeBytes: object.size,
+    const completion = await persistCompletedExport({
+      complete: () =>
+        state.complete({
+          exportId: job.id,
+          leaseToken,
+          rowCount: recordCount,
+          objectKey: key,
+          etag: object.etag,
+          sizeBytes: object.size,
+        }),
+      completedObjectMatches: () =>
+        state.completedObjectMatches({ exportId: job.id, objectKey: key, etag: object.etag }),
     });
-    if (!completed) {
-      await env.EXPORT_BUCKET.delete(key);
+    if (completion === 'fenced') {
       logExportEvent('warn', 'export_completion_fenced', {
         exportId: job.id,
         generation: job.dispatch_generation,
@@ -392,8 +417,19 @@ export async function processGenerateMessage(
     const failure = deadlineError ?? error;
     await writer?.abort(failure).catch(() => undefined);
     await uploadParts?.catch(() => undefined);
-    await upload?.abort().catch(() => undefined);
-    await env.EXPORT_BUCKET.delete(objectKey(job.id)).catch(() => undefined);
+    if (upload && !objectCompletionAttempted) {
+      try {
+        await abortMultipartUpload(upload);
+        await state.clearClaimedMultipartUpload({
+          exportId: job.id,
+          generation: job.dispatch_generation,
+          leaseToken,
+          multipartUploadId: upload.uploadId,
+        });
+      } catch {
+        // Preserve multipart_upload_id so reclaim or scheduled cleanup can retry the abort.
+      }
+    }
     const outcome = await handleGenerationFailure({
       error: failure,
       exportId: job.id,
@@ -508,7 +544,9 @@ export async function processScheduledExportWork(
     let stage = 'multipart_abort';
     try {
       const key = objectKey(item.id);
-      await env.EXPORT_BUCKET.resumeMultipartUpload(key, item.multipart_upload_id).abort();
+      await abortMultipartUpload(
+        env.EXPORT_BUCKET.resumeMultipartUpload(key, item.multipart_upload_id)
+      );
       stage = 'state_update';
       await state.clearMultipartUpload(item.id);
       logExportEvent('info', 'failed_export_multipart_deleted', { exportId: item.id });

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -1,21 +1,84 @@
-import { ExportQueueMessageSchema, type ExportQueueMessage, parseCursor } from './contracts';
+import { ExportQueueMessageSchema, type ExportQueueMessage } from './contracts';
 import {
   createReplicaQuery,
   createStateDb,
   type ExportJob,
   type HyperdriveBinding,
 } from './databases';
-import { uploadGzipStream } from './gzip';
 import { createSourceAdapters, type ExportRecord } from './source-adapters';
 import type { SourceAdapter } from './source-adapters';
+import { uploadGzipStream } from './gzip';
 import { classifyFetchFailure, logExportEvent, safeError } from './observability';
 
+const MAX_PROCESSING_MS = 13 * 60 * 1000;
+const SOURCE_PROCESSING_MS = 12 * 60 * 1000;
 const PART_BYTES = 5 * 1024 * 1024;
-const MAX_PROCESSING_MS = 10 * 60 * 1000;
 const PAGE_SIZE = 1_000;
 
-export function hasProcessingTimeRemaining(startedAt: number, now: number = Date.now()): boolean {
-  return now - startedAt < MAX_PROCESSING_MS;
+export class TerminalExportError extends Error {
+  constructor(
+    readonly failureCode: string,
+    readonly redactedMessage: string,
+    message: string
+  ) {
+    super(message);
+    this.name = 'TerminalExportError';
+  }
+}
+
+function exportDeadlineError(): TerminalExportError {
+  return new TerminalExportError(
+    'export_deadline_exceeded',
+    'The export was too large to complete within the processing limit.',
+    'Export exceeded the 13-minute processing deadline'
+  );
+}
+
+export async function handleGenerationFailure(input: {
+  error: unknown;
+  exportId: string;
+  generation: number;
+  leaseToken: string;
+  phase: string;
+  source: string | null;
+  markFailed: (input: {
+    exportId: string;
+    generation: number;
+    leaseToken: string;
+    failureCode: string;
+    redactedMessage: string;
+  }) => Promise<void>;
+  releaseForRetry: (exportId: string, generation: number, leaseToken: string) => Promise<void>;
+}): Promise<'failed' | 'retry'> {
+  if (input.error instanceof TerminalExportError) {
+    await input.markFailed({
+      exportId: input.exportId,
+      generation: input.generation,
+      leaseToken: input.leaseToken,
+      failureCode: input.error.failureCode,
+      redactedMessage: input.error.redactedMessage,
+    });
+    logExportEvent('error', 'export_generation_failed', {
+      exportId: input.exportId,
+      generation: input.generation,
+      phase: input.phase,
+      source: input.source,
+      terminal: true,
+      ...safeError(input.error),
+    });
+    return 'failed';
+  }
+
+  await input.releaseForRetry(input.exportId, input.generation, input.leaseToken);
+  logExportEvent('error', 'export_generation_failed', {
+    exportId: input.exportId,
+    generation: input.generation,
+    phase: input.phase,
+    source: input.source,
+    terminal: false,
+    ...safeError(input.error),
+  });
+  return 'retry';
 }
 
 export type ExportEnv = {
@@ -45,7 +108,6 @@ function exportIdFromObjectKey(value: string): string | undefined {
 export const exportArtifact = {
   contentDisposition: 'attachment; filename="kilo-data-export.jsonl.gz"',
   contentType: 'application/gzip',
-  partBytes: PART_BYTES,
 } as const;
 
 export function isAllowedWebCallbackUrl(value: string): boolean {
@@ -68,7 +130,6 @@ export function resolveSourceAdapter(
     ? adapters.find(adapter => adapter.readPage)
     : adapters.find(adapter => adapter.name === persistedSource);
 }
-
 export async function attachNewMultipartUpload(input: {
   upload: Pick<R2MultipartUpload, 'uploadId' | 'abort'>;
   exportId: string;
@@ -93,34 +154,6 @@ export async function attachNewMultipartUpload(input: {
   } catch (error) {
     await input.upload.abort().catch(() => undefined);
     throw error;
-  }
-}
-
-export async function dispatchContinuation(input: {
-  queue: Pick<Queue<ExportQueueMessage>, 'send'>;
-  exportId: string;
-  generation: number;
-  markSent: (exportId: string, generation: number) => Promise<void>;
-}): Promise<void> {
-  try {
-    await input.queue.send({
-      version: 1,
-      operation: 'generate',
-      exportId: input.exportId,
-      generation: input.generation,
-    });
-    await input.markSent(input.exportId, input.generation);
-    logExportEvent('info', 'export_continuation_dispatched', {
-      exportId: input.exportId,
-      generation: input.generation,
-    });
-  } catch (error) {
-    // The transactional outbox remains available for scheduled recovery.
-    logExportEvent('warn', 'export_continuation_deferred', {
-      exportId: input.exportId,
-      generation: input.generation,
-      ...safeError(error),
-    });
   }
 }
 
@@ -168,19 +201,24 @@ export async function processGenerateMessage(
   let uploadParts:
     | Promise<Array<{ partNumber: number; etag: string; sizeBytes: number }>>
     | undefined;
+  let upload: R2MultipartUpload | undefined;
+  let deadline: ReturnType<typeof setTimeout> | undefined;
+  let deadlineError: TerminalExportError | undefined;
   let phase = 'claim';
   let activeSource = job.current_source;
 
   try {
-    if (job.current_source === null && job.multipart_upload_id) {
-      phase = 'finalization';
-      logExportEvent('info', 'export_finalization_started', {
-        exportId: job.id,
-        generation: job.dispatch_generation,
-        nextPartNumber: job.next_part_number,
-      });
-      await finalizeExport(env, state, job, leaseToken);
-      return;
+    if (
+      job.multipart_upload_id ||
+      job.dispatch_generation !== 0 ||
+      job.current_source !== null ||
+      job.source_cursor !== null
+    ) {
+      throw new TerminalExportError(
+        'retired_multipart_export',
+        'This export was created by an older generator and must be requested again.',
+        'Existing multipart export cannot be resumed by the one-shot generator'
+      );
     }
 
     const adapters = createSourceAdapters(createReplicaQuery(env.EXPORT_REPLICA_DB));
@@ -192,70 +230,53 @@ export async function processGenerateMessage(
 
     const key = objectKey(job.id);
     phase = 'multipart';
-    let upload: R2MultipartUpload;
-    if (job.multipart_upload_id) {
-      upload = env.EXPORT_BUCKET.resumeMultipartUpload(key, job.multipart_upload_id);
-      logExportEvent('info', 'export_generation_attempt_started', {
-        exportId: job.id,
-        generation: job.dispatch_generation,
-        source: adapter.name,
-        uploadMode: 'resumed',
-        nextPartNumber: job.next_part_number,
-      });
-    } else {
-      upload = await env.EXPORT_BUCKET.createMultipartUpload(key, {
-        httpMetadata: {
-          contentType: exportArtifact.contentType,
-          contentDisposition: exportArtifact.contentDisposition,
-        },
-      });
-      const attachResult = await attachNewMultipartUpload({
-        upload,
-        exportId: job.id,
-        generation: job.dispatch_generation,
-        leaseToken,
-        attach: input => state.attachMultipartUpload(input),
-      });
-      if (attachResult !== 'attached') {
-        logExportEvent('info', 'export_generation_skipped', {
-          exportId: job.id,
-          generation: job.dispatch_generation,
-          reason: attachResult,
-        });
-        return;
-      }
-      logExportEvent('info', 'export_generation_attempt_started', {
-        exportId: job.id,
-        generation: job.dispatch_generation,
-        source: adapter.name,
-        uploadMode: 'created',
-        nextPartNumber: job.next_part_number,
-      });
-    }
+    upload = await env.EXPORT_BUCKET.createMultipartUpload(key, {
+      httpMetadata: {
+        contentType: exportArtifact.contentType,
+        contentDisposition: exportArtifact.contentDisposition,
+      },
+    });
+    const attachResult = await attachNewMultipartUpload({
+      upload,
+      exportId: job.id,
+      generation: job.dispatch_generation,
+      leaseToken,
+      attach: input => state.attachMultipartUpload(input),
+    });
+    if (attachResult !== 'attached') return;
+    logExportEvent('info', 'export_generation_attempt_started', {
+      exportId: job.id,
+      generation: job.dispatch_generation,
+      source: adapter.name,
+      uploadMode: 'single_invocation_multipart',
+    });
     const encoder = new TextEncoder();
     const compressor = new CompressionStream('gzip');
     const processingStartedAt = Date.now();
-    let isFinal = false;
+    const activeUpload = upload;
     uploadParts = uploadGzipStream({
       stream: compressor.readable,
       partBytes: PART_BYTES,
-      startPartNumber: job.next_part_number,
-      isFinal: () => isFinal,
-      uploadPart: (partNumber, value) => upload.uploadPart(partNumber, value),
+      uploadPart: (partNumber, value) => activeUpload.uploadPart(partNumber, value),
     });
     writer = compressor.writable.getWriter();
+    deadline = setTimeout(() => {
+      deadlineError = exportDeadlineError();
+      void writer?.abort(deadlineError).catch(() => undefined);
+    }, MAX_PROCESSING_MS);
     let uncompressedSize = 0;
     let pageCount = 0;
-    if (job.next_part_number === 1) {
-      const header = encoder.encode(exportHeader(job));
-      await writer.write(header);
-      uncompressedSize += header.byteLength;
-    }
-    let cursor = parseCursor(job.source_cursor);
+    const header = encoder.encode(exportHeader(job));
+    await writer.write(header);
+    uncompressedSize += header.byteLength;
+    let cursor = null;
     let recordCount = 0;
     let nextSource: string | null = adapter.name;
 
-    while (nextSource && hasProcessingTimeRemaining(processingStartedAt)) {
+    while (nextSource) {
+      if (Date.now() - processingStartedAt >= SOURCE_PROCESSING_MS) {
+        throw deadlineError ?? exportDeadlineError();
+      }
       const readPage = adapter.readPage;
       if (!readPage) throw new Error('Export job has an invalid current source');
       phase = 'source_read';
@@ -266,10 +287,11 @@ export async function processGenerateMessage(
         cursor,
         limit: PAGE_SIZE,
       });
-      const pagePayload = page.records.map(jsonLine).join('');
-      const pageBytes = encoder.encode(pagePayload);
-      await writer.write(pageBytes);
-      uncompressedSize += pageBytes.byteLength;
+      for (const record of page.records) {
+        const recordBytes = encoder.encode(jsonLine(record));
+        await writer.write(recordBytes);
+        uncompressedSize += recordBytes.byteLength;
+      }
       pageCount += 1;
       recordCount += page.records.length;
       if (page.nextCursor) {
@@ -288,104 +310,64 @@ export async function processGenerateMessage(
       cursor = null;
       nextSource = adapter.name;
     }
-    isFinal = nextSource === null;
     phase = 'compression_finalize';
     await writer.close();
     const parts = await uploadParts;
     if (parts.length === 0) throw new Error('Compressed export produced no multipart data');
-    phase = 'checkpoint';
-    const checkpointed = await state.checkpoint({
+    if (deadlineError) throw deadlineError;
+    phase = 'object_finalize';
+    const object = await upload.complete(
+      parts.map(part => ({ partNumber: part.partNumber, etag: part.etag }))
+    );
+    if (deadlineError) throw deadlineError;
+    phase = 'state_update';
+    const completed = await state.complete({
       exportId: job.id,
       leaseToken,
-      parts,
       rowCount: recordCount,
-      cursor,
-      nextSource,
-      nextGeneration: job.dispatch_generation + 1,
-      multipartUploadId: upload.uploadId,
+      objectKey: key,
+      etag: object.etag,
+      sizeBytes: object.size,
     });
-    if (!checkpointed) {
-      logExportEvent('warn', 'export_checkpoint_rejected', {
+    if (!completed) {
+      await env.EXPORT_BUCKET.delete(key);
+      logExportEvent('warn', 'export_completion_fenced', {
         exportId: job.id,
         generation: job.dispatch_generation,
+        reason: 'lost_lease_or_terminal_state',
       });
       return;
     }
 
-    logExportEvent('info', 'export_generation_checkpointed', {
+    logExportEvent('info', 'export_completed', {
       exportId: job.id,
       generation: job.dispatch_generation,
-      nextGeneration: job.dispatch_generation + 1,
-      source: adapter.name,
-      nextSource,
       pageCount,
       rowCount: recordCount,
-      partCount: parts.length,
       uncompressedBytes: uncompressedSize,
+      sizeBytes: object.size,
     });
-
-    await dispatchContinuation({
-      queue: env.EXPORT_QUEUE,
-      exportId: job.id,
-      generation: job.dispatch_generation + 1,
-      markSent: (exportId, generation) => state.markOutboxGenerationSent(exportId, generation),
-    });
-
-    // Finalization runs from the checkpointed continuation so a crash after the
-    // R2 upload cannot complete a multipart object whose part is not durable.
-    if (nextSource) return;
   } catch (error) {
-    await writer?.abort(error).catch(() => undefined);
+    const failure = deadlineError ?? error;
+    await writer?.abort(failure).catch(() => undefined);
     await uploadParts?.catch(() => undefined);
-    await state.releaseForRetry(job.id, job.dispatch_generation, leaseToken);
-    logExportEvent('error', 'export_generation_failed', {
+    await upload?.abort().catch(() => undefined);
+    await env.EXPORT_BUCKET.delete(objectKey(job.id)).catch(() => undefined);
+    const outcome = await handleGenerationFailure({
+      error: failure,
       exportId: job.id,
       generation: job.dispatch_generation,
+      leaseToken,
       phase,
       source: activeSource,
-      ...safeError(error),
+      markFailed: input => state.markLeasedExportFailed(input),
+      releaseForRetry: (exportId, generation, token) =>
+        state.releaseForRetry(exportId, generation, token),
     });
-    throw error;
+    if (outcome === 'retry') throw failure;
+  } finally {
+    if (deadline) clearTimeout(deadline);
   }
-}
-
-async function finalizeExport(
-  env: ExportEnv,
-  state: ReturnType<typeof createStateDb>,
-  job: ExportJob,
-  leaseToken: string
-): Promise<void> {
-  if (!job.multipart_upload_id)
-    throw new Error('Final export is missing its multipart upload checkpoint');
-  const key = objectKey(job.id);
-  let verified = await env.EXPORT_BUCKET.head(key);
-  if (!verified) {
-    const upload = env.EXPORT_BUCKET.resumeMultipartUpload(key, job.multipart_upload_id);
-    const parts = await state.parts(job.id);
-    await upload.complete(parts.map(item => ({ partNumber: item.part_number, etag: item.etag })));
-    verified = await env.EXPORT_BUCKET.head(key);
-  }
-  if (!verified) throw new Error('Completed export object was not found');
-  const completed = await state.complete({
-    exportId: job.id,
-    leaseToken,
-    objectKey: key,
-    etag: verified.etag,
-    sizeBytes: verified.size,
-  });
-  if (!completed) {
-    logExportEvent('warn', 'export_completion_fenced', {
-      exportId: job.id,
-      generation: job.dispatch_generation,
-      reason: 'lost_lease_or_terminal_state',
-    });
-    return;
-  }
-  logExportEvent('info', 'export_completed', {
-    exportId: job.id,
-    generation: job.dispatch_generation,
-    sizeBytes: verified.size,
-  });
 }
 
 export async function consumeExportBatch(

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -190,6 +190,22 @@ export async function persistCompletedExport(input: {
     throw error;
   }
 }
+
+export async function handleFencedCompletion(input: {
+  exportId: string;
+  generation: number;
+  scheduleObjectDeletion: () => Promise<boolean>;
+}): Promise<boolean> {
+  const cleanupScheduled = await input.scheduleObjectDeletion();
+  logExportEvent('warn', 'export_completion_fenced', {
+    exportId: input.exportId,
+    generation: input.generation,
+    reason: 'lost_lease_or_terminal_state',
+    cleanupScheduled,
+  });
+  return cleanupScheduled;
+}
+
 function jsonLine(record: ExportRecord): string {
   return `${JSON.stringify(record)}\n`;
 }
@@ -397,10 +413,11 @@ export async function processGenerateMessage(
         state.completedObjectMatches({ exportId: job.id, objectKey: key, etag: object.etag }),
     });
     if (completion === 'fenced') {
-      logExportEvent('warn', 'export_completion_fenced', {
+      await handleFencedCompletion({
         exportId: job.id,
         generation: job.dispatch_generation,
-        reason: 'lost_lease_or_terminal_state',
+        scheduleObjectDeletion: () =>
+          state.scheduleTerminalObjectDeletion({ exportId: job.id, objectKey: key }),
       });
       return;
     }

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -11,9 +11,12 @@ import type { SourceAdapter } from './source-adapters';
 import { classifyFetchFailure, logExportEvent, safeError } from './observability';
 
 const PART_BYTES = 5 * 1024 * 1024;
-const MAX_UNCOMPRESSED_BYTES_PER_INVOCATION = 32 * 1024 * 1024;
-const MAX_PAGES_PER_INVOCATION = 200;
-const PAGE_SIZE = 100;
+const MAX_PROCESSING_MS = 10 * 60 * 1000;
+const PAGE_SIZE = 1_000;
+
+export function hasProcessingTimeRemaining(startedAt: number, now: number = Date.now()): boolean {
+  return now - startedAt < MAX_PROCESSING_MS;
+}
 
 export type ExportEnv = {
   PRIMARY_STATE_DB: HyperdriveBinding;
@@ -231,6 +234,7 @@ export async function processGenerateMessage(
     }
     const encoder = new TextEncoder();
     const compressor = new CompressionStream('gzip');
+    const processingStartedAt = Date.now();
     let isFinal = false;
     uploadParts = uploadGzipStream({
       stream: compressor.readable,
@@ -251,11 +255,7 @@ export async function processGenerateMessage(
     let recordCount = 0;
     let nextSource: string | null = adapter.name;
 
-    while (
-      nextSource &&
-      pageCount < MAX_PAGES_PER_INVOCATION &&
-      uncompressedSize < MAX_UNCOMPRESSED_BYTES_PER_INVOCATION
-    ) {
+    while (nextSource && hasProcessingTimeRemaining(processingStartedAt)) {
       const readPage = adapter.readPage;
       if (!readPage) throw new Error('Export job has an invalid current source');
       phase = 'source_read';

--- a/services/user-data-export/test/worker.test.ts
+++ b/services/user-data-export/test/worker.test.ts
@@ -2,6 +2,8 @@ import { env, SELF } from 'cloudflare:test';
 import { describe, expect, it } from 'vitest';
 import { USER_DATA_EXPORT_AUDIENCE } from '@kilocode/worker-utils/internal-service-token-audiences';
 import { signKiloToken } from '@kilocode/worker-utils/kilo-token';
+import { gunzipSync } from 'node:zlib';
+import { uploadGzipStream } from '../src/gzip';
 
 describe('user-data-export worker', () => {
   const internalApiKey = String(env.INTERNAL_API_SECRET);
@@ -91,5 +93,40 @@ describe('user-data-export worker', () => {
     });
 
     expect(response.status).toBe(400);
+  });
+
+  it('stores a compact gzip object in R2', async () => {
+    const key = `test/${crypto.randomUUID()}.jsonl.gz`;
+    const payload = `${'{"source":"test","value":null}\n'.repeat(10_000)}`;
+    const compressor = new CompressionStream('gzip');
+    const upload = await env.EXPORT_BUCKET.createMultipartUpload(key, {
+      httpMetadata: {
+        contentType: 'application/gzip',
+        contentDisposition: 'attachment; filename="kilo-data-export.jsonl.gz"',
+      },
+    });
+    const parts = uploadGzipStream({
+      stream: compressor.readable,
+      partBytes: 5 * 1024 * 1024,
+      uploadPart: (partNumber, value) => upload.uploadPart(partNumber, value),
+    });
+    const writer = compressor.writable.getWriter();
+    await writer.write(new TextEncoder().encode(payload));
+    await writer.close();
+
+    const uploaded = await parts;
+    const stored = await upload.complete(
+      uploaded.map(part => ({ partNumber: part.partNumber, etag: part.etag }))
+    );
+    const object = await env.EXPORT_BUCKET.get(key);
+    if (!object) throw new Error('Test gzip object was not stored');
+
+    expect(stored?.size).toBeLessThan(payload.length);
+    expect(object?.httpMetadata).toMatchObject({
+      contentType: 'application/gzip',
+      contentDisposition: 'attachment; filename="kilo-data-export.jsonl.gz"',
+    });
+    expect(gunzipSync(await object.arrayBuffer()).toString()).toBe(payload);
+    await env.EXPORT_BUCKET.delete(key);
   });
 });


### PR DESCRIPTION
## Summary
- include source-native `id` and nullable `createdAt` on `microdollar_usage_metadata` records while leaving `system_prompt_prefix` records unchanged
- generate each export in one Queue invocation instead of checkpointing every 20,000 rows
- write JSONL records individually into `CompressionStream`
- flush compressed bytes through a reusable 5 MiB R2 multipart buffer, with one legal short final part
- remove zero-output gzip padding and cross-invocation multipart continuation state
- stop source processing terminally at 12 minutes, enforce a hard abort at 13 minutes, and use a 16-minute lease against the platform 15-minute maximum
- abort and clean multipart state before transient retries; generation-fence terminal failures so they are acknowledged instead of retried
- defer account-deletion object cleanup until an active export lease expires

## Context
A production export containing 25,445,152 bytes of JSONL produced a 36,700,584-byte gzip because seven artificial continuations each padded a small compressed member to 5 MiB. A normal gzip of the same data is approximately 188 KiB. The original `200 pages × 100 rows` cutoff, rather than a measured runtime limit, caused those continuations.

The new path keeps multipart upload only as an in-invocation periodic buffer required by R2. It does not persist partial progress or resume across Queue invocations. A transient failure retries the complete export; a deterministic deadline failure is marked terminal immediately.

## Verification
- `pnpm --filter user-data-export typecheck`
- `pnpm --filter user-data-export test` (40 tests)
- `pnpm --filter user-data-export test:workers` (5 tests, including real CompressionStream → multipart R2 → gunzip round trip)
- `pnpm --filter user-data-export lint`
- `pnpm --filter web test --runTestsByPath src/lib/user/index.test.ts --runInBand` (112 tests)
- `pnpm --filter web typecheck`
- `git diff --check`