### PR TITLE
feat(extension): add beta badge to Agents tab

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agents-mode-switch.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-mode-switch.tsx
@@ -2,10 +2,14 @@ import type { JSX } from 'react';
 import type { SidePanelMode } from '@/src/shared/side-panel-mode';
 
 const tabBaseClassName =
-  'relative h-9 shrink-0 rounded-md px-3 type-label transition outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring ring-offset-2 ring-offset-surface-background';
+  'relative flex h-9 shrink-0 items-center justify-center gap-1.5 rounded-md px-3 type-label transition outline-none focus-visible:ring-2 focus-visible:ring-brand-primary-ring ring-offset-2 ring-offset-surface-background';
 
 const tabActiveClassName = `${tabBaseClassName} bg-surface-selected text-foreground font-medium`;
 const tabInactiveClassName = `${tabBaseClassName} text-foreground-muted hover:bg-surface-hover`;
+
+// Same pill vocabulary as the session status badges, in the brand tint.
+const betaBadgeClassName =
+  'rounded-full bg-brand-primary/15 px-1.5 py-0.5 type-eyebrow uppercase tracking-wide text-brand-primary';
 
 export const AgentsModeSwitch = ({
   mode,
@@ -32,7 +36,7 @@ export const AgentsModeSwitch = ({
       Browser
     </button>
     <button
-      aria-label="Agents"
+      aria-label="Agents beta"
       aria-selected={mode === 'agents'}
       className={mode === 'agents' ? tabActiveClassName : tabInactiveClassName}
       onClick={() => {
@@ -42,6 +46,9 @@ export const AgentsModeSwitch = ({
       type="button"
     >
       Agents
+      <span aria-hidden="true" className={betaBadgeClassName}>
+        Beta
+      </span>
     </button>
   </div>
 );


### PR DESCRIPTION
## Summary
- Adds a small brand-tinted BETA pill next to the Agents tab in the side panel mode switch.
- Reuses the existing session status badge vocabulary (rounded-full, tinted background) and existing design tokens only.
- Pill is aria-hidden; the tab accessible name is now `Agents beta` so screen readers announce it once.

## Verification
- `pnpm --filter kilo-extension verify` (typecheck, lint, 1395 unit tests) passed.
- `pnpm --filter kilo-extension build` passed.
- E2E skipped: change is one isolated component; existing specs match `getByRole('tab', { name: 'Agents' })` by substring, so they stay green.