### PR TITLE
chore(ai-gateway): update Grok latest alias mapping to grok-4.6

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/xai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/xai.ts
@@ -1,4 +1,4 @@
-export const GROK_CURRENT_VERCEL_MODEL_ID = 'xai/grok-4.5';
+export const GROK_CURRENT_VERCEL_MODEL_ID = 'xai/grok-4.6';
 
 export function isGrokModel(requestedModel: string) {
   return requestedModel.includes('grok');


### PR DESCRIPTION
Updates `GROK_CURRENT_VERCEL_MODEL_ID` to `xai/grok-4.6` reflecting the latest Grok model (`x-ai/grok-4.6`) from the OpenRouter model catalog.