### PR TITLE
fix(ai-gateway): map GLM latest alias to Vercel

### DIFF
--- a/apps/web/src/lib/ai-gateway/latest-model-aliases.ts
+++ b/apps/web/src/lib/ai-gateway/latest-model-aliases.ts
@@ -8,6 +8,7 @@ export const KIMI_LATEST_MODEL_ALIAS = '~moonshotai/kimi-latest';
 export const GEMINI_PRO_LATEST_MODEL_ALIAS = '~google/gemini-pro-latest';
 export const GEMINI_FLASH_LATEST_MODEL_ALIAS = '~google/gemini-flash-latest';
 export const GROK_LATEST_MODEL_ALIAS = '~x-ai/grok-latest';
+export const GLM_LATEST_MODEL_ALIAS = '~z-ai/glm-latest';
 export const DEEPSEEK_V4_FLASH_LATEST_MODEL_ALIAS = '~deepseek/deepseek-v4-flash-latest';
 
 export const LATEST_MODEL_ALIASES = [
@@ -21,5 +22,6 @@ export const LATEST_MODEL_ALIASES = [
   GEMINI_PRO_LATEST_MODEL_ALIAS,
   GEMINI_FLASH_LATEST_MODEL_ALIAS,
   GROK_LATEST_MODEL_ALIAS,
+  GLM_LATEST_MODEL_ALIAS,
   DEEPSEEK_V4_FLASH_LATEST_MODEL_ALIAS,
 ] as const;

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.test.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/ai-gateway/providers/openai';
 import { mapModelIdToVercel } from '@/lib/ai-gateway/providers/vercel/mapModelIdToVercel';
 import { GROK_CURRENT_VERCEL_MODEL_ID } from '@/lib/ai-gateway/providers/xai';
+import { GLM_CURRENT_VERCEL_MODEL_ID } from '@/lib/ai-gateway/providers/zai';
 import {
   CLAUDE_FABLE_LATEST_MODEL_ALIAS,
   CLAUDE_HAIKU_LATEST_MODEL_ALIAS,
@@ -26,6 +27,7 @@ import {
   GEMINI_PRO_LATEST_MODEL_ALIAS,
   GPT_LATEST_MODEL_ALIAS,
   GPT_MINI_LATEST_MODEL_ALIAS,
+  GLM_LATEST_MODEL_ALIAS,
   GROK_LATEST_MODEL_ALIAS,
   KIMI_LATEST_MODEL_ALIAS,
   LATEST_MODEL_ALIASES,
@@ -44,6 +46,7 @@ describe('mapModelIdToVercel', () => {
       [GEMINI_PRO_LATEST_MODEL_ALIAS, GEMINI_PRO_CURRENT_VERCEL_MODEL_ID],
       [GEMINI_FLASH_LATEST_MODEL_ALIAS, GEMINI_FLASH_CURRENT_VERCEL_MODEL_ID],
       [GROK_LATEST_MODEL_ALIAS, GROK_CURRENT_VERCEL_MODEL_ID],
+      [GLM_LATEST_MODEL_ALIAS, GLM_CURRENT_VERCEL_MODEL_ID],
       [DEEPSEEK_V4_FLASH_LATEST_MODEL_ALIAS, 'deepseek/deepseek-v4-flash-0731'],
     ])('maps %s to the current Vercel model id', (input, expected) => {
       expect(mapModelIdToVercel(input)).toBe(expected);
@@ -61,6 +64,7 @@ describe('mapModelIdToVercel', () => {
         GEMINI_PRO_LATEST_MODEL_ALIAS,
         GEMINI_FLASH_LATEST_MODEL_ALIAS,
         GROK_LATEST_MODEL_ALIAS,
+        GLM_LATEST_MODEL_ALIAS,
         DEEPSEEK_V4_FLASH_LATEST_MODEL_ALIAS,
       ]);
     });

--- a/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/mapModelIdToVercel.ts
@@ -16,6 +16,7 @@ import {
 } from '@/lib/ai-gateway/providers/openai';
 import { inferVercelFirstPartyInferenceProviderForModel } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import { GROK_CURRENT_VERCEL_MODEL_ID } from '@/lib/ai-gateway/providers/xai';
+import { GLM_CURRENT_VERCEL_MODEL_ID } from '@/lib/ai-gateway/providers/zai';
 import {
   CLAUDE_FABLE_LATEST_MODEL_ALIAS,
   CLAUDE_HAIKU_LATEST_MODEL_ALIAS,
@@ -26,6 +27,7 @@ import {
   GEMINI_PRO_LATEST_MODEL_ALIAS,
   GPT_LATEST_MODEL_ALIAS,
   GPT_MINI_LATEST_MODEL_ALIAS,
+  GLM_LATEST_MODEL_ALIAS,
   GROK_LATEST_MODEL_ALIAS,
   KIMI_LATEST_MODEL_ALIAS,
 } from '@/lib/ai-gateway/latest-model-aliases';
@@ -41,6 +43,7 @@ const vercelModelIdMapping: Record<string, string | undefined> = {
   [GEMINI_PRO_LATEST_MODEL_ALIAS]: GEMINI_PRO_CURRENT_VERCEL_MODEL_ID,
   [GEMINI_FLASH_LATEST_MODEL_ALIAS]: GEMINI_FLASH_CURRENT_VERCEL_MODEL_ID,
   [GROK_LATEST_MODEL_ALIAS]: GROK_CURRENT_VERCEL_MODEL_ID,
+  [GLM_LATEST_MODEL_ALIAS]: GLM_CURRENT_VERCEL_MODEL_ID,
   [DEEPSEEK_V4_FLASH_LATEST_MODEL_ALIAS]: 'deepseek/deepseek-v4-flash-0731',
   'inclusionai/ling-3.0-flash:free': 'inclusionai/ling-3.0-flash-free',
   'mistralai/codestral-2508': 'mistral/codestral',

--- a/apps/web/src/lib/ai-gateway/providers/zai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/zai.ts
@@ -5,3 +5,4 @@ export function isGlmModel(model: string) {
 // Partner routing stays pinned when the current GLM model changes.
 export const FRIENDLI_GLM_PUBLIC_ID = 'z-ai/glm-5.2';
 export const GLM_CURRENT_MODEL_ID = 'z-ai/glm-5.3';
+export const GLM_CURRENT_VERCEL_MODEL_ID = 'zai/glm-5.3';


### PR DESCRIPTION
## Summary
- register `~z-ai/glm-latest` as a managed latest-model alias
- map the alias to the current Vercel GLM model ID, `zai/glm-5.3`
- cover the mapping and alias catalog in the existing table-driven tests

## Testing
- CI only, as requested