### PR TITLE
fix(mobile,extension): use the real cloud agent prompt cap

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
@@ -1,3 +1,4 @@
+import { CLOUD_AGENT_PROMPT_MAX_LENGTH } from '@kilocode/cloud-agent-sdk/limits';
 import { describe, expect, it, vi } from 'vitest';
 
 import {
@@ -73,8 +74,8 @@ describe('constants', () => {
     expect(PROMPT_MIN_LENGTH).toBe(3);
   });
 
-  it('promptMaxLength is 4000', () => {
-    expect(PROMPT_MAX_LENGTH).toBe(4000);
+  it('promptMaxLength is the shared cloud agent prompt cap', () => {
+    expect(PROMPT_MAX_LENGTH).toBe(CLOUD_AGENT_PROMPT_MAX_LENGTH);
   });
 
   it('mode is "code"', () => {

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
@@ -32,6 +32,7 @@ import { fetchModelPreferences } from '@/src/shared/model-preferences-client';
 import { isGatewayModelId } from '@/src/shared/model-picker-rows';
 import { getModelPreferencesQueryKey } from '@/src/shared/side-panel-query-options';
 import { thinkingEffortLabel } from '@/src/shared/kilo-api-client';
+import { CLOUD_AGENT_PROMPT_MAX_LENGTH } from '@kilocode/cloud-agent-sdk/limits';
 import type { KiloGatewayModelOption } from '@/src/shared/kilo-api-client';
 import { useExtensionAgents } from './agents-provider';
 import { activeSessionsQueryKey, sessionHistoryQueryKey } from './agents-session-list';
@@ -43,7 +44,7 @@ import { useGatewayModels } from './use-gateway-models';
 // ---------------------------------------------------------------------------
 
 const PROMPT_MIN_LENGTH = 3;
-const PROMPT_MAX_LENGTH = 4000;
+const PROMPT_MAX_LENGTH = CLOUD_AGENT_PROMPT_MAX_LENGTH;
 const MODE = 'code' as const;
 
 /**

--- a/apps/mobile/src/components/agents/chat-composer-input-row.tsx
+++ b/apps/mobile/src/components/agents/chat-composer-input-row.tsx
@@ -1,4 +1,5 @@
 import { ArrowUp, Paperclip, Square } from '@/components/ui/icons';
+import { CLOUD_AGENT_PROMPT_MAX_LENGTH } from '@kilocode/cloud-agent-sdk/limits';
 import { type RefObject } from 'react';
 import { useTranslation } from 'react-i18next';
 import {
@@ -119,7 +120,7 @@ export function ChatComposerInputRow({
           placeholder={placeholder}
           placeholderTextColor={colors.mutedForeground}
           multiline
-          maxLength={4000}
+          maxLength={CLOUD_AGENT_PROMPT_MAX_LENGTH}
           onChangeText={onChangeText}
           onFocus={onInputFocus}
           onBlur={onInputBlur}

--- a/apps/mobile/src/components/agents/chat-composer.tsx
+++ b/apps/mobile/src/components/agents/chat-composer.tsx
@@ -6,6 +6,7 @@
 import * as Haptics from 'expo-haptics';
 import { useActionSheet } from '@expo/react-native-action-sheet';
 import { type SlashCommandInfo } from '@kilocode/cloud-agent-sdk';
+import { CLOUD_AGENT_PROMPT_MAX_LENGTH } from '@kilocode/cloud-agent-sdk/limits';
 import { type RemoteCommandState } from '@kilocode/cloud-agent-sdk/remote-command-catalog';
 import {
   type Ref,
@@ -474,7 +475,7 @@ export function ChatComposer({
   useSharePrefill({
     shareId,
     inputRef,
-    maxLength: 4000,
+    maxLength: CLOUD_AGENT_PROMPT_MAX_LENGTH,
     onChangeText: handleChangeText,
     addCandidates,
     onDelivered: () => {
@@ -500,7 +501,7 @@ export function ChatComposer({
       applyVoiceDraftToInput({
         input: inputRef.current,
         draft,
-        maxLength: 4000,
+        maxLength: CLOUD_AGENT_PROMPT_MAX_LENGTH,
         onChangeText: handleChangeText,
       });
     },
@@ -537,7 +538,7 @@ export function ChatComposer({
         input: inputRef.current,
         draft: textRef.current,
         selection: selectionRef.current,
-        maxLength: 4000,
+        maxLength: CLOUD_AGENT_PROMPT_MAX_LENGTH,
         onChangeText: handleChangeText,
       });
     },

--- a/apps/mobile/src/components/agents/new-session-prompt.tsx
+++ b/apps/mobile/src/components/agents/new-session-prompt.tsx
@@ -1,3 +1,4 @@
+import { CLOUD_AGENT_PROMPT_MAX_LENGTH } from '@kilocode/cloud-agent-sdk/limits';
 import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   type LayoutChangeEvent,
@@ -45,7 +46,7 @@ const PROMPT_INPUT_LINE_HEIGHT = 24;
 const PROMPT_INPUT_VERTICAL_PADDING = 16;
 const PROMPT_INPUT_HORIZONTAL_PADDING = Platform.OS === 'android' ? 48 : 16;
 const PROMPT_INPUT_ANDROID_HORIZONTAL_INSET = 24;
-const PROMPT_INPUT_MAX_CHARS = 4000;
+const PROMPT_INPUT_MAX_CHARS = CLOUD_AGENT_PROMPT_MAX_LENGTH;
 const PROMPT_INPUT_MIN_HEIGHT =
   PROMPT_INPUT_LINE_HEIGHT * PROMPT_INPUT_DEFAULT_LINES + PROMPT_INPUT_VERTICAL_PADDING;
 const PROMPT_INPUT_MAX_HEIGHT =

--- a/apps/mobile/src/lib/share-payload.ts
+++ b/apps/mobile/src/lib/share-payload.ts
@@ -1,3 +1,4 @@
+import { CLOUD_AGENT_PROMPT_MAX_LENGTH } from '@kilocode/cloud-agent-sdk/limits';
 import * as Crypto from 'expo-crypto';
 import { cacheDirectory, copyAsync, deleteAsync } from 'expo-file-system/legacy';
 import { type ShareIntent } from 'expo-share-intent';
@@ -13,8 +14,8 @@ export type SharePayload = {
   failedFiles: string[];
 };
 
-/** Mirrors PROMPT_INPUT_MAX_CHARS in new-session-prompt.tsx (module-local; composer clamps again). */
-export const SHARE_TEXT_MAX_CHARS = 4000;
+/** The cloud agent prompt cap; the composer clamps again on delivery. */
+export const SHARE_TEXT_MAX_CHARS = CLOUD_AGENT_PROMPT_MAX_LENGTH;
 
 export const SHARE_PAYLOAD_MAX_ENTRIES = 5;
 

--- a/apps/web/src/lib/cloud-agent/constants.ts
+++ b/apps/web/src/lib/cloud-agent/constants.ts
@@ -178,11 +178,7 @@ export function normalizeAttachmentExtension(extension: string | undefined | nul
 export type { CloudAgentAttachments } from '@kilocode/app-shared/cloud-agent';
 
 /**
- * Maximum prompt length (in characters) accepted by the cloud agent.
- *
- * Mirrors the server-side cap in `services/cloud-agent-next/src/schema.ts`
- * (`Limits.MAX_PROMPT_LENGTH`). Prompts exceeding this would be rejected by
- * the worker, so we enforce the same limit client-side to give users
- * immediate feedback.
+ * Maximum prompt length (in characters) accepted by the cloud agent. Defined
+ * once in the SDK so the web, mobile, and extension composers share it.
  */
-export const CLOUD_AGENT_PROMPT_MAX_LENGTH = 100_000;
+export { CLOUD_AGENT_PROMPT_MAX_LENGTH } from '@kilocode/cloud-agent-sdk/limits';

--- a/packages/cloud-agent-sdk/src/limits.ts
+++ b/packages/cloud-agent-sdk/src/limits.ts
@@ -1,0 +1,8 @@
+/**
+ * Maximum prompt length (in characters) accepted by the cloud agent.
+ *
+ * Mirrors the server-side cap in `services/cloud-agent-next/src/schema.ts`
+ * (`Limits.MAX_PROMPT_LENGTH`). Every client enforces the same limit so a
+ * composer never silently drops text the worker would have accepted.
+ */
+export const CLOUD_AGENT_PROMPT_MAX_LENGTH = 100_000;


### PR DESCRIPTION
## Summary

The mobile and extension composers capped the prompt at 4000 characters. The cloud agent accepts 100000 — `Limits.MAX_PROMPT_LENGTH` in `services/cloud-agent-next/src/schema.ts` — and the web composer already uses that number. On mobile the cap sat on the native `TextInput`, so a long paste lost its tail with no toast and no counter. The extension carried the same 4000 literal.

The cap now lives once in `@kilocode/cloud-agent-sdk/limits`, a package all three apps already depend on. The web constant re-exports it, so the web keeps its exported name and its behaviour.

<details>
<summary>Files</summary>

- `packages/cloud-agent-sdk/src/limits.ts` — new; holds `CLOUD_AGENT_PROMPT_MAX_LENGTH = 100_000` and names the server cap it mirrors.
- `apps/web/src/lib/cloud-agent/constants.ts` — re-exports the SDK constant instead of declaring its own copy.
- `apps/mobile/src/components/agents/chat-composer-input-row.tsx` — the `TextInput` `maxLength` uses the shared cap.
- `apps/mobile/src/components/agents/chat-composer.tsx` — the share-prefill, voice-draft, and clipboard-paste paths use the shared cap.
- `apps/mobile/src/components/agents/new-session-prompt.tsx` — `PROMPT_INPUT_MAX_CHARS` uses the shared cap.
- `apps/mobile/src/lib/share-payload.ts` — `SHARE_TEXT_MAX_CHARS` uses the shared cap, so shared text is no longer cut at 4000 before it reaches a composer.
- `apps/extension/entrypoints/sidepanel/agents-new-session.tsx` — `PROMPT_MAX_LENGTH` uses the shared cap.

</details>

Tests: 1 test file changed — the extension constant test asserts the shared cap instead of the literal 4000.

Generated: none — no lockfiles, build output, or generated artifacts changed.

## Verification

- `pnpm typecheck` in `apps/mobile`, `apps/extension`, and `apps/web` — passed.
- `pnpm lint` in `apps/mobile` and `apps/extension` — 0 warnings, 0 errors.
- `vitest run` on the touched tests — extension `agents-new-session` 31 passed; mobile `share-payload`, `share-prefill`, `composer-paste-text`, `chat-composer`, `new-session-prompt-initial-prompt` 49 passed.

No E2E report attached.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

Two behaviours stay as they are. Mobile shows no character counter, unlike the web composer, which shows one from 90% of the cap. Mobile still truncates at the cap itself, now at the same length the worker rejects.

No manual step is needed before or after merge.

Stacked on #5463.


---

## Stack

1. #5463 — `feat(mobile): kilo remote hint, Live now slots, and remote remap` (base `main`)
2. #5475 — this PR (base `mobile-batch-1154`)

Merge in order.
