### PR TITLE
fix(mobile): correct sign-in language picker layering

### DIFF
--- a/apps/mobile/src/components/agents/session-list-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.mounted.test.tsx
@@ -31,6 +31,12 @@ const focusCallback = vi.hoisted(() => ({
 }));
 const refetchSpy = vi.hoisted(() => vi.fn());
 const invalidateQueries = vi.hoisted(() => vi.fn());
+const sessionListState = vi.hoisted(() => ({
+  storedSessions: [] as { session_id: string; organization_id: string | null }[],
+  activeSessions: [] as { id: string }[],
+  storedIsFetching: false,
+  storedLoadedPageCount: 1,
+}));
 
 vi.mock('react-native', () => ({
   Platform: { OS: 'ios' },
@@ -99,10 +105,12 @@ vi.mock('@/components/agents/use-agent-session-navigator', () => ({
 }));
 vi.mock('@/components/agents/use-agent-session-list-data', () => ({
   useAgentSessionListData: () => ({
-    storedSessions: [],
-    activeSessions: [],
+    storedSessions: sessionListState.storedSessions,
+    activeSessions: sessionListState.activeSessions,
     activeIsError: false,
     isLoading: false,
+    storedIsFetching: sessionListState.storedIsFetching,
+    storedLoadedPageCount: sessionListState.storedLoadedPageCount,
     paging: {},
     refetch: refetchSpy,
     handleRetry: vi.fn(),
@@ -156,6 +164,10 @@ describe('AgentSessionListScreen foreground refresh', () => {
     (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
     focusState.current = true;
     focusCallback.current = undefined;
+    sessionListState.storedSessions = [];
+    sessionListState.activeSessions = [];
+    sessionListState.storedIsFetching = false;
+    sessionListState.storedLoadedPageCount = 1;
     refetchSpy.mockClear();
     invalidateQueries.mockClear();
   });
@@ -169,6 +181,34 @@ describe('AgentSessionListScreen foreground refresh', () => {
     mountedRenderers.length = 0;
     appState.listeners.clear();
     vi.restoreAllMocks();
+  });
+
+  it('keeps the history loading while a cleared session cache refills', async () => {
+    sessionListState.activeSessions = [{ id: 'active-session' }];
+    sessionListState.storedIsFetching = true;
+    sessionListState.storedLoadedPageCount = 0;
+
+    const renderer = await renderScreen();
+    const content = renderer.root.find(
+      node => typeof node.type === 'string' && (node.type as string) === 'AgentSessionListContent'
+    );
+
+    expect(content.props.hasAnySessions).toBe(true);
+    expect(content.props.isLoading).toBe(true);
+  });
+
+  it('keeps a confirmed empty session result visible during a background refetch', async () => {
+    sessionListState.activeSessions = [{ id: 'active-session' }];
+    sessionListState.storedIsFetching = true;
+    sessionListState.storedLoadedPageCount = 1;
+
+    const renderer = await renderScreen();
+    const content = renderer.root.find(
+      node => typeof node.type === 'string' && (node.type as string) === 'AgentSessionListContent'
+    );
+
+    expect(content.props.hasAnySessions).toBe(true);
+    expect(content.props.isLoading).toBe(false);
   });
 
   it('refetches and invalidates the active-sessions tray on foreground while focused', async () => {

--- a/apps/mobile/src/components/agents/session-list-screen.tsx
+++ b/apps/mobile/src/components/agents/session-list-screen.tsx
@@ -74,6 +74,8 @@ export function AgentSessionListScreen() {
     activeSessions,
     activeIsError,
     isLoading,
+    storedIsFetching,
+    storedLoadedPageCount,
     paging,
     refetch,
     handleRetry,
@@ -237,7 +239,7 @@ export function AgentSessionListScreen() {
           sections={sections}
           hasAnySessions={hasAnySessions}
           hasPinnedActive={hasPinnedActive}
-          isLoading={isLoading || !ready}
+          isLoading={isLoading || !ready || (storedIsFetching && storedLoadedPageCount === 0)}
           isError={contentIsError}
           activeIsError={activeIsError}
           hasStoredSessions={storedSessions.length > 0}

--- a/apps/mobile/src/components/agents/use-agent-session-list-data.ts
+++ b/apps/mobile/src/components/agents/use-agent-session-list-data.ts
@@ -225,6 +225,8 @@ export function useAgentSessionListData(options: {
     activeSessions,
     activeIsError,
     isLoading,
+    storedIsFetching,
+    storedLoadedPageCount,
     paging,
     refetch,
     handleRetry,

--- a/apps/mobile/src/components/kilo-chat/app-aware-keyboard-padding.tsx
+++ b/apps/mobile/src/components/kilo-chat/app-aware-keyboard-padding.tsx
@@ -10,7 +10,11 @@ function keyboardPaddingFromEvent(event: KeyboardEvent): number {
   return event.endCoordinates.height;
 }
 
-export function AppAwareKeyboardPaddingView({ style, ...props }: ComponentProps<typeof View>) {
+export function AppAwareKeyboardPaddingView({
+  style,
+  keyboardOffset = 0,
+  ...props
+}: ComponentProps<typeof View> & { keyboardOffset?: number }) {
   const [keyboardPadding, setKeyboardPadding] = useState(0);
 
   useEffect(() => {
@@ -55,5 +59,7 @@ export function AppAwareKeyboardPaddingView({ style, ...props }: ComponentProps<
     };
   }, []);
 
-  return <View {...props} style={[style, { paddingBottom: keyboardPadding }]} />;
+  const resolvedKeyboardPadding = keyboardPadding > 0 ? keyboardPadding + keyboardOffset : 0;
+
+  return <View {...props} style={[style, { paddingBottom: resolvedKeyboardPadding }]} />;
 }

--- a/apps/mobile/src/components/language-picker-sheet.mounted.test.tsx
+++ b/apps/mobile/src/components/language-picker-sheet.mounted.test.tsx
@@ -14,6 +14,20 @@ const reloadAppAsync = vi.hoisted(() => vi.fn());
 const setLanguagePreferenceAsync = vi.hoisted(() => vi.fn());
 const writeLanguageReturnTarget = vi.hoisted(() => vi.fn());
 const renameAndroidNotificationChannels = vi.hoisted(() => vi.fn());
+const platform = vi.hoisted(() => ({ OS: 'android' as 'android' | 'ios' }));
+const insets = vi.hoisted(() => ({ top: 0, bottom: 0, left: 0, right: 0 }));
+const keyboard = vi.hoisted(() => {
+  const listeners = new Map<string, (event?: { endCoordinates: { height: number } }) => void>();
+  return {
+    listeners,
+    addListener: vi.fn(
+      (event: string, listener: (event?: { endCoordinates: { height: number } }) => void) => {
+        listeners.set(event, listener);
+        return { remove: vi.fn(() => listeners.delete(event)) };
+      }
+    ),
+  };
+});
 const i18nManager = vi.hoisted(() => ({
   allowRTL: vi.fn(),
   isRTL: false,
@@ -45,8 +59,11 @@ const flatListMock = vi.hoisted(
 );
 vi.mock('react-native', () => ({
   ActivityIndicator: 'ActivityIndicator',
+  AppState: { addEventListener: vi.fn(() => ({ remove: vi.fn() })) },
   FlatList: flatListMock,
+  Keyboard: keyboard,
   Modal: 'Modal',
+  Platform: platform,
   Pressable: 'Pressable',
   ScrollView: 'ScrollView',
   TextInput: 'TextInput',
@@ -61,13 +78,15 @@ vi.mock('react-native-reanimated', () => ({
   SlideOutDown: { duration: vi.fn() },
 }));
 vi.mock('react-native-safe-area-context', () => ({
-  useSafeAreaInsets: () => ({ top: 0, bottom: 0, left: 0, right: 0 }),
+  useSafeAreaInsets: () => insets,
 }));
 vi.mock('sonner-native', () => ({ toast: { error: vi.fn() } }));
 vi.mock('@rn-primitives/portal', () => ({ Portal: 'Portal' }));
 vi.mock('expo', () => ({ reloadAppAsync }));
+vi.mock('@/components/empty-state', () => ({ EmptyState: 'EmptyState' }));
 vi.mock('@/components/picker-sheet', () => ({ PickerSheet: 'PickerSheet' }));
 vi.mock('@/components/ui/choice-row', () => ({ ChoiceRow: 'ChoiceRow' }));
+vi.mock('@/components/ui/icons', () => ({ SearchX: 'SearchX' }));
 vi.mock('@/components/ui/text', () => ({ Text: 'Text' }));
 vi.mock('@/lib/hooks/use-theme-colors', () => ({
   useThemeColors: () => ({ mutedForeground: '#6b7280' }),
@@ -169,6 +188,10 @@ describe('LanguagePickerSheet apply', () => {
     setLanguagePreferenceAsync.mockResolvedValue(true);
     reloadAppAsync.mockReset();
     writeLanguageReturnTarget.mockReset();
+    platform.OS = 'android';
+    insets.bottom = 0;
+    keyboard.listeners.clear();
+    keyboard.addListener.mockClear();
     i18nManager.isRTL = false;
     i18nManager.forceRTL.mockReset();
     vi.mocked(toast.error).mockClear();
@@ -176,6 +199,81 @@ describe('LanguagePickerSheet apply', () => {
 
   afterEach(async () => {
     await i18n.changeLanguage('en');
+  });
+
+  it('keeps the Android sheet above the keyboard and navigation inset', async () => {
+    insets.bottom = 24;
+    const renderer = await mountSheet(vi.fn<() => void>());
+    const overlay = findByType(renderer.root, 'View').find(
+      node => node.props.className === 'flex-1 justify-end bg-black/40'
+    );
+    if (!overlay) {
+      throw new Error('keyboard-aware sheet overlay not found');
+    }
+
+    expect(overlay.props.style).toEqual([undefined, { paddingBottom: 0 }]);
+    expect(keyboard.addListener).toHaveBeenCalledWith('keyboardDidShow', expect.any(Function));
+
+    act(() => {
+      keyboard.listeners.get('keyboardDidShow')?.({ endCoordinates: { height: 240 } });
+    });
+    expect(overlay.props.style).toEqual([undefined, { paddingBottom: 264 }]);
+
+    act(() => {
+      keyboard.listeners.get('keyboardDidHide')?.();
+    });
+    expect(overlay.props.style).toEqual([undefined, { paddingBottom: 0 }]);
+
+    renderer.unmount();
+  });
+
+  it('keeps the iOS sheet above the keyboard without adding its safe-area inset', async () => {
+    platform.OS = 'ios';
+    insets.bottom = 24;
+    const renderer = await mountSheet(vi.fn<() => void>());
+    const overlay = findByType(renderer.root, 'View').find(
+      node => node.props.className === 'flex-1 justify-end bg-black/40'
+    );
+    if (!overlay) {
+      throw new Error('keyboard-aware sheet overlay not found');
+    }
+
+    expect(keyboard.addListener).toHaveBeenCalledWith('keyboardWillShow', expect.any(Function));
+
+    act(() => {
+      keyboard.listeners.get('keyboardWillShow')?.({ endCoordinates: { height: 240 } });
+    });
+    expect(overlay.props.style).toEqual([undefined, { paddingBottom: 240 }]);
+
+    renderer.unmount();
+  });
+
+  it('shows the standard empty state when the search matches no languages', async () => {
+    const renderer = await mountSheet(vi.fn<() => void>());
+    const input = findByType(renderer.root, 'TextInput')[0];
+    if (!input) {
+      throw new Error('language search input not found');
+    }
+
+    act(() => {
+      (input.props.onChangeText as (value: string) => void)('zzzzzz');
+    });
+
+    const emptyState = findByType(renderer.root, 'EmptyState')[0];
+    expect(emptyState?.props).toMatchObject({
+      icon: 'SearchX',
+      placement: 'top',
+      title: 'No languages match',
+      description: 'Try a different search term.',
+    });
+    expect(findByType(renderer.root, 'ChoiceRow')).toHaveLength(0);
+
+    act(() => {
+      (input.props.onChangeText as (value: string) => void)('');
+    });
+    expect(findByType(renderer.root, 'EmptyState')).toHaveLength(0);
+
+    renderer.unmount();
   });
 
   it('applies an LTR language in place without reloading the app', async () => {

--- a/apps/mobile/src/components/language-picker-sheet.tsx
+++ b/apps/mobile/src/components/language-picker-sheet.tsx
@@ -6,6 +6,7 @@ import {
   FlatList,
   I18nManager,
   Modal,
+  Platform,
   Pressable,
   TextInput,
   View,
@@ -13,8 +14,11 @@ import {
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 import { toast } from 'sonner-native';
 
+import { EmptyState } from '@/components/empty-state';
+import { AppAwareKeyboardPaddingView } from '@/components/kilo-chat/app-aware-keyboard-padding';
 import { PickerSheet } from '@/components/picker-sheet';
 import { ChoiceRow } from '@/components/ui/choice-row';
+import { SearchX } from '@/components/ui/icons';
 import { Text } from '@/components/ui/text';
 import { applyLanguagePreference } from '@/i18n/apply-language';
 import { languageRows } from '@/i18n/language-rows';
@@ -225,9 +229,12 @@ export function LanguagePickerSheet({
             ) : null
           }
           ListEmptyComponent={
-            <Text variant="muted" className="py-8 text-center text-sm">
-              {t('language.noMatches')}
-            </Text>
+            <EmptyState
+              icon={SearchX}
+              placement="top"
+              title={t('language.noMatches')}
+              description={t('agents.sessionList.tryDifferentSearch')}
+            />
           }
           renderItem={({ item }) => (
             <ChoiceRow
@@ -267,7 +274,10 @@ export function LanguagePickerSheet({
         }
       }}
     >
-      <View className="flex-1 justify-end bg-black/40">
+      <AppAwareKeyboardPaddingView
+        className="flex-1 justify-end bg-black/40"
+        keyboardOffset={Platform.OS === 'android' ? insets.bottom : 0}
+      >
         <Pressable
           className="flex-1"
           accessibilityLabel={t('common.cancel')}
@@ -284,7 +294,7 @@ export function LanguagePickerSheet({
         >
           {renderSheetContent()}
         </View>
-      </View>
+      </AppAwareKeyboardPaddingView>
     </Modal>
   );
 }

--- a/apps/mobile/src/components/login-screen.test.ts
+++ b/apps/mobile/src/components/login-screen.test.ts
@@ -284,6 +284,24 @@ describe('login-screen language globe', () => {
     renderer.unmount();
   });
 
+  it('renders the globe after the screen without raising it above the toaster', async () => {
+    const renderer = await mountLoginScreen();
+    const globe = findGlobe(renderer.root);
+    const parent = globe.parent;
+    if (!parent) {
+      throw new Error('language globe parent not found');
+    }
+
+    const scrollViewIndex = parent.children.findIndex(
+      child => typeof child !== 'string' && (child.type as string) === 'ScrollView'
+    );
+    expect(scrollViewIndex).toBeGreaterThanOrEqual(0);
+    expect(parent.children.indexOf(globe)).toBeGreaterThan(scrollViewIndex);
+    expect(globe.props.className).not.toMatch(/\bz-/);
+
+    renderer.unmount();
+  });
+
   it('disables the globe during pending auth', async () => {
     deviceAuth.status = 'pending';
     deviceAuth.code = 'UC-1234';

--- a/apps/mobile/src/components/login-screen.tsx
+++ b/apps/mobile/src/components/login-screen.tsx
@@ -227,21 +227,6 @@ export function LoginScreen() {
         // eslint-disable-next-line react-native/no-inline-styles -- dynamic keyboard padding
         style={{ paddingBottom: androidKeyboardPad }}
       >
-        <Pressable
-          onPress={() => {
-            setLanguagePickerOpen(true);
-          }}
-          disabled={globeDisabled}
-          hitSlop={8}
-          accessibilityRole="button"
-          accessibilityLabel={t('common.language')}
-          accessibilityState={{ disabled: globeDisabled }}
-          className="absolute z-10 h-11 w-11 items-center justify-center rounded-full active:opacity-70 disabled:opacity-50"
-          // eslint-disable-next-line react-native/no-inline-styles -- safe-area + RTL-aware trailing edge
-          style={{ top: insets.top + 8, ...globeTrailing }}
-        >
-          <Globe size={22} color={colors.foreground} />
-        </Pressable>
         <ScrollView
           className="flex-1 bg-background"
           contentContainerClassName="flex-grow items-center justify-center gap-6 px-6 py-8"
@@ -365,6 +350,21 @@ export function LoginScreen() {
             )}
           </View>
         </ScrollView>
+        <Pressable
+          onPress={() => {
+            setLanguagePickerOpen(true);
+          }}
+          disabled={globeDisabled}
+          hitSlop={8}
+          accessibilityRole="button"
+          accessibilityLabel={t('common.language')}
+          accessibilityState={{ disabled: globeDisabled }}
+          className="absolute h-11 w-11 items-center justify-center rounded-full active:opacity-70 disabled:opacity-50"
+          // eslint-disable-next-line react-native/no-inline-styles -- safe-area + RTL-aware trailing edge
+          style={{ top: insets.top + 8, ...globeTrailing }}
+        >
+          <Globe size={22} color={colors.foreground} />
+        </Pressable>
       </View>
       <LanguagePickerSheet
         visible={languagePickerOpen}


### PR DESCRIPTION
## Summary
- Keep the sign-in globe behind toast notifications.
- Move the language sheet above Android and iOS keyboards.
- Show the standard translated search empty state.

## Verification
- `pnpm format`
- `pnpm typecheck`
- `pnpm lint`
- `pnpm check:unused`
- `pnpm test` (5,899 tests)
- `pnpm check:i18n` (87 catalogs)