### PR TITLE
fix(ai-gateway): validate Custom LLM organization IDs

### DIFF
--- a/apps/web/src/lib/ai-gateway/custom-llm/access.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/access.test.ts
@@ -8,24 +8,28 @@ const definition: CustomLlmDefinition = {
   context_length: 128_000,
   max_completion_tokens: 4096,
   base_url: 'https://example.com/v1',
-  organization_ids: ['organization-1'],
+  organization_ids: ['00000000-0000-4000-8000-000000000101'],
   group_ids: ['00000000-0000-4000-8000-000000000001'],
 };
 
 describe('hasCustomLlmAccess', () => {
   it('allows organization-wide access without a matching group', () => {
-    expect(hasCustomLlmAccess(definition, 'organization-1', [])).toBe(true);
+    expect(hasCustomLlmAccess(definition, '00000000-0000-4000-8000-000000000101', [])).toBe(true);
   });
 
   it('allows access through a matching group when the organization is not allowed', () => {
     expect(
-      hasCustomLlmAccess(definition, 'organization-2', ['00000000-0000-4000-8000-000000000001'])
+      hasCustomLlmAccess(definition, '00000000-0000-4000-8000-000000000102', [
+        '00000000-0000-4000-8000-000000000001',
+      ])
     ).toBe(true);
   });
 
   it('denies access when neither the organization nor a group matches', () => {
     expect(
-      hasCustomLlmAccess(definition, 'organization-2', ['00000000-0000-4000-8000-000000000002'])
+      hasCustomLlmAccess(definition, '00000000-0000-4000-8000-000000000102', [
+        '00000000-0000-4000-8000-000000000002',
+      ])
     ).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts
@@ -32,7 +32,7 @@ const baseDefinition = {
   context_length: 1_000_000,
   max_completion_tokens: 65_536,
   base_url: 'https://us-central1-aiplatform.googleapis.com/v1',
-  organization_ids: ['org-1'],
+  organization_ids: ['00000000-0000-4000-8000-000000000001'],
 };
 
 describe('CustomLlmCredentialsSchema and CustomLlmDefinitionSchema', () => {
@@ -48,6 +48,15 @@ describe('CustomLlmCredentialsSchema and CustomLlmDefinitionSchema', () => {
 
   it('validates custom LLM definition without credentials', () => {
     expect(CustomLlmDefinitionSchema.safeParse(baseDefinition).success).toBe(true);
+  });
+
+  it('rejects non-UUID organization IDs', () => {
+    expect(
+      CustomLlmDefinitionSchema.safeParse({
+        ...baseDefinition,
+        organization_ids: ['organization-1'],
+      }).success
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/routers/admin/custom-llm-router.test.ts
+++ b/apps/web/src/routers/admin/custom-llm-router.test.ts
@@ -17,7 +17,7 @@ const validDefinition: CustomLlmDefinition = {
   context_length: 128000,
   max_completion_tokens: 4096,
   base_url: 'https://api.openai.com/v1',
-  organization_ids: ['org_test_123'],
+  organization_ids: ['00000000-0000-4000-8000-000000000100'],
   group_ids: ['00000000-0000-4000-8000-000000000123'],
 };
 

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1977,7 +1977,7 @@ export const CustomLlmDefinitionSchema = z.object({
   ...CustomLlmMetadataSchema.shape,
   ...CustomLlmApiConfigSchema.shape,
   display_name: z.string(),
-  organization_ids: z.array(z.string()),
+  organization_ids: z.array(z.uuid()),
   group_ids: z.array(z.uuid()).optional(),
   pricing: CustomLlmPricingSchema.optional(),
 });


### PR DESCRIPTION
## Summary
- require every Custom LLM `organization_ids` entry to be a UUID
- update existing fixtures to use valid organization UUIDs
- add regression coverage rejecting non-UUID organization IDs

## Validation
- `pnpm --filter @kilocode/db typecheck`
- `pnpm --filter web typecheck`
- `pnpm -w exec oxlint --config .oxlintrc.json packages/db/src/schema-types.ts apps/web/src/lib/ai-gateway/custom-llm/access.test.ts apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts apps/web/src/routers/admin/custom-llm-router.test.ts`
- `pnpm --filter web test --runInBand src/lib/ai-gateway/custom-llm/access.test.ts src/lib/ai-gateway/custom-llm/google-service-account.test.ts src/routers/admin/custom-llm-router.test.ts`
- `pnpm format:check`
- `git diff --check`