### PR TITLE
fix(mobile): surface image picker launch failures

### DIFF
--- a/apps/mobile/src/components/agents/attachment-picker.test.ts
+++ b/apps/mobile/src/components/agents/attachment-picker.test.ts
@@ -1,5 +1,6 @@
 import { type ActionSheetProps } from '@expo/react-native-action-sheet';
 import * as DocumentPicker from 'expo-document-picker';
+import * as ImagePicker from 'expo-image-picker';
 import { describe, expect, it, vi } from 'vitest';
 
 import { pickAgentAttachments } from './attachment-picker';
@@ -9,9 +10,15 @@ const reactNativeMock = vi.hoisted(() => ({
   openSettings: vi.fn(),
 }));
 
+const announcingToastMock = vi.hoisted(() => ({ error: vi.fn() }));
+
 vi.mock('react-native', () => ({
   Alert: { alert: reactNativeMock.alert },
   Linking: { openSettings: reactNativeMock.openSettings },
+}));
+
+vi.mock('@/lib/a11y/announcing-toast', () => ({
+  announcingToast: { error: announcingToastMock.error, success: vi.fn(), warning: vi.fn() },
 }));
 
 vi.mock('expo-document-picker', () => ({
@@ -63,6 +70,21 @@ describe('agent attachment picker', () => {
       expect.any(Function)
     );
     expect(reactNativeMock.alert).not.toHaveBeenCalled();
+  });
+
+  // Android unregisters the picker's ActivityResultLauncher when the launching
+  // Activity is destroyed, so every later launch rejects until the process
+  // restarts. Surface it instead of rejecting into an unhandled promise.
+  it('toasts a recovery hint when the library launch rejects', async () => {
+    announcingToastMock.error.mockClear();
+    vi.mocked(ImagePicker.launchImageLibraryAsync).mockRejectedValueOnce(
+      new Error("Call to function 'ExponentImagePicker.launchImageLibraryAsync' has been rejected.")
+    );
+
+    expect(await pickWithSheetSelection(1)).toEqual([]);
+    expect(announcingToastMock.error).toHaveBeenCalledWith(
+      'Could not open the photo picker. Restart Kilo and try again.'
+    );
   });
 });
 

--- a/apps/mobile/src/components/agents/attachment-picker.ts
+++ b/apps/mobile/src/components/agents/attachment-picker.ts
@@ -5,12 +5,8 @@ import { type ActionSheetProps } from '@expo/react-native-action-sheet';
 import { Alert, Linking } from 'react-native';
 
 import { mimeForExtension, normalizeAttachmentExtension } from '@/lib/agent-attachments/validate';
+import { IMAGE_PICKER_OPTIONS, launchImagePicker } from '@/lib/agent-attachments/image-picker';
 import { type AgentAttachmentCandidate } from '@/lib/agent-attachments/use-agent-attachment-upload';
-
-const IMAGE_PICKER_OPTIONS = {
-  mediaTypes: ['images'],
-  quality: 1,
-} satisfies ImagePicker.ImagePickerOptions;
 
 function showPermissionSettingsAlert({ message, title }: { message: string; title: string }) {
   Alert.alert(title, message, [
@@ -73,22 +69,18 @@ async function pickAgentCameraImage(): Promise<AgentAttachmentCandidate[]> {
     });
     return [];
   }
-  const result = await ImagePicker.launchCameraAsync(IMAGE_PICKER_OPTIONS);
-  if (result.canceled) {
-    return [];
-  }
-  return result.assets.map(normalizeImageAsset);
+  const assets = await launchImagePicker(ImagePicker.launchCameraAsync(IMAGE_PICKER_OPTIONS));
+  return assets.map(asset => normalizeImageAsset(asset));
 }
 
 async function pickAgentLibraryImages(): Promise<AgentAttachmentCandidate[]> {
-  const result = await ImagePicker.launchImageLibraryAsync({
-    ...IMAGE_PICKER_OPTIONS,
-    allowsMultipleSelection: true,
-  });
-  if (result.canceled) {
-    return [];
-  }
-  return result.assets.map(normalizeImageAsset);
+  const assets = await launchImagePicker(
+    ImagePicker.launchImageLibraryAsync({
+      ...IMAGE_PICKER_OPTIONS,
+      allowsMultipleSelection: true,
+    })
+  );
+  return assets.map(asset => normalizeImageAsset(asset));
 }
 
 async function pickAgentDocuments(): Promise<AgentAttachmentCandidate[]> {

--- a/apps/mobile/src/components/kilo-chat/message-attachment-picker.test.ts
+++ b/apps/mobile/src/components/kilo-chat/message-attachment-picker.test.ts
@@ -28,9 +28,15 @@ const reactNativeMock = vi.hoisted(() => ({
   openSettings: vi.fn(),
 }));
 
+const announcingToastMock = vi.hoisted(() => ({ error: vi.fn() }));
+
 vi.mock('react-native', () => ({
   Alert: { alert: reactNativeMock.alert },
   Linking: { openSettings: reactNativeMock.openSettings },
+}));
+
+vi.mock('@/lib/a11y/announcing-toast', () => ({
+  announcingToast: { error: announcingToastMock.error, success: vi.fn(), warning: vi.fn() },
 }));
 
 vi.mock('expo-file-system', () => ({
@@ -138,6 +144,20 @@ describe('message attachment picker permissions', () => {
       },
     ]);
     expect(globalThis.fetch).not.toHaveBeenCalled();
+  });
+
+  // Android unregisters the picker's ActivityResultLauncher when the launching
+  // Activity is destroyed, so every later launch rejects until the process
+  // restarts. Surface it instead of rejecting into an unhandled promise.
+  it('toasts a recovery hint when the library launch rejects', async () => {
+    launchImageLibraryMock.mockRejectedValueOnce(
+      new Error("Call to function 'ExponentImagePicker.launchImageLibraryAsync' has been rejected.")
+    );
+
+    expect(await pickLibraryImages()).toEqual([]);
+    expect(announcingToastMock.error).toHaveBeenCalledWith(
+      'Could not open the photo picker. Restart Kilo and try again.'
+    );
   });
 
   it('returns normalized document selections without materializing', async () => {

--- a/apps/mobile/src/components/kilo-chat/message-attachment-picker.ts
+++ b/apps/mobile/src/components/kilo-chat/message-attachment-picker.ts
@@ -5,6 +5,7 @@ import { Alert, Linking } from 'react-native';
 import { type AddFileInput } from '@kilocode/kilo-chat-hooks';
 
 import { type ClipboardImageFile } from '@/lib/agent-attachments/clipboard-image';
+import { IMAGE_PICKER_OPTIONS, launchImagePicker } from '@/lib/agent-attachments/image-picker';
 
 import {
   type MessageAttachment,
@@ -18,11 +19,6 @@ export type PickedAttachment = {
   input: AddFileInput;
   localUri: string;
 };
-
-const IMAGE_PICKER_OPTIONS = {
-  mediaTypes: ['images'],
-  quality: 1,
-} satisfies ImagePicker.ImagePickerOptions;
 
 function assetToSelection(asset: LocalAttachmentAsset): MessageAttachment {
   const file = new File(asset.uri);
@@ -89,26 +85,20 @@ export async function pickCameraImage(): Promise<MessageAttachment[]> {
     return [];
   }
 
-  const result = await ImagePicker.launchCameraAsync(IMAGE_PICKER_OPTIONS);
+  const assets = await launchImagePicker(ImagePicker.launchCameraAsync(IMAGE_PICKER_OPTIONS));
 
-  if (result.canceled) {
-    return [];
-  }
-
-  return result.assets.map(imageAssetToSelection);
+  return assets.map(asset => imageAssetToSelection(asset));
 }
 
 export async function pickLibraryImages(): Promise<MessageAttachment[]> {
-  const result = await ImagePicker.launchImageLibraryAsync({
-    ...IMAGE_PICKER_OPTIONS,
-    allowsMultipleSelection: true,
-  });
+  const assets = await launchImagePicker(
+    ImagePicker.launchImageLibraryAsync({
+      ...IMAGE_PICKER_OPTIONS,
+      allowsMultipleSelection: true,
+    })
+  );
 
-  if (result.canceled) {
-    return [];
-  }
-
-  return result.assets.map(imageAssetToSelection);
+  return assets.map(asset => imageAssetToSelection(asset));
 }
 
 export async function pickFiles(): Promise<MessageAttachment[]> {

--- a/apps/mobile/src/lib/agent-attachments/image-picker.test.ts
+++ b/apps/mobile/src/lib/agent-attachments/image-picker.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { launchImagePicker } from './image-picker';
+
+const toastMock = vi.hoisted(() => ({ error: vi.fn() }));
+
+vi.mock('@/lib/a11y/announcing-toast', () => ({
+  announcingToast: { error: toastMock.error, success: vi.fn(), warning: vi.fn() },
+}));
+
+type LaunchResult = Awaited<Parameters<typeof launchImagePicker>[0]>;
+
+const ASSET = { uri: 'file:///photo.jpg', height: 1, width: 1 };
+
+async function resolving(result: LaunchResult): Promise<LaunchResult> {
+  await Promise.resolve();
+  return result;
+}
+
+describe('launchImagePicker', () => {
+  it('returns the picked assets', async () => {
+    const assets = await launchImagePicker(resolving({ canceled: false, assets: [ASSET] }));
+
+    expect(assets).toEqual([ASSET]);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  it('returns nothing and stays quiet when the user cancels', async () => {
+    const assets = await launchImagePicker(resolving({ canceled: true, assets: null }));
+
+    expect(assets).toEqual([]);
+    expect(toastMock.error).not.toHaveBeenCalled();
+  });
+
+  // Android unregisters the picker's ActivityResultLauncher when the launching
+  // Activity is destroyed, so every later launch rejects until the process
+  // restarts. The user must hear about it instead of getting a silent no-op.
+  it('toasts a recovery hint when the native launch rejects', async () => {
+    toastMock.error.mockClear();
+
+    const assets = await launchImagePicker(
+      Promise.reject(new Error('Attempting to launch an unregistered ActivityResultLauncher'))
+    );
+
+    expect(assets).toEqual([]);
+    expect(toastMock.error).toHaveBeenCalledWith(
+      'Could not open the photo picker. Restart Kilo and try again.'
+    );
+  });
+});

--- a/apps/mobile/src/lib/agent-attachments/image-picker.ts
+++ b/apps/mobile/src/lib/agent-attachments/image-picker.ts
@@ -1,0 +1,38 @@
+import type * as ImagePicker from 'expo-image-picker';
+
+import { announcingToast } from '@/lib/a11y/announcing-toast';
+
+export const IMAGE_PICKER_OPTIONS = {
+  mediaTypes: ['images'],
+  quality: 1,
+} satisfies ImagePicker.ImagePickerOptions;
+
+/**
+ * Run a camera / photo-library launch and return the picked assets, or an
+ * empty list when the user cancels or the native launch fails.
+ *
+ * On Android, expo-image-picker registers its `ActivityResultLauncher` once,
+ * when the module is created, while expo-modules-core unregisters that key on
+ * the launching Activity's `ON_DESTROY`
+ * (`AppContextActivityResultRegistry.register`). The module keeps the stale
+ * launcher, so after any Activity recreation every launch rejects with
+ * "Attempting to launch an unregistered ActivityResultLauncher" until the
+ * process restarts. No JS API can re-register it, so tell the user how to
+ * recover instead of rejecting into an unhandled promise and attaching
+ * nothing. expo-document-picker uses `startActivityForResult` and is not
+ * affected. Upstream: https://github.com/expo/expo/issues/41252
+ *
+ * `launch` is the in-flight promise, not a thunk: both picker entry points are
+ * `async` wrappers, so a native failure always arrives as a rejection.
+ */
+export async function launchImagePicker(
+  launch: Promise<ImagePicker.ImagePickerResult>
+): Promise<ImagePicker.ImagePickerAsset[]> {
+  try {
+    const result = await launch;
+    return result.canceled ? [] : result.assets;
+  } catch {
+    announcingToast.error('Could not open the photo picker. Restart Kilo and try again.');
+    return [];
+  }
+}


### PR DESCRIPTION
Fixes [KILO-APP-4G](https://kilo-code.sentry.io/issues/KILO-APP-4G) — 27 events, 5 users, Android only.

## The bug

`expo-image-picker` registers its Android `ActivityResultLauncher` once, when the module is created. `expo-modules-core` unregisters that key on the launching Activity's `ON_DESTROY` (`AppContextActivityResultRegistry.register`). The `AppContext` outlives Activity recreation, so the module keeps the stale launcher and every later launch rejects with:

```
java.lang.IllegalStateException: Attempting to launch an unregistered ActivityResultLauncher
```

It stays broken until the process restarts. This is upstream and unfixed: expo/expo#41252.

Both mobile pickers awaited the launch with no `catch`, so the rejection escaped as an unhandled promise. The action sheet closed, no attachment appeared, and the user got no explanation.

## The change

Route every camera / photo-library launch through one shared helper, `launchImagePicker`. It returns the picked assets, or toasts `Could not open the photo picker. Restart Kilo and try again.` and returns an empty list.

- `src/lib/agent-attachments/image-picker.ts` — new helper, plus the `IMAGE_PICKER_OPTIONS` that both modules previously duplicated.
- `src/components/agents/attachment-picker.ts` and `src/components/kilo-chat/message-attachment-picker.ts` — use it.

`expo-document-picker` uses `startActivityForResult` and is not affected, so the Files source keeps its existing path.

## Scope

This does not repair the launcher — no JS API can re-register it. It replaces a silent failure with an actionable message. The real fix belongs upstream; we wait for it rather than patching `expo-modules-core` native code.

## Checks

`pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` clean. `pnpm test`: 439 files, 4510 tests passed.
