### PR TITLE
fix(ai-gateway): include models with no endpoints in Redis id lists

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.test.ts
@@ -1,6 +1,35 @@
 import { describe, expect, it } from '@jest/globals';
-import { extractVercelInferenceProviderIdsFromModel } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import {
+  extractVercelInferenceProviderIdsFromModel,
+  getLanguageModelIds,
+} from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { StoredModel } from '@kilocode/db';
+
+function storedModel(partial: Partial<StoredModel> & Pick<StoredModel, 'id'>): StoredModel {
+  return {
+    name: partial.id,
+    endpoints: [{ provider_name: 'test' }],
+    ...partial,
+  };
+}
+
+describe('getLanguageModelIds', () => {
+  it('includes language models even when they have no endpoints', () => {
+    expect(
+      getLanguageModelIds({
+        'vendor/with-endpoints': storedModel({ id: 'vendor/with-endpoints' }),
+        'vendor/no-endpoints': storedModel({ id: 'vendor/no-endpoints', endpoints: [] }),
+        'vendor/untyped': storedModel({ id: 'vendor/untyped', type: undefined, endpoints: [] }),
+        'vendor/embedding': storedModel({
+          id: 'vendor/embedding',
+          type: 'embedding',
+          endpoints: [],
+        }),
+        'vendor/image': storedModel({ id: 'vendor/image', type: 'image' }),
+      })
+    ).toEqual(['vendor/with-endpoints', 'vendor/no-endpoints', 'vendor/untyped']);
+  });
+});
 
 describe('extractVercelInferenceProviderIdsFromModel', () => {
   it('builds a deduplicated plain provider list for a model', () => {

--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
@@ -41,13 +41,13 @@ export const getOpenRouterModelsMetadataFromDatabase = createStoredModelsFromDat
 );
 
 /**
- * The ids of language models that have at least one endpoint. This is the list
- * mirrored to the lightweight `*-model-ids` Redis keys so existence checks can
- * avoid loading the full model catalog.
+ * The ids of language models, including those with no endpoints. This is the
+ * list mirrored to the lightweight `*-model-ids` Redis keys so existence checks
+ * can avoid loading the full model catalog.
  */
 export function getLanguageModelIds(models: StoredModelMap): string[] {
   return Object.values(models)
-    .filter(model => (model.type ?? 'language') === 'language' && model.endpoints.length > 0)
+    .filter(model => (model.type ?? 'language') === 'language')
     .map(model => model.id);
 }
 


### PR DESCRIPTION
## Summary

Provider sync currently omits OpenRouter and Vercel language models from the lightweight Redis `*-model-ids` lists when they have an empty endpoints array. Existence checks then treat those models as unknown.

Include language model IDs in those Redis lists even when they have no endpoints. Embedding and image models are still excluded.

## Verification

- [ ] No manual verification in this environment: Docker/Postgres were unavailable, so the web Jest suite could not run. Targeted `oxlint` on the changed files passed.
- [ ]

## Visual Changes

N/A

## Reviewer Notes

`getLanguageModelIds` is what `mirrorToRedis` writes to `openrouter-model-ids` and `vercel-model-ids`. Downstream existence checks (`getOpenRouterModelsFromRedis`, `getVercelModelsFromRedis`) will now return true for language models with empty endpoint lists.