### PR TITLE
fix(mobile): match linked-account rows to other profile cards

### DIFF
--- a/apps/mobile/src/components/profile-screen.tsx
+++ b/apps/mobile/src/components/profile-screen.tsx
@@ -43,8 +43,21 @@ import {
 import { getSecurityAgentPath } from '@/lib/security-agent';
 import { useTRPC } from '@/lib/trpc';
 
-function providerIcon(_provider: string) {
-  return KeyRound;
+const PROVIDER_LABELS: Record<string, string> = {
+  anaconda: 'Anaconda',
+  apple: 'Apple',
+  discord: 'Discord',
+  email: 'Email',
+  'fake-login': 'Test Account',
+  github: 'GitHub',
+  gitlab: 'GitLab',
+  google: 'Google',
+  linkedin: 'LinkedIn',
+  workos: 'Enterprise SSO',
+};
+
+function providerLabel(provider: string) {
+  return PROVIDER_LABELS[provider] ?? provider;
 }
 
 export function ProfileScreen() {
@@ -244,24 +257,17 @@ export function ProfileScreen() {
               />
             )}
 
-            {data?.providers.map(p => {
-              const Icon = providerIcon(p.provider);
-              return (
-                <Animated.View
-                  key={`${p.provider}-${p.email}`}
-                  className="flex-row items-start gap-3 rounded-lg bg-secondary p-3"
-                  entering={FadeIn.duration(200)}
-                >
-                  <Icon size={18} color={colors.secondaryForeground} />
-                  <View className="min-w-0 flex-1">
-                    <Text className="text-sm font-medium capitalize">{p.provider}</Text>
-                    <Text variant="muted" className="text-xs">
-                      {p.email}
-                    </Text>
-                  </View>
-                </Animated.View>
-              );
-            })}
+            {data?.providers.map((p, index) => (
+              <Animated.View key={`${p.provider}-${p.email}`} entering={FadeIn.duration(200)}>
+                <ConfigureRow
+                  icon={KeyRound}
+                  title={providerLabel(p.provider)}
+                  subtitle={p.email}
+                  className="rounded-lg bg-secondary px-3"
+                  last={index === data.providers.length - 1}
+                />
+              </Animated.View>
+            ))}
           </View>
         )}
 


### PR DESCRIPTION
## What
Linked-account rows on the mobile profile screen now use the same `ConfigureRow` card as Agents, Reviews, Organization, and App.

## Why
The WorkOS (and every other provider) row used a custom layout: a bare key icon and the raw provider id (`workos`). That broke the visual rhythm of the rest of the screen.

## How
- Render each linked provider with `ConfigureRow` (tinted icon tile, title, email subtitle).
- Map known provider ids to the same display names as web (`Enterprise SSO`, `GitHub`, `Google`, …).
- Leave the row inert (no chevron): there is no linked-account detail screen on mobile.

## Visual
Before: bare icon + capitalized slug, no tile.
After: boxed tinted icon + proper name + email, same card chrome as the other rows.