### PR TITLE
feat(web): paginate cloud-agent chat history

### DIFF
--- a/apps/web/src/components/cloud-agent-next/ChildSessionDrawer.tsx
+++ b/apps/web/src/components/cloud-agent-next/ChildSessionDrawer.tsx
@@ -11,15 +11,34 @@ import {
   SheetHeader,
   SheetTitle,
 } from '@/components/ui/sheet';
-import type { ChildSessionHydrationState } from '@kilocode/cloud-agent-sdk';
+import type { ChildSessionHydrationState, OlderMessagesError } from '@kilocode/cloud-agent-sdk';
 import { useManager } from './CloudAgentProvider';
 import { MessageBubble } from './MessageBubble';
 import { MessageErrorBoundary } from './MessageErrorBoundary';
 import type { ChildSessionDrawerEntry, OpenChildSession } from './ChildSessionSection';
+import { OlderMessagesHeader } from './OlderMessagesHeader';
+import {
+  shouldAnnounceOlderMessagesArrival,
+  useOlderMessagesPagination,
+} from './older-messages-scroll';
 
 const IDLE_HYDRATION_STATE: ChildSessionHydrationState = { status: 'idle' };
 const AUTO_SCROLL_PAUSE_DISTANCE_PX = 20;
 const AUTO_SCROLL_RESUME_DISTANCE_PX = 100;
+
+type ReadyPagination = {
+  hasOlder: boolean;
+  isLoadingOlder: boolean;
+  olderError: OlderMessagesError | null;
+  omittedItemCount: number;
+};
+
+const IDLE_PAGINATION: ReadyPagination = {
+  hasOlder: false,
+  isLoadingOlder: false,
+  olderError: null,
+  omittedItemCount: 0,
+};
 
 type ChildSessionDrawerProps = {
   stack: ChildSessionDrawerEntry[];
@@ -58,6 +77,35 @@ export function ChildSessionDrawer({
   const isAutoScrollingRef = useRef(false);
   const autoScrollRunRef = useRef(0);
   const lastScrollTopRef = useRef(0);
+  const olderArrivalInitializedRef = useRef(false);
+  const olderArrivalCountRef = useRef(0);
+  const olderArrivalNewestKeyRef = useRef<string | null>(null);
+  const [olderArrivalAnnouncement, setOlderArrivalAnnouncement] = useState('');
+  const readyPagination: ReadyPagination =
+    hydrationState.status === 'ready'
+      ? {
+          hasOlder: hydrationState.hasOlder,
+          isLoadingOlder: hydrationState.isLoadingOlder,
+          olderError: hydrationState.olderError,
+          omittedItemCount: hydrationState.omittedItemCount,
+        }
+      : IDLE_PAGINATION;
+
+  const loadOlderChildMessages = useCallback(() => {
+    if (!selectedSessionId) return;
+    void manager.loadOlderChildMessages(selectedSessionId);
+  }, [manager, selectedSessionId]);
+  const { requestOlderMessages, tryLoadOlderFromScroll } = useOlderMessagesPagination({
+    scrollElementRef: scrollContainerRef,
+    hasOlderMessages: readyPagination.hasOlder,
+    isLoadingOlderMessages: readyPagination.isLoadingOlder,
+    olderMessagesError: readyPagination.olderError,
+    onLoad: loadOlderChildMessages,
+    isProgrammaticScrollRef: isAutoScrollingRef,
+    lastScrollTopRef,
+    resetKey: selectedSessionId,
+    overflowCheckKey: messages.length,
+  });
   const autoScrollFrameRef = useRef(0);
   const followUpAutoScrollFrameRef = useRef(0);
   const delayedAutoScrollRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -138,9 +186,32 @@ export function ChildSessionDrawer({
     shouldAutoScrollRef.current = true;
     setShouldAutoScroll(true);
     lastScrollTopRef.current = 0;
+    olderArrivalInitializedRef.current = false;
+    olderArrivalCountRef.current = 0;
+    olderArrivalNewestKeyRef.current = null;
+    setOlderArrivalAnnouncement('');
     setShowScrollButton(false);
     scheduleScrollToBottom();
   }, [selectedSessionId, scheduleScrollToBottom]);
+
+  useEffect(() => {
+    const newest = messages.at(-1)?.info.id ?? null;
+    const nextCount = messages.length;
+    if (
+      shouldAnnounceOlderMessagesArrival({
+        wasInitialized: olderArrivalInitializedRef.current,
+        previousCount: olderArrivalCountRef.current,
+        nextCount,
+        previousNewestKey: olderArrivalNewestKeyRef.current,
+        nextNewestKey: newest,
+      })
+    ) {
+      setOlderArrivalAnnouncement('Earlier messages loaded');
+    }
+    olderArrivalInitializedRef.current = true;
+    olderArrivalCountRef.current = nextCount;
+    olderArrivalNewestKeyRef.current = newest;
+  }, [messages]);
 
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
@@ -165,7 +236,9 @@ export function ChildSessionDrawer({
       shouldAutoScrollRef.current = true;
       setShouldAutoScroll(true);
     }
-  }, [cancelScheduledAutoScroll]);
+
+    tryLoadOlderFromScroll(el.scrollTop);
+  }, [cancelScheduledAutoScroll, tryLoadOlderFromScroll]);
 
   const scrollToBottom = useCallback(() => {
     shouldAutoScrollRef.current = true;
@@ -248,6 +321,17 @@ export function ChildSessionDrawer({
             onScroll={handleScroll}
           >
             <div ref={messagesContentRef}>
+              <div className="sr-only" aria-live="polite">
+                {olderArrivalAnnouncement}
+              </div>
+              {hydrationState.status === 'ready' && (
+                <OlderMessagesHeader
+                  isLoadingOlderMessages={readyPagination.isLoadingOlder}
+                  olderMessagesError={readyPagination.olderError}
+                  olderMessagesOmittedItemCount={readyPagination.omittedItemCount}
+                  onRetry={requestOlderMessages}
+                />
+              )}
               {hydrationState.status === 'loading' && (
                 <div className="border-border bg-muted/20 text-muted-foreground mb-4 flex items-center gap-2 rounded-lg border px-3 py-2 text-sm">
                   <Loader2 className="size-4 shrink-0 animate-spin" />

--- a/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudAgentProvider.tsx
@@ -19,6 +19,7 @@ import {
 import type { SendMessagePayload } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { CLOUD_AGENT_NEXT_WS_URL, SESSION_INGEST_WS_URL } from '@/lib/constants';
 import { usePostHog } from 'posthog-js/react';
+import { fetchWebSessionSnapshotPage } from './session-page-adapter';
 
 const ManagerContext = createContext<SessionManager | null>(null);
 const UserWebConnectionContext = createContext<UserWebConnection | null>(null);
@@ -145,6 +146,8 @@ export function CloudAgentProvider({ children, organizationId }: CloudAgentProvi
           messages: messagesResult.messages as SessionSnapshot['messages'],
         };
       },
+
+      fetchSnapshotPage: (id, options) => fetchWebSessionSnapshotPage(trpcClient, id, options),
 
       userWebConnection: sharedConnection,
 

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -30,6 +30,12 @@ import { SuggestionContextProvider } from './SuggestionCard';
 import { SessionContinuationPanel } from './SessionContinuationPanel';
 import { CloudAgentTerminalPane } from './CloudAgentTerminalDock';
 import { CloudAgentBillingError } from './CloudAgentBillingError';
+import { OlderMessagesHeader } from './OlderMessagesHeader';
+import {
+  OLDER_MESSAGES_NEAR_BOTTOM_PX,
+  shouldAnnounceOlderMessagesArrival,
+  useOlderMessagesPagination,
+} from './older-messages-scroll';
 import { billingPayerPresentation } from './billing-payer-presentation';
 import type { OrganizationRole } from '@/lib/organizations/organization-types';
 import { CloudAgentWorkspaceTabs } from './CloudAgentWorkspaceTabs';
@@ -284,6 +290,10 @@ export default function CloudChatPage({
   const remoteModelState = useAtomValue(manager.atoms.remoteModelState);
   const observedModel = useAtomValue(manager.atoms.observedModel);
   const remoteModelOverride = useAtomValue(manager.atoms.remoteModelOverride);
+  const hasOlderMessages = useAtomValue(manager.atoms.hasOlderMessages);
+  const isLoadingOlderMessages = useAtomValue(manager.atoms.isLoadingOlderMessages);
+  const olderMessagesError = useAtomValue(manager.atoms.olderMessagesError);
+  const olderMessagesOmittedItemCount = useAtomValue(manager.atoms.olderMessagesOmittedItemCount);
 
   useCliSessionPresence(fetchedSessionData?.kiloSessionId ?? null);
 
@@ -361,6 +371,24 @@ export default function CloudChatPage({
   const isAutoScrollingRef = useRef(false);
   const autoScrollRunRef = useRef(0);
   const lastScrollTopRef = useRef(0);
+  const wasNearBottomRef = useRef(true);
+  const olderArrivalInitializedRef = useRef(false);
+  const olderArrivalCountRef = useRef(0);
+  const olderArrivalNewestKeyRef = useRef<string | null>(null);
+  const [olderArrivalAnnouncement, setOlderArrivalAnnouncement] = useState('');
+
+  const loadOlderMessages = useCallback(() => manager.loadOlderMessages(), [manager]);
+  const { requestOlderMessages, tryLoadOlderFromScroll } = useOlderMessagesPagination({
+    scrollElementRef: scrollContainerRef,
+    hasOlderMessages,
+    isLoadingOlderMessages,
+    olderMessagesError,
+    onLoad: loadOlderMessages,
+    isProgrammaticScrollRef: isAutoScrollingRef,
+    lastScrollTopRef,
+    resetKey: sessionIdFromParams,
+    overflowCheckKey: staticMessages.length + dynamicMessages.length,
+  });
 
   const autoScrollFrameRef = useRef(0);
   const followUpAutoScrollFrameRef = useRef(0);
@@ -448,9 +476,33 @@ export default function CloudChatPage({
 
     setChatUI({ shouldAutoScroll: true });
     lastScrollTopRef.current = 0;
+    wasNearBottomRef.current = true;
+    olderArrivalInitializedRef.current = false;
+    olderArrivalCountRef.current = 0;
+    olderArrivalNewestKeyRef.current = null;
+    setOlderArrivalAnnouncement('');
     setShowScrollButton(false);
     scheduleScrollToBottom();
   }, [sessionIdFromParams, setChatUI, scheduleScrollToBottom]);
+
+  useEffect(() => {
+    const newest = dynamicMessages.at(-1)?.info.id ?? staticMessages.at(-1)?.info.id ?? null;
+    const nextCount = staticMessages.length + dynamicMessages.length;
+    if (
+      shouldAnnounceOlderMessagesArrival({
+        wasInitialized: olderArrivalInitializedRef.current,
+        previousCount: olderArrivalCountRef.current,
+        nextCount,
+        previousNewestKey: olderArrivalNewestKeyRef.current,
+        nextNewestKey: newest,
+      })
+    ) {
+      setOlderArrivalAnnouncement('Earlier messages loaded');
+    }
+    olderArrivalInitializedRef.current = true;
+    olderArrivalCountRef.current = nextCount;
+    olderArrivalNewestKeyRef.current = newest;
+  }, [dynamicMessages, staticMessages]);
 
   const handleScroll = useCallback(() => {
     const el = scrollContainerRef.current;
@@ -468,10 +520,18 @@ export default function CloudChatPage({
 
     if (scrolledUp) {
       setChatUI({ shouldAutoScroll: false });
-    } else if (distanceFromBottom < 100) {
+    } else if (distanceFromBottom < OLDER_MESSAGES_NEAR_BOTTOM_PX) {
       setChatUI({ shouldAutoScroll: true });
     }
-  }, [setChatUI]);
+
+    tryLoadOlderFromScroll(el.scrollTop);
+
+    const isNearBottom = distanceFromBottom < OLDER_MESSAGES_NEAR_BOTTOM_PX;
+    if (isNearBottom && !wasNearBottomRef.current) {
+      manager.trimRetainedHistory();
+    }
+    wasNearBottomRef.current = isNearBottom;
+  }, [manager, setChatUI, tryLoadOlderFromScroll]);
 
   const scrollToBottom = useCallback(() => {
     setChatUI({ shouldAutoScroll: true });
@@ -888,6 +948,15 @@ export default function CloudChatPage({
                           onScroll={handleScroll}
                         >
                           <div ref={messagesContentRef}>
+                            <div className="sr-only" aria-live="polite">
+                              {olderArrivalAnnouncement}
+                            </div>
+                            <OlderMessagesHeader
+                              isLoadingOlderMessages={isLoadingOlderMessages}
+                              olderMessagesError={olderMessagesError}
+                              olderMessagesOmittedItemCount={olderMessagesOmittedItemCount}
+                              onRetry={requestOlderMessages}
+                            />
                             <StaticMessages
                               messages={staticMessages}
                               pendingMessages={pendingMessages}

--- a/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
+++ b/apps/web/src/components/cloud-agent-next/CloudChatPage.tsx
@@ -387,7 +387,7 @@ export default function CloudChatPage({
     isProgrammaticScrollRef: isAutoScrollingRef,
     lastScrollTopRef,
     resetKey: sessionIdFromParams,
-    overflowCheckKey: staticMessages.length + dynamicMessages.length,
+    overflowCheckKey: `${chatTabActive}:${staticMessages.length + dynamicMessages.length}`,
   });
 
   const autoScrollFrameRef = useRef(0);

--- a/apps/web/src/components/cloud-agent-next/OlderMessagesHeader.tsx
+++ b/apps/web/src/components/cloud-agent-next/OlderMessagesHeader.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import type { OlderMessagesError } from '@kilocode/cloud-agent-sdk';
+import { Button } from '@/components/ui/button';
+import { selectOlderMessagesHeaderState } from './older-messages-scroll';
+
+type OlderMessagesHeaderProps = {
+  isLoadingOlderMessages: boolean;
+  olderMessagesError: OlderMessagesError | null;
+  olderMessagesOmittedItemCount: number;
+  onRetry: () => void;
+};
+
+function omittedMessage(count: number): string {
+  if (count === 1) {
+    return 'Some earlier items from this session could not be displayed.';
+  }
+  return `${count} earlier items from this session could not be displayed.`;
+}
+
+export function OlderMessagesHeader({
+  isLoadingOlderMessages,
+  olderMessagesError,
+  olderMessagesOmittedItemCount,
+  onRetry,
+}: OlderMessagesHeaderProps) {
+  const state = selectOlderMessagesHeaderState({
+    isLoadingOlderMessages,
+    olderMessagesError,
+    olderMessagesOmittedItemCount,
+  });
+
+  if (state.kind === 'hidden') {
+    return null;
+  }
+
+  if (state.kind === 'retryable') {
+    return (
+      <div className="mb-3 flex items-center justify-between gap-3">
+        <p className="text-muted-foreground text-sm">Couldn't load earlier messages.</p>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={onRetry}
+          className="min-h-11 shrink-0"
+        >
+          Retry
+        </Button>
+      </div>
+    );
+  }
+
+  const text =
+    state.kind === 'invalid_data'
+      ? "Earlier messages aren't available."
+      : state.kind === 'too_large'
+        ? 'Earlier messages are too large to load.'
+        : omittedMessage(state.count);
+
+  return <p className="text-muted-foreground mb-3 text-sm">{text}</p>;
+}

--- a/apps/web/src/components/cloud-agent-next/older-messages-scroll.test.ts
+++ b/apps/web/src/components/cloud-agent-next/older-messages-scroll.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from '@jest/globals';
 import { type OlderMessagesError } from '@kilocode/cloud-agent-sdk';
 import {
+  canAutoloadOlderMessages,
   restoreScrollAfterPrepend,
   selectOlderMessagesHeaderState,
   shouldAnnounceOlderMessagesArrival,
@@ -98,6 +99,20 @@ describe('shouldTriggerOlderMessagesLoad', () => {
         olderMessagesError: error('retryable'),
       })
     ).toBe(false);
+  });
+});
+
+describe('canAutoloadOlderMessages', () => {
+  it('returns false when the scroller is hidden', () => {
+    expect(canAutoloadOlderMessages({ hidden: true, clientHeight: 400 })).toBe(false);
+  });
+
+  it('returns false when the scroller has no height', () => {
+    expect(canAutoloadOlderMessages({ hidden: false, clientHeight: 0 })).toBe(false);
+  });
+
+  it('returns true when the scroller is visible and has height', () => {
+    expect(canAutoloadOlderMessages({ hidden: false, clientHeight: 400 })).toBe(true);
   });
 });
 

--- a/apps/web/src/components/cloud-agent-next/older-messages-scroll.test.ts
+++ b/apps/web/src/components/cloud-agent-next/older-messages-scroll.test.ts
@@ -1,0 +1,174 @@
+import { describe, expect, it } from '@jest/globals';
+import { type OlderMessagesError } from '@kilocode/cloud-agent-sdk';
+import {
+  restoreScrollAfterPrepend,
+  selectOlderMessagesHeaderState,
+  shouldAnnounceOlderMessagesArrival,
+  shouldTriggerOlderMessagesLoad,
+} from './older-messages-scroll';
+
+function error(kind: OlderMessagesError['kind']): OlderMessagesError {
+  return { kind };
+}
+
+describe('shouldTriggerOlderMessagesLoad', () => {
+  it('returns false when there are no older messages', () => {
+    expect(
+      shouldTriggerOlderMessagesLoad({
+        hasOlderMessages: false,
+        isLoadingOlderMessages: false,
+        isInFlight: false,
+        olderMessagesError: null,
+      })
+    ).toBe(false);
+  });
+
+  it('returns false when a page is already loading', () => {
+    expect(
+      shouldTriggerOlderMessagesLoad({
+        hasOlderMessages: true,
+        isLoadingOlderMessages: true,
+        isInFlight: false,
+        olderMessagesError: null,
+      })
+    ).toBe(false);
+  });
+
+  it('returns false while the local in-flight latch is still set', () => {
+    expect(
+      shouldTriggerOlderMessagesLoad({
+        hasOlderMessages: true,
+        isLoadingOlderMessages: false,
+        isInFlight: true,
+        olderMessagesError: null,
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for a non-retryable invalid_data terminal failure', () => {
+    expect(
+      shouldTriggerOlderMessagesLoad({
+        hasOlderMessages: true,
+        isLoadingOlderMessages: false,
+        isInFlight: false,
+        olderMessagesError: error('invalid_data'),
+      })
+    ).toBe(false);
+  });
+
+  it('returns false for a non-retryable too_large terminal failure', () => {
+    expect(
+      shouldTriggerOlderMessagesLoad({
+        hasOlderMessages: true,
+        isLoadingOlderMessages: false,
+        isInFlight: false,
+        olderMessagesError: error('too_large'),
+      })
+    ).toBe(false);
+  });
+
+  it('returns true for a retryable failure so the gesture can re-trigger', () => {
+    expect(
+      shouldTriggerOlderMessagesLoad({
+        hasOlderMessages: true,
+        isLoadingOlderMessages: false,
+        isInFlight: false,
+        olderMessagesError: error('retryable'),
+      })
+    ).toBe(true);
+  });
+
+  it('returns true in the happy path with no error and a cursor', () => {
+    expect(
+      shouldTriggerOlderMessagesLoad({
+        hasOlderMessages: true,
+        isLoadingOlderMessages: false,
+        isInFlight: false,
+        olderMessagesError: null,
+      })
+    ).toBe(true);
+  });
+
+  it('gives the loading/in-flight guards priority over the retryable path', () => {
+    expect(
+      shouldTriggerOlderMessagesLoad({
+        hasOlderMessages: true,
+        isLoadingOlderMessages: true,
+        isInFlight: true,
+        olderMessagesError: error('retryable'),
+      })
+    ).toBe(false);
+  });
+});
+
+describe('restoreScrollAfterPrepend', () => {
+  it('adds the height delta to scrollTop', () => {
+    const el = { scrollTop: 12, scrollHeight: 800 };
+    restoreScrollAfterPrepend(el, 500);
+    expect(el.scrollTop).toBe(312);
+  });
+
+  it('leaves scrollTop unchanged when height did not grow', () => {
+    const el = { scrollTop: 40, scrollHeight: 400 };
+    restoreScrollAfterPrepend(el, 400);
+    expect(el.scrollTop).toBe(40);
+  });
+});
+
+describe('selectOlderMessagesHeaderState', () => {
+  it('hides the banner while loading with no omitted count', () => {
+    expect(
+      selectOlderMessagesHeaderState({
+        isLoadingOlderMessages: true,
+        olderMessagesError: null,
+        olderMessagesOmittedItemCount: 0,
+      })
+    ).toEqual({ kind: 'hidden' });
+  });
+
+  it('keeps the omitted banner through a subsequent load', () => {
+    expect(
+      selectOlderMessagesHeaderState({
+        isLoadingOlderMessages: true,
+        olderMessagesError: null,
+        olderMessagesOmittedItemCount: 5,
+      })
+    ).toEqual({ kind: 'omitted', count: 5 });
+  });
+
+  it('prefers a retryable error over loading', () => {
+    expect(
+      selectOlderMessagesHeaderState({
+        isLoadingOlderMessages: true,
+        olderMessagesError: error('retryable'),
+        olderMessagesOmittedItemCount: 0,
+      })
+    ).toEqual({ kind: 'retryable' });
+  });
+});
+
+describe('shouldAnnounceOlderMessagesArrival', () => {
+  it('announces only when items prepend after the list has painted', () => {
+    expect(
+      shouldAnnounceOlderMessagesArrival({
+        wasInitialized: true,
+        previousCount: 10,
+        nextCount: 20,
+        previousNewestKey: 'msg_new',
+        nextNewestKey: 'msg_new',
+      })
+    ).toBe(true);
+  });
+
+  it('skips the initial paint', () => {
+    expect(
+      shouldAnnounceOlderMessagesArrival({
+        wasInitialized: false,
+        previousCount: 0,
+        nextCount: 10,
+        previousNewestKey: null,
+        nextNewestKey: 'msg_new',
+      })
+    ).toBe(false);
+  });
+});

--- a/apps/web/src/components/cloud-agent-next/older-messages-scroll.ts
+++ b/apps/web/src/components/cloud-agent-next/older-messages-scroll.ts
@@ -41,6 +41,10 @@ export function restoreScrollAfterPrepend(
   el.scrollTop += el.scrollHeight - previousScrollHeight;
 }
 
+export function canAutoloadOlderMessages(el: { hidden: boolean; clientHeight: number }): boolean {
+  return !el.hidden && el.clientHeight > 0;
+}
+
 export type OlderMessagesHeaderState =
   | { kind: 'hidden' }
   | { kind: 'retryable' }
@@ -171,12 +175,17 @@ export function useOlderMessagesPagination({
     const el = scrollElementRef.current;
     pendingHeightRef.current = null;
     if (!el) return;
+    if (olderMessagesError != null) return;
     isProgrammaticScrollRef.current = true;
     restoreScrollAfterPrepend(el, previousHeight);
     lastScrollTopRef.current = el.scrollTop;
     requestAnimationFrame(() => {
       isProgrammaticScrollRef.current = false;
-      if (el.scrollTop < OLDER_MESSAGES_NEAR_TOP_PX && olderMessagesError === null) {
+      if (
+        canAutoloadOlderMessages(el) &&
+        el.scrollTop < OLDER_MESSAGES_NEAR_TOP_PX &&
+        olderMessagesError === null
+      ) {
         requestOlderMessages();
       }
     });
@@ -193,6 +202,7 @@ export function useOlderMessagesPagination({
     if (olderMessagesError) return;
     const el = scrollElementRef.current;
     if (!el) return;
+    if (!canAutoloadOlderMessages(el)) return;
     if (el.scrollHeight <= el.clientHeight) {
       requestOlderMessages();
     }

--- a/apps/web/src/components/cloud-agent-next/older-messages-scroll.ts
+++ b/apps/web/src/components/cloud-agent-next/older-messages-scroll.ts
@@ -41,7 +41,7 @@ export function restoreScrollAfterPrepend(
   el.scrollTop += el.scrollHeight - previousScrollHeight;
 }
 
-export function canAutoloadOlderMessages(el: { hidden: boolean; clientHeight: number }): boolean {
+export function canAutoloadOlderMessages(el: Pick<HTMLElement, 'hidden' | 'clientHeight'>): boolean {
   return !el.hidden && el.clientHeight > 0;
 }
 

--- a/apps/web/src/components/cloud-agent-next/older-messages-scroll.ts
+++ b/apps/web/src/components/cloud-agent-next/older-messages-scroll.ts
@@ -41,7 +41,9 @@ export function restoreScrollAfterPrepend(
   el.scrollTop += el.scrollHeight - previousScrollHeight;
 }
 
-export function canAutoloadOlderMessages(el: Pick<HTMLElement, 'hidden' | 'clientHeight'>): boolean {
+export function canAutoloadOlderMessages(
+  el: Pick<HTMLElement, 'hidden' | 'clientHeight'>
+): boolean {
   return !el.hidden && el.clientHeight > 0;
 }
 

--- a/apps/web/src/components/cloud-agent-next/older-messages-scroll.ts
+++ b/apps/web/src/components/cloud-agent-next/older-messages-scroll.ts
@@ -1,0 +1,211 @@
+'use client';
+
+import { useCallback, useEffect, useLayoutEffect, useRef, type RefObject } from 'react';
+import { type OlderMessagesError } from '@kilocode/cloud-agent-sdk';
+
+export const OLDER_MESSAGES_NEAR_TOP_PX = 80;
+export const OLDER_MESSAGES_NEAR_BOTTOM_PX = 100;
+
+type ShouldTriggerOlderMessagesLoadInputs = {
+  hasOlderMessages: boolean;
+  isLoadingOlderMessages: boolean;
+  isInFlight: boolean;
+  olderMessagesError: OlderMessagesError | null;
+};
+
+export function shouldTriggerOlderMessagesLoad({
+  hasOlderMessages,
+  isLoadingOlderMessages,
+  isInFlight,
+  olderMessagesError,
+}: ShouldTriggerOlderMessagesLoadInputs): boolean {
+  if (!hasOlderMessages) {
+    return false;
+  }
+  if (isLoadingOlderMessages) {
+    return false;
+  }
+  if (isInFlight) {
+    return false;
+  }
+  if (olderMessagesError && olderMessagesError.kind !== 'retryable') {
+    return false;
+  }
+  return true;
+}
+
+export function restoreScrollAfterPrepend(
+  el: { scrollTop: number; scrollHeight: number },
+  previousScrollHeight: number
+): void {
+  el.scrollTop += el.scrollHeight - previousScrollHeight;
+}
+
+export type OlderMessagesHeaderState =
+  | { kind: 'hidden' }
+  | { kind: 'retryable' }
+  | { kind: 'invalid_data' }
+  | { kind: 'too_large' }
+  | { kind: 'omitted'; count: number };
+
+export function selectOlderMessagesHeaderState({
+  isLoadingOlderMessages,
+  olderMessagesError,
+  olderMessagesOmittedItemCount,
+}: {
+  isLoadingOlderMessages: boolean;
+  olderMessagesError: OlderMessagesError | null;
+  olderMessagesOmittedItemCount: number;
+}): OlderMessagesHeaderState {
+  if (olderMessagesError) {
+    if (olderMessagesError.kind === 'retryable') {
+      return { kind: 'retryable' };
+    }
+    if (olderMessagesError.kind === 'invalid_data') {
+      return { kind: 'invalid_data' };
+    }
+    return { kind: 'too_large' };
+  }
+  if (isLoadingOlderMessages) {
+    if (olderMessagesOmittedItemCount > 0) {
+      return { kind: 'omitted', count: olderMessagesOmittedItemCount };
+    }
+    return { kind: 'hidden' };
+  }
+  if (olderMessagesOmittedItemCount > 0) {
+    return { kind: 'omitted', count: olderMessagesOmittedItemCount };
+  }
+  return { kind: 'hidden' };
+}
+
+type ShouldAnnounceOlderMessagesArrivalInputs = {
+  wasInitialized: boolean;
+  previousCount: number;
+  nextCount: number;
+  previousNewestKey: string | null;
+  nextNewestKey: string | null;
+};
+
+export function shouldAnnounceOlderMessagesArrival({
+  wasInitialized,
+  previousCount,
+  nextCount,
+  previousNewestKey,
+  nextNewestKey,
+}: ShouldAnnounceOlderMessagesArrivalInputs): boolean {
+  if (!wasInitialized) {
+    return false;
+  }
+  if (nextCount <= previousCount) {
+    return false;
+  }
+  if (previousNewestKey == null || nextNewestKey == null) {
+    return false;
+  }
+  return previousNewestKey === nextNewestKey;
+}
+
+type UseOlderMessagesPaginationInputs = {
+  scrollElementRef: RefObject<HTMLElement | null>;
+  hasOlderMessages: boolean;
+  isLoadingOlderMessages: boolean;
+  olderMessagesError: OlderMessagesError | null;
+  onLoad: () => void | Promise<void>;
+  isProgrammaticScrollRef: RefObject<boolean>;
+  lastScrollTopRef: RefObject<number>;
+  resetKey: string | null | undefined;
+  overflowCheckKey?: unknown;
+};
+
+export function useOlderMessagesPagination({
+  scrollElementRef,
+  hasOlderMessages,
+  isLoadingOlderMessages,
+  olderMessagesError,
+  onLoad,
+  isProgrammaticScrollRef,
+  lastScrollTopRef,
+  resetKey,
+  overflowCheckKey,
+}: UseOlderMessagesPaginationInputs): {
+  requestOlderMessages: () => void;
+  tryLoadOlderFromScroll: (scrollTop: number) => void;
+} {
+  const inFlightRef = useRef(false);
+  const pendingHeightRef = useRef<number | null>(null);
+  const wasLoadingRef = useRef(isLoadingOlderMessages);
+
+  useEffect(() => {
+    inFlightRef.current = false;
+    pendingHeightRef.current = null;
+    wasLoadingRef.current = false;
+  }, [resetKey]);
+
+  const requestOlderMessages = useCallback(() => {
+    if (
+      !shouldTriggerOlderMessagesLoad({
+        hasOlderMessages,
+        isLoadingOlderMessages,
+        isInFlight: inFlightRef.current,
+        olderMessagesError,
+      })
+    ) {
+      return;
+    }
+    const el = scrollElementRef.current;
+    if (el) pendingHeightRef.current = el.scrollHeight;
+    inFlightRef.current = true;
+    void Promise.resolve(onLoad()).finally(() => {
+      queueMicrotask(() => {
+        inFlightRef.current = false;
+      });
+    });
+  }, [hasOlderMessages, isLoadingOlderMessages, olderMessagesError, onLoad, scrollElementRef]);
+
+  useLayoutEffect(() => {
+    const wasLoading = wasLoadingRef.current;
+    wasLoadingRef.current = isLoadingOlderMessages;
+    if (!wasLoading || isLoadingOlderMessages) return;
+    const previousHeight = pendingHeightRef.current;
+    if (previousHeight == null) return;
+    const el = scrollElementRef.current;
+    pendingHeightRef.current = null;
+    if (!el) return;
+    isProgrammaticScrollRef.current = true;
+    restoreScrollAfterPrepend(el, previousHeight);
+    lastScrollTopRef.current = el.scrollTop;
+    requestAnimationFrame(() => {
+      isProgrammaticScrollRef.current = false;
+      if (el.scrollTop < OLDER_MESSAGES_NEAR_TOP_PX && olderMessagesError === null) {
+        requestOlderMessages();
+      }
+    });
+  }, [
+    isLoadingOlderMessages,
+    isProgrammaticScrollRef,
+    lastScrollTopRef,
+    olderMessagesError,
+    requestOlderMessages,
+    scrollElementRef,
+  ]);
+
+  useLayoutEffect(() => {
+    if (olderMessagesError) return;
+    const el = scrollElementRef.current;
+    if (!el) return;
+    if (el.scrollHeight <= el.clientHeight) {
+      requestOlderMessages();
+    }
+  }, [olderMessagesError, overflowCheckKey, requestOlderMessages, scrollElementRef]);
+
+  const tryLoadOlderFromScroll = useCallback(
+    (scrollTop: number) => {
+      if (scrollTop < OLDER_MESSAGES_NEAR_TOP_PX) {
+        requestOlderMessages();
+      }
+    },
+    [requestOlderMessages]
+  );
+
+  return { requestOlderMessages, tryLoadOlderFromScroll };
+}

--- a/apps/web/src/components/cloud-agent-next/session-page-adapter.test.ts
+++ b/apps/web/src/components/cloud-agent-next/session-page-adapter.test.ts
@@ -1,0 +1,251 @@
+import { describe, expect, it, jest } from '@jest/globals';
+import {
+  type KiloSdkMessageHistory,
+  type KiloSdkMessageHistoryPage,
+  type KiloSdkStoredMessage,
+  type KiloSessionId,
+} from '@kilocode/cloud-agent-sdk';
+import { fetchWebSessionSnapshotPage, type SessionPageTrpcClient } from './session-page-adapter';
+
+function kiloSessionId(id: string): KiloSessionId {
+  return id as KiloSessionId;
+}
+
+function storedMessage(
+  overrides: {
+    id?: string;
+    sessionID?: string;
+    created?: number;
+    text?: string;
+  } = {}
+): KiloSdkStoredMessage {
+  const id = overrides.id ?? 'msg_user_01';
+  const sessionID = overrides.sessionID ?? 'ses_123';
+  const created = overrides.created ?? 1_761_000_000_100;
+  const text = overrides.text ?? 'hello';
+
+  return {
+    info: {
+      id,
+      sessionID,
+      role: 'user',
+      time: { created },
+      agent: 'build',
+      model: { providerID: 'openrouter', modelID: 'anthropic/claude-sonnet-4' },
+    },
+    parts: [
+      {
+        id: `${id}-text`,
+        sessionID,
+        messageID: id,
+        type: 'text',
+        text,
+      },
+    ],
+  };
+}
+
+function historyPage(
+  overrides: Partial<KiloSdkMessageHistoryPage> = {}
+): KiloSdkMessageHistoryPage {
+  return {
+    messages: [],
+    nextCursor: null,
+    omittedItemCount: 0,
+    ...overrides,
+  };
+}
+
+function createClient(
+  query: SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+): SessionPageTrpcClient {
+  return {
+    cliSessionsV2: {
+      getSessionMessagesPage: { query },
+    },
+  };
+}
+
+describe('fetchWebSessionSnapshotPage', () => {
+  it('maps a successful shared history page to SessionSnapshotPageOutcome success', async () => {
+    const message = storedMessage();
+    const page = historyPage({
+      messages: [message],
+      nextCursor: 'opaque-cursor',
+      omittedItemCount: 2,
+    });
+    const query = jest.fn<
+      SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+    >(async () => ({
+      kiloSessionId: 'ses_123',
+      history: page,
+      watermarkEventId: 42,
+    }));
+
+    const result = await fetchWebSessionSnapshotPage(
+      createClient(query),
+      kiloSessionId('ses_123'),
+      {}
+    );
+
+    expect(result).toEqual({
+      kind: 'success',
+      info: { id: 'ses_123' },
+      messages: page.messages,
+      nextCursor: 'opaque-cursor',
+      omittedItemCount: 2,
+      watermarkEventId: 42,
+    });
+    expect(query).toHaveBeenCalledWith({ session_id: 'ses_123' });
+  });
+
+  it('forwards the continuation cursor to the tRPC layer as `cursor`', async () => {
+    const query = jest.fn<
+      SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+    >(async () => ({
+      kiloSessionId: 'ses_123',
+      history: historyPage({ nextCursor: null }),
+    }));
+
+    await fetchWebSessionSnapshotPage(createClient(query), kiloSessionId('ses_123'), {
+      cursor: 'opaque-cursor',
+    });
+
+    expect(query).toHaveBeenCalledWith({
+      session_id: 'ses_123',
+      cursor: 'opaque-cursor',
+    });
+  });
+
+  it('omits the cursor from the tRPC request when the manager has no continuation', async () => {
+    const query = jest.fn<
+      SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+    >(async () => ({
+      kiloSessionId: 'ses_123',
+      history: historyPage({ nextCursor: null }),
+    }));
+
+    await fetchWebSessionSnapshotPage(createClient(query), kiloSessionId('ses_123'), {
+      cursor: '',
+    });
+
+    expect(query).toHaveBeenCalledWith({ session_id: 'ses_123' });
+  });
+
+  it('maps a session with no messages (history:null) to an empty success page', async () => {
+    const query = jest.fn<
+      SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+    >(async () => ({
+      kiloSessionId: 'ses_new',
+      history: null,
+    }));
+
+    await expect(
+      fetchWebSessionSnapshotPage(createClient(query), kiloSessionId('ses_new'), {})
+    ).resolves.toEqual({
+      kind: 'success',
+      info: { id: 'ses_new' },
+      messages: [],
+      nextCursor: null,
+      omittedItemCount: 0,
+    });
+  });
+
+  it('passes typed retryable_failure through verbatim so the UI can offer Retry', async () => {
+    const history: KiloSdkMessageHistory = {
+      kind: 'retryable_failure',
+      phase: 'page_parts',
+    };
+    const query = jest.fn<
+      SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+    >(async () => ({
+      kiloSessionId: 'ses_123',
+      history,
+    }));
+
+    await expect(
+      fetchWebSessionSnapshotPage(createClient(query), kiloSessionId('ses_123'), {})
+    ).resolves.toEqual({
+      kind: 'retryable_failure',
+      phase: 'page_parts',
+    });
+  });
+
+  it('passes typed too_large and invalid_data failures through verbatim', async () => {
+    const histories: KiloSdkMessageHistory[] = [
+      {
+        kind: 'too_large',
+        maximumBytes: 8 * 1024 * 1024,
+        phase: 'message_scan',
+      },
+      { kind: 'invalid_data' },
+    ];
+    const query =
+      jest.fn<SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']>();
+    for (const history of histories) {
+      query.mockResolvedValueOnce({
+        kiloSessionId: 'ses_123',
+        history,
+      });
+    }
+    const client = createClient(query);
+
+    const results = await Promise.all([
+      fetchWebSessionSnapshotPage(client, kiloSessionId('ses_123'), {}),
+      fetchWebSessionSnapshotPage(client, kiloSessionId('ses_123'), {}),
+    ]);
+
+    expect(results).toEqual(histories);
+  });
+
+  it('lets the tRPC input schema default the limit to 50 on the initial read', async () => {
+    const query = jest.fn<
+      SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+    >(async () => ({
+      kiloSessionId: 'ses_123',
+      history: historyPage({ nextCursor: null }),
+    }));
+
+    await fetchWebSessionSnapshotPage(createClient(query), kiloSessionId('ses_123'), {});
+
+    const call = query.mock.calls[0]?.[0] as Record<string, unknown> | undefined;
+    expect(call).toBeDefined();
+    expect(call?.limit).toBeUndefined();
+  });
+
+  it('carries watermarkEventId through when the web router includes it', async () => {
+    const query = jest.fn<
+      SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+    >(async () => ({
+      kiloSessionId: 'ses_123',
+      history: historyPage({ nextCursor: null }),
+      watermarkEventId: 77,
+    }));
+
+    const result = await fetchWebSessionSnapshotPage(
+      createClient(query),
+      kiloSessionId('ses_123'),
+      {}
+    );
+
+    expect(result).toMatchObject({ kind: 'success', watermarkEventId: 77 });
+  });
+
+  it('omits watermarkEventId from the page when the web router does not include it', async () => {
+    const query = jest.fn<
+      SessionPageTrpcClient['cliSessionsV2']['getSessionMessagesPage']['query']
+    >(async () => ({
+      kiloSessionId: 'ses_123',
+      history: historyPage({ nextCursor: null }),
+    }));
+
+    const result = await fetchWebSessionSnapshotPage(
+      createClient(query),
+      kiloSessionId('ses_123'),
+      {}
+    );
+
+    expect(result).toMatchObject({ kind: 'success' });
+    expect((result as Record<string, unknown>).watermarkEventId).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/cloud-agent-next/session-page-adapter.ts
+++ b/apps/web/src/components/cloud-agent-next/session-page-adapter.ts
@@ -1,0 +1,61 @@
+import {
+  type KiloSdkMessageHistory,
+  type KiloSdkMessageHistoryPage,
+  type KiloSessionId,
+  type SessionSnapshotPage,
+  type SessionSnapshotPageOutcome,
+} from '@kilocode/cloud-agent-sdk';
+
+type SessionMessagesPageResult = {
+  kiloSessionId: string;
+  history: KiloSdkMessageHistory | null;
+  watermarkEventId?: number | null;
+};
+
+export type SessionPageTrpcClient = {
+  cliSessionsV2: {
+    getSessionMessagesPage: {
+      query: (input: { session_id: string; cursor?: string }) => Promise<SessionMessagesPageResult>;
+    };
+  };
+};
+
+function isHistoryPage(history: KiloSdkMessageHistory): history is KiloSdkMessageHistoryPage {
+  return 'messages' in history && Array.isArray(history.messages);
+}
+
+export async function fetchWebSessionSnapshotPage(
+  trpcClient: SessionPageTrpcClient,
+  kiloSessionId: KiloSessionId,
+  options: { cursor?: string }
+): Promise<SessionSnapshotPageOutcome> {
+  const result = await trpcClient.cliSessionsV2.getSessionMessagesPage.query({
+    session_id: kiloSessionId,
+    ...(options.cursor ? { cursor: options.cursor } : {}),
+  });
+
+  const history = result.history;
+  if (history === null) {
+    return {
+      kind: 'success',
+      info: { id: result.kiloSessionId },
+      messages: [],
+      nextCursor: null,
+      omittedItemCount: 0,
+      ...(result.watermarkEventId != null ? { watermarkEventId: result.watermarkEventId } : {}),
+    };
+  }
+
+  if (isHistoryPage(history)) {
+    return {
+      kind: 'success',
+      info: { id: result.kiloSessionId },
+      messages: history.messages as SessionSnapshotPage['messages'],
+      nextCursor: history.nextCursor,
+      omittedItemCount: history.omittedItemCount,
+      ...(result.watermarkEventId != null ? { watermarkEventId: result.watermarkEventId } : {}),
+    };
+  }
+
+  return history;
+}

--- a/dev/seed/app/paged-history.ts
+++ b/dev/seed/app/paged-history.ts
@@ -1,0 +1,356 @@
+import { execFileSync } from 'node:child_process';
+
+import { cli_sessions_v2, kilocode_users } from '@kilocode/db/schema';
+import { signKiloToken } from '@kilocode/worker-utils';
+import { and, eq, or } from 'drizzle-orm';
+
+import type { SeedResult } from '../index';
+import { getSeedDb } from '../lib/db';
+import { normalizeSeedEmail } from '../lib/email';
+import {
+  buildAssistantMessageItem,
+  buildSessionItem,
+  buildUserMessageItem,
+  parseSessionIngestServiceStatus,
+  type SessionIngestItem,
+} from '../lib/mobile-sheet-fixtures';
+
+export const usage = '<email>';
+
+export const SESSION_ID = 'ses_000000000005PagedHistory01';
+export const SESSION_TITLE = '60-message pagination fixture';
+export const SESSION_SLUG = 'paged-history-fixture';
+export const MESSAGE_COUNT = 60;
+
+const TOKEN_EXPIRES_SECONDS = 3600;
+const POLL_TIMEOUT_MS = 30_000;
+const POLL_INTERVAL_MS = 500;
+const BASE_CREATED_AT = 1_700_100_000_000;
+
+function printUsage(): void {
+  console.log(`Usage: pnpm dev:seed app:paged-history ${usage}`);
+  console.log('');
+  console.log('Seeds one read-only cloud-agent session with 60 tall transcript');
+  console.log('messages so the first page (50) overflows and older history stays');
+  console.log('behind a scroll-up. Writes the cli_sessions_v2 row, then ingests');
+  console.log('through the local cloudflare-session-ingest worker.');
+  console.log('No cloud-agent session ID is set, so the UI is historical/read-only.');
+  console.log('');
+  console.log('Examples:');
+  console.log('  pnpm dev:seed app:paged-history evgeny@kilocode.ai');
+  console.log('  pnpm -s dev:seed app:paged-history evgeny@kilocode.ai --json');
+}
+
+function isValidEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+function parseArgs(args: string[]): string {
+  const positionals: string[] = [];
+  for (const arg of args) {
+    if (arg.startsWith('--')) {
+      throw new Error(`Unknown argument: ${arg}`);
+    }
+    positionals.push(arg.trim());
+  }
+
+  const [email, ...rest] = positionals;
+  if (!email) {
+    printUsage();
+    throw new Error('email is required');
+  }
+  if (rest.length > 0) {
+    printUsage();
+    throw new Error(`Unexpected extra arguments: ${rest.join(' ')}`);
+  }
+  if (!isValidEmail(email)) {
+    throw new Error(`email is not a valid address: ${email}`);
+  }
+  return email;
+}
+
+function readSessionIngestStatusJson(): string {
+  try {
+    return execFileSync('pnpm', ['-s', 'dev:status', '--json'], { encoding: 'utf8' });
+  } catch (error) {
+    throw new Error(
+      `dev:status --json failed: ${error instanceof Error ? error.message : String(error)}`
+    );
+  }
+}
+
+function paddedIndex(index: number): string {
+  return String(index).padStart(10, '0');
+}
+
+function messageIdFor(index: number): string {
+  return `msgPaged${paddedIndex(index)}`;
+}
+
+function partIdFor(index: number): string {
+  return `prtPaged${paddedIndex(index)}`;
+}
+
+function messageBody(role: 'User' | 'Assistant', index: number): string {
+  return [
+    `${role} message ${index} of ${MESSAGE_COUNT}.`,
+    '',
+    'Padded so fifty messages overflow the chat viewport.',
+    'Short one-liners stay on-screen, and the near-top autoload then pulls the older page immediately.',
+    `Marker line A for message ${index}.`,
+    `Marker line B for message ${index}.`,
+    `Marker line C for message ${index}.`,
+    `Marker line D for message ${index}.`,
+    `Marker line E for message ${index}.`,
+    `Marker line F for message ${index}.`,
+    `Marker line G for message ${index}.`,
+    `End of ${role.toLowerCase()} message ${index}.`,
+  ].join('\n');
+}
+
+function buildTextPartItem(params: {
+  partId: string;
+  sessionId: string;
+  messageId: string;
+  text: string;
+}): SessionIngestItem {
+  return {
+    type: 'part',
+    data: {
+      id: params.partId,
+      sessionID: params.sessionId,
+      messageID: params.messageId,
+      type: 'text',
+      text: params.text,
+    },
+  };
+}
+
+export function buildPagedHistoryIngestItems(): SessionIngestItem[] {
+  const items: SessionIngestItem[] = [
+    buildSessionItem({
+      sessionId: SESSION_ID,
+      slug: SESSION_SLUG,
+      title: SESSION_TITLE,
+    }),
+  ];
+
+  for (let index = 1; index <= MESSAGE_COUNT; index += 1) {
+    const createdAt = BASE_CREATED_AT + index * 1_000;
+    const messageId = messageIdFor(index);
+    const isUser = index % 2 === 1;
+
+    if (isUser) {
+      items.push(
+        buildUserMessageItem({
+          messageId,
+          sessionId: SESSION_ID,
+          createdAt,
+        }),
+        buildTextPartItem({
+          partId: partIdFor(index),
+          sessionId: SESSION_ID,
+          messageId,
+          text: messageBody('User', index),
+        })
+      );
+      continue;
+    }
+
+    items.push(
+      buildAssistantMessageItem({
+        messageId,
+        sessionId: SESSION_ID,
+        parentId: messageIdFor(index - 1),
+        createdAt,
+        completedAt: createdAt + 200,
+        cost: 0.001,
+        tokens: {
+          total: 40,
+          input: 20,
+          output: 16,
+          reasoning: 0,
+          cache: { read: 2, write: 2 },
+        },
+      }),
+      buildTextPartItem({
+        partId: partIdFor(index),
+        sessionId: SESSION_ID,
+        messageId,
+        text: messageBody('Assistant', index),
+      })
+    );
+  }
+
+  return items;
+}
+
+async function ingestSession(
+  baseUrl: string,
+  sessionId: string,
+  token: string,
+  items: SessionIngestItem[]
+): Promise<void> {
+  const response = await fetch(`${baseUrl}/api/session/${sessionId}/ingest?v=1`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ data: items }),
+  });
+  if (!response.ok) {
+    const body = await response.text();
+    throw new Error(`Ingest of ${sessionId} failed (${response.status}): ${body}`);
+  }
+}
+
+async function pollForMessages(baseUrl: string, sessionId: string, token: string): Promise<number> {
+  const deadline = Date.now() + POLL_TIMEOUT_MS;
+
+  for (;;) {
+    const response = await fetch(`${baseUrl}/api/session/${sessionId}/messages?limit=100`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    if (!response.ok) {
+      throw new Error(`Messages read of ${sessionId} failed (${response.status})`);
+    }
+
+    const payload: unknown = await response.json();
+    if (!isRecord(payload) || payload.success !== true) {
+      throw new Error(`Messages read of ${sessionId} returned an unexpected shape`);
+    }
+
+    const history = payload.history;
+    if (history === null) {
+      if (Date.now() >= deadline) {
+        throw new Error(`Timed out waiting for history of ${sessionId}`);
+      }
+      await sleep(POLL_INTERVAL_MS);
+      continue;
+    }
+    if (!isRecord(history)) {
+      throw new Error(`Messages read of ${sessionId} returned an unexpected history shape`);
+    }
+    if (history.kind !== undefined) {
+      throw new Error(`session-ingest reported ${String(history.kind)} for ${sessionId}`);
+    }
+    if (!Array.isArray(history.messages)) {
+      throw new Error(`Messages read of ${sessionId} returned an unexpected history shape`);
+    }
+
+    if (history.messages.length === MESSAGE_COUNT) {
+      return history.messages.length;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out waiting for ${MESSAGE_COUNT} messages in ${sessionId}; saw ${history.messages.length}`
+      );
+    }
+    await sleep(POLL_INTERVAL_MS);
+  }
+}
+
+export async function run(...args: string[]): Promise<SeedResult | void> {
+  if (args.includes('--help') || args.includes('-h')) {
+    printUsage();
+    return;
+  }
+
+  const email = parseArgs(args);
+
+  const secret = process.env.NEXTAUTH_SECRET;
+  if (!secret) {
+    throw new Error(
+      'NEXTAUTH_SECRET is not set for this worktree. Ensure local env is prepared (pnpm dev:worktree:prepare).'
+    );
+  }
+
+  const normalizedEmail = normalizeSeedEmail(email);
+  const db = getSeedDb();
+  const matches = await db
+    .select({
+      userId: kilocode_users.id,
+      email: kilocode_users.google_user_email,
+      apiTokenPepper: kilocode_users.api_token_pepper,
+      isAdmin: kilocode_users.is_admin,
+    })
+    .from(kilocode_users)
+    .where(
+      or(
+        eq(kilocode_users.google_user_email, email),
+        eq(kilocode_users.normalized_email, normalizedEmail)
+      )
+    );
+
+  if (matches.length === 0) {
+    throw new Error(
+      `No user found for email ${email}. Sign in locally first, or seed a user (pnpm dev:seed app:create-user).`
+    );
+  }
+
+  const exactMatches = matches.filter(match => match.email === email);
+  const resolvedMatches = exactMatches.length > 0 ? exactMatches : matches;
+  if (resolvedMatches.length > 1) {
+    const matchList = resolvedMatches.map(match => `${match.email} (${match.userId})`).join(', ');
+    throw new Error(`Multiple users matched ${email}: ${matchList}`);
+  }
+
+  const [user] = resolvedMatches;
+
+  const { token } = await signKiloToken({
+    userId: user.userId,
+    pepper: user.apiTokenPepper,
+    secret,
+    expiresInSeconds: TOKEN_EXPIRES_SECONDS,
+    env: process.env.NODE_ENV ?? 'development',
+    extra: user.isAdmin ? { isAdmin: true } : undefined,
+  });
+
+  const serviceStatus = parseSessionIngestServiceStatus(readSessionIngestStatusJson());
+  if (serviceStatus.status !== 'up') {
+    throw new Error(
+      `cloudflare-session-ingest is not up (status=${serviceStatus.status}). Start the local stack first.`
+    );
+  }
+  const sessionIngestUrl = `http://localhost:${serviceStatus.port}`;
+
+  await db
+    .delete(cli_sessions_v2)
+    .where(
+      and(eq(cli_sessions_v2.kilo_user_id, user.userId), eq(cli_sessions_v2.session_id, SESSION_ID))
+    );
+
+  await db.insert(cli_sessions_v2).values({
+    session_id: SESSION_ID,
+    kilo_user_id: user.userId,
+    title: SESSION_TITLE,
+    created_on_platform: 'cloud-agent-web',
+  } satisfies typeof cli_sessions_v2.$inferInsert);
+
+  await ingestSession(sessionIngestUrl, SESSION_ID, token, buildPagedHistoryIngestItems());
+  const messageCount = await pollForMessages(sessionIngestUrl, SESSION_ID, token);
+
+  console.log('');
+  console.log('Seeded a read-only 60-message cloud-agent transcript.');
+  console.log('Hard-refresh /cloud/chat?sessionId=' + SESSION_ID + '.');
+  console.log('Newest 50 should be on screen; scroll up for the older 10.');
+
+  return {
+    userId: user.userId,
+    email: user.email,
+    sessionId: SESSION_ID,
+    messageCount,
+    sessionIngestPort: serviceStatus.port,
+    sessionIngestUrl,
+    chatPath: `/cloud/chat?sessionId=${SESSION_ID}`,
+  };
+}


### PR DESCRIPTION
## Summary

Web cloud-agent chat now loads older transcript pages on scroll-up, matching mobile pagination.

- Wire `fetchSnapshotPage` through a tRPC adapter in `CloudAgentProvider` (keeps SDK `fetchSnapshot` as fallback)
- Share `useOlderMessagesPagination` for the main transcript and child-session drawer
- Restore scroll after prepend, autoload when the first page does not overflow, and trim retained history when returning to the bottom
- Header for retryable / invalid / too-large errors and omitted items, plus a screen-reader announcement when earlier messages arrive
- Local seed `pnpm dev:seed app:paged-history <email>` for a 60-message read-only fixture

## Verification

- [x] Local 60-message fixture (`ses_000000000005PagedHistory01`): newest 50 on first load, scroll-up loads the older 10 without jumping
- [ ] Child-session drawer pagination
- [ ] Retry header after a retryable load failure

## Visual Changes

N/A — existing chat layout; older-message status text and Retry appear only when paginating.

## Reviewer Notes

No backend/SDK changes. Automatic follow-up loads skip retryable errors; Retry or a new scroll-up may re-fire.

Local fixture (do not poke DO SQLite):

```
pnpm dev:seed app:paged-history <email>
# /cloud/chat?sessionId=ses_000000000005PagedHistory01
```