### PR TITLE
perf: parallelize local environment sync

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -244,6 +244,7 @@ should pass against the local PostgreSQL database.
 | `KILO_PORT_OFFSET=auto pnpm dev:start` | Start all local services in a tmux dashboard with worktree-safe ports |
 | `pnpm dev:stop` | Stop the tmux session and all services |
 | `pnpm dev:env` | Sync `.dev.vars` files from `.env.local` (see [Worker `.dev.vars` setup](#worker-dev-vars-setup)) |
+| `pnpm dev:env --missing-secrets-only` | Sync env files and create missing local Secrets Store entries without refreshing existing secrets |
 | `pnpm test` | Run web, web environment, and local development-tool tests |
 | `pnpm typecheck` | Run the TypeScript type checker |
 | `pnpm lint` | Lint all source files |
@@ -405,7 +406,9 @@ Most workers require a `.dev.vars` file with secrets like `NEXTAUTH_SECRET` and 
 pnpm dev:env
 ```
 
-The script (`dev/local/env-sync/`) scans every `.dev.vars.example` in the repo and `apps/web/.env.development.local.example`, resolves each variable's value, and writes (or patches) the corresponding generated local env file. Before applying, it shows a diff of what will change and asks for confirmation.
+The script (`dev/local/env-sync/`) scans every `.dev.vars.example` in the repo and `apps/web/.env.development.local.example`, resolves each variable's value, and writes (or patches) the corresponding generated local env file. Before applying, it shows a diff of what will change and asks for confirmation. Local Secrets Store checks and writes run across four independent Worker persistence directories at a time; set `KILO_ENV_SYNC_CONCURRENCY` to an integer from 1 through 32 to override that limit.
+
+For fast worktree setup, pass `--missing-secrets-only`. It creates bindings that are absent from the local Secrets Store while preserving existing source-backed values; a normal `pnpm dev:env` continues to refresh those values from their configured sources.
 
 Values are resolved using annotations in example env file comment lines:
 

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -1116,6 +1116,7 @@ async function cmdStop(repoRoot: string, force: boolean): Promise<void> {
 
 async function cmdEnv(args: string[], repoRoot: string): Promise<void> {
   const check = args.includes('--check') || args.includes('check');
+  const missingSecretsOnly = args.includes('--missing-secrets-only');
 
   // Runs before the sync: worker and Next.js env values are derived from this
   // worktree's ports, and a fresh worktree has published none yet.
@@ -1129,6 +1130,7 @@ async function cmdEnv(args: string[], repoRoot: string): Promise<void> {
   const result = await syncEnvVars({
     repoRoot,
     check,
+    missingSecretsOnly,
     yes,
     targets: targets.length > 0 ? targets : undefined,
   });
@@ -1160,6 +1162,8 @@ Usage:
   dev:env [targets...]    Sync env vars (.dev.vars + .env.development.local)
   dev:env --check         Validate env vars (CI mode)
   dev:env -y              Sync without confirmation
+  dev:env --missing-secrets-only
+                          Create missing Secrets Store entries without refreshing existing ones
 
 Targets: app, app-builder, agents, code-review, security-agent, mobile, all, or any service/group name
 Multiple targets can be specified: dev:start kiloclaw security-agent`);

--- a/dev/local/env-sync/concurrency.ts
+++ b/dev/local/env-sync/concurrency.ts
@@ -1,0 +1,39 @@
+const DEFAULT_ENV_SYNC_CONCURRENCY = 4;
+const MAX_ENV_SYNC_CONCURRENCY = 32;
+
+function resolveEnvSyncConcurrency(value = process.env.KILO_ENV_SYNC_CONCURRENCY): number {
+  if (value === undefined || value === '') return DEFAULT_ENV_SYNC_CONCURRENCY;
+
+  const concurrency = Number(value);
+  if (!Number.isInteger(concurrency) || concurrency < 1 || concurrency > MAX_ENV_SYNC_CONCURRENCY) {
+    throw new Error(
+      `KILO_ENV_SYNC_CONCURRENCY must be an integer between 1 and ${MAX_ENV_SYNC_CONCURRENCY}`
+    );
+  }
+  return concurrency;
+}
+
+async function mapWithConcurrency<T, R>(
+  values: readonly T[],
+  concurrency: number,
+  map: (value: T, index: number) => Promise<R>
+): Promise<R[]> {
+  if (values.length === 0) return [];
+  if (!Number.isInteger(concurrency) || concurrency < 1) {
+    throw new Error('Concurrency must be a positive integer');
+  }
+
+  const results = new Array<R>(values.length);
+  let nextIndex = 0;
+  const workers = Array.from({ length: Math.min(concurrency, values.length) }, async () => {
+    while (true) {
+      const index = nextIndex++;
+      if (index >= values.length) return;
+      results[index] = await map(values[index] as T, index);
+    }
+  });
+  await Promise.all(workers);
+  return results;
+}
+
+export { mapWithConcurrency, resolveEnvSyncConcurrency };

--- a/dev/local/env-sync/index.ts
+++ b/dev/local/env-sync/index.ts
@@ -2,7 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import * as readline from 'node:readline';
 import { resolveTargets } from '../services';
-import { computePlan, findDevVarsExamples } from './plan';
+import { computePlanAsync, findDevVarsExamples } from './plan';
 import { planHasChanges, displayPlan, applyEnvLocalAutoCreates, applyPlan } from './output';
 import type { SyncResult, CheckResult } from './types';
 
@@ -39,12 +39,14 @@ function resolveServiceFilter(targets?: string[]): Set<string> | undefined {
 async function syncEnvVars(options: {
   repoRoot: string;
   check?: boolean;
+  missingSecretsOnly?: boolean;
   yes?: boolean;
   targets?: string[];
 }): Promise<SyncResult> {
-  const { repoRoot, check = false, yes = false, targets } = options;
+  const { repoRoot, check = false, missingSecretsOnly = false, yes = false, targets } = options;
   const serviceFilter = resolveServiceFilter(targets);
-  const plan = computePlan(repoRoot, serviceFilter, !check);
+  const refreshSourceBackedSecrets = !check && !missingSecretsOnly;
+  const plan = await computePlanAsync(repoRoot, serviceFilter, refreshSourceBackedSecrets);
 
   if (plan.missingEnvLocal) {
     displayPlan(plan);
@@ -74,8 +76,10 @@ async function syncEnvVars(options: {
     if (shouldApply) {
       applyEnvLocalAutoCreates(plan.envLocalAutoCreates, repoRoot);
       const applyReadyPlan =
-        plan.envLocalAutoCreates.length > 0 ? computePlan(repoRoot, serviceFilter, true) : plan;
-      applyPlan(applyReadyPlan, repoRoot);
+        plan.envLocalAutoCreates.length > 0
+          ? await computePlanAsync(repoRoot, serviceFilter, refreshSourceBackedSecrets)
+          : plan;
+      await applyPlan(applyReadyPlan, repoRoot, { missingSecretsOnly });
       console.log(`\n${GREEN}✓ Applied${RESET}`);
     } else {
       console.log('Skipped.');
@@ -99,7 +103,7 @@ async function checkEnvVars(repoRoot: string, targets?: string[]): Promise<Check
   }
 
   const serviceFilter = resolveServiceFilter(targets);
-  const plan = computePlan(repoRoot, serviceFilter, false);
+  const plan = await computePlanAsync(repoRoot, serviceFilter, false);
   const totalMissing =
     plan.devVarsChanges.reduce((sum, c) => sum + c.missingValues.length, 0) +
     plan.secretStoreWarnings.reduce((sum, c) => sum + c.bindings.length, 0);
@@ -144,6 +148,7 @@ function findRepoRoot(): string {
 async function main() {
   const args = process.argv.slice(2);
   const checkMode = args.includes('--check');
+  const missingSecretsOnly = args.includes('--missing-secrets-only');
   const yesMode = args.includes('--yes') || args.includes('-y');
   const targets = args.filter(a => !a.startsWith('-'));
 
@@ -165,6 +170,7 @@ async function main() {
 
   const result = await syncEnvVars({
     repoRoot,
+    missingSecretsOnly,
     yes: yesMode,
     targets: targets.length > 0 ? targets : undefined,
   });

--- a/dev/local/env-sync/output.test.ts
+++ b/dev/local/env-sync/output.test.ts
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import test from 'node:test';
+import { applyPlan } from './output';
+import type { EnvSyncPlan, SecretStoreAutoCreate } from './types';
+
+function secretCreate(workerDir: string, secretName: string): SecretStoreAutoCreate {
+  return {
+    workerDir,
+    binding: {
+      binding: secretName,
+      store_id: 'store-id',
+      secret_name: secretName,
+    },
+    sourceKey: secretName,
+    value: `value-for-${secretName}`,
+  };
+}
+
+test('creates missing secrets concurrently across stores and rechecks existing secrets', async () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'env-sync-output-'));
+  const existing = secretCreate('services/event-service', 'EXISTING_SECRET');
+  const missing = secretCreate('services/model-eval-ingest', 'MISSING_SECRET');
+  for (const create of [existing, missing]) {
+    fs.mkdirSync(path.join(repoRoot, create.workerDir, '.wrangler'), { recursive: true });
+  }
+
+  const plan: EnvSyncPlan = {
+    lanIp: undefined,
+    devVarsChanges: [],
+    envDevLocalChanges: [],
+    envLocalAutoCreates: [],
+    secretStoreWarnings: [],
+    secretStoreAutoCreates: [existing, missing],
+    consistencyWarnings: [],
+    execWarnings: [],
+    missingEnvLocal: false,
+  };
+  let active = 0;
+  let maxActive = 0;
+  const created: string[] = [];
+  try {
+    await applyPlan(plan, repoRoot, {
+      concurrency: 2,
+      missingSecretsOnly: true,
+      runWrangler: async (_repoRoot, workerDir, args, input) => {
+        active++;
+        maxActive = Math.max(maxActive, active);
+        await new Promise(resolve => setTimeout(resolve, 20));
+        active--;
+
+        if (args.includes('list')) {
+          return {
+            status: 0,
+            stderr: '',
+            stdout: workerDir === existing.workerDir ? 'EXISTING_SECRET\n' : '',
+          };
+        }
+        assert.ok(input?.startsWith('value-for-'));
+        assert.ok(!args.some(arg => arg.startsWith('value-for-')));
+        created.push(args[args.indexOf('--name') + 1] ?? '');
+        return { status: 0, stderr: '', stdout: '' };
+      },
+    });
+
+    assert.equal(maxActive, 2);
+    assert.deepEqual(created, ['MISSING_SECRET']);
+  } finally {
+    fs.rmSync(repoRoot, { recursive: true, force: true });
+  }
+});

--- a/dev/local/env-sync/output.ts
+++ b/dev/local/env-sync/output.ts
@@ -1,6 +1,8 @@
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { withProcessLockAsync } from '../process-lock';
+import { mapWithConcurrency, resolveEnvSyncConcurrency } from './concurrency';
 import type {
   DevVarsFileChange,
   EnvLocalAutoCreate,
@@ -261,32 +263,56 @@ function applyEnvLocalAutoCreates(creates: EnvLocalAutoCreate[], repoRoot: strin
 // Secrets store creation
 // ---------------------------------------------------------------------------
 
-function createSecretsStoreSecret(
+type WranglerResult = {
+  status: number;
+  stderr: string;
+  stdout: string;
+};
+
+type WranglerRunner = typeof runWrangler;
+
+type ApplyPlanOptions = {
+  concurrency?: number;
+  missingSecretsOnly?: boolean;
+  runWrangler?: WranglerRunner;
+};
+
+function runWrangler(
+  repoRoot: string,
+  workerDir: string,
+  args: string[],
+  input?: string
+): Promise<WranglerResult> {
+  return new Promise((resolve, reject) => {
+    const child = spawn('pnpm', ['wrangler', ...args], {
+      cwd: path.join(repoRoot, workerDir),
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.setEncoding('utf-8');
+    child.stderr.setEncoding('utf-8');
+    child.stdout.on('data', chunk => (stdout += chunk));
+    child.stderr.on('data', chunk => (stderr += chunk));
+    child.once('error', reject);
+    child.once('close', code => resolve({ status: code ?? 1, stderr, stdout }));
+    child.stdin.end(input);
+  });
+}
+
+async function createSecretsStoreSecret(
   repoRoot: string,
   workerDir: string,
   storeId: string,
   secretName: string,
-  value: string
-): void {
-  const result = spawnSync(
-    'pnpm',
-    [
-      'wrangler',
-      'secrets-store',
-      'secret',
-      'create',
-      storeId,
-      '--name',
-      secretName,
-      '--scopes',
-      'workers',
-    ],
-    {
-      cwd: path.join(repoRoot, workerDir),
-      encoding: 'utf-8',
-      input: `${value}\n`, // Complete Wrangler's prompt without exposing the value in argv.
-      stdio: ['pipe', 'pipe', 'pipe'],
-    }
+  value: string,
+  runner: WranglerRunner = runWrangler
+): Promise<void> {
+  const result = await runner(
+    repoRoot,
+    workerDir,
+    ['secrets-store', 'secret', 'create', storeId, '--name', secretName, '--scopes', 'workers'],
+    `${value}\n` // Complete Wrangler's prompt without exposing the value in argv.
   );
   if (result.status !== 0) {
     const errorOutput = result.stderr.trim();
@@ -296,25 +322,92 @@ function createSecretsStoreSecret(
   }
 }
 
-function applySecretsStoreAutoCreates(creates: SecretStoreAutoCreate[], repoRoot: string): void {
-  if (creates.length === 0) return;
-
-  console.log('\nCreating secrets store secrets...');
-  for (const create of creates) {
-    createSecretsStoreSecret(
-      repoRoot,
-      create.workerDir,
-      create.binding.store_id,
-      create.binding.secret_name,
-      create.value
-    );
-    console.log(`  ✓ ${create.binding.secret_name}`);
+function resolveWranglerPersistenceDir(repoRoot: string, workerDir: string): string {
+  const wranglerDir = path.join(repoRoot, workerDir, '.wrangler');
+  try {
+    return fs.realpathSync(wranglerDir);
+  } catch {
+    return wranglerDir;
   }
 }
 
-function applyPlan(plan: EnvSyncPlan, repoRoot: string): void {
+async function secretExists(
+  create: SecretStoreAutoCreate,
+  repoRoot: string,
+  runner: WranglerRunner = runWrangler
+): Promise<boolean> {
+  const result = await runner(repoRoot, create.workerDir, [
+    'secrets-store',
+    'secret',
+    'list',
+    create.binding.store_id,
+  ]);
+  if (result.status !== 0) {
+    const errorOutput = result.stderr.trim();
+    throw new Error(
+      `Failed to list Secrets Store secrets for ${create.workerDir}${errorOutput ? `: ${errorOutput}` : ''}`
+    );
+  }
+  return result.stdout.includes(create.binding.secret_name);
+}
+
+async function applySecretsStoreAutoCreates(
+  creates: SecretStoreAutoCreate[],
+  repoRoot: string,
+  options: ApplyPlanOptions = {}
+): Promise<void> {
+  if (creates.length === 0) return;
+
+  console.log('\nCreating secrets store secrets...');
+  const groups = new Map<string, SecretStoreAutoCreate[]>();
+  for (const create of creates) {
+    const persistenceDir = resolveWranglerPersistenceDir(repoRoot, create.workerDir);
+    const group = groups.get(persistenceDir) ?? [];
+    group.push(create);
+    groups.set(persistenceDir, group);
+  }
+
+  await mapWithConcurrency(
+    [...groups.entries()],
+    options.concurrency ?? resolveEnvSyncConcurrency(),
+    async ([persistenceDir, group]) => {
+      const lockPath = path.join(persistenceDir, '.env-sync-secrets.lock');
+      await withProcessLockAsync(
+        lockPath,
+        `Secrets Store for ${group[0]?.workerDir ?? persistenceDir}`,
+        async () => {
+          for (const create of group) {
+            if (
+              options.missingSecretsOnly &&
+              (await secretExists(create, repoRoot, options.runWrangler))
+            ) {
+              console.log(`  ✓ ${create.binding.secret_name} already exists`);
+              continue;
+            }
+            await createSecretsStoreSecret(
+              repoRoot,
+              create.workerDir,
+              create.binding.store_id,
+              create.binding.secret_name,
+              create.value,
+              options.runWrangler
+            );
+            console.log(`  ✓ ${create.binding.secret_name}`);
+          }
+        },
+        30_000
+      );
+    }
+  );
+}
+
+async function applyPlan(
+  plan: EnvSyncPlan,
+  repoRoot: string,
+  options: ApplyPlanOptions = {}
+): Promise<void> {
   // Create secrets store secrets first
-  applySecretsStoreAutoCreates(plan.secretStoreAutoCreates, repoRoot);
+  await applySecretsStoreAutoCreates(plan.secretStoreAutoCreates, repoRoot, options);
 
   for (const change of plan.devVarsChanges) {
     const devVarsPath = path.join(repoRoot, change.workerDir, '.dev.vars');

--- a/dev/local/env-sync/plan.test.ts
+++ b/dev/local/env-sync/plan.test.ts
@@ -3,7 +3,7 @@ import * as fs from 'node:fs';
 import * as os from 'node:os';
 import * as path from 'node:path';
 import test from 'node:test';
-import { computePlan } from './plan';
+import { computePlan, computePlanAsync } from './plan';
 import { resolveAnnotatedValue } from './parse';
 import type { ExampleEntry } from './types';
 import { serviceUrl } from '../mobile-env';
@@ -625,6 +625,63 @@ test('check mode accepts an existing source-backed local Secrets Store secret', 
       const plan = computePlan(repo.root, new Set(['event-service']), false);
       assert.deepEqual(plan.secretStoreAutoCreates, []);
     });
+  } finally {
+    repo.cleanup();
+  }
+});
+
+test('checks independent local Secrets Store persistence directories concurrently', async () => {
+  const repo = createRepo({
+    '.env.local': [
+      'NEXTAUTH_SECRET=local-nextauth-secret',
+      'INTERNAL_API_SECRET=local-internal-secret',
+      '',
+    ].join('\n'),
+    'services/event-service/package.json': JSON.stringify({ scripts: { dev: 'wrangler dev' } }),
+    'services/event-service/wrangler.jsonc': `{
+      "secrets_store_secrets": [{
+        "binding": "NEXTAUTH_SECRET",
+        "store_id": "store-id",
+        "secret_name": "NEXTAUTH_SECRET_PROD"
+      }]
+    }`,
+    'services/model-eval-ingest/package.json': JSON.stringify({
+      scripts: { dev: 'wrangler dev' },
+    }),
+    'services/model-eval-ingest/wrangler.jsonc': `{
+      "secrets_store_secrets": [{
+        "binding": "INTERNAL_API_SECRET",
+        "store_id": "store-id",
+        "secret_name": "INTERNAL_API_SECRET_DEV"
+      }]
+    }`,
+  });
+  let active = 0;
+  let maxActive = 0;
+  const calls: string[] = [];
+  try {
+    const plan = await computePlanAsync(
+      repo.root,
+      new Set(['event-service', 'cloudflare-model-eval-ingest']),
+      false,
+      {
+        concurrency: 2,
+        listSecrets: async (_repoRoot, workerDir) => {
+          calls.push(workerDir);
+          active++;
+          maxActive = Math.max(maxActive, active);
+          await new Promise(resolve => setTimeout(resolve, 20));
+          active--;
+          return workerDir === 'services/event-service'
+            ? 'NEXTAUTH_SECRET_PROD\n'
+            : 'INTERNAL_API_SECRET_DEV\n';
+        },
+      }
+    );
+
+    assert.equal(maxActive, 2);
+    assert.deepEqual(calls.sort(), ['services/event-service', 'services/model-eval-ingest']);
+    assert.deepEqual(plan.secretStoreAutoCreates, []);
   } finally {
     repo.cleanup();
   }

--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -1,9 +1,11 @@
-import { spawnSync } from 'node:child_process';
+import { execFile, spawnSync } from 'node:child_process';
 import { randomBytes } from 'node:crypto';
 import * as fs from 'node:fs';
 import * as path from 'node:path';
+import { promisify } from 'node:util';
 import { detectLanIp } from '../lan-ip';
 import { services } from '../services';
+import { mapWithConcurrency, resolveEnvSyncConcurrency } from './concurrency';
 import type {
   Annotation,
   DevVarsFileChange,
@@ -374,6 +376,20 @@ function extractSecretsStoreBindings(repoRoot: string, workerDir: string): Secre
 // Local secrets store check (via wrangler CLI)
 // ---------------------------------------------------------------------------
 
+const execFileAsync = promisify(execFile);
+
+type SecretsStoreQuery = {
+  cacheKey: string;
+  persistenceDir: string;
+  storeId: string;
+  workerDir: string;
+};
+
+type AsyncPlanOptions = {
+  concurrency?: number;
+  listSecrets?: (repoRoot: string, workerDir: string, storeId: string) => Promise<string>;
+};
+
 function listLocalStoreSecrets(repoRoot: string, workerDir: string, storeId: string): string {
   const result = spawnSync('pnpm', ['wrangler', 'secrets-store', 'secret', 'list', storeId], {
     cwd: path.join(repoRoot, workerDir),
@@ -381,6 +397,85 @@ function listLocalStoreSecrets(repoRoot: string, workerDir: string, storeId: str
     stdio: ['pipe', 'pipe', 'pipe'],
   });
   return result.status === 0 ? result.stdout : '';
+}
+
+async function listLocalStoreSecretsAsync(
+  repoRoot: string,
+  workerDir: string,
+  storeId: string
+): Promise<string> {
+  try {
+    const { stdout } = await execFileAsync(
+      'pnpm',
+      ['wrangler', 'secrets-store', 'secret', 'list', storeId],
+      {
+        cwd: path.join(repoRoot, workerDir),
+        encoding: 'utf-8',
+      }
+    );
+    return stdout;
+  } catch {
+    return '';
+  }
+}
+
+function getSecretsStoreQueries(
+  repoRoot: string,
+  serviceFilter?: Set<string>
+): SecretsStoreQuery[] {
+  const queries = new Map<string, SecretsStoreQuery>();
+  for (const [name, svc] of services) {
+    if (svc.type !== 'worker') continue;
+    if (serviceFilter && !serviceFilter.has(name)) continue;
+
+    const bindings = extractSecretsStoreBindings(repoRoot, svc.dir);
+    for (const binding of bindings) {
+      const cacheKey = `${svc.dir}:${binding.store_id}`;
+      if (queries.has(cacheKey)) continue;
+      const wranglerDir = path.join(repoRoot, svc.dir, '.wrangler');
+      let persistenceDir = wranglerDir;
+      try {
+        persistenceDir = fs.realpathSync(wranglerDir);
+      } catch {
+        // Wrangler will create this service-local persistence directory on demand.
+      }
+      queries.set(cacheKey, {
+        cacheKey,
+        persistenceDir,
+        storeId: binding.store_id,
+        workerDir: svc.dir,
+      });
+    }
+  }
+  return [...queries.values()];
+}
+
+async function loadLocalStoreSecrets(
+  repoRoot: string,
+  serviceFilter?: Set<string>,
+  options: AsyncPlanOptions = {}
+): Promise<Map<string, string>> {
+  const groups = new Map<string, SecretsStoreQuery[]>();
+  for (const query of getSecretsStoreQueries(repoRoot, serviceFilter)) {
+    const group = groups.get(query.persistenceDir) ?? [];
+    group.push(query);
+    groups.set(query.persistenceDir, group);
+  }
+
+  const listSecrets = options.listSecrets ?? listLocalStoreSecretsAsync;
+  const groupedResults = await mapWithConcurrency(
+    [...groups.values()],
+    options.concurrency ?? resolveEnvSyncConcurrency(),
+    async queries => {
+      const results: [string, string][] = [];
+      // Store IDs sharing one Wrangler persistence directory use the same local SQLite state.
+      for (const query of queries) {
+        results.push([query.cacheKey, await listSecrets(repoRoot, query.workerDir, query.storeId)]);
+      }
+      return results;
+    }
+  );
+  return new Map(groupedResults.flat());
 }
 
 function resolveSecretStoreSource(
@@ -463,7 +558,8 @@ function collectLocalSecretSources(
 function computePlan(
   repoRoot: string,
   serviceFilter?: Set<string>,
-  refreshSourceBackedSecrets = true
+  refreshSourceBackedSecrets = true,
+  prefetchedStoreOutputs?: ReadonlyMap<string, string>
 ): EnvSyncPlan {
   const envLocalPath = path.join(repoRoot, '.env.local');
   if (!fs.existsSync(envLocalPath)) {
@@ -703,7 +799,7 @@ function computePlan(
   const secretStoreWarnings: SecretStoreWarning[] = [];
   const secretStoreAutoCreates: SecretStoreAutoCreate[] = [];
   // Cache keyed by workerDir+storeId — wrangler scopes secret visibility per worker locally
-  const storeOutputCache = new Map<string, string>();
+  const storeOutputCache = new Map(prefetchedStoreOutputs);
 
   for (const [name, svc] of services) {
     if (svc.type !== 'worker') continue;
@@ -793,4 +889,17 @@ function computePlan(
   };
 }
 
-export { computePlan, findDevVarsExamples };
+async function computePlanAsync(
+  repoRoot: string,
+  serviceFilter?: Set<string>,
+  refreshSourceBackedSecrets = true,
+  options: AsyncPlanOptions = {}
+): Promise<EnvSyncPlan> {
+  if (!fs.existsSync(path.join(repoRoot, '.env.local'))) {
+    return computePlan(repoRoot, serviceFilter, refreshSourceBackedSecrets);
+  }
+  const storeOutputs = await loadLocalStoreSecrets(repoRoot, serviceFilter, options);
+  return computePlan(repoRoot, serviceFilter, refreshSourceBackedSecrets, storeOutputs);
+}
+
+export { computePlan, computePlanAsync, findDevVarsExamples };

--- a/dev/local/mobile-workflow.test.ts
+++ b/dev/local/mobile-workflow.test.ts
@@ -81,7 +81,8 @@ test('env sync refreshes source-backed Wrangler secrets through completed stdin 
   const envOutput = fs.readFileSync('dev/local/env-sync/output.ts', 'utf8');
 
   assert.match(plan, /Recreate source-backed secrets/);
-  assert.match(envOutput, /input: `\$\{value\}\\n`/);
+  assert.match(envOutput, /`\$\{value\}\\n`/);
+  assert.match(envOutput, /child\.stdin\.end\(input\)/);
   assert.match(envOutput, /Failed to create Secrets Store secret/);
 });
 


### PR DESCRIPTION
## Summary

- parallelize local Secrets Store discovery across independent Wrangler persistence directories
- parallelize Secrets Store creation across independent persistence directories while locking shared SQLite state
- add `--missing-secrets-only` for fast worktree setup without refreshing existing source-backed secrets
- add a configurable `KILO_ENV_SYNC_CONCURRENCY` limit and document the workflow

## Performance

- warm all-service `dev:env --check`: **20.9s → 7.1s** locally

## Safety

- secret values are passed to Wrangler over stdin and never placed in argv
- operations sharing one resolved `.wrangler` directory remain serialized and cross-process locked; Wrangler 4.112.0 produced `SQLITE_READONLY` failures when tested with concurrent writers to one local store
- missing-only mode rechecks each secret under the lock before creating it

## Testing

- `node --import tsx --test dev/local/*.test.ts dev/local/env-sync/*.test.ts dev/local/scripts/*.test.ts` (212 passed)
- focused TypeScript check for changed env-sync files
- focused oxlint and oxfmt checks
- `git diff --check`