### PR TITLE
fix(mobile): scope child session error to the child sheet

### DIFF
--- a/apps/mobile/src/components/agents/child-session-sheet-state.test.ts
+++ b/apps/mobile/src/components/agents/child-session-sheet-state.test.ts
@@ -34,12 +34,63 @@ describe('getChildSessionSheetState', () => {
     ).toBe('empty');
   });
 
+  it('shows an empty state when the session error is null', () => {
+    expect(
+      getChildSessionSheetState(
+        {
+          status: 'ready',
+          cursor: null,
+          hasOlder: false,
+          isLoadingOlder: false,
+          olderError: null,
+          omittedItemCount: 0,
+        },
+        0,
+        null
+      )
+    ).toBe('empty');
+  });
+
   it('shows an error after failed hydration with no messages', () => {
     expect(getChildSessionSheetState({ status: 'error', message: 'Failed' }, 0)).toBe('error');
   });
 
   it('keeps rendering messages if a refresh fails', () => {
     expect(getChildSessionSheetState({ status: 'error', message: 'Failed' }, 1)).toBe('content');
+  });
+
+  it('shows an error for a runtime error with no messages and hydration ready', () => {
+    expect(
+      getChildSessionSheetState(
+        {
+          status: 'ready',
+          cursor: null,
+          hasOlder: false,
+          isLoadingOlder: false,
+          olderError: null,
+          omittedItemCount: 0,
+        },
+        0,
+        'Requests ending with a model turn are not supported.'
+      )
+    ).toBe('error');
+  });
+
+  it('keeps rendering messages when a runtime error exists', () => {
+    expect(
+      getChildSessionSheetState(
+        {
+          status: 'ready',
+          cursor: null,
+          hasOlder: false,
+          isLoadingOlder: false,
+          olderError: null,
+          omittedItemCount: 0,
+        },
+        1,
+        'Requests ending with a model turn are not supported.'
+      )
+    ).toBe('content');
   });
 });
 

--- a/apps/mobile/src/components/agents/child-session-sheet-state.ts
+++ b/apps/mobile/src/components/agents/child-session-sheet-state.ts
@@ -19,16 +19,20 @@ export type ChildSessionSheetMountState = {
 
 export function getChildSessionSheetState(
   hydrationState: ChildSessionHydrationState,
-  messageCount: number
+  messageCount: number,
+  sessionError?: string | null
 ): ChildSessionSheetState {
   if (messageCount > 0) {
     return 'content';
   }
-  if (hydrationState.status === 'ready') {
-    return 'empty';
-  }
   if (hydrationState.status === 'error') {
     return 'error';
+  }
+  if (sessionError) {
+    return 'error';
+  }
+  if (hydrationState.status === 'ready') {
+    return 'empty';
   }
   return 'loading';
 }

--- a/apps/mobile/src/components/agents/child-session-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/child-session-sheet.mounted.test.tsx
@@ -131,6 +131,7 @@ function buildProps({
     title: 'Subagent',
     getChildMessages,
     hydrationState,
+    sessionError: null,
     isStreaming: false,
     hasOlderMessages: false,
     isLoadingOlderMessages: false,

--- a/apps/mobile/src/components/agents/child-session-sheet.tsx
+++ b/apps/mobile/src/components/agents/child-session-sheet.tsx
@@ -24,6 +24,7 @@ import { MessageErrorBoundary } from './message-error-boundary';
 import { PartDetailSheetHost } from './part-detail-sheet-host';
 import { getChildSessionSheetState } from './child-session-sheet-state';
 import { SessionMessageList } from './session-message-list';
+import { SessionStatusIndicator } from './session-status-indicator';
 import { WorkingIndicator } from './working-indicator';
 
 type ChildSessionSheetProps = {
@@ -32,6 +33,7 @@ type ChildSessionSheetProps = {
   title: string;
   getChildMessages: (sessionId: string) => StoredMessage[];
   hydrationState: ChildSessionHydrationState;
+  sessionError: string | null;
   isStreaming: boolean;
   hasOlderMessages: boolean;
   isLoadingOlderMessages: boolean;
@@ -53,6 +55,7 @@ export function ChildSessionSheet({
   title,
   getChildMessages,
   hydrationState,
+  sessionError,
   isStreaming,
   hasOlderMessages,
   isLoadingOlderMessages,
@@ -67,7 +70,7 @@ export function ChildSessionSheet({
   modelOptions,
 }: Readonly<ChildSessionSheetProps>) {
   const messages = getChildMessages(sessionId);
-  const state = getChildSessionSheetState(hydrationState, messages.length);
+  const state = getChildSessionSheetState(hydrationState, messages.length, sessionError);
   const modelLabel = getChildSessionModelLabel(messages, modelOptions ?? []);
   // Safe-area context can return 0 inside a RN `Modal` (pageSheet doesn't
   // always propagate the home-indicator inset), so we floor the value with
@@ -107,13 +110,16 @@ export function ChildSessionSheet({
       />
     );
   } else if (state === 'error') {
-    content = (
-      <QueryError
-        title="Could not load subagent session"
-        message={hydrationState.status === 'error' ? hydrationState.message : undefined}
-        onRetry={onRetry}
-      />
-    );
+    content =
+      hydrationState.status === 'error' ? (
+        <QueryError
+          title="Could not load subagent session"
+          message={hydrationState.message}
+          onRetry={onRetry}
+        />
+      ) : (
+        <QueryError title="Subagent session failed" message={sessionError ?? undefined} />
+      );
   } else if (state === 'empty') {
     content = (
       <EmptyState
@@ -130,6 +136,17 @@ export function ChildSessionSheet({
           title="Loading subagent session"
           description="Waiting for subagent messages…"
         />
+      </View>
+    );
+  }
+
+  if (state === 'content' && sessionError) {
+    content = (
+      <View className="flex-1">
+        <SessionStatusIndicator
+          indicator={{ type: 'error', message: sessionError, timestamp: 0 }}
+        />
+        {content}
       </View>
     );
   }

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -201,6 +201,7 @@ export function SessionDetailContent({
   );
   const getChildMessages = useAtomValue(manager.atoms.childMessages);
   const getChildSessionHydrationState = useAtomValue(manager.atoms.childSessionHydrationState);
+  const getChildSessionError = useAtomValue(manager.atoms.childSessionError);
   const pendingMessages = useAtomValue(manager.atoms.pendingMessages);
   const activeSessionType = useAtomValue(manager.atoms.activeSessionType);
   const remoteModelState = useAtomValue(manager.atoms.remoteModelState);
@@ -1159,6 +1160,7 @@ export function SessionDetailContent({
             title={childSessionSheet.sheet.title}
             getChildMessages={getChildMessages}
             hydrationState={getChildSessionHydrationState(childSessionSheet.sheet.sessionId)}
+            sessionError={getChildSessionError(childSessionSheet.sheet.sessionId)}
             isStreaming={getChildSessionStreaming(messages, childSessionSheet.sheet.sessionId)}
             hasOlderMessages={childHasOlderMessages}
             isLoadingOlderMessages={childIsLoadingOlderMessages}

--- a/packages/cloud-agent-sdk/src/service-state.test.ts
+++ b/packages/cloud-agent-sdk/src/service-state.test.ts
@@ -322,6 +322,23 @@ describe('createServiceState', () => {
       });
     });
 
+    it('adopts the server-reported root session ID for errors', () => {
+      const onError = jest.fn();
+      const onChildSessionError = jest.fn();
+      const state = createServiceState(makeConfig({ onError, onChildSessionError }));
+
+      state.process({ type: 'session.created', info: makeSession('server-root') });
+      state.process({
+        type: 'session.error',
+        error: 'Root session failed.',
+        sessionId: 'server-root',
+      });
+
+      expect(onError).toHaveBeenCalledWith('Root session failed.');
+      expect(onChildSessionError).not.toHaveBeenCalled();
+      expect(state.getStatus()).toEqual({ type: 'error', message: 'Root session failed.' });
+    });
+
     it('keeps events without a sessionId on the legacy root path', () => {
       const onError = jest.fn();
       const onChildSessionError = jest.fn();

--- a/packages/cloud-agent-sdk/src/service-state.test.ts
+++ b/packages/cloud-agent-sdk/src/service-state.test.ts
@@ -284,6 +284,56 @@ describe('createServiceState', () => {
       expect(state.getStatus()).toEqual({ type: 'error', message: 'Something went wrong' });
     });
 
+    it('scopes child errors to onChildSessionError without touching root state', () => {
+      const onError = jest.fn();
+      const onChildSessionError = jest.fn();
+      const state = createServiceState(makeConfig({ onError, onChildSessionError }));
+
+      state.process({
+        type: 'session.error',
+        error: 'Requests ending with a model turn are not supported.',
+        sessionId: 'child-1',
+      });
+
+      expect(onError).not.toHaveBeenCalled();
+      expect(state.getStatus()).toEqual({ type: 'idle' });
+      expect(onChildSessionError).toHaveBeenCalledWith(
+        'child-1',
+        'Requests ending with a model turn are not supported.'
+      );
+    });
+
+    it('keeps root session errors on onError and root status', () => {
+      const onError = jest.fn();
+      const onChildSessionError = jest.fn();
+      const state = createServiceState(makeConfig({ onError, onChildSessionError }));
+
+      state.process({
+        type: 'session.error',
+        error: 'Requests ending with a model turn are not supported.',
+        sessionId: 'root-1',
+      });
+
+      expect(onError).toHaveBeenCalledWith('Requests ending with a model turn are not supported.');
+      expect(onChildSessionError).not.toHaveBeenCalled();
+      expect(state.getStatus()).toEqual({
+        type: 'error',
+        message: 'Requests ending with a model turn are not supported.',
+      });
+    });
+
+    it('keeps events without a sessionId on the legacy root path', () => {
+      const onError = jest.fn();
+      const onChildSessionError = jest.fn();
+      const state = createServiceState(makeConfig({ onError, onChildSessionError }));
+
+      state.process({ type: 'session.error', error: 'Something went wrong' });
+
+      expect(onError).toHaveBeenCalledWith('Something went wrong');
+      expect(onChildSessionError).not.toHaveBeenCalled();
+      expect(state.getStatus()).toEqual({ type: 'error', message: 'Something went wrong' });
+    });
+
     it('is suppressed after stopped(error) — aftershock absorption', () => {
       const onError = jest.fn();
       const state = createServiceState(makeConfig({ onError }));

--- a/packages/cloud-agent-sdk/src/service-state.ts
+++ b/packages/cloud-agent-sdk/src/service-state.ts
@@ -109,6 +109,7 @@ function upsertByRequestId<T extends { requestId: string }>(
 }
 
 function createServiceState(config: ServiceStateConfig): ServiceState {
+  let rootSessionId = config.rootSessionId;
   let activity: SessionActivity = INITIAL_ACTIVITY;
   let status: AgentStatus = IDLE_STATUS;
   let cloudStatus: CloudStatus | null = null;
@@ -135,7 +136,7 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
   }
 
   function isRootSession(sessionId: string): boolean {
-    return sessionId === config.rootSessionId;
+    return sessionId === rootSessionId;
   }
 
   function processSessionStatus(event: Extract<ServiceEvent, { type: 'session.status' }>): void {
@@ -246,6 +247,9 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
   }
 
   function processSessionCreated(event: Extract<ServiceEvent, { type: 'session.created' }>): void {
+    if (event.info.parentID == null) {
+      rootSessionId = event.info.id;
+    }
     // Only track root session info
     if (isRootSession(event.info.id)) {
       sessionInfo = event.info;

--- a/packages/cloud-agent-sdk/src/service-state.ts
+++ b/packages/cloud-agent-sdk/src/service-state.ts
@@ -26,6 +26,7 @@ type ServiceStateConfig = {
   /** The root session ID we're tracking (to detect child sessions). */
   rootSessionId: string;
   onError?: ((message: string) => void) | undefined;
+  onChildSessionError?: ((sessionId: string, message: string) => void) | undefined;
   onQuestionAsked?: ((requestId: string, questions?: QuestionInfo[]) => void) | undefined;
   onQuestionResolved?: ((requestId: string) => void) | undefined;
   onPermissionAsked?:
@@ -229,6 +230,14 @@ function createServiceState(config: ServiceStateConfig): ServiceState {
 
   function processSessionError(event: Extract<ServiceEvent, { type: 'session.error' }>): void {
     if (terminated) return;
+
+    // Child session errors are scoped to the child. They must not touch the
+    // shared root status or onError, which drive the parent status indicator.
+    // Events without a sessionId keep the legacy root behavior.
+    if (event.sessionId !== undefined && !isRootSession(event.sessionId)) {
+      config.onChildSessionError?.(event.sessionId, event.error);
+      return;
+    }
 
     config.onError?.(event.error);
     status = { type: 'error', message: event.error };

--- a/packages/cloud-agent-sdk/src/session-manager.test.ts
+++ b/packages/cloud-agent-sdk/src/session-manager.test.ts
@@ -128,6 +128,7 @@ const mockSessionCallbacks: {
     state: Extract<MessageDeliveryState, { status: 'failed' }>
   ) => void;
   onError?: (message: string) => void;
+  onChildSessionError?: (sessionId: string, message: string) => void;
 } = {};
 
 let latestStorage: JotaiSessionStorage | null = null;
@@ -163,6 +164,7 @@ jest.mock('./session', () => ({
         state: Extract<MessageDeliveryState, { status: 'failed' }>
       ) => void;
       onError?: (message: string) => void;
+      onChildSessionError?: (sessionId: string, message: string) => void;
       transport?: {
         userWebConnection?: unknown;
         fetchSnapshotPage?: (
@@ -232,6 +234,7 @@ jest.mock('./session', () => ({
       mockSessionCallbacks.onMessageCompleted = sessionConfig.onMessageCompleted;
       mockSessionCallbacks.onMessageFailed = sessionConfig.onMessageFailed;
       mockSessionCallbacks.onError = sessionConfig.onError;
+      mockSessionCallbacks.onChildSessionError = sessionConfig.onChildSessionError;
       return mockSession;
     }
   ),
@@ -433,6 +436,7 @@ describe('createSessionManager', () => {
     mockSessionCallbacks.onMessageCompleted = undefined;
     mockSessionCallbacks.onMessageFailed = undefined;
     mockSessionCallbacks.onError = undefined;
+    mockSessionCallbacks.onChildSessionError = undefined;
   });
 
   // -------------------------------------------------------------------------
@@ -3019,6 +3023,58 @@ describe('createSessionManager', () => {
       expect(state('child-omit')).toEqual(
         expect.objectContaining({ status: 'ready', omittedItemCount: 5 })
       );
+    });
+  });
+
+  describe('child session errors', () => {
+    it('routes child session errors to the per-child atom without touching root atoms', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+
+      mockSessionCallbacks.onChildSessionError?.(
+        'child-1',
+        'Requests ending with a model turn are not supported.'
+      );
+
+      expect(atomValue<string | null>(config.store, mgr.atoms.error)).toBeNull();
+      expect(atomValue(config.store, mgr.atoms.statusIndicator)).toBeNull();
+      const childSessionError = atomValue<(childSessionId: string) => string | null>(
+        config.store,
+        mgr.atoms.childSessionError
+      );
+      expect(childSessionError('child-1')).toBe(
+        'Requests ending with a model turn are not supported.'
+      );
+      expect(childSessionError('other-child')).toBeNull();
+    });
+
+    it('clears child session errors when switching sessions', async () => {
+      const config = createMockConfig();
+      const mgr = createSessionManager(config);
+
+      await mgr.switchSession(kiloId('ses-root'));
+
+      mockSessionCallbacks.onChildSessionError?.(
+        'child-1',
+        'Requests ending with a model turn are not supported.'
+      );
+
+      expect(
+        atomValue<(childSessionId: string) => string | null>(
+          config.store,
+          mgr.atoms.childSessionError
+        )('child-1')
+      ).toBe('Requests ending with a model turn are not supported.');
+
+      await mgr.switchSession(kiloId('ses-other'));
+
+      const childSessionError = atomValue<(childSessionId: string) => string | null>(
+        config.store,
+        mgr.atoms.childSessionError
+      );
+      expect(childSessionError('child-1')).toBeNull();
     });
   });
 

--- a/packages/cloud-agent-sdk/src/session-manager.ts
+++ b/packages/cloud-agent-sdk/src/session-manager.ts
@@ -367,6 +367,7 @@ type SessionManagerAtoms = {
   contextUsage: Atom<ContextUsage | undefined>;
   childMessages: Atom<(childSessionId: string) => StoredMessage[]>;
   childSessionHydrationState: Atom<(childSessionId: string) => ChildSessionHydrationState>;
+  childSessionError: Atom<(childSessionId: string) => string | null>;
   /** True when the latest page left a non-null cursor (more history to load). */
   hasOlderMessages: W<boolean>;
   /** True while `loadOlderMessages()` is fetching a page. */
@@ -642,6 +643,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
    */
   const availableCommandsAtom = atom<SlashCommandInfo[]>([]);
   const childSessionHydrationStatesAtom = atom<Map<string, ChildSessionHydrationState>>(new Map());
+  const childSessionErrorsAtom = atom<Map<string, string>>(new Map());
   const hasOlderMessagesAtom = atom<boolean>(false);
   const isLoadingOlderMessagesAtom = atom<boolean>(false);
   const olderMessagesErrorAtom = atom<OlderMessagesError | null>(null);
@@ -725,6 +727,10 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     const states = get(childSessionHydrationStatesAtom);
     return (childSessionId: string): ChildSessionHydrationState =>
       states.get(childSessionId) ?? IDLE_CHILD_SESSION_HYDRATION_STATE;
+  });
+  const childSessionErrorAtom = atom(get => {
+    const errors = get(childSessionErrorsAtom);
+    return (childSessionId: string): string | null => errors.get(childSessionId) ?? null;
   });
 
   // Private mutable state
@@ -853,6 +859,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
     store.set(failedPromptAtom, null);
     store.set(fetchedSessionDataAtom, null);
     store.set(childSessionHydrationStatesAtom, new Map());
+    store.set(childSessionErrorsAtom, new Map());
     store.set(chatUIAtom, { shouldAutoScroll: true });
     store.set(availableCommandsAtom, []);
     store.set(hasOlderMessagesAtom, false);
@@ -1690,6 +1697,11 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
         }
         store.set(errorAtom, message);
       },
+      onChildSessionError: (childSessionId, message) => {
+        const next = new Map(store.get(childSessionErrorsAtom));
+        next.set(childSessionId, message);
+        store.set(childSessionErrorsAtom, next);
+      },
       onMessageFailed: (_messageId, deliveryState) => {
         if (deliveryState.reason !== 'exhausted') return;
         setIndicator({
@@ -2188,6 +2200,7 @@ function createSessionManager(config: SessionManagerConfig): SessionManager {
       contextUsage: contextUsageAtom,
       childMessages: childMessagesAtom,
       childSessionHydrationState: childSessionHydrationStateAtom,
+      childSessionError: childSessionErrorAtom,
       hasOlderMessages: hasOlderMessagesAtom,
       isLoadingOlderMessages: isLoadingOlderMessagesAtom,
       olderMessagesError: olderMessagesErrorAtom,

--- a/packages/cloud-agent-sdk/src/session.ts
+++ b/packages/cloud-agent-sdk/src/session.ts
@@ -56,6 +56,7 @@ type CloudAgentSessionConfig = {
   websocketBaseUrl?: string;
   storage?: SessionStorage;
   onError?: (message: string) => void;
+  onChildSessionError?: (sessionId: string, message: string) => void;
   onQuestionAsked?: (requestId: string, questions?: QuestionInfo[]) => void;
   onQuestionResolved?: (requestId: string) => void;
   onPermissionAsked?: (
@@ -229,6 +230,7 @@ function createCloudAgentSession(config: CloudAgentSessionConfig): CloudAgentSes
   const serviceState = createServiceState({
     rootSessionId: config.kiloSessionId,
     onError: config.onError,
+    onChildSessionError: config.onChildSessionError,
     onQuestionAsked: config.onQuestionAsked,
     onQuestionResolved: config.onQuestionResolved,
     onPermissionAsked: config.onPermissionAsked,


### PR DESCRIPTION
## Summary

- A subagent failure now appears only in the failed subagent's sheet, not on the main session screen.
- The main session's composer stays clear of a subagent's error.
- The main composer stays usable and shows Stop while the main session works.
- A failed subagent with no transcript shows a "Subagent session failed" error screen.
- A failed subagent with a transcript shows the error as a banner above its messages.

---

A `session.error` event with a non-root `sessionId` now routes to a new `onChildSessionError` callback and returns before the shared root status or `onError` path. An event without a `sessionId` keeps the legacy root behavior. This keeps a child failure from touching the parent status indicator.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/service-state.ts` — adds `onChildSessionError` to `ServiceStateConfig`; `processSessionError` routes non-root `sessionId` events to it and returns before the root error path.
- `packages/cloud-agent-sdk/src/session.ts` — adds `onChildSessionError` to `CloudAgentSessionConfig` and forwards it to `createServiceState`.

</details>

The session manager records each child's failure message in a new `childSessionErrorsAtom` map and exposes a read-only `childSessionError` atom that returns the message for a child id, or null. The map clears with the other atoms on switch and destroy, so a stale child error cannot leak into the next session.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/session-manager.ts` — adds the `childSessionError` atom to `SessionManagerAtoms`, the backing map, the derived reader, the `onChildSessionError` handler, and the clear/reset wiring.

</details>

The child session sheet renders a runtime failure only in the failed child: a child with no messages shows a "Subagent session failed" error state, and a child with messages shows an error banner above the transcript. The parent detail screen reads the per-child error atom and passes the open child's message into the sheet.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/child-session-sheet-state.ts` — `getChildSessionSheetState` takes a `sessionError` argument and returns `error` for it when the child has no messages.
- `apps/mobile/src/components/agents/child-session-sheet.tsx` — accepts `sessionError`; renders the no-message error state or the above-transcript banner.
- `apps/mobile/src/components/agents/session-detail-content.tsx` — reads `manager.atoms.childSessionError` and passes the open child's message to the sheet.

</details>

Tests: 3 test files updated (`child-session-sheet-state.test.ts`, `service-state.test.ts`, `session-manager.test.ts`).
Generated: none.

---

## Verification

One iOS device round ran two cases.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| S1 — parent happy path | The parent session shows the Stop control while the agent works, then returns the composer to a usable state with no error text above it. | iOS | passed |
| S2 — cold-start reopen | Reopening the parent session shows a usable composer and no error text above it. | iOS | passed |

No defect was reproduced on an unfixed build: the fix landed before round 1, so no round ran on an unfixed build.

## Visual Changes

**Parent session detail screen (mobile).** The user sees a usable composer and no error banner above it after a message round trip. In the picture, the Preparation complete row sits above the Message... composer, where an error banner would appear, and no error text is present.

![01-parent-happy-path-idle.png](https://github.com/user-attachments/assets/fb082279-7540-450b-9456-0bafef7e8764)

## Reviewer Notes

Human steps: none needed.

Notes: none.
