### PR TITLE
Support x-api-key credentials for custom LLMs

### DIFF
--- a/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
+++ b/apps/web/src/app/admin/custom-llms/CustomLlmsContent.tsx
@@ -443,6 +443,23 @@ export function CustomLlmsContent() {
                   }}
                 />
               </div>
+              {!editor.credentialsJson.trim() && (
+                <div className="bg-muted text-muted-foreground mt-2 rounded-md p-3 text-xs">
+                  <p>Add an API key using one of these credential formats:</p>
+                  <pre className="text-foreground mt-2 overflow-x-auto font-mono whitespace-pre-wrap">
+                    {`{
+  "type": "api_key",
+  "api_key": "YOUR_API_KEY"
+}`}
+                  </pre>
+                  <p className="mt-2">
+                    Use{' '}
+                    <code className="text-foreground">&quot;type&quot;: &quot;x-api-key&quot;</code>{' '}
+                    instead when the provider expects an{' '}
+                    <code className="text-foreground">x-api-key</code> header.
+                  </p>
+                </div>
+              )}
             </div>
 
             <div>

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -156,6 +156,7 @@ const provider = {
   apiUrl: 'https://openrouter.ai/api/v1',
   apiUrlOverrides: {},
   apiKey: 'test-key',
+  apiKeyHeader: null,
   supportedChatApis: ['chat_completions', 'responses', 'messages'],
   responseTransforms: null,
   transformRequest: jest.fn(),

--- a/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts
+++ b/apps/web/src/lib/ai-gateway/custom-llm/google-service-account.test.ts
@@ -42,6 +42,12 @@ describe('CustomLlmCredentialsSchema and CustomLlmDefinitionSchema', () => {
     ).toBe(true);
   });
 
+  it('accepts x-api-key credentials', () => {
+    expect(
+      CustomLlmCredentialsSchema.safeParse({ type: 'x-api-key', api_key: 'partner-token' }).success
+    ).toBe(true);
+  });
+
   it('accepts Google Cloud service account authentication', () => {
     expect(CustomLlmCredentialsSchema.safeParse(serviceAccount('private-key')).success).toBe(true);
   });

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.test.ts
@@ -12,12 +12,17 @@ async function transformRequest(
   request: GatewayRequest,
   options: Partial<Omit<CustomLlmApiConfig, 'internal_id' | 'base_url'>> = {}
 ) {
-  const provider = buildDirectProvider('custom', ['chat_completions'], {
-    internal_id: 'upstream-model',
-    base_url: 'https://llm.example.com/v1',
-    api_key: 'test-key',
-    ...options,
-  });
+  const provider = buildDirectProvider(
+    'custom',
+    ['chat_completions'],
+    {
+      internal_id: 'upstream-model',
+      base_url: 'https://llm.example.com/v1',
+      api_key: 'test-key',
+      ...options,
+    },
+    null
+  );
 
   await provider.transformRequest({
     provider,
@@ -98,22 +103,32 @@ describe('custom LLM Gemini reasoning transform configuration', () => {
 
 describe('buildDirectProvider response transforms', () => {
   it('enables Gemini thought content rewriting when the transform is enabled', () => {
-    const provider = buildDirectProvider('custom', ['chat_completions'], {
-      internal_id: 'upstream-model',
-      base_url: 'https://llm.example.com/v1',
-      api_key: 'test-key',
-      reasoning_details_transform: ReasoningDetailsTransform.GeminiThought,
-    });
+    const provider = buildDirectProvider(
+      'custom',
+      ['chat_completions'],
+      {
+        internal_id: 'upstream-model',
+        base_url: 'https://llm.example.com/v1',
+        api_key: 'test-key',
+        reasoning_details_transform: ReasoningDetailsTransform.GeminiThought,
+      },
+      null
+    );
 
     expect(provider.responseTransforms).toBe(ReasoningDetailsTransform.GeminiThought);
   });
 
   it('sets response transforms to null when the transform is not enabled', () => {
-    const provider = buildDirectProvider('custom', ['chat_completions'], {
-      internal_id: 'upstream-model',
-      base_url: 'https://llm.example.com/v1',
-      api_key: 'test-key',
-    });
+    const provider = buildDirectProvider(
+      'custom',
+      ['chat_completions'],
+      {
+        internal_id: 'upstream-model',
+        base_url: 'https://llm.example.com/v1',
+        api_key: 'test-key',
+      },
+      null
+    );
 
     expect(provider.responseTransforms).toBeNull();
   });

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
@@ -90,13 +90,15 @@ function sanitizeJsonRefToolResults(context: TransformRequestContext) {
 export function buildDirectProvider(
   id: 'custom' | 'experiment',
   supportedChatApis: ReadonlyArray<GatewayChatApiKind>,
-  upstream: ResolvedExperimentUpstream
+  upstream: ResolvedExperimentUpstream,
+  apiKeyHeader?: 'x-api-key'
 ): Provider {
   return {
     id,
     apiUrl: upstream.base_url,
     apiUrlOverrides: {},
     apiKey: upstream.api_key,
+    apiKeyHeader,
     supportedChatApis,
     responseTransforms: upstream.reasoning_details_transform ?? null,
     async transformRequest(context) {

--- a/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
+++ b/apps/web/src/lib/ai-gateway/experiments/build-direct-provider.ts
@@ -91,7 +91,7 @@ export function buildDirectProvider(
   id: 'custom' | 'experiment',
   supportedChatApis: ReadonlyArray<GatewayChatApiKind>,
   upstream: ResolvedExperimentUpstream,
-  apiKeyHeader?: 'x-api-key'
+  apiKeyHeader: 'x-api-key' | null
 ): Provider {
   return {
     id,

--- a/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/apply-provider-specific-logic.test.ts
@@ -95,6 +95,7 @@ describe('applyReasoningDetailsTransform', () => {
       apiUrl: 'https://example.com/v1',
       apiUrlOverrides: {},
       apiKey: 'test-key',
+      apiKeyHeader: null,
       supportedChatApis: ['chat_completions'],
       responseTransforms,
       async transformRequest() {},

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -90,6 +90,7 @@ async function checkDirectBYOK(
       apiUrl: directByok.base_url,
       apiUrlOverrides: directByok.base_url_overrides,
       apiKey: userByok[0].decryptedAPIKey,
+      apiKeyHeader: null,
       supportedChatApis: directByok.supported_chat_apis,
       responseTransforms: null,
       async transformRequest(context) {
@@ -137,10 +138,10 @@ async function checkCustomLlm(
   }
 
   let apiKey: string;
-  let apiKeyHeader: 'x-api-key' | undefined;
+  let apiKeyHeader: 'x-api-key' | null = null;
   if (parsedCredentials.data.type === 'api_key' || parsedCredentials.data.type === 'x-api-key') {
     apiKey = parsedCredentials.data.api_key;
-    apiKeyHeader = parsedCredentials.data.type === 'x-api-key' ? 'x-api-key' : undefined;
+    apiKeyHeader = parsedCredentials.data.type === 'x-api-key' ? 'x-api-key' : null;
   } else {
     apiKey = await getGoogleServiceAccountAccessToken(parsedCredentials.data);
   }
@@ -261,7 +262,7 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
     if (selection?.status === 'active') {
       return {
         kind: 'provider',
-        provider: buildDirectProvider('experiment', ['chat_completions'], selection.upstream),
+        provider: buildDirectProvider('experiment', ['chat_completions'], selection.upstream, null),
         userByok: null,
         bypassAccessCheck: false,
         experiment: {

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -137,8 +137,10 @@ async function checkCustomLlm(
   }
 
   let apiKey: string;
-  if (parsedCredentials.data.type === 'api_key') {
+  let apiKeyHeader: 'x-api-key' | undefined;
+  if (parsedCredentials.data.type === 'api_key' || parsedCredentials.data.type === 'x-api-key') {
     apiKey = parsedCredentials.data.api_key;
+    apiKeyHeader = parsedCredentials.data.type === 'x-api-key' ? 'x-api-key' : undefined;
   } else {
     apiKey = await getGoogleServiceAccountAccessToken(parsedCredentials.data);
   }
@@ -158,7 +160,8 @@ async function checkCustomLlm(
             ? 'responses'
             : 'chat_completions',
       ],
-      resolvedCustomLlm
+      resolvedCustomLlm,
+      apiKeyHeader
     ),
     userByok: null,
     bypassAccessCheck: true,

--- a/apps/web/src/lib/ai-gateway/providers/partner/providers.ts
+++ b/apps/web/src/lib/ai-gateway/providers/partner/providers.ts
@@ -10,6 +10,7 @@ export const FRIENDLI_GLM_PROVIDER = {
   apiUrl: 'https://api.friendli.ai/serverless/v1',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('FRIENDLI_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: [
     'chat_completions',
     // 'messages', // supported, not tested
@@ -43,6 +44,7 @@ export const PERPLEXITY_KIMI_PROVIDER = {
   apiUrl: 'https://api.perplexity.ai/router/v1',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('PERPLEXITY_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: [
     'chat_completions',
     // 'messages', // supported, not tested

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -8,6 +8,7 @@ export const OPENROUTER = {
   apiUrl: 'https://openrouter.ai/api/v1',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('OPENROUTER_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: ['chat_completions', 'messages', 'responses'],
   responseTransforms: null,
   async transformRequest() {},
@@ -18,6 +19,7 @@ export const ALIBABA = {
   apiUrl: 'https://dashscope-intl.aliyuncs.com/compatible-mode/v1',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('ALIBABA_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: [
     'chat_completions',
     // 'responses', // supported, not tested
@@ -33,6 +35,7 @@ export const SEED = {
   apiUrl: 'https://ark.ap-southeast.bytepluses.com/api/v3',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('BYTEDANCE_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: [
     'chat_completions',
     // 'responses', // supported, not tested
@@ -61,6 +64,7 @@ export const LONGCAT = {
   apiUrl: 'https://api.longcat.ai/openai/v1',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('LONGCAT_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: ['chat_completions'],
   responseTransforms: null,
   async transformRequest(context) {
@@ -79,6 +83,7 @@ export const MARTIAN = {
   apiUrl: 'https://api.withmartian.com/v1',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('MARTIAN_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: ['chat_completions', 'responses', 'messages'],
   responseTransforms: null,
   async transformRequest(context) {
@@ -91,6 +96,7 @@ export const MISTRAL = {
   apiUrl: 'https://api.mistral.ai/v1',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('MISTRAL_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: [],
   responseTransforms: null,
   async transformRequest() {},
@@ -101,6 +107,7 @@ export const STREAMLAKE = {
   apiUrl: 'https://vanchin.streamlake.ai/api/gateway/v1/endpoints',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('STREAMLAKE_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: ['chat_completions'],
   responseTransforms: null,
   async transformRequest(context) {
@@ -113,6 +120,7 @@ export const VERCEL_AI_GATEWAY = {
   apiUrl: 'https://ai-gateway.vercel.sh/v1',
   apiUrlOverrides: {},
   apiKey: getEnvVariable('VERCEL_AI_GATEWAY_API_KEY'),
+  apiKeyHeader: null,
   supportedChatApis: ['chat_completions', 'messages', 'responses'],
   responseTransforms: null,
   async transformRequest(context) {

--- a/apps/web/src/lib/ai-gateway/providers/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/types.ts
@@ -53,6 +53,8 @@ export type Provider = {
   apiUrl: string;
   apiUrlOverrides: ProviderApiUrlOverrides;
   apiKey: string;
+  /** Uses bearer authorization unless the provider requires an x-api-key header. */
+  apiKeyHeader?: 'x-api-key';
   supportedChatApis: ReadonlyArray<GatewayChatApiKind>;
   responseTransforms: ProviderResponseTransforms | null;
   transformRequest(context: TransformRequestContext): Promise<void>;

--- a/apps/web/src/lib/ai-gateway/providers/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/types.ts
@@ -54,7 +54,7 @@ export type Provider = {
   apiUrlOverrides: ProviderApiUrlOverrides;
   apiKey: string;
   /** Uses bearer authorization unless the provider requires an x-api-key header. */
-  apiKeyHeader?: 'x-api-key';
+  apiKeyHeader: 'x-api-key' | null;
   supportedChatApis: ReadonlyArray<GatewayChatApiKind>;
   responseTransforms: ProviderResponseTransforms | null;
   transformRequest(context: TransformRequestContext): Promise<void>;

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.generation.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.generation.test.ts
@@ -20,6 +20,7 @@ const provider: Provider = {
   apiUrl: 'https://openrouter.example/api/v1',
   apiUrlOverrides: {},
   apiKey: 'test-api-key',
+  apiKeyHeader: null,
   supportedChatApis: [],
   responseTransforms: null,
   transformRequest: async () => {},

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -218,7 +218,11 @@ export async function upstreamRequest({
   for (const [key, value] of Object.entries(ATTRIBUTION_HEADERS)) {
     headers.set(key, value);
   }
-  headers.set('Authorization', `Bearer ${provider.apiKey}`);
+  if (provider.apiKeyHeader === 'x-api-key') {
+    headers.set('x-api-key', provider.apiKey);
+  } else {
+    headers.set('Authorization', `Bearer ${provider.apiKey}`);
+  }
   headers.set('Content-Type', 'application/json');
 
   Object.entries(extraHeaders).forEach(([key, value]) => {

--- a/apps/web/src/tests/openrouterApi.timeout.test.ts
+++ b/apps/web/src/tests/openrouterApi.timeout.test.ts
@@ -70,6 +70,25 @@ describe('upstreamRequest timeout', () => {
     }
   );
 
+  it('uses x-api-key instead of authorization when configured by the provider', async () => {
+    const mockFetch = jest.fn().mockResolvedValue(new Response('{}'));
+    global.fetch = mockFetch;
+
+    const result = await upstreamRequest({
+      chatApi: 'chat_completions',
+      search: '',
+      method: 'POST',
+      body: { model: 'test-model', messages: [{ role: 'user', content: 'test' }] },
+      extraHeaders: {},
+      provider: { ...OPENROUTER, apiKey: 'custom-key', apiKeyHeader: 'x-api-key' },
+    });
+
+    expect(result.type).toBe('success');
+    const headers = mockFetch.mock.calls[0]?.[1]?.headers as Headers;
+    expect(headers.get('x-api-key')).toBe('custom-key');
+    expect(headers.has('authorization')).toBe(false);
+  });
+
   it('reports a client disconnect instead of an upstream disconnect when the caller aborts', async () => {
     const controller = new AbortController();
     controller.abort();

--- a/packages/db/src/schema-types.ts
+++ b/packages/db/src/schema-types.ts
@@ -2087,8 +2087,16 @@ export const CustomLlmApiKeyCredentialsSchema = z.object({
 
 export type CustomLlmApiKeyCredentials = z.infer<typeof CustomLlmApiKeyCredentialsSchema>;
 
+export const CustomLlmXApiKeyCredentialsSchema = z.object({
+  type: z.literal('x-api-key'),
+  api_key: z.string().min(1),
+});
+
+export type CustomLlmXApiKeyCredentials = z.infer<typeof CustomLlmXApiKeyCredentialsSchema>;
+
 export const CustomLlmCredentialsSchema = z.discriminatedUnion('type', [
   CustomLlmApiKeyCredentialsSchema,
+  CustomLlmXApiKeyCredentialsSchema,
   GoogleServiceAccountKeySchema,
 ]);
 

--- a/packages/worker-utils/src/redact-headers.test.ts
+++ b/packages/worker-utils/src/redact-headers.test.ts
@@ -6,6 +6,7 @@ describe('redactSensitiveHeaders', () => {
     const input = {
       authorization: 'Bearer secret-jwt',
       'proxy-authorization': 'Basic cHJveHk6c2VjcmV0',
+      'x-api-key': 'provider-secret',
       cookie: 'session=abc123',
       'set-cookie': 'session=abc123; Path=/',
       'x-gitlab-token': 'glpat-secret',
@@ -20,6 +21,7 @@ describe('redactSensitiveHeaders', () => {
     expect(result).toEqual({
       authorization: '[REDACTED]',
       'proxy-authorization': '[REDACTED]',
+      'x-api-key': '[REDACTED]',
       cookie: '[REDACTED]',
       'set-cookie': '[REDACTED]',
       'x-gitlab-token': '[REDACTED]',

--- a/packages/worker-utils/src/redact-headers.ts
+++ b/packages/worker-utils/src/redact-headers.ts
@@ -3,6 +3,7 @@ const SENSITIVE_HEADERS = new Set([
   'proxy-authorization',
   'cookie',
   'set-cookie',
+  'x-api-key',
   'x-gitlab-token',
   'x-hub-signature',
   'x-hub-signature-256',


### PR DESCRIPTION
## Summary
- show API key credential JSON guidance when custom LLM credentials are hidden or empty
- add an `x-api-key` credential type that sends the key in the `x-api-key` header instead of bearer authorization
- redact `x-api-key` values in shared header diagnostics

## Testing
- CI only, as requested