### PR TITLE
fix(deploy): support project-scoped Vercel tokens

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -13,7 +13,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  VERCEL_VERSION: '53.3.1'
+  VERCEL_VERSION: '59.5.0'
   VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
 
 jobs:

--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -35,7 +35,7 @@ jobs:
     environment: production
 
     env:
-      VERCEL_VERSION: '53.3.1'
+      VERCEL_VERSION: '59.5.0'
 
     steps:
       - name: Install Vercel CLI

--- a/.github/workflows/stage-vercel-deployment.yml
+++ b/.github/workflows/stage-vercel-deployment.yml
@@ -34,7 +34,7 @@ jobs:
 
     env:
       TARGET_ENVIRONMENT: ${{ inputs.target_environment }}
-      VERCEL_VERSION: '53.3.1'
+      VERCEL_VERSION: '59.5.0'
       VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
       VERCEL_PROJECT_ID: ${{ vars[inputs.vercel_project_id_var] }}
 


### PR DESCRIPTION
## Summary

- upgrade the Vercel CLI from 53.3.1 to 59.5.0 across production staging and promotion workflows
- pick up upstream support for deployments authenticated with project-scoped tokens

## Root cause

Vercel CLI 53.3.1 fetched both the project and its owning team before deploying. The new project-scoped tokens can read their project but intentionally cannot read the team, so the CLI aborted with the misleading `Could not retrieve Project Settings` error before starting a build. Vercel added project-scoped deploy support in 56.3.1; 59.5.0 is the current stable release.

Upstream fix: https://github.com/vercel/vercel/pull/16999

## Validation

- `actionlint .github/workflows/deploy-production.yml .github/workflows/promote-vercel-deployment.yml .github/workflows/stage-vercel-deployment.yml`
- `git diff --check`
- `npm exec --yes --package=vercel@59.5.0 -- vercel --version`