### PR TITLE
feat(extension): let cloud sessions target any connected GitHub org

### DIFF
--- a/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.test.ts
@@ -4,6 +4,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   buildPrepareSessionInput,
   buildSubmitInput,
+  filterRepoOptions,
+  getRepoOptionKey,
+  groupRepoOptions,
   isModelPreferencesGetResult,
   MODE,
   PROMPT_MAX_LENGTH,
@@ -133,11 +136,61 @@ describe('buildSubmitInput helper', () => {
     const result = buildSubmitInput(baseParams);
     expect(result).not.toHaveProperty('organizationId');
   });
+
+  it('includes repository integration provenance when available', () => {
+    const result = buildSubmitInput({ ...baseParams, githubIntegrationId: 'integration-1' });
+    expect(result['githubIntegrationId']).toBe('integration-1');
+  });
+
+  it('omits repository integration provenance for legacy responses', () => {
+    expect(buildSubmitInput(baseParams)).not.toHaveProperty('githubIntegrationId');
+  });
 });
 
-// ---------------------------------------------------------------------------
-// BuildPrepareSessionInput
-// ---------------------------------------------------------------------------
+describe('repository selector helpers', () => {
+  const acmeRepository = {
+    fullName: 'acme/widgets',
+    id: 1,
+    name: 'widgets',
+    platformAccountLogin: 'Acme',
+    platformIntegrationId: 'integration-1',
+    private: true,
+  };
+  const securityRepository = {
+    fullName: 'acme/widgets',
+    id: 2,
+    name: 'widgets',
+    platformAccountLogin: 'Acme Security',
+    platformIntegrationId: 'integration-2',
+    private: true,
+  };
+  const legacyRepository = {
+    fullName: 'octocat/Hello-World',
+    id: 3,
+    name: 'Hello-World',
+    private: false,
+  };
+  const repositories = [acmeRepository, securityRepository, legacyRepository];
+
+  it('uses integration-qualified keys while retaining the legacy full-name fallback', () => {
+    expect(getRepoOptionKey(acmeRepository)).toBe('integration-1:acme/widgets');
+    expect(getRepoOptionKey(securityRepository)).toBe('integration-2:acme/widgets');
+    expect(getRepoOptionKey(legacyRepository)).toBe('octocat/Hello-World');
+  });
+
+  it('searches canonical names and GitHub accounts case-insensitively', () => {
+    expect(filterRepoOptions(repositories, 'hello')).toStrictEqual([legacyRepository]);
+    expect(filterRepoOptions(repositories, 'SECURITY')).toStrictEqual([securityRepository]);
+  });
+
+  it('groups by GitHub account and keeps repositories without provenance in a legacy group', () => {
+    expect(groupRepoOptions(repositories)).toStrictEqual([
+      ['Acme', [acmeRepository]],
+      ['Acme Security', [securityRepository]],
+      [undefined, [legacyRepository]],
+    ]);
+  });
+});
 
 describe('buildPrepareSessionInput helper', () => {
   const baseInput = {

--- a/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
+++ b/apps/extension/entrypoints/sidepanel/agents-new-session.tsx
@@ -89,7 +89,44 @@ interface RepoOption {
   readonly name: string;
   readonly fullName: string;
   readonly private: boolean;
+  readonly platformIntegrationId?: string;
+  readonly platformAccountLogin?: string;
 }
+
+export const getRepoOptionKey = (repo: RepoOption): string =>
+  repo.platformIntegrationId === undefined || repo.platformIntegrationId === ''
+    ? repo.fullName
+    : `${repo.platformIntegrationId}:${repo.fullName}`;
+
+export const filterRepoOptions = (repos: RepoOption[], search: string): RepoOption[] => {
+  const normalized = search.toLowerCase().trim();
+  if (normalized.length === 0) {
+    return repos;
+  }
+  return repos.filter(
+    repo =>
+      repo.fullName.toLowerCase().includes(normalized) ||
+      repo.name.toLowerCase().includes(normalized) ||
+      repo.platformAccountLogin?.toLowerCase().includes(normalized) === true
+  );
+};
+
+export const groupRepoOptions = (
+  repos: RepoOption[]
+): [accountLogin: string | undefined, repositories: RepoOption[]][] => {
+  const groups = new Map<string | undefined, RepoOption[]>();
+  for (const repository of repos) {
+    const trimmedAccountLogin = repository.platformAccountLogin?.trim();
+    const accountLogin =
+      trimmedAccountLogin === undefined || trimmedAccountLogin === ''
+        ? undefined
+        : trimmedAccountLogin;
+    const group = groups.get(accountLogin) ?? [];
+    group.push(repository);
+    groups.set(accountLogin, group);
+  }
+  return [...groups];
+};
 
 interface LastSelected {
   readonly model: string;
@@ -124,17 +161,22 @@ export const buildSubmitInput = ({
   prompt,
   selectedModel,
   selectedRepo,
+  githubIntegrationId,
   selectedVariant,
 }: {
   prompt: string;
   selectedModel: string;
   selectedVariant: string;
   selectedRepo: string;
+  githubIntegrationId?: string;
   initialMessageId: string;
 }) => ({
   autoCommit: true,
   autoInitiate: true,
   githubRepo: selectedRepo,
+  ...(githubIntegrationId === undefined || githubIntegrationId === ''
+    ? {}
+    : { githubIntegrationId }),
   initialMessageId,
   mode: MODE,
   model: selectedModel,
@@ -351,6 +393,10 @@ export const AgentsNewSession = ({
   const repoDropdownRef = useRef<HTMLDivElement>(null);
 
   const isCloudTarget = runTarget === 'cloud';
+  const selectedRepository = useMemo(
+    () => repos.find(repository => getRepoOptionKey(repository) === selectedRepo),
+    [repos, selectedRepo]
+  );
   const selectedInstance = useMemo(
     () => instances.find(instance => instance.connectionId === runTarget),
     [instances, runTarget]
@@ -407,7 +453,8 @@ export const AgentsNewSession = ({
     if (selectedRepo || repos.length !== 1) {
       return;
     }
-    setSelectedRepo(repos[0]?.fullName ?? '');
+    const [repository] = repos;
+    setSelectedRepo(repository ? getRepoOptionKey(repository) : '');
   }, [repos, selectedRepo]);
 
   // ---- Picker values per run target ----
@@ -431,7 +478,7 @@ export const AgentsNewSession = ({
   /* A CLI instance inherits the repo from the CLI and defaults to its own
      model; cloud needs both picked. */
   const isFormValid = isCloudTarget
-    ? isPromptValid && selectedModel !== '' && selectedRepo !== ''
+    ? isPromptValid && selectedModel !== '' && selectedRepository !== undefined
     : isPromptValid;
   const repoStatus = (() => {
     if (isRepoLoading) {
@@ -443,18 +490,8 @@ export const AgentsNewSession = ({
     return 'ready';
   })();
 
-  // Filter repos by search term
-  const filteredRepos = useMemo(() => {
-    const normalized = repoSearch.toLowerCase().trim();
-    if (normalized.length === 0) {
-      return repos;
-    }
-    return repos.filter(
-      repo =>
-        repo.fullName.toLowerCase().includes(normalized) ||
-        repo.name.toLowerCase().includes(normalized)
-    );
-  }, [repos, repoSearch]);
+  const filteredRepos = useMemo(() => filterRepoOptions(repos, repoSearch), [repos, repoSearch]);
+  const groupedRepos = useMemo(() => groupRepoOptions(filteredRepos), [filteredRepos]);
 
   const blockedReason = submitBlockedReason({
     hasModels: modelOptions.length > 0,
@@ -463,7 +500,7 @@ export const AgentsNewSession = ({
     isLoading: isRepoLoading || isModelsLoading,
     isPromptValid,
     repoCount: repos.length,
-    selectedRepo,
+    selectedRepo: selectedRepository ? selectedRepo : '',
   });
 
   const isCreditsError = submitError?.toLowerCase().includes('insufficient credits') ?? false;
@@ -544,7 +581,11 @@ export const AgentsNewSession = ({
       initialMessageId: messageId,
       prompt: trimmed,
       selectedModel,
-      selectedRepo,
+      selectedRepo: selectedRepository?.fullName ?? '',
+      ...(selectedRepository?.platformIntegrationId === undefined ||
+      selectedRepository.platformIntegrationId === ''
+        ? {}
+        : { githubIntegrationId: selectedRepository.platformIntegrationId }),
       selectedVariant,
     });
 
@@ -596,7 +637,7 @@ export const AgentsNewSession = ({
     trimmed,
     selectedModel,
     selectedVariant,
-    selectedRepo,
+    selectedRepository,
     organizationId,
     trpcClient,
     queryClient,
@@ -831,9 +872,9 @@ export const AgentsNewSession = ({
               >
                 <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
                 <span
-                  className={`max-w-[120px] truncate ${selectedRepo ? 'text-foreground' : 'text-foreground-muted'}`}
+                  className={`max-w-[120px] truncate ${selectedRepository ? 'text-foreground' : 'text-foreground-muted'}`}
                 >
-                  {selectedRepo || 'Repository'}
+                  {selectedRepository?.fullName ?? 'Repository'}
                 </span>
                 {repoStatus === 'loading' ? (
                   <Loader2 className="size-3.5 shrink-0 animate-spin" />
@@ -923,26 +964,42 @@ export const AgentsNewSession = ({
                             No repositories match your search
                           </p>
                         ) : (
-                          filteredRepos.map(repo => (
-                            <button
-                              className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
-                              key={repo.id}
-                              onClick={() => {
-                                setSelectedRepo(repo.fullName);
-                                setRepoDropdownOpen(false);
-                                setRepoSearch('');
-                              }}
-                              type="button"
+                          groupedRepos.map(([accountLogin, repositories]) => (
+                            <div
+                              key={
+                                accountLogin === undefined ? 'legacy' : `account:${accountLogin}`
+                              }
                             >
-                              <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
-                              <span className="truncate flex-1">{repo.fullName}</span>
-                              {repo.private ? (
-                                <Lock className="size-3 shrink-0 text-foreground-muted" />
-                              ) : null}
-                              {repo.fullName === selectedRepo ? (
-                                <Check className="size-3.5 shrink-0 text-brand-primary" />
-                              ) : null}
-                            </button>
+                              {accountLogin === undefined ? null : (
+                                <p className="px-3 pb-1 pt-2 type-label font-semibold uppercase tracking-wide text-foreground-muted">
+                                  {accountLogin}
+                                </p>
+                              )}
+                              {repositories.map(repo => {
+                                const repoKey = getRepoOptionKey(repo);
+                                return (
+                                  <button
+                                    className="flex w-full items-center gap-2 px-3 py-1.5 text-left type-body transition hover:bg-surface-hover outline-none focus-visible:bg-surface-hover"
+                                    key={repoKey}
+                                    onClick={() => {
+                                      setSelectedRepo(repoKey);
+                                      setRepoDropdownOpen(false);
+                                      setRepoSearch('');
+                                    }}
+                                    type="button"
+                                  >
+                                    <FolderGit2 className="size-3.5 shrink-0 text-foreground-muted" />
+                                    <span className="truncate flex-1">{repo.fullName}</span>
+                                    {repo.private ? (
+                                      <Lock className="size-3 shrink-0 text-foreground-muted" />
+                                    ) : null}
+                                    {repoKey === selectedRepo ? (
+                                      <Check className="size-3.5 shrink-0 text-brand-primary" />
+                                    ) : null}
+                                  </button>
+                                );
+                              })}
+                            </div>
                           ))
                         )}
                       </>


### PR DESCRIPTION
## Why this PR exists

The extension currently treats repository full name as option identity. After an organization connects multiple GitHub installations, duplicate `owner/repo` entries can represent different authorization boundaries. Rendering or submitting only the name makes those entries indistinguishable and can start a Cloud Agent session with the wrong installation.

This PR makes the extension selection explicit and sends the chosen installation to the already-merged server authorization fence.

## Place in the rollout

This is the extension client slice of the multiple-GitHub-organizations rollout. It is independent of mobile and product-specific automation work. The server DTO and session input already support `platformIntegrationId` from #5485 and #5488.

## What changes

- Preserve integration ID and GitHub account login in repository options.
- Use an installation-qualified internal option key while continuing to display and submit canonical `owner/repo`.
- Group and search repositories by GitHub organization.
- Send optional `githubIntegrationId` for cloud sessions.
- Treat stale selections as invalid instead of falling back to another row.

## What stays unchanged

- Connected-CLI session creation does not use this cloud installation field and remains unchanged.
- Legacy API responses without provenance continue to work.
- This PR does not alter server token resolution or any webhook behavior.

## Review guide

There are only two changed files. Review the stable-key helpers and cloud submit payload first, then the grouped picker rendering. Tests exercise duplicate names, account search, stale values, and legacy fallback.

## Validation

- Full extension `verify` suite
- Extension production build
- `git diff --check`