### PR TITLE
fix(extension): session context, cost, and model parity with mobile

### DIFF
--- a/apps/extension/AGENTS.md
+++ b/apps/extension/AGENTS.md
@@ -59,7 +59,7 @@ Before committing extension changes, run `pnpm format`. Prefer `pnpm --filter ki
 
 - Safe mode exposes read tools (`get_page_snapshot`, `find_in_page`, `get_element_details`, `search_memories`, `get_memory`, and when the model supports images `get_viewport_screenshot`), workflow read tools (`search_workflows`, `get_workflow`), and card-gated tools (`save_workflow`, `save_memory`).
 - `search_workflows` without a query lists workflows scoped to the selected tab. With a query it searches every site, ranks in-scope matches first, and reports `inScope` and `startUrl` per result.
-- `save_workflow` and `save_memory` are card-gated — the executor blocks the tool turn until the user approves or rejects on the approval card, unless auto-approve workflow changes is on, which stores a workflow save with no card; `save_memory` is always card-gated.
+- `save_workflow` and `save_memory` are card-gated — the executor blocks the tool turn until the user approves or rejects on the approval card. Auto-approve workflow changes stores a workflow save with no card. Auto-approve memory saves does the same for `save_memory`; it is off by default, so the confirmation card is the default behavior. A settings read failure always falls back to showing the card.
 - `run_workflow` is gated behind the "Allow workflows in safe mode" toggle. In dangerous mode the toggle is bypassed and `run_workflow` is always available.
 - `delete_workflow` and `eval` are dangerous-mode only and never exposed in safe mode.
 - Safe tools must not click, type, navigate, submit forms, read cookies, read storage (other than the user's own saved memories via `search_memories`/`get_memory`), or run model-authored JavaScript. The one allowed side effect is `get_viewport_screenshot` momentarily foregrounding the target tab to capture the visible viewport, then restoring the previously active tab.
@@ -93,7 +93,7 @@ Do not treat a dry run that stops after recorded actions as a broken workflow, a
 
 ### Settings
 
-- Auto-approve workflow changes and Auto-approve workflow runs are off by default.
+- Auto-approve workflow changes and Auto-approve workflow runs are off by default. The memory equivalent, Auto-approve memory saves, lives in the memories settings section with its own storage key (`local:kiloMemorySettings`), so a workflow toggle write cannot revert it.
 - The approval card shows a unified diff of the script when a stored workflow is edited, and the plain script when a new workflow is created.
 
 ## Prompt Context

--- a/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
+++ b/apps/extension/entrypoints/sidepanel/agent-chat-panel.tsx
@@ -318,6 +318,7 @@ export const AgentChatPanel = ({
         onCompact={() => {
           void compactActiveConversation();
         }}
+        placement="above"
         promptTokens={activePromptTokens}
         sessionCostUsd={activeSessionCostUsd}
       />

--- a/apps/extension/entrypoints/sidepanel/agents-composer.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-composer.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useState } from 'react';
-import type { ChangeEvent, JSX, KeyboardEvent } from 'react';
+import type { ChangeEvent, JSX, KeyboardEvent, ReactNode } from 'react';
 
 export const AgentsComposer = ({
   canSend,
@@ -7,6 +7,7 @@ export const AgentsComposer = ({
   isStreaming,
   isReadOnly,
   isLoading,
+  modelPicker,
   onSend,
   onStop,
 }: {
@@ -15,6 +16,8 @@ export const AgentsComposer = ({
   isStreaming: boolean;
   isReadOnly: boolean;
   isLoading: boolean;
+  /** Model control row; omitted when the session has no pickable catalog. */
+  modelPicker?: ReactNode;
   onSend: (text: string) => void | Promise<void>;
   onStop: () => void;
 }): JSX.Element => {
@@ -95,6 +98,7 @@ export const AgentsComposer = ({
         placeholder="Send a message…"
         value={draft}
       />
+      {modelPicker === undefined ? null : <div className="mt-2 flex gap-2">{modelPicker}</div>}
       <div className="mt-2 flex gap-2">
         <button
           className={`type-label h-9 ${isStreaming ? 'flex-1' : 'w-full'} rounded-md border border-transparent bg-brand-primary px-3 text-brand-primary-foreground transition hover:bg-brand-primary-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background disabled:cursor-not-allowed disabled:bg-surface-selected disabled:text-foreground-subtle`}

--- a/apps/extension/entrypoints/sidepanel/agents-new-session-cli-target.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session-cli-target.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi } from 'vitest';
+
+import { CLI_MODEL_ID } from '@kilocode/cloud-agent-sdk';
+
+import { buildCreateRemoteSessionInput } from './agents-new-session';
+
+/* eslint-disable jest/no-untyped-mock-factory, vitest/prefer-import-in-mock -- WXT virtual module has no importable runtime type in Vitest. */
+// Agents-new-session transitively imports the WXT '#imports' virtual module.
+// Stub it so the graph loads under Vitest.
+vi.mock('#imports', () => ({
+  browser: { runtime: { sendMessage: vi.fn() }, tabs: { query: vi.fn() } },
+  storage: {
+    getItem: vi.fn(),
+    setItem: vi.fn(),
+    watch: vi.fn(() => () => {
+      /* No-op unwatch */
+    }),
+  },
+}));
+
+describe('buildCreateRemoteSessionInput helper', () => {
+  it('carries the picked model as a kilo model ref', () => {
+    const input = buildCreateRemoteSessionInput({
+      organizationId: null,
+      selectedModel: 'anthropic/claude-sonnet-4.5',
+      selectedVariant: '',
+    });
+    expect(input).toStrictEqual({
+      model: { modelID: 'anthropic/claude-sonnet-4.5', providerID: 'kilo' },
+    });
+  });
+
+  it('adds the variant when one is picked', () => {
+    const input = buildCreateRemoteSessionInput({
+      organizationId: null,
+      selectedModel: 'gpt-5',
+      selectedVariant: 'xhigh',
+    });
+    expect(input.model).toStrictEqual({
+      modelID: 'gpt-5',
+      providerID: 'kilo',
+      variant: 'xhigh',
+    });
+  });
+
+  it('omits the model for the CLI default, so the CLI keeps its own model', () => {
+    const input = buildCreateRemoteSessionInput({
+      organizationId: null,
+      selectedModel: CLI_MODEL_ID,
+      selectedVariant: '',
+    });
+    expect(input).toStrictEqual({});
+  });
+
+  it('omits the model before the catalog loads', () => {
+    const input = buildCreateRemoteSessionInput({
+      organizationId: null,
+      selectedModel: '',
+      selectedVariant: 'high',
+    });
+    expect(input).toStrictEqual({});
+  });
+
+  it('adds orgId for an organization target', () => {
+    const input = buildCreateRemoteSessionInput({
+      organizationId: 'org-42',
+      selectedModel: 'gpt-5',
+      selectedVariant: '',
+    });
+    expect(input.orgId).toBe('org-42');
+  });
+
+  it('omits orgId for a personal target', () => {
+    expect(
+      buildCreateRemoteSessionInput({
+        organizationId: undefined,
+        selectedModel: CLI_MODEL_ID,
+        selectedVariant: '',
+      })
+    ).not.toHaveProperty('orgId');
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
@@ -18,16 +18,21 @@ import {
   TerminalSquare,
 } from 'lucide-react';
 import {
+  CLI_MODEL_ID,
+  cliModelLabel,
   createRemoteSessionOnConnection,
   formatSessionError,
   parseCreateSessionResponse,
 } from '@kilocode/cloud-agent-sdk';
+import type { CreateRemoteSessionInput } from '@kilocode/cloud-agent-sdk';
 import { generateMessageId } from '@kilocode/cloud-agent-sdk/message-id';
 import type { StoredAuth } from '@/src/shared/auth';
 import { getKiloApiBaseUrl, loadStoredAuth } from '@/src/shared/auth';
 import { fetchModelPreferences } from '@/src/shared/model-preferences-client';
+import { isGatewayModelId } from '@/src/shared/model-picker-rows';
 import { getModelPreferencesQueryKey } from '@/src/shared/side-panel-query-options';
 import { thinkingEffortLabel } from '@/src/shared/kilo-api-client';
+import type { KiloGatewayModelOption } from '@/src/shared/kilo-api-client';
 import { useExtensionAgents } from './agents-provider';
 import { activeSessionsQueryKey, sessionHistoryQueryKey } from './agents-session-list';
 import { ModelPicker } from './model-picker';
@@ -40,6 +45,19 @@ import { useGatewayModels } from './use-gateway-models';
 const PROMPT_MIN_LENGTH = 3;
 const PROMPT_MAX_LENGTH = 4000;
 const MODE = 'code' as const;
+
+/**
+ * Synthetic first row for a CLI target: keep the CLI on its own configured
+ * model. Picking it omits `model` from `create_session`, so the CLI decides.
+ * The shared picker hides the favorite star on it: model preferences are keyed
+ * by gateway model id, and this id is not one.
+ */
+const CLI_DEFAULT_MODEL_OPTION: KiloGatewayModelOption = {
+  id: CLI_MODEL_ID,
+  isPreferred: true,
+  name: cliModelLabel(null),
+  variants: [],
+};
 
 export { PROMPT_MAX_LENGTH, PROMPT_MIN_LENGTH, MODE };
 // Exported for focused test coverage.
@@ -124,6 +142,32 @@ export const buildSubmitInput = ({
   model: selectedModel,
   prompt,
   ...(selectedVariant ? { variant: selectedVariant } : {}),
+});
+
+/**
+ * `create_session` carries the model itself, so a CLI session starts on the
+ * picked gateway model — no first-prompt override needed. `CLI_MODEL_ID` means
+ * "leave the CLI on its own model": the field is omitted from the wire.
+ */
+export const buildCreateRemoteSessionInput = ({
+  organizationId,
+  selectedModel,
+  selectedVariant,
+}: {
+  organizationId: string | null | undefined;
+  selectedModel: string;
+  selectedVariant: string;
+}): CreateRemoteSessionInput => ({
+  ...(organizationId === null || organizationId === undefined ? {} : { orgId: organizationId }),
+  ...(selectedModel === '' || selectedModel === CLI_MODEL_ID
+    ? {}
+    : {
+        model: {
+          modelID: selectedModel,
+          providerID: 'kilo',
+          ...(selectedVariant ? { variant: selectedVariant } : {}),
+        },
+      }),
 });
 
 /**
@@ -293,6 +337,10 @@ export const AgentsNewSession = ({
   const [selectedRepo, setSelectedRepo] = useState('');
   const [selectedModel, setSelectedModel] = useState('');
   const [selectedVariant, setSelectedVariant] = useState('');
+  /* A CLI target keeps its own model choice, so switching targets never leaks
+     the synthetic CLI id into a cloud submit, or a cloud model into the CLI. */
+  const [cliModel, setCliModel] = useState<string>(CLI_MODEL_ID);
+  const [cliVariant, setCliVariant] = useState('');
   /** 'cloud' or a CLI instance connectionId. */
   const [runTarget, setRunTarget] = useState('cloud');
   const [isModelUserSelected, setIsModelUserSelected] = useState(false);
@@ -363,17 +411,26 @@ export const AgentsNewSession = ({
     setSelectedRepo(repos[0]?.fullName ?? '');
   }, [repos, selectedRepo]);
 
+  // ---- Picker values per run target ----
+  const pickerModelOptions = useMemo(
+    () => (isCloudTarget ? modelOptions : [CLI_DEFAULT_MODEL_OPTION, ...modelOptions]),
+    [isCloudTarget, modelOptions]
+  );
+  const pickerModel = isCloudTarget ? selectedModel : cliModel;
+  const pickerVariant = isCloudTarget ? selectedVariant : cliVariant;
+
   // ---- Variants for current model ----
   const selectedModelOption = useMemo(
-    () => modelOptions.find(opt => opt.id === selectedModel),
-    [modelOptions, selectedModel]
+    () => modelOptions.find(opt => opt.id === pickerModel),
+    [modelOptions, pickerModel]
   );
   const availableVariants = selectedModelOption?.variants ?? [];
 
   // ---- Derived state ----
   const trimmed = trimValue(prompt);
   const isPromptValid = trimmed.length >= PROMPT_MIN_LENGTH && trimmed.length <= PROMPT_MAX_LENGTH;
-  // A CLI instance inherits repo and model from the CLI; cloud needs both.
+  /* A CLI instance inherits the repo from the CLI and defaults to its own
+     model; cloud needs both picked. */
   const isFormValid = isCloudTarget
     ? isPromptValid && selectedModel !== '' && selectedRepo !== ''
     : isPromptValid;
@@ -415,22 +472,34 @@ export const AgentsNewSession = ({
   // ---- Handlers ----
   const handleModelSelect = useCallback(
     (modelId: string) => {
-      setSelectedModel(modelId);
-      setIsModelUserSelected(true);
-      setSelectedVariant('');
-      setLastSelectedMutation.mutate({ model: modelId });
+      if (isCloudTarget) {
+        setSelectedModel(modelId);
+        setIsModelUserSelected(true);
+        setSelectedVariant('');
+      } else {
+        setCliModel(modelId);
+        setCliVariant('');
+      }
+      if (isGatewayModelId(modelId)) {
+        // Never persist a non-gateway id: it would wipe the real lastSelected.
+        setLastSelectedMutation.mutate({ model: modelId });
+      }
     },
-    [setLastSelectedMutation]
+    [isCloudTarget, setLastSelectedMutation]
   );
 
   const handleVariantSelect = useCallback(
     (variant: string) => {
-      setSelectedVariant(variant);
-      if (selectedModel) {
-        setLastSelectedMutation.mutate({ model: selectedModel, variant });
+      if (isCloudTarget) {
+        setSelectedVariant(variant);
+      } else {
+        setCliVariant(variant);
+      }
+      if (isGatewayModelId(pickerModel)) {
+        setLastSelectedMutation.mutate({ model: pickerModel, variant });
       }
     },
-    [selectedModel, setLastSelectedMutation]
+    [isCloudTarget, pickerModel, setLastSelectedMutation]
   );
 
   const handleSubmit = useCallback(async () => {
@@ -447,7 +516,11 @@ export const AgentsNewSession = ({
         const raw = await createRemoteSessionOnConnection(
           userWebConnection,
           runTarget,
-          organizationId === null ? undefined : { orgId: organizationId }
+          buildCreateRemoteSessionInput({
+            organizationId,
+            selectedModel: cliModel,
+            selectedVariant: cliVariant,
+          })
         );
         const parsed = parseCreateSessionResponse(raw);
         if (!parsed.ok) {
@@ -518,6 +591,8 @@ export const AgentsNewSession = ({
     isSubmitting,
     isCloudTarget,
     runTarget,
+    cliModel,
+    cliVariant,
     userWebConnection,
     trimmed,
     selectedModel,
@@ -659,66 +734,67 @@ export const AgentsNewSession = ({
 
         {/* Toolbar: model + variant + repo */}
         <div className="flex flex-wrap items-center gap-2">
-          {/* Model picker (cloud target only) — same component as the browser tab.
+          {/* Model picker — same component as the browser tab, for both run
+              targets. A CLI target also gets the synthetic "CLI default" row.
               The wrapper's min width stops the flexible trigger collapsing to a
               sliver once the repo and Run-on pickers share the row; the row
               wraps instead. */}
-          {isCloudTarget && auth !== undefined ? (
+          {auth === undefined ? null : (
             <div className="flex min-w-36 flex-1">
               <ModelPicker
                 auth={auth}
-                disabled={isSubmitting || modelOptions.length === 0}
-                model={selectedModel}
-                modelOptions={modelOptions}
+                disabled={isSubmitting || pickerModelOptions.length === 0}
+                model={pickerModel}
+                modelOptions={pickerModelOptions}
                 onModelChange={handleModelSelect}
                 organizationId={organizationId ?? undefined}
               />
             </div>
-          ) : null}
-          {isCloudTarget
-            ? (() => {
-                if (modelLoadError !== undefined) {
-                  return (
-                    <div className="flex items-center gap-1.5">
-                      <AlertTriangle className="size-3.5 shrink-0 text-status-red-400" />
-                      <span className="type-label text-status-red-400">{modelLoadError}</span>
-                      <button
-                        className="type-label text-link hover:text-link-hover underline underline-offset-4"
-                        onClick={() => {
-                          void refetchModels();
-                        }}
-                        type="button"
-                      >
-                        Retry
-                      </button>
-                    </div>
-                  );
-                }
-                if (isModelsLoading) {
-                  return null;
-                }
-                if (modelOptions.length === 0) {
-                  return (
-                    <div className="flex items-center gap-1.5">
-                      <span className="type-label text-foreground-muted">No models available</span>
-                      <button
-                        className="type-label text-link hover:text-link-hover underline underline-offset-4"
-                        onClick={() => {
-                          void refetchModels();
-                        }}
-                        type="button"
-                      >
-                        Retry
-                      </button>
-                    </div>
-                  );
-                }
-                return null;
-              })()
-            : null}
+          )}
+          {(() => {
+            if (modelLoadError !== undefined) {
+              return (
+                <div className="flex items-center gap-1.5">
+                  <AlertTriangle className="size-3.5 shrink-0 text-status-red-400" />
+                  <span className="type-label text-status-red-400">{modelLoadError}</span>
+                  <button
+                    className="type-label text-link hover:text-link-hover underline underline-offset-4"
+                    onClick={() => {
+                      void refetchModels();
+                    }}
+                    type="button"
+                  >
+                    Retry
+                  </button>
+                </div>
+              );
+            }
+            if (isModelsLoading) {
+              return null;
+            }
+            if (modelOptions.length === 0) {
+              return (
+                <div className="flex items-center gap-1.5">
+                  <span className="type-label text-foreground-muted">
+                    {isCloudTarget ? 'No models available' : 'Only the CLI model is available'}
+                  </span>
+                  <button
+                    className="type-label text-link hover:text-link-hover underline underline-offset-4"
+                    onClick={() => {
+                      void refetchModels();
+                    }}
+                    type="button"
+                  >
+                    Retry
+                  </button>
+                </div>
+              );
+            }
+            return null;
+          })()}
 
-          {/* Variant picker (cloud target only) */}
-          {isCloudTarget && availableVariants.length > 0 ? (
+          {/* Variant picker */}
+          {availableVariants.length > 0 ? (
             <div className="relative">
               <div className="flex h-8 items-center gap-1.5 rounded-md border border-border bg-surface-overlay px-2 type-label text-foreground-on-secondary transition hover:bg-surface-hover outline-none focus-within:ring-2 focus-within:ring-brand-primary-ring">
                 <select
@@ -728,7 +804,7 @@ export const AgentsNewSession = ({
                   onChange={changeEvent => {
                     handleVariantSelect(changeEvent.target.value);
                   }}
-                  value={selectedVariant}
+                  value={pickerVariant}
                 >
                   <option value="">Auto</option>
                   {availableVariants.map(variant => (
@@ -918,7 +994,7 @@ export const AgentsNewSession = ({
         {/* CLI target hint */}
         {isCloudTarget || selectedInstance === undefined ? null : (
           <p className="type-label -mt-2 text-foreground-muted">
-            Runs in {selectedInstance.projectName} with the repository and model of the CLI.
+            Runs in {selectedInstance.projectName} with the repository of the CLI.
           </p>
         )}
 

--- a/apps/extension/entrypoints/sidepanel/agents-session-controls.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-session-controls.test.ts
@@ -1,0 +1,298 @@
+/* eslint-disable sort-keys */
+import { describe, expect, it } from 'vitest';
+import type {
+  ContextUsage,
+  RemoteModelCatalogV1,
+  RemoteModelState,
+} from '@kilocode/cloud-agent-sdk';
+import type { KiloGatewayModelOption } from '@/src/shared/kilo-api-client';
+import {
+  cliCatalogModelId,
+  findCliCatalogModelRef,
+  resolveSessionContextWindow,
+  selectSessionCostUsd,
+  selectSessionModelPicker,
+  shouldShowContextMetrics,
+} from './agents-session-controls';
+
+const model = (id: string, contextLength?: number): KiloGatewayModelOption => ({
+  id,
+  isPreferred: false,
+  name: id,
+  variants: [],
+  ...(contextLength === undefined ? {} : { contextLength }),
+});
+
+const usage = (modelID: string, providerID = 'kilo'): ContextUsage => ({
+  contextTokens: 1234,
+  modelID,
+  providerID,
+});
+
+describe('resolveSessionContextWindow()', () => {
+  it('resolves the window for a gateway model', () => {
+    expect(resolveSessionContextWindow(usage('a/b'), [model('a/b', 200_000)])).toBe(200_000);
+  });
+
+  it('returns undefined without context usage', () => {
+    expect(resolveSessionContextWindow(undefined, [model('a/b', 200_000)])).toBeUndefined();
+  });
+
+  it('returns undefined for a non-gateway provider', () => {
+    expect(
+      resolveSessionContextWindow(usage('a/b', 'anthropic'), [model('a/b', 200_000)])
+    ).toBeUndefined();
+  });
+
+  it('returns undefined when the catalog has no matching id', () => {
+    expect(resolveSessionContextWindow(usage('a/b'), [model('c/d', 200_000)])).toBeUndefined();
+  });
+
+  it('returns undefined when the matching option has no window', () => {
+    expect(resolveSessionContextWindow(usage('a/b'), [model('a/b')])).toBeUndefined();
+  });
+
+  it('ignores a non-positive window', () => {
+    expect(resolveSessionContextWindow(usage('a/b'), [model('a/b', 0)])).toBeUndefined();
+  });
+
+  it('treats a conflicting duplicate id as unknown', () => {
+    expect(
+      resolveSessionContextWindow(usage('a/b'), [model('a/b', 200_000), model('a/b', 128_000)])
+    ).toBeUndefined();
+  });
+
+  it('accepts an agreeing duplicate id', () => {
+    expect(
+      resolveSessionContextWindow(usage('a/b'), [model('a/b', 200_000), model('a/b', 200_000)])
+    ).toBe(200_000);
+  });
+});
+
+describe('selectSessionCostUsd()', () => {
+  it('takes the persisted total when it is larger', () => {
+    expect(selectSessionCostUsd(2_500_000, 1.5)).toBe(2.5);
+  });
+
+  it('takes the live total when it is larger', () => {
+    expect(selectSessionCostUsd(1_000_000, 3.25)).toBe(3.25);
+  });
+
+  it('ignores a missing or non-finite persisted total', () => {
+    expect(selectSessionCostUsd(null, 2)).toBe(2);
+    expect(selectSessionCostUsd(undefined, 2)).toBe(2);
+    expect(selectSessionCostUsd(Number.NaN, 2)).toBe(2);
+  });
+
+  it('clamps negative inputs to zero', () => {
+    expect(selectSessionCostUsd(-5, -1)).toBe(0);
+  });
+});
+
+const noUsage: ContextUsage | undefined = undefined;
+
+describe('shouldShowContextMetrics()', () => {
+  it('hides while the session loads', () => {
+    expect(shouldShowContextMetrics(true, usage('a/b'))).toBe(false);
+  });
+
+  it('hides until the first assistant reply reports usage', () => {
+    expect(shouldShowContextMetrics(false, noUsage)).toBe(false);
+  });
+
+  it('shows for a loaded session with usage', () => {
+    expect(shouldShowContextMetrics(false, usage('a/b'))).toBe(true);
+  });
+});
+
+const catalogModel = (
+  id: string,
+  extra: { readonly name?: string; readonly recommendedIndex?: number } = {}
+): RemoteModelCatalogV1['providers'][number]['models'][number] => ({
+  capabilities: { attachment: false, reasoning: false },
+  id,
+  limits: { context: 128_000, output: 8000 },
+  variants: [],
+  ...extra,
+});
+
+const catalog: RemoteModelCatalogV1 = {
+  protocolVersion: 1,
+  providers: [
+    { id: 'kilo', models: [catalogModel('grok-code', { recommendedIndex: 0 })], name: 'Kilo' },
+    { id: 'anthropic', models: [catalogModel('claude-sonnet-4', { name: 'Sonnet 4' })] },
+  ],
+  defaultModel: { modelID: 'grok-code', providerID: 'kilo' },
+  truncated: false,
+};
+
+const remoteState = (overrides: Partial<RemoteModelState> = {}): RemoteModelState => ({
+  ownerConnectionId: null,
+  protocol: 'unknown',
+  refresh: 'idle',
+  ...overrides,
+});
+
+const pickerInput = {
+  activeSessionType: null,
+  cloudOverride: null,
+  gatewayModels: [model('a/b', 200_000)],
+  observedModel: null,
+  remoteModelOverride: null,
+  remoteModelState: remoteState(),
+  sessionModel: null,
+} satisfies Parameters<typeof selectSessionModelPicker>[0];
+
+describe('cliCatalogModelId and findCliCatalogModelRef', () => {
+  it('round-trips a catalog model ref through its row id', () => {
+    const id = cliCatalogModelId({ modelID: 'claude-sonnet-4', providerID: 'anthropic' });
+    expect(id).toBe('cli:anthropic/claude-sonnet-4');
+    expect(findCliCatalogModelRef(catalog, id)).toStrictEqual({
+      modelID: 'claude-sonnet-4',
+      providerID: 'anthropic',
+    });
+  });
+
+  it('returns undefined for an id the catalog does not have', () => {
+    expect(findCliCatalogModelRef(catalog, 'cli:anthropic/nope')).toBeUndefined();
+    expect(findCliCatalogModelRef(undefined, 'cli:anthropic/claude-sonnet-4')).toBeUndefined();
+    expect(findCliCatalogModelRef(catalog, 'anthropic/claude-sonnet-4')).toBeUndefined();
+  });
+});
+
+describe('selectSessionModelPicker()', () => {
+  it('picks gateway models for a cloud-agent session', () => {
+    expect(
+      selectSessionModelPicker({
+        ...pickerInput,
+        activeSessionType: 'cloud-agent',
+        cloudOverride: { model: 'picked' },
+        sessionModel: 'configured',
+      })
+    ).toStrictEqual({
+      disabledReason: undefined,
+      options: pickerInput.gatewayModels,
+      selectedId: 'picked',
+      target: 'cloud-agent',
+    });
+  });
+
+  it('falls back to the session model for a cloud-agent session', () => {
+    expect(
+      selectSessionModelPicker({
+        ...pickerInput,
+        activeSessionType: 'cloud-agent',
+        sessionModel: 'configured',
+      }).selectedId
+    ).toBe('configured');
+  });
+
+  it('picks gateway models for a legacy remote session', () => {
+    expect(
+      selectSessionModelPicker({
+        ...pickerInput,
+        activeSessionType: 'remote',
+        remoteModelOverride: {
+          selection: { model: { modelID: 'picked', providerID: 'kilo' } },
+          source: 'legacy-gateway',
+        },
+        remoteModelState: remoteState({ protocol: 'legacy' }),
+      })
+    ).toStrictEqual({
+      disabledReason: undefined,
+      options: pickerInput.gatewayModels,
+      selectedId: 'picked',
+      target: 'remote-legacy',
+    });
+  });
+
+  it("projects a v1 CLI's own catalog, prefixed so no gateway id can collide", () => {
+    const picker = selectSessionModelPicker({
+      ...pickerInput,
+      activeSessionType: 'remote',
+      remoteModelState: remoteState({ catalog, protocol: 'v1' }),
+    });
+
+    expect(picker.target).toBe('remote-cli');
+    expect(picker.options.map(option => option.id)).toStrictEqual([
+      'cli:kilo/grok-code',
+      'cli:anthropic/claude-sonnet-4',
+    ]);
+    expect(picker.options.map(option => option.name)).toStrictEqual(['grok-code', 'Sonnet 4']);
+    // No row is promoted: the CLI's own catalog order stands.
+    expect(picker.options.map(option => option.isPreferred)).toStrictEqual([false, false]);
+    expect(picker.options[0]?.contextLength).toBe(128_000);
+  });
+
+  it('selects the catalog default, then the observed model, then the override', () => {
+    const base = {
+      ...pickerInput,
+      activeSessionType: 'remote' as const,
+      remoteModelState: remoteState({ catalog, protocol: 'v1' }),
+    };
+
+    expect(selectSessionModelPicker(base).selectedId).toBe('cli:kilo/grok-code');
+    expect(
+      selectSessionModelPicker({
+        ...base,
+        observedModel: { model: { modelID: 'claude-sonnet-4', providerID: 'anthropic' } },
+      }).selectedId
+    ).toBe('cli:anthropic/claude-sonnet-4');
+    expect(
+      selectSessionModelPicker({
+        ...base,
+        observedModel: { model: { modelID: 'claude-sonnet-4', providerID: 'anthropic' } },
+        remoteModelOverride: {
+          selection: { model: { modelID: 'grok-code', providerID: 'kilo' } },
+          source: 'cli-catalog',
+        },
+      }).selectedId
+    ).toBe('cli:kilo/grok-code');
+  });
+
+  it('offers no options while a v1 CLI has reported no catalog', () => {
+    expect(
+      selectSessionModelPicker({
+        ...pickerInput,
+        activeSessionType: 'remote',
+        remoteModelState: remoteState({ protocol: 'v1' }),
+        sessionModel: 'session-model',
+      })
+    ).toStrictEqual({
+      disabledReason: 'Loading models…',
+      options: [],
+      selectedId: 'session-model',
+      target: 'remote-unavailable',
+    });
+  });
+
+  it('offers no options when the CLI catalog has no connected provider', () => {
+    const picker = selectSessionModelPicker({
+      ...pickerInput,
+      activeSessionType: 'remote',
+      remoteModelState: remoteState({
+        catalog: { ...catalog, providers: [] },
+        protocol: 'v1',
+      }),
+    });
+
+    expect(picker.target).toBe('remote-unavailable');
+    expect(picker.disabledReason).toBe('Loading models…');
+  });
+
+  it('reports a failed catalog fetch as unavailable', () => {
+    expect(
+      selectSessionModelPicker({
+        ...pickerInput,
+        activeSessionType: 'remote',
+        remoteModelState: remoteState({ protocol: 'unknown', refresh: 'error' }),
+      }).disabledReason
+    ).toBe('Models unavailable');
+  });
+
+  it('has no picker for a read-only or unresolved session', () => {
+    const readOnly = selectSessionModelPicker({ ...pickerInput, activeSessionType: 'read-only' });
+    expect(readOnly.target).toBeNull();
+    expect(selectSessionModelPicker(pickerInput).target).toBeNull();
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/agents-session-controls.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-session-controls.ts
@@ -1,0 +1,190 @@
+import type {
+  ActiveSessionType,
+  ContextUsage,
+  ModelRef,
+  ModelSelection,
+  RemoteModelCatalogV1,
+  RemoteModelOverride,
+  RemoteModelState,
+} from '@kilocode/cloud-agent-sdk';
+import { CLI_CATALOG_ID_PREFIX } from '@/src/shared/model-picker-rows';
+import type { KiloGatewayModelOption } from '@/src/shared/kilo-api-client';
+
+/** Provider id the gateway reports for its own catalog. Remote CLIs report their own. */
+const GATEWAY_PROVIDER_ID = 'kilo';
+
+const isPositive = (value: number | undefined): value is number =>
+  value !== undefined && Number.isFinite(value) && value > 0;
+
+/**
+ * Context window of the model that produced the latest assistant message.
+ * Only the gateway catalog is available here, so a remote CLI provider stays
+ * unknown. A conflicting duplicate id is unknown too — never guess a window.
+ */
+export const resolveSessionContextWindow = (
+  contextUsage: ContextUsage | undefined,
+  modelOptions: readonly KiloGatewayModelOption[]
+): number | undefined => {
+  if (contextUsage === undefined || contextUsage.providerID !== GATEWAY_PROVIDER_ID) {
+    return undefined;
+  }
+
+  const windows = new Set<number>();
+  for (const option of modelOptions) {
+    if (option.id === contextUsage.modelID && isPositive(option.contextLength)) {
+      windows.add(option.contextLength);
+    }
+  }
+
+  return windows.size === 1 ? [...windows].at(0) : undefined;
+};
+
+/**
+ * Canonical session spend in USD. Session cost only grows, so the persisted
+ * total and the live client sum are both lower bounds and the max is closest
+ * to the truth.
+ */
+export const selectSessionCostUsd = (
+  persistedMicrodollars: number | null | undefined,
+  liveUsd: number
+): number => {
+  const persisted =
+    typeof persistedMicrodollars === 'number' && Number.isFinite(persistedMicrodollars)
+      ? Math.max(0, persistedMicrodollars / 1_000_000)
+      : 0;
+  const live = Number.isFinite(liveUsd) ? Math.max(0, liveUsd) : 0;
+
+  return Math.max(persisted, live);
+};
+
+/** The indicator needs a loaded session with at least one assistant reply. */
+export const shouldShowContextMetrics = (
+  isLoading: boolean,
+  contextUsage: ContextUsage | undefined
+): boolean => !isLoading && contextUsage !== undefined;
+
+/** Picker row id for a CLI-catalog model. Carries the CLI's own model ref. */
+export const cliCatalogModelId = (model: ModelRef): string =>
+  `${CLI_CATALOG_ID_PREFIX}${model.providerID}/${model.modelID}`;
+
+/**
+ * The catalog entry a picker row id points at. Compares built ids instead of
+ * parsing, so a model id containing a slash stays unambiguous.
+ */
+export const findCliCatalogModelRef = (
+  catalog: RemoteModelCatalogV1 | undefined,
+  optionId: string
+): ModelRef | undefined => {
+  for (const provider of catalog?.providers ?? []) {
+    for (const model of provider.models) {
+      const modelRef = { modelID: model.id, providerID: provider.id };
+      if (cliCatalogModelId(modelRef) === optionId) {
+        return modelRef;
+      }
+    }
+  }
+
+  return undefined;
+};
+
+/** The CLI's own catalog projected onto the shared picker's option shape. */
+const buildCliCatalogOptions = (catalog: RemoteModelCatalogV1): readonly KiloGatewayModelOption[] =>
+  catalog.providers.flatMap(provider =>
+    provider.models.map(model => ({
+      contextLength: model.limits.context,
+      id: cliCatalogModelId({ modelID: model.id, providerID: provider.id }),
+      // No RECOMMENDED group: keep the CLI's own catalog order, as mobile does.
+      isPreferred: false,
+      name: model.name ?? model.id,
+      variants: model.variants,
+      ...(model.isFree === undefined ? {} : { isFree: model.isFree }),
+      ...(model.hasUserByokAvailable === undefined
+        ? {}
+        : { hasUserByokAvailable: model.hasUserByokAvailable }),
+      ...(model.mayTrainOnYourPrompts === undefined
+        ? {}
+        : { mayTrainOnYourPrompts: model.mayTrainOnYourPrompts }),
+    }))
+  );
+
+/**
+ * Which catalog an open session picks from, and which override setter applies.
+ * A v1 CLI owns its catalog, so a gateway model id is rejected at send; a CLI
+ * that has not reported one yet gets a disabled trigger, never a wrong model.
+ */
+// eslint-disable-next-line typescript-eslint/consistent-type-definitions -- AGENTS.md prefers type
+export type SessionModelPicker = {
+  readonly target: 'cloud-agent' | 'remote-cli' | 'remote-legacy' | 'remote-unavailable' | null;
+  readonly options: readonly KiloGatewayModelOption[];
+  readonly selectedId: string;
+  readonly disabledReason: string | undefined;
+};
+
+export const selectSessionModelPicker = ({
+  activeSessionType,
+  cloudOverride,
+  gatewayModels,
+  observedModel,
+  remoteModelOverride,
+  remoteModelState,
+  sessionModel,
+}: {
+  activeSessionType: ActiveSessionType | null;
+  cloudOverride: { readonly model: string } | null;
+  gatewayModels: readonly KiloGatewayModelOption[];
+  observedModel: ModelSelection | null;
+  remoteModelOverride: RemoteModelOverride | null;
+  remoteModelState: RemoteModelState;
+  sessionModel: string | null | undefined;
+}): SessionModelPicker => {
+  if (activeSessionType === 'remote') {
+    const { catalog } = remoteModelState;
+
+    // An empty catalog (no connected provider) is as unpickable as no catalog.
+    if (
+      remoteModelState.protocol === 'v1' &&
+      catalog !== undefined &&
+      catalog.providers.length > 0
+    ) {
+      const selection =
+        remoteModelOverride?.selection ??
+        observedModel ??
+        (catalog.defaultModel === undefined ? null : { model: catalog.defaultModel });
+
+      return {
+        disabledReason: undefined,
+        options: buildCliCatalogOptions(catalog),
+        selectedId: selection === null ? '' : cliCatalogModelId(selection.model),
+        target: 'remote-cli',
+      };
+    }
+
+    if (remoteModelState.protocol === 'legacy') {
+      return {
+        disabledReason: undefined,
+        options: gatewayModels,
+        selectedId: remoteModelOverride?.selection.model.modelID ?? sessionModel ?? '',
+        target: 'remote-legacy',
+      };
+    }
+
+    return {
+      disabledReason:
+        remoteModelState.refresh === 'error' ? 'Models unavailable' : 'Loading models…',
+      options: [],
+      selectedId: observedModel?.model.modelID ?? sessionModel ?? '',
+      target: 'remote-unavailable',
+    };
+  }
+
+  if (activeSessionType === 'cloud-agent') {
+    return {
+      disabledReason: undefined,
+      options: gatewayModels,
+      selectedId: cloudOverride?.model ?? sessionModel ?? '',
+      target: 'cloud-agent',
+    };
+  }
+
+  return { disabledReason: undefined, options: [], selectedId: '', target: null };
+};

--- a/apps/extension/entrypoints/sidepanel/agents-session-list.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-session-list.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   activeSessionsQueryKey,
+  historyEmptyMessage,
   mapActiveSessionRow,
   mapHistorySessionRow,
   sessionHistoryQueryKey,
@@ -208,5 +209,28 @@ describe('query key functions', () => {
         'search term',
       ]);
     });
+  });
+});
+
+describe('historyEmptyMessage()', () => {
+  it('keeps the search copy while searching, whatever else is listed', () => {
+    expect(historyEmptyMessage({ hasActiveSessions: true, isSearching: true })).toBe(
+      'No sessions match your search.'
+    );
+    expect(historyEmptyMessage({ hasActiveSessions: false, isSearching: true })).toBe(
+      'No sessions match your search.'
+    );
+  });
+
+  it('does not claim a first run when active sessions are listed above', () => {
+    expect(historyEmptyMessage({ hasActiveSessions: true, isSearching: false })).toBe(
+      'No past sessions yet.'
+    );
+  });
+
+  it('invites the first session only when the account has none', () => {
+    expect(historyEmptyMessage({ hasActiveSessions: false, isSearching: false })).toBe(
+      'No sessions yet. Start your first session above.'
+    );
   });
 });

--- a/apps/extension/entrypoints/sidepanel/agents-session-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-session-list.tsx
@@ -143,6 +143,42 @@ export const sessionStatusBadge = (
 };
 
 // ---------------------------------------------------------------------------
+// Shared layout + copy
+// ---------------------------------------------------------------------------
+
+/** One vertical rhythm for both sections. */
+const sectionClass = 'space-y-2 px-4 py-2';
+
+/**
+ * One text column for both sections: an Active row indents its title by
+ * px-2 (8px) + a size-3.5 icon (14px) + gap-1.5 (6px) = 28px. `pl-7` puts a
+ * History row, a sub-line, and an empty line on that same left edge.
+ */
+const rowTextColumnClass = 'py-1.5 pl-7 pr-2';
+
+/** One empty-state treatment for both sections. */
+const emptyStateClass = 'type-label pl-7 pr-2 text-foreground-muted';
+
+/**
+ * Pick the History empty-state copy. With active sessions listed above, the
+ * account is not empty, so the first-run sentence would be a false statement.
+ */
+export const historyEmptyMessage = ({
+  hasActiveSessions,
+  isSearching,
+}: {
+  hasActiveSessions: boolean;
+  isSearching: boolean;
+}): string => {
+  if (isSearching) {
+    return 'No sessions match your search.';
+  }
+  return hasActiveSessions
+    ? 'No past sessions yet.'
+    : 'No sessions yet. Start your first session above.';
+};
+
+// ---------------------------------------------------------------------------
 // Active sessions section
 // ---------------------------------------------------------------------------
 
@@ -214,7 +250,7 @@ const ActiveSessionsSection = ({
 
   if (isLoading) {
     return (
-      <div className="space-y-1 px-4 py-2">
+      <div className={sectionClass}>
         <div className="flex items-center gap-2">
           <Bot className="size-4 text-foreground-muted" />
           <span className="type-label text-foreground-muted">Active</span>
@@ -226,7 +262,7 @@ const ActiveSessionsSection = ({
 
   if (isError && data === undefined) {
     return (
-      <div className="space-y-2 px-4 py-2">
+      <div className={sectionClass}>
         <div className="flex items-center gap-2">
           <Bot className="size-4 text-foreground-muted" />
           <span className="type-label text-foreground-muted">Active</span>
@@ -255,7 +291,7 @@ const ActiveSessionsSection = ({
   }
 
   return (
-    <div className="space-y-1 px-4 py-2">
+    <div className={sectionClass}>
       <div className="flex items-center gap-2">
         <Bot className="size-4 text-foreground-muted" />
         <span className="type-label text-foreground-muted">Active</span>
@@ -283,7 +319,7 @@ const ActiveSessionsSection = ({
         </div>
       ) : null}
       {sessions.length === 0 ? (
-        <p className="type-label text-foreground-muted pl-6">No active sessions</p>
+        <p className={emptyStateClass}>No active sessions</p>
       ) : (
         <div className="space-y-0.5">
           {sessions.map(session => {
@@ -466,7 +502,7 @@ const HistorySessionsSection = ({
   const showSearch = inputValue !== '' || isLoading || hasError || rows.length > 0;
 
   return (
-    <div className="space-y-2 px-4 py-3">
+    <div className={sectionClass}>
       <div className="flex items-center gap-2">
         <History className="size-4 text-foreground-muted" />
         <span className="type-label text-foreground-muted">History</span>
@@ -514,9 +550,9 @@ const HistorySessionsSection = ({
 
       {/* Loading state */}
       {isLoading ? (
-        <div className="space-y-2 py-1">
+        <div className="space-y-0.5">
           {[1, 2, 3].map(idx => (
-            <div className="flex items-center gap-2 px-2 py-1.5" key={idx}>
+            <div className={`flex items-center gap-2 ${rowTextColumnClass}`} key={idx}>
               <span className="h-3 flex-1 animate-pulse rounded bg-surface-selected" />
               <span className="h-3 w-10 animate-pulse rounded bg-surface-selected" />
             </div>
@@ -526,13 +562,9 @@ const HistorySessionsSection = ({
 
       {/* Empty state */}
       {hasNoResults ? (
-        <div className="py-3 text-center">
-          <p className="type-body text-foreground-muted">
-            {isSearching
-              ? 'No sessions match your search.'
-              : 'No sessions yet. Start your first session above.'}
-          </p>
-        </div>
+        <p className={emptyStateClass}>
+          {historyEmptyMessage({ hasActiveSessions: activeIds.size > 0, isSearching })}
+        </p>
       ) : null}
 
       {/* Row list */}
@@ -540,7 +572,7 @@ const HistorySessionsSection = ({
         <div className="space-y-0.5">
           {rows.map(session => (
             <button
-              className="w-full rounded-md px-2 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring"
+              className={`w-full rounded-md text-left type-body transition hover:bg-surface-hover outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring ${rowTextColumnClass}`}
               key={session.id}
               onClick={() => {
                 onOpenSession(session.id);

--- a/apps/extension/entrypoints/sidepanel/agents-session-view.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-session-view.test.ts
@@ -3,8 +3,12 @@
 
 import { createElement as h, StrictMode } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { fireEvent, render } from '@testing-library/react';
+import type { ReactElement } from 'react';
 import type { StandalonePermission, StandaloneQuestion } from '@kilocode/cloud-agent-sdk';
+import type { StoredAuth } from '@/src/shared/auth';
+import type { KiloGatewayModelOption } from '@/src/shared/kilo-api-client';
 import { AgentsBlockingCards } from './agents-blocking-cards';
 import { AgentsComposer } from './agents-composer';
 import { AgentsMessageList } from './agents-message-list';
@@ -71,6 +75,55 @@ describe('agents composer rendering', () => {
       })
     );
     expect(container.textContent).toContain('Send message');
+  });
+
+  it('renders the model picker slot when provided', () => {
+    const { container } = render(
+      h(AgentsComposer, {
+        canSend: true,
+        canInterrupt: true,
+        isStreaming: false,
+        isReadOnly: false,
+        isLoading: false,
+        modelPicker: h('button', { type: 'button' }, 'Model slot'),
+        onSend: () => {},
+        onStop: () => {},
+      })
+    );
+    expect(container.textContent).toContain('Model slot');
+  });
+
+  it('omits the model picker slot when not provided', () => {
+    const { container } = render(
+      h(AgentsComposer, {
+        canSend: true,
+        canInterrupt: true,
+        isStreaming: false,
+        isReadOnly: false,
+        isLoading: false,
+        onSend: () => {},
+        onStop: () => {},
+      })
+    );
+    expect(container.textContent).not.toContain('Model slot');
+    expect(container.textContent).toContain('Send message');
+  });
+
+  it('drops the model picker slot in the read-only state', () => {
+    const { container } = render(
+      h(AgentsComposer, {
+        canSend: false,
+        canInterrupt: false,
+        isStreaming: false,
+        isReadOnly: true,
+        isLoading: false,
+        modelPicker: h('button', { type: 'button' }, 'Model slot'),
+        onSend: () => {},
+        onStop: () => {},
+      })
+    );
+    expect(container.textContent).toContain('This session is read-only');
+    expect(container.textContent).not.toContain('Model slot');
   });
 
   it('renders Stop button when isStreaming is true', () => {
@@ -496,6 +549,12 @@ const mockAtoms = {
   hasOlderMessages: createAtom('hasOlderMessages'),
   isLoadingOlderMessages: createAtom('isLoadingOlderMessages'),
   olderMessagesError: createAtom('olderMessagesError'),
+  contextUsage: createAtom('contextUsage'),
+  totalCost: createAtom('totalCost'),
+  activeSessionType: createAtom('activeSessionType'),
+  remoteModelState: createAtom('remoteModelState'),
+  remoteModelOverride: createAtom('remoteModelOverride'),
+  cloudAgentModelOverride: createAtom('cloudAgentModelOverride'),
 };
 
 const mockManager = {
@@ -509,21 +568,71 @@ const mockManager = {
   respondToPermission: vi.fn(),
   loadOlderMessages: vi.fn(),
   destroy: vi.fn(),
+  setRemoteModelOverride: vi.fn(),
+  setCloudAgentModelOverride: vi.fn(),
 };
+
+const mockSetLastSelected = vi.fn();
+const mockTrpcClient = {
+  modelPreferences: { setLastSelected: { mutate: mockSetLastSelected } },
+};
+
+/* The view reads stored auth and the gateway catalog through react-query. */
+const withQueryClient = (node: ReactElement): ReactElement =>
+  h(
+    QueryClientProvider,
+    { client: new QueryClient({ defaultOptions: { queries: { retry: false } } }) },
+    node
+  );
+
+let storedAuth: StoredAuth | null = null;
+let storedModelOptions: KiloGatewayModelOption[] = [];
 
 let storedAtomValues: Record<string, unknown> = {};
 let storedOrganizationId: string | null = null;
 
 const mockGetKiloApiBaseUrl = vi.fn(() => 'https://app.kilocode.com');
 
+// A promise-returning stub the mock factories share, so no factory resolves inline.
+function resolved<Value>(value?: Value): Promise<Value | undefined> {
+  return Promise.resolve(value);
+}
+
 // eslint-disable-next-line jest/no-untyped-mock-factory, vitest/prefer-import-in-mock -- mock type inference is sufficient; dynamic import changes factory signature
 vi.mock('@/src/shared/auth', () => ({
   getKiloApiBaseUrl: () => mockGetKiloApiBaseUrl(),
+  loadStoredAuth: () => resolved(storedAuth),
+}));
+
+// eslint-disable-next-line jest/no-untyped-mock-factory, vitest/prefer-import-in-mock -- mock type inference is sufficient; dynamic import changes factory signature
+vi.mock('./use-gateway-models', () => ({
+  useGatewayModels: () => ({
+    isLoading: false,
+    modelLoadError: undefined,
+    modelOptions: storedModelOptions,
+    refetchModels: () => resolved(),
+  }),
+}));
+
+// The embedded picker's favorites query would otherwise hit the network.
+// eslint-disable-next-line jest/no-untyped-mock-factory, vitest/prefer-import-in-mock -- mock type inference is sufficient; dynamic import changes factory signature
+vi.mock('./use-model-preferences', () => ({
+  useModelPreferences: () => ({
+    favorites: new Set<string>(),
+    refetch: () => resolved(),
+    status: 'ready',
+    toggleError: false,
+    toggleFavorite: () => {},
+  }),
 }));
 
 // eslint-disable-next-line jest/no-untyped-mock-factory, vitest/prefer-import-in-mock -- mock type inference is sufficient; dynamic import changes factory signature
 vi.mock('./agents-provider', () => ({
-  useExtensionAgents: () => ({ manager: mockManager, organizationId: storedOrganizationId }),
+  useExtensionAgents: () => ({
+    manager: mockManager,
+    organizationId: storedOrganizationId,
+    trpcClient: mockTrpcClient,
+  }),
 }));
 
 // eslint-disable-next-line jest/no-untyped-mock-factory, vitest/prefer-import-in-mock -- mock type inference is sufficient; dynamic import changes factory signature
@@ -562,7 +671,15 @@ describe('agents session view integration', () => {
       hasOlderMessages: false,
       isLoadingOlderMessages: false,
       olderMessagesError: null,
+      contextUsage: undefined,
+      totalCost: 0,
+      activeSessionType: null,
+      remoteModelState: { ownerConnectionId: null, protocol: 'unknown', refresh: 'idle' },
+      remoteModelOverride: null,
+      cloudAgentModelOverride: null,
     };
+    storedAuth = null;
+    storedModelOptions = [];
     /* eslint-disable unicorn/no-useless-undefined -- void-returning mock placValue */
     mockManager.switchSession.mockResolvedValue(undefined);
     mockManager.send.mockResolvedValue(true);
@@ -574,7 +691,9 @@ describe('agents session view integration', () => {
 
   async function renderView() {
     const { AgentsSessionView } = await import('./agents-session-view');
-    return render(h(AgentsSessionView, { kiloSessionId: 'ses-test-1', onBack: () => {} }));
+    return render(
+      withQueryClient(h(AgentsSessionView, { kiloSessionId: 'ses-test-1', onBack: () => {} }))
+    );
   }
 
   // ---- Status indicator error Retry ----
@@ -1117,7 +1236,9 @@ describe('agents session view integration', () => {
     // A new failed prompt arrives — banner should reappear
     storedAtomValues['failedPrompt'] = 'another failure';
     const { AgentsSessionView } = await import('./agents-session-view');
-    rerender(h(AgentsSessionView, { kiloSessionId: 'ses-test-1', onBack: () => {} }));
+    rerender(
+      withQueryClient(h(AgentsSessionView, { kiloSessionId: 'ses-test-1', onBack: () => {} }))
+    );
     await vi.waitFor(() => {
       expect(container.textContent).toContain('Message failed to send');
     });
@@ -1426,7 +1547,11 @@ describe('agents session view integration', () => {
     // This simulates the production/dev StrictMode cycle where:
     //   mount → effect (switchSession) → cleanup (defer destroy) → remount → effect (cancel + switchSession)
     const { unmount } = render(
-      h(StrictMode, {}, h(AgentsSessionView, { kiloSessionId: 'ses-test-1', onBack: () => {} }))
+      h(
+        StrictMode,
+        {},
+        withQueryClient(h(AgentsSessionView, { kiloSessionId: 'ses-test-1', onBack: () => {} }))
+      )
     );
 
     // StrictMode causes double mount: switchSession fires twice within the same component instance.
@@ -1446,5 +1571,158 @@ describe('agents session view integration', () => {
     expect(mockManager.destroy).toHaveBeenCalledOnce();
 
     vi.useRealTimers();
+  });
+
+  // ---- Context usage + session cost indicator ----
+
+  const usageAtom = { contextTokens: 12_000, modelID: 'a/b', providerID: 'kilo' };
+  const gatewayModel: KiloGatewayModelOption = {
+    contextLength: 200_000,
+    id: 'a/b',
+    isPreferred: false,
+    name: 'A B',
+    variants: [],
+  };
+
+  it('hides the context indicator and reserves its slot before the first assistant reply', async () => {
+    const { container } = await renderView();
+
+    expect(container.querySelector('[aria-label^="Context usage"]')).toBeNull();
+    expect(container.querySelector('span[aria-hidden="true"].size-8')).not.toBeNull();
+  });
+
+  it('hides the context indicator while the session is loading', async () => {
+    storedAtomValues['isLoading'] = true;
+    storedAtomValues['contextUsage'] = usageAtom;
+    const { container } = await renderView();
+
+    expect(container.querySelector('[aria-label^="Context usage"]')).toBeNull();
+  });
+
+  it('shows the context percentage when the gateway catalog knows the window', async () => {
+    storedAtomValues['contextUsage'] = usageAtom;
+    storedModelOptions = [gatewayModel];
+    const { container } = await renderView();
+
+    const summary = container.querySelector('[aria-label^="Context usage"]');
+    expect(summary?.getAttribute('aria-label')).toBe('Context usage: 12,000 / 200,000 tokens (6%)');
+  });
+
+  it('shows tokens only when the context window is unknown', async () => {
+    storedAtomValues['contextUsage'] = { ...usageAtom, providerID: 'anthropic' };
+    storedModelOptions = [gatewayModel];
+    const { container } = await renderView();
+
+    const summary = container.querySelector('[aria-label^="Context usage"]');
+    expect(summary?.getAttribute('aria-label')).toBe('Context usage: 12,000 tokens');
+  });
+
+  it('shows the larger of the persisted and live session cost, with compaction disabled', async () => {
+    storedAtomValues['contextUsage'] = usageAtom;
+    storedAtomValues['totalCost'] = 1.5;
+    storedAtomValues['fetchedSessionData'] = { title: 'T', totalCostMicrodollars: 2_500_000 };
+    const { container } = await renderView();
+
+    expect(container.textContent).toContain('Session cost $2.5000');
+    const compactBtn = [...container.querySelectorAll('button')].find(
+      b => b.textContent === 'Compact now'
+    );
+    expect(compactBtn?.getAttribute('disabled')).not.toBeNull();
+  });
+
+  // ---- In-session model picker ----
+
+  async function renderWithPicker(sessionType: string, protocol: string) {
+    // Jsdom has no scrollIntoView; the picker scrolls its selected row into view.
+    Element.prototype.scrollIntoView = () => {};
+    storedAuth = { token: 'token-1', userEmail: undefined };
+    storedModelOptions = [gatewayModel, { ...gatewayModel, id: 'c/d', name: 'C D' }];
+    storedAtomValues['activeSessionType'] = sessionType;
+    storedAtomValues['remoteModelState'] = {
+      ownerConnectionId: null,
+      protocol,
+      refresh: 'idle',
+    };
+    storedAtomValues['canSend'] = true;
+    const view = await renderView();
+    return view;
+  }
+
+  it('shows the session model in the composer picker for a cloud-agent session', async () => {
+    storedAtomValues['sessionConfig'] = { mode: 'code', model: 'a/b' };
+    const { container } = await renderWithPicker('cloud-agent', 'unknown');
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[aria-label="Model"]')).not.toBeNull();
+    });
+    expect(container.querySelector<HTMLElement>('[aria-label="Model"]')?.dataset['modelId']).toBe(
+      'a/b'
+    );
+  });
+
+  it('shows the in-session override instead of the session model', async () => {
+    storedAtomValues['sessionConfig'] = { mode: 'code', model: 'a/b' };
+    storedAtomValues['cloudAgentModelOverride'] = { model: 'c/d' };
+    const { container } = await renderWithPicker('cloud-agent', 'unknown');
+
+    await vi.waitFor(() => {
+      expect(container.querySelector<HTMLElement>('[aria-label="Model"]')?.dataset['modelId']).toBe(
+        'c/d'
+      );
+    });
+  });
+
+  it('applies a pick to the cloud-agent override and persists it', async () => {
+    storedAtomValues['sessionConfig'] = { mode: 'code', model: 'a/b' };
+    const { container } = await renderWithPicker('cloud-agent', 'unknown');
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[aria-label="Model"]')).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector('[aria-label="Model"]')!);
+    fireEvent.click(container.querySelector('[aria-label="C D"]')!);
+
+    expect(mockManager.setCloudAgentModelOverride).toHaveBeenCalledWith({ model: 'c/d' });
+    expect(mockManager.setRemoteModelOverride).not.toHaveBeenCalled();
+    // The tRPC call runs inside the mutation, one microtask after the click.
+    await vi.waitFor(() => {
+      expect(mockSetLastSelected).toHaveBeenCalledWith({ model: 'c/d' });
+    });
+  });
+
+  it('applies a pick to the legacy remote override', async () => {
+    const { container } = await renderWithPicker('remote', 'legacy');
+
+    await vi.waitFor(() => {
+      expect(container.querySelector('[aria-label="Model"]')).not.toBeNull();
+    });
+    fireEvent.click(container.querySelector('[aria-label="Model"]')!);
+    fireEvent.click(container.querySelector('[aria-label="C D"]')!);
+
+    expect(mockManager.setRemoteModelOverride).toHaveBeenCalledWith({
+      selection: { model: { modelID: 'c/d', providerID: 'kilo' } },
+      source: 'legacy-gateway',
+    });
+    expect(mockManager.setCloudAgentModelOverride).not.toHaveBeenCalled();
+  });
+
+  it('omits the picker for a remote session whose CLI owns the catalog', async () => {
+    const { container } = await renderWithPicker('remote', 'v1');
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Send message');
+    });
+    expect(container.querySelector('[aria-label="Model"]')).toBeNull();
+  });
+
+  it('omits the picker until stored auth resolves', async () => {
+    storedAtomValues['activeSessionType'] = 'cloud-agent';
+    storedAtomValues['canSend'] = true;
+    const { container } = await renderView();
+
+    await vi.waitFor(() => {
+      expect(container.textContent).toContain('Send message');
+    });
+    expect(container.querySelector('[aria-label="Model"]')).toBeNull();
   });
 });

--- a/apps/extension/entrypoints/sidepanel/agents-session-view.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-session-view.tsx
@@ -1,18 +1,50 @@
+/* eslint-disable import/max-dependencies */
 /* eslint-disable max-lines -- Cohesive single view component; splitting would reduce clarity */
+import { storage } from '#imports';
+import { useMutation, useQuery } from '@tanstack/react-query';
 import { useAtomValue } from 'jotai';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import type { JSX } from 'react';
 import type { KiloSessionId } from '@kilocode/cloud-agent-sdk';
 import { AlertTriangle, ArrowLeft, GitPullRequest } from 'lucide-react';
-import { getKiloApiBaseUrl } from '@/src/shared/auth';
+import type { StoredAuth } from '@/src/shared/auth';
+import { getKiloApiBaseUrl, loadStoredAuth } from '@/src/shared/auth';
+import { isGatewayModelId } from '@/src/shared/model-picker-rows';
 import { displayRepoName } from './agents-format';
 import { useExtensionAgents } from './agents-provider';
 import { AgentsMessageList } from './agents-message-list';
 import { AgentsComposer } from './agents-composer';
 import { AgentsBlockingCards } from './agents-blocking-cards';
+import { ContextDonut } from './context-donut';
+import { ModelPicker } from './model-picker';
+import { useGatewayModels } from './use-gateway-models';
+import {
+  findCliCatalogModelRef,
+  resolveSessionContextWindow,
+  selectSessionCostUsd,
+  selectSessionModelPicker,
+  shouldShowContextMetrics,
+} from './agents-session-controls';
 
 const CREDITS_KEYWORDS =
   /(?:insufficient\s*credits|add\s*(?:at\s*least\s*)?\$\d|payment\s*required)/i;
+
+/*
+ * Same query key and fetcher as the new-session form's own stored-auth query,
+ * so both views share one cache entry and one read of extension storage.
+ */
+const storedAuthQueryKey = ['side-panel', 'stored-auth'] as const;
+
+const useStoredAuth = (): StoredAuth | undefined => {
+  const query = useQuery({
+    queryFn: async () => (await loadStoredAuth(storage)) ?? null,
+    queryKey: storedAuthQueryKey,
+    select: data => data ?? undefined,
+    staleTime: Infinity,
+  });
+
+  return query.data ?? undefined;
+};
 
 const statusIndicatorClass = (type: string): string => {
   if (type === 'error') {
@@ -35,7 +67,7 @@ export const AgentsSessionView = ({
   /** Prompt to auto-send once the session accepts messages (CLI spawn flow). */
   initialPrompt?: string | undefined;
 }): JSX.Element => {
-  const { manager, organizationId } = useExtensionAgents();
+  const { manager, organizationId, trpcClient } = useExtensionAgents();
   const { atoms } = manager;
   const messages = useAtomValue(atoms.messagesList);
   const isLoading = useAtomValue(atoms.isLoading);
@@ -53,6 +85,13 @@ export const AgentsSessionView = ({
   const hasOlderMessages = useAtomValue(atoms.hasOlderMessages);
   const isLoadingOlderMessages = useAtomValue(atoms.isLoadingOlderMessages);
   const olderMessagesError = useAtomValue(atoms.olderMessagesError);
+  const contextUsage = useAtomValue(atoms.contextUsage);
+  const liveCostUsd = useAtomValue(atoms.totalCost);
+  const activeSessionType = useAtomValue(atoms.activeSessionType);
+  const remoteModelState = useAtomValue(atoms.remoteModelState);
+  const remoteModelOverride = useAtomValue(atoms.remoteModelOverride);
+  const observedModel = useAtomValue(atoms.observedModel);
+  const cloudAgentModelOverride = useAtomValue(atoms.cloudAgentModelOverride);
 
   const [retryingPrompt, setRetryingPrompt] = useState(false);
   const [retryingSwitch, setRetryingSwitch] = useState(false);
@@ -232,6 +271,103 @@ export const AgentsSessionView = ({
     void manager.loadOlderMessages();
   }, [manager]);
 
+  // ---- Context usage + session cost (header indicator) ----
+  const auth = useStoredAuth();
+  const { modelOptions } = useGatewayModels({
+    auth: auth ?? { token: '', userEmail: undefined },
+    organizationId: organizationId ?? undefined,
+  });
+  const contextWindow = useMemo(
+    () => resolveSessionContextWindow(contextUsage, modelOptions),
+    [contextUsage, modelOptions]
+  );
+  const sessionCostUsd = selectSessionCostUsd(
+    fetchedSessionData?.totalCostMicrodollars,
+    liveCostUsd
+  );
+  const showContextMetrics = shouldShowContextMetrics(isLoading, contextUsage);
+
+  // ---- In-session model picker ----
+  const picker = useMemo(
+    () =>
+      selectSessionModelPicker({
+        activeSessionType,
+        cloudOverride: cloudAgentModelOverride,
+        gatewayModels: modelOptions,
+        observedModel,
+        remoteModelOverride,
+        remoteModelState,
+        sessionModel: sessionConfig?.model,
+      }),
+    [
+      activeSessionType,
+      cloudAgentModelOverride,
+      modelOptions,
+      observedModel,
+      remoteModelOverride,
+      remoteModelState,
+      sessionConfig?.model,
+    ]
+  );
+  const setLastSelectedMutation = useMutation({
+    mutationFn: (input: { model: string }) =>
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-type-assertion -- tRPC mutation input union
+      trpcClient.modelPreferences.setLastSelected.mutate(input as never),
+  });
+
+  const handleModelChange = useCallback(
+    (modelId: string) => {
+      if (picker.target === 'remote-cli') {
+        // The CLI owns this catalog: send its own provider/model, not a gateway id.
+        const modelRef = findCliCatalogModelRef(remoteModelState.catalog, modelId);
+        if (modelRef !== undefined) {
+          manager.setRemoteModelOverride({
+            selection: { model: modelRef },
+            source: 'cli-catalog',
+          });
+        }
+      } else if (picker.target === 'remote-legacy') {
+        manager.setRemoteModelOverride({
+          selection: { model: { modelID: modelId, providerID: 'kilo' } },
+          source: 'legacy-gateway',
+        });
+      } else {
+        // A model change drops the previous model's variant, as the new-session form does.
+        manager.setCloudAgentModelOverride({ model: modelId });
+      }
+      // Model preferences are keyed by gateway model id; a CLI id would poison them.
+      if (isGatewayModelId(modelId)) {
+        setLastSelectedMutation.mutate({ model: modelId });
+      }
+    },
+    [manager, picker.target, remoteModelState.catalog, setLastSelectedMutation]
+  );
+
+  // Memoized like the browser tab's own donut slot, so the composer sees a stable node.
+  const modelPicker = useMemo(() => {
+    if (picker.target === null || auth === undefined) {
+      return;
+    }
+
+    return (
+      <>
+        <ModelPicker
+          auth={auth}
+          disabled={isReadOnly || picker.options.length === 0}
+          model={picker.selectedId}
+          modelOptions={picker.options}
+          onModelChange={handleModelChange}
+          organizationId={organizationId ?? undefined}
+        />
+        {picker.disabledReason === undefined ? null : (
+          <span className="shrink-0 self-center type-label text-foreground-muted">
+            {picker.disabledReason}
+          </span>
+        )}
+      </>
+    );
+  }, [auth, handleModelChange, isReadOnly, organizationId, picker]);
+
   const rawTitle = fetchedSessionData?.title ?? '';
   const title = rawTitle === '' ? 'Session' : rawTitle;
   const rawRepository = fetchedSessionData?.repository ?? fetchedSessionData?.gitUrl;
@@ -264,6 +400,19 @@ export const AgentsSessionView = ({
               </p>
             ) : null}
           </div>
+          {/* The donut sits in the header here, so its popover opens downward. Agent
+              sessions never compact, so no compaction handler is passed. */}
+          {showContextMetrics ? (
+            <ContextDonut
+              contextLength={contextWindow}
+              placement="below"
+              promptTokens={contextUsage?.contextTokens ?? 0}
+              sessionCostUsd={sessionCostUsd}
+            />
+          ) : (
+            // Reserve the slot so the title does not reflow when the first reply lands.
+            <span aria-hidden="true" className="size-8 shrink-0" />
+          )}
           {associatedPr === null ? null : (
             <a
               aria-label={`Open pull request #${associatedPr.number}`}
@@ -472,6 +621,7 @@ export const AgentsSessionView = ({
             isStreaming={isStreaming}
             isLoading={false}
             isReadOnly={isReadOnly}
+            modelPicker={modelPicker}
             onSend={handleSend}
             onStop={handleStop}
           />

--- a/apps/extension/entrypoints/sidepanel/context-donut.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/context-donut.test.tsx
@@ -1,0 +1,104 @@
+/* eslint-disable no-unsafe-type-assertion -- DOM queries return HTMLElement; the donut renders buttons and divs. */
+// @vitest-environment jsdom
+
+import { describe, expect, it, vi } from 'vitest';
+import { fireEvent, render } from '@testing-library/react';
+import { ContextDonut } from './context-donut';
+
+const CONTEXT_LENGTH = 1000;
+const PROMPT_TOKENS = 500;
+const SESSION_COST_USD = 0.25;
+
+const popoverClass = (container: HTMLElement): string => {
+  const node = container.querySelector('details > div');
+  if (node === null) {
+    throw new Error('Popover is missing.');
+  }
+
+  return node.className;
+};
+
+describe('context donut rendering', () => {
+  it('omits the compact button when the caller has no compaction', () => {
+    const { queryByRole } = render(
+      <ContextDonut
+        contextLength={CONTEXT_LENGTH}
+        placement="below"
+        promptTokens={PROMPT_TOKENS}
+        sessionCostUsd={SESSION_COST_USD}
+      />
+    );
+
+    expect(queryByRole('button', { name: 'Compact now' })).toBeNull();
+  });
+
+  it('renders the compact button disabled until compaction is possible', () => {
+    const onCompact = vi.fn();
+    const { getByRole, rerender } = render(
+      <ContextDonut
+        canCompact={false}
+        contextLength={CONTEXT_LENGTH}
+        onCompact={onCompact}
+        placement="above"
+        promptTokens={PROMPT_TOKENS}
+        sessionCostUsd={SESSION_COST_USD}
+      />
+    );
+
+    expect((getByRole('button', { name: 'Compact now' }) as HTMLButtonElement).disabled).toBe(true);
+
+    rerender(
+      <ContextDonut
+        canCompact
+        contextLength={CONTEXT_LENGTH}
+        onCompact={onCompact}
+        placement="above"
+        promptTokens={PROMPT_TOKENS}
+        sessionCostUsd={SESSION_COST_USD}
+      />
+    );
+    const button = getByRole('button', { name: 'Compact now' }) as HTMLButtonElement;
+    expect(button.disabled).toBe(false);
+
+    fireEvent.click(button);
+    // eslint-disable-next-line vitest/prefer-called-times -- current linter requires CalledOnce; avoiding contradiction
+    expect(onCompact).toHaveBeenCalledOnce();
+  });
+
+  it('anchors the popover on the requested side', () => {
+    const above = render(
+      <ContextDonut
+        contextLength={CONTEXT_LENGTH}
+        placement="above"
+        promptTokens={PROMPT_TOKENS}
+        sessionCostUsd={SESSION_COST_USD}
+      />
+    );
+    expect(popoverClass(above.container)).toContain('bottom-10');
+    expect(popoverClass(above.container)).not.toContain('top-10');
+
+    const below = render(
+      <ContextDonut
+        contextLength={CONTEXT_LENGTH}
+        placement="below"
+        promptTokens={PROMPT_TOKENS}
+        sessionCostUsd={SESSION_COST_USD}
+      />
+    );
+    expect(popoverClass(below.container)).toContain('top-10');
+    expect(popoverClass(below.container)).not.toContain('bottom-10');
+  });
+
+  it('keeps the context usage label the browser-tab e2e specs query', () => {
+    const { getByLabelText } = render(
+      <ContextDonut
+        contextLength={CONTEXT_LENGTH}
+        placement="above"
+        promptTokens={PROMPT_TOKENS}
+        sessionCostUsd={SESSION_COST_USD}
+      />
+    );
+
+    expect(getByLabelText('Context usage: 500 / 1,000 tokens (50%)')).not.toBeNull();
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/context-donut.tsx
+++ b/apps/extension/entrypoints/sidepanel/context-donut.tsx
@@ -14,15 +14,20 @@ const RADIUS = 6;
 const CIRCUMFERENCE = 2 * Math.PI * RADIUS;
 
 export const ContextDonut = ({
-  canCompact,
+  canCompact = false,
   contextLength,
   onCompact,
+  placement,
   promptTokens,
   sessionCostUsd,
 }: {
-  canCompact: boolean;
+  /** Only meaningful with `onCompact`; without it no button is rendered. */
+  canCompact?: boolean;
   contextLength: number | undefined;
-  onCompact: () => void;
+  /** Omit when the caller cannot compact: the button is left out, not disabled. */
+  onCompact?: () => void;
+  /** Which side of the trigger the popover opens on. */
+  placement: 'above' | 'below';
   promptTokens: number;
   sessionCostUsd: number;
 }): JSX.Element => {
@@ -64,21 +69,25 @@ export const ContextDonut = ({
           />
         </svg>
       </summary>
-      <div className="absolute bottom-10 right-0 z-20 w-56 rounded-lg border border-border bg-surface-overlay p-3 shadow-lg shadow-black/50">
+      <div
+        className={`absolute right-0 z-20 w-56 rounded-lg border border-border bg-surface-overlay p-3 shadow-lg shadow-black/50 ${placement === 'above' ? 'bottom-10' : 'top-10'}`}
+      >
         <p className="text-sm font-semibold text-foreground">Context</p>
         <p className="type-label mt-1 text-foreground-muted">{summary}</p>
         <p className="type-label mt-1 text-foreground-muted">Session cost {sessionCostLabel}</p>
-        <button
-          className="type-label mt-3 h-8 w-full rounded-md border border-border bg-surface-overlay px-2 text-foreground-on-secondary outline-none transition hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background disabled:cursor-not-allowed disabled:bg-surface-selected disabled:text-foreground-subtle"
-          disabled={!canCompact}
-          onClick={() => {
-            detailsRef.current?.removeAttribute('open');
-            onCompact();
-          }}
-          type="button"
-        >
-          Compact now
-        </button>
+        {onCompact === undefined ? null : (
+          <button
+            className="type-label mt-3 h-8 w-full rounded-md border border-border bg-surface-overlay px-2 text-foreground-on-secondary outline-none transition hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background disabled:cursor-not-allowed disabled:bg-surface-selected disabled:text-foreground-subtle"
+            disabled={!canCompact}
+            onClick={() => {
+              detailsRef.current?.removeAttribute('open');
+              onCompact();
+            }}
+            type="button"
+          >
+            Compact now
+          </button>
+        )}
       </div>
     </details>
   );

--- a/apps/extension/entrypoints/sidepanel/conversation-list.test.ts
+++ b/apps/extension/entrypoints/sidepanel/conversation-list.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import {
+  decideConversationScroll,
+  isAtConversationBottom,
+  isDifferentConversation,
+} from './conversation-list';
+
+/*
+ * The virtualizer renders no rows under jsdom (see agents-session-view.test.ts),
+ * so these tests cover the scroll decision itself, not the DOM scroll.
+ */
+
+const atBottom = { clientHeight: 400, scrollHeight: 2000, scrollTop: 1600 };
+const scrolledUp = { clientHeight: 400, scrollHeight: 2000, scrollTop: 400 };
+
+describe('isAtConversationBottom()', () => {
+  it('accepts the exact bottom', () => {
+    expect(isAtConversationBottom(atBottom)).toBe(true);
+  });
+
+  it('accepts a correction inside the 100px band', () => {
+    // A late row measurement moves the offset by tens of pixels; that is not the user leaving.
+    expect(isAtConversationBottom({ ...atBottom, scrollTop: 1520 })).toBe(true);
+  });
+
+  it('rejects a position past the band', () => {
+    expect(isAtConversationBottom({ ...atBottom, scrollTop: 1480 })).toBe(false);
+  });
+
+  it('treats a non-scrollable list as the bottom', () => {
+    expect(isAtConversationBottom({ clientHeight: 400, scrollHeight: 400, scrollTop: 0 })).toBe(
+      true
+    );
+  });
+});
+
+describe('decideConversationScroll()', () => {
+  it('keeps following through a virtualizer correction at the bottom', () => {
+    expect(
+      decideConversationScroll({
+        lastPinnedTop: 1600,
+        position: { ...atBottom, scrollTop: 1540 },
+        sawDownwardIntent: false,
+      })
+    ).toBe('keep');
+  });
+
+  it('releases when an offset we did not write sits away from the bottom', () => {
+    // A scrollbar drag: nothing else moved the list, so this is the user leaving.
+    expect(
+      decideConversationScroll({
+        lastPinnedTop: 1600,
+        position: scrolledUp,
+        sawDownwardIntent: false,
+      })
+    ).toBe('release');
+  });
+
+  it('releases on a drag away from the bottom even without a recorded gesture', () => {
+    // The upward drag and our pin write coalesce into one scroll event, so direction is unusable.
+    expect(
+      decideConversationScroll({
+        lastPinnedTop: 1600,
+        position: { ...atBottom, scrollTop: 0 },
+        sawDownwardIntent: false,
+      })
+    ).toBe('release');
+  });
+
+  it('keeps pinning when content grew below the offset we last wrote', () => {
+    // Growth raises scrollHeight without moving scrollTop: the offset is still ours.
+    expect(
+      decideConversationScroll({
+        lastPinnedTop: 1600,
+        position: { ...atBottom, scrollHeight: 3000 },
+        sawDownwardIntent: false,
+      })
+    ).toBe('keep');
+  });
+
+  it('tolerates the sub-pixel offset a fractional device ratio reports back', () => {
+    expect(
+      decideConversationScroll({
+        lastPinnedTop: 1600,
+        position: { ...atBottom, scrollHeight: 3000, scrollTop: 1600.5 },
+        sawDownwardIntent: false,
+      })
+    ).toBe('keep');
+  });
+
+  it('does not re-follow when a programmatic scroll lands at the bottom', () => {
+    expect(
+      decideConversationScroll({
+        lastPinnedTop: 400,
+        position: atBottom,
+        sawDownwardIntent: false,
+      })
+    ).toBe('keep');
+  });
+
+  it('re-follows when a downward gesture reaches the bottom', () => {
+    expect(
+      decideConversationScroll({
+        lastPinnedTop: 400,
+        position: atBottom,
+        sawDownwardIntent: true,
+      })
+    ).toBe('follow');
+  });
+
+  it('does not re-follow on a downward gesture that has not reached the bottom yet', () => {
+    // Away from the bottom the decision never re-arms following, whatever it does otherwise.
+    expect(
+      decideConversationScroll({
+        lastPinnedTop: 400,
+        position: { ...atBottom, scrollTop: 1000 },
+        sawDownwardIntent: true,
+      })
+    ).not.toBe('follow');
+  });
+});
+
+describe('isDifferentConversation()', () => {
+  const ends = { firstKey: 'a', lastKey: 'z' };
+
+  it('reports a swap when both ends change', () => {
+    expect(isDifferentConversation(ends, { firstKey: 'p', lastKey: 'q' })).toBe(true);
+  });
+
+  it('does not report a swap when older messages are prepended', () => {
+    expect(isDifferentConversation(ends, { firstKey: 'older', lastKey: 'z' })).toBe(false);
+  });
+
+  it('does not report a swap when a new message is appended', () => {
+    expect(isDifferentConversation(ends, { firstKey: 'a', lastKey: 'newer' })).toBe(false);
+  });
+
+  it('does not report a swap when nothing changed', () => {
+    expect(isDifferentConversation(ends, ends)).toBe(false);
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/conversation-list.tsx
+++ b/apps/extension/entrypoints/sidepanel/conversation-list.tsx
@@ -2,11 +2,69 @@
 import { ArrowDown } from 'lucide-react';
 import { useCallback, useEffect, useLayoutEffect, useRef, useState } from 'react';
 import type { CSSProperties, JSX } from 'react';
-import { useVirtualizer } from '@tanstack/react-virtual';
+import { elementScroll, useVirtualizer } from '@tanstack/react-virtual';
 import { getConversationScrollKey } from '@/src/shared/agent-conversation';
 import type { GroupedConversationItem } from '@/src/shared/agent-conversation';
 import { LEGACY_CONVERSATION_GREETING } from '@/src/shared/agent-conversation-tabs';
 import { AgentConversationItemView } from './agent-conversation-events';
+
+/**
+ * Distance from the end that still counts as "at the bottom". Mobile uses the
+ * same 100px band (`use-session-auto-scroll-state.ts`). It must stay well above
+ * the corrections the virtualizer applies when a row's real height replaces the
+ * estimate, otherwise its own scroll writes read as the user leaving the bottom.
+ */
+const AT_BOTTOM_THRESHOLD_PX = 100;
+
+// eslint-disable-next-line typescript-eslint/consistent-type-definitions -- AGENTS.md prefers type
+type ScrollPosition = {
+  clientHeight: number;
+  scrollHeight: number;
+  scrollTop: number;
+};
+
+/** What a scroll position means for auto-scroll. Pure, so it is unit tested. */
+export type ConversationScrollDecision = 'follow' | 'keep' | 'release';
+
+export const isAtConversationBottom = (position: ScrollPosition): boolean =>
+  position.scrollTop + position.clientHeight >= position.scrollHeight - AT_BOTTOM_THRESHOLD_PX;
+
+/*
+ * A scroll event carries no gesture, so user intent is decided by who wrote the
+ * offset, not by how far it moved. `lastPinnedTop` is the offset our own pin
+ * wrote, so a position away from the bottom that still equals it is content
+ * growing below us; any other position away from the bottom is someone else
+ * moving the list, which is the user leaving. Inside the bottom band nothing is
+ * released, so the virtualizer's own end-anchoring writes stay harmless.
+ */
+export const decideConversationScroll = ({
+  lastPinnedTop,
+  position,
+  sawDownwardIntent,
+}: {
+  lastPinnedTop: number;
+  position: ScrollPosition;
+  sawDownwardIntent: boolean;
+}): ConversationScrollDecision => {
+  if (isAtConversationBottom(position)) {
+    return sawDownwardIntent ? 'follow' : 'keep';
+  }
+
+  return Math.abs(position.scrollTop - lastPinnedTop) > 1 ? 'release' : 'keep';
+};
+
+// eslint-disable-next-line typescript-eslint/consistent-type-definitions -- AGENTS.md prefers type
+type ConversationEnds = { firstKey: string; lastKey: string };
+
+/*
+ * The list stays mounted while the panel swaps conversations, so a released pin
+ * must not leak into the next one. Loading older messages keeps the last item,
+ * a new message keeps the first: only another conversation replaces both ends.
+ */
+export const isDifferentConversation = (
+  previous: ConversationEnds,
+  next: ConversationEnds
+): boolean => previous.firstKey !== next.firstKey && previous.lastKey !== next.lastKey;
 
 const getConversationItemKey = (item: GroupedConversationItem): string =>
   item.type === 'event' ? item.event.id : item.toolCall.id;
@@ -16,9 +74,20 @@ const getListSpacerStyle = (height: number): CSSProperties => ({
 const getVirtualRowStyle = (start: number): CSSProperties => ({
   transform: `translateY(${start}px)`,
 });
-const isScrolledToBottom = (element: HTMLElement): boolean =>
-  element.scrollTop + element.clientHeight >= element.scrollHeight - 16;
+const readScrollPosition = (element: HTMLElement): ScrollPosition => ({
+  clientHeight: element.clientHeight,
+  scrollHeight: element.scrollHeight,
+  scrollTop: element.scrollTop,
+});
 const isScrollable = (element: HTMLElement): boolean => element.scrollHeight > element.clientHeight;
+const getConversationEnds = (items: GroupedConversationItem[]): ConversationEnds | null => {
+  const [first] = items;
+  const last = items.at(-1);
+
+  return first === undefined || last === undefined
+    ? null
+    : { firstKey: getConversationItemKey(first), lastKey: getConversationItemKey(last) };
+};
 
 const ConversationVirtualRow = ({
   index,
@@ -78,11 +147,18 @@ export const ConversationList = ({
   const listRef = useRef<HTMLElement | null>(null);
   // Source of truth for auto-scroll, owned outside React so a streaming render cannot race it. The state mirror below only drives the jump button.
   const isStuckToBottomRef = useRef(true);
-  const lastScrollTopRef = useRef(0);
   const lastPinnedTopRef = useRef(0);
-  const pinFrameRef = useRef<number | null>(null);
+  /* A pin that follows a deliberate re-arm (mount, jump button, conversation swap,
+     downward gesture) starts from wherever the user is, so it skips the guard once. */
+  const forcePinRef = useRef(true);
+  const conversationEndsRef = useRef<ConversationEnds | null>(null);
   const [showJumpButton, setShowJumpButton] = useState(false);
   const scrollKey = getConversationScrollKey(items);
+  /*
+   * Deliberately no `anchorTo: 'end'`: `pinToBottom` below re-glues the end off
+   * the live DOM offset on every measurement, so a second end-anchor would only
+   * add a writer that works from a stale offset (see `scrollToFn`).
+   */
   const virtualizer = useVirtualizer({
     count: items.length,
     /*
@@ -94,15 +170,28 @@ export const ConversationList = ({
     estimateSize: () => 52,
     getScrollElement: () => listRef.current,
     overscan: 8,
+    /*
+     * Every virtualizer scroll write is a measurement correction computed from
+     * the offset it last *observed*. That lags the DOM by a frame, because the
+     * only thing that tells it about a move is the scroll event: a scrollbar
+     * drag lands, the correction fires in the same frame, and the drag is undone
+     * before any code can read it. Drop a correction whose starting offset is no
+     * longer the live one — it is stale by definition, and the pin below re-glues
+     * the bottom from the live DOM anyway. A correction that does agree with the
+     * DOM still runs, so a row measured above a reader scrolled up keeps their
+     * view in place.
+     */
+    scrollToFn: (offset, scrollOptions, instance) => {
+      const element = listRef.current;
+
+      if (element !== null && Math.abs(offset - element.scrollTop) > 1) {
+        return;
+      }
+
+      elementScroll(offset, scrollOptions, instance);
+    },
   });
   const totalSize = virtualizer.getTotalSize();
-
-  const cancelPin = useCallback((): void => {
-    if (pinFrameRef.current !== null) {
-      cancelAnimationFrame(pinFrameRef.current);
-      pinFrameRef.current = null;
-    }
-  }, []);
 
   const releaseToManualScroll = useCallback((): void => {
     if (!isStuckToBottomRef.current) {
@@ -110,9 +199,8 @@ export const ConversationList = ({
     }
 
     isStuckToBottomRef.current = false;
-    cancelPin();
     setShowJumpButton(true);
-  }, [cancelPin]);
+  }, []);
 
   const followBottomAgain = useCallback((): void => {
     if (isStuckToBottomRef.current) {
@@ -120,51 +208,46 @@ export const ConversationList = ({
     }
 
     isStuckToBottomRef.current = true;
+    forcePinRef.current = true;
     setShowJumpButton(false);
   }, []);
 
-  // Pin to the bottom across a few frames so late virtualizer measurements cannot leave us short. An auto-pin (force false) bails when the position sits above the last pin: a scrollbar drag's scroll event can coalesce with our pin write so handleScroll misses it, but sampling scrollTop here catches the upward move and releases instead of yanking the view back.
-  const pinToBottom = useCallback(
-    (force = false): void => {
-      cancelPin();
+  /*
+   * One write against the live DOM, which already accounts for the list padding
+   * the virtualizer knows nothing about. Convergence is measurement-driven, not
+   * frame-budgeted: every row measurement changes `totalSize` and re-runs the
+   * effect below, and `anchorTo: 'end'` holds the end in between. Deliberately
+   * not `scrollToIndex`, whose reconcile loop keeps re-targeting the end for
+   * seconds and drags a reader who scrolls up back down.
+   *
+   * The same decision runs here, not only in the scroll handler: this pin fires
+   * from a layout effect, before the browser can deliver the scroll event for a
+   * scrollbar drag, and a drag plus this write inside one frame coalesce into a
+   * single event that reports our offset. Sampling the live offset is the only
+   * place that upward drag is still visible.
+   */
+  const pinToBottom = useCallback((): void => {
+    const element = listRef.current;
 
-      const runPass = (remainingPasses: number, allowRelease: boolean): void => {
-        const element = listRef.current;
+    if (element === null) {
+      return;
+    }
 
-        if (element === null || !isStuckToBottomRef.current || items.length === 0) {
-          pinFrameRef.current = null;
-          return;
-        }
+    const decision = decideConversationScroll({
+      lastPinnedTop: lastPinnedTopRef.current,
+      position: readScrollPosition(element),
+      sawDownwardIntent: false,
+    });
 
-        if (
-          allowRelease &&
-          lastPinnedTopRef.current - element.scrollTop > 16 &&
-          !isScrolledToBottom(element)
-        ) {
-          releaseToManualScroll();
-          return;
-        }
+    if (!forcePinRef.current && decision === 'release') {
+      releaseToManualScroll();
+      return;
+    }
 
-        virtualizer.scrollToIndex(items.length - 1, { align: 'end' });
-        element.scrollTop = element.scrollHeight;
-        lastPinnedTopRef.current = element.scrollTop;
-        lastScrollTopRef.current = element.scrollTop;
-
-        if (remainingPasses > 0) {
-          pinFrameRef.current = requestAnimationFrame(() => {
-            runPass(remainingPasses - 1, true);
-          });
-          return;
-        }
-
-        pinFrameRef.current = null;
-      };
-
-      // A forced pin (jump-to-latest) re-pins from wherever the user is, so it skips the release check on its first pass; later passes re-enable it once the fresh baseline is set.
-      runPass(5, !force);
-    },
-    [cancelPin, items.length, releaseToManualScroll, virtualizer]
-  );
+    forcePinRef.current = false;
+    element.scrollTop = element.scrollHeight;
+    lastPinnedTopRef.current = element.scrollTop;
+  }, [releaseToManualScroll]);
 
   // Bind scroll detection straight to the DOM node so upward intent is seen on the input event itself, before any in-flight pin can write the position back to the bottom.
   useEffect(() => {
@@ -177,8 +260,8 @@ export const ConversationList = ({
     /*
      * A downward user gesture arms a re-follow: handleScroll completes it once
      * that gesture actually reaches the bottom. Requiring recorded intent is
-     * what stops the virtualizer's post-scroll-up re-measurement — which
-     * teleports scrollTop straight back to the bottom — from re-arming on its own.
+     * what stops a programmatic scroll that lands at the bottom from re-arming
+     * on its own.
      */
     let sawDownwardIntent = false;
     const handleWheel = (event: WheelEvent): void => {
@@ -221,26 +304,25 @@ export const ConversationList = ({
         sawDownwardIntent = true;
       }
     };
+    // Backstop for gestures with no input event of their own, such as dragging the scrollbar.
     const handleScroll = (): void => {
-      const currentTop = element.scrollTop;
-      const previousTop = lastScrollTopRef.current;
-      lastScrollTopRef.current = currentTop;
+      const position = readScrollPosition(element);
+      const decision = decideConversationScroll({
+        lastPinnedTop: lastPinnedTopRef.current,
+        position,
+        sawDownwardIntent,
+      });
 
-      // Backstop for gestures with no input event of their own, such as dragging the scrollbar: any move above the last pinned position is the user leaving the bottom.
-      if (
-        currentTop < previousTop - 1 &&
-        currentTop < lastPinnedTopRef.current - 1 &&
-        !isScrolledToBottom(element)
-      ) {
+      if (decision === 'release') {
         sawDownwardIntent = false;
         releaseToManualScroll();
         return;
       }
 
-      // Re-arm once a real downward gesture (not a virtualizer teleport) reaches the bottom. Reset the pin baseline to this bottom so the next content-growth pin does not read a stale-high lastPinned and mistake the growth gap for a scroll-up.
-      if (sawDownwardIntent && isScrolledToBottom(element)) {
+      // Reset the pin baseline to this bottom so the next content-growth pin does not read a stale-high lastPinned and mistake the growth gap for a scroll-up.
+      if (decision === 'follow') {
         sawDownwardIntent = false;
-        lastPinnedTopRef.current = currentTop;
+        lastPinnedTopRef.current = position.scrollTop;
         followBottomAgain();
       }
     };
@@ -260,7 +342,21 @@ export const ConversationList = ({
     };
   }, [followBottomAgain, releaseToManualScroll]);
 
-  useEffect(() => cancelPin, [cancelPin]);
+  // Registered before the pin effect so a conversation swap re-arms following in the same commit that pins it.
+  useLayoutEffect(() => {
+    const ends = getConversationEnds(items);
+
+    if (ends === null) {
+      return;
+    }
+
+    const previous = conversationEndsRef.current;
+    conversationEndsRef.current = ends;
+
+    if (previous !== null && isDifferentConversation(previous, ends)) {
+      followBottomAgain();
+    }
+  }, [followBottomAgain, items]);
 
   useLayoutEffect(() => {
     if (items.length > 0 && isStuckToBottomRef.current) {
@@ -270,7 +366,7 @@ export const ConversationList = ({
 
   const jumpToLatest = (): void => {
     followBottomAgain();
-    pinToBottom(true);
+    pinToBottom();
   };
   const virtualItems = virtualizer.getVirtualItems();
 

--- a/apps/extension/entrypoints/sidepanel/memory-settings.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/memory-settings.test.tsx
@@ -1,0 +1,92 @@
+/* eslint-disable import/first, jest/no-conditional-expect, jest/no-hooks, jest/no-untyped-mock-factory, no-unsafe-type-assertion, vitest/prefer-import-in-mock -- test fixture constraints */
+// @vitest-environment jsdom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, render, waitFor } from '@testing-library/react';
+
+vi.mock('#imports', () => ({ storage: {} }));
+
+vi.mock('./use-agent-memories', () => ({
+  useAgentMemories: () => ({
+    isLoaded: true,
+    loadError: false,
+    memories: [],
+    pendingDraft: undefined,
+    reload: vi.fn(),
+  }),
+}));
+
+vi.mock('@/src/shared/agent-memory-settings', () => ({
+  loadMemorySettings: vi.fn(),
+  saveMemorySettings: vi.fn(),
+}));
+
+import { loadMemorySettings, saveMemorySettings } from '@/src/shared/agent-memory-settings';
+import { MemorySettings } from './memory-settings';
+
+const mockLoad = vi.mocked(loadMemorySettings);
+const mockSave = vi.mocked(saveMemorySettings);
+
+const TOGGLE_LABEL = 'Auto-approve memory saves';
+
+describe('memory settings auto-approve toggle', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('shows the stored value and persists a toggle', async () => {
+    mockLoad.mockResolvedValue({ autoApproveMemorySaves: false });
+    mockSave.mockResolvedValue();
+
+    const { getByLabelText } = render(<MemorySettings />);
+    const toggle = getByLabelText(TOGGLE_LABEL) as HTMLButtonElement;
+
+    await waitFor(() => {
+      expect(toggle.disabled).toBe(false);
+    });
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+
+    fireEvent.click(toggle);
+
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledWith(expect.anything(), {
+        autoApproveMemorySaves: true,
+      });
+    });
+    expect(toggle.getAttribute('aria-checked')).toBe('true');
+  });
+
+  it('keeps the toggle disabled when the setting cannot be read', async () => {
+    mockLoad.mockRejectedValue(new Error('read failed'));
+
+    const { getByLabelText } = render(<MemorySettings />);
+    const toggle = getByLabelText(TOGGLE_LABEL) as HTMLButtonElement;
+
+    await waitFor(() => {
+      // eslint-disable-next-line vitest/prefer-called-times -- current linter requires CalledOnce; avoiding contradiction
+      expect(mockLoad).toHaveBeenCalledOnce();
+    });
+    expect(toggle.disabled).toBe(true);
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('rolls back and reports a failed save', async () => {
+    mockLoad.mockResolvedValue({ autoApproveMemorySaves: false });
+    mockSave.mockRejectedValue(new Error('write failed'));
+
+    const { getByLabelText, findByText } = render(<MemorySettings />);
+    const toggle = getByLabelText(TOGGLE_LABEL) as HTMLButtonElement;
+
+    await waitFor(() => {
+      expect(toggle.disabled).toBe(false);
+    });
+    fireEvent.click(toggle);
+
+    await findByText("Couldn't save the setting. Try again.");
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+  });
+});

--- a/apps/extension/entrypoints/sidepanel/memory-settings.test.tsx
+++ b/apps/extension/entrypoints/sidepanel/memory-settings.test.tsx
@@ -1,4 +1,4 @@
-/* eslint-disable import/first, jest/no-conditional-expect, jest/no-hooks, jest/no-untyped-mock-factory, no-unsafe-type-assertion, vitest/prefer-import-in-mock -- test fixture constraints */
+/* eslint-disable import/first, jest/no-conditional-expect, jest/no-hooks, jest/no-untyped-mock-factory, no-unsafe-type-assertion, promise/avoid-new, vitest/prefer-import-in-mock -- test fixture constraints */
 // @vitest-environment jsdom
 
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
@@ -71,6 +71,46 @@ describe('memory settings auto-approve toggle', () => {
       expect(mockLoad).toHaveBeenCalledOnce();
     });
     expect(toggle.disabled).toBe(true);
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+  });
+
+  it('stores the last toggle when saves overlap', async () => {
+    mockLoad.mockResolvedValue({ autoApproveMemorySaves: false });
+    /* The first write resolves only after the second one is requested, so an
+       unordered implementation would store `true` while the toggle reads off. */
+    const settleFirstSave: (() => void)[] = [];
+    const firstSave = new Promise<void>(resolve => {
+      settleFirstSave.push(resolve);
+    });
+    mockSave.mockReturnValueOnce(firstSave);
+    mockSave.mockResolvedValueOnce();
+
+    const { getByLabelText } = render(<MemorySettings />);
+    const toggle = getByLabelText(TOGGLE_LABEL) as HTMLButtonElement;
+
+    await waitFor(() => {
+      expect(toggle.disabled).toBe(false);
+    });
+
+    fireEvent.click(toggle);
+    fireEvent.click(toggle);
+    expect(toggle.getAttribute('aria-checked')).toBe('false');
+
+    // Only the first save has started; the second waits its turn.
+    await waitFor(() => {
+      expect(settleFirstSave).toHaveLength(1);
+    });
+    // eslint-disable-next-line vitest/prefer-called-times -- current linter requires CalledOnce; avoiding contradiction
+    expect(mockSave).toHaveBeenCalledOnce();
+
+    settleFirstSave[0]?.();
+
+    await waitFor(() => {
+      expect(mockSave).toHaveBeenCalledTimes(2);
+    });
+    expect(mockSave).toHaveBeenLastCalledWith(expect.anything(), {
+      autoApproveMemorySaves: false,
+    });
     expect(toggle.getAttribute('aria-checked')).toBe('false');
   });
 

--- a/apps/extension/entrypoints/sidepanel/memory-settings.tsx
+++ b/apps/extension/entrypoints/sidepanel/memory-settings.tsx
@@ -1,13 +1,19 @@
 import { storage } from '#imports';
 import { Trash2 } from 'lucide-react';
 import type { JSX } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { deleteAgentMemory } from '@/src/shared/agent-memories-storage';
+import { loadMemorySettings, saveMemorySettings } from '@/src/shared/agent-memory-settings';
 import { deriveMemoriesSettingsView } from './memory-settings-state';
 import { useAgentMemories } from './use-agent-memories';
+import { SettingsToggle } from './workflow-settings';
 
 const EMPTY_MESSAGE =
   'No memories yet. Highlight text on any page, right-click, and choose Add to memory.';
 const LOAD_ERROR_MESSAGE = "Couldn't load memories. Try again.";
+const SETTINGS_SAVE_ERROR_MESSAGE = "Couldn't save the setting. Try again.";
+const AUTO_APPROVE_LABEL = 'Auto-approve memory saves';
+const AUTO_APPROVE_DESCRIPTION = 'Let Kilo save a memory without the approval card.';
 
 const secondaryButtonClass =
   'type-label h-8 rounded-md border border-border bg-surface-overlay px-3 text-foreground-on-secondary transition hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background';
@@ -16,12 +22,59 @@ export const MemorySettings = (): JSX.Element => {
   const { isLoaded, loadError, memories, reload } = useAgentMemories();
   const view = deriveMemoriesSettingsView({ isLoaded, loadError, memories });
 
+  /* Undefined until the setting is read: the toggle stays disabled, so a failed
+     read never presents the default as the stored value. */
+  const [autoApprove, setAutoApprove] = useState<boolean | undefined>();
+  const [saveError, setSaveError] = useState(false);
+
+  useEffect(() => {
+    void (async () => {
+      try {
+        const settings = await loadMemorySettings(storage);
+        setAutoApprove(settings.autoApproveMemorySaves);
+      } catch {
+        /* Leave the toggle disabled and unchecked. */
+      }
+    })();
+  }, []);
+
+  const onToggle = useCallback(() => {
+    if (autoApprove === undefined) {
+      return;
+    }
+    const next = !autoApprove;
+    setSaveError(false);
+    setAutoApprove(next);
+    void (async () => {
+      try {
+        await saveMemorySettings(storage, { autoApproveMemorySaves: next });
+      } catch {
+        /* Keep the stored value visible; toggling again retries the save. */
+        setAutoApprove(!next);
+        setSaveError(true);
+      }
+    })();
+  }, [autoApprove]);
+
   return (
     <section
       aria-label="Memories"
       className="min-w-0 rounded-xl border border-border bg-surface-raised p-3"
     >
       <h2 className="type-label text-foreground-muted">Memories</h2>
+
+      <div className="mt-2 flex flex-col gap-2">
+        <SettingsToggle
+          checked={autoApprove === true}
+          description={AUTO_APPROVE_DESCRIPTION}
+          disabled={autoApprove === undefined}
+          label={AUTO_APPROVE_LABEL}
+          onToggle={onToggle}
+        />
+        {saveError ? (
+          <p className="type-body text-status-red-400">{SETTINGS_SAVE_ERROR_MESSAGE}</p>
+        ) : null}
+      </div>
 
       {view.kind === 'loading' ? (
         <p className="type-body mt-2 text-foreground-muted">Loading…</p>

--- a/apps/extension/entrypoints/sidepanel/memory-settings.tsx
+++ b/apps/extension/entrypoints/sidepanel/memory-settings.tsx
@@ -1,11 +1,12 @@
 import { storage } from '#imports';
 import { Trash2 } from 'lucide-react';
 import type { JSX } from 'react';
-import { useCallback, useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { deleteAgentMemory } from '@/src/shared/agent-memories-storage';
 import { loadMemorySettings, saveMemorySettings } from '@/src/shared/agent-memory-settings';
 import { deriveMemoriesSettingsView } from './memory-settings-state';
 import { useAgentMemories } from './use-agent-memories';
+import { createSerialAsyncChain } from './model-preferences-state';
 import { SettingsToggle } from './workflow-settings';
 
 const EMPTY_MESSAGE =
@@ -26,6 +27,10 @@ export const MemorySettings = (): JSX.Element => {
      read never presents the default as the stored value. */
   const [autoApprove, setAutoApprove] = useState<boolean | undefined>();
   const [saveError, setSaveError] = useState(false);
+  /* Rapid toggles each write the whole settings record. Without ordering, an
+     earlier write can land after a later one and store the value the user just
+     turned off. One chain per mount keeps the last click authoritative. */
+  const saveChainRef = useRef(createSerialAsyncChain());
 
   useEffect(() => {
     void (async () => {
@@ -45,7 +50,7 @@ export const MemorySettings = (): JSX.Element => {
     const next = !autoApprove;
     setSaveError(false);
     setAutoApprove(next);
-    void (async () => {
+    void saveChainRef.current.enqueue(async () => {
       try {
         await saveMemorySettings(storage, { autoApproveMemorySaves: next });
       } catch {
@@ -53,7 +58,7 @@ export const MemorySettings = (): JSX.Element => {
         setAutoApprove(!next);
         setSaveError(true);
       }
-    })();
+    });
   }, [autoApprove]);
 
   return (

--- a/apps/extension/entrypoints/sidepanel/model-picker-row.tsx
+++ b/apps/extension/entrypoints/sidepanel/model-picker-row.tsx
@@ -1,6 +1,7 @@
 import { BookOpenCheck, Check, Star } from 'lucide-react';
 import type { JSX } from 'react';
 import type { KiloGatewayModelOption } from '@/src/shared/kilo-api-client';
+import { modelRowDisplayId } from '@/src/shared/model-picker-rows';
 
 const rowButtonClass =
   'flex min-w-0 flex-1 items-start gap-2 rounded-md px-2 py-2 text-left outline-none transition hover:bg-surface-hover focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background';
@@ -49,7 +50,7 @@ export const ModelPickerModelRow = ({
         <span className="min-w-0 flex-1">
           <span className="block truncate text-sm font-medium text-foreground">{model.name}</span>
           <span className="mt-0.5 block truncate font-mono text-xs text-foreground-muted">
-            {model.id}
+            {modelRowDisplayId(model.id)}
           </span>
           {showFree || showByok || showDataCollected ? (
             <span className="mt-1 flex flex-wrap items-center gap-1">

--- a/apps/extension/entrypoints/sidepanel/model-picker.tsx
+++ b/apps/extension/entrypoints/sidepanel/model-picker.tsx
@@ -3,7 +3,11 @@ import { useEffect, useMemo, useRef, useState } from 'react';
 import type { JSX } from 'react';
 import type { StoredAuth } from '@/src/shared/auth';
 import type { KiloGatewayModelOption } from '@/src/shared/kilo-api-client';
-import { buildExtensionModelPickerRows } from '@/src/shared/model-picker-rows';
+import {
+  buildExtensionModelPickerRows,
+  isGatewayModelId,
+  modelRowDisplayId,
+} from '@/src/shared/model-picker-rows';
 import { ModelPickerModelRow } from './model-picker-row';
 import { useModelPreferences } from './use-model-preferences';
 
@@ -40,7 +44,8 @@ export const ModelPicker = ({
   const selectedOption = modelOptions.find(option => option.id === model);
   // Always show the conversation's own model: its name when the catalog has it, its raw id
   // While the catalog is missing or stale. 'Loading models...' means no model is stored yet.
-  const triggerLabel = selectedOption?.name ?? (model === '' ? 'Loading models...' : model);
+  const triggerLabel =
+    selectedOption?.name ?? (model === '' ? 'Loading models...' : modelRowDisplayId(model));
 
   const rows = useMemo(
     () =>
@@ -196,7 +201,8 @@ export const ModelPicker = ({
                         model={row.model}
                         onSelect={handleSelect}
                         onToggleFavorite={toggleFavorite}
-                        showStar={status !== 'terminal'}
+                        // Favorites are stored per gateway model id; a CLI row has none.
+                        showStar={status !== 'terminal' && isGatewayModelId(row.model.id)}
                         starDisabled={status === 'loading'}
                       />
                     </div>

--- a/apps/extension/entrypoints/sidepanel/pending-approval.test.ts
+++ b/apps/extension/entrypoints/sidepanel/pending-approval.test.ts
@@ -55,6 +55,20 @@ const createStorage = ({
   };
 };
 
+/* A getItem that throws for one key, so a settings read failure is testable
+   without a conditional inside the test body. */
+const failGetItemForKey = (storage: TestStorage, failingKey: string): void => {
+  const { values } = storage;
+
+  storage.getItem = (key: string) => {
+    if (key === failingKey) {
+      throw new Error('Settings read failed.');
+    }
+
+    return values.get(key);
+  };
+};
+
 const memoryDraft = (
   overrides: Partial<PendingAgentMemoryDraft> = {}
 ): PendingAgentMemoryDraft => ({
@@ -85,6 +99,11 @@ const abortSignal = (): AbortSignal => {
 const autoApproveSettings = (): Record<string, unknown> => ({
   ...DEFAULT_WORKFLOW_SETTINGS,
   autoApproveWorkflowChanges: true,
+});
+
+// Memory settings value that enables auto-approve of memory saves.
+const autoApproveMemorySettings = (): Record<string, unknown> => ({
+  autoApproveMemorySaves: true,
 });
 
 // Clear the atom and lock between tests.
@@ -1030,5 +1049,74 @@ describe(requestApproval, () => {
       status: 'approved',
     });
     expect(atomStore.get(pendingLockAtom)).toBe(false);
+  });
+
+  it('auto-approve memory save stores the memory without a card or draft', async () => {
+    const storage = createStorage();
+    storage.values.set('local:kiloAgentMemories', []);
+    storage.values.set('local:kiloMemorySettings', autoApproveMemorySettings());
+
+    const outcome = await requestApproval(storage, 'memory', memoryDraft(), abortSignal());
+    expect(outcome).toMatchObject({ autoApproved: true, status: 'approved' });
+
+    const memories = storage.values.get('local:kiloAgentMemories') as Record<string, unknown>[];
+    expect(memories[0]?.['id']).toBe((outcome as { savedId: string }).savedId);
+    expect(storage.values.has('local:kiloPendingAgentMemoryDraft')).toBe(false);
+
+    // No card and the lock released.
+    const atomStore = getDefaultStore();
+    expect({
+      atom: atomStore.get(pendingApprovalAtom),
+      lock: atomStore.get(pendingLockAtom),
+    }).toStrictEqual({ atom: undefined, lock: false });
+  });
+
+  it('shows the memory card when auto-approve of memory saves is off', async () => {
+    const storage = createStorage();
+    storage.values.set('local:kiloAgentMemories', []);
+    storage.values.set('local:kiloMemorySettings', { autoApproveMemorySaves: false });
+
+    const promise = requestApproval(storage, 'memory', memoryDraft(), abortSignal());
+    await new Promise(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    const atomStore = getDefaultStore();
+    expect({
+      draft: storage.values.has('local:kiloPendingAgentMemoryDraft'),
+      kind: atomStore.get(pendingApprovalAtom)?.kind,
+      memories: storage.values.get('local:kiloAgentMemories'),
+    }).toStrictEqual({ draft: true, kind: 'memory', memories: [] });
+
+    atomStore.get(pendingApprovalAtom)?.settle({
+      autoApproved: false,
+      savedId: 'mem-off',
+      status: 'approved',
+    });
+    await promise;
+  });
+
+  it('falls back to the memory card when the memory settings cannot be read', async () => {
+    const storage = createStorage();
+    storage.values.set('local:kiloAgentMemories', []);
+    failGetItemForKey(storage, 'local:kiloMemorySettings');
+
+    const promise = requestApproval(storage, 'memory', memoryDraft(), abortSignal());
+    await new Promise(resolve => {
+      setTimeout(resolve, 0);
+    });
+
+    const atomStore = getDefaultStore();
+    expect({
+      kind: atomStore.get(pendingApprovalAtom)?.kind,
+      memories: storage.values.get('local:kiloAgentMemories'),
+    }).toStrictEqual({ kind: 'memory', memories: [] });
+
+    atomStore.get(pendingApprovalAtom)?.settle({
+      autoApproved: false,
+      savedId: 'mem-fallback',
+      status: 'approved',
+    });
+    await promise;
   });
 });

--- a/apps/extension/entrypoints/sidepanel/pending-approval.ts
+++ b/apps/extension/entrypoints/sidepanel/pending-approval.ts
@@ -1,6 +1,8 @@
 /* eslint-disable max-lines -- Request, persistence, and auto-approve share one lock and one settle contract. */
 import { atom, getDefaultStore } from 'jotai';
 import type { PendingAgentMemoryDraft } from '@/src/shared/agent-memories';
+import { loadMemorySettings } from '@/src/shared/agent-memory-settings';
+import type { AgentMemorySettingsStorageArea } from '@/src/shared/agent-memory-settings';
 import {
   addAgentMemory,
   clearPendingAgentMemoryDraft,
@@ -20,8 +22,8 @@ import type { AgentWorkflowsStorageArea } from '@/src/shared/agent-workflows-sto
 
 // ---------- types ----------
 
-// AutoApproved is true only for workflow saves applied without a card.
-// Enabled by the auto-approve setting. Every card approval reports false.
+/* AutoApproved is true only for saves applied without a card, enabled by the
+   per-kind auto-approve setting. Every card approval reports false. */
 export type ApprovalOutcome =
   | { status: 'approved'; savedId: string; autoApproved: boolean }
   | { status: 'rejected' }
@@ -54,8 +56,11 @@ export { pendingLockAtom };
 
 // ---------- shared storage type ----------
 
-// Unified storage area that satisfies both memory and workflow storage contracts.
-type UnifiedStorage = AgentMemoriesStorageArea & AgentWorkflowsStorageArea;
+/* Unified storage area that satisfies the memory, memory-settings, and
+   workflow storage contracts. */
+type UnifiedStorage = AgentMemoriesStorageArea &
+  AgentMemorySettingsStorageArea &
+  AgentWorkflowsStorageArea;
 
 // ---------- draft persistence helpers ----------
 
@@ -211,10 +216,12 @@ export const applyApprovalDecision = async (
  * Request user approval for a save. Persists the draft to storage FIRST, then sets the atom,
  * and returns a Promise that settles exactly once (first-wins).
  *
- * Workflow saves check the auto-approve setting before persisting the draft. When the
- * setting enables it, the save applies immediately without a card and returns approved
- * with autoApproved true. A failed settings read falls back to the approval card (the
- * cautious path, since auto-approve cannot be verified); a hash failure returns failed.
+ * Both kinds check their auto-approve setting before persisting the draft: a workflow
+ * save reads autoApproveWorkflowChanges, a memory save reads autoApproveMemorySaves.
+ * When the setting enables it, the save applies immediately without a card and returns
+ * approved with autoApproved true. A failed settings read falls back to the approval
+ * card (the cautious path, since auto-approve cannot be verified); a hash failure
+ * returns failed.
  *
  * Single-flight: if another approval is already pending, returns failed immediately.
  * Persist failure: returns failed without setting the atom — the card never shows.
@@ -237,34 +244,38 @@ export const requestApproval = async (
   }
   atomStore.set(pendingLockAtom, true);
 
-  if (kind === 'workflow') {
-    let autoApproveWorkflowChanges = false;
-    try {
-      ({ autoApproveWorkflowChanges } = await loadWorkflowSettings(storage));
-    } catch {
-      // A failed settings read must not block the save.
-      // Auto-approve cannot be verified, so fall through to the approval card.
-      autoApproveWorkflowChanges = false;
+  let autoApprove = false;
+  try {
+    if (kind === 'workflow') {
+      const workflowSettings = await loadWorkflowSettings(storage);
+      autoApprove = workflowSettings.autoApproveWorkflowChanges;
+    } else {
+      const memorySettings = await loadMemorySettings(storage);
+      autoApprove = memorySettings.autoApproveMemorySaves;
     }
+  } catch {
+    // A failed settings read must not block the save.
+    // Auto-approve cannot be verified, so fall through to the approval card.
+    autoApprove = false;
+  }
 
-    if (autoApproveWorkflowChanges) {
-      try {
-        if (signal.aborted) {
-          return { status: 'aborted' };
-        }
-        const outcome = await applyApprovalDecision(storage, kind, draft, true);
-        if (outcome.status === 'approved') {
-          return { autoApproved: true, savedId: outcome.savedId, status: 'approved' };
-        }
-        return outcome;
-      } catch (error) {
-        return {
-          reason: error instanceof Error ? error.message : 'Failed to save workflow.',
-          status: 'failed',
-        };
-      } finally {
-        atomStore.set(pendingLockAtom, false);
+  if (autoApprove) {
+    try {
+      if (signal.aborted) {
+        return { status: 'aborted' };
       }
+      const outcome = await applyApprovalDecision(storage, kind, draft, true);
+      if (outcome.status === 'approved') {
+        return { autoApproved: true, savedId: outcome.savedId, status: 'approved' };
+      }
+      return outcome;
+    } catch (error) {
+      return {
+        reason: error instanceof Error ? error.message : `Failed to save ${kind}.`,
+        status: 'failed',
+      };
+    } finally {
+      atomStore.set(pendingLockAtom, false);
     }
   }
 

--- a/apps/extension/entrypoints/sidepanel/workflow-settings.tsx
+++ b/apps/extension/entrypoints/sidepanel/workflow-settings.tsx
@@ -54,7 +54,8 @@ const SETTINGS_TOGGLE_ROWS = [
 const secondaryButtonClass =
   'type-label h-8 rounded-md border border-border bg-surface-overlay px-3 text-foreground-on-secondary transition hover:bg-surface-hover focus:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring focus-visible:ring-offset-2 focus-visible:ring-offset-surface-background';
 
-const SettingsToggle = ({
+/** Shared with the Memories settings section. */
+export const SettingsToggle = ({
   checked,
   description,
   disabled,

--- a/apps/extension/src/shared/agent-memory-settings.test.ts
+++ b/apps/extension/src/shared/agent-memory-settings.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+import {
+  DEFAULT_MEMORY_SETTINGS,
+  MEMORY_SETTINGS_STORAGE_KEY,
+  loadMemorySettings,
+  saveMemorySettings,
+} from './agent-memory-settings';
+
+const createStorage = () => {
+  const values = new Map<string, unknown>();
+  return {
+    getItem: (key: string) => values.get(key),
+    setItem: (key: string, value: unknown) => {
+      values.set(key, value);
+    },
+    values,
+  };
+};
+
+describe('memory settings storage', () => {
+  it('defaults auto-approve of memory saves to off', () => {
+    expect(DEFAULT_MEMORY_SETTINGS).toStrictEqual({ autoApproveMemorySaves: false });
+  });
+
+  it('loads the default record when nothing is stored', async () => {
+    const storage = createStorage();
+    await expect(loadMemorySettings(storage)).resolves.toStrictEqual(DEFAULT_MEMORY_SETTINGS);
+  });
+
+  it('loads the default record for a malformed value', async () => {
+    const storage = createStorage();
+    storage.values.set(MEMORY_SETTINGS_STORAGE_KEY, 'not-an-object');
+    await expect(loadMemorySettings(storage)).resolves.toStrictEqual(DEFAULT_MEMORY_SETTINGS);
+
+    storage.values.set(MEMORY_SETTINGS_STORAGE_KEY, { autoApproveMemorySaves: 'yes' });
+    await expect(loadMemorySettings(storage)).resolves.toStrictEqual(DEFAULT_MEMORY_SETTINGS);
+  });
+
+  it('round-trips the flag', async () => {
+    const storage = createStorage();
+    await saveMemorySettings(storage, { autoApproveMemorySaves: true });
+    await expect(loadMemorySettings(storage)).resolves.toStrictEqual({
+      autoApproveMemorySaves: true,
+    });
+
+    await saveMemorySettings(storage, { autoApproveMemorySaves: false });
+    await expect(loadMemorySettings(storage)).resolves.toStrictEqual(DEFAULT_MEMORY_SETTINGS);
+  });
+});

--- a/apps/extension/src/shared/agent-memory-settings.ts
+++ b/apps/extension/src/shared/agent-memory-settings.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod';
+
+export const MEMORY_SETTINGS_STORAGE_KEY = 'local:kiloMemorySettings';
+
+// eslint-disable-next-line typescript-eslint/consistent-type-definitions -- AGENTS.md prefers type
+export type AgentMemorySettings = {
+  autoApproveMemorySaves: boolean;
+};
+
+/**
+ * Off by default: `save_memory` shows the approval card until the user opts out.
+ * Kept in its own storage key so the Memories settings section never writes the
+ * workflow settings blob — both sections are mounted at once and would clobber
+ * each other's toggles.
+ */
+export const DEFAULT_MEMORY_SETTINGS: AgentMemorySettings = {
+  autoApproveMemorySaves: false,
+};
+
+export const agentMemorySettingsSchema = z
+  .object({
+    autoApproveMemorySaves: z.boolean().default(false),
+  })
+  .strip();
+
+type MaybePromise<Value> = Promise<Value> | Value;
+
+export interface AgentMemorySettingsStorageArea {
+  getItem(key: typeof MEMORY_SETTINGS_STORAGE_KEY): MaybePromise<unknown>;
+  setItem(key: typeof MEMORY_SETTINGS_STORAGE_KEY, value: unknown): MaybePromise<void>;
+}
+
+export const loadMemorySettings = async (
+  storageArea: AgentMemorySettingsStorageArea
+): Promise<AgentMemorySettings> => {
+  const parsed = agentMemorySettingsSchema.safeParse(
+    await storageArea.getItem(MEMORY_SETTINGS_STORAGE_KEY)
+  );
+  return parsed.success ? parsed.data : DEFAULT_MEMORY_SETTINGS;
+};
+
+export const saveMemorySettings = async (
+  storageArea: AgentMemorySettingsStorageArea,
+  settings: AgentMemorySettings
+): Promise<void> => {
+  await storageArea.setItem(MEMORY_SETTINGS_STORAGE_KEY, agentMemorySettingsSchema.parse(settings));
+};

--- a/apps/extension/src/shared/model-picker-rows.test.ts
+++ b/apps/extension/src/shared/model-picker-rows.test.ts
@@ -1,7 +1,13 @@
 import { describe, expect, it } from 'vitest';
+import { CLI_MODEL_ID } from '@kilocode/cloud-agent-sdk';
 import type { KiloGatewayModelOption } from './kilo-api-client';
 import type { ExtensionModelPickerRow } from './model-picker-rows';
-import { buildExtensionModelPickerRows } from './model-picker-rows';
+import {
+  buildExtensionModelPickerRows,
+  CLI_CATALOG_ID_PREFIX,
+  isGatewayModelId,
+  modelRowDisplayId,
+} from './model-picker-rows';
 
 const model = (
   id: string,
@@ -151,5 +157,35 @@ describe('extension model picker rows', () => {
     );
 
     expect(favoriteFlags).toStrictEqual({ all: false, fav: true, rec: false });
+  });
+});
+
+describe('isGatewayModelId()', () => {
+  it('accepts a gateway catalog id', () => {
+    expect(isGatewayModelId('anthropic/claude-sonnet-4')).toBe(true);
+  });
+
+  it('rejects the synthetic CLI default id', () => {
+    expect(isGatewayModelId(CLI_MODEL_ID)).toBe(false);
+  });
+
+  it('rejects a CLI-catalog row id', () => {
+    expect(isGatewayModelId(`${CLI_CATALOG_ID_PREFIX}opencode/grok-code`)).toBe(false);
+  });
+
+  it('rejects an empty id', () => {
+    expect(isGatewayModelId('')).toBe(false);
+  });
+});
+
+describe('modelRowDisplayId()', () => {
+  it('strips the CLI-catalog prefix', () => {
+    expect(modelRowDisplayId(`${CLI_CATALOG_ID_PREFIX}opencode/grok-code`)).toBe(
+      'opencode/grok-code'
+    );
+  });
+
+  it('leaves a gateway id untouched', () => {
+    expect(modelRowDisplayId('anthropic/claude-sonnet-4')).toBe('anthropic/claude-sonnet-4');
   });
 });

--- a/apps/extension/src/shared/model-picker-rows.ts
+++ b/apps/extension/src/shared/model-picker-rows.ts
@@ -1,4 +1,20 @@
+import { CLI_MODEL_ID } from '@kilocode/cloud-agent-sdk';
 import type { KiloGatewayModelOption } from './kilo-api-client';
+
+/** Prefix of a picker row projected from a remote CLI's own model catalog. */
+export const CLI_CATALOG_ID_PREFIX = 'cli:';
+
+/**
+ * Server-side model preferences (favorites, last selected) are keyed by gateway
+ * model id. The synthetic "CLI default" row and every CLI-catalog row are not
+ * gateway models, so their ids must never reach those endpoints.
+ */
+export const isGatewayModelId = (id: string): boolean =>
+  id !== '' && id !== CLI_MODEL_ID && !id.startsWith(CLI_CATALOG_ID_PREFIX);
+
+/** Id shown to the user: a CLI-catalog row shows the CLI's own provider/model. */
+export const modelRowDisplayId = (id: string): string =>
+  id.startsWith(CLI_CATALOG_ID_PREFIX) ? id.slice(CLI_CATALOG_ID_PREFIX.length) : id;
 
 export type ExtensionModelPickerRow =
   | { key: string; title: string; type: 'header' }

--- a/apps/extension/tests/e2e/agents-mode.test.ts
+++ b/apps/extension/tests/e2e/agents-mode.test.ts
@@ -926,3 +926,67 @@ test('Agents new session toolbar stays usable at the narrowest panel width', asy
     await cleanup();
   }
 });
+
+test('Agents session header reports context usage and session cost', async () => {
+  const sessionId = DEFAULT_CLOUD_SESSION.kiloSessionId;
+  let eventCounter = 0;
+  const ev = (streamEventType: string, data: unknown): Record<string, unknown> => ({
+    data,
+    eventId: ++eventCounter,
+    executionId: 'exec-usage',
+    sessionId,
+    streamEventType,
+    timestamp: new Date().toISOString(),
+  });
+  const kilocode = (type: string, properties: unknown): Record<string, unknown> =>
+    ev('kilocode', { properties, type });
+  // 1200 input + 300 output + 100 reasoning + 400 cache read = 2000 context tokens.
+  const events: Record<string, unknown>[] = [
+    kilocode('session.created', { info: { id: sessionId } }),
+    kilocode('message.updated', {
+      info: {
+        agent: 'build',
+        cost: 0.0125,
+        id: 'msg-usage-1',
+        mode: 'code',
+        modelID: 'claude-sonnet-4',
+        path: { cwd: '/', root: '/' },
+        providerID: 'anthropic',
+        role: 'assistant',
+        sessionID: sessionId,
+        time: { completed: Date.now(), created: Date.now() },
+        tokens: { cache: { read: 400, write: 0 }, input: 1200, output: 300, reasoning: 100 },
+      },
+    }),
+    kilocode('message.part.updated', {
+      part: {
+        id: 'part-usage-1',
+        messageID: 'msg-usage-1',
+        sessionID: sessionId,
+        text: 'Done with the fix.',
+        type: 'text',
+      },
+    }),
+    ev('complete', { currentBranch: 'main' }),
+  ];
+
+  const { cleanup, getSidePanel } = await setupAgentsTest({ cloudAgentWsEvents: events });
+  try {
+    const sidePanel = await getSidePanel();
+    await navigateToAgentsMode(sidePanel);
+    await sidePanel.getByText('Fix login bug').click();
+    await expect(sidePanel.getByLabel('Back to sessions')).toBeVisible({ timeout: 10_000 });
+    await expect(sidePanel.getByText('Done with the fix.')).toBeVisible({ timeout: 10_000 });
+
+    // The indicator reports the summed context tokens, never a fabricated value.
+    const indicator = sidePanel.getByLabel(/^Context usage:/u);
+    await expect(indicator).toBeVisible({ timeout: 10_000 });
+    await expect(indicator).toHaveAttribute('aria-label', /2,000 tokens/u);
+
+    // The popover carries the session cost streamed with the assistant message.
+    await indicator.click();
+    await expect(sidePanel.getByText('Session cost $0.0125')).toBeVisible({ timeout: 10_000 });
+  } finally {
+    await cleanup();
+  }
+});

--- a/apps/extension/tests/e2e/agents-mode.test.ts
+++ b/apps/extension/tests/e2e/agents-mode.test.ts
@@ -606,10 +606,21 @@ test('Agents new session spawns onto a connected CLI instance', async () => {
     await expect(runOn).toBeVisible({ timeout: 10_000 });
     await runOn.selectOption(DEFAULT_INSTANCE.connectionId);
 
-    // Cloud-only pickers leave the form; the CLI hint appears.
-    await expect(sidePanel.getByLabel('Model', { exact: true })).toBeHidden();
+    // The CLI target keeps the model picker and starts on the CLI's own model.
+    const modelTrigger = sidePanel.getByLabel('Model', { exact: true });
+    await expect(modelTrigger).toBeVisible({ timeout: 10_000 });
+    await expect(modelTrigger).toContainText('CLI default');
+    // The repo still comes from the CLI checkout, so that picker stays hidden.
     await expect(sidePanel.getByLabel('Select repository')).toBeHidden();
     await expect(sidePanel.getByText(/Runs in checkout-service/)).toBeVisible();
+
+    // Overriding the CLI model with a gateway model.
+    await modelTrigger.click();
+    await sidePanel
+      .getByRole('dialog', { name: 'Select model' })
+      .locator('[data-model-id="anthropic/claude-sonnet-4"]')
+      .click();
+    await expect(modelTrigger).toContainText('Claude Sonnet 4');
 
     await sidePanel.getByRole('button', { name: 'Start session' }).click();
 
@@ -623,6 +634,10 @@ test('Agents new session spawns onto a connected CLI instance', async () => {
         (message as { command?: string }).command === 'create_session'
     );
     expect(spawnCommands.length).toBeGreaterThan(0);
+    // The picked gateway model travels with the spawn command, so the CLI starts on it.
+    expect(spawnCommands[0]).toMatchObject({
+      data: { model: { modelID: 'anthropic/claude-sonnet-4', providerID: 'kilo' } },
+    });
     await expect(sidePanel.getByRole('heading', { name: 'Spawned session' })).toBeVisible({
       timeout: 15_000,
     });

--- a/apps/extension/tests/e2e/firefox-selenium-e2e.ts
+++ b/apps/extension/tests/e2e/firefox-selenium-e2e.ts
@@ -2897,10 +2897,10 @@ const scenarios: FirefoxScenario[] = [
         await clickButtonByLabel(session.driver, `Delete memory "${betaPreview}"`);
         await waitForText(session.driver, EMPTY_MEMORIES_MESSAGE);
 
-        const regionButtons = await session.driver.findElements(
-          By.css('section[aria-label="Memories"] button')
+        const memoryRowButtons = await session.driver.findElements(
+          By.css('section[aria-label="Memories"] button[aria-label^="Delete memory"]')
         );
-        assert.equal(regionButtons.length, 0);
+        assert.equal(memoryRowButtons.length, 0);
         await closeFirefoxSettings(session.driver);
       }),
   },

--- a/apps/extension/tests/e2e/memories.test.ts
+++ b/apps/extension/tests/e2e/memories.test.ts
@@ -15,6 +15,9 @@ import {
 
 const PENDING_DRAFT_KEY = 'kiloPendingAgentMemoryDraft';
 const AGENT_MEMORIES_KEY = 'kiloAgentMemories';
+const MEMORY_SETTINGS_KEY = 'kiloMemorySettings';
+
+const memorySettingsSchema = z.object({ autoApproveMemorySaves: z.boolean() });
 
 const EMPTY_MEMORIES_MESSAGE =
   'No memories yet. Highlight text on any page, right-click, and choose Add to memory.';
@@ -766,6 +769,47 @@ test('memory tools are available in dangerous mode', async () => {
       .locator('xpath=ancestor::details[1]');
     await expect(searchDetails.getByText('DangerMode unique memory preview text')).toBeVisible();
     await expect(sidePanel.getByText('Dangerous mode used search_memories.')).toBeVisible();
+  } finally {
+    await context.close();
+    await fixture.close();
+    await rm(userDataDir, { force: true, recursive: true });
+  }
+});
+
+test('memories settings auto-approve toggle starts off and persists', async () => {
+  const fixture = await startFixtureServer();
+  const { context, extensionId, userDataDir } = await launchExtensionContext();
+
+  try {
+    await mockKiloApi(context);
+    const sidePanel = await openAuthenticatedSidePanel(context, extensionId);
+    await openSettingsMemories(sidePanel);
+
+    const toggle = sidePanel.getByRole('switch', { name: 'Auto-approve memory saves' });
+
+    // Default is the confirmation card: the setting ships off.
+    await expect(toggle).toBeEnabled();
+    await expect(toggle).toHaveAttribute('aria-checked', 'false');
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-checked', 'true');
+
+    // Confirm through storage, not the DOM, that the setting was written.
+    await expect
+      .poll(async () => {
+        const stored = await readExtensionStorage(sidePanel, [MEMORY_SETTINGS_KEY]);
+        const settings = memorySettingsSchema.safeParse(stored[MEMORY_SETTINGS_KEY]);
+
+        return settings.success && settings.data.autoApproveMemorySaves;
+      })
+      .toBe(true);
+
+    // The choice survives a side panel reload.
+    await sidePanel.reload();
+    await openSettingsMemories(sidePanel);
+    await expect(
+      sidePanel.getByRole('switch', { name: 'Auto-approve memory saves' })
+    ).toHaveAttribute('aria-checked', 'true');
   } finally {
     await context.close();
     await fixture.close();


### PR DESCRIPTION
## What

Six agents-tab fixes, for parity with the mobile app and consistency with the extension's own browser tab.

| Reported | Fix |
|---|---|
| No context or cost for a session | The open session header shows the browser tab's `ContextDonut`: context usage, percent when the model's window is known, and session cost. |
| A running session has no model picker | The composer now carries a model picker. Cloud-agent and legacy remote sessions use the gateway catalog; a v1 remote CLI session uses the catalog the CLI itself reports. |
| A new remote CLI session has no model picker | The new-session form offers the picker for a CLI target too. The pick rides `create_session`; `CLI default` leaves the CLI's own model alone. |
| Opening a session does not show the latest messages | The conversation list pins to the newest message on open, settling on virtualizer measurement instead of a fixed frame budget. |
| Weird spacing in the session list | One vertical rhythm and one empty-state treatment across Active and History, one text column for titles, sub-lines, and empty text. |
| `save_memory` should have a confirmation option | New `Auto-approve memory saves` setting in the memories section, **off by default**, so the confirmation card stays the default. |

## Notes

- **Reuse over new code.** Context usage and cost come from the existing `@kilocode/cloud-agent-sdk` atoms (`contextUsage`, `totalCost`) and `fetchedSessionData.totalCostMicrodollars`; the indicator is the browser tab's existing `ContextDonut`; the picker is the existing `ModelPicker`. Mobile's behavior is mirrored, including its rule that a mid-session model change applies to the next message and is not gated on streaming.
- **Honest states.** An unknown context window renders tokens only, never a fake percent. A CLI session with no catalog shows a disabled picker with a reason instead of a gateway model it cannot run.
- **Favorites stay clean.** `CLI default` and CLI-catalog rows are not gateway ids, so they are never sent to `modelPreferences.addFavorite` and show no favorite control.
- **Scroll fix root cause.** `virtual-core` issues corrective `scrollTo` writes on row measurement, from an offset that lags the DOM by a frame. The old code could not tell those from a user scroll, so one corrective write latched auto-scroll off for the whole mount and nothing re-pinned. The pin now compares against the live offset and drops stale corrections; a reader who scrolls up stays put.
- The dead permanently-disabled `Compact now` button is gone where compaction is impossible, and `ContextDonut` takes an explicit `placement` instead of a child-selector hack.
- `AGENTS.md` updated: `save_memory` is no longer unconditionally card-gated.

## Verification

- `pnpm --filter kilo-extension typecheck` / `lint` / `test` — clean; unit tests 89 files.
- `pnpm --filter kilo-extension e2e:chrome` — full mocked suite green.
- `pnpm --filter kilo-extension e2e:firefox` — green; one assertion narrowed, because the Memories section legitimately holds a settings toggle now.
- `pnpm --filter kilo-extension e2e:local` — run against a local stack with a real connected `kilo` CLI instance and a real cloud-agent session. The live suite has 7 failures that reproduce identically on `main` at the same commit (frontier timing, dangerous-mode eval, manual compaction, CLI reopen). Each was baselined on `main` before being ruled pre-existing; `local-backend-live.test.ts:608` was run twice per side to confirm it is flaky on both.
