### PR TITLE
chore(mobile): bump app version to 1.0.5

### DIFF
--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -28,7 +28,7 @@ const config: ExpoConfig = {
   name: 'Kilo',
   owner: 'kilocode',
   slug: 'kilo-app',
-  version: '1.0.4',
+  version: '1.0.5',
   // Portrait-only is an accepted, documented product deviation from WCAG 1.3.4
   // (Orientation). Landscape layouts and iPad split-view/multitasking are out
   // of scope; `ios.requireFullScreen` below enforces that. This is not claimed


### PR DESCRIPTION
Bumps the mobile app version from 1.0.4 to 1.0.5 in `apps/mobile/app.config.ts`.