### PR TITLE
fix(ai-gateway): cache before environment details

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -38,7 +38,7 @@ function findEnvironmentDetailsCacheTargetIndex(
 
 function setCacheControlOnChatCompletionsMessage(
   message: OpenAI.ChatCompletionMessageParam,
-  isFinalMessage = false
+  isFinalUserMessage: boolean
 ) {
   if (typeof message.content === 'string') {
     message.content = [
@@ -50,10 +50,9 @@ function setCacheControlOnChatCompletionsMessage(
       },
     ];
   } else if (Array.isArray(message.content)) {
-    const cacheTargetIndex =
-      isFinalMessage && message.role === 'user'
-        ? findEnvironmentDetailsCacheTargetIndex(message.content)
-        : undefined;
+    const cacheTargetIndex = isFinalUserMessage
+      ? findEnvironmentDetailsCacheTargetIndex(message.content)
+      : undefined;
     const cacheTarget =
       cacheTargetIndex === undefined ? message.content.at(-1) : message.content[cacheTargetIndex];
     if (cacheTarget) {
@@ -79,7 +78,7 @@ function isResponsesInputMessage(
 
 function setPromptCacheBreakpointOnResponsesMessage(
   message: OpenAI.Responses.ResponseInputItem,
-  isFinalMessage = false
+  isFinalUserMessage: boolean
 ) {
   if (isResponsesInputMessage(message)) {
     if (typeof message.content === 'string') {
@@ -91,10 +90,9 @@ function setPromptCacheBreakpointOnResponsesMessage(
         },
       ];
     } else if (Array.isArray(message.content)) {
-      const cacheTargetIndex =
-        isFinalMessage && message.role === 'user'
-          ? findEnvironmentDetailsCacheTargetIndex(message.content)
-          : undefined;
+      const cacheTargetIndex = isFinalUserMessage
+        ? findEnvironmentDetailsCacheTargetIndex(message.content)
+        : undefined;
       const cacheTarget =
         cacheTargetIndex === undefined ? message.content.at(-1) : message.content[cacheTargetIndex];
       if (cacheTarget) {
@@ -122,7 +120,7 @@ function setPromptCacheBreakpointOnResponsesMessage(
 function setCacheControlOnMessagesMessage(
   message: Anthropic.MessageParam,
   cacheControl: Anthropic.CacheControlEphemeral,
-  isFinalMessage = false
+  isFinalUserMessage: boolean
 ) {
   if (typeof message.content === 'string') {
     message.content = [
@@ -133,10 +131,9 @@ function setCacheControlOnMessagesMessage(
       },
     ];
   } else {
-    const environmentDetailsCacheTargetIndex =
-      isFinalMessage && message.role === 'user'
-        ? findEnvironmentDetailsCacheTargetIndex(message.content)
-        : undefined;
+    const environmentDetailsCacheTargetIndex = isFinalUserMessage
+      ? findEnvironmentDetailsCacheTargetIndex(message.content)
+      : undefined;
     const environmentDetailsCacheTarget =
       environmentDetailsCacheTargetIndex === undefined
         ? undefined
@@ -196,7 +193,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       console.debug(
         '[addCacheBreakpoints] setting cache breakpoint on system chat completions message'
       );
-      setCacheControlOnChatCompletionsMessage(systemMessage);
+      setCacheControlOnChatCompletionsMessage(systemMessage, false);
     }
     const lastMessage = request.body.messages.findLast(
       msg => msg.role === 'user' || msg.role === 'tool'
@@ -207,7 +204,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       );
       setCacheControlOnChatCompletionsMessage(
         lastMessage,
-        lastMessage === request.body.messages.at(-1)
+        lastMessage.role === 'user' && lastMessage === request.body.messages.at(-1)
       );
     }
   } else if (
@@ -221,7 +218,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     );
     if (systemMessage) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on system responses message');
-      setPromptCacheBreakpointOnResponsesMessage(systemMessage);
+      setPromptCacheBreakpointOnResponsesMessage(systemMessage, false);
     }
     const lastMessage = request.body.input.findLast(
       msg => (msg.type === 'message' && msg.role === 'user') || msg.type === 'function_call_output'
@@ -232,7 +229,9 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       );
       setPromptCacheBreakpointOnResponsesMessage(
         lastMessage,
-        lastMessage === request.body.input.at(-1)
+        isResponsesInputMessage(lastMessage) &&
+          lastMessage.role === 'user' &&
+          lastMessage === request.body.input.at(-1)
       );
     }
   } else if (
@@ -249,7 +248,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       setCacheControlOnMessagesMessage(
         lastMessage,
         cacheControl,
-        lastMessage === request.body.messages.at(-1)
+        lastMessage.role === 'user' && lastMessage === request.body.messages.at(-1)
       );
     }
   }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -24,7 +24,22 @@ export function hasMiddleOutTransform(request: GatewayRequest) {
   );
 }
 
-function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionMessageParam) {
+function findEnvironmentDetailsCacheTargetIndex(
+  content: ReadonlyArray<{ type: string; text?: string }>
+) {
+  const environmentDetailsIndex = content.findIndex(
+    (item, index) =>
+      index > 0 &&
+      (item.type === 'text' || item.type === 'input_text') &&
+      item.text?.startsWith('<environment_details>')
+  );
+  return environmentDetailsIndex > 0 ? environmentDetailsIndex - 1 : undefined;
+}
+
+function setCacheControlOnChatCompletionsMessage(
+  message: OpenAI.ChatCompletionMessageParam,
+  isFinalMessage = false
+) {
   if (typeof message.content === 'string') {
     message.content = [
       {
@@ -35,10 +50,15 @@ function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionM
       },
     ];
   } else if (Array.isArray(message.content)) {
-    const lastItem = message.content.at(-1);
-    if (lastItem) {
+    const cacheTargetIndex =
+      isFinalMessage && message.role === 'user'
+        ? findEnvironmentDetailsCacheTargetIndex(message.content)
+        : undefined;
+    const cacheTarget =
+      cacheTargetIndex === undefined ? message.content.at(-1) : message.content[cacheTargetIndex];
+    if (cacheTarget) {
       // @ts-expect-error non-standard extension
-      lastItem.cache_control = { type: 'ephemeral' };
+      cacheTarget.cache_control = { type: 'ephemeral' };
     }
   }
 }
@@ -57,7 +77,10 @@ function isResponsesInputMessage(
   );
 }
 
-function setPromptCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.ResponseInputItem) {
+function setPromptCacheBreakpointOnResponsesMessage(
+  message: OpenAI.Responses.ResponseInputItem,
+  isFinalMessage = false
+) {
   if (isResponsesInputMessage(message)) {
     if (typeof message.content === 'string') {
       message.content = [
@@ -68,9 +91,14 @@ function setPromptCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.Re
         },
       ];
     } else if (Array.isArray(message.content)) {
-      const lastItem = message.content.at(-1);
-      if (lastItem) {
-        lastItem.prompt_cache_breakpoint = RESPONSES_PROMPT_CACHE_BREAKPOINT;
+      const cacheTargetIndex =
+        isFinalMessage && message.role === 'user'
+          ? findEnvironmentDetailsCacheTargetIndex(message.content)
+          : undefined;
+      const cacheTarget =
+        cacheTargetIndex === undefined ? message.content.at(-1) : message.content[cacheTargetIndex];
+      if (cacheTarget) {
+        cacheTarget.prompt_cache_breakpoint = RESPONSES_PROMPT_CACHE_BREAKPOINT;
       }
     }
   } else if (message.type === 'function_call_output') {
@@ -93,7 +121,8 @@ function setPromptCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.Re
 
 function setCacheControlOnMessagesMessage(
   message: Anthropic.MessageParam,
-  cacheControl: Anthropic.CacheControlEphemeral
+  cacheControl: Anthropic.CacheControlEphemeral,
+  isFinalMessage = false
 ) {
   if (typeof message.content === 'string') {
     message.content = [
@@ -104,9 +133,21 @@ function setCacheControlOnMessagesMessage(
       },
     ];
   } else {
-    const lastItem = message.content.findLast(isCacheableMessagesContentBlock);
-    if (lastItem) {
-      lastItem.cache_control = cacheControl;
+    const environmentDetailsCacheTargetIndex =
+      isFinalMessage && message.role === 'user'
+        ? findEnvironmentDetailsCacheTargetIndex(message.content)
+        : undefined;
+    const environmentDetailsCacheTarget =
+      environmentDetailsCacheTargetIndex === undefined
+        ? undefined
+        : message.content[environmentDetailsCacheTargetIndex];
+    const cacheTarget =
+      environmentDetailsCacheTarget &&
+      isCacheableMessagesContentBlock(environmentDetailsCacheTarget)
+        ? environmentDetailsCacheTarget
+        : message.content.findLast(isCacheableMessagesContentBlock);
+    if (cacheTarget) {
+      cacheTarget.cache_control = cacheControl;
     }
   }
 }
@@ -164,7 +205,10 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       console.debug(
         `[addCacheBreakpoints] setting cache breakpoint on last ${lastMessage.role} chat completions message`
       );
-      setCacheControlOnChatCompletionsMessage(lastMessage);
+      setCacheControlOnChatCompletionsMessage(
+        lastMessage,
+        lastMessage === request.body.messages.at(-1)
+      );
     }
   } else if (
     request.kind === 'responses' &&
@@ -186,7 +230,10 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       console.debug(
         `[addCacheBreakpoints] setting cache breakpoint on last ${lastMessage.type} responses message`
       );
-      setPromptCacheBreakpointOnResponsesMessage(lastMessage);
+      setPromptCacheBreakpointOnResponsesMessage(
+        lastMessage,
+        lastMessage === request.body.input.at(-1)
+      );
     }
   } else if (
     request.kind === 'messages' &&
@@ -199,7 +246,11 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       // Vercel AI Gateway does not honor top-level cache_control on Messages API requests.
       const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
       delete request.body.cache_control;
-      setCacheControlOnMessagesMessage(lastMessage, cacheControl);
+      setCacheControlOnMessagesMessage(
+        lastMessage,
+        cacheControl,
+        lastMessage === request.body.messages.at(-1)
+      );
     }
   }
 }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -36,10 +36,7 @@ function findEnvironmentDetailsCacheTargetIndex(
   return environmentDetailsIndex > 0 ? environmentDetailsIndex - 1 : undefined;
 }
 
-function setCacheControlOnChatCompletionsMessage(
-  message: OpenAI.ChatCompletionMessageParam,
-  isFinalUserMessage: boolean
-) {
+function setCacheControlOnChatCompletionsMessage(message: OpenAI.ChatCompletionMessageParam) {
   if (typeof message.content === 'string') {
     message.content = [
       {
@@ -50,9 +47,8 @@ function setCacheControlOnChatCompletionsMessage(
       },
     ];
   } else if (Array.isArray(message.content)) {
-    const cacheTargetIndex = isFinalUserMessage
-      ? findEnvironmentDetailsCacheTargetIndex(message.content)
-      : undefined;
+    const cacheTargetIndex =
+      message.role === 'user' ? findEnvironmentDetailsCacheTargetIndex(message.content) : undefined;
     const cacheTarget =
       cacheTargetIndex === undefined ? message.content.at(-1) : message.content[cacheTargetIndex];
     if (cacheTarget) {
@@ -76,10 +72,7 @@ function isResponsesInputMessage(
   );
 }
 
-function setPromptCacheBreakpointOnResponsesMessage(
-  message: OpenAI.Responses.ResponseInputItem,
-  isFinalUserMessage: boolean
-) {
+function setPromptCacheBreakpointOnResponsesMessage(message: OpenAI.Responses.ResponseInputItem) {
   if (isResponsesInputMessage(message)) {
     if (typeof message.content === 'string') {
       message.content = [
@@ -90,9 +83,10 @@ function setPromptCacheBreakpointOnResponsesMessage(
         },
       ];
     } else if (Array.isArray(message.content)) {
-      const cacheTargetIndex = isFinalUserMessage
-        ? findEnvironmentDetailsCacheTargetIndex(message.content)
-        : undefined;
+      const cacheTargetIndex =
+        message.role === 'user'
+          ? findEnvironmentDetailsCacheTargetIndex(message.content)
+          : undefined;
       const cacheTarget =
         cacheTargetIndex === undefined ? message.content.at(-1) : message.content[cacheTargetIndex];
       if (cacheTarget) {
@@ -119,8 +113,7 @@ function setPromptCacheBreakpointOnResponsesMessage(
 
 function setCacheControlOnMessagesMessage(
   message: Anthropic.MessageParam,
-  cacheControl: Anthropic.CacheControlEphemeral,
-  isFinalUserMessage: boolean
+  cacheControl: Anthropic.CacheControlEphemeral
 ) {
   if (typeof message.content === 'string') {
     message.content = [
@@ -131,9 +124,8 @@ function setCacheControlOnMessagesMessage(
       },
     ];
   } else {
-    const environmentDetailsCacheTargetIndex = isFinalUserMessage
-      ? findEnvironmentDetailsCacheTargetIndex(message.content)
-      : undefined;
+    const environmentDetailsCacheTargetIndex =
+      message.role === 'user' ? findEnvironmentDetailsCacheTargetIndex(message.content) : undefined;
     const environmentDetailsCacheTarget =
       environmentDetailsCacheTargetIndex === undefined
         ? undefined
@@ -193,7 +185,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       console.debug(
         '[addCacheBreakpoints] setting cache breakpoint on system chat completions message'
       );
-      setCacheControlOnChatCompletionsMessage(systemMessage, false);
+      setCacheControlOnChatCompletionsMessage(systemMessage);
     }
     const lastMessage = request.body.messages.findLast(
       msg => msg.role === 'user' || msg.role === 'tool'
@@ -202,10 +194,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       console.debug(
         `[addCacheBreakpoints] setting cache breakpoint on last ${lastMessage.role} chat completions message`
       );
-      setCacheControlOnChatCompletionsMessage(
-        lastMessage,
-        lastMessage.role === 'user' && lastMessage === request.body.messages.at(-1)
-      );
+      setCacheControlOnChatCompletionsMessage(lastMessage);
     }
   } else if (
     request.kind === 'responses' &&
@@ -218,7 +207,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     );
     if (systemMessage) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on system responses message');
-      setPromptCacheBreakpointOnResponsesMessage(systemMessage, false);
+      setPromptCacheBreakpointOnResponsesMessage(systemMessage);
     }
     const lastMessage = request.body.input.findLast(
       msg => (msg.type === 'message' && msg.role === 'user') || msg.type === 'function_call_output'
@@ -227,12 +216,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       console.debug(
         `[addCacheBreakpoints] setting cache breakpoint on last ${lastMessage.type} responses message`
       );
-      setPromptCacheBreakpointOnResponsesMessage(
-        lastMessage,
-        isResponsesInputMessage(lastMessage) &&
-          lastMessage.role === 'user' &&
-          lastMessage === request.body.input.at(-1)
-      );
+      setPromptCacheBreakpointOnResponsesMessage(lastMessage);
     }
   } else if (
     request.kind === 'messages' &&
@@ -245,11 +229,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       // Vercel AI Gateway does not honor top-level cache_control on Messages API requests.
       const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
       delete request.body.cache_control;
-      setCacheControlOnMessagesMessage(
-        lastMessage,
-        cacheControl,
-        lastMessage.role === 'user' && lastMessage === request.body.messages.at(-1)
-      );
+      setCacheControlOnMessagesMessage(lastMessage, cacheControl);
     }
   }
 }

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -70,6 +70,33 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
+  test('adds a cache breakpoint before environment details in the final chat completions user message', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'test-model',
+        messages: [
+          { role: 'user', content: 'First prompt' },
+          { role: 'assistant', content: 'First response' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Latest prompt' },
+              { type: 'text', text: '<environment_details>dynamic context' },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.messages.at(-1)?.content).toEqual([
+      { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
+      { type: 'text', text: '<environment_details>dynamic context' },
+    ]);
+  });
+
   test('does nothing for chat completions requests when any cache_control is already present', () => {
     const request: GatewayRequest = {
       kind: 'chat_completions',
@@ -207,6 +234,43 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
+  test('adds a cache breakpoint before environment details in the final responses user message', () => {
+    const request: GatewayRequest = {
+      kind: 'responses',
+      body: {
+        model: 'test-model',
+        input: [
+          { type: 'message', role: 'user', content: 'First prompt' },
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'Latest prompt' },
+              { type: 'input_text', text: '<environment_details>dynamic context' },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
+    const lastMessage = request.body.input.at(-1);
+    expect(lastMessage).toMatchObject({
+      type: 'message',
+      role: 'user',
+      content: [
+        {
+          type: 'input_text',
+          text: 'Latest prompt',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+        { type: 'input_text', text: '<environment_details>dynamic context' },
+      ],
+    });
+  });
+
   test('adds cache_control to the last content block of a messages request', () => {
     const request: GatewayRequest = {
       kind: 'messages',
@@ -260,6 +324,34 @@ describe('addCacheBreakpoints', () => {
         text: 'Latest detail',
         cache_control: { type: 'ephemeral', ttl: '1h' },
       },
+    ]);
+  });
+
+  test('adds cache_control before environment details in the final messages user message', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        messages: [
+          { role: 'user', content: 'First prompt' },
+          { role: 'assistant', content: 'First response' },
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Latest prompt' },
+              { type: 'text', text: '<environment_details>dynamic context' },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.messages.at(-1)?.content).toEqual([
+      { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
+      { type: 'text', text: '<environment_details>dynamic context' },
     ]);
   });
 

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -70,7 +70,7 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
-  test('adds a cache breakpoint before environment details in the final chat completions user message', () => {
+  test('adds a cache breakpoint before environment details in a chat completions user message', () => {
     const request: GatewayRequest = {
       kind: 'chat_completions',
       body: {
@@ -85,13 +85,14 @@ describe('addCacheBreakpoints', () => {
               { type: 'text', text: '<environment_details>dynamic context' },
             ],
           },
+          { role: 'assistant', content: 'Latest response' },
         ],
       },
     };
 
     addCacheBreakpoints(request);
 
-    expect(request.body.messages.at(-1)?.content).toEqual([
+    expect(request.body.messages.at(-2)?.content).toEqual([
       { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
       { type: 'text', text: '<environment_details>dynamic context' },
     ]);
@@ -234,7 +235,7 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
-  test('adds a cache breakpoint before environment details in the final responses user message', () => {
+  test('adds a cache breakpoint before environment details in a responses user message', () => {
     const request: GatewayRequest = {
       kind: 'responses',
       body: {
@@ -249,6 +250,12 @@ describe('addCacheBreakpoints', () => {
               { type: 'input_text', text: '<environment_details>dynamic context' },
             ],
           },
+          {
+            type: 'function_call',
+            call_id: 'call_123',
+            name: 'get_context',
+            arguments: '{}',
+          },
         ],
       },
     };
@@ -256,8 +263,8 @@ describe('addCacheBreakpoints', () => {
     addCacheBreakpoints(request);
 
     if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
-    const lastMessage = request.body.input.at(-1);
-    expect(lastMessage).toMatchObject({
+    const userMessage = request.body.input.at(-2);
+    expect(userMessage).toMatchObject({
       type: 'message',
       role: 'user',
       content: [
@@ -327,7 +334,7 @@ describe('addCacheBreakpoints', () => {
     ]);
   });
 
-  test('adds cache_control before environment details in the final messages user message', () => {
+  test('adds cache_control before environment details in a messages user message', () => {
     const request: GatewayRequest = {
       kind: 'messages',
       body: {
@@ -343,13 +350,14 @@ describe('addCacheBreakpoints', () => {
               { type: 'text', text: '<environment_details>dynamic context' },
             ],
           },
+          { role: 'assistant', content: '' },
         ],
       },
     };
 
     addCacheBreakpoints(request);
 
-    expect(request.body.messages.at(-1)?.content).toEqual([
+    expect(request.body.messages.at(-2)?.content).toEqual([
       { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
       { type: 'text', text: '<environment_details>dynamic context' },
     ]);


### PR DESCRIPTION
## Summary
- place generated cache breakpoints immediately before appended `<environment_details>` content in final user messages
- apply the behavior consistently across Chat Completions, Responses, and Messages request formats
- preserve existing end-of-message cache placement in all other cases

## Testing
- left to CI as requested