### PR TITLE
feat(mobile): show subagent model on child session card and sheet

### DIFF
--- a/apps/mobile/src/components/agents/child-session-message.test.ts
+++ b/apps/mobile/src/components/agents/child-session-message.test.ts
@@ -7,7 +7,10 @@ import {
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
 import { ChildSessionMessage, ChildSessionSection } from './child-session-section';
+import { ChildSessionModelLabel } from './child-session-model-label';
 import { MessageErrorBoundary } from './message-error-boundary';
 
 vi.mock('react-native', () => ({
@@ -80,6 +83,17 @@ function makeMessage(parts: Part[]): StoredMessage {
     parts,
   };
 }
+
+const modelOption: SessionModelOption = {
+  id: 'kilo/model',
+  name: 'Test Model',
+  displayId: 'model',
+  variants: [],
+  isPreferred: false,
+  showGatewayMetadata: false,
+  provider: { id: 'kilo', name: 'Kilo' },
+  modelRef: { providerID: 'kilo', modelID: 'model' },
+};
 
 function findAll(
   node: unknown,
@@ -208,5 +222,70 @@ describe('ChildSessionMessage routing seam', () => {
     );
     expect(limitTexts).toHaveLength(1);
     expect(renderPart).not.toHaveBeenCalled();
+  });
+});
+
+describe('ChildSessionSection model label', () => {
+  it('renders the model label when child messages carry model data', () => {
+    const childMessages = [makeMessage([makeTextPart('child text')])];
+    const onOpenChildSession = vi.fn<(sessionId: string, title: string) => void>();
+    const part = makeToolPart('task', taskCompletedState);
+
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = ChildSessionSection({
+      part,
+      childMessages,
+      modelOptions: [modelOption],
+      onOpenChildSession,
+    });
+
+    const labels = findByType(root, ChildSessionModelLabel);
+    expect(labels).toHaveLength(1);
+    expect(labels[0]?.props).toMatchObject({ modelLabel: 'Test Model' });
+  });
+
+  it('hides the model label when child messages are empty and still renders the card', () => {
+    const onOpenChildSession = vi.fn<(sessionId: string, title: string) => void>();
+    const part = makeToolPart('task', taskCompletedState);
+
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = ChildSessionSection({
+      part,
+      childMessages: [],
+      modelOptions: [modelOption],
+      onOpenChildSession,
+    });
+
+    expect(findByType(root, ChildSessionModelLabel)).toHaveLength(0);
+    const taskNameTexts = findAll(
+      root,
+      el => el.type === 'Text' && textChildren(el) === 'child task'
+    );
+    expect(taskNameTexts).toHaveLength(1);
+  });
+
+  it('passes modelOptions through to the nested ChildSessionSection', () => {
+    const childMessages = [makeMessage([makeTextPart('child text')])];
+    const getChildMessages = vi.fn((id: string) => (id === 'child-1' ? childMessages : []));
+    const renderPart = vi.fn();
+    const onOpenChildSession = vi.fn<(sessionId: string, title: string) => void>();
+
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = ChildSessionMessage({
+      message: makeMessage([makeToolPart('task', taskCompletedState)]),
+      depth: 0,
+      getChildMessages,
+      renderPart,
+      onOpenChildSession,
+      modelOptions: [modelOption],
+    });
+
+    const sections = findByType(root, ChildSessionSection);
+    expect(sections).toHaveLength(1);
+    const section = sections[0];
+    if (!section) {
+      throw new Error('expected ChildSessionSection');
+    }
+    expect(section.props).toMatchObject({ modelOptions: [modelOption] });
   });
 });

--- a/apps/mobile/src/components/agents/child-session-model-label.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/child-session-model-label.mounted.test.tsx
@@ -1,0 +1,41 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/components/ui/selectable-text.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import { ChildSessionModelLabel } from './child-session-model-label';
+
+// The real `@/components/ui/text` loads `@rn-primitives/slot`, whose node_modules
+// `.mjs` contains JSX that this pipeline cannot transform. Provide a real context
+// so any `useContext(TextClassContext)` consumer still resolves.
+vi.mock('@/components/ui/text', async () => {
+  const React = await import('react');
+  return {
+    Text: 'Text',
+    TextClassContext: React.createContext<string | undefined>(undefined),
+  };
+});
+
+describe('ChildSessionModelLabel mounted', () => {
+  it('renders the literal Model: accessibility label with the model name as text', async () => {
+    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      rendererRef.current = TestRenderer.create(
+        createElement(ChildSessionModelLabel, { modelLabel: 'Claude Sonnet 4' })
+      );
+    });
+    const renderer = rendererRef.current;
+    if (!renderer) {
+      throw new Error('renderer was not created');
+    }
+
+    const nodes = renderer.root.findAll(
+      node => node.props.accessibilityLabel === 'Model: Claude Sonnet 4'
+    );
+    expect(nodes).toHaveLength(1);
+    expect(nodes[0]?.children).toEqual(['Claude Sonnet 4']);
+  });
+});

--- a/apps/mobile/src/components/agents/child-session-model-label.tsx
+++ b/apps/mobile/src/components/agents/child-session-model-label.tsx
@@ -1,0 +1,13 @@
+import { Text } from '@/components/ui/text';
+
+export function ChildSessionModelLabel({ modelLabel }: Readonly<{ modelLabel: string }>) {
+  return (
+    <Text
+      className="text-xs leading-4 text-muted-foreground"
+      numberOfLines={1}
+      accessibilityLabel={`Model: ${modelLabel}`}
+    >
+      {modelLabel}
+    </Text>
+  );
+}

--- a/apps/mobile/src/components/agents/child-session-model.test.ts
+++ b/apps/mobile/src/components/agents/child-session-model.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  type AssistantMessage,
+  type Part,
+  type StepFinishPart,
+  type StoredMessage,
+  type UserMessage,
+} from '@kilocode/cloud-agent-sdk';
+
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
+import { getChildSessionModelLabel } from './child-session-model';
+
+/**
+ * Child-session model label resolution.
+ *
+ * Contract:
+ *  - scans from the last message to the first
+ *  - the last assistant message with resolvable model data wins
+ *  - returns null for empty transcripts, user-only transcripts, and legacy
+ *    blank provider/model fields
+ *  - prefers the routed model on the last step-finish part over info-level
+ *    provider/model
+ *  - falls back to a date-suffix-stripped raw modelID for unknown models
+ */
+
+const catalogOption: SessionModelOption = {
+  id: 'anthropic/claude-sonnet-4',
+  name: 'Claude Sonnet 4',
+  displayId: 'claude-sonnet-4',
+  variants: [],
+  isPreferred: false,
+  showGatewayMetadata: false,
+  provider: { id: 'anthropic', name: 'Anthropic' },
+  modelRef: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+};
+
+function assistantInfo(overrides: Partial<AssistantMessage> = {}): AssistantMessage {
+  return {
+    id: 'msg-1',
+    sessionID: 'ses-1',
+    role: 'assistant',
+    time: { created: 1 },
+    parentID: 'msg-0',
+    modelID: 'claude-sonnet-4',
+    providerID: 'anthropic',
+    mode: 'code',
+    agent: 'test',
+    path: { cwd: '/', root: '/' },
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    ...overrides,
+  };
+}
+
+function userInfo(overrides: Partial<UserMessage> = {}): UserMessage {
+  return {
+    id: 'u-1',
+    sessionID: 'ses-1',
+    role: 'user',
+    time: { created: 1 },
+    agent: 'test',
+    model: { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+    ...overrides,
+  };
+}
+
+function stepFinish(overrides: Partial<StepFinishPart> = {}): StepFinishPart {
+  return {
+    id: 'p-finish',
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'step-finish',
+    reason: 'stop',
+    cost: 0,
+    tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    ...overrides,
+  };
+}
+
+function storedMessage(info: AssistantMessage | UserMessage, parts: Part[] = []): StoredMessage {
+  return { info, parts };
+}
+
+// The `model` field is present on the wire and in the Zod contract but
+// absent from the generated `StepFinishPart` type, so we cast — same
+// pattern as `message-model-label.test.ts` and `part-utils.test.ts`.
+function stepFinishWithRouted(
+  routed: { providerID: string; modelID: string },
+  overrides: Partial<StepFinishPart> = {}
+): StepFinishPart {
+  return Object.assign(stepFinish(overrides), { model: routed }) as StepFinishPart;
+}
+
+describe('getChildSessionModelLabel', () => {
+  it('returns null for an empty transcript', () => {
+    expect(getChildSessionModelLabel([], [catalogOption])).toBeNull();
+  });
+
+  it('returns null for a user-only transcript', () => {
+    const messages = [storedMessage(userInfo())];
+    expect(getChildSessionModelLabel(messages, [catalogOption])).toBeNull();
+  });
+
+  it('returns the catalog name when info matches a catalog option', () => {
+    const messages = [storedMessage(assistantInfo())];
+    expect(getChildSessionModelLabel(messages, [catalogOption])).toBe('Claude Sonnet 4');
+  });
+
+  it('strips a trailing date suffix for an unknown model', () => {
+    const messages = [
+      storedMessage(assistantInfo({ providerID: 'kilo', modelID: 'claude-sonnet-4-20260101' })),
+    ];
+    expect(getChildSessionModelLabel(messages, [catalogOption])).toBe('claude-sonnet-4');
+  });
+
+  it('returns null for legacy blank providerID/modelID', () => {
+    const messages = [storedMessage(assistantInfo({ providerID: '', modelID: '' }))];
+    expect(getChildSessionModelLabel(messages, [catalogOption])).toBeNull();
+  });
+
+  it('prefers the routed model on the last step-finish part', () => {
+    const info = assistantInfo({
+      id: 'm1',
+      providerID: 'kilo',
+      modelID: 'kilo-auto/efficient',
+    });
+    const finish = stepFinishWithRouted(
+      { providerID: 'anthropic', modelID: 'claude-sonnet-4' },
+      { id: 'sf-1' }
+    );
+    const messages = [storedMessage(info, [finish])];
+    expect(getChildSessionModelLabel(messages, [catalogOption])).toBe('Claude Sonnet 4');
+  });
+
+  it('lets the last assistant message with model data win', () => {
+    const first = storedMessage(
+      assistantInfo({ id: 'm1', providerID: 'openai', modelID: 'gpt-4o' })
+    );
+    const second = storedMessage(
+      assistantInfo({ id: 'm2', providerID: 'anthropic', modelID: 'claude-sonnet-4' })
+    );
+    expect(getChildSessionModelLabel([first, second], [catalogOption])).toBe('Claude Sonnet 4');
+  });
+});

--- a/apps/mobile/src/components/agents/child-session-model.ts
+++ b/apps/mobile/src/components/agents/child-session-model.ts
@@ -1,0 +1,27 @@
+import { type StoredMessage } from '@kilocode/cloud-agent-sdk';
+
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
+import { resolveMessageDisplayModel } from './message-model-label';
+import { friendlyModelName } from './session-model-display';
+
+/**
+ * Resolve the display model for a child session from its transcript. The last
+ * assistant message with model data wins; returns `null` when no model data
+ * exists.
+ */
+export function getChildSessionModelLabel(
+  childMessages: StoredMessage[],
+  modelOptions: SessionModelOption[]
+): string | null {
+  for (let i = childMessages.length - 1; i >= 0; i -= 1) {
+    const message = childMessages[i];
+    if (message) {
+      const resolved = resolveMessageDisplayModel(message);
+      if (resolved) {
+        return friendlyModelName(resolved.providerID, resolved.modelID, modelOptions);
+      }
+    }
+  }
+  return null;
+}

--- a/apps/mobile/src/components/agents/child-session-section.tsx
+++ b/apps/mobile/src/components/agents/child-session-section.tsx
@@ -12,6 +12,7 @@ import {
 import { SpinningIcon } from '@/components/ui/spinning-icon';
 import { Text } from '@/components/ui/text';
 import { type ThemeColors, useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 
 import {
   type ChildSessionCardState,
@@ -19,6 +20,8 @@ import {
   getChildSessionCardState,
   getTaskToolSessionId,
 } from './child-session-card-state';
+import { getChildSessionModelLabel } from './child-session-model';
+import { ChildSessionModelLabel } from './child-session-model-label';
 import { MessageErrorBoundary } from './message-error-boundary';
 import { isToolPart } from './part-types';
 
@@ -38,12 +41,14 @@ type ChildSessionSectionProps = {
   part: ToolPart;
   childMessages: StoredMessage[];
   onOpenChildSession: OpenChildSession;
+  modelOptions?: SessionModelOption[];
 };
 
 export function ChildSessionSection({
   part,
   childMessages,
   onOpenChildSession,
+  modelOptions,
 }: Readonly<ChildSessionSectionProps>) {
   const colors = useThemeColors();
 
@@ -52,6 +57,7 @@ export function ChildSessionSection({
     childMessages
   );
   const latestActivityLabel = getChildSessionActivityLabel(latestActivity);
+  const modelLabel = getChildSessionModelLabel(childMessages, modelOptions ?? []);
 
   const { status } = part.state;
   const isRunning = status === 'running' || status === 'pending';
@@ -75,7 +81,7 @@ export function ChildSessionSection({
         }}
         disabled={!sessionId}
         accessibilityRole="button"
-        accessibilityLabel={`${agentName}, ${taskName}, ${latestActivityLabel}, ${status}`}
+        accessibilityLabel={`${agentName}, ${taskName}${modelLabel ? `, ${modelLabel}` : ''}, ${latestActivityLabel}, ${status}`}
         accessibilityHint={sessionId ? 'Open subagent session' : undefined}
         accessibilityState={{ disabled: !sessionId }}
       >
@@ -94,6 +100,7 @@ export function ChildSessionSection({
           <Text className="text-sm leading-5 text-foreground" numberOfLines={1}>
             {taskName}
           </Text>
+          {modelLabel ? <ChildSessionModelLabel modelLabel={modelLabel} /> : null}
           <Text className="text-xs leading-4 text-muted-foreground" numberOfLines={1}>
             {
               // oxlint-disable-next-line anti-slop/no-runtime-typeof -- ChildSessionActivity has no discriminant field to narrow on, and `'tool' in latestActivity` would throw for the string variant.
@@ -121,12 +128,14 @@ export function ChildSessionMessage({
   getChildMessages,
   renderPart,
   onOpenChildSession,
+  modelOptions,
 }: Readonly<{
   message: StoredMessage;
   depth: number;
   getChildMessages: (sessionId: string) => StoredMessage[];
   renderPart: RenderPartFn;
   onOpenChildSession: OpenChildSession;
+  modelOptions?: SessionModelOption[];
 }>) {
   if (depth >= MAX_NESTING_DEPTH) {
     return <Text className="text-xs text-muted-foreground">Maximum nesting depth reached.</Text>;
@@ -145,6 +154,7 @@ export function ChildSessionMessage({
               part={p}
               childMessages={nestedMessages}
               onOpenChildSession={onOpenChildSession}
+              modelOptions={modelOptions}
             />
           );
         }

--- a/apps/mobile/src/components/agents/child-session-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/child-session-sheet.mounted.test.tsx
@@ -1,0 +1,206 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as src/components/ui/selectable-text.mounted.test.tsx) */
+import { type ComponentProps, createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  type ChildSessionHydrationState,
+  type OlderMessagesError,
+  type StoredMessage,
+  type TextPart,
+} from '@kilocode/cloud-agent-sdk';
+
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
+import { ChildSessionSheet } from './child-session-sheet';
+import { ChildSessionModelLabel } from './child-session-model-label';
+
+vi.mock('react-native', () => ({
+  Modal: 'Modal',
+  View: 'View',
+  Pressable: 'Pressable',
+}));
+vi.mock('react-native-reanimated', () => ({
+  default: { View: 'AnimatedView' },
+  LinearTransition: { duration: () => ({}) },
+}));
+vi.mock('react-native-safe-area-context', () => ({
+  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+}));
+// The real `@/components/ui/text` loads `@rn-primitives/slot`, whose node_modules
+// `.mjs` contains JSX that this pipeline cannot transform. Provide a real context
+// so any `useContext(TextClassContext)` consumer still resolves.
+vi.mock('@/components/ui/text', async () => {
+  const React = await import('react');
+  return {
+    Text: 'Text',
+    TextClassContext: React.createContext<string | undefined>(undefined),
+  };
+});
+vi.mock('@/components/ui/icons', () => ({
+  Bot: 'Bot',
+  ChevronRight: 'ChevronRight',
+  Loader2: 'Loader2',
+}));
+vi.mock('@/components/ui/spinning-icon', () => ({
+  SpinningIcon: 'SpinningIcon',
+}));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({}),
+}));
+vi.mock('./session-message-list', () => ({
+  SessionMessageList: () => null,
+}));
+vi.mock('./part-detail-sheet-host', () => ({
+  PartDetailSheetHost: ({ children }: { children?: unknown }) => children,
+}));
+vi.mock('./working-indicator', () => ({
+  WorkingIndicator: () => null,
+}));
+vi.mock('./message-error-boundary', () => ({
+  MessageErrorBoundary: ({ children }: { children?: unknown }) => children,
+}));
+vi.mock('@/components/empty-state', () => ({
+  EmptyState: 'EmptyState',
+}));
+vi.mock('@/components/query-error', () => ({
+  QueryError: 'QueryError',
+}));
+vi.mock('@/components/sheet-header', () => ({
+  SheetHeader: 'SheetHeader',
+}));
+
+const modelOption: SessionModelOption = {
+  id: 'kilo/model',
+  name: 'Test Model',
+  displayId: 'model',
+  variants: [],
+  isPreferred: false,
+  showGatewayMetadata: false,
+  provider: { id: 'kilo', name: 'Kilo' },
+  modelRef: { providerID: 'kilo', modelID: 'model' },
+};
+
+function makeTextPart(text: string): TextPart {
+  return { id: 't1', sessionID: 's1', messageID: 'm1', type: 'text', text };
+}
+
+function makeAssistantMessage(): StoredMessage {
+  return {
+    info: {
+      id: 'm1',
+      sessionID: 's1',
+      role: 'assistant',
+      time: { created: 1 },
+      parentID: 'm0',
+      modelID: 'model',
+      providerID: 'kilo',
+      mode: 'code',
+      agent: 'build',
+      path: { cwd: '/', root: '/' },
+      cost: 0,
+      tokens: { total: 0, input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts: [makeTextPart('child text')],
+  };
+}
+
+const readyState: ChildSessionHydrationState = {
+  status: 'ready',
+  cursor: null,
+  hasOlder: false,
+  isLoadingOlder: false,
+  olderError: null,
+  omittedItemCount: 0,
+};
+
+const errorState: ChildSessionHydrationState = { status: 'error', message: 'Failed' };
+
+type SheetPropsFixture = {
+  getChildMessages: (sessionId: string) => StoredMessage[];
+  hydrationState: ChildSessionHydrationState;
+};
+
+function buildProps({
+  getChildMessages,
+  hydrationState,
+}: SheetPropsFixture): ComponentProps<typeof ChildSessionSheet> {
+  return {
+    visible: true,
+    sessionId: 'child-1',
+    title: 'Subagent',
+    getChildMessages,
+    hydrationState,
+    isStreaming: false,
+    hasOlderMessages: false,
+    isLoadingOlderMessages: false,
+    olderMessagesError: null as OlderMessagesError | null,
+    olderMessagesOmittedItemCount: 0,
+    onLoadOlderMessages: vi.fn<() => void>(),
+    renderPart: () => null,
+    onOpenChildSession: vi.fn<(sessionId: string, title: string) => void>(),
+    onRetry: vi.fn<() => void>(),
+    onClose: vi.fn<() => void>(),
+    modelOptions: [modelOption],
+  };
+}
+
+async function renderSheet(props: ComponentProps<typeof ChildSessionSheet>) {
+  const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+    current: undefined,
+  };
+  await act(async () => {
+    await Promise.resolve();
+    rendererRef.current = TestRenderer.create(createElement(ChildSessionSheet, props));
+  });
+  const renderer = rendererRef.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  return renderer;
+}
+
+describe('ChildSessionSheet mounted', () => {
+  it('renders the model row when child messages carry model data', async () => {
+    const messages = [makeAssistantMessage()];
+    const renderer = await renderSheet(
+      buildProps({
+        getChildMessages: () => messages,
+        hydrationState: readyState,
+      })
+    );
+
+    const labels = renderer.root.findAllByType(ChildSessionModelLabel);
+    expect(labels).toHaveLength(1);
+    expect(labels[0]?.props).toMatchObject({ modelLabel: 'Test Model' });
+
+    const a11yNodes = renderer.root.findAll(
+      node => node.props.accessibilityLabel === 'Model: Test Model'
+    );
+    expect(a11yNodes).toHaveLength(1);
+  });
+
+  it('renders no model row for an empty transcript', async () => {
+    const renderer = await renderSheet(
+      buildProps({
+        getChildMessages: () => [],
+        hydrationState: readyState,
+      })
+    );
+
+    expect(renderer.root.findAllByType(ChildSessionModelLabel)).toHaveLength(0);
+  });
+
+  it('renders the QueryError and no model row when hydration fails', async () => {
+    const renderer = await renderSheet(
+      buildProps({
+        getChildMessages: () => [],
+        hydrationState: errorState,
+      })
+    );
+
+    expect(renderer.root.findAllByType(ChildSessionModelLabel)).toHaveLength(0);
+    const errors = renderer.root.findAll(node => (node.type as string) === 'QueryError');
+    expect(errors).toHaveLength(1);
+  });
+});

--- a/apps/mobile/src/components/agents/child-session-sheet.tsx
+++ b/apps/mobile/src/components/agents/child-session-sheet.tsx
@@ -11,12 +11,15 @@ import { EmptyState } from '@/components/empty-state';
 import { QueryError } from '@/components/query-error';
 import { SheetHeader } from '@/components/sheet-header';
 import { Bot } from '@/components/ui/icons';
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 
 import {
   ChildSessionMessage,
   type OpenChildSession,
   type RenderPartFn,
 } from './child-session-section';
+import { getChildSessionModelLabel } from './child-session-model';
+import { ChildSessionModelLabel } from './child-session-model-label';
 import { MessageErrorBoundary } from './message-error-boundary';
 import { PartDetailSheetHost } from './part-detail-sheet-host';
 import { getChildSessionSheetState } from './child-session-sheet-state';
@@ -41,6 +44,7 @@ type ChildSessionSheetProps = {
   onClose: () => void;
   /** Fires on iOS after the native pageSheet dismiss animation completes. */
   onDismiss?: () => void;
+  modelOptions?: SessionModelOption[];
 };
 
 export function ChildSessionSheet({
@@ -60,9 +64,11 @@ export function ChildSessionSheet({
   onRetry,
   onClose,
   onDismiss,
+  modelOptions,
 }: Readonly<ChildSessionSheetProps>) {
   const messages = getChildMessages(sessionId);
   const state = getChildSessionSheetState(hydrationState, messages.length);
+  const modelLabel = getChildSessionModelLabel(messages, modelOptions ?? []);
   // Safe-area context can return 0 inside a RN `Modal` (pageSheet doesn't
   // always propagate the home-indicator inset), so we floor the value with
   // a comfortable constant to keep the last row / working indicator clear
@@ -91,6 +97,7 @@ export function ChildSessionSheet({
                 getChildMessages={getChildMessages}
                 renderPart={renderPart}
                 onOpenChildSession={onOpenChildSession}
+                modelOptions={modelOptions}
               />
             </View>
           </MessageErrorBoundary>
@@ -137,6 +144,11 @@ export function ChildSessionSheet({
     >
       <View className="flex-1 bg-background">
         <SheetHeader title={title} onDone={onClose} />
+        {modelLabel ? (
+          <View className="border-b border-border px-4 py-2">
+            <ChildSessionModelLabel modelLabel={modelLabel} />
+          </View>
+        ) : null}
         <PartDetailSheetHost messages={messages}>{content}</PartDetailSheetHost>
       </View>
     </Modal>

--- a/apps/mobile/src/components/agents/message-bubble.tsx
+++ b/apps/mobile/src/components/agents/message-bubble.tsx
@@ -7,6 +7,7 @@ import { Bubble } from '@/components/ui/bubble';
 import { Button } from '@/components/ui/button';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 
 import { InMessageBubbleContext } from './bubble-text-selection-context';
 import { ChatMarkdownText } from './chat-markdown-text';
@@ -24,6 +25,7 @@ type MessageBubbleProps = {
   isLastAssistantMessage?: boolean;
   isSessionStreaming?: boolean;
   getChildMessages?: (sessionId: string) => StoredMessage[];
+  modelOptions?: SessionModelOption[];
   defaultReasoningExpanded?: boolean;
   onOpenChildSession?: OpenChildSession;
   /** Per-user-message delivery state. v1 surfaces only a "Queued" badge. */
@@ -47,6 +49,7 @@ function MessageBubbleImpl({
   isLastAssistantMessage,
   isSessionStreaming,
   getChildMessages,
+  modelOptions,
   defaultReasoningExpanded,
   onOpenChildSession,
   deliveryState,
@@ -228,6 +231,7 @@ function MessageBubbleImpl({
                 getChildMessages={getChildMessages}
                 defaultReasoningExpanded={defaultReasoningExpanded}
                 onOpenChildSession={onOpenChildSession}
+                modelOptions={modelOptions}
               />
             ))}
           </View>

--- a/apps/mobile/src/components/agents/part-renderer.test.ts
+++ b/apps/mobile/src/components/agents/part-renderer.test.ts
@@ -1,9 +1,12 @@
-import { type ReasoningPart, type TextPart } from '@kilocode/cloud-agent-sdk';
+import { type ReasoningPart, type TextPart, type ToolPart } from '@kilocode/cloud-agent-sdk';
 import { describe, expect, it, vi } from 'vitest';
+
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 
 import { PartRenderer } from './part-renderer';
 import { ReasoningPartRenderer } from './reasoning-part-renderer';
 import { TextPartRenderer } from './text-part-renderer';
+import { ToolPartRenderer } from './tool-part-renderer';
 
 vi.mock('./child-session-section', () => ({}));
 vi.mock('./compaction-separator', () => ({
@@ -50,6 +53,38 @@ function makeTextPart(text: string, synthetic?: boolean, ended = true): TextPart
   }
   return part;
 }
+
+function makeToolPart(): ToolPart {
+  return {
+    id: 'tool-1',
+    sessionID: 's1',
+    messageID: 'm1',
+    type: 'tool',
+    callID: 'call-1',
+    tool: 'bash',
+    state: {
+      status: 'completed',
+      input: { command: 'echo hi' },
+      output: 'hi',
+      title: 'bash',
+      metadata: {},
+      time: { start: 1, end: 2 },
+    },
+  };
+}
+
+const modelOptions: SessionModelOption[] = [
+  {
+    id: 'kilo/model',
+    name: 'Test Model',
+    displayId: 'model',
+    variants: [],
+    isPreferred: false,
+    showGatewayMetadata: false,
+    provider: { id: 'kilo', name: 'Kilo' },
+    modelRef: { providerID: 'kilo', modelID: 'model' },
+  },
+];
 
 describe('PartRenderer', () => {
   it('does not mount a completed empty reasoning part', () => {
@@ -112,5 +147,19 @@ describe('PartRenderer', () => {
     ).props.children;
     expect(textElement.type).toBe(TextPartRenderer);
     expect(textElement.props).toMatchObject({ text: 'Hello world' });
+  });
+
+  it('passes modelOptions through to ToolPartRenderer for a tool part', () => {
+    const part = makeToolPart();
+    // eslint-disable-next-line new-cap
+    const result = PartRenderer({ part, modelOptions });
+    expect(result).not.toBeNull();
+    const toolElement = (
+      result as unknown as {
+        props: { children: { type: unknown; props: Record<string, unknown> } };
+      }
+    ).props.children;
+    expect(toolElement.type).toBe(ToolPartRenderer);
+    expect(toolElement.props).toMatchObject({ modelOptions });
   });
 });

--- a/apps/mobile/src/components/agents/part-renderer.tsx
+++ b/apps/mobile/src/components/agents/part-renderer.tsx
@@ -1,5 +1,7 @@
 import { type Part, type StoredMessage } from '@kilocode/cloud-agent-sdk';
 
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
 import { CompactionSeparator } from './compaction-separator';
 import { FilePartRenderer } from './file-part-renderer';
 import { MessageErrorBoundary } from './message-error-boundary';
@@ -23,6 +25,7 @@ type PartRendererProps = {
   getChildMessages?: (sessionId: string) => StoredMessage[];
   defaultReasoningExpanded?: boolean;
   onOpenChildSession?: OpenChildSession;
+  modelOptions?: SessionModelOption[];
 };
 
 export function PartRenderer({
@@ -31,6 +34,7 @@ export function PartRenderer({
   getChildMessages,
   defaultReasoningExpanded,
   onOpenChildSession,
+  modelOptions,
 }: Readonly<PartRendererProps>) {
   if (!partRendersContent(part)) {
     return null;
@@ -50,6 +54,7 @@ export function PartRenderer({
           getChildMessages={getChildMessages}
           renderPart={props => <PartRenderer {...props} />}
           onOpenChildSession={onOpenChildSession}
+          modelOptions={modelOptions}
         />
       </MessageErrorBoundary>
     );

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -787,6 +787,7 @@ export function SessionDetailContent({
           isLastAssistantMessage={item.message.info.id === lastAssistantMessageId}
           isSessionStreaming={isStreaming}
           getChildMessages={getChildMessages}
+          modelOptions={modelOptions}
           defaultReasoningExpanded={reasoningDefaultExpanded}
           onOpenChildSession={handleOpenChildSession}
           deliveryState={deliveryState}
@@ -801,6 +802,7 @@ export function SessionDetailContent({
       lastAssistantMessageId,
       isStreaming,
       getChildMessages,
+      modelOptions,
       reasoningDefaultExpanded,
       handleOpenChildSession,
       pendingMessages,
@@ -1178,6 +1180,7 @@ export function SessionDetailContent({
             }}
             onClose={handleCloseChildSession}
             onDismiss={handleChildSheetDismiss}
+            modelOptions={modelOptions}
           />
         ) : null}
 

--- a/apps/mobile/src/components/agents/tool-part-renderer.test.ts
+++ b/apps/mobile/src/components/agents/tool-part-renderer.test.ts
@@ -2,6 +2,8 @@ import { type StoredMessage, type ToolPart } from '@kilocode/cloud-agent-sdk';
 import * as React from 'react';
 import { describe, expect, it, vi } from 'vitest';
 
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
 import {
   BashToolCard,
   EditToolCard,
@@ -104,6 +106,19 @@ function makeStoredMessage(): StoredMessage {
     parts: [],
   };
 }
+
+const modelOptions: SessionModelOption[] = [
+  {
+    id: 'kilo/model',
+    name: 'Test Model',
+    displayId: 'model',
+    variants: [],
+    isPreferred: false,
+    showGatewayMetadata: false,
+    provider: { id: 'kilo', name: 'Kilo' },
+    modelRef: { providerID: 'kilo', modelID: 'model' },
+  },
+];
 
 function findAll(
   node: unknown,
@@ -232,5 +247,30 @@ describe('ToolPartRenderer child navigation seam', () => {
     // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
     const root = ToolPartRenderer({ part: makeToolPart('task', taskCompletedState) });
     expect(findByType(root, TaskToolCard)).toHaveLength(1);
+  });
+
+  it('passes modelOptions through to ChildSessionSection for a task part', () => {
+    const childMessage = makeStoredMessage();
+    const getChildMessages = vi.fn((id: string) => (id === 'child-1' ? [childMessage] : []));
+    const renderPart = vi.fn();
+    const onOpenChildSession = vi.fn<(sessionId: string, title: string) => void>();
+    const part = makeToolPart('task', taskCompletedState);
+
+    // eslint-disable-next-line new-cap, react-compiler-runtime/react-compiler-runtime -- direct function call
+    const root = ToolPartRenderer({
+      part,
+      getChildMessages,
+      renderPart,
+      onOpenChildSession,
+      modelOptions,
+    });
+
+    const sections = findByType(root, ChildSessionSection);
+    expect(sections).toHaveLength(1);
+    const section = sections[0];
+    if (!section) {
+      throw new Error('expected ChildSessionSection');
+    }
+    expect(section.props).toMatchObject({ modelOptions });
   });
 });

--- a/apps/mobile/src/components/agents/tool-part-renderer.tsx
+++ b/apps/mobile/src/components/agents/tool-part-renderer.tsx
@@ -1,5 +1,7 @@
 import { type StoredMessage, type ToolPart } from '@kilocode/cloud-agent-sdk';
 
+import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
+
 import {
   ChildSessionSection,
   getTaskToolSessionId,
@@ -27,6 +29,7 @@ type ToolPartRendererProps = {
   getChildMessages?: (sessionId: string) => StoredMessage[];
   renderPart?: RenderPartFn;
   onOpenChildSession?: OpenChildSession;
+  modelOptions?: SessionModelOption[];
 };
 
 export function ToolPartRenderer({
@@ -34,6 +37,7 @@ export function ToolPartRenderer({
   getChildMessages,
   renderPart,
   onOpenChildSession,
+  modelOptions,
 }: Readonly<ToolPartRendererProps>) {
   if (part.tool === 'plan_exit' || part.tool === 'plan_enter') {
     return null;
@@ -48,6 +52,7 @@ export function ToolPartRenderer({
         part={part}
         childMessages={childMessages}
         onOpenChildSession={onOpenChildSession}
+        modelOptions={modelOptions}
       />
     );
   }


### PR DESCRIPTION
<!-- PR title format: type(scope): description — e.g., feat(auth): add SSO login -->
<!-- Keep the title under 72 characters, use imperative mood, no trailing period. -->

## Summary

A subagent card in the session transcript now shows the model the subagent used, in a muted line under the task name.

The subagent session sheet now shows the model used, in a muted row under the title.

---

A new pure helper `getChildSessionModelLabel` resolves the model a subagent session ran with. It walks the child transcript from the last message backward and returns the friendly name of the first assistant message whose model resolves, or null when no model data exists. A new `ChildSessionModelLabel` component renders that name as one muted line with a `Model:` accessibility label.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/child-session-model.ts` — adds `getChildSessionModelLabel`; it scans child messages from the end and returns the friendly name of the first assistant message with a resolvable model, or null.
- `apps/mobile/src/components/agents/child-session-model-label.tsx` — adds `ChildSessionModelLabel`; a muted one-line `Text` whose accessibility label reads `Model: <label>`.

</details>

The subagent card and the subagent sheet each render the resolved model as a muted line. The card shows it under the task name and appends it to the card's accessibility label; the sheet shows it in a bordered row under the header. Neither surface renders the line when no model resolves.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/child-session-section.tsx` — resolves the label from the child messages, renders it under the task name, and adds it to the card accessibility label; accepts and forwards `modelOptions` through `ChildSessionMessage`.
- `apps/mobile/src/components/agents/child-session-sheet.tsx` — resolves the label from the sheet's messages, renders a bordered muted row under the header, and forwards `modelOptions` to `ChildSessionMessage`.

</details>

A new optional `modelOptions` prop carries the session's model catalog from the session detail screen down to the subagent card. The prop is optional at every level, so an existing caller that omits it still renders without a model line. The same options that drive the session model picker also supply the friendly name for the subagent's model.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/session-detail-content.tsx` — passes the resolved `modelOptions` to `MessageBubble` and to `ChildSessionSheet`.
- `apps/mobile/src/components/agents/message-bubble.tsx` — accepts `modelOptions` and forwards it to `PartRenderer`.
- `apps/mobile/src/components/agents/part-renderer.tsx` — accepts `modelOptions` and forwards it to `ToolPartRenderer`.
- `apps/mobile/src/components/agents/tool-part-renderer.tsx` — accepts `modelOptions` and forwards it to `ChildSessionSection`.

</details>

Tests: 6 files changed — 3 added and 3 extended — cover the helper, the mounted label, the mounted sheet, and the prop threading.
Generated: none.

---

## Visual Changes

### Subagent session sheet

The sheet now shows the subagent model below the sheet title.

In the picture, the row under the "Reply with ok" title and the Done button reads `qwen/qwen3.7-plus`. The handoff names this the `Model: ` row; the picture shows the model value without a visible "Model: " prefix.

![sheet-model.png](https://github.com/user-attachments/assets/647b678e-103d-44ab-9678-33db116ebb5c)

### Subagent card on the session page

The subagent card label now includes the model.

In the picture, the card shows `general`, `Reply with ok`, `qwen/qwen3.7-plus`, and the `completed` badge.

![card-model.png](https://github.com/user-attachments/assets/8d97ebd7-3725-4c66-bd6f-fa688f3d7813)

## Verification

One case ran on the iOS platform.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| Subagent model on the sheet row and the card label | The sheet row and the completed card label show the same model string. | iOS | passed |

No defect was reproduced on the unfixed build.

No recording exists.

## Reviewer Notes

No human steps are needed.

Notes: none.
