### PR TITLE
fix(web): disable R2 checksums that break cloud agent image uploads

### DIFF
--- a/apps/web/src/lib/r2/client.ts
+++ b/apps/web/src/lib/r2/client.ts
@@ -1,5 +1,5 @@
-import { S3Client } from '@aws-sdk/client-s3';
 import { getEnvVariable } from '@/lib/dotenvx';
+import { createR2S3Client } from './create-r2-s3-client';
 
 // R2 configuration from environment variables
 const R2_ACCOUNT_ID = getEnvVariable('R2_ACCOUNT_ID');
@@ -39,13 +39,10 @@ if (!R2_CLI_SESSIONS_BUCKET_NAME) {
  * R2 is Cloudflare's S3-compatible object storage service.
  * The client is configured with R2-specific endpoint and credentials.
  */
-export const r2Client = new S3Client({
-  region: 'auto',
-  endpoint: `https://${R2_ACCOUNT_ID}.r2.cloudflarestorage.com`,
-  credentials: {
-    accessKeyId: R2_ACCESS_KEY_ID,
-    secretAccessKey: R2_SECRET_ACCESS_KEY,
-  },
+export const r2Client = createR2S3Client({
+  accountId: R2_ACCOUNT_ID,
+  accessKeyId: R2_ACCESS_KEY_ID,
+  secretAccessKey: R2_SECRET_ACCESS_KEY,
 });
 
 export const r2CliSessionsBucketName = R2_CLI_SESSIONS_BUCKET_NAME;

--- a/apps/web/src/lib/r2/create-r2-s3-client.test.ts
+++ b/apps/web/src/lib/r2/create-r2-s3-client.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { createR2S3Client as CreateR2S3Client } from './create-r2-s3-client';
+
+jest.mock('@aws-sdk/client-s3', () => ({
+  S3Client: jest.fn().mockImplementation((config: unknown) => ({ config })),
+}));
+
+let createR2S3Client: typeof CreateR2S3Client;
+let MockS3Client: jest.Mock;
+
+describe('createR2S3Client', () => {
+  beforeEach(async () => {
+    jest.clearAllMocks();
+    const aws = await import('@aws-sdk/client-s3');
+    const client = await import('./create-r2-s3-client');
+    MockS3Client = aws.S3Client as unknown as jest.Mock;
+    createR2S3Client = client.createR2S3Client;
+  });
+
+  it('disables flexible checksums so browser PUTs are not signed with empty-body CRC32', () => {
+    createR2S3Client({
+      accountId: 'deadbeef',
+      accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+      secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+    });
+
+    expect(MockS3Client).toHaveBeenCalledWith({
+      region: 'auto',
+      endpoint: 'https://deadbeef.r2.cloudflarestorage.com',
+      credentials: {
+        accessKeyId: 'AKIAIOSFODNN7EXAMPLE',
+        secretAccessKey: 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY',
+      },
+      requestChecksumCalculation: 'WHEN_REQUIRED',
+      responseChecksumValidation: 'WHEN_REQUIRED',
+    });
+  });
+});

--- a/apps/web/src/lib/r2/create-r2-s3-client.ts
+++ b/apps/web/src/lib/r2/create-r2-s3-client.ts
@@ -1,0 +1,24 @@
+import { S3Client } from '@aws-sdk/client-s3';
+
+export type R2S3ClientCredentials = {
+  accountId: string;
+  accessKeyId: string;
+  secretAccessKey: string;
+};
+
+export function createR2S3Client({
+  accountId,
+  accessKeyId,
+  secretAccessKey,
+}: R2S3ClientCredentials): S3Client {
+  return new S3Client({
+    region: 'auto',
+    endpoint: `https://${accountId}.r2.cloudflarestorage.com`,
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+    },
+    requestChecksumCalculation: 'WHEN_REQUIRED',
+    responseChecksumValidation: 'WHEN_REQUIRED',
+  });
+}


### PR DESCRIPTION
## Summary

Cloud agent image uploads fail in the browser with `Failed to upload file: Network error during upload`.

The composer PUTs directly to a Cloudflare R2 presigned URL. `@aws-sdk/client-s3` 3.729+ defaults to `requestChecksumCalculation: WHEN_SUPPORTED`, so `getSignedUrl` embeds `x-amz-checksum-crc32=AAAAAA==` (CRC32 of an empty body — the `PutObjectCommand` has no `Body` at sign time). The browser then uploads the real file; R2 rejects the checksum. That shows up as `xhr.onerror` rather than a readable HTTP status.

This disables flexible checksums on the shared R2 S3 client (`WHEN_REQUIRED`), matching the working Kilo Chat `aws4fetch` path.

## Test plan

- [x] `pnpm exec jest src/lib/r2/create-r2-s3-client.test.ts src/lib/r2/cloud-agent-attachments.test.ts` in `apps/web`
- [ ] Attach a PNG/JPEG in the cloud agent composer and confirm the thumbnail completes without the network-error toast
- [ ] Confirm send still includes the attachment