### PR TITLE
fix(ai-gateway): cache single-message requests

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -177,7 +177,6 @@ export function addCacheBreakpoints(request: GatewayRequest) {
   if (
     request.kind === 'chat_completions' &&
     Array.isArray(request.body.messages) &&
-    request.body.messages.length > 1 &&
     !containsCacheControl(request.body.messages)
   ) {
     const systemMessage = request.body.messages.find(msg => msg.role === 'system');
@@ -199,7 +198,6 @@ export function addCacheBreakpoints(request: GatewayRequest) {
   } else if (
     request.kind === 'responses' &&
     Array.isArray(request.body.input) &&
-    request.body.input.length > 1 &&
     !containsCacheControl(request.body.input)
   ) {
     const systemMessage = request.body.input.find(
@@ -218,11 +216,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       );
       setPromptCacheBreakpointOnResponsesMessage(lastMessage);
     }
-  } else if (
-    request.kind === 'messages' &&
-    request.body.messages.length > 1 &&
-    !containsCacheControl(request.body.messages)
-  ) {
+  } else if (request.kind === 'messages' && !containsCacheControl(request.body.messages)) {
     const lastMessage = request.body.messages.findLast(hasCacheableMessagesContent);
     if (lastMessage) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on last messages message');

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -98,6 +98,31 @@ describe('addCacheBreakpoints', () => {
     ]);
   });
 
+  test('adds a cache breakpoint before environment details in a single chat completions user message', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'test-model',
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Build snake in plain JS' },
+              { type: 'text', text: '<environment_details>dynamic context' },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.messages.at(0)?.content).toEqual([
+      { type: 'text', text: 'Build snake in plain JS', cache_control: { type: 'ephemeral' } },
+      { type: 'text', text: '<environment_details>dynamic context' },
+    ]);
+  });
+
   test('does nothing for chat completions requests when any cache_control is already present', () => {
     const request: GatewayRequest = {
       kind: 'chat_completions',
@@ -278,6 +303,41 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
+  test('adds a cache breakpoint before environment details in a single responses user message', () => {
+    const request: GatewayRequest = {
+      kind: 'responses',
+      body: {
+        model: 'test-model',
+        input: [
+          {
+            type: 'message',
+            role: 'user',
+            content: [
+              { type: 'input_text', text: 'Build snake in plain JS' },
+              { type: 'input_text', text: '<environment_details>dynamic context' },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
+    expect(request.body.input.at(0)).toMatchObject({
+      type: 'message',
+      role: 'user',
+      content: [
+        {
+          type: 'input_text',
+          text: 'Build snake in plain JS',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+        { type: 'input_text', text: '<environment_details>dynamic context' },
+      ],
+    });
+  });
+
   test('adds cache_control to the last content block of a messages request', () => {
     const request: GatewayRequest = {
       kind: 'messages',
@@ -359,6 +419,32 @@ describe('addCacheBreakpoints', () => {
 
     expect(request.body.messages.at(-2)?.content).toEqual([
       { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
+      { type: 'text', text: '<environment_details>dynamic context' },
+    ]);
+  });
+
+  test('adds cache_control before environment details in a single messages user message', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'text', text: 'Build snake in plain JS' },
+              { type: 'text', text: '<environment_details>dynamic context' },
+            ],
+          },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.messages.at(0)?.content).toEqual([
+      { type: 'text', text: 'Build snake in plain JS', cache_control: { type: 'ephemeral' } },
       { type: 'text', text: '<environment_details>dynamic context' },
     ]);
   });


### PR DESCRIPTION
## Summary
- remove the multi-message requirement from automatic cache breakpoint insertion
- allow single user messages with appended `<environment_details>` content to cache the stable prompt prefix
- cover Chat Completions, Responses, and Messages request formats

## Testing
- left to CI as requested