### PR TITLE
Enable LongCat free model

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -87,22 +87,22 @@ describe('isFreeModel', () => {
       expect(autoFreeModels.map(({ model }) => model)).toContain(tencent_hy3_free_model.public_id);
     });
 
-    test('retains the disabled LongCat 2.0 configuration for later enablement', async () => {
+    test('registers LongCat 2.0 as a free preferred model', async () => {
       expect(kiloExclusiveModels).toContain(longcat_2_free_model);
-      expect(findKiloExclusiveModel(longcat_2_free_model.public_id)).toBeNull();
-      expect(await isFreeModel(longcat_2_free_model.public_id)).toBe(false);
+      expect(findKiloExclusiveModel(longcat_2_free_model.public_id)).toBe(longcat_2_free_model);
+      expect(await isFreeModel(longcat_2_free_model.public_id)).toBe(true);
       expect(longcat_2_free_model).toMatchObject({
         internal_id: 'LongCat-2.0',
         gateway: 'longcat',
         context_length: 1_048_756,
         max_completion_tokens: 131_072,
-        status: 'disabled',
+        status: 'public',
       });
       expect(autoFreeModels.map(({ model }) => model)).not.toContain(
         longcat_2_free_model.public_id
       );
-      expect(preferredModels).not.toContain(longcat_2_free_model.public_id);
-      expect(getAiSdkProvider(longcat_2_free_model.public_id, null)).toBe('openai-compatible');
+      expect(preferredModels).toContain(longcat_2_free_model.public_id);
+      expect(getAiSdkProvider(longcat_2_free_model.public_id, null)).toBeUndefined();
     });
 
     test('routes the discounted Claude Opus offering through the stealth provider identity', () => {

--- a/apps/web/src/lib/ai-gateway/providers/longcat.ts
+++ b/apps/web/src/lib/ai-gateway/providers/longcat.ts
@@ -11,7 +11,7 @@ export const longcat_2_free_model: KiloExclusiveModel = {
     'LongCat 2.0 is a sparse mixture-of-experts language model from Meituan, with 48B active parameters out of 1.6T total. It is suited for coding, repository-level changes, long-horizon problem solving, and agentic workflows. Available free in Kilo for a limited time.',
   context_length: 1_048_756,
   max_completion_tokens: 131_072,
-  status: 'disabled',
+  status: 'public',
   flags: ['reasoning'],
   gateway: 'longcat',
   internal_id: 'LongCat-2.0',

--- a/apps/web/src/lib/ai-gateway/providers/model-settings.ts
+++ b/apps/web/src/lib/ai-gateway/providers/model-settings.ts
@@ -19,7 +19,6 @@ import {
   REASONING_VARIANTS_BINARY,
 } from '@/lib/ai-gateway/providers/variants';
 import { normalizeModelId } from '@/lib/ai-gateway/model-utils';
-import { longcat_2_free_model } from '@/lib/ai-gateway/providers/longcat';
 
 export async function getOpenRouterDerivedModelVariants(
   model: string
@@ -69,9 +68,6 @@ export function getAiSdkProvider(
   directProviderId: DirectUserByokInferenceProviderId | null
 ): Exclude<CustomLlmProvider, 'openrouter' /*the default*/> | undefined {
   if (directProviderId === 'morph-byok') {
-    return 'openai-compatible';
-  }
-  if (model === longcat_2_free_model.public_id) {
     return 'openai-compatible';
   }
   if (directProviderId === 'opencode-go' && (isMinimaxModel(model) || isQwenModel(model))) {

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.test.ts
@@ -6,7 +6,10 @@ import {
   tryGetProviderById,
 } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
-import type { TransformRequestContext } from '@/lib/ai-gateway/providers/types';
+import {
+  ReasoningDetailsTransform,
+  type TransformRequestContext,
+} from '@/lib/ai-gateway/providers/types';
 
 describe('LongCat provider', () => {
   test('targets the LongCat chat completions endpoint', () => {
@@ -14,6 +17,7 @@ describe('LongCat provider', () => {
       'https://api.longcat.ai/openai/v1/chat/completions'
     );
     expect(LONGCAT.supportedChatApis).toEqual(['chat_completions']);
+    expect(LONGCAT.responseTransforms).toBe(ReasoningDetailsTransform.ReasoningContent);
   });
 
   test.each([

--- a/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
+++ b/apps/web/src/lib/ai-gateway/providers/provider-definitions.ts
@@ -1,6 +1,10 @@
 import { getEnvVariable } from '@/lib/dotenvx';
 import { isReasoningExplicitlyDisabled } from '@/lib/ai-gateway/providers/openrouter/request-helpers';
-import type { Provider, ProviderId } from '@/lib/ai-gateway/providers/types';
+import {
+  ReasoningDetailsTransform,
+  type Provider,
+  type ProviderId,
+} from '@/lib/ai-gateway/providers/types';
 import { applyVercelSettings } from '@/lib/ai-gateway/providers/vercel';
 
 export const OPENROUTER = {
@@ -66,7 +70,7 @@ export const LONGCAT = {
   apiKey: getEnvVariable('LONGCAT_API_KEY'),
   apiKeyHeader: null,
   supportedChatApis: ['chat_completions'],
-  responseTransforms: null,
+  responseTransforms: ReasoningDetailsTransform.ReasoningContent,
   async transformRequest(context) {
     context.request.body.thinking = {
       type: isReasoningExplicitlyDisabled(context.request) ? 'disabled' : 'enabled',


### PR DESCRIPTION
## Summary
- enable the LongCat 2.0 free model
- normalize LongCat `reasoning_content` through the shared reasoning-details transform
- remove the LongCat AI SDK provider override so it defaults to OpenRouter

## Testing
- CI only, as requested