### PR TITLE
feat(ai-gateway): recommend GLM 5.3

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/zai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/zai.ts
@@ -4,4 +4,4 @@ export function isGlmModel(model: string) {
 
 // Partner routing stays pinned when the current GLM model changes.
 export const FRIENDLI_GLM_PUBLIC_ID = 'z-ai/glm-5.2';
-export const GLM_CURRENT_MODEL_ID = 'z-ai/glm-5.2';
+export const GLM_CURRENT_MODEL_ID = 'z-ai/glm-5.3';

--- a/apps/web/src/tests/openrouter-models-config.test.ts
+++ b/apps/web/src/tests/openrouter-models-config.test.ts
@@ -16,7 +16,7 @@ describe('OpenRouter Models Config', () => {
       CLAUDE_SONNET_CURRENT_MODEL_ID,
       CLAUDE_OPUS_CURRENT_MODEL_ID,
       GPT_CURRENT_MODEL_ID,
-      'z-ai/glm-5.2',
+      'z-ai/glm-5.3',
       tencent_hy3_free_model.public_id,
     ];
 


### PR DESCRIPTION
## Summary
- update the current GLM recommendation to `z-ai/glm-5.3`
- keep Friendli partner routing pinned to GLM 5.2
- update the preferred-model assertion

## Testing
- Not run locally; CI will validate the change.