### PR TITLE
feat(cloud-agent-next): add isolated Standard allocation

### DIFF
--- a/apps/web/src/routers/admin-session-traces.test.ts
+++ b/apps/web/src/routers/admin-session-traces.test.ts
@@ -234,7 +234,7 @@ describe('admin.sessionTraces authorization', () => {
     const viewer = await insertAdmin({ can_view_sessions: true });
     const sessionId = `ses_${crypto.randomUUID()}`;
     const cloudAgentSessionId = `agent_${crypto.randomUUID()}`;
-    const sandboxId = `ses-${'a'.repeat(48)}`;
+    const sandboxId = `istd-${'a'.repeat(48)}`;
     await db.insert(cli_sessions_v2).values({
       session_id: sessionId,
       kilo_user_id: owner.id,
@@ -250,17 +250,17 @@ describe('admin.sessionTraces authorization', () => {
       created_at: '2026-07-31T08:43:36.040Z',
     });
     await db.insert(cloud_billing_sku).values({
-      id: 'cloud-agent-small-test',
-      name: 'Cloud Agent Small',
+      id: 'cloud-agent-standard-test',
+      name: 'Cloud Agent Standard',
       unit: 'second',
       rate_cents_per_unit: '0.001',
     });
     await db.insert(container_usage_interval).values({
-      id: `cloud-agent-next-sandbox-small-containment:${sandboxId}:1`,
-      service: 'cloud-agent-next-sandbox-small-containment',
+      id: `cloud-agent-next-sandbox-containment:${sandboxId}:1`,
+      service: 'cloud-agent-next-sandbox-containment',
       instance_id: sandboxId,
       start_epoch_ms: 1,
-      cloud_billing_sku_id: 'cloud-agent-small-test',
+      cloud_billing_sku_id: 'cloud-agent-standard-test',
       context_fingerprint: 'b'.repeat(64),
       subject_type: 'user',
       subject_id: owner.id,
@@ -271,10 +271,10 @@ describe('admin.sessionTraces authorization', () => {
       last_seen_at: '2026-07-31T09:30:00.000Z',
       metadata: {
         durable_object_id: 'durable-object-id',
-        container_class: 'SandboxSmallContainment',
-        vcpu: '2',
-        memory_mib: '6144',
-        disk_mb: '10000',
+        container_class: 'SandboxContainment',
+        vcpu: '4',
+        memory_mib: '12288',
+        disk_mb: '20000',
       },
     });
 
@@ -288,9 +288,9 @@ describe('admin.sessionTraces authorization', () => {
       intervals: [
         {
           cloudflareInstanceId: 'durable-object-id',
-          containerClass: 'SandboxSmallContainment',
-          sku: { id: 'cloud-agent-small-test', name: 'Cloud Agent Small' },
-          capacity: { vcpu: 2, memoryBytes: 6_442_450_944, diskBytes: 10_000_000_000 },
+          containerClass: 'SandboxContainment',
+          sku: { id: 'cloud-agent-standard-test', name: 'Cloud Agent Standard' },
+          capacity: { vcpu: 4, memoryBytes: 12_884_901_888, diskBytes: 20_000_000_000 },
           capacitySource: 'recorded',
         },
       ],
@@ -305,7 +305,7 @@ describe('admin.sessionTraces authorization', () => {
     ).resolves.toMatchObject({ available: true });
     expect(providerWindows).toEqual([
       {
-        key: `cloud-agent-next-sandbox-small-containment:${sandboxId}:1`,
+        key: `cloud-agent-next-sandbox-containment:${sandboxId}:1`,
         instanceId: 'durable-object-id',
         start: '2026-07-31T08:33:36.040Z',
         end: '2026-07-31T09:05:07.000Z',

--- a/apps/web/src/routers/admin/session-container-telemetry.ts
+++ b/apps/web/src/routers/admin/session-container-telemetry.ts
@@ -263,6 +263,7 @@ export async function getSessionContainerInfo(
     scope: !sandboxId
       ? 'unknown'
       : sandboxId.startsWith('ses-') ||
+          sandboxId.startsWith('istd-') ||
           sandboxId.startsWith('crv-') ||
           sandboxId.startsWith('dind-')
         ? 'isolated'

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -59,6 +59,7 @@ export type CloudAgentPrepareSessionInput = {
   callbackTarget?: CallbackTarget;
   createdOnPlatform?: string;
   gateThreshold?: 'off' | 'all' | 'warning' | 'critical';
+  sandboxAllocation?: 'isolated-standard';
   runtimeSkills?: Array<{
     name: string;
     rawMarkdown: string;

--- a/services/cloud-agent-next/src/container-usage-context.test.ts
+++ b/services/cloud-agent-next/src/container-usage-context.test.ts
@@ -130,6 +130,27 @@ describe('container usage context', () => {
     expect(JSON.stringify(input)).not.toContain('Kilo-Org/cloud');
   });
 
+  it.each(['scheduled', 'webhook'])(
+    'attributes isolated Standard %s usage to the session',
+    origin => {
+      const input = buildSandboxBillingInput(
+        metadata({
+          sessionId: `agent_${origin}`,
+          userId: 'user_standard',
+          orgId: 'org_standard',
+          billingOrigin: origin,
+        }),
+        'istd-abcdef'
+      );
+
+      expect(input).toMatchObject({
+        sandboxId: 'istd-abcdef',
+        sessionId: `agent_${origin}`,
+        metadata: { origin },
+      });
+    }
+  );
+
   it('omits session, origin, and repository metadata for shared containers', () => {
     const first = buildSandboxBillingInput(
       metadata({
@@ -228,6 +249,32 @@ describe('container usage context', () => {
     ).toThrow('Isolated sandbox billing requires session attribution');
   });
 
+  it.each(['Sandbox', 'SandboxContainment'] as const)(
+    'accepts isolated Standard attribution for %s',
+    sandboxClassName => {
+      expect(() =>
+        assertSandboxBillingAllocation(sandboxClassName, {
+          sandboxId: 'istd-abcdef',
+          subject: { type: 'org', id: 'org_standard' },
+          actor: { type: 'user', id: 'user_standard' },
+          sessionId: 'agent_standard',
+          metadata: { origin: 'scheduled' },
+        })
+      ).not.toThrow();
+    }
+  );
+
+  it('requires session attribution for isolated Standard sandboxes', () => {
+    expect(() =>
+      assertSandboxBillingAllocation('Sandbox', {
+        sandboxId: 'istd-abcdef',
+        subject: { type: 'org', id: 'org_standard' },
+        actor: { type: 'user', id: 'user_standard' },
+        metadata: { origin: 'webhook' },
+      })
+    ).toThrow('Isolated sandbox billing requires session attribution');
+  });
+
   it('rejects unsupported isolated origins at the sandbox RPC boundary', () => {
     expect(() =>
       assertSandboxBillingAllocation('SandboxSmall', {
@@ -249,7 +296,19 @@ describe('container usage context', () => {
         sessionId: 'agent_1',
         metadata: { origin: 'cloud-agent' },
       })
-    ).toThrow('SandboxDIND billing requires a dind- sandbox ID');
+    ).toThrow('SandboxDIND billing received an incompatible sandbox ID');
+  });
+
+  it('rejects isolated Standard IDs for Small container classes', () => {
+    expect(() =>
+      assertSandboxBillingAllocation('SandboxSmall', {
+        sandboxId: 'istd-abcdef',
+        subject: { type: 'user', id: 'user_1' },
+        actor: { type: 'user', id: 'user_1' },
+        sessionId: 'agent_1',
+        metadata: { origin: 'cloud-agent' },
+      })
+    ).toThrow('SandboxSmall billing received an incompatible sandbox ID');
   });
 
   it('skips shadow configuration when a sandbox does not expose the metering RPC', async () => {

--- a/services/cloud-agent-next/src/container-usage-context.ts
+++ b/services/cloud-agent-next/src/container-usage-context.ts
@@ -7,6 +7,7 @@ import {
 } from '@kilocode/container-usage';
 import { z } from 'zod';
 import { logger } from './logger.js';
+import { classifySandboxId, isIsolatedSandboxId, isValidSandboxId } from './sandbox-id.js';
 import type { SessionMetadata } from './persistence/session-metadata.js';
 import type { SandboxId, SandboxInstance } from './types.js';
 import type { BillingContext } from '@kilocode/container-usage';
@@ -75,10 +76,7 @@ const sandboxBillingInputEnvelopeSchema = z
       .string()
       .min(1)
       .max(63)
-      .refine(
-        value => /^(ses|crv|dind|org|usr|bot|ubt)-[0-9a-f]+$/.test(value) || value.includes('__'),
-        'Invalid sandboxId format'
-      )
+      .refine(isValidSandboxId, 'Invalid sandboxId format')
       .transform(value => value as SandboxId),
     subject: billingSubjectSchema,
     actor: billingActorSchema,
@@ -116,10 +114,6 @@ function normalizedOrigin(origin: string | undefined): string {
   return KNOWN_ORIGINS.has(origin) ? origin : 'other';
 }
 
-function isIsolatedSandbox(sandboxId: SandboxId): boolean {
-  return /^(crv|dind|ses)-/.test(sandboxId);
-}
-
 export function buildSandboxBillingInput(
   metadata: SessionMetadata,
   sandboxId: SandboxId,
@@ -131,7 +125,7 @@ export function buildSandboxBillingInput(
   const actor = metadata.identity.botId
     ? { type: 'bot' as const, id: metadata.identity.botId }
     : { type: 'user' as const, id: metadata.identity.userId };
-  const isolated = isIsolatedSandbox(sandboxId);
+  const isolated = isIsolatedSandboxId(sandboxId);
 
   return {
     sandboxId,
@@ -163,15 +157,18 @@ export function assertSandboxBillingAllocation(
   sandboxClassName: SandboxClassName,
   input: SandboxBillingInput
 ): void {
-  const shared = sandboxClassName === 'Sandbox' || sandboxClassName === 'SandboxContainment';
-  if (shared) {
+  const sandboxIdClass = classifySandboxId(input.sandboxId);
+  const standardClass = sandboxClassName === 'Sandbox' || sandboxClassName === 'SandboxContainment';
+  const isolatedPrefixedLegacyId =
+    /^(ses|istd|crv|dind)-/.test(input.sandboxId) && input.sandboxId.includes('__');
+  if (isolatedPrefixedLegacyId) {
+    throw new Error('Shared sandbox billing requires a shared sandbox ID');
+  }
+  const sharedAllocation = sandboxIdClass === 'shared' || sandboxIdClass === 'legacy-shared';
+
+  if (standardClass && sharedAllocation) {
     if (input.sessionId !== undefined) {
       throw new Error('Shared sandbox billing cannot contain session attribution');
-    }
-    const legacySharedId =
-      !/^(ses|crv|dind)-/.test(input.sandboxId) && input.sandboxId.includes('__');
-    if (!/^(org|usr|bot|ubt)-/.test(input.sandboxId) && !legacySharedId) {
-      throw new Error('Shared sandbox billing requires a shared sandbox ID');
     }
     if (input.metadata !== undefined && Object.keys(input.metadata).length > 0) {
       throw new Error('Shared sandbox billing cannot contain metadata');
@@ -179,14 +176,15 @@ export function assertSandboxBillingAllocation(
     return;
   }
 
-  const expectedPrefix =
-    sandboxClassName === 'SandboxDIND'
-      ? 'dind-'
+  const expectedSandboxIdClass = standardClass
+    ? 'isolated-standard'
+    : sandboxClassName === 'SandboxDIND'
+      ? 'devcontainer'
       : sandboxClassName === 'SandboxSmall' || sandboxClassName === 'SandboxSmallContainment'
-        ? 'ses-'
-        : 'crv-';
-  if (!input.sandboxId.startsWith(expectedPrefix)) {
-    throw new Error(`${sandboxClassName} billing requires a ${expectedPrefix} sandbox ID`);
+        ? 'isolated-small'
+        : 'code-review';
+  if (sandboxIdClass !== expectedSandboxIdClass) {
+    throw new Error(`${sandboxClassName} billing received an incompatible sandbox ID`);
   }
   if (!input.sessionId) {
     throw new Error('Isolated sandbox billing requires session attribution');

--- a/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
+++ b/services/cloud-agent-next/src/persistence/CloudAgentSession.ts
@@ -289,6 +289,7 @@ type GroupedRegisterSessionInput = {
     | 'shallow'
     | 'credentialContainment'
     | 'devcontainerRequested'
+    | 'sandboxAllocation'
   >;
 };
 

--- a/services/cloud-agent-next/src/persistence/schemas.ts
+++ b/services/cloud-agent-next/src/persistence/schemas.ts
@@ -1,6 +1,7 @@
 import * as z from 'zod';
 import { MESSAGE_ID_FORMAT_DESCRIPTION, MESSAGE_ID_PATTERN } from '../session/message-id.js';
 import { BUILTIN_AGENT_MODES, Limits } from '../schema.js';
+import { isValidSandboxId } from '../sandbox-id.js';
 import type { SandboxId } from '../types.js';
 
 /**
@@ -497,10 +498,7 @@ export const MetadataSchema = z.object({
   branchName: z.string().optional(),
   sandboxId: z
     .string()
-    .refine(
-      s => /^(ses|crv|dind|org|usr|bot|ubt)-[0-9a-f]+$/.test(s) || s.includes('__'),
-      'Invalid sandboxId format'
-    )
+    .refine(isValidSandboxId, 'Invalid sandboxId format')
     .transform(s => s as SandboxId)
     .optional(),
   devcontainer: z

--- a/services/cloud-agent-next/src/persistence/session-metadata.test.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.test.ts
@@ -241,6 +241,30 @@ describe('session metadata boundary', () => {
     expect(getSandboxProvider(parseSessionMetadata(current))).toBe('cloudflare');
   });
 
+  it('round-trips isolated Standard allocation metadata as Cloudflare', () => {
+    const current = {
+      metadataSchemaVersion: 2 as const,
+      identity: {
+        sessionId: 'agent_isolated_standard',
+        userId: 'user_isolated_standard',
+      },
+      auth: {},
+      workspace: {
+        sandboxId: 'istd-abcdef' as const,
+        sandboxAllocation: 'isolated-standard' as const,
+      },
+      lifecycle: {
+        version: 1,
+        timestamp: 1,
+      },
+    };
+
+    const parsed = parseSessionMetadata(current);
+    expect(parsed).toEqual(current);
+    expect(getSandboxProvider(parsed)).toBe('cloudflare');
+    expect(parseSessionMetadata(serializeSessionMetadata(parsed))).toEqual(current);
+  });
+
   it('accepts Vercel metadata only for an isolated non-devcontainer sandbox', () => {
     const current = {
       metadataSchemaVersion: 2 as const,

--- a/services/cloud-agent-next/src/persistence/session-metadata.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.ts
@@ -2,7 +2,7 @@ import * as z from 'zod';
 import { sessionIdSchema as kiloSessionIdSchema } from '@kilocode/session-ingest-contracts';
 
 import { PROVIDER_CAPABILITIES } from '../agent-sandbox/capabilities.js';
-import { isGeneratedSharedSandboxId } from '../sandbox-id.js';
+import { isGeneratedSharedSandboxId, isValidSandboxId } from '../sandbox-id.js';
 import { SHARED_SANDBOX_FAILOVER_SUFFIX } from '../shared-sandbox-route.js';
 import { MESSAGE_ID_FORMAT_DESCRIPTION, MESSAGE_ID_PATTERN } from '../session/message-id.js';
 import { type AgentSandboxProvider, type SandboxId } from '../types.js';
@@ -16,10 +16,7 @@ import {
 
 const SandboxIdSchema = z
   .string()
-  .refine(
-    s => /^(ses|crv|dind|org|usr|bot|ubt)-[0-9a-f]+$/.test(s) || s.includes('__'),
-    'Invalid sandboxId format'
-  )
+  .refine(isValidSandboxId, 'Invalid sandboxId format')
   .transform(s => s as SandboxId);
 
 const SharedSandboxIdSchema = z
@@ -245,6 +242,7 @@ const MetadataWorkspaceSchema = z
     credentialContainment: CredentialContainmentSchema.optional(),
     managedScmContainment: z.boolean().optional(),
     devcontainerRequested: z.boolean().optional(),
+    sandboxAllocation: z.literal('isolated-standard').optional(),
   })
   .strip()
   .superRefine((workspace, context) => {

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -273,7 +273,13 @@ export function prepareInputToSessionCreateRequest(input: PrepareInput): Session
       variant: input.variant,
     },
     repository,
-    runtime: input.devcontainer ? { devcontainer: true } : undefined,
+    runtime:
+      input.devcontainer || input.sandboxAllocation
+        ? {
+            ...(input.devcontainer ? { devcontainer: true } : {}),
+            ...(input.sandboxAllocation ? { sandboxAllocation: input.sandboxAllocation } : {}),
+          }
+        : undefined,
     clone: input.cloneFromKiloSessionId
       ? { cloneFromKiloSessionId: input.cloneFromKiloSessionId }
       : undefined,

--- a/services/cloud-agent-next/src/router/schemas.test.ts
+++ b/services/cloud-agent-next/src/router/schemas.test.ts
@@ -231,6 +231,21 @@ describe('legacy live attachment input compatibility', () => {
     expect(PrepareSessionInput.safeParse({ ...input, sandboxAllocation: 'standard' }).success).toBe(
       false
     );
+    expect(
+      PrepareSessionInput.safeParse({
+        ...input,
+        devcontainer: true,
+        autoInitiate: true,
+        sandboxAllocation: 'isolated-standard',
+      }).success
+    ).toBe(false);
+    expect(
+      PrepareSessionInput.safeParse({
+        ...input,
+        createdOnPlatform: 'code-review',
+        sandboxAllocation: 'isolated-standard',
+      }).success
+    ).toBe(false);
   });
 
   it('accepts a GitHub integration id only with a legacy GitHub repository', () => {

--- a/services/cloud-agent-next/src/router/schemas.test.ts
+++ b/services/cloud-agent-next/src/router/schemas.test.ts
@@ -217,6 +217,22 @@ describe('grouped unified session input contracts', () => {
 });
 
 describe('legacy live attachment input compatibility', () => {
+  it('accepts only the supported isolated Standard allocation', () => {
+    const input = {
+      prompt: 'Update the repository',
+      mode: 'code',
+      model: 'claude-sonnet-4-5-20250929',
+      githubRepo: 'acme/repo',
+    };
+
+    expect(
+      PrepareSessionInput.safeParse({ ...input, sandboxAllocation: 'isolated-standard' }).success
+    ).toBe(true);
+    expect(PrepareSessionInput.safeParse({ ...input, sandboxAllocation: 'standard' }).success).toBe(
+      false
+    );
+  });
+
   it('accepts a GitHub integration id only with a legacy GitHub repository', () => {
     const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
     const input = {

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -646,6 +646,24 @@ export const PrepareSessionInput = z
     path: ['githubRepo'],
   })
   .superRefine((data, ctx) => {
+    if (data.sandboxAllocation === 'isolated-standard' && data.devcontainer) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['sandboxAllocation'],
+        message: 'Isolated Standard allocation cannot be combined with devcontainer',
+      });
+    }
+    if (
+      data.sandboxAllocation === 'isolated-standard' &&
+      data.createdOnPlatform === 'code-review'
+    ) {
+      ctx.addIssue({
+        code: 'custom',
+        path: ['sandboxAllocation'],
+        message: 'Isolated Standard allocation cannot be combined with code review',
+      });
+    }
+
     if (data.githubIntegrationId !== undefined && data.githubRepo === undefined) {
       ctx.addIssue({
         code: 'custom',

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -572,6 +572,10 @@ const PrepareSessionSharedFields = {
     .describe(
       'When true, route the session to a Docker-in-Docker sandbox that supports devcontainer runtimes'
     ),
+  sandboxAllocation: z
+    .literal('isolated-standard')
+    .optional()
+    .describe('Allocate a dedicated Standard Cloudflare container for this session'),
 };
 
 const PrepareSessionNonCloneVariant = z.object({

--- a/services/cloud-agent-next/src/sandbox-id.test.ts
+++ b/services/cloud-agent-next/src/sandbox-id.test.ts
@@ -348,6 +348,32 @@ describe('generateSandboxId', () => {
     });
   });
 
+  describe('isolated Standard sandbox', () => {
+    it('bypasses organization routing with a deterministic per-session identity', async () => {
+      await expect(
+        generateSandboxRoutingTarget(undefined, 'my-org', 'user-id', 'agent_abc123', undefined, {
+          sandboxAllocation: 'isolated-standard',
+        })
+      ).resolves.toEqual({
+        kind: 'isolated',
+        sandboxId: 'istd-51256c9fcd04ef0144d0afcdfb9ffb2abc280ff2e0bae370',
+      });
+    });
+
+    it('produces different identities for different sessions', async () => {
+      const first = await generateSandboxId(undefined, 'org', 'user', 'session-a', undefined, {
+        sandboxAllocation: 'isolated-standard',
+      });
+      const second = await generateSandboxId(undefined, 'org', 'user', 'session-b', undefined, {
+        sandboxAllocation: 'isolated-standard',
+      });
+
+      expect(first).toMatch(/^istd-[0-9a-f]{48}$/);
+      expect(second).toMatch(/^istd-[0-9a-f]{48}$/);
+      expect(first).not.toBe(second);
+    });
+  });
+
   describe('devcontainer sandbox', () => {
     it('bypasses shared slot routing', async () => {
       await expect(
@@ -678,6 +704,23 @@ describe('getSandboxNamespace', () => {
     expect(ns).toBe(mockSandboxSmallContainment);
   });
 
+  it('should return Sandbox for istd- prefixed IDs', () => {
+    const ns = getSandboxNamespace(
+      mockEnv,
+      'istd-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6'
+    );
+    expect(ns).toBe(mockSandbox);
+  });
+
+  it('should return SandboxContainment for contained istd- prefixed IDs', () => {
+    const ns = getSandboxNamespace(
+      mockEnv,
+      'istd-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6',
+      { managedScmContainment: true }
+    );
+    expect(ns).toBe(mockSandboxContainment);
+  });
+
   it('should return SandboxCodeReview for crv- prefixed IDs', () => {
     const ns = getSandboxNamespace(mockEnv, 'crv-a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6');
     expect(ns).toBe(mockSandboxCodeReview);
@@ -730,6 +773,7 @@ describe('getOutboundContainerId', () => {
   it.each([
     ['org-a1b2c3', 'shared-do-id'],
     ['ses-a1b2c3', 'small-do-id'],
+    ['istd-a1b2c3', 'shared-do-id'],
     ['dind-a1b2c3', 'dind-do-id'],
   ])('derives %s from the selected sandbox namespace', (sandboxId, expected) => {
     const createNamespace = (containerId: string) => ({

--- a/services/cloud-agent-next/src/sandbox-id.ts
+++ b/services/cloud-agent-next/src/sandbox-id.ts
@@ -44,7 +44,35 @@ export type SandboxRoutingTarget =
 export type SandboxRoutingOptions = {
   devcontainer?: boolean;
   createdOnPlatform?: string;
+  sandboxAllocation?: 'isolated-standard';
 };
+
+export type SandboxIdClass =
+  | 'shared'
+  | 'legacy-shared'
+  | 'isolated-small'
+  | 'isolated-standard'
+  | 'code-review'
+  | 'devcontainer'
+  | 'unknown';
+
+export function classifySandboxId(sandboxId: string): SandboxIdClass {
+  if (/^istd-[0-9a-f]+$/.test(sandboxId)) return 'isolated-standard';
+  if (/^ses-[0-9a-f]+$/.test(sandboxId)) return 'isolated-small';
+  if (/^crv-[0-9a-f]+$/.test(sandboxId)) return 'code-review';
+  if (/^dind-[0-9a-f]+$/.test(sandboxId)) return 'devcontainer';
+  if (/^(org|usr|bot|ubt)-[0-9a-f]+$/.test(sandboxId)) return 'shared';
+  if (sandboxId.includes('__')) return 'legacy-shared';
+  return 'unknown';
+}
+
+export function isValidSandboxId(sandboxId: string): sandboxId is SandboxId {
+  return classifySandboxId(sandboxId) !== 'unknown';
+}
+
+export function isIsolatedSandboxId(sandboxId: string): boolean {
+  return /^(ses|istd|crv|dind)-/.test(sandboxId);
+}
 
 export function isGeneratedSharedSandboxId(sandboxId: string): sandboxId is SandboxId {
   return /^(org|usr|bot|ubt)-[0-9a-f]{48}$/.test(sandboxId);
@@ -91,8 +119,9 @@ export function isOrgInList(raw: string | undefined, orgId: string | undefined):
  * Returns the correct DurableObjectNamespace for the given sandbox ID.
  * - Docker-in-Docker sandboxes (dind-* prefix) use SandboxDIND
  * - Code Reviewer ephemeral sandboxes (crv-* prefix) use SandboxCodeReview
- * - Per-session sandboxes (ses-* prefix) use SandboxSmall
- * - All others use Sandbox
+ * - Per-session Small sandboxes (ses-* prefix) use SandboxSmall
+ * - Per-session Standard sandboxes (istd-* prefix) use Sandbox
+ * - Shared and legacy shared sandboxes use Sandbox
  */
 export function getSandboxNamespace(
   env: SandboxNamespaceEnv,
@@ -107,6 +136,9 @@ export function getSandboxNamespace(
   }
   if (sandboxId.startsWith('ses-')) {
     return options.managedScmContainment === true ? env.SandboxSmallContainment : env.SandboxSmall;
+  }
+  if (sandboxId.startsWith('istd-')) {
+    return options.managedScmContainment === true ? env.SandboxContainment : env.Sandbox;
   }
   return options.managedScmContainment === true ? env.SandboxContainment : env.Sandbox;
 }
@@ -241,6 +273,9 @@ export async function generateSandboxRoutingTarget(
   }
   if (routingOptions.createdOnPlatform === 'code-review') {
     return { kind: 'isolated', sandboxId: await hashToSandboxId(sessionId, 'crv') };
+  }
+  if (routingOptions.sandboxAllocation === 'isolated-standard') {
+    return { kind: 'isolated', sandboxId: await hashToSandboxId(sessionId, 'istd') };
   }
   if (perSessionOrgs.has('*') || (orgId !== undefined && perSessionOrgs.has(orgId))) {
     return { kind: 'isolated', sandboxId: await hashToSandboxId(sessionId, 'ses') };

--- a/services/cloud-agent-next/src/session/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session/session-prepare.test.ts
@@ -331,6 +331,40 @@ describe('createSessionWithLedger admission ladder', () => {
     });
   });
 
+  it('routes and persists isolated Standard allocation for an agent session', async () => {
+    const sandboxId = `istd-${'a'.repeat(48)}` as const;
+    generateSandboxRoutingTargetMock.mockResolvedValueOnce({ kind: 'isolated', sandboxId });
+    const doStub = makeDoStub();
+    const ctx = makeContext(doStub);
+
+    await runCreate(
+      ctx,
+      makeRequest({
+        runtime: { sandboxAllocation: 'isolated-standard' },
+        options: { operationKey: OPERATION_KEY, createdOnPlatform: 'webhook' },
+      })
+    );
+
+    expect(generateSandboxRoutingTargetMock).toHaveBeenCalledWith(
+      undefined,
+      undefined,
+      USER_ID,
+      CLOUD_AGENT_SESSION_ID,
+      undefined,
+      expect.objectContaining({ sandboxAllocation: 'isolated-standard' })
+    );
+    expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: expect.objectContaining({ createdOnPlatform: 'webhook' }),
+        workspace: expect.objectContaining({
+          sandboxId,
+          sandboxProvider: 'cloudflare',
+          sandboxAllocation: 'isolated-standard',
+        }),
+      })
+    );
+  });
+
   it('passes a normalized GitHub repository URL to the session-ingest create call', async () => {
     const ctx = makeContext(makeDoStub());
 
@@ -1595,6 +1629,13 @@ describe('createSessionWithLedger changed-intent rejection', () => {
       retry: makeRequest({ finalization: { autoCommit: true }, options: ORIGINAL_OPTIONS }),
     },
     {
+      name: 'the sandbox allocation',
+      retry: makeRequest({
+        runtime: { sandboxAllocation: 'isolated-standard' },
+        options: ORIGINAL_OPTIONS,
+      }),
+    },
+    {
       name: 'the appended system prompt',
       retry: makeRequest({
         profile: { overrides: { appendSystemPrompt: 'Follow these extra rules' } },
@@ -1924,6 +1965,30 @@ describe('createSessionWithLedger clone allocation outcomes', () => {
     expect(sandboxSessionGet).toHaveBeenCalledTimes(1);
     expect(cloudAgentSessionGet).not.toHaveBeenCalled();
     expect(doStub.registerSession).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects isolated Standard allocation for workspace sessions before external effects', async () => {
+    generateSessionIdMock.mockReturnValue(WORKSPACE_SESSION_ID);
+    const doStub = makeDoStub();
+    const ctx = makeContext(doStub);
+    ctx.env.CONTROL_PLANE_IDS = USER_ID;
+
+    await expect(
+      runCreate(
+        ctx,
+        makeRequest({
+          runtime: { sandboxAllocation: 'isolated-standard' },
+          options: { operationKey: OPERATION_KEY },
+        })
+      )
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Isolated Standard allocation is not supported for control-plane sessions',
+    });
+
+    expect(createCliSessionMock).not.toHaveBeenCalled();
+    expect(doStub.createSessionWithInitialAdmission).not.toHaveBeenCalled();
+    expect(admitOperationMock).not.toHaveBeenCalled();
   });
 
   it('surfaces BAD_REQUEST session_clone_failed when the clone is rejected', async () => {
@@ -2644,5 +2709,19 @@ describe('prepareInputToSessionCreateRequest clone mapping', () => {
     });
 
     expect(request.clone).toBeUndefined();
+  });
+
+  it('maps isolated Standard allocation into grouped runtime intent', () => {
+    const request = prepareInputToSessionCreateRequest({
+      prompt: 'Continue',
+      mode: 'code',
+      model: 'claude-3',
+      githubRepo: 'acme/repo',
+      shallow: false,
+      devcontainer: false,
+      sandboxAllocation: 'isolated-standard',
+    });
+
+    expect(request.runtime).toEqual({ sandboxAllocation: 'isolated-standard' });
   });
 });

--- a/services/cloud-agent-next/src/session/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session/session-prepare.test.ts
@@ -1991,6 +1991,43 @@ describe('createSessionWithLedger clone allocation outcomes', () => {
     expect(admitOperationMock).not.toHaveBeenCalled();
   });
 
+  it.each([
+    {
+      name: 'devcontainer',
+      runtime: { devcontainer: true, sandboxAllocation: 'isolated-standard' } as const,
+      billingOrigin: 'cloud-agent',
+    },
+    {
+      name: 'code review',
+      runtime: { sandboxAllocation: 'isolated-standard' } as const,
+      billingOrigin: 'code-review',
+    },
+  ])(
+    'rejects isolated Standard allocation with $name routing before external effects',
+    async input => {
+      const doStub = makeDoStub();
+      const ctx = makeContext(doStub);
+
+      await expect(
+        createSessionWithLedger(
+          makeRequest({
+            runtime: input.runtime,
+            options: { operationKey: OPERATION_KEY },
+          }),
+          ctx,
+          { ...CREATE_OPTIONS, billingOrigin: input.billingOrigin }
+        )
+      ).rejects.toMatchObject({
+        code: 'BAD_REQUEST',
+        message: 'Isolated Standard allocation is incompatible with specialized sandbox routing',
+      });
+
+      expect(admitOperationMock).not.toHaveBeenCalled();
+      expect(generateSandboxRoutingTargetMock).not.toHaveBeenCalled();
+      expect(doStub.createSessionWithInitialAdmission).not.toHaveBeenCalled();
+    }
+  );
+
   it('surfaces BAD_REQUEST session_clone_failed when the clone is rejected', async () => {
     createCliSessionMock.mockResolvedValue({ status: 'rejected', code: 'source_access_denied' });
     const doStub = makeDoStub();

--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -70,8 +70,18 @@ type SharedSandboxRouteMetadata = NonNullable<
 
 function assertSupportedSandboxAllocation(
   input: SessionRegistrationInput,
-  ctx: SessionRegistrationContext
+  ctx: SessionRegistrationContext,
+  options?: { billingOrigin?: string }
 ): void {
+  if (
+    input.runtime?.sandboxAllocation === 'isolated-standard' &&
+    (input.runtime.devcontainer === true || options?.billingOrigin === 'code-review')
+  ) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Isolated Standard allocation is incompatible with specialized sandbox routing',
+    });
+  }
   if (
     input.runtime?.sandboxAllocation === 'isolated-standard' &&
     sessionPlaneForNewOwner(ctx.env, {
@@ -807,7 +817,7 @@ export async function registerNewSession(
   ctx: SessionRegistrationContext,
   options?: { billingOrigin?: string }
 ): Promise<SessionRegistrationResult> {
-  assertSupportedSandboxAllocation(input, ctx);
+  assertSupportedSandboxAllocation(input, ctx, options);
   const allocation = await allocateNewSession(input, ctx, options);
   const stub = resolveSessionStub(ctx.env, ctx.userId, allocation.cloudAgentSessionId);
   let registerResult: Awaited<ReturnType<typeof stub.registerSession>>;
@@ -1062,6 +1072,7 @@ export async function startNewSession(
   options?: { billingOrigin?: string },
   ledger?: SessionCreationLedgerHooks
 ): Promise<StartedSessionResult> {
+  assertSupportedSandboxAllocation(input, ctx, options);
   const allocation = await allocateSessionForCreate(input, ctx, options, ledger);
   return registerAndAdmitInitialTurn(input, ctx, options, allocation, ledger);
 }
@@ -1272,7 +1283,7 @@ export async function createSessionWithLedger(
   ctx: SessionRegistrationContext,
   options: SessionLedgerCreateOptions
 ): Promise<LedgerSessionCreateResult> {
-  assertSupportedSandboxAllocation(input, ctx);
+  assertSupportedSandboxAllocation(input, ctx, { billingOrigin: options.billingOrigin });
   const db = getPgDb(ctx.env);
   const admission = await admitOperation(db, {
     userId: ctx.userId,

--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -68,6 +68,24 @@ type SharedSandboxRouteMetadata = NonNullable<
   NonNullable<SessionMetadata['workspace']>['sandboxRoute']
 >;
 
+function assertSupportedSandboxAllocation(
+  input: SessionRegistrationInput,
+  ctx: SessionRegistrationContext
+): void {
+  if (
+    input.runtime?.sandboxAllocation === 'isolated-standard' &&
+    sessionPlaneForNewOwner(ctx.env, {
+      userId: ctx.userId,
+      orgId: input.options?.kilocodeOrganizationId,
+    }) === 'control'
+  ) {
+    throw new TRPCError({
+      code: 'BAD_REQUEST',
+      message: 'Isolated Standard allocation is not supported for control-plane sessions',
+    });
+  }
+}
+
 export type SessionRegistrationContext = {
   env: Env;
   userId: string;
@@ -465,6 +483,7 @@ async function allocateNewSession(
       {
         devcontainer: input.runtime?.devcontainer,
         createdOnPlatform: options?.billingOrigin === 'code-review' ? 'code-review' : undefined,
+        sandboxAllocation: input.runtime?.sandboxAllocation,
       }
     );
     if (target.kind === 'shared') {
@@ -769,6 +788,9 @@ function buildSessionRegistrationCommand(
       ...(allocation.sandboxRoute ? { sandboxRoute: allocation.sandboxRoute } : {}),
       credentialContainment: allocation.credentialContainment,
       ...(input.runtime?.devcontainer ? { devcontainerRequested: true } : {}),
+      ...(input.runtime?.sandboxAllocation
+        ? { sandboxAllocation: input.runtime.sandboxAllocation }
+        : {}),
     },
   };
 }
@@ -785,6 +807,7 @@ export async function registerNewSession(
   ctx: SessionRegistrationContext,
   options?: { billingOrigin?: string }
 ): Promise<SessionRegistrationResult> {
+  assertSupportedSandboxAllocation(input, ctx);
   const allocation = await allocateNewSession(input, ctx, options);
   const stub = resolveSessionStub(ctx.env, ctx.userId, allocation.cloudAgentSessionId);
   let registerResult: Awaited<ReturnType<typeof stub.registerSession>>;
@@ -1198,7 +1221,14 @@ export async function sessionCreateIntentFingerprint(
       },
       repository: repositoryCreateIntent(input.repository),
       finalization: input.finalization,
-      runtime: input.runtime?.devcontainer ? { devcontainer: true } : undefined,
+      runtime: input.runtime
+        ? {
+            ...(input.runtime.devcontainer ? { devcontainer: true } : {}),
+            ...(input.runtime.sandboxAllocation
+              ? { sandboxAllocation: input.runtime.sandboxAllocation }
+              : {}),
+          }
+        : undefined,
       options: input.options
         ? {
             kilocodeOrganizationId: input.options.kilocodeOrganizationId || undefined,
@@ -1242,6 +1272,7 @@ export async function createSessionWithLedger(
   ctx: SessionRegistrationContext,
   options: SessionLedgerCreateOptions
 ): Promise<LedgerSessionCreateResult> {
+  assertSupportedSandboxAllocation(input, ctx);
   const db = getPgDb(ctx.env);
   const admission = await admitOperation(db, {
     userId: ctx.userId,

--- a/services/cloud-agent-next/src/session/session-requests.ts
+++ b/services/cloud-agent-next/src/session/session-requests.ts
@@ -45,6 +45,7 @@ export type SessionRepositoryRequest =
 
 export type SessionRuntimeIntent = {
   devcontainer?: boolean;
+  sandboxAllocation?: 'isolated-standard';
 };
 
 export type SessionCreateRequest = {

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -123,6 +123,7 @@ export type SandboxId =
   | `bot-${string}`
   | `ubt-${string}`
   | `ses-${string}`
+  | `istd-${string}`
   | `crv-${string}`
   | `dind-${string}`
   | `${string}__${string}`


### PR DESCRIPTION
## Summary

- Add a trusted `sandboxAllocation: 'isolated-standard'` prepare-session capability that creates deterministic, per-session `istd-*` sandbox identities.
- Route isolated Standard identities through the existing `Sandbox` or `SandboxContainment` classes, preserving credential containment without adding container classes, bindings, capacity definitions, or billing SKUs.
- Centralize sandbox identity classification so persisted metadata and billing treat `istd-*` as isolated, require session/origin attribution, and continue using `cloud-agent-standard-2026-07`.
- Persist the allocation as immutable session intent and reject it before side effects when the owner resolves to the unsupported `workspace_*` control plane.

## Verification

- Not manually exercised against a live Cloudflare container because this PR adds a dormant trusted API capability; trigger persistence and forwarding will be added separately.

## Visual Changes

N/A

## Reviewer Notes

- Focus review on the billing distinction between shared Standard IDs (`org-*`, `usr-*`, `bot-*`, `ubt-*`) and isolated Standard IDs (`istd-*`) that use the same physical container classes.
- `workspace_*` sessions intentionally fail closed until `SandboxControl` supports allocation-aware namespace selection and equivalent containment/billing behavior.
- Existing `ses-*` isolated Small routing remains unchanged.