### PR TITLE
fix(config): remove retired codebase search schema

### DIFF
--- a/apps/web/src/app/config.json/extras.ts
+++ b/apps/web/src/app/config.json/extras.ts
@@ -109,10 +109,6 @@ export const kiloExtras = {
     notebook_execute: { $ref: '#/$defs/PermissionRuleConfig' },
   },
   experimental: {
-    codebase_search: {
-      description: 'Enable AI-powered codebase search',
-      type: 'boolean',
-    },
     agent_requirements: {
       description:
         'Require declared agent skills, MCPs, and VS Code extensions before VS Code prompts can run',

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -119,9 +119,9 @@ describe('kilo config.json schema merge', () => {
     expect(permissionObject.properties.read).toBeDefined();
   });
 
-  test('adds kilo experimental keys without dropping upstream', () => {
+  test('merges kilo experimental keys without restoring retired keys', () => {
     const exp = props.experimental as { properties: Record<string, unknown> };
-    expect(exp.properties.codebase_search).toBeDefined();
+    expect(exp.properties.codebase_search).toBeUndefined();
     expect(exp.properties.agent_requirements).toEqual(expect.objectContaining({ type: 'boolean' }));
     expect(exp.properties.native_notebook_tools).toEqual(
       expect.objectContaining({ type: 'boolean' })


### PR DESCRIPTION
## Summary

Remove the retired `experimental.codebase_search` property from the Kilo Cloud config JSON Schema mirror after its removal in Kilo Code [PR #13084](https://github.com/Kilo-Org/kilocode/pull/13084).

Update the focused schema merge test to ensure the retired key remains absent while the surviving Kilo experimental keys and upstream keys are preserved.

## Verification

- [x] No manual testing required; this is a non-UI JSON Schema metadata cleanup.
- [x] `pnpm --filter web test -- --runInBand src/tests/cli-config-schema.test.ts` — 11 tests passed
- [x] Oxlint on both changed files
- [x] Oxfmt check on both changed files
- [x] `pnpm --filter web typecheck`
- [x] `git diff --check`

## Visual Changes

N/A
