### PR TITLE
fix(ai-gateway): skip Vercel routing for Kimi models

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -27,6 +27,7 @@ import {
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { isKimiModel } from '@/lib/ai-gateway/providers/moonshotai';
 
 type VercelRoutingPercentages = {
   paid: number;
@@ -96,6 +97,11 @@ export async function shouldRouteToVercel(
 ) {
   // BYOK in the Vercel AI Gateway was not working for Laguna models.
   if (requestedModel.includes('laguna')) {
+    return false;
+  }
+
+  if (isKimiModel(requestedModel)) {
+    // 2026-08-12: K3 is timing out during review, let's see if this fixes it.
     return false;
   }
 


### PR DESCRIPTION
## Summary

- Skip Vercel AI Gateway routing for Kimi models so they stay on OpenRouter.
- Temporary workaround while K3 times out during review on Vercel.

## Test plan

- [ ] Request a Kimi/K3 model and confirm it is not routed to Vercel.
- [ ] Confirm non-Kimi models still follow the existing Vercel/OpenRouter percentage split.