### PR TITLE
fix(ci): unbreak the kilo-app release preflight

### DIFF
--- a/.github/workflows/kilo-app-release.yml
+++ b/.github/workflows/kilo-app-release.yml
@@ -89,7 +89,11 @@ jobs:
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: |
-          ENV_OUTPUT=$(pnpx eas-cli@21.8.0 env:list --environment production --format long)
+          if ! ENV_OUTPUT=$(pnpx eas-cli@21.8.0 env:list --environment production --format long 2>&1); then
+            echo "$ENV_OUTPUT"
+            echo "::error::eas env:list failed"
+            exit 1
+          fi
           MISSING=""
           for NAME in API_BASE_URL WEB_BASE_URL CLOUD_AGENT_WS_URL SESSION_INGEST_WS_URL APPSFLYER_DEV_KEY APPSFLYER_APP_ID KILO_CHAT_URL EVENT_SERVICE_URL NOTIFICATIONS_URL POSTHOG_API_KEY SENTRY_AUTH_TOKEN EXPO_PUBLIC_SENTRY_ENVIRONMENT; do
             if ! printf '%s\n' "$ENV_OUTPUT" | grep -qE "^Name[[:space:]]+${NAME}[[:space:]]*$"; then
@@ -106,7 +110,12 @@ jobs:
         working-directory: apps/mobile
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
-        run: EAS_BUILD_PROFILE=production pnpx eas-cli@21.8.0 env:exec production --non-interactive 'pnpm assert:config'
+        # EAS_BUILD_PROFILE belongs inside the quoted command: eas-cli evaluates
+        # app.config.ts itself to resolve the project, and the production profile
+        # makes that evaluation throw on env the CLI never injects. SENTRY_AUTH_TOKEN
+        # is a SECRET variable that only EAS builders can read, so the assertion run
+        # gets a placeholder. The step above proves the real secret exists.
+        run: pnpx eas-cli@21.8.0 env:exec production --non-interactive 'EAS_BUILD_PROFILE=production SENTRY_AUTH_TOKEN=preflight-placeholder pnpm assert:config'
 
   build-and-submit:
     needs: [check-changes, validate, preflight]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -6,18 +6,93 @@ settings:
 
 catalogs:
   default:
+    '@cloudflare/vitest-pool-workers':
+      specifier: 0.16.13
+      version: 0.16.13
+    '@cloudflare/workers-types':
+      specifier: 4.20260605.1
+      version: 4.20260605.1
+    '@octokit/auth-app':
+      specifier: 8.2.0
+      version: 8.2.0
+    '@sentry/cli':
+      specifier: 3.6.2
+      version: 3.6.2
+    '@tanstack/query-async-storage-persister':
+      specifier: 5.100.10
+      version: 5.100.10
+    '@tanstack/react-query':
+      specifier: 5.100.10
+      version: 5.100.10
+    '@tanstack/react-query-persist-client':
+      specifier: 5.100.10
+      version: 5.100.10
+    '@trpc/client':
+      specifier: 11.17.0
+      version: 11.17.0
+    '@trpc/server':
+      specifier: 11.17.0
+      version: 11.17.0
+    '@trpc/tanstack-react-query':
+      specifier: 11.17.0
+      version: 11.17.0
+    '@types/jsonwebtoken':
+      specifier: 9.0.10
+      version: 9.0.10
     '@types/node':
       specifier: 24.12.4
       version: 24.12.4
     '@typescript/native-preview':
       specifier: 7.0.0-dev.20260514.1
       version: 7.0.0-dev.20260514.1
+    '@vitest/coverage-v8':
+      specifier: 4.1.6
+      version: 4.1.6
+    '@vitest/ui':
+      specifier: 4.1.6
+      version: 4.1.6
+    '@workos-inc/node':
+      specifier: 8.13.0
+      version: 8.13.0
+    aws4fetch:
+      specifier: 1.0.20
+      version: 1.0.20
+    drizzle-kit:
+      specifier: 0.31.10
+      version: 0.31.10
+    jose:
+      specifier: 6.2.3
+      version: 6.2.3
+    jsonwebtoken:
+      specifier: 9.0.3
+      version: 9.0.3
+    p-limit:
+      specifier: 7.3.0
+      version: 7.3.0
+    stripe:
+      specifier: 19.3.1
+      version: 19.3.1
     tsx:
       specifier: 4.21.0
       version: 4.21.0
     typescript:
       specifier: 5.9.3
       version: 5.9.3
+    ulid:
+      specifier: 3.0.2
+      version: 3.0.2
+    vitest:
+      specifier: 4.1.6
+      version: 4.1.6
+    workers-tagged-logger:
+      specifier: 1.0.0
+      version: 1.0.0
+    wrangler:
+      specifier: 4.112.0
+      version: 4.112.0
+    zod:
+      specifier: 4.4.3
+      version: 4.4.3
 
 overrides:
   '@babel/plugin-transform-modules-systemjs': 7.29.7
@@ -71,7 +146,7 @@ overrides:
   shell-quote: 1.10.0
   '@slack/web-api': 7.19.0
 
-packageExtensionsChecksum: sha256-4f/k7Hd0rFgrZvan+MM5hKRF7ZOROy5CFlQdxSwVtGE=
+packageExtensionsChecksum: sha256-1pgKZxx87NNMe1poF5N5u5kZB/qlEyILBQPxofM1shE=
 
 patchedDependencies:
   expo-server-sdk: 7850520582b5b394397b35d1ea195192fe78589d8a6a748fe15177b818c4ed0b
@@ -98,13 +173,13 @@ importers:
         version: 7.0.0-dev.20260514.1
       eslint-plugin-zod-utils:
         specifier: 1.0.11
-        version: 1.0.11(typescript@5.9.3)
+        version: 1.0.11(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
       husky:
         specifier: 9.1.7
         version: 9.1.7
       ink:
         specifier: 6.8.0
-        version: 6.8.0(react@19.2.6)
+        version: 6.8.0(@types/react@19.2.14)(bufferutil@4.1.0)(react-devtools-core@6.1.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react@19.2.6)(utf-8-validate@6.0.6)
       oxfmt:
         specifier: 0.40.0
         version: 0.40.0
@@ -447,7 +522,7 @@ importers:
         version: 0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
       react-native-appsflyer:
         specifier: 6.18.0
-        version: 6.18.0(patch_hash=82df99378c830e774b0f01796d8be595da114d1d13393d85ddd47d565c5c2aab)
+        version: 6.18.0(patch_hash=82df99378c830e774b0f01796d8be595da114d1d13393d85ddd47d565c5c2aab)(typescript@6.0.3)
       react-native-css:
         specifier: 3.0.7
         version: 3.0.7(@expo/metro-config@57.0.7(bufferutil@4.1.0)(expo@57.0.10)(typescript@6.0.3)(utf-8-validate@6.0.6))(lightningcss@1.30.1)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -10665,9 +10740,6 @@ packages:
   bail@2.0.2:
     resolution: {integrity: sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==}
 
-  balanced-match@1.0.2:
-    resolution: {integrity: sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==}
-
   balanced-match@4.0.4:
     resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
     engines: {node: 18 || 20 || >=22}
@@ -10787,9 +10859,6 @@ packages:
   bplist-parser@0.3.2:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
-
-  brace-expansion@1.1.12:
-    resolution: {integrity: sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==}
 
   brace-expansion@5.0.9:
     resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
@@ -11307,9 +11376,6 @@ packages:
 
   compute-scroll-into-view@2.0.4:
     resolution: {integrity: sha512-y/ZA3BGnxoM/QHHQ2Uy49CLtnWPbt4tTPpEEZiEmmiWBFKjej7nEyH8Ryz54jH0MLXflUYA3Er2zUxPSJu5R+g==}
-
-  concat-map@0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
 
   concat-stream@1.6.2:
     resolution: {integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==}
@@ -17507,10 +17573,6 @@ packages:
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
 
-  tinyexec@1.0.4:
-    resolution: {integrity: sha512-u9r3uZC0bdpGOXtlxUIdwf9pkmvhqJdrVCH9fapQtgy/OeTTMZ1nqH7agtvEfmGui6e1XxjcdrlxvxJvc3sMqw==}
-    engines: {node: '>=18'}
-
   tinyexec@1.2.4:
     resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
     engines: {node: '>=18'}
@@ -20928,10 +20990,6 @@ snapshots:
   '@esbuild/win32-x64@0.28.1':
     optional: true
 
-  '@eslint-community/eslint-utils@4.9.1':
-    dependencies:
-      eslint-visitor-keys: 3.4.3
-
   '@eslint-community/eslint-utils@4.9.1(eslint@9.39.4(jiti@2.7.0))':
     dependencies:
       eslint: 9.39.4(jiti@2.7.0)
@@ -22828,7 +22886,7 @@ snapshots:
 
   '@napi-rs/wasm-runtime@0.2.12':
     dependencies:
-      '@emnapi/core': 1.10.0
+      '@emnapi/core': 1.11.2
       '@emnapi/runtime': 1.11.2
       '@tybys/wasm-util': 0.10.1
     optional: true
@@ -22840,18 +22898,18 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
-    dependencies:
-      '@emnapi/core': 1.10.0
-      '@emnapi/runtime': 1.10.0
-      '@tybys/wasm-util': 0.10.1
-    optional: true
-
   '@napi-rs/wasm-runtime@1.1.4(@emnapi/core@1.9.2)(@emnapi/runtime@1.9.2)':
     dependencies:
       '@emnapi/core': 1.9.2
       '@emnapi/runtime': 1.9.2
       '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)':
+    dependencies:
+      '@emnapi/core': 1.10.0
+      '@emnapi/runtime': 1.10.0
+      '@tybys/wasm-util': 0.10.3
     optional: true
 
   '@napi-rs/wasm-runtime@1.1.6(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)':
@@ -24694,7 +24752,7 @@ snapshots:
     dependencies:
       '@emnapi/core': 1.10.0
       '@emnapi/runtime': 1.10.0
-      '@napi-rs/wasm-runtime': 1.1.4(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
+      '@napi-rs/wasm-runtime': 1.1.6(@emnapi/core@1.10.0)(@emnapi/runtime@1.10.0)
     optional: true
 
   '@rolldown/binding-win32-arm64-msvc@1.0.3':
@@ -26917,12 +26975,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@typescript-eslint/utils@8.67.0(typescript@5.9.3)':
+  '@typescript-eslint/utils@8.67.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)':
     dependencies:
-      '@eslint-community/eslint-utils': 4.9.1
+      '@eslint-community/eslint-utils': 4.9.1(eslint@9.39.4(jiti@2.7.0))
       '@typescript-eslint/scope-manager': 8.67.0
       '@typescript-eslint/types': 8.67.0
       '@typescript-eslint/typescript-estree': 8.67.0(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
       typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
@@ -27176,7 +27235,7 @@ snapshots:
       flatted: 3.4.2
       pathe: 2.0.3
       sirv: 3.0.2
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vitest: 4.1.6(@opentelemetry/api@1.9.1)(@types/node@24.12.4)(@vitest/coverage-v8@4.1.6)(@vitest/ui@4.1.6)(esbuild@0.28.1)(jiti@2.7.0)(jsdom@29.1.1)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
 
@@ -27904,8 +27963,6 @@ snapshots:
 
   bail@2.0.2: {}
 
-  balanced-match@1.0.2: {}
-
   balanced-match@4.0.4: {}
 
   bare-events@2.8.2: {}
@@ -28019,11 +28076,6 @@ snapshots:
   bplist-parser@0.3.2:
     dependencies:
       big-integer: 1.6.52
-
-  brace-expansion@1.1.12:
-    dependencies:
-      balanced-match: 1.0.2
-      concat-map: 0.0.1
 
   brace-expansion@5.0.9:
     dependencies:
@@ -28557,8 +28609,6 @@ snapshots:
       - supports-color
 
   compute-scroll-into-view@2.0.4: {}
-
-  concat-map@0.0.1: {}
 
   concat-stream@1.6.2:
     dependencies:
@@ -29485,9 +29535,10 @@ snapshots:
       typescript: 6.0.3
       yaml: 2.8.4
 
-  eslint-plugin-zod-utils@1.0.11(typescript@5.9.3):
+  eslint-plugin-zod-utils@1.0.11(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3):
     dependencies:
-      '@typescript-eslint/utils': 8.67.0(typescript@5.9.3)
+      '@typescript-eslint/utils': 8.67.0(eslint@9.39.4(jiti@2.7.0))(typescript@5.9.3)
+      eslint: 9.39.4(jiti@2.7.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -31239,38 +31290,6 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  ink@6.8.0(react@19.2.6):
-    dependencies:
-      '@alcalzone/ansi-tokenize': 0.2.5
-      ansi-escapes: 7.3.0
-      ansi-styles: 6.2.3
-      auto-bind: 5.0.1
-      chalk: 5.6.2
-      cli-boxes: 3.0.0
-      cli-cursor: 4.0.0
-      cli-truncate: 5.2.0
-      code-excerpt: 4.0.0
-      es-toolkit: 1.45.1
-      indent-string: 5.0.0
-      is-in-ci: 2.0.0
-      patch-console: 2.0.0
-      react: 19.2.6
-      react-reconciler: 0.33.0(react@19.2.6)
-      scheduler: 0.27.0
-      signal-exit: 3.0.7
-      slice-ansi: 8.0.0
-      stack-utils: 2.0.6
-      string-width: 8.2.0
-      terminal-size: 4.0.1
-      type-fest: 5.5.0
-      widest-line: 6.0.0
-      wrap-ansi: 9.0.2
-      ws: 8.21.0
-      yoga-layout: 3.2.1
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-
   inline-style-parser@0.2.7: {}
 
   internmap@2.0.3: {}
@@ -32404,7 +32423,7 @@ snapshots:
       lodash.isstring: 4.0.1
       lodash.once: 4.1.1
       ms: 2.1.3
-      semver: 7.7.4
+      semver: 7.8.5
 
   jsrsasign@11.1.3: {}
 
@@ -32734,8 +32753,8 @@ snapshots:
 
   magicast@0.5.2:
     dependencies:
-      '@babel/parser': 7.29.0
-      '@babel/types': 7.29.0
+      '@babel/parser': 7.29.7
+      '@babel/types': 7.29.7
       source-map-js: 1.2.1
 
   mailgun.js@12.7.1:
@@ -33587,7 +33606,7 @@ snapshots:
 
   minimatch@3.1.5:
     dependencies:
-      brace-expansion: 1.1.12
+      brace-expansion: 5.0.9
 
   minimatch@5.1.9:
     dependencies:
@@ -35150,7 +35169,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  react-native-appsflyer@6.18.0(patch_hash=82df99378c830e774b0f01796d8be595da114d1d13393d85ddd47d565c5c2aab): {}
+  react-native-appsflyer@6.18.0(patch_hash=82df99378c830e774b0f01796d8be595da114d1d13393d85ddd47d565c5c2aab)(typescript@6.0.3):
+    dependencies:
+      '@expo/config-plugins': 57.0.6(typescript@6.0.3)
+    transitivePeerDependencies:
+      - supports-color
+      - typescript
 
   react-native-css@3.0.7(@expo/metro-config@57.0.7(bufferutil@4.1.0)(expo@57.0.10)(typescript@6.0.3)(utf-8-validate@6.0.6))(lightningcss@1.30.1)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3):
     dependencies:
@@ -36847,8 +36871,6 @@ snapshots:
 
   tinybench@2.9.0: {}
 
-  tinyexec@1.0.4: {}
-
   tinyexec@1.2.4: {}
 
   tinyglobby@0.2.16:
@@ -37401,7 +37423,7 @@ snapshots:
   vite-node@6.0.0(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4):
     dependencies:
       cac: 7.0.0
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       obug: 2.1.1
       pathe: 2.0.3
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
@@ -37476,7 +37498,7 @@ snapshots:
       '@vitest/snapshot': 4.1.6
       '@vitest/spy': 4.1.6
       '@vitest/utils': 4.1.6
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -37484,8 +37506,8 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@22.19.19)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
@@ -37518,7 +37540,7 @@ snapshots:
       '@vitest/snapshot': 4.1.6
       '@vitest/spy': 4.1.6
       '@vitest/utils': 4.1.6
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -37526,8 +37548,8 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@24.12.4)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
@@ -37560,7 +37582,7 @@ snapshots:
       '@vitest/snapshot': 4.1.6
       '@vitest/spy': 4.1.6
       '@vitest/utils': 4.1.6
-      es-module-lexer: 2.0.0
+      es-module-lexer: 2.3.1
       expect-type: 1.3.0
       magic-string: 0.30.21
       obug: 2.1.1
@@ -37568,8 +37590,8 @@ snapshots:
       picomatch: 4.0.4
       std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 1.0.4
-      tinyglobby: 0.2.16
+      tinyexec: 1.2.4
+      tinyglobby: 0.2.17
       tinyrainbow: 3.1.0
       vite: 8.0.16(@types/node@25.5.2)(esbuild@0.28.1)(jiti@2.7.0)(terser@5.46.0)(tsx@4.21.0)(yaml@2.8.4)
       why-is-node-running: 2.3.0
@@ -38133,8 +38155,6 @@ snapshots:
     optionalDependencies:
       bufferutil: 4.1.0
       utf-8-validate: 6.0.6
-
-  ws@8.21.0: {}
 
   ws@8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6):
     optionalDependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -149,6 +149,9 @@ packageExtensions:
   expo-share-intent:
     dependencies:
       '@expo/plist': '*'
+  react-native-appsflyer:
+    dependencies:
+      '@expo/config-plugins': '*'
 patchedDependencies:
   expo-server-sdk: patches/expo-server-sdk.patch
   react-native-appsflyer@6.18.0: patches/react-native-appsflyer@6.18.0.patch


### PR DESCRIPTION
Fixes the `preflight` job in [kilo-app Release run 32768868183](https://github.com/Kilo-Org/cloud/actions/runs/32768868183/job/97564516868).

## Failure 1: `Verify EAS production environment`

The log showed only `Error: env:list command failed.` The real reason went to eas-cli's stdout, which the step captured into `$ENV_OUTPUT`.

The reason: eas-cli spawns `node_modules/.pnpm/expo@.../expo/bin/cli config --json` directly, so it bypasses the pnpm bin shim that exports `NODE_PATH`. `react-native-appsflyer/expo/withAppsFlyerIos.js` requires `@expo/config-plugins` and deep paths under it, but the package declares no dependencies at all. Without the shim the require fails, so every eas-cli command that reads the app config fails.

The fix declares the dep through `packageExtensions`, next to the identical entries for `@sentry/react-native` and `expo-share-intent`. It resolves to `@expo/config-plugins@57.0.6` — the same instance the SDK 57 graph already uses, so no duplicate copy.

## Failure 2: `Assert production config contract`

This step would have failed next, for a different reason. `EAS_BUILD_PROFILE=production` applied to the eas-cli process itself, and eas-cli evaluates `app.config.ts` to resolve the project before it injects any environment. Under the production profile that evaluation throws on the missing env, and it also throws on the missing `SENTRY_AUTH_TOKEN`, which is a `SECRET` variable only EAS builders can read.

The variable now sits inside the quoted command, so it applies to `pnpm assert:config` and not to eas-cli. The run gets a placeholder `SENTRY_AUTH_TOKEN`; step 8 already proves the real secret exists in the EAS production environment.

## Verification

Both steps ran locally against the real EAS project, with the CI environment (`GITHUB_ACTIONS=1`, no `.env` loading):

| Command | main | this branch |
| --- | --- | --- |
| `expo config --json` outside the pnpm shim | exit 1, `Cannot find module '@expo/config-plugins'` | exit 0 |
| `eas env:list --environment production --format long` | exit 1 | exit 0, all 12 required names present |
| `eas env:exec production ... assert:config` | exit 1 | exit 0, `Expo config contract OK` |

`pnpm install --frozen-lockfile` passes on the updated lockfile.

## Not in scope

No CI job evaluates the app config outside the pnpm shim, so nothing catches a repeat of failure 1 before the nightly release. A guard is a separate change.