### PR TITLE
fix(ai-gateway): cache instruction prompts

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -141,6 +141,20 @@ function setCacheControlOnMessagesMessage(
   }
 }
 
+function setCacheControlOnMessagesSystem(
+  system: NonNullable<Anthropic.MessageCreateParams['system']>,
+  cacheControl: Anthropic.CacheControlEphemeral
+): NonNullable<Anthropic.MessageCreateParams['system']> {
+  if (typeof system === 'string') {
+    return [{ type: 'text', text: system, cache_control: cacheControl }];
+  }
+  const cacheTarget = system.at(-1);
+  if (cacheTarget) {
+    cacheTarget.cache_control = cacheControl;
+  }
+  return system;
+}
+
 function isCacheableMessagesContentBlock(
   item: Anthropic.ContentBlockParam
 ): item is Exclude<
@@ -200,12 +214,14 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     Array.isArray(request.body.input) &&
     !containsCacheControl(request.body.input)
   ) {
-    const systemMessage = request.body.input.find(
-      msg => msg.type === 'message' && msg.role === 'system'
+    const instructionsMessage = request.body.input.findLast(
+      msg => msg.type === 'message' && (msg.role === 'system' || msg.role === 'developer')
     );
-    if (systemMessage) {
-      console.debug('[addCacheBreakpoints] setting cache breakpoint on system responses message');
-      setPromptCacheBreakpointOnResponsesMessage(systemMessage);
+    if (instructionsMessage) {
+      console.debug(
+        '[addCacheBreakpoints] setting cache breakpoint on instructions responses message'
+      );
+      setPromptCacheBreakpointOnResponsesMessage(instructionsMessage);
     }
     const lastMessage = request.body.input.findLast(
       msg => (msg.type === 'message' && msg.role === 'user') || msg.type === 'function_call_output'
@@ -216,13 +232,21 @@ export function addCacheBreakpoints(request: GatewayRequest) {
       );
       setPromptCacheBreakpointOnResponsesMessage(lastMessage);
     }
-  } else if (request.kind === 'messages' && !containsCacheControl(request.body.messages)) {
+  } else if (
+    request.kind === 'messages' &&
+    !containsCacheControl(request.body.system) &&
+    !containsCacheControl(request.body.messages)
+  ) {
+    const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
+    delete request.body.cache_control;
+    if (request.body.system) {
+      console.debug('[addCacheBreakpoints] setting cache breakpoint on messages system prompt');
+      request.body.system = setCacheControlOnMessagesSystem(request.body.system, cacheControl);
+    }
     const lastMessage = request.body.messages.findLast(hasCacheableMessagesContent);
     if (lastMessage) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on last messages message');
       // Vercel AI Gateway does not honor top-level cache_control on Messages API requests.
-      const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
-      delete request.body.cache_control;
       setCacheControlOnMessagesMessage(lastMessage, cacheControl);
     }
   }

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -237,6 +237,7 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     !containsCacheControl(request.body.system) &&
     !containsCacheControl(request.body.messages)
   ) {
+    // Vercel AI Gateway does not honor top-level cache_control on Messages API requests.
     const cacheControl = request.body.cache_control ?? { type: 'ephemeral' };
     delete request.body.cache_control;
     if (request.body.system) {
@@ -246,7 +247,6 @@ export function addCacheBreakpoints(request: GatewayRequest) {
     const lastMessage = request.body.messages.findLast(hasCacheableMessagesContent);
     if (lastMessage) {
       console.debug('[addCacheBreakpoints] setting cache breakpoint on last messages message');
-      // Vercel AI Gateway does not honor top-level cache_control on Messages API requests.
       setCacheControlOnMessagesMessage(lastMessage, cacheControl);
     }
   }

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -219,6 +219,40 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
+  test('adds a cache breakpoint to the last responses instructions message', () => {
+    const request: GatewayRequest = {
+      kind: 'responses',
+      body: {
+        model: 'test-model',
+        input: [
+          { type: 'message', role: 'system', content: 'You are helpful.' },
+          { type: 'message', role: 'developer', content: 'Be concise.' },
+          { type: 'message', role: 'user', content: 'Latest prompt' },
+        ],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    if (request.kind !== 'responses' || !Array.isArray(request.body.input)) return;
+    expect(request.body.input.at(0)).toMatchObject({
+      type: 'message',
+      role: 'system',
+      content: 'You are helpful.',
+    });
+    expect(request.body.input.at(1)).toMatchObject({
+      type: 'message',
+      role: 'developer',
+      content: [
+        {
+          type: 'input_text',
+          text: 'Be concise.',
+          prompt_cache_breakpoint: { mode: 'explicit' },
+        },
+      ],
+    });
+  });
+
   test('does nothing for responses requests when any prompt_cache_breakpoint is already present', () => {
     const request: GatewayRequest = {
       kind: 'responses',
@@ -338,12 +372,13 @@ describe('addCacheBreakpoints', () => {
     });
   });
 
-  test('adds cache_control to the last content block of a messages request', () => {
+  test('adds cache_control to the system prompt and last content block of a messages request', () => {
     const request: GatewayRequest = {
       kind: 'messages',
       body: {
         model: 'anthropic/claude-sonnet-4-5',
         max_tokens: 1024,
+        system: 'You are helpful.',
         messages: [
           { role: 'user', content: 'First prompt' },
           { role: 'assistant', content: 'First response' },
@@ -355,8 +390,33 @@ describe('addCacheBreakpoints', () => {
     addCacheBreakpoints(request);
 
     expect(request.body.cache_control).toBeUndefined();
+    expect(request.body.system).toEqual([
+      { type: 'text', text: 'You are helpful.', cache_control: { type: 'ephemeral' } },
+    ]);
     expect(request.body.messages.at(-1)?.content).toEqual([
       { type: 'text', text: 'Latest prompt', cache_control: { type: 'ephemeral' } },
+    ]);
+  });
+
+  test('adds cache_control to the last block of a messages system prompt', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        system: [
+          { type: 'text', text: 'You are helpful.' },
+          { type: 'text', text: 'Be concise.' },
+        ],
+        messages: [{ role: 'user', content: 'Latest prompt' }],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.system).toEqual([
+      { type: 'text', text: 'You are helpful.' },
+      { type: 'text', text: 'Be concise.', cache_control: { type: 'ephemeral' } },
     ]);
   });
 
@@ -502,5 +562,27 @@ describe('addCacheBreakpoints', () => {
     addCacheBreakpoints(request);
 
     expect(request.body.cache_control).toBeUndefined();
+  });
+
+  test('does nothing for messages requests when the system prompt has cache_control', () => {
+    const request: GatewayRequest = {
+      kind: 'messages',
+      body: {
+        model: 'anthropic/claude-sonnet-4-5',
+        max_tokens: 1024,
+        system: [
+          {
+            type: 'text',
+            text: 'You are helpful.',
+            cache_control: { type: 'ephemeral' },
+          },
+        ],
+        messages: [{ role: 'user', content: 'Latest prompt' }],
+      },
+    };
+
+    addCacheBreakpoints(request);
+
+    expect(request.body.messages.at(-1)?.content).toBe('Latest prompt');
   });
 });


### PR DESCRIPTION
## Summary
- add Anthropic Messages cache breakpoints to top-level system prompts
- use the last Responses system or developer instruction as the stable-prefix breakpoint
- preserve existing nested-breakpoint detection across Anthropic system and message content

## Testing
- Not run locally per request; CI will validate the change.