### PR TITLE
feat(mobile): share model favorites across pickers

### DIFF
--- a/apps/mobile/src/components/agents/model-picker-content.tsx
+++ b/apps/mobile/src/components/agents/model-picker-content.tsx
@@ -14,7 +14,7 @@ import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import {
   buildModelPickerRows,
-  modelPickerFavoriteId,
+  favoriteToggleAction,
   type ModelPickerRow,
 } from '@/lib/model-picker-rows';
 import {
@@ -28,7 +28,7 @@ export function ModelPickerContent() {
   const router = useRouter();
   const colors = useThemeColors();
   const { bottom } = useSafeAreaInsets();
-  const { favorites, favoritesError, toggleFavorite } = useModelPreferences(undefined);
+  const { favorites, favoritesError, addFavorite, removeFavorite } = useModelPreferences(undefined);
   const favoriteIds = useMemo(() => new Set(favorites), [favorites]);
   const [search, setSearch] = useState('');
   const [bridge, setBridge] = useState(() => getModelPickerBridge());
@@ -88,9 +88,16 @@ export function ModelPickerContent() {
   // selection haptic on press — this callback must not fire a second one.
   const handleToggleFavorite = useCallback(
     (option: SessionModelOption) => {
-      toggleFavorite(modelPickerFavoriteId(option));
+      const action = favoriteToggleAction(option, favorites);
+      if (action.type === 'remove') {
+        for (const model of action.models) {
+          removeFavorite({ model });
+        }
+      } else {
+        addFavorite({ model: action.model });
+      }
     },
-    [toggleFavorite]
+    [favorites, addFavorite, removeFavorite]
   );
 
   const handleSelectVariant = useCallback(

--- a/apps/mobile/src/lib/hooks/use-model-preferences.ts
+++ b/apps/mobile/src/lib/hooks/use-model-preferences.ts
@@ -118,18 +118,6 @@ export function useModelPreferences(organizationId: string | undefined) {
     })
   );
 
-  const toggleFavorite = useCallback(
-    (model: string) => {
-      const isFavorite = query.data?.favorites.includes(model) ?? false;
-      if (isFavorite) {
-        removeFavorite.mutate({ model });
-      } else {
-        addFavorite.mutate({ model });
-      }
-    },
-    [query.data?.favorites, addFavorite, removeFavorite]
-  );
-
   return {
     favorites: query.data?.favorites ?? [],
     favoritesError,
@@ -140,6 +128,5 @@ export function useModelPreferences(organizationId: string | undefined) {
     addFavorite: addFavorite.mutate,
     removeFavorite: removeFavorite.mutate,
     setFavorites: setFavorites.mutate,
-    toggleFavorite,
   };
 }

--- a/apps/mobile/src/lib/model-picker-rows.test.ts
+++ b/apps/mobile/src/lib/model-picker-rows.test.ts
@@ -1,29 +1,38 @@
+/* eslint-disable max-lines -- Favorite-id helpers cover every representation. */
 import { describe, expect, it } from 'vitest';
 
 import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 
-import { buildModelPickerRows, modelPickerFavoriteId } from './model-picker-rows';
+import {
+  buildModelPickerRows,
+  canonicalFavoriteId,
+  favoriteKeysForOption,
+  favoriteToggleAction,
+  isFavoriteOption,
+  modelPickerFavoriteId,
+} from './model-picker-rows';
 
 const noFavorites = new Set<string>();
 
-const gatewayModels: SessionModelOption[] = [
-  {
-    id: 'anthropic/claude-sonnet-4',
-    name: 'Claude Sonnet 4',
-    displayId: 'anthropic/claude-sonnet-4',
-    variants: ['low'],
-    isPreferred: true,
-    showGatewayMetadata: true,
-  },
-  {
-    id: 'openai/gpt-5',
-    name: 'GPT-5',
-    displayId: 'openai/gpt-5',
-    variants: ['medium'],
-    isPreferred: false,
-    showGatewayMetadata: true,
-  },
-];
+const gatewayClaude: SessionModelOption = {
+  id: 'anthropic/claude-sonnet-4',
+  name: 'Claude Sonnet 4',
+  displayId: 'anthropic/claude-sonnet-4',
+  variants: ['low'],
+  isPreferred: true,
+  showGatewayMetadata: true,
+};
+
+const gatewayGpt5: SessionModelOption = {
+  id: 'openai/gpt-5',
+  name: 'GPT-5',
+  displayId: 'openai/gpt-5',
+  variants: ['medium'],
+  isPreferred: false,
+  showGatewayMetadata: true,
+};
+
+const gatewayModels: SessionModelOption[] = [gatewayClaude, gatewayGpt5];
 
 const remoteWorkspaceClaude: SessionModelOption = {
   id: 'remote-model-0',
@@ -45,6 +54,18 @@ const remoteInternalDeployment: SessionModelOption = {
   isPreferred: false,
   provider: { id: 'custom-openai', name: 'Custom OpenAI' },
   modelRef: { providerID: 'custom-openai', modelID: 'shared/model.id' },
+  overrideSource: 'cli-catalog',
+  showGatewayMetadata: false,
+};
+
+const remoteKiloClaude: SessionModelOption = {
+  id: 'remote-model-kilo',
+  name: 'Claude Sonnet 4',
+  displayId: 'anthropic/claude-sonnet-4',
+  variants: [],
+  isPreferred: false,
+  provider: { id: 'kilo', name: 'Kilo' },
+  modelRef: { providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4' },
   overrideSource: 'cli-catalog',
   showGatewayMetadata: false,
 };
@@ -199,5 +220,165 @@ describe('modelPickerFavoriteId', () => {
       showGatewayMetadata: true,
     };
     expect(modelPickerFavoriteId(legacyOption)).toBe('anthropic/claude-sonnet-4');
+  });
+});
+
+describe('canonicalFavoriteId', () => {
+  it('keys a Gateway option by its Gateway model id', () => {
+    expect(canonicalFavoriteId(gatewayGpt5)).toBe('openai/gpt-5');
+  });
+
+  it('keys a kilo CLI option by its Gateway model id, not remote:kilo', () => {
+    expect(canonicalFavoriteId(remoteKiloClaude)).toBe('anthropic/claude-sonnet-4');
+  });
+
+  it('keys a non-kilo CLI option by remote:provider:model', () => {
+    expect(canonicalFavoriteId(remoteInternalDeployment)).toBe(
+      'remote:custom-openai:shared/model.id'
+    );
+  });
+
+  it('keys a legacy-gateway option by its id', () => {
+    const legacyOption: SessionModelOption = {
+      id: 'anthropic/claude-sonnet-4',
+      name: 'Claude Sonnet 4',
+      displayId: 'anthropic/claude-sonnet-4',
+      variants: [],
+      isPreferred: false,
+      modelRef: { providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4' },
+      overrideSource: 'legacy-gateway',
+      showGatewayMetadata: true,
+    };
+    expect(canonicalFavoriteId(legacyOption)).toBe('anthropic/claude-sonnet-4');
+  });
+});
+
+describe('isFavoriteOption', () => {
+  it('matches a kilo CLI option by its Gateway id', () => {
+    expect(isFavoriteOption(remoteKiloClaude, new Set(['anthropic/claude-sonnet-4']))).toBe(true);
+  });
+
+  it('matches a kilo CLI option by its remote:kilo alias', () => {
+    expect(
+      isFavoriteOption(remoteKiloClaude, new Set(['remote:kilo:anthropic/claude-sonnet-4']))
+    ).toBe(true);
+  });
+
+  it('matches a Gateway option by its Gateway id', () => {
+    expect(isFavoriteOption(gatewayClaude, new Set(['anthropic/claude-sonnet-4']))).toBe(true);
+  });
+
+  it('matches a Gateway option by its remote:kilo alias', () => {
+    expect(
+      isFavoriteOption(gatewayClaude, new Set(['remote:kilo:anthropic/claude-sonnet-4']))
+    ).toBe(true);
+  });
+
+  it('does not match a Gateway option by an unrelated remote key', () => {
+    expect(isFavoriteOption(gatewayGpt5, new Set(['remote:custom-openai:shared/model.id']))).toBe(
+      false
+    );
+  });
+});
+
+describe('favoriteKeysForOption', () => {
+  it('includes both the Gateway id and the remote:kilo alias for a kilo CLI option', () => {
+    expect(favoriteKeysForOption(remoteKiloClaude).toSorted()).toEqual([
+      'anthropic/claude-sonnet-4',
+      'remote:kilo:anthropic/claude-sonnet-4',
+    ]);
+  });
+
+  it('includes both the Gateway id and the remote:kilo alias for a Gateway option', () => {
+    expect(favoriteKeysForOption(gatewayClaude).toSorted()).toEqual([
+      'anthropic/claude-sonnet-4',
+      'remote:kilo:anthropic/claude-sonnet-4',
+    ]);
+  });
+});
+
+describe('favoriteToggleAction', () => {
+  it('removes only the stored remote:kilo alias', () => {
+    expect(favoriteToggleAction(gatewayClaude, ['remote:kilo:anthropic/claude-sonnet-4'])).toEqual({
+      type: 'remove',
+      models: ['remote:kilo:anthropic/claude-sonnet-4'],
+    });
+  });
+
+  it('removes both stored keys in any order', () => {
+    const action = favoriteToggleAction(gatewayClaude, [
+      'anthropic/claude-sonnet-4',
+      'remote:kilo:anthropic/claude-sonnet-4',
+    ]);
+    expect(action.type).toBe('remove');
+    if (action.type === 'remove') {
+      expect(action.models.toSorted()).toEqual([
+        'anthropic/claude-sonnet-4',
+        'remote:kilo:anthropic/claude-sonnet-4',
+      ]);
+    }
+  });
+
+  it('adds the canonical id for an unstarred kilo CLI option', () => {
+    expect(favoriteToggleAction(remoteKiloClaude, [])).toEqual({
+      type: 'add',
+      model: 'anthropic/claude-sonnet-4',
+    });
+  });
+
+  it('removes a stored non-kilo remote key', () => {
+    expect(
+      favoriteToggleAction(remoteInternalDeployment, ['remote:custom-openai:shared/model.id'])
+    ).toEqual({
+      type: 'remove',
+      models: ['remote:custom-openai:shared/model.id'],
+    });
+  });
+});
+
+describe('favorite grouping across representations', () => {
+  it('puts only the Gateway Claude in FAVORITES for a Gateway-only list', () => {
+    const favoriteIds = new Set([
+      'anthropic/claude-sonnet-4',
+      'remote:custom-openai:shared/model.id',
+    ]);
+    const rows = buildModelPickerRows({ models: gatewayModels, search: '', favoriteIds });
+    const favoriteRows = rows.filter(row => row.type === 'model' && row.isFavorite);
+    expect(favoriteRows.map(row => (row.type === 'model' ? row.model.id : ''))).toEqual([
+      'anthropic/claude-sonnet-4',
+    ]);
+  });
+
+  it('puts both the kilo CLI and custom CLI rows in FAVORITES for a CLI list', () => {
+    const favoriteIds = new Set([
+      'anthropic/claude-sonnet-4',
+      'remote:custom-openai:shared/model.id',
+    ]);
+    const rows = buildModelPickerRows({
+      models: [remoteKiloClaude, remoteInternalDeployment],
+      search: '',
+      favoriteIds,
+    });
+    const favoriteRows = rows.filter(row => row.type === 'model' && row.isFavorite);
+    expect(favoriteRows.map(row => (row.type === 'model' ? row.model.id : ''))).toEqual([
+      'remote-model-kilo',
+      'remote-model-1',
+    ]);
+  });
+
+  it('keeps the write id unchanged when BYOK is available on a Gateway option', () => {
+    const byokGateway: SessionModelOption = {
+      ...gatewayClaude,
+      hasUserByokAvailable: true,
+    };
+    expect(canonicalFavoriteId(byokGateway)).toBe('anthropic/claude-sonnet-4');
+  });
+
+  it('keeps the write id unchanged when BYOK is available on a custom CLI option', () => {
+    const byokCustom: SessionModelOption = {
+      ...remoteInternalDeployment,
+      hasUserByokAvailable: true,
+    };
+    expect(canonicalFavoriteId(byokCustom)).toBe('remote:custom-openai:shared/model.id');
   });
 });

--- a/apps/mobile/src/lib/model-picker-rows.test.ts
+++ b/apps/mobile/src/lib/model-picker-rows.test.ts
@@ -220,35 +220,13 @@ describe('canonicalFavoriteId', () => {
     };
     expect(canonicalFavoriteId(legacyOption)).toBe('anthropic/claude-sonnet-4');
   });
-});
 
-describe('canonicalFavoriteId', () => {
   it('keys a Gateway option by its Gateway model id', () => {
     expect(canonicalFavoriteId(gatewayGpt5)).toBe('openai/gpt-5');
   });
 
   it('keys a kilo CLI option by its Gateway model id, not remote:kilo', () => {
     expect(canonicalFavoriteId(remoteKiloClaude)).toBe('anthropic/claude-sonnet-4');
-  });
-
-  it('keys a non-kilo CLI option by remote:provider:model', () => {
-    expect(canonicalFavoriteId(remoteInternalDeployment)).toBe(
-      'remote:custom-openai:shared/model.id'
-    );
-  });
-
-  it('keys a legacy-gateway option by its id', () => {
-    const legacyOption: SessionModelOption = {
-      id: 'anthropic/claude-sonnet-4',
-      name: 'Claude Sonnet 4',
-      displayId: 'anthropic/claude-sonnet-4',
-      variants: [],
-      isPreferred: false,
-      modelRef: { providerID: 'kilo', modelID: 'anthropic/claude-sonnet-4' },
-      overrideSource: 'legacy-gateway',
-      showGatewayMetadata: true,
-    };
-    expect(canonicalFavoriteId(legacyOption)).toBe('anthropic/claude-sonnet-4');
   });
 });
 

--- a/apps/mobile/src/lib/model-picker-rows.test.ts
+++ b/apps/mobile/src/lib/model-picker-rows.test.ts
@@ -9,7 +9,6 @@ import {
   favoriteKeysForOption,
   favoriteToggleAction,
   isFavoriteOption,
-  modelPickerFavoriteId,
 } from './model-picker-rows';
 
 const noFavorites = new Set<string>();
@@ -186,12 +185,12 @@ describe('buildModelPickerRows', () => {
   });
 });
 
-describe('modelPickerFavoriteId', () => {
+describe('canonicalFavoriteId', () => {
   it('keys CLI catalog options by provider and model identity, not the opaque id', () => {
-    expect(modelPickerFavoriteId(remoteWorkspaceClaude)).toBe(
+    expect(canonicalFavoriteId(remoteWorkspaceClaude)).toBe(
       'remote:anthropic-local:shared/model.id'
     );
-    expect(modelPickerFavoriteId(remoteInternalDeployment)).toBe(
+    expect(canonicalFavoriteId(remoteInternalDeployment)).toBe(
       'remote:custom-openai:shared/model.id'
     );
   });
@@ -205,7 +204,7 @@ describe('modelPickerFavoriteId', () => {
       isPreferred: false,
       showGatewayMetadata: true,
     };
-    expect(modelPickerFavoriteId(gatewayOption)).toBe('anthropic/claude-sonnet-4');
+    expect(canonicalFavoriteId(gatewayOption)).toBe('anthropic/claude-sonnet-4');
   });
 
   it('keeps legacy Gateway options on the Gateway model id shared with Gateway favorites', () => {
@@ -219,7 +218,7 @@ describe('modelPickerFavoriteId', () => {
       overrideSource: 'legacy-gateway',
       showGatewayMetadata: true,
     };
-    expect(modelPickerFavoriteId(legacyOption)).toBe('anthropic/claude-sonnet-4');
+    expect(canonicalFavoriteId(legacyOption)).toBe('anthropic/claude-sonnet-4');
   });
 });
 

--- a/apps/mobile/src/lib/model-picker-rows.ts
+++ b/apps/mobile/src/lib/model-picker-rows.ts
@@ -38,9 +38,6 @@ export function canonicalFavoriteId(model: SessionModelOption): string {
   return model.id;
 }
 
-// Legacy alias kept for existing callers and tests.
-export const modelPickerFavoriteId = canonicalFavoriteId;
-
 // Every stored string that marks this option starred. Gateway options accept
 // their Gateway id and the historical `remote:kilo:<id>` alias; kilo CLI options
 // accept the same pair; other-provider CLI options accept only their

--- a/apps/mobile/src/lib/model-picker-rows.ts
+++ b/apps/mobile/src/lib/model-picker-rows.ts
@@ -10,15 +10,69 @@ type ModelGroup = {
   models: SessionModelOption[];
 };
 
-// Favorites are persisted server-side by this key, so it must be stable
-// across sessions and catalog refreshes. CLI catalog options get opaque
-// order-based `id`s (`remote-model-N`), so favorite them by their CLI model
-// identity instead. Legacy Gateway options keep `id` — it is the Gateway
-// model id and already shared with regular Gateway favorites.
-export function modelPickerFavoriteId(model: SessionModelOption): string {
-  return model.modelRef && model.overrideSource !== 'legacy-gateway'
-    ? `remote:${model.modelRef.providerID}:${model.modelRef.modelID}`
-    : model.id;
+export type FavoriteToggleAction =
+  | { type: 'add'; model: string }
+  | { type: 'remove'; models: string[] };
+
+// A CLI-catalog option is one with a CLI `modelRef` that is not a legacy
+// Gateway projection. A Gateway or legacy-gateway option is everything else,
+// including an option with no `modelRef`.
+function isCliCatalogOption(model: SessionModelOption): boolean {
+  return Boolean(model.modelRef) && model.overrideSource !== 'legacy-gateway';
+}
+
+// The stable write id. Favorites are persisted server-side by this key, so it
+// must be stable across sessions and catalog refreshes. CLI catalog options get
+// opaque order-based `id`s (`remote-model-N`), so favorite them by their CLI
+// model identity instead. Kilo CLI options share the Gateway model id; other
+// providers get a `remote:<provider>:<model>` key. Gateway and legacy-gateway
+// options keep `id` — the Gateway model id shared with regular Gateway
+// favorites.
+export function canonicalFavoriteId(model: SessionModelOption): string {
+  const modelRef = isCliCatalogOption(model) ? model.modelRef : undefined;
+  if (modelRef) {
+    return modelRef.providerID === 'kilo'
+      ? modelRef.modelID
+      : `remote:${modelRef.providerID}:${modelRef.modelID}`;
+  }
+  return model.id;
+}
+
+// Legacy alias kept for existing callers and tests.
+export const modelPickerFavoriteId = canonicalFavoriteId;
+
+// Every stored string that marks this option starred. Gateway options accept
+// their Gateway id and the historical `remote:kilo:<id>` alias; kilo CLI options
+// accept the same pair; other-provider CLI options accept only their
+// `remote:<provider>:<model>` key.
+export function favoriteKeysForOption(model: SessionModelOption): string[] {
+  const modelRef = isCliCatalogOption(model) ? model.modelRef : undefined;
+  if (modelRef) {
+    if (modelRef.providerID === 'kilo') {
+      return [modelRef.modelID, `remote:kilo:${modelRef.modelID}`];
+    }
+    return [`remote:${modelRef.providerID}:${modelRef.modelID}`];
+  }
+  return [model.id, `remote:kilo:${model.id}`];
+}
+
+export function isFavoriteOption(
+  model: SessionModelOption,
+  favoriteIds: ReadonlySet<string>
+): boolean {
+  return favoriteKeysForOption(model).some(key => favoriteIds.has(key));
+}
+
+export function favoriteToggleAction(
+  option: SessionModelOption,
+  storedFavorites: readonly string[]
+): FavoriteToggleAction {
+  const stored = new Set(storedFavorites);
+  const matching = favoriteKeysForOption(option).filter(key => stored.has(key));
+  if (matching.length > 0) {
+    return { type: 'remove', models: matching };
+  }
+  return { type: 'add', model: canonicalFavoriteId(option) };
 }
 
 export function buildModelPickerRows({
@@ -33,8 +87,8 @@ export function buildModelPickerRows({
   const query = search.toLowerCase().trim();
   const filtered = models.filter(model => !query || searchableText(model).includes(query));
 
-  const favorites = filtered.filter(model => favoriteIds.has(modelPickerFavoriteId(model)));
-  const rest = filtered.filter(model => !favoriteIds.has(modelPickerFavoriteId(model)));
+  const favorites = filtered.filter(model => isFavoriteOption(model, favoriteIds));
+  const rest = filtered.filter(model => !isFavoriteOption(model, favoriteIds));
 
   const rows: ModelPickerRow[] = [];
 

--- a/apps/mobile/src/lib/use-session-model-options.test.ts
+++ b/apps/mobile/src/lib/use-session-model-options.test.ts
@@ -7,7 +7,7 @@ import {
   createRemoteModelOverride,
   revalidateLegacyGatewayOverride,
 } from './hooks/use-session-model-options';
-import { buildModelPickerRows, modelPickerFavoriteId } from './model-picker-rows';
+import { buildModelPickerRows, canonicalFavoriteId } from './model-picker-rows';
 import { resolveSessionContextInfo } from './session-context-info';
 
 const gatewayModels = [
@@ -514,7 +514,7 @@ describe('buildSessionModelOptions capacity projection', () => {
     }
     expect(gatewayOption.provider).toBeUndefined();
     expect(gatewayOption.modelRef).toBeUndefined();
-    expect(modelPickerFavoriteId(gatewayOption)).toBe('gateway/recommended');
+    expect(canonicalFavoriteId(gatewayOption)).toBe('gateway/recommended');
     expect(
       buildModelPickerRows({ models: result.options, search: '', favoriteIds: new Set() })
         .filter(row => row.type === 'header')


### PR DESCRIPTION
## Summary

The mobile New session and Session model pickers now share the same star / FAVORITES state for the same model. Before, the two pickers wrote different id strings for one model, so a star on one page did not mark the other.

The change keeps one stored favorites list and adds a read-side match layer plus a canonical write id. No stored id migration, no new table, no new favorites API.

## Verification

- `pnpm test src/lib/model-picker-rows.test.ts src/lib/use-session-model-options.test.ts` — 44 tests pass.
- `pnpm typecheck`, `pnpm lint`, `pnpm check:unused`, `pnpm format`, `git diff --check` all pass from `apps/mobile`.
- Runtime behavior verified by the bot E2E loop on an iOS simulator: S1–S4 passed live (Gateway star sync, unstar sync, reverse path, CLI kilo overlap). S5 (CLI-only favorite hidden) and S7 (BYOK) hit their scenario-defined skip conditions and are covered by unit tests; S6 (inline error) is inspection-only.

## Visual Changes

N/A. The star icon and picker layout are unchanged. Only which star is filled now reflects a shared favorite.

## Reviewer Notes

- The core logic lives in `apps/mobile/src/lib/model-picker-rows.ts`: `canonicalFavoriteId` (write), `favoriteKeysForOption` (match/unstar), `isFavoriteOption`, and `favoriteToggleAction`.
- `handleToggleFavorite` in `model-picker-content.tsx` no longer calls `toggleFavorite`; it applies `favoriteToggleAction` then `addFavorite`/`removeFavorite` so unstar removes every accepted alias.
- Gateway and CLI kilo options share one stored id; other CLI providers keep `remote:<provider>:<model>`. Old `remote:kilo:<id>` stars still match on read.

---

### For the user

Starring a model on one picker now marks it starred on the other picker when that model appears in both lists. Unstarring clears it everywhere.

### For the product manager

Model favorites are now consistent across the New session and Session pickers. A model starred in one place shows the same star state in the other.

### For the maintainer

One backend favorites list remains. The picker now derives a canonical write id and a set of accepted match keys per option, so Gateway ids and the historical `remote:kilo:` alias reconcile to the same favorite. Unstar removes every accepted key. `buildModelPickerRows` filters favorites with `isFavoriteOption`, and the toggle path uses `favoriteToggleAction` followed by `addFavorite`/`removeFavorite`.

### Human steps

No step is needed. No secret, migration, flag, or deploy order is required.
