### PR TITLE
fix(auth): remove sign-in discovery rate limits

### DIFF
--- a/apps/web/src/app/api/sso/organizations/route.test.ts
+++ b/apps/web/src/app/api/sso/organizations/route.test.ts
@@ -234,7 +234,22 @@ describe('POST /api/sso/organizations', () => {
     expect(mockGetAllUserProviders).not.toHaveBeenCalled();
   });
 
-  it('fails closed when a rate-limit policy is unavailable', async () => {
+  it('continues discovery when rate-limit policies are not configured', async () => {
+    mockCheckRateLimit
+      .mockResolvedValueOnce({ rateLimited: false, error: 'not-found' })
+      .mockResolvedValueOnce({ rateLimited: false, error: 'not-found' });
+
+    const response = await POST(request({ email: 'user@example.com' }));
+
+    expect(response.status).toBe(200);
+    expect(mockGetAllUserProviders).toHaveBeenCalledWith('user@example.com');
+    expect(mockCaptureMessage).not.toHaveBeenCalledWith(
+      'Sign-in discovery rate limit unavailable',
+      expect.anything()
+    );
+  });
+
+  it('still rejects when a configured rate-limit policy has an operational error', async () => {
     mockCheckRateLimit
       .mockResolvedValueOnce({ rateLimited: false, error: 'not-found' })
       .mockResolvedValueOnce({
@@ -248,7 +263,7 @@ describe('POST /api/sso/organizations', () => {
       level: 'error',
       tags: { source: 'sso-organizations-rate-limit' },
       extra: {
-        ipLimiterUnavailable: true,
+        ipLimiterUnavailable: false,
         emailLimiterUnavailable: true,
       },
     });

--- a/apps/web/src/app/api/sso/organizations/route.test.ts
+++ b/apps/web/src/app/api/sso/organizations/route.test.ts
@@ -1,4 +1,3 @@
-import { checkRateLimit } from '@vercel/firewall';
 import { captureMessage } from '@sentry/nextjs';
 import { NextRequest, NextResponse } from 'next/server';
 import { verifyTurnstileJWT } from '@/lib/auth/verify-turnstile-jwt';
@@ -6,17 +5,14 @@ import { getAllUserProviders, getWorkOSOrganization } from '@/lib/user';
 import { resolveSsoAuthorityForDomain } from '@/lib/organizations/organization-sso-policy';
 import { isNewAccountEligibleForMagicLink } from '@/lib/auth/email-signin-eligibility';
 
-jest.mock('@vercel/firewall');
 jest.mock('@sentry/nextjs');
 jest.mock('@/lib/auth/verify-turnstile-jwt');
 jest.mock('@/lib/user');
 jest.mock('@/lib/organizations/organization-sso-policy');
 jest.mock('@/lib/auth/email-signin-eligibility');
-jest.mock('@/lib/config.server', () => ({ NEXTAUTH_SECRET: 'test-secret' }));
 
-import { discoveryEmailRateLimitKey, POST } from './route';
+import { POST } from './route';
 
-const mockCheckRateLimit = jest.mocked(checkRateLimit);
 const mockCaptureMessage = jest.mocked(captureMessage);
 const mockVerifyTurnstileJWT = jest.mocked(verifyTurnstileJWT);
 const mockGetAllUserProviders = jest.mocked(getAllUserProviders);
@@ -37,7 +33,6 @@ describe('POST /api/sso/organizations', () => {
     mockVerifyTurnstileJWT.mockResolvedValue({ success: true, token: {} } as Awaited<
       ReturnType<typeof verifyTurnstileJWT>
     >);
-    mockCheckRateLimit.mockResolvedValue({ rateLimited: false });
     mockGetAllUserProviders.mockResolvedValue({ kind: 'not_found' });
     mockIsNewAccountEligibleForMagicLink.mockResolvedValue(true);
     mockResolveSsoAuthorityForDomain.mockImplementation(async domain => ({
@@ -54,7 +49,7 @@ describe('POST /api/sso/organizations', () => {
 
     const response = await POST(request({ email: 'user@example.com' }));
     expect(response.status).toBe(401);
-    expect(mockCheckRateLimit).not.toHaveBeenCalled();
+    expect(mockGetAllUserProviders).not.toHaveBeenCalled();
   });
 
   it('rejects invalid request email', async () => {
@@ -198,76 +193,5 @@ describe('POST /api/sso/organizations', () => {
 
     expect((await POST(request({ email: 'first.last+tag@gmail.com' }))).status).toBe(503);
     expect(mockIsNewAccountEligibleForMagicLink).not.toHaveBeenCalled();
-  });
-
-  it('uses one HMAC rate-limit key for normalized Gmail equivalents', async () => {
-    const emailForms = [
-      'first.last+tag@gmail.com',
-      'firstlast@gmail.com',
-      'first.last@googlemail.com',
-    ];
-
-    expect(emailForms.map(discoveryEmailRateLimitKey)).toEqual([
-      discoveryEmailRateLimitKey('firstlast@gmail.com'),
-      discoveryEmailRateLimitKey('firstlast@gmail.com'),
-      discoveryEmailRateLimitKey('firstlast@gmail.com'),
-    ]);
-
-    for (const email of emailForms) {
-      await POST(request({ email }));
-    }
-
-    const emailLimitKeys = mockCheckRateLimit.mock.calls
-      .filter(([id]) => id === 'sign-in-discovery-email')
-      .map(([, options]) => options?.rateLimitKey);
-    expect(new Set(emailLimitKeys)).toEqual(
-      new Set([discoveryEmailRateLimitKey('firstlast@gmail.com')])
-    );
-  });
-
-  it('rejects a rate-limited discovery request', async () => {
-    mockCheckRateLimit
-      .mockResolvedValueOnce({ rateLimited: true })
-      .mockResolvedValueOnce({ rateLimited: false });
-
-    expect((await POST(request({ email: 'user@example.com' }))).status).toBe(429);
-    expect(mockGetAllUserProviders).not.toHaveBeenCalled();
-  });
-
-  it('continues discovery when rate-limit policies are not configured', async () => {
-    mockCheckRateLimit
-      .mockResolvedValueOnce({ rateLimited: false, error: 'not-found' })
-      .mockResolvedValueOnce({ rateLimited: false, error: 'not-found' });
-
-    const response = await POST(request({ email: 'user@example.com' }));
-
-    expect(response.status).toBe(200);
-    expect(mockGetAllUserProviders).toHaveBeenCalledWith('user@example.com');
-    expect(mockCaptureMessage).not.toHaveBeenCalledWith(
-      'Sign-in discovery rate limit unavailable',
-      expect.anything()
-    );
-  });
-
-  it('still rejects when a configured rate-limit policy has an operational error', async () => {
-    mockCheckRateLimit
-      .mockResolvedValueOnce({ rateLimited: false, error: 'not-found' })
-      .mockResolvedValueOnce({
-        rateLimited: false,
-        error: 'blocked',
-      });
-
-    expect((await POST(request({ email: 'user@example.com' }))).status).toBe(503);
-    expect(mockGetAllUserProviders).not.toHaveBeenCalled();
-    expect(mockCaptureMessage).toHaveBeenCalledWith('Sign-in discovery rate limit unavailable', {
-      level: 'error',
-      tags: { source: 'sso-organizations-rate-limit' },
-      extra: {
-        ipLimiterUnavailable: false,
-        emailLimiterUnavailable: true,
-      },
-    });
-    expect(JSON.stringify(mockCaptureMessage.mock.calls)).not.toContain('not-found');
-    expect(JSON.stringify(mockCaptureMessage.mock.calls)).not.toContain('blocked');
   });
 });

--- a/apps/web/src/app/api/sso/organizations/route.ts
+++ b/apps/web/src/app/api/sso/organizations/route.ts
@@ -20,6 +20,12 @@ const warnInSentry = sentryLogger('sso-organizations', 'warning');
 const DISCOVERY_IP_RATE_LIMIT_ID = 'sign-in-discovery-ip';
 const DISCOVERY_EMAIL_RATE_LIMIT_ID = 'sign-in-discovery-email';
 
+type RateLimitResult = Awaited<ReturnType<typeof checkRateLimit>>;
+
+function hasOperationalRateLimitError(result: RateLimitResult): boolean {
+  return Boolean(result.error && result.error !== 'not-found');
+}
+
 export function discoveryEmailRateLimitKey(email: string): string {
   return createHmac('sha256', NEXTAUTH_SECRET).update(normalizeEmail(email)).digest('base64url');
 }
@@ -68,13 +74,13 @@ export async function POST(request: Request): Promise<NextResponse> {
     if (ipLimit.rateLimited || emailLimit.rateLimited) {
       return NextResponse.json({ error: 'Please try again later.' }, { status: 429 });
     }
-    if (ipLimit.error || emailLimit.error) {
+    if (hasOperationalRateLimitError(ipLimit) || hasOperationalRateLimitError(emailLimit)) {
       captureMessage('Sign-in discovery rate limit unavailable', {
         level: 'error',
         tags: { source: 'sso-organizations-rate-limit' },
         extra: {
-          ipLimiterUnavailable: Boolean(ipLimit.error),
-          emailLimiterUnavailable: Boolean(emailLimit.error),
+          ipLimiterUnavailable: hasOperationalRateLimitError(ipLimit),
+          emailLimiterUnavailable: hasOperationalRateLimitError(emailLimit),
         },
       });
       return NextResponse.json({ error: 'Please try again later.' }, { status: 503 });

--- a/apps/web/src/app/api/sso/organizations/route.ts
+++ b/apps/web/src/app/api/sso/organizations/route.ts
@@ -1,8 +1,8 @@
 import { NextResponse } from 'next/server';
-import { captureException, captureMessage } from '@sentry/nextjs';
+import { captureException } from '@sentry/nextjs';
 import { sentryLogger } from '@/lib/utils.server';
 import { verifyTurnstileJWT } from '@/lib/auth/verify-turnstile-jwt';
-import { getLowerDomainFromEmail, normalizeEmail } from '@/lib/utils';
+import { getLowerDomainFromEmail } from '@/lib/utils';
 import { getAllUserProviders, getWorkOSOrganization } from '@/lib/user';
 import { resolveSsoAuthorityForDomain } from '@/lib/organizations/organization-sso-policy';
 import {
@@ -10,25 +10,10 @@ import {
   SignInDiscoveryResponseSchema,
   type SignInDiscoveryResponse,
 } from '@/lib/schemas/sso-organizations';
-import { checkRateLimit } from '@vercel/firewall';
-import { createHmac } from 'node:crypto';
-import { NEXTAUTH_SECRET } from '@/lib/config.server';
 import { isNewAccountEligibleForMagicLink } from '@/lib/auth/email-signin-eligibility';
 import { ProdNonSSOAuthProviders } from '@/lib/auth/provider-metadata';
 
 const warnInSentry = sentryLogger('sso-organizations', 'warning');
-const DISCOVERY_IP_RATE_LIMIT_ID = 'sign-in-discovery-ip';
-const DISCOVERY_EMAIL_RATE_LIMIT_ID = 'sign-in-discovery-email';
-
-type RateLimitResult = Awaited<ReturnType<typeof checkRateLimit>>;
-
-function hasOperationalRateLimitError(result: RateLimitResult): boolean {
-  return Boolean(result.error && result.error !== 'not-found');
-}
-
-export function discoveryEmailRateLimitKey(email: string): string {
-  return createHmac('sha256', NEXTAUTH_SECRET).update(normalizeEmail(email)).digest('base64url');
-}
 
 function discoveryResponse(response: SignInDiscoveryResponse, init?: ResponseInit): NextResponse {
   return NextResponse.json(SignInDiscoveryResponseSchema.parse(response), init);
@@ -63,28 +48,6 @@ export async function POST(request: Request): Promise<NextResponse> {
       return NextResponse.json({ error: 'Invalid email address.' }, { status: 400 });
     }
     const { email } = parsedRequest.data;
-
-    const [ipLimit, emailLimit] = await Promise.all([
-      checkRateLimit(DISCOVERY_IP_RATE_LIMIT_ID, { request }),
-      checkRateLimit(DISCOVERY_EMAIL_RATE_LIMIT_ID, {
-        request,
-        rateLimitKey: discoveryEmailRateLimitKey(email),
-      }),
-    ]);
-    if (ipLimit.rateLimited || emailLimit.rateLimited) {
-      return NextResponse.json({ error: 'Please try again later.' }, { status: 429 });
-    }
-    if (hasOperationalRateLimitError(ipLimit) || hasOperationalRateLimitError(emailLimit)) {
-      captureMessage('Sign-in discovery rate limit unavailable', {
-        level: 'error',
-        tags: { source: 'sso-organizations-rate-limit' },
-        extra: {
-          ipLimiterUnavailable: hasOperationalRateLimitError(ipLimit),
-          emailLimiterUnavailable: hasOperationalRateLimitError(emailLimit),
-        },
-      });
-      return NextResponse.json({ error: 'Please try again later.' }, { status: 503 });
-    }
 
     const providerLookup = await getAllUserProviders(email);
     if (providerLookup.kind === 'ambiguous') {


### PR DESCRIPTION
## Summary

- Remove the IP and normalized-email Vercel Firewall checks added to `/api/sso/organizations` by #5453.
- Prevent legitimate email-first and SSO sign-ins from receiving discovery `429` responses.
- Retain Turnstile verification before provider or SSO discovery, along with existing magic-link and account-creation rate limits.

## Verification

- [ ] Not manually tested against production because this change must be deployed before production can exercise the updated route. The focused route suite covers normal discovery and confirms Turnstile remains required.

## Visual Changes

N/A

## Reviewer Notes

Production telemetry showed legitimate discovery requests receiving `429` responses after the new `sign-in-discovery-ip` and `sign-in-discovery-email` policies were enabled. This removes only those two discovery limits; the pre-existing `magic-link-email` limit, signup IP limits, and Turnstile gate remain unchanged.

After deployment, the two now-unused Vercel Firewall rules can be removed.

Automated checks run locally:

- `pnpm --filter web test apps/web/src/app/api/sso/organizations/route.test.ts --runInBand` (14 tests)
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`