### PR TITLE
fix(user): stop re-scrubbing usage prefixes during anonymize

### DIFF
--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -1635,18 +1635,6 @@ export async function anonymizeCloudUserData(
       )
     );
 
-  // Microdollar usage metadata: strip user-authored prompt prefix and system prompt reference
-  await tx.execute(sql`
-    UPDATE ${microdollar_usage_metadata}
-    SET user_prompt_prefix = NULL,
-        system_prompt_prefix_id = NULL
-    WHERE id IN (
-      SELECT id FROM ${microdollar_usage}
-      WHERE kilo_user_id = ${userId}
-    )
-    AND (user_prompt_prefix IS NOT NULL OR system_prompt_prefix_id IS NOT NULL)
-  `);
-
   // ── 4. Nullify FK references ─────────────────────────────────────────
   await tx
     .update(user_feedback)


### PR DESCRIPTION
## Summary

- Remove the leftover unbounded `UPDATE microdollar_usage_metadata` from `anonymizeCloudUserData`.
- Usage prompt prefixes are already owned by the paged `usage_prompt_prefixes` queue step (and by `softDeleteUser`'s page helper).
- That leftover query timed out in production (`KILOCODE-WEB-5K4`) and surfaced as Cloud user `worker_item_rejected` / Retry wait.

## Test plan

- [x] `pnpm --filter web test -- src/lib/user/index.test.ts src/lib/user/deletion-queue/handlers/usage-prompt-prefixes.test.ts` (36 suites, 475 passed)
- [ ] After deploy, confirm the stuck request's Cloud user step completes without another `57014` on `microdollar_usage_metadata`