### PR TITLE
feat(mobile): add Review PR destination to the share gate

### DIFF
--- a/apps/mobile/src/components/share/share-gate-sheet.tsx
+++ b/apps/mobile/src/components/share/share-gate-sheet.tsx
@@ -2,7 +2,7 @@
 import { useQuery } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
 import { useRouter } from 'expo-router';
-import { Plus, X } from 'lucide-react-native';
+import { GitPullRequest, Plus, X } from 'lucide-react-native';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { Alert, Pressable, View } from 'react-native';
 import { toast } from 'sonner-native';
@@ -13,12 +13,15 @@ import {
 } from '@/components/agents/session-detail-routes';
 import { expandPlatformFilter } from '@/components/agents/session-list-helpers';
 import { getNewAgentSessionPath } from '@/components/agents/session-list-routes';
+import { DestinationOptionRow } from '@/components/destination-option-row';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
+import { FEATURE_FLAG_PR_REVIEW, useFeatureFlag } from '@/lib/analytics/posthog';
 import { useAgentSessions } from '@/lib/hooks/use-agent-sessions';
 import { useRemoteInstanceSpawn } from '@/lib/hooks/use-remote-instance-spawn';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { useOrganization } from '@/lib/organization-context';
+import { getPrReviewPath } from '@/lib/profile-agent-navigation';
 import { resolveRemoteSubmitOutcome } from '@/lib/remote-submit-outcome';
 import { appendShareParams, setPendingShareNavigation } from '@/lib/share-navigation';
 import { clearSharePayload, peekSharePayload, type ShareId } from '@/lib/share-payload';
@@ -40,6 +43,7 @@ import { ShareDestinationList } from './share-destination-list';
 import { isShareCommitEnabled, selectShareGateState } from './share-gate-state';
 import { SharePayloadPreview } from './share-payload-preview';
 import { type SharePayloadValidation, validateSharePayload } from './share-payload-validation';
+import { selectShareReviewPr } from './share-review-pr';
 
 type ShareGateSheetProps = {
   shareId: string | undefined;
@@ -164,6 +168,17 @@ export function ShareGateSheet({ shareId }: Readonly<ShareGateSheetProps>) {
     ]
   );
 
+  const prReviewEnabled = useFeatureFlag(FEATURE_FLAG_PR_REVIEW, true);
+  const reviewPr = useMemo(
+    () =>
+      selectShareReviewPr({
+        text: payload?.text ?? '',
+        prReviewEnabled,
+        showNewSession: state.showNewSession,
+      }),
+    [payload?.text, prReviewEnabled, state.showNewSession]
+  );
+
   const instanceRows = useMemo(
     () =>
       selectShareCliSpawnRows({
@@ -189,6 +204,18 @@ export function ShareGateSheet({ shareId }: Readonly<ShareGateSheetProps>) {
     abandon();
     router.back();
   }, [abandon, router]);
+
+  const handleReviewPr = useCallback(() => {
+    if (!reviewPr) {
+      return;
+    }
+    void Haptics.selectionAsync();
+    setPendingShareNavigation({
+      href: getPrReviewPath(reviewPr.owner, reviewPr.repo, reviewPr.number) as string,
+      shareId: null,
+    });
+    dismiss();
+  }, [dismiss, reviewPr]);
 
   useEffect(
     () => () => {
@@ -353,6 +380,16 @@ export function ShareGateSheet({ shareId }: Readonly<ShareGateSheetProps>) {
         <View className="items-center px-6 pb-6 pt-4">
           <Text className="text-center text-sm text-muted-foreground">{state.message}</Text>
         </View>
+      ) : null}
+
+      {reviewPr ? (
+        <DestinationOptionRow
+          icon={GitPullRequest}
+          title="Review PR"
+          subtitle={`${reviewPr.owner}/${reviewPr.repo} #${reviewPr.number}`}
+          accessibilityLabel="Review PR"
+          onPress={handleReviewPr}
+        />
       ) : null}
 
       {showNewSession ? (

--- a/apps/mobile/src/components/share/share-payload-navigator.tsx
+++ b/apps/mobile/src/components/share/share-payload-navigator.tsx
@@ -6,6 +6,7 @@ import {
   navigationContainsShareGate,
   parseShareHrefParams,
   type PendingShareNavigation,
+  shareDeliveryShareId,
   takePendingShareNavigation,
 } from '@/lib/share-navigation';
 
@@ -46,6 +47,11 @@ function deliver(
 ): void {
   const focused = isShareNavigationTargetFocused(pending.href, pathname);
   if (focused) {
+    // A null shareId is a non-share destination (e.g. Review PR): the target
+    // screen is already focused, so there is nothing to push or deliver.
+    if (!shareDeliveryShareId(pending)) {
+      return;
+    }
     // Committed href's org is the destination identity; path-only focus is
     // about the screen, not its params. undefined clears a stale org param.
     router.setParams({

--- a/apps/mobile/src/components/share/share-review-pr.test.ts
+++ b/apps/mobile/src/components/share/share-review-pr.test.ts
@@ -1,0 +1,67 @@
+import { describe, expect, it } from 'vitest';
+
+import { selectShareReviewPr } from './share-review-pr';
+
+const PR_URL = 'https://github.com/octocat/hello-world/pull/42';
+
+describe('selectShareReviewPr', () => {
+  it('returns the parsed destination when flag, new-session and PR text all hold', () => {
+    expect(
+      selectShareReviewPr({ text: PR_URL, prReviewEnabled: true, showNewSession: true })
+    ).toEqual({
+      owner: 'octocat',
+      repo: 'hello-world',
+      number: 42,
+    });
+  });
+
+  it('returns null when the flag is off', () => {
+    expect(
+      selectShareReviewPr({ text: PR_URL, prReviewEnabled: false, showNewSession: true })
+    ).toBeNull();
+  });
+
+  it('returns null for non-PR text', () => {
+    expect(
+      selectShareReviewPr({
+        text: 'https://example.com',
+        prReviewEnabled: true,
+        showNewSession: true,
+      })
+    ).toBeNull();
+  });
+
+  it('returns null when showNewSession is false even for a PR URL', () => {
+    expect(
+      selectShareReviewPr({ text: PR_URL, prReviewEnabled: true, showNewSession: false })
+    ).toBeNull();
+  });
+
+  it('matches a title-plus-URL text', () => {
+    expect(
+      selectShareReviewPr({
+        text: `Fix the thing\n${PR_URL}`,
+        prReviewEnabled: true,
+        showNewSession: true,
+      })
+    ).toEqual({
+      owner: 'octocat',
+      repo: 'hello-world',
+      number: 42,
+    });
+  });
+
+  it('returns the first URL when two PR URLs are present', () => {
+    expect(
+      selectShareReviewPr({
+        text: `${PR_URL} https://github.com/octocat/hello-world/pull/7`,
+        prReviewEnabled: true,
+        showNewSession: true,
+      })
+    ).toEqual({
+      owner: 'octocat',
+      repo: 'hello-world',
+      number: 42,
+    });
+  });
+});

--- a/apps/mobile/src/components/share/share-review-pr.ts
+++ b/apps/mobile/src/components/share/share-review-pr.ts
@@ -1,0 +1,18 @@
+import { findFirstGitHubPrUrl, type GitHubPrUrl } from '@/lib/github-pr-url';
+
+/**
+ * Decide whether the share gate shows the Review PR destination. The option is
+ * visible only when the feature flag is on, the gate would otherwise offer a
+ * New session (not a stale-share / all-rejected terminal state), and the staged
+ * text contains a parseable github.com PR URL.
+ */
+export function selectShareReviewPr(input: {
+  text: string;
+  prReviewEnabled: boolean;
+  showNewSession: boolean;
+}): GitHubPrUrl | null {
+  if (!input.prReviewEnabled || !input.showNewSession) {
+    return null;
+  }
+  return findFirstGitHubPrUrl(input.text);
+}

--- a/apps/mobile/src/lib/github-pr-url.test.ts
+++ b/apps/mobile/src/lib/github-pr-url.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { parseGitHubPrUrl } from './github-pr-url';
+import { findFirstGitHubPrUrl, parseGitHubPrUrl } from './github-pr-url';
 
 describe('parseGitHubPrUrl', () => {
   it('parses a canonical PR URL', () => {
@@ -101,6 +101,64 @@ describe('parseGitHubPrUrl', () => {
       owner: 'my.repo',
       repo: 'a-b_c',
       number: 1,
+    });
+  });
+});
+
+describe('findFirstGitHubPrUrl', () => {
+  it('parses a bare canonical PR URL', () => {
+    expect(findFirstGitHubPrUrl('https://github.com/octocat/hello-world/pull/42')).toEqual({
+      owner: 'octocat',
+      repo: 'hello-world',
+      number: 42,
+    });
+  });
+
+  it('parses a title plus URL', () => {
+    expect(
+      findFirstGitHubPrUrl('Fix the thing\nhttps://github.com/octocat/hello-world/pull/42')
+    ).toEqual({
+      owner: 'octocat',
+      repo: 'hello-world',
+      number: 42,
+    });
+  });
+
+  it('returns the first URL when two PR URLs are present', () => {
+    expect(
+      findFirstGitHubPrUrl(
+        'https://github.com/octocat/hello-world/pull/42 https://github.com/octocat/hello-world/pull/7'
+      )
+    ).toEqual({
+      owner: 'octocat',
+      repo: 'hello-world',
+      number: 42,
+    });
+  });
+
+  it('returns null for an issue URL', () => {
+    expect(findFirstGitHubPrUrl('https://github.com/octocat/hello-world/issues/42')).toBeNull();
+  });
+
+  it('returns null for a GitLab URL', () => {
+    expect(findFirstGitHubPrUrl('https://gitlab.com/octocat/hello-world/pull/42')).toBeNull();
+  });
+
+  it('returns null for plain text', () => {
+    expect(findFirstGitHubPrUrl('no url here at all')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(findFirstGitHubPrUrl('')).toBeNull();
+  });
+
+  it('parses a PR URL with extra words on one line', () => {
+    expect(
+      findFirstGitHubPrUrl('See https://github.com/octocat/hello-world/pull/42 please')
+    ).toEqual({
+      owner: 'octocat',
+      repo: 'hello-world',
+      number: 42,
     });
   });
 });

--- a/apps/mobile/src/lib/github-pr-url.ts
+++ b/apps/mobile/src/lib/github-pr-url.ts
@@ -1,4 +1,4 @@
-type GitHubPrUrl = {
+export type GitHubPrUrl = {
   owner: string;
   repo: string;
   number: number;
@@ -42,4 +42,27 @@ export function parseGitHubPrUrl(href: string): GitHubPrUrl | null {
     return null;
   }
   return { owner, repo, number };
+}
+
+/**
+ * Find the first GitHub PR URL in free text. Tries the whole trimmed string
+ * first, then each whitespace-separated token, so a title or surrounding words
+ * do not hide the URL. Returns `null` when no token parses as a PR URL.
+ */
+export function findFirstGitHubPrUrl(text: string): GitHubPrUrl | null {
+  if (typeof text !== 'string' || text.length === 0) {
+    return null;
+  }
+  const trimmed = text.trim();
+  const whole = parseGitHubPrUrl(trimmed);
+  if (whole) {
+    return whole;
+  }
+  for (const token of trimmed.split(/\s+/)) {
+    const parsed = parseGitHubPrUrl(token);
+    if (parsed) {
+      return parsed;
+    }
+  }
+  return null;
 }

--- a/apps/mobile/src/lib/share-navigation.test.ts
+++ b/apps/mobile/src/lib/share-navigation.test.ts
@@ -8,6 +8,7 @@ import {
   navigationContainsShareGate,
   parseShareHrefParams,
   setPendingShareNavigation,
+  shareDeliveryShareId,
   takePendingShareNavigation,
 } from './share-navigation';
 
@@ -60,7 +61,9 @@ describe('share-navigation', () => {
     const taken: string[] = [];
     let next = takePendingShareNavigation();
     while (next) {
-      taken.push(next.shareId);
+      if (shareDeliveryShareId(next)) {
+        taken.push(next.shareId);
+      }
       next = takePendingShareNavigation();
     }
     expect(taken).toHaveLength(SHARE_PAYLOAD_MAX_ENTRIES);
@@ -77,6 +80,31 @@ describe('share-navigation', () => {
     setPendingShareNavigation({ href: '/b', shareId: 'b' });
     __resetPendingShareNavigationForTests();
     expect(takePendingShareNavigation()).toBeNull();
+  });
+
+  it('enqueues and returns a null-shareId navigation unchanged', () => {
+    setPendingShareNavigation({
+      href: '/(app)/pr-review/octocat/hello-world/42',
+      shareId: null,
+    });
+    expect(takePendingShareNavigation()).toEqual({
+      href: '/(app)/pr-review/octocat/hello-world/42',
+      shareId: null,
+    });
+  });
+});
+
+describe('shareDeliveryShareId', () => {
+  it('is false when shareId is null', () => {
+    expect(
+      shareDeliveryShareId({ href: '/(app)/pr-review/octocat/hello-world/42', shareId: null })
+    ).toBe(false);
+  });
+
+  it('is true when shareId is a string', () => {
+    expect(shareDeliveryShareId({ href: '/(app)/agent-chat/new?shareId=a', shareId: 'a' })).toBe(
+      true
+    );
   });
 });
 

--- a/apps/mobile/src/lib/share-navigation.ts
+++ b/apps/mobile/src/lib/share-navigation.ts
@@ -1,6 +1,17 @@
 import { SHARE_PAYLOAD_MAX_ENTRIES, type ShareId } from '@/lib/share-payload';
 
-export type PendingShareNavigation = { href: string; shareId: ShareId };
+export type PendingShareNavigation = { href: string; shareId: ShareId | null };
+
+/**
+ * Narrow a pending navigation to the delivery case: `shareId` is a string.
+ * A null `shareId` means the gate dismissed to a non-share destination (e.g.
+ * Review PR) that must push `href` without delivering a payload.
+ */
+export function shareDeliveryShareId(
+  pending: PendingShareNavigation
+): pending is PendingShareNavigation & { shareId: ShareId } {
+  return pending.shareId !== null;
+}
 
 /** FIFO of committed share destinations waiting for gate dismiss + delivery. */
 const pendingQueue: PendingShareNavigation[] = [];


### PR DESCRIPTION
## What

When a user shares a github.com pull request URL into the mobile app, the share gate now shows a **Review PR** destination above **New session**, CLI instances, and recent sessions. Tapping it opens the in-app PR review for that owner/repo/number and does not deliver the share into a session.

## Notes

**For the user:** Sharing a GitHub PR link now offers a one-tap "Review PR" action in the share sheet. Tapping it opens the PR review screen instead of starting a new session.

**For the product manager:** The share gate gains a Review PR destination, gated by the `mobile-pr-review` feature flag (default on). Non-PR shares and flag-off behavior are unchanged.

**For the maintainer:** A new `findFirstGitHubPrUrl` helper reuses the existing `parseGitHubPrUrl` on whitespace tokens to detect a PR URL in staged `payload.text`. `selectShareReviewPr` gates visibility on the feature flag and `showNewSession`. `PendingShareNavigation` now carries `shareId: ShareId | null`; a `null` shareId means the navigator pushes the href without `setParams`, so Review PR navigates without staging a share delivery. The header renders a `DestinationOptionRow` with the `GitPullRequest` icon.

## Human steps

- **Before merge:** attach the E2E screenshots listed under Visual Changes (the automated upload had no browser session). No secret, environment value, migration, or deploy order is required. The feature flag `mobile-pr-review` defaults on.

## Visual Changes

Automated upload failed (no browser session on the host). Attach these iOS simulator screenshots as GitHub user-attachments before merge:

- `s1-gate-assert.png` — share gate for a PR-URL share: `Review PR` (subtitle `kilo-stub/discussion-mixed #1`) above `New session`.
- `s1-gate.png` — share gate for a PR-URL share, earlier capture.

Local paths:

- `/Users/igor/Projects/pr-5298-screenshots/s1-gate-assert.png`
- `/Users/igor/Projects/pr-5298-screenshots/s1-gate.png`

E2E: bot-e2e — iOS simulator verification (S1 happy PR share, S2 non-PR share, S3 existing destination) passed.
