### PR TITLE
feat(mobile): add range text selection to message details

### DIFF
--- a/apps/mobile/src/components/agents/message-details-content.ts
+++ b/apps/mobile/src/components/agents/message-details-content.ts
@@ -5,6 +5,7 @@ import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 import { collectCopyableText } from './collect-copyable-text';
 import { formatCost } from './context-usage-display';
 import { resolveMessageDisplayModel } from './message-model-label';
+import { isPartStreaming } from './part-types';
 import { friendlyModelName } from './session-model-display';
 
 type MessageDetailsTokenRow = {
@@ -19,6 +20,7 @@ type MessageDetailsContent = {
   costLabel: string | null;
   tokenRows: MessageDetailsTokenRow[] | null;
   copyableText: string | null;
+  canSelectText: boolean;
 };
 
 const SENT_TIME_FORMATTER = new Intl.DateTimeFormat(undefined, {
@@ -39,6 +41,9 @@ export function getMessageDetailsContent(
   const sentTimeLabel = formatMessageSentTime(message.info.time.created);
   const copyable = collectCopyableText(message);
   const copyableText = copyable.length > 0 ? copyable : null;
+  const canSelectText =
+    copyableText !== null &&
+    !message.parts.some(part => isPartInFlightForSelect(part, message.info.role));
 
   if (message.info.role !== 'assistant') {
     return {
@@ -48,6 +53,7 @@ export function getMessageDetailsContent(
       costLabel: null,
       tokenRows: null,
       copyableText,
+      canSelectText,
     };
   }
 
@@ -75,7 +81,23 @@ export function getMessageDetailsContent(
         ]
       : null,
     copyableText,
+    canSelectText,
   };
+}
+
+/**
+ * A part blocks range selection while it is in flight. A user text part never
+ * streams, so only an assistant text part with a `time` that lacks `end` is
+ * in flight; reasoning and tool parts reuse the shared streaming check.
+ */
+function isPartInFlightForSelect(
+  part: StoredMessage['parts'][number],
+  role: StoredMessage['info']['role']
+): boolean {
+  if (part.type === 'text') {
+    return role === 'assistant' && part.time !== undefined && part.time.end === undefined;
+  }
+  return isPartStreaming(part);
 }
 
 type AssistantUsage = {

--- a/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
@@ -1,0 +1,210 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/test/render-with-providers.tsx) */
+import {
+  type AssistantMessage,
+  type Part,
+  type StoredMessage,
+  type UserMessage,
+} from '@kilocode/cloud-agent-sdk';
+import { createElement, type ReactElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { MessageDetailsSheet } from './message-details-sheet';
+
+vi.mock('react-native', () => ({
+  Modal: 'Modal',
+  ScrollView: 'ScrollView',
+  Pressable: 'Pressable',
+  View: 'View',
+}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ bottom: 0 }),
+}));
+vi.mock('@/components/sheet-header', () => ({
+  SheetHeader: 'SheetHeader',
+}));
+vi.mock('@/components/ui/text', async () => {
+  const React = await import('react');
+  return {
+    Text: 'Text',
+    TextClassContext: React.createContext<string | undefined>(undefined),
+  };
+});
+vi.mock('@/components/ui/selectable-text', () => ({
+  SelectableText: 'SelectableText',
+}));
+vi.mock('./message-details-copy', () => ({
+  handleMessageDetailsCopy: vi.fn(),
+}));
+
+function userInfo(overrides: Partial<UserMessage> = {}): UserMessage {
+  return {
+    id: 'u-1',
+    sessionID: 'ses-1',
+    role: 'user',
+    time: { created: 1_700_000_000_000 },
+    agent: 'test',
+    model: { providerID: 'kilo', modelID: 'claude-sonnet-4' },
+    ...overrides,
+  };
+}
+
+function assistantInfo(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    id: 'msg-1',
+    sessionID: 'ses-1',
+    role: 'assistant',
+    time: { created: 1_700_000_000_000 },
+    parentID: 'msg-0',
+    modelID: 'claude-sonnet-4',
+    providerID: 'kilo',
+    mode: 'code',
+    agent: 'test',
+    path: { cwd: '/', root: '/' },
+    cost: 0,
+    tokens: {
+      input: 0,
+      output: 0,
+      reasoning: 0,
+      cache: { read: 0, write: 0 },
+    },
+    ...overrides,
+  };
+}
+
+function textPart(text: string, id = 'p-text'): Part {
+  return {
+    id,
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'text',
+    text,
+  };
+}
+
+function textPartWithTime(
+  text: string,
+  time: { start: number; end?: number },
+  id = 'p-text-time'
+): Part {
+  return {
+    id,
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'text',
+    text,
+    time,
+  };
+}
+
+function storedMessage(info: AssistantMessage | UserMessage, parts: Part[] = []): StoredMessage {
+  return { info, parts };
+}
+
+function sheetElement(message: StoredMessage | null): ReactElement {
+  return createElement(MessageDetailsSheet, {
+    visible: true,
+    message,
+    modelOptions: [],
+    onClose: vi.fn<() => void>(),
+  });
+}
+
+function findByTestID(
+  root: TestRenderer.ReactTestInstance,
+  testID: string
+): TestRenderer.ReactTestInstance[] {
+  return root.findAll(node => node.props.testID === testID);
+}
+
+function press(instance: TestRenderer.ReactTestInstance | undefined): void {
+  if (!instance) {
+    throw new Error('target not found');
+  }
+  const onPress = instance.props.onPress as (() => void) | undefined;
+  if (typeof onPress !== 'function') {
+    throw new TypeError('target has no onPress');
+  }
+  onPress();
+}
+
+async function mountSheet(message: StoredMessage | null): Promise<TestRenderer.ReactTestRenderer> {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  await act(async () => {
+    await Promise.resolve();
+    ref.current = TestRenderer.create(sheetElement(message));
+  });
+  const renderer = ref.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+async function unmount(renderer: TestRenderer.ReactTestRenderer): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    renderer.unmount();
+  });
+}
+
+describe('MessageDetailsSheet mounted', () => {
+  it('renders Copy message and Select text for a finished copyable user message', async () => {
+    const renderer = await mountSheet(storedMessage(userInfo(), [textPart('hello world')]));
+
+    expect(findByTestID(renderer.root, 'message-details-copy')).toHaveLength(1);
+    expect(findByTestID(renderer.root, 'message-details-select-text')).toHaveLength(1);
+
+    await unmount(renderer);
+  });
+
+  it('opens the child sheet with the copyable body when Select text is pressed', async () => {
+    const renderer = await mountSheet(storedMessage(userInfo(), [textPart('selectable body')]));
+
+    const modals = () =>
+      renderer.root.findAll(
+        node => typeof node.type === 'string' && (node.type as string) === 'Modal'
+      );
+    const visibleModals = () => modals().filter(node => node.props.visible === true);
+
+    // Before press: only the details sheet Modal is visible; the child Modal is hidden.
+    expect(modals()).toHaveLength(2);
+    expect(visibleModals()).toHaveLength(1);
+
+    await act(async () => {
+      await Promise.resolve();
+      press(findByTestID(renderer.root, 'message-details-select-text')[0]);
+    });
+
+    // After press: the child Modal flips to visible and shows the copyable body.
+    expect(visibleModals()).toHaveLength(2);
+
+    const selectable = renderer.root.findAll(
+      node => typeof node.type === 'string' && (node.type as string) === 'SelectableText'
+    );
+    expect(selectable).toHaveLength(1);
+    expect(selectable[0]?.props.children).toBe('selectable body');
+
+    await unmount(renderer);
+  });
+
+  it('hides Select text for a streaming assistant text part but keeps Copy message', async () => {
+    const renderer = await mountSheet(
+      storedMessage(assistantInfo(), [textPartWithTime('streaming body', { start: 1 })])
+    );
+
+    expect(findByTestID(renderer.root, 'message-details-copy')).toHaveLength(1);
+    expect(findByTestID(renderer.root, 'message-details-select-text')).toHaveLength(0);
+
+    await unmount(renderer);
+  });
+
+  it('renders neither button when there is no copyable text', async () => {
+    const renderer = await mountSheet(storedMessage(userInfo(), []));
+
+    expect(findByTestID(renderer.root, 'message-details-copy')).toHaveLength(0);
+    expect(findByTestID(renderer.root, 'message-details-select-text')).toHaveLength(0);
+
+    await unmount(renderer);
+  });
+});

--- a/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
@@ -158,26 +158,31 @@ describe('MessageDetailsSheet mounted', () => {
     await unmount(renderer);
   });
 
-  it('opens the child sheet with the copyable body when Select text is pressed', async () => {
+  it('swaps the details Modal content to the select view when Select text is pressed', async () => {
     const renderer = await mountSheet(storedMessage(userInfo(), [textPart('selectable body')]));
 
     const modals = () =>
       renderer.root.findAll(
         node => typeof node.type === 'string' && (node.type as string) === 'Modal'
       );
-    const visibleModals = () => modals().filter(node => node.props.visible === true);
+    const sheetHeaderTitles = () =>
+      renderer.root
+        .findAll(node => typeof node.type === 'string' && (node.type as string) === 'SheetHeader')
+        .map(node => node.props.title as string | undefined);
 
-    // Before press: only the details sheet Modal is visible; the child Modal is hidden.
-    expect(modals()).toHaveLength(2);
-    expect(visibleModals()).toHaveLength(1);
+    // Before press: a single Modal shows the details content.
+    expect(modals()).toHaveLength(1);
+    expect(sheetHeaderTitles()).toContain('Message details');
 
     await act(async () => {
       await Promise.resolve();
       press(findByTestID(renderer.root, 'message-details-select-text')[0]);
     });
 
-    // After press: the child Modal flips to visible and shows the copyable body.
-    expect(visibleModals()).toHaveLength(2);
+    // After press: the same single Modal swaps to the Select text view.
+    expect(modals()).toHaveLength(1);
+    expect(sheetHeaderTitles()).toContain('Select text');
+    expect(sheetHeaderTitles()).not.toContain('Message details');
 
     const selectable = renderer.root.findAll(
       node => typeof node.type === 'string' && (node.type as string) === 'SelectableText'

--- a/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.mounted.test.tsx
@@ -193,6 +193,42 @@ describe('MessageDetailsSheet mounted', () => {
     await unmount(renderer);
   });
 
+  it('returns to the details view when Android back is pressed in the Select text view', async () => {
+    const renderer = await mountSheet(storedMessage(userInfo(), [textPart('selectable body')]));
+
+    const modal = () => {
+      const found = renderer.root.findAll(
+        node => typeof node.type === 'string' && (node.type as string) === 'Modal'
+      );
+      if (!found[0]) {
+        throw new Error('Modal not found');
+      }
+      return found[0];
+    };
+
+    await act(async () => {
+      await Promise.resolve();
+      press(findByTestID(renderer.root, 'message-details-select-text')[0]);
+    });
+
+    const onRequestClose = modal().props.onRequestClose as (() => void) | undefined;
+    expect(typeof onRequestClose).toBe('function');
+
+    await act(async () => {
+      await Promise.resolve();
+      onRequestClose?.();
+    });
+
+    const sheetHeaderTitles = () =>
+      renderer.root
+        .findAll(node => typeof node.type === 'string' && (node.type as string) === 'SheetHeader')
+        .map(node => node.props.title as string | undefined);
+    expect(sheetHeaderTitles()).toContain('Message details');
+    expect(sheetHeaderTitles()).not.toContain('Select text');
+
+    await unmount(renderer);
+  });
+
   it('hides Select text for a streaming assistant text part but keeps Copy message', async () => {
     const renderer = await mountSheet(
       storedMessage(assistantInfo(), [textPartWithTime('streaming body', { start: 1 })])

--- a/apps/mobile/src/components/agents/message-details-sheet.test.ts
+++ b/apps/mobile/src/components/agents/message-details-sheet.test.ts
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- cohesive unit suite: projection, empty, canSelectText, and copy wiring share one harness */
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
@@ -258,6 +259,113 @@ describe('getMessageDetailsContent — empty', () => {
     const message = storedMessage(info, [textPart('x')]);
     const content = getMessageDetailsContent(message, catalogOptions);
     expect(content.sentTimeLabel).toBeNull();
+  });
+});
+
+function textPartWithTime(
+  text: string,
+  time: { start: number; end?: number },
+  id = 'p-text-time'
+): Part {
+  return {
+    id,
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'text',
+    text,
+    time,
+  };
+}
+
+function reasoningPart(
+  text: string,
+  time: { start: number; end?: number },
+  id = 'p-reasoning'
+): Part {
+  return {
+    id,
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'reasoning',
+    text,
+    time,
+  };
+}
+
+function runningToolPart(id = 'p-tool'): Part {
+  return {
+    id,
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'tool',
+    callID: 'call-1',
+    tool: 'bash',
+    state: { status: 'running', input: { command: 'echo hi' }, time: { start: 1 } },
+  };
+}
+
+describe('getMessageDetailsContent — canSelectText', () => {
+  it('allows selection for a finished user text part with no time', () => {
+    const message = storedMessage(userInfo(), [textPart('user body')]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).toBe('user body');
+    expect(content.canSelectText).toBe(true);
+  });
+
+  it('allows selection for a reconciled user text part with start and no end', () => {
+    const message = storedMessage(userInfo(), [textPartWithTime('user body', { start: 1 })]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).toBe('user body');
+    expect(content.canSelectText).toBe(true);
+  });
+
+  it('allows selection for a finished assistant text part with time.end', () => {
+    const message = storedMessage(assistantInfo(), [
+      textPartWithTime('assistant body', { start: 1, end: 2 }),
+    ]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).toBe('assistant body');
+    expect(content.canSelectText).toBe(true);
+  });
+
+  it('allows selection for a finished assistant text part with no time', () => {
+    const message = storedMessage(assistantInfo(), [textPart('assistant body')]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).toBe('assistant body');
+    expect(content.canSelectText).toBe(true);
+  });
+
+  it('hides selection for a streaming assistant text part but keeps copyable text', () => {
+    const message = storedMessage(assistantInfo(), [
+      textPartWithTime('streaming body', { start: 1 }),
+    ]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).toBe('streaming body');
+    expect(content.canSelectText).toBe(false);
+  });
+
+  it('hides selection while an assistant tool part is running', () => {
+    const message = storedMessage(assistantInfo(), [runningToolPart()]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).not.toBeNull();
+    expect(content.canSelectText).toBe(false);
+  });
+
+  it('hides selection while an assistant reasoning part is in flight', () => {
+    const message = storedMessage(assistantInfo(), [
+      textPart('finished text'),
+      reasoningPart('thinking...', { start: 1 }),
+    ]);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).not.toBeNull();
+    expect(content.canSelectText).toBe(false);
+  });
+
+  it('hides both actions for a user message with no parts', () => {
+    const message = storedMessage(userInfo(), []);
+    const content = getMessageDetailsContent(message, catalogOptions);
+    expect(content.copyableText).toBeNull();
+    expect(content.canSelectText).toBe(false);
   });
 });
 

--- a/apps/mobile/src/components/agents/message-details-sheet.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.tsx
@@ -47,7 +47,13 @@ export function MessageDetailsSheet({
       visible={visible}
       animationType="slide"
       presentationStyle="pageSheet"
-      onRequestClose={onClose}
+      onRequestClose={
+        selectVisible
+          ? () => {
+              setSelectVisible(false);
+            }
+          : onClose
+      }
     >
       {selectVisible ? (
         <MessageTextSelectSheet

--- a/apps/mobile/src/components/agents/message-details-sheet.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.tsx
@@ -1,5 +1,5 @@
 import { type StoredMessage } from '@kilocode/cloud-agent-sdk';
-import { useMemo } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { Modal, Pressable, ScrollView, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -10,6 +10,7 @@ import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 import { formatExactTokens } from './context-usage-display';
 import { handleMessageDetailsCopy } from './message-details-copy';
 import { getMessageDetailsContent } from './message-details-content';
+import { MessageTextSelectSheet } from './message-text-select-sheet';
 
 type MessageDetailsSheetProps = {
   visible: boolean;
@@ -25,84 +26,119 @@ export function MessageDetailsSheet({
   onClose,
 }: Readonly<MessageDetailsSheetProps>) {
   const insets = useSafeAreaInsets();
+  const [selectVisible, setSelectVisible] = useState(false);
   const content = useMemo(
     () => (message ? getMessageDetailsContent(message, modelOptions) : null),
     [message, modelOptions]
   );
+
+  useEffect(() => {
+    if (!visible) {
+      setSelectVisible(false);
+    }
+  }, [visible]);
 
   const handleCopy = () => {
     handleMessageDetailsCopy(content?.copyableText);
   };
 
   return (
-    <Modal
-      visible={visible}
-      animationType="slide"
-      presentationStyle="pageSheet"
-      onRequestClose={onClose}
-    >
-      <View className="flex-1 bg-background">
-        <SheetHeader title="Message details" onDone={onClose} doneLabel="Done" />
+    <>
+      <Modal
+        visible={visible}
+        animationType="slide"
+        presentationStyle="pageSheet"
+        onRequestClose={onClose}
+      >
+        <View className="flex-1 bg-background">
+          <SheetHeader title="Message details" onDone={onClose} doneLabel="Done" />
 
-        {content ? (
-          <ScrollView contentContainerClassName="px-6 pb-6 pt-2">
-            {content.copyableText ? (
-              <Pressable
-                onPress={handleCopy}
-                accessibilityRole="button"
-                accessibilityLabel="Copy message"
-                className="mb-6 rounded-md border border-border px-4 py-3 active:opacity-70"
-                testID="message-details-copy"
-              >
-                <Text className="text-center text-base font-medium text-foreground">
-                  Copy message
-                </Text>
-              </Pressable>
-            ) : null}
+          {content ? (
+            <ScrollView contentContainerClassName="px-6 pb-6 pt-2">
+              {content.copyableText ? (
+                <View className="mb-6 gap-2">
+                  <Pressable
+                    onPress={handleCopy}
+                    accessibilityRole="button"
+                    accessibilityLabel="Copy message"
+                    className="rounded-md border border-border px-4 py-3 active:opacity-70"
+                    testID="message-details-copy"
+                  >
+                    <Text className="text-center text-base font-medium text-foreground">
+                      Copy message
+                    </Text>
+                  </Pressable>
 
-            <View className="gap-4">
-              <Row label="Role">
-                <Text className="text-base font-medium text-foreground">{content.roleLabel}</Text>
-              </Row>
-
-              {content.sentTimeLabel ? (
-                <Row label="Sent">
-                  <Text className="text-base font-medium text-foreground tabular-nums">
-                    {content.sentTimeLabel}
-                  </Text>
-                </Row>
-              ) : null}
-
-              {content.modelLabel ? (
-                <Row label="Model">
-                  <Text className="text-base font-medium text-foreground">
-                    {content.modelLabel}
-                  </Text>
-                </Row>
-              ) : null}
-            </View>
-
-            {content.costLabel && content.tokenRows ? (
-              <View className="mt-8 gap-4">
-                <Text className="text-sm font-semibold text-foreground">Cost & tokens</Text>
-                <Row label="Cost">
-                  <Text className="text-base font-medium text-foreground tabular-nums">
-                    {content.costLabel}
-                  </Text>
-                </Row>
-                <View className="gap-3">
-                  {content.tokenRows.map(row => (
-                    <TokenRow key={row.label} label={row.label} value={row.value} />
-                  ))}
+                  {content.canSelectText ? (
+                    <Pressable
+                      onPress={() => {
+                        setSelectVisible(true);
+                      }}
+                      accessibilityRole="button"
+                      accessibilityLabel="Select text"
+                      className="rounded-md border border-border px-4 py-3 active:opacity-70"
+                      testID="message-details-select-text"
+                    >
+                      <Text className="text-center text-base font-medium text-foreground">
+                        Select text
+                      </Text>
+                    </Pressable>
+                  ) : null}
                 </View>
-              </View>
-            ) : null}
-          </ScrollView>
-        ) : null}
+              ) : null}
 
-        <View style={{ height: insets.bottom }} className="bg-background" />
-      </View>
-    </Modal>
+              <View className="gap-4">
+                <Row label="Role">
+                  <Text className="text-base font-medium text-foreground">{content.roleLabel}</Text>
+                </Row>
+
+                {content.sentTimeLabel ? (
+                  <Row label="Sent">
+                    <Text className="text-base font-medium text-foreground tabular-nums">
+                      {content.sentTimeLabel}
+                    </Text>
+                  </Row>
+                ) : null}
+
+                {content.modelLabel ? (
+                  <Row label="Model">
+                    <Text className="text-base font-medium text-foreground">
+                      {content.modelLabel}
+                    </Text>
+                  </Row>
+                ) : null}
+              </View>
+
+              {content.costLabel && content.tokenRows ? (
+                <View className="mt-8 gap-4">
+                  <Text className="text-sm font-semibold text-foreground">Cost & tokens</Text>
+                  <Row label="Cost">
+                    <Text className="text-base font-medium text-foreground tabular-nums">
+                      {content.costLabel}
+                    </Text>
+                  </Row>
+                  <View className="gap-3">
+                    {content.tokenRows.map(row => (
+                      <TokenRow key={row.label} label={row.label} value={row.value} />
+                    ))}
+                  </View>
+                </View>
+              ) : null}
+            </ScrollView>
+          ) : null}
+
+          <View style={{ height: insets.bottom }} className="bg-background" />
+        </View>
+      </Modal>
+
+      <MessageTextSelectSheet
+        visible={selectVisible}
+        text={content?.copyableText ?? ''}
+        onClose={() => {
+          setSelectVisible(false);
+        }}
+      />
+    </>
   );
 }
 

--- a/apps/mobile/src/components/agents/message-details-sheet.tsx
+++ b/apps/mobile/src/components/agents/message-details-sheet.tsx
@@ -43,13 +43,20 @@ export function MessageDetailsSheet({
   };
 
   return (
-    <>
-      <Modal
-        visible={visible}
-        animationType="slide"
-        presentationStyle="pageSheet"
-        onRequestClose={onClose}
-      >
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      {selectVisible ? (
+        <MessageTextSelectSheet
+          text={content?.copyableText ?? ''}
+          onClose={() => {
+            setSelectVisible(false);
+          }}
+        />
+      ) : (
         <View className="flex-1 bg-background">
           <SheetHeader title="Message details" onDone={onClose} doneLabel="Done" />
 
@@ -129,16 +136,8 @@ export function MessageDetailsSheet({
 
           <View style={{ height: insets.bottom }} className="bg-background" />
         </View>
-      </Modal>
-
-      <MessageTextSelectSheet
-        visible={selectVisible}
-        text={content?.copyableText ?? ''}
-        onClose={() => {
-          setSelectVisible(false);
-        }}
-      />
-    </>
+      )}
+    </Modal>
   );
 }
 

--- a/apps/mobile/src/components/agents/message-text-select-sheet.tsx
+++ b/apps/mobile/src/components/agents/message-text-select-sheet.tsx
@@ -1,0 +1,45 @@
+import { Modal, ScrollView, View } from 'react-native';
+import { useSafeAreaInsets } from 'react-native-safe-area-context';
+
+import { SheetHeader } from '@/components/sheet-header';
+import { SelectableText } from '@/components/ui/selectable-text';
+
+type MessageTextSelectSheetProps = {
+  visible: boolean;
+  text: string;
+  onClose: () => void;
+};
+
+/**
+ * Child page-sheet that shows the copyable message body in a read-only
+ * selectable field. The parent only sets `visible` when `text.length > 0`, so
+ * an empty string never renders `SelectableText`.
+ */
+export function MessageTextSelectSheet({
+  visible,
+  text,
+  onClose,
+}: Readonly<MessageTextSelectSheetProps>) {
+  const insets = useSafeAreaInsets();
+
+  return (
+    <Modal
+      visible={visible}
+      animationType="slide"
+      presentationStyle="pageSheet"
+      onRequestClose={onClose}
+    >
+      <View className="flex-1 bg-background">
+        <SheetHeader title="Select text" onDone={onClose} doneLabel="Done" />
+
+        {text.length > 0 ? (
+          <ScrollView contentContainerClassName="px-6 pb-6 pt-3">
+            <SelectableText className="text-base leading-6 text-foreground">{text}</SelectableText>
+          </ScrollView>
+        ) : null}
+
+        <View style={{ height: insets.bottom }} className="bg-background" />
+      </View>
+    </Modal>
+  );
+}

--- a/apps/mobile/src/components/agents/message-text-select-sheet.tsx
+++ b/apps/mobile/src/components/agents/message-text-select-sheet.tsx
@@ -1,45 +1,33 @@
-import { Modal, ScrollView, View } from 'react-native';
+import { ScrollView, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { SheetHeader } from '@/components/sheet-header';
 import { SelectableText } from '@/components/ui/selectable-text';
 
 type MessageTextSelectSheetProps = {
-  visible: boolean;
   text: string;
   onClose: () => void;
 };
 
 /**
- * Child page-sheet that shows the copyable message body in a read-only
- * selectable field. The parent only sets `visible` when `text.length > 0`, so
- * an empty string never renders `SelectableText`.
+ * Content-only view for the details sheet's Select text mode. The parent
+ * renders this inside the single details Modal when `selectVisible` is true.
+ * An empty string never renders `SelectableText`.
  */
-export function MessageTextSelectSheet({
-  visible,
-  text,
-  onClose,
-}: Readonly<MessageTextSelectSheetProps>) {
+export function MessageTextSelectSheet({ text, onClose }: Readonly<MessageTextSelectSheetProps>) {
   const insets = useSafeAreaInsets();
 
   return (
-    <Modal
-      visible={visible}
-      animationType="slide"
-      presentationStyle="pageSheet"
-      onRequestClose={onClose}
-    >
-      <View className="flex-1 bg-background">
-        <SheetHeader title="Select text" onDone={onClose} doneLabel="Done" />
+    <View className="flex-1 bg-background">
+      <SheetHeader title="Select text" onDone={onClose} doneLabel="Done" />
 
-        {text.length > 0 ? (
-          <ScrollView contentContainerClassName="px-6 pb-6 pt-3">
-            <SelectableText className="text-base leading-6 text-foreground">{text}</SelectableText>
-          </ScrollView>
-        ) : null}
+      {text.length > 0 ? (
+        <ScrollView contentContainerClassName="px-6 pb-6 pt-3">
+          <SelectableText className="text-base leading-6 text-foreground">{text}</SelectableText>
+        </ScrollView>
+      ) : null}
 
-        <View style={{ height: insets.bottom }} className="bg-background" />
-      </View>
-    </Modal>
+      <View style={{ height: insets.bottom }} className="bg-background" />
+    </View>
   );
 }


### PR DESCRIPTION
## Summary

The user can now select a range of text in the mobile agent chat. Long-press still opens the message details sheet. A new "Select text" action under "Copy message" swaps the details sheet to a "Select text" view that shows the copyable message body in a read-only selectable field. The user selects a range and uses the platform copy callout.

For the product manager: the app gains a "Select text" action on the message details sheet for finished messages with copyable text. A streaming message hides the action; a message with no copyable text shows neither "Copy message" nor "Select text".

For the maintainer: `getMessageDetailsContent` now projects `canSelectText`, true only when the message has copyable text and no part is in flight. A user text part never streams; an assistant text part is in flight only when `time` exists without `end`. Reasoning and tool parts reuse `isPartStreaming`. A new `MessageTextSelectSheet` content view reuses `SelectableText` and swaps into the single details Modal.

## Verification

- [x] `pnpm typecheck`, `pnpm lint`, `pnpm format:check` pass in `apps/mobile`.
- [x] Unit and mounted tests pass (4 files, 37 tests).
- [x] E2E (iOS simulator): long-press opens details; Select text swaps to the select view; in-bubble markdown does not enter native selection.

## Visual Changes

The details sheet gains a "Select text" action under "Copy message":

![s1-user-details.png](https://github.com/user-attachments/assets/df2a1088-124a-4ea8-a506-c16cb279b402)

Tapping it swaps the sheet to a read-only selectable view of the message body:

![s2-selectview.png](https://github.com/user-attachments/assets/0edf5b47-b326-4c1c-bc40-5ba0c038a0eb)

## Reviewer Notes

- Streaming hide is unit/mounted tested only; no live E2E streaming case (a short prompt finishes before the long-press).
- The Select text view swaps content inside the single details Modal (a nested `pageSheet` never presents on iOS). E2E S2 is the live check.

No human steps are needed.
