### PR TITLE
feat(web): serve /usage analytics from Postgres replica

### DIFF
--- a/apps/web/src/routers/usage-analytics-router.test.ts
+++ b/apps/web/src/routers/usage-analytics-router.test.ts
@@ -1,5 +1,6 @@
 jest.mock('@/lib/redis', () => ({ redisClient: {} }));
 
+import { PgDialect } from 'drizzle-orm/pg-core';
 import {
   CostSourceSchema,
   MAX_SCOPE_ORGANIZATION_IDS,
@@ -21,26 +22,38 @@ const PARENT_ORG = '11111111-1111-4111-8111-111111111111';
 const CHILD_ORG_A = '22222222-2222-4222-8222-222222222222';
 const CHILD_ORG_B = '33333333-3333-4333-8333-333333333333';
 
+const dialect = new PgDialect();
+
+function compile(builder: WhereBuilder) {
+  const sql = builder.toSQL();
+  if (!sql) return { sql: '', params: [] as unknown[] };
+  const compiled = dialect.sqlToQuery(sql);
+  return { sql: compiled.sql, params: compiled.params };
+}
+
 function scopeSql(rawFilters: Record<string, unknown>) {
   const filters = UsageAnalyticsFiltersSchema.parse({ ...baseFilters, ...rawFilters });
   const where = new WhereBuilder();
   buildScopeConditions(where, filters, CTX_USER);
-  return { sql: where.sql(), bindings: where.bindings.map(b => b.value) };
+  return compile(where);
 }
 
 describe('usage analytics cost source', () => {
   it('defaults to billable cost for existing clients', () => {
     expect(UsageAnalyticsFiltersSchema.parse(baseFilters).costSource).toBe('cost');
-    expect(costColumnFor('cost')).toBe('total_cost_microdollars');
-    expect(costSumExprSql('cost')).toBe('COALESCE(SUM(total_cost_microdollars), 0)');
+    expect(dialect.sqlToQuery(costColumnFor('cost')).sql).toContain('cost');
+    expect(dialect.sqlToQuery(costSumExprSql('cost')).sql).toMatch(/COALESCE\(SUM\(/);
+    expect(dialect.sqlToQuery(costSumExprSql('cost')).sql).toContain('cost');
+    expect(dialect.sqlToQuery(costSumExprSql('cost')).sql).not.toContain('market_cost');
   });
 
-  it('uses the estimated market cost rollup when selected', () => {
+  it('uses the estimated market cost when selected', () => {
     expect(
       UsageAnalyticsFiltersSchema.parse({ ...baseFilters, costSource: 'market' }).costSource
     ).toBe('market');
-    expect(costColumnFor('market')).toBe('total_market_cost_microdollars');
-    expect(costSumExprSql('market')).toBe('COALESCE(SUM(total_market_cost_microdollars), 0)');
+    expect(dialect.sqlToQuery(costColumnFor('market')).sql).toContain('market_cost');
+    expect(dialect.sqlToQuery(costSumExprSql('market')).sql).toMatch(/COALESCE\(SUM\(/);
+    expect(dialect.sqlToQuery(costSumExprSql('market')).sql).toContain('market_cost');
   });
 
   it('rejects arbitrary cost source values', () => {
@@ -52,53 +65,62 @@ describe('usage analytics cost source', () => {
 
 describe('usage analytics scope conditions', () => {
   it('pins a single org to the caller in self view', () => {
-    const { sql, bindings } = scopeSql({ organizationId: PARENT_ORG, viewAs: 'self' });
-    expect(sql).toContain('organization_id = ?');
-    expect(sql).toContain('kilo_user_id = ?');
-    expect(bindings).toEqual([PARENT_ORG, CTX_USER]);
+    const { sql, params } = scopeSql({ organizationId: PARENT_ORG, viewAs: 'self' });
+    expect(sql).toContain('organization_id');
+    expect(sql).toContain('kilo_user_id');
+    expect(sql).not.toContain('IS NULL');
+    expect(params).toEqual([PARENT_ORG, CTX_USER]);
   });
 
   it('does not pin to the caller in org-wide view', () => {
-    const { sql, bindings } = scopeSql({ organizationId: PARENT_ORG, viewAs: 'org-wide' });
-    expect(sql).toContain('organization_id = ?');
+    const { sql, params } = scopeSql({ organizationId: PARENT_ORG, viewAs: 'org-wide' });
+    expect(sql).toContain('organization_id');
     expect(sql).not.toContain('kilo_user_id');
-    expect(bindings).toEqual([PARENT_ORG]);
+    expect(params).toEqual([PARENT_ORG]);
   });
 
   it('aggregates org-wide across all orgs when organizationIds is set', () => {
-    const { sql, bindings } = scopeSql({
+    const { sql, params } = scopeSql({
       organizationIds: [PARENT_ORG, CHILD_ORG_A, CHILD_ORG_B],
     });
-    expect(sql).toContain('organization_id IN (?, ?, ?)');
+    expect(sql).toContain('organization_id');
+    expect(sql).toMatch(/in/i);
     expect(sql).not.toContain('kilo_user_id');
-    expect(bindings).toEqual([PARENT_ORG, CHILD_ORG_A, CHILD_ORG_B]);
+    expect(params).toEqual([PARENT_ORG, CHILD_ORG_A, CHILD_ORG_B]);
   });
 
   it('honors explicit user filters in the all-orgs aggregate', () => {
-    const { sql, bindings } = scopeSql({
+    const { sql, params } = scopeSql({
       organizationIds: [PARENT_ORG, CHILD_ORG_A],
       userIds: [CTX_USER],
     });
-    expect(sql).toContain('organization_id IN (?, ?)');
-    expect(sql).toContain('kilo_user_id IN (?)');
-    expect(bindings).toEqual([PARENT_ORG, CHILD_ORG_A, CTX_USER]);
+    expect(sql).toContain('organization_id');
+    expect(sql).toContain('kilo_user_id');
+    expect(params).toEqual([PARENT_ORG, CHILD_ORG_A, CTX_USER]);
   });
 
   it('takes precedence over a single organizationId', () => {
-    const { sql, bindings } = scopeSql({
+    const { sql, params } = scopeSql({
       organizationId: CHILD_ORG_B,
       organizationIds: [PARENT_ORG, CHILD_ORG_A],
     });
-    expect(sql).toContain('organization_id IN (?, ?)');
-    expect(bindings).toEqual([PARENT_ORG, CHILD_ORG_A]);
+    expect(sql).toContain('organization_id');
+    expect(params).toEqual([PARENT_ORG, CHILD_ORG_A]);
   });
 
   it('falls back to personal scope with no org', () => {
-    const { sql, bindings } = scopeSql({});
-    expect(sql).toContain('kilo_user_id = ?');
-    expect(sql).toContain('organization_id = ?');
-    // personal-only pins kilo_user_id to caller and org to the empty-string sentinel
-    expect(bindings).toEqual([CTX_USER, '']);
+    const { sql, params } = scopeSql({});
+    expect(sql).toContain('kilo_user_id');
+    expect(sql).toContain('organization_id');
+    expect(sql).toContain('IS NULL');
+    expect(params).toEqual([CTX_USER]);
+  });
+
+  it('includes org-attributed rows when personalScope is include-orgs', () => {
+    const { sql, params } = scopeSql({ personalScope: 'include-orgs' });
+    expect(sql).toContain('kilo_user_id');
+    expect(sql).not.toContain('organization_id');
+    expect(params).toEqual([CTX_USER]);
   });
 
   it('caps organizationIds at the boundary to bound auth fan-out', () => {

--- a/apps/web/src/routers/usage-analytics-router.test.ts
+++ b/apps/web/src/routers/usage-analytics-router.test.ts
@@ -112,7 +112,7 @@ describe('usage analytics scope conditions', () => {
     const { sql, params } = scopeSql({});
     expect(sql).toContain('kilo_user_id');
     expect(sql).toContain('organization_id');
-    expect(sql).toContain('IS NULL');
+    expect(sql).toMatch(/is null/i);
     expect(params).toEqual([CTX_USER]);
   });
 

--- a/apps/web/src/routers/usage-analytics-router.test.ts
+++ b/apps/web/src/routers/usage-analytics-router.test.ts
@@ -112,6 +112,7 @@ describe('usage analytics scope conditions', () => {
     const { sql, params } = scopeSql({});
     expect(sql).toContain('kilo_user_id');
     expect(sql).toContain('organization_id');
+    // personal-only pins kilo_user_id to caller and organization_id IS NULL
     expect(sql).toMatch(/is null/i);
     expect(params).toEqual([CTX_USER]);
   });

--- a/apps/web/src/routers/usage-analytics-router.ts
+++ b/apps/web/src/routers/usage-analytics-router.ts
@@ -63,10 +63,15 @@ export type {
   UsageAnalyticsFilters,
 } from '@/routers/usage-analytics-schemas';
 
+// ---------------------------------------------------------------------------
+// Table / tier resolution
+// ---------------------------------------------------------------------------
+
 type GranularityTier = 'hourly' | 'daily' | 'monthly';
 
 type TableMeta = {
   tier: GranularityTier;
+  /** Effective granularity after auto-downgrade (may differ from requested). */
   effectiveGranularity: Granularity;
 };
 
@@ -76,12 +81,13 @@ function resolveTier(granularity: Granularity, startDate: string): TableMeta {
   const ageDays = (now - startMs) / (24 * 60 * 60 * 1000);
 
   if (granularity === 'hour') {
-    // Keep the previous 7-day hourly window so a 30d/1y "hour" request does
-    // not emit tens of thousands of buckets. periodToDateRange('7d') snaps to
-    // UTC midnight, so ageDays can be up to ~7.99.
+    // Use < 8 rather than <= 7: periodToDateRange('7d') snaps the start to
+    // UTC midnight, so ageDays can be up to ~7.99 for a genuine "past week"
+    // request. The < 8 threshold keeps all 7-day windows in the hourly tier.
     if (ageDays < 8) {
       return { tier: 'hourly', effectiveGranularity: 'hour' };
     }
+    // Auto-downgrade: hourly buckets are only used for the past 7 days.
     return { tier: 'daily', effectiveGranularity: 'day' };
   }
 
@@ -92,6 +98,14 @@ function resolveTier(granularity: Granularity, startDate: string): TableMeta {
   return { tier: 'monthly', effectiveGranularity: 'month' };
 }
 
+// ---------------------------------------------------------------------------
+// SQL WHERE clause builder
+// ---------------------------------------------------------------------------
+
+/**
+ * Accumulates SQL WHERE clauses. Callers push conditions in any order;
+ * `toSQL()` joins them with AND.
+ */
 export class WhereBuilder {
   readonly conditions: SQL[] = [];
 
@@ -104,6 +118,11 @@ export class WhereBuilder {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Authorization
+// ---------------------------------------------------------------------------
+
+/** True when the filters target one or more organizations (vs personal usage). */
 function isOrgScope(filters: UsageAnalyticsFilters): boolean {
   return Boolean(filters.organizationId) || (filters.organizationIds?.length ?? 0) > 0;
 }
@@ -111,6 +130,12 @@ function isOrgScope(filters: UsageAnalyticsFilters): boolean {
 async function ensureScopeAccess(ctx: TRPCContext, filters: UsageAnalyticsFilters): Promise<void> {
   const userId = ctx.user.id;
 
+  // Multi-org aggregate ("All Organizations"): always org-wide, and the caller
+  // must be owner/billing_manager of every org in the list. A parent owner has
+  // inherited owner/billing access to children, so this passes for the parent
+  // plus all of its children while rejecting any org they cannot administer.
+  // Batched into a fixed number of queries so a large org list cannot fan out
+  // into one authorization query per id.
   if (filters.organizationIds && filters.organizationIds.length > 0) {
     await ensureOrganizationsAccess(ctx, filters.organizationIds, ORGANIZATION_BILLING_ROLES);
     return;
@@ -141,6 +166,10 @@ async function ensureScopeAccess(ctx: TRPCContext, filters: UsageAnalyticsFilter
   }
 }
 
+// ---------------------------------------------------------------------------
+// WHERE clause helpers
+// ---------------------------------------------------------------------------
+
 function buildDateConditions(where: WhereBuilder, filters: UsageAnalyticsFilters): void {
   where.add(gte(microdollar_usage.created_at, filters.startDate));
   where.add(lt(microdollar_usage.created_at, filters.endDate));
@@ -152,6 +181,8 @@ export function buildScopeConditions(
   ctxUserId: string
 ): void {
   if (filters.organizationIds && filters.organizationIds.length > 0) {
+    // Aggregate across the parent org and its children. Always org-wide, so
+    // honor any explicit user include/exclude filters but never pin to self.
     where.add(inArray(microdollar_usage.organization_id, filters.organizationIds));
     if (filters.userIds && filters.userIds.length > 0) {
       where.add(inArray(microdollar_usage.kilo_user_id, filters.userIds));
@@ -176,6 +207,7 @@ export function buildScopeConditions(
   } else {
     where.add(eq(microdollar_usage.kilo_user_id, ctxUserId));
     if (filters.personalScope === 'personal-only') {
+      // Personal usage is stored with a NULL organization_id.
       where.add(isNull(microdollar_usage.organization_id));
     }
   }
@@ -235,6 +267,10 @@ function buildWhereClause(
   return where;
 }
 
+// ---------------------------------------------------------------------------
+// Metric SQL expression
+// ---------------------------------------------------------------------------
+
 export function costColumnFor(costSource: CostSource): SQL<number> {
   switch (costSource) {
     case 'cost':
@@ -293,6 +329,19 @@ function metricExprSql(metric: Metric, costSource: CostSource): SQL<number> {
   }
 }
 
+// ---------------------------------------------------------------------------
+// Bucket expression for timeseries / table grouping
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns a SQL expression that formats the time column as a string bucket,
+ * matching the granularity the caller requested.
+ *
+ * Hourly  → 'YYYY-MM-DD HH24:MI:SS'  (matches what Postgres timestamp::text returns)
+ * Day     → 'YYYY-MM-DD'
+ * Week    → 'YYYY-MM-DD' of the Monday-aligned week start
+ * Month   → 'YYYY-MM-DD' of the first of the month
+ */
 function bucketExprSql(effectiveGranularity: Granularity): SQL<string> {
   const createdAtUtc = sql`${microdollar_usage.created_at} AT TIME ZONE 'UTC'`;
   if (effectiveGranularity === 'hour') {
@@ -304,8 +353,13 @@ function bucketExprSql(effectiveGranularity: Granularity): SQL<string> {
   if (effectiveGranularity === 'month') {
     return sql<string>`TO_CHAR(DATE_TRUNC('month', ${createdAtUtc}), 'YYYY-MM-DD')`;
   }
+  // 'day'
   return sql<string>`TO_CHAR(DATE_TRUNC('day', ${createdAtUtc}), 'YYYY-MM-DD')`;
 }
+
+// ---------------------------------------------------------------------------
+// Dimension column name
+// ---------------------------------------------------------------------------
 
 function dimensionColumn(dimension: Dimension): SQL<string> {
   switch (dimension) {
@@ -328,11 +382,20 @@ const usageMetadataJoin = eq(microdollar_usage.id, microdollar_usage_metadata.id
 const usageFeatureJoin = eq(microdollar_usage_metadata.feature_id, feature.feature_id);
 const usageModeJoin = eq(microdollar_usage_metadata.mode_id, mode.mode_id);
 
+// ---------------------------------------------------------------------------
+// getSummary
+// ---------------------------------------------------------------------------
+
 function ratioSafe(numerator: number, denominator: number): number {
   if (denominator === 0) return 0;
   return numerator / denominator;
 }
 
+/**
+ * Convert an aggregate value (often returned as a string by Postgres) to a
+ * JS number. Values above `MAX_SAFE_INTEGER` are logged as a warning but still
+ * returned so the UI does not crash.
+ */
 function toSafeNumber(value: unknown): number {
   const n = Number(value);
   if (!Number.isFinite(n)) return 0;
@@ -343,6 +406,10 @@ function toSafeNumber(value: unknown): number {
   }
   return n;
 }
+
+// ---------------------------------------------------------------------------
+// User list (for org context)
+// ---------------------------------------------------------------------------
 
 const MAX_USER_LABEL_LOOKUP_IDS = 1_000;
 
@@ -361,6 +428,10 @@ const UserListOutputSchema = z.object({
   ),
 });
 
+// ---------------------------------------------------------------------------
+// Scope organizations (org usage page Scope selector)
+// ---------------------------------------------------------------------------
+
 const ScopeOrganizationsInputSchema = z.object({
   organizationId: z.uuid(),
 });
@@ -373,6 +444,7 @@ const ScopeOrganizationSchema = z.object({
 const ScopeOrganizationsOutputSchema = z.object({
   organizationId: z.string(),
   organizationName: z.string(),
+  /** Direct child organizations, sorted by name. Empty when not a parent org. */
   children: z.array(ScopeOrganizationSchema),
 });
 
@@ -414,6 +486,10 @@ function queryScope(input: UsageAnalyticsFilters): 'org' | 'user' {
 function queryPeriod(input: UsageAnalyticsFilters): string {
   return `${input.startDate}/${input.endDate}`;
 }
+
+// ---------------------------------------------------------------------------
+// Router definition
+// ---------------------------------------------------------------------------
 
 export const usageAnalyticsRouter = createTRPCRouter({
   getSummary: baseProcedure
@@ -591,6 +667,8 @@ export const usageAnalyticsRouter = createTRPCRouter({
       );
 
       const values = rows.map(row => ({ key: row.key ?? '', value: toSafeNumber(row.value) }));
+      // Percentages are relative to the *returned* rows (limited by input.limit).
+      // They will not reflect the true share when the result set is capped.
       const totalValue = values.reduce((s, r) => s + r.value, 0);
 
       return {
@@ -616,6 +694,8 @@ export const usageAnalyticsRouter = createTRPCRouter({
       const where = buildWhereClause(input, ctx.user.id, true);
       const requestedDims = input.groupBy;
 
+      // For dimensions not in groupBy, emit an empty string constant so the
+      // row shape stays stable regardless of which dimensions were requested.
       const featExpr = requestedDims.includes('feature') ? featureName : sql<string>`''`;
       const modelExpr = requestedDims.includes('model') ? modelName : sql<string>`''`;
       const modeExpr = requestedDims.includes('mode') ? modeName : sql<string>`''`;
@@ -625,6 +705,7 @@ export const usageAnalyticsRouter = createTRPCRouter({
       const providerExpr = requestedDims.includes('provider') ? providerName : sql<string>`''`;
       const projectExpr = requestedDims.includes('project') ? projectName : sql<string>`''`;
 
+      // GROUP BY columns: bucket + each requested dimension column
       const dimGroupBy = requestedDims.map(d => dimensionColumn(d));
       const groupByClause = [bucketExpr, ...dimGroupBy];
 
@@ -716,6 +797,8 @@ export const usageAnalyticsRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Organization not found' });
       }
 
+      // Exclude soft-deleted children so they never appear in the scope list or
+      // get folded into the All Organizations aggregate.
       const children = await readDb
         .select({ id: organizations.id, name: organizations.name })
         .from(organizations)
@@ -756,6 +839,7 @@ export const usageAnalyticsRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       const accessByOrg = await getOrganizationsAccessRoles(ctx, input.organizationIds);
 
+      // Require access to every requested org (mirrors the single-org guard).
       const hasAccessToAll = input.organizationIds.every(orgId => accessByOrg.has(orgId));
       if (!hasAccessToAll) {
         throw new TRPCError({
@@ -764,6 +848,8 @@ export const usageAnalyticsRouter = createTRPCRouter({
         });
       }
 
+      // Only owner/billing_manager of *every* requested org may resolve other
+      // members; anyone else can resolve only their own id.
       const canSeeAllMembers = input.organizationIds.every(orgId => {
         const role = accessByOrg.get(orgId);
         return role === 'owner' || role === 'billing_manager';

--- a/apps/web/src/routers/usage-analytics-router.ts
+++ b/apps/web/src/routers/usage-analytics-router.ts
@@ -1,16 +1,15 @@
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
-import { and, asc, eq, inArray, isNull, or } from 'drizzle-orm';
+import { and, asc, eq, gte, inArray, isNull, lt, notInArray, or, sql, type SQL } from 'drizzle-orm';
 import { baseProcedure, createTRPCRouter, type TRPCContext } from '@/lib/trpc/init';
 import { readDb } from '@/lib/drizzle';
-import { getEnvVariable } from '@/lib/dotenvx';
+import { timedUsageQuery } from '@/lib/usage-query';
 import {
-  executeSnowflakeStatement,
-  resolveSnowflakeConfig,
-  type SnowflakeBinding,
-} from '@/lib/snowflake';
-import {
+  feature,
   kilocode_users,
+  microdollar_usage,
+  microdollar_usage_metadata,
+  mode,
   organization_memberships,
   organizations,
   user_auth_provider,
@@ -64,15 +63,10 @@ export type {
   UsageAnalyticsFilters,
 } from '@/routers/usage-analytics-schemas';
 
-// ---------------------------------------------------------------------------
-// Table / tier resolution
-// ---------------------------------------------------------------------------
-
 type GranularityTier = 'hourly' | 'daily' | 'monthly';
 
 type TableMeta = {
   tier: GranularityTier;
-  /** Effective granularity after auto-downgrade (may differ from requested). */
   effectiveGranularity: Granularity;
 };
 
@@ -82,132 +76,34 @@ function resolveTier(granularity: Granularity, startDate: string): TableMeta {
   const ageDays = (now - startMs) / (24 * 60 * 60 * 1000);
 
   if (granularity === 'hour') {
-    // Use < 8 rather than <= 7: periodToDateRange('7d') snaps the start to
-    // UTC midnight, so ageDays can be up to ~7.99 for a genuine "past week"
-    // request. The < 8 threshold keeps all 7-day windows in the hourly tier.
+    // Keep the previous 7-day hourly window so a 30d/1y "hour" request does
+    // not emit tens of thousands of buckets. periodToDateRange('7d') snaps to
+    // UTC midnight, so ageDays can be up to ~7.99.
     if (ageDays < 8) {
       return { tier: 'hourly', effectiveGranularity: 'hour' };
     }
-    // Auto-downgrade: hourly data is only available for the past 7 days.
     return { tier: 'daily', effectiveGranularity: 'day' };
   }
 
   if (granularity === 'day' || granularity === 'week') {
-    // MICRODOLLAR_USAGE_DAILY holds full history — no age-based downgrade needed.
     return { tier: 'daily', effectiveGranularity: granularity };
   }
 
   return { tier: 'monthly', effectiveGranularity: 'month' };
 }
 
-/**
- * Returns the Snowflake table name for a given tier.
- * Both daily and monthly tiers use MICRODOLLAR_USAGE_DAILY; monthly queries
- * add a DATE_TRUNC('MONTH', usage_day) bucket expression on top.
- */
-function getTableName(tier: GranularityTier): string {
-  return tier === 'hourly' ? 'MICRODOLLAR_USAGE_HOURLY' : 'MICRODOLLAR_USAGE_DAILY';
-}
-
-/** The column that holds the time value for a given tier. */
-function getTimeColumn(tier: GranularityTier): string {
-  return tier === 'hourly' ? 'usage_hour' : 'usage_date';
-}
-
-// ---------------------------------------------------------------------------
-// Date helpers
-// ---------------------------------------------------------------------------
-
-function ceilIsoToUtcDayExclusive(iso: string): string {
-  const d = new Date(iso);
-  const dayStartMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
-  if (d.getTime() === dayStartMs) {
-    return iso.slice(0, 10);
-  }
-  return new Date(dayStartMs + 86_400_000).toISOString().slice(0, 10);
-}
-
-function floorIsoToUtcMonth(iso: string): string {
-  return `${iso.slice(0, 7)}-01`;
-}
-
-function ceilIsoToUtcMonthExclusive(iso: string): string {
-  const d = new Date(iso);
-  const firstOfMonthMs = Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), 1);
-  if (d.getTime() === firstOfMonthMs) {
-    return iso.slice(0, 10);
-  }
-  const next = new Date(Date.UTC(d.getUTCFullYear(), d.getUTCMonth() + 1, 1));
-  return next.toISOString().slice(0, 10);
-}
-
-// ---------------------------------------------------------------------------
-// SQL WHERE clause builder
-// ---------------------------------------------------------------------------
-
-/**
- * Accumulates SQL WHERE clauses with positional `?` bindings.
- * Callers push conditions in any order; `sql()` joins them with AND.
- */
 export class WhereBuilder {
-  readonly clauses: string[] = [];
-  readonly bindings: SnowflakeBinding[] = [];
+  readonly conditions: SQL[] = [];
 
-  private push(clause: string, ...bindings: SnowflakeBinding[]) {
-    bindings.forEach(b => this.bindings.push(b));
-    this.clauses.push(clause);
+  add(condition: SQL): void {
+    this.conditions.push(condition);
   }
 
-  addTimestampRange(column: string, gte: string, lt: string): void {
-    this.push(
-      `${column} >= ? AND ${column} < ?`,
-      { type: 'TEXT', value: gte },
-      { type: 'TEXT', value: lt }
-    );
-  }
-
-  addDateRange(column: string, gte: string, lt: string): void {
-    this.push(
-      `${column} >= ? AND ${column} < ?`,
-      { type: 'TEXT', value: gte },
-      { type: 'TEXT', value: lt }
-    );
-  }
-
-  addEq(column: string, value: string): void {
-    this.push(`${column} = ?`, { type: 'TEXT', value });
-  }
-
-  addIsNull(column: string): void {
-    this.clauses.push(`${column} IS NULL`);
-  }
-
-  addIn(column: string, values: string[]): void {
-    const placeholders = values.map(() => '?').join(', ');
-    this.push(
-      `${column} IN (${placeholders})`,
-      ...values.map(v => ({ type: 'TEXT' as const, value: v }))
-    );
-  }
-
-  addNotIn(column: string, values: string[]): void {
-    const placeholders = values.map(() => '?').join(', ');
-    this.push(
-      `${column} NOT IN (${placeholders})`,
-      ...values.map(v => ({ type: 'TEXT' as const, value: v }))
-    );
-  }
-
-  sql(): string {
-    return this.clauses.length > 0 ? this.clauses.join('\n  AND ') : '1=1';
+  toSQL(): SQL | undefined {
+    return this.conditions.length > 0 ? and(...this.conditions) : undefined;
   }
 }
 
-// ---------------------------------------------------------------------------
-// Authorization
-// ---------------------------------------------------------------------------
-
-/** True when the filters target one or more organizations (vs personal usage). */
 function isOrgScope(filters: UsageAnalyticsFilters): boolean {
   return Boolean(filters.organizationId) || (filters.organizationIds?.length ?? 0) > 0;
 }
@@ -215,12 +111,6 @@ function isOrgScope(filters: UsageAnalyticsFilters): boolean {
 async function ensureScopeAccess(ctx: TRPCContext, filters: UsageAnalyticsFilters): Promise<void> {
   const userId = ctx.user.id;
 
-  // Multi-org aggregate ("All Organizations"): always org-wide, and the caller
-  // must be owner/billing_manager of every org in the list. A parent owner has
-  // inherited owner/billing access to children, so this passes for the parent
-  // plus all of its children while rejecting any org they cannot administer.
-  // Batched into a fixed number of queries so a large org list cannot fan out
-  // into one authorization query per id.
   if (filters.organizationIds && filters.organizationIds.length > 0) {
     await ensureOrganizationsAccess(ctx, filters.organizationIds, ORGANIZATION_BILLING_ROLES);
     return;
@@ -251,33 +141,9 @@ async function ensureScopeAccess(ctx: TRPCContext, filters: UsageAnalyticsFilter
   }
 }
 
-// ---------------------------------------------------------------------------
-// WHERE clause helpers
-// ---------------------------------------------------------------------------
-
-function buildDateConditions(
-  where: WhereBuilder,
-  tier: GranularityTier,
-  filters: UsageAnalyticsFilters
-): void {
-  const timeCol = getTimeColumn(tier);
-
-  if (tier === 'hourly') {
-    where.addTimestampRange(timeCol, filters.startDate, filters.endDate);
-  } else if (tier === 'daily') {
-    where.addDateRange(
-      timeCol,
-      filters.startDate.slice(0, 10),
-      ceilIsoToUtcDayExclusive(filters.endDate)
-    );
-  } else {
-    // monthly — daily table, filter by day boundaries aligned to month
-    where.addDateRange(
-      timeCol,
-      floorIsoToUtcMonth(filters.startDate),
-      ceilIsoToUtcMonthExclusive(filters.endDate)
-    );
-  }
+function buildDateConditions(where: WhereBuilder, filters: UsageAnalyticsFilters): void {
+  where.add(gte(microdollar_usage.created_at, filters.startDate));
+  where.add(lt(microdollar_usage.created_at, filters.endDate));
 }
 
 export function buildScopeConditions(
@@ -286,67 +152,82 @@ export function buildScopeConditions(
   ctxUserId: string
 ): void {
   if (filters.organizationIds && filters.organizationIds.length > 0) {
-    // Aggregate across the parent org and its children. Always org-wide, so
-    // honor any explicit user include/exclude filters but never pin to self.
-    where.addIn('organization_id', filters.organizationIds);
+    where.add(inArray(microdollar_usage.organization_id, filters.organizationIds));
     if (filters.userIds && filters.userIds.length > 0) {
-      where.addIn('kilo_user_id', filters.userIds);
+      where.add(inArray(microdollar_usage.kilo_user_id, filters.userIds));
     }
     if (filters.excludedUserIds && filters.excludedUserIds.length > 0) {
-      where.addNotIn('kilo_user_id', filters.excludedUserIds);
+      where.add(notInArray(microdollar_usage.kilo_user_id, filters.excludedUserIds));
     }
     return;
   }
   if (filters.organizationId) {
-    where.addEq('organization_id', filters.organizationId);
+    where.add(eq(microdollar_usage.organization_id, filters.organizationId));
     if (filters.viewAs === 'self') {
-      where.addEq('kilo_user_id', ctxUserId);
+      where.add(eq(microdollar_usage.kilo_user_id, ctxUserId));
     } else {
       if (filters.userIds && filters.userIds.length > 0) {
-        where.addIn('kilo_user_id', filters.userIds);
+        where.add(inArray(microdollar_usage.kilo_user_id, filters.userIds));
       }
       if (filters.excludedUserIds && filters.excludedUserIds.length > 0) {
-        where.addNotIn('kilo_user_id', filters.excludedUserIds);
+        where.add(notInArray(microdollar_usage.kilo_user_id, filters.excludedUserIds));
       }
     }
   } else {
-    where.addEq('kilo_user_id', ctxUserId);
+    where.add(eq(microdollar_usage.kilo_user_id, ctxUserId));
     if (filters.personalScope === 'personal-only') {
-      // DBT coalesces personal Snowflake usage rollups to an empty-string sentinel
-      // so incremental merges can match on organization_id.
-      where.addEq('organization_id', '');
+      where.add(isNull(microdollar_usage.organization_id));
     }
   }
 }
 
+const featureName: SQL<string> = sql<string>`COALESCE(${feature.feature}, '')`;
+const modeName: SQL<string> = sql<string>`COALESCE(${mode.mode}, '')`;
+const modelName: SQL<string> = sql<string>`COALESCE(${microdollar_usage.model}, '')`;
+const providerName: SQL<string> = sql<string>`COALESCE(${microdollar_usage.provider}, '')`;
+const projectName: SQL<string> = sql<string>`COALESCE(${microdollar_usage.project_id}, '')`;
+
+function inValues(column: SQL, values: string[]): SQL {
+  return sql`${column} IN (${sql.join(
+    values.map(value => sql`${value}`),
+    sql`, `
+  )})`;
+}
+
+function notInValues(column: SQL, values: string[]): SQL {
+  return sql`${column} NOT IN (${sql.join(
+    values.map(value => sql`${value}`),
+    sql`, `
+  )})`;
+}
+
 function buildDimensionConditions(where: WhereBuilder, filters: UsageAnalyticsFilters): void {
-  const addInIfNonEmpty = (column: string, values: string[] | undefined) => {
-    if (values && values.length > 0) where.addIn(column, values);
+  const addInIfNonEmpty = (column: SQL, values: string[] | undefined) => {
+    if (values && values.length > 0) where.add(inValues(column, values));
   };
-  const addNotInIfNonEmpty = (column: string, values: string[] | undefined) => {
-    if (values && values.length > 0) where.addNotIn(column, values);
+  const addNotInIfNonEmpty = (column: SQL, values: string[] | undefined) => {
+    if (values && values.length > 0) where.add(notInValues(column, values));
   };
 
-  addInIfNonEmpty('feature', filters.features);
-  addInIfNonEmpty('model', filters.models);
-  addInIfNonEmpty('mode', filters.modes);
-  addInIfNonEmpty('provider', filters.providers);
-  addInIfNonEmpty('project_id', filters.projects);
-  addNotInIfNonEmpty('feature', filters.excludedFeatures);
-  addNotInIfNonEmpty('model', filters.excludedModels);
-  addNotInIfNonEmpty('mode', filters.excludedModes);
-  addNotInIfNonEmpty('provider', filters.excludedProviders);
-  addNotInIfNonEmpty('project_id', filters.excludedProjects);
+  addInIfNonEmpty(featureName, filters.features);
+  addInIfNonEmpty(modelName, filters.models);
+  addInIfNonEmpty(modeName, filters.modes);
+  addInIfNonEmpty(providerName, filters.providers);
+  addInIfNonEmpty(projectName, filters.projects);
+  addNotInIfNonEmpty(featureName, filters.excludedFeatures);
+  addNotInIfNonEmpty(modelName, filters.excludedModels);
+  addNotInIfNonEmpty(modeName, filters.excludedModes);
+  addNotInIfNonEmpty(providerName, filters.excludedProviders);
+  addNotInIfNonEmpty(projectName, filters.excludedProjects);
 }
 
 function buildWhereClause(
-  tier: GranularityTier,
   filters: UsageAnalyticsFilters,
   ctxUserId: string,
   includeDimensions: boolean
 ): WhereBuilder {
   const where = new WhereBuilder();
-  buildDateConditions(where, tier, filters);
+  buildDateConditions(where, filters);
   buildScopeConditions(where, filters, ctxUserId);
   if (includeDimensions) {
     buildDimensionConditions(where, filters);
@@ -354,207 +235,104 @@ function buildWhereClause(
   return where;
 }
 
-// ---------------------------------------------------------------------------
-// Metric SQL expression
-// ---------------------------------------------------------------------------
-
-export function costColumnFor(costSource: CostSource): string {
+export function costColumnFor(costSource: CostSource): SQL<number> {
   switch (costSource) {
     case 'cost':
-      return 'total_cost_microdollars';
+      return sql<number>`${microdollar_usage.cost}`;
     case 'market':
-      return 'total_market_cost_microdollars';
+      return sql<number>`COALESCE(${microdollar_usage_metadata.market_cost}, 0)`;
   }
 }
 
-export function costSumExprSql(costSource: CostSource): string {
-  return `COALESCE(SUM(${costColumnFor(costSource)}), 0)`;
+export function costSumExprSql(costSource: CostSource): SQL<number> {
+  return sql<number>`COALESCE(SUM(${costColumnFor(costSource)}), 0)`;
 }
 
-function metricExprSql(metric: Metric, tier: GranularityTier, costSource: CostSource): string {
+const requestCountExpr = sql<number>`COUNT(*)`;
+const inputTokensExpr = sql<number>`COALESCE(SUM(${microdollar_usage.input_tokens}), 0)`;
+const outputTokensExpr = sql<number>`COALESCE(SUM(${microdollar_usage.output_tokens}), 0)`;
+const cacheWriteTokensExpr = sql<number>`COALESCE(SUM(${microdollar_usage.cache_write_tokens}), 0)`;
+const cacheHitTokensExpr = sql<number>`COALESCE(SUM(${microdollar_usage.cache_hit_tokens}), 0)`;
+const totalTokensExpr = sql<number>`COALESCE(SUM(${microdollar_usage.input_tokens} + ${microdollar_usage.output_tokens} + ${microdollar_usage.cache_write_tokens} + ${microdollar_usage.cache_hit_tokens}), 0)`;
+const errorCountExpr = sql<number>`COUNT(*) FILTER (WHERE ${microdollar_usage.has_error})`;
+const cancelledCountExpr = sql<number>`COUNT(*) FILTER (WHERE ${microdollar_usage_metadata.cancelled})`;
+const freeRequestCountExpr = sql<number>`COUNT(*) FILTER (WHERE ${microdollar_usage_metadata.is_free})`;
+const byokRequestCountExpr = sql<number>`COUNT(*) FILTER (WHERE ${microdollar_usage_metadata.is_byok})`;
+const totalLatencyMsExpr = sql<number>`COALESCE(SUM(${microdollar_usage_metadata.latency}), 0)`;
+const latencyCountExpr = sql<number>`COUNT(${microdollar_usage_metadata.latency})`;
+const totalGenerationTimeMsExpr = sql<number>`COALESCE(SUM(${microdollar_usage_metadata.generation_time}), 0)`;
+const generationTimeCountExpr = sql<number>`COUNT(${microdollar_usage_metadata.generation_time})`;
+
+function metricExprSql(metric: Metric, costSource: CostSource): SQL<number> {
   const costSumExpr = costSumExprSql(costSource);
   switch (metric) {
     case 'cost':
       return costSumExpr;
     case 'requests':
-      return 'COALESCE(SUM(request_count), 0)';
+      return sql<number>`COALESCE(${requestCountExpr}, 0)`;
     case 'inputTokens':
-      return 'COALESCE(SUM(total_input_tokens), 0)';
+      return inputTokensExpr;
     case 'outputTokens':
-      return 'COALESCE(SUM(total_output_tokens), 0)';
+      return outputTokensExpr;
     case 'tokens':
-      return 'COALESCE(SUM(total_tokens), 0)';
+      return totalTokensExpr;
     case 'errorRate':
-      return 'CASE WHEN COALESCE(SUM(request_count), 0) = 0 THEN 0 ELSE COALESCE(SUM(error_count), 0)::FLOAT / SUM(request_count)::FLOAT END';
+      return sql<number>`CASE WHEN ${requestCountExpr} = 0 THEN 0 ELSE (${errorCountExpr})::FLOAT / (${requestCountExpr})::FLOAT END`;
     case 'avgLatencyMs':
-      return 'CASE WHEN COALESCE(SUM(latency_count), 0) = 0 THEN 0 ELSE COALESCE(SUM(total_latency_ms), 0)::FLOAT / SUM(latency_count)::FLOAT END';
-    case 'avgGenerationTimeMs': {
-      const countExpr = generationTimeCountExprSql(tier);
-      return `CASE WHEN COALESCE(SUM(${countExpr}), 0) = 0 THEN 0 ELSE COALESCE(SUM(total_generation_time_ms), 0)::FLOAT / SUM(${countExpr})::FLOAT END`;
-    }
+      return sql<number>`CASE WHEN ${latencyCountExpr} = 0 THEN 0 ELSE (${totalLatencyMsExpr})::FLOAT / (${latencyCountExpr})::FLOAT END`;
+    case 'avgGenerationTimeMs':
+      return sql<number>`CASE WHEN ${generationTimeCountExpr} = 0 THEN 0 ELSE (${totalGenerationTimeMsExpr})::FLOAT / (${generationTimeCountExpr})::FLOAT END`;
     case 'costPerRequest':
-      return `CASE WHEN COALESCE(SUM(request_count), 0) = 0 THEN 0 ELSE ${costSumExpr}::FLOAT / SUM(request_count)::FLOAT END`;
+      return sql<number>`CASE WHEN ${requestCountExpr} = 0 THEN 0 ELSE (${costSumExpr})::FLOAT / (${requestCountExpr})::FLOAT END`;
     case 'tokensPerRequest':
-      return 'CASE WHEN COALESCE(SUM(request_count), 0) = 0 THEN 0 ELSE COALESCE(SUM(total_tokens), 0)::FLOAT / SUM(request_count)::FLOAT END';
+      return sql<number>`CASE WHEN ${requestCountExpr} = 0 THEN 0 ELSE (${totalTokensExpr})::FLOAT / (${requestCountExpr})::FLOAT END`;
     case 'cacheHitRatio':
-      return 'CASE WHEN COALESCE(SUM(total_input_tokens + total_cache_hit_tokens), 0) = 0 THEN 0 ELSE COALESCE(SUM(total_cache_hit_tokens), 0)::FLOAT / SUM(total_input_tokens + total_cache_hit_tokens)::FLOAT END';
+      return sql<number>`CASE WHEN COALESCE(SUM(${microdollar_usage.input_tokens} + ${microdollar_usage.cache_hit_tokens}), 0) = 0 THEN 0 ELSE COALESCE(SUM(${microdollar_usage.cache_hit_tokens}), 0)::FLOAT / SUM(${microdollar_usage.input_tokens} + ${microdollar_usage.cache_hit_tokens})::FLOAT END`;
     case 'outputInputRatio':
-      return 'CASE WHEN COALESCE(SUM(total_input_tokens), 0) = 0 THEN 0 ELSE COALESCE(SUM(total_output_tokens), 0)::FLOAT / SUM(total_input_tokens)::FLOAT END';
+      return sql<number>`CASE WHEN COALESCE(SUM(${microdollar_usage.input_tokens}), 0) = 0 THEN 0 ELSE COALESCE(SUM(${microdollar_usage.output_tokens}), 0)::FLOAT / SUM(${microdollar_usage.input_tokens})::FLOAT END`;
   }
 }
 
-function generationTimeCountExprSql(tier: GranularityTier): string {
-  if (tier === 'hourly') {
-    return 'IFF(total_generation_time_ms IS NOT NULL, 1, 0)';
-  }
-  // Daily rollups do not currently carry a generation-time observation count.
-  // Derive one only for the window backed by hourly rollups so older daily
-  // history does not reuse latency_count as an incorrect denominator.
-  return 'IFF(total_generation_time_ms IS NOT NULL AND usage_date >= DATEADD(day, -7, CURRENT_DATE), 1, 0)';
-}
-
-// ---------------------------------------------------------------------------
-// Bucket expression for timeseries / table grouping
-// ---------------------------------------------------------------------------
-
-/**
- * Returns a SQL expression that formats the time column as a string bucket,
- * matching the granularity the caller requested.
- *
- * Hourly  → 'YYYY-MM-DD HH24:MI:SS'  (matches what Postgres timestamp::text returns)
- * Day     → 'YYYY-MM-DD'
- * Week    → 'YYYY-MM-DD' of the Monday-aligned week start
- * Month   → 'YYYY-MM-DD' of the first of the month (from daily table)
- */
-function bucketExprSql(effectiveGranularity: Granularity, tier: GranularityTier): string {
-  const timeCol = getTimeColumn(tier);
-
+function bucketExprSql(effectiveGranularity: Granularity): SQL<string> {
+  const createdAtUtc = sql`${microdollar_usage.created_at} AT TIME ZONE 'UTC'`;
   if (effectiveGranularity === 'hour') {
-    return `TO_VARCHAR(${timeCol}, 'YYYY-MM-DD HH24:MI:SS')`;
+    return sql<string>`TO_CHAR(DATE_TRUNC('hour', ${createdAtUtc}), 'YYYY-MM-DD HH24:MI:SS')`;
   }
   if (effectiveGranularity === 'week') {
-    return `TO_VARCHAR(DATE_TRUNC('WEEK', ${timeCol}), 'YYYY-MM-DD')`;
+    return sql<string>`TO_CHAR(DATE_TRUNC('week', ${createdAtUtc}), 'YYYY-MM-DD')`;
   }
   if (effectiveGranularity === 'month') {
-    // Daily table, group by month
-    return `TO_VARCHAR(DATE_TRUNC('MONTH', ${timeCol}), 'YYYY-MM-DD')`;
+    return sql<string>`TO_CHAR(DATE_TRUNC('month', ${createdAtUtc}), 'YYYY-MM-DD')`;
   }
-  // 'day'
-  return `TO_VARCHAR(${timeCol}, 'YYYY-MM-DD')`;
+  return sql<string>`TO_CHAR(DATE_TRUNC('day', ${createdAtUtc}), 'YYYY-MM-DD')`;
 }
 
-// ---------------------------------------------------------------------------
-// Dimension column name
-// ---------------------------------------------------------------------------
-
-function dimensionColumn(dimension: Dimension): string {
+function dimensionColumn(dimension: Dimension): SQL<string> {
   switch (dimension) {
     case 'feature':
-      return 'feature';
+      return featureName;
     case 'model':
-      return 'model';
+      return modelName;
     case 'mode':
-      return 'mode';
+      return modeName;
     case 'user':
-      return 'kilo_user_id';
+      return sql<string>`${microdollar_usage.kilo_user_id}`;
     case 'provider':
-      return 'provider';
+      return providerName;
     case 'project':
-      return 'project_id';
+      return projectName;
   }
 }
 
-// ---------------------------------------------------------------------------
-// Timed query wrapper
-// ---------------------------------------------------------------------------
-
-function parseTimeoutEnv(envKey: string, fallback: number): number {
-  const raw = getEnvVariable(envKey);
-  if (!raw) return fallback;
-  const parsed = Number(raw);
-  if (!Number.isFinite(parsed) || parsed < 0) return fallback;
-  return parsed;
-}
-
-function defaultTimeoutForScope(scope: 'user' | 'org' | 'admin'): number {
-  if (scope === 'admin') return parseTimeoutEnv('USAGE_QUERY_TIMEOUT_ADMIN_MS', 20_000);
-  if (scope === 'org') return parseTimeoutEnv('USAGE_QUERY_TIMEOUT_ORG_MS', 10_000);
-  return parseTimeoutEnv('USAGE_QUERY_TIMEOUT_USER_MS', 5_000);
-}
-
-async function timedSnowflakeQuery<T>(
-  params: {
-    route: string;
-    queryLabel: string;
-    scope: 'user' | 'org' | 'admin';
-    period: string | null;
-    timeoutMs?: number;
-  },
-  queryFn: (signal: AbortSignal) => Promise<T>
-): Promise<T> {
-  const timeoutMs = params.timeoutMs ?? defaultTimeoutForScope(params.scope);
-  const start = performance.now();
-  let rowCount = 0;
-
-  const controller = new AbortController();
-  let settled = false;
-  const timer = setTimeout(() => {
-    if (!settled) controller.abort();
-  }, timeoutMs);
-
-  try {
-    const result = await queryFn(controller.signal);
-    settled = true;
-    rowCount = Array.isArray(result) ? result.length : 1;
-    return result;
-  } catch (error) {
-    settled = true;
-    console.error(
-      JSON.stringify({
-        type: 'usage_query_error',
-        route: params.route,
-        queryLabel: params.queryLabel,
-        scope: params.scope,
-        period: params.period,
-        message: error instanceof Error ? error.message : String(error),
-      })
-    );
-    throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
-      message: 'Usage data temporarily unavailable',
-    });
-  } finally {
-    clearTimeout(timer);
-    const durationMs = Math.round((performance.now() - start) * 100) / 100;
-    console.log(
-      JSON.stringify({
-        type: 'usage_query',
-        route: params.route,
-        queryLabel: params.queryLabel,
-        scope: params.scope,
-        period: params.period,
-        durationMs,
-        rowCount,
-        timeoutMs,
-      })
-    );
-  }
-}
-
-// ---------------------------------------------------------------------------
-// getSummary
-// ---------------------------------------------------------------------------
+const usageMetadataJoin = eq(microdollar_usage.id, microdollar_usage_metadata.id);
+const usageFeatureJoin = eq(microdollar_usage_metadata.feature_id, feature.feature_id);
+const usageModeJoin = eq(microdollar_usage_metadata.mode_id, mode.mode_id);
 
 function ratioSafe(numerator: number, denominator: number): number {
   if (denominator === 0) return 0;
   return numerator / denominator;
 }
 
-/**
- * Convert an aggregate value (often returned as a string by Snowflake) to a
- * JS number. Values above `MAX_SAFE_INTEGER` are logged as a warning but still
- * returned so the UI does not crash.
- */
 function toSafeNumber(value: unknown): number {
   const n = Number(value);
   if (!Number.isFinite(n)) return 0;
@@ -565,10 +343,6 @@ function toSafeNumber(value: unknown): number {
   }
   return n;
 }
-
-// ---------------------------------------------------------------------------
-// User list (for org context)
-// ---------------------------------------------------------------------------
 
 const MAX_USER_LABEL_LOOKUP_IDS = 1_000;
 
@@ -587,10 +361,6 @@ const UserListOutputSchema = z.object({
   ),
 });
 
-// ---------------------------------------------------------------------------
-// Scope organizations (org usage page Scope selector)
-// ---------------------------------------------------------------------------
-
 const ScopeOrganizationsInputSchema = z.object({
   organizationId: z.uuid(),
 });
@@ -603,7 +373,6 @@ const ScopeOrganizationSchema = z.object({
 const ScopeOrganizationsOutputSchema = z.object({
   organizationId: z.string(),
   organizationName: z.string(),
-  /** Direct child organizations, sorted by name. Empty when not a parent org. */
   children: z.array(ScopeOrganizationSchema),
 });
 
@@ -638,9 +407,13 @@ function legacyOAuthProviderKey(provider: AuthProviderId, providerAccountId: str
   return `${provider}:${providerAccountId}`;
 }
 
-// ---------------------------------------------------------------------------
-// Router definition
-// ---------------------------------------------------------------------------
+function queryScope(input: UsageAnalyticsFilters): 'org' | 'user' {
+  return isOrgScope(input) ? 'org' : 'user';
+}
+
+function queryPeriod(input: UsageAnalyticsFilters): string {
+  return `${input.startDate}/${input.endDate}`;
+}
 
 export const usageAnalyticsRouter = createTRPCRouter({
   getSummary: baseProcedure
@@ -649,100 +422,61 @@ export const usageAnalyticsRouter = createTRPCRouter({
     .query(async ({ input, ctx }): Promise<SummaryOutput> => {
       await ensureScopeAccess(ctx, input);
 
-      const config = resolveSnowflakeConfig();
       const meta = resolveTier(input.granularity, input.startDate);
-      if (!config) {
-        return {
-          costMicrodollars: 0,
-          requestCount: 0,
-          inputTokens: 0,
-          outputTokens: 0,
-          cacheWriteTokens: 0,
-          cacheHitTokens: 0,
-          errorCount: 0,
-          cancelledCount: 0,
-          freeRequestCount: 0,
-          byokRequestCount: 0,
-          totalLatencyMs: 0,
-          totalGenerationTimeMs: 0,
-          latencyCount: 0,
-          generationTimeCount: 0,
-          totalTokens: 0,
-          distinctUsers: 0,
-          errorRate: 0,
-          avgLatencyMs: 0,
-          avgGenerationTimeMs: 0,
-          costPerRequest: 0,
-          tokensPerRequest: 0,
-          cacheHitRatio: 0,
-          outputInputRatio: 0,
-          effectiveGranularity: meta.effectiveGranularity,
-        };
-      }
-      const table = getTableName(meta.tier);
-      const where = buildWhereClause(meta.tier, input, ctx.user.id, true);
-      const generationTimeCountExpr = generationTimeCountExprSql(meta.tier);
-      const costSumExpr = costSumExprSql(input.costSource);
+      const where = buildWhereClause(input, ctx.user.id, true);
 
-      const statement = `
-        SELECT
-          ${costSumExpr},
-          COALESCE(SUM(request_count), 0),
-          COALESCE(SUM(total_input_tokens), 0),
-          COALESCE(SUM(total_output_tokens), 0),
-          COALESCE(SUM(total_cache_write_tokens), 0),
-          COALESCE(SUM(total_cache_hit_tokens), 0),
-          COALESCE(SUM(error_count), 0),
-          COALESCE(SUM(cancelled_count), 0),
-          COALESCE(SUM(free_request_count), 0),
-          COALESCE(SUM(byok_request_count), 0),
-          COALESCE(SUM(total_latency_ms), 0),
-          COALESCE(SUM(total_generation_time_ms), 0),
-          COALESCE(SUM(latency_count), 0),
-          COALESCE(SUM(${generationTimeCountExpr}), 0),
-          COALESCE(SUM(total_tokens), 0),
-          COUNT(DISTINCT kilo_user_id)
-        FROM ${table}
-        WHERE ${where.sql()}
-      `;
-
-      const rows = await timedSnowflakeQuery(
+      const rows = await timedUsageQuery(
         {
+          db: readDb,
           route: 'usageAnalytics.getSummary',
           queryLabel: `summary_${meta.tier}`,
-          scope: isOrgScope(input) ? 'org' : 'user',
-          period: `${input.startDate}/${input.endDate}`,
+          scope: queryScope(input),
+          period: queryPeriod(input),
         },
-        signal =>
-          executeSnowflakeStatement({
-            config,
-            statement,
-            bindings: where.bindings,
-            timeoutSeconds: Math.ceil(
-              defaultTimeoutForScope(isOrgScope(input) ? 'org' : 'user') / 1000
-            ),
-            signal,
-          })
+        tx =>
+          tx
+            .select({
+              costMicrodollars: costSumExprSql(input.costSource),
+              requestCount: requestCountExpr,
+              inputTokens: inputTokensExpr,
+              outputTokens: outputTokensExpr,
+              cacheWriteTokens: cacheWriteTokensExpr,
+              cacheHitTokens: cacheHitTokensExpr,
+              errorCount: errorCountExpr,
+              cancelledCount: cancelledCountExpr,
+              freeRequestCount: freeRequestCountExpr,
+              byokRequestCount: byokRequestCountExpr,
+              totalLatencyMs: totalLatencyMsExpr,
+              totalGenerationTimeMs: totalGenerationTimeMsExpr,
+              latencyCount: latencyCountExpr,
+              generationTimeCount: generationTimeCountExpr,
+              totalTokens: totalTokensExpr,
+              distinctUsers: sql<number>`COUNT(DISTINCT ${microdollar_usage.kilo_user_id})`,
+            })
+            .from(microdollar_usage)
+            .leftJoin(microdollar_usage_metadata, usageMetadataJoin)
+            .leftJoin(feature, usageFeatureJoin)
+            .leftJoin(mode, usageModeJoin)
+            .where(where.toSQL())
       );
 
-      const row = rows[0] ?? [];
-
-      const costMicrodollars = toSafeNumber(row[0]);
-      const requestCount = toSafeNumber(row[1]);
-      const inputTokens = toSafeNumber(row[2]);
-      const outputTokens = toSafeNumber(row[3]);
-      const cacheWriteTokens = toSafeNumber(row[4]);
-      const cacheHitTokens = toSafeNumber(row[5]);
-      const errorCount = toSafeNumber(row[6]);
-      const cancelledCount = toSafeNumber(row[7]);
-      const freeRequestCount = toSafeNumber(row[8]);
-      const byokRequestCount = toSafeNumber(row[9]);
-      const totalLatencyMs = toSafeNumber(row[10]);
-      const totalGenerationTimeMs = toSafeNumber(row[11]);
-      const latencyCount = toSafeNumber(row[12]);
-      const generationTimeCount = toSafeNumber(row[13]);
-      const totalTokens = toSafeNumber(row[14]);
-      const distinctUsers = toSafeNumber(row[15]);
+      const row = rows[0];
+      const costMicrodollars = toSafeNumber(row?.costMicrodollars);
+      const requestCount = toSafeNumber(row?.requestCount);
+      const inputTokens = toSafeNumber(row?.inputTokens);
+      const outputTokens = toSafeNumber(row?.outputTokens);
+      const cacheWriteTokens = toSafeNumber(row?.cacheWriteTokens);
+      const cacheHitTokens = toSafeNumber(row?.cacheHitTokens);
+      const errorCount = toSafeNumber(row?.errorCount);
+      const cancelledCount = toSafeNumber(row?.cancelledCount);
+      const freeRequestCount = toSafeNumber(row?.freeRequestCount);
+      const byokRequestCount = toSafeNumber(row?.byokRequestCount);
+      const totalLatencyMs = toSafeNumber(row?.totalLatencyMs);
+      const totalGenerationTimeMs = toSafeNumber(row?.totalGenerationTimeMs);
+      const latencyCount = toSafeNumber(row?.latencyCount);
+      const generationTimeCount = toSafeNumber(row?.generationTimeCount);
+      const totalTokens = toSafeNumber(row?.totalTokens);
+      const distinctUsers = toSafeNumber(row?.distinctUsers);
 
       return {
         costMicrodollars,
@@ -778,65 +512,44 @@ export const usageAnalyticsRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       await ensureScopeAccess(ctx, input);
 
-      const config = resolveSnowflakeConfig();
       const meta = resolveTier(input.granularity, input.startDate);
-      if (!config) {
-        return { timeseries: [], effectiveGranularity: meta.effectiveGranularity };
-      }
-      const table = getTableName(meta.tier);
-      const bucketExpr = bucketExprSql(meta.effectiveGranularity, meta.tier);
-      const metricExpr = metricExprSql(input.metric, meta.tier, input.costSource);
-      const where = buildWhereClause(meta.tier, input, ctx.user.id, true);
+      const bucketExpr = bucketExprSql(meta.effectiveGranularity);
+      const metricExpr = metricExprSql(input.metric, input.costSource);
+      const where = buildWhereClause(input, ctx.user.id, true);
+      const splitCol = input.splitBy ? dimensionColumn(input.splitBy) : undefined;
 
-      let statement: string;
-      if (input.splitBy) {
-        const splitCol = dimensionColumn(input.splitBy);
-        statement = `
-          SELECT
-            ${bucketExpr} AS bucket,
-            ${metricExpr} AS value,
-            ${splitCol} AS label
-          FROM ${table}
-          WHERE ${where.sql()}
-          GROUP BY 1, 3
-          ORDER BY 1
-        `;
-      } else {
-        statement = `
-          SELECT
-            ${bucketExpr} AS bucket,
-            ${metricExpr} AS value
-          FROM ${table}
-          WHERE ${where.sql()}
-          GROUP BY 1
-          ORDER BY 1
-        `;
-      }
-
-      const rows = await timedSnowflakeQuery(
+      const rows = await timedUsageQuery(
         {
+          db: readDb,
           route: 'usageAnalytics.getTimeseries',
           queryLabel: `timeseries_${meta.tier}${input.splitBy ? `_split_${input.splitBy}` : ''}`,
-          scope: isOrgScope(input) ? 'org' : 'user',
-          period: `${input.startDate}/${input.endDate}`,
+          scope: queryScope(input),
+          period: queryPeriod(input),
         },
-        signal =>
-          executeSnowflakeStatement({
-            config,
-            statement,
-            bindings: where.bindings,
-            timeoutSeconds: Math.ceil(
-              defaultTimeoutForScope(isOrgScope(input) ? 'org' : 'user') / 1000
-            ),
-            signal,
-          })
+        tx => {
+          const query = tx
+            .select({
+              datetime: bucketExpr,
+              value: metricExpr,
+              label: splitCol ?? sql<string | null>`CAST(NULL AS TEXT)`,
+            })
+            .from(microdollar_usage)
+            .leftJoin(microdollar_usage_metadata, usageMetadataJoin)
+            .leftJoin(feature, usageFeatureJoin)
+            .leftJoin(mode, usageModeJoin)
+            .where(where.toSQL());
+
+          return splitCol
+            ? query.groupBy(bucketExpr, splitCol).orderBy(bucketExpr)
+            : query.groupBy(bucketExpr).orderBy(bucketExpr);
+        }
       );
 
       return {
         timeseries: rows.map(row => ({
-          datetime: row[0] ?? '',
-          value: toSafeNumber(row[1]),
-          label: input.splitBy ? (row[2] ?? undefined) : undefined,
+          datetime: row.datetime ?? '',
+          value: toSafeNumber(row.value),
+          label: input.splitBy ? (row.label ?? undefined) : undefined,
         })),
         effectiveGranularity: meta.effectiveGranularity,
       };
@@ -848,53 +561,36 @@ export const usageAnalyticsRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       await ensureScopeAccess(ctx, input);
 
-      const config = resolveSnowflakeConfig();
       const meta = resolveTier(input.granularity, input.startDate);
-      if (!config) {
-        return { breakdown: [], totalValue: 0, effectiveGranularity: meta.effectiveGranularity };
-      }
-      const table = getTableName(meta.tier);
       const dimCol = dimensionColumn(input.dimension);
-      const metricExpr = metricExprSql(input.metric, meta.tier, input.costSource);
-      const where = buildWhereClause(meta.tier, input, ctx.user.id, true);
+      const metricExpr = metricExprSql(input.metric, input.costSource);
+      const where = buildWhereClause(input, ctx.user.id, true);
 
-      const statement = `
-        SELECT
-          ${dimCol} AS key,
-          ${metricExpr} AS value
-        FROM ${table}
-        WHERE ${where.sql()}
-        GROUP BY 1
-        ORDER BY 2 DESC
-        LIMIT ${Number(input.limit)}
-      `;
-
-      // SAFETY: LIMIT value is interpolated directly into SQL but is
-      // validated by Zod above: `z.number().int().min(1).max(10_000)`.
-      // Snowflake's SQL API v2 does not support parameter binding for LIMIT.
-
-      const rows = await timedSnowflakeQuery(
+      const rows = await timedUsageQuery(
         {
+          db: readDb,
           route: 'usageAnalytics.getBreakdown',
           queryLabel: `breakdown_${meta.tier}_by_${input.dimension}`,
-          scope: isOrgScope(input) ? 'org' : 'user',
-          period: `${input.startDate}/${input.endDate}`,
+          scope: queryScope(input),
+          period: queryPeriod(input),
         },
-        signal =>
-          executeSnowflakeStatement({
-            config,
-            statement,
-            bindings: where.bindings,
-            timeoutSeconds: Math.ceil(
-              defaultTimeoutForScope(isOrgScope(input) ? 'org' : 'user') / 1000
-            ),
-            signal,
-          })
+        tx =>
+          tx
+            .select({
+              key: dimCol,
+              value: metricExpr,
+            })
+            .from(microdollar_usage)
+            .leftJoin(microdollar_usage_metadata, usageMetadataJoin)
+            .leftJoin(feature, usageFeatureJoin)
+            .leftJoin(mode, usageModeJoin)
+            .where(where.toSQL())
+            .groupBy(dimCol)
+            .orderBy(sql`${metricExpr} DESC`)
+            .limit(input.limit)
       );
 
-      const values = rows.map(row => ({ key: row[0] ?? '', value: toSafeNumber(row[1]) }));
-      // Percentages are relative to the *returned* rows (limited by input.limit).
-      // They will not reflect the true share when the result set is capped.
+      const values = rows.map(row => ({ key: row.key ?? '', value: toSafeNumber(row.value) }));
       const totalValue = values.reduce((s, r) => s + r.value, 0);
 
       return {
@@ -915,101 +611,83 @@ export const usageAnalyticsRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       await ensureScopeAccess(ctx, input);
 
-      const config = resolveSnowflakeConfig();
       const meta = resolveTier(input.granularity, input.startDate);
-      if (!config) {
-        return { rows: [], effectiveGranularity: meta.effectiveGranularity };
-      }
-      const table = getTableName(meta.tier);
-      const bucketExpr = bucketExprSql(meta.effectiveGranularity, meta.tier);
-      const where = buildWhereClause(meta.tier, input, ctx.user.id, true);
-      const costSumExpr = costSumExprSql(input.costSource);
-
+      const bucketExpr = bucketExprSql(meta.effectiveGranularity);
+      const where = buildWhereClause(input, ctx.user.id, true);
       const requestedDims = input.groupBy;
 
-      // For dimensions not in groupBy, emit an empty string constant so the
-      // row shape stays stable regardless of which dimensions were requested.
-      const featExpr = requestedDims.includes('feature') ? 'feature' : "''";
-      const modelExpr = requestedDims.includes('model') ? 'model' : "''";
-      const modeExpr = requestedDims.includes('mode') ? 'mode' : "''";
-      const userExpr = requestedDims.includes('user') ? 'kilo_user_id' : "''";
-      const providerExpr = requestedDims.includes('provider') ? 'provider' : "''";
-      const projectExpr = requestedDims.includes('project') ? 'project_id' : "''";
+      const featExpr = requestedDims.includes('feature') ? featureName : sql<string>`''`;
+      const modelExpr = requestedDims.includes('model') ? modelName : sql<string>`''`;
+      const modeExpr = requestedDims.includes('mode') ? modeName : sql<string>`''`;
+      const userExpr = requestedDims.includes('user')
+        ? sql<string>`${microdollar_usage.kilo_user_id}`
+        : sql<string>`''`;
+      const providerExpr = requestedDims.includes('provider') ? providerName : sql<string>`''`;
+      const projectExpr = requestedDims.includes('project') ? projectName : sql<string>`''`;
 
-      // GROUP BY columns: bucket (pos 1) + each requested dimension column
-      // SAFETY: dimensionColumn() returns only hardcoded string literals from
-      // a typed enum chain — never user input.
-      const dimGroupByCols = requestedDims.map(d => dimensionColumn(d)).join(', ');
-      const groupByClause = dimGroupByCols ? `1, ${dimGroupByCols}` : '1';
+      const dimGroupBy = requestedDims.map(d => dimensionColumn(d));
+      const groupByClause = [bucketExpr, ...dimGroupBy];
 
-      const statement = `
-        SELECT
-          ${bucketExpr} AS datetime,
-          ${featExpr} AS dim_feature,
-          ${modelExpr} AS dim_model,
-          ${modeExpr} AS dim_mode,
-          ${userExpr} AS dim_user,
-          ${providerExpr} AS dim_provider,
-          ${projectExpr} AS dim_project,
-          ${costSumExpr},
-          COALESCE(SUM(request_count), 0),
-          COALESCE(SUM(total_input_tokens), 0),
-          COALESCE(SUM(total_output_tokens), 0),
-          COALESCE(SUM(total_cache_write_tokens), 0),
-          COALESCE(SUM(total_cache_hit_tokens), 0),
-          COALESCE(SUM(error_count), 0)
-        FROM ${table}
-        WHERE ${where.sql()}
-        GROUP BY ${groupByClause}
-        ORDER BY 1 DESC
-        LIMIT ${Number(input.limit)}
-      `;
-
-      const rows = await timedSnowflakeQuery(
+      const rows = await timedUsageQuery(
         {
+          db: readDb,
           route: 'usageAnalytics.getTable',
           queryLabel: `table_${meta.tier}_groupby_${requestedDims.join('+') || 'none'}`,
-          scope: isOrgScope(input) ? 'org' : 'user',
-          period: `${input.startDate}/${input.endDate}`,
+          scope: queryScope(input),
+          period: queryPeriod(input),
         },
-        signal =>
-          executeSnowflakeStatement({
-            config,
-            statement,
-            bindings: where.bindings,
-            timeoutSeconds: Math.ceil(
-              defaultTimeoutForScope(isOrgScope(input) ? 'org' : 'user') / 1000
-            ),
-            signal,
-          })
+        tx =>
+          tx
+            .select({
+              datetime: bucketExpr,
+              dimFeature: featExpr,
+              dimModel: modelExpr,
+              dimMode: modeExpr,
+              dimUser: userExpr,
+              dimProvider: providerExpr,
+              dimProject: projectExpr,
+              costMicrodollars: costSumExprSql(input.costSource),
+              requestCount: requestCountExpr,
+              inputTokens: inputTokensExpr,
+              outputTokens: outputTokensExpr,
+              cacheWriteTokens: cacheWriteTokensExpr,
+              cacheHitTokens: cacheHitTokensExpr,
+              errorCount: errorCountExpr,
+            })
+            .from(microdollar_usage)
+            .leftJoin(microdollar_usage_metadata, usageMetadataJoin)
+            .leftJoin(feature, usageFeatureJoin)
+            .leftJoin(mode, usageModeJoin)
+            .where(where.toSQL())
+            .groupBy(...groupByClause)
+            .orderBy(sql`${bucketExpr} DESC`)
+            .limit(input.limit)
       );
-
-      const dimIndexMap: Record<Dimension, number> = {
-        feature: 1,
-        model: 2,
-        mode: 3,
-        user: 4,
-        provider: 5,
-        project: 6,
-      };
 
       return {
         rows: rows.map(row => {
           const dimensions: Record<string, string> = {};
           for (const d of requestedDims) {
-            const raw = row[dimIndexMap[d]];
+            const raw = {
+              feature: row.dimFeature,
+              model: row.dimModel,
+              mode: row.dimMode,
+              user: row.dimUser,
+              provider: row.dimProvider,
+              project: row.dimProject,
+            }[d];
             dimensions[d] = typeof raw === 'string' ? raw : '';
           }
           return {
-            datetime: row[0] ?? '',
+            datetime: row.datetime ?? '',
             dimensions,
-            costMicrodollars: toSafeNumber(row[7]),
-            requestCount: toSafeNumber(row[8]),
-            inputTokens: toSafeNumber(row[9]),
-            outputTokens: toSafeNumber(row[10]),
-            cacheWriteTokens: toSafeNumber(row[11]),
-            cacheHitTokens: toSafeNumber(row[12]),
-            errorCount: toSafeNumber(row[13]),
+            costMicrodollars: toSafeNumber(row.costMicrodollars),
+            requestCount: toSafeNumber(row.requestCount),
+            inputTokens: toSafeNumber(row.inputTokens),
+            outputTokens: toSafeNumber(row.outputTokens),
+            cacheWriteTokens: toSafeNumber(row.cacheWriteTokens),
+            cacheHitTokens: toSafeNumber(row.cacheHitTokens),
+            errorCount: toSafeNumber(row.errorCount),
           };
         }),
         effectiveGranularity: meta.effectiveGranularity,
@@ -1038,8 +716,6 @@ export const usageAnalyticsRouter = createTRPCRouter({
         throw new TRPCError({ code: 'NOT_FOUND', message: 'Organization not found' });
       }
 
-      // Exclude soft-deleted children so they never appear in the scope list or
-      // get folded into the All Organizations aggregate.
       const children = await readDb
         .select({ id: organizations.id, name: organizations.name })
         .from(organizations)
@@ -1080,7 +756,6 @@ export const usageAnalyticsRouter = createTRPCRouter({
     .query(async ({ input, ctx }) => {
       const accessByOrg = await getOrganizationsAccessRoles(ctx, input.organizationIds);
 
-      // Require access to every requested org (mirrors the single-org guard).
       const hasAccessToAll = input.organizationIds.every(orgId => accessByOrg.has(orgId));
       if (!hasAccessToAll) {
         throw new TRPCError({
@@ -1089,8 +764,6 @@ export const usageAnalyticsRouter = createTRPCRouter({
         });
       }
 
-      // Only owner/billing_manager of *every* requested org may resolve other
-      // members; anyone else can resolve only their own id.
       const canSeeAllMembers = input.organizationIds.every(orgId => {
         const role = accessByOrg.get(orgId);
         return role === 'owner' || role === 'billing_manager';


### PR DESCRIPTION
## Summary

`/usage` (and the org usage-details dashboard) no longer depends on Snowflake.

`usageAnalytics.getSummary`, `getTimeseries`, `getBreakdown`, and `getTable` now query the Postgres **read replica** (`readDb`) against `microdollar_usage` joined to `microdollar_usage_metadata`, `feature`, and `mode`. Auth, scope listing, and user-label resolution were already on Postgres.

This is not a primary-DB swap. Gateway writes stay on the Frankfurt primary. Analytics reads use the same `timedUsageQuery` / `SET LOCAL statement_timeout` path as other usage endpoints (5s user / 10s org / 20s admin).

## Why this is safe enough

- Personal queries hit the existing `(kilo_user_id, created_at)` index.
- Org queries reuse the existing `organization_id` index plus the date predicate, matching `organizations.usageStats` and `/api/profile/usage`.
- Date windows are the caller-supplied ISO range, so we do not scan unbounded history.
- Hourly granularity still auto-downgrades after 8 days so a 30d/1y “hour” request does not emit tens of thousands of buckets.
- Personal-only scope uses `organization_id IS NULL` (Postgres), not Snowflake’s empty-string sentinel.
- Public leaderboards and KiloClaw trial-inactivity checks still use Snowflake.

## Follow-up

A composite `(organization_id, created_at)` index on `microdollar_usage` would make large org-wide 30d/1y queries cheaper. That should be added with `CREATE INDEX CONCURRENTLY` as a separate ops-aware migration, not in this PR.

## Test plan

- [x] Updated `usage-analytics-router.test.ts` for Postgres scope SQL (`IS NULL` personal org, market-cost column, include-orgs).
- [ ] `pnpm --filter web exec jest src/routers/usage-analytics-router.test.ts`
- [ ] Load `/usage` for a personal account (today / 7d / 30d) and confirm KPIs, charts, and table populate without Snowflake env.
- [ ] Load an org usage-details page as owner (self + org-wide + All Organizations).
- [ ] Confirm a missing/unreachable Snowflake config no longer zeros `/usage`.
- [ ] Confirm public leaderboard routes still work (unchanged Snowflake path).