### PR TITLE
fix(user-data-export): stop dropping per-page span attributes

### DIFF
--- a/services/user-data-export/src/span-attributes.test.ts
+++ b/services/user-data-export/src/span-attributes.test.ts
@@ -1,0 +1,46 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+/**
+ * Span attribute names are expanded into nested objects when they are exported, so
+ * `db.name` becomes `{ db: { name } }`. A key cannot be both a value and an object: when
+ * one attribute is a dotted prefix of another, the shorter key wins and the longer keys
+ * are dropped silently, with no error anywhere in the Worker.
+ *
+ * This bit us for real. `export_source_page` set a scalar at `export.page` next to
+ * `export.page.records`, `export.page.uncompressed_bytes`, and `export.page.has_more`,
+ * and the exported spans carried only `export.page`. The per-page record and byte counts
+ * were missing from every trace, which is precisely the data those spans exist to
+ * provide. Nothing failed; the attributes just were not there.
+ *
+ * Scanning source text is unusual for a unit test, but the failure is invisible to
+ * ordinary assertions: the Worker behaves correctly and only the telemetry is wrong.
+ */
+const SOURCE_FILES = ['worker.ts', 'databases.ts'];
+const ATTRIBUTE_PATTERN = /'((?:export|db)\.[a-z0-9_.]+)'/g;
+
+function spanAttributeKeys(): string[] {
+  return SOURCE_FILES.flatMap(file => {
+    const source = fs.readFileSync(path.join(__dirname, file), 'utf-8');
+    return [...source.matchAll(ATTRIBUTE_PATTERN)].map(match => match[1] as string);
+  });
+}
+
+describe('span attribute names', () => {
+  it('are discoverable, so the collision check below cannot pass vacuously', () => {
+    expect(new Set(spanAttributeKeys()).size).toBeGreaterThan(10);
+  });
+
+  it('never use a key that is a dotted prefix of another key', () => {
+    const keys = [...new Set(spanAttributeKeys())].sort();
+
+    const collisions = keys.flatMap(candidate =>
+      keys
+        .filter(other => other.startsWith(`${candidate}.`))
+        .map(other => `${candidate} would shadow ${other}`)
+    );
+
+    expect(collisions).toEqual([]);
+  });
+});

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -391,13 +391,18 @@ export async function processGenerateMessage(
       activeSource = adapter.name;
       // One span per page rather than per source: the loop advances cursors and adapters
       // with continue/break, so a per-source span cannot wrap it without restructuring
-      // the control flow. Group by the source attribute to get per-source totals. The
-      // nested postgres_read_page span splits read time from compress-and-write time.
+      // the control flow. Group by export.source to get per-source totals. The nested
+      // postgres_read_page span splits read time from compress-and-write time.
+      //
+      // Every key below stays a leaf under the export.page object. Setting a scalar at
+      // export.page alongside export.page.* silently loses the nested keys, because
+      // dotted attribute names are expanded into nested objects on export and a scalar
+      // cannot also be an object.
       const pageNumber = pageCount + 1;
       const pageLimit = adapter.pageSize ?? PAGE_SIZE;
       const page = await withSpan(
         'export_source_page',
-        { source: adapter.name, 'export.page': pageNumber },
+        { 'export.source': adapter.name, 'export.page.number': pageNumber },
         async span => {
           const result = await readPage({
             kiloUserId: job.kilo_user_id,
@@ -412,7 +417,10 @@ export async function processGenerateMessage(
             pageBytes += recordBytes.byteLength;
           }
           uncompressedSize += pageBytes;
-          span.setAttribute('export.page.rows', result.records.length);
+          // Records, not database rows: an adapter can fan one row out to several
+          // records, so this deliberately differs from db.response.returned_rows on the
+          // nested read span.
+          span.setAttribute('export.page.records', result.records.length);
           span.setAttribute('export.page.uncompressed_bytes', pageBytes);
           span.setAttribute('export.page.has_more', result.nextCursor !== null);
           return result;
@@ -554,9 +562,9 @@ export async function consumeExportBatch(
       await withSpan(
         'export_generate',
         {
-          exportId: parsed.data.exportId,
-          generation: parsed.data.generation,
-          attempt: message.attempts,
+          'export.id': parsed.data.exportId,
+          'export.generation': parsed.data.generation,
+          'export.attempt': message.attempts,
         },
         () => processMessage(env, parsed.data)
       );


### PR DESCRIPTION
Follow-up to #5199, which is merged and deployed. The first real exported trace confirms tracing works end to end, and also shows that one of the spans I added is losing most of its attributes.

## The bug

`export_source_page` sets a scalar at `export.page` and then three nested keys under it. Only the scalar survives export:

```json
{ "name": "export_source_page", "export": { "page": 22 }, "source": "microdollar_usage_metadata" }
```

`export.page.rows`, `export.page.uncompressed_bytes`, and `export.page.has_more` are all absent from every one of the 22 page spans in the trace. Dotted attribute names are expanded into nested objects, so `export.page` cannot be both a number and an object — the scalar wins and the nested keys are dropped silently. Nothing fails: the export completes normally and only the telemetry is wrong.

This is not a value-coercion problem. The same post-`await` `setAttribute` pattern works fine where no prefix collision exists — `export_claim` carries `export.claimed`, `export_multipart_attach` carries `export.attach_result`, and `export_state_update` carries `export.rows`, `export.size_bytes`, and `export.completion`. It is specifically the shadowed keys that vanish. I cannot tell from the outside whether the drop happens in Cloudflare's exporter or at Axiom ingestion; the fix is the same either way.

The lost keys are the ones that make the span worth having — per-page record and byte counts are what let you correlate page size against duration.

## Changes

- Every per-page key is now a leaf under the `export.page` object: `export.page.number`, `export.page.records`, `export.page.uncompressed_bytes`, `export.page.has_more`. No scalar sits at `export.page`.
- `export.page.rows` is renamed to `export.page.records` because it counts emitted records, not database rows. The trace proves these genuinely differ (see below), so sharing a name with `db.response.returned_rows` on the nested read span would be misleading.
- The remaining bare keys are namespaced: `source` → `export.source` (it was landing at `source.source` inside Axiom's own envelope), and `exportId`/`generation`/`attempt` → `export.id`/`export.generation`/`export.attempt`.
- A test fails when any attribute name is a dotted prefix of another. It scans source text, which is unusual, but this failure is invisible to ordinary assertions. I verified it catches the real thing by reintroducing the bug:

```
✗ never use a key that is a dotted prefix of another key
  + "export.page would shadow export.page.has_more",
  + "export.page would shadow export.page.records",
  + "export.page would shadow export.page.uncompressed_bytes",
```

`wrangler-config.test.ts` already asserts against config file text, so text-scanning tests have a precedent here.

## What the trace shows about the export itself

Every number below is from the single merged trace (`b91c7cc6aefb55d7d363a926706df772`, 22 pages, 17,420 records, 713 KB artifact).

| Segment | Time | Share of the 10,572 ms export |
|---|---|---|
| Postgres page reads (22 × `postgres_read_page`) | 9,219 ms | **87%** |
| ...of which connection setup (`postgres_connect`) | 3,113 ms | **29%** |
| `microdollar_usage_metadata` alone (17 of 22 pages) | 7,297 ms | 69% |
| R2 (create + 1 part + complete) | 840 ms | 8% |
| State writes (claim + attach + complete) | 501 ms | 5% |

- **The per-page connection churn is confirmed and now quantified.** 3.1 seconds of a 10.6-second export is spent opening 22 connections and issuing `BEGIN READ ONLY`. Connect settles at ~110–130 ms per page after the first few. Reusing one connection per binding should recover most of ~2.9 s. This is the follow-up flagged in #5199; still out of scope here.
- **Two sources with no data cost 822 ms.** `app_builder_projects` and `app_builder_messages` each returned 0 rows and each still cost ~410 ms of connect-plus-query.
- **The export is entirely I/O bound**: 911 ms CPU against 10,631 ms wall, 8.6%. This retroactively justifies skipping a compression span — gzip is not where the time goes.
- **The record/row gap is real and both numbers are correct.** `export.rows` reports 17,420 while the read spans sum to 17,125 database rows. The 295 difference is exactly `kilocode_users` fanning 1 row into 23 field records (+22) and `cli_sessions` fanning 91 rows into 364 records (+273). 23 + 364 + 497 + 16,536 = 17,420. That the two independently-instrumented counters reconcile to the row is a good sign the instrumentation is sound.

## A correction to #5199

I claimed Hyperdrive is not auto-instrumented. That is too strong. The runtime does emit a `hyperdrive_connect` span, which appears in the trace as a child of my `postgres_connect`. But it reports `0 ms` with no attributes, and there are no query-level spans, no row counts, and no usable timing. The custom spans are still what surface the 87%, so the conclusion holds even though the premise was imprecise. Cloudflare's spans-and-attributes docs do not list Hyperdrive at all, so the docs are incomplete here.

## Verification

- `tsgo --noEmit` clean
- `oxlint` — 0 warnings, 0 errors
- `vitest run` — 82 passed (2 new)
- `vitest run --config vitest.workers.config.ts` — 5 passed
- `oxfmt --list-different .` — no differences

Branched fresh off `main` and cherry-picked, since #5199 was squash-merged.

Confirming the attributes actually arrive needs another deploy plus one queue run; the local suites can only prove the keys no longer collide.