### PR TITLE
feat(ai-gateway): add disclaimer description for custom LLMs

### DIFF
--- a/apps/web/src/lib/ai-gateway/custom-llm/listAvailableCustomLlms.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/listAvailableCustomLlms.ts
@@ -4,6 +4,9 @@ import { CustomLlmDefinitionSchema, type CustomLlmDefinition } from '@kilocode/d
 import { orderOpenCodeSettings } from './order-opencode-variants';
 import { hasCustomLlmAccess } from './access';
 
+const CUSTOM_LLM_DESCRIPTION =
+  'Access to this model was granted by a Kilo admin. This model has no availability or data retention guarantees. Do not use for mission critical workloads. Existence of the model may be confidential.';
+
 function convert(publicId: string, model: CustomLlmDefinition) {
   return {
     id: publicId,
@@ -11,7 +14,7 @@ function convert(publicId: string, model: CustomLlmDefinition) {
     hugging_face_id: '',
     name: model.display_name,
     created: 1756238927,
-    description: model.display_name,
+    description: CUSTOM_LLM_DESCRIPTION,
     context_length: model.context_length,
     architecture: {
       modality: model.supports_image_input ? 'text+image-\u003Etext' : 'text-\u003Etext',


### PR DESCRIPTION
Custom LLMs (`kilo-internal/*`) previously surfaced with an empty/meaningless description in the model catalog. They now carry a standard disclaimer:

> Access to this model was granted by a Kilo admin. This model has no availability or data retention guarantees. Do not use for mission critical workloads. Existence of the model may be confidential.

## Changes

- `apps/web/src/lib/ai-gateway/custom-llm/listAvailableCustomLlms.ts`: set `description` to the disclaimer instead of duplicating `display_name` (which is already shown as `name`).

## Verification

- Formatted with `oxfmt` and linted with `oxlint` (0 warnings/errors).
- Jest suites in this area require a live Postgres test database, which is unavailable in this environment; the change is a string-literal swap on the same property, so types are unaffected.