### PR TITLE
fix(exports): actually allow requesting a new export while a ready one exists

### DIFF
--- a/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
+++ b/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
@@ -136,10 +136,9 @@ export function DataExportsClient() {
   const activeExportCopy = activeExport
     ? USER_EXPORT_STATUS_COPY[getDisplayStatus(activeExport)]
     : null;
-  // TEMPORARY: pre-launch testing only. The readyExport gate is dropped so a new
-  // export can be requested while a prior one is still downloadable; restore
-  // `|| Boolean(readyExport)` before going live (pairs with the temporary 5-minute
-  // server throttle in user-exports-router.ts).
+  // A ready/downloadable export must not block requesting a new one — only disable
+  // while a request is in flight, the list is refetching, or an export is actively
+  // generating. The re-request throttle is enforced server-side.
   const requestDisabled =
     requestMutation.isPending || listQuery.isRefetching || Boolean(activeExport);
 

--- a/apps/web/src/routers/user-exports-router.test.ts
+++ b/apps/web/src/routers/user-exports-router.test.ts
@@ -126,6 +126,29 @@ describe('user exports router guards and serialization', () => {
     );
   });
 
+  it('allows a fresh request when a ready export exists but is past the throttle window', async () => {
+    const pastThrottle = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    const [ready] = await db
+      .insert(user_data_exports)
+      .values({
+        kilo_user_id: owner.id,
+        snapshot_at: pastThrottle,
+        status: 'ready',
+        r2_object_key: `exports/${crypto.randomUUID()}/export.jsonl.gz`,
+        size_bytes: 1,
+        requested_at: pastThrottle,
+        completed_at: pastThrottle,
+        expires_at: new Date(Date.now() + 60_000).toISOString(),
+      })
+      .returning({ id: user_data_exports.id });
+
+    const requested = await (await createCallerForUser(owner.id)).userExports.request();
+
+    // A still-downloadable ready export must not short-circuit a new request.
+    expect(requested.id).not.toBe(ready.id);
+    expect(requested.status).toBe('queued');
+  });
+
   it('does not authorize another user or an expired export for download', async () => {
     const [ready] = await db
       .insert(user_data_exports)

--- a/apps/web/src/routers/user-exports-router.ts
+++ b/apps/web/src/routers/user-exports-router.ts
@@ -73,8 +73,10 @@ export const userExportsRouter = createTRPCRouter({
           last_error_redacted AS failure_message, dispatch_generation
         FROM user_data_exports
         WHERE kilo_user_id = ${ctx.user.id}
-          AND (status IN ('queued', 'processing', 'finalizing')
-            OR (status = 'ready' AND expires_at > now()))
+          -- Only short-circuit on an in-progress export (return it instead of starting a
+          -- duplicate generation). A completed/ready export must not block requesting a
+          -- fresh one; that is governed solely by the re-request throttle below.
+          AND status IN ('queued', 'processing', 'finalizing')
         ORDER BY created_at DESC, id DESC
         LIMIT 1
       `);


### PR DESCRIPTION
## Summary

**Bug fix / follow-up to #5169.** #5169 dropped the client-side "Request export" button gate, but left the **server** short-circuit in place. As Kilobot flagged, that means clicking the now-enabled button with a `ready` export present just returns the existing export (the `result.status === 'ready'` toast fires) and no new export is created — so repeat requests still didn't work.

Root cause: `userExports.request` short-circuited on `status = 'ready' AND expires_at > now()`, returning the existing row before the throttle was evaluated. Requesting another export is intended behavior; the only intended gate is the re-request throttle.

## Changes
- **Server** (`user-exports-router.ts`): `request()` now short-circuits only on an *in-progress* export (`queued`/`processing`/`finalizing`) — still returned instead of starting a duplicate generation. A `ready` export no longer blocks a new request.
- **Client** (`DataExportsClient.tsx`): reword the button-gate comment (the gate itself was already dropped in #5169) to describe intended behavior rather than a temporary testing hack.
- **Test**: a `ready` export past the throttle window now yields a new `queued` export.

## Framing correction
The button/short-circuit behavior is a **bug fix**, not a temporary change (correcting the "TEMP" framing from #5169). The only temporary, pre-launch change remains the `24h -> 5m` throttle from #5166 (still marked TEMPORARY in `user-exports-router.ts`); this PR does not touch it.

## Testing
`apps/web/src/routers/user-exports-router.test.ts`: 9 tests pass (1 new). Lint clean on changed files.
