### PR TITLE
fix(webhook-agent-ingest): prevent duplicate cron alarm firings

### DIFF
--- a/services/webhook-agent-ingest/src/dos/TriggerDO.ts
+++ b/services/webhook-agent-ingest/src/dos/TriggerDO.ts
@@ -727,7 +727,21 @@ export class TriggerDO extends DurableObject<Env> {
   private async scheduleNextAlarm(config: TriggerConfig): Promise<void> {
     if (!config.cronExpression || config.activationMode !== 'scheduled') return;
 
-    const nextTime = computeNextCronTime(config.cronExpression, config.cronTimezone ?? 'UTC');
+    // Compute strictly after the later of "now" and the occurrence we most recently
+    // targeted (config.nextScheduledAt). Using "now" alone is not enough: if the alarm
+    // fired a little early (e.g. due to jitter), "now" can still be before that target
+    // occurrence, and croner would hand back the *same* occurrence again, causing it to
+    // fire twice. Anchoring on nextScheduledAt when it's still ahead of "now" guarantees
+    // we always advance to the following occurrence instead.
+    const previousTarget = config.nextScheduledAt ? new Date(config.nextScheduledAt) : null;
+    const referenceTime =
+      previousTarget && previousTarget.getTime() > Date.now() ? previousTarget : undefined;
+
+    const nextTime = computeNextCronTime(
+      config.cronExpression,
+      config.cronTimezone ?? 'UTC',
+      referenceTime
+    );
     if (!nextTime) {
       // DST spring-forward can skip an occurrence. Schedule a retry in 1 hour
       // so the trigger doesn't stop forever. Set a flag so alarm() knows this
@@ -744,8 +758,11 @@ export class TriggerDO extends DurableObject<Env> {
     // cause alarm() to skip the next real cron fire.
     await this.ctx.storage.delete('alarmRetry');
 
-    // Add jitter to prevent thundering herd on popular cron times (±30s)
-    const jitterMs = Math.floor(Math.random() * 60_000) - 30_000;
+    // Add jitter to prevent thundering herd on popular cron times. This must be a
+    // delay only (0-30s) — never negative — otherwise the alarm could fire before
+    // its target occurrence, which (combined with the minimum-delay floor below)
+    // caused the same occurrence to be fired twice in the past.
+    const jitterMs = Math.floor(Math.random() * 30_000);
     const alarmTime = Math.max(nextTime.getTime() + jitterMs, Date.now() + 60_000);
     await this.ctx.storage.setAlarm(alarmTime);
 

--- a/services/webhook-agent-ingest/src/dos/TriggerDO.ts
+++ b/services/webhook-agent-ingest/src/dos/TriggerDO.ts
@@ -348,7 +348,14 @@ export class TriggerDO extends DurableObject<Env> {
         updates.cronExpression !== undefined ||
         updates.cronTimezone !== undefined
       ) {
-        // Reactivated or cron expression changed — reschedule
+        // Reactivated or cron expression changed — reschedule from scratch.
+        // Clear the inherited nextScheduledAt first: scheduleNextAlarm() anchors on
+        // a future nextScheduledAt to avoid re-firing an occurrence that was just
+        // handled by alarm(). Here nextScheduledAt still reflects a pending (never
+        // fired) occurrence under the *old* config, so leaving it set would make
+        // scheduleNextAlarm skip past a still-valid, possibly sooner occurrence
+        // under the new cron expression/timezone.
+        updatedConfig.nextScheduledAt = null;
         await this.ctx.storage.deleteAlarm();
         await this.ctx.storage.delete('alarmRetry');
         await this.scheduleNextAlarm(updatedConfig);
@@ -734,8 +741,11 @@ export class TriggerDO extends DurableObject<Env> {
     // fire twice. Anchoring on nextScheduledAt when it's still ahead of "now" guarantees
     // we always advance to the following occurrence instead.
     const previousTarget = config.nextScheduledAt ? new Date(config.nextScheduledAt) : null;
-    const referenceTime =
-      previousTarget && previousTarget.getTime() > Date.now() ? previousTarget : undefined;
+    const isValidFutureTarget =
+      previousTarget !== null &&
+      !Number.isNaN(previousTarget.getTime()) &&
+      previousTarget.getTime() > Date.now();
+    const referenceTime = isValidFutureTarget ? previousTarget : undefined;
 
     const nextTime = computeNextCronTime(
       config.cronExpression,

--- a/services/webhook-agent-ingest/src/util/cron.test.ts
+++ b/services/webhook-agent-ingest/src/util/cron.test.ts
@@ -73,6 +73,21 @@ describe('computeNextCronTime', () => {
     expect(second).toBeInstanceOf(Date);
     expect(second!.getTime()).toBeGreaterThan(first!.getTime());
   });
+
+  it('advances across a day boundary when anchored far in the future', () => {
+    // Daily-at-midnight schedule, anchored 3 days out — must skip ahead to the
+    // occurrence after the anchor, not just the next occurrence after "now".
+    const reference = new Date(Date.now() + 3 * 24 * 60 * 60_000);
+    const next = computeNextCronTime('0 0 * * *', 'UTC', reference);
+    expect(next).toBeInstanceOf(Date);
+    expect(next!.getTime()).toBeGreaterThan(reference.getTime());
+  });
+
+  it('returns null instead of throwing when `after` is an Invalid Date', () => {
+    const invalidDate = new Date('not-a-date');
+    expect(invalidDate.getTime()).toBeNaN();
+    expect(computeNextCronTime('* * * * *', 'UTC', invalidDate)).toBeNull();
+  });
 });
 
 describe('enforcesMinimumInterval', () => {

--- a/services/webhook-agent-ingest/src/util/cron.test.ts
+++ b/services/webhook-agent-ingest/src/util/cron.test.ts
@@ -52,6 +52,27 @@ describe('computeNextCronTime', () => {
   it('returns null for invalid expression', () => {
     expect(computeNextCronTime('invalid', 'UTC')).toBeNull();
   });
+
+  it('returns the occurrence after a given reference time, not after now', () => {
+    // Every minute, anchored on a fixed reference in the past relative to "now"
+    // but in the future relative to some earlier point — the result should be
+    // strictly after the reference, regardless of the current wall-clock time.
+    const reference = new Date(Date.now() + 5 * 60_000); // 5 minutes from now
+    const next = computeNextCronTime('* * * * *', 'UTC', reference);
+    expect(next).toBeInstanceOf(Date);
+    expect(next!.getTime()).toBeGreaterThan(reference.getTime());
+  });
+
+  it('does not return the same occurrence twice when called again before that occurrence passes', () => {
+    // Simulates the alarm firing early: compute the target occurrence, then
+    // immediately ask for the "next" occurrence using that target as the reference.
+    // It must advance past it instead of returning the same time again.
+    const first = computeNextCronTime('* * * * *', 'UTC');
+    expect(first).toBeInstanceOf(Date);
+    const second = computeNextCronTime('* * * * *', 'UTC', first!);
+    expect(second).toBeInstanceOf(Date);
+    expect(second!.getTime()).toBeGreaterThan(first!.getTime());
+  });
 });
 
 describe('enforcesMinimumInterval', () => {

--- a/services/webhook-agent-ingest/src/util/cron.ts
+++ b/services/webhook-agent-ingest/src/util/cron.ts
@@ -1,12 +1,20 @@
 import { Cron } from 'croner';
 
 /**
- * Compute the next occurrence of a cron expression after now.
+ * Compute the next occurrence of a cron expression strictly after `after`
+ * (defaults to now). Passing the previously targeted occurrence as `after`
+ * guarantees the result advances to the following occurrence even if this
+ * is called before that previous occurrence's wall-clock time has passed
+ * (e.g. an alarm that fired a few seconds early).
  */
-export function computeNextCronTime(expression: string, timezone: string): Date | null {
+export function computeNextCronTime(
+  expression: string,
+  timezone: string,
+  after?: Date
+): Date | null {
   try {
     const job = new Cron(expression, { timezone });
-    return job.nextRun() ?? null;
+    return job.nextRun(after) ?? null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Summary

Fixes a bug where a Cloud Agent scheduled webhook trigger could fire twice for the same cron occurrence — one invocation up to 30s early, followed by a duplicate ~1 minute later (as seen in the screenshot on the "Scheduled requests" table, e.g. `12:09` and `12:10`).

Root cause, in `services/webhook-agent-ingest/src/dos/TriggerDO.ts`:
- `scheduleNextAlarm()` applied jitter in the range `±30s` when scheduling the Durable Object alarm for the next cron occurrence. Negative jitter meant the alarm could fire **before** its target time.
- When the alarm fired early, the reschedule logic recomputed "next occurrence" relative to "now" — but "now" was still before the intended occurrence, so `croner` returned the *same* occurrence again, causing it to be scheduled (and fired) a second time.

Fix:
- `computeNextCronTime()` (`services/webhook-agent-ingest/src/util/cron.ts`) now accepts an optional `after` reference `Date`, passed through to `croner`'s `nextRun(after)`.
- `scheduleNextAlarm()` jitter changed from `±30s` to `0–30s` (delay-only, never negative), so the alarm can no longer fire ahead of its target occurrence.
- `scheduleNextAlarm()` also anchors on `max(now, previousTarget)` when a valid future `nextScheduledAt` exists, so even a slightly-early alarm fire (clock skew, platform-level timing) correctly advances to the *next* occurrence instead of recomputing the one just handled.
- `updateConfig()`'s "reactivated or cron expression changed" branch now clears the inherited `nextScheduledAt` before rescheduling — otherwise a pending (never-fired) occurrence carried over from the old config would get treated as "already consumed" by the new anchoring logic, silently skipping a valid, possibly sooner occurrence under the new cron expression/timezone.

No architectural changes — this is a targeted fix within the existing Durable Object alarm-based scheduling design.

## Verification

- [ ] No manual verification was performed. Triggering this bug requires waiting for a live scheduled cron occurrence against a deployed Durable Object (or advancing DO alarm time in a real environment), which wasn't practical in this session. Verification relied on unit tests exercising `computeNextCronTime()`'s new `after` parameter, including early-fire, far-future-anchor, and invalid-date cases, plus reasoning through all call sites of `scheduleNextAlarm()` (initial configure, normal alarm fire, DST-retry branch, and config update) via a static review pass.
- [ ]

## Visual Changes

N/A

## Reviewer Notes

- Core logic lives in `TriggerDO.scheduleNextAlarm()` and `alarm()` — worth tracing through all four call sites (initial `configure()`, `updateConfig()`'s reactivate/cron-change branch, the normal `alarm()` fire path, and the DST `alarmRetry` retry path) to confirm the anchoring behaves correctly in each.
- `nextScheduledAt` is dual-purpose (UI display value and internal "occurrence already handled" marker); the `updateConfig()` fix clears it explicitly where it would otherwise be misread as "already fired" for a config that hasn't fired yet.
- No test harness exists for `TriggerDO`'s Durable Object alarm scheduling directly (only `cron.ts` unit tests); the DO-level behavior (config update reschedule, DST retry) was verified by code reading rather than an integration test.