### PR TITLE
fix(web): merge Kilo fields into referenced config schema

### DIFF
--- a/apps/web/src/app/config.json/route.ts
+++ b/apps/web/src/app/config.json/route.ts
@@ -20,17 +20,39 @@ function isObject(value: unknown): value is Schema {
 }
 
 export function merge(schema: Schema): Schema {
-  const properties = isObject(schema.properties) ? { ...schema.properties } : {};
-  Object.assign(properties, kiloExtras.top);
-
-  const agent = isObject(properties.agent) ? { ...properties.agent } : {};
-  agent.properties = {
-    ...(isObject(agent.properties) ? agent.properties : {}),
-    ...kiloExtras.agents,
-  };
-  properties.agent = agent;
-
   const defs = isObject(schema.$defs) ? { ...schema.$defs } : undefined;
+
+  const mergeProperties = (source: unknown): Schema => {
+    const properties = isObject(source) ? { ...source } : {};
+
+    Object.assign(properties, kiloExtras.top);
+
+    const agent = isObject(properties.agent) ? { ...properties.agent } : {};
+    agent.properties = {
+      ...(isObject(agent.properties) ? agent.properties : {}),
+      ...kiloExtras.agents,
+    };
+    properties.agent = agent;
+
+    const experimental = isObject(properties.experimental) ? { ...properties.experimental } : {};
+    experimental.properties = {
+      ...(isObject(experimental.properties) ? experimental.properties : {}),
+      ...kiloExtras.experimental,
+    };
+    properties.experimental = experimental;
+
+    return properties;
+  };
+
+  const config =
+    schema.$ref === '#/$defs/Config' && defs && isObject(defs.Config)
+      ? { ...defs.Config, properties: mergeProperties(defs.Config.properties) }
+      : undefined;
+
+  if (config && defs) {
+    defs.Config = config;
+  }
+
   if (defs && isObject(defs.PermissionConfig)) {
     const permissionConfig = { ...defs.PermissionConfig };
     if (Array.isArray(permissionConfig.anyOf)) {
@@ -45,14 +67,11 @@ export function merge(schema: Schema): Schema {
     }
   }
 
-  const experimental = isObject(properties.experimental) ? { ...properties.experimental } : {};
-  experimental.properties = {
-    ...(isObject(experimental.properties) ? experimental.properties : {}),
-    ...kiloExtras.experimental,
+  return {
+    ...schema,
+    ...(defs ? { $defs: defs } : {}),
+    ...(config ? {} : { properties: mergeProperties(schema.properties) }),
   };
-  properties.experimental = experimental;
-
-  return { ...schema, ...(defs ? { $defs: defs } : {}), properties };
 }
 
 export async function GET() {

--- a/apps/web/src/tests/cli-config-schema.test.ts
+++ b/apps/web/src/tests/cli-config-schema.test.ts
@@ -39,6 +39,44 @@ const upstream: Schema = {
   },
 };
 
+const referencedUpstream: Schema = {
+  $schema: 'https://json-schema.org/draft/2020-12/schema',
+  $ref: '#/$defs/Config',
+  $defs: {
+    Config: {
+      type: 'object',
+      properties: {
+        existing: { type: 'boolean' },
+        agent: {
+          type: 'object',
+          properties: {
+            build: { ref: 'AgentConfig', type: 'object', properties: {} },
+          },
+        },
+        experimental: {
+          type: 'object',
+          properties: {
+            batch_tool: { type: 'boolean' },
+          },
+        },
+      },
+      additionalProperties: false,
+    },
+    PermissionConfig: {
+      anyOf: [
+        { $ref: '#/$defs/PermissionActionConfig' },
+        {
+          type: 'object',
+          properties: {
+            read: { $ref: '#/$defs/PermissionRuleConfig' },
+          },
+          additionalProperties: { $ref: '#/$defs/PermissionRuleConfig' },
+        },
+      ],
+    },
+  },
+};
+
 describe('kilo config.json schema merge', () => {
   const out = merge(upstream);
   const props = out.properties as Record<string, unknown>;
@@ -134,5 +172,41 @@ describe('kilo config.json schema merge', () => {
     expect(out.$schema).toBe(upstream.$schema);
     expect(out.ref).toBe('Config');
     expect(out.type).toBe('object');
+  });
+
+  test('adds Kilo keys to a referenced Config definition', () => {
+    const out = merge(referencedUpstream);
+    const defs = out.$defs as Record<string, unknown>;
+    const config = defs.Config as {
+      properties: Record<string, unknown>;
+      additionalProperties: boolean;
+    };
+    const props = config.properties;
+
+    expect(props.commit_message).toBeDefined();
+    expect(props.remote_control).toBeDefined();
+    expect(props.web_search).toBeDefined();
+    expect(props.privacy_mode).toBeDefined();
+    expect(props.existing).toEqual({ type: 'boolean' });
+
+    const agent = props.agent as { properties: Record<string, unknown> };
+    expect(agent.properties.ask).toBeDefined();
+    expect(agent.properties.debug).toBeDefined();
+    expect(agent.properties.orchestrator).toBeDefined();
+    expect(agent.properties.build).toBeDefined();
+
+    const experimental = props.experimental as { properties: Record<string, unknown> };
+    expect(experimental.properties.codebase_search).toBeDefined();
+    expect(experimental.properties.batch_tool).toBeDefined();
+    expect(config.additionalProperties).toBe(false);
+    expect(out.properties).toBeUndefined();
+  });
+
+  test('does not mutate the upstream referenced schema', () => {
+    const before = structuredClone(referencedUpstream);
+
+    merge(referencedUpstream);
+
+    expect(referencedUpstream).toEqual(before);
   });
 });


### PR DESCRIPTION
The upstream CLI schema now uses a root `$ref` to `$defs.Config`, so sibling root-level schema keywords are ignored by JSON Schema validators. Kilo-only configuration fields were therefore reported as unknown even though they were present in the response.

Merge Kilo top-level fields, primary agents, and experimental fields into `$defs.Config.properties` when that referenced shape is present, while retaining the existing inline-root behavior and permission additions. The merge clones affected structures so upstream schema objects are preserved.

Add regression coverage for both schema shapes, including strict `additionalProperties: false` behavior and preservation of upstream agent and experimental properties.

Fixes Kilo-Org/kilocode#13140