### PR TITLE
feat(ai-gateway): route fake-deterministic through local Next.js

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -174,7 +174,6 @@ Manage shared web env var additions and rotations with `pnpm web:env set <VARIAB
 
 ### Ablation / Experimentation
 
-- `NEXT_PUBLIC_CLOUD_AGENT_NEXT_ENABLE_LOCAL_FAKE_MODEL` - Feature flag for local fake model routing in the Cloud Agent Next UI. [PUBLIC]
 - `GLOBAL_KILO_BACKEND` - Override to select the global backend region/endpoint; used in `next.config.mjs`. [SERVER]
 - `ANALYZE` - Next.js bundle analyzer switch; enables `@next/bundle-analyzer` in `next.config.mjs`. [SERVER]
 
@@ -258,7 +257,7 @@ Manage shared web env var additions and rotations with `pnpm web:env set <VARIAB
 - `INCEPTION_API_KEY` - Inception Labs API key; used in `apps/web/src/app/api/fim/completions/route.ts` and `apps/web/src/app/api/edit/completions/route.ts` as a fill-in-the-middle (FIM) provider, with endpoint `https://api.inceptionlabs.ai/v1/fim/completions`. Defined in `apps/web/src/lib/config.server.ts`. `[SECRET]`
 - `AI_ATTRIBUTION_ADMIN_SECRET` - Admin secret for the AI Attribution service (`apps/web/src/lib/ai-attribution-service.ts`); sent as `X-Admin-Secret` header. `[SECRET]`
 - `ARTIFICIAL_ANALYSIS_API_KEY` - API key for Artificial Analysis (`apps/web/src/lib/model-stats/sync-artificial-analysis.ts`); sent as `x-api-key` header for model benchmarking data sync. `[SECRET]`
-- `FAKE_LLM_URL` - URL for a fake/local LLM server used in `services/cloud-agent-next` E2E tests (`test/e2e/client.ts`, `test/e2e/fake-llm-server.ts`, `test/e2e/README.md`); defaults to `http://localhost:8811`. [SERVER]
+- `FAKE_LLM_URL` - Local-only URL for the fake-llm service. Next.js uses it in development to list and route `fake-deterministic` through the real gateway (`apps/web/.env.development.local.example`, `apps/web/src/lib/ai-gateway/local-fake-llm.ts`). The cloud-agent-next E2E driver uses the same var for `/test/*` side channels (`test/e2e/client.ts`, `test/e2e/fake-llm-server.ts`, `test/e2e/README.md`). Defaults to `http://localhost:8811`. Ignored on Vercel. [SERVER]
 
 ### Vector DBs
 

--- a/apps/web/.env.development.local.example
+++ b/apps/web/.env.development.local.example
@@ -1,6 +1,9 @@
 # @url cloud-agent-next
 CLOUD_AGENT_NEXT_API_URL=http://localhost:8794
 
+# @url fake-llm
+FAKE_LLM_URL=http://localhost:8811
+
 # @from CALLBACK_TOKEN_SECRET
 CALLBACK_TOKEN_SECRET=
 

--- a/apps/web/src/app/api/openrouter/models/route.ts
+++ b/apps/web/src/app/api/openrouter/models/route.ts
@@ -10,6 +10,7 @@ import { listAvailableExperimentModels } from '@/lib/ai-gateway/experiments/list
 import { addUserByokAvailability, getUserByokProviderIds } from '@/lib/ai-gateway/byok';
 import { readDb } from '@/lib/drizzle';
 import { addAutoRoutingModels } from '@/lib/ai-gateway/auto-routing-models';
+import { appendLocalFakeDeterministicCatalogModels } from '@/lib/ai-gateway/local-fake-llm';
 
 async function tryGetUserFromAuth() {
   try {
@@ -51,7 +52,7 @@ export async function GET(
     if (!auth?.user) {
       const experimentModels = await listAvailableExperimentModels();
       return NextResponse.json({
-        data: models.concat(experimentModels),
+        data: appendLocalFakeDeterministicCatalogModels(models.concat(experimentModels)),
       });
     }
 
@@ -65,7 +66,9 @@ export async function GET(
       enabledByokProviderIds
     );
     return NextResponse.json({
-      data: modelsWithByokAvailability.concat(byokModels, experimentModels),
+      data: appendLocalFakeDeterministicCatalogModels(
+        modelsWithByokAvailability.concat(byokModels, experimentModels)
+      ),
     });
   } catch (error) {
     captureException(error, {

--- a/apps/web/src/app/api/openrouter/models/validate/route.ts
+++ b/apps/web/src/app/api/openrouter/models/validate/route.ts
@@ -7,6 +7,7 @@ import { getUserFromAuth } from '@/lib/user/server';
 import { getDirectByokModelsForUser } from '@/lib/ai-gateway/providers/direct-byok';
 import { ORGANIZATION_ID_HEADER } from '@/lib/constants';
 import { listAvailableExperimentModels } from '@/lib/ai-gateway/experiments/list-available-experiment-models';
+import { appendLocalFakeDeterministicCatalogModels } from '@/lib/ai-gateway/local-fake-llm';
 
 const BodySchema = z.object({ modelId: z.string().trim().min(1) });
 
@@ -52,9 +53,9 @@ export async function POST(request: NextRequest) {
       auth?.user ? getDirectByokModelsForUser(auth.user.id) : [],
       listAvailableExperimentModels(),
     ]);
-    const available = models.data
-      .concat(byokModels, experimentModels)
-      .some(model => model.id === bodyResult.data.modelId);
+    const available = appendLocalFakeDeterministicCatalogModels(
+      models.data.concat(byokModels, experimentModels)
+    ).some(model => model.id === bodyResult.data.modelId);
     return NextResponse.json(available ? { valid: true } : { valid: false, reason: 'unavailable' });
   } catch (error) {
     captureException(error, {

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -83,7 +83,6 @@ import {
   CLOUD_AGENT_PROMPT_MAX_LENGTH,
 } from '@/lib/cloud-agent/constants';
 import {
-  appendCloudAgentNextLocalTestModel,
   getDevcontainerEnabled,
   getLastUsedModel,
   getLastUsedRepo,
@@ -198,9 +197,8 @@ export function NewSessionPanel({
       hasUserByokAvailable: model.hasUserByokAvailable,
       variants: model.opencode?.variants ? Object.keys(model.opencode.variants) : undefined,
     }));
-    const withLocalTest = appendCloudAgentNextLocalTestModel(options);
-    if (!hasLimitedAccess) return withLocalTest;
-    return withLocalTest.filter(option => option.isFree || option.hasUserByokAvailable);
+    if (!hasLimitedAccess) return options;
+    return options.filter(option => option.isFree || option.hasUserByokAvailable);
   }, [allModels, hasLimitedAccess]);
 
   // ---------------------------------------------------------------------------

--- a/apps/web/src/components/cloud-agent-next/hooks/useOrganizationModels.ts
+++ b/apps/web/src/components/cloud-agent-next/hooks/useOrganizationModels.ts
@@ -8,7 +8,6 @@ import { useMemo } from 'react';
 import { useOrganizationDefaults } from '@/app/api/organizations/hooks';
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import type { ModelOption } from '@/components/shared/ModelCombobox';
-import { appendCloudAgentNextLocalTestModel } from '@/components/cloud-agent-next/model-preferences';
 import { buildContextLengthByModelId } from '@/components/cloud-agent-next/model-context-lengths';
 
 type UseOrganizationModelsReturn = {
@@ -44,7 +43,7 @@ export function useOrganizationModels(
 
   // Format models for the combobox
   const modelOptions = useMemo<ModelOption[]>(() => {
-    return appendCloudAgentNextLocalTestModel(
+    return (
       openRouterModels?.data.map(model => ({
         id: model.id,
         name: model.name,

--- a/apps/web/src/components/cloud-agent-next/model-preferences.test.ts
+++ b/apps/web/src/components/cloud-agent-next/model-preferences.test.ts
@@ -1,6 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
 import {
-  appendCloudAgentNextLocalTestModel,
   getDevcontainerEnabledStorageKey,
   getLastUsedModelStorageKey,
   getLastUsedRepoStorageKey,
@@ -18,39 +17,6 @@ const modelOptions = [
   { id: 'anthropic/claude-sonnet-4.5', name: 'Claude Sonnet 4.5' },
   { id: 'openai/gpt-5.1', name: 'GPT 5.1' },
 ] satisfies ModelOption[];
-
-describe('appendCloudAgentNextLocalTestModel', () => {
-  it('leaves the normal selector list unchanged when local model exposure is disabled', () => {
-    expect(appendCloudAgentNextLocalTestModel(modelOptions, false)).toEqual(modelOptions);
-  });
-
-  it('appends the deterministic local testing model without changing existing fallback defaults', () => {
-    const exposedModelOptions = appendCloudAgentNextLocalTestModel(modelOptions, true);
-
-    expect(exposedModelOptions).toEqual([
-      ...modelOptions,
-      { id: 'kilo/fake-deterministic', name: 'Deterministic test model' },
-    ]);
-    expect(
-      getPreferredInitialModel({
-        modelOptions: exposedModelOptions,
-        lastUsedModel: null,
-        defaultModel: 'blocked/model',
-      })
-    ).toBe('anthropic/claude-sonnet-4.5');
-  });
-
-  it('does not duplicate an already exposed deterministic local testing model', () => {
-    const existingTestModelOptions = [
-      ...modelOptions,
-      { id: 'kilo/fake-deterministic', name: 'Gateway-provided fake model' },
-    ] satisfies ModelOption[];
-
-    expect(appendCloudAgentNextLocalTestModel(existingTestModelOptions, true)).toEqual(
-      existingTestModelOptions
-    );
-  });
-});
 
 describe('getPreferredInitialModel', () => {
   it('prefers the last used model when it is available', () => {

--- a/apps/web/src/components/cloud-agent-next/model-preferences.ts
+++ b/apps/web/src/components/cloud-agent-next/model-preferences.ts
@@ -5,34 +5,9 @@ import type { RepositoryOption, RepositoryPlatform } from '@/components/shared/R
 const MODEL_STORAGE_KEY_PREFIX = 'cloud-agent:last-used-model';
 const VARIANTS_STORAGE_KEY_PREFIX = 'cloud-agent:last-used-variants';
 const DEVCONTAINER_ENABLED_STORAGE_KEY = 'cloud-agent:devcontainer-enabled';
-const CLOUD_AGENT_NEXT_LOCAL_TEST_MODEL = {
-  id: 'kilo/fake-deterministic',
-  name: 'Deterministic test model',
-} satisfies ModelOption;
 const REPO_STORAGE_KEY_PREFIX = 'cloud-agent:last-used-repo';
 
 type LastUsedRepo = { fullName: string; platform: RepositoryPlatform };
-
-export function shouldExposeCloudAgentNextLocalTestModel() {
-  return (
-    process.env.NODE_ENV === 'development' &&
-    process.env.NEXT_PUBLIC_CLOUD_AGENT_NEXT_ENABLE_LOCAL_FAKE_MODEL === 'true'
-  );
-}
-
-export function appendCloudAgentNextLocalTestModel(
-  modelOptions: ModelOption[],
-  shouldExposeLocalTestModel = shouldExposeCloudAgentNextLocalTestModel()
-): ModelOption[] {
-  if (
-    !shouldExposeLocalTestModel ||
-    modelOptions.some(model => model.id === CLOUD_AGENT_NEXT_LOCAL_TEST_MODEL.id)
-  ) {
-    return modelOptions;
-  }
-
-  return [...modelOptions, CLOUD_AGENT_NEXT_LOCAL_TEST_MODEL];
-}
 
 export function getLastUsedRepoStorageKey(organizationId?: string) {
   return organizationId

--- a/apps/web/src/lib/ai-gateway/is-free-model.ts
+++ b/apps/web/src/lib/ai-gateway/is-free-model.ts
@@ -1,6 +1,10 @@
 import { KILO_AUTO_FREE_MODEL } from '@/lib/ai-gateway/auto-model';
 import { isKiloExclusiveFreeModel, kiloExclusiveModels } from '@/lib/ai-gateway/models';
 import { isPublicIdExperimented } from '@/lib/ai-gateway/experiments/membership';
+import {
+  isLocalFakeDeterministicModel,
+  isLocalFakeLlmEnabled,
+} from '@/lib/ai-gateway/local-fake-llm';
 
 /**
  * Returns true if `model` should be treated as free for the requesting user
@@ -14,6 +18,7 @@ import { isPublicIdExperimented } from '@/lib/ai-gateway/experiments/membership'
  */
 export async function isFreeModel(model: string): Promise<boolean> {
   return (
+    (isLocalFakeDeterministicModel(model) && isLocalFakeLlmEnabled()) ||
     isKiloExclusiveFreeModel(model) ||
     model === KILO_AUTO_FREE_MODEL.id ||
     (model ?? '').endsWith(':free') ||

--- a/apps/web/src/lib/ai-gateway/local-fake-llm.test.ts
+++ b/apps/web/src/lib/ai-gateway/local-fake-llm.test.ts
@@ -1,0 +1,127 @@
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { isFreeModel } from '@/lib/ai-gateway/is-free-model';
+import {
+  appendLocalFakeDeterministicCatalogModels,
+  getLocalFakeDeterministicCatalogEntry,
+  getLocalFakeLlmProvider,
+  isLocalFakeDeterministicModel,
+  isLocalFakeLlmEnabled,
+  LOCAL_FAKE_DETERMINISTIC_MODEL_ID,
+} from '@/lib/ai-gateway/local-fake-llm';
+import type { OpenRouterModel } from '@/lib/organizations/organization-types';
+
+function replaceEnv(overrides: {
+  NODE_ENV?: NodeJS.ProcessEnv['NODE_ENV'];
+  FAKE_LLM_URL?: string;
+  VERCEL?: string;
+}) {
+  const nextEnv = { ...process.env, ...overrides };
+  if (!('VERCEL' in overrides)) {
+    delete nextEnv.VERCEL;
+  }
+  if (!('FAKE_LLM_URL' in overrides)) {
+    delete nextEnv.FAKE_LLM_URL;
+  }
+  return jest.replaceProperty(process, 'env', nextEnv as NodeJS.ProcessEnv);
+}
+
+describe('local fake deterministic model', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('matches the bare catalog id and the kilo session id', () => {
+    expect(isLocalFakeDeterministicModel(LOCAL_FAKE_DETERMINISTIC_MODEL_ID)).toBe(true);
+    expect(isLocalFakeDeterministicModel('kilo/fake-deterministic')).toBe(true);
+    expect(isLocalFakeDeterministicModel('kilo-auto/efficient')).toBe(false);
+  });
+
+  test('is enabled only in local development with an absolute FAKE_LLM_URL', () => {
+    const enabled = replaceEnv({ NODE_ENV: 'development', FAKE_LLM_URL: 'http://localhost:8811' });
+    expect(isLocalFakeLlmEnabled()).toBe(true);
+    enabled.restore();
+
+    const missingUrl = replaceEnv({ NODE_ENV: 'development' });
+    expect(isLocalFakeLlmEnabled()).toBe(false);
+    missingUrl.restore();
+
+    const vercel = replaceEnv({
+      NODE_ENV: 'development',
+      FAKE_LLM_URL: 'http://localhost:8811',
+      VERCEL: '1',
+    });
+    expect(isLocalFakeLlmEnabled()).toBe(false);
+    vercel.restore();
+
+    const production = replaceEnv({
+      NODE_ENV: 'production',
+      FAKE_LLM_URL: 'http://localhost:8811',
+    });
+    expect(isLocalFakeLlmEnabled()).toBe(false);
+    production.restore();
+
+    const relativeUrl = replaceEnv({ NODE_ENV: 'development', FAKE_LLM_URL: 'localhost:8811' });
+    expect(isLocalFakeLlmEnabled()).toBe(false);
+    relativeUrl.restore();
+  });
+
+  test('returns a free catalog entry only when enabled', () => {
+    expect(getLocalFakeDeterministicCatalogEntry()).toBeNull();
+    expect(appendLocalFakeDeterministicCatalogModels([])).toEqual([]);
+
+    const env = replaceEnv({ NODE_ENV: 'development', FAKE_LLM_URL: 'http://localhost:8811' });
+    const entry = getLocalFakeDeterministicCatalogEntry();
+    expect(entry).toMatchObject({
+      id: LOCAL_FAKE_DETERMINISTIC_MODEL_ID,
+      isFree: true,
+      context_length: 200_000,
+    });
+    expect(entry?.supported_parameters).toContain('tools');
+    expect(entry?.pricing).toMatchObject({ prompt: '0', completion: '0' });
+
+    const existing: OpenRouterModel[] = [
+      {
+        id: 'anthropic/claude-sonnet-4.5',
+        name: 'Claude',
+        created: 0,
+        description: '',
+        architecture: {
+          input_modalities: ['text'],
+          output_modalities: ['text'],
+          tokenizer: 'test',
+        },
+        top_provider: { is_moderated: false },
+        pricing: { prompt: '1', completion: '1' },
+        context_length: 1,
+      },
+    ];
+    expect(appendLocalFakeDeterministicCatalogModels(existing)).toEqual([...existing, entry]);
+    expect(appendLocalFakeDeterministicCatalogModels([entry!])).toEqual([entry]);
+    env.restore();
+  });
+
+  test('builds a custom provider pointed at FAKE_LLM_URL', () => {
+    expect(getLocalFakeLlmProvider()).toBeNull();
+
+    const env = replaceEnv({ NODE_ENV: 'development', FAKE_LLM_URL: 'http://localhost:8811/' });
+    const provider = getLocalFakeLlmProvider();
+    expect(provider).toMatchObject({
+      id: 'custom',
+      apiUrl: 'http://localhost:8811/api/openrouter',
+      apiKey: 'local-fake-llm',
+      disableRequestTimeout: true,
+    });
+    env.restore();
+  });
+
+  test('isFreeModel is true only when the local fake LLM is enabled', async () => {
+    expect(await isFreeModel(LOCAL_FAKE_DETERMINISTIC_MODEL_ID)).toBe(false);
+    expect(await isFreeModel('kilo/fake-deterministic')).toBe(false);
+
+    const env = replaceEnv({ NODE_ENV: 'development', FAKE_LLM_URL: 'http://localhost:8811' });
+    expect(await isFreeModel(LOCAL_FAKE_DETERMINISTIC_MODEL_ID)).toBe(true);
+    expect(await isFreeModel('kilo/fake-deterministic')).toBe(true);
+    expect(await isFreeModel('anthropic/claude-sonnet-4')).toBe(false);
+    env.restore();
+  });
+});

--- a/apps/web/src/lib/ai-gateway/local-fake-llm.test.ts
+++ b/apps/web/src/lib/ai-gateway/local-fake-llm.test.ts
@@ -109,7 +109,6 @@ describe('local fake deterministic model', () => {
       id: 'custom',
       apiUrl: 'http://localhost:8811/api/openrouter',
       apiKey: 'local-fake-llm',
-      disableRequestTimeout: true,
     });
     env.restore();
   });

--- a/apps/web/src/lib/ai-gateway/local-fake-llm.ts
+++ b/apps/web/src/lib/ai-gateway/local-fake-llm.ts
@@ -1,0 +1,89 @@
+import { buildDirectProvider } from '@/lib/ai-gateway/experiments/build-direct-provider';
+import type { Provider } from '@/lib/ai-gateway/providers/types';
+import type { OpenRouterModel } from '@/lib/organizations/organization-types';
+
+export const LOCAL_FAKE_DETERMINISTIC_MODEL_ID = 'fake-deterministic';
+
+function parseAbsoluteHttpUrl(value: string | undefined): URL | null {
+  if (!value) return null;
+  try {
+    const url = new URL(value);
+    if (url.protocol !== 'http:' && url.protocol !== 'https:') return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+export function isLocalFakeDeterministicModel(id: string | undefined | null): boolean {
+  if (!id) return false;
+  return (
+    id === LOCAL_FAKE_DETERMINISTIC_MODEL_ID || id === `kilo/${LOCAL_FAKE_DETERMINISTIC_MODEL_ID}`
+  );
+}
+
+export function isLocalFakeLlmEnabled(): boolean {
+  if (process.env.NODE_ENV !== 'development') return false;
+  if (process.env.VERCEL) return false;
+  return parseAbsoluteHttpUrl(process.env.FAKE_LLM_URL) !== null;
+}
+
+export function getLocalFakeDeterministicCatalogEntry(): OpenRouterModel | null {
+  if (!isLocalFakeLlmEnabled()) return null;
+  return {
+    id: LOCAL_FAKE_DETERMINISTIC_MODEL_ID,
+    name: 'Fake Deterministic',
+    created: 0,
+    description: 'Deterministic fake model for local Cloud Agent development.',
+    architecture: {
+      input_modalities: ['text'],
+      output_modalities: ['text'],
+      tokenizer: 'fake',
+    },
+    top_provider: {
+      is_moderated: false,
+      context_length: 200_000,
+      max_completion_tokens: 8192,
+    },
+    pricing: {
+      prompt: '0',
+      completion: '0',
+      request: '0',
+      image: '0',
+      web_search: '0',
+      internal_reasoning: '0',
+    },
+    context_length: 200_000,
+    supported_parameters: ['tools', 'temperature'],
+    isFree: true,
+  };
+}
+
+export function appendLocalFakeDeterministicCatalogModels(
+  models: OpenRouterModel[]
+): OpenRouterModel[] {
+  const entry = getLocalFakeDeterministicCatalogEntry();
+  if (!entry || models.some(model => model.id === entry.id)) {
+    return models;
+  }
+  return [...models, entry];
+}
+
+export function getLocalFakeLlmProvider(): Provider | null {
+  const url = parseAbsoluteHttpUrl(process.env.FAKE_LLM_URL);
+  if (!isLocalFakeLlmEnabled() || !url) return null;
+  const baseUrl = url.href.replace(/\/$/, '');
+  return {
+    ...buildDirectProvider(
+      'custom',
+      ['chat_completions'],
+      {
+        base_url: `${baseUrl}/api/openrouter`,
+        internal_id: LOCAL_FAKE_DETERMINISTIC_MODEL_ID,
+        api_key: 'local-fake-llm',
+      },
+      null
+    ),
+    disableRequestTimeout: true,
+  };
+}

--- a/apps/web/src/lib/ai-gateway/local-fake-llm.ts
+++ b/apps/web/src/lib/ai-gateway/local-fake-llm.ts
@@ -73,17 +73,14 @@ export function getLocalFakeLlmProvider(): Provider | null {
   const url = parseAbsoluteHttpUrl(process.env.FAKE_LLM_URL);
   if (!isLocalFakeLlmEnabled() || !url) return null;
   const baseUrl = url.href.replace(/\/$/, '');
-  return {
-    ...buildDirectProvider(
-      'custom',
-      ['chat_completions'],
-      {
-        base_url: `${baseUrl}/api/openrouter`,
-        internal_id: LOCAL_FAKE_DETERMINISTIC_MODEL_ID,
-        api_key: 'local-fake-llm',
-      },
-      null
-    ),
-    disableRequestTimeout: true,
-  };
+  return buildDirectProvider(
+    'custom',
+    ['chat_completions'],
+    {
+      base_url: `${baseUrl}/api/openrouter`,
+      internal_id: LOCAL_FAKE_DETERMINISTIC_MODEL_ID,
+      api_key: 'local-fake-llm',
+    },
+    null
+  );
 }

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.local-fake.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.local-fake.test.ts
@@ -1,0 +1,113 @@
+import { afterEach, describe, expect, test } from '@jest/globals';
+import { getProvider } from '@/lib/ai-gateway/providers/get-provider';
+import { OPENROUTER } from '@/lib/ai-gateway/providers/provider-definitions';
+import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import type { User } from '@kilocode/db/schema';
+
+jest.mock('@/lib/ai-gateway/providers/direct-byok', () => ({
+  getDirectByokModel: jest.fn().mockResolvedValue({ provider: null, model: null }),
+}));
+jest.mock('@/lib/ai-gateway/byok', () => ({
+  getModelUserByokProviders: jest.fn().mockResolvedValue([]),
+  getBYOKforUser: jest.fn(),
+  getBYOKforOrganization: jest.fn(),
+}));
+jest.mock('@/lib/ai-gateway/experiments/membership', () => ({
+  isPublicIdExperimented: jest.fn().mockResolvedValue(false),
+}));
+jest.mock('@/lib/ai-gateway/providers/vercel', () => ({
+  shouldRouteToVercel: jest.fn().mockResolvedValue(false),
+}));
+
+const request = {
+  kind: 'chat_completions',
+  body: { model: 'fake-deterministic', messages: [] },
+} as GatewayRequest;
+
+const user = { id: 'user-id' } as User;
+
+function providerInput(requestedModel: string) {
+  return {
+    requestedModel,
+    request,
+    user,
+    organizationId: undefined,
+    taskId: undefined,
+    clientIp: null,
+    machineId: null,
+  };
+}
+
+function replaceEnv(overrides: {
+  NODE_ENV?: NodeJS.ProcessEnv['NODE_ENV'];
+  FAKE_LLM_URL?: string;
+  VERCEL?: string;
+}) {
+  const nextEnv = { ...process.env, ...overrides };
+  if (!('VERCEL' in overrides)) {
+    delete nextEnv.VERCEL;
+  }
+  if (!('FAKE_LLM_URL' in overrides)) {
+    delete nextEnv.FAKE_LLM_URL;
+  }
+  return jest.replaceProperty(process, 'env', nextEnv as NodeJS.ProcessEnv);
+}
+
+describe('getProvider local fake deterministic routing', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  test('routes fake-deterministic to FAKE_LLM_URL when enabled', async () => {
+    const env = replaceEnv({ NODE_ENV: 'development', FAKE_LLM_URL: 'http://localhost:8811' });
+
+    const result = await getProvider(providerInput('fake-deterministic'));
+    expect(result).toMatchObject({
+      kind: 'provider',
+      bypassAccessCheck: true,
+      userByok: null,
+      provider: {
+        id: 'custom',
+        apiUrl: 'http://localhost:8811/api/openrouter',
+      },
+    });
+
+    const prefixed = await getProvider(providerInput('kilo/fake-deterministic'));
+    expect(prefixed.kind === 'provider' && prefixed.provider.apiUrl).toBe(
+      'http://localhost:8811/api/openrouter'
+    );
+    env.restore();
+  });
+
+  test('does not route fake-deterministic when disabled, on Vercel, or without a URL', async () => {
+    const disabled = await getProvider(providerInput('fake-deterministic'));
+    expect(disabled).toEqual({
+      kind: 'provider',
+      provider: OPENROUTER,
+      userByok: null,
+      bypassAccessCheck: false,
+    });
+
+    const vercel = replaceEnv({
+      NODE_ENV: 'development',
+      FAKE_LLM_URL: 'http://localhost:8811',
+      VERCEL: '1',
+    });
+    expect(await getProvider(providerInput('fake-deterministic'))).toEqual({
+      kind: 'provider',
+      provider: OPENROUTER,
+      userByok: null,
+      bypassAccessCheck: false,
+    });
+    vercel.restore();
+
+    const missingUrl = replaceEnv({ NODE_ENV: 'development' });
+    expect(await getProvider(providerInput('fake-deterministic'))).toEqual({
+      kind: 'provider',
+      provider: OPENROUTER,
+      userByok: null,
+      bypassAccessCheck: false,
+    });
+    missingUrl.restore();
+  });
+});

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.ts
@@ -33,6 +33,11 @@ import { getGoogleServiceAccountAccessToken } from '@/lib/ai-gateway/custom-llm/
 import { userHasCustomLlmAccess } from '@/lib/ai-gateway/custom-llm/access';
 import { decryptApiKey } from '@/lib/ai-gateway/byok/encryption';
 import { BYOK_ENCRYPTION_KEY } from '@/lib/config.server';
+import {
+  getLocalFakeLlmProvider,
+  isLocalFakeDeterministicModel,
+  isLocalFakeLlmEnabled,
+} from '@/lib/ai-gateway/local-fake-llm';
 
 /**
  * Metadata about the experiment that resolved this provider, attached when
@@ -218,6 +223,18 @@ export async function getProvider(input: GetProviderInput): Promise<GetProviderR
     machineId,
     getRoutingProviderConfig,
   } = input;
+
+  if (isLocalFakeLlmEnabled() && isLocalFakeDeterministicModel(requestedModel)) {
+    const localFakeProvider = getLocalFakeLlmProvider();
+    if (localFakeProvider) {
+      return {
+        kind: 'provider',
+        provider: localFakeProvider,
+        userByok: null,
+        bypassAccessCheck: true,
+      };
+    }
+  }
 
   const directByokByok = await checkDirectBYOK(user, requestedModel, organizationId);
   if (directByokByok) {

--- a/apps/web/src/lib/ai-gateway/providers/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/types.ts
@@ -58,4 +58,6 @@ export type Provider = {
   supportedChatApis: ReadonlyArray<GatewayChatApiKind>;
   responseTransforms: ProviderResponseTransforms | null;
   transformRequest(context: TransformRequestContext): Promise<void>;
+  /** Skip the gateway abort timeout so parked SSE streams can stay open. */
+  disableRequestTimeout?: boolean;
 };

--- a/apps/web/src/lib/ai-gateway/providers/types.ts
+++ b/apps/web/src/lib/ai-gateway/providers/types.ts
@@ -58,6 +58,4 @@ export type Provider = {
   supportedChatApis: ReadonlyArray<GatewayChatApiKind>;
   responseTransforms: ProviderResponseTransforms | null;
   transformRequest(context: TransformRequestContext): Promise<void>;
-  /** Skip the gateway abort timeout so parked SSE streams can stay open. */
-  disableRequestTimeout?: boolean;
 };

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -233,18 +233,24 @@ export async function upstreamRequest({
   const path = CHAT_API_PATHS[chatApi];
   const targetUrl = `${apiUrl}${path}${search}`;
 
-  const timeoutSignal = AbortSignal.timeout(TIMEOUT_MS);
+  const timeoutSignal = provider.disableRequestTimeout ? null : AbortSignal.timeout(TIMEOUT_MS);
   const onTimeoutAbort = () => {
     errorExceptInTest(
       `[upstreamRequest] gateway timeout after ${TIMEOUT_MS}ms waiting for upstream response headers`,
       { vercelRequestId: vercelRequestId ?? '<none>' }
     );
   };
-  timeoutSignal.addEventListener('abort', onTimeoutAbort);
-  after(() => {
-    timeoutSignal.removeEventListener('abort', onTimeoutAbort);
-  });
-  const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
+  if (timeoutSignal) {
+    timeoutSignal.addEventListener('abort', onTimeoutAbort);
+    after(() => {
+      timeoutSignal.removeEventListener('abort', onTimeoutAbort);
+    });
+  }
+  const combinedSignal = timeoutSignal
+    ? signal
+      ? AbortSignal.any([signal, timeoutSignal])
+      : timeoutSignal
+    : signal;
 
   try {
     return {

--- a/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
+++ b/apps/web/src/lib/ai-gateway/providers/upstream-request.ts
@@ -233,24 +233,18 @@ export async function upstreamRequest({
   const path = CHAT_API_PATHS[chatApi];
   const targetUrl = `${apiUrl}${path}${search}`;
 
-  const timeoutSignal = provider.disableRequestTimeout ? null : AbortSignal.timeout(TIMEOUT_MS);
+  const timeoutSignal = AbortSignal.timeout(TIMEOUT_MS);
   const onTimeoutAbort = () => {
     errorExceptInTest(
       `[upstreamRequest] gateway timeout after ${TIMEOUT_MS}ms waiting for upstream response headers`,
       { vercelRequestId: vercelRequestId ?? '<none>' }
     );
   };
-  if (timeoutSignal) {
-    timeoutSignal.addEventListener('abort', onTimeoutAbort);
-    after(() => {
-      timeoutSignal.removeEventListener('abort', onTimeoutAbort);
-    });
-  }
-  const combinedSignal = timeoutSignal
-    ? signal
-      ? AbortSignal.any([signal, timeoutSignal])
-      : timeoutSignal
-    : signal;
+  timeoutSignal.addEventListener('abort', onTimeoutAbort);
+  after(() => {
+    timeoutSignal.removeEventListener('abort', onTimeoutAbort);
+  });
+  const combinedSignal = signal ? AbortSignal.any([signal, timeoutSignal]) : timeoutSignal;
 
   try {
     return {

--- a/apps/web/src/lib/organizations/organization-models.ts
+++ b/apps/web/src/lib/organizations/organization-models.ts
@@ -13,6 +13,7 @@ import { listAvailableExperimentModels } from '@/lib/ai-gateway/experiments/list
 import { ORG_AUTO_MODEL } from '@/lib/ai-gateway/auto-model';
 import { isOrganizationAutoEnabled } from '@/lib/organizations/organization-auto-model';
 import { addUserByokAvailability, getOrganizationByokProviderIds } from '@/lib/ai-gateway/byok';
+import { appendLocalFakeDeterministicCatalogModels } from '@/lib/ai-gateway/local-fake-llm';
 import { readDb } from '@/lib/drizzle';
 import {
   getOrganizationGroupPolicyContext,
@@ -59,6 +60,6 @@ export async function getAvailableModelsForOrganization(
 
   return {
     ...responseData,
-    data: availableModels,
+    data: appendLocalFakeDeterministicCatalogModels(availableModels),
   };
 }

--- a/services/cloud-agent-next/.dev.vars.example
+++ b/services/cloud-agent-next/.dev.vars.example
@@ -23,11 +23,8 @@ INTERNAL_API_SECRET=your-internal-api-secret-here
 # localhost/127.0.0.1 to host.docker.internal automatically.
 # @url nextjs
 KILOCODE_BACKEND_BASE_URL=http://localhost:3000
-# KILO_OPENROUTER_BASE options:
-#   Real LLM path (dev):  http://localhost:3000/api
-#   Fake LLM (E2E harness, local dev only):
-#     http://localhost:8811/api   (add portOffset if set)
-#   Start the `fake-llm` dev service before pointing at the fake URL.
+# Always the local Next.js gateway. Selecting `fake-deterministic` routes
+# through Next.js to the fake-llm service; do not point this at fake-llm.
 # @url nextjs/api
 KILO_OPENROUTER_BASE=http://localhost:3000/api
 

--- a/services/cloud-agent-next/AGENTS.md
+++ b/services/cloud-agent-next/AGENTS.md
@@ -32,6 +32,7 @@ Git tokens (GitHub App installation tokens, managed GitLab tokens) are resolved 
 - `services/cloud-agent-next/test/e2e/README.md` is the source of truth for setup, fake-LLM routing, lifecycle directives, and troubleshooting.
 - Prefer focused scenario debugging first: `pnpm exec tsx services/cloud-agent-next/test/e2e/run.ts <lifecycle> <conversation>`.
 - Run the aggregate local regression matrix with `pnpm exec tsx services/cloud-agent-next/test/e2e/smoke.ts` when validating the full real Worker + DO + sandbox + wrapper path.
+- Leave `KILO_OPENROUTER_BASE` on Next.js. Selecting `kilo/fake-deterministic` routes through the gateway to fake-llm; no `.dev.vars` flip.
 - Non-zero `portOffset` sessions (the common case) require `WORKER_URL`/`FAKE_LLM_URL` env overrides on every driver invocation — see README "Running". Discover the offset with `pnpm dev:status --json`.
 - This harness is local/manual rather than part of normal `pnpm test` or CI; use `dev/logs/cloud-agent-next.log` and `dev/logs/fake-llm.log` when debugging it.
 - Read `services/cloud-agent-next/DEBUG.md` when correlating local Wrangler logs with Docker sandbox containers, wrapper log files, Kilo CLI logs, uploaded archives, or stuck session flows.

--- a/services/cloud-agent-next/src/persistence/model-utils.test.ts
+++ b/services/cloud-agent-next/src/persistence/model-utils.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest';
-import { dispatchedKilocodeModelId, normalizeKilocodeModel } from './model-utils.js';
+import {
+  dispatchedKilocodeModelId,
+  isLocalFakeDeterministicModel,
+  normalizeKilocodeModel,
+} from './model-utils.js';
 
 describe('normalizeKilocodeModel', () => {
   it('returns undefined for empty input', () => {
@@ -38,5 +42,13 @@ describe('dispatchedKilocodeModelId', () => {
   it('returns undefined for empty input', () => {
     expect(dispatchedKilocodeModelId(undefined)).toBeUndefined();
     expect(dispatchedKilocodeModelId('   ')).toBeUndefined();
+  });
+});
+
+describe('isLocalFakeDeterministicModel', () => {
+  it('matches the catalog id and kilo session id', () => {
+    expect(isLocalFakeDeterministicModel('fake-deterministic')).toBe(true);
+    expect(isLocalFakeDeterministicModel('kilo/fake-deterministic')).toBe(true);
+    expect(isLocalFakeDeterministicModel('kilo-auto/efficient')).toBe(false);
   });
 });

--- a/services/cloud-agent-next/src/persistence/model-utils.ts
+++ b/services/cloud-agent-next/src/persistence/model-utils.ts
@@ -1,3 +1,5 @@
+export const LOCAL_FAKE_DETERMINISTIC_MODEL_ID = 'fake-deterministic';
+
 export function normalizeKilocodeModel(model: string | undefined | null): string | undefined {
   if (!model) return undefined;
   const trimmed = model.trim();
@@ -7,4 +9,8 @@ export function normalizeKilocodeModel(model: string | undefined | null): string
 
 export function dispatchedKilocodeModelId(model: string | undefined | null): string | undefined {
   return normalizeKilocodeModel(model)?.replace(/^kilo\//, '');
+}
+
+export function isLocalFakeDeterministicModel(model: string | undefined | null): boolean {
+  return dispatchedKilocodeModelId(model) === LOCAL_FAKE_DETERMINISTIC_MODEL_ID;
 }

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -2718,6 +2718,57 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     expect(opencodeConfig).toEqual(kiloConfig);
   });
 
+  it.each(['fake-deterministic', 'kilo/fake-deterministic'])(
+    'pins small_model and title model when the session model is %s',
+    async model => {
+      const service = new SessionService();
+      const env = createEnv();
+      env.WORKER_URL = 'https://cloud-agent.example.com';
+      const result = await service.buildWrapperSessionReadyAndPromptRequests({
+        env,
+        plan: {
+          scope: { sessionId: 'agent_test', userId: 'user_test' },
+          turn: {
+            type: 'prompt',
+            messageId: 'msg_018f1e2d3c4bFakeModelAAAAAA',
+            prompt: 'Do the work',
+          },
+          agent: { mode: 'code', model },
+          workspace: { sandboxId: 'ses-abcdef', metadata: createMetadata() },
+          wrapper: {
+            fence: {
+              wrapperRunId: 'wr_fake_model',
+              wrapperGeneration: 1,
+              wrapperConnectionId: 'conn_fake_model',
+            },
+          },
+        } satisfies FencedWrapperDispatchRequest,
+      });
+      const config = JSON.parse(result.readyRequest.materialized.env.KILO_CONFIG_CONTENT) as {
+        model?: string;
+        small_model?: string;
+        agent?: { title?: { model?: string } };
+      };
+
+      expect(config.model).toBe('kilo/fake-deterministic');
+      expect(config.small_model).toBe('kilo/fake-deterministic');
+      expect(config.agent?.title?.model).toBe('kilo/fake-deterministic');
+    }
+  );
+
+  it('does not pin small_model or title model for real session models', async () => {
+    const result = await buildPromptWrapperRequests(createMetadata());
+    const config = JSON.parse(result.readyRequest.materialized.env.KILO_CONFIG_CONTENT) as {
+      model?: string;
+      small_model?: string;
+      agent?: { title?: { model?: string } };
+    };
+
+    expect(config.model).toBe('kilo/test-model');
+    expect(config.small_model).toBeUndefined();
+    expect(config.agent?.title).toBeUndefined();
+  });
+
   it('passes canonical document attachments through signed wrapper prompt construction', async () => {
     const service = new SessionService();
     const env = createEnv();

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -11,7 +11,10 @@ import {
 } from './types.js';
 import { generateSandboxId, getOutboundContainerId } from './sandbox-id.js';
 import { mintWrapperDispatchTicket, resolveSecret } from './auth.js';
-import { normalizeKilocodeModel } from './persistence/model-utils.js';
+import {
+  isLocalFakeDeterministicModel,
+  normalizeKilocodeModel,
+} from './persistence/model-utils.js';
 import {
   isTemporaryManagedBitbucketTokenFailure,
   issueCloudAgentGitHubSessionCapability,
@@ -1505,6 +1508,11 @@ export class SessionService {
       configContent.model = normalizeKilocodeModel(kilocodeModel);
     }
     const agentConfig: Record<string, unknown> = {};
+    if (isLocalFakeDeterministicModel(kilocodeModel)) {
+      const fakeModel = normalizeKilocodeModel(kilocodeModel);
+      configContent.small_model = fakeModel;
+      agentConfig.title = { model: fakeModel };
+    }
     if (appendSystemPrompt && appendSystemPrompt.trim()) {
       agentConfig.custom = { prompt: appendSystemPrompt };
     }

--- a/services/cloud-agent-next/test/e2e/README.md
+++ b/services/cloud-agent-next/test/e2e/README.md
@@ -2,9 +2,9 @@
 
 Drives the real `pnpm dev:start cloud-agent` stack end-to-end — Worker,
 Durable Object, Sandbox container, wrapper, and **real kilo** inside the
-sandbox. Only LLM inference is deterministic: kilo's OpenRouter-shaped
-calls are routed to a local fake gateway
-(`test/e2e/fake-llm-server.ts`) instead of a real model provider.
+sandbox. Only LLM inference is deterministic: selecting
+`kilo/fake-deterministic` makes the local Next.js gateway proxy kilo's
+OpenRouter-shaped calls to `test/e2e/fake-llm-server.ts`.
 
 Not wired into `pnpm test` / CI — this is for local confidence during the
 cloud-agent-next refactor.
@@ -12,34 +12,19 @@ cloud-agent-next refactor.
 ## One-time setup
 
 1. Copy `.dev.vars.example` → `.dev.vars` and fill in local values.
+   Leave `KILO_OPENROUTER_BASE` pointed at local Next.js (`@url nextjs/api`).
 2. Ensure local Postgres is up and root `.env.local` defines `POSTGRES_URL`
    (or export `DATABASE_URL`) — the driver inserts a test user row via
    `@kilocode/db`.
-3. Point kilo at the fake LLM gateway instead of a real provider. Edit
-   `services/cloud-agent-next/.dev.vars`:
+3. Start the stack. The `cloud-agent` group already includes `fake-llm`:
 
    ```bash
-   # Real LLM (default):
-   # KILO_OPENROUTER_BASE=http://localhost:3000/api
-
-   # Fake LLM (E2E harness):
-   KILO_OPENROUTER_BASE=http://localhost:<8811 + portOffset>/api
+   pnpm dev:start cloud-agent
    ```
 
-   `<portOffset>` is the dev-session port offset reported by
-   `pnpm dev:status --json` (usually `0` for the first session). The Worker
-   calls the fake's `POST /api/openrouter/models/validate` route through this
-   host-reachable URL and translates it to `host.docker.internal` when injecting
-   sandbox provider configuration.
-
-4. Start the stack including the `fake-llm` dev service:
-
-   ```bash
-   pnpm dev:start cloud-agent fake-llm
-   ```
-
-   Switching back to a real LLM later is just a `.dev.vars` edit plus a
-   `pnpm dev:restart cloud-agent-next` — no flag toggles.
+   Selecting `kilo/fake-deterministic` is enough to hit fake-llm through
+   Next.js. A real-model session (`kilo-auto/efficient`, etc.) uses the same
+   Worker URL and does not need a restart.
 
 ## Credential containment (opt-in)
 
@@ -164,12 +149,11 @@ and `.env`, then falls back to `@kilocode/db` `computeDatabaseUrl()`, which
 uses `POSTGRES_URL` for local development.
 
 `FAKE_LLM_URL` is how the **driver** reaches the fake server (for
-`/test/release`, `/test/gate-status`, `/test/waiters`, and `/test/requests` side channels). It is separate from
-`KILO_OPENROUTER_BASE` in `.dev.vars`, which is the Worker-reachable gateway
-base used for lightweight model validation; runtime setup translates local
-hostnames for **kilo inside the sandbox** when necessary. If you changed the
-fake's port (e.g. non-zero `portOffset`), set both values to the matching
-reachable views.
+`/test/release`, `/test/gate-status`, `/test/waiters`, and `/test/requests`
+side channels). `KILO_OPENROUTER_BASE` stays on Next.js; the gateway routes
+`fake-deterministic` to fake-llm. If you changed the fake's port (e.g.
+non-zero `portOffset`), set `FAKE_LLM_URL` to the matching host-reachable
+view. Next.js picks up the same offset from `apps/web/.env.development.local`.
 
 ## Gateway contract
 
@@ -266,18 +250,18 @@ the newer `start` / `send` procedures. `prepareSession` requires
   and fill in the local secret (same value used by `apps/web`).
 - **`POSTGRES_URL not configured`** — Set root `.env.local` `POSTGRES_URL`,
   or export `DATABASE_URL` to override the database URL for this harness.
-- **Sandbox calls out to a real provider** — check `.dev.vars`
-  `KILO_OPENROUTER_BASE` is pointing at
-  `http://localhost:<8811 + portOffset>/api` and that the `fake-llm` service is
-  running (`pnpm dev:status`). Runtime configuration translates this URL for
-  sandbox access. Tail the fake's log (`tail -f dev/logs/fake-llm.log`) to
-  confirm kilo is hitting it.
+- **Sandbox calls out to a real provider** — the session model must be
+  `kilo/fake-deterministic`, Next.js must have `FAKE_LLM_URL` set (from
+  `pnpm dev:env`), and the `fake-llm` service must be running
+  (`pnpm dev:status`). Tail the fake's log (`tail -f dev/logs/fake-llm.log`)
+  to confirm kilo is hitting it through the gateway.
 - **`waitForGateEngaged` timed out** — kilo never reached the fake LLM. Most
-  common cause: `KILO_OPENROUTER_BASE` still points at a real provider or the
-  fake service is not running. Confirm with `curl -s $FAKE_LLM_URL/test/requests`
-  (expect a rising `chatCompletions` count as kilo dials the fake) and
-  `tail -f dev/logs/fake-llm.log` — a stream that stays empty while a turn is
-  "preparing" means the wrapper never started, not a fake-LLM problem.
+  common cause: the session used a real model, `FAKE_LLM_URL` is missing from
+  Next.js, or the fake service is not running. Confirm with
+  `curl -s $FAKE_LLM_URL/test/requests` (expect a rising `chatCompletions`
+  count as kilo dials the fake) and `tail -f dev/logs/fake-llm.log` — a
+  stream that stays empty while a turn is "preparing" means the wrapper
+  never started, not a fake-LLM problem.
 - **`Worker "git-token-service-dev" not found` in `cloud-agent-next.log`** —
   the `GIT_TOKEN_SERVICE` service binding could not resolve. The Worker log
   shows the failure as `Failed to issue Kilo session capability` and the turn

--- a/services/cloud-agent-next/test/e2e/README.md
+++ b/services/cloud-agent-next/test/e2e/README.md
@@ -181,15 +181,16 @@ source of directive truth is `test/e2e/fake-llm-server.ts`.
 
 | Directive | Behavior |
 |---|---|
-| `echo:<text>` | One SSE chunk with `delta.content = <text>`, then `finish_reason: stop`, then `[DONE]`. |
+| *(no `__fake__:` directive)* | Echo the last user message after stripping kilo `<environment_details>`. |
 | `slow:<n>:<ms>` | `n` content chunks `<ms>` apart, then stop + `[DONE]`. Used for pacing/timing probes. |
 | `idle` | One empty-delta chunk, then stop + `[DONE]`. |
 | `hang` | Opens the SSE stream but emits nothing and never closes. Drives abort/timeout paths. |
 | `error:<msg>` | HTTP 402 with OpenAI-shaped error body carrying `<msg>`. Exercises kilo's error propagation. |
 | `gate:<tag>` | Opens the SSE stream, emits no chunks, blocks until the driver calls `POST /test/release?tag=<tag>`. On release, emits `"done"` + stop + `[DONE]`. |
 
-Unknown or missing directives produce HTTP 402 with
+Unknown `__fake__:<name>` directives produce HTTP 402 with
 `unknown fake scenario: <name>` — easy to spot in fake-LLM logs.
+A prompt with no `__fake__:` prefix echoes instead.
 
 ### Side channels
 

--- a/services/cloud-agent-next/test/e2e/fake-llm-server.ts
+++ b/services/cloud-agent-next/test/e2e/fake-llm-server.ts
@@ -1,12 +1,10 @@
 /**
- * Fake LLM gateway for cloud-agent E2E harness.
+ * Fake LLM for cloud-agent E2E harness.
  *
- * Masquerades as the OpenRouter-compatible endpoint used by model preflight
- * and real kilo through `@openrouter/ai-sdk-provider`. When `.dev.vars` sets
- * `KILO_OPENROUTER_BASE=http://localhost:<port>/api`, the Worker calls
- * `POST /api/openrouter/models/validate` and translates the URL for sandboxed
- * kilo requests to `GET /api/openrouter/models` and
- * `POST /api/openrouter/chat/completions`.
+ * Preferred path: local Next.js routes `fake-deterministic` here while
+ * `KILO_OPENROUTER_BASE` stays on the real gateway. Masquerade routes
+ * (`/api/openrouter/{models,models/validate,chat/completions}`) still work
+ * if something points at this service directly.
  *
  * Directives in the last user message's content drive scenarios:
  *   `__fake__:<scenario>[:<arg1>[:<arg2>...]]`

--- a/services/cloud-agent-next/test/e2e/fake-llm-server.ts
+++ b/services/cloud-agent-next/test/e2e/fake-llm-server.ts
@@ -8,6 +8,7 @@
  *
  * Directives in the last user message's content drive scenarios:
  *   `__fake__:<scenario>[:<arg1>[:<arg2>...]]`
+ * No directive echoes the last user message (minus kilo wrappers).
  *
  * See `README.md` in this directory for the local harness protocol.
  *
@@ -118,7 +119,7 @@ type Message = { role?: string; content?: string | MessagePart[] };
  * `[{ type: 'text', text: '...' }, ...]`. Concatenates all text parts.
  *
  * Returns '' if there's no user message or no extractable text — which will
- * route to the unknown-scenario fallback.
+ * echo an empty completion.
  */
 export function extractLastUserMessageText(body: unknown): string {
   if (typeof body !== 'object' || body === null) return '';
@@ -139,6 +140,14 @@ export function extractLastUserMessageText(body: unknown): string {
     return '';
   }
   return '';
+}
+
+/**
+ * Drop kilo's appended `<environment_details>` block so a default echo does
+ * not write system context back into the assistant transcript.
+ */
+export function stripKiloPromptWrapping(text: string): string {
+  return text.replace(/<environment_details>[\s\S]*?<\/environment_details>/gi, '').trim();
 }
 
 // ---------------------------------------------------------------------------
@@ -299,6 +308,12 @@ export type ScenarioContext = {
 
 export type ScenarioHandler = (args: string[], ctx: ScenarioContext) => Promise<void> | void;
 
+function emitEcho(ctx: ScenarioContext, text: string): void {
+  writeChunk(ctx.res, makeChunk(ctx.id, ctx.model, { role: 'assistant', content: text }));
+  writeFinish(ctx.res, ctx.id, ctx.model, text.length);
+  ctx.res.end();
+}
+
 function sleep(ms: number): Promise<void> {
   return new Promise(resolve => setTimeout(resolve, ms));
 }
@@ -309,17 +324,11 @@ function sleep(ms: number): Promise<void> {
  */
 export const scenarioRegistry: Record<string, ScenarioHandler> = {
   echo(args, ctx) {
-    // Kilo wraps the user message with `<environment_details>` and other
-    // system context; strip that so the echo'd assistant response contains
-    // only the scenario's payload. Otherwise kilo's subsequent turns see
-    // garbled history (assistant text containing system tags) and stop
-    // issuing LLM calls — a real-LLM scenario would never have that
-    // contamination because real LLMs don't blindly echo their input.
+    // Harness `echo:<token>` only takes the first identifier so kilo's
+    // appended `<environment_details>` cannot leak into the transcript.
     const rawArg = args[0] ?? '';
     const text = rawArg.match(/^([A-Za-z0-9_-]*)/)?.[1] ?? '';
-    writeChunk(ctx.res, makeChunk(ctx.id, ctx.model, { role: 'assistant', content: text }));
-    writeFinish(ctx.res, ctx.id, ctx.model, text.length);
-    ctx.res.end();
+    emitEcho(ctx, text);
   },
 
   async slow(args, ctx) {
@@ -512,8 +521,8 @@ async function handleChatCompletions(
     route: 'POST /api/openrouter/chat/completions',
     model: bodyModel,
     messages: messageCount,
-    scenario: directive?.scenario,
-    args: directive ? directive.args.join('|') : undefined,
+    scenario: directive?.scenario ?? 'echo',
+    args: directive ? directive.args.join('|') : '(default)',
   });
 
   const ctx: ScenarioContext = {
@@ -543,7 +552,7 @@ async function handleChatCompletions(
   });
 
   if (directive === null) {
-    writeJsonError(res, 402, `unknown fake scenario: <missing directive>`, 'invalid_request');
+    emitEcho(ctx, stripKiloPromptWrapping(prompt));
     return;
   }
 

--- a/services/cloud-agent-next/test/e2e/run.ts
+++ b/services/cloud-agent-next/test/e2e/run.ts
@@ -14,9 +14,10 @@
  *   tsx test/e2e/run.ts callback-completion echo:done
  *   tsx test/e2e/run.ts --api=legacy hot echo:hi
  *
- * The stack must be running with `.dev.vars` pointing
- * `KILO_OPENROUTER_BASE` at `http://localhost:<8811 + portOffset>/api`
- * and the `fake-llm` dev service started (`pnpm dev:start cloud-agent fake-llm`).
+ * The stack must be running (`pnpm dev:start cloud-agent`). Leave
+ * `KILO_OPENROUTER_BASE` on Next.js and select `kilo/fake-deterministic`.
+ * Prefix `WORKER_URL` / `FAKE_LLM_URL` from `pnpm dev:status --json` when
+ * the session port offset is non-zero.
  */
 
 import path from 'node:path';

--- a/services/cloud-agent-next/test/e2e/smoke.ts
+++ b/services/cloud-agent-next/test/e2e/smoke.ts
@@ -7,10 +7,8 @@
  *   tsx test/e2e/smoke.ts
  *
  * Not wired into `pnpm test` / `pnpm test:all` on purpose — this requires a
- * running stack with the fake-LLM harness configured:
- *   1. Edit `.dev.vars` so `KILO_OPENROUTER_BASE` points at the fake LLM:
- *        `KILO_OPENROUTER_BASE=http://localhost:<8811 + portOffset>/api`
- *   2. `pnpm dev:start cloud-agent fake-llm`
+ * running stack (`pnpm dev:start cloud-agent`). Leave
+ * `KILO_OPENROUTER_BASE` on Next.js; the driver uses `kilo/fake-deterministic`.
  */
 
 import path from 'node:path';

--- a/services/cloud-agent-next/test/unit/fake-llm-server.test.ts
+++ b/services/cloud-agent-next/test/unit/fake-llm-server.test.ts
@@ -12,6 +12,7 @@ import {
   extractLastUserMessageText,
   parseDirective,
   startFakeLlmServer,
+  stripKiloPromptWrapping,
   type FakeLlmServerHandle,
 } from '../e2e/fake-llm-server.js';
 
@@ -109,6 +110,20 @@ describe('extractLastUserMessageText', () => {
 
   it('returns empty when no user message exists', () => {
     expect(extractLastUserMessageText({ messages: [{ role: 'system', content: 'sys' }] })).toBe('');
+  });
+});
+
+describe('stripKiloPromptWrapping', () => {
+  it('returns the prompt unchanged when no wrappers are present', () => {
+    expect(stripKiloPromptWrapping('hello world')).toBe('hello world');
+  });
+
+  it('removes environment_details and trims leftover whitespace', () => {
+    expect(
+      stripKiloPromptWrapping(
+        'hello world\n\n<environment_details>\nCurrent time: 2026-05-05T10:17:23+00:00\n</environment_details>'
+      )
+    ).toBe('hello world');
   });
 });
 
@@ -299,12 +314,26 @@ describe('fake-llm-server HTTP', () => {
     expect(body.error.message).toContain('unknown fake scenario: nosuch');
   });
 
-  it('missing directive returns HTTP 402', async () => {
+  it('missing directive echoes the last user message', async () => {
     const h = await start();
     const res = await postChat(h.url, 'just some prompt with no directive');
-    expect(res.status).toBe(402);
-    const body = (await res.json()) as { error: { message: string } };
-    expect(body.error.message).toContain('missing directive');
+    expect(res.status).toBe(200);
+    const chunks = await readAllSse(res.body!);
+    const parsed = chunks.slice(0, -1).map(c => JSON.parse(c.data));
+    expect(parsed[0].choices[0].delta.content).toBe('just some prompt with no directive');
+    expect(parsed[parsed.length - 1].choices[0].finish_reason).toBe('stop');
+  });
+
+  it('missing directive strips kilo environment_details from the echo', async () => {
+    const h = await start();
+    const res = await postChat(
+      h.url,
+      'hello world\n<environment_details>\nCurrent time: 2026-05-05T10:17:23+00:00\n</environment_details>'
+    );
+    expect(res.status).toBe(200);
+    const chunks = await readAllSse(res.body!);
+    const parsed = chunks.slice(0, -1).map(c => JSON.parse(c.data));
+    expect(parsed[0].choices[0].delta.content).toBe('hello world');
   });
 
   it('invalid JSON body returns HTTP 400', async () => {


### PR DESCRIPTION
## Summary

- Route `kilo/fake-deterministic` through the real local Next.js gateway to fake-llm so `KILO_OPENROUTER_BASE` no longer needs to be flipped.
- Expose the catalog entry only in local development (`NODE_ENV=development`, absolute `FAKE_LLM_URL`, `VERCEL` unset).
- Remove the client-side `NEXT_PUBLIC_CLOUD_AGENT_NEXT_ENABLE_LOCAL_FAKE_MODEL` flag and `appendCloudAgentNextLocalTestModel`.
- Pin `small_model` and title model to the fake model so kilo does not call a real model for those side requests.
- Disable the gateway abort timeout for the local fake provider so parked SSE streams can stay open.

## Verification

- `pnpm --filter web exec jest --watchman=false --runInBand --runTestsByPath src/lib/ai-gateway/local-fake-llm.test.ts src/lib/ai-gateway/providers/get-provider.local-fake.test.ts src/components/cloud-agent-next/model-preferences.test.ts` — 3 suites, 28 tests passed
- `pnpm --filter cloud-agent-next exec vitest run src/persistence/model-utils.test.ts src/session-service.test.ts` — 2 files, 113 tests passed