### PR TITLE
fix(web-env): show masked secret input

### DIFF
--- a/scripts/web-env/shared.ts
+++ b/scripts/web-env/shared.ts
@@ -725,8 +725,15 @@ export function readSecret(prompt: string): Promise<string> {
           resolve(value);
           return;
         }
-        if (character === '\u007f') value = value.slice(0, -1);
-        else value += character;
+        if (character === '\u007f') {
+          if (value) {
+            value = value.slice(0, -1);
+            process.stdout.write('\b \b');
+          }
+        } else {
+          value += character;
+          process.stdout.write('*');
+        }
       }
     };
     process.stdin.on('data', onData);


### PR DESCRIPTION
## Summary

<img width="1144" height="266" alt="CleanShot 2026-08-19 at 11 16 27@2x" src="https://github.com/user-attachments/assets/874eb4af-04d7-4478-bf63-ca0a6530541c" />

- display one `*` for each character entered or pasted into `pnpm web:env set` secret prompts
- remove the corresponding mask when Backspace removes a character
- keep the plaintext secret hidden

