### PR TITLE
fix(web): stop sending NextAuth debug logs in production

### DIFF
--- a/apps/web/src/lib/user/server.ts
+++ b/apps/web/src/lib/user/server.ts
@@ -25,7 +25,7 @@ import DiscordProvider from 'next-auth/providers/discord';
 import WorkOSProvider from 'next-auth/providers/workos';
 import AppleProvider from 'next-auth/providers/apple';
 import CredentialsProvider from 'next-auth/providers/credentials';
-import { allow_fake_login, ORGANIZATION_ID_HEADER } from '@/lib/constants';
+import { allow_fake_login, IS_DEVELOPMENT, ORGANIZATION_ID_HEADER } from '@/lib/constants';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { verifyAndConsumeMagicLinkToken } from '@/lib/auth/magic-link-tokens';
 import { redirect } from 'next/navigation';
@@ -563,8 +563,12 @@ type ExtendedProfile = Profile & {
 };
 
 const posthogClient = PostHogClient();
+// NextAuth calls a user-provided `debug` logger regardless of the `debug` option,
+// and its debug payloads contain sensitive data (tokens, secrets, provider config).
+// Only wire up the debug logger in local development.
+// https://next-auth.js.org/configuration/options
 const logger: LoggerInstance = {
-  debug: logExceptInTest,
+  debug: IS_DEVELOPMENT ? logExceptInTest : () => {},
   warn: sentryLogger('NEXTAUTH', 'warning'),
   error: sentryLogger('NEXTAUTH', 'error'),
 };


### PR DESCRIPTION
## Problem

`apps/web/src/lib/user/server.ts` passes a `logger` with a `debug` implementation to NextAuth. Per the [NextAuth docs](https://next-auth.js.org/configuration/options):

> If the debug level is defined by the user, it will be called regardless of the `debug: false` option.

So NextAuth internal debug payloads — which include sensitive values such as provider config, secrets and tokens — have been logged in production.

## Fix

Only wire up the `debug` logger when `NODE_ENV === 'development'`; in all other environments it is a no-op. `warn` and `error` still route to Sentry as before.

Tests not run (fast fix).