### PR TITLE
feat(ai-gateway): add Hy3 to Auto Free

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -85,9 +85,7 @@ describe('isFreeModel', () => {
       expect(findKiloExclusiveModel('tencent/hy3:free')).toBe(tencent_hy3_free_model);
       expect(tencent_hy3_free_model.internal_id).toBe('tencent/hy3');
       expect(tencent_hy3_free_model.inference_provider_restriction).toEqual(['tencent']);
-      expect(autoFreeModels.map(({ model }) => model)).toContain(
-        tencent_hy3_free_model.public_id
-      );
+      expect(autoFreeModels.map(({ model }) => model)).toContain(tencent_hy3_free_model.public_id);
     });
 
     test('retains the disabled LongCat 2.0 configuration for later enablement', async () => {

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -81,11 +81,11 @@ describe('isFreeModel', () => {
       expect(findKiloExclusiveModel('qwen/qwen3.7-plus')).toBeNull();
     });
 
-    test('registers Tencent Hy3 as free without adding it to Auto Free', () => {
+    test('registers Tencent Hy3 as an Auto Free model', () => {
       expect(findKiloExclusiveModel('tencent/hy3:free')).toBe(tencent_hy3_free_model);
       expect(tencent_hy3_free_model.internal_id).toBe('tencent/hy3');
       expect(tencent_hy3_free_model.inference_provider_restriction).toEqual(['tencent']);
-      expect(autoFreeModels.map(({ model }) => model)).not.toContain(
+      expect(autoFreeModels.map(({ model }) => model)).toContain(
         tencent_hy3_free_model.public_id
       );
     });
@@ -189,19 +189,19 @@ describe('isFreeModel', () => {
         Object.fromEntries(autoFreeModels.map(({ model, reasoning }) => [model, reasoning]))
       ).toEqual({
         'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
+        'tencent/hy3:free': { enabled: true, effort: 'high' },
         'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
       });
     });
 
-    test('weights non-Laguna auto-free models higher than Laguna', () => {
-      const lagunaModel = autoFreeModels.find(({ model }) => model.includes('laguna'));
-      expect(lagunaModel?.weight).toBe(1);
-
-      for (const candidate of autoFreeModels) {
-        if (!candidate.model.includes('laguna')) {
-          expect(candidate.weight).toBe(9);
-        }
-      }
+    test('weights Auto Free models at 80% StepFun, 10% Hy3, and 10% Laguna', () => {
+      expect(
+        Object.fromEntries(autoFreeModels.map(({ model, weight }) => [model, weight]))
+      ).toEqual({
+        'stepfun/step-3.7-flash:free': 8,
+        'tencent/hy3:free': 1,
+        'poolside/laguna-s-2.1:free': 1,
+      });
     });
 
     test('uses autoFreeModels weights when selecting a model', () => {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -92,7 +92,6 @@ export const preferredModels = [
   KILO_AUTO_FREE_MODEL.id,
 
   ...autoFreeModels.map(({ model }) => model),
-  ...(tencent_hy3_free_model.status === 'public' ? [tencent_hy3_free_model.public_id] : []),
   ...(longcat_2_free_model.status === 'public' ? [longcat_2_free_model.public_id] : []),
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -48,7 +48,16 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
     ? [
         {
           model: stepfun_37_flash_free_model.public_id,
-          weight: 9,
+          weight: 8,
+          reasoning: { enabled: true, effort: 'high' },
+        } satisfies AutoFreeModel,
+      ]
+    : []),
+  ...(tencent_hy3_free_model.status === 'public'
+    ? [
+        {
+          model: tencent_hy3_free_model.public_id,
+          weight: 1,
           reasoning: { enabled: true, effort: 'high' },
         } satisfies AutoFreeModel,
       ]


### PR DESCRIPTION
## Summary
- add Tencent Hy3 to Auto Free with high reasoning
- reduce StepFun weighting for an 80% StepFun, 10% Hy3, 10% Laguna split
- update Auto Free model coverage for reasoning and weights

## Testing
- CI only, as requested