### PR TITLE
feat(mobile): add Share to PR link tap sheet

### DIFF
--- a/apps/mobile/src/components/agents/chat-link-actions.test.ts
+++ b/apps/mobile/src/components/agents/chat-link-actions.test.ts
@@ -54,14 +54,15 @@ describe('chat link actions', () => {
     expect(getSelectedChatLinkAction(sheet, 4)).toBeNull();
   });
 
-  it('builds the tap sheet with exactly Review PR / Open in browser / Cancel', () => {
+  it('builds the tap sheet with Review PR / Open in browser / Share / Cancel', () => {
     const sheet = buildPrLinkTapActionSheet();
 
-    expect(sheet.options).toEqual(['Review PR', 'Open in browser', 'Cancel']);
-    expect(sheet.cancelButtonIndex).toBe(2);
+    expect(sheet.options).toEqual(['Review PR', 'Open in browser', 'Share', 'Cancel']);
+    expect(sheet.cancelButtonIndex).toBe(3);
     expect(getSelectedChatLinkAction(sheet, 0)).toBe('review-pr');
     expect(getSelectedChatLinkAction(sheet, 1)).toBe('open');
-    expect(getSelectedChatLinkAction(sheet, 2)).toBeNull();
+    expect(getSelectedChatLinkAction(sheet, 2)).toBe('share');
+    expect(getSelectedChatLinkAction(sheet, 3)).toBeNull();
     expect(getSelectedChatLinkAction(sheet, undefined)).toBeNull();
   });
 

--- a/apps/mobile/src/components/agents/chat-link-actions.ts
+++ b/apps/mobile/src/components/agents/chat-link-actions.ts
@@ -30,7 +30,7 @@ export function buildChatLinkActionSheet({ isPrLink = false }: { isPrLink?: bool
  * The tap (not long-press) action sheet for a GitHub PR link. The accepted
  * contract is exactly four options: Review PR, Open in browser, Share, Cancel.
  * This is intentionally distinct from the long-press sheet, which also
- * offers Copy and Share link.
+ * offers Copy link.
  */
 export function buildPrLinkTapActionSheet() {
   const actions: ChatLinkActionOption[] = [

--- a/apps/mobile/src/components/agents/chat-link-actions.ts
+++ b/apps/mobile/src/components/agents/chat-link-actions.ts
@@ -28,14 +28,15 @@ export function buildChatLinkActionSheet({ isPrLink = false }: { isPrLink?: bool
 
 /**
  * The tap (not long-press) action sheet for a GitHub PR link. The accepted
- * contract is exactly three options: Review PR, Open in browser, Cancel.
+ * contract is exactly four options: Review PR, Open in browser, Share, Cancel.
  * This is intentionally distinct from the long-press sheet, which also
- * offers Copy/Share.
+ * offers Copy and Share link.
  */
 export function buildPrLinkTapActionSheet() {
   const actions: ChatLinkActionOption[] = [
     { kind: 'review-pr', label: 'Review PR' },
     { kind: 'open', label: 'Open in browser' },
+    { kind: 'share', label: 'Share' },
     { kind: 'cancel', label: 'Cancel' },
   ];
 

--- a/apps/mobile/src/components/agents/chat-markdown-text.tsx
+++ b/apps/mobile/src/components/agents/chat-markdown-text.tsx
@@ -46,8 +46,8 @@ export function ChatMarkdownText(props: Readonly<ChatMarkdownTextProps>) {
       if (!prReviewEnabled || !parseGitHubPrUrl(href)) {
         return false;
       }
-      // Tap on a PR link shows exactly three options: Review PR / Open in
-      // browser / Cancel. The richer Copy/Share sheet is long-press only.
+      // Tap on a PR link shows exactly four options: Review PR / Open in
+      // browser / Share / Cancel.
       const sheet = buildPrLinkTapActionSheet();
       showActionSheetWithOptions(
         {
@@ -68,6 +68,10 @@ export function ChatMarkdownText(props: Readonly<ChatMarkdownTextProps>) {
           }
           if (action === 'open') {
             void openExternalUrl(href, { label: 'link' });
+            return;
+          }
+          if (action === 'share') {
+            void performChatLinkAction('share', href);
           }
         }
       );


### PR DESCRIPTION
## Summary

Tapping a pull request link in a chat now shows a Share option in the action sheet. Tapping Share opens the system share sheet with the link.

---

The PR-link tap sheet gains a Share action between Open in browser and Cancel. The tap handler routes the Share selection through the existing share path, which opens the system share sheet and shows a retry toast on failure. The `buildPrLinkTapActionSheet` contract now returns four options with the cancel index at 3; the long-press sheet and non-PR tap behavior stay the same.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/chat-link-actions.ts` — adds the Share option to `buildPrLinkTapActionSheet` and updates its contract comment from three to four options.
- `apps/mobile/src/components/agents/chat-markdown-text.tsx` — dispatches the `share` selection to `performChatLinkAction('share', href)`, adds a `return` after the `open` branch, and updates the tap-sheet comment.

</details>

Tests: 1 test file updated (`apps/mobile/src/components/agents/chat-link-actions.test.ts`).
Generated: none.

---

## Verification

On iOS, 2 cases ran and both passed.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| S2 — Cancel dismisses the tap sheet | Tapping Cancel on the PR link tap sheet dismisses it, opens no share sheet, and leaves the link visible. | iOS | passed |
| S1 — Share opens the system share sheet | The tap sheet shows Review PR, Open in browser, Share, and Cancel, and tapping Share opens the iOS system share sheet. | iOS | passed |

No defects reproduced.

No human steps needed.

## Visual Changes

**PR link tap sheet** — Tapping a PR markdown link now opens a tap sheet with Review PR, Open in browser, Share, and Cancel. Tapping Share opens the iOS system share sheet.

![s1-share-sheet.png](https://github.com/user-attachments/assets/643b9e2b-6538-4004-be6c-0db2806b47f0)

## Reviewer Notes

None.
