### PR TITLE
fix(ai-gateway): reject providerOptions requests

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -249,6 +249,22 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     jest.useRealTimers();
   });
 
+  it('rejects providerOptions and directs clients to provider', async () => {
+    const { POST } = await import('./route');
+    const response = await POST(
+      makeRequest({ ...makeBody(), providerOptions: { gateway: { only: ['anthropic'] } } }) as never
+    );
+
+    expect(response.status).toBe(400);
+    expect(await response.json()).toEqual({
+      error: 'The providerOptions field is not supported. Use provider instead.',
+      error_type: 'unsupported_field',
+      message: 'The providerOptions field is not supported. Use provider instead.',
+    });
+    expect(mockedGetProvider).not.toHaveBeenCalled();
+    expect(mockedUpstreamRequest).not.toHaveBeenCalled();
+  });
+
   it('blocks request-local rules-engine block actions before upstream', async () => {
     mockedRedisGet.mockResolvedValue(cachedRulesEngineAction('block'));
     mockedClassifyAbuse.mockResolvedValue(classifyResult('block'));

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -209,6 +209,14 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     return malformedJsonResponse(e);
   }
 
+  if (requestBodyParsed.body.providerOptions !== undefined) {
+    const error = 'The providerOptions field is not supported. Use provider instead.';
+    return NextResponse.json(
+      { error, error_type: ProxyErrorType.unsupported_field, message: error },
+      { status: 400 }
+    );
+  }
+
   if (
     typeof requestBodyParsed.body.model !== 'string' ||
     requestBodyParsed.body.model.trim().length === 0


### PR DESCRIPTION
## Summary
- reject gateway requests that specify `providerOptions`
- direct clients to use the supported `provider` field instead
- cover the early error response and verify no upstream routing occurs

## Testing
- not run locally; CI will handle tests as requested
- `pnpm exec oxfmt apps/web/src/app/api/openrouter/[...path]/route.ts apps/web/src/app/api/openrouter/[...path]/route.test.ts`
- `git diff --check`