### PR TITLE
fix(mobile): do not specify Authorization for defaults unless organization id is present

### DIFF
--- a/apps/mobile/src/lib/hooks/use-available-models.test.ts
+++ b/apps/mobile/src/lib/hooks/use-available-models.test.ts
@@ -1,13 +1,21 @@
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { toModelOptions } from './use-available-models';
+import { toModelOptions, useOrgDefaultModel } from './use-available-models';
+
+const { getItemAsync } = vi.hoisted(() => ({
+  getItemAsync: vi.fn(),
+}));
+
+const { useQueryMock } = vi.hoisted(() => ({
+  useQueryMock: vi.fn(),
+}));
 
 // Stub native/expo modules so pure-node Vitest can resolve the
 // module graph when importing from use-available-models.ts.
-vi.mock('expo-secure-store', () => ({}));
-vi.mock('@tanstack/react-query', () => ({}));
+vi.mock('expo-secure-store', () => ({ getItemAsync }));
+vi.mock('@tanstack/react-query', () => ({ useQuery: useQueryMock }));
 vi.mock('@/lib/config', () => ({ API_BASE_URL: 'https://api.example.com' }));
-vi.mock('@/lib/storage-keys', () => ({ AUTH_TOKEN_KEY: 'mock-token' }));
+vi.mock('@/lib/storage-keys', () => ({ AUTH_TOKEN_KEY: 'auth-token-key' }));
 
 describe('toModelOptions', () => {
   it('passes pricing through to the ModelOption', () => {
@@ -32,5 +40,76 @@ describe('toModelOptions', () => {
 
   it('returns empty array for undefined data', () => {
     expect(toModelOptions(undefined)).toEqual([]);
+  });
+});
+
+describe('useOrgDefaultModel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('does not specify Authorization header when organization id is not present', async () => {
+    getItemAsync.mockResolvedValue('test-jwt-token');
+    const captured = { queryFn: vi.fn() };
+    useQueryMock.mockImplementation((options: { queryFn: () => Promise<unknown> }) => {
+      captured.queryFn = vi.fn(options.queryFn);
+      return { data: undefined, isLoading: false };
+    });
+
+    useOrgDefaultModel(undefined);
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        enabled: false,
+      })
+    );
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ defaultModel: 'kilo-auto/balanced' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    await expect(captured.queryFn()).rejects.toThrow('Missing organizationId');
+    expect(mockFetch).not.toHaveBeenCalled();
+
+    vi.unstubAllGlobals();
+  });
+
+  it('specifies Authorization header when organization id is present', async () => {
+    getItemAsync.mockResolvedValue('test-jwt-token');
+    const captured = { queryFn: vi.fn() };
+    useQueryMock.mockImplementation((options: { queryFn: () => Promise<unknown> }) => {
+      captured.queryFn = vi.fn(options.queryFn);
+      return { data: { defaultModel: 'org-default-model' }, isLoading: false };
+    });
+
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: vi.fn().mockResolvedValue({ defaultModel: 'org-default-model' }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const hookResult = useOrgDefaultModel('org-123');
+    expect(hookResult.defaultModel).toBe('org-default-model');
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['org-default-model', 'org-123'],
+        enabled: true,
+      })
+    );
+
+    const result = await captured.queryFn();
+    expect(result).toEqual({ defaultModel: 'org-default-model' });
+    expect(mockFetch).toHaveBeenCalledWith(
+      'https://api.example.com/api/organizations/org-123/defaults',
+      {
+        headers: {
+          Accept: 'application/json',
+          Authorization: 'Bearer test-jwt-token',
+        },
+      }
+    );
+
+    vi.unstubAllGlobals();
   });
 });

--- a/apps/mobile/src/lib/hooks/use-available-models.test.ts
+++ b/apps/mobile/src/lib/hooks/use-available-models.test.ts
@@ -53,15 +53,8 @@ describe('useOrgDefaultModel', () => {
     const captured = { queryFn: vi.fn() };
     useQueryMock.mockImplementation((options: { queryFn: () => Promise<unknown> }) => {
       captured.queryFn = vi.fn(options.queryFn);
-      return { data: undefined, isLoading: false };
+      return { data: { defaultModel: 'kilo-auto/balanced' }, isLoading: false };
     });
-
-    useOrgDefaultModel(undefined);
-    expect(useQueryMock).toHaveBeenCalledWith(
-      expect.objectContaining({
-        enabled: false,
-      })
-    );
 
     const mockFetch = vi.fn().mockResolvedValue({
       ok: true,
@@ -69,8 +62,22 @@ describe('useOrgDefaultModel', () => {
     });
     vi.stubGlobal('fetch', mockFetch);
 
-    await expect(captured.queryFn()).rejects.toThrow('Missing organizationId');
-    expect(mockFetch).not.toHaveBeenCalled();
+    const hookResult = useOrgDefaultModel(undefined);
+    expect(hookResult.defaultModel).toBe('kilo-auto/balanced');
+    expect(useQueryMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        queryKey: ['org-default-model', undefined],
+        enabled: true,
+      })
+    );
+
+    const result = await captured.queryFn();
+    expect(result).toEqual({ defaultModel: 'kilo-auto/balanced' });
+    expect(mockFetch).toHaveBeenCalledWith('https://api.example.com/api/defaults', {
+      headers: {
+        Accept: 'application/json',
+      },
+    });
 
     vi.unstubAllGlobals();
   });

--- a/apps/mobile/src/lib/hooks/use-available-models.ts
+++ b/apps/mobile/src/lib/hooks/use-available-models.ts
@@ -139,12 +139,17 @@ async function fetchModels(organizationId: string | undefined): Promise<ModelRes
   }
 }
 
-async function fetchOrgDefaults(organizationId: string): Promise<{ defaultModel: string }> {
+async function fetchOrgDefaults(
+  organizationId: string | undefined
+): Promise<{ defaultModel: string }> {
   const token = await SecureStore.getItemAsync(AUTH_TOKEN_KEY);
-  const response = await fetch(`${API_BASE_URL}/api/organizations/${organizationId}/defaults`, {
+  const url = organizationId
+    ? `${API_BASE_URL}/api/organizations/${organizationId}/defaults`
+    : `${API_BASE_URL}/api/defaults`;
+  const response = await fetch(url, {
     headers: {
       Accept: 'application/json',
-      ...(token ? { Authorization: `Bearer ${token}` } : {}),
+      ...(organizationId && token ? { Authorization: `Bearer ${token}` } : {}),
     },
   });
   if (!response.ok) {

--- a/apps/mobile/src/lib/hooks/use-available-models.ts
+++ b/apps/mobile/src/lib/hooks/use-available-models.ts
@@ -164,13 +164,10 @@ export function useOrgDefaultModel(organizationId: string | undefined) {
   const { data, isLoading } = useQuery({
     queryKey: ['org-default-model', organizationId] as const,
     queryFn: async () => {
-      if (!organizationId) {
-        throw new Error('Missing organizationId');
-      }
       const defaults = await fetchOrgDefaults(organizationId);
       return defaults;
     },
-    enabled: Boolean(organizationId),
+    enabled: true,
     staleTime: 60_000,
   });
   return { defaultModel: data?.defaultModel, isLoading };


### PR DESCRIPTION
Omit the `Authorization` header when requesting `/api/defaults` unless an organization ID is present.