### PR TITLE
feat(cloud-agent): select GitHub installations on clients

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
@@ -3,6 +3,7 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildPrepareSessionInput,
   buildSubmitInput,
+  getRepoOptionKey,
   isModelPreferencesGetResult,
   MODE,
   PROMPT_MAX_LENGTH,
@@ -131,6 +132,29 @@ describe('buildSubmitInput helper', () => {
   it('does not include organizationId (handled by caller)', () => {
     const result = buildSubmitInput(baseParams);
     expect(result).not.toHaveProperty('organizationId');
+  });
+
+  it('includes repository integration provenance when available', () => {
+    const result = buildSubmitInput({ ...baseParams, githubIntegrationId: 'integration-1' });
+    expect(result['githubIntegrationId']).toBe('integration-1');
+  });
+
+  it('omits repository integration provenance for legacy responses', () => {
+    expect(buildSubmitInput(baseParams)).not.toHaveProperty('githubIntegrationId');
+  });
+});
+
+describe('getRepoOptionKey helper', () => {
+  const repository = { fullName: 'owner/repo', id: 1, name: 'repo', private: false };
+
+  it('distinguishes duplicate repositories across integrations', () => {
+    expect(getRepoOptionKey({ ...repository, platformIntegrationId: 'integration-1' })).not.toBe(
+      getRepoOptionKey({ ...repository, platformIntegrationId: 'integration-2' })
+    );
+  });
+
+  it('uses the legacy full name when provenance is absent', () => {
+    expect(getRepoOptionKey(repository)).toBe('owner/repo');
   });
 });
 

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
@@ -88,7 +88,14 @@ interface RepoOption {
   readonly name: string;
   readonly fullName: string;
   readonly private: boolean;
+  readonly platformIntegrationId?: string;
+  readonly platformAccountLogin?: string;
 }
+
+export const getRepoOptionKey = (repo: RepoOption): string =>
+  repo.platformIntegrationId === undefined || repo.platformIntegrationId === ''
+    ? repo.fullName
+    : `${repo.platformIntegrationId}:${repo.fullName}`;
 
 interface LastSelected {
   readonly model: string;
@@ -123,17 +130,22 @@ export const buildSubmitInput = ({
   prompt,
   selectedModel,
   selectedRepo,
+  githubIntegrationId,
   selectedVariant,
 }: {
   prompt: string;
   selectedModel: string;
   selectedVariant: string;
   selectedRepo: string;
+  githubIntegrationId?: string;
   initialMessageId: string;
 }) => ({
   autoCommit: true,
   autoInitiate: true,
   githubRepo: selectedRepo,
+  ...(githubIntegrationId === undefined || githubIntegrationId === ''
+    ? {}
+    : { githubIntegrationId }),
   initialMessageId,
   mode: MODE,
   model: selectedModel,
@@ -350,6 +362,10 @@ export const AgentsNewSession = ({
   const repoDropdownRef = useRef<HTMLDivElement>(null);
 
   const isCloudTarget = runTarget === 'cloud';
+  const selectedRepository = useMemo(
+    () => repos.find(repository => getRepoOptionKey(repository) === selectedRepo),
+    [repos, selectedRepo]
+  );
   const selectedInstance = useMemo(
     () => instances.find(instance => instance.connectionId === runTarget),
     [instances, runTarget]
@@ -406,7 +422,8 @@ export const AgentsNewSession = ({
     if (selectedRepo || repos.length !== 1) {
       return;
     }
-    setSelectedRepo(repos[0]?.fullName ?? '');
+    const [repository] = repos;
+    setSelectedRepo(repository ? getRepoOptionKey(repository) : '');
   }, [repos, selectedRepo]);
 
   // ---- Picker values per run target ----
@@ -430,7 +447,7 @@ export const AgentsNewSession = ({
   /* A CLI instance inherits the repo from the CLI and defaults to its own
      model; cloud needs both picked. */
   const isFormValid = isCloudTarget
-    ? isPromptValid && selectedModel !== '' && selectedRepo !== ''
+    ? isPromptValid && selectedModel !== '' && selectedRepository !== undefined
     : isPromptValid;
   const repoStatus = (() => {
     if (isRepoLoading) {
@@ -451,9 +468,19 @@ export const AgentsNewSession = ({
     return repos.filter(
       repo =>
         repo.fullName.toLowerCase().includes(normalized) ||
-        repo.name.toLowerCase().includes(normalized)
+        repo.name.toLowerCase().includes(normalized) ||
+        repo.platformAccountLogin?.toLowerCase().includes(normalized) === true
     );
   }, [repos, repoSearch]);
+  const groupedRepos = useMemo(() => {
+    const groups = new Map<string | undefined, RepoOption[]>();
+    for (const repository of filteredRepos) {
+      const group = groups.get(repository.platformAccountLogin) ?? [];
+      group.push(repository);
+      groups.set(repository.platformAccountLogin, group);
+    }
+    return [...groups];
+  }, [filteredRepos]);
 
   const blockedReason = submitBlockedReason({
     hasModels: modelOptions.length > 0,
@@ -462,7 +489,7 @@ export const AgentsNewSession = ({
     isLoading: isRepoLoading || isModelsLoading,
     isPromptValid,
     repoCount: repos.length,
-    selectedRepo,
+    selectedRepo: selectedRepository ? selectedRepo : '',
   });
 
   const isCreditsError = submitError?.toLowerCase().includes('insufficient credits') ?? false;
@@ -543,7 +570,11 @@ export const AgentsNewSession = ({
       initialMessageId: messageId,
       prompt: trimmed,
       selectedModel,
-      selectedRepo,
+      selectedRepo: selectedRepository?.fullName ?? '',
+      ...(selectedRepository?.platformIntegrationId === undefined ||
+      selectedRepository.platformIntegrationId === ''
+        ? {}
+        : { githubIntegrationId: selectedRepository.platformIntegrationId }),
       selectedVariant,
     });
 
@@ -595,7 +626,7 @@ export const AgentsNewSession = ({
     trimmed,
     selectedModel,
     selectedVariant,
-    selectedRepo,
+    selectedRepository,
     organizationId,
     trpcClient,
     queryClient,
@@ -832,7 +863,7 @@ export const AgentsNewSession = ({
                 <span
                   className={`max-w-[120px] truncate ${selectedRepo ? 'text-foreground' : 'text-foreground-muted'}`}
                 >
-                  {selectedRepo || 'Repository'}
+                  {selectedRepository?.fullName ?? 'Repository'}
                 </span>
                 {repoStatus === 'loading' ? (
                   <Loader2 className="size-3.5 shrink-0 animate-spin" />
@@ -922,26 +953,38 @@ export const AgentsNewSession = ({
                             No repositories match your search
                           </p>
                         ) : (
-                          filteredRepos.map(repo => (
-                            <button
-                              className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
-                              key={repo.id}
-                              onClick={() => {
-                                setSelectedRepo(repo.fullName);
-                                setRepoDropdownOpen(false);
-                                setRepoSearch('');
-                              }}
-                              type="button"
-                            >
-                              <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
-                              <span className="truncate flex-1">{repo.fullName}</span>
-                              {repo.private ? (
-                                <Lock className="size-3 shrink-0 text-foreground-muted" />
+                          groupedRepos.map(([accountLogin, repositories]) => (
+                            <div key={accountLogin ?? 'legacy'}>
+                              {accountLogin !== undefined && accountLogin !== '' ? (
+                                <p className="px-3 pb-1 pt-2 type-label font-semibold uppercase tracking-wide text-foreground-muted">
+                                  {accountLogin}
+                                </p>
                               ) : null}
-                              {repo.fullName === selectedRepo ? (
-                                <Check className="size-3.5 shrink-0 text-brand-primary" />
-                              ) : null}
-                            </button>
+                              {repositories.map(repo => {
+                                const repoKey = getRepoOptionKey(repo);
+                                return (
+                                  <button
+                                    className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
+                                    key={repoKey}
+                                    onClick={() => {
+                                      setSelectedRepo(repoKey);
+                                      setRepoDropdownOpen(false);
+                                      setRepoSearch('');
+                                    }}
+                                    type="button"
+                                  >
+                                    <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
+                                    <span className="truncate flex-1">{repo.fullName}</span>
+                                    {repo.private ? (
+                                      <Lock className="size-3 shrink-0 text-foreground-muted" />
+                                    ) : null}
+                                    {repoKey === selectedRepo ? (
+                                      <Check className="size-3.5 shrink-0 text-brand-primary" />
+                                    ) : null}
+                                  </button>
+                                );
+                              })}
+                            </div>
                           ))
                         )}
                       </>

--- a/apps/mobile/src/app/(app)/agent-chat/new.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/new.tsx
@@ -179,6 +179,7 @@ function NewSessionScreenBody() {
     models,
     modelsSettled: !isLoadingModels && !isModelsError && models.length > 0,
   });
+  const selectedRepository = repositories.find(repository => repository.key === selectedRepo);
 
   const {
     profile,
@@ -240,7 +241,8 @@ function NewSessionScreenBody() {
     model: displayModel,
     organizationId,
     onCreated: handleCreated,
-    selectedRepo,
+    selectedRepo: selectedRepository?.fullName ?? '',
+    githubIntegrationId: selectedRepository?.platformIntegrationId,
     setIsCreating,
     variant: displayVariant,
     autoCommit,
@@ -428,7 +430,7 @@ function NewSessionScreenBody() {
         isRemoteTargetSelected,
         isSubmitting,
         model: displayModel,
-        selectedRepo,
+        selectedRepo: selectedRepository?.key ?? '',
         isProfileLoading,
       });
 

--- a/apps/mobile/src/app/(app)/agent-chat/repo-picker.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/repo-picker.tsx
@@ -2,7 +2,7 @@ import { useFocusEffect, useRouter } from 'expo-router';
 import * as Haptics from 'expo-haptics';
 import { Check, Info, Lock, Search, SearchX, Unlock } from '@/components/ui/icons';
 import { useCallback, useMemo, useRef, useState } from 'react';
-import { FlatList, Pressable, TextInput, View } from 'react-native';
+import { Pressable, SectionList, TextInput, View } from 'react-native';
 import { useTranslation } from 'react-i18next';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -11,7 +11,7 @@ import { PickerSheet } from '@/components/picker-sheet';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import { clearRepoPickerBridge, getRepoPickerBridge } from '@/lib/picker-bridge';
-import { filterRepoPickerOptions } from '@/lib/repo-picker-filter';
+import { filterRepoPickerOptions, groupRepoPickerOptions } from '@/lib/repo-picker-filter';
 
 export default function RepoPickerScreen() {
   const router = useRouter();
@@ -45,6 +45,7 @@ export default function RepoPickerScreen() {
     () => filterRepoPickerOptions({ repositories: bridge?.repositories ?? [], search }),
     [bridge, search]
   );
+  const sections = useMemo(() => groupRepoPickerOptions(filtered), [filtered]);
 
   const handleSelect = useCallback(
     (repo: string) => {
@@ -70,10 +71,10 @@ export default function RepoPickerScreen() {
 
   return (
     <PickerSheet title={t('agentChat.repoPicker.title')} onDone={closePicker} scrollable={false}>
-      <FlatList
+      <SectionList
         className="flex-1 bg-background"
-        data={filtered}
-        keyExtractor={repo => repo.fullName}
+        sections={sections}
+        keyExtractor={repo => repo.key}
         keyboardShouldPersistTaps="handled"
         keyboardDismissMode="on-drag"
         contentContainerStyle={{ paddingBottom: bottom }}
@@ -110,11 +111,18 @@ export default function RepoPickerScreen() {
             }
           />
         }
+        renderSectionHeader={({ section }) =>
+          section.title ? (
+            <Text className="bg-background px-4 pb-1 pt-3 text-xs font-semibold uppercase tracking-wide text-muted-foreground">
+              {section.title}
+            </Text>
+          ) : null
+        }
         renderItem={({ item: repo }) => (
           <Pressable
             className="flex-row items-center gap-3 border-b border-border px-4 py-3 active:bg-secondary will-change-pressable"
             onPress={() => {
-              handleSelect(repo.fullName);
+              handleSelect(repo.key);
             }}
             accessibilityRole="button"
             accessibilityLabel={repo.fullName}
@@ -127,9 +135,7 @@ export default function RepoPickerScreen() {
             <Text className="flex-1 text-base text-foreground" numberOfLines={1}>
               {repo.fullName}
             </Text>
-            {bridge.currentValue === repo.fullName ? (
-              <Check size={18} color={colors.primary} />
-            ) : null}
+            {bridge.currentValue === repo.key ? <Check size={18} color={colors.primary} /> : null}
           </Pressable>
         )}
       />

--- a/apps/mobile/src/components/agents/continuation-seed.test.ts
+++ b/apps/mobile/src/components/agents/continuation-seed.test.ts
@@ -88,4 +88,23 @@ describe('resolveContinuationResolution', () => {
 
     expect(result).toEqual({ kind: 'unresolved-model' });
   });
+
+  it('preserves repository integration provenance when continuing', () => {
+    const result = resolveContinuationResolution({
+      gitUrl: GIT_URL,
+      mode: 'code',
+      model: 'test-model',
+      variant: 'default',
+      repositories: [{ fullName: 'owner/repo', platformIntegrationId: 'integration-1' }],
+      models: MODELS,
+    });
+
+    expect(result).toEqual({
+      kind: 'cloud-agent',
+      repo: 'owner/repo',
+      model: 'test-model',
+      variant: 'default',
+      githubIntegrationId: 'integration-1',
+    });
+  });
 });

--- a/apps/mobile/src/components/agents/continuation-seed.ts
+++ b/apps/mobile/src/components/agents/continuation-seed.ts
@@ -7,7 +7,13 @@ import {
 } from '@/components/agents/new-session-prefill';
 
 export type ContinuationResolution =
-  | { kind: 'cloud-agent'; repo: string; model: string; variant: string }
+  | {
+      kind: 'cloud-agent';
+      repo: string;
+      model: string;
+      variant: string;
+      githubIntegrationId?: string;
+    }
   | { kind: 'unmatched-repository' }
   | { kind: 'unresolved-model' };
 
@@ -22,7 +28,7 @@ export function resolveContinuationResolution(args: {
   mode: string;
   model: string;
   variant: string;
-  repositories: { fullName: string }[];
+  repositories: { fullName: string; platformIntegrationId?: string }[];
   models: { id: string; variants: string[] }[];
 }): ContinuationResolution {
   const { gitUrl, mode, model, variant, repositories, models } = args;
@@ -50,10 +56,18 @@ export function resolveContinuationResolution(args: {
     return { kind: 'unresolved-model' };
   }
 
+  const matchingRepositories = repositories.filter(candidate => candidate.fullName === repo);
+  if (matchingRepositories.length !== 1) {
+    return { kind: 'unmatched-repository' };
+  }
+  const repository = matchingRepositories[0];
   return {
     kind: 'cloud-agent',
     repo,
     model: resolvedModel.model,
     variant: resolvedModel.variant,
+    ...(repository?.platformIntegrationId
+      ? { githubIntegrationId: repository.platformIntegrationId }
+      : {}),
   };
 }

--- a/apps/mobile/src/components/agents/new-session-configure-form.test.ts
+++ b/apps/mobile/src/components/agents/new-session-configure-form.test.ts
@@ -162,7 +162,7 @@ function defaultProps() {
     onChangeRepo: vi.fn(),
     onOpenGitHubIntegration: vi.fn(),
     onRefreshRepos: vi.fn(),
-    repositories: [] as { fullName: string; isPrivate: boolean }[],
+    repositories: [] as { key: string; fullName: string; isPrivate: boolean }[],
     selectedRepo: '',
     profile: null as {
       id: string;
@@ -206,9 +206,9 @@ describe('NewSessionConfigureForm', () => {
     const { NewSessionConfigureForm } = await import('./new-session-configure-form');
 
     const orderedRepositories = [
-      { fullName: 'Kilo-Org/cloud', isPrivate: true },
-      { fullName: 'octocat/Hello-World', isPrivate: false },
-      { fullName: 'acme/widgets', isPrivate: true },
+      { key: 'Kilo-Org/cloud', fullName: 'Kilo-Org/cloud', isPrivate: true },
+      { key: 'octocat/Hello-World', fullName: 'octocat/Hello-World', isPrivate: false },
+      { key: 'acme/widgets', fullName: 'acme/widgets', isPrivate: true },
     ];
 
     // eslint-disable-next-line new-cap -- plain function call, matching repo test convention

--- a/apps/mobile/src/components/agents/new-session-configure-form.tsx
+++ b/apps/mobile/src/components/agents/new-session-configure-form.tsx
@@ -19,7 +19,11 @@ import {
 import { type ModelOption } from '@/lib/hooks/use-available-models';
 import { type SessionModelOption } from '@/lib/hooks/use-session-model-options';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
-import { type InstancePickerInstance, type ModelPickerSelection } from '@/lib/picker-bridge';
+import {
+  type InstancePickerInstance,
+  type ModelPickerSelection,
+  type RepoOption,
+} from '@/lib/picker-bridge';
 import { remoteSpawnInstanceDisconnectedNote } from '@/lib/remote-submit-outcome';
 
 type NewSessionConfigureFormProps = {
@@ -63,7 +67,7 @@ type NewSessionConfigureFormProps = {
   onChangeRepo: (fullName: string) => void;
   onOpenGitHubIntegration: () => void;
   onRefreshRepos: () => void;
-  repositories: { fullName: string; isPrivate: boolean }[];
+  repositories: RepoOption[];
   selectedRepo: string;
   // Environment profile (Cloud Agent only).
   profile: EffectiveAgentProfile | null;

--- a/apps/mobile/src/components/agents/new-session-prefill.ts
+++ b/apps/mobile/src/components/agents/new-session-prefill.ts
@@ -172,8 +172,8 @@ export function resolvePrefillRepo(
   }
 
   const lower = prefill.repo.toLowerCase();
-  const match = repositories.find(r => r.fullName.toLowerCase() === lower);
-  return match?.fullName ?? null;
+  const matches = repositories.filter(r => r.fullName.toLowerCase() === lower);
+  return matches.length === 1 ? (matches[0]?.fullName ?? null) : null;
 }
 
 /**

--- a/apps/mobile/src/components/agents/new-session-repository-section.tsx
+++ b/apps/mobile/src/components/agents/new-session-repository-section.tsx
@@ -8,9 +8,8 @@ import { Text } from '@/components/ui/text';
 import { QueryError } from '@/components/query-error';
 import { RepoSelector } from '@/components/agents/repo-selector';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
+import { type RepoOption } from '@/lib/picker-bridge';
 import { type RepositorySectionView } from './new-session-repository-state';
-
-type RepositoryItem = { fullName: string; isPrivate: boolean };
 
 type NewSessionRepositorySectionProps = {
   disabled: boolean;
@@ -19,7 +18,7 @@ type NewSessionRepositorySectionProps = {
   onChange: (value: string) => void;
   onOpenGitHubIntegration: () => void;
   onRefreshRepos: () => void;
-  repositories: RepositoryItem[];
+  repositories: RepoOption[];
   value: string;
 };
 

--- a/apps/mobile/src/components/agents/repo-selector.tsx
+++ b/apps/mobile/src/components/agents/repo-selector.tsx
@@ -5,13 +5,8 @@ import { useTranslation } from 'react-i18next';
 
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
-import { setRepoPickerBridge } from '@/lib/picker-bridge';
+import { type RepoOption, setRepoPickerBridge } from '@/lib/picker-bridge';
 import { cn } from '@/lib/utils';
-
-type RepoOption = {
-  fullName: string;
-  isPrivate: boolean;
-};
 
 type RepoSelectorProps = {
   value: string;
@@ -32,9 +27,11 @@ export function RepoSelector({
   const colors = useThemeColors();
   const { t } = useTranslation();
   const effectivelyDisabled = disabled || isLoading || repositories.length === 0;
+  const selectedRepository = repositories.find(repository => repository.key === value);
 
   const label =
-    value || (isLoading ? t('agentChat.repoPicker.loading') : t('agentChat.repoPicker.title'));
+    selectedRepository?.fullName ??
+    (isLoading ? t('agentChat.repoPicker.loading') : t('agentChat.repoPicker.title'));
 
   function handlePress() {
     if (effectivelyDisabled) {

--- a/apps/mobile/src/components/agents/use-continue-cloud-create.ts
+++ b/apps/mobile/src/components/agents/use-continue-cloud-create.ts
@@ -22,7 +22,7 @@ export function useContinueCloudCreate(
   organizationId: string | undefined
 ): (
   sessionId: KiloSessionId,
-  dest: { repo: string; model: string; variant: string },
+  dest: { repo: string; model: string; variant: string; githubIntegrationId?: string },
   mode: string
 ) => Promise<void> {
   const router = useRouter();
@@ -43,12 +43,13 @@ export function useContinueCloudCreate(
   return useCallback(
     async (
       sessionId: KiloSessionId,
-      dest: { repo: string; model: string; variant: string },
+      dest: { repo: string; model: string; variant: string; githubIntegrationId?: string },
       mode: string
     ) => {
       const intentFingerprint = JSON.stringify({
         cloneFromKiloSessionId: sessionId,
         repo: dest.repo,
+        githubIntegrationId: dest.githubIntegrationId ?? null,
         model: dest.model,
         variant: dest.variant || undefined,
         mode,
@@ -73,6 +74,7 @@ export function useContinueCloudCreate(
         model: dest.model,
         variant: dest.variant || undefined,
         githubRepo: dest.repo,
+        ...(dest.githubIntegrationId ? { githubIntegrationId: dest.githubIntegrationId } : {}),
         autoCommit: false,
         autoInitiate: true as const,
         operationKey,

--- a/apps/mobile/src/components/agents/use-continue-session.test.ts
+++ b/apps/mobile/src/components/agents/use-continue-session.test.ts
@@ -306,6 +306,21 @@ describe('useContinueSession cloud clone wiring', () => {
     expect(input.initialMessageId).toBeUndefined();
   });
 
+  it('forwards repository integration provenance into the continued session', async () => {
+    resolutionRef.value = { ...CLOUD_RESOLUTION, githubIntegrationId: 'integration-1' };
+    prepareSessionMutate.mockResolvedValueOnce({
+      kiloSessionId: 'ses_12345678901234567890123456',
+    });
+    const mount = mountContinueSession({ sessionId: SESSION_ID, organizationId: 'org-1' });
+
+    await mount.result.continueSession(FIELDS);
+
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).toMatchObject({
+      githubRepo: 'owner/repo',
+      githubIntegrationId: 'integration-1',
+    });
+  });
+
   it('never drains history and never queries instances: only the repository list is fetched', async () => {
     prepareSessionMutate.mockResolvedValueOnce({
       kiloSessionId: 'ses_12345678901234567890123456',

--- a/apps/mobile/src/components/agents/use-new-session-creator.test.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.test.ts
@@ -278,6 +278,7 @@ function runCreator(args: {
   variant?: string;
   organizationId?: string;
   selectedRepo?: string;
+  githubIntegrationId?: string;
   autoCommit?: boolean;
   profileId?: string | null;
 }): CreatorResult {
@@ -318,6 +319,7 @@ function runCreator(args: {
       model: args.model ?? 'model-1',
       organizationId: args.organizationId,
       selectedRepo: args.selectedRepo ?? 'owner/repo',
+      ...(args.githubIntegrationId ? { githubIntegrationId: args.githubIntegrationId } : {}),
       // eslint-disable-next-line no-empty-function -- no-op state setter
       setIsCreating: () => {},
       variant: args.variant ?? 'v1',
@@ -572,6 +574,31 @@ describe('useNewSessionCreator mode passthrough', () => {
     expect(prepareSessionMutate.mock.calls[0]?.[0]).toMatchObject({
       mode: 'reviewer',
     });
+  });
+});
+
+describe('useNewSessionCreator repository provenance', () => {
+  it('includes the selected GitHub integration when available', async () => {
+    prepareSessionMutate.mockResolvedValue(sessionResult());
+    const creator = runCreator({ githubIntegrationId: 'integration-1' });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).toMatchObject({
+      githubRepo: 'owner/repo',
+      githubIntegrationId: 'integration-1',
+    });
+  });
+
+  it('omits the integration for repositories from legacy responses', async () => {
+    prepareSessionMutate.mockResolvedValue(sessionResult());
+    const creator = runCreator({});
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).not.toHaveProperty('githubIntegrationId');
   });
 });
 

--- a/apps/mobile/src/components/agents/use-new-session-creator.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.ts
@@ -28,6 +28,7 @@ type UseNewSessionCreatorInput = {
   /** Invoked on the success path before navigation; failures never fire it. */
   onCreated?: () => void;
   selectedRepo: string;
+  githubIntegrationId?: string;
   setIsCreating: (value: boolean) => void;
   variant: string;
   /** Commit and push the agent's changes (true) or leave them uncommitted (false). */
@@ -43,6 +44,7 @@ type PrepareSessionInput = {
   model: string;
   variant: string | undefined;
   githubRepo: string;
+  githubIntegrationId?: string;
   autoCommit: boolean;
   autoInitiate: boolean;
   operationKey: string;
@@ -69,6 +71,7 @@ export function useNewSessionCreator({
   organizationId,
   onCreated,
   selectedRepo,
+  githubIntegrationId,
   setIsCreating,
   variant,
   autoCommit,
@@ -133,6 +136,7 @@ export function useNewSessionCreator({
       model,
       variant: variant || undefined,
       repo: selectedRepo,
+      githubIntegrationId: githubIntegrationId ?? null,
       autoCommit,
       organizationId: organizationId ?? null,
       profileId: profileId ?? null,
@@ -160,6 +164,7 @@ export function useNewSessionCreator({
         model,
         variant: variant || undefined,
         githubRepo: selectedRepo,
+        ...(githubIntegrationId ? { githubIntegrationId } : {}),
         autoCommit,
         autoInitiate: true,
         operationKey,
@@ -240,6 +245,7 @@ export function useNewSessionCreator({
     }
   }, [
     selectedRepo,
+    githubIntegrationId,
     model,
     mode,
     variant,

--- a/apps/mobile/src/components/agents/use-new-session-prefill.ts
+++ b/apps/mobile/src/components/agents/use-new-session-prefill.ts
@@ -33,7 +33,7 @@ export function useNewSessionPrefill(): NewSessionPrefill {
 }
 
 export type UseNewSessionPrefillTargetsInput = {
-  repositories: { fullName: string }[];
+  repositories: { key: string; fullName: string }[];
   // !isLoadingRepos && !isReposError && repositories.length > 0
   reposSettled: boolean;
   models: { id: string; variants: string[] }[];
@@ -61,7 +61,9 @@ export function useNewSessionPrefillTargets(input: UseNewSessionPrefillTargetsIn
     hasAppliedRepo.current = true;
     const resolved = resolvePrefillRepo(repositories, prefill);
     if (resolved) {
-      setSelectedRepo(resolved);
+      setSelectedRepo(
+        repositories.find(repository => repository.fullName === resolved)?.key ?? resolved
+      );
     }
   }
 

--- a/apps/mobile/src/lib/picker-bridge.test.ts
+++ b/apps/mobile/src/lib/picker-bridge.test.ts
@@ -5,6 +5,7 @@ import {
   clearModelPickerBridge,
   commitModelPickerSelection,
   getModelPickerBridge,
+  getRepoOptionKey,
   resolveModelPickerSelection,
   setModelPickerBridge,
 } from './picker-bridge';
@@ -131,5 +132,19 @@ describe('model picker bridge', () => {
 
     expect(commitModelPickerSelection(bridge, remoteOption.id, 'high')).toBe(true);
     expect(onSelect).toHaveBeenCalledWith({ option: remoteOption, variant: 'high' });
+  });
+});
+
+describe('repository picker bridge', () => {
+  const repository = { fullName: 'owner/repo' };
+
+  it('distinguishes duplicate repositories across integrations', () => {
+    expect(getRepoOptionKey({ ...repository, platformIntegrationId: 'integration-1' })).not.toBe(
+      getRepoOptionKey({ ...repository, platformIntegrationId: 'integration-2' })
+    );
+  });
+
+  it('uses the legacy full name when provenance is absent', () => {
+    expect(getRepoOptionKey(repository)).toBe('owner/repo');
   });
 });

--- a/apps/mobile/src/lib/picker-bridge.ts
+++ b/apps/mobile/src/lib/picker-bridge.ts
@@ -42,9 +42,21 @@ type ModePickerBridge = {
 };
 
 export type RepoOption = {
+  key: string;
   fullName: string;
   isPrivate: boolean;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
 };
+
+export function getRepoOptionKey(repository: {
+  fullName: string;
+  platformIntegrationId?: string;
+}): string {
+  return repository.platformIntegrationId
+    ? `${repository.platformIntegrationId}:${repository.fullName}`
+    : repository.fullName;
+}
 
 type RepoPickerBridge = {
   repositories: RepoOption[];

--- a/apps/mobile/src/lib/repo-picker-filter.test.ts
+++ b/apps/mobile/src/lib/repo-picker-filter.test.ts
@@ -1,11 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { filterRepoPickerOptions } from './repo-picker-filter';
+import { filterRepoPickerOptions, groupRepoPickerOptions } from './repo-picker-filter';
 
 const repositories = [
-  { fullName: 'Kilo-Org/cloud', isPrivate: true },
-  { fullName: 'octocat/Hello-World', isPrivate: false },
-  { fullName: 'acme/widgets', isPrivate: true },
+  {
+    key: 'integration-1:Kilo-Org/cloud',
+    fullName: 'Kilo-Org/cloud',
+    isPrivate: true,
+    platformIntegrationId: 'integration-1',
+    platformAccountLogin: 'Kilo-Org',
+  },
+  { key: 'octocat/Hello-World', fullName: 'octocat/Hello-World', isPrivate: false },
+  { key: 'acme/widgets', fullName: 'acme/widgets', isPrivate: true },
 ];
 
 describe('filterRepoPickerOptions', () => {
@@ -15,5 +21,15 @@ describe('filterRepoPickerOptions', () => {
 
   it('filters repositories by full name case-insensitively', () => {
     expect(filterRepoPickerOptions({ repositories, search: 'hello' })).toEqual([repositories[1]]);
+  });
+
+  it('filters and groups repositories by GitHub account while retaining legacy entries', () => {
+    expect(filterRepoPickerOptions({ repositories, search: 'kilo-org' })).toEqual([
+      repositories[0],
+    ]);
+    expect(groupRepoPickerOptions(repositories)).toEqual([
+      { title: 'Kilo-Org', data: [repositories[0]] },
+      { title: undefined, data: [repositories[1], repositories[2]] },
+    ]);
   });
 });

--- a/apps/mobile/src/lib/repo-picker-filter.ts
+++ b/apps/mobile/src/lib/repo-picker-filter.ts
@@ -1,5 +1,10 @@
 import { type RepoOption } from '@/lib/picker-bridge';
 
+export type RepoPickerSection = {
+  title?: string;
+  data: RepoOption[];
+};
+
 export function filterRepoPickerOptions({
   repositories,
   search,
@@ -11,5 +16,19 @@ export function filterRepoPickerOptions({
   if (!query) {
     return repositories;
   }
-  return repositories.filter(repo => repo.fullName.toLowerCase().includes(query));
+  return repositories.filter(
+    repo =>
+      repo.fullName.toLowerCase().includes(query) ||
+      repo.platformAccountLogin?.toLowerCase().includes(query)
+  );
+}
+
+export function groupRepoPickerOptions(repositories: RepoOption[]): RepoPickerSection[] {
+  const sections = new Map<string | undefined, RepoOption[]>();
+  for (const repository of repositories) {
+    const group = sections.get(repository.platformAccountLogin) ?? [];
+    group.push(repository);
+    sections.set(repository.platformAccountLogin, group);
+  }
+  return [...sections].map(([title, data]) => ({ title, data }));
 }

--- a/apps/mobile/src/lib/use-new-session-repos.ts
+++ b/apps/mobile/src/lib/use-new-session-repos.ts
@@ -6,6 +6,7 @@ import {
   resolveRepositorySectionView,
 } from '@/components/agents/new-session-repository-state';
 import { useGitHubReposRefresh } from '@/lib/use-github-repos-refresh';
+import { getRepoOptionKey, type RepoOption } from '@/lib/picker-bridge';
 import { useTRPC } from '@/lib/trpc';
 
 type UseNewSessionReposArgs = {
@@ -13,7 +14,7 @@ type UseNewSessionReposArgs = {
 };
 
 type UseNewSessionReposResult = {
-  repositories: { fullName: string; isPrivate: boolean }[];
+  repositories: RepoOption[];
   view: RepositorySectionView;
   isRetrying: boolean;
   openGitHubIntegration: () => void;
@@ -60,10 +61,24 @@ export function useNewSessionRepos({
     if (!repoData?.repositories) {
       return [];
     }
-    return repoData.repositories.map(r => ({
-      fullName: r.fullName,
-      isPrivate: r.private,
-    }));
+    return repoData.repositories.map(r => {
+      // Optional while older API deployments remain reachable.
+      const repository = r as typeof r & {
+        platformIntegrationId?: string;
+        platformAccountLogin?: string;
+      };
+      return {
+        key: getRepoOptionKey(repository),
+        fullName: repository.fullName,
+        isPrivate: repository.private,
+        ...(repository.platformIntegrationId
+          ? { platformIntegrationId: repository.platformIntegrationId }
+          : {}),
+        ...(repository.platformAccountLogin
+          ? { platformAccountLogin: repository.platformAccountLogin }
+          : {}),
+      };
+    });
   }, [repoData]);
 
   return { repositories, view, isRetrying, openGitHubIntegration, refreshReposForceFresh };

--- a/apps/web/src/app/api/integrations/github/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.test.ts
@@ -26,6 +26,15 @@ jest.mock('@/lib/user/server');
 jest.mock('@/lib/bot/github-link-state');
 jest.mock('@/lib/bot-identity');
 jest.mock('@/lib/integrations/platforms/github/adapter');
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    select: jest.fn(() => ({
+      from: jest.fn(() => ({
+        where: jest.fn(async () => []),
+      })),
+    })),
+  },
+}));
 jest.mock('@/lib/bot', () => ({
   bot: {
     initialize: jest.fn(async () => undefined),
@@ -732,7 +741,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
     expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
   });
 
-  test('app-initiated pending_setup_failed redirects to /github-app fallback', async () => {
+  test('ambiguous app-initiated pending request returns successful pending no-op', async () => {
     mockedConsumeInstallState.mockResolvedValue({
       token: DB_TOKEN,
       kilo_user_id: USER_ID,
@@ -745,11 +754,6 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
       created_at: new Date().toISOString(),
     });
 
-    const { createPendingIntegration } =
-      await import('@/lib/integrations/db/platform-integrations');
-    const mockedCreatePending = jest.mocked(createPendingIntegration);
-    mockedCreatePending.mockRejectedValue(new Error('DB error') as never);
-
     const { GET } = await import('./route');
     const response = await GET(
       makeRequest(
@@ -758,7 +762,7 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
     );
 
     expect(response.status).toBe(307);
-    expectRedirectLocation(response, '/github-app?fromApp=1&error=pending_setup_failed');
+    expectRedirectLocation(response, '/github-app?fromApp=1&github_pending_approval=true');
   });
 
   test('app-initiated org success preserves organizationId on redirect', async () => {

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -1,10 +1,13 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user/server';
-import type { User } from '@kilocode/db/schema';
+import { platform_integrations, type User } from '@kilocode/db/schema';
 import { Octokit } from '@octokit/rest';
 import { createAppAuth } from '@octokit/auth-app';
-import { exchangeGitHubOAuthCode } from '@/lib/integrations/platforms/github/adapter';
+import {
+  exchangeGitHubOAuthCode,
+  fetchGitHubInstallationRequests,
+} from '@/lib/integrations/platforms/github/adapter';
 import {
   getGitHubAppTypeForOrganization,
   getGitHubAppCredentials,
@@ -15,7 +18,6 @@ import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 import {
   createPendingIntegration,
   findIntegrationByInstallationId,
-  findPendingInstallationByRequesterId,
   upsertPlatformIntegrationForOwner,
 } from '@/lib/integrations/db/platform-integrations';
 import type {
@@ -23,6 +25,8 @@ import type {
   IntegrationPermissions,
   Owner,
 } from '@/lib/integrations/core/types';
+import { db } from '@/lib/drizzle';
+import { and, eq, isNull } from 'drizzle-orm';
 import { parseStateReturn } from '@/lib/integrations/validate-return-path';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { verifyGitHubBotLinkState } from '@/lib/bot/github-link-state';
@@ -435,47 +439,86 @@ async function handleCoreInstallFlow(params: {
         }
       }
 
+      let githubRequest: { id: string; accountId: string; accountLogin: string } | undefined;
       if (githubRequester) {
-        const existingPending = await findPendingInstallationByRequesterId(githubRequester.id);
-
-        if (existingPending) {
-          const existingOwnerId =
-            existingPending.owned_by_organization_id || existingPending.owned_by_user_id;
-
-          console.log('User already has a pending installation', {
-            existingPendingId: existingPending.id,
-            existingOwnerId,
-            githubRequesterId: githubRequester.id,
-          });
-
-          const queryParam =
-            owner.type === 'org'
-              ? `error=pending_installation_exists&org=${existingOwnerId}`
-              : 'error=pending_installation_exists';
-
-          return NextResponse.redirect(
-            new URL(
-              isAppInitiated
-                ? appFallbackPath(queryParam)
-                : appendQueryParam(redirectPath, queryParam),
-              APP_URL
+        const requests = await fetchGitHubInstallationRequests(githubAppType);
+        const requesterRequests = requests.filter(
+          request => request.requesterId === githubRequester.id
+        );
+        const recorded = await db
+          .select({ platformAccountId: platform_integrations.platform_account_id })
+          .from(platform_integrations)
+          .where(
+            and(
+              eq(platform_integrations.platform, 'github'),
+              eq(platform_integrations.github_app_type, githubAppType),
+              eq(platform_integrations.integration_status, 'pending'),
+              isNull(platform_integrations.platform_installation_id)
             )
           );
+        const recordedAccountIds = new Set(recorded.map(row => row.platformAccountId));
+        const unrecorded = requesterRequests.filter(
+          request => !recordedAccountIds.has(request.accountId)
+        );
+        if (unrecorded.length === 1) {
+          githubRequest = unrecorded[0];
+        } else if (requesterRequests.length === 1) {
+          const existing = requesterRequests[0];
+          const [existingPending] = await db
+            .select({ id: platform_integrations.id })
+            .from(platform_integrations)
+            .where(
+              and(
+                owner.type === 'org'
+                  ? eq(platform_integrations.owned_by_organization_id, owner.id)
+                  : eq(platform_integrations.owned_by_user_id, owner.id),
+                eq(platform_integrations.platform, 'github'),
+                eq(platform_integrations.github_app_type, githubAppType),
+                eq(platform_integrations.platform_account_id, existing.accountId),
+                eq(platform_integrations.integration_status, 'pending'),
+                isNull(platform_integrations.platform_installation_id)
+              )
+            )
+            .limit(1);
+          if (existingPending) {
+            githubRequest = existing;
+          }
         }
       }
 
-      await createPendingIntegration({
-        organizationId: owner.type === 'org' ? owner.id : undefined,
-        userId: owner.type === 'user' ? owner.id : undefined,
-        requester: {
-          kilo_user_id: user.id,
-          kilo_user_email: user.google_user_email,
-          kilo_user_name: user.google_user_name,
-          requested_at: new Date().toISOString(),
-        },
-        githubRequester,
-        githubAppType,
-      });
+      if (githubRequest) {
+        const [existingPending] = await db
+          .select({ id: platform_integrations.id })
+          .from(platform_integrations)
+          .where(
+            and(
+              owner.type === 'org'
+                ? eq(platform_integrations.owned_by_organization_id, owner.id)
+                : eq(platform_integrations.owned_by_user_id, owner.id),
+              eq(platform_integrations.platform, 'github'),
+              eq(platform_integrations.github_app_type, githubAppType),
+              eq(platform_integrations.platform_account_id, githubRequest.accountId),
+              eq(platform_integrations.integration_status, 'pending'),
+              isNull(platform_integrations.platform_installation_id)
+            )
+          )
+          .limit(1);
+        if (!existingPending) {
+          await createPendingIntegration({
+            organizationId: owner.type === 'org' ? owner.id : undefined,
+            userId: owner.type === 'user' ? owner.id : undefined,
+            requester: {
+              kilo_user_id: user.id,
+              kilo_user_email: user.google_user_email,
+              kilo_user_name: user.google_user_name,
+              requested_at: new Date().toISOString(),
+            },
+            githubRequester,
+            githubRequest,
+            githubAppType,
+          });
+        }
+      }
 
       const orgParam =
         isAppInitiated && owner.type === 'org'

--- a/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
+++ b/apps/web/src/components/cloud-agent-next/NewSessionPanel.tsx
@@ -116,6 +116,8 @@ type Repository = {
   fullName: string;
   private: boolean;
   workspaceUuid?: string;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
 };
 
 type NewSessionPanelProps = {
@@ -208,6 +210,9 @@ export function NewSessionPanel({
   // ---------------------------------------------------------------------------
   const [prompt, setPrompt] = useState('');
   const [selectedRepo, setSelectedRepo] = useState('');
+  const [selectedGitHubIntegrationId, setSelectedGitHubIntegrationId] = useState<
+    string | undefined
+  >();
   const [selectedPlatform, setSelectedPlatform] = useState<RepositoryPlatform>('github');
   const [mode, setMode] = useState<AgentMode>('code');
   const [model, setModel] = useState<string>('');
@@ -512,6 +517,8 @@ export function NewSessionPanel({
       fullName: repo.fullName,
       private: repo.private,
       platform: 'github' as const,
+      platformIntegrationId: repo.platformIntegrationId,
+      platformAccountLogin: repo.platformAccountLogin,
     }));
     const gitlab = gitlabRepositories.map(repo => ({
       id: repo.id,
@@ -541,8 +548,8 @@ export function NewSessionPanel({
       if (!fullName || seen.has(fullName)) continue;
       seen.add(fullName);
 
-      const match = unifiedRepositories.find(r => r.fullName === fullName);
-      if (match) result.push(match);
+      const matches = unifiedRepositories.filter(r => r.fullName === fullName);
+      if (matches.length === 1) result.push(matches[0]);
     }
 
     return result;
@@ -556,11 +563,16 @@ export function NewSessionPanel({
   const handleRepoSelect = useCallback(
     (repo: RepositoryOption, userInitiated = true) => {
       setSelectedRepo(repo.fullName);
+      setSelectedGitHubIntegrationId(
+        repo.platform === 'github' ? repo.platformIntegrationId : undefined
+      );
       setShowRepositoryRequiredMessage(false);
       if (userInitiated) setIsRepoUserSelected(true);
       if (repo.platform) {
         setSelectedPlatform(repo.platform);
-        if (userInitiated) setLastUsedRepo(repo.fullName, repo.platform, organizationId);
+        if (userInitiated) {
+          setLastUsedRepo(repo.fullName, repo.platform, organizationId, repo.platformIntegrationId);
+        }
       }
     },
     [organizationId]
@@ -620,20 +632,17 @@ export function NewSessionPanel({
       const repoName = extractRepoFromGitUrl(url);
       if (!repoName) continue;
 
-      const match = unifiedRepositories.find(
-        r => r.fullName.toLowerCase() === repoName.toLowerCase()
-      );
-      if (!match) continue;
-
-      setSelectedRepo(match.fullName);
-      setShowRepositoryRequiredMessage(false);
       const platform = detectGitPlatform(url);
-      if (platform) {
-        setSelectedPlatform(platform);
-      }
+      const matches = unifiedRepositories.filter(
+        r =>
+          r.fullName.toLowerCase() === repoName.toLowerCase() &&
+          (platform === null || r.platform === platform)
+      );
+      if (matches.length !== 1) continue;
+      handleRepoSelect(matches[0], false);
       break;
     }
-  }, [prompt, isRepoUserSelected, unifiedRepositories]);
+  }, [prompt, isRepoUserSelected, unifiedRepositories, handleRepoSelect]);
 
   const repoError =
     githubRepoError || gitlabRepoError || (organizationId ? bitbucketRepoError : null);
@@ -875,20 +884,31 @@ export function NewSessionPanel({
   // ---------------------------------------------------------------------------
   const [repoPopoverOpen, setRepoPopoverOpen] = useState(false);
 
-  const recentFullNames = useMemo(() => new Set(recentRepos.map(r => r.fullName)), [recentRepos]);
+  const repositoryKey = (repo: RepositoryOption) =>
+    `${repo.platform ?? 'other'}:${repo.platformIntegrationId ?? ''}:${repo.id}`;
+  const isSelectedRepository = (repo: RepositoryOption) =>
+    repo.fullName === selectedRepo &&
+    repo.platform === selectedPlatform &&
+    (repo.platform !== 'github' || repo.platformIntegrationId === selectedGitHubIntegrationId);
+  const recentKeys = useMemo(() => new Set(recentRepos.map(repositoryKey)), [recentRepos]);
   const githubRepos = unifiedRepositories.filter(
-    r => r.platform === 'github' && !recentFullNames.has(r.fullName)
+    r => r.platform === 'github' && !recentKeys.has(repositoryKey(r))
   );
+  const githubRepoGroups = Object.groupBy(
+    githubRepos,
+    repo => repo.platformAccountLogin ?? 'GitHub'
+  );
+  const hasMultipleGitHubAccounts = Object.keys(githubRepoGroups).length > 1;
   const gitlabRepos = unifiedRepositories.filter(
-    r => r.platform === 'gitlab' && !recentFullNames.has(r.fullName)
+    r => r.platform === 'gitlab' && !recentKeys.has(repositoryKey(r))
   );
   const bitbucketRepos = unifiedRepositories.filter(
-    r => r.platform === 'bitbucket' && !recentFullNames.has(r.fullName)
+    r => r.platform === 'bitbucket' && !recentKeys.has(repositoryKey(r))
   );
   const otherRepos = unifiedRepositories.filter(
-    r => !r.platform && !recentFullNames.has(r.fullName)
+    r => !r.platform && !recentKeys.has(repositoryKey(r))
   );
-  const filteredUnifiedRepos = unifiedRepositories.filter(r => !recentFullNames.has(r.fullName));
+  const filteredUnifiedRepos = unifiedRepositories.filter(r => !recentKeys.has(repositoryKey(r)));
 
   const handleRepoPillSelect = useCallback(
     (repo: RepositoryOption) => {
@@ -978,7 +998,11 @@ export function NewSessionPanel({
       return;
     }
     const selectedRepository = unifiedRepositories.find(
-      repository => repository.fullName === selectedRepo && repository.platform === selectedPlatform
+      repository =>
+        repository.fullName === selectedRepo &&
+        repository.platform === selectedPlatform &&
+        (selectedPlatform !== 'github' ||
+          repository.platformIntegrationId === selectedGitHubIntegrationId)
     );
     if (
       selectedPlatform === 'bitbucket' &&
@@ -1066,6 +1090,7 @@ export function NewSessionPanel({
           result = await trpcClient.organizations.cloudAgentNext.prepareSession.mutate({
             ...baseInput,
             githubRepo: selectedRepo,
+            githubIntegrationId: selectedGitHubIntegrationId,
             organizationId,
           });
         }
@@ -1134,6 +1159,7 @@ export function NewSessionPanel({
     selectedPlatform,
     selectedProfileId,
     selectedRepo,
+    selectedGitHubIntegrationId,
     slashCommands,
     trpc.cliSessionsV2.list,
     trpcClient,
@@ -1620,43 +1646,37 @@ export function NewSessionPanel({
                       <CommandGroup heading="Recently used">
                         {recentRepos.map(repo => (
                           <RepoCommandItem
-                            key={`recent-${repo.id}`}
+                            key={`recent-${repositoryKey(repo)}`}
                             repo={repo}
-                            isSelected={
-                              repo.fullName === selectedRepo && repo.platform === selectedPlatform
-                            }
+                            isSelected={isSelectedRepository(repo)}
                             onSelect={handleRepoPillSelect}
                           />
                         ))}
                       </CommandGroup>
                     )}
-                    {hasMultiplePlatforms ? (
+                    {hasMultiplePlatforms || hasMultipleGitHubAccounts ? (
                       <>
-                        {githubRepos.length > 0 && (
-                          <CommandGroup heading="GitHub">
-                            {githubRepos.map(repo => (
-                              <RepoCommandItem
-                                key={repo.id}
-                                repo={repo}
-                                isSelected={
-                                  repo.fullName === selectedRepo &&
-                                  repo.platform === selectedPlatform
-                                }
-                                onSelect={handleRepoPillSelect}
-                              />
-                            ))}
-                          </CommandGroup>
+                        {Object.entries(githubRepoGroups).map(([accountLogin, repositories]) =>
+                          repositories?.length ? (
+                            <CommandGroup key={accountLogin} heading={accountLogin}>
+                              {repositories.map(repo => (
+                                <RepoCommandItem
+                                  key={repositoryKey(repo)}
+                                  repo={repo}
+                                  isSelected={isSelectedRepository(repo)}
+                                  onSelect={handleRepoPillSelect}
+                                />
+                              ))}
+                            </CommandGroup>
+                          ) : null
                         )}
                         {gitlabRepos.length > 0 && (
                           <CommandGroup heading="GitLab">
                             {gitlabRepos.map(repo => (
                               <RepoCommandItem
-                                key={repo.id}
+                                key={repositoryKey(repo)}
                                 repo={repo}
-                                isSelected={
-                                  repo.fullName === selectedRepo &&
-                                  repo.platform === selectedPlatform
-                                }
+                                isSelected={isSelectedRepository(repo)}
                                 onSelect={handleRepoPillSelect}
                               />
                             ))}
@@ -1666,12 +1686,9 @@ export function NewSessionPanel({
                           <CommandGroup heading="Bitbucket">
                             {bitbucketRepos.map(repo => (
                               <RepoCommandItem
-                                key={repo.id}
+                                key={repositoryKey(repo)}
                                 repo={repo}
-                                isSelected={
-                                  repo.fullName === selectedRepo &&
-                                  repo.platform === selectedPlatform
-                                }
+                                isSelected={isSelectedRepository(repo)}
                                 onSelect={handleRepoPillSelect}
                               />
                             ))}
@@ -1681,12 +1698,9 @@ export function NewSessionPanel({
                           <CommandGroup heading="Other">
                             {otherRepos.map(repo => (
                               <RepoCommandItem
-                                key={repo.id}
+                                key={repositoryKey(repo)}
                                 repo={repo}
-                                isSelected={
-                                  repo.fullName === selectedRepo &&
-                                  repo.platform === selectedPlatform
-                                }
+                                isSelected={isSelectedRepository(repo)}
                                 onSelect={handleRepoPillSelect}
                               />
                             ))}
@@ -1697,11 +1711,9 @@ export function NewSessionPanel({
                       <CommandGroup>
                         {filteredUnifiedRepos.map(repo => (
                           <RepoCommandItem
-                            key={repo.id}
+                            key={repositoryKey(repo)}
                             repo={repo}
-                            isSelected={
-                              repo.fullName === selectedRepo && repo.platform === selectedPlatform
-                            }
+                            isSelected={isSelectedRepository(repo)}
                             onSelect={handleRepoPillSelect}
                           />
                         ))}
@@ -1792,7 +1804,7 @@ function RepoCommandItem({
 }) {
   return (
     <CommandItem
-      value={repo.fullName}
+      value={`${repo.fullName} ${repo.platformAccountLogin ?? ''} ${repo.platformIntegrationId ?? ''}`}
       onSelect={() => onSelect(repo)}
       className="flex items-center gap-2"
     >

--- a/apps/web/src/components/cloud-agent-next/model-preferences.ts
+++ b/apps/web/src/components/cloud-agent-next/model-preferences.ts
@@ -11,7 +11,11 @@ const CLOUD_AGENT_NEXT_LOCAL_TEST_MODEL = {
 } satisfies ModelOption;
 const REPO_STORAGE_KEY_PREFIX = 'cloud-agent:last-used-repo';
 
-type LastUsedRepo = { fullName: string; platform: RepositoryPlatform };
+type LastUsedRepo = {
+  fullName: string;
+  platform: RepositoryPlatform;
+  platformIntegrationId?: string;
+};
 
 export function shouldExposeCloudAgentNextLocalTestModel() {
   return (
@@ -55,7 +59,14 @@ export function parseLastUsedRepo(rawValue: string | null): LastUsedRepo | null 
         parsed.platform === 'gitlab' ||
         parsed.platform === 'bitbucket')
     ) {
-      return { fullName: parsed.fullName, platform: parsed.platform };
+      return {
+        fullName: parsed.fullName,
+        platform: parsed.platform,
+        platformIntegrationId:
+          'platformIntegrationId' in parsed && typeof parsed.platformIntegrationId === 'string'
+            ? parsed.platformIntegrationId
+            : undefined,
+      };
     }
     return null;
   } catch {
@@ -70,11 +81,12 @@ export function getLastUsedRepo(organizationId?: string): LastUsedRepo | null {
 export function setLastUsedRepo(
   fullName: string,
   platform: RepositoryPlatform,
-  organizationId?: string
+  organizationId?: string,
+  platformIntegrationId?: string
 ) {
   safeLocalStorage.setItem(
     getLastUsedRepoStorageKey(organizationId),
-    JSON.stringify({ fullName, platform } satisfies LastUsedRepo)
+    JSON.stringify({ fullName, platform, platformIntegrationId } satisfies LastUsedRepo)
   );
 }
 
@@ -96,10 +108,14 @@ export function getPreferredInitialRepo({
   isLoadingBitbucketRepos: boolean;
 }): RepositoryOption | undefined {
   if (lastUsedRepo) {
-    const match = availableRepos.find(
-      repo => repo.fullName === lastUsedRepo.fullName && repo.platform === lastUsedRepo.platform
+    const matches = availableRepos.filter(
+      repo =>
+        repo.fullName === lastUsedRepo.fullName &&
+        repo.platform === lastUsedRepo.platform &&
+        (lastUsedRepo.platformIntegrationId === undefined ||
+          repo.platformIntegrationId === lastUsedRepo.platformIntegrationId)
     );
-    if (match) return match;
+    if (matches.length === 1) return matches[0];
 
     const isSavedRepoLoading =
       lastUsedRepo.platform === 'github'

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -24,6 +24,7 @@ import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombob
 import { useModelSelectorList } from '@/app/api/openrouter/hooks';
 import { buildGitHubInstallState } from './github-install-state';
 import { useConfirm } from '@/components/ui/confirm';
+import { OrganizationGitHubInstallations } from './OrganizationGitHubInstallations';
 
 type GitHubIntegrationDetailsProps = {
   organizationId?: string;
@@ -116,7 +117,14 @@ export function buildAppReturnOutcomeView(input: {
   };
 }
 
-export function GitHubIntegrationDetails({
+export function GitHubIntegrationDetails(props: GitHubIntegrationDetailsProps) {
+  if (props.organizationId && !props.appReturnPath) {
+    return <OrganizationGitHubInstallations organizationId={props.organizationId} />;
+  }
+  return <GitHubIntegrationDetailsContent {...props} />;
+}
+
+function GitHubIntegrationDetailsContent({
   organizationId,
   installState,
   fromApp,
@@ -444,7 +452,7 @@ export function GitHubIntegrationDetails({
         destructive: true,
       })
     ) {
-      uninstallApp.mutate(managementInput, {
+      uninstallApp.mutate(input, {
         onSuccess: async () => {
           toast.success('GitHub App uninstalled');
           await refetch();
@@ -468,7 +476,7 @@ export function GitHubIntegrationDetails({
         destructive: true,
       })
     ) {
-      cancelPendingInstallation.mutate(managementInput, {
+      cancelPendingInstallation.mutate(input, {
         onSuccess: async () => {
           toast.success('Installation request cancelled');
           await refetch();
@@ -483,7 +491,7 @@ export function GitHubIntegrationDetails({
   };
 
   const handleRefresh = () => {
-    refreshInstallation.mutate(managementInput, {
+    refreshInstallation.mutate(input, {
       onSuccess: async () => {
         toast.success('Installation details refreshed', {
           description: 'Permissions and repositories have been updated from GitHub.',
@@ -518,9 +526,6 @@ export function GitHubIntegrationDetails({
   }
 
   const installation = installationData?.installation;
-  const managementInput = organizationId
-    ? { organizationId, integrationId: installation?.id }
-    : undefined;
   const status = installation?.status;
   const isPendingApproval = status === 'awaiting_installation';
 

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -444,7 +444,7 @@ export function GitHubIntegrationDetails({
         destructive: true,
       })
     ) {
-      uninstallApp.mutate(input, {
+      uninstallApp.mutate(managementInput, {
         onSuccess: async () => {
           toast.success('GitHub App uninstalled');
           await refetch();
@@ -468,7 +468,7 @@ export function GitHubIntegrationDetails({
         destructive: true,
       })
     ) {
-      cancelPendingInstallation.mutate(input, {
+      cancelPendingInstallation.mutate(managementInput, {
         onSuccess: async () => {
           toast.success('Installation request cancelled');
           await refetch();
@@ -483,7 +483,7 @@ export function GitHubIntegrationDetails({
   };
 
   const handleRefresh = () => {
-    refreshInstallation.mutate(input, {
+    refreshInstallation.mutate(managementInput, {
       onSuccess: async () => {
         toast.success('Installation details refreshed', {
           description: 'Permissions and repositories have been updated from GitHub.',
@@ -518,6 +518,9 @@ export function GitHubIntegrationDetails({
   }
 
   const installation = installationData?.installation;
+  const managementInput = organizationId
+    ? { organizationId, integrationId: installation?.id }
+    : undefined;
   const status = installation?.status;
   const isPendingApproval = status === 'awaiting_installation';
 

--- a/apps/web/src/components/integrations/IntegrationDetailPage.tsx
+++ b/apps/web/src/components/integrations/IntegrationDetailPage.tsx
@@ -38,7 +38,7 @@ const integrationDetailRegistry = {
     title: 'GitHub Integration',
     userSubtitle: 'Set up personal repository access and optional Cloud Agent attribution',
     organizationSubtitle: organizationName =>
-      `Manage repository access for ${organizationName} and link your personal identity.`,
+      `Connect the GitHub organizations whose repositories ${organizationName} can use.`,
     render: async ({ organizationId, search }) => {
       const { GitHubIntegrationDetails } =
         await import('@/components/integrations/GitHubIntegrationDetails');

--- a/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
+++ b/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
@@ -1,0 +1,259 @@
+'use client';
+
+import { useState } from 'react';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { ChevronDown, ExternalLink, Github, MoreHorizontal, RefreshCw } from 'lucide-react';
+import { toast } from 'sonner';
+import { useTRPC } from '@/lib/trpc/utils';
+import { buildGitHubInstallState } from './github-install-state';
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useConfirm } from '@/components/ui/confirm';
+import { cn } from '@/lib/utils';
+import { useOrganizationWithMembers } from '@/app/api/organizations/hooks';
+
+type OrganizationGitHubInstallationsProps = {
+  organizationId: string;
+};
+
+const statusLabel = {
+  connected: 'Connected',
+  pending: 'Pending approval',
+  suspended: 'Suspended',
+  needs_attention: 'Needs attention',
+} as const;
+
+export function OrganizationGitHubInstallations({
+  organizationId,
+}: OrganizationGitHubInstallationsProps) {
+  const trpc = useTRPC();
+  const queryClient = useQueryClient();
+  const confirm = useConfirm();
+  const [starting, setStarting] = useState(false);
+  const input = { organizationId };
+  const { data: organization } = useOrganizationWithMembers(organizationId);
+  const githubAppName =
+    organization?.settings?.github_app_type === 'lite'
+      ? process.env.NEXT_PUBLIC_GITHUB_LITE_APP_NAME || 'KiloConnect-Lite'
+      : process.env.NEXT_PUBLIC_GITHUB_APP_NAME || 'KiloConnect';
+  const query = useQuery(trpc.githubApps.listOrganizationInstallations.queryOptions(input));
+  const invalidate = async () => {
+    await queryClient.invalidateQueries({
+      queryKey: trpc.githubApps.listOrganizationInstallations.queryKey(input),
+    });
+  };
+  const refresh = useMutation(
+    trpc.githubApps.refreshInstallation.mutationOptions({
+      onSuccess: async () => {
+        toast.success('GitHub access refreshed');
+        await invalidate();
+      },
+      onError: error =>
+        toast.error('Could not refresh GitHub access', { description: error.message }),
+    })
+  );
+  const uninstall = useMutation(
+    trpc.githubApps.uninstallApp.mutationOptions({
+      onSuccess: async () => {
+        toast.success('GitHub organization disconnected');
+        await invalidate();
+      },
+      onError: error =>
+        toast.error('Could not disconnect GitHub organization', { description: error.message }),
+    })
+  );
+  const cancel = useMutation(
+    trpc.githubApps.cancelPendingInstallation.mutationOptions({
+      onSuccess: async () => {
+        toast.success('Installation request removed from Kilo');
+        await invalidate();
+      },
+      onError: error =>
+        toast.error('Could not remove installation request', { description: error.message }),
+    })
+  );
+  const mint = useMutation(trpc.githubApps.mintInstallState.mutationOptions());
+
+  const startInstall = async () => {
+    setStarting(true);
+    try {
+      const result = await mint.mutateAsync({ organizationId });
+      window.location.href = `https://github.com/apps/${githubAppName}/installations/new?state=${encodeURIComponent(buildGitHubInstallState(result.token))}`;
+    } catch (error) {
+      setStarting(false);
+      toast.error('Could not open GitHub setup', {
+        description: error instanceof Error ? error.message : 'Unknown error',
+      });
+    }
+  };
+
+  if (query.isLoading) {
+    return <div className="h-40 animate-pulse rounded-xl border border-border bg-card" />;
+  }
+
+  const installations = query.data?.installations ?? [];
+  return (
+    <Card className="min-w-0 overflow-hidden">
+      <CardHeader className="gap-4 sm:flex-row sm:items-start sm:justify-between">
+        <div className="space-y-1.5">
+          <CardTitle>GitHub organizations</CardTitle>
+          <CardDescription>
+            Connect the GitHub organizations whose repositories Kilo Cloud Agent and Code Reviewer
+            can use.
+          </CardDescription>
+        </div>
+        {query.data?.canAdd && (
+          <Button onClick={startInstall} disabled={starting} className="shrink-0">
+            <Github className="size-4" />
+            {starting ? 'Opening GitHub...' : 'Connect GitHub'}
+          </Button>
+        )}
+      </CardHeader>
+      <CardContent>
+        {query.isError ? (
+          <p className="text-destructive text-sm">Could not load GitHub organizations.</p>
+        ) : installations.length === 0 ? (
+          <div className="min-w-0 rounded-lg border border-dashed p-6 text-sm text-muted-foreground">
+            No GitHub organizations are connected yet. GitHub will let you choose an organization
+            and repository access.
+          </div>
+        ) : (
+          <div className="divide-y rounded-lg border">
+            {installations.map(installation => {
+              const selectedCount = installation.repositories.length;
+              const repositoryScope =
+                installation.repositorySelection === 'all'
+                  ? 'All repositories'
+                  : `${selectedCount} selected ${selectedCount === 1 ? 'repository' : 'repositories'}`;
+              return (
+                <Collapsible key={installation.id}>
+                  <div className="flex min-w-0 items-center gap-3 p-4">
+                    <Github className="size-5 shrink-0 text-muted-foreground" />
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="truncate font-medium">
+                          {installation.accountLogin ?? 'GitHub organization'}
+                        </span>
+                        <Badge
+                          variant={installation.status === 'connected' ? 'default' : 'secondary'}
+                        >
+                          {statusLabel[installation.status]}
+                        </Badge>
+                        {installation.isPrimary && installations.length > 1 && (
+                          <Badge variant="outline">Primary</Badge>
+                        )}
+                      </div>
+                      <p className="mt-1 text-sm text-muted-foreground">{repositoryScope}</p>
+                    </div>
+                    {installation.repositorySelection === 'selected' && selectedCount > 0 && (
+                      <CollapsibleTrigger asChild>
+                        <Button variant="ghost" size="sm" className="group shrink-0">
+                          Repositories
+                          <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+                        </Button>
+                      </CollapsibleTrigger>
+                    )}
+                    <DropdownMenu>
+                      <DropdownMenuTrigger asChild>
+                        <Button
+                          variant="ghost"
+                          size="icon"
+                          aria-label={`Manage ${installation.accountLogin ?? 'GitHub organization'}`}
+                        >
+                          <MoreHorizontal className="size-4" />
+                        </Button>
+                      </DropdownMenuTrigger>
+                      <DropdownMenuContent align="end">
+                        {installation.installationId && (
+                          <DropdownMenuItem asChild>
+                            <a
+                              href={`https://github.com/apps/${githubAppName}/installations/${installation.installationId}`}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              Manage on GitHub <ExternalLink className="ml-auto size-3.5" />
+                            </a>
+                          </DropdownMenuItem>
+                        )}
+                        {installation.canRefresh && (
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              refresh.mutate({ organizationId, integrationId: installation.id })
+                            }
+                          >
+                            Refresh access <RefreshCw className="ml-auto size-3.5" />
+                          </DropdownMenuItem>
+                        )}
+                        {(installation.canCancel || installation.canUninstall) && (
+                          <DropdownMenuSeparator />
+                        )}
+                        {installation.canCancel && (
+                          <DropdownMenuItem
+                            onSelect={() =>
+                              cancel.mutate({ organizationId, integrationId: installation.id })
+                            }
+                          >
+                            Remove pending request
+                          </DropdownMenuItem>
+                        )}
+                        {installation.canUninstall && installation.installationId && (
+                          <DropdownMenuItem
+                            variant="destructive"
+                            onSelect={async () => {
+                              const account =
+                                installation.accountLogin ?? 'this GitHub organization';
+                              if (
+                                await confirm({
+                                  title: `Disconnect ${account}?`,
+                                  description: `This uninstalls the Kilo GitHub App from ${account}. Kilo will lose access to its repositories.`,
+                                  confirmLabel: `Disconnect ${account}`,
+                                  destructive: true,
+                                })
+                              ) {
+                                uninstall.mutate({
+                                  organizationId,
+                                  integrationId: installation.id,
+                                });
+                              }
+                            }}
+                          >
+                            Disconnect organization
+                          </DropdownMenuItem>
+                        )}
+                      </DropdownMenuContent>
+                    </DropdownMenu>
+                  </div>
+                  {installation.repositorySelection === 'selected' && (
+                    <CollapsibleContent>
+                      <div className="border-t bg-muted/30 px-4 py-3">
+                        <ul className="grid gap-1 sm:grid-cols-2">
+                          {installation.repositories.map(repository => (
+                            <li
+                              key={repository.id}
+                              className={cn('truncate font-mono text-xs text-muted-foreground')}
+                            >
+                              {repository.full_name}
+                            </li>
+                          ))}
+                        </ul>
+                      </div>
+                    </CollapsibleContent>
+                  )}
+                </Collapsible>
+              );
+            })}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
+++ b/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
@@ -114,7 +114,11 @@ export function OrganizationGitHubInstallations({
         {query.data?.canAdd && (
           <Button onClick={startInstall} disabled={starting} className="shrink-0">
             <Github className="size-4" />
-            {starting ? 'Opening GitHub...' : 'Connect GitHub'}
+            {starting
+              ? 'Opening GitHub...'
+              : installations.length
+                ? 'Add organization'
+                : 'Connect GitHub'}
           </Button>
         )}
       </CardHeader>

--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -40,6 +40,7 @@ type SecurityAgentContextValue = {
   // Permission & config state
   hasIntegration: boolean;
   hasPermission: boolean;
+  integrationId: string | null;
   isLoadingPermission: boolean;
   isLoadingConfig: boolean;
   reauthorizeUrl: string | undefined;
@@ -1382,6 +1383,7 @@ function useSecurityAgentProviderValue(
 
   const hasIntegration = permissionData?.hasIntegration ?? false;
   const hasPermission = permissionData?.hasPermissions ?? false;
+  const integrationId = permissionData?.integrationId ?? null;
   const reauthorizeUrl = permissionData?.reauthorizeUrl ?? undefined;
   const isEnabled = configData ? configData.isEnabled : undefined;
   const hasConfig = configData?.hasConfig ?? false;
@@ -1407,6 +1409,7 @@ function useSecurityAgentProviderValue(
       isOrg,
       hasIntegration,
       hasPermission,
+      integrationId,
       isLoadingPermission,
       isLoadingConfig,
       reauthorizeUrl,
@@ -1470,6 +1473,7 @@ function useSecurityAgentProviderValue(
       isOrg,
       hasIntegration,
       hasPermission,
+      integrationId,
       isLoadingPermission,
       isLoadingConfig,
       reauthorizeUrl,

--- a/apps/web/src/components/security-agent/SecurityAgentLayout.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentLayout.tsx
@@ -301,6 +301,7 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
     isOrg,
     hasIntegration,
     hasPermission,
+    integrationId,
     isLoadingPermission,
     isLoadingConfig,
     isEnabled,
@@ -352,8 +353,8 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
   );
 
   const handleRefreshPermissions = () => {
-    if (isOrg && organizationId) {
-      refreshMutate({ organizationId });
+    if (isOrg && organizationId && integrationId) {
+      refreshMutate({ organizationId, integrationId });
     } else {
       refreshMutate(undefined);
     }

--- a/apps/web/src/components/shared/RepositoryCombobox.tsx
+++ b/apps/web/src/components/shared/RepositoryCombobox.tsx
@@ -27,6 +27,8 @@ export type RepositoryOption = {
   description?: string;
   platform?: RepositoryPlatform;
   workspaceUuid?: string;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
 };
 
 export type RepositoryComboboxProps = {

--- a/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -98,6 +98,7 @@ type PrepareSessionSharedFields = {
   variant?: string;
   // GitHub-specific params
   githubRepo?: string;
+  githubIntegrationId?: string;
   /** GitHub Personal Access Token for private repositories */
   githubToken?: string;
   // Generic git params for GitLab and other providers

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
@@ -9,6 +9,8 @@ const mockGetIntegrationForOwner =
   jest.fn<(owner: Owner, platform: string) => Promise<PlatformIntegration | null>>();
 const mockUpdateRepositoriesForIntegration =
   jest.fn<(integrationId: string, repositories: unknown[]) => Promise<void>>();
+const mockGetIntegrationsByOrganization =
+  jest.fn<(organizationId: string, platform: string) => Promise<PlatformIntegration[]>>();
 const mockFetchGitHubRepositories =
   jest.fn<(installationId: string, appType: string) => Promise<unknown[]>>();
 const mockGenerateGitHubInstallationToken =
@@ -27,6 +29,7 @@ const mockCheckExistingFork =
 jest.mock('@/lib/integrations/db/platform-integrations', () => ({
   getIntegrationForOrganization: mockGetIntegrationForOrganization,
   getIntegrationForOwner: mockGetIntegrationForOwner,
+  getIntegrationsByOrganization: mockGetIntegrationsByOrganization,
   updateRepositoriesForIntegration: mockUpdateRepositoriesForIntegration,
 }));
 
@@ -151,17 +154,58 @@ describe('github-integration-helpers', () => {
 
   describe('fetchGitHubRepositoriesForOrganization', () => {
     it('returns cached repositories for an active integration', async () => {
-      mockGetIntegrationForOrganization.mockResolvedValue(buildIntegration());
+      mockGetIntegrationsByOrganization.mockResolvedValue([buildIntegration()]);
 
-      const { fetchGitHubRepositoriesForOrganization } =
+      const { fetchAllGitHubRepositoriesForOrganization } =
         await import('./github-integration-helpers');
-      const result = await fetchGitHubRepositoriesForOrganization('org-123');
+      const result = await fetchAllGitHubRepositoriesForOrganization('org-123');
 
       expect(result.integrationInstalled).toBe(true);
       expect(result.repositories).toEqual([
-        { id: 1, name: 'repo', fullName: 'org/repo', private: false },
+        {
+          id: 1,
+          name: 'repo',
+          fullName: 'org/repo',
+          private: false,
+          platformIntegrationId: 'integration-1',
+        },
       ]);
       expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
+    });
+
+    it('preserves installation provenance across multiple GitHub organizations', async () => {
+      mockGetIntegrationsByOrganization.mockResolvedValue([
+        buildIntegration({
+          id: 'integration-1',
+          platform_account_login: 'acme-core',
+          repositories: [{ id: 1, name: 'api', full_name: 'acme-core/api', private: true }],
+        }),
+        buildIntegration({
+          id: 'integration-2',
+          platform_installation_id: 'installation-2',
+          platform_account_login: 'acme-security',
+          repositories: [
+            { id: 2, name: 'scanner', full_name: 'acme-security/scanner', private: true },
+          ],
+        }),
+      ]);
+
+      const { fetchAllGitHubRepositoriesForOrganization } =
+        await import('./github-integration-helpers');
+      const result = await fetchAllGitHubRepositoriesForOrganization('org-123');
+
+      expect(result.repositories).toEqual([
+        expect.objectContaining({
+          fullName: 'acme-core/api',
+          platformIntegrationId: 'integration-1',
+          platformAccountLogin: 'acme-core',
+        }),
+        expect.objectContaining({
+          fullName: 'acme-security/scanner',
+          platformIntegrationId: 'integration-2',
+          platformAccountLogin: 'acme-security',
+        }),
+      ]);
     });
 
     it('returns integrationInstalled false when no integration exists', async () => {

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import {
+  getIntegrationsByOrganization,
   getIntegrationForOrganization,
   getIntegrationForOwner,
   updateRepositoriesForIntegration,
@@ -11,7 +12,10 @@ import {
 } from '@/lib/integrations/platforms/github/adapter';
 import { DEMO_SOURCE_OWNER, DEMO_SOURCE_REPO_NAME } from '@/components/cloud-agent/demo-config';
 import { PLATFORM } from '@/lib/integrations/core/constants';
-import { isPlatformIntegrationSuspended } from '@/lib/integrations/core/health';
+import {
+  isPlatformIntegrationHealthy,
+  isPlatformIntegrationSuspended,
+} from '@/lib/integrations/core/health';
 import {
   requireNumericPlatformRepositories,
   type PlatformRepository,
@@ -24,19 +28,28 @@ type GitHubRepositoriesResult = {
     name: string;
     fullName: string;
     private: boolean;
+    platformIntegrationId?: string;
+    platformAccountLogin?: string;
   }[];
   syncedAt?: string | null;
   errorMessage?: string;
 };
 
 const mapRepositories = (
-  repositories: PlatformRepository[]
+  repositories: PlatformRepository[],
+  integration?: { id: string; platform_account_login: string | null }
 ): GitHubRepositoriesResult['repositories'] => {
   return repositories.map(repo => ({
     id: repo.id,
     name: repo.name,
     fullName: repo.full_name,
     private: repo.private,
+    ...(integration
+      ? {
+          platformIntegrationId: integration.id,
+          platformAccountLogin: integration.platform_account_login ?? undefined,
+        }
+      : {}),
   }));
 };
 
@@ -124,41 +137,60 @@ export async function fetchGitHubRepositoriesForOrganization(
   forceRefresh: boolean = false
 ): Promise<GitHubRepositoriesResult> {
   const integration = await getIntegrationForOrganization(organizationId, PLATFORM.GITHUB);
+  return fetchRepositoriesForIntegrations(
+    integration && isPlatformIntegrationHealthy(integration) ? [integration] : [],
+    forceRefresh
+  );
+}
 
-  if (!integration) {
+export async function fetchAllGitHubRepositoriesForOrganization(
+  organizationId: string,
+  forceRefresh: boolean = false
+): Promise<GitHubRepositoriesResult> {
+  const integrations = (
+    await getIntegrationsByOrganization(organizationId, PLATFORM.GITHUB)
+  ).filter(isPlatformIntegrationHealthy);
+  return fetchRepositoriesForIntegrations(integrations, forceRefresh);
+}
+
+async function fetchRepositoriesForIntegrations(
+  integrations: Awaited<ReturnType<typeof getIntegrationsByOrganization>>,
+  forceRefresh: boolean
+): Promise<GitHubRepositoriesResult> {
+  if (integrations.length === 0) {
     return missingIntegrationResponse('No GitHub integration found for this organization');
   }
 
-  if (isPlatformIntegrationSuspended(integration)) {
-    return missingIntegrationResponse('GitHub integration is suspended');
-  }
-
-  if (!integration.platform_installation_id) {
-    return missingIntegrationResponse('GitHub integration is not properly configured');
-  }
-
   try {
-    const cachedRepositories = requireNumericPlatformRepositories(integration.repositories);
-    // If forceRefresh or no cached repos, fetch from GitHub and update cache
-    if (forceRefresh || !cachedRepositories?.length) {
-      const appType = integration.github_app_type || 'standard';
-      const repositories = await fetchGitHubRepositories(
-        integration.platform_installation_id,
-        appType
-      );
-      await updateRepositoriesForIntegration(integration.id, repositories);
-      return {
-        integrationInstalled: true,
-        repositories: mapRepositories(repositories),
-        syncedAt: new Date().toISOString(),
-      };
-    }
-
-    // Return cached repos
+    const results = await Promise.all(
+      integrations.map(async integration => {
+        if (!integration.platform_installation_id) return { repositories: [], syncedAt: null };
+        const cachedRepositories = requireNumericPlatformRepositories(integration.repositories);
+        if (forceRefresh || !cachedRepositories?.length) {
+          const repositories = await fetchGitHubRepositories(
+            integration.platform_installation_id,
+            integration.github_app_type || 'standard'
+          );
+          await updateRepositoriesForIntegration(integration.id, repositories);
+          return {
+            repositories: mapRepositories(repositories, integration),
+            syncedAt: new Date().toISOString(),
+          };
+        }
+        return {
+          repositories: mapRepositories(cachedRepositories, integration),
+          syncedAt: integration.repositories_synced_at,
+        };
+      })
+    );
     return {
       integrationInstalled: true,
-      repositories: mapRepositories(cachedRepositories),
-      syncedAt: integration.repositories_synced_at,
+      repositories: results.flatMap(result => result.repositories),
+      syncedAt: results
+        .map(result => result.syncedAt)
+        .filter((value): value is string => value !== null)
+        .sort()
+        .at(0),
     };
   } catch (_error) {
     throw new TRPCError({

--- a/apps/web/src/lib/integrations/core/schemas.ts
+++ b/apps/web/src/lib/integrations/core/schemas.ts
@@ -29,6 +29,7 @@ export const PendingApprovalMetadataSchema = z.object({
   status: z.enum([PENDING_APPROVAL_STATUS.AWAITING_INSTALLATION]),
   requester: KiloRequesterSchema.optional(),
   github_requester: GitHubRequesterSchema.optional(),
+  github_request_id: z.string().optional(),
 });
 
 /**

--- a/apps/web/src/lib/integrations/core/types.ts
+++ b/apps/web/src/lib/integrations/core/types.ts
@@ -80,4 +80,5 @@ export type PendingApprovalMetadata = {
   status: string;
   requester?: KiloRequester;
   github_requester?: GitHubRequester;
+  github_request_id?: string;
 };

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/drizzle';
 import { platform_integrations } from '@kilocode/db/schema';
-import { eq, and, isNull, desc, sql } from 'drizzle-orm';
+import { eq, and, isNull, asc, desc, sql } from 'drizzle-orm';
 import type {
   GitHubRequester,
   IntegrationPermissions,
@@ -57,10 +57,17 @@ export async function getIntegrationForOrganization(organizationId: string, plat
     .where(
       and(
         eq(platform_integrations.owned_by_organization_id, organizationId),
-        eq(platform_integrations.platform, platform)
+        eq(platform_integrations.platform, platform),
+        ...(platform === PLATFORM.GITHUB ? [platformIntegrationHealthSql()] : [])
       )
     )
-    .orderBy(desc(platformIntegrationHealthSql()), desc(platform_integrations.updated_at))
+    .orderBy(
+      desc(platformIntegrationHealthSql()),
+      platform === PLATFORM.GITHUB
+        ? asc(platform_integrations.created_at)
+        : desc(platform_integrations.updated_at),
+      asc(platform_integrations.id)
+    )
     .limit(1);
 
   return integration || null;
@@ -90,6 +97,27 @@ export async function getIntegrationById(integrationId: string, organizationId?:
     .limit(1);
 
   return integration || null;
+}
+
+export async function getGitHubIntegrationById(owner: Owner, integrationId: string) {
+  const ownershipCondition =
+    owner.type === 'user'
+      ? eq(platform_integrations.owned_by_user_id, owner.id)
+      : eq(platform_integrations.owned_by_organization_id, owner.id);
+
+  const [integration] = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.id, integrationId),
+        ownershipCondition,
+        eq(platform_integrations.platform, PLATFORM.GITHUB)
+      )
+    )
+    .limit(1);
+
+  return integration ?? null;
 }
 
 /**
@@ -519,6 +547,9 @@ export async function getIntegrationForOwner(
   platform: string,
   status?: IntegrationStatus
 ) {
+  if (owner.type === 'org' && platform === PLATFORM.GITHUB) {
+    return getIntegrationForOrganization(owner.id, platform);
+  }
   const ownershipCondition =
     owner.type === 'user'
       ? eq(platform_integrations.owned_by_user_id, owner.id)

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -354,7 +354,7 @@ export async function getIntegrationsByOrganization(organizationId: string, plat
         eq(platform_integrations.platform, platform)
       )
     )
-    .orderBy(desc(platform_integrations.created_at));
+    .orderBy(asc(platform_integrations.created_at), asc(platform_integrations.id));
 }
 
 /**
@@ -367,12 +367,14 @@ export async function createPendingIntegration({
   userId,
   requester,
   githubRequester,
+  githubRequest,
   githubAppType,
 }: {
   organizationId?: string;
   userId?: string;
   requester: KiloRequester;
   githubRequester?: GitHubRequester;
+  githubRequest?: { id: string; accountId: string; accountLogin: string };
   githubAppType?: 'standard' | 'lite';
 }) {
   // Ensure exactly one of organizationId or userId is provided
@@ -387,6 +389,7 @@ export async function createPendingIntegration({
     pending_approval: {
       requester,
       github_requester: githubRequester,
+      github_request_id: githubRequest?.id,
       status: PENDING_APPROVAL_STATUS.AWAITING_INSTALLATION,
     },
   };
@@ -402,6 +405,8 @@ export async function createPendingIntegration({
       repository_access: null, // Will be set to GitHub's value when approved
       integration_status: INTEGRATION_STATUS.PENDING, // Use integration_status instead of repository_access
       github_app_type: githubAppType ?? 'standard',
+      platform_account_id: githubRequest?.accountId ?? null,
+      platform_account_login: githubRequest?.accountLogin ?? null,
       metadata,
       // Denormalized requester columns for fast indexed queries
       kilo_requester_user_id: requester.kilo_user_id,

--- a/apps/web/src/lib/integrations/github-apps-service.test.ts
+++ b/apps/web/src/lib/integrations/github-apps-service.test.ts
@@ -44,6 +44,45 @@ describe('getInstallation', () => {
       await db.delete(organizations).where(eq(organizations.id, organization.id));
     }
   });
+
+  it('keeps the oldest healthy organization installation primary', async () => {
+    const [organization] = await db
+      .insert(organizations)
+      .values({ name: `GitHub primary ${crypto.randomUUID()}` })
+      .returning();
+    const oldestCreatedAt = '2026-01-01T00:00:00.000Z';
+    const newestCreatedAt = '2026-02-01T00:00:00.000Z';
+    const rows = await db
+      .insert(platform_integrations)
+      .values([
+        {
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: crypto.randomUUID(),
+          integration_status: 'active',
+          repository_access: 'all',
+          created_at: oldestCreatedAt,
+        },
+        {
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: crypto.randomUUID(),
+          integration_status: 'active',
+          repository_access: 'all',
+          created_at: newestCreatedAt,
+        },
+      ])
+      .returning();
+
+    try {
+      const integration = await getInstallation({ type: 'org', id: organization.id });
+      expect(integration?.id).toBe(rows[0].id);
+    } finally {
+      await db.delete(organizations).where(eq(organizations.id, organization.id));
+    }
+  });
 });
 
 describe('isInstallationGoneError', () => {

--- a/apps/web/src/lib/integrations/github-apps-service.ts
+++ b/apps/web/src/lib/integrations/github-apps-service.ts
@@ -2,14 +2,15 @@ import 'server-only';
 import { db } from '@/lib/drizzle';
 import type { PlatformIntegration } from '@kilocode/db/schema';
 import { platform_integrations } from '@kilocode/db/schema';
-import { eq, and, desc, isNull } from 'drizzle-orm';
+import { eq, and, asc, desc, isNull } from 'drizzle-orm';
 import { TRPCError } from '@trpc/server';
 import { requireNumericPlatformRepositories, type Owner } from '@/lib/integrations/core/types';
 import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
 import { platformIntegrationHealthSql } from '@/lib/integrations/core/health';
 import {
-  deleteIntegration,
+  deleteIntegrationForOwner,
   findPendingInstallationByKiloUserId,
+  getGitHubIntegrationById,
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
 import {
@@ -32,7 +33,8 @@ export async function listIntegrations(owner: Owner) {
   const integrations = await db
     .select()
     .from(platform_integrations)
-    .where(and(ownershipCondition, eq(platform_integrations.platform, 'github')));
+    .where(and(ownershipCondition, eq(platform_integrations.platform, 'github')))
+    .orderBy(asc(platform_integrations.created_at), asc(platform_integrations.id));
 
   return integrations;
 }
@@ -50,7 +52,13 @@ export async function getInstallation(owner: Owner): Promise<PlatformIntegration
     .select()
     .from(platform_integrations)
     .where(and(ownershipCondition, eq(platform_integrations.platform, 'github')))
-    .orderBy(desc(platformIntegrationHealthSql()), desc(platform_integrations.updated_at))
+    .orderBy(
+      desc(platformIntegrationHealthSql()),
+      owner.type === 'org'
+        ? asc(platform_integrations.created_at)
+        : desc(platform_integrations.updated_at),
+      asc(platform_integrations.id)
+    )
     .limit(1);
 
   return integration || null;
@@ -85,27 +93,16 @@ export function isInstallationGoneError(error: unknown): boolean {
  */
 export async function uninstallApp(
   owner: Owner,
+  integrationId: string | undefined,
   _userId: string,
   _userEmail: string,
   _userName: string
 ) {
-  const ownershipCondition =
-    owner.type === 'user'
-      ? eq(platform_integrations.owned_by_user_id, owner.id)
-      : eq(platform_integrations.owned_by_organization_id, owner.id);
-
-  // Get the integration
-  const [integration] = await db
-    .select()
-    .from(platform_integrations)
-    .where(
-      and(
-        ownershipCondition,
-        eq(platform_integrations.platform, 'github'),
-        eq(platform_integrations.integration_status, INTEGRATION_STATUS.ACTIVE)
-      )
-    )
-    .limit(1);
+  const integration = integrationId
+    ? await getGitHubIntegrationById(owner, integrationId)
+    : owner.type === 'user'
+      ? await getInstallation(owner)
+      : null;
 
   if (!integration) {
     throw new TRPCError({
@@ -137,21 +134,12 @@ export async function uninstallApp(
     // Installation is already gone on GitHub, continue to delete from our database
   }
 
-  // Delete from database
-  if (owner.type === 'org') {
-    await deleteIntegration(owner.id, 'github');
-    // TODO: Add audit log when integration audit actions are defined
-  } else {
-    // Delete for user
-    await db
-      .delete(platform_integrations)
-      .where(
-        and(
-          eq(platform_integrations.owned_by_user_id, owner.id),
-          eq(platform_integrations.platform, 'github')
-        )
-      );
-  }
+  await deleteIntegrationForOwner(
+    owner,
+    PLATFORM.GITHUB,
+    appType,
+    integration.platform_installation_id
+  );
 
   return { success: true };
 }
@@ -218,7 +206,7 @@ export async function listRepositories(
 /**
  * Cancel a pending installation
  */
-export async function cancelPendingInstallation(owner: Owner) {
+export async function cancelPendingInstallation(owner: Owner, integrationId?: string) {
   const ownershipCondition =
     owner.type === 'user'
       ? eq(platform_integrations.owned_by_user_id, owner.id)
@@ -231,6 +219,7 @@ export async function cancelPendingInstallation(owner: Owner) {
     .where(
       and(
         ownershipCondition,
+        ...(integrationId ? [eq(platform_integrations.id, integrationId)] : []),
         eq(platform_integrations.platform, 'github'),
         eq(platform_integrations.integration_status, INTEGRATION_STATUS.PENDING),
         isNull(platform_integrations.platform_installation_id)

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -9,6 +9,37 @@ import { type GitHubAppType, getGitHubAppCredentials } from './app-selector';
 
 export type { GitHubAppType } from './app-selector';
 
+export type GitHubInstallationRequest = {
+  id: string;
+  accountId: string;
+  accountLogin: string;
+  requesterId: string | null;
+  requesterLogin: string | null;
+};
+
+export async function fetchGitHubInstallationRequests(
+  appType: GitHubAppType = 'standard'
+): Promise<GitHubInstallationRequest[]> {
+  const credentials = getGitHubAppCredentials(appType);
+  const auth = createAppAuth({ appId: credentials.appId, privateKey: credentials.privateKey });
+  const { token } = await auth({ type: 'app' });
+  const octokit = new Octokit({ auth: token });
+  const requests = await octokit.paginate(
+    octokit.apps.listInstallationRequestsForAuthenticatedApp,
+    {
+      per_page: 100,
+    }
+  );
+
+  return requests.map(request => ({
+    id: request.id.toString(),
+    accountId: request.account.id.toString(),
+    accountLogin: 'login' in request.account ? request.account.login : request.account.slug,
+    requesterId: request.requester?.id?.toString() ?? null,
+    requesterLogin: request.requester?.login ?? null,
+  }));
+}
+
 /**
  * Verifies GitHub webhook signature
  * @param appType - The type of GitHub App to verify against (defaults to 'standard')

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -4,6 +4,7 @@ const mockVerifyGitHubWebhookSignature = jest.fn(
   (_payload: string, _signature: string, _appType: string) => true
 );
 const mockFindIntegrationByInstallationId = jest.fn();
+const mockGetIntegrationForOrganization = jest.fn();
 const mockLogWebhookEvent = jest.fn();
 const mockUpdateWebhookEvent = jest.fn();
 const mockHandlePullRequest = jest.fn();
@@ -27,6 +28,8 @@ jest.mock('@/lib/integrations/db/platform-integrations', () => ({
     installationId: string | undefined,
     githubAppType?: string
   ) => mockFindIntegrationByInstallationId(platform, installationId, githubAppType),
+  getIntegrationForOrganization: (organizationId: string, platform: string) =>
+    mockGetIntegrationForOrganization(organizationId, platform),
 }));
 
 jest.mock('@/lib/integrations/db/webhook-events', () => ({
@@ -188,6 +191,7 @@ async function waitForAfterTask() {
 describe('handleGitHubWebhook', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    mockGetIntegrationForOrganization.mockResolvedValue(integration);
     mockVerifyGitHubWebhookSignature.mockReturnValue(true);
     mockFindIntegrationByInstallationId.mockResolvedValue(integration);
     mockLogWebhookEvent.mockResolvedValue({ id: 'we_1', isDuplicate: false });

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -16,7 +16,10 @@ import {
   PullRequestReviewPayloadSchema,
   GitHubAppAuthorizationRevokedPayloadSchema,
 } from '@/lib/integrations/platforms/github/webhook-schemas';
-import { findIntegrationByInstallationId } from '@/lib/integrations/db/platform-integrations';
+import {
+  findIntegrationByInstallationId,
+  getIntegrationForOrganization,
+} from '@/lib/integrations/db/platform-integrations';
 import {
   handleInstallationCreated,
   handleInstallationDeleted,
@@ -170,7 +173,7 @@ export async function handleGitHubWebhook(
         }
         // Note: For installation.created, webhook logging happens inside handler
         // because we need organization_id which is only available after processing
-        return await handleInstallationCreated(parseResult.data);
+        return await handleInstallationCreated(parseResult.data, appType);
       }
 
       if (action === GITHUB_ACTION.DELETED) {
@@ -459,6 +462,18 @@ export async function handleGitHubWebhook(
       return NextResponse.json({ message: 'Integration suspended' }, { status: 200 });
     }
 
+    const primaryIntegration = integration.owned_by_organization_id
+      ? await getIntegrationForOrganization(integration.owned_by_organization_id, PLATFORM.GITHUB)
+      : integration;
+    const isSecondaryOrganizationInstallation = primaryIntegration?.id !== integration.id;
+    if (isSecondaryOrganizationInstallation && eventType !== GITHUB_EVENT.PULL_REQUEST) {
+      logExceptInTest('Secondary GitHub installation event suppressed', {
+        integration_id: integration.id,
+        event_type: eventType,
+      });
+      return NextResponse.json({ message: 'Event received' }, { status: 200 });
+    }
+
     // Handle push events
     if (eventType === GITHUB_EVENT.PUSH) {
       const parseResult = PushEventPayloadSchema.safeParse(payload);
@@ -514,14 +529,16 @@ export async function handleGitHubWebhook(
       // to avoid blocking the webhook response — when a matching session is on
       // a supported platform the function makes an outbound GitHub GraphQL
       // call, which can add significant latency.
-      const upsertOwner = integration.owned_by_organization_id
-        ? ({
-            kind: 'organization',
-            organizationId: integration.owned_by_organization_id,
-          } as const)
-        : integration.owned_by_user_id
-          ? ({ kind: 'user', userId: integration.owned_by_user_id } as const)
-          : null;
+      const upsertOwner = isSecondaryOrganizationInstallation
+        ? null
+        : integration.owned_by_organization_id
+          ? ({
+              kind: 'organization',
+              organizationId: integration.owned_by_organization_id,
+            } as const)
+          : integration.owned_by_user_id
+            ? ({ kind: 'user', userId: integration.owned_by_user_id } as const)
+            : null;
 
       // `closed` events are not routed to the code-review pipeline.
       if (action === GITHUB_ACTION.CLOSED) {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/installation-handler.ts
@@ -33,7 +33,10 @@ import type { GitHubAppType } from '../app-selector';
  * Handles: created, deleted, suspend, unsuspend
  */
 
-export async function handleInstallationCreated(payload: InstallationCreatedPayload) {
+export async function handleInstallationCreated(
+  payload: InstallationCreatedPayload,
+  appType: GitHubAppType
+) {
   const { installation, requester } = payload;
   const requesterId = requester?.id?.toString();
 
@@ -48,26 +51,36 @@ export async function handleInstallationCreated(payload: InstallationCreatedPayl
     requester_login: requester?.login,
   });
 
-  // Simple 1:1 mapping: Find THE pending installation by this requester
-  if (!requesterId) {
-    // No requester ID - let callback handle (direct install flow)
-    logExceptInTest('No requester ID - callback will handle');
-    return NextResponse.json({ message: 'Installation recorded' }, { status: 200 });
-  }
-
-  // Direct indexed query - O(1) lookup using platform_requester_account_id column
-  const [pending] = await db
+  const targetMatches = await db
     .select()
     .from(platform_integrations)
     .where(
       and(
         eq(platform_integrations.platform, PLATFORM.GITHUB),
-        eq(platform_integrations.platform_requester_account_id, requesterId),
+        eq(platform_integrations.github_app_type, appType),
+        eq(platform_integrations.platform_account_id, installationData.account_id),
         eq(platform_integrations.integration_status, INTEGRATION_STATUS.PENDING),
         isNull(platform_integrations.platform_installation_id)
       )
-    )
-    .limit(1);
+    );
+
+  let pending = targetMatches.length === 1 ? targetMatches[0] : undefined;
+  if (!pending && requesterId) {
+    const legacyMatches = await db
+      .select()
+      .from(platform_integrations)
+      .where(
+        and(
+          eq(platform_integrations.platform, PLATFORM.GITHUB),
+          eq(platform_integrations.github_app_type, appType),
+          eq(platform_integrations.platform_requester_account_id, requesterId),
+          eq(platform_integrations.integration_status, INTEGRATION_STATUS.PENDING),
+          isNull(platform_integrations.platform_installation_id),
+          isNull(platform_integrations.platform_account_id)
+        )
+      );
+    if (legacyMatches.length === 1) pending = legacyMatches[0];
+  }
 
   if (!pending) {
     // No pending - normal install via callback will handle
@@ -93,7 +106,6 @@ export async function handleInstallationCreated(payload: InstallationCreatedPayl
 
   // Auto-sync repositories on installation
   try {
-    const appType = pending.github_app_type || 'standard';
     const repos = await fetchGitHubRepositories(installationData.installation_id, appType);
     await updateRepositoriesForIntegration(pending.id, repos);
     logExceptInTest('Auto-synced repositories on installation', {

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -732,6 +732,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         return {
           hasIntegration: false,
           hasPermissions: false,
+          integrationId: null,
           reauthorizeUrl: null,
           authInvalidAt: integration?.auth_invalid_at ?? null,
           authInvalidReason: integration?.auth_invalid_reason ?? null,
@@ -745,6 +746,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
 
       return {
         hasIntegration: true,
+        integrationId: integration.id,
         hasPermissions: hasEffectivePermissions,
         reauthorizeUrl: hasEffectivePermissions
           ? null

--- a/apps/web/src/routers/cloud-agent-next-schemas.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.ts
@@ -345,6 +345,7 @@ const PrepareSessionSharedFields = {
     .string()
     .regex(/^[a-zA-Z0-9_.-]+\/[a-zA-Z0-9_.-]+$/, 'Invalid repository format')
     .optional(),
+  githubIntegrationId: z.uuid().optional(),
   gitlabProject: z
     .string()
     .regex(
@@ -430,6 +431,10 @@ export const basePrepareSessionNextSchema = z
       path: ['githubRepo'],
     }
   )
+  .refine(data => data.githubIntegrationId === undefined || data.githubRepo !== undefined, {
+    message: 'GitHub integration requires a GitHub repository',
+    path: ['githubIntegrationId'],
+  })
   .refine(hasOnlyOneAttachmentField, {
     message: 'Must not provide both attachments and images',
     path: ['attachments'],

--- a/apps/web/src/routers/github-apps-router.test.ts
+++ b/apps/web/src/routers/github-apps-router.test.ts
@@ -42,6 +42,8 @@ jest.mock('@/lib/integrations/github-apps-service', () => ({}));
 jest.mock('@/lib/integrations/db/platform-integrations', () => ({
   getIntegrationForOwner: (owner: Owner, platform: string) =>
     mockGetIntegrationForOwner(owner, platform),
+  getGitHubIntegrationById: (_owner: Owner, _integrationId: string) =>
+    mockGetIntegrationForOwner(_owner, 'github'),
   upsertPlatformIntegrationForOwner: (owner: Owner, details: Record<string, unknown>) =>
     mockUpsertPlatformIntegrationForOwner(owner, details),
   updateRepositoriesForIntegration: (integrationId: string, repositories: unknown[]) =>

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -3,7 +3,9 @@ import { baseProcedure, createTRPCRouter } from '@/lib/trpc/init';
 import * as z from 'zod';
 import * as githubAppsService from '@/lib/integrations/github-apps-service';
 import {
+  findIntegrationByInstallationId,
   getIntegrationForOwner,
+  getGitHubIntegrationById,
   upsertPlatformIntegrationForOwner,
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
@@ -27,6 +29,7 @@ import {
 import { requireNumericPlatformRepositories } from '@/lib/integrations/core/types';
 import { createGitHubUserAuthorizationState } from '@/lib/integrations/platforms/github/user-authorization-state';
 import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
+import { ORGANIZATION_MANAGE_ROLES } from '@kilocode/app-shared/organizations';
 import {
   disconnectGitHubUserAuthorization,
   getGitHubUserAuthorizationStatus,
@@ -140,6 +143,7 @@ export const githubAppsRouter = createTRPCRouter({
     return {
       installed: isInstalled,
       installation: {
+        id: integration.id,
         installationId: integration.platform_installation_id,
         accountId: integration.platform_account_id,
         accountLogin: integration.platform_account_login,
@@ -216,28 +220,45 @@ export const githubAppsRouter = createTRPCRouter({
     }),
 
   // Uninstall GitHub App
-  uninstallApp: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
-    const owner = await resolveAuthorizedOwner(ctx, input?.organizationId);
-    const result = await githubAppsService.uninstallApp(
-      owner,
-      ctx.user.id,
-      ctx.user.google_user_email,
-      ctx.user.google_user_name
-    );
+  uninstallApp: baseProcedure
+    .input(
+      z
+        .object({
+          organizationId: z.string().uuid().optional(),
+          integrationId: z.string().uuid().optional(),
+        })
+        .optional()
+    )
+    .mutation(async ({ ctx, input }) => {
+      const owner = await resolveAuthorizedOwner(
+        ctx,
+        input?.organizationId,
+        input?.organizationId ? ORGANIZATION_MANAGE_ROLES : undefined
+      );
+      if (input?.organizationId && !input.integrationId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Integration ID is required' });
+      }
+      const result = await githubAppsService.uninstallApp(
+        owner,
+        input?.integrationId,
+        ctx.user.id,
+        ctx.user.google_user_email,
+        ctx.user.google_user_name
+      );
 
-    if (input?.organizationId) {
-      await createAuditLog({
-        organization_id: input.organizationId,
-        action: 'organization.settings.change',
-        actor_id: ctx.user.id,
-        actor_email: ctx.user.google_user_email,
-        actor_name: ctx.user.google_user_name,
-        message: 'Uninstalled Kilo GitHub App',
-      });
-    }
+      if (input?.organizationId) {
+        await createAuditLog({
+          organization_id: input.organizationId,
+          action: 'organization.settings.change',
+          actor_id: ctx.user.id,
+          actor_email: ctx.user.google_user_email,
+          actor_name: ctx.user.google_user_name,
+          message: `Uninstalled Kilo GitHub App installation ${input.integrationId}`,
+        });
+      }
 
-    return result;
-  }),
+      return result;
+    }),
 
   // List repositories accessible by an integration
   listRepositories: baseProcedure
@@ -275,13 +296,39 @@ export const githubAppsRouter = createTRPCRouter({
 
   // Cancel pending installation
   cancelPendingInstallation: baseProcedure
-    .input(optionalOrgInput)
+    .input(
+      z
+        .object({
+          organizationId: z.string().uuid().optional(),
+          integrationId: z.string().uuid().optional(),
+        })
+        .optional()
+    )
     .mutation(async ({ ctx, input }) => {
+      let role: Awaited<ReturnType<typeof ensureOrganizationAccess>> | null = null;
       if (input?.organizationId) {
-        await ensureOrganizationAccess(ctx, input.organizationId);
+        role = await ensureOrganizationAccess(ctx, input.organizationId);
+        if (!input.integrationId) {
+          throw new TRPCError({ code: 'BAD_REQUEST', message: 'Integration ID is required' });
+        }
       }
       const owner = resolveOwner(ctx, input?.organizationId);
-      const result = await githubAppsService.cancelPendingInstallation(owner);
+      if (input?.integrationId) {
+        const integration = await getGitHubIntegrationById(owner, input.integrationId);
+        if (!integration) {
+          throw new TRPCError({ code: 'NOT_FOUND', message: 'Pending installation not found' });
+        }
+        const canCancel =
+          !input.organizationId ||
+          ctx.user.is_admin ||
+          role === 'owner' ||
+          role === 'admin' ||
+          integration.kilo_requester_user_id === ctx.user.id;
+        if (!canCancel) {
+          throw new TRPCError({ code: 'FORBIDDEN', message: 'Cannot cancel this request' });
+        }
+      }
+      const result = await githubAppsService.cancelPendingInstallation(owner, input?.integrationId);
 
       if (input?.organizationId) {
         await createAuditLog({
@@ -298,69 +345,83 @@ export const githubAppsRouter = createTRPCRouter({
     }),
 
   // Refresh installation details from GitHub (permissions, events, repositories)
-  refreshInstallation: baseProcedure.input(optionalOrgInput).mutation(async ({ ctx, input }) => {
-    if (input?.organizationId) {
-      await ensureOrganizationAccess(ctx, input.organizationId);
-    }
-    const owner = resolveOwner(ctx, input?.organizationId);
+  refreshInstallation: baseProcedure
+    .input(
+      z
+        .object({
+          organizationId: z.string().uuid().optional(),
+          integrationId: z.string().uuid().optional(),
+        })
+        .optional()
+    )
+    .mutation(async ({ ctx, input }) => {
+      if (input?.organizationId) {
+        await ensureOrganizationAccess(ctx, input.organizationId);
+      }
+      const owner = resolveOwner(ctx, input?.organizationId);
 
-    const integration = await getIntegrationForOwner(owner, 'github');
-    if (!integration || !integration.platform_installation_id) {
-      throw new TRPCError({
-        code: 'NOT_FOUND',
-        message: 'No GitHub integration found',
+      if (input?.organizationId && !input.integrationId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Integration ID is required' });
+      }
+      const integration = input?.integrationId
+        ? await getGitHubIntegrationById(owner, input.integrationId)
+        : await getIntegrationForOwner(owner, 'github');
+      if (!integration || !integration.platform_installation_id) {
+        throw new TRPCError({
+          code: 'NOT_FOUND',
+          message: 'No GitHub integration found',
+        });
+      }
+
+      const installationId = integration.platform_installation_id;
+      const appType = integration.github_app_type || 'standard';
+
+      const installationDetails = await fetchGitHubInstallationDetails(installationId, appType);
+      if (!installationDetails.account.id || !installationDetails.account.login) {
+        throw new TRPCError({
+          code: 'BAD_GATEWAY',
+          message: 'GitHub installation account identity unavailable',
+        });
+      }
+
+      const upsertResult = await upsertPlatformIntegrationForOwner(owner, {
+        platform: 'github',
+        integrationType: 'app',
+        platformInstallationId: installationId,
+        platformAccountId: installationDetails.account.id.toString(),
+        platformAccountLogin: installationDetails.account.login,
+        permissions: installationDetails.permissions,
+        scopes: installationDetails.events,
+        repositoryAccess: installationDetails.repository_selection,
+        installedAt: installationDetails.created_at,
+        // Keep the integration's app type so a lite refresh is never matched
+        // against (or converted into) the standard app's row.
+        githubAppType: appType,
       });
-    }
 
-    const installationId = integration.platform_installation_id;
-    const appType = integration.github_app_type || 'standard';
+      if (!upsertResult.ok) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'This GitHub installation is already claimed by another account.',
+        });
+      }
 
-    const installationDetails = await fetchGitHubInstallationDetails(installationId, appType);
-    if (!installationDetails.account.id || !installationDetails.account.login) {
-      throw new TRPCError({
-        code: 'BAD_GATEWAY',
-        message: 'GitHub installation account identity unavailable',
-      });
-    }
+      const repositories = await fetchGitHubRepositories(installationId, appType);
+      await updateRepositoriesForIntegration(integration.id, repositories);
 
-    const upsertResult = await upsertPlatformIntegrationForOwner(owner, {
-      platform: 'github',
-      integrationType: 'app',
-      platformInstallationId: installationId,
-      platformAccountId: installationDetails.account.id.toString(),
-      platformAccountLogin: installationDetails.account.login,
-      permissions: installationDetails.permissions,
-      scopes: installationDetails.events,
-      repositoryAccess: installationDetails.repository_selection,
-      installedAt: installationDetails.created_at,
-      // Keep the integration's app type so a lite refresh is never matched
-      // against (or converted into) the standard app's row.
-      githubAppType: appType,
-    });
+      if (input?.organizationId) {
+        await createAuditLog({
+          organization_id: input.organizationId,
+          action: 'organization.settings.change',
+          actor_id: ctx.user.id,
+          actor_email: ctx.user.google_user_email,
+          actor_name: ctx.user.google_user_name,
+          message: `Refreshed GitHub App installation ${integration.id}`,
+        });
+      }
 
-    if (!upsertResult.ok) {
-      throw new TRPCError({
-        code: 'CONFLICT',
-        message: 'This GitHub installation is already claimed by another account.',
-      });
-    }
-
-    const repositories = await fetchGitHubRepositories(installationId, appType);
-    await updateRepositoriesForIntegration(integration.id, repositories);
-
-    if (input?.organizationId) {
-      await createAuditLog({
-        organization_id: input.organizationId,
-        action: 'organization.settings.change',
-        actor_id: ctx.user.id,
-        actor_email: ctx.user.google_user_email,
-        actor_name: ctx.user.google_user_name,
-        message: 'Refreshed GitHub App installation details',
-      });
-    }
-
-    return { success: true };
-  }),
+      return { success: true };
+    }),
 
   // Dev-only: Add an existing GitHub installation manually
   devAddInstallation: baseProcedure
@@ -408,8 +469,16 @@ export const githubAppsRouter = createTRPCRouter({
         });
       }
 
-      const integration = await getIntegrationForOwner(owner, 'github');
-      if (integration) {
+      const integration = await findIntegrationByInstallationId(
+        'github',
+        input.installationId,
+        appType
+      );
+      const belongsToOwner =
+        integration &&
+        ((owner.type === 'org' && integration.owned_by_organization_id === owner.id) ||
+          (owner.type === 'user' && integration.owned_by_user_id === owner.id));
+      if (integration && belongsToOwner) {
         const repositories = await fetchGitHubRepositories(input.installationId, appType);
         await updateRepositoriesForIntegration(integration.id, repositories);
       }

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -47,6 +47,51 @@ export const githubAppsRouter = createTRPCRouter({
     return githubAppsService.listIntegrations(owner);
   }),
 
+  listOrganizationInstallations: baseProcedure
+    .input(z.object({ organizationId: z.string().uuid() }))
+    .query(async ({ ctx, input }) => {
+      const role = await ensureOrganizationAccess(ctx, input.organizationId);
+      const integrations = await githubAppsService.listIntegrations({
+        type: 'org',
+        id: input.organizationId,
+      });
+      const primaryId = integrations.find(isPlatformIntegrationHealthy)?.id ?? null;
+
+      return {
+        canAdd: integrations.length === 0,
+        installations: integrations.map(integration => {
+          const repositories = requireNumericPlatformRepositories(integration.repositories) ?? [];
+          const status: 'connected' | 'pending' | 'suspended' | 'needs_attention' =
+            isPlatformIntegrationHealthy(integration)
+              ? 'connected'
+              : integration.integration_status === 'pending'
+                ? 'pending'
+                : integration.suspended_at || integration.integration_status === 'suspended'
+                  ? 'suspended'
+                  : 'needs_attention';
+          const canCancel =
+            status === 'pending' &&
+            (ctx.user.is_admin ||
+              role === 'owner' ||
+              role === 'admin' ||
+              integration.kilo_requester_user_id === ctx.user.id);
+
+          return {
+            id: integration.id,
+            accountLogin: integration.platform_account_login,
+            installationId: integration.platform_installation_id,
+            status,
+            repositorySelection: integration.repository_access,
+            repositories,
+            isPrimary: integration.id === primaryId,
+            canRefresh: status !== 'pending',
+            canUninstall: ctx.user.is_admin || role === 'owner' || role === 'admin',
+            canCancel,
+          };
+        }),
+      };
+    }),
+
   getUserAuthorization: baseProcedure.query(async ({ ctx }) => {
     return getGitHubUserAuthorizationStatus(ctx.user.id);
   }),
@@ -104,6 +149,7 @@ export const githubAppsRouter = createTRPCRouter({
       // which called ensureOrganizationAccess with no role filter.
       const owner = await resolveAuthorizedOwner(ctx, input.organizationId, [
         'owner',
+        'admin',
         'billing_manager',
         'member',
       ]);

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -58,7 +58,7 @@ export const githubAppsRouter = createTRPCRouter({
       const primaryId = integrations.find(isPlatformIntegrationHealthy)?.id ?? null;
 
       return {
-        canAdd: integrations.length === 0,
+        canAdd: integrations.length === 0 || ctx.user.is_admin,
         installations: integrations.map(integration => {
           const repositories = requireNumericPlatformRepositories(integration.repositories) ?? [];
           const status: 'connected' | 'pending' | 'suspended' | 'needs_attention' =
@@ -153,6 +153,15 @@ export const githubAppsRouter = createTRPCRouter({
         'billing_manager',
         'member',
       ]);
+      if (owner.type === 'org') {
+        const integrations = await githubAppsService.listIntegrations(owner);
+        if (integrations.length > 0 && !ctx.user.is_admin) {
+          throw new TRPCError({
+            code: 'FORBIDDEN',
+            message: 'Only Kilo administrators can add another GitHub organization',
+          });
+        }
+      }
       const appType = await getGitHubAppTypeForOrganization(input.organizationId ?? null);
 
       const token = await createInstallState({

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.test.ts
@@ -157,6 +157,7 @@ jest.mock('@/lib/organizations/organization-usage', () => ({
 
 jest.mock('@/lib/cloud-agent/github-integration-helpers', () => ({
   fetchGitHubRepositoriesForOrganization: mockFetchGitHubRepositoriesForOrganization,
+  fetchAllGitHubRepositoriesForOrganization: mockFetchGitHubRepositoriesForOrganization,
 }));
 
 jest.mock('@/lib/cloud-agent/gitlab-integration-helpers', () => ({

--- a/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
+++ b/apps/web/src/routers/organizations/organization-cloud-agent-next-router.ts
@@ -13,7 +13,7 @@ import {
   organizationMemberProcedure,
   organizationMemberMutationProcedure,
 } from '@/routers/organizations/utils';
-import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
+import { fetchAllGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
 import {
   BitbucketOrganizationRepositoryListResultSchema,
   fetchBitbucketRepositoriesForOrganization,
@@ -238,6 +238,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       const {
         gitlabProject,
         githubRepo,
+        githubIntegrationId,
         bitbucketRepo,
         organizationId,
         attachments,
@@ -250,6 +251,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       // envVars/setupCommands/mcpServers overrides unchanged.
       let gitParams: {
         githubRepo?: string;
+        githubIntegrationId?: string;
         gitUrl?: string;
         platform?: 'github' | 'gitlab' | 'bitbucket';
         bitbucketWorkspaceUuid?: string;
@@ -268,7 +270,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
           bitbucketRepositoryUuid: bitbucketRepo.repositoryUuid,
         };
       } else {
-        gitParams = { githubRepo, platform: PLATFORM.GITHUB };
+        gitParams = { githubRepo, githubIntegrationId, platform: PLATFORM.GITHUB };
       }
 
       try {
@@ -640,6 +642,8 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
             fullName: z.string(),
             private: z.boolean(),
             defaultBranch: z.string().optional(),
+            platformIntegrationId: z.string().uuid().optional(),
+            platformAccountLogin: z.string().optional(),
           })
         ),
         integrationInstalled: z.boolean(),
@@ -648,7 +652,7 @@ export const organizationCloudAgentNextRouter = createTRPCRouter({
       })
     )
     .query(async ({ ctx, input }) => {
-      const result = await fetchGitHubRepositoriesForOrganization(
+      const result = await fetchAllGitHubRepositoriesForOrganization(
         input.organizationId,
         input.forceRefresh
       );

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.ts
@@ -24,7 +24,7 @@ import {
   type CodeReviewAgentConfig,
   type RepositoryModelOverride,
 } from '@/lib/agent-config/core/types';
-import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
+import { fetchAllGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
 import { fetchGitLabRepositoriesForOrganization } from '@/lib/cloud-agent/gitlab-integration-helpers';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
 import { createDefaultCodeReviewConfig } from '@/lib/code-reviews/core/default-config';
@@ -474,7 +474,10 @@ export const organizationReviewAgentRouter = createTRPCRouter({
       })
     )
     .query(async ({ input }) => {
-      return await fetchGitHubRepositoriesForOrganization(input.organizationId, input.forceRefresh);
+      return await fetchAllGitHubRepositoriesForOrganization(
+        input.organizationId,
+        input.forceRefresh
+      );
     }),
 
   /**

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -245,6 +245,7 @@ type GroupedRegisterSessionInput = {
     | {
         type: 'github';
         repo: string;
+        githubIntegrationId?: string;
         branch?: string;
       }
     | {
@@ -296,6 +297,9 @@ function repositoryMetadataFromRegistrationInput(
       return {
         type: 'github',
         repo: repository.repo,
+        ...(repository.githubIntegrationId
+          ? { githubIntegrationId: repository.githubIntegrationId }
+          : {}),
         upstreamBranch: repository.branch,
       };
     case 'gitlab':
@@ -379,6 +383,7 @@ function isSameRegistrationRepository(
       return (
         stored.type === 'github' &&
         stored.repo === submitted.repo &&
+        stored.githubIntegrationId === submitted.githubIntegrationId &&
         stored.upstreamBranch === submitted.branch
       );
     case 'gitlab':

--- a/services/cloud-agent-next/src/persistence/session-metadata.test.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.test.ts
@@ -98,6 +98,7 @@ describe('session metadata boundary', () => {
         type: 'github' as const,
         repo: 'acme/repo',
         token: 'github-token',
+        githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
         githubInstallationId: '987',
         githubAppType: 'standard' as const,
         upstreamBranch: 'main',
@@ -148,6 +149,20 @@ describe('session metadata boundary', () => {
     expect(parseSessionMetadata(current)).toEqual(current);
     expect(serializeSessionMetadata(current)).toEqual(current);
     expect(CurrentSessionMetadataSchema.parse(current)).toEqual(current);
+  });
+
+  it('keeps existing GitHub metadata valid when the integration id is omitted', () => {
+    const current = {
+      metadataSchemaVersion: 2 as const,
+      identity: { sessionId: 'agent_legacy_github', userId: 'user_legacy_github' },
+      auth: {},
+      repository: { type: 'github' as const, repo: 'acme/repo' },
+      lifecycle: { version: 1, timestamp: 1 },
+    };
+
+    expect(parseSessionMetadata(current)).toEqual(current);
+    expect(serializeSessionMetadata(current)).toEqual(current);
+    expect(parseSessionMetadata(current).repository).not.toHaveProperty('githubIntegrationId');
   });
 
   it('parses and serializes clone source metadata', () => {

--- a/services/cloud-agent-next/src/persistence/session-metadata.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.ts
@@ -100,6 +100,7 @@ const MetadataRepositorySchema = z.preprocess(
           type: z.literal('github'),
           repo: z.string(),
           platform: z.literal('github').optional(),
+          githubIntegrationId: z.string().uuid().optional(),
           githubInstallationId: z.string().optional(),
           githubAppType: z.enum(['standard', 'lite']).optional(),
           ...RepositoryCommonSchema,

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.test.ts
@@ -75,7 +75,7 @@ vi.mock('../../model-validation.js', () => ({
 }));
 
 vi.mock('../../session/validate-repository-access.js', () => ({
-  assertBitbucketRepositoryAccessBeforeSessionCreation: assertBitbucketRepositoryAccessMock,
+  assertRepositoryAccessBeforeSessionCreation: assertBitbucketRepositoryAccessMock,
 }));
 
 vi.mock('./organization-membership.js', () => ({
@@ -186,6 +186,28 @@ describe('prepareSession operation-ledger admission gate', () => {
     );
     expect(startNewSessionMock).not.toHaveBeenCalled();
     expect(registerNewSessionMock).not.toHaveBeenCalled();
+  });
+
+  it('adapts the legacy GitHub integration id into grouped repository identity', async () => {
+    const caller = router.createCaller(createContext());
+    const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await caller.prepareSession({
+      prompt: 'Test prompt',
+      mode: 'code',
+      model: 'claude-3',
+      githubRepo: 'acme/repo',
+      githubIntegrationId,
+      autoInitiate: true,
+    });
+
+    expect(startNewSessionMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+      }),
+      expect.any(Object),
+      expect.any(Object)
+    );
   });
 
   it('ignores operationKey when autoInitiate is false and retains legacy registration', async () => {

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -46,7 +46,7 @@ import type { Env } from '../../types.js';
 import type { SessionProfileBundle } from '../../session-profile.js';
 import type { SessionCreateRequest } from '../../session/session-requests.js';
 import { assertKiloModelAvailable } from '../../model-validation.js';
-import { assertBitbucketRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
+import { assertRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
 import { assertOrganizationMembership } from './organization-membership.js';
 
 type SessionPrepareHandlers = {
@@ -207,6 +207,7 @@ export function prepareInputToSessionCreateRequest(input: PrepareInput): Session
     repository = {
       type: 'github',
       repo: input.githubRepo,
+      ...(input.githubIntegrationId ? { githubIntegrationId: input.githubIntegrationId } : {}),
       branch: input.upstreamBranch,
     };
   } else {
@@ -331,7 +332,7 @@ const prepareSessionHandler = internalApiProtectedProcedure
           input.kilocodeOrganizationId
         );
       }
-      await assertBitbucketRepositoryAccessBeforeSessionCreation({
+      await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,
         orgId: input.kilocodeOrganizationId,

--- a/services/cloud-agent-next/src/router/handlers/session-start.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-start.ts
@@ -24,7 +24,7 @@ import {
 } from './session-prepare.js';
 import type { SessionCreateRequest } from '../../session/session-requests.js';
 import { assertKiloModelAvailable } from '../../model-validation.js';
-import { assertBitbucketRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
+import { assertRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
 import { assertOrganizationMembership } from './organization-membership.js';
 
 type SessionStartHandlers = {
@@ -44,7 +44,12 @@ function startInputToSessionCreateRequest(
   let repository: SessionCreateRequest['repository'];
   switch (repo.type) {
     case 'github':
-      repository = { type: 'github', repo: repo.repo, branch: repo.branch };
+      repository = {
+        type: 'github',
+        repo: repo.repo,
+        ...(repo.githubIntegrationId ? { githubIntegrationId: repo.githubIntegrationId } : {}),
+        branch: repo.branch,
+      };
       break;
     case 'gitlab':
       repository = { type: 'gitlab', url: repo.url, branch: repo.branch };
@@ -101,7 +106,7 @@ const startSessionHandler = protectedProcedure
         db = getPgDb(ctx.env);
         await assertOrganizationMembership(db, ctx.userId, organizationId);
       }
-      await assertBitbucketRepositoryAccessBeforeSessionCreation({
+      await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,
         orgId: organizationId,

--- a/services/cloud-agent-next/src/router/schemas.test.ts
+++ b/services/cloud-agent-next/src/router/schemas.test.ts
@@ -190,9 +190,52 @@ describe('grouped unified session input contracts', () => {
       }).success
     ).toBe(true);
   });
+
+  it('accepts a GitHub integration id only on GitHub repository inputs', () => {
+    const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+    expect(
+      StartSessionInput.safeParse({
+        ...baseStartInput,
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId,
+        },
+      }).success
+    ).toBe(true);
+    expect(
+      StartSessionInput.safeParse({
+        ...baseStartInput,
+        repository: {
+          type: 'gitlab',
+          url: 'https://gitlab.com/acme/repo.git',
+          githubIntegrationId,
+        },
+      }).success
+    ).toBe(false);
+  });
 });
 
 describe('legacy live attachment input compatibility', () => {
+  it('accepts a GitHub integration id only with a legacy GitHub repository', () => {
+    const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+    const input = {
+      prompt: 'Update the repository',
+      mode: 'code',
+      model: 'claude-sonnet-4-5-20250929',
+      githubIntegrationId,
+    };
+
+    expect(PrepareSessionInput.safeParse({ ...input, githubRepo: 'acme/repo' }).success).toBe(true);
+    expect(
+      PrepareSessionInput.safeParse({
+        ...input,
+        gitUrl: 'https://gitlab.com/acme/repo.git',
+        platform: 'gitlab',
+      }).success
+    ).toBe(false);
+  });
+
   it('accepts shell-safe Git branch punctuation used by current-branch reviews', () => {
     const branch = 'feature/alex+metadata@v2,fix=1#manual';
 

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -442,6 +442,11 @@ const PrepareSessionSharedFields = {
   githubRepo: githubRepoSchema
     .optional()
     .describe('GitHub repository in format org/repo (mutually exclusive with gitUrl)'),
+  githubIntegrationId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('GitHub platform integration ID that must authorize the selected repository'),
   githubToken: z
     .string()
     .optional()
@@ -637,6 +642,14 @@ export const PrepareSessionInput = z
     path: ['githubRepo'],
   })
   .superRefine((data, ctx) => {
+    if (data.githubIntegrationId !== undefined && data.githubRepo === undefined) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['githubIntegrationId'],
+        message: 'GitHub integration identity is only valid for GitHub repositories',
+      });
+    }
+
     const hasBitbucketIds =
       data.bitbucketWorkspaceUuid !== undefined && data.bitbucketRepositoryUuid !== undefined;
     if (
@@ -767,11 +780,17 @@ export const RepositoryInputSchema = z.discriminatedUnion('type', [
   z.object({
     type: z.literal('github'),
     repo: githubRepoSchema.describe('GitHub repository in org/repo format'),
+    githubIntegrationId: z
+      .string()
+      .uuid()
+      .optional()
+      .describe('GitHub platform integration ID that must authorize the selected repository'),
     branch: branchNameSchema.optional().describe('Branch to checkout'),
   }),
   z.object({
     type: z.literal('gitlab'),
     url: gitUrlSchema.describe('GitLab repository HTTPS URL'),
+    githubIntegrationId: z.never().optional(),
     branch: branchNameSchema.optional().describe('Branch to checkout'),
   }),
   z.object({
@@ -780,12 +799,14 @@ export const RepositoryInputSchema = z.discriminatedUnion('type', [
     workspaceUuid: z.string().uuid(),
     repositoryUuid: z.string().uuid(),
     bitbucketIntegrationId: z.string().uuid().optional(),
+    githubIntegrationId: z.never().optional(),
     branch: branchNameSchema.optional().describe('Branch to checkout'),
   }),
   z.object({
     type: z.literal('git'),
     url: gitUrlSchema.describe('Git repository HTTPS URL'),
     token: z.string().optional().describe('Git authentication token'),
+    githubIntegrationId: z.never().optional(),
     branch: branchNameSchema.optional().describe('Branch to checkout'),
   }),
 ]);

--- a/services/cloud-agent-next/src/services/git-token-service-client.test.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.test.ts
@@ -263,6 +263,35 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
     });
   });
 
+  it('forwards the expected integration id through capability issuance', async () => {
+    const issueGitHubSessionCapability = vi.fn().mockResolvedValue({
+      success: true,
+      capability: 'kgh2.opaque',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+      source: 'installation',
+      gitAuthor: { name: 'kiloconnect[bot]', email: 'bot@example.com' },
+    });
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await issueCloudAgentGitHubSessionCapability(createEnv({ issueGitHubSessionCapability }), {
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      outboundContainerId: 'container-test',
+      expectedIntegrationId,
+      allowUserAuthorization: false,
+    });
+
+    expect(issueGitHubSessionCapability).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      outboundContainerId: 'container-test',
+      expectedIntegrationId,
+      allowUserAuthorization: false,
+    });
+  });
+
   it('reports issuance failure without resolving raw authentication', async () => {
     const issueGitHubSessionCapability = vi.fn().mockResolvedValue({
       success: false,
@@ -533,6 +562,42 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
         appType: 'standard',
         source: 'installation',
       },
+    });
+  });
+
+  it('preserves the expected integration id through direct and legacy fallbacks', async () => {
+    const getCloudAgentAuthForRepo = vi
+      .fn()
+      .mockRejectedValue(new Error('RPC method getCloudAgentAuthForRepo is not available'));
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'installation-token',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await resolveCloudAgentGitHubAuthForRepo(
+      createEnv({ getCloudAgentAuthForRepo, getTokenForRepo }),
+      {
+        githubRepo: 'acme/repo',
+        userId: 'user_1',
+        expectedIntegrationId,
+        allowUserAuthorization: false,
+      }
+    );
+
+    expect(getCloudAgentAuthForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      expectedIntegrationId,
+      allowUserAuthorization: false,
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      expectedIntegrationId,
     });
   });
 });

--- a/services/cloud-agent-next/src/services/git-token-service-client.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.ts
@@ -29,7 +29,7 @@ export type ResolveGitHubTokenResult =
 
 export async function resolveGitHubTokenForRepo(
   env: GitTokenServiceEnv,
-  params: { githubRepo: string; userId: string; orgId?: string }
+  params: { githubRepo: string; userId: string; orgId?: string; expectedIntegrationId?: string }
 ): Promise<ResolveGitHubTokenResult> {
   try {
     if (!env.GIT_TOKEN_SERVICE) {
@@ -107,6 +107,7 @@ type IssueCloudAgentGitHubSessionCapabilityParams = {
   userId: string;
   outboundContainerId: string;
   orgId?: string;
+  expectedIntegrationId?: string;
   allowUserAuthorization: boolean;
 };
 
@@ -120,12 +121,15 @@ type CloudAgentGitHubAuthResult =
 
 async function resolveLegacyInstallationAuthForRepo(
   env: GitTokenServiceEnv,
-  params: { githubRepo: string; userId: string; orgId?: string }
+  params: { githubRepo: string; userId: string; orgId?: string; expectedIntegrationId?: string }
 ): Promise<CloudAgentGitHubAuthResult> {
   const legacyParams = {
     githubRepo: params.githubRepo,
     userId: params.userId,
     ...(params.orgId !== undefined ? { orgId: params.orgId } : {}),
+    ...(params.expectedIntegrationId !== undefined
+      ? { expectedIntegrationId: params.expectedIntegrationId }
+      : {}),
   };
   const result = await resolveGitHubTokenForRepo(env, legacyParams);
   if (!result.success) return result;
@@ -147,6 +151,7 @@ export async function resolveCloudAgentGitHubAuthForRepo(
     githubRepo: string;
     userId: string;
     orgId?: string;
+    expectedIntegrationId?: string;
     allowUserAuthorization: boolean;
   }
 ): Promise<CloudAgentGitHubAuthResult> {
@@ -213,6 +218,9 @@ function resolveGitHubAuthFallbackForCapability(
     githubRepo: params.githubRepo,
     userId: params.userId,
     ...(params.orgId !== undefined ? { orgId: params.orgId } : {}),
+    ...(params.expectedIntegrationId !== undefined
+      ? { expectedIntegrationId: params.expectedIntegrationId }
+      : {}),
     allowUserAuthorization: params.allowUserAuthorization,
   });
 }

--- a/services/cloud-agent-next/src/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session-prepare.test.ts
@@ -166,6 +166,7 @@ function createInternalApiContext(options: {
   requestInternalApiKey?: string | null;
   skipBalanceCheck?: boolean;
   doStub?: ReturnType<typeof createMockDOStub>;
+  getTokenForRepo?: ReturnType<typeof vi.fn>;
   getBitbucketToken?: ReturnType<typeof vi.fn>;
   githubTokenContainmentOrgIds?: string;
   gitlabTokenContainmentOrgIds?: string;
@@ -224,6 +225,15 @@ function createInternalApiContext(options: {
       R2_BUCKET: {} as TRPCContext['env']['R2_BUCKET'],
       CLOUD_AGENT_REPORT_QUEUE: {} as TRPCContext['env']['CLOUD_AGENT_REPORT_QUEUE'],
       GIT_TOKEN_SERVICE: {
+        getTokenForRepo:
+          options.getTokenForRepo ??
+          vi.fn().mockResolvedValue({
+            success: true,
+            token: 'managed-github-token',
+            installationId: '123',
+            accountLogin: 'acme',
+            appType: 'standard',
+          }),
         getBitbucketToken:
           options.getBitbucketToken ??
           vi.fn().mockResolvedValue({ success: true, token: 'managed-bitbucket-token' }),
@@ -1391,6 +1401,36 @@ describe('start endpoint', () => {
         workspace: expect.objectContaining({
           credentialContainment: { github: true, gitlab: false, bitbucket: false, kilocode: false },
         }),
+      })
+    );
+  });
+
+  it('preflights and registers grouped starts with exact GitHub integration identity', async () => {
+    const doStub = createMockDOStub();
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'managed-github-token',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const caller = appRouter.createCaller(createInternalApiContext({ doStub, getTokenForRepo }));
+    const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await caller.start({
+      message: { prompt: 'Use the selected GitHub installation' },
+      agent: { mode: 'code', model: 'anthropic/claude-sonnet-4-20250514' },
+      repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+    });
+
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'test-user-123',
+      expectedIntegrationId: githubIntegrationId,
+    });
+    expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
       })
     );
   });

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -2152,6 +2152,30 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
     expect(result.readyRequest.materialized.env.KILOCODE_TOKEN).toBe('kilo-token');
   });
 
+  it('forwards persisted GitHub integration identity to contained capability issuance', async () => {
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+    const metadata = parseSessionMetadata({
+      ...createMetadata({
+        githubRepo: 'acme/repo',
+        gitUrl: undefined,
+        gitToken: undefined,
+        platform: 'github',
+      }),
+      repository: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: expectedIntegrationId,
+      },
+    });
+
+    await buildPromptWrapperRequests(metadata);
+
+    expect(tokenMocks.issueCloudAgentGitHubSessionCapability).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ expectedIntegrationId })
+    );
+  });
+
   it('uses a managed GitHub capability for shared standard sandboxes', async () => {
     const result = await buildPromptWrapperRequests({
       ...createMetadata({
@@ -2896,6 +2920,31 @@ describe('SessionService.buildWrapperSessionReadyAndPromptRequests', () => {
       name: 'kiloconnect[bot]',
       email: 'bot@example.com',
     });
+  });
+
+  it('forwards persisted GitHub integration identity to direct token resolution', async () => {
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+    const metadata = parseSessionMetadata({
+      ...createMetadata({
+        githubRepo: 'acme/repo',
+        gitUrl: undefined,
+        gitToken: undefined,
+        platform: 'github',
+        sandboxId: 'dind-abcdef',
+      }),
+      repository: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: expectedIntegrationId,
+      },
+    });
+
+    await buildPromptWrapperRequests(metadata);
+
+    expect(tokenMocks.resolveCloudAgentGitHubAuthForRepo).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ expectedIntegrationId })
+    );
   });
 
   it('requests user GitHub auth eligibility for Slack bot sessions', async () => {

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -1727,6 +1727,9 @@ export class SessionService {
         githubRepo: github.repo,
         userId: metadata.identity.userId,
         orgId: metadata.identity.orgId,
+        ...(github.githubIntegrationId
+          ? { expectedIntegrationId: github.githubIntegrationId }
+          : {}),
         allowUserAuthorization:
           metadata.identity.createdOnPlatform === 'cloud-agent-web' ||
           metadata.identity.createdOnPlatform === 'slack',

--- a/services/cloud-agent-next/src/session/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session/session-prepare.test.ts
@@ -1550,6 +1550,25 @@ describe('createSessionWithLedger changed-intent rejection', () => {
       }),
     },
     {
+      name: 'the GitHub integration',
+      original: makeRequest({
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+        },
+        options: ORIGINAL_OPTIONS,
+      }),
+      retry: makeRequest({
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+        },
+        options: ORIGINAL_OPTIONS,
+      }),
+    },
+    {
       name: 'the model',
       retry: makeRequest({ agent: { mode: 'code', model: 'gpt-4' }, options: ORIGINAL_OPTIONS }),
     },

--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -1084,7 +1084,12 @@ function canonicalJson(value: unknown): string {
 function repositoryCreateIntent(repository: SessionRepositoryRequest): Record<string, unknown> {
   switch (repository.type) {
     case 'github':
-      return { type: 'github', repo: repository.repo, branch: repository.branch };
+      return {
+        type: 'github',
+        repo: repository.repo,
+        githubIntegrationId: repository.githubIntegrationId,
+        branch: repository.branch,
+      };
     case 'gitlab':
       return { type: 'gitlab', url: repository.url, branch: repository.branch };
     case 'bitbucket':

--- a/services/cloud-agent-next/src/session/session-requests.ts
+++ b/services/cloud-agent-next/src/session/session-requests.ts
@@ -20,6 +20,7 @@ export type SessionRepositoryRequest =
   | {
       type: 'github';
       repo: string;
+      githubIntegrationId?: string;
       branch?: string;
     }
   | {

--- a/services/cloud-agent-next/src/session/validate-repository-access.test.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
-import { assertBitbucketRepositoryAccessBeforeSessionCreation } from './validate-repository-access.js';
+import { assertRepositoryAccessBeforeSessionCreation } from './validate-repository-access.js';
 
 const repository = {
   type: 'bitbucket' as const,
@@ -8,13 +8,81 @@ const repository = {
   repositoryUuid: '123e4567-e89b-12d3-a456-426614174021',
 };
 
+describe('GitHub session creation preflight', () => {
+  it('skips legacy GitHub repositories without an integration pin', async () => {
+    const getTokenForRepo = vi.fn();
+
+    await expect(
+      assertRepositoryAccessBeforeSessionCreation({
+        env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+        userId: 'user-1',
+        repository: { type: 'github', repo: 'acme/repo' },
+      })
+    ).resolves.toBeUndefined();
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('preflights a pinned GitHub repository against the exact integration', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'token',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const orgId = '123e4567-e89b-12d3-a456-426614174030';
+    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+    await expect(
+      assertRepositoryAccessBeforeSessionCreation({
+        env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+        userId: 'user-1',
+        orgId,
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: expectedIntegrationId,
+        },
+      })
+    ).resolves.toBeUndefined();
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      orgId,
+      expectedIntegrationId,
+    });
+  });
+
+  it('rejects an integration mismatch before session allocation', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: false,
+      reason: 'integration_mismatch',
+    });
+
+    await expect(
+      assertRepositoryAccessBeforeSessionCreation({
+        env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+        userId: 'user-1',
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+        },
+      })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'GitHub repository authorization failed (integration_mismatch)',
+    });
+  });
+});
+
 describe('Bitbucket session creation preflight', () => {
   it('validates organization sessions against the organization-owned integration', async () => {
     const getBitbucketToken = vi.fn().mockResolvedValue({ success: true, token: 'token' });
     const orgId = '123e4567-e89b-12d3-a456-426614174030';
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId,
@@ -36,7 +104,7 @@ describe('Bitbucket session creation preflight', () => {
     const integrationId = '123e4567-e89b-12d3-a456-426614174022';
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId,
@@ -57,7 +125,7 @@ describe('Bitbucket session creation preflight', () => {
     const getBitbucketToken = vi.fn().mockResolvedValue({ success: true, token: 'token' });
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         repository,
@@ -76,7 +144,7 @@ describe('Bitbucket session creation preflight', () => {
     });
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId: '123e4567-e89b-12d3-a456-426614174030',
@@ -95,7 +163,7 @@ describe('Bitbucket session creation preflight', () => {
     });
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId: '123e4567-e89b-12d3-a456-426614174030',
@@ -109,7 +177,7 @@ describe('Bitbucket session creation preflight', () => {
 
   it('reports an unavailable token-service binding as service unavailable', async () => {
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: {} as never,
         userId: 'user-1',
         orgId: '123e4567-e89b-12d3-a456-426614174030',
@@ -125,7 +193,7 @@ describe('Bitbucket session creation preflight', () => {
     const getBitbucketToken = vi.fn().mockRejectedValue(new Error('binding unavailable'));
 
     await expect(
-      assertBitbucketRepositoryAccessBeforeSessionCreation({
+      assertRepositoryAccessBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getBitbucketToken } } as never,
         userId: 'user-1',
         orgId: '123e4567-e89b-12d3-a456-426614174030',

--- a/services/cloud-agent-next/src/session/validate-repository-access.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.ts
@@ -2,16 +2,36 @@ import { TRPCError } from '@trpc/server';
 import type { PersistenceEnv } from '../persistence/types.js';
 import {
   isTemporaryManagedBitbucketTokenFailure,
+  resolveGitHubTokenForRepo,
   resolveManagedBitbucketToken,
 } from '../services/git-token-service-client.js';
 import type { SessionRepositoryRequest } from './session-requests.js';
 
-export async function assertBitbucketRepositoryAccessBeforeSessionCreation(input: {
+export async function assertRepositoryAccessBeforeSessionCreation(input: {
   env: PersistenceEnv;
   userId: string;
   orgId?: string;
   repository: SessionRepositoryRequest;
 }): Promise<void> {
+  if (input.repository.type === 'github' && input.repository.githubIntegrationId) {
+    const result = await resolveGitHubTokenForRepo(input.env, {
+      githubRepo: input.repository.repo,
+      userId: input.userId,
+      ...(input.orgId ? { orgId: input.orgId } : {}),
+      expectedIntegrationId: input.repository.githubIntegrationId,
+    });
+    if (!result.success) {
+      throw new TRPCError({
+        code:
+          result.error.reason === 'service_not_configured' || result.error.reason === 'rpc_error'
+            ? 'SERVICE_UNAVAILABLE'
+            : 'BAD_REQUEST',
+        message: `GitHub repository authorization failed (${result.error.reason})`,
+      });
+    }
+    return;
+  }
+
   if (input.repository.type !== 'bitbucket') return;
   if (!input.orgId) {
     throw new TRPCError({

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -184,6 +184,8 @@ type GetTokenForRepoResult =
         | 'database_not_configured'
         | 'invalid_repo_format'
         | 'no_installation_found'
+        | 'repository_not_installed'
+        | 'integration_mismatch'
         | 'invalid_org_id';
     };
 
@@ -205,6 +207,7 @@ type ManagedGitHubAuthParams = {
   githubRepo: string;
   userId: string;
   orgId?: string;
+  expectedIntegrationId?: string;
   allowUserAuthorization: boolean;
 };
 
@@ -227,6 +230,7 @@ type GetCloudAgentAuthForRepoResult =
         | 'invalid_repo_format'
         | 'no_installation_found'
         | 'repository_not_installed'
+        | 'integration_mismatch'
         | 'invalid_org_id';
     };
 
@@ -249,6 +253,7 @@ type IssueGitHubSessionCapabilityResult =
         | 'invalid_repo_format'
         | 'no_installation_found'
         | 'repository_not_installed'
+        | 'integration_mismatch'
         | 'invalid_org_id'
         | 'capability_configuration_error';
     };
@@ -267,7 +272,8 @@ type RedeemGitHubSessionCapabilityResult =
         | 'repository_mismatch'
         | 'invalid_upstream_request'
         | 'source_unavailable'
-        | 'identity_mismatch';
+        | 'identity_mismatch'
+        | 'integration_mismatch';
     };
 
 type GetGitLabTokenFailureReason =
@@ -422,6 +428,7 @@ export type GitTokenService = {
     githubRepo: string;
     userId: string;
     orgId?: string;
+    expectedIntegrationId?: string;
   }): Promise<GetTokenForRepoResult>;
   getToken(installationId: string, appType?: 'standard' | 'lite'): Promise<string>;
   getCloudAgentAuthForRepo?(

--- a/services/git-token-service/src/github-session-capability.test.ts
+++ b/services/git-token-service/src/github-session-capability.test.ts
@@ -11,6 +11,7 @@ const claims = {
   userId: 'user_1',
   outboundContainerId: 'outbound-container-1',
   orgId: 'ef2eb5c7-27ce-4f43-b6d3-8f282abc145b',
+  integrationId: 'a65bf5a4-00f7-4a80-8841-4212d4fa9ede',
   owner: 'acme',
   repo: 'widgets',
   source: 'user',
@@ -44,6 +45,7 @@ describe('GitHubSessionCapabilityCodec', () => {
       userId: 'user_1',
       outboundContainerId: claims.outboundContainerId,
       orgId: claims.orgId,
+      integrationId: claims.integrationId,
       owner: 'acme',
       repo: 'widgets',
       source: 'user',
@@ -73,6 +75,15 @@ describe('GitHubSessionCapabilityCodec', () => {
     });
     expect(codec.decode(capability)).not.toHaveProperty('outboundContainerId');
     vi.useRealTimers();
+  });
+
+  it('continues decoding existing claims without an integration ID', () => {
+    const { integrationId: _integrationId, ...existingClaims } = claims;
+    const codec = new GitHubSessionCapabilityCodec(encryptionKey);
+
+    const decoded = codec.decode(codec.issue(existingClaims));
+
+    expect(decoded).not.toHaveProperty('integrationId');
   });
 
   it.each([

--- a/services/git-token-service/src/github-session-capability.ts
+++ b/services/git-token-service/src/github-session-capability.ts
@@ -41,6 +41,7 @@ const GitHubSessionCapabilityClaimsBaseSchema = z.object({
   purpose: z.literal(CAPABILITY_PURPOSE),
   userId: z.string().min(1),
   orgId: z.string().uuid().optional(),
+  integrationId: z.string().uuid().optional(),
   owner: GitHubPathPartSchema,
   repo: GitHubPathPartSchema,
   source: z.enum(['user', 'installation']),
@@ -72,6 +73,7 @@ export type GitHubSessionCapabilitySubject = {
   userId: string;
   outboundContainerId?: string;
   orgId?: string;
+  integrationId?: string;
   owner: string;
   repo: string;
   source: GitHubAuthSource;

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -705,6 +705,27 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     ).rejects.toThrow('repository not accessible');
     expect(serviceMocks.getToken).not.toHaveBeenCalled();
   });
+
+  it('forwards the expected integration fence and exposes only its sanitized mismatch', async () => {
+    const params = {
+      githubRepo: 'acme/repository',
+      userId: 'user-1',
+      orgId: '00000000-0000-4000-8000-000000000001',
+      expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+    };
+    serviceMocks.findInstallationId.mockResolvedValue({
+      success: false,
+      reason: 'integration_mismatch',
+    });
+
+    await expect(createService().getTokenForRepo(params)).resolves.toEqual({
+      success: false,
+      reason: 'integration_mismatch',
+    });
+    expect(serviceMocks.findInstallationId).toHaveBeenCalledWith(params);
+    expect(serviceMocks.findRefreshCandidates).not.toHaveBeenCalled();
+    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
+  });
 });
 
 const outboundContainerId = 'outbound-container-1';
@@ -763,6 +784,70 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     expect(result.capability).not.toContain('installation-token');
     expect(result).not.toHaveProperty('githubToken');
     expect(result).not.toHaveProperty('token');
+  });
+
+  it('preserves an expected integration fence through capability redemption', async () => {
+    const expectedIntegrationId = '00000000-0000-4000-8000-000000000002';
+    const orgId = '00000000-0000-4000-8000-000000000001';
+    const service = createService();
+    const issued = await service.issueGitHubSessionCapability({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      orgId,
+      expectedIntegrationId,
+      outboundContainerId,
+    });
+    if (!issued.success) throw new Error('Expected successful issuance');
+    expect(serviceMocks.findManagedInstallationForRepo).toHaveBeenLastCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      orgId,
+      expectedIntegrationId,
+      outboundContainerId,
+    });
+    serviceMocks.findManagedInstallationForRepo.mockClear();
+
+    await expect(
+      service.redeemGitHubSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestMethod: 'GET',
+        requestUrl: 'https://github.com/acme/repo.git/info/refs?service=git-upload-pack',
+      })
+    ).resolves.toMatchObject({ success: true });
+    expect(serviceMocks.findManagedInstallationForRepo).toHaveBeenLastCalledWith({
+      userId: 'user_1',
+      orgId,
+      expectedIntegrationId,
+      githubRepo: 'acme/repo',
+    });
+  });
+
+  it('returns integration_mismatch when a capability fence no longer authorizes its row', async () => {
+    const service = createService();
+    const issued = await service.issueGitHubSessionCapability({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      orgId: '00000000-0000-4000-8000-000000000001',
+      expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+      outboundContainerId,
+    });
+    if (!issued.success) throw new Error('Expected successful issuance');
+    serviceMocks.getTokenForRepo.mockClear();
+    serviceMocks.findManagedInstallationForRepo.mockResolvedValueOnce({
+      success: false,
+      reason: 'integration_mismatch',
+    });
+
+    await expect(
+      service.redeemGitHubSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestMethod: 'GET',
+        requestUrl: 'https://github.com/acme/repo.git/info/refs?service=git-upload-pack',
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
+    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
 
   it('returns a sanitized declared failure when capability key configuration is invalid', async () => {

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -92,6 +92,7 @@ export type GetTokenForRepoParams = {
   githubRepo: string;
   userId: string;
   orgId?: string;
+  expectedIntegrationId?: string;
 };
 
 export type GetTokenForRepoSuccess = {
@@ -109,7 +110,8 @@ export type GetTokenForRepoFailure = {
     | 'invalid_repo_format'
     | 'no_installation_found'
     | 'repository_not_installed'
-    | 'invalid_org_id';
+    | 'invalid_org_id'
+    | 'integration_mismatch';
 };
 
 export type GetTokenForRepoResult = GetTokenForRepoSuccess | GetTokenForRepoFailure;
@@ -179,6 +181,7 @@ export type RedeemGitHubSessionCapabilityFailureReason =
   | 'repository_mismatch'
   | 'invalid_upstream_request'
   | 'source_unavailable'
+  | 'integration_mismatch'
   | 'identity_mismatch';
 export type RedeemGitHubSessionCapabilityResult =
   | RedeemGitHubSessionCapabilitySuccess
@@ -779,6 +782,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
         case 'invalid_repo_format':
         case 'no_installation_found':
         case 'invalid_org_id':
+        case 'integration_mismatch':
           return { success: false, reason: installation.reason };
       }
     }
@@ -820,6 +824,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
         case 'no_installation_found':
         case 'repository_not_installed':
         case 'invalid_org_id':
+        case 'integration_mismatch':
           return { success: false, reason: installation.reason };
       }
     }
@@ -887,6 +892,9 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
           ? { outboundContainerId: params.outboundContainerId }
           : {}),
         ...(params.orgId !== undefined ? { orgId: params.orgId } : {}),
+        ...(params.expectedIntegrationId !== undefined
+          ? { integrationId: params.expectedIntegrationId }
+          : {}),
         ...repository,
         source: auth.source,
         identity: this.getSessionIdentity(auth),
@@ -934,6 +942,9 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     const authParams = {
       userId: claims.userId,
       ...(claims.orgId !== undefined ? { orgId: claims.orgId } : {}),
+      ...(claims.integrationId !== undefined
+        ? { expectedIntegrationId: claims.integrationId }
+        : {}),
       githubRepo: `${claims.owner}/${claims.repo}`,
     };
     let auth: GetCloudAgentAuthForRepoResult | null;
@@ -945,6 +956,9 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
       } catch {
         return { success: false, reason: 'source_unavailable' };
       }
+    }
+    if (auth && !auth.success && auth.reason === 'integration_mismatch') {
+      return { success: false, reason: 'integration_mismatch' };
     }
     if (!auth || !auth.success || auth.source !== claims.source) {
       return { success: false, reason: 'source_unavailable' };
@@ -983,9 +997,12 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
 
   private async redeemPinnedUserAuthorization(
     params: GetTokenForRepoParams
-  ): Promise<GetCloudAgentAuthForRepoSuccess | null> {
+  ): Promise<GetCloudAgentAuthForRepoResult | null> {
     const installation =
       await this.installationLookupService.findManagedInstallationForRepo(params);
+    if (!installation.success && installation.reason === 'integration_mismatch') {
+      return { success: false, reason: 'integration_mismatch' };
+    }
     if (!installation.success || installation.githubAppType === 'lite') return null;
     if (
       installation.permissions?.contents !== 'write' ||

--- a/services/git-token-service/src/installation-lookup-service.behavior.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.behavior.test.ts
@@ -12,6 +12,8 @@ type InstallationRow = {
   platform_account_login: string | null;
   github_app_type: 'standard' | 'lite' | null;
   owned_by_organization_id: string | null;
+  owned_by_user_id?: string | null;
+  integration_status?: string;
   repository_access?: string | null;
   repositories?: { full_name: string }[] | null;
   permissions?: Record<string, unknown> | null;
@@ -229,6 +231,105 @@ describe('InstallationLookupService', () => {
     });
 
     expect(result).toEqual({ success: false, reason: 'ambiguous_installation' });
+  });
+
+  it('resolves the exact active organization integration with repository access', async () => {
+    const integrationId = '00000000-0000-4000-8000-000000000002';
+    const orgId = '00000000-0000-4000-8000-000000000001';
+    const service = createService([
+      {
+        id: integrationId,
+        platform_installation_id: '100',
+        platform_account_login: 'renamed-owner',
+        github_app_type: 'standard',
+        integration_status: 'active',
+        owned_by_organization_id: orgId,
+        owned_by_user_id: null,
+        repository_access: 'selected',
+        repositories: [{ full_name: 'renamed-owner/repository' }],
+        permissions: { contents: 'write', pull_requests: 'write' },
+      },
+    ]);
+
+    await expect(
+      service.findManagedInstallationForRepo({
+        githubRepo: 'renamed-owner/repository',
+        userId: 'user-1',
+        orgId,
+        expectedIntegrationId: integrationId,
+      })
+    ).resolves.toEqual({
+      success: true,
+      installationId: '100',
+      accountLogin: 'renamed-owner',
+      githubAppType: 'standard',
+      repoName: 'repository',
+      permissions: { contents: 'write', pull_requests: 'write' },
+    });
+  });
+
+  it.each<[string, Partial<InstallationRow>]>([
+    ['wrong organization', { owned_by_organization_id: '00000000-0000-4000-8000-000000000099' }],
+    ['personal row', { owned_by_organization_id: null, owned_by_user_id: 'user-1' }],
+    ['suspended row', { integration_status: 'suspended' }],
+    ['repository owner mismatch', { platform_account_login: 'other-owner' }],
+    [
+      'selected repository mismatch',
+      { repositories: [{ full_name: 'renamed-owner/other-repository' }] },
+    ],
+  ])('rejects an expected integration with %s', async (_reason, override) => {
+    const integrationId = '00000000-0000-4000-8000-000000000002';
+    const orgId = '00000000-0000-4000-8000-000000000001';
+    const service = createService([
+      {
+        id: integrationId,
+        platform_installation_id: '100',
+        platform_account_login: 'renamed-owner',
+        github_app_type: 'standard',
+        integration_status: 'active',
+        owned_by_organization_id: orgId,
+        owned_by_user_id: null,
+        repository_access: 'selected',
+        repositories: [{ full_name: 'renamed-owner/repository' }],
+        permissions: null,
+        ...override,
+      },
+    ]);
+
+    await expect(
+      service.findManagedInstallationForRepo({
+        githubRepo: 'renamed-owner/repository',
+        userId: 'user-1',
+        orgId,
+        expectedIntegrationId: integrationId,
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
+  });
+
+  it('does not accept an expected integration without an organization', async () => {
+    const service = createService([]);
+
+    await expect(
+      service.findManagedInstallationForRepo({
+        githubRepo: 'renamed-owner/repository',
+        userId: 'user-1',
+        expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
+    expect(getWorkerDb).not.toHaveBeenCalled();
+  });
+
+  it('returns integration_mismatch when the expected row is not visible to the fenced query', async () => {
+    const service = createService([]);
+
+    await expect(
+      service.findManagedInstallationForRepo({
+        githubRepo: 'renamed-owner/repository',
+        userId: 'user-1',
+        orgId: '00000000-0000-4000-8000-000000000001',
+        expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
   });
 
   it.each(['owner/repository/extra', 'owner/', '/repository', 'owner//repository', 'owner'])(

--- a/services/git-token-service/src/installation-lookup-service.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.test.ts
@@ -3,6 +3,7 @@ import { getWorkerDb } from '@kilocode/db/client';
 import {
   buildInstallationLookupQuery,
   buildInstallationRefreshCandidatesQuery,
+  buildManagedInstallationLookupQuery,
 } from './installation-lookup-service.js';
 
 const params = {
@@ -54,5 +55,25 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.sql).toContain('"kilocode_users"."blocked_reason" is null');
     expect(query.sql).toContain('"organization_memberships"."id" is not null');
     expect(query.params).toContain(10);
+  });
+
+  it('uses a supplied integration ID as an exact organization authorization fence', () => {
+    const db = getWorkerDb('postgres://unused:unused@localhost:0/unused');
+    const expectedIntegrationId = '00000000-0000-4000-8000-000000000002';
+    const query = buildManagedInstallationLookupQuery(db, {
+      ...params,
+      expectedIntegrationId,
+    }).toSQL();
+
+    expect(query.sql).toContain('"platform_integrations"."id" =');
+    expect(query.sql).toContain('"platform_integrations"."integration_status" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_organization_id" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" is null');
+    expect(query.sql).toContain('"organization_memberships"."id" is not null');
+    expect(query.sql).not.toContain('"platform_integrations"."owned_by_user_id" =');
+    expect(query.params).toContain(expectedIntegrationId);
+    expect(query.params).toContain(params.orgId);
+    expect(query.params).toContain('renamed-owner');
+    expect(query.params).toContain(1);
   });
 });

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -11,6 +11,7 @@ export type FindInstallationParams = {
   githubRepo: string;
   userId: string;
   orgId?: string;
+  expectedIntegrationId?: string;
 };
 
 const InstallationLookupResultSchema = z.object({
@@ -36,6 +37,12 @@ const ManagedInstallationLookupResultSchema = InstallationLookupResultSchema.ext
   permissions: z.record(z.string(), z.unknown()).nullable(),
 });
 
+const ExactManagedInstallationLookupResultSchema = ManagedInstallationLookupResultSchema.extend({
+  id: z.string().uuid(),
+  integration_status: z.string(),
+  owned_by_user_id: z.string().nullable(),
+});
+
 const MAX_INSTALLATION_LOGIN_REFRESH_CANDIDATES = 10;
 
 export type InstallationLookupSuccess = {
@@ -52,7 +59,8 @@ export type InstallationLookupFailure = {
     | 'invalid_repo_format'
     | 'no_installation_found'
     | 'ambiguous_installation'
-    | 'invalid_org_id';
+    | 'invalid_org_id'
+    | 'integration_mismatch';
 };
 
 export type InstallationLookupResult = InstallationLookupSuccess | InstallationLookupFailure;
@@ -101,6 +109,31 @@ function buildAuthorizedInstallationsQuery(
               )
             )
         );
+  const exactIntegrationOwner =
+    params.expectedIntegrationId === undefined
+      ? undefined
+      : params.orgId === undefined
+        ? sql`false`
+        : and(
+            eq(platform_integrations.id, params.expectedIntegrationId),
+            eq(platform_integrations.owned_by_organization_id, params.orgId),
+            isNull(platform_integrations.owned_by_user_id),
+            isNotNull(organization_memberships.id)
+          );
+  const legacyAuthorizedOwner =
+    params.expectedIntegrationId === undefined
+      ? or(
+          and(
+            isNotNull(platform_integrations.owned_by_organization_id),
+            eq(platform_integrations.owned_by_organization_id, sql`${params.orgId ?? null}::uuid`),
+            isNotNull(organization_memberships.id)
+          ),
+          and(
+            isNotNull(platform_integrations.owned_by_user_id),
+            eq(platform_integrations.owned_by_user_id, params.userId)
+          )
+        )
+      : undefined;
 
   return db
     .select({
@@ -108,7 +141,9 @@ function buildAuthorizedInstallationsQuery(
       platform_installation_id: platform_integrations.platform_installation_id,
       platform_account_login: platform_integrations.platform_account_login,
       github_app_type: platform_integrations.github_app_type,
+      integration_status: platform_integrations.integration_status,
       owned_by_organization_id: platform_integrations.owned_by_organization_id,
+      owned_by_user_id: platform_integrations.owned_by_user_id,
       repository_access: platform_integrations.repository_access,
       repositories: platform_integrations.repositories,
       permissions: platform_integrations.permissions,
@@ -136,17 +171,8 @@ function buildAuthorizedInstallationsQuery(
         accountLoginFilter,
         isNotNull(platform_integrations.platform_installation_id),
         requestedOrganizationMembership,
-        or(
-          and(
-            isNotNull(platform_integrations.owned_by_organization_id),
-            eq(platform_integrations.owned_by_organization_id, sql`${params.orgId ?? null}::uuid`),
-            isNotNull(organization_memberships.id)
-          ),
-          and(
-            isNotNull(platform_integrations.owned_by_user_id),
-            eq(platform_integrations.owned_by_user_id, params.userId)
-          )
-        )
+        exactIntegrationOwner,
+        legacyAuthorizedOwner
       )
     )
     .orderBy(
@@ -156,7 +182,9 @@ function buildAuthorizedInstallationsQuery(
 
 export function buildInstallationLookupQuery(db: WorkerDb, params: FindInstallationParams) {
   const [repoOwner = ''] = params.githubRepo.split('/');
-  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(2);
+  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(
+    params.expectedIntegrationId === undefined ? 2 : 1
+  );
 }
 
 export function buildInstallationRefreshCandidatesQuery(
@@ -170,7 +198,9 @@ export function buildInstallationRefreshCandidatesQuery(
 
 export function buildManagedInstallationLookupQuery(db: WorkerDb, params: FindInstallationParams) {
   const [repoOwner = ''] = params.githubRepo.split('/');
-  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(2);
+  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(
+    params.expectedIntegrationId === undefined ? 2 : 1
+  );
 }
 
 export class InstallationLookupService {
@@ -196,6 +226,14 @@ export class InstallationLookupService {
       return { success: false, reason: 'invalid_org_id' };
     }
 
+    if (
+      params.expectedIntegrationId !== undefined &&
+      (params.orgId === undefined ||
+        !z.string().uuid().safeParse(params.expectedIntegrationId).success)
+    ) {
+      return { success: false, reason: 'integration_mismatch' };
+    }
+
     const repoParts = params.githubRepo.split('/');
     if (repoParts.length !== 2 || repoParts.some(part => part.length === 0)) {
       return { success: false, reason: 'invalid_repo_format' };
@@ -211,6 +249,20 @@ export class InstallationLookupService {
     }
 
     const rows = await buildInstallationLookupQuery(this.getDb(), params);
+
+    if (params.expectedIntegrationId !== undefined) {
+      const selected = ExactManagedInstallationLookupResultSchema.safeParse(rows[0]);
+      if (!selected.success || !this.matchesExpectedIntegration(selected.data, params)) {
+        return { success: false, reason: 'integration_mismatch' };
+      }
+
+      return {
+        success: true,
+        installationId: selected.data.platform_installation_id,
+        accountLogin: selected.data.platform_account_login ?? '',
+        githubAppType: selected.data.github_app_type ?? 'standard',
+      };
+    }
 
     if (rows.length === 0) {
       return { success: false, reason: 'no_installation_found' };
@@ -288,6 +340,22 @@ export class InstallationLookupService {
     }
 
     const rows = await buildManagedInstallationLookupQuery(this.getDb(), params);
+    if (params.expectedIntegrationId !== undefined) {
+      const selected = ExactManagedInstallationLookupResultSchema.safeParse(rows[0]);
+      if (!selected.success || !this.matchesExpectedIntegration(selected.data, params)) {
+        return { success: false, reason: 'integration_mismatch' };
+      }
+
+      return {
+        success: true,
+        installationId: selected.data.platform_installation_id,
+        accountLogin: selected.data.platform_account_login ?? '',
+        githubAppType: selected.data.github_app_type ?? 'standard',
+        repoName,
+        permissions: selected.data.permissions,
+      };
+    }
+
     if (rows.length === 0) {
       return { success: false, reason: 'no_installation_found' };
     }
@@ -323,5 +391,29 @@ export class InstallationLookupService {
       repoName,
       permissions: selected.permissions,
     };
+  }
+
+  private matchesExpectedIntegration(
+    selected: z.infer<typeof ExactManagedInstallationLookupResultSchema>,
+    params: FindInstallationParams
+  ): boolean {
+    if (
+      selected.id !== params.expectedIntegrationId ||
+      selected.integration_status !== 'active' ||
+      selected.owned_by_organization_id !== params.orgId ||
+      selected.owned_by_user_id !== null ||
+      selected.platform_account_login?.toLowerCase() !==
+        params.githubRepo.split('/')[0]?.toLowerCase()
+    ) {
+      return false;
+    }
+
+    if (selected.repository_access === 'all') return true;
+    if (selected.repository_access !== 'selected') return false;
+    return Boolean(
+      selected.repositories?.some(
+        repository => repository.full_name.toLowerCase() === params.githubRepo.toLowerCase()
+      )
+    );
   }
 }


### PR DESCRIPTION
## Summary
- preserve GitHub installation provenance in mobile and extension repository options
- submit `githubIntegrationId` for new and continued Cloud Agent sessions
- group repositories by GitHub account where supported
- reject ambiguous prefill and continuation matches instead of choosing the first duplicate

## Stack
- Previous: #5488
- **This PR:** 6 of 7
- Next: #5489

## Validation
- Mobile: 5,902 tests passed, typecheck and lint passed
- Extension: 1,399 tests passed, typecheck, lint, and format check passed