### PR TITLE
fix(composer): recover after error and allow attachment-only send

### DIFF
--- a/apps/mobile/src/components/agents/chat-composer-attachment-send.test.ts
+++ b/apps/mobile/src/components/agents/chat-composer-attachment-send.test.ts
@@ -7,12 +7,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { type AgentMode } from '@/components/agents/mode-selector';
 import { type ChatComposer } from './chat-composer';
 
-// The composer's uncontrolled input is covered by Appium E2E; this suite pins
-// the draft-restore contract that a native E2E cannot easily prove: a restored
-// draft must be readable by an immediate send (before any keystroke). The
-// component is invoked as a plain function with mocked hooks so the restore
-// effect runs synchronously, and the submit path is driven through the
-// onSubmit handler found on the ChatComposerInputRow element in the tree.
+// The attachment-only send contract: a ready (`uploaded`) attachment with an
+// empty draft must enable send and deliver `prompt: ''` plus the wire payload.
+// Unlike chat-composer.test.ts, this suite uses the real
+// `resolveChatComposerControlState` so `canSend` follows text and ready
+// attachments, and mocks `useAgentAttachmentUpload` with a controllable return.
 
 const onSendMock = vi.fn(async () => undefined);
 
@@ -22,6 +21,13 @@ const onSendMock = vi.fn(async () => undefined);
 // re-render (`rerender`) with the refs — the composer's live text and its
 // applied-draft flag — intact, and start a fresh instance with `mount`.
 const refSlots = vi.hoisted(() => ({ slots: [] as { current: unknown }[], cursor: 0 }));
+
+// Controllable upload state. The mock factory reads these at call time, so a
+// test mutates them before mounting to drive the ready vs empty cases.
+const uploadState = vi.hoisted(() => ({
+  attachments: [] as { status?: string; remoteFilename?: string }[],
+  toWirePayload: (() => undefined) as () => unknown,
+}));
 
 vi.mock('react', async () => {
   const actual = await vi.importActual<typeof React>('react');
@@ -132,24 +138,8 @@ vi.mock('@/components/agents/use-text-height', () => ({
   }),
 }));
 
-vi.mock('@/components/agents/chat-composer-input-state', () => ({
-  // The real gate (hasText → canSend) is covered by chat-composer-input-state
-  // tests; this suite isolates the restore → send path. `canSend` follows the
-  // live draft (textRef, the first useRef slot) so an empty draft stays
-  // non-sendable now that handleSend no longer guards on `!trimmed`.
-  resolveChatComposerControlState: () => {
-    const draft = (refSlots.slots[0]?.current as string | undefined) ?? '';
-    return {
-      canSend: draft.trim().length > 0,
-      inputAccessibilityDisabled: false,
-      inputEditable: true,
-      paperclipDisabled: false,
-      showToolbar: true,
-      toolbarDisabled: false,
-      voiceDisabled: false,
-    };
-  },
-}));
+// NOTE: `resolveChatComposerControlState` is intentionally NOT mocked here so
+// `canSend` follows text and ready attachments through the real helper.
 
 vi.mock('@/components/ui/blur-bar', () => ({
   BlurBar: () => null,
@@ -174,14 +164,14 @@ vi.mock('@/lib/hooks/use-current-user-id', () => ({
 
 vi.mock('@/lib/agent-attachments/use-agent-attachment-upload', () => ({
   useAgentAttachmentUpload: () => ({
-    attachments: [],
+    attachments: uploadState.attachments,
     addCandidates: vi.fn(async () => undefined),
     removeAttachment: vi.fn(() => undefined),
     retryAttachment: vi.fn(() => undefined),
     reset: vi.fn(() => undefined),
     isUploading: false,
     hasFailedAttachments: false,
-    toWirePayload: () => undefined,
+    toWirePayload: uploadState.toWirePayload,
     toSubmissionPayload: () => undefined,
   }),
 }));
@@ -279,15 +269,6 @@ function requireInputRowOnSubmit(render: React.ReactElement): () => void {
   return onSubmit;
 }
 
-function requireInputRowOnChangeText(render: React.ReactElement): (text: string) => void {
-  const rowProps = findInputRowProps(render);
-  const onChangeText = rowProps?.onChangeText as ((text: string) => void) | undefined;
-  if (onChangeText === undefined) {
-    throw new Error('ChatComposerInputRow element did not carry an onChangeText handler');
-  }
-  return onChangeText;
-}
-
 async function mount(props: ComposerProps): Promise<React.ReactElement> {
   refSlots.slots.length = 0;
   return rerender(props);
@@ -309,76 +290,30 @@ beforeEach(() => {
   vi.clearAllMocks();
   refSlots.slots.length = 0;
   refSlots.cursor = 0;
+  uploadState.attachments = [];
+  uploadState.toWirePayload = () => undefined;
 });
 
-// The restore contract has one axis: whether the host resolved a draft. Both
-// cases run the identical mount → submit sequence, so one table drives them.
-const RESTORE_CASES = [
-  {
-    name: 'sends the restored draft immediately on submit, before any keystroke',
-    initialDraft: 'Restored draft text',
-    sent: 'Restored draft text',
-  },
-  {
-    name: 'does not send when there is no restored draft',
-    initialDraft: undefined,
-    sent: null,
-  },
-] as const;
+describe('ChatComposer attachment-only send', () => {
+  it('sends an empty draft with a ready attachment, passing prompt and the wire payload', async () => {
+    uploadState.attachments = [{ status: 'uploaded', remoteFilename: 'file.png' }];
+    uploadState.toWirePayload = () => ({ path: 'path-1', files: ['file.png'] });
 
-describe('ChatComposer draft restore', () => {
-  it.each(RESTORE_CASES)('$name', async ({ initialDraft, sent }) => {
-    const render = await mount(
-      makeProps({
-        draftKey: 'agent-composer:sess-1',
-        initialDraft,
-      })
-    );
+    const render = await mount(makeProps({ draftKey: 'agent-composer:sess-1' }));
 
-    // The restore effect runs synchronously under the mocked hooks; submit
-    // must read the restored text from the live ref, not the mount-time ''.
     requireInputRowOnSubmit(render)();
     await settle();
 
-    if (sent === null) {
-      expect(onSendMock).not.toHaveBeenCalled();
-      return;
-    }
     expect(onSendMock).toHaveBeenCalledTimes(1);
-    expect(onSendMock).toHaveBeenCalledWith(sent, undefined, undefined);
+    expect(onSendMock).toHaveBeenCalledWith('', { path: 'path-1', files: ['file.png'] }, undefined);
   });
 
-  // The host mounts the composer before identity (`user.getMe`) and the draft
-  // load settle, so `initialDraft` is undefined on the first render and arrives
-  // later. Both cases below start from that first render.
-  it('is usable before the draft settles and applies a draft that arrives after mount', async () => {
-    await mount(makeProps({ draftKey: 'agent-composer:sess-1', initialDraft: undefined }));
+  it('does not send an empty draft with no attachments', async () => {
+    const render = await mount(makeProps({ draftKey: 'agent-composer:sess-1' }));
 
-    const settled = await rerender(
-      makeProps({ draftKey: 'agent-composer:sess-1', initialDraft: 'Restored draft text' })
-    );
-    requireInputRowOnSubmit(settled)();
+    requireInputRowOnSubmit(render)();
     await settle();
 
-    expect(onSendMock).toHaveBeenCalledWith('Restored draft text', undefined, undefined);
-  });
-
-  it('keeps text typed before the draft settles instead of restoring over it', async () => {
-    const pending = await mount(
-      makeProps({ draftKey: 'agent-composer:sess-1', initialDraft: undefined })
-    );
-    requireInputRowOnChangeText(pending)('typed while identity was loading');
-
-    const settled = await rerender(
-      makeProps({ draftKey: 'agent-composer:sess-1', initialDraft: 'Restored draft text' })
-    );
-    requireInputRowOnSubmit(settled)();
-    await settle();
-
-    expect(onSendMock).toHaveBeenCalledWith(
-      'typed while identity was loading',
-      undefined,
-      undefined
-    );
+    expect(onSendMock).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/components/agents/chat-composer-input-row.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/chat-composer-input-row.mounted.test.tsx
@@ -1,0 +1,105 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as composer-paste-button.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChatComposerInputRow } from './chat-composer-input-row';
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  Pressable: 'Pressable',
+  TextInput: 'TextInput',
+  View: 'View',
+}));
+vi.mock('@/components/ui/icons', () => ({
+  ArrowUp: 'ArrowUp',
+  Paperclip: 'Paperclip',
+  Square: 'Square',
+}));
+vi.mock('@/components/voice-input-control', () => ({
+  VoiceInputButton: 'VoiceInputButton',
+}));
+vi.mock('@/components/agents/chat-composer-input-height', () => ({
+  shouldEnableComposerInputScroll: () => false,
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ mutedForeground: '#6b7280' }),
+}));
+
+type RenderProps = {
+  inputEditable: boolean;
+};
+
+function makeProps(overrides: Partial<RenderProps> = {}) {
+  return {
+    attachmentsEnabled: false,
+    canSend: false,
+    disabled: false,
+    inputAccessibilityDisabled: false,
+    inputEditable: false,
+    inputRef: { current: null },
+    isSending: false,
+    isStreaming: false,
+    maxInputHeight: 120,
+    measureHeight: 40,
+    onAddAttachment: () => undefined,
+    onChangeText: () => undefined,
+    onInputBlur: () => undefined,
+    onInputFocus: () => undefined,
+    onInputLayout: () => undefined,
+    onSelectionChange: () => undefined,
+    onStop: () => undefined,
+    onSubmit: () => undefined,
+    onToggleVoice: () => undefined,
+    paperclipDisabled: false,
+    placeholder: 'Message the agent',
+    textInputStyle: {},
+    voiceDisabled: false,
+    voiceInputAvailable: false,
+    voiceInputStatus: 'idle' as const,
+    ...overrides,
+  };
+}
+
+function findTextInput(root: TestRenderer.ReactTestInstance): TestRenderer.ReactTestInstance {
+  return root.find(node => typeof node.type === 'string' && (node.type as string) === 'TextInput');
+}
+
+async function renderRow(props: RenderProps): Promise<TestRenderer.ReactTestRenderer> {
+  const holder: { current?: TestRenderer.ReactTestRenderer } = {};
+  await act(async () => {
+    await Promise.resolve();
+    holder.current = TestRenderer.create(createElement(ChatComposerInputRow, makeProps(props)));
+  });
+  const renderer = holder.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+describe('ChatComposerInputRow mounted — iOS writing-tools lock', () => {
+  it('blocks writing tools and selection when the input is not editable', async () => {
+    const renderer = await renderRow({ inputEditable: false });
+
+    const input = findTextInput(renderer.root);
+    expect(input.props.editable).toBe(false);
+    expect(input.props.contextMenuHidden).toBe(true);
+    expect(input.props.pointerEvents).toBe('none');
+
+    renderer.unmount();
+  });
+
+  it('leaves the input editable and gesture-enabled when it is editable', async () => {
+    const renderer = await renderRow({ inputEditable: true });
+
+    const input = findTextInput(renderer.root);
+    expect(input.props.editable).toBe(true);
+    expect(
+      input.props.contextMenuHidden === undefined || input.props.contextMenuHidden === false
+    ).toBe(true);
+    expect(input.props.pointerEvents).not.toBe('none');
+
+    renderer.unmount();
+  });
+});

--- a/apps/mobile/src/components/agents/chat-composer-input-row.tsx
+++ b/apps/mobile/src/components/agents/chat-composer-input-row.tsx
@@ -123,6 +123,8 @@ export function ChatComposerInputRow({
           style={textInputStyle}
           scrollEnabled={inputScrollable}
           editable={inputEditable}
+          contextMenuHidden={!inputEditable}
+          pointerEvents={inputEditable ? 'auto' : 'none'}
           accessibilityState={{ disabled: inputAccessibilityDisabled }}
           returnKeyType="default"
           submitBehavior="newline"

--- a/apps/mobile/src/components/agents/chat-composer-input-state.test.ts
+++ b/apps/mobile/src/components/agents/chat-composer-input-state.test.ts
@@ -6,6 +6,7 @@ describe('resolveChatComposerControlState', () => {
   it('disables nothing and allows sending when idle with text and no voice session', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 0,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: false,
       hasText: true,
@@ -32,6 +33,7 @@ describe('resolveChatComposerControlState', () => {
     ]) {
       const state = resolveChatComposerControlState({
         attachmentsCount: 0,
+        readyAttachmentsCount: 0,
         attachmentMax: 5,
         disabled: override.disabled,
         hasText: true,
@@ -51,6 +53,7 @@ describe('resolveChatComposerControlState', () => {
   it('keeps the input editable and toolbar enabled while streaming when text is present', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 0,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: false,
       hasText: true,
@@ -69,6 +72,7 @@ describe('resolveChatComposerControlState', () => {
   it('keeps the input editable while streaming with an empty draft (canSend stays false)', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 0,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: false,
       hasText: false,
@@ -86,6 +90,7 @@ describe('resolveChatComposerControlState', () => {
   it('still blocks send mid-stream when the parent disabled flag is on (e.g. read-only or capability gate)', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 0,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: true,
       hasText: true,
@@ -99,9 +104,10 @@ describe('resolveChatComposerControlState', () => {
     expect(state.toolbarDisabled).toBe(true);
   });
 
-  it('does not allow send when the draft is empty even with attachments and no overrides', () => {
+  it('does not allow send when the draft is empty and no attachment is ready', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 2,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: false,
       hasText: false,
@@ -115,9 +121,42 @@ describe('resolveChatComposerControlState', () => {
     expect(state.showToolbar).toBe(true);
   });
 
+  it('allows send when the draft is empty and at least one attachment is ready', () => {
+    const state = resolveChatComposerControlState({
+      attachmentsCount: 1,
+      readyAttachmentsCount: 1,
+      attachmentMax: 5,
+      disabled: false,
+      hasText: false,
+      isFocused: false,
+      isSending: false,
+      voiceInputActive: false,
+    });
+
+    expect(state.canSend).toBe(true);
+    expect(state.toolbarDisabled).toBe(false);
+    expect(state.showToolbar).toBe(true);
+  });
+
+  it('allows send with text and no attachments', () => {
+    const state = resolveChatComposerControlState({
+      attachmentsCount: 0,
+      readyAttachmentsCount: 0,
+      attachmentMax: 5,
+      disabled: false,
+      hasText: true,
+      isFocused: false,
+      isSending: false,
+      voiceInputActive: false,
+    });
+
+    expect(state.canSend).toBe(true);
+  });
+
   it('keeps the toolbar visible when focused, has text, has attachments, or voice is active', () => {
     const base = {
       attachmentsCount: 0,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: false,
       hasText: false,
@@ -140,6 +179,7 @@ describe('resolveChatComposerControlState', () => {
   it('disables the paperclip when at or above the attachment cap', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 5,
+      readyAttachmentsCount: 5,
       attachmentMax: 5,
       disabled: false,
       hasText: true,
@@ -154,6 +194,7 @@ describe('resolveChatComposerControlState', () => {
   it('disables the paperclip while the composer is in a toolbar-disabled state', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 0,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: false,
       hasText: true,
@@ -168,6 +209,7 @@ describe('resolveChatComposerControlState', () => {
   it('disables the paperclip and input while this owner is voice active', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 0,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: false,
       hasText: true,
@@ -184,6 +226,7 @@ describe('resolveChatComposerControlState', () => {
   it('leaves voice enabled (only toolbar gates it) when the composer is otherwise ready', () => {
     const state = resolveChatComposerControlState({
       attachmentsCount: 0,
+      readyAttachmentsCount: 0,
       attachmentMax: 5,
       disabled: false,
       hasText: false,

--- a/apps/mobile/src/components/agents/chat-composer-input-state.ts
+++ b/apps/mobile/src/components/agents/chat-composer-input-state.ts
@@ -1,5 +1,7 @@
 type ChatComposerControlInput = {
   attachmentsCount: number;
+  /** Number of attachments with `status === 'uploaded'`. */
+  readyAttachmentsCount: number;
   attachmentMax: number;
   disabled: boolean;
   hasText: boolean;
@@ -9,7 +11,7 @@ type ChatComposerControlInput = {
 };
 
 type ChatComposerControlState = {
-  /** Backend requires a non-empty prompt even with attachments. */
+  /** Backend accepts an empty prompt when at least one attachment is ready. */
   canSend: boolean;
   /** Mirrors `editable` on the text input. */
   inputEditable: boolean;
@@ -38,6 +40,7 @@ export function resolveChatComposerControlState(
 ): ChatComposerControlState {
   const {
     attachmentsCount,
+    readyAttachmentsCount,
     attachmentMax,
     disabled,
     hasText,
@@ -57,7 +60,7 @@ export function resolveChatComposerControlState(
   const inputEditable = !toolbarDisabled && !voiceInputActive;
   const showToolbar = isFocused || hasText || attachmentsCount > 0 || voiceInputActive;
   return {
-    canSend: hasText && !disabled && !isSending,
+    canSend: (hasText || readyAttachmentsCount > 0) && !disabled && !isSending,
     inputAccessibilityDisabled: !inputEditable,
     inputEditable,
     paperclipDisabled,

--- a/apps/mobile/src/components/agents/chat-composer.tsx
+++ b/apps/mobile/src/components/agents/chat-composer.tsx
@@ -393,6 +393,8 @@ export function ChatComposer({
 
   const control = resolveChatComposerControlState({
     attachmentsCount: upload.attachments.length,
+    readyAttachmentsCount: upload.attachments.filter(attachment => attachment.status === 'uploaded')
+      .length,
     attachmentMax: AGENT_ATTACHMENT_MAX_FILES,
     disabled,
     hasText,
@@ -589,7 +591,7 @@ export function ChatComposer({
 
   async function handleSend() {
     const trimmed = textRef.current.trim();
-    if (!trimmed || !control.canSend) {
+    if (!control.canSend) {
       return;
     }
     if (upload.isUploading) {

--- a/apps/mobile/src/components/agents/session-composer-disabled.test.ts
+++ b/apps/mobile/src/components/agents/session-composer-disabled.test.ts
@@ -1,0 +1,61 @@
+// eslint-disable-next-line import/no-nodejs-modules -- vitest-only guard, runs in node, never bundled into the app
+import { readFileSync } from 'node:fs';
+// eslint-disable-next-line import/no-nodejs-modules -- vitest-only guard, runs in node, never bundled into the app
+import { fileURLToPath } from 'node:url';
+
+import { describe, expect, it } from 'vitest';
+
+import { resolveSessionComposerDisabled } from './session-composer-disabled';
+
+const idleInput = {
+  isReadOnly: false,
+  canSend: true,
+  shouldShowLoading: false,
+  hasBlockingInteraction: false,
+  requiresModel: false,
+  hasModel: true,
+};
+
+describe('resolveSessionComposerDisabled', () => {
+  it('returns false for a writable idle session', () => {
+    expect(resolveSessionComposerDisabled(idleInput)).toBe(false);
+  });
+
+  it('returns true when read-only', () => {
+    expect(resolveSessionComposerDisabled({ ...idleInput, isReadOnly: true })).toBe(true);
+  });
+
+  it('returns true when cannot send', () => {
+    expect(resolveSessionComposerDisabled({ ...idleInput, canSend: false })).toBe(true);
+  });
+
+  it('returns true while loading', () => {
+    expect(resolveSessionComposerDisabled({ ...idleInput, shouldShowLoading: true })).toBe(true);
+  });
+
+  it('returns true when a blocking interaction is active', () => {
+    expect(resolveSessionComposerDisabled({ ...idleInput, hasBlockingInteraction: true })).toBe(
+      true
+    );
+  });
+
+  it('returns true when a model is required but missing', () => {
+    expect(
+      resolveSessionComposerDisabled({ ...idleInput, requiresModel: true, hasModel: false })
+    ).toBe(true);
+  });
+
+  it('returns false when a model is required and present', () => {
+    expect(
+      resolveSessionComposerDisabled({ ...idleInput, requiresModel: true, hasModel: true })
+    ).toBe(false);
+  });
+});
+
+describe('composer unlock source check', () => {
+  it('does not lock the composer on an error', () => {
+    const sourcePath = fileURLToPath(new URL('session-detail-content.tsx', import.meta.url));
+    const source = readFileSync(sourcePath, 'utf8');
+    expect(source).not.toMatch(/Boolean\(error\)/);
+  });
+});

--- a/apps/mobile/src/components/agents/session-composer-disabled.ts
+++ b/apps/mobile/src/components/agents/session-composer-disabled.ts
@@ -1,0 +1,16 @@
+export function resolveSessionComposerDisabled(input: {
+  isReadOnly: boolean;
+  canSend: boolean;
+  shouldShowLoading: boolean;
+  hasBlockingInteraction: boolean;
+  requiresModel: boolean;
+  hasModel: boolean;
+}): boolean {
+  return (
+    input.isReadOnly ||
+    !input.canSend ||
+    input.shouldShowLoading ||
+    input.hasBlockingInteraction ||
+    (input.requiresModel && !input.hasModel)
+  );
+}

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -30,6 +30,7 @@ import {
   type ContextSheetIdentity,
   getContextSheetMountState,
 } from '@/components/agents/context-usage-display';
+import { resolveSessionComposerDisabled } from '@/components/agents/session-composer-disabled';
 import { SessionConnectionIndicator } from '@/components/agents/session-connection-indicator';
 import { SessionContextMetrics } from '@/components/agents/session-context-metrics';
 import { SessionContextSheet } from '@/components/agents/session-context-sheet';
@@ -698,13 +699,14 @@ export function SessionDetailContent({
   // not share, the composer pops in and the layout jumps on every open.
   const isComposerMounted = !isReadOnly || messages.length === 0;
   const isComposerVisible = isComposerMounted && !hasBlockingInteraction;
-  const isComposerDisabled =
-    isReadOnly ||
-    !canSend ||
-    shouldShowLoading ||
-    Boolean(error) ||
-    hasBlockingInteraction ||
-    (requiresModel && !currentModel);
+  const isComposerDisabled = resolveSessionComposerDisabled({
+    isReadOnly,
+    canSend,
+    shouldShowLoading,
+    hasBlockingInteraction,
+    requiresModel,
+    hasModel: Boolean(currentModel),
+  });
   const composerPlaceholder =
     (cloudStatus && COMPOSER_PLACEHOLDERS[cloudStatus.type]) ?? 'Message...';
   const keyboardContainerKind = getSessionKeyboardContainerKind(Platform.OS);

--- a/apps/web/src/routers/cloud-agent-next-schemas.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.ts
@@ -328,22 +328,8 @@ export const sendMessageNextPayloadSchema = z.discriminatedUnion('type', [
  * `.min(1)` prompt via `sendMessageNextPayloadSchema`.
  */
 export const sendMessageNextSendPayloadSchema = z.discriminatedUnion('type', [
-  z.object({
-    type: z.literal('prompt'),
-    prompt: z.string(),
-    mode: agentModeSendMessageSchema,
-    model: z.string().min(1),
-    variant: z
-      .string()
-      .max(50)
-      .regex(/^[a-zA-Z]+$/)
-      .optional(),
-  }),
-  z.object({
-    type: z.literal('command'),
-    command: z.string().min(1),
-    arguments: z.string().default(''),
-  }),
+  sendMessageNextPayloadSchema.options[0].extend({ prompt: z.string() }),
+  sendMessageNextPayloadSchema.options[1],
 ]);
 
 // Schema for preparing a session

--- a/apps/web/src/routers/cloud-agent-next-schemas.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.ts
@@ -320,6 +320,32 @@ export const sendMessageNextPayloadSchema = z.discriminatedUnion('type', [
   }),
 ]);
 
+/**
+ * Send-only execution payload for follow-up messages. Mirrors
+ * `sendMessageNextPayloadSchema` but allows an empty prompt, because a
+ * follow-up send may carry attachments or images with no text. Used only by
+ * `baseSendMessageNextSchema.payload`; prepare `initialPayload` keeps the
+ * `.min(1)` prompt via `sendMessageNextPayloadSchema`.
+ */
+export const sendMessageNextSendPayloadSchema = z.discriminatedUnion('type', [
+  z.object({
+    type: z.literal('prompt'),
+    prompt: z.string(),
+    mode: agentModeSendMessageSchema,
+    model: z.string().min(1),
+    variant: z
+      .string()
+      .max(50)
+      .regex(/^[a-zA-Z]+$/)
+      .optional(),
+  }),
+  z.object({
+    type: z.literal('command'),
+    command: z.string().min(1),
+    arguments: z.string().default(''),
+  }),
+]);
+
 // Schema for preparing a session
 export const basePrepareSessionNextSchema = z
   .object({
@@ -422,7 +448,7 @@ export const baseInitiateFromPreparedSessionNextSchema = z
 export const baseSendMessageNextSchema = z
   .object({
     cloudAgentSessionId: z.string(),
-    payload: sendMessageNextPayloadSchema,
+    payload: sendMessageNextSendPayloadSchema,
     autoCommit: z.boolean().optional(),
     messageId: messageIdNextSchema.nullish(),
     attachments: cloudAgentAttachmentsSchema.optional(),
@@ -431,7 +457,20 @@ export const baseSendMessageNextSchema = z
   .refine(hasOnlyOneAttachmentField, {
     message: 'Must not provide both attachments and images',
     path: ['attachments'],
-  });
+  })
+  .refine(
+    data => {
+      if (data.payload.type === 'command') return true;
+      if (data.payload.prompt.trim().length > 0) return true;
+      const hasFiles =
+        (data.attachments?.files.length ?? 0) > 0 || (data.images?.files.length ?? 0) > 0;
+      return hasFiles;
+    },
+    {
+      message: 'Prompt is required',
+      path: ['payload', 'prompt'],
+    }
+  );
 
 // Schema for interrupting a session
 export const baseInterruptSessionNextSchema = z.object({

--- a/apps/web/src/routers/cloud-agent-next-send-schema.test.ts
+++ b/apps/web/src/routers/cloud-agent-next-send-schema.test.ts
@@ -1,0 +1,104 @@
+import { describe, expect, it } from '@jest/globals';
+import {
+  basePrepareSessionNextSchema,
+  baseSendMessageNextSchema,
+} from './cloud-agent-next-schemas';
+
+const MESSAGE_UUID = '12345678-1234-4234-9234-123456789abc';
+const ATTACHMENT_ID = '87654321-4321-4321-8321-cba987654321';
+
+const promptPayload = (prompt: string) => ({
+  type: 'prompt' as const,
+  prompt,
+  mode: 'code',
+  model: 'gpt-4',
+});
+
+const commandPayload = () => ({
+  type: 'command' as const,
+  command: 'ls',
+});
+
+const attachments = (filename: string) => ({
+  path: MESSAGE_UUID,
+  files: [filename],
+});
+
+const images = (filename: string) => ({
+  path: MESSAGE_UUID,
+  files: [filename],
+});
+
+describe('baseSendMessageNextSchema', () => {
+  it('accepts an empty prompt with an attachment', () => {
+    const result = baseSendMessageNextSchema.safeParse({
+      cloudAgentSessionId: 'cloud-session-1',
+      payload: promptPayload(''),
+      attachments: attachments(`${ATTACHMENT_ID}.png`),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('accepts an empty prompt with an image', () => {
+    const result = baseSendMessageNextSchema.safeParse({
+      cloudAgentSessionId: 'cloud-session-1',
+      payload: promptPayload(''),
+      images: images(`${ATTACHMENT_ID}.png`),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('rejects an empty prompt with no files', () => {
+    const result = baseSendMessageNextSchema.safeParse({
+      cloudAgentSessionId: 'cloud-session-1',
+      payload: promptPayload(''),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('rejects a whitespace-only prompt with no files', () => {
+    const result = baseSendMessageNextSchema.safeParse({
+      cloudAgentSessionId: 'cloud-session-1',
+      payload: promptPayload('   '),
+    });
+    expect(result.success).toBe(false);
+  });
+
+  it('accepts a command payload with no prompt and no files', () => {
+    const result = baseSendMessageNextSchema.safeParse({
+      cloudAgentSessionId: 'cloud-session-1',
+      payload: commandPayload(),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('still accepts a text-only prompt', () => {
+    const result = baseSendMessageNextSchema.safeParse({
+      cloudAgentSessionId: 'cloud-session-1',
+      payload: promptPayload('hello'),
+    });
+    expect(result.success).toBe(true);
+  });
+
+  it('still accepts a text prompt with an attachment', () => {
+    const result = baseSendMessageNextSchema.safeParse({
+      cloudAgentSessionId: 'cloud-session-1',
+      payload: promptPayload('hello'),
+      attachments: attachments(`${ATTACHMENT_ID}.png`),
+    });
+    expect(result.success).toBe(true);
+  });
+});
+
+describe('basePrepareSessionNextSchema initialPayload', () => {
+  it('still rejects an empty prompt in initialPayload', () => {
+    const result = basePrepareSessionNextSchema.safeParse({
+      githubRepo: 'owner/repo',
+      prompt: 'hello',
+      mode: 'code',
+      model: 'gpt-4',
+      initialPayload: promptPayload(''),
+    });
+    expect(result.success).toBe(false);
+  });
+});

--- a/services/cloud-agent-next/src/router/schemas.test.ts
+++ b/services/cloud-agent-next/src/router/schemas.test.ts
@@ -373,6 +373,77 @@ describe('sendMessageV2 input compatibility', () => {
   });
 });
 
+describe('attachment-only follow-up send', () => {
+  it('accepts an empty prompt with document attachments on send and sendMessageV2', () => {
+    expect(
+      SendMessageInput.safeParse({
+        cloudAgentSessionId: validSessionId,
+        message: { prompt: '', attachments: validAttachments },
+      }).success
+    ).toBe(true);
+    expect(
+      SendMessageV2Input.safeParse({
+        ...baseSendMessageInput,
+        prompt: '',
+        attachments: validAttachments,
+      }).success
+    ).toBe(true);
+    expect(
+      SendMessageV2Input.safeParse({
+        cloudAgentSessionId: validSessionId,
+        payload: { type: 'prompt', ...basePromptInput, prompt: '' },
+        attachments: validAttachments,
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects an empty or whitespace-only prompt with no attachments', () => {
+    for (const prompt of ['', '   ']) {
+      expect(
+        SendMessageInput.safeParse({
+          cloudAgentSessionId: validSessionId,
+          message: { prompt },
+        }).success
+      ).toBe(false);
+      expect(
+        SendMessageV2Input.safeParse({ ...baseSendMessageInput, prompt: prompt }).success
+      ).toBe(false);
+      expect(
+        SendMessageV2Input.safeParse({
+          cloudAgentSessionId: validSessionId,
+          payload: { type: 'prompt', ...basePromptInput, prompt },
+        }).success
+      ).toBe(false);
+    }
+  });
+
+  it('still accepts a command payload with no prompt and no attachments', () => {
+    expect(
+      SendMessageV2Input.safeParse({
+        cloudAgentSessionId: validSessionId,
+        payload: { type: 'command', command: 'compact', arguments: '--aggressive' },
+      }).success
+    ).toBe(true);
+  });
+
+  it('still rejects an empty prompt on prepareSession initialPayload', () => {
+    expect(
+      PrepareSessionInput.safeParse({
+        prompt: 'Review the current branch',
+        mode: 'code',
+        model: 'claude-sonnet-4-5-20250929',
+        githubRepo: 'acme/repo',
+        initialPayload: {
+          type: 'prompt',
+          prompt: '',
+          mode: 'code',
+          model: 'claude-sonnet-4-5-20250929',
+        },
+      }).success
+    ).toBe(false);
+  });
+});
+
 describe('Bitbucket clone URL parsing', () => {
   it('keeps canonical Bitbucket repository identity limited to HTTPS clone URLs', () => {
     expect(parseCanonicalBitbucketCloneUrl('https://bitbucket.org/acme/repo.git')).toEqual({

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -97,6 +97,28 @@ function rejectAmbiguousAttachments(
 }
 
 /**
+ * Reject a prompt that is empty or whitespace-only when there are no
+ * `attachments.files` and no `images.files`. Command turns have no prompt and
+ * must skip this rule at the call site.
+ */
+function rejectEmptyPromptWithoutAttachments(
+  data: {
+    prompt?: unknown;
+    attachments?: { files?: unknown[] } | undefined;
+    images?: { files?: unknown[] } | undefined;
+  },
+  ctx: z.RefinementCtx,
+  path: (string | number)[] = ['prompt']
+): void {
+  const prompt = typeof data.prompt === 'string' ? data.prompt : '';
+  if (prompt.trim().length > 0) return;
+  const hasFiles =
+    (data.attachments?.files?.length ?? 0) > 0 || (data.images?.files?.length ?? 0) > 0;
+  if (hasFiles) return;
+  ctx.addIssue({ code: 'custom', path, message: 'Prompt is required' });
+}
+
+/**
  * Base prompt payload schema used by all execution endpoints.
  * Contains the essential fields for Kilocode execution.
  */
@@ -120,6 +142,38 @@ export const PromptPayload = z.object({
 export const PromptSendPayload = z.object({
   type: z.literal('prompt'),
   prompt: z.string().min(1, 'Prompt is required'),
+  mode: ModeSlugSchema,
+  model: modelIdSchema,
+  variant: z
+    .string()
+    .max(50)
+    .regex(/^[a-zA-Z]+$/)
+    .optional(),
+});
+
+/**
+ * Send-only flat prompt payload. Allows an empty prompt when attachments are
+ * present; the empty-prompt refine runs on the input, not on this field.
+ * Used only by `SendMessageV2FlatInput`.
+ */
+export const FollowUpPromptPayload = z.object({
+  prompt: z.string(),
+  mode: ModeSlugSchema,
+  model: modelIdSchema,
+  variant: z
+    .string()
+    .max(50)
+    .regex(/^[a-zA-Z]+$/)
+    .optional(),
+});
+
+/**
+ * Send-only discriminated prompt payload clone. Allows an empty prompt when
+ * attachments are present. Used only by `SendMessageV2PromptPayloadInput`.
+ */
+export const FollowUpPromptSendPayload = z.object({
+  type: z.literal('prompt'),
+  prompt: z.string(),
   mode: ModeSlugSchema,
   model: modelIdSchema,
   variant: z
@@ -264,9 +318,9 @@ const SendMessageV2Options = z.object({
   messageId: MessageIdSchema.nullish().describe('Optional message ID for correlating the request'),
 });
 
-const SendMessageV2FlatInput = SendMessageV2Options.extend(PromptPayload.shape);
+const SendMessageV2FlatInput = SendMessageV2Options.extend(FollowUpPromptPayload.shape);
 const SendMessageV2PromptPayloadInput = SendMessageV2Options.extend({
-  payload: PromptSendPayload,
+  payload: FollowUpPromptSendPayload,
 });
 const SendMessageV2CommandPayloadInput = SendMessageV2Options.extend({
   payload: CommandSendPayload,
@@ -280,15 +334,29 @@ export const SendMessageV2Input = z
   ])
   .superRefine((input, ctx) => {
     rejectAmbiguousAttachments(input, ctx);
-    if ('payload' in input && input.payload.type === 'command') {
-      if (input.attachments !== undefined || input.images !== undefined) {
-        ctx.addIssue({
-          code: 'custom',
-          path: ['attachments'],
-          message: 'Attachments cannot be attached to slash commands',
-        });
+    if ('payload' in input) {
+      if (input.payload.type === 'command') {
+        if (input.attachments !== undefined || input.images !== undefined) {
+          ctx.addIssue({
+            code: 'custom',
+            path: ['attachments'],
+            message: 'Attachments cannot be attached to slash commands',
+          });
+        }
+        return;
       }
+      rejectEmptyPromptWithoutAttachments(
+        { prompt: input.payload.prompt, attachments: input.attachments, images: input.images },
+        ctx,
+        ['payload', 'prompt']
+      );
+      return;
     }
+    rejectEmptyPromptWithoutAttachments(
+      { prompt: input.prompt, attachments: input.attachments, images: input.images },
+      ctx,
+      ['prompt']
+    );
   })
   .transform(input => {
     if ('payload' in input && input.payload.type === 'prompt') {
@@ -814,11 +882,17 @@ export const SendMessageInput = z
     cloudAgentSessionId: sessionIdSchema,
     message: z
       .object({
-        prompt: z.string().min(1, 'Prompt is required'),
+        prompt: z.string(),
         ...AttachmentFieldsSchema,
         id: MessageIdSchema.nullish(),
       })
-      .superRefine(rejectAmbiguousAttachments),
+      .superRefine(rejectAmbiguousAttachments)
+      .superRefine((message, ctx) =>
+        rejectEmptyPromptWithoutAttachments(
+          { prompt: message.prompt, attachments: message.attachments, images: message.images },
+          ctx
+        )
+      ),
     agent: z
       .object({
         mode: ModeSlugSchema,

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -156,32 +156,13 @@ export const PromptSendPayload = z.object({
  * present; the empty-prompt refine runs on the input, not on this field.
  * Used only by `SendMessageV2FlatInput`.
  */
-export const FollowUpPromptPayload = z.object({
-  prompt: z.string(),
-  mode: ModeSlugSchema,
-  model: modelIdSchema,
-  variant: z
-    .string()
-    .max(50)
-    .regex(/^[a-zA-Z]+$/)
-    .optional(),
-});
+export const FollowUpPromptPayload = PromptPayload.extend({ prompt: z.string() });
 
 /**
  * Send-only discriminated prompt payload clone. Allows an empty prompt when
  * attachments are present. Used only by `SendMessageV2PromptPayloadInput`.
  */
-export const FollowUpPromptSendPayload = z.object({
-  type: z.literal('prompt'),
-  prompt: z.string(),
-  mode: ModeSlugSchema,
-  model: modelIdSchema,
-  variant: z
-    .string()
-    .max(50)
-    .regex(/^[a-zA-Z]+$/)
-    .optional(),
-});
+export const FollowUpPromptSendPayload = PromptSendPayload.extend({ prompt: z.string() });
 
 export const CommandSendPayload = z.object({
   type: z.literal('command'),

--- a/services/cloud-agent-next/src/session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.test.ts
@@ -1155,6 +1155,36 @@ describe('SessionMessageQueue', () => {
     expect(pending?.intent?.turn).toMatchObject({ attachments });
   });
 
+  it('admits an empty prompt when attachment files are present', async () => {
+    const harness = createQueueHarness();
+    const attachments = {
+      path: '123e4567-e89b-12d3-a456-426614174000',
+      files: ['123e4567-e89b-12d3-a456-426614174001.pdf'],
+    };
+
+    const result = await harness.queue.admitSubmittedMessage({
+      userId: 'user_test' as UserId,
+      turn: { type: 'prompt', id: FIRST_MESSAGE_ID, prompt: '', attachments },
+    });
+
+    expect(result).toMatchObject({ success: true, messageId: FIRST_MESSAGE_ID });
+  });
+
+  it('rejects an empty prompt with no attachments', async () => {
+    const harness = createQueueHarness();
+
+    const result = await harness.queue.admitSubmittedMessage({
+      userId: 'user_test' as UserId,
+      turn: { type: 'prompt', id: FIRST_MESSAGE_ID, prompt: '' },
+    });
+
+    expect(result).toEqual({
+      success: false,
+      code: 'BAD_REQUEST',
+      error: 'No prompt provided',
+    });
+  });
+
   it('rejects queue admission once durable pending capacity is exhausted', async () => {
     const harness = createQueueHarness();
     for (let index = 0; index < PENDING_SESSION_MESSAGE_LIMIT; index++) {

--- a/services/cloud-agent-next/src/session/session-message-queue.ts
+++ b/services/cloud-agent-next/src/session/session-message-queue.ts
@@ -838,7 +838,11 @@ export function createSessionMessageQueue(
         return buildAdmissionError('BAD_REQUEST', MESSAGE_ID_FORMAT_DESCRIPTION);
       }
 
-      if (explicitTurn.type === 'prompt' && !explicitTurn.prompt) {
+      if (
+        explicitTurn.type === 'prompt' &&
+        !explicitTurn.prompt.trim() &&
+        !(explicitTurn.attachments?.files.length ?? 0)
+      ) {
         return buildAdmissionError('BAD_REQUEST', 'No prompt provided');
       }
       if (explicitTurn.type === 'command' && explicitTurn.attachments !== undefined) {

--- a/services/cloud-agent-next/test/unit/wrapper/server.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/server.test.ts
@@ -1031,6 +1031,54 @@ describe('createPromptHandler', () => {
     expect(deps.kiloClient.sendPromptAsync).not.toHaveBeenCalled();
   });
 
+  it('accepts an empty prompt with a signed attachment and materializes it', async () => {
+    const state = new WrapperState();
+    const deps = createMockDeps(state);
+    const handler = createPromptHandler(defaultServerConfig, deps);
+
+    const response = await handler(
+      jsonRequest({
+        message: {
+          id: 'msg_empty_prompt_attachment',
+          prompt: '',
+          attachments: [
+            {
+              filename: 'brief.pdf',
+              mime: 'application/pdf',
+              signedUrl: 'https://r2.example.com/brief.pdf',
+              localPath: '/tmp/brief.pdf',
+            },
+          ],
+        },
+        session: completeBinding,
+      })
+    );
+
+    expect(response.status).toBe(200);
+    expect(deps.materializePromptAttachments).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an empty prompt with no attachments and no parts', async () => {
+    const state = new WrapperState();
+    const deps = createMockDeps(state);
+    const handler = createPromptHandler(defaultServerConfig, deps);
+
+    const response = await handler(
+      jsonRequest({
+        message: { id: 'msg_empty_prompt', prompt: '' },
+        session: completeBinding,
+      })
+    );
+    const data = await readJson(response);
+
+    expect(response.status).toBe(400);
+    expect(data).toEqual({
+      error: 'INVALID_REQUEST',
+      message: 'Either message.prompt or message.parts is required',
+    });
+    expect(deps.materializePromptAttachments).not.toHaveBeenCalled();
+  });
+
   it('rejects prompt with incomplete session binding', async () => {
     const state = new WrapperState();
     const deps = createMockDeps(state);

--- a/services/cloud-agent-next/wrapper/src/server.ts
+++ b/services/cloud-agent-next/wrapper/src/server.ts
@@ -461,7 +461,9 @@ export function createPromptHandler(config: ServerConfig, deps: ServerDependenci
     if (!body.message?.id) {
       return errorResponse('INVALID_REQUEST', 'message.id is required', 400);
     }
-    if (!body.message.prompt && !body.message.parts) {
+    const hasAttachments = (body.message.attachments?.length ?? 0) > 0;
+    const hasParts = Array.isArray(body.message.parts) && body.message.parts.length > 0;
+    if (!body.message.prompt && !hasParts && !hasAttachments) {
       return errorResponse(
         'INVALID_REQUEST',
         'Either message.prompt or message.parts is required',


### PR DESCRIPTION
## Summary

Fixes three composer defects without a rewrite.

**For the user:** after `Assistant request failed`, the composer unlocks so you can type and send again in the same session; the red banner stays until the next successful send. A disabled composer on iOS no longer opens writing tools or a selection menu. A ready attachment with no text now sends.

**For the product manager:** the composer now recovers from an assistant error instead of dead-ending the session, and attachment-only sends work end to end. An empty prompt with no attachments stays rejected.

**For the maintainer:** the composer disabled state now derives from real locks only (`resolveSessionComposerDisabled` — read-only, transport `canSend`, loading, blocking interaction, missing model), dropping the `Boolean(error)` lock. The iOS `TextInput` sets `contextMenuHidden` and `pointerEvents="none"` when not editable. Attachment-only send is enabled by `readyAttachmentsCount` in `canSend`, and the backend accepts an empty prompt plus attachments across three gates: the send schemas (send-only clones plus `rejectEmptyPromptWithoutAttachments`), the wrapper `createPromptHandler`, and `admitSubmittedMessage`. Prepare and new-session paths keep `.min(1)`.

## Verification

- `pnpm --filter kilo-app test` — 4525 passed
- `pnpm --filter cloud-agent-next test` — 2548 passed, 3 skipped
- `pnpm --filter web test -- src/routers/cloud-agent-next-send-schema.test.ts` — 8 passed
- `pnpm --filter kilo-app typecheck`, `pnpm --filter cloud-agent-next typecheck`, `pnpm --filter web typecheck` — pass
- `pnpm --filter kilo-app lint`, `pnpm --filter cloud-agent-next lint`, `pnpm --filter web lint` — 0 warnings, 0 errors
- `pnpm -w exec oxfmt --check` on changed files — pass

Automated E2E (bot-e2e) covers the three runtime behaviors on iOS.

## Visual Changes

N/A — behavior-only changes; no visual redesign. The red banner, composer layout, and send button appearance are unchanged.

## Reviewer Notes

- The three backend gates (schema, wrapper, admission) must all accept an empty prompt only when attachment or part files are present; an empty prompt with no attachments stays rejected everywhere.
- Prepare and new-session paths intentionally keep `.min(1)`; only follow-up send is relaxed.
- kilo-chat and web `ChatInput` are unchanged.

## Human steps

No human step is needed. No migration, secret, flag, or deploy-order change.
