### PR TITLE
fix(kilo-pass): avoid stale seat subscriptions

### DIFF
--- a/apps/web/src/lib/kilo-pass-org/stripe-adapter.test.ts
+++ b/apps/web/src/lib/kilo-pass-org/stripe-adapter.test.ts
@@ -15,6 +15,7 @@ const invoicePaymentsList =
     (params: Stripe.InvoicePaymentListParams) => Promise<Stripe.ApiList<Stripe.InvoicePayment>>
   >();
 const select = jest.fn();
+const selectOrderBy = jest.fn();
 const updateDb = jest.fn();
 const updateSet = jest.fn();
 const activatePaidAgreement = jest.fn();
@@ -106,11 +107,12 @@ describe('organization Kilo Pass Stripe adapter', () => {
   beforeEach(() => {
     jest.resetAllMocks();
     const rows = [dbAgreement()];
+    selectOrderBy.mockReturnValue({ limit: async () => rows });
     select.mockReturnValue({
       from: () => ({
         where: () => ({
           limit: async () => rows,
-          orderBy: () => ({ limit: async () => rows }),
+          orderBy: selectOrderBy,
         }),
       }),
     });
@@ -342,6 +344,29 @@ describe('organization Kilo Pass Stripe adapter', () => {
       expand: ['data.payment.payment_intent'],
       limit: 10,
     });
+    expect(selectOrderBy).toHaveBeenCalledTimes(1);
+  });
+
+  test('rejects an ended seat subscription before creating a pending agreement', async () => {
+    retrieve.mockResolvedValue(
+      subscription({
+        status: 'canceled',
+        ended_at: 1_776_120_000,
+        items: { ...subscription().items, data: [subscription().items.data[0]!] },
+      })
+    );
+    const { createOrganizationKiloPassCheckout } = await import('./stripe-adapter');
+
+    await expect(
+      createOrganizationKiloPassCheckout({
+        organizationId: 'org_1',
+        actorUserId: 'user_1',
+        tier: 'tier_19',
+        allocations: [],
+      })
+    ).rejects.toThrow('An active organization seat subscription is required');
+    expect(createPendingAgreement).not.toHaveBeenCalled();
+    expect(update).not.toHaveBeenCalled();
   });
 
   test('does not request a browser action after a hard payment decline', async () => {
@@ -567,6 +592,30 @@ describe('organization Kilo Pass Stripe adapter', () => {
     expect(activatePaidAgreement).toHaveBeenCalledWith(
       expect.objectContaining({ agreementId: 'agreement_1' })
     );
+  });
+
+  test('ends a pending agreement when its seat subscription has ended without a pass invoice', async () => {
+    const rows = [{ id: 'agreement_1', providerSubscriptionId: 'sub_1' }];
+    select.mockReturnValue({
+      from: () => ({
+        where: () => ({ orderBy: () => ({ limit: async () => rows }) }),
+      }),
+    });
+    retrieve.mockResolvedValue(
+      subscription({
+        status: 'canceled',
+        ended_at: 1_776_120_000,
+        latest_invoice: {
+          status: 'paid',
+          parent: { subscription_details: { subscription: 'sub_1' } },
+          lines: { data: [] },
+        } as unknown as Stripe.Invoice,
+      })
+    );
+    const { reconcileOrganizationKiloPassPayment } = await import('./stripe-adapter');
+
+    await expect(reconcileOrganizationKiloPassPayment('org_1')).resolves.toBe(true);
+    expect(updateSet).toHaveBeenCalledWith({ state: 'ended' });
   });
 
   test('does not grant a supplement while payment review suspends issuance', async () => {

--- a/apps/web/src/lib/kilo-pass-org/stripe-adapter.ts
+++ b/apps/web/src/lib/kilo-pass-org/stripe-adapter.ts
@@ -98,9 +98,13 @@ export async function createOrganizationKiloPassCheckout(input: {
         eq(organization_seats_purchases.subscription_status, 'active')
       )
     )
+    .orderBy(desc(organization_seats_purchases.created_at))
     .limit(1);
   if (!purchase) throw new Error('An active organization seat subscription is required');
   const subscription = await stripe.subscriptions.retrieve(purchase.subscriptionId);
+  if (subscription.status !== 'active' || subscription.ended_at) {
+    throw new Error('An active organization seat subscription is required');
+  }
   const existingPassItem = subscription.items.data.find(item => !isSeatLineItem(item));
   if (existingPassItem) throw new Error('KILO_PASS_ORG_ALREADY_EXISTS');
   const seatItem = paidSeatItem(subscription);
@@ -302,7 +306,10 @@ export async function handleOrganizationKiloPassInvoicePaid(params: {
 /** Repairs a pending agreement when Stripe has already finalized its add-on invoice. */
 export async function reconcileOrganizationKiloPassPayment(organizationId: string) {
   const [agreement] = await db
-    .select({ providerSubscriptionId: kilo_pass_org_agreements.provider_subscription_id })
+    .select({
+      id: kilo_pass_org_agreements.id,
+      providerSubscriptionId: kilo_pass_org_agreements.provider_subscription_id,
+    })
     .from(kilo_pass_org_agreements)
     .where(
       and(
@@ -318,8 +325,22 @@ export async function reconcileOrganizationKiloPassPayment(organizationId: strin
     expand: ['latest_invoice'],
   });
   const invoice = subscription.latest_invoice;
-  if (!invoice || typeof invoice === 'string' || invoice.status !== 'paid') return false;
-  return handleOrganizationKiloPassInvoicePaid({ invoice });
+  if (invoice && typeof invoice !== 'string' && invoice.status === 'paid') {
+    const activated = await handleOrganizationKiloPassInvoicePaid({ invoice });
+    if (activated) return true;
+  }
+  if (subscription.status !== 'canceled' && !subscription.ended_at) return false;
+
+  await db
+    .update(kilo_pass_org_agreements)
+    .set({ state: KiloPassOrgAgreementState.Ended })
+    .where(
+      and(
+        eq(kilo_pass_org_agreements.id, agreement.id),
+        eq(kilo_pass_org_agreements.state, KiloPassOrgAgreementState.PendingPayment)
+      )
+    );
+  return true;
 }
 
 /** Keep the paid seat subscription alive while removing only its Kilo Pass add-on at renewal. */


### PR DESCRIPTION
## Root cause
The seat-purchase table is append-only, so historical rows can remain marked `active` after a later row records that the provider subscription ended. Checkout selected an arbitrary `active` row, attempted to update an ended Stripe subscription, and had already saved a pending agreement before Stripe rejected the request. This left the agreement stuck in `pending_payment`.

The fix selects the newest active seat record, verifies that Stripe still considers the subscription active before persisting an agreement, and ends previously stranded pending agreements during reconciliation when their provider subscription has ended.

## Summary
- select the newest active organization seat purchase during Kilo Pass checkout
- reject provider subscriptions that have already ended before persisting a pending agreement
- close stranded pending agreements during reconciliation when their provider subscription has ended

## Testing
- `pnpm --filter web test -- --runInBand src/lib/kilo-pass-org/stripe-adapter.test.ts`
- `pnpm --filter web typecheck`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/kilo-pass-org/stripe-adapter.ts apps/web/src/lib/kilo-pass-org/stripe-adapter.test.ts`
- `pnpm exec oxfmt --list-different apps/web/src/lib/kilo-pass-org/stripe-adapter.ts apps/web/src/lib/kilo-pass-org/stripe-adapter.test.ts`
- `git diff --check`