### PR TITLE
feat(web): consolidate personal settings into /settings

### DIFF
--- a/apps/web/src/app/(app)/components/AppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/AppSidebar.tsx
@@ -15,7 +15,13 @@ import { WastelandSidebar } from '@/components/wasteland/WastelandSidebar';
 const UUID = '[0-9a-f-]{36}';
 
 // Routes linked from the footer user menu (see SidebarUserFooter). Keep in sync.
-const FOOTER_MENU_ROUTES = ['/connected-accounts', '/data-exports', '/install', '/learn'];
+const FOOTER_MENU_ROUTES = [
+  '/connected-accounts',
+  '/data-exports',
+  '/install',
+  '/learn',
+  '/settings',
+];
 
 /** Extract the townId from a /gastown/[townId] pathname, or null. */
 function extractGastownTownId(pathname: string): string | null {

--- a/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
+++ b/apps/web/src/app/(app)/components/PersonalAppSidebar.tsx
@@ -84,6 +84,11 @@ export default function PersonalAppSidebar(props: React.ComponentProps<typeof Si
       icon: ChartColumnIncreasing,
       url: '/usage',
     },
+    {
+      title: 'Settings',
+      icon: Settings,
+      url: '/settings',
+    },
   ];
 
   // KiloClaw group

--- a/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
@@ -10,7 +10,15 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarImage, AvatarFallback } from '@radix-ui/react-avatar';
-import { BookOpen, ChevronsUpDown, Download, FileDown, LogOut, UserCog } from 'lucide-react';
+import {
+  BookOpen,
+  ChevronsUpDown,
+  Download,
+  FileDown,
+  LogOut,
+  Settings,
+  UserCog,
+} from 'lucide-react';
 import { signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 
@@ -88,6 +96,10 @@ export default function SidebarUserFooter({ user, isLoading }: SidebarUserFooter
             <DropdownMenuItem onClick={() => router.push('/data-exports')}>
               <FileDown className="h-4 w-4" />
               Request data export
+            </DropdownMenuItem>
+            <DropdownMenuItem onClick={() => router.push('/settings')}>
+              <Settings className="h-4 w-4" />
+              Settings
             </DropdownMenuItem>
             <DropdownMenuItem onClick={() => router.push('/install')}>
               <Download className="h-4 w-4" />

--- a/apps/web/src/app/(app)/profile/loading.tsx
+++ b/apps/web/src/app/(app)/profile/loading.tsx
@@ -1,6 +1,5 @@
-import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Coins, CreditCard } from 'lucide-react';
 import { PageLayout } from '@/components/PageLayout';
 
 export default function ProfileLoading() {
@@ -84,39 +83,14 @@ export default function ProfileLoading() {
         </div>
       </div>
 
-      {/* Payment Details Card */}
-      <div className="flex w-full flex-col gap-4 xl:flex-row xl:items-stretch">
-        <div className="flex-3">
-          <Card className="h-full w-full text-left">
-            <CardHeader>
-              <CardTitle className="flex items-center gap-2">
-                <CreditCard className="h-5 w-5" />
-                Payment Details
-              </CardTitle>
-            </CardHeader>
-            <CardContent className="space-y-4">
-              <div className="space-y-2">
-                <Skeleton className="h-4 w-full" />
-                <Skeleton className="h-10 w-48" /> {/* Remove payment method button */}
-              </div>
-            </CardContent>
-          </Card>
-        </div>
-      </div>
-
-      {/* Auto Top-Up Card */}
+      {/* Settings Link Card */}
       <Card className="w-full text-left">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Coins className="h-5 w-5" />
-            Automatic Top Up
-          </CardTitle>
+          <Skeleton className="h-6 w-64" />
+          <Skeleton className="mt-2 h-4 w-full" />
         </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="space-y-2">
-            <Skeleton className="h-10 w-full max-w-xs" /> {/* Toggle */}
-            <Skeleton className="h-4 w-64" /> {/* Description */}
-          </div>
+        <CardContent>
+          <Skeleton className="h-10 w-32" />
         </CardContent>
       </Card>
 

--- a/apps/web/src/app/(app)/profile/page.tsx
+++ b/apps/web/src/app/(app)/profile/page.tsx
@@ -13,10 +13,8 @@ import { cookies } from 'next/headers';
 import CreditPurchaseOptions from '@/components/payment/CreditPurchaseOptions';
 import { MessageErrorBoundary } from '@/components/cloud-agent/MessageErrorBoundary';
 
-import { Coins } from 'lucide-react';
 import { SurveyCredits } from '@/components/SurveyCredits';
 import { RedeemPromoCode } from '@/components/profile/RedeemPromoCode';
-import { AutoTopUpToggle } from '@/components/payment/AutoTopUpToggle';
 import { IntegrationsCard } from '@/components/profile/IntegrationsCard';
 import { getUserOrganizationsWithSeats } from '@/lib/organizations/organizations';
 import { PageLayout } from '@/components/PageLayout';
@@ -26,8 +24,9 @@ import { CreateKilocodeOrgButton } from '@/components/dev/CreateKilocodeOrgButto
 import { isFeatureFlagEnabled } from '@/lib/posthog-feature-flags';
 import { UserProfileCard } from '@/components/profile/UserProfileCard';
 import { getContributorChampionProfileBadgeForUser } from '@/lib/contributor-champions/service';
-import { AutoRoutingModeCard } from '@/components/auto-routing/AutoRoutingModeCard';
 import { smartAppBannerItunes } from '@/lib/smart-app-banner';
+import { Button } from '@/components/ui/button';
+import Link from 'next/link';
 
 export const metadata = { itunes: smartAppBannerItunes('/profile') };
 
@@ -98,17 +97,17 @@ export default async function ProfilePage({ searchParams }: AppPageProps) {
 
       <Card className="w-full text-left">
         <CardHeader>
-          <CardTitle className="flex items-center gap-2">
-            <Coins className="h-5 w-5" />
-            Automatic Top Up
-          </CardTitle>
+          <CardTitle>Automatic Top Up &amp; Auto Routing</CardTitle>
+          <CardDescription>
+            Configure automatic top-up and auto-routing in Settings.
+          </CardDescription>
         </CardHeader>
         <CardContent>
-          <AutoTopUpToggle />
+          <Button asChild variant="outline">
+            <Link href="/settings">Open Settings</Link>
+          </Button>
         </CardContent>
       </Card>
-
-      <AutoRoutingModeCard />
 
       {params.source && (
         <IntegrationsCard

--- a/apps/web/src/app/(app)/settings/loading.tsx
+++ b/apps/web/src/app/(app)/settings/loading.tsx
@@ -1,0 +1,45 @@
+import { Card, CardContent, CardHeader } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PageLayout } from '@/components/PageLayout';
+
+export default function SettingsLoading() {
+  return (
+    <PageLayout title="Settings">
+      <Card className="w-full text-left">
+        <CardHeader>
+          <Skeleton className="h-6 w-48" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-10 w-full max-w-xs" />
+          <Skeleton className="h-4 w-64" />
+        </CardContent>
+      </Card>
+
+      <Card className="w-full">
+        <CardHeader>
+          <Skeleton className="h-6 w-32" />
+          <Skeleton className="mt-2 h-4 w-full" />
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Skeleton className="h-9 w-full" />
+          <Skeleton className="h-20 w-full" />
+          <Skeleton className="h-9 w-32" />
+        </CardContent>
+      </Card>
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {Array.from({ length: 7 }, (_, index) => (
+          <Card key={index} className="h-full">
+            <CardContent className="flex h-full items-start gap-3 p-4">
+              <Skeleton className="h-10 w-10 shrink-0 rounded-lg" />
+              <div className="min-w-0 flex-1 space-y-2">
+                <Skeleton className="h-5 w-32" />
+                <Skeleton className="h-4 w-full" />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </PageLayout>
+  );
+}

--- a/apps/web/src/app/(app)/settings/page.tsx
+++ b/apps/web/src/app/(app)/settings/page.tsx
@@ -1,0 +1,109 @@
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { AutoRoutingModeCard } from '@/components/auto-routing/AutoRoutingModeCard';
+import { AutoTopUpToggle } from '@/components/payment/AutoTopUpToggle';
+import { getUserFromAuthOrRedirect } from '@/lib/user/server';
+import { PageLayout } from '@/components/PageLayout';
+import Link from 'next/link';
+import {
+  Coins,
+  FileDown,
+  Key,
+  Plug,
+  Receipt,
+  Sparkles,
+  User,
+} from 'lucide-react';
+import type { ElementType } from 'react';
+
+const NAV_LINKS: Array<{
+  href: string;
+  title: string;
+  description: string;
+  icon: ElementType;
+}> = [
+  {
+    href: '/profile',
+    title: 'Your Profile',
+    description: 'Edit your name, photo, and social links',
+    icon: User,
+  },
+  {
+    href: '/connected-accounts',
+    title: 'Connected Accounts',
+    description: 'Manage login methods',
+    icon: Plug,
+  },
+  {
+    href: '/data-exports',
+    title: 'Data Exports',
+    description: 'Request data export or deletion',
+    icon: FileDown,
+  },
+  {
+    href: '/byok',
+    title: 'Bring Your Own Key',
+    description: 'Bring your own API keys',
+    icon: Key,
+  },
+  {
+    href: '/credits',
+    title: 'Credits',
+    description: 'Purchase credits and view history',
+    icon: Coins,
+  },
+  {
+    href: '/invoices',
+    title: 'Invoices',
+    description: 'Billing invoices',
+    icon: Receipt,
+  },
+  {
+    href: '/subscriptions',
+    title: 'Subscriptions',
+    description: 'Manage subscriptions',
+    icon: Sparkles,
+  },
+];
+
+export default async function SettingsPage() {
+  await getUserFromAuthOrRedirect('/users/sign_in');
+
+  return (
+    <PageLayout title="Settings">
+      <Card className="w-full text-left">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2">
+            <Coins className="h-5 w-5" />
+            Automatic Top Up
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <AutoTopUpToggle />
+        </CardContent>
+      </Card>
+
+      <AutoRoutingModeCard />
+
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        {NAV_LINKS.map(link => {
+          const Icon = link.icon;
+          return (
+            <Link key={link.href} href={link.href} className="block">
+              <Card className="hover:border-primary/20 h-full transition-shadow duration-200 hover:shadow-md">
+                <CardContent className="flex h-full items-start gap-3 p-4">
+                  <div className="bg-primary/10 flex h-10 w-10 shrink-0 items-center justify-center rounded-lg">
+                    <Icon className="text-primary h-5 w-5" />
+                  </div>
+                  <div className="min-w-0 flex-1">
+                    <p className="text-foreground font-semibold">{link.title}</p>
+                    <p className="text-muted-foreground mt-1 text-sm">{link.description}</p>
+                  </div>
+                </CardContent>
+              </Card>
+            </Link>
+          );
+        })}
+      </div>
+    </PageLayout>
+  );
+}

--- a/apps/web/tests/setup-smoke/profile.spec.ts
+++ b/apps/web/tests/setup-smoke/profile.spec.ts
@@ -62,6 +62,9 @@ test.describe('local setup smoke', () => {
     await expect(profileCard.getByRole('button', { name: 'Edit profile' })).toBeVisible();
     await expect(profileCard.getByText(testEmail, { exact: true })).toBeVisible();
 
+    await expect(page.getByRole('link', { name: 'Open Settings' })).toBeVisible();
+
+    await page.goto('/settings');
     await expect(page.getByText('Auto routing', { exact: true })).toBeVisible();
   });
 });


### PR DESCRIPTION
## Summary

Adds a new `/settings` page that consolidates the personal-level settings currently scattered across `/profile` and other destinations. Auto top-up and auto routing now live on `/settings`; `/profile` gets a single link card pointing at it.

## Changes

- **New `/settings` page** (`apps/web/src/app/(app)/settings/page.tsx`)
  - Embeds `AutoTopUpToggle` (personal) and `AutoRoutingModeCard` (no `organizationId` → personal mode)
  - Link-card grid to `/profile`, `/connected-accounts`, `/data-exports`, `/byok`, `/credits`, `/invoices`, `/subscriptions`
  - Matching `loading.tsx` skeleton
- **Navigation**
  - `SidebarUserFooter`: new `Settings` entry between *Request data export* and *Install*
  - `PersonalAppSidebar`: new `Settings` entry in the Dashboard group, after *Usage*
  - `AppSidebar.tsx`: `/settings` added to `FOOTER_MENU_ROUTES` so users with a disabled personal account get the org sidebar on `/settings`
- **`/profile`**
  - Remove `AutoTopUpToggle` and `AutoRoutingModeCard` imports/usage
  - Replace the *Automatic Top Up* card with a link card → `/settings`
  - Remove the obsolete *Auto Top-Up* and *Payment Details* loading skeletons; add a Settings link card skeleton
- **Setup-smoke test** (`apps/web/tests/setup-smoke/profile.spec.ts`)
  - Auto routing was asserted on `/profile`; move the assertion to `/settings` and add a check for the new *Open Settings* link on `/profile`

<img width="270" height="313" alt="settings_in_profile_dropdown" src="https://github.com/user-attachments/assets/142f33fc-fdac-41f0-abea-cead455356b3" />
<img width="1606" height="869" alt="settings_page" src="https://github.com/user-attachments/assets/e3855403-ebe1-49b3-b8f7-3c19611df9d1" />

## Unchanged (per plan)

- `AutoRoutingModeCard` on `/organizations/[id]/providers-and-models`
- `AutoTopUpToggle` on `/credits`
- `OrganizationAppSidebar`

## Validation

- `pnpm --filter web typecheck` — pass
- `pnpm --filter web lint` — 0 warnings, 0 errors