### PR TITLE
fix(session-ingest): swallow the R2 delete failure in the DO wipe

### DIFF
--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -1004,6 +1004,15 @@ async function registerAllocatedSession(
   // prior attempt whose response was lost. The DO method is not idempotent, so
   // the retry returns this rejection; treat it as idempotent success instead of
   // rolling back a live clone, tombstoning its IDs, or settling the row failed.
+  //
+  // The rejection can only come from this caller's own retry, because the DO name
+  // `${userId}:${cloudAgentSessionId}` is request-identity bound on both entries:
+  // a first attempt allocates a fresh random `cloudAgentSessionId`
+  // (`generateSessionId`), so only `withDORetry` can reach that DO again; a
+  // same-operationKey replay rebuilds the ID from `row.canonical_result` in
+  // `rebuildCloneAllocation`, so the DO belongs to the same ledger row. Keep that
+  // property if either entry changes; otherwise an unrelated conflict would be
+  // swallowed as success here.
   logger.info('Session registered for lazy preparation');
   const result = {
     cloudAgentSessionId: allocation.cloudAgentSessionId,

--- a/services/session-ingest/src/dos/SessionIngestDO.test.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.test.ts
@@ -1992,4 +1992,28 @@ describe('SessionIngestDO clone primitives', () => {
       })
     ).toEqual({ status: 'empty' });
   });
+
+  it('swallows an R2 delete failure so resetCloneStage still returns a typed reject', async () => {
+    const harness = makeCloneHarness([itemRow(1, 'message/src', 'message', 1, 'items/blob')]);
+    harness.deleteObject.mockRejectedValueOnce(new Error('r2 unavailable'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(harness.durableObject.resetCloneStage()).resolves.toBeUndefined();
+
+    expect(harness.deleteAll).toHaveBeenCalled();
+    expect(harness.items).toHaveLength(0);
+    expect(consoleError).toHaveBeenCalled();
+    consoleError.mockRestore();
+  });
+
+  it('marks the DO deleted even when the clear R2 delete fails', async () => {
+    const harness = makeCloneHarness([itemRow(1, 'message/src', 'message', 1, 'items/blob')]);
+    harness.deleteObject.mockRejectedValueOnce(new Error('r2 unavailable'));
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
+
+    await expect(harness.durableObject.clear()).resolves.toBeUndefined();
+
+    expect(harness.meta.get('deleted')).toBe('true');
+    consoleError.mockRestore();
+  });
 });

--- a/services/session-ingest/src/dos/SessionIngestDO.ts
+++ b/services/session-ingest/src/dos/SessionIngestDO.ts
@@ -1171,6 +1171,11 @@ export class SessionIngestDO extends DurableObject<Env> {
    * Cancel the alarm, wipe SQLite, then delete the captured R2-backed item blobs.
    * Shared by `clear()` and `resetCloneStage()`; `clear()` additionally marks the
    * DO deleted.
+   *
+   * The R2 delete is best-effort: the SQLite wipe has already committed when it
+   * runs, so a transient R2 failure must not throw. A throw would leave `clear()`
+   * wiped but unmarked, and would turn a typed `rejected` clone result into an
+   * uncaught exception at the RPC boundary.
    */
   private async wipeStorage(): Promise<void> {
     // Capture the R2 keys first (synchronous SQLite). The SQLite wipe below must
@@ -1190,7 +1195,14 @@ export class SessionIngestDO extends DurableObject<Env> {
 
     // Delete the captured R2 objects last, after the SQLite wipe is complete.
     if (r2Keys.length > 0) {
-      await this.env.SESSION_INGEST_R2.delete(r2Keys);
+      try {
+        await this.env.SESSION_INGEST_R2.delete(r2Keys);
+      } catch (error) {
+        console.error('Failed to delete wiped session ingest R2 bodies', {
+          count: r2Keys.length,
+          error: error instanceof Error ? error.message : String(error),
+        });
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Follow up to #5440. It answers the two unresolved review comments from @pandemicsyn.

- A transient R2 outage no longer breaks a session wipe or a failed session clone. The wipe finishes, the failure is logged, and the caller gets its normal result instead of an unexpected error.

---

## Comment 1: the unguarded R2 delete — valid, fixed

`wipeStorage()` deleted the captured R2 bodies with no try/catch, unlike the sibling cleanup path `deleteDestinationR2Bodies` in `session-clone.ts:343`, which swallows the same failure on purpose.

The SQLite wipe commits before the R2 delete runs, so a throw leaves committed state behind. Two paths broke:

- **`clear()`** wiped SQLite through `storage.deleteAll()`, then threw before writing the `deleted=true` marker. The Durable Object stayed wiped but unmarked. #5440 introduced this one: it moved the R2 delete from before `deleteAll()` to after it, and moved the marker write out of the shared helper.
- **`resetCloneStage()`** turned a typed `rejected` clone result into an uncaught exception at the RPC boundary. Reached from `session-clone.ts:412,423,505,533,551,555`.

The delete is now best-effort and logs the failure, mirroring `deleteDestinationR2Bodies`. The SQLite state is already consistent at that point either way.

## Comment 2: `Session already registered` — no defect, comment added

The comment asks for a request-identity correlation. It already exists, one level up, so this needed a code comment and not a code change:

- A first attempt allocates a fresh random `cloudAgentSessionId` (`generateSessionId`, `session-service.ts:1091`), so the Durable Object name `${userId}:${cloudAgentSessionId}` is new. Only `withDORetry` can reach that Durable Object again.
- A same-operationKey replay rebuilds the ID from `row.canonical_result` in `rebuildCloneAllocation` (`session-registration.ts:640`), so the Durable Object belongs to the same ledger row.

Both entries into `registerAllocatedSession` are therefore identity bound, and the rejection can only come from this caller's own retry. The comment now records that property so a future refactor does not break it.

The comment also states the branch covers "both clone and non-clone create paths". It does not: `registerAllocatedSession` is clone-only, and `registerNewSession` has no such check. `grep` for `already registered` in `services/cloud-agent-next/src` returns only this one call site.

<details>
<summary>Files</summary>

- `services/session-ingest/src/dos/SessionIngestDO.ts` — wraps the R2 delete in `wipeStorage()` in a try/catch that logs.
- `services/cloud-agent-next/src/session/session-registration.ts` — records why the clone-only already-registered rejection is safe as idempotent success.
- `services/session-ingest/src/dos/SessionIngestDO.test.ts` — two regression tests.

</details>

Tests: 1 test file changed (2 tests added).
Generated: none.

## Verification

Both new tests fail on the unfixed code and pass with the fix.

| Check | Command | Result |
|---|---|---|
| Unit tests | `pnpm --filter cloudflare-session-ingest exec vitest run src/dos/SessionIngestDO.test.ts` | 34 passed |
| Same tests, fix reverted | as above, with `SessionIngestDO.ts` stashed | 2 failed, 32 passed |
| Typecheck | `pnpm --filter cloudflare-session-ingest typecheck` | passed |
| Typecheck | `pnpm --filter cloud-agent-next typecheck` | passed |
| Lint | `pnpm --filter cloudflare-session-ingest lint` | 0 warnings, 0 errors |
| Format | `pnpm exec oxfmt --list-different` on the three files | clean |

The reverted run failed with `Error: r2 unavailable` on both new cases, which is the exact throw the guard now absorbs.

## Reviewer Notes

No human steps required.