### PR TITLE
fix(session-ingest): preserve concurrent same-host CLI connections

### DIFF
--- a/services/session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.test.ts
@@ -4117,13 +4117,44 @@ describe('UserConnectionDO', () => {
     });
   });
 
-  // -------------------------------------------------------------------------
-  // Same-host reconnect: a rebooted host advertises the same instance name and
-  // projectName on a fresh connectionId. The stale socket must be closed so
-  // `getConnectedInstances` lists the host exactly once.
-  // -------------------------------------------------------------------------
+  describe('same-host connections', () => {
+    it('keeps two same-folder clients connected when they advertise the same session', async () => {
+      const { doInstance, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj', version: '1.2.3' };
+      const sessions = [makeSession('shared', 'idle')];
 
-  describe('same-host replace', () => {
+      for (let cycle = 0; cycle < 3; cycle++) {
+        sendHeartbeat(doInstance, first, sessions, { instance });
+        sendHeartbeat(doInstance, second, sessions, { instance });
+
+        expect(first.close).not.toHaveBeenCalled();
+        expect(second.close).not.toHaveBeenCalled();
+        expect(doInstance.getConnectedInstances().instances).toEqual([
+          { connectionId: 'conn-1', ...instance },
+          { connectionId: 'conn-2', ...instance },
+        ]);
+      }
+    });
+
+    it('keeps two idle same-folder clients visible immediately', async () => {
+      const { doInstance, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj', version: '1.2.3' };
+
+      sendHeartbeat(doInstance, first, [], { instance });
+      sendHeartbeat(doInstance, second, [], { instance });
+
+      expect(first.close).not.toHaveBeenCalled();
+      expect(second.close).not.toHaveBeenCalled();
+      expect(doInstance.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-1', ...instance },
+        { connectionId: 'conn-2', ...instance },
+      ]);
+    });
+
     it('keeps concurrent same-host connections with distinct sessions open across repeated heartbeats', async () => {
       const { doInstance, mockCtx } = setup();
       const first = addCliSocket(mockCtx, 'conn-1');
@@ -4167,39 +4198,6 @@ describe('UserConnectionDO', () => {
       expect(doInstance.getConnectedInstances().instances).toHaveLength(3);
     });
 
-    it('replaces a same-host connection immediately when the new connection claims its session', async () => {
-      const { doInstance, mockCtx } = setup();
-      const first = addCliSocket(mockCtx, 'conn-1');
-      const second = addCliSocket(mockCtx, 'conn-2');
-      const instance = { name: 'host-a', projectName: 'proj' };
-
-      sendHeartbeat(doInstance, first, [makeSession('s1')], { instance });
-      sendHeartbeat(doInstance, second, [makeSession('s1')], { instance });
-
-      expect(first.close).toHaveBeenCalledWith(1000, 'replaced by same-host reconnect');
-      expect(second.close).not.toHaveBeenCalled();
-      expect(doInstance.getConnectedInstances().instances).toEqual([
-        { connectionId: 'conn-2', ...instance },
-      ]);
-    });
-
-    it('replaces a same-host connection when a later heartbeat claims its sessions', async () => {
-      const { doInstance, mockCtx } = setup();
-      const first = addCliSocket(mockCtx, 'conn-1');
-      const second = addCliSocket(mockCtx, 'conn-2');
-      const instance = { name: 'host-a', projectName: 'proj' };
-
-      sendHeartbeat(doInstance, first, [makeSession('s1')], { instance });
-      sendHeartbeat(doInstance, second, [], { instance });
-
-      expect(first.close).not.toHaveBeenCalled();
-
-      sendHeartbeat(doInstance, second, [makeSession('s1')], { instance });
-
-      expect(first.close).toHaveBeenCalledWith(1000, 'replaced by same-host reconnect');
-      expect(second.close).not.toHaveBeenCalled();
-    });
-
     it('keeps a same-host connection open when only some sessions transfer', async () => {
       const { doInstance, mockCtx } = setup();
       const first = addCliSocket(mockCtx, 'conn-1');
@@ -4235,7 +4233,7 @@ describe('UserConnectionDO', () => {
       ]);
     });
 
-    it('hides a stale same-host connection while keeping fresh concurrent connections open', async () => {
+    it('removes an expired same-host connection while keeping fresh concurrent connections open', async () => {
       const { doInstance, mockCtx } = setup();
       const stale = addCliSocket(mockCtx, 'conn-stale');
       const fresh = addCliSocket(mockCtx, 'conn-fresh');
@@ -4254,12 +4252,13 @@ describe('UserConnectionDO', () => {
       expect(stale.close).not.toHaveBeenCalled();
       expect(fresh.close).not.toHaveBeenCalled();
       expect(replacement.close).not.toHaveBeenCalled();
+      expect(doInstance.getConnectedInstances().instances).toHaveLength(3);
+
+      clock.mockReturnValue(now + 30_000);
       expect(doInstance.getConnectedInstances().instances).toEqual([
         { connectionId: 'conn-fresh', ...instance },
         { connectionId: 'conn-replacement', ...instance },
       ]);
-
-      clock.mockReturnValue(now + 30_000);
       await doInstance.alarm();
 
       expect(stale.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
@@ -4267,7 +4266,7 @@ describe('UserConnectionDO', () => {
       expect(replacement.close).not.toHaveBeenCalled();
     });
 
-    it('immediately hides a stale idle connection and closes it after the heartbeat timeout', async () => {
+    it('removes a stale idle connection from the instance list when its heartbeat expires', async () => {
       const { doInstance, mockCtx } = setup();
       const first = addCliSocket(mockCtx, 'conn-1');
       const second = addCliSocket(mockCtx, 'conn-2');
@@ -4281,19 +4280,23 @@ describe('UserConnectionDO', () => {
       expect(first.close).not.toHaveBeenCalled();
       expect(second.close).not.toHaveBeenCalled();
       expect(doInstance.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-1', ...instance },
         { connectionId: 'conn-2', ...instance },
       ]);
 
       clock.mockReturnValue(now + 29_000);
       sendHeartbeat(doInstance, second, [], { instance });
       clock.mockReturnValue(now + 30_000);
+      expect(doInstance.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-2', ...instance },
+      ]);
       await doInstance.alarm();
 
       expect(first.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
       expect(second.close).not.toHaveBeenCalled();
     });
 
-    it('preserves hidden stale instances across hibernation and restores a live instance on heartbeat', async () => {
+    it('preserves both same-folder instances across hibernation', async () => {
       const { doInstance, ctx, mockCtx } = setup();
       const first = addCliSocket(mockCtx, 'conn-1');
       const second = addCliSocket(mockCtx, 'conn-2');
@@ -4304,12 +4307,6 @@ describe('UserConnectionDO', () => {
 
       const restored = new UserConnectionDO(ctx as never, {} as never);
       expect(restored.getConnectedInstances().instances).toEqual([
-        { connectionId: 'conn-2', ...instance },
-      ]);
-
-      sendHeartbeat(restored, first, [], { instance });
-
-      expect(restored.getConnectedInstances().instances).toEqual([
         { connectionId: 'conn-1', ...instance },
         { connectionId: 'conn-2', ...instance },
       ]);
@@ -4317,7 +4314,7 @@ describe('UserConnectionDO', () => {
       expect(second.close).not.toHaveBeenCalled();
     });
 
-    it('expires a hidden stale connection after hibernation without resetting its heartbeat age', async () => {
+    it('expires a stale connection after hibernation without resetting its heartbeat age', async () => {
       const { doInstance, ctx, mockCtx } = setup();
       const first = addCliSocket(mockCtx, 'conn-1');
       const second = addCliSocket(mockCtx, 'conn-2');
@@ -4400,16 +4397,13 @@ describe('UserConnectionDO', () => {
       expect(second.close).not.toHaveBeenCalled();
     });
 
-    it('does not broadcast cli.disconnected or overwrite the owner-change terminal result for a same-host replaced socket', async () => {
+    it('preserves both clients when shared-session ownership changes during a pending command', async () => {
       const { doInstance, mockCtx } = setup();
       const first = addCliSocket(mockCtx, 'conn-1');
       const webWs = addWebSocket(mockCtx, 'web-1');
+      const instance = { name: 'host-a', projectName: 'proj' };
 
-      sendHeartbeat(doInstance, first, [makeSession('s1')], {
-        instance: { name: 'host-a', projectName: 'proj' },
-      });
-
-      // An owner-fenced pending command targets the first socket.
+      sendHeartbeat(doInstance, first, [makeSession('s1')], { instance });
       await sendCommand(doInstance, webWs, {
         id: 'cmd-1',
         command: 'send_message',
@@ -4418,22 +4412,13 @@ describe('UserConnectionDO', () => {
       });
       const correlationId = getCorrelationId(first);
       webWs.send.mockClear();
-
-      // A second socket on a different connectionId claims the same host.
       const second = addCliSocket(mockCtx, 'conn-2');
-      sendHeartbeat(doInstance, second, [makeSession('s1')], {
-        instance: { name: 'host-a', projectName: 'proj' },
-      });
-
-      expect(first.close).toHaveBeenCalledWith(1000, 'replaced by same-host reconnect');
-
-      // Drain the stale-close failPendingCommandsForSocket waitUntil so the
-      // owner-change terminal result settles before the close event runs.
+      sendHeartbeat(doInstance, second, [makeSession('s1')], { instance });
       await flushAsync();
 
-      // The stale close delivers the owner-change error, not 'CLI disconnected'.
-      const preClose = allSent(webWs);
-      expect(preClose.find(m => m.type === 'response' && m.id === 'cmd-1')).toEqual({
+      expect(first.close).not.toHaveBeenCalled();
+      expect(second.close).not.toHaveBeenCalled();
+      expect(allSent(webWs).find(message => message.id === 'cmd-1')).toEqual({
         type: 'response',
         id: 'cmd-1',
         error: {
@@ -4442,17 +4427,7 @@ describe('UserConnectionDO', () => {
           message: 'Session owner changed',
         },
       });
-      webWs.send.mockClear();
 
-      // The close event for the stale first socket now fires.
-      mockCtx.removeSocket(first);
-      await disconnectCli(doInstance, first);
-
-      const msgs = allSent(webWs);
-      expect(msgs.some(m => m.type === 'system' && m.event === 'cli.disconnected')).toBe(false);
-      expect(msgs.filter(m => m.type === 'response' && m.id === 'cmd-1')).toHaveLength(0);
-
-      // Durable terminal entry keeps the owner-change error.
       const durable = mockCtx.storage.store.get(`pendingCommand/${correlationId}`) as {
         state: string;
         error?: unknown;

--- a/services/session-ingest/src/dos/UserConnectionDO.test.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.test.ts
@@ -4124,33 +4124,248 @@ describe('UserConnectionDO', () => {
   // -------------------------------------------------------------------------
 
   describe('same-host replace', () => {
-    it('closes the stale socket when a second connectionId heartbeats the same instance identity', async () => {
+    it('keeps concurrent same-host connections with distinct sessions open across repeated heartbeats', async () => {
       const { doInstance, mockCtx } = setup();
       const first = addCliSocket(mockCtx, 'conn-1');
       const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj' };
 
-      sendHeartbeat(doInstance, first, [], {
-        instance: { name: 'host-a', projectName: 'proj' },
-      });
-      sendHeartbeat(doInstance, second, [], {
-        instance: { name: 'host-a', projectName: 'proj' },
-      });
+      sendHeartbeat(doInstance, first, [makeSession('s1')], { instance });
+      sendHeartbeat(doInstance, second, [makeSession('s2')], { instance });
+      sendHeartbeat(doInstance, first, [makeSession('s1')], { instance });
+      sendHeartbeat(doInstance, second, [makeSession('s2')], { instance });
+
+      expect(first.close).not.toHaveBeenCalled();
+      expect(second.close).not.toHaveBeenCalled();
+      expect(doInstance.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-1', ...instance },
+        { connectionId: 'conn-2', ...instance },
+      ]);
+      expect(doInstance.getActiveSessions()).toEqual([
+        expect.objectContaining({ id: 's1', connectionId: 'conn-1' }),
+        expect.objectContaining({ id: 's2', connectionId: 'conn-2' }),
+      ]);
+    });
+
+    it('keeps concurrent idle and active connections with the same instance identity open', async () => {
+      const { doInstance, mockCtx } = setup();
+      const idle = addCliSocket(mockCtx, 'conn-idle');
+      const active = addCliSocket(mockCtx, 'conn-active');
+      const otherIdle = addCliSocket(mockCtx, 'conn-other-idle');
+      const instance = { name: 'host-a', projectName: 'proj' };
+
+      sendHeartbeat(doInstance, idle, [], { instance });
+      sendHeartbeat(doInstance, active, [makeSession('s1')], { instance });
+      sendHeartbeat(doInstance, otherIdle, [], { instance });
+      sendHeartbeat(doInstance, idle, [], { instance });
+      sendHeartbeat(doInstance, active, [makeSession('s1')], { instance });
+      sendHeartbeat(doInstance, otherIdle, [], { instance });
+
+      expect(idle.close).not.toHaveBeenCalled();
+      expect(active.close).not.toHaveBeenCalled();
+      expect(otherIdle.close).not.toHaveBeenCalled();
+      expect(doInstance.getConnectedInstances().instances).toHaveLength(3);
+    });
+
+    it('replaces a same-host connection immediately when the new connection claims its session', async () => {
+      const { doInstance, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj' };
+
+      sendHeartbeat(doInstance, first, [makeSession('s1')], { instance });
+      sendHeartbeat(doInstance, second, [makeSession('s1')], { instance });
 
       expect(first.close).toHaveBeenCalledWith(1000, 'replaced by same-host reconnect');
       expect(second.close).not.toHaveBeenCalled();
+      expect(doInstance.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-2', ...instance },
+      ]);
+    });
 
-      // The mock close does not drop the socket; remove it to mirror the
-      // runtime close before asserting the live-instance scan.
-      mockCtx.removeSocket(first);
+    it('replaces a same-host connection when a later heartbeat claims its sessions', async () => {
+      const { doInstance, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj' };
 
-      const { instances } = doInstance.getConnectedInstances();
-      expect(instances).toHaveLength(1);
-      expect(instances[0].connectionId).toBe('conn-2');
-      expect(instances[0]).toEqual({
-        connectionId: 'conn-2',
-        name: 'host-a',
-        projectName: 'proj',
-      });
+      sendHeartbeat(doInstance, first, [makeSession('s1')], { instance });
+      sendHeartbeat(doInstance, second, [], { instance });
+
+      expect(first.close).not.toHaveBeenCalled();
+
+      sendHeartbeat(doInstance, second, [makeSession('s1')], { instance });
+
+      expect(first.close).toHaveBeenCalledWith(1000, 'replaced by same-host reconnect');
+      expect(second.close).not.toHaveBeenCalled();
+    });
+
+    it('keeps a same-host connection open when only some sessions transfer', async () => {
+      const { doInstance, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj' };
+
+      sendHeartbeat(doInstance, first, [makeSession('s1'), makeSession('s2')], { instance });
+      sendHeartbeat(doInstance, second, [makeSession('s2')], { instance });
+
+      expect(first.close).not.toHaveBeenCalled();
+      expect(second.close).not.toHaveBeenCalled();
+      expect(doInstance.getActiveSessions()).toEqual([
+        expect.objectContaining({ id: 's1', connectionId: 'conn-1' }),
+        expect.objectContaining({ id: 's2', connectionId: 'conn-2' }),
+      ]);
+    });
+
+    it('does not mark a closing connection as replaced when it retains another session', async () => {
+      const { doInstance, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj' };
+
+      sendHeartbeat(doInstance, first, [makeSession('s1'), makeSession('s2')], { instance });
+      first.readyState = WebSocket.CLOSING;
+      sendHeartbeat(doInstance, second, [makeSession('s2')], { instance });
+
+      expect(first.close).not.toHaveBeenCalled();
+      expect(first.deserializeAttachment()).not.toHaveProperty('replaced');
+      expect(doInstance.getActiveSessions()).toEqual([
+        expect.objectContaining({ id: 's1', connectionId: 'conn-1' }),
+        expect.objectContaining({ id: 's2', connectionId: 'conn-2' }),
+      ]);
+    });
+
+    it('hides a stale same-host connection while keeping fresh concurrent connections open', async () => {
+      const { doInstance, mockCtx } = setup();
+      const stale = addCliSocket(mockCtx, 'conn-stale');
+      const fresh = addCliSocket(mockCtx, 'conn-fresh');
+      const replacement = addCliSocket(mockCtx, 'conn-replacement');
+      const instance = { name: 'host-a', projectName: 'proj' };
+      const now = Date.now();
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      sendHeartbeat(doInstance, stale, [], { instance });
+      clock.mockReturnValue(now + 14_000);
+      sendHeartbeat(doInstance, fresh, [makeSession('s2')], { instance });
+      clock.mockReturnValue(now + 15_000);
+      sendHeartbeat(doInstance, replacement, [], { instance });
+      sendHeartbeat(doInstance, fresh, [makeSession('s2')], { instance });
+
+      expect(stale.close).not.toHaveBeenCalled();
+      expect(fresh.close).not.toHaveBeenCalled();
+      expect(replacement.close).not.toHaveBeenCalled();
+      expect(doInstance.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-fresh', ...instance },
+        { connectionId: 'conn-replacement', ...instance },
+      ]);
+
+      clock.mockReturnValue(now + 30_000);
+      await doInstance.alarm();
+
+      expect(stale.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
+      expect(fresh.close).not.toHaveBeenCalled();
+      expect(replacement.close).not.toHaveBeenCalled();
+    });
+
+    it('immediately hides a stale idle connection and closes it after the heartbeat timeout', async () => {
+      const { doInstance, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj' };
+      const now = Date.now();
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      sendHeartbeat(doInstance, first, [], { instance });
+      sendHeartbeat(doInstance, second, [], { instance });
+
+      expect(first.close).not.toHaveBeenCalled();
+      expect(second.close).not.toHaveBeenCalled();
+      expect(doInstance.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-2', ...instance },
+      ]);
+
+      clock.mockReturnValue(now + 29_000);
+      sendHeartbeat(doInstance, second, [], { instance });
+      clock.mockReturnValue(now + 30_000);
+      await doInstance.alarm();
+
+      expect(first.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
+      expect(second.close).not.toHaveBeenCalled();
+    });
+
+    it('preserves hidden stale instances across hibernation and restores a live instance on heartbeat', async () => {
+      const { doInstance, ctx, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj' };
+
+      sendHeartbeat(doInstance, first, [], { instance });
+      sendHeartbeat(doInstance, second, [], { instance });
+
+      const restored = new UserConnectionDO(ctx as never, {} as never);
+      expect(restored.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-2', ...instance },
+      ]);
+
+      sendHeartbeat(restored, first, [], { instance });
+
+      expect(restored.getConnectedInstances().instances).toEqual([
+        { connectionId: 'conn-1', ...instance },
+        { connectionId: 'conn-2', ...instance },
+      ]);
+      expect(first.close).not.toHaveBeenCalled();
+      expect(second.close).not.toHaveBeenCalled();
+    });
+
+    it('expires a hidden stale connection after hibernation without resetting its heartbeat age', async () => {
+      const { doInstance, ctx, mockCtx } = setup();
+      const first = addCliSocket(mockCtx, 'conn-1');
+      const second = addCliSocket(mockCtx, 'conn-2');
+      const instance = { name: 'host-a', projectName: 'proj' };
+      const now = Date.now();
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      sendHeartbeat(doInstance, first, [], { instance });
+      sendHeartbeat(doInstance, second, [], { instance });
+      clock.mockReturnValue(now + 29_000);
+      sendHeartbeat(doInstance, second, [], { instance });
+      clock.mockReturnValue(now + 30_000);
+
+      const restored = new UserConnectionDO(ctx as never, {} as never);
+      await restored.alarm();
+
+      expect(first.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
+      expect(second.close).not.toHaveBeenCalled();
+    });
+
+    it('preserves the first observed heartbeat time for legacy sockets across repeated hibernation', async () => {
+      const { doInstance, ctx, mockCtx } = setup();
+      const stale = addCliSocket(mockCtx, 'conn-stale');
+      const now = Date.now();
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+
+      doInstance.getActiveSessions();
+      clock.mockReturnValue(now + 29_000);
+      const firstRestore = new UserConnectionDO(ctx as never, {} as never);
+      firstRestore.getActiveSessions();
+      clock.mockReturnValue(now + 30_000);
+      const secondRestore = new UserConnectionDO(ctx as never, {} as never);
+      await secondRestore.alarm();
+
+      expect(stale.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
+    });
+
+    it('preserves the initial connection time when a CLI never sends a heartbeat', async () => {
+      const { doInstance, ctx } = setup();
+      const now = Date.now();
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(now);
+      const silent = connectCliSocket(doInstance, 'conn-silent');
+
+      clock.mockReturnValue(now + 30_000);
+      const restored = new UserConnectionDO(ctx as never, {} as never);
+      await restored.alarm();
+
+      expect(silent.close).toHaveBeenCalledWith(4408, 'heartbeat timeout');
     });
 
     it('keeps both sockets open when the projectName differs', async () => {
@@ -4206,7 +4421,7 @@ describe('UserConnectionDO', () => {
 
       // A second socket on a different connectionId claims the same host.
       const second = addCliSocket(mockCtx, 'conn-2');
-      sendHeartbeat(doInstance, second, [], {
+      sendHeartbeat(doInstance, second, [makeSession('s1')], {
         instance: { name: 'host-a', projectName: 'proj' },
       });
 

--- a/services/session-ingest/src/dos/UserConnectionDO.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.ts
@@ -47,6 +47,8 @@ type WSAttachment =
       // socket already heartbeated) and skips the `cliGone` pending-command
       // sweep and the `cli.disconnected` broadcast.
       replaced?: true;
+      hiddenUntilHeartbeat?: true;
+      heartbeatAt?: number;
       // Undefined means no protocolVersion has been reported yet — either the
       // CLI hasn't sent its first heartbeat, or it's a legacy build that
       // predates this field entirely. Both cases fall back to legacy behavior.
@@ -318,7 +320,11 @@ export class UserConnectionDO extends DurableObject<Env> {
         for (const session of sessions) {
           this.sessionOwners.set(session.id, connectionId);
         }
-        this.lastHeartbeatAt.set(connectionId, Date.now());
+        const heartbeatAt = attachment.heartbeatAt ?? Date.now();
+        this.lastHeartbeatAt.set(connectionId, heartbeatAt);
+        if (attachment.heartbeatAt === undefined) {
+          ws.serializeAttachment({ ...attachment, heartbeatAt });
+        }
       } else {
         if (attachment.replaced) continue;
         webCount++;
@@ -365,15 +371,16 @@ export class UserConnectionDO extends DurableObject<Env> {
       const reconnect = this.closeStaleSocket(connectionId);
 
       const kiloUserId = url.searchParams.get('kiloUserId') ?? undefined;
+      const now = Date.now();
       const attachment: WSAttachment = {
         role: 'cli',
         connectionId,
         sessions: [],
+        heartbeatAt: now,
         kiloUserId,
       };
       this.ctx.acceptWebSocket(server, ['cli']);
       server.serializeAttachment(attachment);
-      const now = Date.now();
       this.lastHeartbeatAt.set(connectionId, now);
       this.scheduleNextAlarm(now);
 
@@ -583,7 +590,16 @@ export class UserConnectionDO extends DurableObject<Env> {
     // Legacy CLIs omit `instance` entirely; only close a stale same-host
     // socket when the heartbeat actually carries an instance identity.
     if (instance) {
-      this.closeStaleSocketsForInstance(instance.name, instance.projectName, connectionId);
+      const isNewInstance =
+        attachment.instance?.name !== instance.name ||
+        attachment.instance.projectName !== instance.projectName;
+      this.closeStaleSocketsForInstance(
+        instance.name,
+        instance.projectName,
+        connectionId,
+        sessions,
+        isNewInstance
+      );
     }
     const now = Date.now();
     this.lastHeartbeatAt.set(connectionId, now);
@@ -658,6 +674,7 @@ export class UserConnectionDO extends DurableObject<Env> {
       role: 'cli',
       connectionId,
       sessions,
+      heartbeatAt: now,
       protocolVersion,
       capabilities,
       kiloUserId: attachment.kiloUserId,
@@ -1905,7 +1922,9 @@ export class UserConnectionDO extends DurableObject<Env> {
     const instances: ConnectedInstanceRow[] = [];
     for (const ws of this.ctx.getWebSockets('cli')) {
       const att = ws.deserializeAttachment() as WSAttachment | null;
-      if (att?.role !== 'cli' || !att.instance) continue;
+      if (att?.role !== 'cli' || !att.instance || att.replaced || att.hiddenUntilHeartbeat) {
+        continue;
+      }
       instances.push({
         connectionId: att.connectionId,
         name: att.instance.name,
@@ -2040,18 +2059,37 @@ export class UserConnectionDO extends DurableObject<Env> {
     return false;
   }
 
-  // Old form: one live CLI socket per connectionId, including a rebooted host's stale socket. Remove when every CLI advertises a stable host id.
   private closeStaleSocketsForInstance(
     name: string,
     projectName: string,
-    keepConnectionId: string
+    keepConnectionId: string,
+    sessions: HeartbeatSession[],
+    isNewInstance: boolean
   ): void {
     if (!name || !projectName) return;
 
+    const incomingSessionIds = new Set(sessions.map(session => session.id));
+
     for (const ws of this.ctx.getWebSockets('cli')) {
       const att = ws.deserializeAttachment() as WSAttachment | null;
-      if (att?.role !== 'cli' || att.connectionId === keepConnectionId) continue;
+      if (att?.role !== 'cli' || att.connectionId === keepConnectionId || att.replaced) continue;
       if (att.instance?.name !== name || att.instance?.projectName !== projectName) continue;
+
+      const ownsSameSessions =
+        att.sessions.length > 0 &&
+        att.sessions.length === incomingSessionIds.size &&
+        att.sessions.every(session => incomingSessionIds.has(session.id));
+      if (!ownsSameSessions) {
+        if (
+          ws.readyState === WebSocket.OPEN &&
+          isNewInstance &&
+          att.sessions.length === 0 &&
+          sessions.length === 0
+        ) {
+          ws.serializeAttachment({ ...att, hiddenUntilHeartbeat: true });
+        }
+        continue;
+      }
 
       console.log('Closing stale CLI socket for same-host reconnect', {
         connectionId: att.connectionId,

--- a/services/session-ingest/src/dos/UserConnectionDO.ts
+++ b/services/session-ingest/src/dos/UserConnectionDO.ts
@@ -42,12 +42,6 @@ type WSAttachment =
       role: 'cli';
       connectionId: string;
       sessions: HeartbeatSession[];
-      // Set on a stale same-host socket just before its close so
-      // `handleCliDisconnect` treats the close as a replacement (the new
-      // socket already heartbeated) and skips the `cliGone` pending-command
-      // sweep and the `cli.disconnected` broadcast.
-      replaced?: true;
-      hiddenUntilHeartbeat?: true;
       heartbeatAt?: number;
       // Undefined means no protocolVersion has been reported yet — either the
       // CLI hasn't sent its first heartbeat, or it's a legacy build that
@@ -587,20 +581,6 @@ export class UserConnectionDO extends DurableObject<Env> {
     instance: Instance | undefined
   ): void {
     const { connectionId } = attachment;
-    // Legacy CLIs omit `instance` entirely; only close a stale same-host
-    // socket when the heartbeat actually carries an instance identity.
-    if (instance) {
-      const isNewInstance =
-        attachment.instance?.name !== instance.name ||
-        attachment.instance.projectName !== instance.projectName;
-      this.closeStaleSocketsForInstance(
-        instance.name,
-        instance.projectName,
-        connectionId,
-        sessions,
-        isNewInstance
-      );
-    }
     const now = Date.now();
     this.lastHeartbeatAt.set(connectionId, now);
     this.connectionProtocolVersion.set(connectionId, protocolVersion);
@@ -1758,16 +1738,11 @@ export class UserConnectionDO extends DurableObject<Env> {
     // Exclude the closing socket: under wrangler/workerd, getWebSockets() still
     // includes it during webSocketClose, so matching self would always look "replaced"
     // and skip ownership cleanup + attention reset (DEF-5 E2E failure).
-    // A same-host replacement sets the `replaced` marker on this socket's own
-    // attachment before closing (see closeStaleSocketsForInstance), because its
-    // replacement carries a different connectionId.
-    const replaced =
-      attachment.replaced ||
-      this.ctx.getWebSockets('cli').some(ws => {
-        if (ws === disconnectedWs) return false;
-        const att = ws.deserializeAttachment() as WSAttachment | null;
-        return att?.role === 'cli' && att.connectionId === connectionId;
-      });
+    const replaced = this.ctx.getWebSockets('cli').some(ws => {
+      if (ws === disconnectedWs) return false;
+      const att = ws.deserializeAttachment() as WSAttachment | null;
+      return att?.role === 'cli' && att.connectionId === connectionId;
+    });
 
     // Fail pending commands that targeted this specific socket.
     // Await so the durable terminal entries are persisted before we proceed
@@ -1920,9 +1895,12 @@ export class UserConnectionDO extends DurableObject<Env> {
   getConnectedInstances(): { instances: ConnectedInstanceRow[] } {
     this.ensureState();
     const instances: ConnectedInstanceRow[] = [];
+    const now = Date.now();
     for (const ws of this.ctx.getWebSockets('cli')) {
       const att = ws.deserializeAttachment() as WSAttachment | null;
-      if (att?.role !== 'cli' || !att.instance || att.replaced || att.hiddenUntilHeartbeat) {
+      if (att?.role !== 'cli' || !att.instance || ws.readyState !== WebSocket.OPEN) continue;
+      const heartbeatAt = this.lastHeartbeatAt.get(att.connectionId);
+      if (heartbeatAt !== undefined && now - heartbeatAt >= UserConnectionDO.HEARTBEAT_TIMEOUT_MS) {
         continue;
       }
       instances.push({
@@ -2057,60 +2035,6 @@ export class UserConnectionDO extends DurableObject<Env> {
       }
     }
     return false;
-  }
-
-  private closeStaleSocketsForInstance(
-    name: string,
-    projectName: string,
-    keepConnectionId: string,
-    sessions: HeartbeatSession[],
-    isNewInstance: boolean
-  ): void {
-    if (!name || !projectName) return;
-
-    const incomingSessionIds = new Set(sessions.map(session => session.id));
-
-    for (const ws of this.ctx.getWebSockets('cli')) {
-      const att = ws.deserializeAttachment() as WSAttachment | null;
-      if (att?.role !== 'cli' || att.connectionId === keepConnectionId || att.replaced) continue;
-      if (att.instance?.name !== name || att.instance?.projectName !== projectName) continue;
-
-      const ownsSameSessions =
-        att.sessions.length > 0 &&
-        att.sessions.length === incomingSessionIds.size &&
-        att.sessions.every(session => incomingSessionIds.has(session.id));
-      if (!ownsSameSessions) {
-        if (
-          ws.readyState === WebSocket.OPEN &&
-          isNewInstance &&
-          att.sessions.length === 0 &&
-          sessions.length === 0
-        ) {
-          ws.serializeAttachment({ ...att, hiddenUntilHeartbeat: true });
-        }
-        continue;
-      }
-
-      console.log('Closing stale CLI socket for same-host reconnect', {
-        connectionId: att.connectionId,
-        name,
-        projectName,
-      });
-      this.ctx.waitUntil(
-        this.failPendingCommandsForSocket(ws, false).catch((error: unknown) => {
-          console.error('Failed to persist terminal commands for stale socket', {
-            connectionId: att.connectionId,
-            error: error instanceof Error ? error.message : String(error),
-          });
-        })
-      );
-      // Preserve session ownership — the rebooting host's replacement socket
-      // re-claims the same sessions in its first heartbeat.
-      // Mark the attachment so `handleCliDisconnect` routes this close through
-      // the `replaced` early-return (the replacement already heartbeated).
-      ws.serializeAttachment({ ...att, replaced: true });
-      ws.close(1000, 'replaced by same-host reconnect');
-    }
   }
 
   private replaceWebSocket(connectionId: string): void {


### PR DESCRIPTION
## Summary
- Keep concurrent CLI clients in the same folder connected and visible.
- Preserve both clients when their session lists are identical, overlapping, distinct, or empty.
- Persist heartbeat timestamps across Durable Object hibernation and exclude expired instances from the picker.

## Verification
- `pnpm --filter cloudflare-session-ingest test` — 919 passed, 3 skipped.
- `pnpm --filter cloudflare-session-ingest typecheck`.
- `pnpm --filter cloudflare-session-ingest lint`.
- `pnpm format`.