### PR TITLE
fix(web): update data export download expiry copy to 24 hours

### DIFF
--- a/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
+++ b/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
@@ -150,7 +150,7 @@ export function DataExportsClient() {
           <CardDescription>
             The export includes your App Builder project titles and the prompt prefixes recorded
             with your usage history. Large accounts can take a while to generate. We&apos;ll email
-            you when it&apos;s ready, and downloads expire 7 days after that.
+            you when it&apos;s ready, and downloads expire 24 hours after that.
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col items-start gap-3">


### PR DESCRIPTION
## Summary
Updates the copy on the Data Exports page (`/data-exports`) to reflect that downloads expire **24 hours** after the export is ready, instead of 7 days.

## Changes
- `apps/web/src/app/(app)/data-exports/DataExportsClient.tsx`: "downloads expire 7 days after that" → "downloads expire 24 hours after that"

## Notes
Copy-only change; no logic affected.