### PR TITLE
fix(web): refuse CSA GDPR deletion only for admin, super-admin, or bot

### DIFF
--- a/.env.local.example
+++ b/.env.local.example
@@ -104,7 +104,7 @@ STRIPE_KILOCLAW_2026_05_10_COMMIT_PRICE_ID=price_test_kiloclaw_2026_05_10_commit
 # Internal API secret (generate: openssl rand -base64 32)
 INTERNAL_API_SECRET=changeme
 # Support service API (CSA GDPR web only). Distinct from INTERNAL_API_SECRET.
-# Leak = enumerate any email + wipe any non-staff, non-live-sub customer.
+# Leak = enumerate any email + wipe any non-admin, non-bot, non-live-sub customer.
 # Generate: openssl rand -base64 32
 SUPPORT_API_SECRET=changeme
 # Git token service persisted-authorization disconnect

--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -69,7 +69,7 @@ Manage shared web env var additions and rotations with `pnpm web:env set <VARIAB
 - `STYTCH_PROJECT_SECRET` - Stytch project secret. `[SECRET]`
 - `STYTCH_PUBLIC_TOKEN` - Stytch legacy public token alias used in some test fixtures. [PUBLIC]
 - `INTERNAL_API_SECRET` - Shared secret for internal API calls between services; used in `apps/web/src/lib/kiloclaw/cli-runs.test.ts`, `kiloclaw-router.test.ts`, dev seed scripts, and other service routers. `[SECRET]`
-- `SUPPORT_API_SECRET` - Dedicated shared secret for the customer-support-automation GDPR web app. Accepted only on `GET /api/internal/support/users` and `POST /api/internal/support/users/gdpr-removal` via `Authorization: Bearer`. Not a user JWT and not `INTERNAL_API_SECRET`. Leak = enumerate any email + wipe any non-staff, non-live-subscription customer. Distinct values for Development / Staging / Production. Do not put the production value on Cloud preview deployments. Rotate by updating Cloud and CSA together. `[SECRET]`
+- `SUPPORT_API_SECRET` - Dedicated shared secret for the customer-support-automation GDPR web app. Accepted only on `GET /api/internal/support/users` and `POST /api/internal/support/users/gdpr-removal` via `Authorization: Bearer`. Not a user JWT and not `INTERNAL_API_SECRET`. Leak = enumerate any email + wipe any non-admin, non-bot, non-live-subscription customer. Distinct values for Development / Staging / Production. Do not put the production value on Cloud preview deployments. Rotate by updating Cloud and CSA together. `[SECRET]`
 - `CALLBACK_TOKEN_SECRET` - Secret for signing callback tokens. Required for local development. `[SECRET]`
 - `INTERNAL_SECRET` - Alias/fallback for `INTERNAL_API_SECRET`; used in KiloClaw E2E scripts (`services/kiloclaw/e2e/`). `[SECRET]`
 

--- a/apps/web/src/app/api/internal/support/_auth.ts
+++ b/apps/web/src/app/api/internal/support/_auth.ts
@@ -65,10 +65,6 @@ export function isSupportDeletionRefused(user: {
   is_admin: boolean;
   is_super_admin: boolean;
   is_bot: boolean;
-  hosted_domain: string | null;
-  google_user_email: string;
 }): boolean {
-  if (user.is_admin || user.is_super_admin || user.is_bot) return true;
-  if (user.hosted_domain === 'kilocode.ai') return true;
-  return isKiloOwnedEmailDomain(emailDomainAfterLastAt(user.google_user_email));
+  return user.is_admin || user.is_super_admin || user.is_bot;
 }

--- a/apps/web/src/app/api/internal/support/users/gdpr-removal/route.test.ts
+++ b/apps/web/src/app/api/internal/support/users/gdpr-removal/route.test.ts
@@ -313,24 +313,29 @@ describe('POST /api/internal/support/users/gdpr-removal', () => {
     { name: 'admin', overrides: { is_admin: true } },
     { name: 'super_admin', overrides: { is_super_admin: true } },
     { name: 'bot', overrides: { is_bot: true } },
+  ])('returns 403 for $name and does not destroy', async ({ overrides }) => {
+    mockedFindUserById.mockResolvedValue(targetUser(overrides));
+
+    const res = await POST(request());
+    expect(res.status).toBe(403);
+    expect(destroy).not.toHaveBeenCalled();
+    expect(mockedSoftDeleteUser).not.toHaveBeenCalled();
+    expect(mockedAssertUserCanBeSoftDeleted).not.toHaveBeenCalled();
+    expect(events[0]).toMatchObject({ outcome: 'refused', target: `user:${USER_ID}` });
+  });
+
+  test.each([
     { name: '@kilocode.ai email', overrides: { google_user_email: 'staff@kilocode.ai' } },
     { name: '@kilo.ai email', overrides: { google_user_email: 'staff@kilo.ai' } },
-    {
-      name: 'subdomain of kilocode.ai',
-      overrides: { google_user_email: 'user@corp.kilocode.ai' },
-    },
-    {
-      name: 'mixed-case KiloCode.ai',
-      overrides: { google_user_email: 'Admin@KiloCode.ai' },
-    },
     { name: 'hosted_domain kilocode.ai', overrides: { hosted_domain: 'kilocode.ai' } },
-  ])('returns 403 for $name and does not destroy', async ({ overrides }) => {
+  ])('does not refuse $name without admin/bot flags', async ({ overrides }) => {
     mockedFindUserById.mockResolvedValue(
       targetUser({
         google_user_email: (overrides.google_user_email as string | undefined) ?? CUSTOMER_EMAIL,
         ...overrides,
       })
     );
+    mockedListAllActiveInstanceRows.mockResolvedValue([]);
 
     const res = await POST(
       request({
@@ -339,18 +344,6 @@ describe('POST /api/internal/support/users/gdpr-removal', () => {
         ).toLowerCase(),
       })
     );
-    expect(res.status).toBe(403);
-    expect(destroy).not.toHaveBeenCalled();
-    expect(mockedSoftDeleteUser).not.toHaveBeenCalled();
-    expect(mockedAssertUserCanBeSoftDeleted).not.toHaveBeenCalled();
-    expect(events[0]).toMatchObject({ outcome: 'refused', target: `user:${USER_ID}` });
-  });
-
-  test('does not refuse evilkilocode.ai', async () => {
-    mockedFindUserById.mockResolvedValue(targetUser({ google_user_email: 'user@evilkilocode.ai' }));
-    mockedListAllActiveInstanceRows.mockResolvedValue([]);
-
-    const res = await POST(request({ email: 'user@evilkilocode.ai' }));
     expect(res.status).toBe(200);
     expect(mockedSoftDeleteUser).toHaveBeenCalledWith(USER_ID);
     expect(events[0]).toMatchObject({ outcome: 'deleted' });


### PR DESCRIPTION
## Summary

- CSA GDPR deletion (`POST /api/internal/support/users/gdpr-removal`) now refuses only `is_admin`, `is_super_admin`, or `is_bot` accounts.
- `@kilocode.ai` / `@kilo.ai` email and `hosted_domain === kilocode.ai` no longer block deletion, so support can remove non-admin staff-domain users.
- Actor email still must be a Kilo-owned domain.

## Test plan

- [x] `pnpm --filter web test -- src/app/api/internal/support/users/gdpr-removal/route.test.ts` (24 passed)
- [ ] Confirm CSA can delete a non-admin `@kilocode.ai` user
- [ ] Confirm CSA still gets 403 for admin / super-admin / bot