### PR TITLE
feat(cloud-agent): select GitHub installations on web

### DIFF
--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -115,6 +115,8 @@ type Repository = {
   fullName: string;
   private: boolean;
   workspaceUuid?: string;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
 };
 
 type NewSessionPanelProps = {
@@ -206,6 +208,9 @@ export function NewSessionPanel({
   // ---------------------------------------------------------------------------
   const [prompt, setPrompt] = useState('');
   const [selectedRepo, setSelectedRepo] = useState('');
+  const [selectedGitHubIntegrationId, setSelectedGitHubIntegrationId] = useState<
+    string | undefined
+  >();
   const [selectedPlatform, setSelectedPlatform] = useState<RepositoryPlatform>('github');
   const [mode, setMode] = useState<AgentMode>('code');
   const [model, setModel] = useState<string>('');
@@ -510,6 +515,8 @@ export function NewSessionPanel({
       fullName: repo.fullName,
       private: repo.private,
       platform: 'github' as const,
+      platformIntegrationId: repo.platformIntegrationId,
+      platformAccountLogin: repo.platformAccountLogin,
     }));
     const gitlab = gitlabRepositories.map(repo => ({
       id: repo.id,
@@ -539,8 +546,8 @@ export function NewSessionPanel({
       if (!fullName || seen.has(fullName)) continue;
       seen.add(fullName);
 
-      const match = unifiedRepositories.find(r => r.fullName === fullName);
-      if (match) result.push(match);
+      const matches = unifiedRepositories.filter(r => r.fullName === fullName);
+      if (matches.length === 1) result.push(matches[0]);
     }
 
     return result;
@@ -554,11 +561,16 @@ export function NewSessionPanel({
   const handleRepoSelect = useCallback(
     (repo: RepositoryOption, userInitiated = true) => {
       setSelectedRepo(repo.fullName);
+      setSelectedGitHubIntegrationId(
+        repo.platform === 'github' ? repo.platformIntegrationId : undefined
+      );
       setShowRepositoryRequiredMessage(false);
       if (userInitiated) setIsRepoUserSelected(true);
       if (repo.platform) {
         setSelectedPlatform(repo.platform);
-        if (userInitiated) setLastUsedRepo(repo.fullName, repo.platform, organizationId);
+        if (userInitiated) {
+          setLastUsedRepo(repo.fullName, repo.platform, organizationId, repo.platformIntegrationId);
+        }
       }
     },
     [organizationId]
@@ -618,20 +630,17 @@ export function NewSessionPanel({
       const repoName = extractRepoFromGitUrl(url);
       if (!repoName) continue;
 
-      const match = unifiedRepositories.find(
-        r => r.fullName.toLowerCase() === repoName.toLowerCase()
-      );
-      if (!match) continue;
-
-      setSelectedRepo(match.fullName);
-      setShowRepositoryRequiredMessage(false);
       const platform = detectGitPlatform(url);
-      if (platform) {
-        setSelectedPlatform(platform);
-      }
+      const matches = unifiedRepositories.filter(
+        r =>
+          r.fullName.toLowerCase() === repoName.toLowerCase() &&
+          (platform === null || r.platform === platform)
+      );
+      if (matches.length !== 1) continue;
+      handleRepoSelect(matches[0], false);
       break;
     }
-  }, [prompt, isRepoUserSelected, unifiedRepositories]);
+  }, [prompt, isRepoUserSelected, unifiedRepositories, handleRepoSelect]);
 
   const repoError =
     githubRepoError || gitlabRepoError || (organizationId ? bitbucketRepoError : null);
@@ -873,20 +882,31 @@ export function NewSessionPanel({
   // ---------------------------------------------------------------------------
   const [repoPopoverOpen, setRepoPopoverOpen] = useState(false);
 
-  const recentFullNames = useMemo(() => new Set(recentRepos.map(r => r.fullName)), [recentRepos]);
+  const repositoryKey = (repo: RepositoryOption) =>
+    `${repo.platform ?? 'other'}:${repo.platformIntegrationId ?? ''}:${repo.id}`;
+  const isSelectedRepository = (repo: RepositoryOption) =>
+    repo.fullName === selectedRepo &&
+    repo.platform === selectedPlatform &&
+    (repo.platform !== 'github' || repo.platformIntegrationId === selectedGitHubIntegrationId);
+  const recentKeys = useMemo(() => new Set(recentRepos.map(repositoryKey)), [recentRepos]);
   const githubRepos = unifiedRepositories.filter(
-    r => r.platform === 'github' && !recentFullNames.has(r.fullName)
+    r => r.platform === 'github' && !recentKeys.has(repositoryKey(r))
   );
+  const githubRepoGroups = Object.groupBy(
+    githubRepos,
+    repo => repo.platformAccountLogin ?? 'GitHub'
+  );
+  const hasMultipleGitHubAccounts = Object.keys(githubRepoGroups).length > 1;
   const gitlabRepos = unifiedRepositories.filter(
-    r => r.platform === 'gitlab' && !recentFullNames.has(r.fullName)
+    r => r.platform === 'gitlab' && !recentKeys.has(repositoryKey(r))
   );
   const bitbucketRepos = unifiedRepositories.filter(
-    r => r.platform === 'bitbucket' && !recentFullNames.has(r.fullName)
+    r => r.platform === 'bitbucket' && !recentKeys.has(repositoryKey(r))
   );
   const otherRepos = unifiedRepositories.filter(
-    r => !r.platform && !recentFullNames.has(r.fullName)
+    r => !r.platform && !recentKeys.has(repositoryKey(r))
   );
-  const filteredUnifiedRepos = unifiedRepositories.filter(r => !recentFullNames.has(r.fullName));
+  const filteredUnifiedRepos = unifiedRepositories.filter(r => !recentKeys.has(repositoryKey(r)));
 
   const handleRepoPillSelect = useCallback(
     (repo: RepositoryOption) => {
@@ -976,7 +996,11 @@ export function NewSessionPanel({
       return;
     }
     const selectedRepository = unifiedRepositories.find(
-      repository => repository.fullName === selectedRepo && repository.platform === selectedPlatform
+      repository =>
+        repository.fullName === selectedRepo &&
+        repository.platform === selectedPlatform &&
+        (selectedPlatform !== 'github' ||
+          repository.platformIntegrationId === selectedGitHubIntegrationId)
     );
     if (
       selectedPlatform === 'bitbucket' &&
@@ -1064,6 +1088,7 @@ export function NewSessionPanel({
           result = await trpcClient.organizations.cloudAgentNext.prepareSession.mutate({
             ...baseInput,
             githubRepo: selectedRepo,
+            githubIntegrationId: selectedGitHubIntegrationId,
             organizationId,
           });
         }
@@ -1132,6 +1157,7 @@ export function NewSessionPanel({
     selectedPlatform,
     selectedProfileId,
     selectedRepo,
+    selectedGitHubIntegrationId,
     slashCommands,
     trpc.cliSessionsV2.list,
     trpcClient,
@@ -1618,43 +1644,37 @@ export function NewSessionPanel({
                       <CommandGroup heading="Recently used">
                         {recentRepos.map(repo => (
                           <RepoCommandItem
-                            key={`recent-${repo.id}`}
+                            key={`recent-${repositoryKey(repo)}`}
                             repo={repo}
-                            isSelected={
-                              repo.fullName === selectedRepo && repo.platform === selectedPlatform
-                            }
+                            isSelected={isSelectedRepository(repo)}
                             onSelect={handleRepoPillSelect}
                           />
                         ))}
                       </CommandGroup>
                     )}
-                    {hasMultiplePlatforms ? (
+                    {hasMultiplePlatforms || hasMultipleGitHubAccounts ? (
                       <>
-                        {githubRepos.length > 0 && (
-                          <CommandGroup heading="GitHub">
-                            {githubRepos.map(repo => (
-                              <RepoCommandItem
-                                key={repo.id}
-                                repo={repo}
-                                isSelected={
-                                  repo.fullName === selectedRepo &&
-                                  repo.platform === selectedPlatform
-                                }
-                                onSelect={handleRepoPillSelect}
-                              />
-                            ))}
-                          </CommandGroup>
+                        {Object.entries(githubRepoGroups).map(([accountLogin, repositories]) =>
+                          repositories?.length ? (
+                            <CommandGroup key={accountLogin} heading={accountLogin}>
+                              {repositories.map(repo => (
+                                <RepoCommandItem
+                                  key={repositoryKey(repo)}
+                                  repo={repo}
+                                  isSelected={isSelectedRepository(repo)}
+                                  onSelect={handleRepoPillSelect}
+                                />
+                              ))}
+                            </CommandGroup>
+                          ) : null
                         )}
                         {gitlabRepos.length > 0 && (
                           <CommandGroup heading="GitLab">
                             {gitlabRepos.map(repo => (
                               <RepoCommandItem
-                                key={repo.id}
+                                key={repositoryKey(repo)}
                                 repo={repo}
-                                isSelected={
-                                  repo.fullName === selectedRepo &&
-                                  repo.platform === selectedPlatform
-                                }
+                                isSelected={isSelectedRepository(repo)}
                                 onSelect={handleRepoPillSelect}
                               />
                             ))}
@@ -1664,12 +1684,9 @@ export function NewSessionPanel({
                           <CommandGroup heading="Bitbucket">
                             {bitbucketRepos.map(repo => (
                               <RepoCommandItem
-                                key={repo.id}
+                                key={repositoryKey(repo)}
                                 repo={repo}
-                                isSelected={
-                                  repo.fullName === selectedRepo &&
-                                  repo.platform === selectedPlatform
-                                }
+                                isSelected={isSelectedRepository(repo)}
                                 onSelect={handleRepoPillSelect}
                               />
                             ))}
@@ -1679,12 +1696,9 @@ export function NewSessionPanel({
                           <CommandGroup heading="Other">
                             {otherRepos.map(repo => (
                               <RepoCommandItem
-                                key={repo.id}
+                                key={repositoryKey(repo)}
                                 repo={repo}
-                                isSelected={
-                                  repo.fullName === selectedRepo &&
-                                  repo.platform === selectedPlatform
-                                }
+                                isSelected={isSelectedRepository(repo)}
                                 onSelect={handleRepoPillSelect}
                               />
                             ))}
@@ -1695,11 +1709,9 @@ export function NewSessionPanel({
                       <CommandGroup>
                         {filteredUnifiedRepos.map(repo => (
                           <RepoCommandItem
-                            key={repo.id}
+                            key={repositoryKey(repo)}
                             repo={repo}
-                            isSelected={
-                              repo.fullName === selectedRepo && repo.platform === selectedPlatform
-                            }
+                            isSelected={isSelectedRepository(repo)}
                             onSelect={handleRepoPillSelect}
                           />
                         ))}
@@ -1790,7 +1802,7 @@ function RepoCommandItem({
 }) {
   return (
     <CommandItem
-      value={repo.fullName}
+      value={`${repo.fullName} ${repo.platformAccountLogin ?? ''} ${repo.platformIntegrationId ?? ''}`}
       onSelect={() => onSelect(repo)}
       className="flex items-center gap-2"
     >

--- a/apps/web/src/components/cloud-agent-next/model-preferences.ts
+++ b/apps/web/src/components/cloud-agent-next/model-preferences.ts
@@ -7,7 +7,11 @@ const VARIANTS_STORAGE_KEY_PREFIX = 'cloud-agent:last-used-variants';
 const DEVCONTAINER_ENABLED_STORAGE_KEY = 'cloud-agent:devcontainer-enabled';
 const REPO_STORAGE_KEY_PREFIX = 'cloud-agent:last-used-repo';
 
-type LastUsedRepo = { fullName: string; platform: RepositoryPlatform };
+type LastUsedRepo = {
+  fullName: string;
+  platform: RepositoryPlatform;
+  platformIntegrationId?: string;
+};
 
 export function getLastUsedRepoStorageKey(organizationId?: string) {
   return organizationId
@@ -30,7 +34,14 @@ export function parseLastUsedRepo(rawValue: string | null): LastUsedRepo | null 
         parsed.platform === 'gitlab' ||
         parsed.platform === 'bitbucket')
     ) {
-      return { fullName: parsed.fullName, platform: parsed.platform };
+      return {
+        fullName: parsed.fullName,
+        platform: parsed.platform,
+        platformIntegrationId:
+          'platformIntegrationId' in parsed && typeof parsed.platformIntegrationId === 'string'
+            ? parsed.platformIntegrationId
+            : undefined,
+      };
     }
     return null;
   } catch {
@@ -45,11 +56,12 @@ export function getLastUsedRepo(organizationId?: string): LastUsedRepo | null {
 export function setLastUsedRepo(
   fullName: string,
   platform: RepositoryPlatform,
-  organizationId?: string
+  organizationId?: string,
+  platformIntegrationId?: string
 ) {
   safeLocalStorage.setItem(
     getLastUsedRepoStorageKey(organizationId),
-    JSON.stringify({ fullName, platform } satisfies LastUsedRepo)
+    JSON.stringify({ fullName, platform, platformIntegrationId } satisfies LastUsedRepo)
   );
 }
 
@@ -71,10 +83,14 @@ export function getPreferredInitialRepo({
   isLoadingBitbucketRepos: boolean;
 }): RepositoryOption | undefined {
   if (lastUsedRepo) {
-    const match = availableRepos.find(
-      repo => repo.fullName === lastUsedRepo.fullName && repo.platform === lastUsedRepo.platform
+    const matches = availableRepos.filter(
+      repo =>
+        repo.fullName === lastUsedRepo.fullName &&
+        repo.platform === lastUsedRepo.platform &&
+        (lastUsedRepo.platformIntegrationId === undefined ||
+          repo.platformIntegrationId === lastUsedRepo.platformIntegrationId)
     );
-    if (match) return match;
+    if (matches.length === 1) return matches[0];
 
     const isSavedRepoLoading =
       lastUsedRepo.platform === 'github'

--- a/apps/web/src/components/shared/RepositoryCombobox.tsx
+++ b/apps/web/src/components/shared/RepositoryCombobox.tsx
@@ -27,6 +27,8 @@ export type RepositoryOption = {
   description?: string;
   platform?: RepositoryPlatform;
   workspaceUuid?: string;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
 };
 
 export type RepositoryComboboxProps = {

--- a/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -98,6 +98,7 @@ type PrepareSessionSharedFields = {
   variant?: string;
   // GitHub-specific params
   githubRepo?: string;
+  githubIntegrationId?: string;
   /** GitHub Personal Access Token for private repositories */
   githubToken?: string;
   // Generic git params for GitLab and other providers

--- a/apps/web/src/routers/cloud-agent-next-schemas.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.ts
@@ -345,6 +345,7 @@ const PrepareSessionSharedFields = {
     .string()
     .regex(/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/, 'Invalid repository format')
     .optional(),
+  githubIntegrationId: z.uuid().optional(),
   gitlabProject: z
     .string()
     .regex(
@@ -430,6 +431,10 @@ export const basePrepareSessionNextSchema = z
       path: ['githubRepo'],
     }
   )
+  .refine(data => data.githubIntegrationId === undefined || data.githubRepo !== undefined, {
+    message: 'GitHub integration requires a GitHub repository',
+    path: ['githubIntegrationId'],
+  })
   .refine(hasOnlyOneAttachmentField, {
     message: 'Must not provide both attachments and images',
     path: ['attachments'],

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -157,6 +157,7 @@ jest.mock('@/lib/organizations/organization-usage', () => ({
 
 jest.mock('@/lib/cloud-agent/github-integration-helpers', () => ({
   fetchGitHubRepositoriesForOrganization: mockFetchGitHubRepositoriesForOrganization,
+  fetchAllGitHubRepositoriesForOrganization: mockFetchGitHubRepositoriesForOrganization,
 }));
 
 jest.mock('@/lib/cloud-agent/gitlab-integration-helpers', () => ({

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -13,7 +13,7 @@ import {
   organizationMemberProcedure,
   organizationMemberMutationProcedure,
 } from '@/routers/organizations/utils';
-import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
+import { fetchAllGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
 import {
   BitbucketOrganizationRepositoryListResultSchema,
   fetchBitbucketRepositoriesForOrganization,
@@ -238,6 +238,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       const {
         gitlabProject,
         githubRepo,
+        githubIntegrationId,
         bitbucketRepo,
         organizationId,
         attachments,
@@ -250,6 +251,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       // envVars/setupCommands/mcpServers overrides unchanged.
       let gitParams: {
         githubRepo?: string;
+        githubIntegrationId?: string;
         gitUrl?: string;
         platform?: 'github' | 'gitlab' | 'bitbucket';
         bitbucketWorkspaceUuid?: string;
@@ -268,7 +270,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
           bitbucketRepositoryUuid: bitbucketRepo.repositoryUuid,
         };
       } else {
-        gitParams = { githubRepo, platform: PLATFORM.GITHUB };
+        gitParams = { githubRepo, githubIntegrationId, platform: PLATFORM.GITHUB };
       }
 
       try {
@@ -640,6 +642,8 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
             fullName: z.string(),
             private: z.boolean(),
             defaultBranch: z.string().optional(),
+            platformIntegrationId: z.string().uuid().optional(),
+            platformAccountLogin: z.string().optional(),
           })
         ),
         integrationInstalled: z.boolean(),
@@ -648,7 +652,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
-      const result = await fetchGitHubRepositoriesForOrganization(
+      const result = await fetchAllGitHubRepositoriesForOrganization(
         input.organizationId,
         input.forceRefresh
       );

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -245,6 +245,7 @@ type GroupedRegisterSessionInput = {
     | {
         type: 'github';
         repo: string;
+        githubIntegrationId?: string;
         branch?: string;
       }
     | {
@@ -296,6 +297,9 @@ function repositoryMetadataFromRegistrationInput(
       return {
         type: 'github',
         repo: repository.repo,
+        ...(repository.githubIntegrationId
+          ? { githubIntegrationId: repository.githubIntegrationId }
+          : {}),
         upstreamBranch: repository.branch,
       };
     case 'gitlab':
@@ -379,6 +383,7 @@ function isSameRegistrationRepository(
       return (
         stored.type === 'github' &&
         stored.repo === submitted.repo &&
+        stored.githubIntegrationId === submitted.githubIntegrationId &&
         stored.upstreamBranch === submitted.branch
       );
     case 'gitlab':

--- a/services/cloud-agent-next/src/persistence/session-metadata.test.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.test.ts
@@ -98,6 +98,7 @@ describe('session metadata boundary', () => {
         type: 'github' as const,
         repo: 'acme/repo',
         token: 'github-token',
+        githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
         githubInstallationId: '987',
         githubAppType: 'standard' as const,
         upstreamBranch: 'main',
@@ -148,6 +149,20 @@ describe('session metadata boundary', () => {
     expect(parseSessionMetadata(current)).toEqual(current);
     expect(serializeSessionMetadata(current)).toEqual(current);
     expect(CurrentSessionMetadataSchema.parse(current)).toEqual(current);
+  });
+
+  it('keeps existing GitHub metadata valid when the integration id is omitted', () => {
+    const current = {
+      metadataSchemaVersion: 2 as const,
+      identity: { sessionId: 'agent_legacy_github', userId: 'user_legacy_github' },
+      auth: {},
+      repository: { type: 'github' as const, repo: 'acme/repo' },
+      lifecycle: { version: 1, timestamp: 1 },
+    };
+
+    expect(parseSessionMetadata(current)).toEqual(current);
+    expect(serializeSessionMetadata(current)).toEqual(current);
+    expect(parseSessionMetadata(current).repository).not.toHaveProperty('githubIntegrationId');
   });
 
   it('parses and serializes clone source metadata', () => {

--- a/services/cloud-agent-next/src/persistence/session-metadata.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.ts
@@ -100,6 +100,7 @@ const MetadataRepositorySchema = z.preprocess(
           type: z.literal('github'),
           repo: z.string(),
           platform: z.literal('github').optional(),
+          githubIntegrationId: z.string().uuid().optional(),
           githubInstallationId: z.string().optional(),
           githubAppType: z.enum(['standard', 'lite']).optional(),
           ...RepositoryCommonSchema,

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.test.ts
@@ -75,7 +75,7 @@ vi.mock('../../model-validation.js', () => ({
 }));
 
 vi.mock('../../session/validate-repository-access.js', () => ({
-  assertBitbucketRepositoryAccessBeforeSessionCreation: assertBitbucketRepositoryAccessMock,
+  assertRepositoryAccessBeforeSessionCreation: assertBitbucketRepositoryAccessMock,
 }));
 
 vi.mock('./organization-membership.js', () => ({
@@ -186,6 +186,28 @@ describe('prepareSession operation-ledger admission gate', () => {
     );
     expect(startNewSessionMock).not.toHaveBeenCalled();
     expect(registerNewSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('adapts the legacy GitHub integration id into grouped repository identity', async () => {
+    const caller = router.createCaller(createContext());
+    const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await caller.prepareSession({
+      prompt: 'Test prompt',
+      mode: 'code',
+      model: 'claude-3',
+      githubRepo: 'acme/repo',
+      githubIntegrationId,
+      autoInitiate: true,
+    });
+
+    expect(startNewSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+      }),
+      expect.any(Object),
+      expect.any(Object)
+    );
   });
 
   it('ignores operationKey when autoInitiate is false and retains legacy registration', async () => {

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -46,7 +46,7 @@ import type { Env } from '../../types.js';
 import type { SessionProfileBundle } from '../../session-profile.js';
 import type { SessionCreateRequest } from '../../session/session-requests.js';
 import { assertKiloModelAvailable } from '../../model-validation.js';
-import { assertBitbucketRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
+import { assertRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
 import { assertOrganizationMembership } from './organization-membership.js';
 
 type SessionPrepareHandlers = {
@@ -207,6 +207,7 @@ export function prepareInputToSessionCreateRequest(input: PrepareInput): Session
     repository = {
       type: 'github',
       repo: input.githubRepo,
+      ...(input.githubIntegrationId ? { githubIntegrationId: input.githubIntegrationId } : {}),
       branch: input.upstreamBranch,
     };
   } else {
@@ -331,7 +332,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
           input.kilocodeOrganizationId
         );
       }
-      await assertBitbucketRepositoryAccessBeforeSessionCreation({
+      await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,
         orgId: input.kilocodeOrganizationId,

--- a/services/cloud-agent-next/src/router/handlers/session-start.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-start.ts
@@ -24,7 +24,7 @@ import {
 } from './session-prepare.js';
 import type { SessionCreateRequest } from '../../session/session-requests.js';
 import { assertKiloModelAvailable } from '../../model-validation.js';
-import { assertBitbucketRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
+import { assertRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
 import { assertOrganizationMembership } from './organization-membership.js';
 
 type SessionStartHandlers = {
@@ -44,7 +44,12 @@ function startInputToSessionCreateRequest(
   let repository: SessionCreateRequest['repository'];
   switch (repo.type) {
     case 'github':
-      repository = { type: 'github', repo: repo.repo, branch: repo.branch };
+      repository = {
+        type: 'github',
+        repo: repo.repo,
+        ...(repo.githubIntegrationId ? { githubIntegrationId: repo.githubIntegrationId } : {}),
+        branch: repo.branch,
+      };
       break;
     case 'gitlab':
       repository = { type: 'gitlab', url: repo.url, branch: repo.branch };
@@ -101,7 +106,7 @@ const startSessionHandler = protectedProcedure
         db = getPgDb(ctx.env);
         await assertOrganizationMembership(db, ctx.userId, organizationId);
       }
-      await assertBitbucketRepositoryAccessBeforeSessionCreation({
+      await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,
         orgId: organizationId,

--- a/services/cloud-agent-next/src/router/schemas.test.ts
+++ b/services/cloud-agent-next/src/router/schemas.test.ts
@@ -190,9 +190,52 @@ describe('grouped unified session input contracts', () => {
       }).success
     ).toBe(true);
   });
+
+  it('accepts a GitHub integration id only on GitHub repository inputs', () => {
+    const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+    expect(
+      StartSessionInput.safeParse({
+        ...baseStartInput,
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId,
+        },
+      }).success
+    ).toBe(true);
+    expect(
+      StartSessionInput.safeParse({
+        ...baseStartInput,
+        repository: {
+          type: 'gitlab',
+          url: 'https://gitlab.com/acme/repo.git',
+          githubIntegrationId,
+        },
+      }).success
+    ).toBe(false);
+  });
 });
 
 describe('legacy live attachment input compatibility', () => {
+  it('accepts a GitHub integration id only with a legacy GitHub repository', () => {
+    const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+    const input = {
+      prompt: 'Update the repository',
+      mode: 'code',
+      model: 'claude-sonnet-4-5-20250929',
+      githubIntegrationId,
+    };
+
+    expect(PrepareSessionInput.safeParse({ ...input, githubRepo: 'acme/repo' }).success).toBe(true);
+    expect(
+      PrepareSessionInput.safeParse({
+        ...input,
+        gitUrl: 'https://gitlab.com/acme/repo.git',
+        platform: 'gitlab',
+      }).success
+    ).toBe(false);
+  });
+
   it('accepts shell-safe Git branch punctuation used by current-branch reviews', () => {
     const branch = 'feature/alex+metadata@v2,fix=1#manual';
 

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -442,6 +442,11 @@ const PrepareSessionSharedFields = {
   githubRepo: githubRepoSchema
     .optional()
     .describe('GitHub repository in format org/repo (mutually exclusive with gitUrl)'),
+  githubIntegrationId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('GitHub platform integration ID that must authorize the selected repository'),
   githubToken: z
     .string()
     .optional()
@@ -637,6 +642,14 @@ export const PrepareSessionInput = z
     path: ['githubRepo'],
   })
   .superRefine((data, ctx) => {
+    if (data.githubIntegrationId !== undefined && data.githubRepo === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['githubIntegrationId'],
+        message: 'GitHub integration identity is only valid for GitHub repositories',
+      });
+    }
+
     const hasBitbucketIds =
       data.bitbucketWorkspaceUuid !== undefined && data.bitbucketRepositoryUuid !== undefined;
     if (
@@ -767,11 +780,17 @@ export const RepositoryInputSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('github'),
     repo: githubRepoSchema.describe('GitHub repository in org/repo format'),
+    githubIntegrationId: z
+      .string()
+      .uuid()
+      .optional()
+      .describe('GitHub platform integration ID that must authorize the selected repository'),
     branch: branchNameSchema.optional().describe('Branch to checkout'),
   }),
   z.object({
     type: z.literal('gitlab'),
     url: gitUrlSchema.describe('GitLab repository HTTPS URL'),
+    githubIntegrationId: z.never().optional(),
     branch: branchNameSchema.optional().describe('Branch to checkout'),
   }),
   z.object({
@@ -780,12 +799,14 @@ export const RepositoryInputSchema = z.discriminatedUnion('type', [
     workspaceUuid: z.string().uuid(),
     repositoryUuid: z.string().uuid(),
     bitbucketIntegrationId: z.string().uuid().optional(),
+    githubIntegrationId: z.never().optional(),
     branch: branchNameSchema.optional().describe('Branch to checkout'),
   }),
   z.object({
     type: z.literal('git'),
     url: gitUrlSchema.describe('Git repository HTTPS URL'),
     token: z.string().optional().describe('Git authentication token'),
+    githubIntegrationId: z.never().optional(),
     branch: branchNameSchema.optional().describe('Branch to checkout'),
   }),
 ]);

--- a/services/cloud-agent-next/src/services/git-token-service-client.test.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.test.ts
@@ -263,6 +263,35 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
     });
   });
 
+  it('forwards the expected integration id through capability issuance', async () => {
+    const issueGitHubSessionCapability = vi.fn().mockResolvedValue({
+      success: true,
+      capability: 'kgh2.opaque',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+      source: 'installation',
+      gitAuthor: { name: 'kiloconnect[bot]', email: 'bot@example.com' },
+    });
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await issueCloudAgentGitHubSessionCapability(createEnv({ issueGitHubSessionCapability }), {
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      outboundContainerId: 'container-test',
+      expectedIntegrationId,
+      allowUserAuthorization: false,
+    });
+
+    expect(issueGitHubSessionCapability).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      outboundContainerId: 'container-test',
+      expectedIntegrationId,
+      allowUserAuthorization: false,
+    });
+  });
+
   it('reports issuance failure without resolving raw authentication', async () => {
     const issueGitHubSessionCapability = vi.fn().mockResolvedValue({
       success: false,
@@ -533,6 +562,42 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
         appType: 'standard',
         source: 'installation',
       },
+    });
+  });
+
+  it('preserves the expected integration id through direct and legacy fallbacks', async () => {
+    const getCloudAgentAuthForRepo = vi
+      .fn()
+      .mockRejectedValue(new Error('RPC method getCloudAgentAuthForRepo is not available'));
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'installation-token',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await resolveCloudAgentGitHubAuthForRepo(
+      createEnv({ getCloudAgentAuthForRepo, getTokenForRepo }),
+      {
+        githubRepo: 'acme/repo',
+        userId: 'user_1',
+        expectedIntegrationId,
+        allowUserAuthorization: false,
+      }
+    );
+
+    expect(getCloudAgentAuthForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      expectedIntegrationId,
+      allowUserAuthorization: false,
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      expectedIntegrationId,
     });
   });
 });

--- a/services/cloud-agent-next/src/services/git-token-service-client.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.ts
@@ -29,7 +29,7 @@ export type ResolveGitHubTokenResult =
 
 export async function resolveGitHubTokenForRepo(
   env: GitTokenServiceEnv,
-  params: { githubRepo: string; userId: string; orgId?: string }
+  params: { githubRepo: string; userId: string; orgId?: string; expectedIntegrationId?: string }
 ): Promise<ResolveGitHubTokenResult> {
   try {
     if (!env.GIT_TOKEN_SERVICE) {
@@ -107,6 +107,7 @@ type IssueCloudAgentGitHubSessionCapabilityParams = {
   userId: string;
   outboundContainerId: string;
   orgId?: string;
+  expectedIntegrationId?: string;
   allowUserAuthorization: boolean;
 };
 
@@ -120,12 +121,15 @@ type CloudAgentGitHubAuthResult =
 
 async function resolveLegacyInstallationAuthForRepo(
   env: GitTokenServiceEnv,
-  params: { githubRepo: string; userId: string; orgId?: string }
+  params: { githubRepo: string; userId: string; orgId?: string; expectedIntegrationId?: string }
 ): Promise<CloudAgentGitHubAuthResult> {
   const legacyParams = {
     githubRepo: params.githubRepo,
     userId: params.userId,
     ...(params.orgId !== undefined ? { orgId: params.orgId } : {}),
+    ...(params.expectedIntegrationId !== undefined
+      ? { expectedIntegrationId: params.expectedIntegrationId }
+      : {}),
   };
   const result = await resolveGitHubTokenForRepo(env, legacyParams);
   if (!result.success) return result;
@@ -147,6 +151,7 @@ export async function resolveCloudAgentGitHubAuthForRepo(
     githubRepo: string;
     userId: string;
     orgId?: string;
+    expectedIntegrationId?: string;
     allowUserAuthorization: boolean;
   }
 ): Promise<CloudAgentGitHubAuthResult> {
@@ -213,6 +218,9 @@ function resolveGitHubAuthFallbackForCapability(
     githubRepo: params.githubRepo,
     userId: params.userId,
     ...(params.orgId !== undefined ? { orgId: params.orgId } : {}),
+    ...(params.expectedIntegrationId !== undefined
+      ? { expectedIntegrationId: params.expectedIntegrationId }
+      : {}),
     allowUserAuthorization: params.allowUserAuthorization,
   });
 }

--- a/services/cloud-agent-next/src/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session-prepare.test.ts
@@ -166,6 +166,7 @@ function createInternalApiContext(options: {
   requestInternalApiKey?: string | null;
   skipBalanceCheck?: boolean;
   doStub?: ReturnType<typeof createMockDOStub>;
+  getTokenForRepo?: ReturnType<typeof vi.fn>;
   getBitbucketToken?: ReturnType<typeof vi.fn>;
   githubTokenContainmentOrgIds?: string;
   gitlabTokenContainmentOrgIds?: string;
@@ -224,6 +225,15 @@ function createInternalApiContext(options: {
       R2_BUCKET: {} as TRPCContext['env']['R2_BUCKET'],
       CLOUD_AGENT_REPORT_QUEUE: {} as TRPCContext['env']['CLOUD_AGENT_REPORT_QUEUE'],
       GIT_TOKEN_SERVICE: {
+        getTokenForRepo:
+          options.getTokenForRepo ??
+          vi.fn().mockResolvedValue({
+            success: true,
+            token: 'managed-github-token',
+            installationId: '123',
+            accountLogin: 'acme',
+            appType: 'standard',
+          }),
         getBitbucketToken:
           options.getBitbucketToken ??
           vi.fn().mockResolvedValue({ success: true, token: 'managed-bitbucket-token' }),
@@ -1391,6 +1401,36 @@ describe('start endpoint', () => {
         workspace: expect.objectContaining({
           credentialContainment: { github: true, gitlab: false, bitbucket: false, kilocode: false },
         }),
+      })
+    );
+  });
+
+  it('preflights and registers grouped starts with exact GitHub integration identity', async () => {
+    const doStub = createMockDOStub();
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'managed-github-token',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const caller = appRouter.createCaller(createInternalApiContext({ doStub, getTokenForRepo }));
+    const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await caller.start({
+      message: { prompt: 'Use the selected GitHub installation' },
+      agent: { mode: 'code', model: 'anthropic/claude-sonnet-4-20250514' },
+      repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+    });
+
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'test-user-123',
+      expectedIntegrationId: githubIntegrationId,
+    });
+    expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
       })
     );
   });

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -2152,6 +2152,30 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     expect(result.readyRequest.materialized.env.KILOCODE_TOKEN).toBe('kilo-token');
   });
 
+  it('forwards persisted GitHub integration identity to contained capability issuance', async () => {
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+    const metadata = parseSessionMetadata({
+      ...createMetadata({
+        githubRepo: 'acme/repo',
+        gitUrl: undefined,
+        gitToken: undefined,
+        platform: 'github',
+      }),
+      repository: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: expectedIntegrationId,
+      },
+    });
+
+    await buildPromptWrapperRequests(metadata);
+
+    expect(tokenMocks.issueCloudAgentGitHubSessionCapability).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ expectedIntegrationId })
+    );
+  });
+
   it('uses a managed GitHub capability for shared standard sandboxes', async () => {
     const result = await buildPromptWrapperRequests({
       ...createMetadata({
@@ -2947,6 +2971,31 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
       name: 'kiloconnect[bot]',
       email: 'bot@example.com',
     });
+  });
+
+  it('forwards persisted GitHub integration identity to direct token resolution', async () => {
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+    const metadata = parseSessionMetadata({
+      ...createMetadata({
+        githubRepo: 'acme/repo',
+        gitUrl: undefined,
+        gitToken: undefined,
+        platform: 'github',
+        sandboxId: 'dind-abcdef',
+      }),
+      repository: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: expectedIntegrationId,
+      },
+    });
+
+    await buildPromptWrapperRequests(metadata);
+
+    expect(tokenMocks.resolveCloudAgentGitHubAuthForRepo).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ expectedIntegrationId })
+    );
   });
 
   it('requests user GitHub auth eligibility for Slack bot sessions', async () => {

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -1735,6 +1735,9 @@ export class SessionService {
         githubRepo: github.repo,
         userId: metadata.identity.userId,
         orgId: metadata.identity.orgId,
+        ...(github.githubIntegrationId
+          ? { expectedIntegrationId: github.githubIntegrationId }
+          : {}),
         allowUserAuthorization:
           metadata.identity.createdOnPlatform === 'cloud-agent-web' ||
           metadata.identity.createdOnPlatform === 'slack',

--- a/services/cloud-agent-next/src/session/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session/session-prepare.test.ts
@@ -1550,6 +1550,25 @@ describe('createSessionWithLedger changed-intent rejection', () => {
       }),
     },
     {
+      name: 'the GitHub integration',
+      original: makeRequest({
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+        },
+        options: ORIGINAL_OPTIONS,
+      }),
+      retry: makeRequest({
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+        },
+        options: ORIGINAL_OPTIONS,
+      }),
+    },
+    {
       name: 'the model',
       retry: makeRequest({ agent: { mode: 'code', model: 'gpt-4' }, options: ORIGINAL_OPTIONS }),
     },

--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -1084,7 +1084,12 @@ function canonicalJson(value: unknown): string {
 function repositoryCreateIntent(repository: SessionRepositoryRequest): Record<string, unknown> {
   switch (repository.type) {
     case 'github':
-      return { type: 'github', repo: repository.repo, branch: repository.branch };
+      return {
+        type: 'github',
+        repo: repository.repo,
+        githubIntegrationId: repository.githubIntegrationId,
+        branch: repository.branch,
+      };
     case 'gitlab':
       return { type: 'gitlab', url: repository.url, branch: repository.branch };
     case 'bitbucket':

--- a/services/cloud-agent-next/src/session/session-requests.ts
+++ b/services/cloud-agent-next/src/session/session-requests.ts
@@ -20,6 +20,7 @@ export type SessionRepositoryRequest =
   | {
       type: 'github';
       repo: string;
+      githubIntegrationId?: string;
       branch?: string;
     }
   | {

--- a/services/cloud-agent-next/src/session/validate-repository-access.test.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { assertBitbucketRepositoryAccessBeforeSessionCreation } from './validate-repository-access.js';
+import { assertRepositoryAccessBeforeSessionCreation } from './validate-repository-access.js';
 
 const repository = {
   type: 'bitbucket' as const,
@@ -8,13 +8,81 @@ const repository = {
   repositoryUuid: '123e4567-e89b-12d3-a456-426614174021',
 };
 
+describe('GitHub session creation preflight', () => {
+  it('skips legacy GitHub repositories without an integration pin', async () => {
+    const getTokenForRepo = vi.fn();
+
+    await expect(
+      assertRepositoryAccessBeforeSessionCreation({
+        env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+        userId: 'user-1',
+        repository: { type: 'github', repo: 'acme/repo' },
+      })
+    ).resolves.toBeUndefined();
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('preflights a pinned GitHub repository against the exact integration', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'token',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const orgId = '123e4567-e89b-12d3-a456-426614174030';
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await expect(
+      assertRepositoryAccessBeforeSessionCreation({
+        env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+        userId: 'user-1',
+        orgId,
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: expectedIntegrationId,
+        },
+      })
+    ).resolves.toBeUndefined();
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      orgId,
+      expectedIntegrationId,
+    });
+  });
+
+  it('rejects an integration mismatch before session allocation', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: false,
+      reason: 'integration_mismatch',
+    });
+
+    await expect(
+      assertRepositoryAccessBeforeSessionCreation({
+        env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+        userId: 'user-1',
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+        },
+      })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'GitHub repository authorization failed (integration_mismatch)',
+    });
+  });
+});
+
 describe('Bitbucket session creation preflight', () => {
   it('validates organization sessions against the organization-owned integration', async () => {
     const getBitbucketToken = vi.fn().mockResolvedValue({ success: true, token: 'token' });
     const orgId = '123e4567-e89b-12d3-a456-426614174030';
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId,
@@ -36,7 +104,7 @@ describe('Bitbucket session creation preflight', () => {
     const integrationId = '123e4567-e89b-12d3-a456-426614174022';
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId,
@@ -57,7 +125,7 @@ describe('Bitbucket session creation preflight', () => {
     const getBitbucketToken = vi.fn().mockResolvedValue({ success: true, token: 'token' });
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         repository,
@@ -76,7 +144,7 @@ describe('Bitbucket session creation preflight', () => {
     });
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId: '123e4567-e89b-12d3-a456-426614174030',
@@ -95,7 +163,7 @@ describe('Bitbucket session creation preflight', () => {
     });
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId: '123e4567-e89b-12d3-a456-426614174030',
@@ -109,7 +177,7 @@ describe('Bitbucket session creation preflight', () => {
 
   it('reports an unavailable token-service binding as service unavailable', async () => {
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: {} as never,
         userId: 'user-1',
         orgId: '123e4567-e89b-12d3-a456-426614174030',
@@ -125,7 +193,7 @@ describe('Bitbucket session creation preflight', () => {
     const getBitbucketToken = vi.fn().mockRejectedValue(new Error('binding unavailable'));
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId: '123e4567-e89b-12d3-a456-426614174030',

--- a/services/cloud-agent-next/src/session/validate-repository-access.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.ts
@@ -2,16 +2,36 @@ import { TRPCError } from '@trpc/server';
 import type { PersistenceEnv } from '../persistence/types.js';
 import {
   isTemporaryManagedBitbucketTokenFailure,
+  resolveGitHubTokenForRepo,
   resolveManagedBitbucketToken,
 } from '../services/git-token-service-client.js';
 import type { SessionRepositoryRequest } from './session-requests.js';
 
-export async function assertBitbucketRepositoryAccessBeforeSessionCreation(input: {
+export async function assertRepositoryAccessBeforeSessionCreation(input: {
   env: PersistenceEnv;
   userId: string;
   orgId?: string;
   repository: SessionRepositoryRequest;
 }): Promise<void> {
+  if (input.repository.type === 'github' && input.repository.githubIntegrationId) {
+    const result = await resolveGitHubTokenForRepo(input.env, {
+      githubRepo: input.repository.repo,
+      userId: input.userId,
+      ...(input.orgId ? { orgId: input.orgId } : {}),
+      expectedIntegrationId: input.repository.githubIntegrationId,
+    });
+    if (!result.success) {
+      throw new TRPCError({
+        code:
+          result.error.reason === 'service_not_configured' || result.error.reason === 'rpc_error'
+            ? 'SERVICE_UNAVAILABLE'
+            : 'BAD_REQUEST',
+        message: `GitHub repository authorization failed (${result.error.reason})`,
+      });
+    }
+    return;
+  }
+
   if (input.repository.type !== 'bitbucket') return;
   if (!input.orgId) {
     throw new TRPCError({

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -184,6 +184,8 @@ type GetTokenForRepoResult =
         | 'database_not_configured'
         | 'invalid_repo_format'
         | 'no_installation_found'
+        | 'repository_not_installed'
+        | 'integration_mismatch'
         | 'invalid_org_id';
     };
 
@@ -205,6 +207,7 @@ type ManagedGitHubAuthParams = {
   githubRepo: string;
   userId: string;
   orgId?: string;
+  expectedIntegrationId?: string;
   allowUserAuthorization: boolean;
 };
 
@@ -227,6 +230,7 @@ type GetCloudAgentAuthForRepoResult =
         | 'invalid_repo_format'
         | 'no_installation_found'
         | 'repository_not_installed'
+        | 'integration_mismatch'
         | 'invalid_org_id';
     };
 
@@ -249,6 +253,7 @@ type IssueGitHubSessionCapabilityResult =
         | 'invalid_repo_format'
         | 'no_installation_found'
         | 'repository_not_installed'
+        | 'integration_mismatch'
         | 'invalid_org_id'
         | 'capability_configuration_error';
     };
@@ -267,7 +272,8 @@ type RedeemGitHubSessionCapabilityResult =
         | 'repository_mismatch'
         | 'invalid_upstream_request'
         | 'source_unavailable'
-        | 'identity_mismatch';
+        | 'identity_mismatch'
+        | 'integration_mismatch';
     };
 
 type GetGitLabTokenFailureReason =
@@ -422,6 +428,7 @@ export type GitTokenService = {
     githubRepo: string;
     userId: string;
     orgId?: string;
+    expectedIntegrationId?: string;
   }): Promise<GetTokenForRepoResult>;
   getToken(installationId: string, appType?: 'standard' | 'lite'): Promise<string>;
   getCloudAgentAuthForRepo?(

--- a/services/git-token-service/src/github-session-capability.test.ts
+++ b/services/git-token-service/src/github-session-capability.test.ts
@@ -11,6 +11,7 @@ const claims = {
   userId: 'user_1',
   outboundContainerId: 'outbound-container-1',
   orgId: 'ef2eb5c7-27ce-4f43-b6d3-8f282abc145b',
+  integrationId: 'a65bf5a4-00f7-4a80-8841-4212d4fa9ede',
   owner: 'acme',
   repo: 'widgets',
   source: 'user',
@@ -44,6 +45,7 @@ describe('GitHubSessionCapabilityCodec', () => {
       userId: 'user_1',
       outboundContainerId: claims.outboundContainerId,
       orgId: claims.orgId,
+      integrationId: claims.integrationId,
       owner: 'acme',
       repo: 'widgets',
       source: 'user',
@@ -73,6 +75,15 @@ describe('GitHubSessionCapabilityCodec', () => {
     });
     expect(codec.decode(capability)).not.toHaveProperty('outboundContainerId');
     vi.useRealTimers();
+  });
+
+  it('continues decoding existing claims without an integration ID', () => {
+    const { integrationId: _integrationId, ...existingClaims } = claims;
+    const codec = new GitHubSessionCapabilityCodec(encryptionKey);
+
+    const decoded = codec.decode(codec.issue(existingClaims));
+
+    expect(decoded).not.toHaveProperty('integrationId');
   });
 
   it.each([

--- a/services/git-token-service/src/github-session-capability.ts
+++ b/services/git-token-service/src/github-session-capability.ts
@@ -41,6 +41,7 @@ const GitHubSessionCapabilityClaimsBaseSchema = z.object({
   purpose: z.literal(CAPABILITY_PURPOSE),
   userId: z.string().min(1),
   orgId: z.string().uuid().optional(),
+  integrationId: z.string().uuid().optional(),
   owner: GitHubPathPartSchema,
   repo: GitHubPathPartSchema,
   source: z.enum(['user', 'installation']),
@@ -72,6 +73,7 @@ export type GitHubSessionCapabilitySubject = {
   userId: string;
   outboundContainerId?: string;
   orgId?: string;
+  integrationId?: string;
   owner: string;
   repo: string;
   source: GitHubAuthSource;

--- a/services/git-token-service/src/github-user-authorization-entrypoint.test.ts
+++ b/services/git-token-service/src/github-user-authorization-entrypoint.test.ts
@@ -7,7 +7,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const serviceMocks = vi.hoisted(() => ({
   findManagedInstallationForRepo: vi.fn(),
+  findRefreshCandidates: vi.fn(),
+  updateAccountLogin: vi.fn(),
   getTokenForRepo: vi.fn(),
+  refreshInstallationAccountLoginIfDue: vi.fn(),
   selectUserAuthorization: vi.fn(),
   disconnectUserAuthorization: vi.fn(),
   getUserAccessToken: vi.fn(),
@@ -26,12 +29,15 @@ vi.mock('cloudflare:workers', () => ({
 vi.mock('./github-token-service.js', () => ({
   GitHubTokenService: class GitHubTokenService {
     getTokenForRepo = serviceMocks.getTokenForRepo;
+    refreshInstallationAccountLoginIfDue = serviceMocks.refreshInstallationAccountLoginIfDue;
   },
 }));
 
 vi.mock('./installation-lookup-service.js', () => ({
   InstallationLookupService: class InstallationLookupService {
     findManagedInstallationForRepo = serviceMocks.findManagedInstallationForRepo;
+    findRefreshCandidates = serviceMocks.findRefreshCandidates;
+    updateAccountLogin = serviceMocks.updateAccountLogin;
   },
 }));
 
@@ -130,6 +136,52 @@ describe('GitTokenRPCEntrypoint.getCloudAgentAuthForRepo', () => {
         email: '240665456+kiloconnect[bot]@users.noreply.github.com',
       },
     });
+  });
+
+  it('repairs stale login metadata before resolving fenced Cloud Agent auth', async () => {
+    const params = {
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      orgId: '00000000-0000-4000-8000-000000000001',
+      expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+      allowUserAuthorization: true,
+    };
+    serviceMocks.findManagedInstallationForRepo
+      .mockResolvedValueOnce({ success: false, reason: 'integration_mismatch' })
+      .mockResolvedValueOnce({
+        success: true,
+        installationId: '123',
+        accountLogin: 'acme',
+        githubAppType: 'standard',
+        repoName: 'repo',
+        permissions: { contents: 'write', pull_requests: 'write' },
+      });
+    serviceMocks.findRefreshCandidates.mockResolvedValue({
+      success: true,
+      candidates: [
+        {
+          integrationId: params.expectedIntegrationId,
+          installationId: '123',
+          accountLogin: 'old-acme',
+          githubAppType: 'standard',
+        },
+      ],
+    });
+    serviceMocks.refreshInstallationAccountLoginIfDue.mockResolvedValue('acme');
+    serviceMocks.updateAccountLogin.mockResolvedValue(true);
+    vi.spyOn(console, 'log').mockImplementation(() => {});
+
+    await expect(createService().getCloudAgentAuthForRepo(params)).resolves.toMatchObject({
+      success: true,
+      source: 'user',
+      githubToken: 'user-token',
+    });
+    expect(serviceMocks.findManagedInstallationForRepo).toHaveBeenCalledTimes(2);
+    expect(serviceMocks.findRefreshCandidates).toHaveBeenCalledWith(params);
+    expect(serviceMocks.updateAccountLogin).toHaveBeenCalledWith(
+      params.expectedIntegrationId,
+      'acme'
+    );
   });
 
   it.each(['credential_unreadable', 'credential_configuration_error'] as const)(

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -705,6 +705,27 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     ).rejects.toThrow('repository not accessible');
     expect(serviceMocks.getToken).not.toHaveBeenCalled();
   });
+
+  it('forwards the expected integration fence and exposes only its sanitized mismatch', async () => {
+    const params = {
+      githubRepo: 'acme/repository',
+      userId: 'user-1',
+      orgId: '00000000-0000-4000-8000-000000000001',
+      expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+    };
+    serviceMocks.findInstallationId.mockResolvedValue({
+      success: false,
+      reason: 'integration_mismatch',
+    });
+
+    await expect(createService().getTokenForRepo(params)).resolves.toEqual({
+      success: false,
+      reason: 'integration_mismatch',
+    });
+    expect(serviceMocks.findInstallationId).toHaveBeenCalledWith(params);
+    expect(serviceMocks.findRefreshCandidates).not.toHaveBeenCalled();
+    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
+  });
 });
 
 const outboundContainerId = 'outbound-container-1';
@@ -763,6 +784,70 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     expect(result.capability).not.toContain('installation-token');
     expect(result).not.toHaveProperty('githubToken');
     expect(result).not.toHaveProperty('token');
+  });
+
+  it('preserves an expected integration fence through capability redemption', async () => {
+    const expectedIntegrationId = '00000000-0000-4000-8000-000000000002';
+    const orgId = '00000000-0000-4000-8000-000000000001';
+    const service = createService();
+    const issued = await service.issueGitHubSessionCapability({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      orgId,
+      expectedIntegrationId,
+      outboundContainerId,
+    });
+    if (!issued.success) throw new Error('Expected successful issuance');
+    expect(serviceMocks.findManagedInstallationForRepo).toHaveBeenLastCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      orgId,
+      expectedIntegrationId,
+      outboundContainerId,
+    });
+    serviceMocks.findManagedInstallationForRepo.mockClear();
+
+    await expect(
+      service.redeemGitHubSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestMethod: 'GET',
+        requestUrl: 'https://github.com/acme/repo.git/info/refs?service=git-upload-pack',
+      })
+    ).resolves.toMatchObject({ success: true });
+    expect(serviceMocks.findManagedInstallationForRepo).toHaveBeenLastCalledWith({
+      userId: 'user_1',
+      orgId,
+      expectedIntegrationId,
+      githubRepo: 'acme/repo',
+    });
+  });
+
+  it('returns integration_mismatch when a capability fence no longer authorizes its row', async () => {
+    const service = createService();
+    const issued = await service.issueGitHubSessionCapability({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      orgId: '00000000-0000-4000-8000-000000000001',
+      expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+      outboundContainerId,
+    });
+    if (!issued.success) throw new Error('Expected successful issuance');
+    serviceMocks.getTokenForRepo.mockClear();
+    serviceMocks.findManagedInstallationForRepo.mockResolvedValueOnce({
+      success: false,
+      reason: 'integration_mismatch',
+    });
+
+    await expect(
+      service.redeemGitHubSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestMethod: 'GET',
+        requestUrl: 'https://github.com/acme/repo.git/info/refs?service=git-upload-pack',
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
+    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
 
   it('returns a sanitized declared failure when capability key configuration is invalid', async () => {

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -706,25 +706,47 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     expect(serviceMocks.getToken).not.toHaveBeenCalled();
   });
 
-  it('forwards the expected integration fence and exposes only its sanitized mismatch', async () => {
+  it('repairs stale login metadata within the expected integration fence', async () => {
     const params = {
       githubRepo: 'acme/repository',
       userId: 'user-1',
       orgId: '00000000-0000-4000-8000-000000000001',
       expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
     };
-    serviceMocks.findInstallationId.mockResolvedValue({
-      success: false,
-      reason: 'integration_mismatch',
+    serviceMocks.findInstallationId
+      .mockResolvedValueOnce({ success: false, reason: 'integration_mismatch' })
+      .mockResolvedValueOnce({
+        success: true,
+        installationId: '123',
+        accountLogin: 'acme',
+        githubAppType: 'standard',
+      });
+    serviceMocks.findRefreshCandidates.mockResolvedValue({
+      success: true,
+      candidates: [
+        {
+          integrationId: params.expectedIntegrationId,
+          installationId: '123',
+          accountLogin: 'old-acme',
+          githubAppType: 'standard',
+        },
+      ],
     });
+    serviceMocks.refreshInstallationAccountLoginIfDue.mockResolvedValue('acme');
+    serviceMocks.updateAccountLogin.mockResolvedValue(true);
+    serviceMocks.getTokenForRepo.mockResolvedValue('scoped-token');
+    vi.spyOn(console, 'log').mockImplementation(() => {});
 
-    await expect(createService().getTokenForRepo(params)).resolves.toEqual({
-      success: false,
-      reason: 'integration_mismatch',
+    await expect(createService().getTokenForRepo(params)).resolves.toMatchObject({
+      success: true,
+      token: 'scoped-token',
     });
-    expect(serviceMocks.findInstallationId).toHaveBeenCalledWith(params);
-    expect(serviceMocks.findRefreshCandidates).not.toHaveBeenCalled();
-    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
+    expect(serviceMocks.findInstallationId).toHaveBeenCalledTimes(2);
+    expect(serviceMocks.findRefreshCandidates).toHaveBeenCalledWith(params);
+    expect(serviceMocks.updateAccountLogin).toHaveBeenCalledWith(
+      params.expectedIntegrationId,
+      'acme'
+    );
   });
 });
 
@@ -823,7 +845,7 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     });
   });
 
-  it('returns integration_mismatch when a capability fence no longer authorizes its row', async () => {
+  it('returns integration_mismatch when repair cannot restore a capability fence', async () => {
     const service = createService();
     const issued = await service.issueGitHubSessionCapability({
       githubRepo: 'acme/repo',
@@ -831,13 +853,16 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
       orgId: '00000000-0000-4000-8000-000000000001',
       expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
       outboundContainerId,
+      allowUserAuthorization: true,
     });
     if (!issued.success) throw new Error('Expected successful issuance');
     serviceMocks.getTokenForRepo.mockClear();
-    serviceMocks.findManagedInstallationForRepo.mockResolvedValueOnce({
+    serviceMocks.findManagedInstallationForRepo.mockClear();
+    serviceMocks.findManagedInstallationForRepo.mockResolvedValue({
       success: false,
       reason: 'integration_mismatch',
     });
+    serviceMocks.findRefreshCandidates.mockResolvedValue({ success: true, candidates: [] });
 
     await expect(
       service.redeemGitHubSessionCapability({
@@ -847,6 +872,13 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
         requestUrl: 'https://github.com/acme/repo.git/info/refs?service=git-upload-pack',
       })
     ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
+    expect(serviceMocks.findManagedInstallationForRepo).toHaveBeenCalledTimes(2);
+    expect(serviceMocks.findRefreshCandidates).toHaveBeenCalledWith({
+      userId: 'user_1',
+      orgId: '00000000-0000-4000-8000-000000000001',
+      expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+      githubRepo: 'acme/repo',
+    });
     expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
 

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -92,6 +92,7 @@ export type GetTokenForRepoParams = {
   githubRepo: string;
   userId: string;
   orgId?: string;
+  expectedIntegrationId?: string;
 };
 
 export type GetTokenForRepoSuccess = {
@@ -109,7 +110,8 @@ export type GetTokenForRepoFailure = {
     | 'invalid_repo_format'
     | 'no_installation_found'
     | 'repository_not_installed'
-    | 'invalid_org_id';
+    | 'invalid_org_id'
+    | 'integration_mismatch';
 };
 
 export type GetTokenForRepoResult = GetTokenForRepoSuccess | GetTokenForRepoFailure;
@@ -179,6 +181,7 @@ export type RedeemGitHubSessionCapabilityFailureReason =
   | 'repository_mismatch'
   | 'invalid_upstream_request'
   | 'source_unavailable'
+  | 'integration_mismatch'
   | 'identity_mismatch';
 export type RedeemGitHubSessionCapabilityResult =
   | RedeemGitHubSessionCapabilitySuccess
@@ -779,6 +782,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
         case 'invalid_repo_format':
         case 'no_installation_found':
         case 'invalid_org_id':
+        case 'integration_mismatch':
           return { success: false, reason: installation.reason };
       }
     }
@@ -820,6 +824,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
         case 'no_installation_found':
         case 'repository_not_installed':
         case 'invalid_org_id':
+        case 'integration_mismatch':
           return { success: false, reason: installation.reason };
       }
     }
@@ -887,6 +892,9 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
           ? { outboundContainerId: params.outboundContainerId }
           : {}),
         ...(params.orgId !== undefined ? { orgId: params.orgId } : {}),
+        ...(params.expectedIntegrationId !== undefined
+          ? { integrationId: params.expectedIntegrationId }
+          : {}),
         ...repository,
         source: auth.source,
         identity: this.getSessionIdentity(auth),
@@ -934,6 +942,9 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     const authParams = {
       userId: claims.userId,
       ...(claims.orgId !== undefined ? { orgId: claims.orgId } : {}),
+      ...(claims.integrationId !== undefined
+        ? { expectedIntegrationId: claims.integrationId }
+        : {}),
       githubRepo: `${claims.owner}/${claims.repo}`,
     };
     let auth: GetCloudAgentAuthForRepoResult | null;
@@ -945,6 +956,9 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
       } catch {
         return { success: false, reason: 'source_unavailable' };
       }
+    }
+    if (auth && !auth.success && auth.reason === 'integration_mismatch') {
+      return { success: false, reason: 'integration_mismatch' };
     }
     if (!auth || !auth.success || auth.source !== claims.source) {
       return { success: false, reason: 'source_unavailable' };
@@ -983,9 +997,12 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
 
   private async redeemPinnedUserAuthorization(
     params: GetTokenForRepoParams
-  ): Promise<GetCloudAgentAuthForRepoSuccess | null> {
+  ): Promise<GetCloudAgentAuthForRepoResult | null> {
     const installation =
       await this.installationLookupService.findManagedInstallationForRepo(params);
+    if (!installation.success && installation.reason === 'integration_mismatch') {
+      return { success: false, reason: 'integration_mismatch' };
+    }
     if (!installation.success || installation.githubAppType === 'lite') return null;
     if (
       installation.permissions?.contents !== 'write' ||

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -43,7 +43,10 @@ import {
   handleGitLabCredentialBrokerRequest,
 } from './gitlab-credential-broker-handler.js';
 import type { GitLabCredentialBroker } from './gitlab-credential-broker.js';
-import { InstallationLookupService } from './installation-lookup-service.js';
+import {
+  InstallationLookupService,
+  type InstallationLookupFailure,
+} from './installation-lookup-service.js';
 import {
   GitHubSessionCapabilityCodec,
   GitHubSessionCapabilityError,
@@ -757,6 +760,40 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     }
   }
 
+  private shouldRepairGitHubInstallationLogin(
+    params: GetTokenForRepoParams,
+    reason: InstallationLookupFailure['reason'] | 'repository_not_installed'
+  ): boolean {
+    return (
+      reason === 'no_installation_found' ||
+      (params.expectedIntegrationId !== undefined && reason === 'integration_mismatch')
+    );
+  }
+
+  private async findInstallationIdWithLoginRepair(params: GetTokenForRepoParams) {
+    let installation = await this.installationLookupService.findInstallationId(params);
+    if (
+      !installation.success &&
+      this.shouldRepairGitHubInstallationLogin(params, installation.reason)
+    ) {
+      await this.refreshGitHubInstallationLogins(params);
+      installation = await this.installationLookupService.findInstallationId(params);
+    }
+    return installation;
+  }
+
+  private async findManagedInstallationWithLoginRepair(params: GetTokenForRepoParams) {
+    let installation = await this.installationLookupService.findManagedInstallationForRepo(params);
+    if (
+      !installation.success &&
+      this.shouldRepairGitHubInstallationLogin(params, installation.reason)
+    ) {
+      await this.refreshGitHubInstallationLogins(params);
+      installation = await this.installationLookupService.findManagedInstallationForRepo(params);
+    }
+    return installation;
+  }
+
   /**
    * Get a GitHub token for a repository.
    *
@@ -769,11 +806,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
    * @returns Token and installation details, or a failure reason
    */
   async getTokenForRepo(params: GetTokenForRepoParams): Promise<GetTokenForRepoResult> {
-    let installation = await this.installationLookupService.findInstallationId(params);
-    if (!installation.success && installation.reason === 'no_installation_found') {
-      await this.refreshGitHubInstallationLogins(params);
-      installation = await this.installationLookupService.findInstallationId(params);
-    }
+    const installation = await this.findInstallationIdWithLoginRepair(params);
     if (!installation.success) {
       switch (installation.reason) {
         case 'ambiguous_installation':
@@ -810,11 +843,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
   async getCloudAgentAuthForRepo(
     params: GetCloudAgentAuthForRepoParams
   ): Promise<GetCloudAgentAuthForRepoResult> {
-    let installation = await this.installationLookupService.findManagedInstallationForRepo(params);
-    if (!installation.success && installation.reason === 'no_installation_found') {
-      await this.refreshGitHubInstallationLogins(params);
-      installation = await this.installationLookupService.findManagedInstallationForRepo(params);
-    }
+    const installation = await this.findManagedInstallationWithLoginRepair(params);
     if (!installation.success) {
       switch (installation.reason) {
         case 'ambiguous_installation':
@@ -998,8 +1027,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
   private async redeemPinnedUserAuthorization(
     params: GetTokenForRepoParams
   ): Promise<GetCloudAgentAuthForRepoResult | null> {
-    const installation =
-      await this.installationLookupService.findManagedInstallationForRepo(params);
+    const installation = await this.findManagedInstallationWithLoginRepair(params);
     if (!installation.success && installation.reason === 'integration_mismatch') {
       return { success: false, reason: 'integration_mismatch' };
     }

--- a/services/git-token-service/src/installation-lookup-service.behavior.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.behavior.test.ts
@@ -12,6 +12,8 @@ type InstallationRow = {
   platform_account_login: string | null;
   github_app_type: 'standard' | 'lite' | null;
   owned_by_organization_id: string | null;
+  owned_by_user_id?: string | null;
+  integration_status?: string;
   repository_access?: string | null;
   repositories?: { full_name: string }[] | null;
   permissions?: Record<string, unknown> | null;
@@ -229,6 +231,105 @@ describe('InstallationLookupService', () => {
     });
 
     expect(result).toEqual({ success: false, reason: 'ambiguous_installation' });
+  });
+
+  it('resolves the exact active organization integration with repository access', async () => {
+    const integrationId = '00000000-0000-4000-8000-000000000002';
+    const orgId = '00000000-0000-4000-8000-000000000001';
+    const service = createService([
+      {
+        id: integrationId,
+        platform_installation_id: '100',
+        platform_account_login: 'renamed-owner',
+        github_app_type: 'standard',
+        integration_status: 'active',
+        owned_by_organization_id: orgId,
+        owned_by_user_id: null,
+        repository_access: 'selected',
+        repositories: [{ full_name: 'renamed-owner/repository' }],
+        permissions: { contents: 'write', pull_requests: 'write' },
+      },
+    ]);
+
+    await expect(
+      service.findManagedInstallationForRepo({
+        githubRepo: 'renamed-owner/repository',
+        userId: 'user-1',
+        orgId,
+        expectedIntegrationId: integrationId,
+      })
+    ).resolves.toEqual({
+      success: true,
+      installationId: '100',
+      accountLogin: 'renamed-owner',
+      githubAppType: 'standard',
+      repoName: 'repository',
+      permissions: { contents: 'write', pull_requests: 'write' },
+    });
+  });
+
+  it.each<[string, Partial<InstallationRow>]>([
+    ['wrong organization', { owned_by_organization_id: '00000000-0000-4000-8000-000000000099' }],
+    ['personal row', { owned_by_organization_id: null, owned_by_user_id: 'user-1' }],
+    ['suspended row', { integration_status: 'suspended' }],
+    ['repository owner mismatch', { platform_account_login: 'other-owner' }],
+    [
+      'selected repository mismatch',
+      { repositories: [{ full_name: 'renamed-owner/other-repository' }] },
+    ],
+  ])('rejects an expected integration with %s', async (_reason, override) => {
+    const integrationId = '00000000-0000-4000-8000-000000000002';
+    const orgId = '00000000-0000-4000-8000-000000000001';
+    const service = createService([
+      {
+        id: integrationId,
+        platform_installation_id: '100',
+        platform_account_login: 'renamed-owner',
+        github_app_type: 'standard',
+        integration_status: 'active',
+        owned_by_organization_id: orgId,
+        owned_by_user_id: null,
+        repository_access: 'selected',
+        repositories: [{ full_name: 'renamed-owner/repository' }],
+        permissions: null,
+        ...override,
+      },
+    ]);
+
+    await expect(
+      service.findManagedInstallationForRepo({
+        githubRepo: 'renamed-owner/repository',
+        userId: 'user-1',
+        orgId,
+        expectedIntegrationId: integrationId,
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
+  });
+
+  it('does not accept an expected integration without an organization', async () => {
+    const service = createService([]);
+
+    await expect(
+      service.findManagedInstallationForRepo({
+        githubRepo: 'renamed-owner/repository',
+        userId: 'user-1',
+        expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
+    expect(getWorkerDb).not.toHaveBeenCalled();
+  });
+
+  it('returns integration_mismatch when the expected row is not visible to the fenced query', async () => {
+    const service = createService([]);
+
+    await expect(
+      service.findManagedInstallationForRepo({
+        githubRepo: 'renamed-owner/repository',
+        userId: 'user-1',
+        orgId: '00000000-0000-4000-8000-000000000001',
+        expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
   });
 
   it.each(['owner/repository/extra', 'owner/', '/repository', 'owner//repository', 'owner'])(

--- a/services/git-token-service/src/installation-lookup-service.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.test.ts
@@ -3,6 +3,7 @@ import { getWorkerDb } from '@kilocode/db/client';
 import {
   buildInstallationLookupQuery,
   buildInstallationRefreshCandidatesQuery,
+  buildManagedInstallationLookupQuery,
 } from './installation-lookup-service.js';
 
 const params = {
@@ -54,5 +55,25 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.sql).toContain('"kilocode_users"."blocked_reason" is null');
     expect(query.sql).toContain('"organization_memberships"."id" is not null');
     expect(query.params).toContain(10);
+  });
+
+  it('uses a supplied integration ID as an exact organization authorization fence', () => {
+    const db = getWorkerDb('postgres://unused:unused@localhost:0/unused');
+    const expectedIntegrationId = '00000000-0000-4000-8000-000000000002';
+    const query = buildManagedInstallationLookupQuery(db, {
+      ...params,
+      expectedIntegrationId,
+    }).toSQL();
+
+    expect(query.sql).toContain('"platform_integrations"."id" =');
+    expect(query.sql).toContain('"platform_integrations"."integration_status" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_organization_id" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" is null');
+    expect(query.sql).toContain('"organization_memberships"."id" is not null');
+    expect(query.sql).not.toContain('"platform_integrations"."owned_by_user_id" =');
+    expect(query.params).toContain(expectedIntegrationId);
+    expect(query.params).toContain(params.orgId);
+    expect(query.params).toContain('renamed-owner');
+    expect(query.params).toContain(1);
   });
 });

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -11,6 +11,7 @@ export type FindInstallationParams = {
   githubRepo: string;
   userId: string;
   orgId?: string;
+  expectedIntegrationId?: string;
 };
 
 const InstallationLookupResultSchema = z.object({
@@ -36,6 +37,12 @@ const ManagedInstallationLookupResultSchema = InstallationLookupResultSchema.ext
   permissions: z.record(z.string(), z.unknown()).nullable(),
 });
 
+const ExactManagedInstallationLookupResultSchema = ManagedInstallationLookupResultSchema.extend({
+  id: z.string().uuid(),
+  integration_status: z.string(),
+  owned_by_user_id: z.string().nullable(),
+});
+
 const MAX_INSTALLATION_LOGIN_REFRESH_CANDIDATES = 10;
 
 export type InstallationLookupSuccess = {
@@ -52,7 +59,8 @@ export type InstallationLookupFailure = {
     | 'invalid_repo_format'
     | 'no_installation_found'
     | 'ambiguous_installation'
-    | 'invalid_org_id';
+    | 'invalid_org_id'
+    | 'integration_mismatch';
 };
 
 export type InstallationLookupResult = InstallationLookupSuccess | InstallationLookupFailure;
@@ -101,6 +109,31 @@ function buildAuthorizedInstallationsQuery(
               )
             )
         );
+  const exactIntegrationOwner =
+    params.expectedIntegrationId === undefined
+      ? undefined
+      : params.orgId === undefined
+        ? sql`false`
+        : and(
+            eq(platform_integrations.id, params.expectedIntegrationId),
+            eq(platform_integrations.owned_by_organization_id, params.orgId),
+            isNull(platform_integrations.owned_by_user_id),
+            isNotNull(organization_memberships.id)
+          );
+  const legacyAuthorizedOwner =
+    params.expectedIntegrationId === undefined
+      ? or(
+          and(
+            isNotNull(platform_integrations.owned_by_organization_id),
+            eq(platform_integrations.owned_by_organization_id, sql`${params.orgId ?? null}::uuid`),
+            isNotNull(organization_memberships.id)
+          ),
+          and(
+            isNotNull(platform_integrations.owned_by_user_id),
+            eq(platform_integrations.owned_by_user_id, params.userId)
+          )
+        )
+      : undefined;
 
   return db
     .select({
@@ -108,7 +141,9 @@ function buildAuthorizedInstallationsQuery(
       platform_installation_id: platform_integrations.platform_installation_id,
       platform_account_login: platform_integrations.platform_account_login,
       github_app_type: platform_integrations.github_app_type,
+      integration_status: platform_integrations.integration_status,
       owned_by_organization_id: platform_integrations.owned_by_organization_id,
+      owned_by_user_id: platform_integrations.owned_by_user_id,
       repository_access: platform_integrations.repository_access,
       repositories: platform_integrations.repositories,
       permissions: platform_integrations.permissions,
@@ -136,17 +171,8 @@ function buildAuthorizedInstallationsQuery(
         accountLoginFilter,
         isNotNull(platform_integrations.platform_installation_id),
         requestedOrganizationMembership,
-        or(
-          and(
-            isNotNull(platform_integrations.owned_by_organization_id),
-            eq(platform_integrations.owned_by_organization_id, sql`${params.orgId ?? null}::uuid`),
-            isNotNull(organization_memberships.id)
-          ),
-          and(
-            isNotNull(platform_integrations.owned_by_user_id),
-            eq(platform_integrations.owned_by_user_id, params.userId)
-          )
-        )
+        exactIntegrationOwner,
+        legacyAuthorizedOwner
       )
     )
     .orderBy(
@@ -156,7 +182,9 @@ function buildAuthorizedInstallationsQuery(
 
 export function buildInstallationLookupQuery(db: WorkerDb, params: FindInstallationParams) {
   const [repoOwner = ''] = params.githubRepo.split('/');
-  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(2);
+  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(
+    params.expectedIntegrationId === undefined ? 2 : 1
+  );
 }
 
 export function buildInstallationRefreshCandidatesQuery(
@@ -170,7 +198,9 @@ export function buildInstallationRefreshCandidatesQuery(
 
 export function buildManagedInstallationLookupQuery(db: WorkerDb, params: FindInstallationParams) {
   const [repoOwner = ''] = params.githubRepo.split('/');
-  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(2);
+  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(
+    params.expectedIntegrationId === undefined ? 2 : 1
+  );
 }
 
 export class InstallationLookupService {
@@ -196,6 +226,14 @@ export class InstallationLookupService {
       return { success: false, reason: 'invalid_org_id' };
     }
 
+    if (
+      params.expectedIntegrationId !== undefined &&
+      (params.orgId === undefined ||
+        !z.string().uuid().safeParse(params.expectedIntegrationId).success)
+    ) {
+      return { success: false, reason: 'integration_mismatch' };
+    }
+
     const repoParts = params.githubRepo.split('/');
     if (repoParts.length !== 2 || repoParts.some(part => part.length === 0)) {
       return { success: false, reason: 'invalid_repo_format' };
@@ -211,6 +249,20 @@ export class InstallationLookupService {
     }
 
     const rows = await buildInstallationLookupQuery(this.getDb(), params);
+
+    if (params.expectedIntegrationId !== undefined) {
+      const selected = ExactManagedInstallationLookupResultSchema.safeParse(rows[0]);
+      if (!selected.success || !this.matchesExpectedIntegration(selected.data, params)) {
+        return { success: false, reason: 'integration_mismatch' };
+      }
+
+      return {
+        success: true,
+        installationId: selected.data.platform_installation_id,
+        accountLogin: selected.data.platform_account_login ?? '',
+        githubAppType: selected.data.github_app_type ?? 'standard',
+      };
+    }
 
     if (rows.length === 0) {
       return { success: false, reason: 'no_installation_found' };
@@ -288,6 +340,22 @@ export class InstallationLookupService {
     }
 
     const rows = await buildManagedInstallationLookupQuery(this.getDb(), params);
+    if (params.expectedIntegrationId !== undefined) {
+      const selected = ExactManagedInstallationLookupResultSchema.safeParse(rows[0]);
+      if (!selected.success || !this.matchesExpectedIntegration(selected.data, params)) {
+        return { success: false, reason: 'integration_mismatch' };
+      }
+
+      return {
+        success: true,
+        installationId: selected.data.platform_installation_id,
+        accountLogin: selected.data.platform_account_login ?? '',
+        githubAppType: selected.data.github_app_type ?? 'standard',
+        repoName,
+        permissions: selected.data.permissions,
+      };
+    }
+
     if (rows.length === 0) {
       return { success: false, reason: 'no_installation_found' };
     }
@@ -323,5 +391,29 @@ export class InstallationLookupService {
       repoName,
       permissions: selected.permissions,
     };
+  }
+
+  private matchesExpectedIntegration(
+    selected: z.infer<typeof ExactManagedInstallationLookupResultSchema>,
+    params: FindInstallationParams
+  ): boolean {
+    if (
+      selected.id !== params.expectedIntegrationId ||
+      selected.integration_status !== 'active' ||
+      selected.owned_by_organization_id !== params.orgId ||
+      selected.owned_by_user_id !== null ||
+      selected.platform_account_login?.toLowerCase() !==
+        params.githubRepo.split('/')[0]?.toLowerCase()
+    ) {
+      return false;
+    }
+
+    if (selected.repository_access === 'all') return true;
+    if (selected.repository_access !== 'selected') return false;
+    return Boolean(
+      selected.repositories?.some(
+        repository => repository.full_name.toLowerCase() === params.githubRepo.toLowerCase()
+      )
+    );
   }
 }


### PR DESCRIPTION
## Summary
- expose repository installation provenance through the organization Cloud Agent API
- group web repository choices by GitHub organization
- submit the selected installation ID through session preparation
- prevent recent/pasted duplicate repository names from silently selecting the wrong installation

<img width="1578" height="1054" alt="CleanShot 2026-08-26 at 14 20 13@2x" src="https://github.com/user-attachments/assets/33022b9b-9d19-4a51-b2a8-d8381ff14722" />
