### PR TITLE
fix(web): exclude Kilo Pass from Teams seat price display

### DIFF
--- a/apps/web/src/components/subscriptions/seats/SeatsDetail.tsx
+++ b/apps/web/src/components/subscriptions/seats/SeatsDetail.tsx
@@ -26,6 +26,7 @@ import { DetailPageHeader } from '@/components/subscriptions/DetailPageHeader';
 import { BillingHistoryTable } from '@/components/subscriptions/BillingHistoryTable';
 import { formatDateLabel, isSeatsTerminal } from '@/components/subscriptions/helpers';
 import { useCursorPagination } from '@/components/subscriptions/useCursorPagination';
+import { formatSeatPrice, getSeatPriceInterval } from './seat-price';
 
 export function SeatsDetail({ organizationId }: { organizationId: string }) {
   const trpc = useTRPC();
@@ -163,12 +164,7 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
 
   const paidSeatItemId = subscriptionQuery.data?.paidSeatItemId ?? null;
   const paidSeatItem = subscription.items.data.find(item => item.id === paidSeatItemId) ?? null;
-  const currentInterval =
-    paidSeatItem?.price?.recurring?.interval === 'year' ? 'annual' : 'monthly';
-  const totalAmount = subscription.items.data.reduce(
-    (sum, item) => sum + (item.price?.unit_amount ?? 0) * (item.quantity ?? 0),
-    0
-  );
+  const currentInterval = getSeatPriceInterval(paidSeatItem) === 'year' ? 'annual' : 'monthly';
   const hasPendingCycleChange = subscription.schedule != null;
   const hasKiloPass =
     kiloPassQuery.data?.commercialState === 'active' ||
@@ -200,7 +196,7 @@ export function SeatsDetail({ organizationId }: { organizationId: string }) {
             <DetailRow label="Billing cycle" value={capitalize(currentInterval)} />
             <DetailRow
               label="Price"
-              value={`$${(totalAmount / 100).toFixed(2)}/${currentInterval === 'annual' ? 'year' : 'month'}`}
+              value={formatSeatPrice(subscription.items.data, paidSeatItemId)}
             />
             <DetailRow
               label="Next billing"

--- a/apps/web/src/components/subscriptions/seats/SeatsGroup.tsx
+++ b/apps/web/src/components/subscriptions/seats/SeatsGroup.tsx
@@ -3,7 +3,6 @@
 import { useQuery } from '@tanstack/react-query';
 import { Users } from 'lucide-react';
 import type { ReactNode } from 'react';
-import type Stripe from 'stripe';
 import { useTRPC } from '@/lib/trpc/utils';
 import { SubscriptionCard } from '@/components/subscriptions/SubscriptionCard';
 import { SubscriptionGroup } from '@/components/subscriptions/SubscriptionGroup';
@@ -14,20 +13,8 @@ import {
 } from '@/components/subscriptions/helpers';
 import type { OrganizationPlan } from '@/lib/organizations/organization-types';
 import { capitalize } from '@/lib/utils';
+import { formatSeatPrice } from './seat-price';
 import { SeatsSubscribeCard } from './SeatsSubscribeCard';
-
-function getSeatPrice(
-  subscription: Stripe.Subscription,
-  paidSeatItem: Stripe.SubscriptionItem | null
-) {
-  const totalAmount = subscription.items.data.reduce(
-    (sum: number, item: Stripe.SubscriptionItem) =>
-      sum + (item.price?.unit_amount ?? 0) * (item.quantity ?? 0),
-    0
-  );
-  const interval = paidSeatItem?.price?.recurring?.interval === 'year' ? 'year' : 'month';
-  return `$${(totalAmount / 100).toFixed(2)}/${interval}`;
-}
 
 export function SeatsGroup({
   organizationId,
@@ -76,7 +63,7 @@ export function SeatsGroup({
               title={planName}
               subtitle={`${query.data?.seatsUsed ?? 0} of ${query.data?.totalSeats ?? 0} seats in use`}
               status={subscription.status}
-              price={getSeatPrice(subscription, paidSeatItem)}
+              price={formatSeatPrice(subscription.items.data, paidSeatItemId)}
               billingDate={formatDateLabel(
                 paidSeatItem?.current_period_end
                   ? new Date(paidSeatItem.current_period_end * 1000).toISOString()

--- a/apps/web/src/components/subscriptions/seats/seat-price.test.ts
+++ b/apps/web/src/components/subscriptions/seats/seat-price.test.ts
@@ -1,0 +1,120 @@
+import { formatSeatPrice, getSeatPriceInterval, getSeatPriceLineItems } from './seat-price';
+
+function item(overrides: {
+  id: string;
+  quantity?: number | null;
+  unitAmount?: number | null;
+  product?: unknown;
+  interval?: string | null;
+}) {
+  return {
+    id: overrides.id,
+    quantity: overrides.quantity,
+    price: {
+      product: overrides.product ?? 'prod_teams',
+      unit_amount: overrides.unitAmount,
+      recurring: { interval: overrides.interval ?? 'month' },
+    },
+  };
+}
+
+describe('formatSeatPrice', () => {
+  test('displays only the recurring seat-item amount for a seat-only subscription', () => {
+    expect(
+      formatSeatPrice([item({ id: 'si_teams', quantity: 3, unitAmount: 1800 })], 'si_teams')
+    ).toBe('$54.00/month');
+  });
+
+  test('excludes Kilo Pass and other add-on items from the Teams price', () => {
+    expect(
+      formatSeatPrice(
+        [
+          item({ id: 'si_teams', quantity: 3, unitAmount: 1800, product: 'prod_teams' }),
+          item({
+            id: 'si_pass',
+            quantity: 3,
+            unitAmount: 4900,
+            product: 'prod_kilo_pass',
+          }),
+        ],
+        'si_teams'
+      )
+    ).toBe('$54.00/month');
+  });
+
+  test('sums multiple qualifying seat items that share the paid seat product', () => {
+    expect(
+      formatSeatPrice(
+        [
+          item({ id: 'si_paid', quantity: 2, unitAmount: 1800, product: 'prod_teams' }),
+          item({ id: 'si_extra', quantity: 1, unitAmount: 1800, product: 'prod_teams' }),
+          item({ id: 'si_pass', quantity: 3, unitAmount: 4900, product: 'prod_kilo_pass' }),
+        ],
+        'si_paid'
+      )
+    ).toBe('$54.00/month');
+  });
+
+  test('treats missing quantity and unit amount as zero', () => {
+    expect(
+      formatSeatPrice(
+        [
+          item({ id: 'si_missing_qty', quantity: null, unitAmount: 1800 }),
+          item({ id: 'si_missing_amount', quantity: 3, unitAmount: null, product: 'prod_teams' }),
+        ],
+        'si_missing_qty'
+      )
+    ).toBe('$0.00/month');
+  });
+
+  test('returns a zero monthly price when the paid seat item is missing', () => {
+    expect(
+      formatSeatPrice(
+        [item({ id: 'si_pass', quantity: 3, unitAmount: 4900, product: 'prod_kilo_pass' })],
+        null
+      )
+    ).toBe('$0.00/month');
+  });
+
+  test('preserves yearly billing interval from the paid seat item', () => {
+    expect(
+      formatSeatPrice(
+        [item({ id: 'si_teams', quantity: 3, unitAmount: 18000, interval: 'year' })],
+        'si_teams'
+      )
+    ).toBe('$540.00/year');
+  });
+});
+
+describe('getSeatPriceLineItems', () => {
+  test('includes free promotional seats on the same product and skips add-ons', () => {
+    const items = [
+      item({ id: 'si_paid', quantity: 3, unitAmount: 1800, product: 'prod_teams' }),
+      item({ id: 'si_free', quantity: 2, unitAmount: 0, product: 'prod_teams' }),
+      item({ id: 'si_pass', quantity: 3, unitAmount: 4900, product: 'prod_kilo_pass' }),
+    ];
+
+    expect(getSeatPriceLineItems(items, 'si_paid').map(seatItem => seatItem.id)).toEqual([
+      'si_paid',
+      'si_free',
+    ]);
+  });
+
+  test('falls back to only the paid item when its product id is not a string', () => {
+    const items = [
+      item({ id: 'si_paid', quantity: 3, unitAmount: 1800, product: { id: 'prod_teams' } }),
+      item({ id: 'si_other', quantity: 1, unitAmount: 1800, product: 'prod_teams' }),
+    ];
+
+    expect(getSeatPriceLineItems(items, 'si_paid').map(seatItem => seatItem.id)).toEqual([
+      'si_paid',
+    ]);
+  });
+});
+
+describe('getSeatPriceInterval', () => {
+  test('defaults to month when the paid seat item or interval is missing', () => {
+    expect(getSeatPriceInterval(null)).toBe('month');
+    expect(getSeatPriceInterval(item({ id: 'si_teams', interval: null }))).toBe('month');
+  });
+});

--- a/apps/web/src/components/subscriptions/seats/seat-price.ts
+++ b/apps/web/src/components/subscriptions/seats/seat-price.ts
@@ -1,0 +1,51 @@
+export type SeatPriceLineItem = {
+  id: string;
+  quantity?: number | null;
+  price?: {
+    product?: unknown;
+    unit_amount?: number | null;
+    recurring?: { interval?: string | null } | null;
+  } | null;
+};
+
+function getProductId(item: SeatPriceLineItem | null): string | null {
+  const product = item?.price?.product;
+  return typeof product === 'string' && product.trim() !== '' ? product : null;
+}
+
+function getItemAmountCents(item: SeatPriceLineItem): number {
+  return (item.price?.unit_amount ?? 0) * (item.quantity ?? 0);
+}
+
+export function getSeatPriceLineItems(
+  items: readonly SeatPriceLineItem[],
+  paidSeatItemId: string | null
+): SeatPriceLineItem[] {
+  const paidSeatItem = paidSeatItemId
+    ? (items.find(item => item.id === paidSeatItemId) ?? null)
+    : null;
+  if (!paidSeatItem) return [];
+
+  const paidProductId = getProductId(paidSeatItem);
+  if (!paidProductId) return [paidSeatItem];
+
+  return items.filter(item => item.id === paidSeatItem.id || getProductId(item) === paidProductId);
+}
+
+export function getSeatPriceInterval(
+  paidSeatItem: Pick<SeatPriceLineItem, 'price'> | null
+): 'month' | 'year' {
+  return paidSeatItem?.price?.recurring?.interval === 'year' ? 'year' : 'month';
+}
+
+export function formatSeatPrice(
+  items: readonly SeatPriceLineItem[],
+  paidSeatItemId: string | null
+): string {
+  const seatItems = getSeatPriceLineItems(items, paidSeatItemId);
+  const paidSeatItem = paidSeatItemId
+    ? (seatItems.find(item => item.id === paidSeatItemId) ?? null)
+    : null;
+  const totalAmount = seatItems.reduce((sum, item) => sum + getItemAmountCents(item), 0);
+  return `$${(totalAmount / 100).toFixed(2)}/${getSeatPriceInterval(paidSeatItem)}`;
+}


### PR DESCRIPTION
## Summary
Teams and Enterprise Seats now show only the recurring seat amount when Kilo Pass shares the same Stripe subscription.

### Why this change is needed
Organization billing stores Teams seats and Kilo Pass as separate line items on one Stripe subscription. The subscription overview and Teams detail page summed every item and labeled the total as the Teams price. An organization with $54/month of Teams seats and $147/month of Kilo Passes therefore saw $201/month as the Teams price, even though Kilo Pass was already shown separately.

### How this is addressed
- Price the Teams/Enterprise Seats card and detail page from the paid seat item and any other items on that same seat product.
- Leave Kilo Pass and other add-on items out of that displayed amount.
- Keep the existing billing interval and renewal-date behavior.
- Share one client-safe helper so both views stay consistent.

A mixed subscription with 3 Teams seats at $18/month and 3 Kilo Pass Pro items at $49/month now shows `$54.00/month` on both Teams views. The Kilo Pass view remains `$147/month`. The Stripe invoice total may still be `$201/month`.

## Human Verification
- Ran `pnpm --filter web exec jest src/components/subscriptions/seats/seat-price.test.ts src/components/subscriptions/seats/SeatsDetail.test.ts --no-coverage` (15 passed). Coverage includes seat-only, mixed Teams + Kilo Pass, multiple qualifying seat items, and missing quantity/unit amount.

## Reviewer Notes
### Human Reviewer Flags
- The helper includes extra seat items only when they share the paid item's product ID. That matches the paid + free promotional-seat contract, but it is a judgment call if custom seat prices ever use a different product.
- If `paidSeatItemId` is missing, the Teams price now shows `$0.00/month` instead of summing the whole Stripe subscription. Safer for mixed subscriptions; unknown seat prices outside `KNOWN_SEAT_PRICE_IDS` no longer fall back to the invoice total.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Display-only change. No Stripe subscription contents, invoices, checkout, webhooks, or billing behavior were modified.
- The helper lives in `apps/web/src/components/subscriptions/seats/seat-price.ts` instead of `stripe-seat-line-items.ts` because the latter imports `server-only` config and cannot be used from these client components.
- Both `SeatsGroup` and `SeatsDetail` now call `formatSeatPrice(subscription.items.data, paidSeatItemId)`.

</details>
