### PR TITLE
fix(mobile): hold stored sessions across blank refetch

### DIFF
--- a/apps/mobile/src/lib/agent-session-render-hold.test.ts
+++ b/apps/mobile/src/lib/agent-session-render-hold.test.ts
@@ -1,0 +1,133 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  resolveStoredSessionsHold,
+  type StoredSessionsHold,
+} from '@/lib/agent-session-render-hold';
+
+type Session = { session_id: string; title: string };
+
+const session = (id: string): Session => ({ session_id: id, title: id });
+
+describe('resolveStoredSessionsHold', () => {
+  it('renders non-empty current and captures a hold keyed to the query key', () => {
+    const current = [session('a'), session('b')];
+
+    const result = resolveStoredSessionsHold({
+      current,
+      isFetching: false,
+      queryKeyJson: 'key-1',
+      previousHold: null,
+    });
+
+    expect(result.sessions).toBe(current);
+    expect(result.hold).toEqual({ key: 'key-1', sessions: current });
+  });
+
+  it('renders held rows and keeps the hold when empty + fetching + same key', () => {
+    const held = [session('a'), session('b')];
+    const previousHold: StoredSessionsHold<Session> = { key: 'key-1', sessions: held };
+
+    const result = resolveStoredSessionsHold({
+      current: [],
+      isFetching: true,
+      queryKeyJson: 'key-1',
+      previousHold,
+    });
+
+    expect(result.sessions).toBe(held);
+    expect(result.hold).toBe(previousHold);
+  });
+
+  it('renders empty and clears the hold when empty + fetching + different key', () => {
+    const previousHold: StoredSessionsHold<Session> = {
+      key: 'key-1',
+      sessions: [session('a')],
+    };
+
+    const result = resolveStoredSessionsHold({
+      current: [],
+      isFetching: true,
+      queryKeyJson: 'key-2',
+      previousHold,
+    });
+
+    expect(result.sessions).toEqual([]);
+    expect(result.hold).toBeNull();
+  });
+
+  it('renders empty and keeps hold null on a cold load (empty + fetching + no hold)', () => {
+    const result = resolveStoredSessionsHold({
+      current: [],
+      isFetching: true,
+      queryKeyJson: 'key-1',
+      previousHold: null,
+    });
+
+    expect(result.sessions).toEqual([]);
+    expect(result.hold).toBeNull();
+  });
+
+  it('renders empty and clears the hold on a settled empty (empty + not fetching + hold set)', () => {
+    const previousHold: StoredSessionsHold<Session> = {
+      key: 'key-1',
+      sessions: [session('a')],
+    };
+
+    const result = resolveStoredSessionsHold({
+      current: [],
+      isFetching: false,
+      queryKeyJson: 'key-1',
+      previousHold,
+    });
+
+    expect(result.sessions).toEqual([]);
+    expect(result.hold).toBeNull();
+  });
+
+  it('recovers: held rows render, then fresh non-empty data updates the hold', () => {
+    const held = [session('a')];
+    const previousHold: StoredSessionsHold<Session> = { key: 'key-1', sessions: held };
+
+    const heldRender = resolveStoredSessionsHold({
+      current: [],
+      isFetching: true,
+      queryKeyJson: 'key-1',
+      previousHold,
+    });
+    expect(heldRender.sessions).toBe(held);
+
+    const fresh = [session('a'), session('b')];
+    const recovered = resolveStoredSessionsHold({
+      current: fresh,
+      isFetching: true,
+      queryKeyJson: 'key-1',
+      previousHold: heldRender.hold,
+    });
+
+    expect(recovered.sessions).toBe(fresh);
+    expect(recovered.hold).toEqual({ key: 'key-1', sessions: fresh });
+  });
+
+  it('keeps the same held array across two consecutive blank renders', () => {
+    const held = [session('a')];
+    const previousHold: StoredSessionsHold<Session> = { key: 'key-1', sessions: held };
+
+    const first = resolveStoredSessionsHold({
+      current: [],
+      isFetching: true,
+      queryKeyJson: 'key-1',
+      previousHold,
+    });
+    const second = resolveStoredSessionsHold({
+      current: [],
+      isFetching: true,
+      queryKeyJson: 'key-1',
+      previousHold: first.hold,
+    });
+
+    expect(first.sessions).toBe(held);
+    expect(second.sessions).toBe(held);
+    expect(second.hold).toBe(previousHold);
+  });
+});

--- a/apps/mobile/src/lib/agent-session-render-hold.ts
+++ b/apps/mobile/src/lib/agent-session-render-hold.ts
@@ -1,0 +1,46 @@
+/**
+ * Pure render-hold decision for the stored session list.
+ *
+ * `reconcileFirstPage` empties the cached pages of the stored infinite query
+ * before refetching page one (departure of a live session, mutation settle).
+ * During that refetch the cache legitimately holds zero rows, but the list
+ * must keep rendering the last non-empty rows: blanking flashes "No sessions
+ * yet" and unmounts the SectionList, which resets scroll to the top.
+ *
+ * The hold is scoped to the query key: a filter or sort change builds a new
+ * key and must keep its designed skeleton loading state instead of showing
+ * the previous filter's rows.
+ */
+
+export type StoredSessionsHold<T> = {
+  /** JSON-encoded infinite query key the held sessions belong to. */
+  key: string;
+  sessions: T[];
+};
+
+type ResolvedStoredSessionsHold<T> = {
+  /** Sessions to render: the live rows, or the held rows during a blank refetch. */
+  sessions: T[];
+  /** Hold to carry into the next render, or null when the hold is released. */
+  hold: StoredSessionsHold<T> | null;
+};
+
+export function resolveStoredSessionsHold<T>(input: {
+  /** Sessions collected from the live cache (may be empty mid-refetch). */
+  current: T[];
+  /** `stored.isFetching` — true while the blank+refetch is in flight. */
+  isFetching: boolean;
+  /** JSON-encoded current infinite query key. */
+  queryKeyJson: string;
+  /** Hold captured by the previous render, or null. */
+  previousHold: StoredSessionsHold<T> | null;
+}): ResolvedStoredSessionsHold<T> {
+  const { current, isFetching, queryKeyJson, previousHold } = input;
+  if (current.length > 0) {
+    return { sessions: current, hold: { key: queryKeyJson, sessions: current } };
+  }
+  if (isFetching && previousHold?.key === queryKeyJson) {
+    return { sessions: previousHold.sessions, hold: previousHold };
+  }
+  return { sessions: current, hold: null };
+}

--- a/apps/mobile/src/lib/hooks/use-agent-sessions.ts
+++ b/apps/mobile/src/lib/hooks/use-agent-sessions.ts
@@ -20,6 +20,10 @@ import {
   buildAgentSessionSearchInput,
 } from '@/lib/agent-session-input';
 import { collectSearchPages, collectUnfilteredPages } from '@/lib/agent-session-pages';
+import {
+  resolveStoredSessionsHold,
+  type StoredSessionsHold,
+} from '@/lib/agent-session-render-hold';
 import { groupAgentSessionsByDate } from '@/lib/agent-session-groups';
 import {
   type AgentSessionSortBy,
@@ -250,6 +254,27 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
   // using the shared collection helper.
   const storedSessions = useMemo(() => collectUnfilteredPages(stored.data?.pages), [stored.data]);
 
+  // Render hold: `reconcileFirstPage` (departure effect below, mutation
+  // settle via `invalidateAgentSessionQueries`) empties the cached pages
+  // before refetching page one. Keep rendering the last non-empty rows for
+  // the same query key until the refetch delivers, so the SectionList never
+  // unmounts and scroll survives. A key change (filter/sort) or a settled
+  // empty result releases the hold.
+  const storedQueryKeyJson = JSON.stringify(
+    trpc.cliSessionsV2.list.infiniteQueryKey(buildAgentSessionListInput(options ?? {}))
+  );
+  const storedHoldRef = useRef<StoredSessionsHold<StoredSession> | null>(null);
+  const resolvedStored = resolveStoredSessionsHold({
+    current: storedSessions,
+    isFetching: stored.isFetching,
+    queryKeyJson: storedQueryKeyJson,
+    previousHold: storedHoldRef.current,
+  });
+  useEffect(() => {
+    storedHoldRef.current = resolvedStored.hold;
+  }, [resolvedStored.hold]);
+  const renderedStoredSessions = resolvedStored.sessions;
+
   // The server already filters by context; this covers the window where a WS
   // heartbeat has introduced a row the client has not enriched yet (see
   // `filterActiveSessionsByOrganization`).
@@ -279,8 +304,8 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
   );
 
   const dateGroups = useMemo(
-    () => groupAgentSessionsByDate(storedSessions, sortBy),
-    [storedSessions, sortBy]
+    () => groupAgentSessionsByDate(renderedStoredSessions, sortBy),
+    [renderedStoredSessions, sortBy]
   );
 
   // Departure-triggered stored reset. Only the active poll has a refetch
@@ -294,7 +319,8 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
   //
   // The guard is strictly "id present before, absent now": the empty→populated
   // transition (first poll) is ignored, and the initial mount with a non-empty
-  // set is ignored (no "before" to compare against).
+  // set is ignored (no "before" to compare against). The render hold above
+  // keeps the last rows visible while this reset refetches page one.
   const previousActiveIdsRef = useRef<Set<string> | null>(null);
   useEffect(() => {
     const previous = previousActiveIdsRef.current;
@@ -317,7 +343,7 @@ export function useAgentSessions(options?: UseAgentSessionsOptions) {
   }, [activeSessionIds, queryClient, trpc]);
 
   return {
-    storedSessions,
+    storedSessions: renderedStoredSessions,
     activeSessions,
     activeSessionIds,
     activeExclusionIds,

--- a/apps/mobile/src/lib/query/infinite-retention.test.ts
+++ b/apps/mobile/src/lib/query/infinite-retention.test.ts
@@ -1,4 +1,4 @@
-import { QueryClient } from '@tanstack/react-query';
+import { InfiniteQueryObserver, QueryClient } from '@tanstack/react-query';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -110,5 +110,40 @@ describe('reconcileFirstPage', () => {
     // eslint-disable-next-line typescript-eslint/no-confusing-void-expression -- asserting the void return proves the call needs no await.
     const returned = reconcileFirstPage(queryClient, ['trpc', 'cliSessionsV2', 'list']);
     expect(returned).toBeUndefined();
+  });
+
+  it('empties pages and flips fetchStatus to fetching in the same flush on an observed idle query', () => {
+    const queryClient = new QueryClient();
+    const prefix = ['trpc', 'cliSessionsV2', 'list'];
+    const fullKey = [...prefix, { input: { organizationId: 'org-1' } }];
+    queryClient.setQueryData(fullKey, {
+      pages: [page([{ id: 'a', title: 'a' }])],
+      pageParams: [0],
+    });
+
+    const observer = new InfiniteQueryObserver(queryClient, {
+      queryKey: fullKey,
+      // eslint-disable-next-line require-await -- the recipe pins an async queryFn for the flush contract; the body needs no await.
+      queryFn: async () => page([{ id: 'a', title: 'a' }]),
+      initialPageParam: 0,
+      getNextPageParam: () => undefined,
+      staleTime: Infinity,
+      retry: false,
+    });
+    // eslint-disable-next-line no-empty-function -- a real listener is required to activate the observer; the body is intentionally empty.
+    const unsubscribe = observer.subscribe(() => {});
+
+    // The observer must be settled before the blank, or the fetchStatus flip
+    // below would be vacuous.
+    expect(observer.getCurrentResult().data).toBeDefined();
+    expect(observer.getCurrentResult().fetchStatus).toBe('idle');
+
+    reconcileFirstPage(queryClient, prefix);
+
+    const data = queryClient.getQueryData(fullKey) as { pages: Page[] };
+    expect(data.pages).toEqual([]);
+    expect(queryClient.getQueryState(fullKey)?.fetchStatus).toBe('fetching');
+
+    unsubscribe();
   });
 });


### PR DESCRIPTION
## Summary

The Agents tab session list no longer flashes an empty "No sessions yet" or "No past sessions" message during a background refresh.

The session list keeps its scroll position when a live session ends or when a rename, delete, or create settles.

---

The stored session list now renders the last non-empty rows while `reconcileFirstPage` blanks the cache and refetches page one. The new `resolveStoredSessionsHold` contract and `StoredSessionsHold` type decide the render from the live rows, the fetch state, and the previous hold, scoped to the JSON-encoded infinite query key, so a filter or sort change still shows its skeleton instead of the previous filter's rows. The hold releases when the refetch settles with rows or with an empty result.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/agent-session-render-hold.ts` — adds the `StoredSessionsHold` type and the pure `resolveStoredSessionsHold` helper.
- `apps/mobile/src/lib/hooks/use-agent-sessions.ts` — computes the JSON query key, feeds the live rows and fetch state into the helper, stores the hold in a ref, and renders the resolved rows for date grouping and the returned `storedSessions`.

</details>

Tests: 2 files — `apps/mobile/src/lib/agent-session-render-hold.test.ts` (new) and `apps/mobile/src/lib/query/infinite-retention.test.ts` (updated).
Generated: none.

---

## Visual Changes

**Agents tab session list (iOS).** When a live session ends, the list keeps its history rows and scroll position, and no empty state appears. The clipped row under the TODAY header and the 22:41 history rows below it show the kept scroll position.

![s2-after-departure.png](https://github.com/user-attachments/assets/1ba56143-468e-473c-b38e-f2b9bcc5c708)

## Verification

Two cases ran on iOS.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| s1 | The list keeps its history rows and shows no empty state during the departure refetch, pull-to-refresh, and one poll cycle. | iOS | passed |
| s2 | A list scrolled into the history keeps its position when the live session ends. | iOS | passed |

The rounds reproduced no defect on an unfixed build; the fix was already in place, so no unfixed-build repro ran.
Recordings: `/private/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo-workflow-agents-list-stability-53a1.xPYOqS/e2e-verify-r1-BQRXsC/s1-blanking-refetch.mp4` and `/private/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo-workflow-agents-list-stability-53a1.xPYOqS/e2e-verify-r2-ANxpxY/s2-scroll-live-dead.mp4`.

## Reviewer Notes

No human steps are needed.
