### PR TITLE
refactor(ai-gateway): group partner providers

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -29,8 +29,8 @@ import {
 import { gemma_4_26b_a4b_it_free_model } from '@/lib/ai-gateway/providers/google';
 import { tencent_hy3_free_model } from '@/lib/ai-gateway/providers/tencent';
 import { getEffectiveModelDecision } from '@/lib/organizations/effective-model-access.server';
-import { getPercentageRoutedPartnerProvider } from '@/lib/ai-gateway/providers/partner-routing';
-import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/zai';
+import { getPercentageRoutedPartnerProvider } from '@/lib/ai-gateway/providers/partner/routing';
+import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/partner/constants';
 import type { GatewayMessagesRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import { warnExceptInTest } from '@/lib/utils.server';
 
@@ -69,7 +69,7 @@ jest.mock('@/lib/ai-gateway/abuse-service', () => {
   };
 });
 jest.mock('@/lib/ai-gateway/providers/get-provider');
-jest.mock('@/lib/ai-gateway/providers/partner-routing');
+jest.mock('@/lib/ai-gateway/providers/partner/routing');
 jest.mock('@/lib/ai-gateway/providers/direct-byok', () => ({
   getDirectByokModel: jest.fn(async () => ({ provider: null, model: null })),
 }));

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -64,7 +64,7 @@ import {
   rewriteModelResponse,
   logUnrewrittenResponse,
 } from '@/lib/ai-gateway/rewriteModelResponse';
-import { getPercentageRoutedPartnerProvider } from '@/lib/ai-gateway/providers/partner-routing';
+import { getPercentageRoutedPartnerProvider } from '@/lib/ai-gateway/providers/partner/routing';
 import {
   createAnonymousContext,
   isAnonymousContext,

--- a/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.test.ts
@@ -1,8 +1,10 @@
 import { describe, expect, test } from '@jest/globals';
 import { captureMessage } from '@sentry/nextjs';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
-import { PERPLEXITY_KIMI_PUBLIC_ID } from '@/lib/ai-gateway/providers/moonshotai';
-import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/zai';
+import {
+  FRIENDLI_GLM_PUBLIC_ID,
+  PERPLEXITY_KIMI_PUBLIC_ID,
+} from '@/lib/ai-gateway/providers/partner/constants';
 import {
   applyCustomPricingToPricing,
   applyCustomPricingToModel,

--- a/apps/web/src/lib/ai-gateway/custom-pricing.ts
+++ b/apps/web/src/lib/ai-gateway/custom-pricing.ts
@@ -2,8 +2,7 @@ import { captureMessage } from '@sentry/nextjs';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import type { JustTheCostsUsageStats } from '@/lib/ai-gateway/processUsage.types';
 import { QWEN37_MAX_MODEL_ID, QWEN37_PLUS_MODEL_ID } from '@/lib/ai-gateway/providers/qwen';
-import { PERPLEXITY_KIMI_PUBLIC_ID } from '@/lib/ai-gateway/providers/moonshotai';
-import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/zai';
+import { partnerPricingByModelId } from '@/lib/ai-gateway/providers/partner/pricing';
 import {
   calculateCost_mUsd,
   type Pricing,
@@ -61,34 +60,7 @@ export const customPricingByModelId: Record<string, CustomPricing> = {
       },
     ],
   },
-  [PERPLEXITY_KIMI_PUBLIC_ID]: {
-    fallbackOnly: true,
-    pricing: [
-      {
-        start_context_length: 0,
-        pricing: {
-          prompt_per_million: 3,
-          completion_per_million: 15,
-          input_cache_read_per_million: 0.3,
-          input_cache_write_per_million: null,
-        },
-      },
-    ],
-  },
-  [FRIENDLI_GLM_PUBLIC_ID]: {
-    fallbackOnly: true,
-    pricing: [
-      {
-        start_context_length: 0,
-        pricing: {
-          prompt_per_million: 1.4,
-          completion_per_million: 4.4,
-          input_cache_read_per_million: 0.26,
-          input_cache_write_per_million: null,
-        },
-      },
-    ],
-  },
+  ...partnerPricingByModelId,
 };
 
 export function getCustomPricing(modelId: string): CustomPricing | undefined {

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -12,8 +12,10 @@ import {
   type Provider,
   type ProviderId,
 } from '@/lib/ai-gateway/providers/types';
-import { PERPLEXITY_KIMI_PUBLIC_ID } from '@/lib/ai-gateway/providers/moonshotai';
-import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/zai';
+import {
+  FRIENDLI_GLM_PUBLIC_ID,
+  PERPLEXITY_KIMI_PUBLIC_ID,
+} from '@/lib/ai-gateway/providers/partner/constants';
 
 function makeRequest(model: string, models?: string[]): GatewayRequest {
   return {

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.ts
@@ -16,12 +16,12 @@ import {
   isOpus5Model,
 } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { OpenRouterInferenceProviderIdSchema } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
+import { applyMoonshotModelSettings, isKimiModel } from '@/lib/ai-gateway/providers/moonshotai';
+import { isGlmModel } from '@/lib/ai-gateway/providers/zai';
 import {
-  applyMoonshotModelSettings,
-  isKimiModel,
+  FRIENDLI_GLM_PUBLIC_ID,
   PERPLEXITY_KIMI_PUBLIC_ID,
-} from '@/lib/ai-gateway/providers/moonshotai';
-import { FRIENDLI_GLM_PUBLIC_ID, isGlmModel } from '@/lib/ai-gateway/providers/zai';
+} from '@/lib/ai-gateway/providers/partner/constants';
 import { isMinimaxModel } from '@/lib/ai-gateway/providers/minimax';
 import {
   ReasoningDetailsTransform,

--- a/apps/web/src/lib/ai-gateway/providers/moonshotai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/moonshotai.ts
@@ -11,8 +11,6 @@ export function applyMoonshotModelSettings(requestToMutate: GatewayRequest) {
   delete requestToMutate.body.top_p;
 }
 
-// Partner routing stays pinned when the current Kimi model changes.
-export const PERPLEXITY_KIMI_PUBLIC_ID = 'moonshotai/kimi-k3';
 export const KIMI_CURRENT_MODEL_ID = 'moonshotai/kimi-k3';
 
 export const KIMI_CURRENT_VERCEL_MODEL_ID = KIMI_CURRENT_MODEL_ID;

--- a/apps/web/src/lib/ai-gateway/providers/partner/constants.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner/constants.ts
@@ -1,0 +1,3 @@
+// Partner routing stays pinned when the current public models change.
+export const FRIENDLI_GLM_PUBLIC_ID = 'z-ai/glm-5.2';
+export const PERPLEXITY_KIMI_PUBLIC_ID = 'moonshotai/kimi-k3';

--- a/apps/web/src/lib/ai-gateway/providers/partner/pricing.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner/pricing.ts
@@ -1,0 +1,41 @@
+import type { PricingTiers } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+import {
+  FRIENDLI_GLM_PUBLIC_ID,
+  PERPLEXITY_KIMI_PUBLIC_ID,
+} from '@/lib/ai-gateway/providers/partner/constants';
+
+type PartnerPricing = {
+  fallbackOnly: true;
+  pricing: PricingTiers;
+};
+
+export const partnerPricingByModelId = {
+  [PERPLEXITY_KIMI_PUBLIC_ID]: {
+    fallbackOnly: true,
+    pricing: [
+      {
+        start_context_length: 0,
+        pricing: {
+          prompt_per_million: 3,
+          completion_per_million: 15,
+          input_cache_read_per_million: 0.3,
+          input_cache_write_per_million: null,
+        },
+      },
+    ],
+  },
+  [FRIENDLI_GLM_PUBLIC_ID]: {
+    fallbackOnly: true,
+    pricing: [
+      {
+        start_context_length: 0,
+        pricing: {
+          prompt_per_million: 1.4,
+          completion_per_million: 4.4,
+          input_cache_read_per_million: 0.26,
+          input_cache_write_per_million: null,
+        },
+      },
+    ],
+  },
+} satisfies Record<string, PartnerPricing>;

--- a/apps/web/src/lib/ai-gateway/providers/partner/providers.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner/providers.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, test } from '@jest/globals';
+
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import {
+  FRIENDLI_GLM_PUBLIC_ID,
+  PERPLEXITY_KIMI_PUBLIC_ID,
+} from '@/lib/ai-gateway/providers/partner/constants';
+import {
+  FRIENDLI_GLM_PROVIDER,
+  PERPLEXITY_KIMI_PROVIDER,
+} from '@/lib/ai-gateway/providers/partner/providers';
+import {
+  ReasoningDetailsTransform,
+  type TransformRequestContext,
+} from '@/lib/ai-gateway/providers/types';
+
+describe.each([
+  {
+    name: 'Friendli GLM',
+    provider: FRIENDLI_GLM_PROVIDER,
+    expectedUrl: 'https://api.friendli.ai/serverless/v1/chat/completions',
+    requestedModel: FRIENDLI_GLM_PUBLIC_ID,
+    upstreamModel: 'zai-org/GLM-5.2',
+  },
+  {
+    name: 'Perplexity Kimi',
+    provider: PERPLEXITY_KIMI_PROVIDER,
+    expectedUrl: 'https://api.perplexity.ai/router/v1/chat/completions',
+    requestedModel: PERPLEXITY_KIMI_PUBLIC_ID,
+    upstreamModel: 'perplexity/kimi-k3',
+  },
+])('$name provider', ({ provider, expectedUrl, requestedModel, upstreamModel }) => {
+  test('supports the chat completions API', () => {
+    expect(`${provider.apiUrl}/chat/completions`).toBe(expectedUrl);
+    expect(provider.supportedChatApis).toEqual(['chat_completions']);
+  });
+
+  test('enables the reasoning details response transform', () => {
+    expect(provider.responseTransforms).toBe(ReasoningDetailsTransform.ReasoningContent);
+  });
+
+  test('hardwires the upstream model and removes provider settings', async () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: requestedModel,
+        messages: [{ role: 'user', content: 'hello' }],
+        provider: { order: ['friendli'] },
+      },
+    };
+
+    await provider.transformRequest({ request } as TransformRequestContext);
+
+    expect(request.body.model).toBe(upstreamModel);
+    expect(request.body.provider).toBeUndefined();
+  });
+});
+
+describe('Friendli GLM reasoning', () => {
+  test.each([
+    [
+      { enabled: false as const, effort: 'none' as const },
+      { chat_template_kwargs: { enable_thinking: false } },
+    ],
+    [
+      { enabled: true as const, effort: 'high' as const },
+      {
+        chat_template_kwargs: { enable_thinking: true },
+        reasoning_effort: 'high',
+        parse_reasoning: true,
+        include_reasoning: true,
+      },
+    ],
+  ])('maps reasoning %p to Friendli settings', async (reasoning, expected) => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: FRIENDLI_GLM_PUBLIC_ID,
+        messages: [{ role: 'user', content: 'hello' }],
+        reasoning,
+      },
+    };
+
+    await FRIENDLI_GLM_PROVIDER.transformRequest({ request } as TransformRequestContext);
+
+    expect(request.body).toMatchObject(expected);
+    expect(request.body.reasoning).toBeUndefined();
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/partner/providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner/providers.ts
@@ -1,0 +1,66 @@
+import { getEnvVariable } from '@/lib/dotenvx';
+import {
+  isReasoningExplicitlyDisabled,
+  removeChatCompletionsToolNames,
+} from '@/lib/ai-gateway/providers/openrouter/request-helpers';
+import { ReasoningDetailsTransform, type Provider } from '@/lib/ai-gateway/providers/types';
+
+export const FRIENDLI_GLM_PROVIDER = {
+  id: 'friendli',
+  apiUrl: 'https://api.friendli.ai/serverless/v1',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('FRIENDLI_API_KEY'),
+  supportedChatApis: [
+    'chat_completions',
+    // 'messages', // supported, not tested
+    // 'responses', // supported, not tested
+  ],
+  responseTransforms: ReasoningDetailsTransform.ReasoningContent,
+  async transformRequest(context) {
+    context.request.body.model = 'zai-org/GLM-5.2';
+    delete context.request.body.provider;
+
+    if (context.request.kind === 'chat_completions') {
+      const requestBody = context.request.body;
+      if (isReasoningExplicitlyDisabled(context.request)) {
+        requestBody.chat_template_kwargs = { enable_thinking: false };
+        delete requestBody.reasoning;
+        delete requestBody.reasoning_effort;
+      } else {
+        requestBody.chat_template_kwargs = { enable_thinking: true };
+        requestBody.reasoning_effort =
+          requestBody.reasoning?.effort ?? requestBody.reasoning_effort ?? undefined;
+        requestBody.parse_reasoning = true;
+        requestBody.include_reasoning = true;
+        delete requestBody.reasoning;
+      }
+    }
+  },
+} as const satisfies Provider;
+
+export const PERPLEXITY_KIMI_PROVIDER = {
+  id: 'perplexity',
+  apiUrl: 'https://api.perplexity.ai/router/v1',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('PERPLEXITY_API_KEY'),
+  supportedChatApis: [
+    'chat_completions',
+    // 'messages', // supported, not tested
+    // 'responses', // supported, not tested
+  ],
+  responseTransforms: ReasoningDetailsTransform.ReasoningContent,
+  async transformRequest(context) {
+    context.request.body.model = 'perplexity/kimi-k3';
+    if (context.request.kind === 'chat_completions') {
+      context.request.body.reasoning_effort = isReasoningExplicitlyDisabled(context.request)
+        ? 'none'
+        : (context.request.body.reasoning?.effort ??
+          context.request.body.reasoning_effort ??
+          undefined);
+      delete context.request.body.reasoning;
+      removeChatCompletionsToolNames(context.request.body);
+    }
+    delete context.request.body.provider;
+    delete context.request.body.user;
+  },
+} as const satisfies Provider;

--- a/apps/web/src/lib/ai-gateway/providers/partner/routing.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner/routing.test.ts
@@ -2,19 +2,24 @@ import { afterAll, beforeEach, describe, expect, it } from '@jest/globals';
 
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import {
+  FRIENDLI_GLM_PUBLIC_ID,
+  PERPLEXITY_KIMI_PUBLIC_ID,
+} from '@/lib/ai-gateway/providers/partner/constants';
+import {
+  FRIENDLI_GLM_PROVIDER,
+  PERPLEXITY_KIMI_PROVIDER,
+} from '@/lib/ai-gateway/providers/partner/providers';
+import {
   selectPercentageRoutedPartnerProvider,
   type PercentageRoutedPartnerInput,
-} from '@/lib/ai-gateway/providers/partner-routing';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+} from '@/lib/ai-gateway/providers/partner/routing';
 import type { RuntimeGatewayRoutingConfig } from '@/lib/ai-gateway/providers/routing-config';
-import { PERPLEXITY_KIMI_PUBLIC_ID } from '@/lib/ai-gateway/providers/moonshotai';
-import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/zai';
 
-const originalFriendliApiKey = PROVIDERS.FRIENDLI_GLM.apiKey;
-const originalPerplexityApiKey = PROVIDERS.PERPLEXITY_KIMI.apiKey;
+const originalFriendliApiKey = FRIENDLI_GLM_PROVIDER.apiKey;
+const originalPerplexityApiKey = PERPLEXITY_KIMI_PROVIDER.apiKey;
 
 function setApiKey(
-  provider: typeof PROVIDERS.FRIENDLI_GLM | typeof PROVIDERS.PERPLEXITY_KIMI,
+  provider: typeof FRIENDLI_GLM_PROVIDER | typeof PERPLEXITY_KIMI_PROVIDER,
   value: string
 ) {
   Object.defineProperty(provider, 'apiKey', {
@@ -26,13 +31,13 @@ function setApiKey(
 }
 
 beforeEach(() => {
-  setApiKey(PROVIDERS.FRIENDLI_GLM, 'test-friendli-key');
-  setApiKey(PROVIDERS.PERPLEXITY_KIMI, 'test-perplexity-key');
+  setApiKey(FRIENDLI_GLM_PROVIDER, 'test-friendli-key');
+  setApiKey(PERPLEXITY_KIMI_PROVIDER, 'test-perplexity-key');
 });
 
 afterAll(() => {
-  setApiKey(PROVIDERS.FRIENDLI_GLM, originalFriendliApiKey);
-  setApiKey(PROVIDERS.PERPLEXITY_KIMI, originalPerplexityApiKey);
+  setApiKey(FRIENDLI_GLM_PROVIDER, originalFriendliApiKey);
+  setApiKey(PERPLEXITY_KIMI_PROVIDER, originalPerplexityApiKey);
 });
 
 function request(
@@ -78,14 +83,14 @@ function selectPartner(
 
 describe('getPercentageRoutedPartnerProvider', () => {
   it.each([
-    [FRIENDLI_GLM_PUBLIC_ID, PROVIDERS.FRIENDLI_GLM],
-    [PERPLEXITY_KIMI_PUBLIC_ID, PROVIDERS.PERPLEXITY_KIMI],
+    [FRIENDLI_GLM_PUBLIC_ID, FRIENDLI_GLM_PROVIDER],
+    [PERPLEXITY_KIMI_PUBLIC_ID, PERPLEXITY_KIMI_PROVIDER],
   ])('routes exact model %s', (model, expectedProvider) => {
     expect(selectPartner({ requestedModel: model })).toBe(expectedProvider);
   });
 
   it('routes chat completions requests', () => {
-    expect(selectPartner()).toBe(PROVIDERS.FRIENDLI_GLM);
+    expect(selectPartner()).toBe(FRIENDLI_GLM_PROVIDER);
   });
 
   it.each(['messages', 'responses'] as const)('does not route untested %s requests', kind => {
@@ -93,14 +98,12 @@ describe('getPercentageRoutedPartnerProvider', () => {
   });
 
   it('allows an empty provider object', () => {
-    expect(selectPartner({ request: request('chat_completions', {}) })).toBe(
-      PROVIDERS.FRIENDLI_GLM
-    );
+    expect(selectPartner({ request: request('chat_completions', {}) })).toBe(FRIENDLI_GLM_PROVIDER);
   });
 
   it.each([
-    [FRIENDLI_GLM_PUBLIC_ID, 'friendli', PROVIDERS.FRIENDLI_GLM],
-    [PERPLEXITY_KIMI_PUBLIC_ID, 'perplexity', PROVIDERS.PERPLEXITY_KIMI],
+    [FRIENDLI_GLM_PUBLIC_ID, 'friendli', FRIENDLI_GLM_PROVIDER],
+    [PERPLEXITY_KIMI_PUBLIC_ID, 'perplexity', PERPLEXITY_KIMI_PROVIDER],
   ])('honors provider filters for %s', (requestedModel, providerId, expectedProvider) => {
     expect(
       selectPartner({
@@ -126,8 +129,8 @@ describe('getPercentageRoutedPartnerProvider', () => {
   });
 
   it.each([
-    [FRIENDLI_GLM_PUBLIC_ID, { data_collection: 'deny' } as const, PROVIDERS.FRIENDLI_GLM],
-    [PERPLEXITY_KIMI_PUBLIC_ID, { zdr: true } as const, PROVIDERS.PERPLEXITY_KIMI],
+    [FRIENDLI_GLM_PUBLIC_ID, { data_collection: 'deny' } as const, FRIENDLI_GLM_PROVIDER],
+    [PERPLEXITY_KIMI_PUBLIC_ID, { zdr: true } as const, PERPLEXITY_KIMI_PROVIDER],
   ])('routes ZDR model %s with data policy options', (requestedModel, provider, expected) => {
     expect(selectPartner({ requestedModel, request: request('chat_completions', provider) })).toBe(
       expected
@@ -137,7 +140,7 @@ describe('getPercentageRoutedPartnerProvider', () => {
   it.each(['openrouter', 'vercel'] as const)(
     'routes from managed provider %s',
     sourceProviderId => {
-      expect(selectPartner({ sourceProviderId })).toBe(PROVIDERS.FRIENDLI_GLM);
+      expect(selectPartner({ sourceProviderId })).toBe(FRIENDLI_GLM_PROVIDER);
     }
   );
 
@@ -153,7 +156,7 @@ describe('getPercentageRoutedPartnerProvider', () => {
   });
 
   it('does not route without a non-empty partner API key', () => {
-    setApiKey(PROVIDERS.FRIENDLI_GLM, '  ');
+    setApiKey(FRIENDLI_GLM_PROVIDER, '  ');
 
     expect(selectPartner()).toBeNull();
   });

--- a/apps/web/src/lib/ai-gateway/providers/partner/routing.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner/routing.ts
@@ -1,13 +1,18 @@
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import {
+  FRIENDLI_GLM_PUBLIC_ID,
+  PERPLEXITY_KIMI_PUBLIC_ID,
+} from '@/lib/ai-gateway/providers/partner/constants';
+import {
+  FRIENDLI_GLM_PROVIDER,
+  PERPLEXITY_KIMI_PROVIDER,
+} from '@/lib/ai-gateway/providers/partner/providers';
 import { getRuntimeGatewayRoutingConfig } from '@/lib/ai-gateway/providers/routing-config';
 import {
   passesRoutingPercentage,
   type RoutingCohort,
 } from '@/lib/ai-gateway/providers/routing-percentage';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
-import { PERPLEXITY_KIMI_PUBLIC_ID } from '@/lib/ai-gateway/providers/moonshotai';
-import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/zai';
 
 type PartnerRoute = {
   provider: Provider;
@@ -24,11 +29,11 @@ export type PercentageRoutedPartnerInput = {
 
 const PARTNER_ROUTES: Readonly<Record<string, PartnerRoute>> = {
   [FRIENDLI_GLM_PUBLIC_ID]: {
-    provider: PROVIDERS.FRIENDLI_GLM,
+    provider: FRIENDLI_GLM_PROVIDER,
     cohort: 'friendli',
   },
   [PERPLEXITY_KIMI_PUBLIC_ID]: {
-    provider: PROVIDERS.PERPLEXITY_KIMI,
+    provider: PERPLEXITY_KIMI_PROVIDER,
     cohort: 'perplexity',
   },
 };

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
@@ -3,9 +3,6 @@ import { describe, expect, test } from '@jest/globals';
 import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { TransformRequestContext } from '@/lib/ai-gateway/providers/types';
-import { ReasoningDetailsTransform } from '@/lib/ai-gateway/providers/types';
-import { PERPLEXITY_KIMI_PUBLIC_ID } from '@/lib/ai-gateway/providers/moonshotai';
-import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/zai';
 
 describe('LongCat provider', () => {
   test('targets the LongCat chat completions endpoint', () => {
@@ -53,79 +50,5 @@ describe('LongCat provider', () => {
     } as TransformRequestContext);
 
     expect(extraHeaders['Mt-User-Id']).toBe('hashed-user-id');
-  });
-});
-
-describe.each([
-  {
-    name: 'Friendli GLM',
-    provider: PROVIDERS.FRIENDLI_GLM,
-    expectedUrl: 'https://api.friendli.ai/serverless/v1/chat/completions',
-    requestedModel: FRIENDLI_GLM_PUBLIC_ID,
-    upstreamModel: 'zai-org/GLM-5.2',
-  },
-  {
-    name: 'Perplexity Kimi',
-    provider: PROVIDERS.PERPLEXITY_KIMI,
-    expectedUrl: 'https://api.perplexity.ai/router/v1/chat/completions',
-    requestedModel: PERPLEXITY_KIMI_PUBLIC_ID,
-    upstreamModel: 'perplexity/kimi-k3',
-  },
-])('$name provider', ({ provider, expectedUrl, requestedModel, upstreamModel }) => {
-  test('supports the chat completions API', () => {
-    expect(`${provider.apiUrl}/chat/completions`).toBe(expectedUrl);
-    expect(provider.supportedChatApis).toEqual(['chat_completions']);
-  });
-
-  test('enables the reasoning details response transform', () => {
-    expect(provider.responseTransforms).toBe(ReasoningDetailsTransform.ReasoningContent);
-  });
-
-  test('hardwires the upstream model and removes provider settings', async () => {
-    const request: GatewayRequest = {
-      kind: 'chat_completions',
-      body: {
-        model: requestedModel,
-        messages: [{ role: 'user', content: 'hello' }],
-        provider: { order: ['friendli'] },
-      },
-    };
-
-    await provider.transformRequest({ request } as TransformRequestContext);
-
-    expect(request.body.model).toBe(upstreamModel);
-    expect(request.body.provider).toBeUndefined();
-  });
-});
-
-describe('Friendli GLM reasoning', () => {
-  test.each([
-    [
-      { enabled: false as const, effort: 'none' as const },
-      { chat_template_kwargs: { enable_thinking: false } },
-    ],
-    [
-      { enabled: true as const, effort: 'high' as const },
-      {
-        chat_template_kwargs: { enable_thinking: true },
-        reasoning_effort: 'high',
-        parse_reasoning: true,
-        include_reasoning: true,
-      },
-    ],
-  ])('maps reasoning %p to Friendli settings', async (reasoning, expected) => {
-    const request: GatewayRequest = {
-      kind: 'chat_completions',
-      body: {
-        model: FRIENDLI_GLM_PUBLIC_ID,
-        messages: [{ role: 'user', content: 'hello' }],
-        reasoning,
-      },
-    };
-
-    await PROVIDERS.FRIENDLI_GLM.transformRequest({ request } as TransformRequestContext);
-
-    expect(request.body).toMatchObject(expected);
-    expect(request.body.reasoning).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -1,9 +1,6 @@
 import { getEnvVariable } from '@/lib/dotenvx';
-import {
-  isReasoningExplicitlyDisabled,
-  removeChatCompletionsToolNames,
-} from '@/lib/ai-gateway/providers/openrouter/request-helpers';
-import { ReasoningDetailsTransform, type Provider } from '@/lib/ai-gateway/providers/types';
+import { isReasoningExplicitlyDisabled } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
+import type { Provider } from '@/lib/ai-gateway/providers/types';
 import { applyVercelSettings } from '@/lib/ai-gateway/providers/vercel';
 
 export default {
@@ -93,64 +90,6 @@ export default {
     supportedChatApis: [],
     responseTransforms: null,
     async transformRequest() {},
-  },
-  FRIENDLI_GLM: {
-    id: 'friendli',
-    apiUrl: 'https://api.friendli.ai/serverless/v1',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('FRIENDLI_API_KEY'),
-    supportedChatApis: [
-      'chat_completions',
-      // 'messages', // supported, not tested
-      // 'responses', // supported, not tested
-    ],
-    responseTransforms: ReasoningDetailsTransform.ReasoningContent,
-    async transformRequest(context) {
-      context.request.body.model = 'zai-org/GLM-5.2';
-      delete context.request.body.provider;
-
-      if (context.request.kind === 'chat_completions') {
-        const requestBody = context.request.body;
-        if (isReasoningExplicitlyDisabled(context.request)) {
-          requestBody.chat_template_kwargs = { enable_thinking: false };
-          delete requestBody.reasoning;
-          delete requestBody.reasoning_effort;
-        } else {
-          requestBody.chat_template_kwargs = { enable_thinking: true };
-          requestBody.reasoning_effort =
-            requestBody.reasoning?.effort ?? requestBody.reasoning_effort ?? undefined;
-          requestBody.parse_reasoning = true;
-          requestBody.include_reasoning = true;
-          delete requestBody.reasoning;
-        }
-      }
-    },
-  },
-  PERPLEXITY_KIMI: {
-    id: 'perplexity',
-    apiUrl: 'https://api.perplexity.ai/router/v1',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('PERPLEXITY_API_KEY'),
-    supportedChatApis: [
-      'chat_completions',
-      // 'messages', // supported, not tested
-      // 'responses', // supported, not tested
-    ],
-    responseTransforms: ReasoningDetailsTransform.ReasoningContent,
-    async transformRequest(context) {
-      context.request.body.model = 'perplexity/kimi-k3';
-      if (context.request.kind === 'chat_completions') {
-        context.request.body.reasoning_effort = isReasoningExplicitlyDisabled(context.request)
-          ? 'none'
-          : (context.request.body.reasoning?.effort ??
-            context.request.body.reasoning_effort ??
-            undefined);
-        delete context.request.body.reasoning;
-        removeChatCompletionsToolNames(context.request.body);
-      }
-      delete context.request.body.provider;
-      delete context.request.body.user;
-    },
   },
   STREAMLAKE: {
     id: 'streamlake',

--- a/apps/web/src/lib/ai-gateway/providers/zai.ts
+++ b/apps/web/src/lib/ai-gateway/providers/zai.ts
@@ -2,7 +2,5 @@ export function isGlmModel(model: string) {
   return model.includes('glm');
 }
 
-// Partner routing stays pinned when the current GLM model changes.
-export const FRIENDLI_GLM_PUBLIC_ID = 'z-ai/glm-5.2';
 export const GLM_CURRENT_MODEL_ID = 'z-ai/glm-5.3';
 export const GLM_CURRENT_VERCEL_MODEL_ID = 'zai/glm-5.3';


### PR DESCRIPTION
## Summary
- group partner routing, provider definitions, constants, pricing, and tests under `ai-gateway/providers/partner`
- remove partner-only providers from the shared provider registry
- compose partner pricing into the shared custom pricing map

## Testing
- CI only, as requested
- formatting and `git diff --check` completed locally