### PR TITLE
fix(user-data-export): export traces to Axiom and instrument export work

### DIFF
--- a/services/user-data-export/src/databases.ts
+++ b/services/user-data-export/src/databases.ts
@@ -1,5 +1,6 @@
 import { getWorkerDb, pg } from '@kilocode/db/client';
 import { sql } from 'drizzle-orm';
+import { safeError, setSpanFields, withSpan } from './observability';
 import type { ReplicaQuery } from './source-adapters';
 
 export type HyperdriveBinding = { connectionString: string };
@@ -361,23 +362,49 @@ export function createStateDb(binding: HyperdriveBinding) {
 
 type ExportQueueRow = { id: string; export_id: string; generation: number };
 
-export function createReplicaQuery(binding: HyperdriveBinding): ReplicaQuery {
-  return async (text: string, values: unknown[]): Promise<Record<string, unknown>[]> => {
-    const client = new pg.Client({
-      connectionString: binding.connectionString,
-      statement_timeout: 30_000,
-    });
-    try {
-      await client.connect();
-      await client.query('BEGIN READ ONLY');
-      const result = await client.query<Record<string, unknown>>(text, values);
-      await client.query('COMMIT');
-      return result.rows;
-    } catch (error) {
-      await client.query('ROLLBACK').catch(() => undefined);
-      throw error;
-    } finally {
-      await client.end();
-    }
-  };
+/**
+ * Build the page-reading query function for one Hyperdrive binding.
+ *
+ * `database` only labels spans, so pass the logical binding name rather than anything
+ * derived from the connection string, which carries credentials.
+ *
+ * Every source page an export reads passes through here, and Hyperdrive is not
+ * auto-instrumented, so this is the one place that can make read cost visible. The
+ * nested connect span is deliberate: this opens a fresh connection and transaction per
+ * page, and the split between connect and query time is the only way to see what that
+ * setup actually costs against a remote warehouse.
+ *
+ * The query text is intentionally not recorded. The enclosing per-source span already
+ * identifies which of the six queries ran, so the text would add bytes to every span
+ * without adding information, and keeping it out avoids growing the exported surface.
+ */
+export function createReplicaQuery(binding: HyperdriveBinding, database: string): ReplicaQuery {
+  return async (text: string, values: unknown[]): Promise<Record<string, unknown>[]> =>
+    withSpan(
+      'postgres_read_page',
+      { 'db.system.name': 'postgresql', 'db.name': database },
+      async span => {
+        const client = new pg.Client({
+          connectionString: binding.connectionString,
+          statement_timeout: 30_000,
+        });
+        try {
+          await withSpan('postgres_connect', { 'db.name': database }, async () => {
+            await client.connect();
+            await client.query('BEGIN READ ONLY');
+          });
+          const result = await client.query<Record<string, unknown>>(text, values);
+          await client.query('COMMIT');
+          span.setAttribute('db.response.returned_rows', result.rows.length);
+          return result.rows;
+        } catch (error) {
+          span.setAttribute('db.read.failed', true);
+          setSpanFields(span, safeError(error));
+          await client.query('ROLLBACK').catch(() => undefined);
+          throw error;
+        } finally {
+          await client.end();
+        }
+      }
+    );
 }

--- a/services/user-data-export/src/observability.test.ts
+++ b/services/user-data-export/src/observability.test.ts
@@ -1,5 +1,21 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
-import { classifyFetchFailure, logExportEvent, safeError } from './observability';
+import {
+  classifyFetchFailure,
+  logExportEvent,
+  safeError,
+  setSpanFields,
+  withSpan,
+  type ExportSpan,
+} from './observability';
+
+function recordingSpan(): ExportSpan & { attributes: [string, unknown][] } {
+  const attributes: [string, unknown][] = [];
+  return {
+    attributes,
+    isTraced: true,
+    setAttribute: (key, value) => void attributes.push([key, value]),
+  };
+}
 
 afterEach(() => vi.restoreAllMocks());
 
@@ -45,6 +61,50 @@ describe('export observability', () => {
     });
 
     expect(safeError(error)).toEqual({ errorName: 'Error' });
+  });
+});
+
+describe('span fields', () => {
+  it('copies booleans, numbers, and strings onto the span', () => {
+    const span = recordingSpan();
+
+    setSpanFields(span, { source: 'cli_sessions', 'export.page': 3, 'export.done': false });
+
+    expect(span.attributes).toEqual([
+      ['source', 'cli_sessions'],
+      ['export.page', 3],
+      ['export.done', false],
+    ]);
+  });
+
+  /**
+   * setAttribute rejects null, and our field records use null freely for values that are
+   * not resolved yet, so dropping both null and undefined keeps call sites from having to
+   * pre-filter.
+   */
+  it('drops null and undefined instead of forwarding them', () => {
+    const span = recordingSpan();
+
+    setSpanFields(span, { source: null, generation: undefined, exportId: 'export-id' });
+
+    expect(span.attributes).toEqual([['exportId', 'export-id']]);
+  });
+});
+
+describe('withSpan', () => {
+  it('returns the callback result so instrumentation stays transparent', async () => {
+    await expect(withSpan('probe', { source: 'test' }, async () => 'value')).resolves.toBe('value');
+    expect(withSpan('probe', {}, () => 42)).toBe(42);
+  });
+
+  it('propagates failures rather than swallowing them', async () => {
+    const failure = new Error('read failed');
+
+    await expect(
+      withSpan('probe', {}, async () => {
+        throw failure;
+      })
+    ).rejects.toBe(failure);
   });
 });
 

--- a/services/user-data-export/src/observability.ts
+++ b/services/user-data-export/src/observability.ts
@@ -1,6 +1,59 @@
+import { tracing } from 'cloudflare:workers';
+
 type LogLevel = 'info' | 'warn' | 'error';
 
-type ExportLogFields = Record<string, boolean | number | string | null | undefined>;
+export type ExportFields = Record<string, boolean | number | string | null | undefined>;
+
+/**
+ * The subset of the runtime span we rely on.
+ *
+ * Declared locally rather than reusing the ambient `Span` class so call sites do not
+ * depend on a platform type whose surface is still changing during the tracing beta,
+ * and so the unit-test stub for `cloudflare:workers` stays trivially typed.
+ */
+export type ExportSpan = {
+  readonly isTraced: boolean;
+  setAttribute(key: string, value?: boolean | number | string): void;
+};
+
+/**
+ * Run `callback` inside a custom span named `name`, tagged with `fields`.
+ *
+ * Cloudflare auto-instruments fetch, R2, and queue operations, but not Hyperdrive:
+ * `pg` reaches Postgres over a raw TCP socket, so every query this service makes is
+ * invisible to tracing unless we wrap it ourselves. That covers the bulk of the work
+ * in an export, which is why the spans below exist.
+ *
+ * Spans nest automatically via async context, so a span opened here becomes a child of
+ * whichever span is already active and the parent covers any awaited work inside it.
+ *
+ * `fields` must stay free of personal data for the same reason `logExportEvent` fields
+ * do: attributes are exported to the traces destination. Identifiers that describe the
+ * job (export id, generation, source name) are fine; user ids, row contents, SQL text,
+ * and cursor values are not.
+ */
+export function withSpan<T>(
+  name: string,
+  fields: ExportFields,
+  callback: (span: ExportSpan) => T
+): T {
+  return tracing.enterSpan(name, span => {
+    setSpanFields(span, fields);
+    return callback(span);
+  });
+}
+
+/**
+ * Copy `fields` onto a span, skipping empty values.
+ *
+ * `setAttribute` treats `undefined` as a no-op but rejects `null`, which our field
+ * records use freely (for example a not-yet-resolved `source`), so both are dropped.
+ */
+export function setSpanFields(span: ExportSpan, fields: ExportFields): void {
+  for (const [key, value] of Object.entries(fields)) {
+    if (value !== null && value !== undefined) span.setAttribute(key, value);
+  }
+}
 
 export function safeError(error: unknown): { errorName: string; errorCode?: string | number } {
   if (!(error instanceof Error)) return { errorName: 'NonErrorThrow' };
@@ -48,7 +101,7 @@ export function classifyFetchFailure(error: unknown): FetchFailureReason {
   return 'unknown';
 }
 
-export function logExportEvent(level: LogLevel, event: string, fields: ExportLogFields = {}): void {
+export function logExportEvent(level: LogLevel, event: string, fields: ExportFields = {}): void {
   const value = JSON.stringify({ event, service: 'user-data-export', ...fields });
   if (level === 'error') console.error(value);
   else if (level === 'warn') console.warn(value);

--- a/services/user-data-export/src/test-support/cloudflare-workers-stub.ts
+++ b/services/user-data-export/src/test-support/cloudflare-workers-stub.ts
@@ -1,0 +1,26 @@
+/**
+ * Stub for the `cloudflare:workers` module used by the node-environment unit tests,
+ * wired up through `resolve.alias` in `vitest.config.ts`.
+ *
+ * `src/observability.ts` imports `tracing` from `cloudflare:workers`, which only the
+ * Workers runtime can resolve; under plain vitest the import fails with "Cannot find
+ * package 'cloudflare:workers'" and takes every test that reaches `worker.ts` with it.
+ *
+ * `enterSpan` here mirrors the part of the real contract our code depends on: it always
+ * invokes the callback and returns its value, and hands over a span whose `setAttribute`
+ * is a no-op. That matches the runtime for an unsampled request, which is also what the
+ * `test/` workers-pool suite observes (`isTraced === false`), so instrumented code paths
+ * behave the same in both suites.
+ */
+const inertSpan = {
+  isTraced: false,
+  setAttribute: () => undefined,
+};
+
+export const tracing = {
+  enterSpan: <T, A extends unknown[]>(
+    _name: string,
+    callback: (span: typeof inertSpan, ...args: A) => T,
+    ...args: A
+  ): T => callback(inertSpan, ...args),
+};

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -1,4 +1,4 @@
-import { ExportQueueMessageSchema, type ExportQueueMessage } from './contracts';
+import { ExportQueueMessageSchema, type ExportCursor, type ExportQueueMessage } from './contracts';
 import {
   createReplicaQuery,
   createStateDb,
@@ -9,7 +9,7 @@ import {
 import { createSourceAdapters, type ExportRecord } from './source-adapters';
 import type { SourceAdapter } from './source-adapters';
 import { uploadGzipStream } from './gzip';
-import { classifyFetchFailure, logExportEvent, safeError } from './observability';
+import { classifyFetchFailure, logExportEvent, safeError, withSpan } from './observability';
 
 const MAX_PROCESSING_MS = 13 * 60 * 1000;
 const SOURCE_PROCESSING_MS = 12 * 60 * 1000;
@@ -248,7 +248,11 @@ export async function processGenerateMessage(
 ): Promise<void> {
   const state = createStateDb(env.PRIMARY_STATE_DB);
   const leaseToken = crypto.randomUUID();
-  const job = await state.claim(message.exportId, message.generation, leaseToken);
+  const job = await withSpan('export_claim', {}, async span => {
+    const claimed = await state.claim(message.exportId, message.generation, leaseToken);
+    span.setAttribute('export.claimed', claimed !== null);
+    return claimed;
+  });
   if (!job) {
     logExportEvent('info', 'export_generation_skipped', {
       exportId: message.exportId,
@@ -280,15 +284,19 @@ export async function processGenerateMessage(
     if (job.multipart_upload_id) {
       const multipartUploadId = job.multipart_upload_id;
       phase = 'orphan_cleanup';
-      const recovered = await recoverInterruptedMultipartUpload({
-        upload: env.EXPORT_BUCKET.resumeMultipartUpload(objectKey(job.id), multipartUploadId),
-        clear: () =>
-          state.clearClaimedMultipartUpload({
-            exportId: job.id,
-            generation: job.dispatch_generation,
-            leaseToken,
-            multipartUploadId,
-          }),
+      const recovered = await withSpan('export_orphan_cleanup', {}, async span => {
+        const cleared = await recoverInterruptedMultipartUpload({
+          upload: env.EXPORT_BUCKET.resumeMultipartUpload(objectKey(job.id), multipartUploadId),
+          clear: () =>
+            state.clearClaimedMultipartUpload({
+              exportId: job.id,
+              generation: job.dispatch_generation,
+              leaseToken,
+              multipartUploadId,
+            }),
+        });
+        span.setAttribute('export.lease_retained', cleared);
+        return cleared;
       });
       if (!recovered) {
         logExportEvent('info', 'export_generation_skipped', {
@@ -303,8 +311,8 @@ export async function processGenerateMessage(
     }
 
     const adapters = createSourceAdapters({
-      replicaQuery: createReplicaQuery(env.EXPORT_REPLICA_DB),
-      warehouseQuery: createReplicaQuery(env.EXPORT_WAREHOUSE_DB),
+      replicaQuery: createReplicaQuery(env.EXPORT_REPLICA_DB, 'replica'),
+      warehouseQuery: createReplicaQuery(env.EXPORT_WAREHOUSE_DB, 'warehouse'),
     });
     let adapter = resolveSourceAdapter(adapters, job.current_source);
     if (!adapter || !adapter.readPage) {
@@ -320,12 +328,22 @@ export async function processGenerateMessage(
         contentDisposition: exportArtifact.contentDisposition,
       },
     });
-    const attachResult = await attachNewMultipartUpload({
-      upload,
-      exportId: job.id,
-      generation: job.dispatch_generation,
-      leaseToken,
-      attach: input => state.attachMultipartUpload(input),
+    // Bound to a const so the closure below keeps the non-undefined narrowing, matching
+    // how activeUpload is captured for the part uploader further down.
+    const attachingUpload = upload;
+    // R2's createMultipartUpload above is auto-instrumented; the state write that binds
+    // the upload id to the job is not, and it is what decides whether this attempt owns
+    // the export or has been fenced.
+    const attachResult = await withSpan('export_multipart_attach', {}, async span => {
+      const result = await attachNewMultipartUpload({
+        upload: attachingUpload,
+        exportId: job.id,
+        generation: job.dispatch_generation,
+        leaseToken,
+        attach: input => state.attachMultipartUpload(input),
+      });
+      span.setAttribute('export.attach_result', result);
+      return result;
     });
     if (attachResult !== 'attached') return;
     logExportEvent('info', 'export_generation_attempt_started', {
@@ -344,6 +362,10 @@ export async function processGenerateMessage(
       uploadPart: (partNumber, value) => activeUpload.uploadPart(partNumber, value),
     });
     writer = compressor.writable.getWriter();
+    // Same reason as activeUpload: the spans below are closures, where the non-undefined
+    // narrowing on the outer `writer` and `uploadParts` bindings does not survive.
+    const activeWriter = writer;
+    const activeUploadParts = uploadParts;
     deadline = setTimeout(() => {
       deadlineError = exportDeadlineError();
       void writer?.abort(deadlineError).catch(() => undefined);
@@ -353,7 +375,9 @@ export async function processGenerateMessage(
     const header = encoder.encode(exportHeader(job));
     await writer.write(header);
     uncompressedSize += header.byteLength;
-    let cursor = null;
+    // Annotated because the page span reads this inside a closure, which stops the
+    // implicit widening TypeScript would otherwise infer from the assignments below.
+    let cursor: ExportCursor | null = null;
     let recordCount = 0;
     let nextSource: string | null = adapter.name;
 
@@ -365,17 +389,35 @@ export async function processGenerateMessage(
       if (!readPage) throw new Error('Export job has an invalid current source');
       phase = 'source_read';
       activeSource = adapter.name;
-      const page = await readPage({
-        kiloUserId: job.kilo_user_id,
-        snapshotAt: job.snapshot_at,
-        cursor,
-        limit: adapter.pageSize ?? PAGE_SIZE,
-      });
-      for (const record of page.records) {
-        const recordBytes = encoder.encode(jsonLine(record));
-        await writer.write(recordBytes);
-        uncompressedSize += recordBytes.byteLength;
-      }
+      // One span per page rather than per source: the loop advances cursors and adapters
+      // with continue/break, so a per-source span cannot wrap it without restructuring
+      // the control flow. Group by the source attribute to get per-source totals. The
+      // nested postgres_read_page span splits read time from compress-and-write time.
+      const pageNumber = pageCount + 1;
+      const pageLimit = adapter.pageSize ?? PAGE_SIZE;
+      const page = await withSpan(
+        'export_source_page',
+        { source: adapter.name, 'export.page': pageNumber },
+        async span => {
+          const result = await readPage({
+            kiloUserId: job.kilo_user_id,
+            snapshotAt: job.snapshot_at,
+            cursor,
+            limit: pageLimit,
+          });
+          let pageBytes = 0;
+          for (const record of result.records) {
+            const recordBytes = encoder.encode(jsonLine(record));
+            await activeWriter.write(recordBytes);
+            pageBytes += recordBytes.byteLength;
+          }
+          uncompressedSize += pageBytes;
+          span.setAttribute('export.page.rows', result.records.length);
+          span.setAttribute('export.page.uncompressed_bytes', pageBytes);
+          span.setAttribute('export.page.has_more', result.nextCursor !== null);
+          return result;
+        }
+      );
       pageCount += 1;
       recordCount += page.records.length;
       if (page.nextCursor) {
@@ -395,8 +437,14 @@ export async function processGenerateMessage(
       nextSource = adapter.name;
     }
     phase = 'compression_finalize';
-    await writer.close();
-    const parts = await uploadParts;
+    // Draining the compressor is where any part uploads still in flight are awaited, so
+    // this span is the wait-on-R2 tail of the export rather than compression cost alone.
+    const parts = await withSpan('export_compression_finalize', {}, async span => {
+      await activeWriter.close();
+      const uploaded = await activeUploadParts;
+      span.setAttribute('export.parts', uploaded.length);
+      return uploaded;
+    });
     if (parts.length === 0) throw new Error('Compressed export produced no multipart data');
     if (deadlineError) throw deadlineError;
     if (deadline) {
@@ -409,19 +457,27 @@ export async function processGenerateMessage(
       parts.map(part => ({ partNumber: part.partNumber, etag: part.etag }))
     );
     phase = 'state_update';
-    const completion = await persistCompletedExport({
-      complete: () =>
-        state.complete({
-          exportId: job.id,
-          leaseToken,
-          rowCount: recordCount,
-          objectKey: key,
-          etag: object.etag,
-          sizeBytes: object.size,
-        }),
-      completedObjectMatches: () =>
-        state.completedObjectMatches({ exportId: job.id, objectKey: key, etag: object.etag }),
-    });
+    const completion = await withSpan(
+      'export_state_update',
+      { 'export.rows': recordCount, 'export.size_bytes': object.size },
+      async span => {
+        const result = await persistCompletedExport({
+          complete: () =>
+            state.complete({
+              exportId: job.id,
+              leaseToken,
+              rowCount: recordCount,
+              objectKey: key,
+              etag: object.etag,
+              sizeBytes: object.size,
+            }),
+          completedObjectMatches: () =>
+            state.completedObjectMatches({ exportId: job.id, objectKey: key, etag: object.etag }),
+        });
+        span.setAttribute('export.completion', result);
+        return result;
+      }
+    );
     if (completion === 'fenced') {
       await handleFencedCompletion({
         exportId: job.id,
@@ -492,7 +548,18 @@ export async function consumeExportBatch(
       continue;
     }
     try {
-      await processMessage(env, parsed.data);
+      // Wrapped here rather than inside processGenerateMessage so the span covers the
+      // whole attempt, including the retry decision below, and so every span the
+      // generator opens inherits the export id and attempt number as ancestors.
+      await withSpan(
+        'export_generate',
+        {
+          exportId: parsed.data.exportId,
+          generation: parsed.data.generation,
+          attempt: message.attempts,
+        },
+        () => processMessage(env, parsed.data)
+      );
       message.ack();
     } catch (error) {
       logExportEvent('warn', 'export_queue_retry_requested', {
@@ -528,12 +595,18 @@ export async function consumeDeadLetterBatch(
   }
 }
 
+/**
+ * The cron runs every five minutes and its four stages are sequential, so without spans
+ * per stage a slow sweep is indistinguishable from a slow lease expiry query.
+ */
 export async function reconcile(env: ExportEnv): Promise<void> {
   const state = createStateDb(env.PRIMARY_STATE_DB);
-  await state.reconcile();
-  await deletePendingObjects(env.EXPORT_BUCKET, state);
-  await processScheduledExportWork(env, state);
-  await dispatchReadyNotifications(env, state);
+  await withSpan('reconcile_leases', {}, () => state.reconcile());
+  await withSpan('reconcile_object_deletions', {}, () =>
+    deletePendingObjects(env.EXPORT_BUCKET, state)
+  );
+  await withSpan('reconcile_scheduled_work', {}, () => processScheduledExportWork(env, state));
+  await withSpan('reconcile_notifications', {}, () => dispatchReadyNotifications(env, state));
 }
 
 export async function processScheduledExportWork(

--- a/services/user-data-export/src/wrangler-config.test.ts
+++ b/services/user-data-export/src/wrangler-config.test.ts
@@ -24,6 +24,20 @@ describe('wrangler config', () => {
     expect(config).toContain('"EXPORT_WAREHOUSE_DB"');
   });
 
+  /**
+   * Traces reached Axiom as nothing but the destination's one-off pre-flight span
+   * because this config enabled logs only. `observability.enabled` does not turn on
+   * tracing while the feature is in beta, and a destination receives spans only from
+   * Workers that name it, so both keys have to survive future edits to this file.
+   */
+  it('enables tracing and names the traces destination', () => {
+    const observability = config.slice(config.indexOf('"observability"'));
+    const traces = observability.slice(observability.indexOf('"traces"'));
+
+    expect(traces).toMatch(/"enabled":\s*true/);
+    expect(traces).toContain('"axiom-traces"');
+  });
+
   it('points local development at the warehouse database, not the primary', () => {
     const warehouseSection = config.slice(config.indexOf('"EXPORT_WAREHOUSE_DB"'));
     const localConnection = /"localConnectionString":\s*"([^"]+)"/.exec(warehouseSection)?.[1];

--- a/services/user-data-export/vitest.config.ts
+++ b/services/user-data-export/vitest.config.ts
@@ -1,5 +1,17 @@
+import { resolve } from 'node:path';
 import { defineConfig } from 'vitest/config';
 
 export default defineConfig({
+  resolve: {
+    // src/observability.ts imports `tracing` from cloudflare:workers, which only the
+    // Workers runtime resolves. The workers-pool suite (vitest.workers.config.ts) gets
+    // the real module; these node-environment tests get a pass-through stub.
+    alias: {
+      'cloudflare:workers': resolve(
+        import.meta.dirname,
+        'src/test-support/cloudflare-workers-stub.ts'
+      ),
+    },
+  },
   test: { environment: 'node', include: ['src/**/*.test.ts'] },
 });

--- a/services/user-data-export/wrangler.jsonc
+++ b/services/user-data-export/wrangler.jsonc
@@ -21,6 +21,19 @@
       "enabled": true,
       "head_sampling_rate": 1,
     },
+    // observability.enabled alone does not turn on tracing while Workers tracing is
+    // in beta, and a destination only receives spans from Workers that name it, so
+    // both keys below are required. "axiom-traces" must match the destination
+    // configured under Workers Observability in the Cloudflare dashboard; without it
+    // Axiom receives only the one-off pre-flight span emitted when the destination
+    // is saved. Sampling stays at 1: this Worker runs a 5-minute cron plus one queue
+    // message per export, so full-fidelity tracing is far below the free tier.
+    "traces": {
+      "enabled": true,
+      "persist": true,
+      "head_sampling_rate": 1,
+      "destinations": ["axiom-traces"],
+    },
   },
   "logpush": true,
   "routes": [


### PR DESCRIPTION
## Problem

Traces upload from Cloudflare to Axiom was enabled for the `user-data-export` Worker, but Axiom contained exactly one record — the destination's one-off pre-flight span:

```json
{
  "name": "Hello from Cloudflare 👋 (axiom-traces)",
  "service": { "name": "cloudflare-workers-observability" },
  "telemetry": { "sdk": { "name": "pre-flight-check", "version": "1.0.0" } }
}
```

That span is emitted once when a destination is saved, so it proved the destination worked while confirming that **zero real Worker spans had ever been routed to it**.

Two independent causes:

1. **The Worker never opted into tracing.** Its `observability` block enabled `logs` only. Per [Cloudflare's docs](https://developers.cloudflare.com/workers/observability/traces/), `observability.enabled` does *not* turn on tracing while the feature is in beta, and a destination only receives spans from Workers that name it in `traces.destinations`. This Worker was the only one in the repo without a `traces` block — `kilo-ops`, `wasteland`, `gastown`, `container-usage-meter`, and `cloud-agent-next` all have one.

2. **The expensive work is invisible even with tracing on.** Cloudflare auto-instruments fetch, cache, KV, R2, D1, Durable Objects, Queues, Images, Email, and rate limiting — [but not Hyperdrive](https://developers.cloudflare.com/workers/observability/traces/spans-and-attributes/). This service reaches Postgres through `pg` over a raw TCP socket across three Hyperdrive bindings, so every source page read and state write produced no span at all, while accounting for the bulk of an export's cost against its 13-minute deadline. Enabling export alone would have yielded a root handler span, a few R2 multipart spans, and nothing about the actual work.

## Changes

**Config** — `wrangler.jsonc` now enables tracing and names the destination. `persist: true` keeps the existing Cloudflare dashboard view. Sampling stays at `1`: a 5-minute cron plus one queue message per export is far below the 10M events/month free tier.

**Instrumentation** — a single `withSpan(name, fields, callback)` helper in `src/observability.ts` confines the `cloudflare:workers` import to one module:

| Span | Answers |
|---|---|
| `export_generate` | Total attempt cost, tagged with export id, generation, attempt |
| `export_claim` | Lease acquisition, and whether the job was claimable |
| `export_orphan_cleanup` | Interrupted-upload recovery, lease retained or lost |
| `export_multipart_attach` | The un-instrumented state write that decides ownership vs fencing |
| `export_source_page` | Per page: source, page number, rows, uncompressed bytes, has-more |
| `postgres_read_page` → `postgres_connect` | Every source read, split into connect vs query time |
| `export_compression_finalize` | The wait-on-R2 tail, plus part count |
| `export_state_update` | Completion write, with row count, size, and fenced/completed outcome |
| `reconcile_*` (4 spans) | Which of the four cron stages is slow |

`console.log` output is auto-attributed to the enclosing span, so the existing structured logs now correlate with the trace for free.

## Notes for reviewers

- **No PII in attributes.** Attributes carry only job-shaped identifiers — export id, generation, source name, counts — matching the discipline the existing `logExportEvent` fields already follow. User ids, row contents, SQL text, and cursor values are deliberately excluded; span attributes are exported to a third party just like logs. The query text is omitted from `postgres_read_page` because the enclosing per-source span already identifies which of the six queries ran.
- **`export_source_page` is per page, not per source.** The pagination loop advances cursors and adapters with `continue`/`break`, so a per-source span could not wrap it without restructuring control flow in a function with careful deadline-abort and lease-fencing logic. Group by the `source` attribute for per-source totals. Budget ~3 spans per page; a multi-thousand-page export is where `head_sampling_rate` would come down.
- **Closure narrowing.** Moving code into callbacks costs TypeScript's non-undefined narrowing on the `writer`, `uploadParts`, and `upload` bindings, handled with `activeWriter`-style consts matching the file's existing `activeUpload` pattern. `cursor` gained an explicit `ExportCursor | null` annotation for the same reason.
- **Test wiring.** The node-pool unit tests cannot resolve `cloudflare:workers` (verified: `Cannot find package 'cloudflare:workers'`), so the import is confined to `observability.ts` and aliased to a pass-through stub, following the existing `services/auto-routing` precedent. The stub's span reports `isTraced: false` with a no-op `setAttribute`, which is exactly what the real runtime does for an unsampled request — so instrumented code paths behave identically in both suites.
- **Only `enterSpan` is used.** `@cloudflare/workers-types@4.20260605.1` (catalog-pinned, shared by 16 packages) has no `startActiveSpan` or `span.end()`, and a runtime probe confirmed the same. No catalog bump needed. This also ruled out a span around the gzip stream pipeline, which is low value anyway since `r2_uploadPart` is already auto-instrumented and non-I/O work often reports 0 ms.

## Verification

- `tsgo --noEmit` clean
- `oxlint` — 0 warnings, 0 errors
- `vitest run` — 80 passed (5 new, covering `setSpanFields` null/undefined handling and `withSpan` result/error transparency)
- `vitest run --config vitest.workers.config.ts` — 5 passed
- `oxfmt --list-different .` — no differences
- `wrangler deploy --dry-run` — config parses, all bindings resolve

A new test in `wrangler-config.test.ts` locks in `traces.enabled` and the destination name, since this file already exists to guard config regressions and this exact omission is what caused the issue.

Traces reaching Axiom can only be confirmed after deploy; please sanity-check that the destination is named exactly `axiom-traces` (taken from the pre-flight span above).

## Follow-ups, deliberately not in this PR

- **Per-page connection churn.** `createReplicaQuery` opens a fresh connection and transaction for every page — `connect` → `BEGIN READ ONLY` → query → `COMMIT` → `end` — against a `us-east-2` warehouse, on a job with a hard 13-minute deadline and an existing `export_deadline_exceeded` terminal error. The new `postgres_connect` span quantifies this before anyone attempts a fix.
- **Wrapping the 24 `createStateDb` methods.** The phase spans already cover the hot path, so this is a large diff for little additional signal.
- **Other services may have the same export gap.** `kilo-ops`, `wasteland`, and `gastown` enable traces but name no `destinations`, so their spans likely are not reaching Axiom either. Out of scope here.
- **Logs.** The `logs` block also names no `destinations`, so if an `axiom-logs` destination exists, logs are not reaching it. Left alone since I could not confirm whether it exists.