### PR TITLE
fix(ai-gateway): apply provider policy before Vercel routing

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -316,7 +316,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     const { POST } = await import('./route');
     const response = await POST(makeRequest(makeBody()) as never);
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(await response.json()).toMatchObject({
       error_type: 'abuse_blocked',
       message: 'Request blocked by abuse prevention rules.',

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -417,7 +417,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect(response.status).toBe(200);
     const getRoutingProviderConfig = mockedGetProvider.mock.calls[0]?.[0].getRoutingProviderConfig;
     expect(getRoutingProviderConfig).toBeDefined();
-    expect(await getRoutingProviderConfig?.()).toEqual({ only: ['amazon-bedrock'] });
+    expect(await getRoutingProviderConfig?.()).toMatchObject({ only: ['amazon-bedrock'] });
   });
 
   it('returns 404 when the OpenRouter model id is unknown', async () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -395,6 +395,31 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect(mockedGetBalanceAndOrgSettings.mock.calls[0]?.[2]).toBe(readDb);
   });
 
+  it('selects the provider after applying the organization provider allow-list', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-1',
+    });
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: { provider_allow_list: ['amazon-bedrock'] },
+      plan: 'enterprise',
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('anthropic/claude-sonnet-4.5')) as never);
+
+    expect(response.status).toBe(200);
+    const getRoutingProviderConfig = mockedGetProvider.mock.calls[0]?.[0].getRoutingProviderConfig;
+    expect(getRoutingProviderConfig).toBeDefined();
+    expect(await getRoutingProviderConfig?.()).toEqual({ only: ['amazon-bedrock'] });
+  });
+
   it('returns 404 when the OpenRouter model id is unknown', async () => {
     mockedIsValidOpenRouterModelId.mockResolvedValue(false);
 

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -417,7 +417,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect(response.status).toBe(200);
     const getRoutingProviderConfig = mockedGetProvider.mock.calls[0]?.[0].getRoutingProviderConfig;
     expect(getRoutingProviderConfig).toBeDefined();
-    expect(await getRoutingProviderConfig?.()).toMatchObject({ only: ['amazon-bedrock'] });
+    expect((await getRoutingProviderConfig?.())?.only).toEqual(['amazon-bedrock']);
   });
 
   it('returns 404 when the OpenRouter model id is unknown', async () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -420,6 +420,20 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect((await getRoutingProviderConfig?.())?.only).toEqual(['amazon-bedrock']);
   });
 
+  it('skips group policy evaluation when organization policy denies the model', async () => {
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: { model_deny_list: ['openai/gpt-4o'] },
+      plan: 'enterprise',
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody()) as never);
+
+    expect(response.status).toBe(403);
+    expect(mockedGetEffectiveModelDecision).not.toHaveBeenCalled();
+  });
+
   it('returns 404 when the OpenRouter model id is unknown', async () => {
     mockedIsValidOpenRouterModelId.mockResolvedValue(false);
 

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -316,7 +316,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     const { POST } = await import('./route');
     const response = await POST(makeRequest(makeBody()) as never);
 
-    expect(response.status).toBe(404);
+    expect(response.status).toBe(403);
     expect(await response.json()).toMatchObject({
       error_type: 'abuse_blocked',
       message: 'Request blocked by abuse prevention rules.',
@@ -421,6 +421,15 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
   });
 
   it('skips group policy evaluation when organization policy denies the model', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-1',
+    });
     mockedGetBalanceAndOrgSettings.mockResolvedValue({
       balance: 1000,
       settings: { model_deny_list: ['openai/gpt-4o'] },
@@ -430,7 +439,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     const { POST } = await import('./route');
     const response = await POST(makeRequest(makeBody()) as never);
 
-    expect(response.status).toBe(403);
+    expect(response.status).toBe(404);
     expect(mockedGetEffectiveModelDecision).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -602,6 +602,46 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     );
   }
 
+  async function resolveAccessCheck(modelId: string) {
+    const { balance, settings, plan } = await balanceAndSettingsPromise;
+    const { error: modelRestrictionError, providerConfig } = checkOrganizationModelRestrictions({
+      modelId,
+      settings,
+      organizationPlan: plan,
+    });
+    let effectiveProviderConfig = providerConfig;
+    let groupModelAllowed = true;
+    const groupPolicy = await organizationGroupPolicyPromise;
+    if (groupPolicy) {
+      const groupDecision = await getEffectiveModelDecision(groupPolicy, modelId);
+      groupModelAllowed = groupDecision.allowed;
+      if (groupDecision.eligibleProviderRoutes) {
+        const currentOnly = providerConfig?.only;
+        const only = currentOnly
+          ? currentOnly.filter(provider => groupDecision.eligibleProviderRoutes?.has(provider))
+          : [...groupDecision.eligibleProviderRoutes];
+        effectiveProviderConfig = { ...providerConfig, only };
+      }
+    }
+    return {
+      balance,
+      effectiveProviderConfig,
+      groupModelAllowed,
+      modelRestrictionError,
+      plan,
+      settings,
+    };
+  }
+
+  const accessChecks = new Map<string, ReturnType<typeof resolveAccessCheck>>();
+  function getAccessCheck(modelId: string) {
+    const existing = accessChecks.get(modelId);
+    if (existing) return existing;
+    const accessCheck = resolveAccessCheck(modelId);
+    accessChecks.set(modelId, accessCheck);
+    return accessCheck;
+  }
+
   // Resolve the initial provider before abuse enforcement because abuse needs
   // provider/BYOK context, and quarantine-3 may later rewrite these values.
   const initialProviderResultForAbuseService = await getProvider({
@@ -612,6 +652,9 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     taskId,
     clientIp: ipAddress ?? null,
     machineId: machineIdHeader,
+    getRoutingProviderConfig: isAnonymousContext(user)
+      ? undefined
+      : async () => (await getAccessCheck(effectiveModelIdLowerCased)).effectiveProviderConfig,
   });
   if (initialProviderResultForAbuseService.kind === 'not-found') {
     // Paused experiment for this public id — return a local model-unavailable
@@ -735,6 +778,9 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       taskId,
       clientIp: ipAddress ?? null,
       machineId: machineIdHeader,
+      getRoutingProviderConfig: isAnonymousContext(user)
+        ? undefined
+        : async () => (await getAccessCheck(effectiveModelIdLowerCased)).effectiveProviderConfig,
     });
     if (quarantineProviderResult.kind === 'not-found') {
       if (rulesEngineDecision.delayMs > 0) {
@@ -780,7 +826,14 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   // Skip balance/org checks for anonymous users - they can only use free models
   if (!isAnonymousContext(user) && !effectiveProviderContext.bypassAccessCheck) {
-    const { balance, settings, plan } = await balanceAndSettingsPromise;
+    const {
+      balance,
+      effectiveProviderConfig,
+      groupModelAllowed,
+      modelRestrictionError,
+      plan,
+      settings,
+    } = await getAccessCheck(effectiveModelIdLowerCased);
 
     if (
       balance <= 0 &&
@@ -792,35 +845,12 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
     // Organization model/provider restrictions check
     // Provider/model access policy applies to Enterprise plans; data collection applies to all plans.
-    const { error: modelRestrictionError, providerConfig } = checkOrganizationModelRestrictions({
-      modelId: effectiveModelIdLowerCased,
-      settings,
-      organizationPlan: plan,
-    });
     if (modelRestrictionError) {
       return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelRestrictionError;
     }
 
-    let effectiveProviderConfig = providerConfig;
-    const groupPolicy = await organizationGroupPolicyPromise;
-    if (groupPolicy) {
-      // Started right after auth so the DB read overlapped the work above; the
-      // decision itself is in-memory against the cached provider index.
-      const groupDecision = await getEffectiveModelDecision(
-        groupPolicy,
-        effectiveModelIdLowerCased
-      );
-      if (!groupDecision.allowed) {
-        return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelNotAllowedResponse();
-      }
-      if (groupDecision.eligibleProviderRoutes) {
-        const currentOnly = providerConfig?.only;
-        const only = currentOnly
-          ? currentOnly.filter(provider => groupDecision.eligibleProviderRoutes?.has(provider))
-          : [...groupDecision.eligibleProviderRoutes];
-        if (only.length === 0) return modelNotAllowedResponse();
-        effectiveProviderConfig = { ...providerConfig, only };
-      }
+    if (!groupModelAllowed || effectiveProviderConfig?.only?.length === 0) {
+      return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelNotAllowedResponse();
     }
 
     // Experiment traffic captures prompts to R2 for partner evaluation, which

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -647,20 +647,18 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     };
   }
 
-  const accessChecks = new Map<string, ReturnType<typeof resolveAccessCheck>>();
-  function getAccessCheck(modelId: string) {
-    const existing = accessChecks.get(modelId);
-    if (existing) return existing;
-    const accessCheck = resolveAccessCheck(modelId);
-    accessChecks.set(modelId, accessCheck);
-    return accessCheck;
+  function createAccessCheckResolver(modelId: string) {
+    let accessCheck: ReturnType<typeof resolveAccessCheck> | undefined;
+    const get = () => (accessCheck ??= resolveAccessCheck(modelId));
+    return {
+      get,
+      getRoutingProviderConfig: isAnonymousContext(user)
+        ? undefined
+        : async () => (await get()).effectiveProviderConfig,
+    };
   }
 
-  function getRoutingProviderConfigFor(modelId: string) {
-    return isAnonymousContext(user)
-      ? undefined
-      : async () => (await getAccessCheck(modelId)).effectiveProviderConfig;
-  }
+  let accessCheckResolver = createAccessCheckResolver(effectiveModelIdLowerCased);
 
   // Resolve the initial provider before abuse enforcement because abuse needs
   // provider/BYOK context, and quarantine-3 may later rewrite these values.
@@ -672,7 +670,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     taskId,
     clientIp: ipAddress ?? null,
     machineId: machineIdHeader,
-    getRoutingProviderConfig: getRoutingProviderConfigFor(effectiveModelIdLowerCased),
+    getRoutingProviderConfig: accessCheckResolver.getRoutingProviderConfig,
   });
   if (initialProviderResultForAbuseService.kind === 'not-found') {
     // Paused experiment for this public id — return a local model-unavailable
@@ -788,6 +786,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     abuseDowngradedFrom = effectiveModelIdLowerCased;
     requestBodyParsed.body.model = rulesEngineDecision.modelOverride;
     effectiveModelIdLowerCased = rulesEngineDecision.modelOverride;
+    accessCheckResolver = createAccessCheckResolver(effectiveModelIdLowerCased);
     const quarantineProviderResult = await getProvider({
       requestedModel: effectiveModelIdLowerCased,
       request: requestBodyParsed,
@@ -796,7 +795,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       taskId,
       clientIp: ipAddress ?? null,
       machineId: machineIdHeader,
-      getRoutingProviderConfig: getRoutingProviderConfigFor(effectiveModelIdLowerCased),
+      getRoutingProviderConfig: accessCheckResolver.getRoutingProviderConfig,
     });
     if (quarantineProviderResult.kind === 'not-found') {
       if (rulesEngineDecision.delayMs > 0) {
@@ -850,7 +849,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       modelRestrictionError,
       plan,
       settings,
-    } = await getAccessCheck(effectiveModelIdLowerCased);
+    } = await accessCheckResolver.get();
 
     if (
       balance <= 0 &&

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -609,6 +609,17 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       settings,
       organizationPlan: plan,
     });
+    if (modelRestrictionError) {
+      return {
+        balance,
+        effectiveProviderConfig: providerConfig,
+        groupModelAllowed: true,
+        groupProvidersAllowed: true,
+        modelRestrictionError,
+        plan,
+        settings,
+      };
+    }
     let effectiveProviderConfig = providerConfig;
     let groupModelAllowed = true;
     let groupProvidersAllowed = true;

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -611,6 +611,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     });
     let effectiveProviderConfig = providerConfig;
     let groupModelAllowed = true;
+    let groupProvidersAllowed = true;
     const groupPolicy = await organizationGroupPolicyPromise;
     if (groupPolicy) {
       const groupDecision = await getEffectiveModelDecision(groupPolicy, modelId);
@@ -620,6 +621,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
         const only = currentOnly
           ? currentOnly.filter(provider => groupDecision.eligibleProviderRoutes?.has(provider))
           : [...groupDecision.eligibleProviderRoutes];
+        groupProvidersAllowed = only.length > 0;
         effectiveProviderConfig = { ...providerConfig, only };
       }
     }
@@ -627,6 +629,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       balance,
       effectiveProviderConfig,
       groupModelAllowed,
+      groupProvidersAllowed,
       modelRestrictionError,
       plan,
       settings,
@@ -642,6 +645,12 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     return accessCheck;
   }
 
+  function getRoutingProviderConfigFor(modelId: string) {
+    return isAnonymousContext(user)
+      ? undefined
+      : async () => (await getAccessCheck(modelId)).effectiveProviderConfig;
+  }
+
   // Resolve the initial provider before abuse enforcement because abuse needs
   // provider/BYOK context, and quarantine-3 may later rewrite these values.
   const initialProviderResultForAbuseService = await getProvider({
@@ -652,9 +661,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     taskId,
     clientIp: ipAddress ?? null,
     machineId: machineIdHeader,
-    getRoutingProviderConfig: isAnonymousContext(user)
-      ? undefined
-      : async () => (await getAccessCheck(effectiveModelIdLowerCased)).effectiveProviderConfig,
+    getRoutingProviderConfig: getRoutingProviderConfigFor(effectiveModelIdLowerCased),
   });
   if (initialProviderResultForAbuseService.kind === 'not-found') {
     // Paused experiment for this public id — return a local model-unavailable
@@ -778,9 +785,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       taskId,
       clientIp: ipAddress ?? null,
       machineId: machineIdHeader,
-      getRoutingProviderConfig: isAnonymousContext(user)
-        ? undefined
-        : async () => (await getAccessCheck(effectiveModelIdLowerCased)).effectiveProviderConfig,
+      getRoutingProviderConfig: getRoutingProviderConfigFor(effectiveModelIdLowerCased),
     });
     if (quarantineProviderResult.kind === 'not-found') {
       if (rulesEngineDecision.delayMs > 0) {
@@ -830,6 +835,7 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       balance,
       effectiveProviderConfig,
       groupModelAllowed,
+      groupProvidersAllowed,
       modelRestrictionError,
       plan,
       settings,
@@ -849,9 +855,10 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelRestrictionError;
     }
 
-    if (!groupModelAllowed || effectiveProviderConfig?.only?.length === 0) {
+    if (!groupModelAllowed) {
       return isAutoEfficientRequest ? efficientPoolBlockedResponse() : modelNotAllowedResponse();
     }
+    if (!groupProvidersAllowed) return modelNotAllowedResponse();
 
     // Experiment traffic captures prompts to R2 for partner evaluation, which
     // is a form of data collection that the gateway-pinned `data_collection`

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -282,6 +282,8 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
 
   const eligibleForVercelRouting =
     !kiloExclusiveModel || kiloExclusiveModel.flags.includes('vercel-routing');
+  const resolveRoutingProviderConfig = async () =>
+    (await getRoutingProviderConfig?.()) ?? request.body.provider;
 
   if (
     eligibleForVercelRouting &&
@@ -289,7 +291,7 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
       requestedModel,
       request,
       taskId || user.id,
-      await getRoutingProviderConfig?.()
+      resolveRoutingProviderConfig
     ))
   ) {
     return {

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -1,4 +1,7 @@
-import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import type {
+  GatewayRequest,
+  OpenRouterProviderConfig,
+} from '@/lib/ai-gateway/providers/openrouter/types';
 import { shouldRouteToVercel } from '@/lib/ai-gateway/providers/vercel';
 import { findKiloExclusiveModel, isKiloExclusiveModel } from '@/lib/ai-gateway/models';
 import { CUSTOM_LLM_PREFIX } from '@/lib/ai-gateway/model-utils';
@@ -195,10 +198,22 @@ export type GetProviderInput = {
   /** Machine identifier from `x-kilocode-machineid`. Used as the machine-
    *  cohort allocation subject for experiment routing. */
   machineId: string | null;
+  /** Resolves organization/group provider policy only when selecting a managed
+   * gateway. Direct BYOK and custom LLM routes remain exempt. */
+  getRoutingProviderConfig?: () => Promise<OpenRouterProviderConfig | undefined>;
 };
 
 export async function getProvider(input: GetProviderInput): Promise<GetProviderResult> {
-  const { requestedModel, request, user, organizationId, taskId, clientIp, machineId } = input;
+  const {
+    requestedModel,
+    request,
+    user,
+    organizationId,
+    taskId,
+    clientIp,
+    machineId,
+    getRoutingProviderConfig,
+  } = input;
 
   const directByokByok = await checkDirectBYOK(user, requestedModel, organizationId);
   if (directByokByok) {
@@ -270,7 +285,12 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
 
   if (
     eligibleForVercelRouting &&
-    (await shouldRouteToVercel(requestedModel, request, taskId || user.id))
+    (await shouldRouteToVercel(
+      requestedModel,
+      request,
+      taskId || user.id,
+      await getRoutingProviderConfig?.()
+    ))
   ) {
     return {
       kind: 'provider',

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -162,22 +162,20 @@ describe('shouldRouteToVercel', () => {
   async function loadShouldRouteToVercel(options?: { optOut?: boolean }) {
     jest.resetModules();
     jest.doMock('@/lib/ai-gateway/providers/routing-config', () => ({
-      getRuntimeGatewayRoutingConfig: jest.fn().mockResolvedValue({
+      getRuntimeGatewayRoutingConfig: jest.fn(async () => ({
         vercelPaid: 100,
         vercelFree: 100,
         vercelOptOutModels: new Set(options?.optOut ? ['anthropic/claude-sonnet-4.5'] : []),
         friendli: 0,
         perplexity: 0,
-      }),
+      })),
     }));
     jest.doMock('@/lib/ai-gateway/is-free-model', () => ({
-      isFreeModel: jest.fn().mockResolvedValue(false),
+      isFreeModel: jest.fn(async () => false),
     }));
     jest.doMock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
-      getVercelModelsFromRedis: jest
-        .fn()
-        .mockResolvedValue(new Set(['anthropic/claude-sonnet-4.5'])),
-      getCachedVercelInferenceProviderIdsForModel: jest.fn().mockResolvedValue(['anthropic']),
+      getVercelModelsFromRedis: jest.fn(async () => new Set(['anthropic/claude-sonnet-4.5'])),
+      getCachedVercelInferenceProviderIdsForModel: jest.fn(async () => ['anthropic']),
     }));
     return (await import('@/lib/ai-gateway/providers/vercel')).shouldRouteToVercel;
   }

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -147,6 +147,80 @@ describe('convertProviderOptions', () => {
   });
 });
 
+describe('shouldRouteToVercel', () => {
+  function request(provider?: GatewayRequest['body']['provider']): GatewayRequest {
+    return {
+      kind: 'chat_completions',
+      body: {
+        model: 'anthropic/claude-sonnet-4.5',
+        messages: [{ role: 'user', content: 'hello' }],
+        provider,
+      },
+    };
+  }
+
+  async function loadShouldRouteToVercel(options?: { optOut?: boolean }) {
+    jest.resetModules();
+    jest.doMock('@/lib/ai-gateway/providers/routing-config', () => ({
+      getRuntimeGatewayRoutingConfig: jest.fn().mockResolvedValue({
+        vercelPaid: 100,
+        vercelFree: 100,
+        vercelOptOutModels: new Set(options?.optOut ? ['anthropic/claude-sonnet-4.5'] : []),
+        friendli: 0,
+        perplexity: 0,
+      }),
+    }));
+    jest.doMock('@/lib/ai-gateway/is-free-model', () => ({
+      isFreeModel: jest.fn().mockResolvedValue(false),
+    }));
+    jest.doMock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
+      getVercelModelsFromRedis: jest
+        .fn()
+        .mockResolvedValue(new Set(['anthropic/claude-sonnet-4.5'])),
+      getCachedVercelInferenceProviderIdsForModel: jest.fn().mockResolvedValue(['anthropic']),
+    }));
+    return (await import('@/lib/ai-gateway/providers/vercel')).shouldRouteToVercel;
+  }
+
+  it('uses resolved provider policy instead of unrestricted request preferences', async () => {
+    const shouldRouteToVercel = await loadShouldRouteToVercel();
+
+    await expect(
+      shouldRouteToVercel('anthropic/claude-sonnet-4.5', request(), 'seed', async () => ({
+        only: ['google-vertex'],
+      }))
+    ).resolves.toBe(false);
+  });
+
+  it('falls back to request preferences when no policy config is resolved', async () => {
+    const shouldRouteToVercel = await loadShouldRouteToVercel();
+
+    await expect(
+      shouldRouteToVercel(
+        'anthropic/claude-sonnet-4.5',
+        request({ only: ['anthropic'] }),
+        'seed',
+        async () => undefined
+      )
+    ).resolves.toBe(true);
+  });
+
+  it('does not resolve provider policy for models opted out of Vercel routing', async () => {
+    const shouldRouteToVercel = await loadShouldRouteToVercel({ optOut: true });
+    const getRoutingProviderConfig = jest.fn(async () => ({ only: ['anthropic'] }));
+
+    await expect(
+      shouldRouteToVercel(
+        'anthropic/claude-sonnet-4.5',
+        request(),
+        'seed',
+        getRoutingProviderConfig
+      )
+    ).resolves.toBe(false);
+    expect(getRoutingProviderConfig).not.toHaveBeenCalled();
+  });
+});
+
 describe('applyVercelSettings BYOK pinning', () => {
   function byokRequest(ignore: string[]): GatewayRequest {
     return {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -8,6 +8,7 @@ import {
 } from '@/lib/ai-gateway/providers/openrouter/inference-provider-id';
 import type {
   GatewayRequest,
+  OpenRouterProviderConfig,
   VercelInferenceProviderConfig,
   VercelProviderConfig,
 } from '@/lib/ai-gateway/providers/openrouter/types';
@@ -62,7 +63,8 @@ export function isVercelRoutingOptOut(requestedModel: string, optOutModels: Read
 export async function shouldRouteToVercel(
   requestedModel: string,
   request: GatewayRequest,
-  randomSeed: string
+  randomSeed: string,
+  routingProviderConfig = request.body.provider
 ) {
   const routingConfig = await getRuntimeGatewayRoutingConfig();
   if (isVercelRoutingOptOut(requestedModel, routingConfig.vercelOptOutModels)) {
@@ -88,7 +90,7 @@ export async function shouldRouteToVercel(
     return false;
   }
 
-  const provider = request.body.provider;
+  const provider: OpenRouterProviderConfig | undefined = routingProviderConfig;
   if (provider && (provider.only || provider.ignore?.length)) {
     const { only, ignore } = provider;
     const vercelInferenceProviders =

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -64,7 +64,7 @@ export async function shouldRouteToVercel(
   requestedModel: string,
   request: GatewayRequest,
   randomSeed: string,
-  routingProviderConfig = request.body.provider
+  getRoutingProviderConfig: () => Promise<OpenRouterProviderConfig | undefined>
 ) {
   const routingConfig = await getRuntimeGatewayRoutingConfig();
   if (isVercelRoutingOptOut(requestedModel, routingConfig.vercelOptOutModels)) {
@@ -90,7 +90,7 @@ export async function shouldRouteToVercel(
     return false;
   }
 
-  const provider: OpenRouterProviderConfig | undefined = routingProviderConfig;
+  const provider = await getRoutingProviderConfig();
   if (provider && (provider.only || provider.ignore?.length)) {
     const { only, ignore } = provider;
     const vercelInferenceProviders =


### PR DESCRIPTION
## Summary
- resolve organization and group provider policies before managed gateway selection
- check Vercel inference-provider availability against the effective allow-list
- keep direct BYOK, custom LLM, experiment, and Vercel BYOK routes exempt from the extra policy lookup
- cache access decisions per effective model and cover the ordering with a route regression test

## Testing
- CI only, as requested