### PR TITLE
feat(github): redesign organization integrations

### DIFF
--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -24,6 +24,7 @@ import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombob
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { buildGitHubInstallState } from './github-install-state';
 import { useConfirm } from '@/components/ui/confirm';
+import { OrganizationGitHubInstallations } from './OrganizationGitHubInstallations';
 
 type GitHubIntegrationDetailsProps = {
   organizationId?: string;
@@ -116,7 +117,14 @@ export function buildAppReturnOutcomeView(input: {
   };
 }
 
-export function GitHubIntegrationDetails({
+export function GitHubIntegrationDetails(props: GitHubIntegrationDetailsProps) {
+  if (props.organizationId && !props.appReturnPath) {
+    return <OrganizationGitHubInstallations organizationId={props.organizationId} />;
+  }
+  return <GitHubIntegrationDetailsContent {...props} />;
+}
+
+function GitHubIntegrationDetailsContent({
   organizationId,
   installState,
   fromApp,
@@ -444,7 +452,7 @@ export function GitHubIntegrationDetails({
         destructive: true,
       })
     ) {
-      uninstallApp.mutate(managementInput, {
+      uninstallApp.mutate(input, {
         onSuccess: async () => {
           toast.success('GitHub App uninstalled');
           await refetch();
@@ -468,7 +476,7 @@ export function GitHubIntegrationDetails({
         destructive: true,
       })
     ) {
-      cancelPendingInstallation.mutate(managementInput, {
+      cancelPendingInstallation.mutate(input, {
         onSuccess: async () => {
           toast.success('Installation request cancelled');
           await refetch();
@@ -483,7 +491,7 @@ export function GitHubIntegrationDetails({
   };
 
   const handleRefresh = () => {
-    refreshInstallation.mutate(managementInput, {
+    refreshInstallation.mutate(input, {
       onSuccess: async () => {
         toast.success('Installation details refreshed', {
           description: 'Permissions and repositories have been updated from GitHub.',
@@ -518,9 +526,6 @@ export function GitHubIntegrationDetails({
   }
 
   const installation = installationData?.installation;
-  const managementInput = organizationId
-    ? { organizationId, integrationId: installation?.id }
-    : undefined;
   const status = installation?.status;
   const isPendingApproval = status === 'awaiting_installation';
 

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -444,7 +444,7 @@ export function GitHubIntegrationDetails({
         destructive: true,
       })
     ) {
-      uninstallApp.mutate(input, {
+      uninstallApp.mutate(managementInput, {
         onSuccess: async () => {
           toast.success('GitHub App uninstalled');
           await refetch();
@@ -468,7 +468,7 @@ export function GitHubIntegrationDetails({
         destructive: true,
       })
     ) {
-      cancelPendingInstallation.mutate(input, {
+      cancelPendingInstallation.mutate(managementInput, {
         onSuccess: async () => {
           toast.success('Installation request cancelled');
           await refetch();
@@ -483,7 +483,7 @@ export function GitHubIntegrationDetails({
   };
 
   const handleRefresh = () => {
-    refreshInstallation.mutate(input, {
+    refreshInstallation.mutate(managementInput, {
       onSuccess: async () => {
         toast.success('Installation details refreshed', {
           description: 'Permissions and repositories have been updated from GitHub.',
@@ -518,6 +518,9 @@ export function GitHubIntegrationDetails({
   }
 
   const installation = installationData?.installation;
+  const managementInput = organizationId
+    ? { organizationId, integrationId: installation?.id }
+    : undefined;
   const status = installation?.status;
   const isPendingApproval = status === 'awaiting_installation';
 

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -468,7 +468,7 @@ function GitHubIntegrationDetailsContent({
         destructive: true,
       })
     ) {
-      uninstallApp.mutate(input, {
+      uninstallApp.mutate(managementInput, {
         onSuccess: async () => {
           toast.success('GitHub App uninstalled');
           await refetch();
@@ -492,7 +492,7 @@ function GitHubIntegrationDetailsContent({
         destructive: true,
       })
     ) {
-      cancelPendingInstallation.mutate(input, {
+      cancelPendingInstallation.mutate(managementInput, {
         onSuccess: async () => {
           toast.success('Installation request cancelled');
           await refetch();
@@ -507,7 +507,7 @@ function GitHubIntegrationDetailsContent({
   };
 
   const handleRefresh = () => {
-    refreshInstallation.mutate(input, {
+    refreshInstallation.mutate(managementInput, {
       onSuccess: async () => {
         toast.success('Installation details refreshed', {
           description: 'Permissions and repositories have been updated from GitHub.',
@@ -542,6 +542,9 @@ function GitHubIntegrationDetailsContent({
   }
 
   const installation = installationData?.installation;
+  const managementInput = organizationId
+    ? { organizationId, integrationId: installation?.id }
+    : undefined;
   const status = installation?.status;
   const isPendingApproval = status === 'awaiting_installation';
 

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -117,11 +117,70 @@ export function buildAppReturnOutcomeView(input: {
   };
 }
 
+function GitHubIntegrationOutcomeToasts({
+  success,
+  userConnectionSuccess,
+  error,
+  pendingApproval,
+  existingPendingOrg,
+}: Pick<
+  GitHubIntegrationDetailsProps,
+  'success' | 'userConnectionSuccess' | 'error' | 'pendingApproval' | 'existingPendingOrg'
+>) {
+  useEffect(() => {
+    if (success) {
+      toast.success('GitHub App installed successfully!');
+    }
+    if (userConnectionSuccess) {
+      toast.success('GitHub identity connected');
+    }
+    if (pendingApproval) {
+      toast.info('Installation pending admin approval');
+    }
+    if (error === 'pending_installation_exists' && existingPendingOrg) {
+      toast.error('Cannot create installation request', {
+        description: `You already have a pending GitHub installation in another organization. Please complete or cancel that installation first.`,
+        duration: 8000,
+      });
+    } else if (error === 'not_installation_admin') {
+      toast.error(
+        'Only a GitHub admin of that account can connect it. Ask an organization admin to install Kilo.',
+        { duration: 8000 }
+      );
+    } else if (error === 'installation_already_claimed') {
+      toast.error(
+        'That GitHub installation is already connected to another Kilo account. Disconnect it there first.',
+        { duration: 8000 }
+      );
+    } else if (error === 'github_authorization_required') {
+      toast.error('GitHub did not return an authorization. Start the connection again.', {
+        duration: 8000,
+      });
+    } else if (error === 'already_connected_to_another_account') {
+      toast.error('This GitHub identity is already connected to another Kilo account.');
+    } else if (error === 'disconnect_existing_identity_first') {
+      toast.error('Disconnect your current GitHub identity before connecting another account.');
+    } else if (error === 'install_state_user_mismatch') {
+      // Handled by the fromApp fallback card or non-app mismatch landing.
+    } else if (error) {
+      toast.error(`GitHub connection failed: ${error}`);
+    }
+  }, [success, userConnectionSuccess, error, pendingApproval, existingPendingOrg]);
+
+  return null;
+}
+
 export function GitHubIntegrationDetails(props: GitHubIntegrationDetailsProps) {
-  if (props.organizationId && !props.appReturnPath) {
-    return <OrganizationGitHubInstallations organizationId={props.organizationId} />;
-  }
-  return <GitHubIntegrationDetailsContent {...props} />;
+  return (
+    <>
+      <GitHubIntegrationOutcomeToasts {...props} />
+      {props.organizationId && !props.appReturnPath ? (
+        <OrganizationGitHubInstallations organizationId={props.organizationId} />
+      ) : (
+        <GitHubIntegrationDetailsContent {...props} />
+      )}
+    </>
+  );
 }
 
 function GitHubIntegrationDetailsContent({
@@ -129,10 +188,8 @@ function GitHubIntegrationDetailsContent({
   installState,
   fromApp,
   success,
-  userConnectionSuccess,
   error,
   pendingApproval,
-  existingPendingOrg,
   appReturnPath,
   onInstallationDetected,
 }: GitHubIntegrationDetailsProps) {
@@ -302,47 +359,6 @@ function GitHubIntegrationDetailsContent({
     installationDetectedRef.current = true;
     onInstallationDetected?.();
   }, [appReturnPath, isInstalled, onInstallationDetected]);
-
-  // Show success/error/pending toasts
-  useEffect(() => {
-    if (success) {
-      toast.success('GitHub App installed successfully!');
-    }
-    if (userConnectionSuccess) {
-      toast.success('GitHub identity connected');
-    }
-    if (pendingApproval) {
-      toast.info('Installation pending admin approval');
-    }
-    if (error === 'pending_installation_exists' && existingPendingOrg) {
-      toast.error('Cannot create installation request', {
-        description: `You already have a pending GitHub installation in another organization. Please complete or cancel that installation first.`,
-        duration: 8000,
-      });
-    } else if (error === 'not_installation_admin') {
-      toast.error(
-        'Only a GitHub admin of that account can connect it. Ask an organization admin to install Kilo.',
-        { duration: 8000 }
-      );
-    } else if (error === 'installation_already_claimed') {
-      toast.error(
-        'That GitHub installation is already connected to another Kilo account. Disconnect it there first.',
-        { duration: 8000 }
-      );
-    } else if (error === 'github_authorization_required') {
-      toast.error('GitHub did not return an authorization. Start the connection again.', {
-        duration: 8000,
-      });
-    } else if (error === 'already_connected_to_another_account') {
-      toast.error('This GitHub identity is already connected to another Kilo account.');
-    } else if (error === 'disconnect_existing_identity_first') {
-      toast.error('Disconnect your current GitHub identity before connecting another account.');
-    } else if (error === 'install_state_user_mismatch') {
-      // Handled by the fromApp fallback card — no toast needed.
-    } else if (error) {
-      toast.error(`GitHub connection failed: ${error}`);
-    }
-  }, [success, userConnectionSuccess, error, pendingApproval, existingPendingOrg]);
 
   const handleModelChange = (modelSlug: string) => {
     setSelectedModel(modelSlug);

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -175,7 +175,32 @@ export function GitHubIntegrationDetails(props: GitHubIntegrationDetailsProps) {
     <>
       <GitHubIntegrationOutcomeToasts {...props} />
       {props.organizationId && !props.appReturnPath ? (
-        <OrganizationGitHubInstallations organizationId={props.organizationId} />
+        <div className="space-y-6">
+          <OrganizationGitHubInstallations organizationId={props.organizationId} />
+          <Card>
+            <CardHeader>
+              <div className="space-y-1.5">
+                <div className="flex flex-wrap items-center gap-2">
+                  <CardTitle className="flex items-center gap-2">
+                    <UserRound className="h-5 w-5" />
+                    Use your GitHub identity
+                  </CardTitle>
+                  <Badge variant="outline">Optional</Badge>
+                </div>
+                <CardDescription>
+                  Your GitHub identity is personal, not owned by this organization. Manage it from
+                  your personal integration to let eligible Cloud Agent sessions act as you where
+                  supported repository access is available.
+                </CardDescription>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <Button asChild variant="outline">
+                <Link href="/integrations/github#github-identity">Manage GitHub identity</Link>
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
       ) : (
         <GitHubIntegrationDetailsContent {...props} />
       )}

--- a/apps/web/src/components/integrations/IntegrationDetailPage.tsx
+++ b/apps/web/src/components/integrations/IntegrationDetailPage.tsx
@@ -38,7 +38,7 @@ const integrationDetailRegistry = {
     title: 'GitHub Integration',
     userSubtitle: 'Set up personal repository access and optional Cloud Agent attribution',
     organizationSubtitle: organizationName =>
-      `Manage repository access for ${organizationName} and link your personal identity.`,
+      `Connect the GitHub organizations whose repositories ${organizationName} can use.`,
     render: async ({ organizationId, search }) => {
       const { GitHubIntegrationDetails } =
         await import('@/components/integrations/GitHubIntegrationDetails');

--- a/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
+++ b/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronDown, ExternalLink, Github, MoreHorizontal, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import { useTRPC } from '@/lib/trpc/utils';
+import { buildGitHubInstallState } from './github-install-state';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useConfirm } from '@/components/ui/confirm';
+import { cn } from '@/lib/utils';
+import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
+
+type OrganizationGitHubInstallationsProps = {
+  organizationId: string;
+};
+
+const statusLabel = {
+  connected: 'Connected',
+  pending: 'Pending approval',
+  suspended: 'Suspended',
+  needs_attention: 'Needs attention',
+} as const;
+
+export function OrganizationGitHubInstallations({
+  organizationId,
+}: OrganizationGitHubInstallationsProps) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const confirm = useConfirm();
+  const [starting, setStarting] = useState(false);
+  const input = { organizationId };
+  const { data: organization } = useOrganizationWithMembers(organizationId);
+  const githubAppName =
+    organization?.settings?.github_app_type === 'lite'
+      ? process.env.NEXT_PUBLIC_GITHUB_LITE_APP_NAME || 'KiloConnect-Lite'
+      : process.env.NEXT_PUBLIC_GITHUB_APP_NAME || 'KiloConnect';
+  const query = useQuery(trpc.githubApps.listOrganizationInstallations.queryOptions(input));
+  const invalidate = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: trpc.githubApps.listOrganizationInstallations.queryKey(input),
+    });
+  };
+  const refresh = useMutation(
+    trpc.githubApps.refreshInstallation.mutationOptions({
+      onSuccess: async () => {
+        toast.success('GitHub access refreshed');
+        await invalidate();
+      },
+      onError: error =>
+        toast.error('Could not refresh GitHub access', { description: error.message }),
+    })
+  );
+  const uninstall = useMutation(
+    trpc.githubApps.uninstallApp.mutationOptions({
+      onSuccess: async () => {
+        toast.success('GitHub organization disconnected');
+        await invalidate();
+      },
+      onError: error =>
+        toast.error('Could not disconnect GitHub organization', { description: error.message }),
+    })
+  );
+  const cancel = useMutation(
+    trpc.githubApps.cancelPendingInstallation.mutationOptions({
+      onSuccess: async () => {
+        toast.success('Installation request removed from Kilo');
+        await invalidate();
+      },
+      onError: error =>
+        toast.error('Could not remove installation request', { description: error.message }),
+    })
+  );
+  const mint = useMutation(trpc.githubApps.mintInstallState.mutationOptions());
+
+  const startInstall = async () => {
+    setStarting(true);
+    try {
+      const result = await mint.mutateAsync({ organizationId });
+      window.location.href = `https://github.com/apps/${githubAppName}/installations/new?state=${encodeURIComponent(buildGitHubInstallState(result.token))}`;
+    } catch (error) {
+      setStarting(false);
+      toast.error('Could not open GitHub setup', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+
+  if (query.isLoading) {
+    return <div className="h-40 animate-pulse rounded-xl border border-border bg-card" />;
+  }
+
+  const installations = query.data?.installations ?? [];
+  return (
+    <Card className="min-w-0 overflow-hidden">
+      <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1.5">
+          <CardTitle>GitHub organizations</CardTitle>
+          <CardDescription>
+            Connect the GitHub organizations whose repositories Kilo Cloud Agent and Code Reviewer
+            can use.
+          </CardDescription>
+        </div>
+        {query.data?.canAdd && (
+          <Button onClick={startInstall} disabled={starting} className="shrink-0">
+            <Github className="size-4" />
+            {starting ? 'Opening GitHub...' : 'Connect GitHub'}
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent>
+        {query.isError ? (
+          <p className="text-destructive text-sm">Could not load GitHub organizations.</p>
+        ) : installations.length === 0 ? (
+          <div className="min-w-0 rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+            No GitHub organizations are connected yet. GitHub will let you choose an organization
+            and repository access.
+          </div>
+        ) : (
+          <div className="divide-y rounded-lg border">
+            {installations.map(installation => {
+              const selectedCount = installation.repositories.length;
+              const repositoryScope =
+                installation.repositorySelection === 'all'
+                  ? 'All repositories'
+                  : `${selectedCount} selected ${selectedCount === 1 ? 'repository' : 'repositories'}`;
+              return (
+                <Collapsible key={installation.id}>
+                  <div className="flex min-w-0 items-center gap-3 p-4">
+                    <Github className="size-5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="truncate font-medium">
+                          {installation.accountLogin ?? 'GitHub organization'}
+                        </span>
+                        <Badge
+                          variant={installation.status === 'connected' ? 'default' : 'secondary'}
+                        >
+                          {statusLabel[installation.status]}
+                        </Badge>
+                        {installation.isPrimary && installations.length > 1 && (
+                          <Badge variant="outline">Primary</Badge>
+                        )}
+                      </div>
+                      <p className="mt-1 text-sm text-muted-foreground">{repositoryScope}</p>
+                    </div>
+                    {installation.repositorySelection === 'selected' && selectedCount > 0 && (
+                      <CollapsibleTrigger asChild>
+                        <Button variant="ghost" size="sm" className="group shrink-0">
+                          Repositories
+                          <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+                        </Button>
+                      </CollapsibleTrigger>
+                    )}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Manage ${installation.accountLogin ?? 'GitHub organization'}`}
+                        >
+                          <MoreHorizontal className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {installation.installationId && (
+                          <DropdownMenuItem asChild>
+                            <a
+                              href={`https://github.com/apps/${githubAppName}/installations/${installation.installationId}`}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              Manage on GitHub <ExternalLink className="ml-auto size-3.5" />
+                            </a>
+                          </DropdownMenuItem>
+                        )}
+                        {installation.canRefresh && (
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              refresh.mutate({ organizationId, integrationId: installation.id })
+                            }
+                          >
+                            Refresh access <RefreshCw className="ml-auto size-3.5" />
+                          </DropdownMenuItem>
+                        )}
+                        {(installation.canCancel || installation.canUninstall) && (
+                          <DropdownMenuSeparator />
+                        )}
+                        {installation.canCancel && (
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              cancel.mutate({ organizationId, integrationId: installation.id })
+                            }
+                          >
+                            Remove pending request
+                          </DropdownMenuItem>
+                        )}
+                        {installation.canUninstall && installation.installationId && (
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onSelect={async () => {
+                              const account =
+                                installation.accountLogin ?? 'this GitHub organization';
+                              if (
+                                await confirm({
+                                  title: `Disconnect ${account}?`,
+                                  description: `This uninstalls the Kilo GitHub App from ${account}. Kilo will lose access to its repositories.`,
+                                  confirmLabel: `Disconnect ${account}`,
+                                  destructive: true,
+                                })
+                              ) {
+                                uninstall.mutate({
+                                  organizationId,
+                                  integrationId: installation.id,
+                                });
+                              }
+                            }}
+                          >
+                            Disconnect organization
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                  {installation.repositorySelection === 'selected' && (
+                    <CollapsibleContent>
+                      <div className="border-t bg-muted/30 px-4 py-3">
+                        <ul className="grid gap-1 sm:grid-cols-2">
+                          {installation.repositories.map(repository => (
+                            <li
+                              key={repository.id}
+                              className={cn('truncate font-mono text-xs text-muted-foreground')}
+                            >
+                              {repository.full_name}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </CollapsibleContent>
+                  )}
+                </Collapsible>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
+++ b/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
@@ -8,7 +8,7 @@ import { useTRPC } from '@/lib/trpc/utils';
 import { buildGitHubInstallState } from './github-install-state';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Card } from '@/components/ui/card';
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
 import {
   DropdownMenu,
@@ -18,7 +18,6 @@ import {
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
 import { useConfirm } from '@/components/ui/confirm';
-import { cn } from '@/lib/utils';
 import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
 
 type OrganizationGitHubInstallationsProps = {
@@ -97,55 +96,68 @@ export function OrganizationGitHubInstallations({
   };
 
   if (query.isLoading) {
-    return <div className="h-40 animate-pulse rounded-xl border border-border bg-card" />;
+    return (
+      <Card className="overflow-hidden" aria-busy="true" aria-label="Loading GitHub organizations">
+        <div className="px-5 py-5 sm:px-6">
+          <div className="h-5 w-44 animate-pulse rounded bg-muted" />
+        </div>
+        <div className="border-border flex items-center gap-3 border-t px-4 py-5 sm:px-6">
+          <div className="size-5 animate-pulse rounded bg-muted" />
+          <div className="flex-1 space-y-2">
+            <div className="h-4 w-32 animate-pulse rounded bg-muted" />
+            <div className="h-3 w-24 animate-pulse rounded bg-muted" />
+          </div>
+        </div>
+      </Card>
+    );
   }
 
   const installations = query.data?.installations ?? [];
   return (
-    <Card className="min-w-0 overflow-hidden">
-      <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
-        <div className="space-y-1.5">
-          <CardTitle>GitHub organizations</CardTitle>
-          <CardDescription>
-            Connect the GitHub organizations whose repositories Kilo Cloud Agent and Code Reviewer
-            can use.
-          </CardDescription>
+    <section className="min-w-0" aria-labelledby="github-organizations-heading">
+      <Card className="overflow-hidden">
+        <div className="flex flex-col gap-3 px-5 py-5 sm:flex-row sm:items-center sm:justify-between sm:px-6">
+          <h2 id="github-organizations-heading" className="type-heading">
+            GitHub organizations
+          </h2>
+          {query.data?.canAdd && (
+            <Button
+              onClick={startInstall}
+              disabled={starting}
+              className="min-h-11 w-full shrink-0 sm:min-h-0 sm:w-auto"
+            >
+              <Github className="size-4" />
+              {starting ? 'Opening GitHub...' : 'Connect GitHub'}
+            </Button>
+          )}
         </div>
-        {query.data?.canAdd && (
-          <Button onClick={startInstall} disabled={starting} className="shrink-0">
-            <Github className="size-4" />
-            {starting ? 'Opening GitHub...' : 'Connect GitHub'}
-          </Button>
-        )}
-      </CardHeader>
-      <CardContent>
+
         {query.isError ? (
-          <p className="text-destructive text-sm">Could not load GitHub organizations.</p>
+          <p className="border-border border-t px-5 py-6 text-sm text-destructive sm:px-6">
+            Could not load GitHub organizations.
+          </p>
         ) : installations.length === 0 ? (
-          <div className="min-w-0 rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+          <p className="border-border border-t px-5 py-8 text-center text-sm text-muted-foreground sm:px-6">
             No GitHub organizations are connected yet. GitHub will let you choose an organization
             and repository access.
-          </div>
+          </p>
         ) : (
-          <div className="divide-y rounded-lg border">
+          <div className="divide-border border-border divide-y border-t">
             {installations.map(installation => {
               const selectedCount = installation.repositories.length;
               const repositoryScope =
                 installation.repositorySelection === 'all'
                   ? 'All repositories'
                   : `${selectedCount} selected ${selectedCount === 1 ? 'repository' : 'repositories'}`;
+              const accountName = installation.accountLogin ?? 'GitHub organization';
               return (
                 <Collapsible key={installation.id}>
-                  <div className="flex min-w-0 items-center gap-3 p-4">
-                    <Github className="size-5 shrink-0 text-muted-foreground" />
+                  <div className="flex min-w-0 items-center gap-3 px-4 py-4 sm:px-5">
+                    <Github className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
                     <div className="min-w-0 flex-1">
-                      <div className="flex flex-wrap items-center gap-2">
-                        <span className="truncate font-medium">
-                          {installation.accountLogin ?? 'GitHub organization'}
-                        </span>
-                        <Badge
-                          variant={installation.status === 'connected' ? 'default' : 'secondary'}
-                        >
+                      <div className="flex min-w-0 flex-wrap items-center gap-2">
+                        <span className="max-w-full truncate font-medium">{accountName}</span>
+                        <Badge variant={installation.status === 'connected' ? 'new' : 'secondary'}>
                           {statusLabel[installation.status]}
                         </Badge>
                         {installation.isPrimary && installations.length > 1 && (
@@ -156,8 +168,13 @@ export function OrganizationGitHubInstallations({
                     </div>
                     {installation.repositorySelection === 'selected' && selectedCount > 0 && (
                       <CollapsibleTrigger asChild>
-                        <Button variant="ghost" size="sm" className="group shrink-0">
-                          Repositories
+                        <Button
+                          variant="ghost"
+                          size="sm"
+                          className="group min-h-11 min-w-11 shrink-0 px-0 sm:min-h-0 sm:min-w-0 sm:px-3"
+                          aria-label={`Show repositories for ${accountName}`}
+                        >
+                          <span className="hidden sm:inline">Repositories</span>
                           <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
                         </Button>
                       </CollapsibleTrigger>
@@ -167,7 +184,8 @@ export function OrganizationGitHubInstallations({
                         <Button
                           variant="ghost"
                           size="icon"
-                          aria-label={`Manage ${installation.accountLogin ?? 'GitHub organization'}`}
+                          className="min-h-11 min-w-11 sm:min-h-0 sm:min-w-0"
+                          aria-label={`Manage ${accountName}`}
                         >
                           <MoreHorizontal className="size-4" />
                         </Button>
@@ -234,12 +252,12 @@ export function OrganizationGitHubInstallations({
                   </div>
                   {installation.repositorySelection === 'selected' && (
                     <CollapsibleContent>
-                      <div className="border-t bg-muted/30 px-4 py-3">
+                      <div className="border-border bg-muted/30 border-t px-4 py-3 sm:px-5">
                         <ul className="grid gap-1 sm:grid-cols-2">
                           {installation.repositories.map(repository => (
                             <li
                               key={repository.id}
-                              className={cn('truncate font-mono text-xs text-muted-foreground')}
+                              className="truncate font-mono text-xs text-muted-foreground"
                             >
                               {repository.full_name}
                             </li>
@@ -253,7 +271,7 @@ export function OrganizationGitHubInstallations({
             })}
           </div>
         )}
-      </CardContent>
-    </Card>
+      </Card>
+    </section>
   );
 }

--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -40,6 +40,7 @@ type SecurityAgentContextValue = {
   // Permission & config state
   hasIntegration: boolean;
   hasPermission: boolean;
+  integrationId: string | null;
   isLoadingPermission: boolean;
   isLoadingConfig: boolean;
   reauthorizeUrl: string | undefined;
@@ -1382,6 +1383,7 @@ function useSecurityAgentProviderValue(
 
   const hasIntegration = permissionData?.hasIntegration ?? false;
   const hasPermission = permissionData?.hasPermissions ?? false;
+  const integrationId = permissionData?.integrationId ?? null;
   const reauthorizeUrl = permissionData?.reauthorizeUrl ?? undefined;
   const isEnabled = configData ? configData.isEnabled : undefined;
   const hasConfig = configData?.hasConfig ?? false;
@@ -1407,6 +1409,7 @@ function useSecurityAgentProviderValue(
       isOrg,
       hasIntegration,
       hasPermission,
+      integrationId,
       isLoadingPermission,
       isLoadingConfig,
       reauthorizeUrl,
@@ -1470,6 +1473,7 @@ function useSecurityAgentProviderValue(
       isOrg,
       hasIntegration,
       hasPermission,
+      integrationId,
       isLoadingPermission,
       isLoadingConfig,
       reauthorizeUrl,

--- a/apps/web/src/components/security-agent/SecurityAgentLayout.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentLayout.tsx
@@ -301,6 +301,7 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
     isOrg,
     hasIntegration,
     hasPermission,
+    integrationId,
     isLoadingPermission,
     isLoadingConfig,
     isEnabled,
@@ -352,8 +353,8 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
   );
 
   const handleRefreshPermissions = () => {
-    if (isOrg && organizationId) {
-      refreshMutate({ organizationId });
+    if (isOrg && organizationId && integrationId) {
+      refreshMutate({ organizationId, integrationId });
     } else {
       refreshMutate(undefined);
     }

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
@@ -7,6 +7,8 @@ const mockGetIntegrationForOrganization =
   jest.fn<(organizationId: string, platform: string) => Promise<PlatformIntegration | null>>();
 const mockGetIntegrationForOwner =
   jest.fn<(owner: Owner, platform: string) => Promise<PlatformIntegration | null>>();
+const mockGetPrimaryGitHubIntegrationForOrganization =
+  jest.fn<(organizationId: string) => Promise<PlatformIntegration | null>>();
 const mockUpdateRepositoriesForIntegration =
   jest.fn<(integrationId: string, repositories: unknown[]) => Promise<void>>();
 const mockFetchGitHubRepositories =
@@ -27,6 +29,7 @@ const mockCheckExistingFork =
 jest.mock('@/lib/integrations/db/platform-integrations', () => ({
   getIntegrationForOrganization: mockGetIntegrationForOrganization,
   getIntegrationForOwner: mockGetIntegrationForOwner,
+  getPrimaryGitHubIntegrationForOrganization: mockGetPrimaryGitHubIntegrationForOrganization,
   updateRepositoriesForIntegration: mockUpdateRepositoriesForIntegration,
 }));
 
@@ -101,6 +104,7 @@ describe('github-integration-helpers', () => {
 
       expect(result.integrationInstalled).toBe(false);
       expect(result.repositories).toEqual([]);
+      expect(result.errorMessage).toBe('GitHub integration is suspended');
       expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
     });
 
@@ -151,7 +155,7 @@ describe('github-integration-helpers', () => {
 
   describe('fetchGitHubRepositoriesForOrganization', () => {
     it('returns cached repositories for an active integration', async () => {
-      mockGetIntegrationForOrganization.mockResolvedValue(buildIntegration());
+      mockGetPrimaryGitHubIntegrationForOrganization.mockResolvedValue(buildIntegration());
 
       const { fetchGitHubRepositoriesForOrganization } =
         await import('./github-integration-helpers');
@@ -165,6 +169,7 @@ describe('github-integration-helpers', () => {
     });
 
     it('returns integrationInstalled false when no integration exists', async () => {
+      mockGetPrimaryGitHubIntegrationForOrganization.mockResolvedValue(null);
       mockGetIntegrationForOrganization.mockResolvedValue(null);
 
       const { fetchGitHubRepositoriesForOrganization } =
@@ -176,6 +181,7 @@ describe('github-integration-helpers', () => {
     });
 
     it('returns no repositories when the integration is suspended', async () => {
+      mockGetPrimaryGitHubIntegrationForOrganization.mockResolvedValue(null);
       mockGetIntegrationForOrganization.mockResolvedValue(
         buildIntegration({
           integration_status: 'suspended',
@@ -190,10 +196,27 @@ describe('github-integration-helpers', () => {
 
       expect(result.integrationInstalled).toBe(false);
       expect(result.repositories).toEqual([]);
+      expect(result.errorMessage).toBe('GitHub integration is suspended');
+      expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+    });
+
+    it('returns no repositories when the integration requires reauthorization', async () => {
+      mockGetPrimaryGitHubIntegrationForOrganization.mockResolvedValue(null);
+      mockGetIntegrationForOrganization.mockResolvedValue(
+        buildIntegration({ auth_invalid_at: '2026-06-25 18:00:00+00' })
+      );
+
+      const { fetchGitHubRepositoriesForOrganization } =
+        await import('./github-integration-helpers');
+      const result = await fetchGitHubRepositoriesForOrganization('org-123');
+
+      expect(result.integrationInstalled).toBe(false);
+      expect(result.errorMessage).toBe('GitHub integration requires reauthorization');
       expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
     });
 
     it('does not refresh repositories for a suspended integration even with forceRefresh', async () => {
+      mockGetPrimaryGitHubIntegrationForOrganization.mockResolvedValue(null);
       mockGetIntegrationForOrganization.mockResolvedValue(
         buildIntegration({ integration_status: 'suspended' })
       );

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
@@ -2,6 +2,7 @@ import { TRPCError } from '@trpc/server';
 import {
   getIntegrationForOrganization,
   getIntegrationForOwner,
+  getPrimaryGitHubIntegrationForOrganization,
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
 import {
@@ -50,7 +51,7 @@ const missingIntegrationResponse = (message: string): GitHubRepositoriesResult =
 export async function getGitHubTokenForOrganization(
   organizationId: string
 ): Promise<string | undefined> {
-  const integration = await getIntegrationForOrganization(organizationId, PLATFORM.GITHUB);
+  const integration = await getPrimaryGitHubIntegrationForOrganization(organizationId);
 
   if (!integration?.platform_installation_id) {
     return undefined;
@@ -102,7 +103,7 @@ export async function getGitHubTokenForUser(userId: string): Promise<string | un
 export async function getGitHubInstallationIdForOrganization(
   organizationId: string
 ): Promise<string | undefined> {
-  const integration = await getIntegrationForOrganization(organizationId, PLATFORM.GITHUB);
+  const integration = await getPrimaryGitHubIntegrationForOrganization(organizationId);
   return integration?.platform_installation_id ?? undefined;
 }
 
@@ -123,14 +124,23 @@ export async function fetchGitHubRepositoriesForOrganization(
   organizationId: string,
   forceRefresh: boolean = false
 ): Promise<GitHubRepositoriesResult> {
-  const integration = await getIntegrationForOrganization(organizationId, PLATFORM.GITHUB);
+  const integration = await getPrimaryGitHubIntegrationForOrganization(organizationId);
 
   if (!integration) {
+    const unavailableIntegration = await getIntegrationForOrganization(
+      organizationId,
+      PLATFORM.GITHUB
+    );
+    if (isPlatformIntegrationSuspended(unavailableIntegration)) {
+      return missingIntegrationResponse('GitHub integration is suspended');
+    }
+    if (unavailableIntegration?.auth_invalid_at) {
+      return missingIntegrationResponse('GitHub integration requires reauthorization');
+    }
+    if (unavailableIntegration) {
+      return missingIntegrationResponse('GitHub integration is not properly configured');
+    }
     return missingIntegrationResponse('No GitHub integration found for this organization');
-  }
-
-  if (isPlatformIntegrationSuspended(integration)) {
-    return missingIntegrationResponse('GitHub integration is suspended');
   }
 
   if (!integration.platform_installation_id) {

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/drizzle';
 import { platform_integrations } from '@kilocode/db/schema';
-import { eq, and, isNull, desc, sql } from 'drizzle-orm';
+import { eq, and, isNull, asc, desc, sql } from 'drizzle-orm';
 import type {
   GitHubRequester,
   IntegrationPermissions,
@@ -57,10 +57,17 @@ export async function getIntegrationForOrganization(organizationId: string, plat
     .where(
       and(
         eq(platform_integrations.owned_by_organization_id, organizationId),
-        eq(platform_integrations.platform, platform)
+        eq(platform_integrations.platform, platform),
+        ...(platform === PLATFORM.GITHUB ? [platformIntegrationHealthSql()] : [])
       )
     )
-    .orderBy(desc(platformIntegrationHealthSql()), desc(platform_integrations.updated_at))
+    .orderBy(
+      desc(platformIntegrationHealthSql()),
+      platform === PLATFORM.GITHUB
+        ? asc(platform_integrations.created_at)
+        : desc(platform_integrations.updated_at),
+      asc(platform_integrations.id)
+    )
     .limit(1);
 
   return integration || null;
@@ -90,6 +97,27 @@ export async function getIntegrationById(integrationId: string, organizationId?:
     .limit(1);
 
   return integration || null;
+}
+
+export async function getGitHubIntegrationById(owner: Owner, integrationId: string) {
+  const ownershipCondition =
+    owner.type === 'user'
+      ? eq(platform_integrations.owned_by_user_id, owner.id)
+      : eq(platform_integrations.owned_by_organization_id, owner.id);
+
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.id, integrationId),
+        ownershipCondition,
+        eq(platform_integrations.platform, PLATFORM.GITHUB)
+      )
+    )
+    .limit(1);
+
+  return integration ?? null;
 }
 
 /**
@@ -519,6 +547,9 @@ export async function getIntegrationForOwner(
   platform: string,
   status?: IntegrationStatus
 ) {
+  if (owner.type === 'org' && platform === PLATFORM.GITHUB) {
+    return getIntegrationForOrganization(owner.id, platform);
+  }
   const ownershipCondition =
     owner.type === 'user'
       ? eq(platform_integrations.owned_by_user_id, owner.id)

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -48,7 +48,8 @@ export async function findIntegrationByInstallationId(
 }
 
 /**
- * Gets platform integration for an organization
+ * Gets an organization's preferred integration, including an unhealthy row
+ * when no healthy integration exists. Use this for status and recovery UI.
  */
 export async function getIntegrationForOrganization(organizationId: string, platform: string) {
   const [integration] = await db
@@ -57,8 +58,7 @@ export async function getIntegrationForOrganization(organizationId: string, plat
     .where(
       and(
         eq(platform_integrations.owned_by_organization_id, organizationId),
-        eq(platform_integrations.platform, platform),
-        ...(platform === PLATFORM.GITHUB ? [platformIntegrationHealthSql()] : [])
+        eq(platform_integrations.platform, platform)
       )
     )
     .orderBy(
@@ -71,6 +71,27 @@ export async function getIntegrationForOrganization(organizationId: string, plat
     .limit(1);
 
   return integration || null;
+}
+
+/**
+ * Gets the oldest healthy GitHub integration for an organization.
+ * Operational callers must not fall back to an unhealthy installation.
+ */
+export async function getPrimaryGitHubIntegrationForOrganization(organizationId: string) {
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.owned_by_organization_id, organizationId),
+        eq(platform_integrations.platform, PLATFORM.GITHUB),
+        platformIntegrationHealthSql()
+      )
+    )
+    .orderBy(asc(platform_integrations.created_at), asc(platform_integrations.id))
+    .limit(1);
+
+  return integration ?? null;
 }
 
 export async function getAllIntegationsForOrganization(organizationId: string) {
@@ -548,7 +569,7 @@ export async function getIntegrationForOwner(
   status?: IntegrationStatus
 ) {
   if (owner.type === 'org' && platform === PLATFORM.GITHUB) {
-    return getIntegrationForOrganization(owner.id, platform);
+    return getPrimaryGitHubIntegrationForOrganization(owner.id);
   }
   const ownershipCondition =
     owner.type === 'user'

--- a/apps/web/src/lib/integrations/github-apps-service.test.ts
+++ b/apps/web/src/lib/integrations/github-apps-service.test.ts
@@ -44,6 +44,45 @@ describe('getInstallation', () => {
       await db.delete(organizations).where(eq(organizations.id, organization.id));
     }
   });
+
+  it('keeps the oldest healthy organization installation primary', async () => {
+    const [organization] = await db
+      .insert(organizations)
+      .values({ name: `GitHub primary ${crypto.randomUUID()}` })
+      .returning();
+    const oldestCreatedAt = '2026-01-01T00:00:00.000Z';
+    const newestCreatedAt = '2026-02-01T00:00:00.000Z';
+    const rows = await db
+      .insert(platform_integrations)
+      .values([
+        {
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: crypto.randomUUID(),
+          integration_status: 'active',
+          repository_access: 'all',
+          created_at: oldestCreatedAt,
+        },
+        {
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: crypto.randomUUID(),
+          integration_status: 'active',
+          repository_access: 'all',
+          created_at: newestCreatedAt,
+        },
+      ])
+      .returning();
+
+    try {
+      const integration = await getInstallation({ type: 'org', id: organization.id });
+      expect(integration?.id).toBe(rows[0].id);
+    } finally {
+      await db.delete(organizations).where(eq(organizations.id, organization.id));
+    }
+  });
 });
 
 describe('isInstallationGoneError', () => {

--- a/apps/web/src/lib/integrations/github-apps-service.test.ts
+++ b/apps/web/src/lib/integrations/github-apps-service.test.ts
@@ -2,7 +2,11 @@ import { describe, expect, it } from '@jest/globals';
 import { organizations, platform_integrations } from '@kilocode/db/schema';
 import { eq } from 'drizzle-orm';
 import { db } from '@/lib/drizzle';
-import { getIntegrationForOrganization } from '@/lib/integrations/db/platform-integrations';
+import {
+  getIntegrationForOrganization,
+  getIntegrationForOwner,
+  getPrimaryGitHubIntegrationForOrganization,
+} from '@/lib/integrations/db/platform-integrations';
 import { getInstallation, isInstallationGoneError } from './github-apps-service';
 
 describe('getInstallation', () => {
@@ -79,6 +83,41 @@ describe('getInstallation', () => {
     try {
       const integration = await getInstallation({ type: 'org', id: organization.id });
       expect(integration?.id).toBe(rows[0].id);
+    } finally {
+      await db.delete(organizations).where(eq(organizations.id, organization.id));
+    }
+  });
+
+  it('keeps an auth-invalid installation visible without selecting it as primary', async () => {
+    const [organization] = await db
+      .insert(organizations)
+      .values({ name: `GitHub recovery ${crypto.randomUUID()}` })
+      .returning();
+    const [row] = await db
+      .insert(platform_integrations)
+      .values({
+        owned_by_organization_id: organization.id,
+        platform: 'github',
+        integration_type: 'app',
+        platform_installation_id: crypto.randomUUID(),
+        integration_status: 'active',
+        repository_access: 'all',
+        auth_invalid_at: new Date().toISOString(),
+        auth_invalid_reason: 'installation_token_auth_failed',
+      })
+      .returning();
+
+    try {
+      const visibleIntegration = await getIntegrationForOrganization(organization.id, 'github');
+      const primaryIntegration = await getPrimaryGitHubIntegrationForOrganization(organization.id);
+      const ownerIntegration = await getIntegrationForOwner(
+        { type: 'org', id: organization.id },
+        'github'
+      );
+
+      expect(visibleIntegration?.id).toBe(row.id);
+      expect(primaryIntegration).toBeNull();
+      expect(ownerIntegration).toBeNull();
     } finally {
       await db.delete(organizations).where(eq(organizations.id, organization.id));
     }

--- a/apps/web/src/lib/integrations/github-apps-service.ts
+++ b/apps/web/src/lib/integrations/github-apps-service.ts
@@ -2,14 +2,15 @@ import 'server-only';
 import { db } from '@/lib/drizzle';
 import type { PlatformIntegration } from '@kilocode/db/schema';
 import { platform_integrations } from '@kilocode/db/schema';
-import { eq, and, desc, isNull } from 'drizzle-orm';
+import { eq, and, asc, desc, isNull } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import { requireNumericPlatformRepositories, type Owner } from '@/lib/integrations/core/types';
 import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
 import { platformIntegrationHealthSql } from '@/lib/integrations/core/health';
 import {
-  deleteIntegration,
+  deleteIntegrationForOwner,
   findPendingInstallationByKiloUserId,
+  getGitHubIntegrationById,
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
 import {
@@ -32,7 +33,8 @@ export async function listIntegrations(owner: Owner) {
   const integrations = await db
     .select()
     .from(platform_integrations)
-    .where(and(ownershipCondition, eq(platform_integrations.platform, 'github')));
+    .where(and(ownershipCondition, eq(platform_integrations.platform, 'github')))
+    .orderBy(asc(platform_integrations.created_at), asc(platform_integrations.id));
 
   return integrations;
 }
@@ -50,7 +52,13 @@ export async function getInstallation(owner: Owner): Promise<PlatformIntegration
     .select()
     .from(platform_integrations)
     .where(and(ownershipCondition, eq(platform_integrations.platform, 'github')))
-    .orderBy(desc(platformIntegrationHealthSql()), desc(platform_integrations.updated_at))
+    .orderBy(
+      desc(platformIntegrationHealthSql()),
+      owner.type === 'org'
+        ? asc(platform_integrations.created_at)
+        : desc(platform_integrations.updated_at),
+      asc(platform_integrations.id)
+    )
     .limit(1);
 
   return integration || null;
@@ -85,27 +93,16 @@ export function isInstallationGoneError(error: unknown): boolean {
  */
 export async function uninstallApp(
   owner: Owner,
+  integrationId: string | undefined,
   _userId: string,
   _userEmail: string,
   _userName: string
 ) {
-  const ownershipCondition =
-    owner.type === 'user'
-      ? eq(platform_integrations.owned_by_user_id, owner.id)
-      : eq(platform_integrations.owned_by_organization_id, owner.id);
-
-  // Get the integration
-  const [integration] = await db
-    .select()
-    .from(platform_integrations)
-    .where(
-      and(
-        ownershipCondition,
-        eq(platform_integrations.platform, 'github'),
-        eq(platform_integrations.integration_status, INTEGRATION_STATUS.ACTIVE)
-      )
-    )
-    .limit(1);
+  const integration = integrationId
+    ? await getGitHubIntegrationById(owner, integrationId)
+    : owner.type === 'user'
+      ? await getInstallation(owner)
+      : null;
 
   if (!integration) {
     throw new TRPCError({
@@ -137,21 +134,12 @@ export async function uninstallApp(
     // Installation is already gone on GitHub, continue to delete from our database
   }
 
-  // Delete from database
-  if (owner.type === 'org') {
-    await deleteIntegration(owner.id, 'github');
-    // TODO: Add audit log when integration audit actions are defined
-  } else {
-    // Delete for user
-    await db
-      .delete(platform_integrations)
-      .where(
-        and(
-          eq(platform_integrations.owned_by_user_id, owner.id),
-          eq(platform_integrations.platform, 'github')
-        )
-      );
-  }
+  await deleteIntegrationForOwner(
+    owner,
+    PLATFORM.GITHUB,
+    appType,
+    integration.platform_installation_id
+  );
 
   return { success: true };
 }
@@ -218,7 +206,7 @@ export async function listRepositories(
 /**
  * Cancel a pending installation
  */
-export async function cancelPendingInstallation(owner: Owner) {
+export async function cancelPendingInstallation(owner: Owner, integrationId?: string) {
   const ownershipCondition =
     owner.type === 'user'
       ? eq(platform_integrations.owned_by_user_id, owner.id)
@@ -231,6 +219,7 @@ export async function cancelPendingInstallation(owner: Owner) {
     .where(
       and(
         ownershipCondition,
+        ...(integrationId ? [eq(platform_integrations.id, integrationId)] : []),
         eq(platform_integrations.platform, 'github'),
         eq(platform_integrations.integration_status, INTEGRATION_STATUS.PENDING),
         isNull(platform_integrations.platform_installation_id)

--- a/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
@@ -77,6 +77,7 @@ const mockRecordOperationAcceptance = jest.fn<(...args: unknown[]) => Promise<un
 const mockSettleOperation = jest.fn<(...args: unknown[]) => Promise<unknown>>();
 const mockGetSecurityAgentCommandStatus = jest.fn<(...args: unknown[]) => Promise<unknown>>();
 const mockGetSecurityAgentCommandStatuses = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockGetReauthorizeUrl = jest.fn<(installationId: string) => string>();
 
 jest.mock('../services/manual-sync-client', () => ({
   submitManualSecuritySync: mockSubmitManualSecuritySync,
@@ -102,7 +103,7 @@ jest.mock('@kilocode/db/operation-ledger', () => ({
 }));
 jest.mock('../github/permissions', () => ({
   hasSecurityReviewPermissions: () => true,
-  getReauthorizeUrl: jest.fn(),
+  getReauthorizeUrl: mockGetReauthorizeUrl,
 }));
 jest.mock('../github/dependabot-api', () => ({
   checkDependabotAlertsAvailability: mockCheckDependabotAlertsAvailability,
@@ -182,6 +183,9 @@ beforeEach(() => {
   mockRecordOperationAcceptance.mockResolvedValue({ status: 'admitted' });
   mockMarkReconcilePending.mockResolvedValue({ status: 'reconcile_pending' });
   mockSettleOperation.mockResolvedValue({ settled: true });
+  mockGetReauthorizeUrl.mockImplementation(
+    installationId => `https://github.com/apps/kilocode/installations/${installationId}`
+  );
 });
 
 function createHandlers() {
@@ -200,6 +204,30 @@ function createHandlers() {
         integration_status: 'active',
         platform_installation_id: 'installation-123',
         repositories: [{ id: 1, full_name: 'kilo/repo', name: 'repo', private: true }],
+      }) as never,
+    trackingExtras: () => ({}),
+  });
+}
+
+function createHandlersWithUnhealthyStatusIntegration() {
+  return createSecurityAgentHandlers({
+    resolveOwner: () => ({
+      type: 'org',
+      id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      userId: 'user-123',
+    }),
+    resolveSecurityOwner: () => ({ organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' }),
+    resolveResourceId: () => 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    verifyFindingOwnership: () => true,
+    getIntegration: async () => null,
+    getStatusIntegration: async () =>
+      ({
+        id: 'integration-123',
+        integration_status: 'active',
+        platform_installation_id: 'installation-123',
+        permissions: { dependabot_alerts: 'read' },
+        auth_invalid_at: '2026-06-25 18:00:00+00',
+        auth_invalid_reason: 'installation_token_auth_failed',
       }) as never,
     trackingExtras: () => ({}),
   });
@@ -252,6 +280,25 @@ const context = {
     is_admin: false,
   },
 } as never;
+
+describe('getPermissionStatus', () => {
+  it('uses the status integration to preserve reauthorization details', async () => {
+    await expect(
+      createHandlersWithUnhealthyStatusIntegration().getPermissionStatus({
+        ctx: context,
+        input: {},
+      })
+    ).resolves.toEqual({
+      hasIntegration: true,
+      integrationId: 'integration-123',
+      hasPermissions: false,
+      reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-123',
+      authInvalidAt: '2026-06-25 18:00:00+00',
+      authInvalidReason: 'installation_token_auth_failed',
+    });
+    expect(mockGetReauthorizeUrl).toHaveBeenCalledWith('installation-123');
+  });
+});
 
 describe('trackUiInteraction', () => {
   it('tracks an allowlisted interaction with authenticated personal identity', async () => {

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -732,6 +732,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         return {
           hasIntegration: false,
           hasPermissions: false,
+          integrationId: null,
           reauthorizeUrl: null,
           authInvalidAt: integration?.auth_invalid_at ?? null,
           authInvalidReason: integration?.auth_invalid_reason ?? null,
@@ -745,6 +746,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
 
       return {
         hasIntegration: true,
+        integrationId: integration.id,
         hasPermissions: hasEffectivePermissions,
         reauthorizeUrl: hasEffectivePermissions
           ? null

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -146,7 +146,7 @@ import {
 
 type Owner = { type: 'user' | 'org'; id: string; userId: string };
 
-type Integration = Awaited<ReturnType<typeof getIntegrationForOwner>>;
+type Integration = Awaited<ReturnType<typeof getIntegrationForOwner>> | null;
 
 /**
  * TExtra represents additional input fields injected by the tRPC procedure middleware.
@@ -159,6 +159,7 @@ type SecurityAgentDeps<TExtra = {}> = {
   resolveResourceId: (ctx: TRPCContext, input: TExtra) => string;
   verifyFindingOwnership: (finding: SecurityFinding, ctx: TRPCContext, input: TExtra) => boolean;
   getIntegration: (ctx: TRPCContext, input: TExtra) => Promise<Integration>;
+  getStatusIntegration?: (ctx: TRPCContext, input: TExtra) => Promise<Integration>;
   trackingExtras: (ctx: TRPCContext, input: TExtra) => { organizationId?: string };
 };
 
@@ -726,7 +727,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
     // -----------------------------------------------------------------------
     getPermissionStatus: async ({ ctx, input }: { ctx: TRPCContext; input: unknown }) => {
       const extra = toExtra(input);
-      const integration = await deps.getIntegration(ctx, extra);
+      const integration = await (deps.getStatusIntegration ?? deps.getIntegration)(ctx, extra);
 
       if (!integration || integration.integration_status !== 'active') {
         return {

--- a/apps/web/src/routers/admin/oss-sponsorship-router.ts
+++ b/apps/web/src/routers/admin/oss-sponsorship-router.ts
@@ -21,7 +21,7 @@ import {
 import { getAcceptInviteUrl } from '@/lib/organizations/organizations';
 import { grantEntityCreditForCategory } from '@/lib/promotionalCredits';
 import { TRPCError } from '@trpc/server';
-import { getIntegrationForOrganization } from '@/lib/integrations/db/platform-integrations';
+import { getPrimaryGitHubIntegrationForOrganization } from '@/lib/integrations/db/platform-integrations';
 import { getAgentConfig } from '@/lib/agent-config/db/agent-configs';
 
 const OssCsvRowSchema = z.object({
@@ -348,8 +348,8 @@ export const ossSponsorshipRouter = createTRPCRouter({
         const monthlyCredits = org.settings.oss_monthly_credit_amount_microdollars;
 
         // Check GitHub integration status
-        const githubIntegration = await getIntegrationForOrganization(org.id, 'github');
-        const hasGitHubIntegration = githubIntegration?.integration_status === 'active';
+        const githubIntegration = await getPrimaryGitHubIntegrationForOrganization(org.id);
+        const hasGitHubIntegration = githubIntegration !== null;
 
         // Check Code Reviews configuration status
         const codeReviewConfig = await getAgentConfig(org.id, 'code_review', 'github');

--- a/apps/web/src/routers/github-apps-router.test.ts
+++ b/apps/web/src/routers/github-apps-router.test.ts
@@ -42,6 +42,8 @@ jest.mock('@/lib/integrations/github-apps-service', () => ({}));
 jest.mock('@/lib/integrations/db/platform-integrations', () => ({
   getIntegrationForOwner: (owner: Owner, platform: string) =>
     mockGetIntegrationForOwner(owner, platform),
+  getGitHubIntegrationById: (_owner: Owner, _integrationId: string) =>
+    mockGetIntegrationForOwner(_owner, 'github'),
   upsertPlatformIntegrationForOwner: (owner: Owner, details: Record<string, unknown>) =>
     mockUpsertPlatformIntegrationForOwner(owner, details),
   updateRepositoriesForIntegration: (integrationId: string, repositories: unknown[]) =>

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -3,7 +3,9 @@ import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import * as z from 'zod';
 import * as githubAppsService from '@/lib/integrations/github-apps-service';
 import {
+  findIntegrationByInstallationId,
   getIntegrationForOwner,
+  getGitHubIntegrationById,
   upsertPlatformIntegrationForOwner,
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
@@ -27,6 +29,7 @@ import {
 import { requireNumericPlatformRepositories } from '@/lib/integrations/core/types';
 import { createGitHubUserAuthorizationState } from '@/lib/integrations/platforms/github/user-authorization-state';
 import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
+import { ORGANIZATION_MANAGE_ROLES } from '@kilocode/app-shared/organizations';
 import {
   disconnectGitHubUserAuthorization,
   getGitHubUserAuthorizationStatus,
@@ -140,6 +143,7 @@ export const githubAppsRouter = createTRPCRouter({
     return {
       installed: isInstalled,
       installation: {
+        id: integration.id,
         installationId: integration.platform_installation_id,
         accountId: integration.platform_account_id,
         accountLogin: integration.platform_account_login,
@@ -216,28 +220,45 @@ export const githubAppsRouter = createTRPCRouter({
     }),
 
   // Uninstall GitHub App
-  uninstallApp: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
-    const owner = await resolveAuthorizedOwner(ctx, input?.organizationId);
-    const result = await githubAppsService.uninstallApp(
-      owner,
-      ctx.user.id,
-      ctx.user.google_user_email,
-      ctx.user.google_user_name
-    );
+  uninstallApp: baseProcedure
+    .input(
+      z
+        .object({
+          organizationId: z.string().uuid().optional(),
+          integrationId: z.string().uuid().optional(),
+        })
+        .optional()
+    )
+    .mutation(async ({ ctx, input }) => {
+      const owner = await resolveAuthorizedOwner(
+        ctx,
+        input?.organizationId,
+        input?.organizationId ? ORGANIZATION_MANAGE_ROLES : undefined
+      );
+      if (input?.organizationId && !input.integrationId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Integration ID is required' });
+      }
+      const result = await githubAppsService.uninstallApp(
+        owner,
+        input?.integrationId,
+        ctx.user.id,
+        ctx.user.google_user_email,
+        ctx.user.google_user_name
+      );
 
-    if (input?.organizationId) {
-      await createAuditLog({
-        organization_id: input.organizationId,
-        action: 'organization.settings.change',
-        actor_id: ctx.user.id,
-        actor_email: ctx.user.google_user_email,
-        actor_name: ctx.user.google_user_name,
-        message: 'Uninstalled Kilo GitHub App',
-      });
-    }
+      if (input?.organizationId) {
+        await createAuditLog({
+          organization_id: input.organizationId,
+          action: 'organization.settings.change',
+          actor_id: ctx.user.id,
+          actor_email: ctx.user.google_user_email,
+          actor_name: ctx.user.google_user_name,
+          message: `Uninstalled Kilo GitHub App installation ${input.integrationId}`,
+        });
+      }
 
-    return result;
-  }),
+      return result;
+    }),
 
   // List repositories accessible by an integration
   listRepositories: baseProcedure
@@ -275,13 +296,39 @@ export const githubAppsRouter = createTRPCRouter({
 
   // Cancel pending installation
   cancelPendingInstallation: baseProcedure
-    .input(optionalOrgInput)
+    .input(
+      z
+        .object({
+          organizationId: z.string().uuid().optional(),
+          integrationId: z.string().uuid().optional(),
+        })
+        .optional()
+    )
     .mutation(async ({ ctx, input }) => {
+      let role: Awaited<ReturnType<typeof ensureOrganizationAccess>> | null = null;
       if (input?.organizationId) {
-        await ensureOrganizationAccess(ctx, input.organizationId);
+        role = await ensureOrganizationAccess(ctx, input.organizationId);
+        if (!input.integrationId) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: 'Integration ID is required' });
+        }
       }
       const owner = resolveOwner(ctx, input?.organizationId);
-      const result = await githubAppsService.cancelPendingInstallation(owner);
+      if (input?.integrationId) {
+        const integration = await getGitHubIntegrationById(owner, input.integrationId);
+        if (!integration) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Pending installation not found' });
+        }
+        const canCancel =
+          !input.organizationId ||
+          ctx.user.is_admin ||
+          role === 'owner' ||
+          role === 'admin' ||
+          integration.kilo_requester_user_id === ctx.user.id;
+        if (!canCancel) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot cancel this request' });
+        }
+      }
+      const result = await githubAppsService.cancelPendingInstallation(owner, input?.integrationId);
 
       if (input?.organizationId) {
         await createAuditLog({
@@ -298,69 +345,83 @@ export const githubAppsRouter = createTRPCRouter({
     }),
 
   // Refresh installation details from GitHub (permissions, events, repositories)
-  refreshInstallation: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
-    if (input?.organizationId) {
-      await ensureOrganizationAccess(ctx, input.organizationId);
-    }
-    const owner = resolveOwner(ctx, input?.organizationId);
+  refreshInstallation: baseProcedure
+    .input(
+      z
+        .object({
+          organizationId: z.string().uuid().optional(),
+          integrationId: z.string().uuid().optional(),
+        })
+        .optional()
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (input?.organizationId) {
+        await ensureOrganizationAccess(ctx, input.organizationId);
+      }
+      const owner = resolveOwner(ctx, input?.organizationId);
 
-    const integration = await getIntegrationForOwner(owner, 'github');
-    if (!integration || !integration.platform_installation_id) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: 'No GitHub integration found',
+      if (input?.organizationId && !input.integrationId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Integration ID is required' });
+      }
+      const integration = input?.integrationId
+        ? await getGitHubIntegrationById(owner, input.integrationId)
+        : await getIntegrationForOwner(owner, 'github');
+      if (!integration || !integration.platform_installation_id) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'No GitHub integration found',
+        });
+      }
+
+      const installationId = integration.platform_installation_id;
+      const appType = integration.github_app_type || 'standard';
+
+      const installationDetails = await fetchGitHubInstallationDetails(installationId, appType);
+      if (!installationDetails.account.id || !installationDetails.account.login) {
+        throw new TRPCError({
+          code: 'BAD_GATEWAY',
+          message: 'GitHub installation account identity unavailable',
+        });
+      }
+
+      const upsertResult = await upsertPlatformIntegrationForOwner(owner, {
+        platform: 'github',
+        integrationType: 'app',
+        platformInstallationId: installationId,
+        platformAccountId: installationDetails.account.id.toString(),
+        platformAccountLogin: installationDetails.account.login,
+        permissions: installationDetails.permissions,
+        scopes: installationDetails.events,
+        repositoryAccess: installationDetails.repository_selection,
+        installedAt: installationDetails.created_at,
+        // Keep the integration's app type so a lite refresh is never matched
+        // against (or converted into) the standard app's row.
+        githubAppType: appType,
       });
-    }
 
-    const installationId = integration.platform_installation_id;
-    const appType = integration.github_app_type || 'standard';
+      if (!upsertResult.ok) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'This GitHub installation is already claimed by another account.',
+        });
+      }
 
-    const installationDetails = await fetchGitHubInstallationDetails(installationId, appType);
-    if (!installationDetails.account.id || !installationDetails.account.login) {
-      throw new TRPCError({
-        code: 'BAD_GATEWAY',
-        message: 'GitHub installation account identity unavailable',
-      });
-    }
+      const repositories = await fetchGitHubRepositories(installationId, appType);
+      await updateRepositoriesForIntegration(integration.id, repositories);
 
-    const upsertResult = await upsertPlatformIntegrationForOwner(owner, {
-      platform: 'github',
-      integrationType: 'app',
-      platformInstallationId: installationId,
-      platformAccountId: installationDetails.account.id.toString(),
-      platformAccountLogin: installationDetails.account.login,
-      permissions: installationDetails.permissions,
-      scopes: installationDetails.events,
-      repositoryAccess: installationDetails.repository_selection,
-      installedAt: installationDetails.created_at,
-      // Keep the integration's app type so a lite refresh is never matched
-      // against (or converted into) the standard app's row.
-      githubAppType: appType,
-    });
+      if (input?.organizationId) {
+        await createAuditLog({
+          organization_id: input.organizationId,
+          action: 'organization.settings.change',
+          actor_id: ctx.user.id,
+          actor_email: ctx.user.google_user_email,
+          actor_name: ctx.user.google_user_name,
+          message: `Refreshed GitHub App installation ${integration.id}`,
+        });
+      }
 
-    if (!upsertResult.ok) {
-      throw new TRPCError({
-        code: 'CONFLICT',
-        message: 'This GitHub installation is already claimed by another account.',
-      });
-    }
-
-    const repositories = await fetchGitHubRepositories(installationId, appType);
-    await updateRepositoriesForIntegration(integration.id, repositories);
-
-    if (input?.organizationId) {
-      await createAuditLog({
-        organization_id: input.organizationId,
-        action: 'organization.settings.change',
-        actor_id: ctx.user.id,
-        actor_email: ctx.user.google_user_email,
-        actor_name: ctx.user.google_user_name,
-        message: 'Refreshed GitHub App installation details',
-      });
-    }
-
-    return { success: true };
-  }),
+      return { success: true };
+    }),
 
   // Dev-only: Add an existing GitHub installation manually
   devAddInstallation: baseProcedure
@@ -408,8 +469,16 @@ export const githubAppsRouter = createTRPCRouter({
         });
       }
 
-      const integration = await getIntegrationForOwner(owner, 'github');
-      if (integration) {
+      const integration = await findIntegrationByInstallationId(
+        'github',
+        input.installationId,
+        appType
+      );
+      const belongsToOwner =
+        integration &&
+        ((owner.type === 'org' && integration.owned_by_organization_id === owner.id) ||
+          (owner.type === 'user' && integration.owned_by_user_id === owner.id));
+      if (integration && belongsToOwner) {
         const repositories = await fetchGitHubRepositories(input.installationId, appType);
         await updateRepositoriesForIntegration(integration.id, repositories);
       }

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -47,6 +47,51 @@ export const githubAppsRouter = createTRPCRouter({
     return githubAppsService.listIntegrations(owner);
   }),
 
+  listOrganizationInstallations: baseProcedure
+    .input(z.object({ organizationId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const role = await ensureOrganizationAccess(ctx, input.organizationId);
+      const integrations = await githubAppsService.listIntegrations({
+        type: 'org',
+        id: input.organizationId,
+      });
+      const primaryId = integrations.find(isPlatformIntegrationHealthy)?.id ?? null;
+
+      return {
+        canAdd: integrations.length === 0,
+        installations: integrations.map(integration => {
+          const repositories = requireNumericPlatformRepositories(integration.repositories) ?? [];
+          const status: 'connected' | 'pending' | 'suspended' | 'needs_attention' =
+            isPlatformIntegrationHealthy(integration)
+              ? 'connected'
+              : integration.integration_status === 'pending'
+                ? 'pending'
+                : integration.suspended_at || integration.integration_status === 'suspended'
+                  ? 'suspended'
+                  : 'needs_attention';
+          const canCancel =
+            status === 'pending' &&
+            (ctx.user.is_admin ||
+              role === 'owner' ||
+              role === 'admin' ||
+              integration.kilo_requester_user_id === ctx.user.id);
+
+          return {
+            id: integration.id,
+            accountLogin: integration.platform_account_login,
+            installationId: integration.platform_installation_id,
+            status,
+            repositorySelection: integration.repository_access,
+            repositories,
+            isPrimary: integration.id === primaryId,
+            canRefresh: status !== 'pending',
+            canUninstall: ctx.user.is_admin || role === 'owner' || role === 'admin',
+            canCancel,
+          };
+        }),
+      };
+    }),
+
   getUserAuthorization: baseProcedure.query(async ({ ctx }) => {
     return getGitHubUserAuthorizationStatus(ctx.user.id);
   }),
@@ -104,6 +149,7 @@ export const githubAppsRouter = createTRPCRouter({
       // which called ensureOrganizationAccess with no role filter.
       const owner = await resolveAuthorizedOwner(ctx, input.organizationId, [
         'owner',
+        'admin',
         'billing_manager',
         'member',
       ]);

--- a/apps/web/src/routers/organizations/organization-auto-triage-router.ts
+++ b/apps/web/src/routers/organizations/organization-auto-triage-router.ts
@@ -5,7 +5,7 @@ import {
   organizationBillingMutationProcedure,
 } from './utils';
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
-import { getIntegrationForOrganization } from '@/lib/integrations/db/platform-integrations';
+import { getPrimaryGitHubIntegrationForOrganization } from '@/lib/integrations/db/platform-integrations';
 import {
   getAgentConfig,
   upsertAgentConfig,
@@ -40,7 +40,7 @@ const sharedHandlers = createAutoTriageRouter({
 
   integrationGetter: async owner => {
     if (owner.type !== 'org') return null;
-    return await getIntegrationForOrganization(owner.id, 'github');
+    return await getPrimaryGitHubIntegrationForOrganization(owner.id);
   },
 
   repositoryFetcher: async owner => {

--- a/apps/web/src/routers/organizations/organization-security-agent-router.ts
+++ b/apps/web/src/routers/organizations/organization-security-agent-router.ts
@@ -7,7 +7,10 @@ import {
   OrganizationIdInputSchema,
 } from './utils';
 
-import { getIntegrationForOrganization } from '@/lib/integrations/db/platform-integrations';
+import {
+  getIntegrationForOrganization,
+  getPrimaryGitHubIntegrationForOrganization,
+} from '@/lib/integrations/db/platform-integrations';
 import { createSecurityAgentHandlers } from '@/lib/security-agent/router/shared-handlers';
 
 const handlers = createSecurityAgentHandlers<{ organizationId: string }>({
@@ -23,6 +26,8 @@ const handlers = createSecurityAgentHandlers<{ organizationId: string }>({
   verifyFindingOwnership: (finding, _ctx, input) =>
     finding.owned_by_organization_id === input.organizationId,
   getIntegration: async (_ctx, input) =>
+    await getPrimaryGitHubIntegrationForOrganization(input.organizationId),
+  getStatusIntegration: async (_ctx, input) =>
     await getIntegrationForOrganization(input.organizationId, 'github'),
   trackingExtras: (_ctx, input) => ({
     organizationId: input.organizationId,


### PR DESCRIPTION
## Summary
- replace the organization GitHub settings card with a focused installation list
- show connection health, repository scope, selected repositories, and exact row actions
- keep the personal GitHub identity flow unchanged
- retain single-install behavior until the next pilot PR

| Before | After |
|--------|--------|
| <img width="4388" height="2708" alt="CleanShot 2026-08-26 at 11 09 38@2x" src="https://github.com/user-attachments/assets/22a698b0-59e4-447d-a1bc-eccfe6d84758" /> | <img width="4388" height="2708" alt="CleanShot 2026-08-26 at 11 08 39@2x" src="https://github.com/user-attachments/assets/4b1a2dbd-2e66-4a89-9521-d700099a3505" /> | 