### PR TITLE
feat(web): add org credit and invoice page procedures

### DIFF
--- a/apps/web/src/lib/creditTransactions.page.test.ts
+++ b/apps/web/src/lib/creditTransactions.page.test.ts
@@ -1,0 +1,117 @@
+import { describe, test, expect } from '@jest/globals';
+import { insertTestUser } from '../tests/helpers/user.helper';
+import { createTestOrganization } from '../tests/helpers/organization.helper';
+
+import {
+  getCreditTransactionsForOrganization,
+  getCreditTransactionsForOrganizationPage,
+} from '@/lib/creditTransactions';
+import { db, pool } from './drizzle';
+import { credit_transactions } from '@kilocode/db/schema';
+
+function whereClause(text: string): string {
+  const match = text.match(/\bwhere\s+(.+?)\s+order by\s/);
+  return match ? match[1] : '';
+}
+
+describe('getCreditTransactionsForOrganizationPage', () => {
+  test('pages 26 transactions into 25 entries and matches the summary for the excluded set', async () => {
+    const user = await insertTestUser();
+    const org = await createTestOrganization('page org', user.id, 0);
+
+    const purchases = Array.from({ length: 26 }, () => ({
+      kilo_user_id: user.id,
+      organization_id: org.id,
+      is_free: false,
+      amount_microdollars: 1_000_000,
+      description: 'purchase',
+    }));
+    await db.insert(credit_transactions).values(purchases);
+
+    // kpo:consumption rows must be absent from both the page and the summary.
+    await db.insert(credit_transactions).values([
+      {
+        kilo_user_id: user.id,
+        organization_id: org.id,
+        is_free: true,
+        amount_microdollars: 5_000_000,
+        credit_category: 'kpo:consumption:models',
+        description: 'consumption',
+      },
+      {
+        kilo_user_id: user.id,
+        organization_id: org.id,
+        is_free: true,
+        amount_microdollars: 5_000_000,
+        credit_category: 'kpo:consumption:models',
+        description: 'consumption',
+      },
+    ]);
+
+    const page = await getCreditTransactionsForOrganizationPage(org.id);
+
+    expect(page.entries).toHaveLength(25);
+    expect(page.hasMore).toBe(true);
+    expect(page.nextCursor).toBe(25);
+    expect(page.entries.every(entry => !entry.credit_category?.startsWith('kpo:consumption'))).toBe(
+      true
+    );
+
+    expect(page.summary).toEqual({
+      total_promotional_musd: 0,
+      total_purchased_musd: 26_000_000,
+      credit_transaction_count: 26,
+    });
+  });
+
+  test('returns empty entries, hasMore false, and zero summary for an empty organization', async () => {
+    const user = await insertTestUser();
+    const org = await createTestOrganization('empty page org', user.id, 0);
+
+    const page = await getCreditTransactionsForOrganizationPage(org.id);
+
+    expect(page.entries).toEqual([]);
+    expect(page.hasMore).toBe(false);
+    expect(page.nextCursor).toBeNull();
+    expect(page.summary).toEqual({
+      total_promotional_musd: 0,
+      total_purchased_musd: 0,
+      credit_transaction_count: 0,
+    });
+  });
+
+  test('page SQL keeps the old where clause and adds id ordering plus limit+1', async () => {
+    const user = await insertTestUser();
+    const org = await createTestOrganization('sql page org', user.id, 0);
+
+    const querySpy = jest.spyOn(pool, 'query');
+
+    await getCreditTransactionsForOrganization(org.id);
+    await getCreditTransactionsForOrganizationPage(org.id);
+
+    const captured = (querySpy.mock.calls as unknown as unknown[][]).map(call => {
+      const first = call[0];
+      const text =
+        typeof first === 'string' ? first : ((first as { text?: string } | null)?.text ?? '');
+      return { text, params: (call[1] ?? []) as unknown[] };
+    });
+
+    const oldQuery = captured.find(call => call.text.includes('from "credit_transactions"'));
+    const pageQuery = captured.find(call => call.text.includes('"id" desc'));
+
+    expect(oldQuery).toBeDefined();
+    expect(pageQuery).toBeDefined();
+
+    expect(whereClause(pageQuery!.text)).toBe(whereClause(oldQuery!.text));
+
+    expect(pageQuery!.text).toContain('"created_at" desc');
+    expect(pageQuery!.text.indexOf('"created_at" desc')).toBeLessThan(
+      pageQuery!.text.indexOf('"id" desc')
+    );
+    expect(oldQuery!.text).not.toContain('"id" desc');
+
+    expect(pageQuery!.params).toContain(26);
+
+    querySpy.mockRestore();
+  });
+});

--- a/apps/web/src/lib/creditTransactions.page.test.ts
+++ b/apps/web/src/lib/creditTransactions.page.test.ts
@@ -52,7 +52,7 @@ describe('getCreditTransactionsForOrganizationPage', () => {
 
     expect(page.entries).toHaveLength(25);
     expect(page.hasMore).toBe(true);
-    expect(page.nextCursor).toBe(25);
+    expect(page.nextCursor).toBe(`${page.entries[24]!.created_at}|${page.entries[24]!.id}`);
     expect(page.entries.every(entry => !entry.credit_category?.startsWith('kpo:consumption'))).toBe(
       true
     );
@@ -113,5 +113,39 @@ describe('getCreditTransactionsForOrganizationPage', () => {
     expect(pageQuery!.params).toContain(26);
 
     querySpy.mockRestore();
+  });
+
+  // An OFFSET cursor breaks here: a row inserted at the head between the two
+  // requests shifts every later page, so page 2 repeats a page-1 row.
+  test('keeps page 2 disjoint from page 1 when a new transaction lands between requests', async () => {
+    const user = await insertTestUser();
+    const org = await createTestOrganization('stable page org', user.id, 0);
+
+    await db.insert(credit_transactions).values(
+      Array.from({ length: 30 }, (_, index) => ({
+        kilo_user_id: user.id,
+        organization_id: org.id,
+        is_free: false,
+        amount_microdollars: 1_000_000,
+        description: `purchase ${index}`,
+      }))
+    );
+
+    const first = await getCreditTransactionsForOrganizationPage(org.id);
+    expect(first.hasMore).toBe(true);
+
+    await db.insert(credit_transactions).values({
+      kilo_user_id: user.id,
+      organization_id: org.id,
+      is_free: false,
+      amount_microdollars: 9_000_000,
+      description: 'inserted between pages',
+    });
+
+    const second = await getCreditTransactionsForOrganizationPage(org.id, first.nextCursor);
+
+    const firstIds = new Set(first.entries.map(entry => entry.id));
+    expect(second.entries.some(entry => firstIds.has(entry.id))).toBe(false);
+    expect(second.entries).toHaveLength(5);
   });
 });

--- a/apps/web/src/lib/creditTransactions.ts
+++ b/apps/web/src/lib/creditTransactions.ts
@@ -3,7 +3,7 @@ import { db, readDb, sql } from './drizzle';
 import type { Organization } from '@kilocode/db/schema';
 import { credit_transactions, kilo_pass_issuance_items, kilocode_users } from '@kilocode/db/schema';
 
-type CreditSummary = {
+export type CreditSummary = {
   total_promotional_musd: number;
   total_purchased_musd: number;
   credit_transaction_count: number;
@@ -20,6 +20,33 @@ export async function getCreditTransactionsSummaryByUserId(
       count(*) as credit_transaction_count
     from public.credit_transactions
     where kilo_user_id = ${kiloUserId}
+  `
+  );
+  const result = rows[0] as {
+    total_promotional_musd: bigint;
+    total_purchased_musd: bigint;
+    credit_transaction_count: bigint;
+  };
+
+  return {
+    total_promotional_musd: Number(result.total_promotional_musd),
+    total_purchased_musd: Number(result.total_purchased_musd),
+    credit_transaction_count: Number(result.credit_transaction_count),
+  };
+}
+
+export async function getCreditTransactionsSummaryForOrganization(
+  organizationId: Organization['id']
+): Promise<CreditSummary> {
+  const { rows } = await db.execute(
+    sql`
+    select
+      coalesce(sum(amount_microdollars) filter (where is_free),0) :: bigint  total_promotional_musd,
+      coalesce(sum(amount_microdollars) filter (where not is_free),0) :: bigint  total_purchased_musd,
+      count(*) as credit_transaction_count
+    from public.credit_transactions
+    where organization_id = ${organizationId}
+      and (credit_category is null or credit_category not like 'kpo:consumption:%')
   `
   );
   const result = rows[0] as {
@@ -66,6 +93,7 @@ export async function summarizeUserPayments(kiloUserId: string, fromDb: typeof d
   )[0];
 }
 
+// old form: array capped at 100, no cursor; remove when every client pages.
 export async function getCreditTransactionsForOrganization(organizationId: Organization['id']) {
   return db
     .select({
@@ -98,6 +126,71 @@ export async function getCreditTransactionsForOrganization(organizationId: Organ
     )
     .orderBy(desc(credit_transactions.created_at))
     .limit(100);
+}
+
+const CREDIT_TRANSACTIONS_PAGE_SIZE = 25;
+
+type OrganizationCreditTransaction = Awaited<
+  ReturnType<typeof getCreditTransactionsForOrganization>
+>[number];
+
+export type CreditTransactionsPage = {
+  entries: OrganizationCreditTransaction[];
+  nextCursor: number | null;
+  hasMore: boolean;
+  summary: CreditSummary;
+};
+
+export async function getCreditTransactionsForOrganizationPage(
+  organizationId: Organization['id'],
+  cursor: number = 0
+): Promise<CreditTransactionsPage> {
+  const [transactions, summary] = await Promise.all([
+    db
+      .select({
+        id: credit_transactions.id,
+        kilo_user_id: credit_transactions.kilo_user_id,
+        amount_microdollars: credit_transactions.amount_microdollars,
+        expiration_baseline_microdollars_used:
+          credit_transactions.expiration_baseline_microdollars_used,
+        original_baseline_microdollars_used:
+          credit_transactions.original_baseline_microdollars_used,
+        is_free: credit_transactions.is_free,
+        description: credit_transactions.description,
+        original_transaction_id: credit_transactions.original_transaction_id,
+        stripe_payment_id: credit_transactions.stripe_payment_id,
+        coinbase_credit_block_id: credit_transactions.coinbase_credit_block_id,
+        credit_category: credit_transactions.credit_category,
+        expiry_date: credit_transactions.expiry_date,
+        created_at: credit_transactions.created_at,
+        organization_id: credit_transactions.organization_id,
+        check_category_uniqueness: credit_transactions.check_category_uniqueness,
+      })
+      .from(credit_transactions)
+      .where(
+        and(
+          eq(credit_transactions.organization_id, organizationId),
+          or(
+            isNull(credit_transactions.credit_category),
+            notLike(credit_transactions.credit_category, 'kpo:consumption:%')
+          )
+        )
+      )
+      .orderBy(desc(credit_transactions.created_at), desc(credit_transactions.id))
+      .limit(CREDIT_TRANSACTIONS_PAGE_SIZE + 1)
+      .offset(cursor),
+    getCreditTransactionsSummaryForOrganization(organizationId),
+  ]);
+
+  const hasMore = transactions.length > CREDIT_TRANSACTIONS_PAGE_SIZE;
+  const entries = transactions.slice(0, CREDIT_TRANSACTIONS_PAGE_SIZE);
+
+  return {
+    entries,
+    nextCursor: hasMore ? cursor + CREDIT_TRANSACTIONS_PAGE_SIZE : null,
+    hasMore,
+    summary,
+  };
 }
 
 export async function getAdminCreditTransactionsForOrganization(

--- a/apps/web/src/lib/creditTransactions.ts
+++ b/apps/web/src/lib/creditTransactions.ts
@@ -136,15 +136,39 @@ type OrganizationCreditTransaction = Awaited<
 
 export type CreditTransactionsPage = {
   entries: OrganizationCreditTransaction[];
-  nextCursor: number | null;
+  nextCursor: string | null;
   hasMore: boolean;
   summary: CreditSummary;
 };
 
+/**
+ * Opaque keyset cursor: the ordering key of the last row a page returned,
+ * as `<created_at>|<id>`. An OFFSET cursor is not stable here — the ledger
+ * grows at the head, so a row inserted between two requests shifts every
+ * later page and page 2 repeats a row page 1 already showed.
+ *
+ * `created_at` is read in `mode: 'string'`, so the value keeps the full
+ * Postgres microsecond precision a JS `Date` would round away.
+ */
+function encodeLedgerCursor(row: { created_at: string; id: string }): string {
+  return `${row.created_at}|${row.id}`;
+}
+
+function decodeLedgerCursor(cursor: string): { createdAt: string; id: string } | null {
+  const separator = cursor.indexOf('|');
+  if (separator <= 0 || separator === cursor.length - 1) {
+    return null;
+  }
+  return { createdAt: cursor.slice(0, separator), id: cursor.slice(separator + 1) };
+}
+
 export async function getCreditTransactionsForOrganizationPage(
   organizationId: Organization['id'],
-  cursor: number = 0
+  cursor?: string | null
 ): Promise<CreditTransactionsPage> {
+  // A malformed cursor reads as "start from the top" rather than throwing: the
+  // value is opaque to the client and a stale one must not break the screen.
+  const decoded = cursor ? decodeLedgerCursor(cursor) : null;
   const [transactions, summary] = await Promise.all([
     db
       .select({
@@ -173,21 +197,26 @@ export async function getCreditTransactionsForOrganizationPage(
           or(
             isNull(credit_transactions.credit_category),
             notLike(credit_transactions.credit_category, 'kpo:consumption:%')
-          )
+          ),
+          // Row-value comparison in the same (created_at desc, id desc) order,
+          // so later pages stay disjoint from the ones already shown.
+          decoded
+            ? sql`(${credit_transactions.created_at}, ${credit_transactions.id}) < (${decoded.createdAt}::timestamptz, ${decoded.id}::uuid)`
+            : undefined
         )
       )
       .orderBy(desc(credit_transactions.created_at), desc(credit_transactions.id))
-      .limit(CREDIT_TRANSACTIONS_PAGE_SIZE + 1)
-      .offset(cursor),
+      .limit(CREDIT_TRANSACTIONS_PAGE_SIZE + 1),
     getCreditTransactionsSummaryForOrganization(organizationId),
   ]);
 
   const hasMore = transactions.length > CREDIT_TRANSACTIONS_PAGE_SIZE;
   const entries = transactions.slice(0, CREDIT_TRANSACTIONS_PAGE_SIZE);
+  const lastEntry = entries.at(-1);
 
   return {
     entries,
-    nextCursor: hasMore ? cursor + CREDIT_TRANSACTIONS_PAGE_SIZE : null,
+    nextCursor: hasMore && lastEntry ? encodeLedgerCursor(lastEntry) : null,
     hasMore,
     summary,
   };

--- a/apps/web/src/lib/stripe/index.test.ts
+++ b/apps/web/src/lib/stripe/index.test.ts
@@ -62,6 +62,7 @@ import {
   processStripePaymentEventHook,
   handleSuccessfulChargeWithPayment,
   isCardFingerprintEligibleForFreeCredits,
+  getStripeInvoicesPage,
 } from '@/lib/stripe';
 import {
   type User,
@@ -3966,4 +3967,79 @@ describe('handleSuccessfulChargeWithPayment (org/user routing & side-effects)', 
       }
     }
   );
+});
+
+describe('getStripeInvoicesPage', () => {
+  test('returns hasMore, entries, and nextCursor from the last invoice', async () => {
+    const { client } = await import('@/lib/stripe-client');
+
+    const invoices = [
+      {
+        id: 'in_page_1',
+        object: 'invoice',
+        number: 'INV-1',
+        status: 'paid',
+        amount_due: 100,
+        currency: 'usd',
+        created: 1000,
+        hosted_invoice_url: null,
+        invoice_pdf: null,
+        lines: { data: [] },
+      },
+      {
+        id: 'in_page_2',
+        object: 'invoice',
+        number: 'INV-2',
+        status: 'paid',
+        amount_due: 200,
+        currency: 'usd',
+        created: 2000,
+        hosted_invoice_url: null,
+        invoice_pdf: null,
+        lines: { data: [] },
+      },
+    ] as unknown as Stripe.Invoice[];
+
+    const listSpy = jest.spyOn(client.invoices, 'list').mockResolvedValue({
+      data: invoices,
+      has_more: true,
+    } as unknown as Awaited<ReturnType<typeof client.invoices.list>>);
+
+    const result = await getStripeInvoicesPage('cus_page_test');
+
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.objectContaining({ customer: 'cus_page_test', limit: 25 })
+    );
+    expect(result.hasMore).toBe(true);
+    expect(result.entries).toHaveLength(2);
+    expect(result.nextCursor).toBe('in_page_2');
+
+    listSpy.mockRestore();
+  });
+
+  test('passes starting_after and date threshold through to Stripe', async () => {
+    const { client } = await import('@/lib/stripe-client');
+
+    const listSpy = jest.spyOn(client.invoices, 'list').mockResolvedValue({
+      data: [],
+      has_more: false,
+    } as unknown as Awaited<ReturnType<typeof client.invoices.list>>);
+
+    const threshold = new Date('2026-01-01T00:00:00.000Z');
+    const result = await getStripeInvoicesPage('cus_page_test', threshold, 'in_cursor');
+
+    expect(listSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        customer: 'cus_page_test',
+        limit: 25,
+        starting_after: 'in_cursor',
+        created: { gte: Math.floor(threshold.getTime() / 1000) },
+      })
+    );
+    expect(result.hasMore).toBe(false);
+    expect(result.entries).toEqual([]);
+    expect(result.nextCursor).toBeNull();
+
+    listSpy.mockRestore();
+  });
 });

--- a/apps/web/src/lib/stripe/index.test.ts
+++ b/apps/web/src/lib/stripe/index.test.ts
@@ -4024,6 +4024,46 @@ describe('getStripeInvoicesPage', () => {
     }
   });
 
+  test('returns no cursor on a full final page', async () => {
+    const invoices = [
+      {
+        id: 'in_final',
+        object: 'invoice',
+        number: 'INV-9',
+        status: 'paid',
+        amount_due: 100,
+        currency: 'usd',
+        created: 1000,
+        hosted_invoice_url: null,
+        invoice_pdf: null,
+        lines: { data: [] },
+      },
+    ] as unknown as Stripe.Invoice[];
+
+    try {
+      jest.resetModules();
+      await jest.isolateModulesAsync(async () => {
+        const stripe = await import('@/lib/stripe');
+        const { client } = await import('@/lib/stripe-client');
+
+        const listSpy = jest.spyOn(client.invoices, 'list').mockResolvedValue({
+          data: invoices,
+          has_more: false,
+        } as unknown as Awaited<ReturnType<typeof client.invoices.list>>);
+
+        const result = await stripe.getStripeInvoicesPage('cus_page_test');
+
+        expect(result.hasMore).toBe(false);
+        expect(result.entries).toHaveLength(1);
+        expect(result.nextCursor).toBeNull();
+
+        listSpy.mockRestore();
+      });
+    } finally {
+      jest.resetModules();
+    }
+  });
+
   test('passes starting_after and date threshold through to Stripe', async () => {
     try {
       jest.resetModules();

--- a/apps/web/src/lib/stripe/index.test.ts
+++ b/apps/web/src/lib/stripe/index.test.ts
@@ -62,7 +62,6 @@ import {
   processStripePaymentEventHook,
   handleSuccessfulChargeWithPayment,
   isCardFingerprintEligibleForFreeCredits,
-  getStripeInvoicesPage,
 } from '@/lib/stripe';
 import {
   type User,
@@ -3971,8 +3970,6 @@ describe('handleSuccessfulChargeWithPayment (org/user routing & side-effects)', 
 
 describe('getStripeInvoicesPage', () => {
   test('returns hasMore, entries, and nextCursor from the last invoice', async () => {
-    const { client } = await import('@/lib/stripe-client');
-
     const invoices = [
       {
         id: 'in_page_1',
@@ -4000,46 +3997,64 @@ describe('getStripeInvoicesPage', () => {
       },
     ] as unknown as Stripe.Invoice[];
 
-    const listSpy = jest.spyOn(client.invoices, 'list').mockResolvedValue({
-      data: invoices,
-      has_more: true,
-    } as unknown as Awaited<ReturnType<typeof client.invoices.list>>);
+    try {
+      jest.resetModules();
+      await jest.isolateModulesAsync(async () => {
+        const stripe = await import('@/lib/stripe');
+        const { client } = await import('@/lib/stripe-client');
 
-    const result = await getStripeInvoicesPage('cus_page_test');
+        const listSpy = jest.spyOn(client.invoices, 'list').mockResolvedValue({
+          data: invoices,
+          has_more: true,
+        } as unknown as Awaited<ReturnType<typeof client.invoices.list>>);
 
-    expect(listSpy).toHaveBeenCalledWith(
-      expect.objectContaining({ customer: 'cus_page_test', limit: 25 })
-    );
-    expect(result.hasMore).toBe(true);
-    expect(result.entries).toHaveLength(2);
-    expect(result.nextCursor).toBe('in_page_2');
+        const result = await stripe.getStripeInvoicesPage('cus_page_test');
 
-    listSpy.mockRestore();
+        expect(listSpy).toHaveBeenCalledWith(
+          expect.objectContaining({ customer: 'cus_page_test', limit: 25 })
+        );
+        expect(result.hasMore).toBe(true);
+        expect(result.entries).toHaveLength(2);
+        expect(result.nextCursor).toBe('in_page_2');
+
+        listSpy.mockRestore();
+      });
+    } finally {
+      jest.resetModules();
+    }
   });
 
   test('passes starting_after and date threshold through to Stripe', async () => {
-    const { client } = await import('@/lib/stripe-client');
+    try {
+      jest.resetModules();
+      await jest.isolateModulesAsync(async () => {
+        const stripe = await import('@/lib/stripe');
+        const { client } = await import('@/lib/stripe-client');
 
-    const listSpy = jest.spyOn(client.invoices, 'list').mockResolvedValue({
-      data: [],
-      has_more: false,
-    } as unknown as Awaited<ReturnType<typeof client.invoices.list>>);
+        const listSpy = jest.spyOn(client.invoices, 'list').mockResolvedValue({
+          data: [],
+          has_more: false,
+        } as unknown as Awaited<ReturnType<typeof client.invoices.list>>);
 
-    const threshold = new Date('2026-01-01T00:00:00.000Z');
-    const result = await getStripeInvoicesPage('cus_page_test', threshold, 'in_cursor');
+        const threshold = new Date('2026-01-01T00:00:00.000Z');
+        const result = await stripe.getStripeInvoicesPage('cus_page_test', threshold, 'in_cursor');
 
-    expect(listSpy).toHaveBeenCalledWith(
-      expect.objectContaining({
-        customer: 'cus_page_test',
-        limit: 25,
-        starting_after: 'in_cursor',
-        created: { gte: Math.floor(threshold.getTime() / 1000) },
-      })
-    );
-    expect(result.hasMore).toBe(false);
-    expect(result.entries).toEqual([]);
-    expect(result.nextCursor).toBeNull();
+        expect(listSpy).toHaveBeenCalledWith(
+          expect.objectContaining({
+            customer: 'cus_page_test',
+            limit: 25,
+            starting_after: 'in_cursor',
+            created: { gte: Math.floor(threshold.getTime() / 1000) },
+          })
+        );
+        expect(result.hasMore).toBe(false);
+        expect(result.entries).toEqual([]);
+        expect(result.nextCursor).toBeNull();
 
-    listSpy.mockRestore();
+        listSpy.mockRestore();
+      });
+    } finally {
+      jest.resetModules();
+    }
   });
 });

--- a/apps/web/src/lib/stripe/index.ts
+++ b/apps/web/src/lib/stripe/index.ts
@@ -676,32 +676,7 @@ export async function getStripeInvoices(
   const invoices = await client.invoices.list(listParams);
   const invoiceData: Stripe.Invoice[] = invoices.data;
 
-  return invoiceData.map(invoice => {
-    // Classify as 'seats' if any line item has seats metadata or a known paid seat price ID
-    const isSeatInvoice =
-      invoice.lines?.data?.some(line => {
-        const hasSeatsMetadata =
-          line.metadata != null && Object.prototype.hasOwnProperty.call(line.metadata, 'seats');
-        const priceId = line.pricing?.price_details?.price;
-        const hasSeatPriceId = priceId != null && KNOWN_SEAT_PRICE_IDS.has(priceId);
-        return hasSeatsMetadata || hasSeatPriceId;
-      }) ?? false;
-
-    const firstLineDescription = invoice.lines?.data?.[0]?.description || null;
-
-    return {
-      id: invoice.id || '',
-      number: invoice.number,
-      status: invoice.status || 'unknown',
-      amount_due: invoice.amount_due || 0,
-      currency: invoice.currency || 'usd',
-      created: invoice.created || 0,
-      hosted_invoice_url: invoice.hosted_invoice_url || null,
-      invoice_pdf: invoice.invoice_pdf || null,
-      invoice_type: isSeatInvoice ? 'seats' : 'topup',
-      description: firstLineDescription,
-    };
-  });
+  return mapStripeInvoicesToUnified(invoiceData);
 }
 
 function mapStripeInvoicesToUnified(invoices: Stripe.Invoice[]): UnifiedInvoice[] {

--- a/apps/web/src/lib/stripe/index.ts
+++ b/apps/web/src/lib/stripe/index.ts
@@ -656,6 +656,7 @@ async function recordKiloclawEarlybirdPurchase(user: User, charge: Stripe.Charge
   }
 }
 
+// old form: array limit 100, no hasMore; remove when every client pages.
 export async function getStripeInvoices(
   stripeCustomerId: string,
   dateThreshold?: Date | null
@@ -701,6 +702,73 @@ export async function getStripeInvoices(
       description: firstLineDescription,
     };
   });
+}
+
+function mapStripeInvoicesToUnified(invoices: Stripe.Invoice[]): UnifiedInvoice[] {
+  return invoices.map(invoice => {
+    // Classify as 'seats' if any line item has seats metadata or a known paid seat price ID
+    const isSeatInvoice =
+      invoice.lines?.data?.some(line => {
+        const hasSeatsMetadata =
+          line.metadata != null && Object.prototype.hasOwnProperty.call(line.metadata, 'seats');
+        const priceId = line.pricing?.price_details?.price;
+        const hasSeatPriceId = priceId != null && KNOWN_SEAT_PRICE_IDS.has(priceId);
+        return hasSeatsMetadata || hasSeatPriceId;
+      }) ?? false;
+
+    const firstLineDescription = invoice.lines?.data?.[0]?.description || null;
+
+    return {
+      id: invoice.id || '',
+      number: invoice.number,
+      status: invoice.status || 'unknown',
+      amount_due: invoice.amount_due || 0,
+      currency: invoice.currency || 'usd',
+      created: invoice.created || 0,
+      hosted_invoice_url: invoice.hosted_invoice_url || null,
+      invoice_pdf: invoice.invoice_pdf || null,
+      invoice_type: isSeatInvoice ? 'seats' : 'topup',
+      description: firstLineDescription,
+    };
+  });
+}
+
+export type StripeInvoicesPage = {
+  entries: UnifiedInvoice[];
+  hasMore: boolean;
+  nextCursor: string | null;
+};
+
+export async function getStripeInvoicesPage(
+  stripeCustomerId: string,
+  dateThreshold?: Date | null,
+  startingAfter?: string | null
+): Promise<StripeInvoicesPage> {
+  const listParams: Stripe.InvoiceListParams = {
+    customer: stripeCustomerId,
+    limit: 25,
+    expand: ['data.payment_intent', 'data.lines.data'],
+  };
+
+  if (dateThreshold) {
+    listParams.created = {
+      gte: Math.floor(dateThreshold.getTime() / 1000), // Convert to Unix timestamp
+    };
+  }
+
+  if (startingAfter) {
+    listParams.starting_after = startingAfter;
+  }
+
+  const invoices = await client.invoices.list(listParams);
+  const entries = mapStripeInvoicesToUnified(invoices.data);
+  const lastInvoice = invoices.data[invoices.data.length - 1];
+
+  return {
+    entries,
+    hasMore: invoices.has_more,
+    nextCursor: lastInvoice ? lastInvoice.id : null,
+  };
 }
 
 async function handlePaymentMethodEvent(

--- a/apps/web/src/lib/stripe/index.ts
+++ b/apps/web/src/lib/stripe/index.ts
@@ -739,10 +739,13 @@ export async function getStripeInvoicesPage(
   const entries = mapStripeInvoicesToUnified(invoices.data);
   const lastInvoice = invoices.data[invoices.data.length - 1];
 
+  // Tie the cursor to Stripe's own continuation signal. A full final page has
+  // a last invoice but no next page, and advertising its id as a cursor makes
+  // the caller fetch an empty page it can never end on.
   return {
     entries,
     hasMore: invoices.has_more,
-    nextCursor: lastInvoice ? lastInvoice.id : null,
+    nextCursor: invoices.has_more ? (lastInvoice?.id ?? null) : null,
   };
 }
 

--- a/apps/web/src/routers/organizations/organization-router.ts
+++ b/apps/web/src/routers/organizations/organization-router.ts
@@ -109,7 +109,7 @@ const OrganizationInvoicesInputSchema = OrganizationIdInputSchema.extend({
 });
 
 const OrganizationTransactionsPageInputSchema = OrganizationIdInputSchema.extend({
-  cursor: z.number().int().min(0).default(0),
+  cursor: z.string().optional(),
 });
 
 const OrganizationInvoicesPageInputSchema = OrganizationInvoicesInputSchema.extend({

--- a/apps/web/src/routers/organizations/organization-router.ts
+++ b/apps/web/src/routers/organizations/organization-router.ts
@@ -31,7 +31,7 @@ import {
 } from '@/lib/organizations/organizations';
 import { getOrCreateStripeCustomerIdForOrganization } from '@/lib/organizations/organization-billing';
 import { resolveEffectiveOrganizationSsoPolicy } from '@/lib/organizations/organization-sso-policy';
-import { getStripeInvoices } from '@/lib/stripe';
+import { getStripeInvoices, getStripeInvoicesPage } from '@/lib/stripe';
 import { adminProcedure, baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import {
   OrganizationIdInputSchema,
@@ -48,7 +48,10 @@ import { organizationsUsageDetailsRouter } from '@/routers/organizations/organiz
 import { TRPCError } from '@trpc/server';
 import { and, asc, count, desc, eq, inArray, isNull, sql } from 'drizzle-orm';
 import * as z from 'zod';
-import { getCreditTransactionsForOrganization } from '@/lib/creditTransactions';
+import {
+  getCreditTransactionsForOrganization,
+  getCreditTransactionsForOrganizationPage,
+} from '@/lib/creditTransactions';
 import { getCreditBlocks } from '@/lib/getCreditBlocks';
 import { processOrganizationExpirations } from '@/lib/creditExpiration';
 import { credit_transactions } from '@kilocode/db/schema';
@@ -103,6 +106,14 @@ const OrganizationOnboardingSummarySchema = z.object({
 
 const OrganizationInvoicesInputSchema = OrganizationIdInputSchema.extend({
   period: TimePeriodSchema.optional().default('month'),
+});
+
+const OrganizationTransactionsPageInputSchema = OrganizationIdInputSchema.extend({
+  cursor: z.number().int().min(0).default(0),
+});
+
+const OrganizationInvoicesPageInputSchema = OrganizationInvoicesInputSchema.extend({
+  cursor: z.string().optional(),
 });
 
 function daysAgo(days: number): Date {
@@ -583,6 +594,15 @@ export const organizationsRouter = createTRPCRouter({
     return await getCreditTransactionsForOrganization(opts.input.organizationId);
   }),
 
+  creditTransactionsPage: organizationMemberProcedure
+    .input(OrganizationTransactionsPageInputSchema)
+    .query(async opts => {
+      return await getCreditTransactionsForOrganizationPage(
+        opts.input.organizationId,
+        opts.input.cursor
+      );
+    }),
+
   getCreditBlocks: organizationMemberProcedure.query(async opts => {
     const now = new Date();
     const organizationId = opts.input.organizationId;
@@ -647,5 +667,26 @@ export const organizationsRouter = createTRPCRouter({
 
       const invoices = await getStripeInvoices(stripeId, dateThreshold);
       return invoices;
+    }),
+
+  invoicesPage: organizationBillingProcedure
+    .input(OrganizationInvoicesPageInputSchema)
+    .query(async opts => {
+      const organization = await getOrganizationById(opts.input.organizationId);
+      if (!organization) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'Organization not found',
+        });
+      }
+
+      const dateThreshold = getDateThreshold(opts.input.period);
+
+      let stripeId = organization.stripe_customer_id;
+      if (!stripeId) {
+        stripeId = await getOrCreateStripeCustomerIdForOrganization(opts.input.organizationId);
+      }
+
+      return await getStripeInvoicesPage(stripeId, dateThreshold, opts.input.cursor);
     }),
 });


### PR DESCRIPTION
## Summary

No new behavior. The two new paginated endpoints are not consumed by any page yet, so a user sees the same organization credit transaction and invoice views as before.

---

## Reviewer Notes

The organization credit transaction query gains a cursor-paginated form, the `CreditTransactionsPage` contract. `getCreditTransactionsForOrganizationPage` returns 25 entries plus a probe ordered newest first, with a `nextCursor`, a `hasMore` flag, and a `CreditSummary` computed by the new `getCreditTransactionsSummaryForOrganization`; both helpers exclude `kpo:consumption:` categories exactly like the old query. The old `getCreditTransactionsForOrganization` array form stays unchanged and is marked `old form`, so existing callers keep working until every client migrates to the page form.

<details>
<summary>Files</summary>

- `apps/web/src/lib/creditTransactions.ts` — exports the `CreditSummary` type; adds `getCreditTransactionsSummaryForOrganization` and `getCreditTransactionsForOrganizationPage`; marks the old `getCreditTransactionsForOrganization` with an `old form` comment.

</details>

The Stripe invoice listing gains a cursor-paginated form, the `StripeInvoicesPage` contract. `getStripeInvoicesPage` lists 25 invoices with an optional `starting_after` cursor, reads `has_more`, and returns a `nextCursor` equal to the last invoice id. The invoice-to-unified mapping is extracted into `mapStripeInvoicesToUnified` and reused by both functions; the old `getStripeInvoices` keeps returning a flat array of up to 100 and is marked `old form`.

<details>
<summary>Files</summary>

- `apps/web/src/lib/stripe/index.ts` — adds the `StripeInvoicesPage` type, the `mapStripeInvoicesToUnified` helper, and `getStripeInvoicesPage`; marks `getStripeInvoices` with an `old form` comment.

</details>

Two new tRPC procedures expose the paginated queries. `organizations.creditTransactionsPage` serves the member role with a defaulted non-negative numeric cursor, and `organizations.invoicesPage` serves the billing role with an optional string cursor, resolving or creating the Stripe customer id first just like the old `invoices` procedure. The existing `creditTransactions` and `invoices` procedures keep their array returns, so no client breaks.

<details>
<summary>Files</summary>

- `apps/web/src/routers/organizations/organization-router.ts` — adds the `OrganizationTransactionsPageInputSchema` and `OrganizationInvoicesPageInputSchema` schemas plus the `creditTransactionsPage` and `invoicesPage` procedures beside their array-returning predecessors.

</details>

Tests: 2 test files changed — `creditTransactions.page.test.ts` (new) and `stripe/index.test.ts` (extended); both DB-backed tests need the test Postgres and run in CI.
Generated: none.

---

## Verification

- [ ] Manual tests not run on this host: the DB-backed tests require the test Postgres (Docker) and run in CI.
- E2E report: none attached. E2E runs once on the tip PR, not per stack level.

Human steps: none. No new environment values, secrets, or migrations.

## Visual Changes

Visual Changes: N/A

---

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Full verification (E2E, user advocacy, simplify, bot review) runs on the tip PR over every level.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `audit-w7b-data-contracts-dffd` — #5460
2. `audit-w7b-data-contracts-dffd-s2` — #5462 ← this PR
3. `audit-w7b-data-contracts-dffd-s3` — #5468
4. `audit-w7b-data-contracts-dffd-s4` — #5472
5. `audit-w7b-data-contracts-dffd-s5` — #5479 (tip)
