### PR TITLE
fix(web): return to Cloud Agent setup from integration detail

### DIFF
--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -1201,6 +1201,7 @@ export function NewSessionPanel({ organizationId, isDevcontainerAvailable }: New
             organizationId={organizationId}
             isCheckingConnection={isCheckingConnection}
             onCheckConnection={() => void checkSourceControlConnection()}
+            returnTo={organizationId ? `/organizations/${organizationId}/cloud` : '/cloud'}
           />
         </div>
       </div>

--- a/apps/web/src/components/cloud-agent-next/RepositoryProviderOnboardingPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/RepositoryProviderOnboardingPanel.tsx
@@ -32,6 +32,7 @@ type RepositoryProviderOnboardingPanelProps = {
   organizationId?: string;
   isCheckingConnection?: boolean;
   onCheckConnection: () => void;
+  returnTo?: string;
 };
 
 type RepositoryProvider = {
@@ -40,10 +41,17 @@ type RepositoryProvider = {
   icon: ReactNode;
 };
 
+function withReturnTo(href: string, returnTo?: string): string {
+  if (!returnTo) return href;
+  const separator = href.includes('?') ? '&' : '?';
+  return `${href}${separator}returnTo=${encodeURIComponent(returnTo)}`;
+}
+
 export function RepositoryProviderOnboardingPanel({
   organizationId,
   isCheckingConnection = false,
   onCheckConnection,
+  returnTo,
 }: RepositoryProviderOnboardingPanelProps) {
   const integrationBasePath = organizationId
     ? `/organizations/${organizationId}/integrations`
@@ -51,12 +59,12 @@ export function RepositoryProviderOnboardingPanel({
   const providers: RepositoryProvider[] = [
     {
       name: 'GitHub',
-      href: `${integrationBasePath}/github`,
+      href: withReturnTo(`${integrationBasePath}/github`, returnTo),
       icon: <ProviderLogo provider="github" className="size-5 text-foreground" />,
     },
     {
       name: 'GitLab',
-      href: `${integrationBasePath}/gitlab`,
+      href: withReturnTo(`${integrationBasePath}/gitlab`, returnTo),
       icon: <ProviderLogo provider="gitlab" className="size-5 text-[#FC6D26]" />,
     },
   ];
@@ -64,7 +72,7 @@ export function RepositoryProviderOnboardingPanel({
   if (organizationId) {
     providers.push({
       name: 'Bitbucket',
-      href: `${integrationBasePath}/bitbucket`,
+      href: withReturnTo(`${integrationBasePath}/bitbucket`, returnTo),
       icon: <ProviderLogo provider="bitbucket" className="size-5 text-[#0C66E4]" />,
     });
   }

--- a/apps/web/src/components/integrations/IntegrationDetailPage.tsx
+++ b/apps/web/src/components/integrations/IntegrationDetailPage.tsx
@@ -230,14 +230,23 @@ export async function UserIntegrationDetailPage({
   const entry = getIntegrationDetailEntry(detailPlatform);
   await getUserFromAuthOrRedirect('/users/sign_in');
   const search = await searchParams;
+  const returnTo = search.returnTo ? validateReturnPath(search.returnTo) : null;
 
   return (
     <PageLayout
       title={entry.title}
       subtitle={entry.userSubtitle}
-      headerActions={<BackLink href="/integrations" label="Back to Integrations" />}
+      headerActions={
+        <BackLink
+          href={returnTo ?? '/integrations'}
+          label={returnTo ? 'Return to setup' : 'Back to Integrations'}
+        />
+      }
     >
-      <SuspendedIntegrationDetails platform={detailPlatform} search={search} />
+      <SuspendedIntegrationDetails
+        platform={detailPlatform}
+        search={{ ...search, returnTo: returnTo ?? undefined }}
+      />
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary

When Cloud Agent onboarding shows the "Connect a repository provider" panel (e.g. after a user lands on /cloud without a connected repo), picking GitHub/GitLab/Bitbucket drops the user on the integration detail page whose Back link is hard-coded to /integrations. The user lands somewhere they did not intend instead of returning to the Cloud Agent setup flow.

Two pieces conspired:

- `RepositoryProviderOnboardingPanel` built provider links as plain `/integrations/<platform>` with no `returnTo` query param.
- `UserIntegrationDetailPage` in `IntegrationDetailPage.tsx` ignored `returnTo` entirely; only the organization variant of the same page already honored it.

This change passes a `returnTo` path through the onboarding panel (`/cloud` for personal, `/organizations/<id>/cloud` for org) and updates the user variant of the integration detail page to validate and use it, mirroring the organization variant. The validated `returnTo` is also threaded into the rendered detail component's search params so downstream branches (e.g. `GitHubIntegrationDetails`' `appReturnPath`) keep working for the OAuth round-trip.

Files touched:
- `apps/web/src/components/cloud-agent-next/RepositoryProviderOnboardingPanel.tsx`
- `apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx`
- `apps/web/src/components/integrations/IntegrationDetailPage.tsx`

## Verification

- [x] Manually walk through: visit /cloud without a connected repo -> pick GitHub -> click "Back". Confirm it now returns to /cloud instead of /integrations. Repeat for `/organizations/<id>/cloud`.

Local checks run:
- `oxlint` on the three changed files: 0 warnings, 0 errors.
- `tsgo --noEmit` (apps/web): clean.

## Visual Changes

<img width="1472" height="573" alt="image" src="https://github.com/user-attachments/assets/9538aeef-df56-4d0e-81c3-bffc2dce1361" />

## Reviewer Notes

- `withReturnTo` is a small inline helper to append `returnTo` without breaking callers that already had query strings; today only the generated integration hrefs use it, but the helper is defensive.
- `validateReturnPath` already rejects non-`/` paths, unsafe characters, and double-slash tricks, so the Back href is constrained the same way as the organization variant.
- The pre-existing `GitHubIntegrationDetails` `appReturnPath` plumbing was already `returnTo`-aware but the page never set it; that gap is closed here.