### PR TITLE
fix(ai-gateway): report exclusive provider data collection

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts
@@ -3,6 +3,7 @@ import {
   applyKiloExclusiveModelSettings,
   calculateCost_mUsd,
   convertFromKiloExclusiveModel,
+  getInferenceProvider,
   type KiloExclusiveModel,
   type PricingTiers,
 } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
@@ -114,6 +115,38 @@ describe('convertFromKiloExclusiveModel', () => {
     });
 
     expect(convertFromKiloExclusiveModel(model).pricing.prompt).toBe('0.000001000000');
+  });
+});
+
+describe('getInferenceProvider', () => {
+  it('uses a single inference provider restriction before the gateway', () => {
+    const model = makeModel({
+      internal_id: 'vendor/x',
+      gateway: 'vercel',
+      inference_provider_restriction: ['openai'],
+    });
+
+    expect(getInferenceProvider(model)).toEqual({
+      slug: 'openai',
+      name: 'OPENAI',
+      training: false,
+      retainsPrompts: true,
+    });
+  });
+
+  it('reports data collection for a concrete gateway provider', () => {
+    const model = makeModel({
+      internal_id: 'vendor/x',
+      gateway: 'alibaba',
+      flags: ['requires-data-collection'],
+    });
+
+    expect(getInferenceProvider(model)).toEqual({
+      slug: 'alibaba',
+      name: 'ALIBABA',
+      training: true,
+      retainsPrompts: true,
+    });
   });
 });
 

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -195,15 +195,13 @@ export function getInferenceProvider(model: KiloExclusiveModel): InferenceProvid
     return { slug: 'stealth', name: 'Stealth', training: true, retainsPrompts: true };
   }
 
-  let slug: OpenRouterInferenceProviderId;
-  if (model.inference_provider_restriction.length === 1) {
-    slug = model.inference_provider_restriction[0];
-  } else {
-    if (model.gateway === 'openrouter' || model.gateway === 'vercel') {
-      return null;
-    }
-    slug = OpenRouterInferenceProviderIdSchema.parse(model.gateway);
-  }
+  const slug: OpenRouterInferenceProviderId | null =
+    model.inference_provider_restriction.length === 1
+      ? model.inference_provider_restriction[0]
+      : model.gateway === 'openrouter' || model.gateway === 'vercel'
+        ? null
+        : OpenRouterInferenceProviderIdSchema.parse(model.gateway);
+  if (!slug) return null;
 
   return {
     slug,

--- a/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
+++ b/apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts
@@ -194,14 +194,21 @@ export function getInferenceProvider(model: KiloExclusiveModel): InferenceProvid
   if (model.flags.includes('stealth')) {
     return { slug: 'stealth', name: 'Stealth', training: true, retainsPrompts: true };
   }
-  if (model.gateway === 'openrouter' || model.gateway === 'vercel') {
-    return null;
+
+  let slug: OpenRouterInferenceProviderId;
+  if (model.inference_provider_restriction.length === 1) {
+    slug = model.inference_provider_restriction[0];
+  } else {
+    if (model.gateway === 'openrouter' || model.gateway === 'vercel') {
+      return null;
+    }
+    slug = OpenRouterInferenceProviderIdSchema.parse(model.gateway);
   }
-  const slug = OpenRouterInferenceProviderIdSchema.parse(model.gateway);
+
   return {
     slug,
     name: slug.toUpperCase(),
-    training: false,
+    training: model.flags.includes('requires-data-collection'),
     retainsPrompts: true,
   };
 }


### PR DESCRIPTION
## Summary
- resolve a Kilo-exclusive model with one inference-provider restriction before falling back to its gateway
- derive the provider training indicator from `requires-data-collection` for both restricted providers and concrete gateway providers
- share the provider metadata return path after resolving the provider slug

## Verification
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts src/lib/ai-gateway/models.test.ts`
- `pnpm --filter web typecheck`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.ts apps/web/src/lib/ai-gateway/providers/kilo-exclusive-model.test.ts`
- `git diff --check`