### PR TITLE
feat(ai-gateway): enable Responses API for partner providers

### DIFF
--- a/apps/web/src/app/admin/api/auto-routing/benchmark-config/route.test.ts
+++ b/apps/web/src/app/admin/api/auto-routing/benchmark-config/route.test.ts
@@ -23,7 +23,7 @@ jest.mock('@/lib/ai-gateway/experiments/reserved-ids', () => ({
 }));
 
 // Stub the catalog so tests don't depend on any specific provider file.
-// 'test-exclusive/alibaba-only' maps to the alibaba gateway (chat_completions only).
+// 'test-exclusive/alibaba-only' maps to the alibaba gateway, which lacks Messages support.
 jest.mock('@/lib/ai-gateway/models', () => {
   const actual = jest.requireActual<typeof ModelsModule>('@/lib/ai-gateway/models');
   const stubModel: KiloExclusiveModel = {
@@ -121,6 +121,7 @@ describe('PUT /admin/api/auto-routing/benchmark-config', () => {
     const body = (await response.json()) as { error: string };
     expect(body.error).toContain('test-exclusive/alibaba-only');
     expect(body.error).toContain('chat_completions');
+    expect(body.error).toContain('responses');
     expect(body.error).not.toContain('openai/gpt-5-mini (');
     expect(mockUpdateBenchmarkConfig).not.toHaveBeenCalled();
   });

--- a/apps/web/src/lib/ai-gateway/model-api-kinds.test.ts
+++ b/apps/web/src/lib/ai-gateway/model-api-kinds.test.ts
@@ -5,7 +5,7 @@ import type * as ModelsModule from '@/lib/ai-gateway/models';
 
 // Stub the catalog so the rejection test doesn't depend on any specific provider file.
 // 'test-exclusive/alibaba-only' resolves to a KiloExclusiveModel on the alibaba gateway,
-// which only supports chat_completions, exercising the rejection branch.
+// which does not support Messages, exercising the rejection branch.
 // 'test-exclusive/disabled' is filtered out by findKiloExclusiveModel, mirroring how
 // disabled catalog models fall back to OpenRouter.
 jest.mock('@/lib/ai-gateway/models', () => {
@@ -51,9 +51,12 @@ describe('modelServesAllGatewayChatApis', () => {
     expect(modelServesAllGatewayChatApis('openai/gpt-5-mini')).toBe(true);
   });
 
-  it('rejects a Kilo-exclusive model served by a chat-completions-only provider', () => {
+  it('rejects a Kilo-exclusive model served by a provider without Messages support', () => {
     expect(modelServesAllGatewayChatApis('test-exclusive/alibaba-only')).toBe(false);
-    expect(gatewayChatApisForModel('test-exclusive/alibaba-only')).toEqual(['chat_completions']);
+    expect(gatewayChatApisForModel('test-exclusive/alibaba-only')).toEqual([
+      'chat_completions',
+      'responses',
+    ]);
   });
 
   it('treats disabled Kilo-exclusive models like plain OpenRouter models, matching get-provider', () => {

--- a/apps/web/src/lib/ai-gateway/providers/partner-routing.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner-routing.test.ts
@@ -84,12 +84,8 @@ describe('getPercentageRoutedPartnerProvider', () => {
     expect(selectPartner({ requestedModel: model })).toBe(expectedProvider);
   });
 
-  it.each(['chat_completions', 'messages'] as const)('routes %s requests', kind => {
+  it.each(['chat_completions', 'messages', 'responses'] as const)('routes %s requests', kind => {
     expect(selectPartner({ request: request(kind) })).toBe(PROVIDERS.FRIENDLI_GLM);
-  });
-
-  it('does not route unsupported responses requests', () => {
-    expect(selectPartner({ request: request('responses') })).toBeNull();
   });
 
   it('allows an empty provider object', () => {

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
@@ -52,9 +52,9 @@ describe.each([
     upstreamModel: 'perplexity/kimi-k3',
   },
 ])('$name provider', ({ provider, expectedUrl, requestedModel, upstreamModel }) => {
-  test('supports chat completions and Messages', () => {
+  test('supports all gateway chat APIs', () => {
     expect(`${provider.apiUrl}/messages`).toBe(expectedUrl);
-    expect(provider.supportedChatApis).toEqual(['chat_completions', 'messages']);
+    expect(provider.supportedChatApis).toEqual(['chat_completions', 'messages', 'responses']);
   });
 
   test('enables the reasoning details response transform', () => {

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -18,8 +18,7 @@ export default {
     apiUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
     apiUrlOverrides: {},
     apiKey: getEnvVariable('ALIBABA_API_KEY'),
-    // Prompt caching is not supported on the responses API for Alibaba; enabling it is therefore dangerous.
-    supportedChatApis: ['chat_completions' /*, 'responses'*/],
+    supportedChatApis: ['chat_completions', 'responses'],
     responseTransforms: null,
     async transformRequest(context) {
       context.request.body.enable_thinking = !isReasoningExplicitlyDisabled(context.request);
@@ -30,8 +29,7 @@ export default {
     apiUrl: 'https://ark.ap-southeast.bytepluses.com/api/v3',
     apiUrlOverrides: {},
     apiKey: getEnvVariable('BYTEDANCE_API_KEY'),
-    // Prompt caching is not supported on the responses API for Bytedance; enabling it is therefore dangerous.
-    supportedChatApis: ['chat_completions' /*, 'responses'*/],
+    supportedChatApis: ['chat_completions', 'responses'],
     responseTransforms: null,
     async transformRequest(context) {
       if (!isReasoningExplicitlyDisabled(context.request)) {
@@ -89,10 +87,7 @@ export default {
     apiUrl: 'https://api.friendli.ai/serverless/v1',
     apiUrlOverrides: {},
     apiKey: getEnvVariable('FRIENDLI_API_KEY'),
-    // Direct responses may omit market cost metadata; keep fallback pricing in custom-pricing.ts.
-    supportedChatApis: ['chat_completions', 'messages'],
-    // Chat completions responses report reasoning as `reasoning_content`; expose it as
-    // `reasoning_details` so clients can conserve it across turns.
+    supportedChatApis: ['chat_completions', 'messages', 'responses'],
     responseTransforms: { mapGeminiThoughtContent: false, mapReasoningContentToDetails: true },
     async transformRequest(context) {
       context.request.body.model = 'zai-org/GLM-5.2';
@@ -112,10 +107,7 @@ export default {
     apiUrl: 'https://api.perplexity.ai/router/v1',
     apiUrlOverrides: {},
     apiKey: getEnvVariable('PERPLEXITY_API_KEY'),
-    // Direct responses may omit market cost metadata; keep fallback pricing in custom-pricing.ts.
-    supportedChatApis: ['chat_completions', 'messages'],
-    // Chat completions responses report reasoning as `reasoning_content`; expose it as
-    // `reasoning_details` so clients can conserve it across turns.
+    supportedChatApis: ['chat_completions', 'messages', 'responses'],
     responseTransforms: { mapGeminiThoughtContent: false, mapReasoningContentToDetails: true },
     async transformRequest(context) {
       context.request.body.model = 'perplexity/kimi-k3';


### PR DESCRIPTION
## Summary
- enable the Responses API for Alibaba, ByteDance, Friendli GLM, and Perplexity Kimi
- update provider capability and auto-routing expectations

## Validation
- `git diff --cached --check` passed before commit
- tests not run per request