### PR TITLE
fix(mobile): remove redundant database backup exclusions

### DIFF
--- a/apps/mobile/plugins/backup/kilo_backup_rules.xml
+++ b/apps/mobile/plugins/backup/kilo_backup_rules.xml
@@ -14,5 +14,4 @@
   <exclude domain="sharedpref" path="SecureStore"/>
   <exclude domain="sharedpref" path="appsflyer-data"/>
   <exclude domain="sharedpref" path="appsflyer-purchase-data"/>
-  <exclude domain="database" path="afpurchases.db"/>
 </full-backup-content>

--- a/apps/mobile/plugins/backup/kilo_data_extraction_rules.xml
+++ b/apps/mobile/plugins/backup/kilo_data_extraction_rules.xml
@@ -12,13 +12,11 @@
     <exclude domain="sharedpref" path="SecureStore"/>
     <exclude domain="sharedpref" path="appsflyer-data"/>
     <exclude domain="sharedpref" path="appsflyer-purchase-data"/>
-    <exclude domain="database" path="afpurchases.db"/>
   </cloud-backup>
   <device-transfer>
     <include domain="sharedpref" path="."/>
     <exclude domain="sharedpref" path="SecureStore"/>
     <exclude domain="sharedpref" path="appsflyer-data"/>
     <exclude domain="sharedpref" path="appsflyer-purchase-data"/>
-    <exclude domain="database" path="afpurchases.db"/>
   </device-transfer>
 </data-extraction-rules>


### PR DESCRIPTION
## Summary

- Remove three redundant `afpurchases.db` exclusions from Android backup rules.
- Preserve the shared-preference allowlist and all existing shared-preference exclusions.
- Fix `:app:lintVitalRelease` failures in [the release run](https://github.com/Kilo-Org/cloud/actions/runs/33005523878).

## Verification

- No manual device tests ran; this change only removes invalid XML entries.
- The native Android release build was not rerun.

## Visual Changes

N/A

## Reviewer Notes

- Databases remain excluded because each backup section includes only `sharedpref`.
- Passed: `pnpm format`, `pnpm typecheck`, `pnpm lint`, and `pnpm check:unused` from `apps/mobile`.
- Passed: XML syntax validation, XPath assertions for preserved allowlists, and `git diff --check`.
