### PR TITLE
fix(cloud-agent): add UTC to scheduled trigger timezones

### DIFF
--- a/apps/web/src/components/webhook-triggers/TimezoneSelector.tsx
+++ b/apps/web/src/components/webhook-triggers/TimezoneSelector.tsx
@@ -24,7 +24,7 @@ type TimezoneSelectorProps = {
 /** Get a stable list of IANA timezones. */
 function getTimezones(): string[] {
   try {
-    return Intl.supportedValuesOf('timeZone');
+    return ['UTC', ...Intl.supportedValuesOf('timeZone')];
   } catch {
     // Fallback for older runtimes
     return [


### PR DESCRIPTION
## Summary

- Add UTC to the shared timezone picker used by scheduled cloud agent triggers.
- Keep UTC selectable even though `Intl.supportedValuesOf("timeZone")` excludes it from its timezone list.

## Verification

- Manual UI verification was not performed; the change directly adds the existing backend-supported UTC timezone to the shared picker options.

## Visual Changes

N/A

## Reviewer Notes

- The shared picker is also used by KiloClaw scheduled triggers, which gain the same UTC option.