### PR TITLE
feat(data-export): return all user fields

### DIFF
--- a/apps/web/src/routers/admin/user-data-exports-router.test.ts
+++ b/apps/web/src/routers/admin/user-data-exports-router.test.ts
@@ -1,11 +1,13 @@
 import { eq, inArray, sql } from 'drizzle-orm';
 import { db } from '@/lib/drizzle';
+import { EXPORT_FILE_SCHEMA_VERSION } from '@kilocode/db/user-data-export-file';
 import { dispatchUserDataExport } from '@/lib/user-data-export-worker-client';
 import {
   setDataExportRecoveryAuditSinkForTest,
   type DataExportRecoveryAuditEvent,
 } from './user-data-export-recovery-audit';
 import { createCallerForUser } from '@/routers/test-utils';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import {
   kilocode_users,
@@ -637,6 +639,41 @@ describe('adminUserDataExportsRouter', () => {
     ).toBeDefined();
   });
 
+  // The replacement inherits the column defaults for anything the insert does not name.
+  // Those defaults are 'user' and NULL, so an organization export retried here came back
+  // as a personal export for whoever originally requested it, regenerating one person's
+  // data under a recovery action meant to reproduce the organization's.
+  it('keeps an organization export an organization export when retried', async () => {
+    const organization = await createTestOrganization('Recovery Org', recoveryOwner.id, 0);
+    const [target] = await db
+      .insert(user_data_exports)
+      .values({
+        kilo_user_id: recoveryOwner.id,
+        subject_type: 'organization',
+        organization_id: organization.id,
+        status: 'failed',
+        snapshot_at: '2026-08-03T00:00:00.000Z',
+        requested_at: new Date(Date.now() - 3_600_000).toISOString(),
+        failure_code: 'queue_delivery_exhausted',
+      })
+      .returning({ id: user_data_exports.id });
+    exportIds.push(target.id);
+
+    const result = await (
+      await createCallerForUser(admin.id)
+    ).admin.userDataExports.cancelAndRetry({ exportId: target.id, expectedGeneration: 0 });
+    exportIds.push(result.replacementExportId);
+
+    const replacement = await db.query.user_data_exports.findFirst({
+      where: eq(user_data_exports.id, result.replacementExportId),
+    });
+    expect(replacement).toMatchObject({
+      subject_type: 'organization',
+      organization_id: organization.id,
+      kilo_user_id: recoveryOwner.id,
+    });
+  });
+
   it('creates a pristine replacement from the same logical snapshot and durable outbox', async () => {
     const requestedAt = new Date(Date.now() - 7_200_000).toISOString();
     const [target] = await db
@@ -681,7 +718,9 @@ describe('adminUserDataExportsRouter', () => {
     expect(replacement).toMatchObject({
       kilo_user_id: recoveryOwner.id,
       status: 'queued',
-      schema_version: 1,
+      // The replacement records the format the Worker will write now, not the
+      // original's: a retry regenerates the file with today's code.
+      schema_version: EXPORT_FILE_SCHEMA_VERSION,
       snapshot_at: expect.any(String),
       requested_at: expect.any(String),
       current_source: null,

--- a/apps/web/src/routers/admin/user-data-exports-router.ts
+++ b/apps/web/src/routers/admin/user-data-exports-router.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import { sql } from 'drizzle-orm';
 import * as z from 'zod';
 import { db, readDb } from '@/lib/drizzle';
+import { EXPORT_FILE_SCHEMA_VERSION } from '@kilocode/db/user-data-export-file';
 import { dispatchUserDataExport } from '@/lib/user-data-export-worker-client';
 import { adminProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import {
@@ -101,6 +102,8 @@ type OutboxRow = {
 type RecoveryTarget = {
   id: string;
   kilo_user_id: string;
+  subject_type: 'user' | 'organization';
+  organization_id: string | null;
   status: ExportStatus;
   schema_version: number;
   snapshot_at: string;
@@ -158,7 +161,8 @@ async function lockRecoveryTarget(
   }
 
   const target = await tx.execute<RecoveryTarget>(sql`
-    SELECT id, kilo_user_id, status, schema_version, snapshot_at, requested_at,
+    SELECT id, kilo_user_id, subject_type, organization_id, status, schema_version,
+      snapshot_at, requested_at,
       dispatch_generation, lease_expires_at, multipart_upload_id, r2_object_key
     FROM user_data_exports
     WHERE id = ${input.exportId}
@@ -692,9 +696,19 @@ export const adminUserDataExportsRouter = createTRPCRouter({
         kilo_user_id: string;
         dispatch_generation: number;
       }>(sql`
-        INSERT INTO user_data_exports (kilo_user_id, schema_version, snapshot_at, requested_at)
+        INSERT INTO user_data_exports (
+          kilo_user_id, subject_type, organization_id, schema_version, snapshot_at, requested_at
+        )
         VALUES (
-          ${target.kilo_user_id}, ${target.schema_version},
+          ${target.kilo_user_id},
+          -- Carried, not defaulted. Without these an organization export retried here came
+          -- back as a personal export for whoever originally requested it, because the
+          -- column defaults are 'user' and NULL.
+          ${target.subject_type},
+          ${target.organization_id}::uuid,
+          -- The current format, not the original's: a retry regenerates the file with
+          -- today's code, so copying the old value would describe a file that never existed.
+          ${EXPORT_FILE_SCHEMA_VERSION},
           ${target.snapshot_at}::timestamptz, ${target.requested_at}::timestamptz
         )
         RETURNING id, kilo_user_id, dispatch_generation

--- a/apps/web/src/routers/user-exports-router.ts
+++ b/apps/web/src/routers/user-exports-router.ts
@@ -22,6 +22,7 @@ import {
   ORGANIZATION_EXPORT_ROLES,
   organizationExportAccess,
 } from '@kilocode/db/organization-export-access';
+import { EXPORT_FILE_SCHEMA_VERSION } from '@kilocode/db/user-data-export-file';
 import {
   dispatchUserDataExport,
   requestUserDataExportDownload,
@@ -261,11 +262,15 @@ async function createExportRequest(subject: {
 
     return tx.execute<UserExportRow>(sql`
       WITH created AS (
-        INSERT INTO user_data_exports (kilo_user_id, subject_type, organization_id, snapshot_at)
+        INSERT INTO user_data_exports (kilo_user_id, subject_type, organization_id, schema_version, snapshot_at)
         VALUES (
           ${subject.kiloUserId},
           ${isOrg ? 'organization' : 'user'},
           ${subject.organizationId}::uuid,
+          -- Set explicitly rather than left to the column default, so the row records the
+          -- format of the file the Worker will actually write. The default stays at 1, so
+          -- raising the format never needs a migration.
+          ${EXPORT_FILE_SCHEMA_VERSION},
           ${EXPORT_DATA_CUTOFF}::timestamptz
         )
         RETURNING id, subject_type, organization_id, status, requested_at, started_at, completed_at,

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -16,6 +16,7 @@
     "./kiloclaw-organization-trial-expiry-candidates": "./src/kiloclaw-organization-trial-expiry-candidates.ts",
     "./client": "./src/client.ts",
     "./organization-export-access": "./src/organization-export-access.ts",
+    "./user-data-export-file": "./src/user-data-export-file.ts",
     "./user-soft-delete": "./src/user-soft-delete.ts"
   },
   "dependencies": {

--- a/packages/db/src/user-data-export-file.ts
+++ b/packages/db/src/user-data-export-file.ts
@@ -1,0 +1,23 @@
+/**
+ * The format of the user data export file, recorded on `user_data_exports.schema_version`
+ * and reported as `schemaVersion` in the file's own header.
+ *
+ * Shared rather than defined in the Worker because the row and the file it describes have
+ * to agree, and they are written by different processes: the web router creates the row,
+ * the Worker writes the file. A constant in one of them leaves the other guessing.
+ *
+ * Distinct from the Worker's `EXPORT_SCHEMA_VERSION`, which versions the queue and
+ * download message contract. That one is pinned with `z.literal`, so raising it fails
+ * every in-flight message mid-deploy. This one has no such constraint.
+ *
+ * Raise it when the file's shape changes in a way that could break a reader:
+ *
+ *   1  the original set of sources
+ *   2  the warehouse profile columns added to the identity section (location, historic
+ *      and current, plus the analytics copies of name, email and hosted domain)
+ *
+ * The column's database default stays at 1 deliberately. Every insert sets this value
+ * explicitly, so bumping the format never needs a migration, and a row written without it
+ * is visibly stale rather than quietly wrong.
+ */
+export const EXPORT_FILE_SCHEMA_VERSION = 2;

--- a/services/user-data-export/src/contracts.test.ts
+++ b/services/user-data-export/src/contracts.test.ts
@@ -1,6 +1,12 @@
 import { describe, expect, it } from 'vitest';
 import { ORGANIZATION_EXPORT_ROLES } from '@kilocode/db/organization-export-access';
-import { DownloadRequestSchema, ExportQueueMessageSchema, parseCursor } from './contracts';
+import {
+  DownloadRequestSchema,
+  EXPORT_FILE_SCHEMA_VERSION,
+  EXPORT_SCHEMA_VERSION,
+  ExportQueueMessageSchema,
+  parseCursor,
+} from './contracts';
 import { __test__ } from './databases';
 
 // The Worker re-authorises an organization download against live membership rather than
@@ -30,6 +36,28 @@ describe('organization export roles', () => {
     const rendered = JSON.stringify(__test__.callerMayAccess('user-1').queryChunks);
     expect(rendered).toContain('parent_organization_id');
     expect(rendered).toContain('deleted_at IS NULL');
+  });
+});
+
+// The two versions govern different things and once happened to agree at 1, which read
+// as one constant doing both jobs. Raising the message contract dead-letters every
+// in-flight message; raising the file version does not, and must not be avoided out of
+// fear of the other.
+describe('schema versions', () => {
+  it('versions the file separately from the message contract', () => {
+    expect(EXPORT_FILE_SCHEMA_VERSION).not.toBe(EXPORT_SCHEMA_VERSION);
+  });
+
+  it('keeps the message contract at the version in-flight messages carry', () => {
+    expect(EXPORT_SCHEMA_VERSION).toBe(1);
+    expect(
+      ExportQueueMessageSchema.safeParse({
+        version: 1,
+        operation: 'generate',
+        exportId: '1e6c4a2b-6a1a-4a3f-9b3d-2f8f0a1b7c55',
+        generation: 0,
+      }).success
+    ).toBe(true);
   });
 });
 

--- a/services/user-data-export/src/contracts.ts
+++ b/services/user-data-export/src/contracts.ts
@@ -1,6 +1,26 @@
 import * as z from 'zod';
 
+/**
+ * The queue and download message contract, not the export file's format.
+ *
+ * Pinned with `z.literal` below, so raising it makes every in-flight message fail
+ * validation and dead-letter mid-deploy. It changes only when the message shape does.
+ */
 export const EXPORT_SCHEMA_VERSION = 1;
+
+/**
+ * The format of the export file itself, reported as `schemaVersion` in its header.
+ *
+ * Deliberately separate from the message contract above: the two version different
+ * things and previously happened to agree at 1, which made it look as though one
+ * constant governed both.
+ *
+ * 2 adds the warehouse profile columns to the identity section: location, historic and
+ * current, plus the analytics copies of name, email and hosted domain. Additive for a
+ * reader that ignores unknown fields, breaking for one that does not, and an export file
+ * is the kind of artifact people write strict parsers against.
+ */
+export const EXPORT_FILE_SCHEMA_VERSION = 2;
 
 export const ExportQueueMessageSchema = z
   .object({

--- a/services/user-data-export/src/contracts.ts
+++ b/services/user-data-export/src/contracts.ts
@@ -9,18 +9,11 @@ import * as z from 'zod';
 export const EXPORT_SCHEMA_VERSION = 1;
 
 /**
- * The format of the export file itself, reported as `schemaVersion` in its header.
- *
- * Deliberately separate from the message contract above: the two version different
- * things and previously happened to agree at 1, which made it look as though one
- * constant governed both.
- *
- * 2 adds the warehouse profile columns to the identity section: location, historic and
- * current, plus the analytics copies of name, email and hosted domain. Additive for a
- * reader that ignores unknown fields, breaking for one that does not, and an export file
- * is the kind of artifact people write strict parsers against.
+ * Re-exported from `@kilocode/db` so the Worker and the web router cannot disagree about
+ * the format of a file one writes and the other records. See that module for what the
+ * versions mean and why this one is safe to raise while `EXPORT_SCHEMA_VERSION` is not.
  */
-export const EXPORT_FILE_SCHEMA_VERSION = 2;
+export { EXPORT_FILE_SCHEMA_VERSION } from '@kilocode/db/user-data-export-file';
 
 export const ExportQueueMessageSchema = z
   .object({

--- a/services/user-data-export/src/source-adapters.test.ts
+++ b/services/user-data-export/src/source-adapters.test.ts
@@ -9,6 +9,7 @@ import {
   SOURCES_WITHOUT_DELETED_COLUMN,
   SCOPE_PREDICATES,
   WAREHOUSE_PROFILE_FIELDS,
+  WAREHOUSE_ONLY_FIELDS,
   WAREHOUSE_SOURCE_COLUMNS,
   warehouseQueries,
   type ReplicaQuery,
@@ -70,6 +71,22 @@ const PRIMARY_USER_ROW = {
   normalized_email: null,
   email_domain: null,
 };
+
+/**
+ * A warehouse `users` row. The warehouse-only columns default to null, which is what the
+ * real table holds for most people, and the mapper is strict about their presence: the
+ * probe guarantees the SELECT can name them, so an absent key is a fixture error rather
+ * than a state production can reach.
+ */
+function warehouseUserRow(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: 'user-1',
+    email: 'warehouse@example.com',
+    name: 'Warehouse Name',
+    ...Object.fromEntries(WAREHOUSE_ONLY_FIELDS.map(field => [field, null])),
+    ...overrides,
+  };
+}
 
 const READ_PAGE_INPUT = {
   subject: { type: 'user', kiloUserId: 'owner-user' },
@@ -347,7 +364,11 @@ describe('warehouse availability probe', () => {
     const selected = sourceQueries.warehouseProfileQuery
       .slice('SELECT '.length, sourceQueries.warehouseProfileQuery.indexOf('\nFROM'))
       .split(', ');
-    expect(selected).toEqual(['user_id', ...Object.values(WAREHOUSE_PROFILE_FIELDS)]);
+    expect(selected).toEqual([
+      'user_id',
+      ...Object.values(WAREHOUSE_PROFILE_FIELDS),
+      ...WAREHOUSE_ONLY_FIELDS,
+    ]);
     // Columns the warehouse does not have. Selecting any of them fails at runtime.
     for (const absent of ['google_user_email', 'google_user_name', 'created_at', 'signup_ip']) {
       expect(sourceQueries.warehouseProfileQuery).not.toContain(absent);
@@ -377,7 +398,7 @@ describe('source adapters', () => {
   it('reads each identity field from the database that has it', async () => {
     const { adapters, replicaCalls, warehouseCalls } = harness(
       [PRIMARY_USER_ROW],
-      [{ user_id: 'user-1', email: 'warehouse@example.com', name: 'Warehouse Name' }]
+      [warehouseUserRow()]
     );
 
     await requireAdapter(adapters, 'kilocode_users').readPage?.(READ_PAGE_INPUT);
@@ -390,14 +411,45 @@ describe('source adapters', () => {
     ]);
   });
 
+  // The warehouse holds location and analytics-identity columns with no counterpart on
+  // the primary. They were absent only because they arrived after the identity section
+  // shipped, which left the export returning someone's signup IP while withholding the
+  // country derived from it.
+  it('returns the warehouse columns the primary does not hold', async () => {
+    const { adapters } = harness(
+      [PRIMARY_USER_ROW],
+      [
+        warehouseUserRow({
+          posthog_city: 'Amsterdam',
+          posthog_country_name: 'Netherlands',
+          current_posthog_city: 'Rotterdam',
+          posthog_email: 'analytics@example.com',
+        }),
+      ]
+    );
+
+    const page = await requireAdapter(adapters, 'kilocode_users').readPage?.(READ_PAGE_INPUT);
+    const byField = new Map(page?.records.map(record => [record.field, record.value]));
+
+    // Every declared column reaches the file, not just the ones this fixture populates.
+    for (const field of WAREHOUSE_ONLY_FIELDS) expect(byField.has(field)).toBe(true);
+    expect(byField.get('posthog_city')).toBe('Amsterdam');
+    expect(byField.get('current_posthog_city')).toBe('Rotterdam');
+    // Both generations are kept: where someone was and where they are are different facts.
+    expect(byField.get('posthog_country_name')).toBe('Netherlands');
+    // The analytics copy of identity is distinct from the account's own and is not
+    // collapsed into it.
+    expect(byField.get('posthog_email')).toBe('analytics@example.com');
+    expect(byField.get('google_user_email')).toBe('warehouse@example.com');
+    // A blank stays a blank rather than failing the export.
+    expect(byField.get('vercel_country')).toBeNull();
+  });
+
   // The point of the change: the two fields the warehouse carries are reported as of the
   // snapshot, so a name or email changed after the cutoff does not appear beside five
   // sources frozen before it.
   it('prefers the warehouse copy of email and name over the live values', async () => {
-    const { adapters } = harness(
-      [PRIMARY_USER_ROW],
-      [{ user_id: 'user-1', email: 'warehouse@example.com', name: 'Warehouse Name' }]
-    );
+    const { adapters } = harness([PRIMARY_USER_ROW], [warehouseUserRow()]);
 
     const page = await requireAdapter(adapters, 'kilocode_users').readPage?.(READ_PAGE_INPUT);
     const value = (field: string) => page?.records.find(record => record.field === field)?.value;
@@ -417,10 +469,7 @@ describe('source adapters', () => {
     ['blank', '   '],
     ['a non-string', 42],
   ])('falls back to the live value when the warehouse email is %s', async (_label, bad) => {
-    const { adapters } = harness(
-      [PRIMARY_USER_ROW],
-      [{ user_id: 'user-1', email: bad, name: bad }]
-    );
+    const { adapters } = harness([PRIMARY_USER_ROW], [warehouseUserRow({ email: bad, name: bad })]);
 
     const page = await requireAdapter(adapters, 'kilocode_users').readPage?.(READ_PAGE_INPUT);
     const value = (field: string) => page?.records.find(record => record.field === field)?.value;

--- a/services/user-data-export/src/source-adapters.test.ts
+++ b/services/user-data-export/src/source-adapters.test.ts
@@ -445,6 +445,28 @@ describe('source adapters', () => {
     expect(byField.get('vercel_country')).toBeNull();
   });
 
+  // These columns are unconstrained nullable text and the warehouse's load checks count
+  // nulls rather than forbidding shapes, which is why the email and name path already
+  // tolerates non-strings. A strict mapper here throws a plain Error, which the queue
+  // treats as retryable, so one odd cell would burn four retries on a value frozen in the
+  // snapshot and then fail the whole export.
+  it.each([42, true, {}, [], undefined])(
+    'reads a non-string warehouse value as absent rather than failing the export (%p)',
+    async bad => {
+      const { adapters } = harness(
+        [PRIMARY_USER_ROW],
+        [warehouseUserRow({ posthog_city: bad, posthog_country: 'NL' })]
+      );
+
+      const page = await requireAdapter(adapters, 'kilocode_users').readPage?.(READ_PAGE_INPUT);
+      const byField = new Map(page?.records.map(record => [record.field, record.value]));
+
+      expect(byField.get('posthog_city')).toBeNull();
+      // The rest of the row still comes through.
+      expect(byField.get('posthog_country')).toBe('NL');
+    }
+  );
+
   // The point of the change: the two fields the warehouse carries are reported as of the
   // snapshot, so a name or email changed after the cutoff does not appear beside five
   // sources frozen before it.

--- a/services/user-data-export/src/source-adapters.ts
+++ b/services/user-data-export/src/source-adapters.ts
@@ -434,6 +434,25 @@ function nullableString(value: unknown, field: string): string | null {
   return requiredString(value, field);
 }
 
+/**
+ * A warehouse text column, where anything that is not a string reads as absent.
+ *
+ * Deliberately more tolerant than `nullableString`, and for the same reason
+ * `warehouseProfileValue` is: these columns are unconstrained nullable text, and the
+ * warehouse's own load checks count nulls rather than forbidding shapes. A strict mapper
+ * throws a plain `Error`, which `handleGenerationFailure` treats as retryable, so a single
+ * odd cell would spend the queue's four retries on a value frozen in the snapshot that no
+ * retry can change, and then fail the whole export.
+ *
+ * The strictness is worth keeping on the primary, where the columns are NOT NULL and a
+ * type mismatch means the query named the wrong one. Here it protects nothing: the probe
+ * already guarantees the column exists, so the only thing left to be strict about is the
+ * value, and one unusable value is not worth an export.
+ */
+function warehouseText(value: unknown): string | null {
+  return typeof value === 'string' ? value : null;
+}
+
 function isoTimestamp(value: unknown, field: string): string {
   if (!(typeof value === 'string' || value instanceof Date)) {
     throw new Error(`Replica row has invalid ${field}`);
@@ -640,7 +659,7 @@ export function createSourceAdapters(queries: SourceAdapterQueries): SourceAdapt
             ...WAREHOUSE_ONLY_FIELDS.map(field => ({
               source: 'kilocode_users',
               field,
-              value: nullableString(profile[field], field),
+              value: warehouseText(profile[field]),
             })),
           ],
           nextCursor: null,

--- a/services/user-data-export/src/source-adapters.ts
+++ b/services/user-data-export/src/source-adapters.ts
@@ -128,13 +128,52 @@ LIMIT 1`;
  * one and forgetting the other would silently keep serving the live value, which is the
  * inconsistency this whole path exists to remove.
  *
- * Only email and name. The table has geo columns too, but the export has never had a geo
- * section and adding one is not what sourcing identity from the warehouse means.
+ * Only email and name are overridden this way, because they are the only two the primary
+ * also holds. The warehouse's other columns have no live counterpart and are exported
+ * directly, through `WAREHOUSE_ONLY_FIELDS` below.
  */
 export const WAREHOUSE_PROFILE_FIELDS = {
   google_user_email: 'email',
   google_user_name: 'name',
 } as const;
+
+/**
+ * Warehouse columns the export returns as they are, having no equivalent on the primary.
+ *
+ * Mostly location: the country, city, region and timezone attributed to the person, in
+ * two generations. The `posthog_*` set is what was recorded historically; the
+ * `current_posthog_*` set is the value as of the snapshot. Both are kept, because the
+ * difference between where someone was and where they are is itself information held
+ * about them, and collapsing it would be the export deciding what they get to see.
+ *
+ * `posthog_email`, `posthog_name` and `posthog_hosted_domain` are the analytics copies of
+ * their identity, distinct from the account's own. They can disagree with
+ * `google_user_email` and `google_user_name`, which is exactly why they are worth
+ * returning rather than deduplicating away.
+ *
+ * These arrived after the identity section first shipped, which is the only reason they
+ * were absent. The export already returned `signup_ip` from the primary, so it was
+ * handing someone the address they signed up from while withholding the country derived
+ * from it.
+ */
+export const WAREHOUSE_ONLY_FIELDS = [
+  'posthog_email',
+  'posthog_name',
+  'posthog_hosted_domain',
+  'posthog_country',
+  'posthog_country_name',
+  'posthog_city',
+  'posthog_region_code',
+  'posthog_region_name',
+  'posthog_timezone',
+  'current_posthog_country',
+  'current_posthog_country_name',
+  'current_posthog_city',
+  'current_posthog_region_code',
+  'current_posthog_region_name',
+  'current_posthog_timezone',
+  'vercel_country',
+] as const;
 
 /**
  * The warehouse's copy of those fields. Keyed on `user_id`, which is the warehouse's name
@@ -143,7 +182,10 @@ export const WAREHOUSE_PROFILE_FIELDS = {
  * The interpolated column list comes from the module constant above, never from caller
  * input, on the same basis as `singleKeyPageQuery` below. The user id is a bind parameter.
  */
-const warehouseProfileQuery = `SELECT user_id, ${Object.values(WAREHOUSE_PROFILE_FIELDS).join(', ')}
+const warehouseProfileQuery = `SELECT user_id, ${[
+  ...Object.values(WAREHOUSE_PROFILE_FIELDS),
+  ...WAREHOUSE_ONLY_FIELDS,
+].join(', ')}
 FROM users
 WHERE user_id = $1
 LIMIT 1`;
@@ -584,11 +626,23 @@ export function createSourceAdapters(queries: SourceAdapterQueries): SourceAdapt
           merged[exportField] = warehouseProfileValue(profile[warehouseColumn], row[exportField]);
         }
         return {
-          records: USER_FIELD_MAPPERS.map(([field, mapValue]) => ({
-            source: 'kilocode_users',
-            field,
-            value: mapValue(merged[field]),
-          })),
+          records: [
+            ...USER_FIELD_MAPPERS.map(([field, mapValue]) => ({
+              source: 'kilocode_users',
+              field,
+              value: mapValue(merged[field]),
+            })),
+            // Emitted under the same section: these describe the same person, and the
+            // split between "the primary holds it" and "only the warehouse holds it" is
+            // an implementation detail nobody reading their own export should have to
+            // reason about. Nullable throughout, so a blank stays a blank rather than
+            // failing the export.
+            ...WAREHOUSE_ONLY_FIELDS.map(field => ({
+              source: 'kilocode_users',
+              field,
+              value: nullableString(profile[field], field),
+            })),
+          ],
           nextCursor: null,
         };
       },
@@ -836,7 +890,7 @@ export type WarehouseTableRequirement = { table: string; requiredColumns: readon
  * column, so it takes no addition.
  */
 export const WAREHOUSE_SOURCE_COLUMNS: Record<string, readonly string[]> = {
-  users: ['user_id', ...Object.values(WAREHOUSE_PROFILE_FIELDS)],
+  users: ['user_id', ...Object.values(WAREHOUSE_PROFILE_FIELDS), ...WAREHOUSE_ONLY_FIELDS],
   app_builder_projects: ['id', 'title', DELETED_COLUMN],
   app_builder_messages: ['id', 'data', DELETED_COLUMN],
   cli_sessions: [

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -1,4 +1,9 @@
-import { ExportQueueMessageSchema, type ExportCursor, type ExportQueueMessage } from './contracts';
+import {
+  EXPORT_FILE_SCHEMA_VERSION,
+  ExportQueueMessageSchema,
+  type ExportCursor,
+  type ExportQueueMessage,
+} from './contracts';
 import {
   createReplicaQuery,
   createStateDb,
@@ -279,7 +284,7 @@ export function exportHeader(
 ): string {
   return `${JSON.stringify({
     type: 'header',
-    schemaVersion: 1,
+    schemaVersion: EXPORT_FILE_SCHEMA_VERSION,
     exportId: job.id,
     requestedAt: strictIsoTimestamp(job.requested_at),
     generatedAt: new Date().toISOString(),


### PR DESCRIPTION
## Summary

<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

- Adds 16 records to the identity section of every personal export. 
- schemaVersionis bumped

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
