### PR TITLE
feat(ai-gateway): support fallback custom pricing

### DIFF
--- a/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
@@ -8,7 +8,6 @@ import {
   QWEN37_MAX_MODEL_ID,
   QWEN37_PLUS_MODEL_ID,
 } from './custom-pricing';
-import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 
 jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }));
 
@@ -81,6 +80,7 @@ describe('custom model pricing', () => {
           outputTokens: 10_000,
           cacheHitTokens: 20_000,
           cacheWriteTokens: 30_000,
+          cost_mUsd: 999,
         })
       )
     ).toBe(Math.round(50_000 * 1.25 + 10_000 * 3.75 + 20_000 * 0.125 + 30_000 * 1.5625));
@@ -103,16 +103,16 @@ describe('custom model pricing', () => {
       cacheWriteTokens: 30,
     });
 
-    expect(calculateCustomCost_mUsd(KIMI_CURRENT_MODEL_ID, usage)).toBe(
+    expect(calculateCustomCost_mUsd('moonshotai/kimi-k3', usage)).toBe(
       Math.round(50 * 3 + 10 * 15 + 20 * 0.3 + 30 * 3)
     );
     expect(
-      calculateCustomCost_mUsd(KIMI_CURRENT_MODEL_ID, { ...usage, cost_mUsd: 123 })
+      calculateCustomCost_mUsd('moonshotai/kimi-k3', { ...usage, cost_mUsd: 123 })
     ).toBeUndefined();
   });
 
   test('does not replace displayed pricing for fallback-only custom pricing', () => {
-    const model = makeModel(KIMI_CURRENT_MODEL_ID);
+    const model = makeModel('moonshotai/kimi-k3');
 
     expect(applyCustomPricingToModel(model)).toBe(model);
     expect(applyCustomPricingToPricing(model.id, model.pricing)).toBe(model.pricing);

--- a/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
@@ -2,11 +2,13 @@ import { describe, expect, test } from '@jest/globals';
 import { captureMessage } from '@sentry/nextjs';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import {
+  applyCustomPricingToPricing,
   applyCustomPricingToModel,
   calculateCustomCost_mUsd,
   QWEN37_MAX_MODEL_ID,
   QWEN37_PLUS_MODEL_ID,
 } from './custom-pricing';
+import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 
 jest.mock('@sentry/nextjs', () => ({ captureMessage: jest.fn() }));
 
@@ -91,6 +93,29 @@ describe('custom model pricing', () => {
     expect(
       calculateCustomCost_mUsd(QWEN37_PLUS_MODEL_ID, makeUsage({ inputTokens: 262_144 }))
     ).toBe(Math.round(262_144 * 0.96));
+  });
+
+  test('uses Kimi K3 custom pricing only when market cost is missing', () => {
+    const usage = makeUsage({
+      inputTokens: 100,
+      outputTokens: 10,
+      cacheHitTokens: 20,
+      cacheWriteTokens: 30,
+    });
+
+    expect(calculateCustomCost_mUsd(KIMI_CURRENT_MODEL_ID, usage)).toBe(
+      Math.round(50 * 3 + 10 * 15 + 20 * 0.3 + 30 * 3)
+    );
+    expect(
+      calculateCustomCost_mUsd(KIMI_CURRENT_MODEL_ID, { ...usage, cost_mUsd: 123 })
+    ).toBeUndefined();
+  });
+
+  test('does not replace displayed pricing for fallback-only custom pricing', () => {
+    const model = makeModel(KIMI_CURRENT_MODEL_ID);
+
+    expect(applyCustomPricingToModel(model)).toBe(model);
+    expect(applyCustomPricingToPricing(model.id, model.pricing)).toBe(model.pricing);
   });
 
   test('reports invalid negative uncached token counts', () => {

--- a/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
@@ -111,6 +111,20 @@ describe('custom model pricing', () => {
     ).toBeUndefined();
   });
 
+  test('uses GLM 5.2 Friendli pricing only when market cost is missing', () => {
+    const usage = makeUsage({
+      inputTokens: 100,
+      outputTokens: 10,
+      cacheHitTokens: 20,
+      cacheWriteTokens: 30,
+    });
+
+    expect(calculateCustomCost_mUsd('z-ai/glm-5.2', usage)).toBe(
+      Math.round(50 * 1.4 + 10 * 4.4 + 20 * 0.26 + 30 * 1.4)
+    );
+    expect(calculateCustomCost_mUsd('z-ai/glm-5.2', { ...usage, cost_mUsd: 123 })).toBeUndefined();
+  });
+
   test('does not replace displayed pricing for fallback-only custom pricing', () => {
     const model = makeModel('moonshotai/kimi-k3');
 

--- a/apps/web/src/lib/ai-gateway/custom-pricing.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.ts
@@ -2,7 +2,6 @@ import { captureMessage } from '@sentry/nextjs';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import type { JustTheCostsUsageStats } from '@/lib/ai-gateway/processUsage.types';
 import { QWEN37_MAX_MODEL_ID, QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
-import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import {
   calculateCost_mUsd,
   type Pricing,
@@ -17,14 +16,14 @@ const TOKENS_256K = 256 * 1024;
 export type CustomPricing = {
   pricing: PricingTiers;
   /** Human-readable discount shown in the model name; never used in calculations. */
-  percentage?: number;
+  discountPercentage?: number;
   /** Only use this pricing when the upstream response does not report a market cost. */
   fallbackOnly?: boolean;
 };
 
 export const customPricingByModelId: Record<string, CustomPricing> = {
   [QWEN37_MAX_MODEL_ID]: {
-    percentage: 50,
+    discountPercentage: 50,
     pricing: [
       {
         start_context_length: 0,
@@ -38,7 +37,7 @@ export const customPricingByModelId: Record<string, CustomPricing> = {
     ],
   },
   [QWEN37_PLUS_MODEL_ID]: {
-    percentage: 20,
+    discountPercentage: 20,
     pricing: [
       {
         start_context_length: 0,
@@ -60,7 +59,7 @@ export const customPricingByModelId: Record<string, CustomPricing> = {
       },
     ],
   },
-  [KIMI_CURRENT_MODEL_ID]: {
+  'moonshotai/kimi-k3': {
     fallbackOnly: true,
     pricing: [
       {
@@ -116,7 +115,9 @@ export function applyCustomPricingToModel(model: OpenRouterModel): OpenRouterMod
   if (!customPricing || customPricing.fallbackOnly) return model;
 
   const discountSuffix =
-    customPricing.percentage === undefined ? '' : ` (${customPricing.percentage}% off)`;
+    customPricing.discountPercentage === undefined
+      ? ''
+      : ` (${customPricing.discountPercentage}% off)`;
 
   return {
     ...model,

--- a/apps/web/src/lib/ai-gateway/custom-pricing.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.ts
@@ -73,6 +73,20 @@ export const customPricingByModelId: Record<string, CustomPricing> = {
       },
     ],
   },
+  'z-ai/glm-5.2': {
+    fallbackOnly: true,
+    pricing: [
+      {
+        start_context_length: 0,
+        pricing: {
+          prompt_per_million: 1.4,
+          completion_per_million: 4.4,
+          input_cache_read_per_million: 0.26,
+          input_cache_write_per_million: null,
+        },
+      },
+    ],
+  },
 };
 
 export function getCustomPricing(modelId: string): CustomPricing | undefined {

--- a/apps/web/src/lib/ai-gateway/custom-pricing.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.ts
@@ -2,6 +2,7 @@ import { captureMessage } from '@sentry/nextjs';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import type { JustTheCostsUsageStats } from '@/lib/ai-gateway/processUsage.types';
 import { QWEN37_MAX_MODEL_ID, QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
+import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import {
   calculateCost_mUsd,
   type Pricing,
@@ -17,6 +18,8 @@ export type CustomPricing = {
   pricing: PricingTiers;
   /** Human-readable discount shown in the model name; never used in calculations. */
   percentage?: number;
+  /** Only use this pricing when the upstream response does not report a market cost. */
+  fallbackOnly?: boolean;
 };
 
 export const customPricingByModelId: Record<string, CustomPricing> = {
@@ -57,6 +60,20 @@ export const customPricingByModelId: Record<string, CustomPricing> = {
       },
     ],
   },
+  [KIMI_CURRENT_MODEL_ID]: {
+    fallbackOnly: true,
+    pricing: [
+      {
+        start_context_length: 0,
+        pricing: {
+          prompt_per_million: 3,
+          completion_per_million: 15,
+          input_cache_read_per_million: 0.3,
+          input_cache_write_per_million: null,
+        },
+      },
+    ],
+  },
 };
 
 export function getCustomPricing(modelId: string): CustomPricing | undefined {
@@ -89,12 +106,14 @@ export function applyCustomPricingToPricing(
   pricing: OpenRouterModel['pricing']
 ): OpenRouterModel['pricing'] {
   const customPricing = getCustomPricing(modelId);
-  return customPricing ? applyPricing(pricing, customPricing.pricing[0].pricing) : pricing;
+  return customPricing && !customPricing.fallbackOnly
+    ? applyPricing(pricing, customPricing.pricing[0].pricing)
+    : pricing;
 }
 
 export function applyCustomPricingToModel(model: OpenRouterModel): OpenRouterModel {
   const customPricing = getCustomPricing(model.id);
-  if (!customPricing) return model;
+  if (!customPricing || customPricing.fallbackOnly) return model;
 
   const discountSuffix =
     customPricing.percentage === undefined ? '' : ` (${customPricing.percentage}% off)`;
@@ -111,7 +130,7 @@ export function calculateCustomCost_mUsd(
   usage: JustTheCostsUsageStats
 ): number | undefined {
   const customPricing = getCustomPricing(modelId);
-  if (!customPricing) return undefined;
+  if (!customPricing || (customPricing.fallbackOnly && usage.cost_mUsd > 0)) return undefined;
 
   const uncachedInputTokens = usage.inputTokens - usage.cacheHitTokens - usage.cacheWriteTokens;
   if (uncachedInputTokens < 0) {

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
@@ -11,7 +11,6 @@ import {
 } from './rewriteModelResponse';
 import { isDynamicallyOptedIntoRequestLogging } from '@/lib/ai-gateway/request-logging-opt-ins';
 import { QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/custom-pricing';
-import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
 import { logExceptInTest } from '@/lib/utils.server';
 
@@ -1060,10 +1059,10 @@ describe('rewriteModelResponse', () => {
   test('preserves cost for models with fallback-only custom pricing', async () => {
     const result = await rewriteModelResponse({
       response: jsonResponse({
-        model: KIMI_CURRENT_MODEL_ID,
+        model: 'moonshotai/kimi-k3',
         usage: { cost: 0.5, cost_details: { upstream_inference_cost: 0.4 }, is_byok: false },
       }),
-      model: KIMI_CURRENT_MODEL_ID,
+      model: 'moonshotai/kimi-k3',
       providerId: 'openrouter',
       kind: 'chat_completions',
       logging: makeLogging(),
@@ -1071,7 +1070,7 @@ describe('rewriteModelResponse', () => {
     });
 
     expect(await result.json()).toEqual({
-      model: KIMI_CURRENT_MODEL_ID,
+      model: 'moonshotai/kimi-k3',
       usage: { cost: 0.5, cost_details: { upstream_inference_cost: 0.4 }, is_byok: false },
     });
   });

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.test.ts
@@ -11,6 +11,7 @@ import {
 } from './rewriteModelResponse';
 import { isDynamicallyOptedIntoRequestLogging } from '@/lib/ai-gateway/request-logging-opt-ins';
 import { QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/custom-pricing';
+import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import { KILO_ORGANIZATION_ID } from '@/lib/organizations/constants';
 import { logExceptInTest } from '@/lib/utils.server';
 
@@ -1053,6 +1054,25 @@ describe('rewriteModelResponse', () => {
     expect(await result.json()).toEqual({
       model: QWEN37_PLUS_MODEL_ID,
       usage: {},
+    });
+  });
+
+  test('preserves cost for models with fallback-only custom pricing', async () => {
+    const result = await rewriteModelResponse({
+      response: jsonResponse({
+        model: KIMI_CURRENT_MODEL_ID,
+        usage: { cost: 0.5, cost_details: { upstream_inference_cost: 0.4 }, is_byok: false },
+      }),
+      model: KIMI_CURRENT_MODEL_ID,
+      providerId: 'openrouter',
+      kind: 'chat_completions',
+      logging: makeLogging(),
+      responseTransforms: null,
+    });
+
+    expect(await result.json()).toEqual({
+      model: KIMI_CURRENT_MODEL_ID,
+      usage: { cost: 0.5, cost_details: { upstream_inference_cost: 0.4 }, is_byok: false },
     });
   });
 

--- a/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
+++ b/apps/web/src/lib/ai-gateway/rewriteModelResponse.ts
@@ -918,9 +918,11 @@ export async function rewriteModelResponse({
   responseTransforms,
 }: RewriteModelResponseParams): Promise<NextResponse> {
   const capture = await createRequestLogCapture(response, model, providerId, logging);
+  const customPricing = getCustomPricing(model);
   const requiresCostRemoval =
     (providerId === 'openrouter' || providerId === 'vercel') &&
-    (isKiloExclusiveFreeModel(model) || getCustomPricing(model) !== undefined);
+    (isKiloExclusiveFreeModel(model) ||
+      (customPricing !== undefined && !customPricing.fallbackOnly));
 
   console.debug('[rewriteModelResponse] rewriting response for %s', model);
   const { vercel_request_id: vercelRequestId } = logging;


### PR DESCRIPTION
## Summary

- add an opt-in `fallbackOnly` mode for custom model pricing
- preserve upstream catalog, endpoint, and response pricing for fallback-only entries
- use Moonshot pricing as the Kimi K3 fallback when no market cost is reported
- use Friendli pricing as the GLM 5.2 fallback when no market cost is reported

## Verification

- `NODE_ENV=test pnpm --filter web exec jest --runInBand src/lib/ai-gateway/custom-pricing.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint -- src/lib/ai-gateway/custom-pricing.ts src/lib/ai-gateway/custom-pricing.test.ts`
- `pnpm exec oxfmt --check apps/web/src/lib/ai-gateway/custom-pricing.ts apps/web/src/lib/ai-gateway/custom-pricing.test.ts`