### PR TITLE
fix(ai-gateway): store more error details in api_request_log

### DIFF
--- a/apps/web/src/lib/ai-gateway/api-request-log-errors.test.ts
+++ b/apps/web/src/lib/ai-gateway/api-request-log-errors.test.ts
@@ -1,0 +1,341 @@
+import { describe, expect, test } from '@jest/globals';
+import { detectRequestLogErrors } from './api-request-log-errors';
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+
+const weatherParameters = {
+  type: 'object',
+  properties: {
+    city: { type: 'string' },
+  },
+  required: ['city'],
+};
+
+const chatTool = {
+  type: 'function' as const,
+  function: { name: 'get_weather', parameters: weatherParameters },
+};
+
+const responseTool = {
+  type: 'function' as const,
+  name: 'get_weather',
+  parameters: weatherParameters,
+};
+
+const messageTool = {
+  name: 'get_weather',
+  input_schema: weatherParameters,
+};
+
+function chatRequest(tools = [chatTool]): GatewayRequest {
+  return {
+    kind: 'chat_completions',
+    body: { model: 'test', messages: [], tools },
+  };
+}
+
+function responsesRequest(tools = [responseTool]): GatewayRequest {
+  return {
+    kind: 'responses',
+    body: { model: 'test', input: [], tools },
+  };
+}
+
+function messagesRequest(tools = [messageTool]): GatewayRequest {
+  return {
+    kind: 'messages',
+    body: { model: 'claude-test', max_tokens: 16, messages: [], tools },
+  };
+}
+
+function sse(...payloads: unknown[]): string {
+  return (
+    payloads.map(payload => `data: ${JSON.stringify(payload)}\n\n`).join('') + 'data: [DONE]\n\n'
+  );
+}
+
+describe('detectRequestLogErrors', () => {
+  test('returns null for a successful streamed completion with no tools', () => {
+    expect(
+      detectRequestLogErrors(
+        sse({ id: 'gen-1', choices: [{ index: 0, delta: { content: 'hi' } }] }),
+        chatRequest([])
+      )
+    ).toBeNull();
+  });
+
+  test('returns null for a successful JSON completion with no tools', () => {
+    expect(
+      detectRequestLogErrors(
+        JSON.stringify({
+          choices: [{ message: { content: 'hi' } }],
+        }),
+        chatRequest([])
+      )
+    ).toBeNull();
+  });
+
+  describe('upstream errors', () => {
+    test('stores chat completion SSE error objects', () => {
+      expect(
+        detectRequestLogErrors(
+          sse(
+            { id: 'gen-1', choices: [{ index: 0, delta: { content: 'hi' } }] },
+            { error: { code: 429, message: 'rate limited' } }
+          ),
+          chatRequest()
+        )
+      ).toEqual({
+        upstream_error: { code: 429, message: 'rate limited' },
+      });
+    });
+
+    test('stores messages SSE error objects', () => {
+      expect(
+        detectRequestLogErrors(
+          'event: error\ndata: {"type":"error","error":{"type":"api_error","message":"rate limited"}}\n\n',
+          messagesRequest()
+        )
+      ).toEqual({
+        upstream_error: { type: 'api_error', message: 'rate limited' },
+      });
+    });
+
+    test('stores responses SSE error objects', () => {
+      expect(
+        detectRequestLogErrors(
+          'event: error\ndata: {"type":"error","error":{"type":"server_error","message":"rate limited"}}\n\n',
+          responsesRequest()
+        )
+      ).toEqual({
+        upstream_error: { type: 'server_error', message: 'rate limited' },
+      });
+    });
+
+    test('stores response.failed error details', () => {
+      expect(
+        detectRequestLogErrors(
+          sse({
+            type: 'response.failed',
+            response: {
+              status: 'failed',
+              error: { code: 'server_error', message: 'provider failed' },
+            },
+          }),
+          responsesRequest()
+        )
+      ).toEqual({
+        upstream_error: { code: 'server_error', message: 'provider failed' },
+      });
+    });
+
+    test('stores JSON error bodies', () => {
+      expect(
+        detectRequestLogErrors(
+          JSON.stringify({
+            error: { message: 'Model not found', code: 404 },
+            error_type: 'model_not_found',
+          }),
+          chatRequest()
+        )
+      ).toEqual({
+        upstream_error: { message: 'Model not found', code: 404 },
+      });
+    });
+
+    test('stores string JSON error bodies', () => {
+      expect(
+        detectRequestLogErrors(JSON.stringify({ error: 'temporarily unavailable' }), chatRequest())
+      ).toEqual({
+        upstream_error: 'temporarily unavailable',
+      });
+    });
+
+    test('keeps the last upstream error when several appear in a stream', () => {
+      expect(
+        detectRequestLogErrors(
+          sse({ error: { message: 'first' } }, { error: { message: 'second' } }),
+          chatRequest()
+        )
+      ).toEqual({
+        upstream_error: { message: 'second' },
+      });
+    });
+  });
+
+  describe('tool call argument errors', () => {
+    test('detects unparseable JSON arguments in a chat SSE stream', () => {
+      const result = detectRequestLogErrors(
+        sse(
+          {
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call_1',
+                      function: { name: 'get_weather', arguments: '{"city":' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          {
+            choices: [
+              {
+                index: 0,
+                delta: { tool_calls: [{ index: 0, function: { arguments: '"Paris"' } }] },
+              },
+            ],
+          }
+        ),
+        chatRequest()
+      );
+
+      expect(result?.invalid_tool_call_arguments).toEqual([
+        {
+          tool_call_id: 'call_1',
+          tool_name: 'get_weather',
+          kind: 'unparseable_json',
+          details: expect.any(String),
+        },
+      ]);
+    });
+
+    test('detects schema mismatches in a non-streamed chat completion', () => {
+      expect(
+        detectRequestLogErrors(
+          JSON.stringify({
+            choices: [
+              {
+                message: {
+                  tool_calls: [
+                    {
+                      id: 'call_1',
+                      type: 'function',
+                      function: { name: 'get_weather', arguments: '{"city":1}' },
+                    },
+                  ],
+                },
+              },
+            ],
+          }),
+          chatRequest()
+        )
+      ).toEqual({
+        invalid_tool_call_arguments: [
+          {
+            tool_call_id: 'call_1',
+            tool_name: 'get_weather',
+            kind: 'schema_mismatch',
+            details: expect.anything(),
+          },
+        ],
+      });
+    });
+
+    test('detects unknown tools in a non-streamed responses body', () => {
+      expect(
+        detectRequestLogErrors(
+          JSON.stringify({
+            output: [
+              {
+                type: 'function_call',
+                call_id: 'call_9',
+                name: 'launch_missiles',
+                arguments: '{}',
+              },
+            ],
+          }),
+          responsesRequest()
+        )
+      ).toEqual({
+        invalid_tool_call_arguments: [
+          {
+            tool_call_id: 'call_9',
+            tool_name: 'launch_missiles',
+            kind: 'unknown_tool',
+          },
+        ],
+      });
+    });
+
+    test('detects schema mismatches in a non-streamed messages body', () => {
+      expect(
+        detectRequestLogErrors(
+          JSON.stringify({
+            content: [
+              {
+                type: 'tool_use',
+                id: 'toolu_1',
+                name: 'get_weather',
+                input: { city: 1 },
+              },
+            ],
+          }),
+          messagesRequest()
+        )
+      ).toEqual({
+        invalid_tool_call_arguments: [
+          {
+            tool_call_id: 'toolu_1',
+            tool_name: 'get_weather',
+            kind: 'schema_mismatch',
+            details: expect.anything(),
+          },
+        ],
+      });
+    });
+
+    test('still records tool-call errors when a later SSE error event has no choices', () => {
+      const result = detectRequestLogErrors(
+        sse(
+          {
+            choices: [
+              {
+                index: 0,
+                delta: {
+                  tool_calls: [
+                    {
+                      index: 0,
+                      id: 'call_1',
+                      function: { name: 'missing_tool', arguments: '{}' },
+                    },
+                  ],
+                },
+              },
+            ],
+          },
+          { error: { code: 502, message: 'provider unavailable' } }
+        ),
+        chatRequest()
+      );
+
+      expect(result).toEqual({
+        invalid_tool_call_arguments: [
+          {
+            tool_call_id: 'call_1',
+            tool_name: 'missing_tool',
+            kind: 'unknown_tool',
+          },
+        ],
+        upstream_error: { code: 502, message: 'provider unavailable' },
+      });
+    });
+
+    test('ignores a malformed SSE event and still records later errors', () => {
+      expect(
+        detectRequestLogErrors(
+          'data: not-json\n\n' +
+            'data: {"error":{"message":"still captured"}}\n\n' +
+            'data: [DONE]\n\n',
+          chatRequest()
+        )
+      ).toEqual({
+        upstream_error: { message: 'still captured' },
+      });
+    });
+  });
+});

--- a/apps/web/src/lib/ai-gateway/api-request-log-errors.test.ts
+++ b/apps/web/src/lib/ai-gateway/api-request-log-errors.test.ts
@@ -8,9 +8,9 @@ import type {
 } from '@/lib/ai-gateway/providers/openrouter/types';
 
 const weatherParameters = {
-  type: 'object',
+  type: 'object' as const,
   properties: {
-    city: { type: 'string' },
+    city: { type: 'string' as const },
   },
   required: ['city'],
 };

--- a/apps/web/src/lib/ai-gateway/api-request-log-errors.test.ts
+++ b/apps/web/src/lib/ai-gateway/api-request-log-errors.test.ts
@@ -1,6 +1,11 @@
 import { describe, expect, test } from '@jest/globals';
 import { detectRequestLogErrors } from './api-request-log-errors';
-import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import type {
+  GatewayMessagesRequest,
+  GatewayRequest,
+  GatewayResponsesRequest,
+  OpenRouterChatCompletionRequest,
+} from '@/lib/ai-gateway/providers/openrouter/types';
 
 const weatherParameters = {
   type: 'object',
@@ -10,40 +15,56 @@ const weatherParameters = {
   required: ['city'],
 };
 
-const chatTool = {
-  type: 'function' as const,
-  function: { name: 'get_weather', parameters: weatherParameters },
-};
-
-const responseTool = {
-  type: 'function' as const,
-  name: 'get_weather',
-  parameters: weatherParameters,
-};
-
-const messageTool = {
-  name: 'get_weather',
-  input_schema: weatherParameters,
-};
-
-function chatRequest(tools = [chatTool]): GatewayRequest {
+function chatRequest(overrides: Partial<OpenRouterChatCompletionRequest> = {}): GatewayRequest {
   return {
     kind: 'chat_completions',
-    body: { model: 'test', messages: [], tools },
+    body: {
+      model: 'test',
+      messages: [],
+      tools: [
+        {
+          type: 'function',
+          function: { name: 'get_weather', parameters: weatherParameters },
+        },
+      ],
+      ...overrides,
+    },
   };
 }
 
-function responsesRequest(tools = [responseTool]): GatewayRequest {
+function responsesRequest(overrides: Partial<GatewayResponsesRequest> = {}): GatewayRequest {
   return {
     kind: 'responses',
-    body: { model: 'test', input: [], tools },
+    body: {
+      model: 'test',
+      input: [],
+      tools: [
+        {
+          type: 'function',
+          name: 'get_weather',
+          parameters: weatherParameters,
+        },
+      ],
+      ...overrides,
+    },
   };
 }
 
-function messagesRequest(tools = [messageTool]): GatewayRequest {
+function messagesRequest(overrides: Partial<GatewayMessagesRequest> = {}): GatewayRequest {
   return {
     kind: 'messages',
-    body: { model: 'claude-test', max_tokens: 16, messages: [], tools },
+    body: {
+      model: 'claude-test',
+      max_tokens: 16,
+      messages: [],
+      tools: [
+        {
+          name: 'get_weather',
+          input_schema: weatherParameters,
+        },
+      ],
+      ...overrides,
+    },
   };
 }
 
@@ -58,7 +79,7 @@ describe('detectRequestLogErrors', () => {
     expect(
       detectRequestLogErrors(
         sse({ id: 'gen-1', choices: [{ index: 0, delta: { content: 'hi' } }] }),
-        chatRequest([])
+        chatRequest({ tools: [] })
       )
     ).toBeNull();
   });
@@ -69,7 +90,7 @@ describe('detectRequestLogErrors', () => {
         JSON.stringify({
           choices: [{ message: { content: 'hi' } }],
         }),
-        chatRequest([])
+        chatRequest({ tools: [] })
       )
     ).toBeNull();
   });

--- a/apps/web/src/lib/ai-gateway/api-request-log-errors.test.ts
+++ b/apps/web/src/lib/ai-gateway/api-request-log-errors.test.ts
@@ -43,6 +43,7 @@ function responsesRequest(overrides: Partial<GatewayResponsesRequest> = {}): Gat
           type: 'function',
           name: 'get_weather',
           parameters: weatherParameters,
+          strict: null,
         },
       ],
       ...overrides,

--- a/apps/web/src/lib/ai-gateway/api-request-log-errors.ts
+++ b/apps/web/src/lib/ai-gateway/api-request-log-errors.ts
@@ -25,12 +25,18 @@ export const toolCallArgumentErrorSchema = z.discriminatedUnion('kind', [
 ]);
 
 export const apiRequestLogErrorSchema = z.object({
-  invalid_tool_call_arguments: z.array(toolCallArgumentErrorSchema),
+  invalid_tool_call_arguments: z.array(toolCallArgumentErrorSchema).optional(),
+  upstream_error: z.unknown().optional(),
+  response_body_read_error: z.string().optional(),
 });
 
 export type ApiRequestLogError = z.infer<typeof apiRequestLogErrorSchema>;
 
 type ToolCallError = z.infer<typeof toolCallArgumentErrorSchema>;
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
 
 function checkKnownTool(
   knownToolNames: Set<string>,
@@ -107,6 +113,47 @@ function parseSseDataLines(text: string): string[] {
   return payloads;
 }
 
+function parseJsonLine(line: string): unknown {
+  try {
+    return JSON.parse(line);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractUpstreamError(value: unknown): unknown {
+  if (!isRecord(value)) return undefined;
+  if (value.error != null) return value.error;
+  if (
+    value.type === 'response.failed' &&
+    isRecord(value.response) &&
+    value.response.error != null
+  ) {
+    return value.response.error;
+  }
+  return undefined;
+}
+
+function lastUpstreamError(values: unknown[]): unknown {
+  let found: unknown = undefined;
+  for (const value of values) {
+    const error = extractUpstreamError(value);
+    if (error !== undefined) found = error;
+  }
+  return found;
+}
+
+function buildError(
+  toolErrors: ToolCallError[],
+  upstreamError: unknown
+): ApiRequestLogError | null {
+  if (toolErrors.length === 0 && upstreamError === undefined) return null;
+  return {
+    ...(toolErrors.length > 0 ? { invalid_tool_call_arguments: toolErrors } : {}),
+    ...(upstreamError !== undefined ? { upstream_error: upstreamError } : {}),
+  };
+}
+
 type ToolAccumulator = { id: string; name: string; arguments: string };
 
 function detectChatCompletionSseErrors(
@@ -125,13 +172,20 @@ function detectChatCompletionSseErrors(
   // Accumulate tool call arguments by index across chunks (choice 0 only)
   const byIndex = new Map<number, ToolAccumulator>();
   for (const line of lines) {
-    const chunk: OpenAI.Chat.Completions.ChatCompletionChunk = JSON.parse(line);
-    const choice = chunk.choices.find(c => c.index === 0);
-    for (const toolCall of choice?.delta.tool_calls ?? []) {
+    const chunk = parseJsonLine(line);
+    if (!isRecord(chunk) || !Array.isArray(chunk.choices)) continue;
+    const choice = chunk.choices.find(
+      (item): item is Record<string, unknown> => isRecord(item) && item.index === 0
+    );
+    const delta = isRecord(choice?.delta) ? choice.delta : undefined;
+    if (!Array.isArray(delta?.tool_calls)) continue;
+    for (const toolCall of delta.tool_calls) {
+      if (!isRecord(toolCall) || typeof toolCall.index !== 'number') continue;
+      const fn = isRecord(toolCall.function) ? toolCall.function : undefined;
       const acc = byIndex.get(toolCall.index) ?? { id: '', name: '', arguments: '' };
-      if (toolCall.id) acc.id = toolCall.id;
-      if (toolCall.function?.name) acc.name = toolCall.function.name;
-      acc.arguments += toolCall.function?.arguments ?? '';
+      if (typeof toolCall.id === 'string') acc.id = toolCall.id;
+      if (typeof fn?.name === 'string') acc.name = fn.name;
+      if (typeof fn?.arguments === 'string') acc.arguments += fn.arguments;
       byIndex.set(toolCall.index, acc);
     }
   }
@@ -170,16 +224,22 @@ function detectResponsesSseErrors(
   // response.output_item.done carries the fully assembled function_call item
   const errors: ToolCallError[] = [];
   for (const line of lines) {
-    const event = JSON.parse(line);
-    if (event.type !== 'response.output_item.done' || event.item?.type !== 'function_call')
-      continue;
-    const callId: string = event.item.call_id;
-    const name: string = event.item.name;
-    const argsStr: string = event.item.arguments;
-    if (!checkKnownTool(knownToolNames, callId, name, errors)) continue;
-    const result = parseArgsString(argsStr, callId, name, errors);
+    const event = parseJsonLine(line);
+    if (!isRecord(event) || event.type !== 'response.output_item.done') continue;
+    const item = event.item;
+    if (!isRecord(item) || item.type !== 'function_call') continue;
+    if (typeof item.call_id !== 'string' || typeof item.name !== 'string') continue;
+    const argsStr = typeof item.arguments === 'string' ? item.arguments : '';
+    if (!checkKnownTool(knownToolNames, item.call_id, item.name, errors)) continue;
+    const result = parseArgsString(argsStr, item.call_id, item.name, errors);
     if (result.ok) {
-      validateAgainstSchema(result.parsed, toolSchemaByName.get(name), callId, name, errors);
+      validateAgainstSchema(
+        result.parsed,
+        toolSchemaByName.get(item.name),
+        item.call_id,
+        item.name,
+        errors
+      );
     }
   }
   return errors;
@@ -202,14 +262,21 @@ function detectMessagesSseErrors(
   // Accumulate partial_json fragments by content block index
   const byIndex = new Map<number, ToolAccumulator>();
   for (const line of lines) {
-    const event = JSON.parse(line);
-    if (event.type === 'content_block_start' && event.content_block?.type === 'tool_use') {
-      const id: string = event.content_block.id;
-      const name: string = event.content_block.name;
+    const event = parseJsonLine(line);
+    if (!isRecord(event)) continue;
+    if (event.type === 'content_block_start' && isRecord(event.content_block)) {
+      if (event.content_block.type !== 'tool_use') continue;
+      if (typeof event.index !== 'number') continue;
+      const id = typeof event.content_block.id === 'string' ? event.content_block.id : '';
+      const name = typeof event.content_block.name === 'string' ? event.content_block.name : '';
       byIndex.set(event.index, { id, name, arguments: '' });
-    } else if (event.type === 'content_block_delta' && event.delta?.type === 'input_json_delta') {
+    } else if (event.type === 'content_block_delta' && isRecord(event.delta)) {
+      if (event.delta.type !== 'input_json_delta') continue;
+      if (typeof event.index !== 'number') continue;
       const acc = byIndex.get(event.index);
-      if (acc) acc.arguments += event.delta.partial_json;
+      if (acc && typeof event.delta.partial_json === 'string') {
+        acc.arguments += event.delta.partial_json;
+      }
     }
   }
 
@@ -218,7 +285,6 @@ function detectMessagesSseErrors(
     if (!checkKnownTool(knownToolNames, acc.id, acc.name, errors)) continue;
     const result = parseArgsString(acc.arguments, acc.id, acc.name, errors);
     if (result.ok) {
-      // acc.arguments is accumulated JSON — validate against tool schema
       validateAgainstSchema(
         result.parsed,
         toolSchemaByName.get(acc.name),
@@ -231,30 +297,148 @@ function detectMessagesSseErrors(
   return errors;
 }
 
-/**
- * Checks SSE-streamed response tool call arguments for JSON parse errors or schema mismatches.
- * Returns null if the response is not an SSE stream or if no errors are found.
- */
-export function detectToolCallArgumentErrors(
+function detectChatCompletionJsonErrors(
+  response: unknown,
+  tools: OpenAI.Chat.ChatCompletionTool[] | null | undefined
+): ToolCallError[] {
+  if (!isRecord(response) || !Array.isArray(response.choices)) return [];
+
+  const toolSchemaByName = new Map<string, unknown>();
+  const knownToolNames = new Set<string>();
+  for (const tool of tools ?? []) {
+    if (tool.type === 'function') {
+      knownToolNames.add(tool.function.name);
+      toolSchemaByName.set(tool.function.name, tool.function.parameters);
+    }
+  }
+
+  const errors: ToolCallError[] = [];
+  for (const choice of response.choices) {
+    if (
+      !isRecord(choice) ||
+      !isRecord(choice.message) ||
+      !Array.isArray(choice.message.tool_calls)
+    ) {
+      continue;
+    }
+    for (const toolCall of choice.message.tool_calls) {
+      if (!isRecord(toolCall) || toolCall.type !== 'function' || !isRecord(toolCall.function)) {
+        continue;
+      }
+      const id = typeof toolCall.id === 'string' ? toolCall.id : '';
+      const name = typeof toolCall.function.name === 'string' ? toolCall.function.name : '';
+      if (!name) continue;
+      if (!checkKnownTool(knownToolNames, id, name, errors)) continue;
+      const argsStr =
+        typeof toolCall.function.arguments === 'string' ? toolCall.function.arguments : '';
+      const result = parseArgsString(argsStr, id, name, errors);
+      if (result.ok) {
+        validateAgainstSchema(result.parsed, toolSchemaByName.get(name), id, name, errors);
+      }
+    }
+  }
+  return errors;
+}
+
+function detectResponsesJsonErrors(
+  response: unknown,
+  tools: OpenAI.Responses.ResponseCreateParams['tools']
+): ToolCallError[] {
+  if (!isRecord(response) || !Array.isArray(response.output)) return [];
+
+  const toolSchemaByName = new Map<string, unknown>();
+  const knownToolNames = new Set<string>();
+  for (const tool of tools ?? []) {
+    if (tool.type === 'function') {
+      knownToolNames.add(tool.name);
+      toolSchemaByName.set(tool.name, tool.parameters);
+    }
+  }
+
+  const errors: ToolCallError[] = [];
+  for (const item of response.output) {
+    if (!isRecord(item) || item.type !== 'function_call') continue;
+    const callId = typeof item.call_id === 'string' ? item.call_id : '';
+    const name = typeof item.name === 'string' ? item.name : '';
+    if (!name) continue;
+    if (!checkKnownTool(knownToolNames, callId, name, errors)) continue;
+    const argsStr = typeof item.arguments === 'string' ? item.arguments : '';
+    const result = parseArgsString(argsStr, callId, name, errors);
+    if (result.ok) {
+      validateAgainstSchema(result.parsed, toolSchemaByName.get(name), callId, name, errors);
+    }
+  }
+  return errors;
+}
+
+function detectMessagesJsonErrors(
+  response: unknown,
+  tools: Anthropic.MessageCreateParams['tools']
+): ToolCallError[] {
+  if (!isRecord(response) || !Array.isArray(response.content)) return [];
+
+  const toolSchemaByName = new Map<string, unknown>();
+  const knownToolNames = new Set<string>();
+  for (const tool of tools ?? []) {
+    knownToolNames.add(tool.name);
+    if ('input_schema' in tool) {
+      toolSchemaByName.set(tool.name, tool.input_schema);
+    }
+  }
+
+  const errors: ToolCallError[] = [];
+  for (const block of response.content) {
+    if (!isRecord(block) || block.type !== 'tool_use') continue;
+    const id = typeof block.id === 'string' ? block.id : '';
+    const name = typeof block.name === 'string' ? block.name : '';
+    if (!name) continue;
+    if (!checkKnownTool(knownToolNames, id, name, errors)) continue;
+    validateAgainstSchema(block.input, toolSchemaByName.get(name), id, name, errors);
+  }
+  return errors;
+}
+
+function detectSseErrors(lines: string[], request: GatewayRequest): ApiRequestLogError | null {
+  const events = lines.map(parseJsonLine).filter(value => value !== undefined);
+  const toolErrors =
+    request.kind === 'chat_completions'
+      ? detectChatCompletionSseErrors(lines, request.body.tools)
+      : request.kind === 'responses'
+        ? detectResponsesSseErrors(lines, request.body.tools)
+        : detectMessagesSseErrors(lines, request.body.tools);
+  return buildError(toolErrors, lastUpstreamError(events));
+}
+
+function detectJsonErrors(
   responseText: string,
   request: GatewayRequest
 ): ApiRequestLogError | null {
-  const lines = parseSseDataLines(responseText);
-  if (lines.length === 0) return null;
-
-  let errors: ToolCallError[];
+  let parsed: unknown;
   try {
-    if (request.kind === 'chat_completions') {
-      errors = detectChatCompletionSseErrors(lines, request.body.tools);
-    } else if (request.kind === 'responses') {
-      errors = detectResponsesSseErrors(lines, request.body.tools);
-    } else {
-      errors = detectMessagesSseErrors(lines, request.body.tools);
-    }
+    parsed = JSON.parse(responseText);
   } catch {
     return null;
   }
 
-  if (errors.length === 0) return null;
-  return { invalid_tool_call_arguments: errors };
+  const toolErrors =
+    request.kind === 'chat_completions'
+      ? detectChatCompletionJsonErrors(parsed, request.body.tools)
+      : request.kind === 'responses'
+        ? detectResponsesJsonErrors(parsed, request.body.tools)
+        : detectMessagesJsonErrors(parsed, request.body.tools);
+  return buildError(toolErrors, extractUpstreamError(parsed));
+}
+
+/**
+ * Extracts structured details for `api_request_log.error` from an upstream
+ * response body. Covers SSE and non-streamed JSON: invalid tool-call
+ * arguments and provider error objects.
+ */
+export function detectRequestLogErrors(
+  responseText: string,
+  request: GatewayRequest
+): ApiRequestLogError | null {
+  const lines = parseSseDataLines(responseText);
+  if (lines.length > 0) return detectSseErrors(lines, request);
+  return detectJsonErrors(responseText, request);
 }

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
@@ -1,7 +1,7 @@
 import { api_request_log, type User } from '@kilocode/db/schema';
 import { isKiloExclusiveFreeModel } from '@/lib/ai-gateway/models';
 import { getCustomPricing } from '@/lib/ai-gateway/custom-pricing';
-import { detectToolCallArgumentErrors } from '@/lib/ai-gateway/api-request-log-errors';
+import { detectRequestLogErrors } from '@/lib/ai-gateway/api-request-log-errors';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { ProviderId, ProviderResponseTransforms } from '@/lib/ai-gateway/providers/types';
 import { getOutputHeaders } from '@/lib/ai-gateway/llm-proxy-helpers';
@@ -118,15 +118,12 @@ async function createRequestLogCapture(
       );
     }
     try {
+      const detected =
+        responseText !== undefined ? detectRequestLogErrors(responseText, request) : null;
       const error =
-        responseText !== undefined
-          ? responseReadError !== undefined
-            ? {
-                ...(detectToolCallArgumentErrors(responseText, request) ?? {}),
-                response_body_read_error: responseReadError,
-              }
-            : detectToolCallArgumentErrors(responseText, request)
-          : { response_body_read_error: responseReadError };
+        responseReadError !== undefined
+          ? { ...(detected ?? {}), response_body_read_error: responseReadError }
+          : detected;
       const apiRequestLogId = await db
         .insert(api_request_log)
         .values({


### PR DESCRIPTION
## Summary

`api_request_log.error` previously only recorded SSE tool-call argument problems and response-body read failures. HTTP 4xx/5xx JSON bodies and SSE error events (often on HTTP 200) left `error` null, so the admin "errors only" filter missed them and the raw details stayed buried in `response`.

This change extracts structured details for more failure cases:

- Provider/upstream error objects from SSE events and non-streamed JSON bodies
- `response.failed` errors on the Responses API
- Tool-call argument errors on non-streamed JSON responses (chat completions, responses, and messages)
- Combined tool-call + upstream errors when a stream fails after emitting tool calls

SSE parsing no longer aborts the whole detector when one event is malformed or a chat error chunk omits `choices`.

## Verification

Not run locally; CI will validate the new detector tests.

## Visual Changes

N/A

## Reviewer Notes

Stored shape of new `api_request_log.error` rows may now include `upstream_error` in addition to `invalid_tool_call_arguments` and `response_body_read_error`. Existing rows are unchanged. `invalid_tool_call_arguments` is optional in the schema so read-error-only and upstream-error-only rows validate.
