### PR TITLE
feat(mobile): exit list sessions and hydrate child card models

### DIFF
--- a/apps/mobile/src/components/agents/exit-remote-session-from-list.test.ts
+++ b/apps/mobile/src/components/agents/exit-remote-session-from-list.test.ts
@@ -1,0 +1,239 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { announcingToast } from '@/lib/a11y/announcing-toast';
+
+import { exitRemoteSessionFromList } from './exit-remote-session-from-list';
+
+vi.mock('@/lib/a11y/announcing-toast', () => ({
+  announcingToast: { success: vi.fn(), error: vi.fn() },
+}));
+
+type RetryAction = { label: string; onClick: () => void };
+
+function createHarness() {
+  const confirm = vi.fn(async () => {
+    await Promise.resolve();
+    return true;
+  });
+  const sendExit = vi.fn(async () => {
+    await Promise.resolve();
+  });
+  const refreshActiveList = vi.fn(async () => {
+    await Promise.resolve();
+  });
+  const inFlight = { current: false };
+  return { confirm, sendExit, refreshActiveList, inFlight };
+}
+
+function captureRetryAction(): RetryAction | undefined {
+  const call = vi.mocked(announcingToast.error).mock.calls[0];
+  const options = call?.[1] as { action?: RetryAction } | undefined;
+  return options?.action;
+}
+
+describe('exitRemoteSessionFromList', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('cancels without sending, refreshing, or toasting', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    confirm.mockResolvedValue(false);
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(sendExit).not.toHaveBeenCalled();
+    expect(refreshActiveList).not.toHaveBeenCalled();
+    expect(announcingToast.success).not.toHaveBeenCalled();
+    expect(announcingToast.error).not.toHaveBeenCalled();
+    expect(inFlight.current).toBe(false);
+  });
+
+  it('sends, toasts success, refreshes, and releases the flag', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(sendExit).toHaveBeenCalledTimes(1);
+    expect(announcingToast.success).toHaveBeenCalledWith('Session exited');
+    expect(announcingToast.error).not.toHaveBeenCalled();
+    expect(refreshActiveList).toHaveBeenCalledTimes(1);
+    expect(inFlight.current).toBe(false);
+  });
+
+  it('swallows a refresh failure after a successful send without resending', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    refreshActiveList.mockRejectedValue(new Error('network down'));
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    expect(sendExit).toHaveBeenCalledTimes(1);
+    expect(announcingToast.success).toHaveBeenCalledTimes(1);
+    expect(announcingToast.success).toHaveBeenCalledWith('Session exited');
+    expect(announcingToast.error).not.toHaveBeenCalled();
+    expect(inFlight.current).toBe(false);
+  });
+
+  it('shows a Try again toast on a retryable send failure without refreshing', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    sendExit.mockRejectedValue(new Error('Invalid exit_cli response'));
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    expect(sendExit).toHaveBeenCalledTimes(1);
+    expect(announcingToast.error).toHaveBeenCalledWith('Invalid exit_cli response', {
+      action: { label: 'Try again', onClick: expect.any(Function) },
+    });
+    expect(announcingToast.success).not.toHaveBeenCalled();
+    expect(refreshActiveList).not.toHaveBeenCalled();
+    expect(inFlight.current).toBe(false);
+  });
+
+  it('resends from Try again without a second confirm and holds the flag in flight', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    const retryResolveRef = { resolve: undefined as (() => void) | undefined };
+    sendExit.mockImplementation(async () => {
+      await Promise.resolve();
+      if (sendExit.mock.calls.length === 1) {
+        throw new Error('connection reset');
+      }
+      await new Promise<void>(resolve => {
+        retryResolveRef.resolve = resolve;
+      });
+    });
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    const action = captureRetryAction();
+    if (!action) {
+      throw new Error('Expected retry action on the toast');
+    }
+
+    action.onClick();
+    await vi.waitFor(() => {
+      expect(sendExit).toHaveBeenCalledTimes(2);
+    });
+    expect(confirm).toHaveBeenCalledTimes(1);
+    expect(inFlight.current).toBe(true);
+
+    retryResolveRef.resolve?.();
+    await vi.waitFor(() => {
+      expect(inFlight.current).toBe(false);
+    });
+    expect(announcingToast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('ignores a second Try again tap while the retry send is in flight', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    const retryResolveRef = { resolve: undefined as (() => void) | undefined };
+    sendExit.mockImplementation(async () => {
+      await Promise.resolve();
+      if (sendExit.mock.calls.length === 1) {
+        throw new Error('connection reset');
+      }
+      await new Promise<void>(resolve => {
+        retryResolveRef.resolve = resolve;
+      });
+    });
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    const action = captureRetryAction();
+    if (!action) {
+      throw new Error('Expected retry action on the toast');
+    }
+
+    action.onClick();
+    await vi.waitFor(() => {
+      expect(sendExit).toHaveBeenCalledTimes(2);
+    });
+    expect(inFlight.current).toBe(true);
+
+    action.onClick();
+    expect(sendExit).toHaveBeenCalledTimes(2);
+    expect(inFlight.current).toBe(true);
+
+    retryResolveRef.resolve?.();
+    await vi.waitFor(() => {
+      expect(inFlight.current).toBe(false);
+    });
+    expect(sendExit).toHaveBeenCalledTimes(2);
+    expect(announcingToast.success).toHaveBeenCalledTimes(1);
+  });
+
+  it('shows a non-retryable message with no action and does not resend', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    sendExit.mockRejectedValue(
+      new Error('Remote session exit is not supported for the current session')
+    );
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    expect(sendExit).toHaveBeenCalledTimes(1);
+    expect(announcingToast.error).toHaveBeenCalledWith(
+      'Remote session exit is not supported for the current session'
+    );
+    const options = vi.mocked(announcingToast.error).mock.calls[0]?.[1] as
+      | { action?: RetryAction }
+      | undefined;
+    expect(options?.action).toBeUndefined();
+    expect(announcingToast.success).not.toHaveBeenCalled();
+    expect(refreshActiveList).not.toHaveBeenCalled();
+    expect(inFlight.current).toBe(false);
+  });
+
+  it('falls back to Failed to exit session for a non-Error throw', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    class NotAnError {
+      message = 'opaque';
+    }
+    sendExit.mockImplementation(async () => {
+      await Promise.resolve();
+      // oxlint-disable-next-line typescript-eslint/only-throw-error
+      throw new NotAnError();
+    });
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    expect(sendExit).toHaveBeenCalledTimes(1);
+    expect(announcingToast.error).toHaveBeenCalledWith('Failed to exit session', {
+      action: { label: 'Try again', onClick: expect.any(Function) },
+    });
+  });
+
+  it('returns without confirming when already in flight', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    inFlight.current = true;
+
+    await exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+
+    expect(confirm).not.toHaveBeenCalled();
+    expect(sendExit).not.toHaveBeenCalled();
+    expect(refreshActiveList).not.toHaveBeenCalled();
+    expect(announcingToast.success).not.toHaveBeenCalled();
+    expect(announcingToast.error).not.toHaveBeenCalled();
+  });
+
+  it('releases the flag after a pending send settles', async () => {
+    const { confirm, sendExit, refreshActiveList, inFlight } = createHarness();
+    const sendResolveRef = { resolve: undefined as (() => void) | undefined };
+    sendExit.mockImplementation(async () => {
+      await new Promise<void>(resolve => {
+        sendResolveRef.resolve = resolve;
+      });
+    });
+
+    const pending = exitRemoteSessionFromList({ confirm, sendExit, refreshActiveList, inFlight });
+    await vi.waitFor(() => {
+      expect(sendExit).toHaveBeenCalledTimes(1);
+    });
+    expect(inFlight.current).toBe(true);
+
+    sendResolveRef.resolve?.();
+    await pending;
+    expect(inFlight.current).toBe(false);
+    expect(announcingToast.success).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/mobile/src/components/agents/exit-remote-session-from-list.ts
+++ b/apps/mobile/src/components/agents/exit-remote-session-from-list.ts
@@ -1,0 +1,98 @@
+import { announcingToast } from '@/lib/a11y/announcing-toast';
+
+import { confirmRemoteSessionExit } from './remote-session-exit-confirmation';
+
+const SESSION_EXITED_MESSAGE = 'Session exited';
+/**
+ * Classifier literals copied from `exit-remote-session-with-feedback.ts`. They
+ * must stay in sync with that file (which pins them to the SDK source). The
+ * barrel import is not used here because the mobile test runner cannot resolve
+ * the SDK's transitive web-only `@/...` aliases.
+ */
+const REMOTE_SESSION_EXIT_NOT_SUPPORTED_MESSAGE =
+  'Remote session exit is not supported for the current session';
+const REMOTE_SESSION_EXIT_UNAVAILABLE_MESSAGE =
+  'Remote session exit is unavailable for the current session';
+const REMOTE_SESSION_EXIT_UPGRADE_PREFIX = 'Remote slash commands require a newer Kilo CLI';
+const RETRY_TOAST_LABEL = 'Try again';
+const FALLBACK_ERROR_MESSAGE = 'Failed to exit session';
+
+const NON_RETRYABLE_EXIT_MESSAGES: ReadonlySet<string> = new Set([
+  REMOTE_SESSION_EXIT_NOT_SUPPORTED_MESSAGE,
+  REMOTE_SESSION_EXIT_UNAVAILABLE_MESSAGE,
+]);
+
+function isNonRetryableExitError(message: string): boolean {
+  if (NON_RETRYABLE_EXIT_MESSAGES.has(message)) {
+    return true;
+  }
+  return message.startsWith(REMOTE_SESSION_EXIT_UPGRADE_PREFIX);
+}
+
+type ExitRemoteSessionFromListInput = {
+  confirm: () => Promise<boolean>;
+  sendExit: () => Promise<void>;
+  refreshActiveList: () => Promise<void>;
+  inFlight: { current: boolean };
+};
+
+/**
+ * Exit a running session from the Active now list. Keeps history and never
+ * opens the session. The row passes `showRemoteSessionExitConfirmation` as
+ * `confirm`; this helper wraps `confirmRemoteSessionExit` once and owns the
+ * send/refresh/toast lifecycle. `inFlight` is a shared ref flag that blocks
+ * a second exit while one is in flight.
+ */
+export async function exitRemoteSessionFromList({
+  confirm,
+  sendExit,
+  refreshActiveList,
+  inFlight,
+}: Readonly<ExitRemoteSessionFromListInput>): Promise<void> {
+  if (inFlight.current) {
+    return;
+  }
+
+  const runSend = async (): Promise<void> => {
+    if (inFlight.current) {
+      return;
+    }
+    inFlight.current = true;
+    try {
+      try {
+        await sendExit();
+      } catch (error) {
+        const message = error instanceof Error ? error.message : FALLBACK_ERROR_MESSAGE;
+        if (isNonRetryableExitError(message)) {
+          // Fail-closed: the SDK signalled "do not send". No CTA so the user
+          // sees the copy but cannot trigger another attempt.
+          announcingToast.error(message);
+        } else {
+          // Retryable transport / ACK failure. The retry action re-runs the
+          // send without a second confirm.
+          announcingToast.error(message, {
+            action: {
+              label: RETRY_TOAST_LABEL,
+              onClick: () => {
+                void runSend();
+              },
+            },
+          });
+        }
+        return;
+      }
+
+      announcingToast.success(SESSION_EXITED_MESSAGE);
+      try {
+        await refreshActiveList();
+      } catch {
+        // Swallow the refresh failure: the row already left the live set via
+        // the send. Do not resend `exit_cli`; the user can pull to refresh.
+      }
+    } finally {
+      inFlight.current = false;
+    }
+  };
+
+  await confirmRemoteSessionExit(confirm, runSend);
+}

--- a/apps/mobile/src/components/agents/remote-session-row.tsx
+++ b/apps/mobile/src/components/agents/remote-session-row.tsx
@@ -1,11 +1,13 @@
 import { useActionSheet } from '@expo/react-native-action-sheet';
+import { useQueryClient } from '@tanstack/react-query';
 import * as Haptics from 'expo-haptics';
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Platform, Pressable, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { RenameModal } from '@/components/rename-modal';
 import { SessionRow } from '@/components/ui/session-row';
+import { refreshActiveSessionsNow } from '@/lib/active-sessions-live-sync';
 import { type ActiveSession } from '@/lib/hooks/use-agent-sessions';
 import { useSessionMutations } from '@/lib/hooks/use-session-mutations';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
@@ -15,6 +17,9 @@ import {
   shouldShowNeedsInput,
   useSessionAttentionRevision,
 } from '@/lib/session-attention';
+import { useTRPC } from '@/lib/trpc';
+import { exitRemoteSessionFromList } from './exit-remote-session-from-list';
+import { showRemoteSessionExitConfirmation } from './remote-session-exit-alert';
 import {
   activeSessionMetaTimestamp,
   composeActiveSessionVisibleMeta,
@@ -31,6 +36,7 @@ import {
   formatSpokenTimeAgo,
   sessionRowAccessibilityLabel,
 } from './session-row-accessibility-label';
+import { useUserWebConnection } from './user-web-connection-provider';
 
 type RemoteSessionRowProps = {
   session: ActiveSession;
@@ -51,6 +57,10 @@ export function RemoteSessionRow({
   const { bottom } = useSafeAreaInsets();
   const { showActionSheetWithOptions } = useActionSheet();
   const { renameSession } = useSessionMutations();
+  const queryClient = useQueryClient();
+  const trpc = useTRPC();
+  const connection = useUserWebConnection();
+  const exitingRef = useRef(false);
   const title = session.title.length > 0 ? session.title : 'Untitled session';
   const [renameVisible, setRenameVisible] = useState(false);
   const canManage = interactive;
@@ -97,7 +107,33 @@ export function RemoteSessionRow({
       </View>
     ) : undefined;
 
+  const refreshActiveList = async () => {
+    if (await refreshActiveSessionsNow()) {
+      return;
+    }
+    await queryClient.invalidateQueries(trpc.activeSessions.list.pathFilter());
+  };
+
+  const handleExit = () => {
+    void exitRemoteSessionFromList({
+      confirm: showRemoteSessionExitConfirmation,
+      sendExit: async () => {
+        await connection.sendCommand(
+          session.id,
+          'exit_cli',
+          { protocolVersion: 1 },
+          session.connectionId
+        );
+      },
+      refreshActiveList,
+      inFlight: exitingRef,
+    });
+  };
+
   const handleLongPress = () => {
+    if (exitingRef.current) {
+      return;
+    }
     void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
     showSessionActionMenu({
       showActionSheetWithOptions,
@@ -114,6 +150,7 @@ export function RemoteSessionRow({
           setRenameVisible(true);
         }
       },
+      onExit: handleExit,
     });
   };
 

--- a/apps/mobile/src/components/agents/remote-session-row.tsx
+++ b/apps/mobile/src/components/agents/remote-session-row.tsx
@@ -22,6 +22,7 @@ import { exitRemoteSessionFromList } from './exit-remote-session-from-list';
 import { showRemoteSessionExitConfirmation } from './remote-session-exit-alert';
 import {
   activeSessionMetaTimestamp,
+  canExitSessionFromList,
   composeActiveSessionVisibleMeta,
   formatSessionTotalCost,
   remoteMeta,
@@ -68,6 +69,7 @@ export function RemoteSessionRow({
 
   const revision = useSessionAttentionRevision();
   const raiseId = session.status;
+  const canExit = canExitSessionFromList(session);
   const needsInput = shouldShowNeedsInput({
     status: session.status,
     raiseId,
@@ -150,7 +152,7 @@ export function RemoteSessionRow({
           setRenameVisible(true);
         }
       },
-      onExit: handleExit,
+      onExit: canExit ? handleExit : undefined,
     });
   };
 

--- a/apps/mobile/src/components/agents/session-detail-content-helpers.test.ts
+++ b/apps/mobile/src/components/agents/session-detail-content-helpers.test.ts
@@ -1,12 +1,91 @@
 import { describe, expect, it, vi } from 'vitest';
 
-import { type MessageDeliveryState, type StoredMessage } from '@kilocode/cloud-agent-sdk';
 import {
+  type KiloSessionId,
+  type MessageDeliveryState,
+  type StoredMessage,
+  type ToolPart,
+} from '@kilocode/cloud-agent-sdk';
+import {
+  collectEmptyChildSessionIds,
   countInFlightMessages,
+  hydrateEmptyChildSessions,
   resolveRetryPrompt,
   retryMessageAndClear,
 } from './session-detail-content-helpers';
 import { assistantMessage, userMessage } from './message-bubble-test-utils';
+
+const subagentSessionId = 'ses-child' as KiloSessionId;
+const otherSubagentSessionId = 'ses-child-2' as KiloSessionId;
+
+const noChildMessages = (): StoredMessage[] => [];
+
+function makeToolPart(tool: string, state: ToolPart['state']): ToolPart {
+  return {
+    id: 'p1',
+    sessionID: 'ses-1',
+    messageID: 'msg-1',
+    type: 'tool',
+    tool,
+    callID: 'call-1',
+    state,
+  };
+}
+
+function makeTaskPart(
+  status: 'pending' | 'running' | 'completed' | 'error',
+  sessionId: KiloSessionId = subagentSessionId,
+  input: Record<string, unknown> = {}
+): ToolPart {
+  if (status === 'pending') {
+    return makeToolPart('task', { status: 'pending', input, raw: '' });
+  }
+  if (status === 'running') {
+    return makeToolPart('task', {
+      status: 'running',
+      input,
+      time: { start: 1 },
+      metadata: { sessionId },
+    });
+  }
+  if (status === 'completed') {
+    return makeToolPart('task', {
+      status: 'completed',
+      input,
+      output: 'done',
+      title: 'Task',
+      metadata: { sessionId },
+      time: { start: 1, end: 2 },
+    });
+  }
+  return makeToolPart('task', {
+    status: 'error',
+    input,
+    error: 'failed',
+    metadata: { sessionId },
+    time: { start: 1, end: 2 },
+  });
+}
+
+function makeAssistantMessage(parts: ToolPart[], id = 'msg-1'): StoredMessage {
+  return {
+    info: {
+      id,
+      sessionID: 'ses-1',
+      role: 'assistant',
+      time: { created: 1 },
+      parentID: 'msg-0',
+      modelID: 'claude',
+      providerID: 'anthropic',
+      mode: 'code',
+      agent: 'build',
+      path: { cwd: '/', root: '/' },
+      cost: 0,
+      tokens: { input: 0, output: 0, reasoning: 0, cache: { read: 0, write: 0 } },
+    },
+    parts,
+  };
+}
 
 describe('countInFlightMessages', () => {
   it('excludes a failed pending row from the in-flight count', () => {
@@ -120,5 +199,120 @@ describe('resolveRetryPrompt', () => {
   it('returns null for an assistant row with no preceding user row', () => {
     const assistant = assistantMessage('m5');
     expect(resolveRetryPrompt(assistant, [assistant])).toBeNull();
+  });
+});
+
+describe('collectEmptyChildSessionIds', () => {
+  it('returns [] for no messages', () => {
+    expect(collectEmptyChildSessionIds([], noChildMessages)).toEqual([]);
+  });
+
+  it('returns [] for a non-task tool part', () => {
+    const readPart = makeToolPart('read', {
+      status: 'completed',
+      input: { filePath: 'x' },
+      output: 'y',
+      title: 'read',
+      metadata: {},
+      time: { start: 1, end: 2 },
+    });
+    const messages = [makeAssistantMessage([readPart])];
+    expect(collectEmptyChildSessionIds(messages, noChildMessages)).toEqual([]);
+  });
+
+  it('returns [] for a pending task with no metadata sessionId', () => {
+    const messages = [makeAssistantMessage([makeTaskPart('pending')])];
+    expect(collectEmptyChildSessionIds(messages, noChildMessages)).toEqual([]);
+  });
+
+  it('returns the id for a completed task with empty child messages', () => {
+    const messages = [makeAssistantMessage([makeTaskPart('completed')])];
+    expect(collectEmptyChildSessionIds(messages, noChildMessages)).toEqual([subagentSessionId]);
+  });
+
+  it('returns [] for a completed task with existing child messages', () => {
+    const messages = [makeAssistantMessage([makeTaskPart('completed')])];
+    const getChildMessages = (id: KiloSessionId): StoredMessage[] =>
+      id === subagentSessionId ? [makeAssistantMessage([], 'child-msg')] : [];
+    expect(collectEmptyChildSessionIds(messages, getChildMessages)).toEqual([]);
+  });
+
+  it('includes running and error task states when empty', () => {
+    const messages = [
+      makeAssistantMessage([makeTaskPart('running', subagentSessionId)], 'msg-run'),
+      makeAssistantMessage([makeTaskPart('error', otherSubagentSessionId)], 'msg-err'),
+    ];
+    expect(collectEmptyChildSessionIds(messages, noChildMessages)).toEqual([
+      subagentSessionId,
+      otherSubagentSessionId,
+    ]);
+  });
+
+  it('returns a duplicate task id once', () => {
+    const messages = [
+      makeAssistantMessage([makeTaskPart('completed', subagentSessionId)], 'msg-1'),
+      makeAssistantMessage([makeTaskPart('completed', subagentSessionId)], 'msg-2'),
+    ];
+    expect(collectEmptyChildSessionIds(messages, noChildMessages)).toEqual([subagentSessionId]);
+  });
+
+  it('returns two different empty child ids in first-seen order', () => {
+    const messages = [
+      makeAssistantMessage([makeTaskPart('completed', subagentSessionId)], 'msg-1'),
+      makeAssistantMessage([makeTaskPart('completed', otherSubagentSessionId)], 'msg-2'),
+    ];
+    expect(collectEmptyChildSessionIds(messages, noChildMessages)).toEqual([
+      subagentSessionId,
+      otherSubagentSessionId,
+    ]);
+  });
+});
+
+describe('hydrateEmptyChildSessions', () => {
+  it('does not retry when ready after the first hydrate', async () => {
+    let status = 'loading';
+    const hydrate = vi.fn(async () => {
+      status = 'ready';
+      await Promise.resolve();
+    });
+    const readHydrationStatus = vi.fn(() => status);
+    const retried = new Set<string>();
+    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus, retried);
+    expect(hydrate).toHaveBeenCalledTimes(1);
+    expect(retried.size).toBe(0);
+  });
+
+  it('retries once when the first hydrate errors and the second readies', async () => {
+    let status = 'loading';
+    const hydrate = vi.fn(async () => {
+      status = status === 'loading' ? 'error' : 'ready';
+      await Promise.resolve();
+    });
+    const readHydrationStatus = vi.fn(() => status);
+    const retried = new Set<string>();
+    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus, retried);
+    expect(hydrate).toHaveBeenCalledTimes(2);
+    expect(retried.has(subagentSessionId)).toBe(true);
+  });
+
+  it('stops at two hydrates when the retry also errors', async () => {
+    const hydrate = vi.fn(async () => {
+      await Promise.resolve();
+    });
+    const readHydrationStatus = vi.fn(() => 'error');
+    const retried = new Set<string>();
+    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus, retried);
+    expect(hydrate).toHaveBeenCalledTimes(2);
+    expect(retried.has(subagentSessionId)).toBe(true);
+  });
+
+  it('does not retry an id already in retried', async () => {
+    const hydrate = vi.fn(async () => {
+      await Promise.resolve();
+    });
+    const readHydrationStatus = vi.fn(() => 'error');
+    const retried = new Set<string>([subagentSessionId]);
+    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus, retried);
+    expect(hydrate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/components/agents/session-detail-content-helpers.test.ts
+++ b/apps/mobile/src/components/agents/session-detail-content-helpers.test.ts
@@ -276,10 +276,8 @@ describe('hydrateEmptyChildSessions', () => {
       await Promise.resolve();
     });
     const readHydrationStatus = vi.fn(() => status);
-    const retried = new Set<string>();
-    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus, retried);
+    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus);
     expect(hydrate).toHaveBeenCalledTimes(1);
-    expect(retried.size).toBe(0);
   });
 
   it('retries once when the first hydrate errors and the second readies', async () => {
@@ -289,10 +287,8 @@ describe('hydrateEmptyChildSessions', () => {
       await Promise.resolve();
     });
     const readHydrationStatus = vi.fn(() => status);
-    const retried = new Set<string>();
-    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus, retried);
+    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus);
     expect(hydrate).toHaveBeenCalledTimes(2);
-    expect(retried.has(subagentSessionId)).toBe(true);
   });
 
   it('stops at two hydrates when the retry also errors', async () => {
@@ -300,19 +296,7 @@ describe('hydrateEmptyChildSessions', () => {
       await Promise.resolve();
     });
     const readHydrationStatus = vi.fn(() => 'error');
-    const retried = new Set<string>();
-    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus, retried);
+    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus);
     expect(hydrate).toHaveBeenCalledTimes(2);
-    expect(retried.has(subagentSessionId)).toBe(true);
-  });
-
-  it('does not retry an id already in retried', async () => {
-    const hydrate = vi.fn(async () => {
-      await Promise.resolve();
-    });
-    const readHydrationStatus = vi.fn(() => 'error');
-    const retried = new Set<string>([subagentSessionId]);
-    await hydrateEmptyChildSessions([subagentSessionId], hydrate, readHydrationStatus, retried);
-    expect(hydrate).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/mobile/src/components/agents/session-detail-content-helpers.ts
+++ b/apps/mobile/src/components/agents/session-detail-content-helpers.ts
@@ -98,18 +98,15 @@ export function collectEmptyChildSessionIds(
  * fetch failure (it writes an error status), so the retry reads the status
  * rather than catching a rejection.
  */
-// eslint-disable-next-line eslint/max-params -- the hydrate contract needs ids, hydrate, status reader, and the shared retried set
 export async function hydrateEmptyChildSessions(
   ids: readonly KiloSessionId[],
   hydrate: (id: KiloSessionId) => Promise<void>,
-  readHydrationStatus: (id: KiloSessionId) => string,
-  retried: Set<string>
+  readHydrationStatus: (id: KiloSessionId) => string
 ): Promise<void> {
   await Promise.all(
     ids.map(async id => {
       await hydrate(id);
-      if (readHydrationStatus(id) === 'error' && !retried.has(id)) {
-        retried.add(id);
+      if (readHydrationStatus(id) === 'error') {
         await hydrate(id);
       }
     })

--- a/apps/mobile/src/components/agents/session-detail-content-helpers.ts
+++ b/apps/mobile/src/components/agents/session-detail-content-helpers.ts
@@ -1,6 +1,11 @@
-import { type MessageDeliveryState, type StoredMessage } from '@kilocode/cloud-agent-sdk';
+import {
+  type KiloSessionId,
+  type MessageDeliveryState,
+  type StoredMessage,
+} from '@kilocode/cloud-agent-sdk';
 
-import { firstHumanText } from './part-types';
+import { getTaskToolSessionId } from './child-session-card-state';
+import { firstHumanText, isToolPart } from './part-types';
 
 /**
  * Counts pending messages that are still in flight. A terminal delivery
@@ -60,4 +65,53 @@ export function resolveRetryPrompt(
     }
   }
   return null;
+}
+
+/**
+ * Collects child session ids that appear in task tool parts but have no
+ * hydrated messages yet. Ids are deduplicated and returned in first-seen
+ * order; a child that already has messages is skipped.
+ */
+export function collectEmptyChildSessionIds(
+  messages: readonly StoredMessage[],
+  getChildMessages: (childSessionId: KiloSessionId) => readonly StoredMessage[]
+): KiloSessionId[] {
+  const seen = new Set<KiloSessionId>();
+  const emptyIds: KiloSessionId[] = [];
+  for (const message of messages) {
+    for (const part of message.parts) {
+      const childSessionId = isToolPart(part) ? getTaskToolSessionId(part) : undefined;
+      if (childSessionId !== undefined && !seen.has(childSessionId)) {
+        seen.add(childSessionId);
+        if (getChildMessages(childSessionId).length === 0) {
+          emptyIds.push(childSessionId);
+        }
+      }
+    }
+  }
+  return emptyIds;
+}
+
+/**
+ * Hydrates each empty child session once, retrying an id exactly once when
+ * its first hydration reports an error status. `hydrate` never rejects on a
+ * fetch failure (it writes an error status), so the retry reads the status
+ * rather than catching a rejection.
+ */
+// eslint-disable-next-line eslint/max-params -- the hydrate contract needs ids, hydrate, status reader, and the shared retried set
+export async function hydrateEmptyChildSessions(
+  ids: readonly KiloSessionId[],
+  hydrate: (id: KiloSessionId) => Promise<void>,
+  readHydrationStatus: (id: KiloSessionId) => string,
+  retried: Set<string>
+): Promise<void> {
+  await Promise.all(
+    ids.map(async id => {
+      await hydrate(id);
+      if (readHydrationStatus(id) === 'error' && !retried.has(id)) {
+        retried.add(id);
+        await hydrate(id);
+      }
+    })
+  );
 }

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -59,7 +59,9 @@ import {
   shouldShowSessionFooterRow,
 } from '@/components/agents/session-working-state';
 import {
+  collectEmptyChildSessionIds,
   countInFlightMessages,
+  hydrateEmptyChildSessions,
   resolveRetryPrompt,
   retryMessageAndClear,
 } from '@/components/agents/session-detail-content-helpers';
@@ -169,6 +171,8 @@ export function SessionDetailContent({
   });
   const childSheetReleaseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const composerControlRef = useRef<ChatComposerControl | null>(null);
+  const childHydrateAttemptedRef = useRef<Set<string>>(new Set());
+  const childHydrateRetriedRef = useRef<Set<string>>(new Set());
 
   const clearChildSheetReleaseTimeout = useCallback(() => {
     if (childSheetReleaseTimeoutRef.current !== null) {
@@ -458,10 +462,49 @@ export function SessionDetailContent({
     void manager.switchSession(sessionId);
   }, [sessionId, manager]);
 
+  const store = useStore();
+
+  useEffect(() => {
+    childHydrateAttemptedRef.current = new Set();
+    childHydrateRetriedRef.current = new Set();
+  }, [sessionId]);
+
+  // Hydrate child transcripts for task cards that have no messages yet, so a
+  // reopened parent shows each completed child's model on the card without
+  // opening the child sheet. An attempted id is never hydrated again for the
+  // same parent session; a hydrate error retries once via the retried set.
+  useEffect(() => {
+    if (isLoading) {
+      return;
+    }
+    if (fetchedData?.kiloSessionId !== sessionId) {
+      return;
+    }
+    const liveGetChildMessages = store.get(manager.atoms.childMessages);
+    const readHydrationStatus = (id: KiloSessionId) =>
+      store.get(manager.atoms.childSessionHydrationState)(id).status;
+    const emptyIds = collectEmptyChildSessionIds(messages, liveGetChildMessages).filter(
+      id => !childHydrateAttemptedRef.current.has(id)
+    );
+    if (emptyIds.length === 0) {
+      return;
+    }
+    for (const id of emptyIds) {
+      childHydrateAttemptedRef.current.add(id);
+    }
+    void hydrateEmptyChildSessions(
+      emptyIds,
+      async id => {
+        await manager.hydrateChildSession(id);
+      },
+      readHydrationStatus,
+      childHydrateRetriedRef.current
+    );
+  }, [isLoading, fetchedData?.kiloSessionId, sessionId, messages, manager, store]);
+
   // Refetch the linked PR on every focus so a link, unlink, or mid-session
   // decision change surfaces without reopening the session. A pending review
   // decision gets one 4s follow-up refetch — no polling loop.
-  const store = useStore();
   // The first focus on a session id is owned by `manager.switchSession`, which
   // already fetches the session metadata (including `associatedPr`). Every
   // later focus refetches; this ref tracks which id has been seeded.

--- a/apps/mobile/src/components/agents/session-detail-content.tsx
+++ b/apps/mobile/src/components/agents/session-detail-content.tsx
@@ -172,7 +172,6 @@ export function SessionDetailContent({
   const childSheetReleaseTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const composerControlRef = useRef<ChatComposerControl | null>(null);
   const childHydrateAttemptedRef = useRef<Set<string>>(new Set());
-  const childHydrateRetriedRef = useRef<Set<string>>(new Set());
 
   const clearChildSheetReleaseTimeout = useCallback(() => {
     if (childSheetReleaseTimeoutRef.current !== null) {
@@ -466,13 +465,12 @@ export function SessionDetailContent({
 
   useEffect(() => {
     childHydrateAttemptedRef.current = new Set();
-    childHydrateRetriedRef.current = new Set();
   }, [sessionId]);
 
   // Hydrate child transcripts for task cards that have no messages yet, so a
   // reopened parent shows each completed child's model on the card without
   // opening the child sheet. An attempted id is never hydrated again for the
-  // same parent session; a hydrate error retries once via the retried set.
+  // same parent session; a hydrate error retries once.
   useEffect(() => {
     if (isLoading) {
       return;
@@ -497,8 +495,7 @@ export function SessionDetailContent({
       async id => {
         await manager.hydrateChildSession(id);
       },
-      readHydrationStatus,
-      childHydrateRetriedRef.current
+      readHydrationStatus
     );
   }, [isLoading, fetchedData?.kiloSessionId, sessionId, messages, manager, store]);
 

--- a/apps/mobile/src/components/agents/session-list-helpers.test.ts
+++ b/apps/mobile/src/components/agents/session-list-helpers.test.ts
@@ -1,11 +1,13 @@
 /* eslint-disable max-lines -- cohesive unit-test suite for session-list-helpers pure functions */
 import { describe, expect, it } from 'vitest';
 
+import { CLOUD_AGENT_CONNECTION_ID } from '@/lib/active-sessions-live';
 import { type ActiveSession } from '@/lib/hooks/use-agent-sessions';
 import { parseTimestamp, timeAgo } from '@/lib/utils';
 
 import {
   activeSessionMetaTimestamp,
+  canExitSessionFromList,
   composeActiveSessionSpokenMeta,
   composeActiveSessionVisibleMeta,
   excludeActiveFromGroups,
@@ -331,6 +333,18 @@ describe('selectPinnedActiveSessions', () => {
       searchQuery: '',
     });
     expect(result.map(s => s.id)).toEqual(['pass']);
+  });
+});
+
+describe('canExitSessionFromList', () => {
+  it('returns true for a real CLI connection id', () => {
+    expect(canExitSessionFromList(makeActive({ connectionId: 'c1' }))).toBe(true);
+  });
+
+  it('returns false for the cloud-agent sentinel connection id', () => {
+    expect(canExitSessionFromList(makeActive({ connectionId: CLOUD_AGENT_CONNECTION_ID }))).toBe(
+      false
+    );
   });
 });
 

--- a/apps/mobile/src/components/agents/session-list-helpers.ts
+++ b/apps/mobile/src/components/agents/session-list-helpers.ts
@@ -1,5 +1,6 @@
 import { KNOWN_PLATFORMS } from '@kilocode/app-shared/platforms';
 
+import { CLOUD_AGENT_CONNECTION_ID } from '@/lib/active-sessions-live';
 import { type AgentSessionDateGroup } from '@/lib/agent-session-groups';
 import { type ActiveSession, type StoredSession } from '@/lib/hooks/use-agent-sessions';
 import { platformLabel } from '@/lib/platform-label';
@@ -286,6 +287,15 @@ export function remoteSessionEyebrowLabel(session: {
 }): string {
   const repo = repoNameFromGitUrl(session.gitUrl);
   return repo ? repo.toUpperCase() : remoteAgentLabel(session.createdOnPlatform);
+}
+
+/**
+ * Whether the Active now row's long-press menu may offer Exit session.
+ * Cloud-agent rows carry the sentinel `connectionId` and have no CLI
+ * connection to receive `exit_cli`; only real CLI rows can be exited.
+ */
+export function canExitSessionFromList(session: { connectionId: string }): boolean {
+  return session.connectionId !== CLOUD_AGENT_CONNECTION_ID;
 }
 
 const KNOWN_PLATFORM_VALUES: readonly string[] = KNOWN_PLATFORMS;

--- a/apps/mobile/src/components/agents/session-row-actions.test.ts
+++ b/apps/mobile/src/components/agents/session-row-actions.test.ts
@@ -31,15 +31,18 @@ type Captured = {
 
 function openMenu(args: {
   onRename?: () => void;
+  onExit?: () => void;
   onDelete?: () => void;
   bottomInset?: number;
 }): Captured & {
   onCopySessionId: ReturnType<typeof vi.fn>;
   onRename: ReturnType<typeof vi.fn> | undefined;
+  onExit: ReturnType<typeof vi.fn> | undefined;
   onDelete: ReturnType<typeof vi.fn> | undefined;
 } {
   const onCopySessionId = vi.fn(() => undefined);
   const onRename = args.onRename ? vi.fn(() => undefined) : undefined;
+  const onExit = args.onExit ? vi.fn(() => undefined) : undefined;
   const onDelete = args.onDelete ? vi.fn(() => undefined) : undefined;
   const captured: { current: Captured | null } = { current: null };
 
@@ -52,6 +55,7 @@ function openMenu(args: {
     },
     onCopySessionId,
     ...(onRename ? { onRename } : {}),
+    ...(onExit ? { onExit } : {}),
     ...(onDelete ? { onDelete } : {}),
     bottomInset: args.bottomInset ?? 12,
   });
@@ -63,6 +67,7 @@ function openMenu(args: {
     ...captured.current,
     onCopySessionId,
     onRename,
+    onExit,
     onDelete,
   };
 }
@@ -142,5 +147,58 @@ describe('showSessionActionMenu', () => {
     onSelect(1);
     expect(onRename).toHaveBeenCalledTimes(1);
     expect(onCopySessionId).not.toHaveBeenCalled();
+  });
+
+  it('includes copy, rename, exit, cancel with destructive exit when delete is absent', () => {
+    const { sheetOptions } = openMenu({
+      onRename: () => undefined,
+      onExit: () => undefined,
+    });
+
+    expect(sheetOptions.options).toEqual(['Copy session ID', 'Rename', 'Exit session', 'Cancel']);
+    expect(sheetOptions.cancelButtonIndex).toBe(3);
+    expect(sheetOptions.destructiveButtonIndex).toBe(2);
+  });
+
+  it('omits exit session when onExit is absent', () => {
+    const { sheetOptions } = openMenu({
+      onRename: () => undefined,
+      onDelete: () => undefined,
+    });
+
+    expect(sheetOptions.options).toEqual(['Copy session ID', 'Rename', 'Delete session', 'Cancel']);
+    expect(sheetOptions.options).not.toContain('Exit session');
+  });
+
+  it('orders copy, rename, exit, delete, cancel with destructive delete when both exist', () => {
+    const { sheetOptions } = openMenu({
+      onRename: () => undefined,
+      onExit: () => undefined,
+      onDelete: () => undefined,
+    });
+
+    expect(sheetOptions.options).toEqual([
+      'Copy session ID',
+      'Rename',
+      'Exit session',
+      'Delete session',
+      'Cancel',
+    ]);
+    expect(sheetOptions.cancelButtonIndex).toBe(4);
+    expect(sheetOptions.destructiveButtonIndex).toBe(3);
+  });
+
+  it('dispatches exit at its index without copy, rename, or delete', () => {
+    const { onSelect, onExit, onCopySessionId, onRename, onDelete } = openMenu({
+      onRename: () => undefined,
+      onExit: () => undefined,
+      onDelete: () => undefined,
+    });
+
+    onSelect(2);
+    expect(onExit).toHaveBeenCalledTimes(1);
+    expect(onCopySessionId).not.toHaveBeenCalled();
+    expect(onRename).not.toHaveBeenCalled();
+    expect(onDelete).not.toHaveBeenCalled();
   });
 });

--- a/apps/mobile/src/components/agents/session-row-actions.ts
+++ b/apps/mobile/src/components/agents/session-row-actions.ts
@@ -54,6 +54,12 @@ type SessionActionMenuOptions = {
   onCopySessionId: () => void;
   /** Omitted → no Rename entry. */
   onRename?: () => void;
+  /**
+   * Omitted → no Exit session entry. Additive for the running-session row:
+   * the old menu form (Copy / Rename / Delete / Cancel) stays unchanged for
+   * callers that omit `onExit`.
+   */
+  onExit?: () => void;
   /** Omitted → no Delete entry. */
   onDelete?: () => void;
   /** `useSafeAreaInsets().bottom` — pads the Android custom sheet. */
@@ -62,12 +68,15 @@ type SessionActionMenuOptions = {
 
 /**
  * Shared session long-press menu. Builds one options list — Copy session ID,
- * optional Rename, optional Delete session, Cancel — and dispatches by index.
+ * optional Rename, optional Exit session, optional Delete session, Cancel —
+ * and dispatches by index. Exit session is additive when `onExit` is passed;
+ * callers that omit it keep the old Copy / Rename / Delete / Cancel form.
  * iOS delegates to native ActionSheetIOS via @expo/react-native-action-sheet;
  * Android gets backdrop-tap and hardware-back dismiss from the library.
  */
 export function showSessionActionMenu(opts: SessionActionMenuOptions): void {
-  const { showActionSheetWithOptions, onCopySessionId, onRename, onDelete, bottomInset } = opts;
+  const { showActionSheetWithOptions, onCopySessionId, onRename, onExit, onDelete, bottomInset } =
+    opts;
 
   const options = ['Copy session ID'];
   const handlers: (() => void)[] = [onCopySessionId];
@@ -75,6 +84,10 @@ export function showSessionActionMenu(opts: SessionActionMenuOptions): void {
   if (onRename) {
     options.push('Rename');
     handlers.push(onRename);
+  }
+  if (onExit) {
+    options.push('Exit session');
+    handlers.push(onExit);
   }
   if (onDelete) {
     options.push('Delete session');
@@ -84,7 +97,9 @@ export function showSessionActionMenu(opts: SessionActionMenuOptions): void {
 
   const cancelButtonIndex = options.length - 1;
   const deleteIndex = options.indexOf('Delete session');
-  const destructiveButtonIndex = deleteIndex === -1 ? undefined : deleteIndex;
+  const exitIndex = options.indexOf('Exit session');
+  // Delete wins when both exist; Exit is destructive only when Delete is absent.
+  const destructiveButtonIndex = [deleteIndex, exitIndex].find(index => index !== -1);
 
   showActionSheetWithOptions(
     {


### PR DESCRIPTION
## Summary

Long-press a running session in the Active now list to see a new Exit session entry. Confirm to stop the running session and keep its history. Success shows a "Session exited" toast and refreshes the Active now list; a retryable send failure shows a "Try again" action. Stored rows keep the old menu, and a running session started from a cloud agent omits the entry.

A parent transcript now fills in empty child sessions in the background. A completed or live child then shows its own model on its card without opening the child session. A child with no model in its history shows no model line instead of the parent's model.

---

The Active now row's long-press menu gains an additive Exit session entry, wired through an optional `onExit` callback so callers that omit it keep the old Copy, Rename, Delete, Cancel form. Confirming sends `exit_cli` over the web connection, keeps the session's history, shows a Session exited toast, and refreshes the active list; a retryable send failure shows Try again without a second confirmation, and a non-retryable failure fails closed with no retry action. The destructive button index prefers Delete when both entries exist, and an in-flight flag blocks a second exit while one is running.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/exit-remote-session-from-list.ts` — new helper owns the confirm, send, refresh, and toast lifecycle; classifies non-retryable exit errors and offers a retry action for retryable ones.
- `apps/mobile/src/components/agents/remote-session-row.tsx` — adds the exit handler, the in-flight ref, the active-list refresh, and passes `onExit` only when `canExitSessionFromList` allows; non-interactive rows keep no long-press.
- `apps/mobile/src/components/agents/session-row-actions.ts` — adds the optional `onExit` entry and picks the destructive button index.

</details>

The new pure helper `canExitSessionFromList` gates the Exit session entry. Cloud-agent rows carry the sentinel connection id and have no CLI connection to receive `exit_cli`, so the helper returns false and the row omits the entry. Only real CLI rows can be exited.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/session-list-helpers.ts` — adds `canExitSessionFromList`, which returns false for the cloud-agent sentinel connection id.

</details>

The parent transcript now hydrates empty child sessions in the background through two new helpers, `collectEmptyChildSessionIds` and `hydrateEmptyChildSessions`. A reopened parent shows each completed or live child's own model on its card without opening the child sheet, and a child with no model in its history shows no model line. Each child id is attempted once per parent session and retried once when hydration reports an error status; the child sheet stays closed and hydration reads live atom state through the store so the effect never acts on a stale child-message map.

<details>
<summary>Files</summary>

- `apps/mobile/src/components/agents/session-detail-content.tsx` — adds the hydration effect plus the attempted ref set, reset on session change.
- `apps/mobile/src/components/agents/session-detail-content-helpers.ts` — adds `collectEmptyChildSessionIds` and `hydrateEmptyChildSessions`.

</details>

Tests: 4 files — `exit-remote-session-from-list.test.ts` (new), `session-detail-content-helpers.test.ts`, `session-list-helpers.test.ts`, and `session-row-actions.test.ts`.
Generated: none.

---

## Verification

One round on iOS ran all five cases.

| Case | What it proves | Platform | Result |
|---|---|---|---|
| cold-open | The cloud/sessions deep link opens the Agents list, and the running session row appears under Active now. | ios | passed |
| menu-exit | The long-press menu on the running row lists Copy session ID, Rename, Exit session, and Cancel, with Exit session above Cancel. | ios | passed |
| confirm-keep | The exit dialog shows the right body and buttons, and Keep session running leaves the row in Active now with no toast. | ios | passed |
| exit-success | Exit shows the Session exited toast, moves the row from Active now to History, and leaves no spinner on the row. | ios | passed |
| stored-menu | The long-press menu on the stored row lists Delete session and omits Exit session. | ios | passed |

No product defect reproduced on the unfixed build; the single cold-open retry was a test-flow issue, not a product defect.
Recording: none.

## Visual Changes

### Agents list — Active now section

The Agents list shows the running session in an Active now section above the stored rows. In the picture, the ACTIVE NOW header holds one row: CLOUD, One sentence greeting, a green dot, and 1M AGO.

![01-s1-cold-open.png](https://github.com/user-attachments/assets/409aa176-421b-44d5-ae50-47201f31228e)

### Long-press manage sheet on the running row

A long press on the running row opens a sheet with Copy session ID, Rename, Exit session, and Cancel. In the picture, the red Exit session item sits above Cancel, over the dimmed Active now row.

![01-s2-menu-exit.png](https://github.com/user-attachments/assets/9028886e-fa7a-4bda-bd51-c2c32877d98f)

### Manage sheet on a stored row under TODAY

A long press on a stored row under TODAY opens a sheet with Copy session ID, Rename, Delete session, and Cancel. In the picture, the red Delete session item sits above Cancel, and the sheet has no Exit session item.

![01-s5-stored-menu.png](https://github.com/user-attachments/assets/e6aac78f-01a6-472c-aa21-e45dc93e33a9)

## Reviewer Notes

Human steps: none.

Notes: E2E scope: the child-card model feature (a2) is not bot-E2E-testable because the fake LLM emits only text deltas and never a task tool call, so no child session can be seeded. Its logic is covered by unit tests.
