### PR TITLE
fix(ai-gateway): remove Laguna from Auto Free

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -189,19 +189,13 @@ describe('isFreeModel', () => {
         Object.fromEntries(autoFreeModels.map(({ model, reasoning }) => [model, reasoning]))
       ).toEqual({
         'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
-        'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
       });
     });
 
-    test('weights non-Laguna auto-free models higher than Laguna', () => {
-      const lagunaModel = autoFreeModels.find(({ model }) => model.includes('laguna'));
-      expect(lagunaModel?.weight).toBe(1);
-
-      for (const candidate of autoFreeModels) {
-        if (!candidate.model.includes('laguna')) {
-          expect(candidate.weight).toBe(9);
-        }
-      }
+    test('keeps Laguna preferred without including it in Auto Free', () => {
+      const lagunaModel = 'poolside/laguna-s-2.1:free';
+      expect(autoFreeModels.map(({ model }) => model)).not.toContain(lagunaModel);
+      expect(preferredModels).toContain(lagunaModel);
     });
 
     test('uses autoFreeModels weights when selecting a model', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -53,11 +53,6 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
         } satisfies AutoFreeModel,
       ]
     : []),
-  {
-    model: 'poolside/laguna-s-2.1:free',
-    weight: 1,
-    reasoning: { enabled: true, effort: 'high' },
-  } satisfies AutoFreeModel,
 ];
 
 export function selectAutoFreeCandidate(
@@ -83,6 +78,7 @@ export const preferredModels = [
   KILO_AUTO_FREE_MODEL.id,
 
   ...autoFreeModels.map(({ model }) => model),
+  'poolside/laguna-s-2.1:free',
   ...(tencent_hy3_free_model.status === 'public' ? [tencent_hy3_free_model.public_id] : []),
   ...(longcat_2_free_model.status === 'public' ? [longcat_2_free_model.public_id] : []),
 


### PR DESCRIPTION
## Summary
- remove Laguna S 2.1 from Auto Free candidate routing
- keep Laguna S 2.1 in the preferred model list
- update model-list coverage for the new behavior

## Testing
- CI only, as requested