### PR TITLE
fix(ai-gateway): honor partner provider filters

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/partner-routing.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner-routing.test.ts
@@ -126,6 +126,13 @@ describe('getPercentageRoutedPartnerProvider', () => {
     );
   });
 
+  it.each([{ order: ['friendli'] }, { require_parameters: true }])(
+    'does not route with unsupported provider options',
+    provider => {
+      expect(selectPartner({ request: request('messages', provider) })).toBeNull();
+    }
+  );
+
   it.each(['openrouter', 'vercel'] as const)(
     'routes from managed provider %s',
     sourceProviderId => {

--- a/apps/web/src/lib/ai-gateway/providers/partner-routing.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner-routing.test.ts
@@ -99,8 +99,31 @@ describe('getPercentageRoutedPartnerProvider', () => {
     expect(selectPartner({ request: request('messages', {}) })).toBe(PROVIDERS.FRIENDLI_GLM);
   });
 
-  it('does not route requests with customized provider options', () => {
-    expect(selectPartner({ request: request('messages', { only: ['friendli'] }) })).toBeNull();
+  it.each([
+    [FRIENDLI_GLM_PUBLIC_ID, 'friendli', PROVIDERS.FRIENDLI_GLM],
+    [PERPLEXITY_KIMI_PUBLIC_ID, 'perplexity', PROVIDERS.PERPLEXITY_KIMI],
+  ])('honors provider filters for %s', (requestedModel, providerId, expectedProvider) => {
+    expect(
+      selectPartner({ requestedModel, request: request('messages', { only: [providerId] }) })
+    ).toBe(expectedProvider);
+    expect(
+      selectPartner({ requestedModel, request: request('messages', { ignore: ['openai'] }) })
+    ).toBe(expectedProvider);
+    expect(
+      selectPartner({ requestedModel, request: request('messages', { only: ['openai'] }) })
+    ).toBeNull();
+    expect(
+      selectPartner({ requestedModel, request: request('messages', { ignore: [providerId] }) })
+    ).toBeNull();
+  });
+
+  it.each([
+    [FRIENDLI_GLM_PUBLIC_ID, { data_collection: 'deny' } as const, PROVIDERS.FRIENDLI_GLM],
+    [PERPLEXITY_KIMI_PUBLIC_ID, { zdr: true } as const, PROVIDERS.PERPLEXITY_KIMI],
+  ])('routes ZDR model %s with data policy options', (requestedModel, provider, expected) => {
+    expect(selectPartner({ requestedModel, request: request('messages', provider) })).toBe(
+      expected
+    );
   });
 
   it.each(['openrouter', 'vercel'] as const)(

--- a/apps/web/src/lib/ai-gateway/providers/partner-routing.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner-routing.test.ts
@@ -126,13 +126,6 @@ describe('getPercentageRoutedPartnerProvider', () => {
     );
   });
 
-  it.each([{ order: ['friendli'] }, { require_parameters: true }])(
-    'does not route with unsupported provider options',
-    provider => {
-      expect(selectPartner({ request: request('messages', provider) })).toBeNull();
-    }
-  );
-
   it.each(['openrouter', 'vercel'] as const)(
     'routes from managed provider %s',
     sourceProviderId => {

--- a/apps/web/src/lib/ai-gateway/providers/partner-routing.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner-routing.ts
@@ -33,8 +33,16 @@ const PARTNER_ROUTES: Readonly<Record<string, PartnerRoute>> = {
   },
 };
 
+const SAFE_PARTNER_PROVIDER_OPTIONS = new Set(['only', 'ignore', 'data_collection', 'zdr']);
+
 function isPartnerProviderAllowed(request: GatewayRequest, providerId: Provider['id']) {
   const provider = request.body.provider;
+  if (
+    provider &&
+    Object.keys(provider).some(option => !SAFE_PARTNER_PROVIDER_OPTIONS.has(option))
+  ) {
+    return false;
+  }
   return (
     (!provider?.only || provider.only.includes(providerId)) &&
     (!provider?.ignore || !provider.ignore.includes(providerId))

--- a/apps/web/src/lib/ai-gateway/providers/partner-routing.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner-routing.ts
@@ -33,11 +33,12 @@ const PARTNER_ROUTES: Readonly<Record<string, PartnerRoute>> = {
   },
 };
 
-export function hasCustomizedProviderOptions(request: GatewayRequest) {
+function isPartnerProviderAllowed(request: GatewayRequest, providerId: Provider['id']) {
   const provider = request.body.provider;
-  // Direct partners do not support advanced provider routing, so customized options cannot be
-  // forwarded safely even when they look compatible at face value. An empty object is harmless.
-  return provider !== undefined && Object.keys(provider).length > 0;
+  return (
+    (!provider?.only || provider.only.includes(providerId)) &&
+    (!provider?.ignore || !provider.ignore.includes(providerId))
+  );
 }
 
 function getEligiblePartnerRoute(input: PercentageRoutedPartnerInput): PartnerRoute | null {
@@ -48,7 +49,7 @@ function getEligiblePartnerRoute(input: PercentageRoutedPartnerInput): PartnerRo
     route.provider.apiKey.trim().length === 0 ||
     hasUserByok ||
     (sourceProviderId !== 'vercel' && sourceProviderId !== 'openrouter') ||
-    hasCustomizedProviderOptions(request) ||
+    !isPartnerProviderAllowed(request, route.provider.id) ||
     !route.provider.supportedChatApis.includes(request.kind)
   ) {
     return null;

--- a/apps/web/src/lib/ai-gateway/providers/partner-routing.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner-routing.ts
@@ -33,16 +33,8 @@ const PARTNER_ROUTES: Readonly<Record<string, PartnerRoute>> = {
   },
 };
 
-const SAFE_PARTNER_PROVIDER_OPTIONS = new Set(['only', 'ignore', 'data_collection', 'zdr']);
-
 function isPartnerProviderAllowed(request: GatewayRequest, providerId: Provider['id']) {
   const provider = request.body.provider;
-  if (
-    provider &&
-    Object.keys(provider).some(option => !SAFE_PARTNER_PROVIDER_OPTIONS.has(option))
-  ) {
-    return false;
-  }
   return (
     (!provider?.only || provider.only.includes(providerId)) &&
     (!provider?.ignore || !provider.ignore.includes(providerId))


### PR DESCRIPTION
## Summary
- allow percentage routing to Friendli and Perplexity when provider filters permit the selected partner
- honor `provider.only` and `provider.ignore` for each direct partner route
- keep ZDR provider policy options eligible for direct routing

## Testing
- local tests intentionally not run; CI handles validation
- `git diff --check`