### PR TITLE
feat(coding-plans): rename BytePlus plans to Enterprise and add ZDR copy

### DIFF
--- a/.specs/coding-plans.md
+++ b/.specs/coding-plans.md
@@ -48,11 +48,13 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 
 1.5. The MiniMax token catalog **MUST** contain Token Plan Plus, Token Plan Max, and Token Plan Ultra. All MiniMax token offerings **MUST** share the ordinary MiniMax BYOK provider ID, `minimax`.
 
-1.6. The catalog **MUST** contain BytePlus Coding Plan Lite with Plan ID `byteplus-coding-plan-team-lite`, provider ID `byteplus-coding`, a price of $20 in Kilo Credits, and a 30-day billing period. Its displayed limits **MUST** be described as approximately 1,900 requests every 5 hours, 12,000 requests per week, and 24,000 requests per subscription period. The plan's supported model IDs are `dola-seed-2.0-pro`, `dola-seed-2.0-lite`, `dola-seed-2.0-code`, `bytedance-seed-code`, `kimi-k2.5`, `glm-5.1`, `glm-5.2`, `deepseek-v4-flash`, `deepseek-v4-pro`, and `gpt-oss-120b`. Upstream Auto, Kimi-K2-Thinking, and GLM-4.7 **MUST NOT** be exposed.
+1.6. The catalog **MUST** contain BytePlus Enterprise Coding Plan Lite with Plan ID `byteplus-coding-plan-team-lite`, provider ID `byteplus-coding`, a price of $20 in Kilo Credits, and a 30-day billing period. Its displayed limits **MUST** be described as approximately 1,900 requests every 5 hours, 12,000 requests per week, and 24,000 requests per subscription period. The plan's supported model IDs are `dola-seed-2.0-pro`, `dola-seed-2.0-lite`, `dola-seed-2.0-code`, `bytedance-seed-code`, `kimi-k2.5`, `glm-5.1`, `glm-5.2`, `deepseek-v4-flash`, `deepseek-v4-pro`, and `gpt-oss-120b`. Upstream Auto, Kimi-K2-Thinking, and GLM-4.7 **MUST NOT** be exposed.
 
-1.7. The catalog **MUST** contain BytePlus Coding Plan Pro with Plan ID `byteplus-coding-plan-team-pro`, provider ID `byteplus-coding`, a price of $100 in Kilo Credits, and a 30-day billing period. Its displayed limits **MUST** be described as approximately 9,500 requests every 5 hours, 60,000 requests per week, and 120,000 requests per subscription period. Pro **MUST** support exactly the same model IDs as Lite and **MUST NOT** expose Upstream Auto, Kimi-K2-Thinking, or GLM-4.7.
+1.7. The catalog **MUST** contain BytePlus Enterprise Coding Plan Pro with Plan ID `byteplus-coding-plan-team-pro`, provider ID `byteplus-coding`, a price of $100 in Kilo Credits, and a 30-day billing period. Its displayed limits **MUST** be described as approximately 9,500 requests every 5 hours, 60,000 requests per week, and 120,000 requests per subscription period. Pro **MUST** support exactly the same model IDs as Lite and **MUST NOT** expose Upstream Auto, Kimi-K2-Thinking, or GLM-4.7.
 
 1.8. When no assignable Managed Plan Credential exists for an offering, customer-facing catalog responses **MUST** identify the offering as sold out without exposing credential counts or credential metadata.
+
+1.9. BytePlus Enterprise Coding Plan Lite and Pro catalog feature copy **MUST** include `Zero Data Retention: does not retain prompts or train on your data`.
 
 ## 2. Subscription and billing
 
@@ -165,6 +167,11 @@ The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "S
 8.3. The initial pilot does not require a Coding Plans audit-log history for admin inventory upload or manual revocation actions. Inventory lifecycle state, Upstream Plan ID, request/completion timestamps, attempt count, and sanitized failure information **MUST** record current disposition without retaining raw credentials after remediation starts.
 
 8.4. Current quota responses and logs **MUST NOT** contain Managed Plan Credentials, Provider Management Credentials, authorization headers, raw provider bodies or messages, inventory metadata, Upstream Plan IDs, Upstream Usage IDs, usernames, fingerprints, ciphertext, or provider-native quota fields. Provider responses **MUST** be bounded, validated, and normalized to an explicit non-secret subscription quota-window contract before leaving the Cloud boundary. The initial quota-window contract **MUST NOT** represent monetary balances or purchased-credit balances as subscription quota.
+
+### 2026-08-11 -- BytePlus Enterprise Coding Plan catalog copy
+
+- Renamed BytePlus catalog offerings to Enterprise Coding Plan Lite and Enterprise Coding Plan Pro.
+- Required both BytePlus offerings to display Zero Data Retention catalog copy.
 
 ### 2026-08-06 -- BytePlus Coding Plan usage integration
 

--- a/.specs/subscription-center.md
+++ b/.specs/subscription-center.md
@@ -32,6 +32,7 @@ Updated 2026-06-26 -- MiniMax token plan tiers and provider-level Coding Plan ex
 Updated 2026-08-05 -- BytePlus Coding Plan Pro catalog requirements.
 Updated 2026-08-05 -- closed fresh KiloClaw instance provisioning surfaces.
 Updated 2026-08-06 -- BytePlus Coding Plan quota integration.
+Updated 2026-08-11 -- BytePlus Enterprise Coding Plan catalog copy.
 
 ## Conventions
 
@@ -352,12 +353,14 @@ Commit names, prices, invoices, and credit deductions.
     offering with provider name, plan name, recurring USD price, billing
     period, payment source, and catalog feature copy. MiniMax token offerings
     MUST include Token Plan Plus, Token Plan Max, and Token Plan Ultra.
-    BytePlus offerings MUST include Coding Plan Lite at $20 per 30 days and
-    Coding Plan Pro at $100 per 30 days. Lite MUST display approximately 1,900
-    requests every 5 hours, 12,000 per week, and 24,000 per subscription
-    period. Pro MUST display approximately 9,500 requests every 5 hours,
-    60,000 per week, and 120,000 per subscription period. Both offerings MUST
-    use the model IDs and exclusions defined in `.specs/coding-plans.md`.
+    BytePlus offerings MUST include Enterprise Coding Plan Lite at $20 per 30
+    days and Enterprise Coding Plan Pro at $100 per 30 days. Lite MUST display
+    approximately 1,900 requests every 5 hours, 12,000 per week, and 24,000 per
+    subscription period. Pro MUST display approximately 9,500 requests every 5
+    hours, 60,000 per week, and 120,000 per subscription period. Both offerings
+    MUST display `Zero Data Retention: does not retain prompts or train on your
+    data` and MUST use the model IDs and exclusions defined in
+    `.specs/coding-plans.md`.
     An offering with assignable credential capacity MUST show a subscribe action.
     Purchase messaging MUST explain automatic BYOK setup for the selected
     provider, and purchase MUST be blocked when any personal BYOK key for that
@@ -515,6 +518,11 @@ not yet enforced in the current codebase:
    the current plan and seat count without management actions.
 
 ## Changelog
+
+### 2026-08-11 -- BytePlus Enterprise Coding Plan catalog copy
+
+- Renamed BytePlus catalog offerings to Enterprise Coding Plan Lite and Enterprise Coding Plan Pro.
+- Required both BytePlus offerings to display Zero Data Retention catalog copy.
 
 ### 2026-08-06 -- BytePlus Coding Plan quota integration
 

--- a/apps/web/src/components/subscriptions/AvailableProductCard.tsx
+++ b/apps/web/src/components/subscriptions/AvailableProductCard.tsx
@@ -58,14 +58,17 @@ export function AvailableProductCard({
   return (
     <Card className="border-border/60 relative flex h-full flex-col p-4 text-left shadow-sm">
       <div className="flex items-start justify-between gap-3">
-        <div className="flex min-w-0 items-center gap-2">
+        <div className="flex min-w-0 items-start gap-2">
           <div className="bg-muted flex size-8 shrink-0 items-center justify-center rounded-lg">
             {icon}
           </div>
-          <h3 className="truncate text-sm font-semibold">{title}</h3>
+          <h3 className="min-w-0 text-sm leading-5 font-semibold text-pretty">{title}</h3>
         </div>
         {status ? (
-          <Badge variant="secondary-outline" className="text-muted-foreground rounded-full px-3">
+          <Badge
+            variant="secondary-outline"
+            className="text-muted-foreground shrink-0 rounded-full px-3"
+          >
             {status}
           </Badge>
         ) : null}

--- a/apps/web/src/lib/coding-plans/billing-lifecycle-cron.test.ts
+++ b/apps/web/src/lib/coding-plans/billing-lifecycle-cron.test.ts
@@ -154,7 +154,12 @@ describe('Coding Plan billing lifecycle cron', () => {
     const renewal = await db
       .select({ description: credit_transactions.description })
       .from(credit_transactions)
-      .where(eq(credit_transactions.description, 'Coding plan renewal: BytePlus Coding Plan Lite'));
+      .where(
+        eq(
+          credit_transactions.description,
+          'Coding plan renewal: BytePlus Enterprise Coding Plan Lite'
+        )
+      );
 
     expect(summary.renewals).toBe(1);
     expect(subscription).toMatchObject({
@@ -164,7 +169,9 @@ describe('Coding Plan billing lifecycle cron', () => {
       billing_period_days: 30,
     });
     expect(credential.status).toBe('assigned');
-    expect(renewal).toEqual([{ description: 'Coding plan renewal: BytePlus Coding Plan Lite' }]);
+    expect(renewal).toEqual([
+      { description: 'Coding plan renewal: BytePlus Enterprise Coding Plan Lite' },
+    ]);
   });
 
   it('renews BytePlus Pro for 100 credits while retaining its assigned credential', async () => {
@@ -186,7 +193,12 @@ describe('Coding Plan billing lifecycle cron', () => {
     const renewal = await db
       .select({ description: credit_transactions.description })
       .from(credit_transactions)
-      .where(eq(credit_transactions.description, 'Coding plan renewal: BytePlus Coding Plan Pro'));
+      .where(
+        eq(
+          credit_transactions.description,
+          'Coding plan renewal: BytePlus Enterprise Coding Plan Pro'
+        )
+      );
 
     expect(summary.renewals).toBe(1);
     expect(subscription).toMatchObject({
@@ -196,7 +208,9 @@ describe('Coding Plan billing lifecycle cron', () => {
       billing_period_days: 30,
     });
     expect(credential.status).toBe('assigned');
-    expect(renewal).toEqual([{ description: 'Coding plan renewal: BytePlus Coding Plan Pro' }]);
+    expect(renewal).toEqual([
+      { description: 'Coding plan renewal: BytePlus Enterprise Coding Plan Pro' },
+    ]);
   });
 
   it('renews after the subscriber deletes the installed MiniMax BYOK key', async () => {

--- a/apps/web/src/lib/coding-plans/index.test.ts
+++ b/apps/web/src/lib/coding-plans/index.test.ts
@@ -118,24 +118,26 @@ describe('coding plans', () => {
     expect(CODING_PLAN_CATALOG[BYTEPLUS_PLAN_ID]).toEqual({
       planId: BYTEPLUS_PLAN_ID,
       providerName: 'BytePlus',
-      name: 'Coding Plan Lite',
+      name: 'Enterprise Coding Plan Lite',
       providerId: BYTEPLUS_PROVIDER_ID,
       coveredModelIds: BYTEPLUS_CODING_MODEL_IDS,
       costMicrodollars: COST_MICRODOLLARS,
       billingPeriodDays: 30,
       features: expect.arrayContaining([
         'Kilo automatically configures BytePlus in your BYOK settings.',
+        'Zero Data Retention: does not retain prompts or train on your data',
       ]),
     });
     expect(CODING_PLAN_CATALOG[BYTEPLUS_PRO_PLAN_ID]).toEqual({
       planId: BYTEPLUS_PRO_PLAN_ID,
       providerName: 'BytePlus',
-      name: 'Coding Plan Pro',
+      name: 'Enterprise Coding Plan Pro',
       providerId: BYTEPLUS_PROVIDER_ID,
       coveredModelIds: BYTEPLUS_CODING_MODEL_IDS,
       costMicrodollars: BYTEPLUS_PRO_COST_MICRODOLLARS,
       billingPeriodDays: 30,
       features: expect.arrayContaining([
+        'Zero Data Retention: does not retain prompts or train on your data',
         'For complex, high-intensity development use.',
         'Approximately 9,500 requests every 5 hours, 60,000 requests per week, and 120,000 requests per 30-day subscription period.',
       ]),

--- a/apps/web/src/lib/coding-plans/inventory-slack-summary.test.ts
+++ b/apps/web/src/lib/coding-plans/inventory-slack-summary.test.ts
@@ -113,8 +113,12 @@ describe('buildCodingPlanInventorySlackNotification', () => {
     expect(rendered).toContain('*MiniMax*');
     expect(rendered).toContain('Token Plan Plus · Available `2` · Assigned `0` · Loaded `2`');
     expect(rendered).toContain('*BytePlus*');
-    expect(rendered).toContain('Coding Plan Lite · Available `1` · Assigned `4` · Loaded `5`');
-    expect(rendered).toContain('Coding Plan Pro · Available `3` · Assigned `0` · Loaded `3`');
+    expect(rendered).toContain(
+      'Enterprise Coding Plan Lite · Available `1` · Assigned `4` · Loaded `5`'
+    );
+    expect(rendered).toContain(
+      'Enterprise Coding Plan Pro · Available `3` · Assigned `0` · Loaded `3`'
+    );
   });
 
   it('renders an explicit empty-inventory state', () => {

--- a/apps/web/src/lib/coding-plans/pricing.ts
+++ b/apps/web/src/lib/coding-plans/pricing.ts
@@ -75,13 +75,14 @@ export const CODING_PLAN_CATALOG = {
   'byteplus-coding-plan-team-lite': {
     planId: 'byteplus-coding-plan-team-lite',
     providerName: 'BytePlus',
-    name: 'Coding Plan Lite',
+    name: 'Enterprise Coding Plan Lite',
     providerId: BYTEPLUS_CODING_PROVIDER_ID,
     coveredModelIds: BYTEPLUS_CODING_MODEL_IDS,
     costMicrodollars: 20_000_000,
     billingPeriodDays: 30,
     features: [
       'Kilo automatically configures BytePlus in your BYOK settings.',
+      'Zero Data Retention: does not retain prompts or train on your data',
       'For moderate-intensity development use.',
       'Approximately 1,900 requests every 5 hours, 12,000 requests per week, and 24,000 requests per 30-day subscription period.',
       'Access to the approved BytePlus coding model set.',
@@ -91,13 +92,14 @@ export const CODING_PLAN_CATALOG = {
   'byteplus-coding-plan-team-pro': {
     planId: 'byteplus-coding-plan-team-pro',
     providerName: 'BytePlus',
-    name: 'Coding Plan Pro',
+    name: 'Enterprise Coding Plan Pro',
     providerId: BYTEPLUS_CODING_PROVIDER_ID,
     coveredModelIds: BYTEPLUS_CODING_MODEL_IDS,
     costMicrodollars: 100_000_000,
     billingPeriodDays: 30,
     features: [
       'Kilo automatically configures BytePlus in your BYOK settings.',
+      'Zero Data Retention: does not retain prompts or train on your data',
       'For complex, high-intensity development use.',
       'Approximately 9,500 requests every 5 hours, 60,000 requests per week, and 120,000 requests per 30-day subscription period.',
       'Access to the approved BytePlus coding model set.',

--- a/apps/web/src/routers/coding-plans-router.test.ts
+++ b/apps/web/src/routers/coding-plans-router.test.ts
@@ -167,12 +167,13 @@ describe('coding plans router', () => {
       {
         planId: BYTEPLUS_PLAN_ID,
         providerName: 'BytePlus',
-        name: 'Coding Plan Lite',
+        name: 'Enterprise Coding Plan Lite',
         providerId: 'byteplus-coding',
         costKiloCredits: 20,
         billingPeriodDays: 30,
         features: expect.arrayContaining([
           'Kilo automatically configures BytePlus in your BYOK settings.',
+          'Zero Data Retention: does not retain prompts or train on your data',
         ]),
         availabilityStatus: 'sold_out',
         notificationRequested: false,
@@ -180,11 +181,12 @@ describe('coding plans router', () => {
       {
         planId: BYTEPLUS_PRO_PLAN_ID,
         providerName: 'BytePlus',
-        name: 'Coding Plan Pro',
+        name: 'Enterprise Coding Plan Pro',
         providerId: 'byteplus-coding',
         costKiloCredits: 100,
         billingPeriodDays: 30,
         features: expect.arrayContaining([
+          'Zero Data Retention: does not retain prompts or train on your data',
           'For complex, high-intensity development use.',
           'Approximately 9,500 requests every 5 hours, 60,000 requests per week, and 120,000 requests per 30-day subscription period.',
         ]),


### PR DESCRIPTION
## Summary
Rename BytePlus Coding Plan offerings to Enterprise and surface Zero Data Retention on the plan cards.

### Why this change is needed
BytePlus plans need to read as Enterprise offerings, with an explicit statement that prompts are not retained and data is not used for training.

### How this is addressed
- Catalog names are now Enterprise Coding Plan Lite and Enterprise Coding Plan Pro.
- Both cards include `Zero Data Retention: does not retain prompts or train on your data`.
- Offer-card titles wrap so the longer names stay readable.

## Human Verification
- Specs updated to match the Enterprise names and ZDR copy.
- Targeted web tests passed: 59 tests across catalog, router, Slack summary, and billing renewal suites.
- Browser-checked the Coding Plans tab after fake login.

<img width="561" height="354" alt="Preview 2026-08-11 10 36 25" src="https://github.com/user-attachments/assets/4d0607ed-7979-4ecb-99c3-d8742447ba84" />

<details>
<summary>Manual testing</summary>

- Opened `/subscriptions#coding-plans` locally.
- Confirmed both BytePlus cards show the Enterprise names, the ZDR bullet, and wrapped titles instead of truncation.

</details>

## Reviewer Notes

### Human Reviewer Flags
- `.specs/coding-plans.md` and `.specs/subscription-center.md` now require the Enterprise names and ZDR bullet.
- Card titles still render as `BytePlus Enterprise Coding Plan Lite/Pro` because the UI prefixes the provider name.
- Title wrapping applies to all `AvailableProductCard` offerings, not only BytePlus.
