### PR TITLE
fix(web): delete CLI sessions and shared sessions on user soft-delete

### DIFF
--- a/apps/web/src/lib/external-services.test.ts
+++ b/apps/web/src/lib/external-services.test.ts
@@ -66,6 +66,8 @@ describe('external-services', () => {
           kilo_user_id: testUser.id,
           title: 'Test Session 1',
           created_on_platform: 'vscode',
+          last_mode: 'code',
+          last_model: 'anthropic/claude-3-5-sonnet',
           api_conversation_history_blob_url: 'sessions/test1/api_conversation_history.json',
           task_metadata_blob_url: 'sessions/test1/task_metadata.json',
         })
@@ -77,6 +79,8 @@ describe('external-services', () => {
           kilo_user_id: testUser.id,
           title: 'Test Session 2',
           created_on_platform: 'vscode',
+          last_mode: 'ask',
+          last_model: 'openai/gpt-4o',
           ui_messages_blob_url: 'sessions/test2/ui_messages.json',
           git_state_blob_url: 'sessions/test2/git_state.json',
         })
@@ -98,6 +102,24 @@ describe('external-services', () => {
         { folderName: 'sessions', filename: 'ui_messages' },
         { folderName: 'sessions', filename: 'git_state' },
       ]);
+
+      const remainingSessions = await db
+        .select()
+        .from(cliSessions)
+        .where(eq(cliSessions.kilo_user_id, testUser.id));
+      expect(remainingSessions).toHaveLength(2);
+      for (const session of remainingSessions) {
+        expect(session.title).toBe('Deleted Session');
+        expect(session.git_url).toBeNull();
+        expect(session.cloud_agent_session_id).toBeNull();
+        expect(session.organization_id).toBeNull();
+        expect(session.last_mode).toBeNull();
+        expect(session.last_model).toBeNull();
+        expect(session.api_conversation_history_blob_url).toBeNull();
+        expect(session.task_metadata_blob_url).toBeNull();
+        expect(session.ui_messages_blob_url).toBeNull();
+        expect(session.git_state_blob_url).toBeNull();
+      }
     });
 
     it('should delete shared CLI session blobs when user has shared sessions', async () => {
@@ -146,6 +168,25 @@ describe('external-services', () => {
       expect(deleteBlobs).toHaveBeenCalledWith(sharedSession2.share_id, [
         { folderName: 'shared-sessions', filename: 'ui_messages' },
       ]);
+
+      const remainingSharedSessions = await db
+        .select()
+        .from(sharedCliSessions)
+        .where(eq(sharedCliSessions.kilo_user_id, testUser.id));
+      expect(remainingSharedSessions).toHaveLength(2);
+      for (const shared of remainingSharedSessions) {
+        expect(shared.api_conversation_history_blob_url).toBeNull();
+        expect(shared.task_metadata_blob_url).toBeNull();
+        expect(shared.ui_messages_blob_url).toBeNull();
+        expect(shared.git_state_blob_url).toBeNull();
+      }
+
+      const remainingSessions = await db
+        .select()
+        .from(cliSessions)
+        .where(eq(cliSessions.kilo_user_id, testUser.id));
+      expect(remainingSessions).toHaveLength(1);
+      expect(remainingSessions[0].title).toBe('Deleted Session');
     });
 
     it('should handle sessions with no blob URLs', async () => {
@@ -162,6 +203,13 @@ describe('external-services', () => {
 
       // deleteBlobs should not be called for sessions without blobs
       expect(deleteBlobs).not.toHaveBeenCalled();
+
+      const remainingSessions = await db
+        .select()
+        .from(cliSessions)
+        .where(eq(cliSessions.kilo_user_id, testUser.id));
+      expect(remainingSessions).toHaveLength(1);
+      expect(remainingSessions[0].title).toBe('Deleted Session');
     });
 
     it('should handle sessions with partial blob URLs', async () => {

--- a/apps/web/src/lib/external-services.test.ts
+++ b/apps/web/src/lib/external-services.test.ts
@@ -107,19 +107,7 @@ describe('external-services', () => {
         .select()
         .from(cliSessions)
         .where(eq(cliSessions.kilo_user_id, testUser.id));
-      expect(remainingSessions).toHaveLength(2);
-      for (const session of remainingSessions) {
-        expect(session.title).toBe('Deleted Session');
-        expect(session.git_url).toBeNull();
-        expect(session.cloud_agent_session_id).toBeNull();
-        expect(session.organization_id).toBeNull();
-        expect(session.last_mode).toBeNull();
-        expect(session.last_model).toBeNull();
-        expect(session.api_conversation_history_blob_url).toBeNull();
-        expect(session.task_metadata_blob_url).toBeNull();
-        expect(session.ui_messages_blob_url).toBeNull();
-        expect(session.git_state_blob_url).toBeNull();
-      }
+      expect(remainingSessions).toHaveLength(0);
     });
 
     it('should delete shared CLI session blobs when user has shared sessions', async () => {
@@ -173,20 +161,13 @@ describe('external-services', () => {
         .select()
         .from(sharedCliSessions)
         .where(eq(sharedCliSessions.kilo_user_id, testUser.id));
-      expect(remainingSharedSessions).toHaveLength(2);
-      for (const shared of remainingSharedSessions) {
-        expect(shared.api_conversation_history_blob_url).toBeNull();
-        expect(shared.task_metadata_blob_url).toBeNull();
-        expect(shared.ui_messages_blob_url).toBeNull();
-        expect(shared.git_state_blob_url).toBeNull();
-      }
+      expect(remainingSharedSessions).toHaveLength(0);
 
       const remainingSessions = await db
         .select()
         .from(cliSessions)
         .where(eq(cliSessions.kilo_user_id, testUser.id));
-      expect(remainingSessions).toHaveLength(1);
-      expect(remainingSessions[0].title).toBe('Deleted Session');
+      expect(remainingSessions).toHaveLength(0);
     });
 
     it('should handle sessions with no blob URLs', async () => {
@@ -208,8 +189,7 @@ describe('external-services', () => {
         .select()
         .from(cliSessions)
         .where(eq(cliSessions.kilo_user_id, testUser.id));
-      expect(remainingSessions).toHaveLength(1);
-      expect(remainingSessions[0].title).toBe('Deleted Session');
+      expect(remainingSessions).toHaveLength(0);
     });
 
     it('should handle sessions with partial blob URLs', async () => {

--- a/apps/web/src/lib/external-services.test.ts
+++ b/apps/web/src/lib/external-services.test.ts
@@ -170,6 +170,66 @@ describe('external-services', () => {
       expect(remainingSessions).toHaveLength(0);
     });
 
+    it('should delete cross-user shared CLI session blobs and rows referencing user sessions', async () => {
+      const { deleteBlobs } = await import('@/lib/r2/cli-sessions');
+
+      const otherUser = await insertTestUser({
+        google_user_email: 'test-cross-user-shared@example.com',
+        google_user_name: 'Other Shared User',
+      });
+
+      try {
+        // Create session owned by testUser
+        const [session] = await db
+          .insert(cliSessions)
+          .values({
+            kilo_user_id: testUser.id,
+            title: 'Session to be shared by another user',
+            created_on_platform: 'vscode',
+          })
+          .returning();
+
+        // Create shared session owned by otherUser pointing to testUser's session
+        const [crossUserShared] = await db
+          .insert(sharedCliSessions)
+          .values({
+            session_id: session.session_id,
+            kilo_user_id: otherUser.id,
+            shared_state: 'public',
+            api_conversation_history_blob_url:
+              'shared-sessions/cross-share/api_conversation_history.json',
+            ui_messages_blob_url: 'shared-sessions/cross-share/ui_messages.json',
+          })
+          .returning();
+
+        await softDeleteUserExternalServices(testUser);
+
+        // Verify deleteBlobs was called for otherUser's shared session copy
+        expect(deleteBlobs).toHaveBeenCalledWith(crossUserShared.share_id, [
+          { folderName: 'shared-sessions', filename: 'api_conversation_history' },
+          { folderName: 'shared-sessions', filename: 'ui_messages' },
+        ]);
+
+        // Verify cross-user shared session row is deleted
+        const remainingSharedSessions = await db
+          .select()
+          .from(sharedCliSessions)
+          .where(eq(sharedCliSessions.share_id, crossUserShared.share_id));
+        expect(remainingSharedSessions).toHaveLength(0);
+
+        // Verify session is deleted
+        const remainingSessions = await db
+          .select()
+          .from(cliSessions)
+          .where(eq(cliSessions.kilo_user_id, testUser.id));
+        expect(remainingSessions).toHaveLength(0);
+      } finally {
+        await db.delete(sharedCliSessions).where(eq(sharedCliSessions.kilo_user_id, otherUser.id));
+        await db.delete(cliSessions).where(eq(cliSessions.kilo_user_id, otherUser.id));
+        await db.delete(kilocode_users).where(eq(kilocode_users.id, otherUser.id));
+      }
+    });
+
     it('should handle sessions with no blob URLs', async () => {
       const { deleteBlobs } = await import('@/lib/r2/cli-sessions');
 

--- a/apps/web/src/lib/external-services.ts
+++ b/apps/web/src/lib/external-services.ts
@@ -54,7 +54,7 @@ async function deleteUserFromCustomerIO(email: string): Promise<string | null> {
 }
 
 /**
- * Delete CLI session blobs from R2 storage and scrub sensitive metadata from database rows
+ * Delete CLI session blobs from R2 storage and delete database rows
  */
 async function deleteCliSessionBlobs(userId: string): Promise<string | null> {
   try {
@@ -114,35 +114,12 @@ async function deleteCliSessionBlobs(userId: string): Promise<string | null> {
       }
     }
 
-    // Scrub sensitive metadata and blob URLs from database rows
-    await db
-      .update(sharedCliSessions)
-      .set({
-        api_conversation_history_blob_url: null,
-        task_metadata_blob_url: null,
-        ui_messages_blob_url: null,
-        git_state_blob_url: null,
-      })
-      .where(eq(sharedCliSessions.kilo_user_id, userId));
-
-    await db
-      .update(cliSessions)
-      .set({
-        title: 'Deleted Session',
-        git_url: null,
-        cloud_agent_session_id: null,
-        organization_id: null,
-        last_mode: null,
-        last_model: null,
-        api_conversation_history_blob_url: null,
-        task_metadata_blob_url: null,
-        ui_messages_blob_url: null,
-        git_state_blob_url: null,
-      })
-      .where(eq(cliSessions.kilo_user_id, userId));
+    // Delete database rows for shared sessions and sessions
+    await db.delete(sharedCliSessions).where(eq(sharedCliSessions.kilo_user_id, userId));
+    await db.delete(cliSessions).where(eq(cliSessions.kilo_user_id, userId));
 
     logExceptInTest(
-      `Successfully scrubbed CLI sessions and deleted blobs for user: ${userId} (${userCliSessions.length} sessions, ${userSharedSessions.length} shared sessions)`
+      `Successfully deleted CLI sessions and blobs for user: ${userId} (${userCliSessions.length} sessions, ${userSharedSessions.length} shared sessions)`
     );
     return null;
   } catch (error) {

--- a/apps/web/src/lib/external-services.ts
+++ b/apps/web/src/lib/external-services.ts
@@ -54,7 +54,7 @@ async function deleteUserFromCustomerIO(email: string): Promise<string | null> {
 }
 
 /**
- * Delete CLI session blobs from R2 storage
+ * Delete CLI session blobs from R2 storage and scrub sensitive metadata from database rows
  */
 async function deleteCliSessionBlobs(userId: string): Promise<string | null> {
   try {
@@ -114,8 +114,35 @@ async function deleteCliSessionBlobs(userId: string): Promise<string | null> {
       }
     }
 
+    // Scrub sensitive metadata and blob URLs from database rows
+    await db
+      .update(sharedCliSessions)
+      .set({
+        api_conversation_history_blob_url: null,
+        task_metadata_blob_url: null,
+        ui_messages_blob_url: null,
+        git_state_blob_url: null,
+      })
+      .where(eq(sharedCliSessions.kilo_user_id, userId));
+
+    await db
+      .update(cliSessions)
+      .set({
+        title: 'Deleted Session',
+        git_url: null,
+        cloud_agent_session_id: null,
+        organization_id: null,
+        last_mode: null,
+        last_model: null,
+        api_conversation_history_blob_url: null,
+        task_metadata_blob_url: null,
+        ui_messages_blob_url: null,
+        git_state_blob_url: null,
+      })
+      .where(eq(cliSessions.kilo_user_id, userId));
+
     logExceptInTest(
-      `Successfully deleted CLI session blobs for user: ${userId} (${userCliSessions.length} sessions, ${userSharedSessions.length} shared sessions)`
+      `Successfully scrubbed CLI sessions and deleted blobs for user: ${userId} (${userCliSessions.length} sessions, ${userSharedSessions.length} shared sessions)`
     );
     return null;
   } catch (error) {

--- a/apps/web/src/lib/external-services.ts
+++ b/apps/web/src/lib/external-services.ts
@@ -5,7 +5,7 @@ import { captureException } from '@sentry/nextjs';
 import type { User } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
 import { cliSessions, sharedCliSessions, cli_sessions_v2 } from '@kilocode/db/schema';
-import { eq } from 'drizzle-orm';
+import { eq, inArray, or } from 'drizzle-orm';
 import { deleteBlobs, type FileName } from '@/lib/r2/cli-sessions';
 import { errorExceptInTest, logExceptInTest, warnExceptInTest } from '@/lib/utils.server';
 import { SESSION_INGEST_WORKER_URL } from '@/lib/config.server';
@@ -64,6 +64,8 @@ async function deleteCliSessionBlobs(userId: string): Promise<string | null> {
       .from(cliSessions)
       .where(eq(cliSessions.kilo_user_id, userId));
 
+    const userCliSessionIds = userCliSessions.map(session => session.session_id);
+
     // Delete blobs for each CLI session
     for (const session of userCliSessions) {
       const blobsToDelete: Array<{ folderName: 'sessions'; filename: FileName }> = [];
@@ -86,14 +88,20 @@ async function deleteCliSessionBlobs(userId: string): Promise<string | null> {
       }
     }
 
-    // Fetch all shared CLI sessions owned by the user
-    const userSharedSessions = await db
-      .select()
-      .from(sharedCliSessions)
-      .where(eq(sharedCliSessions.kilo_user_id, userId));
+    // Fetch all shared CLI sessions owned by the user OR referencing the user's CLI sessions
+    // (e.g. cross-user shares created via webhook triggers by other org members)
+    const sharedCondition =
+      userCliSessionIds.length > 0
+        ? or(
+            eq(sharedCliSessions.kilo_user_id, userId),
+            inArray(sharedCliSessions.session_id, userCliSessionIds)
+          )
+        : eq(sharedCliSessions.kilo_user_id, userId);
+
+    const sharedSessionsToDelete = await db.select().from(sharedCliSessions).where(sharedCondition);
 
     // Delete blobs for each shared session
-    for (const sharedSession of userSharedSessions) {
+    for (const sharedSession of sharedSessionsToDelete) {
       const blobsToDelete: Array<{ folderName: 'shared-sessions'; filename: FileName }> = [];
 
       if (sharedSession.api_conversation_history_blob_url) {
@@ -115,11 +123,16 @@ async function deleteCliSessionBlobs(userId: string): Promise<string | null> {
     }
 
     // Delete database rows for shared sessions and sessions
-    await db.delete(sharedCliSessions).where(eq(sharedCliSessions.kilo_user_id, userId));
+    if (sharedSessionsToDelete.length > 0) {
+      const shareIdsToDelete = sharedSessionsToDelete.map(s => s.share_id);
+      await db
+        .delete(sharedCliSessions)
+        .where(inArray(sharedCliSessions.share_id, shareIdsToDelete));
+    }
     await db.delete(cliSessions).where(eq(cliSessions.kilo_user_id, userId));
 
     logExceptInTest(
-      `Successfully deleted CLI sessions and blobs for user: ${userId} (${userCliSessions.length} sessions, ${userSharedSessions.length} shared sessions)`
+      `Successfully deleted CLI sessions and blobs for user: ${userId} (${userCliSessions.length} sessions, ${sharedSessionsToDelete.length} shared sessions)`
     );
     return null;
   } catch (error) {

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -947,7 +947,7 @@ export async function assertUserCanBeSoftDeleted(userId: string): Promise<void> 
  * - credit_transactions, microdollar_usage (billing records)
  * - kilo_pass_subscriptions/issuances/issuance_items (financial)
  * - kilo_pass_welcome_promo_payment_fingerprint_claims (minimal retained payment anti-abuse evidence)
- * - cli_sessions, shared_cli_sessions, cli_sessions_v2 (session history)
+ * - cli_sessions, shared_cli_sessions (session history with sensitive metadata scrubbed)
  * - deployments, app_builder_projects (user assets)
  * - stytch_fingerprints and provider safety identifiers (abuse detection)
  * - referral_code_usages (financial, references anonymized user)
@@ -968,6 +968,7 @@ export async function assertUserCanBeSoftDeleted(userId: string): Promise<void> 
  * - user_admin_notes
  * - referral_codes (user's own code)
  * - magic_link_tokens (email-based)
+ * - CLI session content and sensitive metadata (R2 blobs purged, titles anonymized, git URLs/blob URLs nulled; v2 sessions cleaned up via session ingest)
  * - organization_memberships (removed from all orgs)
  * - organization_membership_removals (tombstones deleted; removed_by anonymized)
  * - organization_invitations (sent by user + addressed to user's email)

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -947,7 +947,6 @@ export async function assertUserCanBeSoftDeleted(userId: string): Promise<void> 
  * - credit_transactions, microdollar_usage (billing records)
  * - kilo_pass_subscriptions/issuances/issuance_items (financial)
  * - kilo_pass_welcome_promo_payment_fingerprint_claims (minimal retained payment anti-abuse evidence)
- * - cli_sessions, shared_cli_sessions (session history with sensitive metadata scrubbed)
  * - deployments, app_builder_projects (user assets)
  * - stytch_fingerprints and provider safety identifiers (abuse detection)
  * - referral_code_usages (financial, references anonymized user)
@@ -968,7 +967,7 @@ export async function assertUserCanBeSoftDeleted(userId: string): Promise<void> 
  * - user_admin_notes
  * - referral_codes (user's own code)
  * - magic_link_tokens (email-based)
- * - CLI session content and sensitive metadata (R2 blobs purged, titles anonymized, git URLs/blob URLs nulled; v2 sessions cleaned up via session ingest)
+ * - CLI sessions (cli_sessions, shared_cli_sessions database rows and R2 blobs purged; v2 sessions deleted via session ingest)
  * - organization_memberships (removed from all orgs)
  * - organization_membership_removals (tombstones deleted; removed_by anonymized)
  * - organization_invitations (sent by user + addressed to user's email)


### PR DESCRIPTION
### Summary

When soft-deleting a user (GDPR / account deletion flow), `deleteCliSessionBlobs` purges the R2 conversation blobs but retained `cli_sessions` and `shared_cli_sessions` rows in PostgreSQL.

This PR updates `deleteCliSessionBlobs` in `apps/web/src/lib/external-services.ts` to:
- Delete `shared_cli_sessions` and `cli_sessions` database rows for the user in PostgreSQL after purging the R2 session blobs.
- Update unit tests in `apps/web/src/lib/external-services.test.ts` to verify database row deletion.
- Update JSDoc documentation in `apps/web/src/lib/user/index.ts`.

### Verification
- Run `pnpm --filter web test apps/web/src/lib/external-services.test.ts` (passed)
- Run `pnpm --filter web run typecheck` (passed)
- Run `pnpm --filter web run lint` (passed)