### PR TITLE
feat(cloud-agent-next): add interactive control-plane terminals

### DIFF
--- a/services/cloud-agent-next/src/agent-sandbox/capabilities.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/capabilities.ts
@@ -19,5 +19,5 @@ export function sessionHasTerminal(
   sessionId: string,
   provider: AgentSandboxProvider = 'cloudflare'
 ): boolean {
-  return sessionPlaneFromId(sessionId) !== 'control' && PROVIDER_CAPABILITIES[provider].terminal;
+  return sessionPlaneFromId(sessionId) === 'control' || PROVIDER_CAPABILITIES[provider].terminal;
 }

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.test.ts
@@ -5,9 +5,10 @@ import { WRAPPER_VERSION } from '../../shared/wrapper-version.js';
 import type { SessionMetadata } from '../../persistence/session-metadata.js';
 import { VercelAgentSandbox } from './vercel-agent-sandbox.js';
 import type { VercelSandboxRuntimeConfig } from './vercel-runtime-config.js';
-import type {
-  VercelSandboxCommand,
-  VercelSandboxRestClient,
+import {
+  VercelSandboxRestError,
+  type VercelSandboxCommand,
+  type VercelSandboxRestClient,
 } from './vercel-sandbox-rest-client.js';
 
 const config: VercelSandboxRuntimeConfig = {
@@ -45,6 +46,21 @@ function command(overrides: Partial<VercelSandboxCommand> = {}): VercelSandboxCo
     exitCode: null,
     startedAt: 1,
     ...overrides,
+  };
+}
+
+function persistedWrapperRuntime(): NonNullable<
+  NonNullable<SessionMetadata['workspace']>['providerRuntime']
+> {
+  return {
+    provider: 'vercel',
+    sessionId: 'session-1',
+    wrapper: {
+      launchId: 'launch-1',
+      commandId: 'command-1',
+      instanceId: 'instance-1',
+      instanceGeneration: 2,
+    },
   };
 }
 
@@ -125,6 +141,170 @@ function ensureRequest() {
 
 describe('VercelAgentSandbox', () => {
   afterEach(() => vi.restoreAllMocks());
+
+  it('rejects unsupported billing admission without creating or inspecting compute', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(metadata(), config, context, {
+      restClient: asRestClient(client),
+    });
+
+    await expect(sandbox.ensureBillingAdmission()).resolves.toEqual({
+      success: false,
+      code: 'meter_unavailable',
+      message: 'Container billing admission is unavailable for Vercel sandbox sessions',
+    });
+    expect(context.beginCreate).not.toHaveBeenCalled();
+    expect(client.createSandbox).not.toHaveBeenCalled();
+    expect(client.getSession).not.toHaveBeenCalled();
+  });
+
+  it('fails enforced billing checks closed without blocking unenforced sessions', async () => {
+    const sandbox = new VercelAgentSandbox(metadata(), config);
+
+    await expect(sandbox.isBillingBlocked()).resolves.toBe(false);
+    await expect(sandbox.isBillingBlocked(false)).resolves.toBe(false);
+    await expect(sandbox.isBillingBlocked(true)).resolves.toBe(true);
+  });
+
+  it('reports billing runtime status unavailable without inspecting provider state', async () => {
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(metadata(persistedWrapperRuntime()), config, undefined, {
+      restClient: asRestClient(client),
+    });
+
+    await expect(sandbox.getBillingRuntimeStatus()).resolves.toBeUndefined();
+    expect(client.getSession).not.toHaveBeenCalled();
+    expect(client.getCommand).not.toHaveBeenCalled();
+  });
+
+  it('observes absent persisted runtimes and wrappers without provider calls or reconciliation', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    const uncreated = new VercelAgentSandbox(metadata(), config, context, {
+      restClient: asRestClient(client),
+    });
+    const withoutWrapper = new VercelAgentSandbox(
+      metadata({ provider: 'vercel', sessionId: 'session-1' }),
+      config,
+      context,
+      { restClient: asRestClient(client) }
+    );
+
+    await expect(uncreated.observeWrappersWithoutWaking()).resolves.toEqual({ status: 'absent' });
+    await expect(withoutWrapper.observeWrappersWithoutWaking()).resolves.toEqual({
+      status: 'absent',
+    });
+    expect(context.beginCreate).not.toHaveBeenCalled();
+    expect(context.getWrapperLaunchIntent).not.toHaveBeenCalled();
+    expect(client.getSession).not.toHaveBeenCalled();
+    expect(client.getCommand).not.toHaveBeenCalled();
+  });
+
+  it.each(['stopped', 'failed', 'aborted'] as const)(
+    'does not inspect commands or mutate persisted state for a %s runtime',
+    async status => {
+      const context = runtimeContext();
+      const client = restClient();
+      client.getSession.mockResolvedValue({ session: { status }, routes: [] });
+      const sandbox = new VercelAgentSandbox(metadata(persistedWrapperRuntime()), config, context, {
+        restClient: asRestClient(client),
+      });
+
+      await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({ status: 'absent' });
+      expect(client.getSession).toHaveBeenCalledWith('session-1', 'ses-abcdef');
+      expect(client.getCommand).not.toHaveBeenCalled();
+      expect(client.executeCommand).not.toHaveBeenCalled();
+      expect(context.clearWrapperProcess).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['pending', 'stopping', 'snapshotting'] as const)(
+    'retains uncertainty without inspecting commands for a %s runtime',
+    async status => {
+      const context = runtimeContext();
+      const client = restClient();
+      client.getSession.mockResolvedValue({ session: { status }, routes: [] });
+      const sandbox = new VercelAgentSandbox(metadata(persistedWrapperRuntime()), config, context, {
+        restClient: asRestClient(client),
+      });
+
+      await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({
+        status: 'inspection-failed',
+        error: `Vercel sandbox runtime is ${status}`,
+      });
+      expect(client.getCommand).not.toHaveBeenCalled();
+      expect(context.clearWrapperProcess).not.toHaveBeenCalled();
+    }
+  );
+
+  it('observes an active wrapper by persisted session and command without mutating its lease', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    const sandbox = new VercelAgentSandbox(metadata(persistedWrapperRuntime()), config, context, {
+      restClient: asRestClient(client),
+    });
+
+    await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({
+      status: 'present',
+      observed: [
+        {
+          representation: 'process',
+          id: 'command-1',
+          instanceId: 'instance-1',
+          instanceGeneration: 2,
+        },
+      ],
+    });
+    expect(client.getSession).toHaveBeenCalledWith('session-1', 'ses-abcdef');
+    expect(client.getCommand).toHaveBeenCalledWith('session-1', 'command-1');
+    expect(context.clearWrapperProcess).not.toHaveBeenCalled();
+  });
+
+  it('reports an exited wrapper absent without clearing or mutating its persisted lease', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    client.getCommand.mockResolvedValue(command({ exitCode: 143 }));
+    const sandbox = new VercelAgentSandbox(metadata(persistedWrapperRuntime()), config, context, {
+      restClient: asRestClient(client),
+    });
+
+    await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({ status: 'absent' });
+    await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({ status: 'absent' });
+    expect(client.getCommand).toHaveBeenCalledTimes(2);
+    expect(context.clearWrapperProcess).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing exact runtime session as absent without probing its command', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    client.getSession.mockRejectedValue(
+      new VercelSandboxRestError('request_failed', 'get-session', 404)
+    );
+    const sandbox = new VercelAgentSandbox(metadata(persistedWrapperRuntime()), config, context, {
+      restClient: asRestClient(client),
+    });
+
+    await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({ status: 'absent' });
+    expect(client.getCommand).not.toHaveBeenCalled();
+    expect(context.clearWrapperProcess).not.toHaveBeenCalled();
+  });
+
+  it('retains provider observation failures without modifying persisted wrapper state', async () => {
+    const context = runtimeContext();
+    const client = restClient();
+    client.getSession.mockRejectedValue(new Error('provider unavailable'));
+    const sandbox = new VercelAgentSandbox(metadata(persistedWrapperRuntime()), config, context, {
+      restClient: asRestClient(client),
+    });
+
+    await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({
+      status: 'inspection-failed',
+      error: 'Error: provider unavailable',
+    });
+    expect(client.getCommand).not.toHaveBeenCalled();
+    expect(context.clearWrapperProcess).not.toHaveBeenCalled();
+  });
 
   it('persists create intent and exact runtime before validating and launching the wrapper', async () => {
     const context = runtimeContext();
@@ -555,7 +735,7 @@ describe('VercelAgentSandbox', () => {
       { restClient: asRestClient(client) }
     );
 
-    await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({
+    await expect(sandbox.discoverSessionWrappers()).resolves.toEqual({
       status: 'present',
       observed: [
         {
@@ -742,14 +922,11 @@ describe('VercelAgentSandbox', () => {
     expect(client.stopSession).not.toHaveBeenCalled();
   });
 
-  it('admits billing as a no-op and observes wrappers through discover', async () => {
+  it('observes wrappers through discover without inspecting billing state', async () => {
     const sandbox = new VercelAgentSandbox(metadata(), config, undefined, {
       restClient: asRestClient(restClient()),
     });
 
-    await expect(sandbox.ensureBillingAdmission()).resolves.toEqual({ success: true });
-    await expect(sandbox.isBillingBlocked()).resolves.toBe(false);
-    await expect(sandbox.isBillingBlocked(true)).resolves.toBe(false);
     await expect(sandbox.getBillingRuntimeStatus()).resolves.toBeUndefined();
     await expect(sandbox.observeWrappersWithoutWaking()).resolves.toEqual({ status: 'absent' });
   });

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-agent-sandbox.ts
@@ -4,6 +4,7 @@ import { WrapperClient } from '../../kilo/wrapper-client.js';
 import { logger } from '../../logger.js';
 import { WRAPPER_VERSION } from '../../shared/wrapper-version.js';
 import type { SessionMetadata } from '../../persistence/session-metadata.js';
+import type { SandboxBillingAdmissionResult } from '../../container-usage-context.js';
 import {
   AgentSandboxUnavailableError,
   type AgentSandbox,
@@ -20,6 +21,7 @@ import {
 import type { SandboxDeleteReason } from '../protocol.js';
 import type { SandboxCreateIntent } from '../runtime-intents.js';
 import type { VercelSandboxRuntimeConfig } from './vercel-runtime-config.js';
+import { classifyVercelSession } from './vercel-runtime-state.js';
 import {
   VercelSandboxRestClient,
   VercelSandboxRestError,
@@ -96,6 +98,22 @@ export class VercelAgentSandbox implements AgentSandbox {
     this.now = dependencies.now ?? Date.now;
     this.runtimeSessionId = metadata.workspace?.providerRuntime?.sessionId;
     this.wrapperProcess = metadata.workspace?.providerRuntime?.wrapper;
+  }
+
+  async ensureBillingAdmission(): Promise<SandboxBillingAdmissionResult> {
+    return {
+      success: false,
+      code: 'meter_unavailable',
+      message: 'Container billing admission is unavailable for Vercel sandbox sessions',
+    };
+  }
+
+  async isBillingBlocked(enforcementRequested = false): Promise<boolean> {
+    return enforcementRequested;
+  }
+
+  async getBillingRuntimeStatus(): Promise<undefined> {
+    return undefined;
   }
 
   private get sandboxName(): string {
@@ -406,24 +424,6 @@ export class VercelAgentSandbox implements AgentSandbox {
     throw new Error('Vercel wrapper did not report the persisted lease');
   }
 
-  // TODO: Vercel is not on the Cloudflare container meter. These admit and
-  // never block so AgentSandbox callers do not throw; wire real billing later.
-  async ensureBillingAdmission() {
-    return { success: true as const };
-  }
-
-  async isBillingBlocked(_enforcementRequested = false): Promise<boolean> {
-    return false;
-  }
-
-  async getBillingRuntimeStatus() {
-    return undefined;
-  }
-
-  observeWrappersWithoutWaking(): Promise<WrapperObservation> {
-    return this.discoverSessionWrappers();
-  }
-
   async ensureWrapper(request: EnsureWrapperRequest) {
     const instance = request.leasedInstance;
     if (!instance) throw new Error('Vercel wrapper startup requires a physical wrapper lease');
@@ -433,6 +433,41 @@ export class VercelAgentSandbox implements AgentSandbox {
     const client = this.wrapperClient(sessionId);
     await this.waitForHealthyWrapper(client, instance);
     return { status: 'wrapper-running' as const, client };
+  }
+
+  async observeWrappersWithoutWaking(): Promise<WrapperObservation> {
+    const runtime = this.persistedRuntime;
+    if (!runtime?.wrapper) return { status: 'absent' };
+
+    try {
+      const session = await this.restClient.getSession(runtime.sessionId, this.sandboxName);
+      if (classifyVercelSession(session.session.status) === 'terminal') {
+        return { status: 'absent' };
+      }
+      if (session.session.status !== 'running') {
+        return {
+          status: 'inspection-failed',
+          error: `Vercel sandbox runtime is ${session.session.status}`,
+        };
+      }
+
+      const command = await this.observeCommand(runtime.sessionId, runtime.wrapper.commandId);
+      if (!command) return { status: 'absent' };
+      return {
+        status: 'present',
+        observed: [
+          observedWrapper(command, {
+            instanceId: runtime.wrapper.instanceId,
+            instanceGeneration: runtime.wrapper.instanceGeneration,
+          }),
+        ],
+      };
+    } catch (error) {
+      if (error instanceof VercelSandboxRestError && error.status === 404) {
+        return { status: 'absent' };
+      }
+      return { status: 'inspection-failed', error: String(error) };
+    }
   }
 
   async discoverSessionWrappers(): Promise<WrapperObservation> {

--- a/services/cloud-agent-next/src/persistence/SandboxControl.ts
+++ b/services/cloud-agent-next/src/persistence/SandboxControl.ts
@@ -5,6 +5,7 @@ import { getSandboxSessionStub } from '../sandbox-session/session-stub.js';
 import { logger } from '../logger.js';
 import {
   createSandboxControlSocketHandler,
+  type SandboxControlConnectionIdentity,
   type SandboxControlOutboundRequest,
   type SandboxControlSocketHandler,
 } from '../sandbox-control/socket.js';
@@ -95,14 +96,42 @@ import { createCloudflareProviderAdapter } from '../sandbox-control/cloudflare-p
 import { createVercelProviderAdapter } from '../sandbox-control/vercel-provider.js';
 import { parseVercelSandboxRuntimeConfig } from '../agent-sandbox/vercel/vercel-runtime-config.js';
 import { buildControlWrapperLaunchEnv } from '../sandbox-control/wrapper-launch-env.js';
-import { isSandboxContainerRunning } from '../container-usage-context.js';
+import {
+  getSandboxBillingRuntimeStatus,
+  isSandboxContainerRunning,
+} from '../container-usage-context.js';
+import { isCloudAgentContainerBillingEnabled } from '../container-billing-rollout.js';
+import { getSandboxNamespace } from '../sandbox-id.js';
+import {
+  validateTerminalBillingRuntime,
+  type SandboxTerminalAccessInput,
+  type SandboxTerminalAccessResult,
+} from '../sandbox-control/terminal-billing.js';
 import type { AgentSandboxProvider } from '../types.js';
 
 const CREDENTIAL_HASH_KEY = 'wrapper_credential_hash';
 const OWNER_ID_KEY = 'owner_id';
 const WRAPPER_READY_AT_KEY = 'wrapper_ready_at';
+const ACTIVE_WRAPPER_RUNTIME_KEY = 'active_wrapper_runtime';
 const DIAGNOSTIC_BUNDLE_KEY = 'diagnostic_bundle';
 const PROVIDER_KIND_KEY = 'provider_kind';
+
+type PersistedWrapperRuntime = SandboxControlConnectionIdentity & {
+  readyConnectionId?: string;
+};
+
+type TerminalRuntimeSnapshot = {
+  allowed: true;
+  connection: SandboxControlConnectionIdentity;
+  physical: PhysicalRecord;
+  provider: AgentSandboxProvider;
+  route: SessionRoute;
+};
+
+type TerminalRuntimeRejection = {
+  allowed: false;
+  reason: string;
+};
 
 export type AttachSessionInput = AttachRouteInput;
 
@@ -111,12 +140,16 @@ export type SandboxControlStatus = {
   physical: PhysicalRecord['state'];
   connection: ConnectionState;
   work: WorkState;
+  wrapperInstanceId?: string;
 };
 
 export class SandboxControl extends DurableObject<Env> {
   readonly sandboxId: string;
   private socketHandler: SandboxControlSocketHandler;
   private kiloReady = false;
+  private activeConnection: SandboxControlConnectionIdentity | null = null;
+  private readyConnectionId: string | null = null;
+  private providerKind: AgentSandboxProvider = 'cloudflare';
   private readonly sessionForwardChains = new Map<string, Promise<void>>();
   private provider: ProviderAdapter;
 
@@ -128,17 +161,38 @@ export class SandboxControl extends DurableObject<Env> {
       new WebSocketRequestResponsePair(SANDBOX_CONTROL_AUTO_PING, SANDBOX_CONTROL_AUTO_PONG)
     );
     this.socketHandler = createSandboxControlSocketHandler(ctx, this.sandboxId, undefined, {
-      onHandshakeComplete: providerInstanceId => this.onHandshakeComplete(providerInstanceId),
-      onReady: () => this.onWrapperReady(),
-      onHeartbeat: payload => this.onHeartbeat(payload),
-      onSessionEvent: (identity, payload) => this.onSessionEvent(identity, payload),
-      onSessionPreparing: (identity, payload) => this.onSessionPreparing(identity, payload),
-      onSocketClosed: handshakeComplete => this.onSocketClosed(handshakeComplete),
+      onHandshakeComplete: identity => this.onHandshakeComplete(identity),
+      onReady: identity => this.onWrapperReady(identity),
+      onHeartbeat: (payload, identity) => this.onHeartbeat(payload, identity),
+      onSessionEvent: (sessionIdentity, payload, identity) =>
+        this.onSessionEvent(sessionIdentity, payload, identity),
+      onSessionPreparing: (sessionIdentity, payload, identity) =>
+        this.onSessionPreparing(sessionIdentity, payload, identity),
+      onSocketClosed: (handshakeComplete, identity) =>
+        this.onSocketClosed(handshakeComplete, identity),
     });
     void ctx.blockConcurrencyWhile(async () => {
-      this.kiloReady = (await ctx.storage.get<number>(WRAPPER_READY_AT_KEY)) !== undefined;
-      const kind = await ctx.storage.get<AgentSandboxProvider>(PROVIDER_KIND_KEY);
-      this.provider = this.createProviderAdapter(kind ?? 'cloudflare');
+      const [readyAt, runtime, kind] = await Promise.all([
+        ctx.storage.get<number>(WRAPPER_READY_AT_KEY),
+        ctx.storage.get<PersistedWrapperRuntime>(ACTIVE_WRAPPER_RUNTIME_KEY),
+        ctx.storage.get<AgentSandboxProvider>(PROVIDER_KIND_KEY),
+      ]);
+      this.providerKind = kind ?? 'cloudflare';
+      this.provider = this.createProviderAdapter(this.providerKind);
+      const current = this.socketHandler.getConnectionIdentity();
+      this.activeConnection = runtime ?? current;
+      if (
+        runtime &&
+        current &&
+        this.sameConnection(runtime, current) &&
+        runtime.readyConnectionId === current.connectionId &&
+        readyAt !== undefined
+      ) {
+        this.readyConnectionId = current.connectionId;
+        this.kiloReady = true;
+      } else {
+        this.kiloReady = !runtime && current !== null && readyAt !== undefined;
+      }
     });
   }
 
@@ -194,7 +248,16 @@ export class SandboxControl extends DurableObject<Env> {
       throw new Error('Invalid wrapper credential hash');
     }
     await this.ctx.storage.put(CREDENTIAL_HASH_KEY, hash);
+    const previous = this.activeConnection ?? this.socketHandler.getConnectionIdentity();
+    this.activeConnection = null;
+    this.readyConnectionId = null;
+    this.kiloReady = false;
     this.socketHandler.closeAll('Credential rotated');
+    await this.ctx.storage.delete([ACTIVE_WRAPPER_RUNTIME_KEY, WRAPPER_READY_AT_KEY]);
+    await this.cancelDeadlineAndAlarm('heartbeatExpiry');
+    if (previous?.wrapperInstanceId) {
+      await this.invalidateTerminalRuntime(previous.wrapperInstanceId, true);
+    }
     await this.appendLog(credentialTransition(Date.now(), 'rotated'));
   }
 
@@ -308,15 +371,89 @@ export class SandboxControl extends DurableObject<Env> {
     return [...table.values()];
   }
 
+  async validateTerminalAccess(
+    input: SandboxTerminalAccessInput
+  ): Promise<SandboxTerminalAccessResult> {
+    const runtime = await this.readTerminalRuntime(input);
+    if (!runtime.allowed) return runtime;
+
+    const enforced = isCloudAgentContainerBillingEnabled(this.env, {
+      userId: input.ownerId,
+      ...(input.organizationId ? { orgId: input.organizationId } : {}),
+    });
+    if (!enforced) return { allowed: true };
+    if (runtime.provider !== 'cloudflare') {
+      return { allowed: false, reason: 'billing_policy_unavailable' };
+    }
+
+    let billing: SandboxTerminalAccessResult;
+    try {
+      const namespace = getSandboxNamespace(this.env, this.sandboxId);
+      const sandbox = getSandbox(namespace, this.sandboxId);
+      billing = validateTerminalBillingRuntime({
+        access: input,
+        sandboxId: this.sandboxId,
+        providerInstanceId: runtime.physical.providerRef ?? '',
+        sandboxDurableObjectId: namespace.idFromName(this.sandboxId).toString(),
+        runtime: await getSandboxBillingRuntimeStatus(sandbox),
+      });
+    } catch {
+      return { allowed: false, reason: 'billing_runtime_unavailable' };
+    }
+    if (!billing.allowed) return billing;
+
+    const current = await this.readTerminalRuntime(input);
+    if (!current.allowed) return current;
+    if (
+      !this.sameConnection(current.connection, runtime.connection) ||
+      current.provider !== runtime.provider ||
+      current.physical.providerRef !== runtime.physical.providerRef ||
+      current.route.kiloSessionId !== runtime.route.kiloSessionId ||
+      current.route.directory !== runtime.route.directory
+    ) {
+      return { allowed: false, reason: 'runtime_changed' };
+    }
+    return { allowed: true };
+  }
+
+  async recordTerminalActivity(
+    input: SandboxTerminalAccessInput
+  ): Promise<SandboxTerminalAccessResult> {
+    const access = await this.validateTerminalAccess(input);
+    if (!access.allowed) return access;
+
+    const runtime = await this.readTerminalRuntime(input);
+    if (!runtime.allowed) return runtime;
+    if (runtime.provider === 'vercel') return { allowed: true };
+
+    const deadlines = await loadDeadlines(this.ctx.storage);
+    if (!this.isCurrentConnection(runtime.connection)) {
+      return { allowed: false, reason: 'runtime_changed' };
+    }
+    const nextDeadline = Math.max(deadlines.idleStop ?? 0, Date.now() + DEADLINE_MS.idleStop);
+    if (nextDeadline !== deadlines.idleStop) {
+      await this.armDeadlineAndAlarm('idleStop', nextDeadline);
+    }
+    if (!this.isCurrentConnection(runtime.connection)) {
+      return { allowed: false, reason: 'runtime_changed' };
+    }
+    await this.renewProviderLease(runtime.connection);
+    return { allowed: true };
+  }
+
   async getStatus(): Promise<SandboxControlStatus> {
     const physical = await loadPhysicalRecord(this.ctx.storage);
     const connection = this.connectionState();
     const work = await this.workState();
+    const runtime = this.readyWrapperRuntime();
     return {
       reported: projectReportedStatus({ physical: physical.state, connection, work }),
       physical: physical.state,
       connection,
       work,
+      ...(physical.state === 'running' && runtime?.wrapperInstanceId
+        ? { wrapperInstanceId: runtime.wrapperInstanceId }
+        : {}),
     };
   }
 
@@ -415,6 +552,7 @@ export class SandboxControl extends DurableObject<Env> {
       OWNER_ID_KEY,
       CREDENTIAL_HASH_KEY,
       WRAPPER_READY_AT_KEY,
+      ACTIVE_WRAPPER_RUNTIME_KEY,
       DIAGNOSTIC_BUNDLE_KEY,
       PROVIDER_KIND_KEY,
     ]);
@@ -430,11 +568,15 @@ export class SandboxControl extends DurableObject<Env> {
     return createCloudflareProviderAdapter({
       sandboxId: this.sandboxId,
       getSandbox: id => {
-        const sandbox = getSandbox(this.env.Sandbox, id);
+        const sandbox = getSandbox(getSandboxNamespace(this.env, id), id);
         return {
           renewActivityTimeout: () => sandbox.renewActivityTimeout(),
           destroy: () => sandbox.destroy(),
-          isContainerRunning: async () => (await isSandboxContainerRunning(sandbox)) === true,
+          isContainerRunning: async () => {
+            const running = await isSandboxContainerRunning(sandbox);
+            if (running === undefined) throw new Error('Sandbox running state is unavailable');
+            return running;
+          },
           startProcess: (command, options) => sandbox.startProcess(command, options),
         };
       },
@@ -456,6 +598,7 @@ export class SandboxControl extends DurableObject<Env> {
     if (stored === undefined) {
       await this.ctx.storage.put(PROVIDER_KIND_KEY, kind);
     }
+    this.providerKind = kind;
     this.provider = this.createProviderAdapter(kind);
     return true;
   }
@@ -491,8 +634,13 @@ export class SandboxControl extends DurableObject<Env> {
       return;
     }
     if (id === 'heartbeatExpiry') {
+      const connection = this.activeConnection;
       this.socketHandler.closeHandshakenSockets(4002, 'heartbeat expired');
       this.kiloReady = false;
+      this.readyConnectionId = null;
+      if (connection) {
+        await this.ctx.storage.put(ACTIVE_WRAPPER_RUNTIME_KEY, connection);
+      }
       await this.ctx.storage.delete(WRAPPER_READY_AT_KEY);
       await this.appendLog(connectionTransition(now, 'ready', 'disconnected', 'heartbeatExpiry'));
       await this.armDeadlineIfAbsent('idleStop', now + DEADLINE_MS.idleStop);
@@ -529,35 +677,87 @@ export class SandboxControl extends DurableObject<Env> {
     }
   }
 
-  private async onHandshakeComplete(providerInstanceId: string): Promise<void> {
+  private async onHandshakeComplete(identity: SandboxControlConnectionIdentity): Promise<void> {
+    const socketConnection = this.socketHandler.getConnectionIdentity();
+    if (!socketConnection || !this.sameConnection(socketConnection, identity)) return;
+
+    const previous = this.activeConnection;
+    this.activeConnection = identity;
+    this.readyConnectionId = null;
+    this.kiloReady = false;
+    await Promise.all([
+      this.ctx.storage.put(ACTIVE_WRAPPER_RUNTIME_KEY, identity),
+      this.ctx.storage.delete(WRAPPER_READY_AT_KEY),
+    ]);
+    if (!this.isCurrentConnection(identity)) return;
     this.socketHandler.closeProvisionalSockets();
+    await this.cancelDeadlineAndAlarm('heartbeatExpiry');
+    if (!this.isCurrentConnection(identity)) return;
+
+    if (previous?.wrapperInstanceId && previous.wrapperInstanceId !== identity.wrapperInstanceId) {
+      await this.invalidateTerminalRuntime(previous.wrapperInstanceId, true);
+      if (!this.isCurrentConnection(identity)) return;
+    }
+
     await this.cancelDeadlineAndAlarm('socketHandshake');
+    if (!this.isCurrentConnection(identity)) return;
     const now = Date.now();
     const current = await loadPhysicalRecord(this.ctx.storage);
+    if (!this.isCurrentConnection(identity)) return;
     if (current.state === 'creating') {
-      const next = confirmRunning(current, providerInstanceId, now);
-      await this.persistPhysical(current, next, 'hello');
+      const providerRef =
+        current.providerRef ??
+        (this.providerKind === 'cloudflare' ? identity.providerInstanceId : undefined);
+      if (providerRef !== undefined) {
+        const next = confirmRunning(current, providerRef, now);
+        await this.persistPhysical(current, next, 'hello');
+        if (!this.isCurrentConnection(identity)) return;
+      }
     }
     await this.appendLog(connectionTransition(now, 'disconnected', 'connected', 'hello'));
     await this.armDeadlineAndAlarm('wrapperReadiness', now + DEADLINE_MS.wrapperReadiness);
     await this.cancelDeadlineAndAlarm('startup');
   }
 
-  private async onWrapperReady(): Promise<void> {
-    this.kiloReady = true;
+  private async onWrapperReady(identity: SandboxControlConnectionIdentity): Promise<void> {
+    if (!this.isCurrentConnection(identity)) return;
     const now = Date.now();
-    await this.ctx.storage.put(WRAPPER_READY_AT_KEY, now);
+    await this.ctx.storage.put({
+      [ACTIVE_WRAPPER_RUNTIME_KEY]: {
+        ...identity,
+        readyConnectionId: identity.connectionId,
+      } satisfies PersistedWrapperRuntime,
+      [WRAPPER_READY_AT_KEY]: now,
+    });
+    if (!this.isCurrentConnection(identity)) return;
+    this.readyConnectionId = identity.connectionId;
+    this.kiloReady = true;
     await this.cancelDeadlineAndAlarm('wrapperReadiness');
     await this.appendLog(connectionTransition(now, 'connected', 'ready', 'sandbox.ready'));
     await this.armDeadlineAndAlarm('heartbeatExpiry', now + DEADLINE_MS.heartbeatExpiry);
     await this.armDeadlineIfAbsent('idleStop', now + DEADLINE_MS.idleStop);
   }
 
-  private async onHeartbeat(payload: SandboxHeartbeatPayload): Promise<void> {
+  private async onHeartbeat(
+    payload: SandboxHeartbeatPayload,
+    identity: SandboxControlConnectionIdentity
+  ): Promise<void> {
+    if (!this.isCurrentConnection(identity)) return;
     this.kiloReady = payload.kilo.ready;
+    if (!payload.kilo.ready) {
+      this.readyConnectionId = null;
+      await Promise.all([
+        this.ctx.storage.put(ACTIVE_WRAPPER_RUNTIME_KEY, identity),
+        this.ctx.storage.delete(WRAPPER_READY_AT_KEY),
+      ]);
+      if (!this.isCurrentConnection(identity)) return;
+    }
+
     const now = Date.now();
     const table = await loadRouteTable(this.ctx.storage);
+    if (!this.isCurrentConnection(identity)) return;
     for (const session of payload.sessions) {
+      if (!this.isCurrentConnection(identity)) return;
       const previous = [...table.values()].find(
         entry => entry.kiloSessionId === session.kiloSessionId
       );
@@ -592,6 +792,7 @@ export class SandboxControl extends DurableObject<Env> {
         await this.appendLog({ at: now, kind: 'deadline', cause: 'observe-only' });
       }
     }
+    if (!this.isCurrentConnection(identity)) return;
     await saveRouteTable(this.ctx.storage, table);
     await this.armDeadlineAndAlarm('heartbeatExpiry', now + DEADLINE_MS.heartbeatExpiry);
     if (hasActiveWork(table)) {
@@ -599,12 +800,18 @@ export class SandboxControl extends DurableObject<Env> {
     } else {
       await this.armDeadlineIfAbsent('idleStop', now + DEADLINE_MS.idleStop);
     }
-    await this.renewProviderLease();
+    await this.renewProviderLease(identity);
   }
 
-  private async renewProviderLease(): Promise<void> {
+  private async renewProviderLease(identity: SandboxControlConnectionIdentity): Promise<void> {
     const physical = await loadPhysicalRecord(this.ctx.storage);
-    if (physical.state !== 'running' || physical.providerRef === null) return;
+    if (
+      !this.isCurrentConnection(identity) ||
+      physical.state !== 'running' ||
+      physical.providerRef === null
+    ) {
+      return;
+    }
     try {
       await this.provider.ensureLeaseAtLeast(physical.providerRef, leaseAtLeastMs());
     } catch {
@@ -614,40 +821,46 @@ export class SandboxControl extends DurableObject<Env> {
 
   private async onSessionEvent(
     identity: SessionEventIdentity | undefined,
-    payload: SessionEventPayload
+    payload: SessionEventPayload,
+    connection: SandboxControlConnectionIdentity
   ): Promise<void> {
+    if (!this.isCurrentConnection(connection)) return;
     if (!identity) {
       logger
         .withFields({ sandboxId: this.sandboxId, eventType: payload.type })
         .warn('session.event missing identity');
       return;
     }
-    await this.forwardRoutedSessionFrame(identity, payload.type, route =>
-      this.forwardSessionEvent(route, identity, payload)
+    await this.forwardRoutedSessionFrame(identity, payload.type, connection, route =>
+      this.forwardSessionEvent(route, identity, payload, connection)
     );
   }
 
   private async onSessionPreparing(
     identity: SessionEventIdentity | undefined,
-    payload: SessionPreparingPayload
+    payload: SessionPreparingPayload,
+    connection: SandboxControlConnectionIdentity
   ): Promise<void> {
+    if (!this.isCurrentConnection(connection)) return;
     if (!identity) {
       logger
         .withFields({ sandboxId: this.sandboxId, eventType: 'session.preparing' })
         .warn('session.event missing identity');
       return;
     }
-    await this.forwardRoutedSessionFrame(identity, 'session.preparing', route =>
-      this.forwardSessionPreparing(route, identity, payload)
+    await this.forwardRoutedSessionFrame(identity, 'session.preparing', connection, route =>
+      this.forwardSessionPreparing(route, identity, payload, connection)
     );
   }
 
   private async forwardRoutedSessionFrame(
     identity: SessionEventIdentity,
     eventType: string,
+    connection: SandboxControlConnectionIdentity,
     forward: (route: SessionRoute) => Promise<void>
   ): Promise<void> {
     const table = await loadRouteTable(this.ctx.storage);
+    if (!this.isCurrentConnection(connection)) return;
     const route = resolveSessionEventRoute(table, identity);
     if (!route) {
       logger
@@ -663,7 +876,9 @@ export class SandboxControl extends DurableObject<Env> {
     }
 
     const previous = this.sessionForwardChains.get(route.sessionId) ?? Promise.resolve();
-    const next = previous.catch(() => undefined).then(() => forward(route));
+    const next = previous
+      .catch(() => undefined)
+      .then(() => (this.isCurrentConnection(connection) ? forward(route) : undefined));
     this.sessionForwardChains.set(route.sessionId, next);
     this.ctx.waitUntil(next);
   }
@@ -671,8 +886,10 @@ export class SandboxControl extends DurableObject<Env> {
   private async forwardSessionEvent(
     route: SessionRoute,
     identity: SessionEventIdentity,
-    payload: SessionEventPayload
+    payload: SessionEventPayload,
+    connection: SandboxControlConnectionIdentity
   ): Promise<void> {
+    if (!this.isCurrentConnection(connection)) return;
     try {
       const applied = await withDORetry(
         () => getSandboxSessionStub(this.env, route.ownerId, route.sessionId),
@@ -683,7 +900,9 @@ export class SandboxControl extends DurableObject<Env> {
     } catch {
       // Session DO retry exhausted; flag the route for session.sync.
     }
+    if (!this.isCurrentConnection(connection)) return;
     const table = await loadRouteTable(this.ctx.storage);
+    if (!this.isCurrentConnection(connection)) return;
     markNeedsSync(table, route.sessionId);
     await saveRouteTable(this.ctx.storage, table);
   }
@@ -691,8 +910,10 @@ export class SandboxControl extends DurableObject<Env> {
   private async forwardSessionPreparing(
     route: SessionRoute,
     identity: SessionEventIdentity,
-    payload: SessionPreparingPayload
+    payload: SessionPreparingPayload,
+    connection: SandboxControlConnectionIdentity
   ): Promise<void> {
+    if (!this.isCurrentConnection(connection)) return;
     try {
       const applied = await withDORetry(
         () => getSandboxSessionStub(this.env, route.ownerId, route.sessionId),
@@ -703,25 +924,40 @@ export class SandboxControl extends DurableObject<Env> {
     } catch {
       // Session DO retry exhausted; flag the route for session.sync.
     }
+    if (!this.isCurrentConnection(connection)) return;
     const table = await loadRouteTable(this.ctx.storage);
+    if (!this.isCurrentConnection(connection)) return;
     markNeedsSync(table, route.sessionId);
     await saveRouteTable(this.ctx.storage, table);
   }
 
-  private async onSocketClosed(handshakeComplete: boolean): Promise<void> {
-    if (!handshakeComplete) return;
+  private async onSocketClosed(
+    handshakeComplete: boolean,
+    identity?: SandboxControlConnectionIdentity
+  ): Promise<void> {
+    if (!handshakeComplete || !identity || !this.isActiveConnection(identity)) return;
+    const replacement = this.socketHandler.getConnectionIdentity();
+    if (replacement && !this.sameConnection(replacement, identity)) return;
+
     this.kiloReady = false;
-    await this.ctx.storage.delete(WRAPPER_READY_AT_KEY);
+    this.readyConnectionId = null;
+    await Promise.all([
+      this.ctx.storage.put(ACTIVE_WRAPPER_RUNTIME_KEY, identity),
+      this.ctx.storage.delete(WRAPPER_READY_AT_KEY),
+    ]);
+    if (!this.isActiveConnection(identity)) return;
     await this.appendLog(connectionTransition(Date.now(), 'ready', 'disconnected', 'socket close'));
     await this.cancelDeadlineAndAlarm('heartbeatExpiry');
-    await this.reconcileLostConnection();
+    if (!this.isActiveConnection(identity)) return;
+    await this.reconcileLostConnection(identity);
   }
 
-  private async reconcileLostConnection(): Promise<void> {
+  private async reconcileLostConnection(identity: SandboxControlConnectionIdentity): Promise<void> {
+    if (!this.isActiveConnection(identity)) return;
     const physical = await loadPhysicalRecord(this.ctx.storage);
-    if (physical.state !== 'running') return;
-    const next = await this.observeCurrentProvider(physical);
-    if (next.state === 'running') {
+    if (!this.isActiveConnection(identity) || physical.state !== 'running') return;
+    const next = await this.observeCurrentProvider(physical, identity);
+    if (next.state === 'running' && this.isActiveConnection(identity)) {
       await this.armDeadlineAndAlarm('wrapperReadiness', Date.now() + DEADLINE_MS.wrapperReadiness);
     }
   }
@@ -758,18 +994,110 @@ export class SandboxControl extends DurableObject<Env> {
     return physical;
   }
 
-  private async observeCurrentProvider(physical: PhysicalRecord): Promise<PhysicalRecord> {
+  private async observeCurrentProvider(
+    physical: PhysicalRecord,
+    identity?: SandboxControlConnectionIdentity
+  ): Promise<PhysicalRecord> {
     let result: ObserveResult;
     try {
       result = await this.provider.observe(physical.providerRef);
     } catch {
       result = 'unknown';
     }
+    const current = await loadPhysicalRecord(this.ctx.storage);
+    if (
+      current.state !== physical.state ||
+      current.providerRef !== physical.providerRef ||
+      (identity && !this.isActiveConnection(identity))
+    ) {
+      return current;
+    }
     return this.observeProvider(result);
   }
 
+  private sameConnection(
+    left: SandboxControlConnectionIdentity,
+    right: SandboxControlConnectionIdentity
+  ): boolean {
+    return (
+      left.connectionId === right.connectionId &&
+      left.providerInstanceId === right.providerInstanceId &&
+      left.wrapperInstanceId === right.wrapperInstanceId
+    );
+  }
+
+  private isActiveConnection(identity: SandboxControlConnectionIdentity): boolean {
+    return this.activeConnection !== null && this.sameConnection(this.activeConnection, identity);
+  }
+
+  private isCurrentConnection(identity: SandboxControlConnectionIdentity): boolean {
+    const current = this.socketHandler.getConnectionIdentity();
+    return (
+      current !== null &&
+      this.sameConnection(current, identity) &&
+      this.isActiveConnection(identity)
+    );
+  }
+
+  private readyWrapperRuntime(): SandboxControlConnectionIdentity | null {
+    const current = this.socketHandler.getConnectionIdentity();
+    if (
+      !current ||
+      !this.isActiveConnection(current) ||
+      !this.kiloReady ||
+      this.readyConnectionId !== current.connectionId
+    ) {
+      return null;
+    }
+    return current;
+  }
+
+  private async readTerminalRuntime(
+    input: SandboxTerminalAccessInput
+  ): Promise<TerminalRuntimeSnapshot | TerminalRuntimeRejection> {
+    if (
+      typeof input.sessionId !== 'string' ||
+      input.sessionId.length === 0 ||
+      typeof input.ownerId !== 'string' ||
+      input.ownerId.length === 0 ||
+      typeof input.wrapperInstanceId !== 'string' ||
+      input.wrapperInstanceId.length === 0 ||
+      (input.organizationId !== undefined &&
+        (typeof input.organizationId !== 'string' || input.organizationId.length === 0)) ||
+      (input.botId !== undefined && (typeof input.botId !== 'string' || input.botId.length === 0))
+    ) {
+      return { allowed: false, reason: 'invalid_terminal_access' };
+    }
+
+    const [ownerId, routes, physical] = await Promise.all([
+      this.readOwner(),
+      loadRouteTable(this.ctx.storage),
+      loadPhysicalRecord(this.ctx.storage),
+    ]);
+    if (ownerId !== input.ownerId) return { allowed: false, reason: 'owner_mismatch' };
+    const route = routes.get(input.sessionId);
+    if (!route || route.ownerId !== input.ownerId) {
+      return { allowed: false, reason: 'session_not_attached' };
+    }
+    if (physical.state !== 'running' || physical.providerRef === null) {
+      return { allowed: false, reason: 'runtime_not_running' };
+    }
+
+    const connection = this.readyWrapperRuntime();
+    if (!connection) return { allowed: false, reason: 'runtime_not_ready' };
+    if (!connection.wrapperInstanceId) {
+      return { allowed: false, reason: 'terminal_not_supported' };
+    }
+    if (connection.wrapperInstanceId !== input.wrapperInstanceId) {
+      return { allowed: false, reason: 'wrapper_instance_mismatch' };
+    }
+
+    return { allowed: true, connection, physical, provider: this.providerKind, route };
+  }
+
   private connectionState(): ConnectionState {
-    if (!this.socketHandler.hasHandshakenSocket()) return 'disconnected';
+    const current = this.socketHandler.getConnectionIdentity();
+    if (!current || !this.isActiveConnection(current)) return 'disconnected';
     return this.kiloReady ? 'ready' : 'connected';
   }
 
@@ -794,6 +1122,20 @@ export class SandboxControl extends DurableObject<Env> {
   ): Promise<void> {
     await savePhysicalRecord(this.ctx.storage, to);
     if (from.state !== to.state) {
+      const connection = this.activeConnection;
+      if (connection && (to.state === 'failed' || to.state === 'stopped')) {
+        this.activeConnection = null;
+        this.readyConnectionId = null;
+        this.kiloReady = false;
+        this.socketHandler.closeHandshakenSockets(4002, 'Sandbox runtime unavailable');
+        await this.ctx.storage.delete([ACTIVE_WRAPPER_RUNTIME_KEY, WRAPPER_READY_AT_KEY]);
+        await this.cancelDeadlineAndAlarm('heartbeatExpiry');
+        if (connection.wrapperInstanceId) {
+          await this.invalidateTerminalRuntime(connection.wrapperInstanceId, true);
+        }
+      } else if (to.state === 'unknown' && connection?.wrapperInstanceId) {
+        await this.invalidateTerminalRuntime(connection.wrapperInstanceId, false, connection);
+      }
       await this.appendLog(
         physicalTransition(Date.now(), from.state, to.state, cause, to.providerRef)
       );
@@ -803,6 +1145,32 @@ export class SandboxControl extends DurableObject<Env> {
         );
       }
     }
+  }
+
+  private async invalidateTerminalRuntime(
+    wrapperInstanceId: string,
+    confirmed: boolean,
+    connection?: SandboxControlConnectionIdentity
+  ): Promise<void> {
+    const routes = await loadRouteTable(this.ctx.storage);
+    if (!confirmed && connection && !this.isActiveConnection(connection)) return;
+    await Promise.all(
+      [...routes.values()].map(route => {
+        if (!confirmed && connection && !this.isActiveConnection(connection)) {
+          return Promise.resolve();
+        }
+        return withDORetry(
+          () => getSandboxSessionStub(this.env, route.ownerId, route.sessionId),
+          stub =>
+            stub.invalidateTerminalRuntime({
+              sandboxId: this.sandboxId,
+              wrapperInstanceId,
+              confirmed,
+            }),
+          'invalidateTerminalRuntime'
+        ).catch(() => undefined);
+      })
+    );
   }
 
   private async notifyAttachedSessions(reason: string): Promise<void> {
@@ -827,7 +1195,8 @@ export class SandboxControl extends DurableObject<Env> {
   private async armDeadlineAndAlarm(id: DeadlineId, at: number): Promise<void> {
     const current = await loadDeadlines(this.ctx.storage);
     const wasArmed = current[id] !== undefined;
-    const deadlines = armDeadline(current, id, at);
+    const scheduledAt = id === 'idleStop' ? Math.max(current[id] ?? 0, at) : at;
+    const deadlines = armDeadline(current, id, scheduledAt);
     await saveDeadlines(this.ctx.storage, deadlines);
     if (!wasArmed) {
       await this.appendLog(deadlineTransition(Date.now(), id, 'armed'));

--- a/services/cloud-agent-next/src/router.test.ts
+++ b/services/cloud-agent-next/src/router.test.ts
@@ -2140,6 +2140,49 @@ describe('router question and permission controls', () => {
 });
 
 describe('router terminal procedures', () => {
+  const controlSessionId = 'workspace_12345678-1234-1234-1234-123456789abc' as SessionId;
+  const controlPty = {
+    id: 'pty_123',
+    title: 'Workspace terminal',
+    command: '/bin/sh',
+    args: [],
+    cwd: '/workspace/repo',
+    status: 'running' as const,
+    pid: 123,
+  };
+
+  beforeEach(() => {
+    requireCurrentSessionAccessMock.mockReset().mockResolvedValue({
+      kiloSessionId: 'ses_12345678901234567890123456',
+      organizationId: null,
+    });
+  });
+
+  function createControlTerminalCaller(stub: MockSessionStub) {
+    const cloudAgentSession: MockCAS = { idFromName: vi.fn(), get: vi.fn() };
+    const sandboxSession: MockCAS = {
+      idFromName: vi.fn().mockReturnValue('sandbox-session-do-id'),
+      get: vi.fn().mockReturnValue(stub),
+    };
+    const context = {
+      userId: 'test-user-123',
+      authToken: 'token',
+      botId: undefined,
+      request: new Request('http://test.local'),
+      env: {
+        CLOUD_AGENT_SESSION: cloudAgentSession,
+        SANDBOX_SESSION: sandboxSession,
+      },
+    } as unknown as TRPCContext;
+
+    return {
+      caller: appRouter.createCaller(context),
+      cloudAgentSession,
+      sandboxSession,
+      context,
+    };
+  }
+
   it('creates a terminal through the session Durable Object', async () => {
     const createTerminal = vi.fn().mockResolvedValue({
       success: true,
@@ -2190,6 +2233,116 @@ describe('router terminal procedures', () => {
     });
     expect(cloudAgentSession.idFromName).toHaveBeenCalledWith(`test-user-123:${sessionId}`);
     expect(createTerminal).toHaveBeenCalledWith({ cols: 120, rows: 32 });
+  });
+
+  it('creates control-plane terminals with a dedicated creation operation identity', async () => {
+    const createTerminal = vi.fn().mockResolvedValue({
+      success: true,
+      data: { pty: controlPty },
+    });
+    const { caller, sandboxSession, cloudAgentSession, context } = createControlTerminalCaller({
+      createTerminal,
+    });
+
+    await expect(
+      caller.createTerminal({ cloudAgentSessionId: controlSessionId, cols: 120, rows: 32 })
+    ).resolves.toEqual({ pty: controlPty });
+
+    expect(requireCurrentSessionAccessMock).toHaveBeenCalledWith({
+      env: context.env,
+      kiloUserId: 'test-user-123',
+      cloudAgentSessionId: controlSessionId,
+    });
+    expect(sandboxSession.idFromName).toHaveBeenCalledWith(`test-user-123:${controlSessionId}`);
+    expect(cloudAgentSession.idFromName).not.toHaveBeenCalled();
+    expect(createTerminal).toHaveBeenCalledWith({
+      cols: 120,
+      rows: 32,
+      operationId: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      ),
+    });
+  });
+
+  it('reuses the same control-plane creation operation identity after a retryable Durable Object failure', async () => {
+    const createTerminal = vi
+      .fn()
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Durable Object disconnected'), { retryable: true })
+      )
+      .mockResolvedValueOnce({ success: true, data: { pty: controlPty } });
+    const { caller, sandboxSession } = createControlTerminalCaller({ createTerminal });
+
+    await expect(
+      caller.createTerminal({ cloudAgentSessionId: controlSessionId, cols: 80, rows: 24 })
+    ).resolves.toEqual({ pty: controlPty });
+
+    expect(sandboxSession.idFromName).toHaveBeenCalledTimes(2);
+    expect(createTerminal).toHaveBeenCalledTimes(2);
+    expect(createTerminal.mock.calls[0]?.[0]).toEqual(createTerminal.mock.calls[1]?.[0]);
+    expect(createTerminal.mock.calls[0]?.[0]).toMatchObject({
+      cols: 80,
+      rows: 24,
+      operationId: expect.any(String),
+    });
+  });
+
+  it.each(['create', 'resize', 'close'] as const)(
+    'authorizes control-plane terminal %s before accessing its Durable Object',
+    async operation => {
+      requireCurrentSessionAccessMock.mockRejectedValueOnce(
+        new TRPCError({ code: 'FORBIDDEN', message: 'Session access denied' })
+      );
+      const { caller, sandboxSession } = createControlTerminalCaller({
+        createTerminal: vi.fn(),
+        resizeTerminal: vi.fn(),
+        closeTerminal: vi.fn(),
+      });
+
+      const result =
+        operation === 'create'
+          ? caller.createTerminal({ cloudAgentSessionId: controlSessionId, cols: 80, rows: 24 })
+          : operation === 'resize'
+            ? caller.resizeTerminal({
+                cloudAgentSessionId: controlSessionId,
+                ptyId: 'pty_123',
+                cols: 80,
+                rows: 24,
+              })
+            : caller.closeTerminal({ cloudAgentSessionId: controlSessionId, ptyId: 'pty_123' });
+
+      await expect(result).rejects.toMatchObject({ code: 'FORBIDDEN' });
+      expect(requireCurrentSessionAccessMock).toHaveBeenCalledOnce();
+      expect(sandboxSession.idFromName).not.toHaveBeenCalled();
+      expect(sandboxSession.get).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    {
+      error: 'Terminal access denied: the current wrapper does not support terminals',
+      code: 'FORBIDDEN',
+    },
+    {
+      error: 'Terminal access denied: credential containment is unavailable',
+      code: 'FORBIDDEN',
+    },
+    {
+      error: 'Terminal is only available after the workspace is prepared',
+      code: 'PRECONDITION_FAILED',
+    },
+    {
+      error: 'Terminal is only available to interactive Cloud Agent sessions',
+      code: 'FORBIDDEN',
+    },
+    { error: 'Session not found', code: 'NOT_FOUND' },
+  ])('projects control-plane terminal failure "$error" as $code', async ({ error, code }) => {
+    const createTerminal = vi.fn().mockResolvedValue({ success: false, error });
+    const { caller } = createControlTerminalCaller({ createTerminal });
+
+    await expect(
+      caller.createTerminal({ cloudAgentSessionId: controlSessionId, cols: 80, rows: 24 })
+    ).rejects.toMatchObject({ code, message: error });
   });
 
   it('denies terminal creation before Durable Object access', async () => {
@@ -2258,6 +2411,33 @@ describe('router terminal procedures', () => {
     await expect(
       caller.closeTerminal({ cloudAgentSessionId: sessionId, ptyId: 'pty_123' })
     ).resolves.toEqual({ success: true });
+    expect(resizeTerminal).toHaveBeenCalledWith({ ptyId: 'pty_123', cols: 80, rows: 24 });
+    expect(closeTerminal).toHaveBeenCalledWith({ ptyId: 'pty_123' });
+  });
+
+  it('resizes and closes control-plane terminals through the owner-scoped session Durable Object', async () => {
+    const resizeTerminal = vi.fn().mockResolvedValue({ success: true, data: { pty: controlPty } });
+    const closeTerminal = vi.fn().mockResolvedValue({ success: true, data: { success: true } });
+    const { caller, sandboxSession, cloudAgentSession } = createControlTerminalCaller({
+      resizeTerminal,
+      closeTerminal,
+    });
+
+    await expect(
+      caller.resizeTerminal({
+        cloudAgentSessionId: controlSessionId,
+        ptyId: 'pty_123',
+        cols: 80,
+        rows: 24,
+      })
+    ).resolves.toEqual({ pty: controlPty });
+    await expect(
+      caller.closeTerminal({ cloudAgentSessionId: controlSessionId, ptyId: 'pty_123' })
+    ).resolves.toEqual({ success: true });
+
+    expect(sandboxSession.idFromName).toHaveBeenCalledTimes(2);
+    expect(sandboxSession.idFromName).toHaveBeenCalledWith(`test-user-123:${controlSessionId}`);
+    expect(cloudAgentSession.idFromName).not.toHaveBeenCalled();
     expect(resizeTerminal).toHaveBeenCalledWith({ ptyId: 'pty_123', cols: 80, rows: 24 });
     expect(closeTerminal).toHaveBeenCalledWith({ ptyId: 'pty_123' });
   });

--- a/services/cloud-agent-next/src/router.test.ts
+++ b/services/cloud-agent-next/src/router.test.ts
@@ -2441,6 +2441,21 @@ describe('router terminal procedures', () => {
     expect(resizeTerminal).toHaveBeenCalledWith({ ptyId: 'pty_123', cols: 80, rows: 24 });
     expect(closeTerminal).toHaveBeenCalledWith({ ptyId: 'pty_123' });
   });
+
+  it('returns a retryable error when control-plane terminal closure fails', async () => {
+    const closeTerminal = vi
+      .fn()
+      .mockResolvedValueOnce({ success: false, error: 'Terminal closure failed; please retry' })
+      .mockResolvedValueOnce({ success: true, data: { success: true } });
+    const { caller } = createControlTerminalCaller({ closeTerminal });
+    const input = { cloudAgentSessionId: controlSessionId, ptyId: 'pty_123' };
+
+    await expect(caller.closeTerminal(input)).rejects.toMatchObject({
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'Terminal closure failed; please retry',
+    });
+    await expect(caller.closeTerminal(input)).resolves.toEqual({ success: true });
+  });
 });
 
 describe('legacy V2 execution response compatibility', () => {

--- a/services/cloud-agent-next/src/router/handlers/session-terminal.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-terminal.ts
@@ -7,6 +7,7 @@ import type { SessionId } from '../../types/ids.js';
 import { withDORetry } from '../../utils/do-retry.js';
 import { resolveSessionStub } from '../../sandbox-session/session-stub.js';
 import { sessionHasTerminal } from '../../agent-sandbox/capabilities.js';
+import { sessionPlaneFromId } from '../../session-plane.js';
 import { protectedProcedure } from '../auth.js';
 import { requireCurrentSessionAccess } from '../../session-access.js';
 import {
@@ -23,7 +24,7 @@ function throwTerminalError(result: OperationResult<unknown>): never {
   const code =
     message === 'Session not found'
       ? 'NOT_FOUND'
-      : message.includes('interactive Cloud Agent')
+      : message.startsWith('Terminal access denied:') || message.includes('interactive Cloud Agent')
         ? 'FORBIDDEN'
         : message.includes('workspace is prepared') ||
             message.includes('session wrapper is not running')
@@ -33,7 +34,7 @@ function throwTerminalError(result: OperationResult<unknown>): never {
   throw new TRPCError({ code, message });
 }
 
-function rejectControlPlaneTerminal(sessionId: string): void {
+function rejectUnsupportedTerminal(sessionId: string): void {
   if (!sessionHasTerminal(sessionId)) {
     throw new TRPCError({
       code: 'PRECONDITION_FAILED',
@@ -50,7 +51,6 @@ export function createSessionTerminalHandlers() {
       .mutation(async ({ input, ctx }) => {
         return withLogTags({ source: 'createTerminal' }, async () => {
           const sessionId = input.cloudAgentSessionId as SessionId;
-          rejectControlPlaneTerminal(sessionId);
           logger.setTags({ userId: ctx.userId, sessionId });
           logger.withFields({ cols: input.cols, rows: input.rows }).info('Creating terminal');
           await requireCurrentSessionAccess({
@@ -58,17 +58,18 @@ export function createSessionTerminalHandlers() {
             kiloUserId: ctx.userId,
             cloudAgentSessionId: sessionId,
           });
+          rejectUnsupportedTerminal(sessionId);
 
+          const terminalInput =
+            sessionPlaneFromId(sessionId) === 'control'
+              ? { cols: input.cols, rows: input.rows, operationId: crypto.randomUUID() }
+              : { cols: input.cols, rows: input.rows };
           const result = await withDORetry<
             DurableObjectStub<CloudAgentSession>,
             OperationResult<{ pty: WrapperPty }>
           >(
             () => resolveSessionStub(ctx.env, ctx.userId, sessionId),
-            stub =>
-              stub.createTerminal({
-                cols: input.cols,
-                rows: input.rows,
-              }),
+            stub => stub.createTerminal(terminalInput),
             'createTerminal'
           );
 
@@ -87,13 +88,13 @@ export function createSessionTerminalHandlers() {
       .mutation(async ({ input, ctx }) => {
         return withLogTags({ source: 'resizeTerminal' }, async () => {
           const sessionId = input.cloudAgentSessionId as SessionId;
-          rejectControlPlaneTerminal(sessionId);
           logger.setTags({ userId: ctx.userId, sessionId, ptyId: input.ptyId });
           await requireCurrentSessionAccess({
             env: ctx.env,
             kiloUserId: ctx.userId,
             cloudAgentSessionId: sessionId,
           });
+          rejectUnsupportedTerminal(sessionId);
           const result = await withDORetry<
             DurableObjectStub<CloudAgentSession>,
             OperationResult<{ pty: WrapperPty }>
@@ -122,7 +123,6 @@ export function createSessionTerminalHandlers() {
       .mutation(async ({ input, ctx }) => {
         return withLogTags({ source: 'closeTerminal' }, async () => {
           const sessionId = input.cloudAgentSessionId as SessionId;
-          rejectControlPlaneTerminal(sessionId);
           logger.setTags({ userId: ctx.userId, sessionId, ptyId: input.ptyId });
           logger.info('Closing terminal');
           await requireCurrentSessionAccess({
@@ -130,6 +130,7 @@ export function createSessionTerminalHandlers() {
             kiloUserId: ctx.userId,
             cloudAgentSessionId: sessionId,
           });
+          rejectUnsupportedTerminal(sessionId);
 
           const result = await withDORetry<
             DurableObjectStub<CloudAgentSession>,

--- a/services/cloud-agent-next/src/sandbox-control/frames.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/frames.test.ts
@@ -1,14 +1,40 @@
 import { describe, expect, it } from 'vitest';
-import { MAX_SANDBOX_CONTROL_FRAME_BYTES } from '../shared/sandbox-control-protocol.js';
+import {
+  MAX_SANDBOX_CONTROL_FRAME_BYTES,
+  SANDBOX_CONTROL_PROTOCOL_VERSION,
+  sandboxControlSocketAttachmentSchema,
+  sessionTerminalCloseResultSchema,
+  sessionTerminalConnectResultSchema,
+  sessionTerminalCreateResultSchema,
+  sessionTerminalResizeResultSchema,
+  terminalPtyIdSchema,
+} from '../shared/sandbox-control-protocol.js';
 import {
   errorResponse,
   isControlEvent,
   isControlOperation,
+  isSessionOperation,
   okResponse,
   parseControlFrame,
   parseEventPayload,
   parseOperationPayload,
+  parseSandboxHelloPayload,
 } from './frames.js';
+
+const operationId = '123e4567-e89b-42d3-a456-426614174000';
+const bridgeGeneration = '123e4567-e89b-42d3-a456-426614174001';
+const wrapperInstanceId = '123e4567-e89b-42d3-a456-426614174002';
+const connectionId = '123e4567-e89b-42d3-a456-426614174003';
+const terminalCapability = '0123456789abcdef'.repeat(4);
+const terminalPty = {
+  id: 'pty_1-valid',
+  title: 'Terminal',
+  command: '/bin/bash',
+  args: ['-l'],
+  cwd: '/workspace/repository',
+  status: 'running',
+  pid: 1234,
+};
 
 describe('sandbox control frames', () => {
   it('accepts a valid request envelope', () => {
@@ -40,10 +66,61 @@ describe('sandbox control frames', () => {
     expect(isControlOperation('sandbox.hello')).toBe(true);
     expect(isControlOperation('session.prompt')).toBe(true);
     expect(isControlOperation('http.tunnel')).toBe(false);
+    for (const operation of [
+      'session.terminal.create',
+      'session.terminal.resize',
+      'session.terminal.close',
+      'session.terminal.connect',
+    ]) {
+      expect(isControlOperation(operation)).toBe(true);
+      expect(isSessionOperation(operation)).toBe(true);
+    }
     expect(isControlEvent('sandbox.ready')).toBe(true);
     expect(isControlEvent('session.event')).toBe(true);
     expect(isControlEvent('session.preparing')).toBe(true);
     expect(isControlEvent('sandbox.hello')).toBe(false);
+  });
+
+  it('accepts legacy sandbox hellos and validates optional wrapper instance identity', () => {
+    const legacyPayload = {
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'sandbox_1',
+    };
+    const currentPayload = { ...legacyPayload, wrapperInstanceId };
+
+    expect(SANDBOX_CONTROL_PROTOCOL_VERSION).toBe(1);
+    expect(parseSandboxHelloPayload(legacyPayload)).toEqual(legacyPayload);
+    expect(parseSandboxHelloPayload(currentPayload)).toEqual(currentPayload);
+    expect(parseOperationPayload('sandbox.hello', currentPayload).ok).toBe(true);
+    expect(
+      parseOperationPayload('sandbox.hello', {
+        ...legacyPayload,
+        wrapperInstanceId: 'not-a-uuid',
+      }).ok
+    ).toBe(false);
+  });
+
+  it('preserves old socket attachments while validating optional connection identities', () => {
+    const legacyAttachment = { handshakeComplete: false, acceptedAt: 0 };
+    const currentAttachment = { ...legacyAttachment, connectionId, wrapperInstanceId };
+
+    expect(sandboxControlSocketAttachmentSchema.safeParse(legacyAttachment).success).toBe(true);
+    expect(sandboxControlSocketAttachmentSchema.safeParse(currentAttachment)).toMatchObject({
+      success: true,
+      data: currentAttachment,
+    });
+    expect(
+      sandboxControlSocketAttachmentSchema.safeParse({
+        ...legacyAttachment,
+        connectionId: 'not-a-uuid',
+      }).success
+    ).toBe(false);
+    expect(
+      sandboxControlSocketAttachmentSchema.safeParse({
+        ...legacyAttachment,
+        wrapperInstanceId: 'not-a-uuid',
+      }).success
+    ).toBe(false);
   });
 
   it('validates known operation and event payloads', () => {
@@ -180,6 +257,152 @@ describe('sandbox control frames', () => {
           },
         ],
       }).ok
+    ).toBe(false);
+  });
+
+  it('accepts only bounded URL-safe PTY identifiers', () => {
+    expect(terminalPtyIdSchema.safeParse('PTY_123-valid').success).toBe(true);
+    expect(terminalPtyIdSchema.safeParse('a'.repeat(128)).success).toBe(true);
+
+    for (const ptyId of ['', 'a'.repeat(129), '../pty', 'pty.id', 'pty%2Fid', 'pty id']) {
+      expect(terminalPtyIdSchema.safeParse(ptyId).success).toBe(false);
+    }
+  });
+
+  it('validates terminal creation identity and paired terminal dimensions', () => {
+    for (const payload of [
+      { operationId },
+      { operationId, cols: 2, rows: 2 },
+      { operationId, cols: 500, rows: 200 },
+    ]) {
+      expect(parseOperationPayload('session.terminal.create', payload)).toEqual({
+        ok: true,
+        payload,
+      });
+    }
+
+    for (const payload of [
+      {},
+      { operationId: 'not-a-uuid' },
+      { operationId, cols: 80 },
+      { operationId, rows: 24 },
+      { operationId, cols: 1, rows: 24 },
+      { operationId, cols: 501, rows: 24 },
+      { operationId, cols: 80, rows: 1 },
+      { operationId, cols: 80, rows: 201 },
+      { operationId, cols: 80.5, rows: 24 },
+      { operationId, cols: 80, rows: 24.5 },
+      { operationId, cols: 80, rows: 24, extra: true },
+    ]) {
+      expect(parseOperationPayload('session.terminal.create', payload).ok).toBe(false);
+    }
+  });
+
+  it('validates terminal resizing identity and required bounded dimensions', () => {
+    for (const payload of [
+      { ptyId: 'pty_1-valid', cols: 2, rows: 2 },
+      { ptyId: 'pty_1-valid', cols: 500, rows: 200 },
+    ]) {
+      expect(parseOperationPayload('session.terminal.resize', payload)).toEqual({
+        ok: true,
+        payload,
+      });
+    }
+
+    const payload = { ptyId: 'pty_1-valid', cols: 80, rows: 24 };
+    for (const invalidPayload of [
+      { cols: 80, rows: 24 },
+      { ptyId: 'pty_1-valid', rows: 24 },
+      { ptyId: 'pty_1-valid', cols: 80 },
+      { ...payload, ptyId: '../pty' },
+      { ...payload, cols: 1 },
+      { ...payload, cols: 501 },
+      { ...payload, rows: 1 },
+      { ...payload, rows: 201 },
+      { ...payload, cols: 80.5 },
+      { ...payload, rows: 24.5 },
+      { ...payload, extra: true },
+    ]) {
+      expect(parseOperationPayload('session.terminal.resize', invalidPayload).ok).toBe(false);
+    }
+  });
+
+  it('requires exactly one valid PTY identifier when closing a terminal', () => {
+    const payload = { ptyId: 'pty_1-valid' };
+    expect(parseOperationPayload('session.terminal.close', payload)).toEqual({
+      ok: true,
+      payload,
+    });
+
+    for (const invalidPayload of [{}, { ptyId: '../pty' }, { ...payload, extra: true }]) {
+      expect(parseOperationPayload('session.terminal.close', invalidPayload).ok).toBe(false);
+    }
+  });
+
+  it('validates terminal bridge credentials without restricting arbitrary owner identities', () => {
+    const payload = {
+      ownerId: 'oauth/provider:subject%2Fvalue',
+      ptyId: 'pty_1-valid',
+      bridgeGeneration,
+      capability: terminalCapability,
+    };
+
+    expect(parseOperationPayload('session.terminal.connect', payload)).toEqual({
+      ok: true,
+      payload,
+    });
+    expect(
+      parseOperationPayload('session.terminal.connect', {
+        ...payload,
+        ownerId: 'a'.repeat(300),
+      }).ok
+    ).toBe(true);
+
+    for (const invalidPayload of [
+      { ...payload, ownerId: '' },
+      { ...payload, ptyId: '../pty' },
+      { ...payload, bridgeGeneration: 'not-a-uuid' },
+      { ...payload, capability: terminalCapability.toUpperCase() },
+      { ...payload, capability: terminalCapability.slice(1) },
+      { ...payload, capability: `${terminalCapability}a` },
+      { ...payload, capability: `${terminalCapability.slice(1)}g` },
+      { ...payload, extra: true },
+    ]) {
+      expect(parseOperationPayload('session.terminal.connect', invalidPayload).ok).toBe(false);
+    }
+  });
+
+  it('validates create and resize results against the existing terminal PTY contract', () => {
+    for (const schema of [sessionTerminalCreateResultSchema, sessionTerminalResizeResultSchema]) {
+      expect(schema.safeParse({ pty: terminalPty }).success).toBe(true);
+      expect(schema.safeParse({ pty: { ...terminalPty, status: 'exited' } }).success).toBe(true);
+
+      for (const result of [
+        {},
+        { pty: { ...terminalPty, id: '../pty' } },
+        { pty: { ...terminalPty, args: [1] } },
+        { pty: { ...terminalPty, status: 'closed' } },
+        { pty: { ...terminalPty, pid: 1.5 } },
+        { pty: { ...terminalPty, pid: undefined } },
+        { pty: terminalPty, extra: true },
+      ]) {
+        expect(schema.safeParse(result).success).toBe(false);
+      }
+    }
+  });
+
+  it('validates terminal close and connect result contracts', () => {
+    expect(sessionTerminalCloseResultSchema.safeParse({ success: true }).success).toBe(true);
+    expect(sessionTerminalCloseResultSchema.safeParse({ success: false }).success).toBe(true);
+    expect(sessionTerminalCloseResultSchema.safeParse({ success: 'true' }).success).toBe(false);
+    expect(sessionTerminalCloseResultSchema.safeParse({ success: true, extra: true }).success).toBe(
+      false
+    );
+
+    expect(sessionTerminalConnectResultSchema.safeParse({ connected: true }).success).toBe(true);
+    expect(sessionTerminalConnectResultSchema.safeParse({ connected: false }).success).toBe(false);
+    expect(
+      sessionTerminalConnectResultSchema.safeParse({ connected: true, extra: true }).success
     ).toBe(false);
   });
 

--- a/services/cloud-agent-next/src/sandbox-control/frames.ts
+++ b/services/cloud-agent-next/src/sandbox-control/frames.ts
@@ -19,6 +19,10 @@ import {
   sessionPromptPayloadSchema,
   sessionQuestionResolvePayloadSchema,
   sessionSyncPayloadSchema,
+  sessionTerminalClosePayloadSchema,
+  sessionTerminalConnectPayloadSchema,
+  sessionTerminalCreatePayloadSchema,
+  sessionTerminalResizePayloadSchema,
   type ControlError,
   type ControlErrorCode,
   type ControlEvent,
@@ -43,6 +47,10 @@ const REQUEST_PAYLOAD_SCHEMAS: Record<ControlOperation, z.ZodType> = {
   'session.abort': sessionAbortPayloadSchema,
   'session.sync': sessionSyncPayloadSchema,
   'session.detach': sessionDetachPayloadSchema,
+  'session.terminal.create': sessionTerminalCreatePayloadSchema,
+  'session.terminal.resize': sessionTerminalResizePayloadSchema,
+  'session.terminal.close': sessionTerminalClosePayloadSchema,
+  'session.terminal.connect': sessionTerminalConnectPayloadSchema,
 };
 
 const EVENT_PAYLOAD_SCHEMAS: Record<ControlEvent, z.ZodType> = {

--- a/services/cloud-agent-next/src/sandbox-control/socket.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { SANDBOX_CONTROL_PROTOCOL_VERSION } from '../shared/sandbox-control-protocol.js';
 import { createSandboxControlSocketHandler } from './socket.js';
+import { createControlRequestWaiters } from './waiters.js';
 
 vi.mock('../logger.js', () => {
   const logger = {
@@ -14,7 +15,7 @@ vi.mock('../logger.js', () => {
 });
 
 type FakeWebSocket = {
-  deserializeAttachment: ReturnType<typeof vi.fn>;
+  deserializeAttachment: () => unknown;
   serializeAttachment: ReturnType<typeof vi.fn>;
   send: ReturnType<typeof vi.fn>;
   close: ReturnType<typeof vi.fn>;
@@ -31,24 +32,50 @@ function createFakeState(sockets: FakeWebSocket[] = []) {
 function createFakeWebSocket(
   attachment: unknown = { handshakeComplete: false, acceptedAt: Date.now() }
 ): FakeWebSocket {
-  let stored = attachment;
-  return {
+  let stored =
+    typeof attachment === 'object' && attachment !== null && !('connectionId' in attachment)
+      ? { ...attachment, connectionId: crypto.randomUUID() }
+      : attachment;
+  const socket: FakeWebSocket = {
     deserializeAttachment: vi.fn(() => stored),
     serializeAttachment: vi.fn((next: unknown) => {
       stored = next;
     }),
     send: vi.fn(),
-    close: vi.fn(),
+    close: vi.fn(() => {
+      socket.readyState = 2;
+    }),
     readyState: 1,
   };
+  return socket;
 }
 
 function asWs(ws: FakeWebSocket): WebSocket {
   return ws as unknown as WebSocket;
 }
 
+function helloFrame(
+  providerInstanceId: string,
+  wrapperInstanceId?: string,
+  requestId = 'req_hello'
+): string {
+  return JSON.stringify({
+    type: 'request',
+    requestId,
+    operation: 'sandbox.hello',
+    payload: {
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId,
+      ...(wrapperInstanceId ? { wrapperInstanceId } : {}),
+    },
+  });
+}
+
+const WRAPPER_INSTANCE_ID = '11111111-1111-4111-8111-111111111111';
+const REPLACEMENT_WRAPPER_INSTANCE_ID = '22222222-2222-4222-8222-222222222222';
+
 describe('sandbox control socket handler', () => {
-  it('does not replace the current socket until sandbox.hello succeeds', () => {
+  it('does not replace the current socket until sandbox.hello succeeds', async () => {
     const current = createFakeWebSocket({
       handshakeComplete: true,
       acceptedAt: Date.now(),
@@ -59,7 +86,7 @@ describe('sandbox control socket handler', () => {
     const state = createFakeState([current, incoming]);
     const handler = createSandboxControlSocketHandler(state, 'sbx_test');
 
-    void handler.handleMessage(
+    await handler.handleMessage(
       asWs(incoming),
       JSON.stringify({
         type: 'request',
@@ -84,7 +111,7 @@ describe('sandbox control socket handler', () => {
     );
   });
 
-  it('replaces the previous handshaken socket after sandbox.hello and probes status', () => {
+  it('replaces the previous handshaken socket after sandbox.hello and probes status', async () => {
     const current = createFakeWebSocket({
       handshakeComplete: true,
       acceptedAt: Date.now(),
@@ -95,7 +122,7 @@ describe('sandbox control socket handler', () => {
     const state = createFakeState([current, incoming]);
     const handler = createSandboxControlSocketHandler(state, 'sbx_test');
 
-    void handler.handleMessage(
+    await handler.handleMessage(
       asWs(incoming),
       JSON.stringify({
         type: 'request',
@@ -108,6 +135,7 @@ describe('sandbox control socket handler', () => {
     expect(incoming.serializeAttachment).toHaveBeenCalledWith({
       handshakeComplete: true,
       acceptedAt: expect.any(Number),
+      connectionId: expect.any(String),
       protocolVersion: 1,
       providerInstanceId: 'inst_1',
     });
@@ -127,7 +155,270 @@ describe('sandbox control socket handler', () => {
     expect(statusFrame).toMatchObject({ type: 'request', operation: 'sandbox.status' });
   });
 
-  it('rejects inbound sandbox.status after handshake as not implemented', () => {
+  it('exposes the authenticated connection and wrapper identities', async () => {
+    const incoming = createFakeWebSocket();
+    const onHandshakeComplete = vi.fn();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([incoming]),
+      'sbx_test',
+      undefined,
+      { onHandshakeComplete }
+    );
+
+    await handler.handleMessage(asWs(incoming), helloFrame('inst_1', WRAPPER_INSTANCE_ID));
+
+    const identity = {
+      connectionId: expect.any(String),
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    };
+    expect(handler.getConnectionIdentity()).toEqual(identity);
+    expect(incoming.deserializeAttachment()).toMatchObject({
+      handshakeComplete: true,
+      ...identity,
+    });
+    expect(onHandshakeComplete).toHaveBeenCalledWith(handler.getConnectionIdentity());
+  });
+
+  it('rejects duplicate hellos without replacing the current connection', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    const provisional = createFakeWebSocket();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current, provisional]),
+      'sbx_test'
+    );
+    const identity = handler.getConnectionIdentity();
+
+    await handler.handleMessage(
+      asWs(current),
+      helloFrame('inst_replacement', REPLACEMENT_WRAPPER_INSTANCE_ID, 'req_duplicate')
+    );
+
+    expect(handler.getConnectionIdentity()).toEqual(identity);
+    expect(current.close).not.toHaveBeenCalled();
+    expect(provisional.close).not.toHaveBeenCalled();
+    expect(current.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'response',
+        requestId: 'req_duplicate',
+        ok: false,
+        error: {
+          code: 'protocol_error',
+          message: 'sandbox.hello requires an unconsumed provisional connection',
+          retryable: false,
+        },
+      })
+    );
+  });
+
+  it('ignores closing provisional hellos without replacing the current connection', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+    });
+    const incoming = createFakeWebSocket();
+    incoming.readyState = 2;
+    const onHandshakeComplete = vi.fn();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current, incoming]),
+      'sbx_test',
+      undefined,
+      { onHandshakeComplete }
+    );
+
+    await handler.handleMessage(asWs(incoming), helloFrame('inst_2', WRAPPER_INSTANCE_ID));
+
+    expect(current.close).not.toHaveBeenCalled();
+    expect(incoming.send).not.toHaveBeenCalled();
+    expect(onHandshakeComplete).not.toHaveBeenCalled();
+    expect(handler.getConnectionIdentity()).toMatchObject({ providerInstanceId: 'inst_1' });
+  });
+
+  it('rejects provisional hellos without an original connection identity', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+    });
+    const incoming = createFakeWebSocket({
+      handshakeComplete: false,
+      acceptedAt: Date.now(),
+      connectionId: undefined,
+    });
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current, incoming]),
+      'sbx_test'
+    );
+
+    await handler.handleMessage(asWs(incoming), helloFrame('inst_2', WRAPPER_INSTANCE_ID));
+
+    expect(current.close).not.toHaveBeenCalled();
+    expect(incoming.close).toHaveBeenCalledWith(1008, 'invalid_handshake');
+    expect(handler.getConnectionIdentity()).toMatchObject({ providerInstanceId: 'inst_1' });
+  });
+
+  it('rejects provisional sockets that share another connection identity', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+    });
+    const connectionId = crypto.randomUUID();
+    const incoming = createFakeWebSocket({
+      handshakeComplete: false,
+      acceptedAt: Date.now(),
+      connectionId,
+    });
+    const duplicate = createFakeWebSocket({
+      handshakeComplete: false,
+      acceptedAt: Date.now(),
+      connectionId,
+    });
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current, incoming, duplicate]),
+      'sbx_test'
+    );
+
+    await handler.handleMessage(asWs(incoming), helloFrame('inst_2', WRAPPER_INSTANCE_ID));
+
+    expect(incoming.close).toHaveBeenCalledWith(1008, 'invalid_handshake');
+    expect(current.close).not.toHaveBeenCalled();
+    expect(duplicate.close).not.toHaveBeenCalled();
+    expect(handler.getConnectionIdentity()).toMatchObject({ providerInstanceId: 'inst_1' });
+  });
+
+  it('revokes superseded provisional identities before closing their sockets', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+    });
+    const incoming = createFakeWebSocket();
+    const superseded = createFakeWebSocket();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current, incoming, superseded]),
+      'sbx_test'
+    );
+
+    await handler.handleMessage(asWs(incoming), helloFrame('inst_2', WRAPPER_INSTANCE_ID));
+
+    expect(superseded.deserializeAttachment()).toEqual({
+      handshakeComplete: false,
+      acceptedAt: expect.any(Number),
+    });
+    expect(superseded.close).toHaveBeenCalledWith(1008, 'handshake_required');
+
+    superseded.readyState = 1;
+    await handler.handleMessage(
+      asWs(superseded),
+      helloFrame('inst_stale', REPLACEMENT_WRAPPER_INSTANCE_ID, 'req_stale')
+    );
+
+    expect(incoming.close).not.toHaveBeenCalled();
+    expect(handler.getConnectionIdentity()).toMatchObject({
+      providerInstanceId: 'inst_2',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+  });
+
+  it('activates the replacement identity before exposing handshake or readiness', async () => {
+    const incoming = createFakeWebSocket();
+    let finishActivation: (() => void) | undefined;
+    const activation = new Promise<void>(resolve => {
+      finishActivation = resolve;
+    });
+    const onHandshakeComplete = vi.fn(() => activation);
+    const onReady = vi.fn();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([incoming]),
+      'sbx_test',
+      undefined,
+      { onHandshakeComplete, onReady }
+    );
+    const pending = handler.handleMessage(
+      asWs(incoming),
+      helloFrame('inst_1', WRAPPER_INSTANCE_ID)
+    );
+
+    expect(onHandshakeComplete).toHaveBeenCalledWith(handler.getConnectionIdentity());
+    expect(incoming.send).not.toHaveBeenCalled();
+
+    await handler.handleMessage(
+      asWs(incoming),
+      JSON.stringify({
+        type: 'event',
+        event: 'sandbox.ready',
+        payload: { kiloReady: true, globalFeedAttached: true },
+      })
+    );
+    expect(onReady).not.toHaveBeenCalled();
+
+    finishActivation?.();
+    await pending;
+
+    expect(incoming.send).toHaveBeenCalledTimes(2);
+    await handler.handleMessage(
+      asWs(incoming),
+      JSON.stringify({
+        type: 'event',
+        event: 'sandbox.ready',
+        payload: { kiloReady: true, globalFeedAttached: true },
+      })
+    );
+    expect(onReady).toHaveBeenCalledWith(handler.getConnectionIdentity());
+  });
+
+  it('does not acknowledge an activation superseded by a newer connection', async () => {
+    const first = createFakeWebSocket();
+    const sockets = [first];
+    const firstAttachment = first.deserializeAttachment() as { connectionId: string };
+    let finishActivation: (() => void) | undefined;
+    const activation = new Promise<void>(resolve => {
+      finishActivation = resolve;
+    });
+    const onHandshakeComplete = vi.fn((identity: { connectionId: string }) =>
+      identity.connectionId === firstAttachment.connectionId ? activation : undefined
+    );
+    const handler = createSandboxControlSocketHandler(
+      createFakeState(sockets),
+      'sbx_test',
+      undefined,
+      { onHandshakeComplete }
+    );
+    const firstHandshake = handler.handleMessage(
+      asWs(first),
+      helloFrame('inst_1', WRAPPER_INSTANCE_ID, 'req_first')
+    );
+    const second = createFakeWebSocket();
+    sockets.push(second);
+
+    await handler.handleMessage(
+      asWs(second),
+      helloFrame('inst_2', REPLACEMENT_WRAPPER_INSTANCE_ID, 'req_second')
+    );
+    finishActivation?.();
+    await firstHandshake;
+
+    expect(first.send).not.toHaveBeenCalled();
+    expect(second.send).toHaveBeenCalledTimes(2);
+    expect(handler.getConnectionIdentity()).toMatchObject({
+      providerInstanceId: 'inst_2',
+      wrapperInstanceId: REPLACEMENT_WRAPPER_INSTANCE_ID,
+    });
+  });
+
+  it('rejects inbound sandbox.status after handshake as not implemented', async () => {
     const ws = createFakeWebSocket({
       handshakeComplete: true,
       acceptedAt: Date.now(),
@@ -135,7 +426,7 @@ describe('sandbox control socket handler', () => {
       providerInstanceId: 'inst_1',
     });
     const handler = createSandboxControlSocketHandler(createFakeState([ws]), 'sbx_test');
-    void handler.handleMessage(
+    await handler.handleMessage(
       asWs(ws),
       JSON.stringify({
         type: 'request',
@@ -154,13 +445,13 @@ describe('sandbox control socket handler', () => {
     );
   });
 
-  it('closes a provisional socket that misses the hello deadline', () => {
+  it('closes a provisional socket that misses the hello deadline', async () => {
     const ws = createFakeWebSocket({
       handshakeComplete: false,
       acceptedAt: Date.now() - 11_000,
     });
     const handler = createSandboxControlSocketHandler(createFakeState([ws]), 'sbx_test');
-    void handler.handleMessage(
+    await handler.handleMessage(
       asWs(ws),
       JSON.stringify({
         type: 'request',
@@ -173,14 +464,14 @@ describe('sandbox control socket handler', () => {
     expect(ws.send).not.toHaveBeenCalled();
   });
 
-  it('closes oversized frames with payload_too_large', () => {
+  it('closes oversized frames with payload_too_large', async () => {
     const ws = createFakeWebSocket();
     const handler = createSandboxControlSocketHandler(createFakeState([ws]), 'sbx_test');
-    void handler.handleMessage(asWs(ws), 'x'.repeat(1 * 1024 * 1024 + 1));
+    await handler.handleMessage(asWs(ws), 'x'.repeat(1 * 1024 * 1024 + 1));
     expect(ws.close).toHaveBeenCalledWith(1009, 'payload_too_large');
   });
 
-  it('rejects inbound session.prompt with an invalid payload', () => {
+  it('rejects inbound session.prompt with an invalid payload', async () => {
     const ws = createFakeWebSocket({
       handshakeComplete: true,
       acceptedAt: Date.now(),
@@ -188,7 +479,7 @@ describe('sandbox control socket handler', () => {
       providerInstanceId: 'inst_1',
     });
     const handler = createSandboxControlSocketHandler(createFakeState([ws]), 'sbx_test');
-    void handler.handleMessage(
+    await handler.handleMessage(
       asWs(ws),
       JSON.stringify({
         type: 'request',
@@ -226,7 +517,7 @@ describe('sandbox control socket handler', () => {
       operation: string;
     };
     expect(sent.operation).toBe('sandbox.status');
-    void handler.handleMessage(
+    await handler.handleMessage(
       asWs(ws),
       JSON.stringify({
         type: 'response',
@@ -236,6 +527,206 @@ describe('sandbox control socket handler', () => {
       })
     );
     await expect(pending).resolves.toMatchObject({ ok: true, requestId: sent.requestId });
+  });
+
+  it('prevents provisional responses from settling current connection waiters', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+    });
+    const provisional = createFakeWebSocket();
+    const waiters = createControlRequestWaiters();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current, provisional]),
+      'sbx_test',
+      waiters
+    );
+    const pending = handler.sendRequest({ operation: 'sandbox.status', payload: {} });
+    const request = JSON.parse(current.send.mock.calls[0]?.[0] as string) as { requestId: string };
+    const response = JSON.stringify({
+      type: 'response',
+      requestId: request.requestId,
+      ok: true,
+      result: { healthy: true, state: 'idle', version: 'test' },
+    });
+
+    await handler.handleMessage(asWs(provisional), response);
+
+    expect(waiters.pendingCount()).toBe(1);
+    expect(provisional.close).toHaveBeenCalledWith(1008, 'handshake_required');
+    await handler.handleMessage(asWs(current), response);
+    await expect(pending).resolves.toMatchObject({ ok: true, requestId: request.requestId });
+  });
+
+  it('prevents replaced socket responses from settling replacement waiters', async () => {
+    const previous = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    const incoming = createFakeWebSocket();
+    const waiters = createControlRequestWaiters();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([previous, incoming]),
+      'sbx_test',
+      waiters
+    );
+    await handler.handleMessage(
+      asWs(incoming),
+      helloFrame('inst_2', REPLACEMENT_WRAPPER_INSTANCE_ID)
+    );
+    const pending = handler.sendRequest({ operation: 'sandbox.status', payload: {} });
+    const request = JSON.parse(incoming.send.mock.calls[2]?.[0] as string) as { requestId: string };
+    const response = JSON.stringify({
+      type: 'response',
+      requestId: request.requestId,
+      ok: true,
+      result: { healthy: true, state: 'idle', version: 'test' },
+    });
+
+    previous.readyState = 1;
+    await handler.handleMessage(asWs(previous), response);
+
+    expect(waiters.pendingCount()).toBe(1);
+    expect(handler.getConnectionIdentity()).toMatchObject({
+      wrapperInstanceId: REPLACEMENT_WRAPPER_INSTANCE_ID,
+    });
+    await handler.handleMessage(asWs(incoming), response);
+    await expect(pending).resolves.toMatchObject({ ok: true, requestId: request.requestId });
+  });
+
+  it('rejects stale readiness, heartbeat, and session events before their hooks', async () => {
+    const previous = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    const incoming = createFakeWebSocket();
+    const hooks = {
+      onReady: vi.fn(),
+      onHeartbeat: vi.fn(),
+      onSessionEvent: vi.fn(),
+      onSessionPreparing: vi.fn(),
+    };
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([previous, incoming]),
+      'sbx_test',
+      undefined,
+      hooks
+    );
+    await handler.handleMessage(
+      asWs(incoming),
+      helloFrame('inst_2', REPLACEMENT_WRAPPER_INSTANCE_ID)
+    );
+    const events = [
+      {
+        event: 'sandbox.ready',
+        payload: { kiloReady: true, globalFeedAttached: true },
+      },
+      {
+        event: 'sandbox.heartbeat',
+        payload: { state: 'idle', kilo: { ready: true }, sessions: [] },
+      },
+      {
+        event: 'session.event',
+        session: { directory: '/workspace/a', kiloSessionId: 'kilo_1' },
+        payload: { type: 'message.updated', properties: { id: 'msg_1' } },
+      },
+      {
+        event: 'session.preparing',
+        session: { directory: '/workspace/a', kiloSessionId: 'kilo_1' },
+        payload: {
+          version: 2,
+          attemptId: 'att_1',
+          triggerMessageId: 'msg_1',
+          revision: 1,
+          timestamp: 10,
+          step: 'cloning',
+          message: 'Cloning repository',
+          action: 'step_started',
+        },
+      },
+    ];
+
+    for (const event of events) {
+      previous.readyState = 1;
+      await handler.handleMessage(asWs(previous), JSON.stringify({ type: 'event', ...event }));
+    }
+
+    expect(hooks.onReady).not.toHaveBeenCalled();
+    expect(hooks.onHeartbeat).not.toHaveBeenCalled();
+    expect(hooks.onSessionEvent).not.toHaveBeenCalled();
+    expect(hooks.onSessionPreparing).not.toHaveBeenCalled();
+    expect(handler.getConnectionIdentity()).toMatchObject({
+      wrapperInstanceId: REPLACEMENT_WRAPPER_INSTANCE_ID,
+    });
+  });
+
+  it('rejects stale authenticated requests before responding or changing authority', async () => {
+    const stale = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      connectionId: undefined,
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_stale',
+    });
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_current',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([stale, current]),
+      'sbx_test'
+    );
+
+    await handler.handleMessage(
+      asWs(stale),
+      JSON.stringify({
+        type: 'request',
+        requestId: 'req_stale',
+        operation: 'sandbox.status',
+        payload: {},
+      })
+    );
+
+    expect(stale.send).not.toHaveBeenCalled();
+    expect(stale.close).toHaveBeenCalledWith(1008, 'stale_connection');
+    expect(current.close).not.toHaveBeenCalled();
+    expect(handler.getConnectionIdentity()).toMatchObject({ providerInstanceId: 'inst_current' });
+  });
+
+  it('passes the authoritative connection identity to heartbeat hooks', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    const onHeartbeat = vi.fn();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current]),
+      'sbx_test',
+      undefined,
+      { onHeartbeat }
+    );
+    const payload = { state: 'idle', kilo: { ready: true }, sessions: [] };
+
+    await handler.handleMessage(
+      asWs(current),
+      JSON.stringify({ type: 'event', event: 'sandbox.heartbeat', payload })
+    );
+
+    expect(onHeartbeat).toHaveBeenCalledWith(payload, handler.getConnectionIdentity());
   });
 
   it('rejects in-flight waiters when the current socket closes', async () => {
@@ -301,7 +792,8 @@ describe('sandbox control socket handler', () => {
     );
     expect(onSessionEvent).toHaveBeenCalledWith(
       { directory: '/workspace/a', kiloSessionId: 'kilo_child', rootKiloSessionId: 'kilo_1' },
-      { type: 'message.updated', properties: { id: 'msg_1' } }
+      { type: 'message.updated', properties: { id: 'msg_1' } },
+      handler.getConnectionIdentity()
     );
   });
 
@@ -369,7 +861,159 @@ describe('sandbox control socket handler', () => {
     );
     expect(onSessionPreparing).toHaveBeenCalledWith(
       { directory: '/workspace/a', kiloSessionId: 'kilo_1' },
-      payload
+      payload,
+      handler.getConnectionIdentity()
+    );
+  });
+
+  it('reports the identity when the authoritative connection closes', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    const onSocketClosed = vi.fn();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current]),
+      'sbx_test',
+      undefined,
+      { onSocketClosed }
+    );
+    const identity = handler.getConnectionIdentity();
+    current.readyState = 3;
+
+    await handler.handleClose(asWs(current));
+
+    expect(onSocketClosed).toHaveBeenCalledWith(true, identity);
+    expect(handler.getConnectionIdentity()).toBeNull();
+  });
+
+  it('preserves wrapper identity across reconnects and ignores replaced socket closes', async () => {
+    const previous = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    const incoming = createFakeWebSocket();
+    const waiters = createControlRequestWaiters();
+    const onHandshakeComplete = vi.fn();
+    const onSocketClosed = vi.fn();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([previous, incoming]),
+      'sbx_test',
+      waiters,
+      { onHandshakeComplete, onSocketClosed }
+    );
+    const previousIdentity = handler.getConnectionIdentity();
+
+    await handler.handleMessage(asWs(incoming), helloFrame('inst_1', WRAPPER_INSTANCE_ID));
+
+    const currentIdentity = handler.getConnectionIdentity();
+    expect(currentIdentity).toMatchObject({
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    expect(currentIdentity?.connectionId).not.toBe(previousIdentity?.connectionId);
+    expect(onHandshakeComplete).toHaveBeenCalledWith(currentIdentity);
+
+    const pending = handler.sendRequest({ operation: 'sandbox.status', payload: {} });
+    const request = JSON.parse(incoming.send.mock.calls[2]?.[0] as string) as { requestId: string };
+    await handler.handleClose(asWs(previous));
+
+    expect(onSocketClosed).not.toHaveBeenCalled();
+    expect(waiters.pendingCount()).toBe(1);
+    await handler.handleMessage(
+      asWs(incoming),
+      JSON.stringify({
+        type: 'response',
+        requestId: request.requestId,
+        ok: true,
+        result: { healthy: true, state: 'idle', version: 'test' },
+      })
+    );
+    await expect(pending).resolves.toMatchObject({ ok: true });
+  });
+
+  it('reconstructs the open authoritative connection without relying on timestamps', () => {
+    const acceptedAt = Date.now();
+    const closing = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt,
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_old',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    });
+    closing.readyState = 2;
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt,
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_current',
+      wrapperInstanceId: REPLACEMENT_WRAPPER_INSTANCE_ID,
+    });
+    const state = createFakeState([current, closing]);
+    const initial = createSandboxControlSocketHandler(state, 'sbx_test').getConnectionIdentity();
+    const reconstructed = createSandboxControlSocketHandler(state, 'sbx_test');
+
+    expect(reconstructed.getConnectionIdentity()).toEqual(initial);
+    expect(reconstructed.getConnectionIdentity()).toMatchObject({
+      providerInstanceId: 'inst_current',
+      wrapperInstanceId: REPLACEMENT_WRAPPER_INSTANCE_ID,
+    });
+  });
+
+  it('upgrades one legacy handshaken attachment with a unique connection identity', () => {
+    const legacy = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      connectionId: undefined,
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_legacy',
+    });
+    const handler = createSandboxControlSocketHandler(createFakeState([legacy]), 'sbx_test');
+
+    const identity = handler.getConnectionIdentity();
+
+    expect(identity).toEqual({
+      connectionId: expect.any(String),
+      providerInstanceId: 'inst_legacy',
+    });
+    expect(legacy.serializeAttachment).toHaveBeenCalledWith(
+      expect.objectContaining({
+        handshakeComplete: true,
+        connectionId: identity?.connectionId,
+      })
+    );
+  });
+
+  it('fails closed when multiple legacy attachments cannot establish authority', async () => {
+    const acceptedAt = Date.now();
+    const first = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt,
+      connectionId: undefined,
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_1',
+    });
+    const second = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt,
+      connectionId: undefined,
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_2',
+    });
+    const handler = createSandboxControlSocketHandler(createFakeState([first, second]), 'sbx_test');
+
+    expect(handler.getConnectionIdentity()).toBeNull();
+    expect(handler.hasHandshakenSocket()).toBe(false);
+    expect(first.serializeAttachment).not.toHaveBeenCalled();
+    expect(second.serializeAttachment).not.toHaveBeenCalled();
+    await expect(handler.sendRequest({ operation: 'sandbox.status', payload: {} })).rejects.toThrow(
+      'No ready wrapper socket'
     );
   });
 
@@ -396,7 +1040,7 @@ describe('sandbox control socket handler', () => {
       'sbx_test'
     );
     const pending = handler.sendRequest({ operation: 'sandbox.status', payload: {} });
-    void handler.handleMessage(
+    await handler.handleMessage(
       asWs(incoming),
       JSON.stringify({
         type: 'request',

--- a/services/cloud-agent-next/src/sandbox-control/socket.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.ts
@@ -42,19 +42,33 @@ export type SandboxControlOutboundRequest = {
   timeoutMs?: number;
 };
 
+export type SandboxControlConnectionIdentity = {
+  connectionId: string;
+  providerInstanceId: string;
+  wrapperInstanceId?: string;
+};
+
 export type SandboxControlSocketHooks = {
-  onHandshakeComplete?(providerInstanceId: string): void | Promise<void>;
-  onReady?(): void | Promise<void>;
-  onHeartbeat?(payload: SandboxHeartbeatPayload): void | Promise<void>;
+  onHandshakeComplete?(identity: SandboxControlConnectionIdentity): void | Promise<void>;
+  onReady?(identity: SandboxControlConnectionIdentity): void | Promise<void>;
+  onHeartbeat?(
+    payload: SandboxHeartbeatPayload,
+    identity: SandboxControlConnectionIdentity
+  ): void | Promise<void>;
   onSessionEvent?(
-    identity: SessionEventIdentity | undefined,
-    payload: SessionEventPayload
+    sessionIdentity: SessionEventIdentity | undefined,
+    payload: SessionEventPayload,
+    identity: SandboxControlConnectionIdentity
   ): void | Promise<void>;
   onSessionPreparing?(
-    identity: SessionEventIdentity | undefined,
-    payload: SessionPreparingPayload
+    sessionIdentity: SessionEventIdentity | undefined,
+    payload: SessionPreparingPayload,
+    identity: SandboxControlConnectionIdentity
   ): void | Promise<void>;
-  onSocketClosed?(handshakeComplete: boolean): void | Promise<void>;
+  onSocketClosed?(
+    handshakeComplete: boolean,
+    identity?: SandboxControlConnectionIdentity
+  ): void | Promise<void>;
 };
 
 export type SandboxControlSocketHandler = {
@@ -65,6 +79,7 @@ export type SandboxControlSocketHandler = {
   closeHandshakenSockets(code: number, reason: string): void;
   sendRequest(input: SandboxControlOutboundRequest): Promise<ResponseFrame>;
   hasHandshakenSocket(): boolean;
+  getConnectionIdentity(): SandboxControlConnectionIdentity | null;
   closeProvisionalSockets(): void;
 };
 
@@ -86,19 +101,107 @@ function closeSocket(ws: WebSocket, code: number, reason: string): void {
   }
 }
 
-function currentHandshakenSocket(state: SandboxControlSocketState): WebSocket | null {
+type HandshakenSandboxControlSocket = {
+  socket: WebSocket;
+  identity: SandboxControlConnectionIdentity;
+};
+
+function readConnectionIdentity(
+  attachment: SandboxControlSocketAttachment | null
+): SandboxControlConnectionIdentity | null {
+  if (
+    !attachment?.handshakeComplete ||
+    !attachment.connectionId ||
+    !attachment.providerInstanceId
+  ) {
+    return null;
+  }
+
+  return {
+    connectionId: attachment.connectionId,
+    providerInstanceId: attachment.providerInstanceId,
+    ...(attachment.wrapperInstanceId ? { wrapperInstanceId: attachment.wrapperInstanceId } : {}),
+  };
+}
+
+function currentHandshakenSocket(
+  state: SandboxControlSocketState
+): HandshakenSandboxControlSocket | null {
   let current: WebSocket | null = null;
-  let acceptedAt = -1;
+  let legacy: WebSocket | null = null;
+  let ambiguousLegacy = false;
+
   for (const ws of state.getWebSockets(SANDBOX_CONTROL_WS_TAG)) {
     if (ws.readyState !== 1) continue;
     const attachment = readAttachment(ws);
-    if (!attachment?.handshakeComplete) continue;
-    if (attachment.acceptedAt >= acceptedAt) {
+    if (!attachment?.handshakeComplete || !attachment.providerInstanceId) continue;
+    if (attachment.connectionId) {
+      if (current) return null;
       current = ws;
-      acceptedAt = attachment.acceptedAt;
+      continue;
     }
+    if (legacy) {
+      ambiguousLegacy = true;
+      continue;
+    }
+    legacy = ws;
   }
-  return current;
+
+  if (current) {
+    const identity = readConnectionIdentity(readAttachment(current));
+    return identity ? { socket: current, identity } : null;
+  }
+
+  if (!legacy || ambiguousLegacy) return null;
+  const attachment = readAttachment(legacy);
+  if (!attachment?.handshakeComplete || !attachment.providerInstanceId || legacy.readyState !== 1) {
+    return null;
+  }
+
+  const upgraded: SandboxControlSocketAttachment = {
+    ...attachment,
+    connectionId: crypto.randomUUID(),
+  };
+  legacy.serializeAttachment(upgraded);
+  const identity = readConnectionIdentity(upgraded);
+  return identity ? { socket: legacy, identity } : null;
+}
+
+function isProvisionalSocket(
+  state: SandboxControlSocketState,
+  ws: WebSocket,
+  attachment: SandboxControlSocketAttachment | null
+): attachment is SandboxControlSocketAttachment & { connectionId: string } {
+  if (
+    ws.readyState !== 1 ||
+    !attachment ||
+    attachment.handshakeComplete ||
+    !attachment.connectionId
+  ) {
+    return false;
+  }
+
+  let original = false;
+  for (const candidate of state.getWebSockets(SANDBOX_CONTROL_WS_TAG)) {
+    const candidateAttachment = readAttachment(candidate);
+    if (candidateAttachment?.connectionId !== attachment.connectionId) continue;
+    if (candidate !== ws || original) return false;
+    original = true;
+  }
+  return original;
+}
+
+function isCurrentConnection(
+  state: SandboxControlSocketState,
+  ws: WebSocket,
+  identity: SandboxControlConnectionIdentity
+): boolean {
+  const current = currentHandshakenSocket(state);
+  return (
+    ws.readyState === 1 &&
+    current?.socket === ws &&
+    current.identity.connectionId === identity.connectionId
+  );
 }
 
 export function createSandboxControlSocketHandler(
@@ -107,9 +210,15 @@ export function createSandboxControlSocketHandler(
   waiters: ControlRequestWaiters = createControlRequestWaiters(),
   hooks: SandboxControlSocketHooks = {}
 ): SandboxControlSocketHandler {
+  const activatingConnections = new Set<string>();
+
   return {
     hasHandshakenSocket(): boolean {
       return currentHandshakenSocket(state) !== null;
+    },
+
+    getConnectionIdentity(): SandboxControlConnectionIdentity | null {
+      return currentHandshakenSocket(state)?.identity ?? null;
     },
 
     closeProvisionalSockets(): void {
@@ -138,6 +247,7 @@ export function createSandboxControlSocketHandler(
       const attachment: SandboxControlSocketAttachment = {
         handshakeComplete: false,
         acceptedAt: Date.now(),
+        connectionId: crypto.randomUUID(),
       };
       state.acceptWebSocket(server, [SANDBOX_CONTROL_WS_TAG]);
       server.serializeAttachment(attachment);
@@ -146,6 +256,8 @@ export function createSandboxControlSocketHandler(
     },
 
     async handleMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+      if (ws.readyState !== 1) return;
+
       const attachment = readAttachment(ws);
       if (
         attachment &&
@@ -167,16 +279,125 @@ export function createSandboxControlSocketHandler(
       }
 
       const frame = parsed.frame;
+      if (frame.type === 'request' && frame.operation === 'sandbox.hello') {
+        if (!isProvisionalSocket(state, ws, attachment)) {
+          sendJson(
+            ws,
+            errorResponse(
+              frame.requestId,
+              'protocol_error',
+              'sandbox.hello requires an unconsumed provisional connection'
+            )
+          );
+          if (!attachment?.handshakeComplete || currentHandshakenSocket(state)?.socket !== ws) {
+            closeSocket(ws, 1008, 'invalid_handshake');
+          }
+          return;
+        }
+
+        const payload = parseSandboxHelloPayload(frame.payload);
+        if (!payload) {
+          sendJson(
+            ws,
+            errorResponse(frame.requestId, 'protocol_error', 'Invalid sandbox.hello payload')
+          );
+          return;
+        }
+
+        const identity: SandboxControlConnectionIdentity = {
+          connectionId: attachment.connectionId,
+          providerInstanceId: payload.providerInstanceId,
+          ...(payload.wrapperInstanceId ? { wrapperInstanceId: payload.wrapperInstanceId } : {}),
+        };
+        const completed: SandboxControlSocketAttachment = {
+          handshakeComplete: true,
+          acceptedAt: attachment.acceptedAt,
+          connectionId: identity.connectionId,
+          protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+          providerInstanceId: identity.providerInstanceId,
+          ...(identity.wrapperInstanceId ? { wrapperInstanceId: identity.wrapperInstanceId } : {}),
+        };
+        const superseded: WebSocket[] = [];
+        let replaced = false;
+
+        const provisionals: WebSocket[] = [];
+        for (const existing of state.getWebSockets(SANDBOX_CONTROL_WS_TAG)) {
+          if (existing === ws) continue;
+          const existingAttachment = readAttachment(existing);
+          if (existingAttachment) {
+            replaced ||= existingAttachment.handshakeComplete;
+            existing.serializeAttachment({
+              handshakeComplete: false,
+              acceptedAt: existingAttachment.acceptedAt,
+            } satisfies SandboxControlSocketAttachment);
+          }
+          if (existingAttachment?.handshakeComplete) {
+            superseded.push(existing);
+          } else {
+            provisionals.push(existing);
+          }
+        }
+
+        ws.serializeAttachment(completed);
+        if (replaced) waiters.rejectAll('Wrapper socket replaced');
+        for (const existing of superseded) {
+          closeSocket(existing, 4000, 'Replaced by new handshake');
+        }
+        for (const existing of provisionals) {
+          closeSocket(existing, 1008, 'handshake_required');
+        }
+
+        activatingConnections.add(identity.connectionId);
+        try {
+          const activation = hooks.onHandshakeComplete?.(identity);
+          if (activation) await activation;
+        } finally {
+          activatingConnections.delete(identity.connectionId);
+        }
+
+        if (!isCurrentConnection(state, ws, identity)) return;
+        sendJson(ws, okResponse(frame.requestId, helloResult()));
+        sendJson(ws, {
+          type: 'request',
+          requestId: crypto.randomUUID(),
+          operation: 'sandbox.status',
+          payload: {},
+        });
+        logger.withFields({ sandboxId }).info('Sandbox control handshake complete');
+        return;
+      }
+
+      if (!attachment?.handshakeComplete) {
+        if (frame.type === 'request') {
+          sendJson(
+            ws,
+            errorResponse(frame.requestId, 'handshake_required', 'sandbox.hello is required first')
+          );
+        } else {
+          closeSocket(ws, 1008, 'handshake_required');
+        }
+        return;
+      }
+
+      const current = currentHandshakenSocket(state);
+      const identity = readConnectionIdentity(readAttachment(ws));
+      if (
+        !current ||
+        current.socket !== ws ||
+        !identity ||
+        current.identity.connectionId !== identity.connectionId
+      ) {
+        closeSocket(ws, 1008, 'stale_connection');
+        return;
+      }
+      if (activatingConnections.has(identity.connectionId)) return;
+
       if (frame.type === 'response') {
         waiters.settle(frame);
         return;
       }
 
       if (frame.type === 'event') {
-        if (!attachment?.handshakeComplete) {
-          closeSocket(ws, 1008, 'handshake_required');
-          return;
-        }
         if (!isControlEvent(frame.event)) return;
         const eventPayload = parseEventPayload(frame.event, frame.payload);
         if (!eventPayload.ok) {
@@ -190,66 +411,22 @@ export function createSandboxControlSocketHandler(
           return;
         }
         if (frame.event === 'sandbox.ready') {
-          await hooks.onReady?.();
+          await hooks.onReady?.(identity);
         } else if (frame.event === 'sandbox.heartbeat') {
-          await hooks.onHeartbeat?.(eventPayload.payload as SandboxHeartbeatPayload);
+          await hooks.onHeartbeat?.(eventPayload.payload as SandboxHeartbeatPayload, identity);
         } else if (frame.event === 'session.event') {
-          await hooks.onSessionEvent?.(frame.session, eventPayload.payload as SessionEventPayload);
+          await hooks.onSessionEvent?.(
+            frame.session,
+            eventPayload.payload as SessionEventPayload,
+            identity
+          );
         } else if (frame.event === 'session.preparing') {
           await hooks.onSessionPreparing?.(
             frame.session,
-            eventPayload.payload as SessionPreparingPayload
+            eventPayload.payload as SessionPreparingPayload,
+            identity
           );
         }
-        return;
-      }
-
-      if (frame.operation === 'sandbox.hello') {
-        const payload = parseSandboxHelloPayload(frame.payload);
-        if (!payload) {
-          sendJson(
-            ws,
-            errorResponse(frame.requestId, 'protocol_error', 'Invalid sandbox.hello payload')
-          );
-          return;
-        }
-
-        const completed: SandboxControlSocketAttachment = {
-          handshakeComplete: true,
-          acceptedAt: attachment?.acceptedAt ?? Date.now(),
-          protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
-          providerInstanceId: payload.providerInstanceId,
-        };
-        ws.serializeAttachment(completed);
-
-        let replaced = false;
-        for (const existing of state.getWebSockets(SANDBOX_CONTROL_WS_TAG)) {
-          if (existing === ws) continue;
-          const existingAttachment = readAttachment(existing);
-          if (existingAttachment?.handshakeComplete) {
-            closeSocket(existing, 4000, 'Replaced by new handshake');
-            replaced = true;
-          }
-        }
-        if (replaced) waiters.rejectAll('Wrapper socket replaced');
-
-        sendJson(ws, okResponse(frame.requestId, helloResult()));
-        sendJson(ws, {
-          type: 'request',
-          requestId: crypto.randomUUID(),
-          operation: 'sandbox.status',
-          payload: {},
-        });
-        logger.withFields({ sandboxId }).info('Sandbox control handshake complete');
-        await hooks.onHandshakeComplete?.(payload.providerInstanceId);
-        return;
-      }
-
-      if (!attachment?.handshakeComplete) {
-        sendJson(
-          ws,
-          errorResponse(frame.requestId, 'handshake_required', 'sandbox.hello is required first')
-        );
         return;
       }
 
@@ -288,12 +465,19 @@ export function createSandboxControlSocketHandler(
         })
         .info('Sandbox control socket closed');
       if (!handshakeComplete) return;
-      const remaining = state
-        .getWebSockets(SANDBOX_CONTROL_WS_TAG)
-        .some(other => other !== ws && readAttachment(other)?.handshakeComplete === true);
+
+      const current = currentHandshakenSocket(state);
+      if (current && current.socket !== ws) return;
+      const remaining = state.getWebSockets(SANDBOX_CONTROL_WS_TAG).some(other => {
+        if (other === ws || other.readyState !== 1) return false;
+        return readAttachment(other)?.handshakeComplete === true;
+      });
       if (remaining) return;
+
+      const identity = readConnectionIdentity(readAttachment(ws)) ?? undefined;
+      if (identity) activatingConnections.delete(identity.connectionId);
       waiters.rejectAll('Wrapper socket closed');
-      await hooks.onSocketClosed?.(true);
+      await hooks.onSocketClosed?.(true, identity);
     },
 
     closeAll(reason: string): void {
@@ -315,8 +499,12 @@ export function createSandboxControlSocketHandler(
         throw new Error('session identity is required');
       }
 
-      const ws = currentHandshakenSocket(state);
-      if (!ws || ws.readyState !== 1) {
+      const current = currentHandshakenSocket(state);
+      if (
+        !current ||
+        current.socket.readyState !== 1 ||
+        activatingConnections.has(current.identity.connectionId)
+      ) {
         throw new SandboxControlConnectionError('No ready wrapper socket');
       }
 
@@ -329,7 +517,7 @@ export function createSandboxControlSocketHandler(
         ...(input.session ? { session: input.session } : {}),
       };
       const pending = waiters.wait(requestId, input.timeoutMs);
-      sendJson(ws, frame);
+      sendJson(current.socket, frame);
       return pending;
     },
   };

--- a/services/cloud-agent-next/src/sandbox-control/terminal-billing.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/terminal-billing.test.ts
@@ -1,0 +1,263 @@
+import type { BillingContext } from '@kilocode/container-usage';
+import { describe, expect, it } from 'vitest';
+import { SANDBOX_USAGE_SKUS, type SandboxClassName } from '../container-usage-context.js';
+import {
+  validateTerminalBillingRuntime,
+  type SandboxTerminalAccessInput,
+} from './terminal-billing.js';
+
+const access: SandboxTerminalAccessInput = {
+  sessionId: 'workspace_session',
+  ownerId: 'user_owner',
+  wrapperInstanceId: '8f54ab1b-df33-4324-bce3-42a76fd5a36b',
+};
+
+function context(overrides: Partial<BillingContext> = {}): BillingContext {
+  return {
+    service: 'cloud-agent-next-sandbox-small',
+    instanceId: 'ses-abcdef',
+    sku: SANDBOX_USAGE_SKUS.SandboxSmall,
+    subject: { type: 'user', id: access.ownerId },
+    actor: { type: 'user', id: access.ownerId },
+    sessionId: access.sessionId,
+    metadata: {
+      container_class: 'SandboxSmall',
+      durable_object_id: 'durable-object-small',
+      origin: 'cloud-agent',
+    },
+    startEpochMs: 100,
+    generation: '8ad114f7-7967-4abc-bcc1-ce0f9312413a',
+    measurementStarted: true,
+    nextSeq: 1,
+    usageMeasuredAtMs: 100,
+    ...overrides,
+  };
+}
+
+function billingInput(
+  options: {
+    access?: SandboxTerminalAccessInput;
+    sandboxId?: string;
+    providerInstanceId?: string;
+    sandboxDurableObjectId?: string;
+    sandboxClassName?: SandboxClassName;
+    running?: boolean;
+    blocked?: boolean;
+    context?: BillingContext;
+  } = {}
+) {
+  const sandboxId = options.sandboxId ?? 'ses-abcdef';
+  return {
+    access: options.access ?? access,
+    sandboxId,
+    providerInstanceId: options.providerInstanceId ?? sandboxId,
+    sandboxDurableObjectId: options.sandboxDurableObjectId ?? 'durable-object-small',
+    runtime: {
+      sandboxClassName: options.sandboxClassName ?? 'SandboxSmall',
+      running: options.running ?? true,
+      blocked: options.blocked ?? false,
+      context: options.context ?? context(),
+    },
+  };
+}
+
+describe('validateTerminalBillingRuntime', () => {
+  it('accepts a measured isolated runtime attributed to the session owner', () => {
+    expect(validateTerminalBillingRuntime(billingInput())).toEqual({ allowed: true });
+  });
+
+  it.each([
+    {
+      sandboxId: 'crv-abcdef',
+      sandboxClassName: 'SandboxCodeReview' as const,
+      service: 'cloud-agent-next-sandbox-code-review',
+    },
+    {
+      sandboxId: 'dind-abcdef',
+      sandboxClassName: 'SandboxDIND' as const,
+      service: 'cloud-agent-next-sandbox-dind',
+    },
+  ])('accepts measured $sandboxClassName attribution in its actual namespace', input => {
+    expect(
+      validateTerminalBillingRuntime(
+        billingInput({
+          sandboxId: input.sandboxId,
+          sandboxClassName: input.sandboxClassName,
+          context: context({
+            service: input.service,
+            instanceId: input.sandboxId,
+            sku: SANDBOX_USAGE_SKUS[input.sandboxClassName],
+            metadata: {
+              container_class: input.sandboxClassName,
+              durable_object_id: 'durable-object-small',
+              origin: 'cloud-agent',
+            },
+          }),
+        })
+      )
+    ).toEqual({ allowed: true });
+  });
+
+  it('accepts an organization bot acting for the matching payer', () => {
+    const organizationAccess = { ...access, organizationId: 'org_team', botId: 'bot_worker' };
+    expect(
+      validateTerminalBillingRuntime(
+        billingInput({
+          access: organizationAccess,
+          context: context({
+            subject: { type: 'org', id: 'org_team' },
+            actor: { type: 'bot', id: 'bot_worker' },
+            onBehalfOf: { type: 'org', id: 'org_team' },
+          }),
+        })
+      )
+    ).toEqual({ allowed: true });
+  });
+
+  it('accepts a shared runtime only without session attribution', () => {
+    const shared = billingInput({
+      sandboxId: 'org-abcdef',
+      sandboxClassName: 'Sandbox',
+      context: context({
+        service: 'cloud-agent-next-sandbox',
+        instanceId: 'org-abcdef',
+        sku: SANDBOX_USAGE_SKUS.Sandbox,
+        sessionId: undefined,
+        metadata: { container_class: 'Sandbox', durable_object_id: 'durable-object-small' },
+      }),
+    });
+
+    expect(validateTerminalBillingRuntime(shared)).toEqual({ allowed: true });
+    expect(
+      validateTerminalBillingRuntime({
+        ...shared,
+        runtime: {
+          ...shared.runtime,
+          context: { ...shared.runtime.context, sessionId: access.sessionId },
+        },
+      })
+    ).toEqual({ allowed: false, reason: 'billing_session_mismatch' });
+  });
+
+  it.each([
+    {
+      name: 'missing runtime',
+      input: { ...billingInput(), runtime: undefined },
+      reason: 'billing_runtime_unavailable',
+    },
+    {
+      name: 'stopped runtime',
+      input: billingInput({ running: false }),
+      reason: 'billing_runtime_not_running',
+    },
+    {
+      name: 'blocked runtime',
+      input: billingInput({ blocked: true }),
+      reason: 'billing_blocked',
+    },
+    {
+      name: 'missing context',
+      input: { ...billingInput(), runtime: { ...billingInput().runtime, context: undefined } },
+      reason: 'billing_context_unavailable',
+    },
+    {
+      name: 'unmeasured context',
+      input: billingInput({ context: context({ measurementStarted: false }) }),
+      reason: 'billing_context_unmeasured',
+    },
+    {
+      name: 'stopped generation',
+      input: billingInput({ context: context({ stoppedObservedAtMs: 150 }) }),
+      reason: 'billing_generation_inactive',
+    },
+    {
+      name: 'pending stop',
+      input: billingInput({
+        context: context({
+          pendingStop: {
+            seq: 1,
+            usageSinceLast: 0,
+            measuredAtMs: 150,
+            reason: 'runtime_signal',
+          },
+        }),
+      }),
+      reason: 'billing_generation_inactive',
+    },
+  ])('rejects $name', ({ input, reason }) => {
+    expect(validateTerminalBillingRuntime(input)).toEqual({ allowed: false, reason });
+  });
+
+  it.each([
+    {
+      name: 'sandbox class',
+      input: billingInput({ sandboxClassName: 'SandboxCodeReview' }),
+    },
+    {
+      name: 'provider instance',
+      input: billingInput({ providerInstanceId: 'ses-other' }),
+    },
+    {
+      name: 'billing instance',
+      input: billingInput({ context: context({ instanceId: 'ses-other' }) }),
+    },
+    {
+      name: 'service',
+      input: billingInput({ context: context({ service: 'cloud-agent-next-sandbox' }) }),
+    },
+    {
+      name: 'sku',
+      input: billingInput({ context: context({ sku: SANDBOX_USAGE_SKUS.Sandbox }) }),
+    },
+    {
+      name: 'namespace durable object',
+      input: billingInput({ sandboxDurableObjectId: 'durable-object-other' }),
+    },
+    {
+      name: 'container class metadata',
+      input: billingInput({
+        context: context({
+          metadata: { container_class: 'Sandbox', durable_object_id: 'durable-object-small' },
+        }),
+      }),
+    },
+  ])('rejects mismatched $name', ({ input }) => {
+    expect(validateTerminalBillingRuntime(input)).toEqual({
+      allowed: false,
+      reason: 'billing_runtime_mismatch',
+    });
+  });
+
+  it('rejects a different organization payer', () => {
+    expect(
+      validateTerminalBillingRuntime(
+        billingInput({
+          access: { ...access, organizationId: 'org_expected' },
+          context: context({ subject: { type: 'org', id: 'org_other' } }),
+        })
+      )
+    ).toEqual({ allowed: false, reason: 'billing_payer_mismatch' });
+  });
+
+  it('rejects a different organization actor', () => {
+    expect(
+      validateTerminalBillingRuntime(
+        billingInput({
+          access: { ...access, organizationId: 'org_team' },
+          context: context({
+            subject: { type: 'org', id: 'org_team' },
+            actor: { type: 'user', id: 'user_other' },
+          }),
+        })
+      )
+    ).toEqual({ allowed: false, reason: 'billing_actor_mismatch' });
+  });
+
+  it('rejects isolated attribution for a different session', () => {
+    expect(
+      validateTerminalBillingRuntime(
+        billingInput({ context: context({ sessionId: 'workspace_other' }) })
+      )
+    ).toEqual({ allowed: false, reason: 'billing_session_mismatch' });
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-control/terminal-billing.ts
+++ b/services/cloud-agent-next/src/sandbox-control/terminal-billing.ts
@@ -1,0 +1,108 @@
+import { billingContextSchema } from '@kilocode/container-usage';
+import {
+  SANDBOX_USAGE_SKUS,
+  type SandboxClassName,
+  type getSandboxBillingRuntimeStatus,
+} from '../container-usage-context.js';
+
+export type SandboxTerminalAccessInput = {
+  sessionId: string;
+  ownerId: string;
+  wrapperInstanceId: string;
+  organizationId?: string;
+  botId?: string;
+};
+
+export type SandboxTerminalAccessResult = {
+  allowed: boolean;
+  reason?: string;
+};
+
+type SandboxBillingRuntimeStatus = NonNullable<
+  Awaited<ReturnType<typeof getSandboxBillingRuntimeStatus>>
+>;
+
+type TerminalBillingRuntimeInput = {
+  access: SandboxTerminalAccessInput;
+  sandboxId: string;
+  providerInstanceId: string;
+  sandboxDurableObjectId: string;
+  runtime: SandboxBillingRuntimeStatus | undefined;
+};
+
+function expectedSandboxClassName(sandboxId: string): SandboxClassName {
+  if (sandboxId.startsWith('dind-')) return 'SandboxDIND';
+  if (sandboxId.startsWith('crv-')) return 'SandboxCodeReview';
+  if (sandboxId.startsWith('ses-')) return 'SandboxSmall';
+  return 'Sandbox';
+}
+
+function expectedUsageService(sandboxClassName: SandboxClassName): string {
+  return `cloud-agent-next-${sandboxClassName.replace(/([a-z])([A-Z])/g, '$1-$2').toLowerCase()}`;
+}
+
+export function validateTerminalBillingRuntime(
+  input: TerminalBillingRuntimeInput
+): SandboxTerminalAccessResult {
+  const runtime = input.runtime;
+  if (!runtime) return { allowed: false, reason: 'billing_runtime_unavailable' };
+  if (runtime.running !== true) {
+    return { allowed: false, reason: 'billing_runtime_not_running' };
+  }
+  if (runtime.blocked !== false) return { allowed: false, reason: 'billing_blocked' };
+
+  const parsed = billingContextSchema.safeParse(runtime.context);
+  if (!parsed.success) return { allowed: false, reason: 'billing_context_unavailable' };
+
+  const context = parsed.data;
+  if (!context.measurementStarted) {
+    return { allowed: false, reason: 'billing_context_unmeasured' };
+  }
+  if (context.pendingStop || context.stoppedObservedAtMs !== undefined) {
+    return { allowed: false, reason: 'billing_generation_inactive' };
+  }
+
+  const sandboxClassName = expectedSandboxClassName(input.sandboxId);
+  if (
+    runtime.sandboxClassName !== sandboxClassName ||
+    input.providerInstanceId !== input.sandboxId ||
+    context.instanceId !== input.sandboxId ||
+    context.service !== expectedUsageService(sandboxClassName) ||
+    context.sku !== SANDBOX_USAGE_SKUS[sandboxClassName] ||
+    context.metadata?.container_class !== sandboxClassName ||
+    context.metadata.durable_object_id !== input.sandboxDurableObjectId
+  ) {
+    return { allowed: false, reason: 'billing_runtime_mismatch' };
+  }
+
+  const expectedSubject = input.access.organizationId
+    ? { type: 'org' as const, id: input.access.organizationId }
+    : { type: 'user' as const, id: input.access.ownerId };
+  if (context.subject.type !== expectedSubject.type || context.subject.id !== expectedSubject.id) {
+    return { allowed: false, reason: 'billing_payer_mismatch' };
+  }
+
+  const expectedActor = input.access.botId
+    ? { type: 'bot' as const, id: input.access.botId }
+    : { type: 'user' as const, id: input.access.ownerId };
+  if (context.actor.type !== expectedActor.type || context.actor.id !== expectedActor.id) {
+    return { allowed: false, reason: 'billing_actor_mismatch' };
+  }
+  if (
+    expectedActor.type === 'bot' &&
+    (context.onBehalfOf?.type !== expectedSubject.type ||
+      context.onBehalfOf.id !== expectedSubject.id)
+  ) {
+    return { allowed: false, reason: 'billing_actor_mismatch' };
+  }
+
+  const shared = sandboxClassName === 'Sandbox';
+  if (
+    (shared && context.sessionId !== undefined) ||
+    (!shared && context.sessionId !== input.access.sessionId)
+  ) {
+    return { allowed: false, reason: 'billing_session_mismatch' };
+  }
+
+  return { allowed: true };
+}

--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -5,7 +5,11 @@ import migrations from '../../drizzle/migrations';
 import type { Env } from '../types.js';
 import type { SessionId } from '../types/ids.js';
 import type { SessionMetadata } from '../persistence/session-metadata.js';
-import { parseSessionMetadata, serializeSessionMetadata } from '../persistence/session-metadata.js';
+import {
+  getSandboxProvider,
+  parseSessionMetadata,
+  serializeSessionMetadata,
+} from '../persistence/session-metadata.js';
 import type { OperationResult } from '../persistence/types.js';
 import type { CallbackTarget } from '../callbacks/index.js';
 import {
@@ -30,11 +34,8 @@ import { applyControlPlanePreparingEvent } from './control-plane-preparing.js';
 import { logger } from '../logger.js';
 import { sandboxControlRpc } from './control-rpc.js';
 import { DEADLINE_MS } from '../sandbox-control/deadlines.js';
-import { getSandboxControlStub } from '../sandbox-control/stub.js';
-import { withDORetry } from '../utils/do-retry.js';
 import { createMessageId } from '../session/message-id.js';
 import { buildSessionAttachPayload, fillAttachGitToken } from './attach-payload.js';
-import { getSandboxProvider } from '../persistence/session-metadata.js';
 import { createPreparationProgressRecorder } from '../session/preparation-progress.js';
 import {
   finalizeOtherRunningAttemptsForMessage,
@@ -54,6 +55,11 @@ import {
 } from './control-dispatch.js';
 import { acceptedAlarmDecision } from './accepted-overdue.js';
 import { bootPreparingStep, provisionPreparingStep } from './preparing-steps.js';
+import { createSandboxTerminalBridge, type SandboxTerminalRecord } from './terminal-bridge.js';
+import {
+  createSandboxTerminalLifecycle,
+  SANDBOX_SESSION_METADATA_KEY,
+} from './terminal-lifecycle.js';
 import {
   acceptQueuedMessage,
   assignPreparationAttemptId,
@@ -75,7 +81,7 @@ import {
   type SessionMessageRecord,
 } from './session-message-queue.js';
 
-const METADATA_KEY = 'session_metadata';
+const METADATA_KEY = SANDBOX_SESSION_METADATA_KEY;
 const MESSAGES_KEY = 'session_messages';
 const QUEUE_RETRY_MS = 5_000;
 
@@ -84,6 +90,8 @@ type MessageRecord = SessionMessageRecord;
 export class SandboxSession extends DurableObject<Env> {
   private readonly sessionId: SessionId | undefined;
   private readonly eventQueries: EventQueries;
+  private readonly terminalLifecycle: ReturnType<typeof createSandboxTerminalLifecycle>;
+  private readonly terminalBridge: ReturnType<typeof createSandboxTerminalBridge>;
 
   constructor(ctx: DurableObjectState, env: Env) {
     super(ctx, env);
@@ -91,6 +99,27 @@ export class SandboxSession extends DurableObject<Env> {
     const lastColon = doName?.lastIndexOf(':') ?? -1;
     const sessionIdPart = doName && lastColon > 0 ? doName.slice(lastColon + 1) : undefined;
     this.sessionId = sessionIdPart ? (sessionIdPart as SessionId) : undefined;
+    this.terminalLifecycle = createSandboxTerminalLifecycle({
+      state: ctx,
+      getSessionId: () => this.requireSessionId(),
+      getControl: sandboxId => sandboxControlRpc(env, sandboxId),
+      getDirectory: metadata => this.directory(metadata),
+      closeTerminalBridge: (ptyId, code, reason) =>
+        this.terminalBridge.closeTerminal(ptyId, code, reason),
+      closeAllBridges: (code, reason) => this.terminalBridge.closeAll(code, reason),
+      closeRuntimeBridges: (wrapperInstanceId, code, reason) =>
+        this.terminalBridge.closeRuntime(wrapperInstanceId, code, reason),
+    });
+    this.terminalBridge = createSandboxTerminalBridge({
+      state: ctx,
+      getMetadata: () => this.getMetadata(),
+      getTerminal: async (ptyId): Promise<SandboxTerminalRecord | undefined> =>
+        this.terminalLifecycle.getTerminal(ptyId),
+      requestConnect: async (record, payload) =>
+        this.terminalLifecycle.requestConnect(record, payload),
+      reportActivity: async record => this.terminalLifecycle.reportActivity(record),
+      markEnded: async record => this.terminalLifecycle.markEnded(record),
+    });
     const db = drizzle(ctx.storage, { logger: false });
     this.eventQueries = createEventQueries(db, ctx.storage.sql);
     void ctx.blockConcurrencyWhile(async () => {
@@ -99,6 +128,16 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   async fetch(request: Request): Promise<Response> {
+    const pathname = new URL(request.url).pathname;
+    if (pathname === '/terminal/browser') {
+      return this.terminalBridge.handleBrowserUpgrade(request);
+    }
+    if (pathname === '/terminal/wrapper') {
+      return this.terminalBridge.handleWrapperUpgrade(request);
+    }
+    if (pathname !== '/stream' || this.terminalLifecycle.isBlocked()) {
+      return new Response('Not found', { status: 404 });
+    }
     const sessionId = this.requireSessionId();
     const handler = createStreamHandler(this.ctx, this.eventQueries, sessionId, {
       deriveCloudStatus: () => this.deriveCloudStatus(),
@@ -107,21 +146,30 @@ export class SandboxSession extends DurableObject<Env> {
     return handler.handleStreamRequest(request);
   }
 
-  async webSocketMessage(_ws: WebSocket, _message: string | ArrayBuffer): Promise<void> {}
+  async webSocketMessage(ws: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    await this.terminalBridge.handleMessage(ws, message);
+  }
 
   async webSocketClose(
-    _ws: WebSocket,
-    _code: number,
-    _reason: string,
-    _wasClean: boolean
-  ): Promise<void> {}
+    ws: WebSocket,
+    code: number,
+    reason: string,
+    wasClean: boolean
+  ): Promise<void> {
+    await this.terminalBridge.handleClose(ws, code, reason, wasClean);
+  }
+
+  async webSocketError(ws: WebSocket, error: unknown): Promise<void> {
+    await this.terminalBridge.handleError(ws, error);
+  }
 
   async receiveSandboxControlEvent(input: {
     identity: { directory: string; kiloSessionId?: string; rootKiloSessionId?: string };
     payload: { type: string; properties: Record<string, unknown>; timestamp?: string };
   }): Promise<{ applied: boolean }> {
     const metadata = await this.getMetadata();
-    if (!metadata) {
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (!metadata || epoch === null) {
       logger
         .withFields({
           sessionId: this.sessionId,
@@ -173,6 +221,7 @@ export class SandboxSession extends DurableObject<Env> {
         } catch {
           internalSecret = undefined;
         }
+        if (!this.terminalLifecycle.isCurrent(epoch)) return { applied: false };
         if (!internalSecret) {
           logger
             .withFields({
@@ -183,7 +232,7 @@ export class SandboxSession extends DurableObject<Env> {
             .warn('Control-plane child session ingest skipped; internal secret unavailable');
         }
       }
-      if (!isChild || internalSecret) {
+      if ((!isChild || internalSecret) && this.terminalLifecycle.isCurrent(epoch)) {
         this.ctx.waitUntil(
           publishControlPlaneSessionIngest({
             fetchIngest: request => this.env.SESSION_INGEST.fetch(request),
@@ -197,13 +246,19 @@ export class SandboxSession extends DurableObject<Env> {
         );
       }
     }
+    if (!this.terminalLifecycle.isCurrent(epoch)) return { applied: false };
     if (terminal) {
       const before = await this.loadMessages();
+      if (!this.terminalLifecycle.isCurrent(epoch)) return { applied: false };
       if (hasAcceptedMessage(before)) {
-        await this.saveMessages(terminalizeAcceptedMessages(before, terminal));
+        if (!(await this.saveMessages(terminalizeAcceptedMessages(before, terminal), epoch))) {
+          return { applied: false };
+        }
         this.broadcastClientEvent(terminal === 'failed' ? 'error' : 'complete');
         const nextId = nextQueuedMessageId(await this.loadMessages());
-        if (nextId) this.ctx.waitUntil(this.dispatchQueued(nextId));
+        if (nextId && this.terminalLifecycle.isCurrent(epoch)) {
+          this.ctx.waitUntil(this.dispatchQueued(nextId));
+        }
       }
     }
     return { applied: true };
@@ -214,7 +269,8 @@ export class SandboxSession extends DurableObject<Env> {
     payload: SessionPreparingPayload;
   }): Promise<{ applied: boolean }> {
     const metadata = await this.getMetadata();
-    if (!metadata) return { applied: false };
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (!metadata || epoch === null) return { applied: false };
     const root = metadata.auth.kiloSessionId;
     if (
       input.identity.rootKiloSessionId !== undefined &&
@@ -223,6 +279,7 @@ export class SandboxSession extends DurableObject<Env> {
     ) {
       return { applied: false };
     }
+    if (!this.terminalLifecycle.isCurrent(epoch)) return { applied: false };
     const sessionId = this.requireSessionId();
     applyControlPlanePreparingEvent({
       sessionId,
@@ -233,20 +290,18 @@ export class SandboxSession extends DurableObject<Env> {
     return { applied: true };
   }
 
-  async closeOrgStreams(_organizationId: string): Promise<number> {
+  async closeOrgStreams(organizationId: string): Promise<number> {
+    const metadata = this.terminalLifecycle.getStoredMetadata();
+    if (!metadata?.identity.orgId || metadata.identity.orgId !== organizationId) return 0;
+    const records = this.terminalLifecycle.beginRevocation(metadata);
     const sockets = this.ctx.getWebSockets('stream');
-    for (const ws of sockets) ws.close(1001, 'organization streams closed');
+    for (const ws of sockets) ws.close(1000, 'session access revoked');
+    await this.terminalLifecycle.cleanupSession(metadata, records);
     return sockets.length;
   }
 
   async getMetadata(): Promise<SessionMetadata | null> {
-    const raw = await this.ctx.storage.get<unknown>(METADATA_KEY);
-    if (raw === undefined) return null;
-    try {
-      return parseSessionMetadata(raw);
-    } catch {
-      return null;
-    }
+    return this.terminalLifecycle.isDeleted() ? null : this.terminalLifecycle.getStoredMetadata();
   }
 
   async validateKiloGlobalFeedProducer(_params: {
@@ -293,22 +348,31 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   async markAsInterrupted(): Promise<void> {
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (epoch === null) return;
     const { messages } = cancelActiveMessages(await this.loadMessages());
-    await this.saveMessages(messages);
+    await this.saveMessages(messages, epoch);
   }
 
   async interruptExecution(): Promise<{ success: boolean; message?: string }> {
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (epoch === null) return { success: false, message: 'Session not found' };
     const before = await this.loadMessages();
+    if (!this.terminalLifecycle.isCurrent(epoch)) {
+      return { success: false, message: 'Session not found' };
+    }
     const hadWork = hasInterruptibleWork(before);
     const { messages } = cancelActiveMessages(before);
-    await this.saveMessages(messages);
+    if (!(await this.saveMessages(messages, epoch))) {
+      return { success: false, message: 'Session not found' };
+    }
     if (hadWork) {
       this.broadcastClientEvent('interrupted', { reason: 'interrupted' });
     }
     const metadata = await this.getMetadata();
     const sandboxId = metadata?.workspace?.sandboxId;
     const kiloSessionId = metadata?.auth.kiloSessionId;
-    if (sandboxId && kiloSessionId && this.sessionId) {
+    if (sandboxId && kiloSessionId && this.sessionId && this.terminalLifecycle.isCurrent(epoch)) {
       try {
         await sandboxControlRpc(this.env, sandboxId).request({
           operation: 'session.abort',
@@ -320,11 +384,13 @@ export class SandboxSession extends DurableObject<Env> {
           payload: {},
         });
       } catch (error) {
-        logger
-          .withFields({
-            error: error instanceof Error ? error.message : 'abort failed',
-          })
-          .warn('session.abort failed');
+        if (this.terminalLifecycle.isCurrent(epoch)) {
+          logger
+            .withFields({
+              error: error instanceof Error ? error.message : 'abort failed',
+            })
+            .warn('session.abort failed');
+        }
       }
     }
     return { success: hadWork, ...(hadWork ? {} : { message: 'No session work to interrupt' }) };
@@ -358,23 +424,32 @@ export class SandboxSession extends DurableObject<Env> {
     });
   }
 
-  async createTerminal(_input?: {
+  async createTerminal(input?: {
     cols?: number;
     rows?: number;
+    operationId?: string;
   }): Promise<OperationResult<{ pty: WrapperPty }>> {
-    return { success: false, error: 'Terminal is not available for this session' };
+    return this.terminalLifecycle.createTerminal(input);
   }
 
-  async resizeTerminal(_input?: {
+  async resizeTerminal(input?: {
     ptyId?: string;
     cols?: number;
     rows?: number;
   }): Promise<OperationResult<{ pty: WrapperPty }>> {
-    return { success: false, error: 'Terminal is not available for this session' };
+    return this.terminalLifecycle.resizeTerminal(input);
   }
 
-  async closeTerminal(_input?: { ptyId?: string }): Promise<OperationResult<{ success: boolean }>> {
-    return { success: false, error: 'Terminal is not available for this session' };
+  async closeTerminal(input?: { ptyId?: string }): Promise<OperationResult<{ success: boolean }>> {
+    return this.terminalLifecycle.closeTerminal(input);
+  }
+
+  async invalidateTerminalRuntime(input: {
+    sandboxId: string;
+    wrapperInstanceId: string;
+    confirmed: boolean;
+  }): Promise<void> {
+    this.terminalLifecycle.invalidateRuntime(input);
   }
 
   async isSandboxCleanupScheduled(): Promise<boolean> {
@@ -382,18 +457,18 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   async deleteSession(): Promise<void> {
-    const metadata = await this.getMetadata();
-    const sandboxId = metadata?.workspace?.sandboxId;
-    const sessionId = this.sessionId;
-    if (sandboxId && sessionId) {
-      await this.interruptExecution();
-      await withDORetry(
-        () => getSandboxControlStub(this.env, sandboxId),
-        control => control.detachSession(sessionId),
-        'detachSession'
-      );
+    await this.interruptExecution();
+    const metadata = this.terminalLifecycle.getStoredMetadata();
+    const records = this.terminalLifecycle.beginDeletion(metadata);
+    for (const ws of this.ctx.getWebSockets('stream')) {
+      ws.close(1000, 'session access revoked');
     }
-    await this.ctx.storage.deleteAll();
+    await this.terminalLifecycle.cleanupSession(metadata, records);
+    await this.ctx.storage.deleteAlarm();
+    this.ctx.storage.transactionSync(() => {
+      this.eventQueries.deleteOlderThan(Number.MAX_SAFE_INTEGER);
+      this.terminalLifecycle.purgeDeletedState();
+    });
   }
 
   async registerSession(input: {
@@ -406,7 +481,8 @@ export class SandboxSession extends DurableObject<Env> {
     profile?: SessionMetadata['profile'];
     finalization?: SessionMetadata['finalization'];
   }): Promise<OperationResult> {
-    if (await this.getMetadata()) return { success: true };
+    if (this.terminalLifecycle.isBlocked()) return { success: false, error: 'Session not found' };
+    if (this.terminalLifecycle.getStoredMetadata()) return { success: true };
     const repository =
       input.repository &&
       'branch' in input.repository &&
@@ -428,7 +504,8 @@ export class SandboxSession extends DurableObject<Env> {
       ...(input.finalization ? { finalization: input.finalization } : {}),
       lifecycle: { version: 1, timestamp: Date.now() },
     });
-    await this.ctx.storage.put(METADATA_KEY, serializeSessionMetadata(metadata));
+    if (this.terminalLifecycle.isBlocked()) return { success: false, error: 'Session not found' };
+    this.ctx.storage.kv.put(METADATA_KEY, serializeSessionMetadata(metadata));
     return { success: true };
   }
 
@@ -445,14 +522,19 @@ export class SandboxSession extends DurableObject<Env> {
   }): Promise<SessionMessageAdmissionResult> {
     const registered = await this.registerSession(input);
     if (!registered.success) {
-      return { success: false, code: 'INTERNAL', error: registered.error ?? 'register failed' };
+      return {
+        success: false,
+        code: registered.error === 'Session not found' ? 'NOT_FOUND' : 'INTERNAL',
+        error: registered.error ?? 'register failed',
+      };
     }
     return this.queueAndDispatch(input.message.initialTurn);
   }
 
   async tryUpdate(updates: { callbackTarget?: CallbackTarget | null }): Promise<OperationResult> {
     const metadata = await this.getMetadata();
-    if (!metadata) return { success: false, error: 'Session not found' };
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (!metadata || epoch === null) return { success: false, error: 'Session not found' };
     const next = {
       ...metadata,
       callback:
@@ -462,7 +544,10 @@ export class SandboxSession extends DurableObject<Env> {
             ? undefined
             : { target: updates.callbackTarget },
     };
-    await this.ctx.storage.put(METADATA_KEY, serializeSessionMetadata(next));
+    if (!this.terminalLifecycle.isCurrent(epoch)) {
+      return { success: false, error: 'Session not found' };
+    }
+    this.ctx.storage.kv.put(METADATA_KEY, serializeSessionMetadata(next));
     return { success: true };
   }
 
@@ -517,8 +602,11 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   async alarm(): Promise<void> {
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (epoch === null) return;
     const now = Date.now();
     const messages = await this.loadMessages();
+    if (!this.terminalLifecycle.isCurrent(epoch)) return;
     const accepted = messages.find(
       message => message.state === 'accepted' && message.acceptedAt !== undefined
     );
@@ -528,11 +616,14 @@ export class SandboxSession extends DurableObject<Env> {
         await this.failWaitingMessages('accepted_overdue');
         return;
       }
-      await this.ctx.storage.setAlarm(decision.at);
+      if (this.terminalLifecycle.isCurrent(epoch)) {
+        await this.ctx.storage.setAlarm(decision.at);
+      }
       return;
     }
     const queued = messages.filter(message => message.state === 'queued');
     for (const message of queued) {
+      if (!this.terminalLifecycle.isCurrent(epoch)) return;
       await this.dispatchQueued(message.messageId, { allowCreate: false });
     }
   }
@@ -540,16 +631,23 @@ export class SandboxSession extends DurableObject<Env> {
   private async queueAndDispatch(
     turn: AcceptedExecutionTurn
   ): Promise<SessionMessageAdmissionResult> {
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (epoch === null) return { success: false, code: 'NOT_FOUND', error: 'Session not found' };
     const messageId = turn.messageId;
     const messages = await this.loadMessages();
+    if (!this.terminalLifecycle.isCurrent(epoch)) {
+      return { success: false, code: 'NOT_FOUND', error: 'Session not found' };
+    }
     const existing = messages.find(message => message.messageId === messageId);
     if (existing) {
       return { success: true, outcome: 'queued', messageId, compatibilityDelivery: 'queued' };
     }
     messages.push({ messageId, state: 'queued', turn });
-    await this.saveMessages(messages);
+    if (!(await this.saveMessages(messages, epoch))) {
+      return { success: false, code: 'NOT_FOUND', error: 'Session not found' };
+    }
     this.broadcastQueuedMessage(messageId, renderExecutionTurnContent(turn));
-    if (nextQueuedMessageId(messages) === messageId) {
+    if (nextQueuedMessageId(messages) === messageId && this.terminalLifecycle.isCurrent(epoch)) {
       this.ctx.waitUntil(this.dispatchQueued(messageId, { allowCreate: true }));
     }
     return { success: true, outcome: 'queued', messageId, compatibilityDelivery: 'queued' };
@@ -561,18 +659,24 @@ export class SandboxSession extends DurableObject<Env> {
   ): Promise<void> {
     const allowCreate = options?.allowCreate === true;
     const metadata = await this.getMetadata();
+    const epoch = this.terminalLifecycle.captureEpoch();
     const sandboxId = metadata?.workspace?.sandboxId;
     const kiloSessionId = metadata?.auth.kiloSessionId;
     const sessionId = this.sessionId;
-    if (!metadata || !sandboxId || !kiloSessionId || !sessionId) {
-      await this.failWaitingMessages('missing_metadata');
+    if (!metadata || epoch === null || !sandboxId || !kiloSessionId || !sessionId) {
+      if (!this.terminalLifecycle.isBlocked()) await this.failWaitingMessages('missing_metadata');
       return;
     }
     const messages = await this.loadMessages();
-    if (nextQueuedMessageId(messages) !== messageId) return;
+    if (!this.terminalLifecycle.isCurrent(epoch) || nextQueuedMessageId(messages) !== messageId) {
+      return;
+    }
     const assigned = assignPreparationAttemptId(messages, messageId, () => crypto.randomUUID());
     if (!assigned) return;
-    if (assigned.messages !== messages) await this.saveMessages(assigned.messages);
+    if (assigned.messages !== messages && !(await this.saveMessages(assigned.messages, epoch))) {
+      return;
+    }
+    if (!this.terminalLifecycle.isCurrent(epoch)) return;
     const queued = assigned.messages.find(message => message.messageId === messageId);
     const control = sandboxControlRpc(this.env, sandboxId);
     const recorder = createPreparationProgressRecorder({
@@ -591,16 +695,19 @@ export class SandboxSession extends DurableObject<Env> {
       this.broadcastStoredEvent(event);
     }
     let delivery: 'attach' | 'prompt' | undefined;
+    let routeAttached = false;
     try {
       const session = {
         sessionId,
         kiloSessionId,
         directory: this.directory(metadata),
       };
+      if (!this.terminalLifecycle.isCurrent(epoch)) return;
       let before = await control.getStatus();
       const stoppingDeadline = Date.now() + DEADLINE_MS.startup;
       let status: Awaited<ReturnType<typeof control.getStatus>>;
       while (true) {
+        if (!this.terminalLifecycle.isCurrent(epoch)) return;
         if (allowCreate && before.physical === 'stopping') {
           const observed = await observeControlAfterStopping(before, () => control.getStatus(), {
             retryMs: QUEUE_RETRY_MS,
@@ -611,17 +718,20 @@ export class SandboxSession extends DurableObject<Env> {
             await this.failWaitingMessages('environment_failed');
             return;
           }
+          if (!this.terminalLifecycle.isCurrent(epoch)) return;
           if (nextQueuedMessageId(await this.loadMessages()) !== messageId) return;
           before = observed;
         }
         const provision = provisionPreparingStep(before.physical, allowCreate);
         if (provision) recorder.onProgress(provision.step, provision.message);
+        if (!this.terminalLifecycle.isCurrent(epoch)) return;
         status = await control.ensureReady({
           ownerId: metadata.identity.userId,
           provider: getSandboxProvider(metadata),
           allowCreate,
           ...(metadata.auth.kilocodeToken ? { kiloToken: metadata.auth.kilocodeToken } : {}),
         });
+        if (!this.terminalLifecycle.isCurrent(epoch)) return;
         if (!allowCreate || status.physical !== 'stopping') break;
         before = status;
       }
@@ -656,27 +766,42 @@ export class SandboxSession extends DurableObject<Env> {
         }
         return;
       }
+      if (!this.terminalLifecycle.isCurrent(epoch)) return;
+      routeAttached = true;
       await control.attachSession({
         sessionId,
         kiloSessionId,
         directory: session.directory,
         ownerId: metadata.identity.userId,
       });
+      if (!this.terminalLifecycle.isCurrent(epoch)) {
+        await this.compensateSessionAttachment(metadata);
+        return;
+      }
       recorder.onProgress('workspace_setup', 'Setting up workspace…');
       delivery = 'attach';
+      const attachPayload = await fillAttachGitToken(
+        metadata,
+        buildSessionAttachPayload(metadata, {
+          attemptId: recorder.attemptId,
+          triggerMessageId: messageId,
+        }),
+        this.env
+      );
+      if (!this.terminalLifecycle.isCurrent(epoch)) {
+        await this.compensateSessionAttachment(metadata);
+        return;
+      }
       const attached = await control.request({
         operation: 'session.attach',
         session,
-        payload: await fillAttachGitToken(
-          metadata,
-          buildSessionAttachPayload(metadata, {
-            attemptId: recorder.attemptId,
-            triggerMessageId: messageId,
-          }),
-          this.env
-        ),
+        payload: attachPayload,
         timeoutMs: SANDBOX_CONTROL_ATTACH_TIMEOUT_MS,
       });
+      if (!this.terminalLifecycle.isCurrent(epoch)) {
+        await this.compensateSessionAttachment(metadata);
+        return;
+      }
       if (!attached.ok) {
         recorder.finalize({ status: 'failed', safeError: 'Environment preparation failed' });
         logger
@@ -689,8 +814,27 @@ export class SandboxSession extends DurableObject<Env> {
         await this.recordDeliveryFailure(messageId, 'attach');
         return;
       }
+      this.terminalLifecycle.recordAttachment({
+        metadata,
+        sandboxId,
+        wrapperInstanceId: status.wrapperInstanceId,
+        epoch,
+      });
+      if (!this.terminalLifecycle.isCurrent(epoch)) {
+        await this.compensateSessionAttachment(metadata);
+        return;
+      }
       recorder.finalize({ status: 'completed' });
-      if (nextQueuedMessageId(await this.loadMessages()) !== messageId) return;
+      const latestMessages = await this.loadMessages();
+      if (
+        !this.terminalLifecycle.isCurrent(epoch) ||
+        nextQueuedMessageId(latestMessages) !== messageId
+      ) {
+        if (!this.terminalLifecycle.isCurrent(epoch)) {
+          await this.compensateSessionAttachment(metadata);
+        }
+        return;
+      }
       delivery = 'prompt';
       const response = await control.request({
         operation: 'session.prompt',
@@ -715,15 +859,31 @@ export class SandboxSession extends DurableObject<Env> {
           },
         },
       });
+      if (!this.terminalLifecycle.isCurrent(epoch)) {
+        await this.compensateSessionAttachment(metadata);
+        return;
+      }
       if (response.ok) {
-        const accepted = acceptQueuedMessage(await this.loadMessages(), messageId, Date.now());
-        if (!accepted) return;
-        await this.saveMessages(accepted);
-        await this.ctx.storage.setAlarm(Date.now() + DEADLINE_MS.acceptedAlarmCap);
+        const pending = await this.loadMessages();
+        if (!this.terminalLifecycle.isCurrent(epoch)) {
+          await this.compensateSessionAttachment(metadata);
+          return;
+        }
+        const accepted = acceptQueuedMessage(pending, messageId, Date.now());
+        if (!accepted || !(await this.saveMessages(accepted, epoch))) return;
+        if (this.terminalLifecycle.isCurrent(epoch)) {
+          await this.ctx.storage.setAlarm(Date.now() + DEADLINE_MS.acceptedAlarmCap);
+        }
       } else {
         await this.recordDeliveryFailure(messageId, 'prompt');
       }
     } catch (error) {
+      if (!this.terminalLifecycle.isCurrent(epoch)) {
+        if (routeAttached || delivery === 'attach' || delivery === 'prompt') {
+          await this.compensateSessionAttachment(metadata);
+        }
+        return;
+      }
       recorder.finalize({ status: 'failed', safeError: 'Environment preparation failed' });
       logger
         .withFields({
@@ -740,12 +900,24 @@ export class SandboxSession extends DurableObject<Env> {
     }
   }
 
+  private async compensateSessionAttachment(metadata: SessionMetadata): Promise<void> {
+    try {
+      await this.terminalLifecycle.cleanupSession(metadata, []);
+    } catch {
+      logger.withFields({ sessionId: this.sessionId }).warn('Control-plane session detach failed');
+    }
+  }
+
   private async recordDeliveryFailure(messageId: string, kind: 'attach' | 'prompt'): Promise<void> {
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (epoch === null) return;
+    const messages = await this.loadMessages();
+    if (!this.terminalLifecycle.isCurrent(epoch)) return;
     const updated =
       kind === 'attach'
-        ? incrementAttachFailure(await this.loadMessages(), messageId)
-        : incrementPromptFailure(await this.loadMessages(), messageId);
-    await this.saveMessages(updated.messages);
+        ? incrementAttachFailure(messages, messageId)
+        : incrementPromptFailure(messages, messageId);
+    if (!(await this.saveMessages(updated.messages, epoch))) return;
     const exhausted =
       kind === 'attach' ? isAttachExhausted(updated.failures) : isPromptExhausted(updated.failures);
     if (exhausted) {
@@ -756,12 +928,16 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   async failWaitingMessages(reason: string): Promise<void> {
-    const { messages, failedIds } = applyFailWaitingMessages(await this.loadMessages(), reason);
-    if (failedIds.length === 0) return;
-    await this.saveMessages(messages);
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (epoch === null) return;
+    const before = await this.loadMessages();
+    if (!this.terminalLifecycle.isCurrent(epoch)) return;
+    const { messages, failedIds } = applyFailWaitingMessages(before, reason);
+    if (failedIds.length === 0 || !(await this.saveMessages(messages, epoch))) return;
     const now = Date.now();
     const safeError = safeErrorFromQueueReason(reason);
     for (const messageId of failedIds) {
+      if (!this.terminalLifecycle.isCurrent(epoch)) return;
       const record = messages.find(message => message.messageId === messageId);
       if (!record) continue;
       if (record.preparationAttemptId) {
@@ -778,6 +954,7 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   private broadcastMessageFailed(message: SessionMessageRecord, now: number): void {
+    if (this.terminalLifecycle.captureEpoch() === null) return;
     const sessionId = this.requireSessionId();
     const payload = JSON.stringify(failedMessageSnapshot(message, now));
     const eventId = this.eventQueries.insert({
@@ -798,12 +975,16 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   private broadcastStoredEvent(event: StoredEvent): void {
+    if (this.terminalLifecycle.captureEpoch() === null) return;
     const sessionId = this.requireSessionId();
     createStreamHandler(this.ctx, this.eventQueries, sessionId).broadcastEvent(event);
   }
 
   private async armQueueRetry(): Promise<void> {
+    const epoch = this.terminalLifecycle.captureEpoch();
+    if (epoch === null) return;
     const existing = await this.ctx.storage.getAlarm();
+    if (!this.terminalLifecycle.isCurrent(epoch)) return;
     const when = Date.now() + QUEUE_RETRY_MS;
     if (existing === null || existing > when) {
       await this.ctx.storage.setAlarm(when);
@@ -823,10 +1004,14 @@ export class SandboxSession extends DurableObject<Env> {
     payload: unknown
   ): Promise<{ success: boolean }> {
     const metadata = await this.getMetadata();
+    const epoch = this.terminalLifecycle.captureEpoch();
     const sandboxId = metadata?.workspace?.sandboxId;
     const kiloSessionId = metadata?.auth.kiloSessionId;
     const sessionId = this.sessionId;
-    if (!metadata || !sandboxId || !kiloSessionId || !sessionId) {
+    if (!metadata || epoch === null || !sandboxId || !kiloSessionId || !sessionId) {
+      throw new Error('No wrapper found for session');
+    }
+    if (!this.terminalLifecycle.isCurrent(epoch)) {
       throw new Error('No wrapper found for session');
     }
     const response = await sandboxControlRpc(this.env, sandboxId).request({
@@ -838,6 +1023,9 @@ export class SandboxSession extends DurableObject<Env> {
       },
       payload,
     });
+    if (!this.terminalLifecycle.isCurrent(epoch)) {
+      throw new Error('No wrapper found for session');
+    }
     if (!response.ok) {
       throw new Error(response.error?.message ?? 'Control request failed');
     }
@@ -853,6 +1041,7 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   private broadcastQueuedMessage(messageId: string, content: string): void {
+    if (this.terminalLifecycle.captureEpoch() === null) return;
     const sessionId = this.requireSessionId();
     createStreamHandler(this.ctx, this.eventQueries, sessionId).broadcastEvent({
       id: 0,
@@ -868,6 +1057,7 @@ export class SandboxSession extends DurableObject<Env> {
     streamEventType: 'interrupted' | 'complete' | 'error',
     data: Record<string, unknown> = {}
   ): void {
+    if (this.terminalLifecycle.captureEpoch() === null) return;
     const sessionId = this.requireSessionId();
     const timestamp = Date.now();
     const payload = JSON.stringify(data);
@@ -889,11 +1079,16 @@ export class SandboxSession extends DurableObject<Env> {
   }
 
   private async loadMessages(): Promise<MessageRecord[]> {
-    return (await this.ctx.storage.get<MessageRecord[]>(MESSAGES_KEY)) ?? [];
+    if (this.terminalLifecycle.isBlocked()) return [];
+    const messages = await this.ctx.storage.get<MessageRecord[]>(MESSAGES_KEY);
+    return this.terminalLifecycle.isBlocked() ? [] : (messages ?? []);
   }
 
-  private async saveMessages(messages: MessageRecord[]): Promise<void> {
-    await this.ctx.storage.put(MESSAGES_KEY, messages);
+  private async saveMessages(messages: MessageRecord[], epoch?: number): Promise<boolean> {
+    const currentEpoch = epoch ?? this.terminalLifecycle.captureEpoch();
+    if (currentEpoch === null || !this.terminalLifecycle.isCurrent(currentEpoch)) return false;
+    this.ctx.storage.kv.put(MESSAGES_KEY, messages);
+    return true;
   }
 
   private requireSessionId(): SessionId {

--- a/services/cloud-agent-next/src/sandbox-session/attach-payload.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/attach-payload.test.ts
@@ -1,5 +1,7 @@
 import { describe, expect, it, vi } from 'vitest';
 import { parseSessionMetadata } from '../persistence/session-metadata.js';
+import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../shared/runtime-environment.js';
+import { envVarsSchema } from '../types.js';
 import { buildSessionAttachPayload, fillAttachGitToken } from './attach-payload.js';
 
 describe('buildSessionAttachPayload', () => {
@@ -53,6 +55,60 @@ describe('buildSessionAttachPayload', () => {
       preparation: { attemptId: 'att_1', triggerMessageId: 'msg_1' },
     });
   });
+
+  for (const key of CONTROL_RUNTIME_RESERVED_ENV_VARS) {
+    it(`rejects ${key} in public session environment variables`, () => {
+      const result = envVarsSchema.safeParse({ [key]: 'user-controlled-secret' });
+      expect(result.success).toBe(false);
+      if (!result.success) {
+        expect(result.error.message).toContain(key);
+        expect(result.error.message).not.toContain('user-controlled-secret');
+      }
+    });
+
+    it(`rejects persisted profile environment variable ${key} before attach`, () => {
+      const metadata = parseSessionMetadata({
+        metadataSchemaVersion: 2,
+        identity: {
+          sessionId: 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          userId: 'user-1',
+        },
+        auth: { kiloSessionId: 'kilo_1' },
+        profile: { envVars: { [key]: 'user-controlled-secret' } },
+        lifecycle: { version: 1, timestamp: 1 },
+      });
+
+      expect(() => buildSessionAttachPayload(metadata)).toThrow(
+        `Reserved control runtime environment variable: ${key}`
+      );
+    });
+
+    it(`rejects persisted encrypted secret name ${key} before attach`, () => {
+      const metadata = parseSessionMetadata({
+        metadataSchemaVersion: 2,
+        identity: {
+          sessionId: 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+          userId: 'user-1',
+        },
+        auth: { kiloSessionId: 'kilo_1' },
+        profile: {
+          encryptedSecrets: {
+            [key]: {
+              encryptedData: 'encrypted-secret-value',
+              encryptedDEK: 'encrypted-data-key',
+              algorithm: 'rsa-aes-256-gcm',
+              version: 1,
+            },
+          },
+        },
+        lifecycle: { version: 1, timestamp: 1 },
+      });
+
+      expect(() => buildSessionAttachPayload(metadata)).toThrow(
+        `Reserved control runtime environment variable: ${key}`
+      );
+    });
+  }
 
   it('fills a GitHub token from git-token-service when metadata has none', async () => {
     const metadata = parseSessionMetadata({

--- a/services/cloud-agent-next/src/sandbox-session/attach-payload.ts
+++ b/services/cloud-agent-next/src/sandbox-session/attach-payload.ts
@@ -1,9 +1,21 @@
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import type { SessionAttachPayload } from '../shared/sandbox-control-protocol.js';
+import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../shared/runtime-environment.js';
 import { resolveGitHubTokenForRepo } from '../services/git-token-service-client.js';
 import { readProfileBundle } from '../session-profile.js';
 import type { GitTokenService } from '../types.js';
 import { getSessionWorkspacePath } from '../workspace.js';
+
+function rejectReservedControlRuntimeEnvironment(
+  environment: Record<string, unknown> | undefined
+): void {
+  if (!environment) return;
+  for (const key of CONTROL_RUNTIME_RESERVED_ENV_VARS) {
+    if (Object.hasOwn(environment, key)) {
+      throw new Error(`Reserved control runtime environment variable: ${key}`);
+    }
+  }
+}
 
 function gitFromMetadata(
   metadata: SessionMetadata
@@ -44,10 +56,13 @@ export function buildSessionAttachPayload(
   const git = gitFromMetadata(metadata);
   const branch = metadata.workspace?.branchName ?? metadata.repository?.upstreamBranch;
   const profile = readProfileBundle(metadata);
+  rejectReservedControlRuntimeEnvironment(profile.envVars);
+  rejectReservedControlRuntimeEnvironment(profile.encryptedSecrets);
   const env = {
     ...(profile.envVars ?? {}),
     ...(metadata.auth.kilocodeToken ? { KILOCODE_TOKEN: metadata.auth.kilocodeToken } : {}),
   };
+  rejectReservedControlRuntimeEnvironment(env);
   return {
     directory,
     ...(branch ? { branch } : {}),

--- a/services/cloud-agent-next/src/sandbox-session/control-rpc.ts
+++ b/services/cloud-agent-next/src/sandbox-session/control-rpc.ts
@@ -2,6 +2,10 @@ import type { ResponseFrame } from '../shared/sandbox-control-protocol.js';
 import type { SandboxControlOutboundRequest } from '../sandbox-control/socket.js';
 import type { AttachRouteInput } from '../sandbox-control/session-routes.js';
 import type { ConnectionState, PhysicalState } from '../sandbox-control/status-projection.js';
+import type {
+  SandboxTerminalAccessInput,
+  SandboxTerminalAccessResult,
+} from '../sandbox-control/terminal-billing.js';
 import type { Env } from '../types.js';
 
 type SandboxControlRpc = {
@@ -10,9 +14,20 @@ type SandboxControlRpc = {
     provider?: 'cloudflare' | 'vercel';
     kiloToken?: string;
     allowCreate?: boolean;
-  }): Promise<{ connection: ConnectionState; physical: PhysicalState }>;
-  getStatus(): Promise<{ connection: ConnectionState; physical: PhysicalState }>;
+  }): Promise<{
+    connection: ConnectionState;
+    physical: PhysicalState;
+    wrapperInstanceId?: string;
+  }>;
+  getStatus(): Promise<{
+    connection: ConnectionState;
+    physical: PhysicalState;
+    wrapperInstanceId?: string;
+  }>;
   attachSession(input: AttachRouteInput): Promise<unknown>;
+  detachSession(sessionId: string): Promise<{ existed: boolean }>;
+  validateTerminalAccess(input: SandboxTerminalAccessInput): Promise<SandboxTerminalAccessResult>;
+  recordTerminalActivity(input: SandboxTerminalAccessInput): Promise<SandboxTerminalAccessResult>;
   request(input: SandboxControlOutboundRequest): Promise<ResponseFrame>;
 };
 

--- a/services/cloud-agent-next/src/sandbox-session/terminal-bridge.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-bridge.test.ts
@@ -1,0 +1,360 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { parseSessionMetadata } from '../persistence/session-metadata.js';
+import type {
+  ResponseFrame,
+  SessionTerminalConnectPayload,
+} from '../shared/sandbox-control-protocol.js';
+import { createSandboxTerminalBridge, type SandboxTerminalRecord } from './terminal-bridge.js';
+
+const SESSION_ID = 'workspace_aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const WRAPPER_INSTANCE_ID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const PTY_ID = 'pty_test';
+
+class FakeWebSocket {
+  readyState = 0;
+  tags: string[] = [];
+  private attachment: unknown = null;
+
+  readonly send = vi.fn<(message: string | ArrayBuffer) => void>();
+  readonly close = vi.fn<(code: number, reason: string) => void>(() => {
+    this.readyState = 2;
+  });
+  readonly serializeAttachment = vi.fn<(value: unknown) => void>(value => {
+    this.attachment = structuredClone(value);
+  });
+  readonly deserializeAttachment = vi.fn<() => unknown>(() => this.attachment);
+}
+
+class FakeWebSocketPair {
+  readonly 0 = new FakeWebSocket();
+  readonly 1 = new FakeWebSocket();
+}
+
+class FakeResponse {
+  readonly status: number;
+  readonly webSocket?: WebSocket;
+
+  constructor(_body: unknown, init?: ResponseInit & { webSocket?: WebSocket }) {
+    this.status = init?.status ?? 200;
+    this.webSocket = init?.webSocket;
+  }
+}
+
+function asWebSocket(socket: FakeWebSocket): WebSocket {
+  return socket as unknown as WebSocket;
+}
+
+function response(): ResponseFrame {
+  return {
+    type: 'response',
+    requestId: 'request_terminal',
+    ok: true,
+    result: { connected: true },
+  };
+}
+
+function request(pathname: string, authorization?: string): Request {
+  const headers = new Headers({ Upgrade: 'websocket' });
+  if (authorization) headers.set('Authorization', `Bearer ${authorization}`);
+  return new Request(`http://session.test${pathname}?ptyId=${PTY_ID}`, { headers });
+}
+
+function deferred<T>() {
+  let resolve: ((value: T) => void) | undefined;
+  const promise = new Promise<T>(complete => {
+    resolve = complete;
+  });
+  return {
+    promise,
+    resolve(value: T) {
+      if (!resolve) throw new Error('Missing deferred resolver');
+      resolve(value);
+    },
+  };
+}
+
+function createHarness() {
+  const metadata = parseSessionMetadata({
+    metadataSchemaVersion: 2,
+    identity: { sessionId: SESSION_ID, userId: 'user_test' },
+    auth: { kiloSessionId: 'kilo_test' },
+    workspace: { sandboxId: 'ses-abcdef', workspacePath: '/workspace/user_test' },
+    lifecycle: { version: 1, timestamp: 1 },
+  });
+  let record: SandboxTerminalRecord = {
+    ptyId: PTY_ID,
+    ownerId: 'user_test',
+    sessionId: SESSION_ID,
+    kiloSessionId: 'kilo_test',
+    directory: '/workspace/user_test',
+    sandboxId: 'ses-abcdef',
+    wrapperInstanceId: WRAPPER_INSTANCE_ID,
+    state: 'running',
+  };
+  const sockets: FakeWebSocket[] = [];
+  const activities: Promise<unknown>[] = [];
+  const state = {
+    id: { name: `user_test:${SESSION_ID}` },
+    acceptWebSocket: vi.fn((socket: WebSocket, tags: string[] = []) => {
+      const accepted = socket as unknown as FakeWebSocket;
+      accepted.tags = tags;
+      accepted.readyState = 1;
+      sockets.push(accepted);
+    }),
+    getWebSockets: vi.fn((tag?: string) =>
+      sockets.filter(socket => tag === undefined || socket.tags.includes(tag)).map(asWebSocket)
+    ),
+    waitUntil: vi.fn((promise: Promise<unknown>) => {
+      activities.push(promise);
+    }),
+  } as unknown as DurableObjectState;
+  const getMetadata = vi.fn(async () => metadata);
+  const getTerminal = vi.fn(async (ptyId: string) => (ptyId === PTY_ID ? record : undefined));
+  const reportActivity = vi.fn(async () => undefined);
+  const markEnded = vi.fn(async () => {
+    record = { ...record, state: 'ended' };
+  });
+  const requestConnect = vi.fn(
+    async (_record: SandboxTerminalRecord, payload: SessionTerminalConnectPayload) => {
+      const upgrade = await bridge.handleWrapperUpgrade(
+        request('/terminal/wrapper', payload.capability)
+      );
+      expect(upgrade.status).toBe(101);
+      return response();
+    }
+  );
+
+  const bridge = createSandboxTerminalBridge({
+    state,
+    getMetadata,
+    getTerminal,
+    requestConnect,
+    reportActivity,
+    markEnded,
+  });
+
+  return {
+    bridge,
+    sockets,
+    activities,
+    state,
+    getMetadata,
+    getTerminal,
+    requestConnect,
+    reportActivity,
+    markEnded,
+    setRecord(value: SandboxTerminalRecord) {
+      record = value;
+    },
+    get record() {
+      return record;
+    },
+  };
+}
+
+beforeEach(() => {
+  vi.stubGlobal('WebSocketPair', FakeWebSocketPair);
+  vi.stubGlobal('Response', FakeResponse);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('sandbox terminal bridge', () => {
+  it('pairs hibernation sockets, consumes the capability, and forwards native frames', async () => {
+    const harness = createHarness();
+    const upgraded = await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    expect(upgraded.status).toBe(101);
+    expect(harness.sockets).toHaveLength(2);
+
+    const browser = harness.sockets[0];
+    const wrapper = harness.sockets[1];
+    if (!browser || !wrapper) throw new Error('Missing paired sockets');
+    expect(browser.tags).toEqual(['terminal', `terminal:browser:${PTY_ID}`]);
+    expect(wrapper.tags).toEqual(['terminal', `terminal:wrapper:${PTY_ID}`]);
+    expect(browser.deserializeAttachment()).not.toHaveProperty('capabilityHash');
+    expect(wrapper.deserializeAttachment()).not.toHaveProperty('capabilityHash');
+
+    await harness.bridge.handleMessage(asWebSocket(browser), 'ping');
+    await harness.bridge.handleMessage(asWebSocket(browser), 'more input');
+    expect(wrapper.send).toHaveBeenCalledWith('ping');
+    expect(wrapper.send).toHaveBeenCalledWith('more input');
+
+    const binary = new Uint8Array([0, 127, 255]).buffer;
+    await harness.bridge.handleMessage(asWebSocket(wrapper), binary);
+    expect(browser.send).toHaveBeenCalledWith(binary);
+
+    await Promise.all(harness.activities);
+    expect(harness.reportActivity).toHaveBeenCalledTimes(2);
+  });
+
+  it('allows exactly one concurrent redemption of a pending capability', async () => {
+    const harness = createHarness();
+    harness.requestConnect.mockImplementation(async (_record, payload) => {
+      const upgrades = await Promise.all([
+        harness.bridge.handleWrapperUpgrade(request('/terminal/wrapper', payload.capability)),
+        harness.bridge.handleWrapperUpgrade(request('/terminal/wrapper', payload.capability)),
+      ]);
+      expect(upgrades.map(upgrade => upgrade.status).sort()).toEqual([101, 401]);
+      return response();
+    });
+
+    await expect(
+      harness.bridge.handleBrowserUpgrade(request('/terminal/browser'))
+    ).resolves.toMatchObject({ status: 101 });
+    expect(harness.sockets).toHaveLength(2);
+  });
+
+  it('rejects expired producer capabilities without accepting a wrapper socket', async () => {
+    const harness = createHarness();
+    harness.requestConnect.mockImplementation(async (_record, payload) => {
+      const browser = harness.sockets[0];
+      if (!browser) throw new Error('Missing pending browser');
+      const attachment = browser.deserializeAttachment();
+      if (typeof attachment !== 'object' || attachment === null) {
+        throw new Error('Missing pending browser attachment');
+      }
+      browser.serializeAttachment({ ...attachment, capabilityExpiresAt: Date.now() - 1 });
+      await expect(
+        harness.bridge.handleWrapperUpgrade(request('/terminal/wrapper', payload.capability))
+      ).resolves.toMatchObject({ status: 401 });
+      return response();
+    });
+
+    await expect(
+      harness.bridge.handleBrowserUpgrade(request('/terminal/browser'))
+    ).resolves.toMatchObject({ status: 409 });
+    expect(harness.sockets).toHaveLength(1);
+  });
+
+  it('revokes superseded capabilities before closing sockets that remain discoverable', async () => {
+    const harness = createHarness();
+    const firstStarted = deferred<SessionTerminalConnectPayload>();
+    const releaseFirst = deferred<ResponseFrame>();
+    let calls = 0;
+    harness.requestConnect.mockImplementation(async (_record, payload) => {
+      calls += 1;
+      if (calls === 1) {
+        firstStarted.resolve(payload);
+        return releaseFirst.promise;
+      }
+      const upgraded = await harness.bridge.handleWrapperUpgrade(
+        request('/terminal/wrapper', payload.capability)
+      );
+      expect(upgraded.status).toBe(101);
+      return response();
+    });
+
+    const first = harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    const pending = await firstStarted.promise;
+    const oldBrowser = harness.sockets[0];
+    if (!oldBrowser) throw new Error('Missing pending browser');
+    expect(oldBrowser.deserializeAttachment()).toHaveProperty('capabilityHash');
+
+    const second = await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    expect(second.status).toBe(101);
+    expect(oldBrowser.readyState).toBe(2);
+    expect(oldBrowser.deserializeAttachment()).not.toHaveProperty('capabilityHash');
+    await expect(
+      harness.bridge.handleWrapperUpgrade(request('/terminal/wrapper', pending.capability))
+    ).resolves.toMatchObject({ status: 401 });
+
+    releaseFirst.resolve(response());
+    await expect(first).resolves.toMatchObject({ status: 409 });
+    const currentBrowser = harness.sockets.find(
+      socket => socket.readyState === 1 && socket.tags.includes(`terminal:browser:${PTY_ID}`)
+    );
+    expect(currentBrowser).toBeDefined();
+  });
+
+  it('does not let old close events terminate replacement generations', async () => {
+    const harness = createHarness();
+    await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    const oldBrowser = harness.sockets[0];
+    const oldWrapper = harness.sockets[1];
+    if (!oldBrowser || !oldWrapper) throw new Error('Missing original socket pair');
+
+    await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    const browser = harness.sockets[2];
+    const wrapper = harness.sockets[3];
+    if (!browser || !wrapper) throw new Error('Missing replacement socket pair');
+
+    await harness.bridge.handleMessage(asWebSocket(oldWrapper), 'stale output');
+    await harness.bridge.handleClose(asWebSocket(oldBrowser), 1000, 'stale', true);
+    await harness.bridge.handleClose(asWebSocket(oldWrapper), 1000, 'stale', true);
+    expect(browser.send).not.toHaveBeenCalled();
+    expect(browser.readyState).toBe(1);
+    expect(wrapper.readyState).toBe(1);
+    expect(harness.markEnded).not.toHaveBeenCalled();
+  });
+
+  it('acknowledges a browser-initiated close without ending its running PTY', async () => {
+    const harness = createHarness();
+    await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    const browser = harness.sockets[0];
+    const wrapper = harness.sockets[1];
+    if (!browser || !wrapper) throw new Error('Missing socket pair');
+
+    browser.readyState = 2;
+    await harness.bridge.handleClose(asWebSocket(browser), 1000, 'verification reconnect', true);
+
+    expect(browser.close).toHaveBeenCalledWith(1000, 'verification reconnect');
+    expect(wrapper.close).toHaveBeenCalledWith(1000, 'Browser disconnected');
+    expect(harness.markEnded).not.toHaveBeenCalled();
+    expect(harness.record.state).toBe('running');
+    await expect(
+      harness.bridge.handleBrowserUpgrade(request('/terminal/browser'))
+    ).resolves.toMatchObject({ status: 101 });
+  });
+
+  it('ends a PTY only after its current wrapper closes normally', async () => {
+    const harness = createHarness();
+    await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    const browser = harness.sockets[0];
+    const wrapper = harness.sockets[1];
+    if (!browser || !wrapper) throw new Error('Missing socket pair');
+
+    wrapper.readyState = 2;
+    await harness.bridge.handleMessage(asWebSocket(wrapper), 'final output');
+    expect(browser.send).toHaveBeenCalledWith('final output');
+    await harness.bridge.handleClose(asWebSocket(wrapper), 1000, 'process exited', true);
+    expect(harness.markEnded).toHaveBeenCalledOnce();
+    expect(browser.close).toHaveBeenCalledWith(1000, 'PTY session ended');
+
+    const ended = await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    expect(ended.status).toBe(101);
+    expect(harness.sockets[2]?.close).toHaveBeenCalledWith(1000, 'PTY session ended');
+  });
+
+  it('closes oversized frames and normalizes reserved codes and oversized reasons', async () => {
+    const harness = createHarness();
+    await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    const browser = harness.sockets[0];
+    const wrapper = harness.sockets[1];
+    if (!browser || !wrapper) throw new Error('Missing socket pair');
+
+    await harness.bridge.handleMessage(asWebSocket(browser), 'x'.repeat(256 * 1024 + 1));
+    expect(browser.close).toHaveBeenCalledWith(1009, 'Terminal frame too large');
+    expect(wrapper.close).toHaveBeenCalledWith(1009, 'Terminal frame too large');
+
+    await harness.bridge.handleBrowserUpgrade(request('/terminal/browser'));
+    const replacement = harness.sockets[2];
+    if (!replacement) throw new Error('Missing replacement browser');
+    harness.bridge.closeTerminal(PTY_ID, 1006, 'é'.repeat(100));
+    const call = replacement.close.mock.calls[0];
+    expect(call?.[0]).toBe(1011);
+    expect(new TextEncoder().encode(call?.[1] ?? '').byteLength).toBeLessThanOrEqual(123);
+  });
+
+  it('rejects mismatched owner, root session, directory, and sandbox metadata', async () => {
+    for (const field of ['ownerId', 'kiloSessionId', 'directory', 'sandboxId'] as const) {
+      const harness = createHarness();
+      harness.setRecord({ ...harness.record, [field]: 'mismatched' });
+      await expect(
+        harness.bridge.handleBrowserUpgrade(request('/terminal/browser'))
+      ).resolves.toMatchObject({ status: 403 });
+      expect(harness.requestConnect).not.toHaveBeenCalled();
+    }
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-session/terminal-bridge.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-bridge.ts
@@ -1,0 +1,533 @@
+import { timingSafeEqual } from '@kilocode/encryption';
+import { z } from 'zod';
+import type { SessionMetadata } from '../persistence/session-metadata.js';
+import {
+  responseFrameSchema,
+  sessionTerminalConnectPayloadSchema,
+  sessionTerminalConnectResultSchema,
+  terminalPtyIdSchema,
+  wrapperInstanceIdSchema,
+  type ResponseFrame,
+  type SessionTerminalConnectPayload,
+} from '../shared/sandbox-control-protocol.js';
+import {
+  generateSandboxCredential,
+  hashSandboxCredential,
+  parseBearerCredential,
+} from '../sandbox-control/credential.js';
+import { getSessionWorkspacePath } from '../workspace.js';
+
+const TERMINAL_TAG = 'terminal';
+const TERMINAL_CAPABILITY_LIFETIME_MS = 45_000;
+const TERMINAL_ACTIVITY_INTERVAL_MS = 30_000;
+const MAX_TERMINAL_FRAME_BYTES = 256 * 1024;
+const MAX_CLOSE_REASON_BYTES = 123;
+const SOCKET_OPEN = 1;
+const SOCKET_CLOSING = 2;
+const TERMINAL_ENDED_REASON = 'PTY session ended';
+const encoder = new TextEncoder();
+
+export type SandboxTerminalRecord = {
+  ptyId: string;
+  ownerId: string;
+  sessionId: string;
+  kiloSessionId: string;
+  directory: string;
+  sandboxId: string;
+  wrapperInstanceId: string;
+  organizationId?: string;
+  state: 'running' | 'ended';
+};
+
+type SandboxTerminalBridgeOptions = {
+  state: DurableObjectState;
+  getMetadata: () => Promise<SessionMetadata | null>;
+  getTerminal: (ptyId: string) => Promise<SandboxTerminalRecord | undefined>;
+  requestConnect: (
+    record: SandboxTerminalRecord,
+    payload: SessionTerminalConnectPayload
+  ) => Promise<ResponseFrame>;
+  reportActivity: (record: SandboxTerminalRecord) => Promise<void>;
+  markEnded: (record: SandboxTerminalRecord) => Promise<void>;
+};
+
+const terminalSocketAttachmentSchema = z
+  .object({
+    role: z.enum(['browser', 'wrapper']),
+    ptyId: terminalPtyIdSchema,
+    bridgeGeneration: z.string().uuid(),
+    wrapperInstanceId: wrapperInstanceIdSchema,
+    capabilityHash: z
+      .string()
+      .regex(/^[a-f0-9]{64}$/)
+      .optional(),
+    capabilityExpiresAt: z.number().int().nonnegative().optional(),
+    lastActivityReportedAt: z.number().int().nonnegative().optional(),
+  })
+  .strict();
+
+type TerminalSocketAttachment = z.infer<typeof terminalSocketAttachmentSchema>;
+
+type TerminalSocket = {
+  socket: WebSocket;
+  attachment: TerminalSocketAttachment;
+};
+
+function readAttachment(socket: WebSocket): TerminalSocketAttachment | null {
+  const parsed = terminalSocketAttachmentSchema.safeParse(socket.deserializeAttachment());
+  return parsed.success ? parsed.data : null;
+}
+
+function socketTag(role: TerminalSocketAttachment['role'], ptyId: string): string {
+  return `${TERMINAL_TAG}:${role}:${ptyId}`;
+}
+
+function parseInternalPtyId(request: Request, pathname: string): string | null {
+  const url = new URL(request.url);
+  if (url.pathname !== pathname) return null;
+  const entries = [...url.searchParams.entries()];
+  if (entries.length !== 1 || entries[0]?.[0] !== 'ptyId') return null;
+  const parsed = terminalPtyIdSchema.safeParse(entries[0][1]);
+  return parsed.success ? parsed.data : null;
+}
+
+function isWebSocketUpgrade(request: Request): boolean {
+  return request.headers.get('Upgrade')?.toLowerCase() === 'websocket';
+}
+
+function normalizeCloseCode(code: number): number {
+  if (code >= 3000 && code <= 4999) return code;
+  if (code >= 1000 && code <= 1014 && code !== 1004 && code !== 1005 && code !== 1006) {
+    return code;
+  }
+  return 1011;
+}
+
+function normalizeCloseReason(reason: string): string {
+  const bytes = encoder.encode(reason);
+  if (bytes.byteLength <= MAX_CLOSE_REASON_BYTES) return reason;
+  return new TextDecoder().decode(bytes.subarray(0, MAX_CLOSE_REASON_BYTES), { stream: true });
+}
+
+function closeSocket(socket: WebSocket, code: number, reason: string): void {
+  try {
+    socket.close(normalizeCloseCode(code), normalizeCloseReason(reason));
+  } catch {
+    return;
+  }
+}
+
+function revokePendingCapability(socket: WebSocket, attachment: TerminalSocketAttachment): void {
+  if (
+    attachment.role !== 'browser' ||
+    (attachment.capabilityHash === undefined && attachment.capabilityExpiresAt === undefined)
+  ) {
+    return;
+  }
+  const revoked = { ...attachment };
+  delete revoked.capabilityHash;
+  delete revoked.capabilityExpiresAt;
+  socket.serializeAttachment(revoked);
+}
+
+function sameGeneration(
+  first: TerminalSocketAttachment,
+  second: TerminalSocketAttachment
+): boolean {
+  return (
+    first.ptyId === second.ptyId &&
+    first.bridgeGeneration === second.bridgeGeneration &&
+    first.wrapperInstanceId === second.wrapperInstanceId
+  );
+}
+
+export function createSandboxTerminalBridge(options: SandboxTerminalBridgeOptions) {
+  const { state, getMetadata, getTerminal, requestConnect, reportActivity, markEnded } = options;
+
+  function currentSocket(
+    role: TerminalSocketAttachment['role'],
+    ptyId: string
+  ): TerminalSocket | null {
+    for (const socket of state.getWebSockets(socketTag(role, ptyId))) {
+      if (socket.readyState !== SOCKET_OPEN) continue;
+      const attachment = readAttachment(socket);
+      if (attachment?.role === role && attachment.ptyId === ptyId) {
+        return { socket, attachment };
+      }
+    }
+    return null;
+  }
+
+  function recordMatchesMetadata(
+    record: SandboxTerminalRecord | undefined,
+    metadata: SessionMetadata | null,
+    ptyId: string
+  ): record is SandboxTerminalRecord {
+    if (
+      !record ||
+      !metadata ||
+      record.ptyId !== ptyId ||
+      record.ownerId !== metadata.identity.userId ||
+      record.sessionId !== metadata.identity.sessionId ||
+      !record.sessionId.startsWith('workspace_') ||
+      record.kiloSessionId !== metadata.auth.kiloSessionId ||
+      record.sandboxId !== metadata.workspace?.sandboxId ||
+      (record.organizationId ?? null) !== (metadata.identity.orgId ?? null) ||
+      !wrapperInstanceIdSchema.safeParse(record.wrapperInstanceId).success
+    ) {
+      return false;
+    }
+
+    const durableObjectName = state.id.name;
+    if (durableObjectName && durableObjectName !== `${record.ownerId}:${record.sessionId}`) {
+      return false;
+    }
+
+    try {
+      const directory =
+        metadata.workspace?.workspacePath ??
+        getSessionWorkspacePath(
+          metadata.identity.orgId,
+          metadata.identity.userId,
+          metadata.identity.sessionId
+        );
+      return record.directory === directory;
+    } catch {
+      return false;
+    }
+  }
+
+  function closeSockets(sockets: WebSocket[], code: number, reason: string): void {
+    for (const socket of sockets) {
+      const attachment = readAttachment(socket);
+      if (attachment) revokePendingCapability(socket, attachment);
+    }
+    for (const socket of sockets) closeSocket(socket, code, reason);
+  }
+
+  function closeGeneration(
+    attachment: TerminalSocketAttachment,
+    code: number,
+    reason: string
+  ): void {
+    const sockets = state.getWebSockets(TERMINAL_TAG).filter(socket => {
+      const current = readAttachment(socket);
+      return current !== null && sameGeneration(current, attachment);
+    });
+    closeSockets(sockets, code, reason);
+  }
+
+  function closeTerminal(ptyId: string, code = 1000, reason = TERMINAL_ENDED_REASON): void {
+    const sockets = [
+      ...state.getWebSockets(socketTag('browser', ptyId)),
+      ...state.getWebSockets(socketTag('wrapper', ptyId)),
+    ];
+    closeSockets(sockets, code, reason);
+  }
+
+  function closeAll(code = 1000, reason = TERMINAL_ENDED_REASON): void {
+    closeSockets(state.getWebSockets(TERMINAL_TAG), code, reason);
+  }
+
+  function closeRuntime(
+    wrapperInstanceId: string,
+    code = 1000,
+    reason = TERMINAL_ENDED_REASON
+  ): void {
+    const sockets = state
+      .getWebSockets(TERMINAL_TAG)
+      .filter(socket => readAttachment(socket)?.wrapperInstanceId === wrapperInstanceId);
+    closeSockets(sockets, code, reason);
+  }
+
+  function reportSocketActivity(socket: WebSocket, attachment: TerminalSocketAttachment): void {
+    const now = Date.now();
+    if (
+      attachment.lastActivityReportedAt !== undefined &&
+      now - attachment.lastActivityReportedAt < TERMINAL_ACTIVITY_INTERVAL_MS
+    ) {
+      return;
+    }
+
+    socket.serializeAttachment({ ...attachment, lastActivityReportedAt: now });
+    state.waitUntil(
+      (async () => {
+        const [metadata, record] = await Promise.all([
+          getMetadata(),
+          getTerminal(attachment.ptyId),
+        ]);
+        const current = currentSocket(attachment.role, attachment.ptyId);
+        if (
+          !recordMatchesMetadata(record, metadata, attachment.ptyId) ||
+          record.state !== 'running' ||
+          record.wrapperInstanceId !== attachment.wrapperInstanceId ||
+          current?.socket !== socket ||
+          !sameGeneration(current.attachment, attachment)
+        ) {
+          return;
+        }
+        await reportActivity(record);
+      })().catch(() => undefined)
+    );
+  }
+
+  async function handleBrowserUpgrade(request: Request): Promise<Response> {
+    if (!isWebSocketUpgrade(request)) {
+      return new Response('Expected WebSocket upgrade', { status: 426 });
+    }
+    const ptyId = parseInternalPtyId(request, '/terminal/browser');
+    if (!ptyId) return new Response('Invalid PTY ID', { status: 400 });
+
+    const [metadata, record] = await Promise.all([getMetadata(), getTerminal(ptyId)]);
+    if (!record || !metadata) return new Response('PTY not found', { status: 404 });
+    if (!recordMatchesMetadata(record, metadata, ptyId)) {
+      return new Response('Invalid terminal session', { status: 403 });
+    }
+
+    if (record.state === 'ended') {
+      const pair = new WebSocketPair();
+      const attachment: TerminalSocketAttachment = {
+        role: 'browser',
+        ptyId,
+        bridgeGeneration: crypto.randomUUID(),
+        wrapperInstanceId: record.wrapperInstanceId,
+      };
+      state.acceptWebSocket(pair[1], [TERMINAL_TAG, socketTag('browser', ptyId)]);
+      pair[1].serializeAttachment(attachment);
+      closeSocket(pair[1], 1000, TERMINAL_ENDED_REASON);
+      return new Response(null, { status: 101, webSocket: pair[0] });
+    }
+
+    const capability = generateSandboxCredential();
+    const capabilityHash = await hashSandboxCredential(capability);
+    const [latestMetadata, latestRecord] = await Promise.all([getMetadata(), getTerminal(ptyId)]);
+    if (
+      !recordMatchesMetadata(latestRecord, latestMetadata, ptyId) ||
+      latestRecord.state !== 'running' ||
+      latestRecord.wrapperInstanceId !== record.wrapperInstanceId
+    ) {
+      return new Response('Terminal unavailable', { status: 409 });
+    }
+
+    const bridgeGeneration = crypto.randomUUID();
+    const attachment: TerminalSocketAttachment = {
+      role: 'browser',
+      ptyId,
+      bridgeGeneration,
+      wrapperInstanceId: latestRecord.wrapperInstanceId,
+      capabilityHash,
+      capabilityExpiresAt: Date.now() + TERMINAL_CAPABILITY_LIFETIME_MS,
+    };
+    const pair = new WebSocketPair();
+    closeTerminal(ptyId, 4000, 'Terminal connection replaced');
+    state.acceptWebSocket(pair[1], [TERMINAL_TAG, socketTag('browser', ptyId)]);
+    pair[1].serializeAttachment(attachment);
+
+    try {
+      const payload = sessionTerminalConnectPayloadSchema.parse({
+        ownerId: latestRecord.ownerId,
+        ptyId,
+        bridgeGeneration,
+        capability,
+      });
+      const response = responseFrameSchema.safeParse(await requestConnect(latestRecord, payload));
+      if (
+        !response.success ||
+        !response.data.ok ||
+        !sessionTerminalConnectResultSchema.safeParse(response.data.result).success
+      ) {
+        closeGeneration(attachment, 1011, 'Terminal connection failed');
+        return new Response('Terminal connection failed', { status: 502 });
+      }
+
+      const [currentMetadata, currentRecord] = await Promise.all([
+        getMetadata(),
+        getTerminal(ptyId),
+      ]);
+      const browser = currentSocket('browser', ptyId);
+      const wrapper = currentSocket('wrapper', ptyId);
+      if (
+        !recordMatchesMetadata(currentRecord, currentMetadata, ptyId) ||
+        currentRecord.state !== 'running' ||
+        currentRecord.wrapperInstanceId !== attachment.wrapperInstanceId ||
+        browser?.socket !== pair[1] ||
+        !wrapper ||
+        !sameGeneration(browser.attachment, attachment) ||
+        !sameGeneration(wrapper.attachment, attachment)
+      ) {
+        closeGeneration(attachment, 1011, 'Terminal connection replaced');
+        return new Response('Terminal unavailable', { status: 409 });
+      }
+
+      return new Response(null, { status: 101, webSocket: pair[0] });
+    } catch {
+      closeGeneration(attachment, 1011, 'Terminal connection failed');
+      return new Response('Terminal connection failed', { status: 502 });
+    }
+  }
+
+  async function handleWrapperUpgrade(request: Request): Promise<Response> {
+    if (!isWebSocketUpgrade(request)) {
+      return new Response('Expected WebSocket upgrade', { status: 426 });
+    }
+    const ptyId = parseInternalPtyId(request, '/terminal/wrapper');
+    if (!ptyId) return new Response('Invalid PTY ID', { status: 400 });
+
+    const credential = parseBearerCredential(request.headers.get('Authorization'));
+    if (credential === null) return new Response('Unauthorized', { status: 401 });
+
+    const [metadata, record] = await Promise.all([getMetadata(), getTerminal(ptyId)]);
+    if (!recordMatchesMetadata(record, metadata, ptyId) || record.state !== 'running') {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    const presentedHash = await hashSandboxCredential(credential);
+    const browser = currentSocket('browser', ptyId);
+    if (
+      !browser ||
+      browser.attachment.wrapperInstanceId !== record.wrapperInstanceId ||
+      browser.attachment.capabilityHash === undefined ||
+      browser.attachment.capabilityExpiresAt === undefined ||
+      browser.attachment.capabilityExpiresAt <= Date.now() ||
+      !timingSafeEqual(presentedHash, browser.attachment.capabilityHash)
+    ) {
+      return new Response('Unauthorized', { status: 401 });
+    }
+
+    const attachment: TerminalSocketAttachment = {
+      role: 'wrapper',
+      ptyId,
+      bridgeGeneration: browser.attachment.bridgeGeneration,
+      wrapperInstanceId: browser.attachment.wrapperInstanceId,
+    };
+
+    try {
+      const pair = new WebSocketPair();
+      revokePendingCapability(browser.socket, browser.attachment);
+      state.acceptWebSocket(pair[1], [TERMINAL_TAG, socketTag('wrapper', ptyId)]);
+      pair[1].serializeAttachment(attachment);
+      return new Response(null, { status: 101, webSocket: pair[0] });
+    } catch {
+      closeGeneration(browser.attachment, 1011, 'Terminal connection failed');
+      return new Response('Terminal connection failed', { status: 502 });
+    }
+  }
+
+  async function handleMessage(socket: WebSocket, message: string | ArrayBuffer): Promise<void> {
+    const attachment = readAttachment(socket);
+    if (!attachment) return;
+
+    const current = currentSocket(attachment.role, attachment.ptyId);
+    if (current?.socket !== socket) {
+      if (current !== null || socket.readyState !== SOCKET_CLOSING) return;
+    } else if (!sameGeneration(current.attachment, attachment)) {
+      return;
+    }
+
+    const size =
+      typeof message === 'string' ? encoder.encode(message).byteLength : message.byteLength;
+    if (size > MAX_TERMINAL_FRAME_BYTES) {
+      closeGeneration(attachment, 1009, 'Terminal frame too large');
+      return;
+    }
+
+    const peer = currentSocket(
+      attachment.role === 'browser' ? 'wrapper' : 'browser',
+      attachment.ptyId
+    );
+    if (!peer || !sameGeneration(peer.attachment, attachment)) {
+      closeGeneration(attachment, 1011, 'Terminal peer unavailable');
+      return;
+    }
+
+    try {
+      peer.socket.send(message);
+    } catch {
+      closeGeneration(attachment, 1011, 'Terminal connection failed');
+      return;
+    }
+
+    if (socket.readyState === SOCKET_OPEN) reportSocketActivity(socket, attachment);
+  }
+
+  async function handleClose(
+    socket: WebSocket,
+    code: number,
+    reason: string,
+    _wasClean: boolean
+  ): Promise<void> {
+    const attachment = readAttachment(socket);
+    if (!attachment) return;
+
+    if (attachment.role === 'browser') {
+      revokePendingCapability(socket, attachment);
+      closeSocket(socket, code, reason);
+    }
+
+    const currentRoleSocket = currentSocket(attachment.role, attachment.ptyId);
+    if (currentRoleSocket && currentRoleSocket.socket !== socket) return;
+
+    const peer = currentSocket(
+      attachment.role === 'browser' ? 'wrapper' : 'browser',
+      attachment.ptyId
+    );
+    if (!peer || !sameGeneration(peer.attachment, attachment)) return;
+
+    if (attachment.role === 'browser') {
+      closeSocket(peer.socket, code === 1000 ? 1000 : 1011, 'Browser disconnected');
+      return;
+    }
+
+    if (code !== 1000) {
+      revokePendingCapability(peer.socket, peer.attachment);
+      closeSocket(peer.socket, 1011, 'Terminal connection failed');
+      return;
+    }
+
+    try {
+      const [metadata, record] = await Promise.all([getMetadata(), getTerminal(attachment.ptyId)]);
+      const latestBrowser = currentSocket('browser', attachment.ptyId);
+      if (
+        !recordMatchesMetadata(record, metadata, attachment.ptyId) ||
+        record.state !== 'running' ||
+        record.wrapperInstanceId !== attachment.wrapperInstanceId ||
+        !latestBrowser ||
+        !sameGeneration(latestBrowser.attachment, attachment)
+      ) {
+        return;
+      }
+
+      await markEnded(record);
+      const currentBrowser = currentSocket('browser', attachment.ptyId);
+      if (currentBrowser && sameGeneration(currentBrowser.attachment, attachment)) {
+        revokePendingCapability(currentBrowser.socket, currentBrowser.attachment);
+        closeSocket(currentBrowser.socket, 1000, TERMINAL_ENDED_REASON);
+      }
+    } catch {
+      const currentBrowser = currentSocket('browser', attachment.ptyId);
+      if (currentBrowser && sameGeneration(currentBrowser.attachment, attachment)) {
+        revokePendingCapability(currentBrowser.socket, currentBrowser.attachment);
+        closeSocket(currentBrowser.socket, 1011, 'Terminal connection failed');
+      }
+    }
+  }
+
+  async function handleError(socket: WebSocket, _error: unknown): Promise<void> {
+    const attachment = readAttachment(socket);
+    if (!attachment) return;
+    const current = currentSocket(attachment.role, attachment.ptyId);
+    if (current && current.socket !== socket) return;
+    closeGeneration(attachment, 1011, 'Terminal connection failed');
+  }
+
+  return {
+    handleBrowserUpgrade,
+    handleWrapperUpgrade,
+    handleMessage,
+    handleClose,
+    handleError,
+    closeTerminal,
+    closeAll,
+    closeRuntime,
+  };
+}

--- a/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.test.ts
@@ -345,14 +345,30 @@ describe('SandboxSession terminal lifecycle', () => {
     expect(fixture.control.request).toHaveBeenCalledOnce();
   });
 
-  it('closes wrapper PTYs and removes operation ownership on explicit close', async () => {
+  it('ends the terminal only after the wrapper confirms PTY deletion', async () => {
     const fixture = createFixture();
     await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
-
-    await expect(fixture.lifecycle.closeTerminal({ ptyId: 'pty_1' })).resolves.toEqual({
-      success: true,
-      data: { success: true },
+    let finishClose: (frame: ResponseFrame) => void = () => undefined;
+    let notifyCloseStarted: () => void = () => undefined;
+    const closeStarted = new Promise<void>(resolve => {
+      notifyCloseStarted = resolve;
     });
+    const delayedClose = new Promise<ResponseFrame>(resolve => {
+      finishClose = resolve;
+    });
+    fixture.control.request.mockImplementationOnce(async () => {
+      notifyCloseStarted();
+      return delayedClose;
+    });
+
+    const pending = fixture.lifecycle.closeTerminal({ ptyId: 'pty_1' });
+    await closeStarted;
+    expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'running' });
+    expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(true);
+    expect(fixture.closeTerminalBridge).not.toHaveBeenCalled();
+
+    finishClose(response({ success: true }));
+    await expect(pending).resolves.toEqual({ success: true, data: { success: true } });
     expect(fixture.closeTerminalBridge).toHaveBeenCalledWith('pty_1', 1000, 'PTY session ended');
     expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'ended' });
     expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(false);
@@ -364,18 +380,69 @@ describe('SandboxSession terminal lifecycle', () => {
     );
   });
 
-  it('still closes local terminal capabilities when wrapper PTY deletion fails', async () => {
+  it.each([
+    { failure: 'a rejected control request', result: new Error('wrapper unavailable') },
+    {
+      failure: 'an unsuccessful control response',
+      result: {
+        type: 'response',
+        requestId: 'request_1',
+        ok: false,
+        error: { code: 'not_ready', message: 'Wrapper unavailable', retryable: true },
+      } satisfies ResponseFrame,
+    },
+    { failure: 'failed PTY deletion', result: response({ success: false }) },
+    { failure: 'an invalid close result', result: response({ success: 'true' }) },
+  ])('preserves durable ownership for a close retry after $failure', async ({ result }) => {
     const fixture = createFixture();
     await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
-    fixture.control.request.mockRejectedValueOnce(new Error('wrapper unavailable'));
+    if (result instanceof Error) {
+      fixture.control.request.mockRejectedValueOnce(result);
+    } else {
+      fixture.control.request.mockResolvedValueOnce(result);
+    }
 
     await expect(fixture.lifecycle.closeTerminal({ ptyId: 'pty_1' })).resolves.toEqual({
+      success: false,
+      error: 'Terminal closure failed; please retry',
+    });
+    expect(fixture.closeTerminalBridge).not.toHaveBeenCalled();
+    expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'running' });
+    expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(true);
+
+    const restarted = createSandboxTerminalLifecycle({
+      state: { storage: fixture.storage },
+      getSessionId: () => SESSION_ID,
+      getControl: () => fixture.control,
+      getDirectory: () => DIRECTORY,
+      closeTerminalBridge: fixture.closeTerminalBridge,
+      closeAllBridges: fixture.closeAllBridges,
+      closeRuntimeBridges: fixture.closeRuntimeBridges,
+    });
+    await expect(restarted.closeTerminal({ ptyId: 'pty_1' })).resolves.toEqual({
       success: true,
       data: { success: true },
     });
     expect(fixture.closeTerminalBridge).toHaveBeenCalledWith('pty_1', 1000, 'PTY session ended');
     expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'ended' });
     expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(false);
+  });
+
+  it('does not restore terminal records when close finishes after session deletion', async () => {
+    const fixture = createFixture();
+    await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+    fixture.control.request.mockImplementationOnce(async () => {
+      fixture.lifecycle.beginDeletion(fixture.metadata);
+      fixture.lifecycle.purgeDeletedState();
+      return response({ success: true });
+    });
+
+    await expect(fixture.lifecycle.closeTerminal({ ptyId: 'pty_1' })).resolves.toEqual({
+      success: false,
+      error: 'Session not found',
+    });
+    expect([...fixture.values.keys()]).toEqual([SANDBOX_SESSION_LIFECYCLE_KEY]);
+    expect(fixture.closeTerminalBridge).not.toHaveBeenCalled();
   });
 
   it('invalidates only confirmed terminals belonging to the requested runtime', async () => {

--- a/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.test.ts
@@ -1,0 +1,487 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { SandboxControlOutboundRequest } from '../sandbox-control/socket.js';
+import type {
+  SandboxTerminalAccessInput,
+  SandboxTerminalAccessResult,
+} from '../sandbox-control/terminal-billing.js';
+import { parseSessionMetadata, serializeSessionMetadata } from '../persistence/session-metadata.js';
+import {
+  sessionTerminalClosePayloadSchema,
+  sessionTerminalCreatePayloadSchema,
+  sessionTerminalResizePayloadSchema,
+  type ResponseFrame,
+} from '../shared/sandbox-control-protocol.js';
+import {
+  createSandboxTerminalLifecycle,
+  SANDBOX_SESSION_LIFECYCLE_KEY,
+  SANDBOX_SESSION_METADATA_KEY,
+} from './terminal-lifecycle.js';
+
+vi.mock('@cloudflare/sandbox', () => ({ getSandbox: vi.fn() }));
+
+const SESSION_ID = 'workspace_11111111-1111-4111-8111-111111111111';
+const SANDBOX_ID = 'ses-11111111111141118111111111111111';
+const WRAPPER_INSTANCE_ID = '22222222-2222-4222-8222-222222222222';
+const REPLACEMENT_INSTANCE_ID = '33333333-3333-4333-8333-333333333333';
+const FIRST_OPERATION_ID = '44444444-4444-4444-8444-444444444444';
+const SECOND_OPERATION_ID = '55555555-5555-4555-8555-555555555555';
+const DIRECTORY = '/workspace/interactive-session';
+
+function memoryStorage() {
+  const values = new Map<string, unknown>();
+  const kv: SyncKvStorage = {
+    get: <T = unknown>(key: string): T | undefined => values.get(key) as T | undefined,
+    put: <T>(key: string, value: T): void => {
+      values.set(key, value);
+    },
+    delete: (key: string): boolean => values.delete(key),
+    list: <T = unknown>(options?: SyncKvListOptions): Iterable<[string, T]> =>
+      [...values.entries()]
+        .filter(([key]) => !options?.prefix || key.startsWith(options.prefix))
+        .map(([key, value]) => [key, value as T]),
+  };
+  const storage = {
+    kv,
+    transactionSync: <T>(callback: () => T): T => callback(),
+  } as DurableObjectStorage;
+  return { storage, values };
+}
+
+function response(result: unknown): ResponseFrame {
+  return { type: 'response', requestId: 'request_1', ok: true, result };
+}
+
+function createFixture(
+  options: {
+    attached?: boolean;
+    platform?: string;
+    containment?: boolean;
+    organizationId?: string;
+    botId?: string;
+    terminalCapable?: boolean;
+  } = {}
+) {
+  const { storage, values } = memoryStorage();
+  const metadata = parseSessionMetadata({
+    metadataSchemaVersion: 2,
+    identity: {
+      sessionId: SESSION_ID,
+      userId: 'user_1',
+      createdOnPlatform: options.platform ?? 'cloud-agent-web',
+      ...(options.organizationId ? { orgId: options.organizationId } : {}),
+      ...(options.botId ? { botId: options.botId } : {}),
+    },
+    auth: { kiloSessionId: 'kilo_session_1' },
+    agent: { mode: 'code', model: 'test-model' },
+    workspace: {
+      sandboxId: SANDBOX_ID,
+      sandboxProvider: 'cloudflare',
+      ...(options.containment
+        ? {
+            credentialContainment: {
+              github: true,
+              gitlab: false,
+              bitbucket: false,
+              kilocode: false,
+            },
+          }
+        : {}),
+    },
+    lifecycle: { version: 1, timestamp: 1 },
+  });
+  storage.kv.put(SANDBOX_SESSION_METADATA_KEY, serializeSessionMetadata(metadata));
+
+  let wrapperInstanceId = options.terminalCapable === false ? undefined : WRAPPER_INSTANCE_ID;
+  let nextPtyId = 'pty_1';
+  const pty = (id: string) => ({
+    id,
+    title: 'Terminal',
+    command: '/bin/sh',
+    args: [],
+    cwd: DIRECTORY,
+    status: 'running' as const,
+    pid: 1234,
+  });
+  const request = vi.fn(async (input: SandboxControlOutboundRequest): Promise<ResponseFrame> => {
+    if (input.operation === 'session.terminal.create') {
+      sessionTerminalCreatePayloadSchema.parse(input.payload);
+      return response({ pty: pty(nextPtyId) });
+    }
+    if (input.operation === 'session.terminal.resize') {
+      const parsed = sessionTerminalResizePayloadSchema.parse(input.payload);
+      return response({ pty: pty(parsed.ptyId) });
+    }
+    if (input.operation === 'session.terminal.close') {
+      sessionTerminalClosePayloadSchema.parse(input.payload);
+      return response({ success: true });
+    }
+    if (input.operation === 'session.detach') return response({ detached: true });
+    return response({ connected: true });
+  });
+  const control = {
+    ensureReady: vi.fn(async () => ({
+      connection: 'ready' as const,
+      physical: 'running' as const,
+    })),
+    getStatus: vi.fn(async () => ({
+      connection: 'ready' as const,
+      physical: 'running' as const,
+      ...(wrapperInstanceId ? { wrapperInstanceId } : {}),
+    })),
+    attachSession: vi.fn(async () => ({})),
+    detachSession: vi.fn(async () => ({ existed: true })),
+    validateTerminalAccess: vi.fn(
+      async (_input: SandboxTerminalAccessInput): Promise<SandboxTerminalAccessResult> => ({
+        allowed: true,
+      })
+    ),
+    recordTerminalActivity: vi.fn(
+      async (_input: SandboxTerminalAccessInput): Promise<SandboxTerminalAccessResult> => ({
+        allowed: true,
+      })
+    ),
+    request,
+  };
+  const closeTerminalBridge = vi.fn();
+  const closeAllBridges = vi.fn();
+  const closeRuntimeBridges = vi.fn();
+  const lifecycle = createSandboxTerminalLifecycle({
+    state: { storage },
+    getSessionId: () => SESSION_ID,
+    getControl: () => control,
+    getDirectory: () => DIRECTORY,
+    closeTerminalBridge,
+    closeAllBridges,
+    closeRuntimeBridges,
+  });
+
+  function attachCurrentRuntime(): boolean {
+    return lifecycle.recordAttachment({
+      metadata,
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId,
+      epoch: lifecycle.captureEpoch() ?? -1,
+    });
+  }
+
+  if (options.attached !== false && wrapperInstanceId) attachCurrentRuntime();
+
+  return {
+    storage,
+    values,
+    metadata,
+    control,
+    lifecycle,
+    closeTerminalBridge,
+    closeAllBridges,
+    closeRuntimeBridges,
+    attachCurrentRuntime,
+    setWrapperInstanceId: (value: string | undefined) => {
+      wrapperInstanceId = value;
+    },
+    setPtyId: (value: string) => {
+      nextPtyId = value;
+    },
+  };
+}
+
+describe('SandboxSession terminal lifecycle', () => {
+  it('requires successful runtime-bound session attachment without starting compute', async () => {
+    const fixture = createFixture({ attached: false });
+
+    await expect(
+      fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID })
+    ).resolves.toEqual({
+      success: false,
+      error: 'Terminal unavailable until the workspace is prepared',
+    });
+    expect(fixture.control.ensureReady).not.toHaveBeenCalled();
+    expect(fixture.control.request).not.toHaveBeenCalled();
+
+    expect(fixture.attachCurrentRuntime()).toBe(true);
+    await expect(
+      fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID })
+    ).resolves.toMatchObject({
+      success: true,
+      data: { pty: { id: 'pty_1' } },
+    });
+  });
+
+  it.each([
+    [{ platform: 'code-review' }, 'interactive Cloud Agent sessions'],
+    [{ containment: true }, 'credential containment'],
+    [{ terminalCapable: false }, 'does not support terminals'],
+  ])('permanently rejects unsupported terminal access', async (options, reason) => {
+    const fixture = createFixture(options);
+
+    await expect(
+      fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID })
+    ).resolves.toMatchObject({
+      success: false,
+      error: expect.stringMatching(new RegExp(`^Terminal access denied:.*${reason}`)),
+    });
+    expect(fixture.control.request).not.toHaveBeenCalled();
+    expect(fixture.control.ensureReady).not.toHaveBeenCalled();
+  });
+
+  it('verifies trusted billing attribution before creating a shell', async () => {
+    const fixture = createFixture({ organizationId: 'org_1', botId: 'bot_1' });
+    fixture.control.validateTerminalAccess.mockResolvedValue({
+      allowed: false,
+      reason: 'billing_context_unavailable',
+    });
+
+    await expect(
+      fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID })
+    ).resolves.toEqual({
+      success: false,
+      error: 'Terminal access denied: billing_context_unavailable',
+    });
+    expect(fixture.control.validateTerminalAccess).toHaveBeenCalledWith({
+      sessionId: SESSION_ID,
+      ownerId: 'user_1',
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+      organizationId: 'org_1',
+      botId: 'bot_1',
+    });
+    expect(fixture.control.request).not.toHaveBeenCalled();
+  });
+
+  it('keeps transient runtime changes retryable without treating them as billing denial', async () => {
+    const fixture = createFixture();
+    fixture.control.validateTerminalAccess.mockResolvedValue({
+      allowed: false,
+      reason: 'runtime_changed',
+    });
+
+    await expect(
+      fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID })
+    ).resolves.toEqual({
+      success: false,
+      error: 'Terminal unavailable until the workspace is prepared',
+    });
+    expect(fixture.control.request).not.toHaveBeenCalled();
+  });
+
+  it('persists exact terminal ownership and reuses completed creation operations', async () => {
+    const fixture = createFixture({ organizationId: 'org_1' });
+    const input = { operationId: FIRST_OPERATION_ID, cols: 80, rows: 24 };
+
+    const first = await fixture.lifecycle.createTerminal(input);
+    const repeated = await fixture.lifecycle.createTerminal(input);
+
+    expect(first).toEqual(repeated);
+    expect(fixture.control.request).toHaveBeenCalledOnce();
+    expect(fixture.values.get('terminal:pty_1')).toEqual({
+      ptyId: 'pty_1',
+      ownerId: 'user_1',
+      sessionId: SESSION_ID,
+      kiloSessionId: 'kilo_session_1',
+      directory: DIRECTORY,
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+      organizationId: 'org_1',
+      state: 'running',
+    });
+    await expect(
+      fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID, cols: 120, rows: 40 })
+    ).resolves.toMatchObject({
+      success: false,
+      error: expect.stringMatching(/^Terminal access denied:.*operation conflicts/),
+    });
+    expect(fixture.control.request).toHaveBeenCalledOnce();
+  });
+
+  it('joins concurrent creation retries without allocating a second shell', async () => {
+    const fixture = createFixture();
+    let finishCreation: (frame: ResponseFrame) => void = () => undefined;
+    let notifyCreationStarted: () => void = () => undefined;
+    const creationStarted = new Promise<void>(resolve => {
+      notifyCreationStarted = resolve;
+    });
+    const delayedCreation = new Promise<ResponseFrame>(resolve => {
+      finishCreation = resolve;
+    });
+    fixture.control.request.mockImplementationOnce(async () => {
+      notifyCreationStarted();
+      return delayedCreation;
+    });
+
+    const first = fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+    await creationStarted;
+    const repeated = fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+    finishCreation(
+      response({
+        pty: {
+          id: 'pty_1',
+          title: 'Terminal',
+          command: '/bin/sh',
+          args: [],
+          cwd: DIRECTORY,
+          status: 'running',
+          pid: 1234,
+        },
+      })
+    );
+
+    const [firstResult, repeatedResult] = await Promise.all([first, repeated]);
+    expect(firstResult).toEqual(repeatedResult);
+    expect(fixture.control.request).toHaveBeenCalledOnce();
+  });
+
+  it('rejects persisted terminals whose owner no longer matches session metadata', async () => {
+    const fixture = createFixture();
+    await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+    const stored = fixture.values.get('terminal:pty_1');
+    if (typeof stored !== 'object' || stored === null) throw new Error('Terminal record missing');
+    fixture.values.set('terminal:pty_1', { ...stored, ownerId: 'user_other' });
+
+    await expect(
+      fixture.lifecycle.resizeTerminal({ ptyId: 'pty_1', cols: 100, rows: 30 })
+    ).resolves.toEqual({
+      success: false,
+      error: 'Terminal access denied: terminal does not belong to this session',
+    });
+    expect(fixture.control.request).toHaveBeenCalledOnce();
+  });
+
+  it('closes wrapper PTYs and removes operation ownership on explicit close', async () => {
+    const fixture = createFixture();
+    await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+
+    await expect(fixture.lifecycle.closeTerminal({ ptyId: 'pty_1' })).resolves.toEqual({
+      success: true,
+      data: { success: true },
+    });
+    expect(fixture.closeTerminalBridge).toHaveBeenCalledWith('pty_1', 1000, 'PTY session ended');
+    expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'ended' });
+    expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(false);
+    expect(fixture.control.request).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        operation: 'session.terminal.close',
+        payload: { ptyId: 'pty_1' },
+      })
+    );
+  });
+
+  it('still closes local terminal capabilities when wrapper PTY deletion fails', async () => {
+    const fixture = createFixture();
+    await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+    fixture.control.request.mockRejectedValueOnce(new Error('wrapper unavailable'));
+
+    await expect(fixture.lifecycle.closeTerminal({ ptyId: 'pty_1' })).resolves.toEqual({
+      success: true,
+      data: { success: true },
+    });
+    expect(fixture.closeTerminalBridge).toHaveBeenCalledWith('pty_1', 1000, 'PTY session ended');
+    expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'ended' });
+    expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(false);
+  });
+
+  it('invalidates only confirmed terminals belonging to the requested runtime', async () => {
+    const fixture = createFixture();
+    await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+    fixture.setWrapperInstanceId(REPLACEMENT_INSTANCE_ID);
+    fixture.setPtyId('pty_2');
+    expect(fixture.attachCurrentRuntime()).toBe(true);
+    await fixture.lifecycle.createTerminal({ operationId: SECOND_OPERATION_ID });
+
+    fixture.lifecycle.invalidateRuntime({
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+      confirmed: false,
+    });
+    expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'running' });
+    expect(fixture.closeRuntimeBridges).toHaveBeenLastCalledWith(
+      WRAPPER_INSTANCE_ID,
+      1011,
+      'Terminal unavailable'
+    );
+
+    fixture.lifecycle.invalidateRuntime({
+      sandboxId: SANDBOX_ID,
+      wrapperInstanceId: WRAPPER_INSTANCE_ID,
+      confirmed: true,
+    });
+    expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'ended' });
+    expect(fixture.values.get('terminal:pty_2')).toMatchObject({ state: 'running' });
+    expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(false);
+    expect(fixture.values.has(`terminal_operation:${SECOND_OPERATION_ID}`)).toBe(true);
+    expect(fixture.closeRuntimeBridges).toHaveBeenLastCalledWith(
+      WRAPPER_INSTANCE_ID,
+      1000,
+      'PTY session ended'
+    );
+  });
+
+  it('compensates PTY creation that completes after a durable deletion fence', async () => {
+    const fixture = createFixture();
+    let finishCreation: (frame: ResponseFrame) => void = () => undefined;
+    let notifyCreationStarted: () => void = () => undefined;
+    const creationStarted = new Promise<void>(resolve => {
+      notifyCreationStarted = resolve;
+    });
+    const delayedCreation = new Promise<ResponseFrame>(resolve => {
+      finishCreation = resolve;
+    });
+    fixture.control.request.mockImplementationOnce(async () => {
+      notifyCreationStarted();
+      return delayedCreation;
+    });
+
+    const pending = fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+    await creationStarted;
+    const records = fixture.lifecycle.beginDeletion(fixture.metadata);
+    expect(records).toEqual([]);
+    expect(fixture.values.get(SANDBOX_SESSION_LIFECYCLE_KEY)).toMatchObject({
+      state: 'deleted',
+      sandboxId: SANDBOX_ID,
+    });
+    expect(fixture.closeAllBridges).toHaveBeenCalledWith(1000, 'session access revoked');
+
+    finishCreation(
+      response({
+        pty: {
+          id: 'pty_1',
+          title: 'Terminal',
+          command: '/bin/sh',
+          args: [],
+          cwd: DIRECTORY,
+          status: 'running',
+          pid: 1234,
+        },
+      })
+    );
+    await expect(pending).resolves.toEqual({ success: false, error: 'Session not found' });
+    expect(fixture.control.request).toHaveBeenLastCalledWith(
+      expect.objectContaining({ operation: 'session.terminal.close' })
+    );
+    expect(fixture.values.has('terminal:pty_1')).toBe(false);
+    expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(false);
+
+    await fixture.lifecycle.cleanupSession(fixture.metadata, records);
+    expect(fixture.control.detachSession).toHaveBeenCalledWith(SESSION_ID);
+    fixture.lifecycle.purgeDeletedState();
+    expect([...fixture.values.keys()]).toEqual([SANDBOX_SESSION_LIFECYCLE_KEY]);
+    expect(fixture.lifecycle.captureEpoch()).toBeNull();
+  });
+
+  it('detaches the durable session route even when wrapper detachment fails', async () => {
+    const fixture = createFixture({ organizationId: 'org_1' });
+    await fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID });
+    const records = fixture.lifecycle.beginRevocation(fixture.metadata);
+    fixture.control.request.mockRejectedValue(new Error('wrapper unavailable'));
+
+    await fixture.lifecycle.cleanupSession(fixture.metadata, records);
+
+    expect(fixture.control.detachSession).toHaveBeenCalledWith(SESSION_ID);
+    expect(fixture.values.get('terminal:pty_1')).toMatchObject({ state: 'ended' });
+    expect(fixture.values.has(`terminal_operation:${FIRST_OPERATION_ID}`)).toBe(false);
+    await expect(
+      fixture.lifecycle.createTerminal({ operationId: SECOND_OPERATION_ID })
+    ).resolves.toEqual({
+      success: false,
+      error: 'Terminal access denied: session access revoked',
+    });
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.ts
@@ -323,7 +323,7 @@ export function createSandboxTerminalLifecycle(deps: TerminalLifecycleDeps) {
     control: TerminalControl,
     session: SessionRequestIdentity,
     ptyId: string
-  ): Promise<void> {
+  ): Promise<boolean> {
     const payload = sessionTerminalClosePayloadSchema.parse({ ptyId });
     try {
       const response = await control.request({
@@ -331,9 +331,11 @@ export function createSandboxTerminalLifecycle(deps: TerminalLifecycleDeps) {
         session,
         payload,
       });
-      if (response.ok) sessionTerminalCloseResultSchema.safeParse(response.result);
+      if (!response.ok) return false;
+      const result = sessionTerminalCloseResultSchema.safeParse(response.result);
+      return result.success && result.data.success;
     } catch {
-      return;
+      return false;
     }
   }
 
@@ -600,12 +602,12 @@ export function createSandboxTerminalLifecycle(deps: TerminalLifecycleDeps) {
     }
     const { context, record } = ownership.data;
     if (!isCurrent(context.epoch)) return unavailableSession();
+    const closed = await closeWrapperTerminal(context.control, context.session, record.ptyId);
+    if (!isCurrent(context.epoch)) return unavailableSession();
+    if (!closed) return terminalError('Terminal closure failed; please retry');
     markEnded(record);
     deps.closeTerminalBridge(record.ptyId, 1000, 'PTY session ended');
-    await closeWrapperTerminal(context.control, context.session, record.ptyId);
-    return isCurrent(context.epoch)
-      ? { success: true, data: { success: true } }
-      : unavailableSession();
+    return { success: true, data: { success: true } };
   }
 
   async function requestConnect(

--- a/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.ts
@@ -1,0 +1,849 @@
+import { z } from 'zod';
+import type { WrapperPty } from '../kilo/wrapper-client.js';
+import {
+  parseSessionMetadata,
+  requiresContainmentSandbox,
+  type SessionMetadata,
+} from '../persistence/session-metadata.js';
+import type { OperationResult } from '../persistence/types.js';
+import {
+  sessionTerminalClosePayloadSchema,
+  sessionTerminalCloseResultSchema,
+  sessionTerminalConnectPayloadSchema,
+  sessionTerminalConnectResultSchema,
+  sessionTerminalCreatePayloadSchema,
+  sessionTerminalCreateResultSchema,
+  sessionTerminalResizePayloadSchema,
+  sessionTerminalResizeResultSchema,
+  terminalPtyIdSchema,
+  wrapperInstanceIdSchema,
+  type ResponseFrame,
+  type SessionRequestIdentity,
+  type SessionTerminalConnectPayload,
+  type SessionTerminalCreatePayload,
+} from '../shared/sandbox-control-protocol.js';
+import { isTerminalSessionPlatform } from '../terminal/access.js';
+import type { sandboxControlRpc } from './control-rpc.js';
+import type { SandboxTerminalRecord } from './terminal-bridge.js';
+
+export const SANDBOX_SESSION_METADATA_KEY = 'session_metadata';
+export const SANDBOX_SESSION_LIFECYCLE_KEY = 'session_lifecycle_fence';
+
+const ATTACHED_SESSION_KEY = 'terminal_attached_session';
+const TERMINAL_PREFIX = 'terminal:';
+const TERMINAL_OPERATION_PREFIX = 'terminal_operation:';
+const TERMINAL_UNAVAILABLE = 'Terminal unavailable until the workspace is prepared';
+const TERMINAL_ACCESS_DENIED = 'Terminal access denied:';
+
+const terminalRecordSchema = z
+  .object({
+    ptyId: terminalPtyIdSchema,
+    ownerId: z.string().min(1),
+    sessionId: z.string().min(1),
+    kiloSessionId: z.string().min(1),
+    directory: z.string().min(1),
+    sandboxId: z.string().min(1),
+    wrapperInstanceId: wrapperInstanceIdSchema,
+    organizationId: z.string().min(1).optional(),
+    state: z.enum(['running', 'ended']),
+  })
+  .strict();
+
+const attachedSessionSchema = terminalRecordSchema.omit({ ptyId: true, state: true }).strict();
+
+const lifecycleFenceSchema = z
+  .object({
+    epoch: z.number().int().nonnegative(),
+    state: z.enum(['revoked', 'deleted']),
+    sandboxId: z.string().min(1).optional(),
+  })
+  .strict();
+
+const completedCreationSchema = z
+  .object({
+    operationId: z.string().uuid(),
+    record: terminalRecordSchema,
+    result: sessionTerminalCreateResultSchema,
+    cols: z.number().int().min(2).max(500).optional(),
+    rows: z.number().int().min(2).max(200).optional(),
+  })
+  .strict();
+
+type TerminalControl = ReturnType<typeof sandboxControlRpc>;
+type LifecycleFence = z.infer<typeof lifecycleFenceSchema>;
+type AttachedSession = z.infer<typeof attachedSessionSchema>;
+type CompletedCreation = z.infer<typeof completedCreationSchema>;
+type TerminalCreationInput = {
+  cols?: number;
+  rows?: number;
+  operationId?: string;
+};
+type TerminalResizeInput = {
+  ptyId?: string;
+  cols?: number;
+  rows?: number;
+};
+type LifecycleSnapshot = {
+  epoch: number;
+  metadata: SessionMetadata;
+};
+type ReadyTerminalContext = LifecycleSnapshot & {
+  control: TerminalControl;
+  session: SessionRequestIdentity;
+  sandboxId: string;
+  wrapperInstanceId: string;
+};
+type TerminalLifecycleDeps = {
+  state: Pick<DurableObjectState, 'storage'>;
+  getSessionId(): string;
+  getControl(sandboxId: string): TerminalControl;
+  getDirectory(metadata: SessionMetadata): string;
+  closeTerminalBridge(ptyId: string, code?: number, reason?: string): void;
+  closeAllBridges(code?: number, reason?: string): void;
+  closeRuntimeBridges(wrapperInstanceId: string, code?: number, reason?: string): void;
+};
+type InFlightCreation = {
+  fingerprint: string;
+  promise: Promise<OperationResult<{ pty: WrapperPty }>>;
+};
+
+function terminalError<T>(error: string): OperationResult<T> {
+  return { success: false, error };
+}
+
+function denied<T>(reason: string): OperationResult<T> {
+  return terminalError(`${TERMINAL_ACCESS_DENIED} ${reason}`);
+}
+
+function sameTerminalIdentity(left: SandboxTerminalRecord, right: SandboxTerminalRecord): boolean {
+  return (
+    left.ptyId === right.ptyId &&
+    left.ownerId === right.ownerId &&
+    left.sessionId === right.sessionId &&
+    left.kiloSessionId === right.kiloSessionId &&
+    left.directory === right.directory &&
+    left.sandboxId === right.sandboxId &&
+    left.wrapperInstanceId === right.wrapperInstanceId &&
+    left.organizationId === right.organizationId
+  );
+}
+
+function sameAttachment(
+  record: Omit<SandboxTerminalRecord, 'ptyId' | 'state'>,
+  attachment: AttachedSession
+): boolean {
+  return (
+    record.ownerId === attachment.ownerId &&
+    record.sessionId === attachment.sessionId &&
+    record.kiloSessionId === attachment.kiloSessionId &&
+    record.directory === attachment.directory &&
+    record.sandboxId === attachment.sandboxId &&
+    record.wrapperInstanceId === attachment.wrapperInstanceId &&
+    record.organizationId === attachment.organizationId
+  );
+}
+
+export function createSandboxTerminalLifecycle(deps: TerminalLifecycleDeps) {
+  const storage = deps.state.storage;
+  const inFlightCreations = new Map<string, InFlightCreation>();
+
+  function readFence(): LifecycleFence | undefined {
+    const value = storage.kv.get<unknown>(SANDBOX_SESSION_LIFECYCLE_KEY);
+    if (value === undefined) return undefined;
+    const parsed = lifecycleFenceSchema.safeParse(value);
+    return parsed.success ? parsed.data : { epoch: Number.MAX_SAFE_INTEGER, state: 'deleted' };
+  }
+
+  function getStoredMetadata(): SessionMetadata | null {
+    const raw = storage.kv.get<unknown>(SANDBOX_SESSION_METADATA_KEY);
+    if (raw === undefined) return null;
+    try {
+      return parseSessionMetadata(raw);
+    } catch {
+      return null;
+    }
+  }
+
+  function snapshot(): LifecycleSnapshot | null {
+    if (readFence() !== undefined) return null;
+    const metadata = getStoredMetadata();
+    return metadata?.identity.sessionId === deps.getSessionId() ? { epoch: 0, metadata } : null;
+  }
+
+  function isCurrent(epoch: number): boolean {
+    return epoch === 0 && snapshot() !== null;
+  }
+
+  function unavailableSession<T>(): OperationResult<T> {
+    const fence = readFence();
+    return fence?.state === 'revoked'
+      ? denied('session access revoked')
+      : terminalError('Session not found');
+  }
+
+  function readAttachedSession(): AttachedSession | null {
+    const raw = storage.kv.get<unknown>(ATTACHED_SESSION_KEY);
+    if (raw === undefined) return null;
+    const parsed = attachedSessionSchema.safeParse(raw);
+    return parsed.success ? parsed.data : null;
+  }
+
+  function readTerminal(ptyId: string): SandboxTerminalRecord | null {
+    if (!terminalPtyIdSchema.safeParse(ptyId).success) return null;
+    const raw = storage.kv.get<unknown>(`${TERMINAL_PREFIX}${ptyId}`);
+    if (raw === undefined) return null;
+    const parsed = terminalRecordSchema.safeParse(raw);
+    return parsed.success && parsed.data.ptyId === ptyId ? parsed.data : null;
+  }
+
+  function matchesMetadata(record: SandboxTerminalRecord, metadata: SessionMetadata): boolean {
+    return (
+      record.ownerId === metadata.identity.userId &&
+      record.sessionId === metadata.identity.sessionId &&
+      record.kiloSessionId === metadata.auth.kiloSessionId &&
+      record.directory === deps.getDirectory(metadata) &&
+      record.sandboxId === metadata.workspace?.sandboxId &&
+      record.organizationId === metadata.identity.orgId
+    );
+  }
+
+  function clearCompletedCreations(ptyId: string): void {
+    for (const [key, raw] of storage.kv.list<unknown>({ prefix: TERMINAL_OPERATION_PREFIX })) {
+      const operation = completedCreationSchema.safeParse(raw);
+      if (!operation.success || operation.data.record.ptyId === ptyId) {
+        storage.kv.delete(key);
+      }
+    }
+  }
+
+  function markEnded(record: SandboxTerminalRecord): void {
+    const current = readTerminal(record.ptyId);
+    if (!current || !sameTerminalIdentity(current, record)) return;
+    storage.transactionSync(() => {
+      storage.kv.put(`${TERMINAL_PREFIX}${current.ptyId}`, { ...current, state: 'ended' });
+      clearCompletedCreations(current.ptyId);
+    });
+  }
+
+  function makeAttachment(context: ReadyTerminalContext): AttachedSession {
+    return {
+      ownerId: context.metadata.identity.userId,
+      sessionId: context.session.sessionId,
+      kiloSessionId: context.session.kiloSessionId,
+      directory: context.session.directory,
+      sandboxId: context.sandboxId,
+      wrapperInstanceId: context.wrapperInstanceId,
+      ...(context.metadata.identity.orgId
+        ? { organizationId: context.metadata.identity.orgId }
+        : {}),
+    };
+  }
+
+  function accessIdentity(context: ReadyTerminalContext) {
+    return {
+      sessionId: context.session.sessionId,
+      ownerId: context.metadata.identity.userId,
+      wrapperInstanceId: context.wrapperInstanceId,
+      ...(context.metadata.identity.orgId
+        ? { organizationId: context.metadata.identity.orgId }
+        : {}),
+      ...(context.metadata.identity.botId ? { botId: context.metadata.identity.botId } : {}),
+    };
+  }
+
+  async function readyContext(
+    current: LifecycleSnapshot,
+    options: { validateAccess: boolean }
+  ): Promise<OperationResult<{ context: ReadyTerminalContext }>> {
+    const metadata = current.metadata;
+    const sandboxId = metadata.workspace?.sandboxId;
+    const kiloSessionId = metadata.auth.kiloSessionId;
+    if (!sandboxId || !kiloSessionId) return terminalError(TERMINAL_UNAVAILABLE);
+
+    const control = deps.getControl(sandboxId);
+    let status: Awaited<ReturnType<TerminalControl['getStatus']>>;
+    try {
+      status = await control.getStatus();
+    } catch {
+      return isCurrent(current.epoch) ? terminalError(TERMINAL_UNAVAILABLE) : unavailableSession();
+    }
+    if (!isCurrent(current.epoch)) return unavailableSession();
+    if (status.physical !== 'running' || status.connection !== 'ready') {
+      return terminalError(TERMINAL_UNAVAILABLE);
+    }
+    const wrapperInstance = wrapperInstanceIdSchema.safeParse(status.wrapperInstanceId);
+    if (!wrapperInstance.success) {
+      return denied('the running wrapper does not support terminals');
+    }
+
+    const context: ReadyTerminalContext = {
+      ...current,
+      control,
+      sandboxId,
+      wrapperInstanceId: wrapperInstance.data,
+      session: {
+        sessionId: metadata.identity.sessionId,
+        kiloSessionId,
+        directory: deps.getDirectory(metadata),
+      },
+    };
+    const attached = readAttachedSession();
+    if (!attached || !sameAttachment(makeAttachment(context), attached)) {
+      return terminalError(TERMINAL_UNAVAILABLE);
+    }
+    if (!options.validateAccess) return { success: true, data: { context } };
+
+    let access: Awaited<ReturnType<TerminalControl['validateTerminalAccess']>>;
+    try {
+      access = await control.validateTerminalAccess(accessIdentity(context));
+    } catch {
+      return denied('runtime access or billing could not be verified');
+    }
+    if (!isCurrent(current.epoch)) return unavailableSession();
+    if (!access.allowed) {
+      if (
+        access.reason === 'session_not_attached' ||
+        access.reason === 'runtime_not_running' ||
+        access.reason === 'runtime_not_ready' ||
+        access.reason === 'runtime_changed' ||
+        access.reason === 'wrapper_instance_mismatch'
+      ) {
+        return terminalError(TERMINAL_UNAVAILABLE);
+      }
+      return denied(access.reason ?? 'runtime access or billing could not be verified');
+    }
+    const latestAttachment = readAttachedSession();
+    if (!latestAttachment || !sameAttachment(makeAttachment(context), latestAttachment)) {
+      return terminalError(TERMINAL_UNAVAILABLE);
+    }
+    return { success: true, data: { context } };
+  }
+
+  async function closeWrapperTerminal(
+    control: TerminalControl,
+    session: SessionRequestIdentity,
+    ptyId: string
+  ): Promise<void> {
+    const payload = sessionTerminalClosePayloadSchema.parse({ ptyId });
+    try {
+      const response = await control.request({
+        operation: 'session.terminal.close',
+        session,
+        payload,
+      });
+      if (response.ok) sessionTerminalCloseResultSchema.safeParse(response.result);
+    } catch {
+      return;
+    }
+  }
+
+  function completedCreation(
+    operationId: string,
+    context: ReadyTerminalContext,
+    payload: SessionTerminalCreatePayload
+  ): OperationResult<{ pty: WrapperPty }> | undefined {
+    const raw = storage.kv.get<unknown>(`${TERMINAL_OPERATION_PREFIX}${operationId}`);
+    if (raw === undefined) return undefined;
+    const parsed = completedCreationSchema.safeParse(raw);
+    if (!parsed.success || parsed.data.operationId !== operationId) {
+      return denied('terminal creation operation is invalid');
+    }
+    const completion = parsed.data;
+    const expected: SandboxTerminalRecord = {
+      ...makeAttachment(context),
+      ptyId: completion.result.pty.id,
+      state: 'running',
+    };
+    const stored = readTerminal(completion.result.pty.id);
+    if (
+      !sameTerminalIdentity(completion.record, expected) ||
+      completion.cols !== payload.cols ||
+      completion.rows !== payload.rows ||
+      !stored ||
+      stored.state !== 'running' ||
+      !sameTerminalIdentity(stored, expected)
+    ) {
+      return denied('terminal creation operation conflicts with its existing identity');
+    }
+    return { success: true, data: completion.result };
+  }
+
+  function creationFingerprint(
+    context: ReadyTerminalContext,
+    payload: SessionTerminalCreatePayload
+  ): string {
+    return JSON.stringify([
+      context.metadata.identity.userId,
+      context.session.sessionId,
+      context.session.kiloSessionId,
+      context.session.directory,
+      context.sandboxId,
+      context.wrapperInstanceId,
+      context.metadata.identity.orgId ?? null,
+      payload.cols ?? null,
+      payload.rows ?? null,
+    ]);
+  }
+
+  async function performCreation(
+    context: ReadyTerminalContext,
+    payload: SessionTerminalCreatePayload
+  ): Promise<OperationResult<{ pty: WrapperPty }>> {
+    if (!isCurrent(context.epoch)) return unavailableSession();
+    let response: ResponseFrame;
+    try {
+      response = await context.control.request({
+        operation: 'session.terminal.create',
+        session: context.session,
+        payload,
+      });
+    } catch {
+      return isCurrent(context.epoch) ? terminalError(TERMINAL_UNAVAILABLE) : unavailableSession();
+    }
+
+    if (!response.ok) {
+      return terminalError(response.error?.message ?? TERMINAL_UNAVAILABLE);
+    }
+    const result = sessionTerminalCreateResultSchema.safeParse(response.result);
+    if (!result.success) return terminalError('Terminal is unavailable');
+    const pty = result.data.pty;
+    if (
+      !isCurrent(context.epoch) ||
+      pty.cwd !== context.session.directory ||
+      pty.status !== 'running'
+    ) {
+      await closeWrapperTerminal(context.control, context.session, pty.id);
+      return isCurrent(context.epoch)
+        ? denied('the wrapper returned an invalid terminal workspace')
+        : unavailableSession();
+    }
+
+    let status: Awaited<ReturnType<TerminalControl['getStatus']>>;
+    try {
+      status = await context.control.getStatus();
+    } catch {
+      await closeWrapperTerminal(context.control, context.session, pty.id);
+      return terminalError(TERMINAL_UNAVAILABLE);
+    }
+    if (
+      !isCurrent(context.epoch) ||
+      status.physical !== 'running' ||
+      status.connection !== 'ready' ||
+      status.wrapperInstanceId !== context.wrapperInstanceId
+    ) {
+      await closeWrapperTerminal(context.control, context.session, pty.id);
+      return isCurrent(context.epoch) ? terminalError(TERMINAL_UNAVAILABLE) : unavailableSession();
+    }
+
+    const record: SandboxTerminalRecord = {
+      ...makeAttachment(context),
+      ptyId: pty.id,
+      state: 'running',
+    };
+    const attached = readAttachedSession();
+    if (!attached || !sameAttachment(record, attached)) {
+      await closeWrapperTerminal(context.control, context.session, pty.id);
+      return terminalError(TERMINAL_UNAVAILABLE);
+    }
+    const existing = readTerminal(pty.id);
+    if (existing && !sameTerminalIdentity(existing, record)) {
+      await closeWrapperTerminal(context.control, context.session, pty.id);
+      return denied('the wrapper returned a terminal owned by another session');
+    }
+    const completion: CompletedCreation = {
+      operationId: payload.operationId,
+      record,
+      result: result.data,
+      ...(payload.cols === undefined ? {} : { cols: payload.cols }),
+      ...(payload.rows === undefined ? {} : { rows: payload.rows }),
+    };
+    storage.transactionSync(() => {
+      if (!isCurrent(context.epoch)) return;
+      storage.kv.put(`${TERMINAL_PREFIX}${pty.id}`, record);
+      storage.kv.put(`${TERMINAL_OPERATION_PREFIX}${payload.operationId}`, completion);
+    });
+    if (!isCurrent(context.epoch)) {
+      await closeWrapperTerminal(context.control, context.session, pty.id);
+      return unavailableSession();
+    }
+    return { success: true, data: result.data };
+  }
+
+  async function createTerminal(
+    input: TerminalCreationInput = {}
+  ): Promise<OperationResult<{ pty: WrapperPty }>> {
+    const parsed = sessionTerminalCreatePayloadSchema.safeParse({
+      operationId: input.operationId ?? crypto.randomUUID(),
+      ...(input.cols === undefined ? {} : { cols: input.cols }),
+      ...(input.rows === undefined ? {} : { rows: input.rows }),
+    });
+    if (!parsed.success) return denied('invalid terminal creation request');
+    const current = snapshot();
+    if (!current) return unavailableSession();
+    if (!isTerminalSessionPlatform(current.metadata.identity.createdOnPlatform)) {
+      return denied('terminals are only available for interactive Cloud Agent sessions');
+    }
+    if (requiresContainmentSandbox(current.metadata)) {
+      return denied('this session requires unsupported credential containment');
+    }
+
+    const ready = await readyContext(current, { validateAccess: true });
+    if (!ready.success || !ready.data) return terminalError(ready.error ?? TERMINAL_UNAVAILABLE);
+    const context = ready.data.context;
+    const completed = completedCreation(parsed.data.operationId, context, parsed.data);
+    if (completed) return completed;
+
+    const fingerprint = creationFingerprint(context, parsed.data);
+    const existing = inFlightCreations.get(parsed.data.operationId);
+    if (existing) {
+      return existing.fingerprint === fingerprint
+        ? existing.promise
+        : denied('terminal creation operation conflicts with its existing identity');
+    }
+
+    const promise = performCreation(context, parsed.data);
+    const inFlight = { fingerprint, promise };
+    inFlightCreations.set(parsed.data.operationId, inFlight);
+    try {
+      return await promise;
+    } finally {
+      if (inFlightCreations.get(parsed.data.operationId) === inFlight) {
+        inFlightCreations.delete(parsed.data.operationId);
+      }
+    }
+  }
+
+  async function getTerminal(ptyId: string): Promise<SandboxTerminalRecord | undefined> {
+    const current = snapshot();
+    if (!current) return undefined;
+    const record = readTerminal(ptyId);
+    if (!record || !matchesMetadata(record, current.metadata)) return undefined;
+    if (record.state === 'ended') return record;
+    const attached = readAttachedSession();
+    return attached && sameAttachment(record, attached) ? record : undefined;
+  }
+
+  async function ownedTerminalContext(
+    ptyId: string,
+    options: { validateAccess: boolean }
+  ): Promise<OperationResult<{ context: ReadyTerminalContext; record: SandboxTerminalRecord }>> {
+    const current = snapshot();
+    if (!current) return unavailableSession();
+    const record = readTerminal(ptyId);
+    if (!record || !matchesMetadata(record, current.metadata)) {
+      return denied('terminal does not belong to this session');
+    }
+    if (record.state !== 'running') return terminalError('PTY session ended');
+    const ready = await readyContext(current, options);
+    if (!ready.success || !ready.data) return terminalError(ready.error ?? TERMINAL_UNAVAILABLE);
+    const context = ready.data.context;
+    if (record.wrapperInstanceId !== context.wrapperInstanceId) {
+      return denied('terminal does not belong to the current runtime');
+    }
+    const latest = readTerminal(ptyId);
+    if (!latest || latest.state !== 'running' || !sameTerminalIdentity(latest, record)) {
+      return denied('terminal does not belong to the current runtime');
+    }
+    return { success: true, data: { context, record: latest } };
+  }
+
+  async function resizeTerminal(
+    input: TerminalResizeInput = {}
+  ): Promise<OperationResult<{ pty: WrapperPty }>> {
+    const parsed = sessionTerminalResizePayloadSchema.safeParse(input);
+    if (!parsed.success) return denied('invalid terminal resize request');
+    const ownership = await ownedTerminalContext(parsed.data.ptyId, { validateAccess: true });
+    if (!ownership.success || !ownership.data) {
+      return terminalError(ownership.error ?? TERMINAL_UNAVAILABLE);
+    }
+    const { context, record } = ownership.data;
+    if (!isCurrent(context.epoch)) return unavailableSession();
+    const current = readTerminal(record.ptyId);
+    if (!current || current.state !== 'running' || !sameTerminalIdentity(current, record)) {
+      return denied('terminal does not belong to the current runtime');
+    }
+    let response: ResponseFrame;
+    try {
+      response = await context.control.request({
+        operation: 'session.terminal.resize',
+        session: context.session,
+        payload: parsed.data,
+      });
+    } catch {
+      return terminalError(TERMINAL_UNAVAILABLE);
+    }
+    if (!isCurrent(context.epoch)) return unavailableSession();
+    const latest = readTerminal(record.ptyId);
+    if (!latest || latest.state !== 'running' || !sameTerminalIdentity(latest, record)) {
+      return denied('terminal does not belong to the current runtime');
+    }
+    if (!response.ok) return terminalError(response.error?.message ?? TERMINAL_UNAVAILABLE);
+    const result = sessionTerminalResizeResultSchema.safeParse(response.result);
+    if (
+      !result.success ||
+      result.data.pty.id !== record.ptyId ||
+      result.data.pty.cwd !== record.directory
+    ) {
+      return denied('the wrapper returned an invalid terminal identity');
+    }
+    return { success: true, data: result.data };
+  }
+
+  async function closeTerminal(
+    input: { ptyId?: string } = {}
+  ): Promise<OperationResult<{ success: boolean }>> {
+    const parsed = sessionTerminalClosePayloadSchema.safeParse(input);
+    if (!parsed.success) return denied('invalid terminal close request');
+    const ownership = await ownedTerminalContext(parsed.data.ptyId, { validateAccess: false });
+    if (!ownership.success || !ownership.data) {
+      return terminalError(ownership.error ?? TERMINAL_UNAVAILABLE);
+    }
+    const { context, record } = ownership.data;
+    if (!isCurrent(context.epoch)) return unavailableSession();
+    markEnded(record);
+    deps.closeTerminalBridge(record.ptyId, 1000, 'PTY session ended');
+    await closeWrapperTerminal(context.control, context.session, record.ptyId);
+    return isCurrent(context.epoch)
+      ? { success: true, data: { success: true } }
+      : unavailableSession();
+  }
+
+  async function requestConnect(
+    record: SandboxTerminalRecord,
+    input: SessionTerminalConnectPayload
+  ): Promise<ResponseFrame> {
+    const payload = sessionTerminalConnectPayloadSchema.parse(input);
+    if (payload.ptyId !== record.ptyId || payload.ownerId !== record.ownerId) {
+      throw new Error(`${TERMINAL_ACCESS_DENIED} terminal connection identity mismatch`);
+    }
+    const ownership = await ownedTerminalContext(record.ptyId, { validateAccess: true });
+    if (!ownership.success || !ownership.data) {
+      throw new Error(ownership.error ?? TERMINAL_UNAVAILABLE);
+    }
+    const { context, record: current } = ownership.data;
+    if (
+      !isCurrent(context.epoch) ||
+      current.state !== 'running' ||
+      !sameTerminalIdentity(current, record)
+    ) {
+      throw new Error(`${TERMINAL_ACCESS_DENIED} terminal runtime mismatch`);
+    }
+    const response = await context.control.request({
+      operation: 'session.terminal.connect',
+      session: context.session,
+      payload,
+    });
+    if (!isCurrent(context.epoch)) {
+      throw new Error(`${TERMINAL_ACCESS_DENIED} session access revoked`);
+    }
+    if (response.ok && !sessionTerminalConnectResultSchema.safeParse(response.result).success) {
+      throw new Error('Terminal connection response is invalid');
+    }
+    return response;
+  }
+
+  async function reportActivity(record: SandboxTerminalRecord): Promise<void> {
+    const current = snapshot();
+    if (!current || !matchesMetadata(record, current.metadata)) return;
+    const stored = readTerminal(record.ptyId);
+    if (!stored || stored.state !== 'running' || !sameTerminalIdentity(stored, record)) return;
+    const sandboxId = current.metadata.workspace?.sandboxId;
+    if (!sandboxId || sandboxId !== record.sandboxId) return;
+    try {
+      const result = await deps.getControl(sandboxId).recordTerminalActivity({
+        sessionId: record.sessionId,
+        ownerId: record.ownerId,
+        wrapperInstanceId: record.wrapperInstanceId,
+        ...(record.organizationId ? { organizationId: record.organizationId } : {}),
+        ...(current.metadata.identity.botId ? { botId: current.metadata.identity.botId } : {}),
+      });
+      const latest = readTerminal(record.ptyId);
+      if (
+        isCurrent(current.epoch) &&
+        latest?.state === 'running' &&
+        sameTerminalIdentity(latest, record) &&
+        !result.allowed
+      ) {
+        deps.closeTerminalBridge(record.ptyId, 1000, 'session access revoked');
+      }
+    } catch {
+      const latest = readTerminal(record.ptyId);
+      if (
+        isCurrent(current.epoch) &&
+        latest?.state === 'running' &&
+        sameTerminalIdentity(latest, record)
+      ) {
+        deps.closeTerminalBridge(record.ptyId, 1011, 'Terminal unavailable');
+      }
+    }
+  }
+
+  function recordAttachment(input: {
+    metadata: SessionMetadata;
+    sandboxId: string;
+    wrapperInstanceId?: string;
+    epoch: number;
+  }): boolean {
+    if (!isCurrent(input.epoch)) return false;
+    const wrapperInstance = wrapperInstanceIdSchema.safeParse(input.wrapperInstanceId);
+    if (!wrapperInstance.success || !input.metadata.auth.kiloSessionId) {
+      storage.kv.delete(ATTACHED_SESSION_KEY);
+      return false;
+    }
+    const attachment: AttachedSession = {
+      ownerId: input.metadata.identity.userId,
+      sessionId: input.metadata.identity.sessionId,
+      kiloSessionId: input.metadata.auth.kiloSessionId,
+      directory: deps.getDirectory(input.metadata),
+      sandboxId: input.sandboxId,
+      wrapperInstanceId: wrapperInstance.data,
+      ...(input.metadata.identity.orgId ? { organizationId: input.metadata.identity.orgId } : {}),
+    };
+    storage.kv.put(ATTACHED_SESSION_KEY, attachment);
+    return true;
+  }
+
+  function endTerminals(predicate: (record: SandboxTerminalRecord) => boolean) {
+    const records: SandboxTerminalRecord[] = [];
+    for (const [, raw] of storage.kv.list<unknown>({ prefix: TERMINAL_PREFIX })) {
+      const parsed = terminalRecordSchema.safeParse(raw);
+      if (!parsed.success || parsed.data.state !== 'running' || !predicate(parsed.data)) continue;
+      records.push(parsed.data);
+    }
+    for (const record of records) markEnded(record);
+    return records;
+  }
+
+  function beginFence(state: LifecycleFence['state'], metadata: SessionMetadata | null) {
+    const previous = readFence();
+    if (previous?.state === 'deleted') return previous;
+    const fence: LifecycleFence = {
+      epoch: (previous?.epoch ?? 0) + 1,
+      state,
+      ...(metadata?.workspace?.sandboxId
+        ? { sandboxId: metadata.workspace.sandboxId }
+        : previous?.sandboxId
+          ? { sandboxId: previous.sandboxId }
+          : {}),
+    };
+    storage.kv.put(SANDBOX_SESSION_LIFECYCLE_KEY, fence);
+    return fence;
+  }
+
+  function beginRevocation(metadata: SessionMetadata): SandboxTerminalRecord[] {
+    beginFence('revoked', metadata);
+    deps.closeAllBridges(1000, 'session access revoked');
+    const records = endTerminals(() => true);
+    storage.kv.delete(ATTACHED_SESSION_KEY);
+    return records;
+  }
+
+  function beginDeletion(metadata: SessionMetadata | null): SandboxTerminalRecord[] {
+    beginFence('deleted', metadata);
+    deps.closeAllBridges(1000, 'session access revoked');
+    const records = endTerminals(() => true);
+    storage.kv.delete(ATTACHED_SESSION_KEY);
+    return records;
+  }
+
+  async function cleanupSession(
+    metadata: SessionMetadata | null,
+    records: readonly SandboxTerminalRecord[]
+  ): Promise<void> {
+    const sandboxId = metadata?.workspace?.sandboxId ?? readFence()?.sandboxId;
+    const sessionId = metadata?.identity.sessionId ?? records[0]?.sessionId ?? deps.getSessionId();
+    if (!sandboxId || !sessionId) return;
+    const control = deps.getControl(sandboxId);
+    try {
+      for (const record of records) {
+        await closeWrapperTerminal(
+          control,
+          {
+            sessionId: record.sessionId,
+            kiloSessionId: record.kiloSessionId,
+            directory: record.directory,
+          },
+          record.ptyId
+        );
+      }
+      if (metadata?.auth.kiloSessionId) {
+        try {
+          await control.request({
+            operation: 'session.detach',
+            session: {
+              sessionId,
+              kiloSessionId: metadata.auth.kiloSessionId,
+              directory: deps.getDirectory(metadata),
+            },
+            payload: {},
+          });
+        } catch {
+          return;
+        }
+      }
+    } finally {
+      await control.detachSession(sessionId);
+    }
+  }
+
+  function invalidateRuntime(input: {
+    sandboxId: string;
+    wrapperInstanceId: string;
+    confirmed: boolean;
+  }): void {
+    const metadata = getStoredMetadata();
+    if (
+      !metadata ||
+      metadata.workspace?.sandboxId !== input.sandboxId ||
+      !wrapperInstanceIdSchema.safeParse(input.wrapperInstanceId).success
+    ) {
+      return;
+    }
+    deps.closeRuntimeBridges(
+      input.wrapperInstanceId,
+      input.confirmed ? 1000 : 1011,
+      input.confirmed ? 'PTY session ended' : 'Terminal unavailable'
+    );
+    if (!input.confirmed) return;
+    endTerminals(
+      record =>
+        record.sandboxId === input.sandboxId && record.wrapperInstanceId === input.wrapperInstanceId
+    );
+    const attached = readAttachedSession();
+    if (
+      attached?.sandboxId === input.sandboxId &&
+      attached.wrapperInstanceId === input.wrapperInstanceId
+    ) {
+      storage.kv.delete(ATTACHED_SESSION_KEY);
+    }
+  }
+
+  function purgeDeletedState(): void {
+    if (readFence()?.state !== 'deleted') return;
+    const keys = Array.from(storage.kv.list<unknown>(), ([key]) => key);
+    for (const key of keys) {
+      if (key !== SANDBOX_SESSION_LIFECYCLE_KEY) storage.kv.delete(key);
+    }
+  }
+
+  return {
+    beginDeletion,
+    beginRevocation,
+    captureEpoch: () => snapshot()?.epoch ?? null,
+    cleanupSession,
+    closeTerminal,
+    createTerminal,
+    getStoredMetadata,
+    getTerminal,
+    invalidateRuntime,
+    isBlocked: () => readFence() !== undefined,
+    isCurrent,
+    isDeleted: () => readFence()?.state === 'deleted',
+    markEnded: async (record: SandboxTerminalRecord) => markEnded(record),
+    purgeDeletedState,
+    recordAttachment,
+    reportActivity,
+    requestConnect,
+    resizeTerminal,
+  };
+}

--- a/services/cloud-agent-next/src/server-stream-ticket.test.ts
+++ b/services/cloud-agent-next/src/server-stream-ticket.test.ts
@@ -268,9 +268,9 @@ function signTerminalTicket(overrides: Record<string, unknown> = {}): string {
   );
 }
 
-function terminalRequest(ticket: string): Request {
+function terminalRequest(ticket: string, sessionId = 'session-1'): Request {
   return new Request(
-    `http://worker.test/terminal?cloudAgentSessionId=session-1&ptyId=pty-1&ticket=${encodeURIComponent(ticket)}`,
+    `http://worker.test/terminal?cloudAgentSessionId=${encodeURIComponent(sessionId)}&ptyId=pty-1&ticket=${encodeURIComponent(ticket)}`,
     { headers: { Upgrade: 'websocket' } }
   );
 }
@@ -418,6 +418,58 @@ describe('server /terminal ticket nonce consume', () => {
     expect(replay.status).toBe(401);
     await expect(replay.text()).resolves.toBe('Ticket nonce already used');
     expect(connectTerminal).toHaveBeenCalledTimes(1);
+  });
+
+  it('consumes a control-plane terminal nonce exactly once before forwarding the browser upgrade', async () => {
+    const sessionId = 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const env = createEnv();
+    const consumedNonces = installNonceStore(env);
+    const sessionFetch = vi.fn().mockResolvedValue(new Response('bridged', { status: 200 }));
+    env.SANDBOX_SESSION.idFromName.mockReturnValue('sandbox-session-do-id');
+    env.SANDBOX_SESSION.get.mockReturnValue({ fetch: sessionFetch });
+    const ticket = signTerminalTicket({ cloudAgentSessionId: sessionId });
+
+    const first = await fetchWorker(terminalRequest(ticket, sessionId), env);
+
+    expect(first.status).toBe(200);
+    expect(consumedNonces).toEqual(new Set(['nonce-1']));
+    expect(env.SANDBOX_SESSION.idFromName).toHaveBeenCalledWith(`user-1:${sessionId}`);
+    expect(sessionFetch).toHaveBeenCalledOnce();
+    const forwarded = sessionFetch.mock.calls[0]?.[0] as Request;
+    expect(new URL(forwarded.url).search).toBe('?ptyId=pty-1');
+
+    const replay = await fetchWorker(terminalRequest(ticket, sessionId), env);
+
+    expect(replay.status).toBe(401);
+    await expect(replay.text()).resolves.toBe('Ticket nonce already used');
+    expect(consumedNonces).toEqual(new Set(['nonce-1']));
+    expect(sessionFetch).toHaveBeenCalledOnce();
+  });
+
+  it('does not consume a control-plane terminal nonce when current session access is denied', async () => {
+    const sessionId = 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const env = createEnv();
+    const consumedNonces = installNonceStore(env);
+    const sessionFetch = vi.fn().mockResolvedValue(new Response('bridged', { status: 200 }));
+    env.SANDBOX_SESSION.idFromName.mockReturnValue('sandbox-session-do-id');
+    env.SANDBOX_SESSION.get.mockReturnValue({ fetch: sessionFetch });
+    requireCurrentSessionAccessMock.mockRejectedValueOnce(
+      Object.assign(new Error('Session access denied'), { code: 'FORBIDDEN' })
+    );
+    const ticket = signTerminalTicket({ cloudAgentSessionId: sessionId });
+
+    const denied = await fetchWorker(terminalRequest(ticket, sessionId), env);
+
+    expect(denied.status).toBe(403);
+    expect(consumedNonces.size).toBe(0);
+    expect(env.STREAM_TICKET_NONCE_DO.idFromName).not.toHaveBeenCalled();
+    expect(sessionFetch).not.toHaveBeenCalled();
+
+    const authorized = await fetchWorker(terminalRequest(ticket, sessionId), env);
+
+    expect(authorized.status).toBe(200);
+    expect(consumedNonces).toEqual(new Set(['nonce-1']));
+    expect(sessionFetch).toHaveBeenCalledOnce();
   });
 });
 

--- a/services/cloud-agent-next/src/server.test.ts
+++ b/services/cloud-agent-next/src/server.test.ts
@@ -212,6 +212,32 @@ function signWrapperDispatchTicket(overrides: Partial<WrapperDispatchTicketClaim
   );
 }
 
+function signTerminalTicket(
+  cloudAgentSessionId: string,
+  overrides: Record<string, unknown> = {}
+): string {
+  return jwt.sign(
+    {
+      type: 'stream_ticket',
+      purpose: 'terminal',
+      userId: 'user-1',
+      cloudAgentSessionId,
+      ptyId: 'pty_123',
+      nonce: 'nonce-1',
+      ...overrides,
+    },
+    secret,
+    { algorithm: 'HS256', expiresIn: 60, audience: 'cloud-agent-terminal' }
+  );
+}
+
+function installTerminalNonceConsumer(env: MockEnv) {
+  const consume = vi.fn().mockResolvedValue(true);
+  env.STREAM_TICKET_NONCE_DO.idFromName.mockReturnValue('nonce-do-id');
+  env.STREAM_TICKET_NONCE_DO.get.mockReturnValue({ consume });
+  return consume;
+}
+
 beforeEach(() => {
   getRunningTerminalClientMock.mockReset();
   consumeCloudAgentReportBatchMock.mockClear();
@@ -326,7 +352,7 @@ describe('server background reporting', () => {
 });
 
 describe('server /terminal', () => {
-  it('rejects control-plane sessions before consuming the ticket nonce', async () => {
+  it('validates control-plane terminal tickets before selecting the session Durable Object', async () => {
     const sessionId = 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
     const env = createEnv();
     const request = new Request(
@@ -336,12 +362,125 @@ describe('server /terminal', () => {
 
     const response = await fetchWorker(request, env);
 
-    expect(response.status).toBe(412);
-    await expect(response.text()).resolves.toBe('Terminal is not available for this session');
+    expect(response.status).toBe(401);
+    await expect(response.text()).resolves.toBe('Invalid ticket signature');
+    expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
     expect(env.STREAM_TICKET_NONCE_DO.idFromName).not.toHaveBeenCalled();
     expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
     expect(env.SANDBOX_SESSION.idFromName).not.toHaveBeenCalled();
   });
+
+  it('forwards authorized control-plane browser upgrades without tickets or browser credentials', async () => {
+    const sessionId = 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const ticket = signTerminalTicket(sessionId, {
+      organizationId: 'org-1',
+      kiloSessionId: 'ses_12345678901234567890123456',
+    });
+    const env = createEnv();
+    env.WS_ALLOWED_ORIGINS = 'https://app.example.com';
+    const consume = installTerminalNonceConsumer(env);
+    const sessionResponse = new Response('bridged', { status: 200 });
+    const sessionFetch = vi.fn().mockResolvedValue(sessionResponse);
+    env.SANDBOX_SESSION.idFromName.mockReturnValue('sandbox-session-do-id');
+    env.SANDBOX_SESSION.get.mockReturnValue({ fetch: sessionFetch });
+    const request = new Request(
+      `http://worker.test/terminal?cloudAgentSessionId=${sessionId}&ptyId=pty_123&ticket=${encodeURIComponent(ticket)}&role=wrapper&ownerId=attacker`,
+      {
+        headers: {
+          Upgrade: 'websocket',
+          Connection: 'Upgrade',
+          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Version': '13',
+          'Sec-WebSocket-Protocol': 'private-browser-protocol',
+          'Sec-WebSocket-Extensions': 'permessage-deflate',
+          Origin: 'https://app.example.com',
+          Authorization: 'Bearer browser-secret',
+          Cookie: 'session=browser-secret',
+          'X-Terminal-Role': 'wrapper',
+          'X-Internal-Role': 'wrapper',
+          'X-Forwarded-User': 'attacker',
+        },
+      }
+    );
+
+    const response = await fetchWorker(request, env);
+
+    expect(response).toBe(sessionResponse);
+    expect(requireCurrentSessionAccessMock).toHaveBeenCalledWith({
+      env,
+      kiloUserId: 'user-1',
+      cloudAgentSessionId: sessionId,
+      expectedOrganizationId: 'org-1',
+      expectedKiloSessionId: 'ses_12345678901234567890123456',
+    });
+    expect(consume).toHaveBeenCalledOnce();
+    expect(env.SANDBOX_SESSION.idFromName).toHaveBeenCalledWith(`user-1:${sessionId}`);
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+    expect(getRunningTerminalClientMock).not.toHaveBeenCalled();
+    expect(sessionFetch).toHaveBeenCalledOnce();
+
+    const forwarded = sessionFetch.mock.calls[0]?.[0] as Request;
+    const forwardedUrl = new URL(forwarded.url);
+    expect(forwarded).not.toBe(request);
+    expect(forwardedUrl.pathname).toBe('/terminal/browser');
+    expect(forwardedUrl.search).toBe('?ptyId=pty_123');
+    expect(forwarded.headers.get('upgrade')).toBe('websocket');
+    expect(forwarded.headers.get('connection')).toBe('Upgrade');
+    expect(forwarded.headers.get('sec-websocket-key')).toBe('dGhlIHNhbXBsZSBub25jZQ==');
+    expect(forwarded.headers.get('sec-websocket-version')).toBe('13');
+    expect(forwarded.headers.get('sec-websocket-protocol')).toBeNull();
+    expect(forwarded.headers.get('sec-websocket-extensions')).toBeNull();
+    expect(forwarded.headers.get('origin')).toBeNull();
+    expect(forwarded.headers.get('authorization')).toBeNull();
+    expect(forwarded.headers.get('cookie')).toBeNull();
+    expect(forwarded.headers.get('x-terminal-role')).toBeNull();
+    expect(forwarded.headers.get('x-internal-role')).toBeNull();
+    expect(forwarded.headers.get('x-forwarded-user')).toBeNull();
+  });
+
+  it('rejects revoked control-plane access before consuming the browser ticket nonce', async () => {
+    const sessionId = 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const ticket = signTerminalTicket(sessionId);
+    const env = createEnv();
+    requireCurrentSessionAccessMock.mockRejectedValue(
+      Object.assign(new Error('Session access denied'), { code: 'FORBIDDEN' })
+    );
+
+    const response = await fetchWorker(
+      new Request(
+        `http://worker.test/terminal?cloudAgentSessionId=${sessionId}&ptyId=pty_123&ticket=${encodeURIComponent(ticket)}`,
+        { headers: { Upgrade: 'websocket' } }
+      ),
+      env
+    );
+
+    expect(response.status).toBe(403);
+    expect(env.STREAM_TICKET_NONCE_DO.idFromName).not.toHaveBeenCalled();
+    expect(env.SANDBOX_SESSION.idFromName).not.toHaveBeenCalled();
+  });
+
+  it.each(['pty.invalid', 'pty/invalid', 'a'.repeat(129)])(
+    'rejects invalid browser PTY identifiers before ticket validation: %s',
+    async ptyId => {
+      const sessionId = 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+      const env = createEnv();
+      const url = new URL('http://worker.test/terminal');
+      url.searchParams.set('cloudAgentSessionId', sessionId);
+      url.searchParams.set('ptyId', ptyId);
+      url.searchParams.set('ticket', 'unused');
+
+      const response = await fetchWorker(
+        new Request(url, { headers: { Upgrade: 'websocket' } }),
+        env
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.text()).resolves.toBe('Invalid ptyId parameter');
+      expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
+      expect(env.STREAM_TICKET_NONCE_DO.idFromName).not.toHaveBeenCalled();
+      expect(env.SANDBOX_SESSION.idFromName).not.toHaveBeenCalled();
+    }
+  );
 
   it('proxies valid terminal tickets directly to the wrapper container', async () => {
     const ticket = jwt.sign(
@@ -1211,6 +1350,142 @@ describe('server /internal/sandbox-control/seed', () => {
     expect(env.SANDBOX_CONTROL.getByName).toHaveBeenCalledWith('sbx_test');
     expect(setWrapperCredentialHash).toHaveBeenCalledOnce();
     expect(setWrapperCredentialHash.mock.calls[0]?.[0]).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe('server /sandbox-terminal', () => {
+  const sessionId = 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+
+  it('rejects non-WebSocket requests before resolving the session', async () => {
+    const env = createEnv();
+
+    const response = await fetchWorker(
+      new Request(`http://worker.test/sandbox-terminal/user-1/${sessionId}/pty_123`, {
+        headers: { Authorization: 'Bearer producer-capability' },
+      }),
+      env
+    );
+
+    expect(response.status).toBe(426);
+    expect(env.SANDBOX_SESSION.idFromName).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'agent_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
+    'workspace_invalid',
+    'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaax',
+  ])('rejects invalid control-plane session identifiers: %s', async invalidSessionId => {
+    const env = createEnv();
+
+    const response = await fetchWorker(
+      new Request(`http://worker.test/sandbox-terminal/user-1/${invalidSessionId}/pty_123`, {
+        headers: { Upgrade: 'websocket', Authorization: 'Bearer producer-capability' },
+      }),
+      env
+    );
+
+    expect(response.status).toBe(400);
+    await expect(response.text()).resolves.toBe('Invalid sessionId');
+    expect(env.SANDBOX_SESSION.idFromName).not.toHaveBeenCalled();
+  });
+
+  it.each(['pty.invalid', 'pty/invalid', 'a'.repeat(129)])(
+    'rejects invalid wrapper PTY identifiers: %s',
+    async ptyId => {
+      const env = createEnv();
+
+      const response = await fetchWorker(
+        new Request(
+          `http://worker.test/sandbox-terminal/user-1/${sessionId}/${encodeURIComponent(ptyId)}`,
+          {
+            headers: { Upgrade: 'websocket', Authorization: 'Bearer producer-capability' },
+          }
+        ),
+        env
+      );
+
+      expect(response.status).toBe(400);
+      await expect(response.text()).resolves.toBe('Invalid ptyId');
+      expect(env.SANDBOX_SESSION.idFromName).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    { name: 'missing', authorization: undefined },
+    { name: 'basic', authorization: 'Basic producer-capability' },
+    { name: 'empty bearer', authorization: 'Bearer' },
+    { name: 'multiple credentials', authorization: 'Bearer first second' },
+    { name: 'oversized bearer', authorization: `Bearer ${'a'.repeat(257)}` },
+  ])(
+    'rejects $name producer credentials before resolving the session',
+    async ({ authorization }) => {
+      const env = createEnv();
+      const headers = new Headers({ Upgrade: 'websocket' });
+      if (authorization !== undefined) headers.set('Authorization', authorization);
+
+      const response = await fetchWorker(
+        new Request(`http://worker.test/sandbox-terminal/user-1/${sessionId}/pty_123`, { headers }),
+        env
+      );
+
+      expect(response.status).toBe(401);
+      await expect(response.text()).resolves.toBe('Invalid or missing Authorization header');
+      expect(env.SANDBOX_SESSION.idFromName).not.toHaveBeenCalled();
+    }
+  );
+
+  it('routes OAuth owners without double decoding and forwards only wrapper handshake credentials', async () => {
+    const ownerId = 'oauth/github:user%2Fteam%25raw%invalid';
+    const env = createEnv();
+    const sessionResponse = new Response('wrapper bridged', { status: 200 });
+    const sessionFetch = vi.fn().mockResolvedValue(sessionResponse);
+    env.SANDBOX_SESSION.idFromName.mockReturnValue('sandbox-session-do-id');
+    env.SANDBOX_SESSION.get.mockReturnValue({ fetch: sessionFetch });
+    const request = new Request(
+      `http://worker.test/sandbox-terminal/${encodeURIComponent(ownerId)}/${sessionId}/pty_123?ticket=browser-secret&ptyId=attacker&role=browser`,
+      {
+        headers: {
+          Upgrade: 'websocket',
+          Connection: 'Upgrade',
+          'Sec-WebSocket-Key': 'dGhlIHNhbXBsZSBub25jZQ==',
+          'Sec-WebSocket-Version': '13',
+          'Sec-WebSocket-Protocol': 'private-wrapper-protocol',
+          'Sec-WebSocket-Extensions': 'permessage-deflate',
+          Authorization: 'Bearer producer-capability',
+          Cookie: 'session=browser-secret',
+          Origin: 'https://attacker.example.com',
+          'X-Terminal-Role': 'browser',
+          'X-Internal-Role': 'browser',
+          'X-Forwarded-User': 'attacker',
+        },
+      }
+    );
+
+    const response = await fetchWorker(request, env);
+
+    expect(response).toBe(sessionResponse);
+    expect(env.SANDBOX_SESSION.idFromName).toHaveBeenCalledWith(`${ownerId}:${sessionId}`);
+    expect(env.CLOUD_AGENT_SESSION.idFromName).not.toHaveBeenCalled();
+    expect(requireCurrentSessionAccessMock).not.toHaveBeenCalled();
+    expect(sessionFetch).toHaveBeenCalledOnce();
+
+    const forwarded = sessionFetch.mock.calls[0]?.[0] as Request;
+    const forwardedUrl = new URL(forwarded.url);
+    expect(forwarded).not.toBe(request);
+    expect(forwardedUrl.pathname).toBe('/terminal/wrapper');
+    expect(forwardedUrl.search).toBe('?ptyId=pty_123');
+    expect(forwarded.headers.get('upgrade')).toBe('websocket');
+    expect(forwarded.headers.get('connection')).toBe('Upgrade');
+    expect(forwarded.headers.get('sec-websocket-key')).toBe('dGhlIHNhbXBsZSBub25jZQ==');
+    expect(forwarded.headers.get('sec-websocket-version')).toBe('13');
+    expect(forwarded.headers.get('authorization')).toBe('Bearer producer-capability');
+    expect(forwarded.headers.get('sec-websocket-protocol')).toBeNull();
+    expect(forwarded.headers.get('sec-websocket-extensions')).toBeNull();
+    expect(forwarded.headers.get('cookie')).toBeNull();
+    expect(forwarded.headers.get('origin')).toBeNull();
+    expect(forwarded.headers.get('x-terminal-role')).toBeNull();
+    expect(forwarded.headers.get('x-internal-role')).toBeNull();
+    expect(forwarded.headers.get('x-forwarded-user')).toBeNull();
   });
 });
 

--- a/services/cloud-agent-next/src/server.ts
+++ b/services/cloud-agent-next/src/server.ts
@@ -39,9 +39,14 @@ import {
   KILO_FACADE_USER_ID_HEADER,
 } from './kilo-facade/user-kilo-facade.js';
 import { getSandboxControlStub, isSandboxControlId } from './sandbox-control/stub.js';
-import { resolveSessionStub } from './sandbox-session/session-stub.js';
+import { getSandboxSessionStub, resolveSessionStub } from './sandbox-session/session-stub.js';
 import { sessionPlaneFromId } from './session-plane.js';
-import { generateSandboxCredential, hashSandboxCredential } from './sandbox-control/credential.js';
+import {
+  generateSandboxCredential,
+  hashSandboxCredential,
+  parseBearerCredential,
+} from './sandbox-control/credential.js';
+import { PtyIdSchema, sessionIdSchema } from './router/schemas.js';
 
 const app = new Hono<HonoContext>();
 
@@ -52,6 +57,27 @@ function isAllowedWebSocketOrigin(env: Env, origin: string | undefined): boolean
     .filter(Boolean);
   const isRealOrigin = origin !== undefined && origin !== 'null';
   return allowedOrigins.length === 0 || !isRealOrigin || allowedOrigins.includes(origin);
+}
+
+function createTerminalForwardRequest(
+  request: Request,
+  pathname: '/terminal/browser' | '/terminal/wrapper',
+  ptyId: string,
+  authorization?: string
+): Request {
+  const url = new URL(request.url);
+  url.pathname = pathname;
+  url.search = '';
+  url.searchParams.set('ptyId', ptyId);
+
+  const headers = new Headers();
+  for (const name of ['Upgrade', 'Connection', 'Sec-WebSocket-Key', 'Sec-WebSocket-Version']) {
+    const value = request.headers.get(name);
+    if (value !== null) headers.set(name, value);
+  }
+  if (authorization !== undefined) headers.set('Authorization', authorization);
+
+  return new Request(url, { method: 'GET', headers });
 }
 
 // TODO: the name is not very clear. I thought it is a termination of a websocket, not that websocket is for PTY
@@ -68,14 +94,14 @@ async function handleTerminalWebSocket(request: Request, env: Env): Promise<Resp
     return new Response('Missing cloudAgentSessionId parameter', { status: 400 });
   }
 
-  if (sessionPlaneFromId(cloudAgentSessionId) === 'control') {
-    return new Response('Terminal is not available for this session', { status: 412 });
-  }
-
   const ptyId = url.searchParams.get('ptyId');
   if (!ptyId) {
     logger.withFields({ cloudAgentSessionId }).warn('/terminal: Missing ptyId parameter');
     return new Response('Missing ptyId parameter', { status: 400 });
+  }
+  if (!PtyIdSchema.safeParse(ptyId).success) {
+    logger.withFields({ cloudAgentSessionId }).warn('/terminal: Invalid ptyId parameter');
+    return new Response('Invalid ptyId parameter', { status: 400 });
   }
 
   if (!isAllowedWebSocketOrigin(env, request.headers.get('Origin') ?? undefined)) {
@@ -152,6 +178,11 @@ async function handleTerminalWebSocket(request: Request, env: Env): Promise<Resp
 
   logger.withFields({ cloudAgentSessionId, userId, ptyId }).info('/terminal: WebSocket authorized');
 
+  if (sessionPlaneFromId(cloudAgentSessionId) === 'control') {
+    const stub = getSandboxSessionStub(env, userId, cloudAgentSessionId);
+    return stub.fetch(createTerminalForwardRequest(request, '/terminal/browser', ptyId));
+  }
+
   const stub = resolveSessionStub(env, userId, cloudAgentSessionId);
   const metadata = await stub.getMetadata();
   const terminal = await resolveTerminalWrapperClient({
@@ -222,6 +253,39 @@ app.get('/sandbox-control/:sandboxId', async (c: Context<HonoContext>) => {
 
   const stub = getSandboxControlStub(c.env, sandboxId);
   return stub.fetch(c.req.raw);
+});
+
+app.get('/sandbox-terminal/:ownerId/:sessionId/:ptyId', async (c: Context<HonoContext>) => {
+  if (c.req.header('Upgrade')?.toLowerCase() !== 'websocket') {
+    return c.text('Expected WebSocket upgrade', 426);
+  }
+
+  const ownerId = c.req.param('ownerId');
+  const sessionId = c.req.param('sessionId');
+  const ptyId = c.req.param('ptyId');
+  if (!ownerId) {
+    return c.text('Invalid ownerId', 400);
+  }
+  if (
+    !sessionId ||
+    !sessionIdSchema.safeParse(sessionId).success ||
+    sessionPlaneFromId(sessionId) !== 'control'
+  ) {
+    return c.text('Invalid sessionId', 400);
+  }
+  if (!ptyId || !PtyIdSchema.safeParse(ptyId).success) {
+    return c.text('Invalid ptyId', 400);
+  }
+
+  const authorization = c.req.header('Authorization');
+  if (!authorization || parseBearerCredential(authorization) === null) {
+    return c.text('Invalid or missing Authorization header', 401);
+  }
+
+  const stub = getSandboxSessionStub(c.env, ownerId, sessionId);
+  return stub.fetch(
+    createTerminalForwardRequest(c.req.raw, '/terminal/wrapper', ptyId, authorization)
+  );
 });
 
 function createSanitizedForwardRequest(

--- a/services/cloud-agent-next/src/session-plane.test.ts
+++ b/services/cloud-agent-next/src/session-plane.test.ts
@@ -6,7 +6,7 @@ import {
   sessionPlaneFromId,
   sessionSupportsTerminal,
 } from './session-plane.js';
-import { sessionHasTerminal } from './agent-sandbox/capabilities.js';
+import { PROVIDER_CAPABILITIES, sessionHasTerminal } from './agent-sandbox/capabilities.js';
 import { SESSION_ID_RE } from './shared/protocol.js';
 import { sessionIdSchema } from './types.js';
 
@@ -47,14 +47,16 @@ describe('session plane identity', () => {
     expect(isControlPlaneOwner({ CONTROL_PLANE_IDS: 'user-1' }, { userId: 'user-2' })).toBe(false);
   });
 
-  it('disables terminals for control-plane sessions on every provider', () => {
-    expect(sessionSupportsTerminal('agent_12345678-1234-1234-1234-123456789abc')).toBe(true);
-    expect(sessionSupportsTerminal('workspace_12345678-1234-1234-1234-123456789abc')).toBe(false);
-    expect(sessionHasTerminal('workspace_12345678-1234-1234-1234-123456789abc', 'cloudflare')).toBe(
-      false
-    );
-    expect(sessionHasTerminal('agent_12345678-1234-1234-1234-123456789abc', 'cloudflare')).toBe(
-      true
-    );
+  it('supports control-plane terminals independently of legacy provider capabilities', () => {
+    const legacySessionId = 'agent_12345678-1234-1234-1234-123456789abc';
+    const controlSessionId = 'workspace_12345678-1234-1234-1234-123456789abc';
+
+    expect(sessionSupportsTerminal(legacySessionId)).toBe(true);
+    expect(sessionSupportsTerminal(controlSessionId)).toBe(true);
+    expect(sessionHasTerminal(controlSessionId, 'cloudflare')).toBe(true);
+    expect(sessionHasTerminal(controlSessionId, 'vercel')).toBe(true);
+    expect(sessionHasTerminal(legacySessionId, 'cloudflare')).toBe(true);
+    expect(sessionHasTerminal(legacySessionId, 'vercel')).toBe(false);
+    expect(PROVIDER_CAPABILITIES.vercel.terminal).toBe(false);
   });
 });

--- a/services/cloud-agent-next/src/session-plane.ts
+++ b/services/cloud-agent-next/src/session-plane.ts
@@ -11,7 +11,8 @@ export function sessionPlaneFromId(sessionId: string): SessionPlane {
 }
 
 export function sessionSupportsTerminal(sessionId: string): boolean {
-  return sessionPlaneFromId(sessionId) !== 'control';
+  const plane = sessionPlaneFromId(sessionId);
+  return plane === 'legacy' || plane === 'control';
 }
 
 export function generateSessionId(plane: SessionPlane = 'legacy'): SessionId {

--- a/services/cloud-agent-next/src/shared/runtime-environment.ts
+++ b/services/cloud-agent-next/src/shared/runtime-environment.ts
@@ -38,3 +38,9 @@ const SYSTEM_GIT_CONFIG_KEYS: ReadonlySet<string> = new Set(Object.keys(SYSTEM_G
 export function isStrippedGitConfigEnvVar(key: string): boolean {
   return key.startsWith('GIT_CONFIG_') && !SYSTEM_GIT_CONFIG_KEYS.has(key);
 }
+
+export const CONTROL_RUNTIME_RESERVED_ENV_VARS = [
+  'SANDBOX_CONTROL_CREDENTIAL',
+  'SANDBOX_CONTROL_URL',
+  'PROVIDER_INSTANCE_ID',
+] as const;

--- a/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
+++ b/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
@@ -26,6 +26,10 @@ export const SESSION_OPERATIONS = [
   'session.abort',
   'session.sync',
   'session.detach',
+  'session.terminal.create',
+  'session.terminal.resize',
+  'session.terminal.close',
+  'session.terminal.connect',
 ] as const;
 
 export const SANDBOX_EVENTS = ['sandbox.ready', 'sandbox.heartbeat'] as const;
@@ -55,6 +59,14 @@ export const controlErrorCodes = [
 export type ControlErrorCode = (typeof controlErrorCodes)[number];
 
 export const requestIdSchema = z.string().min(1).max(128);
+
+export const terminalPtyIdSchema = z
+  .string()
+  .min(1)
+  .max(128)
+  .regex(/^[a-zA-Z0-9_-]+$/, 'Invalid PTY ID format');
+
+export const wrapperInstanceIdSchema = z.string().uuid();
 
 export const sessionRequestIdentitySchema = z.object({
   sessionId: z.string().min(1),
@@ -114,6 +126,7 @@ export type ControlError = z.infer<typeof controlErrorSchema>;
 export const sandboxHelloPayloadSchema = z.object({
   protocolVersion: z.literal(SANDBOX_CONTROL_PROTOCOL_VERSION),
   providerInstanceId: z.string().min(1).max(256),
+  wrapperInstanceId: wrapperInstanceIdSchema.optional(),
   wrapperVersion: z.string().min(1).max(128).optional(),
 });
 
@@ -340,6 +353,77 @@ export const sessionDetachResultSchema = z
   })
   .strict();
 
+const terminalSizeSchema = z.object({
+  cols: z.number().int().min(2).max(500),
+  rows: z.number().int().min(2).max(200),
+});
+
+const terminalPtySchema = z.object({
+  id: terminalPtyIdSchema,
+  title: z.string(),
+  command: z.string(),
+  args: z.array(z.string()),
+  cwd: z.string(),
+  status: z.enum(['running', 'exited']),
+  pid: z.number().int(),
+});
+
+export const sessionTerminalCreatePayloadSchema = z
+  .object({
+    operationId: z.string().uuid(),
+  })
+  .extend(terminalSizeSchema.partial().shape)
+  .strict()
+  .refine(data => (data.cols === undefined) === (data.rows === undefined), {
+    message: 'cols and rows must be provided together',
+  });
+
+export const sessionTerminalCreateResultSchema = z
+  .object({
+    pty: terminalPtySchema,
+  })
+  .strict();
+
+export const sessionTerminalResizePayloadSchema = z
+  .object({
+    ptyId: terminalPtyIdSchema,
+  })
+  .extend(terminalSizeSchema.shape)
+  .strict();
+
+export const sessionTerminalResizeResultSchema = z
+  .object({
+    pty: terminalPtySchema,
+  })
+  .strict();
+
+export const sessionTerminalClosePayloadSchema = z
+  .object({
+    ptyId: terminalPtyIdSchema,
+  })
+  .strict();
+
+export const sessionTerminalCloseResultSchema = z
+  .object({
+    success: z.boolean(),
+  })
+  .strict();
+
+export const sessionTerminalConnectPayloadSchema = z
+  .object({
+    ownerId: z.string().min(1),
+    ptyId: terminalPtyIdSchema,
+    bridgeGeneration: z.string().uuid(),
+    capability: z.string().regex(/^[a-f0-9]{64}$/),
+  })
+  .strict();
+
+export const sessionTerminalConnectResultSchema = z
+  .object({
+    connected: z.literal(true),
+  })
+  .strict();
+
 export const sessionEventPayloadSchema = z
   .object({
     type: z.string().min(1).max(256),
@@ -381,14 +465,24 @@ export type SessionSyncPayload = z.infer<typeof sessionSyncPayloadSchema>;
 export type SessionSyncResult = z.infer<typeof sessionSyncResultSchema>;
 export type SessionDetachPayload = z.infer<typeof sessionDetachPayloadSchema>;
 export type SessionDetachResult = z.infer<typeof sessionDetachResultSchema>;
+export type SessionTerminalCreatePayload = z.infer<typeof sessionTerminalCreatePayloadSchema>;
+export type SessionTerminalCreateResult = z.infer<typeof sessionTerminalCreateResultSchema>;
+export type SessionTerminalResizePayload = z.infer<typeof sessionTerminalResizePayloadSchema>;
+export type SessionTerminalResizeResult = z.infer<typeof sessionTerminalResizeResultSchema>;
+export type SessionTerminalClosePayload = z.infer<typeof sessionTerminalClosePayloadSchema>;
+export type SessionTerminalCloseResult = z.infer<typeof sessionTerminalCloseResultSchema>;
+export type SessionTerminalConnectPayload = z.infer<typeof sessionTerminalConnectPayloadSchema>;
+export type SessionTerminalConnectResult = z.infer<typeof sessionTerminalConnectResultSchema>;
 export type SessionEventPayload = z.infer<typeof sessionEventPayloadSchema>;
 export type SessionPreparingPayload = z.infer<typeof sessionPreparingPayloadSchema>;
 
 export const sandboxControlSocketAttachmentSchema = z.object({
   handshakeComplete: z.boolean(),
   acceptedAt: z.number().int().nonnegative(),
+  connectionId: z.string().uuid().optional(),
   protocolVersion: z.literal(SANDBOX_CONTROL_PROTOCOL_VERSION).optional(),
   providerInstanceId: z.string().min(1).max(256).optional(),
+  wrapperInstanceId: wrapperInstanceIdSchema.optional(),
 });
 
 export type SandboxControlSocketAttachment = z.infer<typeof sandboxControlSocketAttachmentSchema>;

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -14,7 +14,10 @@ import type { SecretBinding } from './auth.js';
 import * as z from 'zod';
 import { Limits } from './schema.js';
 import { SESSION_ID_RE } from './shared/protocol.js';
-import { PNPM_STORE_ENV_VAR } from './shared/runtime-environment.js';
+import {
+  CONTROL_RUNTIME_RESERVED_ENV_VARS,
+  PNPM_STORE_ENV_VAR,
+} from './shared/runtime-environment.js';
 
 export const sessionIdSchema = z.string().regex(SESSION_ID_RE, 'Invalid session ID format');
 
@@ -91,6 +94,7 @@ export const RESERVED_ENV_VARS = [
   'SESSION_ID',
   'SESSION_HOME',
   PNPM_STORE_ENV_VAR,
+  ...CONTROL_RUNTIME_RESERVED_ENV_VARS,
 ] as const;
 
 export const envVarsSchema = z

--- a/services/cloud-agent-next/test/integration/sandbox-control.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-control.test.ts
@@ -58,13 +58,21 @@ function nextMessage(ws: WebSocket): Promise<string> {
   });
 }
 
-async function completeHello(ws: WebSocket, requestId: string): Promise<void> {
+async function completeHello(
+  ws: WebSocket,
+  requestId: string,
+  identity: { providerInstanceId?: string; wrapperInstanceId?: string } = {}
+): Promise<void> {
   ws.send(
     JSON.stringify({
       type: 'request',
       requestId,
       operation: 'sandbox.hello',
-      payload: { protocolVersion: 1, providerInstanceId: 'inst_1' },
+      payload: {
+        protocolVersion: 1,
+        providerInstanceId: identity.providerInstanceId ?? 'inst_1',
+        ...(identity.wrapperInstanceId ? { wrapperInstanceId: identity.wrapperInstanceId } : {}),
+      },
     })
   );
   await expect(nextMessage(ws)).resolves.toBe(
@@ -88,6 +96,80 @@ async function completeHello(ws: WebSocket, requestId: string): Promise<void> {
       ok: true,
     })
   );
+}
+
+type TerminalRuntimeFixture = {
+  sandboxId: `usr-${string}`;
+  ownerId: string;
+  sessionId: `workspace_${string}`;
+  wrapperInstanceId?: string;
+};
+
+async function initializeTerminalRuntime(fixture: TerminalRuntimeFixture) {
+  const credential = generateSandboxCredential();
+  await seedCredential(credential, fixture.sandboxId);
+  const control = env.SANDBOX_CONTROL.getByName(fixture.sandboxId);
+  await runInDurableObject(control, async instance => {
+    await instance.initializeOwner(fixture.ownerId);
+    await instance.claimCreate(`intent_${fixture.sandboxId}`);
+    await instance.attachSession({
+      sessionId: fixture.sessionId,
+      kiloSessionId: 'kilo_terminal',
+      directory: '/workspace/terminal',
+      ownerId: fixture.ownerId,
+    });
+  });
+  const socket = await connect(credential, fixture.sandboxId);
+  await completeHello(socket, `hello_${fixture.sandboxId}`, {
+    providerInstanceId: fixture.sandboxId,
+    ...(fixture.wrapperInstanceId ? { wrapperInstanceId: fixture.wrapperInstanceId } : {}),
+  });
+  return { control, credential, socket };
+}
+
+function signalWrapperReady(socket: WebSocket): void {
+  socket.send(
+    JSON.stringify({
+      type: 'event',
+      event: 'sandbox.ready',
+      payload: { kiloReady: true, globalFeedAttached: true },
+    })
+  );
+}
+
+async function waitForWrapperReady(fixture: TerminalRuntimeFixture): Promise<void> {
+  const control = env.SANDBOX_CONTROL.getByName(fixture.sandboxId);
+  await vi.waitFor(async () => {
+    const status = await runInDurableObject(control, instance => instance.getStatus());
+    expect(status).toMatchObject({
+      connection: 'ready',
+      ...(fixture.wrapperInstanceId ? { wrapperInstanceId: fixture.wrapperInstanceId } : {}),
+    });
+  });
+}
+
+async function seedTerminalSession(fixture: TerminalRuntimeFixture, ptyId = 'pty_original') {
+  if (!fixture.wrapperInstanceId) throw new Error('Terminal fixture requires wrapper identity');
+  const session = env.SANDBOX_SESSION.getByName(`${fixture.ownerId}:${fixture.sessionId}`);
+  await runInDurableObject(session, async (instance, state) => {
+    await instance.registerSession({
+      identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
+      auth: { kiloSessionId: 'kilo_terminal' },
+      agent: {},
+      workspace: { sandboxId: fixture.sandboxId },
+    });
+    const attachment = {
+      ownerId: fixture.ownerId,
+      sessionId: fixture.sessionId,
+      kiloSessionId: 'kilo_terminal',
+      directory: '/workspace/terminal',
+      sandboxId: fixture.sandboxId,
+      wrapperInstanceId: fixture.wrapperInstanceId,
+    };
+    state.storage.kv.put('terminal_attached_session', attachment);
+    state.storage.kv.put(`terminal:${ptyId}`, { ...attachment, ptyId, state: 'running' });
+  });
+  return session;
 }
 
 describe('SandboxControl in the Workers runtime', () => {
@@ -755,14 +837,25 @@ describe('SandboxSession control-plane regressions', () => {
         requestId: string;
         session: { sessionId: string; kiloSessionId: string; directory: string };
       };
-      if (request.operation !== 'session.abort') return;
-      abortRequests.push({ operation: request.operation, session: request.session });
+      if (request.operation === 'session.abort') {
+        abortRequests.push({ operation: request.operation, session: request.session });
+        ws.send(
+          JSON.stringify({
+            type: 'response',
+            requestId: request.requestId,
+            ok: true,
+            result: { status: 'aborted' },
+          })
+        );
+        return;
+      }
+      if (request.operation !== 'session.detach') return;
       ws.send(
         JSON.stringify({
           type: 'response',
           requestId: request.requestId,
           ok: true,
-          result: { status: 'aborted' },
+          result: { detached: true },
         })
       );
     });
@@ -923,4 +1016,336 @@ describe('SandboxSession control-plane regressions', () => {
       });
     }
   );
+});
+
+describe('SandboxControl terminal runtime coordination', () => {
+  it('exposes a wrapper instance only for the ready current connection', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a001',
+      ownerId: 'owner_wrapper_readiness',
+      sessionId: 'workspace_wrapper_readiness',
+      wrapperInstanceId: 'b40b8d7b-789f-4c2a-82ce-0c5c9aed4621',
+    };
+    const { control, credential, socket } = await initializeTerminalRuntime(fixture);
+
+    await runInDurableObject(control, async instance => {
+      const status = await instance.getStatus();
+      expect(status).toMatchObject({ physical: 'running', connection: 'connected' });
+      expect(status).not.toHaveProperty('wrapperInstanceId');
+    });
+
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+    await runInDurableObject(control, async (_instance, state) => {
+      const persisted = await state.storage.get<{
+        connectionId: string;
+        readyConnectionId?: string;
+        wrapperInstanceId?: string;
+      }>('active_wrapper_runtime');
+      expect(persisted).toMatchObject({ wrapperInstanceId: fixture.wrapperInstanceId });
+      expect(persisted?.readyConnectionId).toBe(persisted?.connectionId);
+    });
+
+    const replacement = await connect(credential, fixture.sandboxId);
+    await completeHello(replacement, 'hello_same_wrapper', {
+      providerInstanceId: fixture.sandboxId,
+      wrapperInstanceId: fixture.wrapperInstanceId,
+    });
+    await runInDurableObject(control, async (instance, state) => {
+      const status = await instance.getStatus();
+      expect(status.connection).toBe('connected');
+      expect(status).not.toHaveProperty('wrapperInstanceId');
+      expect(
+        await state.storage.get<{ readyConnectionId?: string }>('active_wrapper_runtime')
+      ).not.toHaveProperty('readyConnectionId');
+      expect(await state.storage.get('wrapper_ready_at')).toBeUndefined();
+      expect(await state.storage.get('deadlines')).not.toHaveProperty('heartbeatExpiry');
+    });
+
+    signalWrapperReady(replacement);
+    await waitForWrapperReady(fixture);
+    replacement.close();
+  });
+
+  it('preserves ready chat for older wrappers without granting terminal capability', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a002',
+      ownerId: 'owner_legacy_wrapper',
+      sessionId: 'workspace_legacy_wrapper',
+    };
+    const { control, socket } = await initializeTerminalRuntime(fixture);
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+
+    await runInDurableObject(control, async instance => {
+      const status = await instance.getStatus();
+      expect(status).toMatchObject({ physical: 'running', connection: 'ready' });
+      expect(status).not.toHaveProperty('wrapperInstanceId');
+      await expect(
+        instance.validateTerminalAccess({
+          sessionId: fixture.sessionId,
+          ownerId: fixture.ownerId,
+          wrapperInstanceId: '27cbf2d6-aeef-42d0-8992-1a61e83e95a5',
+        })
+      ).resolves.toEqual({ allowed: false, reason: 'terminal_not_supported' });
+    });
+    socket.close();
+  });
+
+  it('validates the current session route, owner, and wrapper incarnation', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a003',
+      ownerId: 'owner_terminal_access',
+      sessionId: 'workspace_terminal_access',
+      wrapperInstanceId: '22c38b5a-5394-4a71-9c88-e3e998565fdb',
+    };
+    const { control, socket } = await initializeTerminalRuntime(fixture);
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+
+    await runInDurableObject(control, async instance => {
+      const input = {
+        sessionId: fixture.sessionId,
+        ownerId: fixture.ownerId,
+        wrapperInstanceId: fixture.wrapperInstanceId ?? '',
+      };
+      await expect(instance.validateTerminalAccess(input)).resolves.toEqual({ allowed: true });
+      await expect(
+        instance.validateTerminalAccess({ ...input, ownerId: 'owner_other' })
+      ).resolves.toEqual({ allowed: false, reason: 'owner_mismatch' });
+      await expect(
+        instance.validateTerminalAccess({ ...input, sessionId: 'workspace_other' })
+      ).resolves.toEqual({ allowed: false, reason: 'session_not_attached' });
+      await expect(
+        instance.validateTerminalAccess({
+          ...input,
+          wrapperInstanceId: 'd4e4d7ee-4456-4038-b64d-a564e96e054d',
+        })
+      ).resolves.toEqual({ allowed: false, reason: 'wrapper_instance_mismatch' });
+      await expect(instance.detachSession(fixture.sessionId)).resolves.toEqual({ existed: true });
+      await expect(instance.validateTerminalAccess(input)).resolves.toEqual({
+        allowed: false,
+        reason: 'session_not_attached',
+      });
+    });
+    socket.close();
+  });
+
+  it('never provisions or wakes a stopped runtime for terminal access or activity', async () => {
+    const control = env.SANDBOX_CONTROL.getByName('usr-a00a');
+    const input = {
+      sessionId: 'workspace_stopped_access',
+      ownerId: 'owner_stopped_access',
+      wrapperInstanceId: '594b4020-64a5-42d4-bcf0-7915af4a099d',
+    };
+
+    await runInDurableObject(control, async instance => {
+      await instance.initializeOwner(input.ownerId);
+      await instance.attachSession({
+        sessionId: input.sessionId,
+        kiloSessionId: 'kilo_terminal',
+        directory: '/workspace/terminal',
+        ownerId: input.ownerId,
+      });
+      await expect(instance.validateTerminalAccess(input)).resolves.toEqual({
+        allowed: false,
+        reason: 'runtime_not_running',
+      });
+      await expect(instance.recordTerminalActivity(input)).resolves.toEqual({
+        allowed: false,
+        reason: 'runtime_not_running',
+      });
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'stopped',
+        providerRef: null,
+        createIntent: null,
+      });
+    });
+  });
+
+  it('preserves PTYs on same-wrapper reconnect and invalidates only replaced runtimes', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a004',
+      ownerId: 'owner_runtime_replacement',
+      sessionId: 'workspace_runtime_replacement',
+      wrapperInstanceId: '2ece7e1a-6f7f-40b3-a4d8-307304eaaf93',
+    };
+    const { control, credential, socket } = await initializeTerminalRuntime(fixture);
+    const session = await seedTerminalSession(fixture);
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+
+    const sameWrapper = await connect(credential, fixture.sandboxId);
+    await completeHello(sameWrapper, 'hello_preserved_runtime', {
+      providerInstanceId: fixture.sandboxId,
+      wrapperInstanceId: fixture.wrapperInstanceId,
+    });
+    await runInDurableObject(session, (_instance, state) => {
+      expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
+        state: 'running',
+      });
+    });
+
+    const newWrapperInstanceId = '0acff5cd-f58d-49fa-8f70-3182940194f5';
+    const newWrapper = await connect(credential, fixture.sandboxId);
+    await completeHello(newWrapper, 'hello_replacement_runtime', {
+      providerInstanceId: fixture.sandboxId,
+      wrapperInstanceId: newWrapperInstanceId,
+    });
+    await runInDurableObject(session, (_instance, state) => {
+      expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
+        state: 'ended',
+      });
+      expect(state.storage.kv.get('terminal_attached_session')).toBeUndefined();
+    });
+    await runInDurableObject(control, async instance => {
+      expect(await instance.getStatus()).not.toHaveProperty('wrapperInstanceId');
+    });
+
+    const replacementFixture = { ...fixture, wrapperInstanceId: newWrapperInstanceId };
+    signalWrapperReady(newWrapper);
+    await waitForWrapperReady(replacementFixture);
+    await seedTerminalSession(replacementFixture, 'pty_current');
+    await runInDurableObject(session, async (instance, state) => {
+      await instance.invalidateTerminalRuntime({
+        sandboxId: fixture.sandboxId,
+        wrapperInstanceId: fixture.wrapperInstanceId ?? '',
+        confirmed: true,
+      });
+      expect(state.storage.kv.get<{ state: string }>('terminal:pty_current')).toMatchObject({
+        state: 'running',
+      });
+    });
+    newWrapper.close();
+  });
+
+  it('keeps PTY ownership on uncertain physical observations', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a005',
+      ownerId: 'owner_uncertain_runtime',
+      sessionId: 'workspace_uncertain_runtime',
+      wrapperInstanceId: '6d1a1a6c-1153-4856-b07b-58b5b4f245aa',
+    };
+    const { control, socket } = await initializeTerminalRuntime(fixture);
+    const session = await seedTerminalSession(fixture);
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+
+    await runInDurableObject(control, async instance => {
+      await expect(instance.observeProvider('unknown')).resolves.toMatchObject({
+        state: 'unknown',
+      });
+      expect(await instance.getStatus()).not.toHaveProperty('wrapperInstanceId');
+    });
+    await runInDurableObject(session, (_instance, state) => {
+      expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
+        state: 'running',
+      });
+    });
+    socket.close();
+  });
+
+  it('invalidates active PTYs when the physical runtime fails', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a008',
+      ownerId: 'owner_failed_runtime',
+      sessionId: 'workspace_failed_runtime',
+      wrapperInstanceId: '84114e6b-77c0-4792-88b9-2db90d789fe1',
+    };
+    const { control, socket } = await initializeTerminalRuntime(fixture);
+    const session = await seedTerminalSession(fixture);
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+
+    await runInDurableObject(control, async instance => {
+      await expect(instance.markFailed()).resolves.toMatchObject({ state: 'failed' });
+      expect(await instance.getStatus()).not.toHaveProperty('wrapperInstanceId');
+    });
+    await runInDurableObject(session, (_instance, state) => {
+      expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
+        state: 'ended',
+      });
+    });
+  });
+
+  it('invalidates active PTYs when a physical stop is confirmed', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a009',
+      ownerId: 'owner_stopped_runtime',
+      sessionId: 'workspace_stopped_runtime',
+      wrapperInstanceId: '78de88a1-a906-4e4f-bd9e-2447c21e6472',
+    };
+    const { control, socket } = await initializeTerminalRuntime(fixture);
+    const session = await seedTerminalSession(fixture);
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+
+    await runInDurableObject(control, async instance => {
+      await instance.beginStop('test');
+      await expect(instance.confirmStopped()).resolves.toMatchObject({ state: 'stopped' });
+      expect(await instance.getStatus()).not.toHaveProperty('wrapperInstanceId');
+    });
+    await runInDurableObject(session, (_instance, state) => {
+      expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
+        state: 'ended',
+      });
+    });
+  });
+
+  it('invalidates active PTYs when wrapper credentials rotate', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a006',
+      ownerId: 'owner_credential_rotation',
+      sessionId: 'workspace_credential_rotation',
+      wrapperInstanceId: 'bf73c60f-fd06-43f1-a93e-3412790a5ca4',
+    };
+    const { control, socket } = await initializeTerminalRuntime(fixture);
+    const session = await seedTerminalSession(fixture);
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+
+    await seedCredential(generateSandboxCredential(), fixture.sandboxId);
+    await runInDurableObject(session, (_instance, state) => {
+      expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
+        state: 'ended',
+      });
+    });
+    await runInDurableObject(control, async instance => {
+      expect(await instance.getStatus()).not.toHaveProperty('wrapperInstanceId');
+    });
+  });
+
+  it('extends idle deadlines monotonically for authorized Cloudflare terminal activity', async () => {
+    const fixture: TerminalRuntimeFixture = {
+      sandboxId: 'usr-a007',
+      ownerId: 'owner_terminal_activity',
+      sessionId: 'workspace_terminal_activity',
+      wrapperInstanceId: '5d1e54ed-31db-4646-a478-4864e87162c3',
+    };
+    const { control, socket } = await initializeTerminalRuntime(fixture);
+    signalWrapperReady(socket);
+    await waitForWrapperReady(fixture);
+
+    await runInDurableObject(control, async (instance, state) => {
+      const current = (await state.storage.get<{ idleStop?: number }>('deadlines')) ?? {};
+      const later = Date.now() + 10 * 60_000;
+      await state.storage.put('deadlines', { ...current, idleStop: later });
+      const activity = {
+        sessionId: fixture.sessionId,
+        ownerId: fixture.ownerId,
+        wrapperInstanceId: fixture.wrapperInstanceId ?? '',
+      };
+      await expect(
+        instance.recordTerminalActivity({
+          ...activity,
+          wrapperInstanceId: '513ea14b-e0b7-4bd8-b6d3-76a05c509c11',
+        })
+      ).resolves.toEqual({ allowed: false, reason: 'wrapper_instance_mismatch' });
+      expect((await state.storage.get<{ idleStop?: number }>('deadlines'))?.idleStop).toBe(later);
+      await expect(instance.recordTerminalActivity(activity)).resolves.toEqual({ allowed: true });
+      const after = await state.storage.get<{ idleStop?: number }>('deadlines');
+      expect(after?.idleStop).toBeGreaterThanOrEqual(later);
+    });
+    socket.close();
+  });
 });

--- a/services/cloud-agent-next/test/integration/sandbox-terminal.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-terminal.test.ts
@@ -10,6 +10,7 @@ import {
   responseFrameSchema,
   sessionTerminalConnectPayloadSchema,
   type RequestFrame,
+  type ResponseFrame,
   type SessionTerminalConnectPayload,
 } from '../../src/shared/sandbox-control-protocol.js';
 import type { SandboxId } from '../../src/types.js';
@@ -53,6 +54,7 @@ type TerminalFixture = {
   connections: TerminalConnection[];
   browsers: BrowserConnection[];
   nextBehavior: ConnectionBehavior;
+  nextCloseResponse?: Omit<ResponseFrame, 'type' | 'requestId'>;
   errors: Error[];
   openBrowser: (behavior?: ConnectionBehavior) => Promise<BrowserConnection>;
   reverseUrl: () => string;
@@ -292,7 +294,9 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
     }
 
     if (request.operation === 'session.terminal.close') {
-      sendResponse(control, request.requestId, { success: true });
+      const response = fixture.nextCloseResponse ?? { ok: true, result: { success: true } };
+      fixture.nextCloseResponse = undefined;
+      control.send(JSON.stringify({ type: 'response', requestId: request.requestId, ...response }));
       return;
     }
 
@@ -406,7 +410,9 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
       auth: { kiloSessionId },
       agent: { mode: 'code', model: 'test-model' },
       workspace: { sandboxId, sandboxProvider: 'cloudflare' },
-      message: { initialTurn: { messageId: `msg_${identity}`, type: 'prompt' } },
+      message: {
+        initialTurn: { messageId: `msg_${identity}`, type: 'prompt', prompt: 'Prepare workspace' },
+      },
     })
   );
   if (!admission.success) throw new Error(`Session admission failed: ${admission.error}`);
@@ -630,6 +636,56 @@ describe('SandboxSession terminal bridge in the Workers runtime', () => {
     if (!replacement) throw new Error('Missing replacement reverse socket');
     replacement.socket.send('upstream recovered');
     await expect(reconnected.inbox.next()).resolves.toBe('upstream recovered');
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it.each([
+    {
+      failure: 'a control request fails',
+      response: {
+        ok: false,
+        error: { code: 'not_ready', message: 'Wrapper unavailable', retryable: true },
+      } satisfies Omit<ResponseFrame, 'type' | 'requestId'>,
+    },
+    { failure: 'PTY deletion returns false', response: { ok: true, result: { success: false } } },
+  ])('keeps a terminal usable and retries close when $failure', async ({ response }) => {
+    const fixture = await createFixture();
+    const browser = await fixture.openBrowser();
+    const wrapper = fixture.connections[0];
+    if (!wrapper) throw new Error('Missing reverse socket');
+    const session = getSandboxSessionStub(env, fixture.ownerId, fixture.sessionId);
+    fixture.nextCloseResponse = response;
+
+    await expect(
+      runInDurableObject(session, instance => instance.closeTerminal({ ptyId: fixture.ptyId }))
+    ).resolves.toEqual({ success: false, error: 'Terminal closure failed; please retry' });
+    await expect(
+      runInDurableObject(session, async (_instance, state) =>
+        state.storage.kv.get(`terminal:${fixture.ptyId}`)
+      )
+    ).resolves.toMatchObject({ state: 'running' });
+
+    browser.socket.send('still running after failed close');
+    await expect(wrapper.inbox.next()).resolves.toBe('still running after failed close');
+    wrapper.socket.send('close can be retried');
+    await expect(browser.inbox.next()).resolves.toBe('close can be retried');
+
+    await expect(
+      runInDurableObject(session, instance => instance.closeTerminal({ ptyId: fixture.ptyId }))
+    ).resolves.toEqual({ success: true, data: { success: true } });
+    await expect(browser.closed).resolves.toMatchObject({
+      code: 1000,
+      reason: 'PTY session ended',
+    });
+    await expect(wrapper.closed).resolves.toMatchObject({
+      code: 1000,
+      reason: 'PTY session ended',
+    });
+    await expect(
+      runInDurableObject(session, async (_instance, state) =>
+        state.storage.kv.get(`terminal:${fixture.ptyId}`)
+      )
+    ).resolves.toMatchObject({ state: 'ended' });
     expect(fixture.errors).toEqual([]);
   });
 

--- a/services/cloud-agent-next/test/integration/sandbox-terminal.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-terminal.test.ts
@@ -1,0 +1,778 @@
+import { SELF, env, runInDurableObject } from 'cloudflare:test';
+import { afterEach, describe, expect, it } from 'vitest';
+import {
+  generateSandboxCredential,
+  hashSandboxCredential,
+} from '../../src/sandbox-control/credential.js';
+import { getSandboxSessionStub } from '../../src/sandbox-session/session-stub.js';
+import {
+  requestFrameSchema,
+  responseFrameSchema,
+  sessionTerminalConnectPayloadSchema,
+  type RequestFrame,
+  type SessionTerminalConnectPayload,
+} from '../../src/shared/sandbox-control-protocol.js';
+import type { SandboxId } from '../../src/types.js';
+import { getSessionWorkspacePath } from '../../src/workspace.js';
+
+type SocketFrame = string | ArrayBuffer;
+
+type SocketInbox = {
+  next: () => Promise<SocketFrame>;
+};
+
+type TerminalConnection = {
+  payload: SessionTerminalConnectPayload;
+  socket: WebSocket;
+  inbox: SocketInbox;
+  closed: Promise<CloseEvent>;
+  unauthorizedStatuses: number[];
+};
+
+type BrowserConnection = {
+  socket: WebSocket;
+  inbox: SocketInbox;
+  closed: Promise<CloseEvent>;
+};
+
+type ConnectionBehavior = {
+  concurrentRedemption?: boolean;
+  unauthorizedFirst?: boolean;
+  initialOutput?: string;
+};
+
+type TerminalFixture = {
+  ownerId: string;
+  sessionId: string;
+  kiloSessionId: string;
+  sandboxId: SandboxId;
+  wrapperInstanceId: string;
+  directory: string;
+  ptyId: string;
+  control: WebSocket;
+  connections: TerminalConnection[];
+  browsers: BrowserConnection[];
+  nextBehavior: ConnectionBehavior;
+  errors: Error[];
+  openBrowser: (behavior?: ConnectionBehavior) => Promise<BrowserConnection>;
+  reverseUrl: () => string;
+  dispose: () => Promise<void>;
+};
+
+const fixtures = new Set<TerminalFixture>();
+
+function createSocketInbox(socket: WebSocket): SocketInbox {
+  const buffered: SocketFrame[] = [];
+  const waiters: Array<(frame: SocketFrame) => void> = [];
+  socket.addEventListener('message', event => {
+    const data = event.data;
+    if (typeof data !== 'string' && !(data instanceof ArrayBuffer)) return;
+    const waiter = waiters.shift();
+    if (waiter) {
+      waiter(data);
+      return;
+    }
+    buffered.push(data);
+  });
+
+  return {
+    next: () => {
+      const frame = buffered.shift();
+      if (frame !== undefined) return Promise.resolve(frame);
+      return new Promise(resolve => waiters.push(resolve));
+    },
+  };
+}
+
+function nextClose(socket: WebSocket): Promise<CloseEvent> {
+  return new Promise(resolve => {
+    socket.addEventListener('close', event => resolve(event), { once: true });
+  });
+}
+
+function parseRequest(frame: SocketFrame): RequestFrame {
+  if (typeof frame !== 'string') throw new Error('Expected a text control frame');
+  return requestFrameSchema.parse(JSON.parse(frame));
+}
+
+function sendResponse(control: WebSocket, requestId: string, result: unknown): void {
+  control.send(JSON.stringify({ type: 'response', requestId, ok: true, result }));
+}
+
+function terminalPty(ptyId: string, directory: string) {
+  return {
+    id: ptyId,
+    title: 'Terminal',
+    command: '/bin/sh',
+    args: [],
+    cwd: directory,
+    status: 'running' as const,
+    pid: 1234,
+  };
+}
+
+async function createFixture(ownerId?: string, organizationId?: string): Promise<TerminalFixture> {
+  const identity = crypto.randomUUID();
+  const owner = ownerId ?? `user_${identity}`;
+  const sessionId = `workspace_${identity}`;
+  const sandboxId = `ses-${identity.replaceAll('-', '')}` as SandboxId;
+  const kiloSessionId = `ses_${identity.replaceAll('-', '')}`;
+  const wrapperInstanceId = crypto.randomUUID();
+  const ptyId = `pty_${identity.replaceAll('-', '')}`;
+  const directory = getSessionWorkspacePath(organizationId, owner, sessionId);
+  const sessionIdentity = {
+    sessionId,
+    userId: owner,
+    createdOnPlatform: 'cloud-agent-web',
+    ...(organizationId ? { orgId: organizationId } : {}),
+  };
+  const credential = generateSandboxCredential();
+  const controlStub = env.SANDBOX_CONTROL.getByName(sandboxId);
+  const sessionStub = getSandboxSessionStub(env, owner, sessionId);
+
+  await runInDurableObject(controlStub, async instance => {
+    await instance.initializeOwner(owner);
+    await instance.claimCreate(crypto.randomUUID());
+    await instance.confirmInstance(sandboxId);
+    await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+  });
+
+  await runInDurableObject(sessionStub, async instance => {
+    const result = await instance.registerSession({
+      identity: sessionIdentity,
+      auth: { kiloSessionId },
+      agent: { mode: 'code', model: 'test-model' },
+      workspace: { sandboxId, sandboxProvider: 'cloudflare' },
+    });
+    expect(result.success).toBe(true);
+  });
+
+  const upgraded = await SELF.fetch(`http://worker.test/sandbox-control/${sandboxId}`, {
+    headers: { Upgrade: 'websocket', Authorization: `Bearer ${credential}` },
+  });
+  if (upgraded.status !== 101 || !upgraded.webSocket) {
+    throw new Error(`Unexpected sandbox control upgrade: ${upgraded.status}`);
+  }
+  const control = upgraded.webSocket;
+  control.accept();
+  const controlInbox = createSocketInbox(control);
+  control.send(
+    JSON.stringify({
+      type: 'request',
+      requestId: `hello_${identity}`,
+      operation: 'sandbox.hello',
+      payload: {
+        protocolVersion: 1,
+        providerInstanceId: sandboxId,
+        wrapperInstanceId,
+      },
+    })
+  );
+
+  const helloFrame = await controlInbox.next();
+  if (typeof helloFrame !== 'string') throw new Error('Expected sandbox hello response');
+  expect(responseFrameSchema.parse(JSON.parse(helloFrame))).toMatchObject({
+    requestId: `hello_${identity}`,
+    ok: true,
+  });
+  const status = parseRequest(await controlInbox.next());
+  expect(status.operation).toBe('sandbox.status');
+  sendResponse(control, status.requestId, {
+    healthy: true,
+    state: 'idle',
+    version: 'test',
+    kiloReady: true,
+  });
+
+  let resolvePreparation: (() => void) | undefined;
+  const prepared = new Promise<void>(resolve => {
+    resolvePreparation = resolve;
+  });
+
+  const fixture: TerminalFixture = {
+    ownerId: owner,
+    sessionId,
+    kiloSessionId,
+    sandboxId,
+    wrapperInstanceId,
+    directory,
+    ptyId,
+    control,
+    connections: [],
+    browsers: [],
+    nextBehavior: {},
+    errors: [],
+    reverseUrl: () =>
+      `http://worker.test/sandbox-terminal/${encodeURIComponent(owner)}/${sessionId}/${ptyId}`,
+    openBrowser: async (behavior = {}) => {
+      fixture.nextBehavior = behavior;
+      const url = new URL('http://worker.test/terminal-test');
+      url.searchParams.set('ownerId', owner);
+      url.searchParams.set('sessionId', sessionId);
+      url.searchParams.set('ptyId', ptyId);
+      url.searchParams.set('ticket', 'browser-ticket-must-not-be-forwarded');
+      const response = await SELF.fetch(url, {
+        headers: {
+          Upgrade: 'websocket',
+          Authorization: 'Bearer browser-credential-must-not-be-forwarded',
+          Cookie: 'session=browser-cookie-must-not-be-forwarded',
+        },
+      });
+      if (response.status !== 101 || !response.webSocket) {
+        throw new Error(`Unexpected terminal browser upgrade: ${response.status}`);
+      }
+      response.webSocket.binaryType = 'arraybuffer';
+      response.webSocket.accept();
+      const browser: BrowserConnection = {
+        socket: response.webSocket,
+        inbox: createSocketInbox(response.webSocket),
+        closed: nextClose(response.webSocket),
+      };
+      fixture.browsers.push(browser);
+      return browser;
+    },
+    dispose: async () => {
+      for (const browser of fixture.browsers) {
+        if (browser.socket.readyState === 1) browser.socket.close(1000, 'test cleanup');
+      }
+      for (const connection of fixture.connections) {
+        if (connection.socket.readyState === 1) connection.socket.close(1000, 'test cleanup');
+      }
+      await runInDurableObject(controlStub, async instance => {
+        const physical = await instance.getPhysicalRecord();
+        if (physical.state === 'running') {
+          await instance.beginStop('test cleanup');
+          await instance.confirmStopped();
+        }
+      });
+      if (control.readyState === 1) control.close(1000, 'test cleanup');
+    },
+  };
+  fixtures.add(fixture);
+
+  async function respond(request: RequestFrame): Promise<void> {
+    if (request.operation === 'sandbox.status') {
+      sendResponse(control, request.requestId, {
+        healthy: true,
+        state: 'idle',
+        version: 'test',
+        kiloReady: true,
+      });
+      return;
+    }
+
+    if (request.operation === 'session.attach') {
+      expect(request.session).toEqual({ sessionId, kiloSessionId, directory });
+      sendResponse(control, request.requestId, { attached: true });
+      return;
+    }
+
+    if (request.operation === 'session.prompt') {
+      const payload = request.payload;
+      if (typeof payload !== 'object' || payload === null || !('messageId' in payload)) {
+        throw new Error('Invalid session prompt request');
+      }
+      sendResponse(control, request.requestId, {
+        messageId: payload.messageId,
+        status: 'accepted',
+      });
+      resolvePreparation?.();
+      return;
+    }
+
+    if (request.operation === 'session.terminal.create') {
+      expect(request.session).toEqual({ sessionId, kiloSessionId, directory });
+      sendResponse(control, request.requestId, { pty: terminalPty(ptyId, directory) });
+      return;
+    }
+
+    if (request.operation === 'session.terminal.resize') {
+      sendResponse(control, request.requestId, { pty: terminalPty(ptyId, directory) });
+      return;
+    }
+
+    if (request.operation === 'session.terminal.close') {
+      sendResponse(control, request.requestId, { success: true });
+      return;
+    }
+
+    if (request.operation === 'session.abort') {
+      sendResponse(control, request.requestId, { status: 'aborted' });
+      return;
+    }
+
+    if (request.operation === 'session.detach') {
+      sendResponse(control, request.requestId, { detached: true });
+      return;
+    }
+
+    if (request.operation !== 'session.terminal.connect') {
+      throw new Error(`Unexpected control operation: ${request.operation}`);
+    }
+
+    expect(request.session).toEqual({ sessionId, kiloSessionId, directory });
+    const payload = sessionTerminalConnectPayloadSchema.parse(request.payload);
+    expect(payload.ownerId).toBe(owner);
+    expect(payload.ptyId).toBe(ptyId);
+    const behavior = fixture.nextBehavior;
+    fixture.nextBehavior = {};
+    const unauthorizedStatuses: number[] = [];
+    const reverse = () =>
+      SELF.fetch(`${fixture.reverseUrl()}?ticket=producer-query-must-not-be-forwarded`, {
+        headers: {
+          Upgrade: 'websocket',
+          Authorization: `Bearer ${payload.capability}`,
+          Cookie: 'session=producer-cookie-must-not-be-forwarded',
+          'x-terminal-role': 'browser',
+        },
+      });
+
+    if (behavior.unauthorizedFirst) {
+      const unauthorized = await SELF.fetch(fixture.reverseUrl(), {
+        headers: {
+          Upgrade: 'websocket',
+          Authorization: `Bearer ${generateSandboxCredential()}`,
+        },
+      });
+      unauthorizedStatuses.push(unauthorized.status);
+    }
+
+    const responses = behavior.concurrentRedemption
+      ? await Promise.all([reverse(), reverse()])
+      : [await reverse()];
+    const accepted = responses.find(response => response.status === 101);
+    if (behavior.concurrentRedemption) {
+      unauthorizedStatuses.push(
+        ...responses.filter(response => response.status !== 101).map(response => response.status)
+      );
+    }
+    if (!accepted?.webSocket) throw new Error('Reverse terminal upgrade was rejected');
+
+    accepted.webSocket.binaryType = 'arraybuffer';
+    accepted.webSocket.accept();
+    const connection: TerminalConnection = {
+      payload,
+      socket: accepted.webSocket,
+      inbox: createSocketInbox(accepted.webSocket),
+      closed: nextClose(accepted.webSocket),
+      unauthorizedStatuses,
+    };
+    fixture.connections.push(connection);
+    if (behavior.initialOutput !== undefined) connection.socket.send(behavior.initialOutput);
+    sendResponse(control, request.requestId, { connected: true });
+  }
+
+  control.addEventListener('message', event => {
+    if (typeof event.data !== 'string') return;
+    const parsed = requestFrameSchema.safeParse(JSON.parse(event.data));
+    if (!parsed.success) return;
+    void respond(parsed.data).catch(error => {
+      fixture.errors.push(error instanceof Error ? error : new Error('Control response failed'));
+      if (control.readyState !== 1) return;
+      control.send(
+        JSON.stringify({
+          type: 'response',
+          requestId: parsed.data.requestId,
+          ok: false,
+          error: { code: 'not_ready', message: 'Test wrapper request failed', retryable: true },
+        })
+      );
+    });
+  });
+
+  control.send(
+    JSON.stringify({
+      type: 'event',
+      event: 'sandbox.ready',
+      payload: { kiloReady: true, globalFeedAttached: true },
+    })
+  );
+
+  await runInDurableObject(controlStub, instance =>
+    instance.request({ operation: 'sandbox.status', payload: {} })
+  );
+
+  await expect(
+    runInDurableObject(controlStub, instance => instance.getStatus())
+  ).resolves.toMatchObject({
+    connection: 'ready',
+    physical: 'running',
+    wrapperInstanceId,
+  });
+
+  const admission = await runInDurableObject(sessionStub, instance =>
+    instance.createSessionWithInitialAdmission({
+      identity: sessionIdentity,
+      auth: { kiloSessionId },
+      agent: { mode: 'code', model: 'test-model' },
+      workspace: { sandboxId, sandboxProvider: 'cloudflare' },
+      message: { initialTurn: { messageId: `msg_${identity}`, type: 'prompt' } },
+    })
+  );
+  if (!admission.success) throw new Error(`Session admission failed: ${admission.error}`);
+  await prepared;
+
+  const created = await runInDurableObject(sessionStub, instance =>
+    instance.createTerminal({ cols: 80, rows: 24 })
+  );
+  if (!created.success) throw new Error(`Terminal creation failed: ${created.error}`);
+  expect(created).toMatchObject({ success: true, data: { pty: { id: ptyId } } });
+  expect(fixture.errors).toEqual([]);
+  return fixture;
+}
+
+afterEach(async () => {
+  for (const fixture of fixtures) await fixture.dispose();
+  fixtures.clear();
+});
+
+describe('SandboxSession terminal bridge in the Workers runtime', () => {
+  it('pairs reentrant hibernating sockets and forwards native terminal frames', async () => {
+    const fixture = await createFixture();
+    const browser = await fixture.openBrowser({ initialOutput: 'initial output' });
+    const wrapper = fixture.connections[0];
+    expect(wrapper).toBeDefined();
+    if (!wrapper) throw new Error('Missing reverse terminal socket');
+    const session = getSandboxSessionStub(env, fixture.ownerId, fixture.sessionId);
+    const latestEventId = await runInDurableObject(session, instance =>
+      instance.getLatestEventId()
+    );
+
+    await expect(browser.inbox.next()).resolves.toBe('initial output');
+
+    browser.socket.send('browser input');
+    await expect(wrapper.inbox.next()).resolves.toBe('browser input');
+
+    wrapper.socket.send('wrapper output');
+    await expect(browser.inbox.next()).resolves.toBe('wrapper output');
+
+    browser.socket.send('ping');
+    await expect(wrapper.inbox.next()).resolves.toBe('ping');
+    wrapper.socket.send('pong');
+    await expect(browser.inbox.next()).resolves.toBe('pong');
+
+    const binary = new Uint8Array([0, 1, 127, 128, 255]);
+    browser.socket.send(binary);
+    const forwarded = await wrapper.inbox.next();
+    expect(forwarded).toBeInstanceOf(ArrayBuffer);
+    if (forwarded instanceof ArrayBuffer) {
+      expect(Array.from(new Uint8Array(forwarded))).toEqual(Array.from(binary));
+    }
+
+    const upstreamBinary = new Uint8Array([255, 128, 0]);
+    wrapper.socket.send(upstreamBinary);
+    const returned = await browser.inbox.next();
+    expect(returned).toBeInstanceOf(ArrayBuffer);
+    if (returned instanceof ArrayBuffer) {
+      expect(Array.from(new Uint8Array(returned))).toEqual(Array.from(upstreamBinary));
+    }
+
+    wrapper.socket.send('\u0000cursor-control');
+    await expect(browser.inbox.next()).resolves.toBe('\u0000cursor-control');
+
+    const attachments = await runInDurableObject(session, async (_instance, state) =>
+      state.getWebSockets('terminal').map(socket => ({
+        tags: state.getTags(socket),
+        attachment: socket.deserializeAttachment(),
+      }))
+    );
+    expect(attachments).toHaveLength(2);
+    expect(attachments).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          tags: ['terminal', `terminal:browser:${fixture.ptyId}`],
+          attachment: expect.objectContaining({
+            role: 'browser',
+            ptyId: fixture.ptyId,
+            bridgeGeneration: wrapper.payload.bridgeGeneration,
+            wrapperInstanceId: fixture.wrapperInstanceId,
+            lastActivityReportedAt: expect.any(Number),
+          }),
+        }),
+        expect.objectContaining({
+          tags: ['terminal', `terminal:wrapper:${fixture.ptyId}`],
+          attachment: expect.objectContaining({
+            role: 'wrapper',
+            ptyId: fixture.ptyId,
+            bridgeGeneration: wrapper.payload.bridgeGeneration,
+            wrapperInstanceId: fixture.wrapperInstanceId,
+            lastActivityReportedAt: expect.any(Number),
+          }),
+        }),
+      ])
+    );
+    for (const entry of attachments) {
+      expect(entry.attachment).not.toHaveProperty('capability');
+      expect(entry.attachment).not.toHaveProperty('capabilityHash');
+    }
+    await expect(
+      runInDurableObject(session, instance => instance.getLatestEventId())
+    ).resolves.toBe(latestEventId);
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('rejects unauthorized producers and atomically consumes concurrent capabilities', async () => {
+    const fixture = await createFixture();
+    const missingCredential = await SELF.fetch(fixture.reverseUrl(), {
+      headers: { Upgrade: 'websocket' },
+    });
+    expect(missingCredential.status).toBe(401);
+
+    await fixture.openBrowser({ unauthorizedFirst: true, concurrentRedemption: true });
+    const connection = fixture.connections[0];
+    if (!connection) throw new Error('Missing authenticated reverse socket');
+    expect(connection.unauthorizedStatuses).toEqual([401, 401]);
+
+    const replay = await SELF.fetch(fixture.reverseUrl(), {
+      headers: {
+        Upgrade: 'websocket',
+        Authorization: `Bearer ${connection.payload.capability}`,
+      },
+    });
+    expect(replay.status).toBe(401);
+
+    const wrongOwner = await SELF.fetch(
+      `http://worker.test/sandbox-terminal/${encodeURIComponent('user_wrong')}/${fixture.sessionId}/${fixture.ptyId}`,
+      {
+        headers: {
+          Upgrade: 'websocket',
+          Authorization: `Bearer ${connection.payload.capability}`,
+        },
+      }
+    );
+    expect(wrongOwner.status).toBe(401);
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('rejects PTYs owned by another workspace session for the same owner', async () => {
+    const first = await createFixture('user_shared_terminal_owner');
+    const second = await createFixture('user_shared_terminal_owner');
+    const query = new URLSearchParams({
+      ownerId: first.ownerId,
+      sessionId: first.sessionId,
+      ptyId: second.ptyId,
+    });
+    const denied = await SELF.fetch(`http://worker.test/terminal-test?${query.toString()}`, {
+      headers: { Upgrade: 'websocket' },
+    });
+    expect(denied.status).toBe(404);
+
+    const session = getSandboxSessionStub(env, first.ownerId, first.sessionId);
+    await expect(
+      runInDurableObject(session, instance =>
+        instance.resizeTerminal({ ptyId: second.ptyId, cols: 100, rows: 30 })
+      )
+    ).resolves.toMatchObject({ success: false });
+    expect(first.errors).toEqual([]);
+    expect(second.errors).toEqual([]);
+  });
+
+  it('reconnects the same PTY while fencing superseded browser and wrapper generations', async () => {
+    const fixture = await createFixture();
+    const first = await fixture.openBrowser();
+    const oldWrapper = fixture.connections[0];
+    if (!oldWrapper) throw new Error('Missing first reverse socket');
+
+    const second = await fixture.openBrowser();
+    const newWrapper = fixture.connections[1];
+    if (!newWrapper) throw new Error('Missing replacement reverse socket');
+
+    await expect(first.closed).resolves.toMatchObject({ code: 4000 });
+    await expect(oldWrapper.closed).resolves.toMatchObject({ code: 4000 });
+    expect(newWrapper.payload.bridgeGeneration).not.toBe(oldWrapper.payload.bridgeGeneration);
+    expect(newWrapper.payload.capability).not.toBe(oldWrapper.payload.capability);
+
+    second.socket.send('replacement input');
+    await expect(newWrapper.inbox.next()).resolves.toBe('replacement input');
+    newWrapper.socket.send('replacement output');
+    await expect(second.inbox.next()).resolves.toBe('replacement output');
+
+    const replay = await SELF.fetch(fixture.reverseUrl(), {
+      headers: {
+        Upgrade: 'websocket',
+        Authorization: `Bearer ${oldWrapper.payload.capability}`,
+      },
+    });
+    expect(replay.status).toBe(401);
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('reconnects a running PTY after the browser disconnects', async () => {
+    const fixture = await createFixture();
+    const first = await fixture.openBrowser();
+    const oldWrapper = fixture.connections[0];
+    if (!oldWrapper) throw new Error('Missing original reverse socket');
+
+    first.socket.close(1000, 'verification reconnect');
+    const [browserClose, wrapperClose] = await Promise.all([first.closed, oldWrapper.closed]);
+    expect(browserClose).toMatchObject({ code: 1000, reason: 'verification reconnect' });
+    expect(wrapperClose).toMatchObject({ code: 1000 });
+
+    const reconnected = await fixture.openBrowser();
+    const replacement = fixture.connections[1];
+    if (!replacement) throw new Error('Missing reconnected reverse socket');
+    reconnected.socket.send('shell still running');
+    await expect(replacement.inbox.next()).resolves.toBe('shell still running');
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('treats abnormal wrapper failures as retryable without ending the PTY', async () => {
+    const fixture = await createFixture();
+    const browser = await fixture.openBrowser();
+    const wrapper = fixture.connections[0];
+    if (!wrapper) throw new Error('Missing reverse socket');
+
+    wrapper.socket.close(1011, 'upstream disconnected');
+    await expect(browser.closed).resolves.toMatchObject({ code: 1011 });
+
+    const reconnected = await fixture.openBrowser();
+    const replacement = fixture.connections[1];
+    if (!replacement) throw new Error('Missing replacement reverse socket');
+    replacement.socket.send('upstream recovered');
+    await expect(reconnected.inbox.next()).resolves.toBe('upstream recovered');
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('revokes terminal sockets only for their matching organization', async () => {
+    const fixture = await createFixture('user_terminal_org', 'org_terminal');
+    const browser = await fixture.openBrowser();
+    const wrapper = fixture.connections[0];
+    if (!wrapper) throw new Error('Missing organization reverse socket');
+    const session = getSandboxSessionStub(env, fixture.ownerId, fixture.sessionId);
+
+    await expect(
+      runInDurableObject(session, instance => instance.closeOrgStreams('org_other'))
+    ).resolves.toBe(0);
+    browser.socket.send('organization still authorized');
+    await expect(wrapper.inbox.next()).resolves.toBe('organization still authorized');
+
+    await expect(
+      runInDurableObject(session, instance => instance.closeOrgStreams('org_terminal'))
+    ).resolves.toBe(0);
+    await expect(browser.closed).resolves.toMatchObject({
+      code: 1000,
+      reason: 'session access revoked',
+    });
+    await expect(wrapper.closed).resolves.toMatchObject({ code: 1000 });
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('closes and permanently fences terminal access when the session is deleted', async () => {
+    const fixture = await createFixture();
+    const browser = await fixture.openBrowser();
+    const wrapper = fixture.connections[0];
+    if (!wrapper) throw new Error('Missing deleted-session reverse socket');
+    const session = getSandboxSessionStub(env, fixture.ownerId, fixture.sessionId);
+
+    await runInDurableObject(session, instance => instance.deleteSession());
+    await expect(browser.closed).resolves.toMatchObject({
+      code: 1000,
+      reason: 'session access revoked',
+    });
+    await expect(wrapper.closed).resolves.toMatchObject({ code: 1000 });
+    await expect(
+      runInDurableObject(session, instance => instance.getMetadata())
+    ).resolves.toBeNull();
+    await expect(
+      runInDurableObject(env.SANDBOX_CONTROL.getByName(fixture.sandboxId), instance =>
+        instance.listRoutes()
+      )
+    ).resolves.toEqual([]);
+
+    const query = new URLSearchParams({
+      ownerId: fixture.ownerId,
+      sessionId: fixture.sessionId,
+      ptyId: fixture.ptyId,
+    });
+    const rejected = await SELF.fetch(`http://worker.test/terminal-test?${query.toString()}`, {
+      headers: { Upgrade: 'websocket' },
+    });
+    expect(rejected.status).toBe(404);
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('invalidates only terminal bridges belonging to the confirmed wrapper runtime', async () => {
+    const fixture = await createFixture();
+    const browser = await fixture.openBrowser();
+    const wrapper = fixture.connections[0];
+    if (!wrapper) throw new Error('Missing runtime-bound reverse socket');
+    const session = getSandboxSessionStub(env, fixture.ownerId, fixture.sessionId);
+
+    await runInDurableObject(session, instance =>
+      instance.invalidateTerminalRuntime({
+        sandboxId: fixture.sandboxId,
+        wrapperInstanceId: crypto.randomUUID(),
+        confirmed: true,
+      })
+    );
+    browser.socket.send('current runtime still active');
+    await expect(wrapper.inbox.next()).resolves.toBe('current runtime still active');
+
+    await runInDurableObject(session, instance =>
+      instance.invalidateTerminalRuntime({
+        sandboxId: fixture.sandboxId,
+        wrapperInstanceId: fixture.wrapperInstanceId,
+        confirmed: true,
+      })
+    );
+    await expect(browser.closed).resolves.toMatchObject({
+      code: 1000,
+      reason: 'PTY session ended',
+    });
+    await expect(wrapper.closed).resolves.toMatchObject({ code: 1000 });
+
+    const reconnect = await fixture.openBrowser();
+    await expect(reconnect.closed).resolves.toMatchObject({
+      code: 1000,
+      reason: 'PTY session ended',
+    });
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('preserves OAuth owner identities without decoding literal percent escapes twice', async () => {
+    const fixture = await createFixture('oauth/google:user%2Fsegment');
+    const browser = await fixture.openBrowser();
+    const wrapper = fixture.connections[0];
+    if (!wrapper) throw new Error('Missing OAuth reverse socket');
+
+    expect(wrapper.payload.ownerId).toBe('oauth/google:user%2Fsegment');
+    browser.socket.send('oauth terminal input');
+    await expect(wrapper.inbox.next()).resolves.toBe('oauth terminal input');
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('marks normally exited PTYs ended and closes authenticated reconnects normally', async () => {
+    const fixture = await createFixture();
+    const browser = await fixture.openBrowser();
+    const wrapper = fixture.connections[0];
+    if (!wrapper) throw new Error('Missing reverse socket');
+
+    wrapper.socket.send('final output');
+    wrapper.socket.close(1000, 'process exited');
+    await expect(browser.inbox.next()).resolves.toBe('final output');
+    await expect(browser.closed).resolves.toMatchObject({
+      code: 1000,
+      reason: 'PTY session ended',
+    });
+
+    const reconnect = await fixture.openBrowser();
+    await expect(reconnect.closed).resolves.toMatchObject({
+      code: 1000,
+      reason: 'PTY session ended',
+    });
+    expect(fixture.connections).toHaveLength(1);
+    expect(fixture.errors).toEqual([]);
+  });
+
+  it('closes oversized native frames without affecting another terminal generation', async () => {
+    const fixture = await createFixture();
+    const browser = await fixture.openBrowser();
+    const wrapper = fixture.connections[0];
+    if (!wrapper) throw new Error('Missing reverse socket');
+
+    browser.socket.send('x'.repeat(256 * 1024 + 1));
+    await expect(browser.closed).resolves.toMatchObject({ code: 1009 });
+    await expect(wrapper.closed).resolves.toMatchObject({ code: 1009 });
+    expect(fixture.errors).toEqual([]);
+  });
+});

--- a/services/cloud-agent-next/test/test-worker.ts
+++ b/services/cloud-agent-next/test/test-worker.ts
@@ -21,7 +21,9 @@ import type {
 } from '../src/notifications-binding.js';
 import { CloudAgentSession as RealCloudAgentSession } from '../src/persistence/CloudAgentSession';
 import { getSandboxControlStub, isSandboxControlId } from '../src/sandbox-control/stub';
-import { resolveSessionStub } from '../src/sandbox-session/session-stub';
+import { getSandboxSessionStub, resolveSessionStub } from '../src/sandbox-session/session-stub';
+import { SESSION_ID_RE } from '../src/shared/protocol.js';
+import { terminalPtyIdSchema } from '../src/shared/sandbox-control-protocol.js';
 import type { Env } from '../src/types';
 
 type RecordedPushCall = SendCloudAgentSessionNotificationParams;
@@ -86,6 +88,32 @@ function routeToUserKiloFacade(request: Request, env: TestEnv, userId: string): 
   return facade.fetch(new Request(request, { headers }));
 }
 
+function createTerminalUpgradeRequest(
+  request: Request,
+  role: 'browser' | 'wrapper',
+  ptyId: string
+): Request {
+  const url = new URL(request.url);
+  url.pathname = `/terminal/${role}`;
+  url.search = '';
+  url.searchParams.set('ptyId', ptyId);
+  const headers = new Headers({ Upgrade: 'websocket' });
+  if (role === 'wrapper') {
+    const authorization = request.headers.get('Authorization');
+    if (authorization !== null) headers.set('Authorization', authorization);
+  }
+  return new Request(url, { method: 'GET', headers });
+}
+
+function isTerminalRouteIdentity(ownerId: string, sessionId: string, ptyId: string): boolean {
+  return (
+    ownerId.length > 0 &&
+    sessionId.startsWith('workspace_') &&
+    SESSION_ID_RE.test(sessionId) &&
+    terminalPtyIdSchema.safeParse(ptyId).success
+  );
+}
+
 export default {
   async fetch(request: Request, env: TestEnv): Promise<Response> {
     const url = new URL(request.url);
@@ -100,6 +128,50 @@ export default {
         return new Response('Invalid sandboxId', { status: 400 });
       }
       return getSandboxControlStub(env, sandboxId).fetch(request);
+    }
+
+    if (url.pathname === '/terminal-test') {
+      if (request.headers.get('Upgrade')?.toLowerCase() !== 'websocket') {
+        return new Response('Expected WebSocket upgrade', { status: 426 });
+      }
+      const ownerId = url.searchParams.get('ownerId');
+      const sessionId = url.searchParams.get('sessionId');
+      const ptyId = url.searchParams.get('ptyId');
+      if (
+        ownerId === null ||
+        sessionId === null ||
+        ptyId === null ||
+        !isTerminalRouteIdentity(ownerId, sessionId, ptyId)
+      ) {
+        return new Response('Invalid terminal identity', { status: 400 });
+      }
+      return getSandboxSessionStub(env, ownerId, sessionId).fetch(
+        createTerminalUpgradeRequest(request, 'browser', ptyId)
+      );
+    }
+
+    if (url.pathname.startsWith('/sandbox-terminal/')) {
+      if (request.headers.get('Upgrade')?.toLowerCase() !== 'websocket') {
+        return new Response('Expected WebSocket upgrade', { status: 426 });
+      }
+      const segments = url.pathname.split('/');
+      if (segments.length !== 5 || !segments[2] || !segments[3] || !segments[4]) {
+        return new Response('Invalid terminal identity', { status: 400 });
+      }
+      let ownerId: string;
+      try {
+        ownerId = decodeURIComponent(segments[2]);
+      } catch {
+        return new Response('Invalid terminal identity', { status: 400 });
+      }
+      const sessionId = segments[3];
+      const ptyId = segments[4];
+      if (!isTerminalRouteIdentity(ownerId, sessionId, ptyId)) {
+        return new Response('Invalid terminal identity', { status: 400 });
+      }
+      return getSandboxSessionStub(env, ownerId, sessionId).fetch(
+        createTerminalUpgradeRequest(request, 'wrapper', ptyId)
+      );
     }
 
     if (url.pathname === '/stream') {

--- a/services/cloud-agent-next/test/unit/wrapper/kilo-api.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/kilo-api.test.ts
@@ -333,6 +333,40 @@ describe('createWrapperKiloClient PTY endpoints', () => {
     expect(requestedUrls[0]?.searchParams.get('directory')).toBe(workspacePath);
   });
 
+  it('resizes PTYs within an explicitly supplied session directory', async () => {
+    const sessionDirectory = '/workspace/control-session';
+    const requestedUrls: URL[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(input => {
+        const requestUrl = input instanceof Request ? input.url : String(input);
+        requestedUrls.push(new URL(requestUrl));
+        return Promise.resolve(
+          new Response(
+            JSON.stringify({
+              id: 'pty_resize_control',
+              title: 'Workspace terminal',
+              command: '/bin/bash',
+              args: [],
+              cwd: sessionDirectory,
+              status: 'running',
+              pid: 43,
+            }),
+            { status: 200, headers: { 'content-type': 'application/json' } }
+          )
+        );
+      })
+    );
+
+    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0', workspacePath);
+
+    await client.resizePty('pty_resize_control', { cols: 100, rows: 35 }, sessionDirectory);
+
+    expect(requestedUrls).toHaveLength(1);
+    expect(requestedUrls[0]?.pathname).toBe('/pty/pty_resize_control');
+    expect(requestedUrls[0]?.searchParams.get('directory')).toBe(sessionDirectory);
+  });
+
   it('deletes PTYs within the configured workspace directory', async () => {
     const requestedUrls: URL[] = [];
     vi.stubGlobal(
@@ -355,5 +389,31 @@ describe('createWrapperKiloClient PTY endpoints', () => {
 
     expect(requestedUrls).toHaveLength(1);
     expect(requestedUrls[0]?.searchParams.get('directory')).toBe(workspacePath);
+  });
+
+  it('deletes PTYs within an explicitly supplied session directory', async () => {
+    const sessionDirectory = '/workspace/another-control-session';
+    const requestedUrls: URL[] = [];
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(input => {
+        const requestUrl = input instanceof Request ? input.url : String(input);
+        requestedUrls.push(new URL(requestUrl));
+        return Promise.resolve(
+          new Response(JSON.stringify(true), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          })
+        );
+      })
+    );
+
+    const client = createWrapperKiloClient(createSdkClient(), 'http://127.0.0.1:0', workspacePath);
+
+    await client.deletePty('pty_delete_control', sessionDirectory);
+
+    expect(requestedUrls).toHaveLength(1);
+    expect(requestedUrls[0]?.pathname).toBe('/pty/pty_delete_control');
+    expect(requestedUrls[0]?.searchParams.get('directory')).toBe(sessionDirectory);
   });
 });

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'bun:test';
 import { applySessionAttach } from './apply-attach';
 import type { WrapperKiloClient } from '../kilo-api';
 import type { PreparingEventDataV2 } from '../../../src/shared/protocol.js';
+import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../../../src/shared/runtime-environment.js';
 
 const session = {
   sessionId: 'workspace_1',
@@ -356,6 +357,62 @@ describe('applySessionAttach', () => {
     expect(ensured).toEqual([[session.kiloSessionId, session.directory]]);
   });
 
+  it('creates an empty shell for an explicitly identified empty session export', async () => {
+    const ensured: Array<[string, string]> = [];
+    const result = await applySessionAttach(
+      session,
+      {},
+      {
+        kiloClient: fakeKilo({
+          ensureSession: async (sessionId, directory) => {
+            ensured.push([sessionId, directory]);
+          },
+        }),
+        sessionExists: async () => false,
+        restoreSession: async () => ({
+          ok: false,
+          error:
+            'snapshot missing info.id (42 bytes); session-ingest may have returned an error body',
+          code: null,
+          step: 'download',
+          emptySnapshot: true,
+        }),
+        ...noFs,
+      }
+    );
+
+    expect(result).toEqual({ ok: true, result: { attached: true } });
+    expect(ensured).toEqual([[session.kiloSessionId, session.directory]]);
+  });
+
+  it('fails attach when snapshot metadata is missing without an empty-export marker', async () => {
+    let ensured = false;
+    const result = await applySessionAttach(
+      session,
+      {},
+      {
+        kiloClient: fakeKilo({
+          ensureSession: async () => {
+            ensured = true;
+          },
+        }),
+        sessionExists: async () => false,
+        restoreSession: async () => ({
+          ok: false,
+          error:
+            'snapshot missing info.id (42 bytes); session-ingest may have returned an error body',
+          code: null,
+          step: 'download',
+        }),
+        ...noFs,
+      }
+    );
+
+    expect(result.ok).toBe(false);
+    if (!result.ok) expect(result.error.code).toBe('not_ready');
+    expect(ensured).toBe(false);
+  });
+
   it('fails attach when restore fails with a non-404', async () => {
     let ensured = false;
     const result = await applySessionAttach(
@@ -458,4 +515,52 @@ describe('applySessionAttach', () => {
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe('protocol_error');
   });
+
+  for (const key of CONTROL_RUNTIME_RESERVED_ENV_VARS) {
+    it(`rejects ${key} before preparation, filesystem, or subprocess side effects`, async () => {
+      const sideEffects: string[] = [];
+      const sensitiveValue = 'must-not-appear-in-error';
+      const result = await applySessionAttach(
+        session,
+        {
+          env: { [key]: sensitiveValue },
+          git: { url: 'https://github.com/acme/demo.git' },
+          setupCommands: ['pnpm install'],
+          preparation: { attemptId: 'att_1', triggerMessageId: 'msg_1' },
+        },
+        {
+          kiloClient: fakeKilo(),
+          hasBootstrapMarker: async () => {
+            sideEffects.push('bootstrap');
+            return false;
+          },
+          mkdir: async () => {
+            sideEffects.push('mkdir');
+          },
+          runGit: async () => {
+            sideEffects.push('git');
+            return { stdout: '', stderr: '', exitCode: 0 };
+          },
+          runSetup: async () => {
+            sideEffects.push('setup');
+            return { stdout: '', stderr: '', exitCode: 0 };
+          },
+          emitPreparing: () => {
+            sideEffects.push('preparing');
+          },
+        }
+      );
+
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          code: 'protocol_error',
+          message: 'Reserved control runtime environment variable',
+          retryable: false,
+        },
+      });
+      expect(sideEffects).toEqual([]);
+      expect(JSON.stringify(result)).not.toContain(sensitiveValue);
+    });
+  }
 });

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
@@ -6,6 +6,7 @@ import {
   type SessionRequestIdentity,
 } from '../../../src/shared/sandbox-control-protocol.js';
 import type { PreparingEventDataV2, PreparingStep } from '../../../src/shared/protocol.js';
+import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../../../src/shared/runtime-environment.js';
 import { git, isTimeoutTermination, logToFile, runProcess, type ExecResult } from '../utils.js';
 import { rememberAttachedRoot, rememberSessionDirectory } from './session-directories';
 import { authenticatedGitUrl } from './git-url';
@@ -174,6 +175,14 @@ export async function applySessionAttach(
     return fail('protocol_error', 'Invalid payload', false);
   }
   const attach = parsed.data;
+  const environment = attach.env;
+  if (
+    environment &&
+    CONTROL_RUNTIME_RESERVED_ENV_VARS.some(key => Object.hasOwn(environment, key))
+  ) {
+    return fail('protocol_error', 'Reserved control runtime environment variable', false);
+  }
+
   const directory = attach.directory ?? session.directory;
   const mkdir = deps.mkdir ?? (dir => fs.mkdir(dir, { recursive: true }).then(() => undefined));
   const hasGit = deps.hasGit ?? defaultHasGit;
@@ -267,7 +276,7 @@ export async function applySessionAttach(
         logToFile(`session.attach ready directory=${directory}`);
         return ok();
       }
-      if (restored.code !== 404) {
+      if (restored.code !== 404 && !restored.emptySnapshot) {
         progress.fail('kilo_session', 'phase:kilo_session', restored.error);
         return fail('not_ready', 'kilo session is not ready', true);
       }

--- a/services/cloud-agent-next/wrapper/src/control/main.ts
+++ b/services/cloud-agent-next/wrapper/src/control/main.ts
@@ -6,7 +6,10 @@ import { CONTROL_PLANE_SANDBOX_PERMISSION } from '../../../src/shared/control-pl
 import { WRAPPER_VERSION } from '../../../src/shared/wrapper-version.js';
 import { createWrapperKiloClient } from '../kilo-api.js';
 import { logToFile } from '../utils.js';
-import { maybeStartSandboxControlClient } from './sandbox-control-runtime';
+import {
+  maybeStartSandboxControlClient,
+  startSandboxControlEventFeed,
+} from './sandbox-control-runtime';
 import {
   buildHeartbeatPayload,
   handleControlRequest,
@@ -21,6 +24,7 @@ import {
   updateSessionSnapshots,
 } from './feed';
 import { rememberChildSession } from './session-directories';
+import { createControlTerminalRuntime } from './terminal-runtime';
 
 const KILO_STARTUP_TIMEOUT_MS = 30_000;
 
@@ -36,6 +40,14 @@ function writeKiloAuthFromEnv(): void {
 }
 
 async function main(): Promise<void> {
+  const controlConfig = {
+    SANDBOX_CONTROL_URL: process.env.SANDBOX_CONTROL_URL,
+    SANDBOX_CONTROL_CREDENTIAL: process.env.SANDBOX_CONTROL_CREDENTIAL,
+    PROVIDER_INSTANCE_ID: process.env.PROVIDER_INSTANCE_ID,
+    wrapperInstanceId: crypto.randomUUID(),
+  };
+  delete process.env.SANDBOX_CONTROL_CREDENTIAL;
+
   logToFile(`control-plane wrapper ${WRAPPER_VERSION} starting`);
   writeKiloAuthFromEnv();
 
@@ -49,23 +61,95 @@ async function main(): Promise<void> {
     },
   });
   const kiloClient = createWrapperKiloClient(result.client, result.server.url, '/');
+  const terminalRuntime = controlConfig.SANDBOX_CONTROL_URL
+    ? createControlTerminalRuntime({
+        controlUrl: controlConfig.SANDBOX_CONTROL_URL,
+        wrapperInstanceId: controlConfig.wrapperInstanceId,
+        kiloClient,
+      })
+    : undefined;
   logToFile(`kilo server started at ${result.server.url}`);
 
   const sessions: HandlerSessionSnapshot[] = [];
-
+  const abort = new AbortController();
   let control: ReturnType<typeof maybeStartSandboxControlClient> = null;
-  control = maybeStartSandboxControlClient(process.env, logToFile, {
+  let kiloReady = false;
+  let shuttingDown = false;
+
+  const shutdown = (exitCode: number): void => {
+    if (shuttingDown) return;
+    shuttingDown = true;
+    kiloReady = false;
+    abort.abort();
+    terminalRuntime?.shutdown();
+    control?.close();
+    result.server.close();
+    process.exit(exitCode);
+  };
+  process.once('SIGTERM', () => shutdown(0));
+  process.once('SIGINT', () => shutdown(0));
+
+  try {
+    await startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: signal => result.client.global.event({ signal, sseMaxRetryAttempts: 1 }),
+      consume: async stream => {
+        for await (const event of unfilteredKiloEvents(stream)) {
+          const permId = permissionAskId(event);
+          if (event.type === 'permission.asked') {
+            if (permId) {
+              logToFile(`auto-approving permission ${permId}`);
+              kiloClient.answerPermission(permId, 'always').catch(err => {
+                logToFile(
+                  `failed to auto-approve permission ${permId}: ${err instanceof Error ? err.message : String(err)}`
+                );
+              });
+            }
+            continue;
+          }
+          if (event.type === 'session.created') {
+            const child = childFromSessionCreated(event.properties);
+            if (child) rememberChildSession(child);
+          }
+          updateSessionSnapshots(event, sessions);
+          const kiloSessionId = eventKiloSessionId(event.properties);
+          const identity = sessionEventIdentity({
+            sessionId: kiloSessionId,
+            directory: event.directory,
+          });
+          control?.sendEvent?.(
+            'session.event',
+            { type: event.type, properties: event.properties },
+            identity
+          );
+        }
+      },
+      onUnexpectedClose: () => {
+        logToFile('control-plane Kilo event feed closed unexpectedly');
+        shutdown(1);
+      },
+    });
+  } catch {
+    logToFile('control-plane Kilo event feed failed to start');
+    shutdown(1);
+    return;
+  }
+
+  kiloReady = true;
+  control = maybeStartSandboxControlClient(controlConfig, logToFile, {
     wrapperVersion: WRAPPER_VERSION,
+    isReady: () => kiloReady && !abort.signal.aborted,
     onRequest: (operation, session, payload) =>
       handleControlRequest(operation, session, payload, {
         kiloClient,
         version: WRAPPER_VERSION,
-        kiloReady: true,
+        kiloReady,
         getStatus: () => ({
           state: sessions.some(item => item.state !== 'idle') ? 'active' : 'idle',
           pendingMessages: [],
         }),
         sessions,
+        ...(terminalRuntime ? { terminalRuntime } : {}),
         emitPreparing: event => {
           if (!session) return;
           control?.sendEvent?.('session.preparing', event, {
@@ -79,7 +163,7 @@ async function main(): Promise<void> {
       buildHeartbeatPayload({
         kiloClient,
         version: WRAPPER_VERSION,
-        kiloReady: true,
+        kiloReady,
         getStatus: () => ({
           state: sessions.some(item => item.state !== 'idle') ? 'active' : 'idle',
           pendingMessages: [],
@@ -87,55 +171,6 @@ async function main(): Promise<void> {
         sessions,
       }),
   });
-
-  const abort = new AbortController();
-  const feed = await result.client.global.event({ signal: abort.signal }).catch(() => undefined);
-  if (feed?.stream) {
-    void (async () => {
-      for await (const event of unfilteredKiloEvents(feed.stream)) {
-        const permId = permissionAskId(event);
-        if (event.type === 'permission.asked') {
-          if (permId) {
-            logToFile(`auto-approving permission ${permId}`);
-            kiloClient.answerPermission(permId, 'always').catch(err => {
-              logToFile(
-                `failed to auto-approve permission ${permId}: ${err instanceof Error ? err.message : String(err)}`
-              );
-            });
-          }
-          continue;
-        }
-        if (event.type === 'session.created') {
-          const child = childFromSessionCreated(event.properties);
-          if (child) rememberChildSession(child);
-        }
-        updateSessionSnapshots(event, sessions);
-        const kiloSessionId = eventKiloSessionId(event.properties);
-        const identity = sessionEventIdentity({
-          sessionId: kiloSessionId,
-          directory: event.directory,
-        });
-        control?.sendEvent?.(
-          'session.event',
-          { type: event.type, properties: event.properties },
-          identity
-        );
-      }
-    })().catch(error => {
-      logToFile(
-        `control-plane feed closed: ${error instanceof Error ? error.message : 'unknown error'}`
-      );
-    });
-  }
-
-  const shutdown = () => {
-    abort.abort();
-    control?.close();
-    result.server.close();
-    process.exit(0);
-  };
-  process.on('SIGTERM', shutdown);
-  process.on('SIGINT', shutdown);
 
   logToFile(`control-plane wrapper ready callHome=${Boolean(control)}`);
 }

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { createSandboxControlClient } from './sandbox-control-client';
+import {
+  createSandboxControlClient,
+  type SandboxControlClientOptions,
+} from './sandbox-control-client';
 
 class FakeWebSocket {
   readyState = 0;
@@ -102,6 +105,29 @@ describe('createSandboxControlClient', () => {
     );
     client.close();
     expect(fake.readyState).toBe(3);
+  });
+
+  it('includes the wrapper process instance in sandbox.hello without exposing the credential', async () => {
+    const fake = new FakeWebSocket();
+    const wrapperInstanceId = crypto.randomUUID();
+    const client = createSandboxControlClient({
+      url: 'wss://example.test/sandbox-control/sbx_1',
+      credential: 'master-control-secret',
+      providerInstanceId: 'inst_1',
+      wrapperInstanceId,
+      openWebSocket: () => fake as unknown as WebSocket,
+    });
+
+    const connecting = client.connect();
+    await handshake(fake);
+    await connecting;
+
+    expect(JSON.parse(fake.sent[0] ?? '{}')).toMatchObject({
+      operation: 'sandbox.hello',
+      payload: { providerInstanceId: 'inst_1', wrapperInstanceId },
+    });
+    expect(fake.sent[0]).not.toContain('master-control-secret');
+    client.close();
   });
 
   it('answers inbound sandbox.status after handshake when onRequest is provided', async () => {
@@ -224,13 +250,15 @@ describe('createSandboxControlClient', () => {
     client.close();
   });
 
-  it('opens a second socket after close and completes hello plus status again', async () => {
+  it('retains its original wrapper process instance across socket reconnects', async () => {
     const sockets: FakeWebSocket[] = [];
+    const wrapperInstanceId = crypto.randomUUID();
     let reconnects = 0;
-    const client = createSandboxControlClient({
+    const options: SandboxControlClientOptions = {
       url: 'wss://example.test/sandbox-control/sbx_1',
       credential: 'secret',
       providerInstanceId: 'inst_1',
+      wrapperInstanceId,
       reconnectDelayMs: () => 0,
       onReconnect: () => {
         reconnects += 1;
@@ -240,19 +268,27 @@ describe('createSandboxControlClient', () => {
         sockets.push(next);
         return next as unknown as WebSocket;
       },
-    });
+    };
+    const client = createSandboxControlClient(options);
 
     const connecting = client.connect();
     await handshake(sockets[0]);
     await connecting;
     expect(reconnects).toBe(0);
+    expect(JSON.parse(sockets[0]?.sent[0] ?? '{}')).toMatchObject({
+      payload: { wrapperInstanceId },
+    });
 
+    options.wrapperInstanceId = crypto.randomUUID();
     sockets[0]?.close();
     await waitForReconnect();
     expect(sockets).toHaveLength(2);
     await handshake(sockets[1]);
     expect(reconnects).toBe(1);
-    expect(sockets[1]?.sent[0]).toContain('sandbox.hello');
+    expect(JSON.parse(sockets[1]?.sent[0] ?? '{}')).toMatchObject({
+      operation: 'sandbox.hello',
+      payload: { wrapperInstanceId },
+    });
     client.close();
   });
 
@@ -406,6 +442,52 @@ describe('createSandboxControlClient', () => {
       type: 'event',
       event: 'sandbox.ready',
     });
+    client.close();
+  });
+
+  it('does not log credentials included in an untrusted handshake failure', async () => {
+    const credential = 'super-secret-token';
+    const logs: string[] = [];
+    const sockets: FakeWebSocket[] = [];
+    const client = createSandboxControlClient({
+      url: 'wss://example.test/sandbox-control/sbx_1?token=signed-url-secret',
+      credential,
+      providerInstanceId: 'inst_1',
+      reconnectDelayMs: () => 0,
+      log: message => logs.push(message),
+      openWebSocket: () => {
+        const next = new FakeWebSocket();
+        sockets.push(next);
+        return next as unknown as WebSocket;
+      },
+    });
+
+    const connecting = client.connect();
+    await Promise.resolve();
+    const first = sockets[0];
+    if (!first) throw new Error('missing first socket');
+    first.open();
+    await Promise.resolve();
+    const hello = JSON.parse(first.sent[0] ?? '{}') as { requestId: string };
+    first.respond(
+      JSON.stringify({
+        type: 'response',
+        requestId: hello.requestId,
+        ok: false,
+        error: {
+          code: 'unauthorized',
+          message: `rejected ${credential} signed-url-secret`,
+          retryable: true,
+        },
+      })
+    );
+    await waitForReconnect();
+    await handshake(sockets[1]);
+    await connecting;
+
+    expect(logs.join('\n')).not.toContain(credential);
+    expect(logs.join('\n')).not.toContain('signed-url-secret');
+    expect(logs).toContain('sandbox control connect failed');
     client.close();
   });
 

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-client.ts
@@ -24,6 +24,7 @@ export type SandboxControlClientOptions = {
   url: string;
   credential: string;
   providerInstanceId: string;
+  wrapperInstanceId?: string;
   wrapperVersion?: string;
   openWebSocket?: (url: string, credential: string) => WebSocket;
   onRequest?: SandboxControlRequestHandler;
@@ -61,6 +62,7 @@ function defaultReconnectDelayMs(attempt: number): number {
 export function createSandboxControlClient(
   options: SandboxControlClientOptions
 ): SandboxControlClient {
+  const wrapperInstanceId = options.wrapperInstanceId;
   let socket: WebSocket | null = null;
   let keepalive: ReturnType<typeof setInterval> | null = null;
   let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
@@ -158,6 +160,7 @@ export function createSandboxControlClient(
         payload: {
           protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
           providerInstanceId: options.providerInstanceId,
+          ...(wrapperInstanceId ? { wrapperInstanceId } : {}),
           ...(options.wrapperVersion ? { wrapperVersion: options.wrapperVersion } : {}),
         },
       };
@@ -179,11 +182,10 @@ export function createSandboxControlClient(
       } else {
         settleFirstSuccess();
       }
-    } catch (error) {
+    } catch {
       discardSocket(ws);
       if (shutDown || gen !== generation) return;
-      const message = error instanceof Error ? error.message : 'connect failed';
-      options.log?.(`sandbox control connect failed: ${message}`);
+      options.log?.('sandbox control connect failed');
       armReconnect('connect failed');
     } finally {
       connectInFlight = false;

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -1,10 +1,12 @@
 import { describe, expect, it } from 'bun:test';
-import type { WrapperKiloClient } from '../kilo-api';
+import type { WrapperKiloClient, WrapperPty } from '../kilo-api';
+import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../../../src/shared/runtime-environment.js';
 import {
   buildHeartbeatPayload,
   handleControlRequest,
   type HandlerDeps,
 } from './sandbox-control-handlers';
+import { ControlTerminalRuntimeError, type ControlTerminalRuntime } from './terminal-runtime';
 
 const session = {
   sessionId: 'ses_1',
@@ -36,6 +38,31 @@ function deps(overrides: Partial<HandlerDeps> = {}): HandlerDeps {
     kiloReady: true,
     getStatus: () => ({ state: 'idle', pendingMessages: [] }),
     sessions: [],
+    ...overrides,
+  };
+}
+
+const pty: WrapperPty = {
+  id: 'pty_1',
+  title: 'Workspace terminal',
+  command: '/bin/bash',
+  args: [],
+  cwd: session.directory,
+  status: 'running',
+  pid: 17,
+};
+
+function fakeTerminalRuntime(
+  overrides: Partial<ControlTerminalRuntime> = {}
+): ControlTerminalRuntime {
+  return {
+    rememberAttachedSession: () => {},
+    detachSession: async () => {},
+    create: async () => ({ pty }),
+    resize: async () => ({ pty }),
+    close: async () => ({ success: true }),
+    connect: async () => ({ connected: true }),
+    shutdown: () => {},
     ...overrides,
   };
 }
@@ -142,6 +169,91 @@ describe('handleControlRequest', () => {
     expect(result).toEqual({ ok: true, result: { attached: true } });
   });
 
+  it('registers terminal eligibility only after successful session attachment', async () => {
+    const attached: unknown[] = [];
+    const terminalRuntime = fakeTerminalRuntime({
+      rememberAttachedSession: identity => attached.push(identity),
+    });
+
+    const request = handleControlRequest('session.attach', session, {}, deps({ terminalRuntime }));
+    expect(attached).toEqual([]);
+
+    expect(await request).toEqual({ ok: true, result: { attached: true } });
+    expect(attached).toEqual([session]);
+
+    const failed = await handleControlRequest(
+      'session.attach',
+      { ...session, sessionId: 'ses_missing', kiloSessionId: 'kilo_missing' },
+      {},
+      deps({ kiloClient: undefined, terminalRuntime })
+    );
+    expect(failed.ok).toBe(false);
+    expect(attached).toEqual([session]);
+  });
+
+  it('keeps mismatched attachment roots ineligible without breaking chat attachment', async () => {
+    const attached: unknown[] = [];
+    const terminalRuntime = fakeTerminalRuntime({
+      rememberAttachedSession: identity => attached.push(identity),
+    });
+
+    const result = await handleControlRequest(
+      'session.attach',
+      session,
+      { snapshotIdentity: 'kilo_other' },
+      deps({ terminalRuntime })
+    );
+
+    expect(result).toEqual({ ok: true, result: { attached: true } });
+    expect(attached).toEqual([]);
+  });
+
+  it('keeps mismatched attachment directories ineligible without breaking chat attachment', async () => {
+    const attached: unknown[] = [];
+    const terminalRuntime = fakeTerminalRuntime({
+      rememberAttachedSession: identity => attached.push(identity),
+    });
+
+    const result = await handleControlRequest(
+      'session.attach',
+      session,
+      { directory: '/workspace/different' },
+      deps({ terminalRuntime })
+    );
+
+    expect(result).toEqual({ ok: true, result: { attached: true } });
+    expect(attached).toEqual([]);
+  });
+
+  it('rejects reserved control environment values before attachment starts', async () => {
+    let kiloRequests = 0;
+    const kiloClient = fakeKilo({
+      getSession: async id => {
+        kiloRequests += 1;
+        return { id };
+      },
+    });
+
+    for (const name of CONTROL_RUNTIME_RESERVED_ENV_VARS) {
+      const result = await handleControlRequest(
+        'session.attach',
+        session,
+        { env: { [name]: 'sensitive-value' } },
+        deps({ kiloClient })
+      );
+      expect(result).toEqual({
+        ok: false,
+        error: {
+          code: 'protocol_error',
+          message: 'Reserved control runtime environment variable',
+          retryable: false,
+        },
+      });
+    }
+
+    expect(kiloRequests).toBe(0);
+  });
+
   it('resolves a pending permission', async () => {
     const answered: unknown[] = [];
     const kiloClient = fakeKilo({
@@ -173,6 +285,198 @@ describe('handleControlRequest', () => {
     const result = await handleControlRequest('session.abort', session, {}, deps({ kiloClient }));
     expect(result).toEqual({ ok: true, result: { status: 'aborted' } });
     expect(aborted).toEqual(['kilo_1']);
+  });
+
+  it('routes validated terminal lifecycle requests to the exact session', async () => {
+    const calls: Array<{ operation: string; identity: unknown; payload: unknown }> = [];
+    const terminalRuntime = fakeTerminalRuntime({
+      create: async (identity, payload) => {
+        calls.push({ operation: 'create', identity, payload });
+        return { pty };
+      },
+      resize: async (identity, payload) => {
+        calls.push({ operation: 'resize', identity, payload });
+        return { pty };
+      },
+      close: async (identity, payload) => {
+        calls.push({ operation: 'close', identity, payload });
+        return { success: true };
+      },
+      connect: async (identity, payload) => {
+        calls.push({ operation: 'connect', identity, payload });
+        return { connected: true };
+      },
+    });
+    const createPayload = {
+      operationId: '00000000-0000-4000-8000-000000000001',
+      cols: 120,
+      rows: 35,
+    };
+    const resizePayload = { ptyId: pty.id, cols: 100, rows: 30 };
+    const closePayload = { ptyId: pty.id };
+    const connectPayload = {
+      ownerId: 'oauth/google:account%2Fsegment',
+      ptyId: pty.id,
+      bridgeGeneration: '00000000-0000-4000-8000-000000000002',
+      capability: 'a'.repeat(64),
+    };
+    const handlerDeps = deps({ terminalRuntime });
+
+    expect(
+      await handleControlRequest('session.terminal.create', session, createPayload, handlerDeps)
+    ).toEqual({ ok: true, result: { pty } });
+    expect(
+      await handleControlRequest('session.terminal.resize', session, resizePayload, handlerDeps)
+    ).toEqual({ ok: true, result: { pty } });
+    expect(
+      await handleControlRequest('session.terminal.close', session, closePayload, handlerDeps)
+    ).toEqual({ ok: true, result: { success: true } });
+    expect(
+      await handleControlRequest('session.terminal.connect', session, connectPayload, handlerDeps)
+    ).toEqual({ ok: true, result: { connected: true } });
+    expect(calls).toEqual([
+      { operation: 'create', identity: session, payload: createPayload },
+      { operation: 'resize', identity: session, payload: resizePayload },
+      { operation: 'close', identity: session, payload: closePayload },
+      { operation: 'connect', identity: session, payload: connectPayload },
+    ]);
+  });
+
+  it('rejects malformed terminal payloads and caller-controlled destinations', async () => {
+    const terminalRuntime = fakeTerminalRuntime();
+    const invalidPayloads: Array<[string, unknown]> = [
+      ['session.terminal.create', { operationId: 'not-a-uuid', cols: 120, rows: 30 }],
+      [
+        'session.terminal.create',
+        { operationId: '00000000-0000-4000-8000-000000000001', cols: 120 },
+      ],
+      ['session.terminal.resize', { ptyId: '../other', cols: 120, rows: 30 }],
+      ['session.terminal.resize', { ptyId: pty.id, cols: 501, rows: 30 }],
+      ['session.terminal.close', { ptyId: pty.id, unexpected: true }],
+      [
+        'session.terminal.connect',
+        {
+          ownerId: 'owner',
+          ptyId: pty.id,
+          bridgeGeneration: '00000000-0000-4000-8000-000000000002',
+          capability: 'a'.repeat(64),
+          url: 'wss://untrusted.example/steal',
+        },
+      ],
+    ];
+
+    for (const [operation, payload] of invalidPayloads) {
+      expect(
+        await handleControlRequest(operation, session, payload, deps({ terminalRuntime }))
+      ).toEqual({
+        ok: false,
+        error: { code: 'protocol_error', message: 'Invalid payload', retryable: false },
+      });
+    }
+  });
+
+  it('returns safe terminal ownership errors without leaking unexpected failures', async () => {
+    const payload = { ptyId: pty.id, cols: 100, rows: 30 };
+    const ownedFailure = await handleControlRequest(
+      'session.terminal.resize',
+      session,
+      payload,
+      deps({
+        terminalRuntime: fakeTerminalRuntime({
+          resize: async () => {
+            throw new ControlTerminalRuntimeError(
+              'unauthorized',
+              'Terminal ownership mismatch',
+              false
+            );
+          },
+        }),
+      })
+    );
+    expect(ownedFailure).toEqual({
+      ok: false,
+      error: { code: 'unauthorized', message: 'Terminal ownership mismatch', retryable: false },
+    });
+
+    const unexpectedFailure = await handleControlRequest(
+      'session.terminal.resize',
+      session,
+      payload,
+      deps({
+        terminalRuntime: fakeTerminalRuntime({
+          resize: async () => {
+            throw new Error('sensitive-capability-value');
+          },
+        }),
+      })
+    );
+    expect(unexpectedFailure).toEqual({
+      ok: false,
+      error: { code: 'not_ready', message: 'Terminal request failed', retryable: false },
+    });
+  });
+
+  it('rejects invalid terminal runtime results', async () => {
+    const result = await handleControlRequest(
+      'session.terminal.connect',
+      session,
+      {
+        ownerId: 'owner',
+        ptyId: pty.id,
+        bridgeGeneration: '00000000-0000-4000-8000-000000000002',
+        capability: 'a'.repeat(64),
+      },
+      deps({
+        terminalRuntime: fakeTerminalRuntime({
+          connect: async () => {
+            const result: { connected: true } = { connected: true };
+            Reflect.set(result, 'connected', false);
+            return result;
+          },
+        }),
+      })
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'protocol_error', message: 'Invalid terminal result', retryable: false },
+    });
+  });
+
+  it('cleans up only the detached session and shuts down on sandbox shutdown', async () => {
+    const detached: unknown[] = [];
+    let shutdowns = 0;
+    const terminalRuntime = fakeTerminalRuntime({
+      detachSession: async identity => {
+        detached.push(identity);
+      },
+      shutdown: () => {
+        shutdowns += 1;
+      },
+    });
+
+    expect(
+      await handleControlRequest('session.detach', session, {}, deps({ terminalRuntime }))
+    ).toEqual({ ok: true, result: { detached: true } });
+    expect(
+      await handleControlRequest('sandbox.shutdown', undefined, {}, deps({ terminalRuntime }))
+    ).toEqual({ ok: true, result: { shuttingDown: true } });
+    expect(detached).toEqual([session]);
+    expect(shutdowns).toBe(1);
+  });
+
+  it('rejects terminal operations when the runtime is unavailable', async () => {
+    const result = await handleControlRequest(
+      'session.terminal.close',
+      session,
+      { ptyId: pty.id },
+      deps()
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'not_ready', message: 'Terminal is not available', retryable: false },
+    });
   });
 
   it('rejects unknown operations', async () => {

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
@@ -1,13 +1,25 @@
 import {
   SESSION_OPERATIONS,
+  sessionAttachPayloadSchema,
+  sessionDetachPayloadSchema,
   sessionPermissionResolvePayloadSchema,
   sessionPromptPayloadSchema,
   sessionQuestionResolvePayloadSchema,
+  sessionTerminalClosePayloadSchema,
+  sessionTerminalCloseResultSchema,
+  sessionTerminalConnectPayloadSchema,
+  sessionTerminalConnectResultSchema,
+  sessionTerminalCreatePayloadSchema,
+  sessionTerminalCreateResultSchema,
+  sessionTerminalResizePayloadSchema,
+  sessionTerminalResizeResultSchema,
   type SandboxHeartbeatPayload,
   type SessionRequestIdentity,
 } from '../../../src/shared/sandbox-control-protocol.js';
+import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../../../src/shared/runtime-environment.js';
 import { isKiloServerUnreachableError, type WrapperKiloClient } from '../kilo-api.js';
 import { applySessionAttach, type AttachPreparingEmitter } from './apply-attach';
+import { ControlTerminalRuntimeError, type ControlTerminalRuntime } from './terminal-runtime.js';
 
 export type HandlerSessionSnapshot = {
   kiloSessionId: string;
@@ -23,6 +35,7 @@ export type HandlerDeps = {
   getStatus: () => { state: 'idle' | 'active' | 'finalizing'; pendingMessages: string[] };
   sessions: HandlerSessionSnapshot[];
   emitPreparing?: AttachPreparingEmitter;
+  terminalRuntime?: ControlTerminalRuntime;
 };
 
 export type ControlHandlerResult =
@@ -69,6 +82,7 @@ export async function handleControlRequest(
     });
   }
   if (operation === 'sandbox.shutdown') {
+    deps.terminalRuntime?.shutdown();
     return ok({ shuttingDown: true });
   }
   if (!SESSION_OPERATION_SET.has(operation)) {
@@ -80,12 +94,9 @@ export async function handleControlRequest(
 
   switch (operation) {
     case 'session.attach':
-      return applySessionAttach(session, payload, {
-        kiloClient: deps.kiloClient,
-        ...(deps.emitPreparing ? { emitPreparing: deps.emitPreparing } : {}),
-      });
+      return handleAttach(session, payload, deps);
     case 'session.detach':
-      return ok({ detached: true });
+      return handleDetach(session, payload, deps);
     case 'session.prompt':
       return handlePrompt(session, payload, deps);
     case 'session.abort':
@@ -96,6 +107,42 @@ export async function handleControlRequest(
       return handleQuestionResolve(payload, deps);
     case 'session.sync':
       return handleSync(session, deps);
+    case 'session.terminal.create':
+      return handleTerminalOperation(
+        session,
+        payload,
+        deps.terminalRuntime,
+        sessionTerminalCreatePayloadSchema,
+        sessionTerminalCreateResultSchema,
+        (runtime, identity, parsed) => runtime.create(identity, parsed)
+      );
+    case 'session.terminal.resize':
+      return handleTerminalOperation(
+        session,
+        payload,
+        deps.terminalRuntime,
+        sessionTerminalResizePayloadSchema,
+        sessionTerminalResizeResultSchema,
+        (runtime, identity, parsed) => runtime.resize(identity, parsed)
+      );
+    case 'session.terminal.close':
+      return handleTerminalOperation(
+        session,
+        payload,
+        deps.terminalRuntime,
+        sessionTerminalClosePayloadSchema,
+        sessionTerminalCloseResultSchema,
+        (runtime, identity, parsed) => runtime.close(identity, parsed)
+      );
+    case 'session.terminal.connect':
+      return handleTerminalOperation(
+        session,
+        payload,
+        deps.terminalRuntime,
+        sessionTerminalConnectPayloadSchema,
+        sessionTerminalConnectResultSchema,
+        (runtime, identity, parsed) => runtime.connect(identity, parsed)
+      );
     default:
       return fail('unknown_operation', 'Unknown operation', false);
   }
@@ -103,6 +150,94 @@ export async function handleControlRequest(
 
 function missingKilo(): ControlHandlerResult {
   return fail('not_ready', 'Kilo is not ready', true);
+}
+
+function terminalFailure(error: unknown): ControlHandlerResult {
+  if (error instanceof ControlTerminalRuntimeError) {
+    return fail(error.code, error.message, error.retryable);
+  }
+  return fail('not_ready', 'Terminal request failed', isKiloServerUnreachableError(error));
+}
+
+async function handleAttach(
+  session: SessionRequestIdentity,
+  payload: unknown,
+  deps: HandlerDeps
+): Promise<ControlHandlerResult> {
+  const parsed = sessionAttachPayloadSchema.safeParse(payload ?? {});
+  if (!parsed.success) return fail('protocol_error', 'Invalid payload', false);
+
+  if (
+    parsed.data.env &&
+    CONTROL_RUNTIME_RESERVED_ENV_VARS.some(name =>
+      Object.prototype.hasOwnProperty.call(parsed.data.env, name)
+    )
+  ) {
+    return fail('protocol_error', 'Reserved control runtime environment variable', false);
+  }
+
+  const result = await applySessionAttach(session, parsed.data, {
+    kiloClient: deps.kiloClient,
+    ...(deps.emitPreparing ? { emitPreparing: deps.emitPreparing } : {}),
+  });
+  if (
+    result.ok &&
+    deps.terminalRuntime &&
+    (parsed.data.directory ?? session.directory) === session.directory &&
+    (parsed.data.snapshotIdentity ?? session.kiloSessionId) === session.kiloSessionId
+  ) {
+    try {
+      deps.terminalRuntime.rememberAttachedSession(session);
+    } catch (error) {
+      return terminalFailure(error);
+    }
+  }
+  return result;
+}
+
+async function handleDetach(
+  session: SessionRequestIdentity,
+  payload: unknown,
+  deps: HandlerDeps
+): Promise<ControlHandlerResult> {
+  if (!sessionDetachPayloadSchema.safeParse(payload).success) {
+    return fail('protocol_error', 'Invalid payload', false);
+  }
+  try {
+    await deps.terminalRuntime?.detachSession(session);
+    return ok({ detached: true });
+  } catch (error) {
+    return terminalFailure(error);
+  }
+}
+
+type RuntimeSchema<Value> = {
+  safeParse(value: unknown): { success: true; data: Value } | { success: false };
+};
+
+async function handleTerminalOperation<Payload, Result>(
+  session: SessionRequestIdentity,
+  payload: unknown,
+  runtime: ControlTerminalRuntime | undefined,
+  payloadSchema: RuntimeSchema<Payload>,
+  resultSchema: RuntimeSchema<Result>,
+  invoke: (
+    terminalRuntime: ControlTerminalRuntime,
+    identity: SessionRequestIdentity,
+    parsed: Payload
+  ) => Promise<Result>
+): Promise<ControlHandlerResult> {
+  const parsedPayload = payloadSchema.safeParse(payload);
+  if (!parsedPayload.success) return fail('protocol_error', 'Invalid payload', false);
+  if (!runtime) return fail('not_ready', 'Terminal is not available', false);
+
+  try {
+    const result = resultSchema.safeParse(await invoke(runtime, session, parsedPayload.data));
+    if (!result.success) return fail('protocol_error', 'Invalid terminal result', false);
+    return ok(result.data);
+  } catch (error) {
+    return terminalFailure(error);
+  }
 }
 
 async function handlePrompt(

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'bun:test';
-import { maybeStartSandboxControlClient } from './sandbox-control-runtime';
+import {
+  maybeStartSandboxControlClient,
+  startSandboxControlEventFeed,
+} from './sandbox-control-runtime';
 import type { SandboxControlClient, SandboxControlClientOptions } from './sandbox-control-client';
 
 function fakeClient(): SandboxControlClient {
@@ -63,6 +66,7 @@ describe('maybeStartSandboxControlClient', () => {
         SANDBOX_CONTROL_URL: 'wss://example.test/sandbox-control/sbx_1',
         SANDBOX_CONTROL_CREDENTIAL: credential,
         PROVIDER_INSTANCE_ID: 'inst_1',
+        wrapperInstanceId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       },
       message => logs.push(message),
       {
@@ -79,6 +83,7 @@ describe('maybeStartSandboxControlClient', () => {
       url: 'wss://example.test/sandbox-control/sbx_1',
       credential,
       providerInstanceId: 'inst_1',
+      wrapperInstanceId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
       wrapperVersion: '2.4.0',
     });
     expect(received?.log).toBeTypeOf('function');
@@ -165,6 +170,54 @@ describe('maybeStartSandboxControlClient', () => {
     started?.close();
   });
 
+  it('emits readiness and heartbeats only while the Kilo event feed is live', async () => {
+    const events: Array<{ event: string; payload: unknown }> = [];
+    const heartbeatPayload = { state: 'idle', kilo: { ready: true }, sessions: [] };
+    let ready = false;
+    let received: SandboxControlClientOptions | undefined;
+    const client: SandboxControlClient = {
+      connect: async () => {},
+      close: () => {},
+      sendEvent: (event, payload) => {
+        events.push({ event, payload });
+      },
+    };
+
+    const started = maybeStartSandboxControlClient(
+      {
+        SANDBOX_CONTROL_URL: 'wss://example.test/sandbox-control/sbx_1',
+        SANDBOX_CONTROL_CREDENTIAL: 'secret',
+        PROVIDER_INSTANCE_ID: 'inst_1',
+      },
+      () => {},
+      {
+        wrapperVersion: '2.4.0',
+        isReady: () => ready,
+        getHeartbeatPayload: () => heartbeatPayload,
+        createClient: options => {
+          received = options;
+          return client;
+        },
+      }
+    );
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(events).toEqual([]);
+
+    ready = true;
+    received?.onReconnect?.();
+    expect(events).toEqual([
+      { event: 'sandbox.ready', payload: { kiloReady: true, globalFeedAttached: true } },
+      { event: 'sandbox.heartbeat', payload: heartbeatPayload },
+    ]);
+
+    ready = false;
+    received?.onReconnect?.();
+    expect(events).toHaveLength(2);
+    started?.close();
+  });
+
   it('emits ready and heartbeat again on reconnect without duplicating timers', async () => {
     const events: Array<{ event: string; payload: unknown }> = [];
     const connected: SandboxControlClient[] = [];
@@ -215,7 +268,7 @@ describe('maybeStartSandboxControlClient', () => {
     let received: SandboxControlClientOptions | undefined;
     const client: SandboxControlClient = {
       connect: async () => {
-        throw new Error('sandbox control connect failed');
+        throw new Error(`sandbox control connect failed: ${credential}`);
       },
       close: () => {},
       sendEvent: (event, payload) => {
@@ -248,5 +301,161 @@ describe('maybeStartSandboxControlClient', () => {
     expect(logs.join('\n')).not.toContain(credential);
     expect(logs.join('\n')).not.toContain('Authorization');
     expect(logs.some(line => line.includes('sandbox control client failed'))).toBe(true);
+  });
+});
+
+describe('startSandboxControlEventFeed', () => {
+  it('waits for a real first event before startup and forwards that event', async () => {
+    const abort = new AbortController();
+    const firstEvent = Promise.withResolvers<void>();
+    const stopped = Promise.withResolvers<void>();
+    const received: unknown[] = [];
+    const failures: unknown[] = [];
+    const connected = { payload: { type: 'server.connected' } };
+    abort.signal.addEventListener('abort', () => stopped.resolve(), { once: true });
+
+    async function* stream(): AsyncGenerator<unknown> {
+      await firstEvent.promise;
+      yield connected;
+      await stopped.promise;
+    }
+
+    let started = false;
+    const starting = startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: async signal => {
+        expect(signal).toBe(abort.signal);
+        return { stream: stream() };
+      },
+      consume: async events => {
+        for await (const event of events) {
+          received.push(event);
+        }
+      },
+      onUnexpectedClose: error => failures.push(error),
+    });
+    void starting.then(() => {
+      started = true;
+    });
+
+    await Promise.resolve();
+    await Promise.resolve();
+    expect(started).toBe(false);
+    expect(received).toEqual([]);
+
+    firstEvent.resolve();
+    await starting;
+    await Promise.resolve();
+    expect(started).toBe(true);
+    expect(received).toEqual([connected]);
+
+    abort.abort();
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    expect(failures).toEqual([]);
+  });
+
+  it('rejects when the global feed subscription fails', async () => {
+    const abort = new AbortController();
+    let consumed = false;
+    const failure = await startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: async () => {
+        throw new Error('Kilo server unavailable');
+      },
+      consume: async () => {
+        consumed = true;
+      },
+      onUnexpectedClose: () => {},
+    }).then(
+      () => undefined,
+      (error: unknown) => error
+    );
+
+    expect(failure).toEqual(new Error('Kilo server unavailable'));
+    expect(consumed).toBe(false);
+  });
+
+  it('rejects when the global feed provides no stream', async () => {
+    const abort = new AbortController();
+    const failure = await startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: async () => ({}),
+      consume: async () => {},
+      onUnexpectedClose: () => {},
+    }).then(
+      () => undefined,
+      (error: unknown) => error
+    );
+
+    expect(failure).toEqual(new Error('Kilo global event feed is unavailable'));
+  });
+
+  it('rejects a stream that ends before its first event', async () => {
+    const abort = new AbortController();
+
+    async function* stream(): AsyncGenerator<unknown> {}
+
+    const failure = await startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: async () => ({ stream: stream() }),
+      consume: async () => {},
+      onUnexpectedClose: () => {},
+    }).then(
+      () => undefined,
+      (error: unknown) => error
+    );
+
+    expect(failure).toEqual(new Error('Kilo global event feed ended before startup'));
+  });
+
+  it('reports an established feed ending as a fatal runtime failure', async () => {
+    const abort = new AbortController();
+    const received: unknown[] = [];
+    const failures: unknown[] = [];
+
+    async function* stream(): AsyncGenerator<unknown> {
+      yield { payload: { type: 'server.connected' } };
+    }
+
+    await startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: async () => ({ stream: stream() }),
+      consume: async events => {
+        for await (const event of events) {
+          received.push(event);
+        }
+      },
+      onUnexpectedClose: error => failures.push(error),
+    });
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+    expect(received).toHaveLength(1);
+    expect(failures).toHaveLength(1);
+    expect(failures[0]).toEqual(new Error('Kilo global event feed ended'));
+  });
+
+  it('reports an established feed error as a fatal runtime failure', async () => {
+    const abort = new AbortController();
+    const failures: unknown[] = [];
+    const failure = new Error('Kilo server exited');
+
+    async function* stream(): AsyncGenerator<unknown> {
+      yield { payload: { type: 'server.connected' } };
+      throw failure;
+    }
+
+    await startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: async () => ({ stream: stream() }),
+      consume: async events => {
+        for await (const event of events) {
+          expect(event).toEqual({ payload: { type: 'server.connected' } });
+        }
+      },
+      onUnexpectedClose: error => failures.push(error),
+    });
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+
+    expect(failures).toEqual([failure]);
   });
 });

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
@@ -9,7 +9,8 @@ type ControlEnv = {
   SANDBOX_CONTROL_URL?: string | undefined;
   SANDBOX_CONTROL_CREDENTIAL?: string | undefined;
   PROVIDER_INSTANCE_ID?: string | undefined;
-} & Record<string, string | undefined>;
+  wrapperInstanceId?: string | undefined;
+};
 
 type StartOptions = {
   wrapperVersion: string;
@@ -17,9 +18,54 @@ type StartOptions = {
   onRequest?: SandboxControlRequestHandler;
   onConnected?: (client: SandboxControlClient) => void;
   getHeartbeatPayload?: () => unknown;
+  isReady?: () => boolean;
+};
+
+type SandboxControlEventFeedOptions = {
+  signal: AbortSignal;
+  open: (signal: AbortSignal) => Promise<{ stream?: AsyncIterable<unknown> }>;
+  consume: (stream: AsyncIterable<unknown>) => Promise<void>;
+  onUnexpectedClose: (error: unknown) => void;
 };
 
 const HEARTBEAT_INTERVAL_MS = 30_000;
+
+export async function startSandboxControlEventFeed(
+  options: SandboxControlEventFeedOptions
+): Promise<void> {
+  const feed = await options.open(options.signal);
+  if (!feed.stream) {
+    throw new Error('Kilo global event feed is unavailable');
+  }
+
+  const iterator = feed.stream[Symbol.asyncIterator]();
+  const first = await iterator.next();
+  if (first.done) {
+    throw new Error('Kilo global event feed ended before startup');
+  }
+
+  async function* establishedFeed(): AsyncGenerator<unknown> {
+    yield first.value;
+    while (true) {
+      const next = await iterator.next();
+      if (next.done) return;
+      yield next.value;
+    }
+  }
+
+  void options.consume(establishedFeed()).then(
+    () => {
+      if (!options.signal.aborted) {
+        options.onUnexpectedClose(new Error('Kilo global event feed ended'));
+      }
+    },
+    error => {
+      if (!options.signal.aborted) {
+        options.onUnexpectedClose(error);
+      }
+    }
+  );
+}
 
 export function maybeStartSandboxControlClient(
   env: ControlEnv,
@@ -44,12 +90,16 @@ export function maybeStartSandboxControlClient(
   }
 
   function handleConnected(active: SandboxControlClient): void {
-    if (closed) return;
+    if (closed || options.isReady?.() === false) return;
     active.sendEvent?.('sandbox.ready', { kiloReady: true, globalFeedAttached: true });
     if (options.getHeartbeatPayload && active.sendEvent) {
       stopHeartbeat();
       active.sendEvent('sandbox.heartbeat', options.getHeartbeatPayload());
       heartbeat = setInterval(() => {
+        if (options.isReady?.() === false) {
+          stopHeartbeat();
+          return;
+        }
         active.sendEvent?.('sandbox.heartbeat', options.getHeartbeatPayload?.());
       }, HEARTBEAT_INTERVAL_MS);
       heartbeat.unref();
@@ -61,6 +111,7 @@ export function maybeStartSandboxControlClient(
     url,
     credential,
     providerInstanceId,
+    ...(env.wrapperInstanceId ? { wrapperInstanceId: env.wrapperInstanceId } : {}),
     wrapperVersion: options.wrapperVersion,
     log,
     onReconnect: () => handleConnected(client),
@@ -79,9 +130,10 @@ export function maybeStartSandboxControlClient(
     .then(() => {
       handleConnected(client);
     })
-    .catch((error: unknown) => {
-      const message = error instanceof Error ? error.message : 'unknown error';
-      log(`sandbox control client failed: ${message}`);
+    .catch(() => {
+      if (!closed) {
+        log('sandbox control client failed');
+      }
     });
 
   return client;

--- a/services/cloud-agent-next/wrapper/src/control/session-directories.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-directories.test.ts
@@ -1,5 +1,7 @@
 import { beforeEach, describe, expect, it } from 'bun:test';
 import {
+  directoryForSession,
+  forgetAttachedRoot,
   rememberAttachedRoot,
   rememberChildSession,
   resetSessionDirectoryState,
@@ -54,5 +56,32 @@ describe('session directory root mappings', () => {
 
     expect(rememberChildSession({ childId: 'c1', parentId: 'root' })).toBeUndefined();
     expect(rootForSession('c1')).toBe('root');
+  });
+
+  it('forgets only the detached root and its child sessions', () => {
+    rememberAttachedRoot('first', '/first');
+    rememberChildSession({ childId: 'first-child', parentId: 'first', directory: '/first' });
+    rememberAttachedRoot('second', '/second');
+    rememberChildSession({ childId: 'second-child', parentId: 'second', directory: '/second' });
+
+    forgetAttachedRoot('first', '/first');
+
+    expect(rootForSession('first')).toBeUndefined();
+    expect(rootForSession('first-child')).toBeUndefined();
+    expect(rootForSession(undefined, '/first')).toBeUndefined();
+    expect(directoryForSession('first')).toBeUndefined();
+    expect(directoryForSession('first-child')).toBeUndefined();
+    expect(rootForSession('second')).toBe('second');
+    expect(rootForSession('second-child')).toBe('second');
+    expect(directoryForSession('second-child')).toBe('/second');
+  });
+
+  it('preserves a root when the requested detach directory does not match', () => {
+    rememberAttachedRoot('root', '/ws');
+
+    forgetAttachedRoot('root', '/different');
+
+    expect(rootForSession('root')).toBe('root');
+    expect(directoryForSession('root')).toBe('/ws');
   });
 });

--- a/services/cloud-agent-next/wrapper/src/control/session-directories.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-directories.ts
@@ -12,6 +12,25 @@ export function rememberAttachedRoot(rootKiloSessionId: string, directory: strin
   rootByDirectory.set(directory, rootKiloSessionId);
 }
 
+export function forgetAttachedRoot(rootKiloSessionId: string, directory: string): void {
+  if (
+    rootBySessionId.get(rootKiloSessionId) !== rootKiloSessionId ||
+    directories.get(rootKiloSessionId) !== directory
+  ) {
+    return;
+  }
+
+  for (const [kiloSessionId, root] of rootBySessionId) {
+    if (root !== rootKiloSessionId) continue;
+    rootBySessionId.delete(kiloSessionId);
+    directories.delete(kiloSessionId);
+  }
+
+  if (rootByDirectory.get(directory) === rootKiloSessionId) {
+    rootByDirectory.delete(directory);
+  }
+}
+
 export function rememberChildSession(input: {
   childId: string;
   parentId?: string;

--- a/services/cloud-agent-next/wrapper/src/control/terminal-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/terminal-runtime.test.ts
@@ -1,0 +1,710 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import type {
+  SessionRequestIdentity,
+  SessionTerminalConnectPayload,
+  SessionTerminalCreatePayload,
+} from '../../../src/shared/sandbox-control-protocol.js';
+import { PNPM_STORE_DIR, PNPM_STORE_ENV_VAR } from '../../../src/shared/runtime-environment.js';
+import type { WrapperKiloClient, WrapperPty } from '../kilo-api.js';
+import { createControlTerminalRuntime, type ControlTerminalRuntime } from './terminal-runtime.js';
+import {
+  rememberAttachedRoot,
+  resetSessionDirectoryState,
+  rootForSession,
+} from './session-directories.js';
+
+const firstSession: SessionRequestIdentity = {
+  sessionId: 'workspace_first',
+  kiloSessionId: 'kilo_first',
+  directory: '/workspace/first',
+};
+
+const secondSession: SessionRequestIdentity = {
+  sessionId: 'workspace_second',
+  kiloSessionId: 'kilo_second',
+  directory: '/workspace/second',
+};
+
+const firstOperationId = '00000000-0000-4000-8000-000000000001';
+const secondOperationId = '00000000-0000-4000-8000-000000000002';
+const wrapperInstanceId = '00000000-0000-4000-8000-000000000010';
+const activeRuntimes = new Set<ControlTerminalRuntime>();
+
+type PtyClientOverrides = Partial<
+  Pick<WrapperKiloClient, 'serverUrl' | 'createPty' | 'resizePty' | 'deletePty'>
+>;
+
+type TerminalFrame = string | Uint8Array;
+
+type TestClose = { code: number; reason: string };
+
+function makePty(directory: string, id = 'pty_first'): WrapperPty {
+  return {
+    id,
+    title: 'Workspace terminal',
+    command: '/bin/bash',
+    args: [],
+    cwd: directory,
+    status: 'running',
+    pid: 73,
+  };
+}
+
+function fakeKilo(overrides: PtyClientOverrides = {}): WrapperKiloClient {
+  return {
+    serverUrl: 'http://127.0.0.1:1',
+    createPty: async input => makePty(input.cwd),
+    resizePty: async (ptyId, _size, directory) =>
+      makePty(directory ?? firstSession.directory, ptyId),
+    deletePty: async () => true,
+    ...overrides,
+  } as WrapperKiloClient;
+}
+
+function createRuntime(
+  kiloClient: WrapperKiloClient,
+  controlUrl = 'ws://127.0.0.1:1/sandbox-control/sandbox'
+): ControlTerminalRuntime {
+  const runtime = createControlTerminalRuntime({
+    controlUrl,
+    wrapperInstanceId,
+    kiloClient,
+  });
+  activeRuntimes.add(runtime);
+  return runtime;
+}
+
+function attach(runtime: ControlTerminalRuntime, identity: SessionRequestIdentity): void {
+  rememberAttachedRoot(identity.kiloSessionId, identity.directory);
+  runtime.rememberAttachedSession(identity);
+}
+
+function creationPayload(
+  operationId = firstOperationId,
+  size?: { cols: number; rows: number }
+): SessionTerminalCreatePayload {
+  return { operationId, ...(size ?? {}) };
+}
+
+function connectionPayload(
+  overrides: Partial<SessionTerminalConnectPayload> = {}
+): SessionTerminalConnectPayload {
+  return {
+    ownerId: 'oauth/google:account%2Fsegment',
+    ptyId: 'pty_first',
+    bridgeGeneration: crypto.randomUUID(),
+    capability: 'a'.repeat(64),
+    ...overrides,
+  };
+}
+
+function createQueue<Value>(name: string) {
+  const values: Value[] = [];
+  const waiting: Array<(value: Value) => void> = [];
+  return {
+    push(value: Value): void {
+      const resolve = waiting.shift();
+      if (resolve) {
+        resolve(value);
+        return;
+      }
+      values.push(value);
+    },
+    next(): Promise<Value> {
+      if (values.length > 0) {
+        const value = values.shift();
+        if (value !== undefined) return Promise.resolve(value);
+      }
+      return new Promise((resolve, reject) => {
+        const timeout = setTimeout(() => reject(new Error(`${name} timed out`)), 500);
+        waiting.push(value => {
+          clearTimeout(timeout);
+          resolve(value);
+        });
+      });
+    },
+  };
+}
+
+function normalizeFrame(frame: string | Buffer): TerminalFrame {
+  return typeof frame === 'string' ? frame : new Uint8Array(frame);
+}
+
+async function terminalFailure(operation: Promise<unknown>): Promise<unknown> {
+  try {
+    await operation;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected terminal operation to fail');
+}
+
+function createBridgeServers(initialOutput?: string) {
+  const events: string[] = [];
+  const reverseRequests: Array<{ url: URL; authorization: string | null }> = [];
+  const localRequests: URL[] = [];
+  const reverseSockets: Array<Bun.ServerWebSocket<{ role: 'reverse' }>> = [];
+  const localSockets: Array<Bun.ServerWebSocket<{ role: 'local' }>> = [];
+  const reverseFrames = createQueue<TerminalFrame>('reverse frame');
+  const localFrames = createQueue<TerminalFrame>('local frame');
+  const reverseCloses = createQueue<TestClose>('reverse close');
+  const localCloses = createQueue<TestClose>('local close');
+
+  const reverse = Bun.serve<{ role: 'reverse' }>({
+    port: 0,
+    fetch(request, server) {
+      events.push('reverse-request');
+      reverseRequests.push({
+        url: new URL(request.url),
+        authorization: request.headers.get('authorization'),
+      });
+      if (server.upgrade(request, { data: { role: 'reverse' } })) return undefined;
+      return new Response('upgrade failed', { status: 400 });
+    },
+    websocket: {
+      open(socket) {
+        events.push('reverse-open');
+        reverseSockets.push(socket);
+      },
+      message(_socket, frame) {
+        reverseFrames.push(normalizeFrame(frame));
+      },
+      close(_socket, code, reason) {
+        reverseCloses.push({ code, reason });
+      },
+    },
+  });
+
+  const local = Bun.serve<{ role: 'local' }>({
+    port: 0,
+    fetch(request, server) {
+      events.push('local-request');
+      localRequests.push(new URL(request.url));
+      if (server.upgrade(request, { data: { role: 'local' } })) return undefined;
+      return new Response('upgrade failed', { status: 400 });
+    },
+    websocket: {
+      open(socket) {
+        events.push('local-open');
+        localSockets.push(socket);
+        if (initialOutput !== undefined) socket.send(initialOutput);
+      },
+      message(socket, frame) {
+        localFrames.push(normalizeFrame(frame));
+        socket.send(frame);
+      },
+      close(_socket, code, reason) {
+        localCloses.push({ code, reason });
+      },
+    },
+  });
+
+  return {
+    controlUrl: `ws://127.0.0.1:${reverse.port}/sandbox-control/sandbox?ignored=true#fragment`,
+    localUrl: `http://127.0.0.1:${local.port}`,
+    events,
+    reverseRequests,
+    localRequests,
+    reverseSockets,
+    localSockets,
+    reverseFrames,
+    localFrames,
+    reverseCloses,
+    localCloses,
+    stop(): void {
+      void reverse.stop(true);
+      void local.stop(true);
+    },
+  };
+}
+
+beforeEach(() => {
+  resetSessionDirectoryState();
+});
+
+afterEach(() => {
+  for (const runtime of activeRuntimes) runtime.shutdown();
+  activeRuntimes.clear();
+  resetSessionDirectoryState();
+});
+
+describe('control terminal PTY ownership', () => {
+  it('requires a successfully attached exact root and directory', async () => {
+    const runtime = createRuntime(fakeKilo());
+
+    expect(await terminalFailure(runtime.create(firstSession, creationPayload()))).toMatchObject({
+      code: 'not_ready',
+      retryable: true,
+    });
+
+    rememberAttachedRoot(firstSession.kiloSessionId, '/workspace/different');
+    expect(() => runtime.rememberAttachedSession(firstSession)).toThrow(
+      'Terminal session ownership mismatch'
+    );
+  });
+
+  it('creates an idempotent directory-scoped PTY with the safe legacy terminal environment', async () => {
+    const createCalls: Array<{ cwd: string; title: string; env: Record<string, string> }> = [];
+    const resizeCalls: Array<{ ptyId: string; cols: number; rows: number; directory?: string }> =
+      [];
+    let releaseCreation: (() => void) | undefined;
+    const creationGate = new Promise<void>(resolve => {
+      releaseCreation = resolve;
+    });
+    const kiloClient = fakeKilo({
+      createPty: async input => {
+        createCalls.push(input);
+        await creationGate;
+        return makePty(input.cwd);
+      },
+      resizePty: async (ptyId, size, directory) => {
+        resizeCalls.push({ ptyId, ...size, directory });
+        return makePty(directory ?? '', ptyId);
+      },
+    });
+    const runtime = createRuntime(kiloClient);
+    attach(runtime, firstSession);
+    const payload = creationPayload(firstOperationId, { cols: 120, rows: 35 });
+
+    const first = runtime.create(firstSession, payload);
+    const concurrent = runtime.create(firstSession, payload);
+    await Promise.resolve();
+    expect(createCalls).toHaveLength(1);
+
+    releaseCreation?.();
+    const [created, duplicate] = await Promise.all([first, concurrent]);
+    expect(created).toEqual({ pty: makePty(firstSession.directory) });
+    expect(duplicate).toEqual(created);
+    expect(await runtime.create(firstSession, payload)).toEqual(created);
+    expect(createCalls).toEqual([
+      {
+        cwd: firstSession.directory,
+        title: 'Workspace terminal',
+        env: {
+          PROMPT_COMMAND: "PS1='\\n\\W\\n\\$ '",
+          PS1: '\\n\\W\\n\\$ ',
+          [PNPM_STORE_ENV_VAR]: PNPM_STORE_DIR,
+          SANDBOX_CONTROL_CREDENTIAL: '',
+        },
+      },
+    ]);
+    expect(resizeCalls).toEqual([
+      { ptyId: 'pty_first', cols: 120, rows: 35, directory: firstSession.directory },
+    ]);
+  });
+
+  it('rejects operation IDs reused for different dimensions or session identities', async () => {
+    const runtime = createRuntime(fakeKilo());
+    attach(runtime, firstSession);
+    attach(runtime, secondSession);
+    await runtime.create(firstSession, creationPayload(firstOperationId, { cols: 100, rows: 30 }));
+
+    expect(
+      await terminalFailure(
+        runtime.create(firstSession, creationPayload(firstOperationId, { cols: 101, rows: 30 }))
+      )
+    ).toMatchObject({ code: 'idempotency_conflict', retryable: false });
+    expect(
+      await terminalFailure(
+        runtime.create(secondSession, creationPayload(firstOperationId, { cols: 100, rows: 30 }))
+      )
+    ).toMatchObject({ code: 'idempotency_conflict', retryable: false });
+  });
+
+  it('deletes a created PTY in its exact directory when initial resize fails', async () => {
+    const deleted: Array<{ ptyId: string; directory?: string }> = [];
+    let failResize = true;
+    let createdCount = 0;
+    const kiloClient = fakeKilo({
+      createPty: async input => {
+        createdCount += 1;
+        return makePty(input.cwd, `pty_${createdCount}`);
+      },
+      resizePty: async (ptyId, _size, directory) => {
+        if (failResize) throw new Error('private upstream detail');
+        return makePty(directory ?? '', ptyId);
+      },
+      deletePty: async (ptyId, directory) => {
+        deleted.push({ ptyId, directory });
+        return true;
+      },
+    });
+    const runtime = createRuntime(kiloClient);
+    attach(runtime, firstSession);
+    const payload = creationPayload(firstOperationId, { cols: 100, rows: 30 });
+
+    expect(await terminalFailure(runtime.create(firstSession, payload))).toMatchObject({
+      code: 'not_ready',
+      message: 'Terminal creation failed',
+      retryable: false,
+    });
+    expect(deleted).toEqual([{ ptyId: 'pty_1', directory: firstSession.directory }]);
+
+    failResize = false;
+    expect(await runtime.create(firstSession, payload)).toEqual({
+      pty: makePty(firstSession.directory, 'pty_2'),
+    });
+  });
+
+  it('rejects a Kilo PTY returned for a different workspace directory', async () => {
+    const deleted: Array<{ ptyId: string; directory?: string }> = [];
+    const kiloClient = fakeKilo({
+      createPty: async () => makePty('/workspace/unowned'),
+      deletePty: async (ptyId, directory) => {
+        deleted.push({ ptyId, directory });
+        return true;
+      },
+    });
+    const runtime = createRuntime(kiloClient);
+    attach(runtime, firstSession);
+
+    expect(await terminalFailure(runtime.create(firstSession, creationPayload()))).toMatchObject({
+      code: 'protocol_error',
+      message: 'Invalid terminal response',
+      retryable: false,
+    });
+    expect(deleted).toEqual([{ ptyId: 'pty_first', directory: firstSession.directory }]);
+  });
+
+  it('fences every PTY operation to its owning session and preserves unrelated sessions on detach', async () => {
+    const resized: Array<{ ptyId: string; directory?: string }> = [];
+    const deleted: Array<{ ptyId: string; directory?: string }> = [];
+    let createdCount = 0;
+    const kiloClient = fakeKilo({
+      createPty: async input => makePty(input.cwd, `pty_${++createdCount}`),
+      resizePty: async (ptyId, _size, directory) => {
+        resized.push({ ptyId, directory });
+        return makePty(directory ?? '', ptyId);
+      },
+      deletePty: async (ptyId, directory) => {
+        deleted.push({ ptyId, directory });
+        return true;
+      },
+    });
+    const runtime = createRuntime(kiloClient);
+    attach(runtime, firstSession);
+    attach(runtime, secondSession);
+    await runtime.create(firstSession, creationPayload(firstOperationId));
+    await runtime.create(secondSession, creationPayload(secondOperationId));
+
+    expect(
+      await terminalFailure(runtime.resize(secondSession, { ptyId: 'pty_1', cols: 100, rows: 30 }))
+    ).toMatchObject({ code: 'unauthorized', retryable: false });
+    expect(await terminalFailure(runtime.close(secondSession, { ptyId: 'pty_1' }))).toMatchObject({
+      code: 'unauthorized',
+      retryable: false,
+    });
+    expect(
+      await terminalFailure(
+        runtime.resize(
+          { ...firstSession, directory: secondSession.directory },
+          { ptyId: 'pty_1', cols: 100, rows: 30 }
+        )
+      )
+    ).toMatchObject({ code: 'unauthorized', retryable: false });
+
+    await runtime.detachSession(firstSession);
+    expect(deleted).toEqual([{ ptyId: 'pty_1', directory: firstSession.directory }]);
+    expect(rootForSession(firstSession.kiloSessionId)).toBeUndefined();
+    expect(rootForSession(secondSession.kiloSessionId)).toBe(secondSession.kiloSessionId);
+
+    expect(await runtime.resize(secondSession, { ptyId: 'pty_2', cols: 110, rows: 40 })).toEqual({
+      pty: makePty(secondSession.directory, 'pty_2'),
+    });
+    expect(resized).toEqual([{ ptyId: 'pty_2', directory: secondSession.directory }]);
+  });
+
+  it('compensates PTY creation that finishes after its session detaches', async () => {
+    let releaseCreation: (() => void) | undefined;
+    const creationGate = new Promise<void>(resolve => {
+      releaseCreation = resolve;
+    });
+    const deleted: Array<{ ptyId: string; directory?: string }> = [];
+    const kiloClient = fakeKilo({
+      createPty: async input => {
+        await creationGate;
+        return makePty(input.cwd);
+      },
+      deletePty: async (ptyId, directory) => {
+        deleted.push({ ptyId, directory });
+        return true;
+      },
+    });
+    const runtime = createRuntime(kiloClient);
+    attach(runtime, firstSession);
+
+    const creation = runtime.create(firstSession, creationPayload());
+    await Promise.resolve();
+    const detached = runtime.detachSession(firstSession);
+    releaseCreation?.();
+
+    expect(await terminalFailure(creation)).toMatchObject({
+      code: 'not_ready',
+      message: 'Terminal session is no longer attached',
+      retryable: false,
+    });
+    await detached;
+    expect(deleted).toEqual([{ ptyId: 'pty_first', directory: firstSession.directory }]);
+  });
+
+  it('removes completed creation-operation state when its PTY is closed', async () => {
+    let createdCount = 0;
+    const kiloClient = fakeKilo({
+      createPty: async input => makePty(input.cwd, `pty_${++createdCount}`),
+    });
+    const runtime = createRuntime(kiloClient);
+    attach(runtime, firstSession);
+    const payload = creationPayload();
+    await runtime.create(firstSession, payload);
+
+    expect(await runtime.close(firstSession, { ptyId: 'pty_1' })).toEqual({
+      success: true,
+    });
+    expect(await runtime.create(firstSession, payload)).toEqual({
+      pty: makePty(firstSession.directory, 'pty_2'),
+    });
+  });
+});
+
+describe('control terminal reverse WebSocket bridge', () => {
+  it('authenticates the trusted reverse origin and relays initial, text, control, and binary frames unchanged', async () => {
+    const servers = createBridgeServers('initial output');
+    const kiloClient = fakeKilo({ serverUrl: servers.localUrl });
+    const runtime = createRuntime(kiloClient, servers.controlUrl);
+    attach(runtime, firstSession);
+    await runtime.create(firstSession, creationPayload());
+    const payload = connectionPayload();
+
+    try {
+      expect(await runtime.connect(firstSession, payload)).toEqual({ connected: true });
+      expect(await runtime.connect(firstSession, payload)).toEqual({ connected: true });
+      expect(await servers.reverseFrames.next()).toBe('initial output');
+      expect(servers.reverseRequests).toHaveLength(1);
+      expect(servers.reverseRequests[0]?.url.pathname).toBe(
+        `/sandbox-terminal/${encodeURIComponent(payload.ownerId)}/${firstSession.sessionId}/${payload.ptyId}`
+      );
+      expect(servers.reverseRequests[0]?.url.search).toBe('');
+      expect(servers.reverseRequests[0]?.url.hash).toBe('');
+      expect(servers.reverseRequests[0]?.authorization).toBe(`Bearer ${payload.capability}`);
+      expect(servers.localRequests[0]?.pathname).toBe(`/pty/${payload.ptyId}/connect`);
+      expect(servers.localRequests[0]?.searchParams.get('directory')).toBe(firstSession.directory);
+      expect(servers.events.indexOf('reverse-open')).toBeLessThan(
+        servers.events.indexOf('local-request')
+      );
+
+      const reverse = servers.reverseSockets[0];
+      if (!reverse) throw new Error('Expected reverse terminal socket');
+      for (const frame of ['ping', 'pong', '\u0000cursor-control']) {
+        reverse.send(frame);
+        expect(await servers.localFrames.next()).toBe(frame);
+        expect(await servers.reverseFrames.next()).toBe(frame);
+      }
+
+      const binary = new Uint8Array([0, 255, 17, 128]);
+      reverse.send(binary);
+      expect(await servers.localFrames.next()).toEqual(binary);
+      expect(await servers.reverseFrames.next()).toEqual(binary);
+    } finally {
+      runtime.shutdown();
+      servers.stop();
+    }
+  });
+
+  it('does not subscribe to the local PTY when the reverse capability is rejected', async () => {
+    const servers = createBridgeServers();
+    const denied = Bun.serve({
+      port: 0,
+      fetch: () => new Response('unauthorized', { status: 401 }),
+    });
+    const runtime = createRuntime(
+      fakeKilo({ serverUrl: servers.localUrl }),
+      `ws://127.0.0.1:${denied.port}/sandbox-control/sandbox`
+    );
+    attach(runtime, firstSession);
+    await runtime.create(firstSession, creationPayload());
+
+    try {
+      expect(
+        await terminalFailure(runtime.connect(firstSession, connectionPayload()))
+      ).toMatchObject({
+        code: 'not_ready',
+        message: 'Terminal transport failed',
+        retryable: true,
+      });
+      expect(servers.localRequests).toEqual([]);
+    } finally {
+      runtime.shutdown();
+      void denied.stop(true);
+      servers.stop();
+    }
+  });
+
+  it('replaces bridge generations and reconnects without deleting the underlying PTY', async () => {
+    const servers = createBridgeServers();
+    let deleted = 0;
+    const kiloClient = fakeKilo({
+      serverUrl: servers.localUrl,
+      deletePty: async () => {
+        deleted += 1;
+        return true;
+      },
+    });
+    const runtime = createRuntime(kiloClient, servers.controlUrl);
+    attach(runtime, firstSession);
+    await runtime.create(firstSession, creationPayload());
+
+    try {
+      const first = connectionPayload();
+      await runtime.connect(firstSession, first);
+      const second = connectionPayload({ bridgeGeneration: crypto.randomUUID() });
+      await runtime.connect(firstSession, second);
+      expect((await servers.reverseCloses.next()).code).toBe(4000);
+      expect((await servers.localCloses.next()).code).toBe(4000);
+
+      const replacement = servers.reverseSockets[1];
+      if (!replacement) throw new Error('Expected replacement reverse terminal socket');
+      replacement.send('replacement input');
+      expect(await servers.localFrames.next()).toBe('replacement input');
+      expect(await servers.reverseFrames.next()).toBe('replacement input');
+
+      replacement.close(1000, 'browser disconnected');
+      expect((await servers.localCloses.next()).code).toBe(1000);
+      expect(deleted).toBe(0);
+
+      expect(
+        await runtime.connect(
+          firstSession,
+          connectionPayload({ bridgeGeneration: crypto.randomUUID() })
+        )
+      ).toEqual({ connected: true });
+      expect(servers.localRequests).toHaveLength(3);
+      expect(deleted).toBe(0);
+    } finally {
+      runtime.shutdown();
+      servers.stop();
+    }
+  });
+
+  it('rejects reconnects that change the terminal owner', async () => {
+    const servers = createBridgeServers();
+    const runtime = createRuntime(fakeKilo({ serverUrl: servers.localUrl }), servers.controlUrl);
+    attach(runtime, firstSession);
+    await runtime.create(firstSession, creationPayload());
+
+    try {
+      await runtime.connect(firstSession, connectionPayload());
+      expect(
+        await terminalFailure(
+          runtime.connect(firstSession, connectionPayload({ ownerId: 'different-owner' }))
+        )
+      ).toMatchObject({ code: 'unauthorized', retryable: false });
+      expect(servers.reverseRequests).toHaveLength(1);
+    } finally {
+      runtime.shutdown();
+      servers.stop();
+    }
+  });
+
+  it('delivers final PTY output before the normal terminal-ended close', async () => {
+    const servers = createBridgeServers();
+    const runtime = createRuntime(fakeKilo({ serverUrl: servers.localUrl }), servers.controlUrl);
+    attach(runtime, firstSession);
+    await runtime.create(firstSession, creationPayload());
+
+    try {
+      await runtime.connect(firstSession, connectionPayload());
+      const local = servers.localSockets[0];
+      if (!local) throw new Error('Expected local terminal socket');
+      local.send('final output');
+      local.close(1000, 'shell exited');
+
+      expect(await servers.reverseFrames.next()).toBe('final output');
+      expect((await servers.reverseCloses.next()).code).toBe(1000);
+      expect(
+        await terminalFailure(runtime.connect(firstSession, connectionPayload()))
+      ).toMatchObject({
+        code: 'not_ready',
+        message: 'PTY session ended',
+        retryable: false,
+      });
+    } finally {
+      runtime.shutdown();
+      servers.stop();
+    }
+  });
+
+  it('translates abnormal local transport closures into safe retryable bridge failures', async () => {
+    const servers = createBridgeServers();
+    const runtime = createRuntime(fakeKilo({ serverUrl: servers.localUrl }), servers.controlUrl);
+    attach(runtime, firstSession);
+    await runtime.create(firstSession, creationPayload());
+
+    try {
+      await runtime.connect(firstSession, connectionPayload());
+      const local = servers.localSockets[0];
+      if (!local) throw new Error('Expected local terminal socket');
+      local.close(1011, 'private upstream failure');
+
+      expect((await servers.reverseCloses.next()).code).toBe(1011);
+    } finally {
+      runtime.shutdown();
+      servers.stop();
+    }
+  });
+
+  it('closes a bridge when its Bun socket output buffer exceeds the fixed bound', async () => {
+    const servers = createBridgeServers();
+    const runtime = createRuntime(fakeKilo({ serverUrl: servers.localUrl }), servers.controlUrl);
+    attach(runtime, firstSession);
+    await runtime.create(firstSession, creationPayload());
+    const bufferedAmount = Object.getOwnPropertyDescriptor(WebSocket.prototype, 'bufferedAmount');
+    if (!bufferedAmount) throw new Error('Expected Bun WebSocket bufferedAmount property');
+
+    try {
+      await runtime.connect(firstSession, connectionPayload());
+      Object.defineProperty(WebSocket.prototype, 'bufferedAmount', {
+        configurable: true,
+        get: () => 1024 * 1024,
+      });
+      const local = servers.localSockets[0];
+      if (!local) throw new Error('Expected local terminal socket');
+      local.send('buffered output');
+
+      expect((await servers.reverseCloses.next()).code).toBe(1011);
+    } finally {
+      Object.defineProperty(WebSocket.prototype, 'bufferedAmount', bufferedAmount);
+      runtime.shutdown();
+      servers.stop();
+    }
+  });
+
+  it('closes oversized terminal frames without deleting the PTY', async () => {
+    const servers = createBridgeServers();
+    let deleted = false;
+    const runtime = createRuntime(
+      fakeKilo({
+        serverUrl: servers.localUrl,
+        deletePty: async () => {
+          deleted = true;
+          return true;
+        },
+      }),
+      servers.controlUrl
+    );
+    attach(runtime, firstSession);
+    await runtime.create(firstSession, creationPayload());
+
+    try {
+      await runtime.connect(firstSession, connectionPayload());
+      const local = servers.localSockets[0];
+      if (!local) throw new Error('Expected local terminal socket');
+      local.send(new Uint8Array(1024 * 1024 + 1));
+
+      expect((await servers.reverseCloses.next()).code).toBe(1009);
+      expect(deleted).toBe(false);
+    } finally {
+      runtime.shutdown();
+      servers.stop();
+    }
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/control/terminal-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/terminal-runtime.ts
@@ -1,0 +1,607 @@
+import {
+  sessionTerminalCreateResultSchema,
+  sessionTerminalResizeResultSchema,
+  type ControlErrorCode,
+  type SessionRequestIdentity,
+  type SessionTerminalClosePayload,
+  type SessionTerminalCloseResult,
+  type SessionTerminalConnectPayload,
+  type SessionTerminalConnectResult,
+  type SessionTerminalCreatePayload,
+  type SessionTerminalCreateResult,
+  type SessionTerminalResizePayload,
+  type SessionTerminalResizeResult,
+} from '../../../src/shared/sandbox-control-protocol.js';
+import { PNPM_STORE_DIR, PNPM_STORE_ENV_VAR } from '../../../src/shared/runtime-environment.js';
+import { isKiloServerUnreachableError, type WrapperKiloClient } from '../kilo-api.js';
+import { directoryForSession, forgetAttachedRoot, rootForSession } from './session-directories.js';
+
+type AttachedTerminalSession = SessionRequestIdentity & {
+  wrapperInstanceId: string;
+};
+
+type OwnedTerminal = AttachedTerminalSession & {
+  ptyId: string;
+  operationId: string;
+  ownerId?: string;
+  state: 'running' | 'ended';
+};
+
+type TerminalCreationOperation = AttachedTerminalSession & {
+  cols?: number;
+  rows?: number;
+  promise: Promise<SessionTerminalCreateResult>;
+};
+
+type TerminalBridge = {
+  terminal: OwnedTerminal;
+  ownerId: string;
+  bridgeGeneration: string;
+  reverse: WebSocket;
+  local?: WebSocket;
+  connection?: Promise<SessionTerminalConnectResult>;
+  closing: boolean;
+};
+
+type AuthenticatedWebSocketConstructor = typeof WebSocket & {
+  new (url: string, options: { headers: Record<string, string> }): WebSocket;
+};
+
+const MAX_TERMINAL_BUFFERED_BYTES = 1024 * 1024;
+
+const WORKSPACE_TERMINAL_ENV = {
+  PROMPT_COMMAND: "PS1='\\n\\W\\n\\$ '",
+  PS1: '\\n\\W\\n\\$ ',
+  [PNPM_STORE_ENV_VAR]: PNPM_STORE_DIR,
+  SANDBOX_CONTROL_CREDENTIAL: '',
+} satisfies Record<string, string>;
+
+export class ControlTerminalRuntimeError extends Error {
+  constructor(
+    readonly code: ControlErrorCode,
+    message: string,
+    readonly retryable: boolean
+  ) {
+    super(message);
+    this.name = 'ControlTerminalRuntimeError';
+  }
+}
+
+export type ControlTerminalRuntime = {
+  rememberAttachedSession(identity: SessionRequestIdentity): void;
+  detachSession(identity: SessionRequestIdentity): Promise<void>;
+  create(
+    identity: SessionRequestIdentity,
+    payload: SessionTerminalCreatePayload
+  ): Promise<SessionTerminalCreateResult>;
+  resize(
+    identity: SessionRequestIdentity,
+    payload: SessionTerminalResizePayload
+  ): Promise<SessionTerminalResizeResult>;
+  close(
+    identity: SessionRequestIdentity,
+    payload: SessionTerminalClosePayload
+  ): Promise<SessionTerminalCloseResult>;
+  connect(
+    identity: SessionRequestIdentity,
+    payload: SessionTerminalConnectPayload
+  ): Promise<SessionTerminalConnectResult>;
+  shutdown(): void;
+};
+
+function sameSession(left: SessionRequestIdentity, right: SessionRequestIdentity): boolean {
+  return (
+    left.sessionId === right.sessionId &&
+    left.kiloSessionId === right.kiloSessionId &&
+    left.directory === right.directory
+  );
+}
+
+function safeKiloFailure(error: unknown, message: string): ControlTerminalRuntimeError {
+  if (error instanceof ControlTerminalRuntimeError) return error;
+  return new ControlTerminalRuntimeError('not_ready', message, isKiloServerUnreachableError(error));
+}
+
+function closeSocket(socket: WebSocket | undefined, code: number, reason: string): void {
+  if (
+    !socket ||
+    (socket.readyState !== WebSocket.CONNECTING && socket.readyState !== WebSocket.OPEN)
+  ) {
+    return;
+  }
+  try {
+    socket.close(code, reason);
+  } catch {
+    return;
+  }
+}
+
+function waitForSocketOpen(socket: WebSocket): Promise<void> {
+  if (socket.readyState === WebSocket.OPEN) return Promise.resolve();
+  if (socket.readyState !== WebSocket.CONNECTING) {
+    return Promise.reject(
+      new ControlTerminalRuntimeError('not_ready', 'Terminal transport failed', true)
+    );
+  }
+
+  return new Promise((resolve, reject) => {
+    const onOpen = () => {
+      cleanup();
+      resolve();
+    };
+    const onFailure = () => {
+      cleanup();
+      reject(new ControlTerminalRuntimeError('not_ready', 'Terminal transport failed', true));
+    };
+    const cleanup = () => {
+      socket.removeEventListener('open', onOpen);
+      socket.removeEventListener('error', onFailure);
+      socket.removeEventListener('close', onFailure);
+    };
+
+    socket.addEventListener('open', onOpen);
+    socket.addEventListener('error', onFailure);
+    socket.addEventListener('close', onFailure);
+  });
+}
+
+export function createControlTerminalRuntime(options: {
+  controlUrl: string;
+  wrapperInstanceId: string;
+  kiloClient: WrapperKiloClient;
+}): ControlTerminalRuntime {
+  const { wrapperInstanceId, kiloClient } = options;
+  const controlOrigin = new URL(options.controlUrl).origin;
+  const attachedSessions = new Map<string, AttachedTerminalSession>();
+  const terminals = new Map<string, OwnedTerminal>();
+  const operations = new Map<string, TerminalCreationOperation>();
+  const bridges = new Map<string, TerminalBridge>();
+  let shutDown = false;
+
+  function requireAttached(identity: SessionRequestIdentity): AttachedTerminalSession {
+    const attached = attachedSessions.get(identity.sessionId);
+    if (!attached || shutDown) {
+      throw new ControlTerminalRuntimeError('not_ready', 'Terminal session is not attached', true);
+    }
+    if (
+      attached.wrapperInstanceId !== wrapperInstanceId ||
+      !sameSession(attached, identity) ||
+      directoryForSession(identity.kiloSessionId) !== identity.directory ||
+      rootForSession(identity.kiloSessionId) !== identity.kiloSessionId ||
+      rootForSession(undefined, identity.directory) !== identity.kiloSessionId
+    ) {
+      throw new ControlTerminalRuntimeError(
+        'unauthorized',
+        'Terminal session ownership mismatch',
+        false
+      );
+    }
+    return attached;
+  }
+
+  function requireTerminal(
+    identity: SessionRequestIdentity,
+    ptyId: string,
+    allowEnded = false
+  ): OwnedTerminal {
+    const attached = requireAttached(identity);
+    const terminal = terminals.get(ptyId);
+    if (
+      !terminal ||
+      terminal.wrapperInstanceId !== attached.wrapperInstanceId ||
+      !sameSession(terminal, attached)
+    ) {
+      throw new ControlTerminalRuntimeError('unauthorized', 'Terminal ownership mismatch', false);
+    }
+    if (!allowEnded && terminal.state !== 'running') {
+      throw new ControlTerminalRuntimeError('not_ready', 'PTY session ended', false);
+    }
+    return terminal;
+  }
+
+  function isCurrentBridge(bridge: TerminalBridge): boolean {
+    return (
+      !bridge.closing &&
+      bridges.get(bridge.terminal.ptyId) === bridge &&
+      terminals.get(bridge.terminal.ptyId) === bridge.terminal &&
+      attachedSessions.get(bridge.terminal.sessionId)?.wrapperInstanceId === wrapperInstanceId
+    );
+  }
+
+  function closeBridge(bridge: TerminalBridge, code: number, reason: string): void {
+    if (bridge.closing) return;
+    bridge.closing = true;
+    if (bridges.get(bridge.terminal.ptyId) === bridge) {
+      bridges.delete(bridge.terminal.ptyId);
+    }
+    closeSocket(bridge.reverse, code, reason);
+    closeSocket(bridge.local, code, reason);
+  }
+
+  function forwardMessage(
+    bridge: TerminalBridge,
+    target: WebSocket | undefined,
+    data: unknown
+  ): void {
+    if (!isCurrentBridge(bridge)) return;
+    if (
+      !target ||
+      target.readyState !== WebSocket.OPEN ||
+      (typeof data !== 'string' && !(data instanceof ArrayBuffer))
+    ) {
+      closeBridge(bridge, 1011, 'Terminal transport failed');
+      return;
+    }
+
+    const messageBytes = typeof data === 'string' ? Buffer.byteLength(data) : data.byteLength;
+    if (messageBytes > MAX_TERMINAL_BUFFERED_BYTES) {
+      closeBridge(bridge, 1009, 'Terminal message too large');
+      return;
+    }
+    if (target.bufferedAmount + messageBytes > MAX_TERMINAL_BUFFERED_BYTES) {
+      closeBridge(bridge, 1011, 'Terminal transport overloaded');
+      return;
+    }
+
+    try {
+      target.send(data);
+    } catch {
+      closeBridge(bridge, 1011, 'Terminal transport failed');
+    }
+  }
+
+  async function createTerminal(
+    attached: AttachedTerminalSession,
+    payload: SessionTerminalCreatePayload
+  ): Promise<SessionTerminalCreateResult> {
+    let createdPtyId: string | undefined;
+    try {
+      const created = await kiloClient.createPty({
+        cwd: attached.directory,
+        title: 'Workspace terminal',
+        env: WORKSPACE_TERMINAL_ENV,
+      });
+      createdPtyId = created.id;
+      if (attachedSessions.get(attached.sessionId) !== attached) {
+        throw new ControlTerminalRuntimeError(
+          'not_ready',
+          'Terminal session is no longer attached',
+          false
+        );
+      }
+
+      const pty =
+        payload.cols !== undefined && payload.rows !== undefined
+          ? await kiloClient.resizePty(
+              created.id,
+              { cols: payload.cols, rows: payload.rows },
+              attached.directory
+            )
+          : created;
+      if (attachedSessions.get(attached.sessionId) !== attached) {
+        throw new ControlTerminalRuntimeError(
+          'not_ready',
+          'Terminal session is no longer attached',
+          false
+        );
+      }
+
+      const result = sessionTerminalCreateResultSchema.safeParse({ pty });
+      if (
+        !result.success ||
+        result.data.pty.id !== created.id ||
+        result.data.pty.cwd !== attached.directory
+      ) {
+        throw new ControlTerminalRuntimeError('protocol_error', 'Invalid terminal response', false);
+      }
+      if (terminals.has(created.id)) {
+        throw new ControlTerminalRuntimeError('unauthorized', 'Terminal ownership mismatch', false);
+      }
+
+      terminals.set(created.id, {
+        ...attached,
+        ptyId: created.id,
+        operationId: payload.operationId,
+        state: 'running',
+      });
+      return result.data;
+    } catch (error) {
+      if (createdPtyId !== undefined) {
+        await kiloClient.deletePty(createdPtyId, attached.directory).catch(() => undefined);
+      }
+      throw safeKiloFailure(error, 'Terminal creation failed');
+    }
+  }
+
+  async function establishBridge(bridge: TerminalBridge): Promise<SessionTerminalConnectResult> {
+    try {
+      await waitForSocketOpen(bridge.reverse);
+      if (!isCurrentBridge(bridge)) {
+        throw new ControlTerminalRuntimeError(
+          'not_ready',
+          'Terminal connection was replaced',
+          true
+        );
+      }
+
+      const localUrl = new URL(
+        `/pty/${encodeURIComponent(bridge.terminal.ptyId)}/connect`,
+        kiloClient.serverUrl
+      );
+      localUrl.protocol = localUrl.protocol === 'https:' ? 'wss:' : 'ws:';
+      localUrl.search = '';
+      localUrl.hash = '';
+      localUrl.searchParams.set('directory', bridge.terminal.directory);
+
+      const local = new WebSocket(localUrl.toString());
+      local.binaryType = 'arraybuffer';
+      bridge.local = local;
+      local.onmessage = event => forwardMessage(bridge, bridge.reverse, event.data);
+      local.onerror = () => {
+        if (isCurrentBridge(bridge)) closeBridge(bridge, 1011, 'Terminal transport failed');
+      };
+      local.onclose = event => {
+        if (!isCurrentBridge(bridge)) return;
+        if (event.code === 1000) {
+          bridge.terminal.state = 'ended';
+          closeBridge(bridge, 1000, 'PTY session ended');
+          return;
+        }
+        closeBridge(bridge, 1011, 'Terminal transport failed');
+      };
+
+      await waitForSocketOpen(local);
+      if (!isCurrentBridge(bridge)) {
+        throw new ControlTerminalRuntimeError(
+          'not_ready',
+          'Terminal connection was replaced',
+          true
+        );
+      }
+      return { connected: true };
+    } catch (error) {
+      closeBridge(bridge, 1011, 'Terminal transport failed');
+      if (error instanceof ControlTerminalRuntimeError) throw error;
+      throw new ControlTerminalRuntimeError('not_ready', 'Terminal transport failed', true);
+    }
+  }
+
+  return {
+    rememberAttachedSession(identity) {
+      if (
+        shutDown ||
+        directoryForSession(identity.kiloSessionId) !== identity.directory ||
+        rootForSession(identity.kiloSessionId) !== identity.kiloSessionId ||
+        rootForSession(undefined, identity.directory) !== identity.kiloSessionId
+      ) {
+        throw new ControlTerminalRuntimeError(
+          'unauthorized',
+          'Terminal session ownership mismatch',
+          false
+        );
+      }
+
+      const existing = attachedSessions.get(identity.sessionId);
+      if (existing) {
+        if (!sameSession(existing, identity)) {
+          throw new ControlTerminalRuntimeError(
+            'unauthorized',
+            'Terminal session ownership mismatch',
+            false
+          );
+        }
+        return;
+      }
+
+      for (const attached of attachedSessions.values()) {
+        if (
+          attached.kiloSessionId === identity.kiloSessionId ||
+          attached.directory === identity.directory
+        ) {
+          throw new ControlTerminalRuntimeError(
+            'unauthorized',
+            'Terminal session ownership mismatch',
+            false
+          );
+        }
+      }
+
+      attachedSessions.set(identity.sessionId, { ...identity, wrapperInstanceId });
+    },
+
+    async detachSession(identity) {
+      const attached = attachedSessions.get(identity.sessionId);
+      if (!attached) return;
+      if (!sameSession(attached, identity)) {
+        throw new ControlTerminalRuntimeError(
+          'unauthorized',
+          'Terminal session ownership mismatch',
+          false
+        );
+      }
+
+      attachedSessions.delete(identity.sessionId);
+      forgetAttachedRoot(identity.kiloSessionId, identity.directory);
+
+      const pending: Promise<unknown>[] = [];
+      for (const [operationId, operation] of operations) {
+        if (!sameSession(operation, attached)) continue;
+        operations.delete(operationId);
+        pending.push(operation.promise);
+      }
+
+      for (const [ptyId, terminal] of terminals) {
+        if (!sameSession(terminal, attached)) continue;
+        const bridge = bridges.get(ptyId);
+        if (bridge) closeBridge(bridge, 1000, 'PTY session ended');
+        terminals.delete(ptyId);
+        pending.push(kiloClient.deletePty(ptyId, terminal.directory));
+      }
+
+      await Promise.allSettled(pending);
+    },
+
+    async create(identity, payload) {
+      const existing = operations.get(payload.operationId);
+      if (existing) {
+        if (
+          existing.wrapperInstanceId !== wrapperInstanceId ||
+          !sameSession(existing, identity) ||
+          existing.cols !== payload.cols ||
+          existing.rows !== payload.rows
+        ) {
+          throw new ControlTerminalRuntimeError(
+            'idempotency_conflict',
+            'Terminal operation identity mismatch',
+            false
+          );
+        }
+        requireAttached(identity);
+        return existing.promise;
+      }
+
+      const attached = requireAttached(identity);
+      const promise = Promise.resolve().then(() => createTerminal(attached, payload));
+      const operation: TerminalCreationOperation = {
+        ...attached,
+        ...(payload.cols !== undefined ? { cols: payload.cols } : {}),
+        ...(payload.rows !== undefined ? { rows: payload.rows } : {}),
+        promise,
+      };
+      operations.set(payload.operationId, operation);
+      void promise.catch(() => {
+        if (operations.get(payload.operationId) === operation) {
+          operations.delete(payload.operationId);
+        }
+      });
+      return promise;
+    },
+
+    async resize(identity, payload) {
+      const terminal = requireTerminal(identity, payload.ptyId);
+      try {
+        const pty = await kiloClient.resizePty(
+          payload.ptyId,
+          { cols: payload.cols, rows: payload.rows },
+          terminal.directory
+        );
+        if (terminals.get(payload.ptyId) !== terminal) {
+          throw new ControlTerminalRuntimeError(
+            'unauthorized',
+            'Terminal ownership mismatch',
+            false
+          );
+        }
+        const result = sessionTerminalResizeResultSchema.safeParse({ pty });
+        if (
+          !result.success ||
+          result.data.pty.id !== payload.ptyId ||
+          result.data.pty.cwd !== terminal.directory
+        ) {
+          throw new ControlTerminalRuntimeError(
+            'protocol_error',
+            'Invalid terminal response',
+            false
+          );
+        }
+        return result.data;
+      } catch (error) {
+        throw safeKiloFailure(error, 'Terminal resize failed');
+      }
+    },
+
+    async close(identity, payload) {
+      const terminal = requireTerminal(identity, payload.ptyId, true);
+      try {
+        const success = await kiloClient.deletePty(payload.ptyId, terminal.directory);
+        if (success && terminals.get(payload.ptyId) === terminal) {
+          const bridge = bridges.get(payload.ptyId);
+          if (bridge) closeBridge(bridge, 1000, 'PTY session ended');
+          terminals.delete(payload.ptyId);
+          const operation = operations.get(terminal.operationId);
+          if (operation && sameSession(operation, terminal)) {
+            operations.delete(terminal.operationId);
+          }
+        }
+        return { success };
+      } catch (error) {
+        throw safeKiloFailure(error, 'Terminal closure failed');
+      }
+    },
+
+    async connect(identity, payload) {
+      const terminal = requireTerminal(identity, payload.ptyId);
+      if (terminal.ownerId !== undefined && terminal.ownerId !== payload.ownerId) {
+        throw new ControlTerminalRuntimeError('unauthorized', 'Terminal owner mismatch', false);
+      }
+
+      const current = bridges.get(payload.ptyId);
+      if (current?.bridgeGeneration === payload.bridgeGeneration) {
+        if (current.ownerId !== payload.ownerId || !current.connection) {
+          throw new ControlTerminalRuntimeError(
+            'unauthorized',
+            'Terminal connection ownership mismatch',
+            false
+          );
+        }
+        return current.connection;
+      }
+      if (current) closeBridge(current, 4000, 'Terminal connection replaced');
+
+      terminal.ownerId = payload.ownerId;
+      const reverseUrl = new URL(controlOrigin);
+      reverseUrl.pathname = `/sandbox-terminal/${encodeURIComponent(payload.ownerId)}/${encodeURIComponent(identity.sessionId)}/${encodeURIComponent(payload.ptyId)}`;
+      reverseUrl.search = '';
+      reverseUrl.hash = '';
+
+      let reverse: WebSocket;
+      try {
+        const WebSocketImpl = WebSocket as AuthenticatedWebSocketConstructor;
+        reverse = new WebSocketImpl(reverseUrl.toString(), {
+          headers: { Authorization: `Bearer ${payload.capability}` },
+        });
+      } catch {
+        throw new ControlTerminalRuntimeError('not_ready', 'Terminal transport failed', true);
+      }
+      reverse.binaryType = 'arraybuffer';
+
+      const bridge: TerminalBridge = {
+        terminal,
+        ownerId: payload.ownerId,
+        bridgeGeneration: payload.bridgeGeneration,
+        reverse,
+        closing: false,
+      };
+      bridges.set(payload.ptyId, bridge);
+      reverse.onmessage = event => forwardMessage(bridge, bridge.local, event.data);
+      reverse.onerror = () => {
+        if (isCurrentBridge(bridge)) closeBridge(bridge, 1011, 'Terminal transport failed');
+      };
+      reverse.onclose = event => {
+        if (!isCurrentBridge(bridge)) return;
+        if (event.code === 1000 && event.reason === 'PTY session ended') {
+          terminal.state = 'ended';
+        }
+        closeBridge(bridge, 1000, 'Terminal connection closed');
+      };
+      const connection = establishBridge(bridge);
+      bridge.connection = connection;
+      return connection;
+    },
+
+    shutdown() {
+      if (shutDown) return;
+      shutDown = true;
+      for (const bridge of bridges.values()) {
+        closeBridge(bridge, 1000, 'PTY session ended');
+      }
+      for (const attached of attachedSessions.values()) {
+        forgetAttachedRoot(attached.kiloSessionId, attached.directory);
+      }
+      bridges.clear();
+      terminals.clear();
+      operations.clear();
+      attachedSessions.clear();
+    },
+  };
+}

--- a/services/cloud-agent-next/wrapper/src/kilo-api.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.ts
@@ -291,8 +291,8 @@ export type WrapperKiloClient = {
     title: string;
     env: Record<string, string>;
   }) => Promise<WrapperPty>;
-  resizePty: (ptyId: string, size: WrapperPtySize) => Promise<WrapperPty>;
-  deletePty: (ptyId: string) => Promise<boolean>;
+  resizePty: (ptyId: string, size: WrapperPtySize, directory?: string) => Promise<WrapperPty>;
+  deletePty: (ptyId: string, directory?: string) => Promise<boolean>;
 
   /**
    * Subscribe to kilo events. The stream yields typed events until the abort
@@ -579,10 +579,10 @@ export function createWrapperKiloClient(
       return result.data as WrapperPty;
     },
 
-    resizePty: async (ptyId, size) => {
+    resizePty: async (ptyId, size, directory = workspacePath) => {
       const result = await v2Client.pty.update({
         ptyID: ptyId,
-        directory: workspacePath,
+        directory,
         size,
       });
       if (!result.data) {
@@ -591,10 +591,10 @@ export function createWrapperKiloClient(
       return result.data as WrapperPty;
     },
 
-    deletePty: async ptyId => {
+    deletePty: async (ptyId, directory = workspacePath) => {
       const result = await v2Client.pty.remove({
         ptyID: ptyId,
-        directory: workspacePath,
+        directory,
       });
       return Boolean(result.data);
     },

--- a/services/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -269,6 +269,19 @@ describe('restoreSession', () => {
     }
   });
 
+  it('returns an upstream failure for unauthorized snapshot responses', async () => {
+    mockFetchStatus(401);
+
+    const result = await restoreSession(SESSION_ID, workspace);
+
+    expect(result).toEqual({
+      ok: false,
+      error: 'download failed status=401',
+      code: 502,
+      step: 'download',
+    });
+  });
+
   it('returns a fixed download error when fetch throws', async () => {
     globalThis.fetch = asFetch(() => Promise.reject(new Error('network token secret')));
     const result = await restoreSession(SESSION_ID, workspace);
@@ -308,20 +321,38 @@ describe('restoreSession', () => {
     });
   });
 
-  it('does not treat an empty export with an extra error field as a missing snapshot', async () => {
-    mockFetchOk(
-      JSON.stringify({ info: {}, messages: [], sessionDiff: [], detail: 'upstream error' })
-    );
+  for (const [description, snapshot] of [
+    ['null session metadata', { info: null, messages: [], sessionDiff: [] }],
+    ['same-size malformed session diffs', { info: {}, messages: [], sessionDiff: {} }],
+    ['missing session diffs', { info: {}, messages: [] }],
+    [
+      'session metadata without an id',
+      { info: { title: 'Existing session' }, messages: [], sessionDiff: [] },
+    ],
+    [
+      'existing messages',
+      { info: {}, messages: [{ info: { id: 'msg_existing' } }], sessionDiff: [] },
+    ],
+    ['existing session diffs', { info: {}, messages: [], sessionDiff: [{ file: 'existing.txt' }] }],
+    [
+      'additional export fields',
+      { info: {}, messages: [], sessionDiff: [], detail: 'upstream error' },
+    ],
+  ] as const) {
+    it(`does not identify ${description} as an empty session export`, async () => {
+      mockFetchOk(JSON.stringify(snapshot));
 
-    const result = await restoreSession(SESSION_ID, workspace);
+      const result = await restoreSession(SESSION_ID, workspace);
 
-    expect(result.ok).toBe(false);
-    if (!result.ok) {
-      expect(result.error).toContain('snapshot missing info.id');
-      expect(result.code).toBeNull();
-      expect(result.step).toBe('download');
-    }
-  });
+      expect(result.ok).toBe(false);
+      if (!result.ok) {
+        expect(result.error).toContain('snapshot missing info.id');
+        expect(result.code).toBeNull();
+        expect(result.step).toBe('download');
+        expect(result).not.toHaveProperty('emptySnapshot');
+      }
+    });
+  }
 
   it('returns download error when the snapshot metadata is not JSON', async () => {
     mockFetchOk('not valid JSON {{{');

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -28,6 +28,7 @@ export type RestoreResult =
       step: 'download' | 'import' | 'diffs';
       subtype?: WorkspaceFailureSubtype;
       detail?: string;
+      emptySnapshot?: true;
     };
 
 type SnapshotDiff = {
@@ -44,6 +45,7 @@ export type RestoreSessionOptions = {
 };
 
 const KILO_IMPORT_TIMEOUT_MS = 120_000;
+const EMPTY_SESSION_INGEST_EXPORT = '{"info":{},"messages":[],"sessionDiff":[]}';
 const JQ_SANITIZE_TOKEN_COUNTS_FILTER =
   'walk(if type == "object" and ((.tokens? | type) == "object") then .tokens |= walk(if type == "number" and . < 0 then 0 else . end) else . end)';
 // Drop leftover CLI UI progress parts (metadata.kilocode.lifecycle == "transient").
@@ -75,7 +77,7 @@ function fail(
   step: Extract<RestoreResult, { ok: false }>['step'],
   subtype?: WorkspaceFailureSubtype,
   detail?: string
-): RestoreResult {
+): Extract<RestoreResult, { ok: false }> {
   return {
     ok: false,
     error,
@@ -756,12 +758,20 @@ export async function restoreSession(
         return fail('snapshot not found (empty export)', 404, 'download');
       }
       if (snapshotInfoValidation.validation === 'missing') {
-        log('snapshot missing info.id — likely an error response');
-        return fail(
+        const result = fail(
           `snapshot missing info.id (${bytesWritten} bytes); session-ingest may have returned an error body`,
           null,
           'download'
         );
+        if (
+          bytesWritten === EMPTY_SESSION_INGEST_EXPORT.length &&
+          (await Bun.file(tmpPath).text()) === EMPTY_SESSION_INGEST_EXPORT
+        ) {
+          log('snapshot contains no session metadata or history');
+          return { ...result, emptySnapshot: true };
+        }
+        log('snapshot missing info.id — likely an error response');
+        return result;
       }
     } catch {
       tryUnlink(tmpPath);


### PR DESCRIPTION
## Summary

Add interactive terminals for `workspace_*` sessions on the existing call-home control plane. Shared control messages negotiate terminal lifecycle; authenticated single-use reverse WebSockets relay raw PTY frames through `SandboxSession`. Legacy `agent_*` terminals are unchanged.

PTYs are bound to owner, session, root Kilo session, workspace directory, sandbox, wrapper runtime, and bridge generation. Credentials are scrubbed from the attach environment. Vercel billing stays fail-closed.