### PR TITLE
fix(web): accept legacy user ids in support GDPR removal

### DIFF
--- a/apps/web/src/app/api/internal/support/users/gdpr-removal/route.test.ts
+++ b/apps/web/src/app/api/internal/support/users/gdpr-removal/route.test.ts
@@ -205,9 +205,10 @@ describe('POST /api/internal/support/users/gdpr-removal', () => {
   });
 
   describe('validation', () => {
-    test('returns 400 for an invalid body', async () => {
-      const res = await POST(request({ userId: 'not-a-uuid' }));
+    test('returns 400 for an empty userId', async () => {
+      const res = await POST(request({ userId: '   ' }));
       expect(res.status).toBe(400);
+      expect(await res.json()).toEqual({ error: 'Invalid body' });
       expect(mockedFindUserById).not.toHaveBeenCalled();
       expect(destroy).not.toHaveBeenCalled();
       expect(events).toHaveLength(0);
@@ -218,6 +219,32 @@ describe('POST /api/internal/support/users/gdpr-removal', () => {
       expect(res.status).toBe(400);
       expect(destroy).not.toHaveBeenCalled();
       expect(events).toHaveLength(0);
+    });
+  });
+
+  test('accepts legacy oauth/google user ids', async () => {
+    const legacyUserId = 'oauth/google:113825116714119418413';
+    mockedFindUserById.mockResolvedValue(
+      targetUser({ id: legacyUserId, google_user_email: CUSTOMER_EMAIL })
+    );
+    mockedListAllActiveInstanceRows.mockResolvedValue([]);
+    mockedAssertUserCanBeSoftDeleted.mockResolvedValue(undefined);
+    mockedSoftDeleteUser.mockResolvedValue(undefined as never);
+    mockedSoftDeleteUserExternalServices.mockResolvedValue([]);
+
+    const res = await POST(request({ userId: legacyUserId }));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toMatchObject({
+      success: true,
+      message: expect.stringContaining(legacyUserId),
+    });
+    expect(mockedFindUserById).toHaveBeenCalledWith(legacyUserId);
+    expect(mockedSoftDeleteUser).toHaveBeenCalledWith(legacyUserId);
+    expect(events[0]).toMatchObject({
+      outcome: 'deleted',
+      claimedActorEmail: ACTOR_EMAIL,
+      correlationId: REQUEST_ID,
+      target: `user:${legacyUserId}`,
     });
   });
 

--- a/apps/web/src/app/api/internal/support/users/gdpr-removal/route.ts
+++ b/apps/web/src/app/api/internal/support/users/gdpr-removal/route.ts
@@ -20,7 +20,7 @@ import {
 } from '../../_auth';
 
 const BodySchema = z.object({
-  userId: z.string().uuid(),
+  userId: z.string().trim().min(1).max(256),
   email: z.string().trim().toLowerCase().email(),
   actorEmail: ActorEmailSchema,
   requestId: RequestIdSchema,


### PR DESCRIPTION
## Summary
- Support GDPR removal required `userId` to be a UUID, so CSA deletes for legacy NextAuth ids (`oauth/google:…`) failed with HTTP 400 `Invalid body`, which CSA maps to `cloudOutcome: precondition`.
- Admin panel delete worked because it does not apply that UUID check.
- Accept non-empty text user ids (with a length cap) to match `kilocode_users.id`.

## Test plan
- [x] `pnpm test -- src/app/api/internal/support/users/gdpr-removal/route.test.ts` (27 passed)
- [ ] Retry a CSA GDPR deletion for a user with a legacy `oauth/google:…` id after deploy
- [ ] Confirm UUID user ids still delete successfully via support API