### PR TITLE
fix(auth): relink stale WorkOS profiles

### DIFF
--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -548,6 +548,49 @@ describe('User', () => {
       expect(updatedUser?.web_session_pepper).not.toBe('web-pepper-before-workos');
     });
 
+    it('replaces a stale WorkOS profile ID for an existing user', async () => {
+      const existingUser = await insertTestUser({
+        google_user_email: 'stale-workos@example.com',
+        web_session_pepper: 'web-pepper-before-workos-relink',
+      });
+      await db.insert(user_auth_provider).values({
+        kilo_user_id: existingUser.id,
+        provider: 'workos',
+        provider_account_id: 'old-workos-profile-id',
+        email: existingUser.google_user_email,
+        avatar_url: 'https://example.com/old-avatar.png',
+        hosted_domain: 'example.com',
+      });
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: existingUser.google_user_email,
+          google_user_name: 'Stale WorkOS User',
+          google_user_image_url: 'https://example.com/new-avatar.png',
+          hosted_domain: 'example.com',
+          provider: 'workos',
+          provider_account_id: 'new-workos-profile-id',
+        },
+        undefined,
+        true
+      );
+
+      expect(result.success).toBe(true);
+      const providers = await db.query.user_auth_provider.findMany({
+        where: eq(user_auth_provider.kilo_user_id, existingUser.id),
+      });
+      expect(providers).toEqual([
+        expect.objectContaining({
+          provider: 'workos',
+          provider_account_id: 'new-workos-profile-id',
+        }),
+      ]);
+      const updatedUser = await db.query.kilocode_users.findFirst({
+        where: eq(kilocode_users.id, existingUser.id),
+      });
+      expect(updatedUser?.web_session_pepper).not.toBe('web-pepper-before-workos-relink');
+    });
+
     it('returns deferredSignInEvent when deferSignInAnalytics is true and user is existing', async () => {
       const user = await insertTestUserAndGoogleAuth({
         google_user_email: 'existing-defer@example.com',

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -585,12 +585,17 @@ export async function createOrUpdateUser(
       existingProviders.length === 1 && existingProviders[0].provider === 'fake-login';
 
     // Link this new provider to the existing user if they don't already have it.
+    // WorkOS profile IDs can change when an organization's SSO connection is
+    // recreated, so a verified SSO callback may also replace a stale WorkOS ID.
     // fake-login is placeholder auth (dev-only) - always allow upgrading from it.
     // Callers pass autoLinkToExistingUser=true only when the credential proves
     // ownership of the email (consumed magic-link/code, or a provider-asserted
     // email_verified claim). Proof authorizes the link; without proof the
     // sign-in keeps the DIFFERENT-OAUTH refusal below.
-    const shouldLink = !hasThisProvider && (onlyHasFakeLogin || autoLinkToExistingUser);
+    const shouldRelinkWorkOS =
+      args.provider === 'workos' && hasThisProvider && autoLinkToExistingUser;
+    const shouldLink =
+      (!hasThisProvider && (onlyHasFakeLogin || autoLinkToExistingUser)) || shouldRelinkWorkOS;
 
     if (shouldLink) {
       let linkedUser = userByEmail;


### PR DESCRIPTION
## Summary

- allow verified WorkOS SSO callbacks to replace a stale WorkOS profile ID
- retain the existing same-provider relinking refusal for other OAuth providers
- add a database-backed regression test covering provider replacement and web-session rotation

## Root cause

WorkOS profile IDs can change when an organization recreates its SSO connection. The initial lookup by `(provider, provider_account_id)` then misses, but the fallback email lookup sees that the user already has a WorkOS provider and returns `DIFFERENT-OAUTH`. The SSO flow surfaces that as a generic OAuth error.

This change treats that specific WorkOS path as an authorized relink only when the caller has supplied `autoLinkToExistingUser`, which the WorkOS SSO flow does after receiving the verified identity assertion. The exact provider/profile lookup has already failed before this branch, and non-WorkOS same-provider changes remain rejected.

The diagnosis was also validated operationally: deleting an affected user's stale WorkOS provider row allowed the next verified callback to recreate the link and restored login.

## Verification

- `pnpm --filter web test --runInBand src/lib/user/index.test.ts -t "replaces a stale WorkOS profile ID|refuses a same-provider different-account sign-in"`
- `pnpm exec oxlint --config .oxlintrc.json apps/web/src/lib/user/index.ts apps/web/src/lib/user/index.test.ts`
- `pnpm --filter web typecheck`
- `git diff --check`