### PR TITLE
chore(ai-gateway): run sync-providers every 5 minutes

### DIFF
--- a/apps/web/src/app/api/cron/sync-providers/route.test.ts
+++ b/apps/web/src/app/api/cron/sync-providers/route.test.ts
@@ -22,8 +22,8 @@ const mockEmitScheduledJobEvent = jest.mocked(emitScheduledJobEvent);
 describe('GET /api/cron/sync-providers', () => {
   beforeEach(() => jest.clearAllMocks());
 
-  it('exports maxDuration of 8 minutes (480 seconds)', () => {
-    expect(maxDuration).toBe(480);
+  it('exports maxDuration of 4 minutes (240 seconds)', () => {
+    expect(maxDuration).toBe(240);
   });
 
   it('emits one event at the cron boundary with aggregate provider counts', async () => {

--- a/apps/web/src/app/api/cron/sync-providers/route.ts
+++ b/apps/web/src/app/api/cron/sync-providers/route.ts
@@ -9,9 +9,9 @@ import {
 import { CRON_SECRET } from '@/lib/config.server';
 import { syncAndStoreProviders } from '@/lib/ai-gateway/providers/openrouter/sync-providers';
 
-// The cron job runs every 10 minutes, so if increasing the timeout beyond 8 minutes
+// The cron job runs every 5 minutes, so if increasing the timeout beyond 4 minutes
 // becomes necessary, the cron schedule in vercel.json should probably be adjusted as well.
-export const maxDuration = 480;
+export const maxDuration = 240;
 
 export async function GET(request: NextRequest) {
   const authHeader = request.headers.get('authorization');

--- a/apps/web/vercel.json
+++ b/apps/web/vercel.json
@@ -6,7 +6,7 @@
     },
     {
       "path": "/api/cron/sync-providers",
-      "schedule": "*/10 * * * *"
+      "schedule": "*/5 * * * *"
     },
     {
       "path": "/api/cron/cleanup-device-auth",


### PR DESCRIPTION
## Summary

Run the sync-providers cron every 5 minutes instead of 10, and lower the route `maxDuration` from 8 minutes to 4 minutes so a slow run cannot overlap the next scheduled invocation.

## Verification

- [ ] Did not run the Jest suite in this environment: the route unit test requires PostgreSQL via the shared worker setup, and Docker is not available here.

## Visual Changes

N/A

## Reviewer Notes

Timeout is 4 minutes (`maxDuration = 240`) so it stays under the new 5-minute cadence.