### PR TITLE
feat(admin): show user login methods

### DIFF
--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.test.ts
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from '@jest/globals';
+import { getLoginMethods } from './UserAdminAccountInfo';
+
+describe('getLoginMethods', () => {
+  it('shows the names of each associated login provider', () => {
+    expect(
+      getLoginMethods(['anaconda', 'github', 'workos']).map(provider => provider.name)
+    ).toEqual(['Anaconda', 'GitHub', 'Enterprise SSO']);
+  });
+
+  it('shows magic-link email login', () => {
+    expect(getLoginMethods(['email']).map(provider => provider.name)).toEqual(['Email']);
+  });
+});

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
@@ -15,6 +15,8 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import Link from 'next/link';
 import { Info, SquareArrowOutUpRight, Webhook } from 'lucide-react';
 import { createHash } from 'crypto';
+import { getProviderById, type AuthProviderId } from '@/lib/auth/provider-metadata';
+import { Badge } from '@/components/ui/badge';
 
 function getGravatarUrl(email: string, size: number = 80): string {
   const hash = createHash('md5').update(email.toLowerCase().trim()).digest('hex');
@@ -109,6 +111,9 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
           <Field label="Email">
             {user.google_user_email} <CopyTextButton text={user.google_user_email} />
           </Field>
+          <Field label="Login Methods">
+            <UserLoginMethods providers={user.login_methods} />
+          </Field>
           <Field label="Normalized Email">
             {user.normalized_email ?? <span className="text-muted-foreground">N/A</span>}
             {user.normalized_email ? <CopyTextButton text={user.normalized_email} /> : null}
@@ -167,6 +172,27 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
       </CardContent>
     </Card>
   );
+}
+
+export function UserLoginMethods({ providers }: { providers: AuthProviderId[] }) {
+  return (
+    <div className="flex flex-wrap gap-1.5">
+      {getLoginMethods(providers).map(metadata => {
+        return (
+          <Badge key={metadata.id} variant="secondary" className="gap-1.5 font-normal">
+            <span className="flex size-3.5 items-center justify-center [&>svg]:size-3.5">
+              {metadata.icon}
+            </span>
+            {metadata.name}
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}
+
+export function getLoginMethods(providers: AuthProviderId[]) {
+  return providers.map(getProviderById);
 }
 
 function Field({

--- a/apps/web/src/app/admin/users/[id]/page.tsx
+++ b/apps/web/src/app/admin/users/[id]/page.tsx
@@ -11,6 +11,7 @@ import {
   organization_memberships,
   organizations,
   auto_top_up_configs,
+  user_auth_provider,
 } from '@kilocode/db/schema';
 import { eq, inArray, desc } from 'drizzle-orm';
 import { findUserById } from '@/lib/user';
@@ -65,6 +66,11 @@ async function getUserData(userId: string): Promise<UserDetailProps | null> {
   const paymentMethodsByUserId = await getPaymentStatusByUserIds([user.id]);
   const creditInfo = await getBalanceForUser(user);
   const hasReceivedCardValidationCredits = await hasReceivedAnyFreeWelcomeCredits(user.id);
+  const authProviders = await db
+    .selectDistinct({ provider: user_auth_provider.provider })
+    .from(user_auth_provider)
+    .where(eq(user_auth_provider.kilo_user_id, userId))
+    .orderBy(user_auth_provider.provider);
 
   // Fetch auto-top-up config
   const autoTopUpConfig =
@@ -92,6 +98,7 @@ async function getUserData(userId: string): Promise<UserDetailProps | null> {
     organization_memberships: organizationMemberships,
     autoTopUpConfig,
     is_sso_protected_domain: isSSOProtectedDomain,
+    login_methods: authProviders.length > 0 ? authProviders.map(row => row.provider) : ['email'],
   };
 }
 

--- a/apps/web/src/types/admin.ts
+++ b/apps/web/src/types/admin.ts
@@ -10,6 +10,7 @@ import type { describePaymentMethods } from '@/lib/admin-utils-serverside';
 import { OrganizationSchema } from '@/lib/organizations/organization-types';
 import { type BalanceForUser } from '@/lib/user/balance';
 import type { PaginationMetadata } from '@/types/pagination';
+import type { AuthProviderId } from '@kilocode/db/schema-types';
 
 export type PaymentMethodStatus = Awaited<ReturnType<typeof describePaymentMethods>>;
 
@@ -35,11 +36,15 @@ export type HasAutoTopUpConfig = {
 export type HasSSOProtectedDomain = {
   is_sso_protected_domain: boolean;
 };
+export type HasLoginMethods = {
+  login_methods: AuthProviderId[];
+};
 export type UserDetailProps = UserTableProps &
   HasCreditInfo &
   UserOrganizationMembershipProps &
   HasAutoTopUpConfig &
-  HasSSOProtectedDomain;
+  HasSSOProtectedDomain &
+  HasLoginMethods;
 export type UsersApiResponse = {
   users: UserTableProps[];
   pagination: PaginationMetadata;


### PR DESCRIPTION
## Summary

Show the authentication methods associated with a user on the internal admin user detail page. The page now reads distinct linked providers from `user_auth_provider`, maps them through the shared provider metadata, and renders compact labeled badges without exposing provider account details. Accounts without linked provider rows are shown as Email login accounts.

## Verification

- [ ] Not manually verified in the browser; the internal admin page requires a running authenticated local environment and representative linked-provider fixtures.

## Visual Changes

<img width="446" height="251" alt="Screenshot 2026-08-26 at 2 58 03 PM" src="https://github.com/user-attachments/assets/d74037f1-c879-4627-8363-b61796d24244" />


## Reviewer Notes

Review the Email fallback for users with no `user_auth_provider` rows. Provider rows are intentionally reduced to distinct method names; linked emails and provider account IDs remain hidden.