### PR TITLE
feat(dev): add public tunnels and exclusive worktree ports

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -244,6 +244,7 @@ should pass against the local PostgreSQL database.
 | Command | Description |
 |---|---|
 | `KILO_PORT_OFFSET=auto pnpm dev:start` | Start all local services in a tmux dashboard with worktree-safe ports |
+| `pnpm dev:start agents cloud-agent-public-tunnels` | Same as `dev:start agents`, plus Cloudflare quick tunnels for sandbox-facing Worker/Next/session-ingest/fake-llm URLs |
 | `pnpm dev:stop` | Stop the tmux session and all services |
 | `pnpm dev:env` | Sync `.dev.vars` files from `.env.local` (see [Worker `.dev.vars` setup](#worker-dev-vars-setup)) |
 | `pnpm dev:env --missing-secrets-only` | Sync env files and create missing local Secrets Store entries without refreshing existing secrets |

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -244,7 +244,7 @@ should pass against the local PostgreSQL database.
 | Command | Description |
 |---|---|
 | `KILO_PORT_OFFSET=auto pnpm dev:start` | Start all local services in a tmux dashboard with worktree-safe ports |
-| `pnpm dev:start agents cloud-agent-public-tunnels` | Same as `dev:start agents`, plus Cloudflare quick tunnels for sandbox-facing Worker/Next/session-ingest/fake-llm URLs |
+| `pnpm dev:start agents cloud-agent-public-tunnels` | Same as `dev:start agents`, plus Cloudflare quick tunnels for sandbox-facing Worker/Next/session-ingest URLs |
 | `pnpm dev:stop` | Stop the tmux session and all services |
 | `pnpm dev:env` | Sync `.dev.vars` files from `.env.local` (see [Worker `.dev.vars` setup](#worker-dev-vars-setup)) |
 | `pnpm dev:env --missing-secrets-only` | Sync env files and create missing local Secrets Store entries without refreshing existing secrets |

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -459,7 +459,16 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
   let serviceNames = topologicalSort([...new Set([...coreServices, ...extraServices])]);
 
   const sessionName = getSessionName();
-  const sessionAlreadyRunning = sessionExists(sessionName);
+  let sessionAlreadyRunning = sessionExists(sessionName);
+  if (
+    sessionAlreadyRunning &&
+    !reuseRunning &&
+    serviceNames.every(name => findServicePane(sessionName, name) === undefined)
+  ) {
+    console.log(`Session ${sessionName} has no running services — recreating it.`);
+    killSession(sessionName);
+    sessionAlreadyRunning = false;
+  }
 
   // --- Pick a free port offset before anything derives URLs from ports ---
   // An explicit KILO_PORT_OFFSET is honored as-is. Otherwise, when the
@@ -559,19 +568,7 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
   }
 
   // --- Check for existing session ---
-  // A session can outlive every service: panes interrupted by hand, the
-  // dashboard closing windows, a partial startup. Rejoining that session used
-  // to print "already running — attaching" over an empty session and required a
-  // manual dev:stop; recreate it instead. Nothing is lost — no service pane
-  // exists to keep.
-  const emptySession =
-    sessionAlreadyRunning &&
-    serviceNames.every(name => findServicePane(sessionName, name) === undefined);
-  if (emptySession) {
-    console.log(`Session ${sessionName} has no running services — recreating it.`);
-    killSession(sessionName);
-  }
-  if (sessionAlreadyRunning && !emptySession) {
+  if (sessionAlreadyRunning) {
     for (const name of serviceNames) {
       const service = getService(name);
       if (service.type !== 'worker' || !findServicePane(sessionName, name)) continue;
@@ -597,36 +594,14 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
       serviceNames.includes('cloud-agent-public-tunnels') &&
       !findServicePane(sessionName, 'cloud-agent-public-tunnels')
     ) {
-      const cloudAgentEnvPath = path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
-      const oldWorker = readEnvValue(cloudAgentEnvPath, 'WORKER_URL');
-      const oldBackend = readEnvValue(cloudAgentEnvPath, 'KILOCODE_BACKEND_BASE_URL');
-      const oldIngest = readEnvValue(cloudAgentEnvPath, 'KILO_SESSION_INGEST_URL');
-      const oldMtime = readEnvMtime(cloudAgentEnvPath);
+      const previous = snapshotCloudAgentPublicTunnelEnv(repoRoot);
       startServiceInTmux(sessionName, 'cloud-agent-public-tunnels');
-      const [workerReady, backendReady, ingestReady] = await Promise.all([
-        waitForEnvValueChange(
-          cloudAgentEnvPath,
-          'WORKER_URL',
-          oldWorker,
-          CAPTURE_TIMEOUT_MS,
-          oldMtime
-        ),
-        waitForEnvValueChange(
-          cloudAgentEnvPath,
-          'KILOCODE_BACKEND_BASE_URL',
-          oldBackend,
-          CAPTURE_TIMEOUT_MS,
-          oldMtime
-        ),
-        waitForEnvValueChange(
-          cloudAgentEnvPath,
-          'KILO_SESSION_INGEST_URL',
-          oldIngest,
-          CAPTURE_TIMEOUT_MS,
-          oldMtime
-        ),
-      ]);
-      if (!workerReady || !backendReady || !ingestReady) {
+      const captured = await waitForCloudAgentPublicTunnelCapture(
+        repoRoot,
+        previous,
+        CAPTURE_TIMEOUT_MS
+      );
+      if (!captured) {
         throw new Error(
           'Public sandbox tunnel URLs were not captured. Check the cloud-agent-public-tunnels window.'
         );
@@ -798,24 +773,9 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
       );
       oldMtimes.set('bitbucket-webhook-tunnel', readEnvMtime(appEnvPath));
     }
-    if (captureServices.includes('cloud-agent-public-tunnels')) {
-      const cloudAgentEnvPath = path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
-      oldValues.set(
-        'cloud-agent-public-tunnels-worker',
-        readEnvValue(cloudAgentEnvPath, 'WORKER_URL')
-      );
-      oldValues.set(
-        'cloud-agent-public-tunnels-backend',
-        readEnvValue(cloudAgentEnvPath, 'KILOCODE_BACKEND_BASE_URL')
-      );
-      oldValues.set(
-        'cloud-agent-public-tunnels-ingest',
-        readEnvValue(cloudAgentEnvPath, 'KILO_SESSION_INGEST_URL')
-      );
-      oldMtimes.set('cloud-agent-public-tunnels-worker', readEnvMtime(cloudAgentEnvPath));
-      oldMtimes.set('cloud-agent-public-tunnels-backend', readEnvMtime(cloudAgentEnvPath));
-      oldMtimes.set('cloud-agent-public-tunnels-ingest', readEnvMtime(cloudAgentEnvPath));
-    }
+    const previousPublicTunnelSnapshot = captureServices.includes('cloud-agent-public-tunnels')
+      ? snapshotCloudAgentPublicTunnelEnv(repoRoot)
+      : undefined;
 
     for (const name of captureServices) {
       startServiceInTmux(sessionName, name, sessionEnv);
@@ -934,49 +894,18 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
       );
     }
 
-    if (captureServices.includes('cloud-agent-public-tunnels')) {
-      const cloudAgentEnvPath = path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
+    if (previousPublicTunnelSnapshot) {
       waits.push(
-        Promise.all([
-          waitForEnvValueChange(
-            cloudAgentEnvPath,
-            'WORKER_URL',
-            oldValues.get('cloud-agent-public-tunnels-worker'),
-            CAPTURE_TIMEOUT_MS,
-            oldMtimes.get('cloud-agent-public-tunnels-worker')
-          ),
-          waitForEnvValueChange(
-            cloudAgentEnvPath,
-            'KILOCODE_BACKEND_BASE_URL',
-            oldValues.get('cloud-agent-public-tunnels-backend'),
-            CAPTURE_TIMEOUT_MS,
-            oldMtimes.get('cloud-agent-public-tunnels-backend')
-          ),
-          waitForEnvValueChange(
-            cloudAgentEnvPath,
-            'KILO_SESSION_INGEST_URL',
-            oldValues.get('cloud-agent-public-tunnels-ingest'),
-            CAPTURE_TIMEOUT_MS,
-            oldMtimes.get('cloud-agent-public-tunnels-ingest')
-          ),
-        ]).then(([workerReady, backendReady, ingestReady]) => {
-          if (workerReady && backendReady && ingestReady) {
+        waitForCloudAgentPublicTunnelCapture(
+          repoRoot,
+          previousPublicTunnelSnapshot,
+          CAPTURE_TIMEOUT_MS
+        ).then(captured => {
+          if (captured) {
             console.log('  Public sandbox tunnel URLs captured');
-            return;
-          }
-          if (!workerReady) {
+          } else {
             console.warn(
-              '  WORKER_URL not captured after 30s - check cloud-agent-public-tunnels window'
-            );
-          }
-          if (!backendReady) {
-            console.warn(
-              '  KILOCODE_BACKEND_BASE_URL not captured after 30s - check cloud-agent-public-tunnels window'
-            );
-          }
-          if (!ingestReady) {
-            console.warn(
-              '  KILO_SESSION_INGEST_URL not captured after 30s - check cloud-agent-public-tunnels window'
+              '  Public sandbox tunnel URLs not captured after 30s - check cloud-agent-public-tunnels window'
             );
           }
         })

--- a/dev/local/cli.ts
+++ b/dev/local/cli.ts
@@ -14,13 +14,14 @@ import {
   resolveGroups,
   topologicalSort,
   portOffset,
+  readPersistedPortOffset,
   writePersistedPortOffset,
   resolveSessionNextAuthUrl,
   resolveDeletionMockSessionEnv,
   services,
 } from './services';
 import { acquireProcessLock, withProcessLockAsync } from './process-lock';
-import { syncInfraEnv } from './infra-env';
+import { currentComposeProject, syncInfraEnv } from './infra-env';
 import { syncEnvVars } from './env-sync';
 import { getWranglerRegistryPath } from './wrangler-registry';
 import {
@@ -42,11 +43,15 @@ import {
   enablePaneBorders,
   isTmuxAvailable,
   findServicePane,
-  isPaneRunningCommand,
+  paneHasRunningService,
   captureServicePane,
   pipeServicePane,
 } from './tmux';
+import type { PaneInfo } from './tmux';
 import { detectLanIp, prepareMobileEnvironment } from './mobile-env';
+import { isPortlessServiceHealthy } from './tunnel-health';
+import { describeForeignPortOwners, foreignPortOwners, listPortOwners } from './compose-port-owner';
+import type { PortOwner } from './compose-port-owner';
 import { probeDockerApi } from './docker-api-probe';
 import {
   findRepoRoot,
@@ -60,6 +65,10 @@ import {
   buildLogPipeCommand,
   probePort,
   restartServiceInTmux,
+  buildStartCommand,
+  shellQuote,
+  snapshotCloudAgentPublicTunnelEnv,
+  waitForCloudAgentPublicTunnelCapture,
 } from './runner';
 
 // ---------------------------------------------------------------------------
@@ -68,22 +77,61 @@ import {
 
 const sleep = (ms: number) => new Promise<void>(r => setTimeout(r, ms));
 
+type PortScanOptions = {
+  portProbe?: typeof probePort;
+  dockerProbe?: typeof probeDockerApi;
+  /** Compose project whose published infra ports are this stack's own. */
+  ownProject?: string;
+  /**
+   * One `docker ps` snapshot, shared across candidate offsets. `undefined` —
+   * docker did not answer — skips the infra scan entirely.
+   */
+  portOwners?: PortOwner[];
+};
+
+type PortScan = {
+  conflicts: string[];
+  reusedHostServices: Set<string>;
+  /** Subset of `conflicts` on infra ports — moving off those loses a database. */
+  infraConflicts?: string[];
+  foreignInfraOwners?: PortOwner[];
+};
+
 // Scan the resolved services' full computed port set for occupants. The
 // shared kiloclaw-docker-tcp bridge on 23750 is reused (not a conflict) when
 // the listener really is the Docker API.
 async function findPortConflicts(
   serviceNames: string[],
-  portProbe: typeof probePort = probePort,
-  dockerProbe: typeof probeDockerApi = probeDockerApi
-): Promise<{
-  conflicts: string[];
-  reusedHostServices: Set<string>;
-}> {
+  options: PortScanOptions = {}
+): Promise<PortScan> {
+  const portProbe = options.portProbe ?? probePort;
+  const dockerProbe = options.dockerProbe ?? probeDockerApi;
   const conflicts: string[] = [];
+  const infraConflicts: string[] = [];
+  const foreignInfraOwners: PortOwner[] = [];
   const reusedHostServices = new Set<string>();
   for (const name of serviceNames) {
     const service = getService(name);
-    if (service.type === 'infra' || service.port <= 0) continue;
+    if (service.port <= 0) continue;
+    // Infra ports used to be skipped here. An offset whose app ports are all
+    // free can still have another compose project sitting on its postgres, and
+    // `docker compose up` then fails with a bare "port is already allocated" —
+    // which is how an auto-selected offset ends up unusable. A container of
+    // *this* worktree's own project is not a conflict: it is the database the
+    // stack is meant to use.
+    if (service.type === 'infra') {
+      // Without a container listing there is no way to tell this worktree's own
+      // postgres from a squatter, and convicting every occupied infra port
+      // would refuse starts that a slow `docker ps` alone should never block.
+      if (options.portOwners === undefined) continue;
+      if (!(await portProbe(service.port))) continue;
+      const owner = options.portOwners.find(entry => entry.port === service.port);
+      if (owner !== undefined && owner.project === options.ownProject) continue;
+      if (owner !== undefined) foreignInfraOwners.push(owner);
+      conflicts.push(`${name}:${service.port}`);
+      infraConflicts.push(`${name}:${service.port}`);
+      continue;
+    }
     const ports = [
       { label: name, port: service.port },
       ...(service.type === 'worker'
@@ -103,7 +151,7 @@ async function findPortConflicts(
       }
     }
   }
-  return { conflicts, reusedHostServices };
+  return { conflicts, reusedHostServices, infraConflicts, foreignInfraOwners };
 }
 
 // Next.js rejects the X11 range. Keep automatic worktree offsets away from it
@@ -148,13 +196,18 @@ async function acquirePortOffsetLease(
   repoRoot: string,
   sessionName: string,
   leasesRoot = path.join(os.tmpdir(), 'kilo-port-offset-leases'),
-  scanPorts: typeof findPortConflicts = findPortConflicts
+  scanPorts: typeof findPortConflicts = findPortConflicts,
+  /** Offset this worktree last started on — the one holding its database. */
+  persistedOffset?: number
 ): Promise<Set<string>> {
   const startingOffset = portOffset;
   const candidates = explicit
     ? [startingOffset]
     : [startingOffset, ...candidatePortOffsets(startingOffset)];
   fs.mkdirSync(leasesRoot, { recursive: true });
+  // One snapshot for all 50 candidates: `docker ps` per candidate would cost
+  // seconds, and container ownership does not change mid-scan.
+  const portOwners = listPortOwners();
 
   for (const candidate of candidates) {
     applyPortOffset(candidate);
@@ -192,12 +245,33 @@ async function acquirePortOffsetLease(
       }
       fs.rmSync(claimPath, { force: true });
 
-      const scan = await scanPorts(serviceNames);
+      const scan = await scanPorts(serviceNames, {
+        ownProject: currentComposeProject(repoRoot, candidate),
+        portOwners,
+      });
       if (scan.conflicts.length > 0) {
         if (explicit) {
           throw new Error(
-            `Refusing to share occupied worktree service ports: ${scan.conflicts.join(', ')}. ` +
-              'Stop the owning worktree or set a distinct KILO_PORT_OFFSET.'
+            [
+              `Refusing to share occupied worktree service ports: ${scan.conflicts.join(', ')}.`,
+              ...describeForeignPortOwners(scan.foreignInfraOwners ?? []).map(line => `  ${line}`),
+              '  Stop the owning worktree or set a distinct KILO_PORT_OFFSET.',
+            ].join('\n')
+          );
+        }
+        // Moving off the offset this worktree last started on means a new
+        // compose project, a new volume, and an empty database — a start that
+        // looks fine and confuses later. Only infra ports carry that cost, so
+        // stop and name the occupant instead of quietly reshuffling.
+        const blockedInfra = scan.infraConflicts ?? [];
+        if (candidate === persistedOffset && blockedInfra.length > 0) {
+          throw new Error(
+            [
+              `Port offset ${candidate} holds this stack's database, but its infrastructure ports are taken: ${blockedInfra.join(', ')}.`,
+              ...describeForeignPortOwners(scan.foreignInfraOwners ?? []).map(line => `  ${line}`),
+              '  Free them and retry. To start on another offset instead — a fresh, empty',
+              '  database — rerun with KILO_PORT_OFFSET=<n>.',
+            ].join('\n')
           );
         }
         continue;
@@ -306,6 +380,48 @@ const CAPTURE_TIMEOUT_MS = 30_000;
 // Commands
 // ---------------------------------------------------------------------------
 
+/**
+ * Infra ports of `serviceNames` that a *different* compose project publishes.
+ *
+ * Offsets are not exclusive across worktrees: another stack's containers can
+ * still hold this offset's ports after our own `dev:stop`. Docker's own error
+ * ("port is already allocated") names neither the owner nor the fix.
+ */
+function collidingInfraPorts(repoRoot: string, serviceNames: string[]): string[] {
+  const ports = serviceNames
+    .filter(name => getService(name).type === 'infra')
+    .map(name => getService(name).port)
+    .filter(port => port > 0);
+  if (ports.length === 0) return [];
+  return describeForeignPortOwners(
+    foreignPortOwners(ports, currentComposeProject(repoRoot, portOffset))
+  );
+}
+
+/**
+ * Tears down this worktree's containers at the offset it no longer uses.
+ *
+ * Nothing else ever names that project again — `dev/.env` is about to be
+ * rewritten to the new one and `dev:stop` only downs what that file names — so
+ * without this the old containers run forever, holding the old offset's ports
+ * against whoever picks it up next. `down` keeps volumes, so returning to that
+ * offset still finds the data.
+ */
+function removeStaleComposeProject(repoRoot: string, previousOffset: number | undefined): void {
+  // Offset 0 is the shared default project; other checkouts may be using it.
+  if (previousOffset === undefined || previousOffset <= 0 || previousOffset === portOffset) return;
+  const project = currentComposeProject(repoRoot, previousOffset);
+  const [cmd, cmdArgs] = buildInfraDownArgs(project);
+  console.log(`${DIM}Removing containers left at offset ${previousOffset} (${project})${RESET}`);
+  try {
+    execFileSync(cmd, cmdArgs, { cwd: repoRoot, stdio: 'ignore' });
+  } catch {
+    console.warn(
+      `⚠ Could not remove ${project}. Free its ports with: docker compose -p ${project} down`
+    );
+  }
+}
+
 async function cmdUp(args: string[], repoRoot: string): Promise<string | undefined> {
   const noAttach = args.includes('--no-attach');
   const reuseRunning = args.includes('--reuse-running');
@@ -357,17 +473,24 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
   let reusedHostServices = new Set<string>();
   if (!sessionAlreadyRunning) {
     const originalOffset = portOffset;
+    // Read before the lease writes over it: it names the offset whose compose
+    // project holds this worktree's containers right now.
+    const previousOffset = readPersistedPortOffset(repoRoot);
     reusedHostServices = await acquirePortOffsetLease(
       serviceNames,
       offsetIsExplicit,
       repoRoot,
-      sessionName
+      sessionName,
+      undefined,
+      undefined,
+      previousOffset
     );
     if (portOffset !== originalOffset)
       console.log(`${DIM}Auto-selected port offset ${portOffset}${RESET}`);
     // Persist before tmux or any service exists: a killed partial startup still
     // leaves every later command on the ports the children inherited.
     writePersistedPortOffset(repoRoot, portOffset);
+    removeStaleComposeProject(repoRoot, previousOffset);
   }
 
   // --- Export port offset for child processes (e.g. scripts/dev.sh) ---
@@ -426,8 +549,29 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
     throw new Error('Failed to prepare required local service environment');
   }
 
+  if (serviceNames.includes('cloud-agent-public-tunnels')) {
+    try {
+      execSync('cloudflared --version', { stdio: 'ignore' });
+    } catch {
+      console.error('cloudflared is not installed. Install it with: brew install cloudflared');
+      process.exit(1);
+    }
+  }
+
   // --- Check for existing session ---
-  if (sessionAlreadyRunning) {
+  // A session can outlive every service: panes interrupted by hand, the
+  // dashboard closing windows, a partial startup. Rejoining that session used
+  // to print "already running — attaching" over an empty session and required a
+  // manual dev:stop; recreate it instead. Nothing is lost — no service pane
+  // exists to keep.
+  const emptySession =
+    sessionAlreadyRunning &&
+    serviceNames.every(name => findServicePane(sessionName, name) === undefined);
+  if (emptySession) {
+    console.log(`Session ${sessionName} has no running services — recreating it.`);
+    killSession(sessionName);
+  }
+  if (sessionAlreadyRunning && !emptySession) {
     for (const name of serviceNames) {
       const service = getService(name);
       if (service.type !== 'worker' || !findServicePane(sessionName, name)) continue;
@@ -447,6 +591,52 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
         const outcome = await restartServiceInTmux(sessionName, 'mobile', mobileEnv);
         if (outcome === 'gave-up')
           throw new Error('mobile did not restart with refreshed mobile URLs');
+      }
+    }
+    if (
+      serviceNames.includes('cloud-agent-public-tunnels') &&
+      !findServicePane(sessionName, 'cloud-agent-public-tunnels')
+    ) {
+      const cloudAgentEnvPath = path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
+      const oldWorker = readEnvValue(cloudAgentEnvPath, 'WORKER_URL');
+      const oldBackend = readEnvValue(cloudAgentEnvPath, 'KILOCODE_BACKEND_BASE_URL');
+      const oldIngest = readEnvValue(cloudAgentEnvPath, 'KILO_SESSION_INGEST_URL');
+      const oldMtime = readEnvMtime(cloudAgentEnvPath);
+      startServiceInTmux(sessionName, 'cloud-agent-public-tunnels');
+      const [workerReady, backendReady, ingestReady] = await Promise.all([
+        waitForEnvValueChange(
+          cloudAgentEnvPath,
+          'WORKER_URL',
+          oldWorker,
+          CAPTURE_TIMEOUT_MS,
+          oldMtime
+        ),
+        waitForEnvValueChange(
+          cloudAgentEnvPath,
+          'KILOCODE_BACKEND_BASE_URL',
+          oldBackend,
+          CAPTURE_TIMEOUT_MS,
+          oldMtime
+        ),
+        waitForEnvValueChange(
+          cloudAgentEnvPath,
+          'KILO_SESSION_INGEST_URL',
+          oldIngest,
+          CAPTURE_TIMEOUT_MS,
+          oldMtime
+        ),
+      ]);
+      if (!workerReady || !backendReady || !ingestReady) {
+        throw new Error(
+          'Public sandbox tunnel URLs were not captured. Check the cloud-agent-public-tunnels window.'
+        );
+      }
+      const cloudAgentPane = findServicePane(sessionName, 'cloud-agent-next');
+      if (cloudAgentPane) {
+        const outcome = await restartServiceInTmux(sessionName, 'cloud-agent-next');
+        if (outcome === 'gave-up') {
+          throw new Error('cloud-agent-next did not restart with public tunnel URLs');
+        }
       }
     }
     console.log(
@@ -497,6 +687,9 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
   // --- Start Docker infra ---
   const hasInfra = serviceNames.some(name => getService(name).type === 'infra');
   if (hasInfra) {
+    for (const line of collidingInfraPorts(repoRoot, serviceNames)) {
+      console.warn(`⚠ ${line}`);
+    }
     console.log(`${BOLD}Starting infrastructure…${RESET}`);
     await startInfra(repoRoot, serviceNames);
     console.log();
@@ -568,6 +761,7 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
     'stripe',
     'app-builder-tunnel',
     'bitbucket-webhook-tunnel',
+    'cloud-agent-public-tunnels',
   ]);
   const captureServices = serviceNames.filter(n => captureServiceSet.has(n));
   const otherServices = serviceNames.filter(n => !captureServiceSet.has(n));
@@ -603,6 +797,24 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
         readEnvValue(appEnvPath, 'BITBUCKET_CODE_REVIEW_WEBHOOK_BASE_URL')
       );
       oldMtimes.set('bitbucket-webhook-tunnel', readEnvMtime(appEnvPath));
+    }
+    if (captureServices.includes('cloud-agent-public-tunnels')) {
+      const cloudAgentEnvPath = path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
+      oldValues.set(
+        'cloud-agent-public-tunnels-worker',
+        readEnvValue(cloudAgentEnvPath, 'WORKER_URL')
+      );
+      oldValues.set(
+        'cloud-agent-public-tunnels-backend',
+        readEnvValue(cloudAgentEnvPath, 'KILOCODE_BACKEND_BASE_URL')
+      );
+      oldValues.set(
+        'cloud-agent-public-tunnels-ingest',
+        readEnvValue(cloudAgentEnvPath, 'KILO_SESSION_INGEST_URL')
+      );
+      oldMtimes.set('cloud-agent-public-tunnels-worker', readEnvMtime(cloudAgentEnvPath));
+      oldMtimes.set('cloud-agent-public-tunnels-backend', readEnvMtime(cloudAgentEnvPath));
+      oldMtimes.set('cloud-agent-public-tunnels-ingest', readEnvMtime(cloudAgentEnvPath));
     }
 
     for (const name of captureServices) {
@@ -716,6 +928,55 @@ async function cmdUp(args: string[], repoRoot: string): Promise<string | undefin
           } else {
             console.warn(
               '  Bitbucket webhook tunnel URL not captured after 30s - check bitbucket-webhook-tunnel window'
+            );
+          }
+        })
+      );
+    }
+
+    if (captureServices.includes('cloud-agent-public-tunnels')) {
+      const cloudAgentEnvPath = path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
+      waits.push(
+        Promise.all([
+          waitForEnvValueChange(
+            cloudAgentEnvPath,
+            'WORKER_URL',
+            oldValues.get('cloud-agent-public-tunnels-worker'),
+            CAPTURE_TIMEOUT_MS,
+            oldMtimes.get('cloud-agent-public-tunnels-worker')
+          ),
+          waitForEnvValueChange(
+            cloudAgentEnvPath,
+            'KILOCODE_BACKEND_BASE_URL',
+            oldValues.get('cloud-agent-public-tunnels-backend'),
+            CAPTURE_TIMEOUT_MS,
+            oldMtimes.get('cloud-agent-public-tunnels-backend')
+          ),
+          waitForEnvValueChange(
+            cloudAgentEnvPath,
+            'KILO_SESSION_INGEST_URL',
+            oldValues.get('cloud-agent-public-tunnels-ingest'),
+            CAPTURE_TIMEOUT_MS,
+            oldMtimes.get('cloud-agent-public-tunnels-ingest')
+          ),
+        ]).then(([workerReady, backendReady, ingestReady]) => {
+          if (workerReady && backendReady && ingestReady) {
+            console.log('  Public sandbox tunnel URLs captured');
+            return;
+          }
+          if (!workerReady) {
+            console.warn(
+              '  WORKER_URL not captured after 30s - check cloud-agent-public-tunnels window'
+            );
+          }
+          if (!backendReady) {
+            console.warn(
+              '  KILOCODE_BACKEND_BASE_URL not captured after 30s - check cloud-agent-public-tunnels window'
+            );
+          }
+          if (!ingestReady) {
+            console.warn(
+              '  KILO_SESSION_INGEST_URL not captured after 30s - check cloud-agent-public-tunnels window'
             );
           }
         })
@@ -867,7 +1128,7 @@ async function missingRunningServices(
   checks: {
     repoRoot?: string;
     findPane?: typeof findServicePane;
-    isPaneRunning?: typeof isPaneRunningCommand;
+    isPaneRunning?: typeof paneHasRunningService;
     probe?: typeof probePort;
     waitMs?: number;
     pollMs?: number;
@@ -880,7 +1141,7 @@ async function missingRunningServices(
     )
   );
   const findPane = checks.findPane ?? findServicePane;
-  const isPaneRunning = checks.isPaneRunning ?? isPaneRunningCommand;
+  const isPaneRunning = checks.isPaneRunning ?? paneHasRunningService;
   const probe = checks.probe ?? probePort;
   const repoRoot = checks.repoRoot ?? process.cwd();
   const missing = requested.filter(name => getService(name).type !== 'infra' && !entries.has(name));
@@ -931,6 +1192,24 @@ function getManifestEntry(
   return manifest?.services.find(entry => entry.name === serviceName);
 }
 
+/**
+ * Liveness for a service that listens on no port (tunnels, stripe).
+ *
+ * `pane_current_command` used to answer this and reported `zsh` — the start
+ * wrapper — as "not running" while the service was alive. For tunnels the
+ * captured public URL is the source of truth: cloudflared stays in the pane
+ * tree while it retries a hostname that no longer resolves. Stripe and a
+ * tunnel that has not captured yet fall back to the process tree.
+ */
+async function isPortlessServiceUp(
+  repoRoot: string,
+  sessionName: string,
+  serviceName: string,
+  pane: PaneInfo
+): Promise<boolean> {
+  return isPortlessServiceHealthy(repoRoot, serviceName, paneHasRunningService(sessionName, pane));
+}
+
 async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
   const sessionName = getSessionName();
   const manifest = readManifest(repoRoot);
@@ -970,7 +1249,10 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
         name === 'nextjs'
           ? (readNextjsDevPort(repoRoot) ?? manifestEntry?.port ?? svc.port)
           : (manifestEntry?.port ?? svc.port);
-      const isUp = port === 0 ? isPaneRunningCommand(sessionName, pane) : await probePort(port);
+      const isUp =
+        port === 0
+          ? await isPortlessServiceUp(repoRoot, sessionName, name, pane)
+          : await probePort(port);
       const status: ServiceStatus = isUp ? 'up' : 'down';
       return {
         name,
@@ -981,8 +1263,20 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
     })
   );
 
+  // A foreign compose project on our infra ports is why an infra service reads
+  // down here and why the next dev:start fails on "port already allocated".
+  const warnings = collidingInfraPorts(
+    repoRoot,
+    runningServices.map(service => service.name)
+  );
+
   if (isJson) {
-    const result = { session: sessionName, portOffset: statusPortOffset, services: entries };
+    const result = {
+      session: sessionName,
+      portOffset: statusPortOffset,
+      services: entries,
+      ...(warnings.length > 0 ? { warnings } : {}),
+    };
     console.log(JSON.stringify(result));
     return;
   }
@@ -994,6 +1288,7 @@ async function cmdStatus(repoRoot: string, isJson = false): Promise<void> {
     const portStr = e.port > 0 ? `:${e.port}` : 'n/a';
     console.log(`${e.name.padEnd(nameWidth)}  ${portStr.padEnd(portWidth)}  ${e.status}`);
   }
+  for (const line of warnings) console.warn(`⚠ ${line}`);
 }
 
 // Metro's jest-haste-map cache ($TMPDIR/metro-file-map-*) persists per project
@@ -1019,6 +1314,44 @@ function clearStaleMetroFileMaps(repoRoot: string): void {
       // Another worktree's file or a race with Metro — leave it.
     }
   }
+}
+
+/**
+ * Print the exact command that starts a service, env prefix included.
+ *
+ * Typing a bare `pnpm run dev` in a service pane is not a restart: worker
+ * commands carry `CLOUDFLARE_HYPERDRIVE_LOCAL_CONNECTION_STRING_*`, without
+ * which wrangler dials the default :5432 — another worktree's postgres, or
+ * nothing. Prefer `dev:restart`; use this when the pane must be driven by hand.
+ */
+function cmdStartCommand(serviceName: string, repoRoot: string): void {
+  if (!services.has(serviceName)) {
+    console.error(`Unknown service: ${serviceName}`);
+    process.exit(1);
+  }
+  const svc = getService(serviceName);
+  if (svc.type === 'infra') {
+    console.error(`${serviceName} is an infrastructure service; use docker compose`);
+    process.exit(1);
+  }
+
+  // The printed line bakes in ports and the Hyperdrive URLs of *this* offset.
+  // Printing a line for a different stack than the one running would recreate
+  // the bug this command exists to prevent, so refuse instead.
+  const manifest = readManifest(repoRoot);
+  if (manifest && manifest.portOffset !== portOffset) {
+    console.error(
+      `Port offset mismatch: this shell resolves ${portOffset}, the running stack uses ${manifest.portOffset}.\n` +
+        `Re-run with KILO_PORT_OFFSET=${manifest.portOffset} to print the command for the running stack.`
+    );
+    process.exit(1);
+  }
+
+  // `pnpm --filter {./dir}` resolves the filter against the cwd, so the repo
+  // root has to be explicit; commands that already cd into the service dir
+  // must not be prefixed twice.
+  const command = buildStartCommand(serviceName);
+  console.log(command.startsWith('cd ') ? command : `cd ${shellQuote(repoRoot)} && ${command}`);
 }
 
 async function cmdRestart(serviceName: string, repoRoot: string): Promise<void> {
@@ -1054,6 +1387,11 @@ async function cmdRestart(serviceName: string, repoRoot: string): Promise<void> 
     clearStaleMetroFileMaps(repoRoot);
   }
 
+  const previousTunnels =
+    serviceName === 'cloud-agent-public-tunnels'
+      ? snapshotCloudAgentPublicTunnelEnv(repoRoot)
+      : undefined;
+
   console.log(`Restarting ${serviceName} (waiting for the old process to shut down)...`);
   const outcome = await restartServiceInTmux(sessionName, serviceName, restartEnv);
   if (outcome === 'gave-up') {
@@ -1061,6 +1399,28 @@ async function cmdRestart(serviceName: string, repoRoot: string): Promise<void> 
     process.exit(1);
   }
   console.log(`Restarted ${serviceName}`);
+
+  if (previousTunnels === undefined) return;
+  console.log('Waiting for new public tunnel URLs...');
+  const captured = await waitForCloudAgentPublicTunnelCapture(
+    repoRoot,
+    previousTunnels,
+    CAPTURE_TIMEOUT_MS
+  );
+  if (!captured) {
+    console.warn(
+      'Public tunnel URLs were not recaptured. cloud-agent-next still has the previous WORKER_URL.'
+    );
+    return;
+  }
+  if (!findServicePane(sessionName, 'cloud-agent-next')) return;
+  console.log('Reloading cloud-agent-next with the new tunnel URLs...');
+  const workerOutcome = await restartServiceInTmux(sessionName, 'cloud-agent-next');
+  if (workerOutcome === 'gave-up') {
+    console.warn('cloud-agent-next did not restart with the new tunnel URLs');
+    return;
+  }
+  console.log('Reloaded cloud-agent-next');
 }
 
 function cmdCapture(serviceName: string, linesArg: string | undefined): void {
@@ -1113,7 +1473,13 @@ async function cmdStop(repoRoot: string, force: boolean): Promise<void> {
       const [cmd, args] = buildInfraDownArgs();
       execFileSync(cmd, args, { cwd: repoRoot, stdio: 'inherit' });
     } catch {
-      // docker compose down may fail if nothing is running
+      // Nothing running is the common case and harmless. A real failure leaves
+      // containers holding this offset's ports with the claim already released,
+      // so say so instead of reporting a clean stop.
+      console.warn(
+        '⚠ docker compose down did not complete — containers may still hold this offset.'
+      );
+      console.warn('  Check with: docker compose -f dev/docker-compose.yml ps');
     }
   }
 
@@ -1160,6 +1526,9 @@ Usage:
                           other kilo-dev sessions are running; --force overrides)
   dev:status [--json]     Show running services and their ports
   dev:restart <service>   Restart a running service
+  dev:start-command <service>
+                          Print the full start command (env prefix included) for
+                          driving a service pane by hand
   dev:capture <service> [lines]
                           Capture a service pane wherever the dashboard moved it
   dev:capture <service> --follow <file>
@@ -1193,7 +1562,17 @@ async function main() {
           () => cmdUp(args.slice(1), repoRoot),
           1_200_000
         );
-        if (sessionToAttach) attachSession(sessionToAttach);
+        if (sessionToAttach) {
+          if (process.stdin.isTTY) {
+            attachSession(sessionToAttach);
+          } else {
+            // tmux needs a controlling terminal; without one `attach-session`
+            // exits non-zero and the started services look like a failed start.
+            console.log(
+              `Not a TTY; services are running. Attach with: tmux attach -t ${sessionToAttach}`
+            );
+          }
+        }
       }
       break;
     case 'stop':
@@ -1214,6 +1593,15 @@ async function main() {
         process.exit(1);
       }
       await cmdRestart(serviceName, repoRoot);
+      break;
+    }
+    case 'start-command': {
+      const serviceName = args[1];
+      if (!serviceName) {
+        console.error('Usage: dev:start-command <service>');
+        process.exit(1);
+      }
+      cmdStartCommand(serviceName, repoRoot);
       break;
     }
     case 'capture': {

--- a/dev/local/compose-port-owner.test.ts
+++ b/dev/local/compose-port-owner.test.ts
@@ -1,0 +1,51 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  describeForeignPortOwners,
+  foreignPortOwners,
+  parsePortOwners,
+} from './compose-port-owner';
+
+const DOCKER_PS = [
+  'kilo-dev-session-agent-2500\tkilo-dev-session-agent-2500-postgres-1\t0.0.0.0:7932->5432/tcp, [::]:7932->5432/tcp',
+  'kilo-dev-sticky-slider-2500\tkilo-dev-sticky-slider-2500-redis-1\t0.0.0.0:8879->6379/tcp',
+  '\tstandalone-container\t0.0.0.0:9000->9000/tcp',
+  'kilo-dev-other-0\tno-published-ports\t5432/tcp',
+  'malformed line without tabs',
+].join('\n');
+
+test('parsePortOwners reads published host ports once per container', () => {
+  assert.deepEqual(parsePortOwners(DOCKER_PS), [
+    {
+      port: 7932,
+      project: 'kilo-dev-session-agent-2500',
+      container: 'kilo-dev-session-agent-2500-postgres-1',
+    },
+    {
+      port: 8879,
+      project: 'kilo-dev-sticky-slider-2500',
+      container: 'kilo-dev-sticky-slider-2500-redis-1',
+    },
+    { port: 9000, project: '(no project)', container: 'standalone-container' },
+  ]);
+});
+
+test('foreignPortOwners reports only ports held by another compose project', () => {
+  const owners = parsePortOwners(DOCKER_PS);
+
+  assert.deepEqual(
+    foreignPortOwners([7932, 8879], 'kilo-dev-sticky-slider-2500', owners).map(o => o.port),
+    [7932]
+  );
+  assert.deepEqual(foreignPortOwners([5432], 'kilo-dev-sticky-slider-2500', owners), []);
+});
+
+test('describeForeignPortOwners names the owner and the way out', () => {
+  const [message] = describeForeignPortOwners(
+    foreignPortOwners([7932], 'kilo-dev-sticky-slider-2500', parsePortOwners(DOCKER_PS))
+  );
+
+  assert.match(message, /port 7932 is held by container kilo-dev-session-agent-2500-postgres-1/);
+  assert.match(message, /docker compose -p kilo-dev-session-agent-2500 down/);
+});

--- a/dev/local/compose-port-owner.ts
+++ b/dev/local/compose-port-owner.ts
@@ -1,0 +1,78 @@
+import { execFileSync } from 'node:child_process';
+
+/**
+ * Which docker compose project holds a published host port.
+ *
+ * Offsets collide across worktrees: a *different* compose project
+ * (`kilo-dev-<other-slug>-2500`) can keep this offset's postgres port after
+ * `dev:stop`, and `docker compose up` then fails with a bare "port is already
+ * allocated" that names neither the port's owner nor the fix.
+ */
+
+type PortOwner = {
+  port: number;
+  project: string;
+  container: string;
+};
+
+/** `docker ps --format '{{.Label "com.docker.compose.project"}}\t{{.Names}}\t{{.Ports}}'` */
+function parsePortOwners(output: string): PortOwner[] {
+  const owners: PortOwner[] = [];
+  for (const line of output.split('\n')) {
+    const [project, container, ports] = line.split('\t');
+    if (!container || !ports) continue;
+    // "0.0.0.0:7932->5432/tcp, [::]:7932->5432/tcp" — published host ports only.
+    for (const match of ports.matchAll(/(?:^|[\s,])(?:[\d.]+|\[[^\]]+\]):(\d+)->/g)) {
+      const port = Number(match[1]);
+      if (owners.some(owner => owner.port === port && owner.container === container)) continue;
+      owners.push({
+        port,
+        project: project === '' ? '(no project)' : project,
+        container,
+      });
+    }
+  }
+  return owners;
+}
+
+/**
+ * `undefined` when docker did not answer — a stopped or wedged daemon. That is
+ * not the same as "no container holds this port", and a caller that decides
+ * ownership must not read an empty list as proof that nobody owns anything.
+ */
+function listPortOwners(): PortOwner[] | undefined {
+  try {
+    return parsePortOwners(
+      execFileSync(
+        'docker',
+        ['ps', '--format', '{{.Label "com.docker.compose.project"}}\t{{.Names}}\t{{.Ports}}'],
+        // A wedged (not stopped) daemon must not hang `dev:status`, which
+        // agents poll in loops.
+        { encoding: 'utf-8', timeout: 2000 }
+      )
+    );
+  } catch {
+    return undefined; // no docker, or the daemon is down
+  }
+}
+
+/** Ports among `ports` published by a container of some other compose project. */
+function foreignPortOwners(
+  ports: number[],
+  ownProject: string,
+  owners: PortOwner[] = listPortOwners() ?? []
+): PortOwner[] {
+  const wanted = new Set(ports);
+  return owners.filter(owner => wanted.has(owner.port) && owner.project !== ownProject);
+}
+
+function describeForeignPortOwners(owners: PortOwner[]): string[] {
+  return owners.map(
+    owner =>
+      `port ${owner.port} is held by container ${owner.container} of compose project ${owner.project}` +
+      ` — free it with: docker compose -p ${owner.project} down`
+  );
+}
+
+export { describeForeignPortOwners, foreignPortOwners, listPortOwners, parsePortOwners };
+export type { PortOwner };

--- a/dev/local/dashboard.tsx
+++ b/dev/local/dashboard.tsx
@@ -33,7 +33,6 @@ import {
   ensureDeadServiceLogPipes,
   snapshotCloudAgentPublicTunnelEnv,
   waitForCloudAgentPublicTunnelCapture,
-  cloudAgentDevVarsPath,
 } from './runner';
 import { isPortlessServiceHealthy, readCapturedTunnelUrl } from './tunnel-health';
 
@@ -321,7 +320,9 @@ function Dashboard({
   const [selectedIdx, setSelectedIdx] = useState(0);
   const [stackIssues, setStackIssues] = useState<string[]>([]);
   const refreshInFlight = useRef(false);
-  const lastWorkerUrl = useRef<string | undefined>(undefined);
+  const lastPublicTunnelSnapshot = useRef<
+    ReturnType<typeof snapshotCloudAgentPublicTunnelEnv> | undefined
+  >(undefined);
   const reloadingWorker = useRef(false);
   const lastTunnelProbe = useRef(new Map<string, { at: number; up: boolean }>());
   const [, bumpViewedRevision] = useState(0);
@@ -440,21 +441,31 @@ function Dashboard({
         if (repairedPipes.length > 0) {
           issues.push(`reattached logs: ${repairedPipes.join(', ')}`);
         }
-        const workerUrl = readEnvValue(cloudAgentDevVarsPath(repoRoot), 'WORKER_URL');
+        const publicTunnelSnapshot = snapshotCloudAgentPublicTunnelEnv(repoRoot);
+        const previousPublicTunnelSnapshot = lastPublicTunnelSnapshot.current;
         if (
-          lastWorkerUrl.current !== undefined &&
-          workerUrl !== undefined &&
-          workerUrl !== lastWorkerUrl.current &&
+          previousPublicTunnelSnapshot?.values.WORKER_URL !== undefined &&
+          publicTunnelSnapshot.values.WORKER_URL !== undefined &&
+          publicTunnelSnapshot.values.WORKER_URL !==
+            previousPublicTunnelSnapshot.values.WORKER_URL &&
           runningServices.has('cloud-agent-next') &&
           !reloadingWorker.current
         ) {
           reloadingWorker.current = true;
           issues.push('reloading worker for new tunnel URL');
-          void restartServiceInTmux(sessionName, 'cloud-agent-next').finally(() => {
-            reloadingWorker.current = false;
-          });
+          void waitForCloudAgentPublicTunnelCapture(
+            repoRoot,
+            previousPublicTunnelSnapshot,
+            CAPTURE_TIMEOUT_MS
+          )
+            .then(captured =>
+              captured ? restartServiceInTmux(sessionName, 'cloud-agent-next') : undefined
+            )
+            .finally(() => {
+              reloadingWorker.current = false;
+            });
         }
-        lastWorkerUrl.current = workerUrl;
+        lastPublicTunnelSnapshot.current = publicTunnelSnapshot;
         setStackIssues(prev => {
           if (prev.length === issues.length && prev.every((item, i) => item === issues[i])) {
             return prev;
@@ -775,33 +786,36 @@ function Dashboard({
         void restartServiceInTmux(sessionName, item.name);
         return;
       }
+      if (reloadingWorker.current) return;
       const previous = snapshotCloudAgentPublicTunnelEnv(repoRoot);
+      reloadingWorker.current = true;
       void (async () => {
-        const outcome = await restartServiceInTmux(sessionName, item.name);
-        if (outcome === 'gave-up') {
-          setStackIssues(['tunnels: restart did not finish']);
-          return;
-        }
-        const captured = await waitForCloudAgentPublicTunnelCapture(
-          repoRoot,
-          previous,
-          CAPTURE_TIMEOUT_MS
-        );
-        if (!captured) {
-          setStackIssues(['tunnels: no new public URL captured']);
-          return;
-        }
-        if (
-          !runningServices.has('cloud-agent-next') &&
-          !findServicePane(sessionName, 'cloud-agent-next')
-        ) {
-          return;
-        }
-        reloadingWorker.current = true;
-        setStackIssues(['reloading worker for new tunnel URL']);
-        await restartServiceInTmux(sessionName, 'cloud-agent-next').finally(() => {
+        try {
+          const outcome = await restartServiceInTmux(sessionName, item.name);
+          if (outcome === 'gave-up') {
+            setStackIssues(['tunnels: restart did not finish']);
+            return;
+          }
+          const captured = await waitForCloudAgentPublicTunnelCapture(
+            repoRoot,
+            previous,
+            CAPTURE_TIMEOUT_MS
+          );
+          if (!captured) {
+            setStackIssues(['tunnels: no new public URL captured']);
+            return;
+          }
+          if (
+            !runningServices.has('cloud-agent-next') &&
+            !findServicePane(sessionName, 'cloud-agent-next')
+          ) {
+            return;
+          }
+          setStackIssues(['reloading worker for new tunnel URL']);
+          await restartServiceInTmux(sessionName, 'cloud-agent-next');
+        } finally {
           reloadingWorker.current = false;
-        });
+        }
       })();
       return;
     }

--- a/dev/local/dashboard.tsx
+++ b/dev/local/dashboard.tsx
@@ -11,7 +11,13 @@ import {
   resolveGroupTransitiveDeps,
 } from './services';
 import type { ServiceGroup } from './services';
-import { getSessionName, killSession, findOtherKiloDevSessions } from './tmux';
+import {
+  getSessionName,
+  killSession,
+  findOtherKiloDevSessions,
+  findServicePane,
+  paneHasRunningService,
+} from './tmux';
 import {
   findRepoRoot,
   probePort,
@@ -24,7 +30,12 @@ import {
   readEnvValue,
   readEnvMtime,
   waitForEnvValueChange,
+  ensureDeadServiceLogPipes,
+  snapshotCloudAgentPublicTunnelEnv,
+  waitForCloudAgentPublicTunnelCapture,
+  cloudAgentDevVarsPath,
 } from './runner';
+import { isPortlessServiceHealthy, readCapturedTunnelUrl } from './tunnel-health';
 
 // ---------------------------------------------------------------------------
 // Types & constants
@@ -50,6 +61,7 @@ type ViewedTarget =
   | null;
 
 const REFRESH_MS = 2000;
+const TUNNEL_REFRESH_MS = 15_000;
 const STARTING_GRACE_MS = 30_000;
 const START_DELAY_MS = 300;
 const SIDEBAR_WIDTH = 40;
@@ -307,6 +319,11 @@ function Dashboard({
     () => new Map(initialServiceNames.map(n => [n, 'starting' as const]))
   );
   const [selectedIdx, setSelectedIdx] = useState(0);
+  const [stackIssues, setStackIssues] = useState<string[]>([]);
+  const refreshInFlight = useRef(false);
+  const lastWorkerUrl = useRef<string | undefined>(undefined);
+  const reloadingWorker = useRef(false);
+  const lastTunnelProbe = useRef(new Map<string, { at: number; up: boolean }>());
   const [, bumpViewedRevision] = useState(0);
 
   const viewedRef = useRef<ViewedTarget>(
@@ -371,25 +388,85 @@ function Dashboard({
   // --- Status polling ---
   useEffect(() => {
     const refresh = async () => {
-      const servicesToProbe = [...runningServices];
-      if (servicesToProbe.length === 0) return;
+      if (refreshInFlight.current) return;
+      refreshInFlight.current = true;
+      try {
+        const servicesToProbe = [...runningServices];
+        if (servicesToProbe.length === 0) return;
 
-      const inGrace = Date.now() - startTimeRef.current < STARTING_GRACE_MS;
-      const entries = await Promise.all(
-        servicesToProbe.map(async (name): Promise<[string, ServiceStatus]> => {
-          const svc = getService(name);
-          if (svc.port === 0) return [name, 'up'];
-          const up = await probePort(svc.port);
-          return [name, up ? 'up' : inGrace ? 'starting' : 'down'];
-        })
-      );
-      setStatuses(prev => {
-        const changed = entries.some(([name, status]) => prev.get(name) !== status);
-        if (!changed) return prev;
-        return new Map(entries);
-      });
+        const repairedPipes = ensureDeadServiceLogPipes(sessionName, servicesToProbe);
+        const inGrace = Date.now() - startTimeRef.current < STARTING_GRACE_MS;
+        const entries = await Promise.all(
+          servicesToProbe.map(async (name): Promise<[string, ServiceStatus]> => {
+            const svc = getService(name);
+            if (svc.port === 0) {
+              const pane = findServicePane(sessionName, name);
+              const paneAlive = pane !== undefined && paneHasRunningService(sessionName, pane);
+              const url = readCapturedTunnelUrl(repoRoot, name);
+              let up: boolean;
+              if (url === undefined) {
+                up = paneAlive;
+              } else {
+                const now = Date.now();
+                const cached = lastTunnelProbe.current.get(url);
+                if (cached !== undefined && now - cached.at < TUNNEL_REFRESH_MS) {
+                  up = cached.up;
+                } else {
+                  up = await isPortlessServiceHealthy(repoRoot, name, paneAlive, 1500);
+                  lastTunnelProbe.current.set(url, { at: now, up });
+                }
+              }
+              return [name, up ? 'up' : inGrace ? 'starting' : 'down'];
+            }
+            const up = await probePort(svc.port);
+            return [name, up ? 'up' : inGrace ? 'starting' : 'down'];
+          })
+        );
+        setStatuses(prev => {
+          const changed = entries.some(([name, status]) => prev.get(name) !== status);
+          if (!changed) return prev;
+          return new Map(entries);
+        });
+
+        const issues: string[] = [];
+        const down = entries.filter(([, status]) => status === 'down').map(([name]) => name);
+        if (down.includes('cloud-agent-public-tunnels')) {
+          issues.push('tunnels: public URL is down');
+        }
+        for (const name of down) {
+          if (name === 'cloud-agent-public-tunnels') continue;
+          issues.push(`${name} is down`);
+        }
+        if (repairedPipes.length > 0) {
+          issues.push(`reattached logs: ${repairedPipes.join(', ')}`);
+        }
+        const workerUrl = readEnvValue(cloudAgentDevVarsPath(repoRoot), 'WORKER_URL');
+        if (
+          lastWorkerUrl.current !== undefined &&
+          workerUrl !== undefined &&
+          workerUrl !== lastWorkerUrl.current &&
+          runningServices.has('cloud-agent-next') &&
+          !reloadingWorker.current
+        ) {
+          reloadingWorker.current = true;
+          issues.push('reloading worker for new tunnel URL');
+          void restartServiceInTmux(sessionName, 'cloud-agent-next').finally(() => {
+            reloadingWorker.current = false;
+          });
+        }
+        lastWorkerUrl.current = workerUrl;
+        setStackIssues(prev => {
+          if (prev.length === issues.length && prev.every((item, i) => item === issues[i])) {
+            return prev;
+          }
+          return issues;
+        });
+      } finally {
+        refreshInFlight.current = false;
+      }
     };
     void refresh().catch(error => {
+      refreshInFlight.current = false;
       console.error('Failed to refresh service statuses:', error);
     });
     const timer = setInterval(refresh, REFRESH_MS);
@@ -694,7 +771,38 @@ function Dashboard({
       const item = sidebarItems[selectedIdx];
       if (!item || item.kind !== 'service') return;
       if (!runningServices.has(item.name)) return;
-      void restartServiceInTmux(sessionName, item.name);
+      if (item.name !== 'cloud-agent-public-tunnels') {
+        void restartServiceInTmux(sessionName, item.name);
+        return;
+      }
+      const previous = snapshotCloudAgentPublicTunnelEnv(repoRoot);
+      void (async () => {
+        const outcome = await restartServiceInTmux(sessionName, item.name);
+        if (outcome === 'gave-up') {
+          setStackIssues(['tunnels: restart did not finish']);
+          return;
+        }
+        const captured = await waitForCloudAgentPublicTunnelCapture(
+          repoRoot,
+          previous,
+          CAPTURE_TIMEOUT_MS
+        );
+        if (!captured) {
+          setStackIssues(['tunnels: no new public URL captured']);
+          return;
+        }
+        if (
+          !runningServices.has('cloud-agent-next') &&
+          !findServicePane(sessionName, 'cloud-agent-next')
+        ) {
+          return;
+        }
+        reloadingWorker.current = true;
+        setStackIssues(['reloading worker for new tunnel URL']);
+        await restartServiceInTmux(sessionName, 'cloud-agent-next').finally(() => {
+          reloadingWorker.current = false;
+        });
+      })();
       return;
     }
     if (input === 'q') {
@@ -789,7 +897,7 @@ function Dashboard({
 
   // --- Scrolling ---
   const headerCount = 2;
-  const footerCount = 1;
+  const footerCount = stackIssues.length > 0 ? 2 : 1;
   const visibleCount = Math.max(1, rows - headerCount - footerCount);
   if (selectedIdx >= scrollRef.current + visibleCount) {
     scrollRef.current = selectedIdx - visibleCount + 1;
@@ -843,6 +951,14 @@ function Dashboard({
         })}
       </Box>
 
+      {stackIssues.length > 0 && (
+        <Text color="yellow">
+          {' '}
+          {stackIssues[0].length > SIDEBAR_WIDTH - 1
+            ? `${stackIssues[0].slice(0, SIDEBAR_WIDTH - 2)}\u2026`
+            : stackIssues[0]}
+        </Text>
+      )}
       <Text dimColor>
         {' '}
         {'\u2191\u2193'} navigate {'\u23ce'} view/start space stop r restart q quit

--- a/dev/local/env-sync/plan.test.ts
+++ b/dev/local/env-sync/plan.test.ts
@@ -928,6 +928,39 @@ test('preserves host.docker.internal in @url defaults for useLanIp services', ()
   }
 });
 
+test('does not overwrite existing public sandbox tunnel URLs', () => {
+  const repo = createRepo({
+    '.env.local': '',
+    [`${workerDir}/package.json`]: JSON.stringify(
+      { scripts: { dev: "wrangler dev --env 'dev'" } },
+      null,
+      2
+    ),
+    [`${workerDir}/wrangler.jsonc`]: '{ "dev": { "port": 8794 } }',
+    [`${workerDir}/.dev.vars.example`]: [
+      '# @url nextjs',
+      'KILOCODE_BACKEND_BASE_URL=http://localhost:3000',
+      '# @url nextjs/api',
+      'KILO_OPENROUTER_BASE=http://localhost:3000/api',
+      '',
+    ].join('\n'),
+    [`${workerDir}/.dev.vars`]: [
+      'KILOCODE_BACKEND_BASE_URL=https://backend.trycloudflare.com',
+      'KILO_OPENROUTER_BASE=https://backend.trycloudflare.com/api',
+      '',
+    ].join('\n'),
+  });
+  try {
+    const plan = computePlan(repo.root, new Set(['cloud-agent-next']));
+    assert.equal(plan.missingEnvLocal, false);
+    const change = plan.devVarsChanges.find(item => item.workerDir === workerDir);
+    assert.ok(!change?.keyChanges.some(item => item.key === 'KILOCODE_BACKEND_BASE_URL'));
+    assert.ok(!change?.keyChanges.some(item => item.key === 'KILO_OPENROUTER_BASE'));
+  } finally {
+    repo.cleanup();
+  }
+});
+
 test('preserves localhost in worker-side @url defaults for useLanIp services', () => {
   const repo = createRepo({
     '.env.local': '',

--- a/dev/local/env-sync/plan.ts
+++ b/dev/local/env-sync/plan.ts
@@ -44,6 +44,7 @@ const GENERATED_LOCAL_SECRET_KEYS = new Set([
   'CALLBACK_TOKEN_SECRET',
   'BYOK_ENCRYPTION_KEY',
 ]);
+const PUBLIC_SANDBOX_TUNNEL_HOST = /\.trycloudflare\.com(?:\/|$)/i;
 
 function createFlyTokenAutoCreate(flyOrgSlug: string): EnvLocalAutoCreate {
   return {
@@ -725,6 +726,7 @@ function computePlan(
         const source = resolvedSources.get(key);
         if (key === FLY_TOKEN_ENV_KEY && shouldCreateFlyToken) continue;
         if (oldVal && source === 'default') continue;
+        if (oldVal && PUBLIC_SANDBOX_TUNNEL_HOST.test(oldVal)) continue;
         if (oldVal !== newVal) {
           keyChanges.push({ key, oldValue: oldVal, newValue: newVal });
         }

--- a/dev/local/infra-env.test.ts
+++ b/dev/local/infra-env.test.ts
@@ -9,6 +9,8 @@ import {
   buildAppEnv,
   buildComposeEnv,
   composeProjectName,
+  currentComposeProject,
+  DEFAULT_COMPOSE_PROJECT,
   syncInfraEnv,
 } from './infra-env';
 import { applyPortOffset, portOffset } from './services';
@@ -102,4 +104,13 @@ test('leaves a value that already names the target host and port', () => {
   assert.deepEqual(kept, []);
   assert.ok(!changed.includes('POSTGRES_URL'));
   assert.equal(content.split('\n')[0], before.trim());
+});
+
+test('currentComposeProject names the project compose really uses', () => {
+  // At offset 0 no dev/.env is written, so compose falls back to the basename
+  // of its project directory. `composeProjectName(root, 0)` names a project no
+  // container ever carries — comparing against it makes a checkout's own
+  // database look like another worktree's squatter.
+  assert.equal(currentComposeProject('/repo/kilo', 0), DEFAULT_COMPOSE_PROJECT);
+  assert.equal(currentComposeProject('/repo/kilo', 2500), 'kilo-dev-kilo-2500');
 });

--- a/dev/local/infra-env.ts
+++ b/dev/local/infra-env.ts
@@ -49,6 +49,19 @@ export function composeProjectName(worktreeRoot: string, offset: number): string
   return `kilo-dev-${slug}-${offset}`;
 }
 
+/**
+ * Compose's own default project name: the basename of the project directory,
+ * which for `docker compose -f dev/docker-compose.yml` is `dev/`. The primary
+ * checkout publishes no `dev/.env`, so this is the project its containers
+ * really carry — `composeProjectName(root, 0)` names a project nothing uses.
+ */
+export const DEFAULT_COMPOSE_PROJECT = 'dev';
+
+/** The project label this worktree's containers carry at `offset`. */
+export function currentComposeProject(worktreeRoot: string, offset: number): string {
+  return offset === 0 ? DEFAULT_COMPOSE_PROJECT : composeProjectName(worktreeRoot, offset);
+}
+
 export function buildComposeEnv(
   project: string,
   ports: Record<string, number>

--- a/dev/local/port-offset-lease.test.ts
+++ b/dev/local/port-offset-lease.test.ts
@@ -11,6 +11,7 @@ import {
   releasePortOffsetClaims,
 } from './cli';
 import { acquireProcessLock } from './process-lock';
+import { currentComposeProject } from './infra-env';
 import { applyPortOffset, portOffset } from './services';
 
 test('reuses a running stack only when every requested service is live', async () => {
@@ -72,11 +73,10 @@ test('reuse waits through the normal service boot window', async () => {
 
 test('port conflict scan includes worker inspector ports', async () => {
   let probes = 0;
-  const result = await findPortConflicts(
-    ['event-service'],
-    async () => ++probes === 2,
-    async () => false
-  );
+  const result = await findPortConflicts(['event-service'], {
+    portProbe: async () => ++probes === 2,
+    dockerProbe: async () => false,
+  });
   assert.equal(probes, 2);
   assert.match(result.conflicts[0], /^event-service-inspector:/);
 });
@@ -233,6 +233,148 @@ test('does not abort claim cleanup when removing a claim fails', async () => {
       throw new Error('read-only filesystem');
     });
   } finally {
+    fs.rmSync(leases, { recursive: true, force: true });
+  }
+});
+
+test('infra ports count as conflicts unless this worktree already owns them', async () => {
+  const initialOffset = portOffset;
+  try {
+    applyPortOffset(2500);
+    const occupied = async () => true;
+
+    const foreign = await findPortConflicts(['postgres'], {
+      portProbe: occupied,
+      ownProject: 'kilo-dev-sticky-slider-2500',
+      portOwners: [
+        { port: 7932, project: 'kilo-dev-other-2500', container: 'kilo-dev-other-2500-postgres-1' },
+      ],
+    });
+    assert.deepEqual(foreign.conflicts, ['postgres:7932']);
+    assert.deepEqual(foreign.infraConflicts, ['postgres:7932']);
+    assert.deepEqual(
+      foreign.foreignInfraOwners?.map(owner => owner.project),
+      ['kilo-dev-other-2500']
+    );
+
+    const ours = await findPortConflicts(['postgres'], {
+      portProbe: occupied,
+      ownProject: 'kilo-dev-sticky-slider-2500',
+      portOwners: [
+        {
+          port: 7932,
+          project: 'kilo-dev-sticky-slider-2500',
+          container: 'kilo-dev-sticky-slider-2500-postgres-1',
+        },
+      ],
+    });
+    assert.deepEqual(ours.conflicts, []);
+
+    // Occupied by something Docker does not own: still a conflict, and no
+    // owner to name in the message.
+    const stranger = await findPortConflicts(['postgres'], {
+      portProbe: occupied,
+      ownProject: 'kilo-dev-sticky-slider-2500',
+      portOwners: [],
+    });
+    assert.deepEqual(stranger.conflicts, ['postgres:7932']);
+    assert.deepEqual(stranger.foreignInfraOwners, []);
+
+    // No snapshot at all — a stopped or wedged docker daemon. Ownership is
+    // unknowable, so the infra port is left to the compose error rather than
+    // blocking a start that has nothing wrong with it.
+    const noSnapshot = await findPortConflicts(['postgres'], {
+      portProbe: occupied,
+      ownProject: 'kilo-dev-sticky-slider-2500',
+    });
+    assert.deepEqual(noSnapshot.conflicts, []);
+  } finally {
+    applyPortOffset(initialOffset);
+  }
+});
+
+test('the primary checkout does not mistake its own default project for a squatter', async () => {
+  const initialOffset = portOffset;
+  try {
+    applyPortOffset(0);
+    const scan = await findPortConflicts(['postgres'], {
+      portProbe: async () => true,
+      ownProject: currentComposeProject('/repo', 0),
+      portOwners: [{ port: 5432, project: 'dev', container: 'dev-postgres-1' }],
+    });
+    assert.deepEqual(scan.conflicts, []);
+  } finally {
+    applyPortOffset(initialOffset);
+  }
+});
+
+test('an occupied infra port on the persisted offset stops the start instead of moving it', async () => {
+  const leases = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-port-lease-'));
+  const initialOffset = portOffset;
+  try {
+    applyPortOffset(3000);
+    let scans = 0;
+    await assert.rejects(
+      acquirePortOffsetLease(
+        [],
+        false,
+        '/worktree/one',
+        'missing-session-one',
+        leases,
+        async () => {
+          scans++;
+          return {
+            conflicts: ['postgres:8432'],
+            infraConflicts: ['postgres:8432'],
+            foreignInfraOwners: [
+              { port: 8432, project: 'kilo-dev-other-3000', container: 'other-postgres-1' },
+            ],
+            reusedHostServices: new Set<string>(),
+          };
+        },
+        3000
+      ),
+      /holds this stack's database[\s\S]*kilo-dev-other-3000[\s\S]*KILO_PORT_OFFSET/
+    );
+    // Stopped at the persisted offset rather than walking 50 candidates.
+    assert.equal(scans, 1);
+  } finally {
+    applyPortOffset(initialOffset);
+    fs.rmSync(leases, { recursive: true, force: true });
+  }
+});
+
+test('an infra conflict away from the persisted offset just moves on', async () => {
+  const leases = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-port-lease-'));
+  const initialOffset = portOffset;
+  try {
+    applyPortOffset(3000);
+    let scans = 0;
+    await acquirePortOffsetLease(
+      [],
+      false,
+      '/worktree/one',
+      'missing-session-one',
+      leases,
+      async () => {
+        scans++;
+        return scans === 1
+          ? {
+              conflicts: ['postgres:8432'],
+              infraConflicts: ['postgres:8432'],
+              foreignInfraOwners: [],
+              reusedHostServices: new Set<string>(),
+            }
+          : { conflicts: [], reusedHostServices: new Set<string>() };
+      },
+      // No persisted offset: nothing of this worktree's lives at 3000 yet.
+      undefined
+    );
+    assert.equal(scans, 2);
+    assert.equal(portOffset, 3100);
+    await releasePortOffsetClaims('/worktree/one', 'missing-session-one', leases);
+  } finally {
+    applyPortOffset(initialOffset);
     fs.rmSync(leases, { recursive: true, force: true });
   }
 });

--- a/dev/local/process-tree.test.ts
+++ b/dev/local/process-tree.test.ts
@@ -1,0 +1,77 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  hasNonShellDescendant,
+  isShellCommand,
+  parseProcessTable,
+  snapshotProcessTable,
+} from './process-tree';
+
+test('parseProcessTable reads pid/ppid/comm columns and skips noise', () => {
+  const rows = parseProcessTable(
+    ['  501     1 /bin/zsh', '42371 42000 -zsh', 'header junk', '', ' 44496 42371 node'].join('\n')
+  );
+
+  assert.deepEqual(rows, [
+    { pid: 501, ppid: 1, command: '/bin/zsh' },
+    { pid: 42371, ppid: 42000, command: '-zsh' },
+    { pid: 44496, ppid: 42371, command: 'node' },
+  ]);
+});
+
+test('isShellCommand ignores login dashes and absolute paths', () => {
+  assert.ok(isShellCommand('-zsh'));
+  assert.ok(isShellCommand('/bin/zsh'));
+  assert.ok(isShellCommand(' sh '));
+  assert.ok(!isShellCommand('node'));
+  assert.ok(!isShellCommand('/opt/homebrew/bin/cloudflared'));
+  assert.ok(!isShellCommand('shell-service')); // basename must match exactly
+});
+
+test('a pane whose only children are leftover shells counts as idle', () => {
+  // The §1 repro: wrangler exited, ctrl-c left a second login shell under the
+  // pane shell. Restart used to read this as "still shutting down" for 60s.
+  const rows = parseProcessTable(['42371 42000 -zsh', '44496 42371 -zsh'].join('\n'));
+
+  assert.equal(hasNonShellDescendant(rows, 42371), false);
+});
+
+test('a service under intermediate shell layers counts as running', () => {
+  // pnpm runs package scripts through `sh -c`, so the live service is never a
+  // depth-1 child: stopping at the first shell would call wrangler idle.
+  const rows = parseProcessTable(
+    ['42371 42000 -zsh', '44496 42371 sh', '44500 44496 node'].join('\n')
+  );
+
+  assert.equal(hasNonShellDescendant(rows, 42371), true);
+});
+
+test('reparented grandchildren of a dead supervisor do not count', () => {
+  // cloudflared reparented to pid 1 is no longer under the pane — status must
+  // not credit the pane for it.
+  const rows = parseProcessTable(['42371 42000 -zsh', '9001 1 cloudflared'].join('\n'));
+
+  assert.equal(hasNonShellDescendant(rows, 42371), false);
+});
+
+test('hasNonShellDescendant terminates on a self-parented row', () => {
+  const rows = parseProcessTable(['42371 42371 -zsh', '44496 42371 -zsh'].join('\n'));
+
+  assert.equal(hasNonShellDescendant(rows, 42371), false);
+});
+
+test('snapshotProcessTable sees this process under a real ps', () => {
+  const rows = snapshotProcessTable();
+
+  assert.ok(rows.length > 1);
+  assert.ok(rows.some(row => row.pid === process.pid));
+});
+
+test('the current test process is a non-shell descendant of its own parent', () => {
+  const rows = snapshotProcessTable();
+  const self = rows.find(row => row.pid === process.pid);
+  assert.ok(self);
+
+  assert.equal(hasNonShellDescendant(rows, self.ppid), true);
+});

--- a/dev/local/process-tree.ts
+++ b/dev/local/process-tree.ts
@@ -1,0 +1,125 @@
+import { execFileSync } from 'node:child_process';
+import * as path from 'node:path';
+
+/**
+ * Process-tree inspection for tmux panes.
+ *
+ * A pane shell always has children of its own kind: the service wrapper is
+ * `$SHELL -lc '<cmd>; exec $SHELL -l'`, ctrl-c and dashboard clicks can leave
+ * an extra login shell parented to the pane, and pnpm runs package scripts
+ * through an intermediate `sh -c`. "Has any child" therefore cannot tell a
+ * dying service from an idle pane — the question is whether the tree below the
+ * pane contains a process that is *not* a shell.
+ */
+
+type ProcessRow = {
+  pid: number;
+  ppid: number;
+  command: string;
+};
+
+// Interactive shells only. A pane whose tree is all shells is idle: anything a
+// user or the CLI typed has already exited.
+const SHELL_COMMANDS = new Set([
+  'ash',
+  'bash',
+  'csh',
+  'dash',
+  'fish',
+  'ksh',
+  'login',
+  'nu',
+  'sh',
+  'tcsh',
+  'zsh',
+]);
+
+/** `ps` prints login shells as `-zsh`, and paths for non-PATH binaries. */
+function normalizeCommand(command: string): string {
+  return path.basename(command.trim()).replace(/^-/, '');
+}
+
+function isShellCommand(command: string): boolean {
+  return SHELL_COMMANDS.has(normalizeCommand(command));
+}
+
+/** Parse `ps -Ao pid=,ppid=,comm=` output. Malformed lines are skipped. */
+function parseProcessTable(output: string): ProcessRow[] {
+  const rows: ProcessRow[] = [];
+  for (const line of output.split('\n')) {
+    const match = line.trim().match(/^(\d+)\s+(\d+)\s+(.+)$/);
+    if (!match) continue;
+    rows.push({
+      pid: Number(match[1]),
+      ppid: Number(match[2]),
+      command: match[3],
+    });
+  }
+  return rows;
+}
+
+/**
+ * One snapshot of the whole table, not one `ps` per pid: restart polls this
+ * every 500ms against a tree that is actively dying, and per-pid calls would
+ * read a half-consistent tree.
+ */
+function snapshotProcessTable(): ProcessRow[] {
+  try {
+    return parseProcessTable(
+      execFileSync('ps', ['-Ao', 'pid=,ppid=,comm='], {
+        encoding: 'utf-8',
+        maxBuffer: 8 * 1024 * 1024,
+        timeout: 2000, // restart polls this every 500ms; never let it wedge
+      })
+    );
+  } catch {
+    return [];
+  }
+}
+
+function childrenByParent(rows: ProcessRow[]): Map<number, ProcessRow[]> {
+  const byParent = new Map<number, ProcessRow[]>();
+  for (const row of rows) {
+    const siblings = byParent.get(row.ppid);
+    if (siblings) siblings.push(row);
+    else byParent.set(row.ppid, [row]);
+  }
+  return byParent;
+}
+
+/**
+ * Whether any descendant of `rootPid` is a non-shell process. Walks the full
+ * tree: a live `pnpm run dev` sits under one or more shell layers, so stopping
+ * at the first shell child would call a running service idle.
+ *
+ * `rootPid` itself is excluded — it is the pane's own shell.
+ */
+function hasNonShellDescendant(rows: ProcessRow[], rootPid: number): boolean {
+  const byParent = childrenByParent(rows);
+  const seen = new Set<number>([rootPid]);
+  const queue = [rootPid];
+  while (queue.length > 0) {
+    const pid = queue.shift() as number;
+    for (const child of byParent.get(pid) ?? []) {
+      if (seen.has(child.pid)) continue; // defensive: ps snapshots can contain cycles after reparenting
+      seen.add(child.pid);
+      if (!isShellCommand(child.command)) return true;
+      queue.push(child.pid);
+    }
+  }
+  return false;
+}
+
+/** Whether `rootPid`'s tree currently runs something other than shells. */
+function hasRunningService(rootPid: number): boolean {
+  return hasNonShellDescendant(snapshotProcessTable(), rootPid);
+}
+
+export {
+  hasNonShellDescendant,
+  hasRunningService,
+  isShellCommand,
+  parseProcessTable,
+  snapshotProcessTable,
+};
+export type { ProcessRow };

--- a/dev/local/public-tunnels.test.ts
+++ b/dev/local/public-tunnels.test.ts
@@ -68,6 +68,30 @@ test('waitForCloudAgentPublicTunnelCapture returns true when all three keys chan
   assert.equal(await waitForCloudAgentPublicTunnelCapture(repoRoot, previous, 1000), true);
 });
 
+test('waitForCloudAgentPublicTunnelCapture waits for all sequential URL writes', async () => {
+  const oldValues = [
+    'WORKER_URL=https://old-worker.trycloudflare.com',
+    'KILOCODE_BACKEND_BASE_URL=https://old-backend.trycloudflare.com',
+    'KILO_SESSION_INGEST_URL=https://old-ingest.trycloudflare.com',
+  ];
+  const repoRoot = withTempRepo(oldValues.join('\n'));
+  const envPath = path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
+  const previous = snapshotCloudAgentPublicTunnelEnv(repoRoot);
+
+  oldValues[0] = 'WORKER_URL=https://new-worker.trycloudflare.com';
+  fs.writeFileSync(envPath, oldValues.join('\n'));
+  fs.utimesSync(envPath, new Date(), new Date(Date.now() + 1000));
+  assert.equal(await waitForCloudAgentPublicTunnelCapture(repoRoot, previous, 200), false);
+
+  oldValues[1] = 'KILOCODE_BACKEND_BASE_URL=https://new-backend.trycloudflare.com';
+  fs.writeFileSync(envPath, oldValues.join('\n'));
+  assert.equal(await waitForCloudAgentPublicTunnelCapture(repoRoot, previous, 200), false);
+
+  oldValues[2] = 'KILO_SESSION_INGEST_URL=https://new-ingest.trycloudflare.com';
+  fs.writeFileSync(envPath, oldValues.join('\n'));
+  assert.equal(await waitForCloudAgentPublicTunnelCapture(repoRoot, previous, 1000), true);
+});
+
 test('waitForCloudAgentPublicTunnelCapture times out when URLs stay the same', async () => {
   const repoRoot = withTempRepo('WORKER_URL=https://worker.trycloudflare.com\n');
   const previous = snapshotCloudAgentPublicTunnelEnv(repoRoot);

--- a/dev/local/public-tunnels.test.ts
+++ b/dev/local/public-tunnels.test.ts
@@ -1,0 +1,75 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import test from 'node:test';
+
+import {
+  buildFollowLogPipeCommand,
+  buildLogPipeCommand,
+  snapshotCloudAgentPublicTunnelEnv,
+  waitForCloudAgentPublicTunnelCapture,
+} from './runner';
+
+function withTempRepo(devVars: string): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-public-tunnels-'));
+  const target = path.join(root, 'services/cloud-agent-next/.dev.vars');
+  fs.mkdirSync(path.dirname(target), { recursive: true });
+  fs.writeFileSync(target, devVars);
+  return root;
+}
+
+test('buildLogPipeCommand cds to the repo so a deleted tmux-server cwd cannot kill tsx', () => {
+  const command = buildLogPipeCommand('/tmp/service.log');
+  assert.match(command, /^cd '/);
+  assert.match(command, /log-filter\.ts/);
+  assert.match(command, /\/tmp\/service\.log/);
+});
+
+test('buildFollowLogPipeCommand groups cd+tsx so tee does not steal the &&', () => {
+  const command = buildFollowLogPipeCommand('/tmp/service.log', '/tmp/follow.log');
+  assert.match(command, /tee -a '\/tmp\/follow\.log' \| \( cd '/);
+});
+
+test('snapshotCloudAgentPublicTunnelEnv reads the three public-tunnel keys', () => {
+  const repoRoot = withTempRepo(
+    [
+      'WORKER_URL=https://worker.trycloudflare.com',
+      'KILOCODE_BACKEND_BASE_URL=https://backend.trycloudflare.com',
+      'KILO_SESSION_INGEST_URL=https://ingest.trycloudflare.com',
+    ].join('\n')
+  );
+
+  const snapshot = snapshotCloudAgentPublicTunnelEnv(repoRoot);
+  assert.equal(snapshot.values.WORKER_URL, 'https://worker.trycloudflare.com');
+  assert.equal(snapshot.values.KILOCODE_BACKEND_BASE_URL, 'https://backend.trycloudflare.com');
+  assert.equal(snapshot.values.KILO_SESSION_INGEST_URL, 'https://ingest.trycloudflare.com');
+  assert.equal(typeof snapshot.mtime, 'number');
+});
+
+test('waitForCloudAgentPublicTunnelCapture returns true when all three keys change', async () => {
+  const repoRoot = withTempRepo(
+    [
+      'WORKER_URL=https://old-worker.trycloudflare.com',
+      'KILOCODE_BACKEND_BASE_URL=https://old-backend.trycloudflare.com',
+      'KILO_SESSION_INGEST_URL=https://old-ingest.trycloudflare.com',
+    ].join('\n')
+  );
+  const previous = snapshotCloudAgentPublicTunnelEnv(repoRoot);
+  fs.writeFileSync(
+    path.join(repoRoot, 'services/cloud-agent-next/.dev.vars'),
+    [
+      'WORKER_URL=https://new-worker.trycloudflare.com',
+      'KILOCODE_BACKEND_BASE_URL=https://new-backend.trycloudflare.com',
+      'KILO_SESSION_INGEST_URL=https://new-ingest.trycloudflare.com',
+    ].join('\n')
+  );
+
+  assert.equal(await waitForCloudAgentPublicTunnelCapture(repoRoot, previous, 1000), true);
+});
+
+test('waitForCloudAgentPublicTunnelCapture times out when URLs stay the same', async () => {
+  const repoRoot = withTempRepo('WORKER_URL=https://worker.trycloudflare.com\n');
+  const previous = snapshotCloudAgentPublicTunnelEnv(repoRoot);
+  assert.equal(await waitForCloudAgentPublicTunnelCapture(repoRoot, previous, 200), false);
+});

--- a/dev/local/runner-compose-env.test.ts
+++ b/dev/local/runner-compose-env.test.ts
@@ -13,6 +13,7 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 import {
+  buildInfraDownArgs,
   composeInterpolatedKeys,
   formatComposeEnvAssignment,
   writeComposeSecretsEnvFile,
@@ -134,4 +135,16 @@ void test('writeComposeSecretsEnvFile returns undefined when no keys match', () 
   } finally {
     rmSync(directory, { recursive: true, force: true });
   }
+});
+
+test('buildInfraDownArgs can target a project other than the published one', () => {
+  const [, defaultArgs] = buildInfraDownArgs();
+  assert.equal(defaultArgs.includes('-p'), false);
+
+  // Tearing down the offset this worktree just moved off: dev/.env still names
+  // the old project's ports, but `down` matches by label, so -p is enough.
+  const [cmd, args] = buildInfraDownArgs('kilo-dev-sticky-slider-2500');
+  assert.equal(cmd, 'docker');
+  assert.deepEqual(args.slice(0, 3), ['compose', '-p', 'kilo-dev-sticky-slider-2500']);
+  assert.equal(args.at(-1), 'down');
 });

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -14,12 +14,13 @@ import {
   breakPane,
   countPanes,
   findServicePane,
-  paneHasRunningChild,
+  paneHasRunningService,
   selectPane,
   setPaneTitle,
   setPaneServiceIdentity,
   setMainLeftLayout,
   pipePane,
+  closePipePane,
 } from './tmux';
 
 // ---------------------------------------------------------------------------
@@ -134,20 +135,105 @@ function buildInfraLogCommand(serviceName: string): string {
   return `docker compose ${profileArg}-f dev/docker-compose.yml logs -f ${shellQuote(serviceName)}`;
 }
 
+function isLogFilterRunning(logPath: string): boolean {
+  try {
+    execFileSync('pgrep', ['-f', logPath], { stdio: 'ignore' });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export function ensureServiceLogPipe(sessionName: string, serviceName: string): void {
+  const pane = findServicePane(sessionName, serviceName);
+  if (!pane) return;
+  const logPath = path.join(findRepoRoot(), 'dev', 'logs', `${serviceName}.log`);
+  fs.mkdirSync(path.dirname(logPath), { recursive: true });
+  fs.closeSync(fs.openSync(logPath, 'a'));
+  if (isLogFilterRunning(logPath)) return;
+  // `pipe-pane -o` is a no-op while tmux still thinks a pipe exists, including
+  // after the filter process has exited. Close first, then attach a new one.
+  closePipePane(sessionName, pane.windowIndex, pane.paneIndex);
+  pipePane(sessionName, pane.windowIndex, pane.paneIndex, buildLogPipeCommand(logPath));
+}
+
+/** Re-attach `pipe-pane` for any known service whose log filter is not running. */
+export function ensureDeadServiceLogPipes(sessionName: string, serviceNames: string[]): string[] {
+  const repaired: string[] = [];
+  for (const name of serviceNames) {
+    const logPath = path.join(findRepoRoot(), 'dev', 'logs', `${name}.log`);
+    if (isLogFilterRunning(logPath)) continue;
+    try {
+      ensureServiceLogPipe(sessionName, name);
+      if (isLogFilterRunning(logPath)) repaired.push(name);
+    } catch {
+      // Pane may have vanished between the list and the attach.
+    }
+  }
+  return repaired;
+}
+
+const CLOUD_AGENT_PUBLIC_TUNNEL_KEYS = [
+  'WORKER_URL',
+  'KILOCODE_BACKEND_BASE_URL',
+  'KILO_SESSION_INGEST_URL',
+] as const;
+
+export function cloudAgentDevVarsPath(repoRoot: string): string {
+  return path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
+}
+
+export type CloudAgentPublicTunnelSnapshot = {
+  values: Record<(typeof CLOUD_AGENT_PUBLIC_TUNNEL_KEYS)[number], string | undefined>;
+  mtime: number | undefined;
+};
+
+export function snapshotCloudAgentPublicTunnelEnv(
+  repoRoot: string
+): CloudAgentPublicTunnelSnapshot {
+  const envPath = cloudAgentDevVarsPath(repoRoot);
+  return {
+    values: {
+      WORKER_URL: readEnvValue(envPath, 'WORKER_URL'),
+      KILOCODE_BACKEND_BASE_URL: readEnvValue(envPath, 'KILOCODE_BACKEND_BASE_URL'),
+      KILO_SESSION_INGEST_URL: readEnvValue(envPath, 'KILO_SESSION_INGEST_URL'),
+    },
+    mtime: readEnvMtime(envPath),
+  };
+}
+
+export async function waitForCloudAgentPublicTunnelCapture(
+  repoRoot: string,
+  previous: CloudAgentPublicTunnelSnapshot,
+  timeoutMs: number
+): Promise<boolean> {
+  const envPath = cloudAgentDevVarsPath(repoRoot);
+  const results = await Promise.all(
+    CLOUD_AGENT_PUBLIC_TUNNEL_KEYS.map(key =>
+      waitForEnvValueChange(envPath, key, previous.values[key], timeoutMs, previous.mtime)
+    )
+  );
+  return results.every(Boolean);
+}
+
 export function buildLogPipeCommand(logPath: string): string {
-  const filterPath = path.join(findRepoRoot(), 'dev', 'local', 'log-filter.ts');
-  // Absolute tsx path: tmux pipe-pane commands inherit the tmux *server's*
-  // PATH, not the caller's, and a server started outside a direnv shell has
-  // no node_modules/.bin on it.
-  const tsxPath = path.join(findRepoRoot(), 'node_modules', '.bin', 'tsx');
-  return `${shellQuote(tsxPath)} ${shellQuote(filterPath)} >> ${shellQuote(logPath)}`;
+  const repoRoot = findRepoRoot();
+  const filterPath = path.join(repoRoot, 'dev', 'local', 'log-filter.ts');
+  // Absolute tsx path and an explicit cd: tmux pipe-pane commands inherit the
+  // tmux *server's* PATH and cwd. A server started outside direnv has no
+  // node_modules/.bin, and a server whose start directory was deleted makes
+  // `tsx` die on `uv_cwd` before it can read the filter.
+  const tsxPath = path.join(repoRoot, 'node_modules', '.bin', 'tsx');
+  return `cd ${shellQuote(repoRoot)} && ${shellQuote(tsxPath)} ${shellQuote(filterPath)} >> ${shellQuote(logPath)}`;
 }
 
 export function buildFollowLogPipeCommand(logPath: string, followPath: string): string {
-  return `tee -a ${shellQuote(followPath)} | ${buildLogPipeCommand(logPath)}`;
+  // Group the cd+tsx command: `|` binds tighter than `&&`, so an ungrouped
+  // `tee | cd && tsx` would run tsx with no pane stdin.
+  return `tee -a ${shellQuote(followPath)} | ( ${buildLogPipeCommand(logPath)} )`;
 }
 
-function shellQuote(value: string): string {
+export function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`;
 }
 
@@ -330,9 +416,14 @@ export function restartServiceInTmux(
   const POLL_MS = 500;
   const ESCALATE_AT_MS = 15_000; // second SIGINT for shutdowns stuck on children
   const GIVE_UP_AT_MS = 60_000;
+  // Two consecutive idle polls, not one: a service on its way out can briefly
+  // have a shell as its last living descendant, and typing then would feed the
+  // keystrokes to a process that still owns the tty.
+  const IDLE_POLLS_BEFORE_RELAUNCH = 2;
   return new Promise<RestartOutcome>(resolve => {
     let elapsed = 0;
     let escalated = false;
+    let idlePolls = 0;
     const settle = (outcome: RestartOutcome) => {
       clearInterval(timer);
       if (inFlightRestarts.get(restartKey) === cancel) inFlightRestarts.delete(restartKey);
@@ -359,7 +450,11 @@ export function restartServiceInTmux(
         }
         return;
       }
-      if (paneHasRunningChild(sessionName, currentPane)) {
+      // Shell children do not count: ctrl-c, send-keys and dashboard clicks
+      // leave extra login shells parented to the pane shell, and waiting on
+      // those meant refusing to relaunch an already-idle pane for 60s.
+      if (paneHasRunningService(sessionName, currentPane)) {
+        idlePolls = 0;
         if (elapsed >= GIVE_UP_AT_MS) {
           // Refuses to die — typing into it would only feed its stdin.
           settle('gave-up');
@@ -376,6 +471,7 @@ export function restartServiceInTmux(
         }
         return;
       }
+      if (++idlePolls < IDLE_POLLS_BEFORE_RELAUNCH) return;
       try {
         const envArgs = Object.entries(env ?? {})
           .map(([key, value]) => `${key}=${shellQuote(value)}`)
@@ -386,6 +482,11 @@ export function restartServiceInTmux(
           envArgs ? `env ${envArgs} ${cmd}` : cmd,
           currentPane.paneIndex
         );
+        try {
+          ensureServiceLogPipe(sessionName, serviceName);
+        } catch {
+          // Restart succeeded; a dead pipe is recoverable on the next poll.
+        }
         settle('relaunched');
       } catch {
         // The dashboard may have moved or closed the pane after we resolved it.
@@ -409,9 +510,15 @@ export function restartServiceInTmux(
  * surprises. Returned as an argv array for execFileSync — keeps the
  * shell out of the loop entirely, matching startInfra.
  */
-export function buildInfraDownArgs(): [string, string[]] {
+export function buildInfraDownArgs(project?: string): [string, string[]] {
   const profileArgs = getAllInfraProfiles().flatMap(p => ['--profile', p]);
-  return ['docker', ['compose', ...profileArgs, '-f', 'dev/docker-compose.yml', 'down']];
+  // `-p` names the project explicitly, for tearing down a project other than
+  // the one `dev/.env` currently publishes (a stack whose offset has moved).
+  const projectArgs = project === undefined ? [] : ['-p', project];
+  return [
+    'docker',
+    ['compose', ...projectArgs, ...profileArgs, '-f', 'dev/docker-compose.yml', 'down'],
+  ];
 }
 
 const COMPOSE_SECRETS_ENV_REL = path.join('dev', '.env.compose-secrets');

--- a/dev/local/runner.ts
+++ b/dev/local/runner.ts
@@ -210,7 +210,7 @@ export async function waitForCloudAgentPublicTunnelCapture(
   const envPath = cloudAgentDevVarsPath(repoRoot);
   const results = await Promise.all(
     CLOUD_AGENT_PUBLIC_TUNNEL_KEYS.map(key =>
-      waitForEnvValueChange(envPath, key, previous.values[key], timeoutMs, previous.mtime)
+      waitForEnvValueChange(envPath, key, previous.values[key], timeoutMs)
     )
   );
   return results.every(Boolean);

--- a/dev/local/scripts/start-public-tunnels.test.ts
+++ b/dev/local/scripts/start-public-tunnels.test.ts
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import {
+  envValueForCapturedUrl,
+  parsePublicTunnelPorts,
+  providerBaseFromBackendTunnel,
+  publicTunnelSpecs,
+  updateEnvValue,
+} from './start-public-tunnels';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+test('requires the three sandbox-facing local ports', () => {
+  assert.throws(() => parsePublicTunnelPorts(['8794', '3000']), /Usage: start-public-tunnels/);
+});
+
+test('builds worker, nextjs, and session-ingest tunnels', () => {
+  assert.deepEqual(publicTunnelSpecs(parsePublicTunnelPorts(['8794', '3000', '8800'])), [
+    { label: 'worker', port: '8794', key: 'WORKER_URL' },
+    { label: 'nextjs', port: '3000', key: 'KILOCODE_BACKEND_BASE_URL' },
+    { label: 'session-ingest', port: '8800', key: 'KILO_SESSION_INGEST_URL' },
+  ]);
+});
+
+test('adds a fake-llm tunnel with the /api suffix when that port is present', () => {
+  const specs = publicTunnelSpecs(parsePublicTunnelPorts(['8794', '3000', '8800', '8811']));
+  const fakeLlm = specs.find(spec => spec.label === 'fake-llm');
+  assert.ok(fakeLlm);
+  assert.deepEqual(fakeLlm, {
+    label: 'fake-llm',
+    port: '8811',
+    key: 'KILO_OPENROUTER_BASE',
+    suffix: '/api',
+  });
+  assert.equal(
+    envValueForCapturedUrl(fakeLlm, 'https://abc.trycloudflare.com'),
+    'https://abc.trycloudflare.com/api'
+  );
+});
+
+test('derives the real-model provider URL from the backend tunnel', () => {
+  assert.equal(
+    providerBaseFromBackendTunnel('https://backend.trycloudflare.com'),
+    'https://backend.trycloudflare.com/api'
+  );
+});
+
+test('can pin KILO_OPENROUTER_BASE to the backend tunnel /api', () => {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'public-tunnels-'));
+  const envPath = path.join(dir, '.dev.vars');
+  fs.writeFileSync(
+    envPath,
+    'KILOCODE_BACKEND_BASE_URL=http://localhost:5500\nKILO_OPENROUTER_BASE=http://localhost:5500/api\n'
+  );
+  updateEnvValue(envPath, 'KILOCODE_BACKEND_BASE_URL', 'https://backend.trycloudflare.com');
+  updateEnvValue(envPath, 'KILO_OPENROUTER_BASE', 'https://backend.trycloudflare.com/api');
+  assert.match(
+    fs.readFileSync(envPath, 'utf8'),
+    /KILO_OPENROUTER_BASE=https:\/\/backend\.trycloudflare\.com\/api/
+  );
+});

--- a/dev/local/scripts/start-public-tunnels.ts
+++ b/dev/local/scripts/start-public-tunnels.ts
@@ -1,0 +1,161 @@
+import { spawn, spawnSync } from 'node:child_process';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = path.resolve(import.meta.dirname, '../../..');
+const cloudAgentDevVarsPath = path.join(repoRoot, 'services/cloud-agent-next/.dev.vars');
+const TRYCLOUDFLARE_URL = /https:\/\/[a-z0-9-]+\.trycloudflare\.com/;
+
+export type PublicTunnelSpec = {
+  label: string;
+  port: string;
+  key: string;
+  suffix?: string;
+};
+
+export function parsePublicTunnelPorts(argv: string[]): {
+  workerPort: string;
+  nextjsPort: string;
+  sessionIngestPort: string;
+  fakeLlmPort?: string;
+} {
+  const [workerPort, nextjsPort, sessionIngestPort, fakeLlmPort] = argv;
+  if (!workerPort || !nextjsPort || !sessionIngestPort) {
+    throw new Error(
+      'Usage: start-public-tunnels.ts <worker-port> <nextjs-port> <session-ingest-port> [fake-llm-port]'
+    );
+  }
+  return {
+    workerPort,
+    nextjsPort,
+    sessionIngestPort,
+    ...(fakeLlmPort ? { fakeLlmPort } : {}),
+  };
+}
+
+export function publicTunnelSpecs(ports: {
+  workerPort: string;
+  nextjsPort: string;
+  sessionIngestPort: string;
+  fakeLlmPort?: string;
+}): PublicTunnelSpec[] {
+  const specs: PublicTunnelSpec[] = [
+    { label: 'worker', port: ports.workerPort, key: 'WORKER_URL' },
+    { label: 'nextjs', port: ports.nextjsPort, key: 'KILOCODE_BACKEND_BASE_URL' },
+    { label: 'session-ingest', port: ports.sessionIngestPort, key: 'KILO_SESSION_INGEST_URL' },
+  ];
+  if (ports.fakeLlmPort) {
+    specs.push({
+      label: 'fake-llm',
+      port: ports.fakeLlmPort,
+      key: 'KILO_OPENROUTER_BASE',
+      suffix: '/api',
+    });
+  }
+  return specs;
+}
+
+export function envValueForCapturedUrl(spec: PublicTunnelSpec, url: string): string {
+  return spec.suffix ? `${url}${spec.suffix}` : url;
+}
+
+export function providerBaseFromBackendTunnel(backendUrl: string): string {
+  return `${backendUrl.replace(/\/+$/, '')}/api`;
+}
+
+export function updateEnvValue(filePath: string, key: string, value: string): void {
+  let content = '';
+  if (fs.existsSync(filePath)) {
+    content = fs.readFileSync(filePath, 'utf-8');
+  }
+
+  const activePattern = new RegExp(`^${key}=.*`, 'm');
+  const commentedPattern = new RegExp(`^# ${key}=.*`, 'm');
+
+  if (activePattern.test(content)) {
+    content = content.replace(activePattern, `${key}=${value}`);
+  } else if (commentedPattern.test(content)) {
+    content = content.replace(commentedPattern, `${key}=${value}`);
+  } else {
+    content = content.endsWith('\n') || content === '' ? content : content + '\n';
+    content += `${key}=${value}\n`;
+  }
+
+  fs.writeFileSync(filePath, content);
+}
+
+function main(): void {
+  if (spawnSync('cloudflared', ['version'], { stdio: 'ignore' }).error) {
+    console.error(
+      'cloudflared not found on PATH. Install it:\n  https://developers.cloudflare.com/cloudflare-one/connections/connect-networks/downloads/\n  brew install cloudflared'
+    );
+    process.exit(1);
+  }
+
+  const specs = publicTunnelSpecs(parsePublicTunnelPorts(process.argv.slice(2)));
+  const children: Array<{ label: string; child: ReturnType<typeof spawn> }> = [];
+  let exiting = false;
+
+  function stopAll(signal: NodeJS.Signals): void {
+    for (const { child } of children) child.kill(signal);
+  }
+
+  function exitAndStopOthers(originLabel: string, code: number | null): void {
+    if (exiting) return;
+    exiting = true;
+    for (const { label, child } of children) {
+      if (label !== originLabel) child.kill('SIGTERM');
+    }
+    process.exit(code ?? 1);
+  }
+
+  for (const spec of specs) {
+    const child = spawn('cloudflared', ['tunnel', '--url', `http://localhost:${spec.port}`], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    children.push({ label: spec.label, child });
+    console.log(`Starting quick tunnel (${spec.label}) -> http://localhost:${spec.port}...`);
+
+    let captured = false;
+    const handleOutput = (data: Buffer) => {
+      process.stderr.write(data);
+      if (captured) return;
+      const match = data.toString().match(TRYCLOUDFLARE_URL);
+      if (!match) return;
+      captured = true;
+      const value = envValueForCapturedUrl(spec, match[0]);
+      updateEnvValue(cloudAgentDevVarsPath, spec.key, value);
+      if (
+        spec.key === 'KILOCODE_BACKEND_BASE_URL' &&
+        !specs.some(item => item.key === 'KILO_OPENROUTER_BASE')
+      ) {
+        updateEnvValue(
+          cloudAgentDevVarsPath,
+          'KILO_OPENROUTER_BASE',
+          providerBaseFromBackendTunnel(match[0])
+        );
+      }
+      console.log(`\n${spec.label} tunnel URL: ${match[0]}`);
+      console.log(`Set ${spec.key}=${value}`);
+    };
+
+    child.stdout.on('data', handleOutput);
+    child.stderr.on('data', handleOutput);
+    child.on('close', code => exitAndStopOthers(spec.label, code));
+  }
+
+  for (const signal of ['SIGINT', 'SIGTERM'] as const) {
+    process.on(signal, () => {
+      stopAll(signal);
+      if (children.length === 0) process.exit(0);
+    });
+  }
+}
+
+if (
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === path.resolve(process.argv[1])
+) {
+  main();
+}

--- a/dev/local/services.test.ts
+++ b/dev/local/services.test.ts
@@ -155,6 +155,22 @@ test('skips NEXTAUTH_URL when the web app is not being started', () => {
   assert.equal(url, undefined);
 });
 
+test('keeps public tunnels out of default and agents starts', () => {
+  const service = getService('cloud-agent-public-tunnels');
+  assert.equal(service.group, 'cloud-agent-public-tunnels');
+  assert.equal(service.type, 'process');
+  assert.equal(service.port, 0);
+  assert.match(service.command.join(' '), /start-public-tunnels\.ts/);
+  assert.equal(service.command.includes(String(8811 + portOffset)), false);
+
+  const alwaysOn = resolveGroups(getAlwaysOnGroupIds());
+  assert.ok(!alwaysOn.includes('cloud-agent-public-tunnels'));
+  assert.ok(!resolveTargets(['agents']).includes('cloud-agent-public-tunnels'));
+  assert.ok(!resolveTargets(['cloud-agent']).includes('cloud-agent-public-tunnels'));
+  assert.ok(!resolveTargets(['all']).includes('cloud-agent-public-tunnels'));
+  assert.ok(resolveTargets(['cloud-agent-public-tunnels']).includes('cloud-agent-public-tunnels'));
+});
+
 test('keeps auto routing workers in their own opt-in group', () => {
   const service = getService('auto-routing');
 

--- a/dev/local/services.ts
+++ b/dev/local/services.ts
@@ -53,6 +53,12 @@ const groups: ServiceGroup[] = [
   { id: 'mobile', label: 'Mobile', alwaysOn: false, sectionBreakBefore: true },
   { id: 'storybook', label: 'Storybook', alwaysOn: false, sectionBreakBefore: true },
   { id: 'deletion-mock', label: 'Deletion Mock', alwaysOn: false, sectionBreakBefore: true },
+  {
+    id: 'cloud-agent-public-tunnels',
+    label: 'Cloud Agent Public Tunnels',
+    alwaysOn: false,
+    sectionBreakBefore: true,
+  },
 ];
 
 type ServiceDef = {
@@ -133,6 +139,7 @@ const serviceMeta: Record<string, ServiceMeta> = {
     dependsOn: [],
     dir: 'services/cloud-agent-next/test/e2e',
   },
+  'cloud-agent-public-tunnels': { group: 'cloud-agent-public-tunnels', dependsOn: [] },
   // git-token-service (shared by cloud-agent, app-builder, gastown)
   'cloudflare-git-token-service': {
     group: 'git-token-service',
@@ -733,6 +740,29 @@ function buildServiceDefs(): ServiceDef[] {
       continue;
     }
 
+    if (name === 'cloud-agent-public-tunnels') {
+      const workerPort =
+        readWranglerPort(path.join(repoRoot, 'services/cloud-agent-next')) + portOffset;
+      const sessionIngestPort =
+        readWranglerPort(path.join(repoRoot, 'services/session-ingest')) + portOffset;
+      defs.push({
+        name,
+        type: 'process',
+        dir: '.',
+        port: 0,
+        dependsOn: meta.dependsOn,
+        command: [
+          'tsx',
+          'dev/local/scripts/start-public-tunnels.ts',
+          String(workerPort),
+          String(nextjsTargetPort),
+          String(sessionIngestPort),
+        ],
+        group: meta.group,
+      });
+      continue;
+    }
+
     // Worker — read port from wrangler.jsonc
     const basePort = readWranglerPort(path.join(repoRoot, dir));
     const port = basePort + portOffset;
@@ -783,7 +813,7 @@ export const shortcuts: Record<string, string[]> = {
     'cloudflare-app-builder',
   ],
   agents: ['cloud-agent-next', 'nextjs', 'cloudflare-session-ingest'],
-  all: serviceDefs.map(s => s.name),
+  all: serviceDefs.map(s => s.name).filter(name => name !== 'cloud-agent-public-tunnels'),
 };
 
 // Rebuild every port-derived service definition (ports, commands) for a new
@@ -795,7 +825,9 @@ export function applyPortOffset(offset: number): void {
   serviceDefs = buildServiceDefs();
   services.clear();
   for (const def of serviceDefs) services.set(def.name, def);
-  shortcuts.all = serviceDefs.map(s => s.name);
+  shortcuts.all = serviceDefs
+    .map(s => s.name)
+    .filter(name => name !== 'cloud-agent-public-tunnels');
 }
 
 // Successive +100 candidate offsets through the same (0, 5000] range the slug

--- a/dev/local/tmux.test.ts
+++ b/dev/local/tmux.test.ts
@@ -704,3 +704,63 @@ test(
     }
   }
 );
+
+test(
+  'restartServiceInTmux relaunches promptly when only leftover shells remain',
+  { skip: !hasTmux },
+  async () => {
+    // The §1 repro: the service already exited and ctrl-c left a second login
+    // shell parented to the pane shell. Waiting on that shell made restart
+    // refuse to type for 60s, so wall-clock is part of the assertion.
+    const sessionName = `kilo-tmux-test-${process.pid}-${Date.now()}`;
+    const serviceName = 'stripe';
+    const tmux = (...args: string[]) => execFileSync('tmux', args, { stdio: 'ignore' });
+
+    try {
+      tmux('new-session', '-d', '-s', sessionName, '-n', 'dashboard', 'sleep 120');
+      tmux('new-window', '-d', '-t', sessionName, '-n', serviceName, '/bin/sh');
+
+      const serviceWindow = listWindows(sessionName).find(window => window.name === serviceName);
+      assert.ok(serviceWindow);
+      const paneTarget = `${sessionName}:${serviceWindow.index}.0`;
+
+      // Leftover login shell, exactly what an interrupted service leaves behind.
+      tmux('send-keys', '-t', paneTarget, '/bin/sh -l', 'Enter');
+      let leftoverShellUp = false;
+      for (let i = 0; i < 40 && !leftoverShellUp; i++) {
+        const panePid = execFileSync(
+          'tmux',
+          ['display-message', '-p', '-t', paneTarget, '#{pane_pid}'],
+          { encoding: 'utf-8' }
+        ).trim();
+        try {
+          execFileSync('pgrep', ['-P', panePid], { stdio: 'ignore' });
+          leftoverShellUp = true;
+        } catch {
+          await sleep(50);
+        }
+      }
+      assert.ok(leftoverShellUp, 'leftover shell should be a child of the pane shell');
+
+      const startedAt = Date.now();
+      const outcome = await restartServiceInTmux(sessionName, serviceName);
+      const elapsedMs = Date.now() - startedAt;
+
+      assert.equal(outcome, 'relaunched');
+      assert.ok(elapsedMs < 10_000, `restart should not wait on idle shells, took ${elapsedMs}ms`);
+      const paneContent = execFileSync('tmux', ['capture-pane', '-p', '-J', '-t', paneTarget], {
+        encoding: 'utf-8',
+      });
+      assert.ok(
+        paneContent.includes(buildStartCommand(serviceName)),
+        'start command should be typed into the idle pane'
+      );
+    } finally {
+      try {
+        tmux('kill-session', '-t', sessionName);
+      } catch {
+        // Session may already be gone if tmux fails during setup.
+      }
+    }
+  }
+);

--- a/dev/local/tmux.ts
+++ b/dev/local/tmux.ts
@@ -1,6 +1,8 @@
 import { execSync, execFileSync } from 'node:child_process';
 import * as path from 'node:path';
 
+import { hasRunningService } from './process-tree';
+
 // ---------------------------------------------------------------------------
 // Types
 // ---------------------------------------------------------------------------
@@ -503,37 +505,33 @@ function pipeServicePane(sessionName: string, serviceName: string, command: stri
   );
 }
 
-function isPaneRunningCommand(sessionName: string, pane: PaneInfo): boolean {
+function panePid(sessionName: string, pane: PaneInfo): number | undefined {
   try {
-    const command = execSync(
-      `tmux display-message -p -t ${sessionName}:${pane.windowIndex}.${pane.paneIndex} "#{pane_current_command}"`,
+    const pid = execSync(
+      `tmux display-message -p -t ${sessionName}:${pane.windowIndex}.${pane.paneIndex} "#{pane_pid}"`,
       { encoding: 'utf-8' }
     ).trim();
-    const commandName = path.basename(command).replace(/^-/, '');
-    return commandName !== '' && !['bash', 'fish', 'nu', 'sh', 'tcsh', 'zsh'].includes(commandName);
+    return /^\d+$/.test(pid) ? Number(pid) : undefined;
   } catch {
-    return false;
+    return undefined;
   }
 }
 
 /**
- * Whether the pane's shell currently has a child process. `pane_current_command`
- * cannot answer this: services run under a `$SHELL -lc '<cmd>; exec $SHELL -l'`
+ * Whether the pane is running an actual service. `pane_current_command` cannot
+ * answer this: services run under a `$SHELL -lc '<cmd>; exec $SHELL -l'`
  * wrapper, so it reports the wrapper shell even while the service is alive.
- * Used to tell "service still shutting down" from "idle shell, safe to type".
+ * "Has any child" cannot answer it either — ctrl-c and dashboard clicks leave
+ * extra login shells parented to the pane shell, which read as "still
+ * shutting down" forever.
+ *
+ * Used to tell "service still shutting down" from "idle shell, safe to type",
+ * and to report status for services that listen on no port.
  */
-function paneHasRunningChild(sessionName: string, pane: PaneInfo): boolean {
-  try {
-    const panePid = execSync(
-      `tmux display-message -p -t ${sessionName}:${pane.windowIndex}.${pane.paneIndex} "#{pane_pid}"`,
-      { encoding: 'utf-8' }
-    ).trim();
-    if (!/^\d+$/.test(panePid)) return false;
-    execSync(`pgrep -P ${panePid}`, { stdio: 'ignore' });
-    return true; // pgrep exits 0 only when at least one child matches
-  } catch {
-    return false;
-  }
+function paneHasRunningService(sessionName: string, pane: PaneInfo): boolean {
+  const pid = panePid(sessionName, pane);
+  if (pid === undefined) return false;
+  return hasRunningService(pid);
 }
 
 function selectPane(sessionName: string, windowTarget: string | number, pane: number): void {
@@ -582,6 +580,16 @@ function pipePane(
     `tmux pipe-pane -t ${paneTarget(sessionName, windowTarget, pane)} -o ${escapeForShell(command)}`,
     { stdio: 'ignore' }
   );
+}
+
+function closePipePane(sessionName: string, windowTarget: string | number, pane: number): void {
+  try {
+    execFileSync('tmux', ['pipe-pane', '-t', paneTarget(sessionName, windowTarget, pane)], {
+      stdio: 'ignore',
+    });
+  } catch {
+    // No pipe, or the pane is already gone.
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -639,12 +647,12 @@ export {
   findServicePane,
   captureServicePane,
   pipeServicePane,
-  isPaneRunningCommand,
-  paneHasRunningChild,
+  paneHasRunningService,
   selectPane,
   setPaneTitle,
   enablePaneBorders,
   pipePane,
+  closePipePane,
   isTmuxAvailable,
   isInsideTmux,
 };

--- a/dev/local/tunnel-health.test.ts
+++ b/dev/local/tunnel-health.test.ts
@@ -1,0 +1,153 @@
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as http from 'node:http';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import test from 'node:test';
+
+import {
+  isPortlessServiceHealthy,
+  isPublicUrl,
+  isTunnelUrlServing,
+  readCapturedTunnelUrl,
+  readEnvValueFromText,
+  TUNNEL_URL_SOURCES,
+} from './tunnel-health';
+
+function withTempRepo(files: Record<string, string>): string {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-tunnel-health-'));
+  for (const [relative, content] of Object.entries(files)) {
+    const target = path.join(root, relative);
+    fs.mkdirSync(path.dirname(target), { recursive: true });
+    fs.writeFileSync(target, content);
+  }
+  return root;
+}
+
+function listen(handler: http.RequestListener): Promise<{ url: string; close: () => void }> {
+  const server = http.createServer(handler);
+  return new Promise(resolve => {
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address();
+      if (address === null || typeof address === 'string') throw new Error('no port');
+      resolve({
+        url: `http://127.0.0.1:${address.port}`,
+        close: () => server.close(),
+      });
+    });
+  });
+}
+
+test('readEnvValueFromText takes the last active assignment and ignores comments', () => {
+  const content = [
+    '# WORKER_URL=https://commented.trycloudflare.com',
+    'WORKER_URL=https://first.trycloudflare.com',
+    'OTHER=1',
+    'WORKER_URL="https://second.trycloudflare.com"',
+  ].join('\n');
+
+  assert.equal(readEnvValueFromText(content, 'WORKER_URL'), 'https://second.trycloudflare.com');
+  assert.equal(readEnvValueFromText(content, 'MISSING'), undefined);
+  assert.equal(readEnvValueFromText('WORKER_URL=\n', 'WORKER_URL'), undefined);
+});
+
+test('readCapturedTunnelUrl reads the file each tunnel script writes', () => {
+  const source = TUNNEL_URL_SOURCES['cloud-agent-public-tunnels'];
+  assert.ok(source);
+  const repoRoot = withTempRepo({
+    [source.file]: `${source.key}=https://tunnel.trycloudflare.com\n`,
+  });
+
+  assert.equal(
+    readCapturedTunnelUrl(repoRoot, 'cloud-agent-public-tunnels'),
+    'https://tunnel.trycloudflare.com'
+  );
+  assert.equal(readCapturedTunnelUrl(repoRoot, 'nextjs'), undefined);
+  assert.equal(readCapturedTunnelUrl('/missing', 'cloud-agent-public-tunnels'), undefined);
+});
+
+test('readCapturedTunnelUrl rejects a value that is not a URL', () => {
+  const source = TUNNEL_URL_SOURCES['kiloclaw-tunnel'];
+  assert.ok(source);
+  const repoRoot = withTempRepo({ [source.file]: `${source.key}=set-me\n` });
+
+  assert.equal(readCapturedTunnelUrl(repoRoot, 'kiloclaw-tunnel'), undefined);
+});
+
+test('isTunnelUrlServing probes /health and treats a live origin as up', async () => {
+  const livePaths: string[] = [];
+  const live = await listen((req, res) => {
+    livePaths.push(req.url ?? '');
+    res.writeHead(req.url === '/health' ? 200 : 404);
+    res.end(req.url === '/health' ? '{"status":"ok"}' : 'not found');
+  });
+  const dead = await listen((_req, res) => {
+    res.writeHead(530); // what the Cloudflare edge returns for a dead quick tunnel
+    res.end('tunnel gone');
+  });
+
+  try {
+    assert.equal(await isTunnelUrlServing(live.url), true);
+    assert.deepEqual(livePaths, ['/health']);
+    assert.equal(await isTunnelUrlServing(`${live.url}/api/gateway/`), true);
+    assert.deepEqual(livePaths, ['/health', '/api/gateway/health']);
+    assert.equal(await isTunnelUrlServing(dead.url), false);
+  } finally {
+    live.close();
+    dead.close();
+  }
+});
+
+test('isTunnelUrlServing reports an unreachable host as down without hanging', async () => {
+  const closed = await listen((_req, res) => res.end('ok'));
+  const url = closed.url;
+  closed.close();
+
+  assert.equal(await isTunnelUrlServing(url, 500), false);
+});
+
+test('isTunnelUrlServing treats a 404 on /health as up', async () => {
+  const origin = await listen((req, res) => {
+    res.writeHead(req.url === '/health' ? 404 : 500);
+    res.end('not found');
+  });
+
+  try {
+    assert.equal(await isTunnelUrlServing(origin.url), true);
+  } finally {
+    origin.close();
+  }
+});
+
+test('isPublicUrl rejects the local URLs docker-local mode writes', () => {
+  // kiloclaw-tunnel writes BACKEND_API_URL=http://localhost:<nextjs-port> when
+  // the docker-local provider skips tunnels. That port answers because nextjs
+  // is up, which says nothing about the tunnel service.
+  assert.equal(isPublicUrl('http://localhost:5500'), false);
+  assert.equal(isPublicUrl('http://127.0.0.1:5500'), false);
+  assert.equal(isPublicUrl('http://host.docker.internal:5500/api/gateway/'), false);
+  assert.equal(isPublicUrl('https://tunnel.trycloudflare.com'), true);
+  assert.equal(isPublicUrl('not-a-url'), false);
+});
+
+test('isPortlessServiceHealthy reports a captured dead URL as down even if the pane is alive', async () => {
+  const source = TUNNEL_URL_SOURCES['cloud-agent-public-tunnels'];
+  assert.ok(source);
+  const dead = withTempRepo({
+    [source.file]: `${source.key}=https://does-not-resolve-kilo-dev.invalid\n`,
+  });
+  const none = withTempRepo({});
+
+  assert.equal(await isPortlessServiceHealthy(dead, 'cloud-agent-public-tunnels', true), false);
+  assert.equal(await isPortlessServiceHealthy(none, 'cloud-agent-public-tunnels', true), true);
+  assert.equal(await isPortlessServiceHealthy(none, 'cloud-agent-public-tunnels', false), false);
+  assert.equal(await isPortlessServiceHealthy(none, 'stripe', true), true);
+});
+
+test('readCapturedTunnelUrl ignores a local URL from docker-local mode', () => {
+  const source = TUNNEL_URL_SOURCES['kiloclaw-tunnel'];
+  assert.ok(source);
+  const repoRoot = withTempRepo({ [source.file]: `${source.key}=http://localhost:5500\n` });
+
+  assert.equal(readCapturedTunnelUrl(repoRoot, 'kiloclaw-tunnel'), undefined);
+});

--- a/dev/local/tunnel-health.ts
+++ b/dev/local/tunnel-health.ts
@@ -1,0 +1,129 @@
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+/**
+ * Liveness for tunnel services, which listen on no local port.
+ *
+ * A tunnel's supervisor can die while its `cloudflared` children keep serving
+ * (they get reparented), so the pane says "idle" while the public URL still
+ * answers. Each tunnel script writes the URL it captured into an env file —
+ * that captured URL, not the pane, is the honest source of truth.
+ */
+
+type TunnelUrlSource = {
+  /** Repo-relative env file the tunnel script writes on capture. */
+  file: string;
+  key: string;
+};
+
+// Keys must match what dev/local/scripts/start-*tunnel*.ts write.
+const TUNNEL_URL_SOURCES: Record<string, TunnelUrlSource> = {
+  'cloud-agent-public-tunnels': {
+    file: 'services/cloud-agent-next/.dev.vars',
+    key: 'WORKER_URL',
+  },
+  'kiloclaw-tunnel': {
+    file: 'services/kiloclaw/.dev.vars',
+    key: 'BACKEND_API_URL',
+  },
+  'app-builder-tunnel': {
+    file: 'apps/web/.env.development.local',
+    key: 'APP_BUILDER_URL',
+  },
+  'bitbucket-webhook-tunnel': {
+    file: 'apps/web/.env.development.local',
+    key: 'BITBUCKET_CODE_REVIEW_WEBHOOK_BASE_URL',
+  },
+};
+
+/** Read `key` from dotenv-style text. Later assignments win, comments do not. */
+function readEnvValueFromText(content: string, key: string): string | undefined {
+  let value: string | undefined;
+  for (const line of content.split('\n')) {
+    const trimmed = line.trim();
+    if (!trimmed.startsWith(`${key}=`)) continue;
+    value = trimmed.slice(key.length + 1).replace(/^["']|["']$/g, '');
+  }
+  return value === '' ? undefined : value;
+}
+
+// A local host proves nothing about a tunnel: kiloclaw-tunnel writes
+// `BACKEND_API_URL=http://localhost:<nextjs-port>` in docker-local mode, and
+// that port answers because *nextjs* is up. Only a public host is evidence.
+const LOCAL_HOSTS = new Set(['localhost', '127.0.0.1', '::1', 'host.docker.internal', '0.0.0.0']);
+
+function isPublicUrl(url: string): boolean {
+  try {
+    const { protocol, hostname } = new URL(url);
+    if (protocol !== 'http:' && protocol !== 'https:') return false;
+    return !LOCAL_HOSTS.has(hostname.replace(/^\[|\]$/g, ''));
+  } catch {
+    return false;
+  }
+}
+
+function readCapturedTunnelUrl(repoRoot: string, serviceName: string): string | undefined {
+  const source = TUNNEL_URL_SOURCES[serviceName];
+  if (!source) return undefined;
+  try {
+    const url = readEnvValueFromText(
+      fs.readFileSync(path.join(repoRoot, source.file), 'utf-8'),
+      source.key
+    );
+    return url !== undefined && isPublicUrl(url) ? url : undefined;
+  } catch {
+    return undefined; // env file not written yet — the tunnel never captured a URL
+  }
+}
+
+function healthCheckUrl(url: string): string {
+  const parsed = new URL(url);
+  parsed.pathname = `${parsed.pathname.replace(/\/+$/, '')}/health`;
+  return parsed.href;
+}
+
+/**
+ * Whether the captured URL still serves. A quick tunnel whose `cloudflared`
+ * exited keeps resolving but the Cloudflare edge answers 502/530, so any 5xx
+ * counts as down. Probe `/health` so workers that implement it return 200;
+ * 404/405 from a live origin still counts as up.
+ */
+async function isTunnelUrlServing(url: string, timeoutMs = 2000): Promise<boolean> {
+  try {
+    const response = await fetch(healthCheckUrl(url), {
+      method: 'GET',
+      redirect: 'manual',
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    await response.body?.cancel();
+    return response.status < 500;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Portless status: a captured public URL is the source of truth. cloudflared
+ * stays in the pane tree while it retries a hostname that no longer resolves,
+ * so process-alive alone would report a dead tunnel as up.
+ */
+async function isPortlessServiceHealthy(
+  repoRoot: string,
+  serviceName: string,
+  paneAlive: boolean,
+  timeoutMs = 2000
+): Promise<boolean> {
+  const url = readCapturedTunnelUrl(repoRoot, serviceName);
+  if (url !== undefined) return isTunnelUrlServing(url, timeoutMs);
+  return paneAlive;
+}
+
+export {
+  isPortlessServiceHealthy,
+  isPublicUrl,
+  isTunnelUrlServing,
+  readCapturedTunnelUrl,
+  readEnvValueFromText,
+  TUNNEL_URL_SOURCES,
+};
+export type { TunnelUrlSource };

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "dev:stop": "tsx dev/local/cli.ts stop",
     "dev:status": "tsx dev/local/cli.ts status",
     "dev:restart": "tsx dev/local/cli.ts restart",
+    "dev:start-command": "tsx dev/local/cli.ts start-command",
     "dev:capture": "tsx dev/local/cli.ts capture",
     "dev:env": "tsx dev/local/cli.ts env",
     "dev:infra-env": "tsx dev/local/infra-env.ts",


### PR DESCRIPTION
## Stack

1. **This PR** — local public tunnels and exclusive worktree ports
2. `sticky-slider-vercel` — gated Vercel sandbox provider
3. `sticky-slider` — call-home control plane

## Summary

Worktree stacks pick exclusive offsets, report honest process liveness, and can start Cloudflare quick tunnels so a remote sandbox can call home to this checkout.

No production Worker or session behavior changes.

