### PR TITLE
feature(data export) plumbs a new db connection

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -177,6 +177,8 @@ Manage shared web env var additions and rotations with `pnpm web:env set <VARIAB
 - `USE_PRODUCTION_DB` - Forces use of the production DB URL in non-production contexts; used by `packages/db/src/database-url.ts`. [SERVER]
 - `DATABASE_CA` - CA certificate content (PEM) for TLS connections to Postgres; used by `packages/db/src/database-url.ts` in tests and scripts. [SERVER]
 - `DATABASE_URL` - Generic/alternate Postgres URL used by E2E tests and some services (`cloud-agent-next`, `kiloclaw`). `[SECRET]`
+- `DATA_EXPORT_POSTGRES_URL` - Connection string for the separate, read-only data export database, loaded out of band and read by `apps/web/src/lib/data-export/db.ts`. Optional: when unset, data export reads are disabled and the application still starts. `[SECRET]`
+- `DATA_EXPORT_DATABASE_CA` - Optional CA certificate content (PEM) for the data export database, for when it does not share the primary's CA. Falls back to `DATABASE_CA`; remote connections require TLS either way. [SERVER]
 
 ### Redis & Queue
 

--- a/apps/web/src/lib/data-export/db.test.ts
+++ b/apps/web/src/lib/data-export/db.test.ts
@@ -31,14 +31,31 @@ describe('resolveSslConfig', () => {
   const originalCa = process.env.DATABASE_CA;
   const originalExportCa = process.env.DATA_EXPORT_DATABASE_CA;
 
+  // Assigning undefined to process.env stores the truthy string 'undefined', which
+  // would leak into every other test file sharing this Jest worker and give their
+  // drizzle pools a bogus PEM CA. Delete the key instead.
+  function restore(key: string, value: string | undefined): void {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
+
   afterEach(() => {
-    process.env.DATABASE_CA = originalCa;
-    process.env.DATA_EXPORT_DATABASE_CA = originalExportCa;
+    restore('DATABASE_CA', originalCa);
+    restore('DATA_EXPORT_DATABASE_CA', originalExportCa);
   });
 
   it('disables TLS only for local hosts', () => {
     expect(resolveSslConfig('localhost')).toBe(false);
     expect(resolveSslConfig('127.0.0.1')).toBe(false);
+  });
+
+  it('treats a bracketed IPv6 loopback as local', () => {
+    // new URL('postgresql://u:p@[::1]:5432/db').hostname === '[::1]'
+    expect(resolveSslConfig(new URL('postgresql://u:p@[::1]:5432/db').hostname)).toBe(false);
+    expect(resolveSslConfig('::1')).toBe(false);
   });
 
   it('requires TLS for remote hosts even with no CA configured', () => {

--- a/apps/web/src/lib/data-export/db.test.ts
+++ b/apps/web/src/lib/data-export/db.test.ts
@@ -1,0 +1,90 @@
+import {
+  MAX_POOL_CONNECTIONS,
+  parseDataExportDatabaseUrl,
+  QUERY_TIMEOUT_MS,
+  resolveSslConfig,
+} from './db';
+
+describe('parseDataExportDatabaseUrl', () => {
+  it('accepts a postgres URL', () => {
+    expect(parseDataExportDatabaseUrl('postgresql://u:p@localhost:5432/data_export')).toEqual({
+      ok: true,
+      url: 'postgresql://u:p@localhost:5432/data_export',
+    });
+  });
+
+  it('reports an unset variable separately from a malformed one', () => {
+    expect(parseDataExportDatabaseUrl(undefined)).toEqual({ ok: false, reason: 'unset' });
+    expect(parseDataExportDatabaseUrl('')).toEqual({ ok: false, reason: 'unset' });
+  });
+
+  it.each([
+    ['missing port', 'postgresql://u:p@localhost/data_export'],
+    ['wrong scheme', 'https://u:p@localhost:5432/data_export'],
+    ['not a URL', 'localhost:5432'],
+  ])('rejects %s', (_label, value) => {
+    expect(parseDataExportDatabaseUrl(value)).toEqual({ ok: false, reason: 'invalid' });
+  });
+});
+
+describe('resolveSslConfig', () => {
+  const originalCa = process.env.DATABASE_CA;
+  const originalExportCa = process.env.DATA_EXPORT_DATABASE_CA;
+
+  afterEach(() => {
+    process.env.DATABASE_CA = originalCa;
+    process.env.DATA_EXPORT_DATABASE_CA = originalExportCa;
+  });
+
+  it('disables TLS only for local hosts', () => {
+    expect(resolveSslConfig('localhost')).toBe(false);
+    expect(resolveSslConfig('127.0.0.1')).toBe(false);
+  });
+
+  it('requires TLS for remote hosts even with no CA configured', () => {
+    delete process.env.DATABASE_CA;
+    delete process.env.DATA_EXPORT_DATABASE_CA;
+
+    // The failure mode that matters: a missing CA must not silently downgrade a
+    // remote connection to plaintext.
+    expect(resolveSslConfig('aws-0-eu-central-1.pooler.supabase.com')).toEqual({
+      rejectUnauthorized: true,
+    });
+  });
+
+  it('prefers an export specific CA over the primary CA', () => {
+    process.env.DATABASE_CA = 'primary-ca';
+    process.env.DATA_EXPORT_DATABASE_CA = 'export-ca';
+
+    expect(resolveSslConfig('db.example.supabase.co')).toEqual({
+      ca: 'export-ca',
+      rejectUnauthorized: true,
+      servername: 'db.example.supabase.co',
+    });
+  });
+
+  it('expands escaped newlines in a PEM CA', () => {
+    delete process.env.DATA_EXPORT_DATABASE_CA;
+    process.env.DATABASE_CA = '-----BEGIN CERTIFICATE-----\\nabc\\n-----END CERTIFICATE-----';
+
+    const ssl = resolveSslConfig('db.example.supabase.co');
+    expect(ssl).toMatchObject({
+      ca: '-----BEGIN CERTIFICATE-----\nabc\n-----END CERTIFICATE-----',
+    });
+  });
+});
+
+describe('pool sizing', () => {
+  it('does not inherit the primary request-path query timeout', () => {
+    // POSTGRES_MAX_QUERY_TIME is 5000 under .env.test and is sized for interactive
+    // queries; bulk export scans need their own budget.
+    expect(QUERY_TIMEOUT_MS).toBe(60_000);
+    expect(QUERY_TIMEOUT_MS).toBeGreaterThan(
+      Number.parseInt(process.env.POSTGRES_MAX_QUERY_TIME || '20000')
+    );
+  });
+
+  it('keeps the pool small so it does not contend with the primary', () => {
+    expect(MAX_POOL_CONNECTIONS).toBe(3);
+  });
+});

--- a/apps/web/src/lib/data-export/db.ts
+++ b/apps/web/src/lib/data-export/db.ts
@@ -1,0 +1,108 @@
+import { getEnvVariable } from '@/lib/dotenvx';
+import { getDatabaseClientConfig } from '@kilocode/db';
+import { pg } from '@kilocode/db/client';
+import { drizzle } from 'drizzle-orm/node-postgres';
+import { attachDatabasePool } from '@vercel/functions';
+
+/**
+ * Client for the data export database: a separate, read-only Postgres instance
+ * loaded out of band to back the user data export feature.
+ *
+ * Export manifests perform bulk scans of large tables. Today those reads go to
+ * the primary's replica (`readDb`, guarded by replica-routing.test.ts); pointing
+ * them here moves that load off the read-write database entirely.
+ *
+ * Three things make this deliberately different from `@/lib/drizzle`:
+ *
+ * 1. It is lazy. The primary pool is created at import time because the app
+ *    cannot serve a single request without it. This database is optional, so
+ *    nothing connects until an export query actually runs. `DATA_EXPORT_POSTGRES_URL`
+ *    has no tracked dotenv default, so external contributors run without it.
+ *
+ * 2. Pool errors log and continue. `drizzle.ts` calls `process.exit(-1)` on an
+ *    idle client error, which is right for the primary and wrong here: the local
+ *    development value may point at a database that has not been loaded yet, and
+ *    an unreachable export database must never take down the web server.
+ *
+ * 3. The schema is owned and loaded out of band by a separate process. No table
+ *    definitions live in `packages/db/src/schema.ts`, so drizzle-kit can never
+ *    generate a migration against a database this repository does not own.
+ */
+
+const DATA_EXPORT_POSTGRES_URL = getEnvVariable('DATA_EXPORT_POSTGRES_URL');
+
+/**
+ * Export reads are few and slow rather than many and fast, so this pool stays
+ * small. The primary already contends for Supabase's connection limit across
+ * ~2,200 concurrent Vercel instances; this must not add to it.
+ */
+const max = 3;
+
+const idleTimeoutMillis = 5_000;
+
+export type DataExportDb = ReturnType<typeof drizzle>;
+
+let cached: { db: DataExportDb; pool: pg.Pool } | null = null;
+
+/**
+ * Whether the export database is configured in this environment. Call before
+ * `getDataExportDb()` to skip the feature rather than surface an error.
+ */
+export function isDataExportDbConfigured(): boolean {
+  return !!DATA_EXPORT_POSTGRES_URL;
+}
+
+/**
+ * Returns the export database client, creating the pool on first use.
+ *
+ * Throws when the variable is unset. Callers that can degrade gracefully should
+ * gate on `isDataExportDbConfigured()` first.
+ */
+export function getDataExportDb(): DataExportDb {
+  return getDataExportClient().db;
+}
+
+function getDataExportClient(): { db: DataExportDb; pool: pg.Pool } {
+  if (cached) return cached;
+
+  if (!DATA_EXPORT_POSTGRES_URL) {
+    throw new Error(
+      'DATA_EXPORT_POSTGRES_URL not configured. Gate export reads on isDataExportDbConfigured().'
+    );
+  }
+
+  const pool = new pg.Pool({
+    ...getDatabaseClientConfig(DATA_EXPORT_POSTGRES_URL),
+    max,
+    idleTimeoutMillis,
+    connectionTimeoutMillis: Number.parseInt(process.env.POSTGRES_CONNECT_TIMEOUT || '30000'),
+    // Supavisor rejects statement_timeout in the startup packet, so query timeouts
+    // are enforced client side instead. See lib/replication-health.ts for the same
+    // constraint on the primary's replicas.
+    query_timeout: Number.parseInt(process.env.POSTGRES_MAX_QUERY_TIME || '20000'),
+    application_name: 'kilocode-web-data-export',
+  });
+
+  // Log and continue: an unreachable export database degrades one feature, unlike
+  // the primary, where a dead pool means the process cannot serve traffic.
+  pool.on('error', (err: Error) => {
+    console.error('Unexpected error on idle client (data export)', err);
+  });
+
+  // Close idle connections before the function suspends. Skipped in tests, where
+  // it interferes with Jest cleanup (same carve-out as lib/drizzle.ts).
+  if (process.env.NODE_ENV !== 'test') {
+    attachDatabasePool(pool);
+  }
+
+  cached = { db: drizzle(pool), pool };
+  return cached;
+}
+
+/** Closes the export database pool. For test teardown and script shutdown. */
+export async function closeDataExportDbConnection(): Promise<void> {
+  if (!cached) return;
+  const { pool } = cached;
+  cached = null;
+  await pool.end();
+}

--- a/apps/web/src/lib/data-export/db.ts
+++ b/apps/web/src/lib/data-export/db.ts
@@ -93,7 +93,9 @@ if (!parsedUrl.ok && parsedUrl.reason === 'invalid') {
   );
 }
 
-const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+// WHATWG URL keeps the brackets on an IPv6 literal, so `new URL(...).hostname`
+// yields '[::1]'. The bare form is kept for callers passing a hostname directly.
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '[::1]', '::1']);
 
 /**
  * The export database is a different host from the primary, so it does not

--- a/apps/web/src/lib/data-export/db.ts
+++ b/apps/web/src/lib/data-export/db.ts
@@ -3,14 +3,11 @@ import { getDatabaseClientConfig } from '@kilocode/db';
 import { pg } from '@kilocode/db/client';
 import { drizzle } from 'drizzle-orm/node-postgres';
 import { attachDatabasePool } from '@vercel/functions';
+import { z } from 'zod';
 
 /**
  * Client for the data export database: a separate, read-only Postgres instance
  * loaded out of band to back the user data export feature.
- *
- * Export manifests perform bulk scans of large tables. Today those reads go to
- * the primary's replica (`readDb`, guarded by replica-routing.test.ts); pointing
- * them here moves that load off the read-write database entirely.
  *
  * Three things make this deliberately different from `@/lib/drizzle`:
  *
@@ -29,34 +26,111 @@ import { attachDatabasePool } from '@vercel/functions';
  *    generate a migration against a database this repository does not own.
  */
 
-const DATA_EXPORT_POSTGRES_URL = getEnvVariable('DATA_EXPORT_POSTGRES_URL');
+/**
+ * Export reads are bulk, keyset-paginated scans rather than interactive queries,
+ * so this pool sets its own timeout instead of reusing `POSTGRES_MAX_QUERY_TIME`.
+ * That variable is sized for the primary's request-path workload (5s under
+ * `.env.test`) and is not applied to any pool in `drizzle.ts`.
+ *
+ * Enforced client side because Supavisor rejects `statement_timeout` in the
+ * startup packet — the same constraint documented in lib/replication-health.ts.
+ * Note that pg destroys the connection on timeout, so a value too low burns one
+ * of the few pooled connections on every slow query.
+ */
+export const QUERY_TIMEOUT_MS = 60_000;
 
 /**
  * Export reads are few and slow rather than many and fast, so this pool stays
  * small. The primary already contends for Supabase's connection limit across
  * ~2,200 concurrent Vercel instances; this must not add to it.
  */
-const max = 3;
+export const MAX_POOL_CONNECTIONS = 3;
 
-const idleTimeoutMillis = 5_000;
+const IDLE_TIMEOUT_MS = 5_000;
+
+const connectionUrlSchema = z
+  .string()
+  .min(1)
+  .refine(
+    value => {
+      try {
+        const url = new URL(value);
+        return (
+          (url.protocol === 'postgres:' || url.protocol === 'postgresql:') &&
+          !!url.hostname &&
+          Number.isInteger(Number(url.port)) &&
+          Number(url.port) > 0
+        );
+      } catch {
+        return false;
+      }
+    },
+    { message: 'must be a postgres:// URL with a host and port' }
+  );
+
+export type DataExportUrlResult =
+  | { ok: true; url: string }
+  | { ok: false; reason: 'unset' | 'invalid' };
+
+/**
+ * Validates the connection string shape up front, so a typo disables the feature
+ * loudly at startup rather than throwing from deep inside the first query.
+ */
+export function parseDataExportDatabaseUrl(raw: string | undefined): DataExportUrlResult {
+  if (!raw) return { ok: false, reason: 'unset' };
+  return connectionUrlSchema.safeParse(raw).success
+    ? { ok: true, url: raw }
+    : { ok: false, reason: 'invalid' };
+}
+
+const parsedUrl = parseDataExportDatabaseUrl(getEnvVariable('DATA_EXPORT_POSTGRES_URL'));
+
+if (!parsedUrl.ok && parsedUrl.reason === 'invalid') {
+  // Set but unusable is an operator error, not an opted-out environment. Say so
+  // once at startup instead of failing at the first export request.
+  console.error(
+    'DATA_EXPORT_POSTGRES_URL is set but is not a valid postgres:// URL. Data export reads are disabled.'
+  );
+}
+
+const LOCAL_HOSTNAMES = new Set(['localhost', '127.0.0.1', '::1']);
+
+/**
+ * The export database is a different host from the primary, so it does not
+ * inherit the primary's `ssl: false` fallback. Anything non-local gets TLS: these
+ * tables carry user-identifiable data, and a missing `DATABASE_CA` must surface
+ * as a connection error rather than a silent plaintext connection.
+ */
+export function resolveSslConfig(hostname: string): pg.ConnectionConfig['ssl'] {
+  if (LOCAL_HOSTNAMES.has(hostname)) return false;
+
+  const ca = process.env.DATA_EXPORT_DATABASE_CA || process.env.DATABASE_CA;
+  if (!ca) return { rejectUnauthorized: true };
+
+  return {
+    ca: ca.replace(/\\n/g, '\n'),
+    rejectUnauthorized: true,
+    servername: hostname,
+  };
+}
 
 export type DataExportDb = ReturnType<typeof drizzle>;
 
 let cached: { db: DataExportDb; pool: pg.Pool } | null = null;
 
 /**
- * Whether the export database is configured in this environment. Call before
- * `getDataExportDb()` to skip the feature rather than surface an error.
+ * Whether the export database is configured and usable in this environment. Call
+ * before `getDataExportDb()` to skip the feature rather than surface an error.
  */
 export function isDataExportDbConfigured(): boolean {
-  return !!DATA_EXPORT_POSTGRES_URL;
+  return parsedUrl.ok;
 }
 
 /**
  * Returns the export database client, creating the pool on first use.
  *
- * Throws when the variable is unset. Callers that can degrade gracefully should
- * gate on `isDataExportDbConfigured()` first.
+ * Throws when the variable is unset or malformed. Callers that can degrade
+ * gracefully should gate on `isDataExportDbConfigured()` first.
  */
 export function getDataExportDb(): DataExportDb {
   return getDataExportClient().db;
@@ -65,21 +139,23 @@ export function getDataExportDb(): DataExportDb {
 function getDataExportClient(): { db: DataExportDb; pool: pg.Pool } {
   if (cached) return cached;
 
-  if (!DATA_EXPORT_POSTGRES_URL) {
+  if (!parsedUrl.ok) {
     throw new Error(
-      'DATA_EXPORT_POSTGRES_URL not configured. Gate export reads on isDataExportDbConfigured().'
+      parsedUrl.reason === 'unset'
+        ? 'DATA_EXPORT_POSTGRES_URL not configured. Gate export reads on isDataExportDbConfigured().'
+        : 'DATA_EXPORT_POSTGRES_URL is set but is not a valid postgres:// URL.'
     );
   }
 
+  const baseConfig = getDatabaseClientConfig(parsedUrl.url);
+
   const pool = new pg.Pool({
-    ...getDatabaseClientConfig(DATA_EXPORT_POSTGRES_URL),
-    max,
-    idleTimeoutMillis,
+    ...baseConfig,
+    ssl: resolveSslConfig(new URL(parsedUrl.url).hostname),
+    max: MAX_POOL_CONNECTIONS,
+    idleTimeoutMillis: IDLE_TIMEOUT_MS,
     connectionTimeoutMillis: Number.parseInt(process.env.POSTGRES_CONNECT_TIMEOUT || '30000'),
-    // Supavisor rejects statement_timeout in the startup packet, so query timeouts
-    // are enforced client side instead. See lib/replication-health.ts for the same
-    // constraint on the primary's replicas.
-    query_timeout: Number.parseInt(process.env.POSTGRES_MAX_QUERY_TIME || '20000'),
+    query_timeout: QUERY_TIMEOUT_MS,
     application_name: 'kilocode-web-data-export',
   });
 


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->
Adds a Postgres client for a separate, database that is used as part of the data export feature. Export manifest reads currently run against the primary database; this is the connection plumbing needed to move them off it later.

Nothing imports the client yet, so this PR changes no behavior.

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
