### PR TITLE
fix(web): hide empty cloud agent reasoning expander

### DIFF
--- a/apps/web/src/components/cloud-agent-next/PartRenderer.tsx
+++ b/apps/web/src/components/cloud-agent-next/PartRenderer.tsx
@@ -29,6 +29,7 @@ import {
   isToolPart,
   isFilePart,
   isReasoningPart,
+  shouldRenderReasoningPart,
   isStepStartPart,
   isStepFinishPart,
   isSubtaskPart,
@@ -323,6 +324,10 @@ function ReasoningPartRenderer({
   const [isExpanded, setIsExpanded] = useState(false);
   const streaming = isStreaming ?? isPartStreaming(part);
 
+  if (!shouldRenderReasoningPart(part)) {
+    return null;
+  }
+
   return (
     <div className="border-muted bg-muted/30 rounded-md border">
       <button
@@ -474,6 +479,9 @@ export function PartRenderer({
 
   // Reasoning parts -> collapsible reasoning display
   if (isReasoningPart(part)) {
+    if (!shouldRenderReasoningPart(part)) {
+      return null;
+    }
     return (
       <MessageErrorBoundary fallback={<PartErrorFallback partType="reasoning" />}>
         <ReasoningPartRenderer part={part} isStreaming={isStreaming} />

--- a/apps/web/src/components/cloud-agent-next/types.test.ts
+++ b/apps/web/src/components/cloud-agent-next/types.test.ts
@@ -1,0 +1,56 @@
+import type { ReasoningPart, TextPart } from './types';
+import { isPartStreaming, shouldRenderReasoningPart } from './types';
+
+function makeReasoningPart(text: string, ended = true): ReasoningPart {
+  return {
+    id: 'r1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'reasoning',
+    text,
+    time: { start: 1, end: ended ? 2 : undefined },
+  };
+}
+
+function makeTextPart(text: string): TextPart {
+  return {
+    id: 't1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'text',
+    text,
+    time: { start: 1, end: 2 },
+  };
+}
+
+describe('shouldRenderReasoningPart', () => {
+  it('does not render a completed reasoning part with empty text', () => {
+    expect(shouldRenderReasoningPart(makeReasoningPart('', true))).toBe(false);
+  });
+
+  it('does not render a completed reasoning part with whitespace-only text', () => {
+    expect(shouldRenderReasoningPart(makeReasoningPart('   \n\t  ', true))).toBe(false);
+  });
+
+  it('renders a completed reasoning part with meaningful text', () => {
+    expect(shouldRenderReasoningPart(makeReasoningPart('thinking through the steps', true))).toBe(
+      true
+    );
+  });
+
+  it('does not render a reasoning part that is empty while streaming', () => {
+    const part = makeReasoningPart('', false);
+    expect(isPartStreaming(part)).toBe(true);
+    expect(shouldRenderReasoningPart(part)).toBe(false);
+  });
+
+  it('does not render a whitespace-only unfinished reasoning part', () => {
+    const part = makeReasoningPart('   \n\t  ', false);
+    expect(isPartStreaming(part)).toBe(true);
+    expect(shouldRenderReasoningPart(part)).toBe(false);
+  });
+
+  it('does not render a non-reasoning part', () => {
+    expect(shouldRenderReasoningPart(makeTextPart('hello'))).toBe(false);
+  });
+});

--- a/apps/web/src/components/cloud-agent-next/types.ts
+++ b/apps/web/src/components/cloud-agent-next/types.ts
@@ -169,6 +169,11 @@ export function isReasoningPart(part: Part): part is ReasoningPart {
   return part.type === 'reasoning';
 }
 
+/** Whether the reasoning expander has content worth showing. */
+export function shouldRenderReasoningPart(part: Part): boolean {
+  return isReasoningPart(part) && part.text.trim() !== '';
+}
+
 /** Check if a part is a StepStartPart */
 export function isStepStartPart(part: Part): part is StepStartPart {
   return part.type === 'step-start';


### PR DESCRIPTION
## Summary
- Hide the cloud agent collapsible Reasoning card when the part text is empty or whitespace-only.
- Matches mobile: models that emit blank reasoning parts no longer leave an empty expander in the transcript.

## Test plan
- [ ] Open a cloud agent session whose model emits empty reasoning parts and confirm the Reasoning expander does not appear.
- [ ] Open a session with real reasoning text and confirm the expander still shows and expands.
- [ ] Confirm a streaming empty reasoning part stays hidden until text arrives.