### PR TITLE
Add LongCat to Auto Free

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -27,6 +27,7 @@ import {
   logFreeModelRequest,
 } from '@/lib/free-model-rate-limiter';
 import { gemma_4_26b_a4b_it_free_model } from '@/lib/ai-gateway/providers/google';
+import { longcat_2_free_model } from '@/lib/ai-gateway/providers/longcat';
 import { tencent_hy3_free_model } from '@/lib/ai-gateway/providers/tencent';
 import { getEffectiveModelDecision } from '@/lib/organizations/effective-model-access.server';
 import { getPercentageRoutedPartnerProvider } from '@/lib/ai-gateway/providers/partner/routing';
@@ -526,8 +527,12 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
 
     expect(response.status).toBe(200);
     expect(mockedGetProvider).toHaveBeenCalledTimes(2);
-    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe('stepfun/step-3.7-flash:free');
-    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe('stepfun/step-3.7-flash');
+    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe(
+      longcat_2_free_model.public_id
+    );
+    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe(
+      longcat_2_free_model.internal_id
+    );
     expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[1]).toMatchObject({
       abuse_delay: 6000,
       abuse_downgraded_from: 'openai/gpt-4o',

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -526,8 +526,8 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
 
     expect(response.status).toBe(200);
     expect(mockedGetProvider).toHaveBeenCalledTimes(2);
-    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe('stepfun/step-3.7-flash:free');
-    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe('stepfun/step-3.7-flash');
+    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe('meituan/longcat-2.0-free');
+    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe('LongCat-2.0');
     expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[1]).toMatchObject({
       abuse_delay: 6000,
       abuse_downgraded_from: 'openai/gpt-4o',

--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -27,7 +27,6 @@ import {
   logFreeModelRequest,
 } from '@/lib/free-model-rate-limiter';
 import { gemma_4_26b_a4b_it_free_model } from '@/lib/ai-gateway/providers/google';
-import { longcat_2_free_model } from '@/lib/ai-gateway/providers/longcat';
 import { tencent_hy3_free_model } from '@/lib/ai-gateway/providers/tencent';
 import { getEffectiveModelDecision } from '@/lib/organizations/effective-model-access.server';
 import { getPercentageRoutedPartnerProvider } from '@/lib/ai-gateway/providers/partner/routing';
@@ -527,12 +526,8 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
 
     expect(response.status).toBe(200);
     expect(mockedGetProvider).toHaveBeenCalledTimes(2);
-    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe(
-      longcat_2_free_model.public_id
-    );
-    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe(
-      longcat_2_free_model.internal_id
-    );
+    expect(mockedGetProvider.mock.calls[1]?.[0].requestedModel).toBe('stepfun/step-3.7-flash:free');
+    expect(mockedUpstreamRequest.mock.calls[0]?.[0].body.model).toBe('stepfun/step-3.7-flash');
     expect(mockedAccountForMicrodollarUsage.mock.calls[0]?.[1]).toMatchObject({
       abuse_delay: 6000,
       abuse_downgraded_from: 'openai/gpt-4o',

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -193,16 +193,18 @@ describe('isFreeModel', () => {
       ).toEqual({
         'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
         'tencent/hy3:free': { enabled: true, effort: 'high' },
+        'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
         'meituan/longcat-2.0-free': { enabled: true, effort: 'high' },
       });
     });
 
-    test('weights Auto Free models at 80% StepFun, 10% Hy3, and 10% LongCat', () => {
+    test('weights Auto Free models at 70% StepFun and 10% each for Hy3, Laguna, and LongCat', () => {
       expect(
         Object.fromEntries(autoFreeModels.map(({ model, weight }) => [model, weight]))
       ).toEqual({
-        'stepfun/step-3.7-flash:free': 8,
+        'stepfun/step-3.7-flash:free': 7,
         'tencent/hy3:free': 1,
+        'poolside/laguna-s-2.1:free': 1,
         'meituan/longcat-2.0-free': 1,
       });
     });

--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -87,7 +87,7 @@ describe('isFreeModel', () => {
       expect(autoFreeModels.map(({ model }) => model)).toContain(tencent_hy3_free_model.public_id);
     });
 
-    test('registers LongCat 2.0 as a free preferred model', async () => {
+    test('registers LongCat 2.0 as an Auto Free model', async () => {
       expect(kiloExclusiveModels).toContain(longcat_2_free_model);
       expect(findKiloExclusiveModel(longcat_2_free_model.public_id)).toBe(longcat_2_free_model);
       expect(await isFreeModel(longcat_2_free_model.public_id)).toBe(true);
@@ -98,9 +98,7 @@ describe('isFreeModel', () => {
         max_completion_tokens: 131_072,
         status: 'public',
       });
-      expect(autoFreeModels.map(({ model }) => model)).not.toContain(
-        longcat_2_free_model.public_id
-      );
+      expect(autoFreeModels.map(({ model }) => model)).toContain(longcat_2_free_model.public_id);
       expect(preferredModels).toContain(longcat_2_free_model.public_id);
       expect(getAiSdkProvider(longcat_2_free_model.public_id, null)).toBeUndefined();
     });
@@ -195,17 +193,17 @@ describe('isFreeModel', () => {
       ).toEqual({
         'stepfun/step-3.7-flash:free': { enabled: true, effort: 'high' },
         'tencent/hy3:free': { enabled: true, effort: 'high' },
-        'poolside/laguna-s-2.1:free': { enabled: true, effort: 'high' },
+        'meituan/longcat-2.0-free': { enabled: true, effort: 'high' },
       });
     });
 
-    test('weights Auto Free models at 80% StepFun, 10% Hy3, and 10% Laguna', () => {
+    test('weights Auto Free models at 80% StepFun, 10% Hy3, and 10% LongCat', () => {
       expect(
         Object.fromEntries(autoFreeModels.map(({ model, weight }) => [model, weight]))
       ).toEqual({
         'stepfun/step-3.7-flash:free': 8,
         'tencent/hy3:free': 1,
-        'poolside/laguna-s-2.1:free': 1,
+        'meituan/longcat-2.0-free': 1,
       });
     });
 

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -47,7 +47,7 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
     ? [
         {
           model: stepfun_37_flash_free_model.public_id,
-          weight: 8,
+          weight: 7,
           reasoning: { enabled: true, effort: 'high' },
         } satisfies AutoFreeModel,
       ]
@@ -61,6 +61,11 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
         } satisfies AutoFreeModel,
       ]
     : []),
+  {
+    model: 'poolside/laguna-s-2.1:free',
+    weight: 1,
+    reasoning: { enabled: true, effort: 'high' },
+  } satisfies AutoFreeModel,
   ...(longcat_2_free_model.status === 'public'
     ? [
         {

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -61,11 +61,15 @@ export const autoFreeModels: ReadonlyArray<AutoFreeModel> = [
         } satisfies AutoFreeModel,
       ]
     : []),
-  {
-    model: 'poolside/laguna-s-2.1:free',
-    weight: 1,
-    reasoning: { enabled: true, effort: 'high' },
-  } satisfies AutoFreeModel,
+  ...(longcat_2_free_model.status === 'public'
+    ? [
+        {
+          model: longcat_2_free_model.public_id,
+          weight: 1,
+          reasoning: { enabled: true, effort: 'high' },
+        } satisfies AutoFreeModel,
+      ]
+    : []),
 ];
 
 export function selectAutoFreeCandidate(
@@ -91,7 +95,6 @@ export const preferredModels = [
   KILO_AUTO_FREE_MODEL.id,
 
   ...autoFreeModels.map(({ model }) => model),
-  ...(longcat_2_free_model.status === 'public' ? [longcat_2_free_model.public_id] : []),
 
   CLAUDE_SONNET_CURRENT_MODEL_ID,
   CLAUDE_OPUS_CURRENT_MODEL_ID,


### PR DESCRIPTION
## Summary
- add LongCat to the Auto Free candidate pool
- keep Laguna and reduce StepFun from weight 8 to 7
- use a 70/10/10/10 split across StepFun, Hy3, Laguna, and LongCat

## Testing
- CI only