### PR TITLE
fix(local-dev): escape repoRoot in tmux new-session command

### DIFF
--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -80,7 +80,7 @@ function createSession(sessionName: string, env?: Record<string, string>): void 
     .join(' ');
   const envPrefix = `${envArgs} `;
   execSync(
-    `tmux new-session -d ${envPrefix}-s ${sessionName} -n dashboard -c ${repoRoot} ${buildInteractiveShellCommand(
+    `tmux new-session -d ${envPrefix}-s ${sessionName} -n dashboard -c ${escapeForShell(repoRoot)} ${buildInteractiveShellCommand(
       `cd ${escapeForShell(repoRoot)}`,
       undefined,
       repoRoot


### PR DESCRIPTION
## Summary

Supersedes #4824 now that the repository is private and the community fork branch can no longer be maintained directly.

Preserves Faisal Misbah’s original commit and authorship while resolving its conflict with the current tmux session setup. The current `repoRoot` passed to `tmux new-session -c` is now shell-escaped, so worktree paths containing spaces or shell-special characters remain a single argument.

## Verification

- `git diff --check`
- Formatting and TypeScript tests could not be run in this worktree shell because Node/pnpm are not available on `PATH`.

Original contribution: #4824