### PR TITLE
feat(ai-gateway): add Vercel routing opt-outs

### DIFF
--- a/apps/web/src/app/admin/gateway/RoutingContent.tsx
+++ b/apps/web/src/app/admin/gateway/RoutingContent.tsx
@@ -24,6 +24,7 @@ export function RoutingContent() {
 
   const [inputValue, setInputValue] = useState('');
   const [freeInputValue, setFreeInputValue] = useState('');
+  const [optOutModelsValue, setOptOutModelsValue] = useState('');
   const [noteValue, setNoteValue] = useState('');
   const [hasChanges, setHasChanges] = useState(false);
 
@@ -31,6 +32,7 @@ export function RoutingContent() {
     if (data) {
       setInputValue(data.vercel_routing_percentage?.toString() ?? '');
       setFreeInputValue(data.vercel_routing_percentage_free?.toString() ?? '');
+      setOptOutModelsValue(data.vercel_routing_opt_out_models.join('\n'));
       setNoteValue('');
       setHasChanges(false);
     }
@@ -42,7 +44,7 @@ export function RoutingContent() {
         void queryClient.invalidateQueries({
           queryKey: trpc.admin.gatewayConfig.get.queryKey(),
         });
-        toast.success('Vercel routing percentage updated');
+        toast.success('Vercel routing configuration updated');
       },
       onError: error => {
         toast.error(error.message || 'Failed to update');
@@ -63,6 +65,17 @@ export function RoutingContent() {
     return num;
   }
 
+  function optOutModels() {
+    return [
+      ...new Set(
+        optOutModelsValue
+          .split('\n')
+          .map(model => model.trim())
+          .filter(Boolean)
+      ),
+    ];
+  }
+
   function handleSave() {
     const note = noteInput();
     const paid = parsePercentage(inputValue);
@@ -76,6 +89,7 @@ export function RoutingContent() {
     mutation.mutate({
       vercel_routing_percentage: paid,
       vercel_routing_percentage_free: free,
+      vercel_routing_opt_out_models: optOutModels(),
       note,
     });
   }
@@ -84,6 +98,7 @@ export function RoutingContent() {
     mutation.mutate({
       vercel_routing_percentage: null,
       vercel_routing_percentage_free: null,
+      vercel_routing_opt_out_models: optOutModels(),
       note: noteInput(),
     });
   }
@@ -102,7 +117,7 @@ export function RoutingContent() {
     <div className="flex w-full flex-col gap-y-6">
       <Card>
         <CardHeader>
-          <CardTitle>Vercel Routing Percentage</CardTitle>
+          <CardTitle>Vercel Routing</CardTitle>
           <CardDescription>
             For models available on the Vercel AI Gateway, controls the percentage of traffic routed
             to Vercel (vs OpenRouter). Models not available on Vercel always go to OpenRouter, so
@@ -157,6 +172,26 @@ export function RoutingContent() {
               className="w-48"
             />
             <span className="text-muted-foreground text-sm">%</span>
+          </div>
+          <div className="flex flex-col gap-2">
+            <Label htmlFor="routing-opt-out-models">Opt-out models</Label>
+            <Textarea
+              id="routing-opt-out-models"
+              aria-describedby="routing-opt-out-models-description"
+              placeholder={'moonshotai/kimi-k3\nprovider/another-model'}
+              value={optOutModelsValue}
+              onChange={e => {
+                setOptOutModelsValue(e.target.value);
+                setHasChanges(true);
+              }}
+              rows={6}
+              className="font-mono text-sm"
+            />
+            <p id="routing-opt-out-models-description" className="text-muted-foreground text-xs">
+              One model ID per line. Matching is exact after entries are lowercased; matching models
+              are excluded from percentage-based Vercel routing. Changes take effect within one
+              minute on warm instances.
+            </p>
           </div>
           <div className="flex items-center gap-3">
             <Button onClick={handleSave} disabled={mutation.isPending || !hasChanges} size="sm">

--- a/apps/web/src/lib/ai-gateway/gateway-config.test.ts
+++ b/apps/web/src/lib/ai-gateway/gateway-config.test.ts
@@ -1,6 +1,6 @@
 import { describe, test, expect } from '@jest/globals';
 import {
-  GatewayPercentageSchema,
+  GatewayRoutingConfigSchema,
   GatewayConfigSchema,
   GatewayConfigInputSchema,
   NOTE_MAX_LENGTH,
@@ -17,42 +17,62 @@ describe('VercelRoutingPercentageSchema', () => {
   });
 });
 
-describe('GatewayPercentageSchema', () => {
+describe('GatewayRoutingConfigSchema', () => {
   test('accepts a numeric percentage', () => {
-    expect(GatewayPercentageSchema.parse({ vercel_routing_percentage: 25 })).toEqual({
+    expect(GatewayRoutingConfigSchema.parse({ vercel_routing_percentage: 25 })).toEqual({
       vercel_routing_percentage: 25,
       vercel_routing_percentage_free: null,
+      vercel_routing_opt_out_models: [],
     });
   });
 
   test('accepts null (written when an admin clears the override)', () => {
-    expect(GatewayPercentageSchema.parse({ vercel_routing_percentage: null })).toEqual({
+    expect(GatewayRoutingConfigSchema.parse({ vercel_routing_percentage: null })).toEqual({
       vercel_routing_percentage: null,
       vercel_routing_percentage_free: null,
+      vercel_routing_opt_out_models: [],
     });
   });
 
   test('defaults the free percentage to null for pre-existing entries', () => {
-    expect(GatewayPercentageSchema.parse({ vercel_routing_percentage: 25 })).toEqual({
+    expect(GatewayRoutingConfigSchema.parse({ vercel_routing_percentage: 25 })).toEqual({
       vercel_routing_percentage: 25,
       vercel_routing_percentage_free: null,
+      vercel_routing_opt_out_models: [],
     });
   });
 
   test('accepts a separate free percentage', () => {
     expect(
-      GatewayPercentageSchema.parse({
+      GatewayRoutingConfigSchema.parse({
         vercel_routing_percentage: 25,
         vercel_routing_percentage_free: 80,
       })
-    ).toEqual({ vercel_routing_percentage: 25, vercel_routing_percentage_free: 80 });
+    ).toEqual({
+      vercel_routing_percentage: 25,
+      vercel_routing_percentage_free: 80,
+      vercel_routing_opt_out_models: [],
+    });
+  });
+
+  test('accepts model opt-outs', () => {
+    expect(
+      GatewayRoutingConfigSchema.parse({
+        vercel_routing_percentage: 25,
+        vercel_routing_opt_out_models: ['moonshotai/kimi-k3'],
+      })
+    ).toEqual({
+      vercel_routing_percentage: 25,
+      vercel_routing_percentage_free: null,
+      vercel_routing_opt_out_models: ['moonshotai/kimi-k3'],
+    });
   });
 
   test('rejects out-of-range values', () => {
-    expect(() => GatewayPercentageSchema.parse({ vercel_routing_percentage: 101 })).toThrow();
-    expect(() => GatewayPercentageSchema.parse({ vercel_routing_percentage: -1 })).toThrow();
+    expect(() => GatewayRoutingConfigSchema.parse({ vercel_routing_percentage: 101 })).toThrow();
+    expect(() => GatewayRoutingConfigSchema.parse({ vercel_routing_percentage: -1 })).toThrow();
     expect(() =>
-      GatewayPercentageSchema.parse({
+      GatewayRoutingConfigSchema.parse({
         vercel_routing_percentage: 25,
         vercel_routing_percentage_free: 101,
       })
@@ -69,6 +89,7 @@ describe('GatewayConfigSchema', () => {
       updated_by_email: 'a@example.com',
     });
     expect(parsed.note).toBeNull();
+    expect(parsed.vercel_routing_opt_out_models).toEqual([]);
   });
 
   test('round-trips a note', () => {
@@ -89,11 +110,13 @@ describe('GatewayConfigInputSchema', () => {
       GatewayConfigInputSchema.parse({
         vercel_routing_percentage: 75,
         vercel_routing_percentage_free: 60,
+        vercel_routing_opt_out_models: ['moonshotai/kimi-k3'],
         note: 'Rollout stable',
       })
     ).toEqual({
       vercel_routing_percentage: 75,
       vercel_routing_percentage_free: 60,
+      vercel_routing_opt_out_models: ['moonshotai/kimi-k3'],
       note: 'Rollout stable',
     });
   });
@@ -103,11 +126,13 @@ describe('GatewayConfigInputSchema', () => {
       GatewayConfigInputSchema.parse({
         vercel_routing_percentage: null,
         vercel_routing_percentage_free: null,
+        vercel_routing_opt_out_models: [],
         note: null,
       })
     ).toEqual({
       vercel_routing_percentage: null,
       vercel_routing_percentage_free: null,
+      vercel_routing_opt_out_models: [],
       note: null,
     });
   });
@@ -117,6 +142,7 @@ describe('GatewayConfigInputSchema', () => {
       GatewayConfigInputSchema.parse({
         vercel_routing_percentage: 50,
         vercel_routing_percentage_free: 50,
+        vercel_routing_opt_out_models: [],
         note: 'x'.repeat(NOTE_MAX_LENGTH + 1),
       })
     ).toThrow();

--- a/apps/web/src/lib/ai-gateway/gateway-config.ts
+++ b/apps/web/src/lib/ai-gateway/gateway-config.ts
@@ -12,6 +12,7 @@ const note = z.string().max(NOTE_MAX_LENGTH);
 export const GatewayConfigSchema = z.object({
   vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
   vercel_routing_percentage_free: VercelRoutingPercentageSchema.nullable().default(null),
+  vercel_routing_opt_out_models: z.array(z.string().min(1)).default([]),
   updated_at: z.string().nullable(),
   updated_by: z.string().nullable(),
   updated_by_email: z.string().nullable(),
@@ -23,6 +24,7 @@ export type GatewayConfig = z.infer<typeof GatewayConfigSchema>;
 export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {
   vercel_routing_percentage: null,
   vercel_routing_percentage_free: null,
+  vercel_routing_opt_out_models: [],
   updated_at: null,
   updated_by: null,
   updated_by_email: null,
@@ -30,7 +32,7 @@ export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {
 };
 
 /**
- * Schema for parsing just the percentage from Redis (used on the hot path).
+ * Schema for parsing the routing settings from Redis (used on the hot path).
  *
  * `vercel_routing_percentage` is nullable because clearing the override in
  * the admin UI persists an explicit `null`. Callers should treat `null` as
@@ -41,14 +43,16 @@ export const DEFAULT_GATEWAY_CONFIG: GatewayConfig = {
  * parse cleanly. Callers should treat `null` as "no override, use
  * DEFAULT_VERCEL_PERCENTAGE_FREE".
  */
-export const GatewayPercentageSchema = z.object({
+export const GatewayRoutingConfigSchema = z.object({
   vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
   vercel_routing_percentage_free: VercelRoutingPercentageSchema.nullable().default(null),
+  vercel_routing_opt_out_models: z.array(z.string().min(1)).default([]),
 });
 
 /** Schema for the admin set-mutation input. */
 export const GatewayConfigInputSchema = z.object({
   vercel_routing_percentage: VercelRoutingPercentageSchema.nullable(),
   vercel_routing_percentage_free: VercelRoutingPercentageSchema.nullable(),
+  vercel_routing_opt_out_models: z.array(z.string()),
   note: note.nullable(),
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from '@jest/globals';
+import { describe, it, expect, jest } from '@jest/globals';
 import {
   applyVercelSettings,
   convertProviderOptions,
@@ -6,9 +6,28 @@ import {
   getVercelInferenceProvidersExcludingIgnored,
   hasCompatibleVercelInferenceProvider,
   passesVercelRoutingPercentage,
+  shouldRouteToVercel,
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import { redisClient } from '@/lib/redis';
+import { getVercelModelsFromRedis } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
+
+jest.mock('@/lib/redis', () => ({
+  redisClient: { get: jest.fn() },
+}));
+jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
+  getCachedVercelInferenceProviderIdsForModel: jest.fn(),
+  getVercelModelsFromRedis: jest.fn(),
+}));
+jest.mock('@/lib/ai-gateway/is-free-model', () => ({
+  isFreeModel: jest.fn(),
+}));
+
+const mockedRedisGet = jest.mocked(redisClient.get);
+const mockedGetVercelModels = jest.mocked(getVercelModelsFromRedis);
+const mockedIsFreeModel = jest.mocked(isFreeModel);
 
 describe('getAnthropicProviderOptionsForVercel', () => {
   it('maps chat completion verbosity to Anthropic effort', () => {
@@ -205,5 +224,33 @@ describe('passesVercelRoutingPercentage', () => {
 
     expect(seedsInFinalBucket.some(seed => passesVercelRoutingPercentage(seed, 99.9))).toBe(true);
     expect(seedsInFinalBucket.some(seed => !passesVercelRoutingPercentage(seed, 99.9))).toBe(true);
+  });
+});
+
+describe('shouldRouteToVercel', () => {
+  it('only opts out exact model ID matches', async () => {
+    mockedRedisGet.mockResolvedValue(
+      JSON.stringify({
+        vercel_routing_percentage: 100,
+        vercel_routing_percentage_free: 100,
+        vercel_routing_opt_out_models: ['moonshotai/kimi-k3'],
+      })
+    );
+    mockedGetVercelModels.mockResolvedValue(
+      new Set(['moonshotai/kimi-k3', 'moonshotai/kimi-k3-fast'])
+    );
+    mockedIsFreeModel.mockResolvedValue(false);
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'moonshotai/kimi-k3',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    };
+
+    await expect(shouldRouteToVercel('moonshotai/kimi-k3', request, 'user-1')).resolves.toBe(false);
+    await expect(shouldRouteToVercel('moonshotai/kimi-k3-fast', request, 'user-1')).resolves.toBe(
+      true
+    );
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -1,33 +1,15 @@
-import { describe, it, expect, jest } from '@jest/globals';
+import { describe, it, expect } from '@jest/globals';
 import {
   applyVercelSettings,
   convertProviderOptions,
   getAnthropicProviderOptionsForVercel,
   getVercelInferenceProvidersExcludingIgnored,
   hasCompatibleVercelInferenceProvider,
+  isVercelRoutingOptOut,
   passesVercelRoutingPercentage,
-  shouldRouteToVercel,
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
-import { redisClient } from '@/lib/redis';
-import { getVercelModelsFromRedis } from '@/lib/ai-gateway/providers/gateway-models-cache';
-import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
-
-jest.mock('@/lib/redis', () => ({
-  redisClient: { get: jest.fn() },
-}));
-jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
-  getCachedVercelInferenceProviderIdsForModel: jest.fn(),
-  getVercelModelsFromRedis: jest.fn(),
-}));
-jest.mock('@/lib/ai-gateway/is-free-model', () => ({
-  isFreeModel: jest.fn(),
-}));
-
-const mockedRedisGet = jest.mocked(redisClient.get);
-const mockedGetVercelModels = jest.mocked(getVercelModelsFromRedis);
-const mockedIsFreeModel = jest.mocked(isFreeModel);
 
 describe('getAnthropicProviderOptionsForVercel', () => {
   it('maps chat completion verbosity to Anthropic effort', () => {
@@ -227,30 +209,11 @@ describe('passesVercelRoutingPercentage', () => {
   });
 });
 
-describe('shouldRouteToVercel', () => {
-  it('only opts out exact model ID matches', async () => {
-    mockedRedisGet.mockResolvedValue(
-      JSON.stringify({
-        vercel_routing_percentage: 100,
-        vercel_routing_percentage_free: 100,
-        vercel_routing_opt_out_models: ['moonshotai/kimi-k3'],
-      })
-    );
-    mockedGetVercelModels.mockResolvedValue(
-      new Set(['moonshotai/kimi-k3', 'moonshotai/kimi-k3-fast'])
-    );
-    mockedIsFreeModel.mockResolvedValue(false);
-    const request: GatewayRequest = {
-      kind: 'chat_completions',
-      body: {
-        model: 'moonshotai/kimi-k3',
-        messages: [{ role: 'user', content: 'hello' }],
-      },
-    };
+describe('isVercelRoutingOptOut', () => {
+  it('only opts out exact model ID matches', () => {
+    const optOutModels = new Set(['moonshotai/kimi-k3']);
 
-    await expect(shouldRouteToVercel('moonshotai/kimi-k3', request, 'user-1')).resolves.toBe(false);
-    await expect(shouldRouteToVercel('moonshotai/kimi-k3-fast', request, 'user-1')).resolves.toBe(
-      true
-    );
+    expect(isVercelRoutingOptOut('moonshotai/kimi-k3', optOutModels)).toBe(true);
+    expect(isVercelRoutingOptOut('moonshotai/kimi-k3-fast', optOutModels)).toBe(false);
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -15,7 +15,7 @@ import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelId
 import { redisClient } from '@/lib/redis';
 import { createCachedFetch } from '@/lib/cached-fetch';
 import {
-  GatewayPercentageSchema,
+  GatewayRoutingConfigSchema,
   DEFAULT_VERCEL_PERCENTAGE,
   DEFAULT_VERCEL_PERCENTAGE_FREE,
 } from '@/lib/ai-gateway/gateway-config';
@@ -27,31 +27,36 @@ import {
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { isKimiModel } from '@/lib/ai-gateway/providers/moonshotai';
 
-type VercelRoutingPercentages = {
+type VercelRoutingConfig = {
   paid: number;
   free: number;
+  optOutModels: ReadonlySet<string>;
 };
 
-const DEFAULT_VERCEL_ROUTING_PERCENTAGES: VercelRoutingPercentages = {
+const DEFAULT_VERCEL_ROUTING_CONFIG: VercelRoutingConfig = {
   paid: DEFAULT_VERCEL_PERCENTAGE,
   free: DEFAULT_VERCEL_PERCENTAGE_FREE,
+  optOutModels: new Set(),
 };
 
-const getVercelRoutingPercentages = createCachedFetch<VercelRoutingPercentages>(
+const getVercelRoutingConfig = createCachedFetch<VercelRoutingConfig>(
   async () => {
     const raw = await redisClient.get<string>(VERCEL_ROUTING_REDIS_KEY);
-    if (!raw) return DEFAULT_VERCEL_ROUTING_PERCENTAGES;
-    const { vercel_routing_percentage, vercel_routing_percentage_free } =
-      GatewayPercentageSchema.parse(JSON.parse(raw));
+    if (!raw) return DEFAULT_VERCEL_ROUTING_CONFIG;
+    const {
+      vercel_routing_percentage,
+      vercel_routing_percentage_free,
+      vercel_routing_opt_out_models,
+    } = GatewayRoutingConfigSchema.parse(JSON.parse(raw));
     return {
       paid: vercel_routing_percentage ?? DEFAULT_VERCEL_PERCENTAGE,
       free: vercel_routing_percentage_free ?? DEFAULT_VERCEL_PERCENTAGE_FREE,
+      optOutModels: new Set(vercel_routing_opt_out_models),
     };
   },
-  600_000,
-  DEFAULT_VERCEL_ROUTING_PERCENTAGES
+  60_000,
+  DEFAULT_VERCEL_ROUTING_CONFIG
 );
 
 export function hasCompatibleVercelInferenceProvider(
@@ -95,16 +100,15 @@ export async function shouldRouteToVercel(
   request: GatewayRequest,
   randomSeed: string
 ) {
-  if (isKimiModel(requestedModel)) {
-    // 2026-08-12: K3 is timing out during review, let's see if this fixes it.
+  const routingConfig = await getVercelRoutingConfig();
+  if (routingConfig.optOutModels.has(requestedModel)) {
     return false;
   }
 
   console.debug('[shouldRouteToVercel] randomizing user to either OpenRouter or Vercel');
-  const percentages = await getVercelRoutingPercentages();
   const routingPercentage = (await isFreeModel(requestedModel))
-    ? percentages.free
-    : percentages.paid;
+    ? routingConfig.free
+    : routingConfig.paid;
 
   const passedRandomization = passesVercelRoutingPercentage(randomSeed, routingPercentage);
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -95,13 +95,17 @@ export function passesVercelRoutingPercentage(randomSeed: string, routingPercent
   return wholePercentageBucket + fractionalPercentageBucket / 1_000 < routingPercentage;
 }
 
+export function isVercelRoutingOptOut(requestedModel: string, optOutModels: ReadonlySet<string>) {
+  return optOutModels.has(requestedModel);
+}
+
 export async function shouldRouteToVercel(
   requestedModel: string,
   request: GatewayRequest,
   randomSeed: string
 ) {
   const routingConfig = await getVercelRoutingConfig();
-  if (routingConfig.optOutModels.has(requestedModel)) {
+  if (isVercelRoutingOptOut(requestedModel, routingConfig.optOutModels)) {
     return false;
   }
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -106,6 +106,7 @@ export async function shouldRouteToVercel(
 ) {
   const routingConfig = await getVercelRoutingConfig();
   if (isVercelRoutingOptOut(requestedModel, routingConfig.optOutModels)) {
+    console.debug(`[shouldRouteToVercel] model ${requestedModel} opted out of Vercel routing`);
     return false;
   }
 

--- a/apps/web/src/routers/admin/gateway-config-router.ts
+++ b/apps/web/src/routers/admin/gateway-config-router.ts
@@ -25,9 +25,15 @@ export const adminGatewayConfigRouter = createTRPCRouter({
   }),
 
   set: adminProcedure.input(GatewayConfigInputSchema).mutation(async ({ input, ctx }) => {
+    const optOutModels = [
+      ...new Set(
+        input.vercel_routing_opt_out_models.map(model => model.trim().toLowerCase()).filter(Boolean)
+      ),
+    ];
     const config: GatewayConfig = {
       vercel_routing_percentage: input.vercel_routing_percentage,
       vercel_routing_percentage_free: input.vercel_routing_percentage_free,
+      vercel_routing_opt_out_models: optOutModels,
       updated_at: new Date().toISOString(),
       updated_by: ctx.user.id,
       updated_by_email: ctx.user.google_user_email,


### PR DESCRIPTION
## Summary
- replace the hardcoded Kimi Vercel routing exception with a Redis-backed exact-match model opt-out list
- normalize and deduplicate model IDs through the existing audited gateway routing config
- add a multiline admin control and reduce warm-instance config propagation to one minute

## Testing
- Not run locally per request; CI will validate the change.