### PR TITLE
fix(ai-gateway): sanitize Perplexity tool messages

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts
@@ -286,6 +286,14 @@ export function removeChatCompletionsReasoning(request: OpenRouterChatCompletion
   }
 }
 
+export function removeChatCompletionsToolNames(request: OpenRouterChatCompletionRequest) {
+  for (const message of request.messages) {
+    if (message.role === 'tool' && 'name' in message) {
+      delete message.name;
+    }
+  }
+}
+
 /**
  * Inverse of the `mapReasoningContentToDetails` response transform: folds
  * OpenRouter-style `reasoning_details` back into the DeepSeek-style

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -1,5 +1,8 @@
 import { getEnvVariable } from '@/lib/dotenvx';
-import { isReasoningExplicitlyDisabled } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
+import {
+  isReasoningExplicitlyDisabled,
+  removeChatCompletionsToolNames,
+} from '@/lib/ai-gateway/providers/openrouter/request-helpers';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
 import { applyVercelSettings } from '@/lib/ai-gateway/providers/vercel';
 
@@ -118,8 +121,10 @@ export default {
             context.request.body.reasoning_effort ??
             undefined);
         delete context.request.body.reasoning;
+        removeChatCompletionsToolNames(context.request.body);
       }
       delete context.request.body.provider;
+      delete context.request.body.user;
     },
   },
   STREAMLAKE: {

--- a/apps/web/src/tests/openrouter-request-helpers.test.ts
+++ b/apps/web/src/tests/openrouter-request-helpers.test.ts
@@ -1,7 +1,33 @@
 import { describe, expect, test } from '@jest/globals';
-import { addCacheBreakpoints } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
-import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import {
+  addCacheBreakpoints,
+  removeChatCompletionsToolNames,
+} from '@/lib/ai-gateway/providers/openrouter/request-helpers';
+import type {
+  GatewayRequest,
+  OpenRouterChatCompletionRequest,
+} from '@/lib/ai-gateway/providers/openrouter/types';
 import type OpenAI from 'openai';
+
+describe('removeChatCompletionsToolNames', () => {
+  test('removes names from tool messages only', () => {
+    const toolMessage: OpenAI.ChatCompletionToolMessageParam & { name?: string } = {
+      role: 'tool',
+      content: 'Tool result',
+      tool_call_id: 'call_123',
+      name: 'read_file',
+    };
+    const request: OpenRouterChatCompletionRequest = {
+      model: 'test-model',
+      messages: [{ role: 'user', content: 'Run the tool', name: 'user-name' }, toolMessage],
+    };
+
+    removeChatCompletionsToolNames(request);
+
+    expect(toolMessage.name).toBeUndefined();
+    expect(request.messages[0]).toHaveProperty('name', 'user-name');
+  });
+});
 
 describe('addCacheBreakpoints', () => {
   test('adds a cache breakpoint to the system message and the last eligible chat completions message when none exist', () => {


### PR DESCRIPTION
## Summary
- remove unsupported tool-message names before sending Perplexity Kimi chat-completions requests
- remove unsupported top-level user metadata from Perplexity requests
- cover selective tool-name removal with a request-helper unit test

## Testing
- pnpm --filter web test -- --runInBand apps/web/src/tests/openrouter-request-helpers.test.ts apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
- pnpm --filter web typecheck
- pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/provider-definitions.ts apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts apps/web/src/tests/openrouter-request-helpers.test.ts
- pnpm exec oxfmt apps/web/src/lib/ai-gateway/providers/provider-definitions.ts apps/web/src/lib/ai-gateway/providers/openrouter/request-helpers.ts apps/web/src/tests/openrouter-request-helpers.test.ts
- git diff --check