### PR TITLE
ci(deploy): scope Vercel tokens by project

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -82,14 +82,16 @@ jobs:
     with:
       target_environment: production
       vercel_project_id_var: VERCEL_PROJECT_ID_APP
-    secrets: inherit
+    secrets:
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_APP }}
 
   stage-global-app:
     uses: ./.github/workflows/stage-vercel-deployment.yml
     with:
       target_environment: production
       vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
-    secrets: inherit
+    secrets:
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}
 
   promote-app:
     needs: [stage-app, check-production-db-startup, run-migrations]
@@ -97,14 +99,17 @@ jobs:
     with:
       deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
       axiom_annotation_dataset: kilocode-app
-    secrets: inherit
+    secrets:
+      AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_APP }}
 
   promote-global-app:
     needs: [stage-global-app, check-production-db-startup, run-migrations]
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
-    secrets: inherit
+    secrets:
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}
 
   resolve-worker-base:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -79,7 +79,8 @@ jobs:
     with:
       target_environment: staging
       vercel_project_id_var: VERCEL_PROJECT_ID_APP
-    secrets: inherit
+    secrets:
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_APP }}
 
   deploy-global-app:
     needs: [check-staging-db-startup, run-migrations]
@@ -87,7 +88,8 @@ jobs:
     with:
       target_environment: staging
       vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
-    secrets: inherit
+    secrets:
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}
 
   deploy-workers:
     needs: [check-staging-db-startup, run-migrations, deploy-app, deploy-global-app]

--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -17,6 +17,13 @@ on:
         required: false
         type: string
         default: 'kilocode-app'
+    secrets:
+      VERCEL_PROJECT_TOKEN:
+        description: 'Vercel token scoped to the project being promoted'
+        required: true
+      AXIOM_ANNOTATION_TOKEN:
+        description: 'Optional Axiom token used to annotate the deployment'
+        required: false
 
 permissions:
   contents: read
@@ -35,7 +42,7 @@ jobs:
         run: npm install -g vercel@${{ env.VERCEL_VERSION }}
 
       - name: Promote Vercel deployment
-        run: vercel promote "${{ inputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
+        run: vercel promote "${{ inputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_PROJECT_TOKEN }}
 
       - name: Annotate production deployment in Axiom
         if: inputs.axiom_annotation_dataset != ''
@@ -48,7 +55,7 @@ jobs:
           AXIOM_ORG_ID: kilo-code-nvjh
           DEPLOYMENT_URL: ${{ inputs.deployment_url }}
           EXPECTED_PROJECT: ${{ inputs.axiom_expected_project }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_PROJECT_TOKEN }}
         run: |
           if [ -z "$AXIOM_ANNOTATION_TOKEN" ]; then
             echo "::warning::Skipping deployment annotation because AXIOM_ANNOTATION_TOKEN is not configured"

--- a/.github/workflows/redeploy-web.yml
+++ b/.github/workflows/redeploy-web.yml
@@ -29,7 +29,8 @@ jobs:
     with:
       target_environment: production
       vercel_project_id_var: VERCEL_PROJECT_ID_APP
-    secrets: inherit
+    secrets:
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_APP }}
 
   stage-global-app:
     needs: verify-main
@@ -37,7 +38,8 @@ jobs:
     with:
       target_environment: production
       vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
-    secrets: inherit
+    secrets:
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}
 
   promote-app:
     needs: stage-app
@@ -45,11 +47,14 @@ jobs:
     with:
       deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
       axiom_annotation_dataset: kilocode-app
-    secrets: inherit
+    secrets:
+      AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_APP }}
 
   promote-global-app:
     needs: stage-global-app
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
-    secrets: inherit
+    secrets:
+      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}

--- a/.github/workflows/stage-vercel-deployment.yml
+++ b/.github/workflows/stage-vercel-deployment.yml
@@ -15,6 +15,10 @@ on:
       deployment_url:
         description: 'Staged Vercel deployment URL'
         value: ${{ jobs.stage.outputs.deployment_url }}
+    secrets:
+      VERCEL_PROJECT_TOKEN:
+        description: 'Vercel token scoped to the project being deployed'
+        required: true
 
 permissions:
   contents: read
@@ -47,9 +51,9 @@ jobs:
         id: deploy
         run: |
           if [ "$TARGET_ENVIRONMENT" = "production" ]; then
-            deployment_output=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_TOKEN }})
+            deployment_output=$(vercel deploy --prod --skip-domain --token=${{ secrets.VERCEL_PROJECT_TOKEN }})
           else
-            deployment_output=$(vercel deploy --target="$TARGET_ENVIRONMENT" --token=${{ secrets.VERCEL_TOKEN }})
+            deployment_output=$(vercel deploy --target="$TARGET_ENVIRONMENT" --token=${{ secrets.VERCEL_PROJECT_TOKEN }})
           fi
 
           deployment_url=$(printf '%s\n' "$deployment_output" | tail -n 1)


### PR DESCRIPTION
## Summary

- use `VERCEL_TOKEN_APP` for `kilocode-app` staging, production, promotion, and manual redeploy jobs
- use `VERCEL_TOKEN_GLOBAL_APP` for equivalent `kilocode-global-app` jobs
- replace inherited secrets with an explicit `VERCEL_PROJECT_TOKEN` reusable-workflow interface

## Validation

- `actionlint .github/workflows/deploy-production.yml .github/workflows/deploy-staging.yml .github/workflows/promote-vercel-deployment.yml .github/workflows/redeploy-web.yml .github/workflows/stage-vercel-deployment.yml`
- `git diff --check`