### PR TITLE
fix(web): revoke sessions on Apple events and clear share ids

### DIFF
--- a/apps/web/src/app/api/auth/apple-notifications/route.test.ts
+++ b/apps/web/src/app/api/auth/apple-notifications/route.test.ts
@@ -1,0 +1,191 @@
+jest.mock('@sentry/nextjs', () => ({ captureException: jest.fn() }));
+jest.mock('@/lib/auth/apple-jwks', () => ({
+  ...jest.requireActual('@/lib/auth/apple-jwks'),
+  verifyAppleJwtWithJwks: jest.fn(),
+}));
+jest.mock('@/lib/web-session-revocation', () => {
+  const actual = jest.requireActual('@/lib/web-session-revocation');
+  return { ...actual, revokeWebSessions: jest.fn(actual.revokeWebSessions) };
+});
+
+import { NextRequest } from 'next/server';
+import { and, eq } from 'drizzle-orm';
+import type jwt from 'jsonwebtoken';
+import {
+  device_refresh_tokens,
+  device_sessions,
+  kilocode_users,
+  user_auth_provider,
+} from '@kilocode/db/schema';
+import { captureException } from '@sentry/nextjs';
+import { verifyAppleJwtWithJwks } from '@/lib/auth/apple-jwks';
+import { revokeWebSessions } from '@/lib/web-session-revocation';
+import { cleanupDbForTest, db } from '@/lib/drizzle';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { POST } from './route';
+
+const mockVerifyAppleJwtWithJwks = jest.mocked(verifyAppleJwtWithJwks);
+const mockRevokeWebSessions = jest.mocked(revokeWebSessions);
+const mockCaptureException = jest.mocked(captureException);
+
+type AppleEventType = 'consent-revoked' | 'account-delete';
+
+const SUB = 'apple-sub-001';
+
+// The app-wide `jsonwebtoken` augmentation (types/next-auth.d.ts) requires
+// kiloUserId/version on JwtPayload; Apple's payload has neither, so cast fixtures.
+const applePayload = (fields: Record<string, unknown>) => fields as unknown as jwt.JwtPayload;
+
+function applePost() {
+  const formData = new FormData();
+  formData.set('payload', 'fake-apple-jwt');
+  return new NextRequest('http://localhost/api/auth/apple-notifications', {
+    method: 'POST',
+    body: formData,
+  });
+}
+
+async function insertAppleProvider(userId: string, sub: string) {
+  await db.insert(user_auth_provider).values({
+    kilo_user_id: userId,
+    provider: 'apple',
+    provider_account_id: sub,
+    email: 'apple-user@example.com',
+    avatar_url: 'https://example.com/apple-avatar.png',
+  });
+}
+
+async function providerRow(sub: string) {
+  const rows = await db
+    .select()
+    .from(user_auth_provider)
+    .where(
+      and(eq(user_auth_provider.provider, 'apple'), eq(user_auth_provider.provider_account_id, sub))
+    );
+  return rows[0];
+}
+
+async function userWebPepper(userId: string) {
+  const [row] = await db.select().from(kilocode_users).where(eq(kilocode_users.id, userId));
+  return row?.web_session_pepper ?? null;
+}
+
+async function sessionRow(sessionId: string) {
+  const [row] = await db.select().from(device_sessions).where(eq(device_sessions.id, sessionId));
+  return row;
+}
+
+async function refreshTokenRow(tokenHash: string) {
+  const [row] = await db
+    .select()
+    .from(device_refresh_tokens)
+    .where(eq(device_refresh_tokens.token_hash, tokenHash));
+  return row;
+}
+
+describe('POST /api/auth/apple-notifications', () => {
+  beforeEach(async () => {
+    await cleanupDbForTest();
+    jest.clearAllMocks();
+  });
+
+  it.each(['consent-revoked', 'account-delete'] as AppleEventType[])(
+    'revokes provider, web, and device sessions for a %s event',
+    async type => {
+      const user = await insertTestUser({ web_session_pepper: 'old-web-pepper' });
+      const other = await insertTestUser();
+      await insertAppleProvider(user.id, SUB);
+
+      const [session] = await db
+        .insert(device_sessions)
+        .values({ kilo_user_id: user.id, user_agent: 'AppleRevokeTest/1.0' })
+        .returning({ id: device_sessions.id });
+      const [otherSession] = await db
+        .insert(device_sessions)
+        .values({ kilo_user_id: other.id, user_agent: 'AppleRevokeTest/1.0' })
+        .returning({ id: device_sessions.id });
+
+      const tokenHash = 'apple-revoke-token-hash';
+      await db.insert(device_refresh_tokens).values({
+        token_hash: tokenHash,
+        device_session_id: session.id,
+        expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+      });
+      const consumedTokenHash = 'apple-revoke-consumed-token-hash';
+      await db.insert(device_refresh_tokens).values({
+        token_hash: consumedTokenHash,
+        device_session_id: session.id,
+        expires_at: new Date(Date.now() + 30 * 24 * 60 * 60 * 1000).toISOString(),
+        consumed_at: new Date().toISOString(),
+      });
+
+      mockVerifyAppleJwtWithJwks.mockResolvedValue(
+        applePayload({ events: JSON.stringify({ type, sub: SUB, event_time: 1_700_000_000 }) })
+      );
+
+      const response = await POST(applePost());
+
+      expect(response.status).toBe(200);
+
+      expect(await providerRow(SUB)).toBeUndefined();
+
+      const webPepper = await userWebPepper(user.id);
+      expect(webPepper).toEqual(expect.any(String));
+      expect(webPepper).not.toBe('old-web-pepper');
+
+      const revoked = await sessionRow(session.id);
+      expect(revoked?.revoked_at).not.toBeNull();
+      expect(revoked?.revoked_reason).toBe('apple_provider_revoked');
+
+      expect(await refreshTokenRow(tokenHash)).toBeUndefined();
+      expect(await refreshTokenRow(consumedTokenHash)).toBeDefined();
+
+      const untouched = await sessionRow(otherSession.id);
+      expect(untouched?.revoked_at).toBeNull();
+    }
+  );
+
+  it('treats an unknown sub as a no-op', async () => {
+    const user = await insertTestUser();
+    await insertAppleProvider(user.id, 'apple-sub-other');
+
+    mockVerifyAppleJwtWithJwks.mockResolvedValue(
+      applePayload({
+        events: JSON.stringify({ type: 'consent-revoked', sub: SUB, event_time: 1_700_000_000 }),
+      })
+    );
+
+    const response = await POST(applePost());
+
+    expect(response.status).toBe(200);
+    expect(await providerRow('apple-sub-other')).toBeDefined();
+    expect(mockRevokeWebSessions).not.toHaveBeenCalled();
+    expect(mockCaptureException).not.toHaveBeenCalled();
+  });
+
+  it('rolls back the provider delete and session revocation when a later statement throws', async () => {
+    const user = await insertTestUser({ web_session_pepper: 'old-web-pepper' });
+    await insertAppleProvider(user.id, SUB);
+
+    const [session] = await db
+      .insert(device_sessions)
+      .values({ kilo_user_id: user.id, user_agent: 'AppleRollbackTest/1.0' })
+      .returning({ id: device_sessions.id });
+
+    mockVerifyAppleJwtWithJwks.mockResolvedValue(
+      applePayload({
+        events: JSON.stringify({ type: 'account-delete', sub: SUB, event_time: 1_700_000_000 }),
+      })
+    );
+    mockRevokeWebSessions.mockRejectedValueOnce(new Error('boom'));
+
+    const response = await POST(applePost());
+
+    expect(response.status).toBe(500);
+    expect(mockCaptureException).toHaveBeenCalled();
+
+    expect(await providerRow(SUB)).toBeDefined();
+    expect(await userWebPepper(user.id)).toBe('old-web-pepper');
+    expect((await sessionRow(session.id))?.revoked_at).toBeNull();
+  });
+});

--- a/apps/web/src/app/api/auth/apple-notifications/route.ts
+++ b/apps/web/src/app/api/auth/apple-notifications/route.ts
@@ -1,12 +1,13 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { db } from '@/lib/drizzle';
-import { user_auth_provider } from '@kilocode/db/schema';
-import { and, eq } from 'drizzle-orm';
+import { device_refresh_tokens, device_sessions, user_auth_provider } from '@kilocode/db/schema';
+import { and, eq, inArray, isNull } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 import { logExceptInTest } from '@/lib/utils.server';
 import { APPLE_CLIENT_ID } from '@/lib/config.server';
 import { AppleJwtClientError, verifyAppleJwtWithJwks } from '@/lib/auth/apple-jwks';
+import { revokeWebSessions } from '@/lib/web-session-revocation';
 
 type AppleEvent = {
   type: 'consent-revoked' | 'account-delete' | 'email-disabled' | 'email-enabled';
@@ -31,14 +32,47 @@ async function handleAppleEvent(event: AppleEvent): Promise<void> {
   logExceptInTest(`Apple auth event: ${type} for sub=${sub}`);
 
   if (type === 'consent-revoked' || type === 'account-delete') {
-    await db
-      .delete(user_auth_provider)
-      .where(
-        and(
-          eq(user_auth_provider.provider, 'apple'),
-          eq(user_auth_provider.provider_account_id, sub)
+    // Compatibility: the old handler deleted the provider row only. Keep the
+    // extra web/device revocation until Apple stops sending these events.
+    await db.transaction(async tx => {
+      const deletedProviders = await tx
+        .delete(user_auth_provider)
+        .where(
+          and(
+            eq(user_auth_provider.provider, 'apple'),
+            eq(user_auth_provider.provider_account_id, sub)
+          )
         )
-      );
+        .returning({ kilo_user_id: user_auth_provider.kilo_user_id });
+      if (deletedProviders.length === 0) return;
+
+      const now = new Date().toISOString();
+      for (const { kilo_user_id } of deletedProviders) {
+        await revokeWebSessions(kilo_user_id, tx);
+
+        await tx
+          .update(device_sessions)
+          .set({ revoked_at: now, revoked_reason: 'apple_provider_revoked' })
+          .where(
+            and(eq(device_sessions.kilo_user_id, kilo_user_id), isNull(device_sessions.revoked_at))
+          );
+
+        await tx
+          .delete(device_refresh_tokens)
+          .where(
+            and(
+              inArray(
+                device_refresh_tokens.device_session_id,
+                tx
+                  .select({ id: device_sessions.id })
+                  .from(device_sessions)
+                  .where(eq(device_sessions.kilo_user_id, kilo_user_id))
+              ),
+              isNull(device_refresh_tokens.consumed_at)
+            )
+          );
+      }
+    });
     logExceptInTest(`Removed apple auth provider for sub=${sub} (${type})`);
   }
   // email-disabled and email-enabled are informational — no action needed

--- a/apps/web/src/lib/user/deletion-queue/handlers/cli-v2.test.ts
+++ b/apps/web/src/lib/user/deletion-queue/handlers/cli-v2.test.ts
@@ -116,6 +116,66 @@ describe('handleCliV2Sessions', () => {
     expect(maxInFlight).toBe(3);
   });
 
+  it('nulls public_id before the ingest DELETE is sent', async () => {
+    const user = await insertTestUser();
+    const sessionId = newSessionId('pub');
+    await insertSession(user.id, sessionId, undefined, '00000000-0000-4000-8000-000000000001');
+
+    let publicIdAtDelete: string | null | undefined = 'unset';
+    jest.spyOn(globalThis, 'fetch').mockImplementation(async input => {
+      const sid = sessionIdFromUrl(input);
+      publicIdAtDelete = await publicIdFor(user.id, sid);
+      await deleteSessionRow(user.id, sid);
+      return new Response(JSON.stringify({ success: true }), { status: 200 });
+    });
+
+    const outcome = await handleCliV2Sessions({
+      request: { user_id: user.id } as UserDeletionRequest,
+      step: runningStep(),
+      context: handlerContext(),
+    });
+
+    expect(outcome).toEqual({ kind: 'succeeded', progress: { processed_count: 1 } });
+    expect(publicIdAtDelete).toBeNull();
+  });
+
+  it('leaves public_id null when the ingest DELETE fails', async () => {
+    const user = await insertTestUser();
+    const sessionId = newSessionId('failpub');
+    await insertSession(user.id, sessionId, undefined, '00000000-0000-4000-8000-000000000002');
+
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('unavailable', { status: 500 }));
+
+    const outcome = await handleCliV2Sessions({
+      request: { user_id: user.id } as UserDeletionRequest,
+      step: runningStep(),
+      context: handlerContext(),
+    });
+
+    expect(outcome.kind).toBe('retry');
+    expect(await publicIdFor(user.id, sessionId)).toBeNull();
+  });
+
+  it('does not null public_id on a session owned by another user', async () => {
+    const user = await insertTestUser();
+    const other = await insertTestUser();
+    const targetId = newSessionId('targetpub');
+    const otherId = newSessionId('otherpub');
+    await insertSession(user.id, targetId, undefined, '00000000-0000-4000-8000-000000000003');
+    await insertSession(other.id, otherId, undefined, '00000000-0000-4000-8000-000000000004');
+
+    mockIngestDelete(user.id);
+
+    const outcome = await handleCliV2Sessions({
+      request: { user_id: user.id } as UserDeletionRequest,
+      step: runningStep(),
+      context: handlerContext(),
+    });
+
+    expect(outcome).toEqual({ kind: 'succeeded', progress: { processed_count: 1 } });
+    expect(await publicIdFor(other.id, otherId)).toBe('00000000-0000-4000-8000-000000000004');
+  });
+
   it('continues after a 409 without dropping already-deleted siblings', async () => {
     const user = await insertTestUser();
     const keepId = newSessionId('keep');
@@ -259,11 +319,17 @@ function newSessionId(label: string): string {
   return `ses_${label}${crypto.randomUUID().replaceAll('-', '')}`.slice(0, 30);
 }
 
-async function insertSession(userId: string, sessionId: string, parentSessionId?: string) {
+async function insertSession(
+  userId: string,
+  sessionId: string,
+  parentSessionId?: string,
+  publicId?: string
+) {
   await db.insert(cli_sessions_v2).values({
     session_id: sessionId,
     kilo_user_id: userId,
     parent_session_id: parentSessionId,
+    public_id: publicId,
     created_on_platform: 'cli',
   });
 }
@@ -282,6 +348,16 @@ async function remainingSessionIds(userId: string): Promise<string[]> {
     .from(cli_sessions_v2)
     .where(eq(cli_sessions_v2.kilo_user_id, userId));
   return rows.map(row => row.session_id).sort();
+}
+
+async function publicIdFor(userId: string, sessionId: string): Promise<string | null> {
+  const rows = await db
+    .select({ public_id: cli_sessions_v2.public_id })
+    .from(cli_sessions_v2)
+    .where(
+      and(eq(cli_sessions_v2.kilo_user_id, userId), eq(cli_sessions_v2.session_id, sessionId))
+    );
+  return rows[0]?.public_id ?? null;
 }
 
 function sessionIdFromUrl(input: RequestInfo | URL): string {

--- a/apps/web/src/lib/user/deletion-queue/handlers/cli-v2.ts
+++ b/apps/web/src/lib/user/deletion-queue/handlers/cli-v2.ts
@@ -81,6 +81,15 @@ async function deleteLeafSession(
   userId: string,
   sessionId: string
 ): Promise<LeafDeleteResult> {
+  // Compatibility: the old path DELETEd first. Keep the null-first order so
+  // share URLs die even if the later DELETE fails.
+  await db
+    .update(cli_sessions_v2)
+    .set({ public_id: null })
+    .where(
+      and(eq(cli_sessions_v2.kilo_user_id, userId), eq(cli_sessions_v2.session_id, sessionId))
+    );
+
   const url = `${SESSION_INGEST_WORKER_URL}/api/session/${encodeURIComponent(sessionId)}`;
   const result = await deletionFetch(context, url, {
     method: 'DELETE',


### PR DESCRIPTION
## Summary

When Apple reports a revoked or deleted Sign in with Apple account, the app now signs that person out of all their web and device sessions in one step.

When a shared session is deleted, its share link stops working before the deletion finishes, so the link stays dead even if the deletion fails.

---

The Apple notifications endpoint treats a consent-revoked or account-delete event as one transaction: it deletes the Apple provider row, then revokes the user's web sessions, active device sessions, and unconsumed device refresh tokens. If any statement throws, the whole transaction rolls back, so a half-revoked account cannot be left. Active device sessions now store the new revoked_reason value `apple_provider_revoked`; sessions the user does not own, and the informational email-disabled and email-enabled events, stay unchanged.

<details>
<summary>Files</summary>

- `apps/web/src/app/api/auth/apple-notifications/route.ts` — wraps the provider delete in one transaction; returns the deleted rows, revokes web sessions, sets the device session revoke reason, and deletes unconsumed refresh tokens per user.

</details>

The deletion-queue session handler nulls the CLI session's public_id column before it sends the external session DELETE, so a share link dies first. A failed DELETE still leaves the share link dead, and a retry stays safe because the null is scoped to one user and one session. Sessions owned by other users keep their public_id unchanged.

<details>
<summary>Files</summary>

- `apps/web/src/lib/user/deletion-queue/handlers/cli-v2.ts` — nulls the session public_id before the external session DELETE.

</details>

Tests: 2 test files changed — one new Apple notifications route test and one extended deletion-queue handler test.
Generated: none.

---

## Verification

- No manual test paths were run for this level.
- E2E: bot-e2e — runtime verification runs on the tip PR, not this level.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

- Human steps: none known — no new environment value, secret, migration, flag, or deploy order is required.
- E2E: bot-e2e — runtime verification runs on the tip PR, not this level.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Full verification (E2E, user advocacy, simplify, bot review) runs on the tip PR over every level.
A review comment on a lower PR is answered on the tip. A red check on a level is repaired on that level.

1. `audit-w7c-privacy-security-9cac` — #5458
2. `audit-w7c-privacy-security-9cac-s2` — #5461
3. `audit-w7c-privacy-security-9cac-s3` — #5464
4. `audit-w7c-privacy-security-9cac-s4` — #5466
5. `audit-w7c-privacy-security-9cac-s5` — #5469
6. `audit-w7c-privacy-security-9cac-s6` — #5470 ← this PR
7. `audit-w7c-privacy-security-9cac-s7` — #5471 (tip)
