### PR TITLE
fix(ai-gateway): guide teams to a custom pool when restrictions block all auto-routing models

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -965,6 +965,66 @@ describe('kilo-auto/efficient classifier billing', () => {
     const [stats] = mockedLogMicrodollarUsage.mock.calls[0];
     expect(stats.cost_mUsd).toBe(1000); // toMicrodollars(0.001)
   });
+
+  it('guides teams that block every pool model to configure a custom Efficient pool', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-123',
+    });
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: {},
+      plan: 'enterprise',
+    });
+    mockedGetEffectiveModelDecision.mockResolvedValue({
+      allowed: false,
+      denialSource: 'group_model',
+    });
+    mockedFetchEfficientAutoDecision.mockResolvedValue({ decision: null, costUsd: 0 });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('kilo-auto/efficient')) as never);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error_type: 'model_not_allowed',
+      message: expect.stringContaining('custom Efficient model pool'),
+    });
+    expect(mockedUpstreamRequest).not.toHaveBeenCalled();
+  });
+
+  it('guides enterprise teams whose deny list blocks every pool model to configure a custom Efficient pool', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-123',
+    });
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: { model_deny_list: ['anthropic/claude-haiku-4'] },
+      plan: 'enterprise',
+    });
+    mockedFetchEfficientAutoDecision.mockResolvedValue({ decision: null, costUsd: 0 });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('kilo-auto/efficient')) as never);
+
+    expect(response.status).toBe(404);
+    expect(await response.json()).toMatchObject({
+      error_type: 'model_not_allowed',
+      message: expect.stringContaining('custom Efficient model pool'),
+    });
+    expect(mockedUpstreamRequest).not.toHaveBeenCalled();
+  });
 });
 
 describe('auto-routing shadow classifier', () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -41,6 +41,7 @@ import {
   makeErrorReadable,
   modelDoesNotExistResponse,
   modelNotAllowedResponse,
+  efficientPoolBlockedResponse,
   extractHeaderAndLimitLength,
   noFreeModelsAvailableResponse,
   organizationAutoConfigurationResponse,
@@ -319,11 +320,17 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   // validation after resolution.
   let routingTarget: string | null = null;
   let classifierCostUsd = 0;
+  // Efficient/balanced requests resolve through the auto-routing pool. Kept for
+  // the org policy check below so a team that blocks every pool model gets
+  // guidance to configure a custom Efficient model pool instead of the generic
+  // model-not-allowed error.
+  let isAutoEfficientRequest = false;
   if (isKiloAutoModel(requestedModelLowerCased)) {
     autoModel = requestedModelLowerCased;
     const isAutoEfficientId =
       requestedModelLowerCased === KILO_AUTO_EFFICIENT_MODEL.id ||
       requestedModelLowerCased === KILO_AUTO_BALANCED_MODEL.id;
+    isAutoEfficientRequest = isAutoEfficientId;
     const efficientDecision = isAutoEfficientId
       ? async () => {
           const { user, authFailedResponse, organizationId } = await authPromise;
@@ -791,7 +798,9 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       settings,
       organizationPlan: plan,
     });
-    if (modelRestrictionError) return modelRestrictionError;
+    if (modelRestrictionError) {
+      return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelRestrictionError;
+    }
 
     let effectiveProviderConfig = providerConfig;
     const groupPolicy = await organizationGroupPolicyPromise;
@@ -802,7 +811,9 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
         groupPolicy,
         effectiveModelIdLowerCased
       );
-      if (!groupDecision.allowed) return modelNotAllowedResponse();
+      if (!groupDecision.allowed) {
+        return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelNotAllowedResponse();
+      }
       if (groupDecision.eligibleProviderRoutes) {
         const currentOnly = providerConfig?.only;
         const only = currentOnly

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -304,12 +304,13 @@ export function modelNotAllowedResponse() {
 }
 
 export function efficientPoolBlockedResponse() {
+  const error = 'Your organization blocks every model in the auto-routing pool.';
   const message =
-    'Your organization blocks every model in the auto-routing pool. ' +
-    'Configure a custom Efficient model pool with allowed models, or adjust your organization model restrictions.';
+    `${error} Configure a custom Efficient model pool with allowed models, ` +
+    `or adjust your organization model restrictions.`;
   return NextResponse.json(
     {
-      error: 'Your organization blocks every model in the auto-routing pool.',
+      error,
       error_type: ProxyErrorType.model_not_allowed,
       message,
     },

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -303,6 +303,20 @@ export function modelNotAllowedResponse() {
   );
 }
 
+export function efficientPoolBlockedResponse() {
+  const message =
+    'Your organization blocks every model in the auto-routing pool. ' +
+    'Configure a custom Efficient model pool with allowed models, or adjust your organization model restrictions.';
+  return NextResponse.json(
+    {
+      error: 'Your organization blocks every model in the auto-routing pool.',
+      error_type: ProxyErrorType.model_not_allowed,
+      message,
+    },
+    { status: 404 }
+  );
+}
+
 export function unavailableModelResponse() {
   const error = 'The requested model is currently unavailable. Please choose a different model.';
   return NextResponse.json(


### PR DESCRIPTION
## Summary

When an organization's model restrictions (group policy or enterprise `model_deny_list`) block every model in the auto-routing pool, `kilo-auto/efficient` / `kilo-auto/balanced` requests fall back to the static balanced Qwen model. If that fallback is also blocked, the gateway returned the generic `model_not_allowed` error, which gives the user no path forward.

This change returns a targeted message that tells the team to configure a custom **Efficient model pool** with allowed models (or adjust their restrictions) instead.

### Readers

- **User:** when their organization blocks every auto-routing model, the user now sees a guidance message (configure a custom Efficient model pool) instead of the generic "model not allowed" error.
- **Product manager:** new visible behavior — a targeted guidance message replaces the generic error in the blocked-pool case. No other visible change.
- **Maintainer:** adds `efficientPoolBlockedResponse()` in `llm-proxy-helpers.ts` and tracks `isAutoEfficientRequest` in the openrouter route, returning the new response from both the enterprise deny-list check and the group-policy check when the request was efficient/balanced. `error_type` stays `model_not_allowed`, so existing client handling is unchanged.

## Verification

No manual test path: the change is backend-only and fully covered by automated tests. `jest route.test.ts` — 31 passed; `jest llm-proxy-helpers` — 60 passed. Bot E2E returned `VERIFICATION PASSED.` for the efficient, balanced, and non-auto scenarios.

## Visual Changes

N/A

## Human steps

No step is needed. No migration, secret, environment value, flag, deploy order, or cache clear is required.

## Reviewer Notes

- Non-auto requests keep the existing `model_not_allowed` message.
- Both restriction paths (enterprise deny list and group policy) return the new response only for efficient/balanced requests.
