### PR TITLE
fix(ai-gateway): mark GLM 5.2 free unavailable

### DIFF
--- a/apps/web/src/lib/ai-gateway/unavailable-models.ts
+++ b/apps/web/src/lib/ai-gateway/unavailable-models.ts
@@ -7,6 +7,7 @@ const unavailableModelIds: ReadonlySet<string> = new Set([
   'nvidia/nemotron-nano-12b-v2-vl:free',
   'nvidia/nemotron-nano-9b-v2:free',
   'openai/gpt-oss-20b:free',
+  'z-ai/glm-5.2:free',
 ]);
 
 export function isUnavailableModel(modelId: string): boolean {


### PR DESCRIPTION
## Summary
- add `z-ai/glm-5.2:free` to the AI Gateway unavailable-model set
- ensure stale clients receive the generic unavailable-model response

## Testing
- Not run locally; CI will handle validation as requested.