### PR TITLE
superseded: cached web repository installation resolver

### DIFF
--- a/apps/web/src/lib/integrations/db/github-installation-resolver.test.ts
+++ b/apps/web/src/lib/integrations/db/github-installation-resolver.test.ts
@@ -1,0 +1,213 @@
+import { afterEach, describe, expect, it } from '@jest/globals';
+import { db } from '@/lib/drizzle';
+import { organizations, platform_integrations } from '@kilocode/db/schema';
+import { inArray } from 'drizzle-orm';
+import { resolveOrganizationGitHubIntegrationForRepository } from './platform-integrations';
+
+const organizationIds = [crypto.randomUUID(), crypto.randomUUID()];
+const installationIds: string[] = [];
+
+async function insertOrganization(organizationId: string) {
+  await db.insert(organizations).values({
+    id: organizationId,
+    name: `GitHub resolver ${organizationId}`,
+  });
+}
+
+async function insertIntegration(
+  organizationId: string,
+  overrides: Partial<typeof platform_integrations.$inferInsert> = {}
+) {
+  const installationId = `resolver-${crypto.randomUUID()}`;
+  installationIds.push(installationId);
+  const [integration] = await db
+    .insert(platform_integrations)
+    .values({
+      owned_by_organization_id: organizationId,
+      platform: 'github',
+      integration_type: 'app',
+      integration_status: 'active',
+      platform_installation_id: installationId,
+      platform_account_login: 'acme',
+      repository_access: 'all',
+      github_app_type: 'standard',
+      ...overrides,
+    })
+    .returning();
+  if (!integration) throw new Error('Expected GitHub integration fixture');
+  return integration;
+}
+
+afterEach(async () => {
+  if (installationIds.length > 0) {
+    await db
+      .delete(platform_integrations)
+      .where(inArray(platform_integrations.platform_installation_id, installationIds));
+    installationIds.length = 0;
+  }
+  await db.delete(organizations).where(inArray(organizations.id, organizationIds));
+});
+
+describe('resolveOrganizationGitHubIntegrationForRepository', () => {
+  it('resolves the exact healthy integration row when its account and repository match', async () => {
+    await insertOrganization(organizationIds[0]);
+    const integration = await insertIntegration(organizationIds[0], {
+      repository_access: 'selected',
+      repositories: [{ id: 1, name: 'api', full_name: 'acme/api', private: true }],
+      github_app_type: 'lite',
+    });
+    await insertIntegration(organizationIds[0], {
+      platform_account_login: 'other',
+    });
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'acme/api',
+        expectedPlatformIntegrationId: integration.id,
+      })
+    ).resolves.toEqual({ success: true, integration });
+  });
+
+  it('fails a pinned integration closed when its selected repositories do not include the repo', async () => {
+    await insertOrganization(organizationIds[0]);
+    const integration = await insertIntegration(organizationIds[0], {
+      repository_access: 'selected',
+      repositories: [{ id: 1, name: 'web', full_name: 'acme/web', private: true }],
+    });
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'acme/api',
+        expectedPlatformIntegrationId: integration.id,
+      })
+    ).resolves.toEqual({ success: false, reason: 'no_installation_found' });
+  });
+
+  it('fails a pinned integration closed when its account does not own the repository', async () => {
+    await insertOrganization(organizationIds[0]);
+    const integration = await insertIntegration(organizationIds[0], {
+      platform_account_login: 'other',
+    });
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'acme/api',
+        expectedPlatformIntegrationId: integration.id,
+      })
+    ).resolves.toEqual({ success: false, reason: 'no_installation_found' });
+  });
+
+  it.each([
+    {
+      access: 'selected' as const,
+      repositories: [{ id: 1, name: 'api', full_name: 'acme/api', private: false }],
+    },
+    { access: 'all' as const, repositories: null },
+  ])('resolves unpinned $access repository access', async fixture => {
+    await insertOrganization(organizationIds[0]);
+    const integration = await insertIntegration(organizationIds[0], {
+      repository_access: fixture.access,
+      repositories: fixture.repositories,
+    });
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'acme/api',
+      })
+    ).resolves.toEqual({ success: true, integration });
+  });
+
+  it('matches a renamed account and repository without case sensitivity', async () => {
+    await insertOrganization(organizationIds[0]);
+    const integration = await insertIntegration(organizationIds[0], {
+      platform_account_login: 'Renamed-Acme',
+      repository_access: 'selected',
+      repositories: [{ id: 1, name: 'API', full_name: 'RENAMED-ACME/API', private: false }],
+    });
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'renamed-acme/api',
+      })
+    ).resolves.toEqual({ success: true, integration });
+  });
+
+  it('ignores same-account installations that do not include the selected repository', async () => {
+    await insertOrganization(organizationIds[0]);
+    await insertIntegration(organizationIds[0], {
+      repository_access: 'selected',
+      repositories: [{ id: 1, name: 'web', full_name: 'acme/web', private: false }],
+    });
+    const integration = await insertIntegration(organizationIds[0], {
+      repository_access: 'selected',
+      repositories: [{ id: 2, name: 'api', full_name: 'acme/api', private: false }],
+      github_app_type: 'lite',
+    });
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'acme/api',
+      })
+    ).resolves.toEqual({ success: true, integration });
+  });
+
+  it.each([{ integration_status: 'suspended' }, { suspended_at: '2026-08-27T00:00:00.000Z' }])(
+    'does not resolve suspended rows ($#)',
+    async suspension => {
+      await insertOrganization(organizationIds[0]);
+      const integration = await insertIntegration(organizationIds[0], suspension);
+
+      await expect(
+        resolveOrganizationGitHubIntegrationForRepository({
+          organizationId: organizationIds[0],
+          repositoryFullName: 'acme/api',
+          expectedPlatformIntegrationId: integration.id,
+        })
+      ).resolves.toEqual({ success: false, reason: 'no_installation_found' });
+    }
+  );
+
+  it('does not resolve an exact integration owned by another organization', async () => {
+    await Promise.all(organizationIds.map(insertOrganization));
+    const integration = await insertIntegration(organizationIds[1]);
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'acme/api',
+        expectedPlatformIntegrationId: integration.id,
+      })
+    ).resolves.toEqual({ success: false, reason: 'no_installation_found' });
+  });
+
+  it('fails closed distinctly when multiple installations match', async () => {
+    await insertOrganization(organizationIds[0]);
+    await insertIntegration(organizationIds[0]);
+    await insertIntegration(organizationIds[0], { github_app_type: 'lite' });
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'acme/api',
+      })
+    ).resolves.toEqual({ success: false, reason: 'ambiguous_installation' });
+  });
+
+  it('requires the repository owner to match even for all-repository access', async () => {
+    await insertOrganization(organizationIds[0]);
+    await insertIntegration(organizationIds[0], { platform_account_login: 'other' });
+
+    await expect(
+      resolveOrganizationGitHubIntegrationForRepository({
+        organizationId: organizationIds[0],
+        repositoryFullName: 'acme/api',
+      })
+    ).resolves.toEqual({ success: false, reason: 'no_installation_found' });
+  });
+});

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -1,6 +1,6 @@
 import { db } from '@/lib/drizzle';
-import { platform_integrations } from '@kilocode/db/schema';
-import { eq, and, isNull, asc, desc, sql } from 'drizzle-orm';
+import { platform_integrations, type PlatformIntegration } from '@kilocode/db/schema';
+import { eq, and, isNull, isNotNull, asc, desc, sql } from 'drizzle-orm';
 import type {
   GitHubRequester,
   IntegrationPermissions,
@@ -92,6 +92,69 @@ export async function getPrimaryGitHubIntegrationForOrganization(organizationId:
     .limit(1);
 
   return integration ?? null;
+}
+
+export type OrganizationGitHubIntegrationResolution =
+  | { success: true; integration: PlatformIntegration }
+  | { success: false; reason: 'no_installation_found' | 'ambiguous_installation' };
+
+/**
+ * Resolves the one healthy organization installation authorized for a GitHub repository.
+ * Repository-specific resolution is intentionally separate from deterministic primary selection.
+ */
+export async function resolveOrganizationGitHubIntegrationForRepository(input: {
+  organizationId: string;
+  repositoryFullName: string;
+  expectedPlatformIntegrationId?: string;
+}): Promise<OrganizationGitHubIntegrationResolution> {
+  const repositoryParts = input.repositoryFullName.split('/');
+  if (repositoryParts.length !== 2 || repositoryParts.some(part => part.length === 0)) {
+    return { success: false, reason: 'no_installation_found' };
+  }
+  const [repositoryOwner] = repositoryParts;
+
+  const integrations = await db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        eq(platform_integrations.owned_by_organization_id, input.organizationId),
+        isNull(platform_integrations.owned_by_user_id),
+        eq(platform_integrations.platform, PLATFORM.GITHUB),
+        eq(platform_integrations.integration_type, 'app'),
+        isNotNull(platform_integrations.platform_installation_id),
+        sql`lower(${platform_integrations.platform_account_login}) = lower(${repositoryOwner})`,
+        platformIntegrationHealthSql(),
+        input.expectedPlatformIntegrationId !== undefined
+          ? eq(platform_integrations.id, input.expectedPlatformIntegrationId)
+          : undefined
+      )
+    );
+
+  const repositoryFullName = input.repositoryFullName.toLowerCase();
+  const matchingIntegrations = integrations.filter(integration => {
+    if (integration.repository_access === 'all') return true;
+    if (integration.repository_access !== 'selected') return false;
+    return Boolean(
+      integration.repositories?.some(
+        repository =>
+          typeof repository.full_name === 'string' &&
+          repository.full_name.toLowerCase() === repositoryFullName
+      )
+    );
+  });
+
+  if (matchingIntegrations.length === 0) {
+    return { success: false, reason: 'no_installation_found' };
+  }
+  if (matchingIntegrations.length > 1) {
+    return { success: false, reason: 'ambiguous_installation' };
+  }
+  const [integration] = matchingIntegrations;
+  if (!integration) {
+    return { success: false, reason: 'no_installation_found' };
+  }
+  return { success: true, integration };
 }
 
 export async function getAllIntegationsForOrganization(organizationId: string) {


### PR DESCRIPTION
Superseded by #5584.

This PR resolves installation identity from cached web/database metadata. The replacement moves resolution to Git Token Service and validates each candidate against live GitHub repository access.

Do not merge this PR. It remains open temporarily only because several existing product branches were based on it; those branches are being rebuilt or simplified against #5584/#5587.