### PR TITLE
docs(data-export): update data exports flow copy

### DIFF
--- a/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
+++ b/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
@@ -11,6 +11,7 @@ import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { LANDING_URL } from '@/lib/constants';
 import { formatBytes } from '@/lib/kiloclaw/instance-display';
 import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
 import {
@@ -26,6 +27,11 @@ import {
 import { DownloadCodeDialog, type DownloadCodeChallenge } from './DownloadCodeDialog';
 
 type BadgeVariant = React.ComponentProps<typeof Badge>['variant'];
+
+const SUPPORT_URL = `${LANDING_URL}/support`;
+
+/** Inline prose links inherit muted description text, so they need explicit affordance. */
+const PROSE_LINK_CLASS = 'text-primary underline underline-offset-4';
 
 const STATUS_BADGE_VARIANT: Record<UserExportDisplayStatus, BadgeVariant> = {
   queued: 'secondary',
@@ -188,10 +194,31 @@ export function DataExportsClient() {
         <CardHeader>
           <CardTitle>Request a new export</CardTitle>
           <CardDescription>
-            The export includes your App Builder project titles and the prompt prefixes recorded
-            with your usage history. Large accounts can take a while to generate. We&apos;ll email
-            you when it&apos;s ready, and downloads expire 24 hours after that. Each download needs
-            a confirmation code we email you.
+            For a limited time, you can use this feature to request an export of your App Builder
+            project titles and prompt prefixes recorded with your usage history from your account
+            creation date to Aug. 2 @ 20:40 UTC. We are making this feature available in response to
+            the{' '}
+            <a
+              className={PROSE_LINK_CLASS}
+              href="https://www.metabase.com/blog/security-update"
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              Metabase security incident
+            </a>{' '}
+            as part of our commitment to transparency, but we want to reiterate that investigation
+            is ongoing. Should new information arise, we will contact users directly in accordance
+            with our legal obligations. As always, Anaconda offers a process for any user to request
+            deletion of their Kilo account and its data. You can submit your request at{' '}
+            <a
+              className={PROSE_LINK_CLASS}
+              href={SUPPORT_URL}
+              rel="noopener noreferrer"
+              target="_blank"
+            >
+              kilo.ai/support
+            </a>
+            .
           </CardDescription>
         </CardHeader>
         <CardContent className="flex flex-col items-start gap-3">

--- a/apps/web/src/app/(app)/data-exports/DownloadCodeDialog.tsx
+++ b/apps/web/src/app/(app)/data-exports/DownloadCodeDialog.tsx
@@ -130,7 +130,7 @@ export function DownloadCodeDialog({
             </p>
           ) : (
             <p id={CODE_HINT_ID} className="text-muted-foreground text-sm">
-              Do not share this code. It unlocks a copy of your account data.
+              Do not share this code. It unlocks a copy of your data export.
             </p>
           )}
 

--- a/apps/web/src/app/(app)/data-exports/RequestDataDeletionCard.tsx
+++ b/apps/web/src/app/(app)/data-exports/RequestDataDeletionCard.tsx
@@ -61,12 +61,9 @@ export function RequestDataDeletionCard() {
                   than a nested <p>. */}
               <AlertDialogDescription>
                 Download your data export before requesting deletion. Once your data is deleted, any
-                export download will no longer be available.
+                export download will no longer be available or recoverable.
                 <span className="mt-4 block">
                   On the support form, choose the Account Deletion category.
-                </span>
-                <span className="mt-4 block">
-                  Any export download will no longer be available or recoverable.
                 </span>
               </AlertDialogDescription>
             </AlertDialogHeader>

--- a/apps/web/src/app/(app)/data-exports/RequestDataDeletionCard.tsx
+++ b/apps/web/src/app/(app)/data-exports/RequestDataDeletionCard.tsx
@@ -38,8 +38,11 @@ export function RequestDataDeletionCard() {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Delete your data</CardTitle>
+        <CardTitle>Request deletion of your data</CardTitle>
         <CardDescription>
+          As always, Anaconda offers a process for any user to request deletion of their Kilo
+          account and its data.
+          <br />
           Data deletion is handled by our support team. Request it from the support form.
         </CardDescription>
       </CardHeader>
@@ -61,6 +64,9 @@ export function RequestDataDeletionCard() {
                 export download will no longer be available.
                 <span className="mt-4 block">
                   On the support form, choose the Account Deletion category.
+                </span>
+                <span className="mt-4 block">
+                  Any export download will no longer be available or recoverable.
                 </span>
               </AlertDialogDescription>
             </AlertDialogHeader>

--- a/apps/web/src/emails/userDataExportReady.html
+++ b/apps/web/src/emails/userDataExportReady.html
@@ -20,10 +20,10 @@
                 "
               >
                 <h1 style="margin: 0 0 16px; color: #1a1a1a; font-size: 24px; line-height: 32px">
-                  Your account export is ready
+                  Your data export is ready
                 </h1>
                 <p style="margin: 0 0 18px; color: #333; font-size: 15px; line-height: 24px">
-                  Your Kilo account export is ready to download. Sign in to access it securely.
+                  Your Kilo data export is ready to download. Sign in to access it securely.
                 </p>
                 <table cellpadding="0" cellspacing="0" role="presentation">
                   <tr>

--- a/apps/web/src/lib/email.test.ts
+++ b/apps/web/src/lib/email.test.ts
@@ -14,7 +14,7 @@ describe('email rendering helpers', () => {
 
 describe('user data export ready email', () => {
   it('uses the required subject and only links to the authenticated export page', () => {
-    expect(subjects.userDataExportReady).toBe('Your Kilo account export is ready');
+    expect(subjects.userDataExportReady).toBe('Your Kilo data export is ready');
     const html = renderTemplate('userDataExportReady', {
       data_exports_url: 'https://app.kilocode.ai/data-exports',
       expiry_date: 'August 15, 2026',

--- a/apps/web/src/lib/email.ts
+++ b/apps/web/src/lib/email.ts
@@ -61,7 +61,7 @@ export const subjects = {
   securityFindingSlaBreach: 'Kilo Security Agent: SLA breached',
   recommendationsDigest: 'Kilo: Your weekly recommendations',
   kiloPassOrgBlocked: 'Action required: Update Kilo Pass assignments',
-  userDataExportReady: 'Your Kilo account export is ready',
+  userDataExportReady: 'Your Kilo data export is ready',
   dataExportDownloadCode: 'Your Kilo data export download code',
 } as const;
 


### PR DESCRIPTION
Updates the copy across the data exports flow to match the reviewed wording in the Google Doc.

Also fixes a missing JSX space that rendered the new support link as `atkilo.ai/support`, and points that link at `LANDING_URL`.

<img width="4388" height="2708" alt="CleanShot 2026-08-14 at 15 02 58@2x" src="https://github.com/user-attachments/assets/f288d923-d211-43a2-9ecc-323351510754" />
<img width="4388" height="2708" alt="CleanShot 2026-08-14 at 15 03 05@2x" src="https://github.com/user-attachments/assets/6586a927-bae5-4bce-9895-28d8c17cb701" />
