### PR TITLE
refactor(ai-gateway): pass provider to usage processing

### DIFF
--- a/apps/web/src/app/api/dev/consume-credits/route.ts
+++ b/apps/web/src/app/api/dev/consume-credits/route.ts
@@ -97,8 +97,8 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
       ttfb_ms: null,
     };
 
-    // Use the existing countAndStoreUsage function
-    await countAndStoreUsage(mockResponse, usageContext, undefined);
+    // Synthetic usage has no upstream provider or generation to fetch.
+    await countAndStoreUsage(mockResponse, usageContext, undefined, undefined);
 
     // Reset the balance cache using the proper function
     await forceImmediateExpirationRecomputation(kiloUserId);

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -365,6 +365,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
         responseTransforms: null,
       })
     );
+    expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[3]).toBe(provider);
   });
 
   it('passes provider response transforms to the response rewriter', async () => {
@@ -1203,6 +1204,7 @@ describe('percentage-routed partner fallback', () => {
         provider: sourceProvider.id,
         status_code: 200,
       });
+      expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[3]).toBe(sourceProvider);
       expect(mockedRewriteModelResponse).toHaveBeenCalledWith(
         expect.objectContaining({ providerId: sourceProvider.id })
       );
@@ -1269,6 +1271,7 @@ describe('percentage-routed partner fallback', () => {
     expect(response.status).toBe(200);
     expect(mockedUpstreamRequest).toHaveBeenCalledTimes(1);
     expect(mockedUpstreamRequest.mock.calls[0]?.[0].provider).toBe(partnerProvider);
+    expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[3]).toBe(partnerProvider);
   });
 
   it('returns a failed managed fallback without a third attempt', async () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -1087,7 +1087,12 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     usageContext.abuse_request_id = classifyResult.request_id;
   }
 
-  accountForMicrodollarUsage(clonedReponse, usageContext, openrouterRequestSpan);
+  accountForMicrodollarUsage(
+    clonedReponse,
+    usageContext,
+    openrouterRequestSpan,
+    effectiveProviderContext.provider
+  );
 
   const requestLogging = {
     user: maybeUser,

--- a/apps/web/src/app/api/openrouter/audio/transcriptions/route.test.ts
+++ b/apps/web/src/app/api/openrouter/audio/transcriptions/route.test.ts
@@ -4,6 +4,8 @@ import { getBalanceAndOrgSettings } from '@/lib/organizations/organization-usage
 import type { User } from '@kilocode/db/schema';
 import { emitApiMetricsForResponse } from '@/lib/ai-gateway/o11y/api-metrics.server';
 import type { OrganizationSettings } from '@/lib/organizations/organization-types';
+import { countAndStoreTranscriptionUsage } from '@/lib/ai-gateway/llm-proxy-helpers';
+import { OPENROUTER } from '@/lib/ai-gateway/providers/provider-definitions';
 
 jest.mock('next/server', () => {
   return {
@@ -28,6 +30,7 @@ jest.mock('@/lib/ai-gateway/llm-proxy-helpers', () => {
 const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
 const mockedGetBalanceAndOrgSettings = jest.mocked(getBalanceAndOrgSettings);
 const mockedEmitApiMetricsForResponse = jest.mocked(emitApiMetricsForResponse);
+const mockedCountAndStoreTranscriptionUsage = jest.mocked(countAndStoreTranscriptionUsage);
 const mockedFetch = jest.fn() as jest.MockedFunction<typeof globalThis.fetch>;
 const originalFetch = globalThis.fetch;
 
@@ -127,6 +130,7 @@ describe('POST /api/gateway/v1/audio/transcriptions', () => {
     expect(upstream.input_audio).toEqual({ data: 'UklGRiQA', format: 'wav' });
     expect(upstream.safety_identifier).toBeTruthy();
     expect(upstream.user).toBe(upstream.safety_identifier);
+    expect(mockedCountAndStoreTranscriptionUsage.mock.calls[0]?.[3]).toBe(OPENROUTER);
     expect(mockedEmitApiMetricsForResponse.mock.calls[0]?.[0]).not.toMatchObject({
       feature: 'vscode-extension',
     });

--- a/apps/web/src/app/api/openrouter/audio/transcriptions/route.ts
+++ b/apps/web/src/app/api/openrouter/audio/transcriptions/route.ts
@@ -267,6 +267,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     });
   }
 
-  countAndStoreTranscriptionUsage(response.clone(), usageContext, span);
+  countAndStoreTranscriptionUsage(response.clone(), usageContext, span, provider);
   return wrapInSafeNextResponse(response);
 }

--- a/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
+++ b/apps/web/src/lib/ai-gateway/llm-proxy-helpers.ts
@@ -42,7 +42,7 @@ import type {
 } from '@/lib/ai-gateway/processUsage.types';
 import { detectContextOverflow } from '@/lib/ai-gateway/context-overflow';
 import { KILO_AUTO_BALANCED_MODEL, KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway/auto-model';
-import type { GatewayChatApiKind, ProviderId } from '@/lib/ai-gateway/providers/types';
+import type { GatewayChatApiKind, Provider, ProviderId } from '@/lib/ai-gateway/providers/types';
 import { computeOpenRouterCostFields } from '@/lib/ai-gateway/processUsage.shared';
 import { persistExperimentAttribution } from '@/lib/ai-gateway/experiments/persist';
 import { ProxyErrorType } from '@/lib/proxy-error-types';
@@ -403,12 +403,13 @@ export function wrapInSafeNextResponse(response: Response) {
 export function accountForMicrodollarUsage(
   clonedReponse: Response,
   usageContext: MicrodollarUsageContext,
-  openrouterRequestSpan: Span | undefined
+  openrouterRequestSpan: Span | undefined,
+  provider: Provider
 ) {
   const logFileExtension = usageContext.isStreaming ? '.log.resp.sse' : '.log.resp.json';
   debugSaveProxyResponseStream(clonedReponse, logFileExtension);
   after(
-    countAndStoreUsage(clonedReponse, usageContext, openrouterRequestSpan).then(
+    countAndStoreUsage(clonedReponse, usageContext, openrouterRequestSpan, provider).then(
       async usageIdentity => {
         // Chain the experiment-attribution write after the microdollar
         // write. This is best-effort analytics: failures here MUST NOT
@@ -1104,7 +1105,8 @@ export function countAndStoreEmbeddingUsage(
 export function countAndStoreTranscriptionUsage(
   clonedResponse: Response,
   usageContext: MicrodollarUsageContext,
-  requestSpan: Span | undefined
+  requestSpan: Span | undefined,
+  provider: Provider
 ) {
   debugSaveProxyResponseStream(clonedResponse, '.log.resp.json');
 
@@ -1130,7 +1132,7 @@ export function countAndStoreTranscriptionUsage(
         return;
       }
 
-      return processTokenData(usageStats, usageContext);
+      return processTokenData(usageStats, usageContext, provider);
     })
   );
 }

--- a/apps/web/src/lib/ai-gateway/processUsage.test.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.test.ts
@@ -266,6 +266,7 @@ describe('parseMicrodollarUsageFromStream approval tests', () => {
           api_kind: apiKind,
           isStreaming: false,
         } as MicrodollarUsageContext,
+        undefined,
         undefined
       )
     ).resolves.toBeNull();

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -16,7 +16,6 @@ import type {
   OpenRouterGeneration,
 } from './providers/openrouter/types';
 import { fetchGeneration } from './providers/upstream-request';
-import { tryGetProviderById } from './providers/provider-definitions';
 import { toMicrodollars } from '../utils';
 import { captureException, captureMessage, startSpan, startInactiveSpan } from '@sentry/nextjs';
 import type { Span } from '@sentry/nextjs';
@@ -31,7 +30,7 @@ import {
 } from '@/lib/organizations/organization-usage';
 import type { OrganizationUsageMutationResult } from '@/lib/organizations/organization-usage';
 import type { DrizzleTransaction } from '@/lib/drizzle';
-import type { ProviderId } from '@/lib/ai-gateway/providers/types';
+import type { Provider, ProviderId } from '@/lib/ai-gateway/providers/types';
 import {
   findKiloExclusiveModel,
   shouldRedactModelNameInMicrodollarUsage,
@@ -934,7 +933,8 @@ async function insertUsageAndMetadataWithBalanceUpdate(
 export function countAndStoreUsage(
   clonedReponse: Response,
   usageContext: MicrodollarUsageContext,
-  openrouterRequestSpan: Span | undefined
+  openrouterRequestSpan: Span | undefined,
+  provider?: Provider
 ) {
   let usageStatsPromise: Promise<MicrodollarUsageStats | null> = Promise.resolve(null);
 
@@ -991,7 +991,7 @@ export function countAndStoreUsage(
     }
   }
 
-  return usageStatsPromise.then(usageStats => processTokenData(usageStats, usageContext));
+  return usageStatsPromise.then(usageStats => processTokenData(usageStats, usageContext, provider));
 }
 
 export function processOpenRouterUsage(
@@ -1219,7 +1219,8 @@ export function calculateKiloExclusiveCost_mUsd(
 
 export async function processTokenData(
   usageStats: MicrodollarUsageStats | null,
-  usageContext: MicrodollarUsageContext
+  usageContext: MicrodollarUsageContext,
+  provider?: Provider
 ): Promise<{ usageId: string; createdAt: string } | null> {
   if (!usageStats) {
     captureMessage('SUSPICIOUS: No usage information', {
@@ -1231,12 +1232,14 @@ export async function processTokenData(
   }
 
   const timer = createTimer();
-  const provider = tryGetProviderById(usageContext.provider);
-  const generation =
-    provider &&
+  let generation: OpenRouterGeneration | undefined;
+  if (
+    provider?.id === usageContext.provider &&
     (await useGenerationLookup(usageStats, usageContext)) &&
-    usageStats.messageId &&
-    (await fetchGeneration(usageStats.messageId, provider));
+    usageStats.messageId
+  ) {
+    generation = await fetchGeneration(usageStats.messageId, provider);
+  }
   if (usageStats.messageId) {
     timer.log(`fetch generation for message ${usageStats.messageId}`);
   }

--- a/apps/web/src/lib/ai-gateway/processUsage.ts
+++ b/apps/web/src/lib/ai-gateway/processUsage.ts
@@ -934,7 +934,7 @@ export function countAndStoreUsage(
   clonedReponse: Response,
   usageContext: MicrodollarUsageContext,
   openrouterRequestSpan: Span | undefined,
-  provider?: Provider
+  provider: Provider | undefined
 ) {
   let usageStatsPromise: Promise<MicrodollarUsageStats | null> = Promise.resolve(null);
 
@@ -1220,7 +1220,7 @@ export function calculateKiloExclusiveCost_mUsd(
 export async function processTokenData(
   usageStats: MicrodollarUsageStats | null,
   usageContext: MicrodollarUsageContext,
-  provider?: Provider
+  provider: Provider | undefined
 ): Promise<{ usageId: string; createdAt: string } | null> {
   if (!usageStats) {
     captureMessage('SUSPICIOUS: No usage information', {


### PR DESCRIPTION
## Summary
- pass the selected provider through chat and transcription usage accounting
- remove the redundant provider ID lookup before generation fetching
- preserve provider-less synthetic credit usage and guard against provider ID mismatches
- cover default, partner, fallback, and transcription provider propagation

## Testing
- CI only, as requested
- `pnpm format:changed`
- `git diff --check`