### PR TITLE
feat(api): add revalidate export to defaults route

### DIFF
--- a/apps/web/src/app/api/defaults/route.test.ts
+++ b/apps/web/src/app/api/defaults/route.test.ts
@@ -1,0 +1,18 @@
+import { GET, revalidate } from './route';
+import { KILO_AUTO_BALANCED_MODEL, KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway/auto-model';
+
+describe('GET /api/defaults', () => {
+  it('exports revalidate interval', () => {
+    expect(revalidate).toBe(3600);
+  });
+
+  it('returns default models', async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data).toEqual({
+      defaultModel: KILO_AUTO_BALANCED_MODEL.id,
+      defaultFreeModel: KILO_AUTO_FREE_MODEL.id,
+    });
+  });
+});

--- a/apps/web/src/app/api/defaults/route.ts
+++ b/apps/web/src/app/api/defaults/route.ts
@@ -1,6 +1,8 @@
 import { NextResponse } from 'next/server';
 import { KILO_AUTO_BALANCED_MODEL, KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway/auto-model';
 
+export const revalidate = 3600;
+
 type DefaultsResponse = {
   defaultModel: string;
   defaultFreeModel: string;


### PR DESCRIPTION
Adds `export const revalidate = 3600;` to `/api/defaults` route.