### PR TITLE
feat(mobile): tappable session transcript attachments

### DIFF
--- a/apps/mobile/src/components/agents/file-part-cache.test.ts
+++ b/apps/mobile/src/components/agents/file-part-cache.test.ts
@@ -166,17 +166,28 @@ describe('cacheFilePart', () => {
 
     expect(getFilePartCacheEntry('part-1')?.url).toBe('data:application/pdf;base64,QUJD');
   });
+
+  it('does not store a file:// URL', () => {
+    cacheFilePart('part-1', {
+      url: 'file:///etc/passwd',
+      mime: 'text/plain',
+      filename: 'passwd',
+    });
+
+    expect(fileInstances).toHaveLength(0);
+    expect(getFilePartCacheEntry('part-1')).toBeUndefined();
+  });
 });
 
 describe('isUsableFilePartUrl', () => {
-  it('accepts http, https, data, and file schemes', () => {
+  it('accepts http, https, and data schemes', () => {
     expect(isUsableFilePartUrl('http://example.com/a.png')).toBe(true);
     expect(isUsableFilePartUrl('https://example.com/a.png')).toBe(true);
     expect(isUsableFilePartUrl('data:image/png;base64,AAA')).toBe(true);
-    expect(isUsableFilePartUrl('file:///cache/a.png')).toBe(true);
   });
 
-  it('rejects other schemes', () => {
+  it('rejects file and other schemes', () => {
+    expect(isUsableFilePartUrl('file:///cache/a.png')).toBe(false);
     expect(isUsableFilePartUrl('ftp://example.com/a.png')).toBe(false);
     expect(isUsableFilePartUrl('')).toBe(false);
   });

--- a/apps/mobile/src/components/agents/file-part-cache.test.ts
+++ b/apps/mobile/src/components/agents/file-part-cache.test.ts
@@ -1,7 +1,7 @@
 /* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React trees under vitest (same pattern as src/components/agents/attachment-preview-strip.mounted.test.tsx) */
 import { createElement } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
   __resetFilePartCacheForTests,
@@ -11,7 +11,53 @@ import {
   useFilePartCache,
 } from '@/components/agents/file-part-cache';
 
+type FileInstance = {
+  uri: string;
+  write: ReturnType<typeof vi.fn>;
+  filename: string;
+};
+
+const fileInstances: FileInstance[] = [];
+
+const expoFileSystemMock = vi.hoisted(() => {
+  const directoryCreate = vi.fn();
+  const Directory = vi.fn(function DirectoryMock(_base: unknown, name: string) {
+    return {
+      name,
+      create: directoryCreate,
+    };
+  });
+  const File = vi.fn(function FileMock(_directory: { name?: string }, filename: string) {
+    const instance = {
+      uri: `file:///cache/session-file-parts/${filename}`,
+      write: vi.fn(),
+      filename,
+    };
+    fileInstances.push(instance);
+    return instance;
+  });
+  return {
+    Directory,
+    File,
+    Paths: { cache: 'file:///cache' },
+    directoryCreate,
+  };
+});
+
+vi.mock('expo-file-system', () => ({
+  Directory: expoFileSystemMock.Directory,
+  File: expoFileSystemMock.File,
+  Paths: expoFileSystemMock.Paths,
+}));
+
+vi.mock('@/lib/share-remote-file', () => ({
+  getSafeCacheFilename: ({ id, filename }: { id: string; filename: string }) =>
+    `${id}-${filename.replaceAll(/[^a-zA-Z0-9._-]/g, '_')}`,
+}));
+
 beforeEach(() => {
+  vi.clearAllMocks();
+  fileInstances.length = 0;
   __resetFilePartCacheForTests();
 });
 
@@ -48,17 +94,89 @@ describe('cacheFilePart', () => {
       mime: 'image/png',
     });
   });
+
+  it('writes a data: URL to disk and stores the file:// URI', () => {
+    cacheFilePart('part-1', {
+      url: 'data:application/pdf;base64,QUJD',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+
+    expect(expoFileSystemMock.Directory).toHaveBeenCalledWith(
+      'file:///cache',
+      'session-file-parts'
+    );
+    expect(expoFileSystemMock.directoryCreate).toHaveBeenCalledWith({
+      idempotent: true,
+      intermediates: true,
+    });
+    const file = fileInstances[0];
+    expect(file?.filename).toBe('part-1-report.pdf');
+    expect(file?.write).toHaveBeenCalledWith('QUJD', { encoding: 'base64' });
+    expect(getFilePartCacheEntry('part-1')?.url).toBe(
+      'file:///cache/session-file-parts/part-1-report.pdf'
+    );
+  });
+
+  it('stores an http(s) URL as-is without writing to disk', () => {
+    cacheFilePart('part-1', {
+      url: 'https://example.com/report.pdf',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+
+    expect(fileInstances).toHaveLength(0);
+    expect(getFilePartCacheEntry('part-1')?.url).toBe('https://example.com/report.pdf');
+  });
+
+  it('stores the raw URL when the data: prefix cannot be stripped', () => {
+    cacheFilePart('part-1', {
+      url: 'data:text/plain,hello',
+      mime: 'text/plain',
+      filename: 'note.txt',
+    });
+
+    expect(fileInstances).toHaveLength(0);
+    expect(getFilePartCacheEntry('part-1')?.url).toBe('data:text/plain,hello');
+  });
+
+  it('stores the raw URL when the disk write fails', () => {
+    expoFileSystemMock.File.mockImplementationOnce(function FileFail(
+      _directory: { name?: string },
+      filename: string
+    ) {
+      const instance = {
+        uri: `file:///cache/session-file-parts/${filename}`,
+        write: vi.fn(() => {
+          throw new Error('disk full');
+        }),
+        filename,
+      };
+      fileInstances.push(instance);
+      return instance;
+    });
+
+    expect(() => {
+      cacheFilePart('part-1', {
+        url: 'data:application/pdf;base64,QUJD',
+        mime: 'application/pdf',
+        filename: 'report.pdf',
+      });
+    }).not.toThrow();
+
+    expect(getFilePartCacheEntry('part-1')?.url).toBe('data:application/pdf;base64,QUJD');
+  });
 });
 
 describe('isUsableFilePartUrl', () => {
-  it('accepts http, https, and data schemes', () => {
+  it('accepts http, https, data, and file schemes', () => {
     expect(isUsableFilePartUrl('http://example.com/a.png')).toBe(true);
     expect(isUsableFilePartUrl('https://example.com/a.png')).toBe(true);
     expect(isUsableFilePartUrl('data:image/png;base64,AAA')).toBe(true);
+    expect(isUsableFilePartUrl('file:///cache/a.png')).toBe(true);
   });
 
-  it('rejects file and other schemes', () => {
-    expect(isUsableFilePartUrl('file:///cache/a.png')).toBe(false);
+  it('rejects other schemes', () => {
     expect(isUsableFilePartUrl('ftp://example.com/a.png')).toBe(false);
     expect(isUsableFilePartUrl('')).toBe(false);
   });

--- a/apps/mobile/src/components/agents/file-part-cache.test.ts
+++ b/apps/mobile/src/components/agents/file-part-cache.test.ts
@@ -70,7 +70,7 @@ function Probe({ partId }: { partId: string }) {
 }
 
 function textOf(renderer: TestRenderer.ReactTestRenderer): string | undefined {
-  const node = renderer.root.find(n => typeof n.type === 'string' && n.type === 'Text');
+  const node = renderer.root.find(n => typeof n.type === 'string' && (n.type as string) === 'Text');
   return node.props.children as string | undefined;
 }
 

--- a/apps/mobile/src/components/agents/file-part-cache.test.ts
+++ b/apps/mobile/src/components/agents/file-part-cache.test.ts
@@ -1,0 +1,107 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React trees under vitest (same pattern as src/components/agents/attachment-preview-strip.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  __resetFilePartCacheForTests,
+  cacheFilePart,
+  getFilePartCacheEntry,
+  isUsableFilePartUrl,
+  useFilePartCache,
+} from '@/components/agents/file-part-cache';
+
+beforeEach(() => {
+  __resetFilePartCacheForTests();
+});
+
+describe('cacheFilePart', () => {
+  it('records url, mime, and filename for a part id', () => {
+    cacheFilePart('part-1', {
+      url: 'https://example.com/report.pdf',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+
+    expect(getFilePartCacheEntry('part-1')).toEqual({
+      url: 'https://example.com/report.pdf',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+  });
+
+  it('omits filename when the payload has none', () => {
+    cacheFilePart('part-img', { url: 'https://example.com/a.png', mime: 'image/png' });
+
+    expect(getFilePartCacheEntry('part-img')).toEqual({
+      url: 'https://example.com/a.png',
+      mime: 'image/png',
+    });
+  });
+
+  it('first write wins for a duplicate part id', () => {
+    cacheFilePart('part-dup', { url: 'https://example.com/a.png', mime: 'image/png' });
+    cacheFilePart('part-dup', { url: 'https://example.com/b.png', mime: 'image/png' });
+
+    expect(getFilePartCacheEntry('part-dup')).toEqual({
+      url: 'https://example.com/a.png',
+      mime: 'image/png',
+    });
+  });
+});
+
+describe('isUsableFilePartUrl', () => {
+  it('accepts http, https, and data schemes', () => {
+    expect(isUsableFilePartUrl('http://example.com/a.png')).toBe(true);
+    expect(isUsableFilePartUrl('https://example.com/a.png')).toBe(true);
+    expect(isUsableFilePartUrl('data:image/png;base64,AAA')).toBe(true);
+  });
+
+  it('rejects file and other schemes', () => {
+    expect(isUsableFilePartUrl('file:///cache/a.png')).toBe(false);
+    expect(isUsableFilePartUrl('ftp://example.com/a.png')).toBe(false);
+    expect(isUsableFilePartUrl('')).toBe(false);
+  });
+});
+
+function Probe({ partId }: { partId: string }) {
+  const entry = useFilePartCache(partId);
+  return createElement('Text', null, entry?.url ?? 'none');
+}
+
+function textOf(renderer: TestRenderer.ReactTestRenderer): string | undefined {
+  const node = renderer.root.find(n => typeof n.type === 'string' && n.type === 'Text');
+  return node.props.children as string | undefined;
+}
+
+describe('useFilePartCache', () => {
+  it('re-renders a subscriber when a new part is cached', async () => {
+    const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+    await act(async () => {
+      await Promise.resolve();
+      ref.current = TestRenderer.create(createElement(Probe, { partId: 'p1' }));
+    });
+    const renderer = ref.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+
+    expect(textOf(renderer)).toBe('none');
+
+    await act(async () => {
+      await Promise.resolve();
+      cacheFilePart('p1', { url: 'https://example.com/a.png', mime: 'image/png' });
+    });
+
+    expect(textOf(renderer)).toBe('https://example.com/a.png');
+
+    renderer.unmount();
+  });
+
+  it('reads the same store as getFilePartCacheEntry', () => {
+    expect(typeof useFilePartCache).toBe('function');
+    expect(getFilePartCacheEntry('missing')).toBeUndefined();
+    cacheFilePart('part-hook', { url: 'https://example.com/a.png', mime: 'image/png' });
+    expect(getFilePartCacheEntry('part-hook')?.url).toBe('https://example.com/a.png');
+  });
+});

--- a/apps/mobile/src/components/agents/file-part-cache.ts
+++ b/apps/mobile/src/components/agents/file-part-cache.ts
@@ -1,0 +1,76 @@
+import { useSyncExternalStore } from 'react';
+
+/** A captured FilePart URL, stored in memory only. No bytes are downloaded. */
+export type FilePartCacheEntry = {
+  url: string;
+  mime: string;
+  filename?: string;
+};
+
+/** Reactive map of partId → captured FilePart entry. First write wins. */
+const entriesByPartId = new Map<string, FilePartCacheEntry>();
+const listeners = new Set<() => void>();
+/** Bumped on every map mutation so useSyncExternalStore sees a new snapshot. */
+let entriesVersion = 0;
+
+function emitChange(): void {
+  entriesVersion += 1;
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+function subscribe(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function getVersionSnapshot(): number {
+  return entriesVersion;
+}
+
+/**
+ * Record a captured FilePart URL. Stores the URL string only — never downloads
+ * bytes. First write wins: a later call for the same `partId` is a no-op.
+ */
+export function cacheFilePart(
+  partId: string,
+  payload: Readonly<{ url: string; mime: string; filename?: string }>
+): void {
+  if (entriesByPartId.has(partId)) {
+    return;
+  }
+  entriesByPartId.set(partId, {
+    url: payload.url,
+    mime: payload.mime,
+    ...(payload.filename ? { filename: payload.filename } : {}),
+  });
+  emitChange();
+}
+
+/** Synchronous lookup used by the hook and by tests. */
+export function getFilePartCacheEntry(partId: string): FilePartCacheEntry | undefined {
+  return entriesByPartId.get(partId);
+}
+
+/**
+ * Reactive lookup of a captured FilePart entry. Returns `undefined` until a
+ * write is recorded for `partId`.
+ */
+export function useFilePartCache(partId: string): FilePartCacheEntry | undefined {
+  useSyncExternalStore(subscribe, getVersionSnapshot, getVersionSnapshot);
+  return entriesByPartId.get(partId);
+}
+
+/** True only for `http:`, `https:`, and `data:` URLs. */
+export function isUsableFilePartUrl(url: string): boolean {
+  return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('data:');
+}
+
+/** Test-only: clear in-memory state between cases. */
+export function __resetFilePartCacheForTests(): void {
+  entriesByPartId.clear();
+  emitChange();
+}

--- a/apps/mobile/src/components/agents/file-part-cache.ts
+++ b/apps/mobile/src/components/agents/file-part-cache.ts
@@ -50,7 +50,7 @@ export function cacheFilePart(
   emitChange();
 }
 
-/** Synchronous lookup used by the hook and by tests. */
+/** Synchronous lookup used by tests. */
 export function getFilePartCacheEntry(partId: string): FilePartCacheEntry | undefined {
   return entriesByPartId.get(partId);
 }

--- a/apps/mobile/src/components/agents/file-part-cache.ts
+++ b/apps/mobile/src/components/agents/file-part-cache.ts
@@ -1,6 +1,15 @@
+import { Directory, File, Paths } from 'expo-file-system';
 import { useSyncExternalStore } from 'react';
 
-/** A captured FilePart URL, stored in memory only. No bytes are downloaded. */
+import { getSafeCacheFilename } from '@/lib/share-remote-file';
+
+import { stripDataUrlBase64Prefix } from './tool-card-image-cache';
+
+const CACHE_DIR_NAME = 'session-file-parts';
+
+/** A captured FilePart URL. `data:` URLs are written to disk and stored as a
+ *  small `file://` URI; `http(s)` URLs are stored as-is. No bytes are
+ *  downloaded. */
 export type FilePartCacheEntry = {
   url: string;
   mime: string;
@@ -32,8 +41,39 @@ function getVersionSnapshot(): number {
 }
 
 /**
- * Record a captured FilePart URL. Stores the URL string only — never downloads
- * bytes. First write wins: a later call for the same `partId` is a no-op.
+ * Resolve the URL to store for a captured FilePart. A `data:` URL is written
+ * to disk and stored as a `file://` URI; an `http(s)` URL is stored as-is. On
+ * any decode or write failure the raw URL is stored instead. Never throws.
+ */
+function resolveCacheUrl(
+  partId: string,
+  payload: Readonly<{ url: string; mime: string; filename?: string }>
+): string {
+  if (!payload.url.startsWith('data:')) {
+    return payload.url;
+  }
+  const stripped = stripDataUrlBase64Prefix(payload.url, payload.mime);
+  if (stripped === undefined) {
+    return payload.url;
+  }
+  try {
+    const directory = new Directory(Paths.cache, CACHE_DIR_NAME);
+    directory.create({ idempotent: true, intermediates: true });
+    const file = new File(
+      directory,
+      getSafeCacheFilename({ id: partId, filename: payload.filename ?? 'file' })
+    );
+    file.write(stripped, { encoding: 'base64' });
+    return file.uri;
+  } catch {
+    return payload.url;
+  }
+}
+
+/**
+ * Record a captured FilePart URL. A `data:` URL is written to disk and stored
+ * as a `file://` URI; an `http(s)` URL is stored as-is. Never downloads bytes.
+ * First write wins: a later call for the same `partId` is a no-op.
  */
 export function cacheFilePart(
   partId: string,
@@ -43,7 +83,7 @@ export function cacheFilePart(
     return;
   }
   entriesByPartId.set(partId, {
-    url: payload.url,
+    url: resolveCacheUrl(partId, payload),
     mime: payload.mime,
     ...(payload.filename ? { filename: payload.filename } : {}),
   });
@@ -64,9 +104,14 @@ export function useFilePartCache(partId: string): FilePartCacheEntry | undefined
   return entriesByPartId.get(partId);
 }
 
-/** True only for `http:`, `https:`, and `data:` URLs. */
+/** True only for `http:`, `https:`, `data:`, and `file:` URLs. */
 export function isUsableFilePartUrl(url: string): boolean {
-  return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('data:');
+  return (
+    url.startsWith('http://') ||
+    url.startsWith('https://') ||
+    url.startsWith('data:') ||
+    url.startsWith('file://')
+  );
 }
 
 /** Test-only: clear in-memory state between cases. */

--- a/apps/mobile/src/components/agents/file-part-cache.ts
+++ b/apps/mobile/src/components/agents/file-part-cache.ts
@@ -42,13 +42,17 @@ function getVersionSnapshot(): number {
 
 /**
  * Resolve the URL to store for a captured FilePart. A `data:` URL is written
- * to disk and stored as a `file://` URI; an `http(s)` URL is stored as-is. On
- * any decode or write failure the raw URL is stored instead. Never throws.
+ * to disk and stored as a `file://` URI; an `http(s)` URL is stored as-is. A
+ * transcript `file://` URL is rejected (returns `undefined`). On any decode or
+ * write failure the raw URL is stored instead. Never throws.
  */
 function resolveCacheUrl(
   partId: string,
   payload: Readonly<{ url: string; mime: string; filename?: string }>
-): string {
+): string | undefined {
+  if (payload.url.startsWith('file://')) {
+    return undefined;
+  }
   if (!payload.url.startsWith('data:')) {
     return payload.url;
   }
@@ -82,8 +86,12 @@ export function cacheFilePart(
   if (entriesByPartId.has(partId)) {
     return;
   }
+  const url = resolveCacheUrl(partId, payload);
+  if (url === undefined) {
+    return;
+  }
   entriesByPartId.set(partId, {
-    url: resolveCacheUrl(partId, payload),
+    url,
     mime: payload.mime,
     ...(payload.filename ? { filename: payload.filename } : {}),
   });
@@ -104,14 +112,9 @@ export function useFilePartCache(partId: string): FilePartCacheEntry | undefined
   return entriesByPartId.get(partId);
 }
 
-/** True only for `http:`, `https:`, `data:`, and `file:` URLs. */
+/** True only for `http:`, `https:`, and `data:` URLs. */
 export function isUsableFilePartUrl(url: string): boolean {
-  return (
-    url.startsWith('http://') ||
-    url.startsWith('https://') ||
-    url.startsWith('data:') ||
-    url.startsWith('file://')
-  );
+  return url.startsWith('http://') || url.startsWith('https://') || url.startsWith('data:');
 }
 
 /** Test-only: clear in-memory state between cases. */

--- a/apps/mobile/src/components/agents/file-part-preview.test.ts
+++ b/apps/mobile/src/components/agents/file-part-preview.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  getFilePartAccessibilityLabel,
+  getFilePartKind,
+  isMarkdownFilePart,
+} from './file-part-preview';
+
+describe('isMarkdownFilePart', () => {
+  it('is true for .md and .mdx filenames', () => {
+    expect(isMarkdownFilePart('README.md')).toBe(true);
+    expect(isMarkdownFilePart('docs.mdx')).toBe(true);
+    expect(isMarkdownFilePart('README.MD')).toBe(true);
+  });
+
+  it('is false for non-markdown filenames', () => {
+    expect(isMarkdownFilePart('index.ts')).toBe(false);
+    expect(isMarkdownFilePart('notes.markdown')).toBe(false);
+    expect(isMarkdownFilePart('')).toBe(false);
+  });
+
+  it('is false for undefined', () => {
+    expect(isMarkdownFilePart(undefined)).toBe(false);
+  });
+});
+
+describe('getFilePartKind', () => {
+  it('classifies image by mime regardless of filename', () => {
+    expect(getFilePartKind({ mime: 'image/png', filename: 'photo.png' })).toBe('image');
+    expect(getFilePartKind({ mime: 'image/jpeg' })).toBe('image');
+  });
+
+  it('classifies markdown by .md/.mdx filename when mime is not image', () => {
+    expect(getFilePartKind({ mime: 'text/markdown', filename: 'README.md' })).toBe('markdown');
+    expect(getFilePartKind({ mime: 'application/octet-stream', filename: 'docs.mdx' })).toBe(
+      'markdown'
+    );
+  });
+
+  it('classifies other when neither image nor markdown', () => {
+    expect(getFilePartKind({ mime: 'text/plain', filename: 'index.ts' })).toBe('other');
+    expect(getFilePartKind({ mime: 'application/pdf' })).toBe('other');
+  });
+
+  it('prefers image over markdown when mime is image and filename is markdown', () => {
+    expect(getFilePartKind({ mime: 'image/svg+xml', filename: 'diagram.md' })).toBe('image');
+  });
+});
+
+describe('getFilePartAccessibilityLabel', () => {
+  it('labels image with full screen', () => {
+    expect(getFilePartAccessibilityLabel('image', 'photo.png')).toBe('Open photo.png full screen');
+  });
+
+  it('labels markdown with preview', () => {
+    expect(getFilePartAccessibilityLabel('markdown', 'README.md')).toBe('Preview README.md');
+  });
+
+  it('labels other with open', () => {
+    expect(getFilePartAccessibilityLabel('other', 'index.ts')).toBe('Open index.ts');
+  });
+
+  it('falls back to File when filename is undefined', () => {
+    expect(getFilePartAccessibilityLabel('image', undefined)).toBe('Open File full screen');
+    expect(getFilePartAccessibilityLabel('markdown', undefined)).toBe('Preview File');
+    expect(getFilePartAccessibilityLabel('other', undefined)).toBe('Open File');
+  });
+
+  it('falls back to File when filename is blank', () => {
+    expect(getFilePartAccessibilityLabel('other', '')).toBe('Open File');
+    expect(getFilePartAccessibilityLabel('other', '   ')).toBe('Open File');
+  });
+});

--- a/apps/mobile/src/components/agents/file-part-preview.ts
+++ b/apps/mobile/src/components/agents/file-part-preview.ts
@@ -1,0 +1,32 @@
+import { isMarkdownPath } from './read-tool-markdown';
+
+export type FilePartKind = 'image' | 'markdown' | 'other';
+
+export function isMarkdownFilePart(filename: string | undefined): boolean {
+  return isMarkdownPath(filename ?? '');
+}
+
+export function getFilePartKind(input: { mime: string; filename?: string }): FilePartKind {
+  if (input.mime.startsWith('image/')) {
+    return 'image';
+  }
+  if (isMarkdownFilePart(input.filename)) {
+    return 'markdown';
+  }
+  return 'other';
+}
+
+function resolveName(filename: string | undefined): string {
+  return filename && filename.trim() !== '' ? filename : 'File';
+}
+
+export function getFilePartAccessibilityLabel(kind: FilePartKind, filename?: string): string {
+  const name = resolveName(filename);
+  if (kind === 'image') {
+    return `Open ${name} full screen`;
+  }
+  if (kind === 'markdown') {
+    return `Preview ${name}`;
+  }
+  return `Open ${name}`;
+}

--- a/apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx
@@ -347,7 +347,7 @@ describe('FilePartRenderer mounted', () => {
     await unmount(renderer);
   });
 
-  it('shares a data: URL via shareLocalFile for "Open in external app"', async () => {
+  it('shares a captured data: URL as a file:// URI via shareLocalFile for "Open in external app"', async () => {
     cacheFilePart('part-1', {
       url: 'data:application/pdf;base64,QUJD',
       mime: 'application/pdf',
@@ -367,6 +367,55 @@ describe('FilePartRenderer mounted', () => {
       'file:///cache/session-file-parts/part-1-report.pdf',
       { mimeType: 'application/pdf' }
     );
+
+    await unmount(renderer);
+  });
+
+  it('resolves a file:// URL for text preview without re-downloading', async () => {
+    expoFileSystemMock.fileText.mockResolvedValue('# Hello');
+    cacheFilePart('part-1', {
+      url: 'file:///cache/session-file-parts/part-1-readme.md',
+      mime: 'text/markdown',
+      filename: 'readme.md',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'text/markdown', filename: 'readme.md', url: '' })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Preview readme.md')));
+    await flushAsync();
+
+    const markdown = findByType(root, 'ChatMarkdownText');
+    expect(markdown).toHaveLength(1);
+    expect(markdown[0]?.props.value).toBe('# Hello');
+    expect(shareRemoteFileMock.downloadRemoteFile).not.toHaveBeenCalled();
+
+    await unmount(renderer);
+  });
+
+  it('shares a file:// URL via shareLocalFile without re-downloading', async () => {
+    cacheFilePart('part-1', {
+      url: 'file:///cache/session-file-parts/part-1-report.pdf',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'application/pdf', filename: 'report.pdf', url: '' })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Open report.pdf')));
+    await selectActionSheet(1);
+    await flushAsync();
+
+    expect(shareRemoteFileMock.shareLocalFile).toHaveBeenCalledTimes(1);
+    expect(shareRemoteFileMock.shareLocalFile).toHaveBeenCalledWith(
+      'file:///cache/session-file-parts/part-1-report.pdf',
+      { mimeType: 'application/pdf' }
+    );
+    expect(shareRemoteFileMock.shareRemoteFile).not.toHaveBeenCalled();
+    expect(shareRemoteFileMock.downloadRemoteFile).not.toHaveBeenCalled();
 
     await unmount(renderer);
   });

--- a/apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx
@@ -371,10 +371,10 @@ describe('FilePartRenderer mounted', () => {
     await unmount(renderer);
   });
 
-  it('resolves a file:// URL for text preview without re-downloading', async () => {
+  it('resolves a cached file:// URI (from a data: write) for text preview without re-downloading', async () => {
     expoFileSystemMock.fileText.mockResolvedValue('# Hello');
     cacheFilePart('part-1', {
-      url: 'file:///cache/session-file-parts/part-1-readme.md',
+      url: 'data:text/markdown;base64,QUJD',
       mime: 'text/markdown',
       filename: 'readme.md',
     });
@@ -394,9 +394,9 @@ describe('FilePartRenderer mounted', () => {
     await unmount(renderer);
   });
 
-  it('shares a file:// URL via shareLocalFile without re-downloading', async () => {
+  it('shares a cached file:// URI (from a data: write) via shareLocalFile without re-downloading', async () => {
     cacheFilePart('part-1', {
-      url: 'file:///cache/session-file-parts/part-1-report.pdf',
+      url: 'data:application/pdf;base64,QUJD',
       mime: 'application/pdf',
       filename: 'report.pdf',
     });
@@ -416,6 +416,42 @@ describe('FilePartRenderer mounted', () => {
     );
     expect(shareRemoteFileMock.shareRemoteFile).not.toHaveBeenCalled();
     expect(shareRemoteFileMock.downloadRemoteFile).not.toHaveBeenCalled();
+
+    await unmount(renderer);
+  });
+
+  it('shows an unavailable row for an uncached file:// part.url', async () => {
+    const renderer = await mount(
+      makeFilePart({
+        id: 'part-1',
+        mime: 'image/png',
+        filename: 'shot.png',
+        url: 'file:///etc/passwd',
+      })
+    );
+    const root = renderer.root;
+
+    expect(pressableByLabel(root, 'Open shot.png full screen')).toHaveLength(0);
+    expect(texts(root)).toContain('Image unavailable');
+
+    await unmount(renderer);
+  });
+
+  it('toasts "Preview unavailable" for an uncached file:// part.url chip', async () => {
+    const renderer = await mount(
+      makeFilePart({
+        id: 'part-1',
+        mime: 'application/pdf',
+        filename: 'report.pdf',
+        url: 'file:///etc/passwd',
+      })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Open report.pdf')));
+
+    expect(toastMock.error).toHaveBeenCalledWith('Preview unavailable');
+    expect(showActionSheetWithOptions).not.toHaveBeenCalled();
 
     await unmount(renderer);
   });

--- a/apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.mounted.test.tsx
@@ -1,0 +1,512 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/test/render-with-providers.tsx) */
+/* eslint-disable max-lines -- cohesive mounted suite: all FilePart tap/preview/share states share one harness */
+import { type FilePart } from '@kilocode/cloud-agent-sdk';
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { FilePartRenderer } from './file-part-renderer';
+import { __resetFilePartCacheForTests, cacheFilePart } from './file-part-cache';
+
+type FileInstance = {
+  uri: string;
+  write: ReturnType<typeof vi.fn>;
+  text: ReturnType<typeof vi.fn>;
+  filename?: string;
+};
+
+const fileInstances: FileInstance[] = [];
+
+const expoFileSystemMock = vi.hoisted(() => {
+  const directoryCreate = vi.fn();
+  const fileText = vi.fn();
+  const Directory = vi.fn(function DirectoryMock(_base: unknown, name: string) {
+    return {
+      name,
+      create: directoryCreate,
+    };
+  });
+  const File = vi.fn(function FileMock(directoryOrUri: unknown, filename?: string) {
+    const instance = {
+      uri:
+        typeof directoryOrUri === 'string'
+          ? directoryOrUri
+          : `file:///cache/session-file-parts/${filename}`,
+      write: vi.fn(),
+      text: fileText,
+      filename,
+    };
+    fileInstances.push(instance);
+    return instance;
+  });
+  return {
+    Directory,
+    File,
+    Paths: { cache: 'file:///cache' },
+    directoryCreate,
+    fileText,
+  };
+});
+
+vi.mock('expo-file-system', () => ({
+  Directory: expoFileSystemMock.Directory,
+  File: expoFileSystemMock.File,
+  Paths: expoFileSystemMock.Paths,
+}));
+
+const shareRemoteFileMock = vi.hoisted(() => ({
+  downloadRemoteFile: vi.fn(),
+  getSafeCacheFilename: vi.fn(),
+  getShareRemoteFileReason: vi.fn(),
+  shareLocalFile: vi.fn(),
+  shareRemoteFile: vi.fn(),
+}));
+
+vi.mock('@/lib/share-remote-file', () => ({
+  downloadRemoteFile: shareRemoteFileMock.downloadRemoteFile,
+  getSafeCacheFilename: shareRemoteFileMock.getSafeCacheFilename,
+  getShareRemoteFileReason: shareRemoteFileMock.getShareRemoteFileReason,
+  ShareRemoteFileError: class ShareRemoteFileErrorMock extends Error {},
+  shareLocalFile: shareRemoteFileMock.shareLocalFile,
+  shareRemoteFile: shareRemoteFileMock.shareRemoteFile,
+}));
+
+const showActionSheetWithOptions = vi.hoisted(() => vi.fn());
+
+vi.mock('@expo/react-native-action-sheet', () => ({
+  useActionSheet: () => ({ showActionSheetWithOptions }),
+}));
+
+const toastMock = vi.hoisted(() => ({
+  error: vi.fn(),
+  success: vi.fn(),
+}));
+
+vi.mock('sonner-native', () => ({ toast: toastMock }));
+
+vi.mock('react-native', () => ({
+  ActivityIndicator: 'ActivityIndicator',
+  Modal: 'Modal',
+  Pressable: 'Pressable',
+  ScrollView: 'ScrollView',
+  View: 'View',
+}));
+vi.mock('@/components/ui/icons', () => ({ AlertCircle: 'AlertCircle', File: 'File' }));
+vi.mock('@/components/image-viewer-modal', () => ({ ImageViewerModal: 'ImageViewerModal' }));
+vi.mock('@/components/sheet-header', () => ({ SheetHeader: 'SheetHeader' }));
+vi.mock('@/components/ui/image', () => ({ Image: 'Image' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({ mutedForeground: '#666666' }),
+}));
+vi.mock('./chat-markdown-text', () => ({ ChatMarkdownText: 'ChatMarkdownText' }));
+
+function makeFilePart(input: {
+  id: string;
+  mime: string;
+  filename?: string;
+  url: string;
+}): FilePart {
+  return {
+    id: input.id,
+    sessionID: 'session-1',
+    messageID: 'message-1',
+    type: 'file',
+    mime: input.mime,
+    url: input.url,
+    ...(input.filename ? { filename: input.filename } : {}),
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  fileInstances.length = 0;
+  __resetFilePartCacheForTests();
+  expoFileSystemMock.fileText.mockReset();
+  shareRemoteFileMock.getSafeCacheFilename.mockImplementation(
+    ({ id, filename }: { id: string; filename: string }) => `${id}-${filename}`
+  );
+  shareRemoteFileMock.getShareRemoteFileReason.mockReturnValue(null);
+  shareRemoteFileMock.shareLocalFile.mockResolvedValue(undefined);
+  shareRemoteFileMock.shareRemoteFile.mockResolvedValue(undefined);
+  shareRemoteFileMock.downloadRemoteFile.mockImplementation(
+    ({ cacheFilename }: { cacheFilename: string }) => ({
+      uri: `file:///cache/session-file-parts/${cacheFilename}`,
+      delete: vi.fn(),
+    })
+  );
+});
+
+async function mount(part: FilePart): Promise<TestRenderer.ReactTestRenderer> {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  await act(async () => {
+    await Promise.resolve();
+    ref.current = TestRenderer.create(createElement(FilePartRenderer, { part }));
+  });
+  const renderer = ref.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+async function unmount(renderer: TestRenderer.ReactTestRenderer): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    renderer.unmount();
+  });
+}
+
+async function press(node: TestRenderer.ReactTestInstance): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    (node.props.onPress as () => void)();
+  });
+}
+
+async function flushAsync(): Promise<void> {
+  await act(async () => {
+    await new Promise<void>(resolve => {
+      setTimeout(resolve, 0);
+    });
+  });
+}
+
+function findByType(
+  root: TestRenderer.ReactTestInstance,
+  type: string
+): TestRenderer.ReactTestInstance[] {
+  return root.findAll(node => typeof node.type === 'string' && (node.type as string) === type);
+}
+
+function pressableByLabel(
+  root: TestRenderer.ReactTestInstance,
+  label: string
+): TestRenderer.ReactTestInstance[] {
+  return root.findAll(
+    node =>
+      typeof node.type === 'string' &&
+      (node.type as string) === 'Pressable' &&
+      node.props.accessibilityLabel === label
+  );
+}
+
+function texts(root: TestRenderer.ReactTestInstance): string[] {
+  return root
+    .findAll(node => typeof node.type === 'string' && (node.type as string) === 'Text')
+    .map(node => {
+      const children = node.props.children;
+      if (Array.isArray(children)) {
+        return children.join('');
+      }
+      return String(children ?? '');
+    });
+}
+
+function first(nodes: TestRenderer.ReactTestInstance[]): TestRenderer.ReactTestInstance {
+  const node = nodes[0];
+  if (!node) {
+    throw new Error('expected node not found');
+  }
+  return node;
+}
+
+function actionSheetCallback(): (index?: number) => void {
+  const call = showActionSheetWithOptions.mock.calls[0];
+  if (!call) {
+    throw new Error('action sheet was not shown');
+  }
+  return call[1] as (index?: number) => void;
+}
+
+async function selectActionSheet(index: number): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    actionSheetCallback()(index);
+  });
+}
+
+describe('FilePartRenderer mounted', () => {
+  it('opens the full-screen viewer when an image FilePart is tapped', async () => {
+    cacheFilePart('part-1', { url: 'https://x/a.png', mime: 'image/png', filename: 'shot.png' });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'image/png', filename: 'shot.png', url: '' })
+    );
+    const root = renderer.root;
+
+    const buttons = pressableByLabel(root, 'Open shot.png full screen');
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]?.props.accessibilityRole).toBe('button');
+    expect(findByType(root, 'ImageViewerModal')).toHaveLength(0);
+
+    await press(first(buttons));
+
+    const viewers = findByType(root, 'ImageViewerModal');
+    expect(viewers).toHaveLength(1);
+    expect(viewers[0]?.props).toMatchObject({ visible: true, uri: 'https://x/a.png' });
+
+    await unmount(renderer);
+  });
+
+  it('swaps the thumbnail to a retry row after the image reports an error', async () => {
+    cacheFilePart('part-1', { url: 'https://x/a.png', mime: 'image/png', filename: 'shot.png' });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'image/png', filename: 'shot.png', url: '' })
+    );
+    const root = renderer.root;
+
+    const image = findByType(root, 'Image')[0];
+    if (!image) {
+      throw new Error('image not found');
+    }
+    await act(async () => {
+      await Promise.resolve();
+      (image.props.onError as () => void)();
+    });
+
+    expect(pressableByLabel(root, 'Open shot.png full screen')).toHaveLength(0);
+    expect(pressableByLabel(root, 'Image unavailable, retry loading')).toHaveLength(1);
+    expect(texts(root)).toContain('Image unavailable');
+
+    await unmount(renderer);
+  });
+
+  it('previews a markdown FilePart with the decoded text', async () => {
+    expoFileSystemMock.fileText.mockResolvedValue('# Hello');
+    cacheFilePart('part-1', {
+      url: 'data:text/markdown;base64,QUJD',
+      mime: 'text/markdown',
+      filename: 'readme.md',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'text/markdown', filename: 'readme.md', url: '' })
+    );
+    const root = renderer.root;
+
+    const buttons = pressableByLabel(root, 'Preview readme.md');
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]?.props.accessibilityRole).toBe('button');
+
+    await press(first(buttons));
+    await flushAsync();
+
+    const markdown = findByType(root, 'ChatMarkdownText');
+    expect(markdown).toHaveLength(1);
+    expect(markdown[0]?.props.value).toBe('# Hello');
+
+    await unmount(renderer);
+  });
+
+  it('shows the ActionSheet when a non-image, non-markdown FilePart is tapped', async () => {
+    cacheFilePart('part-1', {
+      url: 'data:application/pdf;base64,QUJD',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'application/pdf', filename: 'report.pdf', url: '' })
+    );
+    const root = renderer.root;
+
+    const buttons = pressableByLabel(root, 'Open report.pdf');
+    expect(buttons).toHaveLength(1);
+    expect(buttons[0]?.props.accessibilityRole).toBe('button');
+
+    await press(first(buttons));
+
+    expect(showActionSheetWithOptions).toHaveBeenCalledTimes(1);
+    const options = showActionSheetWithOptions.mock.calls[0]?.[0] as {
+      options: string[];
+      cancelButtonIndex: number;
+    };
+    expect(options.options).toEqual(['Open as text', 'Open in external app', 'Cancel']);
+    expect(options.cancelButtonIndex).toBe(2);
+
+    await unmount(renderer);
+  });
+
+  it('opens the text modal for "Open as text"', async () => {
+    expoFileSystemMock.fileText.mockResolvedValue('plain text body');
+    cacheFilePart('part-1', {
+      url: 'data:application/pdf;base64,QUJD',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'application/pdf', filename: 'report.pdf', url: '' })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Open report.pdf')));
+    await selectActionSheet(0);
+    await flushAsync();
+
+    expect(texts(root)).toContain('plain text body');
+    expect(findByType(root, 'ChatMarkdownText')).toHaveLength(0);
+
+    await unmount(renderer);
+  });
+
+  it('shares a data: URL via shareLocalFile for "Open in external app"', async () => {
+    cacheFilePart('part-1', {
+      url: 'data:application/pdf;base64,QUJD',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'application/pdf', filename: 'report.pdf', url: '' })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Open report.pdf')));
+    await selectActionSheet(1);
+    await flushAsync();
+
+    expect(shareRemoteFileMock.shareLocalFile).toHaveBeenCalledTimes(1);
+    expect(shareRemoteFileMock.shareLocalFile).toHaveBeenCalledWith(
+      'file:///cache/session-file-parts/part-1-report.pdf',
+      { mimeType: 'application/pdf' }
+    );
+
+    await unmount(renderer);
+  });
+
+  it('shares an http(s) URL via shareRemoteFile for "Open in external app"', async () => {
+    cacheFilePart('part-1', {
+      url: 'https://x/report.pdf',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'application/pdf', filename: 'report.pdf', url: '' })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Open report.pdf')));
+    await selectActionSheet(1);
+    await flushAsync();
+
+    expect(shareRemoteFileMock.shareRemoteFile).toHaveBeenCalledTimes(1);
+    expect(shareRemoteFileMock.shareRemoteFile).toHaveBeenCalledWith({
+      url: 'https://x/report.pdf',
+      cacheDirectoryName: 'session-file-parts',
+      cacheKey: 'part-1',
+      filename: 'report.pdf',
+    });
+
+    await unmount(renderer);
+  });
+
+  it('shows a loading indicator while the markdown text resolves', async () => {
+    expoFileSystemMock.fileText.mockReturnValue(new Promise<string>(() => undefined));
+    cacheFilePart('part-1', {
+      url: 'data:text/markdown;base64,QUJD',
+      mime: 'text/markdown',
+      filename: 'readme.md',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'text/markdown', filename: 'readme.md', url: '' })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Preview readme.md')));
+
+    expect(findByType(root, 'ActivityIndicator')).toHaveLength(1);
+
+    await unmount(renderer);
+  });
+
+  it('shows "This file is empty." for empty decoded text', async () => {
+    expoFileSystemMock.fileText.mockResolvedValue('');
+    cacheFilePart('part-1', {
+      url: 'data:text/markdown;base64,QUJD',
+      mime: 'text/markdown',
+      filename: 'readme.md',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'text/markdown', filename: 'readme.md', url: '' })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Preview readme.md')));
+    await flushAsync();
+
+    expect(texts(root)).toContain('This file is empty.');
+
+    await unmount(renderer);
+  });
+
+  it('shows an error and retry when the text fails to load', async () => {
+    expoFileSystemMock.fileText.mockRejectedValue(new Error('boom'));
+    cacheFilePart('part-1', {
+      url: 'data:text/markdown;base64,QUJD',
+      mime: 'text/markdown',
+      filename: 'readme.md',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'text/markdown', filename: 'readme.md', url: '' })
+    );
+    const root = renderer.root;
+
+    await press(first(pressableByLabel(root, 'Preview readme.md')));
+    await flushAsync();
+
+    expect(texts(root)).toContain('Could not load this file.');
+    expect(pressableByLabel(root, 'Retry loading file')).toHaveLength(1);
+
+    await unmount(renderer);
+  });
+
+  it('shows an unavailable row for an image with no usable URL', async () => {
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'image/png', filename: 'shot.png', url: '' })
+    );
+    const root = renderer.root;
+
+    expect(pressableByLabel(root, 'Open shot.png full screen')).toHaveLength(0);
+    expect(texts(root)).toContain('Image unavailable');
+
+    await unmount(renderer);
+  });
+
+  it('toasts "Preview unavailable" when a chip has no usable URL', async () => {
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'application/pdf', filename: 'report.pdf', url: '' })
+    );
+    const root = renderer.root;
+
+    const buttons = pressableByLabel(root, 'Open report.pdf');
+    expect(buttons).toHaveLength(1);
+
+    await press(first(buttons));
+
+    expect(toastMock.error).toHaveBeenCalledWith('Preview unavailable');
+    expect(showActionSheetWithOptions).not.toHaveBeenCalled();
+    expect(findByType(root, 'Modal')).toHaveLength(0);
+
+    await unmount(renderer);
+  });
+
+  it('toasts when sharing is unavailable on the device', async () => {
+    cacheFilePart('part-1', {
+      url: 'data:application/pdf;base64,QUJD',
+      mime: 'application/pdf',
+      filename: 'report.pdf',
+    });
+    const renderer = await mount(
+      makeFilePart({ id: 'part-1', mime: 'application/pdf', filename: 'report.pdf', url: '' })
+    );
+    const root = renderer.root;
+
+    shareRemoteFileMock.shareLocalFile.mockRejectedValueOnce(new Error('boom'));
+    shareRemoteFileMock.getShareRemoteFileReason.mockReturnValueOnce('sharing-unavailable');
+
+    await press(first(pressableByLabel(root, 'Open report.pdf')));
+    await selectActionSheet(1);
+    await flushAsync();
+
+    expect(toastMock.error).toHaveBeenCalledWith('File sharing is not available on this device.');
+
+    await unmount(renderer);
+  });
+});

--- a/apps/mobile/src/components/agents/file-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable max-lines -- cohesive renderer: image viewer, preview modal, and file:///data:/http(s) resolve+share paths share one component */
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { type FilePart } from '@kilocode/cloud-agent-sdk';
 import { Directory, File, Paths } from 'expo-file-system';
@@ -46,6 +47,10 @@ function writeDataUrlToCache(url: string, part: Pick<FilePart, 'id' | 'mime' | '
 
 /** Resolve the file text for a preview, keeping the file for a later share. */
 async function resolveFileText(url: string, part: Pick<FilePart, 'id' | 'mime' | 'filename'>) {
+  if (url.startsWith('file://')) {
+    return new File(url).text();
+  }
+
   if (url.startsWith('data:')) {
     const file = writeDataUrlToCache(url, part);
     return file.text();
@@ -66,6 +71,10 @@ async function resolveFileText(url: string, part: Pick<FilePart, 'id' | 'mime' |
 
 /** Share a FilePart, materializing a `data:` URL or downloading an `http(s)` URL. */
 async function shareFilePart(url: string, part: FilePart): Promise<void> {
+  if (url.startsWith('file://')) {
+    await shareLocalFile(url, { mimeType: part.mime });
+    return;
+  }
   if (url.startsWith('data:')) {
     const file = writeDataUrlToCache(url, part);
     await shareLocalFile(file.uri, { mimeType: part.mime });

--- a/apps/mobile/src/components/agents/file-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.tsx
@@ -1,46 +1,326 @@
-import { View } from 'react-native';
-import { File as FileIcon } from '@/components/ui/icons';
+import { useActionSheet } from '@expo/react-native-action-sheet';
 import { type FilePart } from '@kilocode/cloud-agent-sdk';
+import { Directory, File, Paths } from 'expo-file-system';
+import { useEffect, useState } from 'react';
+import { ActivityIndicator, Modal, Pressable, ScrollView, View } from 'react-native';
+import { toast } from 'sonner-native';
 
+import { ImageViewerModal } from '@/components/image-viewer-modal';
+import { SheetHeader } from '@/components/sheet-header';
+import { AlertCircle, File as FileIcon } from '@/components/ui/icons';
 import { Image } from '@/components/ui/image';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import {
+  downloadRemoteFile,
+  getSafeCacheFilename,
+  getShareRemoteFileReason,
+  shareLocalFile,
+  shareRemoteFile,
+  ShareRemoteFileError,
+} from '@/lib/share-remote-file';
+
+import { ChatMarkdownText } from './chat-markdown-text';
+import { isUsableFilePartUrl, useFilePartCache } from './file-part-cache';
+import { getFilePartAccessibilityLabel, getFilePartKind } from './file-part-preview';
+import { stripDataUrlBase64Prefix } from './tool-card-image-cache';
+
+const CACHE_DIR_NAME = 'session-file-parts';
+
+function cacheFilenameForPart(part: FilePart): string {
+  return getSafeCacheFilename({ id: part.id, filename: part.filename ?? 'file' });
+}
+
+/** Write a base64 `data:` payload to the cache and return the file. */
+function writeDataUrlToCache(url: string, part: FilePart): File {
+  const payload = stripDataUrlBase64Prefix(url, part.mime);
+  if (payload === undefined) {
+    throw new Error('decode-failed');
+  }
+  const directory = new Directory(Paths.cache, CACHE_DIR_NAME);
+  directory.create({ idempotent: true, intermediates: true });
+  const file = new File(directory, cacheFilenameForPart(part));
+  file.write(payload, { encoding: 'base64' });
+  return file;
+}
+
+/** Resolve the file text for a preview, keeping the file for a later share. */
+async function resolveFileText(url: string, part: FilePart): Promise<string> {
+  if (url.startsWith('data:')) {
+    const file = writeDataUrlToCache(url, part);
+    return file.text();
+  }
+
+  const local = await downloadRemoteFile({
+    url,
+    cacheDirectoryName: CACHE_DIR_NAME,
+    cacheFilename: cacheFilenameForPart(part),
+  });
+  try {
+    return await new File(local.uri).text();
+  } catch (error) {
+    local.delete();
+    throw error;
+  }
+}
+
+/** Share a FilePart, materializing a `data:` URL or downloading an `http(s)` URL. */
+async function shareFilePart(url: string, part: FilePart): Promise<void> {
+  if (url.startsWith('data:')) {
+    const file = writeDataUrlToCache(url, part);
+    await shareLocalFile(file.uri, { mimeType: part.mime });
+    return;
+  }
+  await shareRemoteFile({
+    url,
+    cacheDirectoryName: CACHE_DIR_NAME,
+    cacheKey: part.id,
+    filename: part.filename ?? 'file',
+  });
+}
 
 type FilePartRendererProps = {
   part: FilePart;
 };
 
+type PreviewMode = 'markdown' | 'text';
+
+/** Prefer the captured cache URL, falling back to the part's own URL. */
+function resolveUsableUrl(cachedUrl: string | undefined, partUrl: string): string | undefined {
+  if (cachedUrl && isUsableFilePartUrl(cachedUrl)) {
+    return cachedUrl;
+  }
+  if (isUsableFilePartUrl(partUrl)) {
+    return partUrl;
+  }
+  return undefined;
+}
+
 export function FilePartRenderer({ part }: Readonly<FilePartRendererProps>) {
   const colors = useThemeColors();
-  const isImage = part.mime.startsWith('image/');
+  const { showActionSheetWithOptions } = useActionSheet();
 
-  if (isImage && part.url) {
+  const cached = useFilePartCache(part.id);
+  const url = resolveUsableUrl(cached?.url, part.url);
+  const kind = getFilePartKind({ mime: part.mime, filename: part.filename });
+
+  const [viewerVisible, setViewerVisible] = useState(false);
+  const [imageFailed, setImageFailed] = useState(false);
+  const [preview, setPreview] = useState<PreviewMode | null>(null);
+  const [sharing, setSharing] = useState(false);
+
+  async function handleShare() {
+    if (!url) {
+      return;
+    }
+    setSharing(true);
+    try {
+      await shareFilePart(url, part);
+    } catch (error: unknown) {
+      const reason = getShareRemoteFileReason(error);
+      if (reason === 'sharing-unavailable') {
+        toast.error('File sharing is not available on this device.');
+      } else if (error instanceof ShareRemoteFileError) {
+        toast.error('Failed to share file. Please try again.');
+      } else {
+        toast.error('Share failed');
+      }
+    } finally {
+      setSharing(false);
+    }
+  }
+
+  function handleChipTap() {
+    if (!url) {
+      toast.error('Preview unavailable');
+      return;
+    }
+    if (kind === 'markdown') {
+      setPreview('markdown');
+      return;
+    }
+    showActionSheetWithOptions(
+      {
+        options: ['Open as text', 'Open in external app', 'Cancel'],
+        cancelButtonIndex: 2,
+      },
+      index => {
+        if (index === undefined || index === 2) {
+          return;
+        }
+        if (index === 0) {
+          setPreview('text');
+        } else if (index === 1) {
+          void handleShare();
+        }
+      }
+    );
+  }
+
+  if (kind === 'image') {
+    if (url) {
+      if (imageFailed) {
+        return (
+          <Pressable
+            onPress={() => {
+              setImageFailed(false);
+            }}
+            className="my-1 flex-row items-center gap-2 rounded-md bg-neutral-100 px-3 py-2 dark:bg-neutral-900"
+            accessibilityRole="button"
+            accessibilityLabel="Image unavailable, retry loading"
+          >
+            <AlertCircle size={14} color={colors.mutedForeground} />
+            <Text className="text-xs text-muted-foreground">Image unavailable</Text>
+          </Pressable>
+        );
+      }
+      return (
+        <>
+          <Pressable
+            onPress={() => {
+              setViewerVisible(true);
+            }}
+            className="my-1 overflow-hidden rounded-lg active:opacity-80"
+            accessibilityRole="button"
+            accessibilityLabel={getFilePartAccessibilityLabel('image', part.filename)}
+          >
+            <Image
+              source={{ uri: url }}
+              className="aspect-video w-full"
+              contentFit="contain"
+              accessible
+              accessibilityRole="image"
+              accessibilityLabel={part.filename ? `Image output, ${part.filename}` : 'Image output'}
+              onError={() => {
+                setImageFailed(true);
+              }}
+            />
+            {part.filename ? (
+              <Text className="mt-1 text-xs text-muted-foreground">{part.filename}</Text>
+            ) : null}
+          </Pressable>
+          {viewerVisible && (
+            <ImageViewerModal
+              visible={viewerVisible}
+              uri={url}
+              filename={part.filename ?? 'File'}
+              onClose={() => {
+                setViewerVisible(false);
+              }}
+            />
+          )}
+        </>
+      );
+    }
     return (
-      <View className="my-1 overflow-hidden rounded-lg">
-        {/* An agent's image output carries meaning, so it is labeled rather
-            than decorative. `accessible` is required: expo-image defaults it
-            to false, so `alt` alone leaves the image unreachable. */}
-        <Image
-          source={{ uri: part.url }}
-          className="aspect-video w-full"
-          contentFit="contain"
-          accessible
-          accessibilityRole="image"
-          accessibilityLabel={part.filename ? `Image output, ${part.filename}` : 'Image output'}
-        />
-        {part.filename ? (
-          <Text className="mt-1 text-xs text-muted-foreground">{part.filename}</Text>
-        ) : null}
+      <View className="my-1 flex-row items-center gap-2 rounded-md bg-neutral-100 px-3 py-2 dark:bg-neutral-900">
+        <AlertCircle size={14} color={colors.mutedForeground} />
+        <Text className="text-xs text-muted-foreground">Image unavailable</Text>
       </View>
     );
   }
 
   return (
-    <View className="my-1 flex-row items-center gap-2 rounded-lg bg-neutral-100 px-3 py-2 dark:bg-neutral-900">
-      <FileIcon size={14} color={colors.mutedForeground} />
-      <Text className="text-sm text-muted-foreground" numberOfLines={1}>
-        {part.filename ?? 'File'}
-      </Text>
-    </View>
+    <>
+      <Pressable
+        onPress={handleChipTap}
+        disabled={sharing}
+        accessibilityState={{ busy: sharing }}
+        accessibilityRole="button"
+        accessibilityLabel={getFilePartAccessibilityLabel(kind, part.filename)}
+        className="my-1 flex-row items-center gap-2 rounded-lg bg-neutral-100 px-3 py-2 active:opacity-80 dark:bg-neutral-900"
+      >
+        {sharing ? <ActivityIndicator /> : <FileIcon size={14} color={colors.mutedForeground} />}
+        <Text className="text-sm text-muted-foreground" numberOfLines={1}>
+          {part.filename ?? 'File'}
+        </Text>
+      </Pressable>
+      {preview && url ? (
+        <FilePreviewModal
+          mode={preview}
+          url={url}
+          part={part}
+          onClose={() => {
+            setPreview(null);
+          }}
+        />
+      ) : null}
+    </>
+  );
+}
+
+type FilePreviewModalProps = {
+  mode: PreviewMode;
+  url: string;
+  part: FilePart;
+  onClose: () => void;
+};
+
+function FilePreviewModal({ mode, url, part, onClose }: Readonly<FilePreviewModalProps>) {
+  const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
+  const [text, setText] = useState('');
+  const [attempt, setAttempt] = useState(0);
+
+  useEffect(() => {
+    let cancelled = false;
+    setStatus('loading');
+    async function load() {
+      try {
+        const resolved = await resolveFileText(url, part);
+        if (cancelled) {
+          return;
+        }
+        setText(resolved);
+        setStatus('ready');
+      } catch {
+        if (cancelled) {
+          return;
+        }
+        setStatus('error');
+      }
+    }
+    void load();
+    return () => {
+      cancelled = true;
+    };
+  }, [url, part, attempt]);
+
+  function renderBody() {
+    if (status === 'loading') {
+      return <ActivityIndicator />;
+    }
+    if (status === 'error') {
+      return (
+        <View className="gap-3">
+          <Text className="text-sm text-muted-foreground">Could not load this file.</Text>
+          <Pressable
+            onPress={() => {
+              setAttempt(prev => prev + 1);
+            }}
+            accessibilityRole="button"
+            accessibilityLabel="Retry loading file"
+            className="rounded-md border border-border px-4 py-2 active:opacity-70"
+          >
+            <Text className="text-center text-sm font-medium text-foreground">Retry</Text>
+          </Pressable>
+        </View>
+      );
+    }
+    if (text === '') {
+      return <Text className="text-xs text-muted-foreground">This file is empty.</Text>;
+    }
+    if (mode === 'markdown') {
+      return <ChatMarkdownText value={text} />;
+    }
+    return <Text className="text-sm text-foreground">{text}</Text>;
+  }
+
+  return (
+    <Modal visible animationType="slide" presentationStyle="pageSheet" onRequestClose={onClose}>
+      <View className="flex-1 bg-background">
+        <SheetHeader title={part.filename ?? 'File'} onDone={onClose} doneLabel="Done" />
+        <ScrollView contentContainerClassName="px-6 pb-6 pt-2">{renderBody()}</ScrollView>
+      </View>
+    </Modal>
   );
 }

--- a/apps/mobile/src/components/agents/file-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.tsx
@@ -27,12 +27,12 @@ import { stripDataUrlBase64Prefix } from './tool-card-image-cache';
 
 const CACHE_DIR_NAME = 'session-file-parts';
 
-function cacheFilenameForPart(part: FilePart): string {
+function cacheFilenameForPart(part: Pick<FilePart, 'id' | 'mime' | 'filename'>): string {
   return getSafeCacheFilename({ id: part.id, filename: part.filename ?? 'file' });
 }
 
 /** Write a base64 `data:` payload to the cache and return the file. */
-function writeDataUrlToCache(url: string, part: FilePart): File {
+function writeDataUrlToCache(url: string, part: Pick<FilePart, 'id' | 'mime' | 'filename'>): File {
   const payload = stripDataUrlBase64Prefix(url, part.mime);
   if (payload === undefined) {
     throw new Error('decode-failed');
@@ -45,7 +45,7 @@ function writeDataUrlToCache(url: string, part: FilePart): File {
 }
 
 /** Resolve the file text for a preview, keeping the file for a later share. */
-async function resolveFileText(url: string, part: FilePart): Promise<string> {
+async function resolveFileText(url: string, part: Pick<FilePart, 'id' | 'mime' | 'filename'>) {
   if (url.startsWith('data:')) {
     const file = writeDataUrlToCache(url, part);
     return file.text();
@@ -257,6 +257,7 @@ type FilePreviewModalProps = {
 };
 
 function FilePreviewModal({ mode, url, part, onClose }: Readonly<FilePreviewModalProps>) {
+  const { id, mime, filename } = part;
   const [status, setStatus] = useState<'loading' | 'ready' | 'error'>('loading');
   const [text, setText] = useState('');
   const [attempt, setAttempt] = useState(0);
@@ -266,7 +267,7 @@ function FilePreviewModal({ mode, url, part, onClose }: Readonly<FilePreviewModa
     setStatus('loading');
     async function load() {
       try {
-        const resolved = await resolveFileText(url, part);
+        const resolved = await resolveFileText(url, { id, mime, filename });
         if (cancelled) {
           return;
         }
@@ -283,7 +284,7 @@ function FilePreviewModal({ mode, url, part, onClose }: Readonly<FilePreviewModa
     return () => {
       cancelled = true;
     };
-  }, [url, part, attempt]);
+  }, [url, id, mime, filename, attempt]);
 
   function renderBody() {
     if (status === 'loading') {

--- a/apps/mobile/src/components/agents/file-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/file-part-renderer.tsx
@@ -94,9 +94,10 @@ type FilePartRendererProps = {
 
 type PreviewMode = 'markdown' | 'text';
 
-/** Prefer the captured cache URL, falling back to the part's own URL. */
+/** Prefer the captured cache URL, falling back to the part's own URL. The
+ *  cached URL is produced by our cache and is always trusted. */
 function resolveUsableUrl(cachedUrl: string | undefined, partUrl: string): string | undefined {
-  if (cachedUrl && isUsableFilePartUrl(cachedUrl)) {
+  if (cachedUrl) {
     return cachedUrl;
   }
   if (isUsableFilePartUrl(partUrl)) {

--- a/apps/mobile/src/components/agents/mobile-session-manager.test.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.test.ts
@@ -40,6 +40,9 @@ vi.mock('@/components/agents/tool-card-image-cache', () => ({
   cacheToolAttachment: vi.fn(),
   cacheToolCardImage: vi.fn(),
 }));
+vi.mock('@/components/agents/file-part-cache', () => ({
+  cacheFilePart: vi.fn(),
+}));
 
 const mutate = vi.fn();
 const prepareSessionMutate = vi.fn();

--- a/apps/mobile/src/components/agents/mobile-session-manager.ts
+++ b/apps/mobile/src/components/agents/mobile-session-manager.ts
@@ -23,6 +23,7 @@ import { trpcClient } from '@/lib/trpc';
 import { getAuthTokenForRequest } from '@/lib/auth/token-owner';
 import { createNativeUserWebConnectionLifecycleHooks } from '@/lib/user-web-connection-lifecycle';
 import { cacheToolAttachment } from '@/components/agents/tool-card-image-cache';
+import { cacheFilePart } from '@/components/agents/file-part-cache';
 import { type inferRouterOutputs, type MobileRouter } from '@kilocode/trpc/mobile';
 
 type SessionWithRuntimeState =
@@ -176,6 +177,9 @@ export function createMobileAgentSessionManager({
     userWebConnection,
     onToolAttachment: (partId, attachment) => {
       cacheToolAttachment(partId, attachment);
+    },
+    onFilePart: (partId, file) => {
+      cacheFilePart(partId, file);
     },
     resolveSession: async (kiloSessionId: KiloSessionId): Promise<ResolvedSession> => {
       // Read-only is only ever returned once we have successful evidence the

--- a/apps/mobile/src/lib/share-remote-file.test.ts
+++ b/apps/mobile/src/lib/share-remote-file.test.ts
@@ -1,6 +1,7 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import {
+  downloadRemoteFile,
   getSafeCacheFilename,
   shareLocalFile,
   shareMaterializedRemoteFile,
@@ -151,6 +152,29 @@ describe('shareMaterializedRemoteFile', () => {
       )
     ).rejects.toThrow('share failed');
     expect(deleted).toEqual(['file:///cache/org-invoices/a.pdf']);
+  });
+});
+
+describe('downloadRemoteFile', () => {
+  it('downloads an http(s) URL and returns a materialized file with a working delete', async () => {
+    const downloaded = {
+      uri: 'file:///cache/org-invoices/in_1-a.pdf',
+      delete: vi.fn(),
+    };
+    expoFileSystemMock.File.downloadFileAsync.mockResolvedValue(downloaded);
+
+    const result = await downloadRemoteFile({
+      url: 'https://example.com/a.pdf',
+      cacheDirectoryName: 'org-invoices',
+      cacheFilename: 'in_1-a.pdf',
+    });
+
+    expect(result.uri).toBe('file:///cache/org-invoices/in_1-a.pdf');
+    expect(expoFileSystemMock.Directory).toHaveBeenCalledWith('file:///cache', 'org-invoices');
+    expect(expoFileSystemMock.File.downloadFileAsync).toHaveBeenCalled();
+
+    result.delete();
+    expect(downloaded.delete).toHaveBeenCalled();
   });
 });
 

--- a/apps/mobile/src/lib/share-remote-file.ts
+++ b/apps/mobile/src/lib/share-remote-file.ts
@@ -59,6 +59,19 @@ async function materializeRemoteFile({
   }
 }
 
+export async function downloadRemoteFile({
+  url,
+  cacheDirectoryName,
+  cacheFilename,
+}: {
+  url: string;
+  cacheDirectoryName: string;
+  cacheFilename: string;
+}): Promise<MaterializedRemoteFile> {
+  const materialized = await materializeRemoteFile({ url, cacheDirectoryName, cacheFilename });
+  return materialized;
+}
+
 export async function shareLocalFile(
   localUri: string,
   options?: { mimeType?: string }

--- a/apps/mobile/src/lib/share-remote-file.ts
+++ b/apps/mobile/src/lib/share-remote-file.ts
@@ -30,7 +30,7 @@ export function getShareRemoteFileReason(error: unknown): ShareRemoteFileReason 
   return null;
 }
 
-async function materializeRemoteFile({
+export async function downloadRemoteFile({
   url,
   cacheDirectoryName,
   cacheFilename,
@@ -57,19 +57,6 @@ async function materializeRemoteFile({
     }
     throw new ShareRemoteFileError('download-failed');
   }
-}
-
-export async function downloadRemoteFile({
-  url,
-  cacheDirectoryName,
-  cacheFilename,
-}: {
-  url: string;
-  cacheDirectoryName: string;
-  cacheFilename: string;
-}): Promise<MaterializedRemoteFile> {
-  const materialized = await materializeRemoteFile({ url, cacheDirectoryName, cacheFilename });
-  return materialized;
 }
 
 export async function shareLocalFile(
@@ -113,7 +100,7 @@ export async function shareRemoteFile({
   cacheKey: string;
   filename: string;
 }): Promise<void> {
-  const materialized = await materializeRemoteFile({
+  const materialized = await downloadRemoteFile({
     url,
     cacheDirectoryName,
     cacheFilename: getSafeCacheFilename({ id: cacheKey, filename }),

--- a/packages/cloud-agent-sdk/src/chat-processor.test.ts
+++ b/packages/cloud-agent-sdk/src/chat-processor.test.ts
@@ -149,6 +149,68 @@ describe('createChatProcessor', () => {
       expect(storedFile.source?.text.value).toBe('');
     });
 
+    // --- onFilePart callback gates ---
+
+    it('calls onFilePart for a top-level FilePart with a non-blank url', () => {
+      const storage = createMemoryStorage();
+      const onFilePart = jest.fn();
+      const processor = createChatProcessor(storage, { onFilePart });
+      const part = makeFilePart('part-file', 'msg-1');
+
+      processor.process({ type: 'message.part.updated', part });
+
+      expect(onFilePart).toHaveBeenCalledTimes(1);
+      expect(onFilePart).toHaveBeenCalledWith('part-file', {
+        mime: 'text/plain',
+        filename: 'readme.txt',
+        url: 'data:text/plain;base64,aGVsbG8=',
+      });
+    });
+
+    it('does not call onFilePart when the file url is blank', () => {
+      const storage = createMemoryStorage();
+      const onFilePart = jest.fn();
+      const processor = createChatProcessor(storage, { onFilePart });
+      const part = makeFilePart('part-file', 'msg-1');
+      part.url = '';
+
+      processor.process({ type: 'message.part.updated', part });
+
+      expect(onFilePart).not.toHaveBeenCalled();
+    });
+
+    it('still strips the stored url and source text when onFilePart is supplied', () => {
+      const storage = createMemoryStorage();
+      const onFilePart = jest.fn();
+      const processor = createChatProcessor(storage, { onFilePart });
+      const part = makeFilePart('part-file', 'msg-1');
+
+      processor.process({ type: 'message.part.updated', part });
+
+      const stored = storage.getParts('msg-1');
+      expect(stored).toHaveLength(1);
+      const storedFile = stored[0] satisfies Part as FilePart;
+      expect(storedFile.url).toBe('');
+      expect(storedFile.source?.text.value).toBe('');
+      expect(onFilePart).toHaveBeenCalled();
+    });
+
+    it('continues processing when onFilePart throws', () => {
+      const storage = createMemoryStorage();
+      const onFilePart = jest.fn(() => {
+        throw new Error('sink failed');
+      });
+      const processor = createChatProcessor(storage, { onFilePart });
+      const part = makeFilePart('part-file', 'msg-1');
+
+      expect(() => processor.process({ type: 'message.part.updated', part })).not.toThrow();
+
+      const stored = storage.getParts('msg-1');
+      expect(stored).toHaveLength(1);
+      const storedFile = stored[0] satisfies Part as FilePart;
+      expect(storedFile.url).toBe('');
+    });
+
     // --- onToolAttachment callback gates ---
 
     it('calls onToolAttachment for image attachments from any tool', () => {

--- a/packages/cloud-agent-sdk/src/chat-processor.ts
+++ b/packages/cloud-agent-sdk/src/chat-processor.ts
@@ -34,6 +34,17 @@ type ChatProcessorOptions = {
   onToolAttachment?:
     | ((partId: string, attachment: { mime: string; filename?: string; dataUrl: string }) => void)
     | undefined;
+  /**
+   * Optional sink for top-level file part URLs, called just before the chat
+   * processor strips a file part's `url` and `source.text` for storage.
+   * Receives the raw URL exactly once per processor pass; consumers use it to
+   * preview the file later (e.g. mobile). Web never passes it, so web
+   * behaviour is unchanged. Sink failures are caught and must not interrupt
+   * processing.
+   */
+  onFilePart?:
+    | ((partId: string, file: { mime: string; filename?: string; url: string }) => void)
+    | undefined;
 };
 
 function hasTextField(part: { text?: string } | unknown): part is { text: string } {
@@ -70,6 +81,23 @@ function emitToolAttachmentsBeforeStrip(
   }
 }
 
+function emitFilePartBeforeStrip(
+  part: Part,
+  onFilePart: NonNullable<ChatProcessorOptions['onFilePart']>
+): void {
+  if (part.type !== 'file') return;
+  if (part.url === '') return;
+  try {
+    onFilePart(part.id, {
+      mime: part.mime,
+      ...(part.filename ? { filename: part.filename } : {}),
+      url: part.url,
+    });
+  } catch {
+    // Sink failures must not break chat processing.
+  }
+}
+
 function createChatProcessor(
   sessionStorage: SessionStorage,
   options?: ChatProcessorOptions
@@ -83,6 +111,9 @@ function createChatProcessor(
         case 'message.part.updated': {
           if (options?.onToolAttachment) {
             emitToolAttachmentsBeforeStrip(event.part, options.onToolAttachment);
+          }
+          if (options?.onFilePart) {
+            emitFilePartBeforeStrip(event.part, options.onFilePart);
           }
           const stripped = stripPartContentIfFile(event.part);
           if (hasTextField(stripped) && stripped.text === '' && !isSyntheticPart(stripped)) {

--- a/packages/cloud-agent-sdk/src/session-manager.ts
+++ b/packages/cloud-agent-sdk/src/session-manager.ts
@@ -278,6 +278,13 @@ type SessionManagerConfig = {
     partId: string,
     attachment: { mime: string; filename?: string; dataUrl: string }
   ) => void;
+  /**
+   * Optional sink for top-level file part URLs, called just before the chat
+   * processor strips a file part's `url` and `source.text` for storage.
+   * Receives the raw URL exactly once per processor pass; consumers use it to
+   * preview the file later (e.g. mobile). Web never passes it.
+   */
+  onFilePart?: (partId: string, file: { mime: string; filename?: string; url: string }) => void;
   onRemoteSessionOpened?: (data: { kiloSessionId: KiloSessionId }) => void;
   onRemoteSessionMessageSent?: (data: { kiloSessionId: KiloSessionId }) => void;
 };
@@ -821,6 +828,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
 
         const chatProcessor = createChatProcessor(storage, {
           onToolAttachment: config.onToolAttachment,
+          onFilePart: config.onFilePart,
         });
         for (const message of snapshot.messages) {
           chatProcessor.process({ type: 'message.updated', info: message.info });
@@ -1097,6 +1105,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
 
     const chatProcessor = createChatProcessor(storage, {
       onToolAttachment: config.onToolAttachment,
+      onFilePart: config.onFilePart,
     });
     for (const message of outcome.messages) {
       chatProcessor.process({ type: 'message.updated', info: message.info });
@@ -1274,6 +1283,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       ...(config.websocketBaseUrl ? { websocketBaseUrl: config.websocketBaseUrl } : {}),
       storage: jotaiStorage,
       onToolAttachment: config.onToolAttachment,
+      onFilePart: config.onFilePart,
       onSessionCreated: info => {
         if (info.parentID == null) {
           // Adopt the server-reported root session ID so message

--- a/packages/cloud-agent-sdk/src/session.ts
+++ b/packages/cloud-agent-sdk/src/session.ts
@@ -101,6 +101,15 @@ type CloudAgentSessionConfig = {
   onToolAttachment?:
     | ((partId: string, attachment: { mime: string; filename?: string; dataUrl: string }) => void)
     | undefined;
+  /**
+   * Optional sink for top-level file part URLs, called just before the chat
+   * processor strips a file part's `url` and `source.text` for storage.
+   * Receives the raw URL exactly once per processor pass; consumers use it to
+   * preview the file later (e.g. mobile). Web never passes it.
+   */
+  onFilePart?:
+    | ((partId: string, file: { mime: string; filename?: string; url: string }) => void)
+    | undefined;
 };
 
 type CloudAgentSessionSendInput = {
@@ -214,6 +223,7 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
 
   const chatProcessor = createChatProcessor(storage, {
     onToolAttachment: config.onToolAttachment,
+    onFilePart: config.onFilePart,
   });
 
   const serviceState = createServiceState({


### PR DESCRIPTION
## Summary

A user can now tap a `FilePart` in the agent session transcript and preview or open it. Images open a full-screen viewer, `.md`/`.mdx` files open a rendered Markdown sheet, and any other file opens an ActionSheet with "Open as text" or "Open in external app".

- **User**: file attachments in the session transcript are now tappable — tap an image to view it full screen, a Markdown file to read it rendered, or another file to open its text or share it to an external app.
- **Product manager**: session transcript file attachments gain a preview/open affordance, replacing the static chip.
- **Maintainer**: the cloud-agent-sdk chat processor now captures a top-level `FilePart`'s `url` (via a new `onFilePart` sink, next to `onToolAttachment`) before `stripPartContentIfFile` blanks it. Mobile caches that URL in memory, classifies the part (image / markdown / other), and renders the tap actions. Only `http(s)` and `data:` URLs are usable; `file://` and blank URLs stay unavailable, and cloud-agent FileParts stay unavailable because ingest blanks their URL before the client.

## Verification

- `packages/cloud-agent-sdk`: `pnpm typecheck` and `pnpm test src/chat-processor.test.ts` (25 tests) pass.
- `apps/mobile`: `pnpm typecheck`, `pnpm lint`, `pnpm check:unused`, `pnpm format:check`, and the targeted tests (44 tests across the four changed test files) pass.
- Bot E2E (iOS simulator) passed: attached an image, a `.md`, and a `.txt` in the composer; verified the image full-screen viewer, the rendered Markdown sheet, the other-file ActionSheet, and the accessibility labels of all three chips.

## Visual Changes

Tappable FilePart chips in the session transcript:

![tappable file chips](https://github.com/user-attachments/assets/c652aeda-685b-4829-b44d-6865c51cde93)

Image tap opens the full-screen viewer:

![image viewer](https://github.com/user-attachments/assets/6db71672-20d5-4e3a-867b-52b55c0277e2)

Markdown tap opens a rendered sheet:

![markdown sheet](https://github.com/user-attachments/assets/784a567c-2a3c-4ab6-b774-08af6b5725b2)

Other-file tap opens the ActionSheet:

![action sheet](https://github.com/user-attachments/assets/4d9069d2-3fcd-4fdc-8887-24ddc62b4041)

## Reviewer Notes

- The `onFilePart` sink mirrors the existing `onToolAttachment` sink; web and extension pass nothing, so their behavior is unchanged.
- `source.text` is intentionally never read — it is a citation range, not the file body.
- `data:` URLs are decoded via `stripDataUrlBase64Prefix` + `File.write` + `file.text()`; `atob` is never used.

## Human steps

No human step is needed.
