### PR TITLE
chore(web): stop cleaning compress request logs

### DIFF
--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.test.ts
@@ -14,7 +14,7 @@ jest.mock('@kilocode/worker-utils/scheduled-job-observability', () => ({
   emitScheduledJobEvent: jest.fn(),
 }));
 
-import { api_request_compress_log, api_request_log } from '@kilocode/db/schema';
+import { api_request_log } from '@kilocode/db/schema';
 import { db, sql } from '@/lib/drizzle';
 import { emitScheduledJobEvent } from '@kilocode/worker-utils/scheduled-job-observability';
 import { GET } from './route';
@@ -50,26 +50,10 @@ async function insertApiRequestLogRecords(count: number, created_at: string) {
   );
 }
 
-async function insertApiRequestCompressLogRecord(created_at: string) {
-  const [row] = await db
-    .insert(api_request_compress_log)
-    .values({
-      created_at,
-      kilo_user_id: 'test-user',
-      provider: 'test-provider',
-      model: 'test-model',
-      request: {},
-      result: {},
-    })
-    .returning();
-  return row;
-}
-
 describe('GET /api/cron/cleanup-api-request-log', () => {
   beforeEach(async () => {
     jest.clearAllMocks();
     await db.delete(api_request_log).where(sql`true`);
-    await db.delete(api_request_compress_log).where(sql`true`);
   });
 
   it('rejects requests without authorization header', async () => {
@@ -93,7 +77,6 @@ describe('GET /api/cron/cleanup-api-request-log', () => {
     expect(mockEmitScheduledJobEvent).toHaveBeenCalledWith({
       outcome: 'succeeded',
       deleted_api_request_log_count: 0,
-      deleted_api_request_compress_log_count: 0,
       deleted_count: 0,
       batch_size: BATCH_SIZE,
       has_more: false,
@@ -115,29 +98,11 @@ describe('GET /api/cron/cleanup-api-request-log', () => {
       expect.objectContaining({
         outcome: 'succeeded',
         deleted_api_request_log_count: 2,
-        deleted_api_request_compress_log_count: 0,
         deleted_count: 2,
       })
     );
 
     const remaining = await db.select().from(api_request_log);
-    expect(remaining).toHaveLength(1);
-    expect(remaining[0].id).toBe(recent.id);
-  });
-
-  it('deletes expired compression records and preserves recent records', async () => {
-    await insertApiRequestCompressLogRecord(daysAgo(45));
-    await insertApiRequestCompressLogRecord(daysAgo(31));
-    const recent = await insertApiRequestCompressLogRecord(daysAgo(1));
-
-    const response = await GET(makeRequest({ authorization: 'Bearer cron-secret' }));
-
-    expect(response.status).toBe(200);
-    const body = await response.json();
-    expect(body.deletedCount).toBe(2);
-    expect(body.hasMore).toBe(false);
-
-    const remaining = await db.select().from(api_request_compress_log);
     expect(remaining).toHaveLength(1);
     expect(remaining[0].id).toBe(recent.id);
   });

--- a/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
+++ b/apps/web/src/app/api/cron/cleanup-api-request-log/route.ts
@@ -6,7 +6,7 @@ import {
   emitScheduledJobEvent,
 } from '@kilocode/worker-utils/scheduled-job-observability';
 import { db } from '@/lib/drizzle';
-import { api_request_compress_log, api_request_log } from '@kilocode/db/schema';
+import { api_request_log } from '@kilocode/db/schema';
 import { asc, inArray, lt } from 'drizzle-orm';
 import { CRON_SECRET } from '@/lib/config.server';
 
@@ -44,36 +44,19 @@ export async function GET(request: Request) {
         ? await db.delete(api_request_log).where(inArray(api_request_log.id, batchIds))
         : null;
 
-    const expiredCompressRows = await db
-      .select({ id: api_request_compress_log.id })
-      .from(api_request_compress_log)
-      .where(lt(api_request_compress_log.created_at, cutoffDate))
-      .orderBy(asc(api_request_compress_log.created_at))
-      .limit(BATCH_SIZE + 1);
-
-    const compressBatchIds = expiredCompressRows.slice(0, BATCH_SIZE).map(row => row.id);
-    const compressResult =
-      compressBatchIds.length > 0
-        ? await db
-            .delete(api_request_compress_log)
-            .where(inArray(api_request_compress_log.id, compressBatchIds))
-        : null;
     const deletedApiRequestLogCount = result?.rowCount ?? 0;
-    const deletedApiRequestCompressLogCount = compressResult?.rowCount ?? 0;
-    const deletedCount = deletedApiRequestLogCount + deletedApiRequestCompressLogCount;
-    const hasMore = expiredRows.length > BATCH_SIZE || expiredCompressRows.length > BATCH_SIZE;
+    const hasMore = expiredRows.length > BATCH_SIZE;
     emitScheduledJobEvent(
       buildScheduledJobSuccessEvent(run, {
         deleted_api_request_log_count: deletedApiRequestLogCount,
-        deleted_api_request_compress_log_count: deletedApiRequestCompressLogCount,
-        deleted_count: deletedCount,
+        deleted_count: deletedApiRequestLogCount,
         batch_size: BATCH_SIZE,
         has_more: hasMore,
       })
     );
 
     return NextResponse.json({
-      deletedCount,
+      deletedCount: deletedApiRequestLogCount,
       batchSize: BATCH_SIZE,
       hasMore,
       cutoffDate,


### PR DESCRIPTION
## Summary
- stop the API request log cleanup cron from querying `api_request_compress_log`
- remove compression-log cleanup metrics and obsolete test coverage
- prepare for safely dropping the table after this code is deployed

## Rollout
This is phase 1 of the table removal. The table-drop PR must merge only after this change is deployed.

## Testing
- CI only, as requested