### PR TITLE
feat(mobile): keep continued sessions on their GitHub installation

### DIFF
--- a/apps/mobile/src/components/agents/continuation-seed.test.ts
+++ b/apps/mobile/src/components/agents/continuation-seed.test.ts
@@ -88,4 +88,52 @@ describe('resolveContinuationResolution', () => {
 
     expect(result).toEqual({ kind: 'unresolved-model' });
   });
+
+  it('preserves unique repository integration provenance when continuing', () => {
+    const result = resolveContinuationResolution({
+      gitUrl: GIT_URL,
+      mode: 'code',
+      model: 'test-model',
+      variant: 'default',
+      repositories: [{ fullName: 'owner/repo', platformIntegrationId: 'integration-1' }],
+      models: MODELS,
+    });
+
+    expect(result).toEqual({
+      kind: 'cloud-agent',
+      repo: 'owner/repo',
+      model: 'test-model',
+      variant: 'default',
+      githubIntegrationId: 'integration-1',
+    });
+  });
+
+  it('omits repository integration provenance for a unique legacy repository', () => {
+    const result = resolveContinuationResolution({
+      gitUrl: GIT_URL,
+      mode: 'code',
+      model: 'test-model',
+      variant: 'default',
+      repositories: REPOS,
+      models: MODELS,
+    });
+
+    expect(result).not.toHaveProperty('githubIntegrationId');
+  });
+
+  it('rejects an ambiguous repository match across installations', () => {
+    const result = resolveContinuationResolution({
+      gitUrl: GIT_URL,
+      mode: 'code',
+      model: 'test-model',
+      variant: 'default',
+      repositories: [
+        { fullName: 'owner/repo', platformIntegrationId: 'integration-1' },
+        { fullName: 'OWNER/REPO', platformIntegrationId: 'integration-2' },
+      ],
+      models: MODELS,
+    });
+
+    expect(result).toEqual({ kind: 'unmatched-repository' });
+  });
 });

--- a/apps/mobile/src/components/agents/continuation-seed.ts
+++ b/apps/mobile/src/components/agents/continuation-seed.ts
@@ -7,7 +7,13 @@ import {
 } from '@/components/agents/new-session-prefill';
 
 export type ContinuationResolution =
-  | { kind: 'cloud-agent'; repo: string; model: string; variant: string }
+  | {
+      kind: 'cloud-agent';
+      repo: string;
+      model: string;
+      variant: string;
+      githubIntegrationId?: string;
+    }
   | { kind: 'unmatched-repository' }
   | { kind: 'unresolved-model' };
 
@@ -22,7 +28,7 @@ export function resolveContinuationResolution(args: {
   mode: string;
   model: string;
   variant: string;
-  repositories: { fullName: string }[];
+  repositories: { fullName: string; platformIntegrationId?: string }[];
   models: { id: string; variants: string[] }[];
 }): ContinuationResolution {
   const { gitUrl, mode, model, variant, repositories, models } = args;
@@ -40,10 +46,18 @@ export function resolveContinuationResolution(args: {
     ...(prefillParams.variant ? { variant: prefillParams.variant } : {}),
   };
 
-  const repo = resolvePrefillRepo(repositories, prefill);
-  if (repo === null) {
+  const resolvedRepo = resolvePrefillRepo(repositories, prefill);
+  if (resolvedRepo === null) {
     return { kind: 'unmatched-repository' };
   }
+
+  const matchingRepositories = repositories.filter(
+    repository => repository.fullName.toLowerCase() === resolvedRepo.toLowerCase()
+  );
+  if (matchingRepositories.length !== 1) {
+    return { kind: 'unmatched-repository' };
+  }
+  const repository = matchingRepositories[0];
 
   const resolvedModel = resolvePrefillModel(models, prefill);
   if (resolvedModel === null) {
@@ -52,8 +66,11 @@ export function resolveContinuationResolution(args: {
 
   return {
     kind: 'cloud-agent',
-    repo,
+    repo: resolvedRepo,
     model: resolvedModel.model,
     variant: resolvedModel.variant,
+    ...(repository?.platformIntegrationId
+      ? { githubIntegrationId: repository.platformIntegrationId }
+      : {}),
   };
 }

--- a/apps/mobile/src/components/agents/use-continue-cloud-create.ts
+++ b/apps/mobile/src/components/agents/use-continue-cloud-create.ts
@@ -22,7 +22,7 @@ export function useContinueCloudCreate(
   organizationId: string | undefined
 ): (
   sessionId: KiloSessionId,
-  dest: { repo: string; model: string; variant: string },
+  dest: { repo: string; model: string; variant: string; githubIntegrationId?: string },
   mode: string
 ) => Promise<void> {
   const router = useRouter();
@@ -43,12 +43,13 @@ export function useContinueCloudCreate(
   return useCallback(
     async (
       sessionId: KiloSessionId,
-      dest: { repo: string; model: string; variant: string },
+      dest: { repo: string; model: string; variant: string; githubIntegrationId?: string },
       mode: string
     ) => {
       const intentFingerprint = JSON.stringify({
         cloneFromKiloSessionId: sessionId,
         repo: dest.repo,
+        githubIntegrationId: dest.githubIntegrationId ?? null,
         model: dest.model,
         variant: dest.variant || undefined,
         mode,
@@ -73,6 +74,7 @@ export function useContinueCloudCreate(
         model: dest.model,
         variant: dest.variant || undefined,
         githubRepo: dest.repo,
+        ...(dest.githubIntegrationId ? { githubIntegrationId: dest.githubIntegrationId } : {}),
         autoCommit: false,
         autoInitiate: true as const,
         operationKey,

--- a/apps/mobile/src/components/agents/use-continue-session.test.ts
+++ b/apps/mobile/src/components/agents/use-continue-session.test.ts
@@ -306,6 +306,36 @@ describe('useContinueSession cloud clone wiring', () => {
     expect(input.initialMessageId).toBeUndefined();
   });
 
+  it('forwards repository integration provenance into the continued session', async () => {
+    resolutionRef.value = { ...CLOUD_RESOLUTION, githubIntegrationId: 'integration-1' };
+    prepareSessionMutate.mockResolvedValueOnce({
+      kiloSessionId: 'ses_12345678901234567890123456',
+    });
+    const mount = mountContinueSession({ sessionId: SESSION_ID, organizationId: 'org-1' });
+
+    await mount.result.continueSession(FIELDS);
+
+    const input = prepareSessionMutate.mock.calls[0]?.[0] as Record<string, unknown>;
+    expect(input).toMatchObject({
+      cloneFromKiloSessionId: SESSION_ID,
+      githubRepo: 'owner/repo',
+      githubIntegrationId: 'integration-1',
+    });
+    expect(input.prompt).toBeUndefined();
+    expect(input.initialMessageId).toBeUndefined();
+  });
+
+  it('omits repository integration provenance from legacy clone input', async () => {
+    prepareSessionMutate.mockResolvedValueOnce({
+      kiloSessionId: 'ses_12345678901234567890123456',
+    });
+    const mount = mountContinueSession({ sessionId: SESSION_ID, organizationId: 'org-1' });
+
+    await mount.result.continueSession(FIELDS);
+
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).not.toHaveProperty('githubIntegrationId');
+  });
+
   it('never drains history and never queries instances: only the repository list is fetched', async () => {
     prepareSessionMutate.mockResolvedValueOnce({
       kiloSessionId: 'ses_12345678901234567890123456',
@@ -423,6 +453,24 @@ describe('useContinueSession cloud clone wiring', () => {
     );
     expect(fingerprints).toHaveLength(2);
     expect(fingerprints[0]).toBe(fingerprints[1]);
+  });
+
+  it('includes repository integration provenance in the operation fingerprint', async () => {
+    resolutionRef.value = { ...CLOUD_RESOLUTION, githubIntegrationId: 'integration-1' };
+    prepareSessionMutate.mockResolvedValueOnce({
+      kiloSessionId: 'ses_12345678901234567890123456',
+    });
+    const mount = mountContinueSession({ sessionId: SESSION_ID, organizationId: 'org-1' });
+
+    await mount.result.continueSession(FIELDS);
+
+    const row = outboxMock.writeSafeRetry.mock.calls[0]?.[0] as { fingerprint: string } | undefined;
+    const fingerprint = row?.fingerprint ?? '';
+    expect(JSON.parse(fingerprint)).toMatchObject({
+      cloneFromKiloSessionId: SESSION_ID,
+      repo: 'owner/repo',
+      githubIntegrationId: 'integration-1',
+    });
   });
 
   it('surfaces connect-repository guidance and does not navigate when the repository is unmatched', async () => {


### PR DESCRIPTION
## Why this PR exists

A continued Cloud Agent session must use the same GitHub App installation as the source session. With multiple installations, repository name alone is no longer sufficient: two installations can expose the same `owner/repo`, and choosing a different one can change both authorization and credentials.

Without this PR, mobile continuation can silently move work to whichever matching installation happens to be returned first. This PR makes continuation preserve exact installation identity and fail closed when that identity cannot be determined uniquely.

## Place in the rollout

This is the continuation-specific mobile slice of the multiple-GitHub-organizations rollout. It is independent from the new-session selector in #5549 so reviewers can evaluate session cloning and idempotency separately from picker UI.

## What changes

- Resolve the source repository against the current repository DTOs and require a unique match.
- Carry `platformIntegrationId` into continuation as `githubIntegrationId`.
- Include installation identity in the operation fingerprint so retries for different installations cannot collide.
- Keep legacy behavior for old DTOs that genuinely have no provenance, while still rejecting ambiguity.

## What stays unchanged

- Continuations remain clone-only and do not create a synthetic prompt or initial message.
- New-session repository selection is not changed here.
- Server-side token authorization remains the fence already merged in #5485.

## Review guide

Start with `continuation-seed.ts`, then verify `use-continue-cloud-create.ts` forwards the resolved identity and fingerprints it. The tests cover unique, ambiguous, legacy, and retry cases.

## Validation

- Focused continuation tests
- Mobile typecheck, lint, unused-code check, and format check
- `git diff --check`