### PR TITLE
fix(ai-gateway): show fallback custom pricing

### DIFF
--- a/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
@@ -129,10 +129,23 @@ describe('custom model pricing', () => {
     ).toBeUndefined();
   });
 
-  test('does not replace displayed pricing for fallback-only custom pricing', () => {
+  test('uses fallback-only custom pricing in the model list', () => {
     const model = makeModel(PERPLEXITY_KIMI_PUBLIC_ID);
 
-    expect(applyCustomPricingToModel(model)).toBe(model);
+    expect(applyCustomPricingToModel(model)).toEqual({
+      ...model,
+      pricing: {
+        prompt: '0.000003000000',
+        completion: '0.000015000000',
+        input_cache_read: '0.000000300000',
+        input_cache_write: undefined,
+      },
+    });
+  });
+
+  test('preserves endpoint pricing for fallback-only custom pricing', () => {
+    const model = makeModel(PERPLEXITY_KIMI_PUBLIC_ID);
+
     expect(applyCustomPricingToPricing(model.id, model.pricing)).toBe(model.pricing);
   });
 

--- a/apps/web/src/lib/ai-gateway/custom-pricing.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.ts
@@ -128,7 +128,7 @@ export function applyCustomPricingToPricing(
 
 export function applyCustomPricingToModel(model: OpenRouterModel): OpenRouterModel {
   const customPricing = getCustomPricing(model.id);
-  if (!customPricing || customPricing.fallbackOnly) return model;
+  if (!customPricing) return model;
 
   const discountSuffix =
     customPricing.discountPercentage === undefined


### PR DESCRIPTION
## Summary
- show fallback-only custom pricing in the AI Gateway model list
- preserve upstream pricing for provider endpoint lists
- keep usage billing fallback behavior unchanged

## Verification
- `pnpm --filter web test --runInBand src/lib/ai-gateway/custom-pricing.test.ts`
- `pnpm --filter web typecheck`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/custom-pricing.ts apps/web/src/lib/ai-gateway/custom-pricing.test.ts`
- `git diff --check`