### PR TITLE
fix(deploy): use global token for Vercel promotion

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -12,10 +12,6 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
-env:
-  VERCEL_VERSION: '59.5.0'
-  VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
-
 jobs:
   check-production-db-startup:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
@@ -98,6 +94,7 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
+      vercel_project_id_var: VERCEL_PROJECT_ID_APP
       axiom_annotation_dataset: kilocode-app
     secrets:
       AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
@@ -108,6 +105,7 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
+      vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
     secrets:
       VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}
 

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -101,7 +101,7 @@ jobs:
       axiom_annotation_dataset: kilocode-app
     secrets:
       AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
-      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_APP }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
   promote-global-app:
     needs: [stage-global-app, check-production-db-startup, run-migrations]
@@ -109,7 +109,7 @@ jobs:
     with:
       deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
     secrets:
-      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
   resolve-worker-base:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -12,6 +12,10 @@ concurrency:
   group: deploy-production
   cancel-in-progress: false
 
+env:
+  VERCEL_VERSION: '59.5.0'
+  VERCEL_ORG_ID: ${{ vars.VERCEL_ORG_ID }}
+
 jobs:
   check-production-db-startup:
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
@@ -94,7 +98,6 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
-      vercel_project_id_var: VERCEL_PROJECT_ID_APP
       axiom_annotation_dataset: kilocode-app
     secrets:
       AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
@@ -105,7 +108,6 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
-      vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
     secrets:
       VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}
 

--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -7,6 +7,10 @@ on:
         description: 'Vercel deployment URL to promote'
         required: true
         type: string
+      vercel_project_id_var:
+        description: 'Name of the GitHub variable containing the Vercel project ID to promote'
+        required: true
+        type: string
       axiom_annotation_dataset:
         description: 'Optional Axiom dataset used to scope deployment annotations'
         required: false
@@ -34,15 +38,89 @@ jobs:
     timeout-minutes: 15
     environment: production
 
-    env:
-      VERCEL_VERSION: '59.5.0'
-
     steps:
-      - name: Install Vercel CLI
-        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
-
       - name: Promote Vercel deployment
-        run: vercel promote "${{ inputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_PROJECT_TOKEN }}
+        id: promote
+        env:
+          DEPLOYMENT_URL: ${{ inputs.deployment_url }}
+          VERCEL_PROJECT_ID: ${{ vars[inputs.vercel_project_id_var] }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_PROJECT_TOKEN }}
+        run: |
+          deployment_host=${DEPLOYMENT_URL#https://}
+          deployment_host=${deployment_host%%/*}
+          deployment=$(curl --fail-with-body --silent --show-error \
+            --connect-timeout 5 \
+            --max-time 30 \
+            --header "Authorization: Bearer $VERCEL_TOKEN" \
+            "https://api.vercel.com/v13/deployments/$deployment_host")
+
+          deployment_id=$(jq -r '.id // empty' <<<"$deployment")
+          deployment_project_id=$(jq -r '.projectId // .project.id // empty' <<<"$deployment")
+          ready_state=$(jq -r '.readyState // empty' <<<"$deployment")
+
+          if [ -z "$VERCEL_PROJECT_ID" ]; then
+            echo "::error::Vercel project ID variable is not configured"
+            exit 1
+          fi
+          if [ -z "$deployment_id" ] || [ "$deployment_project_id" != "$VERCEL_PROJECT_ID" ]; then
+            echo "::error::Deployment does not belong to the expected Vercel project"
+            exit 1
+          fi
+          if [ "$ready_state" != "READY" ]; then
+            echo "::error::Deployment is not ready to promote (state=$ready_state)"
+            exit 1
+          fi
+
+          promotion_http_status=$(curl --fail-with-body --silent --show-error \
+            --connect-timeout 5 \
+            --max-time 30 \
+            --request POST \
+            --header "Authorization: Bearer $VERCEL_TOKEN" \
+            --header "Content-Type: application/json" \
+            --data '{}' \
+            --output /dev/null \
+            --write-out '%{http_code}' \
+            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/promote/$deployment_id")
+
+          echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
+          if [ "$promotion_http_status" = "202" ]; then
+            echo "Vercel queued promotion for deployment $deployment_id"
+            exit 0
+          fi
+
+          deadline=$((SECONDS + 180))
+          while (( SECONDS < deadline )); do
+            project=$(curl --fail-with-body --silent --show-error \
+              --connect-timeout 5 \
+              --max-time 30 \
+              --header "Authorization: Bearer $VERCEL_TOKEN" \
+              "https://api.vercel.com/v9/projects/$VERCEL_PROJECT_ID")
+            promoted_deployment_id=$(jq -r '.lastAliasRequest.toDeploymentId // empty' <<<"$project")
+            promotion_status=$(jq -r '.lastAliasRequest.jobStatus // empty' <<<"$project")
+            promotion_type=$(jq -r '.lastAliasRequest.type // empty' <<<"$project")
+
+            if [ "$promoted_deployment_id" = "$deployment_id" ]; then
+              if [ "$promotion_status" = "succeeded" ] || \
+                { [ "$promotion_status" = "skipped" ] && [ "$promotion_type" = "promote" ]; }; then
+                echo "Promoted Vercel deployment $deployment_id"
+                exit 0
+              fi
+              if [ "$promotion_status" = "failed" ]; then
+                curl --silent --show-error \
+                  --connect-timeout 5 \
+                  --max-time 30 \
+                  --header "Authorization: Bearer $VERCEL_TOKEN" \
+                  "https://api.vercel.com/v1/projects/$VERCEL_PROJECT_ID/promote/aliases?failedOnly=true&limit=100" || true
+                echo "::error::Vercel promotion failed"
+                exit 1
+              fi
+            fi
+
+            sleep 1
+          done
+
+          echo "::error::Vercel promotion did not complete within 3 minutes"
+          exit 1
 
       - name: Annotate production deployment in Axiom
         if: inputs.axiom_annotation_dataset != ''
@@ -53,9 +131,9 @@ jobs:
           AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
           AXIOM_DATASET: ${{ inputs.axiom_annotation_dataset }}
           AXIOM_ORG_ID: kilo-code-nvjh
-          DEPLOYMENT_URL: ${{ inputs.deployment_url }}
           EXPECTED_PROJECT: ${{ inputs.axiom_expected_project }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_PROJECT_TOKEN }}
+          DEPLOYMENT_ID: ${{ steps.promote.outputs.deployment_id }}
         run: |
           if [ -z "$AXIOM_ANNOTATION_TOKEN" ]; then
             echo "::warning::Skipping deployment annotation because AXIOM_ANNOTATION_TOKEN is not configured"
@@ -66,27 +144,11 @@ jobs:
           # deployment reports READY instead of failing on the first check.
           deployment=""
           for attempt in 1 2 3 4 5; do
-            inspection_error=$(mktemp)
-            if ! inspection=$(vercel inspect "$DEPLOYMENT_URL" --json --scope=kilocode --token="$VERCEL_TOKEN" 2>"$inspection_error"); then
-              echo "::warning::vercel inspect failed (attempt $attempt): $(<"$inspection_error")"
-              rm "$inspection_error"
-              if [ "$attempt" != "5" ]; then
-                sleep 5
-              fi
-              continue
-            fi
-            rm "$inspection_error"
-
-            deployment_id=$(jq -r '.id // empty' <<<"$inspection" 2>/dev/null || true)
-            if [ -z "$deployment_id" ]; then
-              echo "::warning::vercel inspect did not return a deployment id (attempt $attempt): $inspection"
-              if [ "$attempt" != "5" ]; then
-                sleep 5
-              fi
-              continue
-            fi
-
-            deployment=$(vercel api "/v13/deployments/$deployment_id" --raw --scope=kilocode --token="$VERCEL_TOKEN" 2>&1)
+            deployment=$(curl --fail-with-body --silent --show-error \
+              --connect-timeout 5 \
+              --max-time 30 \
+              --header "Authorization: Bearer $VERCEL_TOKEN" \
+              "https://api.vercel.com/v13/deployments/$DEPLOYMENT_ID" 2>&1) || true
             ready_state=$(jq -r '.readyState // empty' <<<"$deployment" 2>/dev/null)
             if [ "$ready_state" = "READY" ]; then
               break
@@ -113,7 +175,7 @@ jobs:
           commit_message=$(jq -r '(.meta.githubCommitMessage // "Commit message unavailable" | split("\n")[0])[0:360]' <<<"$deployment")
           commit_ref=$(jq -r '.meta.githubCommitRef // "unknown"' <<<"$deployment")
           commit_author=$(jq -r '.meta.githubCommitAuthorName // .creator.username // "unknown"' <<<"$deployment")
-          deployment_link="https://vercel.com/kilocode/$project/${deployment_id#dpl_}"
+          deployment_link="https://vercel.com/kilocode/$project/${DEPLOYMENT_ID#dpl_}"
 
           payload=$(jq -n \
             --arg dataset "$AXIOM_DATASET" \
@@ -134,7 +196,7 @@ jobs:
               --header "Content-Type: application/json" \
               --data "$payload" \
               https://api.axiom.co/v2/annotations 2>&1); then
-              echo "Created Axiom annotation for Vercel deployment $deployment_id"
+              echo "Created Axiom annotation for Vercel deployment $DEPLOYMENT_ID"
               exit 0
             else
               curl_exit=$?

--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -7,10 +7,6 @@ on:
         description: 'Vercel deployment URL to promote'
         required: true
         type: string
-      vercel_project_id_var:
-        description: 'Name of the GitHub variable containing the Vercel project ID to promote'
-        required: true
-        type: string
       axiom_annotation_dataset:
         description: 'Optional Axiom dataset used to scope deployment annotations'
         required: false
@@ -38,89 +34,15 @@ jobs:
     timeout-minutes: 15
     environment: production
 
+    env:
+      VERCEL_VERSION: '59.5.0'
+
     steps:
+      - name: Install Vercel CLI
+        run: npm install -g vercel@${{ env.VERCEL_VERSION }}
+
       - name: Promote Vercel deployment
-        id: promote
-        env:
-          DEPLOYMENT_URL: ${{ inputs.deployment_url }}
-          VERCEL_PROJECT_ID: ${{ vars[inputs.vercel_project_id_var] }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_PROJECT_TOKEN }}
-        run: |
-          deployment_host=${DEPLOYMENT_URL#https://}
-          deployment_host=${deployment_host%%/*}
-          deployment=$(curl --fail-with-body --silent --show-error \
-            --connect-timeout 5 \
-            --max-time 30 \
-            --header "Authorization: Bearer $VERCEL_TOKEN" \
-            "https://api.vercel.com/v13/deployments/$deployment_host")
-
-          deployment_id=$(jq -r '.id // empty' <<<"$deployment")
-          deployment_project_id=$(jq -r '.projectId // .project.id // empty' <<<"$deployment")
-          ready_state=$(jq -r '.readyState // empty' <<<"$deployment")
-
-          if [ -z "$VERCEL_PROJECT_ID" ]; then
-            echo "::error::Vercel project ID variable is not configured"
-            exit 1
-          fi
-          if [ -z "$deployment_id" ] || [ "$deployment_project_id" != "$VERCEL_PROJECT_ID" ]; then
-            echo "::error::Deployment does not belong to the expected Vercel project"
-            exit 1
-          fi
-          if [ "$ready_state" != "READY" ]; then
-            echo "::error::Deployment is not ready to promote (state=$ready_state)"
-            exit 1
-          fi
-
-          promotion_http_status=$(curl --fail-with-body --silent --show-error \
-            --connect-timeout 5 \
-            --max-time 30 \
-            --request POST \
-            --header "Authorization: Bearer $VERCEL_TOKEN" \
-            --header "Content-Type: application/json" \
-            --data '{}' \
-            --output /dev/null \
-            --write-out '%{http_code}' \
-            "https://api.vercel.com/v10/projects/$VERCEL_PROJECT_ID/promote/$deployment_id")
-
-          echo "deployment_id=$deployment_id" >> "$GITHUB_OUTPUT"
-          if [ "$promotion_http_status" = "202" ]; then
-            echo "Vercel queued promotion for deployment $deployment_id"
-            exit 0
-          fi
-
-          deadline=$((SECONDS + 180))
-          while (( SECONDS < deadline )); do
-            project=$(curl --fail-with-body --silent --show-error \
-              --connect-timeout 5 \
-              --max-time 30 \
-              --header "Authorization: Bearer $VERCEL_TOKEN" \
-              "https://api.vercel.com/v9/projects/$VERCEL_PROJECT_ID")
-            promoted_deployment_id=$(jq -r '.lastAliasRequest.toDeploymentId // empty' <<<"$project")
-            promotion_status=$(jq -r '.lastAliasRequest.jobStatus // empty' <<<"$project")
-            promotion_type=$(jq -r '.lastAliasRequest.type // empty' <<<"$project")
-
-            if [ "$promoted_deployment_id" = "$deployment_id" ]; then
-              if [ "$promotion_status" = "succeeded" ] || \
-                { [ "$promotion_status" = "skipped" ] && [ "$promotion_type" = "promote" ]; }; then
-                echo "Promoted Vercel deployment $deployment_id"
-                exit 0
-              fi
-              if [ "$promotion_status" = "failed" ]; then
-                curl --silent --show-error \
-                  --connect-timeout 5 \
-                  --max-time 30 \
-                  --header "Authorization: Bearer $VERCEL_TOKEN" \
-                  "https://api.vercel.com/v1/projects/$VERCEL_PROJECT_ID/promote/aliases?failedOnly=true&limit=100" || true
-                echo "::error::Vercel promotion failed"
-                exit 1
-              fi
-            fi
-
-            sleep 1
-          done
-
-          echo "::error::Vercel promotion did not complete within 3 minutes"
-          exit 1
+        run: vercel promote "${{ inputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_PROJECT_TOKEN }}
 
       - name: Annotate production deployment in Axiom
         if: inputs.axiom_annotation_dataset != ''
@@ -131,9 +53,9 @@ jobs:
           AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
           AXIOM_DATASET: ${{ inputs.axiom_annotation_dataset }}
           AXIOM_ORG_ID: kilo-code-nvjh
+          DEPLOYMENT_URL: ${{ inputs.deployment_url }}
           EXPECTED_PROJECT: ${{ inputs.axiom_expected_project }}
           VERCEL_TOKEN: ${{ secrets.VERCEL_PROJECT_TOKEN }}
-          DEPLOYMENT_ID: ${{ steps.promote.outputs.deployment_id }}
         run: |
           if [ -z "$AXIOM_ANNOTATION_TOKEN" ]; then
             echo "::warning::Skipping deployment annotation because AXIOM_ANNOTATION_TOKEN is not configured"
@@ -144,11 +66,27 @@ jobs:
           # deployment reports READY instead of failing on the first check.
           deployment=""
           for attempt in 1 2 3 4 5; do
-            deployment=$(curl --fail-with-body --silent --show-error \
-              --connect-timeout 5 \
-              --max-time 30 \
-              --header "Authorization: Bearer $VERCEL_TOKEN" \
-              "https://api.vercel.com/v13/deployments/$DEPLOYMENT_ID" 2>&1) || true
+            inspection_error=$(mktemp)
+            if ! inspection=$(vercel inspect "$DEPLOYMENT_URL" --json --scope=kilocode --token="$VERCEL_TOKEN" 2>"$inspection_error"); then
+              echo "::warning::vercel inspect failed (attempt $attempt): $(<"$inspection_error")"
+              rm "$inspection_error"
+              if [ "$attempt" != "5" ]; then
+                sleep 5
+              fi
+              continue
+            fi
+            rm "$inspection_error"
+
+            deployment_id=$(jq -r '.id // empty' <<<"$inspection" 2>/dev/null || true)
+            if [ -z "$deployment_id" ]; then
+              echo "::warning::vercel inspect did not return a deployment id (attempt $attempt): $inspection"
+              if [ "$attempt" != "5" ]; then
+                sleep 5
+              fi
+              continue
+            fi
+
+            deployment=$(vercel api "/v13/deployments/$deployment_id" --raw --scope=kilocode --token="$VERCEL_TOKEN" 2>&1)
             ready_state=$(jq -r '.readyState // empty' <<<"$deployment" 2>/dev/null)
             if [ "$ready_state" = "READY" ]; then
               break
@@ -175,7 +113,7 @@ jobs:
           commit_message=$(jq -r '(.meta.githubCommitMessage // "Commit message unavailable" | split("\n")[0])[0:360]' <<<"$deployment")
           commit_ref=$(jq -r '.meta.githubCommitRef // "unknown"' <<<"$deployment")
           commit_author=$(jq -r '.meta.githubCommitAuthorName // .creator.username // "unknown"' <<<"$deployment")
-          deployment_link="https://vercel.com/kilocode/$project/${DEPLOYMENT_ID#dpl_}"
+          deployment_link="https://vercel.com/kilocode/$project/${deployment_id#dpl_}"
 
           payload=$(jq -n \
             --arg dataset "$AXIOM_DATASET" \
@@ -196,7 +134,7 @@ jobs:
               --header "Content-Type: application/json" \
               --data "$payload" \
               https://api.axiom.co/v2/annotations 2>&1); then
-              echo "Created Axiom annotation for Vercel deployment $DEPLOYMENT_ID"
+              echo "Created Axiom annotation for Vercel deployment $deployment_id"
               exit 0
             else
               curl_exit=$?

--- a/.github/workflows/promote-vercel-deployment.yml
+++ b/.github/workflows/promote-vercel-deployment.yml
@@ -18,8 +18,8 @@ on:
         type: string
         default: 'kilocode-app'
     secrets:
-      VERCEL_PROJECT_TOKEN:
-        description: 'Vercel token scoped to the project being promoted'
+      VERCEL_TOKEN:
+        description: 'Vercel token used to promote the deployment'
         required: true
       AXIOM_ANNOTATION_TOKEN:
         description: 'Optional Axiom token used to annotate the deployment'
@@ -42,7 +42,7 @@ jobs:
         run: npm install -g vercel@${{ env.VERCEL_VERSION }}
 
       - name: Promote Vercel deployment
-        run: vercel promote "${{ inputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_PROJECT_TOKEN }}
+        run: vercel promote "${{ inputs.deployment_url }}" --scope=kilocode --token=${{ secrets.VERCEL_TOKEN }}
 
       - name: Annotate production deployment in Axiom
         if: inputs.axiom_annotation_dataset != ''
@@ -55,7 +55,7 @@ jobs:
           AXIOM_ORG_ID: kilo-code-nvjh
           DEPLOYMENT_URL: ${{ inputs.deployment_url }}
           EXPECTED_PROJECT: ${{ inputs.axiom_expected_project }}
-          VERCEL_TOKEN: ${{ secrets.VERCEL_PROJECT_TOKEN }}
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
         run: |
           if [ -z "$AXIOM_ANNOTATION_TOKEN" ]; then
             echo "::warning::Skipping deployment annotation because AXIOM_ANNOTATION_TOKEN is not configured"

--- a/.github/workflows/redeploy-web.yml
+++ b/.github/workflows/redeploy-web.yml
@@ -46,6 +46,7 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
+      vercel_project_id_var: VERCEL_PROJECT_ID_APP
       axiom_annotation_dataset: kilocode-app
     secrets:
       AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
@@ -56,5 +57,6 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
+      vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
     secrets:
       VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}

--- a/.github/workflows/redeploy-web.yml
+++ b/.github/workflows/redeploy-web.yml
@@ -49,7 +49,7 @@ jobs:
       axiom_annotation_dataset: kilocode-app
     secrets:
       AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
-      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_APP }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
 
   promote-global-app:
     needs: stage-global-app
@@ -57,4 +57,4 @@ jobs:
     with:
       deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
     secrets:
-      VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}
+      VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}

--- a/.github/workflows/redeploy-web.yml
+++ b/.github/workflows/redeploy-web.yml
@@ -46,7 +46,6 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-app.outputs.deployment_url }}
-      vercel_project_id_var: VERCEL_PROJECT_ID_APP
       axiom_annotation_dataset: kilocode-app
     secrets:
       AXIOM_ANNOTATION_TOKEN: ${{ secrets.AXIOM_ANNOTATION_TOKEN }}
@@ -57,6 +56,5 @@ jobs:
     uses: ./.github/workflows/promote-vercel-deployment.yml
     with:
       deployment_url: ${{ needs.stage-global-app.outputs.deployment_url }}
-      vercel_project_id_var: VERCEL_PROJECT_ID_GLOBAL_APP
     secrets:
       VERCEL_PROJECT_TOKEN: ${{ secrets.VERCEL_TOKEN_GLOBAL_APP }}


### PR DESCRIPTION
## Summary

- keep project-scoped Vercel tokens for stage deployments
- restore the global `VERCEL_TOKEN` for production promotion and deployment annotation
- retain Vercel CLI 59.5.0

## Root cause

Vercel CLI 59.5.0 supports project-scoped tokens for `vercel deploy`, and both stage jobs now pass. `vercel promote` still requires user/team access and fails with project-scoped tokens with `User not found (404)`. Rather than replacing the CLI promotion behavior, this restores the known-working global token only for promotion.

Failed run: https://github.com/Kilo-Org/cloud/actions/runs/32970706871

## Validation

- `actionlint .github/workflows/promote-vercel-deployment.yml .github/workflows/deploy-production.yml .github/workflows/redeploy-web.yml`
- `git diff --check`