### PR TITLE
fix(mobile): match dashed thought row box to solid tool row box

### DIFF
--- a/apps/mobile/src/components/agents/fixed-part-row.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/fixed-part-row.mounted.test.tsx
@@ -185,4 +185,28 @@ describe('FixedPartRow mounted', () => {
     expect(eyebrow.props.numberOfLines).toBe(1);
     expect(eyebrow.props.className).toContain('shrink');
   });
+
+  it('matches the dashed outer box to the solid outer box', async () => {
+    const renderer = await renderRow({
+      label: 'Thought',
+      labelKind: 'eyebrow',
+      variant: 'dashed',
+      accessibilityLabel: 'Thought',
+    });
+
+    const outerView = findHost(renderer.root, 'View').find(
+      node =>
+        typeof node.props.className === 'string' && node.props.className.includes('border-dashed')
+    );
+    expect(outerView).toBeDefined();
+    if (!outerView) {
+      throw new Error('dashed outer view not found');
+    }
+    const className = outerView.props.className as string;
+    expect(className).toContain('overflow-hidden');
+    expect(className).toContain('rounded-lg');
+    expect(className).toContain('border-dashed');
+    expect(className).not.toContain('rounded-xl');
+    expect(className).not.toContain('border-[1.5px]');
+  });
 });

--- a/apps/mobile/src/components/agents/fixed-part-row.tsx
+++ b/apps/mobile/src/components/agents/fixed-part-row.tsx
@@ -44,7 +44,7 @@ export function FixedPartRow({
     <View
       className={
         variant === 'dashed'
-          ? 'rounded-xl border-[1.5px] border-dashed border-border'
+          ? 'overflow-hidden rounded-lg border border-dashed border-border'
           : 'overflow-hidden rounded-lg border border-border'
       }
     >


### PR DESCRIPTION
fix(mobile): match dashed thought row box to solid tool row box

## What changed

A collapsed thought pill in the mobile cloud-agent transcript now sits the same visible distance from neighboring tool pills as two tool pills sit from each other.

## User note

The thought pill between two tool rows no longer looks farther away than the tool rows look from each other. The dashed outline and the `THOUGHT` / `THINKING` label are unchanged.

## Product note

The transcript row rhythm is now uniform: the dashed thought card reuses the solid tool card's radius, border width, and overflow clip, so the visible gutter matches the `gap-2` spacing between tool rows.

## Maintainer note

`FixedPartRow` drew two card shapes: the solid tool card used `overflow-hidden rounded-lg border border-border`, while the dashed thought card used `rounded-xl border-[1.5px] border-dashed border-border`. The thicker stroke and larger radius receded the visible ink from the layout edge on iOS. The dashed branch now reuses the solid outer box and keeps only `border-dashed`. A mounted test locks the dashed outer class.

## Human steps

No human step is needed.

## Visual Changes

This is a subtle 1px spacing adjustment (the dashed thought row now uses the solid row's `rounded-lg` radius and 1px border instead of `rounded-xl` and a 1.5px stroke). No screenshot is attached; the change is locked by a mounted class test and the iOS regression check passed.
