### PR TITLE
fix(mobile): align markdown list markers with item text

### DIFF
--- a/apps/mobile/src/components/agents/markdown-palette.test.ts
+++ b/apps/mobile/src/components/agents/markdown-palette.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest';
 
-import { getPalette } from './markdown-palette';
+import { getMarkdownStyles, getPalette } from './markdown-palette';
 import { type ThemeColors } from '@/lib/hooks/use-theme-colors';
 
 const colors = {
@@ -44,5 +44,15 @@ describe('markdown palette', () => {
     const palette = getPalette('kilo-chat-user', colors);
 
     expect(palette.textColor).toBe(colors.primaryForeground);
+  });
+
+  it('keeps list marker boxes free of a top margin so markers align with the first line', () => {
+    for (const variant of ['assistant', 'user', 'kilo-chat-user'] as const) {
+      const styles = getMarkdownStyles(getPalette(variant, colors));
+
+      // react-native-marked applies `list` to each item's marker box View;
+      // any top margin pushes the marker below the first text line.
+      expect(styles.list).toEqual({ marginBottom: 4 });
+    }
   });
 });

--- a/apps/mobile/src/components/agents/markdown-palette.ts
+++ b/apps/mobile/src/components/agents/markdown-palette.ts
@@ -105,7 +105,14 @@ export function getMarkdownStyles(palette: MarkdownPalette): MarkedStyles {
       paddingLeft: 12,
       marginVertical: 4,
     },
-    list: { marginVertical: 2 },
+    // react-native-marked maps `list` onto each item's marker box
+    // (MDList → markerBoxStyle), not a list container. A top margin shifts
+    // every marker below its item's first text line (tight lists) or pairs
+    // with the loose-list paragraph margin by accident. Keep this margin
+    // bottom-only; the old form was `marginVertical: 2`. `marginBottom: 4`
+    // preserves the current 28px row height (24px text + 4px gap) that
+    // spaces list items.
+    list: { marginBottom: 4 },
     li: { color: textColor, fontSize: 16, lineHeight: 24 },
     hr: {
       borderBottomWidth: 1,

--- a/apps/mobile/src/components/agents/markdown-palette.ts
+++ b/apps/mobile/src/components/agents/markdown-palette.ts
@@ -105,13 +105,8 @@ export function getMarkdownStyles(palette: MarkdownPalette): MarkedStyles {
       paddingLeft: 12,
       marginVertical: 4,
     },
-    // react-native-marked maps `list` onto each item's marker box
-    // (MDList → markerBoxStyle), not a list container. A top margin shifts
-    // every marker below its item's first text line (tight lists) or pairs
-    // with the loose-list paragraph margin by accident. Keep this margin
-    // bottom-only; the old form was `marginVertical: 2`. `marginBottom: 4`
-    // preserves the current 28px row height (24px text + 4px gap) that
-    // spaces list items.
+    // react-native-marked maps `list` onto each item's marker box, not a list
+    // container. A top margin misaligns the marker; keep this bottom-only.
     list: { marginBottom: 4 },
     li: { color: textColor, fontSize: 16, lineHeight: 24 },
     hr: {

--- a/apps/mobile/src/components/agents/markdown-renderer.test.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.test.ts
@@ -707,4 +707,30 @@ describe('MarkdownRenderer list marker alignment', () => {
     assertItemTextMetrics(mounted, ['one', 'two']);
     await unmountMarkdown(mounted);
   });
+
+  it('keeps a leading blockquote margin in a list item', async () => {
+    const mounted = await mountMarkdown('- > quoted text');
+    const rows = mounted.root.findAll(node => propOf(node, 'testID') === 'marked-list-item');
+    expect(rows).toHaveLength(1);
+    const row = rows[0];
+    if (!row) {
+      throw new Error('list item row missing');
+    }
+    const contentViews = viewChildren(row);
+    expect(contentViews).toHaveLength(1);
+    const contentView = contentViews[0];
+    if (!contentView) {
+      throw new Error('list item content View missing');
+    }
+    const blockquotes = viewChildren(contentView);
+    expect(blockquotes).toHaveLength(1);
+    const blockquote = blockquotes[0];
+    if (!blockquote) {
+      throw new Error('blockquote View missing');
+    }
+    const blockquoteStyle = flattenStyle(propOf(blockquote, 'style'));
+    expect(blockquoteStyle.marginVertical).toBe(4);
+    expect(blockquoteStyle.marginTop).toBeUndefined();
+    await unmountMarkdown(mounted);
+  });
 });

--- a/apps/mobile/src/components/agents/markdown-renderer.test.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.test.ts
@@ -2,7 +2,7 @@
 /* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount RN trees under vitest (same pattern as code-block.test.ts) */
 // eslint-disable-next-line import/no-nodejs-modules -- patching the CJS loader is the only way to stub react-native for the externalized react-native-marked; the library under test stays real
 import Module from 'node:module';
-import { type ReactElement, type ReactNode } from 'react';
+import { createElement, type ReactElement, type ReactNode } from 'react';
 import TestRenderer, { act } from 'react-test-renderer';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -24,7 +24,12 @@ const rnStub = {
   StyleSheet: {
     create: (styles: Record<string, unknown>) => styles,
     hairlineWidth: 1,
-    flatten: (style: unknown) => style,
+    // Real flatten semantics: merge arrays with later values winning, pass
+    // non-array values through unchanged.
+    flatten: (style: unknown) =>
+      Array.isArray(style)
+        ? Object.assign({}, ...(style.filter(Boolean) as Record<string, unknown>[]))
+        : style,
   },
   Dimensions: {
     get: () => ({ width: 390, height: 844, scale: 3, fontScale: 1 }),
@@ -138,6 +143,13 @@ function propOf(instance: TestRenderer.ReactTestInstance | undefined, key: strin
   /* eslint-disable typescript-eslint/no-unsafe-member-access -- react-test-renderer props are an index signature */
   return instance.props[key];
   /* eslint-enable typescript-eslint/no-unsafe-member-access */
+}
+
+function flattenStyle(style: unknown): Record<string, unknown> {
+  if (Array.isArray(style)) {
+    return Object.assign({}, ...(style.filter(Boolean) as Record<string, unknown>[]));
+  }
+  return (style ?? {}) as Record<string, unknown>;
 }
 
 describe('MarkdownRenderer key stability', () => {
@@ -556,5 +568,143 @@ describe('MarkdownRenderer empty fence mounting', () => {
     });
     // Restore the stubbed module graph for any dynamic import that follows.
     vi.resetModules();
+  });
+});
+
+describe('MarkdownRenderer list marker alignment', () => {
+  function viewChildren(node: TestRenderer.ReactTestInstance): TestRenderer.ReactTestInstance[] {
+    return node.children.filter(
+      (child): child is TestRenderer.ReactTestInstance =>
+        typeof child === 'object' && (child.type as unknown) === 'View'
+    );
+  }
+
+  async function mountMarkdown(value: string) {
+    const { useMarkdown } = await import('react-native-marked');
+    const { getMarkdownStyles } = await import('./markdown-palette');
+    const { MarkdownRenderer: RendererClass } = await import('./markdown-renderer');
+    const { View: StubView } = await import('react-native');
+    const renderer = new RendererClass(palette, true, {});
+    const styles = getMarkdownStyles(palette);
+    function Host() {
+      const elements = useMarkdown(value, { styles, renderer, colorScheme: 'light' });
+      return createElement(StubView, null, elements);
+    }
+    const rendererRef: { current: TestRenderer.ReactTestRenderer | undefined } = {
+      current: undefined,
+    };
+    await act(async () => {
+      await Promise.resolve();
+      rendererRef.current = TestRenderer.create(createElement(Host));
+    });
+    const mounted = rendererRef.current;
+    if (!mounted) {
+      throw new Error('renderer was not created');
+    }
+    return mounted;
+  }
+
+  async function unmountMarkdown(mounted: TestRenderer.ReactTestRenderer) {
+    await act(async () => {
+      await Promise.resolve();
+      mounted.unmount();
+    });
+  }
+
+  function assertAlignedList(mounted: TestRenderer.ReactTestRenderer, expectedItems: number) {
+    const rows = mounted.root.findAll(node => propOf(node, 'testID') === 'marked-list-item');
+    expect(rows).toHaveLength(expectedItems);
+    for (const row of rows) {
+      // Criterion 3 mechanism: the row lays the fixed-width marker box beside
+      // a shrinking content View, so wrapped text indents under the text and
+      // does not overlap the marker.
+      expect(flattenStyle(propOf(row, 'style')).flexDirection).toBe('row');
+      const contentViews = viewChildren(row);
+      expect(contentViews).toHaveLength(1);
+      const contentView = contentViews[0];
+      if (!contentView) {
+        throw new Error('list item content View missing');
+      }
+      expect(flattenStyle(propOf(contentView, 'style')).flexShrink).toBe(1);
+    }
+    const markers = mounted.root.findAll(node => propOf(node, 'testID') === 'marker-box');
+    expect(markers).toHaveLength(expectedItems);
+    for (const marker of markers) {
+      const box = marker.parent;
+      if (!box) {
+        throw new Error('marker box View missing');
+      }
+      // No top margin on the marker box: the marker shares the row top with
+      // the first text line.
+      expect(flattenStyle(propOf(box, 'style'))).toEqual({ marginBottom: 4 });
+      const markerStyle = flattenStyle(propOf(marker, 'style'));
+      expect(markerStyle.fontSize).toBe(16);
+      expect(markerStyle.lineHeight).toBe(24);
+    }
+  }
+
+  function assertItemTextMetrics(mounted: TestRenderer.ReactTestRenderer, words: string[]) {
+    const itemTexts = mounted.root.findAll(
+      node =>
+        typeof node.type === 'string' &&
+        (node.type as unknown) === 'Text' &&
+        Array.isArray(node.children) &&
+        node.children.some(
+          child => typeof child === 'string' && words.some(word => child.includes(word))
+        )
+    );
+    expect(itemTexts).toHaveLength(words.length);
+    for (const item of itemTexts) {
+      const style = flattenStyle(propOf(item, 'style'));
+      expect(style.fontSize).toBe(16);
+      expect(style.lineHeight).toBe(24);
+    }
+  }
+
+  function assertLooseParagraphMargins(mounted: TestRenderer.ReactTestRenderer) {
+    const rows = mounted.root.findAll(node => propOf(node, 'testID') === 'marked-list-item');
+    for (const row of rows) {
+      const contentViews = viewChildren(row);
+      const contentView = contentViews[0];
+      if (!contentView) {
+        throw new Error('list item content View missing');
+      }
+      const paragraphs = viewChildren(contentView);
+      expect(paragraphs).toHaveLength(1);
+      const paragraphStyle = flattenStyle(propOf(paragraphs[0], 'style'));
+      expect(paragraphStyle.marginTop).toBe(0);
+      expect(paragraphStyle.marginVertical).toBeUndefined();
+      expect(paragraphStyle.marginBottom).toBe(2);
+    }
+  }
+
+  it('aligns tight unordered list markers with the first line of item text', async () => {
+    const mounted = await mountMarkdown('- one\n- two');
+    assertAlignedList(mounted, 2);
+    assertItemTextMetrics(mounted, ['one', 'two']);
+    await unmountMarkdown(mounted);
+  });
+
+  it('aligns tight ordered list markers with the first line of item text', async () => {
+    const mounted = await mountMarkdown('1. one\n2. two');
+    assertAlignedList(mounted, 2);
+    assertItemTextMetrics(mounted, ['one', 'two']);
+    await unmountMarkdown(mounted);
+  });
+
+  it('aligns loose unordered list markers with the first line of item text', async () => {
+    const mounted = await mountMarkdown('- one\n\n- two');
+    assertAlignedList(mounted, 2);
+    assertLooseParagraphMargins(mounted);
+    assertItemTextMetrics(mounted, ['one', 'two']);
+    await unmountMarkdown(mounted);
+  });
+
+  it('aligns loose ordered list markers with the first line of item text', async () => {
+    const mounted = await mountMarkdown('1. one\n\n2. two');
+    assertAlignedList(mounted, 2);
+    assertLooseParagraphMargins(mounted);
+    assertItemTextMetrics(mounted, ['one', 'two']);
+    await unmountMarkdown(mounted);
   });
 });

--- a/apps/mobile/src/components/agents/markdown-renderer.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.ts
@@ -11,7 +11,6 @@ import {
   type GestureResponderEvent,
   type ImageStyle,
   Pressable,
-  StyleSheet,
   Text,
   type TextStyle,
   View,
@@ -201,12 +200,10 @@ export class MarkdownRenderer extends Renderer {
   // in markdown-palette.ts). Rewrite the leading block's vertical margin so
   // loose and tight items start their first line at the row top alike.
   override listItem(children: ReactNode[], styles?: ViewStyle): ReactNode {
-    const first = Array.isArray(children) ? children[0] : undefined;
+    const first = children[0];
     if (isValidElement(first) && first.type === View) {
-      const styleProp = (first.props as { style?: ViewStyle | ViewStyle[] }).style;
-      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- StyleSheet.flatten(undefined) returns undefined at runtime; the RN type says non-null
-      const flat = StyleSheet.flatten(styleProp) ?? {};
-      const { marginVertical, marginBottom, ...rest } = flat;
+      const styleProp = (first.props as { style?: ViewStyle }).style;
+      const { marginVertical, marginBottom, ...rest } = styleProp ?? {};
       const adjusted: ViewStyle = {
         ...rest,
         marginTop: 0,
@@ -215,7 +212,7 @@ export class MarkdownRenderer extends Renderer {
       return super.listItem(
         [
           // eslint-disable-next-line react/no-clone-element -- listItem must rewrite the leading paragraph View's style in place; cloning preserves the element's key and the renderer's key sequence
-          cloneElement(first as ReactElement<{ style?: ViewStyle | ViewStyle[] }>, {
+          cloneElement(first as ReactElement<{ style?: ViewStyle }>, {
             style: adjusted,
           }),
           ...children.slice(1),

--- a/apps/mobile/src/components/agents/markdown-renderer.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.ts
@@ -197,28 +197,35 @@ export class MarkdownRenderer extends Renderer {
   // text in a paragraph View (marked rewrites item `text` tokens to
   // `paragraph` tokens). That paragraph's top margin pushes the first line
   // below the marker, which sits at the row top (see the `list` style note
-  // in markdown-palette.ts). Rewrite the leading block's vertical margin so
-  // loose and tight items start their first line at the row top alike.
+  // in markdown-palette.ts). Rewrite the leading paragraph View's vertical
+  // margin so loose and tight items start their first line at the row top
+  // alike. A leading blockquote or hr View has border properties but no
+  // `paddingVertical`, so it keeps its own spacing.
   override listItem(children: ReactNode[], styles?: ViewStyle): ReactNode {
     const first = children[0];
     if (isValidElement(first) && first.type === View) {
       const styleProp = (first.props as { style?: ViewStyle }).style;
-      const { marginVertical, marginBottom, ...rest } = styleProp ?? {};
-      const adjusted: ViewStyle = {
-        ...rest,
-        marginTop: 0,
-        marginBottom: marginBottom ?? marginVertical,
-      };
-      return super.listItem(
-        [
-          // eslint-disable-next-line react/no-clone-element -- listItem must rewrite the leading paragraph View's style in place; cloning preserves the element's key and the renderer's key sequence
-          cloneElement(first as ReactElement<{ style?: ViewStyle }>, {
-            style: adjusted,
-          }),
-          ...children.slice(1),
-        ],
-        styles
-      );
+      // The paragraph View is the only leading View whose style carries the
+      // paragraph's `paddingVertical` (palette paragraph is
+      // { marginVertical: 2, paddingVertical: 0 }).
+      if (styleProp !== undefined && 'paddingVertical' in styleProp) {
+        const { marginVertical, marginBottom, ...rest } = styleProp;
+        const adjusted: ViewStyle = {
+          ...rest,
+          marginTop: 0,
+          marginBottom: marginBottom ?? marginVertical,
+        };
+        return super.listItem(
+          [
+            // eslint-disable-next-line react/no-clone-element -- listItem must rewrite the leading paragraph View's style in place; cloning preserves the element's key and the renderer's key sequence
+            cloneElement(first as ReactElement<{ style?: ViewStyle }>, {
+              style: adjusted,
+            }),
+            ...children.slice(1),
+          ],
+          styles
+        );
+      }
     }
     return super.listItem(children, styles);
   }

--- a/apps/mobile/src/components/agents/markdown-renderer.ts
+++ b/apps/mobile/src/components/agents/markdown-renderer.ts
@@ -1,10 +1,17 @@
-import { createElement, isValidElement, type ReactNode } from 'react';
+import {
+  cloneElement,
+  createElement,
+  isValidElement,
+  type ReactElement,
+  type ReactNode,
+} from 'react';
 import {
   type AccessibilityActionEvent,
   type AccessibilityRole,
   type GestureResponderEvent,
   type ImageStyle,
   Pressable,
+  StyleSheet,
   Text,
   type TextStyle,
   View,
@@ -185,6 +192,38 @@ export class MarkdownRenderer extends Renderer {
         maxLength: MARKDOWN_CODE_CHARACTER_CAP,
       })
     );
+  }
+
+  // Loose Markdown lists — any blank line between items — wrap every item's
+  // text in a paragraph View (marked rewrites item `text` tokens to
+  // `paragraph` tokens). That paragraph's top margin pushes the first line
+  // below the marker, which sits at the row top (see the `list` style note
+  // in markdown-palette.ts). Rewrite the leading block's vertical margin so
+  // loose and tight items start their first line at the row top alike.
+  override listItem(children: ReactNode[], styles?: ViewStyle): ReactNode {
+    const first = Array.isArray(children) ? children[0] : undefined;
+    if (isValidElement(first) && first.type === View) {
+      const styleProp = (first.props as { style?: ViewStyle | ViewStyle[] }).style;
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- StyleSheet.flatten(undefined) returns undefined at runtime; the RN type says non-null
+      const flat = StyleSheet.flatten(styleProp) ?? {};
+      const { marginVertical, marginBottom, ...rest } = flat;
+      const adjusted: ViewStyle = {
+        ...rest,
+        marginTop: 0,
+        marginBottom: marginBottom ?? marginVertical,
+      };
+      return super.listItem(
+        [
+          // eslint-disable-next-line react/no-clone-element -- listItem must rewrite the leading paragraph View's style in place; cloning preserves the element's key and the renderer's key sequence
+          cloneElement(first as ReactElement<{ style?: ViewStyle | ViewStyle[] }>, {
+            style: adjusted,
+          }),
+          ...children.slice(1),
+        ],
+        styles
+      );
+    }
+    return super.listItem(children, styles);
   }
 
   override escape(text: string, styles?: TextStyle): ReactNode {


### PR DESCRIPTION
## Summary

Bullets and numbers in chat message lists now sit on the same line as the first line of each item's text. The alignment holds for lists with and without blank lines between items.

---

The renderer adds a `listItem` override that flattens the leading paragraph View's vertical margin in loose lists. Loose lists wrap each item's text in a paragraph View whose top margin pushed the first line below the marker, so the override finds that View by its `paddingVertical` style key, sets `marginTop` to 0, and keeps the bottom margin. It clones the View in place, which preserves the renderer's key sequence.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/markdown-renderer.ts` — adds the `listItem` override; it detects the leading paragraph View, rewrites its vertical margins, and clones it in place.

</details>

The `list` palette style changes from `{ marginVertical: 2 }` to `{ marginBottom: 4 }`. react-native-marked applies `list` to each item's marker box, not the list container, so the old top margin pushed the marker below the first text line. The new style moves that space to the bottom, so the marker box keeps its 28px height and the marker sits at the row top.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/markdown-palette.ts` — changes the `list` style to `{ marginBottom: 4 }` and documents the marker-box mapping.

</details>

Tests: 2 files updated — `apps/mobile/src/components/agents/markdown-renderer.test.ts`, `apps/mobile/src/components/agents/markdown-palette.test.ts`.
Generated: none.

---

## Verification

Verification ran 2 cases on the iOS platform.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| ML-1 | Tight bullet and numbered list markers sit on the same line as the first line of the item text. | iOS | passed |
| ML-2 | Loose list markers stay on the item text line and the rows keep an even vertical gap. | iOS | passed |

No defect reproduced on the unfixed build.

## Visual Changes

Agent chat screen, Markdown list rendering. The user sees each bullet and number on the same line as the first line of that item's text. In the lower half, the bullets and numbers each sit level with their item word.

![ml1-list.png](https://github.com/user-attachments/assets/ef61d414-7039-48a2-af56-16f3714dbc10)

## Reviewer Notes

Human steps: none known.
Notes: none.
