### PR TITLE
fix(organizations): make group model grants additive

### DIFF
--- a/apps/web/src/app/api/openrouter/[...path]/route.test.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.test.ts
@@ -411,6 +411,10 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
       settings: { provider_allow_list: ['amazon-bedrock'] },
       plan: 'enterprise',
     });
+    mockedGetEffectiveModelDecision.mockResolvedValue({
+      allowed: true,
+      eligibleProviderRoutes: new Set(['amazon-bedrock']),
+    });
 
     const { POST } = await import('./route');
     const response = await POST(makeRequest(makeBody('anthropic/claude-sonnet-4.5')) as never);
@@ -421,7 +425,7 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     expect((await getRoutingProviderConfig?.())?.only).toEqual(['amazon-bedrock']);
   });
 
-  it('skips group policy evaluation when organization policy denies the model', async () => {
+  it('allows a group grant to override the organization model baseline', async () => {
     mockedGetUserFromAuth.mockResolvedValue({
       user: {
         id: 'user-123',
@@ -440,8 +444,112 @@ describe('POST /api/openrouter/v1/chat/completions rules-engine actions', () => 
     const { POST } = await import('./route');
     const response = await POST(makeRequest(makeBody()) as never);
 
+    expect(response.status).toBe(200);
+    expect(mockedGetEffectiveModelDecision).toHaveBeenCalledWith(
+      expect.anything(),
+      'openai/gpt-4o'
+    );
+  });
+
+  it('allows a group provider grant outside the organization provider baseline', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-1',
+    });
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: { provider_allow_list: ['openai'] },
+      plan: 'enterprise',
+    });
+    mockedGetEffectiveModelDecision.mockResolvedValue({
+      allowed: true,
+      eligibleProviderRoutes: new Set(['google']),
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody('google/gemini-2.5-pro')) as never);
+
+    expect(response.status).toBe(200);
+    const getRoutingProviderConfig = mockedGetProvider.mock.calls[0]?.[0].getRoutingProviderConfig;
+    expect((await getRoutingProviderConfig?.())?.only).toEqual(['google']);
+  });
+
+  it('allows an explicitly granted model through an enterprise experiment', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-1',
+    });
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: { model_deny_list: ['openai/gpt-4o'] },
+      plan: 'enterprise',
+    });
+    mockedGetProvider.mockResolvedValue({
+      kind: 'provider',
+      provider: { ...provider, id: 'friendli' },
+      userByok: null,
+      bypassAccessCheck: false,
+      experiment: {
+        experimentId: 'experiment-1',
+        variantId: 'variant-1',
+        variantVersionId: 'version-1',
+        allocationSubject: 'user',
+      },
+    });
+    mockedGetEffectiveModelDecision.mockResolvedValue({ allowed: true });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody()) as never);
+
+    expect(response.status).toBe(200);
+  });
+
+  it('blocks an enterprise experiment outside the effective provider routes', async () => {
+    mockedGetUserFromAuth.mockResolvedValue({
+      user: {
+        id: 'user-123',
+        google_user_email: 'test@example.com',
+        microdollars_used: 0,
+      } as User,
+      authFailedResponse: null,
+      organizationId: 'org-1',
+    });
+    mockedGetBalanceAndOrgSettings.mockResolvedValue({
+      balance: 1000,
+      settings: { provider_allow_list: ['openai'] },
+      plan: 'enterprise',
+    });
+    mockedGetProvider.mockResolvedValue({
+      kind: 'provider',
+      provider: { ...provider, id: 'friendli' },
+      userByok: null,
+      bypassAccessCheck: false,
+      experiment: {
+        experimentId: 'experiment-1',
+        variantId: 'variant-1',
+        variantVersionId: 'version-1',
+        allocationSubject: 'user',
+      },
+    });
+    mockedGetEffectiveModelDecision.mockResolvedValue({
+      allowed: true,
+      eligibleProviderRoutes: new Set(['openai']),
+    });
+
+    const { POST } = await import('./route');
+    const response = await POST(makeRequest(makeBody()) as never);
+
     expect(response.status).toBe(404);
-    expect(mockedGetEffectiveModelDecision).not.toHaveBeenCalled();
   });
 
   it('returns 404 when the OpenRouter model id is unknown', async () => {
@@ -960,7 +1068,7 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(stats.cost_mUsd).toBe(3000);
   });
 
-  it('passes enterprise organization model deny list to the efficient decision worker', async () => {
+  it('passes effective organization policy denials to the efficient decision worker', async () => {
     mockedGetUserFromAuth.mockResolvedValue({
       user: {
         id: 'user-123',
@@ -977,6 +1085,7 @@ describe('kilo-auto/efficient classifier billing', () => {
       },
       plan: 'enterprise',
     });
+    mockedCollectDeniedAutoRoutingModelIds.mockResolvedValue(['openai/gpt-4o']);
     mockedFetchEfficientAutoDecision.mockResolvedValue({
       decision: {
         model: 'anthropic/claude-haiku-4',
@@ -1090,7 +1199,7 @@ describe('kilo-auto/efficient classifier billing', () => {
     expect(mockedUpstreamRequest).not.toHaveBeenCalled();
   });
 
-  it('guides enterprise teams whose deny list blocks every pool model to configure a custom Efficient pool', async () => {
+  it('guides enterprise teams whose baseline blocks every pool model to configure a custom Efficient pool', async () => {
     mockedGetUserFromAuth.mockResolvedValue({
       user: {
         id: 'user-123',
@@ -1104,6 +1213,11 @@ describe('kilo-auto/efficient classifier billing', () => {
       balance: 1000,
       settings: { model_deny_list: ['anthropic/claude-haiku-4'] },
       plan: 'enterprise',
+    });
+    mockedCollectDeniedAutoRoutingModelIds.mockResolvedValue(['anthropic/claude-haiku-4']);
+    mockedGetEffectiveModelDecision.mockResolvedValue({
+      allowed: false,
+      denialSource: 'organization_model',
     });
     mockedFetchEfficientAutoDecision.mockResolvedValue({ decision: null, costUsd: 0 });
 

--- a/apps/web/src/app/api/openrouter/[...path]/route.ts
+++ b/apps/web/src/app/api/openrouter/[...path]/route.ts
@@ -341,9 +341,11 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
           // Kilo-funded classification with no user to attribute it to.
           if (!user || authFailedResponse) return null;
           const { settings, plan } = await balanceAndSettingsPromise;
-          const deniedFromSettings =
-            plan === 'enterprise' ? (settings?.model_deny_list?.map(normalizeModelId) ?? []) : [];
           const groupPolicy = await organizationGroupPolicyPromise;
+          const deniedFromSettings =
+            !groupPolicy && plan === 'enterprise'
+              ? (settings?.model_deny_list?.map(normalizeModelId) ?? [])
+              : [];
           const deniedFromPolicy = groupPolicy
             ? await collectDeniedAutoRoutingModelIds(groupPolicy, {
                 userId: user.id,
@@ -604,10 +606,11 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
 
   async function resolveAccessCheck(modelId: string) {
     const { balance, settings, plan } = await balanceAndSettingsPromise;
+    const groupPolicy = await organizationGroupPolicyPromise;
     const { error: modelRestrictionError, providerConfig } = checkOrganizationModelRestrictions({
       modelId,
       settings,
-      organizationPlan: plan,
+      organizationPlan: groupPolicy ? undefined : plan,
     });
     if (modelRestrictionError) {
       return {
@@ -616,14 +619,12 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
         groupModelAllowed: true,
         groupProvidersAllowed: true,
         modelRestrictionError,
-        plan,
         settings,
       };
     }
     let effectiveProviderConfig = providerConfig;
     let groupModelAllowed = true;
     let groupProvidersAllowed = true;
-    const groupPolicy = await organizationGroupPolicyPromise;
     if (groupPolicy) {
       const groupDecision = await getEffectiveModelDecision(groupPolicy, modelId);
       groupModelAllowed = groupDecision.allowed;
@@ -642,7 +643,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       groupModelAllowed,
       groupProvidersAllowed,
       modelRestrictionError,
-      plan,
       settings,
     };
   }
@@ -847,7 +847,6 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       groupModelAllowed,
       groupProvidersAllowed,
       modelRestrictionError,
-      plan,
       settings,
     } = await accessCheckResolver.get();
 
@@ -879,11 +878,13 @@ export async function POST(request: NextRequest): Promise<NextResponseType<unkno
       return dataCollectionRequiredResponse();
     }
 
-    // Enterprise `provider_allow_list` is enforced via OpenRouter's
-    // `body.provider.only` field, which doesn't reach a direct partner
-    // upstream. Refuse the experimented public id rather than routing
-    // around the org's allow-list.
-    if (effectiveProviderContext.experiment && plan === 'enterprise') {
+    // OpenRouter's `body.provider.only` does not reach a direct experiment
+    // partner, so enforce any effective provider routes locally instead.
+    if (
+      effectiveProviderContext.experiment &&
+      effectiveProviderConfig?.only &&
+      !effectiveProviderConfig.only.includes(effectiveProviderContext.provider.id)
+    ) {
       return modelNotAllowedResponse();
     }
 

--- a/apps/web/src/components/organizations/groups/policies/model-access/ModelAccessPolicyEditor.tsx
+++ b/apps/web/src/components/organizations/groups/policies/model-access/ModelAccessPolicyEditor.tsx
@@ -76,41 +76,21 @@ export function ModelAccessPolicyEditor({
 
   const selectedModels = useMemo(() => new Set(modelIds.map(normalizeModelId)), [modelIds]);
   const selectedProviders = useMemo(() => new Set(providerSlugs), [providerSlugs]);
-  const deniedModels = useMemo(
-    () => new Set((editorData?.modelDenyList ?? []).map(normalizeModelId)),
-    [editorData]
-  );
-  const providerCeiling = editorData?.providerAllowList;
-  const providerCeilingSet = useMemo(
-    () => (providerCeiling ? new Set(providerCeiling) : null),
-    [providerCeiling]
-  );
   const providerIndex = useMemo(() => buildModelProvidersIndex(providers), [providers]);
 
   const modelRows = useMemo((): ModelRow[] => {
-    return models
-      .map((model, sourceIndex) => {
-        const modelId = normalizeModelId(model.slug);
-        const routes = [...(providerIndex.get(modelId) ?? [])];
-        const eligibleRoutes = providerCeilingSet
-          ? routes.filter(route => providerCeilingSet.has(route))
-          : routes;
-        const unavailableReason = deniedModels.has(modelId)
-          ? 'Unavailable under organization model settings'
-          : eligibleRoutes.length === 0
-            ? 'No route is available under organization provider settings'
-            : undefined;
-        return {
-          modelId,
-          modelName: model.name,
-          providerSlugs: eligibleRoutes,
-          preferredIndex: undefined,
-          sourceIndex,
-          unavailableReason,
-        };
-      })
-      .filter(row => selectedModels.has(row.modelId) || !row.unavailableReason);
-  }, [deniedModels, models, providerCeilingSet, providerIndex, selectedModels]);
+    return models.map((model, sourceIndex) => {
+      const modelId = normalizeModelId(model.slug);
+      const routes = [...(providerIndex.get(modelId) ?? [])];
+      return {
+        modelId,
+        modelName: model.name,
+        providerSlugs: routes,
+        preferredIndex: undefined,
+        sourceIndex,
+      };
+    });
+  }, [models, providerIndex]);
 
   const filteredModels = useMemo(() => {
     const search = modelSearch.trim().toLowerCase();
@@ -127,12 +107,6 @@ export function ModelAccessPolicyEditor({
 
   const providerRows = useMemo((): ProviderRow[] => {
     return providers
-      .filter(
-        provider =>
-          selectedProviders.has(provider.slug) ||
-          !providerCeilingSet ||
-          providerCeilingSet.has(provider.slug)
-      )
       .map(provider => ({
         providerSlug: provider.slug,
         providerDisplayName: provider.displayName,
@@ -142,14 +116,10 @@ export function ModelAccessPolicyEditor({
         retainsPrompts: provider.dataPolicy.retainsPrompts,
         headquarters: provider.headquarters,
         datacenters: provider.datacenters,
-        unavailableReason:
-          providerCeilingSet && !providerCeilingSet.has(provider.slug)
-            ? 'Unavailable under organization provider settings'
-            : undefined,
       }))
       .filter(provider => provider.modelCount > 0)
       .sort((a, b) => a.providerDisplayName.localeCompare(b.providerDisplayName));
-  }, [providerCeilingSet, providers, selectedProviders]);
+  }, [providers]);
 
   const locationOptions = useMemo(() => {
     const values = new Set<string>();

--- a/apps/web/src/components/organizations/providers-and-models/ModelsTab.tsx
+++ b/apps/web/src/components/organizations/providers-and-models/ModelsTab.tsx
@@ -39,7 +39,7 @@ export function ModelsTab({
       <p className="text-muted-foreground text-sm">
         {scope === 'organization'
           ? 'Disable specific models for organization members. New models from enabled providers are allowed by default.'
-          : 'Grant specific models through this policy. Organization-wide restrictions still apply.'}
+          : 'Grant specific models in addition to the organization default access.'}
       </p>
 
       {isLoading ? (

--- a/apps/web/src/lib/ai-gateway/auto-routing-denied-models.test.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-denied-models.test.ts
@@ -23,7 +23,7 @@ function policy(
 const owner = { userId: 'user-1', organizationId: 'org-1' };
 
 describe('policyNeedsCandidateEvaluation', () => {
-  it('is false for an unrestricted policy with only a deny list', () => {
+  it('is false for an unrestricted policy with an inactive baseline deny list', () => {
     expect(
       policyNeedsCandidateEvaluation(policy({ organizationModelDenyList: ['openai/gpt-4o'] }))
     ).toBe(false);
@@ -41,11 +41,18 @@ describe('policyNeedsCandidateEvaluation', () => {
         policy({
           memberGrant: {
             mode: 'selected',
+            includeOrganizationBaseline: false,
             modelAllowList: ['anthropic/claude'],
             providerAllowList: [],
           },
         })
       )
+    ).toBe(true);
+  });
+
+  it('is true for an organization baseline grant', () => {
+    expect(
+      policyNeedsCandidateEvaluation(policy({ memberGrant: { mode: 'organization_baseline' } }))
     ).toBe(true);
   });
 
@@ -63,14 +70,14 @@ describe('collectDeniedAutoRoutingModelIds', () => {
 });
 
 describe('deniedModelIdsForCandidates', () => {
-  it('returns the normalized organization deny list and matching candidates', () => {
+  it('does not apply the organization deny list to an unrestricted grant', () => {
     expect(
       deniedModelIdsForCandidates(
         policy({ organizationModelDenyList: ['openai/gpt-4o:free'] }),
         ['anthropic/claude'],
         () => true
       )
-    ).toEqual(['openai/gpt-4o']);
+    ).toEqual([]);
   });
 
   it('adds models that fail the effective access policy', () => {
@@ -79,6 +86,7 @@ describe('deniedModelIdsForCandidates', () => {
         policy({
           organizationProviderCeiling: ['anthropic'],
           organizationModelDenyList: ['openai/o3'],
+          memberGrant: { mode: 'organization_baseline' },
         }),
         ['anthropic/claude', 'google/gemini-2.5-flash', 'kilo-auto/efficient'],
         modelId => modelId !== 'google/gemini-2.5-flash'
@@ -99,7 +107,10 @@ describe('deniedModelIdsForCandidates', () => {
   it('expands a normalized deny-list entry to matching suffixed candidates', () => {
     expect(
       deniedModelIdsForCandidates(
-        policy({ organizationModelDenyList: ['example/model'] }),
+        policy({
+          organizationModelDenyList: ['example/model'],
+          memberGrant: { mode: 'organization_baseline' },
+        }),
         ['anthropic/claude', 'example/model:suffix'],
         () => true
       )
@@ -112,6 +123,7 @@ describe('deniedModelIdsForCandidates', () => {
         policy({
           memberGrant: {
             mode: 'selected',
+            includeOrganizationBaseline: false,
             modelAllowList: ['anthropic/claude'],
             providerAllowList: [],
           },

--- a/apps/web/src/lib/ai-gateway/auto-routing-denied-models.ts
+++ b/apps/web/src/lib/ai-gateway/auto-routing-denied-models.ts
@@ -24,7 +24,7 @@ export function policyNeedsCandidateEvaluation(policy: EffectiveOrganizationMode
   return (
     policy.requireModelInCurrentSnapshot === true ||
     policy.organizationProviderCeiling !== undefined ||
-    policy.memberGrant.mode === 'selected'
+    policy.memberGrant.mode !== 'unrestricted'
   );
 }
 
@@ -49,7 +49,11 @@ export function deniedModelIdsForCandidates(
   candidateIds: ReadonlyArray<string>,
   isAllowed: (modelId: string) => boolean
 ): string[] {
-  const normalizedDeny = new Set(policy.organizationModelDenyList.map(normalizeModelId));
+  const normalizedDeny = new Set(
+    policy.memberGrant.mode === 'organization_baseline'
+      ? policy.organizationModelDenyList.map(normalizeModelId)
+      : []
+  );
   const denied = new Set(normalizedDeny);
   for (const candidate of new Set(candidateIds.filter(id => !isVirtualAutoModelId(id)))) {
     if (normalizedDeny.has(normalizeModelId(candidate)) || !isAllowed(candidate)) {

--- a/apps/web/src/lib/organizations/effective-model-access.server.test.ts
+++ b/apps/web/src/lib/organizations/effective-model-access.server.test.ts
@@ -193,7 +193,7 @@ describe('effective organization model access', () => {
     ).toBe(false);
   });
 
-  it('lets all dominate selected and none within the organization ceiling', async () => {
+  it('lets group all grant the complete organization baseline', async () => {
     const policy = evaluateEffectiveModelAccessPolicy(
       context({ groupPolicies: [[{ type: 'model_access', data: { mode: 'all' } }]] })
     );
@@ -224,14 +224,15 @@ describe('effective organization model access', () => {
     expect(decision).toMatchObject({ allowed: false, denialSource: 'organization_model' });
   });
 
-  it('intersects provider-derived grants with the organization ceiling', async () => {
+  it('allows provider grants beyond the organization baseline', async () => {
     const policy = evaluateEffectiveModelAccessPolicy(
       context({
+        defaultPolicies: [{ type: 'model_access', data: { mode: 'all' } }],
         groupPolicies: [
           [
             {
               type: 'model_access',
-              data: { mode: 'selected', model_allow_list: [], provider_allow_list: ['anthropic'] },
+              data: { mode: 'selected', model_allow_list: [], provider_allow_list: ['google'] },
             },
           ],
         ],
@@ -240,22 +241,103 @@ describe('effective organization model access', () => {
     const decision = await getEffectiveModelDecision(
       policy,
       'shared/model',
-      async () => new Set(['anthropic', 'openai'])
+      async () => new Set(['google', 'openai'])
     );
     expect(decision.allowed).toBe(true);
-    expect([...decision.eligibleProviderRoutes!]).toEqual(['anthropic']);
+    expect([...decision.eligibleProviderRoutes!]).toEqual(['google', 'openai']);
   });
 
-  it('denies models with no route inside the organization provider ceiling', async () => {
+  it('allows selected model grants beyond the organization baseline', async () => {
     const policy = evaluateEffectiveModelAccessPolicy(
-      context({ groupPolicies: [[{ type: 'model_access', data: { mode: 'all' } }]] })
+      context({
+        groupPolicies: [
+          [
+            {
+              type: 'model_access',
+              data: {
+                mode: 'selected',
+                model_allow_list: ['google/gemini'],
+                provider_allow_list: [],
+              },
+            },
+          ],
+        ],
+      })
     );
     const decision = await getEffectiveModelDecision(
       policy,
       'google/gemini',
       async () => new Set(['google'])
     );
-    expect(decision).toEqual({ allowed: false, denialSource: 'organization_provider' });
+    expect(decision).toEqual({ allowed: true });
+  });
+
+  it('allows selected group models denied by the organization baseline', async () => {
+    const policy = evaluateEffectiveModelAccessPolicy(
+      context({
+        defaultPolicies: [{ type: 'model_access', data: { mode: 'all' } }],
+        groupPolicies: [
+          [
+            {
+              type: 'model_access',
+              data: {
+                mode: 'selected',
+                model_allow_list: ['openai/o3'],
+                provider_allow_list: [],
+              },
+            },
+          ],
+        ],
+      })
+    );
+
+    await expect(
+      getEffectiveModelDecision(policy, 'openai/o3', currentSnapshotLookup)
+    ).resolves.toEqual({ allowed: true });
+    await expect(
+      getEffectiveModelDecision(policy, 'anthropic/claude', currentSnapshotLookup)
+    ).resolves.toMatchObject({ allowed: true });
+  });
+
+  it('keeps organization restrictions as the baseline without an additive grant', async () => {
+    const policy = evaluateEffectiveModelAccessPolicy(
+      context({ defaultPolicies: [{ type: 'model_access', data: { mode: 'all' } }] })
+    );
+
+    await expect(
+      getEffectiveModelDecision(policy, 'google/gemini', async () => new Set(['google']))
+    ).resolves.toEqual({ allowed: false, denialSource: 'organization_provider' });
+    await expect(
+      getEffectiveModelDecision(policy, 'openai/o3', currentSnapshotLookup)
+    ).resolves.toEqual({ allowed: false, denialSource: 'organization_model' });
+  });
+
+  it('combines group all baseline access with selected grants from another group', async () => {
+    const policy = evaluateEffectiveModelAccessPolicy(
+      context({
+        defaultPolicies: [{ type: 'model_access', data: { mode: 'none' } }],
+        groupPolicies: [
+          [{ type: 'model_access', data: { mode: 'all' } }],
+          [
+            {
+              type: 'model_access',
+              data: {
+                mode: 'selected',
+                model_allow_list: ['google/gemini'],
+                provider_allow_list: [],
+              },
+            },
+          ],
+        ],
+      })
+    );
+
+    await expect(
+      getEffectiveModelDecision(policy, 'anthropic/claude', currentSnapshotLookup)
+    ).resolves.toMatchObject({ allowed: true });
+    await expect(
+      getEffectiveModelDecision(policy, 'google/gemini', async () => new Set(['google']))
+    ).resolves.toEqual({ allowed: true });
   });
 
   it('hides restricted exclusive models when every restricted provider is disabled', async () => {

--- a/apps/web/src/lib/organizations/group-policies/model-access/model-access.server.ts
+++ b/apps/web/src/lib/organizations/group-policies/model-access/model-access.server.ts
@@ -22,7 +22,13 @@ export type EffectiveOrganizationModelPolicy = {
   organizationProviderCeiling?: string[];
   memberGrant:
     | { mode: 'unrestricted' }
-    | { mode: 'selected'; modelAllowList: string[]; providerAllowList: string[] };
+    | { mode: 'organization_baseline' }
+    | {
+        mode: 'selected';
+        includeOrganizationBaseline: boolean;
+        modelAllowList: string[];
+        providerAllowList: string[];
+      };
   dataCollection?: OrganizationSettings['data_collection'];
   policyRevision: number;
 };
@@ -61,27 +67,35 @@ export function evaluateEffectiveModelAccessPolicy(
     };
   }
 
-  const policies = [context.defaultPolicies, ...context.groupPolicies]
+  const defaultPolicy = context.defaultPolicies.find(policy => policy.type === 'model_access');
+  const groupPolicies = context.groupPolicies
     .flat()
     .filter(policy => policy.type === 'model_access');
-  if (policies.length === 0 || policies.some(policy => policy.data.mode === 'all')) {
+  const includeOrganizationBaseline =
+    !defaultPolicy ||
+    defaultPolicy.data.mode === 'all' ||
+    groupPolicies.some(policy => policy.data.mode === 'all');
+  const selectedPolicies = [defaultPolicy, ...groupPolicies].flatMap(policy =>
+    policy?.data.mode === 'selected' ? [policy] : []
+  );
+  if (selectedPolicies.length === 0 && includeOrganizationBaseline) {
     return {
       requireModelInCurrentSnapshot: true,
       organizationModelDenyList,
       organizationProviderCeiling,
-      memberGrant: { mode: 'unrestricted' },
+      memberGrant: { mode: 'organization_baseline' },
       dataCollection: context.organization.settings.data_collection,
       policyRevision: context.policyRevision,
     };
   }
 
-  const selectedPolicies = policies.filter(policy => policy.data.mode === 'selected');
   return {
     requireModelInCurrentSnapshot: true,
     organizationModelDenyList,
     organizationProviderCeiling,
     memberGrant: {
       mode: 'selected',
+      includeOrganizationBaseline,
       modelAllowList: [
         ...new Set(
           selectedPolicies.flatMap(policy =>
@@ -113,7 +127,10 @@ export async function getEffectiveModelDecision(
   if (await isModelRestrictionExempt(modelId)) {
     return { allowed: true };
   }
-  if (policy.organizationModelDenyList.includes(normalizedModelId)) {
+  if (
+    policy.memberGrant.mode === 'organization_baseline' &&
+    policy.organizationModelDenyList.includes(normalizedModelId)
+  ) {
     return { allowed: false, denialSource: 'organization_model' };
   }
   const exclusiveProviders = getKiloExclusiveInferenceProviderRestriction(modelId);
@@ -127,7 +144,10 @@ export async function getEffectiveModelDecision(
     ? new Set(policy.organizationProviderCeiling)
     : undefined;
 
-  async function decisionWithinOrganizationCeiling(): Promise<EffectiveModelDecision> {
+  async function decisionWithinOrganizationBaseline(): Promise<EffectiveModelDecision> {
+    if (policy.organizationModelDenyList.includes(normalizedModelId)) {
+      return { allowed: false, denialSource: 'organization_model' };
+    }
     if (!organizationRoutes) return { allowed: true };
     const modelProviders = currentModelProviders ?? (await providerLookup(normalizedModelId));
     if (modelProviders.size === 0) {
@@ -142,32 +162,37 @@ export async function getEffectiveModelDecision(
   }
 
   if (policy.memberGrant.mode === 'unrestricted') {
-    return await decisionWithinOrganizationCeiling();
+    return { allowed: true };
+  }
+  if (policy.memberGrant.mode === 'organization_baseline') {
+    return await decisionWithinOrganizationBaseline();
   }
   if (policy.memberGrant.modelAllowList.includes(normalizedModelId)) {
-    return await decisionWithinOrganizationCeiling();
+    return { allowed: true };
   }
-  if (policy.memberGrant.providerAllowList.length === 0) {
-    return { allowed: false, denialSource: 'no_grant' };
+  if (policy.memberGrant.providerAllowList.length > 0) {
+    const modelProviders = currentModelProviders ?? (await providerLookup(normalizedModelId));
+    const memberProviders = new Set(policy.memberGrant.providerAllowList);
+    const eligibleProviderRoutes = new Set(
+      [...modelProviders].filter(provider => memberProviders.has(provider))
+    );
+    if (eligibleProviderRoutes.size > 0) {
+      if (policy.memberGrant.includeOrganizationBaseline) {
+        const baselineDecision = await decisionWithinOrganizationBaseline();
+        if (baselineDecision.allowed && !baselineDecision.eligibleProviderRoutes) {
+          return baselineDecision;
+        }
+        baselineDecision.eligibleProviderRoutes?.forEach(provider =>
+          eligibleProviderRoutes.add(provider)
+        );
+      }
+      return { allowed: true, eligibleProviderRoutes };
+    }
   }
-  const modelProviders = currentModelProviders ?? (await providerLookup(normalizedModelId));
-  if (modelProviders.size === 0) {
-    return { allowed: false, denialSource: 'group_provider' };
+  if (policy.memberGrant.includeOrganizationBaseline) {
+    return await decisionWithinOrganizationBaseline();
   }
-  const memberProviders = new Set(policy.memberGrant.providerAllowList);
-  const eligibleProviderRoutes = new Set(
-    [...modelProviders].filter(
-      provider =>
-        memberProviders.has(provider) && (!organizationRoutes || organizationRoutes.has(provider))
-    )
-  );
-  if (eligibleProviderRoutes.size === 0) {
-    return {
-      allowed: false,
-      denialSource: organizationRoutes ? 'organization_provider' : 'group_provider',
-    };
-  }
-  return { allowed: true, eligibleProviderRoutes };
+  return { allowed: false, denialSource: 'no_grant' };
 }
 
 export async function isModelRouteAllowed(
@@ -285,7 +310,7 @@ export function normalizeModelAccessPolicy(
 export async function getModelAccessPolicyEditorData(organizationId: string) {
   const [[organization], [catalog]] = await Promise.all([
     db
-      .select({ plan: organizations.plan, settings: organizations.settings })
+      .select({ plan: organizations.plan })
       .from(organizations)
       .where(eq(organizations.id, organizationId))
       .limit(1),
@@ -307,7 +332,5 @@ export async function getModelAccessPolicyEditorData(organizationId: string) {
   return {
     policyType: 'model_access' as const,
     catalog: catalog.data,
-    modelDenyList: organization.settings.model_deny_list ?? [],
-    providerAllowList: organization.settings.provider_allow_list,
   };
 }


### PR DESCRIPTION
## Summary
- show the full synchronized provider/model catalog when editing organization group policies
- treat organization provider/model settings as the default baseline while allowing selected group policies to add access
- enforce the composed policy consistently in direct gateway, auto-routing, and experiment routing
- preserve legacy organization restrictions when no additive group grant applies

## Verification
- `pnpm --filter web exec jest --runInBand src/lib/organizations/effective-model-access.server.test.ts src/lib/ai-gateway/auto-routing-denied-models.test.ts`
- `pnpm --filter web exec jest --runInBand --runTestsByPath src/app/api/openrouter/[...path]/route.test.ts`
- `pnpm --filter web exec jest --runInBand src/lib/organizations/legacy-model-restrictions-parity.test.ts src/lib/organizations/sub-organizations/model-policy.test.ts`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `pnpm format`

Local verification ran with Node 26; the repository declares Node 24.