### PR TITLE
feat(mobile): hide KiloClaw activity row without an instance

### DIFF
--- a/apps/mobile/src/components/notifications-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/notifications-screen.mounted.test.tsx
@@ -128,12 +128,12 @@ async function renderScreen() {
   return result;
 }
 
-function previewSwitches(root: I): I[] {
+function switchesByLabel(root: I, label: string): I[] {
   return root.findAll(
     n =>
       typeof n.type === 'string' &&
       (n.type as string) === 'Switch' &&
-      n.props.accessibilityLabel === 'Show full previews'
+      n.props.accessibilityLabel === label
   );
 }
 
@@ -143,24 +143,6 @@ function previewRetry(root: I): I[] {
       typeof n.type === 'string' &&
       (n.type as string) === 'Pressable' &&
       n.props.accessibilityLabel === 'Retry saving notification previews'
-  );
-}
-
-function kiloclawSwitches(root: I): I[] {
-  return root.findAll(
-    n =>
-      typeof n.type === 'string' &&
-      (n.type as string) === 'Switch' &&
-      n.props.accessibilityLabel === 'KiloClaw activity'
-  );
-}
-
-function chatMessagesSwitches(root: I): I[] {
-  return root.findAll(
-    n =>
-      typeof n.type === 'string' &&
-      (n.type as string) === 'Switch' &&
-      n.props.accessibilityLabel === 'Chat messages'
   );
 }
 
@@ -174,36 +156,19 @@ function skeletonCount(root: I): number {
   return root.findAll(n => typeof n.type === 'string' && (n.type as string) === 'Skeleton').length;
 }
 
-function previewSwitchOnValueChange(root: I): ((value: boolean) => void) | undefined {
-  const sw = previewSwitches(root)[0];
+function switchOnValueChange(root: I, label: string): ((value: boolean) => void) | undefined {
+  const sw = switchesByLabel(root, label)[0];
   return sw ? (sw.props as { onValueChange?: (value: boolean) => void }).onValueChange : undefined;
 }
 
-function kiloclawSwitchOnValueChange(root: I): ((value: boolean) => void) | undefined {
-  const sw = kiloclawSwitches(root)[0];
-  return sw ? (sw.props as { onValueChange?: (value: boolean) => void }).onValueChange : undefined;
-}
-
-// The preview switch renders as soon as the preference query resolves, but it
-// stays disabled until the master gate settles (the device-token query is
-// gated on the permission query, so it settles one cascade later). Wait for the
-// switch to be enabled before driving a change, otherwise the disabled switch
+// The switch renders as soon as the preference query resolves, but it stays
+// disabled until the master gate settles (the device-token query is gated on
+// the permission query, so it settles one cascade later). Wait for the switch
+// to be enabled before driving a change, otherwise the disabled switch
 // swallows the onValueChange.
-async function waitForEnabledPreviewSwitch(renderer: R): Promise<void> {
+async function waitForEnabledSwitch(renderer: R, label: string): Promise<void> {
   await waitFor(() => {
-    const sw = previewSwitches(renderer.root);
-    return sw.length === 1 && sw[0]?.props.disabled === false;
-  }, 200);
-}
-
-// The KiloClaw switch renders as soon as the preference query resolves, but it
-// stays disabled until the master gate settles (the device-token query is
-// gated on the permission query, so it settles one cascade later). Wait for the
-// switch to be enabled before driving a change, otherwise the disabled switch
-// swallows the onValueChange.
-async function waitForEnabledKiloClawSwitch(renderer: R): Promise<void> {
-  await waitFor(() => {
-    const sw = kiloclawSwitches(renderer.root);
+    const sw = switchesByLabel(renderer.root, label);
     return sw.length === 1 && sw[0]?.props.disabled === false;
   }, 200);
 }
@@ -221,19 +186,21 @@ describe('NotificationsScreen message-previews row', () => {
   it('happy: reflects the server value and persists a change', async () => {
     prefsQueryFn.mockResolvedValue(fullPrefs({ notificationPreviews: 'generic' }));
     const { renderer } = await renderScreen();
-    await waitForEnabledPreviewSwitch(renderer);
+    await waitForEnabledSwitch(renderer, 'Show full previews');
 
-    expect(previewSwitches(renderer.root)[0]?.props.value).toBe(false);
+    expect(switchesByLabel(renderer.root, 'Show full previews')[0]?.props.value).toBe(false);
 
     // A change to "full" must persist through the mutation; the refetch then
     // returns the new server value.
     prefsQueryFn.mockResolvedValue(fullPrefs({ notificationPreviews: 'full' }));
     act(() => {
-      previewSwitchOnValueChange(renderer.root)?.(true);
+      switchOnValueChange(renderer.root, 'Show full previews')?.(true);
     });
     await waitFor(() => setPreferenceMutationFn.mock.calls.length === 1);
     expect(setPreferenceMutationFn.mock.calls[0]?.[0]).toEqual({ notificationPreviews: 'full' });
-    await waitFor(() => previewSwitches(renderer.root)[0]?.props.value === true);
+    await waitFor(
+      () => switchesByLabel(renderer.root, 'Show full previews')[0]?.props.value === true
+    );
     expect(toastError).not.toHaveBeenCalled();
   });
 
@@ -244,10 +211,10 @@ describe('NotificationsScreen message-previews row', () => {
       message: 'boom',
     });
     const { renderer } = await renderScreen();
-    await waitForEnabledPreviewSwitch(renderer);
+    await waitForEnabledSwitch(renderer, 'Show full previews');
 
     act(() => {
-      previewSwitchOnValueChange(renderer.root)?.(true);
+      switchOnValueChange(renderer.root, 'Show full previews')?.(true);
     });
     // pending
     expect(activityIndicators(renderer.root).length).toBe(1);
@@ -255,7 +222,7 @@ describe('NotificationsScreen message-previews row', () => {
     await waitFor(() => activityIndicators(renderer.root).length === 0);
 
     // The switch re-renders from the unchanged server value (still generic).
-    expect(previewSwitches(renderer.root)[0]?.props.value).toBe(false);
+    expect(switchesByLabel(renderer.root, 'Show full previews')[0]?.props.value).toBe(false);
     expect(previewRetry(renderer.root).length).toBe(1);
     expect(toastError).toHaveBeenCalledWith('boom');
   });
@@ -267,17 +234,17 @@ describe('NotificationsScreen message-previews row', () => {
       message: 'Unauthorized',
     });
     const { renderer } = await renderScreen();
-    await waitForEnabledPreviewSwitch(renderer);
+    await waitForEnabledSwitch(renderer, 'Show full previews');
 
     act(() => {
-      previewSwitchOnValueChange(renderer.root)?.(true);
+      switchOnValueChange(renderer.root, 'Show full previews')?.(true);
     });
     // pending
     expect(activityIndicators(renderer.root).length).toBe(1);
     // settled
     await waitFor(() => activityIndicators(renderer.root).length === 0);
 
-    expect(previewSwitches(renderer.root)[0]?.props.disabled).toBe(true);
+    expect(switchesByLabel(renderer.root, 'Show full previews')[0]?.props.disabled).toBe(true);
     expect(previewRetry(renderer.root).length).toBe(0);
     expect(toastError).toHaveBeenCalledWith('Unauthorized');
   });
@@ -287,7 +254,7 @@ describe('NotificationsScreen message-previews row', () => {
     prefsQueryFn.mockReturnValue(new Promise(() => undefined));
     const { renderer } = await renderScreen();
 
-    expect(previewSwitches(renderer.root).length).toBe(0);
+    expect(switchesByLabel(renderer.root, 'Show full previews').length).toBe(0);
     expect(skeletonCount(renderer.root)).toBeGreaterThan(0);
   });
 });
@@ -307,10 +274,10 @@ describe('NotificationsScreen KiloClaw activity row', () => {
     prefsQueryFn.mockResolvedValue(fullPrefs());
     const { renderer } = await renderScreen();
 
-    await waitForEnabledKiloClawSwitch(renderer);
+    await waitForEnabledSwitch(renderer, 'KiloClaw activity');
 
     act(() => {
-      kiloclawSwitchOnValueChange(renderer.root)?.(false);
+      switchOnValueChange(renderer.root, 'KiloClaw activity')?.(false);
     });
     await waitFor(() => setPreferenceMutationFn.mock.calls.length === 1);
     expect(setPreferenceMutationFn.mock.calls[0]?.[0]).toEqual({ kiloclawActivity: false });
@@ -321,9 +288,9 @@ describe('NotificationsScreen KiloClaw activity row', () => {
     prefsQueryFn.mockResolvedValue(fullPrefs());
     const { renderer } = await renderScreen();
 
-    await waitFor(() => chatMessagesSwitches(renderer.root).length === 1);
-    expect(kiloclawSwitches(renderer.root).length).toBe(0);
-    expect(chatMessagesSwitches(renderer.root).length).toBe(1);
+    await waitFor(() => switchesByLabel(renderer.root, 'Chat messages').length === 1);
+    expect(switchesByLabel(renderer.root, 'KiloClaw activity').length).toBe(0);
+    expect(switchesByLabel(renderer.root, 'Chat messages').length).toBe(1);
   });
 
   it('retryable unhappy: prefs error shows retry and no KiloClaw row', async () => {
@@ -340,7 +307,7 @@ describe('NotificationsScreen KiloClaw activity row', () => {
             n.props.accessibilityLabel === 'Retry loading notification categories'
         ).length === 1
     );
-    expect(kiloclawSwitches(renderer.root).length).toBe(0);
+    expect(switchesByLabel(renderer.root, 'KiloClaw activity').length).toBe(0);
   });
 
   it('empty loading: pending prefs shows skeletons and no KiloClaw switch', async () => {
@@ -348,7 +315,7 @@ describe('NotificationsScreen KiloClaw activity row', () => {
     prefsQueryFn.mockReturnValue(new Promise(() => undefined));
     const { renderer } = await renderScreen();
 
-    expect(kiloclawSwitches(renderer.root).length).toBe(0);
+    expect(switchesByLabel(renderer.root, 'KiloClaw activity').length).toBe(0);
     expect(skeletonCount(renderer.root)).toBeGreaterThan(0);
   });
 });

--- a/apps/mobile/src/components/notifications-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/notifications-screen.mounted.test.tsx
@@ -22,6 +22,11 @@ const getNotificationPermissionStatus = vi.hoisted(() => vi.fn());
 const getDevicePushToken = vi.hoisted(() => vi.fn());
 const toastError = vi.hoisted(() => vi.fn());
 
+const useKiloClawTabVisible = vi.hoisted(() => vi.fn(() => true));
+vi.mock('@/lib/hooks/use-kiloclaw-tab-visible', () => ({
+  useKiloClawTabVisible,
+}));
+
 vi.mock('react-native', () => ({
   View: 'View',
   Switch: 'Switch',
@@ -141,6 +146,24 @@ function previewRetry(root: I): I[] {
   );
 }
 
+function kiloclawSwitches(root: I): I[] {
+  return root.findAll(
+    n =>
+      typeof n.type === 'string' &&
+      (n.type as string) === 'Switch' &&
+      n.props.accessibilityLabel === 'KiloClaw activity'
+  );
+}
+
+function chatMessagesSwitches(root: I): I[] {
+  return root.findAll(
+    n =>
+      typeof n.type === 'string' &&
+      (n.type as string) === 'Switch' &&
+      n.props.accessibilityLabel === 'Chat messages'
+  );
+}
+
 function activityIndicators(root: I): I[] {
   return root.findAll(
     n => typeof n.type === 'string' && (n.type as string) === 'ActivityIndicator'
@@ -156,6 +179,11 @@ function previewSwitchOnValueChange(root: I): ((value: boolean) => void) | undef
   return sw ? (sw.props as { onValueChange?: (value: boolean) => void }).onValueChange : undefined;
 }
 
+function kiloclawSwitchOnValueChange(root: I): ((value: boolean) => void) | undefined {
+  const sw = kiloclawSwitches(root)[0];
+  return sw ? (sw.props as { onValueChange?: (value: boolean) => void }).onValueChange : undefined;
+}
+
 // The preview switch renders as soon as the preference query resolves, but it
 // stays disabled until the master gate settles (the device-token query is
 // gated on the permission query, so it settles one cascade later). Wait for the
@@ -164,6 +192,18 @@ function previewSwitchOnValueChange(root: I): ((value: boolean) => void) | undef
 async function waitForEnabledPreviewSwitch(renderer: R): Promise<void> {
   await waitFor(() => {
     const sw = previewSwitches(renderer.root);
+    return sw.length === 1 && sw[0]?.props.disabled === false;
+  }, 200);
+}
+
+// The KiloClaw switch renders as soon as the preference query resolves, but it
+// stays disabled until the master gate settles (the device-token query is
+// gated on the permission query, so it settles one cascade later). Wait for the
+// switch to be enabled before driving a change, otherwise the disabled switch
+// swallows the onValueChange.
+async function waitForEnabledKiloClawSwitch(renderer: R): Promise<void> {
+  await waitFor(() => {
+    const sw = kiloclawSwitches(renderer.root);
     return sw.length === 1 && sw[0]?.props.disabled === false;
   }, 200);
 }
@@ -248,6 +288,67 @@ describe('NotificationsScreen message-previews row', () => {
     const { renderer } = await renderScreen();
 
     expect(previewSwitches(renderer.root).length).toBe(0);
+    expect(skeletonCount(renderer.root)).toBeGreaterThan(0);
+  });
+});
+
+describe('NotificationsScreen KiloClaw activity row', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getNotificationPermissionStatus.mockResolvedValue('granted');
+    getDevicePushToken.mockResolvedValue('device-token');
+    pushTokensQueryFn.mockResolvedValue([{ token: 'device-token', platform: 'android' }]);
+    setPreferenceMutationFn.mockResolvedValue({});
+    registerTokenMutationFn.mockResolvedValue({ success: true });
+  });
+
+  it('happy: instance present shows the row and a toggle persists', async () => {
+    useKiloClawTabVisible.mockReturnValue(true);
+    prefsQueryFn.mockResolvedValue(fullPrefs());
+    const { renderer } = await renderScreen();
+
+    await waitForEnabledKiloClawSwitch(renderer);
+
+    act(() => {
+      kiloclawSwitchOnValueChange(renderer.root)?.(false);
+    });
+    await waitFor(() => setPreferenceMutationFn.mock.calls.length === 1);
+    expect(setPreferenceMutationFn.mock.calls[0]?.[0]).toEqual({ kiloclawActivity: false });
+  });
+
+  it('empty: no instance hides the KiloClaw row and keeps the Chat messages row', async () => {
+    useKiloClawTabVisible.mockReturnValue(false);
+    prefsQueryFn.mockResolvedValue(fullPrefs());
+    const { renderer } = await renderScreen();
+
+    await waitFor(() => chatMessagesSwitches(renderer.root).length === 1);
+    expect(kiloclawSwitches(renderer.root).length).toBe(0);
+    expect(chatMessagesSwitches(renderer.root).length).toBe(1);
+  });
+
+  it('retryable unhappy: prefs error shows retry and no KiloClaw row', async () => {
+    useKiloClawTabVisible.mockReturnValue(false);
+    prefsQueryFn.mockRejectedValue(new Error('prefs boom'));
+    const { renderer } = await renderScreen();
+
+    await waitFor(
+      () =>
+        renderer.root.findAll(
+          n =>
+            typeof n.type === 'string' &&
+            (n.type as string) === 'Pressable' &&
+            n.props.accessibilityLabel === 'Retry loading notification categories'
+        ).length === 1
+    );
+    expect(kiloclawSwitches(renderer.root).length).toBe(0);
+  });
+
+  it('empty loading: pending prefs shows skeletons and no KiloClaw switch', async () => {
+    useKiloClawTabVisible.mockReturnValue(false);
+    prefsQueryFn.mockReturnValue(new Promise(() => undefined));
+    const { renderer } = await renderScreen();
+
+    expect(kiloclawSwitches(renderer.root).length).toBe(0);
     expect(skeletonCount(renderer.root)).toBeGreaterThan(0);
   });
 });

--- a/apps/mobile/src/components/notifications-screen.tsx
+++ b/apps/mobile/src/components/notifications-screen.tsx
@@ -1,7 +1,9 @@
 /* eslint-disable max-lines -- The dedicated Notifications screen composes the master
  * OS-permission gate, the push-token registration flow, and 7 per-category toggles
- * with their optimistic-mutation + retry + loading patterns. Extracting subcomponents
- * would re-encode the same hooks. The screen stays a single rendered surface. */
+ * with their optimistic-mutation + retry + loading patterns. CATEGORY_META still
+ * has seven keys; the KiloClaw row is hidden when useKiloClawTabVisible is false.
+ * Extracting subcomponents would re-encode the same hooks. The screen stays a
+ * single rendered surface. */
 import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import * as Application from 'expo-application';
 import * as Notifications from 'expo-notifications';
@@ -41,6 +43,7 @@ import {
   rollbackAgentPushOptimistic,
 } from '@/lib/hooks/agent-push-preference';
 import { useAppLifecycle } from '@/lib/hooks/use-app-lifecycle';
+import { useKiloClawTabVisible } from '@/lib/hooks/use-kiloclaw-tab-visible';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import {
   getDevicePushToken,
@@ -199,6 +202,7 @@ export function NotificationsScreen() {
   const trpc = useTRPC();
   const queryClient = useQueryClient();
   const colors = useThemeColors();
+  const showKiloClawActivity = useKiloClawTabVisible();
   const { token: authToken } = useAuth();
   const isAuthenticated = authToken != null;
 
@@ -477,6 +481,14 @@ export function NotificationsScreen() {
   const previewTerminal = previewErrorCode === 'UNAUTHORIZED';
   const previewDisabled = !notificationsEnabled || isPreviewPending || previewTerminal;
 
+  // Old form: CATEGORY_META always rendered kiloclawActivity. Keep the key in
+  // CATEGORY_META and in notification preferences. Hide the row when the user
+  // has no active instance. Remove this filter only when product deletes the
+  // kiloclawActivity preference.
+  const visibleCategoryMeta = CATEGORY_META.filter(
+    meta => meta.key !== 'kiloclawActivity' || showKiloClawActivity
+  );
+
   return (
     <View className="flex-1 bg-background">
       <ScreenHeader title="Notifications" />
@@ -587,7 +599,7 @@ export function NotificationsScreen() {
           </Text>
           {preferencesLoading && (
             <>
-              {CATEGORY_META.map(meta => (
+              {visibleCategoryMeta.map(meta => (
                 <View
                   key={meta.key}
                   className="min-h-11 flex-row items-center gap-3 rounded-lg bg-secondary p-3"
@@ -613,7 +625,7 @@ export function NotificationsScreen() {
           )}
           {preferences && (
             <>
-              {CATEGORY_META.map(meta => (
+              {visibleCategoryMeta.map(meta => (
                 <CategoryRow
                   key={meta.key}
                   meta={meta}


### PR DESCRIPTION
## Summary

The notifications screen shows the KiloClaw activity row only when you have an active KiloClaw instance. Users without an instance no longer see that row; all other category rows are unchanged.

---

The notifications screen now filters its category list through `useKiloClawTabVisible`, so a user with no active KiloClaw instance never sees the KiloClaw activity row. The `kiloclawActivity` preference key and its `CATEGORY_META` entry stay intact, so stored preferences, the mutation payload, and the default-ON semantics do not change; only the rendered rows are filtered. The next reader must keep this filter until the product deletes the `kiloclawActivity` preference.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/notifications-screen.tsx` — imports `useKiloClawTabVisible`, derives `visibleCategoryMeta` by filtering `CATEGORY_META` (dropping `kiloclawActivity` when the hook returns false), and renders `visibleCategoryMeta` in both the loading skeletons and the category rows.

</details>

Tests: `apps/mobile/src/components/notifications-screen.mounted.test.tsx` adds 4 KiloClaw activity row cases and parameterizes the switch helpers by label.

Generated: none.

---

## Verification

iOS: 2 cases ran.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| N1-no-instance-hides-row | A signed-in user with no active instance does not see the `KiloClaw activity` row, and the other category rows still render. | ios | passed |
| N2-instance-shows-row | A signed-in user with an active instance sees the `KiloClaw activity` row after scroll. | ios | passed |

No defects reproduced. No recording.

## Visual Changes

**Notifications screen, no active instance** — A signed-in user with no active instance sees the category rows and no `KiloClaw activity` row.

![01-notifications-no-kiloclaw-row.png](https://github.com/user-attachments/assets/405cedea-5394-4ebe-a6e3-ca312a1e21d3)

**Notifications screen, active instance** — A signed-in user with an active instance sees the `KiloClaw activity` row after the Balance alerts.

![01-notifications-kiloclaw-row.png](https://github.com/user-attachments/assets/da2087c5-b62a-4227-85ff-826d38840b46)

## Reviewer Notes

none

Human steps: none needed.
