### PR TITLE
feat(admin): show export status counters

### DIFF
--- a/apps/web/src/app/admin/data-exports/DataExportsSummaryStrip.tsx
+++ b/apps/web/src/app/admin/data-exports/DataExportsSummaryStrip.tsx
@@ -31,6 +31,18 @@ function buildItems(summary: DataExportSummary): SummaryItem[] {
       value: summary.active,
     },
     {
+      key: 'ready',
+      label: 'Ready exports',
+      hint: 'Available to download',
+      value: summary.ready,
+    },
+    {
+      key: 'expired',
+      label: 'Expired exports',
+      hint: 'No longer downloadable',
+      value: summary.expired,
+    },
+    {
       key: 'pending-dispatches',
       label: 'Pending dispatches',
       hint: 'Outbox entries due now',
@@ -64,7 +76,7 @@ function buildItems(summary: DataExportSummary): SummaryItem[] {
 }
 
 const stripGridClass =
-  'grid grid-cols-2 gap-px overflow-hidden rounded-lg border bg-border sm:grid-cols-3 xl:grid-cols-6';
+  'grid grid-cols-2 gap-px overflow-hidden rounded-lg border bg-border sm:grid-cols-4 xl:grid-cols-8';
 
 export function DataExportsSummaryStrip({
   summary,
@@ -76,7 +88,7 @@ export function DataExportsSummaryStrip({
   if (isLoading && !summary) {
     return (
       <section aria-label="Export workload summary" className={stripGridClass}>
-        {Array.from({ length: 6 }, (_, index) => (
+        {Array.from({ length: 8 }, (_, index) => (
           <div key={index} className="bg-card flex flex-col gap-2 p-3">
             <Skeleton className="h-3 w-20" />
             <Skeleton className="h-6 w-12" />

--- a/apps/web/src/app/admin/data-exports/data-export-components.test.ts
+++ b/apps/web/src/app/admin/data-exports/data-export-components.test.ts
@@ -10,6 +10,8 @@ import { formatAge, formatBytes, humanizeToken } from './data-export-format';
 const summaryFixture = {
   asOf: '2026-08-09T12:00:00.000Z',
   active: 7,
+  ready: 11,
+  expired: 13,
   needsAttention: 3,
   staleLeases: 2,
   pendingDispatches: 5,
@@ -98,7 +100,7 @@ const degradedRow: DataExportListRow = {
 };
 
 describe('DataExportsSummaryStrip', () => {
-  it('renders all six workload metrics with counts and hints', () => {
+  it('renders all eight workload and status metrics with counts and hints', () => {
     const html = renderToStaticMarkup(
       React.createElement(DataExportsSummaryStrip, {
         summary: summaryFixture,
@@ -108,6 +110,10 @@ describe('DataExportsSummaryStrip', () => {
 
     expect(html).toContain('Needs attention');
     expect(html).toContain('Active exports');
+    expect(html).toContain('Ready exports');
+    expect(html).toContain('Available to download');
+    expect(html).toContain('Expired exports');
+    expect(html).toContain('No longer downloadable');
     expect(html).toContain('Pending dispatches');
     expect(html).toContain('Stale leases');
     expect(html).toContain('Cleanup due');

--- a/apps/web/src/routers/admin/user-data-exports-router.test.ts
+++ b/apps/web/src/routers/admin/user-data-exports-router.test.ts
@@ -122,6 +122,14 @@ describe('adminUserDataExportsRouter', () => {
         },
         {
           kilo_user_id: owner.id,
+          status: 'expired',
+          snapshot_at: new Date(now - 172_800_000).toISOString(),
+          completed_at: new Date(now - 86_400_000).toISOString(),
+          expires_at: new Date(now - 60_000).toISOString(),
+          requested_at: new Date(now - 90_000_000).toISOString(),
+        },
+        {
+          kilo_user_id: owner.id,
           subject_type: 'organization',
           organization_id: subjectOrganization.id,
           status: 'processing',
@@ -236,6 +244,8 @@ describe('adminUserDataExportsRouter', () => {
 
     expect(result).toMatchObject({
       active: 2,
+      ready: 1,
+      expired: 1,
       needsAttention: 4,
       staleLeases: 1,
       pendingDispatches: 1,
@@ -260,7 +270,7 @@ describe('adminUserDataExportsRouter', () => {
     expect(all.rows.map(row => row.health.severity)).toEqual(
       expect.arrayContaining(['error', 'degraded'])
     );
-    expect(searched.pagination.total).toBe(3);
+    expect(searched.pagination.total).toBe(4);
     expect(searched.rows.every(row => row.user.id === owner.id)).toBe(true);
     expect(searched.rows.every(row => row.requestedAt.endsWith('Z'))).toBe(true);
     expect(searched.rows).toEqual(
@@ -301,7 +311,7 @@ describe('adminUserDataExportsRouter', () => {
       limit: 2,
     });
 
-    expect(result.pagination).toMatchObject({ page: 1, limit: 2, total: 4, totalPages: 2 });
+    expect(result.pagination).toMatchObject({ page: 1, limit: 2, total: 5, totalPages: 3 });
     expect(result.rows).toHaveLength(2);
   });
 

--- a/apps/web/src/routers/admin/user-data-exports-router.ts
+++ b/apps/web/src/routers/admin/user-data-exports-router.ts
@@ -396,6 +396,8 @@ export const adminUserDataExportsRouter = createTRPCRouter({
     const result = await readDb.execute<{
       as_of: string;
       active: number | string;
+      ready: number | string;
+      expired: number | string;
       needs_attention: number | string;
       stale_leases: number | string;
       pending_dispatches: number | string;
@@ -406,6 +408,8 @@ export const adminUserDataExportsRouter = createTRPCRouter({
     }>(sql`
       SELECT now() AS as_of,
         count(*) FILTER (WHERE e.status IN ('queued', 'processing', 'finalizing'))::text AS active,
+        count(*) FILTER (WHERE e.status = 'ready')::text AS ready,
+        count(*) FILTER (WHERE e.status = 'expired')::text AS expired,
         count(*) FILTER (WHERE ${needsAttentionSql})::text AS needs_attention,
         count(*) FILTER (
           WHERE e.status IN ('processing', 'finalizing') AND e.lease_expires_at < now()
@@ -450,6 +454,8 @@ export const adminUserDataExportsRouter = createTRPCRouter({
     return {
       asOf: row ? iso(row.as_of) : new Date().toISOString(),
       active: number(row?.active ?? 0) ?? 0,
+      ready: number(row?.ready ?? 0) ?? 0,
+      expired: number(row?.expired ?? 0) ?? 0,
       needsAttention: number(row?.needs_attention ?? 0) ?? 0,
       staleLeases: number(row?.stale_leases ?? 0) ?? 0,
       pendingDispatches: number(row?.pending_dispatches ?? 0) ?? 0,


### PR DESCRIPTION
## Summary

- Add exact Ready and Expired export counts to the admin data export summary API.
- Surface both persisted lifecycle states in the health summary strip alongside active and operational-health metrics.
- Expand the responsive summary layout and loading placeholders from six to eight cells.
- Add router and rendering coverage for both new counters.

## Verification

- Manual browser verification was not performed because the local PostgreSQL service and application stack were not running.

## Visual Changes

| Before | After |
|---|---|
| Summary strip shows six operational counters and omits Ready and Expired totals. | Summary strip shows eight counters, including Ready exports and Expired exports. |

## Reviewer Notes

- Ready and Expired are informational persisted-status totals; unlike health counters, non-zero values are not rendered as attention signals.
- Jest discovered the relevant suites, but global setup could not connect to the inactive local PostgreSQL container before assertions ran.