### PR TITLE
fix(ai-gateway): route endpointless models through Vercel

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.test.ts
@@ -7,6 +7,7 @@ jest.mock('@/lib/redis', () => ({
 import {
   extractVercelInferenceProviderIdsFromModel,
   getLanguageModelIds,
+  getLanguageModelIdsWithoutEndpoints,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { StoredModel } from '@kilocode/db';
 
@@ -33,6 +34,23 @@ describe('getLanguageModelIds', () => {
         'vendor/image': storedModel({ id: 'vendor/image', type: 'image' }),
       })
     ).toEqual(['vendor/with-endpoints', 'vendor/no-endpoints', 'vendor/untyped']);
+  });
+});
+
+describe('getLanguageModelIdsWithoutEndpoints', () => {
+  it('returns only language models with no endpoints', () => {
+    expect(
+      getLanguageModelIdsWithoutEndpoints({
+        'vendor/with-endpoints': storedModel({ id: 'vendor/with-endpoints' }),
+        'vendor/no-endpoints': storedModel({ id: 'vendor/no-endpoints', endpoints: [] }),
+        'vendor/untyped': storedModel({ id: 'vendor/untyped', type: undefined, endpoints: [] }),
+        'vendor/embedding': storedModel({
+          id: 'vendor/embedding',
+          type: 'embedding',
+          endpoints: [],
+        }),
+      })
+    ).toEqual(['vendor/no-endpoints', 'vendor/untyped']);
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
+++ b/apps/web/src/lib/ai-gateway/providers/gateway-models-cache.ts
@@ -54,6 +54,12 @@ export function getLanguageModelIds(models: StoredModelMap): string[] {
     .map(model => model.id);
 }
 
+export function getLanguageModelIdsWithoutEndpoints(models: StoredModelMap): string[] {
+  return Object.values(models)
+    .filter(model => (model.type ?? 'language') === 'language' && model.endpoints.length === 0)
+    .map(model => model.id);
+}
+
 export function extractVercelInferenceProviderIdsFromModel(model: StoredModel): string[] {
   return [
     ...new Set(
@@ -112,6 +118,11 @@ export const getVercelModelsFromRedis = createModelIdsFetcher(
 export const getOpenRouterModelsFromRedis = createModelIdsFetcher(
   GATEWAY_METADATA_REDIS_KEYS.openrouterModelIds,
   'OpenRouter'
+);
+
+export const getOpenRouterModelIdsWithoutEndpointsFromRedis = createModelIdsFetcher(
+  GATEWAY_METADATA_REDIS_KEYS.openrouterModelIdsWithoutEndpoints,
+  'OpenRouter models without endpoints'
 );
 
 // These are (undocumented?) aliases OpenRouter accepts and were in use around 2026-08-11

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -34,6 +34,7 @@ import {
 import {
   extractVercelInferenceProviderIdsFromModel,
   getLanguageModelIds,
+  getLanguageModelIdsWithoutEndpoints,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { syncDirectByokModels } from '@/lib/ai-gateway/providers/direct-byok/sync-direct-byok';
 import { ATTRIBUTION_HEADERS } from '@/lib/ai-gateway/providers/openrouter/attribution-headers';
@@ -371,6 +372,10 @@ async function mirrorToRedis(values: {
   const entries: [RedisKey, unknown][] = [
     [GATEWAY_METADATA_REDIS_KEYS.allProviders, values.providers],
     [GATEWAY_METADATA_REDIS_KEYS.openrouterModelIds, getLanguageModelIds(values.openrouter)],
+    [
+      GATEWAY_METADATA_REDIS_KEYS.openrouterModelIdsWithoutEndpoints,
+      getLanguageModelIdsWithoutEndpoints(values.openrouter),
+    ],
     [GATEWAY_METADATA_REDIS_KEYS.vercelModelIds, getLanguageModelIds(values.vercel)],
   ];
   if (values.openrouterProviders) {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -130,6 +130,24 @@ describe('hasVercelProvidersButNoOpenRouterProviders', () => {
     ).toBe(true);
   });
 
+  it('recognizes an alias for an endpointless OpenRouter model', () => {
+    expect(
+      hasVercelProvidersButNoOpenRouterProviders('kimi-k3', new Set(['moonshotai/kimi-k3']), [
+        'provider',
+      ])
+    ).toBe(true);
+  });
+
+  it('recognizes the internal id of a Kilo-exclusive model', () => {
+    expect(
+      hasVercelProvidersButNoOpenRouterProviders(
+        'deepseek/deepseek-v4-pro:discounted',
+        new Set(['deepseek/deepseek-v4-pro-0813']),
+        ['provider']
+      )
+    ).toBe(true);
+  });
+
   it('returns false when OpenRouter still has inference providers', () => {
     expect(
       hasVercelProvidersButNoOpenRouterProviders(requestedModel, new Set(), ['provider'])

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -4,6 +4,7 @@ import {
   convertProviderOptions,
   getAnthropicProviderOptionsForVercel,
   getVercelInferenceProvidersExcludingIgnored,
+  hasVercelProvidersButNoOpenRouterProviders,
   hasCompatibleVercelInferenceProvider,
   isVercelRoutingOptOut,
   passesVercelRoutingPercentage,
@@ -115,6 +116,36 @@ describe('getVercelInferenceProvidersExcludingIgnored', () => {
         'bedrock',
       ])
     ).toEqual([]);
+  });
+});
+
+describe('hasVercelProvidersButNoOpenRouterProviders', () => {
+  const requestedModel = 'vendor/model';
+
+  it('returns true when only Vercel has inference providers', () => {
+    expect(
+      hasVercelProvidersButNoOpenRouterProviders(requestedModel, new Set([requestedModel]), [
+        'provider',
+      ])
+    ).toBe(true);
+  });
+
+  it('returns false when OpenRouter still has inference providers', () => {
+    expect(
+      hasVercelProvidersButNoOpenRouterProviders(requestedModel, new Set(), ['provider'])
+    ).toBe(false);
+  });
+
+  it('returns false when Vercel has no inference providers', () => {
+    expect(
+      hasVercelProvidersButNoOpenRouterProviders(requestedModel, new Set([requestedModel]), [])
+    ).toBe(false);
+  });
+
+  it('returns false when Vercel provider data is unavailable', () => {
+    expect(
+      hasVercelProvidersButNoOpenRouterProviders(requestedModel, new Set([requestedModel]), null)
+    ).toBe(false);
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -21,6 +21,7 @@ import {
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
 import { getRuntimeGatewayRoutingConfig } from '@/lib/ai-gateway/providers/routing-config';
 import { passesRoutingPercentage } from '@/lib/ai-gateway/providers/routing-percentage';
+import { findKiloExclusiveModel } from '@/lib/ai-gateway/models';
 
 export function hasCompatibleVercelInferenceProvider(
   openRouterInferenceProviders: string[],
@@ -63,8 +64,15 @@ export function hasVercelProvidersButNoOpenRouterProviders(
   openRouterModelIdsWithoutEndpoints: ReadonlySet<string>,
   vercelInferenceProviders: string[] | null
 ) {
+  const possibleOpenRouterModelIds = [
+    requestedModel,
+    mapModelIdToVercel(requestedModel),
+    findKiloExclusiveModel(requestedModel)?.internal_id,
+  ];
   return (
-    openRouterModelIdsWithoutEndpoints.has(requestedModel) &&
+    possibleOpenRouterModelIds.some(
+      modelId => modelId !== undefined && openRouterModelIdsWithoutEndpoints.has(modelId)
+    ) &&
     vercelInferenceProviders !== null &&
     vercelInferenceProviders.length > 0
   );

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -15,6 +15,7 @@ import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelId
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
 import {
   getCachedVercelInferenceProviderIdsForModel,
+  getOpenRouterModelIdsWithoutEndpointsFromRedis,
   getVercelModelsFromRedis,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import type { AnthropicProviderOptions } from '@ai-sdk/anthropic';
@@ -57,6 +58,18 @@ export function isVercelRoutingOptOut(requestedModel: string, optOutModels: Read
   return optOutModels.has(requestedModel);
 }
 
+export function hasVercelProvidersButNoOpenRouterProviders(
+  requestedModel: string,
+  openRouterModelIdsWithoutEndpoints: ReadonlySet<string>,
+  vercelInferenceProviders: string[] | null
+) {
+  return (
+    openRouterModelIdsWithoutEndpoints.has(requestedModel) &&
+    vercelInferenceProviders !== null &&
+    vercelInferenceProviders.length > 0
+  );
+}
+
 export async function shouldRouteToVercel(
   requestedModel: string,
   request: GatewayRequest,
@@ -75,10 +88,6 @@ export async function shouldRouteToVercel(
 
   const passedRandomization = passesVercelRoutingPercentage(randomSeed, routingPercentage);
 
-  if (!passedRandomization) {
-    return false;
-  }
-
   const vercelModels = await getVercelModelsFromRedis();
   const vercelModelId = mapModelIdToVercel(requestedModel);
   if (!vercelModels.has(vercelModelId)) {
@@ -86,11 +95,31 @@ export async function shouldRouteToVercel(
     return false;
   }
 
+  let vercelInferenceProviders: string[] | null | undefined;
+  if (!passedRandomization) {
+    const openRouterModelIdsWithoutEndpoints =
+      await getOpenRouterModelIdsWithoutEndpointsFromRedis();
+    vercelInferenceProviders = await getCachedVercelInferenceProviderIdsForModel(vercelModelId);
+    if (
+      !hasVercelProvidersButNoOpenRouterProviders(
+        requestedModel,
+        openRouterModelIdsWithoutEndpoints,
+        vercelInferenceProviders
+      )
+    ) {
+      return false;
+    }
+    console.debug(
+      '[shouldRouteToVercel] routing to Vercel because no OpenRouter inference providers remain'
+    );
+  }
+
   const provider = request.body.provider;
   if (provider && (provider.only || provider.ignore?.length)) {
     const { only, ignore } = provider;
-    const vercelInferenceProviders =
-      await getCachedVercelInferenceProviderIdsForModel(vercelModelId);
+    if (vercelInferenceProviders === undefined) {
+      vercelInferenceProviders = await getCachedVercelInferenceProviderIdsForModel(vercelModelId);
+    }
 
     if (ignore?.length) {
       if (!vercelInferenceProviders) {

--- a/apps/web/src/lib/redis-keys.ts
+++ b/apps/web/src/lib/redis-keys.ts
@@ -32,6 +32,9 @@ export const GATEWAY_METADATA_REDIS_KEYS = {
   // Lightweight lists of language model ids used for existence checks without
   // loading every model's metadata and endpoints.
   openrouterModelIds: redisKey('ai-gateway.metadata:openrouter-model-ids'),
+  openrouterModelIdsWithoutEndpoints: redisKey(
+    'ai-gateway.metadata:openrouter-model-ids-without-endpoints'
+  ),
   vercelModelIds: redisKey('ai-gateway.metadata:vercel-model-ids'),
   openrouterProviders: redisKey('ai-gateway.metadata:openrouter-providers'),
 } as const;


### PR DESCRIPTION
## Summary

- mirror OpenRouter language model IDs with no inference endpoints to a lightweight Redis set
- bypass the Vercel rollout percentage when OpenRouter has no endpoints and Vercel has cached inference providers
- preserve Vercel opt-outs, model eligibility, and request-level provider constraints
- add focused coverage for endpointless-model extraction and fallback eligibility

## Verification

- [x] Formatted changed files with `oxfmt`
- [x] `git diff --check`
- [ ] Tests delegated to CI as requested

## Visual Changes

N/A

## Reviewer Notes

The new Redis set is fail-closed for the fallback: before provider sync populates the key, it is empty, so requests continue to honor percentage routing rather than being broadly forced to Vercel.