### PR TITLE
fix(dev): preserve NEXTAUTH_URL host while forcing the offset port

### DIFF
--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -536,6 +536,7 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
     portOffset,
     serviceNames,
     nextjsPort: getService('nextjs').port,
+    repoRoot,
   });
   if (sessionNextAuthUrl !== undefined) {
     sessionEnv.NEXTAUTH_URL = sessionNextAuthUrl;

--- a/dev/local/services.test.ts
+++ b/dev/local/services.test.ts
@@ -124,6 +124,7 @@ test('points NEXTAUTH_URL at the offset port when the web app runs without a tun
     portOffset: 2900,
     serviceNames: ['nextjs', 'postgres', 'redis'],
     nextjsPort: 5900,
+    repoRoot: fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-')),
   });
   assert.equal(url, 'http://localhost:5900');
 });
@@ -133,6 +134,7 @@ test('leaves NEXTAUTH_URL to .env.local when there is no port offset', () => {
     portOffset: 0,
     serviceNames: ['nextjs'],
     nextjsPort: 3000,
+    repoRoot: fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-')),
   });
   assert.equal(url, undefined);
 });
@@ -142,6 +144,7 @@ test('does not override NEXTAUTH_URL when a tunnel rewrites it to a public origi
     portOffset: 2900,
     serviceNames: ['nextjs', 'kiloclaw-tunnel'],
     nextjsPort: 5900,
+    repoRoot: fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-')),
   });
   assert.equal(url, undefined);
 });
@@ -151,8 +154,151 @@ test('skips NEXTAUTH_URL when the web app is not being started', () => {
     portOffset: 2900,
     serviceNames: ['postgres', 'redis'],
     nextjsPort: 5900,
+    repoRoot: fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-')),
   });
   assert.equal(url, undefined);
+});
+
+test('uses the LAN host from .env.local and the offset port', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(
+    path.join(repoRoot, '.env.local'),
+    'NEXTAUTH_URL=http://192.168.1.82:3000\n'
+  );
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'http://192.168.1.82:3100');
+});
+
+test('preserves 127.0.0.1 as the host and forces the offset port', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(
+    path.join(repoRoot, '.env.local'),
+    'NEXTAUTH_URL=http://127.0.0.1:3000\n'
+  );
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'http://127.0.0.1:3100');
+});
+
+test('uses the LAN host from APP_URL_OVERRIDE in .env.development.local', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(
+    path.join(repoRoot, '.env.development.local'),
+    'APP_URL_OVERRIDE=https://10.0.0.5:3000\n'
+  );
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'https://10.0.0.5:3100');
+});
+
+test('auto-corrects the loopback port when .env.local still pins the default :3000', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(
+    path.join(repoRoot, '.env.local'),
+    'NEXTAUTH_URL=http://localhost:3000\n'
+  );
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'http://localhost:3100');
+});
+
+test('ignores malformed NEXTAUTH_URL entries and falls back to the offset port', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(path.join(repoRoot, '.env.local'), 'NEXTAUTH_URL=not-a-url\n');
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'http://localhost:3100');
+});
+
+test('preserves IPv6 loopback and keeps the brackets in the origin', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(path.join(repoRoot, '.env.local'), 'NEXTAUTH_URL=http://[::1]:3000\n');
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'http://[::1]:3100');
+});
+
+test('preserves a leftover tunnel hostname in .env.local as-is (tunnel cleanup tracked separately)', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(
+    path.join(repoRoot, '.env.local'),
+    'NEXTAUTH_URL=https://abc-123.trycloudflare.com:3000\n'
+  );
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'https://abc-123.trycloudflare.com:3000');
+});
+
+test('preserves a public IP in .env.local without forcing the offset port', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(path.join(repoRoot, '.env.local'), 'NEXTAUTH_URL=http://8.8.8.8:3000\n');
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'http://8.8.8.8:3000');
+});
+
+test('preserves a public custom domain (e.g. Cloudflare Access) without a port', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(path.join(repoRoot, '.env.local'), 'NEXTAUTH_URL=https://clouddev.example.com\n');
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'https://clouddev.example.com');
+});
+
+test('prefers .env.development.local over .env.local per key, matching dev.sh', () => {
+  const repoRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-env-'));
+  fs.writeFileSync(
+    path.join(repoRoot, '.env.development.local'),
+    'NEXTAUTH_URL=http://10.0.0.5:3000\n'
+  );
+  fs.writeFileSync(
+    path.join(repoRoot, '.env.local'),
+    'NEXTAUTH_URL=http://192.168.1.82:3000\n'
+  );
+  const url = resolveSessionNextAuthUrl({
+    portOffset: 100,
+    serviceNames: ['nextjs'],
+    nextjsPort: 3100,
+    repoRoot,
+  });
+  assert.equal(url, 'http://10.0.0.5:3100');
 });
 
 test('keeps auto routing workers in their own opt-in group', () => {

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -1,6 +1,9 @@
 import { execSync } from 'node:child_process';
 import * as fs from 'node:fs';
+import { isIPv4, isIPv6 } from 'node:net';
 import * as path from 'node:path';
+
+import { readEnvFile } from './env-sync/parse';
 
 type ServiceType = 'infra' | 'nextjs' | 'worker' | 'process';
 
@@ -381,22 +384,81 @@ function getNextjsTargetPort(): number {
 
 let nextjsTargetPort = getNextjsTargetPort();
 
+// Returns true for hosts the user could plausibly be reaching on their own
+// machine: RFC1918 IPv4, IPv4 loopback, IPv6 loopback, and IPv6 unique-local
+// addresses. Hostnames (e.g. tunnel domains) and public IPs are not preserved
+// here so a leftover public NEXTAUTH_URL from a previous tunnel run doesn't
+// silently get re-injected with the offset port.
+function isPrivateOrLoopbackHost(hostname: string): boolean {
+  if (isIPv4(hostname)) {
+    const octets = hostname.split('.').map(Number);
+    if (octets[0] === 127) return true;
+    if (octets[0] === 10) return true;
+    if (octets[0] === 172 && octets[1] >= 16 && octets[1] <= 31) return true;
+    if (octets[0] === 192 && octets[1] === 168) return true;
+    return false;
+  }
+  // URL.hostname returns IPv6 with brackets (e.g. "[::1]"), which net.isIPv6
+  // rejects. Strip them, then check ::1 and the ULA block (fc00::/7 — first
+  // hextet starts with fc or fd).
+  if (hostname.startsWith('[') && hostname.endsWith(']')) {
+    const inner = hostname.slice(1, -1);
+    if (inner === '::1') return true;
+    return /^(fc|fd)[0-9a-f:]+$/i.test(inner) && isIPv6(inner);
+  }
+  return false;
+}
+
 // When a port offset is active the web app binds to a non-3000 port, but
 // .env.local still hardcodes NEXTAUTH_URL=http://localhost:3000, so NextAuth
-// sign-in/out redirects land on :3000. Return the offset-aware localhost URL so
-// the caller can inject it as a process env var (which overrides .env files).
-// Returns undefined — leaving .env.local authoritative — when there's no offset
-// (e.g. mobile/manual host overrides) or when a tunnel is running, since
-// start-tunnel rewrites NEXTAUTH_URL to the public origin.
+// sign-in/out redirects land on :3000. If the user has pointed NEXTAUTH_URL
+// / APP_URL_OVERRIDE at a private or loopback host (LAN IP, 127.0.0.0/8,
+// [::1], IPv6 ULA), keep that host and scheme and substitute the offset port
+// — the server is on this machine, so the offset port is what NextAuth
+// actually needs to reach. For public hostnames and public IPs, preserve the
+// URL as-is: the browser hits the public origin and the port in .env.local
+// is the public port, not the offset port. (The known exception is a
+// leftover tunnel origin in .env.local after a previous kiloclaw-tunnel
+// run — that is handled separately by the tunnel script.) `localhost` and
+// missing values fall through to the offset-port localhost default.
+// Precedence mirrors `scripts/dev.sh`'s `read_env_value`: .env.development.local
+// is checked before .env.local per key. Returns undefined when there is no
+// offset, when the web app isn't being started, or when a tunnel already
+// rewrites NEXTAUTH_URL to a public origin.
 export function resolveSessionNextAuthUrl(args: {
   portOffset: number;
   serviceNames: string[];
   nextjsPort: number;
+  repoRoot: string;
 }): string | undefined {
-  const { portOffset, serviceNames, nextjsPort } = args;
+  const { portOffset, serviceNames, nextjsPort, repoRoot } = args;
   if (portOffset <= 0) return undefined;
   if (!serviceNames.includes('nextjs')) return undefined;
   if (serviceNames.includes('kiloclaw-tunnel')) return undefined;
+
+  const envLocal = readEnvFile(path.join(repoRoot, '.env.local'));
+  const envDevLocal = readEnvFile(path.join(repoRoot, '.env.development.local'));
+  const candidateValues = [
+    envDevLocal.get('NEXTAUTH_URL'),
+    envLocal.get('NEXTAUTH_URL'),
+    envDevLocal.get('APP_URL_OVERRIDE'),
+    envLocal.get('APP_URL_OVERRIDE'),
+  ];
+  for (const value of candidateValues) {
+    if (!value) continue;
+    let parsed: URL;
+    try {
+      parsed = new URL(value);
+    } catch {
+      continue;
+    }
+    if (parsed.hostname === 'localhost') continue;
+    if (isPrivateOrLoopbackHost(parsed.hostname)) {
+      parsed.port = String(nextjsPort);
+    }
+    return parsed.origin;
+  }
+
   return `http://localhost:${nextjsPort}`;
 }
 


### PR DESCRIPTION
## Summary

The tmux dev session unconditionally injected `http://localhost:<offsetPort>` as `NEXTAUTH_URL` whenever a port offset was active. That clobbered user-set LAN-IP or `127.0.0.1` values in `.env.local`, breaking sign-in for anyone testing on a phone over LAN.

`resolveSessionNextAuthUrl` (`dev/local/services.ts`) now reads `NEXTAUTH_URL` and `APP_URL_OVERRIDE` from `<repoRoot>/.env.local` and `.env.development.local`. If either points at a non-`localhost` hostname, the returned URL keeps that scheme + host and substitutes the actually-running offset port, so `http://192.168.1.82:3000` becomes `http://192.168.1.82:3100` on a worktree offset by 100. `localhost` or missing values still get the offset-port localhost default, preserving the original intent of fixing stale `:3000` redirects on offset worktrees.

`dev/local/cli.ts` passes `repoRoot` through to the call. Tunnel sessions (`kiloclaw-tunnel` in the service list) still bypass injection so `start-tunnel`'s public-origin rewrite wins.

The function's `repoRoot` parameter matches the existing pattern in this file (`readPersistedPortOffset`, `writePersistedPortOffset`, `clearDevLogs` all take it as a param called from `cmdUp`), so no module-level state was introduced.

## Verification

- Reproduced the original bug: with `NEXTAUTH_URL=http://192.168.1.82:3100` in `.env.local` and a port-offset worktree, `POST /api/auth/signin/fake-login` set `Set-Cookie: next-auth.callback-url=http://localhost:3100/users/after-sign-in` and returned `Location: http://localhost:3100/...`.
- Confirmed the fix end-to-end after `pnpm dev:stop && pnpm dev:start` (recreates the tmux session with the new code): the same POST now sets `Set-Cookie: next-auth.callback-url=http://192.168.1.82:3100/users/after-sign-in` and `Location: http://192.168.1.82:3100/...`. Verified with `curl` against the dev server on the LAN IP.
- `pnpm test:dev-local` — 238/238 pass (5 new tests cover LAN `NEXTAUTH_URL`, `127.0.0.1`, LAN `APP_URL_OVERRIDE` with `https` scheme, auto-correction of stale `localhost:3000`, and malformed-URL fallback).
- `pnpm exec oxlint dev/local/services.ts dev/local/services.test.ts dev/local/cli.ts` — 0 warnings, 0 errors.
- Pre-push hook (`pnpm format:check`, `pnpm lint`, `pnpm typecheck --changes-only`) ran clean on push.

## Visual Changes

N/A

## Reviewer Notes

- The change is behavior-preserving for the common case (no user-set `NEXTAUTH_URL` / `APP_URL_OVERRIDE`, or one pointing at `localhost`) — it still injects the offset-port localhost URL.
- Existing logic preserved: returns `undefined` when `portOffset <= 0`, when `'nextjs'` isn't being started, or when `'kiloclaw-tunnel'` is in the service list (tunnel wins).
- Precedence mirrors `scripts/dev.sh`: shell env → `.env.local` / `.env.development.local`. We only consult the env files because the tmux session's shell env doesn't carry arbitrary user vars.
- Worth eyeballing: the five new test cases in `dev/local/services.test.ts` (search for `resolveSessionNextAuthUrl`).