### PR TITLE
fix(admin): label data export subjects

### DIFF
--- a/apps/web/src/app/admin/data-exports/DataExportsTable.tsx
+++ b/apps/web/src/app/admin/data-exports/DataExportsTable.tsx
@@ -25,7 +25,7 @@ import {
   statusBadgeClass,
 } from './data-export-format';
 
-const COLUMN_COUNT = 10;
+const COLUMN_COUNT = 11;
 const SKELETON_ROW_COUNT = 5;
 
 function shortId(id: string): string {
@@ -73,6 +73,24 @@ function DataExportRow({ row, asOf }: { row: DataExportListRow; asOf: string | u
         <Badge variant="outline" className={statusBadgeClass(row.status)}>
           {humanizeToken(row.status)}
         </Badge>
+      </TableCell>
+      <TableCell className="w-52 max-w-52 text-sm">
+        <div className="flex flex-col items-start gap-1">
+          <Badge variant="outline">
+            {row.subject.type === 'organization' ? 'Organization' : 'Personal'}
+          </Badge>
+          {row.subject.organization ? (
+            <Link
+              className="text-link hover:text-link-hover block max-w-52 truncate rounded-sm text-xs underline decoration-current/40 underline-offset-4 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+              href={`/admin/organizations/${encodeURIComponent(row.subject.organization.id)}`}
+              title={row.subject.organization.name ?? row.subject.organization.id}
+            >
+              {row.subject.organization.name ?? row.subject.organization.id}
+            </Link>
+          ) : (
+            <span className="text-muted-foreground text-xs">Requester's own data</span>
+          )}
+        </div>
       </TableCell>
       <TableCell className="w-56 max-w-56 text-sm">
         <div className="flex flex-col gap-0.5">
@@ -165,7 +183,8 @@ export function DataExportsTable({
             <TableHead>Requested</TableHead>
             <TableHead>Health</TableHead>
             <TableHead>Status</TableHead>
-            <TableHead>User</TableHead>
+            <TableHead>Subject</TableHead>
+            <TableHead>Requester</TableHead>
             <TableHead>Execution</TableHead>
             <TableHead>Attempts</TableHead>
             <TableHead>Rows / size</TableHead>

--- a/apps/web/src/app/admin/data-exports/[id]/DataExportDetailContent.tsx
+++ b/apps/web/src/app/admin/data-exports/[id]/DataExportDetailContent.tsx
@@ -85,15 +85,39 @@ function ExportIdentityCard({ detail }: { detail: DataExportDetail }) {
   return (
     <Card>
       <CardHeader>
-        <CardTitle>Export and user</CardTitle>
-        <CardDescription>Identity, ownership, and current lifecycle status.</CardDescription>
+        <CardTitle>Export identity</CardTitle>
+        <CardDescription>Data subject, requester, and current lifecycle status.</CardDescription>
       </CardHeader>
       <CardContent>
         <dl className="divide-y divide-border">
           <DetailField label="Export ID">
             <span className="font-mono text-xs break-all">{detail.id}</span>
           </DetailField>
-          <DetailField label="User">
+          <DetailField label="Subject type">
+            <Badge variant="outline">
+              {detail.subject.type === 'organization' ? 'Organization' : 'Personal'}
+            </Badge>
+          </DetailField>
+          {detail.subject.organization ? (
+            <>
+              <DetailField label="Organization">
+                <Link
+                  className="text-link hover:text-link-hover rounded-sm underline decoration-current/40 underline-offset-4 outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                  href={`/admin/organizations/${encodeURIComponent(detail.subject.organization.id)}`}
+                >
+                  {detail.subject.organization.name ?? detail.subject.organization.id}
+                </Link>
+              </DetailField>
+              <DetailField label="Organization ID">
+                <span className="font-mono text-xs break-all">
+                  {detail.subject.organization.id}
+                </span>
+              </DetailField>
+            </>
+          ) : (
+            <DetailField label="Data subject">Requester's own account</DetailField>
+          )}
+          <DetailField label="Requested by">
             <Link
               className="text-link hover:text-link-hover rounded-sm underline decoration-current/40 underline-offset-4 outline-none focus-visible:ring-2 focus-visible:ring-ring"
               href={`/admin/users/${encodeURIComponent(detail.user.id)}`}
@@ -101,8 +125,8 @@ function ExportIdentityCard({ detail }: { detail: DataExportDetail }) {
               {detail.user.email}
             </Link>
           </DetailField>
-          <DetailField label="User name">{detail.user.name ?? 'Not available'}</DetailField>
-          <DetailField label="User ID">
+          <DetailField label="Requester name">{detail.user.name ?? 'Not available'}</DetailField>
+          <DetailField label="Requester ID">
             <span className="font-mono text-xs break-all">{detail.user.id}</span>
           </DetailField>
           <DetailField label="Status">

--- a/apps/web/src/app/admin/data-exports/data-export-components.test.ts
+++ b/apps/web/src/app/admin/data-exports/data-export-components.test.ts
@@ -22,6 +22,7 @@ const summaryFixture = {
 const healthyRow: DataExportListRow = {
   id: '2c4f8a10-1111-4222-8333-444455556666',
   user: { id: 'user-1', email: 'ready@example.com', name: 'Ready User' },
+  subject: { type: 'user', organization: null },
   status: 'ready',
   schemaVersion: 1,
   currentSource: null,
@@ -63,6 +64,13 @@ const degradedRow: DataExportListRow = {
   ...healthyRow,
   id: '9d8c7b6a-5555-4666-8777-888899990000',
   user: { id: 'user-2', email: 'stuck@example.com', name: null },
+  subject: {
+    type: 'organization',
+    organization: {
+      id: '5f9022b7-424e-4fa8-a0d7-b84cf3fc73ad',
+      name: 'Stuck Organization',
+    },
+  },
   status: 'processing',
   currentSource: 'kilocode_users',
   attemptCount: 2,
@@ -121,7 +129,7 @@ describe('DataExportsSummaryStrip', () => {
 });
 
 describe('DataExportsTable', () => {
-  it('renders rows with health, status, user, and one-shot execution details', () => {
+  it('renders rows with subject, requester, health, and execution details', () => {
     const html = renderToStaticMarkup(
       React.createElement(DataExportsTable, {
         rows: [healthyRow, degradedRow],
@@ -132,7 +140,14 @@ describe('DataExportsTable', () => {
 
     // Links and navigation targets
     expect(html).toContain('href="/admin/users/user-1"');
+    expect(html).toContain('href="/admin/organizations/5f9022b7-424e-4fa8-a0d7-b84cf3fc73ad"');
     expect(html).toContain('href="/admin/data-exports/2c4f8a10-1111-4222-8333-444455556666"');
+
+    // Subject and requester are distinct concepts
+    expect(html).toContain('Personal');
+    expect(html).toContain('Organization');
+    expect(html).toContain('Stuck Organization');
+    expect(html).toContain('Requester');
 
     // Health badges use text, not color alone
     expect(html).toContain('OK');

--- a/apps/web/src/routers/admin/user-data-exports-router.test.ts
+++ b/apps/web/src/routers/admin/user-data-exports-router.test.ts
@@ -359,6 +359,57 @@ describe('adminUserDataExportsRouter', () => {
     expect(detail.actions.cancelAndRetry).toEqual({ eligible: true, disabledReason: null });
   });
 
+  it('allows an organization retry when its requester has a usable personal export', async () => {
+    const result = await (
+      await createCallerForUser(admin.id)
+    ).admin.userDataExports.cancelAndRetry({
+      exportId: organizationExportId,
+      expectedGeneration: 0,
+    });
+    exportIds.push(result.replacementExportId);
+
+    const replacement = await db.query.user_data_exports.findFirst({
+      where: eq(user_data_exports.id, result.replacementExportId),
+    });
+    expect(replacement).toMatchObject({
+      kilo_user_id: owner.id,
+      subject_type: 'organization',
+      organization_id: subjectOrganizationId,
+    });
+  });
+
+  it('rejects an organization retry when another requester has a usable export for it', async () => {
+    await db
+      .update(user_data_exports)
+      .set({ status: 'failed' })
+      .where(eq(user_data_exports.id, organizationExportId));
+    const [blocker] = await db
+      .insert(user_data_exports)
+      .values({
+        kilo_user_id: recoveryOwner.id,
+        subject_type: 'organization',
+        organization_id: subjectOrganizationId,
+        status: 'ready',
+        snapshot_at: '2026-08-03T00:00:00.000Z',
+        r2_object_key: `exports/${crypto.randomUUID()}/kilo-data-export.jsonl.gz`,
+        size_bytes: 1024,
+        completed_at: new Date().toISOString(),
+        expires_at: new Date(Date.now() + 86_400_000).toISOString(),
+      })
+      .returning({ id: user_data_exports.id });
+    exportIds.push(blocker.id);
+
+    await expect(
+      (await createCallerForUser(admin.id)).admin.userDataExports.cancelAndRetry({
+        exportId: organizationExportId,
+        expectedGeneration: 0,
+      })
+    ).rejects.toMatchObject({
+      code: 'CONFLICT',
+      message: 'This organization already has another active or downloadable export',
+    });
+  });
+
   it('returns not found for an unknown export', async () => {
     await expect(
       (await createCallerForUser(admin.id)).admin.userDataExports.detail({

--- a/apps/web/src/routers/admin/user-data-exports-router.test.ts
+++ b/apps/web/src/routers/admin/user-data-exports-router.test.ts
@@ -15,6 +15,7 @@ import {
   user_data_export_object_deletions,
   user_data_export_parts,
   user_data_exports,
+  organizations,
   type User,
 } from '@kilocode/db/schema';
 
@@ -34,6 +35,8 @@ describe('adminUserDataExportsRouter', () => {
   let deletionKeys: string[] = [];
   let failedExportId: string;
   let leasedProcessingExportId: string;
+  let organizationExportId: string;
+  let subjectOrganizationId: string;
   let cleanupDueBaseline = 0;
   let recoveryAuditEvents: DataExportRecoveryAuditEvent[] = [];
 
@@ -70,6 +73,12 @@ describe('adminUserDataExportsRouter', () => {
     `);
     cleanupDueBaseline = Number(dueCleanup.rows[0]?.count ?? 0);
     const now = Date.now();
+    const subjectOrganization = await createTestOrganization(
+      `Data Export Subject ${crypto.randomUUID()}`,
+      owner.id,
+      0
+    );
+    subjectOrganizationId = subjectOrganization.id;
     const rows = await db
       .insert(user_data_exports)
       .values([
@@ -113,6 +122,8 @@ describe('adminUserDataExportsRouter', () => {
         },
         {
           kilo_user_id: owner.id,
+          subject_type: 'organization',
+          organization_id: subjectOrganization.id,
           status: 'processing',
           snapshot_at: new Date(now - 86_400_000).toISOString(),
           dispatch_generation: 0,
@@ -139,6 +150,7 @@ describe('adminUserDataExportsRouter', () => {
       throw new Error('Expected export fixtures');
     leasedProcessingExportId = processing.id;
     failedExportId = failed.id;
+    organizationExportId = processingWithoutLease.id;
     await db.insert(user_data_export_outbox).values([
       {
         export_id: processing.id,
@@ -174,6 +186,7 @@ describe('adminUserDataExportsRouter', () => {
         .delete(user_data_export_object_deletions)
         .where(inArray(user_data_export_object_deletions.object_key, deletionKeys));
     deletionKeys = [];
+    await db.delete(organizations).where(eq(organizations.id, subjectOrganizationId));
     setDataExportRecoveryAuditSinkForTest(null);
     jest.clearAllMocks();
   });
@@ -250,6 +263,20 @@ describe('adminUserDataExportsRouter', () => {
     expect(searched.pagination.total).toBe(3);
     expect(searched.rows.every(row => row.user.id === owner.id)).toBe(true);
     expect(searched.rows.every(row => row.requestedAt.endsWith('Z'))).toBe(true);
+    expect(searched.rows).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ subject: { type: 'user', organization: null } }),
+        expect.objectContaining({
+          subject: {
+            type: 'organization',
+            organization: {
+              id: subjectOrganizationId,
+              name: expect.stringContaining('Data Export Subject'),
+            },
+          },
+        }),
+      ])
+    );
     expect(searched.rows.find(row => row.status === 'ready')?.health).toMatchObject({
       severity: 'degraded',
       email: 'retry_due',
@@ -314,6 +341,22 @@ describe('adminUserDataExportsRouter', () => {
     );
     expect(JSON.stringify(failedDetail)).not.toContain('multipart-failed');
     expect(JSON.stringify(processingDetail)).not.toContain('safe-etag');
+  });
+
+  it('returns the organization subject separately from the requester in detail', async () => {
+    const detail = await (
+      await createCallerForUser(admin.id)
+    ).admin.userDataExports.detail({ exportId: organizationExportId });
+
+    expect(detail.user).toMatchObject({ id: owner.id, email: owner.google_user_email });
+    expect(detail.subject).toEqual({
+      type: 'organization',
+      organization: {
+        id: subjectOrganizationId,
+        name: expect.stringContaining('Data Export Subject'),
+      },
+    });
+    expect(detail.actions.cancelAndRetry).toEqual({ eligible: true, disabledReason: null });
   });
 
   it('returns not found for an unknown export', async () => {

--- a/apps/web/src/routers/admin/user-data-exports-router.ts
+++ b/apps/web/src/routers/admin/user-data-exports-router.ts
@@ -145,13 +145,24 @@ async function lockRecoveryTarget(
   tx: DbTransaction,
   input: z.infer<typeof RecoveryInputSchema>
 ): Promise<RecoveryTarget> {
-  const initial = await tx.execute<{ kilo_user_id: string }>(sql`
-    SELECT kilo_user_id FROM user_data_exports WHERE id = ${input.exportId} LIMIT 1
+  const initial = await tx.execute<{
+    kilo_user_id: string;
+    organization_id: string | null;
+  }>(sql`
+    SELECT kilo_user_id, organization_id
+    FROM user_data_exports
+    WHERE id = ${input.exportId}
+    LIMIT 1
   `);
-  const ownerId = initial.rows[0]?.kilo_user_id;
-  if (!ownerId) throw new TRPCError({ code: 'NOT_FOUND', message: 'Data export not found' });
+  const initialRow = initial.rows[0];
+  if (!initialRow) throw new TRPCError({ code: 'NOT_FOUND', message: 'Data export not found' });
 
-  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${ownerId}, 0))`);
+  const ownerId = initialRow.kilo_user_id;
+  const subjectLockKey = initialRow.organization_id ?? ownerId;
+  await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${subjectLockKey}, 0))`);
+  if (subjectLockKey !== ownerId) {
+    await tx.execute(sql`SELECT pg_advisory_xact_lock(hashtextextended(${ownerId}, 0))`);
+  }
   const owner = await tx.execute<{ id: string; blocked_reason: string | null }>(sql`
     SELECT id, blocked_reason FROM kilocode_users WHERE id = ${ownerId} FOR UPDATE
   `);
@@ -697,7 +708,15 @@ export const adminUserDataExportsRouter = createTRPCRouter({
       const target = await lockRecoveryTarget(tx, input);
       const blocker = await tx.execute<{ id: string }>(sql`
         SELECT id FROM user_data_exports
-        WHERE kilo_user_id = ${target.kilo_user_id} AND id <> ${target.id}
+        WHERE id <> ${target.id}
+          AND subject_type = ${target.subject_type}
+          AND (
+            (subject_type = 'user' AND kilo_user_id = ${target.kilo_user_id})
+            OR (
+              subject_type = 'organization'
+              AND organization_id = ${target.organization_id}::uuid
+            )
+          )
           AND (
             status IN ('queued', 'processing', 'finalizing')
             OR (status = 'ready' AND expires_at > now())
@@ -705,7 +724,9 @@ export const adminUserDataExportsRouter = createTRPCRouter({
         LIMIT 1
       `);
       if (blocker.rows[0]) {
-        conflict('This user already has another active or downloadable export');
+        conflict(
+          `This ${target.subject_type === 'organization' ? 'organization' : 'user'} already has another active or downloadable export`
+        );
       }
       const cleanupQueued = await scheduleCleanup(tx, target, 'admin_replace');
       const deleted = await tx.execute<{ id: string }>(sql`

--- a/apps/web/src/routers/admin/user-data-exports-router.ts
+++ b/apps/web/src/routers/admin/user-data-exports-router.ts
@@ -45,6 +45,9 @@ type ExportRow = {
   kilo_user_id: string;
   user_email: string;
   user_name: string | null;
+  subject_type: 'user' | 'organization';
+  organization_id: string | null;
+  organization_name: string | null;
   status: ExportStatus;
   schema_version: number;
   snapshot_at: string;
@@ -249,10 +252,20 @@ function healthInput(row: ExportRow): ExportHealthInput {
   };
 }
 
+function serializeSubject(row: ExportRow) {
+  if (row.subject_type === 'user') return { type: 'user' as const, organization: null };
+  if (!row.organization_id) throw new Error('Organization export is missing its subject ID');
+  return {
+    type: 'organization' as const,
+    organization: { id: row.organization_id, name: row.organization_name },
+  };
+}
+
 function serialize(row: ExportRow, asOf: string) {
   return {
     id: row.id,
     user: { id: row.kilo_user_id, email: row.user_email, name: row.user_name },
+    subject: serializeSubject(row),
     status: row.status,
     schemaVersion: row.schema_version,
     currentSource: row.current_source,
@@ -326,7 +339,8 @@ function listConditions(input: z.infer<typeof ListInputSchema>) {
 const baseSelect = sql`
   SELECT
     e.id, e.kilo_user_id, u.google_user_email AS user_email,
-    u.google_user_name AS user_name, e.status, e.schema_version, e.snapshot_at,
+    u.google_user_name AS user_name, e.subject_type, e.organization_id,
+    org.name AS organization_name, e.status, e.schema_version, e.snapshot_at,
     e.current_source, e.source_cursor IS NOT NULL AS has_source_cursor,
     EXISTS (
       SELECT 1 FROM user_data_export_parts persisted_parts WHERE persisted_parts.export_id = e.id
@@ -341,7 +355,15 @@ const baseSelect = sql`
     e.r2_object_key IS NOT NULL AS has_r2_object,
     EXISTS (
       SELECT 1 FROM user_data_exports other
-      WHERE other.kilo_user_id = e.kilo_user_id AND other.id <> e.id
+      WHERE other.id <> e.id
+        AND other.subject_type = e.subject_type
+        AND (
+          (e.subject_type = 'user' AND other.kilo_user_id = e.kilo_user_id)
+          OR (
+            e.subject_type = 'organization'
+            AND other.organization_id = e.organization_id
+          )
+        )
         AND (
           other.status IN ('queued', 'processing', 'finalizing')
           OR (other.status = 'ready' AND other.expires_at > now())
@@ -351,6 +373,7 @@ const baseSelect = sql`
     o.attempt_count AS current_outbox_attempt_count, o.sent_at AS current_outbox_sent_at
   FROM user_data_exports e
   INNER JOIN kilocode_users u ON u.id = e.kilo_user_id
+  LEFT JOIN organizations org ON org.id = e.organization_id
   LEFT JOIN user_data_export_outbox o
     ON o.export_id = e.id
     AND o.generation = e.dispatch_generation
@@ -537,7 +560,7 @@ export const adminUserDataExportsRouter = createTRPCRouter({
       cancelAndRetry: {
         eligible: !row.has_other_usable_export,
         disabledReason: row.has_other_usable_export
-          ? 'This user already has another active or downloadable export.'
+          ? `This ${row.subject_type === 'organization' ? 'organization' : 'user'} already has another active or downloadable export.`
           : null,
       },
     };


### PR DESCRIPTION
## Summary

- Distinguish personal and organization exports in the data export health list with a dedicated Subject column, while relabeling the export initiator as the Requester.
- Expand export detail responses and UI to show the subject type, organization name and ID when applicable, and requester identity separately.
- Extend the admin router contract with a discriminated subject object and organization metadata.
- Make cancel-and-retry eligibility subject-aware, so personal exports are compared by user and organization exports by organization.

## Verification

- Manual browser verification was not performed because no local dev env for this exists.

## Visual Changes

| Before | After |
|---|---|
| Data export list does not identify whether an export contains personal or organization data. | Add screenshot of the list with Personal and Organization subject labels. |
| Export detail groups all identity information under “Export and user.” | Add screenshot of the detail view with separate subject and requester fields. |

## Reviewer Notes

- Review the subject-aware retry eligibility query carefully: organization exports now conflict with other usable exports for the same organization, not with the requester’s personal exports.
- Organization names are joined for display, while the persisted subject type and organization ID remain authoritative.