### PR TITLE
fix(user-data-export): shorten download retention to 24 hours

### DIFF
--- a/services/user-data-export/src/databases.ts
+++ b/services/user-data-export/src/databases.ts
@@ -114,7 +114,7 @@ export function createStateDb(binding: HyperdriveBinding) {
           UPDATE user_data_exports
           SET status = 'ready', r2_object_key = ${input.objectKey}, r2_etag = ${input.etag}, size_bytes = ${input.sizeBytes},
             row_count = ${input.rowCount}, current_source = NULL, source_cursor = NULL,
-            completed_at = now(), expires_at = now() + interval '7 days', multipart_upload_id = NULL,
+            completed_at = now(), expires_at = now() + interval '24 hours', multipart_upload_id = NULL,
             lease_token = NULL, lease_expires_at = NULL, updated_at = now()
           WHERE id = ${input.exportId} AND status = 'processing' AND lease_token = ${input.leaseToken}
           RETURNING id


### PR DESCRIPTION
## Summary
The user data export feature set the completed export retention window to **7 days**, but the Data Exports UI copy states that downloads expire **24 hours** after the export is ready. This changes the retention interval so the behavior matches the stated copy.

## Change
- `services/user-data-export/src/databases.ts`: on export completion, `expires_at = now() + interval '7 days'` → `interval '24 hours'`.

## Why this makes auto-removal work as described
The cleanup cron already sweeps expired exports:
- `expiredObjects()` selects `status = 'ready' AND expires_at <= now()`
- `markExpired()` deletes the R2 object and marks the row `expired`

With the shorter interval, exports are now auto-removed ~24 hours after they become ready, matching the UI text.

## Related
- UI copy change (7 days → 24 hours) is in #5187. This PR makes the backend retention match that copy. Both should land for the page and behavior to be fully consistent.

## Testing
- `vitest run` — 56 passed
- `vitest run --config vitest.workers.config.ts` — 5 passed