### PR TITLE
feat(auth): brand the NextAuth signout confirmation page

### DIFF
--- a/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
+++ b/apps/web/src/app/(app)/components/SidebarUserFooter.tsx
@@ -11,7 +11,6 @@ import {
 } from '@/components/ui/dropdown-menu';
 import { Avatar, AvatarImage, AvatarFallback } from '@radix-ui/react-avatar';
 import { BookOpen, ChevronsUpDown, Download, FileDown, LogOut, UserCog } from 'lucide-react';
-import { signOut } from 'next-auth/react';
 import { useRouter } from 'next/navigation';
 
 type User = {
@@ -37,12 +36,8 @@ function getUserInitials(name: string) {
 export default function SidebarUserFooter({ user, isLoading }: SidebarUserFooterProps) {
   const router = useRouter();
 
-  const handleLogout = async () => {
-    try {
-      await fetch('/api/auth/revoke-web-session', { method: 'POST' });
-    } finally {
-      await signOut({ callbackUrl: '/' });
-    }
+  const handleLogout = () => {
+    router.push('/users/sign_out?callbackUrl=%2F');
   };
 
   return (

--- a/apps/web/src/app/device-auth/DeviceAuthClient.tsx
+++ b/apps/web/src/app/device-auth/DeviceAuthClient.tsx
@@ -1,7 +1,6 @@
 'use client';
 
 import { useState } from 'react';
-import { signOut } from 'next-auth/react';
 import { z } from 'zod';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -55,14 +54,10 @@ export function DeviceAuthClient({ code, viewerToken, isAppMode, user }: DeviceA
   const shellClassName = getDeviceAuthShellClassName(isAppMode);
   const outcomeHeaderClassName = getDeviceAuthOutcomeHeaderClassName();
 
-  const handleSignOut = async () => {
+  const handleSignOut = () => {
     setIsSigningOut(true);
-
-    try {
-      await fetch('/api/auth/revoke-web-session', { method: 'POST' });
-    } finally {
-      await signOut({ callbackUrl: getDeviceAuthSignInUrl(code, { app: isAppMode }) });
-    }
+    const callbackUrl = getDeviceAuthSignInUrl(code, { app: isAppMode });
+    window.location.assign(`/users/sign_out?callbackUrl=${encodeURIComponent(callbackUrl)}`);
   };
 
   const redirectToSignIn = () => {

--- a/apps/web/src/app/users/sign_out/page.tsx
+++ b/apps/web/src/app/users/sign_out/page.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+import { useRouter, useSearchParams } from 'next/navigation';
+import { signOut } from 'next-auth/react';
+import { useState } from 'react';
+
+import { AuthPageLayout } from '@/components/auth/AuthPageLayout';
+import { Button } from '@/components/ui/button';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card';
+
+function safeCallbackUrl(raw: string | null): string {
+  if (!raw) return '/profile';
+  if (!raw.startsWith('/') || raw.startsWith('//')) return '/profile';
+  return raw;
+}
+
+export default function SignOutPage() {
+  const router = useRouter();
+  const params = useSearchParams();
+  const callbackUrl = safeCallbackUrl(params.get('callbackUrl'));
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSignOut = async () => {
+    if (submitting) return;
+    setSubmitting(true);
+    try {
+      await fetch('/api/auth/revoke-web-session', { method: 'POST' });
+    } finally {
+      await signOut({ callbackUrl });
+    }
+  };
+
+  return (
+    <AuthPageLayout>
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Sign out of Kilo?</CardTitle>
+          <CardDescription>
+            You&apos;ll need to sign in again to access your account.
+          </CardDescription>
+        </CardHeader>
+        <CardContent />
+        <CardFooter className="flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => router.back()}
+            disabled={submitting}
+          >
+            Cancel
+          </Button>
+          <Button type="button" onClick={handleSignOut} disabled={submitting}>
+            {submitting ? 'Signing out…' : 'Sign out'}
+          </Button>
+        </CardFooter>
+      </Card>
+    </AuthPageLayout>
+  );
+}

--- a/apps/web/src/components/dev/actions.ts
+++ b/apps/web/src/components/dev/actions.ts
@@ -33,5 +33,5 @@ export async function nuke() {
     throw new Error('Failed to nuke account. Please try again later.');
   }
 
-  redirect('/api/auth/signout?callbackUrl=/profile');
+  redirect('/users/sign_out?callbackUrl=/profile');
 }

--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -1058,6 +1058,7 @@ export const authOptions: NextAuthOptions = {
   pages: {
     signIn: '/users/sign_in',
     error: '/users/sign_in',
+    signOut: '/users/sign_out',
   },
   debug: !!getEnvVariable('DEBUG_AUTH'),
 };


### PR DESCRIPTION
## Summary

`GET /api/auth/signout` was rendering NextAuth's built-in, unstyled confirmation page because `authOptions.pages` only overrode `signIn` and `error`, so the signout flow looked off-brand while the rest of the app uses `kilo-design` tokens and `AuthPageLayout`. Worse, the in-app signout entry points (sidebar dropdown, device-auth flow) bypassed the confirmation entirely by calling `signOut({ callbackUrl })` from `next-auth/react`, which `POST`s `/api/auth/signout` and follows the returned redirect without rendering a confirmation page.

This change adds a branded `/users/sign_out` page that reuses `AuthPageLayout`, the existing `Card`/`Button` primitives, and the same `revoke-web-session` + `signOut({ callbackUrl })` flow used elsewhere. The page reads `callbackUrl` from the query string, restricts it to same-origin paths, and falls back to `/profile` when absent. NextAuth `pages.signOut` is pointed at it, so any external/manual `GET /api/auth/signout` lands on the branded page. The sidebar and device-auth signout entry points are updated to navigate to `/users/sign_out?callbackUrl=...` instead of calling `signOut` directly, so they share the same confirmation UI. The profile "sign out browser sessions" dialog is left calling `signOut` directly because that flow runs a server-side tRPC mutation that already rotates the user's web-session pepper — routing through a Cancel-capable confirmation page afterwards would let the user dismiss it with a stale NextAuth cookie. The dev "nuke" action (`apps/web/src/components/dev/actions.ts`) is updated to point at `/users/sign_out?callbackUrl=/profile` directly because NextAuth's `pages.signOut` redirect drops the original query string (see `node_modules/next-auth/src/core/index.ts:199`).

## Verification

<!-- Manually tested paths only. -->

- [x] Manually load `http://localhost:<port>/users/sign_out` and confirm it renders inside `AuthPageLayout` with brand tokens, the "Sign out" button calls `signOut({ callbackUrl })`, and "Cancel" returns to the previous page.
- [x] Manually load `http://localhost:<port>/users/sign_out?callbackUrl=/profile` and confirm `signOut` lands on `/profile`.
- [x] Manually load `http://localhost:<port>/api/auth/signout?callbackUrl=/profile` and confirm it redirects to the branded page and lands on `/profile` after confirmation.
- [x] From the sidebar user dropdown, click "Sign out", confirm the branded page appears, click "Sign out", and confirm the user is signed out and lands on `/`.
- [x] From the profile "sign out browser sessions" dialog, confirm, and confirm the user is signed out and lands on `/users/sign_in` without a second confirmation step.
- [x] Run the dev "nuke" action from the dev panel and confirm the user is routed through the branded page to `/profile`.

## Visual Changes

| Before | After |
|---|---|
| Plain NextAuth default confirmation page on `GET /api/auth/signout`; sidebar/device-auth signout skipped confirmation entirely. | Branded `/users/sign_out` page reused by `pages.signOut`, the sidebar dropdown, and the device-auth flow. |