### PR TITLE
fix(kilo-pass): stop App Store purchases that cannot be honored

### DIFF
--- a/apps/mobile/src/components/kilo-pass/kilo-pass-native-iap-owner.tsx
+++ b/apps/mobile/src/components/kilo-pass/kilo-pass-native-iap-owner.tsx
@@ -92,6 +92,12 @@ export type KiloPassNativeIapContextValue = {
   clearError: () => void;
   /** True when the App Store account already owns a pass on another Kilo account. */
   ownedByAnotherAccount: boolean;
+  /** Apple product ID of a Kilo Pass this device already owns, if any. */
+  ownedAppleProductId: string | null;
+  /** Original transaction ID of that owned purchase, for server-side preflight. */
+  ownedOriginalTransactionId: string | null;
+  /** False until StoreKit has answered once with what this device owns. */
+  ownershipChecked: boolean;
 };
 
 const KiloPassNativeIapContext = createContext<KiloPassNativeIapContextValue | null>(null);
@@ -120,6 +126,7 @@ export function KiloPassNativeIapOwner({ children }: { children: ReactNode }) {
   const clearError = useCallback(() => {
     setErrorMessage(null);
   }, []);
+  const [ownershipChecked, setOwnershipChecked] = useState(false);
   const recoveredPurchaseIdsRef = useRef(new Set<string>());
   const recoveryInFlightPurchaseIdsRef = useRef(new Set<string>());
   const activePurchaseRequestRef = useRef<{ sku: string } | null>(null);
@@ -154,6 +161,12 @@ export function KiloPassNativeIapOwner({ children }: { children: ReactNode }) {
       }
 
       if (activePurchaseRequestRef.current?.sku !== purchase.productId) {
+        // StoreKit answered the in-flight request with a transaction for another
+        // SKU (an upgrade it refused re-delivers the current subscription), and no
+        // purchase error follows. Release the request or the screen keeps its
+        // "Completing purchase" state forever. The recovery effect below still
+        // completes this transaction if it is not yet linked.
+        releasePurchaseRequest();
         return;
       }
 
@@ -172,6 +185,10 @@ export function KiloPassNativeIapOwner({ children }: { children: ReactNode }) {
     finishTransaction,
     requestPurchase,
     restorePurchases: restoreStorePurchases,
+    // The hook's own fetch is the only one that publishes into `availablePurchases`.
+    // The module-level `getAvailablePurchases` returns the list without touching
+    // hook state, which left every ownership check blind until a manual restore.
+    getAvailablePurchases: refreshAvailablePurchases,
   } = actionsRef;
 
   // Server-backed fallback for the recovery SKU list: when the StoreKit fetch
@@ -188,6 +205,21 @@ export function KiloPassNativeIapOwner({ children }: { children: ReactNode }) {
     }
     return serverProductsQuery.data?.products.map(product => product.appleProductId) ?? [];
   }, [productsQuery.products, serverProductsQuery.data]);
+
+  const ownedPurchase = useMemo(() => {
+    if (Platform.OS !== 'ios') {
+      return null;
+    }
+    return (
+      availablePurchases.find(purchase =>
+        isRecoverableKiloPassPurchase(purchase, enabledAppleProductIds)
+      ) ?? null
+    );
+  }, [availablePurchases, enabledAppleProductIds]);
+  const ownedAppleProductId = ownedPurchase?.productId ?? null;
+  const ownedOriginalTransactionId =
+    (ownedPurchase as { originalTransactionIdentifierIOS?: string | null } | null)
+      ?.originalTransactionIdentifierIOS ?? null;
 
   const ownedByAnotherAccount = useMemo(
     () =>
@@ -300,12 +332,25 @@ export function KiloPassNativeIapOwner({ children }: { children: ReactNode }) {
   }, [authEpoch, queryClient]);
 
   useEffect(() => {
+    if (Platform.OS !== 'ios') {
+      setOwnershipChecked(true);
+      return;
+    }
     if (!connected) {
       return;
     }
 
-    void getAvailableIapPurchases();
-  }, [connected]);
+    void (async () => {
+      try {
+        await refreshAvailablePurchases();
+      } finally {
+        // Purchases are only known after StoreKit answers. Until then the screen
+        // must not start a purchase: a device subscription owned by another Kilo
+        // account would otherwise charge the user before any check can see it.
+        setOwnershipChecked(true);
+      }
+    })();
+  }, [connected, refreshAvailablePurchases]);
 
   useEffect(() => {
     if (availablePurchases.length === 0 || enabledAppleProductIds.length === 0) {
@@ -356,6 +401,9 @@ export function KiloPassNativeIapOwner({ children }: { children: ReactNode }) {
       errorMessage,
       clearError,
       ownedByAnotherAccount,
+      ownedAppleProductId,
+      ownedOriginalTransactionId,
+      ownershipChecked,
     }),
     [
       clearError,
@@ -363,7 +411,10 @@ export function KiloPassNativeIapOwner({ children }: { children: ReactNode }) {
       errorMessage,
       isRequestingPurchase,
       isRestoringPurchases,
+      ownedAppleProductId,
       ownedByAnotherAccount,
+      ownedOriginalTransactionId,
+      ownershipChecked,
       productsQuery.errorMessage,
       productsQuery.isLoading,
       productsQuery.isRefetching,

--- a/apps/mobile/src/components/kilo-pass/kilo-pass-subscription-screen.test.ts
+++ b/apps/mobile/src/components/kilo-pass/kilo-pass-subscription-screen.test.ts
@@ -34,6 +34,9 @@ const mocks = vi.hoisted(() => ({
     productsRefetch: vi.fn(),
     purchase: vi.fn(),
     ownedByAnotherAccount: false,
+    ownedAppleProductId: null as string | null,
+    ownedOriginalTransactionId: null as string | null,
+    ownershipChecked: true,
   },
   routerPush: vi.fn(),
 }));
@@ -65,6 +68,7 @@ vi.mock('@tanstack/react-query', () => ({
     isPending: mocks.preflightIsPending,
   }),
   useQuery: () => mocks.presentation,
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
 }));
 
 vi.mock('@/components/detail-screen', () => ({
@@ -244,6 +248,9 @@ function setNativeIapPresentation(): void {
   mockedPlatform.OS = 'ios';
   mocks.presentation.data = { kind: 'native_iap', webUrl: null };
   mocks.nativeIap.productsIsLoading = false;
+  mocks.nativeIap.ownedAppleProductId = null;
+  mocks.nativeIap.ownedOriginalTransactionId = null;
+  mocks.nativeIap.ownershipChecked = true;
 }
 
 // ── Tests ────────────────────────────────────────────────────────────
@@ -291,8 +298,47 @@ describe('KiloPassSubscriptionScreen', () => {
       storefront: 'app_store',
       product: 'kilo_pass',
       appleProductId: product.appleProductId,
+      appleOriginalTransactionId: null,
     });
     expect(mocks.nativeIap.purchase).toHaveBeenCalledTimes(1);
+
+    renderer.unmount();
+  });
+
+  it('blocked: tiles stay disabled until StoreKit reports what this device owns', async () => {
+    setNativeIapPresentation();
+    mocks.nativeIap.products = [product];
+    mocks.nativeIap.ownershipChecked = false;
+
+    const renderer = await renderScreen();
+    const tiles = productTiles(renderer);
+    expect((first(tiles).props as { disabled?: boolean }).disabled).toBe(true);
+
+    renderer.unmount();
+  });
+
+  it('sends the owned original transaction id to preflight', async () => {
+    setNativeIapPresentation();
+    mocks.nativeIap.products = [product];
+    mocks.nativeIap.ownedAppleProductId = product.appleProductId;
+    mocks.nativeIap.ownedOriginalTransactionId = 'orig-123';
+    mocks.preflightMutateAsync.mockResolvedValue({
+      allowed: false,
+      statusClass: 'terminal',
+      reason: 'owned_by_another_account',
+    });
+
+    const renderer = await renderScreen();
+    await press(first(productTiles(renderer)));
+
+    expect(mocks.preflightMutateAsync).toHaveBeenCalledWith({
+      platform: 'ios',
+      storefront: 'app_store',
+      product: 'kilo_pass',
+      appleProductId: product.appleProductId,
+      appleOriginalTransactionId: 'orig-123',
+    });
+    expect(mocks.nativeIap.purchase).not.toHaveBeenCalled();
 
     renderer.unmount();
   });

--- a/apps/mobile/src/components/kilo-pass/kilo-pass-subscription-screen.tsx
+++ b/apps/mobile/src/components/kilo-pass/kilo-pass-subscription-screen.tsx
@@ -4,7 +4,7 @@ import { useRouter } from 'expo-router';
 import { useEffect, useRef, useState } from 'react';
 import { ActivityIndicator, Platform, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
-import { useMutation, useQuery } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 
 import { DetailScreenScrollView } from '@/components/detail-screen';
 import { ScreenHeader } from '@/components/screen-header';
@@ -38,7 +38,7 @@ type SubscriptionScreenFeedback = { type: 'success' | 'info' | 'error'; text: st
 
 /** Shown when the App Store account already owns a pass on another Kilo account. */
 export const KILO_PASS_OTHER_ACCOUNT_COPY =
-  'This App Store subscription belongs to another Kilo account. Sign in to that account to manage it.';
+  'The Kilo Pass on this Apple Account belongs to a different Kilo account. Sign in to that Kilo account to manage it.';
 
 /**
  * A failed preflight is either retryable (transient network/5xx) or
@@ -48,6 +48,16 @@ export const KILO_PASS_OTHER_ACCOUNT_COPY =
 type PreflightFailure =
   | { kind: 'retryable'; message: string; product: AppStoreKiloPassProduct }
   | { kind: 'nonRetryable'; message: string };
+
+function getPreflightFailureMessage(reason: string | null): string {
+  if (reason === 'already_subscribed') {
+    return 'You already have a Kilo Pass subscription.';
+  }
+  if (reason === 'owned_by_another_account') {
+    return KILO_PASS_OTHER_ACCOUNT_COPY;
+  }
+  return 'Kilo Pass purchase is not available right now.';
+}
 
 function formatTier(product: AppStoreKiloPassProduct): string {
   return `$${product.webMonthlyPriceUsd} in credits`;
@@ -164,9 +174,20 @@ function KiloPassNativeIapContent() {
     productsRefetch,
     purchase,
     ownedByAnotherAccount,
+    ownedAppleProductId,
+    ownedOriginalTransactionId,
+    ownershipChecked,
   } = useKiloPassNativeIap();
   useInlinePurchaseErrorOwnership();
+  const queryClient = useQueryClient();
   const preflightPurchase = useMutation(trpc.kiloPass.preflightPurchase.mutationOptions());
+  const invalidateAfterManagement = async () => {
+    await Promise.all([
+      queryClient.invalidateQueries(trpc.kiloPass.getState.pathFilter()),
+      queryClient.invalidateQueries(trpc.user.getContextBalance.pathFilter()),
+      queryClient.invalidateQueries(trpc.kiloPass.getPurchasePresentation.pathFilter()),
+    ]);
+  };
   const [restoreFeedback, setRestoreFeedback] = useState<SubscriptionScreenFeedback | null>(null);
   const [preflightFailure, setPreflightFailure] = useState<PreflightFailure | null>(null);
   let feedback: SubscriptionScreenFeedback | null = restoreFeedback;
@@ -180,7 +201,11 @@ function KiloPassNativeIapContent() {
   const preflightBlocked = preflightFailure?.kind === 'nonRetryable';
   const isRetryDisabled = isPending || productsIsRefetching;
   const tilesDisabled =
-    isPending || preflightBlocked || preflightPurchase.isPending || ownedByAnotherAccount;
+    isPending ||
+    preflightBlocked ||
+    preflightPurchase.isPending ||
+    ownedByAnotherAccount ||
+    !ownershipChecked;
   const [privacyPolicyLink, termsOfUseLink] = getKiloPassLegalLinks(WEB_BASE_URL);
   const mountedRef = useRef(true);
   useEffect(() => {
@@ -206,6 +231,7 @@ function KiloPassNativeIapContent() {
         storefront: 'app_store',
         product: 'kilo_pass',
         appleProductId: product.appleProductId,
+        appleOriginalTransactionId: ownedOriginalTransactionId,
       });
     } catch {
       setPreflightFailure({
@@ -219,10 +245,7 @@ function KiloPassNativeIapContent() {
     if (!preflight.allowed) {
       setPreflightFailure({
         kind: 'nonRetryable',
-        message:
-          preflight.reason === 'already_subscribed'
-            ? 'You already have a Kilo Pass subscription.'
-            : 'Kilo Pass purchase is not available right now.',
+        message: getPreflightFailureMessage(preflight.reason),
       });
       return;
     }
@@ -240,6 +263,18 @@ function KiloPassNativeIapContent() {
 
   const handleProductPress = (product: AppStoreKiloPassProduct) => {
     void Haptics.selectionAsync();
+
+    // Apple owns tier changes inside a subscription group: requesting another SKU
+    // while this device already owns one is refused by StoreKit, and the app cannot
+    // show the proration Apple applies. Send those taps to App Store management.
+    if (ownedAppleProductId && ownedAppleProductId !== product.appleProductId) {
+      void (async () => {
+        const { openAppStoreManagement } = await import('./kilo-pass-ios-manage');
+        await openAppStoreManagement({ invalidateAfter: invalidateAfterManagement });
+      })();
+      return;
+    }
+
     void runPreflight(product);
   };
 
@@ -347,6 +382,7 @@ function KiloPassNativeIapContent() {
             onResult={result => {
               if (result === 'restored') {
                 setRestoreFeedback({ type: 'success', text: 'Subscription restored.' });
+                ensureProfileAfterKiloPassPurchase(router);
               } else if (result === 'empty') {
                 setRestoreFeedback({ type: 'info', text: 'No purchases to restore.' });
               } else {

--- a/apps/mobile/src/components/profile-credits-card.mounted.test.tsx
+++ b/apps/mobile/src/components/profile-credits-card.mounted.test.tsx
@@ -22,6 +22,11 @@ const balanceQuery = vi.hoisted(() => ({
 vi.mock('@tanstack/react-query', () => ({
   keepPreviousData: (value: unknown) => value,
   useQuery: () => balanceQuery,
+  useQueryClient: () => ({ invalidateQueries: vi.fn() }),
+}));
+
+vi.mock('expo-router', () => ({
+  useFocusEffect: () => undefined,
 }));
 
 vi.mock('@/lib/trpc', () => ({

--- a/apps/mobile/src/components/profile-credits-card.tsx
+++ b/apps/mobile/src/components/profile-credits-card.tsx
@@ -1,6 +1,8 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { formatDollars, fromMicrodollars } from '@kilocode/app-shared/utils';
-import { keepPreviousData, useQuery } from '@tanstack/react-query';
+import { keepPreviousData, useQuery, useQueryClient } from '@tanstack/react-query';
+import { useFocusEffect } from 'expo-router';
+import { useCallback, useRef } from 'react';
 import { ChevronDown } from '@/components/ui/icons';
 import { ActivityIndicator, Platform, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
@@ -29,6 +31,24 @@ export function CreditsCard({ enabled, orgs }: Readonly<CreditsCardProps>) {
   const { bottom } = useSafeAreaInsets();
   const { organizationId, setOrganizationId } = useOrganization();
   const selectedOrgId = organizationId ?? undefined;
+  const queryClient = useQueryClient();
+
+  // Credits and pass state also change from webhooks (renewal, refund, expiry),
+  // which no client action invalidates. Refetching when the tab regains focus
+  // catches those without polling in the background. The first focus is the
+  // mount fetch, so it is skipped.
+  const tabFocusedBeforeRef = useRef(false);
+  useFocusEffect(
+    useCallback(() => {
+      if (!tabFocusedBeforeRef.current) {
+        tabFocusedBeforeRef.current = true;
+        return;
+      }
+      void queryClient.invalidateQueries(trpc.user.getContextBalance.pathFilter());
+      void queryClient.invalidateQueries(trpc.user.getCreditBlocks.pathFilter());
+      void queryClient.invalidateQueries(trpc.kiloPass.getState.pathFilter());
+    }, [queryClient, trpc])
+  );
 
   const {
     data: balance,

--- a/apps/mobile/src/lib/kilo-pass/subscription-card-state.ts
+++ b/apps/mobile/src/lib/kilo-pass/subscription-card-state.ts
@@ -83,13 +83,17 @@ export function getAppStoreKiloPassOwnershipPreflight(params: {
   }
 
   const enabledAppleProductIds = new Set(params.enabledAppleProductIds);
+  // StoreKit returns `Transaction.appAccountToken` as an uppercase `UUID.uuidString`,
+  // while the backend stores the lowercase Postgres uuid. Compare case-insensitively
+  // or every restore on a device that already owns the pass reads as another owner.
+  const currentAppAccountToken = params.currentAppAccountToken.toLowerCase();
   const hasDifferentOwnerPurchase = params.availablePurchases.some(
     purchase =>
       purchase.store === 'apple' &&
       purchase.purchaseState !== 'pending' &&
       enabledAppleProductIds.has(purchase.productId) &&
       Boolean(purchase.appAccountToken) &&
-      purchase.appAccountToken !== params.currentAppAccountToken
+      purchase.appAccountToken?.toLowerCase() !== currentAppAccountToken
   );
 
   return hasDifferentOwnerPurchase ? 'owned-by-another-account' : null;

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.test.tsx
@@ -468,7 +468,7 @@ describe('createAppStoreKiloPassPurchaseActions', () => {
 
     expect(showError).toHaveBeenCalledTimes(1);
     expect(showError).toHaveBeenCalledWith(
-      'This App Store subscription is linked to another Kilo account.'
+      'The Kilo Pass on this Apple Account belongs to a different Kilo account.'
     );
   });
 
@@ -805,7 +805,7 @@ describe('createAppStoreKiloPassPurchaseActions', () => {
 
     expect(result).toBe('failed');
     expect(showError).toHaveBeenCalledWith(
-      'This App Store subscription is linked to another Kilo account.'
+      'The Kilo Pass on this Apple Account belongs to a different Kilo account.'
     );
   });
 
@@ -836,7 +836,7 @@ describe('createAppStoreKiloPassPurchaseActions', () => {
 
     expect(restoreResult).toBe('failed');
     expect(showError).toHaveBeenCalledWith(
-      'This App Store subscription is linked to another Kilo account.'
+      'The Kilo Pass on this Apple Account belongs to a different Kilo account.'
     );
   });
 

--- a/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
+++ b/apps/mobile/src/lib/kilo-pass/use-store-kilo-pass-purchase.ts
@@ -24,9 +24,9 @@ const APP_STORE_ACCOUNT_TOKEN_MISMATCH_MESSAGE =
 const APP_STORE_PURCHASE_NOT_LINKED_TO_ACCOUNT_MESSAGE =
   "This App Store purchase isn't linked to your Kilo account. Make sure you're signed in to the Apple ID that made the purchase, then try again.";
 const APP_STORE_SUBSCRIPTION_OWNED_BY_ANOTHER_ACCOUNT_MESSAGE =
-  'This App Store subscription is linked to another Kilo account.';
+  'The Kilo Pass on this Apple Account belongs to a different Kilo account.';
 const APP_STORE_PURCHASE_NOT_LINKED_USER_MESSAGE =
-  "This App Store purchase isn't linked to your Kilo account. Sign in to the Apple ID used for the purchase, then try again.";
+  "This App Store purchase isn't linked to your Kilo account. Sign in to the Apple Account used for the purchase, then try again.";
 const PURCHASE_ERROR_TOAST_DEDUPE_MS = 1500;
 const RESTORE_PURCHASES_ERROR_MESSAGE = 'Failed to restore purchases. Try again.';
 

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.test.ts
@@ -1255,7 +1255,7 @@ describe('processAppStoreKiloPassNotification', () => {
     );
   });
 
-  it('reverses the Apple paid base amount plus issued bonus and promo credits for the refunded issuance', async () => {
+  it('reverses the granted base amount plus issued bonus and promo credits for the refunded issuance', async () => {
     const user = await insertTestUser();
     const decodedTransaction = transaction({
       appAccountToken: user.app_store_account_token,
@@ -1383,7 +1383,7 @@ describe('processAppStoreKiloPassNotification', () => {
     expect(creditTransactions).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          amountMicrodollars: -toMicrodollars(24.7),
+          amountMicrodollars: -toMicrodollars(19),
           description: 'App Store Kilo Pass refund clawback',
         }),
         expect.objectContaining({
@@ -1396,18 +1396,13 @@ describe('processAppStoreKiloPassNotification', () => {
         }),
       ])
     );
-    expect(creditTransactions).not.toEqual(
-      expect.arrayContaining([
-        expect.objectContaining({
-          amountMicrodollars: -toMicrodollars(19),
-        }),
-      ])
-    );
 
+    // Granted credits are reversed in full, so the refund leaves the acquired
+    // total exactly where it started rather than minus the App Store margin.
     const updatedUser = await db.query.kilocode_users.findFirst({
       where: eq(kilocode_users.id, user.id),
     });
-    expect(updatedUser?.total_microdollars_acquired).toBe(-toMicrodollars(5.7));
+    expect(updatedUser?.total_microdollars_acquired).toBe(0);
   });
 
   it('scopes App Store refund reversals to the refunded transaction after a same-month upgrade', async () => {
@@ -1862,7 +1857,7 @@ describe('processAppStoreKiloPassNotification', () => {
       refundTransaction: { currency: 'USD', price: 0 },
     },
   ])(
-    'ends subscription and writes processed_at even when USD refund price is invalid ($name)',
+    'reverses the granted base amount regardless of the reported refund price ($name)',
     async ({ name, refundTransaction }) => {
       const user = await insertTestUser();
       const decodedTransaction = transaction({
@@ -1902,7 +1897,11 @@ describe('processAppStoreKiloPassNotification', () => {
         .select()
         .from(credit_transactions)
         .where(eq(credit_transactions.kilo_user_id, user.id));
-      expect(negativeCreditTransactions.filter(row => row.amount_microdollars < 0)).toHaveLength(0);
+      expect(
+        negativeCreditTransactions
+          .filter(row => row.amount_microdollars < 0)
+          .map(row => row.amount_microdollars)
+      ).toEqual([-toMicrodollars(19)]);
 
       const refundEvent = await db.query.kilo_pass_store_events.findFirst({
         where: eq(kilo_pass_store_events.event_id, refundNotificationUUID),

--- a/apps/web/src/lib/kilo-pass/apple-store-notifications.ts
+++ b/apps/web/src/lib/kilo-pass/apple-store-notifications.ts
@@ -389,23 +389,6 @@ function getRefundReversalDescription(kind: KiloPassIssuanceItemKind): string {
   return 'App Store Kilo Pass promo refund clawback';
 }
 
-function getAppleTransactionPriceMicrodollars(
-  transaction: AppleStoreDecodedTransaction
-): number | null {
-  if (transaction.currency !== 'USD') {
-    return null;
-  }
-  if (
-    typeof transaction.price !== 'number' ||
-    !Number.isFinite(transaction.price) ||
-    transaction.price <= 0
-  ) {
-    throw new Error('App Store refund transaction is missing a valid price');
-  }
-
-  return transaction.price * 1_000;
-}
-
 function getAppStoreProviderPaymentId(providerTransactionId: string): string {
   return `kilo-pass:${KiloPassPaymentProvider.AppStore}:${providerTransactionId}`;
 }
@@ -445,7 +428,6 @@ async function reverseAppStoreRefundCredits(
     throw new Error('App Store refund cannot find the subscribed user');
   }
 
-  const usdPriceMicrodollars = getAppleTransactionPriceMicrodollars(transaction);
   const ownedBaseCreditRows = await tx
     .select({
       creditTransactionId: credit_transactions.id,
@@ -472,28 +454,6 @@ async function reverseAppStoreRefundCredits(
 
   const ownedBaseCredit = ownedBaseCreditRows[0] ?? null;
 
-  let baseReversalMicrodollars: number | null;
-  if (usdPriceMicrodollars !== null) {
-    baseReversalMicrodollars = usdPriceMicrodollars;
-  } else if (ownedBaseCredit !== null) {
-    baseReversalMicrodollars = ownedBaseCredit.amountMicrodollars;
-  } else {
-    baseReversalMicrodollars = null;
-    captureException(
-      new Error(
-        'App Store non-USD refund: no stored purchase amount found, skipping base clawback'
-      ),
-      {
-        tags: { area: 'kilo-pass', operation: 'reverse-app-store-refund-credits' },
-        extra: {
-          transactionId: transaction.transactionId,
-          originalTransactionId: transaction.originalTransactionId,
-          currency: transaction.currency ?? null,
-        },
-      }
-    );
-  }
-
   const issueMonth = dayjs(storePurchase.purchased_at).utc().format('YYYY-MM-01');
   const issuance = await tx.query.kilo_pass_issuances.findFirst({
     where: and(
@@ -509,7 +469,7 @@ async function reverseAppStoreRefundCredits(
     isFree: boolean;
   }[] = [];
 
-  if (ownedBaseCredit && baseReversalMicrodollars !== null) {
+  if (ownedBaseCredit) {
     issuedItems.push({
       itemId: ownedBaseCredit.creditTransactionId,
       kind: KiloPassIssuanceItemKind.Base,
@@ -574,10 +534,10 @@ async function reverseAppStoreRefundCredits(
   const reversedItemKinds: KiloPassIssuanceItemKind[] = [];
   let totalReversalMicrodollars = 0;
   for (const item of issuedItems) {
-    const reversalAmountMicrodollars =
-      item.kind === KiloPassIssuanceItemKind.Base
-        ? (baseReversalMicrodollars ?? item.amountMicrodollars)
-        : item.amountMicrodollars;
+    // Reverse what Kilo granted, never the App Store price. Apple returns the full
+    // charge to the customer and reverses its own commission, so clawing back the
+    // store price would leave a customer who spent nothing at minus the store margin.
+    const reversalAmountMicrodollars = item.amountMicrodollars;
 
     if (reversalAmountMicrodollars <= 0) {
       continue;

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -161,6 +161,7 @@ type KiloPassCaller = {
     product: 'credits' | 'kilo_pass';
     program?: string | null;
     appleProductId: string;
+    appleOriginalTransactionId?: string | null;
   }) => Promise<{
     allowed: boolean;
     statusClass: 'healthy' | 'pending' | 'retryable' | 'terminal' | 'inactive';
@@ -170,6 +171,7 @@ type KiloPassCaller = {
       | 'unsupported_combination'
       | 'unknown_product'
       | 'already_subscribed'
+      | 'owned_by_another_account'
       | null;
   }>;
   completeAppStorePurchase: (input: {
@@ -1082,6 +1084,87 @@ describe('kiloPassRouter', () => {
         storefront: 'app_store',
         product: 'kilo_pass',
         appleProductId: 'kilopass.tier19.monthly.v1',
+      });
+
+      expect(result).toEqual({ allowed: true, statusClass: 'healthy', reason: null });
+    });
+
+    it("blocks a purchase when this device's subscription belongs to another Kilo account", async () => {
+      const owner = await insertTestUser();
+      const buyer = await insertTestUser();
+      const providerSubscriptionId = `orig_${crypto.randomUUID()}`;
+      const { id: subscriptionId } = await insertSubscription({
+        kiloUserId: owner.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+        paymentProvider: KiloPassPaymentProvider.AppStore,
+        providerSubscriptionId,
+      });
+      await db.insert(kilo_pass_store_purchases).values({
+        kilo_pass_subscription_id: subscriptionId,
+        kilo_user_id: owner.id,
+        payment_provider: KiloPassPaymentProvider.AppStore,
+        product_id: 'kilopass.tier19.monthly.v1',
+        provider_subscription_id: providerSubscriptionId,
+        provider_transaction_id: `tx_${crypto.randomUUID()}`,
+        provider_original_transaction_id: providerSubscriptionId,
+        app_account_token: owner.app_store_account_token,
+        environment: 'Sandbox',
+        purchased_at: '2026-01-01T00:00:00.000Z',
+        expires_at: '2026-02-01T00:00:00.000Z',
+        raw_payload_json: {},
+      });
+
+      const caller = await createCallerForUser(buyer.id);
+      const result = await caller.kiloPass.preflightPurchase({
+        platform: 'ios',
+        storefront: 'app_store',
+        product: 'kilo_pass',
+        appleProductId: 'kilopass.tier19.monthly.v1',
+        appleOriginalTransactionId: providerSubscriptionId,
+      });
+
+      expect(result).toEqual({
+        allowed: false,
+        statusClass: 'terminal',
+        reason: 'owned_by_another_account',
+      });
+    });
+
+    it('allows the owning account to buy with its own device transaction', async () => {
+      const owner = await insertTestUser();
+      const providerSubscriptionId = `orig_${crypto.randomUUID()}`;
+      const { id: subscriptionId } = await insertSubscription({
+        kiloUserId: owner.id,
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'canceled',
+        paymentProvider: KiloPassPaymentProvider.AppStore,
+        providerSubscriptionId,
+      });
+      await db.insert(kilo_pass_store_purchases).values({
+        kilo_pass_subscription_id: subscriptionId,
+        kilo_user_id: owner.id,
+        payment_provider: KiloPassPaymentProvider.AppStore,
+        product_id: 'kilopass.tier19.monthly.v1',
+        provider_subscription_id: providerSubscriptionId,
+        provider_transaction_id: `tx_${crypto.randomUUID()}`,
+        provider_original_transaction_id: providerSubscriptionId,
+        app_account_token: owner.app_store_account_token,
+        environment: 'Sandbox',
+        purchased_at: '2026-01-01T00:00:00.000Z',
+        expires_at: '2026-02-01T00:00:00.000Z',
+        raw_payload_json: {},
+      });
+
+      const caller = await createCallerForUser(owner.id);
+      const result = await caller.kiloPass.preflightPurchase({
+        platform: 'ios',
+        storefront: 'app_store',
+        product: 'kilo_pass',
+        appleProductId: 'kilopass.tier19.monthly.v1',
+        appleOriginalTransactionId: providerSubscriptionId,
       });
 
       expect(result).toEqual({ allowed: true, statusClass: 'healthy', reason: null });

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -1038,6 +1038,11 @@ const PreflightPurchaseInputSchema = z.object({
   product: PurchaseProductSchema,
   program: z.string().max(64).nullable().optional(),
   appleProductId: z.string().min(1),
+  /**
+   * Original transaction ID of a Kilo Pass this device already owns, when StoreKit
+   * reports one. Untrusted: it can only deny a purchase, never grant one.
+   */
+  appleOriginalTransactionId: z.string().min(1).max(64).nullable().optional(),
 });
 
 const PurchasePresentationCtaOutputSchema = z.object({
@@ -1070,6 +1075,7 @@ const PreflightPurchaseOutputSchema = z.object({
       'unsupported_combination',
       'unknown_product',
       'already_subscribed',
+      'owned_by_another_account',
     ])
     .nullable(),
 });
@@ -1237,6 +1243,22 @@ export const kiloPassRouter = createTRPCRouter({
 
       if (!getMobileStoreKiloPassProductByAppleProductId(input.appleProductId)) {
         return { allowed: false, statusClass: 'terminal', reason: 'unknown_product' };
+      }
+
+      // Refuse before StoreKit is invoked when this device's subscription belongs to
+      // another Kilo account. The client-side check races the StoreKit purchase list,
+      // and losing that race charges the user for a purchase the server then rejects.
+      if (input.appleOriginalTransactionId) {
+        const devicePurchase = await readDb.query.kilo_pass_store_purchases.findFirst({
+          columns: { kilo_user_id: true },
+          where: and(
+            eq(kilo_pass_store_purchases.payment_provider, KiloPassPaymentProvider.AppStore),
+            eq(kilo_pass_store_purchases.provider_subscription_id, input.appleOriginalTransactionId)
+          ),
+        });
+        if (devicePurchase && devicePurchase.kilo_user_id !== ctx.user.id) {
+          return { allowed: false, statusClass: 'terminal', reason: 'owned_by_another_account' };
+        }
       }
 
       const hasLiveOtherProviderSub =


### PR DESCRIPTION
Found while testing App Store Kilo Pass end to end on a simulator with a local StoreKit configuration. Six defects, two of which cost real money.

## What was broken

**A user could be charged for a purchase the backend then refuses.** The IAP owner refreshed StoreKit ownership through the module-level `getAvailablePurchases`, which returns the list without publishing into the hook's `availablePurchases` state. Every ownership check was therefore blind until a manual restore, so the guard never ran on a cold start. Signing into a second Kilo account and tapping a tier created a real StoreKit transaction, the server rejected it with `Store subscription already belongs to another user`, and because completion failed the app never called `finishTransaction` — the transaction stays open and retries forever. Only an Apple refund returns the money.

**A legitimate owner was told their subscription belonged to someone else.** StoreKit returns `Transaction.appAccountToken` as an uppercase `UUID.uuidString`; the database stores the lowercase Postgres `uuid`. The comparison was case-sensitive, so any user restoring on a device that already owned the pass hit "belongs to another Kilo account" with the tier tiles disabled — purchase and restore both blocked.

**A refused tier change hung the screen permanently.** StoreKit answers a cross-SKU request by re-delivering the current subscription. The SKU guard dropped that transaction without releasing the pending state, leaving "Completing purchase" on screen until the app was killed.

**A refund took more than it gave.** The clawback reversed the App Store price rather than the credits granted, so a refunded customer who never spent a cent landed at minus the store margin (-$14.70 on the $49 tier) and had to top that up before any credit worked.

## Changes

- Refresh ownership through the hook fetch that publishes into `availablePurchases`.
- Keep tier tiles disabled until StoreKit reports what the device owns.
- Send the device's original transaction ID to `preflightPurchase`, which now refuses with `owned_by_another_account` before StoreKit is invoked. Three layers now cover this: gated tiles, server preflight, and the existing completion check.
- Compare app account tokens case-insensitively.
- Release the purchase request when StoreKit answers with another SKU, and route tier changes to App Store management, where Apple owns proration.
- Close the purchase screen after a successful restore, as a purchase already does.
- Reverse granted credits on refund instead of the store price.
- Refetch credits and pass state when the profile tab regains focus, so webhook-driven changes (renewal, refund, expiry) do not sit stale on an open screen.
- Clearer ownership copy: "The Kilo Pass on this Apple Account belongs to a different Kilo account."

## Verified on a simulator

Purchase, restore, restore idempotency, same-month and next-month renewal, renewal replay, auto-renew off/on, `DID_FAIL_TO_RENEW`, `EXPIRED`, refund clawback (now $0 balance instead of -$14.70), and a second Kilo account blocked at all three layers.

## Not covered here

Apple signature verification, App Store Server Notifications, and tier upgrade/downgrade need a physical device with a sandbox tester — Xcode's local StoreKit refuses tier changes and does not sign transactions.