### PR TITLE
(janitor/dedupe): Consolidate Authorization: Bearer token extraction

### DIFF
--- a/apps/web/src/app/api/internal/auto-routing-benchmark/decider-candidates/route.ts
+++ b/apps/web/src/app/api/internal/auto-routing-benchmark/decider-candidates/route.ts
@@ -1,19 +1,13 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { timingSafeEqual } from '@kilocode/encryption';
+import { extractBearerToken } from '@kilocode/worker-utils/extract-bearer-token';
 import {
   AUTO_DECIDER_MAX_COST_USD,
   AUTO_DECIDER_MIN_COST_USD,
   listAutoRoutingDeciderCandidates,
 } from '@/lib/model-stats/auto-routing-decider-candidates';
 import { INTERNAL_API_SECRET } from '@/lib/config.server';
-
-function extractBearerToken(authHeader: string | null): string | null {
-  if (!authHeader) return null;
-  const trimmed = authHeader.trim();
-  if (trimmed.slice(0, 7).toLowerCase() !== 'bearer ') return null;
-  return trimmed.slice(7).trim() || null;
-}
 
 function parseCostBound(value: string | null, fallback: number): number {
   if (value === null) return fallback;

--- a/apps/web/src/app/api/internal/auto-routing-benchmark/token/route.ts
+++ b/apps/web/src/app/api/internal/auto-routing-benchmark/token/route.ts
@@ -24,6 +24,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { timingSafeEqual } from '@kilocode/encryption';
+import { extractBearerToken } from '@kilocode/worker-utils/extract-bearer-token';
 import { z } from 'zod';
 import { and, eq } from 'drizzle-orm';
 import { kilocode_users, organization_memberships } from '@kilocode/db/schema';
@@ -37,16 +38,6 @@ const RequestSchema = z.object({
 });
 
 const SIX_HOURS_IN_SECONDS = 6 * 60 * 60;
-
-// Inline bearer extraction (case-insensitive prefix, RFC 6750 §2.1). Kept local
-// to avoid importing @kilocode/worker-utils, whose transitive `jose` ESM import
-// breaks under jest's CJS transform.
-function extractBearerToken(authHeader: string | null): string | null {
-  if (!authHeader) return null;
-  const trimmed = authHeader.trim();
-  if (trimmed.slice(0, 7).toLowerCase() !== 'bearer ') return null;
-  return trimmed.slice(7).trim() || null;
-}
 
 export async function POST(req: NextRequest) {
   const token = extractBearerToken(req.headers.get('authorization'));

--- a/apps/web/src/lib/mcp-gateway/http.ts
+++ b/apps/web/src/lib/mcp-gateway/http.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 import { NextResponse } from 'next/server';
 import { GatewayError } from '@kilocode/mcp-gateway';
+import { extractBearerToken as extractBearerTokenFromHeader } from '@kilocode/worker-utils/extract-bearer-token';
 
 export function gatewayErrorResponse(error: unknown) {
   if (error instanceof GatewayError) {
@@ -16,8 +17,5 @@ export function gatewayErrorResponse(error: unknown) {
 }
 
 export function extractBearerToken(headers: Headers): string | null {
-  const authorization = headers.get('authorization');
-  if (!authorization?.toLowerCase().startsWith('bearer ')) return null;
-  const token = authorization.slice(7).trim();
-  return token.length > 0 ? token : null;
+  return extractBearerTokenFromHeader(headers.get('authorization'));
 }

--- a/packages/worker-utils/package.json
+++ b/packages/worker-utils/package.json
@@ -24,6 +24,7 @@
     "./cloud-agent-next-client": "./src/cloud-agent-next-client.ts",
     "./cloud-agent-session-access": "./src/cloud-agent-session-access.ts",
     "./kilo-model-id": "./src/kilo-model-id.ts",
+    "./extract-bearer-token": "./src/extract-bearer-token.ts",
     "./cloud-agent-queue-report": "./src/cloud-agent-queue-report.ts",
     "./cloud-agent-failure": "./src/cloud-agent-failure.ts",
     "./security-auto-analysis-policy": "./src/security-auto-analysis-policy.ts",

--- a/services/db-proxy/src/utils/auth.test.ts
+++ b/services/db-proxy/src/utils/auth.test.ts
@@ -71,7 +71,19 @@ describe('auth utilities', () => {
 
       const token = extractBearerToken(c);
 
-      expect(token).toBe('');
+      expect(token).toBeNull();
+    });
+
+    it('extracts token case-insensitively per RFC 6750', () => {
+      const c = createMockContext();
+      (c.req.header as jest.Mock).mockImplementation((name: string) => {
+        if (name === 'Authorization') return 'bearer my-token-123';
+        return undefined;
+      });
+
+      const token = extractBearerToken(c);
+
+      expect(token).toBe('my-token-123');
     });
   });
 

--- a/services/db-proxy/src/utils/auth.ts
+++ b/services/db-proxy/src/utils/auth.ts
@@ -1,17 +1,14 @@
 import type { Context } from 'hono';
 import type { ContentfulStatusCode } from 'hono/utils/http-status';
 import { timingSafeEqual } from '@kilocode/encryption';
+import { extractBearerToken as extractBearerTokenFromHeader } from '@kilocode/worker-utils/extract-bearer-token';
 import type { Env, ErrorCode } from '../types';
 
 /**
  * Extract bearer token from Authorization header
  */
 export function extractBearerToken(c: Context<{ Bindings: Env }>): string | null {
-  const authHeader = c.req.header('Authorization');
-  if (!authHeader?.startsWith('Bearer ')) {
-    return null;
-  }
-  return authHeader.slice(7);
+  return extractBearerTokenFromHeader(c.req.header('Authorization'));
 }
 
 /**


### PR DESCRIPTION
## Summary

`extractBearerToken` (parse `Authorization: Bearer <token>`) was independently reimplemented in five places instead of using the existing `@kilocode/worker-utils` helper:

- `services/db-proxy/src/utils/auth.ts` — **already drifted**: case-sensitive `'Bearer '` match (no lowercase support) and returned `''` instead of `null` for an empty token.
- `apps/web/src/lib/mcp-gateway/http.ts`
- `apps/web/src/app/api/internal/auto-routing-benchmark/decider-candidates/route.ts`
- `apps/web/src/app/api/internal/auto-routing-benchmark/token/route.ts` — explicitly avoided importing `@kilocode/worker-utils` because the root export pulls in `jose`, which broke under Jest's CJS transform.

All five represent the same domain concept (RFC 6750 §2.1 bearer-token parsing) and are the kind of security-relevant logic that should have one owner — the `db-proxy` drift is a concrete example of behavior silently diverging.

## Change

- Added a dependency-free subpath export, `@kilocode/worker-utils/extract-bearer-token`, for the existing zero-import `extract-bearer-token.ts`, following the same pattern already used for `./kilo-model-id` etc. so consumers don't need to pull in the package's `jose` dependency.
- Updated all five call sites to delegate to the shared implementation, removing the local reimplementations (including the now-unnecessary "kept local to avoid importing worker-utils" workaround in `token/route.ts`).
- Fixed the `db-proxy` test expectations to match the corrected (case-insensitive, `null`-for-empty) behavior, and added a case-insensitivity regression test.

## Verification

- `services/db-proxy`: `npx jest` — 35/35 passing.
- `packages/worker-utils`: `npx vitest run` — 355/355 passing.
- `services/db-proxy`, `packages/worker-utils`: `npx tsgo --noEmit` — clean.
- `oxfmt --list-different` on all changed files — clean.
- Full `apps/web` typecheck/test run was not completed in this environment (no local Postgres available for the Jest DB fixtures, and the whole-repo `tsgo` run exceeded the sandbox time budget); the two changed `apps/web` route files and `lib/mcp-gateway/http.ts` are simple, type-equivalent delegations to the same shared function signature (`string | null | undefined -> string | null`).