### PR TITLE
feat(data exports): enable user data exports for all users

### DIFF
--- a/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
@@ -18,7 +18,6 @@ type User = {
   google_user_name: string;
   google_user_email: string;
   google_user_image_url: string;
-  is_admin: boolean;
 };
 
 type SidebarUserFooterProps = {
@@ -86,12 +85,10 @@ export default function SidebarUserFooter({ user, isLoading }: SidebarUserFooter
               <UserCog className="h-4 w-4" />
               Connected Accounts
             </DropdownMenuItem>
-            {user.is_admin && (
-              <DropdownMenuItem onClick={() => router.push('/data-exports')}>
-                <FileDown className="h-4 w-4" />
-                Request data export
-              </DropdownMenuItem>
-            )}
+            <DropdownMenuItem onClick={() => router.push('/data-exports')}>
+              <FileDown className="h-4 w-4" />
+              Request data export
+            </DropdownMenuItem>
             <DropdownMenuItem onClick={() => router.push('/install')}>
               <Download className="h-4 w-4" />
               Install

--- a/apps/web/src/app/(app)/data-exports/page.test.ts
+++ b/apps/web/src/app/(app)/data-exports/page.test.ts
@@ -1,0 +1,42 @@
+import React from 'react';
+
+const mockGetUserFromAuth = jest.fn();
+const mockNotFound = jest.fn(() => {
+  throw new Error('NEXT_NOT_FOUND');
+});
+
+(globalThis as typeof globalThis & { React: typeof React }).React = React;
+
+jest.mock('@/lib/user/server', () => ({ getUserFromAuth: mockGetUserFromAuth }));
+jest.mock('next/navigation', () => ({ notFound: mockNotFound }));
+jest.mock('@/components/PageLayout', () => ({ PageLayout: () => null }));
+jest.mock('./DataExportsClient', () => ({ DataExportsClient: () => null }));
+jest.mock('./RequestDataDeletionCard', () => ({ RequestDataDeletionCard: () => null }));
+
+// `.test.ts`, not `.test.tsx`: jest's testMatch is `**/src/**/*.test.ts`, so a `.tsx`
+// suite is silently never collected. An earlier version of this file was a `.tsx` and
+// never ran, which is how its deletion went unnoticed.
+describe('DataExportsPage', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('authenticates the visitor without requiring Kilo staff', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: null });
+    const { default: DataExportsPage } = await import('./page');
+
+    await expect(DataExportsPage()).rejects.toThrow('NEXT_NOT_FOUND');
+    // `adminOnly: false` is the whole guard: signed out is still refused, but a signed-in
+    // non-staff user reaches the page. Asserted explicitly so a regression to
+    // `adminOnly: true` fails here rather than silently hiding the page from users.
+    expect(mockGetUserFromAuth).toHaveBeenCalledWith({ adminOnly: false });
+  });
+
+  it('renders for a signed-in user who is not a Kilo admin', async () => {
+    mockGetUserFromAuth.mockResolvedValue({ user: { id: 'user-1', is_admin: false } });
+    const { default: DataExportsPage } = await import('./page');
+
+    await expect(DataExportsPage()).resolves.toBeTruthy();
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/(app)/data-exports/page.tsx
+++ b/apps/web/src/app/(app)/data-exports/page.tsx
@@ -5,7 +5,7 @@ import { DataExportsClient } from './DataExportsClient';
 import { RequestDataDeletionCard } from './RequestDataDeletionCard';
 
 export default async function DataExportsPage() {
-  const { user } = await getUserFromAuth({ adminOnly: true });
+  const { user } = await getUserFromAuth({ adminOnly: false });
   if (!user) notFound();
 
   return (

--- a/apps/web/src/routers/user-exports-router.test.ts
+++ b/apps/web/src/routers/user-exports-router.test.ts
@@ -129,9 +129,9 @@ describe('user exports router guards and serialization', () => {
     expect(() => __test__.requireWebSession(false)).not.toThrow();
   });
 
-  it('rejects non-admin users', async () => {
+  it('allows non-admin users to list their exports', async () => {
     const caller = await createCallerForUser(stranger.id);
-    await expect(caller.userExports.list()).rejects.toMatchObject({ code: 'FORBIDDEN' });
+    await expect(caller.userExports.list()).resolves.toEqual({ exports: [], nextCursor: null });
   });
 
   it('normalizes database timestamp text into strict UTC ISO strings', () => {

--- a/apps/web/src/routers/user-exports-router.ts
+++ b/apps/web/src/routers/user-exports-router.ts
@@ -17,7 +17,7 @@ import {
 } from '@/lib/auth/data-export-download-codes';
 import { db } from '@/lib/drizzle';
 import { sendDataExportDownloadCodeEmail } from '@/lib/email';
-import { adminProcedure, createTRPCRouter, type TRPCContext } from '@/lib/trpc/init';
+import { baseProcedure, createTRPCRouter, type TRPCContext } from '@/lib/trpc/init';
 import {
   ORGANIZATION_EXPORT_ROLES,
   organizationExportAccess,
@@ -165,10 +165,9 @@ async function exportableOrganizations(userId: string): Promise<{ id: string; na
  * role on it.
  *
  * The shared predicate, not `ensureOrganizationAccess`, which every other organization
- * router uses. That helper grants `owner` to any `is_admin` caller, so on this router —
- * where every procedure is `adminProcedure` — it would authorise on staff status rather
- * than on membership, and nobody may export another person's or another organization's
- * data.
+ * router uses. That helper grants `owner` to any `is_admin` caller, so it would authorise
+ * a Kilo staff member on staff status rather than on membership, and nobody — staff
+ * included — may export another person's or another organization's data.
  *
  * Shared with the Worker, which re-checks independently, because the two must reach the
  * same verdict. They once did not, and an export generated, showed as ready, and then
@@ -246,8 +245,7 @@ async function createExportRequest(subject: {
       FROM user_data_exports exports
       WHERE ${scopeFilter}
         AND exports.status <> 'failed'
-        -- TEMPORARY: throttle lowered to 5 minutes for pre-launch testing; restore to 24 hours before going live.
-        AND exports.requested_at > now() - interval '5 minutes'
+        AND exports.requested_at > now() - interval '24 hours'
       ORDER BY exports.requested_at DESC
       LIMIT 1
     `);
@@ -421,13 +419,13 @@ function downloadCodeError(result: Exclude<ReserveDownloadCodeResult, 'ok'>): TR
 }
 
 export const userExportsRouter = createTRPCRouter({
-  request: adminProcedure.mutation(async ({ ctx }) => {
+  request: baseProcedure.mutation(async ({ ctx }) => {
     requireWebSession(ctx.authViaToken);
     const row = await createExportRequest({ kiloUserId: ctx.user.id, organizationId: null });
     return serialize(row);
   }),
 
-  requestOrganization: adminProcedure
+  requestOrganization: baseProcedure
     .input(OrganizationExportSchema)
     .mutation(async ({ ctx, input }) => {
       requireWebSession(ctx.authViaToken);
@@ -443,18 +441,18 @@ export const userExportsRouter = createTRPCRouter({
     }),
 
   /** Organizations the caller may export, for rendering the organization buttons. */
-  exportableOrganizations: adminProcedure.query(async ({ ctx }) => {
+  exportableOrganizations: baseProcedure.query(async ({ ctx }) => {
     requireWebSession(ctx.authViaToken);
     return { organizations: await exportableOrganizations(ctx.user.id) };
   }),
 
-  list: adminProcedure.input(ListInputSchema).query(async ({ ctx, input }) => {
+  list: baseProcedure.input(ListInputSchema).query(async ({ ctx, input }) => {
     requireWebSession(ctx.authViaToken);
     // Two independent reasons an export is visible.
     //
     // Anything the caller requested, whatever its subject. Whoever pressed the button
     // always sees the result, even if the access that admitted the request is not
-    // access this query can reproduce — a Kilo staff elevation, for instance.
+    // access this query can still reproduce — an export role revoked afterwards, say.
     //
     // Plus every export belonging to an organization they may export, so a second
     // admin is not refused by the one-active-export-per-org constraint while being
@@ -508,7 +506,7 @@ export const userExportsRouter = createTRPCRouter({
    * held web session alone cannot reach the artifact without also reaching the
    * inbox.
    */
-  requestDownloadCode: adminProcedure.input(ExportIdSchema).mutation(async ({ ctx, input }) => {
+  requestDownloadCode: baseProcedure.input(ExportIdSchema).mutation(async ({ ctx, input }) => {
     requireWebSession(ctx.authViaToken);
     await requireDownloadableExport(ctx, input.exportId);
     const email = requireDownloadCodeRecipient(ctx.user.google_user_email);
@@ -539,7 +537,7 @@ export const userExportsRouter = createTRPCRouter({
   }),
 
   /** Step 2 of the download: redeem the emailed code for one signed URL. */
-  createDownload: adminProcedure.input(DownloadInputSchema).mutation(async ({ ctx, input }) => {
+  createDownload: baseProcedure.input(DownloadInputSchema).mutation(async ({ ctx, input }) => {
     requireWebSession(ctx.authViaToken);
     await requireDownloadableExport(ctx, input.exportId);
     const email = requireDownloadCodeRecipient(ctx.user.google_user_email);


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

Data exports were restricted to Kilo staff while the feature was being built. This removes the `is_admin` gate so any signed in user can request and download an export of their own data.

The gate came off in three places: the `/data-exports` page, the user menu entry that links to it, and all six `userExports` tRPC procedures. Those procedures move from `adminProcedure` to `baseProcedure`, which still requires an authenticated session, so the endpoints are open to signed in users rather than public.

The request throttle also goes back to 24 hours. It had been lowered to 5 minutes for pre-launch testing, with a comment saying to restore it before going live, while the message shown to users already said 24 hours. The code and the copy now agree.

## Changes

- `page.tsx`: `getUserFromAuth({ adminOnly: true })` becomes `adminOnly: false`. A signed out visitor still gets `notFound()`.
- `SidebarUserFooter.tsx`: the user menu entry renders for everyone. The `is_admin` field is dropped from the component's local `User` type, since nothing else used it.
- `user-exports-router.ts`: `request`, `requestOrganization`, `exportableOrganizations`, `list`, `requestDownloadCode` and `createDownload` move to `baseProcedure`.
- `user-exports-router.ts`: throttle restored from `interval '5 minutes'` to `interval '24 hours'`, and the TEMPORARY comment removed.
- `user-exports-router.ts`: two comments reworded. One justified this router doing its own membership check by stating that every procedure here is `adminProcedure`, which is no longer true. The other cited a Kilo staff elevation as the reason a requester might see an export whose access the list query cannot reproduce, which can no longer happen, so it now cites a revoked export role. The behavior both comments describe is unchanged.
- `user-exports-router.test.ts`: `rejects non-admin users` becomes `allows non-admin users to list their exports`, asserting an empty list instead of FORBIDDEN.
- `page.test.ts`: new. Covers the page guard, asserting `adminOnly: false`, that a signed out visitor is refused, and that a signed in non-admin user renders.

## What this does not change

- Organization exports still require an owner or admin role on that organization, checked by `requireExportableOrganization` and re-checked independently by the export Worker. Kilo staff status does not grant access to another organization's data, and the test covering that still passes.
- API token and extension callers are still refused by `requireWebSession`.
- The emailed download code step is unchanged.

## Verification

No manual testing was run. The dev stack for this change is owned by the reviewer, so verification here was automated only: `pnpm --filter web test -- data-export user-exports-router` passes 164 tests across 14 suites, alongside `format:check`, `lint` and `typecheck`. The boxes below are the manual paths still worth walking.

- [ ] Sign in as a non-admin user, confirm Request data export appears in the user menu and the page loads
- [ ] Request an export as a non-admin user, confirm a second request inside 24 hours is refused
- [ ] Confirm a non-admin user who is not an owner or admin of any organization sees no organization export buttons

## Visual Changes

The user menu entry linking to `/data-exports` is now visible to all signed in users, where it previously rendered only for `is_admin` accounts. Screenshots to add: the user menu on a non-admin account, before and after.

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

- `baseProcedure` still requires an authenticated session. `createTRPCContext` throws UNAUTHORIZED when there is no user, so this widens access from staff to signed in users, not to anonymous callers.
- Dropping `adminProcedure` also stops `emitAdminAccessEvent` firing for these procedures. That is intended, since they are no longer an admin surface, but it does mean these calls no longer appear in the admin access log.
- The new page test is `page.test.ts`, not `.tsx`. Jest's `testMatch` in `apps/web/jest.config.ts` is `**/src/**/*.test.ts`, so a `.tsx` suite is never collected. A `page.test.tsx` existed on an earlier branch and was deleted in #5202 without any failure, because it had never run.
