### PR TITLE
fix(web): stop killing the process on replica pool errors

### DIFF
--- a/apps/web/src/lib/drizzle.test.ts
+++ b/apps/web/src/lib/drizzle.test.ts
@@ -1,4 +1,4 @@
-import { pool, db, selectReplicaUrl } from '@/lib/drizzle';
+import { pool, db, selectReplicaUrl, shouldExitOnPoolError } from '@/lib/drizzle';
 
 describe('drizzle', () => {
   describe('pool', () => {
@@ -32,6 +32,24 @@ describe('drizzle', () => {
       } finally {
         consoleSpy.mockRestore();
       }
+    });
+
+    it('exits on a primary pool error outside test mode', () => {
+      // A dead primary pool means the process cannot serve traffic at all.
+      expect(shouldExitOnPoolError('primary', 'production')).toBe(true);
+    });
+
+    it('does not exit on a replica pool error outside test mode', () => {
+      // Regression guard: exiting here escalated a replica-only outage into 107
+      // instance terminations on 2026-08-12 while the primary was healthy.
+      // The replica is a read-path optimisation with a primary fallback, so a
+      // broken replica must degrade reads rather than kill the process.
+      expect(shouldExitOnPoolError('replica', 'production')).toBe(false);
+    });
+
+    it('never exits in test mode, so pool.end() cleanup cannot kill the runner', () => {
+      expect(shouldExitOnPoolError('primary', 'test')).toBe(false);
+      expect(shouldExitOnPoolError('replica', 'test')).toBe(false);
     });
   });
 

--- a/apps/web/src/lib/drizzle.ts
+++ b/apps/web/src/lib/drizzle.ts
@@ -130,14 +130,37 @@ if (process.env.NODE_ENV !== 'test') {
   }
 }
 
-// Pool error handlers: idle client errors trigger process exit in production
-// because a failed connection pool means the process cannot serve traffic.
-// In test mode, pool.end() during cleanup triggers idle client errors.
-// Attach a non-exiting listener in test mode to prevent Node from throwing
-// on an emitted error with zero listeners (same contract as replication-health.ts).
+/**
+ * Whether an idle-client pool error should terminate the process. Pure and
+ * exported so it can be unit-tested without a database, like `selectReplicaUrl`
+ * above and `classifyReplicaRow` in replication-health.ts.
+ *
+ * A dead *primary* pool means the process cannot serve traffic, so it exits and
+ * lets the platform replace the instance.
+ *
+ * A dead *replica* pool does not, so it only logs. The replica is a read-path
+ * optimisation and `selectReplicaUrl` already treats a missing replica as "use
+ * the primary". Exiting here escalated a replica-only outage into whole-instance
+ * termination: when both EU replicas refused connections on 2026-08-12 this
+ * handler fired 107 times in under an hour, killing instances whose primary was
+ * healthy the entire time and taking writes and primary reads down with them.
+ * Reads aimed at a broken replica now fail per-request instead.
+ *
+ * In test mode neither exits: `pool.end()` during cleanup emits idle-client
+ * errors, and a listener must stay attached so Node does not treat the emit as
+ * an unhandled throw.
+ */
+export function shouldExitOnPoolError(
+  poolKind: 'primary' | 'replica',
+  nodeEnv = process.env.NODE_ENV
+): boolean {
+  if (nodeEnv === 'test') return false;
+  return poolKind === 'primary';
+}
+
 pool.on('error', (err: Error) => {
   console.error('Unexpected error on idle client (primary)', err);
-  if (process.env.NODE_ENV !== 'test') {
+  if (shouldExitOnPoolError('primary')) {
     process.exit(-1);
   }
 });
@@ -145,7 +168,7 @@ pool.on('error', (err: Error) => {
 if (usesSeparateReplica) {
   replicaPool.on('error', (err: Error) => {
     console.error('Unexpected error on idle client (replica)', err);
-    if (process.env.NODE_ENV !== 'test') {
+    if (shouldExitOnPoolError('replica')) {
       process.exit(-1);
     }
   });


### PR DESCRIPTION
## What

The replica pool's idle-client error handler in `apps/web/src/lib/drizzle.ts` called `process.exit(-1)`. This stops it doing that. The primary pool's behaviour is unchanged.

The exit decision moves into a pure exported `shouldExitOnPoolError()` so it can be unit-tested.

## Why

During the EU read-replica outage today, this handler fired **107 times** between 12:53:40Z and 13:47:57Z on `kilocode-app`, terminating 107 function instances. The primary handler fired **zero** times in the same window — the primary was healthy the entire time.

```
Pool     | Project              | Count | Window
---------|----------------------|-------|-----------------------
replica  | kilocode-app         |  107  | 12:53:40Z → 13:47:57Z
replica  | kilocode-global-app  |    1  | 09:01:00Z
primary  | —                    |    0  | —
```

So a replica-only degradation was escalated into whole-instance termination, taking down writes and primary reads that were still serving fine, and forcing 107 cold starts that each reopened connections to *both* pools — extra primary connection churn during an incident that never involved the primary. That matters given the note at `drizzle.ts:89-93` about ~2,200 concurrent instances already pressing on Supabase's ~500 connection limit.

The old comment justified the exit as *"a failed connection pool means the process cannot serve traffic."* True for the primary. Not true for the replica, which is a read-path optimisation that already degrades gracefully — `selectReplicaUrl()` (`drizzle.ts:61-66`) treats a missing replica as "use the primary". The one case the comment didn't cover is exactly the case that fired 107 times.

The handlers date to the initial commit; #5011 only added the `NODE_ENV !== 'test'` guard, so exiting on replica errors was never a deliberate decision about replica failure modes.

## Tradeoff

This is a behaviour change, not a pure win. A broken replica pool now surfaces as per-request read errors instead of an instance restart. Today that would have meant degraded reads on `/usage`, `/profile` and similar rather than hard failures across the board — better, but reads can still fail.

The more complete fix is falling back to the primary at runtime when the replica pool is unhealthy. I deliberately left that out: the pools are module-level constants, it needs a routing layer, and it shifts read load onto a primary that is already connection-constrained. Worth doing separately with proper thought about load.

## Why a pure function

The previous inline `NODE_ENV !== 'test'` check made the behaviour untestable in-process — under Jest neither pool ever exits, so a test could not tell the primary and replica handlers apart. Extracting the decision follows the existing pattern of `selectReplicaUrl` here and `classifyReplicaRow` in `replication-health.ts`.

## Testing

- Three cases added to `drizzle.test.ts`: primary exits in production, replica does not, neither exits in test mode.
- **Regression guard verified**: temporarily restored the old behaviour (`return true`) and confirmed the replica test fails, then reverted.
- `drizzle.test.ts` + `replication-health.test.ts`: 26 passed.
- `pnpm --filter web lint`, `pnpm --filter web typecheck`, `pnpm format:check`: all clean.

## Note on the branch name

The branch is named `fix-db-pool-metrics` from the original investigation, which began with `/api/cron/db-pool-metrics`. That cron turned out to be healthy and is untouched here; this change is an unrelated finding from the same incident.
