### PR TITLE
fix(data-exports): redirect guests to sign in

### DIFF
--- a/apps/web/src/app/(app)/data-exports/page.test.ts
+++ b/apps/web/src/app/(app)/data-exports/page.test.ts
@@ -1,14 +1,12 @@
 import React from 'react';
 
-const mockGetUserFromAuth = jest.fn();
-const mockNotFound = jest.fn(() => {
-  throw new Error('NEXT_NOT_FOUND');
-});
+const mockGetUserFromAuthOrRedirect = jest.fn();
 
 (globalThis as typeof globalThis & { React: typeof React }).React = React;
 
-jest.mock('@/lib/user/server', () => ({ getUserFromAuth: mockGetUserFromAuth }));
-jest.mock('next/navigation', () => ({ notFound: mockNotFound }));
+jest.mock('@/lib/user/server', () => ({
+  getUserFromAuthOrRedirect: mockGetUserFromAuthOrRedirect,
+}));
 jest.mock('@/components/PageLayout', () => ({ PageLayout: () => null }));
 jest.mock('./DataExportsClient', () => ({ DataExportsClient: () => null }));
 jest.mock('./RequestDataDeletionCard', () => ({ RequestDataDeletionCard: () => null }));
@@ -18,19 +16,23 @@ describe('DataExportsPage', () => {
     jest.clearAllMocks();
   });
 
-  it('authenticates the visitor without requiring Kilo staff', async () => {
-    mockGetUserFromAuth.mockResolvedValue({ user: null });
+  it('redirects unauthenticated visitors to sign in and returns them to data exports', async () => {
+    mockGetUserFromAuthOrRedirect.mockRejectedValue(new Error('NEXT_REDIRECT'));
     const { default: DataExportsPage } = await import('./page');
 
-    await expect(DataExportsPage()).rejects.toThrow('NEXT_NOT_FOUND');
-    expect(mockGetUserFromAuth).toHaveBeenCalledWith({ adminOnly: false });
+    await expect(DataExportsPage()).rejects.toThrow('NEXT_REDIRECT');
+    expect(mockGetUserFromAuthOrRedirect).toHaveBeenCalledWith(
+      '/users/sign_in?callbackPath=/data-exports'
+    );
   });
 
   it('renders for a signed-in non-admin user', async () => {
-    mockGetUserFromAuth.mockResolvedValue({ user: { id: 'user-1', is_admin: false } });
+    mockGetUserFromAuthOrRedirect.mockResolvedValue({ id: 'user-1', is_admin: false });
     const { default: DataExportsPage } = await import('./page');
 
     await expect(DataExportsPage()).resolves.toBeTruthy();
-    expect(mockNotFound).not.toHaveBeenCalled();
+    expect(mockGetUserFromAuthOrRedirect).toHaveBeenCalledWith(
+      '/users/sign_in?callbackPath=/data-exports'
+    );
   });
 });

--- a/apps/web/src/app/(app)/data-exports/page.tsx
+++ b/apps/web/src/app/(app)/data-exports/page.tsx
@@ -1,12 +1,10 @@
-import { getUserFromAuth } from '@/lib/user/server';
-import { notFound } from 'next/navigation';
+import { getUserFromAuthOrRedirect } from '@/lib/user/server';
 import { PageLayout } from '@/components/PageLayout';
 import { DataExportsClient } from './DataExportsClient';
 import { RequestDataDeletionCard } from './RequestDataDeletionCard';
 
 export default async function DataExportsPage() {
-  const { user } = await getUserFromAuth({ adminOnly: false });
-  if (!user) notFound();
+  await getUserFromAuthOrRedirect('/users/sign_in?callbackPath=/data-exports');
 
   return (
     <PageLayout


### PR DESCRIPTION
## Summary

- Replace the `/data-exports` page's unauthenticated 404 with the standard protected-page sign-in redirect.
- Preserve `/data-exports` as the callback path so users following export-ready links return to the intended page after authentication.
- Update page-level regression coverage for both guest redirects and signed-in non-admin access.

## Verification

- Manual browser verification was not performed because no local development stack or PostgreSQL service was available.

## Visual Changes

| Before | After |
|---|---|
| Unauthenticated visits to `/data-exports` render a 404 page. | Unauthenticated visits redirect to sign-in and return to `/data-exports` after authentication. |

## Reviewer Notes

- This uses the same `getUserFromAuthOrRedirect` pattern as other protected app pages and does not change authorization for signed-in users.
- The focused Jest file was discovered, but repository-wide test setup could not connect to the unavailable local PostgreSQL service before assertions ran.