### PR TITLE
feat(cloud-agent-next): add gated Vercel sandbox provider

### DIFF
--- a/ENVIRONMENT.md
+++ b/ENVIRONMENT.md
@@ -360,6 +360,8 @@ When `VERCEL_TARGET_ENV` is absent in local development or a script process, tra
 - `KILO_BIN_PATH` - Path or name of the `kilo` CLI binary; used by `services/cloud-agent-next/scripts/update-default-slash-commands.mjs`. [SERVER]
 - `WORKSPACE_PATH` - Filesystem path of the agent workspace. [SERVER]
 - `SESSION_ID` - Reserved session identifier for the `cloud-agent-next` runtime; reserved in `RESERVED_ENV_VARS`. [SERVER]
+- `CONTROL_PLANE_IDS` - Comma-separated user or org IDs admitted to the call-home control plane at session creation. Empty admits nobody. `*` includes personal accounts. [SERVER]
+- `VERCEL_SANDBOX_ORG_IDS` - Comma-separated org IDs routed to Vercel sandboxes. Empty is off. `*` includes personal accounts. [SERVER]
 - `HOME` - Reserved in `RESERVED_ENV_VARS` for cloud-agent-next session home management. [SYSTEM]
 
 ### Gastown

--- a/services/cloud-agent-next/.dev.vars.example
+++ b/services/cloud-agent-next/.dev.vars.example
@@ -51,6 +51,24 @@ KILOCODE_TOKEN_CONTAINMENT_ORG_IDS=
 # Comma-separated list of org IDs that receive workspace repo snapshots, or `*` for all orgs/users
 REPO_SNAPSHOT_ORG_IDS=
 
+# Vercel Sandbox operational configuration (optional)
+# Snapshot/build values must come from a successful `pnpm --filter cloud-agent-next snapshot:vercel`
+# acceptance run. Partial configuration never enables Vercel.
+VERCEL_PROJECT_ID=
+VERCEL_TEAM_ID=
+VERCEL_SANDBOX_SNAPSHOT_ID=
+VERCEL_SANDBOX_RUNTIME_BUILD_ID=
+VERCEL_SANDBOX_RUNTIME=node24
+VERCEL_SANDBOX_INITIAL_TIMEOUT_MS=300000
+VERCEL_SANDBOX_EXTEND_DURATION_MS=600000
+# Keep `VERCEL_TOKEN` in local secrets/.dev.vars only; never commit a token value.
+# VERCEL_TOKEN=
+
+# Vercel enrollment is the allowlist itself. Empty is off. Comma-separated org
+# IDs, or `*` for every organization and personal accounts. Organizations must
+# also be isolated by PER_SESSION_SANDBOX_ORG_IDS.
+VERCEL_SANDBOX_ORG_IDS=
+
 # GitHub App credentials for git commit attribution
 # These identify commits as coming from the Kilo Code GitHub App
 # Format for git config:

--- a/services/cloud-agent-next/package.json
+++ b/services/cloud-agent-next/package.json
@@ -16,9 +16,9 @@
     "prestart": "pnpm run build:wrapper",
     "start": "scripts/dev-with-docker-proxy.sh",
     "types": "wrangler types",
-    "lint": "pnpm -w exec oxlint --config .oxlintrc.json services/cloud-agent-next/src services/cloud-agent-next/wrapper/src",
-    "format": "oxfmt src",
-    "format:check": "oxfmt --list-different src",
+    "lint": "pnpm -w exec oxlint --config .oxlintrc.json services/cloud-agent-next/src services/cloud-agent-next/scripts services/cloud-agent-next/wrapper/src",
+    "format": "oxfmt src scripts",
+    "format:check": "oxfmt --list-different src scripts",
     "build:wrapper": "bun run --cwd wrapper build",
     "test": "vitest run",
     "test:watch": "vitest",
@@ -27,6 +27,7 @@
     "test:wrapper": "pnpm -C wrapper run test",
     "test:all": "vitest run && vitest run --config vitest.workers.config.ts && pnpm run test:wrapper",
     "typecheck": "tsgo --noEmit && pnpm -C wrapper run typecheck",
+    "snapshot:vercel": "tsx scripts/vercel-snapshot.ts",
     "update-default-slash-commands": "node scripts/update-default-slash-commands.mjs"
   },
   "dependencies": {

--- a/services/cloud-agent-next/scripts/vercel-snapshot.test.ts
+++ b/services/cloud-agent-next/scripts/vercel-snapshot.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it, vi } from 'vitest';
+import { WRAPPER_VERSION } from '../src/shared/wrapper-version.js';
+import {
+  applyDevVarsFallback,
+  createAcceptedConfig,
+  createRuntimeManifest,
+  defaultRuntimeBuildId,
+  main,
+  parseDevVars,
+  parseScanOutput,
+  redactSecrets,
+  resolveSnapshotInputs,
+  truncateOutput,
+  validateRuntimeManifest,
+} from './vercel-snapshot.js';
+
+describe('Vercel snapshot operator pure logic', () => {
+  const manifest = createRuntimeManifest({
+    runtimeBuildId: 'cloud-agent-2026-06-10.1',
+    wrapperVersion: '2.3.0',
+    wrapperBytes: new TextEncoder().encode('wrapper'),
+  });
+
+  it('creates a deterministic pinned manifest', () => {
+    expect(manifest).toEqual({
+      runtimeBuildId: 'cloud-agent-2026-06-10.1',
+      wrapperVersion: '2.3.0',
+      runtime: 'node24',
+      bunVersion: '1.3.14',
+      wrapperSha256: 'a622b10ddc23c8c9e9ec39d4833ae9b7b772ef40cb430425cb1689b76ec3490c',
+    });
+  });
+
+  it('reports manifest fields that do not match', () => {
+    expect(validateRuntimeManifest({ ...manifest, runtime: 'node22' }, manifest)).toEqual([
+      'runtime mismatch',
+    ]);
+  });
+
+  it('normalizes scan observations without exposing file contents', () => {
+    expect(
+      parseScanOutput('repository\t/vercel/sandbox/.git\ncredential-path\t/root/.ssh\n')
+    ).toEqual([
+      { kind: 'credential-path', path: '/root/.ssh' },
+      { kind: 'repository', path: '/vercel/sandbox/.git' },
+    ]);
+  });
+
+  it('rejects malformed scan output', () => {
+    expect(() => parseScanOutput('credential-path\trelative/path\n')).toThrow(
+      'invalid scan output'
+    );
+  });
+
+  it('loads token, team, and project from .dev.vars when the process env is empty', () => {
+    const vars = parseDevVars(
+      [
+        'VERCEL_TOKEN=token-from-file',
+        "VERCEL_TEAM_ID='team_from_file'",
+        'VERCEL_PROJECT_ID="prj_from_file"',
+        '',
+      ].join('\n')
+    );
+    const env: NodeJS.ProcessEnv = {};
+    applyDevVarsFallback(env, vars);
+    expect(env).toEqual({
+      VERCEL_TOKEN: 'token-from-file',
+      VERCEL_TEAM_ID: 'team_from_file',
+      VERCEL_PROJECT_ID: 'prj_from_file',
+    });
+  });
+
+  it('defaults wrapper path, wrapper version, and a dated build id', () => {
+    const input = resolveSnapshotInputs({});
+    expect(input.wrapperPath).toMatch(/wrapper\/dist\/wrapper\.js$/);
+    expect(input.controlWrapperPath).toMatch(/wrapper\/dist\/control-wrapper\.js$/);
+    expect(input.wrapperVersion).toBe(WRAPPER_VERSION);
+    expect(input.runtimeBuildId).toMatch(/^local-\d{8}-\d{6}$/);
+    expect(defaultRuntimeBuildId(new Date('2026-08-19T12:34:56.000Z'))).toBe(
+      'local-20260819-123456'
+    );
+  });
+
+  it('does not overwrite an already-exported VERCEL_TOKEN', () => {
+    const env: NodeJS.ProcessEnv = { VERCEL_TOKEN: 'exported-token' };
+    applyDevVarsFallback(env, parseDevVars('VERCEL_TOKEN=file-token\n'));
+    expect(env.VERCEL_TOKEN).toBe('exported-token');
+  });
+
+  it('redacts secrets and keeps the tail of long command output', () => {
+    expect(redactSecrets('token=abc123 leftover', ['abc123'])).toBe('token=[redacted] leftover');
+    expect(truncateOutput('abcdefghij', 4)).toBe('…ghij');
+  });
+
+  it('emits only accepted runtime enrollment configuration', () => {
+    expect(createAcceptedConfig('snap_123', manifest)).toEqual({
+      VERCEL_SANDBOX_SNAPSHOT_ID: 'snap_123',
+      VERCEL_SANDBOX_RUNTIME_BUILD_ID: 'cloud-agent-2026-06-10.1',
+      VERCEL_SANDBOX_RUNTIME: 'node24',
+    });
+  });
+
+  it('documents activation ordering and the post-activation rollback constraint', async () => {
+    const write = vi.spyOn(process.stdout, 'write').mockImplementation(() => true);
+
+    await main(['help']);
+
+    const output = write.mock.calls.map(([chunk]) => String(chunk)).join('');
+    expect(output).toContain('Deploy code with VERCEL_SANDBOX_ORG_IDS empty');
+    expect(output).toContain(
+      'Disabling enrollment prevents new Vercel selection but does not stop already-pinned sessions'
+    );
+    expect(output).toContain(
+      'Do not roll code back past version-2 tombstone support until live Vercel sessions and version-2 tombstones are drained or remediated'
+    );
+    write.mockRestore();
+  });
+});

--- a/services/cloud-agent-next/scripts/vercel-snapshot.test.ts
+++ b/services/cloud-agent-next/scripts/vercel-snapshot.test.ts
@@ -61,7 +61,7 @@ describe('Vercel snapshot operator pure logic', () => {
         '',
       ].join('\n')
     );
-    const env: NodeJS.ProcessEnv = {};
+    const env: Record<string, string | undefined> = {};
     applyDevVarsFallback(env, vars);
     expect(env).toEqual({
       VERCEL_TOKEN: 'token-from-file',
@@ -82,7 +82,7 @@ describe('Vercel snapshot operator pure logic', () => {
   });
 
   it('does not overwrite an already-exported VERCEL_TOKEN', () => {
-    const env: NodeJS.ProcessEnv = { VERCEL_TOKEN: 'exported-token' };
+    const env: Record<string, string | undefined> = { VERCEL_TOKEN: 'exported-token' };
     applyDevVarsFallback(env, parseDevVars('VERCEL_TOKEN=file-token\n'));
     expect(env.VERCEL_TOKEN).toBe('exported-token');
   });

--- a/services/cloud-agent-next/scripts/vercel-snapshot.ts
+++ b/services/cloud-agent-next/scripts/vercel-snapshot.ts
@@ -170,7 +170,7 @@ export function parseDevVars(content: string): Map<string, string> {
 }
 
 export function applyDevVarsFallback(
-  env: NodeJS.ProcessEnv,
+  env: Record<string, string | undefined>,
   vars: Map<string, string>,
   keys: readonly string[] = DEV_VARS_FALLBACK_KEYS
 ): void {

--- a/services/cloud-agent-next/scripts/vercel-snapshot.ts
+++ b/services/cloud-agent-next/scripts/vercel-snapshot.ts
@@ -1,0 +1,1154 @@
+#!/usr/bin/env node
+
+import { createHash, randomUUID } from 'node:crypto';
+import { spawn } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { readFile, writeFile } from 'node:fs/promises';
+import { basename, dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { WRAPPER_VERSION } from '../src/shared/wrapper-version.js';
+
+export const SNAPSHOT_RUNTIME = 'node24';
+export const PINNED_BUN_VERSION = '1.3.14';
+export const PINNED_KILO_VERSION = '7.4.20';
+export const SNAPSHOT_MANIFEST_PATH = '/usr/local/share/kilo/runtime-manifest.json';
+export const SNAPSHOT_WRAPPER_PATH = '/usr/local/bin/kilocode-wrapper.js';
+export const SNAPSHOT_CONTROL_WRAPPER_PATH = '/usr/local/bin/kilocode-control-wrapper.js';
+const API_BASE = 'https://api.vercel.com';
+const DEFAULT_TIMEOUT_MS = 10 * 60_000;
+const MAX_RESPONSE_BYTES = 1024 * 1024;
+const MAX_FAILURE_OUTPUT_CHARS = 8_000;
+const WAITED_COMMAND_TRANSPORT_ALLOWANCE_MS = 15_000;
+const SECRET_ENV_NAMES = ['VERCEL_TOKEN'];
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEV_VARS_PATH = resolve(PACKAGE_ROOT, '.dev.vars');
+const DEFAULT_WRAPPER_PATH = resolve(PACKAGE_ROOT, 'wrapper', 'dist', 'wrapper.js');
+const DEFAULT_CONTROL_WRAPPER_PATH = resolve(PACKAGE_ROOT, 'wrapper', 'dist', 'control-wrapper.js');
+const DEV_VARS_FALLBACK_KEYS = ['VERCEL_TOKEN', 'VERCEL_TEAM_ID', 'VERCEL_PROJECT_ID'];
+
+export type RuntimeManifest = {
+  runtimeBuildId: string;
+  wrapperVersion: string;
+  runtime: typeof SNAPSHOT_RUNTIME;
+  bunVersion: string;
+  wrapperSha256: string;
+};
+
+export type ScanObservation = {
+  kind: 'credential-path' | 'git-config' | 'git-remote' | 'repository' | 'session-log';
+  path: string;
+};
+
+export type AcceptedConfig = {
+  VERCEL_SANDBOX_SNAPSHOT_ID: string;
+  VERCEL_SANDBOX_RUNTIME_BUILD_ID: string;
+  VERCEL_SANDBOX_RUNTIME: typeof SNAPSHOT_RUNTIME;
+};
+
+type ProviderConfig = { token: string; teamId: string; projectId: string };
+type Args = Record<string, string | boolean>;
+type SessionTarget = { sandboxName: string; sessionId: string };
+const liveSessions = new Set<SessionTarget>();
+
+function log(message: string): void {
+  process.stderr.write(`[snapshot] ${message}\n`);
+}
+
+export function redactSecrets(text: string, secrets: readonly string[]): string {
+  return secrets.reduce(
+    (value, secret) => (secret ? value.split(secret).join('[redacted]') : value),
+    text
+  );
+}
+
+export function truncateOutput(text: string, maxChars = MAX_FAILURE_OUTPUT_CHARS): string {
+  const trimmed = text.replaceAll('\0', '').trimEnd();
+  if (trimmed.length <= maxChars) return trimmed;
+  return `…${trimmed.slice(-maxChars)}`;
+}
+
+export function createRuntimeManifest(input: {
+  runtimeBuildId: string;
+  wrapperVersion: string;
+  wrapperBytes: Uint8Array;
+  bunVersion?: string;
+}): RuntimeManifest {
+  if (!/^[A-Za-z0-9._-]{1,128}$/.test(input.runtimeBuildId)) {
+    throw new Error('runtime build ID must be 1-128 URL-safe characters');
+  }
+  if (!/^\d+\.\d+\.\d+$/.test(input.wrapperVersion)) {
+    throw new Error('wrapper version must be a semantic version');
+  }
+  return {
+    runtimeBuildId: input.runtimeBuildId,
+    wrapperVersion: input.wrapperVersion,
+    runtime: SNAPSHOT_RUNTIME,
+    bunVersion: input.bunVersion ?? PINNED_BUN_VERSION,
+    wrapperSha256: createHash('sha256').update(input.wrapperBytes).digest('hex'),
+  };
+}
+
+export function validateRuntimeManifest(actual: unknown, expected: RuntimeManifest): string[] {
+  if (!actual || typeof actual !== 'object' || Array.isArray(actual))
+    return ['manifest is not an object'];
+  const record = actual as Record<string, unknown>;
+  return (Object.keys(expected) as Array<keyof RuntimeManifest>)
+    .filter(key => record[key] !== expected[key])
+    .map(key => `${key} mismatch`);
+}
+
+export function parseScanOutput(output: string): ScanObservation[] {
+  const allowedKinds = new Set<ScanObservation['kind']>([
+    'credential-path',
+    'git-config',
+    'git-remote',
+    'repository',
+    'session-log',
+  ]);
+  const observations: ScanObservation[] = [];
+  for (const line of output.split('\n')) {
+    if (!line) continue;
+    const tab = line.indexOf('\t');
+    if (tab < 1) throw new Error('invalid scan output');
+    const kind = line.slice(0, tab);
+    const path = line.slice(tab + 1);
+    if (!allowedKinds.has(kind as ScanObservation['kind']) || !path.startsWith('/')) {
+      throw new Error('invalid scan output');
+    }
+    observations.push({ kind: kind as ScanObservation['kind'], path });
+  }
+  return observations.sort((a, b) => `${a.kind}\0${a.path}`.localeCompare(`${b.kind}\0${b.path}`));
+}
+
+export function createAcceptedConfig(
+  snapshotId: string,
+  manifest: RuntimeManifest
+): AcceptedConfig {
+  if (!snapshotId || snapshotId.length > 256) throw new Error('invalid snapshot ID');
+  return {
+    VERCEL_SANDBOX_SNAPSHOT_ID: snapshotId,
+    VERCEL_SANDBOX_RUNTIME_BUILD_ID: manifest.runtimeBuildId,
+    VERCEL_SANDBOX_RUNTIME: manifest.runtime,
+  };
+}
+
+function parseArgs(argv: string[]): { command: string; args: Args } {
+  const [command = 'help', ...rest] = argv;
+  const args: Args = {};
+  for (let index = 0; index < rest.length; index++) {
+    const item = rest[index];
+    if (!item.startsWith('--')) throw new Error(`unexpected argument: ${item}`);
+    const key = item.slice(2);
+    const next = rest[index + 1];
+    if (!next || next.startsWith('--')) args[key] = true;
+    else {
+      args[key] = next;
+      index++;
+    }
+  }
+  return { command, args };
+}
+
+export function parseDevVars(content: string): Map<string, string> {
+  const vars = new Map<string, string>();
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    const eqIdx = line.indexOf('=');
+    if (eqIdx === -1) continue;
+    const key = line.slice(0, eqIdx).trim();
+    let value = line.slice(eqIdx + 1).trim();
+    if (
+      (value.startsWith('"') && value.endsWith('"')) ||
+      (value.startsWith("'") && value.endsWith("'"))
+    ) {
+      value = value.slice(1, -1);
+    }
+    if (key) vars.set(key, value);
+  }
+  return vars;
+}
+
+export function applyDevVarsFallback(
+  env: NodeJS.ProcessEnv,
+  vars: Map<string, string>,
+  keys: readonly string[] = DEV_VARS_FALLBACK_KEYS
+): void {
+  for (const key of keys) {
+    if (env[key]?.trim()) continue;
+    const value = vars.get(key)?.trim();
+    if (value) env[key] = value;
+  }
+}
+
+function loadLocalDevVars(): void {
+  let content: string;
+  try {
+    content = readFileSync(DEV_VARS_PATH, 'utf8');
+  } catch {
+    return;
+  }
+  applyDevVarsFallback(process.env, parseDevVars(content));
+}
+
+function requiredArg(args: Args, name: string): string {
+  const value = args[name];
+  if (typeof value !== 'string' || value.length === 0) throw new Error(`--${name} is required`);
+  return value;
+}
+
+function optionalArg(args: Args, name: string): string | undefined {
+  const value = args[name];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+export function defaultRuntimeBuildId(now = new Date()): string {
+  const date = now.toISOString().slice(0, 10).replaceAll('-', '');
+  const time = now.toISOString().slice(11, 19).replaceAll(':', '');
+  return `local-${date}-${time}`;
+}
+
+export function resolveSnapshotInputs(args: Args): {
+  wrapperPath: string;
+  controlWrapperPath: string;
+  wrapperVersion: string;
+  runtimeBuildId: string;
+} {
+  return {
+    wrapperPath: resolve(optionalArg(args, 'wrapper') ?? DEFAULT_WRAPPER_PATH),
+    controlWrapperPath: resolve(
+      optionalArg(args, 'control-wrapper') ?? DEFAULT_CONTROL_WRAPPER_PATH
+    ),
+    wrapperVersion: optionalArg(args, 'wrapper-version') ?? WRAPPER_VERSION,
+    runtimeBuildId: optionalArg(args, 'build-id') ?? defaultRuntimeBuildId(),
+  };
+}
+
+function optionalNumber(args: Args, name: string, fallback: number): number {
+  const value = args[name];
+  if (value === undefined) return fallback;
+  if (typeof value !== 'string') throw new Error(`--${name} requires a value`);
+  const parsed = Number(value);
+  if (!Number.isInteger(parsed) || parsed < 1000)
+    throw new Error(`--${name} must be an integer >= 1000`);
+  return parsed;
+}
+
+function providerConfig(args: Args): ProviderConfig {
+  loadLocalDevVars();
+  const token = process.env.VERCEL_TOKEN?.trim();
+  if (!token) throw new Error('VERCEL_TOKEN is required for live operations');
+  const teamId = optionalArg(args, 'team-id') ?? process.env.VERCEL_TEAM_ID?.trim();
+  const projectId = optionalArg(args, 'project-id') ?? process.env.VERCEL_PROJECT_ID?.trim();
+  if (!teamId) throw new Error('--team-id is required (or set VERCEL_TEAM_ID in .dev.vars)');
+  if (!projectId)
+    throw new Error('--project-id is required (or set VERCEL_PROJECT_ID in .dev.vars)');
+  return { token, teamId, projectId };
+}
+
+function assertNoSecretArgs(argv: string[]): void {
+  for (const name of SECRET_ENV_NAMES) {
+    const value = process.env[name];
+    if (value && argv.some(argument => argument.includes(value))) {
+      throw new Error(`${name} must not be passed as a command argument`);
+    }
+  }
+}
+
+async function readBoundedBytes(
+  response: Response,
+  maxBytes: number,
+  operation: string
+): Promise<Uint8Array> {
+  const declaredLength = Number(response.headers.get('content-length') ?? 0);
+  if (declaredLength > maxBytes) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`${operation} response is too large`);
+  }
+  if (!response.body) throw new Error(`${operation} returned an empty response`);
+  const body = response.body as ReadableStream<Uint8Array>;
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let total = 0;
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk.done) break;
+      total += chunk.value.byteLength;
+      if (total > maxBytes) {
+        await reader.cancel().catch(() => undefined);
+        throw new Error(`${operation} response is too large`);
+      }
+      chunks.push(chunk.value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+  const bytes = new Uint8Array(total);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return bytes;
+}
+
+async function boundedJson(response: Response, operation: string): Promise<unknown> {
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`${operation} failed with status ${response.status}`);
+  }
+  const bytes = await readBoundedBytes(response, MAX_RESPONSE_BYTES, operation);
+  try {
+    return JSON.parse(new TextDecoder().decode(bytes));
+  } catch {
+    throw new Error(`${operation} returned invalid JSON`);
+  }
+}
+
+async function api(config: ProviderConfig, path: string, init: RequestInit, operation: string) {
+  const url = new URL(path, API_BASE);
+  url.searchParams.set('teamId', config.teamId);
+  const headers = new Headers(init.headers);
+  headers.set('Authorization', `Bearer ${config.token}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 60_000);
+  try {
+    return await boundedJson(
+      await fetch(url, { ...init, headers, signal: controller.signal }),
+      operation
+    );
+  } catch (error) {
+    if (error instanceof Error && error.name === 'AbortError')
+      throw new Error(`${operation} timed out`);
+    throw error;
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function object(value: unknown, operation: string): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    throw new Error(`${operation} returned an invalid response`);
+  }
+  return value as Record<string, unknown>;
+}
+
+function stringField(record: Record<string, unknown>, field: string, operation: string): string {
+  const value = record[field];
+  if (typeof value !== 'string' || !value)
+    throw new Error(`${operation} returned an invalid response`);
+  return value;
+}
+
+async function createSandbox(
+  config: ProviderConfig,
+  name: string,
+  timeoutMs: number,
+  snapshotId?: string
+): Promise<SessionTarget> {
+  const body = {
+    projectId: config.projectId,
+    name,
+    runtime: SNAPSHOT_RUNTIME,
+    timeout: timeoutMs,
+    persistent: false,
+    env: {},
+    ...(snapshotId ? { source: { type: 'snapshot', snapshotId } } : {}),
+    tags: { 'kilo-managed-by': 'snapshot-operator' },
+  };
+  const envelope = object(
+    await api(
+      config,
+      '/v2/sandboxes',
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+      },
+      'create sandbox'
+    ),
+    'create sandbox'
+  );
+  const sandbox = object(envelope.sandbox, 'create sandbox');
+  const session = object(envelope.session, 'create sandbox');
+  const sessionId = stringField(session, 'id', 'create sandbox');
+  if (
+    stringField(sandbox, 'name', 'create sandbox') !== name ||
+    sandbox.persistent !== false ||
+    sandbox.currentSessionId !== sessionId ||
+    session.sourceSandboxName !== name ||
+    session.projectId !== config.projectId ||
+    session.runtime !== SNAPSHOT_RUNTIME ||
+    (snapshotId && session.sourceSnapshotId !== snapshotId)
+  ) {
+    throw new Error('create sandbox correlation failed');
+  }
+  const target = { sandboxName: name, sessionId };
+  liveSessions.add(target);
+  log(`created ${name} session=${sessionId}${snapshotId ? ` snapshot=${snapshotId}` : ''}`);
+  return target;
+}
+
+function optionalStringField(record: Record<string, unknown>, field: string): string | undefined {
+  const value = record[field];
+  return typeof value === 'string' && value.length > 0 ? value : undefined;
+}
+
+function commandLabel(command: string, args: string[]): string {
+  const first = args[0] === '-lc' ? args[1] : args.join(' ');
+  const preview = first ? `${command} ${first}` : command;
+  return preview.length > 120 ? `${preview.slice(0, 117)}...` : preview;
+}
+
+function formatCommandFailure(
+  config: ProviderConfig,
+  sessionId: string,
+  command: string,
+  args: string[],
+  finished: Record<string, unknown> | undefined,
+  extras: string[]
+): string {
+  const exit =
+    finished && typeof finished.exitCode === 'number' ? ` (exit ${finished.exitCode})` : '';
+  const cmdId = finished ? optionalStringField(finished, 'id') : undefined;
+  const parts = [
+    `execute command failed${exit}: ${commandLabel(command, args)}`,
+    `session=${sessionId}`,
+  ];
+  if (cmdId) parts.push(`cmd=${cmdId}`);
+  const secrets = [config.token];
+  for (const extra of extras) {
+    const cleaned = truncateOutput(redactSecrets(extra, secrets));
+    if (cleaned) parts.push(cleaned);
+  }
+  return parts.join('\n');
+}
+
+async function readRemoteTextIfPresent(
+  config: ProviderConfig,
+  sessionId: string,
+  path: string
+): Promise<string | undefined> {
+  try {
+    return new TextDecoder().decode(await readRemoteFile(config, sessionId, path));
+  } catch {
+    return undefined;
+  }
+}
+
+async function execute(
+  config: ProviderConfig,
+  sessionId: string,
+  command: string,
+  args: string[],
+  options: { sudo?: boolean; timeoutMs?: number; label?: string } = {}
+): Promise<string> {
+  const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const stdoutPath = `/tmp/kilo-operator-${randomUUID()}.stdout`;
+  const stderrPath = `/tmp/kilo-operator-${randomUUID()}.stderr`;
+  const wrapped = `${shellCommand(command, args)} >${shellQuote(stdoutPath)} 2>${shellQuote(stderrPath)}`;
+  const body = {
+    command: 'bash',
+    args: ['-lc', wrapped],
+    env: {},
+    sudo: options.sudo ?? false,
+    wait: true,
+    timeout: timeoutMs,
+  };
+  log(options.label ?? `exec ${commandLabel(command, args)}`);
+  const response = await fetchWithAuth(
+    config,
+    `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/cmd`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    },
+    timeoutMs + WAITED_COMMAND_TRANSPORT_ALLOWANCE_MS
+  );
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    const stdout = await readRemoteTextIfPresent(config, sessionId, stdoutPath);
+    const stderr = await readRemoteTextIfPresent(config, sessionId, stderrPath);
+    throw new Error(
+      formatCommandFailure(config, sessionId, command, args, undefined, [
+        `http ${response.status}`,
+        stdout ? `stdout:\n${stdout}` : '',
+        stderr ? `stderr:\n${stderr}` : '',
+      ])
+    );
+  }
+  const text = await boundedText(response, 'execute command');
+  const lines = text.split('\n').filter(Boolean);
+  if (lines.length !== 2) throw new Error('execute command returned an invalid response');
+  let finished: Record<string, unknown>;
+  try {
+    finished = object(object(JSON.parse(lines[1]), 'execute command').command, 'execute command');
+  } catch {
+    throw new Error('execute command returned an invalid response');
+  }
+  if (finished.sessionId !== sessionId || finished.exitCode !== 0) {
+    const stdout = await readRemoteTextIfPresent(config, sessionId, stdoutPath);
+    const stderr = await readRemoteTextIfPresent(config, sessionId, stderrPath);
+    throw new Error(
+      formatCommandFailure(config, sessionId, command, args, finished, [
+        stdout ? `stdout:\n${stdout}` : '',
+        stderr ? `stderr:\n${stderr}` : '',
+      ])
+    );
+  }
+  const stdout = (await readRemoteTextIfPresent(config, sessionId, stdoutPath)) ?? '';
+  await executeRaw(config, sessionId, 'rm', ['-f', stdoutPath, stderrPath]).catch(() => undefined);
+  return stdout;
+}
+
+async function executeRaw(
+  config: ProviderConfig,
+  sessionId: string,
+  command: string,
+  args: string[]
+): Promise<void> {
+  const response = await fetchWithAuth(
+    config,
+    `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/cmd`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        command,
+        args,
+        env: {},
+        sudo: false,
+        wait: true,
+        timeout: 30_000,
+      }),
+    },
+    45_000
+  );
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`execute command failed with status ${response.status}`);
+  }
+  await response.body?.cancel().catch(() => undefined);
+}
+
+async function executeForFile(
+  config: ProviderConfig,
+  sessionId: string,
+  command: string,
+  args: string[]
+): Promise<string> {
+  return execute(config, sessionId, command, args, { label: 'capture remote output' });
+}
+
+async function fetchWithAuth(
+  config: ProviderConfig,
+  path: string,
+  init: RequestInit,
+  deadlineMs = 60_000
+): Promise<Response> {
+  const url = new URL(path, API_BASE);
+  url.searchParams.set('teamId', config.teamId);
+  const headers = new Headers(init.headers);
+  headers.set('Authorization', `Bearer ${config.token}`);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), deadlineMs);
+  try {
+    return await fetch(url, { ...init, headers, signal: controller.signal });
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+async function boundedText(response: Response, operation: string): Promise<string> {
+  return new TextDecoder().decode(await readBoundedBytes(response, MAX_RESPONSE_BYTES, operation));
+}
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'"'"'`)}'`;
+}
+
+function shellCommand(command: string, args: string[]): string {
+  return [command, ...args].map(shellQuote).join(' ');
+}
+
+function tarString(header: Uint8Array, offset: number, length: number, value: string): void {
+  const bytes = new TextEncoder().encode(value);
+  if (bytes.byteLength >= length) throw new Error('file path is too long');
+  header.set(bytes, offset);
+}
+
+function tarOctal(header: Uint8Array, offset: number, length: number, value: number): void {
+  tarString(header, offset, length, value.toString(8).padStart(length - 1, '0'));
+}
+
+async function gzipTar(path: string, content: Uint8Array): Promise<Uint8Array> {
+  const header = new Uint8Array(512);
+  tarString(header, 0, 100, path);
+  tarOctal(header, 100, 8, 0o755);
+  tarOctal(header, 108, 8, 0);
+  tarOctal(header, 116, 8, 0);
+  tarOctal(header, 124, 12, content.byteLength);
+  tarOctal(header, 136, 12, 0);
+  header.fill(0x20, 148, 156);
+  header[156] = 0x30;
+  tarString(header, 257, 8, 'ustar  ');
+  tarOctal(
+    header,
+    148,
+    8,
+    header.reduce((sum, byte) => sum + byte, 0)
+  );
+  const padding = new Uint8Array((512 - (content.byteLength % 512)) % 512);
+  const stream = new Blob([header, content, padding, new Uint8Array(1024)])
+    .stream()
+    .pipeThrough(new CompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+async function writeRemoteFile(
+  config: ProviderConfig,
+  sessionId: string,
+  destinationDirectory: string,
+  name: string,
+  content: Uint8Array
+): Promise<void> {
+  const response = await fetchWithAuth(
+    config,
+    `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/fs/write`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/gzip', 'x-cwd': destinationDirectory },
+      body: await gzipTar(name, content),
+    }
+  );
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`write file failed with status ${response.status}`);
+  }
+  await response.body?.cancel().catch(() => undefined);
+}
+
+async function readRemoteFile(
+  config: ProviderConfig,
+  sessionId: string,
+  path: string
+): Promise<Uint8Array> {
+  const response = await fetchWithAuth(
+    config,
+    `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/fs/read`,
+    {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path }),
+    }
+  );
+  if (!response.ok) {
+    await response.body?.cancel().catch(() => undefined);
+    throw new Error(`read file failed with status ${response.status}`);
+  }
+  return readBoundedBytes(response, MAX_RESPONSE_BYTES, 'read file');
+}
+
+async function stopSession(config: ProviderConfig, target: SessionTarget): Promise<void> {
+  log(`stopping ${target.sandboxName} session=${target.sessionId}`);
+  const envelope = object(
+    await api(
+      config,
+      `/v2/sandboxes/sessions/${encodeURIComponent(target.sessionId)}/stop`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: '{}',
+      },
+      'stop session'
+    ),
+    'stop session'
+  );
+  const session = object(envelope.session, 'stop session');
+  if (session.id !== target.sessionId || session.sourceSandboxName !== target.sandboxName) {
+    throw new Error('stop session correlation failed');
+  }
+  liveSessions.delete(target);
+}
+
+async function stopTrackedSessions(config: ProviderConfig): Promise<void> {
+  const remaining = [...liveSessions];
+  if (remaining.length === 0) return;
+  log(`stopping ${remaining.length} leftover sandbox${remaining.length === 1 ? '' : 'es'}`);
+  const failures: string[] = [];
+  for (const target of remaining) {
+    try {
+      await stopSession(config, target);
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'unknown failure';
+      failures.push(`${target.sandboxName}: ${message}`);
+    }
+  }
+  if (failures.length) throw new Error(`failed to stop leftover sandboxes: ${failures.join('; ')}`);
+}
+
+async function withTrackedSessions<T>(config: ProviderConfig, fn: () => Promise<T>): Promise<T> {
+  const onSignal = () => {
+    log('signal received; stopping leftover sandboxes');
+    void stopTrackedSessions(config).finally(() => process.exit(1));
+  };
+  process.once('SIGINT', onSignal);
+  process.once('SIGTERM', onSignal);
+  try {
+    return await fn();
+  } finally {
+    process.removeListener('SIGINT', onSignal);
+    process.removeListener('SIGTERM', onSignal);
+    await stopTrackedSessions(config).catch(error => {
+      const message = error instanceof Error ? error.message : 'unknown failure';
+      log(message);
+    });
+  }
+}
+
+async function extendSession(config: ProviderConfig, target: SessionTarget, duration: number) {
+  const envelope = object(
+    await api(
+      config,
+      `/v2/sandboxes/sessions/${encodeURIComponent(target.sessionId)}/extend-timeout`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration }),
+      },
+      'extend timeout'
+    ),
+    'extend timeout'
+  );
+  const session = object(envelope.session, 'extend timeout');
+  if (session.id !== target.sessionId || session.sourceSandboxName !== target.sandboxName) {
+    throw new Error('extend timeout correlation failed');
+  }
+}
+
+async function createSnapshot(config: ProviderConfig, sessionId: string): Promise<string> {
+  const envelope = object(
+    await api(
+      config,
+      `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}/snapshot`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ expiration: 0 }),
+      },
+      'create snapshot'
+    ),
+    'create snapshot'
+  );
+  const snapshot = object(envelope.snapshot, 'create snapshot');
+  if (snapshot.sourceSessionId !== sessionId || snapshot.status !== 'created') {
+    throw new Error('create snapshot correlation failed');
+  }
+  return stringField(snapshot, 'id', 'create snapshot');
+}
+
+async function listSnapshotIds(config: ProviderConfig): Promise<Set<string>> {
+  const url = new URL('/v2/sandboxes/snapshots', API_BASE);
+  url.searchParams.set('teamId', config.teamId);
+  url.searchParams.set('project', config.projectId);
+  url.searchParams.set('limit', '50');
+  const headers = new Headers({ Authorization: `Bearer ${config.token}` });
+  const envelope = object(
+    await boundedJson(await fetch(url, { headers }), 'list snapshots'),
+    'list snapshots'
+  );
+  if (!Array.isArray(envelope.snapshots))
+    throw new Error('list snapshots returned an invalid response');
+  return new Set(
+    envelope.snapshots.map(value =>
+      stringField(object(value, 'list snapshots'), 'id', 'list snapshots')
+    )
+  );
+}
+
+async function inspectSnapshot(
+  config: ProviderConfig,
+  snapshotId: string
+): Promise<Record<string, unknown>> {
+  const envelope = object(
+    await api(
+      config,
+      `/v2/sandboxes/snapshots/${encodeURIComponent(snapshotId)}`,
+      { method: 'GET' },
+      'get snapshot'
+    ),
+    'get snapshot'
+  );
+  const snapshot = object(envelope.snapshot, 'get snapshot');
+  if (snapshot.id !== snapshotId || snapshot.status !== 'created')
+    throw new Error('snapshot is unavailable');
+  return snapshot;
+}
+
+function scanCommand(): string {
+  return String.raw`set -euo pipefail
+emit() { printf '%s\t%s\n' "$1" "$2"; }
+for path in /root/.ssh /root/.aws /root/.config/gh /root/.config/glab /home/vercel-sandbox/.ssh /home/vercel-sandbox/.aws /home/vercel-sandbox/.config/gh /home/vercel-sandbox/.config/glab /vercel/sandbox/.env /vercel/sandbox/.env.local; do
+  [ ! -e "$path" ] || emit credential-path "$path"
+done
+for path in /root/.gitconfig /home/vercel-sandbox/.gitconfig /vercel/sandbox/.gitconfig; do
+  [ ! -s "$path" ] || emit git-config "$path"
+done
+for root in /vercel/sandbox /usr/local/share/kilo; do
+  [ -d "$root" ] || continue
+  find "$root" -xdev -type d -name .git -print
+done 2>/dev/null | LC_ALL=C sort | while IFS= read -r path; do emit repository "$path"; done
+for root in /vercel/sandbox /usr/local/share/kilo /tmp; do
+  [ -d "$root" ] || continue
+  find "$root" -xdev -type f \( -name '*.log' -o -name '*session*' \) -print
+done 2>/dev/null | LC_ALL=C sort | while IFS= read -r path; do emit session-log "$path"; done
+for root in /vercel/sandbox /usr/local/share/kilo; do
+  [ -d "$root" ] || continue
+  find "$root" -xdev -type f -path '*/.git/config' -print
+done 2>/dev/null | LC_ALL=C sort | while IFS= read -r path; do emit git-remote "$path"; done`;
+}
+
+async function scanRemote(config: ProviderConfig, sessionId: string): Promise<void> {
+  const output = await executeForFile(config, sessionId, 'bash', ['-lc', scanCommand()]);
+  const findings = parseScanOutput(output);
+  if (findings.length) {
+    throw new Error(
+      `credential/state scan failed: ${findings.map(item => `${item.kind}:${item.path}`).join(', ')}`
+    );
+  }
+}
+
+async function installBuilder(config: ProviderConfig, sessionId: string): Promise<void> {
+  const steps: Array<{ label: string; script: string }> = [
+    {
+      label: 'install packages (dnf)',
+      script: 'sudo dnf install -y git git-lfs jq tar gzip',
+    },
+    {
+      label: `install bun ${PINNED_BUN_VERSION}`,
+      script: `curl -fsSL https://bun.sh/install | bash -s ${shellQuote(`bun-v${PINNED_BUN_VERSION}`)} && sudo install -m 0755 "$HOME/.bun/bin/bun" /usr/local/bin/bun`,
+    },
+    {
+      label: `install kilo ${PINNED_KILO_VERSION}`,
+      script: `sudo npm install -g ${shellQuote(`@kilocode/cli@${PINNED_KILO_VERSION}`)}`,
+    },
+    {
+      label: 'verify runtime pins',
+      script: [
+        'sudo mkdir -p /usr/local/share/kilo /opt/git/etc',
+        'sudo git lfs install --system --skip-repo',
+        `test "$(bun --version)" = ${shellQuote(PINNED_BUN_VERSION)}`,
+        'case "$(node --version)" in v24.*) ;; *) echo "unexpected node $(node --version)" >&2; exit 1 ;; esac',
+        'curl --version >/dev/null',
+        'git --version >/dev/null',
+        'kilo --version >/dev/null',
+      ].join('\n'),
+    },
+  ];
+  for (const step of steps) {
+    await execute(config, sessionId, 'bash', ['-lc', `set -euo pipefail\n${step.script}`], {
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+      label: step.label,
+    });
+  }
+}
+
+async function smokeWrapper(config: ProviderConfig, sessionId: string, manifest: RuntimeManifest) {
+  const smokeSessionId = `agent_${randomUUID()}`;
+  const script = `set -euo pipefail
+rm -f /tmp/kilo-snapshot-smoke.log /tmp/kilo-snapshot-smoke.err /tmp/kilo-snapshot-health.json
+mkdir -p /tmp/kilo-snapshot-home
+dump_wrapper() {
+  echo "wrapper smoke failed" >&2
+  [ -s /tmp/kilo-snapshot-smoke.err ] && { echo "wrapper stderr:" >&2; cat /tmp/kilo-snapshot-smoke.err >&2; }
+  [ -s /tmp/kilo-snapshot-smoke.log ] && { echo "wrapper log:" >&2; cat /tmp/kilo-snapshot-smoke.log >&2; }
+}
+cleanup() { kill "$pid" 2>/dev/null || true; wait "$pid" 2>/dev/null || true; rm -rf /tmp/kilo-snapshot-home /tmp/kilo-snapshot-smoke.log /tmp/kilo-snapshot-smoke.err /tmp/kilo-snapshot-health.json; }
+HOME=/tmp/kilo-snapshot-home WRAPPER_PORT=5099 WRAPPER_LOG_PATH=/tmp/kilo-snapshot-smoke.log bun ${SNAPSHOT_WRAPPER_PATH} --agent-session ${shellQuote(smokeSessionId)} --user-id snapshot-operator >/tmp/kilo-snapshot-smoke.err 2>&1 &
+pid=$!
+trap cleanup EXIT
+for attempt in $(seq 1 60); do
+  if curl -fsS http://127.0.0.1:5099/health > /tmp/kilo-snapshot-health.json; then break; fi
+  if ! kill -0 "$pid" 2>/dev/null; then dump_wrapper; exit 1; fi
+  sleep 1
+done
+if [ ! -s /tmp/kilo-snapshot-health.json ]; then dump_wrapper; exit 1; fi
+jq -e --arg version ${shellQuote(manifest.wrapperVersion)} '.version == $version' /tmp/kilo-snapshot-health.json >/dev/null`;
+  await execute(config, sessionId, 'bash', ['-lc', script], {
+    timeoutMs: 90_000,
+    label: 'smoke wrapper',
+  });
+}
+
+async function runLocal(command: string, args: string[], cwd: string): Promise<void> {
+  await new Promise<void>((resolvePromise, reject) => {
+    const child = spawn(command, args, { cwd, stdio: 'inherit', env: process.env });
+    const timeout = setTimeout(() => {
+      child.kill('SIGTERM');
+      reject(new Error(`${command} timed out`));
+    }, DEFAULT_TIMEOUT_MS);
+    child.once('error', error => {
+      clearTimeout(timeout);
+      reject(new Error(`${command} failed to start: ${error.message}`));
+    });
+    child.once('exit', (code, signal) => {
+      clearTimeout(timeout);
+      if (code === 0) resolvePromise();
+      else reject(new Error(`${command} failed (${signal ?? `exit ${code ?? 'unknown'}`})`));
+    });
+  });
+}
+
+async function readExpectedManifest(args: Args): Promise<RuntimeManifest> {
+  const input = resolveSnapshotInputs(args);
+  const wrapperBytes = await readFile(input.wrapperPath);
+  return createRuntimeManifest({
+    runtimeBuildId: input.runtimeBuildId,
+    wrapperVersion: input.wrapperVersion,
+    wrapperBytes,
+  });
+}
+
+async function validateChild(
+  config: ProviderConfig,
+  snapshotId: string,
+  expected: RuntimeManifest,
+  timeoutMs: number
+): Promise<void> {
+  const target = await createSandbox(
+    config,
+    `ses-snapshot-validate-${randomUUID()}`,
+    timeoutMs,
+    snapshotId
+  );
+  try {
+    const raw = await readRemoteFile(config, target.sessionId, SNAPSHOT_MANIFEST_PATH);
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(new TextDecoder().decode(raw));
+    } catch {
+      throw new Error('runtime manifest is invalid JSON');
+    }
+    const errors = validateRuntimeManifest(manifest, expected);
+    if (errors.length) throw new Error(`runtime manifest validation failed: ${errors.join(', ')}`);
+    await execute(config, target.sessionId, 'bash', [
+      '-lc',
+      `test "$(bun --version)" = ${shellQuote(expected.bunVersion)} && test "$(sha256sum ${SNAPSHOT_WRAPPER_PATH} | cut -d' ' -f1)" = ${shellQuote(expected.wrapperSha256)} && test -f ${SNAPSHOT_CONTROL_WRAPPER_PATH} && git --version >/dev/null && kilo --version >/dev/null`,
+    ]);
+    await smokeWrapper(config, target.sessionId, expected);
+    await scanRemote(config, target.sessionId);
+  } finally {
+    await stopSession(config, target).catch(error => {
+      const message = error instanceof Error ? error.message : 'unknown failure';
+      log(`failed to stop ${target.sandboxName}: ${message}`);
+    });
+  }
+}
+
+async function buildSnapshot(args: Args): Promise<void> {
+  const config = providerConfig(args);
+  const { wrapperPath, controlWrapperPath } = resolveSnapshotInputs(args);
+  if (args['skip-wrapper-build'] !== true) {
+    log('building wrapper bundle');
+    await runLocal('bun', ['run', 'build'], dirname(dirname(wrapperPath)));
+  }
+  const expected = await readExpectedManifest(args);
+  const timeoutMs = optionalNumber(args, 'timeout-ms', DEFAULT_TIMEOUT_MS);
+  const wrapper = await readFile(wrapperPath);
+  const controlWrapper = await readFile(controlWrapperPath);
+  await withTrackedSessions(config, async () => {
+    const builder = await createSandbox(config, `ses-snapshot-builder-${randomUUID()}`, timeoutMs);
+    await installBuilder(config, builder.sessionId);
+    const stagedWrapperPath = `/tmp/${basename(SNAPSHOT_WRAPPER_PATH)}`;
+    const stagedControlWrapperPath = `/tmp/${basename(SNAPSHOT_CONTROL_WRAPPER_PATH)}`;
+    const stagedManifestPath = `/tmp/${basename(SNAPSHOT_MANIFEST_PATH)}`;
+    log('uploading wrapper, control wrapper, and runtime manifest');
+    await writeRemoteFile(config, builder.sessionId, '/tmp', basename(stagedWrapperPath), wrapper);
+    await writeRemoteFile(
+      config,
+      builder.sessionId,
+      '/tmp',
+      basename(stagedControlWrapperPath),
+      controlWrapper
+    );
+    await writeRemoteFile(
+      config,
+      builder.sessionId,
+      '/tmp',
+      basename(stagedManifestPath),
+      new TextEncoder().encode(`${JSON.stringify(expected, null, 2)}\n`)
+    );
+    await execute(
+      config,
+      builder.sessionId,
+      'bash',
+      [
+        '-lc',
+        `sudo install -m 0755 ${shellQuote(stagedWrapperPath)} ${shellQuote(SNAPSHOT_WRAPPER_PATH)} && sudo install -m 0755 ${shellQuote(stagedControlWrapperPath)} ${shellQuote(SNAPSHOT_CONTROL_WRAPPER_PATH)} && sudo install -m 0644 ${shellQuote(stagedManifestPath)} ${shellQuote(SNAPSHOT_MANIFEST_PATH)} && rm -f ${shellQuote(stagedWrapperPath)} ${shellQuote(stagedControlWrapperPath)} ${shellQuote(stagedManifestPath)}`,
+      ],
+      { label: 'install wrappers and manifest' }
+    );
+    log('smoking wrapper');
+    await smokeWrapper(config, builder.sessionId, expected);
+    log('scanning builder for leftover credentials/state');
+    await scanRemote(config, builder.sessionId);
+    log('creating snapshot');
+    const snapshotId = await createSnapshot(config, builder.sessionId);
+    log(`snapshot ${snapshotId}`);
+    await stopSession(config, builder);
+    await inspectSnapshot(config, snapshotId);
+    log('validating child from snapshot');
+    await validateChild(config, snapshotId, expected, timeoutMs);
+    const accepted = createAcceptedConfig(snapshotId, expected);
+    if (typeof args.output === 'string')
+      await writeFile(resolve(args.output), `${JSON.stringify(accepted, null, 2)}\n`);
+    process.stdout.write(`${JSON.stringify(accepted)}\n`);
+  });
+}
+
+async function validateSnapshot(args: Args): Promise<void> {
+  const config = providerConfig(args);
+  await withTrackedSessions(config, async () => {
+    const expected = await readExpectedManifest(args);
+    const snapshotId = requiredArg(args, 'snapshot-id');
+    await inspectSnapshot(config, snapshotId);
+    await validateChild(
+      config,
+      snapshotId,
+      expected,
+      optionalNumber(args, 'timeout-ms', DEFAULT_TIMEOUT_MS)
+    );
+    process.stdout.write(`${JSON.stringify(createAcceptedConfig(snapshotId, expected))}\n`);
+  });
+}
+
+async function checkSnapshot(args: Args): Promise<void> {
+  const config = providerConfig(args);
+  const snapshotId = requiredArg(args, 'snapshot-id');
+  const snapshot = await inspectSnapshot(config, snapshotId);
+  process.stdout.write(
+    `${JSON.stringify({ snapshotId, available: true, expiresAt: snapshot.expiresAt ?? null, lastUsedAt: snapshot.lastUsedAt ?? null })}\n`
+  );
+}
+
+async function stopNamedSession(args: Args): Promise<void> {
+  const config = providerConfig(args);
+  const sessionId = requiredArg(args, 'session-id');
+  const sandboxName = requiredArg(args, 'sandbox-name');
+  await stopSession(config, { sandboxName, sessionId });
+  process.stdout.write(`${JSON.stringify({ stopped: true, sandboxName, sessionId })}\n`);
+}
+
+async function acceptance(args: Args): Promise<void> {
+  const config = providerConfig(args);
+  await withTrackedSessions(config, async () => {
+    const expected = await readExpectedManifest(args);
+    const snapshotId = requiredArg(args, 'snapshot-id');
+    const timeoutMs = optionalNumber(args, 'timeout-ms', DEFAULT_TIMEOUT_MS);
+    await inspectSnapshot(config, snapshotId);
+    await validateChild(config, snapshotId, expected, timeoutMs);
+    const snapshotsBefore = await listSnapshotIds(config);
+    const target = await createSandbox(
+      config,
+      `ses-snapshot-accept-${randomUUID()}`,
+      timeoutMs,
+      snapshotId
+    );
+    const results: Record<string, 'pass' | 'external'> = {
+      snapshotValidation: 'pass',
+      create: 'pass',
+      command: 'pass',
+      wrapperBootstrap: 'pass',
+      keepalive: 'pass',
+      stop: 'pass',
+      noAutomaticSnapshot: 'pass',
+      workspace: 'external',
+      delivery: 'external',
+      networking: 'external',
+      activeLoss: 'external',
+      cloudflareRegression: 'external',
+    };
+    await execute(config, target.sessionId, 'bash', [
+      '-lc',
+      'case "$(node --version)" in v24.*) ;; *) echo "unexpected node $(node --version)" >&2; exit 1 ;; esac',
+    ]);
+    await extendSession(config, target, 60_000);
+    await stopSession(config, target);
+    await inspectSnapshot(config, snapshotId);
+    const snapshotsAfter = await listSnapshotIds(config);
+    const unexpectedSnapshots = [...snapshotsAfter].filter(id => !snapshotsBefore.has(id));
+    if (unexpectedSnapshots.length)
+      throw new Error('non-persistent session created an unexpected snapshot');
+    process.stdout.write(
+      `${JSON.stringify({ acceptedConfig: createAcceptedConfig(snapshotId, expected), results })}\n`
+    );
+  });
+}
+
+function printHelp(): void {
+  process.stdout.write(`Vercel credential-free base snapshot operator harness
+
+Usage:
+  pnpm --filter cloud-agent-next snapshot:vercel <command> [options]
+
+Commands:
+  build       Build wrapper assets into a clean builder, scan, snapshot, and validate a child
+  validate    Validate an existing snapshot through a disposable non-persistent child
+  check       Check snapshot availability and retention metadata
+  stop        Stop one leftover session by exact session ID
+  acceptance Run the provider-level acceptance matrix and report external Worker-only rows
+  help        Show this help
+
+Live commands require VERCEL_TOKEN, VERCEL_TEAM_ID, and VERCEL_PROJECT_ID.
+These may come from the environment, services/cloud-agent-next/.dev.vars, or:
+  --team-id <id> --project-id <id>
+
+Build/validate/acceptance arguments:
+  --snapshot-id <id>       Required except for build
+  --build-id <id>          Defaults to local-YYYYMMDD-HHMMSS
+  --wrapper <path>         Defaults to wrapper/dist/wrapper.js
+  --control-wrapper <path> Defaults to wrapper/dist/control-wrapper.js
+  --wrapper-version <semver> Defaults to the current WRAPPER_VERSION
+  --timeout-ms <ms>        Optional bounded sandbox timeout (default ${DEFAULT_TIMEOUT_MS})
+  --skip-wrapper-build     Build only: use the existing wrapper bundle
+  --output <path>          Build only: write accepted config JSON
+  --session-id <id>        Stop only: exact Vercel session ID
+  --sandbox-name <name>    Stop only: exact sandbox name used to create it
+
+Activation and rollback:
+  1. Deploy code with VERCEL_SANDBOX_ORG_IDS empty.
+  2. Verify no deployed version-1 Vercel tombstones exist.
+  3. Build and accept the snapshot.
+  4. Configure accepted runtime values and one allowlisted organization.
+  5. Enable enrollment.
+  6. During an incident, disable enrollment first.
+  7. Disabling enrollment prevents new Vercel selection but does not stop already-pinned sessions.
+  8. Do not roll code back past version-2 tombstone support until live Vercel sessions and version-2 tombstones are drained or remediated.
+
+The harness never prints provider response bodies or tokens. Failed remote commands print redacted stdout/stderr.
+It never sends DELETE for a named sandbox. Every created session is stopped by exact session ID, including after snapshot and on SIGINT/SIGTERM.
+`);
+}
+
+export async function main(argv = process.argv.slice(2)): Promise<void> {
+  loadLocalDevVars();
+  assertNoSecretArgs(argv);
+  const { command, args } = parseArgs(argv);
+  if (command === 'help' || command === '--help' || command === '-h') return printHelp();
+  if (command === 'build') return buildSnapshot(args);
+  if (command === 'validate') return validateSnapshot(args);
+  if (command === 'check') return checkSnapshot(args);
+  if (command === 'stop') return stopNamedSession(args);
+  if (command === 'acceptance') return acceptance(args);
+  throw new Error(`unknown command: ${command}`);
+}
+
+if (process.argv[1] && resolve(process.argv[1]) === fileURLToPath(import.meta.url)) {
+  main().catch(error => {
+    const message = error instanceof Error ? error.message : 'unknown failure';
+    process.stderr.write(`snapshot operator failed: ${message}\n`);
+    process.exitCode = 1;
+  });
+}

--- a/services/cloud-agent-next/scripts/vercel-wss-smoke.ts
+++ b/services/cloud-agent-next/scripts/vercel-wss-smoke.ts
@@ -1,0 +1,184 @@
+#!/usr/bin/env node
+
+import { randomUUID } from 'node:crypto';
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { VercelSandboxRestClient } from '../src/agent-sandbox/vercel/vercel-sandbox-rest-client.js';
+import { parseVercelSandboxRuntimeConfig } from '../src/agent-sandbox/vercel/vercel-runtime-config.js';
+
+const PACKAGE_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const DEV_VARS_PATH = resolve(PACKAGE_ROOT, '.dev.vars');
+const SMOKE_TIMEOUT_MS = 120_000;
+const COMMAND_TIMEOUT_MS = 45_000;
+
+function parseDevVars(content: string): Record<string, string> {
+  const vars: Record<string, string> = {};
+  for (const rawLine of content.split('\n')) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+    const eqIdx = line.indexOf('=');
+    if (eqIdx === -1) continue;
+    vars[line.slice(0, eqIdx).trim()] = line.slice(eqIdx + 1).trim();
+  }
+  return vars;
+}
+
+function requireValue(name: string, value: string | undefined): string {
+  if (!value) throw new Error(`${name} is required`);
+  return value;
+}
+
+function log(message: string): void {
+  process.stderr.write(`[wss-smoke] ${message}\n`);
+}
+
+const bunClientSource = `
+const url = process.env.SANDBOX_CONTROL_URL;
+const credential = process.env.SANDBOX_CONTROL_TOKEN;
+const instanceId = process.env.SANDBOX_CONTROL_INSTANCE_ID;
+if (!url || !credential || !instanceId) {
+  console.error('missing env');
+  process.exit(2);
+}
+
+function once(ws, type, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(type + ' timeout')), timeoutMs);
+    ws.addEventListener(type, (event) => {
+      clearTimeout(timer);
+      resolve(event);
+    }, { once: true });
+    ws.addEventListener('error', (event) => {
+      clearTimeout(timer);
+      reject(event.error ?? new Error(type + ' error'));
+    }, { once: true });
+  });
+}
+
+async function handshake(label) {
+  const ws = new WebSocket(url, { headers: { Authorization: 'Bearer ' + credential } });
+  await once(ws, 'open', 15000);
+  const requestId = crypto.randomUUID();
+  ws.send(JSON.stringify({
+    type: 'request',
+    requestId,
+    operation: 'sandbox.hello',
+    payload: { protocolVersion: 1, providerInstanceId: instanceId },
+  }));
+  const helloEvent = await once(ws, 'message', 15000);
+  const hello = JSON.parse(String(helloEvent.data));
+  if (hello.type !== 'response' || hello.requestId !== requestId || hello.ok !== true) {
+    throw new Error(label + ' hello failed');
+  }
+  const statusEvent = await once(ws, 'message', 15000);
+  const status = JSON.parse(String(statusEvent.data));
+  if (status.type !== 'request' || status.operation !== 'sandbox.status') {
+    throw new Error(label + ' missing status probe');
+  }
+  ws.send(JSON.stringify({ type: 'response', requestId: status.requestId, ok: true }));
+  return ws;
+}
+
+const first = await handshake('first');
+first.close();
+await once(first, 'close', 5000);
+const second = await handshake('reconnect');
+second.close();
+console.log('ok');
+`;
+
+async function main(): Promise<void> {
+  const local = parseDevVars(readFileSync(DEV_VARS_PATH, 'utf8'));
+  const workerHttpUrl = requireValue('WORKER_URL', process.env.WORKER_URL ?? local.WORKER_URL);
+  const internalSecret = requireValue(
+    'INTERNAL_API_SECRET',
+    process.env.INTERNAL_API_SECRET ?? local.INTERNAL_API_SECRET
+  );
+  const runtime = parseVercelSandboxRuntimeConfig({
+    VERCEL_TOKEN: process.env.VERCEL_TOKEN ?? local.VERCEL_TOKEN,
+    VERCEL_TEAM_ID: process.env.VERCEL_TEAM_ID ?? local.VERCEL_TEAM_ID,
+    VERCEL_PROJECT_ID: process.env.VERCEL_PROJECT_ID ?? local.VERCEL_PROJECT_ID,
+    VERCEL_SANDBOX_SNAPSHOT_ID:
+      process.env.VERCEL_SANDBOX_SNAPSHOT_ID ?? local.VERCEL_SANDBOX_SNAPSHOT_ID,
+    VERCEL_SANDBOX_RUNTIME_BUILD_ID:
+      process.env.VERCEL_SANDBOX_RUNTIME_BUILD_ID ?? local.VERCEL_SANDBOX_RUNTIME_BUILD_ID,
+    VERCEL_SANDBOX_RUNTIME: process.env.VERCEL_SANDBOX_RUNTIME ?? local.VERCEL_SANDBOX_RUNTIME,
+    VERCEL_SANDBOX_INITIAL_TIMEOUT_MS:
+      process.env.VERCEL_SANDBOX_INITIAL_TIMEOUT_MS ?? local.VERCEL_SANDBOX_INITIAL_TIMEOUT_MS,
+    VERCEL_SANDBOX_EXTEND_DURATION_MS:
+      process.env.VERCEL_SANDBOX_EXTEND_DURATION_MS ?? local.VERCEL_SANDBOX_EXTEND_DURATION_MS,
+  });
+  if (!runtime) throw new Error('Vercel runtime config is incomplete');
+
+  const sandboxId = `ses-wss-${randomUUID().replaceAll('-', '').slice(0, 16)}`;
+  const seedResponse = await fetch(
+    `${workerHttpUrl.replace(/\/+$/, '')}/internal/sandbox-control/seed`,
+    {
+      method: 'POST',
+      headers: {
+        'content-type': 'application/json',
+        'x-internal-api-key': internalSecret,
+      },
+      body: JSON.stringify({ sandboxId }),
+    }
+  );
+  if (!seedResponse.ok) {
+    throw new Error(`seed failed: ${seedResponse.status}`);
+  }
+  const seeded = (await seedResponse.json()) as { credential?: unknown };
+  if (typeof seeded.credential !== 'string' || seeded.credential.length === 0) {
+    throw new Error('seed did not return a credential');
+  }
+
+  const workerUrl = new URL(workerHttpUrl);
+  workerUrl.protocol = workerUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+  workerUrl.pathname = `/sandbox-control/${sandboxId}`;
+  workerUrl.search = '';
+  workerUrl.hash = '';
+
+  const client = new VercelSandboxRestClient({
+    accessToken: runtime.accessToken,
+    teamId: runtime.teamId,
+    projectId: runtime.projectId,
+    fetch,
+  });
+
+  log(`creating vercel sandbox ${sandboxId}`);
+  const created = await client.createSandbox({
+    name: sandboxId,
+    operationId: `wss-smoke-${sandboxId}`,
+    runtimeBuildId: runtime.runtimeBuildId,
+    snapshotId: runtime.snapshotId,
+    runtime: runtime.runtime,
+    timeoutMs: Math.min(runtime.initialTimeoutMs, SMOKE_TIMEOUT_MS),
+  });
+  const sessionId = created.session.id;
+  try {
+    log('running bun websocket client inside sandbox');
+    const result = await client.executeCommand(sessionId, {
+      command: 'bun',
+      args: ['-e', bunClientSource],
+      env: {
+        SANDBOX_CONTROL_URL: workerUrl.toString(),
+        SANDBOX_CONTROL_TOKEN: seeded.credential,
+        SANDBOX_CONTROL_INSTANCE_ID: sessionId,
+      },
+      sudo: false,
+      wait: true,
+      timeoutMs: COMMAND_TIMEOUT_MS,
+    });
+    if (result.finished.exitCode !== 0) {
+      throw new Error(`sandbox client exited ${result.finished.exitCode}`);
+    }
+    log('pass: authenticated wss hello, status probe, drop, reconnect');
+  } finally {
+    log('stopping vercel sandbox');
+    await client.stopSession(sessionId, sandboxId).catch(() => undefined);
+  }
+}
+
+main().catch(error => {
+  process.stderr.write(`[wss-smoke] ${error instanceof Error ? error.message : String(error)}\n`);
+  process.exit(1);
+});

--- a/services/cloud-agent-next/src/agent-sandbox/agent-sandbox-contract.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/agent-sandbox-contract.test.ts
@@ -6,6 +6,9 @@ import type { SessionMetadata } from '../persistence/session-metadata.js';
 import type { Env, SandboxInstance } from '../types.js';
 import { CloudflareAgentSandbox } from './cloudflare/cloudflare-agent-sandbox.js';
 import type { AgentSandbox } from './protocol.js';
+import { VercelAgentSandbox } from './vercel/vercel-agent-sandbox.js';
+import type { VercelSandboxRuntimeConfig } from './vercel/vercel-runtime-config.js';
+import type { VercelSandboxRestClient } from './vercel/vercel-sandbox-rest-client.js';
 
 /**
  * Shared behavioral contract every AgentSandbox adapter must satisfy for a
@@ -13,7 +16,7 @@ import type { AgentSandbox } from './protocol.js';
  * workspace preparation, reconciliation) stay in the per-provider suites.
  */
 
-function sessionMetadata(provider: 'cloudflare'): SessionMetadata {
+function sessionMetadata(provider: 'cloudflare' | 'vercel'): SessionMetadata {
   return {
     metadataSchemaVersion: 2,
     identity: { sessionId: 'agent_contract', userId: 'user_contract' },
@@ -36,56 +39,75 @@ function idleCloudflareSandbox(): AgentSandbox {
   });
 }
 
-describe.each([['cloudflare', idleCloudflareSandbox]] as const)(
-  'AgentSandbox contract (%s)',
-  (_provider, createIdleSandbox) => {
-    it('reports absent wrappers when none are running', async () => {
-      await expect(createIdleSandbox().discoverSessionWrappers()).resolves.toEqual({
-        status: 'absent',
-      });
+function idleVercelSandbox(): AgentSandbox {
+  const config: VercelSandboxRuntimeConfig = {
+    accessToken: 'token',
+    teamId: 'team',
+    projectId: 'project',
+    snapshotId: 'snapshot',
+    runtimeBuildId: 'build',
+    runtime: 'node24',
+    initialTimeoutMs: 300_000,
+    extendDurationMs: 600_000,
+  };
+  const restClient = {} as VercelSandboxRestClient;
+  return new VercelAgentSandbox(sessionMetadata('vercel'), config, undefined, {
+    restClient,
+    sleep: () => Promise.resolve(),
+    now: () => 1,
+  });
+}
+
+describe.each([
+  ['cloudflare', idleCloudflareSandbox],
+  ['vercel', idleVercelSandbox],
+] as const)('AgentSandbox contract (%s)', (_provider, createIdleSandbox) => {
+  it('reports absent wrappers when none are running', async () => {
+    await expect(createIdleSandbox().discoverSessionWrappers()).resolves.toEqual({
+      status: 'absent',
+    });
+  });
+
+  it('treats stopping wrappers as settled when none are running', async () => {
+    const result = await createIdleSandbox().stopWrappers({
+      target: { kind: 'session' },
+      attemptId: 'attempt-contract',
+      reason: 'session-delete',
     });
 
-    it('treats stopping wrappers as settled when none are running', async () => {
-      const result = await createIdleSandbox().stopWrappers({
-        target: { kind: 'session' },
-        attemptId: 'attempt-contract',
-        reason: 'session-delete',
-      });
+    expect(result.status).toBe('absent');
+  });
 
-      expect(result.status).toBe('absent');
+  it('scopes instance-targeted stops to the leased instance', async () => {
+    const result = await createIdleSandbox().stopWrappers({
+      target: {
+        kind: 'instance',
+        instance: { instanceId: 'instance-other', instanceGeneration: 7 },
+      },
+      attemptId: 'attempt-contract',
+      reason: 'startup-failed',
     });
 
-    it('scopes instance-targeted stops to the leased instance', async () => {
-      const result = await createIdleSandbox().stopWrappers({
-        target: {
-          kind: 'instance',
-          instance: { instanceId: 'instance-other', instanceGeneration: 7 },
-        },
-        attemptId: 'attempt-contract',
-        reason: 'startup-failed',
-      });
+    expect(result.status).toBe('absent');
+  });
 
-      expect(result.status).toBe('absent');
-    });
+  it('returns no running wrapper when none exists', async () => {
+    await expect(createIdleSandbox().getRunningWrapper()).resolves.toBeNull();
+  });
 
-    it('returns no running wrapper when none exists', async () => {
-      await expect(createIdleSandbox().getRunningWrapper()).resolves.toBeNull();
-    });
+  it('resolves recovery deletion without throwing', async () => {
+    await expect(createIdleSandbox().delete('recovery')).resolves.toBeUndefined();
+  });
 
-    it('resolves recovery deletion without throwing', async () => {
-      await expect(createIdleSandbox().delete('recovery')).resolves.toBeUndefined();
-    });
+  it('keeps the sandbox alive without a running wrapper', async () => {
+    await expect(createIdleSandbox().keepAlive()).resolves.toBeUndefined();
+  });
 
-    it('keeps the sandbox alive without a running wrapper', async () => {
-      await expect(createIdleSandbox().keepAlive()).resolves.toBeUndefined();
-    });
+  it('reports terminal availability as a declared capability outcome', async () => {
+    const result = await createIdleSandbox().getRunningTerminalClient();
 
-    it('reports terminal availability as a declared capability outcome', async () => {
-      const result = await createIdleSandbox().getRunningTerminalClient();
-
-      expect(['ready', 'not-running', 'unhealthy', 'capability-unavailable']).toContain(
-        result.status
-      );
-    });
-  }
-);
+    expect(['ready', 'not-running', 'unhealthy', 'capability-unavailable']).toContain(
+      result.status
+    );
+  });
+});

--- a/services/cloud-agent-next/src/agent-sandbox/capabilities.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/capabilities.ts
@@ -1,4 +1,5 @@
 import type { AgentSandboxProvider } from '../types.js';
+import { sessionPlaneFromId } from '../session-plane.js';
 
 export type ProviderCapabilities = {
   terminal: boolean;
@@ -11,4 +12,12 @@ export type ProviderCapabilities = {
  */
 export const PROVIDER_CAPABILITIES: Record<AgentSandboxProvider, ProviderCapabilities> = {
   cloudflare: { terminal: true, devcontainer: true },
+  vercel: { terminal: false, devcontainer: false },
 };
+
+export function sessionHasTerminal(
+  sessionId: string,
+  provider: AgentSandboxProvider = 'cloudflare'
+): boolean {
+  return sessionPlaneFromId(sessionId) !== 'control' && PROVIDER_CAPABILITIES[provider].terminal;
+}

--- a/services/cloud-agent-next/src/agent-sandbox/factory.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/factory.test.ts
@@ -1,12 +1,14 @@
+import { getSandbox } from '@cloudflare/sandbox';
 import { describe, expect, it, vi } from 'vitest';
 import type { Env } from '../types.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import { createAgentSandbox } from './factory.js';
 import { CloudflareAgentSandbox } from './cloudflare/cloudflare-agent-sandbox.js';
+import { VercelAgentSandbox } from './vercel/vercel-agent-sandbox.js';
 
 vi.mock('@cloudflare/sandbox', () => ({ getSandbox: vi.fn() }));
 
-function metadata(provider?: 'cloudflare'): SessionMetadata {
+function metadata(provider?: 'cloudflare' | 'vercel'): SessionMetadata {
   return {
     metadataSchemaVersion: 2,
     identity: { sessionId: 'agent_sandbox', userId: 'user_sandbox' },
@@ -25,4 +27,66 @@ describe('AgentSandbox provider factory', () => {
       );
     }
   );
+
+  it('resolves configured Vercel metadata to the exact-session adapter without Cloudflare bindings', () => {
+    const sandbox = createAgentSandbox(
+      {
+        VERCEL_TOKEN: 'token',
+        VERCEL_TEAM_ID: 'team',
+        VERCEL_PROJECT_ID: 'project',
+        VERCEL_SANDBOX_SNAPSHOT_ID: 'snapshot',
+        VERCEL_SANDBOX_RUNTIME_BUILD_ID: 'build',
+        VERCEL_SANDBOX_RUNTIME: 'node24',
+        VERCEL_SANDBOX_INITIAL_TIMEOUT_MS: '300000',
+        VERCEL_SANDBOX_EXTEND_DURATION_MS: '600000',
+      } as Env,
+      metadata('vercel')
+    );
+
+    expect(sandbox).toBeInstanceOf(VercelAgentSandbox);
+    expect(getSandbox).not.toHaveBeenCalled();
+  });
+
+  it('uses persisted runtime identity instead of mutable enrollment snapshot values', () => {
+    const pinned = metadata('vercel');
+    pinned.workspace = {
+      ...pinned.workspace,
+      providerRuntime: {
+        provider: 'vercel',
+        sessionId: 'session-1',
+        projectId: 'project-pinned',
+        snapshotId: 'snapshot-pinned',
+        runtimeBuildId: 'build-pinned',
+        runtime: 'node24',
+      },
+    };
+    const sandbox = createAgentSandbox(
+      {
+        VERCEL_TOKEN: 'token',
+        VERCEL_TEAM_ID: 'team',
+        VERCEL_PROJECT_ID: 'project-current',
+        VERCEL_SANDBOX_SNAPSHOT_ID: 'snapshot-current',
+        VERCEL_SANDBOX_RUNTIME_BUILD_ID: 'build-current',
+        VERCEL_SANDBOX_RUNTIME: 'node24',
+        VERCEL_SANDBOX_INITIAL_TIMEOUT_MS: '300000',
+        VERCEL_SANDBOX_EXTEND_DURATION_MS: '600000',
+      } as Env,
+      pinned
+    );
+
+    expect((sandbox as any).config).toMatchObject({
+      projectId: 'project-pinned',
+      snapshotId: 'snapshot-pinned',
+      runtimeBuildId: 'build-pinned',
+    });
+  });
+
+  it('requires operational configuration only for Vercel metadata', () => {
+    expect(() => createAgentSandbox({} as Env, metadata('vercel'))).toThrow(
+      'Vercel sandbox operational configuration is incomplete'
+    );
+    expect(createAgentSandbox({} as Env, metadata('cloudflare'))).toBeInstanceOf(
+      CloudflareAgentSandbox
+    );
+  });
 });

--- a/services/cloud-agent-next/src/agent-sandbox/factory.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/factory.ts
@@ -1,25 +1,44 @@
-import type { SessionMetadata } from '../persistence/session-metadata.js';
+import { getSandboxProvider, type SessionMetadata } from '../persistence/session-metadata.js';
 import type { Env } from '../types.js';
-import type { AgentSandbox, AgentSandboxLifecycle, AgentSandboxLifecycleHost } from './protocol.js';
+import {
+  AgentSandboxUnavailableError,
+  type AgentSandbox,
+  type AgentSandboxLifecycle,
+  type AgentSandboxLifecycleHost,
+  type AgentSandboxRuntimeContext,
+} from './protocol.js';
 import { CloudflareAgentSandbox } from './cloudflare/cloudflare-agent-sandbox.js';
+import { VercelAgentSandbox } from './vercel/vercel-agent-sandbox.js';
+import { VercelSandboxLifecycle } from './vercel/vercel-lifecycle.js';
+import { resolveVercelSandboxRuntimeConfig } from './vercel/vercel-runtime-config.js';
 
-export function createAgentSandbox(env: Env, metadata: SessionMetadata): AgentSandbox {
+export function createAgentSandbox(
+  env: Env,
+  metadata: SessionMetadata,
+  runtimeContext?: AgentSandboxRuntimeContext
+): AgentSandbox {
+  if (getSandboxProvider(metadata) === 'vercel') {
+    const config = resolveVercelSandboxRuntimeConfig(env, metadata.workspace?.providerRuntime);
+    if (!config) {
+      throw new AgentSandboxUnavailableError(
+        'Vercel sandbox operational configuration is incomplete',
+        'provider_not_configured'
+      );
+    }
+    return new VercelAgentSandbox(metadata, config, runtimeContext);
+  }
   return new CloudflareAgentSandbox(env, metadata);
 }
 
 /**
- * Provider-side lifecycle reconciliation seam. Cloudflare runtimes are
- * locally addressed, so creation never needs reconciliation and deletion is
- * driven synchronously by the session; providers whose runtimes are created
- * or deleted through remote APIs dispatch to their own lifecycle here.
+ * Vercel is the only provider with asynchronous create/deletion
+ * reconciliation; its methods self-guard on stored intent state, so sessions
+ * on other providers reduce to no-ops. Providers that add reconciled state
+ * extend this to dispatch on it.
  */
 export function createAgentSandboxLifecycle(
-  _env: Env,
-  _host: AgentSandboxLifecycleHost
+  env: Env,
+  host: AgentSandboxLifecycleHost
 ): AgentSandboxLifecycle {
-  return {
-    reconcileCreateIntent: async () => undefined,
-    planDeletion: async () => ({ kind: 'not-applicable' }),
-    reconcilePendingDeletion: async () => 'none',
-  };
+  return new VercelSandboxLifecycle(env, host);
 }

--- a/services/cloud-agent-next/src/agent-sandbox/protocol.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/protocol.ts
@@ -6,13 +6,19 @@ import type {
   FencedWrapperDispatchRequest,
   WorkspaceReady,
 } from '../execution/types.js';
+import type {
+  SandboxCreateIntent,
+  SandboxCreateIntentInput,
+  SandboxProviderRuntimeInput,
+  SandboxWrapperLaunchIntent,
+} from './runtime-intents.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import type { SandboxBillingAdmissionResult } from '../container-usage-context.js';
 import type { SandboxClassName } from '../container-usage-context.js';
 import type { BillingContext } from '@kilocode/container-usage';
 import type { SandboxId } from '../types.js';
 
-export type SandboxDeleteReason = 'explicit' | 'retention-expired' | 'recovery';
+export type SandboxDeleteReason = 'explicit' | 'retention-expired' | 'recovery' | 'late-create';
 
 export type SessionDeletionIntent = {
   reason: Extract<SandboxDeleteReason, 'explicit' | 'retention-expired'>;
@@ -129,6 +135,27 @@ export type EnsuredWrapper =
       kiloSessionId: string;
     };
 
+export type AgentSandboxRuntimeContext = {
+  getCreateIntent(): Promise<SandboxCreateIntent | undefined>;
+  beginCreate(input: SandboxCreateIntentInput): Promise<SandboxCreateIntent>;
+  clearCreateIntent(operationId: string): Promise<void>;
+  persistRuntimeOnce(input: SandboxProviderRuntimeInput): Promise<void>;
+  getWrapperLaunchIntent(): Promise<SandboxWrapperLaunchIntent | undefined>;
+  clearWrapperLaunchIntent(launchId: string): Promise<void>;
+  beginWrapperLaunch(input: {
+    sessionId: string;
+    instance: WrapperInstanceLease;
+  }): Promise<SandboxWrapperLaunchIntent>;
+  persistWrapperProcessOnce(input: {
+    sessionId: string;
+    launchId: string;
+    commandId: string;
+    instance: WrapperInstanceLease;
+  }): Promise<void>;
+  clearWrapperProcess(input: { sessionId: string; commandId: string }): Promise<void>;
+  isDeletionPending(): Promise<boolean>;
+};
+
 /**
  * Product-specific runtime seam for one Cloud Agent session.
  * Provider process, filesystem, and raw sandbox APIs remain private to adapters.
@@ -181,6 +208,7 @@ export type ProviderDeletionPlan =
  */
 export type AgentSandboxLifecycleHost = {
   storage: DurableObjectStorage;
+  runtimeContext: AgentSandboxRuntimeContext;
   scheduleAlarmAtOrBefore(deadline: number): Promise<void>;
   eraseDurableObjectState(): Promise<void>;
   purgeDeletedSessionPayload(): Promise<void>;

--- a/services/cloud-agent-next/src/agent-sandbox/runtime-intents.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/runtime-intents.ts
@@ -1,0 +1,33 @@
+import type {
+  VercelCreateIntent,
+  VercelWrapperLaunchIntent,
+} from './vercel/vercel-runtime-state.js';
+
+/**
+ * Durable, provider-tagged intents recorded by the owning session before it
+ * mutates remote provider state, so interrupted operations reconcile instead
+ * of leaking runtimes. Providers whose runtimes are created through remote
+ * APIs without idempotency keys contribute one union member each; providers
+ * with locally addressed runtimes (Cloudflare) never record intents.
+ */
+export type SandboxCreateIntentInput = {
+  provider: 'vercel';
+  sandboxName: string;
+  projectId: string;
+  snapshotId: string;
+  runtimeBuildId: string;
+  runtime: VercelCreateIntent['runtime'];
+};
+
+export type SandboxCreateIntent = VercelCreateIntent;
+
+export type SandboxProviderRuntimeInput = {
+  provider: 'vercel';
+  sessionId: string;
+  projectId: string;
+  snapshotId: string;
+  runtimeBuildId: string;
+  runtime: VercelCreateIntent['runtime'];
+};
+
+export type SandboxWrapperLaunchIntent = VercelWrapperLaunchIntent;

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.test.ts
@@ -519,4 +519,16 @@ describe('VercelAgentSandbox', () => {
     expect(client.inspectByName).not.toHaveBeenCalled();
     expect(client.stopSession).not.toHaveBeenCalled();
   });
+
+  it('admits billing as a no-op and observes wrappers through discover', async () => {
+    const sandbox = new VercelAgentSandbox(metadata(), config, undefined, {
+      restClient: asRestClient(restClient()),
+    });
+
+    await expect(sandbox.ensureBillingAdmission()).resolves.toEqual({ success: true });
+    await expect(sandbox.isBillingBlocked()).resolves.toBe(false);
+    await expect(sandbox.isBillingBlocked(true)).resolves.toBe(false);
+    await expect(sandbox.getBillingRuntimeStatus()).resolves.toBeUndefined();
+    await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({ status: 'absent' });
+  });
 });

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.test.ts
@@ -286,6 +286,79 @@ describe('VercelAgentSandbox', () => {
     expect(client.listCommands).toHaveBeenCalledWith('session-1');
   });
 
+  it('relaunches a dead wrapper when a delivery-plan snapshot contains an older lease', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    client.getCommand.mockResolvedValue(command({ id: 'command-old', exitCode: 1 }));
+    const snapshot = metadata({
+      provider: 'vercel',
+      sessionId: 'session-1',
+      wrapper: {
+        launchId: 'launch-old',
+        commandId: 'command-old',
+        instanceId: 'instance-old',
+        instanceGeneration: 1,
+      },
+    });
+    const previous = new VercelAgentSandbox(snapshot, config, context, {
+      restClient: asRestClient(client),
+    });
+    const replacement = new VercelAgentSandbox(snapshot, config, context, {
+      restClient: asRestClient(client),
+    });
+    vi.spyOn(Object.getPrototypeOf(replacement), 'wrapperClient').mockReturnValue({
+      health: vi.fn().mockResolvedValue({
+        healthy: true,
+        version: WRAPPER_VERSION,
+        wrapperInstanceId: 'instance-1',
+        wrapperInstanceGeneration: 2,
+      }),
+    });
+
+    await expect(previous.discoverSessionWrappers()).resolves.toEqual({ status: 'absent' });
+    await expect(replacement.ensureWrapper(ensureRequest())).resolves.toMatchObject({
+      status: 'wrapper-running',
+    });
+
+    expect(context.clearWrapperProcess).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      commandId: 'command-old',
+    });
+    expect(context.persistWrapperProcessOnce).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      launchId: 'launch-1',
+      commandId: 'command-1',
+      instance: { instanceId: 'instance-1', instanceGeneration: 2 },
+    });
+  });
+
+  it('does not replace a live wrapper belonging to another physical lease', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    client.getCommand.mockResolvedValue(command({ id: 'command-old' }));
+    const sandbox = new VercelAgentSandbox(
+      metadata({
+        provider: 'vercel',
+        sessionId: 'session-1',
+        wrapper: {
+          launchId: 'launch-old',
+          commandId: 'command-old',
+          instanceId: 'instance-old',
+          instanceGeneration: 1,
+        },
+      }),
+      config,
+      context,
+      { restClient: asRestClient(client) }
+    );
+
+    await expect(sandbox.ensureWrapper(ensureRequest())).rejects.toThrow(
+      'Persisted Vercel wrapper belongs to a different physical lease'
+    );
+    expect(context.clearWrapperProcess).not.toHaveBeenCalled();
+    expect(context.beginWrapperLaunch).not.toHaveBeenCalled();
+  });
+
   it('does not launch from a cached runtime after deletion is fenced', async () => {
     const context = runtimeContext();
     context.isDeletionPending.mockResolvedValue(true);
@@ -459,6 +532,155 @@ describe('VercelAgentSandbox', () => {
     ).resolves.toEqual({ status: 'absent' });
     expect(client.listCommands).not.toHaveBeenCalled();
     expect(context.persistWrapperProcessOnce).not.toHaveBeenCalled();
+    expect(context.clearWrapperLaunchIntent).not.toHaveBeenCalled();
+  });
+
+  it('observes an interrupted wrapper launch without replacing its lease or intent', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValue({
+      sessionId: 'session-1',
+      launchId: 'launch-old',
+      instanceId: 'instance-old',
+      instanceGeneration: 1,
+      startedAt: 1,
+    });
+    const client = restClient();
+    client.listCommands.mockResolvedValue([
+      command({ id: 'command-old', args: ['kilo-launch:launch-old'] }),
+    ]);
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client) }
+    );
+
+    await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({
+      status: 'present',
+      observed: [
+        {
+          representation: 'process',
+          id: 'command-old',
+          instanceId: 'instance-old',
+          instanceGeneration: 1,
+        },
+      ],
+    });
+    expect(context.clearWrapperLaunchIntent).not.toHaveBeenCalled();
+    expect(context.persistWrapperProcessOnce).not.toHaveBeenCalled();
+  });
+
+  it('clears a settled absent launch before starting a wrapper under the current lease', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValueOnce({
+      sessionId: 'session-1',
+      launchId: 'launch-old',
+      instanceId: 'instance-old',
+      instanceGeneration: 1,
+      startedAt: 1,
+    });
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client), now: () => 30_001 }
+    );
+    vi.spyOn(Object.getPrototypeOf(sandbox), 'wrapperClient').mockReturnValue({
+      health: vi.fn().mockResolvedValue({
+        healthy: true,
+        version: WRAPPER_VERSION,
+        wrapperInstanceId: 'instance-1',
+        wrapperInstanceGeneration: 2,
+      }),
+    });
+
+    await expect(sandbox.discoverSessionWrappers()).resolves.toEqual({ status: 'absent' });
+    await expect(sandbox.ensureWrapper(ensureRequest())).resolves.toMatchObject({
+      status: 'wrapper-running',
+    });
+
+    expect(context.clearWrapperLaunchIntent).toHaveBeenCalledWith('launch-old');
+    expect(context.beginWrapperLaunch).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      instance: { instanceId: 'instance-1', instanceGeneration: 2 },
+    });
+  });
+
+  it('does not clear an interrupted launch while its command may still appear', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValue({
+      sessionId: 'session-1',
+      launchId: 'launch-old',
+      instanceId: 'instance-old',
+      instanceGeneration: 1,
+      startedAt: 1,
+    });
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client), now: () => 30_000 }
+    );
+
+    await expect(sandbox.discoverSessionWrappers()).resolves.toMatchObject({
+      status: 'inspection-failed',
+      error: expect.stringContaining('Vercel wrapper launch is still settling'),
+    });
+    expect(context.clearWrapperLaunchIntent).not.toHaveBeenCalled();
+  });
+
+  it('fails discovery closed when an interrupted launch has multiple live commands', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValue({
+      sessionId: 'session-1',
+      launchId: 'launch-old',
+      instanceId: 'instance-old',
+      instanceGeneration: 1,
+      startedAt: 1,
+    });
+    const client = restClient();
+    client.listCommands.mockResolvedValue([
+      command({ id: 'command-old-1', args: ['kilo-launch:launch-old'] }),
+      command({ id: 'command-old-2', args: ['kilo-launch:launch-old'] }),
+    ]);
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client) }
+    );
+
+    await expect(sandbox.discoverSessionWrappers()).resolves.toMatchObject({
+      status: 'inspection-failed',
+      error: expect.stringContaining('Vercel wrapper launch matched multiple commands'),
+    });
+    expect(context.clearWrapperLaunchIntent).not.toHaveBeenCalled();
+  });
+
+  it('does not inspect an interrupted launch belonging to another runtime session', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValue({
+      sessionId: 'session-other',
+      launchId: 'launch-old',
+      instanceId: 'instance-old',
+      instanceGeneration: 1,
+      startedAt: 1,
+    });
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client) }
+    );
+
+    await expect(sandbox.discoverSessionWrappers()).resolves.toMatchObject({
+      status: 'inspection-failed',
+      error: expect.stringContaining('Vercel wrapper launch intent targets a different session'),
+    });
+    expect(client.listCommands).not.toHaveBeenCalled();
     expect(context.clearWrapperLaunchIntent).not.toHaveBeenCalled();
   });
 

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.test.ts
@@ -1,0 +1,522 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import type { AgentSandboxRuntimeContext } from '../protocol.js';
+import { WRAPPER_VERSION } from '../../shared/wrapper-version.js';
+import type { SessionMetadata } from '../../persistence/session-metadata.js';
+import { VercelAgentSandbox } from './vercel-agent-sandbox.js';
+import type { VercelSandboxRuntimeConfig } from './vercel-runtime-config.js';
+import type {
+  VercelSandboxCommand,
+  VercelSandboxRestClient,
+} from './vercel-sandbox-rest-client.js';
+
+const config: VercelSandboxRuntimeConfig = {
+  accessToken: 'token',
+  teamId: 'team',
+  projectId: 'project',
+  snapshotId: 'snapshot',
+  runtimeBuildId: 'build',
+  runtime: 'node24',
+  initialTimeoutMs: 300_000,
+  extendDurationMs: 600_000,
+};
+
+function metadata(runtime?: NonNullable<SessionMetadata['workspace']>['providerRuntime']) {
+  return {
+    metadataSchemaVersion: 2,
+    identity: { sessionId: 'agent_vercel', userId: 'user_vercel' },
+    auth: {},
+    workspace: {
+      sandboxId: 'ses-abcdef',
+      sandboxProvider: 'vercel',
+      providerRuntime: runtime,
+    },
+    lifecycle: { version: 1, timestamp: 1 },
+  } satisfies SessionMetadata;
+}
+
+function command(overrides: Partial<VercelSandboxCommand> = {}): VercelSandboxCommand {
+  return {
+    id: 'command-1',
+    name: 'bun',
+    args: ['run', '/usr/local/bin/kilocode-wrapper.js', 'kilo-launch:launch-1'],
+    cwd: '/',
+    sessionId: 'session-1',
+    exitCode: null,
+    startedAt: 1,
+    ...overrides,
+  };
+}
+
+function runtimeContext() {
+  const context = {
+    getCreateIntent: vi.fn().mockResolvedValue(undefined),
+    beginCreate: vi.fn().mockResolvedValue({
+      version: 1,
+      sandboxName: 'ses-abcdef',
+      operationId: 'operation-1',
+      projectId: 'project',
+      snapshotId: 'snapshot',
+      runtimeBuildId: 'build',
+      runtime: 'node24',
+      startedAt: 1,
+      settleUntil: 10_000,
+      attempts: 1,
+      nextRetryAt: 1,
+    }),
+    clearCreateIntent: vi.fn().mockResolvedValue(undefined),
+    persistRuntimeOnce: vi.fn().mockResolvedValue(undefined),
+    getWrapperLaunchIntent: vi.fn().mockResolvedValue(undefined),
+    clearWrapperLaunchIntent: vi.fn().mockResolvedValue(undefined),
+    beginWrapperLaunch: vi.fn().mockResolvedValue({
+      sessionId: 'session-1',
+      launchId: 'launch-1',
+      instanceId: 'instance-1',
+      instanceGeneration: 2,
+      startedAt: 1,
+    }),
+    persistWrapperProcessOnce: vi.fn().mockResolvedValue(undefined),
+    clearWrapperProcess: vi.fn().mockResolvedValue(undefined),
+    isDeletionPending: vi.fn().mockResolvedValue(false),
+  } satisfies AgentSandboxRuntimeContext;
+  return context;
+}
+
+function restClient() {
+  return {
+    createSandbox: vi.fn().mockResolvedValue({ session: { id: 'session-1' } }),
+    inspectByName: vi.fn(),
+    readFile: vi.fn().mockImplementation((_sessionId: string, path: string) =>
+      Promise.resolve(
+        new TextEncoder().encode(
+          path.endsWith('runtime-manifest.json')
+            ? JSON.stringify({
+                runtimeBuildId: 'build',
+                wrapperVersion: WRAPPER_VERSION,
+                runtime: 'node24',
+                bunVersion: '1.3.14',
+                wrapperSha256: 'a'.repeat(64),
+              })
+            : `1.3.14\n${'a'.repeat(64)}\n`
+        )
+      )
+    ),
+    executeCommand: vi.fn().mockResolvedValue(command()),
+    listCommands: vi.fn().mockResolvedValue([]),
+    getCommand: vi.fn().mockResolvedValue(command()),
+    killCommand: vi.fn().mockResolvedValue(command({ exitCode: 143 })),
+    getSession: vi.fn().mockResolvedValue({ session: { status: 'running' }, routes: [] }),
+    extendSessionTimeout: vi.fn(),
+    stopSession: vi.fn(),
+  };
+}
+
+function asRestClient(client: ReturnType<typeof restClient>): VercelSandboxRestClient {
+  return client as unknown as VercelSandboxRestClient;
+}
+
+function ensureRequest() {
+  return {
+    leasedInstance: { instanceId: 'instance-1', instanceGeneration: 2 },
+    plan: {},
+    prepared: { context: { workspacePath: '/workspace' } },
+  } as never;
+}
+
+describe('VercelAgentSandbox', () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it('persists create intent and exact runtime before validating and launching the wrapper', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    const health = vi.fn().mockResolvedValue({
+      healthy: true,
+      version: WRAPPER_VERSION,
+      wrapperInstanceId: 'instance-1',
+      wrapperInstanceGeneration: 2,
+    });
+    const wrapperHealth = vi
+      .spyOn(
+        Object.getPrototypeOf(
+          new VercelAgentSandbox(metadata(), config, context, { restClient: asRestClient(client) })
+        ),
+        'wrapperClient'
+      )
+      .mockReturnValue({ health });
+    const sandbox = new VercelAgentSandbox(metadata(), config, context, {
+      restClient: asRestClient(client),
+    });
+
+    await sandbox.ensureWrapper(ensureRequest());
+
+    expect(context.beginCreate).toHaveBeenCalledOnce();
+    expect(context.persistRuntimeOnce).toHaveBeenCalledWith({
+      provider: 'vercel',
+      sessionId: 'session-1',
+      projectId: 'project',
+      snapshotId: 'snapshot',
+      runtimeBuildId: 'build',
+      runtime: 'node24',
+    });
+    expect(client.readFile).toHaveBeenCalledWith(
+      'session-1',
+      '/usr/local/share/kilo/runtime-manifest.json',
+      16 * 1024
+    );
+    expect(context.beginWrapperLaunch).toHaveBeenCalledBefore(context.persistWrapperProcessOnce);
+    expect(client.executeCommand).toHaveBeenCalledWith(
+      'session-1',
+      expect.objectContaining({
+        wait: false,
+        command: 'sh',
+        args: ['-lc', expect.stringContaining('kilo-launch:launch-1')],
+        env: expect.objectContaining({
+          KILO_AGENT_SESSION_ID: 'agent_vercel',
+          KILO_USER_ID: 'user_vercel',
+        }),
+      })
+    );
+    const launchEnv = vi.mocked(client.executeCommand).mock.calls[0]?.[1]?.env;
+    expect(launchEnv).toBeDefined();
+    expect(launchEnv).not.toHaveProperty('WORKSPACE_PATH');
+    expect(context.persistWrapperProcessOnce).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      launchId: 'launch-1',
+      commandId: 'command-1',
+      instance: { instanceId: 'instance-1', instanceGeneration: 2 },
+    });
+    expect(health).toHaveBeenCalledOnce();
+    wrapperHealth.mockRestore();
+  });
+
+  it('uses bounded exponential delays until wrapper health matches the persisted lease', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const health = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('wrapper is starting'))
+      .mockResolvedValueOnce({
+        healthy: true,
+        version: WRAPPER_VERSION,
+        wrapperInstanceId: 'instance-1',
+        wrapperInstanceGeneration: 1,
+      })
+      .mockResolvedValueOnce({
+        healthy: true,
+        version: WRAPPER_VERSION,
+        wrapperInstanceId: 'instance-1',
+        wrapperInstanceGeneration: 2,
+      });
+    vi.spyOn(
+      Object.getPrototypeOf(
+        new VercelAgentSandbox(metadata(), config, context, { restClient: asRestClient(client) })
+      ),
+      'wrapperClient'
+    ).mockReturnValue({ health });
+    const sandbox = new VercelAgentSandbox(metadata(), config, context, {
+      restClient: asRestClient(client),
+      sleep,
+    });
+
+    await expect(sandbox.ensureWrapper(ensureRequest())).resolves.toMatchObject({
+      status: 'wrapper-running',
+    });
+    expect(health).toHaveBeenCalledTimes(3);
+    expect(sleep.mock.calls).toEqual([[250], [500]]);
+  });
+
+  it('limits wrapper readiness exhaustion to eight health transactions', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    const sleep = vi.fn().mockResolvedValue(undefined);
+    const health = vi.fn().mockResolvedValue({
+      healthy: true,
+      version: 'stale-wrapper-version',
+      wrapperInstanceId: 'instance-1',
+      wrapperInstanceGeneration: 2,
+    });
+    vi.spyOn(
+      Object.getPrototypeOf(
+        new VercelAgentSandbox(metadata(), config, context, { restClient: asRestClient(client) })
+      ),
+      'wrapperClient'
+    ).mockReturnValue({ health });
+    const sandbox = new VercelAgentSandbox(metadata(), config, context, {
+      restClient: asRestClient(client),
+      sleep,
+    });
+
+    await expect(sandbox.ensureWrapper(ensureRequest())).rejects.toThrow(
+      'Vercel wrapper did not report the persisted lease'
+    );
+    expect(health).toHaveBeenCalledTimes(8);
+    expect(sleep.mock.calls).toEqual([[250], [500], [1_000], [2_000], [4_000], [8_000], [14_000]]);
+  });
+
+  it('recovers a lost launch only from one exact-session launch marker', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValue({
+      sessionId: 'session-1',
+      launchId: 'launch-1',
+      instanceId: 'instance-1',
+      instanceGeneration: 2,
+      startedAt: 1,
+    });
+    const client = restClient();
+    vi.mocked(client.listCommands).mockResolvedValue([command()]);
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client) }
+    );
+
+    await expect(
+      (
+        sandbox as unknown as {
+          ensureWrapperCommand: (
+            sessionId: string,
+            instance: { instanceId: string; instanceGeneration: number }
+          ) => Promise<VercelSandboxCommand>;
+        }
+      ).ensureWrapperCommand('session-1', { instanceId: 'instance-1', instanceGeneration: 2 })
+    ).resolves.toMatchObject({ id: 'command-1' });
+    expect(client.executeCommand).not.toHaveBeenCalled();
+    expect(client.listCommands).toHaveBeenCalledWith('session-1');
+  });
+
+  it('does not launch from a cached runtime after deletion is fenced', async () => {
+    const context = runtimeContext();
+    context.isDeletionPending.mockResolvedValue(true);
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client) }
+    );
+
+    await expect(sandbox.ensureWrapper(ensureRequest())).rejects.toThrow(
+      'Vercel sandbox deletion is pending'
+    );
+    expect(client.readFile).not.toHaveBeenCalled();
+    expect(client.executeCommand).not.toHaveBeenCalled();
+  });
+
+  it('fails closed on duplicate launch markers without starting another wrapper', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValue({
+      sessionId: 'session-1',
+      launchId: 'launch-1',
+      instanceId: 'instance-1',
+      instanceGeneration: 2,
+      startedAt: 1,
+    });
+    const client = restClient();
+    client.listCommands.mockResolvedValue([command(), command({ id: 'command-2' })]);
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client) }
+    );
+
+    await expect(sandbox.ensureWrapper(ensureRequest())).rejects.toThrow(
+      'Vercel wrapper launch matched multiple commands'
+    );
+    expect(client.executeCommand.mock.calls.some(([, input]) => input.wait === false)).toBe(false);
+    expect(context.persistWrapperProcessOnce).not.toHaveBeenCalled();
+  });
+
+  it('extends timeout only when the exact session approaches its watermark', async () => {
+    const distantClient = restClient();
+    distantClient.getSession.mockResolvedValue({
+      session: { status: 'running', startedAt: 0, requestedAt: 0, timeout: 500_000 },
+      routes: [],
+    });
+    const nearClient = restClient();
+    nearClient.getSession.mockResolvedValue({
+      session: { status: 'running', startedAt: 0, requestedAt: 0, timeout: 350_000 },
+      routes: [],
+    });
+    const runtime = { provider: 'vercel' as const, sessionId: 'session-1' };
+
+    await new VercelAgentSandbox(metadata(runtime), config, undefined, {
+      restClient: asRestClient(distantClient),
+      now: () => 100_000,
+    }).keepAlive();
+    await new VercelAgentSandbox(metadata(runtime), config, undefined, {
+      restClient: asRestClient(nearClient),
+      now: () => 100_000,
+    }).keepAlive();
+
+    expect(distantClient.extendSessionTimeout).not.toHaveBeenCalled();
+    expect(nearClient.extendSessionTimeout).toHaveBeenCalledWith(
+      'session-1',
+      'ses-abcdef',
+      600_000
+    );
+  });
+
+  it('reconciles an unresolved launch before confirming wrapper cleanup', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValue({
+      sessionId: 'session-1',
+      launchId: 'launch-1',
+      instanceId: 'instance-1',
+      instanceGeneration: 2,
+      startedAt: 1,
+    });
+    const client = restClient();
+    client.listCommands.mockResolvedValue([command()]);
+    client.getCommand
+      .mockResolvedValueOnce(command())
+      .mockResolvedValueOnce(command({ exitCode: 143 }));
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client), sleep: async () => undefined }
+    );
+
+    await expect(
+      sandbox.stopWrappers({
+        target: { kind: 'session' },
+        attemptId: 'attempt-unresolved',
+        reason: 'startup-failed',
+      })
+    ).resolves.toEqual({ status: 'absent', stoppedInstanceIds: ['instance-1'] });
+    expect(context.persistWrapperProcessOnce).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      launchId: 'launch-1',
+      commandId: 'command-1',
+      instance: { instanceId: 'instance-1', instanceGeneration: 2 },
+    });
+    expect(client.killCommand).toHaveBeenCalledWith('session-1', 'command-1', 15);
+  });
+
+  it('does not stop a newer wrapper for a stale instance target', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(
+      metadata({
+        provider: 'vercel',
+        sessionId: 'session-1',
+        wrapper: {
+          launchId: 'launch-2',
+          commandId: 'command-2',
+          instanceId: 'instance-1',
+          instanceGeneration: 3,
+        },
+      }),
+      config,
+      context,
+      { restClient: asRestClient(client), sleep: async () => undefined }
+    );
+
+    await expect(
+      sandbox.stopWrappers({
+        target: {
+          kind: 'instance',
+          instance: { instanceId: 'instance-1', instanceGeneration: 2 },
+        },
+        attemptId: 'attempt-stale',
+        reason: 'startup-failed',
+      })
+    ).resolves.toEqual({ status: 'absent' });
+    expect(client.getCommand).not.toHaveBeenCalled();
+    expect(client.killCommand).not.toHaveBeenCalled();
+    expect(context.clearWrapperProcess).not.toHaveBeenCalled();
+  });
+
+  it('does not reconcile a newer unresolved launch for a stale instance target', async () => {
+    const context = runtimeContext();
+    context.getWrapperLaunchIntent.mockResolvedValue({
+      sessionId: 'session-1',
+      launchId: 'launch-2',
+      instanceId: 'instance-1',
+      instanceGeneration: 3,
+      startedAt: 1,
+    });
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client), sleep: async () => undefined }
+    );
+
+    await expect(
+      sandbox.stopWrappers({
+        target: {
+          kind: 'instance',
+          instance: { instanceId: 'instance-1', instanceGeneration: 2 },
+        },
+        attemptId: 'attempt-stale-launch',
+        reason: 'startup-failed',
+      })
+    ).resolves.toEqual({ status: 'absent' });
+    expect(client.listCommands).not.toHaveBeenCalled();
+    expect(context.persistWrapperProcessOnce).not.toHaveBeenCalled();
+    expect(context.clearWrapperLaunchIntent).not.toHaveBeenCalled();
+  });
+
+  it('discovers and stops a matching instance target without stopping the VM', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    vi.mocked(client.getCommand)
+      .mockResolvedValueOnce(command())
+      .mockResolvedValueOnce(command())
+      .mockResolvedValueOnce(command({ exitCode: 143 }));
+    const sandbox = new VercelAgentSandbox(
+      metadata({
+        provider: 'vercel',
+        sessionId: 'session-1',
+        wrapper: {
+          launchId: 'launch-1',
+          commandId: 'command-1',
+          instanceId: 'instance-1',
+          instanceGeneration: 2,
+        },
+      }),
+      config,
+      context,
+      { restClient: asRestClient(client), sleep: async () => undefined }
+    );
+
+    await expect(sandbox.discoverSessionWrappers()).resolves.toMatchObject({ status: 'present' });
+    await expect(
+      sandbox.stopWrappers({
+        target: {
+          kind: 'instance',
+          instance: { instanceId: 'instance-1', instanceGeneration: 2 },
+        },
+        attemptId: 'attempt-1',
+        reason: 'idle-timeout',
+      })
+    ).resolves.toEqual({ status: 'absent', stoppedInstanceIds: ['instance-1'] });
+    expect(client.killCommand).toHaveBeenCalledWith('session-1', 'command-1', 15);
+    expect(client.stopSession).not.toHaveBeenCalled();
+    expect(context.clearWrapperProcess).toHaveBeenCalledWith({
+      sessionId: 'session-1',
+      commandId: 'command-1',
+    });
+    await expect(sandbox.discoverSessionWrappers()).resolves.toEqual({ status: 'absent' });
+    expect(client.getCommand).toHaveBeenCalledTimes(3);
+  });
+
+  it('keeps recovery delete from recreating, looking up by name, or deleting by name', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(metadata(), config, context, {
+      restClient: asRestClient(client),
+    });
+
+    await sandbox.delete('recovery');
+
+    expect(context.beginCreate).not.toHaveBeenCalled();
+    expect(client.inspectByName).not.toHaveBeenCalled();
+    expect(client.stopSession).not.toHaveBeenCalled();
+  });
+});

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.ts
@@ -1,0 +1,626 @@
+import { z } from 'zod';
+
+import { WrapperClient } from '../../kilo/wrapper-client.js';
+import { logger } from '../../logger.js';
+import { WRAPPER_VERSION } from '../../shared/wrapper-version.js';
+import type { SessionMetadata } from '../../persistence/session-metadata.js';
+import {
+  AgentSandboxUnavailableError,
+  type AgentSandbox,
+  type AgentSandboxRuntimeContext,
+  type EnsureWrapperRequest,
+  type StopWrappersResult,
+  type TerminalClientResult,
+  type WrapperInstanceLease,
+  type WrapperLogs,
+  type WrapperObservation,
+  type WrapperStopReason,
+  type WrapperStopTarget,
+} from '../protocol.js';
+import type { SandboxDeleteReason } from '../protocol.js';
+import type { SandboxCreateIntent } from '../runtime-intents.js';
+import type { VercelSandboxRuntimeConfig } from './vercel-runtime-config.js';
+import {
+  VercelSandboxRestClient,
+  VercelSandboxRestError,
+  type VercelSandboxCommand,
+} from './vercel-sandbox-rest-client.js';
+import { VercelWrapperTransport } from './vercel-wrapper-transport.js';
+
+export const VERCEL_SANDBOX_UNAVAILABLE_MESSAGE =
+  'Terminal access is unavailable for Vercel sandbox sessions';
+
+const RUNTIME_MANIFEST_PATH = '/usr/local/share/kilo/runtime-manifest.json';
+const WRAPPER_PATH = '/usr/local/bin/kilocode-wrapper.js';
+const WRAPPER_PORT = 5000;
+const MANIFEST_MAX_BYTES = 16 * 1024;
+const WRAPPER_LOG_MAX_BYTES = 1024 * 1024;
+const WRAPPER_HEALTH_RETRY_DELAYS_MS = [250, 500, 1_000, 2_000, 4_000, 8_000, 14_000];
+const WRAPPER_LAUNCH_SETTLE_MS = 30_000;
+const STOP_OBSERVATION_DELAYS_MS = [100, 500, 1_000];
+const wrapperManifestSchema = z
+  .object({
+    runtimeBuildId: z.string().min(1),
+    wrapperVersion: z.string().min(1),
+    runtime: z.literal('node24'),
+    bunVersion: z.string().min(1),
+    wrapperSha256: z.string().regex(/^[0-9a-f]{64}$/),
+  })
+  .passthrough();
+
+export type VercelAgentSandboxDependencies = {
+  restClient?: VercelSandboxRestClient;
+  sleep?: (ms: number) => Promise<void>;
+  now?: () => number;
+};
+
+function observedWrapper(command: VercelSandboxCommand, instance?: WrapperInstanceLease) {
+  return {
+    representation: 'process' as const,
+    id: command.id,
+    ...(instance
+      ? {
+          instanceId: instance.instanceId,
+          instanceGeneration: instance.instanceGeneration,
+        }
+      : {}),
+  };
+}
+
+export class VercelAgentSandbox implements AgentSandbox {
+  private readonly restClient: VercelSandboxRestClient;
+  private readonly injectedRestClient?: VercelSandboxRestClient;
+  private readonly sleep: (ms: number) => Promise<void>;
+  private readonly now: () => number;
+  private runtimeSessionId?: string;
+  private wrapperProcess?: NonNullable<
+    NonNullable<SessionMetadata['workspace']>['providerRuntime']
+  >['wrapper'];
+
+  constructor(
+    private readonly metadata: SessionMetadata,
+    private readonly config: VercelSandboxRuntimeConfig,
+    private readonly runtimeContext?: AgentSandboxRuntimeContext,
+    dependencies: VercelAgentSandboxDependencies = {}
+  ) {
+    this.injectedRestClient = dependencies.restClient;
+    this.restClient =
+      this.injectedRestClient ??
+      new VercelSandboxRestClient({
+        accessToken: config.accessToken,
+        teamId: config.teamId,
+        projectId: config.projectId,
+        fetch,
+      });
+    this.sleep = dependencies.sleep ?? (ms => new Promise(resolve => setTimeout(resolve, ms)));
+    this.now = dependencies.now ?? Date.now;
+    this.runtimeSessionId = metadata.workspace?.providerRuntime?.sessionId;
+    this.wrapperProcess = metadata.workspace?.providerRuntime?.wrapper;
+  }
+
+  private get sandboxName(): string {
+    const sandboxName = this.metadata.workspace?.sandboxId;
+    if (!sandboxName) throw new AgentSandboxUnavailableError('Vercel sandbox name is unavailable');
+    return sandboxName;
+  }
+
+  private get persistedRuntime() {
+    return this.runtimeSessionId
+      ? {
+          provider: 'vercel' as const,
+          sessionId: this.runtimeSessionId,
+          wrapper: this.wrapperProcess,
+        }
+      : undefined;
+  }
+
+  private requireRuntimeContext(): AgentSandboxRuntimeContext {
+    if (!this.runtimeContext) {
+      throw new AgentSandboxUnavailableError(
+        'Vercel sandbox mutation requires the owning session runtime context'
+      );
+    }
+    return this.runtimeContext;
+  }
+
+  private createRestClient(projectId: string): VercelSandboxRestClient {
+    return (
+      this.injectedRestClient ??
+      new VercelSandboxRestClient({
+        accessToken: this.config.accessToken,
+        teamId: this.config.teamId,
+        projectId,
+        fetch,
+      })
+    );
+  }
+
+  private createInput(intent: SandboxCreateIntent) {
+    return {
+      name: intent.sandboxName,
+      operationId: intent.operationId,
+      runtimeBuildId: intent.runtimeBuildId,
+      snapshotId: intent.snapshotId,
+      runtime: intent.runtime,
+      timeoutMs: this.config.initialTimeoutMs,
+    };
+  }
+
+  private async ensureRuntimeSession(): Promise<string> {
+    const context = this.requireRuntimeContext();
+    if (await context.isDeletionPending()) {
+      throw new AgentSandboxUnavailableError(
+        'Vercel sandbox deletion is pending',
+        'runtime_not_running'
+      );
+    }
+    if (this.persistedRuntime?.sessionId) return this.persistedRuntime.sessionId;
+    const existingIntent = await context.getCreateIntent();
+    const intent =
+      existingIntent ??
+      (await context.beginCreate({
+        provider: 'vercel',
+        sandboxName: this.sandboxName,
+        projectId: this.config.projectId,
+        snapshotId: this.config.snapshotId,
+        runtimeBuildId: this.config.runtimeBuildId,
+        runtime: this.config.runtime,
+      }));
+    const createClient = this.createRestClient(intent.projectId);
+
+    let runtime;
+    if (existingIntent) {
+      runtime = await createClient.inspectByName(this.createInput(intent));
+      if (!runtime) {
+        if (this.now() < intent.settleUntil) {
+          throw new AgentSandboxUnavailableError(
+            'Vercel sandbox creation is still settling',
+            'runtime_creation_failed'
+          );
+        }
+        await context.clearCreateIntent(intent.operationId);
+        throw new AgentSandboxUnavailableError(
+          'Vercel sandbox creation was conclusively absent',
+          'runtime_creation_failed'
+        );
+      }
+    } else {
+      runtime = await createClient.createSandbox(this.createInput(intent));
+    }
+    if (await context.isDeletionPending()) {
+      throw new AgentSandboxUnavailableError(
+        'Vercel sandbox deletion won creation',
+        'runtime_not_running'
+      );
+    }
+    await context.persistRuntimeOnce({
+      provider: 'vercel',
+      sessionId: runtime.session.id,
+      projectId: intent.projectId,
+      snapshotId: intent.snapshotId,
+      runtimeBuildId: intent.runtimeBuildId,
+      runtime: intent.runtime,
+    });
+    this.runtimeSessionId = runtime.session.id;
+    return runtime.session.id;
+  }
+
+  private async validateRuntimeManifest(sessionId: string): Promise<void> {
+    const bytes = await this.restClient.readFile(
+      sessionId,
+      RUNTIME_MANIFEST_PATH,
+      MANIFEST_MAX_BYTES
+    );
+    let manifest: unknown;
+    try {
+      manifest = JSON.parse(new TextDecoder().decode(bytes));
+    } catch {
+      throw new AgentSandboxUnavailableError(
+        'Vercel runtime manifest is invalid',
+        'runtime_configuration_drift'
+      );
+    }
+    const parsed = wrapperManifestSchema.safeParse(manifest);
+    if (
+      !parsed.success ||
+      parsed.data.runtimeBuildId !== this.config.runtimeBuildId ||
+      parsed.data.wrapperVersion !== WRAPPER_VERSION ||
+      parsed.data.runtime !== this.config.runtime
+    ) {
+      throw new AgentSandboxUnavailableError(
+        'Vercel runtime manifest does not match the pinned runtime',
+        'runtime_configuration_drift'
+      );
+    }
+
+    const verificationPath = `/tmp/kilo-runtime-verification-${crypto.randomUUID()}.txt`;
+    try {
+      await this.restClient.executeCommand(sessionId, {
+        command: 'sh',
+        args: [
+          '-lc',
+          `bun --version > ${verificationPath} && sha256sum ${WRAPPER_PATH} | cut -d' ' -f1 >> ${verificationPath}`,
+        ],
+        cwd: '/',
+        env: {},
+        sudo: false,
+        wait: true,
+      });
+      const verification = new TextDecoder()
+        .decode(await this.restClient.readFile(sessionId, verificationPath, 256))
+        .trim()
+        .split('\n');
+      if (
+        verification.length !== 2 ||
+        verification[0] !== parsed.data.bunVersion ||
+        verification[1] !== parsed.data.wrapperSha256
+      ) {
+        throw new AgentSandboxUnavailableError(
+          'Vercel runtime artifacts do not match the runtime manifest',
+          'runtime_configuration_drift'
+        );
+      }
+    } finally {
+      await this.restClient
+        .executeCommand(sessionId, {
+          command: 'rm',
+          args: ['-f', '--', verificationPath],
+          cwd: '/',
+          env: {},
+          sudo: false,
+          wait: true,
+        })
+        .catch(() => undefined);
+    }
+  }
+
+  private wrapperClient(sessionId: string): WrapperClient {
+    return new WrapperClient({
+      transport: new VercelWrapperTransport({
+        restClient: this.restClient,
+        sessionId,
+        port: WRAPPER_PORT,
+      }),
+    });
+  }
+
+  private commandMatchesLaunch(command: VercelSandboxCommand, launchId: string): boolean {
+    return command.args.some(argument => argument.includes(`kilo-launch:${launchId}`));
+  }
+
+  private async recoverLaunchCommand(sessionId: string, launchId: string) {
+    const matches = (await this.restClient.listCommands(sessionId)).filter(
+      command => command.exitCode === null && this.commandMatchesLaunch(command, launchId)
+    );
+    if (matches.length !== 1) {
+      throw new AgentSandboxUnavailableError(
+        matches.length === 0
+          ? 'Vercel wrapper launch is still unresolved'
+          : 'Vercel wrapper launch matched multiple commands',
+        'runtime_infrastructure_failed'
+      );
+    }
+    return matches[0];
+  }
+
+  private async ensureWrapperCommand(
+    sessionId: string,
+    instance: WrapperInstanceLease
+  ): Promise<VercelSandboxCommand> {
+    const context = this.requireRuntimeContext();
+    if (await context.isDeletionPending()) {
+      throw new AgentSandboxUnavailableError(
+        'Vercel sandbox deletion is pending',
+        'runtime_not_running'
+      );
+    }
+    const persisted = this.persistedRuntime?.wrapper;
+    if (persisted) {
+      if (
+        persisted.instanceId !== instance.instanceId ||
+        persisted.instanceGeneration !== instance.instanceGeneration
+      ) {
+        throw new AgentSandboxUnavailableError(
+          'Persisted Vercel wrapper belongs to a different physical lease',
+          'runtime_infrastructure_failed'
+        );
+      }
+      const command = await this.observeCommand(sessionId, persisted.commandId);
+      if (command) return command;
+      await context.clearWrapperProcess({ sessionId, commandId: persisted.commandId });
+      this.wrapperProcess = undefined;
+    }
+    const existingIntent = await context.getWrapperLaunchIntent();
+    const intent = existingIntent ?? (await context.beginWrapperLaunch({ sessionId, instance }));
+    if (
+      intent.sessionId !== sessionId ||
+      intent.instanceId !== instance.instanceId ||
+      intent.instanceGeneration !== instance.instanceGeneration
+    ) {
+      throw new AgentSandboxUnavailableError(
+        'Vercel wrapper launch intent does not match the current lease',
+        'runtime_infrastructure_failed'
+      );
+    }
+
+    const command = existingIntent
+      ? await this.recoverLaunchCommand(sessionId, intent.launchId)
+      : await this.restClient.executeCommand(sessionId, {
+          command: 'sh',
+          args: [
+            '-lc',
+            `exec bun run ${WRAPPER_PATH} --agent-session "$KILO_AGENT_SESSION_ID" --user-id "$KILO_USER_ID" # kilo-launch:${intent.launchId}`,
+          ],
+          cwd: '/',
+          env: {
+            WRAPPER_PORT: String(WRAPPER_PORT),
+            WRAPPER_LOG_PATH: `/tmp/kilocode-wrapper-${this.metadata.identity.sessionId}.log`,
+            KILO_AGENT_SESSION_ID: this.metadata.identity.sessionId,
+            KILO_USER_ID: this.metadata.identity.userId,
+            KILO_CLOUD_AGENT: '1',
+            KILO_SESSION_RETRY_LIMIT: '5',
+            WRAPPER_INSTANCE_ID: intent.instanceId,
+            WRAPPER_INSTANCE_GENERATION: String(intent.instanceGeneration),
+          },
+          sudo: false,
+          wait: false,
+        });
+    await context.persistWrapperProcessOnce({
+      sessionId,
+      launchId: intent.launchId,
+      commandId: command.id,
+      instance,
+    });
+    this.wrapperProcess = {
+      launchId: intent.launchId,
+      commandId: command.id,
+      instanceId: instance.instanceId,
+      instanceGeneration: instance.instanceGeneration,
+    };
+    return command;
+  }
+
+  private async waitForHealthyWrapper(
+    client: WrapperClient,
+    instance: WrapperInstanceLease
+  ): Promise<void> {
+    for (let attempt = 0; attempt <= WRAPPER_HEALTH_RETRY_DELAYS_MS.length; attempt++) {
+      try {
+        const health = await client.health();
+        if (
+          health.healthy &&
+          health.version === WRAPPER_VERSION &&
+          health.wrapperInstanceId === instance.instanceId &&
+          health.wrapperInstanceGeneration === instance.instanceGeneration
+        ) {
+          return;
+        }
+      } catch {
+        // Wrapper startup remains observable through the next bounded health attempt.
+      }
+      const delay = WRAPPER_HEALTH_RETRY_DELAYS_MS[attempt];
+      if (delay !== undefined) await this.sleep(delay);
+    }
+    throw new Error('Vercel wrapper did not report the persisted lease');
+  }
+
+  async ensureWrapper(request: EnsureWrapperRequest) {
+    const instance = request.leasedInstance;
+    if (!instance) throw new Error('Vercel wrapper startup requires a physical wrapper lease');
+    const sessionId = await this.ensureRuntimeSession();
+    await this.validateRuntimeManifest(sessionId);
+    await this.ensureWrapperCommand(sessionId, instance);
+    const client = this.wrapperClient(sessionId);
+    await this.waitForHealthyWrapper(client, instance);
+    return { status: 'wrapper-running' as const, client };
+  }
+
+  async discoverSessionWrappers(): Promise<WrapperObservation> {
+    const runtime = this.persistedRuntime;
+    if (!runtime?.wrapper) return { status: 'absent' };
+    try {
+      const command = await this.observeCommand(runtime.sessionId, runtime.wrapper.commandId);
+      if (!command) {
+        await this.runtimeContext?.clearWrapperProcess({
+          sessionId: runtime.sessionId,
+          commandId: runtime.wrapper.commandId,
+        });
+        this.wrapperProcess = undefined;
+        return { status: 'absent' };
+      }
+      return {
+        status: 'present',
+        observed: [
+          observedWrapper(command, {
+            instanceId: runtime.wrapper.instanceId,
+            instanceGeneration: runtime.wrapper.instanceGeneration,
+          }),
+        ],
+      };
+    } catch (error) {
+      return { status: 'inspection-failed', error: String(error) };
+    }
+  }
+
+  private async observeCommand(
+    sessionId: string,
+    commandId: string
+  ): Promise<VercelSandboxCommand | null> {
+    try {
+      const command = await this.restClient.getCommand(sessionId, commandId);
+      return command.exitCode === null ? command : null;
+    } catch (error) {
+      if (error instanceof VercelSandboxRestError && error.status === 404) return null;
+      throw error;
+    }
+  }
+
+  private async reconcileWrapperForStop(target: WrapperStopTarget): Promise<void> {
+    const runtime = this.persistedRuntime;
+    if (!runtime || runtime.wrapper || !this.runtimeContext) return;
+    const intent = await this.runtimeContext.getWrapperLaunchIntent();
+    if (!intent) return;
+    if (
+      target.kind === 'instance' &&
+      (intent.instanceId !== target.instance.instanceId ||
+        intent.instanceGeneration !== target.instance.instanceGeneration)
+    ) {
+      return;
+    }
+    if (intent.sessionId !== runtime.sessionId) {
+      throw new Error('Vercel wrapper launch intent targets a different session');
+    }
+    const matches = (await this.restClient.listCommands(runtime.sessionId)).filter(
+      command => command.exitCode === null && this.commandMatchesLaunch(command, intent.launchId)
+    );
+    if (matches.length > 1) {
+      throw new Error('Vercel wrapper launch matched multiple commands during cleanup');
+    }
+    const command = matches[0];
+    if (!command) {
+      if (this.now() - intent.startedAt < WRAPPER_LAUNCH_SETTLE_MS) {
+        throw new Error('Vercel wrapper launch is still settling during cleanup');
+      }
+      await this.runtimeContext.clearWrapperLaunchIntent(intent.launchId);
+      return;
+    }
+    await this.runtimeContext.persistWrapperProcessOnce({
+      sessionId: runtime.sessionId,
+      launchId: intent.launchId,
+      commandId: command.id,
+      instance: {
+        instanceId: intent.instanceId,
+        instanceGeneration: intent.instanceGeneration,
+      },
+    });
+    this.wrapperProcess = {
+      launchId: intent.launchId,
+      commandId: command.id,
+      instanceId: intent.instanceId,
+      instanceGeneration: intent.instanceGeneration,
+    };
+  }
+
+  async stopWrappers(request: {
+    target: WrapperStopTarget;
+    attemptId: string;
+    reason: WrapperStopReason;
+  }): Promise<StopWrappersResult> {
+    try {
+      await this.reconcileWrapperForStop(request.target);
+    } catch (error) {
+      return { status: 'inspection-failed', error: String(error) };
+    }
+    const runtime = this.persistedRuntime;
+    if (!runtime?.wrapper) return { status: 'absent' };
+    if (
+      request.target.kind === 'instance' &&
+      (runtime.wrapper.instanceId !== request.target.instance.instanceId ||
+        runtime.wrapper.instanceGeneration !== request.target.instance.instanceGeneration)
+    ) {
+      return { status: 'absent' };
+    }
+    const { commandId } = runtime.wrapper;
+    const initial = await this.observeCommand(runtime.sessionId, commandId);
+    if (!initial) {
+      await this.runtimeContext?.clearWrapperProcess({ sessionId: runtime.sessionId, commandId });
+      this.wrapperProcess = undefined;
+      return { status: 'absent', stoppedInstanceIds: [runtime.wrapper.instanceId] };
+    }
+    await this.restClient.killCommand(runtime.sessionId, commandId, 15);
+    for (const delay of STOP_OBSERVATION_DELAYS_MS) {
+      await this.sleep(delay);
+      if (!(await this.observeCommand(runtime.sessionId, commandId))) {
+        await this.runtimeContext?.clearWrapperProcess({ sessionId: runtime.sessionId, commandId });
+        this.wrapperProcess = undefined;
+        return { status: 'absent', stoppedInstanceIds: [runtime.wrapper.instanceId] };
+      }
+    }
+    await this.restClient.killCommand(runtime.sessionId, commandId, 9);
+    const final = await this.observeCommand(runtime.sessionId, commandId);
+    if (final) {
+      return {
+        status: 'still-present',
+        observed: [
+          observedWrapper(final, {
+            instanceId: runtime.wrapper.instanceId,
+            instanceGeneration: runtime.wrapper.instanceGeneration,
+          }),
+        ],
+      };
+    }
+    await this.runtimeContext?.clearWrapperProcess({ sessionId: runtime.sessionId, commandId });
+    this.wrapperProcess = undefined;
+    return { status: 'absent', stoppedInstanceIds: [runtime.wrapper.instanceId] };
+  }
+
+  async probeHealth(): Promise<void> {
+    const runtime = this.persistedRuntime;
+    if (!runtime)
+      throw new AgentSandboxUnavailableError(
+        'Vercel runtime is not running',
+        'runtime_not_running'
+      );
+    const session = await this.restClient.getSession(runtime.sessionId, this.sandboxName);
+    if (session.session.status !== 'running') {
+      throw new AgentSandboxUnavailableError(
+        'Vercel runtime is not running',
+        'runtime_not_running'
+      );
+    }
+  }
+
+  async getRunningWrapper(): Promise<WrapperClient | null> {
+    const runtime = this.persistedRuntime;
+    if (!runtime?.wrapper) return null;
+    const command = await this.observeCommand(runtime.sessionId, runtime.wrapper.commandId);
+    return command ? this.wrapperClient(runtime.sessionId) : null;
+  }
+
+  async getRunningTerminalClient(): Promise<TerminalClientResult> {
+    return {
+      status: 'capability-unavailable',
+      message: VERCEL_SANDBOX_UNAVAILABLE_MESSAGE,
+    };
+  }
+
+  async readWrapperLogs(): Promise<WrapperLogs | null> {
+    const runtime = this.persistedRuntime;
+    if (!runtime?.wrapper) return null;
+    const path = `/tmp/kilocode-wrapper-${this.metadata.identity.sessionId}.log`;
+    try {
+      const content = await this.restClient.readFile(
+        runtime.sessionId,
+        path,
+        WRAPPER_LOG_MAX_BYTES
+      );
+      return { files: { [path]: new TextDecoder().decode(content) } };
+    } catch {
+      return { files: {} };
+    }
+  }
+
+  async keepAlive(): Promise<void> {
+    const runtime = this.persistedRuntime;
+    if (!runtime) return;
+    const inspected = await this.restClient.getSession(runtime.sessionId, this.sandboxName);
+    if (inspected.session.status !== 'running') return;
+    const startedAt = inspected.session.startedAt ?? inspected.session.requestedAt;
+    const expiresAt = startedAt + inspected.session.timeout;
+    const extensionWatermarkMs = Math.max(60_000, Math.floor(this.config.extendDurationMs / 2));
+    if (expiresAt - this.now() > extensionWatermarkMs) return;
+    await this.restClient.extendSessionTimeout(
+      runtime.sessionId,
+      this.sandboxName,
+      this.config.extendDurationMs
+    );
+  }
+
+  async delete(reason: SandboxDeleteReason): Promise<void> {
+    // VM teardown is reconciled by the session deletion tombstone
+    // (VercelSandboxLifecycle); the adapter has nothing to tear down here.
+    logger
+      .withFields({ sessionId: this.metadata.identity.sessionId, reason })
+      .debug('Vercel sandbox delete deferred to the session deletion tombstone');
+  }
+}

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.ts
@@ -404,6 +404,24 @@ export class VercelAgentSandbox implements AgentSandbox {
     throw new Error('Vercel wrapper did not report the persisted lease');
   }
 
+  // TODO: Vercel is not on the Cloudflare container meter. These admit and
+  // never block so AgentSandbox callers do not throw; wire real billing later.
+  async ensureBillingAdmission() {
+    return { success: true as const };
+  }
+
+  async isBillingBlocked(_enforcementRequested = false): Promise<boolean> {
+    return false;
+  }
+
+  async getBillingRuntimeStatus() {
+    return undefined;
+  }
+
+  observeWrappersWithoutWaking(): Promise<WrapperObservation> {
+    return this.discoverSessionWrappers();
+  }
+
   async ensureWrapper(request: EnsureWrapperRequest) {
     const instance = request.leasedInstance;
     if (!instance) throw new Error('Vercel wrapper startup requires a physical wrapper lease');

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.ts
@@ -316,17 +316,19 @@ export class VercelAgentSandbox implements AgentSandbox {
     }
     const persisted = this.persistedRuntime?.wrapper;
     if (persisted) {
-      if (
-        persisted.instanceId !== instance.instanceId ||
-        persisted.instanceGeneration !== instance.instanceGeneration
-      ) {
-        throw new AgentSandboxUnavailableError(
-          'Persisted Vercel wrapper belongs to a different physical lease',
-          'runtime_infrastructure_failed'
-        );
-      }
       const command = await this.observeCommand(sessionId, persisted.commandId);
-      if (command) return command;
+      if (command) {
+        if (
+          persisted.instanceId !== instance.instanceId ||
+          persisted.instanceGeneration !== instance.instanceGeneration
+        ) {
+          throw new AgentSandboxUnavailableError(
+            'Persisted Vercel wrapper belongs to a different physical lease',
+            'runtime_infrastructure_failed'
+          );
+        }
+        return command;
+      }
       await context.clearWrapperProcess({ sessionId, commandId: persisted.commandId });
       this.wrapperProcess = undefined;
     }
@@ -435,8 +437,39 @@ export class VercelAgentSandbox implements AgentSandbox {
 
   async discoverSessionWrappers(): Promise<WrapperObservation> {
     const runtime = this.persistedRuntime;
-    if (!runtime?.wrapper) return { status: 'absent' };
+    if (!runtime) return { status: 'absent' };
     try {
+      if (!runtime.wrapper) {
+        const intent = await this.runtimeContext?.getWrapperLaunchIntent();
+        if (!intent) return { status: 'absent' };
+        if (intent.sessionId !== runtime.sessionId) {
+          throw new Error('Vercel wrapper launch intent targets a different session');
+        }
+        const matches = (await this.restClient.listCommands(runtime.sessionId)).filter(
+          command =>
+            command.exitCode === null && this.commandMatchesLaunch(command, intent.launchId)
+        );
+        if (matches.length > 1) {
+          throw new Error('Vercel wrapper launch matched multiple commands during discovery');
+        }
+        const command = matches[0];
+        if (command) {
+          return {
+            status: 'present',
+            observed: [
+              observedWrapper(command, {
+                instanceId: intent.instanceId,
+                instanceGeneration: intent.instanceGeneration,
+              }),
+            ],
+          };
+        }
+        if (this.now() - intent.startedAt < WRAPPER_LAUNCH_SETTLE_MS) {
+          throw new Error('Vercel wrapper launch is still settling during discovery');
+        }
+        await this.runtimeContext?.clearWrapperLaunchIntent(intent.launchId);
+        return { status: 'absent' };
+      }
       const command = await this.observeCommand(runtime.sessionId, runtime.wrapper.commandId);
       if (!command) {
         await this.runtimeContext?.clearWrapperProcess({

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-lifecycle.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-lifecycle.ts
@@ -1,0 +1,264 @@
+import { logger } from '../../logger.js';
+import { getSandboxProvider, type SessionMetadata } from '../../persistence/session-metadata.js';
+import type {
+  AgentSandboxLifecycle,
+  AgentSandboxLifecycleHost,
+  ProviderDeletionPlan,
+  SessionDeletionIntent,
+} from '../protocol.js';
+import {
+  parseVercelSandboxCredentials,
+  type VercelSandboxCredentials,
+  type VercelSandboxRuntimeConfigEnv,
+} from './vercel-runtime-config.js';
+import {
+  claimVercelStopAttempt,
+  classifyVercelSession,
+  parseVercelCreateIntent,
+  parseVercelStopTombstone,
+  retryVercelStopAttempt,
+  VERCEL_CREATE_INTENT_KEY,
+  VERCEL_CREATE_RETRY_DELAY_MS,
+  VERCEL_DELETION_TOMBSTONE_KEY,
+  VERCEL_STOP_ATTEMPT_TIMEOUT_MS,
+  type VercelCreateIntent,
+  type VercelStopTombstone,
+} from './vercel-runtime-state.js';
+import { VercelSandboxRestClient, VercelSandboxRestError } from './vercel-sandbox-rest-client.js';
+
+const RECONCILE_RETRY_INTERVAL_MS = 5 * 60 * 1000;
+const MANUAL_REMEDIATION_RETRY_INTERVAL_MS = 60 * 60 * 1000;
+
+/**
+ * Reconciles durable Vercel runtime state (create intents and deletion
+ * tombstones) against the Vercel API until it reaches a terminal state.
+ * Every method self-guards on stored state: sessions on other providers
+ * never persist these keys, so all methods reduce to no-ops for them.
+ */
+export class VercelSandboxLifecycle implements AgentSandboxLifecycle {
+  constructor(
+    private readonly env: VercelSandboxRuntimeConfigEnv,
+    private readonly host: AgentSandboxLifecycleHost
+  ) {}
+
+  restClient(credentials: VercelSandboxCredentials, projectId?: string): VercelSandboxRestClient {
+    return new VercelSandboxRestClient({
+      accessToken: credentials.accessToken,
+      projectId,
+      teamId: credentials.teamId,
+      fetch,
+    });
+  }
+
+  async planDeletion(input: {
+    metadata: SessionMetadata;
+    intent: SessionDeletionIntent;
+    now: number;
+  }): Promise<ProviderDeletionPlan> {
+    const { metadata, intent, now } = input;
+    if (getSandboxProvider(metadata) !== 'vercel') return { kind: 'not-applicable' };
+    const sandboxName = metadata.workspace?.sandboxId;
+    if (!sandboxName) return { kind: 'complete' };
+    const createIntentRaw = await this.host.storage.get(VERCEL_CREATE_INTENT_KEY);
+    const createIntent =
+      createIntentRaw === undefined ? undefined : parseVercelCreateIntent(createIntentRaw);
+    const sessionId = metadata.workspace?.providerRuntime?.sessionId;
+    if (!sessionId && !createIntent) return { kind: 'complete' };
+    const tombstone = parseVercelStopTombstone({
+      version: 2,
+      provider: 'vercel',
+      sandboxName,
+      sessionId,
+      unresolvedCreate: createIntent
+        ? {
+            operationId: createIntent.operationId,
+            projectId: createIntent.projectId,
+            snapshotId: createIntent.snapshotId,
+            runtimeBuildId: createIntent.runtimeBuildId,
+            runtime: createIntent.runtime,
+            settleUntil: createIntent.settleUntil,
+          }
+        : undefined,
+      intent,
+      stop: { status: 'needed', attempts: 0, nextAttemptAt: now },
+    });
+    if ('status' in tombstone) throw new Error('Unexpected legacy Vercel deletion tombstone');
+    return { kind: 'deferred', entries: { [VERCEL_DELETION_TOMBSTONE_KEY]: tombstone } };
+  }
+
+  async reconcilePendingDeletion(now: number): Promise<'handled' | 'none'> {
+    const raw = await this.host.storage.get(VERCEL_DELETION_TOMBSTONE_KEY);
+    if (raw === undefined) return 'none';
+    const tombstone = parseVercelStopTombstone(raw);
+    if ('status' in tombstone) {
+      logger.error('Legacy Vercel deletion tombstone requires manual remediation');
+      await this.host.scheduleAlarmAtOrBefore(now + MANUAL_REMEDIATION_RETRY_INTERVAL_MS);
+      return 'handled';
+    }
+    const retryAt =
+      tombstone.stop.status === 'stopping'
+        ? tombstone.stop.attemptDeadlineAt
+        : tombstone.stop.nextAttemptAt;
+    if (now < retryAt) {
+      await this.host.scheduleAlarmAtOrBefore(retryAt);
+      return 'handled';
+    }
+    await this.reconcileDeletion(tombstone, now);
+    return 'handled';
+  }
+
+  private async retainDeletionForRetry(
+    tombstone: VercelStopTombstone,
+    attemptId: string,
+    now: number
+  ): Promise<void> {
+    const retryAt = now + RECONCILE_RETRY_INTERVAL_MS;
+    const retrying = retryVercelStopAttempt(tombstone, attemptId, retryAt) ?? tombstone;
+    await this.host.storage.put(VERCEL_DELETION_TOMBSTONE_KEY, retrying);
+    await this.host.scheduleAlarmAtOrBefore(retryAt);
+  }
+
+  private async reconcileDeletion(tombstone: VercelStopTombstone, now: number): Promise<void> {
+    await this.host.purgeDeletedSessionPayload();
+    const credentials = parseVercelSandboxCredentials(this.env);
+    if (!credentials) {
+      await this.host.scheduleAlarmAtOrBefore(now + RECONCILE_RETRY_INTERVAL_MS);
+      return;
+    }
+    let current = tombstone;
+    const unresolved = current.unresolvedCreate;
+    const client = this.restClient(credentials, unresolved?.projectId);
+
+    if (!current.sessionId && unresolved) {
+      try {
+        const observation = await client.inspectByName({
+          name: current.sandboxName,
+          operationId: unresolved.operationId,
+          runtimeBuildId: unresolved.runtimeBuildId,
+          snapshotId: unresolved.snapshotId,
+          runtime: unresolved.runtime,
+        });
+        if (observation) {
+          current = { ...current, sessionId: observation.session.id };
+          await this.host.storage.put(VERCEL_DELETION_TOMBSTONE_KEY, current);
+        } else if (now >= unresolved.settleUntil) {
+          await this.host.eraseDurableObjectState();
+          return;
+        } else {
+          await this.host.scheduleAlarmAtOrBefore(now + RECONCILE_RETRY_INTERVAL_MS);
+          return;
+        }
+      } catch (error) {
+        logger
+          .withFields({
+            sessionId: this.host.getSessionIdForLogs(),
+            error: error instanceof Error ? error.message : String(error),
+          })
+          .warn('Vercel late-create reconciliation remains unresolved');
+        await this.host.scheduleAlarmAtOrBefore(now + RECONCILE_RETRY_INTERVAL_MS);
+        return;
+      }
+    }
+
+    if (!current.sessionId) return;
+    const attemptId = crypto.randomUUID();
+    const claimed = claimVercelStopAttempt(
+      current,
+      attemptId,
+      now,
+      now + VERCEL_STOP_ATTEMPT_TIMEOUT_MS
+    );
+    if (!claimed) {
+      const retryAt =
+        current.stop.status === 'stopping'
+          ? current.stop.attemptDeadlineAt
+          : current.stop.nextAttemptAt;
+      await this.host.scheduleAlarmAtOrBefore(retryAt);
+      return;
+    }
+    await this.host.storage.put(VERCEL_DELETION_TOMBSTONE_KEY, claimed);
+    const claimedSessionId = claimed.sessionId;
+    if (!claimedSessionId) throw new Error('Claimed Vercel stop is missing its exact session ID');
+
+    try {
+      const stopped = await client.stopSession(claimedSessionId, claimed.sandboxName);
+      if (classifyVercelSession(stopped.status, { notFoundIsTerminal: true }) === 'terminal') {
+        await this.host.eraseDurableObjectState();
+        return;
+      }
+    } catch {
+      try {
+        const inspected = await client.getSession(claimedSessionId, claimed.sandboxName);
+        if (
+          classifyVercelSession(inspected.session.status, { notFoundIsTerminal: true }) ===
+          'terminal'
+        ) {
+          await this.host.eraseDurableObjectState();
+          return;
+        }
+      } catch (inspectionError) {
+        if (inspectionError instanceof VercelSandboxRestError && inspectionError.status === 404) {
+          await this.host.eraseDurableObjectState();
+          return;
+        }
+      }
+    }
+    await this.retainDeletionForRetry(claimed, attemptId, now);
+  }
+
+  async reconcileCreateIntent(now: number): Promise<void> {
+    const raw = await this.host.storage.get(VERCEL_CREATE_INTENT_KEY);
+    if (raw === undefined) return;
+    const intent = parseVercelCreateIntent(raw);
+    if (now < intent.nextRetryAt) {
+      await this.host.scheduleAlarmAtOrBefore(intent.nextRetryAt);
+      return;
+    }
+    const credentials = parseVercelSandboxCredentials(this.env);
+    if (!credentials) {
+      await this.host.scheduleAlarmAtOrBefore(now + RECONCILE_RETRY_INTERVAL_MS);
+      return;
+    }
+    const retrying = {
+      ...intent,
+      attempts: intent.attempts + 1,
+      nextRetryAt: now + VERCEL_CREATE_RETRY_DELAY_MS,
+    } satisfies VercelCreateIntent;
+    await this.host.storage.put(VERCEL_CREATE_INTENT_KEY, retrying);
+    try {
+      const observation = await this.restClient(credentials, intent.projectId).inspectByName({
+        name: intent.sandboxName,
+        operationId: intent.operationId,
+        runtimeBuildId: intent.runtimeBuildId,
+        snapshotId: intent.snapshotId,
+        runtime: intent.runtime,
+      });
+      if (observation) {
+        await this.host.runtimeContext.persistRuntimeOnce({
+          provider: 'vercel',
+          sessionId: observation.session.id,
+          projectId: intent.projectId,
+          snapshotId: intent.snapshotId,
+          runtimeBuildId: intent.runtimeBuildId,
+          runtime: intent.runtime,
+        });
+        return;
+      }
+      if (now >= intent.settleUntil) {
+        await this.host.runtimeContext.clearCreateIntent(intent.operationId);
+        return;
+      }
+    } catch (error) {
+      logger
+        .withFields({
+          provider: 'vercel',
+          operation: 'reconcile-create',
+          sandboxName: intent.sandboxName,
+          attempt: retrying.attempts,
+          failureClass: error instanceof VercelSandboxRestError ? error.kind : 'unknown',
+        })
+        .warn('Vercel create intent remains unresolved');
+    }
+    await this.host.scheduleAlarmAtOrBefore(retrying.nextRetryAt);
+  }
+}

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-runtime-config.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-runtime-config.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+  parseVercelSandboxCredentials,
+  parseVercelSandboxEnrollment,
+  parseVercelSandboxRuntimeConfig,
+} from './vercel-runtime-config.js';
+
+const completeRuntimeEnv = {
+  VERCEL_TOKEN: 'token',
+  VERCEL_TEAM_ID: 'team-id',
+  VERCEL_PROJECT_ID: 'project-id',
+  VERCEL_SANDBOX_SNAPSHOT_ID: 'snapshot-id',
+  VERCEL_SANDBOX_RUNTIME_BUILD_ID: 'build-id',
+  VERCEL_SANDBOX_RUNTIME: 'node24',
+  VERCEL_SANDBOX_INITIAL_TIMEOUT_MS: '300000',
+  VERCEL_SANDBOX_EXTEND_DURATION_MS: '600000',
+};
+
+describe('parseVercelSandboxCredentials', () => {
+  it('parses the minimal exact-session cleanup configuration', () => {
+    expect(
+      parseVercelSandboxCredentials({ VERCEL_TOKEN: ' token ', VERCEL_TEAM_ID: ' team ' })
+    ).toEqual({ accessToken: 'token', teamId: 'team' });
+    expect(parseVercelSandboxCredentials({ VERCEL_TOKEN: 'token' })).toBeUndefined();
+  });
+});
+
+describe('parseVercelSandboxRuntimeConfig', () => {
+  it('parses complete operational configuration at the point of use', () => {
+    expect(parseVercelSandboxRuntimeConfig(completeRuntimeEnv)).toEqual({
+      accessToken: 'token',
+      teamId: 'team-id',
+      projectId: 'project-id',
+      snapshotId: 'snapshot-id',
+      runtimeBuildId: 'build-id',
+      runtime: 'node24',
+      initialTimeoutMs: 300000,
+      extendDurationMs: 600000,
+    });
+  });
+
+  it.each([
+    'VERCEL_TOKEN',
+    'VERCEL_TEAM_ID',
+    'VERCEL_PROJECT_ID',
+    'VERCEL_SANDBOX_SNAPSHOT_ID',
+    'VERCEL_SANDBOX_RUNTIME_BUILD_ID',
+    'VERCEL_SANDBOX_RUNTIME',
+    'VERCEL_SANDBOX_INITIAL_TIMEOUT_MS',
+    'VERCEL_SANDBOX_EXTEND_DURATION_MS',
+  ] as const)('rejects configuration missing %s', key => {
+    const env = { ...completeRuntimeEnv };
+    delete env[key];
+    expect(parseVercelSandboxRuntimeConfig(env)).toBeUndefined();
+  });
+
+  it.each([
+    ['VERCEL_SANDBOX_RUNTIME', 'node22'],
+    ['VERCEL_SANDBOX_INITIAL_TIMEOUT_MS', '0'],
+    ['VERCEL_SANDBOX_INITIAL_TIMEOUT_MS', '1.5'],
+    ['VERCEL_SANDBOX_EXTEND_DURATION_MS', '-1'],
+    ['VERCEL_SANDBOX_EXTEND_DURATION_MS', 'not-a-number'],
+  ] as const)('rejects invalid %s', (key, value) => {
+    expect(
+      parseVercelSandboxRuntimeConfig({ ...completeRuntimeEnv, [key]: value })
+    ).toBeUndefined();
+  });
+});
+
+describe('parseVercelSandboxEnrollment', () => {
+  it('is disabled when the list is empty', () => {
+    expect(parseVercelSandboxEnrollment({})).toEqual({
+      enabled: false,
+      orgIds: new Set(),
+      allowPersonal: false,
+    });
+    expect(parseVercelSandboxEnrollment({ VERCEL_SANDBOX_ORG_IDS: '  ,  ' })).toEqual({
+      enabled: false,
+      orgIds: new Set(),
+      allowPersonal: false,
+    });
+  });
+
+  it('parses an explicit organization allowlist', () => {
+    expect(
+      parseVercelSandboxEnrollment({
+        VERCEL_SANDBOX_ORG_IDS: ' org-a,org-b, org-a ',
+      })
+    ).toEqual({ enabled: true, orgIds: new Set(['org-a', 'org-b']), allowPersonal: false });
+  });
+
+  it('treats wildcard as every org plus personal', () => {
+    expect(
+      parseVercelSandboxEnrollment({
+        VERCEL_SANDBOX_ORG_IDS: '*',
+      })
+    ).toEqual({ enabled: true, orgIds: new Set(['*']), allowPersonal: true });
+  });
+});

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-runtime-config.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-runtime-config.ts
@@ -1,0 +1,131 @@
+import { z } from 'zod';
+
+const positiveIntegerString = z
+  .string()
+  .regex(/^\d+$/)
+  .transform(Number)
+  .pipe(z.number().int().positive().safe());
+
+const runtimeConfigSchema = z.object({
+  VERCEL_TOKEN: z.string().trim().min(1),
+  VERCEL_TEAM_ID: z.string().trim().min(1),
+  VERCEL_PROJECT_ID: z.string().trim().min(1),
+  VERCEL_SANDBOX_SNAPSHOT_ID: z.string().trim().min(1),
+  VERCEL_SANDBOX_RUNTIME_BUILD_ID: z.string().trim().min(1),
+  VERCEL_SANDBOX_RUNTIME: z.literal('node24'),
+  VERCEL_SANDBOX_INITIAL_TIMEOUT_MS: positiveIntegerString,
+  VERCEL_SANDBOX_EXTEND_DURATION_MS: positiveIntegerString,
+});
+
+export type VercelSandboxRuntimeConfig = {
+  accessToken: string;
+  teamId: string;
+  projectId: string;
+  snapshotId: string;
+  runtimeBuildId: string;
+  runtime: 'node24';
+  initialTimeoutMs: number;
+  extendDurationMs: number;
+};
+
+export type VercelSandboxCredentials = {
+  accessToken: string;
+  teamId: string;
+};
+
+export type VercelSandboxRuntimeConfigEnv = {
+  VERCEL_TOKEN?: string;
+  VERCEL_TEAM_ID?: string;
+  VERCEL_PROJECT_ID?: string;
+  VERCEL_SANDBOX_SNAPSHOT_ID?: string;
+  VERCEL_SANDBOX_RUNTIME_BUILD_ID?: string;
+  VERCEL_SANDBOX_RUNTIME?: string;
+  VERCEL_SANDBOX_INITIAL_TIMEOUT_MS?: string;
+  VERCEL_SANDBOX_EXTEND_DURATION_MS?: string;
+};
+
+export function parseVercelSandboxCredentials(
+  env: VercelSandboxRuntimeConfigEnv
+): VercelSandboxCredentials | undefined {
+  const accessToken = env.VERCEL_TOKEN?.trim();
+  const teamId = env.VERCEL_TEAM_ID?.trim();
+  return accessToken && teamId ? { accessToken, teamId } : undefined;
+}
+
+export function parseVercelSandboxRuntimeConfig(
+  env: VercelSandboxRuntimeConfigEnv
+): VercelSandboxRuntimeConfig | undefined {
+  const result = runtimeConfigSchema.safeParse(env);
+  if (!result.success) return undefined;
+
+  return {
+    accessToken: result.data.VERCEL_TOKEN,
+    teamId: result.data.VERCEL_TEAM_ID,
+    projectId: result.data.VERCEL_PROJECT_ID,
+    snapshotId: result.data.VERCEL_SANDBOX_SNAPSHOT_ID,
+    runtimeBuildId: result.data.VERCEL_SANDBOX_RUNTIME_BUILD_ID,
+    runtime: result.data.VERCEL_SANDBOX_RUNTIME,
+    initialTimeoutMs: result.data.VERCEL_SANDBOX_INITIAL_TIMEOUT_MS,
+    extendDurationMs: result.data.VERCEL_SANDBOX_EXTEND_DURATION_MS,
+  };
+}
+
+/**
+ * Operational config for a session's Vercel runtime: environment values,
+ * overlaid with the session's persisted runtime identity once one exists so
+ * later env rotations cannot repoint an already-created runtime.
+ */
+export function resolveVercelSandboxRuntimeConfig(
+  env: VercelSandboxRuntimeConfigEnv,
+  persisted?: {
+    projectId?: string;
+    snapshotId?: string;
+    runtimeBuildId?: string;
+    runtime?: string;
+  }
+): VercelSandboxRuntimeConfig | undefined {
+  const configured = parseVercelSandboxRuntimeConfig(env);
+  if (!configured) return undefined;
+  return persisted?.projectId &&
+    persisted.snapshotId &&
+    persisted.runtimeBuildId &&
+    persisted.runtime === 'node24'
+    ? {
+        ...configured,
+        projectId: persisted.projectId,
+        snapshotId: persisted.snapshotId,
+        runtimeBuildId: persisted.runtimeBuildId,
+        runtime: persisted.runtime,
+      }
+    : configured;
+}
+
+export type VercelSandboxEnrollmentEnv = {
+  VERCEL_SANDBOX_ORG_IDS?: string;
+};
+
+export type VercelSandboxEnrollment = {
+  enabled: boolean;
+  orgIds: Set<string>;
+  allowPersonal: boolean;
+};
+
+export function parseVercelSandboxEnrollment(
+  env: VercelSandboxEnrollmentEnv
+): VercelSandboxEnrollment {
+  const orgIds = new Set(
+    (env.VERCEL_SANDBOX_ORG_IDS ?? '')
+      .split(',')
+      .map(orgId => orgId.trim())
+      .filter(Boolean)
+  );
+  if (orgIds.size === 0) {
+    return { enabled: false, orgIds, allowPersonal: false };
+  }
+
+  return {
+    enabled: true,
+    orgIds,
+    allowPersonal: orgIds.has('*'),
+  };
+}

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-runtime-state.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-runtime-state.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  claimVercelStopAttempt,
+  classifyVercelSession,
+  parseVercelCreateIntent,
+  parseVercelStopTombstone,
+  parseVercelWrapperLaunchIntent,
+  retryVercelStopAttempt,
+  type VercelCreateIntent,
+  type VercelStopTombstone,
+} from './vercel-runtime-state.js';
+
+const createIntent: VercelCreateIntent = {
+  version: 1,
+  sandboxName: 'ses-abcdef',
+  operationId: 'operation-1',
+  projectId: 'project-1',
+  snapshotId: 'snapshot-1',
+  runtimeBuildId: 'build-1',
+  runtime: 'node24',
+  startedAt: 100,
+  settleUntil: 500,
+  attempts: 1,
+  nextRetryAt: 200,
+};
+
+const stopTombstone: VercelStopTombstone = {
+  version: 2,
+  provider: 'vercel',
+  sandboxName: 'ses-abcdef',
+  sessionId: 'session-1',
+  intent: { reason: 'explicit', startedAt: 100 },
+  stop: { status: 'needed', attempts: 0, nextAttemptAt: 100 },
+};
+
+describe('Vercel durable runtime state', () => {
+  it('validates durable create and wrapper launch intents', () => {
+    expect(parseVercelCreateIntent(createIntent)).toEqual(createIntent);
+    expect(
+      parseVercelWrapperLaunchIntent({
+        sessionId: 'session-1',
+        launchId: 'launch-1',
+        instanceId: 'instance-1',
+        instanceGeneration: 2,
+        startedAt: 100,
+      })
+    ).toEqual({
+      sessionId: 'session-1',
+      launchId: 'launch-1',
+      instanceId: 'instance-1',
+      instanceGeneration: 2,
+      startedAt: 100,
+    });
+    expect(() => parseVercelCreateIntent({ ...createIntent, attempts: -1 })).toThrow();
+  });
+
+  it('parses exact-session tombstones without accepting sensitive or unknown fields', () => {
+    expect(parseVercelStopTombstone(stopTombstone)).toEqual(stopTombstone);
+    expect(() => parseVercelStopTombstone({ ...stopTombstone, userId: 'user-1' })).toThrow();
+  });
+
+  it('claims one due stop attempt and retries only its matching claim', () => {
+    const claimed = claimVercelStopAttempt(stopTombstone, 'attempt-1', 100, 150);
+    expect(claimed).toEqual({
+      ...stopTombstone,
+      stop: {
+        status: 'stopping',
+        attempts: 1,
+        nextAttemptAt: 100,
+        attemptId: 'attempt-1',
+        attemptDeadlineAt: 150,
+      },
+    });
+    if (!claimed) throw new Error('Expected stop claim');
+
+    expect(claimVercelStopAttempt(claimed, 'attempt-2', 120, 170)).toBeNull();
+    expect(retryVercelStopAttempt(claimed, 'stale-attempt', 200)).toBeNull();
+    expect(retryVercelStopAttempt(claimed, 'attempt-1', 200)).toEqual({
+      ...stopTombstone,
+      stop: { status: 'needed', attempts: 1, nextAttemptAt: 200 },
+    });
+  });
+
+  it('allows an expired stop claim to be reclaimed', () => {
+    const claimed = claimVercelStopAttempt(stopTombstone, 'attempt-1', 100, 150);
+    if (!claimed) throw new Error('Expected stop claim');
+
+    expect(claimVercelStopAttempt(claimed, 'attempt-2', 150, 250)?.stop).toEqual({
+      status: 'stopping',
+      attempts: 2,
+      nextAttemptAt: 100,
+      attemptId: 'attempt-2',
+      attemptDeadlineAt: 250,
+    });
+  });
+
+  it('classifies stopped, aborted, failed, and policy-approved absence as terminal', () => {
+    expect(classifyVercelSession('stopped')).toBe('terminal');
+    expect(classifyVercelSession('aborted')).toBe('terminal');
+    expect(classifyVercelSession('failed')).toBe('terminal');
+    expect(classifyVercelSession('running')).toBe('active');
+    expect(classifyVercelSession('not-found', { notFoundIsTerminal: true })).toBe('terminal');
+    expect(classifyVercelSession('not-found', { notFoundIsTerminal: false })).toBe('unknown');
+  });
+
+  it('fails closed when legacy version-1 tombstones are encountered', () => {
+    expect(
+      parseVercelStopTombstone({
+        version: 1,
+        provider: 'vercel',
+        sandboxName: 'ses-abcdef',
+        ownershipProof: 'legacy-proof',
+      })
+    ).toEqual({ status: 'manual-remediation', version: 1 });
+    expect(() => parseVercelStopTombstone({ version: 3, provider: 'vercel' })).toThrow();
+  });
+});

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-runtime-state.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-runtime-state.ts
@@ -1,0 +1,183 @@
+import * as z from 'zod';
+
+import type { SandboxId } from '../../types.js';
+
+/**
+ * Durable-storage keys for Vercel runtime state owned by the session DO.
+ * The key names are persisted in live sessions and must stay stable.
+ */
+export const VERCEL_CREATE_INTENT_KEY = 'vercel_create_intent';
+export const VERCEL_WRAPPER_LAUNCH_INTENT_KEY = 'vercel_wrapper_launch_intent';
+export const VERCEL_DELETION_TOMBSTONE_KEY = 'vercel_deletion_tombstone';
+
+export const VERCEL_CREATE_SETTLE_MS = 5 * 60 * 1000;
+export const VERCEL_CREATE_RETRY_DELAY_MS = 10 * 1000;
+export const VERCEL_STOP_ATTEMPT_TIMEOUT_MS = 30 * 1000;
+
+const SandboxIdSchema = z
+  .string()
+  .regex(/^ses-[0-9a-f]+$/)
+  .transform(value => value as SandboxId);
+const VercelSandboxRuntimeSchema = z.enum(['node22', 'node24', 'node26', 'python3.13']);
+
+export const VercelCreateIntentSchema = z
+  .object({
+    version: z.literal(1),
+    sandboxName: SandboxIdSchema,
+    operationId: z.string().min(1),
+    projectId: z.string().min(1),
+    snapshotId: z.string().min(1),
+    runtimeBuildId: z.string().min(1),
+    runtime: VercelSandboxRuntimeSchema,
+    startedAt: z.number().nonnegative(),
+    settleUntil: z.number().nonnegative(),
+    attempts: z.number().int().nonnegative(),
+    nextRetryAt: z.number().nonnegative(),
+  })
+  .strict();
+
+export const VercelWrapperLaunchIntentSchema = z
+  .object({
+    sessionId: z.string().min(1),
+    launchId: z.string().min(1),
+    instanceId: z.string().min(1),
+    instanceGeneration: z.number().int().nonnegative(),
+    startedAt: z.number().nonnegative(),
+  })
+  .strict();
+
+const VercelUnresolvedCreateSchema = z
+  .object({
+    operationId: z.string().min(1),
+    projectId: z.string().min(1),
+    snapshotId: z.string().min(1),
+    runtimeBuildId: z.string().min(1),
+    runtime: VercelSandboxRuntimeSchema,
+    settleUntil: z.number().nonnegative(),
+  })
+  .strict();
+
+const VercelStopStateSchema = z.discriminatedUnion('status', [
+  z
+    .object({
+      status: z.literal('needed'),
+      attempts: z.number().int().nonnegative(),
+      nextAttemptAt: z.number().nonnegative(),
+    })
+    .strict(),
+  z
+    .object({
+      status: z.literal('stopping'),
+      attempts: z.number().int().positive(),
+      nextAttemptAt: z.number().nonnegative(),
+      attemptId: z.string().min(1),
+      attemptDeadlineAt: z.number().nonnegative(),
+    })
+    .strict(),
+]);
+
+export const VercelStopTombstoneSchema = z
+  .object({
+    version: z.literal(2),
+    provider: z.literal('vercel'),
+    sandboxName: SandboxIdSchema,
+    sessionId: z.string().min(1).optional(),
+    unresolvedCreate: VercelUnresolvedCreateSchema.optional(),
+    intent: z
+      .object({
+        reason: z.enum(['explicit', 'retention-expired']),
+        startedAt: z.number().nonnegative(),
+      })
+      .strict(),
+    stop: VercelStopStateSchema,
+  })
+  .strict()
+  .refine(value => value.sessionId !== undefined || value.unresolvedCreate !== undefined, {
+    message: 'Vercel stop tombstone requires an exact session or unresolved create',
+  });
+
+const LegacyVercelStopTombstoneSchema = z.object({
+  version: z.literal(1),
+  provider: z.literal('vercel'),
+});
+
+export type VercelCreateIntent = z.infer<typeof VercelCreateIntentSchema>;
+export type VercelWrapperLaunchIntent = z.infer<typeof VercelWrapperLaunchIntentSchema>;
+export type VercelStopTombstone = z.infer<typeof VercelStopTombstoneSchema>;
+
+export function parseVercelCreateIntent(value: unknown): VercelCreateIntent {
+  return VercelCreateIntentSchema.parse(value);
+}
+
+export function parseVercelWrapperLaunchIntent(value: unknown): VercelWrapperLaunchIntent {
+  return VercelWrapperLaunchIntentSchema.parse(value);
+}
+
+export function parseVercelStopTombstone(
+  value: unknown
+): VercelStopTombstone | { status: 'manual-remediation'; version: 1 } {
+  const version = z.object({ version: z.number() }).passthrough().parse(value).version;
+  if (version === 1) {
+    LegacyVercelStopTombstoneSchema.passthrough().parse(value);
+    return { status: 'manual-remediation', version: 1 };
+  }
+  return VercelStopTombstoneSchema.parse(value);
+}
+
+export function claimVercelStopAttempt(
+  tombstone: VercelStopTombstone,
+  attemptId: string,
+  now: number,
+  attemptDeadlineAt: number
+): VercelStopTombstone | null {
+  const due =
+    (tombstone.stop.status === 'needed' && tombstone.stop.nextAttemptAt <= now) ||
+    (tombstone.stop.status === 'stopping' && tombstone.stop.attemptDeadlineAt <= now);
+  if (!due || attemptDeadlineAt <= now) return null;
+
+  return {
+    ...tombstone,
+    stop: {
+      status: 'stopping',
+      attempts: tombstone.stop.attempts + 1,
+      nextAttemptAt: tombstone.stop.nextAttemptAt,
+      attemptId,
+      attemptDeadlineAt,
+    },
+  };
+}
+
+export function retryVercelStopAttempt(
+  tombstone: VercelStopTombstone,
+  attemptId: string,
+  nextAttemptAt: number
+): VercelStopTombstone | null {
+  if (tombstone.stop.status !== 'stopping' || tombstone.stop.attemptId !== attemptId) return null;
+  return {
+    ...tombstone,
+    stop: {
+      status: 'needed',
+      attempts: tombstone.stop.attempts,
+      nextAttemptAt,
+    },
+  };
+}
+
+type VercelSessionStatus =
+  | 'failed'
+  | 'aborted'
+  | 'pending'
+  | 'stopping'
+  | 'snapshotting'
+  | 'running'
+  | 'stopped'
+  | 'not-found';
+
+export function classifyVercelSession(
+  status: VercelSessionStatus,
+  policy: { notFoundIsTerminal: boolean } = { notFoundIsTerminal: false }
+): 'active' | 'terminal' | 'unknown' {
+  if (status === 'stopped' || status === 'aborted' || status === 'failed') return 'terminal';
+  if (status === 'not-found') return policy.notFoundIsTerminal ? 'terminal' : 'unknown';
+  return 'active';
+}

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-sandbox-rest-client.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-sandbox-rest-client.test.ts
@@ -1,0 +1,499 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG,
+  VERCEL_CLOUD_AGENT_RESOURCE_TAG,
+  VERCEL_CLOUD_AGENT_RESOURCE_TAG_VALUE,
+  VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG,
+  VercelSandboxRestClient,
+  type VercelSandboxCommand,
+  type VercelSandboxResource,
+  type VercelSandboxSession,
+} from './vercel-sandbox-rest-client.js';
+
+const sandboxName = 'ses-exact-runtime';
+const sessionId = 'sbox_session_exact';
+const commandId = 'cmd_exact';
+
+function sandbox(overrides: Partial<VercelSandboxResource> = {}): VercelSandboxResource {
+  return {
+    name: sandboxName,
+    currentSessionId: sessionId,
+    status: 'running',
+    persistent: false,
+    createdAt: 1,
+    updatedAt: 2,
+    tags: {
+      [VERCEL_CLOUD_AGENT_RESOURCE_TAG]: VERCEL_CLOUD_AGENT_RESOURCE_TAG_VALUE,
+      [VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG]: 'operation-123',
+      [VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG]: 'runtime-build-123',
+    },
+    ...overrides,
+  };
+}
+
+function session(overrides: Partial<VercelSandboxSession> = {}): VercelSandboxSession {
+  return {
+    id: sessionId,
+    sourceSandboxName: sandboxName,
+    projectId: 'prj_test',
+    sourceSnapshotId: 'snap_base',
+    runtime: 'node24',
+    status: 'running',
+    memory: 4096,
+    vcpus: 2,
+    region: 'iad1',
+    timeout: 300_000,
+    requestedAt: 1,
+    cwd: '/vercel/sandbox',
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides,
+  };
+}
+
+function command(overrides: Partial<VercelSandboxCommand> = {}): VercelSandboxCommand {
+  return {
+    id: commandId,
+    name: 'bash',
+    args: ['-lc', 'echo ready'],
+    cwd: '/vercel/sandbox',
+    sessionId,
+    exitCode: null,
+    startedAt: 3,
+    ...overrides,
+  };
+}
+
+function clientFor(providerFetch: typeof fetch) {
+  return new VercelSandboxRestClient({
+    accessToken: 'secret-access-token',
+    projectId: 'prj_test',
+    teamId: 'team_test',
+    fetch: providerFetch,
+  });
+}
+
+function createInput() {
+  return {
+    name: sandboxName,
+    operationId: 'operation-123',
+    runtimeBuildId: 'runtime-build-123',
+    snapshotId: 'snap_base',
+    runtime: 'node24' as const,
+    timeoutMs: 300_000,
+  };
+}
+
+function jsonResponse(body: unknown, init?: ResponseInit): Response {
+  return Response.json(body, init);
+}
+
+describe('VercelSandboxRestClient', () => {
+  it('creates a non-persistent sandbox and returns its fully correlated runtime locator', async () => {
+    const providerFetch = vi.fn().mockResolvedValue(
+      jsonResponse({
+        sandbox: sandbox(),
+        session: session(),
+        routes: [{ url: 'https://route.example', subdomain: 'route', port: 3000 }],
+      })
+    );
+
+    const result = await clientFor(providerFetch).createSandbox(createInput());
+
+    expect(result.runtime).toEqual({ sandboxName, sessionId });
+    expect(result.routes).toHaveLength(1);
+    const [url, init] = providerFetch.mock.calls[0];
+    expect(url).toBe('https://api.vercel.com/v2/sandboxes?teamId=team_test');
+    expect(init.method).toBe('POST');
+    expect(JSON.parse(init.body as string)).toEqual({
+      projectId: 'prj_test',
+      name: sandboxName,
+      source: { type: 'snapshot', snapshotId: 'snap_base' },
+      runtime: 'node24',
+      timeout: 300_000,
+      persistent: false,
+      tags: {
+        [VERCEL_CLOUD_AGENT_RESOURCE_TAG]: VERCEL_CLOUD_AGENT_RESOURCE_TAG_VALUE,
+        [VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG]: 'operation-123',
+        [VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG]: 'runtime-build-123',
+      },
+    });
+  });
+
+  it('invokes the injected fetch as a free function', async () => {
+    function providerFetch(this: unknown, _input: RequestInfo | URL, _init?: RequestInit) {
+      if (this !== undefined && this !== globalThis) {
+        return Promise.reject(new TypeError('Illegal invocation'));
+      }
+      return Promise.resolve(jsonResponse({ sandbox: sandbox(), session: session(), routes: [] }));
+    }
+
+    await expect(clientFor(providerFetch).createSandbox(createInput())).resolves.toMatchObject({
+      runtime: { sandboxName, sessionId },
+    });
+  });
+
+  it.each([
+    ['sandbox name', { sandbox: sandbox({ name: 'ses-other' }), session: session(), routes: [] }],
+    [
+      'current session',
+      { sandbox: sandbox({ currentSessionId: 'sbox_other' }), session: session(), routes: [] },
+    ],
+    ['project', { sandbox: sandbox(), session: session({ projectId: 'prj_other' }), routes: [] }],
+    [
+      'snapshot',
+      { sandbox: sandbox(), session: session({ sourceSnapshotId: 'snap_other' }), routes: [] },
+    ],
+    ['runtime', { sandbox: sandbox(), session: session({ runtime: 'node22' }), routes: [] }],
+    [
+      'operation tag',
+      {
+        sandbox: sandbox({
+          tags: {
+            [VERCEL_CLOUD_AGENT_RESOURCE_TAG]: VERCEL_CLOUD_AGENT_RESOURCE_TAG_VALUE,
+            [VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG]: 'operation-other',
+            [VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG]: 'runtime-build-123',
+          },
+        }),
+        session: session(),
+        routes: [],
+      },
+    ],
+    ['persistence', { sandbox: sandbox({ persistent: true }), session: session(), routes: [] }],
+  ])('rejects a create envelope with mismatched %s', async (_field, body) => {
+    const client = clientFor(vi.fn().mockResolvedValue(jsonResponse(body)));
+    await expect(client.createSandbox(createInput())).rejects.toThrow(
+      'Vercel Sandbox create failed (correlation_mismatch)'
+    );
+  });
+
+  it('inspects by name without resuming and returns a correlated create envelope', async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValue(
+        jsonResponse({ resumed: false, sandbox: sandbox(), session: session(), routes: [] })
+      );
+
+    const result = await clientFor(providerFetch).inspectByName(createInput());
+
+    expect(result?.runtime).toEqual({ sandboxName, sessionId });
+    expect(providerFetch.mock.calls[0][0]).toBe(
+      'https://api.vercel.com/v2/sandboxes/ses-exact-runtime?projectId=prj_test&teamId=team_test&resume=false'
+    );
+  });
+
+  it('returns null for absent non-resuming create reconciliation', async () => {
+    const client = clientFor(vi.fn().mockResolvedValue(new Response(null, { status: 404 })));
+    await expect(client.inspectByName(createInput())).resolves.toBeNull();
+  });
+
+  it('gets and correlates an exact session', async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ session: session(), routes: [] }));
+    const result = await clientFor(providerFetch).getSession(sessionId, sandboxName);
+    expect(result.session.id).toBe(sessionId);
+    expect(providerFetch.mock.calls[0][0]).toBe(
+      'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact?teamId=team_test'
+    );
+  });
+
+  it('executes a detached command and correlates its session', async () => {
+    const providerFetch = vi.fn().mockResolvedValue(jsonResponse({ command: command() }));
+    const result = await clientFor(providerFetch).executeCommand(sessionId, {
+      command: 'bash',
+      args: ['-lc', 'echo ready'],
+      cwd: '/vercel/sandbox',
+      env: { SAFE_VALUE: 'yes' },
+      sudo: false,
+      timeoutMs: 10_000,
+      wait: false,
+    });
+    expect(result.id).toBe(commandId);
+    expect(JSON.parse(providerFetch.mock.calls[0][1].body as string)).toEqual({
+      command: 'bash',
+      args: ['-lc', 'echo ready'],
+      cwd: '/vercel/sandbox',
+      env: { SAFE_VALUE: 'yes' },
+      sudo: false,
+      timeout: 10_000,
+    });
+  });
+
+  it('parses a bounded wait:true NDJSON command response', async () => {
+    const body = `${JSON.stringify({ command: command() })}\n${JSON.stringify({ command: command({ exitCode: 0 }) })}\n`;
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response(body, { headers: { 'content-type': 'application/x-ndjson' } })
+      );
+    const result = await clientFor(providerFetch).executeCommand(sessionId, {
+      command: 'bash',
+      args: [],
+      env: {},
+      sudo: false,
+      wait: true,
+    });
+    expect(result).toEqual({ command: command(), finished: command({ exitCode: 0 }) });
+  });
+
+  it('rejects oversized JSON and NDJSON responses without including their contents', async () => {
+    const secret = 'provider-secret-response';
+    const oversizedJson = jsonResponse({ session: session(), padding: secret.repeat(70_000) });
+    const jsonClient = clientFor(vi.fn().mockResolvedValue(oversizedJson));
+    await expect(jsonClient.getSession(sessionId, sandboxName)).rejects.toMatchObject({
+      kind: 'response_too_large',
+      message: 'Vercel Sandbox get-session failed (response_too_large)',
+    });
+
+    const oversizedNdjson = new Response(secret.repeat(1_100_000), {
+      headers: { 'content-type': 'application/x-ndjson' },
+    });
+    const streamClient = clientFor(vi.fn().mockResolvedValue(oversizedNdjson));
+    await expect(
+      streamClient.executeCommand(sessionId, {
+        command: 'bash',
+        args: [],
+        env: {},
+        sudo: false,
+        wait: true,
+      })
+    ).rejects.not.toThrow(secret);
+  });
+
+  it('writes a gzip tar archive and reads exact-session files within caller bounds', async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({}))
+      .mockResolvedValueOnce(
+        new Response('response-body', {
+          headers: { 'content-type': 'application/octet-stream' },
+        })
+      );
+    const client = clientFor(providerFetch);
+
+    await client.writeFiles(sessionId, '/tmp', [
+      { path: 'private/request.json', content: '{"token":"secret"}' },
+    ]);
+    await expect(client.readFile(sessionId, '/tmp/private/response.json', 32)).resolves.toEqual(
+      new TextEncoder().encode('response-body')
+    );
+
+    const [writeUrl, writeInit] = providerFetch.mock.calls[0];
+    expect(writeUrl).toBe(
+      'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact/fs/write?teamId=team_test'
+    );
+    expect(new Headers(writeInit.headers).get('content-type')).toBe('application/gzip');
+    expect(new Headers(writeInit.headers).get('x-cwd')).toBe('/tmp');
+    expect(writeInit.body).toBeInstanceOf(Uint8Array);
+    expect(providerFetch.mock.calls[1][0]).toBe(
+      'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact/fs/read?teamId=team_test'
+    );
+    expect(JSON.parse(providerFetch.mock.calls[1][1].body as string)).toEqual({
+      path: '/tmp/private/response.json',
+    });
+  });
+
+  it('rejects file responses that exceed the requested read bound', async () => {
+    const client = clientFor(
+      vi.fn().mockResolvedValue(
+        new Response('too-large', {
+          headers: { 'content-length': '9', 'content-type': 'application/octet-stream' },
+        })
+      )
+    );
+
+    await expect(client.readFile(sessionId, '/tmp/response', 4)).rejects.toMatchObject({
+      kind: 'response_too_large',
+      operation: 'read-file',
+    });
+  });
+
+  it('lists, gets, and kills only commands correlated to the exact session', async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ commands: [command()] }))
+      .mockResolvedValueOnce(jsonResponse({ command: command() }))
+      .mockResolvedValueOnce(jsonResponse({ command: command({ exitCode: 143 }) }));
+    const client = clientFor(providerFetch);
+
+    await expect(client.listCommands(sessionId)).resolves.toEqual([command()]);
+    await expect(client.getCommand(sessionId, commandId)).resolves.toEqual(command());
+    await expect(client.killCommand(sessionId, commandId, 15)).resolves.toEqual(
+      command({ exitCode: 143 })
+    );
+    expect(providerFetch.mock.calls.map(([url]) => url)).toEqual([
+      'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact/cmd?teamId=team_test',
+      'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact/cmd/cmd_exact?teamId=team_test',
+      'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact/cmd/cmd_exact/kill?teamId=team_test',
+    ]);
+  });
+
+  it.each([
+    ['list-commands', { commands: [command({ sessionId: 'sbox_other' })] }],
+    ['get-command', { command: command({ id: 'cmd_other' }) }],
+    ['kill-command', { command: command({ sessionId: 'sbox_other' }) }],
+  ])('rejects mismatched %s responses', async (operation, body) => {
+    const client = clientFor(vi.fn().mockResolvedValue(jsonResponse(body)));
+    const call =
+      operation === 'list-commands'
+        ? client.listCommands(sessionId)
+        : operation === 'get-command'
+          ? client.getCommand(sessionId, commandId)
+          : client.killCommand(sessionId, commandId, 9);
+    await expect(call).rejects.toThrow(`Vercel Sandbox ${operation} failed (correlation_mismatch)`);
+  });
+
+  it('extends and stops the exact correlated session without a named DELETE API', async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValueOnce(jsonResponse({ session: session({ timeout: 360_000 }) }))
+      .mockResolvedValueOnce(jsonResponse({ session: session({ status: 'stopped' }) }));
+    const client = clientFor(providerFetch);
+
+    await expect(
+      client.extendSessionTimeout(sessionId, sandboxName, 60_000)
+    ).resolves.toMatchObject({
+      timeout: 360_000,
+    });
+    await expect(client.stopSession(sessionId, sandboxName)).resolves.toMatchObject({
+      status: 'stopped',
+    });
+    expect(providerFetch.mock.calls.map(([url, init]) => [url, init.method])).toEqual([
+      [
+        'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact/extend-timeout?teamId=team_test',
+        'POST',
+      ],
+      [
+        'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact/stop?teamId=team_test',
+        'POST',
+      ],
+    ]);
+    const stopInit = providerFetch.mock.calls[1]?.[1] as RequestInit;
+    expect(stopInit.body).toBe('{}');
+    expect(new Headers(stopInit.headers).get('Content-Type')).toBe('application/json');
+    expect('deleteSandbox' in client).toBe(false);
+  });
+
+  it('aborts stalled observation requests with a secret-safe typed error', async () => {
+    const controller = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+    let providerSignal: AbortSignal | null | undefined;
+    const providerFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      providerSignal = init?.signal;
+      if (!providerSignal) return Promise.reject(new Error('missing provider deadline'));
+      return new Promise<Response>((_resolve, reject) => {
+        providerSignal?.addEventListener('abort', () => reject(providerSignal?.reason), {
+          once: true,
+        });
+      });
+    });
+    const request = clientFor(providerFetch).getSession(sessionId, sandboxName);
+
+    controller.abort(new Error('provider-secret-timeout'));
+    const error = await request.catch(cause => cause);
+
+    expect(timeout).toHaveBeenCalledWith(30_000);
+    expect(providerSignal?.aborted).toBe(true);
+    expect(error).toMatchObject({
+      kind: 'request_failed',
+      operation: 'get-session',
+      message: 'Vercel Sandbox get-session failed (request_failed)',
+    });
+    expect(String(error)).not.toContain('provider-secret-timeout');
+    timeout.mockRestore();
+  });
+
+  it('classifies a deadline while reading a provider body as request failure', async () => {
+    const controller = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+    const providerFetch = vi.fn((_input: RequestInfo | URL, init?: RequestInit) => {
+      const signal = init?.signal;
+      return Promise.resolve(
+        new Response(
+          new ReadableStream({
+            start(streamController) {
+              signal?.addEventListener('abort', () => streamController.error(signal.reason), {
+                once: true,
+              });
+            },
+          })
+        )
+      );
+    });
+    const request = clientFor(providerFetch).readFile(sessionId, '/tmp/response', 32);
+
+    controller.abort(new Error('provider-secret-timeout'));
+    const error = await request.catch(cause => cause);
+
+    expect(error).toMatchObject({ kind: 'request_failed', operation: 'read-file' });
+    expect(String(error)).not.toContain('provider-secret-timeout');
+    timeout.mockRestore();
+  });
+
+  it('bounds waited command deadlines with transport allowance and a maximum', async () => {
+    const controller = new AbortController();
+    const timeout = vi.spyOn(AbortSignal, 'timeout').mockReturnValue(controller.signal);
+    const providerFetch = vi.fn().mockRejectedValue(new Error('provider unavailable'));
+    const client = clientFor(providerFetch);
+
+    await expect(
+      client.executeCommand(sessionId, {
+        command: 'bash',
+        args: [],
+        env: {},
+        sudo: false,
+        timeoutMs: 30_000,
+        wait: true,
+      })
+    ).rejects.toMatchObject({ kind: 'request_failed', operation: 'execute-command' });
+    await expect(
+      client.executeCommand(sessionId, {
+        command: 'bash',
+        args: [],
+        env: {},
+        sudo: false,
+        timeoutMs: 600_000,
+        wait: true,
+      })
+    ).rejects.toMatchObject({ kind: 'request_failed', operation: 'execute-command' });
+    await expect(
+      client.executeCommand(sessionId, {
+        command: 'bash',
+        args: [],
+        env: {},
+        sudo: false,
+        wait: false,
+      })
+    ).rejects.toMatchObject({ kind: 'request_failed', operation: 'execute-command' });
+
+    expect(timeout.mock.calls).toEqual([[40_000], [300_000], [120_000]]);
+    timeout.mockRestore();
+  });
+
+  it('uses secret-safe typed errors for transport, provider, and invalid response failures', async () => {
+    const reflectedSecret = 'secret-access-token reflected-provider-body';
+    const providerClient = clientFor(
+      vi.fn().mockResolvedValue(new Response(reflectedSecret, { status: 403 }))
+    );
+    await expect(providerClient.getSession(sessionId, sandboxName)).rejects.toMatchObject({
+      kind: 'request_failed',
+      operation: 'get-session',
+      status: 403,
+      message: 'Vercel Sandbox get-session failed (request_failed, status 403)',
+    });
+    await expect(providerClient.getSession(sessionId, sandboxName)).rejects.not.toThrow(
+      reflectedSecret
+    );
+
+    const invalidClient = clientFor(
+      vi.fn().mockResolvedValue(jsonResponse({ token: reflectedSecret }))
+    );
+    await expect(invalidClient.getSession(sessionId, sandboxName)).rejects.toMatchObject({
+      kind: 'invalid_response',
+    });
+    await expect(invalidClient.getSession(sessionId, sandboxName)).rejects.not.toThrow(
+      reflectedSecret
+    );
+  });
+});

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-sandbox-rest-client.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-sandbox-rest-client.ts
@@ -1,0 +1,768 @@
+import { z } from 'zod';
+
+const VERCEL_SANDBOX_API_BASE_URL = 'https://api.vercel.com';
+const VERCEL_SANDBOX_NAME = /^ses-[A-Za-z0-9_-]+$/;
+const MAX_JSON_RESPONSE_BYTES = 1024 * 1024;
+const MAX_NDJSON_RESPONSE_BYTES = 1024 * 1024;
+const MAX_NDJSON_LINE_BYTES = 256 * 1024;
+const MAX_NDJSON_LINES = 2;
+const OBSERVATION_CONTROL_DEADLINE_MS = 30_000;
+const STANDARD_REQUEST_DEADLINE_MS = 120_000;
+const WAITED_COMMAND_TRANSPORT_ALLOWANCE_MS = 10_000;
+const MAX_PROVIDER_REQUEST_DEADLINE_MS = 300_000;
+
+export const VERCEL_CLOUD_AGENT_RESOURCE_TAG = 'kilo-managed-by';
+export const VERCEL_CLOUD_AGENT_RESOURCE_TAG_VALUE = 'cloud-agent-session';
+export const VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG = 'kilo-create-operation';
+export const VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG = 'kilo-runtime-build';
+
+const runtimeSchema = z.enum(['node22', 'node24', 'node26', 'python3.13']);
+const statusSchema = z.enum([
+  'failed',
+  'aborted',
+  'pending',
+  'stopping',
+  'snapshotting',
+  'running',
+  'stopped',
+]);
+const sandboxResourceSchema = z.object({
+  name: z.string(),
+  currentSessionId: z.string(),
+  status: z.enum(['stopping', 'running', 'stopped']),
+  persistent: z.boolean(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+  tags: z.record(z.string(), z.string()).optional().default({}),
+});
+const sessionSchema = z.object({
+  id: z.string(),
+  sourceSandboxName: z.string(),
+  projectId: z.string(),
+  sourceSnapshotId: z.string().optional(),
+  runtime: z.string(),
+  status: statusSchema,
+  memory: z.number(),
+  vcpus: z.number(),
+  region: z.string(),
+  timeout: z.number(),
+  requestedAt: z.number(),
+  startedAt: z.number().optional(),
+  requestedStopAt: z.number().optional(),
+  stoppedAt: z.number().optional(),
+  abortedAt: z.number().optional(),
+  duration: z.number().optional(),
+  cwd: z.string(),
+  createdAt: z.number(),
+  updatedAt: z.number(),
+});
+const routeSchema = z.object({
+  url: z.string(),
+  subdomain: z.string(),
+  port: z.number(),
+});
+const commandSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  args: z.array(z.string()),
+  cwd: z.string(),
+  sessionId: z.string(),
+  exitCode: z.number().nullable(),
+  startedAt: z.number(),
+});
+const finishedCommandSchema = commandSchema.extend({ exitCode: z.number() });
+const sandboxEnvelopeSchema = z.object({
+  sandbox: sandboxResourceSchema,
+  session: sessionSchema,
+  routes: z.array(routeSchema),
+});
+const inspectedSandboxEnvelopeSchema = sandboxEnvelopeSchema.extend({ resumed: z.literal(false) });
+const sessionEnvelopeSchema = z.object({ session: sessionSchema });
+const sessionAndRoutesEnvelopeSchema = sessionEnvelopeSchema.extend({
+  routes: z.array(routeSchema),
+});
+const commandEnvelopeSchema = z.object({ command: commandSchema });
+const finishedCommandEnvelopeSchema = z.object({ command: finishedCommandSchema });
+const commandsEnvelopeSchema = z.object({ commands: z.array(commandSchema) });
+
+export type VercelSandboxRuntime = z.infer<typeof runtimeSchema>;
+export type VercelSandboxResource = z.infer<typeof sandboxResourceSchema>;
+export type VercelSandboxSession = z.infer<typeof sessionSchema>;
+export type VercelSandboxRoute = z.infer<typeof routeSchema>;
+export type VercelSandboxCommand = z.infer<typeof commandSchema>;
+
+export type VercelSandboxRestClientConfig = {
+  accessToken: string;
+  projectId?: string;
+  teamId: string;
+  fetch: typeof fetch;
+};
+
+export type CreateSandboxInput = {
+  name: string;
+  operationId: string;
+  runtimeBuildId: string;
+  snapshotId: string;
+  runtime: VercelSandboxRuntime;
+  timeoutMs: number;
+};
+
+export type VercelSandboxCreateEnvelope = {
+  sandbox: VercelSandboxResource;
+  session: VercelSandboxSession;
+  routes: VercelSandboxRoute[];
+  runtime: { sandboxName: string; sessionId: string };
+};
+
+export type ExecuteCommandInput = {
+  command: string;
+  args: string[];
+  cwd?: string;
+  env: Record<string, string>;
+  sudo: boolean;
+  timeoutMs?: number;
+  wait: boolean;
+};
+
+export type WaitedCommandResult = {
+  command: VercelSandboxCommand;
+  finished: VercelSandboxCommand & { exitCode: number };
+};
+
+export type VercelSandboxFile = {
+  path: string;
+  content: string | Uint8Array;
+};
+
+type VercelSandboxOperation =
+  | 'inspect'
+  | 'create'
+  | 'get-session'
+  | 'execute-command'
+  | 'list-commands'
+  | 'get-command'
+  | 'kill-command'
+  | 'write-files'
+  | 'read-file'
+  | 'extend-timeout'
+  | 'stop-session';
+export type VercelSandboxErrorKind =
+  | 'invalid_configuration'
+  | 'invalid_request'
+  | 'request_failed'
+  | 'invalid_response'
+  | 'response_too_large'
+  | 'correlation_mismatch';
+
+export class VercelSandboxRestError extends Error {
+  constructor(
+    public readonly kind: VercelSandboxErrorKind,
+    public readonly operation: VercelSandboxOperation,
+    public readonly status?: number
+  ) {
+    super(
+      status === undefined
+        ? `Vercel Sandbox ${operation} failed (${kind})`
+        : `Vercel Sandbox ${operation} failed (${kind}, status ${status})`
+    );
+    this.name = 'VercelSandboxRestError';
+  }
+}
+
+function requireValue(value: string, operation: VercelSandboxOperation): void {
+  if (value.length === 0) throw new VercelSandboxRestError('invalid_configuration', operation);
+}
+
+function requireIdentifier(value: string, operation: VercelSandboxOperation): void {
+  if (value.length === 0 || value.length > 256) {
+    throw new VercelSandboxRestError('invalid_request', operation);
+  }
+}
+
+function requireSandboxName(name: string, operation: VercelSandboxOperation): void {
+  if (name.length > 128 || !VERCEL_SANDBOX_NAME.test(name)) {
+    throw new VercelSandboxRestError('invalid_request', operation);
+  }
+}
+
+function requirePositiveDuration(value: number, operation: VercelSandboxOperation): void {
+  if (!Number.isInteger(value) || value < 1000) {
+    throw new VercelSandboxRestError('invalid_request', operation);
+  }
+}
+
+function writeTarString(header: Uint8Array, offset: number, length: number, value: string): void {
+  const bytes = new TextEncoder().encode(value);
+  if (bytes.byteLength >= length)
+    throw new VercelSandboxRestError('invalid_request', 'write-files');
+  header.set(bytes, offset);
+}
+
+function writeTarOctal(header: Uint8Array, offset: number, length: number, value: number): void {
+  writeTarString(header, offset, length, value.toString(8).padStart(length - 1, '0'));
+}
+
+async function createGzipTar(files: VercelSandboxFile[]): Promise<Uint8Array> {
+  const encoder = new TextEncoder();
+  const chunks: Uint8Array[] = [];
+  for (const file of files) {
+    if (!file.path || file.path.startsWith('/') || file.path.includes('..')) {
+      throw new VercelSandboxRestError('invalid_request', 'write-files');
+    }
+    const content = typeof file.content === 'string' ? encoder.encode(file.content) : file.content;
+    const header = new Uint8Array(512);
+    writeTarString(header, 0, 100, file.path);
+    writeTarOctal(header, 100, 8, 0o600);
+    writeTarOctal(header, 108, 8, 0);
+    writeTarOctal(header, 116, 8, 0);
+    writeTarOctal(header, 124, 12, content.byteLength);
+    writeTarOctal(header, 136, 12, 0);
+    header.fill(0x20, 148, 156);
+    header[156] = 0x30;
+    writeTarString(header, 257, 8, 'ustar  ');
+    const checksum = header.reduce((sum, byte) => sum + byte, 0);
+    writeTarOctal(header, 148, 8, checksum);
+    chunks.push(header, content);
+    const padding = (512 - (content.byteLength % 512)) % 512;
+    if (padding) chunks.push(new Uint8Array(padding));
+  }
+  chunks.push(new Uint8Array(1024));
+  const stream = new Blob(chunks).stream().pipeThrough(new CompressionStream('gzip'));
+  return new Uint8Array(await new Response(stream).arrayBuffer());
+}
+
+function correlateSession(
+  session: VercelSandboxSession,
+  expectedSessionId: string,
+  expectedSandboxName: string | undefined,
+  operation: VercelSandboxOperation
+): void {
+  if (
+    session.id !== expectedSessionId ||
+    (expectedSandboxName !== undefined && session.sourceSandboxName !== expectedSandboxName)
+  ) {
+    throw new VercelSandboxRestError('correlation_mismatch', operation);
+  }
+}
+
+function correlateCommand(
+  command: VercelSandboxCommand,
+  expectedSessionId: string,
+  expectedCommandId: string | undefined,
+  operation: VercelSandboxOperation
+): void {
+  if (
+    command.sessionId !== expectedSessionId ||
+    (expectedCommandId !== undefined && command.id !== expectedCommandId)
+  ) {
+    throw new VercelSandboxRestError('correlation_mismatch', operation);
+  }
+}
+
+export class VercelSandboxRestClient {
+  private readonly responseSignals = new WeakMap<Response, AbortSignal>();
+
+  constructor(private readonly config: VercelSandboxRestClientConfig) {}
+
+  async createSandbox(input: CreateSandboxInput): Promise<VercelSandboxCreateEnvelope> {
+    const operation = 'create';
+    const projectId = this.requireProjectConfiguration(operation);
+    requireSandboxName(input.name, operation);
+    requireIdentifier(input.operationId, operation);
+    requireIdentifier(input.runtimeBuildId, operation);
+    requireIdentifier(input.snapshotId, operation);
+    requirePositiveDuration(input.timeoutMs, operation);
+    if (!runtimeSchema.safeParse(input.runtime).success) {
+      throw new VercelSandboxRestError('invalid_request', operation);
+    }
+
+    const response = await this.fetchProvider(operation, this.collectionUrl(), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        projectId,
+        name: input.name,
+        source: { type: 'snapshot', snapshotId: input.snapshotId },
+        runtime: input.runtime,
+        timeout: input.timeoutMs,
+        persistent: false,
+        tags: {
+          [VERCEL_CLOUD_AGENT_RESOURCE_TAG]: VERCEL_CLOUD_AGENT_RESOURCE_TAG_VALUE,
+          [VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG]: input.operationId,
+          [VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG]: input.runtimeBuildId,
+        },
+      }),
+    });
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, sandboxEnvelopeSchema, operation);
+    this.correlateCreateEnvelope(envelope, input, operation);
+    return this.withRuntime(envelope);
+  }
+
+  async inspectByName(
+    input: Omit<CreateSandboxInput, 'timeoutMs'>
+  ): Promise<VercelSandboxCreateEnvelope | null> {
+    const operation = 'inspect';
+    const projectId = this.requireProjectConfiguration(operation);
+    requireSandboxName(input.name, operation);
+    requireIdentifier(input.operationId, operation);
+    requireIdentifier(input.runtimeBuildId, operation);
+    requireIdentifier(input.snapshotId, operation);
+    if (!runtimeSchema.safeParse(input.runtime).success) {
+      throw new VercelSandboxRestError('invalid_request', operation);
+    }
+    const url = this.namedSandboxUrl(input.name, projectId);
+    url.searchParams.set('resume', 'false');
+    const response = await this.fetchProvider(operation, url, { method: 'GET' });
+    if (response.status === 404) return null;
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, inspectedSandboxEnvelopeSchema, operation);
+    this.correlateCreateEnvelope(envelope, input, operation);
+    return this.withRuntime(envelope);
+  }
+
+  async getSession(
+    sessionId: string,
+    expectedSandboxName: string
+  ): Promise<{ session: VercelSandboxSession; routes: VercelSandboxRoute[] }> {
+    const operation = 'get-session';
+    this.validateSessionTarget(sessionId, expectedSandboxName, operation);
+    const response = await this.fetchProvider(operation, this.sessionUrl(sessionId), {
+      method: 'GET',
+    });
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, sessionAndRoutesEnvelopeSchema, operation);
+    correlateSession(envelope.session, sessionId, expectedSandboxName, operation);
+    return envelope;
+  }
+
+  async executeCommand(
+    sessionId: string,
+    input: ExecuteCommandInput & { wait: true }
+  ): Promise<WaitedCommandResult>;
+  async executeCommand(
+    sessionId: string,
+    input: ExecuteCommandInput & { wait: false }
+  ): Promise<VercelSandboxCommand>;
+  async executeCommand(
+    sessionId: string,
+    input: ExecuteCommandInput
+  ): Promise<VercelSandboxCommand | WaitedCommandResult> {
+    const operation = 'execute-command';
+    this.validateConfiguration(operation);
+    requireIdentifier(sessionId, operation);
+    requireIdentifier(input.command, operation);
+    if (input.timeoutMs !== undefined) requirePositiveDuration(input.timeoutMs, operation);
+    const response = await this.fetchProvider(
+      operation,
+      this.commandsUrl(sessionId),
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          command: input.command,
+          args: input.args,
+          cwd: input.cwd,
+          env: input.env,
+          sudo: input.sudo,
+          ...(input.wait ? { wait: true } : {}),
+          timeout: input.timeoutMs,
+        }),
+      },
+      input.wait ? this.waitedCommandDeadlineMs(input.timeoutMs) : undefined
+    );
+    await this.requireSuccessfulResponse(response, operation);
+    if (input.wait) return this.parseWaitedCommand(response, sessionId, operation);
+    const envelope = await this.parseJson(response, commandEnvelopeSchema, operation);
+    correlateCommand(envelope.command, sessionId, undefined, operation);
+    return envelope.command;
+  }
+
+  async listCommands(sessionId: string): Promise<VercelSandboxCommand[]> {
+    const operation = 'list-commands';
+    this.validateConfiguration(operation);
+    requireIdentifier(sessionId, operation);
+    const response = await this.fetchProvider(operation, this.commandsUrl(sessionId), {
+      method: 'GET',
+    });
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, commandsEnvelopeSchema, operation);
+    for (const command of envelope.commands) {
+      correlateCommand(command, sessionId, undefined, operation);
+    }
+    return envelope.commands;
+  }
+
+  async getCommand(sessionId: string, commandId: string): Promise<VercelSandboxCommand> {
+    const operation = 'get-command';
+    this.validateCommandTarget(sessionId, commandId, operation);
+    const response = await this.fetchProvider(operation, this.commandUrl(sessionId, commandId), {
+      method: 'GET',
+    });
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, commandEnvelopeSchema, operation);
+    correlateCommand(envelope.command, sessionId, commandId, operation);
+    return envelope.command;
+  }
+
+  async killCommand(
+    sessionId: string,
+    commandId: string,
+    signal: number
+  ): Promise<VercelSandboxCommand> {
+    const operation = 'kill-command';
+    this.validateCommandTarget(sessionId, commandId, operation);
+    if (!Number.isInteger(signal) || signal < 1 || signal > 64) {
+      throw new VercelSandboxRestError('invalid_request', operation);
+    }
+    const url = new URL(
+      `${this.commandUrl(sessionId, commandId).pathname}/kill`,
+      VERCEL_SANDBOX_API_BASE_URL
+    );
+    url.searchParams.set('teamId', this.config.teamId);
+    const response = await this.fetchProvider(operation, url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ signal }),
+    });
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, commandEnvelopeSchema, operation);
+    correlateCommand(envelope.command, sessionId, commandId, operation);
+    return envelope.command;
+  }
+
+  async writeFiles(sessionId: string, cwd: string, files: VercelSandboxFile[]): Promise<void> {
+    const operation = 'write-files';
+    this.validateConfiguration(operation);
+    requireIdentifier(sessionId, operation);
+    if (!cwd.startsWith('/') || files.length === 0) {
+      throw new VercelSandboxRestError('invalid_request', operation);
+    }
+    const response = await this.fetchProvider(operation, this.fileActionUrl(sessionId, 'write'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/gzip', 'x-cwd': cwd },
+      body: await createGzipTar(files),
+    });
+    await this.requireSuccessfulResponse(response, operation);
+    await response.body?.cancel().catch(() => undefined);
+  }
+
+  async readFile(sessionId: string, path: string, maxBytes: number): Promise<Uint8Array> {
+    const operation = 'read-file';
+    this.validateConfiguration(operation);
+    requireIdentifier(sessionId, operation);
+    if (!path.startsWith('/') || !Number.isInteger(maxBytes) || maxBytes < 1) {
+      throw new VercelSandboxRestError('invalid_request', operation);
+    }
+    const response = await this.fetchProvider(operation, this.fileActionUrl(sessionId, 'read'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ path }),
+    });
+    await this.requireSuccessfulResponse(response, operation);
+    return this.readBoundedBytes(response, maxBytes, operation);
+  }
+
+  async extendSessionTimeout(
+    sessionId: string,
+    expectedSandboxName: string,
+    durationMs: number
+  ): Promise<VercelSandboxSession> {
+    const operation = 'extend-timeout';
+    this.validateSessionTarget(sessionId, expectedSandboxName, operation);
+    requirePositiveDuration(durationMs, operation);
+    const response = await this.fetchProvider(
+      operation,
+      this.sessionActionUrl(sessionId, 'extend-timeout'),
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ duration: durationMs }),
+      }
+    );
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, sessionEnvelopeSchema, operation);
+    correlateSession(envelope.session, sessionId, expectedSandboxName, operation);
+    return envelope.session;
+  }
+
+  async stopSession(sessionId: string, expectedSandboxName: string): Promise<VercelSandboxSession> {
+    const operation = 'stop-session';
+    this.validateSessionTarget(sessionId, expectedSandboxName, operation);
+    const response = await this.fetchProvider(operation, this.sessionActionUrl(sessionId, 'stop'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: '{}',
+    });
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, sessionEnvelopeSchema, operation);
+    correlateSession(envelope.session, sessionId, expectedSandboxName, operation);
+    return envelope.session;
+  }
+
+  private correlateCreateEnvelope(
+    envelope: z.infer<typeof sandboxEnvelopeSchema>,
+    input: Omit<CreateSandboxInput, 'timeoutMs'>,
+    operation: VercelSandboxOperation
+  ): void {
+    const tags = envelope.sandbox.tags;
+    if (
+      envelope.sandbox.name !== input.name ||
+      envelope.sandbox.persistent ||
+      envelope.sandbox.currentSessionId !== envelope.session.id ||
+      envelope.session.sourceSandboxName !== input.name ||
+      envelope.session.projectId !== this.config.projectId ||
+      envelope.session.sourceSnapshotId !== input.snapshotId ||
+      envelope.session.runtime !== input.runtime ||
+      tags[VERCEL_CLOUD_AGENT_RESOURCE_TAG] !== VERCEL_CLOUD_AGENT_RESOURCE_TAG_VALUE ||
+      tags[VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG] !== input.operationId ||
+      tags[VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG] !== input.runtimeBuildId
+    ) {
+      throw new VercelSandboxRestError('correlation_mismatch', operation);
+    }
+  }
+
+  private withRuntime(
+    envelope: z.infer<typeof sandboxEnvelopeSchema>
+  ): VercelSandboxCreateEnvelope {
+    return {
+      ...envelope,
+      runtime: { sandboxName: envelope.sandbox.name, sessionId: envelope.session.id },
+    };
+  }
+
+  private validateConfiguration(operation: VercelSandboxOperation): void {
+    requireValue(this.config.accessToken, operation);
+    requireValue(this.config.teamId, operation);
+  }
+
+  private requireProjectConfiguration(operation: VercelSandboxOperation): string {
+    this.validateConfiguration(operation);
+    const projectId = this.config.projectId;
+    if (!projectId) throw new VercelSandboxRestError('invalid_configuration', operation);
+    return projectId;
+  }
+
+  private validateSessionTarget(
+    sessionId: string,
+    sandboxName: string,
+    operation: VercelSandboxOperation
+  ): void {
+    this.validateConfiguration(operation);
+    requireIdentifier(sessionId, operation);
+    requireSandboxName(sandboxName, operation);
+  }
+
+  private validateCommandTarget(
+    sessionId: string,
+    commandId: string,
+    operation: VercelSandboxOperation
+  ): void {
+    this.validateConfiguration(operation);
+    requireIdentifier(sessionId, operation);
+    requireIdentifier(commandId, operation);
+  }
+
+  private collectionUrl(): URL {
+    const url = new URL('/v2/sandboxes', VERCEL_SANDBOX_API_BASE_URL);
+    url.searchParams.set('teamId', this.config.teamId);
+    return url;
+  }
+
+  private namedSandboxUrl(name: string, projectId: string): URL {
+    const url = new URL(`/v2/sandboxes/${encodeURIComponent(name)}`, VERCEL_SANDBOX_API_BASE_URL);
+    url.searchParams.set('projectId', projectId);
+    url.searchParams.set('teamId', this.config.teamId);
+    return url;
+  }
+
+  private sessionUrl(sessionId: string): URL {
+    const url = new URL(
+      `/v2/sandboxes/sessions/${encodeURIComponent(sessionId)}`,
+      VERCEL_SANDBOX_API_BASE_URL
+    );
+    url.searchParams.set('teamId', this.config.teamId);
+    return url;
+  }
+
+  private commandsUrl(sessionId: string): URL {
+    const url = new URL(`${this.sessionUrl(sessionId).pathname}/cmd`, VERCEL_SANDBOX_API_BASE_URL);
+    url.searchParams.set('teamId', this.config.teamId);
+    return url;
+  }
+
+  private commandUrl(sessionId: string, commandId: string): URL {
+    const url = new URL(
+      `${this.commandsUrl(sessionId).pathname}/${encodeURIComponent(commandId)}`,
+      VERCEL_SANDBOX_API_BASE_URL
+    );
+    url.searchParams.set('teamId', this.config.teamId);
+    return url;
+  }
+
+  private sessionActionUrl(sessionId: string, action: string): URL {
+    const url = new URL(
+      `${this.sessionUrl(sessionId).pathname}/${action}`,
+      VERCEL_SANDBOX_API_BASE_URL
+    );
+    url.searchParams.set('teamId', this.config.teamId);
+    return url;
+  }
+
+  private fileActionUrl(sessionId: string, action: 'read' | 'write'): URL {
+    return this.sessionActionUrl(sessionId, `fs/${action}`);
+  }
+
+  private requestDeadlineMs(operation: VercelSandboxOperation): number {
+    switch (operation) {
+      case 'create':
+      case 'execute-command':
+      case 'write-files':
+      case 'read-file':
+        return STANDARD_REQUEST_DEADLINE_MS;
+      default:
+        return OBSERVATION_CONTROL_DEADLINE_MS;
+    }
+  }
+
+  private waitedCommandDeadlineMs(commandTimeoutMs: number | undefined): number {
+    if (commandTimeoutMs === undefined) return STANDARD_REQUEST_DEADLINE_MS;
+    return Math.min(
+      commandTimeoutMs + WAITED_COMMAND_TRANSPORT_ALLOWANCE_MS,
+      MAX_PROVIDER_REQUEST_DEADLINE_MS
+    );
+  }
+
+  private async fetchProvider(
+    operation: VercelSandboxOperation,
+    url: URL,
+    init: RequestInit,
+    deadlineMs = this.requestDeadlineMs(operation)
+  ): Promise<Response> {
+    const headers = new Headers(init.headers);
+    headers.set('Authorization', `Bearer ${this.config.accessToken}`);
+    const deadlineSignal = AbortSignal.timeout(deadlineMs);
+    const signal = init.signal ? AbortSignal.any([init.signal, deadlineSignal]) : deadlineSignal;
+    try {
+      const fetchImpl = this.config.fetch;
+      const response = await fetchImpl(url.toString(), { ...init, headers, signal });
+      this.responseSignals.set(response, signal);
+      return response;
+    } catch {
+      throw new VercelSandboxRestError('request_failed', operation);
+    }
+  }
+
+  private async requireSuccessfulResponse(
+    response: Response,
+    operation: VercelSandboxOperation
+  ): Promise<void> {
+    if (!response.ok) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new VercelSandboxRestError('request_failed', operation, response.status);
+    }
+  }
+
+  private async parseJson<T>(
+    response: Response,
+    schema: z.ZodType<T>,
+    operation: VercelSandboxOperation
+  ): Promise<T> {
+    const text = await this.readBoundedText(response, MAX_JSON_RESPONSE_BYTES, operation);
+    let body: unknown;
+    try {
+      body = JSON.parse(text);
+    } catch {
+      throw new VercelSandboxRestError('invalid_response', operation);
+    }
+    const parsed = schema.safeParse(body);
+    if (!parsed.success) throw new VercelSandboxRestError('invalid_response', operation);
+    return parsed.data;
+  }
+
+  private async parseWaitedCommand(
+    response: Response,
+    sessionId: string,
+    operation: VercelSandboxOperation
+  ): Promise<WaitedCommandResult> {
+    const contentType = response.headers.get('content-type')?.split(';', 1)[0].trim();
+    if (contentType !== 'application/x-ndjson') {
+      throw new VercelSandboxRestError('invalid_response', operation);
+    }
+    const text = await this.readBoundedText(response, MAX_NDJSON_RESPONSE_BYTES, operation);
+    const lines = text.split('\n').filter(line => line.length > 0);
+    if (
+      lines.length !== MAX_NDJSON_LINES ||
+      lines.some(line => new TextEncoder().encode(line).byteLength > MAX_NDJSON_LINE_BYTES)
+    ) {
+      throw new VercelSandboxRestError('invalid_response', operation);
+    }
+    let startedBody: unknown;
+    let finishedBody: unknown;
+    try {
+      startedBody = JSON.parse(lines[0]);
+      finishedBody = JSON.parse(lines[1]);
+    } catch {
+      throw new VercelSandboxRestError('invalid_response', operation);
+    }
+    const started = commandEnvelopeSchema.safeParse(startedBody);
+    const finished = finishedCommandEnvelopeSchema.safeParse(finishedBody);
+    if (!started.success || !finished.success) {
+      throw new VercelSandboxRestError('invalid_response', operation);
+    }
+    correlateCommand(started.data.command, sessionId, undefined, operation);
+    correlateCommand(finished.data.command, sessionId, started.data.command.id, operation);
+    return { command: started.data.command, finished: finished.data.command };
+  }
+
+  private async readBoundedText(
+    response: Response,
+    maxBytes: number,
+    operation: VercelSandboxOperation
+  ): Promise<string> {
+    return new TextDecoder().decode(await this.readBoundedBytes(response, maxBytes, operation));
+  }
+
+  private async readBoundedBytes(
+    response: Response,
+    maxBytes: number,
+    operation: VercelSandboxOperation
+  ): Promise<Uint8Array> {
+    const declaredLength = response.headers.get('content-length');
+    if (declaredLength !== null && Number(declaredLength) > maxBytes) {
+      await response.body?.cancel().catch(() => undefined);
+      throw new VercelSandboxRestError('response_too_large', operation);
+    }
+    if (response.body === null) throw new VercelSandboxRestError('invalid_response', operation);
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let bytesRead = 0;
+    try {
+      while (true) {
+        const chunk: ReadableStreamReadResult<Uint8Array> = await reader.read();
+        if (chunk.done) break;
+        bytesRead += chunk.value.byteLength;
+        if (bytesRead > maxBytes) {
+          await reader.cancel().catch(() => undefined);
+          throw new VercelSandboxRestError('response_too_large', operation);
+        }
+        chunks.push(chunk.value);
+      }
+      const bytes = new Uint8Array(bytesRead);
+      let offset = 0;
+      for (const chunk of chunks) {
+        bytes.set(chunk, offset);
+        offset += chunk.byteLength;
+      }
+      return bytes;
+    } catch (error) {
+      if (error instanceof VercelSandboxRestError) throw error;
+      if (this.responseSignals.get(response)?.aborted) {
+        throw new VercelSandboxRestError('request_failed', operation);
+      }
+      throw new VercelSandboxRestError('invalid_response', operation);
+    } finally {
+      reader.releaseLock();
+    }
+  }
+}

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-wrapper-transport.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-wrapper-transport.test.ts
@@ -1,0 +1,122 @@
+import { describe, expect, it, vi } from 'vitest';
+import { VercelWrapperTransport } from './vercel-wrapper-transport.js';
+import type { VercelSandboxRestClient } from './vercel-sandbox-rest-client.js';
+
+const sessionId = 'sbox_session_exact';
+const secretBody = { prompt: 'private prompt', token: 'secret-token' };
+
+type RestClientDouble = {
+  writeFiles: ReturnType<typeof vi.fn>;
+  executeCommand: ReturnType<typeof vi.fn>;
+  readFile: ReturnType<typeof vi.fn>;
+};
+
+function transportFor(overrides: Partial<RestClientDouble> = {}) {
+  const restClient = {
+    writeFiles: vi.fn().mockResolvedValue(undefined),
+    executeCommand: vi.fn().mockResolvedValue({
+      command: { id: 'cmd_1' },
+      finished: { id: 'cmd_1', exitCode: 0 },
+    }),
+    readFile: vi
+      .fn()
+      .mockResolvedValueOnce(new TextEncoder().encode('{"status":"sent"}'))
+      .mockResolvedValueOnce(new TextEncoder().encode('202')),
+    ...overrides,
+  };
+  return {
+    restClient,
+    transport: new VercelWrapperTransport({
+      restClient: restClient as unknown as VercelSandboxRestClient,
+      sessionId,
+      port: 5000,
+      randomId: () => 'safeRandom123',
+    }),
+  };
+}
+
+describe('VercelWrapperTransport', () => {
+  it('stages private bodies, executes bun in the exact session, preserves status, and cleans up', async () => {
+    const { restClient, transport } = transportFor();
+
+    const response = await transport.request('POST', '/job/prompt', secretBody);
+
+    expect(response.status).toBe(202);
+    await expect(response.json()).resolves.toEqual({ status: 'sent' });
+    expect(restClient.writeFiles).toHaveBeenCalledWith(sessionId, '/tmp', [
+      {
+        path: 'kilo-wrapper-safeRandom123/request.json',
+        content: JSON.stringify(secretBody),
+      },
+    ]);
+    const executeCalls = vi.mocked(restClient.executeCommand).mock.calls;
+    expect(executeCalls[0][0]).toBe(sessionId);
+    expect(executeCalls[0][1]).toMatchObject({
+      command: 'bun',
+      args: ['-e', expect.stringContaining('await fetch(url, init)')],
+      env: {
+        KILO_WRAPPER_METHOD: 'POST',
+        KILO_WRAPPER_URL: 'http://127.0.0.1:5000/job/prompt',
+        KILO_WRAPPER_RESPONSE: '/tmp/kilo-wrapper-safeRandom123/response.json',
+        KILO_WRAPPER_STATUS: '/tmp/kilo-wrapper-safeRandom123/status.txt',
+        KILO_WRAPPER_REQUEST: '/tmp/kilo-wrapper-safeRandom123/request.json',
+      },
+      wait: true,
+    });
+    expect(executeCalls[1][1]).toMatchObject({
+      command: 'rm',
+      args: ['-rf', '--', '/tmp/kilo-wrapper-safeRandom123'],
+      wait: true,
+    });
+    expect(JSON.stringify(executeCalls)).not.toContain('private prompt');
+    expect(JSON.stringify(executeCalls)).not.toContain('secret-token');
+  });
+
+  it('always removes staged files when bun or response reads fail without leaking bodies', async () => {
+    const providerError = new Error('exact-session command failed');
+    const { restClient, transport } = transportFor({
+      executeCommand: vi
+        .fn()
+        .mockRejectedValueOnce(providerError)
+        .mockResolvedValueOnce({ command: {}, finished: { exitCode: 0 } }),
+    });
+
+    await expect(transport.request('POST', '/session/ready', secretBody)).rejects.toBe(
+      providerError
+    );
+    expect(restClient.executeCommand).toHaveBeenLastCalledWith(
+      sessionId,
+      expect.objectContaining({
+        command: 'rm',
+        args: ['-rf', '--', '/tmp/kilo-wrapper-safeRandom123'],
+      })
+    );
+    await expect(transport.request('POST', '/job/prompt', secretBody)).rejects.not.toThrow(
+      /private prompt|secret-token/
+    );
+  });
+
+  it('bounds response and status reads and uses the long readiness timeout', async () => {
+    const { restClient, transport } = transportFor();
+
+    await transport.request('POST', '/session/ready', {});
+
+    expect(restClient.executeCommand).toHaveBeenNthCalledWith(
+      1,
+      sessionId,
+      expect.objectContaining({ timeoutMs: 120_000 })
+    );
+    expect(restClient.readFile).toHaveBeenNthCalledWith(
+      1,
+      sessionId,
+      '/tmp/kilo-wrapper-safeRandom123/response.json',
+      1024 * 1024
+    );
+    expect(restClient.readFile).toHaveBeenNthCalledWith(
+      2,
+      sessionId,
+      '/tmp/kilo-wrapper-safeRandom123/status.txt',
+      3
+    );
+  });
+});

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-wrapper-transport.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-wrapper-transport.ts
@@ -1,0 +1,129 @@
+import type { WrapperTransport } from '../../kilo/wrapper-client.js';
+import type { VercelSandboxRestClient } from './vercel-sandbox-rest-client.js';
+
+const RESPONSE_LIMIT_BYTES = 1024 * 1024;
+const STATUS_LIMIT_BYTES = 3;
+const DEFAULT_TIMEOUT_MS = 30_000;
+const SESSION_READY_TIMEOUT_MS = 120_000;
+const SAFE_RANDOM_ID = /^[A-Za-z0-9_-]+$/;
+const WRAPPER_HTTP_SCRIPT = `
+import { mkdir } from "node:fs/promises";
+import { dirname } from "node:path";
+const method = process.env.KILO_WRAPPER_METHOD;
+const url = process.env.KILO_WRAPPER_URL;
+const responsePath = process.env.KILO_WRAPPER_RESPONSE;
+const statusPath = process.env.KILO_WRAPPER_STATUS;
+const requestPath = process.env.KILO_WRAPPER_REQUEST;
+if (!method || !url || !responsePath || !statusPath) process.exit(2);
+await mkdir(dirname(responsePath), { recursive: true });
+const init = { method, headers: { "Content-Type": "application/json" } };
+if (requestPath) init.body = await Bun.file(requestPath).arrayBuffer();
+const res = await fetch(url, init);
+await Bun.write(responsePath, await res.arrayBuffer());
+await Bun.write(statusPath, String(res.status));
+`.trim();
+
+export type VercelWrapperTransportOptions = {
+  restClient: VercelSandboxRestClient;
+  sessionId: string;
+  port: number;
+  randomId?: () => string;
+};
+
+function defaultRandomId(): string {
+  const bytes = new Uint8Array(16);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, byte => byte.toString(16).padStart(2, '0')).join('');
+}
+
+export class VercelWrapperTransport implements WrapperTransport {
+  private readonly restClient: VercelSandboxRestClient;
+  private readonly sessionId: string;
+  private readonly port: number;
+  private readonly randomId: () => string;
+
+  constructor(options: VercelWrapperTransportOptions) {
+    this.restClient = options.restClient;
+    this.sessionId = options.sessionId;
+    this.port = options.port;
+    this.randomId = options.randomId ?? defaultRandomId;
+  }
+
+  async request(method: 'GET' | 'POST', path: string, body?: unknown): Promise<Response> {
+    const randomId = this.randomId();
+    if (!SAFE_RANDOM_ID.test(randomId)) throw new Error('Invalid wrapper transport request ID');
+    const directory = `/tmp/kilo-wrapper-${randomId}`;
+    const requestPath = `${directory}/request.json`;
+    const responsePath = `${directory}/response.json`;
+    const statusPath = `${directory}/status.txt`;
+    let response: Response | undefined;
+    let requestError: unknown;
+
+    try {
+      if (body !== undefined) {
+        await this.restClient.writeFiles(this.sessionId, '/tmp', [
+          {
+            path: `kilo-wrapper-${randomId}/request.json`,
+            content: JSON.stringify(body),
+          },
+        ]);
+      }
+
+      const result = await this.restClient.executeCommand(this.sessionId, {
+        command: 'bun',
+        args: ['-e', WRAPPER_HTTP_SCRIPT],
+        cwd: '/tmp',
+        env: {
+          KILO_WRAPPER_METHOD: method,
+          KILO_WRAPPER_URL: `http://127.0.0.1:${this.port}${path}`,
+          KILO_WRAPPER_RESPONSE: responsePath,
+          KILO_WRAPPER_STATUS: statusPath,
+          ...(body !== undefined ? { KILO_WRAPPER_REQUEST: requestPath } : {}),
+        },
+        sudo: false,
+        timeoutMs: path === '/session/ready' ? SESSION_READY_TIMEOUT_MS : DEFAULT_TIMEOUT_MS,
+        wait: true,
+      });
+      if (result.finished.exitCode !== 0) throw new Error('Vercel wrapper request failed');
+
+      const [responseBytes, statusBytes] = await Promise.all([
+        this.restClient.readFile(this.sessionId, responsePath, RESPONSE_LIMIT_BYTES),
+        this.restClient.readFile(this.sessionId, statusPath, STATUS_LIMIT_BYTES),
+      ]);
+      const status = Number(new TextDecoder().decode(statusBytes));
+      if (!Number.isInteger(status) || status < 100 || status > 599) {
+        throw new Error('Vercel wrapper returned an invalid HTTP status');
+      }
+      response = new Response(responseBytes, {
+        status,
+        headers: { 'Content-Type': 'application/json' },
+      });
+    } catch (error) {
+      requestError = error;
+    }
+
+    try {
+      await this.cleanup(directory);
+    } catch {
+      if (requestError === undefined) throw new Error('Vercel wrapper request cleanup failed');
+    }
+    if (requestError !== undefined) throw requestError;
+    if (!response) throw new Error('Vercel wrapper request produced no response');
+    return response;
+  }
+
+  private async cleanup(directory: string): Promise<void> {
+    const result = await this.restClient.executeCommand(this.sessionId, {
+      command: 'rm',
+      args: ['-rf', '--', directory],
+      cwd: '/tmp',
+      env: {},
+      sudo: false,
+      timeoutMs: DEFAULT_TIMEOUT_MS,
+      wait: true,
+    });
+    if (result.finished.exitCode !== 0) {
+      throw new Error('Vercel wrapper request cleanup failed');
+    }
+  }
+}

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -918,7 +918,17 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       beginWrapperLaunch: async input => {
         if (await this.hasDeletionIntent()) throw new Error('Session deletion is pending');
         const existing = await this.ctx.storage.get(VERCEL_WRAPPER_LAUNCH_INTENT_KEY);
-        if (existing !== undefined) return parseVercelWrapperLaunchIntent(existing);
+        if (existing !== undefined) {
+          const intent = parseVercelWrapperLaunchIntent(existing);
+          if (
+            intent.sessionId !== input.sessionId ||
+            intent.instanceId !== input.instance.instanceId ||
+            intent.instanceGeneration !== input.instance.instanceGeneration
+          ) {
+            throw new Error('Vercel wrapper launch intent does not match the current lease');
+          }
+          return intent;
+        }
         const intent = parseVercelWrapperLaunchIntent({
           sessionId: input.sessionId,
           launchId: crypto.randomUUID(),
@@ -1053,7 +1063,11 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
           ) {
             return { status: 'absent' };
           }
-          return createAgentSandbox(this.env, metadata).observeWrappersWithoutWaking();
+          return createAgentSandbox(
+            this.env,
+            metadata,
+            this.getAgentSandboxRuntimeContext()
+          ).observeWrappersWithoutWaking();
         },
         recordSharedSandboxFailover: routeKey =>
           this.sharedSandboxFailoverRecorder

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -158,6 +158,7 @@ import { createAgentSandbox, createAgentSandboxLifecycle } from '../agent-sandbo
 import { isCloudAgentContainerBillingEnabled } from '../container-billing-rollout.js';
 import type {
   AgentSandboxLifecycle,
+  AgentSandboxRuntimeContext,
   SandboxDeleteReason,
   SessionDeletionIntent,
   StopWrappersResult,
@@ -169,6 +170,16 @@ import {
   CODE_REVIEW_EPHEMERAL_SANDBOX_DESTROY_DELAY_MS,
   isCodeReviewEphemeralSandboxId,
 } from '../code-review-ephemeral-sandbox.js';
+import {
+  parseVercelCreateIntent,
+  parseVercelWrapperLaunchIntent,
+  VERCEL_CREATE_INTENT_KEY,
+  VERCEL_CREATE_RETRY_DELAY_MS,
+  VERCEL_CREATE_SETTLE_MS,
+  VERCEL_DELETION_TOMBSTONE_KEY,
+  VERCEL_WRAPPER_LAUNCH_INTENT_KEY,
+} from '../agent-sandbox/vercel/vercel-runtime-state.js';
+import { updateProviderRuntime } from './session-metadata.js';
 
 // ---------------------------------------------------------------------------
 // Alarm Constants
@@ -727,12 +738,17 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
         sendToWrapper: (ingestTagId, command, fence) =>
           this.sendToWrapper(ingestTagId, command, fence),
         getOrchestratorOverride: () => this.orchestrator,
+        sandboxRuntimeContext: this.getAgentSandboxRuntimeContext(),
         discoverSessionWrappers: metadata =>
           this.physicalWrapperObserver
             ? this.physicalWrapperObserver()
             : this.orchestrator
               ? Promise.resolve({ status: 'absent' })
-              : createAgentSandbox(this.env, metadata).discoverSessionWrappers(),
+              : createAgentSandbox(
+                  this.env,
+                  metadata,
+                  this.getAgentSandboxRuntimeContext()
+                ).discoverSessionWrappers(),
         requestAlarmAtOrBefore: deadline => this.scheduleAlarmAtOrBefore(deadline),
         checkBillingAdmission: () => this.containerBillingAdmissionFailure(),
       });
@@ -742,7 +758,10 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
   }
 
   private async hasDeletionIntent(): Promise<boolean> {
-    return (await this.ctx.storage.get<SessionDeletionIntent>(DELETION_INTENT_KEY)) !== undefined;
+    return (
+      (await this.ctx.storage.get<SessionDeletionIntent>(DELETION_INTENT_KEY)) !== undefined ||
+      (await this.ctx.storage.get(VERCEL_DELETION_TOMBSTONE_KEY)) !== undefined
+    );
   }
 
   private async canUseSandboxRuntime(): Promise<boolean> {
@@ -807,6 +826,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
     if (!this.sandboxLifecycle) {
       this.sandboxLifecycle = createAgentSandboxLifecycle(this.env, {
         storage: this.ctx.storage,
+        runtimeContext: this.getAgentSandboxRuntimeContext(),
         scheduleAlarmAtOrBefore: deadline => this.scheduleAlarmAtOrBefore(deadline),
         eraseDurableObjectState: () => this.eraseDurableObjectState(),
         purgeDeletedSessionPayload: () => this.purgeDeletedSessionPayload(),
@@ -814,6 +834,157 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       });
     }
     return this.sandboxLifecycle;
+  }
+
+  private getAgentSandboxRuntimeContext(): AgentSandboxRuntimeContext {
+    return {
+      getCreateIntent: async () => {
+        const raw = await this.ctx.storage.get(VERCEL_CREATE_INTENT_KEY);
+        return raw === undefined ? undefined : parseVercelCreateIntent(raw);
+      },
+      beginCreate: async input => {
+        if (await this.hasDeletionIntent()) throw new Error('Session deletion is pending');
+        const existing = await this.ctx.storage.get(VERCEL_CREATE_INTENT_KEY);
+        if (existing !== undefined) {
+          const intent = parseVercelCreateIntent(existing);
+          if (
+            intent.sandboxName !== input.sandboxName ||
+            intent.projectId !== input.projectId ||
+            intent.snapshotId !== input.snapshotId ||
+            intent.runtimeBuildId !== input.runtimeBuildId ||
+            intent.runtime !== input.runtime
+          ) {
+            throw new Error('Vercel create intent does not match the pinned runtime configuration');
+          }
+          return intent;
+        }
+        const now = Date.now();
+        const intent = parseVercelCreateIntent({
+          version: 1,
+          sandboxName: input.sandboxName,
+          operationId: crypto.randomUUID(),
+          projectId: input.projectId,
+          snapshotId: input.snapshotId,
+          runtimeBuildId: input.runtimeBuildId,
+          runtime: input.runtime,
+          startedAt: now,
+          settleUntil: now + VERCEL_CREATE_SETTLE_MS,
+          attempts: 1,
+          nextRetryAt: now + VERCEL_CREATE_RETRY_DELAY_MS,
+        });
+        await this.ctx.storage.put(VERCEL_CREATE_INTENT_KEY, intent);
+        await this.scheduleAlarmAtOrBefore(intent.nextRetryAt);
+        return intent;
+      },
+      clearCreateIntent: async operationId => {
+        const raw = await this.ctx.storage.get(VERCEL_CREATE_INTENT_KEY);
+        if (raw === undefined) return;
+        const intent = parseVercelCreateIntent(raw);
+        if (intent.operationId === operationId) {
+          await this.ctx.storage.delete(VERCEL_CREATE_INTENT_KEY);
+        }
+      },
+      persistRuntimeOnce: async input => {
+        if (await this.hasDeletionIntent()) throw new Error('Session deletion is pending');
+        await this.ctx.storage.transaction(async transaction => {
+          const rawMetadata = await transaction.get('metadata');
+          if (!rawMetadata) throw new Error('Session metadata unavailable');
+          const metadata = parseSessionMetadata(rawMetadata);
+          const updated = updateProviderRuntime(metadata, {
+            provider: input.provider,
+            sessionId: input.sessionId,
+            projectId: input.projectId,
+            snapshotId: input.snapshotId,
+            runtimeBuildId: input.runtimeBuildId,
+            runtime: input.runtime,
+            wrapper: metadata.workspace?.providerRuntime?.wrapper,
+          });
+          await transaction.put('metadata', updated);
+          await transaction.delete(VERCEL_CREATE_INTENT_KEY);
+        });
+      },
+      getWrapperLaunchIntent: async () => {
+        const raw = await this.ctx.storage.get(VERCEL_WRAPPER_LAUNCH_INTENT_KEY);
+        return raw === undefined ? undefined : parseVercelWrapperLaunchIntent(raw);
+      },
+      clearWrapperLaunchIntent: async launchId => {
+        const raw = await this.ctx.storage.get(VERCEL_WRAPPER_LAUNCH_INTENT_KEY);
+        if (raw === undefined) return;
+        const intent = parseVercelWrapperLaunchIntent(raw);
+        if (intent.launchId === launchId) {
+          await this.ctx.storage.delete(VERCEL_WRAPPER_LAUNCH_INTENT_KEY);
+        }
+      },
+      beginWrapperLaunch: async input => {
+        if (await this.hasDeletionIntent()) throw new Error('Session deletion is pending');
+        const existing = await this.ctx.storage.get(VERCEL_WRAPPER_LAUNCH_INTENT_KEY);
+        if (existing !== undefined) return parseVercelWrapperLaunchIntent(existing);
+        const intent = parseVercelWrapperLaunchIntent({
+          sessionId: input.sessionId,
+          launchId: crypto.randomUUID(),
+          instanceId: input.instance.instanceId,
+          instanceGeneration: input.instance.instanceGeneration,
+          startedAt: Date.now(),
+        });
+        await this.ctx.storage.put(VERCEL_WRAPPER_LAUNCH_INTENT_KEY, intent);
+        return intent;
+      },
+      persistWrapperProcessOnce: async input => {
+        if (await this.hasDeletionIntent()) throw new Error('Session deletion is pending');
+        await this.ctx.storage.transaction(async transaction => {
+          const rawMetadata = await transaction.get('metadata');
+          if (!rawMetadata) throw new Error('Session metadata unavailable');
+          const metadata = parseSessionMetadata(rawMetadata);
+          const runtime = metadata.workspace?.providerRuntime;
+          if (!runtime || runtime.sessionId !== input.sessionId) {
+            throw new Error('Vercel wrapper session does not match persisted runtime');
+          }
+          const launchIntentRaw = await transaction.get(VERCEL_WRAPPER_LAUNCH_INTENT_KEY);
+          if (launchIntentRaw !== undefined) {
+            const launchIntent = parseVercelWrapperLaunchIntent(launchIntentRaw);
+            if (launchIntent.launchId !== input.launchId) {
+              throw new Error('Vercel wrapper process does not match the launch intent');
+            }
+          }
+          const existing = runtime.wrapper;
+          if (
+            existing &&
+            (existing.launchId !== input.launchId ||
+              existing.commandId !== input.commandId ||
+              existing.instanceId !== input.instance.instanceId ||
+              existing.instanceGeneration !== input.instance.instanceGeneration)
+          ) {
+            throw new Error('Vercel wrapper process is immutable until cleared');
+          }
+          const updated = updateProviderRuntime(metadata, {
+            ...runtime,
+            wrapper: {
+              launchId: input.launchId,
+              commandId: input.commandId,
+              instanceId: input.instance.instanceId,
+              instanceGeneration: input.instance.instanceGeneration,
+            },
+          });
+          await transaction.put('metadata', updated);
+          await transaction.delete(VERCEL_WRAPPER_LAUNCH_INTENT_KEY);
+        });
+      },
+      clearWrapperProcess: async input => {
+        if (await this.hasDeletionIntent()) return;
+        const metadata = await this.getStoredMetadata();
+        const runtime = metadata?.workspace?.providerRuntime;
+        if (!metadata || !runtime || runtime.sessionId !== input.sessionId) return;
+        if (runtime.wrapper?.commandId !== input.commandId) return;
+        await this.ctx.storage.put(
+          'metadata',
+          updateProviderRuntime(metadata, {
+            ...runtime,
+            wrapper: undefined,
+          })
+        );
+      },
+      isDeletionPending: () => this.hasDeletionIntent(),
+    };
   }
 
   private getWrapperSupervisor(): WrapperSupervisor {
@@ -856,7 +1027,11 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
             return { status: 'absent' };
           }
           try {
-            return await createAgentSandbox(this.env, metadata).stopWrappers(request);
+            return await createAgentSandbox(
+              this.env,
+              metadata,
+              this.getAgentSandboxRuntimeContext()
+            ).stopWrappers(request);
           } catch (error) {
             return {
               status: 'inspection-failed',
@@ -1539,6 +1714,16 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
       if (existingMetadata.workspace?.sandboxId !== newMetadata.workspace?.sandboxId) {
         throw new Error('Registered sandbox name cannot be changed');
       }
+      const existingRuntime = existingMetadata.workspace?.providerRuntime;
+      const newRuntime = newMetadata.workspace?.providerRuntime;
+      if (existingRuntime?.sessionId !== newRuntime?.sessionId) {
+        throw new Error('Persisted Vercel session ID cannot be changed');
+      }
+      for (const field of ['projectId', 'snapshotId', 'runtimeBuildId', 'runtime'] as const) {
+        if (existingRuntime?.[field] !== newRuntime?.[field]) {
+          throw new Error(`Persisted Vercel ${field} cannot be changed`);
+        }
+      }
     }
     await this.ctx.storage.put('metadata', newMetadata);
 
@@ -1988,9 +2173,14 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
   private async purgeDeletedSessionPayload(
     additionalRetainedKeys: readonly string[] = []
   ): Promise<void> {
-    // The deletion fence survives the purge, along with any durable keys a
-    // provider's deferred deletion plan asked the session to persist.
-    const retainedKeys = new Set<string>([DELETION_INTENT_KEY, ...additionalRetainedKeys]);
+    // The deletion fence survives the purge, along with the Vercel tombstone
+    // (the lifecycle reconciler purges without passing keys) and any durable
+    // keys a provider's deferred deletion plan asked the session to persist.
+    const retainedKeys = new Set<string>([
+      DELETION_INTENT_KEY,
+      VERCEL_DELETION_TOMBSTONE_KEY,
+      ...additionalRetainedKeys,
+    ]);
     while (true) {
       const persistedKeys = await this.ctx.storage.list({ limit: 128 });
       const sensitiveKeys = [...persistedKeys.keys()].filter(key => !retainedKeys.has(key));
@@ -2114,9 +2304,7 @@ export class CloudAgentSession extends DurableObject<WorkerEnv> {
   ): Promise<'complete' | 'deferred' | 'physical-cleanup-pending'> {
     const metadata = await this.getStoredMetadata();
     if (!metadata) {
-      // Metadata already purged but the deletion fence is still present:
-      // provider-side deletion is reconciling asynchronously via alarms.
-      if (await this.ctx.storage.get(DELETION_INTENT_KEY)) {
+      if (await this.ctx.storage.get(VERCEL_DELETION_TOMBSTONE_KEY)) {
         return 'deferred';
       }
       const lease = await getWrapperLease(this.ctx.storage);

--- a/services/cloud-agent-next/src/persistence/session-metadata.test.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.test.ts
@@ -7,6 +7,7 @@ import {
   parseSessionMetadata,
   requiresContainmentSandbox,
   serializeSessionMetadata,
+  updateProviderRuntime,
 } from './session-metadata.js';
 
 const callbackTarget = {
@@ -223,6 +224,156 @@ describe('session metadata boundary', () => {
 
     expect(parseSessionMetadata(current)).toEqual(current);
     expect(getSandboxProvider(parseSessionMetadata(current))).toBe('cloudflare');
+  });
+
+  it('accepts Vercel metadata only for an isolated non-devcontainer sandbox', () => {
+    const current = {
+      metadataSchemaVersion: 2 as const,
+      identity: {
+        sessionId: 'agent_vercel_provider',
+        userId: 'user_vercel_provider',
+      },
+      auth: {},
+      workspace: {
+        sandboxId: 'ses-abcdef' as const,
+        sandboxProvider: 'vercel' as const,
+      },
+      lifecycle: {
+        version: 1,
+        timestamp: 1,
+      },
+    };
+
+    expect(parseSessionMetadata(current)).toEqual(current);
+    expect(getSandboxProvider(parseSessionMetadata(current))).toBe('vercel');
+  });
+
+  it('persists one immutable Vercel session locator and mutable wrapper lease', () => {
+    const metadata = parseSessionMetadata({
+      metadataSchemaVersion: 2,
+      identity: { sessionId: 'agent_vercel_runtime', userId: 'user_vercel_runtime' },
+      auth: {},
+      workspace: {
+        sandboxId: 'ses-abcdef',
+        sandboxProvider: 'vercel',
+      },
+      lifecycle: { version: 1, timestamp: 1 },
+    });
+
+    const runtimeLocator = {
+      provider: 'vercel' as const,
+      sessionId: 'session-1',
+      projectId: 'project-1',
+      snapshotId: 'snapshot-1',
+      runtimeBuildId: 'build-1',
+      runtime: 'node24' as const,
+    };
+    const located = updateProviderRuntime(metadata, runtimeLocator);
+    const launched = updateProviderRuntime(located, {
+      ...runtimeLocator,
+      wrapper: {
+        launchId: 'launch-1',
+        commandId: 'command-1',
+        instanceId: 'instance-1',
+        instanceGeneration: 2,
+      },
+    });
+
+    expect(serializeSessionMetadata(launched).workspace?.providerRuntime).toEqual({
+      ...runtimeLocator,
+      wrapper: {
+        launchId: 'launch-1',
+        commandId: 'command-1',
+        instanceId: 'instance-1',
+        instanceGeneration: 2,
+      },
+    });
+    expect(updateProviderRuntime(launched, runtimeLocator).workspace?.providerRuntime).toEqual(
+      runtimeLocator
+    );
+    expect(() =>
+      updateProviderRuntime(located, { ...runtimeLocator, sessionId: 'session-2' })
+    ).toThrow('Vercel session ID is immutable');
+    expect(() =>
+      updateProviderRuntime(located, { ...runtimeLocator, runtimeBuildId: 'build-2' })
+    ).toThrow('Vercel runtimeBuildId is immutable');
+  });
+
+  it('rejects provider runtime mismatches and devcontainers', () => {
+    const base = {
+      metadataSchemaVersion: 2,
+      identity: { sessionId: 'agent_runtime_mismatch', userId: 'user_runtime_mismatch' },
+      auth: {},
+      lifecycle: { version: 1, timestamp: 1 },
+    };
+
+    expect(() =>
+      parseSessionMetadata({
+        ...base,
+        workspace: {
+          sandboxId: 'ses-abcdef',
+          sandboxProvider: 'cloudflare',
+          providerRuntime: { provider: 'vercel', sessionId: 'session-1' },
+        },
+      })
+    ).toThrow('Invalid current session metadata');
+    expect(() =>
+      parseSessionMetadata({
+        ...base,
+        workspace: {
+          sandboxId: 'ses-abcdef',
+          sandboxProvider: 'vercel',
+          providerRuntime: { provider: 'vercel', sessionId: 'session-1' },
+          devcontainerRequested: true,
+        },
+      })
+    ).toThrow('Invalid current session metadata');
+  });
+
+  it('rejects Vercel metadata pinned to a shared sandbox identity', () => {
+    expect(() =>
+      parseSessionMetadata({
+        metadataSchemaVersion: 2,
+        identity: { sessionId: 'agent_vercel_shared', userId: 'user_vercel_shared' },
+        auth: {},
+        workspace: { sandboxId: 'org-abcdef', sandboxProvider: 'vercel' },
+        lifecycle: { version: 1, timestamp: 1 },
+      })
+    ).toThrow('Invalid current session metadata');
+  });
+
+  it('rejects Vercel metadata requesting a devcontainer runtime', () => {
+    expect(() =>
+      parseSessionMetadata({
+        metadataSchemaVersion: 2,
+        identity: { sessionId: 'agent_vercel_dind', userId: 'user_vercel_dind' },
+        auth: {},
+        workspace: {
+          sandboxId: 'ses-abcdef',
+          sandboxProvider: 'vercel',
+          devcontainerRequested: true,
+        },
+        lifecycle: { version: 1, timestamp: 1 },
+      })
+    ).toThrow('Invalid current session metadata');
+  });
+
+  it('rejects Vercel metadata carrying an already prepared devcontainer', () => {
+    expect(() =>
+      parseSessionMetadata({
+        metadataSchemaVersion: 2,
+        identity: { sessionId: 'agent_vercel_prepared_dind', userId: 'user_vercel_dind' },
+        auth: {},
+        workspace: { sandboxId: 'ses-abcdef', sandboxProvider: 'vercel' },
+        devcontainer: {
+          workspacePath: '/workspace/user/sessions/agent_vercel_prepared_dind',
+          innerWorkspaceFolder: '/workspaces/repo',
+          wrapperPort: 4173,
+          configPath: '.devcontainer/devcontainer.json',
+        },
+        lifecycle: { version: 1, timestamp: 1 },
+      })
+    ).toThrow('Invalid current session metadata');
   });
 
   it('parses and serializes current grouped DIND workspace metadata', () => {

--- a/services/cloud-agent-next/src/persistence/session-metadata.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.ts
@@ -28,7 +28,30 @@ const SharedSandboxIdSchema = z
   .transform(s => s as SandboxId);
 
 const MessageIdSchema = z.string().regex(MESSAGE_ID_PATTERN, MESSAGE_ID_FORMAT_DESCRIPTION);
-const SandboxProviderSchema = z.enum(['cloudflare']);
+const SandboxProviderSchema = z.enum(['cloudflare', 'vercel']);
+
+const VercelProviderRuntimeSchema = z
+  .object({
+    provider: z.literal('vercel'),
+    sessionId: z.string().min(1),
+    projectId: z.string().min(1).optional(),
+    snapshotId: z.string().min(1).optional(),
+    runtimeBuildId: z.string().min(1).optional(),
+    runtime: z.enum(['node22', 'node24', 'node26', 'python3.13']).optional(),
+    wrapper: z
+      .object({
+        launchId: z.string().min(1),
+        commandId: z.string().min(1),
+        instanceId: z.string().min(1),
+        instanceGeneration: z.number().int().nonnegative(),
+      })
+      .strip()
+      .optional(),
+  })
+  .strip();
+
+/** One member per provider that persists runtime identity in session metadata. */
+const ProviderRuntimeSchema = z.discriminatedUnion('provider', [VercelProviderRuntimeSchema]);
 
 const MetadataIdentitySchema = z
   .object({
@@ -213,6 +236,7 @@ const MetadataWorkspaceSchema = z
     sandboxId: SandboxIdSchema.optional(),
     sandboxRoute: MetadataSharedSandboxRouteSchema.optional(),
     sandboxProvider: SandboxProviderSchema.optional(),
+    providerRuntime: ProviderRuntimeSchema.optional(),
     workspacePath: z.string().optional(),
     sessionHome: z.string().optional(),
     branchName: z.string().optional(),
@@ -254,9 +278,20 @@ const MetadataWorkspaceSchema = z
   })
   .refine(
     workspace =>
+      workspace.sandboxProvider !== 'vercel' || workspace.sandboxId?.startsWith('ses-') === true,
+    'Vercel sandbox metadata requires an isolated ses-* sandbox'
+  )
+  .refine(
+    workspace =>
       PROVIDER_CAPABILITIES[workspace.sandboxProvider ?? 'cloudflare'].devcontainer ||
       workspace.devcontainerRequested !== true,
     'Sandbox provider does not support devcontainers'
+  )
+  .refine(
+    workspace =>
+      workspace.providerRuntime === undefined ||
+      workspace.providerRuntime.provider === workspace.sandboxProvider,
+    'Provider runtime must match the workspace sandbox provider'
   );
 
 const MetadataDevContainerSchema = z
@@ -492,4 +527,31 @@ export function parseSessionMetadata(raw: unknown): SessionMetadata {
 
 export function serializeSessionMetadata(metadata: SessionMetadata): SessionMetadata {
   return CurrentSessionMetadataSchema.parse(metadata);
+}
+
+export function updateProviderRuntime(
+  metadata: SessionMetadata,
+  providerRuntime: z.input<typeof ProviderRuntimeSchema>
+): SessionMetadata {
+  const workspace = metadata.workspace;
+  if (workspace?.sandboxProvider !== providerRuntime.provider) {
+    throw new Error('Vercel provider runtime requires Vercel sandbox metadata');
+  }
+  const existing = workspace.providerRuntime;
+  if (existing !== undefined && existing.sessionId !== providerRuntime.sessionId) {
+    throw new Error('Vercel session ID is immutable');
+  }
+  for (const field of ['projectId', 'snapshotId', 'runtimeBuildId', 'runtime'] as const) {
+    if (existing?.[field] !== undefined && existing[field] !== providerRuntime[field]) {
+      throw new Error(`Vercel ${field} is immutable`);
+    }
+  }
+
+  return serializeSessionMetadata({
+    ...metadata,
+    workspace: {
+      ...workspace,
+      providerRuntime: ProviderRuntimeSchema.parse(providerRuntime),
+    },
+  });
 }

--- a/services/cloud-agent-next/src/sandbox-id.test.ts
+++ b/services/cloud-agent-next/src/sandbox-id.test.ts
@@ -62,6 +62,47 @@ describe('generateSandboxId', () => {
       expect(id1).toBe(id2);
     });
 
+    it('keeps control-plane and legacy shared IDs disjoint for the same owner', async () => {
+      const uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+      const legacy = await generateSandboxId(undefined, 'org-id', 'user-id', `agent_${uuid}`);
+      const control = await generateSandboxId(undefined, 'org-id', 'user-id', `workspace_${uuid}`);
+      expect(legacy).not.toBe(control);
+      expect(legacy.startsWith('org-')).toBe(true);
+      expect(control.startsWith('org-')).toBe(true);
+    });
+
+    it('keeps control-plane and legacy isolated IDs disjoint', async () => {
+      const uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+      const legacy = await generateSandboxId('*', 'org-id', 'user-id', `agent_${uuid}`);
+      const control = await generateSandboxId('*', 'org-id', 'user-id', `workspace_${uuid}`);
+      expect(legacy).not.toBe(control);
+      expect(legacy.startsWith('ses-')).toBe(true);
+      expect(control.startsWith('ses-')).toBe(true);
+    });
+
+    it('derives disjoint shared IDs from control-plane versus legacy route keys', async () => {
+      const uuid = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+      const legacyRoute = await generateSandboxRoutingTarget(
+        undefined,
+        'org-id',
+        'user-id',
+        `agent_${uuid}`
+      );
+      const controlRoute = await generateSandboxRoutingTarget(
+        undefined,
+        'org-id',
+        'user-id',
+        `workspace_${uuid}`
+      );
+      expect(legacyRoute.kind).toBe('shared');
+      expect(controlRoute.kind).toBe('shared');
+      if (legacyRoute.kind !== 'shared' || controlRoute.kind !== 'shared') return;
+      expect(legacyRoute.routeKey).not.toBe(controlRoute.routeKey);
+      expect(await deriveSharedSandboxId(legacyRoute.routeKey, 'a')).not.toBe(
+        await deriveSharedSandboxId(controlRoute.routeKey, 'a')
+      );
+    });
+
     it.each([
       [
         'org',
@@ -426,6 +467,20 @@ describe('generateSandboxId', () => {
 });
 
 describe('selectSandboxForNewSession', () => {
+  const completeVercelConfiguration = {
+    VERCEL_SANDBOX_ORG_IDS: 'org-id',
+    VERCEL_TOKEN: 'token',
+    VERCEL_TEAM_ID: 'team-id',
+    VERCEL_PROJECT_ID: 'project-id',
+    VERCEL_SANDBOX_SNAPSHOT_ID: 'snapshot-id',
+    VERCEL_SANDBOX_RUNTIME_BUILD_ID: 'build-id',
+    VERCEL_SANDBOX_RUNTIME: 'node24',
+    VERCEL_SANDBOX_INITIAL_TIMEOUT_MS: '300000',
+    VERCEL_SANDBOX_EXTEND_DURATION_MS: '600000',
+  };
+  const controlSessionId = 'workspace_12345678-1234-1234-1234-123456789abc';
+  const legacySessionId = 'agent_12345678-1234-1234-1234-123456789abc';
+
   it('selects Cloudflare by default while preserving shared sandbox allocation', async () => {
     const selection = await selectSandboxForNewSession({
       env: {},
@@ -438,9 +493,128 @@ describe('selectSandboxForNewSession', () => {
     expect(selection.sandboxId).toMatch(/^org-/);
   });
 
-  it('selects Cloudflare for isolated per-session organizations', async () => {
+  it('selects Vercel for an enabled, allowlisted, isolated control-plane session', async () => {
     const selection = await selectSandboxForNewSession({
-      env: { PER_SESSION_SANDBOX_ORG_IDS: 'org-id' },
+      env: { PER_SESSION_SANDBOX_ORG_IDS: 'org-id', ...completeVercelConfiguration },
+      orgId: 'org-id',
+      userId: 'user-id',
+      sessionId: controlSessionId,
+    });
+
+    expect(selection.provider).toBe('vercel');
+    expect(selection.sandboxId).toMatch(/^ses-/);
+  });
+
+  it('keeps an enrolled isolated legacy session on Cloudflare', async () => {
+    const selection = await selectSandboxForNewSession({
+      env: { PER_SESSION_SANDBOX_ORG_IDS: 'org-id', ...completeVercelConfiguration },
+      orgId: 'org-id',
+      userId: 'user-id',
+      sessionId: legacySessionId,
+    });
+
+    expect(selection.provider).toBe('cloudflare');
+    expect(selection.sandboxId).toMatch(/^ses-/);
+  });
+
+  it('keeps an enrolled organization on Cloudflare when it is not isolated', async () => {
+    const selection = await selectSandboxForNewSession({
+      env: { ...completeVercelConfiguration },
+      orgId: 'org-id',
+      userId: 'user-id',
+      sessionId: 'session-id',
+    });
+
+    expect(selection.provider).toBe('cloudflare');
+    expect(selection.sandboxId).toMatch(/^org-/);
+  });
+
+  it.each(Object.keys(completeVercelConfiguration))(
+    'keeps partial Vercel configuration on Cloudflare when %s is absent',
+    async missingKey => {
+      const configuration = { ...completeVercelConfiguration };
+      delete configuration[missingKey as keyof typeof configuration];
+      const selection = await selectSandboxForNewSession({
+        env: { PER_SESSION_SANDBOX_ORG_IDS: 'org-id', ...configuration },
+        orgId: 'org-id',
+        userId: 'user-id',
+        sessionId: 'session-id',
+      });
+
+      expect(selection.provider).toBe('cloudflare');
+      expect(selection.sandboxId).toMatch(/^ses-/);
+    }
+  );
+
+  it('keeps organizations outside the explicit Vercel allowlist on Cloudflare', async () => {
+    const selection = await selectSandboxForNewSession({
+      env: {
+        PER_SESSION_SANDBOX_ORG_IDS: 'org-id',
+        ...completeVercelConfiguration,
+        VERCEL_SANDBOX_ORG_IDS: 'other-org',
+      },
+      orgId: 'org-id',
+      userId: 'user-id',
+      sessionId: 'session-id',
+    });
+
+    expect(selection.provider).toBe('cloudflare');
+    expect(selection.sandboxId).toMatch(/^ses-/);
+  });
+
+  it('selects Vercel for any isolated control-plane organization when enrollment is wildcarded', async () => {
+    const selection = await selectSandboxForNewSession({
+      env: {
+        PER_SESSION_SANDBOX_ORG_IDS: '*',
+        ...completeVercelConfiguration,
+        VERCEL_SANDBOX_ORG_IDS: '*',
+      },
+      orgId: 'org-id',
+      userId: 'user-id',
+      sessionId: controlSessionId,
+    });
+
+    expect(selection.provider).toBe('vercel');
+    expect(selection.sandboxId).toMatch(/^ses-/);
+  });
+
+  it('keeps personal legacy sessions on Cloudflare even when Vercel enrollment is wildcarded', async () => {
+    const selection = await selectSandboxForNewSession({
+      env: {
+        PER_SESSION_SANDBOX_ORG_IDS: '*',
+        ...completeVercelConfiguration,
+        VERCEL_SANDBOX_ORG_IDS: '*',
+      },
+      userId: 'user-id',
+      sessionId: legacySessionId,
+    });
+
+    expect(selection.provider).toBe('cloudflare');
+    expect(selection.sandboxId).toMatch(/^ses-/);
+  });
+
+  it('selects Vercel for personal isolated control-plane sessions when enrollment is wildcarded', async () => {
+    const selection = await selectSandboxForNewSession({
+      env: {
+        PER_SESSION_SANDBOX_ORG_IDS: '*',
+        ...completeVercelConfiguration,
+        VERCEL_SANDBOX_ORG_IDS: '*',
+      },
+      userId: 'user-id',
+      sessionId: controlSessionId,
+    });
+
+    expect(selection.provider).toBe('vercel');
+    expect(selection.sandboxId).toMatch(/^ses-/);
+  });
+
+  it('keeps invalid operational configuration on Cloudflare', async () => {
+    const selection = await selectSandboxForNewSession({
+      env: {
+        PER_SESSION_SANDBOX_ORG_IDS: 'org-id',
+        ...completeVercelConfiguration,
+        VERCEL_SANDBOX_RUNTIME: 'node22',
+      },
       orgId: 'org-id',
       userId: 'user-id',
       sessionId: 'session-id',
@@ -452,7 +626,7 @@ describe('selectSandboxForNewSession', () => {
 
   it('keeps devcontainer sessions on Cloudflare DIND allocation', async () => {
     const selection = await selectSandboxForNewSession({
-      env: { PER_SESSION_SANDBOX_ORG_IDS: 'org-id' },
+      env: { PER_SESSION_SANDBOX_ORG_IDS: 'org-id', ...completeVercelConfiguration },
       orgId: 'org-id',
       userId: 'user-id',
       sessionId: 'session-id',

--- a/services/cloud-agent-next/src/sandbox-id.ts
+++ b/services/cloud-agent-next/src/sandbox-id.ts
@@ -1,9 +1,17 @@
 import type { AgentSandboxProvider, SandboxId, Env } from './types.js';
+import { sessionPlaneFromId } from './session-plane.js';
 import type { Sandbox } from '@cloudflare/sandbox';
+import {
+  parseVercelSandboxEnrollment,
+  parseVercelSandboxRuntimeConfig,
+  type VercelSandboxEnrollmentEnv,
+  type VercelSandboxRuntimeConfigEnv,
+} from './agent-sandbox/vercel/vercel-runtime-config.js';
 
 export const MANAGED_SCM_OUTBOUND_HANDLER = 'managedScm';
 
 const SHARED_SANDBOX_ID_VERSION = 'shared-v3';
+const CONTROL_PLANE_SHARED_SANDBOX_ID_VERSION = 'shared-control-v1';
 
 type SharedSandboxPrefix = 'org' | 'usr' | 'bot' | 'ubt';
 type SandboxNamespaceEnv = Pick<
@@ -137,7 +145,8 @@ export type SandboxSelection = {
 
 export type SandboxSelectionEnv = {
   PER_SESSION_SANDBOX_ORG_IDS?: string;
-};
+} & VercelSandboxEnrollmentEnv &
+  VercelSandboxRuntimeConfigEnv;
 
 type SelectSandboxForNewSessionInput = {
   env: SandboxSelectionEnv;
@@ -147,6 +156,36 @@ type SelectSandboxForNewSessionInput = {
   botId?: string;
   devcontainer?: boolean;
 };
+
+/**
+ * Resolves the sandbox provider for an already-computed sandbox ID. Vercel
+ * is call-home only: isolated `workspace_` sessions whose owner is on
+ * `VERCEL_SANDBOX_ORG_IDS` (`*` includes personal) with complete operational
+ * configuration. Legacy `agent_` sessions and everything else stay on Cloudflare.
+ */
+export function selectSandboxProvider(input: {
+  env: SandboxSelectionEnv;
+  orgId?: string;
+  sandboxId: SandboxId;
+  sessionId: string;
+  devcontainer?: boolean;
+}): AgentSandboxProvider {
+  const enrollment = parseVercelSandboxEnrollment(input.env);
+  const runtimeConfig = parseVercelSandboxRuntimeConfig(input.env);
+  const enrolled =
+    input.orgId !== undefined
+      ? enrollment.orgIds.has('*') || enrollment.orgIds.has(input.orgId)
+      : enrollment.allowPersonal;
+  const useVercel =
+    sessionPlaneFromId(input.sessionId) === 'control' &&
+    !input.devcontainer &&
+    input.sandboxId.startsWith('ses-') &&
+    enrollment.enabled &&
+    enrolled &&
+    runtimeConfig !== undefined;
+
+  return useVercel ? 'vercel' : 'cloudflare';
+}
 
 export async function selectSandboxForNewSession(
   input: SelectSandboxForNewSessionInput
@@ -159,7 +198,15 @@ export async function selectSandboxForNewSession(
     input.botId,
     input.devcontainer
   );
-  return { sandboxId, provider: 'cloudflare' };
+  const provider = selectSandboxProvider({
+    env: input.env,
+    orgId: input.orgId,
+    sandboxId,
+    sessionId: input.sessionId,
+    devcontainer: input.devcontainer,
+  });
+
+  return { sandboxId, provider };
 }
 
 /**
@@ -204,7 +251,11 @@ export async function generateSandboxRoutingTarget(
     ? `${sandboxOrgSegment}__${userId}__bot:${botId}`
     : `${sandboxOrgSegment}__${userId}`;
   const prefix: SharedSandboxPrefix = botId ? (orgId ? 'bot' : 'ubt') : orgId ? 'org' : 'usr';
-  const routeKey = await hashToSandboxId(`${SHARED_SANDBOX_ID_VERSION}:${originalFormat}`, prefix);
+  const sharedVersion =
+    sessionPlaneFromId(sessionId) === 'control'
+      ? CONTROL_PLANE_SHARED_SANDBOX_ID_VERSION
+      : SHARED_SANDBOX_ID_VERSION;
+  const routeKey = await hashToSandboxId(`${sharedVersion}:${originalFormat}`, prefix);
 
   return {
     kind: 'shared',

--- a/services/cloud-agent-next/src/session-plane.test.ts
+++ b/services/cloud-agent-next/src/session-plane.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest';
+import {
+  generateSessionId,
+  isControlPlaneOwner,
+  sessionPlaneForNewOwner,
+  sessionPlaneFromId,
+  sessionSupportsTerminal,
+} from './session-plane.js';
+import { sessionHasTerminal } from './agent-sandbox/capabilities.js';
+import { SESSION_ID_RE } from './shared/protocol.js';
+import { sessionIdSchema } from './types.js';
+
+describe('session plane identity', () => {
+  it('classifies workspace_ as control and everything else as legacy', () => {
+    expect(sessionPlaneFromId('workspace_12345678-1234-1234-1234-123456789abc')).toBe('control');
+    expect(sessionPlaneFromId('agent_12345678-1234-1234-1234-123456789abc')).toBe('legacy');
+    expect(sessionPlaneFromId('agent2_12345678-1234-1234-1234-123456789abc')).toBe('legacy');
+  });
+
+  it('accepts agent_ and workspace_ session IDs and rejects agent2_', () => {
+    expect(SESSION_ID_RE.test('agent_12345678-1234-1234-1234-123456789abc')).toBe(true);
+    expect(SESSION_ID_RE.test('workspace_12345678-1234-1234-1234-123456789abc')).toBe(true);
+    expect(SESSION_ID_RE.test('agent2_12345678-1234-1234-1234-123456789abc')).toBe(false);
+    expect(SESSION_ID_RE.test('Workspace_12345678-1234-1234-1234-123456789abc')).toBe(false);
+    expect(
+      sessionIdSchema.safeParse('workspace_12345678-1234-1234-1234-123456789abc').success
+    ).toBe(true);
+    expect(sessionIdSchema.safeParse('agent2_12345678-1234-1234-1234-123456789abc').success).toBe(
+      false
+    );
+  });
+
+  it('mints workspace_ only for allowlisted owners', () => {
+    expect(generateSessionId('legacy').startsWith('agent_')).toBe(true);
+    expect(generateSessionId('control').startsWith('workspace_')).toBe(true);
+    expect(sessionIdSchema.safeParse(generateSessionId('control')).success).toBe(true);
+    expect(sessionPlaneForNewOwner({ CONTROL_PLANE_IDS: 'user-1' }, { userId: 'user-1' })).toBe(
+      'control'
+    );
+    expect(
+      sessionPlaneForNewOwner({ CONTROL_PLANE_IDS: 'org-1' }, { userId: 'user-2', orgId: 'org-1' })
+    ).toBe('control');
+    expect(sessionPlaneForNewOwner({ CONTROL_PLANE_IDS: '*' }, { userId: 'user-3' })).toBe(
+      'control'
+    );
+    expect(sessionPlaneForNewOwner({}, { userId: 'user-1', orgId: 'org-1' })).toBe('legacy');
+    expect(isControlPlaneOwner({ CONTROL_PLANE_IDS: 'user-1' }, { userId: 'user-2' })).toBe(false);
+  });
+
+  it('disables terminals for control-plane sessions on every provider', () => {
+    expect(sessionSupportsTerminal('agent_12345678-1234-1234-1234-123456789abc')).toBe(true);
+    expect(sessionSupportsTerminal('workspace_12345678-1234-1234-1234-123456789abc')).toBe(false);
+    expect(sessionHasTerminal('workspace_12345678-1234-1234-1234-123456789abc', 'cloudflare')).toBe(
+      false
+    );
+    expect(sessionHasTerminal('agent_12345678-1234-1234-1234-123456789abc', 'cloudflare')).toBe(
+      true
+    );
+  });
+});

--- a/services/cloud-agent-next/src/session-plane.ts
+++ b/services/cloud-agent-next/src/session-plane.ts
@@ -1,0 +1,47 @@
+import type { SessionId } from './types.js';
+
+export type SessionPlane = 'legacy' | 'control';
+
+export type ControlPlaneOwnerEnv = {
+  CONTROL_PLANE_IDS?: string;
+};
+
+export function sessionPlaneFromId(sessionId: string): SessionPlane {
+  return sessionId.startsWith('workspace_') ? 'control' : 'legacy';
+}
+
+export function sessionSupportsTerminal(sessionId: string): boolean {
+  return sessionPlaneFromId(sessionId) !== 'control';
+}
+
+export function generateSessionId(plane: SessionPlane = 'legacy'): SessionId {
+  const id = crypto.randomUUID();
+  return plane === 'control' ? `workspace_${id}` : `agent_${id}`;
+}
+
+export function isControlPlaneOwner(
+  env: ControlPlaneOwnerEnv,
+  owner: { userId: string; orgId?: string }
+): boolean {
+  return (
+    ownerIdInList(env.CONTROL_PLANE_IDS, owner.userId) ||
+    ownerIdInList(env.CONTROL_PLANE_IDS, owner.orgId)
+  );
+}
+
+export function sessionPlaneForNewOwner(
+  env: ControlPlaneOwnerEnv,
+  owner: { userId: string; orgId?: string }
+): SessionPlane {
+  return isControlPlaneOwner(env, owner) ? 'control' : 'legacy';
+}
+
+function ownerIdInList(raw: string | undefined, id: string | undefined): boolean {
+  if (!raw) return false;
+  const items = raw
+    .split(',')
+    .map(value => value.trim())
+    .filter(Boolean);
+  if (items.includes('*')) return true;
+  return id !== undefined && items.includes(id);
+}

--- a/services/cloud-agent-next/src/session/agent-runtime.test.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.test.ts
@@ -44,7 +44,7 @@ function createMemoryStorage(
   } as MemoryRuntimeStorage & DurableObjectStorage;
 }
 
-function createMetadata(provider: 'cloudflare' = 'cloudflare'): SessionMetadata {
+function createMetadata(provider: 'cloudflare' | 'vercel' = 'cloudflare'): SessionMetadata {
   return {
     metadataSchemaVersion: 2,
     identity: {
@@ -129,30 +129,30 @@ describe('AgentRuntime', () => {
     expect(createSandbox).not.toHaveBeenCalled();
   });
 
-  it('returns a permanent delivery failure for an intentionally unavailable sandbox capability', async () => {
+  it('returns a permanent delivery failure for a disabled persisted Vercel capability', async () => {
     const createSandbox = vi.fn(
       () =>
         ({
           discoverSessionWrappers: async () => {
-            throw new AgentSandboxUnavailableError('Sandbox runtime is unavailable');
+            throw new AgentSandboxUnavailableError('Vercel sandbox runtime is unavailable');
           },
         }) as unknown as AgentSandbox
     );
     const runtime = createAgentRuntime({
       storage: createMemoryStorage(),
       env: { WORKER_URL: 'http://worker.test' } as Env,
-      getMetadata: async () => createMetadata(),
+      getMetadata: async () => createMetadata('vercel'),
       createAgentSandbox: createSandbox,
       getSessionIdForLogs: () => 'agent_runtime',
       sendToWrapper: () => false,
     });
 
-    await expect(runtime.send(createPlan(createMetadata()))).resolves.toEqual({
+    await expect(runtime.send(createPlan(createMetadata('vercel')))).resolves.toEqual({
       success: false,
       code: 'SANDBOX_CAPABILITY_UNAVAILABLE',
       error: 'Sandbox runtime delivery is unavailable for this session',
     });
-    expect(createSandbox).toHaveBeenCalledWith(createMetadata());
+    expect(createSandbox).toHaveBeenCalledWith(createMetadata('vercel'));
   });
 
   it('preflights cold delivery, authorizes its physical lease, and returns the existing queue result shape', async () => {

--- a/services/cloud-agent-next/src/session/agent-runtime.ts
+++ b/services/cloud-agent-next/src/session/agent-runtime.ts
@@ -4,6 +4,7 @@ import { createAgentSandbox } from '../agent-sandbox/factory.js';
 import {
   AgentSandboxUnavailableError,
   type AgentSandbox,
+  type AgentSandboxRuntimeContext,
   type WrapperInstanceLease,
   type WrapperObservation,
 } from '../agent-sandbox/protocol.js';
@@ -89,6 +90,7 @@ export type AgentRuntimeDependencies = {
     fence?: { wrapperGeneration: number; wrapperConnectionId: string }
   ) => boolean;
   getOrchestratorOverride?: () => AgentRuntimeOrchestrator | undefined;
+  sandboxRuntimeContext?: AgentSandboxRuntimeContext;
   createAgentSandbox?: (metadata: SessionMetadata) => AgentSandbox;
   discoverSessionWrappers?: (metadata: SessionMetadata) => Promise<WrapperObservation>;
   requestAlarmAtOrBefore?: (deadline: number) => Promise<void>;
@@ -144,7 +146,8 @@ export function createAgentRuntime(dependencies: AgentRuntimeDependencies): Agen
   } = dependencies;
   const resolveAgentSandbox =
     dependencies.createAgentSandbox ??
-    ((metadata: SessionMetadata) => createAgentSandbox(env, metadata));
+    ((metadata: SessionMetadata) =>
+      createAgentSandbox(env, metadata, dependencies.sandboxRuntimeContext));
   let orchestrator: AgentRuntimeOrchestrator | undefined;
 
   function getOrchestrator(): AgentRuntimeOrchestrator {

--- a/services/cloud-agent-next/src/shared/protocol.ts
+++ b/services/cloud-agent-next/src/shared/protocol.ts
@@ -251,8 +251,8 @@ export type CommandsAvailableData = {
 };
 
 /**
- * Regex for validating session IDs (agent_<uuid>).
+ * Regex for validating session IDs (`agent_<uuid>` legacy, `workspace_<uuid>` control plane).
  * Shared between worker (zod schema) and wrapper (defense-in-depth validation).
  */
 export const SESSION_ID_RE =
-  /^agent_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+  /^(agent|workspace)_[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -126,10 +126,10 @@ export type SandboxId =
   | `${string}__${string}`
   | `${string}__${string}__${string}`;
 
-export type AgentSandboxProvider = 'cloudflare';
+export type AgentSandboxProvider = 'cloudflare' | 'vercel';
 
 /** Unique identifier for a session within a sandbox */
-export type SessionId = `agent_${string}`;
+export type SessionId = `agent_${string}` | `workspace_${string}`;
 
 export type SessionContext = {
   sandboxId: SandboxId;
@@ -577,6 +577,18 @@ export type Env = {
   GITHUB_APP_BOT_USER_ID?: string;
   /** Comma-separated org IDs that use per-session Cloudflare sandbox containers */
   PER_SESSION_SANDBOX_ORG_IDS?: string;
+  /** Comma-separated user or org IDs admitted to the call-home control plane. `*` includes personal. */
+  CONTROL_PLANE_IDS?: string;
+  VERCEL_TOKEN?: string;
+  VERCEL_TEAM_ID?: string;
+  VERCEL_PROJECT_ID?: string;
+  VERCEL_SANDBOX_SNAPSHOT_ID?: string;
+  VERCEL_SANDBOX_RUNTIME_BUILD_ID?: string;
+  VERCEL_SANDBOX_RUNTIME?: string;
+  VERCEL_SANDBOX_INITIAL_TIMEOUT_MS?: string;
+  VERCEL_SANDBOX_EXTEND_DURATION_MS?: string;
+  /** Comma-separated org IDs routed to Vercel. Empty is off. `*` includes personal. */
+  VERCEL_SANDBOX_ORG_IDS?: string;
   /** Comma-separated org IDs whose GitHub token uses credential containment, or `*` for all orgs */
   GITHUB_TOKEN_CONTAINMENT_ORG_IDS?: string;
   /** Comma-separated org IDs whose GitLab token uses credential containment, or `*` for all orgs */

--- a/services/cloud-agent-next/tsconfig.json
+++ b/services/cloud-agent-next/tsconfig.json
@@ -16,6 +16,7 @@
   "include": [
     "worker-configuration.d.ts",
     "src/**/*.ts",
+    "scripts/**/*.ts",
     "drizzle/migrations.js",
     "vitest.config.ts"
   ]

--- a/services/cloud-agent-next/vitest.config.ts
+++ b/services/cloud-agent-next/vitest.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
     name: 'unit',
     globals: true,
     environment: 'node',
-    include: ['src/**/*.test.ts', 'test/unit/**/*.test.ts'],
+    include: ['src/**/*.test.ts', 'scripts/**/*.test.ts', 'test/unit/**/*.test.ts'],
     exclude: ['test/integration/**/*.test.ts'],
     coverage: {
       provider: 'v8',


### PR DESCRIPTION
## Stack

1. `sticky-slider-tunnels` — local public tunnels
2. **This PR** — gated Vercel sandbox provider
3. `sticky-slider` — call-home control plane

## Summary

Adds the Vercel agent-sandbox adapter, snapshot harness, and metadata runtime persistence. Enrollment stays off unless `VERCEL_SANDBOX_ORG_IDS` is set.

Call-home `workspace_` sessions and the control-plane DOs land in the next PR.

