### PR TITLE
fix(mobile): keep transcript row gaps uniform around blank text parts

### DIFF
--- a/apps/mobile/src/components/agents/message-visibility.test.ts
+++ b/apps/mobile/src/components/agents/message-visibility.test.ts
@@ -88,6 +88,11 @@ describe('partRendersContent', () => {
     expect(partRendersContent(textPart({ text: '' }))).toBe(false);
   });
 
+  it('returns false for a whitespace-only text part', () => {
+    expect(partRendersContent(textPart({ text: '\n\n' }))).toBe(false);
+    expect(partRendersContent(textPart({ text: '   ' }))).toBe(false);
+  });
+
   it('returns true for a bash tool part', () => {
     expect(partRendersContent(toolPart('bash'))).toBe(true);
   });

--- a/apps/mobile/src/components/agents/message-visibility.ts
+++ b/apps/mobile/src/components/agents/message-visibility.ts
@@ -20,8 +20,10 @@ import {
 export function partRendersContent(part: Part): boolean {
   if (isTextPart(part)) {
     // Snapshot-init progress shows only in the fixed WorkingIndicator row, and
-    // TextPartRenderer renders nothing for empty text.
-    return !isSnapshotProgressPart(part) && part.text !== '';
+    // TextPartRenderer renders nothing for blank text. Whitespace-only text is
+    // blank: markdown draws no ink for it, so counting it as content adds a
+    // zero-height row that eats a transcript gap and doubles the visible one.
+    return !isSnapshotProgressPart(part) && part.text.trim() !== '';
   }
   if (isToolPart(part)) {
     // ToolPartRenderer renders nothing for the plan-mode transition tools.

--- a/apps/mobile/src/components/agents/text-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/text-part-renderer.tsx
@@ -5,7 +5,7 @@ type TextPartRendererProps = {
 };
 
 export function TextPartRenderer({ text }: Readonly<TextPartRendererProps>) {
-  if (!text) {
+  if (!text.trim()) {
     return null;
   }
 


### PR DESCRIPTION
Follow-up to #5318, which did not fix the reported gap.

## What changed

A whitespace-only assistant text part no longer counts as transcript content, so the gap between two neighboring transcript rows is always one gap.

## User note

The gap above and below a collapsed `THOUGHT` row now matches the gap between two tool rows. Nothing else in the transcript moves.

## Product note

Row rhythm is uniform again: every adjacent row pair in a session transcript sits 8pt apart, whatever the hidden parts between them are.

## Maintainer note

Root cause is not the dashed box that #5318 changed. `partRendersContent` accepted any text part with `text !== ''`, so a whitespace-only text part (models emit `"\n\n"` between tool calls) passed as content:

- inside one message it rendered a zero-height markdown row, which consumed one of the `gap-2` gaps in `MessageBubble` — the visible gap doubled to 16pt;
- alone in a message it kept `messageRendersContent` true, so `mergeSessionTranscript` kept the message and its `px-4 py-1` wrapper added the same 8pt.

`partRendersContent` now trims, matching the reasoning-part rule next to it, and `TextPartRenderer` trims its own guard so the two stay in step.

## Verification

Local e2e on an iPhone 17 Pro simulator (real dev build, local stack, CLI session seeded through `session-ingest`), pixel-measured from `simctl` screenshots:

| boundary | before | after |
|---|---|---|
| tool row → tool row | 21px | 21px |
| tool row → `THOUGHT` row | 21px | 21px |
| across a blank text part | 42px | 21px |
| across a blank-text-only message | 42px | 21px |

`pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused` and `pnpm test` (4916 tests) pass in `apps/mobile`.

## Human steps

No human step is needed.