### PR TITLE
fix(mobile): make sentry-dsn a plain .js for the Expo config loader

### DIFF
--- a/apps/mobile/src/lib/sentry-dsn.js
+++ b/apps/mobile/src/lib/sentry-dsn.js
@@ -1,3 +1,7 @@
+/** Public Sentry DSN and native init options, shared by JS init
+ *  (_layout.tsx) and the config plugin (app.config.ts).
+ *  Plain .js because the Expo config loader cannot consume workspace TS
+ *  (same reason env-keys.js exists). */
 export const SENTRY_DSN =
   'https://618cf025f1c6bdea8043fcd80668fe6b@o4509356317474816.ingest.us.sentry.io/4511110711279616';
 


### PR DESCRIPTION
## Summary

`pnpm release:internal` (and every `eas build`) failed at `expo config --json`:

```
Cannot find module './src/lib/sentry-dsn'
Require stack:
- apps/mobile/app.config.js
```

- `app.config.ts` imports `./src/lib/sentry-dsn`, added in #5308.
- The Expo config loader transpiles only the entry config file; the nested import is resolved by plain Node resolution, which never loads a `.ts` module.
- Repo convention for config-time imports is plain `.js` — see `src/lib/env-keys.js` and `src/lib/universal-link-paths.js` ("the Expo config loader cannot consume workspace TS").

## Fix

Rename `src/lib/sentry-dsn.ts` to `src/lib/sentry-dsn.js` with the same convention header. No code changes; `_layout.tsx` keeps importing `@/lib/sentry-dsn` (resolves under `allowJs`).

## Verification

- `GITHUB_ACTIONS=true node_modules/.bin/expo config --json` succeeds (failed before with the error above).
- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` all pass.