### PR TITLE
fix: keep sub-organization overview available

### DIFF
--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationSections.test.ts
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationSections.test.ts
@@ -1,0 +1,53 @@
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import { OverviewSection } from './SubOrganizationSections';
+
+globalThis.React = React;
+
+const overview = {
+  canCreateSubOrganizations: false,
+  children: [
+    {
+      id: 'd69f3c69-2fe8-4752-bd91-8a493b8581b3',
+      name: 'Child organization',
+      plan: 'enterprise' as const,
+      requireSeats: true,
+      memberCount: 4,
+      pendingInvitationCount: 0,
+      seatCount: { used: 4, total: 10 },
+      balanceMicrodollars: 25_000_000,
+    },
+  ],
+};
+
+describe('OverviewSection usage data states', () => {
+  it('keeps organization details visible when usage data is unavailable', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OverviewSection, {
+        organizationId: '4ab109e4-2558-4290-84d8-894bd50bbdac',
+        data: overview,
+        spendByOrganization: new Map(),
+        usageDataStatus: 'unavailable',
+      })
+    );
+
+    expect(html).toContain('Child organization');
+    expect(html).toContain('30-day usage data is temporarily unavailable');
+    expect(html).toContain('Unavailable');
+  });
+
+  it('shows spend when usage data is available', () => {
+    const html = renderToStaticMarkup(
+      React.createElement(OverviewSection, {
+        organizationId: '4ab109e4-2558-4290-84d8-894bd50bbdac',
+        data: overview,
+        spendByOrganization: new Map([[overview.children[0].id, 1_500_000]]),
+        usageDataStatus: 'available',
+      })
+    );
+
+    expect(html).toContain('$1.50');
+    expect(html).not.toContain('temporarily unavailable');
+  });
+});

--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationSections.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationSections.tsx
@@ -46,6 +46,8 @@ export type UsageByOrganization = Map<
   { costMicrodollars: number; requests: number; tokens: number }
 >;
 
+export type UsageDataStatus = 'loading' | 'available' | 'unavailable';
+
 function OrganizationLink({ id, name }: { id: string; name: string }) {
   return (
     <Link
@@ -97,10 +99,12 @@ export function OverviewSection({
   organizationId,
   data,
   spendByOrganization,
+  usageDataStatus,
 }: {
   organizationId: string;
   data: Overview;
   spendByOrganization: Map<string, number>;
+  usageDataStatus: UsageDataStatus;
 }) {
   return (
     <Card>
@@ -116,50 +120,67 @@ export function OverviewSection({
           <CreateSubOrganizationButton organizationId={organizationId} />
         )}
       </CardHeader>
-      <CardContent className="overflow-x-auto">
+      <CardContent className="space-y-4">
+        {usageDataStatus === 'unavailable' && (
+          <Alert variant="warning">
+            <AlertTriangle className="size-4" />
+            <AlertDescription>
+              30-day usage data is temporarily unavailable. Organization details remain current, but
+              spend cannot be shown right now.
+            </AlertDescription>
+          </Alert>
+        )}
         {data.children.length === 0 ? (
           <p className="text-muted-foreground py-6 text-center text-sm">
             No sub-organizations yet. Create one to start managing it separately.
           </p>
         ) : (
-          <Table>
-            <TableHeader>
-              <TableRow>
-                <TableHead>Sub-organization</TableHead>
-                <TableHead>Plan</TableHead>
-                <TableHead className="text-right">Members</TableHead>
-                <TableHead className="text-right">Seats</TableHead>
-                <TableHead className="text-right">Credit balance</TableHead>
-                <TableHead className="text-right">Spend (30 days)</TableHead>
-              </TableRow>
-            </TableHeader>
-            <TableBody>
-              {data.children.map(child => (
-                <TableRow key={child.id}>
-                  <TableCell className="font-medium">
-                    <OrganizationLink id={child.id} name={child.name} />
-                  </TableCell>
-                  <TableCell>
-                    <Badge variant="outline" className="capitalize">
-                      {child.plan}
-                    </Badge>
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums">{child.memberCount}</TableCell>
-                  <TableCell className="text-right tabular-nums">
-                    {child.requireSeats
-                      ? `${child.seatCount.used} / ${child.seatCount.total}`
-                      : 'Not required'}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums">
-                    {formatMicrodollars(child.balanceMicrodollars)}
-                  </TableCell>
-                  <TableCell className="text-right tabular-nums">
-                    {formatMicrodollars(spendByOrganization.get(child.id) ?? 0)}
-                  </TableCell>
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Sub-organization</TableHead>
+                  <TableHead>Plan</TableHead>
+                  <TableHead className="text-right">Members</TableHead>
+                  <TableHead className="text-right">Seats</TableHead>
+                  <TableHead className="text-right">Credit balance</TableHead>
+                  <TableHead className="text-right">Spend (30 days)</TableHead>
                 </TableRow>
-              ))}
-            </TableBody>
-          </Table>
+              </TableHeader>
+              <TableBody>
+                {data.children.map(child => (
+                  <TableRow key={child.id}>
+                    <TableCell className="font-medium">
+                      <OrganizationLink id={child.id} name={child.name} />
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="outline" className="capitalize">
+                        {child.plan}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">{child.memberCount}</TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {child.requireSeats
+                        ? `${child.seatCount.used} / ${child.seatCount.total}`
+                        : 'Not required'}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatMicrodollars(child.balanceMicrodollars)}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {usageDataStatus === 'loading' ? (
+                        <Skeleton className="ml-auto h-4 w-16" />
+                      ) : usageDataStatus === 'unavailable' ? (
+                        <span className="text-muted-foreground">Unavailable</span>
+                      ) : (
+                        formatMicrodollars(spendByOrganization.get(child.id) ?? 0)
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
         )}
       </CardContent>
     </Card>
@@ -559,10 +580,12 @@ export function CreditsSection({
   organizationId,
   data,
   thirtyDaySpend,
+  usageDataStatus,
 }: {
   organizationId: string;
   data: Credits;
   thirtyDaySpend: Map<string, number>;
+  usageDataStatus: UsageDataStatus;
 }) {
   return (
     <div className="space-y-4">
@@ -572,6 +595,15 @@ export function CreditsSection({
           <AlertDescription>
             Kilo Pass allocation data is temporarily unavailable. Credit balances and usage remain
             current.
+          </AlertDescription>
+        </Alert>
+      )}
+      {usageDataStatus === 'unavailable' && (
+        <Alert variant="warning">
+          <AlertTriangle className="size-4" />
+          <AlertDescription>
+            30-day usage data is temporarily unavailable. Credit balances remain current, but burn
+            and runway cannot be calculated right now.
           </AlertDescription>
         </Alert>
       )}
@@ -650,10 +682,24 @@ export function CreditsSection({
                           : 'None'}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
-                      {formatMicrodollars(spend)}
+                      {usageDataStatus === 'loading' ? (
+                        <Skeleton className="ml-auto h-4 w-16" />
+                      ) : usageDataStatus === 'unavailable' ? (
+                        <span className="text-muted-foreground">Unavailable</span>
+                      ) : (
+                        formatMicrodollars(spend)
+                      )}
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
-                      {runway === null ? 'No observed burn' : `${Math.floor(runway)} days`}
+                      {usageDataStatus === 'loading' ? (
+                        <Skeleton className="ml-auto h-4 w-20" />
+                      ) : usageDataStatus === 'unavailable' ? (
+                        <span className="text-muted-foreground">Unavailable</span>
+                      ) : runway === null ? (
+                        'No observed burn'
+                      ) : (
+                        `${Math.floor(runway)} days`
+                      )}
                     </TableCell>
                   </TableRow>
                 );

--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
@@ -159,7 +159,7 @@ export function SubOrganizationsPage({
   );
   const usageDataStatus: UsageDataStatus = thirtyDaySpend.data
     ? 'available'
-    : thirtyDaySpend.error
+    : thirtyDaySpend.error || overview.error || thirtyDaySpend.fetchStatus === 'idle'
       ? 'unavailable'
       : 'loading';
   const selectedUsage = useMemo<UsageByOrganization>(() => {

--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
@@ -159,9 +159,11 @@ export function SubOrganizationsPage({
   );
   const usageDataStatus: UsageDataStatus = thirtyDaySpend.data
     ? 'available'
-    : thirtyDaySpend.error || overview.error || thirtyDaySpend.fetchStatus === 'idle'
+    : thirtyDaySpend.error || overview.error
       ? 'unavailable'
-      : 'loading';
+      : overview.data && !hasChildren
+        ? 'available'
+        : 'loading';
   const selectedUsage = useMemo<UsageByOrganization>(() => {
     const costs = toMetricMap(usageCost.data?.breakdown);
     const requests = toMetricMap(usageRequests.data?.breakdown);

--- a/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
+++ b/apps/web/src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationsPage.tsx
@@ -34,6 +34,7 @@ import {
   PermissionsSection,
   SectionState,
   UsageSection,
+  type UsageDataStatus,
   type UsageByOrganization,
 } from './SubOrganizationSections';
 import { DistributeFundsPage } from './distribute-funds/DistributeFundsPage';
@@ -156,6 +157,11 @@ export function SubOrganizationsPage({
     () => toMetricMap(thirtyDaySpend.data?.breakdown),
     [thirtyDaySpend.data?.breakdown]
   );
+  const usageDataStatus: UsageDataStatus = thirtyDaySpend.data
+    ? 'available'
+    : thirtyDaySpend.error
+      ? 'unavailable'
+      : 'loading';
   const selectedUsage = useMemo<UsageByOrganization>(() => {
     const costs = toMetricMap(usageCost.data?.breakdown);
     const requests = toMetricMap(usageRequests.data?.breakdown);
@@ -177,7 +183,6 @@ export function SubOrganizationsPage({
     usageTokens.data?.breakdown,
   ]);
 
-  const overviewError = overview.error ?? thirtyDaySpend.error;
   const usageError = usageCost.error ?? usageRequests.error ?? usageTokens.error;
   const usageLoading = usageCost.isLoading || usageRequests.isLoading || usageTokens.isLoading;
 
@@ -208,15 +213,13 @@ export function SubOrganizationsPage({
         </div>
 
         <TabsContent value="overview" className="mt-6">
-          <SectionState
-            isLoading={overview.isLoading || thirtyDaySpend.isLoading}
-            error={overviewError}
-          >
+          <SectionState isLoading={overview.isLoading} error={overview.error}>
             {overview.data && (
               <OverviewSection
                 organizationId={organizationId}
                 data={overview.data}
                 spendByOrganization={thirtyDaySpendByOrganization}
+                usageDataStatus={usageDataStatus}
               />
             )}
           </SectionState>
@@ -255,15 +258,13 @@ export function SubOrganizationsPage({
         </TabsContent>
 
         <TabsContent value="credits" className="mt-6">
-          <SectionState
-            isLoading={credits.isLoading || thirtyDaySpend.isLoading}
-            error={credits.error ?? thirtyDaySpend.error}
-          >
+          <SectionState isLoading={credits.isLoading} error={credits.error}>
             {credits.data && (
               <CreditsSection
                 organizationId={organizationId}
                 data={credits.data}
                 thirtyDaySpend={thirtyDaySpendByOrganization}
+                usageDataStatus={usageDataStatus}
               />
             )}
           </SectionState>


### PR DESCRIPTION
## Summary
- decouple sub-organization overview and credits data from the 30-day usage query
- show loading placeholders and a scoped warning when spend analytics are unavailable
- avoid presenting unavailable spend and runway as zero values

## Verification
- `pnpm --filter web exec jest --runInBand --runTestsByPath "src/app/(app)/organizations/[id]/sub-organizations/SubOrganizationSections.test.ts"`
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`