### PR TITLE
fix(web): clarify data export covers user or org links

### DIFF
--- a/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
+++ b/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
@@ -217,8 +217,8 @@ export function DataExportsClient() {
               >
                 Metabase’s security incident
               </a>{' '}
-              from your account creation date to Aug. 2 @ 20:40 UTC and can be linked to a user
-              or organization.
+              from your account creation date to Aug. 2 @ 20:40 UTC and can be linked to a user or
+              organization.
             </span>
             <span className="block">
               We are making this feature available as part of our commitment to transparency. We

--- a/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
+++ b/apps/web/src/app/(app)/data-exports/DataExportsClient.tsx
@@ -217,7 +217,8 @@ export function DataExportsClient() {
               >
                 Metabase’s security incident
               </a>{' '}
-              from your account creation date to Aug. 2 @ 20:40 UTC.
+              from your account creation date to Aug. 2 @ 20:40 UTC and can be linked to a user
+              or organization.
             </span>
             <span className="block">
               We are making this feature available as part of our commitment to transparency. We


### PR DESCRIPTION
## Summary
- Update the data export request copy so users know incident-window exports can be linked to a user or organization.

## Test plan
- [ ] Open `/data-exports` and confirm the request-card copy includes the user/organization clause
- [ ] Confirm the rest of the incident/transparency copy is unchanged