### PR TITLE
test(cloud-agent-next): stabilize batch admission lifecycle tests

### DIFF
--- a/services/cloud-agent-next/test/unit/wrapper/batch-admission.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/batch-admission.test.ts
@@ -15,6 +15,14 @@ vi.mock('../../../wrapper/src/utils.js', () => ({
   logToFile: vi.fn(),
 }));
 
+vi.mock('../../../wrapper/src/log-uploader.js', () => ({
+  createLogUploader: vi.fn(() => ({
+    start: vi.fn(),
+    uploadNow: vi.fn().mockResolvedValue(undefined),
+    stop: vi.fn(),
+  })),
+}));
+
 const config: ServerConfig = {
   port: 5000,
   workspacePath: '/workspace',
@@ -190,7 +198,6 @@ describe('wrapper batch admission', () => {
     const sendToIngest = vi.fn();
     state.setSendToIngestFn(sendToIngest);
     await bindSessionContext(binding, config, deps);
-    state.setLogUploader(null);
     state.acceptMessage('message-1', { autoCommit: false, condenseOnComplete: false });
     const lifecycle = createLifecycleManager(
       { workspacePath: '/workspace' },
@@ -241,7 +248,6 @@ describe('wrapper batch admission', () => {
     const sendToIngest = vi.fn();
     state.setSendToIngestFn(sendToIngest);
     await bindSessionContext(binding, config, deps);
-    state.setLogUploader(null);
     let resolvePrompt: (() => void) | undefined;
     vi.mocked(deps.kiloClient.sendPromptAsync).mockImplementationOnce(
       () =>

--- a/services/cloud-agent-next/test/unit/wrapper/batch-admission.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/batch-admission.test.ts
@@ -190,6 +190,7 @@ describe('wrapper batch admission', () => {
     const sendToIngest = vi.fn();
     state.setSendToIngestFn(sendToIngest);
     await bindSessionContext(binding, config, deps);
+    state.setLogUploader(null);
     state.acceptMessage('message-1', { autoCommit: false, condenseOnComplete: false });
     const lifecycle = createLifecycleManager(
       { workspacePath: '/workspace' },
@@ -240,6 +241,7 @@ describe('wrapper batch admission', () => {
     const sendToIngest = vi.fn();
     state.setSendToIngestFn(sendToIngest);
     await bindSessionContext(binding, config, deps);
+    state.setLogUploader(null);
     let resolvePrompt: (() => void) | undefined;
     vi.mocked(deps.kiloClient.sendPromptAsync).mockImplementationOnce(
       () =>


### PR DESCRIPTION
## Summary

- Mock the log uploader throughout wrapper batch-admission tests so fake-timer lifecycle coverage never performs real filesystem, subprocess, or network work.
- Preserve the normal uploader finalization path while preventing completion events from intermittently stalling.

## Verification

- [ ] No manual testing performed; this change only isolates automated unit tests and does not modify production behavior.

## Visual Changes

N/A

## Reviewer Notes

- Focused admission/lifecycle regression suite: 22 tests passed.
- Service lint, explicit test-file lint, service/wrapper typechecks, formatting, and whitespace checks passed.