### PR TITLE
fix(ai-gateway): reject disabled exclusive models

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -25,7 +25,10 @@ import { debugSaveProxyRequest } from '@/lib/debugUtils';
 import { setTag, startInactiveSpan } from '@sentry/nextjs';
 import { getUserFromAuth } from '@/lib/user/server';
 import { sentryRootSpan } from '@/lib/getRootSpan';
-import { isDeadFreeModel, isKiloExclusiveRateLimitedModel } from '@/lib/ai-gateway/models';
+import {
+  isDisabledKiloExclusiveModel,
+  isKiloExclusiveRateLimitedModel,
+} from '@/lib/ai-gateway/models';
 import {
   hasBestEffortGuessDataCollectionRequirement,
   isFreeModel,
@@ -673,7 +676,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
   }
 
   if (
-    isDeadFreeModel(effectiveModelIdLowerCased) ||
+    isDisabledKiloExclusiveModel(effectiveModelIdLowerCased) ||
     (!autoModel && isUnavailableModel(effectiveModelIdLowerCased))
   ) {
     console.warn(`User requested unavailable model ${effectiveModelIdLowerCased}; rejecting.`);

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -150,10 +150,8 @@ export function shouldRedactErrorResponse(provider: ProviderId, model: string): 
   return provider === 'experiment' || isKiloStealthModel(model);
 }
 
-export function isDeadFreeModel(model: string): boolean {
-  return !!kiloExclusiveModels.find(
-    m => m.public_id === model && m.status === 'disabled' && !m.pricing
-  );
+export function isDisabledKiloExclusiveModel(model: string): boolean {
+  return !!kiloExclusiveModels.find(m => m.public_id === model && m.status === 'disabled');
 }
 
 export function findKiloExclusiveModel(model: string): KiloExclusiveModel | null {

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -11,7 +11,7 @@ import { qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
 import { gemma_4_26b_a4b_it_free_model } from '@/lib/ai-gateway/providers/google';
 import {
   findKiloExclusiveModel,
-  isDeadFreeModel,
+  isDisabledKiloExclusiveModel,
   kiloExclusiveModels,
 } from '@/lib/ai-gateway/models';
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
@@ -277,11 +277,11 @@ describe('disabled paid Kilo-exclusive model fallback', () => {
     global.fetch = originalFetch;
   });
 
-  it('keeps the OpenRouter model available without Kilo-exclusive blocking or routing', async () => {
+  it('keeps the OpenRouter model listed without active Kilo-exclusive routing', async () => {
     const models = await getEnhancedOpenRouterModels();
 
     expect(models.data.some(model => model.id === disabledPaidModel.public_id)).toBe(true);
-    expect(isDeadFreeModel(disabledPaidModel.public_id)).toBe(false);
+    expect(isDisabledKiloExclusiveModel(disabledPaidModel.public_id)).toBe(true);
     expect(findKiloExclusiveModel(disabledPaidModel.public_id)).toBeNull();
   });
 });


### PR DESCRIPTION
## Summary
- reject every disabled Kilo-exclusive model instead of only disabled free models
- keep disabled paid models visible in the OpenRouter catalog without active exclusive routing
- update the regression assertion for the expanded disabled-model predicate

## Verification
- `pnpm --filter web exec jest --runInBand --runTestsByPath src/lib/ai-gateway/providers/openrouter/index.test.ts` (23 passed)
- `pnpm --filter web exec jest --runInBand --runTestsByPath src/app/api/openrouter/[...path]/route.test.ts` (36 passed)
- `pnpm --filter web typecheck`
- targeted oxlint, oxfmt, and `git diff --check`

## Full suite
- 10,419 tests passed; 4 failures are caused by separate unstaged provider changes and are not included in this PR.