### PR TITLE
fix(ai-gateway): reject unknown OpenRouter model ids

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -5,7 +5,10 @@ import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage
 import { classifyAbuse } from '@/lib/ai-gateway/abuse-service';
 import { getProvider } from '@/lib/ai-gateway/providers/get-provider';
 import { upstreamRequest } from '@/lib/ai-gateway/providers/upstream-request';
-import { getOpenRouterModelsFromRedis } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import {
+  getOpenRouterModelsFromRedis,
+  isValidOpenRouterModelId,
+} from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { emitApiMetricsForResponse } from '@/lib/ai-gateway/o11y/api-metrics.server';
 import { accountForMicrodollarUsage } from '@/lib/ai-gateway/llm-proxy-helpers';
 import { redisClient } from '@/lib/redis';
@@ -116,6 +119,7 @@ const mockedClassifyAbuse = jest.mocked(classifyAbuse);
 const mockedGetProvider = jest.mocked(getProvider);
 const mockedUpstreamRequest = jest.mocked(upstreamRequest);
 const mockedGetOpenRouterModels = jest.mocked(getOpenRouterModelsFromRedis);
+const mockedIsValidOpenRouterModelId = jest.mocked(isValidOpenRouterModelId);
 const mockedEmitApiMetricsForResponse = jest.mocked(emitApiMetricsForResponse);
 const mockedAccountForMicrodollarUsage = jest.mocked(accountForMicrodollarUsage);
 const mockedRedisGet = jest.mocked(redisClient.get);
@@ -227,6 +231,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
     mockedGetOpenRouterModels.mockResolvedValue(new Set(['stepfun/step-3.7-flash:free']));
+    mockedIsValidOpenRouterModelId.mockResolvedValue(true);
     mockedUpstreamRequest.mockResolvedValue({
       type: 'success',
       response: upstreamJsonResponse({ id: 'chatcmpl-1', model: 'openai/gpt-4o', choices: [] }),
@@ -323,6 +328,20 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect(response.status).toBe(200);
     expect(mockedGetBalanceAndOrgSettings).toHaveBeenCalledTimes(1);
     expect(mockedGetBalanceAndOrgSettings.mock.calls[0]?.[2]).toBe(readDb);
+  });
+
+  it('returns 404 when the OpenRouter model id is unknown', async () => {
+    mockedIsValidOpenRouterModelId.mockResolvedValue(false);
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('not-a-real-model')) as never);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error_type: 'model_not_found',
+      message: expect.stringContaining("The requested model 'not-a-real-model' does not exist."),
+    });
+    expect(mockedUpstreamRequest).not.toHaveBeenCalled();
   });
 
   it('rate limits rules-engine rate-limit actions before upstream', async () => {
@@ -550,6 +569,7 @@ describe('kilo-auto/efficient classifier billing', () => {
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
     mockedGetOpenRouterModels.mockResolvedValue(new Set());
+    mockedIsValidOpenRouterModelId.mockResolvedValue(true);
     mockedUpstreamRequest.mockResolvedValue({
       type: 'success',
       response: upstreamJsonResponse({
@@ -898,6 +918,7 @@ describe('auto-routing shadow classifier', () => {
     mockedRedisGet.mockResolvedValue(null);
     mockedRedisSet.mockResolvedValue('OK');
     mockedGetOpenRouterModels.mockResolvedValue(new Set());
+    mockedIsValidOpenRouterModelId.mockResolvedValue(true);
     mockedUpstreamRequest.mockResolvedValue({
       type: 'success',
       response: upstreamJsonResponse({ id: 'chatcmpl-1', model: 'openai/gpt-4o', choices: [] }),

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -50,6 +50,7 @@ import {
   storeAndPreviousResponseIdIsNotSupported,
   apiKindNotSupportedResponse,
   checkExclusiveModelProviderAllowed,
+  modelDoesNotExistOnOpenRouterResponse,
 } from '@/lib/ai-gateway/llm-proxy-helpers';
 import { ProxyErrorType } from '@/lib/proxy-error-types';
 import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage';
@@ -114,6 +115,7 @@ import {
   evaluateEffectiveModelAccessPolicy,
   getEffectiveModelDecision,
 } from '@/lib/organizations/effective-model-access.server';
+import { isValidOpenRouterModelId } from '@/lib/ai-gateway/providers/gateway-models-cache';
 
 export const maxDuration = 800;
 
@@ -902,6 +904,13 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     usageContext.session_id,
     taskId ?? null
   );
+
+  if (
+    effectiveProviderContext.provider.id === 'openrouter' &&
+    !(await isValidOpenRouterModelId(requestBodyParsed.body.model))
+  ) {
+    return modelDoesNotExistOnOpenRouterResponse(effectiveModelIdLowerCased);
+  }
 
   const toolsAvailable = getToolsAvailable(requestBodyParsed);
   const toolsUsed = getToolsUsed(requestBodyParsed);

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -322,6 +322,22 @@ export function modelDoesNotExistResponse() {
   );
 }
 
+export function modelDoesNotExistOnOpenRouterResponse(model: string) {
+  const error =
+    `The requested model '${model}' does not exist. ` +
+    `Please use an exact model id as listed on /api/gateway/models. ` +
+    `If this is a newly released model, please try again in a few minutes.`;
+  errorExceptInTest(`[modelDoesNotExistOnOpenRouterResponse] ${error}`);
+  return NextResponse.json(
+    {
+      error,
+      error_type: ProxyErrorType.model_not_found,
+      message: error,
+    },
+    { status: 404 }
+  );
+}
+
 export function noFreeModelsAvailableResponse() {
   const error = `No free models are currently available for ${KILO_AUTO_FREE_MODEL.id}. Please try again later, or switch to ${KILO_AUTO_BALANCED_MODEL.id} for affordable paid inference.`;
   return NextResponse.json(

--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.test.ts
@@ -1,4 +1,9 @@
-import { describe, expect, it } from '@jest/globals';
+import { describe, expect, it, jest } from '@jest/globals';
+
+jest.mock('@/lib/redis', () => ({
+  redisClient: { get: jest.fn() },
+}));
+
 import {
   extractVercelInferenceProviderIdsFromModel,
   getLanguageModelIds,
@@ -45,5 +50,46 @@ describe('extractVercelInferenceProviderIdsFromModel', () => {
     };
 
     expect(extractVercelInferenceProviderIdsFromModel(model)).toEqual(['anthropic', 'bedrock']);
+  });
+});
+
+describe('isValidOpenRouterModelId', () => {
+  async function loadValidator() {
+    jest.resetModules();
+    const { isValidOpenRouterModelId } =
+      await import('@/lib/ai-gateway/providers/gateway-models-cache');
+    const { redisClient: freshRedisClient } = await import('@/lib/redis');
+    return {
+      isValidOpenRouterModelId,
+      redisGet: jest.mocked(freshRedisClient.get),
+    };
+  }
+
+  it('accepts known legacy aliases without consulting Redis', async () => {
+    const { isValidOpenRouterModelId, redisGet } = await loadValidator();
+
+    await expect(isValidOpenRouterModelId('gpt-4o')).resolves.toBe(true);
+    expect(redisGet).not.toHaveBeenCalled();
+  });
+
+  it('accepts ids present in the Redis catalog', async () => {
+    const { isValidOpenRouterModelId, redisGet } = await loadValidator();
+    redisGet.mockResolvedValue(JSON.stringify(['openai/gpt-4o']));
+
+    await expect(isValidOpenRouterModelId('openai/gpt-4o')).resolves.toBe(true);
+  });
+
+  it('rejects ids missing from a non-empty Redis catalog', async () => {
+    const { isValidOpenRouterModelId, redisGet } = await loadValidator();
+    redisGet.mockResolvedValue(JSON.stringify(['openai/gpt-4o']));
+
+    await expect(isValidOpenRouterModelId('not-a-real-model')).resolves.toBe(false);
+  });
+
+  it('fails open when Redis has no model ids', async () => {
+    const { isValidOpenRouterModelId, redisGet } = await loadValidator();
+    redisGet.mockResolvedValue(null);
+
+    await expect(isValidOpenRouterModelId('not-a-real-model')).resolves.toBe(true);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
@@ -6,10 +6,13 @@ import { createCachedFetch } from '@/lib/cached-fetch';
 import { GATEWAY_METADATA_REDIS_KEYS, vercelInferenceProvidersRedisKey } from '@/lib/redis-keys';
 import type { RedisKey } from '@/lib/redis-keys';
 import { readDb } from '@/lib/drizzle';
+import { warnExceptInTest } from '@/lib/utils.server';
 
 export type StoredModelMap = Record<string, StoredModel>;
 
 const StoredModelMapSchema = z.record(z.string(), StoredModelSchema);
+
+const TTL_MS = 300_000;
 
 function createStoredModelsFromDatabaseFetcher(provider: 'openrouter' | 'vercel', name: string) {
   return createCachedFetch<StoredModelMap>(
@@ -25,7 +28,7 @@ function createStoredModelsFromDatabaseFetcher(provider: 'openrouter' | 'vercel'
       }
       return StoredModelMapSchema.parse(row.models);
     },
-    600_000,
+    TTL_MS,
     {}
   );
 }
@@ -75,7 +78,7 @@ export function getCachedVercelInferenceProviderIdsForModel(
         }
         return VercelInferenceProvidersSchema.parse(JSON.parse(raw));
       },
-      600_000,
+      TTL_MS,
       null
     );
     vercelInferenceProviderFetchers.set(modelId, fetchProviders);
@@ -96,7 +99,7 @@ function createModelIdsFetcher(redisKey: RedisKey, name: string) {
       }
       return new Set(ModelIdsSchema.parse(raw));
     },
-    600_000,
+    TTL_MS,
     new Set<string>()
   );
 }
@@ -110,3 +113,93 @@ export const getOpenRouterModelsFromRedis = createModelIdsFetcher(
   GATEWAY_METADATA_REDIS_KEYS.openrouterModelIds,
   'OpenRouter'
 );
+
+// These are (undocumented?) aliases OpenRouter accepts and were in use around 2026-08-11
+// Preferably do not add entries here, instead have the user use the documented id from the /models catalog
+const legacyOpenRouterAliases: ReadonlySet<string> = new Set([
+  'anthropic/claude-haiku-4-5',
+  'anthropic/claude-opus-4-6',
+  'anthropic/claude-sonnet-4-5',
+  'anthropic/claude-sonnet-4-6',
+  'anthropic/claude-sonnet-5-20260630',
+  'claude-fable-5',
+  'claude-haiku-4.5',
+  'claude-haiku-4-5-20251001',
+  'claude-opus-4-8',
+  'claude-opus-5',
+  'claude-sonnet-4',
+  'claude-sonnet-4.5',
+  'claude-sonnet-5',
+  'codex-auto-review',
+  'deepseek-v4-flash',
+  'deepseek-v4-flash-0731',
+  'deepseek-v4-pro',
+  'gemini-2.5-flash',
+  'gemini-2.5-flash-lite',
+  'gemini-2.5-pro',
+  'gemini-3-pro-image',
+  'gemma-4-26b-a4b-it',
+  'gemma-4-31b-it',
+  'glm-4.7-flash',
+  'glm-5.1',
+  'glm-5.2',
+  'gpt-3.5-turbo',
+  'gpt-3.5-turbo-16k',
+  'gpt-4.1',
+  'gpt-4.1-mini',
+  'gpt-4o',
+  'gpt-4o-2024-08-06',
+  'gpt-4o-mini',
+  'gpt-4o-mini-2024-07-18',
+  'gpt-5.1',
+  'gpt-5.1-codex',
+  'gpt-5.1-codex-max',
+  'gpt-5.1-codex-mini',
+  'gpt-5.2',
+  'gpt-5.2-codex',
+  'gpt-5.2-pro',
+  'gpt-5.3-codex',
+  'gpt-5.4',
+  'gpt-5.4-mini',
+  'gpt-5.4-nano',
+  'gpt-5.4-pro',
+  'gpt-5.5',
+  'gpt-5.6-luna',
+  'gpt-5.6-luna-pro',
+  'gpt-5.6-sol',
+  'gpt-5.6-terra',
+  'gpt-5-nano',
+  'gpt-5-pro',
+  'gpt-oss-20b',
+  'gpt-oss-safeguard-20b',
+  'hy3',
+  'kimi-k2.6',
+  'kimi-k3',
+  'laguna-s-2.1',
+  'laguna-xs-2.1',
+  'mimo-v2.5',
+  'minimax-m2.5',
+  'minimax-m3',
+  'minimax/minimax-m2.5-20260211',
+  'o1-pro',
+  'o3-pro',
+  'openai/gpt-4o-mini-transcribe',
+  'openai/gpt-4o-transcribe',
+  'openai/gpt-5.3-chat',
+  'qwen3.8-max',
+  'step-3.5-flash',
+]);
+
+export async function isValidOpenRouterModelId(modelId: string): Promise<boolean> {
+  if (legacyOpenRouterAliases.has(modelId)) {
+    return true;
+  }
+  const openRouterModelIds = await getOpenRouterModelsFromRedis();
+  if (openRouterModelIds.size === 0) {
+    warnExceptInTest(
+      '[isValidOpenRouterModelId] no model metadata available, assuming id is valid'
+    );
+    return true;
+  }
+  return openRouterModelIds.has(modelId);
+}


### PR DESCRIPTION
## Summary

Unknown or misspelled OpenRouter model ids currently reach the upstream provider. Reject them at the gateway with a 404 that points at `/api/gateway/models`.

- Check the requested id against the Redis OpenRouter catalog before the upstream call.
- Allow a fixed set of undocumented aliases that were already in use.
- Fail open if Redis has no model ids, so a cache outage does not block inference.
- Align in-process catalog cache TTL with the 5-minute provider sync interval.

## Verification

- [x] `oxfmt` on the three changed files
- [x] `oxlint` on the three changed files (0 warnings, 0 errors)
- [ ] No Jest run in this environment (unit tests for `isValidOpenRouterModelId` are not added)

## Visual Changes

N/A

## Reviewer Notes

Validation runs only when the effective provider is OpenRouter. The error uses `effectiveModelIdLowerCased` in the message and `requestBodyParsed.body.model` for the catalog lookup so aliases match the original requested id.