### PR TITLE
fix(mobile): use Kilo in user-facing copy

### DIFF
--- a/apps/mobile/src/components/consent/consent-card.tsx
+++ b/apps/mobile/src/components/consent/consent-card.tsx
@@ -132,8 +132,8 @@ export function ConsentCard({ mode = 'onboarding' }: ConsentCardProps) {
   const handleSecondaryAction = () => {
     const message =
       mode === 'review'
-        ? 'kilo needs this consent to function. Revoking will sign you out. You can accept again on next sign-in.'
-        : 'kilo needs to share data with AI providers to work. If you decline, you will be signed out.';
+        ? 'Kilo needs this consent to function. Revoking will sign you out. You can accept again on next sign-in.'
+        : 'Kilo needs to share data with AI providers to work. If you decline, you will be signed out.';
 
     Alert.alert(actions.destructiveTitle, message, [
       { text: 'Cancel', style: 'cancel' },
@@ -190,12 +190,12 @@ export function ConsentCard({ mode = 'onboarding' }: ConsentCardProps) {
           <View className="h-10 w-10 items-center justify-center rounded-lg bg-secondary">
             <Shield size={20} color={colors.foreground} />
           </View>
-          <Text className="text-base font-semibold text-foreground">kilo</Text>
+          <Text className="text-base font-semibold text-foreground">Kilo</Text>
         </View>
 
         <Text className="mt-6 text-2xl font-bold text-foreground">Before we get started</Text>
         <Text className="mt-3 text-base text-muted-foreground">
-          kilo sends your messages to AI providers to generate responses. Here&apos;s what&apos;s
+          Kilo sends your messages to AI providers to generate responses. Here&apos;s what&apos;s
           shared and with whom.
         </Text>
 

--- a/apps/mobile/src/components/consent/consent-card.tsx
+++ b/apps/mobile/src/components/consent/consent-card.tsx
@@ -132,8 +132,8 @@ export function ConsentCard({ mode = 'onboarding' }: ConsentCardProps) {
   const handleSecondaryAction = () => {
     const message =
       mode === 'review'
-        ? 'Kilo Code needs this consent to function. Revoking will sign you out. You can accept again on next sign-in.'
-        : 'Kilo Code needs to share data with AI providers to work. If you decline, you will be signed out.';
+        ? 'kilo needs this consent to function. Revoking will sign you out. You can accept again on next sign-in.'
+        : 'kilo needs to share data with AI providers to work. If you decline, you will be signed out.';
 
     Alert.alert(actions.destructiveTitle, message, [
       { text: 'Cancel', style: 'cancel' },
@@ -190,13 +190,13 @@ export function ConsentCard({ mode = 'onboarding' }: ConsentCardProps) {
           <View className="h-10 w-10 items-center justify-center rounded-lg bg-secondary">
             <Shield size={20} color={colors.foreground} />
           </View>
-          <Text className="text-base font-semibold text-foreground">Kilo Code</Text>
+          <Text className="text-base font-semibold text-foreground">kilo</Text>
         </View>
 
         <Text className="mt-6 text-2xl font-bold text-foreground">Before we get started</Text>
         <Text className="mt-3 text-base text-muted-foreground">
-          Kilo Code sends your messages to AI providers to generate responses. Here&apos;s
-          what&apos;s shared and with whom.
+          kilo sends your messages to AI providers to generate responses. Here&apos;s what&apos;s
+          shared and with whom.
         </Text>
 
         <Text className="mt-6 text-sm font-semibold text-foreground">Required to use Kilo</Text>

--- a/apps/mobile/src/components/login-screen.tsx
+++ b/apps/mobile/src/components/login-screen.tsx
@@ -187,7 +187,7 @@ export function LoginScreen() {
         >
           <View className="w-full max-w-sm items-center gap-2">
             <Image source={logo} className="mb-1 h-16 w-16" accessibilityLabel="Kilo logo" />
-            <Text className="text-center text-lg">Welcome to kilo</Text>
+            <Text className="text-center text-lg">Welcome to Kilo</Text>
           </View>
 
           {/* Branch fade animations parked mid-flight on remount — e1 measured 2/2

--- a/apps/mobile/src/components/login-screen.tsx
+++ b/apps/mobile/src/components/login-screen.tsx
@@ -187,7 +187,7 @@ export function LoginScreen() {
         >
           <View className="w-full max-w-sm items-center gap-2">
             <Image source={logo} className="mb-1 h-16 w-16" accessibilityLabel="Kilo logo" />
-            <Text className="text-center text-lg">Welcome to Kilo Code</Text>
+            <Text className="text-center text-lg">Welcome to kilo</Text>
           </View>
 
           {/* Branch fade animations parked mid-flight on remount — e1 measured 2/2

--- a/apps/mobile/src/components/login/__tests__/idle-auth.mounted.test.tsx
+++ b/apps/mobile/src/components/login/__tests__/idle-auth.mounted.test.tsx
@@ -136,15 +136,15 @@ describe('IdleAuth SSO recovery', () => {
   });
 });
 
-describe('IdleAuth sign-in-or-create copy', () => {
-  it('shows the sign-in-or-create heading and a Continue button', async () => {
+describe('IdleAuth email continue copy', () => {
+  it('shows a Continue button with email accessibility', async () => {
     const start = vi.fn<StartFn>();
     const renderer = await mountIdleAuth(start);
 
-    expect(texts(renderer.root)).toContain('Sign in or create an account');
     expect(texts(renderer.root)).toContain('Continue');
+    expect(texts(renderer.root)).not.toContain('Sign in or create an account');
 
-    const btn = findButton(renderer.root, 'Continue with email, sign in or create an account');
+    const btn = findButton(renderer.root, 'Continue with email');
     expect(btn).toBeTruthy();
 
     act(() => {

--- a/apps/mobile/src/components/login/idle-auth.tsx
+++ b/apps/mobile/src/components/login/idle-auth.tsx
@@ -210,7 +210,6 @@ export function IdleAuth({
         </View>
       )}
 
-      <Text className="text-base font-semibold text-foreground">Sign in or create an account</Text>
       <FormField
         label="Email address"
         placeholder="you@example.com"
@@ -237,7 +236,7 @@ export function IdleAuth({
         className="flex-row gap-2"
         disabled={authBusy}
         onPress={() => void handleSendCode()}
-        accessibilityLabel="Continue with email, sign in or create an account"
+        accessibilityLabel="Continue with email"
       >
         {busy === 'otp-send' ? <ActivityIndicator size="small" /> : null}
         <Text>Continue</Text>

--- a/apps/mobile/src/lib/auth/use-native-auth.test.ts
+++ b/apps/mobile/src/lib/auth/use-native-auth.test.ts
@@ -417,7 +417,7 @@ describe('useNativeAuth created-account announcement', () => {
       await result?.verifyEmailCode('user@example.com', '123456');
     });
 
-    expect(announcingToast.success).toHaveBeenCalledWith('Account created. Welcome to kilo.');
+    expect(announcingToast.success).toHaveBeenCalledWith('Account created. Welcome to Kilo.');
   });
 
   it('stays silent when created is absent', async () => {

--- a/apps/mobile/src/lib/auth/use-native-auth.test.ts
+++ b/apps/mobile/src/lib/auth/use-native-auth.test.ts
@@ -417,7 +417,7 @@ describe('useNativeAuth created-account announcement', () => {
       await result?.verifyEmailCode('user@example.com', '123456');
     });
 
-    expect(announcingToast.success).toHaveBeenCalledWith('Account created. Welcome to Kilo Code.');
+    expect(announcingToast.success).toHaveBeenCalledWith('Account created. Welcome to kilo.');
   });
 
   it('stays silent when created is absent', async () => {

--- a/apps/mobile/src/lib/auth/use-native-auth.ts
+++ b/apps/mobile/src/lib/auth/use-native-auth.ts
@@ -139,7 +139,7 @@ export function useNativeAuth(): NativeAuthResult {
           'expiresIn' in parsed ? parsed.expiresIn : undefined
         );
         if (parsed.created === true) {
-          announcingToast.success('Account created. Welcome to kilo.');
+          announcingToast.success('Account created. Welcome to Kilo.');
         }
       } else if (result.errorCode === 'SSO_ERROR') {
         handleSsoError(credential.email ?? '', result.ssoOrganizationId);
@@ -206,7 +206,7 @@ export function useNativeAuth(): NativeAuthResult {
           'expiresIn' in parsed ? parsed.expiresIn : undefined
         );
         if (parsed.created === true) {
-          announcingToast.success('Account created. Welcome to kilo.');
+          announcingToast.success('Account created. Welcome to Kilo.');
         }
       } else if (result.errorCode === 'SSO_ERROR') {
         handleSsoError(response.data.user.email, result.ssoOrganizationId);
@@ -304,7 +304,7 @@ export function useNativeAuth(): NativeAuthResult {
           'expiresIn' in parsed ? parsed.expiresIn : undefined
         );
         if (parsed.created === true) {
-          announcingToast.success('Account created. Welcome to kilo.');
+          announcingToast.success('Account created. Welcome to Kilo.');
         }
         return true;
       } catch (error) {

--- a/apps/mobile/src/lib/auth/use-native-auth.ts
+++ b/apps/mobile/src/lib/auth/use-native-auth.ts
@@ -139,7 +139,7 @@ export function useNativeAuth(): NativeAuthResult {
           'expiresIn' in parsed ? parsed.expiresIn : undefined
         );
         if (parsed.created === true) {
-          announcingToast.success('Account created. Welcome to Kilo Code.');
+          announcingToast.success('Account created. Welcome to kilo.');
         }
       } else if (result.errorCode === 'SSO_ERROR') {
         handleSsoError(credential.email ?? '', result.ssoOrganizationId);
@@ -206,7 +206,7 @@ export function useNativeAuth(): NativeAuthResult {
           'expiresIn' in parsed ? parsed.expiresIn : undefined
         );
         if (parsed.created === true) {
-          announcingToast.success('Account created. Welcome to Kilo Code.');
+          announcingToast.success('Account created. Welcome to kilo.');
         }
       } else if (result.errorCode === 'SSO_ERROR') {
         handleSsoError(response.data.user.email, result.ssoOrganizationId);
@@ -304,7 +304,7 @@ export function useNativeAuth(): NativeAuthResult {
           'expiresIn' in parsed ? parsed.expiresIn : undefined
         );
         if (parsed.created === true) {
-          announcingToast.success('Account created. Welcome to Kilo Code.');
+          announcingToast.success('Account created. Welcome to kilo.');
         }
         return true;
       } catch (error) {

--- a/packages/notifications/src/push-presentation.ts
+++ b/packages/notifications/src/push-presentation.ts
@@ -45,17 +45,17 @@ export function androidChannelIdForPushData(data: PushData): AndroidNotification
 export function genericPushContentForPushData(data: PushData): { title: string; body: string } {
   switch (data.type) {
     case 'cloud_agent_session':
-      return { title: 'kilo', body: 'Your agent session has an update' };
+      return { title: 'Kilo', body: 'Your agent session has an update' };
     case 'chat.message':
-      return { title: 'kilo', body: 'You have a new message' };
+      return { title: 'Kilo', body: 'You have a new message' };
     case 'instance-lifecycle':
-      return { title: 'kilo', body: 'Your instance has an update' };
+      return { title: 'Kilo', body: 'Your instance has an update' };
     case 'scheduled-action':
-      return { title: 'kilo', body: 'A scheduled action has an update' };
+      return { title: 'Kilo', body: 'A scheduled action has an update' };
     case 'low_balance':
-      return { title: 'kilo', body: 'Your balance needs attention' };
+      return { title: 'Kilo', body: 'Your balance needs attention' };
     case 'security_finding':
-      return { title: 'kilo', body: 'A security finding needs attention' };
+      return { title: 'Kilo', body: 'A security finding needs attention' };
     default: {
       // Exhaustiveness: new PushData variants must be handled above.
       const _exhaustive: never = data;

--- a/packages/notifications/src/push-presentation.ts
+++ b/packages/notifications/src/push-presentation.ts
@@ -45,17 +45,17 @@ export function androidChannelIdForPushData(data: PushData): AndroidNotification
 export function genericPushContentForPushData(data: PushData): { title: string; body: string } {
   switch (data.type) {
     case 'cloud_agent_session':
-      return { title: 'Kilo Code', body: 'Your agent session has an update' };
+      return { title: 'kilo', body: 'Your agent session has an update' };
     case 'chat.message':
-      return { title: 'Kilo Code', body: 'You have a new message' };
+      return { title: 'kilo', body: 'You have a new message' };
     case 'instance-lifecycle':
-      return { title: 'Kilo Code', body: 'Your instance has an update' };
+      return { title: 'kilo', body: 'Your instance has an update' };
     case 'scheduled-action':
-      return { title: 'Kilo Code', body: 'A scheduled action has an update' };
+      return { title: 'kilo', body: 'A scheduled action has an update' };
     case 'low_balance':
-      return { title: 'Kilo Code', body: 'Your balance needs attention' };
+      return { title: 'kilo', body: 'Your balance needs attention' };
     case 'security_finding':
-      return { title: 'Kilo Code', body: 'A security finding needs attention' };
+      return { title: 'kilo', body: 'A security finding needs attention' };
     default: {
       // Exhaustiveness: new PushData variants must be handled above.
       const _exhaustive: never = data;

--- a/services/notifications/src/__tests__/dispatch-push.test.ts
+++ b/services/notifications/src/__tests__/dispatch-push.test.ts
@@ -1286,7 +1286,7 @@ describe('NotificationChannelDO preview mode and channel', () => {
     const stub = getDO('user-generic');
     await stub.dispatchPush(baseInput({ userId: 'user-generic', idempotencyKey: 'k-generic' }));
     const [[messages]] = vi.mocked(sendPushNotifications).mock.calls;
-    expect(messages[0].title).toBe('Kilo Code');
+    expect(messages[0].title).toBe('kilo');
     expect(messages[0].title).not.toBe('T');
     expect(messages[0].body).not.toBe('B');
   });
@@ -1305,7 +1305,7 @@ describe('NotificationChannelDO preview mode and channel', () => {
     const stub = getDO('user-throw');
     await stub.dispatchPush(baseInput({ userId: 'user-throw', idempotencyKey: 'k-throw' }));
     const [[messages]] = vi.mocked(sendPushNotifications).mock.calls;
-    expect(messages[0].title).toBe('Kilo Code');
+    expect(messages[0].title).toBe('kilo');
     expect(messages[0].body).not.toBe('B');
   });
 });

--- a/services/notifications/src/__tests__/dispatch-push.test.ts
+++ b/services/notifications/src/__tests__/dispatch-push.test.ts
@@ -1286,7 +1286,7 @@ describe('NotificationChannelDO preview mode and channel', () => {
     const stub = getDO('user-generic');
     await stub.dispatchPush(baseInput({ userId: 'user-generic', idempotencyKey: 'k-generic' }));
     const [[messages]] = vi.mocked(sendPushNotifications).mock.calls;
-    expect(messages[0].title).toBe('kilo');
+    expect(messages[0].title).toBe('Kilo');
     expect(messages[0].title).not.toBe('T');
     expect(messages[0].body).not.toBe('B');
   });
@@ -1305,7 +1305,7 @@ describe('NotificationChannelDO preview mode and channel', () => {
     const stub = getDO('user-throw');
     await stub.dispatchPush(baseInput({ userId: 'user-throw', idempotencyKey: 'k-throw' }));
     const [[messages]] = vi.mocked(sendPushNotifications).mock.calls;
-    expect(messages[0].title).toBe('kilo');
+    expect(messages[0].title).toBe('Kilo');
     expect(messages[0].body).not.toBe('B');
   });
 });


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

The app now calls itself "Kilo" instead of "Kilo Code". The new name appears on the login
welcome, the consent screen, the account-created message, and lock-screen push notifications.

The login screen no longer shows the "Sign in or create an account" heading above the email field.

Screen readers now announce the email Continue button as "Continue with email".

---

Every mobile surface that names the product now says "Kilo" instead of "Kilo Code":
the login welcome, the consent card header and intro body, the two consent-revocation alert
messages, the account-created success toast, and the six generic lock-screen push titles. This
is a copy-only rename with no contract, schema, or logic change, so stored data and callers
behave exactly as before. "Kilo" is now the canonical product name, and later copy must match it.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/login-screen.tsx` — welcome text now "Welcome to Kilo".
- `apps/mobile/src/components/consent/consent-card.tsx` — header title, intro body, and two consent-revocation alert bodies use "Kilo".
- `apps/mobile/src/lib/auth/use-native-auth.ts` — three created-account success toasts say "Account created. Welcome to Kilo."
- `packages/notifications/src/push-presentation.ts` — six generic push titles now "Kilo".

</details>

The login screen removes the redundant "Sign in or create an account" heading above the email
field, and the email Continue button's accessibility label becomes "Continue with email". Screen
readers announce the shorter label while the visible "Continue" text stays. No other behavior
changes.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/login/idle-auth.tsx` — deletes the heading; updates the Continue accessibility label.

</details>

Tests: 3 test files updated to match the new copy.
Generated: none.

---

## Verification

Three cases ran on iOS.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| L1 | The welcome text no longer shows `Kilo Code`. | iOS | passed |
| L2 | The redundant `Sign in or create an account` heading no longer appears. | iOS | passed |
| L3 | The email Continue button exposes the accessibility label `Continue with email` and keeps the visible label `Continue`. | iOS | passed |

Unit tests pass: `apps/mobile` 5280 tests, `services/notifications` 192 tests.

No defects reproduced.

## Visual Changes

**Signed-out iOS login screen** — A user now sees `Welcome to Kilo` and the email `Continue` button. The `Sign in or create an account` heading is gone.

![login-copy.png](https://github.com/user-attachments/assets/2d8b7486-3ded-4216-9fb1-8dbeb88381f7)

The screenshot came from the earlier lowercase build, so it shows `Welcome to kilo`. The shipped copy is `Welcome to Kilo`.

## Reviewer Notes

No human steps are needed.
