### PR TITLE
test(web): mock legacy user id in GDPR removal test

### DIFF
--- a/apps/web/src/app/api/internal/support/users/gdpr-removal/route.test.ts
+++ b/apps/web/src/app/api/internal/support/users/gdpr-removal/route.test.ts
@@ -223,7 +223,7 @@ describe('POST /api/internal/support/users/gdpr-removal', () => {
   });
 
   test('accepts legacy oauth/google user ids', async () => {
-    const legacyUserId = 'oauth/google:113825116714119418413';
+    const legacyUserId = 'oauth/google:123456789012345678901';
     mockedFindUserById.mockResolvedValue(
       targetUser({ id: legacyUserId, google_user_email: CUSTOMER_EMAIL })
     );


### PR DESCRIPTION
## Summary
- Replaces a real-looking OAuth Google subject id in the support GDPR removal route test with a clearly fake mock id.

## Test plan
- [x] Diff-only fixture change; no behavior change
- [ ] Optional: `pnpm --filter @kilocode/web test src/app/api/internal/support/users/gdpr-removal/route.test.ts`