### PR TITLE
feat(data-export): add code_indexing_manifest source

### DIFF
--- a/packages/db/src/user-data-export-file.ts
+++ b/packages/db/src/user-data-export-file.ts
@@ -15,9 +15,11 @@
  *   1  the original set of sources
  *   2  the warehouse profile columns added to the identity section (location, historic
  *      and current, plus the analytics copies of name, email and hosted domain)
+ *   3  the `code_indexing_manifest` source (project, branch and file path per indexed
+ *      file), which the original set omitted
  *
  * The column's database default stays at 1 deliberately. Every insert sets this value
  * explicitly, so bumping the format never needs a migration, and a row written without it
  * is visibly stale rather than quietly wrong.
  */
-export const EXPORT_FILE_SCHEMA_VERSION = 2;
+export const EXPORT_FILE_SCHEMA_VERSION = 3;

--- a/services/user-data-export/src/source-adapters.test.ts
+++ b/services/user-data-export/src/source-adapters.test.ts
@@ -336,6 +336,7 @@ describe('warehouse availability probe', () => {
       'cli_sessions',
       'system_prompt_prefix',
       'microdollar_usage_metadata',
+      'code_indexing_manifest',
     ]);
   });
 
@@ -387,6 +388,7 @@ describe('source adapters', () => {
       'cli_sessions',
       'system_prompt_prefix',
       'microdollar_usage_metadata',
+      'code_indexing_manifest',
     ]);
   });
 
@@ -828,5 +830,103 @@ describe('source adapters', () => {
     await expect(
       requireAdapter(adapters, 'cli_sessions').readPage?.(READ_PAGE_INPUT)
     ).rejects.toThrow('most_significant_position');
+  });
+
+  const MANIFEST_ROW = {
+    id: 'manifest-1',
+    project_id: 'project-a',
+    git_branch: 'main',
+    file_path: 'src/index.ts',
+  };
+
+  it('emits the three manifest fields per row, keyed by the row that carried them', async () => {
+    const { adapters } = harness([MANIFEST_ROW]);
+
+    const page = await requireAdapter(adapters, 'code_indexing_manifest').readPage?.({
+      ...READ_PAGE_INPUT,
+      limit: 1,
+    });
+
+    // One id across all three, so a file, its branch and its project stay groupable.
+    expect(page?.records).toEqual([
+      {
+        source: 'code_indexing_manifest',
+        id: 'manifest-1',
+        field: 'project_id',
+        value: 'project-a',
+      },
+      { source: 'code_indexing_manifest', id: 'manifest-1', field: 'git_branch', value: 'main' },
+      {
+        source: 'code_indexing_manifest',
+        id: 'manifest-1',
+        field: 'file_path',
+        value: 'src/index.ts',
+      },
+    ]);
+    expect(page?.nextCursor).toEqual({ key: ['manifest-1'] });
+  });
+
+  // The load was narrowed on 2026-08-14 and `_snowflake_inserted_at` went with it, leaving
+  // the cutoff in the unload's WHERE clause alone. Naming it here would fail a table that
+  // is present and complete, so the read is scope, cursor and limit like its neighbours.
+  it('reads the manifest with no snapshot bound of its own', async () => {
+    const { adapters, warehouseCalls } = harness([MANIFEST_ROW]);
+
+    await requireAdapter(adapters, 'code_indexing_manifest').readPage?.(READ_PAGE_INPUT);
+
+    expect(warehouseCalls[0].text).not.toContain('_snowflake_inserted_at');
+    expect(warehouseCalls[0].values).toEqual(['owner-user', null, 100]);
+  });
+
+  // `organization_id` is NOT NULL on this table, so a personal row still names an
+  // organization and only `kilo_user_id` isolates one person's rows.
+  it('scopes the manifest on the column the subject calls for', async () => {
+    const { adapters, warehouseCalls } = harness([MANIFEST_ROW]);
+    const adapter = requireAdapter(adapters, 'code_indexing_manifest');
+
+    await adapter.readPage?.(READ_PAGE_INPUT);
+    await adapter.readPage?.(ORG_READ_PAGE_INPUT);
+
+    expect(warehouseCalls[0].text).toContain('WHERE kilo_user_id = $1');
+    expect(warehouseCalls[0].values[0]).toBe('owner-user');
+    expect(warehouseCalls[1].text).toContain('WHERE organization_id = $1');
+    expect(warehouseCalls[1].values[0]).toBe('org-1');
+  });
+
+  it('marks every field of a manifest row prod has since deleted', async () => {
+    const { adapters } = harness([{ ...MANIFEST_ROW, _snowflake_deleted: true }]);
+
+    const page = await requireAdapter(adapters, 'code_indexing_manifest').readPage?.(
+      READ_PAGE_INPUT
+    );
+
+    expect(page?.records).toHaveLength(3);
+    for (const record of page?.records ?? []) expect(record.softDeleted).toBe(true);
+  });
+
+  // Unknown is not deleted: the column is NULL throughout on a table whose reload has not
+  // run, so an absent mark has to cover both readings.
+  it('leaves a manifest row unmarked when the warehouse cannot say', async () => {
+    const { adapters } = harness([{ ...MANIFEST_ROW, _snowflake_deleted: null }]);
+
+    const page = await requireAdapter(adapters, 'code_indexing_manifest').readPage?.(
+      READ_PAGE_INPUT
+    );
+
+    for (const record of page?.records ?? []) expect(record).not.toHaveProperty('softDeleted');
+  });
+
+  // NOT NULL on the primary, unconstrained in the warehouse. One odd cell must not spend
+  // the queue's retries on a value frozen in the snapshot.
+  it('reads a non-string manifest value as absent rather than failing the export', async () => {
+    const { adapters } = harness([{ ...MANIFEST_ROW, git_branch: 42 }]);
+
+    const page = await requireAdapter(adapters, 'code_indexing_manifest').readPage?.(
+      READ_PAGE_INPUT
+    );
+    const byField = new Map(page?.records.map(record => [record.field, record.value]));
+
+    expect(byField.get('git_branch')).toBeNull();
+    expect(byField.get('file_path')).toBe('src/index.ts');
   });
 });

--- a/services/user-data-export/src/source-adapters.test.ts
+++ b/services/user-data-export/src/source-adapters.test.ts
@@ -866,21 +866,14 @@ describe('source adapters', () => {
     expect(page?.nextCursor).toEqual({ key: ['manifest-1'] });
   });
 
-  // The load was narrowed on 2026-08-14 and `_snowflake_inserted_at` went with it, leaving
-  // the cutoff in the unload's WHERE clause alone. Naming it here would fail a table that
-  // is present and complete, so the read is scope, cursor and limit like its neighbours.
-  it('reads the manifest with no snapshot bound of its own', async () => {
-    const { adapters, warehouseCalls } = harness([MANIFEST_ROW]);
-
-    await requireAdapter(adapters, 'code_indexing_manifest').readPage?.(READ_PAGE_INPUT);
-
-    expect(warehouseCalls[0].text).not.toContain('_snowflake_inserted_at');
-    expect(warehouseCalls[0].values).toEqual(['owner-user', null, 100]);
-  });
-
-  // `organization_id` is NOT NULL on this table, so a personal row still names an
-  // organization and only `kilo_user_id` isolates one person's rows.
-  it('scopes the manifest on the column the subject calls for', async () => {
+  // The tight-scoping guard for this source, and the reason it needs one of its own.
+  // `organization_id` on a personal row is a uuid derived from the user rather than an
+  // organization, which invites a query reaching for both owner columns at once to "catch
+  // everything". A user read must name `kilo_user_id` and nothing else, an org read
+  // `organization_id` and nothing else, so neither subject can widen into the other's rows.
+  // The scope value is the first bind parameter in both, with only cursor and limit after
+  // it: no third predicate, and nothing interpolated.
+  it('scopes each manifest read to one owner column and never both', async () => {
     const { adapters, warehouseCalls } = harness([MANIFEST_ROW]);
     const adapter = requireAdapter(adapters, 'code_indexing_manifest');
 
@@ -888,9 +881,11 @@ describe('source adapters', () => {
     await adapter.readPage?.(ORG_READ_PAGE_INPUT);
 
     expect(warehouseCalls[0].text).toContain('WHERE kilo_user_id = $1');
-    expect(warehouseCalls[0].values[0]).toBe('owner-user');
+    expect(warehouseCalls[0].text).not.toContain('organization_id');
+    expect(warehouseCalls[0].values).toEqual(['owner-user', null, 100]);
     expect(warehouseCalls[1].text).toContain('WHERE organization_id = $1');
-    expect(warehouseCalls[1].values[0]).toBe('org-1');
+    expect(warehouseCalls[1].text).not.toContain('kilo_user_id');
+    expect(warehouseCalls[1].values).toEqual(['org-1', null, 100]);
   });
 
   it('marks every field of a manifest row prod has since deleted', async () => {

--- a/services/user-data-export/src/source-adapters.ts
+++ b/services/user-data-export/src/source-adapters.ts
@@ -247,8 +247,8 @@ LIMIT 1`;
  * "everything they own across both" above: indexing under an organization writes
  * `kilo_user_id` as NULL outright, so a person's own export carries their personal
  * indexing only and the organization's export carries the rest. It is also the one table
- * whose `organization_id` is not always an organization — see `codeIndexingPageQuery`,
- * which is where that column's two readings are set out.
+ * whose `organization_id` is not always an organization — see `codeIndexingQueries`, which
+ * is where that column's two readings are set out.
  *
  * The warehouse has no `created_at` on any table and is itself a point-in-time
  * snapshot, so there is no `snapshot_at` bound to apply here.
@@ -422,21 +422,18 @@ const userPromptQueries = subjectPageQueries({
  *     `organizations` row, in strict 1:1 with 13,010 users. A real organization appears
  *     only on rows where `kilo_user_id` is NULL.
  *
- * Both scopes therefore land where they should with no extra predicate, and this source
- * needs no builder of its own. `kilo_user_id = $1` selects that person's personal
- * indexing; `organization_id = $1` is bound to a real organization id, which no personal
- * row's derived uuid can equal, so personal work cannot reach an organization's export
- * through the column that merely looks like an org tag.
+ * Each subject is therefore scoped by exactly one of the two columns, and never by both.
+ * `kilo_user_id = $1` selects that person's personal indexing. `organization_id = $1` is
+ * bound to a real organization id, which no personal row's derived uuid can equal, so
+ * personal work cannot reach an organization's export through the column that merely looks
+ * like an org tag. Widening either read to reach for both columns is what would break
+ * that, which is why this source takes the same single-predicate shape as every other and
+ * needs no builder of its own.
  *
- * Rows with both columns NULL are the source's tombstones — 9,591,426 of 41,368,545, every
- * payload column NULL. Neither predicate matches NULL, so scoping alone excludes them and
- * they never reach the file as id-only records. `_snowflake_deleted` is still selected,
- * because the deleted rows that do carry an owner are labelled rather than hidden.
- *
- * No `snapshot_at` bound, for the same reason as its neighbours. The warehouse copy was
- * narrowed on 2026-08-14 to the six requested columns plus `_snowflake_deleted`;
- * `_snowflake_inserted_at` survives only in the unload's WHERE clause, so the loaded table
- * is already cut at the shared cutoff and carries no column to bound on.
+ * Rows with both columns NULL are the source's tombstones, every payload column NULL.
+ * Neither predicate matches NULL, so scoping alone excludes them and they never reach the
+ * file as id-only records. `_snowflake_deleted` is still selected, because the deleted rows
+ * that do carry an owner are labelled rather than hidden.
  */
 const codeIndexingQueries = subjectPageQueries({
   table: 'code_indexing_manifest',
@@ -1025,10 +1022,8 @@ export const WAREHOUSE_SOURCE_COLUMNS: Record<string, readonly string[]> = {
   ],
   system_prompt_prefix: ['system_prompt_prefix_id', 'system_prompt_prefix', DELETED_COLUMN],
   microdollar_usage_metadata: ['id', 'user_prompt_prefix'],
-  // The whole of the narrowed table bar its two owner columns, which `sourceQueryScopes`
-  // covers. `_snowflake_inserted_at` is deliberately absent: it was dropped from the load
-  // on 2026-08-14 and survives only in the unload's WHERE clause, so probing for it would
-  // fail a table that is in fact present and complete.
+  // Every column the query reads, and only those. The two owner columns are covered by
+  // `sourceQueryScopes` instead, which is what pairs each subject with its predicate.
   code_indexing_manifest: ['id', 'project_id', 'git_branch', 'file_path', DELETED_COLUMN],
 };
 

--- a/services/user-data-export/src/source-adapters.ts
+++ b/services/user-data-export/src/source-adapters.ts
@@ -939,8 +939,10 @@ export function createSourceAdapters(queries: SourceAdapterQueries): SourceAdapt
  *
  * The user variant filters on `kilo_user_id = $1` and returns everything that person
  * owns, in their personal workspace and in any organization workspace they worked in.
- * It skips rows an organization owns outright with no user attached, which exist only on
- * `app_builder_projects` and `app_builder_messages`.
+ * It skips rows an organization owns outright with no user attached, which exist on
+ * `app_builder_projects`, `app_builder_messages` and `code_indexing_manifest`. On the last
+ * of those every organization-scoped row is of that shape, so an organization's indexing
+ * reaches only the organization variant.
  *
  * The organization variant filters on `organization_id = $1`, which returns that
  * organization's workspace and never a member's personal workspace, since the predicate

--- a/services/user-data-export/src/source-adapters.ts
+++ b/services/user-data-export/src/source-adapters.ts
@@ -233,14 +233,22 @@ LIMIT 1`;
  *
  *     app_builder_projects          2,143    user XOR org
  *     app_builder_messages        266,095    user XOR org
+ *     code_indexing_manifest   20,170,449    user XOR org
  *     cli_sessions                      0    both columns set
  *     system_prompt_prefix              0    both columns set
  *     microdollar_usage_metadata        0    both columns set
  *
- * On the first two, an organization can own a row outright with no user attached, so
+ * On the first three, an organization can own a row outright with no user attached, so
  * `kilo_user_id = $1` genuinely skips those. On the other three every row names a user,
  * so an organization-workspace row matches both predicates. Both outcomes are intended;
  * the difference is in what the source model records, not in the export's rules.
+ *
+ * `code_indexing_manifest` is the strongest form of the first case, and it qualifies the
+ * "everything they own across both" above: indexing under an organization writes
+ * `kilo_user_id` as NULL outright, so a person's own export carries their personal
+ * indexing only and the organization's export carries the rest. It is also the one table
+ * whose `organization_id` is not always an organization — see `codeIndexingPageQuery`,
+ * which is where that column's two readings are set out.
  *
  * The warehouse has no `created_at` on any table and is itself a point-in-time
  * snapshot, so there is no `snapshot_at` bound to apply here.
@@ -402,6 +410,39 @@ const userPromptQueries = subjectPageQueries({
   columns: 'id, user_prompt_prefix',
 });
 
+/**
+ * The two owner columns are complementary rather than alternative, and neither is a plain
+ * organization tag:
+ *
+ *   - `kilo_user_id` is set only when the file was indexed in a PERSONAL context, and is
+ *     NULL on rows indexed under an organization. It names one person's own work.
+ *   - `organization_id` is NOT always an organization. Indexing outside an org falls
+ *     through to `getUserUUID(user)` = `uuidv5(user.id, ...)`, so a personal row carries a
+ *     uuid DERIVED FROM THE USER. Measured 2026-08-12: 13,010 such ids appear in no
+ *     `organizations` row, in strict 1:1 with 13,010 users. A real organization appears
+ *     only on rows where `kilo_user_id` is NULL.
+ *
+ * Both scopes therefore land where they should with no extra predicate, and this source
+ * needs no builder of its own. `kilo_user_id = $1` selects that person's personal
+ * indexing; `organization_id = $1` is bound to a real organization id, which no personal
+ * row's derived uuid can equal, so personal work cannot reach an organization's export
+ * through the column that merely looks like an org tag.
+ *
+ * Rows with both columns NULL are the source's tombstones — 9,591,426 of 41,368,545, every
+ * payload column NULL. Neither predicate matches NULL, so scoping alone excludes them and
+ * they never reach the file as id-only records. `_snowflake_deleted` is still selected,
+ * because the deleted rows that do carry an owner are labelled rather than hidden.
+ *
+ * No `snapshot_at` bound, for the same reason as its neighbours. The warehouse copy was
+ * narrowed on 2026-08-14 to the six requested columns plus `_snowflake_deleted`;
+ * `_snowflake_inserted_at` survives only in the unload's WHERE clause, so the loaded table
+ * is already cut at the shared cutoff and carries no column to bound on.
+ */
+const codeIndexingQueries = subjectPageQueries({
+  table: 'code_indexing_manifest',
+  columns: 'id, project_id, git_branch, file_path, _snowflake_deleted',
+});
+
 // Message payloads are whole conversations rather than single fields, so this source
 // reads fewer rows per page than the others.
 const MESSAGE_PAGE_SIZE = 200;
@@ -423,6 +464,13 @@ type SystemPromptRow = {
   deleted: unknown;
 };
 type UserPromptRow = { id: string; user_prompt_prefix: string | null };
+type CodeIndexingRow = {
+  id: string;
+  project_id: string | null;
+  git_branch: string | null;
+  file_path: string | null;
+  deleted: unknown;
+};
 
 function requiredString(value: unknown, field: string): string {
   if (typeof value !== 'string') throw new Error(`Replica row has invalid ${field}`);
@@ -833,6 +881,59 @@ export function createSourceAdapters(queries: SourceAdapterQueries): SourceAdapt
         };
       },
     },
+    {
+      name: 'code_indexing_manifest',
+      warehouseTable: 'code_indexing_manifest',
+      async readPage(input): Promise<SourcePage> {
+        const [after] = keyCursorValues(input.cursor, 1);
+        const rows: CodeIndexingRow[] = await warehouseQuery(
+          codeIndexingQueries[input.subject.type],
+          [subjectScopeValue(input.subject), after, input.limit]
+        ).then(result =>
+          result.map(row => ({
+            id: requiredString(row.id, 'id'),
+            // Nullable through `warehouseText` rather than `nullableString`, though all
+            // three are NOT NULL on the primary. The warehouse declares no constraints,
+            // and a strict mapper would spend the queue's retries on a value frozen in
+            // the snapshot. See the note on `warehouseText`.
+            project_id: warehouseText(row.project_id),
+            git_branch: warehouseText(row.git_branch),
+            file_path: warehouseText(row.file_path),
+            deleted: row._snowflake_deleted,
+          }))
+        );
+        return {
+          // Three records per manifest row, sharing the row's id, so a file and the
+          // branch and project it was indexed under stay groupable. `file_hash`,
+          // `chunk_count` and the line counts are deliberately not exported: they
+          // describe the index, not the person's work.
+          records: rows.flatMap(row => [
+            {
+              source: 'code_indexing_manifest',
+              id: row.id,
+              field: 'project_id',
+              value: row.project_id,
+              ...deletionMark(row.deleted),
+            },
+            {
+              source: 'code_indexing_manifest',
+              id: row.id,
+              field: 'git_branch',
+              value: row.git_branch,
+              ...deletionMark(row.deleted),
+            },
+            {
+              source: 'code_indexing_manifest',
+              id: row.id,
+              field: 'file_path',
+              value: row.file_path,
+              ...deletionMark(row.deleted),
+            },
+          ]),
+          nextCursor: nextKeyCursor(rows, input.limit, row => [row.id]),
+        };
+      },
+    },
   ];
 }
 
@@ -865,6 +966,8 @@ export const warehouseQueries = {
   systemPromptOrgQuery: systemPromptQueries.organization,
   userPromptUserQuery: userPromptQueries.user,
   userPromptOrgQuery: userPromptQueries.organization,
+  codeIndexingUserQuery: codeIndexingQueries.user,
+  codeIndexingOrgQuery: codeIndexingQueries.organization,
 };
 
 export const sourceQueries = { ...warehouseQueries, userQuery, warehouseProfileQuery };
@@ -922,6 +1025,11 @@ export const WAREHOUSE_SOURCE_COLUMNS: Record<string, readonly string[]> = {
   ],
   system_prompt_prefix: ['system_prompt_prefix_id', 'system_prompt_prefix', DELETED_COLUMN],
   microdollar_usage_metadata: ['id', 'user_prompt_prefix'],
+  // The whole of the narrowed table bar its two owner columns, which `sourceQueryScopes`
+  // covers. `_snowflake_inserted_at` is deliberately absent: it was dropped from the load
+  // on 2026-08-14 and survives only in the unload's WHERE clause, so probing for it would
+  // fail a table that is in fact present and complete.
+  code_indexing_manifest: ['id', 'project_id', 'git_branch', 'file_path', DELETED_COLUMN],
 };
 
 /** Sources filtered by a scope column, as opposed to one of their own keys. */
@@ -1039,6 +1147,8 @@ export const sourceQueryScopes: Record<keyof typeof sourceQueries, ScopePredicat
   systemPromptOrgQuery: 'organization_id = $1',
   userPromptUserQuery: 'kilo_user_id = $1',
   userPromptOrgQuery: 'organization_id = $1',
+  codeIndexingUserQuery: 'kilo_user_id = $1',
+  codeIndexingOrgQuery: 'organization_id = $1',
   userQuery: 'id = $1',
   warehouseProfileQuery: 'user_id = $1',
 };


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

- Updates `code_indexing_manifest` as a sixth warehouse source in the user data export.
- Bumps the export file format to version 3.

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
