### PR TITLE
feat(mobile): restore consent-gated masked Sentry replay and screenshots

### DIFF
--- a/apps/mobile/src/app/_layout.tsx
+++ b/apps/mobile/src/app/_layout.tsx
@@ -91,8 +91,11 @@ installE2EWebSocketLatency();
 
 // DEC-02 consent rule: crash and error reporting is mandatory, so
 // `initSentry(false)` runs at module scope — a crash during bootstrap
-// must still be reported. The optional group is `tracesSampleRate`
-// only. Account identity is cleared by step 7's `Sentry.setUser(null)`.
+// must still be reported. The optional group is `tracesSampleRate` plus
+// MASKED session replay and error screenshots (DEC-02 amendment, owner
+// decision 2026-08-17); the replay integration is only registered once
+// optional consent is accepted, so no replay code runs before the
+// decision. Account identity is cleared by step 7's `Sentry.setUser(null)`.
 //
 // In-scope core-loop spans (tracesSampleRate > 0 when optional consent is true):
 // — `app.start.cold` / `app.start.warm` (TTID / TTFD via React Navigation
@@ -109,7 +112,16 @@ function initSentry(optionalConsented: boolean) {
     environment: resolveSentryEnvironment(SENTRY_ENVIRONMENT, __DEV__),
     ...sentryOptionsForConsent(optionalConsented),
 
-    integrations: [navigationIntegration],
+    integrations: optionalConsented
+      ? [
+          navigationIntegration,
+          Sentry.mobileReplayIntegration({
+            maskAllText: true,
+            maskAllImages: true,
+            maskAllVectors: true,
+          }),
+        ]
+      : [navigationIntegration],
     enableNativeFramesTracking: false,
 
     beforeSend: scrubEvent as NonNullable<Parameters<typeof Sentry.init>[0]>['beforeSend'],

--- a/apps/mobile/src/components/consent/consent-details.mounted.test.tsx
+++ b/apps/mobile/src/components/consent/consent-details.mounted.test.tsx
@@ -121,6 +121,7 @@ describe('ConsentDetails copy', () => {
     expect(titles).toContain('Kilo Gateway (our backend)');
     expect(titles).toContain('Crash reporting');
     expect(titles).toContain('Product analytics');
+    expect(titles).toContain('Error screenshots and session replay');
     expect(titles).toContain('Install attribution');
   });
 
@@ -165,9 +166,24 @@ describe('ConsentDetails copy', () => {
     expect(footer).toBeDefined();
 
     const texts = collectTextStrings(footer);
-    // Must contain the session-replay callout (still in crash section).
-    expect(texts.some((t: string) => t.includes('session replay'))).toBe(true);
+    // Must state that screen capture is gated on optional sharing.
+    expect(
+      texts.some((t: string) => t.includes('no screen capture unless optional sharing is on'))
+    ).toBe(true);
     // Must NOT contain the analytics callout — it moved to Product analytics.
     expect(texts.some((t: string) => t.includes('No prompt or conversation content'))).toBe(false);
+  });
+
+  it('replay section discloses on-device masking', () => {
+    const renderer = mount();
+    const sections = findAllSectionProps(renderer.root);
+    const replay = sections.find(s => s.title === 'Error screenshots and session replay');
+    expect(replay).toBeDefined();
+
+    const footer = replay?.footer;
+    expect(footer).toBeDefined();
+
+    const texts = collectTextStrings(footer);
+    expect(texts.some((t: string) => t.includes('masked on your device'))).toBe(true);
   });
 });

--- a/apps/mobile/src/components/consent/consent-details.tsx
+++ b/apps/mobile/src/components/consent/consent-details.tsx
@@ -57,8 +57,8 @@ export function ConsentDetails({ mode = 'onboarding' }: ConsentDetailsProps) {
             <View className="mt-3 gap-3">
               <View className="rounded-md bg-warn-tile-bg p-3">
                 <Text className="text-xs text-warn">
-                  We do not capture session replay, screenshots of your screen, or your
-                  screen&apos;s view hierarchy.
+                  Crash reports include no screen capture unless optional sharing is on (see below).
+                  We never capture your screen&apos;s view hierarchy.
                 </Text>
               </View>
             </View>
@@ -81,6 +81,21 @@ export function ConsentDetails({ mode = 'onboarding' }: ConsentDetailsProps) {
               <View className="rounded-md bg-warn-tile-bg p-3">
                 <Text className="text-xs text-warn">
                   No prompt or conversation content is sent to product analytics.
+                </Text>
+              </View>
+            </View>
+          }
+        />
+        <Section
+          title="Error screenshots and session replay"
+          what="Masked screenshots when an error happens, and masked recordings of a small sample of sessions."
+          why="See what the app displayed when something broke."
+          who="Sentry."
+          footer={
+            <View className="mt-3">
+              <View className="rounded-md bg-warn-tile-bg p-3">
+                <Text className="text-xs text-warn">
+                  Text and images are masked on your device before anything is sent.
                 </Text>
               </View>
             </View>

--- a/apps/mobile/src/lib/sentry-consent.test.ts
+++ b/apps/mobile/src/lib/sentry-consent.test.ts
@@ -17,13 +17,13 @@ describe('sentryOptionsForConsent', () => {
     });
   });
 
-  it('disables replay, screenshots, and view-hierarchy even when consent is accepted', () => {
+  it('enables masked replay and screenshots, never view-hierarchy, when consent is accepted', () => {
     const options = sentryOptionsForConsent(true);
 
-    expect(options.attachScreenshot).toBe(false);
+    expect(options.attachScreenshot).toBe(true);
     expect(options.attachViewHierarchy).toBe(false);
-    expect(options.replaysSessionSampleRate).toBe(0);
-    expect(options.replaysOnErrorSampleRate).toBe(0);
+    expect(options.replaysSessionSampleRate).toBe(0.1);
+    expect(options.replaysOnErrorSampleRate).toBe(1);
     expect(options.tracesSampleRate).toBe(0.1);
   });
 

--- a/apps/mobile/src/lib/sentry-consent.ts
+++ b/apps/mobile/src/lib/sentry-consent.ts
@@ -1,9 +1,10 @@
 import * as Sentry from '@sentry/react-native';
 
-// Performance tracing (TTID/TTFD, app start) must not run before the user
-// accepts consent (the consent copy only promises "anonymous performance and
-// crash data" — see consent-card.tsx). Session replay, screenshots, and
-// view-hierarchy capture are never enabled.
+// Performance tracing (TTID/TTFD, app start), session replay, and error
+// screenshots must not run before the user accepts consent. With optional
+// consent accepted, replay and screenshots are captured MASKED (maskAllText/
+// maskAllImages in _layout.tsx; DEC-02 amendment, owner decision 2026-08-17,
+// disclosed in consent-details.tsx). View-hierarchy capture is never enabled.
 // This is the pure decision function; src/app/_layout.tsx re-inits Sentry
 // with these options (via reinitSentryForConsent below) whenever the stored
 // consent state changes.
@@ -30,10 +31,10 @@ export function sentryOptionsForConsent(optionalConsented: boolean): SentryConse
   }
 
   return {
-    replaysSessionSampleRate: 0,
-    replaysOnErrorSampleRate: 0,
+    replaysSessionSampleRate: 0.1,
+    replaysOnErrorSampleRate: 1,
     tracesSampleRate: 0.1,
-    attachScreenshot: false,
+    attachScreenshot: true,
     attachViewHierarchy: false,
   };
 }


### PR DESCRIPTION
## Changes

- Consented users get masked session replay (0.1 of sessions, 1.0 on errors) and error screenshots (`src/lib/sentry-consent.ts`).
- The replay integration registers only after optional consent is accepted; no replay code runs before the decision (`src/app/_layout.tsx`).
- All replay text, images, and vectors are masked on the device (`maskAllText`, `maskAllImages`, `maskAllVectors`).
- View-hierarchy capture stays off in every state.
- Declined, revoked, and pre-decision states keep zero visual capture, unchanged.
- The consent details screen discloses the masked capture as a new optional-group section (`src/components/consent/consent-details.tsx`).

## Why

Owner decision 2026-08-17 (DEC-02 amendment). #5011 removed replay and screenshots even for consented users. Store builds 1.0.2/1.0.3 still run pre-#5011 code and sent replays today; the next scheduled release build (1.0.4, daily run ~06:10 UTC) would ship the removal. This PR restores the capability before that build.

## Evidence

- `apps/mobile`: format, typecheck, lint, check:unused green; 4511 tests pass (439 files).
- `sentry-consent.test.ts` asserts the new consented options and the unchanged declined options.
- `consent-details.mounted.test.tsx` asserts the new disclosure copy in both sections.

## Notes

- Pre-consent behavior is unchanged: `initSentry(false)` at module scope keeps mandatory crash reporting on with zero visual capture.
- The consent re-init path (`Sentry.close` then `init`) is unchanged; the integration list now follows consent.
