### PR TITLE
refactor(ai-gateway): use named provider exports

### DIFF
--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -33,7 +33,7 @@ import {
   selectAutoFreeCandidate,
 } from '@/lib/ai-gateway/models';
 import { getOpenRouterModelsFromRedis } from '@/lib/ai-gateway/providers/gateway-models-cache';
-import { getProviderById } from '@/lib/ai-gateway/providers/provider-definitions';
+import { tryGetProviderById } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 import {
   getOrganizationAutoRoute,
@@ -98,7 +98,7 @@ function gatewaySupportsApiKind(
   apiKind: GatewayRequest['kind'] | null
 ): boolean {
   if (apiKind === null) return true;
-  const provider = getProviderById(gateway);
+  const provider = tryGetProviderById(gateway);
   return provider?.supportedChatApis.some(k => k === apiKind) ?? false;
 }
 

--- a/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
+++ b/apps/web/src/lib/ai-gateway/auto-model/resolution.ts
@@ -33,7 +33,7 @@ import {
   selectAutoFreeCandidate,
 } from '@/lib/ai-gateway/models';
 import { getOpenRouterModelsFromRedis } from '@/lib/ai-gateway/providers/gateway-models-cache';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { getProviderById } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { ProviderId } from '@/lib/ai-gateway/providers/types';
 import {
   getOrganizationAutoRoute,
@@ -98,7 +98,7 @@ function gatewaySupportsApiKind(
   apiKind: GatewayRequest['kind'] | null
 ): boolean {
   if (apiKind === null) return true;
-  const provider = Object.values(PROVIDERS).find(p => p.id === gateway);
+  const provider = getProviderById(gateway);
   return provider?.supportedChatApis.some(k => k === apiKind) ?? false;
 }
 

--- a/apps/web/src/lib/ai-gateway/model-api-kinds.ts
+++ b/apps/web/src/lib/ai-gateway/model-api-kinds.ts
@@ -1,5 +1,5 @@
 import { findKiloExclusiveModel } from '@/lib/ai-gateway/models';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { getProviderById, OPENROUTER } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { GatewayChatApiKind } from '@/lib/ai-gateway/providers/types';
 
 const GATEWAY_CHAT_API_KINDS: readonly GatewayChatApiKind[] = [
@@ -16,8 +16,7 @@ const GATEWAY_CHAT_API_KINDS: readonly GatewayChatApiKind[] = [
  */
 export function gatewayChatApisForModel(modelId: string): ReadonlyArray<GatewayChatApiKind> {
   const exclusive = findKiloExclusiveModel(modelId);
-  const provider =
-    Object.values(PROVIDERS).find(p => p.id === exclusive?.gateway) ?? PROVIDERS.OPENROUTER;
+  const provider = (exclusive && getProviderById(exclusive.gateway)) ?? OPENROUTER;
   return provider.supportedChatApis;
 }
 

--- a/apps/web/src/lib/ai-gateway/model-api-kinds.ts
+++ b/apps/web/src/lib/ai-gateway/model-api-kinds.ts
@@ -1,5 +1,5 @@
 import { findKiloExclusiveModel } from '@/lib/ai-gateway/models';
-import { getProviderById, OPENROUTER } from '@/lib/ai-gateway/providers/provider-definitions';
+import { OPENROUTER, tryGetProviderById } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { GatewayChatApiKind } from '@/lib/ai-gateway/providers/types';
 
 const GATEWAY_CHAT_API_KINDS: readonly GatewayChatApiKind[] = [
@@ -16,7 +16,7 @@ const GATEWAY_CHAT_API_KINDS: readonly GatewayChatApiKind[] = [
  */
 export function gatewayChatApisForModel(modelId: string): ReadonlyArray<GatewayChatApiKind> {
   const exclusive = findKiloExclusiveModel(modelId);
-  const provider = (exclusive && getProviderById(exclusive.gateway)) ?? OPENROUTER;
+  const provider = (exclusive && tryGetProviderById(exclusive.gateway)) ?? OPENROUTER;
   return provider.supportedChatApis;
 }
 

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -16,7 +16,7 @@ import type {
   OpenRouterGeneration,
 } from './providers/openrouter/types';
 import { fetchGeneration } from './providers/upstream-request';
-import { getProviderById } from './providers/provider-definitions';
+import { tryGetProviderById } from './providers/provider-definitions';
 import { toMicrodollars } from '../utils';
 import { captureException, captureMessage, startSpan, startInactiveSpan } from '@sentry/nextjs';
 import type { Span } from '@sentry/nextjs';
@@ -1231,7 +1231,7 @@ export async function processTokenData(
   }
 
   const timer = createTimer();
-  const provider = getProviderById(usageContext.provider);
+  const provider = tryGetProviderById(usageContext.provider);
   const generation =
     provider &&
     (await useGenerationLookup(usageStats, usageContext)) &&

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -16,7 +16,7 @@ import type {
   OpenRouterGeneration,
 } from './providers/openrouter/types';
 import { fetchGeneration } from './providers/upstream-request';
-import PROVIDERS from './providers/provider-definitions';
+import { getProviderById } from './providers/provider-definitions';
 import { toMicrodollars } from '../utils';
 import { captureException, captureMessage, startSpan, startInactiveSpan } from '@sentry/nextjs';
 import type { Span } from '@sentry/nextjs';
@@ -1231,7 +1231,7 @@ export async function processTokenData(
   }
 
   const timer = createTimer();
-  const provider = Object.values(PROVIDERS).find(p => p.id === usageContext.provider);
+  const provider = getProviderById(usageContext.provider);
   const generation =
     provider &&
     (await useGenerationLookup(usageStats, usageContext)) &&

--- a/apps/web/src/lib/ai-gateway/providerHash.test.ts
+++ b/apps/web/src/lib/ai-gateway/providerHash.test.ts
@@ -1,4 +1,4 @@
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { OPENROUTER, VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import {
   generateOpenRouterDownstreamSafetyIdentifier,
   generateProviderSpecificHash,
@@ -9,28 +9,28 @@ describe('generateProviderSpecificHash', () => {
   const testUserId = 'test-user-123';
 
   it('should generate different hashes for different providers', () => {
-    const openRouterHash = generateProviderSpecificHash(testUserId, PROVIDERS.OPENROUTER);
-    const vercelHash = generateProviderSpecificHash(testUserId, PROVIDERS.VERCEL_AI_GATEWAY);
+    const openRouterHash = generateProviderSpecificHash(testUserId, OPENROUTER);
+    const vercelHash = generateProviderSpecificHash(testUserId, VERCEL_AI_GATEWAY);
 
     expect(openRouterHash).not.toBe(vercelHash);
   });
 
   it('should generate consistent hashes for the same provider and user', () => {
-    const hash1 = generateProviderSpecificHash(testUserId, PROVIDERS.OPENROUTER);
-    const hash2 = generateProviderSpecificHash(testUserId, PROVIDERS.OPENROUTER);
+    const hash1 = generateProviderSpecificHash(testUserId, OPENROUTER);
+    const hash2 = generateProviderSpecificHash(testUserId, OPENROUTER);
 
     expect(hash1).toBe(hash2);
   });
 
   it('should generate different hashes for different users on the same provider', () => {
-    const user1Hash = generateProviderSpecificHash('user1', PROVIDERS.OPENROUTER);
-    const user2Hash = generateProviderSpecificHash('user2', PROVIDERS.OPENROUTER);
+    const user1Hash = generateProviderSpecificHash('user1', OPENROUTER);
+    const user2Hash = generateProviderSpecificHash('user2', OPENROUTER);
 
     expect(user1Hash).not.toBe(user2Hash);
   });
 
   it('should return a base64 encoded string', () => {
-    const hash = generateProviderSpecificHash(testUserId, PROVIDERS.VERCEL_AI_GATEWAY);
+    const hash = generateProviderSpecificHash(testUserId, VERCEL_AI_GATEWAY);
 
     // Base64 pattern check
     expect(hash).toMatch(/^[A-Za-z0-9+/]+=*$/);
@@ -42,7 +42,7 @@ describe('downstream safety identifiers', () => {
 
   it('uses the OpenRouter-specific user hash for OpenRouter', () => {
     expect(generateOpenRouterDownstreamSafetyIdentifier(testUserId)).toBe(
-      generateProviderSpecificHash(testUserId, PROVIDERS.OPENROUTER)
+      generateProviderSpecificHash(testUserId, OPENROUTER)
     );
   });
 

--- a/apps/web/src/lib/ai-gateway/providerHash.ts
+++ b/apps/web/src/lib/ai-gateway/providerHash.ts
@@ -1,6 +1,6 @@
 import crypto from 'crypto';
 import { type Provider } from '@/lib/ai-gateway/providers/types';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { OPENROUTER, VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import { getEnvVariable } from '@/lib/dotenvx';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 
@@ -26,11 +26,11 @@ export function generateProviderSpecificHash(payload: string, provider: Provider
 }
 
 export function generateOpenRouterDownstreamSafetyIdentifier(userId: string): string {
-  return generateProviderSpecificHash(userId, PROVIDERS.OPENROUTER);
+  return generateProviderSpecificHash(userId, OPENROUTER);
 }
 
 export function generateVercelDownstreamSafetyIdentifier(userId: string): string {
-  return generateProviderSpecificHash(userId, PROVIDERS.VERCEL_AI_GATEWAY);
+  return generateProviderSpecificHash(userId, VERCEL_AI_GATEWAY);
 }
 
 export function generateOpenRouterUpstreamSafetyIdentifier(userId: string): string | null {

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -14,8 +14,8 @@ import type { AnonymousUserContext } from '@/lib/anonymous';
 import { isAnonymousContext } from '@/lib/anonymous';
 import type { BYOKResult, Provider } from '@/lib/ai-gateway/providers/types';
 import {
-  getProviderById,
   OPENROUTER,
+  tryGetProviderById,
   VERCEL_AI_GATEWAY,
 } from '@/lib/ai-gateway/providers/provider-definitions';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
@@ -282,7 +282,7 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
 
   return {
     kind: 'provider',
-    provider: (kiloExclusiveModel && getProviderById(kiloExclusiveModel.gateway)) ?? OPENROUTER,
+    provider: (kiloExclusiveModel && tryGetProviderById(kiloExclusiveModel.gateway)) ?? OPENROUTER,
     userByok: null,
     bypassAccessCheck: false,
   };

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -13,7 +13,11 @@ import { eq } from 'drizzle-orm';
 import type { AnonymousUserContext } from '@/lib/anonymous';
 import { isAnonymousContext } from '@/lib/anonymous';
 import type { BYOKResult, Provider } from '@/lib/ai-gateway/providers/types';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import {
+  getProviderById,
+  OPENROUTER,
+  VERCEL_AI_GATEWAY,
+} from '@/lib/ai-gateway/providers/provider-definitions';
 import { getDirectByokModel } from '@/lib/ai-gateway/providers/direct-byok';
 import { CustomLlmCredentialsSchema, CustomLlmDefinitionSchema } from '@kilocode/db/schema-types';
 import { buildDirectProvider } from '@/lib/ai-gateway/experiments/build-direct-provider';
@@ -205,7 +209,7 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
   if (vercelByok) {
     return {
       kind: 'provider',
-      provider: PROVIDERS.VERCEL_AI_GATEWAY,
+      provider: VERCEL_AI_GATEWAY,
       userByok: vercelByok,
       bypassAccessCheck: false,
     };
@@ -270,7 +274,7 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
   ) {
     return {
       kind: 'provider',
-      provider: PROVIDERS.VERCEL_AI_GATEWAY,
+      provider: VERCEL_AI_GATEWAY,
       userByok: null,
       bypassAccessCheck: false,
     };
@@ -278,9 +282,7 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
 
   return {
     kind: 'provider',
-    provider:
-      Object.values(PROVIDERS).find(p => p.id === kiloExclusiveModel?.gateway) ??
-      PROVIDERS.OPENROUTER,
+    provider: (kiloExclusiveModel && getProviderById(kiloExclusiveModel.gateway)) ?? OPENROUTER,
     userByok: null,
     bypassAccessCheck: false,
   };
@@ -294,16 +296,16 @@ export async function getEmbeddingProvider(
   // 1. BYOK check — route through Vercel AI Gateway when user has their own key
   const userByok = await checkVercelBYOK(user, requestedModel, organizationId);
   if (userByok) {
-    return { provider: PROVIDERS.VERCEL_AI_GATEWAY, userByok };
+    return { provider: VERCEL_AI_GATEWAY, userByok };
   }
 
   // 2. All non-BYOK embedding requests go through OpenRouter
-  return { provider: PROVIDERS.OPENROUTER, userByok: null };
+  return { provider: OPENROUTER, userByok: null };
 }
 
 export async function getTranscriptionProvider(): Promise<{
   provider: Provider;
   userByok: BYOKResult[] | null;
 }> {
-  return { provider: PROVIDERS.OPENROUTER, userByok: null };
+  return { provider: OPENROUTER, userByok: null };
 }

--- a/apps/web/src/lib/ai-gateway/providers/getEmbeddingProvider.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/getEmbeddingProvider.test.ts
@@ -3,7 +3,7 @@ import {
   getEmbeddingProvider,
   getTranscriptionProvider,
 } from '@/lib/ai-gateway/providers/get-provider';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { OPENROUTER, VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import { createAnonymousContext } from '@/lib/anonymous';
 import {
   getModelUserByokProviders,
@@ -37,7 +37,7 @@ describe('getEmbeddingProvider', () => {
     mockedGetBYOKforOrganization.mockClear().mockResolvedValue(null);
   });
 
-  it('should route all non-BYOK models to PROVIDERS.OPENROUTER', async () => {
+  it('should route all non-BYOK models to OpenRouter', async () => {
     const user = createTestUser();
 
     for (const model of [
@@ -47,7 +47,7 @@ describe('getEmbeddingProvider', () => {
     ]) {
       const result = await getEmbeddingProvider(model, user, undefined);
       expect(result.provider.id).toBe('openrouter');
-      expect(result.provider).toBe(PROVIDERS.OPENROUTER);
+      expect(result.provider).toBe(OPENROUTER);
       expect(result.userByok).toBeNull();
     }
   });
@@ -62,7 +62,7 @@ describe('getEmbeddingProvider', () => {
     const result = await getEmbeddingProvider('openai/text-embedding-3-small', user, undefined);
 
     expect(result.provider.id).toBe('vercel');
-    expect(result.provider).toBe(PROVIDERS.VERCEL_AI_GATEWAY);
+    expect(result.provider).toBe(VERCEL_AI_GATEWAY);
     expect(result.userByok).toBe(mockByokResult);
     expect(mockedGetBYOKforUser).toHaveBeenCalledWith(readDb, user.id, ['openai']);
   });
@@ -106,7 +106,7 @@ describe('getTranscriptionProvider', () => {
   it('routes transcription requests to OpenRouter', async () => {
     const result = await getTranscriptionProvider();
 
-    expect(result.provider).toBe(PROVIDERS.OPENROUTER);
+    expect(result.provider).toBe(OPENROUTER);
     expect(result.userByok).toBeNull();
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.ts
@@ -4,7 +4,7 @@ import {
   preferredModels,
 } from '@/lib/ai-gateway/models';
 import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { OPENROUTER } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { OpenRouterModel } from '@/lib/organizations/organization-types';
 import {
   OpenRouterModelsResponseSchema,
@@ -203,10 +203,10 @@ async function enhancedModelList(models: OpenRouterModel[]) {
  * Use this for syncing model stats where you need complete data including :free variants
  */
 export async function getRawOpenRouterModels(): Promise<OpenRouterModelsResponse> {
-  const response = await fetch(`${PROVIDERS.OPENROUTER.apiUrl}/models`, {
+  const response = await fetch(`${OPENROUTER.apiUrl}/models`, {
     method: 'GET',
     headers: {
-      Authorization: `Bearer ${PROVIDERS.OPENROUTER.apiKey}`,
+      Authorization: `Bearer ${OPENROUTER.apiKey}`,
       ...ATTRIBUTION_HEADERS,
     },
     next: { revalidate: 60 },
@@ -263,17 +263,14 @@ export async function getEnhancedOpenRouterModels(): Promise<OpenRouterModelsRes
  * Fetch speech-to-text models from the OpenRouter API.
  */
 export async function getOpenRouterTranscriptionModels(): Promise<OpenRouterModelsResponse> {
-  const response = await fetch(
-    `${PROVIDERS.OPENROUTER.apiUrl}/models?output_modalities=transcription`,
-    {
-      method: 'GET',
-      headers: {
-        Authorization: `Bearer ${PROVIDERS.OPENROUTER.apiKey}`,
-        ...ATTRIBUTION_HEADERS,
-      },
-      next: { revalidate: 60 },
-    }
-  );
+  const response = await fetch(`${OPENROUTER.apiUrl}/models?output_modalities=transcription`, {
+    method: 'GET',
+    headers: {
+      Authorization: `Bearer ${OPENROUTER.apiKey}`,
+      ...ATTRIBUTION_HEADERS,
+    },
+    next: { revalidate: 60 },
+  });
 
   if (!response.ok) {
     const errorMessage = `Failed to fetch OpenRouter transcription models: ${response.status} ${response.statusText}`;

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/sync-providers.ts
@@ -19,7 +19,7 @@ import { modelsByProvider } from '@kilocode/db/schema';
 import { db } from '@/lib/drizzle';
 import { desc, lt, sql } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { OPENROUTER, VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import { logAutoModelChangesForAllOrgs } from '@/lib/organizations/auto-model-change-log';
 import type { Provider } from '@/lib/ai-gateway/providers/types';
 import type { StoredModel } from '@kilocode/db/schema-types';
@@ -449,8 +449,8 @@ export async function applySnapshotChangesAndAudit(params: {
 export async function syncAndStoreProviders() {
   const startTime = performance.now();
 
-  const openrouter_data = await fetchGatewayModels(PROVIDERS.OPENROUTER);
-  const vercel_data = await fetchGatewayModels(PROVIDERS.VERCEL_AI_GATEWAY);
+  const openrouter_data = await fetchGatewayModels(OPENROUTER);
+  const vercel_data = await fetchGatewayModels(VERCEL_AI_GATEWAY);
 
   const openrouterProviders = await fetchProviders();
   if (openrouterProviders.length < 10) {

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
@@ -1,15 +1,19 @@
 import { describe, expect, test } from '@jest/globals';
 
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import {
+  getProviderById,
+  LONGCAT,
+  OPENROUTER,
+} from '@/lib/ai-gateway/providers/provider-definitions';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { TransformRequestContext } from '@/lib/ai-gateway/providers/types';
 
 describe('LongCat provider', () => {
   test('targets the LongCat chat completions endpoint', () => {
-    expect(`${PROVIDERS.LONGCAT.apiUrl}/chat/completions`).toBe(
+    expect(`${LONGCAT.apiUrl}/chat/completions`).toBe(
       'https://api.longcat.ai/openai/v1/chat/completions'
     );
-    expect(PROVIDERS.LONGCAT.supportedChatApis).toEqual(['chat_completions']);
+    expect(LONGCAT.supportedChatApis).toEqual(['chat_completions']);
   });
 
   test.each([
@@ -27,7 +31,7 @@ describe('LongCat provider', () => {
       },
     };
 
-    await PROVIDERS.LONGCAT.transformRequest({ request } as TransformRequestContext);
+    await LONGCAT.transformRequest({ request } as TransformRequestContext);
 
     expect(request.body.thinking).toEqual({ type: expectedType });
     expect(request.body.provider).toBeUndefined();
@@ -44,11 +48,22 @@ describe('LongCat provider', () => {
     };
     const extraHeaders: Record<string, string> = {};
 
-    await PROVIDERS.LONGCAT.transformRequest({
+    await LONGCAT.transformRequest({
       request,
       extraHeaders,
     } as TransformRequestContext);
 
     expect(extraHeaders['Mt-User-Id']).toBe('hashed-user-id');
+  });
+});
+
+describe('getProviderById', () => {
+  test('resolves static provider definitions', () => {
+    expect(getProviderById('openrouter')).toBe(OPENROUTER);
+  });
+
+  test('does not claim dynamically constructed providers', () => {
+    expect(getProviderById('direct-byok')).toBeUndefined();
+    expect(getProviderById('friendli')).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
@@ -1,9 +1,9 @@
 import { describe, expect, test } from '@jest/globals';
 
 import {
-  getProviderById,
   LONGCAT,
   OPENROUTER,
+  tryGetProviderById,
 } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { TransformRequestContext } from '@/lib/ai-gateway/providers/types';
@@ -57,13 +57,13 @@ describe('LongCat provider', () => {
   });
 });
 
-describe('getProviderById', () => {
+describe('tryGetProviderById', () => {
   test('resolves static provider definitions', () => {
-    expect(getProviderById('openrouter')).toBe(OPENROUTER);
+    expect(tryGetProviderById('openrouter')).toBe(OPENROUTER);
   });
 
   test('does not claim dynamically constructed providers', () => {
-    expect(getProviderById('direct-byok')).toBeUndefined();
-    expect(getProviderById('friendli')).toBeUndefined();
+    expect(tryGetProviderById('direct-byok')).toBeUndefined();
+    expect(tryGetProviderById('friendli')).toBeUndefined();
   });
 });

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -120,7 +120,7 @@ export const VERCEL_AI_GATEWAY = {
   },
 } as const satisfies Provider;
 
-export function getProviderById(providerId: ProviderId): Provider | undefined {
+export function tryGetProviderById(providerId: ProviderId): Provider | undefined {
   switch (providerId) {
     case 'openrouter':
       return OPENROUTER;

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -1,116 +1,144 @@
 import { getEnvVariable } from '@/lib/dotenvx';
 import { isReasoningExplicitlyDisabled } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
-import type { Provider } from '@/lib/ai-gateway/providers/types';
+import type { Provider, ProviderId } from '@/lib/ai-gateway/providers/types';
 import { applyVercelSettings } from '@/lib/ai-gateway/providers/vercel';
 
-export default {
-  OPENROUTER: {
-    id: 'openrouter',
-    apiUrl: 'https://openrouter.ai/api/v1',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('OPENROUTER_API_KEY'),
-    supportedChatApis: ['chat_completions', 'messages', 'responses'],
-    responseTransforms: null,
-    async transformRequest() {},
+export const OPENROUTER = {
+  id: 'openrouter',
+  apiUrl: 'https://openrouter.ai/api/v1',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('OPENROUTER_API_KEY'),
+  supportedChatApis: ['chat_completions', 'messages', 'responses'],
+  responseTransforms: null,
+  async transformRequest() {},
+} as const satisfies Provider;
+
+export const ALIBABA = {
+  id: 'alibaba',
+  apiUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('ALIBABA_API_KEY'),
+  supportedChatApis: [
+    'chat_completions',
+    // 'responses', // supported, not tested
+  ],
+  responseTransforms: null,
+  async transformRequest(context) {
+    context.request.body.enable_thinking = !isReasoningExplicitlyDisabled(context.request);
   },
-  ALIBABA: {
-    id: 'alibaba',
-    apiUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('ALIBABA_API_KEY'),
-    supportedChatApis: [
-      'chat_completions',
-      // 'responses', // supported, not tested
-    ],
-    responseTransforms: null,
-    async transformRequest(context) {
-      context.request.body.enable_thinking = !isReasoningExplicitlyDisabled(context.request);
-    },
-  },
-  SEED: {
-    id: 'seed',
-    apiUrl: 'https://ark.ap-southeast.bytepluses.com/api/v3',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('BYTEDANCE_API_KEY'),
-    supportedChatApis: [
-      'chat_completions',
-      // 'responses', // supported, not tested
-    ],
-    responseTransforms: null,
-    async transformRequest(context) {
-      if (!isReasoningExplicitlyDisabled(context.request)) {
-        context.request.body.thinking = { type: 'enabled' };
-        if (context.request.kind === 'chat_completions') {
-          context.request.body.reasoning_effort ??= context.request.body.reasoning?.effort;
-        }
-      } else {
-        context.request.body.thinking = { type: 'disabled' };
+} as const satisfies Provider;
+
+export const SEED = {
+  id: 'seed',
+  apiUrl: 'https://ark.ap-southeast.bytepluses.com/api/v3',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('BYTEDANCE_API_KEY'),
+  supportedChatApis: [
+    'chat_completions',
+    // 'responses', // supported, not tested
+  ],
+  responseTransforms: null,
+  async transformRequest(context) {
+    if (!isReasoningExplicitlyDisabled(context.request)) {
+      context.request.body.thinking = { type: 'enabled' };
+      if (context.request.kind === 'chat_completions') {
+        context.request.body.reasoning_effort ??= context.request.body.reasoning?.effort;
       }
-      if (context.request.kind === 'responses') {
-        delete context.request.body.prompt_cache_key;
-        delete context.request.body.safety_identifier;
-        delete context.request.body.user;
-        delete context.request.body.provider;
-      }
-    },
-  },
-  LONGCAT: {
-    id: 'longcat',
-    apiUrl: 'https://api.longcat.ai/openai/v1',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('LONGCAT_API_KEY'),
-    supportedChatApis: ['chat_completions'],
-    responseTransforms: null,
-    async transformRequest(context) {
-      context.request.body.thinking = {
-        type: isReasoningExplicitlyDisabled(context.request) ? 'disabled' : 'enabled',
-      };
+    } else {
+      context.request.body.thinking = { type: 'disabled' };
+    }
+    if (context.request.kind === 'responses') {
+      delete context.request.body.prompt_cache_key;
+      delete context.request.body.safety_identifier;
+      delete context.request.body.user;
       delete context.request.body.provider;
-      if (context.request.body.user) {
-        context.extraHeaders['Mt-User-Id'] = context.request.body.user;
-      }
-    },
+    }
   },
-  MARTIAN: {
-    id: 'martian',
-    apiUrl: 'https://api.withmartian.com/v1',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('MARTIAN_API_KEY'),
-    supportedChatApis: ['chat_completions', 'responses', 'messages'],
-    responseTransforms: null,
-    async transformRequest(context) {
-      delete context.request.body.provider;
-    },
+} as const satisfies Provider;
+
+export const LONGCAT = {
+  id: 'longcat',
+  apiUrl: 'https://api.longcat.ai/openai/v1',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('LONGCAT_API_KEY'),
+  supportedChatApis: ['chat_completions'],
+  responseTransforms: null,
+  async transformRequest(context) {
+    context.request.body.thinking = {
+      type: isReasoningExplicitlyDisabled(context.request) ? 'disabled' : 'enabled',
+    };
+    delete context.request.body.provider;
+    if (context.request.body.user) {
+      context.extraHeaders['Mt-User-Id'] = context.request.body.user;
+    }
   },
-  MISTRAL: {
-    id: 'mistral',
-    apiUrl: 'https://api.mistral.ai/v1',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('MISTRAL_API_KEY'),
-    supportedChatApis: [],
-    responseTransforms: null,
-    async transformRequest() {},
+} as const satisfies Provider;
+
+export const MARTIAN = {
+  id: 'martian',
+  apiUrl: 'https://api.withmartian.com/v1',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('MARTIAN_API_KEY'),
+  supportedChatApis: ['chat_completions', 'responses', 'messages'],
+  responseTransforms: null,
+  async transformRequest(context) {
+    delete context.request.body.provider;
   },
-  STREAMLAKE: {
-    id: 'streamlake',
-    apiUrl: 'https://vanchin.streamlake.ai/api/gateway/v1/endpoints',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('STREAMLAKE_API_KEY'),
-    supportedChatApis: ['chat_completions'],
-    responseTransforms: null,
-    async transformRequest(context) {
-      delete context.request.body.provider;
-    },
+} as const satisfies Provider;
+
+export const MISTRAL = {
+  id: 'mistral',
+  apiUrl: 'https://api.mistral.ai/v1',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('MISTRAL_API_KEY'),
+  supportedChatApis: [],
+  responseTransforms: null,
+  async transformRequest() {},
+} as const satisfies Provider;
+
+export const STREAMLAKE = {
+  id: 'streamlake',
+  apiUrl: 'https://vanchin.streamlake.ai/api/gateway/v1/endpoints',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('STREAMLAKE_API_KEY'),
+  supportedChatApis: ['chat_completions'],
+  responseTransforms: null,
+  async transformRequest(context) {
+    delete context.request.body.provider;
   },
-  VERCEL_AI_GATEWAY: {
-    id: 'vercel',
-    apiUrl: 'https://ai-gateway.vercel.sh/v1',
-    apiUrlOverrides: {},
-    apiKey: getEnvVariable('VERCEL_AI_GATEWAY_API_KEY'),
-    supportedChatApis: ['chat_completions', 'messages', 'responses'],
-    responseTransforms: null,
-    async transformRequest(context) {
-      await applyVercelSettings(context.model, context.request, context.userByok);
-    },
+} as const satisfies Provider;
+
+export const VERCEL_AI_GATEWAY = {
+  id: 'vercel',
+  apiUrl: 'https://ai-gateway.vercel.sh/v1',
+  apiUrlOverrides: {},
+  apiKey: getEnvVariable('VERCEL_AI_GATEWAY_API_KEY'),
+  supportedChatApis: ['chat_completions', 'messages', 'responses'],
+  responseTransforms: null,
+  async transformRequest(context) {
+    await applyVercelSettings(context.model, context.request, context.userByok);
   },
-} as const satisfies Record<string, Provider>;
+} as const satisfies Provider;
+
+export function getProviderById(providerId: ProviderId): Provider | undefined {
+  switch (providerId) {
+    case 'openrouter':
+      return OPENROUTER;
+    case 'alibaba':
+      return ALIBABA;
+    case 'seed':
+      return SEED;
+    case 'longcat':
+      return LONGCAT;
+    case 'martian':
+      return MARTIAN;
+    case 'mistral':
+      return MISTRAL;
+    case 'streamlake':
+      return STREAMLAKE;
+    case 'vercel':
+      return VERCEL_AI_GATEWAY;
+    default:
+      return undefined;
+  }
+}

--- a/apps/web/src/lib/coding-plans/inventory-validation.ts
+++ b/apps/web/src/lib/coding-plans/inventory-validation.ts
@@ -19,7 +19,7 @@ import {
 } from '@/lib/coding-plans/byteplus-control-plane';
 import type { CodingPlanId, CodingPlanProviderId } from '@/lib/coding-plans/pricing';
 import { getCodingPlanPrice } from '@/lib/coding-plans/pricing';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import { sentryLogger } from '@/lib/utils.server';
 
 const logWarning = sentryLogger('coding-plans-inventory-validation', 'warning');
@@ -72,7 +72,7 @@ async function validateMiniMaxCodingPlanCredential(
   });
 
   const output = await generateText({
-    model: createGateway({ apiKey: PROVIDERS.VERCEL_AI_GATEWAY.apiKey })(
+    model: createGateway({ apiKey: VERCEL_AI_GATEWAY.apiKey })(
       UserByokTestModels[MINIMAX_PROVIDER_ID]
     ),
     prompt: 'Say hi',

--- a/apps/web/src/routers/byok-router.ts
+++ b/apps/web/src/routers/byok-router.ts
@@ -30,7 +30,7 @@ import {
   getOpenRouterModelsMetadataFromDatabase,
 } from '@/lib/ai-gateway/providers/gateway-models-cache';
 import { AISDKError, createGateway, generateText } from 'ai';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import { getVercelInferenceProviderConfigForUserByok } from '@/lib/ai-gateway/providers/vercel';
 import { decryptByokRow } from '@/lib/ai-gateway/byok';
 import type { GatewayProviderOptions } from '@ai-sdk/gateway';
@@ -428,7 +428,7 @@ export const byokRouter = createTRPCRouter({
         return {
           finalProvider,
           model: createGateway({
-            apiKey: PROVIDERS.VERCEL_AI_GATEWAY.apiKey,
+            apiKey: VERCEL_AI_GATEWAY.apiKey,
           })(model),
           providerOptions: {
             gateway: {

--- a/apps/web/src/scripts/byok/test.ts
+++ b/apps/web/src/scripts/byok/test.ts
@@ -1,6 +1,6 @@
 import 'dotenv/config';
 import OpenAI from 'openai';
-import PROVIDERS from '@/lib/ai-gateway/providers/provider-definitions';
+import { VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { Stream } from 'openai/streaming';
 import type { ChatCompletionChunk } from 'openai/resources';
 
@@ -18,8 +18,8 @@ async function main() {
   }
 
   const openai = new OpenAI({
-    apiKey: PROVIDERS.VERCEL_AI_GATEWAY.apiKey,
-    baseURL: PROVIDERS.VERCEL_AI_GATEWAY.apiUrl,
+    apiKey: VERCEL_AI_GATEWAY.apiKey,
+    baseURL: VERCEL_AI_GATEWAY.apiUrl,
   });
 
   const stream = (await openai.chat.completions.create({

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -1,6 +1,6 @@
 import { captureException } from '@sentry/nextjs';
 import { upstreamRequest } from '../lib/ai-gateway/providers/upstream-request';
-import PROVIDERS from '../lib/ai-gateway/providers/provider-definitions';
+import { OPENROUTER } from '../lib/ai-gateway/providers/provider-definitions';
 
 jest.mock('@sentry/nextjs', () => ({
   captureException: jest.fn(),
@@ -59,7 +59,7 @@ describe('upstreamRequest timeout', () => {
         body: { model: 'test-model', messages: [{ role: 'user', content: 'test' }] },
         extraHeaders: {},
         provider: {
-          ...PROVIDERS.OPENROUTER,
+          ...OPENROUTER,
           apiUrl: 'https://gateway.example.test/v3',
           apiUrlOverrides,
         },
@@ -83,7 +83,7 @@ describe('upstreamRequest timeout', () => {
         messages: [{ role: 'user', content: 'test' }],
       },
       extraHeaders: {},
-      provider: PROVIDERS.OPENROUTER,
+      provider: OPENROUTER,
       signal: controller.signal,
     });
 
@@ -116,7 +116,7 @@ describe('upstreamRequest timeout', () => {
         messages: [{ role: 'user', content: 'test' }],
       },
       extraHeaders: {},
-      provider: PROVIDERS.OPENROUTER,
+      provider: OPENROUTER,
     });
 
     expect(result.type).toBe('error');
@@ -144,7 +144,7 @@ describe('upstreamRequest timeout', () => {
         messages: [{ role: 'user', content: 'test' }],
       },
       extraHeaders: {},
-      provider: PROVIDERS.OPENROUTER,
+      provider: OPENROUTER,
     });
 
     expect(result.type).toBe('error');
@@ -172,7 +172,7 @@ describe('upstreamRequest timeout', () => {
         messages: [{ role: 'user', content: 'test' }],
       },
       extraHeaders: {},
-      provider: PROVIDERS.OPENROUTER,
+      provider: OPENROUTER,
       vercelRequestId: 'iad1::iad1::request-id',
     });
 
@@ -207,7 +207,7 @@ describe('upstreamRequest timeout', () => {
         messages: [{ role: 'user', content: 'test' }],
       },
       extraHeaders: {},
-      provider: PROVIDERS.OPENROUTER,
+      provider: OPENROUTER,
       signal: controller.signal,
       vercelRequestId: 'iad1::iad1::request-id',
     });
@@ -238,7 +238,7 @@ describe('upstreamRequest timeout', () => {
         messages: [{ role: 'user', content: 'test' }],
       },
       extraHeaders: {},
-      provider: PROVIDERS.OPENROUTER,
+      provider: OPENROUTER,
     });
 
     expect(result.type).toBe('error');
@@ -274,7 +274,7 @@ describe('upstreamRequest timeout', () => {
         messages: [{ role: 'user', content: 'test' }],
       },
       extraHeaders: {},
-      provider: PROVIDERS.OPENROUTER,
+      provider: OPENROUTER,
     });
 
     expect(result.type).toBe('error');
@@ -306,7 +306,7 @@ describe('upstreamRequest timeout', () => {
       },
       extraHeaders: {},
       provider: {
-        ...PROVIDERS.OPENROUTER,
+        ...OPENROUTER,
         apiUrl: 'https://gateway.example.test/v1?token=url-secret',
       },
     });
@@ -354,7 +354,7 @@ describe('upstreamRequest timeout', () => {
         messages: [{ role: 'user', content: 'test' }],
       },
       extraHeaders: {},
-      provider: PROVIDERS.OPENROUTER,
+      provider: OPENROUTER,
     });
 
     expect(result.type).toBe('error');
@@ -392,7 +392,7 @@ describe('upstreamRequest timeout', () => {
       },
       extraHeaders: { 'x-safe-extra-header': 'extra-header-secret' },
       provider: {
-        ...PROVIDERS.OPENROUTER,
+        ...OPENROUTER,
         apiUrl: 'https://gateway.example.test/v1?token=url-secret',
         apiKey: 'provider-api-key-secret',
       },


### PR DESCRIPTION
## Summary
- replace the enumerable provider definitions dictionary with separate named provider exports
- replace runtime dictionary scans with an explicit `getProviderById` switch
- update consumers to import only the providers they use

This prevents callers from treating the module as a complete or semantically meaningful provider registry.

## Testing
- CI only
- formatting and `git diff --check` completed locally