### PR TITLE
perf(data-export): reuse warehouse connection

### DIFF
--- a/services/user-data-export/src/databases.test.ts
+++ b/services/user-data-export/src/databases.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it, vi } from 'vitest';
+import { createReplicaDatabase } from './databases';
+
+describe('replica database lifecycle', () => {
+  it('reuses one max-one pool and closes it once after all queries', async () => {
+    const query = vi
+      .fn()
+      .mockResolvedValueOnce({ rows: [{ id: 'first' }] })
+      .mockResolvedValueOnce({ rows: [{ id: 'second' }] });
+    const end = vi.fn().mockResolvedValue(undefined);
+    const createPool = vi.fn(() => ({ query, end }));
+    const warehouse = createReplicaDatabase(
+      { connectionString: 'postgres://hyperdrive.example/database' },
+      'warehouse',
+      createPool
+    );
+
+    await expect(warehouse.query('SELECT $1', ['first'])).resolves.toEqual([{ id: 'first' }]);
+    await expect(warehouse.query('SELECT $1', ['second'])).resolves.toEqual([{ id: 'second' }]);
+    await warehouse.close();
+
+    expect(createPool).toHaveBeenCalledOnce();
+    expect(createPool).toHaveBeenCalledWith({
+      connectionString: 'postgres://hyperdrive.example/database',
+      max: 1,
+      statement_timeout: 30_000,
+    });
+    expect(query).toHaveBeenNthCalledWith(1, 'SELECT $1', ['first']);
+    expect(query).toHaveBeenNthCalledWith(2, 'SELECT $1', ['second']);
+    expect(query).toHaveBeenCalledTimes(2);
+    expect(end).toHaveBeenCalledOnce();
+  });
+
+  it('leaves cleanup with the owner when a query rejects', async () => {
+    const failure = new Error('warehouse unavailable');
+    const query = vi.fn().mockRejectedValue(failure);
+    const end = vi.fn().mockResolvedValue(undefined);
+    const warehouse = createReplicaDatabase(
+      { connectionString: 'postgres://hyperdrive.example/database' },
+      'warehouse',
+      () => ({ query, end })
+    );
+
+    await expect(warehouse.query('SELECT 1', [])).rejects.toBe(failure);
+    expect(end).not.toHaveBeenCalled();
+
+    await warehouse.close();
+    expect(end).toHaveBeenCalledOnce();
+  });
+});

--- a/services/user-data-export/src/databases.ts
+++ b/services/user-data-export/src/databases.ts
@@ -1,7 +1,7 @@
 import { getWorkerDb, pg } from '@kilocode/db/client';
 import { organizationExportAccess } from '@kilocode/db/organization-export-access';
 import { sql } from 'drizzle-orm';
-import { safeError, setSpanFields, withSpan } from './observability';
+import { logExportEvent, safeError, setSpanFields, withSpan } from './observability';
 import type { ReplicaQuery } from './source-adapters';
 
 export type HyperdriveBinding = { connectionString: string };
@@ -397,51 +397,76 @@ export function createStateDb(binding: HyperdriveBinding) {
 
 type ExportQueueRow = { id: string; export_id: string; generation: number };
 
+export type ReplicaDatabase = {
+  query: ReplicaQuery;
+  close: () => Promise<void>;
+};
+
+type ReplicaPool = {
+  query: (text: string, values: unknown[]) => Promise<{ rows: Record<string, unknown>[] }>;
+  end: () => Promise<void>;
+};
+
 /**
- * Build the page-reading query function for one Hyperdrive binding.
+ * Build one invocation-scoped warehouse connection pool.
  *
  * `database` only labels spans, so pass the logical binding name rather than anything
  * derived from the connection string, which carries credentials.
  *
  * Every source page an export reads passes through here, and Hyperdrive is not
- * auto-instrumented, so this is the one place that can make read cost visible. The
- * nested connect span is deliberate: this opens a fresh connection and transaction per
- * page, and the split between connect and query time is the only way to see what that
- * setup actually costs against a remote warehouse.
+ * auto-instrumented, so this is the one place that can make read cost visible. The pool
+ * has one client because pages are read sequentially. Keeping it for the invocation avoids
+ * reconnecting for every page while still preventing I/O state from crossing invocations.
+ * Callers must await each query before starting the next; max: 1 is a guard, not a source
+ * of query parallelism.
  *
  * The query text is intentionally not recorded. The enclosing per-source span already
  * identifies which of the six queries ran, so the text would add bytes to every span
  * without adding information, and keeping it out avoids growing the exported surface.
  */
-export function createReplicaQuery(binding: HyperdriveBinding, database: string): ReplicaQuery {
-  return async (text: string, values: unknown[]): Promise<Record<string, unknown>[]> =>
-    withSpan(
-      'postgres_read_page',
-      { 'db.system.name': 'postgresql', 'db.name': database },
-      async span => {
-        const client = new pg.Client({
-          connectionString: binding.connectionString,
-          statement_timeout: 30_000,
-        });
-        try {
-          await withSpan('postgres_connect', { 'db.name': database }, async () => {
-            await client.connect();
-            await client.query('BEGIN READ ONLY');
-          });
-          const result = await client.query<Record<string, unknown>>(text, values);
-          await client.query('COMMIT');
-          span.setAttribute('db.response.returned_rows', result.rows.length);
-          return result.rows;
-        } catch (error) {
-          span.setAttribute('db.read.failed', true);
-          setSpanFields(span, safeError(error));
-          await client.query('ROLLBACK').catch(() => undefined);
-          throw error;
-        } finally {
-          await client.end();
+export function createReplicaDatabase(
+  binding: HyperdriveBinding,
+  database: string,
+  createPool: (config: pg.PoolConfig) => ReplicaPool = config => {
+    const pool = new pg.Pool(config);
+    // node-postgres emits idle-client failures through EventEmitter rather than through
+    // query(). Without a listener they become uncaught errors for the invocation.
+    pool.on('error', error => {
+      logExportEvent('warn', 'postgres_pool_error', {
+        database,
+        ...safeError(error),
+      });
+    });
+    return {
+      query: (text, values) => pool.query<Record<string, unknown>>(text, values),
+      end: () => pool.end(),
+    };
+  }
+): ReplicaDatabase {
+  const pool = createPool({
+    connectionString: binding.connectionString,
+    max: 1,
+    statement_timeout: 30_000,
+  });
+  return {
+    query: (text, values) =>
+      withSpan(
+        'postgres_read_page',
+        { 'db.system.name': 'postgresql', 'db.name': database },
+        async span => {
+          try {
+            const result = await pool.query(text, values);
+            span.setAttribute('db.response.returned_rows', result.rows.length);
+            return result.rows;
+          } catch (error) {
+            span.setAttribute('db.read.failed', true);
+            setSpanFields(span, safeError(error));
+            throw error;
+          }
         }
-      }
-    );
+      ),
+    close: () => pool.end(),
+  };
 }
 
 export const __test__ = { callerMayAccess };

--- a/services/user-data-export/src/worker.test.ts
+++ b/services/user-data-export/src/worker.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   consumeDeadLetterBatch,
   consumeExportBatch,
+  closeReplicaDatabase,
   deletePendingObjects,
   exportHeader,
   exportTrailer,
@@ -322,6 +323,53 @@ describe('one-shot generator state', () => {
         next_part_number: 2,
       })
     ).toBe(true);
+  });
+});
+
+describe('replica database cleanup', () => {
+  it('closes the invocation-owned database exactly once', async () => {
+    const close = vi.fn().mockResolvedValue(undefined);
+
+    await closeReplicaDatabase({
+      database: { query: vi.fn(), close },
+      exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+      generation: 2,
+    });
+
+    expect(close).toHaveBeenCalledOnce();
+  });
+
+  it('does not replace a completed generation outcome when close fails', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    await expect(
+      closeReplicaDatabase({
+        database: {
+          query: vi.fn(),
+          close: vi.fn().mockRejectedValue(new Error('connection shutdown failed')),
+        },
+        exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+        generation: 2,
+      })
+    ).resolves.toBeUndefined();
+
+    expect(parsedLog(warn)).toEqual({
+      event: 'export_warehouse_close_failed',
+      service: 'user-data-export',
+      exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+      generation: 2,
+      errorName: 'Error',
+    });
+  });
+
+  it('does nothing when generation exits before opening the database', async () => {
+    await expect(
+      closeReplicaDatabase({
+        database: undefined,
+        exportId: 'f6ba5ce5-9061-4f7f-9ec6-76f047573f1c',
+        generation: 2,
+      })
+    ).resolves.toBeUndefined();
   });
 });
 

--- a/services/user-data-export/src/worker.ts
+++ b/services/user-data-export/src/worker.ts
@@ -5,11 +5,12 @@ import {
   type ExportQueueMessage,
 } from './contracts';
 import {
-  createReplicaQuery,
+  createReplicaDatabase,
   createStateDb,
   type ExportCompletionResult,
   type ExportJob,
   type HyperdriveBinding,
+  type ReplicaDatabase,
 } from './databases';
 import { SourceReadError, TerminalExportError } from './errors';
 import {
@@ -72,6 +73,25 @@ export function hasRetiredGeneratorState(
   job: Pick<ExportJob, 'current_source' | 'source_cursor' | 'next_part_number'>
 ): boolean {
   return job.current_source !== null || job.source_cursor !== null || job.next_part_number !== 1;
+}
+
+export async function closeReplicaDatabase(input: {
+  database: ReplicaDatabase | undefined;
+  exportId: string;
+  generation: number;
+}): Promise<void> {
+  if (!input.database) return;
+  try {
+    await input.database.close();
+  } catch (error) {
+    // Cleanup must be awaited, but it must not replace the generation outcome. In
+    // particular, a close failure after state completion must not retry a ready export.
+    logExportEvent('warn', 'export_warehouse_close_failed', {
+      exportId: input.exportId,
+      generation: input.generation,
+      ...safeError(error),
+    });
+  }
 }
 
 export async function handleGenerationFailure(input: {
@@ -401,6 +421,7 @@ export async function processGenerateMessage(
   let objectCompletionAttempted = false;
   let phase = 'claim';
   let activeSource = job.current_source;
+  let warehouse: ReplicaDatabase | undefined;
 
   try {
     if (hasRetiredGeneratorState(job)) {
@@ -443,15 +464,16 @@ export async function processGenerateMessage(
     // Resolved once, from persisted state, and reused for every page. Deriving it per
     // page would let a single mis-set field change scope midway through a file.
     const subject = exportSubject(job);
-    const warehouseQuery = createReplicaQuery(env.EXPORT_WAREHOUSE_DB, 'warehouse');
-    const allAdapters = createSourceAdapters({ warehouseQuery });
+    warehouse = createReplicaDatabase(env.EXPORT_WAREHOUSE_DB, 'warehouse');
+    const activeWarehouse = warehouse;
+    const allAdapters = createSourceAdapters({ warehouseQuery: activeWarehouse.query });
 
     // Before anything is written, because the header names what is missing and cannot
     // be amended once the first part has been uploaded. One query, not one per source.
     phase = 'source_probe';
     const sources = await withSpan('export_source_probe', {}, async span => {
       const present = await findPresentWarehouseTables(
-        warehouseQuery,
+        activeWarehouse.query,
         warehouseRequirements(allAdapters, job.subject_type)
       );
       const partitioned = partitionSources(allAdapters, job.subject_type, present);
@@ -763,6 +785,11 @@ export async function processGenerateMessage(
     if (outcome === 'retry') throw failure;
   } finally {
     if (deadline) clearTimeout(deadline);
+    await closeReplicaDatabase({
+      database: warehouse,
+      exportId: job.id,
+      generation: job.dispatch_generation,
+    });
   }
 }
 


### PR DESCRIPTION
## Summary

- Reuse one invocation-scoped `pg.Pool` with `max: 1` for the export warehouse instead of opening a new Hyperdrive client and transaction for every page.
- Run each sequential page read directly through the pool, removing per-page `BEGIN READ ONLY` and `COMMIT` round trips.
- Close the pool from the generation lifecycle on every exit path, while logging cleanup failures without replacing a successful or failed export outcome.
- Add lifecycle coverage for pool reuse, query failures, absent handles, and cleanup failures.

## Verification

- Manual production export verification was not performed because this change affects a production Hyperdrive-backed queue worker and requires deployment to exercise the real connection lifecycle.

## Visual Changes

N/A

## Reviewer Notes

- Warehouse reads remain strictly sequential; `max: 1` prevents additional connections and is not used for query parallelism.
- The export warehouse is frozen at its load cutoff, so removing independent per-page read-only transactions does not weaken cross-page consistency.
- Pool shutdown is awaited on every path, but shutdown failures are intentionally logged and suppressed so cleanup cannot retry an export already marked ready.