### PR TITLE
fix(web): prefill gateway routing note

### DIFF
--- a/apps/web/src/app/admin/gateway/RoutingContent.tsx
+++ b/apps/web/src/app/admin/gateway/RoutingContent.tsx
@@ -33,7 +33,7 @@ export function RoutingContent() {
       setInputValue(data.vercel_routing_percentage?.toString() ?? '');
       setFreeInputValue(data.vercel_routing_percentage_free?.toString() ?? '');
       setOptOutModelsValue(data.vercel_routing_opt_out_models.join('\n'));
-      setNoteValue('');
+      setNoteValue(data.note ?? '');
       setHasChanges(false);
     }
   }, [data]);


### PR DESCRIPTION
## Summary
- prefill the Vercel gateway routing note textarea with the currently persisted note

## Testing
- Not run locally; CI will validate the change.