### PR TITLE
Disable latest model aliases for Enterprise users

### DIFF
--- a/apps/web/src/lib/ai-gateway/latest-model-aliases.ts
+++ b/apps/web/src/lib/ai-gateway/latest-model-aliases.ts
@@ -23,9 +23,3 @@ export const LATEST_MODEL_ALIASES = [
   GROK_LATEST_MODEL_ALIAS,
   DEEPSEEK_V4_FLASH_LATEST_MODEL_ALIAS,
 ] as const;
-
-const latestModelAliasSet = new Set<string>(LATEST_MODEL_ALIASES);
-
-export function isLatestModelAlias(modelId: string): boolean {
-  return latestModelAliasSet.has(modelId);
-}

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.test.ts
@@ -74,7 +74,7 @@ describe('checkOrganizationModelRestrictions', () => {
       expect(result.error?.status).toBe(404);
     });
 
-    it('excludes latest aliases from model deny lists while retaining provider config', () => {
+    it('applies model deny lists to latest aliases', () => {
       const result = checkOrganizationModelRestrictions({
         modelId: CLAUDE_SONNET_LATEST_MODEL_ALIAS,
         settings: {
@@ -84,7 +84,8 @@ describe('checkOrganizationModelRestrictions', () => {
         organizationPlan: 'enterprise',
       });
 
-      expect(result).toEqual({ error: null, providerConfig: { only: ['anthropic'] } });
+      expect(result.error).not.toBeNull();
+      expect(result.error?.status).toBe(404);
     });
 
     it('should allow any model when deny list is empty on enterprise plan', () => {

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -32,7 +32,6 @@ import { getFraudDetectionHeaders, toMicrodollars } from '@/lib/utils';
 import { normalizeProjectId } from '@/lib/normalizeProjectId';
 import { getXKiloCodeVersionNumber } from '@/lib/userAgent';
 import { normalizeModelId } from '@/lib/ai-gateway/providers/openrouter';
-import { isLatestModelAlias } from '@/lib/ai-gateway/latest-model-aliases';
 import { createParser, type EventSourceMessage } from 'eventsource-parser';
 import { sentryRootSpan } from '../getRootSpan';
 import { findKiloExclusiveModel, shouldRedactErrorResponse } from '@/lib/ai-gateway/models';
@@ -493,11 +492,7 @@ export function checkOrganizationModelRestrictions(params: {
   // Model/provider access restrictions only apply to Enterprise plans.
   if (params.organizationPlan === 'enterprise') {
     const modelDenyList = params.settings.model_deny_list;
-    // TODO: Consider removing latest aliases instead of retaining this model-policy exception.
-    if (
-      !isLatestModelAlias(normalizedModelId) &&
-      modelDenyList?.some(entry => normalizeModelId(entry) === normalizedModelId)
-    ) {
+    if (modelDenyList?.some(entry => normalizeModelId(entry) === normalizedModelId)) {
       return { error: modelNotAllowedResponse() };
     }
   }

--- a/apps/web/src/lib/model-allow.server.test.ts
+++ b/apps/web/src/lib/model-allow.server.test.ts
@@ -90,8 +90,8 @@ describe('model access predicates', () => {
     await expect(isAllowed('x-ai/grok-4.6')).resolves.toBe(true);
   });
 
-  test('latest aliases bypass model restrictions but retain provider availability', async () => {
-    const withProviders = createAllowPredicateFromRestrictions(
+  test('latest aliases remain subject to model restrictions', async () => {
+    const deniedByModelPolicy = createAllowPredicateFromRestrictions(
       {
         requireModelInCurrentSnapshot: true,
         providerAllowList: ['anthropic'],
@@ -99,17 +99,17 @@ describe('model access predicates', () => {
       },
       lookup({})
     );
-    const withoutProviders = createAllowPredicateFromRestrictions(
+    const missingFromSnapshot = createAllowPredicateFromRestrictions(
       {
         requireModelInCurrentSnapshot: true,
-        providerAllowList: [],
-        modelDenyList: [CLAUDE_SONNET_LATEST_MODEL_ALIAS],
+        providerAllowList: ['anthropic'],
+        modelDenyList: [],
       },
       lookup({})
     );
 
-    await expect(withProviders(CLAUDE_SONNET_LATEST_MODEL_ALIAS)).resolves.toBe(true);
-    await expect(withoutProviders(CLAUDE_SONNET_LATEST_MODEL_ALIAS)).resolves.toBe(false);
+    await expect(deniedByModelPolicy(CLAUDE_SONNET_LATEST_MODEL_ALIAS)).resolves.toBe(false);
+    await expect(missingFromSnapshot(CLAUDE_SONNET_LATEST_MODEL_ALIAS)).resolves.toBe(false);
   });
 
   test.each(['kilo-auto/balanced', 'kilo-internal/private-model', 'kimi-coding/kimi-for-coding'])(

--- a/apps/web/src/lib/model-allow.server.ts
+++ b/apps/web/src/lib/model-allow.server.ts
@@ -7,7 +7,6 @@ import {
 } from '@/lib/ai-gateway/model-utils';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
 import { getProviderSlugsForModel } from '@/lib/ai-gateway/providers/openrouter/models-by-provider-index.server';
-import { isLatestModelAlias } from '@/lib/ai-gateway/latest-model-aliases';
 
 export type ProviderAwareAllowPredicate = (modelId: string) => Promise<boolean>;
 
@@ -47,11 +46,6 @@ export function createAllowPredicateFromProviderAllowList(
     const normalizedModelId = normalizeModelId(modelId);
     if (!requireModelInCurrentSnapshot && !providerAllowSet && modelDenySet.size === 0) return true;
     if (await isModelRestrictionExempt(modelId)) return true;
-    // TODO: Consider removing latest aliases instead of retaining this model-policy exception.
-    if (isLatestModelAlias(normalizedModelId)) {
-      // Provider compatibility is enforced at inference through provider routing options.
-      return !providerAllowSet || providerAllowSet.size > 0;
-    }
     if (modelDenySet.has(normalizedModelId)) {
       return false;
     }

--- a/apps/web/src/lib/organizations/effective-model-access.server.test.ts
+++ b/apps/web/src/lib/organizations/effective-model-access.server.test.ts
@@ -94,7 +94,7 @@ describe('effective organization model access', () => {
     ).resolves.toEqual({ allowed: true });
   });
 
-  it('excludes latest aliases from model restrictions while enforcing provider routes', async () => {
+  it('applies organization model restrictions to latest aliases', async () => {
     const policy = evaluateEffectiveModelAccessPolicy(
       context({
         organization: {
@@ -110,22 +110,19 @@ describe('effective organization model access', () => {
 
     await expect(
       getEffectiveModelDecision(policy, CLAUDE_SONNET_LATEST_MODEL_ALIAS, async () => {
-        throw new Error('latest aliases must not use snapshot provider metadata');
+        throw new Error('denied models must not use snapshot provider metadata');
       })
-    ).resolves.toEqual({
-      allowed: true,
-      eligibleProviderRoutes: new Set(['anthropic']),
-    });
+    ).resolves.toEqual({ allowed: false, denialSource: 'organization_model' });
   });
 
-  it('denies latest aliases when the organization allows no providers', async () => {
+  it('requires latest aliases to exist in the current snapshot', async () => {
     const policy = evaluateEffectiveModelAccessPolicy(
       context({
         organization: {
           ...context().organization,
           settings: {
-            model_deny_list: [CLAUDE_SONNET_LATEST_MODEL_ALIAS],
-            provider_allow_list: [],
+            model_deny_list: [],
+            provider_allow_list: ['anthropic'],
           },
         },
         defaultPolicies: [{ type: 'model_access', data: { mode: 'all' } }],
@@ -133,8 +130,8 @@ describe('effective organization model access', () => {
     );
 
     await expect(
-      getEffectiveModelDecision(policy, CLAUDE_SONNET_LATEST_MODEL_ALIAS)
-    ).resolves.toEqual({ allowed: false, denialSource: 'organization_provider' });
+      getEffectiveModelDecision(policy, CLAUDE_SONNET_LATEST_MODEL_ALIAS, async () => new Set())
+    ).resolves.toEqual({ allowed: false, denialSource: 'organization_model' });
   });
 
   it.each(['kilo-auto/balanced', 'kilo-internal/private-model', 'kimi-coding/kimi-for-coding'])(

--- a/apps/web/src/lib/organizations/group-policies/model-access/model-access.server.ts
+++ b/apps/web/src/lib/organizations/group-policies/model-access/model-access.server.ts
@@ -10,7 +10,6 @@ import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 import { normalizeInferenceProviderId } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { getProviderSlugsForModel } from '@/lib/ai-gateway/providers/openrouter/models-by-provider-index.server';
 import { isModelRestrictionExempt } from '@/lib/model-allow.server';
-import { isLatestModelAlias } from '@/lib/ai-gateway/latest-model-aliases';
 import { db } from '@/lib/drizzle';
 import {
   getOrganizationGroupPolicyContext,
@@ -114,17 +113,13 @@ export async function getEffectiveModelDecision(
   if (await isModelRestrictionExempt(modelId)) {
     return { allowed: true };
   }
-  // TODO: Consider removing latest aliases instead of retaining this model-policy exception.
-  const latestAlias = isLatestModelAlias(normalizedModelId);
-  if (!latestAlias && policy.organizationModelDenyList.includes(normalizedModelId)) {
+  if (policy.organizationModelDenyList.includes(normalizedModelId)) {
     return { allowed: false, denialSource: 'organization_model' };
   }
   const exclusiveProviders = getKiloExclusiveInferenceProviderRestriction(modelId);
   const currentModelProviders =
     exclusiveProviders ??
-    (policy.requireModelInCurrentSnapshot && !latestAlias
-      ? await providerLookup(normalizedModelId)
-      : undefined);
+    (policy.requireModelInCurrentSnapshot ? await providerLookup(normalizedModelId) : undefined);
   if (currentModelProviders?.size === 0) {
     return { allowed: false, denialSource: 'organization_model' };
   }
@@ -134,12 +129,6 @@ export async function getEffectiveModelDecision(
 
   async function decisionWithinOrganizationCeiling(): Promise<EffectiveModelDecision> {
     if (!organizationRoutes) return { allowed: true };
-    if (latestAlias) {
-      // Aliases have no snapshot endpoints, so pass the ceiling through to provider.only.
-      return organizationRoutes.size > 0
-        ? { allowed: true, eligibleProviderRoutes: organizationRoutes }
-        : { allowed: false, denialSource: 'organization_provider' };
-    }
     const modelProviders = currentModelProviders ?? (await providerLookup(normalizedModelId));
     if (modelProviders.size === 0) {
       return { allowed: false, denialSource: 'organization_model' };
@@ -161,9 +150,7 @@ export async function getEffectiveModelDecision(
   if (policy.memberGrant.providerAllowList.length === 0) {
     return { allowed: false, denialSource: 'no_grant' };
   }
-  const modelProviders = latestAlias
-    ? new Set(policy.memberGrant.providerAllowList)
-    : (currentModelProviders ?? (await providerLookup(normalizedModelId)));
+  const modelProviders = currentModelProviders ?? (await providerLookup(normalizedModelId));
   if (modelProviders.size === 0) {
     return { allowed: false, denialSource: 'group_provider' };
   }

--- a/apps/web/src/routers/organizations/organization-settings-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-settings-router.test.ts
@@ -438,7 +438,7 @@ describe('organizations settings trpc router', () => {
       expect(result.data.map(model => model.id)).toEqual(['openai/gpt-4o']);
     });
 
-    it('keeps latest aliases available despite model deny lists and missing snapshot routes', async () => {
+    it('excludes latest aliases denied by model policy', async () => {
       const organization = await createTestOrganization(
         'Latest Alias Enterprise',
         owner.id,
@@ -456,7 +456,7 @@ describe('organizations settings trpc router', () => {
         organizationId: organization.id,
       });
 
-      expect(result.data.map(model => model.id)).toEqual([CLAUDE_SONNET_LATEST_MODEL_ALIAS]);
+      expect(result.data).toEqual([]);
     });
 
     it('should exclude models in model_deny_list for enterprise orgs', async () => {


### PR DESCRIPTION
## Summary
- remove the managed `-latest` alias exemption from Enterprise model-policy evaluation
- require aliases to pass the same deny-list, current-snapshot, provider, and member-grant checks as other model IDs
- remove these aliases from Enterprise model listings and reject Enterprise inference requests that use them
- leave non-Enterprise alias routing unchanged

## Reason for removal
Managed `-latest` aliases bypassed Enterprise model policies through a special exemption. Administrators therefore had no effective way to disable them with the model deny list, current-snapshot restrictions, provider restrictions, or member grants. Removing the aliases for Enterprise users closes that policy bypass.

## Intended behavior
Managed aliases such as `~anthropic/claude-sonnet-latest` do not exist in the models-by-provider current snapshot. Enterprise access requires current-snapshot membership, so removing the exception intentionally causes these aliases to disappear from `listAvailableModels` and direct inference requests to fail with the existing model-not-allowed `404`, even when the organization has no explicit model deny-list entry.

Explicit deny-list entries for an alias are also enforced instead of bypassed. This PR does not resolve an alias to a concrete catalog model and does not preserve managed latest aliases for Enterprise users.

Non-Enterprise users retain the existing alias-routing behavior.

## Verification
- regression coverage updated for explicit alias denial and missing-snapshot rejection
- effective organization policy, available-model filtering, and proxy restriction paths covered
- current PR checks pass: build, typecheck, lint, format, tests, Drizzle checks, and secret scanning