### PR TITLE
refactor(ai-gateway): extract upstream attempts

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -15,11 +15,9 @@ import type {
   GatewayMessagesRequest,
   GatewayRequest,
 } from '@/lib/ai-gateway/providers/openrouter/types';
-import { applyProviderSpecificLogic } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
 import { getProvider } from '@/lib/ai-gateway/providers/get-provider';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
-import { buildExperimentPromptCapture } from '@/lib/ai-gateway/experiments/persist';
-import { upstreamRequest } from '@/lib/ai-gateway/providers/upstream-request';
+import { sendUpstreamAttempt } from '@/lib/ai-gateway/providers/upstream-attempt';
 import { debugSaveProxyRequest } from '@/lib/debugUtils';
 import { setTag, startInactiveSpan } from '@sentry/nextjs';
 import { getUserFromAuth } from '@/lib/user/server';
@@ -84,11 +82,7 @@ import {
   resolveAbuseClassificationCacheIdentityKey,
   sleepForRulesEngineAction,
 } from '@/lib/ai-gateway/abuse-service';
-import {
-  emitApiMetricsForResponse,
-  getToolsAvailable,
-  getToolsUsed,
-} from '@/lib/ai-gateway/o11y/api-metrics.server';
+import { emitApiMetricsForResponse } from '@/lib/ai-gateway/o11y/api-metrics.server';
 import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
 import { isUnavailableModel } from '@/lib/ai-gateway/unavailable-models';
 import { isCloudflareIP } from '@/lib/cloudflare-ip';
@@ -118,7 +112,6 @@ import {
   evaluateEffectiveModelAccessPolicy,
   getEffectiveModelDecision,
 } from '@/lib/organizations/effective-model-access.server';
-import { isValidOpenRouterModelId } from '@/lib/ai-gateway/providers/gateway-models-cache';
 
 export const maxDuration = 800;
 
@@ -934,56 +927,27 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     op: 'http.client',
   });
 
-  const extraHeaders: Record<string, string> = {};
-  await applyProviderSpecificLogic(
-    effectiveProviderContext.provider,
-    effectiveModelIdLowerCased,
-    requestBodyParsed,
-    extraHeaders,
-    effectiveProviderContext.userByok,
+  const attempt = await sendUpstreamAttempt({
+    providerContext: effectiveProviderContext,
+    requestedModel: effectiveModelIdLowerCased,
+    request: requestBodyParsed,
     fraudHeaders,
-    user.id,
-    organizationId ?? null,
-    usageContext.session_id,
-    taskId ?? null
-  );
-
-  if (
-    effectiveProviderContext.provider.id === 'openrouter' &&
-    !(await isValidOpenRouterModelId(requestBodyParsed.body.model))
-  ) {
-    return modelDoesNotExistOnOpenRouterResponse(effectiveModelIdLowerCased);
-  }
-
-  const toolsAvailable = getToolsAvailable(requestBodyParsed);
-  const toolsUsed = getToolsUsed(requestBodyParsed);
-
-  // Capture the bounded prompt for experimented requests AFTER provider
-  // transforms have produced the canonical upstream body. Stored on the
-  // usage context so the async `after()` hook can persist it without
-  // retaining a reference to the full uncapped body.
-  if (effectiveProviderContext.experiment) {
-    usageContext.experimentPromptCapture = buildExperimentPromptCapture(requestBodyParsed);
-  }
-
-  if (rulesEngineDecision.delayMs > 0) {
-    await sleepForRulesEngineAction(rulesEngineDecision.delayMs);
-  }
-
-  const upstreamResult = await upstreamRequest({
-    chatApi: requestBodyParsed.kind,
+    userId: user.id,
+    organizationId: organizationId ?? null,
+    sessionId: usageContext.session_id,
+    taskId: taskId ?? null,
+    delayMs: rulesEngineDecision.delayMs,
     search: url.search,
     method: request.method,
-    body: requestBodyParsed.body,
-    extraHeaders,
-    provider: effectiveProviderContext.provider,
     signal: request.signal,
     vercelRequestId,
   });
-  if (upstreamResult.type === 'error') {
-    return upstreamResult.response;
+  if (attempt.type === 'invalid-openrouter-model') {
+    return modelDoesNotExistOnOpenRouterResponse(effectiveModelIdLowerCased);
   }
-  const response = upstreamResult.response;
+  if (attempt.type === 'error') return attempt.response;
+  const { response, toolsAvailable, toolsUsed, experimentPromptCapture } = attempt;
+  if (experimentPromptCapture) usageContext.experimentPromptCapture = experimentPromptCapture;
   logExceptInTest(
     'upstream response status: %s, x-vercel-id: %s, session_id: %s',
     response.status,

--- a/apps/web/src/lib/ai-gateway/providers/upstream-attempt.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-attempt.ts
@@ -1,0 +1,105 @@
+import type { NextResponse } from 'next/server';
+
+import { buildExperimentPromptCapture } from '@/lib/ai-gateway/experiments/persist';
+import { getToolsAvailable, getToolsUsed } from '@/lib/ai-gateway/o11y/api-metrics.server';
+import type { ExperimentPromptCapture } from '@/lib/ai-gateway/processUsage.types';
+import { sleepForRulesEngineAction } from '@/lib/ai-gateway/abuse-service';
+import { applyProviderSpecificLogic } from '@/lib/ai-gateway/providers/apply-provider-specific-logic';
+import type { GetProviderProviderResult } from '@/lib/ai-gateway/providers/get-provider';
+import { isValidOpenRouterModelId } from '@/lib/ai-gateway/providers/gateway-models-cache';
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import { upstreamRequest } from '@/lib/ai-gateway/providers/upstream-request';
+import type { FraudDetectionHeaders } from '@/lib/utils';
+
+type SendUpstreamAttemptInput = {
+  providerContext: GetProviderProviderResult;
+  requestedModel: string;
+  request: GatewayRequest;
+  fraudHeaders: FraudDetectionHeaders;
+  userId: string;
+  organizationId: string | null;
+  sessionId: string | null;
+  taskId: string | null;
+  delayMs: number;
+  search: string;
+  method: string;
+  signal?: AbortSignal;
+  vercelRequestId?: string | null;
+};
+
+type SendUpstreamAttemptResult =
+  | { type: 'invalid-openrouter-model' }
+  | { type: 'error'; response: NextResponse }
+  | {
+      type: 'success';
+      response: Response;
+      toolsAvailable: string[];
+      toolsUsed: string[];
+      experimentPromptCapture?: ExperimentPromptCapture;
+    };
+
+/** Sends one upstream attempt and mutates the request with provider-specific transforms. */
+export async function sendUpstreamAttempt({
+  providerContext,
+  requestedModel,
+  request,
+  fraudHeaders,
+  userId,
+  organizationId,
+  sessionId,
+  taskId,
+  delayMs,
+  search,
+  method,
+  signal,
+  vercelRequestId,
+}: SendUpstreamAttemptInput): Promise<SendUpstreamAttemptResult> {
+  const extraHeaders: Record<string, string> = {};
+  await applyProviderSpecificLogic(
+    providerContext.provider,
+    requestedModel,
+    request,
+    extraHeaders,
+    providerContext.userByok,
+    fraudHeaders,
+    userId,
+    organizationId,
+    sessionId,
+    taskId
+  );
+
+  if (providerContext.provider.id === 'openrouter') {
+    const transformedModel = request.body.model;
+    if (!transformedModel || !(await isValidOpenRouterModelId(transformedModel))) {
+      return { type: 'invalid-openrouter-model' };
+    }
+  }
+
+  const experimentPromptCapture = providerContext.experiment
+    ? buildExperimentPromptCapture(request)
+    : undefined;
+
+  if (delayMs > 0) {
+    await sleepForRulesEngineAction(delayMs);
+  }
+
+  const result = await upstreamRequest({
+    chatApi: request.kind,
+    search,
+    method,
+    body: request.body,
+    extraHeaders,
+    provider: providerContext.provider,
+    signal,
+    vercelRequestId,
+  });
+  if (result.type === 'error') return result;
+
+  return {
+    type: 'success',
+    response: result.response,
+    toolsAvailable: getToolsAvailable(request),
+    toolsUsed: getToolsUsed(request),
+    experimentPromptCapture,
+  };
+}


### PR DESCRIPTION
## Summary
- extract one complete provider upstream attempt from the gateway route into `lib/ai-gateway/providers/upstream-attempt.ts`
- keep provider-specific transforms, fresh extra headers, OpenRouter model validation, experiment prompt capture, rules-engine delay, upstream transport handling, and tool metadata together
- leave route-level response processing, metrics, billing, and error rewriting unchanged

## Behavior
This is a behavior-preserving preparatory refactor for #5281. It introduces no retries or new routing behavior.

## Verification
- `pnpm --filter web test --runInBand --runTestsByPath "src/app/api/openrouter/[...path]/route.test.ts"` (29 tests)
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`