### PR TITLE
feat(ai-gateway): route GLM through managed Friendli BYOK

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -236,6 +236,7 @@ Manage shared web env var additions and rotations with `pnpm web:env set <VARIAB
 ### AI Providers
 
 - `OPENROUTER_API_KEY` - Primary OpenRouter API key for model inference through the AI gateway; provider definition in `apps/web/src/lib/ai-gateway/providers/provider-definitions.ts` pointing to `https://openrouter.ai/api/v1`. `[SECRET]`
+- `FRIENDLI_API_KEY` - Optional Kilo-managed Friendli API key merged into Vercel AI Gateway BYOK settings for requests that are not using user or organization BYOK. `[SECRET]`
 - `MISTRAL_API_KEY` - Mistral API key; used in `apps/web/src/lib/ai-gateway/embeddings/embedding-providers.ts` for `codestral-embed-2505` and `mistral-embed` embeddings, in the FIM completions proxy at `apps/web/src/app/api/fim/completions/route.ts` (routes Mistral Codestral vs. La Plateforme keys), and as a provider config in `apps/web/src/lib/config.server.ts`. `[SECRET]`
 - `LONGCAT_API_KEY` - LongCat API key for model inference through the AI gateway; provider definition in `apps/web/src/lib/ai-gateway/providers/provider-definitions.ts`. `[SECRET]`
 - `STREAMLAKE_API_KEY` - StreamLake API key for model inference through the AI gateway; provider definition in `apps/web/src/lib/ai-gateway/providers/provider-definitions.ts`. `[SECRET]`

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -107,6 +107,14 @@ describe('applyPreferredProvider', () => {
     expect(request.body.provider).toEqual({ order: ['novita'] });
   });
 
+  it('prefers Friendli then Novita for GLM models', () => {
+    const request = makeRequest('z-ai/glm-5.2');
+
+    applyPreferredProvider('z-ai/glm-5.2', request.body);
+
+    expect(request.body.provider).toEqual({ order: ['friendli', 'novita'] });
+  });
+
   it('overwrites a malformed provider value', () => {
     const request = makeRequest('anthropic/claude-sonnet-4.5');
     Object.assign(request.body, { provider: 'lmstudio' });

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -70,8 +70,8 @@ export function getPreferredProviderOrder(requestedModel: string): string[] {
   }
   if (isGlmModel(requestedModel)) {
     return [
+      OpenRouterInferenceProviderIdSchema.enum.friendli,
       OpenRouterInferenceProviderIdSchema.enum.novita,
-      OpenRouterInferenceProviderIdSchema.enum['z-ai'],
     ];
   }
   if (isQwenModel(requestedModel)) {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -11,6 +11,16 @@ import {
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 
+const originalFriendliApiKey = process.env.FRIENDLI_API_KEY;
+
+afterEach(() => {
+  if (originalFriendliApiKey === undefined) {
+    delete process.env.FRIENDLI_API_KEY;
+  } else {
+    process.env.FRIENDLI_API_KEY = originalFriendliApiKey;
+  }
+});
+
 describe('getAnthropicProviderOptionsForVercel', () => {
   it('maps chat completion verbosity to Anthropic effort', () => {
     const request: GatewayRequest = {
@@ -179,6 +189,51 @@ describe('applyVercelSettings BYOK pinning', () => {
       anthropic: [{ apiKey: 'sk-anthropic' }],
     });
     expect(request.body.providerOptions?.gateway?.only).toEqual(['anthropic']);
+  });
+
+  it('does not merge the managed Friendli key into user BYOK settings', async () => {
+    process.env.FRIENDLI_API_KEY = 'friendli-managed-key';
+    const request = byokRequest([]);
+
+    await applyVercelSettings('anthropic/claude-sonnet-4.5', request, [
+      { decryptedAPIKey: 'sk-anthropic', providerId: 'anthropic' },
+    ]);
+
+    expect(request.body.providerOptions?.gateway?.byok).toEqual({
+      anthropic: [{ apiKey: 'sk-anthropic' }],
+    });
+  });
+});
+
+describe('applyVercelSettings managed BYOK', () => {
+  function managedRequest(): GatewayRequest {
+    return {
+      kind: 'chat_completions',
+      body: {
+        model: 'moonshotai/kimi-k3',
+        messages: [{ role: 'user', content: 'hello' }],
+      },
+    };
+  }
+
+  it('merges the configured Friendli key into the gateway BYOK settings', async () => {
+    process.env.FRIENDLI_API_KEY = 'friendli-managed-key';
+    const request = managedRequest();
+
+    await applyVercelSettings('moonshotai/kimi-k3', request, null);
+
+    expect(request.body.providerOptions?.gateway?.byok).toEqual({
+      friendli: [{ apiKey: 'friendli-managed-key' }],
+    });
+  });
+
+  it('does not add Friendli BYOK settings when the key is not configured', async () => {
+    delete process.env.FRIENDLI_API_KEY;
+    const request = managedRequest();
+
+    await applyVercelSettings('moonshotai/kimi-k3', request, null);
+
+    expect(request.body.providerOptions?.gateway?.byok).toBeUndefined();
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -27,6 +27,7 @@ import {
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
+import { getEnvVariable } from '@/lib/dotenvx';
 
 type VercelRoutingConfig = {
   paid: number;
@@ -305,6 +306,14 @@ export async function applyVercelSettings(
       requestToMutate,
       vercelInferenceProviders
     );
+
+    const friendliApiKey = getEnvVariable('FRIENDLI_API_KEY');
+    if (friendliApiKey && requestToMutate.body.providerOptions.gateway) {
+      requestToMutate.body.providerOptions.gateway.byok = {
+        ...requestToMutate.body.providerOptions.gateway.byok,
+        friendli: [{ apiKey: friendliApiKey }],
+      };
+    }
   }
 
   if (requestToMutate.body.providerOptions) {

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
@@ -6,6 +6,7 @@ import {
   rewriteModelResponse_Responses,
   rewriteModelResponse,
   logUnrewrittenResponse,
+  sanitizeApiRequestLogRequest,
   type RequestLoggingParams,
 } from './rewriteModelResponse';
 import { isDynamicallyOptedIntoRequestLogging } from '@/lib/ai-gateway/request-logging-opt-ins';
@@ -909,6 +910,37 @@ function makeLogging(overrides?: Partial<RequestLoggingParams>): RequestLoggingP
     ...overrides,
   };
 }
+
+describe('sanitizeApiRequestLogRequest', () => {
+  test('removes gateway BYOK credentials without mutating the upstream request', () => {
+    const request = {
+      kind: 'chat_completions',
+      body: {
+        model: 'zai/glm-5.2',
+        messages: [{ role: 'user', content: 'hello' }],
+        providerOptions: {
+          gateway: {
+            order: ['friendli', 'novita'],
+            byok: { friendli: [{ apiKey: 'friendli-managed-key' }] },
+          },
+          anthropic: { effort: 'high' },
+        },
+      },
+    } satisfies RequestLoggingParams['request'];
+
+    expect(sanitizeApiRequestLogRequest(request)).toEqual({
+      model: 'zai/glm-5.2',
+      messages: [{ role: 'user', content: 'hello' }],
+      providerOptions: {
+        gateway: { order: ['friendli', 'novita'] },
+        anthropic: { effort: 'high' },
+      },
+    });
+    expect(request.body.providerOptions.gateway.byok).toEqual({
+      friendli: [{ apiKey: 'friendli-managed-key' }],
+    });
+  });
+});
 
 describe('rewriteModelResponse', () => {
   test('rewrites paid-model Kilo organization traffic without stripping cost', async () => {

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
@@ -944,14 +944,8 @@ describe('sanitizeApiRequestLogRequest', () => {
         gateway: {
           order: ['friendli', 'novita'],
           byok: {
-            friendli: [{ apiKey: '[redacted]', baseURL: 'https://api.friendli.ai' }],
-            bedrock: [
-              {
-                accessKeyId: '[redacted]',
-                secretAccessKey: '[redacted]',
-                region: 'us-east-1',
-              },
-            ],
+            friendli: [{ apiKey: '[redacted]' }],
+            bedrock: [{ apiKey: '[redacted]' }],
           },
         },
         anthropic: { effort: 'high' },

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
@@ -912,7 +912,7 @@ function makeLogging(overrides?: Partial<RequestLoggingParams>): RequestLoggingP
 }
 
 describe('sanitizeApiRequestLogRequest', () => {
-  test('removes gateway BYOK credentials without mutating the upstream request', () => {
+  test('replaces gateway BYOK credentials without mutating the upstream request', () => {
     const request = {
       kind: 'chat_completions',
       body: {
@@ -921,7 +921,16 @@ describe('sanitizeApiRequestLogRequest', () => {
         providerOptions: {
           gateway: {
             order: ['friendli', 'novita'],
-            byok: { friendli: [{ apiKey: 'friendli-managed-key' }] },
+            byok: {
+              friendli: [{ apiKey: 'friendli-managed-key', baseURL: 'https://api.friendli.ai' }],
+              bedrock: [
+                {
+                  accessKeyId: 'AKIAEXAMPLE',
+                  secretAccessKey: 'bedrock-secret',
+                  region: 'us-east-1',
+                },
+              ],
+            },
           },
           anthropic: { effort: 'high' },
         },
@@ -932,12 +941,28 @@ describe('sanitizeApiRequestLogRequest', () => {
       model: 'zai/glm-5.2',
       messages: [{ role: 'user', content: 'hello' }],
       providerOptions: {
-        gateway: { order: ['friendli', 'novita'] },
+        gateway: {
+          order: ['friendli', 'novita'],
+          byok: {
+            friendli: [{ apiKey: '[redacted]', baseURL: 'https://api.friendli.ai' }],
+            bedrock: [
+              {
+                accessKeyId: '[redacted]',
+                secretAccessKey: '[redacted]',
+                region: 'us-east-1',
+              },
+            ],
+          },
+        },
         anthropic: { effort: 'high' },
       },
     });
-    expect(request.body.providerOptions.gateway.byok).toEqual({
-      friendli: [{ apiKey: 'friendli-managed-key' }],
+    expect(request.body.providerOptions.gateway.byok.friendli[0].apiKey).toBe(
+      'friendli-managed-key'
+    );
+    expect(request.body.providerOptions.gateway.byok.bedrock[0]).toMatchObject({
+      accessKeyId: 'AKIAEXAMPLE',
+      secretAccessKey: 'bedrock-secret',
     });
   });
 });

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
@@ -81,6 +81,24 @@ async function isLoggingEnabledForUser(
   });
 }
 
+export function sanitizeApiRequestLogRequest(request: GatewayRequest): unknown {
+  const gateway = request.body.providerOptions?.gateway;
+  if (!gateway || !('byok' in gateway)) {
+    return sanitizeJsonbValue(request.body);
+  }
+
+  const gatewayWithoutByok = { ...gateway };
+  delete gatewayWithoutByok.byok;
+
+  return sanitizeJsonbValue({
+    ...request.body,
+    providerOptions: {
+      ...request.body.providerOptions,
+      gateway: gatewayWithoutByok,
+    },
+  });
+}
+
 async function createRequestLogCapture(
   response: Response,
   model: string,
@@ -137,7 +155,7 @@ async function createRequestLogCapture(
           status_code: status,
           model,
           provider,
-          request: sanitizeJsonbValue(request.body),
+          request: sanitizeApiRequestLogRequest(request),
           response: responseText,
           error: sanitizeJsonbValue(error),
         })

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
@@ -83,18 +83,30 @@ async function isLoggingEnabledForUser(
 
 export function sanitizeApiRequestLogRequest(request: GatewayRequest): unknown {
   const gateway = request.body.providerOptions?.gateway;
-  if (!gateway || !('byok' in gateway)) {
+  if (!gateway?.byok) {
     return sanitizeJsonbValue(request.body);
   }
 
-  const gatewayWithoutByok = { ...gateway };
-  delete gatewayWithoutByok.byok;
+  const redactedByok = Object.fromEntries(
+    Object.entries(gateway.byok).map(([provider, credentials]) => [
+      provider,
+      credentials.map(credential =>
+        'apiKey' in credential
+          ? { ...credential, apiKey: '[redacted]' }
+          : {
+              ...credential,
+              accessKeyId: '[redacted]',
+              secretAccessKey: '[redacted]',
+            }
+      ),
+    ])
+  );
 
   return sanitizeJsonbValue({
     ...request.body,
     providerOptions: {
       ...request.body.providerOptions,
-      gateway: gatewayWithoutByok,
+      gateway: { ...gateway, byok: redactedByok },
     },
   });
 }

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
@@ -90,15 +90,7 @@ export function sanitizeApiRequestLogRequest(request: GatewayRequest): unknown {
   const redactedByok = Object.fromEntries(
     Object.entries(gateway.byok).map(([provider, credentials]) => [
       provider,
-      credentials.map(credential =>
-        'apiKey' in credential
-          ? { ...credential, apiKey: '[redacted]' }
-          : {
-              ...credential,
-              accessKeyId: '[redacted]',
-              secretAccessKey: '[redacted]',
-            }
-      ),
+      credentials.map(() => ({ apiKey: '[redacted]' })),
     ])
   );
 


### PR DESCRIPTION
## Summary
- merge `FRIENDLI_API_KEY` into Vercel AI Gateway BYOK settings for managed requests
- prefer Friendli then Novita for GLM models and remove Z.ai from the preferred order
- keep user and organization BYOK settings isolated from the managed Friendli key
- retain provider entries in `providerOptions.gateway.byok` for `api_request_log`, replacing every credential with `{ apiKey: "[redacted]" }`
- document the optional secret and cover configured/unconfigured behavior

## Verification
- `pnpm --filter web exec jest --runInBand --forceExit src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts src/lib/ai-gateway/rewriteModelResponse.test.ts src/lib/ai-gateway/providers/vercel/index.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm format`
- `git diff --check`