### PR TITLE
fix(ai-gateway): allow Laguna models on Vercel routing

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -95,11 +95,6 @@ export async function shouldRouteToVercel(
   request: GatewayRequest,
   randomSeed: string
 ) {
-  // BYOK in the Vercel AI Gateway was not working for Laguna models.
-  if (requestedModel.includes('laguna')) {
-    return false;
-  }
-
   if (isKimiModel(requestedModel)) {
     // 2026-08-12: K3 is timing out during review, let's see if this fixes it.
     return false;


### PR DESCRIPTION
## Summary
- Stop excluding Laguna models from Vercel AI Gateway routing.
- The previous skip existed because BYOK was broken for those models.

## Test plan
- [ ] Request a Laguna model through the AI gateway and confirm it can route to Vercel when other conditions match.
- [ ] Confirm Kimi models still skip Vercel routing.