### PR TITLE
fix(auth): restore returning sign-in navigation

### DIFF
--- a/apps/web/src/hooks/useSignInFlow.test.ts
+++ b/apps/web/src/hooks/useSignInFlow.test.ts
@@ -523,6 +523,24 @@ describe('useSignInFlow discovery cancellation', () => {
     expect(fetchMock).toHaveBeenCalledTimes(2);
   });
 
+  it('returns a remembered user from the email form to their sign-in option', () => {
+    mockHint = {
+      lastEmail: 'returning@example.com',
+      lastAuthMethod: 'google',
+      lastLogin: '2026-08-26T00:00:00.000Z',
+    };
+    mounted = mountFlow({ searchParams: {} });
+
+    expect(mounted.container.querySelector('#tier')?.textContent).toBe('returning');
+    expect(mounted.container.querySelector('#email-input')?.textContent).toBe('true');
+
+    act(() => button(mounted!.container, 'back').click());
+
+    expect(mounted.container.querySelector('#tier')?.textContent).toBe('returning');
+    expect(mounted.container.querySelector('#email-input')?.textContent).toBe('false');
+    expect(mockClearHint).not.toHaveBeenCalled();
+  });
+
   it('auto-opens once for a genuinely changed prefilled query email', () => {
     mounted = mountFlow({ searchParams: { email: 'first@example.com' } });
 

--- a/apps/web/src/hooks/useSignInFlow.test.ts
+++ b/apps/web/src/hooks/useSignInFlow.test.ts
@@ -160,6 +160,7 @@ function FlowProbe({ props = { searchParams: {} } }: { props?: SignInFlowProps }
       id: 'submit-email',
       onClick: () => flow.handleEmailSubmit({ preventDefault: () => undefined } as React.FormEvent),
     }),
+    createElement('button', { id: 'clear-hint', onClick: flow.handleClearHint }),
     createElement('button', { id: 'clear-invite', onClick: flow.handleClearInvite }),
     createElement('button', { id: 'retry-turnstile', onClick: flow.handleRetryTurnstile })
   );
@@ -539,6 +540,28 @@ describe('useSignInFlow discovery cancellation', () => {
     expect(mounted.container.querySelector('#tier')?.textContent).toBe('returning');
     expect(mounted.container.querySelector('#email-input')?.textContent).toBe('false');
     expect(mockClearHint).not.toHaveBeenCalled();
+  });
+
+  it('clears a remembered account and returns to neutral email-first sign-in', () => {
+    mockHint = {
+      lastEmail: 'returning@example.com',
+      lastAuthMethod: 'google',
+      lastLogin: '2026-08-26T00:00:00.000Z',
+    };
+    mockClearHint.mockImplementation(() => {
+      mockHint = null;
+    });
+    mounted = mountFlow({ searchParams: {} });
+
+    act(() => button(mounted!.container, 'back').click());
+    expect(mounted.container.querySelector('#email-input')?.textContent).toBe('false');
+
+    act(() => button(mounted!.container, 'clear-hint').click());
+
+    expect(mockClearHint).toHaveBeenCalledTimes(1);
+    expect(mounted.container.querySelector('#tier')?.textContent).toBe('new');
+    expect(mounted.container.querySelector('#email-input')?.textContent).toBe('true');
+    expect(mounted.container.querySelector('#email')?.textContent).toBe('');
   });
 
   it('auto-opens once for a genuinely changed prefilled query email', () => {

--- a/apps/web/src/hooks/useSignInFlow.ts
+++ b/apps/web/src/hooks/useSignInFlow.ts
@@ -817,8 +817,8 @@ export function useSignInFlow({
     setTurnstileError(false);
     setError('');
     setAvailableProviders([]);
-    setShowEmailInput(!isSignUp);
-  }, [clearPendingSso, isSignUp, retireTurnstileWidget]);
+    setShowEmailInput(tier === 'new' && !isSignUp);
+  }, [clearPendingSso, isSignUp, retireTurnstileWidget, tier]);
 
   const handleShowEmailInput = useCallback(() => {
     retireTurnstileWidget();


### PR DESCRIPTION
## Summary

- Make `Back to sign in options` close the email form for remembered returning users.
- Restore their saved provider or Enterprise SSO option without clearing the sign-in hint.
- Preserve email-first landing for users without a remembered account and provider-first landing for explicit signup.
- Add regression coverage for switching away from a remembered account.

## Verification

- [x] Seeded a remembered Google sign-in hint in the local app, reproduced the post-sign-out email form, clicked `Back to sign in options`, and confirmed the view changed to `Welcome back` with `Continue with Google`.
- [x] Clicked `Not you? Use a different account` and confirmed it cleared the remembered email and restored the blank email-first form.
- [x] Repeated the account-switch flow through `or see other sign-in methods`; confirmed `Enterprise SSO` targets `/users/sign_in?sso=true` and `Install Kilo Code` targets `/get-started`.

## Visual Changes

| Before | After |
|---|---|
| Email form remained visible when Back was clicked. ![Remembered user email form before clicking Back](https://github.com/user-attachments/assets/ef20d698-bd52-4ca5-86a6-51f017e48690) | Back restores the remembered provider option. ![Remembered Google provider after clicking Back](https://github.com/user-attachments/assets/b92b20ca-95c5-4610-abdc-cd0b9a6372f4) |

## Reviewer Notes

Sign-out intentionally leaves the local sign-in hint in place. That puts the next sign-in page in the `returning` tier, but `handleBack` previously forced `showEmailInput` to `true` for every non-signup page, making the button a no-op in the reported state. The fix derives the landing view from the active tier instead.

Both `Not you? Use a different account` and `or see other sign-in methods` intentionally clear the same hint and return to neutral email-first sign-in.

Automated checks run locally:

- `pnpm --filter web test apps/web/src/hooks/useSignInFlow.test.ts --runInBand` (28 tests)
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`