### PR TITLE
feat(coding-plans): expand admin operations

### DIFF
--- a/apps/web/src/app/admin/coding-plans/CodingPlansOperationsContent.tsx
+++ b/apps/web/src/app/admin/coding-plans/CodingPlansOperationsContent.tsx
@@ -1,9 +1,9 @@
 'use client';
 
 import Link from 'next/link';
-import { useReducer, useState } from 'react';
-import { useMutation, useQuery } from '@tanstack/react-query';
-import { Copy, ExternalLink, RefreshCw, ShieldAlert, Upload } from 'lucide-react';
+import { useEffect, useReducer, useState } from 'react';
+import { keepPreviousData, useMutation, useQuery } from '@tanstack/react-query';
+import { Copy, ExternalLink, RefreshCw, Search, ShieldAlert, Upload, X } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { Alert, AlertDescription } from '@/components/ui/alert';
@@ -40,11 +40,20 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Textarea } from '@/components/ui/textarea';
 import { SubscriptionStatusBadge } from '@/components/subscriptions/SubscriptionStatusBadge';
 import {
+  canSubmitExtensionDays,
+  getCancelSubscriptionDialogCopy,
+  getCodingPlanInsights,
   getCodingPlanProviderDisplayName,
+  getExtendSubscriptionDialogCopy,
+  getInventoryReplacementCompleteToast,
+  getInventoryReplacementDialogCopy,
+  getPlanPerformanceRows,
   getReplacementCompleteToast,
   getReplacementDialogCopy,
   getRevocationCompleteToast,
   getRevocationDialogCopy,
+  getSubscriptionSummaryItems,
+  type InsightsRangeDays,
 } from '@/app/admin/coding-plans/coding-plan-operations';
 import {
   formatCodingPlanPrice,
@@ -57,6 +66,8 @@ import type { UserByokProviderId } from '@/lib/ai-gateway/providers/openrouter/i
 import type { CodingPlanId } from '@/lib/coding-plans/pricing';
 import { useTRPC } from '@/lib/trpc/utils';
 
+type SubscriptionDisplayStatus = 'active' | 'pending_cancellation' | 'past_due' | 'canceled';
+
 type OperationsState = {
   providerId: UserByokProviderId;
   planId: CodingPlanId;
@@ -64,6 +75,36 @@ type OperationsState = {
   completeSelection: RevocationSelection | null;
   replacementSelection: RevocationSelection | null;
   replacementApiKey: string;
+  inventoryReplacementId: string;
+  inventoryReplacementApiKey: string;
+  inventoryReplacementConfirmOpen: boolean;
+  cancelSelection: AdminCodingPlanSubscriptionItem | null;
+  extendSelection: AdminCodingPlanSubscriptionItem | null;
+  extendDays: string;
+};
+
+const EMPTY_SUBSCRIPTION_SUMMARY = {
+  total: 0,
+  active: 0,
+  pendingCancellation: 0,
+  pastDue: 0,
+};
+
+const EMPTY_INSIGHT_TOTALS = {
+  liveSubscriptions: 0,
+  pendingCancellation: 0,
+  pastDue: 0,
+  mrrKiloCredits: 0,
+  revenueAtRiskKiloCredits: 0,
+  pastDueMrrKiloCredits: 0,
+  createdInRange: 0,
+  createdInPriorRange: 0,
+  canceledInRange: 0,
+  liveAtRangeStart: 0,
+  retainedFromRangeStart: 0,
+  currentWaitersJoinedInRange: 0,
+  currentWaitersJoinedInPriorRange: 0,
+  currentWaitlistTotal: 0,
 };
 
 const INITIAL_OPERATIONS_STATE: OperationsState = {
@@ -73,6 +114,12 @@ const INITIAL_OPERATIONS_STATE: OperationsState = {
   completeSelection: null,
   replacementSelection: null,
   replacementApiKey: '',
+  inventoryReplacementId: '',
+  inventoryReplacementApiKey: '',
+  inventoryReplacementConfirmOpen: false,
+  cancelSelection: null,
+  extendSelection: null,
+  extendDays: '7',
 };
 
 function updateOperationsState(state: OperationsState, update: Partial<OperationsState>) {
@@ -90,7 +137,19 @@ export function CodingPlansOperationsContent() {
     completeSelection,
     replacementSelection,
     replacementApiKey,
+    inventoryReplacementId,
+    inventoryReplacementApiKey,
+    inventoryReplacementConfirmOpen,
+    cancelSelection,
+    extendSelection,
+    extendDays,
   } = state;
+  const [subscriptionPage, setSubscriptionPage] = useState(1);
+  const [subscriptionSearchDraft, setSubscriptionSearchDraft] = useState('');
+  const [subscriptionSearch, setSubscriptionSearch] = useState('');
+  const [subscriptionStatus, setSubscriptionStatus] = useState<SubscriptionDisplayStatus | 'all'>(
+    'all'
+  );
   const setProviderId = (providerId: UserByokProviderId) => updateState({ providerId });
   const setPlanId = (planId: CodingPlanId) => updateState({ planId });
   const setEntriesText = (entriesText: string) => updateState({ entriesText });
@@ -99,12 +158,33 @@ export function CodingPlansOperationsContent() {
   const setReplacementSelection = (replacementSelection: RevocationSelection | null) =>
     updateState({ replacementSelection });
   const setReplacementApiKey = (replacementApiKey: string) => updateState({ replacementApiKey });
+  const setInventoryReplacementId = (inventoryReplacementId: string) =>
+    updateState({ inventoryReplacementId });
+  const setInventoryReplacementApiKey = (inventoryReplacementApiKey: string) =>
+    updateState({ inventoryReplacementApiKey });
+  const setInventoryReplacementConfirmOpen = (inventoryReplacementConfirmOpen: boolean) =>
+    updateState({ inventoryReplacementConfirmOpen });
+  const setCancelSelection = (cancelSelection: AdminCodingPlanSubscriptionItem | null) =>
+    updateState({ cancelSelection });
+  const setExtendSelection = (extendSelection: AdminCodingPlanSubscriptionItem | null) =>
+    updateState({ extendSelection });
+  const setExtendDays = (extendDays: string) => updateState({ extendDays });
 
   const countsQuery = useQuery(trpc.codingPlans.adminKeyInventory.queryOptions({}));
   const queueQuery = useQuery(trpc.codingPlans.adminRevocationQueue.queryOptions({}));
-  const subscriptionsQuery = useQuery(trpc.codingPlans.adminListSubscriptions.queryOptions({}));
-  const availabilityIntentCountsQuery = useQuery(
-    trpc.codingPlans.adminAvailabilityIntentCounts.queryOptions({})
+  const subscriptionsQuery = useQuery({
+    ...trpc.codingPlans.adminListSubscriptions.queryOptions({
+      page: subscriptionPage,
+      search: subscriptionSearch || undefined,
+      status: subscriptionStatus === 'all' ? undefined : subscriptionStatus,
+    }),
+    placeholderData: keepPreviousData,
+  });
+  const subscriptionOverviewQuery = useQuery(
+    trpc.codingPlans.adminSubscriptionOverview.queryOptions()
+  );
+  const insightsQuery = useQuery(
+    trpc.codingPlans.adminInsights.queryOptions({ rangeDays: insightsRangeDays })
   );
   const catalogQuery = useQuery(trpc.codingPlans.catalog.queryOptions());
 
@@ -113,7 +193,8 @@ export function CodingPlansOperationsContent() {
       countsQuery.refetch(),
       queueQuery.refetch(),
       subscriptionsQuery.refetch(),
-      availabilityIntentCountsQuery.refetch(),
+      subscriptionOverviewQuery.refetch(),
+      insightsQuery.refetch(),
     ]);
   };
 
@@ -152,14 +233,68 @@ export function CodingPlansOperationsContent() {
       onError: error => toast.error(error.message || 'Unable to replace credential.'),
     })
   );
+  const inventoryReplacementMutation = useMutation(
+    trpc.codingPlans.adminReplaceInventoryCredential.mutationOptions({
+      onSuccess: async () => {
+        setInventoryReplacementId('');
+        setInventoryReplacementApiKey('');
+        setInventoryReplacementConfirmOpen(false);
+        toast.success(getInventoryReplacementCompleteToast());
+        await refreshOperations();
+      },
+      onError: error => toast.error(error.message || 'Unable to replace inventory credential.'),
+    })
+  );
+  const cancelMutation = useMutation(
+    trpc.codingPlans.adminCancelSubscription.mutationOptions({
+      onSuccess: async () => {
+        setCancelSelection(null);
+        toast.success('Subscription cancellation scheduled at period end.');
+        await refreshOperations();
+      },
+      onError: error => toast.error(error.message || 'Unable to cancel subscription.'),
+    })
+  );
+  const extendMutation = useMutation(
+    trpc.codingPlans.adminExtendSubscriptionPeriod.mutationOptions({
+      onSuccess: async result => {
+        setExtendSelection(null);
+        setExtendDays('7');
+        toast.success(
+          `Current period extended to ${formatDateLabel(result.currentPeriodEnd)}. Renewal now ${formatDateLabel(result.creditRenewalAt)}.`
+        );
+        await refreshOperations();
+      },
+      onError: error => toast.error(error.message || 'Unable to extend subscription.'),
+    })
+  );
   const submittedEntries = entriesText
     .split('\n')
     .map(entry => entry.trim())
     .filter(entry => entry.length > 0);
+  const canSubmitExtend = canSubmitExtensionDays(extendDays);
+
+  useEffect(() => {
+    const normalizedPage = subscriptionsQuery.data?.pagination.page;
+    if (
+      normalizedPage === undefined ||
+      normalizedPage === subscriptionPage ||
+      subscriptionsQuery.isFetching ||
+      subscriptionsQuery.isPlaceholderData
+    ) {
+      return;
+    }
+    setSubscriptionPage(normalizedPage);
+  }, [
+    subscriptionPage,
+    subscriptionsQuery.data?.pagination.page,
+    subscriptionsQuery.isFetching,
+    subscriptionsQuery.isPlaceholderData,
+  ]);
   const workItems = queueQuery.data ?? [];
   const inventoryCounts = countsQuery.data ?? [];
-  const subscriptions = subscriptionsQuery.data ?? [];
-  const availabilityIntentCounts = availabilityIntentCountsQuery.data ?? [];
+  const subscriptions = subscriptionsQuery.data?.items ?? [];
+  const subscriptionPagination = subscriptionsQuery.data?.pagination;
   const catalog = catalogQuery.data ?? [];
   const providerOptions = Array.from(
     new Map(
@@ -196,48 +331,25 @@ export function CodingPlansOperationsContent() {
       count: countCredentialsByStatus('revocation_pending'),
     },
   ];
-  const countSubscriptionsByDisplayStatus = (status: string) =>
-    subscriptions.reduce(
-      (total, subscription) =>
-        total + (getCodingPlanDisplayStatus(subscription) === status ? 1 : 0),
-      0
-    );
-  const subscriptionSummary = [
-    {
-      label: 'Total subscriptions',
-      count: subscriptions.length,
-    },
-    {
-      label: 'Active subscriptions',
-      count: countSubscriptionsByDisplayStatus('active'),
-    },
-    {
-      label: 'Cancellation pending',
-      count: countSubscriptionsByDisplayStatus('pending_cancellation'),
-    },
-    {
-      label: 'Past due subscriptions',
-      count: countSubscriptionsByDisplayStatus('past_due'),
-    },
-  ];
-  const insights = getCodingPlanInsights(subscriptions, insightsRangeDays);
+  const subscriptionSummary = getSubscriptionSummaryItems(
+    subscriptionOverviewQuery.data ?? EMPTY_SUBSCRIPTION_SUMMARY
+  );
+  const insights = getCodingPlanInsights(
+    insightsQuery.data?.totals ?? EMPTY_INSIGHT_TOTALS,
+    insightsRangeDays
+  );
   const planPerformanceRows = getPlanPerformanceRows({
-    catalog,
-    subscriptions,
+    catalog: catalog.map(plan => ({
+      planId: plan.planId,
+      planName: plan.name,
+      providerName: plan.providerName,
+    })),
     inventoryCounts,
-    availabilityIntentCounts,
-    rangeDays: insightsRangeDays,
+    planInsights: insightsQuery.data?.plans ?? [],
   });
   const insightsLoading =
-    subscriptionsQuery.isLoading ||
-    countsQuery.isLoading ||
-    catalogQuery.isLoading ||
-    availabilityIntentCountsQuery.isLoading;
-  const insightsError =
-    subscriptionsQuery.isError ||
-    countsQuery.isError ||
-    catalogQuery.isError ||
-    availabilityIntentCountsQuery.isError;
+    insightsQuery.isLoading || countsQuery.isLoading || catalogQuery.isLoading;
+  const insightsError = insightsQuery.isError || countsQuery.isError || catalogQuery.isError;
 
   return (
     <div className="flex w-full flex-col gap-6">
@@ -271,13 +383,15 @@ export function CodingPlansOperationsContent() {
           <div className="flex flex-col justify-between gap-3 sm:flex-row sm:items-center">
             <p className="text-muted-foreground text-sm">
               Rolling metrics use the selected window. Current-state cards show live totals.
+              Waitlist movement uses join dates for users still waiting; resolved intents are
+              removed.
             </p>
             <InsightsRangeFilter value={insightsRangeDays} onChange={setInsightsRangeDays} />
           </div>
           <KpiCards
             items={insights}
-            isLoading={subscriptionsQuery.isLoading}
-            isError={subscriptionsQuery.isError}
+            isLoading={insightsQuery.isLoading}
+            isError={insightsQuery.isError}
           />
           <PlanPerformanceTable
             rows={planPerformanceRows}
@@ -290,15 +404,35 @@ export function CodingPlansOperationsContent() {
         <TabsContent value="subscriptions" className="mt-0 space-y-6">
           <SummaryCards
             items={subscriptionSummary}
-            isLoading={subscriptionsQuery.isLoading}
-            isError={subscriptionsQuery.isError}
+            isLoading={subscriptionOverviewQuery.isLoading}
+            isError={subscriptionOverviewQuery.isError}
             ariaLabel="Coding Plan subscription summary"
           />
 
           <SubscriptionsTable
             items={subscriptions}
+            pagination={subscriptionPagination}
             isLoading={subscriptionsQuery.isLoading}
+            isFetching={subscriptionsQuery.isFetching}
             isError={subscriptionsQuery.isError}
+            searchDraft={subscriptionSearchDraft}
+            search={subscriptionSearch}
+            status={subscriptionStatus}
+            onSearchDraftChange={setSubscriptionSearchDraft}
+            onSearch={nextSearch => {
+              setSubscriptionSearch(nextSearch);
+              setSubscriptionPage(1);
+            }}
+            onStatusChange={status => {
+              setSubscriptionStatus(status);
+              setSubscriptionPage(1);
+            }}
+            onPageChange={setSubscriptionPage}
+            onCancel={setCancelSelection}
+            onExtend={item => {
+              setExtendSelection(item);
+              setExtendDays('7');
+            }}
           />
         </TabsContent>
 
@@ -353,6 +487,19 @@ export function CodingPlansOperationsContent() {
                 entries: submittedEntries,
               });
             }}
+            inventoryReplacementId={inventoryReplacementId}
+            inventoryReplacementApiKey={inventoryReplacementApiKey}
+            onInventoryReplacementIdChange={setInventoryReplacementId}
+            onInventoryReplacementApiKeyChange={setInventoryReplacementApiKey}
+            onConfirmInventoryReplacement={() => {
+              if (
+                inventoryReplacementId.trim().length === 0 ||
+                inventoryReplacementApiKey.trim().length === 0
+              ) {
+                return;
+              }
+              setInventoryReplacementConfirmOpen(true);
+            }}
           />
         </TabsContent>
       </Tabs>
@@ -373,6 +520,36 @@ export function CodingPlansOperationsContent() {
         onReplace={(inventoryKeyId, apiKey) =>
           replacementMutation.mutate({ inventoryKeyId, apiKey })
         }
+        cancelSelection={cancelSelection}
+        cancelPending={cancelMutation.isPending}
+        onCloseCancel={() => setCancelSelection(null)}
+        onCancel={subscriptionId => cancelMutation.mutate({ subscriptionId })}
+        extendSelection={extendSelection}
+        extendDays={extendDays}
+        extendPending={extendMutation.isPending}
+        canSubmitExtend={canSubmitExtend}
+        onCloseExtend={() => {
+          setExtendSelection(null);
+          setExtendDays('7');
+        }}
+        onExtendDaysChange={setExtendDays}
+        onExtend={(subscriptionId, days) => extendMutation.mutate({ subscriptionId, days })}
+        inventoryReplacementId={inventoryReplacementId}
+        inventoryReplacementConfirmOpen={inventoryReplacementConfirmOpen}
+        inventoryReplacementPending={inventoryReplacementMutation.isPending}
+        onCloseInventoryReplacement={() => setInventoryReplacementConfirmOpen(false)}
+        onReplaceInventoryCredential={() => {
+          if (
+            inventoryReplacementId.trim().length === 0 ||
+            inventoryReplacementApiKey.trim().length === 0
+          ) {
+            return;
+          }
+          inventoryReplacementMutation.mutate({
+            inventoryKeyId: inventoryReplacementId.trim(),
+            apiKey: inventoryReplacementApiKey,
+          });
+        }}
       />
     </div>
   );
@@ -389,22 +566,6 @@ type KpiItem = {
   detail: string;
 };
 
-type InsightsRangeDays = 7 | 14 | 30;
-
-type AdminCodingPlanCatalogItem = {
-  planId: string;
-  providerName: string;
-  name: string;
-  providerId: string;
-  costKiloCredits: number;
-  billingPeriodDays: number;
-};
-
-type AvailabilityIntentCountItem = {
-  planId: string;
-  count: number;
-};
-
 type PlanPerformanceRow = {
   planId: string;
   planName: string;
@@ -415,6 +576,7 @@ type PlanPerformanceRow = {
   canceledSubscriptionsInRange: number;
   availableCredentials: number;
   waitlistIntents: number;
+  currentWaitersJoinedInRange: number;
 };
 
 type InventoryCountItem = {
@@ -435,6 +597,7 @@ type AdminCodingPlanSubscriptionItem = {
   id: string;
   userId: string;
   userName: string;
+  userEmail: string;
   planId: string;
   planName: string;
   providerId: string;
@@ -561,7 +724,11 @@ function KpiCards({
                 <p className="font-mono text-2xl font-semibold tabular-nums">{item.value}</p>
               )}
             </div>
-            <p className="text-muted-foreground text-xs leading-5">{item.detail}</p>
+            {isLoading ? (
+              <Skeleton aria-hidden="true" className="h-8 w-40" />
+            ) : isError ? null : (
+              <p className="text-muted-foreground text-xs leading-5">{item.detail}</p>
+            )}
           </CardContent>
         </Card>
       ))}
@@ -592,11 +759,12 @@ function PlanPerformanceTable({
       </CardHeader>
       <CardContent>
         <div className="overflow-x-auto rounded-lg border">
-          <Table className="min-w-[76rem] table-fixed">
+          <Table className="min-w-[88rem] table-fixed">
             <colgroup>
               <col className="w-72" />
               <col className="w-36" />
               <col className="w-36" />
+              <col className="w-48" />
               <col className="w-48" />
               <col className="w-48" />
               <col className="w-48" />
@@ -611,18 +779,19 @@ function PlanPerformanceTable({
                 <TableHead className="text-right">Canceled ({rangeLabel})</TableHead>
                 <TableHead className="text-right">Available inventory</TableHead>
                 <TableHead className="text-right">Waitlist</TableHead>
+                <TableHead className="text-right">Current waiters joined ({rangeLabel})</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isError ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="h-24 text-center text-red-300">
+                  <TableCell colSpan={8} className="h-24 text-center text-red-300">
                     Unable to load plan performance.
                   </TableCell>
                 </TableRow>
-              ) : rows.length === 0 ? (
+              ) : isLoading || rows.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={7} className="text-muted-foreground h-24 text-center">
+                  <TableCell colSpan={8} className="text-muted-foreground h-24 text-center">
                     {isLoading ? 'Loading plan performance...' : 'No plan performance data.'}
                   </TableCell>
                 </TableRow>
@@ -653,6 +822,9 @@ function PlanPerformanceTable({
                     <TableCell className="text-right font-mono tabular-nums">
                       {formatIntegerValue(row.waitlistIntents)}
                     </TableCell>
+                    <TableCell className="text-right font-mono tabular-nums">
+                      {formatIntegerValue(row.currentWaitersJoinedInRange)}
+                    </TableCell>
                   </TableRow>
                 ))
               )}
@@ -662,166 +834,6 @@ function PlanPerformanceTable({
       </CardContent>
     </Card>
   );
-}
-
-function getCodingPlanInsights(
-  subscriptions: AdminCodingPlanSubscriptionItem[],
-  rangeDays: InsightsRangeDays
-): KpiItem[] {
-  const now = new Date();
-  const rangeStart = addDays(now, -rangeDays);
-  const priorRangeStart = addDays(now, -rangeDays * 2);
-  const rangeLabel = `${rangeDays}-day`;
-  const rangeDetailLabel = `last ${rangeDays} days`;
-  const priorRangeDetailLabel = `prior ${rangeDays} days`;
-  const liveSubscriptions = subscriptions.filter(subscription => isLiveSubscription(subscription));
-  const pendingCancellationSubscriptions = liveSubscriptions.filter(
-    subscription => getCodingPlanDisplayStatus(subscription) === 'pending_cancellation'
-  );
-  const pastDueSubscriptions = liveSubscriptions.filter(
-    subscription => subscription.status === 'past_due'
-  );
-  const createdInRange = subscriptions.filter(subscription =>
-    isTimestampBetween(subscription.createdAt, rangeStart, now)
-  );
-  const createdInPriorRange = subscriptions.filter(subscription =>
-    isTimestampBetween(subscription.createdAt, priorRangeStart, rangeStart)
-  );
-  const canceledInRange = subscriptions.filter(
-    subscription =>
-      subscription.status === 'canceled' &&
-      subscription.canceledAt !== null &&
-      isTimestampBetween(subscription.canceledAt, rangeStart, now)
-  );
-  const subscriptionsActiveAtPeriodStart = subscriptions.filter(subscription =>
-    wasSubscriptionLiveAt(subscription, rangeStart)
-  );
-  const retainedSubscriptions = subscriptionsActiveAtPeriodStart.filter(
-    subscription => subscription.status !== 'canceled'
-  );
-  const mrr = liveSubscriptions.reduce(
-    (total, subscription) => total + getMonthlyKiloCreditValue(subscription),
-    0
-  );
-  const revenueAtRisk = [...pendingCancellationSubscriptions, ...pastDueSubscriptions].reduce(
-    (total, subscription) => total + getMonthlyKiloCreditValue(subscription),
-    0
-  );
-  const periodGrowthRate = calculateRate(
-    createdInRange.length - canceledInRange.length,
-    createdInPriorRange.length
-  );
-  const retentionRate = calculateRate(
-    retainedSubscriptions.length,
-    subscriptionsActiveAtPeriodStart.length
-  );
-  const churnRate = calculateRate(canceledInRange.length, subscriptionsActiveAtPeriodStart.length);
-
-  return [
-    {
-      label: 'Active MRR',
-      value: formatCurrencyValue(mrr),
-      detail: `${liveSubscriptions.length} live subscription${liveSubscriptions.length === 1 ? '' : 's'}`,
-    },
-    {
-      label: `${rangeLabel} growth`,
-      value: formatPercentValue(periodGrowthRate),
-      detail: `${formatSignedCount(createdInRange.length - canceledInRange.length)} net in ${rangeDetailLabel}`,
-    },
-    {
-      label: `${rangeLabel} retention`,
-      value: formatPercentValue(retentionRate),
-      detail: `${retainedSubscriptions.length}/${subscriptionsActiveAtPeriodStart.length} retained from ${rangeDays} days ago`,
-    },
-    {
-      label: `${rangeLabel} churn`,
-      value: formatPercentValue(churnRate),
-      detail: `${canceledInRange.length} canceled in ${rangeDetailLabel}`,
-    },
-    {
-      label: 'Revenue at risk',
-      value: formatCurrencyValue(revenueAtRisk),
-      detail: `${pendingCancellationSubscriptions.length} canceling, ${pastDueSubscriptions.length} past due`,
-    },
-    {
-      label: 'New subscriptions',
-      value: formatIntegerValue(createdInRange.length),
-      detail: `${createdInPriorRange.length} created in ${priorRangeDetailLabel}`,
-    },
-    {
-      label: 'Cancellation pending',
-      value: formatPercentValue(
-        calculateRate(pendingCancellationSubscriptions.length, liveSubscriptions.length)
-      ),
-      detail: `${pendingCancellationSubscriptions.length}/${liveSubscriptions.length} live subscriptions`,
-    },
-    {
-      label: 'Past due exposure',
-      value: formatCurrencyValue(
-        pastDueSubscriptions.reduce(
-          (total, subscription) => total + getMonthlyKiloCreditValue(subscription),
-          0
-        )
-      ),
-      detail: `${pastDueSubscriptions.length} subscription${pastDueSubscriptions.length === 1 ? '' : 's'} in recovery`,
-    },
-  ];
-}
-
-function getPlanPerformanceRows({
-  catalog,
-  subscriptions,
-  inventoryCounts,
-  availabilityIntentCounts,
-  rangeDays,
-}: {
-  catalog: AdminCodingPlanCatalogItem[];
-  subscriptions: AdminCodingPlanSubscriptionItem[];
-  inventoryCounts: InventoryCountItem[];
-  availabilityIntentCounts: AvailabilityIntentCountItem[];
-  rangeDays: InsightsRangeDays;
-}): PlanPerformanceRow[] {
-  const now = new Date();
-  const rangeStart = addDays(now, -rangeDays);
-
-  return catalog.map(plan => {
-    const planSubscriptions = subscriptions.filter(
-      subscription => subscription.planId === plan.planId
-    );
-    const liveSubscriptions = planSubscriptions.filter(subscription =>
-      isLiveSubscription(subscription)
-    );
-    const newSubscriptionsInRange = planSubscriptions.filter(subscription =>
-      isTimestampBetween(subscription.createdAt, rangeStart, now)
-    ).length;
-    const canceledSubscriptionsInRange = planSubscriptions.filter(
-      subscription =>
-        subscription.status === 'canceled' &&
-        subscription.canceledAt !== null &&
-        isTimestampBetween(subscription.canceledAt, rangeStart, now)
-    ).length;
-    const availableCredentials = inventoryCounts
-      .filter(item => item.planId === plan.planId && item.status === 'available')
-      .reduce((total, item) => total + item.count, 0);
-    const waitlistIntents =
-      availabilityIntentCounts.find(item => item.planId === plan.planId)?.count ?? 0;
-    const monthlyRecurringValue = liveSubscriptions.reduce(
-      (total, subscription) => total + getMonthlyKiloCreditValue(subscription),
-      0
-    );
-
-    return {
-      planId: plan.planId,
-      planName: plan.name,
-      providerName: plan.providerName,
-      activeSubscriptions: liveSubscriptions.length,
-      monthlyRecurringValue,
-      newSubscriptionsInRange,
-      canceledSubscriptionsInRange,
-      availableCredentials,
-      waitlistIntents,
-    };
-  });
 }
 
 function InventoryCountsTable({
@@ -940,37 +952,6 @@ function getInventoryCountRows(items: InventoryCountItem[]): InventoryCountRow[]
   );
 }
 
-function isLiveSubscription(subscription: AdminCodingPlanSubscriptionItem): boolean {
-  return subscription.status === 'active' || subscription.status === 'past_due';
-}
-
-function addDays(date: Date, days: number): Date {
-  const result = new Date(date);
-  result.setDate(result.getDate() + days);
-  return result;
-}
-
-function isTimestampBetween(value: string, start: Date, end: Date): boolean {
-  const timestamp = new Date(value).getTime();
-  return timestamp >= start.getTime() && timestamp < end.getTime();
-}
-
-function wasSubscriptionLiveAt(subscription: AdminCodingPlanSubscriptionItem, date: Date): boolean {
-  const createdAt = new Date(subscription.createdAt).getTime();
-  const canceledAt = subscription.canceledAt ? new Date(subscription.canceledAt).getTime() : null;
-  const target = date.getTime();
-
-  return createdAt < target && (canceledAt === null || canceledAt >= target);
-}
-
-function getMonthlyKiloCreditValue(subscription: AdminCodingPlanSubscriptionItem): number {
-  return subscription.costKiloCredits * (30 / subscription.billingPeriodDays);
-}
-
-function calculateRate(numerator: number, denominator: number): number | null {
-  return denominator === 0 ? null : numerator / denominator;
-}
-
 function formatCurrencyValue(value: number): string {
   return value.toLocaleString('en-US', {
     style: 'currency',
@@ -980,46 +961,130 @@ function formatCurrencyValue(value: number): string {
   });
 }
 
-function formatPercentValue(value: number | null): string {
-  if (value === null) {
-    return '—';
-  }
-
-  return value.toLocaleString('en-US', {
-    style: 'percent',
-    minimumFractionDigits: 0,
-    maximumFractionDigits: 1,
-  });
-}
-
 function formatIntegerValue(value: number): string {
   return value.toLocaleString('en-US');
-}
-
-function formatSignedCount(value: number): string {
-  return value > 0 ? `+${formatIntegerValue(value)}` : formatIntegerValue(value);
 }
 
 function formatInsightsRangeLabel(rangeDays: InsightsRangeDays): string {
   return `last ${rangeDays} days`;
 }
 
+const SUBSCRIPTION_STATUS_FILTERS: Array<{
+  value: SubscriptionDisplayStatus | 'all';
+  label: string;
+}> = [
+  { value: 'all', label: 'All statuses' },
+  { value: 'active', label: 'Active' },
+  { value: 'pending_cancellation', label: 'Cancellation pending' },
+  { value: 'past_due', label: 'Past due' },
+  { value: 'canceled', label: 'Canceled' },
+];
+
 function SubscriptionsTable({
   items,
+  pagination,
   isLoading,
+  isFetching,
   isError,
+  searchDraft,
+  search,
+  status,
+  onSearchDraftChange,
+  onSearch,
+  onStatusChange,
+  onPageChange,
+  onCancel,
+  onExtend,
 }: {
   items: AdminCodingPlanSubscriptionItem[];
+  pagination?: { page: number; total: number; totalPages: number };
   isLoading: boolean;
+  isFetching: boolean;
   isError: boolean;
+  searchDraft: string;
+  search: string;
+  status: SubscriptionDisplayStatus | 'all';
+  onSearchDraftChange: (value: string) => void;
+  onSearch: (value: string) => void;
+  onStatusChange: (value: SubscriptionDisplayStatus | 'all') => void;
+  onPageChange: (page: number) => void;
+  onCancel: (item: AdminCodingPlanSubscriptionItem) => void;
+  onExtend: (item: AdminCodingPlanSubscriptionItem) => void;
 }) {
+  const currentPage = pagination?.page ?? 1;
+  const totalPages = Math.max(pagination?.totalPages ?? 1, 1);
+
   return (
     <Card>
       <CardHeader>
         <CardTitle>Subscriptions</CardTitle>
         <CardDescription>Coding Plan subscriptions and billing state.</CardDescription>
       </CardHeader>
-      <CardContent>
+      <CardContent className="space-y-4">
+        <form
+          className="flex flex-col gap-3 lg:flex-row lg:items-end"
+          onSubmit={event => {
+            event.preventDefault();
+            onSearch(searchDraft.trim());
+          }}
+        >
+          <div className="space-y-2 lg:w-80">
+            <Label htmlFor="coding-plan-subscription-search">Search</Label>
+            <Input
+              id="coding-plan-subscription-search"
+              value={searchDraft}
+              onChange={event => onSearchDraftChange(event.target.value)}
+              placeholder="User ID or email"
+            />
+          </div>
+          <div className="space-y-2 lg:w-56">
+            <Label htmlFor="coding-plan-subscription-status">Status</Label>
+            <Select
+              value={status}
+              onValueChange={value => onStatusChange(value as SubscriptionDisplayStatus | 'all')}
+            >
+              <SelectTrigger id="coding-plan-subscription-status">
+                <SelectValue placeholder="All statuses" />
+              </SelectTrigger>
+              <SelectContent>
+                {SUBSCRIPTION_STATUS_FILTERS.map(option => (
+                  <SelectItem key={option.value} value={option.value}>
+                    {option.label}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="flex gap-2">
+            <Button type="submit" variant="secondary" size="sm" className="h-9">
+              <Search className="size-4" />
+              Search
+            </Button>
+            {search || searchDraft ? (
+              <Button
+                type="button"
+                variant="ghost"
+                size="sm"
+                className="h-9"
+                onClick={() => {
+                  onSearchDraftChange('');
+                  onSearch('');
+                }}
+              >
+                <X className="size-4" />
+                Clear
+              </Button>
+            ) : null}
+          </div>
+        </form>
+        <p className="text-muted-foreground -mt-2 text-xs">
+          Search matches a user ID or email address.
+        </p>
+        {isFetching && !isLoading ? (
+          <p className="text-muted-foreground flex items-center gap-2 text-xs" role="status">
+            <RefreshCw className="size-3 animate-spin" /> Updating results…
+          </p>
+        ) : null}
         <div className="overflow-x-auto rounded-lg border">
           <Table>
             <TableHeader>
@@ -1030,18 +1095,19 @@ function SubscriptionsTable({
                 <TableHead>Status</TableHead>
                 <TableHead>Billing date</TableHead>
                 <TableHead className="text-right">Price</TableHead>
+                <TableHead className="text-right">Actions</TableHead>
               </TableRow>
             </TableHeader>
             <TableBody>
               {isError ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="h-24 text-center text-red-300">
+                  <TableCell colSpan={7} className="h-24 text-center text-red-300">
                     Unable to load subscriptions.
                   </TableCell>
                 </TableRow>
               ) : items.length === 0 ? (
                 <TableRow>
-                  <TableCell colSpan={6} className="text-muted-foreground h-24 text-center">
+                  <TableCell colSpan={7} className="text-muted-foreground h-24 text-center">
                     {isLoading ? 'Loading subscriptions...' : 'No subscriptions recorded.'}
                   </TableCell>
                 </TableRow>
@@ -1053,6 +1119,8 @@ function SubscriptionsTable({
                     item.status === 'past_due'
                       ? formatLocalDateTimeLabel(billingDate.date)
                       : formatDateLabel(billingDate.date);
+                  const canCancel = item.status === 'active' && !item.cancelAtPeriodEnd;
+                  const canExtend = item.status === 'active';
 
                   return (
                     <TableRow key={item.id}>
@@ -1063,6 +1131,8 @@ function SubscriptionsTable({
                         >
                           {item.userName}
                         </Link>
+                        <div className="text-muted-foreground mt-1">{item.userEmail}</div>
+                        <div className="text-muted-foreground mt-1">{item.userId}</div>
                       </TableCell>
                       <TableCell className="min-w-56 font-mono text-xs">
                         <div className="flex items-center gap-2">
@@ -1097,12 +1167,51 @@ function SubscriptionsTable({
                           item.planId
                         )}
                       </TableCell>
+                      <TableCell>
+                        <div className="flex justify-end gap-2">
+                          {canExtend ? (
+                            <Button variant="secondary" size="sm" onClick={() => onExtend(item)}>
+                              Extend
+                            </Button>
+                          ) : null}
+                          {canCancel ? (
+                            <Button variant="destructive" size="sm" onClick={() => onCancel(item)}>
+                              Cancel
+                            </Button>
+                          ) : null}
+                        </div>
+                      </TableCell>
                     </TableRow>
                   );
                 })
               )}
             </TableBody>
           </Table>
+        </div>
+        <div className="flex flex-col items-start justify-between gap-3 text-sm sm:flex-row sm:items-center">
+          <p className="text-muted-foreground">
+            {pagination
+              ? `${pagination.total.toLocaleString()} subscription${pagination.total === 1 ? '' : 's'} · page ${pagination.page} of ${totalPages}`
+              : 'Loading subscription count...'}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => onPageChange(Math.max(1, currentPage - 1))}
+              disabled={currentPage <= 1 || isFetching}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="secondary"
+              size="sm"
+              onClick={() => onPageChange(currentPage + 1)}
+              disabled={!pagination || currentPage >= totalPages || isFetching}
+            >
+              Next
+            </Button>
+          </div>
         </div>
       </CardContent>
     </Card>
@@ -1142,6 +1251,11 @@ function OperationsTabs({
   onPlanChange,
   onEntriesTextChange,
   onUpload,
+  inventoryReplacementId,
+  inventoryReplacementApiKey,
+  onInventoryReplacementIdChange,
+  onInventoryReplacementApiKeyChange,
+  onConfirmInventoryReplacement,
 }: {
   inventorySummary: SummaryItem[];
   inventoryCounts: InventoryCountItem[];
@@ -1166,6 +1280,11 @@ function OperationsTabs({
   onPlanChange: (planId: string) => void;
   onEntriesTextChange: (entriesText: string) => void;
   onUpload: () => void;
+  inventoryReplacementId: string;
+  inventoryReplacementApiKey: string;
+  onInventoryReplacementIdChange: (inventoryKeyId: string) => void;
+  onInventoryReplacementApiKeyChange: (apiKey: string) => void;
+  onConfirmInventoryReplacement: () => void;
 }) {
   const hasSelectedPlan = planOptions.some(plan => plan.planId === selectedPlanId);
   const isBytePlusSelected = selectedProviderId === 'byteplus-coding';
@@ -1176,6 +1295,7 @@ function OperationsTabs({
         <TabsTrigger value="overview">Overview</TabsTrigger>
         <TabsTrigger value="revocation-queue">Pending Key Rotation</TabsTrigger>
         <TabsTrigger value="inventory-upload">Upload validated inventory</TabsTrigger>
+        <TabsTrigger value="replace-credential">Replace credential</TabsTrigger>
       </TabsList>
 
       <TabsContent value="overview" className="mt-0 space-y-6">
@@ -1394,6 +1514,55 @@ function OperationsTabs({
           </CardContent>
         </Card>
       </TabsContent>
+
+      <TabsContent value="replace-credential" className="mt-0">
+        <Card>
+          <CardHeader>
+            <CardTitle>Replace inventory credential</CardTitle>
+            <CardDescription>
+              Replace the API key for an available or assigned inventory ID. Kilo validates the key,
+              encrypts it, and updates any assigned BYOK copy.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="space-y-2">
+              <Label htmlFor="inventory-replacement-id">Inventory ID</Label>
+              <Input
+                id="inventory-replacement-id"
+                value={inventoryReplacementId}
+                onChange={event => onInventoryReplacementIdChange(event.target.value)}
+                placeholder="Inventory UUID"
+                autoComplete="off"
+                className="font-mono"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label htmlFor="inventory-replacement-api-key">Replacement API key</Label>
+              <Input
+                id="inventory-replacement-api-key"
+                type="password"
+                value={inventoryReplacementApiKey}
+                onChange={event => onInventoryReplacementApiKeyChange(event.target.value)}
+                placeholder={getInventoryReplacementDialogCopy().placeholder}
+                autoComplete="off"
+              />
+            </div>
+            <Alert>
+              <ShieldAlert className="size-4" />
+              <AlertDescription>{getInventoryReplacementDialogCopy().description}</AlertDescription>
+            </Alert>
+            <Button
+              onClick={onConfirmInventoryReplacement}
+              disabled={
+                inventoryReplacementId.trim().length === 0 ||
+                inventoryReplacementApiKey.trim().length === 0
+              }
+            >
+              Review replacement
+            </Button>
+          </CardContent>
+        </Card>
+      </TabsContent>
     </Tabs>
   );
 }
@@ -1409,6 +1578,22 @@ function OperationsDialogs({
   onCloseReplacement,
   onReplacementApiKeyChange,
   onReplace,
+  cancelSelection,
+  cancelPending,
+  onCloseCancel,
+  onCancel,
+  extendSelection,
+  extendDays,
+  extendPending,
+  canSubmitExtend,
+  onCloseExtend,
+  onExtendDaysChange,
+  onExtend,
+  inventoryReplacementId,
+  inventoryReplacementConfirmOpen,
+  inventoryReplacementPending,
+  onCloseInventoryReplacement,
+  onReplaceInventoryCredential,
 }: {
   completeSelection: RevocationSelection | null;
   completePending: boolean;
@@ -1420,6 +1605,22 @@ function OperationsDialogs({
   onCloseReplacement: () => void;
   onReplacementApiKeyChange: (apiKey: string) => void;
   onReplace: (inventoryKeyId: string, apiKey: string) => void;
+  cancelSelection: AdminCodingPlanSubscriptionItem | null;
+  cancelPending: boolean;
+  onCloseCancel: () => void;
+  onCancel: (subscriptionId: string) => void;
+  extendSelection: AdminCodingPlanSubscriptionItem | null;
+  extendDays: string;
+  extendPending: boolean;
+  canSubmitExtend: boolean;
+  onCloseExtend: () => void;
+  onExtendDaysChange: (days: string) => void;
+  onExtend: (subscriptionId: string, days: number) => void;
+  inventoryReplacementId: string;
+  inventoryReplacementConfirmOpen: boolean;
+  inventoryReplacementPending: boolean;
+  onCloseInventoryReplacement: () => void;
+  onReplaceInventoryCredential: () => void;
 }) {
   // Copy derives from the retained selection. The null fallback only applies
   // while a dialog is closed or animating out, so it is never visible.
@@ -1429,17 +1630,26 @@ function OperationsDialogs({
   const replacementCopy = getReplacementDialogCopy(
     replacementSelection?.providerDisplayName ?? 'the provider'
   );
+  const cancelCopy = getCancelSubscriptionDialogCopy(cancelSelection?.userName ?? 'this user');
+  const extendCopy = getExtendSubscriptionDialogCopy(extendSelection?.userName ?? 'this user');
+  const parsedExtendDays = Number(extendDays);
+  const inventoryReplacementCopy = getInventoryReplacementDialogCopy(inventoryReplacementId);
 
   return (
     <>
-      <Dialog open={completeSelection !== null} onOpenChange={open => !open && onCloseComplete()}>
-        <DialogContent>
+      <Dialog
+        open={completeSelection !== null}
+        onOpenChange={open => {
+          if (!open && !completePending) onCloseComplete();
+        }}
+      >
+        <DialogContent showCloseButton={!completePending}>
           <DialogHeader>
             <DialogTitle>{revocationCopy.title}</DialogTitle>
             <DialogDescription>{revocationCopy.description}</DialogDescription>
           </DialogHeader>
           <DialogFooter>
-            <Button variant="secondary" onClick={onCloseComplete}>
+            <Button variant="secondary" onClick={onCloseComplete} disabled={completePending}>
               Keep pending
             </Button>
             <Button
@@ -1457,9 +1667,11 @@ function OperationsDialogs({
 
       <Dialog
         open={replacementSelection !== null}
-        onOpenChange={open => !open && onCloseReplacement()}
+        onOpenChange={open => {
+          if (!open && !replacementPending) onCloseReplacement();
+        }}
       >
-        <DialogContent>
+        <DialogContent showCloseButton={!replacementPending}>
           <DialogHeader>
             <DialogTitle>{replacementCopy.title}</DialogTitle>
             <DialogDescription>{replacementCopy.description}</DialogDescription>
@@ -1476,7 +1688,7 @@ function OperationsDialogs({
             />
           </div>
           <DialogFooter>
-            <Button variant="secondary" onClick={onCloseReplacement}>
+            <Button variant="secondary" onClick={onCloseReplacement} disabled={replacementPending}>
               Keep pending
             </Button>
             <Button
@@ -1487,6 +1699,103 @@ function OperationsDialogs({
               disabled={replacementApiKey.trim().length === 0 || replacementPending}
             >
               {replacementPending ? 'Validating...' : 'Validate and replace'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={cancelSelection !== null}
+        onOpenChange={open => {
+          if (!open && !cancelPending) onCloseCancel();
+        }}
+      >
+        <DialogContent showCloseButton={!cancelPending}>
+          <DialogHeader>
+            <DialogTitle>{cancelCopy.title}</DialogTitle>
+            <DialogDescription>{cancelCopy.description}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="secondary" onClick={onCloseCancel} disabled={cancelPending}>
+              Keep subscription
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => cancelSelection && onCancel(cancelSelection.id)}
+              disabled={cancelPending}
+            >
+              {cancelPending ? 'Scheduling cancellation...' : 'Cancel at period end'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={extendSelection !== null}
+        onOpenChange={open => {
+          if (!open && !extendPending) onCloseExtend();
+        }}
+      >
+        <DialogContent showCloseButton={!extendPending}>
+          <DialogHeader>
+            <DialogTitle>{extendCopy.title}</DialogTitle>
+            <DialogDescription>{extendCopy.description}</DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="extend-subscription-days">Additional days</Label>
+            <Input
+              id="extend-subscription-days"
+              type="number"
+              min={1}
+              max={90}
+              value={extendDays}
+              onChange={event => onExtendDaysChange(event.target.value)}
+            />
+            {extendSelection ? (
+              <p className="text-muted-foreground text-xs">
+                Current period ends {formatDateLabel(extendSelection.currentPeriodEnd)}. Renewal is{' '}
+                {formatDateLabel(extendSelection.creditRenewalAt)}.
+              </p>
+            ) : null}
+          </div>
+          <DialogFooter>
+            <Button variant="secondary" onClick={onCloseExtend} disabled={extendPending}>
+              Keep dates
+            </Button>
+            <Button
+              onClick={() =>
+                extendSelection && canSubmitExtend && onExtend(extendSelection.id, parsedExtendDays)
+              }
+              disabled={!canSubmitExtend || extendPending}
+            >
+              {extendPending ? 'Extending period...' : 'Extend period'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Dialog
+        open={inventoryReplacementConfirmOpen}
+        onOpenChange={open => {
+          if (!open && !inventoryReplacementPending) onCloseInventoryReplacement();
+        }}
+      >
+        <DialogContent showCloseButton={!inventoryReplacementPending}>
+          <DialogHeader>
+            <DialogTitle>{inventoryReplacementCopy.title}</DialogTitle>
+            <DialogDescription>{inventoryReplacementCopy.description}</DialogDescription>
+          </DialogHeader>
+          <p className="font-mono text-sm">{inventoryReplacementId.trim()}</p>
+          <DialogFooter>
+            <Button
+              variant="secondary"
+              onClick={onCloseInventoryReplacement}
+              disabled={inventoryReplacementPending}
+            >
+              Keep current key
+            </Button>
+            <Button onClick={onReplaceInventoryCredential} disabled={inventoryReplacementPending}>
+              {inventoryReplacementPending ? 'Validating...' : 'Validate and replace'}
             </Button>
           </DialogFooter>
         </DialogContent>

--- a/apps/web/src/app/admin/coding-plans/coding-plan-operations.test.ts
+++ b/apps/web/src/app/admin/coding-plans/coding-plan-operations.test.ts
@@ -1,9 +1,17 @@
 import {
+  canSubmitExtensionDays,
+  getCancelSubscriptionDialogCopy,
+  getCodingPlanInsights,
   getCodingPlanProviderDisplayName,
+  getExtendSubscriptionDialogCopy,
+  getInventoryReplacementCompleteToast,
+  getInventoryReplacementDialogCopy,
+  getPlanPerformanceRows,
   getReplacementCompleteToast,
   getReplacementDialogCopy,
   getRevocationCompleteToast,
   getRevocationDialogCopy,
+  getSubscriptionSummaryItems,
 } from '@/app/admin/coding-plans/coding-plan-operations';
 
 const CATALOG = [
@@ -65,5 +73,157 @@ describe('provider-aware replacement copy', () => {
 
   it('stays provider-neutral when the provider is unknown', () => {
     expect(getReplacementCompleteToast(null)).toBe('Credential replaced and returned to stock.');
+  });
+});
+
+describe('inventory replacement copy', () => {
+  it('describes encryption and assigned BYOK updates', () => {
+    const dialog = getInventoryReplacementDialogCopy('11111111-1111-1111-1111-111111111111');
+    expect(getInventoryReplacementCompleteToast()).toBe('Inventory credential replaced.');
+    expect(dialog.title).toBe('Replace inventory API key');
+    expect(dialog.description).toContain('11111111-1111-1111-1111-111111111111');
+    expect(dialog.description).toContain('encrypts');
+    expect(dialog.description).toContain('assigned BYOK');
+  });
+});
+
+describe('canSubmitExtensionDays', () => {
+  it('accepts whole days from 1 to 90 and rejects fractions', () => {
+    expect(canSubmitExtensionDays('7')).toBe(true);
+    expect(canSubmitExtensionDays('1.5')).toBe(false);
+    expect(canSubmitExtensionDays('0')).toBe(false);
+    expect(canSubmitExtensionDays('91')).toBe(false);
+  });
+});
+
+describe('subscription action copy', () => {
+  it('names the user in cancel and extend dialogs', () => {
+    expect(getCancelSubscriptionDialogCopy('Ada').title).toBe("Cancel Ada's subscription?");
+    expect(getCancelSubscriptionDialogCopy('Ada').description).toContain(
+      'end of the current paid period'
+    );
+    expect(getExtendSubscriptionDialogCopy('Ada').title).toBe("Extend Ada's current period?");
+    expect(getExtendSubscriptionDialogCopy('Ada').description).toContain(
+      'without charging credits'
+    );
+  });
+});
+
+describe('aggregate insight helpers', () => {
+  it('maps summary counts onto the existing subscription cards', () => {
+    expect(
+      getSubscriptionSummaryItems({
+        total: 11,
+        active: 6,
+        pendingCancellation: 2,
+        pastDue: 1,
+      })
+    ).toEqual([
+      { label: 'Total subscriptions', count: 11 },
+      { label: 'Active subscriptions', count: 6 },
+      { label: 'Cancellation pending', count: 2 },
+      { label: 'Past due subscriptions', count: 1 },
+    ]);
+  });
+
+  it('preserves 7-day KPI copy from bounded totals', () => {
+    const insights = getCodingPlanInsights(
+      {
+        liveSubscriptions: 4,
+        pendingCancellation: 1,
+        pastDue: 1,
+        mrrKiloCredits: 80,
+        revenueAtRiskKiloCredits: 40,
+        pastDueMrrKiloCredits: 20,
+        createdInRange: 3,
+        createdInPriorRange: 2,
+        canceledInRange: 1,
+        liveAtRangeStart: 4,
+        retainedFromRangeStart: 3,
+        currentWaitersJoinedInRange: 2,
+        currentWaitersJoinedInPriorRange: 1,
+        currentWaitlistTotal: 5,
+      },
+      7
+    );
+
+    expect(insights).toEqual([
+      { label: 'Active MRR', value: '$80', detail: '4 live subscriptions' },
+      { label: '7-day growth', value: '100%', detail: '+2 net in last 7 days' },
+      { label: '7-day retention', value: '75%', detail: '3/4 retained from 7 days ago' },
+      { label: '7-day churn', value: '25%', detail: '1 canceled in last 7 days' },
+      { label: 'Revenue at risk', value: '$40', detail: '1 canceling, 1 past due' },
+      { label: 'New subscriptions', value: '3', detail: '2 created in prior 7 days' },
+      {
+        label: 'Cancellation pending',
+        value: '25%',
+        detail: '1/4 live subscriptions',
+      },
+      { label: 'Past due exposure', value: '$20', detail: '1 subscription in recovery' },
+      {
+        label: 'Current waiters joined (7-day)',
+        value: '2',
+        detail: '1 current waiters joined in prior 7 days · 5 currently waiting',
+      },
+    ]);
+  });
+
+  it('joins bounded plan insight rows with catalog and inventory counts', () => {
+    expect(
+      getPlanPerformanceRows({
+        catalog: [
+          {
+            planId: 'minimax-token-plan-plus',
+            planName: 'Token Plan Plus',
+            providerName: 'MiniMax',
+          },
+          {
+            planId: 'byteplus-coding-plan-team-lite',
+            planName: 'Enterprise Coding Plan Lite',
+            providerName: 'BytePlus',
+          },
+        ],
+        inventoryCounts: [
+          { planId: 'minimax-token-plan-plus', status: 'available', count: 4 },
+          { planId: 'minimax-token-plan-plus', status: 'assigned', count: 2 },
+        ],
+        planInsights: [
+          {
+            planId: 'minimax-token-plan-plus',
+            liveSubscriptions: 2,
+            monthlyRecurringValueKiloCredits: 40,
+            createdInRange: 1,
+            canceledInRange: 0,
+            currentWaitersJoinedInRange: 2,
+            currentWaitlistTotal: 3,
+          },
+        ],
+      })
+    ).toEqual([
+      {
+        planId: 'minimax-token-plan-plus',
+        planName: 'Token Plan Plus',
+        providerName: 'MiniMax',
+        activeSubscriptions: 2,
+        monthlyRecurringValue: 40,
+        newSubscriptionsInRange: 1,
+        canceledSubscriptionsInRange: 0,
+        availableCredentials: 4,
+        waitlistIntents: 3,
+        currentWaitersJoinedInRange: 2,
+      },
+      {
+        planId: 'byteplus-coding-plan-team-lite',
+        planName: 'Enterprise Coding Plan Lite',
+        providerName: 'BytePlus',
+        activeSubscriptions: 0,
+        monthlyRecurringValue: 0,
+        newSubscriptionsInRange: 0,
+        canceledSubscriptionsInRange: 0,
+        availableCredentials: 0,
+        waitlistIntents: 0,
+        currentWaitersJoinedInRange: 0,
+      },
+    ]);
   });
 });

--- a/apps/web/src/app/admin/coding-plans/coding-plan-operations.ts
+++ b/apps/web/src/app/admin/coding-plans/coding-plan-operations.ts
@@ -48,3 +48,252 @@ export function getReplacementDialogCopy(providerDisplayName: string): {
     placeholder: `Paste new ${providerDisplayName} API key`,
   };
 }
+
+export function getInventoryReplacementCompleteToast(): string {
+  return 'Inventory credential replaced.';
+}
+
+export function getInventoryReplacementDialogCopy(inventoryKeyId?: string): {
+  title: string;
+  description: string;
+  placeholder: string;
+} {
+  const target = inventoryKeyId?.trim() ? ` ${inventoryKeyId.trim()}` : '';
+  return {
+    title: 'Replace inventory API key',
+    description: `Kilo validates the replacement key for inventory ID${target}, encrypts it, and rotates the stored available or assigned key plus any assigned BYOK copy for a live subscription.`,
+    placeholder: 'Paste replacement API key',
+  };
+}
+
+export function canSubmitExtensionDays(value: string): boolean {
+  const days = Number(value);
+  return Number.isInteger(days) && days >= 1 && days <= 90;
+}
+
+export function getCancelSubscriptionDialogCopy(userName: string): {
+  title: string;
+  description: string;
+} {
+  return {
+    title: `Cancel ${userName}'s subscription?`,
+    description:
+      'This stops renewal at the end of the current paid period. Access stays active until that date.',
+  };
+}
+
+export function getExtendSubscriptionDialogCopy(userName: string): {
+  title: string;
+  description: string;
+} {
+  return {
+    title: `Extend ${userName}'s current period?`,
+    description: 'Adds days to the current period end and renewal date without charging credits.',
+  };
+}
+
+export type InsightsRangeDays = 7 | 14 | 30;
+
+export type AdminSubscriptionSummary = {
+  total: number;
+  active: number;
+  pendingCancellation: number;
+  pastDue: number;
+};
+
+export type AdminInsightsTotals = {
+  liveSubscriptions: number;
+  pendingCancellation: number;
+  pastDue: number;
+  mrrKiloCredits: number;
+  revenueAtRiskKiloCredits: number;
+  pastDueMrrKiloCredits: number;
+  createdInRange: number;
+  createdInPriorRange: number;
+  canceledInRange: number;
+  liveAtRangeStart: number;
+  retainedFromRangeStart: number;
+  currentWaitersJoinedInRange: number;
+  currentWaitersJoinedInPriorRange: number;
+  currentWaitlistTotal: number;
+};
+
+export type AdminPlanInsight = {
+  planId: string;
+  liveSubscriptions: number;
+  monthlyRecurringValueKiloCredits: number;
+  createdInRange: number;
+  canceledInRange: number;
+  currentWaitersJoinedInRange: number;
+  currentWaitlistTotal: number;
+};
+
+export type AdminInsightsCatalogItem = {
+  planId: string;
+  planName: string;
+  providerName: string;
+};
+
+export type AdminInsightsInventoryCount = {
+  planId: string;
+  status: string;
+  count: number;
+};
+
+export type AdminInsightsKpiItem = {
+  label: string;
+  value: string;
+  detail: string;
+};
+
+export type AdminPlanPerformanceRow = {
+  planId: string;
+  planName: string;
+  providerName: string;
+  activeSubscriptions: number;
+  monthlyRecurringValue: number;
+  newSubscriptionsInRange: number;
+  canceledSubscriptionsInRange: number;
+  availableCredentials: number;
+  waitlistIntents: number;
+  currentWaitersJoinedInRange: number;
+};
+
+export function getSubscriptionSummaryItems(
+  summary: AdminSubscriptionSummary
+): Array<{ label: string; count: number }> {
+  return [
+    { label: 'Total subscriptions', count: summary.total },
+    { label: 'Active subscriptions', count: summary.active },
+    { label: 'Cancellation pending', count: summary.pendingCancellation },
+    { label: 'Past due subscriptions', count: summary.pastDue },
+  ];
+}
+
+export function getCodingPlanInsights(
+  totals: AdminInsightsTotals,
+  rangeDays: InsightsRangeDays
+): AdminInsightsKpiItem[] {
+  const rangeLabel = `${rangeDays}-day`;
+  const rangeDetailLabel = `last ${rangeDays} days`;
+  const priorRangeDetailLabel = `prior ${rangeDays} days`;
+  const periodGrowthRate = calculateRate(
+    totals.createdInRange - totals.canceledInRange,
+    totals.createdInPriorRange
+  );
+  const retentionRate = calculateRate(totals.retainedFromRangeStart, totals.liveAtRangeStart);
+  const churnRate = calculateRate(totals.canceledInRange, totals.liveAtRangeStart);
+
+  return [
+    {
+      label: 'Active MRR',
+      value: formatCurrencyValue(totals.mrrKiloCredits),
+      detail: `${totals.liveSubscriptions} live subscription${totals.liveSubscriptions === 1 ? '' : 's'}`,
+    },
+    {
+      label: `${rangeLabel} growth`,
+      value: formatPercentValue(periodGrowthRate),
+      detail: `${formatSignedCount(totals.createdInRange - totals.canceledInRange)} net in ${rangeDetailLabel}`,
+    },
+    {
+      label: `${rangeLabel} retention`,
+      value: formatPercentValue(retentionRate),
+      detail: `${totals.retainedFromRangeStart}/${totals.liveAtRangeStart} retained from ${rangeDays} days ago`,
+    },
+    {
+      label: `${rangeLabel} churn`,
+      value: formatPercentValue(churnRate),
+      detail: `${totals.canceledInRange} canceled in ${rangeDetailLabel}`,
+    },
+    {
+      label: 'Revenue at risk',
+      value: formatCurrencyValue(totals.revenueAtRiskKiloCredits),
+      detail: `${totals.pendingCancellation} canceling, ${totals.pastDue} past due`,
+    },
+    {
+      label: 'New subscriptions',
+      value: formatIntegerValue(totals.createdInRange),
+      detail: `${totals.createdInPriorRange} created in ${priorRangeDetailLabel}`,
+    },
+    {
+      label: 'Cancellation pending',
+      value: formatPercentValue(
+        calculateRate(totals.pendingCancellation, totals.liveSubscriptions)
+      ),
+      detail: `${totals.pendingCancellation}/${totals.liveSubscriptions} live subscriptions`,
+    },
+    {
+      label: 'Past due exposure',
+      value: formatCurrencyValue(totals.pastDueMrrKiloCredits),
+      detail: `${totals.pastDue} subscription${totals.pastDue === 1 ? '' : 's'} in recovery`,
+    },
+    {
+      label: `Current waiters joined (${rangeLabel})`,
+      value: formatIntegerValue(totals.currentWaitersJoinedInRange),
+      detail: `${totals.currentWaitersJoinedInPriorRange} current waiters joined in ${priorRangeDetailLabel} · ${totals.currentWaitlistTotal} currently waiting`,
+    },
+  ];
+}
+
+export function getPlanPerformanceRows({
+  catalog,
+  inventoryCounts,
+  planInsights,
+}: {
+  catalog: readonly AdminInsightsCatalogItem[];
+  inventoryCounts: readonly AdminInsightsInventoryCount[];
+  planInsights: readonly AdminPlanInsight[];
+}): AdminPlanPerformanceRow[] {
+  return catalog.map(plan => {
+    const insight = planInsights.find(item => item.planId === plan.planId);
+    const availableCredentials = inventoryCounts
+      .filter(item => item.planId === plan.planId && item.status === 'available')
+      .reduce((total, item) => total + item.count, 0);
+
+    return {
+      planId: plan.planId,
+      planName: plan.planName,
+      providerName: plan.providerName,
+      activeSubscriptions: insight?.liveSubscriptions ?? 0,
+      monthlyRecurringValue: insight?.monthlyRecurringValueKiloCredits ?? 0,
+      newSubscriptionsInRange: insight?.createdInRange ?? 0,
+      canceledSubscriptionsInRange: insight?.canceledInRange ?? 0,
+      availableCredentials,
+      waitlistIntents: insight?.currentWaitlistTotal ?? 0,
+      currentWaitersJoinedInRange: insight?.currentWaitersJoinedInRange ?? 0,
+    };
+  });
+}
+
+function calculateRate(numerator: number, denominator: number): number | null {
+  return denominator === 0 ? null : numerator / denominator;
+}
+
+function formatCurrencyValue(value: number): string {
+  return value.toLocaleString('en-US', {
+    style: 'currency',
+    currency: 'USD',
+    minimumFractionDigits: Number.isInteger(value) ? 0 : 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatPercentValue(value: number | null): string {
+  if (value === null) {
+    return '—';
+  }
+
+  return value.toLocaleString('en-US', {
+    style: 'percent',
+    minimumFractionDigits: 0,
+    maximumFractionDigits: 1,
+  });
+}
+
+function formatIntegerValue(value: number): string {
+  return value.toLocaleString('en-US');
+}
+
+function formatSignedCount(value: number): string {
+  return value > 0 ? `+${formatIntegerValue(value)}` : formatIntegerValue(value);
+}

--- a/apps/web/src/lib/coding-plans/billing-lifecycle-cron.test.ts
+++ b/apps/web/src/lib/coding-plans/billing-lifecycle-cron.test.ts
@@ -1,7 +1,11 @@
 /* eslint-disable drizzle/enforce-delete-with-where */
 import { eq } from 'drizzle-orm';
 
-import { runCodingPlanBillingLifecycleCron } from '@/lib/coding-plans/billing-lifecycle-cron';
+import {
+  processCodingPlanCancellationAtPeriodEnd,
+  processCodingPlanRenewal,
+  runCodingPlanBillingLifecycleCron,
+} from '@/lib/coding-plans/billing-lifecycle-cron';
 import { subscribeToCodingPlan, uploadKeysToInventory } from '@/lib/coding-plans';
 import type { CodingPlanId } from '@/lib/coding-plans/pricing';
 import { db } from '@/lib/drizzle';
@@ -257,6 +261,61 @@ describe('Coding Plan billing lifecycle cron', () => {
     expect(credential.upstream_plan_id).toEqual(expect.any(String));
     expect(credential.encrypted_api_key).toBeNull();
     expect(maybePerformAutoTopUp).not.toHaveBeenCalled();
+  });
+
+  it('rechecks an extended cancellation deadline after a stale sweep selection', async () => {
+    const { subscriptionId } = await createSubscription(COST_MICRODOLLARS);
+    const futureEnd = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    await db
+      .update(coding_plan_subscriptions)
+      .set({
+        cancel_at_period_end: true,
+        current_period_end: futureEnd,
+        credit_renewal_at: futureEnd,
+      })
+      .where(eq(coding_plan_subscriptions.id, subscriptionId));
+
+    await expect(
+      processCodingPlanCancellationAtPeriodEnd(db, subscriptionId, new Date().toISOString())
+    ).resolves.toBe(false);
+
+    const [subscription] = await db
+      .select()
+      .from(coding_plan_subscriptions)
+      .where(eq(coding_plan_subscriptions.id, subscriptionId));
+    const [credential] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, subscription.key_inventory_id!));
+    expect(subscription.status).toBe('active');
+    expect(subscription.cancel_at_period_end).toBe(true);
+    expect(subscription.installed_byok_key_id).not.toBeNull();
+    expect(credential.status).toBe('assigned');
+    expect(credential.encrypted_api_key).not.toBeNull();
+  });
+
+  it('rechecks an extended renewal deadline after a stale sweep selection', async () => {
+    const { user, subscriptionId } = await createSubscription(COST_MICRODOLLARS * 2);
+    const futureEnd = new Date(Date.now() + 7 * 24 * 60 * 60 * 1000).toISOString();
+    await db
+      .update(coding_plan_subscriptions)
+      .set({ current_period_end: futureEnd, credit_renewal_at: futureEnd })
+      .where(eq(coding_plan_subscriptions.id, subscriptionId));
+
+    await expect(
+      processCodingPlanRenewal(db, subscriptionId, user.id, new Date().toISOString())
+    ).resolves.toBe('waiting');
+
+    const terms = await db
+      .select()
+      .from(coding_plan_terms)
+      .where(eq(coding_plan_terms.subscription_id, subscriptionId));
+    const [savedUser] = await db
+      .select()
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, user.id));
+    expect(terms.map(term => term.kind)).toEqual(['activation']);
+    expect(savedUser.microdollars_used).toBe(COST_MICRODOLLARS);
   });
 
   it('terminates unfunded renewal immediately when auto-top-up is disabled', async () => {

--- a/apps/web/src/lib/coding-plans/billing-lifecycle-cron.ts
+++ b/apps/web/src/lib/coding-plans/billing-lifecycle-cron.ts
@@ -101,11 +101,7 @@ async function sweepCancelAtPeriodEnd(
   summary: CodingPlanCronSummary
 ): Promise<void> {
   const rows = await database
-    .select({
-      id: coding_plan_subscriptions.id,
-      installed_byok_key_id: coding_plan_subscriptions.installed_byok_key_id,
-      key_inventory_id: coding_plan_subscriptions.key_inventory_id,
-    })
+    .select({ id: coding_plan_subscriptions.id })
     .from(coding_plan_subscriptions)
     .where(
       and(
@@ -119,44 +115,8 @@ async function sweepCancelAtPeriodEnd(
 
   for (const row of rows) {
     try {
-      await database.transaction(async tx => {
-        await tx
-          .update(coding_plan_subscriptions)
-          .set({
-            status: 'canceled',
-            canceled_at: nowIso,
-            cancellation_reason: 'user_canceled',
-            cancel_at_period_end: false,
-            installed_byok_key_id: null,
-          })
-          .where(
-            and(
-              eq(coding_plan_subscriptions.id, row.id),
-              eq(coding_plan_subscriptions.status, 'active')
-            )
-          );
-        if (row.installed_byok_key_id) {
-          await tx
-            .delete(byok_api_keys)
-            .where(
-              and(
-                eq(byok_api_keys.id, row.installed_byok_key_id),
-                eq(byok_api_keys.management_source, 'coding_plan')
-              )
-            );
-        }
-        if (row.key_inventory_id) {
-          await tx
-            .update(coding_plan_key_inventory)
-            .set({
-              status: 'revocation_pending',
-              encrypted_api_key: null,
-              revocation_requested_at: nowIso,
-            })
-            .where(eq(coding_plan_key_inventory.id, row.key_inventory_id));
-        }
-      });
-      summary.canceled_at_period_end++;
+      const processed = await processCodingPlanCancellationAtPeriodEnd(database, row.id, nowIso);
+      if (processed) summary.canceled_at_period_end++;
     } catch (error) {
       summary.errors++;
       logError('Failed to end canceled coding plan access', {
@@ -165,6 +125,70 @@ async function sweepCancelAtPeriodEnd(
       });
     }
   }
+}
+
+export async function processCodingPlanCancellationAtPeriodEnd(
+  database: PostgresJsDatabase<typeof schema>,
+  subscriptionId: string,
+  nowIso: string
+): Promise<boolean> {
+  return database.transaction(async tx => {
+    const { rows: lockedRows } = await tx.execute<{
+      installed_byok_key_id: string | null;
+      key_inventory_id: string | null;
+    }>(sql`
+      SELECT installed_byok_key_id, key_inventory_id
+      FROM coding_plan_subscriptions
+      WHERE id = ${subscriptionId}
+        AND status = 'active'
+        AND cancel_at_period_end = true
+        AND current_period_end <= ${nowIso}
+      FOR UPDATE
+    `);
+    const locked = lockedRows[0];
+    if (!locked) return false;
+
+    const result = await tx
+      .update(coding_plan_subscriptions)
+      .set({
+        status: 'canceled',
+        canceled_at: nowIso,
+        cancellation_reason: 'user_canceled',
+        cancel_at_period_end: false,
+        installed_byok_key_id: null,
+      })
+      .where(
+        and(
+          eq(coding_plan_subscriptions.id, subscriptionId),
+          eq(coding_plan_subscriptions.status, 'active'),
+          eq(coding_plan_subscriptions.cancel_at_period_end, true),
+          lte(coding_plan_subscriptions.current_period_end, nowIso)
+        )
+      );
+    if ((result.rowCount ?? 0) === 0) return false;
+
+    if (locked.installed_byok_key_id) {
+      await tx
+        .delete(byok_api_keys)
+        .where(
+          and(
+            eq(byok_api_keys.id, locked.installed_byok_key_id),
+            eq(byok_api_keys.management_source, 'coding_plan')
+          )
+        );
+    }
+    if (locked.key_inventory_id) {
+      await tx
+        .update(coding_plan_key_inventory)
+        .set({
+          status: 'revocation_pending',
+          encrypted_api_key: null,
+          revocation_requested_at: nowIso,
+        })
+        .where(eq(coding_plan_key_inventory.id, locked.key_inventory_id));
+    }
+    return true;
+  });
 }
 
 async function sweepRenewals(
@@ -211,7 +235,7 @@ async function sweepRenewals(
       status: selectedRow.status === 'past_due' ? 'past_due' : 'active',
     };
     try {
-      const result = await processRenewal(database, row, nowIso);
+      const result = await processCodingPlanRenewal(database, row.id, row.user_id, nowIso);
       if (result === 'renewed') {
         summary.renewals++;
         try {
@@ -262,9 +286,10 @@ async function sweepRenewals(
   }
 }
 
-async function processRenewal(
+export async function processCodingPlanRenewal(
   database: PostgresJsDatabase<typeof schema>,
-  selectedRow: RenewalRow,
+  subscriptionId: string,
+  userId: string,
   nowIso: string
 ): Promise<RenewalResult> {
   // Renewal processing has one durable outcome per due term, guarded by row locks
@@ -272,11 +297,9 @@ async function processRenewal(
   // window, wait for in-flight grace recovery, or terminate and queue revocation.
   const result = await database.transaction(async tx => {
     await tx.execute(
-      sql`SELECT id FROM coding_plan_subscriptions WHERE id = ${selectedRow.id} FOR UPDATE`
+      sql`SELECT id FROM coding_plan_subscriptions WHERE id = ${subscriptionId} FOR UPDATE`
     );
-    await tx.execute(
-      sql`SELECT id FROM kilocode_users WHERE id = ${selectedRow.user_id} FOR UPDATE`
-    );
+    await tx.execute(sql`SELECT id FROM kilocode_users WHERE id = ${userId} FOR UPDATE`);
     const [row] = await tx
       .select({
         id: coding_plan_subscriptions.id,
@@ -296,9 +319,14 @@ async function processRenewal(
       })
       .from(coding_plan_subscriptions)
       .innerJoin(kilocode_users, eq(coding_plan_subscriptions.user_id, kilocode_users.id))
-      .where(eq(coding_plan_subscriptions.id, selectedRow.id))
+      .where(eq(coding_plan_subscriptions.id, subscriptionId))
       .limit(1);
-    if (!row || row.status === 'canceled' || row.cancel_at_period_end) {
+    if (
+      !row ||
+      row.status === 'canceled' ||
+      row.cancel_at_period_end ||
+      new Date(row.credit_renewal_at) > new Date(nowIso)
+    ) {
       return 'waiting';
     }
 

--- a/apps/web/src/lib/coding-plans/index.ts
+++ b/apps/web/src/lib/coding-plans/index.ts
@@ -2,7 +2,7 @@ import 'server-only';
 
 import { createHash } from 'node:crypto';
 import { addDays } from 'date-fns';
-import { and, eq, inArray, sql } from 'drizzle-orm';
+import { and, eq, inArray, isNotNull, ne, sql } from 'drizzle-orm';
 import pLimit from 'p-limit';
 
 import { decryptApiKey, encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
@@ -14,7 +14,7 @@ import {
   type CodingPlanCredentialValidationResult,
   validateCodingPlanCredential,
 } from '@/lib/coding-plans/inventory-validation';
-import { getCodingPlanPrice, type CodingPlanId } from '@/lib/coding-plans/pricing';
+import { getCodingPlanPrice, isCodingPlanId, type CodingPlanId } from '@/lib/coding-plans/pricing';
 import { db } from '@/lib/drizzle';
 import { maybeIssueKiloPassBonusFromUsageThreshold } from '@/lib/kilo-pass/usage-triggered-bonus';
 import { sentryLogger } from '@/lib/utils.server';
@@ -35,6 +35,17 @@ export class CodingPlanInventoryUploadError extends Error {
     super(message);
     this.name = 'CodingPlanInventoryUploadError';
   }
+}
+
+export class CodingPlanInventoryReplacementError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'CodingPlanInventoryReplacementError';
+  }
+}
+
+function inventoryReplacementError(message: string): CodingPlanInventoryReplacementError {
+  return new CodingPlanInventoryReplacementError(message);
 }
 
 function databaseConstraint(error: unknown): string | null {
@@ -643,4 +654,281 @@ export async function getKeyInventoryCounts(
     status: row.status,
     count: Number.parseInt(row.count, 10),
   }));
+}
+
+export async function adminCancelCodingPlanSubscription(subscriptionId: string): Promise<void> {
+  const result = await db
+    .update(coding_plan_subscriptions)
+    .set({ cancel_at_period_end: true })
+    .where(
+      and(
+        eq(coding_plan_subscriptions.id, subscriptionId),
+        eq(coding_plan_subscriptions.status, 'active')
+      )
+    );
+  if ((result.rowCount ?? 0) === 0) {
+    throw new Error('No active subscription found.');
+  }
+  logInfo('Coding plan admin cancellation scheduled', { subscriptionId });
+}
+
+export async function extendCodingPlanSubscriptionPeriod(
+  subscriptionId: string,
+  days: number,
+  adminUserId: string
+): Promise<{ currentPeriodEnd: string; creditRenewalAt: string }> {
+  const result = await db.transaction(async tx => {
+    const { rows: lockedRows } = await tx.execute<{
+      id: string;
+      user_id: string;
+      plan_id: string;
+      current_period_end: string;
+    }>(sql`
+      SELECT id, user_id, plan_id, current_period_end
+      FROM coding_plan_subscriptions
+      WHERE id = ${subscriptionId}
+        AND status = 'active'
+      FOR UPDATE
+    `);
+    const locked = lockedRows[0];
+    if (!locked) {
+      throw new Error('No active subscription found.');
+    }
+
+    const [updated] = await tx
+      .update(coding_plan_subscriptions)
+      .set({
+        current_period_end: sql`${coding_plan_subscriptions.current_period_end} + make_interval(days => ${days})`,
+        credit_renewal_at: sql`${coding_plan_subscriptions.credit_renewal_at} + make_interval(days => ${days})`,
+      })
+      .where(
+        and(
+          eq(coding_plan_subscriptions.id, subscriptionId),
+          eq(coding_plan_subscriptions.status, 'active')
+        )
+      )
+      .returning({
+        currentPeriodEnd: coding_plan_subscriptions.current_period_end,
+        creditRenewalAt: coding_plan_subscriptions.credit_renewal_at,
+      });
+    if (!updated) {
+      throw new Error('No active subscription found.');
+    }
+
+    const transactionId = crypto.randomUUID();
+    const occurredAt = new Date().toISOString();
+    const description = `Coding plan extension: ${days} additional day${days === 1 ? '' : 's'}`;
+    await tx.insert(credit_transactions).values({
+      id: transactionId,
+      kilo_user_id: locked.user_id,
+      amount_microdollars: 0,
+      is_free: true,
+      description,
+      credit_category: `coding-plan:extension:${subscriptionId}:${transactionId}`,
+      created_by_kilo_user_id: adminUserId,
+      created_at: occurredAt,
+    });
+    await tx.insert(coding_plan_terms).values({
+      subscription_id: subscriptionId,
+      user_id: locked.user_id,
+      plan_id: locked.plan_id,
+      kind: 'extension',
+      idempotency_key: `extension:${subscriptionId}:${transactionId}`,
+      period_start: locked.current_period_end,
+      period_end: updated.currentPeriodEnd,
+      cost_microdollars: 0,
+      credit_transaction_id: transactionId,
+      created_at: occurredAt,
+    });
+
+    return {
+      currentPeriodEnd: new Date(updated.currentPeriodEnd).toISOString(),
+      creditRenewalAt: new Date(updated.creditRenewalAt).toISOString(),
+    };
+  });
+
+  logInfo('Coding plan subscription period extended', { subscriptionId, days, adminUserId });
+  return result;
+}
+
+type InventoryReplacementOptions = {
+  validateCredential?: InventoryCredentialValidator;
+};
+
+export async function replaceInventoryCredential(
+  inventoryKeyId: string,
+  apiKey: string,
+  options: InventoryReplacementOptions = {}
+): Promise<void> {
+  if (!BYOK_ENCRYPTION_KEY) {
+    throw inventoryReplacementError('BYOK encryption is not configured');
+  }
+
+  const [credential] = await db
+    .select({
+      planId: coding_plan_key_inventory.plan_id,
+      providerId: coding_plan_key_inventory.provider_id,
+      upstreamPlanId: coding_plan_key_inventory.upstream_plan_id,
+      upstreamUsageId: coding_plan_key_inventory.upstream_usage_id,
+      credentialFingerprint: coding_plan_key_inventory.credential_fingerprint,
+      status: coding_plan_key_inventory.status,
+    })
+    .from(coding_plan_key_inventory)
+    .where(
+      and(
+        eq(coding_plan_key_inventory.id, inventoryKeyId),
+        inArray(coding_plan_key_inventory.status, ['available', 'assigned'])
+      )
+    )
+    .limit(1);
+  if (!credential) {
+    throw inventoryReplacementError('Credential is not eligible for replacement.');
+  }
+  if (!isCodingPlanId(credential.planId)) {
+    throw inventoryReplacementError('Credential has an unsupported Coding Plan ID.');
+  }
+  const plan = getCodingPlanPrice(credential.planId);
+  if (!plan || plan.providerId !== credential.providerId) {
+    throw inventoryReplacementError('Credential has an unsupported Coding Plan provider.');
+  }
+  const normalizedApiKey = apiKey.trim();
+  if (!normalizedApiKey) {
+    throw inventoryReplacementError(`A replacement ${plan.providerName} API key is required.`);
+  }
+  const replacementFingerprint = codingPlanCredentialFingerprint(normalizedApiKey);
+  if (replacementFingerprint === credential.credentialFingerprint) {
+    throw inventoryReplacementError(
+      `Replacement ${plan.providerName} credential must be different from the current credential.`
+    );
+  }
+
+  const [duplicateCredential] = await db
+    .select({ id: coding_plan_key_inventory.id })
+    .from(coding_plan_key_inventory)
+    .where(
+      and(
+        eq(coding_plan_key_inventory.credential_fingerprint, replacementFingerprint),
+        ne(coding_plan_key_inventory.id, inventoryKeyId)
+      )
+    )
+    .limit(1);
+  if (duplicateCredential) {
+    throw inventoryReplacementError(
+      `Replacement ${plan.providerName} credential is already present in inventory.`
+    );
+  }
+
+  const validateCredential = options.validateCredential ?? validateCodingPlanCredential;
+  const validationResult = getCodingPlanValidationResult(
+    await validateCredential({
+      apiKey: normalizedApiKey,
+      planId: credential.planId,
+      providerId: plan.providerId,
+      upstreamPlanId: credential.upstreamPlanId,
+    })
+  );
+  if (
+    !validationResult.valid ||
+    (plan.providerId === 'byteplus-coding' && !validationResult.upstreamUsageId)
+  ) {
+    throw inventoryReplacementError(
+      `Replacement ${plan.providerName} credential failed validation. Confirm plan access and supported model behavior, then try again.`
+    );
+  }
+
+  const encryptedApiKey = encryptApiKey(normalizedApiKey, BYOK_ENCRYPTION_KEY);
+  const nextUpstreamUsageId =
+    plan.providerId === 'byteplus-coding'
+      ? validationResult.upstreamUsageId
+      : credential.upstreamUsageId;
+
+  try {
+    await db.transaction(async tx => {
+      const { rows: lockedRows } = await tx.execute<{
+        plan_id: string;
+        provider_id: string;
+        upstream_plan_id: string;
+        credential_fingerprint: string;
+        status: string;
+      }>(sql`
+        SELECT plan_id, provider_id, upstream_plan_id, credential_fingerprint, status
+        FROM coding_plan_key_inventory
+        WHERE id = ${inventoryKeyId}
+        FOR UPDATE
+      `);
+      const locked = lockedRows[0];
+      if (!locked || (locked.status !== 'available' && locked.status !== 'assigned')) {
+        throw inventoryReplacementError('Credential is not eligible for replacement.');
+      }
+      if (
+        locked.plan_id !== credential.planId ||
+        locked.provider_id !== credential.providerId ||
+        locked.upstream_plan_id !== credential.upstreamPlanId ||
+        locked.credential_fingerprint !== credential.credentialFingerprint
+      ) {
+        throw inventoryReplacementError(
+          'Credential changed during replacement. Refresh and try again.'
+        );
+      }
+
+      const result = await tx
+        .update(coding_plan_key_inventory)
+        .set({
+          encrypted_api_key: encryptedApiKey,
+          credential_fingerprint: replacementFingerprint,
+          upstream_usage_id: nextUpstreamUsageId,
+        })
+        .where(
+          and(
+            eq(coding_plan_key_inventory.id, inventoryKeyId),
+            eq(coding_plan_key_inventory.plan_id, credential.planId),
+            eq(coding_plan_key_inventory.provider_id, credential.providerId),
+            eq(coding_plan_key_inventory.upstream_plan_id, credential.upstreamPlanId),
+            eq(coding_plan_key_inventory.credential_fingerprint, credential.credentialFingerprint),
+            inArray(coding_plan_key_inventory.status, ['available', 'assigned'])
+          )
+        );
+      if ((result.rowCount ?? 0) === 0) {
+        throw inventoryReplacementError('Credential is not eligible for replacement.');
+      }
+
+      if (locked.status === 'assigned') {
+        const liveInstalledKeys = await tx
+          .select({ id: coding_plan_subscriptions.installed_byok_key_id })
+          .from(coding_plan_subscriptions)
+          .where(
+            and(
+              eq(coding_plan_subscriptions.key_inventory_id, inventoryKeyId),
+              isNotNull(coding_plan_subscriptions.installed_byok_key_id),
+              inArray(coding_plan_subscriptions.status, ['active', 'past_due'])
+            )
+          );
+        const installedKeyIds = liveInstalledKeys.flatMap(row => (row.id ? [row.id] : []));
+        if (installedKeyIds.length > 0) {
+          await tx
+            .update(byok_api_keys)
+            .set({ encrypted_api_key: encryptedApiKey })
+            .where(
+              and(
+                eq(byok_api_keys.management_source, 'coding_plan'),
+                inArray(byok_api_keys.id, installedKeyIds)
+              )
+            );
+        }
+      }
+    });
+  } catch (error) {
+    if (error instanceof CodingPlanInventoryReplacementError) throw error;
+    if (databaseConstraint(error) === 'UQ_coding_plan_key_inv_provider_usage_id') {
+      throw inventoryReplacementError(
+        'The resolved BytePlus seat is already attached to inventory.'
+      );
+    }
+    throw inventoryReplacementError('Unable to replace the credential due to a database error.');
+  }
+
+  logInfo('Coding plan inventory credential replaced', {
+    inventoryKeyId,
+    planId: credential.planId,
+  });
 }

--- a/apps/web/src/routers/coding-plans-router.test.ts
+++ b/apps/web/src/routers/coding-plans-router.test.ts
@@ -1367,7 +1367,14 @@ describe('coding plans router', () => {
       code: 'PRECONDITION_FAILED',
       message: 'Credential is not eligible for replacement.',
     });
-    expect(duplicate.status).toBe('available');
+    const [unchangedDuplicate] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, duplicate.id));
+    expect(unchangedDuplicate).toMatchObject({
+      status: 'available',
+      credential_fingerprint: codingPlanCredentialFingerprint('already-present-key'),
+    });
   });
 
   it('rejects inventory replacement after the stored credential identity changes', async () => {

--- a/apps/web/src/routers/coding-plans-router.test.ts
+++ b/apps/web/src/routers/coding-plans-router.test.ts
@@ -1,11 +1,13 @@
 /* eslint-disable drizzle/enforce-delete-with-where */
 import { generateText } from 'ai';
 import { eq } from 'drizzle-orm';
-import { encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
+import { decryptApiKey, encryptApiKey } from '@/lib/ai-gateway/byok/encryption';
+import { codingPlanCredentialFingerprint } from '@/lib/coding-plans/credential-fingerprint';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
 import { db } from '@/lib/drizzle';
 import { uploadKeysToInventory } from '@/lib/coding-plans';
 import { getBytePlusUsage } from '@/lib/coding-plans/byteplus-usage';
+import { CODING_PLAN_IDS } from '@/lib/coding-plans/pricing';
 import { redisClient } from '@/lib/redis';
 import { createCallerForUser } from '@/routers/test-utils';
 import { insertTestUser } from '@/tests/helpers/user.helper';
@@ -54,6 +56,65 @@ const mockedRedisDel = jest.mocked(redisClient.del);
 
 function inventoryEntry(key: string, upstreamPlanId = `minimax-plan-${crypto.randomUUID()}`) {
   return `${key}::${upstreamPlanId}`;
+}
+
+async function insertInventory(
+  overrides: Partial<typeof coding_plan_key_inventory.$inferInsert> = {}
+) {
+  const [row] = await db
+    .insert(coding_plan_key_inventory)
+    .values({
+      plan_id: PLAN_ID,
+      provider_id: 'minimax',
+      upstream_plan_id: `minimax-plan-${crypto.randomUUID()}`,
+      encrypted_api_key: encryptApiKey('old-secret', BYOK_ENCRYPTION_KEY),
+      credential_fingerprint: crypto.randomUUID(),
+      status: 'available',
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+function emptyInsightPlan(planId: string) {
+  return {
+    planId,
+    liveSubscriptions: 0,
+    monthlyRecurringValueKiloCredits: 0,
+    createdInRange: 0,
+    canceledInRange: 0,
+    currentWaitersJoinedInRange: 0,
+    currentWaitlistTotal: 0,
+  };
+}
+
+function catalogInsightPlans(
+  overrides: Partial<
+    Record<(typeof CODING_PLAN_IDS)[number], Partial<ReturnType<typeof emptyInsightPlan>>>
+  > = {}
+) {
+  return CODING_PLAN_IDS.map(planId => ({
+    ...emptyInsightPlan(planId),
+    ...overrides[planId],
+  }));
+}
+
+function subscriptionValues(
+  userId: string,
+  overrides: Partial<typeof coding_plan_subscriptions.$inferInsert> = {}
+) {
+  return {
+    user_id: userId,
+    plan_id: PLAN_ID,
+    provider_id: 'minimax',
+    status: 'canceled' as const,
+    cost_microdollars: COST_MICRODOLLARS,
+    billing_period_days: 30,
+    current_period_start: '2026-06-20T12:00:00.000Z',
+    current_period_end: '2026-07-20T12:00:00.000Z',
+    credit_renewal_at: '2026-07-20T12:00:00.000Z',
+    ...overrides,
+  };
 }
 
 function usageResponse() {
@@ -989,5 +1050,575 @@ describe('coding plans router', () => {
         subscriptionExpiresAt: '2026-08-15T12:00:00.000Z',
       }),
     ]);
+  });
+
+  it('paginates admin subscriptions 20 per page with totals', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const users = await Promise.all(Array.from({ length: 23 }, () => insertTestUser()));
+    await db.insert(coding_plan_subscriptions).values(
+      users.map((user, index) =>
+        subscriptionValues(user.id, {
+          created_at: new Date(Date.UTC(2026, 0, 1, 0, 0, index)).toISOString(),
+        })
+      )
+    );
+    const caller = await createCallerForUser(admin.id);
+
+    const firstPage = await caller.codingPlans.adminListSubscriptions({ page: 1 });
+    expect(firstPage.items).toHaveLength(20);
+    expect(firstPage.pagination).toEqual({ page: 1, total: 23, totalPages: 2 });
+
+    const secondPage = await caller.codingPlans.adminListSubscriptions({ page: 2 });
+    expect(secondPage.items).toHaveLength(3);
+    expect(secondPage.pagination).toEqual({ page: 2, total: 23, totalPages: 2 });
+  });
+
+  it('searches admin subscriptions by user id and email substring', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const emailUser = await insertTestUser({
+      google_user_email: 'unique-search-target@example.com',
+      normalized_email: 'unique-search-target@example.com',
+    });
+    const idUser = await insertTestUser({ id: 'searchable-user-id-42' });
+    const otherUser = await insertTestUser();
+    await db
+      .insert(coding_plan_subscriptions)
+      .values([
+        subscriptionValues(emailUser.id),
+        subscriptionValues(idUser.id),
+        subscriptionValues(otherUser.id),
+      ]);
+    const caller = await createCallerForUser(admin.id);
+
+    const emailMatches = await caller.codingPlans.adminListSubscriptions({
+      search: 'unique-search-target',
+    });
+    expect(emailMatches.items).toEqual([
+      expect.objectContaining({
+        userId: emailUser.id,
+        userEmail: 'unique-search-target@example.com',
+      }),
+    ]);
+
+    const idMatches = await caller.codingPlans.adminListSubscriptions({
+      search: 'searchable-user-id',
+    });
+    expect(idMatches.items).toEqual([expect.objectContaining({ userId: idUser.id })]);
+  });
+
+  it('filters admin subscriptions by display status', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const activeUser = await insertTestUser();
+    const pendingUser = await insertTestUser();
+    const activeInventory = await insertInventory({ status: 'assigned' });
+    const pendingInventory = await insertInventory({ status: 'assigned' });
+    await db.insert(coding_plan_subscriptions).values([
+      subscriptionValues(activeUser.id, {
+        key_inventory_id: activeInventory.id,
+        status: 'active',
+        cancel_at_period_end: false,
+      }),
+      subscriptionValues(pendingUser.id, {
+        key_inventory_id: pendingInventory.id,
+        status: 'active',
+        cancel_at_period_end: true,
+      }),
+    ]);
+    const caller = await createCallerForUser(admin.id);
+
+    const active = await caller.codingPlans.adminListSubscriptions({ status: 'active' });
+    expect(active.items).toEqual([expect.objectContaining({ userId: activeUser.id })]);
+
+    const pending = await caller.codingPlans.adminListSubscriptions({
+      status: 'pending_cancellation',
+    });
+    expect(pending.items).toEqual([expect.objectContaining({ userId: pendingUser.id })]);
+  });
+
+  it('schedules admin cancellation at period end and rejects canceled subscriptions', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const user = await insertTestUser();
+    const inventory = await insertInventory({ status: 'assigned' });
+    const [active] = await db
+      .insert(coding_plan_subscriptions)
+      .values(
+        subscriptionValues(user.id, {
+          key_inventory_id: inventory.id,
+          status: 'active',
+        })
+      )
+      .returning();
+    const [canceled] = await db
+      .insert(coding_plan_subscriptions)
+      .values(
+        subscriptionValues(user.id, {
+          plan_id: MAX_PLAN_ID,
+          status: 'canceled',
+          canceled_at: '2026-07-20T12:00:00.000Z',
+          cancellation_reason: 'user_cancelled',
+        })
+      )
+      .returning();
+    const caller = await createCallerForUser(admin.id);
+
+    await caller.codingPlans.adminCancelSubscription({ subscriptionId: active.id });
+    const [updated] = await db
+      .select()
+      .from(coding_plan_subscriptions)
+      .where(eq(coding_plan_subscriptions.id, active.id));
+    expect(updated.cancel_at_period_end).toBe(true);
+    expect(updated.status).toBe('active');
+
+    await expect(
+      caller.codingPlans.adminCancelSubscription({ subscriptionId: canceled.id })
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'No active subscription found.',
+    });
+  });
+
+  it('extends an active subscription period and rejects canceled or invalid days', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const user = await insertTestUser();
+    const inventory = await insertInventory({ status: 'assigned' });
+    const [active] = await db
+      .insert(coding_plan_subscriptions)
+      .values(
+        subscriptionValues(user.id, {
+          key_inventory_id: inventory.id,
+          status: 'active',
+          current_period_end: '2026-07-20T12:00:00.000Z',
+          credit_renewal_at: '2026-07-20T12:00:00.000Z',
+        })
+      )
+      .returning();
+    const [canceled] = await db
+      .insert(coding_plan_subscriptions)
+      .values(
+        subscriptionValues(user.id, {
+          plan_id: MAX_PLAN_ID,
+          status: 'canceled',
+          canceled_at: '2026-07-20T12:00:00.000Z',
+          cancellation_reason: 'user_cancelled',
+        })
+      )
+      .returning();
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(
+      caller.codingPlans.adminExtendSubscriptionPeriod({
+        subscriptionId: active.id,
+        days: 7,
+      })
+    ).resolves.toEqual({
+      currentPeriodEnd: '2026-07-27T12:00:00.000Z',
+      creditRenewalAt: '2026-07-27T12:00:00.000Z',
+    });
+
+    const [extensionTerm] = await db
+      .select()
+      .from(coding_plan_terms)
+      .where(eq(coding_plan_terms.subscription_id, active.id));
+    expect(extensionTerm).toMatchObject({
+      user_id: user.id,
+      plan_id: PLAN_ID,
+      kind: 'extension',
+      cost_microdollars: 0,
+    });
+    expect(new Date(extensionTerm.period_start).toISOString()).toBe('2026-07-20T12:00:00.000Z');
+    expect(new Date(extensionTerm.period_end).toISOString()).toBe('2026-07-27T12:00:00.000Z');
+    const [extensionTransaction] = await db
+      .select()
+      .from(credit_transactions)
+      .where(eq(credit_transactions.id, extensionTerm.credit_transaction_id));
+    expect(extensionTransaction).toMatchObject({
+      kilo_user_id: user.id,
+      amount_microdollars: 0,
+      is_free: true,
+      created_by_kilo_user_id: admin.id,
+      description: 'Coding plan extension: 7 additional days',
+    });
+
+    await expect(
+      caller.codingPlans.adminExtendSubscriptionPeriod({
+        subscriptionId: canceled.id,
+        days: 7,
+      })
+    ).rejects.toMatchObject({
+      code: 'NOT_FOUND',
+      message: 'No active subscription found.',
+    });
+    await expect(
+      caller.codingPlans.adminExtendSubscriptionPeriod({
+        subscriptionId: active.id,
+        days: 0,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+    await expect(
+      caller.codingPlans.adminExtendSubscriptionPeriod({
+        subscriptionId: active.id,
+        days: 91,
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+  });
+
+  it('replaces available and assigned inventory credentials and rejects ineligible keys', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const user = await insertTestUser();
+    const available = await insertInventory({
+      encrypted_api_key: encryptApiKey('old-secret', BYOK_ENCRYPTION_KEY),
+      credential_fingerprint: codingPlanCredentialFingerprint('old-secret'),
+    });
+    const assigned = await insertInventory({
+      encrypted_api_key: encryptApiKey('assigned-old-secret', BYOK_ENCRYPTION_KEY),
+      credential_fingerprint: codingPlanCredentialFingerprint('assigned-old-secret'),
+      status: 'assigned',
+      assigned_to_user_id: user.id,
+    });
+    const [installedByok] = await db
+      .insert(byok_api_keys)
+      .values({
+        kilo_user_id: user.id,
+        organization_id: null,
+        provider_id: 'minimax',
+        encrypted_api_key: encryptApiKey('assigned-old-secret', BYOK_ENCRYPTION_KEY),
+        management_source: 'coding_plan',
+        created_by: user.id,
+      })
+      .returning();
+    await db.insert(coding_plan_subscriptions).values(
+      subscriptionValues(user.id, {
+        key_inventory_id: assigned.id,
+        installed_byok_key_id: installedByok.id,
+        status: 'active',
+      })
+    );
+    const duplicate = await insertInventory({
+      encrypted_api_key: encryptApiKey('already-present-key', BYOK_ENCRYPTION_KEY),
+      credential_fingerprint: codingPlanCredentialFingerprint('already-present-key'),
+    });
+    const pending = await insertInventory({ status: 'revocation_pending' });
+    const caller = await createCallerForUser(admin.id);
+
+    mockedGenerateText.mockResolvedValueOnce({ finishReason: 'stop' } as never);
+    await caller.codingPlans.adminReplaceInventoryCredential({
+      inventoryKeyId: available.id,
+      apiKey: 'available-replacement-key',
+    });
+    const [replacedAvailable] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, available.id));
+    expect(replacedAvailable.status).toBe('available');
+    expect(replacedAvailable.credential_fingerprint).toBe(
+      codingPlanCredentialFingerprint('available-replacement-key')
+    );
+    expect(replacedAvailable.encrypted_api_key).not.toBeNull();
+    expect(decryptApiKey(replacedAvailable.encrypted_api_key!, BYOK_ENCRYPTION_KEY)).toBe(
+      'available-replacement-key'
+    );
+
+    mockedGenerateText.mockResolvedValueOnce({ finishReason: 'stop' } as never);
+    await caller.codingPlans.adminReplaceInventoryCredential({
+      inventoryKeyId: assigned.id,
+      apiKey: 'assigned-replacement-key',
+    });
+    const [replacedAssigned] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, assigned.id));
+    const [replacedByok] = await db
+      .select()
+      .from(byok_api_keys)
+      .where(eq(byok_api_keys.id, installedByok.id));
+    expect(replacedAssigned.status).toBe('assigned');
+    expect(replacedAssigned.encrypted_api_key).not.toBeNull();
+    expect(decryptApiKey(replacedAssigned.encrypted_api_key!, BYOK_ENCRYPTION_KEY)).toBe(
+      'assigned-replacement-key'
+    );
+    expect(decryptApiKey(replacedByok.encrypted_api_key, BYOK_ENCRYPTION_KEY)).toBe(
+      'assigned-replacement-key'
+    );
+
+    await expect(
+      caller.codingPlans.adminReplaceInventoryCredential({
+        inventoryKeyId: available.id,
+        apiKey: 'available-replacement-key',
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: expect.stringContaining('must be different from the current credential'),
+    });
+    await expect(
+      caller.codingPlans.adminReplaceInventoryCredential({
+        inventoryKeyId: available.id,
+        apiKey: 'already-present-key',
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: expect.stringContaining('already present in inventory'),
+    });
+    await expect(
+      caller.codingPlans.adminReplaceInventoryCredential({
+        inventoryKeyId: pending.id,
+        apiKey: 'pending-replacement-key',
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Credential is not eligible for replacement.',
+    });
+    expect(duplicate.status).toBe('available');
+  });
+
+  it('rejects inventory replacement after the stored credential identity changes', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const available = await insertInventory({
+      encrypted_api_key: encryptApiKey('first-secret', BYOK_ENCRYPTION_KEY),
+      credential_fingerprint: codingPlanCredentialFingerprint('first-secret'),
+    });
+    const caller = await createCallerForUser(admin.id);
+    let resolveValidation: (() => void) | undefined;
+    const validationGate = new Promise<void>(resolve => {
+      resolveValidation = resolve;
+    });
+    mockedGenerateText.mockImplementationOnce(async () => {
+      await db
+        .update(coding_plan_key_inventory)
+        .set({
+          credential_fingerprint: codingPlanCredentialFingerprint('changed-secret'),
+          encrypted_api_key: encryptApiKey('changed-secret', BYOK_ENCRYPTION_KEY),
+        })
+        .where(eq(coding_plan_key_inventory.id, available.id));
+      resolveValidation?.();
+      return { finishReason: 'stop' } as never;
+    });
+
+    const replacement = caller.codingPlans.adminReplaceInventoryCredential({
+      inventoryKeyId: available.id,
+      apiKey: 'next-secret',
+    });
+    await validationGate;
+    await expect(replacement).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Credential changed during replacement. Refresh and try again.',
+    });
+    const [unchanged] = await db
+      .select()
+      .from(coding_plan_key_inventory)
+      .where(eq(coding_plan_key_inventory.id, available.id));
+    expect(unchanged.credential_fingerprint).toBe(
+      codingPlanCredentialFingerprint('changed-secret')
+    );
+    expect(decryptApiKey(unchanged.encrypted_api_key!, BYOK_ENCRYPTION_KEY)).toBe('changed-secret');
+  });
+
+  it('returns bounded subscription summary and selectable-range insight aggregates', async () => {
+    const admin = await insertTestUser({ is_admin: true });
+    const activeUser = await insertTestUser();
+    const retainedUser = await insertTestUser();
+    const pendingUser = await insertTestUser();
+    const pastDueUser = await insertTestUser();
+    const canceledUser = await insertTestUser();
+    const resolvedUser = await insertTestUser();
+    const byteplusUser = await insertTestUser();
+    const byteplusWaiter = await insertTestUser();
+    const historicalUser = await insertTestUser();
+    const daysAgo = (days: number) =>
+      new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+    const activeInventory = await insertInventory();
+    const retainedInventory = await insertInventory();
+    const pendingInventory = await insertInventory();
+    const pastDueInventory = await insertInventory();
+    const byteplusInventory = await insertInventory({
+      plan_id: BYTEPLUS_PLAN_ID,
+      provider_id: 'byteplus-coding',
+    });
+    await db.insert(coding_plan_subscriptions).values([
+      subscriptionValues(activeUser.id, {
+        status: 'active',
+        key_inventory_id: activeInventory.id,
+        created_at: daysAgo(3),
+      }),
+      subscriptionValues(retainedUser.id, {
+        status: 'active',
+        key_inventory_id: retainedInventory.id,
+        created_at: daysAgo(15),
+      }),
+      subscriptionValues(pendingUser.id, {
+        status: 'active',
+        cancel_at_period_end: true,
+        key_inventory_id: pendingInventory.id,
+        created_at: daysAgo(10),
+      }),
+      subscriptionValues(pastDueUser.id, {
+        status: 'past_due',
+        key_inventory_id: pastDueInventory.id,
+        created_at: daysAgo(40),
+      }),
+      subscriptionValues(canceledUser.id, {
+        created_at: daysAgo(45),
+        canceled_at: daysAgo(5),
+        cancellation_reason: 'user_cancelled',
+      }),
+      subscriptionValues(byteplusUser.id, {
+        plan_id: BYTEPLUS_PLAN_ID,
+        provider_id: 'byteplus-coding',
+        status: 'active',
+        key_inventory_id: byteplusInventory.id,
+        created_at: daysAgo(2),
+      }),
+      subscriptionValues(historicalUser.id, {
+        plan_id: 'legacy-unknown-plan',
+        provider_id: 'legacy-provider',
+        created_at: daysAgo(3),
+        canceled_at: daysAgo(2),
+        cancellation_reason: 'user_cancelled',
+      }),
+    ]);
+    await db.insert(coding_plan_availability_intents).values([
+      {
+        user_id: canceledUser.id,
+        plan_id: PLAN_ID,
+        created_at: daysAgo(4),
+      },
+      {
+        user_id: pendingUser.id,
+        plan_id: PLAN_ID,
+        created_at: daysAgo(10),
+      },
+      {
+        user_id: resolvedUser.id,
+        plan_id: PLAN_ID,
+        created_at: daysAgo(12),
+      },
+      {
+        user_id: byteplusWaiter.id,
+        plan_id: BYTEPLUS_PLAN_ID,
+        created_at: daysAgo(1),
+      },
+      {
+        user_id: historicalUser.id,
+        plan_id: 'legacy-unknown-plan',
+        created_at: daysAgo(1),
+      },
+    ]);
+    await db.insert(credit_transactions).values({
+      kilo_user_id: resolvedUser.id,
+      amount_microdollars: -COST_MICRODOLLARS,
+      is_free: false,
+      description: 'Coding plan activation',
+    });
+    const [activationTransaction] = await db
+      .select({ id: credit_transactions.id })
+      .from(credit_transactions)
+      .where(eq(credit_transactions.kilo_user_id, resolvedUser.id));
+    const [resolvedSubscription] = await db
+      .insert(coding_plan_subscriptions)
+      .values(
+        subscriptionValues(resolvedUser.id, {
+          created_at: daysAgo(11),
+          canceled_at: daysAgo(11),
+          cancellation_reason: 'user_cancelled',
+        })
+      )
+      .returning();
+    await db.insert(coding_plan_terms).values({
+      subscription_id: resolvedSubscription.id,
+      user_id: resolvedUser.id,
+      plan_id: PLAN_ID,
+      kind: 'activation',
+      idempotency_key: `activation:${resolvedUser.id}`,
+      period_start: daysAgo(11),
+      period_end: daysAgo(-19),
+      cost_microdollars: COST_MICRODOLLARS,
+      credit_transaction_id: activationTransaction.id,
+      created_at: daysAgo(11),
+    });
+    const caller = await createCallerForUser(admin.id);
+
+    await expect(caller.codingPlans.adminSubscriptionOverview()).resolves.toEqual({
+      total: 8,
+      active: 3,
+      pendingCancellation: 1,
+      pastDue: 1,
+    });
+    const sevenDayInsights = await caller.codingPlans.adminInsights({ rangeDays: 7 });
+    expect(sevenDayInsights.plans).toHaveLength(CODING_PLAN_IDS.length);
+    expect(sevenDayInsights.plans.map(plan => plan.planId)).toEqual([...CODING_PLAN_IDS]);
+    expect(sevenDayInsights).toEqual({
+      rangeDays: 7,
+      totals: {
+        liveSubscriptions: 5,
+        pendingCancellation: 1,
+        pastDue: 1,
+        mrrKiloCredits: 100,
+        revenueAtRiskKiloCredits: 40,
+        pastDueMrrKiloCredits: 20,
+        createdInRange: 2,
+        createdInPriorRange: 2,
+        canceledInRange: 1,
+        liveAtRangeStart: 4,
+        retainedFromRangeStart: 3,
+        currentWaitersJoinedInRange: 2,
+        currentWaitersJoinedInPriorRange: 1,
+        currentWaitlistTotal: 3,
+      },
+      plans: catalogInsightPlans({
+        [PLAN_ID]: {
+          liveSubscriptions: 4,
+          monthlyRecurringValueKiloCredits: 80,
+          createdInRange: 1,
+          canceledInRange: 1,
+          currentWaitersJoinedInRange: 1,
+          currentWaitlistTotal: 2,
+        },
+        [BYTEPLUS_PLAN_ID]: {
+          liveSubscriptions: 1,
+          monthlyRecurringValueKiloCredits: 20,
+          createdInRange: 1,
+          currentWaitersJoinedInRange: 1,
+          currentWaitlistTotal: 1,
+        },
+      }),
+    });
+    await expect(caller.codingPlans.adminInsights({ rangeDays: 14 })).resolves.toMatchObject({
+      rangeDays: 14,
+      totals: {
+        createdInRange: 4,
+        createdInPriorRange: 1,
+        canceledInRange: 2,
+        currentWaitersJoinedInRange: 3,
+        currentWaitersJoinedInPriorRange: 0,
+        currentWaitlistTotal: 3,
+      },
+      plans: catalogInsightPlans({
+        [PLAN_ID]: {
+          liveSubscriptions: 4,
+          monthlyRecurringValueKiloCredits: 80,
+          createdInRange: 3,
+          canceledInRange: 2,
+          currentWaitersJoinedInRange: 2,
+          currentWaitlistTotal: 2,
+        },
+        [BYTEPLUS_PLAN_ID]: {
+          liveSubscriptions: 1,
+          monthlyRecurringValueKiloCredits: 20,
+          createdInRange: 1,
+          currentWaitersJoinedInRange: 1,
+          currentWaitlistTotal: 1,
+        },
+      }),
+    });
+    await expect(caller.codingPlans.adminInsights({ rangeDays: 30 })).resolves.toMatchObject({
+      rangeDays: 30,
+      totals: {
+        createdInRange: 5,
+        createdInPriorRange: 2,
+        canceledInRange: 2,
+        currentWaitersJoinedInRange: 3,
+        currentWaitersJoinedInPriorRange: 0,
+        currentWaitlistTotal: 3,
+      },
+    });
   });
 });

--- a/apps/web/src/routers/coding-plans-router.ts
+++ b/apps/web/src/routers/coding-plans-router.ts
@@ -1,14 +1,18 @@
-import { and, desc, eq, sql } from 'drizzle-orm';
+import { and, count, desc, eq, ilike, or, sql, type SQL } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import * as z from 'zod';
 
 import {
+  adminCancelCodingPlanSubscription,
   cancelCodingPlanSubscription,
+  CodingPlanInventoryReplacementError,
   CodingPlanInventoryUploadError,
+  extendCodingPlanSubscriptionPeriod,
   getAvailableCodingPlanIds,
   getCodingPlanAvailabilityIntentCounts,
   getCodingPlanAvailabilityIntentPlanIds,
   getKeyInventoryCounts,
+  replaceInventoryCredential,
   requestCodingPlanAvailabilityNotification,
   subscribeToCodingPlan,
   terminateCodingPlanImmediately,
@@ -55,6 +59,28 @@ const BillingHistoryInputSchema = z.object({
   subscriptionId: SubscriptionIdSchema,
   cursor: z.string().optional(),
 });
+const ADMIN_SUBSCRIPTION_PAGE_SIZE = 20;
+const AdminSubscriptionDisplayStatusSchema = z.enum([
+  'active',
+  'pending_cancellation',
+  'past_due',
+  'canceled',
+]);
+const AdminListSubscriptionsInputSchema = z.object({
+  page: z.number().int().min(1).max(10_000).default(1),
+  search: z
+    .string()
+    .trim()
+    .max(200)
+    .optional()
+    .transform(value => (value && value.length > 0 ? value : undefined)),
+  status: AdminSubscriptionDisplayStatusSchema.optional(),
+});
+const AdminInsightsRangeDaysSchema = z.union([z.literal(7), z.literal(14), z.literal(30)]);
+const AdminInsightsInputSchema = z.object({
+  rangeDays: AdminInsightsRangeDaysSchema.default(7),
+});
+
 const CodingPlanUsageOutputSchema = z.object({
   schemaVersion: z.literal(1),
   fetchedAt: z.iso.datetime(),
@@ -177,6 +203,359 @@ function toCodingPlanSubscriptionView(subscription: CodingPlanSubscriptionRow) {
   };
 }
 
+function adminSubscriptionSearchFilter(search: string | undefined): SQL | undefined {
+  if (!search) return undefined;
+  const pattern = `%${search}%`;
+  return or(
+    ilike(kilocode_users.id, pattern),
+    ilike(kilocode_users.google_user_email, pattern),
+    ilike(kilocode_users.normalized_email, pattern)
+  );
+}
+
+function toNumericCount(value: string | number | null | undefined): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') return Number.parseInt(value, 10) || 0;
+  return 0;
+}
+
+function toNumericCredits(value: string | number | null | undefined): number {
+  if (typeof value === 'number') return value;
+  if (typeof value === 'string') return Number.parseFloat(value) || 0;
+  return 0;
+}
+
+async function getAdminSubscriptionSummary() {
+  const { rows } = await db.execute<{
+    total: string;
+    active: string;
+    pending_cancellation: string;
+    past_due: string;
+  }>(sql`
+    SELECT
+      COUNT(*)::int AS total,
+      COUNT(*) FILTER (
+        WHERE status = 'active' AND cancel_at_period_end = false
+      )::int AS active,
+      COUNT(*) FILTER (
+        WHERE status = 'active' AND cancel_at_period_end = true
+      )::int AS pending_cancellation,
+      COUNT(*) FILTER (WHERE status = 'past_due')::int AS past_due
+    FROM coding_plan_subscriptions
+  `);
+  const summary = rows[0];
+  return {
+    total: toNumericCount(summary?.total),
+    active: toNumericCount(summary?.active),
+    pendingCancellation: toNumericCount(summary?.pending_cancellation),
+    pastDue: toNumericCount(summary?.past_due),
+  };
+}
+
+type AdminInsightPlanRow = {
+  planId: (typeof CODING_PLAN_IDS)[number];
+  liveSubscriptions: number;
+  pendingCancellation: number;
+  pastDue: number;
+  monthlyRecurringValueKiloCredits: number;
+  revenueAtRiskKiloCredits: number;
+  pastDueMrrKiloCredits: number;
+  createdInRange: number;
+  createdInPriorRange: number;
+  canceledInRange: number;
+  liveAtRangeStart: number;
+  retainedFromRangeStart: number;
+  currentWaitersJoinedInRange: number;
+  currentWaitersJoinedInPriorRange: number;
+  currentWaitlistTotal: number;
+};
+
+function emptyAdminInsightPlanRow(planId: (typeof CODING_PLAN_IDS)[number]): AdminInsightPlanRow {
+  return {
+    planId,
+    liveSubscriptions: 0,
+    pendingCancellation: 0,
+    pastDue: 0,
+    monthlyRecurringValueKiloCredits: 0,
+    revenueAtRiskKiloCredits: 0,
+    pastDueMrrKiloCredits: 0,
+    createdInRange: 0,
+    createdInPriorRange: 0,
+    canceledInRange: 0,
+    liveAtRangeStart: 0,
+    retainedFromRangeStart: 0,
+    currentWaitersJoinedInRange: 0,
+    currentWaitersJoinedInPriorRange: 0,
+    currentWaitlistTotal: 0,
+  };
+}
+
+function toPublicAdminInsightPlan(plan: AdminInsightPlanRow) {
+  return {
+    planId: plan.planId,
+    liveSubscriptions: plan.liveSubscriptions,
+    monthlyRecurringValueKiloCredits: plan.monthlyRecurringValueKiloCredits,
+    createdInRange: plan.createdInRange,
+    canceledInRange: plan.canceledInRange,
+    currentWaitersJoinedInRange: plan.currentWaitersJoinedInRange,
+    currentWaitlistTotal: plan.currentWaitlistTotal,
+  };
+}
+
+function sumAdminInsightTotals(plans: readonly AdminInsightPlanRow[]) {
+  return plans.reduce(
+    (totals, plan) => ({
+      liveSubscriptions: totals.liveSubscriptions + plan.liveSubscriptions,
+      pendingCancellation: totals.pendingCancellation + plan.pendingCancellation,
+      pastDue: totals.pastDue + plan.pastDue,
+      mrrKiloCredits: totals.mrrKiloCredits + plan.monthlyRecurringValueKiloCredits,
+      revenueAtRiskKiloCredits: totals.revenueAtRiskKiloCredits + plan.revenueAtRiskKiloCredits,
+      pastDueMrrKiloCredits: totals.pastDueMrrKiloCredits + plan.pastDueMrrKiloCredits,
+      createdInRange: totals.createdInRange + plan.createdInRange,
+      createdInPriorRange: totals.createdInPriorRange + plan.createdInPriorRange,
+      canceledInRange: totals.canceledInRange + plan.canceledInRange,
+      liveAtRangeStart: totals.liveAtRangeStart + plan.liveAtRangeStart,
+      retainedFromRangeStart: totals.retainedFromRangeStart + plan.retainedFromRangeStart,
+      currentWaitersJoinedInRange:
+        totals.currentWaitersJoinedInRange + plan.currentWaitersJoinedInRange,
+      currentWaitersJoinedInPriorRange:
+        totals.currentWaitersJoinedInPriorRange + plan.currentWaitersJoinedInPriorRange,
+      currentWaitlistTotal: totals.currentWaitlistTotal + plan.currentWaitlistTotal,
+    }),
+    {
+      liveSubscriptions: 0,
+      pendingCancellation: 0,
+      pastDue: 0,
+      mrrKiloCredits: 0,
+      revenueAtRiskKiloCredits: 0,
+      pastDueMrrKiloCredits: 0,
+      createdInRange: 0,
+      createdInPriorRange: 0,
+      canceledInRange: 0,
+      liveAtRangeStart: 0,
+      retainedFromRangeStart: 0,
+      currentWaitersJoinedInRange: 0,
+      currentWaitersJoinedInPriorRange: 0,
+      currentWaitlistTotal: 0,
+    }
+  );
+}
+
+async function getAdminInsights(rangeDays: 7 | 14 | 30) {
+  const catalogPlanValues = sql.join(
+    CODING_PLAN_IDS.map((planId, index) => sql`(${planId}, ${index + 1})`),
+    sql`, `
+  );
+  const catalogPlanIds = sql.join(
+    CODING_PLAN_IDS.map(planId => sql`${planId}`),
+    sql`, `
+  );
+  const { rows } = await db.execute<{
+    plan_id: string;
+    live_subscriptions: string;
+    pending_cancellation: string;
+    past_due: string;
+    monthly_recurring_value_kilo_credits: string;
+    revenue_at_risk_kilo_credits: string;
+    past_due_mrr_kilo_credits: string;
+    created_in_range: string;
+    created_in_prior_range: string;
+    canceled_in_range: string;
+    live_at_range_start: string;
+    retained_from_range_start: string;
+    current_waiters_joined_in_range: string;
+    current_waiters_joined_in_prior_range: string;
+    current_waitlist_total: string;
+  }>(sql`
+    WITH catalog_plans(plan_id, sort_order) AS (
+      SELECT * FROM (VALUES ${catalogPlanValues}) AS catalog(plan_id, sort_order)
+    ),
+    bounds AS (
+      SELECT
+        NOW() AS now_at,
+        NOW() - make_interval(days => ${rangeDays}) AS range_start,
+        NOW() - make_interval(days => ${rangeDays * 2}) AS prior_range_start
+    ),
+    subscription_metrics AS (
+      SELECT
+        subscriptions.plan_id,
+        COUNT(*) FILTER (
+          WHERE subscriptions.status IN ('active', 'past_due')
+        )::int AS live_subscriptions,
+        COUNT(*) FILTER (
+          WHERE subscriptions.status = 'active'
+            AND subscriptions.cancel_at_period_end = true
+        )::int AS pending_cancellation,
+        COUNT(*) FILTER (
+          WHERE subscriptions.status = 'past_due'
+        )::int AS past_due,
+        COALESCE(
+          SUM(
+            (subscriptions.cost_microdollars::numeric / 1000000)
+            * (30.0 / NULLIF(subscriptions.billing_period_days, 0))
+          ) FILTER (WHERE subscriptions.status IN ('active', 'past_due')),
+          0
+        ) AS monthly_recurring_value_kilo_credits,
+        COALESCE(
+          SUM(
+            (subscriptions.cost_microdollars::numeric / 1000000)
+            * (30.0 / NULLIF(subscriptions.billing_period_days, 0))
+          ) FILTER (
+            WHERE subscriptions.status = 'past_due'
+               OR (
+                 subscriptions.status = 'active'
+                 AND subscriptions.cancel_at_period_end = true
+               )
+          ),
+          0
+        ) AS revenue_at_risk_kilo_credits,
+        COALESCE(
+          SUM(
+            (subscriptions.cost_microdollars::numeric / 1000000)
+            * (30.0 / NULLIF(subscriptions.billing_period_days, 0))
+          ) FILTER (WHERE subscriptions.status = 'past_due'),
+          0
+        ) AS past_due_mrr_kilo_credits,
+        COUNT(*) FILTER (
+          WHERE subscriptions.created_at >= (SELECT range_start FROM bounds)
+            AND subscriptions.created_at < (SELECT now_at FROM bounds)
+        )::int AS created_in_range,
+        COUNT(*) FILTER (
+          WHERE subscriptions.created_at >= (SELECT prior_range_start FROM bounds)
+            AND subscriptions.created_at < (SELECT range_start FROM bounds)
+        )::int AS created_in_prior_range,
+        COUNT(*) FILTER (
+          WHERE subscriptions.status = 'canceled'
+            AND subscriptions.canceled_at IS NOT NULL
+            AND subscriptions.canceled_at >= (SELECT range_start FROM bounds)
+            AND subscriptions.canceled_at < (SELECT now_at FROM bounds)
+        )::int AS canceled_in_range,
+        COUNT(*) FILTER (
+          WHERE subscriptions.created_at < (SELECT range_start FROM bounds)
+            AND (
+              subscriptions.canceled_at IS NULL
+              OR subscriptions.canceled_at >= (SELECT range_start FROM bounds)
+            )
+        )::int AS live_at_range_start,
+        COUNT(*) FILTER (
+          WHERE subscriptions.created_at < (SELECT range_start FROM bounds)
+            AND (
+              subscriptions.canceled_at IS NULL
+              OR subscriptions.canceled_at >= (SELECT range_start FROM bounds)
+            )
+            AND subscriptions.status <> 'canceled'
+        )::int AS retained_from_range_start
+      FROM coding_plan_subscriptions AS subscriptions
+      WHERE subscriptions.plan_id IN (${catalogPlanIds})
+      GROUP BY subscriptions.plan_id
+    ),
+    current_waiters AS (
+      SELECT intents.plan_id, intents.created_at
+      FROM coding_plan_availability_intents AS intents
+      WHERE intents.plan_id IN (${catalogPlanIds})
+        AND NOT EXISTS (
+          SELECT 1
+          FROM coding_plan_terms AS terms
+          WHERE terms.user_id = intents.user_id
+            AND terms.plan_id = intents.plan_id
+            AND terms.kind = 'activation'
+            AND terms.created_at >= intents.created_at
+        )
+    ),
+    waiter_metrics AS (
+      SELECT
+        waiters.plan_id,
+        COUNT(*)::int AS current_waitlist_total,
+        COUNT(*) FILTER (
+          WHERE waiters.created_at >= (SELECT range_start FROM bounds)
+            AND waiters.created_at < (SELECT now_at FROM bounds)
+        )::int AS current_waiters_joined_in_range,
+        COUNT(*) FILTER (
+          WHERE waiters.created_at >= (SELECT prior_range_start FROM bounds)
+            AND waiters.created_at < (SELECT range_start FROM bounds)
+        )::int AS current_waiters_joined_in_prior_range
+      FROM current_waiters AS waiters
+      GROUP BY waiters.plan_id
+    )
+    SELECT
+      catalog.plan_id,
+      COALESCE(subscriptions.live_subscriptions, 0) AS live_subscriptions,
+      COALESCE(subscriptions.pending_cancellation, 0) AS pending_cancellation,
+      COALESCE(subscriptions.past_due, 0) AS past_due,
+      COALESCE(
+        subscriptions.monthly_recurring_value_kilo_credits,
+        0
+      ) AS monthly_recurring_value_kilo_credits,
+      COALESCE(subscriptions.revenue_at_risk_kilo_credits, 0) AS revenue_at_risk_kilo_credits,
+      COALESCE(subscriptions.past_due_mrr_kilo_credits, 0) AS past_due_mrr_kilo_credits,
+      COALESCE(subscriptions.created_in_range, 0) AS created_in_range,
+      COALESCE(subscriptions.created_in_prior_range, 0) AS created_in_prior_range,
+      COALESCE(subscriptions.canceled_in_range, 0) AS canceled_in_range,
+      COALESCE(subscriptions.live_at_range_start, 0) AS live_at_range_start,
+      COALESCE(subscriptions.retained_from_range_start, 0) AS retained_from_range_start,
+      COALESCE(waiters.current_waiters_joined_in_range, 0) AS current_waiters_joined_in_range,
+      COALESCE(
+        waiters.current_waiters_joined_in_prior_range,
+        0
+      ) AS current_waiters_joined_in_prior_range,
+      COALESCE(waiters.current_waitlist_total, 0) AS current_waitlist_total
+    FROM catalog_plans AS catalog
+    LEFT JOIN subscription_metrics AS subscriptions
+      ON subscriptions.plan_id = catalog.plan_id
+    LEFT JOIN waiter_metrics AS waiters
+      ON waiters.plan_id = catalog.plan_id
+    ORDER BY catalog.sort_order
+  `);
+
+  const plansById = new Map(rows.map(row => [row.plan_id, row]));
+  const plans = CODING_PLAN_IDS.map(planId => {
+    const row = plansById.get(planId);
+    if (!row) return emptyAdminInsightPlanRow(planId);
+    return {
+      planId,
+      liveSubscriptions: toNumericCount(row.live_subscriptions),
+      pendingCancellation: toNumericCount(row.pending_cancellation),
+      pastDue: toNumericCount(row.past_due),
+      monthlyRecurringValueKiloCredits: toNumericCredits(row.monthly_recurring_value_kilo_credits),
+      revenueAtRiskKiloCredits: toNumericCredits(row.revenue_at_risk_kilo_credits),
+      pastDueMrrKiloCredits: toNumericCredits(row.past_due_mrr_kilo_credits),
+      createdInRange: toNumericCount(row.created_in_range),
+      createdInPriorRange: toNumericCount(row.created_in_prior_range),
+      canceledInRange: toNumericCount(row.canceled_in_range),
+      liveAtRangeStart: toNumericCount(row.live_at_range_start),
+      retainedFromRangeStart: toNumericCount(row.retained_from_range_start),
+      currentWaitersJoinedInRange: toNumericCount(row.current_waiters_joined_in_range),
+      currentWaitersJoinedInPriorRange: toNumericCount(row.current_waiters_joined_in_prior_range),
+      currentWaitlistTotal: toNumericCount(row.current_waitlist_total),
+    };
+  });
+
+  return {
+    rangeDays,
+    totals: sumAdminInsightTotals(plans),
+    plans: plans.map(toPublicAdminInsightPlan),
+  };
+}
+
+function adminSubscriptionStatusFilter(
+  status: z.infer<typeof AdminSubscriptionDisplayStatusSchema> | undefined
+): SQL | undefined {
+  if (!status) return undefined;
+  if (status === 'active') {
+    return and(
+      eq(coding_plan_subscriptions.status, 'active'),
+      eq(coding_plan_subscriptions.cancel_at_period_end, false)
+    );
+  }
+  if (status === 'pending_cancellation') {
+    return and(
+      eq(coding_plan_subscriptions.status, 'active'),
+      eq(coding_plan_subscriptions.cancel_at_period_end, true)
+    );
+  }
+  return eq(coding_plan_subscriptions.status, status);
+}
+
 export const codingPlansRouter = createTRPCRouter({
   catalog: baseProcedure.query(async ({ ctx }) => {
     const [availablePlanIds, notificationIntentPlanIds] = await Promise.all([
@@ -204,29 +583,62 @@ export const codingPlansRouter = createTRPCRouter({
     return subscriptions.map(toCodingPlanSubscriptionView);
   }),
 
-  adminListSubscriptions: adminProcedure.input(z.object({})).query(async () => {
-    const subscriptions = await db
-      .select({
-        ...codingPlanSubscriptionColumns,
-        userName: kilocode_users.google_user_name,
-      })
-      .from(coding_plan_subscriptions)
-      .innerJoin(kilocode_users, eq(kilocode_users.id, coding_plan_subscriptions.user_id))
-      .leftJoin(
-        coding_plan_key_inventory,
-        eq(coding_plan_key_inventory.id, coding_plan_subscriptions.key_inventory_id)
-      )
-      .orderBy(desc(coding_plan_subscriptions.created_at));
+  adminListSubscriptions: adminProcedure
+    .input(AdminListSubscriptionsInputSchema)
+    .query(async ({ input }) => {
+      const filters = and(
+        adminSubscriptionSearchFilter(input.search),
+        adminSubscriptionStatusFilter(input.status)
+      );
+      const [{ total }] = await db
+        .select({ total: count() })
+        .from(coding_plan_subscriptions)
+        .innerJoin(kilocode_users, eq(kilocode_users.id, coding_plan_subscriptions.user_id))
+        .leftJoin(
+          coding_plan_key_inventory,
+          eq(coding_plan_key_inventory.id, coding_plan_subscriptions.key_inventory_id)
+        )
+        .where(filters);
+      const totalPages = Math.ceil(total / ADMIN_SUBSCRIPTION_PAGE_SIZE);
+      const page = totalPages === 0 || input.page > totalPages ? 1 : input.page;
+      const subscriptions = await db
+        .select({
+          ...codingPlanSubscriptionColumns,
+          userName: kilocode_users.google_user_name,
+          userEmail: kilocode_users.google_user_email,
+        })
+        .from(coding_plan_subscriptions)
+        .innerJoin(kilocode_users, eq(kilocode_users.id, coding_plan_subscriptions.user_id))
+        .leftJoin(
+          coding_plan_key_inventory,
+          eq(coding_plan_key_inventory.id, coding_plan_subscriptions.key_inventory_id)
+        )
+        .where(filters)
+        .orderBy(desc(coding_plan_subscriptions.created_at), desc(coding_plan_subscriptions.id))
+        .limit(ADMIN_SUBSCRIPTION_PAGE_SIZE)
+        .offset((page - 1) * ADMIN_SUBSCRIPTION_PAGE_SIZE);
 
-    return subscriptions.map(subscription => ({
-      ...toCodingPlanSubscriptionView(subscription),
-      userId: subscription.userId,
-      userName: subscription.userName,
-    }));
+      return {
+        items: subscriptions.map(subscription => ({
+          ...toCodingPlanSubscriptionView(subscription),
+          userId: subscription.userId,
+          userName: subscription.userName,
+          userEmail: subscription.userEmail,
+        })),
+        pagination: { page, total, totalPages },
+      };
+    }),
+
+  adminSubscriptionOverview: adminProcedure.query(async () => {
+    return getAdminSubscriptionSummary();
   }),
 
   adminAvailabilityIntentCounts: adminProcedure.input(z.object({})).query(async () => {
     return getCodingPlanAvailabilityIntentCounts();
+  }),
+
+  adminInsights: adminProcedure.input(AdminInsightsInputSchema).query(async ({ input }) => {
+    return getAdminInsights(input.rangeDays);
   }),
 
   getSubscriptionDetail: baseProcedure
@@ -407,6 +819,61 @@ export const codingPlansRouter = createTRPCRouter({
           throw new TRPCError({ code: 'NOT_FOUND', message });
         }
         throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+      }
+    }),
+
+  adminCancelSubscription: adminProcedure
+    .input(z.object({ subscriptionId: SubscriptionIdSchema }))
+    .mutation(async ({ input }) => {
+      try {
+        await adminCancelCodingPlanSubscription(input.subscriptionId);
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes('No active subscription')) {
+          throw new TRPCError({ code: 'NOT_FOUND', message });
+        }
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+      }
+    }),
+
+  adminExtendSubscriptionPeriod: adminProcedure
+    .input(
+      z.object({
+        subscriptionId: SubscriptionIdSchema,
+        days: z.number().int().min(1).max(90),
+      })
+    )
+    .mutation(async ({ input, ctx }) => {
+      try {
+        return await extendCodingPlanSubscriptionPeriod(
+          input.subscriptionId,
+          input.days,
+          ctx.user.id
+        );
+      } catch (error) {
+        const message = error instanceof Error ? error.message : String(error);
+        if (message.includes('No active subscription')) {
+          throw new TRPCError({ code: 'NOT_FOUND', message });
+        }
+        throw new TRPCError({ code: 'INTERNAL_SERVER_ERROR', message });
+      }
+    }),
+
+  adminReplaceInventoryCredential: adminProcedure
+    .input(
+      z.object({ inventoryKeyId: z.string().uuid(), apiKey: z.string().trim().min(1).max(500) })
+    )
+    .mutation(async ({ input }) => {
+      try {
+        await replaceInventoryCredential(input.inventoryKeyId, input.apiKey);
+      } catch (error) {
+        if (error instanceof CodingPlanInventoryReplacementError) {
+          throw new TRPCError({ code: 'PRECONDITION_FAILED', message: error.message });
+        }
+        throw new TRPCError({
+          code: 'INTERNAL_SERVER_ERROR',
+          message: 'Unable to replace the inventory credential.',
+        });
       }
     }),
 


### PR DESCRIPTION
## Summary
Adds scalable administration controls and operational insights for Coding Plans.

### Why this change is needed
Coding Plan operators need to find and manage individual subscriptions without loading the entire subscription history. They also need current demand and plan-health signals, along with safe tools for credential rotation and subscription lifecycle support.

### How this is addressed
- Adds 20-row subscription pagination with user ID/email search and status filtering.
- Adds bounded, server-side subscription and waitlist aggregates for selectable 7, 14, and 30-day insights.
- Adds validated, encrypted inventory credential replacement, including assigned BYOK propagation.
- Adds period-end cancellation and admin-granted period extensions.
- Records extensions as zero-cost, admin-attributed ledger terms.
- Rechecks renewal and cancellation deadlines under row locks so concurrent extensions cannot be charged or canceled using stale lifecycle selections.

## Human Verification
- Verified 132 targeted Jest tests across the Coding Plans router, lifecycle, library, and admin operation helpers.
- Completed focused code review and follow-up acceptance review with no remaining blocker, major, or minor findings.
- React Doctor scored the changed React surface 92/100.

## Reviewer Notes
### Human Reviewer Flags
- Waitlist period metrics describe join dates for users who are still waiting. Resolved intents are removed by the current data model, so this is not a complete historical movement ledger.
- Insight responses are intentionally bounded to the five current Coding Plan catalog IDs. Unknown historical plan IDs remain included in the overall subscription summary but not catalog-specific KPI totals.
- Admin extensions preserve the original paid term and append a zero-cost extension term linked to an admin-attributed credit transaction.

### Code Reviewer Agent
<details>
<summary>Code Reviewer Notes</summary>

- Subscription and waiter insights use one grouped scan per source and return a fixed five-plan result.
- Inventory replacement validates before persistence, encrypts with the existing BYOK mechanism, and revalidates identity and status under a transaction lock.
- Lifecycle regression tests cover stale renewal and cancellation candidates after an admin extension.

</details>
