### PR TITLE
fix(auth): discover legacy account providers

### DIFF
--- a/apps/web/src/app/api/sso/organizations/route.test.ts
+++ b/apps/web/src/app/api/sso/organizations/route.test.ts
@@ -117,6 +117,27 @@ describe('POST /api/sso/organizations', () => {
     });
   });
 
+  it('enforces required SSO for a discovered legacy Google Workspace account', async () => {
+    mockGetAllUserProviders.mockResolvedValue({
+      kind: 'found',
+      user: {
+        kiloUserId: 'oauth/google:synthetic-account',
+        providers: ['google'],
+        primaryEmail: 'legacy-workspace@example.com',
+      },
+    });
+    mockResolveSsoAuthorityForDomain.mockResolvedValue({
+      status: 'required',
+      domain: 'example.com',
+      sourceOrganizationId: 'organization-1',
+    });
+    mockGetWorkOSOrganization.mockResolvedValue({ id: 'workos-organization-1' } as never);
+
+    await expect(
+      (await POST(request({ email: 'legacy-workspace@example.com' }))).json()
+    ).resolves.toEqual({ kind: 'sso', organizationId: 'workos-organization-1' });
+  });
+
   it('returns server-authorized account-creation choices for an eligible unknown email', async () => {
     await expect((await POST(request({ email: 'new@example.com' }))).json()).resolves.toEqual({
       kind: 'new',

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -430,25 +430,28 @@ describe('User', () => {
       });
     });
 
-    it('uses legacy OAuth ID provenance for a Google Workspace account', async () => {
-      const user = await insertTestUser({
-        id: 'oauth/google:synthetic-workspace-account',
-        google_user_email: 'legacy-workspace@example.com',
-        google_user_name: 'Legacy Workspace User',
-        normalized_email: 'legacy-workspace@example.com',
-        hosted_domain: 'example.com',
-      });
+    it.each(['google', 'github', 'gitlab'] as const)(
+      'uses legacy %s OAuth ID provenance when provider rows are missing',
+      async provider => {
+        const user = await insertTestUser({
+          id: `oauth/${provider}:synthetic-account`,
+          google_user_email: `legacy-${provider}@example.com`,
+          google_user_name: 'Legacy Workspace User',
+          normalized_email: `legacy-${provider}@example.com`,
+          hosted_domain: 'example.com',
+        });
 
-      await expect(getAllUserProviders('legacy-workspace@example.com')).resolves.toEqual({
-        kind: 'found',
-        user: {
-          kiloUserId: user.id,
-          providers: ['google'],
-          primaryEmail: 'legacy-workspace@example.com',
-          workosHostedDomain: undefined,
-        },
-      });
-    });
+        await expect(getAllUserProviders(`legacy-${provider}@example.com`)).resolves.toEqual({
+          kind: 'found',
+          user: {
+            kiloUserId: user.id,
+            providers: [provider],
+            primaryEmail: `legacy-${provider}@example.com`,
+            workosHostedDomain: undefined,
+          },
+        });
+      }
+    );
 
     it('keeps linked provider rows authoritative over legacy OAuth ID provenance', async () => {
       const user = await insertTestUser({
@@ -477,6 +480,30 @@ describe('User', () => {
         },
       });
     });
+
+    it.each(['oauth/google:', 'oauth/googleish:account', 'oauth/workos:account'])(
+      'does not infer a provider from malformed or unsupported legacy ID %s',
+      async id => {
+        const email = `invalid-legacy-${randomUUID()}@example.com`;
+        const user = await insertTestUser({
+          id,
+          google_user_email: email,
+          google_user_name: 'Invalid Legacy User',
+          normalized_email: email,
+          hosted_domain: 'unknown.example.com',
+        });
+
+        await expect(getAllUserProviders(email)).resolves.toEqual({
+          kind: 'found',
+          user: {
+            kiloUserId: user.id,
+            providers: [],
+            primaryEmail: email,
+            workosHostedDomain: undefined,
+          },
+        });
+      }
+    );
 
     it('does not infer a provider from an unknown legacy hosted domain', async () => {
       const user = await insertTestUser({

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -144,6 +144,7 @@ import { hashNormalizedEmailForDeletionTombstone } from '@/lib/impact/referral';
 import { generateOpenRouterDownstreamSafetyIdentifier } from '@/lib/ai-gateway/providerHash';
 import { createTestPaymentMethod } from '@/tests/helpers/payment-method.helper';
 import { insertTestUser, insertTestUserAndGoogleAuth } from '@/tests/helpers/user.helper';
+import { hosted_domain_specials } from '@/lib/auth/constants';
 import { createTestOrganization } from '@/tests/helpers/organization.helper';
 import { forceImmediateExpirationRecomputation } from '@/lib/balanceCache';
 import { randomUUID } from 'crypto';
@@ -407,6 +408,44 @@ describe('User', () => {
     it('returns null for an email that is not linked to an account', async () => {
       await expect(getAllUserProviders('no-match@example.com')).resolves.toEqual({
         kind: 'not_found',
+      });
+    });
+
+    it('uses the explicit legacy provider sentinel when provider rows are missing', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'legacy-provider@example.com',
+        google_user_name: 'Legacy Provider User',
+        normalized_email: 'legacy-provider@example.com',
+        hosted_domain: hosted_domain_specials.github,
+      });
+
+      await expect(getAllUserProviders('legacy-provider@example.com')).resolves.toEqual({
+        kind: 'found',
+        user: {
+          kiloUserId: user.id,
+          providers: ['github'],
+          primaryEmail: 'legacy-provider@example.com',
+          workosHostedDomain: undefined,
+        },
+      });
+    });
+
+    it('does not infer a provider from an unknown legacy hosted domain', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'unknown-legacy@example.com',
+        google_user_name: 'Unknown Legacy User',
+        normalized_email: 'unknown-legacy@example.com',
+        hosted_domain: 'unknown.example.com',
+      });
+
+      await expect(getAllUserProviders('unknown-legacy@example.com')).resolves.toEqual({
+        kind: 'found',
+        user: {
+          kiloUserId: user.id,
+          providers: [],
+          primaryEmail: 'unknown-legacy@example.com',
+          workosHostedDomain: undefined,
+        },
       });
     });
 

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -430,6 +430,54 @@ describe('User', () => {
       });
     });
 
+    it('uses legacy OAuth ID provenance for a Google Workspace account', async () => {
+      const user = await insertTestUser({
+        id: 'oauth/google:synthetic-workspace-account',
+        google_user_email: 'legacy-workspace@example.com',
+        google_user_name: 'Legacy Workspace User',
+        normalized_email: 'legacy-workspace@example.com',
+        hosted_domain: 'example.com',
+      });
+
+      await expect(getAllUserProviders('legacy-workspace@example.com')).resolves.toEqual({
+        kind: 'found',
+        user: {
+          kiloUserId: user.id,
+          providers: ['google'],
+          primaryEmail: 'legacy-workspace@example.com',
+          workosHostedDomain: undefined,
+        },
+      });
+    });
+
+    it('keeps linked provider rows authoritative over legacy OAuth ID provenance', async () => {
+      const user = await insertTestUser({
+        id: 'oauth/google:synthetic-linked-account',
+        google_user_email: 'linked-legacy@example.com',
+        google_user_name: 'Linked Legacy User',
+        normalized_email: 'linked-legacy@example.com',
+        hosted_domain: 'example.com',
+      });
+      await db.insert(user_auth_provider).values({
+        kilo_user_id: user.id,
+        provider: 'email',
+        provider_account_id: 'linked-legacy@example.com',
+        email: 'linked-legacy@example.com',
+        avatar_url: '',
+        hosted_domain: 'example.com',
+      });
+
+      await expect(getAllUserProviders('linked-legacy@example.com')).resolves.toEqual({
+        kind: 'found',
+        user: {
+          kiloUserId: user.id,
+          providers: ['email'],
+          primaryEmail: 'linked-legacy@example.com',
+          workosHostedDomain: undefined,
+        },
+      });
+    });
+
     it('does not infer a provider from an unknown legacy hosted domain', async () => {
       const user = await insertTestUser({
         google_user_email: 'unknown-legacy@example.com',

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -1949,6 +1949,10 @@ async function getUserProviderInfo(user: User): Promise<UserProviderLookupResult
 }
 
 function legacyProviderFromHostedDomain(user: User): AuthProviderId[] {
+  if (user.id.startsWith('oauth/google:')) return ['google'];
+  if (user.id.startsWith('oauth/github:')) return ['github'];
+  if (user.id.startsWith('oauth/gitlab:')) return ['gitlab'];
+
   switch (user.hosted_domain) {
     case hosted_domain_specials.non_workspace_google_account:
       return ['google'];

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -1949,9 +1949,8 @@ async function getUserProviderInfo(user: User): Promise<UserProviderLookupResult
 }
 
 function legacyProviderFromHostedDomain(user: User): AuthProviderId[] {
-  if (user.id.startsWith('oauth/google:')) return ['google'];
-  if (user.id.startsWith('oauth/github:')) return ['github'];
-  if (user.id.startsWith('oauth/gitlab:')) return ['gitlab'];
+  const legacyOAuthProvider = parseLegacyOAuthProvider(user.id);
+  if (legacyOAuthProvider) return [legacyOAuthProvider];
 
   switch (user.hosted_domain) {
     case hosted_domain_specials.non_workspace_google_account:
@@ -1972,6 +1971,18 @@ function legacyProviderFromHostedDomain(user: User): AuthProviderId[] {
       return ['email'];
     default:
       return [];
+  }
+}
+
+function parseLegacyOAuthProvider(userId: string): AuthProviderId | null {
+  const match = /^oauth\/(google|github|gitlab):(.+)$/.exec(userId);
+  switch (match?.[1]) {
+    case 'google':
+    case 'github':
+    case 'gitlab':
+      return match[1];
+    default:
+      return null;
   }
 }
 

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -124,6 +124,7 @@ import type { TRPCError } from '@trpc/server';
 import type { UUID } from 'node:crypto';
 import { checkDiscordGuildMembership } from '@/lib/integrations/discord-guild-membership';
 import type { AuthProviderId } from '@/lib/auth/provider-metadata';
+import { hosted_domain_specials } from '@/lib/auth/constants';
 import {
   generateOpenRouterDownstreamSafetyIdentifier,
   generateOpenRouterUpstreamSafetyIdentifier,
@@ -1933,16 +1934,41 @@ async function getUserProviderInfo(user: User): Promise<UserProviderLookupResult
     .orderBy(user_auth_provider.created_at);
 
   const workosProvider = providers.find(p => p.provider === 'workos');
+  const discoveredProviders =
+    providers.length > 0 ? providers.map(p => p.provider) : legacyProviderFromHostedDomain(user);
 
   return {
     kind: 'found',
     user: {
       kiloUserId: user.id,
-      providers: providers.map(p => p.provider),
+      providers: discoveredProviders,
       primaryEmail: user.google_user_email,
       workosHostedDomain: workosProvider?.hosted_domain ?? undefined,
     },
   };
+}
+
+function legacyProviderFromHostedDomain(user: User): AuthProviderId[] {
+  switch (user.hosted_domain) {
+    case hosted_domain_specials.non_workspace_google_account:
+      return ['google'];
+    case hosted_domain_specials.anaconda:
+      return ['anaconda'];
+    case hosted_domain_specials.apple:
+      return ['apple'];
+    case hosted_domain_specials.github:
+      return ['github'];
+    case hosted_domain_specials.gitlab:
+      return ['gitlab'];
+    case hosted_domain_specials.linkedin:
+      return ['linkedin'];
+    case hosted_domain_specials.discord:
+      return ['discord'];
+    case hosted_domain_specials.email:
+      return ['email'];
+    default:
+      return [];
+  }
 }
 
 /**


### PR DESCRIPTION
## Summary

- Restore sign-in discovery for existing legacy accounts that predate authoritative `user_auth_provider` rows.
- Parse recognized historical OAuth user IDs with an exact provider-and-account grammar, including Google Workspace accounts whose hosted domain is a real domain.
- Fall back to explicit legacy `hosted_domain` provider sentinels for later legacy account shapes.
- Keep linked provider rows authoritative and preserve fail-closed behavior for malformed or unknown IDs, arbitrary domains, SSO, and development-only login.

## Verification

- [ ] Not manually tested end-to-end because reproducing these legacy data shapes requires synthetic database fixtures. Provider lookup and discovery behavior were exercised with synthetic data in the automated regression coverage described below.

## Visual Changes

N/A

## Reviewer Notes

The fallback runs only when an existing account has zero linked provider rows. It strictly accepts the historically evidenced `oauth/google:<account>`, `oauth/github:<account>`, and `oauth/gitlab:<account>` forms with a non-empty account component before consulting explicit production provider sentinels. It deliberately excludes WorkOS, malformed and unknown OAuth IDs, arbitrary hosted domains, null values, and the development-only provider.

A linked provider row always overrides legacy ID or hosted-domain provenance. Discovery still evaluates required SSO for the matched primary-email domain before returning a legacy provider.

Automated checks run locally:

- `pnpm --filter web test apps/web/src/lib/user/index.test.ts apps/web/src/app/api/sso/organizations/route.test.ts --runInBand` (150 tests)
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`

Static review history:

- First review: addressed missing Google Workspace legacy-account discovery using historical OAuth ID provenance.
- Second review: replaced permissive prefix matching with strict legacy ID parsing and expanded malformed-ID, provider-precedence, and required-SSO coverage.