### PR TITLE
fix(mobile): count grep/glob badge from sheet rows

### DIFF
--- a/apps/mobile/src/components/agents/tool-card-display.test.ts
+++ b/apps/mobile/src/components/agents/tool-card-display.test.ts
@@ -320,6 +320,40 @@ describe('getToolDisplay badge rules', () => {
     ).toBeUndefined();
     expect(getDisplay(makeToolPart('grep', running({ pattern: 'foo' }))).badge).toBeUndefined();
   });
+
+  it('counts grep sheet rows, not the Found caption', () => {
+    expect(
+      getDisplay(
+        makeToolPart('grep', completed({ pattern: 'x' }, 'Found 1 match\nsrc/a.ts:\n  Line 1: x'))
+      ).badge
+    ).toBe('2 matches');
+  });
+
+  it('omits the grep badge when only a Found caption exists', () => {
+    expect(
+      getDisplay(makeToolPart('grep', completed({ pattern: 'x' }, 'Found 1 match'))).badge
+    ).toBeUndefined();
+  });
+
+  it('counts glob sheet rows, not the Found caption', () => {
+    expect(
+      getDisplay(
+        makeToolPart(
+          'glob',
+          completed(
+            { pattern: 'src/**/*.ts' },
+            'Found 2 file(s) matching "src/**/*.ts":\nsrc/a.ts\nsrc/b.ts'
+          )
+        )
+      ).badge
+    ).toBe('2 files');
+  });
+
+  it('omits the glob badge when only a Found caption exists', () => {
+    expect(
+      getDisplay(makeToolPart('glob', completed({ pattern: 'src/**/*.ts' }, 'Found 1 file'))).badge
+    ).toBeUndefined();
+  });
 });
 
 describe('toolPartHasDetails', () => {

--- a/apps/mobile/src/components/agents/tool-card-display.ts
+++ b/apps/mobile/src/components/agents/tool-card-display.ts
@@ -8,6 +8,7 @@ import {
   truncateText,
 } from './tool-card-utils';
 import { listPatchFilePaths } from './tool-patch-model';
+import { buildResultRowsModel } from './tool-list-model';
 
 export type ToolDisplay = {
   title: string;
@@ -15,11 +16,8 @@ export type ToolDisplay = {
   badge?: string;
 };
 
-function countOutputLines(output: string): number {
-  if (output.length === 0) {
-    return 0;
-  }
-  return output.split('\n').filter(line => line.trim().length > 0).length;
+function countResultRows(output: string, kind: 'grep' | 'glob'): number {
+  return buildResultRowsModel(output, kind).rows.length;
 }
 
 /**
@@ -65,8 +63,8 @@ export function getToolDisplay(part: ToolPart): ToolDisplay {
     case 'glob': {
       const pattern = typeof input.pattern === 'string' ? input.pattern : '';
       const output = status === 'completed' ? part.state.output : undefined;
-      const matchCount = output ? countOutputLines(output) : undefined;
-      const badge = matchCount !== undefined ? `${matchCount} files` : undefined;
+      const matchCount = output ? countResultRows(output, 'glob') : undefined;
+      const badge = matchCount !== undefined && matchCount > 0 ? `${matchCount} files` : undefined;
       return { title: 'glob', subtitle: pattern || 'glob', badge };
     }
     case 'grep': {
@@ -77,8 +75,9 @@ export function getToolDisplay(part: ToolPart): ToolDisplay {
         subtitle += ` (${include})`;
       }
       const output = status === 'completed' ? part.state.output : undefined;
-      const matchCount = output ? countOutputLines(output) : undefined;
-      const badge = matchCount !== undefined ? `${matchCount} matches` : undefined;
+      const matchCount = output ? countResultRows(output, 'grep') : undefined;
+      const badge =
+        matchCount !== undefined && matchCount > 0 ? `${matchCount} matches` : undefined;
       return { title: 'grep', subtitle, badge };
     }
     case 'list': {


### PR DESCRIPTION
## Summary

- User: the grep and glob tool cards now show a badge count that matches the files shown when you tap the card. A card with only a `Found N` summary and no files no longer shows a misleading `1 matches` badge.
- Product: the badge count on grep/glob cards now reflects the actual visible result rows, removing a misleading off-by-one badge.
- Maintainer: `getToolDisplay` now derives the badge from `buildResultRowsModel(output, kind).rows.length` instead of a raw non-empty-line count, so the lifted `Found N` caption is not counted. The badge is omitted when the model has zero rows.

## Verification

- Automated only: `pnpm --filter kilo-app exec vitest run src/components/agents/tool-card-display.test.ts` (36 tests pass), `pnpm --filter kilo-app typecheck`, `pnpm --filter kilo-app lint`.
- No manual device test: this is a pure string projection, unit-tested against the same model the sheet uses.

## Visual Changes

N/A

## Reviewer Notes

- E2E: bot-e2e — skipped; pure string projection unit-tested against the same model the sheet uses. No runtime behavior to verify on a device.
- Human steps: none.
