### PR TITLE
refactor(ai-gateway): derive upstream path from API kind

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -945,7 +945,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   const upstreamResult = await upstreamRequest({
     chatApi: requestBodyParsed.kind,
-    path,
     search: url.search,
     method: request.method,
     body: requestBodyParsed.body,

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -27,6 +27,11 @@ type UpstreamFetchFailureFamily =
 const TIMEOUT_MS = 10 * 60 * 1000;
 // fetchWithBackoff reserves the next delay before retrying, so 75s yields about one minute.
 const GENERATION_FETCH_MAX_DELAY_MS = 75 * 1000;
+const CHAT_API_PATHS = {
+  chat_completions: '/chat/completions',
+  responses: '/responses',
+  messages: '/messages',
+} as const satisfies Record<GatewayChatApiKind, string>;
 
 function getProviderTargetHost(apiUrl: string): string {
   try {
@@ -191,7 +196,6 @@ function upstreamFetchFailureResponse(
 
 export async function upstreamRequest({
   chatApi,
-  path,
   search,
   method,
   body,
@@ -201,7 +205,6 @@ export async function upstreamRequest({
   vercelRequestId,
 }: {
   chatApi: GatewayChatApiKind;
-  path: string;
   search: string;
   method: string;
   body: OpenRouterChatCompletionRequest | GatewayResponsesRequest | GatewayMessagesRequest;
@@ -223,6 +226,7 @@ export async function upstreamRequest({
   });
 
   const apiUrl = provider.apiUrlOverrides[chatApi] ?? provider.apiUrl;
+  const path = CHAT_API_PATHS[chatApi];
   const targetUrl = `${apiUrl}${path}${search}`;
 
   const timeoutSignal = AbortSignal.timeout(TIMEOUT_MS);

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -33,25 +33,27 @@ describe('upstreamRequest timeout', () => {
   test.each([
     {
       chatApi: 'messages',
-      path: '/messages',
       apiUrlOverrides: { messages: 'https://messages.example.test/v3/v1' },
       expectedUrl: 'https://messages.example.test/v3/v1/messages?beta=true',
     },
     {
       chatApi: 'responses',
-      path: '/responses',
       apiUrlOverrides: {},
       expectedUrl: 'https://gateway.example.test/v3/responses?beta=true',
     },
+    {
+      chatApi: 'chat_completions',
+      apiUrlOverrides: {},
+      expectedUrl: 'https://gateway.example.test/v3/chat/completions?beta=true',
+    },
   ] as const)(
-    'uses the $chatApi API URL override when provided',
-    async ({ chatApi, path, apiUrlOverrides, expectedUrl }) => {
+    'builds the canonical $chatApi URL and uses its override when provided',
+    async ({ chatApi, apiUrlOverrides, expectedUrl }) => {
       const mockFetch = jest.fn().mockResolvedValue(new Response('{}'));
       global.fetch = mockFetch;
 
       const result = await upstreamRequest({
         chatApi,
-        path,
         search: '?beta=true',
         method: 'POST',
         body: { model: 'test-model', messages: [{ role: 'user', content: 'test' }] },
@@ -74,7 +76,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '',
       method: 'POST',
       body: {
@@ -108,7 +109,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '',
       method: 'POST',
       body: {
@@ -137,7 +137,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '',
       method: 'POST',
       body: {
@@ -166,7 +165,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '',
       method: 'POST',
       body: {
@@ -202,7 +200,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '',
       method: 'POST',
       body: {
@@ -234,7 +231,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '',
       method: 'POST',
       body: {
@@ -271,7 +267,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '',
       method: 'POST',
       body: {
@@ -303,7 +298,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '?trace=search-secret',
       method: 'POST',
       body: {
@@ -353,7 +347,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '',
       method: 'POST',
       body: {
@@ -391,7 +384,6 @@ describe('upstreamRequest timeout', () => {
 
     const result = await upstreamRequest({
       chatApi: 'chat_completions',
-      path: '/chat/completions',
       search: '?trace=search-secret',
       method: 'POST',
       body: {


### PR DESCRIPTION
## Summary
- remove the redundant `path` parameter from `upstreamRequest`
- derive each canonical upstream endpoint from `GatewayChatApiKind`
- cover URL construction for Chat Completions, Responses, and Messages, including API-specific base URL overrides

## Verification
- `NODE_ENV=test pnpm --filter web exec jest --runTestsByPath src/tests/openrouterApi.timeout.test.ts "src/app/api/openrouter/[...path]/route.test.ts" --runInBand`
- `pnpm --filter web typecheck`
- changed-file `oxlint` and `oxfmt --list-different`
- `git diff --check`