### PR TITLE
fix(ai-gateway): check Vercel providers after policy filtering

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -33,6 +33,7 @@ import { getPercentageRoutedPartnerProvider } from '@/lib/ai-gateway/providers/p
 import { FRIENDLI_GLM_PUBLIC_ID } from '@/lib/ai-gateway/providers/partner/constants';
 import type { GatewayMessagesRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import { warnExceptInTest } from '@/lib/utils.server';
+import { hasAvailableVercelInferenceProvider } from '@/lib/ai-gateway/providers/vercel';
 
 jest.mock('next/server', () => {
   return {
@@ -70,6 +71,10 @@ jest.mock('@/lib/ai-gateway/abuse-service', () => {
 });
 jest.mock('@/lib/ai-gateway/providers/get-provider');
 jest.mock('@/lib/ai-gateway/providers/partner/routing');
+jest.mock('@/lib/ai-gateway/providers/vercel', () => ({
+  ...jest.requireActual('@/lib/ai-gateway/providers/vercel'),
+  hasAvailableVercelInferenceProvider: jest.fn(),
+}));
 jest.mock('@/lib/ai-gateway/providers/direct-byok', () => ({
   getDirectByokModel: jest.fn(async () => ({ provider: null, model: null })),
 }));
@@ -150,6 +155,7 @@ const mockedLogFreeModelRequest = jest.mocked(logFreeModelRequest);
 const mockedGetEffectiveModelDecision = jest.mocked(getEffectiveModelDecision);
 const mockedGetPercentageRoutedPartnerProvider = jest.mocked(getPercentageRoutedPartnerProvider);
 const mockedWarnExceptInTest = jest.mocked(warnExceptInTest);
+const mockedHasAvailableVercelInferenceProvider = jest.mocked(hasAvailableVercelInferenceProvider);
 
 const provider = {
   id: 'openrouter',
@@ -393,6 +399,34 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect(response.status).toBe(200);
     expect(mockedGetBalanceAndOrgSettings).toHaveBeenCalledTimes(1);
     expect(mockedGetBalanceAndOrgSettings.mock.calls[0]?.[2]).toBe(readDb);
+  });
+
+  it('checks Vercel provider availability after applying the organization allow-list', async () => {
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: { provider_allow_list: ['openai'] },
+      plan: 'enterprise',
+    });
+    mockedGetProvider.mockResolvedValue({
+      kind: 'provider',
+      provider: vercelProvider,
+      userByok: null,
+      bypassAccessCheck: false,
+      vercelFallbackProvider: provider,
+    });
+    mockedHasAvailableVercelInferenceProvider.mockImplementation(async (_model, request) => {
+      expect(request.body.provider?.only).toEqual(['openai']);
+      return false;
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody()) as never);
+
+    expect(response.status).toBe(200);
+    expect(mockedHasAvailableVercelInferenceProvider).toHaveBeenCalledTimes(1);
+    expect(mockedUpstreamRequest).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: expect.objectContaining({ id: 'openrouter' }) })
+    );
   });
 
   it('returns 404 when the OpenRouter model id is unknown', async () => {

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -65,6 +65,7 @@ import {
   logUnrewrittenResponse,
 } from '@/lib/ai-gateway/rewriteModelResponse';
 import { getPercentageRoutedPartnerProvider } from '@/lib/ai-gateway/providers/partner/routing';
+import { hasAvailableVercelInferenceProvider } from '@/lib/ai-gateway/providers/vercel';
 import {
   createAnonymousContext,
   isAnonymousContext,
@@ -846,6 +847,17 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
     if (effectiveProviderConfig && !effectiveProviderContext.experiment) {
       requestBodyParsed.body.provider = effectiveProviderConfig;
     }
+  }
+
+  if (
+    effectiveProviderContext.vercelFallbackProvider &&
+    !(await hasAvailableVercelInferenceProvider(effectiveModelIdLowerCased, requestBodyParsed))
+  ) {
+    effectiveProviderContext = {
+      ...effectiveProviderContext,
+      provider: effectiveProviderContext.vercelFallbackProvider,
+      vercelFallbackProvider: undefined,
+    };
   }
 
   const partnerProvider = await getPercentageRoutedPartnerProvider({

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -53,6 +53,8 @@ export type GetProviderProviderResult = {
   bypassAccessCheck: boolean;
   /** Present when this provider was resolved through a model experiment. */
   experiment?: ExperimentRouting;
+  /** Managed fallback used if the final provider allow-list cannot be served by Vercel. */
+  vercelFallbackProvider?: Provider;
 };
 
 /**
@@ -198,7 +200,7 @@ export type GetProviderInput = {
 };
 
 export async function getProvider(input: GetProviderInput): Promise<GetProviderResult> {
-  const { requestedModel, request, user, organizationId, taskId, clientIp, machineId } = input;
+  const { requestedModel, user, organizationId, taskId, clientIp, machineId } = input;
 
   const directByokByok = await checkDirectBYOK(user, requestedModel, organizationId);
   if (directByokByok) {
@@ -267,22 +269,22 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
 
   const eligibleForVercelRouting =
     !kiloExclusiveModel || kiloExclusiveModel.flags.includes('vercel-routing');
+  const fallbackProvider =
+    (kiloExclusiveModel && tryGetProviderById(kiloExclusiveModel.gateway)) ?? OPENROUTER;
 
-  if (
-    eligibleForVercelRouting &&
-    (await shouldRouteToVercel(requestedModel, request, taskId || user.id))
-  ) {
+  if (eligibleForVercelRouting && (await shouldRouteToVercel(requestedModel, taskId || user.id))) {
     return {
       kind: 'provider',
       provider: VERCEL_AI_GATEWAY,
       userByok: null,
       bypassAccessCheck: false,
+      vercelFallbackProvider: fallbackProvider,
     };
   }
 
   return {
     kind: 'provider',
-    provider: (kiloExclusiveModel && tryGetProviderById(kiloExclusiveModel.gateway)) ?? OPENROUTER,
+    provider: fallbackProvider,
     userByok: null,
     bypassAccessCheck: false,
   };

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -59,11 +59,7 @@ export function isVercelRoutingOptOut(requestedModel: string, optOutModels: Read
   return optOutModels.has(requestedModel);
 }
 
-export async function shouldRouteToVercel(
-  requestedModel: string,
-  request: GatewayRequest,
-  randomSeed: string
-) {
+export async function shouldRouteToVercel(requestedModel: string, randomSeed: string) {
   const routingConfig = await getRuntimeGatewayRoutingConfig();
   if (isVercelRoutingOptOut(requestedModel, routingConfig.vercelOptOutModels)) {
     console.debug(`[shouldRouteToVercel] model ${requestedModel} opted out of Vercel routing`);
@@ -88,6 +84,14 @@ export async function shouldRouteToVercel(
     return false;
   }
 
+  return true;
+}
+
+export async function hasAvailableVercelInferenceProvider(
+  requestedModel: string,
+  request: GatewayRequest
+) {
+  const vercelModelId = mapModelIdToVercel(requestedModel);
   const provider = request.body.provider;
   if (provider && (provider.only || provider.ignore?.length)) {
     const { only, ignore } = provider;


### PR DESCRIPTION
## Summary
- defer Vercel inference-provider compatibility until organization and group allow-lists are applied
- retain the managed fallback provider when Vercel is selected by percentage/model routing
- fall back when the final provider set cannot serve the model through Vercel

## Testing
- not run locally; CI will validate the change