### PR TITLE
Add internal ID control when copying custom LLMs

### DIFF
--- a/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
+++ b/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
@@ -52,8 +52,9 @@ type CopyState = {
   sourcePublicId: string;
   publicId: string;
   displayName: string;
+  internalId: string;
   validationError: {
-    field: 'publicId' | 'displayName' | null;
+    field: 'publicId' | 'displayName' | 'internalId' | null;
     message: string;
   } | null;
 };
@@ -116,14 +117,18 @@ export function CustomLlmsContent() {
     setEditor(initialEditorState);
   }, []);
 
-  const openCopy = useCallback((sourcePublicId: string, sourceDisplayName: string) => {
-    setCopy({
-      sourcePublicId,
-      publicId: sourcePublicId,
-      displayName: sourceDisplayName,
-      validationError: null,
-    });
-  }, []);
+  const openCopy = useCallback(
+    (sourcePublicId: string, sourceDisplayName: string, sourceInternalId: string) => {
+      setCopy({
+        sourcePublicId,
+        publicId: sourcePublicId,
+        displayName: sourceDisplayName,
+        internalId: sourceInternalId,
+        validationError: null,
+      });
+    },
+    []
+  );
 
   const closeCopy = useCallback(() => {
     setCopy(null);
@@ -134,6 +139,7 @@ export function CustomLlmsContent() {
 
     const publicId = copy.publicId.trim();
     const displayName = copy.displayName.trim();
+    const internalId = copy.internalId.trim();
 
     if (!publicId) {
       setCopy(prev =>
@@ -174,11 +180,24 @@ export function CustomLlmsContent() {
       return;
     }
 
+    if (!internalId) {
+      setCopy(prev =>
+        prev
+          ? {
+              ...prev,
+              validationError: { field: 'internalId', message: 'New internal ID is required' },
+            }
+          : prev
+      );
+      return;
+    }
+
     try {
       await copyMutation.mutateAsync({
         source_public_id: copy.sourcePublicId,
         public_id: publicId,
         display_name: displayName,
+        internal_id: internalId,
       });
       toast.success('Custom LLM copied');
       closeCopy();
@@ -335,7 +354,13 @@ export function CustomLlmsContent() {
                     <Button
                       variant="outline"
                       size="sm"
-                      onClick={() => openCopy(item.public_id, item.definition.display_name)}
+                      onClick={() =>
+                        openCopy(
+                          item.public_id,
+                          item.definition.display_name,
+                          item.definition.internal_id
+                        )
+                      }
                       aria-label={`Copy ${item.public_id}`}
                       title="Copy custom LLM"
                     >
@@ -478,7 +503,7 @@ export function CustomLlmsContent() {
             <DialogDescription>
               Copy the definition and encrypted credentials from{' '}
               <code className="font-mono">{copy?.sourcePublicId}</code>. Enter a new public ID and
-              display name for the copy.
+              adjust the display name and internal ID for the copy.
             </DialogDescription>
           </DialogHeader>
 
@@ -518,6 +543,27 @@ export function CustomLlmsContent() {
                 aria-invalid={copy?.validationError?.field === 'displayName'}
                 aria-describedby={
                   copy?.validationError?.field === 'displayName'
+                    ? 'copy-validation-error'
+                    : undefined
+                }
+              />
+            </div>
+
+            <div>
+              <Label htmlFor="copy-internal-id">New Internal ID</Label>
+              <Input
+                id="copy-internal-id"
+                value={copy?.internalId ?? ''}
+                onChange={event =>
+                  setCopy(prev =>
+                    prev ? { ...prev, internalId: event.target.value, validationError: null } : prev
+                  )
+                }
+                placeholder="e.g. copied-model"
+                className="font-mono"
+                aria-invalid={copy?.validationError?.field === 'internalId'}
+                aria-describedby={
+                  copy?.validationError?.field === 'internalId'
                     ? 'copy-validation-error'
                     : undefined
                 }

--- a/apps/web/src/routers/admin/custom-llm-router.test.ts
+++ b/apps/web/src/routers/admin/custom-llm-router.test.ts
@@ -184,7 +184,7 @@ describe('adminCustomLlmRouter', () => {
   });
 
   describe('copy', () => {
-    it('copies a custom LLM with its encrypted credentials and a new ID and name', async () => {
+    it('copies a custom LLM with its encrypted credentials and new IDs and name', async () => {
       const caller = await createCallerForUser(admin.id);
       const sourcePublicId = 'kilo-internal/test-model-copy-source';
       const copiedPublicId = 'kilo-internal/test-model-copy-target';
@@ -199,6 +199,7 @@ describe('adminCustomLlmRouter', () => {
         source_public_id: sourcePublicId,
         public_id: copiedPublicId,
         display_name: 'Copied GPT-4',
+        internal_id: 'copied-gpt-4',
       });
 
       expect(result).toEqual({
@@ -206,6 +207,7 @@ describe('adminCustomLlmRouter', () => {
         definition: {
           ...validDefinition,
           display_name: 'Copied GPT-4',
+          internal_id: 'copied-gpt-4',
         },
       });
 
@@ -221,6 +223,7 @@ describe('adminCustomLlmRouter', () => {
       expect(copiedRow?.definition).toEqual({
         ...validDefinition,
         display_name: 'Copied GPT-4',
+        internal_id: 'copied-gpt-4',
       });
       expect(copiedRow?.encrypted_api_key).toEqual(sourceRow?.encrypted_api_key);
       expect((result as Record<string, unknown>).encrypted_api_key).toBeUndefined();
@@ -247,6 +250,7 @@ describe('adminCustomLlmRouter', () => {
           source_public_id: sourcePublicId,
           public_id: existingPublicId,
           display_name: 'Should not overwrite',
+          internal_id: 'should-not-overwrite',
         })
       ).rejects.toMatchObject({
         code: 'CONFLICT',
@@ -257,6 +261,35 @@ describe('adminCustomLlmRouter', () => {
         .from(custom_llm2)
         .where(eq(custom_llm2.public_id, existingPublicId));
       expect(existingRow?.definition.display_name).toBe('Existing model');
+    });
+
+    it('rejects a copy with an empty internal ID', async () => {
+      const caller = await createCallerForUser(admin.id);
+      const sourcePublicId = 'kilo-internal/test-model-copy-empty-internal-id-source';
+      const copiedPublicId = 'kilo-internal/test-model-copy-empty-internal-id-target';
+
+      await caller.admin.customLlm.upsert({
+        public_id: sourcePublicId,
+        definition: validDefinition,
+        credentials: { type: 'api_key', api_key: 'sk-source-secret' },
+      });
+
+      await expect(
+        caller.admin.customLlm.copy({
+          source_public_id: sourcePublicId,
+          public_id: copiedPublicId,
+          display_name: 'Copied model',
+          internal_id: '   ',
+        })
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+      });
+
+      const [copiedRow] = await db
+        .select()
+        .from(custom_llm2)
+        .where(eq(custom_llm2.public_id, copiedPublicId));
+      expect(copiedRow).toBeUndefined();
     });
   });
 

--- a/apps/web/src/routers/admin/custom-llm-router.ts
+++ b/apps/web/src/routers/admin/custom-llm-router.ts
@@ -28,6 +28,7 @@ const CopyCustomLlmSchema = z.object({
   source_public_id: publicIdSchema,
   public_id: publicIdSchema,
   display_name: z.string().trim().min(1, 'display_name is required'),
+  internal_id: z.string().trim().min(1, 'internal_id is required'),
 });
 
 const DeleteCustomLlmSchema = z.object({
@@ -120,6 +121,7 @@ export const adminCustomLlmRouter = createTRPCRouter({
         definition: {
           ...source.definition,
           display_name: input.display_name,
+          internal_id: input.internal_id,
         },
         encrypted_api_key: source.encrypted_api_key,
       })


### PR DESCRIPTION
## Summary
- add a prefilled internal ID field to the custom LLM copy dialog
- validate and persist the chosen internal ID while preserving all other definition settings and encrypted credentials
- cover internal ID replacement and whitespace rejection in the router tests

## Testing
- local tests not run; CI will handle verification
- formatting and whitespace checks passed