### PR TITLE
fix(kilo-pass): void collectible Stripe invoices on cancel

### DIFF
--- a/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.test.ts
+++ b/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.test.ts
@@ -1,0 +1,161 @@
+import { describe, expect, it, jest } from '@jest/globals';
+
+import { abandonCollectibleInvoicesForStripeSubscription } from './abandon-collectible-invoices';
+
+type InvoicePage = {
+  data: Array<{ id: string; status: 'draft' | 'open' | 'paid' | 'void' | 'uncollectible' }>;
+  has_more: boolean;
+};
+
+function createStripeInvoiceClient() {
+  return {
+    invoices: {
+      list: jest.fn<
+        (params: { status?: string; starting_after?: string }) => Promise<InvoicePage>
+      >(),
+      voidInvoice: jest.fn<(invoiceId: string) => Promise<unknown>>(),
+      del: jest.fn<(invoiceId: string) => Promise<unknown>>(),
+      retrieve:
+        jest.fn<
+          (invoiceId: string) => Promise<{ status: InvoicePage['data'][number]['status'] }>
+        >(),
+    },
+  };
+}
+
+describe('abandonCollectibleInvoicesForStripeSubscription', () => {
+  it('voids open invoices and deletes draft invoices for the subscription', async () => {
+    const stripe = createStripeInvoiceClient();
+    stripe.invoices.list.mockImplementation(async (params: { status?: string }) => {
+      if (params.status === 'open') {
+        return {
+          data: [
+            { id: 'in_open_1', status: 'open' },
+            { id: 'in_open_2', status: 'open' },
+          ],
+          has_more: false,
+        } satisfies InvoicePage;
+      }
+      if (params.status === 'draft') {
+        return {
+          data: [{ id: 'in_draft_1', status: 'draft' }],
+          has_more: false,
+        } satisfies InvoicePage;
+      }
+      return { data: [], has_more: false } satisfies InvoicePage;
+    });
+    stripe.invoices.voidInvoice.mockResolvedValue({});
+    stripe.invoices.del.mockResolvedValue({});
+
+    await abandonCollectibleInvoicesForStripeSubscription({
+      stripe,
+      stripeSubscriptionId: 'sub_kilo_pass',
+    });
+
+    expect(stripe.invoices.list).toHaveBeenCalledWith({
+      subscription: 'sub_kilo_pass',
+      status: 'open',
+      limit: 100,
+    });
+    expect(stripe.invoices.list).toHaveBeenCalledWith({
+      subscription: 'sub_kilo_pass',
+      status: 'draft',
+      limit: 100,
+    });
+    expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_open_1');
+    expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_open_2');
+    expect(stripe.invoices.del).toHaveBeenCalledWith('in_draft_1');
+    expect(stripe.invoices.retrieve).not.toHaveBeenCalled();
+  });
+
+  it('pages through collectible invoices', async () => {
+    const stripe = createStripeInvoiceClient();
+    stripe.invoices.list.mockImplementation(
+      async (params: { status?: string; starting_after?: string }) => {
+        if (params.status === 'open' && params.starting_after == null) {
+          return {
+            data: [{ id: 'in_open_page_1', status: 'open' }],
+            has_more: true,
+          } satisfies InvoicePage;
+        }
+        if (params.status === 'open' && params.starting_after === 'in_open_page_1') {
+          return {
+            data: [{ id: 'in_open_page_2', status: 'open' }],
+            has_more: false,
+          } satisfies InvoicePage;
+        }
+        return { data: [], has_more: false } satisfies InvoicePage;
+      }
+    );
+    stripe.invoices.voidInvoice.mockResolvedValue({});
+
+    await abandonCollectibleInvoicesForStripeSubscription({
+      stripe,
+      stripeSubscriptionId: 'sub_paged',
+    });
+
+    expect(stripe.invoices.list).toHaveBeenCalledWith({
+      subscription: 'sub_paged',
+      status: 'open',
+      limit: 100,
+      starting_after: 'in_open_page_1',
+    });
+    expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_open_page_1');
+    expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_open_page_2');
+  });
+
+  it('ignores invoices that are already paid, void, or missing', async () => {
+    const stripe = createStripeInvoiceClient();
+    stripe.invoices.list.mockImplementation(async (params: { status?: string }) => {
+      if (params.status === 'open') {
+        return {
+          data: [
+            { id: 'in_paid_race', status: 'open' },
+            { id: 'in_already_void', status: 'open' },
+            { id: 'in_missing', status: 'open' },
+          ],
+          has_more: false,
+        } satisfies InvoicePage;
+      }
+      return { data: [], has_more: false } satisfies InvoicePage;
+    });
+    stripe.invoices.voidInvoice.mockImplementation(async (invoiceId: string) => {
+      if (invoiceId === 'in_missing') {
+        throw { code: 'resource_missing' };
+      }
+      throw new Error('invoice cannot be voided');
+    });
+    stripe.invoices.retrieve.mockImplementation(async (invoiceId: string) => {
+      if (invoiceId === 'in_paid_race') return { status: 'paid' };
+      if (invoiceId === 'in_already_void') return { status: 'void' };
+      throw { code: 'resource_missing' };
+    });
+
+    await abandonCollectibleInvoicesForStripeSubscription({
+      stripe,
+      stripeSubscriptionId: 'sub_races',
+    });
+  });
+
+  it('rethrows unexpected void failures', async () => {
+    const stripe = createStripeInvoiceClient();
+    stripe.invoices.list.mockImplementation(async (params: { status?: string }) => {
+      if (params.status === 'open') {
+        return {
+          data: [{ id: 'in_open_fail', status: 'open' }],
+          has_more: false,
+        } satisfies InvoicePage;
+      }
+      return { data: [], has_more: false } satisfies InvoicePage;
+    });
+    stripe.invoices.voidInvoice.mockRejectedValue(new Error('stripe down'));
+    stripe.invoices.retrieve.mockResolvedValue({ status: 'open' });
+
+    await expect(
+      abandonCollectibleInvoicesForStripeSubscription({
+        stripe,
+        stripeSubscriptionId: 'sub_fail',
+      })
+    ).rejects.toThrow('stripe down');
+  });
+});

--- a/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.test.ts
+++ b/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.test.ts
@@ -17,9 +17,6 @@ function createStripeInvoiceClient(): StripeCollectibleInvoiceClient & {
   invoices: {
     list: jest.MockedFunction<StripeCollectibleInvoiceClient['invoices']['list']>;
     update: jest.MockedFunction<StripeCollectibleInvoiceClient['invoices']['update']>;
-    finalizeInvoice: jest.MockedFunction<
-      StripeCollectibleInvoiceClient['invoices']['finalizeInvoice']
-    >;
     voidInvoice: jest.MockedFunction<StripeCollectibleInvoiceClient['invoices']['voidInvoice']>;
     retrieve: jest.MockedFunction<StripeCollectibleInvoiceClient['invoices']['retrieve']>;
   };
@@ -28,7 +25,6 @@ function createStripeInvoiceClient(): StripeCollectibleInvoiceClient & {
     invoices: {
       list: jest.fn<StripeCollectibleInvoiceClient['invoices']['list']>(),
       update: jest.fn<StripeCollectibleInvoiceClient['invoices']['update']>(),
-      finalizeInvoice: jest.fn<StripeCollectibleInvoiceClient['invoices']['finalizeInvoice']>(),
       voidInvoice: jest.fn<StripeCollectibleInvoiceClient['invoices']['voidInvoice']>(),
       retrieve: jest.fn<StripeCollectibleInvoiceClient['invoices']['retrieve']>(),
     },
@@ -36,7 +32,7 @@ function createStripeInvoiceClient(): StripeCollectibleInvoiceClient & {
 }
 
 describe('abandonCollectibleInvoicesForStripeSubscription', () => {
-  it('voids open invoices and finalizes then voids draft invoices for the subscription', async () => {
+  it('voids open invoices and disables auto-advance on draft invoices for the subscription', async () => {
     const stripe = createStripeInvoiceClient();
     stripe.invoices.list.mockImplementation(async params => {
       if (params.status === 'open') {
@@ -57,7 +53,6 @@ describe('abandonCollectibleInvoicesForStripeSubscription', () => {
       return { data: [], has_more: false } satisfies InvoicePage;
     });
     stripe.invoices.update.mockResolvedValue({});
-    stripe.invoices.finalizeInvoice.mockResolvedValue({});
     stripe.invoices.voidInvoice.mockResolvedValue({});
 
     await abandonCollectibleInvoicesForStripeSubscription({
@@ -78,10 +73,7 @@ describe('abandonCollectibleInvoicesForStripeSubscription', () => {
     expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_open_1');
     expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_open_2');
     expect(stripe.invoices.update).toHaveBeenCalledWith('in_draft_1', { auto_advance: false });
-    expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith('in_draft_1', {
-      auto_advance: false,
-    });
-    expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_draft_1');
+    expect(stripe.invoices.voidInvoice).not.toHaveBeenCalledWith('in_draft_1');
     expect(stripe.invoices.retrieve).not.toHaveBeenCalled();
   });
 
@@ -150,6 +142,29 @@ describe('abandonCollectibleInvoicesForStripeSubscription', () => {
       stripe,
       stripeSubscriptionId: 'sub_races',
     });
+  });
+
+  it('voids a listed draft that is already open when auto-advance cannot be disabled', async () => {
+    const stripe = createStripeInvoiceClient();
+    stripe.invoices.list.mockImplementation(async params => {
+      if (params.status === 'draft') {
+        return {
+          data: [{ id: 'in_draft_raced_open', status: 'draft' }],
+          has_more: false,
+        } satisfies InvoicePage;
+      }
+      return { data: [], has_more: false } satisfies InvoicePage;
+    });
+    stripe.invoices.update.mockRejectedValue(new Error('invoice already finalized'));
+    stripe.invoices.retrieve.mockResolvedValue({ status: 'open' });
+    stripe.invoices.voidInvoice.mockResolvedValue({});
+
+    await abandonCollectibleInvoicesForStripeSubscription({
+      stripe,
+      stripeSubscriptionId: 'sub_draft_race',
+    });
+
+    expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_draft_raced_open');
   });
 
   it('rethrows unexpected void failures', async () => {

--- a/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.test.ts
+++ b/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.test.ts
@@ -1,27 +1,36 @@
 import { describe, expect, it, jest } from '@jest/globals';
+import type Stripe from 'stripe';
 
-import { abandonCollectibleInvoicesForStripeSubscription } from './abandon-collectible-invoices';
+import {
+  abandonCollectibleInvoicesForStripeSubscription,
+  type StripeCollectibleInvoiceClient,
+} from './abandon-collectible-invoices';
+
+type InvoiceStatus = NonNullable<Stripe.Invoice['status']>;
 
 type InvoicePage = {
-  data: Array<{ id: string; status: 'draft' | 'open' | 'paid' | 'void' | 'uncollectible' }>;
+  data: Array<{ id: string; status: InvoiceStatus }>;
   has_more: boolean;
 };
 
-function createStripeInvoiceClient() {
+function createStripeInvoiceClient(): StripeCollectibleInvoiceClient & {
+  invoices: {
+    list: jest.MockedFunction<StripeCollectibleInvoiceClient['invoices']['list']>;
+    update: jest.MockedFunction<StripeCollectibleInvoiceClient['invoices']['update']>;
+    finalizeInvoice: jest.MockedFunction<
+      StripeCollectibleInvoiceClient['invoices']['finalizeInvoice']
+    >;
+    voidInvoice: jest.MockedFunction<StripeCollectibleInvoiceClient['invoices']['voidInvoice']>;
+    retrieve: jest.MockedFunction<StripeCollectibleInvoiceClient['invoices']['retrieve']>;
+  };
+} {
   return {
     invoices: {
-      list: jest.fn<
-        (params: { status?: string; starting_after?: string }) => Promise<InvoicePage>
-      >(),
-      update:
-        jest.fn<(invoiceId: string, params: { auto_advance?: boolean }) => Promise<unknown>>(),
-      finalizeInvoice:
-        jest.fn<(invoiceId: string, params?: { auto_advance?: boolean }) => Promise<unknown>>(),
-      voidInvoice: jest.fn<(invoiceId: string) => Promise<unknown>>(),
-      retrieve:
-        jest.fn<
-          (invoiceId: string) => Promise<{ status: InvoicePage['data'][number]['status'] }>
-        >(),
+      list: jest.fn<StripeCollectibleInvoiceClient['invoices']['list']>(),
+      update: jest.fn<StripeCollectibleInvoiceClient['invoices']['update']>(),
+      finalizeInvoice: jest.fn<StripeCollectibleInvoiceClient['invoices']['finalizeInvoice']>(),
+      voidInvoice: jest.fn<StripeCollectibleInvoiceClient['invoices']['voidInvoice']>(),
+      retrieve: jest.fn<StripeCollectibleInvoiceClient['invoices']['retrieve']>(),
     },
   };
 }
@@ -29,7 +38,7 @@ function createStripeInvoiceClient() {
 describe('abandonCollectibleInvoicesForStripeSubscription', () => {
   it('voids open invoices and finalizes then voids draft invoices for the subscription', async () => {
     const stripe = createStripeInvoiceClient();
-    stripe.invoices.list.mockImplementation(async (params: { status?: string }) => {
+    stripe.invoices.list.mockImplementation(async params => {
       if (params.status === 'open') {
         return {
           data: [
@@ -78,23 +87,21 @@ describe('abandonCollectibleInvoicesForStripeSubscription', () => {
 
   it('pages through collectible invoices', async () => {
     const stripe = createStripeInvoiceClient();
-    stripe.invoices.list.mockImplementation(
-      async (params: { status?: string; starting_after?: string }) => {
-        if (params.status === 'open' && params.starting_after == null) {
-          return {
-            data: [{ id: 'in_open_page_1', status: 'open' }],
-            has_more: true,
-          } satisfies InvoicePage;
-        }
-        if (params.status === 'open' && params.starting_after === 'in_open_page_1') {
-          return {
-            data: [{ id: 'in_open_page_2', status: 'open' }],
-            has_more: false,
-          } satisfies InvoicePage;
-        }
-        return { data: [], has_more: false } satisfies InvoicePage;
+    stripe.invoices.list.mockImplementation(async params => {
+      if (params.status === 'open' && params.starting_after == null) {
+        return {
+          data: [{ id: 'in_open_page_1', status: 'open' }],
+          has_more: true,
+        } satisfies InvoicePage;
       }
-    );
+      if (params.status === 'open' && params.starting_after === 'in_open_page_1') {
+        return {
+          data: [{ id: 'in_open_page_2', status: 'open' }],
+          has_more: false,
+        } satisfies InvoicePage;
+      }
+      return { data: [], has_more: false } satisfies InvoicePage;
+    });
     stripe.invoices.voidInvoice.mockResolvedValue({});
 
     await abandonCollectibleInvoicesForStripeSubscription({
@@ -114,7 +121,7 @@ describe('abandonCollectibleInvoicesForStripeSubscription', () => {
 
   it('ignores invoices that are already paid, void, or missing', async () => {
     const stripe = createStripeInvoiceClient();
-    stripe.invoices.list.mockImplementation(async (params: { status?: string }) => {
+    stripe.invoices.list.mockImplementation(async params => {
       if (params.status === 'open') {
         return {
           data: [
@@ -147,7 +154,7 @@ describe('abandonCollectibleInvoicesForStripeSubscription', () => {
 
   it('rethrows unexpected void failures', async () => {
     const stripe = createStripeInvoiceClient();
-    stripe.invoices.list.mockImplementation(async (params: { status?: string }) => {
+    stripe.invoices.list.mockImplementation(async params => {
       if (params.status === 'open') {
         return {
           data: [{ id: 'in_open_fail', status: 'open' }],

--- a/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.test.ts
+++ b/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.test.ts
@@ -13,8 +13,11 @@ function createStripeInvoiceClient() {
       list: jest.fn<
         (params: { status?: string; starting_after?: string }) => Promise<InvoicePage>
       >(),
+      update:
+        jest.fn<(invoiceId: string, params: { auto_advance?: boolean }) => Promise<unknown>>(),
+      finalizeInvoice:
+        jest.fn<(invoiceId: string, params?: { auto_advance?: boolean }) => Promise<unknown>>(),
       voidInvoice: jest.fn<(invoiceId: string) => Promise<unknown>>(),
-      del: jest.fn<(invoiceId: string) => Promise<unknown>>(),
       retrieve:
         jest.fn<
           (invoiceId: string) => Promise<{ status: InvoicePage['data'][number]['status'] }>
@@ -24,7 +27,7 @@ function createStripeInvoiceClient() {
 }
 
 describe('abandonCollectibleInvoicesForStripeSubscription', () => {
-  it('voids open invoices and deletes draft invoices for the subscription', async () => {
+  it('voids open invoices and finalizes then voids draft invoices for the subscription', async () => {
     const stripe = createStripeInvoiceClient();
     stripe.invoices.list.mockImplementation(async (params: { status?: string }) => {
       if (params.status === 'open') {
@@ -44,8 +47,9 @@ describe('abandonCollectibleInvoicesForStripeSubscription', () => {
       }
       return { data: [], has_more: false } satisfies InvoicePage;
     });
+    stripe.invoices.update.mockResolvedValue({});
+    stripe.invoices.finalizeInvoice.mockResolvedValue({});
     stripe.invoices.voidInvoice.mockResolvedValue({});
-    stripe.invoices.del.mockResolvedValue({});
 
     await abandonCollectibleInvoicesForStripeSubscription({
       stripe,
@@ -64,7 +68,11 @@ describe('abandonCollectibleInvoicesForStripeSubscription', () => {
     });
     expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_open_1');
     expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_open_2');
-    expect(stripe.invoices.del).toHaveBeenCalledWith('in_draft_1');
+    expect(stripe.invoices.update).toHaveBeenCalledWith('in_draft_1', { auto_advance: false });
+    expect(stripe.invoices.finalizeInvoice).toHaveBeenCalledWith('in_draft_1', {
+      auto_advance: false,
+    });
+    expect(stripe.invoices.voidInvoice).toHaveBeenCalledWith('in_draft_1');
     expect(stripe.invoices.retrieve).not.toHaveBeenCalled();
   });
 

--- a/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.ts
+++ b/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.ts
@@ -17,10 +17,6 @@ export type StripeCollectibleInvoiceClient = {
       params: Stripe.InvoiceListParams
     ) => PromiseLike<{ data: CollectibleInvoice[]; has_more: boolean }>;
     update: (invoiceId: string, params: Stripe.InvoiceUpdateParams) => Promise<unknown>;
-    finalizeInvoice: (
-      invoiceId: string,
-      params?: Stripe.InvoiceFinalizeInvoiceParams
-    ) => Promise<unknown>;
     voidInvoice: (invoiceId: string) => Promise<unknown>;
     retrieve: (invoiceId: string) => PromiseLike<Pick<Stripe.Invoice, 'status'>>;
   };
@@ -58,13 +54,11 @@ async function listInvoicesByStatus(params: {
   return invoices;
 }
 
-async function finalizeDraftThenVoid(params: {
+async function disableDraftAutoAdvance(params: {
   stripe: StripeCollectibleInvoiceClient;
   invoiceId: string;
 }): Promise<void> {
   await params.stripe.invoices.update(params.invoiceId, { auto_advance: false });
-  await params.stripe.invoices.finalizeInvoice(params.invoiceId, { auto_advance: false });
-  await params.stripe.invoices.voidInvoice(params.invoiceId);
 }
 
 async function ignoreIfAlreadyAbandoned(params: {
@@ -88,7 +82,7 @@ async function ignoreIfAlreadyAbandoned(params: {
     return;
   }
   if (status === 'draft') {
-    await finalizeDraftThenVoid({ stripe: params.stripe, invoiceId: params.invoiceId });
+    await disableDraftAutoAdvance({ stripe: params.stripe, invoiceId: params.invoiceId });
     return;
   }
   throw params.error;
@@ -103,7 +97,7 @@ async function abandonInvoice(params: {
 
   try {
     if (params.invoice.status === 'draft') {
-      await finalizeDraftThenVoid({ stripe: params.stripe, invoiceId });
+      await disableDraftAutoAdvance({ stripe: params.stripe, invoiceId });
       return;
     }
     await params.stripe.invoices.voidInvoice(invoiceId);

--- a/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.ts
+++ b/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.ts
@@ -14,8 +14,12 @@ export type StripeCollectibleInvoiceClient = {
     list: (
       params: Stripe.InvoiceListParams
     ) => PromiseLike<Pick<Stripe.ApiList<Stripe.Invoice>, 'data' | 'has_more'>>;
+    update: (invoiceId: string, params: Stripe.InvoiceUpdateParams) => Promise<unknown>;
+    finalizeInvoice: (
+      invoiceId: string,
+      params?: Stripe.InvoiceFinalizeInvoiceParams
+    ) => Promise<unknown>;
     voidInvoice: (invoiceId: string) => Promise<unknown>;
-    del: (invoiceId: string) => Promise<unknown>;
     retrieve: (invoiceId: string) => PromiseLike<Pick<Stripe.Invoice, 'status'>>;
   };
 };
@@ -52,6 +56,15 @@ async function listInvoicesByStatus(params: {
   return invoices;
 }
 
+async function finalizeDraftThenVoid(params: {
+  stripe: StripeCollectibleInvoiceClient;
+  invoiceId: string;
+}): Promise<void> {
+  await params.stripe.invoices.update(params.invoiceId, { auto_advance: false });
+  await params.stripe.invoices.finalizeInvoice(params.invoiceId, { auto_advance: false });
+  await params.stripe.invoices.voidInvoice(params.invoiceId);
+}
+
 async function ignoreIfAlreadyAbandoned(params: {
   stripe: StripeCollectibleInvoiceClient;
   invoiceId: string;
@@ -72,6 +85,10 @@ async function ignoreIfAlreadyAbandoned(params: {
     await params.stripe.invoices.voidInvoice(params.invoiceId);
     return;
   }
+  if (status === 'draft') {
+    await finalizeDraftThenVoid({ stripe: params.stripe, invoiceId: params.invoiceId });
+    return;
+  }
   throw params.error;
 }
 
@@ -84,7 +101,7 @@ async function abandonInvoice(params: {
 
   try {
     if (params.invoice.status === 'draft') {
-      await params.stripe.invoices.del(invoiceId);
+      await finalizeDraftThenVoid({ stripe: params.stripe, invoiceId });
       return;
     }
     await params.stripe.invoices.voidInvoice(invoiceId);

--- a/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.ts
+++ b/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.ts
@@ -1,0 +1,114 @@
+import 'server-only';
+
+import type Stripe from 'stripe';
+
+const COLLECTIBLE_INVOICE_STATUSES = ['open', 'draft'] as const;
+const ALREADY_ABANDONED_INVOICE_STATUSES: ReadonlySet<string> = new Set([
+  'void',
+  'paid',
+  'uncollectible',
+]);
+
+export type StripeCollectibleInvoiceClient = {
+  invoices: {
+    list: (
+      params: Stripe.InvoiceListParams
+    ) => PromiseLike<Pick<Stripe.ApiList<Stripe.Invoice>, 'data' | 'has_more'>>;
+    voidInvoice: (invoiceId: string) => Promise<unknown>;
+    del: (invoiceId: string) => Promise<unknown>;
+    retrieve: (invoiceId: string) => PromiseLike<Pick<Stripe.Invoice, 'status'>>;
+  };
+};
+
+function isStripeResourceMissing(error: unknown): boolean {
+  return (
+    typeof error === 'object' &&
+    error !== null &&
+    'code' in error &&
+    error.code === 'resource_missing'
+  );
+}
+
+async function listInvoicesByStatus(params: {
+  stripe: StripeCollectibleInvoiceClient;
+  stripeSubscriptionId: string;
+  status: (typeof COLLECTIBLE_INVOICE_STATUSES)[number];
+}): Promise<Stripe.Invoice[]> {
+  const invoices: Stripe.Invoice[] = [];
+  let startingAfter: string | undefined;
+
+  do {
+    const page = await params.stripe.invoices.list({
+      subscription: params.stripeSubscriptionId,
+      status: params.status,
+      limit: 100,
+      ...(startingAfter ? { starting_after: startingAfter } : {}),
+    });
+    invoices.push(...page.data);
+    const lastInvoice = page.data.at(-1);
+    startingAfter = page.has_more && lastInvoice?.id ? lastInvoice.id : undefined;
+  } while (startingAfter);
+
+  return invoices;
+}
+
+async function ignoreIfAlreadyAbandoned(params: {
+  stripe: StripeCollectibleInvoiceClient;
+  invoiceId: string;
+  error: unknown;
+}): Promise<void> {
+  if (isStripeResourceMissing(params.error)) return;
+
+  let status: Stripe.Invoice.Status | null | undefined;
+  try {
+    status = (await params.stripe.invoices.retrieve(params.invoiceId)).status;
+  } catch (retrieveError) {
+    if (isStripeResourceMissing(retrieveError)) return;
+    throw params.error;
+  }
+
+  if (status != null && ALREADY_ABANDONED_INVOICE_STATUSES.has(status)) return;
+  if (status === 'open') {
+    await params.stripe.invoices.voidInvoice(params.invoiceId);
+    return;
+  }
+  throw params.error;
+}
+
+async function abandonInvoice(params: {
+  stripe: StripeCollectibleInvoiceClient;
+  invoice: Pick<Stripe.Invoice, 'id' | 'status'>;
+}): Promise<void> {
+  const invoiceId = params.invoice.id;
+  if (!invoiceId) return;
+
+  try {
+    if (params.invoice.status === 'draft') {
+      await params.stripe.invoices.del(invoiceId);
+      return;
+    }
+    await params.stripe.invoices.voidInvoice(invoiceId);
+  } catch (error) {
+    await ignoreIfAlreadyAbandoned({
+      stripe: params.stripe,
+      invoiceId,
+      error,
+    });
+  }
+}
+
+export async function abandonCollectibleInvoicesForStripeSubscription(params: {
+  stripe: StripeCollectibleInvoiceClient;
+  stripeSubscriptionId: string;
+}): Promise<void> {
+  for (const status of COLLECTIBLE_INVOICE_STATUSES) {
+    const invoices = await listInvoicesByStatus({
+      stripe: params.stripe,
+      stripeSubscriptionId: params.stripeSubscriptionId,
+      status,
+    });
+    for (const invoice of invoices) {
+      await abandonInvoice({ stripe: params.stripe, invoice });
+    }
+  }
+}

--- a/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.ts
+++ b/apps/web/src/lib/kilo-pass/abandon-collectible-invoices.ts
@@ -9,11 +9,13 @@ const ALREADY_ABANDONED_INVOICE_STATUSES: ReadonlySet<string> = new Set([
   'uncollectible',
 ]);
 
+export type CollectibleInvoice = Pick<Stripe.Invoice, 'id' | 'status'>;
+
 export type StripeCollectibleInvoiceClient = {
   invoices: {
     list: (
       params: Stripe.InvoiceListParams
-    ) => PromiseLike<Pick<Stripe.ApiList<Stripe.Invoice>, 'data' | 'has_more'>>;
+    ) => PromiseLike<{ data: CollectibleInvoice[]; has_more: boolean }>;
     update: (invoiceId: string, params: Stripe.InvoiceUpdateParams) => Promise<unknown>;
     finalizeInvoice: (
       invoiceId: string,
@@ -37,8 +39,8 @@ async function listInvoicesByStatus(params: {
   stripe: StripeCollectibleInvoiceClient;
   stripeSubscriptionId: string;
   status: (typeof COLLECTIBLE_INVOICE_STATUSES)[number];
-}): Promise<Stripe.Invoice[]> {
-  const invoices: Stripe.Invoice[] = [];
+}): Promise<CollectibleInvoice[]> {
+  const invoices: CollectibleInvoice[] = [];
   let startingAfter: string | undefined;
 
   do {
@@ -94,7 +96,7 @@ async function ignoreIfAlreadyAbandoned(params: {
 
 async function abandonInvoice(params: {
   stripe: StripeCollectibleInvoiceClient;
-  invoice: Pick<Stripe.Invoice, 'id' | 'status'>;
+  invoice: CollectibleInvoice;
 }): Promise<void> {
   const invoiceId = params.invoice.id;
   if (!invoiceId) return;

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -90,6 +90,9 @@ type StripeMock = {
   };
   invoices: {
     list: ReturnType<typeof jest.fn>;
+    voidInvoice: ReturnType<typeof jest.fn>;
+    del: ReturnType<typeof jest.fn>;
+    retrieve: ReturnType<typeof jest.fn>;
   };
 };
 
@@ -374,6 +377,9 @@ jest.mock('@/lib/stripe-client', () => {
     },
     invoices: {
       list: jest.fn(),
+      voidInvoice: jest.fn(),
+      del: jest.fn(),
+      retrieve: jest.fn(),
     },
   };
 
@@ -491,6 +497,9 @@ function expectNoStripeManagementCalls(stripeMock: StripeMock): void {
   expect(stripeMock.subscriptionSchedules.update).not.toHaveBeenCalled();
   expect(stripeMock.subscriptionSchedules.release).not.toHaveBeenCalled();
   expect(stripeMock.invoices.list).not.toHaveBeenCalled();
+  expect(stripeMock.invoices.voidInvoice).not.toHaveBeenCalled();
+  expect(stripeMock.invoices.del).not.toHaveBeenCalled();
+  expect(stripeMock.invoices.retrieve).not.toHaveBeenCalled();
 }
 
 async function insertBaseCreditsIssuance(params: {
@@ -684,6 +693,10 @@ describe('kiloPassRouter', () => {
     stripeMock.checkout.sessions.retrieve.mockReset();
     stripeMock.billingPortal.sessions.create.mockReset();
     stripeMock.invoices.list.mockReset();
+    stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
+    stripeMock.invoices.voidInvoice.mockReset();
+    stripeMock.invoices.del.mockReset();
+    stripeMock.invoices.retrieve.mockReset();
     getAppStoreVerifierMock().verifyAppleKiloPassTransactionJws.mockReset();
     getStoreCompletionMock().completeStoreKiloPassPurchase.mockReset();
     getPosthogTrackingMock().trackKiloPassPurchaseCompleted.mockReset();
@@ -3819,6 +3832,16 @@ describe('kiloPassRouter', () => {
       expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_test_cancel_me', {
         cancel_at_period_end: true,
       });
+      expect(stripeMock.invoices.list).toHaveBeenCalledWith({
+        subscription: 'sub_test_cancel_me',
+        status: 'open',
+        limit: 100,
+      });
+      expect(stripeMock.invoices.list).toHaveBeenCalledWith({
+        subscription: 'sub_test_cancel_me',
+        status: 'draft',
+        limit: 100,
+      });
 
       const updated = await db.query.kilo_pass_subscriptions.findFirst({
         columns: { status: true, cancel_at_period_end: true },
@@ -3826,6 +3849,81 @@ describe('kiloPassRouter', () => {
       });
       expect(updated?.status).toBe('active');
       expect(updated?.cancel_at_period_end).toBe(true);
+    });
+
+    it('voids open invoices and deletes draft invoices so Stripe stops collection', async () => {
+      const stripeMock = getStripeMock();
+      stripeMock.subscriptions.update.mockResolvedValue({});
+      stripeMock.invoices.list.mockImplementation(async (params: { status?: string }) => {
+        if (params.status === 'open') {
+          return { data: [{ id: 'in_open_failed', status: 'open' }], has_more: false };
+        }
+        if (params.status === 'draft') {
+          return { data: [{ id: 'in_draft_pending', status: 'draft' }], has_more: false };
+        }
+        return { data: [], has_more: false };
+      });
+      stripeMock.invoices.voidInvoice.mockResolvedValue({});
+      stripeMock.invoices.del.mockResolvedValue({});
+
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-cancel-void-invoices@example.com',
+      });
+      await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_test_cancel_void',
+        tier: KiloPassTier.Tier49,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+        cancelAtPeriodEnd: false,
+      });
+
+      const caller = await createCallerForUser(user.id);
+      const result = await caller.kiloPass.cancelSubscription();
+
+      expect(result).toEqual({ success: true });
+      expect(stripeMock.invoices.voidInvoice).toHaveBeenCalledWith('in_open_failed');
+      expect(stripeMock.invoices.del).toHaveBeenCalledWith('in_draft_pending');
+
+      const updated = await db.query.kilo_pass_subscriptions.findFirst({
+        columns: { cancel_at_period_end: true },
+        where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_test_cancel_void'),
+      });
+      expect(updated?.cancel_at_period_end).toBe(true);
+    });
+
+    it('does not persist cancellation when voiding collectible invoices fails', async () => {
+      const stripeMock = getStripeMock();
+      stripeMock.subscriptions.update.mockResolvedValue({});
+      stripeMock.invoices.list.mockImplementation(async (params: { status?: string }) => {
+        if (params.status === 'open') {
+          return { data: [{ id: 'in_open_failed', status: 'open' }], has_more: false };
+        }
+        return { data: [], has_more: false };
+      });
+      stripeMock.invoices.voidInvoice.mockRejectedValue(new Error('stripe void failed'));
+      stripeMock.invoices.retrieve.mockResolvedValue({ status: 'open' });
+
+      const user = await insertTestUser({
+        google_user_email: 'kilo-pass-cancel-void-fails@example.com',
+      });
+      await insertSubscription({
+        kiloUserId: user.id,
+        stripeSubscriptionId: 'sub_test_cancel_void_fail',
+        tier: KiloPassTier.Tier19,
+        cadence: KiloPassCadence.Monthly,
+        status: 'active',
+        cancelAtPeriodEnd: false,
+      });
+
+      const caller = await createCallerForUser(user.id);
+      await expect(caller.kiloPass.cancelSubscription()).rejects.toThrow('stripe void failed');
+
+      const updated = await db.query.kilo_pass_subscriptions.findFirst({
+        columns: { cancel_at_period_end: true },
+        where: eq(kilo_pass_subscriptions.stripe_subscription_id, 'sub_test_cancel_void_fail'),
+      });
+      expect(updated?.cancel_at_period_end).toBe(false);
     });
 
     it('rejects active Google Play subscriptions without canceling in Stripe', async () => {

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -90,8 +90,9 @@ type StripeMock = {
   };
   invoices: {
     list: ReturnType<typeof jest.fn>;
+    update: ReturnType<typeof jest.fn>;
+    finalizeInvoice: ReturnType<typeof jest.fn>;
     voidInvoice: ReturnType<typeof jest.fn>;
-    del: ReturnType<typeof jest.fn>;
     retrieve: ReturnType<typeof jest.fn>;
   };
 };
@@ -377,8 +378,9 @@ jest.mock('@/lib/stripe-client', () => {
     },
     invoices: {
       list: jest.fn(),
+      update: jest.fn(),
+      finalizeInvoice: jest.fn(),
       voidInvoice: jest.fn(),
-      del: jest.fn(),
       retrieve: jest.fn(),
     },
   };
@@ -497,8 +499,9 @@ function expectNoStripeManagementCalls(stripeMock: StripeMock): void {
   expect(stripeMock.subscriptionSchedules.update).not.toHaveBeenCalled();
   expect(stripeMock.subscriptionSchedules.release).not.toHaveBeenCalled();
   expect(stripeMock.invoices.list).not.toHaveBeenCalled();
+  expect(stripeMock.invoices.update).not.toHaveBeenCalled();
+  expect(stripeMock.invoices.finalizeInvoice).not.toHaveBeenCalled();
   expect(stripeMock.invoices.voidInvoice).not.toHaveBeenCalled();
-  expect(stripeMock.invoices.del).not.toHaveBeenCalled();
   expect(stripeMock.invoices.retrieve).not.toHaveBeenCalled();
 }
 
@@ -694,8 +697,9 @@ describe('kiloPassRouter', () => {
     stripeMock.billingPortal.sessions.create.mockReset();
     stripeMock.invoices.list.mockReset();
     stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
+    stripeMock.invoices.update.mockReset();
+    stripeMock.invoices.finalizeInvoice.mockReset();
     stripeMock.invoices.voidInvoice.mockReset();
-    stripeMock.invoices.del.mockReset();
     stripeMock.invoices.retrieve.mockReset();
     getAppStoreVerifierMock().verifyAppleKiloPassTransactionJws.mockReset();
     getStoreCompletionMock().completeStoreKiloPassPurchase.mockReset();
@@ -3851,7 +3855,7 @@ describe('kiloPassRouter', () => {
       expect(updated?.cancel_at_period_end).toBe(true);
     });
 
-    it('voids open invoices and deletes draft invoices so Stripe stops collection', async () => {
+    it('voids open invoices and finalizes then voids draft invoices so Stripe stops collection', async () => {
       const stripeMock = getStripeMock();
       stripeMock.subscriptions.update.mockResolvedValue({});
       stripeMock.invoices.list.mockImplementation(async (params: { status?: string }) => {
@@ -3863,8 +3867,9 @@ describe('kiloPassRouter', () => {
         }
         return { data: [], has_more: false };
       });
+      stripeMock.invoices.update.mockResolvedValue({});
+      stripeMock.invoices.finalizeInvoice.mockResolvedValue({});
       stripeMock.invoices.voidInvoice.mockResolvedValue({});
-      stripeMock.invoices.del.mockResolvedValue({});
 
       const user = await insertTestUser({
         google_user_email: 'kilo-pass-cancel-void-invoices@example.com',
@@ -3883,7 +3888,16 @@ describe('kiloPassRouter', () => {
 
       expect(result).toEqual({ success: true });
       expect(stripeMock.invoices.voidInvoice).toHaveBeenCalledWith('in_open_failed');
-      expect(stripeMock.invoices.del).toHaveBeenCalledWith('in_draft_pending');
+      expect(stripeMock.invoices.update).toHaveBeenCalledWith('in_draft_pending', {
+        auto_advance: false,
+      });
+      expect(stripeMock.invoices.finalizeInvoice).toHaveBeenCalledWith('in_draft_pending', {
+        auto_advance: false,
+      });
+      expect(stripeMock.invoices.voidInvoice).toHaveBeenCalledWith('in_draft_pending');
+      expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_test_cancel_void', {
+        cancel_at_period_end: true,
+      });
 
       const updated = await db.query.kilo_pass_subscriptions.findFirst({
         columns: { cancel_at_period_end: true },
@@ -3918,6 +3932,7 @@ describe('kiloPassRouter', () => {
 
       const caller = await createCallerForUser(user.id);
       await expect(caller.kiloPass.cancelSubscription()).rejects.toThrow('stripe void failed');
+      expect(stripeMock.subscriptions.update).not.toHaveBeenCalled();
 
       const updated = await db.query.kilo_pass_subscriptions.findFirst({
         columns: { cancel_at_period_end: true },

--- a/apps/web/src/routers/kilo-pass-router.test.ts
+++ b/apps/web/src/routers/kilo-pass-router.test.ts
@@ -91,7 +91,6 @@ type StripeMock = {
   invoices: {
     list: ReturnType<typeof jest.fn>;
     update: ReturnType<typeof jest.fn>;
-    finalizeInvoice: ReturnType<typeof jest.fn>;
     voidInvoice: ReturnType<typeof jest.fn>;
     retrieve: ReturnType<typeof jest.fn>;
   };
@@ -379,7 +378,6 @@ jest.mock('@/lib/stripe-client', () => {
     invoices: {
       list: jest.fn(),
       update: jest.fn(),
-      finalizeInvoice: jest.fn(),
       voidInvoice: jest.fn(),
       retrieve: jest.fn(),
     },
@@ -500,7 +498,6 @@ function expectNoStripeManagementCalls(stripeMock: StripeMock): void {
   expect(stripeMock.subscriptionSchedules.release).not.toHaveBeenCalled();
   expect(stripeMock.invoices.list).not.toHaveBeenCalled();
   expect(stripeMock.invoices.update).not.toHaveBeenCalled();
-  expect(stripeMock.invoices.finalizeInvoice).not.toHaveBeenCalled();
   expect(stripeMock.invoices.voidInvoice).not.toHaveBeenCalled();
   expect(stripeMock.invoices.retrieve).not.toHaveBeenCalled();
 }
@@ -698,7 +695,6 @@ describe('kiloPassRouter', () => {
     stripeMock.invoices.list.mockReset();
     stripeMock.invoices.list.mockResolvedValue({ data: [], has_more: false });
     stripeMock.invoices.update.mockReset();
-    stripeMock.invoices.finalizeInvoice.mockReset();
     stripeMock.invoices.voidInvoice.mockReset();
     stripeMock.invoices.retrieve.mockReset();
     getAppStoreVerifierMock().verifyAppleKiloPassTransactionJws.mockReset();
@@ -3855,7 +3851,7 @@ describe('kiloPassRouter', () => {
       expect(updated?.cancel_at_period_end).toBe(true);
     });
 
-    it('voids open invoices and finalizes then voids draft invoices so Stripe stops collection', async () => {
+    it('voids open invoices and disables auto-advance on draft invoices so Stripe stops collection', async () => {
       const stripeMock = getStripeMock();
       stripeMock.subscriptions.update.mockResolvedValue({});
       stripeMock.invoices.list.mockImplementation(async (params: { status?: string }) => {
@@ -3868,7 +3864,6 @@ describe('kiloPassRouter', () => {
         return { data: [], has_more: false };
       });
       stripeMock.invoices.update.mockResolvedValue({});
-      stripeMock.invoices.finalizeInvoice.mockResolvedValue({});
       stripeMock.invoices.voidInvoice.mockResolvedValue({});
 
       const user = await insertTestUser({
@@ -3891,10 +3886,7 @@ describe('kiloPassRouter', () => {
       expect(stripeMock.invoices.update).toHaveBeenCalledWith('in_draft_pending', {
         auto_advance: false,
       });
-      expect(stripeMock.invoices.finalizeInvoice).toHaveBeenCalledWith('in_draft_pending', {
-        auto_advance: false,
-      });
-      expect(stripeMock.invoices.voidInvoice).toHaveBeenCalledWith('in_draft_pending');
+      expect(stripeMock.invoices.voidInvoice).not.toHaveBeenCalledWith('in_draft_pending');
       expect(stripeMock.subscriptions.update).toHaveBeenCalledWith('sub_test_cancel_void', {
         cancel_at_period_end: true,
       });

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -78,6 +78,7 @@ import type Stripe from 'stripe';
 import { dayjs } from '@/lib/kilo-pass/dayjs';
 import { computeChurnkeyAuthHash } from '@/lib/churnkey/auth';
 import { closePauseEvent } from '@/lib/kilo-pass/pause-events';
+import { abandonCollectibleInvoicesForStripeSubscription } from '@/lib/kilo-pass/abandon-collectible-invoices';
 import {
   getAllMobileStoreKiloPassProducts,
   getMobileStoreKiloPassProductByAppleProductId,
@@ -2069,6 +2070,11 @@ export const kiloPassRouter = createTRPCRouter({
 
       await stripe.subscriptions.update(subscription.stripeSubscriptionId, {
         cancel_at_period_end: true,
+      });
+
+      await abandonCollectibleInvoicesForStripeSubscription({
+        stripe,
+        stripeSubscriptionId: subscription.stripeSubscriptionId,
       });
 
       const updated = await db

--- a/apps/web/src/routers/kilo-pass-router.ts
+++ b/apps/web/src/routers/kilo-pass-router.ts
@@ -2068,13 +2068,13 @@ export const kiloPassRouter = createTRPCRouter({
         });
       }
 
-      await stripe.subscriptions.update(subscription.stripeSubscriptionId, {
-        cancel_at_period_end: true,
-      });
-
       await abandonCollectibleInvoicesForStripeSubscription({
         stripe,
         stripeSubscriptionId: subscription.stripeSubscriptionId,
+      });
+
+      await stripe.subscriptions.update(subscription.stripeSubscriptionId, {
+        cancel_at_period_end: true,
       });
 
       const updated = await db


### PR DESCRIPTION
## Summary

Canceling Kilo Pass only set `cancel_at_period_end`, so Stripe kept retrying failed or pending invoices. This stops collection by abandoning collectible invoices before scheduling cancellation.

- Void open invoices for the Stripe subscription
- For drafts, disable `auto_advance`, finalize, then void (instead of deleting drafts)
- Do not persist cancellation if abandoning invoices fails
- Ignore invoices that are already paid, void, uncollectible, or missing

## Test plan

- [x] `oxlint` on the four changed kilo-pass files
- [x] `pnpm typecheck --changes-only`
- [x] `pnpm --filter web test -- src/lib/kilo-pass/abandon-collectible-invoices.test.ts src/routers/kilo-pass-router.test.ts` (139 passed)