### PR TITLE
feat(ai-gateway): add custom LLM Gemini reasoning transform

### DIFF
--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
@@ -170,6 +170,20 @@ describe('buildDirectProvider Gemini reasoning transform', () => {
     expect(request.body).not.toHaveProperty('stream');
   });
 
+  it('does not send an invalid Gemini thinking_level when reasoning_effort is none', async () => {
+    const request = makeRequest();
+    request.body.reasoning_effort = 'none';
+
+    await transformRequest(request, {
+      use_gemini_reasoning_transform: true,
+      extra_body: { google: { existing: true } },
+    });
+
+    const body = request.body as typeof request.body & { google?: Record<string, unknown> };
+    expect(body.google).toEqual({ existing: true });
+    expect(body).not.toHaveProperty('reasoning_effort');
+  });
+
   it('still sets thinking_config when reasoning_effort is absent', async () => {
     const request = makeRequest();
 

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
@@ -8,7 +8,12 @@ type ChatCompletionRequest = Extract<GatewayRequest, { kind: 'chat_completions' 
 
 async function transformRequest(
   request: GatewayRequest,
-  options: { sanitize_ref_fields?: boolean; thought_signature_mapping?: string } = {}
+  options: {
+    sanitize_ref_fields?: boolean;
+    use_gemini_reasoning_transform?: boolean;
+    extra_body?: Record<string, unknown>;
+    remove_from_body?: string[];
+  } = {}
 ) {
   const provider = buildDirectProvider('custom', ['chat_completions'], {
     internal_id: 'upstream-model',
@@ -66,71 +71,37 @@ function makeRequest(): ChatCompletionRequest {
   return request;
 }
 
-describe('custom LLM thought signature mapping configuration', () => {
+describe('custom LLM Gemini reasoning transform configuration', () => {
   const config = {
     internal_id: 'upstream-model',
     base_url: 'https://llm.example.com/v1',
   };
 
-  it('accepts a dot-separated property path', () => {
+  it('accepts the Gemini reasoning transform flag', () => {
     expect(
       CustomLlmApiConfigSchema.safeParse({
         ...config,
-        thought_signature_mapping: 'extra_content.provider.thought_signature',
+        use_gemini_reasoning_transform: true,
       }).success
     ).toBe(true);
   });
-
-  it.each(['', 'extra_content..thought_signature', '__proto__.thought_signature'])(
-    'rejects unsafe property path %p',
-    thought_signature_mapping => {
-      expect(
-        CustomLlmApiConfigSchema.safeParse({ ...config, thought_signature_mapping }).success
-      ).toBe(false);
-    }
-  );
-});
-
-describe('custom LLM thought content mapping configuration', () => {
-  const config = {
-    internal_id: 'upstream-model',
-    base_url: 'https://llm.example.com/v1',
-  };
-
-  it('accepts a dot-separated property path', () => {
-    expect(
-      CustomLlmApiConfigSchema.safeParse({
-        ...config,
-        thought_content_mapping: 'extra_content.flags.thought',
-      }).success
-    ).toBe(true);
-  });
-
-  it.each(['', 'extra_content..thought', 'constructor.prototype.thought'])(
-    'rejects unsafe property path %p',
-    thought_content_mapping => {
-      expect(
-        CustomLlmApiConfigSchema.safeParse({ ...config, thought_content_mapping }).success
-      ).toBe(false);
-    }
-  );
 });
 
 describe('buildDirectProvider response transforms', () => {
-  it('exposes the thought content property path without other upstream configuration', () => {
+  it('exposes the Gemini thought content path when the transform is enabled', () => {
     const provider = buildDirectProvider('custom', ['chat_completions'], {
       internal_id: 'upstream-model',
       base_url: 'https://llm.example.com/v1',
       api_key: 'test-key',
-      thought_content_mapping: 'extra_content.flags.thought',
+      use_gemini_reasoning_transform: true,
     });
 
     expect(provider.responseTransforms).toEqual({
-      thoughtContentMapping: 'extra_content.flags.thought',
+      thoughtContentMapping: 'extra_content.google.thought',
     });
   });
 
-  it('sets response transforms to null when no mapping is configured', () => {
+  it('sets response transforms to null when the transform is not enabled', () => {
     const provider = buildDirectProvider('custom', ['chat_completions'], {
       internal_id: 'upstream-model',
       base_url: 'https://llm.example.com/v1',
@@ -141,12 +112,12 @@ describe('buildDirectProvider response transforms', () => {
   });
 });
 
-describe('buildDirectProvider thought signature mapping', () => {
+describe('buildDirectProvider Gemini reasoning transform', () => {
   it('maps assistant tool-call signatures and removes camel-case transport fields', async () => {
     const request = makeRequest();
 
     await transformRequest(request, {
-      thought_signature_mapping: 'extra_content.provider.thought_signature',
+      use_gemini_reasoning_transform: true,
     });
 
     expect(request.body.model).toBe('upstream-model');
@@ -161,7 +132,7 @@ describe('buildDirectProvider thought signature mapping', () => {
             function: { name: 'lookup', arguments: '{}' },
             extra_content: {
               trace_id: 'trace-1',
-              provider: { thought_signature: 'assistant-signature' },
+              google: { thought_signature: 'assistant-signature' },
             },
           },
         ],
@@ -174,7 +145,47 @@ describe('buildDirectProvider thought signature mapping', () => {
     ]);
   });
 
-  it('preserves signatures when no mapping is configured', async () => {
+  it('moves reasoning_effort into google.thinking_config and keeps extra_body', async () => {
+    const request = makeRequest();
+    request.body.reasoning_effort = 'high';
+
+    await transformRequest(request, {
+      use_gemini_reasoning_transform: true,
+      extra_body: { temperature: 0.2, google: { existing: true } },
+      remove_from_body: ['stream'],
+    });
+
+    expect(request.body).toMatchObject({
+      model: 'upstream-model',
+      temperature: 0.2,
+      google: {
+        existing: true,
+        thinking_config: {
+          thinking_level: 'high',
+          include_thoughts: true,
+        },
+      },
+    });
+    expect(request.body).not.toHaveProperty('reasoning_effort');
+    expect(request.body).not.toHaveProperty('stream');
+  });
+
+  it('still sets thinking_config when reasoning_effort is absent', async () => {
+    const request = makeRequest();
+
+    await transformRequest(request, { use_gemini_reasoning_transform: true });
+
+    expect(request.body).toMatchObject({
+      google: {
+        thinking_config: {
+          include_thoughts: true,
+        },
+      },
+    });
+    expect(request.body).not.toHaveProperty('reasoning_effort');
+  });
+
+  it('preserves signatures when the transform is not enabled', async () => {
     const request = makeRequest();
 
     await transformRequest(request);

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
@@ -83,11 +83,11 @@ function applyGeminiReasoningTransform(context: TransformRequestContext, reasoni
     return;
   }
 
-  const body = context.request.body as Record<string, unknown>;
-  delete body.reasoning_effort;
+  const extra = context.request.body as typeof context.request.body & { google?: unknown };
+  delete extra.reasoning_effort;
 
-  const existingGoogle = isRecord(body.google) ? body.google : {};
-  body.google = {
+  const existingGoogle = isRecord(extra.google) ? extra.google : {};
+  extra.google = {
     ...existingGoogle,
     thinking_config: {
       ...(reasoningEffort !== undefined ? { thinking_level: reasoningEffort } : {}),

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
@@ -86,14 +86,16 @@ function applyGeminiReasoningTransform(context: TransformRequestContext, reasoni
   const extra = context.request.body as typeof context.request.body & { google?: unknown };
   delete extra.reasoning_effort;
 
-  const existingGoogle = isRecord(extra.google) ? extra.google : {};
-  extra.google = {
-    ...existingGoogle,
-    thinking_config: {
-      ...(reasoningEffort !== undefined ? { thinking_level: reasoningEffort } : {}),
-      include_thoughts: true,
-    },
-  };
+  if (reasoningEffort !== 'none') {
+    const existingGoogle = isRecord(extra.google) ? extra.google : {};
+    extra.google = {
+      ...existingGoogle,
+      thinking_config: {
+        ...(reasoningEffort !== undefined ? { thinking_level: reasoningEffort } : {}),
+        include_thoughts: true,
+      },
+    };
+  }
 
   mapGeminiThoughtSignatures(context);
 }

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
@@ -45,7 +45,10 @@ function setPropertyPath(target: Record<string, unknown>, path: string, value: s
   current[finalSegment] = value;
 }
 
-function mapThoughtSignatures(context: TransformRequestContext, path: string) {
+const GEMINI_THOUGHT_CONTENT_MAPPING = 'extra_content.google.thought';
+const GEMINI_THOUGHT_SIGNATURE_MAPPING = 'extra_content.google.thought_signature';
+
+function mapGeminiThoughtSignatures(context: TransformRequestContext) {
   if (context.request.kind !== 'chat_completions') {
     return;
   }
@@ -69,10 +72,30 @@ function mapThoughtSignatures(context: TransformRequestContext, path: string) {
       const signature = toolCall.thoughtSignature;
       delete toolCall.thoughtSignature;
       if (typeof signature === 'string') {
-        setPropertyPath(toolCall, path, signature);
+        setPropertyPath(toolCall, GEMINI_THOUGHT_SIGNATURE_MAPPING, signature);
       }
     }
   }
+}
+
+function applyGeminiReasoningTransform(context: TransformRequestContext, reasoningEffort: unknown) {
+  if (context.request.kind !== 'chat_completions') {
+    return;
+  }
+
+  const body = context.request.body as Record<string, unknown>;
+  delete body.reasoning_effort;
+
+  const existingGoogle = isRecord(body.google) ? body.google : {};
+  body.google = {
+    ...existingGoogle,
+    thinking_config: {
+      ...(reasoningEffort !== undefined ? { thinking_level: reasoningEffort } : {}),
+      include_thoughts: true,
+    },
+  };
+
+  mapGeminiThoughtSignatures(context);
 }
 
 function renameJsonRefProperties(value: unknown): boolean {
@@ -151,10 +174,16 @@ export function buildDirectProvider(
     apiUrl: upstream.base_url,
     apiKey: upstream.api_key,
     supportedChatApis,
-    responseTransforms: upstream.thought_content_mapping
-      ? { thoughtContentMapping: upstream.thought_content_mapping }
+    responseTransforms: upstream.use_gemini_reasoning_transform
+      ? { thoughtContentMapping: GEMINI_THOUGHT_CONTENT_MAPPING }
       : null,
     async transformRequest(context) {
+      const useGeminiReasoning = Boolean(upstream.use_gemini_reasoning_transform);
+      const reasoningEffort =
+        useGeminiReasoning && context.request.kind === 'chat_completions'
+          ? context.request.body.reasoning_effort
+          : undefined;
+
       if (upstream.remove_from_body) {
         const body = context.request.body as Record<string, unknown>;
         for (const key of upstream.remove_from_body) {
@@ -169,8 +198,8 @@ export function buildDirectProvider(
       if (upstream.add_cache_breakpoints) {
         addCacheBreakpoints(context.request);
       }
-      if (upstream.thought_signature_mapping) {
-        mapThoughtSignatures(context, upstream.thought_signature_mapping);
+      if (useGeminiReasoning) {
+        applyGeminiReasoningTransform(context, reasoningEffort);
       }
       if (upstream.sanitize_ref_fields) {
         sanitizeJsonRefToolResults(context);

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -1915,20 +1915,6 @@ export const CustomLlmMetadataSchema = z.object({
 
 export type CustomLlmMetadata = z.infer<typeof CustomLlmMetadataSchema>;
 
-const CustomLlmPropertyPathSchema = z
-  .string()
-  .min(1)
-  .refine(
-    path =>
-      path
-        .split('.')
-        .every(
-          segment =>
-            segment.length > 0 && !['__proto__', 'constructor', 'prototype'].includes(segment)
-        ),
-    'Must be a dot-separated property path'
-  );
-
 export const CustomLlmApiConfigSchema = z.object({
   internal_id: z.string().min(1),
   base_url: z.url(),
@@ -1937,8 +1923,7 @@ export const CustomLlmApiConfigSchema = z.object({
   extra_headers: CustomLlmExtraHeadersSchema.optional(),
   extra_body: CustomLlmExtraBodySchema.optional(),
   remove_from_body: z.array(z.string()).optional(),
-  thought_signature_mapping: CustomLlmPropertyPathSchema.optional(),
-  thought_content_mapping: CustomLlmPropertyPathSchema.optional(),
+  use_gemini_reasoning_transform: z.boolean().optional(),
 });
 
 export type CustomLlmApiConfig = z.infer<typeof CustomLlmApiConfigSchema>;


### PR DESCRIPTION
## Summary

Adds `use_gemini_reasoning_transform` to custom LLM / experiment upstream config and removes the generic `thought_content_mapping` and `thought_signature_mapping` fields.

When the flag is set, chat completions now behave as if this were configured:

- `extra_body.google.thinking_config.thinking_level` is taken from the request `reasoning_effort`
- `extra_body.google.thinking_config.include_thoughts` is `true`
- `reasoning_effort` is removed from the upstream body
- thought content is read from `extra_content.google.thought`
- tool-call thought signatures are written to `extra_content.google.thought_signature`

Existing `extra_body` and `remove_from_body` values are still applied. No back-compat for the removed mapping fields.

## Verification

- [x] Unit tests updated in `build-direct-provider.test.ts` (CI will run them)

## Visual Changes

N/A

## Reviewer Notes

Only chat completions are transformed. Messages / Responses requests ignore the Gemini-specific body and signature mapping.