### PR TITLE
fix(exports): correct user data cutoff

### DIFF
--- a/apps/web/src/routers/user-exports-router.test.ts
+++ b/apps/web/src/routers/user-exports-router.test.ts
@@ -86,7 +86,7 @@ describe('user exports router guards and serialization', () => {
     );
   });
 
-  it('uses the fixed August 3 UTC data cutoff for new exports', async () => {
+  it('uses the fixed August 2 08:40 UTC data cutoff for new exports', async () => {
     const caller = await createCallerForUser(owner.id);
 
     const requested = await caller.userExports.request();
@@ -95,7 +95,7 @@ describe('user exports router guards and serialization', () => {
       .from(user_data_exports)
       .where(eq(user_data_exports.id, requested.id));
 
-    expect(new Date(row.snapshotAt).toISOString()).toBe('2026-08-03T00:00:00.000Z');
+    expect(new Date(row.snapshotAt).toISOString()).toBe('2026-08-02T08:40:00.000Z');
   });
 
   it('allows an immediate fresh request after a failed export', async () => {

--- a/apps/web/src/routers/user-exports-router.ts
+++ b/apps/web/src/routers/user-exports-router.ts
@@ -13,7 +13,7 @@ import {
 const ExportIdSchema = z.object({ exportId: z.string().uuid() });
 const ListInputSchema = z.object({ cursor: z.string().uuid().optional() }).optional();
 const PAGE_SIZE = 20;
-const EXPORT_DATA_CUTOFF = '2026-08-03T00:00:00.000Z';
+const EXPORT_DATA_CUTOFF = '2026-08-02T08:40:00.000Z';
 
 type UserExportRow = {
   id: string;


### PR DESCRIPTION
## Summary
- cap new user data exports at August 2, 2026 08:40 UTC
- update the database-backed router regression test for the corrected snapshot boundary

## Testing
- `pnpm test -- --runInBand src/routers/user-exports-router.test.ts`
- `pnpm exec oxfmt --check src/routers/user-exports-router.ts src/routers/user-exports-router.test.ts`
- pre-push repository checks