### PR TITLE
fix(mobile): make app.config.ts resolve the languages import

### DIFF
--- a/.github/workflows/kilo-app-ci.yml
+++ b/.github/workflows/kilo-app-ci.yml
@@ -65,6 +65,11 @@ jobs:
       - name: Typecheck
         run: pnpm --filter kilo-app run typecheck
 
+      # The release preflight is the only other job that evaluates app.config.ts,
+      # and it runs nightly. Read the config here so a broken import fails the PR.
+      - name: Read Expo config
+        run: pnpm --filter kilo-app exec expo config --type public > /dev/null
+
   lint:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 15

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -1,6 +1,6 @@
 import type { ExpoConfig } from 'expo/config';
 import { ENV_KEYS, OPTIONAL_ENV_KEYS } from './src/lib/env-keys';
-import { SUPPORTED_LANGUAGES } from './src/i18n/languages';
+import { SUPPORTED_LANGUAGES } from './src/i18n/languages.ts';
 import { SENTRY_NATIVE_OPTIONS } from './src/lib/sentry-dsn';
 import { UNIVERSAL_LINK_PATH_PATTERNS } from './src/lib/universal-link-paths';
 import {

--- a/apps/mobile/tsconfig.json
+++ b/apps/mobile/tsconfig.json
@@ -2,6 +2,9 @@
   "extends": "expo/tsconfig.base",
   "compilerOptions": {
     "strict": true,
+    // app.config.ts imports src/i18n/languages.ts with its extension: the Expo
+    // config loader resolves require('./x.ts') but not the extensionless form.
+    "allowImportingTsExtensions": true,
     "noUncheckedIndexedAccess": true,
     "paths": {
       "@/*": ["./src/*"],


### PR DESCRIPTION
## Summary

- The mobile app config could not be read. Every local mobile prebuild failed, and the nightly release preflight failed with it.
- The config now reads. A CI job checks it on every pull request, so the same break cannot reach `main` again.

---

## Symptom

`expo config` failed on `main`:

```
Error: Error reading Expo config at apps/mobile/app.config.ts:
Cannot find module './src/i18n/languages'
```

That failure blocked two things:

- Every local mobile prebuild, and with it the local E2E gate (see [#5463 report](https://github.com/Kilo-Org/cloud/pull/5463#issuecomment-5404982735)).
- The nightly `kilo-app Release` preflight, which fails at "Verify EAS production environment" because `eas-cli` spawns `expo config --json` ([run 32816122305](https://github.com/Kilo-Org/cloud/actions/runs/32816122305/job/97704718081)).

## Cause

The Expo config loader transpiles `app.config.ts` and hands the result to Node. Node 24 resolves `require('./x.ts')` but not the extensionless `require('./x')`, and the transpiler keeps the specifier as written.

Every other `app.config.ts` import already points at a hand-written `.js` sibling — `env-keys.js`, `sentry-dsn.js`, `url-contract.js`, `universal-link-paths.js`. The `languages` import added by #5444 is the only one without one.

## Fix

Import the module with its extension, and allow the extension in the app's tsconfig.

The alternative was a `languages.js` sibling holding the tag list. It widens `SUPPORTED_LANGUAGES` from a readonly tuple to `string[]`, which erases the `SupportedLanguage` union that `catalogs.ts`, `resolve-language.ts`, `language-rows.ts`, `rtl.ts`, `apply-language.ts`, `use-language-preference.ts`, and two tests depend on.

<details>
<summary>Files</summary>

- `apps/mobile/app.config.ts` — import `./src/i18n/languages.ts` with its extension.
- `apps/mobile/tsconfig.json` — `allowImportingTsExtensions`, with the reason inline.

</details>

## Guard

`assert:config` already evaluates the config, but it runs only in the nightly release workflow and needs the EAS production environment. No pull-request job read the config, so a broken import reached `main` twice (#5444, and the earlier break #5454 repaired). The `typecheck` job in `kilo-app CI` now reads the config. Missing environment variables only warn under `GITHUB_ACTIONS`, so the step needs no secret.

<details>
<summary>Files</summary>

- `.github/workflows/kilo-app-ci.yml` — read the Expo config in the `typecheck` job.

</details>

Tests: none changed.
Generated: none.

---

## Verification

Run from `apps/mobile` on this branch:

| Check | Result |
|---|---|
| `npx expo config --type public` | exit 0 |
| `pnpm typecheck` | exit 0 |
| `pnpm test` | 568 files, 5894 tests passed |
| `pnpm format:check` | exit 0 |

The guard was proven against the defect: with the two source changes stashed, `pnpm --filter kilo-app exec expo config --type public` exits 1; with them applied it exits 0.

## Visual Changes

Visual Changes: N/A — build configuration only.

## Human Steps

- After merge, rerun `kilo-app Release` to confirm the preflight passes, or wait for the next scheduled run.

## Reviewer Notes

- The tsconfig relaxation is typecheck-only and scoped to `apps/mobile`. Metro never bundles `app.config.ts`, and no bundled source uses a `.ts` import specifier.
