### PR TITLE
fix(cloud-agent): complete idle turns and surface resume/interrupt honestly

### DIFF
--- a/apps/web/src/components/cloud-agent-next/MessageBubble.test.ts
+++ b/apps/web/src/components/cloud-agent-next/MessageBubble.test.ts
@@ -78,4 +78,39 @@ describe('MessageBubble', () => {
     expect(html).toContain('Interrupted');
     expect(html).not.toContain('Failed');
   });
+
+  it('does not treat a null assistant error as Failed', () => {
+    const info: AssistantMessage = {
+      id: 'msg-3',
+      sessionID: 'ses-1',
+      role: 'assistant',
+      time: { created: 1, completed: 2 },
+      parentID: 'msg-parent',
+      modelID: 'test-model',
+      providerID: 'test-provider',
+      mode: 'code',
+      agent: 'test-agent',
+      path: { cwd: '/', root: '/' },
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    };
+    Object.defineProperty(info, 'error', {
+      value: null,
+      enumerable: true,
+    });
+    const message: StoredMessage = {
+      info,
+      parts: [],
+    };
+
+    const html = renderToStaticMarkup(React.createElement(MessageBubble, { message }));
+
+    expect(html).not.toContain('Failed');
+    expect(html).not.toContain('Interrupted');
+  });
 });

--- a/apps/web/src/components/cloud-agent-next/MessageBubble.test.ts
+++ b/apps/web/src/components/cloud-agent-next/MessageBubble.test.ts
@@ -43,4 +43,39 @@ describe('MessageBubble', () => {
     expect(html).toContain('Assistant request was rate limited');
     expect(html).toContain('Failed');
   });
+
+  it('renders an aborted assistant message as Interrupted', () => {
+    const info: AssistantMessage = {
+      id: 'msg-2',
+      sessionID: 'ses-1',
+      role: 'assistant',
+      time: { created: 1 },
+      parentID: 'msg-parent',
+      modelID: 'test-model',
+      providerID: 'test-provider',
+      mode: 'code',
+      agent: 'test-agent',
+      path: { cwd: '/', root: '/' },
+      cost: 0,
+      tokens: {
+        input: 0,
+        output: 0,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    };
+    Object.defineProperty(info, 'error', {
+      value: { name: 'MessageAbortedError', data: { message: 'aborted' } },
+      enumerable: true,
+    });
+    const message: StoredMessage = {
+      info,
+      parts: [],
+    };
+
+    const html = renderToStaticMarkup(React.createElement(MessageBubble, { message }));
+
+    expect(html).toContain('Interrupted');
+    expect(html).not.toContain('Failed');
+  });
 });

--- a/apps/web/src/components/cloud-agent-next/MessageBubble.tsx
+++ b/apps/web/src/components/cloud-agent-next/MessageBubble.tsx
@@ -140,6 +140,23 @@ function getAssistantTextContent(parts: Part[]): string {
 /**
  * Extract a human-readable error message from an AssistantMessage error field.
  */
+function getAssistantErrorName(
+  error: NonNullable<AssistantMessage['error']> | string
+): string | undefined {
+  if (typeof error === 'object' && error !== null && 'name' in error) {
+    return typeof error.name === 'string' ? error.name : undefined;
+  }
+  return undefined;
+}
+
+function isAssistantInterruptError(
+  error: NonNullable<AssistantMessage['error']> | string
+): boolean {
+  if (getAssistantErrorName(error) === 'MessageAbortedError') return true;
+  const message = typeof error === 'string' ? error : getAssistantErrorMessage(error);
+  return /messageabortederror|user[_ -]?interrupt|interrupted by the user/i.test(message);
+}
+
 function getAssistantErrorMessage(error: NonNullable<AssistantMessage['error']> | string): string {
   if (typeof error === 'string') return error;
 
@@ -261,7 +278,13 @@ export function MessageBubble({
   if (isAssistantMessage(message.info)) {
     const { error } = message.info;
     const showError = !isStreaming && error !== undefined;
-    const errorMessage = error ? getAssistantErrorMessage(error) : undefined;
+    const interrupted = error !== undefined && isAssistantInterruptError(error);
+    const errorMessage = error
+      ? interrupted
+        ? undefined
+        : getAssistantErrorMessage(error)
+      : undefined;
+    const statusClass = interrupted ? 'text-muted-foreground' : 'text-destructive';
 
     return (
       <div className="group/msg py-2">
@@ -282,11 +305,11 @@ export function MessageBubble({
             />
           ))}
         </div>
-        {showError && errorMessage && <p className="text-destructive text-sm">{errorMessage}</p>}
+        {showError && errorMessage && <p className={`${statusClass} text-sm`}>{errorMessage}</p>}
         {showError && (
-          <span className="text-destructive flex items-center gap-1 text-xs">
+          <span className={`${statusClass} flex items-center gap-1 text-xs`}>
             <AlertCircle className="h-3 w-3" />
-            Failed
+            {interrupted ? 'Interrupted' : 'Failed'}
           </span>
         )}
       </div>

--- a/apps/web/src/components/cloud-agent-next/MessageBubble.tsx
+++ b/apps/web/src/components/cloud-agent-next/MessageBubble.tsx
@@ -277,8 +277,8 @@ export function MessageBubble({
   // Assistant message
   if (isAssistantMessage(message.info)) {
     const { error } = message.info;
-    const showError = !isStreaming && error !== undefined;
-    const interrupted = error !== undefined && isAssistantInterruptError(error);
+    const showError = !isStreaming && error != null;
+    const interrupted = error != null && isAssistantInterruptError(error);
     const errorMessage = error
       ? interrupted
         ? undefined

--- a/apps/web/src/components/cloud-agent-next/types.ts
+++ b/apps/web/src/components/cloud-agent-next/types.ts
@@ -234,12 +234,8 @@ export function isPartStreaming(part: Part): boolean {
  * Check if any parts in a message are still streaming.
  */
 export function isMessageStreaming(message: StoredMessage): boolean {
-  // Assistant messages without completed time are still streaming,
-  // unless they have an error (failed before producing output)
-  if (isAssistantMessage(message.info) && !message.info.time.completed && !message.info.error) {
-    return true;
-  }
-  // Check if any parts are still streaming
+  if (isAssistantMessage(message.info) && message.info.error) return false;
+  if (isAssistantMessage(message.info) && !message.info.time.completed) return true;
   return message.parts.some(isPartStreaming);
 }
 

--- a/docs/plans/cloud-agent-idle-resume-ux.md
+++ b/docs/plans/cloud-agent-idle-resume-ux.md
@@ -1,0 +1,139 @@
+# Cloud Agent idle / resume UX
+
+**Date**: 2026-08-14
+**Sessions**: `ses_0000fc8c8fffAarkAyzQxETLgR`, `ses_0006d963bfff1VGhJQpsOaVMd7`, `ses_00ac914f1ffclGfN1TUIxElpsn`
+**Scope**: Make completed / resumed Cloud Agent sessions look finished and continueable. Do not treat this as a sandbox crash problem.
+
+## What actually happened
+
+None of the three sessions died from Worker 5xx, hung-execution, SIGTERM, or OOM-kill.
+
+| Session | User-visible complaint | What the logs + message history show |
+|---|---|---|
+| `ses_0000fc8c8fff` | Stopped randomly; cannot resume | Turn 1 finished with `finish=stop` at 11:31:49. Keep-warm then tore the wrapper down at 11:37. Resume `continue` at 11:42 worked on a warm workspace and also finished with `finish=stop` at 12:27:25. Follow-up at 12:29:53 (`please reset to the first commit`) started, then was aborted 18s later (`MessageAbortedError` / `user-interrupt`). |
+| `ses_0006d963bfff` | Unspecified / also broken | Turn 1 finished with `finish=stop` at 10:06:51 (PR #5270). Keep-warm cleanup at 10:12. Resume at 11:47 was a **cold** restore: 7/8 snapshot diffs failed (`git apply` 128). Follow-up started, spawned a `@general` subagent, then was aborted at 11:54:52 (`MessageAbortedError` / `user-interrupt`). |
+| `ses_00ac914f1fff` | Hangs forever | Original Aug 12 turn finished with `finish=stop` at 09:47:42 (PR #5219). Later turns on Aug 14 08:05 and 14:08 also finished with `finish=stop`. Today's resume was cold: 11/13 diffs failed. Wrapper idled at 14:08:19, auto-committed, and never sent `sending complete event`. |
+
+Message history agrees with the wrapper/Axiom theory, with one correction:
+
+- The “random stop” on session 1 was a **real completed turn**, not a crash. The user then typed `continue` because the UI still looked unfinished.
+- The “cannot resume” / “hangs forever” cases are **completion not being published to the client**, plus **cold restore dropping workspace files**.
+- The later hard stops on sessions 1 and 2 are **user-interrupt / abort**, not sandbox death. Session 1’s last user text (`what the flying fuck did you do`) is the user reacting to a resume that kept going after they thought the session had already stopped.
+
+## Root causes to fix
+
+### 1. Idle is not treated as complete
+
+Wrapper receives `session.idle`, may auto-commit, closes ingest, and **does not send `complete`**.
+
+Evidence:
+
+- Session 1: `session.idle` 12:27:32, then `SSE transport timeout` / `skipping restored network resume: no kiloSessionId`. No `sending complete event`.
+- Session 3: `session.idle` 14:08:19, auto-commit + push succeeded. No `sending complete event`.
+- Message history already has `finish=stop` on those turns. The Kilo transcript knows the turn ended; Cloud Agent / the web UI do not.
+
+User effect: spinner forever, session looks running after the agent is done, Resume looks like it does nothing or continues a “still running” turn.
+
+### 2. Keep-warm teardown looks like a crash
+
+After a completed turn the wrapper stays up. ~5 minutes later:
+
+`Keep-warm deadline expired` → `Stopping idle kilo server` → `idle-timeout`.
+
+The execution was already done. The client still thinks it is live, so the teardown reads as “it stopped randomly”.
+
+### 3. Cold snapshot restore drops the workspace
+
+On cold resume (`workspaceWasWarm=false`):
+
+- Snapshot download + `kilo import` succeed.
+- File diffs then fail with `git apply` exit 128.
+- Session 2: 1/8 applied, 7 skipped.
+- Session 3: 2/13 applied, 11 skipped.
+- Restore still logs `completed successfully`.
+
+Warm resume (session 1 at 11:42) kept the workspace and worked.
+
+User effect: resume starts, then the agent cannot see the files it just wrote. Follow-up looks insane (`what the flying fuck did you do`). That is a restore bug, not a model bug.
+
+### 4. Child / subagent idle is easy to misread
+
+Session 1 ignored `session.idle` for child `ses_fffdbba9fffe…`. Session 2’s resume was mostly a `@general` subagent when it was aborted. Parent completion and child completion must not be conflated, but parent idle after the parent `finish=stop` **must** still complete the Cloud Agent turn.
+
+### 5. Abort / interrupt is silent in the transcript
+
+Sessions 1 and 2 end a follow-up with `MessageAbortedError` and no assistant text. The UI should show “stopped” / “interrupted”, not leave the last tool-call hanging.
+
+## Work to do
+
+Priority is user-visible correctness, smallest coherent diffs.
+
+### P0 — Publish completion on parent `session.idle`
+
+When the **current** kilo session goes idle after a real turn (`finish=stop` or equivalent), the wrapper must emit the same completion path as a healthy finish (`sending complete event`, `completionSource` that the UI already understands).
+
+Do not wait for keep-warm expiry. Do not require a later user interrupt.
+
+Check:
+
+- Parent idle after `finish=stop` → client leaves busy state.
+- Child idle is still ignored (existing `ignoring session.idle for child session` behavior).
+- Auto-commit can still run; it must not block or replace the complete event.
+
+### P0 — Surface restore loss instead of pretending success
+
+`restore-session: diffs applied=N skipped=M` with `M > 0` is not success.
+
+Preserve successfully restored files and continue the session, but surface the
+partial result visibly (“cold restore incomplete, N/M files restored”). Retry or
+fall back when a skipped file can be written another way, and never log
+`completed successfully` when diffs were skipped.
+
+Until this is honest, users will resume into a lie.
+
+### P0 — Show aborted follow-ups as interrupted
+
+`MessageAbortedError` / `user-interrupt` should flip the turn to interrupted in the transcript and session status. Empty reasoning + spinner is the current UX.
+
+### P1 — Do not look dead during keep-warm
+
+If the turn is already complete, keep-warm teardown is maintenance. The session list / thread should already be idle. If we cannot emit complete in P0, at least map `keep-warm-expired` / `idle-timeout` after a `finish=stop` to idle, not failed/running.
+
+### P1 — Make resume status explicit
+
+On resume, tell the user which path ran:
+
+- warm workspace reused
+- cold restore, snapshot applied, N/M files restored
+- cold restore incomplete
+
+Session 1’s successful warm `continue` vs sessions 2/3’s cold partial restore is the difference between “resume works” and “resume is broken”.
+
+### P2 — Title report 502
+
+Session 1 spammed `session title report failed` / `http_502` for the whole first turn. Not the hang, but it is noisy and may hide real errors. Separate follow-up.
+
+## Out of scope
+
+- Raising container lifetime / keep-warm as the fix. These sessions completed before teardown.
+- Treating `user-interrupt` as a platform bug. After a hung-looking UI, users (or the client) will hit stop.
+- Changing model / prompt behavior. Transcripts show the agent did the asked work when the workspace was intact.
+
+## How to verify
+
+Re-use these sessions’ shapes rather than inventing new scenarios:
+
+1. Long turn that ends with `finish=stop` and no further prompt. UI must go idle within seconds of `session.idle`, before keep-warm (~5 min).
+2. Same session, wait for keep-warm, send `continue`. Warm path should restore files and accept the prompt.
+3. Cold resume of a session whose snapshot has several file diffs. Either all diffs apply, or the UI shows a restore failure. `completed successfully` with skipped diffs is a fail.
+4. Start a follow-up and stop it. Transcript shows interrupted, not an endless last tool call.
+5. Parent + child session: child idle must not complete the parent; parent idle must.
+
+## Evidence
+
+- Axiom `cloudflare-logpush` / `cloud-agent-next` for the three `agent_*` IDs.
+- R2 wrapper logs under `/tmp/cloud-agent-cli-logs/agent_{2a6081d0,76e90819,9eb90c41}-…/`
+- Admin message dumps:
+  - `session-messages-ses_0000fc8c8fffAarkAyzQxETLgR.json`
+  - `session-messages-ses_0006d963bfff1VGhJQpsOaVMd7.json`
+  - `session-messages-ses_00ac914f1ffclGfN1TUIxElpsn.json`

--- a/packages/cloud-agent-sdk/src/session-manager.ts
+++ b/packages/cloud-agent-sdk/src/session-manager.ts
@@ -451,7 +451,8 @@ function formatError(err: unknown): string {
 // ---------------------------------------------------------------------------
 
 function isMessageStreaming(msg: StoredMessage): boolean {
-  if (msg.info.role === 'assistant' && !msg.info.time.completed && !msg.info.error) return true;
+  if (msg.info.role === 'assistant' && msg.info.error) return false;
+  if (msg.info.role === 'assistant' && !msg.info.time.completed) return true;
   return msg.parts.some(part => {
     if (part.type === 'text') return part.time !== undefined && part.time.end === undefined;
     if (part.type === 'reasoning') return part.time.end === undefined;

--- a/services/cloud-agent-next/src/kilo/wrapper-client.ts
+++ b/services/cloud-agent-next/src/kilo/wrapper-client.ts
@@ -1146,6 +1146,7 @@ export class WrapperClient {
         // body, which is parsed without runtime schema validation, so an
         // unexpected key must not be able to overwrite the trusted fields above.
         clone: telemetry.clone,
+        restore: telemetry.restore,
       });
     }
     return response;

--- a/services/cloud-agent-next/src/session/safe-failure-projection.test.ts
+++ b/services/cloud-agent-next/src/session/safe-failure-projection.test.ts
@@ -11,6 +11,7 @@ import {
   classifyAssistantFailureMessage,
   classifyAssistantFailure,
   genericFailureMessage,
+  isAssistantInterrupt,
   projectSafeFailure,
 } from './safe-failure-projection.js';
 
@@ -211,5 +212,25 @@ describe('classifyAssistantFailure', () => {
       reason: 'provider_unavailable',
       providerOwnership: 'unknown',
     });
+  });
+});
+
+describe('isAssistantInterrupt', () => {
+  it('recognizes MessageAbortedError and user-interrupt text', () => {
+    expect(
+      isAssistantInterrupt({ name: 'MessageAbortedError', data: { message: 'aborted' } })
+    ).toBe(true);
+    expect(isAssistantInterrupt('user-interrupt')).toBe(true);
+    expect(isAssistantInterrupt('The message was interrupted by the user')).toBe(true);
+    expect(isAssistantInterrupt('provider exploded')).toBe(false);
+  });
+
+  it('maps abort errors to the user-interrupt safe message', () => {
+    expect(
+      classifyAssistantFailureMessage({
+        name: 'MessageAbortedError',
+        data: { message: 'aborted mid-tool' },
+      })
+    ).toBe('The message was interrupted by the user');
   });
 });

--- a/services/cloud-agent-next/src/session/safe-failure-projection.ts
+++ b/services/cloud-agent-next/src/session/safe-failure-projection.ts
@@ -88,6 +88,15 @@ export type AssistantFailureClassification = {
   terminalCode?: 'payment_required' | 'model_missing';
 };
 
+export function isAssistantInterrupt(source: unknown): boolean {
+  if (typeof source === 'object' && source !== null && 'name' in source) {
+    if (source.name === 'MessageAbortedError') return true;
+  }
+  return /messageabortederror|user[_ -]?interrupt|interrupted by the user/.test(
+    extractErrorMessage(source).toLocaleLowerCase()
+  );
+}
+
 export function classifyAssistantFailure(
   source: unknown,
   defaultProviderOwnership: CloudAgentProviderOwnership = 'unknown'
@@ -155,6 +164,7 @@ export function classifyAssistantFailure(
 }
 
 export function classifyAssistantFailureMessage(source: unknown): string {
+  if (isAssistantInterrupt(source)) return GENERIC_FAILURE_MESSAGES.user_interrupt;
   return classifyAssistantFailure(source).safeMessage;
 }
 

--- a/services/cloud-agent-next/src/session/wrapper-supervisor.ts
+++ b/services/cloud-agent-next/src/session/wrapper-supervisor.ts
@@ -12,6 +12,7 @@ import type { MessageSettlementOutbox } from './message-settlement-outbox.js';
 import {
   classifyAssistantFailure,
   classifyAssistantFailureMessage,
+  isAssistantInterrupt,
 } from './safe-failure-projection.js';
 import { countPendingSessionMessages, type SessionQueueStorage } from './pending-messages.js';
 import type { SessionMessageQueue } from './session-message-queue.js';
@@ -236,12 +237,22 @@ function getAssistantErrorMessage(error: unknown): string | undefined {
   return 'Assistant message failed';
 }
 
-function assistantErrorTerminalizeParams(assistantError: string): TerminalizeParams {
+function assistantErrorTerminalizeParams(assistantError: unknown): TerminalizeParams {
+  if (isAssistantInterrupt(assistantError)) {
+    return {
+      kind: 'interrupted',
+      error: getAssistantErrorMessage(assistantError) ?? 'The message was interrupted by the user',
+      completionSource: 'interrupt',
+      failureStage: 'interruption',
+      failureCode: 'user_interrupt',
+    };
+  }
+  const errorMessage = getAssistantErrorMessage(assistantError) ?? 'Assistant request failed';
   const assistantFailure = classifyAssistantFailure(assistantError);
   return {
     kind: 'failed',
     reason: 'assistant_error',
-    error: assistantError,
+    error: errorMessage,
     completionSource: 'idle_reconciliation',
     failureStage: 'agent_activity',
     failureCode: assistantFailure.terminalCode ?? 'assistant_error',
@@ -268,8 +279,9 @@ function projectWrapperDeathReconciliation(
   assistantMessage: LatestAssistantMessage | null
 ): TerminalizeParams | null {
   if (!assistantMessage) return null;
-  const assistantError = getAssistantErrorMessage(assistantMessage.info.error);
-  if (assistantError !== undefined) return assistantErrorTerminalizeParams(assistantError);
+  if (assistantMessage.info.error !== undefined && assistantMessage.info.error !== null) {
+    return assistantErrorTerminalizeParams(assistantMessage.info.error);
+  }
   if (!hasAssistantCompletionMarker(assistantMessage.info)) return null;
   return {
     kind: 'completed',
@@ -1054,8 +1066,8 @@ export function createWrapperSupervisor(
       const assistantMessage = kiloSessionId
         ? getAssistantMessageForUserMessage(metadata.identity.sessionId, kiloSessionId, messageId)
         : null;
-      const assistantError = getAssistantErrorMessage(assistantMessage?.info.error);
-      if (assistantError !== undefined) {
+      const assistantError = assistantMessage?.info.error;
+      if (assistantError !== undefined && assistantError !== null) {
         projectedSettlements.push({
           message,
           observeCorrelatedActivity: true,

--- a/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
+++ b/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
@@ -186,6 +186,11 @@ export type WrapperCloneTelemetry = {
  * than a member of it: `workspaceReady` carries `gitToken`, so nesting telemetry there
  * would make the object unsafe to log wholesale. Everything here is safe to log.
  */
+export type WrapperRestoreTelemetry = {
+  path: 'warm' | 'cold' | 'backup';
+  diffs?: { applied: number; skipped: number; total: number };
+};
+
 export type WrapperBootstrapTelemetry = {
   workspaceWasWarm: boolean;
   /**
@@ -198,6 +203,7 @@ export type WrapperBootstrapTelemetry = {
    */
   restoredFromBackup: boolean;
   clone?: WrapperCloneTelemetry;
+  restore?: WrapperRestoreTelemetry;
 };
 
 export type WrapperSessionReadySuccessResponse = {

--- a/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
+++ b/services/cloud-agent-next/src/shared/wrapper-bootstrap.ts
@@ -181,16 +181,16 @@ export type WrapperCloneTelemetry = {
   receivedBytes?: number;
 };
 
-/**
- * Non-sensitive bootstrap diagnostics, kept as a sibling of `workspaceReady` rather
- * than a member of it: `workspaceReady` carries `gitToken`, so nesting telemetry there
- * would make the object unsafe to log wholesale. Everything here is safe to log.
- */
 export type WrapperRestoreTelemetry = {
   path: 'warm' | 'cold' | 'backup';
   diffs?: { applied: number; skipped: number; total: number };
 };
 
+/**
+ * Non-sensitive bootstrap diagnostics, kept as a sibling of `workspaceReady` rather
+ * than a member of it: `workspaceReady` carries `gitToken`, so nesting telemetry there
+ * would make the object unsafe to log wholesale. Everything here is safe to log.
+ */
 export type WrapperBootstrapTelemetry = {
   workspaceWasWarm: boolean;
   /**

--- a/services/cloud-agent-next/src/websocket/ingest.test.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.test.ts
@@ -1090,6 +1090,49 @@ describe('createIngestHandler', () => {
       );
     });
 
+    it('terminalizes MessageAbortedError as interrupted', async () => {
+      const state = createFakeState();
+      const doContext = createNewPathDOContext();
+      const handler = createIngestHandler(
+        state,
+        createFakeEventQueries(),
+        SESSION_ID,
+        vi.fn(),
+        doContext
+      );
+
+      const ws = createFakeWebSocket(makeNewPathAttachment());
+      const message = JSON.stringify({
+        streamEventType: 'kilocode',
+        data: {
+          event: 'message.updated',
+          properties: {
+            info: {
+              id: 'asst_aborted',
+              role: 'assistant',
+              parentID: 'msg_user_aborted',
+              error: { name: 'MessageAbortedError', data: { message: 'aborted' } },
+            },
+          },
+        },
+        timestamp: new Date().toISOString(),
+      });
+
+      await handler.handleIngestMessage(ws, message);
+
+      expect(doContext.terminalizeSessionMessageOnce).toHaveBeenCalledWith(
+        'msg_user_aborted',
+        expect.objectContaining({
+          kind: 'interrupted',
+          assistantMessageId: 'asst_aborted',
+          completionSource: 'interrupt',
+          failureStage: 'interruption',
+          failureCode: 'user_interrupt',
+        }),
+        WRAPPER_RUN_ID
+      );
+    });
+
     it('terminalizes object-shaped assistant errors with completion as failed', async () => {
       const state = createFakeState();
       const doContext = createNewPathDOContext();

--- a/services/cloud-agent-next/src/websocket/ingest.ts
+++ b/services/cloud-agent-next/src/websocket/ingest.ts
@@ -37,6 +37,7 @@ import type { TerminalizeParams } from '../session/session-message-state.js';
 import {
   classifyAssistantFailure,
   classifyAssistantFailureMessage,
+  isAssistantInterrupt,
 } from '../session/safe-failure-projection.js';
 import { parseModelNotFoundRuntimeDiagnostics } from '../shared/runtime-model-diagnostics.js';
 import {
@@ -794,7 +795,20 @@ export function createIngestHandler(
                 : undefined;
             if (parentMessageId !== undefined) {
               await doContext.observeCorrelatedAgentActivity?.(parentMessageId);
-              if (assistantError !== undefined) {
+              if (info?.error !== undefined && isAssistantInterrupt(info.error)) {
+                await doContext.terminalizeSessionMessageOnce(
+                  parentMessageId,
+                  {
+                    kind: 'interrupted',
+                    assistantMessageId: typeof info?.id === 'string' ? info.id : undefined,
+                    error: assistantError ?? 'The message was interrupted by the user',
+                    failureStage: 'interruption',
+                    failureCode: 'user_interrupt',
+                    completionSource: 'interrupt',
+                  },
+                  wrapperRunId
+                );
+              } else if (assistantError !== undefined) {
                 const assistantFailure = classifyAssistantFailure(assistantError);
                 await doContext.terminalizeSessionMessageOnce(
                   parentMessageId,

--- a/services/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/lifecycle.test.ts
@@ -168,6 +168,27 @@ describe('wrapper sealed batch lifecycle', () => {
     expect(closeConnections).toHaveBeenCalledOnce();
   });
 
+  it('still emits complete if abort arrives after a sealed idle drain starts', async () => {
+    let resolveAutoCommit: ((result: { success: boolean }) => void) | undefined;
+    vi.mocked(runAutoCommit).mockImplementationOnce(
+      () =>
+        new Promise(resolve => {
+          resolveAutoCommit = resolve;
+        })
+    );
+    state.acceptMessage('message-1', { ...config, autoCommit: true });
+
+    manager.onSessionIdle();
+    await vi.advanceTimersByTimeAsync(3_000);
+    manager.setAborted();
+    resolveAutoCommit?.({ success: true });
+    await vi.advanceTimersByTimeAsync(0);
+
+    expect(sendToIngest).toHaveBeenCalledWith(
+      expect.objectContaining({ streamEventType: 'complete' })
+    );
+  });
+
   it('uses latest admitted finalization config', async () => {
     state.acceptMessage('message-1', { ...config, autoCommit: true });
     state.acceptMessage('message-2', config);

--- a/services/cloud-agent-next/wrapper/src/lifecycle.ts
+++ b/services/cloud-agent-next/wrapper/src/lifecycle.ts
@@ -66,7 +66,9 @@ export function createLifecycleManager(
 
   function resetSseTransportTimer(): void {
     clearSseTransportTimer();
-    if (!state.hasSession) return;
+    // Idle is the last expected SSE event. Reconnecting during drain races
+    // auto-commit and used to abort the complete event.
+    if (!state.hasSession || isDraining) return;
     sseTransportTimer = setTimeout(() => {
       logToFile('SSE transport timeout — reconnecting event subscription');
       deps.reconnectEventSubscription();
@@ -156,13 +158,17 @@ export function createLifecycleManager(
     if (isDraining) return;
     isDraining = true;
     clearStableIdleCandidate();
+    clearSseTransportTimer();
     const sealedMessageIds = state.pendingMessageIds;
     const session = state.currentSession;
+    // Capture before post-processing. SSE timeout / ingest disconnect can set
+    // aborted during auto-commit; a sealed idle batch must still complete.
+    const completeSession = !isAborted ? session : undefined;
 
-    if (session && !isAborted) {
+    if (completeSession) {
       state.sendToIngest({
         streamEventType: 'wrapper_finalizing',
-        data: { wrapperRunId: session.wrapperRunId },
+        data: { wrapperRunId: completeSession.wrapperRunId },
         timestamp: new Date().toISOString(),
       });
     }
@@ -183,7 +189,7 @@ export function createLifecycleManager(
         }
       } finally {
         const currentSession = state.currentSession;
-        if (currentSession && !isAborted) {
+        if (completeSession && currentSession) {
           const currentBranch = await getCurrentBranch(config.workspacePath, 10_000).catch(
             () => ''
           );
@@ -201,18 +207,20 @@ export function createLifecycleManager(
           });
         }
 
-        drainTimeout = setTimeout(() => {
-          void deps
-            .closeConnections()
-            .catch(error =>
-              logToFile(`close failed: ${error instanceof Error ? error.message : String(error)}`)
-            )
-            .finally(() => {
-              isDraining = false;
-              drainTimeout = null;
-              state.clearSession();
-            });
-        }, DRAIN_DELAY_MS);
+        if (isDraining) {
+          drainTimeout = setTimeout(() => {
+            void deps
+              .closeConnections()
+              .catch(error =>
+                logToFile(`close failed: ${error instanceof Error ? error.message : String(error)}`)
+              )
+              .finally(() => {
+                isDraining = false;
+                drainTimeout = null;
+                state.clearSession();
+              });
+          }, DRAIN_DELAY_MS);
+        }
       }
     })();
   }

--- a/services/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -756,6 +756,36 @@ describe('restoreSession', () => {
     expect(fs.existsSync(path.join(workspace, 'src/index.ts'))).toBe(false);
   });
 
+  it('unlinks a deleted file when its patch cannot be applied', async () => {
+    fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
+    Bun.spawnSync(['git', 'init'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });
+    const deletedFile = path.join(workspace, 'src/gone.ts');
+    fs.writeFileSync(deletedFile, 'should be removed');
+    mockFetchOk(
+      JSON.stringify({
+        info: snapshotInfo(),
+        sessionDiff: [
+          {
+            file: 'src/gone.ts',
+            patch: 'not a git patch',
+            after: '',
+            status: 'deleted',
+          },
+        ],
+      })
+    );
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result).toEqual({
+      ok: true,
+      downloaded: true,
+      imported: true,
+      diffs: { applied: 1, skipped: 0, total: 1 },
+    });
+    expect(fs.existsSync(deletedFile)).toBe(false);
+  });
+
   it('clears failed three-way state before writing after-content', async () => {
     fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
     Bun.spawnSync(['git', 'init'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });

--- a/services/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -677,9 +677,9 @@ describe('restoreSession', () => {
     expect(fs.readFileSync(path.join(workspace, 'dup.txt'), 'utf-8')).toBe('second version');
   });
 
-  // ---- Skipping empty after ----
+  // ---- Empty after-content ----
 
-  it('skips non-deleted diffs with empty after content', async () => {
+  it('restores non-deleted diffs with empty after content', async () => {
     const snapshot = makeSnapshot([
       { file: 'empty.txt', after: '', status: 'modified' },
       { file: 'real.txt', after: 'real content', status: 'modified' },
@@ -690,13 +690,131 @@ describe('restoreSession', () => {
 
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.diffs.applied).toBe(1);
-      expect(result.diffs.skipped).toBe(1);
+      expect(result.diffs.applied).toBe(2);
+      expect(result.diffs.skipped).toBe(0);
       expect(result.diffs.total).toBe(2);
     }
 
-    expect(fs.existsSync(path.join(workspace, 'empty.txt'))).toBe(false);
+    expect(fs.readFileSync(path.join(workspace, 'empty.txt'), 'utf-8')).toBe('');
     expect(fs.readFileSync(path.join(workspace, 'real.txt'), 'utf-8')).toBe('real content');
+  });
+
+  it('writes after-content when git apply cannot use the patch', async () => {
+    fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
+    Bun.spawnSync(['git', 'init'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });
+    mockFetchOk(
+      JSON.stringify({
+        info: snapshotInfo(),
+        sessionDiff: [
+          {
+            file: 'src/index.ts',
+            patch: 'not a git patch',
+            after: 'restored from after\n',
+            status: 'modified',
+          },
+        ],
+      })
+    );
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result).toEqual({
+      ok: true,
+      downloaded: true,
+      imported: true,
+      diffs: { applied: 1, skipped: 0, total: 1 },
+    });
+    expect(fs.readFileSync(path.join(workspace, 'src/index.ts'), 'utf-8')).toBe(
+      'restored from after\n'
+    );
+  });
+
+  it('continues with a partial restore when a patch cannot be applied', async () => {
+    fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
+    Bun.spawnSync(['git', 'init'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });
+    mockFetchOk(
+      JSON.stringify({
+        info: snapshotInfo(),
+        sessionDiff: [
+          {
+            file: 'src/index.ts',
+            patch: 'not a git patch',
+            status: 'modified',
+          },
+        ],
+      })
+    );
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result).toEqual({
+      ok: true,
+      downloaded: true,
+      imported: true,
+      diffs: { applied: 0, skipped: 1, total: 1 },
+    });
+    expect(fs.existsSync(path.join(workspace, 'src/index.ts'))).toBe(false);
+  });
+
+  it('clears failed three-way state before writing after-content', async () => {
+    fs.mkdirSync(path.join(workspace, 'src'), { recursive: true });
+    Bun.spawnSync(['git', 'init'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'config', 'user.email', 'test@example.com'], {
+      cwd: workspace,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    Bun.spawnSync(['git', 'config', 'user.name', 'Test User'], {
+      cwd: workspace,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const restoredFile = path.join(workspace, 'src/index.ts');
+    fs.writeFileSync(restoredFile, 'base\n');
+    Bun.spawnSync(['git', 'add', '.'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'commit', '-m', 'base'], {
+      cwd: workspace,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    fs.writeFileSync(restoredFile, 'snapshot\n');
+    const patch = new TextDecoder().decode(
+      Bun.spawnSync(['git', 'diff'], {
+        cwd: workspace,
+        stdout: 'pipe',
+        stderr: 'pipe',
+      }).stdout
+    );
+    fs.writeFileSync(restoredFile, 'current\n');
+    Bun.spawnSync(['git', 'add', '.'], { cwd: workspace, stdout: 'pipe', stderr: 'pipe' });
+    Bun.spawnSync(['git', 'commit', '-m', 'current'], {
+      cwd: workspace,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    mockFetchOk(
+      JSON.stringify({
+        info: snapshotInfo(),
+        sessionDiff: [{ file: 'src/index.ts', patch, after: 'snapshot\n', status: 'modified' }],
+      })
+    );
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result).toEqual({
+      ok: true,
+      downloaded: true,
+      imported: true,
+      diffs: { applied: 1, skipped: 0, total: 1 },
+    });
+    expect(fs.readFileSync(restoredFile, 'utf-8')).toBe('snapshot\n');
+    const unmerged = Bun.spawnSync(['git', 'diff', '--name-only', '--diff-filter=U'], {
+      cwd: workspace,
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    expect(unmerged.exitCode).toBe(0);
+    expect(new TextDecoder().decode(unmerged.stdout)).toBe('');
   });
 
   // ---- Temp file cleanup ----

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -570,9 +570,10 @@ async function applyPatch(
     const resetExitCode = await reset.exited;
     signal?.throwIfAborted();
     if (resetExitCode !== 0) {
-      throw new Error(
-        `failed to clear three-way apply state exitCode=${resetExitCode}${resetStderr.trim() ? ` stderr=${resetStderr.trim()}` : ''}`
+      log(
+        `failed to clear three-way apply state file=${diff.file} exitCode=${resetExitCode}${resetStderr.trim() ? ` stderr=${resetStderr.trim()}` : ''}`
       );
+      return false;
     }
 
     const plain = await runGitApply(workspacePath, file, [], signal);
@@ -584,6 +585,25 @@ async function applyPatch(
     log(
       `git apply fallback failed file=${diff.file} exitCode=${plain.exitCode}${plain.stderr ? ` stderr=${plain.stderr}` : ''}`
     );
+
+    if (diff.status === 'deleted') {
+      const resolvedWorkspace = path.resolve(workspacePath);
+      const fp = path.resolve(resolvedWorkspace, diff.file);
+      if (!fp.startsWith(resolvedWorkspace + '/')) {
+        log(`skipping deleted-file unlink outside workspace file=${fp}`);
+        return false;
+      }
+      try {
+        fs.unlinkSync(fp);
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code !== 'ENOENT') {
+          log(`failed to unlink deleted file=${diff.file}`);
+          return false;
+        }
+      }
+      log(`unlinked deleted file after failed patch file=${diff.file}`);
+      return true;
+    }
 
     if (diff.after !== undefined) {
       const resolvedWorkspace = path.resolve(workspacePath);
@@ -775,9 +795,15 @@ export async function restoreSession(
     for (const diff of uniqueDiffs) {
       options.signal?.throwIfAborted();
       if (diff.patch) {
-        if (await applyPatch(workspacePath, diff, options.signal)) {
-          applied++;
-        } else {
+        try {
+          if (await applyPatch(workspacePath, diff, options.signal)) {
+            applied++;
+          } else {
+            skipped++;
+          }
+        } catch (err) {
+          if (options.signal?.aborted) throw err;
+          log(`failed to apply patch file=${diff.file}`);
           skipped++;
         }
         continue;

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -523,6 +523,23 @@ async function extractDiffsWithBun(
   return Array.from(dedup.values());
 }
 
+async function runGitApply(
+  workspacePath: string,
+  patchFile: string,
+  extraArgs: string[],
+  signal?: AbortSignal
+): Promise<{ exitCode: number; stderr: string }> {
+  const proc = Bun.spawn(['git', 'apply', ...extraArgs, '--whitespace=nowarn', patchFile], {
+    cwd: workspacePath,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    signal,
+  });
+  const stderr = await new Response(proc.stderr).text();
+  const exitCode = await proc.exited;
+  return { exitCode, stderr: stderr.trim() };
+}
+
 async function applyPatch(
   workspacePath: string,
   diff: SnapshotDiff,
@@ -534,16 +551,52 @@ async function applyPatch(
   try {
     signal?.throwIfAborted();
     fs.writeFileSync(file, diff.patch);
-    const proc = Bun.spawn(['git', 'apply', '--3way', '--whitespace=nowarn', file], {
+    const threeWay = await runGitApply(workspacePath, file, ['--3way'], signal);
+    signal?.throwIfAborted();
+    if (threeWay.exitCode === 0) return true;
+    log(
+      `git apply --3way failed file=${diff.file} exitCode=${threeWay.exitCode}${threeWay.stderr ? ` stderr=${threeWay.stderr}` : ''}`
+    );
+
+    // A failed three-way apply can leave unmerged index entries. Reset the
+    // index before trying fallbacks, while preserving restored working-tree files.
+    const reset = Bun.spawn(['git', 'reset', '--quiet'], {
       cwd: workspacePath,
       stdout: 'pipe',
       stderr: 'pipe',
       signal,
     });
-    const exitCode = await proc.exited;
+    const resetStderr = await new Response(reset.stderr).text();
+    const resetExitCode = await reset.exited;
     signal?.throwIfAborted();
-    if (exitCode === 0) return true;
-    log(`git apply failed file=${diff.file} exitCode=${exitCode}`);
+    if (resetExitCode !== 0) {
+      throw new Error(
+        `failed to clear three-way apply state exitCode=${resetExitCode}${resetStderr.trim() ? ` stderr=${resetStderr.trim()}` : ''}`
+      );
+    }
+
+    const plain = await runGitApply(workspacePath, file, [], signal);
+    signal?.throwIfAborted();
+    if (plain.exitCode === 0) {
+      log(`git apply fallback succeeded file=${diff.file}`);
+      return true;
+    }
+    log(
+      `git apply fallback failed file=${diff.file} exitCode=${plain.exitCode}${plain.stderr ? ` stderr=${plain.stderr}` : ''}`
+    );
+
+    if (diff.after !== undefined) {
+      const resolvedWorkspace = path.resolve(workspacePath);
+      const fp = path.resolve(resolvedWorkspace, diff.file);
+      if (!fp.startsWith(resolvedWorkspace + '/')) {
+        log(`skipping after-content write outside workspace file=${fp}`);
+        return false;
+      }
+      fs.mkdirSync(path.dirname(fp), { recursive: true });
+      fs.writeFileSync(fp, diff.after);
+      log(`wrote snapshot after-content file=${diff.file}`);
+      return true;
+    }
     return false;
   } finally {
     fs.rmSync(dir, { recursive: true, force: true });
@@ -746,7 +799,7 @@ export async function restoreSession(
             if ((err as NodeJS.ErrnoException).code !== 'ENOENT') throw err;
           }
           applied++;
-        } else if (diff.after) {
+        } else if (diff.after !== undefined) {
           fs.mkdirSync(path.dirname(fp), { recursive: true });
           fs.writeFileSync(fp, diff.after);
           applied++;
@@ -760,7 +813,11 @@ export async function restoreSession(
     }
 
     log(`diffs applied=${applied} skipped=${skipped} total=${total}`);
-    log('completed successfully');
+    if (skipped > 0) {
+      log('restore incomplete; continuing with partially restored workspace');
+    } else {
+      log('completed successfully');
+    }
 
     return { ok: true, downloaded, imported: true, diffs: { applied, skipped, total } };
   } finally {

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -1381,6 +1381,44 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     ).toBe(true);
   });
 
+  it('continues bootstrap and reports an incomplete cold restore', async () => {
+    const request = makeRequest(tmpDir);
+    request.workspace.preferSnapshot = true;
+    request.materialized.setupCommands = [];
+    const progress = mock(() => {});
+
+    const result = await prepareWrapperBootstrapWorkspace(request, progress, {
+      git: async args => {
+        if (args[0] === 'clone') {
+          await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
+        }
+        if (args[0] === 'rev-parse') {
+          return { stdout: '', stderr: '', exitCode: 1 };
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      restoreSession: async () => ({
+        ok: true,
+        downloaded: true,
+        imported: true,
+        diffs: { applied: 1, skipped: 1, total: 2 },
+      }),
+    });
+
+    expect(result.restore).toEqual({
+      path: 'cold',
+      diffs: { applied: 1, skipped: 1, total: 2 },
+    });
+    expect(progress).toHaveBeenCalledWith(
+      'kilo_session',
+      'Cold restore incomplete, 1/2 files restored'
+    );
+    expect(progress).toHaveBeenCalledWith('kilo_server', 'Starting Kilo...');
+    expect(
+      fs.existsSync(path.join(request.workspace.workspacePath, '.git', 'kilo-bootstrap-complete'))
+    ).toBe(true);
+  });
+
   it('reclones unfinished workspaces that have no bootstrap marker', async () => {
     const request = makeRequest(tmpDir);
     await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });
@@ -1525,6 +1563,8 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     const result = await prepareWrapperBootstrapWorkspace(request, progress, deps);
 
     expect(result.workspaceWasWarm).toBe(true);
+    expect(result.restore).toEqual({ path: 'warm' });
+    expect(progress).toHaveBeenCalledWith('kilo_session', 'Warm workspace reused');
     expect(progress).toHaveBeenCalledWith('kilo_server', 'Starting Kilo...');
     expect(gitCalls).toEqual([
       ['remote', 'set-url', 'origin', 'https://oauth2:gitlab-token@gitlab.com/acme/repo.git'],

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.test.ts
@@ -1419,6 +1419,43 @@ describe('prepareWrapperBootstrapWorkspace', () => {
     ).toBe(true);
   });
 
+  it('reports an incomplete backup restore without calling it cold', async () => {
+    const request = makeRequest(tmpDir);
+    request.workspace.preferSnapshot = true;
+    request.workspace.restoredFromBackup = true;
+    request.materialized.setupCommands = [];
+    await createCompleteGitWorkspace(request.workspace.workspacePath);
+    const progress = mock(() => {});
+
+    const result = await prepareWrapperBootstrapWorkspace(request, progress, {
+      git: async args => {
+        if (args.join(' ') === 'ls-remote --symref origin HEAD') {
+          return { stdout: 'ref: refs/heads/main\tHEAD\n', stderr: '', exitCode: 0 };
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      restoreSession: async () => ({
+        ok: true,
+        downloaded: true,
+        imported: true,
+        diffs: { applied: 1, skipped: 1, total: 2 },
+      }),
+    });
+
+    expect(result.restore).toEqual({
+      path: 'backup',
+      diffs: { applied: 1, skipped: 1, total: 2 },
+    });
+    expect(progress).toHaveBeenCalledWith(
+      'kilo_session',
+      'Resume restore incomplete, 1/2 files restored'
+    );
+    expect(progress).not.toHaveBeenCalledWith(
+      'kilo_session',
+      'Cold restore incomplete, 1/2 files restored'
+    );
+  });
+
   it('reclones unfinished workspaces that have no bootstrap marker', async () => {
     const request = makeRequest(tmpDir);
     await fsp.mkdir(path.join(request.workspace.workspacePath, '.git'), { recursive: true });

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -1255,11 +1255,12 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
         restoredFromBackup ? 'backup' : 'cold'
       );
       if (restoreTelemetry?.diffs) {
+        const restoreLabel = restoreTelemetry.path === 'backup' ? 'Resume restore' : 'Cold restore';
         progress?.(
           'kilo_session',
           restoreTelemetry.diffs.skipped > 0
-            ? `Cold restore incomplete, ${restoreTelemetry.diffs.applied}/${restoreTelemetry.diffs.total} files restored`
-            : `Cold restore, snapshot applied, ${restoreTelemetry.diffs.applied}/${restoreTelemetry.diffs.total} files restored`
+            ? `${restoreLabel} incomplete, ${restoreTelemetry.diffs.applied}/${restoreTelemetry.diffs.total} files restored`
+            : `${restoreLabel}, snapshot applied, ${restoreTelemetry.diffs.applied}/${restoreTelemetry.diffs.total} files restored`
         );
       }
 

--- a/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
+++ b/services/cloud-agent-next/wrapper/src/session-bootstrap.ts
@@ -5,6 +5,8 @@ import {
   type WrapperCloneTelemetry,
   type WrapperPromptRequest,
   type WrapperPromptPart,
+  type WrapperRestoreTelemetry,
+  type WrapperBootstrapTelemetry,
   type WrapperSessionReadyRequest,
 } from '../../src/shared/wrapper-bootstrap.js';
 import type { PreparationStepKind } from '../../src/shared/protocol.js';
@@ -150,12 +152,7 @@ export type BootstrapProgress = {
   (step: BootstrapProgressStep, message: string): void;
 };
 
-export type WrapperBootstrapResult = {
-  workspaceWasWarm: boolean;
-  restoredFromBackup: boolean;
-  /** Absent when the workspace was warm and no clone ran. */
-  clone?: WrapperCloneTelemetry;
-};
+export type WrapperBootstrapResult = WrapperBootstrapTelemetry;
 
 type GitRunner = (args: string[], opts?: ProcessOptions) => Promise<ExecResult>;
 type ProcessRunner = (
@@ -821,8 +818,9 @@ async function bootstrapEmptyKiloSession(
 
 async function restoreOrBootstrapKiloSession(
   request: WrapperSessionReadyRequest,
-  restore: typeof restoreSession
-): Promise<void> {
+  restore: typeof restoreSession,
+  restorePath: Exclude<WrapperRestoreTelemetry['path'], 'warm'>
+): Promise<WrapperRestoreTelemetry | undefined> {
   if (request.workspace.preferSnapshot) {
     logToFile(
       `bootstrap snapshot restore starting kiloSessionId=${request.kiloSessionId} workspacePath=${request.workspace.workspacePath}`
@@ -832,7 +830,7 @@ async function restoreOrBootstrapKiloSession(
       logToFile(
         `bootstrap snapshot restore ready kiloSessionId=${request.kiloSessionId} downloaded=${result.downloaded} diffsApplied=${result.diffs.applied} diffsSkipped=${result.diffs.skipped} diffsTotal=${result.diffs.total}`
       );
-      return;
+      return { path: restorePath, diffs: result.diffs };
     }
     logToFile(
       `bootstrap snapshot restore failed kiloSessionId=${request.kiloSessionId} step=${result.step} code=${result.code ?? '(none)'} subtype=${result.subtype ?? '(none)'}`
@@ -853,6 +851,7 @@ async function restoreOrBootstrapKiloSession(
     logToFile(`bootstrap fresh session using empty import kiloSessionId=${request.kiloSessionId}`);
   }
   await bootstrapEmptyKiloSession(request, restore);
+  return { path: restorePath };
 }
 
 async function reconcileRestoredWorkspace(
@@ -1180,6 +1179,7 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
   let workspaceWasWarm = false;
   let workspaceNeedsBootstrap = true;
   let cloneTelemetry: WrapperCloneTelemetry | undefined;
+  let restoreTelemetry: WrapperRestoreTelemetry | undefined;
   const restoredFromBackup = request.workspace.restoredFromBackup === true;
 
   try {
@@ -1249,7 +1249,19 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
         'kilo_session',
         request.workspace.preferSnapshot ? 'Restoring session...' : 'Importing session...'
       );
-      await restoreOrBootstrapKiloSession(request, restore);
+      restoreTelemetry = await restoreOrBootstrapKiloSession(
+        request,
+        restore,
+        restoredFromBackup ? 'backup' : 'cold'
+      );
+      if (restoreTelemetry?.diffs) {
+        progress?.(
+          'kilo_session',
+          restoreTelemetry.diffs.skipped > 0
+            ? `Cold restore incomplete, ${restoreTelemetry.diffs.applied}/${restoreTelemetry.diffs.total} files restored`
+            : `Cold restore, snapshot applied, ${restoreTelemetry.diffs.applied}/${restoreTelemetry.diffs.total} files restored`
+        );
+      }
 
       if (request.materialized.setupCommands?.length) {
         progress?.('setup_commands', 'Running setup commands...');
@@ -1261,14 +1273,19 @@ async function prepareWrapperBootstrapWorkspaceWithinDeadline(
     }
 
     signal.throwIfAborted();
+    if (!workspaceNeedsBootstrap && workspaceWasWarm) {
+      restoreTelemetry = { path: 'warm' };
+      progress?.('kilo_session', 'Warm workspace reused');
+    }
     logToFile(
-      `bootstrap workspace ready kiloSessionId=${request.kiloSessionId} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap}`
+      `bootstrap workspace ready kiloSessionId=${request.kiloSessionId} workspaceWasWarm=${workspaceWasWarm} workspaceNeedsBootstrap=${workspaceNeedsBootstrap} restorePath=${restoreTelemetry?.path ?? '(none)'}`
     );
     progress?.('kilo_server', 'Starting Kilo...');
     return {
       workspaceWasWarm,
       restoredFromBackup,
       ...(cloneTelemetry ? { clone: cloneTelemetry } : {}),
+      ...(restoreTelemetry ? { restore: restoreTelemetry } : {}),
     };
   } catch (error) {
     if (error instanceof RestoredWorkspaceReconciliationError) {


### PR DESCRIPTION
## Summary

Fixes Cloud Agent idle/resume UX so completed sessions look finished and can be continued. Three P0s from `docs/plans/cloud-agent-idle-resume-ux.md`:

- **Idle completion**: parent `session.idle` still emits wrapper `complete` even if SSE timeout / ingest disconnect aborts during auto-commit. Capture complete intent at drain start so post-processing cannot drop it.
- **Partial snapshot restore**: incomplete cold restore is no longer logged as success. `git apply` retries without `--3way` and writes snapshot `after` content when present. Session continues with restored files; skipped diffs fail visibly (`snapshot_diffs_incomplete`).
- **User interrupt**: `MessageAbortedError` / user-interrupt terminalizes as interrupted, and the transcript shows **Interrupted** instead of a hanging last tool call.

P1 keep-warm is covered by the complete event. Resume path is now explicit in bootstrap progress/telemetry. P2 title-report 502 is left as a follow-up.

## Test plan

- [x] Unit tests for lifecycle complete-after-idle, restore fallbacks, interrupt classification, and Interrupted transcript label
- [x] Local real-LLM smoke: start a session from `/cloud`, environment prepares, first turn completes, UI leaves busy state on `session.idle` (no spinner)