### PR TITLE
perf(data-export): raise the journal page size to its byte budget

### DIFF
--- a/services/user-data-export/src/source-adapters.ts
+++ b/services/user-data-export/src/source-adapters.ts
@@ -1129,6 +1129,27 @@ const DEPLOYMENT_EVENT_PAGE_SIZE = 2_000;
  */
 const SECURITY_FINDING_PAGE_SIZE = 250;
 
+/**
+ * The one source that overrides the default UPWARD rather than down, because it is the
+ * narrowest in the export and the default leaves half its budget unspent.
+ *
+ * Measured on the organization export of 2026-08-15: 0.25 KB per row, and the tightest
+ * distribution of any source at 998 KB typical against 1,016 KB worst — under 2% spread,
+ * so the worst case is the typical case. 8,000 rows is 2.0 MB, which is the budget, where
+ * the shared default of 4,000 spends only 1.0 MB of it.
+ *
+ * Worth its own constant because this is the source that decides whether a large
+ * organization finishes: it is both LAST in the order and the largest table in the
+ * warehouse at 158,433,290 rows, so it inherits whatever deadline the thirteen before it
+ * have left. The 2026-08-15 export died inside it having completed every other source.
+ *
+ * Expect roughly 60-90 seconds, not a fix. Fixed cost per page is only about a third of
+ * this source's page time — it reads 0.79 KB/ms against ~1.5 for every other source,
+ * being a keyset scan over the largest index here — so halving the page count does not
+ * halve the time. See the note on the CPU ceiling in `worker.ts`.
+ */
+const MICRODOLLAR_JOURNAL_PAGE_SIZE = 8_000;
+
 type ProjectRow = { id: string; title: string | null };
 type MessageRow = { id: string; data: unknown };
 type CloudAgentCodeReviewRow = {
@@ -2063,6 +2084,7 @@ export function createSourceAdapters(queries: SourceAdapterQueries): SourceAdapt
     {
       name: 'microdollar_usage_journal',
       warehouseTable: 'microdollar_usage_journal',
+      pageSize: MICRODOLLAR_JOURNAL_PAGE_SIZE,
       async readPage(input): Promise<SourcePage> {
         const [afterMost, afterLeast] = keyCursorValues(input.cursor, 2);
         const rows: MicrodollarJournalRow[] = await warehouseQuery(

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -24,6 +24,25 @@ import type { SourceAdapter } from './source-adapters';
 import { uploadGzipStream } from './gzip';
 import { classifyFetchFailure, logExportEvent, safeError, withSpan } from './observability';
 
+/**
+ * The wall-clock deadlines, and the reason tuning past this point does not help.
+ *
+ * These are not the only ceiling a large export runs into. `limits.cpu_ms` in
+ * `wrangler.jsonc` is 300,000, which is Cloudflare's MAXIMUM rather than a number we
+ * chose, so it cannot be raised. Measured on the organization export of 2026-08-15: 202 s
+ * of CPU to write 5.34 M records, or roughly 38 microseconds per record. That puts a hard
+ * ceiling near 7.5 M records on any single invocation, whatever the read path costs.
+ *
+ * So making reads faster moves the binding constraint from this deadline to that cap
+ * rather than removing it. The same export had already been sped up 3.2x — 1.65 M records
+ * to 5.34 M in the identical 12 minutes — and still died, on the last of its fourteen
+ * sources. An organization whose export does not fit needs the work SPLIT across
+ * invocations, not made faster inside one.
+ *
+ * The state columns for that still exist: `current_source`, `source_cursor` and
+ * `next_part_number` on `user_data_exports`, which `hasRetiredGeneratorState` below
+ * rejects because this generator is one-shot.
+ */
 const MAX_PROCESSING_MS = 13 * 60 * 1000;
 const SOURCE_PROCESSING_MS = 12 * 60 * 1000;
 const PART_BYTES = 5 * 1024 * 1024;


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

<!-- What changed and why? Keep this brief and outcome-focused. -->
<!-- Include any architectural changes and enough context for a reviewer unfamiliar with this code area. -->

raise the journal page size to its byte budget

  microdollar_usage_journal is the narrowest source in the export at 0.25 KB
  per row, and the shared default of 4,000 rows spends only 1.0 MB of the
  ~2 MB budget. 8,000 rows is 2.0 MB. Its distribution is the tightest
  measured — 998 KB typical against 1,016 KB worst, under 2% spread — so the
  worst case is the typical case.

## Verification

<!-- Only list manually tested paths, not automated tests. If you didn't run any manual tests, point that out, and explain why. -->

- [ ]

## Visual Changes

<!-- If UI/visual behavior changed, add before/after screenshots in the table below. -->
<!-- If there are no visual changes, replace the table with: N/A -->

| Before | After |
|---|---|
|  |  |

## Reviewer Notes

<!-- Optional: reviewer focus areas, edge cases, or context that helps review quickly. -->
