### PR TITLE
fix(web): remove legacy GitHub install state

### DIFF
--- a/apps/web/src/app/api/integrations/github/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.test.ts
@@ -9,7 +9,6 @@ import { linkKiloUser } from '@/lib/bot-identity';
 import { bot } from '@/lib/bot';
 import { failureResult } from '@/lib/maybe-result';
 import { consumeInstallState } from '@/lib/integrations/github/install-state';
-import { getEnvVariable } from '@/lib/dotenvx';
 import {
   findIntegrationByInstallationId,
   upsertPlatformIntegrationForOwner,
@@ -18,7 +17,6 @@ import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { assertUserAdministersInstallation } from '@/lib/integrations/platforms/github/app-selector';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import type { StateAdapter } from 'chat';
-import { parseStateReturn } from '@/lib/integrations/validate-return-path';
 
 const mockState = { kind: 'state' } as unknown as StateAdapter;
 
@@ -44,7 +42,6 @@ jest.mock('@octokit/auth-app', () => ({
   createAppAuth: jest.fn(),
 }));
 jest.mock('@/lib/integrations/platforms/github/app-selector', () => ({
-  getGitHubAppTypeForOrganization: jest.fn(async () => 'standard'),
   getGitHubAppCredentials: jest.fn(() => ({
     appId: 'app-id',
     privateKey: 'private-key',
@@ -74,22 +71,6 @@ jest.mock('@sentry/nextjs', () => ({
 jest.mock('@/lib/integrations/github/install-state', () => ({
   consumeInstallState: jest.fn(),
 }));
-jest.mock('@/lib/dotenvx', () => ({
-  getEnvVariable: jest.fn((key: string) => process.env[key] ?? ''),
-  requireEnv: (name: string, value: string | undefined) => {
-    if (!value) throw new Error(`Missing required environment variable ${name}`);
-    return value;
-  },
-}));
-jest.mock('@/lib/integrations/validate-return-path', () => {
-  const actual = jest.requireActual('@/lib/integrations/validate-return-path');
-  return {
-    ...actual,
-    // Wrapped so tests can force the invalid-owner branch while every other
-    // path keeps the real return-path parsing.
-    parseStateReturn: jest.fn(actual.parseStateReturn),
-  };
-});
 
 const mockedGetUserFromAuth = jest.mocked(getUserFromAuth);
 const mockedVerifyGitHubBotLinkState = jest.mocked(verifyGitHubBotLinkState);
@@ -102,16 +83,15 @@ const mockedOctokit = jest.mocked(Octokit);
 const mockedUpsertPlatformIntegrationForOwner = jest.mocked(upsertPlatformIntegrationForOwner);
 const mockedIsOrganizationMember = jest.mocked(isOrganizationMember);
 const mockedConsumeInstallState = jest.mocked(consumeInstallState);
-const mockedGetEnvVariable = jest.mocked(getEnvVariable);
 const mockedAssertUserAdministersInstallation = jest.mocked(assertUserAdministersInstallation);
 const mockedCaptureException = jest.mocked(captureException);
 const mockedCaptureMessage = jest.mocked(captureMessage);
-const mockedParseStateReturn = jest.mocked(parseStateReturn);
 
 const USER_ID = '034489e8-19e0-4479-9d69-2edad719e847';
 const OTHER_USER_ID = 'c00b91a1-6959-4b04-9ef8-e8d37b340f4a';
 const GITHUB_USER_ID = '12345';
 const INSTALLATION_ID = '98765';
+const INSTALL_STATE_TOKEN = 'valid-database-token-for-callback-tests';
 
 beforeEach(() => {
   mockedExchangeGitHubOAuthCode.mockResolvedValue({
@@ -291,13 +271,24 @@ describe('GET /api/integrations/github/callback installation flow', () => {
           },
         }) as never
     );
+    mockedConsumeInstallState.mockResolvedValue({
+      token: INSTALL_STATE_TOKEN,
+      kilo_user_id: USER_ID,
+      owner_type: 'user',
+      owner_id: USER_ID,
+      github_app_type: 'standard',
+      return_to: '/github-app',
+      expires_at: new Date(Date.now() + 300_000).toISOString(),
+      consumed_at: null,
+      created_at: new Date().toISOString(),
+    });
   });
 
   test('associates an existing installation after GitHub updates its configuration', async () => {
     const { GET } = await import('./route');
     const response = await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=update&state=user_${USER_ID}%7Creturn%3D%252Fgithub-app&code=abc`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=update&state=${INSTALL_STATE_TOKEN}&code=abc`
       ) as never
     );
 
@@ -330,7 +321,6 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
       authFailedResponse: null,
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
-    mockedGetEnvVariable.mockReturnValue('true');
     mockedCreateAppAuth.mockReturnValue(
       jest.fn(async () => ({ token: 'github-app-token' })) as never
     );
@@ -496,9 +486,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
   });
 
-  test('consumes a DB-minted token before legacy prefix dispatch (unambiguous routing)', async () => {
-    // A token whose base64url shape begins with the legacy user_ prefix must
-    // still route through the database flow, never the legacy plaintext flow.
+  test('treats a prefixed state as opaque when it matches a database token', async () => {
     const PREFIXED_DB_TOKEN = `user_${DB_TOKEN}`;
     mockedConsumeInstallState.mockResolvedValue({
       token: PREFIXED_DB_TOKEN,
@@ -522,7 +510,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/github-app?github_install=success');
     expect(mockedConsumeInstallState).toHaveBeenCalledWith(PREFIXED_DB_TOKEN);
-    // The owner comes from the DB row (org), not from a legacy user_ parse.
+    // The owner always comes from the database row, never from token contents.
     expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalledWith(
       { type: 'org', id: 'org-db-owner' },
       expect.objectContaining({ platform: 'github' })
@@ -868,11 +856,10 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
   });
 });
 
-describe('GET /api/integrations/github/callback legacy flag gating', () => {
+describe('GET /api/integrations/github/callback plaintext state rejection', () => {
   beforeEach(() => {
     jest.clearAllMocks();
 
-    mockedUpsertPlatformIntegrationForOwner.mockResolvedValue({ ok: true });
     mockedGetUserFromAuth.mockResolvedValue({
       user: {
         id: USER_ID,
@@ -883,104 +870,24 @@ describe('GET /api/integrations/github/callback legacy flag gating', () => {
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
     mockedConsumeInstallState.mockResolvedValue(null);
-    mockedCreateAppAuth.mockReturnValue(
-      jest.fn(async () => ({ token: 'github-app-token' })) as never
-    );
-    mockedOctokit.mockImplementation(
-      () =>
-        ({
-          apps: {
-            getInstallation: jest.fn(async () => ({
-              data: {
-                account: { id: 12_345, login: 'securexg' },
-                created_at: '2026-07-09T19:00:00.000Z',
-                events: ['issues'],
-                permissions: { contents: 'write' },
-                repository_selection: 'all',
-              },
-            })),
-            listReposAccessibleToInstallation: jest.fn(),
-          },
-        }) as never
-    );
   });
 
-  test('accepts legacy org_ prefixed state when flag is enabled', async () => {
-    mockedGetEnvVariable.mockReturnValue('true');
-
+  test.each(['org_', 'user_'])('always rejects %s prefixed plaintext state', async prefix => {
     const { GET } = await import('./route');
     const response = await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=org_${USER_ID}&code=abc`
-      ) as never
-    );
-
-    expect(response.status).toBe(307);
-    expectRedirectLocation(
-      response,
-      `/organizations/${USER_ID}/integrations/github?success=installed`
-    );
-    expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalled();
-  });
-
-  test('refuses legacy org_ prefixed state when flag is disabled', async () => {
-    mockedGetEnvVariable.mockReturnValue('false');
-
-    const { GET } = await import('./route');
-    const response = await GET(
-      makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=org_${USER_ID}`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${prefix}${USER_ID}&code=abc`
       ) as never
     );
 
     expect(response.status).toBe(307);
     expectRedirectLocation(response, '/');
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
-  });
-
-  test('accepts legacy user_ prefixed state when flag is enabled', async () => {
-    mockedGetEnvVariable.mockReturnValue('true');
-
-    const { GET } = await import('./route');
-    const response = await GET(
-      makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}&code=abc`
-      ) as never
-    );
-
-    expect(response.status).toBe(307);
-    expectRedirectLocation(response, `/integrations/github?success=installed`);
-    expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalled();
-  });
-
-  test('refuses legacy user_ prefixed state when flag is disabled', async () => {
-    mockedGetEnvVariable.mockReturnValue('false');
-
-    const { GET } = await import('./route');
-    const response = await GET(
-      makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}&code=abc`
-      ) as never
-    );
-
-    expect(response.status).toBe(307);
-    expectRedirectLocation(response, '/');
-    expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
-  });
-
-  test('accepts legacy state when flag is unset (default enabled)', async () => {
-    mockedGetEnvVariable.mockReturnValue(undefined as unknown as string);
-
-    const { GET } = await import('./route');
-    const response = await GET(
-      makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}&code=abc`
-      ) as never
-    );
-
-    expect(response.status).toBe(307);
-    expectRedirectLocation(response, `/integrations/github?success=installed`);
-    expect(mockedUpsertPlatformIntegrationForOwner).toHaveBeenCalled();
+    expect(mockedExchangeGitHubOAuthCode).not.toHaveBeenCalled();
+    expect(mockedCreateAppAuth).not.toHaveBeenCalled();
+    const serializedMessage = JSON.stringify(mockedCaptureMessage.mock.calls);
+    expect(serializedMessage).not.toContain(`${prefix}${USER_ID}`);
+    expect(serializedMessage).toContain('state_not_bot_link_or_install_token');
   });
 });
 
@@ -997,8 +904,17 @@ describe('GET /api/integrations/github/callback admin proof', () => {
       authFailedResponse: null,
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
-    mockedConsumeInstallState.mockResolvedValue(null);
-    mockedGetEnvVariable.mockReturnValue('true');
+    mockedConsumeInstallState.mockResolvedValue({
+      token: INSTALL_STATE_TOKEN,
+      kilo_user_id: USER_ID,
+      owner_type: 'user',
+      owner_id: USER_ID,
+      github_app_type: 'standard',
+      return_to: null,
+      expires_at: new Date(Date.now() + 300_000).toISOString(),
+      consumed_at: null,
+      created_at: new Date().toISOString(),
+    });
     mockedCreateAppAuth.mockReturnValue(
       jest.fn(async () => ({ token: 'github-app-token' })) as never
     );
@@ -1032,7 +948,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
     const { GET } = await import('./route');
     const response = await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${INSTALL_STATE_TOKEN}`
       ) as never
     );
 
@@ -1048,7 +964,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
     const { GET } = await import('./route');
     const response = await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}&code=abc`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${INSTALL_STATE_TOKEN}&code=abc`
       ) as never
     );
 
@@ -1068,7 +984,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
     const { GET } = await import('./route');
     const response = await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}&code=abc`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${INSTALL_STATE_TOKEN}&code=abc`
       ) as never
     );
 
@@ -1086,7 +1002,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
     const { GET } = await import('./route');
     const response = await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}&code=abc`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${INSTALL_STATE_TOKEN}&code=abc`
       ) as never
     );
 
@@ -1105,7 +1021,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
     const { GET } = await import('./route');
     const response = await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}&code=abc`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${INSTALL_STATE_TOKEN}&code=abc`
       ) as never
     );
 
@@ -1120,7 +1036,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
     const { GET } = await import('./route');
     await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${INSTALL_STATE_TOKEN}`
       ) as never
     );
 
@@ -1138,7 +1054,7 @@ describe('GET /api/integrations/github/callback admin proof', () => {
     mockedAssertUserAdministersInstallation.mockResolvedValue(false);
     await GET(
       makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=user_${USER_ID}&code=abc`
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${INSTALL_STATE_TOKEN}&code=abc`
       ) as never
     );
 
@@ -1168,7 +1084,6 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
     } as never);
     mockedVerifyGitHubBotLinkState.mockReturnValue(null);
     mockedConsumeInstallState.mockResolvedValue(null);
-    mockedGetEnvVariable.mockReturnValue('true');
     mockedCreateAppAuth.mockReturnValue(
       jest.fn(async () => ({ token: 'github-app-token' })) as never
     );
@@ -1259,54 +1174,19 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
     expect(serializedException).toContain(INSTALLATION_ID);
   });
 
-  test('legacy-enabled warning does not include the raw state token', async () => {
-    const RAW_TOKEN = `org_sentry-redaction-legacy-${Date.now()}`;
-    mockedGetEnvVariable.mockReturnValue('true');
-
-    const { GET } = await import('./route');
-    const response = await GET(
-      makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${RAW_TOKEN}`
-      ) as never
-    );
-
-    expect(response.status).toBe(307);
-    expect(mockedCaptureMessage).toHaveBeenCalled();
-    const serializedMessage = JSON.stringify(mockedCaptureMessage.mock.calls);
-    // The raw state is a bearer token and must never reach Sentry.
-    expect(serializedMessage).not.toContain(RAW_TOKEN);
-    // Safe diagnostics survive: state class and the callback id.
-    expect(serializedMessage).toContain('legacy_org');
-    expect(serializedMessage).toContain('legacy_install_state');
-    expect(serializedMessage).toContain(INSTALLATION_ID);
-  });
-
-  test('legacy-refused warning does not include the raw state token', async () => {
-    const RAW_TOKEN = `user_sentry-redaction-refused-${Date.now()}`;
-    mockedGetEnvVariable.mockReturnValue('false');
-
-    const { GET } = await import('./route');
-    const response = await GET(
-      makeRequest(
-        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${RAW_TOKEN}`
-      ) as never
-    );
-
-    expect(response.status).toBe(307);
-    expectRedirectLocation(response, '/');
-    expect(mockedCaptureMessage).toHaveBeenCalled();
-    const serializedMessage = JSON.stringify(mockedCaptureMessage.mock.calls);
-    // The raw state is a bearer token and must never reach Sentry.
-    expect(serializedMessage).not.toContain(RAW_TOKEN);
-    // Safe diagnostics survive: state class and the callback id.
-    expect(serializedMessage).toContain('legacy_user');
-    expect(serializedMessage).toContain('legacy_install_state_disabled');
-    expect(serializedMessage).toContain(INSTALLATION_ID);
-  });
-
   test('missing-installation diagnostic does not include the raw state token or params', async () => {
-    const RAW_TOKEN = `user_${USER_ID}`;
-    mockedGetEnvVariable.mockReturnValue('true');
+    const RAW_TOKEN = `missing-installation-${Date.now()}`;
+    mockedConsumeInstallState.mockResolvedValue({
+      token: RAW_TOKEN,
+      kilo_user_id: USER_ID,
+      owner_type: 'user',
+      owner_id: USER_ID,
+      github_app_type: 'standard',
+      return_to: null,
+      expires_at: new Date(Date.now() + 300_000).toISOString(),
+      consumed_at: null,
+      created_at: new Date().toISOString(),
+    });
 
     const { GET } = await import('./route');
     const response = await GET(
@@ -1322,43 +1202,8 @@ describe('GET /api/integrations/github/callback Sentry redaction', () => {
     // The raw state is a bearer token and must never reach Sentry.
     expect(serializedMessage).not.toContain(RAW_TOKEN);
     // Safe diagnostics survive: state class, reason, and the setup action.
-    expect(serializedMessage).toContain('legacy_user');
+    expect(serializedMessage).toContain('install_token');
     expect(serializedMessage).toContain('missing_installation_id');
     expect(serializedMessage).toContain('setupAction');
-  });
-
-  test('invalid-owner diagnostic does not include the raw state token or params', async () => {
-    const RAW_TOKEN = `user_sentry-redaction-invalid-owner-${Date.now()}`;
-    mockedGetEnvVariable.mockReturnValue('true');
-    // Force the defensive invalid-owner branch inside handleLegacyInstallFlow,
-    // which is unreachable through the legacy prefix gate alone.
-    mockedParseStateReturn.mockReturnValue({ ownerToken: 'unrecognized', returnTo: null });
-
-    try {
-      const { GET } = await import('./route');
-      const response = await GET(
-        makeRequest(
-          `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${RAW_TOKEN}`
-        ) as never
-      );
-
-      expect(response.status).toBe(307);
-      expectRedirectLocation(response, '/');
-      expect(mockedCaptureMessage).toHaveBeenCalled();
-      const serializedMessage = JSON.stringify(mockedCaptureMessage.mock.calls);
-      // The raw state is a bearer token and must never reach Sentry.
-      expect(serializedMessage).not.toContain(RAW_TOKEN);
-      // Safe diagnostics survive: state class, reason, and the callback id.
-      expect(serializedMessage).toContain('legacy_user');
-      expect(serializedMessage).toContain('owner_not_org_or_user_prefix');
-      expect(serializedMessage).toContain(INSTALLATION_ID);
-    } finally {
-      const realParseStateReturn = jest.requireActual('@/lib/integrations/validate-return-path')
-        .parseStateReturn as (rawState: string | null) => {
-        ownerToken: string;
-        returnTo: string | null;
-      };
-      mockedParseStateReturn.mockImplementation(realParseStateReturn);
-    }
   });
 });

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -6,7 +6,6 @@ import { Octokit } from '@octokit/rest';
 import { createAppAuth } from '@octokit/auth-app';
 import { exchangeGitHubOAuthCode } from '@/lib/integrations/platforms/github/adapter';
 import {
-  getGitHubAppTypeForOrganization,
   getGitHubAppCredentials,
   assertUserAdministersInstallation,
   type GitHubAppType,
@@ -23,7 +22,6 @@ import type {
   IntegrationPermissions,
   Owner,
 } from '@/lib/integrations/core/types';
-import { parseStateReturn } from '@/lib/integrations/validate-return-path';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { verifyGitHubBotLinkState } from '@/lib/bot/github-link-state';
 import { linkKiloUser } from '@/lib/bot-identity';
@@ -33,18 +31,11 @@ import { PLATFORM } from '@/lib/integrations/core/constants';
 import { APP_URL } from '@/lib/constants';
 import { consumeInstallState } from '@/lib/integrations/github/install-state';
 import type { GitHubInstallState } from '@kilocode/db/schema';
-import { getEnvVariable } from '@/lib/dotenvx';
 
 const appendQueryParam = (path: string, queryParam: string): string =>
   `${path}${path.includes('?') ? '&' : '?'}${queryParam}`;
 
-type InstallStateClass =
-  | 'none'
-  | 'legacy_org'
-  | 'legacy_user'
-  | 'bot_link'
-  | 'install_token'
-  | 'unknown';
+type InstallStateClass = 'none' | 'bot_link' | 'install_token' | 'unknown';
 
 /**
  * Classifies a GitHub callback state value without revealing its contents.
@@ -53,8 +44,6 @@ type InstallStateClass =
  */
 function classifyInstallState(rawState: string | null): InstallStateClass {
   if (!rawState) return 'none';
-  if (rawState.startsWith('org_')) return 'legacy_org';
-  if (rawState.startsWith('user_')) return 'legacy_user';
   if (rawState.includes('.')) return 'bot_link';
   // Database install tokens are 32 random bytes, base64url-encoded (no dots).
   if (/^[A-Za-z0-9_-]{16,}$/.test(rawState)) return 'install_token';
@@ -157,59 +146,24 @@ export async function GET(request: NextRequest) {
     const setupAction = searchParams.get('setup_action');
     const rawState = searchParams.get('state');
 
-    // 3. New database-backed install state — atomically consume the token.
-    // Consumed before any other dispatch so a minted token is unambiguous:
-    // even if a random base64url token's shape began with a legacy org_/user_
-    // prefix, the DB row wins and the state is never misrouted to legacy or
-    // bot-link parsing.
+    // 3. Atomically consume a database-backed install state before attempting
+    // bot-link parsing. Database tokens are opaque and unambiguous once found.
     if (rawState) {
       const installRow = await consumeInstallState(rawState);
       if (installRow) {
         return await handleNewInstallFlow(request, user, installRow, installationId, setupAction);
       }
 
-      // 4. Legacy plaintext branch — starts with org_ or user_ prefix.
-      // Legacy states are never bot-link or database-minted tokens.
-      // They are accepted only when the GITHUB_LEGACY_INSTALL_STATE flag is enabled.
-      if (rawState.startsWith('org_') || rawState.startsWith('user_')) {
-        const legacyEnabled = (getEnvVariable('GITHUB_LEGACY_INSTALL_STATE') ?? 'true') !== 'false';
-
-        if (legacyEnabled) {
-          // ponytail: the legacy branch is deleted once the legacy-state counter
-          // reports zero for 30 consecutive days.
-          captureMessage('GitHub callback using legacy plaintext install state', {
-            level: 'info',
-            tags: { endpoint: 'github/callback', source: 'legacy_install_state' },
-            extra: { installationId, stateClass: classifyInstallState(rawState) },
-          });
-          return await handleLegacyInstallFlow(
-            request,
-            user,
-            rawState,
-            installationId,
-            setupAction
-          );
-        }
-
-        // Legacy flag disabled: refuse the legacy state.
-        captureMessage('GitHub callback with legacy state refused (flag disabled)', {
-          level: 'warning',
-          tags: { endpoint: 'github/callback', source: 'legacy_install_state_disabled' },
-          extra: { installationId, stateClass: classifyInstallState(rawState) },
-        });
-        return NextResponse.redirect(new URL('/', APP_URL));
-      }
-
-      // 5. Bot-link callback hand-off. Bot-link state tokens use a signed
+      // 4. Bot-link callback hand-off. Bot-link state tokens use a signed
       // dot-separated format and never collide with database tokens, which are
-      // base64url (no dots). Tried last, after DB and legacy dispatch.
+      // base64url (no dots).
       const botLinkState = verifyGitHubBotLinkState(rawState);
       if (botLinkState) {
         return await handleGitHubBotLinkCallback(request, user);
       }
     }
 
-    // 6. Both bot-link and database consume returned null.
+    // 5. Both bot-link verification and database consumption returned null.
     captureMessage('GitHub callback with unrecognized state', {
       level: 'warning',
       tags: { endpoint: 'github/callback', source: 'github_app_installation' },
@@ -240,20 +194,7 @@ export async function GET(request: NextRequest) {
       },
     });
 
-    const { ownerToken: errorOwnerToken, returnTo } = parseStateReturn(rawState);
-
-    let redirectPath = returnTo || '/';
-
-    if (!returnTo && errorOwnerToken.startsWith('org_')) {
-      const orgId = errorOwnerToken.slice(4);
-      redirectPath = `/organizations/${orgId}/integrations/github`;
-    } else if (!returnTo && errorOwnerToken.startsWith('user_')) {
-      redirectPath = `/integrations/github`;
-    }
-
-    return NextResponse.redirect(
-      new URL(appendQueryParam(redirectPath, 'error=installation_failed'), APP_URL)
-    );
+    return NextResponse.redirect(new URL('/?error=installation_failed', APP_URL));
   }
 }
 
@@ -311,56 +252,6 @@ async function handleNewInstallFlow(
 }
 
 /**
- * Legacy plaintext install flow. Parses owner from the org_/user_ prefix.
- * Gated by GITHUB_LEGACY_INSTALL_STATE flag.
- */
-async function handleLegacyInstallFlow(
-  request: NextRequest,
-  user: { id: string; google_user_email: string; google_user_name: string },
-  rawState: string,
-  installationId: string,
-  setupAction: string | null
-): Promise<Response> {
-  // Parse owner from state (with optional |return=<path> suffix)
-  const { ownerToken, returnTo } = parseStateReturn(rawState);
-  let owner: Owner;
-  let ownerId: string;
-
-  if (ownerToken.startsWith('org_')) {
-    ownerId = ownerToken.slice(4);
-    owner = { type: 'org', id: ownerId };
-  } else if (ownerToken.startsWith('user_')) {
-    ownerId = ownerToken.slice(5);
-    owner = { type: 'user', id: ownerId };
-  } else {
-    captureMessage('GitHub callback missing or invalid owner in state', {
-      level: 'warning',
-      tags: { endpoint: 'github/callback', source: 'github_app_installation' },
-      extra: {
-        installationId,
-        stateClass: classifyInstallState(rawState),
-        reason: 'owner_not_org_or_user_prefix',
-      },
-    });
-    return NextResponse.redirect(new URL('/', APP_URL));
-  }
-
-  const appType = await getGitHubAppTypeForOrganization(owner.type === 'org' ? owner.id : null);
-
-  return handleCoreInstallFlow({
-    request,
-    user,
-    owner,
-    ownerId,
-    returnTo,
-    installationId,
-    setupAction,
-    githubAppType: appType,
-  });
-}
-
-/**
- * Core install flow shared by both legacy and new branches.
  * Handles access checks, pending approval, and installation storage.
  */
 async function handleCoreInstallFlow(params: {

--- a/apps/web/src/lib/integrations/validate-return-path.test.ts
+++ b/apps/web/src/lib/integrations/validate-return-path.test.ts
@@ -1,4 +1,4 @@
-import { validateReturnPath, parseStateReturn } from './validate-return-path';
+import { validateReturnPath } from './validate-return-path';
 
 describe('validateReturnPath', () => {
   it('accepts a simple internal path', () => {
@@ -73,66 +73,5 @@ describe('validateReturnPath', () => {
 
   it('rejects triple-slash paths', () => {
     expect(validateReturnPath('///foo')).toBeNull();
-  });
-});
-
-describe('parseStateReturn', () => {
-  it('parses state with return suffix', () => {
-    const encoded = encodeURIComponent('/gastown/onboarding?step=repo');
-    const result = parseStateReturn(`user_abc|return=${encoded}`);
-    expect(result).toEqual({
-      ownerToken: 'user_abc',
-      returnTo: '/gastown/onboarding?step=repo',
-    });
-  });
-
-  it('parses org state with return suffix', () => {
-    const encoded = encodeURIComponent('/gastown/onboarding?step=repo&orgId=123');
-    const result = parseStateReturn(`org_123|return=${encoded}`);
-    expect(result).toEqual({
-      ownerToken: 'org_123',
-      returnTo: '/gastown/onboarding?step=repo&orgId=123',
-    });
-  });
-
-  it('parses state without return suffix (backwards compat)', () => {
-    const result = parseStateReturn('user_abc');
-    expect(result).toEqual({
-      ownerToken: 'user_abc',
-      returnTo: null,
-    });
-  });
-
-  it('parses org state without return suffix', () => {
-    const result = parseStateReturn('org_123');
-    expect(result).toEqual({
-      ownerToken: 'org_123',
-      returnTo: null,
-    });
-  });
-
-  it('returns null returnTo when return path is invalid', () => {
-    const encoded = encodeURIComponent('//evil.com');
-    const result = parseStateReturn(`user_abc|return=${encoded}`);
-    expect(result).toEqual({
-      ownerToken: 'user_abc',
-      returnTo: null,
-    });
-  });
-
-  it('handles null state', () => {
-    const result = parseStateReturn(null);
-    expect(result).toEqual({
-      ownerToken: '',
-      returnTo: null,
-    });
-  });
-
-  it('returns null returnTo when return suffix has malformed percent-encoding', () => {
-    const result = parseStateReturn('user_abc|return=%ZZ');
-    expect(result).toEqual({
-      ownerToken: 'user_abc',
-      returnTo: null,
-    });
   });
 });

--- a/apps/web/src/lib/integrations/validate-return-path.ts
+++ b/apps/web/src/lib/integrations/validate-return-path.ts
@@ -19,26 +19,3 @@ export function validateReturnPath(candidate: string): string | null {
     return null;
   }
 }
-
-export function parseStateReturn(rawState: string | null): {
-  ownerToken: string;
-  returnTo: string | null;
-} {
-  let ownerToken = rawState ?? '';
-  let returnTo: string | null = null;
-
-  if (rawState) {
-    const sepIdx = rawState.indexOf('|return=');
-    if (sepIdx !== -1) {
-      ownerToken = rawState.slice(0, sepIdx);
-      try {
-        const candidate = decodeURIComponent(rawState.slice(sepIdx + '|return='.length));
-        returnTo = validateReturnPath(candidate);
-      } catch {
-        returnTo = null;
-      }
-    }
-  }
-
-  return { ownerToken, returnTo };
-}


### PR DESCRIPTION
## Summary
- remove the `GITHUB_LEGACY_INSTALL_STATE` feature flag and plaintext `user_<UUID>` / `org_<UUID>` callback handling
- require GitHub installation callbacks to use database-backed, single-use install state or a valid signed bot-link state
- remove legacy owner and return-path parsing from callback state
- permanently test that plaintext owner-prefixed states are rejected before OAuth, GitHub App authentication, or persistence

## Security context
Follow-up to #5477. The production flag is already disabled; this removes the dormant compatibility path so an omitted or changed environment variable cannot re-enable plaintext install state.

## Verification
- `pnpm --filter web test -- --runInBand src/app/api/integrations/github/callback/route.test.ts src/lib/integrations/validate-return-path.test.ts` (52 passed)
- `pnpm --filter web typecheck`
- `pnpm -w exec oxlint --config .oxlintrc.json apps/web/src/app/api/integrations/github/callback/route.ts apps/web/src/app/api/integrations/github/callback/route.test.ts apps/web/src/lib/integrations/validate-return-path.ts apps/web/src/lib/integrations/validate-return-path.test.ts`
- `git diff --check origin/main...HEAD`