### PR TITLE
perf(data-export): size pages by bytes per row, not row count

### DIFF
--- a/services/user-data-export/src/source-adapters.test.ts
+++ b/services/user-data-export/src/source-adapters.test.ts
@@ -633,7 +633,7 @@ describe('source adapters', () => {
 
   it('reads fewer message rows per page than the default', () => {
     const messages = requireAdapter(harness().adapters, 'app_builder_messages');
-    expect(messages.pageSize).toBe(200);
+    expect(messages.pageSize).toBe(500);
   });
 
   // The sync metadata was dropped from this projection on request. The table does hold
@@ -1090,10 +1090,15 @@ describe('source adapters', () => {
   });
 
   // Reads fewer rows per page than the default, because a row carries a whole result set.
-  it('cuts the search page size, as the message source does', async () => {
+  // The widest source measured, so it is cut below the message source rather than to the
+  // same number: both sizes come from bytes per row, not from a shared row count.
+  it('cuts the search page size below the message source', async () => {
     const { adapters } = harness([SEARCH_ROW]);
 
-    expect(requireAdapter(adapters, 'code_indexing_search').pageSize).toBe(200);
+    const search = requireAdapter(adapters, 'code_indexing_search').pageSize;
+    const messages = requireAdapter(adapters, 'app_builder_messages').pageSize;
+    expect(search).toBe(400);
+    expect(search).toBeLessThan(messages ?? 0);
   });
 
   it('reads a non-string search value as absent rather than failing the export', async () => {

--- a/services/user-data-export/src/source-adapters.ts
+++ b/services/user-data-export/src/source-adapters.ts
@@ -944,30 +944,70 @@ const securityFindingQueries = subjectPageQueries({
   columns: SECURITY_FINDING_COLUMNS.join(', '),
 });
 
-// Message payloads are whole conversations rather than single fields, so this source
-// reads fewer rows per page than the others.
-const MESSAGE_PAGE_SIZE = 200;
+/**
+ * Page sizes, and why each is the number it is.
+ *
+ * A page costs roughly 300-400 ms of fixed round trip before it has returned a single row,
+ * which is most of what a small page costs at all. Measured on an organization export
+ * 2026-08-15: 200-row pages took 354-668 ms and 1,000-row pages took 620-1,105 ms, so
+ * five times the rows cost under twice the time. Wall clock is therefore governed by page
+ * COUNT far more than by page size, and every size below is as large as its row width
+ * allows rather than as small as it can be.
+ *
+ * That inverts the reasoning these constants originally carried. They were cut to keep
+ * large rows from making a page unwieldy, which was right, but the cut was expressed as a
+ * row count and row counts are not comparable across sources: 200 rows of
+ * `app_builder_messages` is 168 KB and 200 rows of `code_indexing_search` is 1,062 KB.
+ * Each size is now that source's MEASURED bytes per row divided into a shared budget.
+ *
+ * The budget is about 2 MB of uncompressed payload per page, against a 128 MB Worker. A
+ * page is live three times over at peak — the driver's rows, the mapped rows, the emitted
+ * records — so the true high-water mark is nearer three times the figures below. Sizes are
+ * bounded by each source's WORST observed row, not its average, because one page of
+ * outliers is what would exhaust memory rather than the typical case.
+ *
+ * Measurements are from a single large organization and bound nothing about another one.
+ * Where a source's observed spread is wide, the size stays conservative for that reason.
+ */
 
 /**
- * `metadata` carries the whole result set of a search, not a single value, so rows here
- * are large in the same way message payloads are and the page is cut for the same reason.
+ * Whole conversations, one per row. 0.84 KB per row typical, but the widest page observed
+ * held 9.04 KB per row — a 10x spread, the largest of any source here. 500 rows is 420 KB
+ * typical and 4.5 MB at that observed worst, which is why this rises by 2.5x rather than
+ * the 4x its typical width would allow.
  */
-const SEARCH_PAGE_SIZE = 200;
+const MESSAGE_PAGE_SIZE = 500;
+
+/**
+ * `metadata` carries the whole result set of a search, not a single value. The widest
+ * source measured at 5.42 KB per row typical and 6.42 KB worst, so 400 rows is 2.2 MB
+ * typical and 2.6 MB worst. Raised the least of the four, being the one whose rows are
+ * genuinely large rather than occasionally large.
+ */
+const SEARCH_PAGE_SIZE = 400;
 
 /**
  * A review journal row carries `previous_summary_body`, the whole prior summary text, and
- * about 7.4 rows exist per review. Cut for the same reason as the message source.
+ * about 7.4 rows exist per review. 1.37 KB per row typical, 1.96 KB worst, so 1,000 rows
+ * is 1.4 MB typical and 2.0 MB worst.
  */
-const CODE_REVIEW_PAGE_SIZE = 200;
+const CODE_REVIEW_PAGE_SIZE = 1_000;
 
-/** Deployment events carry a payload per event, so the page is cut for the same reason. */
-const DEPLOYMENT_EVENT_PAGE_SIZE = 200;
+/**
+ * Deployment events carry a payload per event, but the payloads proved uniform: 0.84 KB
+ * per row typical against 0.90 KB worst, a 7% spread. A tight distribution is what admits
+ * the largest jump, so 2,000 rows is 1.8 MB even at the observed worst.
+ */
+const DEPLOYMENT_EVENT_PAGE_SIZE = 2_000;
 
 /**
  * A finding carries the whole upstream alert in `raw_data`, plus a description and an
- * analysis blob, and emits fifteen records per row. Cut hardest of the four.
+ * analysis blob, and emits fifteen records per row. Still cut hardest of the five, and the
+ * only one raised without measurement: the organization profiled held no findings, so
+ * there is no bytes-per-row figure to divide into the budget. Raised 2.5x on the strength
+ * of the round-trip argument alone, which is the part that does not depend on width.
  */
-const SECURITY_FINDING_PAGE_SIZE = 100;
+const SECURITY_FINDING_PAGE_SIZE = 250;
 
 type ProjectRow = { id: string; title: string | null };
 type MessageRow = { id: string; data: unknown };

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -27,7 +27,17 @@ import { classifyFetchFailure, logExportEvent, safeError, withSpan } from './obs
 const MAX_PROCESSING_MS = 13 * 60 * 1000;
 const SOURCE_PROCESSING_MS = 12 * 60 * 1000;
 const PART_BYTES = 5 * 1024 * 1024;
-const PAGE_SIZE = 1_000;
+/**
+ * The page size for every source that does not override it, which is every NARROW source:
+ * the widest of them measured 0.48 KB per row, so 4,000 rows is under 2 MB. The sources
+ * whose rows are large enough for that to matter set `pageSize` themselves, and the byte
+ * budget all of those are derived from is documented beside them in `source-adapters.ts`.
+ *
+ * Raised from 1,000 on 2026-08-15. A page costs 300-400 ms of fixed round trip before
+ * returning a row, so an export's wall clock tracks page COUNT far more than page size,
+ * and an organization export was exhausting the 13-minute deadline on round trips alone.
+ */
+const PAGE_SIZE = 4_000;
 
 function exportDeadlineError(): TerminalExportError {
   return new TerminalExportError(


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->
An organization export exhausted the 13-minute deadline at
  deployment_events, source 8 of 14, having spent 92s of CPU against 722s
  of wall clock. Almost all of it was round trips: a page costs 300-400ms
  before returning a row, so 200-row pages took 354-668ms and 1,000-row
  pages took 620-1,105ms. Five times the rows, under twice the time.

  Page sizes were row counts, which are not comparable across sources:
  200 rows of app_builder_messages is 168KB and 200 rows of
  code_indexing_search is 1,062KB. Each is now that source's measured
  bytes per row divided into a shared ~2MB budget, bounded by the worst
  observed row rather than the average.

  Expected ~2x on wall clock. Not a fix for the largest organizations,
  which need resume across invocations.



## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
