### PR TITLE
feat(web): distinguish usage query errors from empty data

### DIFF
--- a/apps/storybook/stories/usage-analytics/UsageDataErrorState.stories.tsx
+++ b/apps/storybook/stories/usage-analytics/UsageDataErrorState.stories.tsx
@@ -1,0 +1,28 @@
+import type { Meta, StoryObj } from '@storybook/nextjs';
+import { UsageDataErrorState } from '@/components/usage-analytics/UsageDataErrorState';
+
+const meta: Meta<typeof UsageDataErrorState> = {
+  title: 'Usage Analytics/UsageDataErrorState',
+  component: UsageDataErrorState,
+  parameters: {
+    layout: 'fullscreen',
+  },
+  decorators: [
+    Story => (
+      <div className="bg-background min-h-screen p-6 sm:p-8">
+        <div className="m-auto w-full max-w-4xl">
+          <Story />
+        </div>
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onRetry: () => undefined,
+  },
+};

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -508,14 +508,44 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
     summary,
     tableRowCount: tableData?.rows.length,
     queries: [
-      usageQueryOutcome({ isLoading: summaryLoading, isError: summaryError }),
-      usageQueryOutcome({ isLoading: tableLoading, isError: tableError }),
-      usageQueryOutcome({ isLoading: timeseriesLoading, isError: timeseriesError }),
-      usageQueryOutcome({ isLoading: featureBreakdownLoading, isError: featureBreakdownError }),
-      usageQueryOutcome({ isLoading: modelBreakdownLoading, isError: modelBreakdownError }),
-      usageQueryOutcome({ isLoading: projectBreakdownLoading, isError: projectBreakdownError }),
+      usageQueryOutcome({
+        isLoading: summaryLoading,
+        isError: summaryError,
+        hasData: summary !== undefined,
+      }),
+      usageQueryOutcome({
+        isLoading: tableLoading,
+        isError: tableError,
+        hasData: tableData !== undefined,
+      }),
+      usageQueryOutcome({
+        isLoading: timeseriesLoading,
+        isError: timeseriesError,
+        hasData: timeseries !== undefined,
+      }),
+      usageQueryOutcome({
+        isLoading: featureBreakdownLoading,
+        isError: featureBreakdownError,
+        hasData: featureBreakdown !== undefined,
+      }),
+      usageQueryOutcome({
+        isLoading: modelBreakdownLoading,
+        isError: modelBreakdownError,
+        hasData: modelBreakdown !== undefined,
+      }),
+      usageQueryOutcome({
+        isLoading: projectBreakdownLoading,
+        isError: projectBreakdownError,
+        hasData: projectBreakdown !== undefined,
+      }),
       ...(isOrgWideView
-        ? [usageQueryOutcome({ isLoading: userBreakdownLoading, isError: userBreakdownError })]
+        ? [
+            usageQueryOutcome({
+              isLoading: userBreakdownLoading,
+              isError: userBreakdownError,
+              hasData: userBreakdown !== undefined,
+            }),
+          ]
         : []),
     ],
   });

--- a/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
+++ b/apps/web/src/components/usage-analytics/UsageAnalyticsDashboard.tsx
@@ -26,7 +26,9 @@ import { BreakdownPieChart } from './BreakdownPieChart';
 import { BreakdownBarChart } from './BreakdownBarChart';
 import { AIAdoptionScoreCard } from './AIAdoptionScoreCard';
 import { ActiveKiloclawsTable } from './ActiveKiloclawsTable';
+import { UsageDataErrorState } from './UsageDataErrorState';
 import { UsageDataPendingState } from './UsageDataPendingState';
+import { resolveUsageDashboardState, usageQueryOutcome } from './usageDataState';
 import {
   PERSONAL_VIEW_ALL_USAGE,
   PERSONAL_VIEW_PERSONAL_ONLY,
@@ -353,41 +355,71 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
     ]
   );
 
-  const { data: summary, isLoading: summaryLoading } = useUsageSummary({
+  const {
+    data: summary,
+    isLoading: summaryLoading,
+    isError: summaryError,
+    refetch: refetchSummary,
+  } = useUsageSummary({
     ...commonArgs,
     enabled: showDetailedUsage,
   });
 
   const splitByDimension = groupBy !== 'none' ? groupBy : undefined;
-  const { data: timeseries, isLoading: timeseriesLoading } = useUsageTimeseries({
+  const {
+    data: timeseries,
+    isLoading: timeseriesLoading,
+    isError: timeseriesError,
+    refetch: refetchTimeseries,
+  } = useUsageTimeseries({
     ...commonArgs,
     metric: chartMetric,
     splitBy: splitByDimension,
     enabled: showDetailedUsage,
   });
 
-  const { data: featureBreakdown, isLoading: featureBreakdownLoading } = useUsageBreakdown({
+  const {
+    data: featureBreakdown,
+    isLoading: featureBreakdownLoading,
+    isError: featureBreakdownError,
+    refetch: refetchFeatureBreakdown,
+  } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'feature',
     metric: 'cost',
     limit: 20,
     enabled: showDetailedUsage,
   });
-  const { data: modelBreakdown, isLoading: modelBreakdownLoading } = useUsageBreakdown({
+  const {
+    data: modelBreakdown,
+    isLoading: modelBreakdownLoading,
+    isError: modelBreakdownError,
+    refetch: refetchModelBreakdown,
+  } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'model',
     metric: 'cost',
     limit: 10,
     enabled: showDetailedUsage,
   });
-  const { data: projectBreakdown, isLoading: projectBreakdownLoading } = useUsageBreakdown({
+  const {
+    data: projectBreakdown,
+    isLoading: projectBreakdownLoading,
+    isError: projectBreakdownError,
+    refetch: refetchProjectBreakdown,
+  } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'project',
     metric: 'cost',
     limit: 10,
     enabled: showDetailedUsage,
   });
-  const { data: userBreakdown, isLoading: userBreakdownLoading } = useUsageBreakdown({
+  const {
+    data: userBreakdown,
+    isLoading: userBreakdownLoading,
+    isError: userBreakdownError,
+    refetch: refetchUserBreakdown,
+  } = useUsageBreakdown({
     ...commonArgs,
     dimension: 'user',
     metric: 'cost',
@@ -397,7 +429,12 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
 
   const tableGroupBy = useMemo<Dimension[]>(() => (groupBy === 'none' ? [] : [groupBy]), [groupBy]);
 
-  const { data: tableData, isLoading: tableLoading } = useUsageTable({
+  const {
+    data: tableData,
+    isLoading: tableLoading,
+    isError: tableError,
+    refetch: refetchTable,
+  } = useUsageTable({
     ...commonArgs,
     groupBy: tableGroupBy,
     limit: 500,
@@ -465,13 +502,42 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
     return list;
   }, [filters]);
 
-  const usageDataPending =
-    period === 'today' &&
-    summary !== undefined &&
-    tableData !== undefined &&
-    summary.requestCount === 0 &&
-    tableData.rows.length === 0 &&
-    activeFilters.length === 0;
+  const usageDashboardState = resolveUsageDashboardState({
+    period,
+    hasActiveFilters: activeFilters.length > 0,
+    summary,
+    tableRowCount: tableData?.rows.length,
+    queries: [
+      usageQueryOutcome({ isLoading: summaryLoading, isError: summaryError }),
+      usageQueryOutcome({ isLoading: tableLoading, isError: tableError }),
+      usageQueryOutcome({ isLoading: timeseriesLoading, isError: timeseriesError }),
+      usageQueryOutcome({ isLoading: featureBreakdownLoading, isError: featureBreakdownError }),
+      usageQueryOutcome({ isLoading: modelBreakdownLoading, isError: modelBreakdownError }),
+      usageQueryOutcome({ isLoading: projectBreakdownLoading, isError: projectBreakdownError }),
+      ...(isOrgWideView
+        ? [usageQueryOutcome({ isLoading: userBreakdownLoading, isError: userBreakdownError })]
+        : []),
+    ],
+  });
+
+  const retryUsageQueries = useCallback(() => {
+    void refetchSummary();
+    void refetchTimeseries();
+    void refetchFeatureBreakdown();
+    void refetchModelBreakdown();
+    void refetchProjectBreakdown();
+    void refetchTable();
+    if (isOrgWideView) void refetchUserBreakdown();
+  }, [
+    isOrgWideView,
+    refetchFeatureBreakdown,
+    refetchModelBreakdown,
+    refetchProjectBreakdown,
+    refetchSummary,
+    refetchTable,
+    refetchTimeseries,
+    refetchUserBreakdown,
+  ]);
 
   const addFilter = useCallback(
     (dimension: Dimension, direction: FilterDirection, value: string): void => {
@@ -728,7 +794,9 @@ export function UsageAnalyticsDashboard(props: UsageAnalyticsDashboardProps) {
               <>
                 <UsageWarning />
 
-                {usageDataPending ? (
+                {usageDashboardState === 'error' ? (
+                  <UsageDataErrorState onRetry={retryUsageQueries} />
+                ) : usageDashboardState === 'pending' ? (
                   <UsageDataPendingState />
                 ) : (
                   <>

--- a/apps/web/src/components/usage-analytics/UsageDataErrorState.tsx
+++ b/apps/web/src/components/usage-analytics/UsageDataErrorState.tsx
@@ -1,0 +1,27 @@
+import { AlertCircle } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent } from '@/components/ui/card';
+
+export type UsageDataErrorStateProps = {
+  onRetry: () => void;
+};
+
+export function UsageDataErrorState({ onRetry }: UsageDataErrorStateProps) {
+  return (
+    <Card>
+      <CardContent className="flex min-h-64 flex-col items-center justify-center gap-3 p-6 text-center sm:p-10">
+        <AlertCircle className="text-muted-foreground size-5" />
+        <div>
+          <h2 className="type-heading">Usage data is unavailable</h2>
+          <p className="type-body text-muted-foreground mt-1 max-w-md">
+            The usage report could not be loaded. This is not an empty period — try loading it
+            again.
+          </p>
+        </div>
+        <Button variant="secondary" size="sm" onClick={onRetry}>
+          Try again
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/usage-analytics/usageDataState.test.ts
+++ b/apps/web/src/components/usage-analytics/usageDataState.test.ts
@@ -1,0 +1,61 @@
+import { resolveUsageDashboardState, usageQueryOutcome } from './usageDataState';
+
+describe('usageQueryOutcome', () => {
+  it('prefers error over loading so a failed refetch is not treated as empty', () => {
+    expect(usageQueryOutcome({ isLoading: true, isError: true })).toBe('error');
+    expect(usageQueryOutcome({ isLoading: true, isError: false })).toBe('loading');
+    expect(usageQueryOutcome({ isLoading: false, isError: false })).toBe('success');
+  });
+});
+
+describe('resolveUsageDashboardState', () => {
+  const emptyToday = {
+    period: 'today',
+    hasActiveFilters: false,
+    summary: { requestCount: 0 },
+    tableRowCount: 0,
+  };
+
+  it('treats a failed query as an error, not as no data', () => {
+    expect(
+      resolveUsageDashboardState({
+        ...emptyToday,
+        summary: undefined,
+        tableRowCount: undefined,
+        queries: ['error', 'success'],
+      })
+    ).toBe('error');
+  });
+
+  it('shows the catching-up state only after successful empty today queries', () => {
+    expect(
+      resolveUsageDashboardState({
+        ...emptyToday,
+        queries: ['success', 'success'],
+      })
+    ).toBe('pending');
+  });
+
+  it('does not treat an in-flight empty day as pending or as an error', () => {
+    expect(
+      resolveUsageDashboardState({
+        ...emptyToday,
+        summary: undefined,
+        tableRowCount: undefined,
+        queries: ['loading', 'loading'],
+      })
+    ).toBe('ready');
+  });
+
+  it('keeps a successful non-empty report in the ready state', () => {
+    expect(
+      resolveUsageDashboardState({
+        period: 'today',
+        hasActiveFilters: false,
+        summary: { requestCount: 4 },
+        tableRowCount: 4,
+        queries: ['success', 'success'],
+      })
+    ).toBe('ready');
+  });
+});

--- a/apps/web/src/components/usage-analytics/usageDataState.test.ts
+++ b/apps/web/src/components/usage-analytics/usageDataState.test.ts
@@ -1,10 +1,14 @@
 import { resolveUsageDashboardState, usageQueryOutcome } from './usageDataState';
 
 describe('usageQueryOutcome', () => {
-  it('prefers error over loading so a failed refetch is not treated as empty', () => {
-    expect(usageQueryOutcome({ isLoading: true, isError: true })).toBe('error');
-    expect(usageQueryOutcome({ isLoading: true, isError: false })).toBe('loading');
-    expect(usageQueryOutcome({ isLoading: false, isError: false })).toBe('success');
+  it('treats a failed initial load as an error, not as empty', () => {
+    expect(usageQueryOutcome({ isLoading: true, isError: true, hasData: false })).toBe('error');
+    expect(usageQueryOutcome({ isLoading: true, isError: false, hasData: false })).toBe('loading');
+    expect(usageQueryOutcome({ isLoading: false, isError: false, hasData: true })).toBe('success');
+  });
+
+  it('keeps cached data after a failed background refetch', () => {
+    expect(usageQueryOutcome({ isLoading: false, isError: true, hasData: true })).toBe('success');
   });
 });
 

--- a/apps/web/src/components/usage-analytics/usageDataState.ts
+++ b/apps/web/src/components/usage-analytics/usageDataState.ts
@@ -1,0 +1,30 @@
+export type UsageQueryOutcome = 'loading' | 'error' | 'success';
+
+export function usageQueryOutcome(query: {
+  isLoading: boolean;
+  isError: boolean;
+}): UsageQueryOutcome {
+  if (query.isError) return 'error';
+  if (query.isLoading) return 'loading';
+  return 'success';
+}
+
+export function resolveUsageDashboardState(args: {
+  period: string;
+  hasActiveFilters: boolean;
+  summary: { requestCount: number } | undefined;
+  tableRowCount: number | undefined;
+  queries: readonly UsageQueryOutcome[];
+}): 'error' | 'pending' | 'ready' {
+  if (args.queries.includes('error')) return 'error';
+
+  const usageDataPending =
+    args.period === 'today' &&
+    args.summary !== undefined &&
+    args.tableRowCount !== undefined &&
+    args.summary.requestCount === 0 &&
+    args.tableRowCount === 0 &&
+    !args.hasActiveFilters;
+
+  return usageDataPending ? 'pending' : 'ready';
+}

--- a/apps/web/src/components/usage-analytics/usageDataState.ts
+++ b/apps/web/src/components/usage-analytics/usageDataState.ts
@@ -3,8 +3,11 @@ export type UsageQueryOutcome = 'loading' | 'error' | 'success';
 export function usageQueryOutcome(query: {
   isLoading: boolean;
   isError: boolean;
+  hasData: boolean;
 }): UsageQueryOutcome {
-  if (query.isError) return 'error';
+  // A background refetch can fail while previous data is still on screen.
+  // Only treat that as a dashboard error when there is nothing to keep showing.
+  if (query.isError && !query.hasData) return 'error';
   if (query.isLoading) return 'loading';
   return 'success';
 }


### PR DESCRIPTION
## Summary

`/usage` no longer treats a failed analytics query as an empty day.

Previously the dashboard ignored `isError`. A timeout or replica failure left `summary`/`tableData` undefined (or leftover zeros), so the page showed `—` / empty charts, and a failed “today” load could look like the catching-up empty state.

Now any failed summary, timeseries, breakdown, or table query shows a dedicated **Usage data is unavailable** card with **Try again**. The catching-up state still only appears after a successful empty today query.

## Test plan

- [x] Unit tests for `resolveUsageDashboardState` (error vs pending vs ready).
- [ ] Force a usage query failure (e.g. statement timeout / replica down) and confirm the error card, not zeros or “Usage data is catching up”.
- [ ] Load `/usage` for a genuine empty today window and confirm the catching-up state still appears.
- [ ] Load a successful 7d/30d report and confirm charts/table still render.