### PR TITLE
fix(ai-gateway): stop injecting Friendli BYOK key

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -236,7 +236,6 @@ Manage shared web env var additions and rotations with `pnpm web:env set <VARIAB
 ### AI Providers
 
 - `OPENROUTER_API_KEY` - Primary OpenRouter API key for model inference through the AI gateway; provider definition in `apps/web/src/lib/ai-gateway/providers/provider-definitions.ts` pointing to `https://openrouter.ai/api/v1`. `[SECRET]`
-- `FRIENDLI_API_KEY` - Optional Kilo-managed Friendli API key merged into Vercel AI Gateway BYOK settings for requests that are not using user or organization BYOK. `[SECRET]`
 - `MISTRAL_API_KEY` - Mistral API key; used in `apps/web/src/lib/ai-gateway/embeddings/embedding-providers.ts` for `codestral-embed-2505` and `mistral-embed` embeddings, in the FIM completions proxy at `apps/web/src/app/api/fim/completions/route.ts` (routes Mistral Codestral vs. La Plateforme keys), and as a provider config in `apps/web/src/lib/config.server.ts`. `[SECRET]`
 - `LONGCAT_API_KEY` - LongCat API key for model inference through the AI gateway; provider definition in `apps/web/src/lib/ai-gateway/providers/provider-definitions.ts`. `[SECRET]`
 - `STREAMLAKE_API_KEY` - StreamLake API key for model inference through the AI gateway; provider definition in `apps/web/src/lib/ai-gateway/providers/provider-definitions.ts`. `[SECRET]`

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -191,7 +191,7 @@ describe('applyVercelSettings BYOK pinning', () => {
     expect(request.body.providerOptions?.gateway?.only).toEqual(['anthropic']);
   });
 
-  it('does not merge the managed Friendli key into user BYOK settings', async () => {
+  it('does not add managed Friendli credentials to user BYOK settings', async () => {
     process.env.FRIENDLI_API_KEY = 'friendli-managed-key';
     const request = byokRequest([]);
 
@@ -205,7 +205,7 @@ describe('applyVercelSettings BYOK pinning', () => {
   });
 });
 
-describe('applyVercelSettings managed BYOK', () => {
+describe('applyVercelSettings managed requests', () => {
   function managedRequest(): GatewayRequest {
     return {
       kind: 'chat_completions',
@@ -216,19 +216,8 @@ describe('applyVercelSettings managed BYOK', () => {
     };
   }
 
-  it('merges the configured Friendli key into the gateway BYOK settings', async () => {
+  it('does not add managed Friendli credentials from the environment', async () => {
     process.env.FRIENDLI_API_KEY = 'friendli-managed-key';
-    const request = managedRequest();
-
-    await applyVercelSettings('moonshotai/kimi-k3', request, null);
-
-    expect(request.body.providerOptions?.gateway?.byok).toEqual({
-      friendli: [{ apiKey: 'friendli-managed-key' }],
-    });
-  });
-
-  it('does not add Friendli BYOK settings when the key is not configured', async () => {
-    delete process.env.FRIENDLI_API_KEY;
     const request = managedRequest();
 
     await applyVercelSettings('moonshotai/kimi-k3', request, null);

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -27,7 +27,6 @@ import {
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
-import { getEnvVariable } from '@/lib/dotenvx';
 
 type VercelRoutingConfig = {
   paid: number;
@@ -306,14 +305,6 @@ export async function applyVercelSettings(
       requestToMutate,
       vercelInferenceProviders
     );
-
-    const friendliApiKey = getEnvVariable('FRIENDLI_API_KEY');
-    if (friendliApiKey && requestToMutate.body.providerOptions.gateway) {
-      requestToMutate.body.providerOptions.gateway.byok = {
-        ...requestToMutate.body.providerOptions.gateway.byok,
-        friendli: [{ apiKey: friendliApiKey }],
-      };
-    }
   }
 
   if (requestToMutate.body.providerOptions) {


### PR DESCRIPTION
## Summary

- stop injecting `FRIENDLI_API_KEY` into Vercel AI Gateway requests
- preserve user BYOK credentials without adding managed Friendli credentials
- remove the obsolete environment variable documentation

## Testing

- `pnpm --filter web test -- --runInBand apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts`
- `pnpm --filter web typecheck`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/vercel/index.ts apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts`
- `git diff --check`