### PR TITLE
feat(mobile): smart-render write tool sheet body

### DIFF
--- a/apps/mobile/src/components/agents/tool-cards/write-tool-card.test.ts
+++ b/apps/mobile/src/components/agents/tool-cards/write-tool-card.test.ts
@@ -1,7 +1,6 @@
 import { type ToolPart } from '@kilocode/cloud-agent-sdk';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-import { type ToolDiffModel } from '../tool-diff-model';
 import { WriteToolCard, WriteToolCardBody } from './write-tool-card';
 import * as React from 'react';
 
@@ -18,25 +17,19 @@ vi.mock('@/components/ui/text', async () => {
 vi.mock('../bubble-text-selection-context', () => ({
   useTranscriptTextSelectable: () => true,
 }));
-vi.mock('../mono-scroll-block', () => ({ MonoScrollBlock: 'MonoScrollBlock' }));
 vi.mock('../fixed-part-row', () => ({ FixedPartRow: 'FixedPartRow' }));
-vi.mock('../tool-diff-preview', () => ({ ToolDiffPreview: 'ToolDiffPreview' }));
+vi.mock('../code-block', () => ({ CodeBlock: 'CodeBlock' }));
+vi.mock('../read-markdown-body', () => ({ ReadMarkdownBody: 'ReadMarkdownBody' }));
 vi.mock('react', async importOriginal => {
   const actual = await importOriginal<typeof React>();
   return {
     default: actual,
     ...actual,
-    useMemo: <T>(fn: () => T): T => fn(),
     // `SelectableText` is invoked directly by the pure walker, outside a React
     // render, so the real `useContext` would throw on the null dispatcher.
     useContext: () => undefined,
   };
 });
-
-const { buildToolDiffModel } = vi.hoisted(() => ({
-  buildToolDiffModel: vi.fn(),
-}));
-vi.mock('../tool-diff-model', () => ({ buildToolDiffModel }));
 
 const { getToolDisplay, toolPartHasDetails, openSpy } = vi.hoisted(() => ({
   getToolDisplay: vi.fn(),
@@ -108,16 +101,6 @@ function makeWritePart(overrides: {
   };
 }
 
-function makeModel(): ToolDiffModel {
-  return {
-    lines: [{ type: 'add', newLine: 1, text: 'hello world', noNewlineAtEndOfFile: false }],
-    filePath: 'src/new.ts',
-    language: 'typescript',
-    truncated: false,
-    tool: 'write',
-  };
-}
-
 function findAll(
   node: unknown,
   predicate: (el: React.ReactElement) => boolean
@@ -152,9 +135,15 @@ function findByType(root: React.ReactElement, type: string): React.ReactElement[
   return findAll(root, el => el.type === type);
 }
 
+function findErrorText(root: React.ReactElement, value: string): React.ReactElement[] {
+  return findAll(
+    root,
+    el => el.type === 'TextInput' && (el.props as { value?: string }).value === value
+  );
+}
+
 describe('WriteToolCard — fixed row', () => {
   beforeEach(() => {
-    buildToolDiffModel.mockReset();
     getToolDisplay.mockReset();
     toolPartHasDetails.mockReset();
     openSpy.mockReset();
@@ -214,84 +203,130 @@ describe('WriteToolCard — fixed row', () => {
   });
 });
 
-describe('WriteToolCardBody — diff preview routing', () => {
-  beforeEach(() => {
-    buildToolDiffModel.mockReset();
-  });
-
-  it('renders ToolDiffPreview when the model exists', () => {
-    const model = makeModel();
-    buildToolDiffModel.mockReturnValue(model);
-    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
-    const root = WriteToolCardBody({ part: makeWritePart({}) }) as unknown as React.ReactElement;
-    const previews = findByType(root, 'ToolDiffPreview');
-    expect(previews).toHaveLength(1);
-  });
-
-  it('passes the model and partId to ToolDiffPreview', () => {
-    const model = makeModel();
-    buildToolDiffModel.mockReturnValue(model);
-    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
-    const root = WriteToolCardBody({ part: makeWritePart({}) }) as unknown as React.ReactElement;
-    const preview = findByType(root, 'ToolDiffPreview')[0];
-    expect(preview).toBeDefined();
-    if (!preview) {
-      throw new Error('preview not found');
-    }
-    expect((preview.props as { model: unknown }).model).toBe(model);
-    expect((preview.props as { partId: unknown }).partId).toBe('write-1');
-  });
-
-  it('renders MonoScrollBlock fallback when the model does not exist', () => {
-    buildToolDiffModel.mockReturnValue(null);
+describe('WriteToolCardBody — smart render routing', () => {
+  it('routes a .md path to ReadMarkdownBody and not CodeBlock', () => {
     // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
     const root = WriteToolCardBody({
-      part: makeWritePart({ content: 'hello' }),
+      part: makeWritePart({ filePath: 'README.md', content: '# Hello' }),
     }) as unknown as React.ReactElement;
+    const bodies = findByType(root, 'ReadMarkdownBody');
+    expect(bodies).toHaveLength(1);
+    const body = bodies[0];
+    if (!body) {
+      throw new Error('body not found');
+    }
+    expect((body.props as { body: unknown }).body).toEqual({ text: '# Hello', footer: undefined });
+    expect(findByType(root, 'CodeBlock')).toHaveLength(0);
     expect(findByType(root, 'ToolDiffPreview')).toHaveLength(0);
-    const blocks = findByType(root, 'MonoScrollBlock');
+  });
+
+  it('routes a .mdx path to ReadMarkdownBody', () => {
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCardBody({
+      part: makeWritePart({ filePath: 'page.mdx', content: '# Page' }),
+    }) as unknown as React.ReactElement;
+    expect(findByType(root, 'ReadMarkdownBody')).toHaveLength(1);
+    expect(findByType(root, 'CodeBlock')).toHaveLength(0);
+    expect(findByType(root, 'ToolDiffPreview')).toHaveLength(0);
+  });
+
+  it('routes a .MD path to ReadMarkdownBody', () => {
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCardBody({
+      part: makeWritePart({ filePath: 'NOTES.MD', content: '# Notes' }),
+    }) as unknown as React.ReactElement;
+    expect(findByType(root, 'ReadMarkdownBody')).toHaveLength(1);
+    expect(findByType(root, 'CodeBlock')).toHaveLength(0);
+  });
+
+  it('routes a non-markdown path to CodeBlock with languageForPath', () => {
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCardBody({
+      part: makeWritePart({ filePath: 'src/new.ts', content: 'hello world' }),
+    }) as unknown as React.ReactElement;
+    const blocks = findByType(root, 'CodeBlock');
     expect(blocks).toHaveLength(1);
     const block = blocks[0];
     if (!block) {
       throw new Error('block not found');
     }
-    expect((block.props as { maxLength?: unknown }).maxLength).toBeUndefined();
-  });
-
-  it('renders no body when the model does not exist and content is empty', () => {
-    buildToolDiffModel.mockReturnValue(null);
-    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
-    const root = WriteToolCardBody({
-      part: makeWritePart({ content: '' }),
-    }) as unknown as React.ReactElement;
+    expect(block.props).toMatchObject({
+      code: 'hello world',
+      language: 'typescript',
+      maxLength: 50_000,
+    });
+    expect(findByType(root, 'ReadMarkdownBody')).toHaveLength(0);
     expect(findByType(root, 'ToolDiffPreview')).toHaveLength(0);
-    expect(findByType(root, 'MonoScrollBlock')).toHaveLength(0);
   });
 
-  it('preserves the error block when the model exists', () => {
-    const model = makeModel();
-    buildToolDiffModel.mockReturnValue(model);
+  it('routes an unknown extension to CodeBlock with null language', () => {
     // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
     const root = WriteToolCardBody({
-      part: makeWritePart({ status: 'error', error: 'write failed' }),
+      part: makeWritePart({ filePath: 'Makefile', content: 'x' }),
     }) as unknown as React.ReactElement;
-    const texts = findAll(
-      root,
-      el => el.type === 'TextInput' && (el.props as { value?: string }).value === 'write failed'
-    );
-    expect(texts).toHaveLength(1);
+    const block = findByType(root, 'CodeBlock')[0];
+    if (!block) {
+      throw new Error('block not found');
+    }
+    expect((block.props as { language: unknown }).language).toBeNull();
   });
 
-  it('preserves the error block when the model does not exist', () => {
-    buildToolDiffModel.mockReturnValue(null);
+  it('renders the empty line for empty non-markdown content', () => {
     // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
     const root = WriteToolCardBody({
-      part: makeWritePart({ content: 'hello', status: 'error', error: 'write error' }),
+      part: makeWritePart({ filePath: 'src/empty.ts', content: '' }),
     }) as unknown as React.ReactElement;
-    const texts = findAll(
-      root,
-      el => el.type === 'TextInput' && (el.props as { value?: string }).value === 'write error'
-    );
+    const texts = findByType(root, 'Text');
     expect(texts).toHaveLength(1);
+    const text = texts[0];
+    if (!text) {
+      throw new Error('text not found');
+    }
+    expect((text.props as { children?: unknown }).children).toBe('This file is empty.');
+    expect(findByType(root, 'CodeBlock')).toHaveLength(0);
+    expect(findByType(root, 'ReadMarkdownBody')).toHaveLength(0);
+  });
+
+  it('routes empty markdown content through ReadMarkdownBody', () => {
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCardBody({
+      part: makeWritePart({ filePath: 'README.md', content: '' }),
+    }) as unknown as React.ReactElement;
+    const bodies = findByType(root, 'ReadMarkdownBody');
+    expect(bodies).toHaveLength(1);
+    const body = bodies[0];
+    if (!body) {
+      throw new Error('body not found');
+    }
+    expect((body.props as { body: { text: string } }).body.text).toBe('');
+    expect(findByType(root, 'CodeBlock')).toHaveLength(0);
+  });
+
+  it('preserves the error block next to a code body', () => {
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCardBody({
+      part: makeWritePart({
+        status: 'error',
+        error: 'write failed',
+        filePath: 'src/new.ts',
+        content: 'hello',
+      }),
+    }) as unknown as React.ReactElement;
+    expect(findErrorText(root, 'write failed')).toHaveLength(1);
+    expect(findByType(root, 'CodeBlock')).toHaveLength(1);
+  });
+
+  it('preserves the error block next to a markdown body', () => {
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCardBody({
+      part: makeWritePart({
+        status: 'error',
+        error: 'write failed',
+        filePath: 'README.md',
+        content: '# Hello',
+      }),
+    }) as unknown as React.ReactElement;
+    expect(findErrorText(root, 'write failed')).toHaveLength(1);
+    expect(findByType(root, 'ReadMarkdownBody')).toHaveLength(1);
   });
 });

--- a/apps/mobile/src/components/agents/tool-cards/write-tool-card.test.ts
+++ b/apps/mobile/src/components/agents/tool-cards/write-tool-card.test.ts
@@ -81,14 +81,12 @@ function makeWritePart(overrides: {
   const filePath = overrides.filePath ?? 'src/new.ts';
   const content = overrides.content ?? 'hello world';
 
-  const state: ToolPart['state'] =
-    overrides.status === 'error'
-      ? makeErrorState({
-          filePath,
-          content,
-          error: overrides.error ?? 'failed',
-        })
-      : makeCompletedState({ filePath, content });
+  let state: ToolPart['state'] = makeCompletedState({ filePath, content });
+  if (overrides.status === 'error') {
+    state = makeErrorState({ filePath, content, error: overrides.error ?? 'failed' });
+  } else if (overrides.status === 'running') {
+    state = { status: 'running', input: { filePath, content }, time: { start: 0 } };
+  }
 
   return {
     id: 'write-1',
@@ -204,6 +202,16 @@ describe('WriteToolCard — fixed row', () => {
 });
 
 describe('WriteToolCardBody — smart render routing', () => {
+  it('renders no body for empty content while pending or running', () => {
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = WriteToolCardBody({
+      part: makeWritePart({ status: 'running', filePath: 'src/empty.ts', content: '' }),
+    }) as unknown as React.ReactElement;
+    expect(findByType(root, 'CodeBlock')).toHaveLength(0);
+    expect(findByType(root, 'ReadMarkdownBody')).toHaveLength(0);
+    expect(findByType(root, 'Text')).toHaveLength(0);
+  });
+
   it('routes a .md path to ReadMarkdownBody and not CodeBlock', () => {
     // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
     const root = WriteToolCardBody({

--- a/apps/mobile/src/components/agents/tool-cards/write-tool-card.tsx
+++ b/apps/mobile/src/components/agents/tool-cards/write-tool-card.tsx
@@ -1,36 +1,45 @@
-import { useMemo } from 'react';
 import { View } from 'react-native';
 import { FilePlus } from 'lucide-react-native';
 import { type ToolPart } from '@kilocode/cloud-agent-sdk';
 
 import { SelectableText } from '@/components/ui/selectable-text';
+import { Text } from '@/components/ui/text';
+import { languageForPath } from '@/lib/pr-review/diff/highlight';
 
+import { CodeBlock } from '../code-block';
 import { FixedPartRow } from '../fixed-part-row';
-import { MonoScrollBlock } from '../mono-scroll-block';
 import { useOpenPartDetail } from '../open-part-detail-context';
+import { ReadMarkdownBody } from '../read-markdown-body';
+import { isMarkdownPath } from '../read-tool-markdown';
 import { getToolDisplay, toolPartHasDetails } from '../tool-card-display';
-import { buildToolDiffModel } from '../tool-diff-model';
-import { ToolDiffPreview } from '../tool-diff-preview';
+
+const WRITE_CODE_CHARACTER_CAP = 50_000;
 
 /**
- * Sheet body for a write tool part: the diff preview when the model exists,
- * else the content block, plus the error. Renders only inside the detail sheet
- * — attachments and the pending/running status line live in
+ * Sheet body for a write tool part: markdown or highlighted code from
+ * `input.content`, plus the error. Diff preview is gone. Renders only inside
+ * the detail sheet — attachments and the pending/running status line live in
  * `ToolPartDetailBody`.
  */
 export function WriteToolCardBody({ part }: Readonly<{ part: ToolPart }>) {
   const input = part.state.input;
+  const filePath = typeof input.filePath === 'string' ? input.filePath : '';
   const content = typeof input.content === 'string' ? input.content : '';
-
   const error = part.state.status === 'error' ? part.state.error : undefined;
 
-  const diffModel = useMemo(() => buildToolDiffModel(part), [part]);
-
   let body: React.ReactNode = null;
-  if (diffModel) {
-    body = <ToolDiffPreview model={diffModel} partId={part.id} />;
-  } else if (content.length > 0) {
-    body = <MonoScrollBlock content={content} textClassName="text-foreground" />;
+  if (isMarkdownPath(filePath)) {
+    body = <ReadMarkdownBody body={{ text: content, footer: undefined }} />;
+  } else if (content === '') {
+    body = <Text className="text-xs text-muted-foreground">This file is empty.</Text>;
+  } else {
+    body = (
+      <CodeBlock
+        code={content}
+        language={languageForPath(filePath)}
+        maxLength={WRITE_CODE_CHARACTER_CAP}
+      />
+    );
   }
 
   return (

--- a/apps/mobile/src/components/agents/tool-cards/write-tool-card.tsx
+++ b/apps/mobile/src/components/agents/tool-cards/write-tool-card.tsx
@@ -26,9 +26,13 @@ export function WriteToolCardBody({ part }: Readonly<{ part: ToolPart }>) {
   const filePath = typeof input.filePath === 'string' ? input.filePath : '';
   const content = typeof input.content === 'string' ? input.content : '';
   const error = part.state.status === 'error' ? part.state.error : undefined;
+  const isFinal = part.state.status === 'completed' || part.state.status === 'error';
 
   let body: React.ReactNode = null;
-  if (isMarkdownPath(filePath)) {
+  if (content === '' && !isFinal) {
+    // Pending or running: the write has not finished, so the file is not yet
+    // known to be empty. `ToolPartDetailBody` already shows the status line.
+  } else if (isMarkdownPath(filePath)) {
     body = <ReadMarkdownBody body={{ text: content, footer: undefined }} />;
   } else if (content === '') {
     body = <Text className="text-xs text-muted-foreground">This file is empty.</Text>;

--- a/apps/mobile/src/components/agents/tool-diff-model.test.ts
+++ b/apps/mobile/src/components/agents/tool-diff-model.test.ts
@@ -39,29 +39,6 @@ function makeEditToolPart(overrides: {
   };
 }
 
-function makeWriteToolPart(overrides: { filePath?: string; content?: string }): ToolPart {
-  const input: Record<string, unknown> = {
-    filePath: overrides.filePath ?? 'src/new.ts',
-    content: overrides.content ?? '',
-  };
-  return {
-    id: 'write-1',
-    sessionID: 'session-1',
-    messageID: 'message-1',
-    type: 'tool' as const,
-    callID: 'call-1',
-    tool: 'write',
-    state: {
-      status: 'completed',
-      input,
-      output: '',
-      title: 'write',
-      metadata: {},
-      time: { start: 0, end: 1 },
-    },
-  };
-}
-
 describe('buildToolDiffModel — edit tool', () => {
   it('returns deleted and added numbered DiffLine rows for a valid edit', () => {
     const part = makeEditToolPart({
@@ -209,106 +186,6 @@ describe('buildToolDiffModel — edit tool', () => {
   });
 });
 
-describe('buildToolDiffModel — write tool', () => {
-  it('returns added numbered DiffLine rows for a valid write', () => {
-    const part = makeWriteToolPart({ content: 'line1\nline2\nline3' });
-    const model = mustBe(buildToolDiffModel(part), 'model');
-    expect(model.tool).toBe('write');
-    expect(model.truncated).toBe(false);
-
-    const { lines } = model;
-    expect(lines).toHaveLength(3);
-    expect(lines[0]).toEqual({
-      type: 'add',
-      newLine: 1,
-      text: 'line1',
-      noNewlineAtEndOfFile: false,
-    });
-    expect(lines[1]).toEqual({
-      type: 'add',
-      newLine: 2,
-      text: 'line2',
-      noNewlineAtEndOfFile: false,
-    });
-    expect(lines[2]).toEqual({
-      type: 'add',
-      newLine: 3,
-      text: 'line3',
-      noNewlineAtEndOfFile: false,
-    });
-  });
-
-  it('resolves language for .js files to javascript', () => {
-    const part = makeWriteToolPart({ filePath: 'src/foo.js', content: 'x' });
-    const model = mustBe(buildToolDiffModel(part), 'model');
-    expect(model.language).toBe('javascript');
-  });
-
-  it('resolves language to null for unknown extensions', () => {
-    const part = makeWriteToolPart({ filePath: 'Makefile', content: 'x' });
-    const model = mustBe(buildToolDiffModel(part), 'model');
-    expect(model.language).toBeNull();
-  });
-
-  it('returns null when content is empty', () => {
-    const part = makeWriteToolPart({ content: '' });
-    expect(buildToolDiffModel(part)).toBeNull();
-  });
-
-  it('returns a valid model for whitespace-only content (blank lines)', () => {
-    const part = makeWriteToolPart({ content: '\n\n' });
-    // splitTrimTrailingEmpty removes the final empty, but keeps \n lines.
-    const model = buildToolDiffModel(part);
-    // Two non-empty entries from ["", ""] after trailing pop.
-    expect(model).not.toBeNull();
-  });
-
-  it('returns null when content is missing (undefined treated as empty)', () => {
-    const part = makeWriteToolPart({ content: undefined });
-    expect(buildToolDiffModel(part)).toBeNull();
-  });
-
-  it('truncates content at the character cap', () => {
-    const longContent = 'x'.repeat(WRITE_CHARACTER_CAP + 100);
-    const part = makeWriteToolPart({ content: longContent });
-    const model = mustBe(buildToolDiffModel(part), 'model');
-    expect(model.truncated).toBe(true);
-    const totalChars =
-      model.lines.reduce((sum, l) => sum + l.text.length, 0) + (model.lines.length - 1);
-    expect(totalChars).toBeLessThanOrEqual(WRITE_CHARACTER_CAP);
-  });
-
-  it('truncates at the line cap', () => {
-    const manyLines = Array.from({ length: WRITE_LINE_CAP + 10 }, (_, i) => `line${i}`).join('\n');
-    const part = makeWriteToolPart({ content: manyLines });
-    const model = mustBe(buildToolDiffModel(part), 'model');
-    expect(model.truncated).toBe(true);
-    expect(model.lines).toHaveLength(WRITE_LINE_CAP);
-  });
-
-  it('strips CR from CRLF, bare-CR, and mixed write content', () => {
-    const crlfPart = makeWriteToolPart({ content: 'alpha\r\nbeta\r\ncharlie' });
-    const crlfModel = mustBe(buildToolDiffModel(crlfPart), 'model');
-    expect(crlfModel.lines).toHaveLength(3);
-    expect(crlfModel.lines[0]).toMatchObject({ type: 'add', newLine: 1, text: 'alpha' });
-    expect(crlfModel.lines[1]).toMatchObject({ type: 'add', newLine: 2, text: 'beta' });
-    expect(crlfModel.lines[2]).toMatchObject({ type: 'add', newLine: 3, text: 'charlie' });
-
-    const barePart = makeWriteToolPart({ content: 'one\rtwo' });
-    const bareModel = mustBe(buildToolDiffModel(barePart), 'model');
-    expect(bareModel.lines).toHaveLength(2);
-    expect(bareModel.lines[0]).toMatchObject({ type: 'add', newLine: 1, text: 'one' });
-    expect(bareModel.lines[1]).toMatchObject({ type: 'add', newLine: 2, text: 'two' });
-
-    const mixedPart = makeWriteToolPart({ content: 'line1\nline2\r\nline3' });
-    const mixedModel = mustBe(buildToolDiffModel(mixedPart), 'model');
-    expect(mixedModel.lines).toHaveLength(3);
-    expect(mixedModel.lines[0]).toMatchObject({ type: 'add', newLine: 1, text: 'line1' });
-    expect(mixedModel.lines[1]).toMatchObject({ type: 'add', newLine: 2, text: 'line2' });
-    expect(mixedModel.lines[2]).toMatchObject({ type: 'add', newLine: 3, text: 'line3' });
-  });
-});
-
 describe('buildToolDiffModel — non-diff tools', () => {
   it('returns null for a bash tool part', () => {
     const part: ToolPart = {
@@ -354,5 +231,3 @@ describe('buildToolDiffModel — non-diff tools', () => {
 // Constants from the model, duplicated here for focused assertion.
 const EDIT_CHARACTER_CAP = 10_000;
 const EDIT_LINE_CAP = 500;
-const WRITE_CHARACTER_CAP = 20_000;
-const WRITE_LINE_CAP = 1000;

--- a/apps/mobile/src/components/agents/tool-diff-model.ts
+++ b/apps/mobile/src/components/agents/tool-diff-model.ts
@@ -1,9 +1,8 @@
-// Pure model that converts edit and write tool inputs into
+// Pure model that converts edit tool inputs into
 // `ParsedDiffLine` rows for the shared tool diff preview.
 //
 // Edit: builds deleted rows from `oldString` and added rows from
 // `newString`, numbered independently from one.
-// Write: builds added rows from `content`, numbered from one.
 //
 // Character and line caps bound output size. The model is null when
 // the input is absent, invalid, or carries no diff content.
@@ -21,8 +20,6 @@ import { languageForPath } from '@/lib/pr-review/diff/highlight';
 // body renders at a time.
 const EDIT_CHARACTER_CAP = 10_000;
 const EDIT_LINE_CAP = 500;
-const WRITE_CHARACTER_CAP = 20_000;
-const WRITE_LINE_CAP = 1000;
 
 export type ToolDiffModel = {
   lines: readonly ParsedDiffLine[];
@@ -34,9 +31,9 @@ export type ToolDiffModel = {
 };
 
 /**
- * Convert an edit or write tool part into a diff model.
- * Returns null when the tool is neither edit nor write, the input is
- * absent or invalid, or the diff content is empty.
+ * Convert an edit tool part into a diff model.
+ * Returns null when the tool is not edit, the input is absent or
+ * invalid, or the diff content is empty.
  */
 export function buildToolDiffModel(part: ToolPart): ToolDiffModel | null {
   const tool = part.tool;
@@ -83,43 +80,6 @@ export function buildToolDiffModel(part: ToolPart): ToolDiffModel | null {
         })
       ),
     ];
-
-    return {
-      lines,
-      filePath,
-      language: languageForPath(filePath),
-      truncated,
-      tool,
-    };
-  }
-
-  if (tool === 'write') {
-    const filePath = typeof input.filePath === 'string' ? input.filePath : '';
-    const content = typeof input.content === 'string' ? input.content : '';
-
-    if (!content) {
-      return null;
-    }
-
-    const sliced = content.slice(0, WRITE_CHARACTER_CAP);
-    const textLines = splitTrimTrailingEmpty(sliced);
-
-    if (textLines.length === 0) {
-      return null;
-    }
-
-    const truncated = content.length > WRITE_CHARACTER_CAP || textLines.length > WRITE_LINE_CAP;
-
-    const cappedLines = textLines.slice(0, WRITE_LINE_CAP);
-
-    const lines: ParsedDiffLine[] = cappedLines.map(
-      (text, i): ParsedDiffLine => ({
-        type: 'add',
-        newLine: i + 1,
-        text,
-        noNewlineAtEndOfFile: false,
-      })
-    );
 
     return {
       lines,

--- a/apps/mobile/src/components/agents/tool-diff-preview.tsx
+++ b/apps/mobile/src/components/agents/tool-diff-preview.tsx
@@ -1,4 +1,4 @@
-// Read-only diff preview for edit and write tool cards.
+// Read-only diff preview for edit tool cards.
 // Renders every `ParsedDiffLine` from the model through the shared
 // `DiffLine` component with syntax highlighting.
 //


### PR DESCRIPTION
## What

The write tool detail sheet now shows the written file content the same way the read tool does, instead of a diff preview.

- `.md` / `.mdx` files render as markdown.
- Every other file renders as highlighted code.
- Empty files show `This file is empty.`
- The red error text still shows on a failed write.

The transcript row (filename + status) is unchanged. The edit tool keeps its diff preview.

## Why

A write is a full new file, not a set of edits. A green add-only diff was the wrong presentation for it. The read tool already has the smart render split (markdown vs highlighted code); the write sheet now reuses it.

## How

`WriteToolCardBody` now routes on `isMarkdownPath(filePath)`: markdown goes through the existing `ReadMarkdownBody`, everything else through the existing `CodeBlock` with `languageForPath`, capped at 50,000 characters to match the read code cap. Empty content shows the same empty line as the read card. The now-dead write branch was removed from `buildToolDiffModel`, along with its character and line caps.

## Human steps

- Before merge: attach the four screenshots listed under Visual Changes to this PR.

## Visual Changes

Screenshot upload failed (no browser session token on the host). The E2E frames are at these local paths; attach them before merge:

- Markdown sheet: `/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo/write-tool-screenshots/write-md-sheet.png`
- Code sheet: `/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo/write-tool-screenshots/write-code-sheet.png`
- Empty sheet: `/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo/write-tool-screenshots/write-empty-sheet.png`
- Error sheet: `/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo/write-tool-screenshots/write-error-sheet.png`

E2E: bot-e2e — all six scenarios passed on iOS (markdown, code, empty, error, edit regression, transcript row).
