### PR TITLE
fix(mobile): avoid choosing the wrong GitHub install from a repo link

### DIFF
--- a/apps/mobile/src/components/agents/new-session-prefill.test.ts
+++ b/apps/mobile/src/components/agents/new-session-prefill.test.ts
@@ -243,6 +243,14 @@ describe('resolvePrefillRepo', () => {
     expect(result).toBe('Kilo-Org/cloud');
   });
 
+  it('returns null when multiple options match case-insensitively', () => {
+    const result = resolvePrefillRepo(
+      [{ fullName: 'Kilo-Org/cloud' }, { fullName: 'kilo-org/CLOUD' }],
+      { mode: 'code', repo: 'KILO-ORG/cloud' }
+    );
+    expect(result).toBeNull();
+  });
+
   it.each([
     { repo: 'other/repo', reposOverride: undefined, desc: 'no match' },
     { repo: 'Kilo-Org/cloud', reposOverride: [] as { fullName: string }[], desc: 'empty list' },
@@ -292,6 +300,17 @@ describe('resolvePrefillRepoSelection', () => {
   it('matches case-insensitively and returns the canonical GitHub casing', () => {
     const result = resolvePrefillRepoSelection(repos, { mode: 'code', repo: 'kilo-Org/Cloud' });
     expect(result).toBe('github:Kilo-Org/cloud');
+  });
+
+  it('returns null when multiple GitHub options match case-insensitively', () => {
+    const result = resolvePrefillRepoSelection(
+      [
+        { platform: 'github', fullName: 'Kilo-Org/cloud' },
+        { platform: 'github', fullName: 'kilo-org/CLOUD' },
+      ],
+      { mode: 'code', repo: 'KILO-ORG/cloud' }
+    );
+    expect(result).toBeNull();
   });
 
   it.each([

--- a/apps/mobile/src/components/agents/new-session-prefill.ts
+++ b/apps/mobile/src/components/agents/new-session-prefill.ts
@@ -160,8 +160,8 @@ export function resolvePrefillModel(
 /**
  * Resolve a prefill repository against the loaded repository list.
  * Match is **case-insensitive**; returns the **matched entry's
- * `fullName`** (GitHub's canonical casing). Returns `null` when
- * `prefill.repo` is absent or nothing matches.
+ * `fullName`** (GitHub's canonical casing). Returns `null` unless exactly
+ * one entry matches.
  */
 export function resolvePrefillRepo(
   repositories: { fullName: string }[],
@@ -172,8 +172,8 @@ export function resolvePrefillRepo(
   }
 
   const lower = prefill.repo.toLowerCase();
-  const match = repositories.find(r => r.fullName.toLowerCase() === lower);
-  return match?.fullName ?? null;
+  const matches = repositories.filter(repository => repository.fullName.toLowerCase() === lower);
+  return matches.length === 1 ? (matches[0]?.fullName ?? null) : null;
 }
 
 /**
@@ -193,10 +193,10 @@ export function resolvePrefillRepoSelection(
   }
 
   const lower = prefill.repo.toLowerCase();
-  const match = repositories.find(
+  const matches = repositories.filter(
     repository => repository.platform === 'github' && repository.fullName.toLowerCase() === lower
   );
-  return match ? `github:${match.fullName}` : null;
+  return matches.length === 1 && matches[0] ? `github:${matches[0].fullName}` : null;
 }
 
 /**


### PR DESCRIPTION
## Why this PR exists

Organizations can now connect more than one GitHub App installation. A pasted or deep-linked `owner/repo` can therefore match multiple mobile repository options, especially while installations overlap during a repository move. The previous first-match behavior could silently choose the wrong installation before the user even sees the new-session form.

This is a small defensive PR: when repository provenance is ambiguous, mobile leaves the selection empty and asks the user to choose rather than guessing.

## Place in the rollout

This is an independent client-safety fix in the broader multiple-GitHub-organizations rollout. It does not require the full mobile installation selector in #5549, and it is useful even before that PR lands.

## What changes

- Resolve pasted and deep-linked repositories case-insensitively only when exactly one loaded option matches.
- Preserve GitHub canonical casing for a unique match.
- Return no preselection for zero or multiple matches.

## What stays unchanged

- Repository links still prefill normally when the match is unique.
- This PR does not change repository rendering, session submission, or continuation behavior. Those are intentionally isolated in #5549 and #5546.

## Review guide

The production change is six lines in `new-session-prefill.ts`; the rest is focused ambiguity coverage. The key question is whether mobile ever selects a repository when provenance is not unique.

## Validation

- Focused mobile prefill tests
- Focused lint and format check
- `git diff --check`