### PR TITLE
chore(ai-gateway): remove legacy custom LLM credential fallbacks

### DIFF
--- a/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
+++ b/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
@@ -153,12 +153,7 @@ export function CustomLlmsContent() {
       return;
     }
 
-    if (
-      editor.mode === 'create' &&
-      !parsedCredentials &&
-      !defResult.data.api_key &&
-      !defResult.data.google_service_account
-    ) {
+    if (editor.mode === 'create' && !parsedCredentials) {
       setEditor(prev => ({
         ...prev,
         validationError: 'Credentials (JSON) are required when creating a custom LLM',

--- a/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts
@@ -1,5 +1,9 @@
 import { GoogleAuth } from 'google-auth-library';
-import { CustomLlmDefinitionSchema, type GoogleServiceAccountKey } from '@kilocode/db/schema-types';
+import {
+  CustomLlmCredentialsSchema,
+  CustomLlmDefinitionSchema,
+  type GoogleServiceAccountKey,
+} from '@kilocode/db/schema-types';
 import { getGoogleServiceAccountAccessToken } from './google-service-account';
 
 jest.mock('google-auth-library');
@@ -31,34 +35,19 @@ const baseDefinition = {
   organization_ids: ['org-1'],
 };
 
-describe('CustomLlmDefinitionSchema authentication', () => {
-  it('accepts legacy API key authentication', () => {
+describe('CustomLlmCredentialsSchema and CustomLlmDefinitionSchema', () => {
+  it('accepts API key credentials', () => {
     expect(
-      CustomLlmDefinitionSchema.safeParse({ ...baseDefinition, api_key: 'partner-token' }).success
+      CustomLlmCredentialsSchema.safeParse({ type: 'api_key', api_key: 'partner-token' }).success
     ).toBe(true);
   });
 
   it('accepts Google Cloud service account authentication', () => {
-    expect(
-      CustomLlmDefinitionSchema.safeParse({
-        ...baseDefinition,
-        google_service_account: serviceAccount('private-key'),
-      }).success
-    ).toBe(true);
+    expect(CustomLlmCredentialsSchema.safeParse(serviceAccount('private-key')).success).toBe(true);
   });
 
-  it('accepts definition without credentials in JSON definition', () => {
+  it('validates custom LLM definition without credentials', () => {
     expect(CustomLlmDefinitionSchema.safeParse(baseDefinition).success).toBe(true);
-  });
-
-  it('rejects definitions with multiple credential methods', () => {
-    expect(
-      CustomLlmDefinitionSchema.safeParse({
-        ...baseDefinition,
-        api_key: 'partner-token',
-        google_service_account: serviceAccount('private-key'),
-      }).success
-    ).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -110,37 +110,31 @@ async function checkCustomLlm(
     return null;
   }
 
-  let apiKey: string | undefined;
-  if (row?.encrypted_api_key) {
-    const decrypted = decryptApiKey(row.encrypted_api_key, BYOK_ENCRYPTION_KEY);
-    let parsedJson: unknown;
-    try {
-      parsedJson = JSON.parse(decrypted);
-    } catch {
-      return null;
-    }
-    const parsedCredentials = CustomLlmCredentialsSchema.safeParse(parsedJson);
-    if (!parsedCredentials.success) {
-      return null;
-    }
-    if (parsedCredentials.data.type === 'api_key') {
-      apiKey = parsedCredentials.data.api_key;
-    } else if (parsedCredentials.data.type === 'service_account') {
-      apiKey = await getGoogleServiceAccountAccessToken(parsedCredentials.data);
-    }
-  } else if (typeof customLlm.api_key === 'string') {
-    apiKey = customLlm.api_key;
-  } else if (customLlm.google_service_account) {
-    apiKey = await getGoogleServiceAccountAccessToken(customLlm.google_service_account);
+  if (!row?.encrypted_api_key) {
+    return null;
   }
 
-  if (!apiKey) {
+  const decrypted = decryptApiKey(row.encrypted_api_key, BYOK_ENCRYPTION_KEY);
+  let parsedJson: unknown;
+  try {
+    parsedJson = JSON.parse(decrypted);
+  } catch {
     return null;
+  }
+  const parsedCredentials = CustomLlmCredentialsSchema.safeParse(parsedJson);
+  if (!parsedCredentials.success) {
+    return null;
+  }
+
+  let apiKey: string;
+  if (parsedCredentials.data.type === 'api_key') {
+    apiKey = parsedCredentials.data.api_key;
+  } else {
+    apiKey = await getGoogleServiceAccountAccessToken(parsedCredentials.data);
   }
 
   const resolvedCustomLlm = {
     ...customLlm,
-    google_service_account: undefined,
     api_key: apiKey,
   };
   return {

--- a/apps/web/src/lib/zod/format-zod-error.test.ts
+++ b/apps/web/src/lib/zod/format-zod-error.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, test } from '@jest/globals';
 import { z } from 'zod';
 import { formatZodIssue, formatZodIssues, formatZodError } from './format-zod-error';
 import { deepStrict } from './deep-strict';
-import { CustomLlmDefinitionSchema } from '@kilocode/db/schema-types';
+import { CustomLlmCredentialsSchema, CustomLlmDefinitionSchema } from '@kilocode/db/schema-types';
 
 describe('formatZodIssue', () => {
   test('formats issue with path', () => {
@@ -43,43 +43,29 @@ describe('formatZodIssue', () => {
 });
 
 describe('formatZodIssues with unions', () => {
-  const schema = deepStrict(CustomLlmDefinitionSchema);
+  const schema = deepStrict(CustomLlmCredentialsSchema);
 
-  test('formats initial definition errors cleanly without ": Invalid input"', () => {
-    const initialDefinition = {
-      internal_id: '',
-      display_name: '',
-      context_length: 0,
-      max_completion_tokens: 0,
-      base_url: '',
+  test('formats initial credentials errors cleanly without ": Invalid input"', () => {
+    const invalidCredentials = {
+      type: 'api_key',
       api_key: '',
-      organization_ids: [],
     };
 
-    const result = schema.safeParse(initialDefinition);
+    const result = schema.safeParse(invalidCredentials);
     expect(result.success).toBe(false);
     if (!result.success) {
       const messages = formatZodIssues(result.error.issues);
       expect(messages).not.toContain(': Invalid input');
       expect(messages).not.toContain('Invalid input');
-      expect(messages).toEqual(
-        expect.arrayContaining([
-          expect.stringContaining('internal_id'),
-          expect.stringContaining('base_url'),
-        ])
-      );
+      expect(messages.some(m => m.includes('api_key'))).toBe(true);
     }
   });
 
-  test('picks the API key branch when api_key is present and fields have typos', () => {
+  test('picks the API key branch when type is api_key and fields have typos', () => {
     const typoInput = {
-      internal_id: 'model-1',
-      dispaly_name: 'Typo Name',
-      context_length: 1000,
-      max_completion_tokens: 100,
-      base_url: 'https://example.com',
+      type: 'api_key',
       api_key: 'secret',
-      organization_ids: [],
+      extra_key: 'unexpected',
     };
 
     const result = schema.safeParse(typoInput);
@@ -87,32 +73,22 @@ describe('formatZodIssues with unions', () => {
     if (!result.success) {
       const messages = formatZodIssues(result.error.issues);
       expect(messages).not.toContain(': Invalid input');
-      expect(messages).toContain('Unrecognized key: "dispaly_name"');
-      expect(messages.some(m => m.includes('display_name'))).toBe(true);
-      expect(messages.some(m => m.includes('google_service_account'))).toBe(false);
+      expect(messages).toContain('Unrecognized key: "extra_key"');
     }
   });
 
-  test('picks the Google service account branch when google_service_account is present', () => {
+  test('picks the Google service account branch when type is service_account', () => {
     const gsaInput = {
-      internal_id: 'model-1',
-      display_name: 'Vertex Gemini',
-      context_length: 1000,
-      max_completion_tokens: 100,
-      base_url: 'https://example.com',
-      organization_ids: [],
-      google_service_account: {
-        type: 'service_account',
-        project_id: 'proj',
-        private_key_id: 'key-id',
-        private_key: 'pk',
-        client_email: 'invalid-email',
-        client_id: '123',
-        auth_uri: 'https://accounts.google.com',
-        token_uri: 'https://oauth2.googleapis.com',
-        auth_provider_x509_cert_url: 'https://example.com',
-        client_x509_cert_url: 'https://example.com',
-      },
+      type: 'service_account',
+      project_id: 'proj',
+      private_key_id: 'key-id',
+      private_key: 'pk',
+      client_email: 'invalid-email',
+      client_id: '123',
+      auth_uri: 'https://accounts.google.com',
+      token_uri: 'https://oauth2.googleapis.com',
+      auth_provider_x509_cert_url: 'https://example.com',
+      client_x509_cert_url: 'https://example.com',
     };
 
     const result = schema.safeParse(gsaInput);
@@ -120,12 +96,13 @@ describe('formatZodIssues with unions', () => {
     if (!result.success) {
       const messages = formatZodIssues(result.error.issues);
       expect(messages).not.toContain(': Invalid input');
-      expect(messages.some(m => m.includes('google_service_account.client_email'))).toBe(true);
+      expect(messages.some(m => m.includes('client_email'))).toBe(true);
       expect(messages.some(m => m.includes('api_key'))).toBe(false);
     }
   });
 
-  test('formats common invalid fields when no credentials are provided', () => {
+  test('formats definition errors for CustomLlmDefinitionSchema', () => {
+    const defSchema = deepStrict(CustomLlmDefinitionSchema);
     const invalidInput = {
       internal_id: '',
       display_name: 'Model 1',
@@ -135,7 +112,7 @@ describe('formatZodIssues with unions', () => {
       organization_ids: [],
     };
 
-    const result = schema.safeParse(invalidInput);
+    const result = defSchema.safeParse(invalidInput);
     expect(result.success).toBe(false);
     if (!result.success) {
       const messages = formatZodIssues(result.error.issues);

--- a/apps/web/src/routers/admin/custom-llm-router.test.ts
+++ b/apps/web/src/routers/admin/custom-llm-router.test.ts
@@ -65,31 +65,9 @@ describe('adminCustomLlmRouter', () => {
       expect(decrypted.api_key).toBe('sk-test-secret-key-123');
     });
 
-    it('quietly migrates legacy api_key from definition JSON on save', async () => {
+    it('creates a new custom LLM with Google Service Account credentials', async () => {
       const caller = await createCallerForUser(admin.id);
-      const publicId = 'kilo-internal/test-model-legacy-key';
-
-      const result = await caller.admin.customLlm.upsert({
-        public_id: publicId,
-        definition: {
-          ...validDefinition,
-          api_key: 'sk-legacy-migrated-key',
-        } as CustomLlmDefinition,
-      });
-
-      expect(result.public_id).toBe(publicId);
-      expect((result.definition as Record<string, unknown>).api_key).toBeUndefined();
-
-      const [row] = await db.select().from(custom_llm2).where(eq(custom_llm2.public_id, publicId));
-      expect(row).toBeDefined();
-      expect((row.definition as Record<string, unknown>).api_key).toBeUndefined();
-      const decrypted = JSON.parse(decryptApiKey(row.encrypted_api_key!, BYOK_ENCRYPTION_KEY));
-      expect(decrypted.api_key).toBe('sk-legacy-migrated-key');
-    });
-
-    it('quietly migrates legacy google_service_account from definition JSON on save', async () => {
-      const caller = await createCallerForUser(admin.id);
-      const publicId = 'kilo-internal/test-model-legacy-gsa';
+      const publicId = 'kilo-internal/test-model-gsa';
 
       const gsa = {
         type: 'service_account' as const,
@@ -106,42 +84,19 @@ describe('adminCustomLlmRouter', () => {
 
       const result = await caller.admin.customLlm.upsert({
         public_id: publicId,
-        definition: {
-          ...validDefinition,
-          google_service_account: gsa,
-        } as unknown as CustomLlmDefinition,
+        definition: validDefinition,
+        credentials: gsa,
       });
 
       expect(result.public_id).toBe(publicId);
-      expect((result.definition as Record<string, unknown>).google_service_account).toBeUndefined();
 
       const [row] = await db.select().from(custom_llm2).where(eq(custom_llm2.public_id, publicId));
       expect(row).toBeDefined();
-      expect((row.definition as Record<string, unknown>).google_service_account).toBeUndefined();
+      expect(row.encrypted_api_key).toBeDefined();
       const decrypted = JSON.parse(decryptApiKey(row.encrypted_api_key!, BYOK_ENCRYPTION_KEY));
+      expect(decrypted.type).toBe('service_account');
       expect(decrypted.project_id).toBe('test-project');
       expect(decrypted.private_key).toBe('pk-secret');
-    });
-
-    it('discards legacy credentials from definition if credentials are provided separately', async () => {
-      const caller = await createCallerForUser(admin.id);
-      const publicId = 'kilo-internal/test-model-discard-legacy';
-
-      const result = await caller.admin.customLlm.upsert({
-        public_id: publicId,
-        definition: {
-          ...validDefinition,
-          api_key: 'sk-old-to-discard',
-        } as CustomLlmDefinition,
-        credentials: { type: 'api_key', api_key: 'sk-new-chosen-key' },
-      });
-
-      expect(result.public_id).toBe(publicId);
-      expect((result.definition as Record<string, unknown>).api_key).toBeUndefined();
-
-      const [row] = await db.select().from(custom_llm2).where(eq(custom_llm2.public_id, publicId));
-      const decrypted = JSON.parse(decryptApiKey(row.encrypted_api_key!, BYOK_ENCRYPTION_KEY));
-      expect(decrypted.api_key).toBe('sk-new-chosen-key');
     });
 
     it('rejects creating new custom LLM when credentials are completely missing', async () => {

--- a/apps/web/src/routers/admin/custom-llm-router.ts
+++ b/apps/web/src/routers/admin/custom-llm-router.ts
@@ -4,7 +4,6 @@ import { custom_llm2 } from '@kilocode/db/schema';
 import {
   CustomLlmCredentialsSchema,
   CustomLlmDefinitionSchema,
-  type CustomLlmCredentials,
   type EncryptedData,
 } from '@kilocode/db/schema-types';
 import { asc, eq } from 'drizzle-orm';
@@ -56,31 +55,6 @@ export const adminCustomLlmRouter = createTRPCRouter({
         });
       }
       encrypted_api_key = encryptApiKey(JSON.stringify(input.credentials), BYOK_ENCRYPTION_KEY);
-    } else if (typeof input.definition.api_key === 'string' && input.definition.api_key.trim()) {
-      // Quietly migrate legacy api_key from definition to encrypted storage
-      if (!BYOK_ENCRYPTION_KEY) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'BYOK_ENCRYPTION_KEY is not configured',
-        });
-      }
-      const migratedCredentials: CustomLlmCredentials = {
-        type: 'api_key',
-        api_key: input.definition.api_key.trim(),
-      };
-      encrypted_api_key = encryptApiKey(JSON.stringify(migratedCredentials), BYOK_ENCRYPTION_KEY);
-    } else if (input.definition.google_service_account) {
-      // Quietly migrate legacy google_service_account from definition to encrypted storage
-      if (!BYOK_ENCRYPTION_KEY) {
-        throw new TRPCError({
-          code: 'INTERNAL_SERVER_ERROR',
-          message: 'BYOK_ENCRYPTION_KEY is not configured',
-        });
-      }
-      encrypted_api_key = encryptApiKey(
-        JSON.stringify(input.definition.google_service_account),
-        BYOK_ENCRYPTION_KEY
-      );
     } else if (existing?.encrypted_api_key) {
       encrypted_api_key = existing.encrypted_api_key;
     } else {
@@ -90,13 +64,11 @@ export const adminCustomLlmRouter = createTRPCRouter({
       });
     }
 
-    const { api_key: _k, google_service_account: _g, ...cleanDefinition } = input.definition;
-
     if (existing) {
       const [updated] = await db
         .update(custom_llm2)
         .set({
-          definition: cleanDefinition,
+          definition: input.definition,
           encrypted_api_key,
         })
         .where(eq(custom_llm2.public_id, input.public_id))
@@ -112,7 +84,7 @@ export const adminCustomLlmRouter = createTRPCRouter({
       .insert(custom_llm2)
       .values({
         public_id: input.public_id,
-        definition: cleanDefinition,
+        definition: input.definition,
         encrypted_api_key,
       })
       .returning({

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1973,24 +1973,13 @@ export const CustomLlmCredentialsSchema = z.discriminatedUnion('type', [
 
 export type CustomLlmCredentials = z.infer<typeof CustomLlmCredentialsSchema>;
 
-const CustomLlmDefinitionBaseSchema = z.object({
+export const CustomLlmDefinitionSchema = z.object({
   ...CustomLlmMetadataSchema.shape,
   ...CustomLlmApiConfigSchema.shape,
   display_name: z.string(),
   organization_ids: z.array(z.string()),
   pricing: CustomLlmPricingSchema.optional(),
 });
-
-export const CustomLlmDefinitionSchema = z.union([
-  CustomLlmDefinitionBaseSchema.extend({
-    api_key: z.string().optional(),
-    google_service_account: z.never().optional(),
-  }),
-  CustomLlmDefinitionBaseSchema.extend({
-    api_key: z.never().optional(),
-    google_service_account: GoogleServiceAccountKeySchema,
-  }),
-]);
 
 export type CustomLlmDefinition = z.infer<typeof CustomLlmDefinitionSchema>;
 


### PR DESCRIPTION
## Summary
- Now that production credentials have been migrated to encrypted storage in `custom_llm2.encrypted_api_key`, remove the legacy unencrypted credential fallbacks.
- Simplified `CustomLlmDefinitionSchema` in `packages/db/src/schema-types.ts` to a single `z.object` representing definition metadata and API config, removing the union and legacy `api_key` / `google_service_account` fields.
- Removed definition credential fallback from `checkCustomLlm` in `get-provider.ts`.
- Removed quiet migration branches and legacy credential stripping in `custom-llm-router.ts` and admin UI.
- Updated test suites to reflect the streamlined schemas.