### PR TITLE
fix: unbreak shipped clients broken by #5337

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agents-provider.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-provider.tsx
@@ -53,7 +53,7 @@ export const ExtensionAgentsProvider = ({
 
     const userWebConnection = createUserWebConnection({
       getAuthToken: async () => {
-        const tokenResult = await trpcClient.activeSessions.getToken.mutate();
+        const tokenResult = await trpcClient.activeSessions.getToken.query();
         return tokenResult.token;
       },
       lifecycleHooks: createBrowserLifecycleHooks(),

--- a/apps/extension/entrypoints/sidepanel/agents-provider.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-provider.tsx
@@ -53,7 +53,7 @@ export const ExtensionAgentsProvider = ({
 
     const userWebConnection = createUserWebConnection({
       getAuthToken: async () => {
-        const tokenResult = await trpcClient.activeSessions.getToken.query();
+        const tokenResult = await trpcClient.activeSessions.createWebTicket.mutate();
         return tokenResult.token;
       },
       lifecycleHooks: createBrowserLifecycleHooks(),

--- a/apps/extension/tests/e2e/agents-fixture.ts
+++ b/apps/extension/tests/e2e/agents-fixture.ts
@@ -521,7 +521,7 @@ export const mockAgentsApi = async (
         return { result: { data: { favorites: [], lastSelected: null } } };
       }
 
-      if (proc === 'activeSessions.getToken') {
+      if (proc === 'activeSessions.createWebTicket' || proc === 'activeSessions.getToken') {
         return {
           result: { data: { expiresAt: 1_700_000_000, token: 'mock-ingest-token' } },
         };

--- a/apps/mobile/src/components/agents/user-web-connection-provider.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/user-web-connection-provider.mounted.test.tsx
@@ -8,8 +8,8 @@ import { UserWebConnectionProvider } from './user-web-connection-provider';
 type AuthConfig = { getAuthToken: () => Promise<string> };
 
 const mocks = vi.hoisted(() => ({
-  mutate: vi.fn(() => ({ token: 'ticket-1', expiresAt: 1_700_000_060 })),
-  query: vi.fn(),
+  mutate: vi.fn(),
+  query: vi.fn(() => ({ token: 'ticket-1', expiresAt: 1_700_000_060 })),
   createUserWebConnection: vi.fn(),
   capturedConfig: null as AuthConfig | null,
 }));
@@ -63,7 +63,7 @@ describe('UserWebConnectionProvider', () => {
     mocks.createUserWebConnection.mockClear();
   });
 
-  it('mints the ingest ticket via the getToken mutation', async () => {
+  it('mints the ingest ticket via the getToken query', async () => {
     const holder: { renderer?: TestRenderer.ReactTestRenderer } = {};
     await act(() => {
       holder.renderer = TestRenderer.create(createElement(UserWebConnectionProvider, null));
@@ -78,8 +78,8 @@ describe('UserWebConnectionProvider', () => {
     const token = await config.getAuthToken();
 
     expect(token).toBe('ticket-1');
-    expect(mocks.mutate).toHaveBeenCalledTimes(1);
-    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.query).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate).not.toHaveBeenCalled();
 
     await act(() => {
       holder.renderer?.unmount();

--- a/apps/mobile/src/components/agents/user-web-connection-provider.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/user-web-connection-provider.mounted.test.tsx
@@ -8,8 +8,8 @@ import { UserWebConnectionProvider } from './user-web-connection-provider';
 type AuthConfig = { getAuthToken: () => Promise<string> };
 
 const mocks = vi.hoisted(() => ({
-  mutate: vi.fn(),
-  query: vi.fn(() => ({ token: 'ticket-1', expiresAt: 1_700_000_060 })),
+  mutate: vi.fn(() => ({ token: 'ticket-1', expiresAt: 1_700_000_060 })),
+  query: vi.fn(),
   createUserWebConnection: vi.fn(),
   capturedConfig: null as AuthConfig | null,
 }));
@@ -47,8 +47,10 @@ vi.mock('@/lib/user-web-connection-lifecycle', () => ({
 vi.mock('@/lib/trpc', () => ({
   trpcClient: {
     activeSessions: {
-      getToken: {
+      createWebTicket: {
         mutate: mocks.mutate,
+      },
+      getToken: {
         query: mocks.query,
       },
     },
@@ -63,7 +65,7 @@ describe('UserWebConnectionProvider', () => {
     mocks.createUserWebConnection.mockClear();
   });
 
-  it('mints the ingest ticket via the getToken query', async () => {
+  it('mints the ingest ticket via the createWebTicket mutation', async () => {
     const holder: { renderer?: TestRenderer.ReactTestRenderer } = {};
     await act(() => {
       holder.renderer = TestRenderer.create(createElement(UserWebConnectionProvider, null));
@@ -78,8 +80,8 @@ describe('UserWebConnectionProvider', () => {
     const token = await config.getAuthToken();
 
     expect(token).toBe('ticket-1');
-    expect(mocks.query).toHaveBeenCalledTimes(1);
-    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.query).not.toHaveBeenCalled();
 
     await act(() => {
       holder.renderer?.unmount();

--- a/apps/mobile/src/components/agents/user-web-connection-provider.test.ts
+++ b/apps/mobile/src/components/agents/user-web-connection-provider.test.ts
@@ -8,11 +8,11 @@ import { UserWebConnectionProvider } from './user-web-connection-provider';
 type AuthConfig = { getAuthToken: () => Promise<string> };
 
 const mocks = vi.hoisted(() => ({
-  mutate: vi.fn(),
-  query: vi.fn(async () => {
+  mutate: vi.fn(async () => {
     await Promise.resolve();
     return { token: 'ticket-1', expiresAt: 1_700_000_060 };
   }),
+  query: vi.fn(),
   capturedConfig: null as AuthConfig | null,
 }));
 
@@ -34,8 +34,10 @@ vi.mock('@/lib/user-web-connection-lifecycle', () => ({
 vi.mock('@/lib/trpc', () => ({
   trpcClient: {
     activeSessions: {
-      getToken: {
+      createWebTicket: {
         mutate: mocks.mutate,
+      },
+      getToken: {
         query: mocks.query,
       },
     },
@@ -49,7 +51,7 @@ describe('UserWebConnectionProvider', () => {
     mocks.query.mockClear();
   });
 
-  it('mints the ingest ticket via the getToken query (not mutation)', async () => {
+  it('mints the ingest ticket via the createWebTicket mutation (not the getToken query)', async () => {
     const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
       current: undefined,
     };
@@ -68,8 +70,8 @@ describe('UserWebConnectionProvider', () => {
     const token = await config.getAuthToken();
 
     expect(token).toBe('ticket-1');
-    expect(mocks.query).toHaveBeenCalledTimes(1);
-    expect(mocks.mutate).not.toHaveBeenCalled();
+    expect(mocks.mutate).toHaveBeenCalledTimes(1);
+    expect(mocks.query).not.toHaveBeenCalled();
 
     const renderer = rendererRef.current;
     if (!renderer) {

--- a/apps/mobile/src/components/agents/user-web-connection-provider.test.ts
+++ b/apps/mobile/src/components/agents/user-web-connection-provider.test.ts
@@ -8,11 +8,11 @@ import { UserWebConnectionProvider } from './user-web-connection-provider';
 type AuthConfig = { getAuthToken: () => Promise<string> };
 
 const mocks = vi.hoisted(() => ({
-  mutate: vi.fn(async () => {
+  mutate: vi.fn(),
+  query: vi.fn(async () => {
     await Promise.resolve();
     return { token: 'ticket-1', expiresAt: 1_700_000_060 };
   }),
-  query: vi.fn(),
   capturedConfig: null as AuthConfig | null,
 }));
 
@@ -49,7 +49,7 @@ describe('UserWebConnectionProvider', () => {
     mocks.query.mockClear();
   });
 
-  it('mints the ingest ticket via the getToken mutation (not query)', async () => {
+  it('mints the ingest ticket via the getToken query (not mutation)', async () => {
     const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
       current: undefined,
     };
@@ -68,8 +68,8 @@ describe('UserWebConnectionProvider', () => {
     const token = await config.getAuthToken();
 
     expect(token).toBe('ticket-1');
-    expect(mocks.mutate).toHaveBeenCalledTimes(1);
-    expect(mocks.query).not.toHaveBeenCalled();
+    expect(mocks.query).toHaveBeenCalledTimes(1);
+    expect(mocks.mutate).not.toHaveBeenCalled();
 
     const renderer = rendererRef.current;
     if (!renderer) {

--- a/apps/mobile/src/components/agents/user-web-connection-provider.tsx
+++ b/apps/mobile/src/components/agents/user-web-connection-provider.tsx
@@ -25,7 +25,7 @@ export function UserWebConnectionProvider({ children }: Readonly<UserWebConnecti
   connectionRef.current ??= createUserWebConnection({
     websocketUrl: `${SESSION_INGEST_WS_URL}/api/user/web`,
     getAuthToken: async () => {
-      const result = await trpcClient.activeSessions.getToken.mutate();
+      const result = await trpcClient.activeSessions.getToken.query();
       return result.token;
     },
     lifecycleHooks: createNativeUserWebConnectionLifecycleHooks(),

--- a/apps/mobile/src/components/agents/user-web-connection-provider.tsx
+++ b/apps/mobile/src/components/agents/user-web-connection-provider.tsx
@@ -25,7 +25,7 @@ export function UserWebConnectionProvider({ children }: Readonly<UserWebConnecti
   connectionRef.current ??= createUserWebConnection({
     websocketUrl: `${SESSION_INGEST_WS_URL}/api/user/web`,
     getAuthToken: async () => {
-      const result = await trpcClient.activeSessions.getToken.query();
+      const result = await trpcClient.activeSessions.createWebTicket.mutate();
       return result.token;
     },
     lifecycleHooks: createNativeUserWebConnectionLifecycleHooks(),

--- a/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
@@ -69,7 +69,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
     sharedConnectionRef.current = createUserWebConnection({
       websocketUrl: `${SESSION_INGEST_WS_URL}/api/user/web`,
       getAuthToken: async () => {
-        const result = await trpcClient.activeSessions.getToken.query();
+        const result = await trpcClient.activeSessions.createWebTicket.mutate();
         return result.token;
       },
       lifecycleHooks: createBrowserLifecycleHooks(),

--- a/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
@@ -69,7 +69,7 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
     sharedConnectionRef.current = createUserWebConnection({
       websocketUrl: `${SESSION_INGEST_WS_URL}/api/user/web`,
       getAuthToken: async () => {
-        const result = await trpcClient.activeSessions.getToken.mutate();
+        const result = await trpcClient.activeSessions.getToken.query();
         return result.token;
       },
       lifecycleHooks: createBrowserLifecycleHooks(),

--- a/apps/web/src/routers/active-sessions-router.test.ts
+++ b/apps/web/src/routers/active-sessions-router.test.ts
@@ -72,7 +72,7 @@ describe('active-sessions-router', () => {
     jest.restoreAllMocks();
   });
 
-  describe('getToken', () => {
+  describe('web ticket minting', () => {
     it('mints a one-use ticket and returns { token, expiresAt }', async () => {
       const fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue(
         new Response(JSON.stringify({ ticket: 'ticket-abc', expiresAt: 1_700_000_060 }), {
@@ -90,6 +90,22 @@ describe('active-sessions-router', () => {
       expect(calledUrl).toBe('https://test-ingest.example.com/api/user/web-ticket');
       expect(init.method).toBe('POST');
       expect((init.headers as Record<string, string>).Authorization).toContain('Bearer ');
+    });
+
+    it('mints the same ticket through the createWebTicket mutation', async () => {
+      jest.spyOn(global, 'fetch').mockResolvedValue(
+        new Response(JSON.stringify({ ticket: 'ticket-abc', expiresAt: 1_700_000_060 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      const caller = await createCallerForUser(regularUser.id);
+
+      await expect(caller.activeSessions.createWebTicket()).resolves.toEqual({
+        token: 'ticket-abc',
+        expiresAt: 1_700_000_060,
+      });
     });
 
     it('throws PRECONDITION_FAILED when the worker returns a non-2xx response', async () => {

--- a/apps/web/src/routers/active-sessions-router.ts
+++ b/apps/web/src/routers/active-sessions-router.ts
@@ -235,7 +235,7 @@ export const activeSessionsRouter = createTRPCRouter({
    * expiry from the worker body. A missing worker URL or a non-2xx mint
    * response fails fast with PRECONDITION_FAILED rather than hanging.
    */
-  getToken: baseProcedure.mutation(async ({ ctx }) => {
+  getToken: baseProcedure.query(async ({ ctx }) => {
     if (!SESSION_INGEST_WORKER_URL) {
       throw new TRPCError({
         code: 'PRECONDITION_FAILED',

--- a/apps/web/src/routers/active-sessions-router.ts
+++ b/apps/web/src/routers/active-sessions-router.ts
@@ -228,56 +228,73 @@ function throwOrgContextFailure(error: unknown): never {
   });
 }
 
+/**
+ * Mint a one-use web ticket from Session Ingest for the given user. The
+ * returned `token` is the opaque ticket; `expiresAt` is the Unix-seconds
+ * expiry from the worker body. A missing worker URL or a non-2xx mint
+ * response fails fast with PRECONDITION_FAILED rather than hanging.
+ */
+async function mintWebTicket(userId: string): Promise<{ token: string; expiresAt: number }> {
+  if (!SESSION_INGEST_WORKER_URL) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Session ingest is not configured',
+    });
+  }
+
+  const token = generateInternalServiceToken(userId);
+  const url = `${SESSION_INGEST_WORKER_URL}/api/user/web-ticket`;
+
+  let response: Response;
+  try {
+    response = await fetch(url, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    });
+  } catch (error) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Session ingest is not configured',
+      cause: error,
+    });
+  }
+
+  if (!response.ok) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Session ingest is not configured',
+    });
+  }
+
+  const raw = await response.json();
+  const parsed = webTicketResponseSchema.safeParse(raw);
+  if (!parsed.success) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Invalid ticket response from session ingest',
+      cause: parsed.error,
+    });
+  }
+  return { token: parsed.data.ticket, expiresAt: parsed.data.expiresAt };
+}
+
 export const activeSessionsRouter = createTRPCRouter({
   /**
-   * Mint a one-use web ticket from Session Ingest for the authenticated user.
-   * The returned `token` is the opaque ticket; `expiresAt` is the Unix-seconds
-   * expiry from the worker body. A missing worker URL or a non-2xx mint
-   * response fails fast with PRECONDITION_FAILED rather than hanging.
+   * Mint a web ticket. This is the path forward: minting is not idempotent,
+   * so it belongs on a mutation.
    */
-  getToken: baseProcedure.query(async ({ ctx }) => {
-    if (!SESSION_INGEST_WORKER_URL) {
-      throw new TRPCError({
-        code: 'PRECONDITION_FAILED',
-        message: 'Session ingest is not configured',
-      });
-    }
+  createWebTicket: baseProcedure.mutation(({ ctx }) => mintWebTicket(ctx.user.id)),
 
-    const token = generateInternalServiceToken(ctx.user.id);
-    const url = `${SESSION_INGEST_WORKER_URL}/api/user/web-ticket`;
-
-    let response: Response;
-    try {
-      response = await fetch(url, {
-        method: 'POST',
-        headers: { Authorization: `Bearer ${token}` },
-      });
-    } catch (error) {
-      throw new TRPCError({
-        code: 'PRECONDITION_FAILED',
-        message: 'Session ingest is not configured',
-        cause: error,
-      });
-    }
-
-    if (!response.ok) {
-      throw new TRPCError({
-        code: 'PRECONDITION_FAILED',
-        message: 'Session ingest is not configured',
-      });
-    }
-
-    const raw = await response.json();
-    const parsed = webTicketResponseSchema.safeParse(raw);
-    if (!parsed.success) {
-      throw new TRPCError({
-        code: 'PRECONDITION_FAILED',
-        message: 'Invalid ticket response from session ingest',
-        cause: parsed.error,
-      });
-    }
-    return { token: parsed.data.ticket, expiresAt: parsed.data.expiresAt };
-  }),
+  /**
+   * TODO: remove once no shipped client calls this. Superseded by
+   * `createWebTicket`. Store builds and installed extensions cannot update in
+   * step with the server, so the procedure has to stay a query: tRPC answers a
+   * query-shaped call to a mutation with 405, and fails the whole batch with
+   * 400 "Cannot mix procedure types in call" when it is batched beside a query.
+   * Drop it when the mobile and extension releases that call `createWebTicket`
+   * have rolled out and the getToken traffic in Axiom reaches zero.
+   */
+  getToken: baseProcedure.query(({ ctx }) => mintWebTicket(ctx.user.id)),
 
   list: baseProcedure.input(listInputSchema).query(async ({ ctx, input }) => {
     const organizationId = input?.organizationId;

--- a/apps/web/src/routers/user-router.test.ts
+++ b/apps/web/src/routers/user-router.test.ts
@@ -11,6 +11,10 @@ import { eq, inArray } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { User } from '@kilocode/db/schema';
 import { sendSignInCodeEmail } from '@/lib/email';
+import {
+  sendAccountDeletionConfirmationEmail,
+  sendAccountDeletionSupportNotification,
+} from '@/lib/email';
 import { performGdprRemoval } from '@/lib/user/gdpr-removal';
 import { assertUserCanBeSoftDeleted, SoftDeletePreconditionError } from '@/lib/user';
 
@@ -19,6 +23,8 @@ jest.mock('@/lib/email', () => {
   return {
     ...actual,
     sendSignInCodeEmail: jest.fn(),
+    sendAccountDeletionConfirmationEmail: jest.fn(),
+    sendAccountDeletionSupportNotification: jest.fn(),
   };
 });
 
@@ -35,6 +41,8 @@ jest.mock('@/lib/user', () => {
 });
 
 const mockSendSignInCodeEmail = jest.mocked(sendSignInCodeEmail);
+const mockSendDeletionConfirmation = jest.mocked(sendAccountDeletionConfirmationEmail);
+const mockSendDeletionSupportNotification = jest.mocked(sendAccountDeletionSupportNotification);
 const mockPerformGdprRemoval = jest.mocked(performGdprRemoval);
 const mockAssertUserCanBeSoftDeleted = jest.mocked(assertUserCanBeSoftDeleted);
 
@@ -1035,12 +1043,16 @@ describe('user router - account deletion', () => {
     });
 
     mockSendSignInCodeEmail.mockReset();
+    mockSendDeletionConfirmation.mockReset();
+    mockSendDeletionSupportNotification.mockReset();
     mockPerformGdprRemoval.mockReset();
     mockAssertUserCanBeSoftDeleted.mockReset();
 
     mockAssertUserCanBeSoftDeleted.mockResolvedValue(undefined);
     mockPerformGdprRemoval.mockResolvedValue({ warnings: [] });
     mockSendSignInCodeEmail.mockResolvedValue({ sent: false, reason: 'provider_not_configured' });
+    mockSendDeletionConfirmation.mockResolvedValue({ sent: true });
+    mockSendDeletionSupportNotification.mockResolvedValue(undefined);
   });
 
   afterEach(async () => {
@@ -1111,6 +1123,26 @@ describe('user router - account deletion', () => {
     ).rejects.toMatchObject({ code: 'UNAUTHORIZED' });
 
     expect(mockPerformGdprRemoval).not.toHaveBeenCalled();
+  });
+
+  it('no input keeps the legacy request flow: emails only, no removal', async () => {
+    const caller = await createCallerForUser(deletionUser.id);
+
+    const result = await caller.user.requestAccountDeletion();
+
+    expect(result).toEqual({ success: true });
+    expect(mockSendDeletionConfirmation).toHaveBeenCalledWith(deletionUser.google_user_email);
+    expect(mockSendDeletionSupportNotification).toHaveBeenCalledWith(
+      deletionUser.google_user_email,
+      deletionUser.id
+    );
+    expect(mockPerformGdprRemoval).not.toHaveBeenCalled();
+
+    const [stored] = await db
+      .select({ requestedAt: kilocode_users.account_deletion_requested_at })
+      .from(kilocode_users)
+      .where(eq(kilocode_users.id, deletionUser.id));
+    expect(stored?.requestedAt).not.toBeNull();
   });
 
   it('valid code calls performGdprRemoval once', async () => {

--- a/apps/web/src/routers/user-router.ts
+++ b/apps/web/src/routers/user-router.ts
@@ -5,7 +5,11 @@ import {
   SoftDeletePreconditionError,
   unlinkAuthProviderFromUser,
 } from '@/lib/user';
-import { sendSignInCodeEmail } from '@/lib/email';
+import {
+  sendAccountDeletionConfirmationEmail,
+  sendAccountDeletionSupportNotification,
+  sendSignInCodeEmail,
+} from '@/lib/email';
 import {
   consumeSignInCode,
   createSignInCode,
@@ -945,10 +949,42 @@ export const userRouter = createTRPCRouter({
     }),
 
   requestAccountDeletion: baseProcedure
-    .input(z.object({ challengeId: z.uuid(), code: z.string().min(1) }))
+    .input(z.object({ challengeId: z.uuid(), code: z.string().min(1) }).optional())
     .mutation(async ({ ctx, input }) => {
       const userEmail = ctx.user.google_user_email;
       const userId = ctx.user.id;
+
+      // TODO: remove this branch, and make the input required again, once no
+      // shipped client calls this without a challenge. Builds already in the
+      // stores send no input and a required input answers them with a 400, so
+      // they keep the old support-ticket flow: it emails the user and support
+      // and deletes nothing, which is what those builds tell the user happened.
+      // Drop it when the mobile release that sends { challengeId, code } has
+      // rolled out and input-less traffic in Axiom reaches zero.
+      if (!input) {
+        const lastRequested = ctx.user.account_deletion_requested_at;
+        if (
+          lastRequested &&
+          Date.now() - new Date(lastRequested).getTime() < ACCOUNT_DELETION_COOLDOWN_MS
+        ) {
+          throw new TRPCError({
+            code: 'TOO_MANY_REQUESTS',
+            message: 'Account deletion already requested. Please wait before trying again.',
+          });
+        }
+
+        await Promise.all([
+          sendAccountDeletionConfirmationEmail(userEmail),
+          sendAccountDeletionSupportNotification(userEmail, userId),
+        ]);
+
+        await db
+          .update(kilocode_users)
+          .set({ account_deletion_requested_at: new Date().toISOString() })
+          .where(eq(kilocode_users.id, userId));
+
+        return successResult();
+      }
 
       try {
         await assertUserCanBeSoftDeleted(userId);


### PR DESCRIPTION
Two procedures in #5337 changed shape in ways that already-installed clients cannot follow. Both keep a compatible path with a TODO for its removal, and both keep the new path as the way forward.

## 1. `activeSessions.getToken` — the outage

Mobile shows "Could not load your account". Axiom pins it to deployment `dpl_GWB6AQmWy8dgLjhUHCZ83SdQRycz` (live 18:40 UTC 2026-08-18), which shipped #5337. That PR changed `activeSessions.getToken` from a query to a mutation.

Every already-installed client still calls it as a query. tRPC 11.17 then fails the call two ways:

- plain `GET /api/trpc/activeSessions.getToken` → **405**, the method map allows only POST for a mutation.
- any batch that pairs it with a query → **400 `Cannot mix procedure types in call: query, mutation`**, which fails the *whole* batch, `user.getMe` included. The mobile root layout reads that as a bootstrap error.

Confirmed across Android (`okhttp/4.9.2`), iOS (`Kilo/97`, `137`, `143`, `144`), browsers and `node`. The previous deployments show zero of either status.

**Fix**

- `createWebTicket` — new mutation, the path forward. Minting a one-use ticket is not idempotent, so it belongs on a mutation. Web, mobile and the extension now call it.
- `getToken` — stays a query for clients that are already installed. Store builds and installed extensions cannot update in step with the server.
- Both share one `mintWebTicket` handler, so behaviour cannot drift.

`httpBatchLink` keeps a separate loader per operation type, so the new mutation never batches beside a query.

Remove `getToken` once the mobile and extension releases that call `createWebTicket` have rolled out and its traffic in Axiom reaches zero.

## 2. `user.requestAccountDeletion` — required input

#5337 gave the mutation a required `{ challengeId, code }`. Shipped builds call it with no input and now get a 400, so the delete-account flow is dead for them.

**Fix**

The input is optional again. With no input the mutation keeps the old support-ticket path: it emails the user and support, stamps the 1 h cooldown, and deletes nothing — exactly what those builds tell the user happened ("Account deletion request sent. Check your email for confirmation."). With a challenge it reauthenticates and performs the GDPR removal as #5337 intended.

No re-auth requirement is weakened: the input-less path never deletes.

Remove the branch, and make the input required again, once the mobile release that sends `{ challengeId, code }` has rolled out and input-less traffic reaches zero.

## Checks

- `pnpm run typecheck` — clean
- `pnpm run lint` — clean
- mobile `user-web-connection-provider` tests — 2 passed
- `apps/web` jest needs a local Postgres that is not running here, so the two new cases in `active-sessions-router.test.ts` and `user-router.test.ts` are unverified locally and ride on CI.