### PR TITLE
fix(dev): don't fail env sync on an empty local Secrets Store

### DIFF
--- a/dev/local/env-sync/index.ts
+++ b/dev/local/env-sync/index.ts
@@ -79,7 +79,7 @@ async function syncEnvVars(options: {
         plan.envLocalAutoCreates.length > 0
           ? await computePlanAsync(repoRoot, serviceFilter, refreshSourceBackedSecrets)
           : plan;
-      await applyPlan(applyReadyPlan, repoRoot, { missingSecretsOnly });
+      await applyPlan(applyReadyPlan, repoRoot);
       console.log(`\n${GREEN}✓ Applied${RESET}`);
     } else {
       console.log('Skipped.');

--- a/dev/local/env-sync/output.test.ts
+++ b/dev/local/env-sync/output.test.ts
@@ -19,11 +19,11 @@ function secretCreate(workerDir: string, secretName: string): SecretStoreAutoCre
   };
 }
 
-test('creates missing secrets concurrently across stores and rechecks existing secrets', async () => {
+test('creates planned secrets concurrently across stores without re-listing them', async () => {
   const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'env-sync-output-'));
-  const existing = secretCreate('services/event-service', 'EXISTING_SECRET');
-  const missing = secretCreate('services/model-eval-ingest', 'MISSING_SECRET');
-  for (const create of [existing, missing]) {
+  const first = secretCreate('services/event-service', 'FIRST_SECRET');
+  const second = secretCreate('services/model-eval-ingest', 'SECOND_SECRET');
+  for (const create of [first, second]) {
     fs.mkdirSync(path.join(repoRoot, create.workerDir, '.wrangler'), { recursive: true });
   }
 
@@ -33,7 +33,7 @@ test('creates missing secrets concurrently across stores and rechecks existing s
     envDevLocalChanges: [],
     envLocalAutoCreates: [],
     secretStoreWarnings: [],
-    secretStoreAutoCreates: [existing, missing],
+    secretStoreAutoCreates: [first, second],
     consistencyWarnings: [],
     execWarnings: [],
     missingEnvLocal: false,
@@ -44,20 +44,13 @@ test('creates missing secrets concurrently across stores and rechecks existing s
   try {
     await applyPlan(plan, repoRoot, {
       concurrency: 2,
-      missingSecretsOnly: true,
-      runWrangler: async (_repoRoot, workerDir, args, input) => {
+      runWrangler: async (_repoRoot, _workerDir, args, input) => {
         active++;
         maxActive = Math.max(maxActive, active);
         await new Promise(resolve => setTimeout(resolve, 20));
         active--;
 
-        if (args.includes('list')) {
-          return {
-            status: 0,
-            stderr: '',
-            stdout: workerDir === existing.workerDir ? 'EXISTING_SECRET\n' : '',
-          };
-        }
+        assert.ok(!args.includes('list'));
         assert.ok(input?.startsWith('value-for-'));
         assert.ok(!args.some(arg => arg.startsWith('value-for-')));
         created.push(args[args.indexOf('--name') + 1] ?? '');
@@ -66,7 +59,7 @@ test('creates missing secrets concurrently across stores and rechecks existing s
     });
 
     assert.equal(maxActive, 2);
-    assert.deepEqual(created, ['MISSING_SECRET']);
+    assert.deepEqual(created.sort(), ['FIRST_SECRET', 'SECOND_SECRET']);
   } finally {
     fs.rmSync(repoRoot, { recursive: true, force: true });
   }

--- a/dev/local/env-sync/output.ts
+++ b/dev/local/env-sync/output.ts
@@ -273,7 +273,6 @@ type WranglerRunner = typeof runWrangler;
 
 type ApplyPlanOptions = {
   concurrency?: number;
-  missingSecretsOnly?: boolean;
   runWrangler?: WranglerRunner;
 };
 
@@ -331,26 +330,6 @@ function resolveWranglerPersistenceDir(repoRoot: string, workerDir: string): str
   }
 }
 
-async function secretExists(
-  create: SecretStoreAutoCreate,
-  repoRoot: string,
-  runner: WranglerRunner = runWrangler
-): Promise<boolean> {
-  const result = await runner(repoRoot, create.workerDir, [
-    'secrets-store',
-    'secret',
-    'list',
-    create.binding.store_id,
-  ]);
-  if (result.status !== 0) {
-    const errorOutput = result.stderr.trim();
-    throw new Error(
-      `Failed to list Secrets Store secrets for ${create.workerDir}${errorOutput ? `: ${errorOutput}` : ''}`
-    );
-  }
-  return result.stdout.includes(create.binding.secret_name);
-}
-
 async function applySecretsStoreAutoCreates(
   creates: SecretStoreAutoCreate[],
   repoRoot: string,
@@ -377,13 +356,7 @@ async function applySecretsStoreAutoCreates(
         `Secrets Store for ${group[0]?.workerDir ?? persistenceDir}`,
         async () => {
           for (const create of group) {
-            if (
-              options.missingSecretsOnly &&
-              (await secretExists(create, repoRoot, options.runWrangler))
-            ) {
-              console.log(`  ✓ ${create.binding.secret_name} already exists`);
-              continue;
-            }
+            // The plan already filtered out secrets that exist locally, so no re-listing here.
             await createSecretsStoreSecret(
               repoRoot,
               create.workerDir,


### PR DESCRIPTION
## Problem

The first `pnpm dev:env --missing-secrets-only` run in a fresh worktree fails while setting up Cloudflare workers:

```
Creating secrets store secrets...
Failed to list Secrets Store secrets for services/deploy-infra/builder: ✘ [ERROR] List request returned no secrets.
[ELIFECYCLE] Command failed with exit code 1.
```

`--missing-secrets-only` (added in #5256) re-listed the local Secrets Store at apply time via `secretExists()` and threw on any non-zero wrangler exit. Wrangler's **local** `secrets-store secret list` exits `1` with `List request returned no secrets.` when the store is empty — exactly the state of a fresh worktree, since Secrets Store persistence lives under each worker's per-worktree `.wrangler` directory. So the sync aborted on the first worker with an empty local store.

## Fix

Drop the apply-time listing. It was redundant with the planner, which already:

- prefetches the same listing (`plan.ts` `loadLocalStoreSecrets`), and
- skips secrets that already exist when source-backed refresh is off, i.e. exactly in `--missing-secrets-only`/`--check` mode (`plan.ts:833`), and
- deliberately treats a failed listing as "empty" rather than fatal (`plan.ts:399`, `plan.ts:417`).

Apply now just creates what the plan selected, so it no longer contradicts the plan. Side effect: one fewer `wrangler secrets-store secret list` per store per run, in line with what #5256 was after.

## Verification

- `tsx dev/local/cli.ts env -y --missing-secrets-only` in a fresh worktree: completes, creates the missing secret, exit 0 (previously exit 1).
- Re-run is a clean no-op (exit 0), confirming the plan-level existence check still short-circuits.
- `pnpm run test:dev-local` — 212 pass; `output.test.ts` updated to assert apply creates the planned secrets concurrently and never issues a `list` call.
- `pnpm format` clean.