### PR TITLE
fix(ai-gateway): forward LongCat user ID header

### DIFF
--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
@@ -34,6 +34,25 @@ describe('LongCat provider', () => {
     expect(request.body.thinking).toEqual({ type: expectedType });
     expect(request.body.provider).toBeUndefined();
   });
+
+  test('forwards the hashed user ID in the LongCat header', async () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'LongCat-2.0',
+        messages: [{ role: 'user', content: 'hello' }],
+        user: 'hashed-user-id',
+      },
+    };
+    const extraHeaders: Record<string, string> = {};
+
+    await PROVIDERS.LONGCAT.transformRequest({
+      request,
+      extraHeaders,
+    } as TransformRequestContext);
+
+    expect(extraHeaders['Mt-User-Id']).toBe('hashed-user-id');
+  });
 });
 
 describe.each([

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -69,6 +69,9 @@ export default {
         type: isReasoningExplicitlyDisabled(context.request) ? 'disabled' : 'enabled',
       };
       delete context.request.body.provider;
+      if (context.request.body.user) {
+        context.extraHeaders['Mt-User-Id'] = context.request.body.user;
+      }
     },
   },
   MARTIAN: {


### PR DESCRIPTION
## Summary
- forward the gateway hashed user ID to LongCat via `Mt-User-Id`
- add focused coverage for the provider request transform

## Verification
- `pnpm --filter web test -- --runInBand src/lib/ai-gateway/providers/provider-definitions.test.ts`
- `pnpm --filter web lint`
- `git diff --check`