### PR TITLE
fix(web): reopen active export download challenge

### DIFF
--- a/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
+++ b/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
@@ -15,16 +15,18 @@ import { LANDING_URL } from '@/lib/constants';
 import { formatBytes } from '@/lib/kiloclaw/instance-display';
 import { useRawTRPCClient, useTRPC } from '@/lib/trpc/utils';
 import {
+  canReuseDownloadCodeChallenge,
   findActiveExport,
   findReadyExport,
   getDisplayStatus,
   getRefetchInterval,
   USER_EXPORT_STATUS_COPY,
+  type DownloadCodeChallenge,
   type ExportableOrganization,
   type UserExport,
   type UserExportDisplayStatus,
 } from './data-export-contract';
-import { DownloadCodeDialog, type DownloadCodeChallenge } from './DownloadCodeDialog';
+import { DownloadCodeDialog } from './DownloadCodeDialog';
 
 type BadgeVariant = React.ComponentProps<typeof Badge>['variant'];
 
@@ -155,14 +157,16 @@ export function DataExportsClient() {
   // Downloading is a two-step step-up: mail a single-use code, then redeem it for
   // one signed URL. A held session alone cannot reach the artifact.
   const [challenge, setChallenge] = useState<DownloadCodeChallenge | null>(null);
+  const [isDownloadCodeDialogOpen, setIsDownloadCodeDialogOpen] = useState(false);
   const requestCodeMutation = useMutation(
     trpc.userExports.requestDownloadCode.mutationOptions({
       onSuccess: (result, variables) => {
         setChallenge({
           exportId: variables.exportId,
           challengeId: result.challengeId,
-          expiresInMinutes: result.expiresInMinutes,
+          expiresAt: Date.now() + result.expiresInMinutes * 60_000,
         });
+        setIsDownloadCodeDialogOpen(true);
       },
       onError: error => {
         toast.error('Download code could not be sent', {
@@ -187,6 +191,14 @@ export function DataExportsClient() {
   // generating. The re-request throttle is enforced server-side.
   const requestDisabled =
     requestMutation.isPending || listQuery.isRefetching || Boolean(personalActiveExport);
+
+  function startDownload(exportId: string) {
+    if (canReuseDownloadCodeChallenge(challenge, exportId)) {
+      setIsDownloadCodeDialogOpen(true);
+      return;
+    }
+    requestCodeMutation.mutate({ exportId });
+  }
 
   return (
     <div className="flex flex-col gap-6">
@@ -343,7 +355,7 @@ export function DataExportsClient() {
                     requestCodeMutation.isPending &&
                     requestCodeMutation.variables?.exportId === record.id
                   }
-                  onDownload={() => requestCodeMutation.mutate({ exportId: record.id })}
+                  onDownload={() => startDownload(record.id)}
                 />
               ))}
             </ul>
@@ -371,12 +383,16 @@ export function DataExportsClient() {
 
       <DownloadCodeDialog
         challenge={challenge}
+        open={isDownloadCodeDialogOpen}
         isResending={requestCodeMutation.isPending}
         onResend={() => {
           if (challenge) requestCodeMutation.mutate({ exportId: challenge.exportId });
         }}
-        onClose={() => setChallenge(null)}
-        onVerified={triggerBrowserDownload}
+        onClose={() => setIsDownloadCodeDialogOpen(false)}
+        onVerified={downloadUrl => {
+          setChallenge(null);
+          triggerBrowserDownload(downloadUrl);
+        }}
       />
     </div>
   );

--- a/apps/web/src/app/(app)/data-exports/DownloadCodeDialog.tsx
+++ b/apps/web/src/app/(app)/data-exports/DownloadCodeDialog.tsx
@@ -15,20 +15,15 @@ import {
 import { Input } from '@/components/ui/input';
 import { Label } from '@/components/ui/label';
 import { useTRPC } from '@/lib/trpc/utils';
-import { DOWNLOAD_CODE_LENGTH } from './data-export-contract';
+import { DOWNLOAD_CODE_LENGTH, type DownloadCodeChallenge } from './data-export-contract';
 
 const CODE_INPUT_ID = 'data-export-download-code';
 const CODE_HINT_ID = 'data-export-download-code-hint';
 const CODE_ERROR_ID = 'data-export-download-code-error';
 
-export type DownloadCodeChallenge = {
-  exportId: string;
-  challengeId: string;
-  expiresInMinutes: number;
-};
-
 type DownloadCodeDialogProps = {
   challenge: DownloadCodeChallenge | null;
+  open: boolean;
   isResending: boolean;
   onResend: () => void;
   onClose: () => void;
@@ -53,6 +48,7 @@ function describeError(code: string | undefined, message: string): string {
 
 export function DownloadCodeDialog({
   challenge,
+  open,
   isResending,
   onResend,
   onClose,
@@ -80,10 +76,13 @@ export function DownloadCodeDialog({
   const errorMessage = createDownload.error
     ? describeError(createDownload.error.data?.code, createDownload.error.message)
     : null;
+  const expiresInMinutes = challenge
+    ? Math.max(1, Math.ceil((challenge.expiresAt - Date.now()) / 60_000))
+    : 10;
 
   return (
     <Dialog
-      open={challenge !== null}
+      open={open && challenge !== null}
       onOpenChange={open => {
         if (!open) onClose();
       }}
@@ -93,7 +92,7 @@ export function DownloadCodeDialog({
           <DialogTitle>Enter your download code</DialogTitle>
           <DialogDescription>
             We emailed a {DOWNLOAD_CODE_LENGTH}-digit code to your account address. It authorizes
-            one download and expires in {challenge?.expiresInMinutes ?? 10} minutes.
+            one download and expires in {expiresInMinutes} minutes.
           </DialogDescription>
         </DialogHeader>
 

--- a/apps/web/src/app/(app)/data-exports/data-export-contract.test.ts
+++ b/apps/web/src/app/(app)/data-exports/data-export-contract.test.ts
@@ -12,17 +12,18 @@ describe('canReuseDownloadCodeChallenge', () => {
   const challenge = {
     exportId: 'export-1',
     challengeId: 'challenge-1',
-    expiresAt: 10_000,
+    expiresAt: 60_000,
   };
 
-  it('reuses a live challenge for the same export', () => {
-    expect(canReuseDownloadCodeChallenge(challenge, 'export-1', 9_999)).toBe(true);
+  it('reuses a challenge for the same export with more than 30 seconds remaining', () => {
+    expect(canReuseDownloadCodeChallenge(challenge, 'export-1', 29_999)).toBe(true);
   });
 
-  it('requests a new challenge for another export or after expiry', () => {
-    expect(canReuseDownloadCodeChallenge(challenge, 'export-2', 9_999)).toBe(false);
-    expect(canReuseDownloadCodeChallenge(challenge, 'export-1', 10_000)).toBe(false);
-    expect(canReuseDownloadCodeChallenge(null, 'export-1', 9_999)).toBe(false);
+  it('requests a new challenge for another export or with 30 seconds or less remaining', () => {
+    expect(canReuseDownloadCodeChallenge(challenge, 'export-2', 29_999)).toBe(false);
+    expect(canReuseDownloadCodeChallenge(challenge, 'export-1', 30_000)).toBe(false);
+    expect(canReuseDownloadCodeChallenge(challenge, 'export-1', 60_000)).toBe(false);
+    expect(canReuseDownloadCodeChallenge(null, 'export-1', 29_999)).toBe(false);
   });
 });
 

--- a/apps/web/src/app/(app)/data-exports/data-export-contract.test.ts
+++ b/apps/web/src/app/(app)/data-exports/data-export-contract.test.ts
@@ -1,4 +1,5 @@
 import {
+  canReuseDownloadCodeChallenge,
   getDisplayStatus,
   getRefetchInterval,
   hasActiveExports,
@@ -6,6 +7,24 @@ import {
   USER_EXPORTS_POLL_INTERVAL_MS,
   type UserExport,
 } from './data-export-contract';
+
+describe('canReuseDownloadCodeChallenge', () => {
+  const challenge = {
+    exportId: 'export-1',
+    challengeId: 'challenge-1',
+    expiresAt: 10_000,
+  };
+
+  it('reuses a live challenge for the same export', () => {
+    expect(canReuseDownloadCodeChallenge(challenge, 'export-1', 9_999)).toBe(true);
+  });
+
+  it('requests a new challenge for another export or after expiry', () => {
+    expect(canReuseDownloadCodeChallenge(challenge, 'export-2', 9_999)).toBe(false);
+    expect(canReuseDownloadCodeChallenge(challenge, 'export-1', 10_000)).toBe(false);
+    expect(canReuseDownloadCodeChallenge(null, 'export-1', 9_999)).toBe(false);
+  });
+});
 
 function makeUserExport(overrides: Partial<UserExport> = {}): UserExport {
   return {

--- a/apps/web/src/app/(app)/data-exports/data-export-contract.ts
+++ b/apps/web/src/app/(app)/data-exports/data-export-contract.ts
@@ -13,6 +13,20 @@
  */
 export const DOWNLOAD_CODE_LENGTH = 8;
 
+export type DownloadCodeChallenge = {
+  exportId: string;
+  challengeId: string;
+  expiresAt: number;
+};
+
+export function canReuseDownloadCodeChallenge(
+  challenge: DownloadCodeChallenge | null,
+  exportId: string,
+  now = Date.now()
+): challenge is DownloadCodeChallenge {
+  return challenge?.exportId === exportId && challenge.expiresAt > now;
+}
+
 export const USER_EXPORT_STATUSES = [
   'queued',
   'processing',

--- a/apps/web/src/app/(app)/data-exports/data-export-contract.ts
+++ b/apps/web/src/app/(app)/data-exports/data-export-contract.ts
@@ -12,6 +12,7 @@
  * sign-in code uses: those are spent in one sitting, this one is not.
  */
 export const DOWNLOAD_CODE_LENGTH = 8;
+const DOWNLOAD_CODE_REUSE_MARGIN_MS = 30_000;
 
 export type DownloadCodeChallenge = {
   exportId: string;
@@ -24,7 +25,9 @@ export function canReuseDownloadCodeChallenge(
   exportId: string,
   now = Date.now()
 ): challenge is DownloadCodeChallenge {
-  return challenge?.exportId === exportId && challenge.expiresAt > now;
+  return (
+    challenge?.exportId === exportId && challenge.expiresAt > now + DOWNLOAD_CODE_REUSE_MARGIN_MS
+  );
 }
 
 export const USER_EXPORT_STATUSES = [


### PR DESCRIPTION
## Summary
- retain an emailed download-code challenge when the entry dialog is dismissed
- reopen the existing challenge for the same export instead of requesting another rate-limited code
- request a fresh challenge for another export or after client-side expiry
- clear the retained challenge after successful verification

## Verification
- `pnpm --filter web typecheck`
- focused `oxlint` on changed files
- `pnpm format`
- direct runtime assertions for challenge reuse and expiry
- `git diff --check`
