### PR TITLE
fix(admin): display API request log size in GB

### DIFF
--- a/apps/web/src/app/admin/api-request-log/page.tsx
+++ b/apps/web/src/app/admin/api-request-log/page.tsx
@@ -13,7 +13,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Download } from 'lucide-react';
 
-const BYTES_PER_MEGABYTE = 1024 * 1024;
+const BYTES_PER_GIGABYTE = 1024 * 1024 * 1024;
 
 export default function ApiRequestLogPage() {
   const [userId, setUserId] = useState('');
@@ -60,7 +60,7 @@ export default function ApiRequestLogPage() {
           <p className="text-muted-foreground text-sm tabular-nums">
             {summaryQuery.data.recordCount.toLocaleString()}{' '}
             {summaryQuery.data.recordCount === 1 ? 'record' : 'records'} ·{' '}
-            {(summaryQuery.data.sizeBytes / BYTES_PER_MEGABYTE).toFixed(1)} MB
+            {(summaryQuery.data.sizeBytes / BYTES_PER_GIGABYTE).toFixed(2)} GB
             {summaryQuery.data.oldestCreatedAt && (
               <>
                 {' '}


### PR DESCRIPTION
## Summary
- display the API request log total relation size in GB instead of MB
- use two decimal places so smaller relation sizes remain visible

Follow-up to #5378.

## Validation
- pnpm exec oxfmt apps/web/src/app/admin/api-request-log/page.tsx
- pnpm exec oxlint --config .oxlintrc.json apps/web/src/app/admin/api-request-log/page.tsx
- git diff --check
- tests deferred to CI