### PR TITLE
fix(mobile): send the device locale on KiloClaw onboarding push registration

### DIFF
--- a/apps/mobile/src/components/kiloclaw/onboarding/notifications-step.mounted.test.tsx
+++ b/apps/mobile/src/components/kiloclaw/onboarding/notifications-step.mounted.test.tsx
@@ -1,0 +1,85 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer for RN trees under vitest (node env, no jsdom). */
+
+// Push-registration payload contract for the KiloClaw onboarding step: the
+// row it writes must carry the active language and the app version. A null
+// locale sends English push copy, and a null app_version drops the Android
+// channel id, so omitting either field breaks a device enrolled from here.
+
+import { createElement } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NotificationsStep } from './notifications-step';
+import { renderWithProviders, waitFor } from '@/test/render-with-providers';
+
+const registerTokenMutationFn = vi.hoisted(() => vi.fn());
+const getNotificationPermissionStatus = vi.hoisted(() => vi.fn());
+const registerForPushNotifications = vi.hoisted(() => vi.fn());
+const getResolvedLanguage = vi.hoisted(() => vi.fn());
+
+// One stable `t` and one stable result object: the step's
+// `completeRegistration` callback depends on `t`, so a fresh function per
+// render would re-fire the mount effect forever.
+const translation = { t: (key: string) => key };
+vi.mock('react-i18next', () => ({ useTranslation: () => translation }));
+vi.mock('react-native', () => ({
+  View: 'View',
+  ScrollView: 'ScrollView',
+  ActivityIndicator: 'ActivityIndicator',
+  Alert: { alert: vi.fn() },
+  Linking: { openSettings: vi.fn() },
+}));
+vi.mock('expo-secure-store', () => ({ setItemAsync: vi.fn() }));
+vi.mock('expo-application', () => ({ nativeApplicationVersion: '1.0.5' }));
+vi.mock('@/components/ui/button', () => ({ Button: 'Button' }));
+vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
+vi.mock('@/components/ui/directional-icons', () => ({ DirectionalChevronRight: () => null }));
+vi.mock('@/components/kiloclaw/bot-avatar', () => ({ BotAvatar: () => null }));
+vi.mock('@/lib/hooks/use-app-lifecycle', () => ({ useAppLifecycle: () => ({ isActive: true }) }));
+vi.mock('@/lib/hooks/use-theme-colors', () => ({
+  useThemeColors: () => ({
+    foreground: '#000000',
+    mutedForeground: '#666666',
+    primaryForeground: '#ffffff',
+  }),
+}));
+vi.mock('@/lib/hooks/use-language-preference', () => ({ getResolvedLanguage }));
+vi.mock('@/lib/notifications', () => ({
+  getNotificationPermissionStatus,
+  getPlatform: () => 'android',
+  registerForPushNotifications,
+}));
+vi.mock('@/lib/trpc', () => ({
+  useTRPC: () => ({
+    user: {
+      registerPushToken: {
+        mutationOptions: () => ({ mutationFn: registerTokenMutationFn }),
+      },
+    },
+  }),
+}));
+
+describe('NotificationsStep push registration', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getNotificationPermissionStatus.mockResolvedValue('granted');
+    registerForPushNotifications.mockResolvedValue('push-1');
+    getResolvedLanguage.mockReturnValue('de');
+    registerTokenMutationFn.mockResolvedValue({ success: true });
+  });
+
+  it('registers the token with the active locale and the app version', async () => {
+    await renderWithProviders(
+      createElement(NotificationsStep, { onComplete: vi.fn<() => void>(), botIdentity: null })
+    );
+
+    // The harness `waitFor` takes a boolean predicate, not an assertion.
+    await waitFor(() => registerTokenMutationFn.mock.calls.length > 0);
+    // TanStack Query passes a context object after the variables.
+    expect(registerTokenMutationFn.mock.calls[0]?.[0]).toEqual({
+      token: 'push-1',
+      platform: 'android',
+      appVersion: '1.0.5',
+      locale: 'de',
+    });
+  });
+});

--- a/apps/mobile/src/components/kiloclaw/onboarding/notifications-step.tsx
+++ b/apps/mobile/src/components/kiloclaw/onboarding/notifications-step.tsx
@@ -1,3 +1,4 @@
+import * as Application from 'expo-application';
 import * as SecureStore from 'expo-secure-store';
 import { DirectionalChevronRight } from '@/components/ui/directional-icons';
 import { useCallback, useEffect, useState } from 'react';
@@ -9,6 +10,7 @@ import { Button } from '@/components/ui/button';
 import { BotAvatar } from '@/components/kiloclaw/bot-avatar';
 import { Text } from '@/components/ui/text';
 import { useAppLifecycle } from '@/lib/hooks/use-app-lifecycle';
+import { getResolvedLanguage } from '@/lib/hooks/use-language-preference';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import {
   getNotificationPermissionStatus,
@@ -60,7 +62,16 @@ export function NotificationsStep({ onComplete, botIdentity }: Readonly<Notifica
           return;
         }
         if (token) {
-          await registerTokenMutateAsync({ token, platform: getPlatform() });
+          await registerTokenMutateAsync({
+            token,
+            platform: getPlatform(),
+            // Both fields are read per token when a push is sent: a null
+            // locale sends English copy, and a null app_version drops the
+            // Android channel id. Omitting them here writes nulls over the
+            // values an earlier registration stored.
+            appVersion: Application.nativeApplicationVersion ?? undefined,
+            locale: getResolvedLanguage(),
+          });
           if (isCancelled()) {
             return;
           }

--- a/apps/mobile/vitest.pure.config.ts
+++ b/apps/mobile/vitest.pure.config.ts
@@ -38,7 +38,9 @@ export default defineProject({
       'src/lib/voice-input/**/*.test.ts',
       'src/components/**/*.test.ts',
       'src/components/pr-review/**/*.test.tsx',
-      'src/components/kiloclaw/**/*.test.tsx',
+      // `!(*.mounted)` keeps `*.mounted.test.tsx` in the mounted project only:
+      // this directory holds both kinds, and a file in both projects runs twice.
+      'src/components/kiloclaw/**/!(*.mounted).test.tsx',
       'src/lib/telemetry/**/*.test.ts',
     ],
   },


### PR DESCRIPTION
## What

A language change already updates the notification locale for that device: `applyLanguagePreference` → `preferences-screen`'s `onApplied` → `attemptPushRegistrationReconciliation`, which re-registers the device token with `locale` when the server row holds a stale value (shipped in #5444). One path still dropped it.

`kiloclaw/onboarding/notifications-step.tsx` called `registerPushToken` with `{ token, platform }` only. The mutation upserts on the token, so it wrote `locale: null` and `app_version: null` over whatever an earlier registration stored. `NotificationChannelDO` reads both per token: a null locale sends English copy, and a null `app_version` drops the Android channel id.

## Change

- Send `locale: getResolvedLanguage()` and `appVersion` from the onboarding step, like the Notifications screen and the reconciliation path do.
- Add `notifications-step.mounted.test.tsx`: it mounts the step with the permission granted and asserts the registration payload. It fails when either field is removed.

## Test

```
pnpm --filter kilo-app vitest run src/components/kiloclaw/onboarding/ src/lib/auth/push-registration-reconciliation.test.ts src/components/notifications-screen.mounted.test.tsx
```

5 files, 39 tests pass. `pnpm lint` and `pnpm typecheck` pass for `apps/mobile`.