### PR TITLE
fix(web): preserve gateway note line breaks

### DIFF
--- a/apps/web/src/app/admin/gateway/RoutingContent.tsx
+++ b/apps/web/src/app/admin/gateway/RoutingContent.tsx
@@ -250,7 +250,7 @@ export function RoutingContent() {
               </p>
             )}
             {data?.note && (
-              <p className="mt-2">
+              <p className="mt-2 whitespace-pre-wrap">
                 <span className="font-medium">Previous note:</span> {data.note}
               </p>
             )}


### PR DESCRIPTION
## Summary
- preserve newline characters when rendering the previous Vercel gateway routing note

## Testing
- Not run locally; CI will validate the change.