### PR TITLE
fix(coding-plans): dedupe pending key rotation queue rows

### DIFF
--- a/apps/web/src/lib/coding-plans/revocation.ts
+++ b/apps/web/src/lib/coding-plans/revocation.ts
@@ -1,6 +1,6 @@
 import 'server-only';
 
-import { and, desc, eq, inArray, ne, sql } from 'drizzle-orm';
+import { and, asc, desc, eq, inArray, isNotNull, max, ne, sql } from 'drizzle-orm';
 
 import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
@@ -65,6 +65,18 @@ export async function listManualCredentialRevocations(input: {
     updatedAt: string;
   }>
 > {
+  const latestSubscription = db
+    .select({
+      keyInventoryId: coding_plan_subscriptions.key_inventory_id,
+      subscriptionExpiresAt: max(coding_plan_subscriptions.current_period_end).as(
+        'subscription_expires_at'
+      ),
+    })
+    .from(coding_plan_subscriptions)
+    .where(isNotNull(coding_plan_subscriptions.key_inventory_id))
+    .groupBy(coding_plan_subscriptions.key_inventory_id)
+    .as('latest_subscription');
+
   const rows = await db
     .select({
       inventoryKeyId: coding_plan_key_inventory.id,
@@ -73,7 +85,7 @@ export async function listManualCredentialRevocations(input: {
       upstreamPlanId: coding_plan_key_inventory.upstream_plan_id,
       status: coding_plan_key_inventory.status,
       revocationRequestedAt: coding_plan_key_inventory.revocation_requested_at,
-      subscriptionExpiresAt: coding_plan_subscriptions.current_period_end,
+      subscriptionExpiresAt: latestSubscription.subscriptionExpiresAt,
       revokedAt: coding_plan_key_inventory.revoked_at,
       revocationAttemptCount: coding_plan_key_inventory.revocation_attempt_count,
       lastRevocationError: coding_plan_key_inventory.last_revocation_error,
@@ -81,8 +93,8 @@ export async function listManualCredentialRevocations(input: {
     })
     .from(coding_plan_key_inventory)
     .leftJoin(
-      coding_plan_subscriptions,
-      eq(coding_plan_subscriptions.key_inventory_id, coding_plan_key_inventory.id)
+      latestSubscription,
+      eq(latestSubscription.keyInventoryId, coding_plan_key_inventory.id)
     )
     .where(
       and(
@@ -92,7 +104,10 @@ export async function listManualCredentialRevocations(input: {
         input.planId ? eq(coding_plan_key_inventory.plan_id, input.planId) : undefined
       )
     )
-    .orderBy(desc(coding_plan_key_inventory.revocation_requested_at));
+    .orderBy(
+      desc(coding_plan_key_inventory.revocation_requested_at),
+      asc(coding_plan_key_inventory.id)
+    );
 
   return rows.map(row => ({
     ...row,

--- a/apps/web/src/routers/coding-plans-router.test.ts
+++ b/apps/web/src/routers/coding-plans-router.test.ts
@@ -859,4 +859,133 @@ describe('coding plans router', () => {
     expect(revoked.upstream_plan_id).toBe('minimax-deprovision-plan');
     expect(revoked.encrypted_api_key).toBeNull();
   });
+
+  it('returns one queue row per inventory credential when multiple canceled subscriptions reference it', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const firstUser = await insertTestUser();
+    const secondUser = await insertTestUser();
+    const [workItem] = await db
+      .insert(coding_plan_key_inventory)
+      .values({
+        plan_id: PLAN_ID,
+        provider_id: 'minimax',
+        upstream_plan_id: 'minimax-deprovision-plan',
+        encrypted_api_key: encryptApiKey('unreturned-secret', BYOK_ENCRYPTION_KEY),
+        credential_fingerprint: crypto.randomUUID(),
+        status: 'revocation_pending',
+        revocation_requested_at: new Date().toISOString(),
+      })
+      .returning();
+    await db.insert(coding_plan_subscriptions).values([
+      {
+        user_id: firstUser.id,
+        plan_id: PLAN_ID,
+        provider_id: 'minimax',
+        key_inventory_id: workItem.id,
+        status: 'canceled',
+        cost_microdollars: COST_MICRODOLLARS,
+        billing_period_days: 30,
+        current_period_start: '2026-06-10T13:55:16.000Z',
+        current_period_end: '2026-07-10T13:55:16.000Z',
+        credit_renewal_at: '2026-07-10T13:55:16.000Z',
+        canceled_at: '2026-07-10T13:55:16.000Z',
+        cancellation_reason: 'user_cancelled',
+      },
+      {
+        user_id: secondUser.id,
+        plan_id: PLAN_ID,
+        provider_id: 'minimax',
+        key_inventory_id: workItem.id,
+        status: 'canceled',
+        cost_microdollars: COST_MICRODOLLARS,
+        billing_period_days: 30,
+        current_period_start: '2026-07-11T02:47:07.000Z',
+        current_period_end: '2026-08-11T02:47:07.000Z',
+        credit_renewal_at: '2026-08-11T02:47:07.000Z',
+        canceled_at: '2026-08-11T02:47:07.000Z',
+        cancellation_reason: 'user_cancelled',
+      },
+    ]);
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(caller.codingPlans.adminRevocationQueue({})).resolves.toEqual([
+      expect.objectContaining({
+        inventoryKeyId: workItem.id,
+        subscriptionExpiresAt: '2026-08-11T02:47:07.000Z',
+      }),
+    ]);
+  });
+
+  it('returns pending inventory credentials that have no subscription reference', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const [workItem] = await db
+      .insert(coding_plan_key_inventory)
+      .values({
+        plan_id: PLAN_ID,
+        provider_id: 'minimax',
+        upstream_plan_id: 'minimax-orphan-plan',
+        encrypted_api_key: encryptApiKey('unreturned-secret', BYOK_ENCRYPTION_KEY),
+        credential_fingerprint: crypto.randomUUID(),
+        status: 'revocation_pending',
+        revocation_requested_at: new Date().toISOString(),
+      })
+      .returning();
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(caller.codingPlans.adminRevocationQueue({})).resolves.toEqual([
+      expect.objectContaining({
+        inventoryKeyId: workItem.id,
+        subscriptionExpiresAt: null,
+      }),
+    ]);
+  });
+
+  it('uses the latest subscription period end when three subscriptions reference one inventory credential', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const users = await Promise.all([insertTestUser(), insertTestUser(), insertTestUser()]);
+    const [workItem] = await db
+      .insert(coding_plan_key_inventory)
+      .values({
+        plan_id: PLAN_ID,
+        provider_id: 'minimax',
+        upstream_plan_id: 'minimax-three-ref-plan',
+        encrypted_api_key: encryptApiKey('unreturned-secret', BYOK_ENCRYPTION_KEY),
+        credential_fingerprint: crypto.randomUUID(),
+        status: 'revocation_pending',
+        revocation_requested_at: new Date().toISOString(),
+      })
+      .returning();
+    const periodEnds = [
+      '2026-06-01T00:00:00.000Z',
+      '2026-08-15T12:00:00.000Z',
+      '2026-07-01T00:00:00.000Z',
+    ] as const;
+    await db.insert(coding_plan_subscriptions).values(
+      users.map((user, index) => {
+        const currentPeriodEnd = periodEnds[index] ?? periodEnds[0];
+        return {
+          user_id: user.id,
+          plan_id: PLAN_ID,
+          provider_id: 'minimax',
+          key_inventory_id: workItem.id,
+          status: 'canceled' as const,
+          cost_microdollars: COST_MICRODOLLARS,
+          billing_period_days: 30,
+          current_period_start: '2026-05-01T00:00:00.000Z',
+          current_period_end: currentPeriodEnd,
+          credit_renewal_at: currentPeriodEnd,
+          canceled_at: currentPeriodEnd,
+          cancellation_reason: 'user_cancelled',
+        };
+      })
+    );
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(caller.codingPlans.adminRevocationQueue({})).resolves.toEqual([
+      expect.objectContaining({
+        inventoryKeyId: workItem.id,
+        subscriptionExpiresAt: '2026-08-15T12:00:00.000Z',
+      }),
+    ]);
+  });
 });


### PR DESCRIPTION
## Summary
Stop the admin Pending Key Rotation queue from rendering the same inventory credential more than once.

### Why this change is needed
`listManualCredentialRevocations` left-joins subscriptions on `key_inventory_id`. That foreign key is not unique and is never cleared on cancel. Replace recycles the same inventory row, so each later subscription adds another join match.

Production on 2026-08-11 showed 6 pending credentials as 8 identical rows except `Subscription expires` (33% overstatement). This is a read-path defect. Historical canceled references are intentional, so a unique constraint would be the wrong fix.

### How this is addressed
- Pre-aggregate the latest `current_period_end` per inventory id, then left-join that one-to-one subquery.
- Keep inventory rows with no subscription, with `subscriptionExpiresAt: null`.
- Order by `revocation_requested_at DESC`, then inventory `id ASC`, so hourly cron batches have stable order.

## Human Verification
- Added router tests for two references, three references, and an orphan inventory row.
- Confirmed the two- and three-reference tests fail on the old join (2 and 3 rows) and pass after the subquery change.
- `pnpm --filter web test -- src/routers/coding-plans-router.test.ts src/lib/coding-plans` — 108 passed.

## Reviewer Notes

### Human Reviewer Flags
- Cancellation still leaves `key_inventory_id` and `assigned_to_user_id` populated. Not fixed here; historical references are treated as intentional.
- No partial unique index on live `key_inventory_id`. That would be cross-tenant hardening, not this bug.
- Replace still maps every failure to HTTP 412.
- Post-deploy, this should return `0` (it was `2`):

```sql
SELECT (SELECT COUNT(*)
        FROM coding_plan_key_inventory i
        LEFT JOIN coding_plan_subscriptions s ON s.key_inventory_id = i.id
        WHERE i.status IN ('revocation_pending','revocation_failed'))
     - (SELECT COUNT(*)
        FROM coding_plan_key_inventory
        WHERE status IN ('revocation_pending','revocation_failed')) AS ui_inflation;
```

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Join stays a LEFT JOIN so zero-subscription inventory rows still appear.
- Expiry uses `max(current_period_end)`, not `canceled_at`. Manual requeue resets `revocation_requested_at` and would break a `canceled_at` equality match.
- No schema, migration, or write-path change. tRPC input/output and BytePlus `upstreamPlanId` redaction are unchanged.

</details>
