### PR TITLE
fix(mobile): stop the Android Fabric crash when starting a new session

### DIFF
--- a/apps/mobile/src/components/agents/use-new-session-creator.test.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.test.ts
@@ -11,8 +11,7 @@ import { clearDraft, flushDraft, loadDraft } from '@/lib/persist/drafts';
 import { useFencedDraftLoad, useRemoteSpawnDraftCleanup } from '@/lib/persist/use-draft-load';
 
 const prepareSessionMutate = vi.hoisted(() => vi.fn());
-const routerPush = vi.hoisted(() => vi.fn());
-const navigationDispatch = vi.hoisted(() => vi.fn());
+const routerReplace = vi.hoisted(() => vi.fn());
 const toastError = vi.hoisted(() => vi.fn());
 const captureEventMock = vi.hoisted(() => vi.fn());
 const invalidateAgentSessionQueries = vi.hoisted(() => vi.fn(async () => undefined));
@@ -25,8 +24,7 @@ const hapticsMock = vi.hoisted(() => ({
 }));
 
 vi.mock('expo-router', () => ({
-  useRouter: () => ({ push: routerPush }),
-  useNavigation: () => ({ dispatch: navigationDispatch }),
+  useRouter: () => ({ replace: routerReplace }),
 }));
 
 vi.mock('@tanstack/react-query', () => ({
@@ -179,11 +177,15 @@ function requireResult(resultRef: { current: CreatorResult | null }): CreatorRes
   return result;
 }
 
-// Fires the frame synchronously so the navigation RESET dispatch runs inside
-// the act() block. Hoisted so the stub is not an inline callback argument
+// Counts the frames the hook schedules and fires them synchronously. The
+// creator must not defer any navigation work to a frame boundary — a stack
+// mutation dispatched one frame after the push crashed Fabric on Android. The
+// stub is hoisted so it is not an inline callback argument
 // (prefer-await-to-callbacks); the parameter is named `frame` because the
 // promise plugin treats a `callback`-named parameter as a promise callback.
+const scheduledFrames = { count: 0 };
 const requestAnimationFrameStub = (frame: () => void): number => {
+  scheduledFrames.count += 1;
   frame();
   return 0;
 };
@@ -218,6 +220,7 @@ beforeEach(() => {
   hapticsMock.calls = 0;
   hapticsMock.rejectWith = undefined;
   attachmentsWire = null;
+  scheduledFrames.count = 0;
   vi.stubGlobal('requestAnimationFrame', requestAnimationFrameStub);
 });
 
@@ -454,7 +457,7 @@ describe('useNewSessionCreator operationKey', () => {
 
   it('does not treat a post-success navigation failure as a create failure and rotates the key', async () => {
     prepareSessionMutate.mockResolvedValue(sessionResult());
-    routerPush.mockImplementationOnce(() => {
+    routerReplace.mockImplementationOnce(() => {
       throw new Error('navigation failed');
     });
     const creator = runCreator({});
@@ -511,42 +514,23 @@ describe('useNewSessionCreator operationKey', () => {
     }
   });
 
-  it('contains a deferred stack-cleanup failure after a success and rotates the key', async () => {
+  it('navigates once and defers no stack mutation to a later frame', async () => {
     prepareSessionMutate.mockResolvedValue(sessionResult());
-    navigationDispatch.mockImplementationOnce(() => {
-      throw new Error('stack cleanup failed');
-    });
-    // The test environment has no requestAnimationFrame; capture the deferred
-    // callback so it can be run after the submit settles, like the real frame
-    // boundary does.
-    const scheduledFrames: (() => void)[] = [];
-    // eslint-disable-next-line promise/prefer-await-to-callbacks -- the arrow is a global stub, not an async callback
-    vi.stubGlobal('requestAnimationFrame', (callback: () => void) => {
-      scheduledFrames.push(callback);
-      return 1;
-    });
-
     const creator = runCreator({});
-    creator.promptRef.current = 'hello';
-    await creator.createSessionFromDraft();
-    expect(toastError).not.toHaveBeenCalled();
 
-    // The deferred stack cleanup runs after the submit returned; a failure
-    // there must be contained instead of surfacing as an uncaught exception.
-    expect(scheduledFrames).toHaveLength(1);
-    expect(() => {
-      scheduledFrames[0]?.();
-    }).not.toThrow();
-    expect(toastError).not.toHaveBeenCalled();
-
-    // The next submit is a fresh intent with a fresh key, not a retry of the
-    // successful operation key.
     creator.promptRef.current = 'hello';
     await creator.createSessionFromDraft();
 
-    const keys = usedOperationKeys();
-    expect(keys[1]).toBeDefined();
-    expect(keys[1]).not.toBe(keys[0]);
+    // The old form pushed the session route and then dispatched a stack RESET
+    // one frame later to drop `agent-chat/new`. That second commit landed while
+    // the native push transition was still running and crashed Fabric on
+    // Android (Sentry KILO-APP-25). `replace` reaches the same stack in one
+    // commit, so nothing may be scheduled on a frame boundary.
+    expect(routerReplace).toHaveBeenCalledTimes(1);
+    expect(routerReplace).toHaveBeenCalledWith(
+      expect.stringContaining(`agent-chat/${sessionResult().kiloSessionId}`)
+    );
+    expect(scheduledFrames.count).toBe(0);
   });
 });
 
@@ -563,7 +547,7 @@ describe('useNewSessionCreator onCreated', () => {
 
     expect(onCreated).toHaveBeenCalledTimes(1);
     expect(prepareSessionMutate).toHaveBeenCalledTimes(1);
-    expect(routerPush).toHaveBeenCalledWith(expect.stringContaining('agent-chat/sess-1'));
+    expect(routerReplace).toHaveBeenCalledWith(expect.stringContaining('agent-chat/sess-1'));
     expect(captureEventMock).toHaveBeenCalledWith('session_created', expect.anything());
     expect(invalidateAgentSessionQueries).toHaveBeenCalledTimes(1);
     expect(toastError).not.toHaveBeenCalled();
@@ -582,7 +566,7 @@ describe('useNewSessionCreator onCreated', () => {
     });
 
     expect(onCreated).toHaveBeenCalledTimes(1);
-    expect(routerPush).toHaveBeenCalledWith(expect.stringContaining('agent-chat/sess-1'));
+    expect(routerReplace).toHaveBeenCalledWith(expect.stringContaining('agent-chat/sess-1'));
     expect(toastError).not.toHaveBeenCalled();
   });
 
@@ -598,7 +582,7 @@ describe('useNewSessionCreator onCreated', () => {
     });
 
     expect(onCreated).not.toHaveBeenCalled();
-    expect(routerPush).not.toHaveBeenCalled();
+    expect(routerReplace).not.toHaveBeenCalled();
     expect(toastError).toHaveBeenCalledWith('boom');
   });
 
@@ -614,7 +598,7 @@ describe('useNewSessionCreator onCreated', () => {
 
     expect(prepareSessionMutate).not.toHaveBeenCalled();
     expect(onCreated).not.toHaveBeenCalled();
-    expect(routerPush).not.toHaveBeenCalled();
+    expect(routerReplace).not.toHaveBeenCalled();
   });
 });
 
@@ -633,7 +617,7 @@ describe('restored new-session submit', () => {
     expect(prepareSessionMutate).toHaveBeenCalledWith(
       expect.objectContaining({ prompt: 'Restored draft prompt' })
     );
-    expect(routerPush).toHaveBeenCalledWith(expect.stringContaining('agent-chat/sess-1'));
+    expect(routerReplace).toHaveBeenCalledWith(expect.stringContaining('agent-chat/sess-1'));
   });
 });
 

--- a/apps/mobile/src/components/agents/use-new-session-creator.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.ts
@@ -1,5 +1,5 @@
 import { type RefObject, useCallback, useRef } from 'react';
-import { type Href, useNavigation, useRouter } from 'expo-router';
+import { useRouter } from 'expo-router';
 import { useQueryClient } from '@tanstack/react-query';
 import { generateMessageId } from '@kilocode/cloud-agent-sdk/message-id';
 import * as Haptics from 'expo-haptics';
@@ -8,6 +8,7 @@ import { toast } from 'sonner-native';
 import { type AgentMode } from '@/components/agents/mode-selector';
 import { resolveNewSessionPromptForCreate } from '@/components/agents/new-session-prompt-state';
 import { isCloudPrepareRetryableError } from '@/components/agents/mobile-session-manager';
+import { replaceWithAgentSession } from '@/components/agents/session-detail-routes';
 import { invalidateAgentSessionQueries } from '@/lib/agent-session-cache';
 import { captureEvent, SESSION_CREATED_EVENT } from '@/lib/analytics/posthog';
 import { useHoistedOperationKey } from '@/lib/operation-key';
@@ -52,7 +53,6 @@ export function useNewSessionCreator({
   variant,
 }: UseNewSessionCreatorInput): UseNewSessionCreatorResult {
   const router = useRouter();
-  const navigation = useNavigation();
   const queryClient = useQueryClient();
   const trpc = useTRPC();
   const promptRef = useRef('');
@@ -156,27 +156,13 @@ export function useNewSessionCreator({
         } catch {
           // A failed haptics call is cosmetic; stay silent and navigate.
         }
-        const path = organizationId
-          ? `/(app)/agent-chat/${result.kiloSessionId}?organizationId=${organizationId}`
-          : `/(app)/agent-chat/${result.kiloSessionId}`;
-        router.push(path as Href);
-        requestAnimationFrame(() => {
-          // Runs after the surrounding try returned, so a failure here would
-          // escape uncaught. The stack cleanup is cosmetic; contain it.
-          try {
-            navigation.dispatch(state => {
-              const routes = state.routes.filter(
-                (r: { name: string }) => r.name !== 'agent-chat/new'
-              );
-              return {
-                type: 'RESET' as const,
-                payload: { ...state, routes, index: routes.length - 1 },
-              };
-            });
-          } catch {
-            // The session already exists; stay silent.
-          }
-        });
+        // One atomic navigation: `replace` drops the new-session route as it
+        // pushes the session route, so back still lands on the session list.
+        // The previous form — `push` plus a `RESET` dispatched one frame later —
+        // mutated the stack while the native push transition was still running,
+        // which crashed Fabric on Android ("addViewAt: failed to insert view
+        // ... The specified child already has a parent", Sentry KILO-APP-25).
+        replaceWithAgentSession(router, result.kiloSessionId, organizationId);
       } catch {
         // Stay silent: no create-failure toast, no duplicate-create retry.
       }
@@ -200,7 +186,6 @@ export function useNewSessionCreator({
     queryClient,
     trpc,
     router,
-    navigation,
     attachments,
     setIsCreating,
     getKey,


### PR DESCRIPTION
## Problem

Google Play and Sentry ([KILO-APP-25](https://kilo-code.sentry.io/issues/KILO-APP-25), 428 events / 122 users, still firing) report a fatal Android crash:

```
IllegalStateException: addViewAt: failed to insert view [112858] into parent [112884] at index 6
Caused by: The specified child already has a parent. You must call removeView() on the child's parent first.
  at com.facebook.react.views.view.ReactClippingViewManager.addView
  at com.facebook.react.fabric.mounting.SurfaceMountingManager.addViewAt
```

## Evidence

- In every sampled event the last breadcrumb is `Navigation to agent-chat/[session-id] {"from":"agent-chat/new"}`, and the crash lands 30–40 ms later — one to two frames.
- The same users push `agent-chat/[session-id]` from the session list without crashing. Only the start-a-new-session path crashes.
- That path is the only one in the app that mutates the stack twice: `use-new-session-creator.ts` called `router.push(sessionPath)` and then, inside `requestAnimationFrame`, dispatched a `RESET` that removed `agent-chat/new` from the middle of the stack.

The second commit lands while the native push transition is still running. `react-native-screens` is still moving the screen's views, so Fabric re-inserts a view that still has a parent and Android throws. The upstream defect is known and unfixed (react-native-screens [#3249](https://github.com/software-mansion/react-native-screens/issues/3249), React Native [#57017](https://github.com/react/react-native/issues/57017)), but the trigger is ours.

## Fix

Use the app's existing `replaceWithAgentSession` helper. `replace` reaches the same stack in one commit — the new-session route is dropped as the session route is pushed — so nothing mutates the stack mid-transition.

- Back still lands on the session list, same as before.
- The forward push animation is unchanged: expo-router's vendored native-stack defaults `animationTypeForReplace` to `'push'`.
- Every other navigation into the session route (in-session create, restart, remote spawn, continue, share gate) already uses a single `replace` or `push`; this was the last site with a deferred stack mutation.

Net −31 lines: the deferred dispatch, its containment `try`, and the `useNavigation` dependency are gone.

## Tests

`pnpm test` (4505 pass). The former "contains a deferred stack-cleanup failure" test is replaced by a regression guard that asserts one `replace` call and zero scheduled frames.

`pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` all clean.

## Not verified

No local Android repro was run. The crash is device- and timing-dependent (122 of many users), and reproducing it needs a real cloud-agent session creation. The cause is established from telemetry: the crash follows only this navigation, and only this navigation commits the stack twice.
