### PR TITLE
fix(web): add reduced-availability banner to usage page

### DIFF
--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/sheet';
 import { UsageTableBase, type UsageTableColumn } from '@/components/usage/UsageTableBase';
+import { UsageAvailabilityBanner } from '@/components/usage/UsageAvailabilityBanner';
 import { UsageWarning } from '@/components/usage/UsageWarning';
 import { SetPageTitle } from '@/components/SetPageTitle';
 import {
@@ -682,6 +683,8 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
 
         <div className="flex-1 overflow-y-auto">
           <div className="m-auto flex w-full max-w-[1140px] flex-col gap-6 p-4 md:p-6">
+            <UsageAvailabilityBanner />
+
             {hasEnterpriseUsageViews && (
               <div className="space-y-4">
                 <div>

--- a/apps/web/src/components/usage/UsageAvailabilityBanner.tsx
+++ b/apps/web/src/components/usage/UsageAvailabilityBanner.tsx
@@ -1,0 +1,26 @@
+import { TriangleAlert } from 'lucide-react';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+
+const USAGE_STATUS_INCIDENT_URL = 'https://status.kilo.ai/incidents/5djn5qjqlp1q';
+
+export function UsageAvailabilityBanner() {
+  return (
+    <Alert variant="warning">
+      <TriangleAlert className="size-4" />
+      <AlertDescription>
+        <span>
+          Usage currently has reduced availability.{' '}
+          <a
+            href={USAGE_STATUS_INCIDENT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:opacity-80"
+          >
+            Check the status page
+          </a>{' '}
+          for updates.
+        </span>
+      </AlertDescription>
+    </Alert>
+  );
+}


### PR DESCRIPTION
## Summary

Adds a warning banner to the usage dashboard (personal `/usage` and org usage-details) stating that usage has reduced availability, with a link to [status.kilo.ai incident 5djn5qjqlp1q](https://status.kilo.ai/incidents/5djn5qjqlp1q).

Uses the existing `Alert` warning variant, matching other status-page notices.

## Verification

- [ ] Not run in this environment (sandbox has no app session). Visual check of `/usage` recommended after deploy.

## Visual Changes

| Before | After |
|---|---|
| No incident notice on usage | Warning banner at top of usage content with status-page link |

## Reviewer Notes

Temporary incident banner — remove once the usage-page outage is resolved.