### PR TITLE
fix(web): ignore disabled Snowflake replication slots

### DIFF
--- a/apps/web/src/app/api/cron/db-replication-health/route.test.ts
+++ b/apps/web/src/app/api/cron/db-replication-health/route.test.ts
@@ -8,6 +8,7 @@ jest.mock('@/lib/config.server', () => ({
 
 jest.mock('@/lib/replication-health', () => ({
   collectReplicationHealth: jest.fn(),
+  isReplicationSlotMonitored: (slotName: string) => !slotName.startsWith('snowflake_'),
 }));
 
 jest.mock('@sentry/nextjs', () => ({
@@ -138,7 +139,7 @@ describe('GET /api/cron/db-replication-health', () => {
         healthy: false,
         slots: [
           {
-            slot_name: 'snowflake_connector_gfqyzuertw',
+            slot_name: 'other_logical_consumer',
             slot_type: 'logical',
             active: false,
             wal_status: 'lost',
@@ -153,8 +154,32 @@ describe('GET /api/cron/db-replication-health', () => {
 
     const body = await response.json();
     expect(body.problems).toEqual([
-      expect.stringContaining('slot snowflake_connector_gfqyzuertw: wal_status=lost'),
+      expect.stringContaining('slot other_logical_consumer: wal_status=lost'),
     ]);
     expect(mockCaptureException).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not alert for an at-risk Snowflake slot while replication is disabled', async () => {
+    mockCollect.mockResolvedValue(
+      report({
+        slots: [
+          {
+            slot_name: 'snowflake_backend_slot',
+            slot_type: 'logical',
+            active: false,
+            wal_status: 'lost',
+            retained_wal_bytes: '0',
+            at_risk: true,
+          },
+        ],
+      })
+    );
+
+    const response = await GET(createRequest({ authorization: 'Bearer cron-secret' }));
+
+    await expect(response.json()).resolves.toEqual(
+      expect.objectContaining({ healthy: true, problems: [] })
+    );
+    expect(mockCaptureException).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/app/api/cron/db-replication-health/route.ts
+++ b/apps/web/src/app/api/cron/db-replication-health/route.ts
@@ -2,7 +2,7 @@ import { captureException } from '@sentry/nextjs';
 import { NextResponse } from 'next/server';
 
 import { CRON_SECRET } from '@/lib/config.server';
-import { collectReplicationHealth } from '@/lib/replication-health';
+import { collectReplicationHealth, isReplicationSlotMonitored } from '@/lib/replication-health';
 
 /**
  * Emits replication health to Axiom (via the Vercel log drain) and alerts Sentry
@@ -65,7 +65,7 @@ export async function GET(request: Request) {
     }
   }
   for (const slot of report.slots) {
-    if (slot.at_risk) {
+    if (slot.at_risk && isReplicationSlotMonitored(slot.slot_name)) {
       problems.push(`slot ${slot.slot_name}: wal_status=${slot.wal_status}, active=${slot.active}`);
     }
   }

--- a/apps/web/src/lib/replication-health.test.ts
+++ b/apps/web/src/lib/replication-health.test.ts
@@ -9,6 +9,7 @@ jest.mock('@/lib/drizzle', () => ({
 import {
   classifyReplicaRow,
   collectReplicationHealth,
+  isReplicationSlotMonitored,
   PROBE_POOL_CONFIG,
   probeReplica,
   REPLICA_LAG_ALERT_SECONDS,
@@ -128,6 +129,14 @@ describe('classifyReplicaRow', () => {
   });
 });
 
+describe('isReplicationSlotMonitored', () => {
+  it('temporarily ignores Snowflake slots only', () => {
+    expect(isReplicationSlotMonitored('snowflake_backend_slot')).toBe(false);
+    expect(isReplicationSlotMonitored('snowflake_connector_gfqyzuertw')).toBe(false);
+    expect(isReplicationSlotMonitored('other_logical_consumer')).toBe(true);
+  });
+});
+
 describe('collectReplicationHealth', () => {
   const originalVercelEnv = process.env.VERCEL_ENV;
 
@@ -227,7 +236,7 @@ describe('collectReplicationHealth', () => {
       [walSenderRow()],
       [
         slotRow(),
-        slotRow({ slot_name: 'snowflake_connector_gfqyzuertw', active: false, wal_status: 'lost' }),
+        slotRow({ slot_name: 'other_logical_consumer', active: false, wal_status: 'lost' }),
       ]
     );
 
@@ -237,8 +246,25 @@ describe('collectReplicationHealth', () => {
     });
 
     expect(report.healthy).toBe(false);
-    const lost = report.slots.find(s => s.slot_name === 'snowflake_connector_gfqyzuertw');
+    const lost = report.slots.find(s => s.slot_name === 'other_logical_consumer');
     expect(lost?.at_risk).toBe(true);
+  });
+
+  it('keeps Snowflake slot telemetry without failing health while replication is disabled', async () => {
+    mockPrimary(
+      [walSenderRow()],
+      [slotRow({ slot_name: 'snowflake_backend_slot', active: false, wal_status: 'lost' })]
+    );
+
+    const report = await collectReplicationHealth({
+      targets: [{ name: 'us-west', url: 'postgres://replica' }],
+      probe: async target => okProbe(target.name),
+    });
+
+    expect(report.healthy).toBe(true);
+    expect(report.slots).toEqual([
+      expect.objectContaining({ slot_name: 'snowflake_backend_slot', at_risk: true }),
+    ]);
   });
 
   it('isolates a throwing probe as an unreachable replica without blanking primary data', async () => {

--- a/apps/web/src/lib/replication-health.ts
+++ b/apps/web/src/lib/replication-health.ts
@@ -65,6 +65,15 @@ const AT_RISK_WAL_STATUSES = new Set(['unreserved', 'lost']);
 const PROBE_TIMEOUT_MS = 5_000;
 
 /**
+ * Snowflake replication is temporarily disabled. Keep collecting and logging
+ * its slot state, but do not fail the health check until replication is enabled
+ * again. Other logical replication slots remain monitored.
+ */
+export function isReplicationSlotMonitored(slotName: string): boolean {
+  return !slotName.startsWith('snowflake_');
+}
+
+/**
  * Connection config for a single probe.
  *
  * IMPORTANT: do not set `statement_timeout` here. node-postgres transmits
@@ -381,7 +390,7 @@ export async function collectReplicationHealth(options?: {
   const healthy =
     errors.length === 0 &&
     replicas.every(replica => replica.status === 'ok') &&
-    slots.every(slot => !slot.at_risk);
+    slots.every(slot => !isReplicationSlotMonitored(slot.slot_name) || !slot.at_risk);
 
   return {
     healthy,


### PR DESCRIPTION
## Summary

- Temporarily exclude `snowflake_*` logical replication slots from replication health failures and Sentry alerts while Snowflake replication is disabled.
- Continue collecting and logging Snowflake slot telemetry, while preserving alerts for all non-Snowflake slots, replicas, and primary-query failures.
- Add regression coverage for both the temporary Snowflake bypass and retained non-Snowflake alerting.

## Verification

- [ ] Not manually tested; this is a server-side cron health-check change covered by focused unit tests.

## Visual Changes

N/A

## Reviewer Notes

- Addresses [KILOCODE-WEB-27JM](https://kilo-code.sentry.io/issues/7651527619/).
- Automated checks: 22 focused Jest tests passed; web typecheck passed; full web lint passed; formatting and `git diff --check` passed.
- Remove `isReplicationSlotMonitored` when Snowflake replication is enabled again.