### PR TITLE
feat(mobile): let new sessions target any connected GitHub org

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/repo-picker.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/repo-picker.tsx
@@ -10,12 +10,12 @@ import { EmptyState } from '@/components/empty-state';
 import { PickerSheet } from '@/components/picker-sheet';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
-import { REPO_PLATFORM_LABEL_KEYS, type RepoOption } from '@/lib/picker-bridge';
+import { getRepoOptionKey, REPO_PLATFORM_LABEL_KEYS, type RepoOption } from '@/lib/picker-bridge';
 import { repoPickerSlot, UNFENCED_ROUTE_KEY, useRouteRegistry } from '@/lib/route-registry';
-import { filterRepoPickerOptions } from '@/lib/repo-picker-filter';
+import { filterRepoPickerOptions, groupRepoPickerOptions } from '@/lib/repo-picker-filter';
 
 type PickerListItem =
-  | { key: string; kind: 'header'; titleKey: string }
+  | { key: string; kind: 'header'; title?: string; titleKey?: string }
   | { key: string; kind: 'repo'; repo: RepoOption };
 
 export default function RepoPickerScreen() {
@@ -56,20 +56,18 @@ export default function RepoPickerScreen() {
   // per-provider); when it is non-empty, render the flat filtered list exactly
   // as before.
   const listItems = useMemo<PickerListItem[]>(() => {
-    if (search.trim()) {
-      return filtered.map(repo => ({
-        key: `${repo.platform}:${repo.fullName}`,
-        kind: 'repo',
-        repo,
-      }));
-    }
-    const sections = bridge?.sections ?? [];
+    const sections = search.trim() ? groupRepoPickerOptions(filtered) : (bridge?.sections ?? []);
     const items: PickerListItem[] = [];
     for (const section of sections) {
       if (section.repos.length > 0) {
-        items.push({ key: `header:${section.key}`, kind: 'header', titleKey: section.titleKey });
+        items.push({
+          key: `header:${section.key}`,
+          kind: 'header',
+          title: section.title,
+          titleKey: section.titleKey,
+        });
         for (const repo of section.repos) {
-          items.push({ key: `${repo.platform}:${repo.fullName}`, kind: 'repo', repo });
+          items.push({ key: getRepoOptionKey(repo), kind: 'repo', repo });
         }
       }
     }
@@ -144,7 +142,7 @@ export default function RepoPickerScreen() {
           if (item.kind === 'header') {
             return (
               <Text className="px-4 pt-4 pb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {t(item.titleKey)}
+                {item.title ?? (item.titleKey ? t(item.titleKey) : '')}
               </Text>
             );
           }
@@ -155,7 +153,7 @@ export default function RepoPickerScreen() {
             <Pressable
               className="flex-row items-center gap-3 border-b border-border px-4 py-3 active:bg-secondary will-change-pressable"
               onPress={() => {
-                handleSelect(`${repo.platform}:${repo.fullName}`);
+                handleSelect(getRepoOptionKey(repo));
               }}
               accessibilityRole="button"
               accessibilityLabel={rowLabel}
@@ -174,7 +172,7 @@ export default function RepoPickerScreen() {
               <Text className="flex-1 text-base text-foreground" numberOfLines={1}>
                 {repo.fullName}
               </Text>
-              {bridge.currentValue === `${repo.platform}:${repo.fullName}` ? (
+              {bridge.currentValue === getRepoOptionKey(repo) ? (
                 <Check size={18} color={colors.primary} />
               ) : null}
             </Pressable>

--- a/apps/mobile/src/components/agents/new-session-repository-state.test.ts
+++ b/apps/mobile/src/components/agents/new-session-repository-state.test.ts
@@ -1,13 +1,41 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  dedupeRepositoriesByPlatformAndFullName,
+  dedupeRepositoriesByIdentity,
   type NewSessionRepository,
   type RepositoryGroup,
   resolveBitbucketStatus,
   resolveProviderStatus,
   resolveRepositoryGroups,
+  toNewSessionGitHubRepository,
 } from './new-session-repository-state';
+
+describe('toNewSessionGitHubRepository', () => {
+  it('preserves integration provenance from the tRPC DTO', () => {
+    expect(
+      toNewSessionGitHubRepository({
+        fullName: 'owner/repo',
+        private: true,
+        platformIntegrationId: 'integration-1',
+        platformAccountLogin: 'owner',
+      })
+    ).toEqual({
+      platform: 'github',
+      fullName: 'owner/repo',
+      isPrivate: true,
+      platformIntegrationId: 'integration-1',
+      platformAccountLogin: 'owner',
+    });
+  });
+
+  it('supports older tRPC responses without provenance', () => {
+    expect(toNewSessionGitHubRepository({ fullName: 'owner/repo', private: false })).toEqual({
+      platform: 'github',
+      fullName: 'owner/repo',
+      isPrivate: false,
+    });
+  });
+});
 
 describe('resolveProviderStatus', () => {
   it('returns loading while the provider query is loading', () => {
@@ -145,22 +173,25 @@ const gitlab = (fullName: string): NewSessionRepository => ({
   isPrivate: false,
 });
 
-describe('dedupeRepositoriesByPlatformAndFullName', () => {
+describe('dedupeRepositoriesByIdentity', () => {
   it('keeps the same fullName on two platforms as two rows', () => {
-    const deduped = dedupeRepositoriesByPlatformAndFullName([
-      github('owner/repo'),
-      gitlab('owner/repo'),
-    ]);
+    const deduped = dedupeRepositoriesByIdentity([github('owner/repo'), gitlab('owner/repo')]);
     expect(deduped).toHaveLength(2);
     expect(deduped.map(repo => repo.platform)).toEqual(['github', 'gitlab']);
   });
 
   it('collapses duplicate rows that share platform and fullName', () => {
-    const deduped = dedupeRepositoriesByPlatformAndFullName([
-      github('owner/repo'),
-      github('owner/repo'),
-    ]);
+    const deduped = dedupeRepositoriesByIdentity([github('owner/repo'), github('owner/repo')]);
     expect(deduped).toHaveLength(1);
+  });
+
+  it('keeps same-name GitHub rows from separate integrations', () => {
+    const deduped = dedupeRepositoriesByIdentity([
+      { ...github('owner/repo'), platformIntegrationId: 'integration-1' },
+      { ...github('owner/repo'), platformIntegrationId: 'integration-2' },
+    ]);
+
+    expect(deduped).toHaveLength(2);
   });
 });
 

--- a/apps/mobile/src/components/agents/new-session-repository-state.ts
+++ b/apps/mobile/src/components/agents/new-session-repository-state.ts
@@ -1,4 +1,4 @@
-import { type RepoPlatform } from '@/lib/picker-bridge';
+import { getRepoOptionKey, type RepoPlatform } from '@/lib/picker-bridge';
 
 export type RepositoryPlatform = RepoPlatform;
 
@@ -12,9 +12,31 @@ export type NewSessionRepository = {
   platform: RepositoryPlatform;
   fullName: string;
   isPrivate: boolean;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
   workspaceUuid?: string;
   repositoryUuid?: string;
 };
+
+export function toNewSessionGitHubRepository(repository: {
+  fullName: string;
+  private: boolean;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
+}): NewSessionRepository {
+  const result: NewSessionRepository = {
+    platform: 'github',
+    fullName: repository.fullName,
+    isPrivate: repository.private,
+  };
+  if (repository.platformIntegrationId) {
+    result.platformIntegrationId = repository.platformIntegrationId;
+  }
+  if (repository.platformAccountLogin) {
+    result.platformAccountLogin = repository.platformAccountLogin;
+  }
+  return result;
+}
 
 export type RepositoryProviderStatus =
   | 'loading'
@@ -110,20 +132,17 @@ export function resolveBitbucketStatus({
 
 // ── Dedup and grouping ───────────────────────────────────────────────
 
-const repositoryKey = (repository: NewSessionRepository): string =>
-  `${repository.platform}/${repository.fullName}`;
-
 /**
- * Deduplicate repository rows by `platform + fullName`, so the same
- * `fullName` on two platforms stays two rows.
+ * Deduplicate repository rows by their picker identity. GitHub rows with the
+ * same full name remain distinct when they came from different integrations.
  */
-export function dedupeRepositoriesByPlatformAndFullName(
+export function dedupeRepositoriesByIdentity(
   repositories: readonly NewSessionRepository[]
 ): NewSessionRepository[] {
   const seen = new Set<string>();
   const result: NewSessionRepository[] = [];
   for (const repository of repositories) {
-    const key = repositoryKey(repository);
+    const key = getRepoOptionKey(repository);
     if (!seen.has(key)) {
       seen.add(key);
       result.push(repository);

--- a/apps/mobile/src/components/agents/new-session-screen-body.tsx
+++ b/apps/mobile/src/components/agents/new-session-screen-body.tsx
@@ -36,7 +36,11 @@ import {
 } from '@/lib/persist/drafts';
 import { useDraftFlushOnBackground } from '@/lib/persist/use-draft-flush';
 import { useFencedDraftLoad, useRemoteSpawnDraftCleanup } from '@/lib/persist/use-draft-load';
-import { type InstancePickerInstance, type ModelPickerSelection } from '@/lib/picker-bridge';
+import {
+  type InstancePickerInstance,
+  type ModelPickerSelection,
+  resolveRepoOptionByKey,
+} from '@/lib/picker-bridge';
 import { shouldShowRunOnSelector } from '@/lib/should-show-run-on-selector';
 import { peekSharePayload } from '@/lib/share-payload';
 import { useNewSessionShareRemote } from '@/lib/use-new-session-share-remote';
@@ -168,19 +172,13 @@ export function NewSessionScreenBody() {
     modelsSettled: !isLoadingModels && !isModelsError && models.length > 0,
   });
 
-  // The picker reports a `platform:fullName` key; resolve it to the full row so
-  // the creator can send the platform-specific repository field. The prefill
-  // seeds the same platform-qualified key, so no bare-fullName fallback is
-  // needed (and one would bind a same-named GitLab/Bitbucket row).
+  // Resolve the picker identity back to the full row so the creator can send
+  // the canonical repository name and its provider-specific provenance.
   const selectedRepository = useMemo(() => {
     if (!selectedRepo) {
       return null;
     }
-    return (
-      repositories.find(
-        repository => `${repository.platform}:${repository.fullName}` === selectedRepo
-      ) ?? null
-    );
+    return resolveRepoOptionByKey(repositories, selectedRepo);
   }, [repositories, selectedRepo]);
 
   const {

--- a/apps/mobile/src/components/agents/repo-selector.tsx
+++ b/apps/mobile/src/components/agents/repo-selector.tsx
@@ -7,11 +7,14 @@ import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import {
   type RepoOption as BridgeRepoOption,
+  getRepoOptionKey,
   REPO_PLATFORM_LABEL_KEYS,
   type RepoPickerSection,
   type RepoPlatform,
+  resolveRepoOptionByKey,
 } from '@/lib/picker-bridge';
 import { repoPickerSlot, UNFENCED_ROUTE_KEY } from '@/lib/route-registry';
+import { groupRepoPickerOptions } from '@/lib/repo-picker-filter';
 import { cn } from '@/lib/utils';
 
 type RepoOption = {
@@ -19,6 +22,8 @@ type RepoOption = {
   isPrivate: boolean;
   /** Provider platform; omitted rows are treated as GitHub until d1 fills it. */
   platform?: RepoPlatform;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
   workspaceUuid?: string;
   repositoryUuid?: string;
 };
@@ -33,18 +38,17 @@ type RepoSelectorProps = {
   disabled?: boolean;
 };
 
-function isRepoPlatform(platform: string): platform is RepoPlatform {
-  return platform === 'github' || platform === 'gitlab' || platform === 'bitbucket';
-}
-
-/** Constant order for provider sections (Bitbucket only when its rows exist, i.e. an org is set). */
-const PROVIDER_SECTION_ORDER: readonly RepoPlatform[] = ['github', 'gitlab', 'bitbucket'];
-
 function toBridgeRepo(repo: RepoOption): BridgeRepoOption {
   return {
     platform: repo.platform ?? 'github',
     fullName: repo.fullName,
     isPrivate: repo.isPrivate,
+    ...(repo.platformIntegrationId !== undefined
+      ? { platformIntegrationId: repo.platformIntegrationId }
+      : {}),
+    ...(repo.platformAccountLogin !== undefined
+      ? { platformAccountLogin: repo.platformAccountLogin }
+      : {}),
     ...(repo.workspaceUuid !== undefined ? { workspaceUuid: repo.workspaceUuid } : {}),
     ...(repo.repositoryUuid !== undefined ? { repositoryUuid: repo.repositoryUuid } : {}),
   };
@@ -63,9 +67,7 @@ function buildRepoSections({
   repositories: RepoOption[];
   recents: RepoOption[];
 }): RepoPickerSection[] {
-  const recentKeys = new Set(
-    recents.map(repo => `${repo.platform ?? 'github'}/${repo.fullName.toLowerCase()}`)
-  );
+  const recentKeys = new Set(recents.map(repo => getRepoOptionKey(toBridgeRepo(repo))));
   const sections: RepoPickerSection[] = [];
   if (recents.length > 0) {
     sections.push({
@@ -74,23 +76,13 @@ function buildRepoSections({
       repos: recents.map(repo => toBridgeRepo(repo)),
     });
   }
-  for (const platform of PROVIDER_SECTION_ORDER) {
-    const repos = repositories.filter(repo => {
-      const repoPlatform = repo.platform ?? 'github';
-      return (
-        repoPlatform === platform &&
-        !recentKeys.has(`${repoPlatform}/${repo.fullName.toLowerCase()}`)
-      );
-    });
-    if (repos.length > 0) {
-      sections.push({
-        key: platform,
-        titleKey: REPO_PLATFORM_LABEL_KEYS[platform],
-        repos: repos.map(repo => toBridgeRepo(repo)),
-      });
-    }
-  }
-  return sections;
+  const nonRecentRepositories = repositories.filter(
+    repo => !recentKeys.has(getRepoOptionKey(toBridgeRepo(repo)))
+  );
+  return [
+    ...sections,
+    ...groupRepoPickerOptions(nonRecentRepositories.map(repo => toBridgeRepo(repo))),
+  ];
 }
 
 export function RepoSelector({
@@ -106,23 +98,21 @@ export function RepoSelector({
   const { t } = useTranslation();
   const effectivelyDisabled = disabled || isLoading || repositories.length === 0;
 
-  // The selection value is `platform:fullName`; show the platform name next to
-  // the fullName so two same-name repos on different providers stay distinct in
-  // the closed state. A bare fullName (legacy prefill) falls back to the
-  // matching row's platform.
-  const colonIndex = value.indexOf(':');
-  const rawPlatform = colonIndex !== -1 ? value.slice(0, colonIndex) : '';
-  const selectedPlatform: RepoPlatform | undefined =
-    colonIndex !== -1 && isRepoPlatform(rawPlatform)
-      ? rawPlatform
-      : repositories.find(repo => repo.fullName === value)?.platform;
-  const displayValue = colonIndex !== -1 ? value.slice(colonIndex + 1) : value;
-  const platformName = selectedPlatform ? t(REPO_PLATFORM_LABEL_KEYS[selectedPlatform]) : undefined;
-  let label = displayValue;
+  const selectedRepository = resolveRepoOptionByKey(
+    repositories.map(repo => toBridgeRepo(repo)),
+    value
+  );
+  const selectedPlatform = selectedRepository?.platform ?? 'github';
+  const platformName = selectedRepository
+    ? t(REPO_PLATFORM_LABEL_KEYS[selectedPlatform])
+    : undefined;
+  let label = selectedRepository?.fullName ?? '';
   if (!label) {
     label = isLoading ? t('agentChat.repoPicker.loading') : t('agentChat.repoPicker.title');
   } else if (platformName) {
-    label = `${platformName} · ${displayValue}`;
+    label = [platformName, selectedRepository?.platformAccountLogin, label]
+      .filter(Boolean)
+      .join(' · ');
   }
 
   function handlePress() {

--- a/apps/mobile/src/components/agents/use-new-session-creator.test.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.test.ts
@@ -711,6 +711,39 @@ describe('useNewSessionCreator repository platform payload', () => {
     expect(payload).not.toHaveProperty('bitbucketRepo');
   });
 
+  it('sends canonical githubRepo plus the selected integration id', async () => {
+    prepareSessionMutate.mockResolvedValue(sessionResult());
+    const creator = runCreator({
+      selectedRepository: {
+        platform: 'github',
+        fullName: 'owner/repo',
+        isPrivate: false,
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+        platformAccountLogin: 'owner',
+      },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).toMatchObject({
+      githubRepo: 'owner/repo',
+      githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+    });
+  });
+
+  it('omits githubIntegrationId for a provenance-free GitHub response', async () => {
+    prepareSessionMutate.mockResolvedValue(sessionResult());
+    const creator = runCreator({
+      selectedRepository: { platform: 'github', fullName: 'owner/repo', isPrivate: false },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).not.toHaveProperty('githubIntegrationId');
+  });
+
   it('sends only gitlabProject for a GitLab row and never githubRepo', async () => {
     prepareSessionMutate.mockResolvedValue(sessionResult());
     const creator = runCreator({
@@ -808,6 +841,50 @@ describe('useNewSessionCreator intentFingerprint repo identity', () => {
       workspaceUuid: 'ws-1234',
       repositoryUuid: 'repo-5678',
     });
+  });
+
+  it('includes the GitHub integration id in the fingerprint', async () => {
+    const creator = runCreator({
+      selectedRepository: {
+        platform: 'github',
+        fullName: 'owner/repo',
+        isPrivate: false,
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    const fingerprint = outboxMock.writeSafeRetry.mock.calls[0]?.[0].fingerprint ?? '';
+    expect((JSON.parse(fingerprint) as { repo: unknown }).repo).toEqual({
+      platform: 'github',
+      fullName: 'owner/repo',
+      platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+    });
+  });
+
+  it('does not reuse an ambiguous legacy bare-name key when provenance is present', async () => {
+    outboxMock.getStoredOperationKey.mockImplementation((fingerprint: string) => {
+      const parsed = JSON.parse(fingerprint) as { repo: unknown };
+      return typeof parsed.repo === 'string' ? 'legacy-stored-key' : null;
+    });
+    const creator = runCreator({
+      selectedRepository: {
+        platform: 'github',
+        fullName: 'owner/repo',
+        isPrivate: false,
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    expect(prepareSessionMutate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ operationKey: 'legacy-stored-key' })
+    );
+    expect(outboxMock.getStoredOperationKey).toHaveBeenCalledTimes(1);
   });
 
   // The deployed app persisted safe-retry rows with the bare `fullName` as

--- a/apps/mobile/src/components/agents/use-new-session-creator.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.ts
@@ -48,6 +48,7 @@ type PrepareSessionInput = {
   variant: string | undefined;
   /** Exactly one repository field is set, matching the selected row's platform. */
   githubRepo?: string;
+  githubIntegrationId?: string;
   gitlabProject?: string;
   bitbucketRepo?: { fullName: string; workspaceUuid: string; repositoryUuid: string };
   autoCommit: boolean;
@@ -150,7 +151,7 @@ export function useNewSessionCreator({
     // intents fall back to the legacy bare-name lookup: two same-named
     // GitLab/Bitbucket rows must never share the stale retry key.
     const legacyIntentFingerprint =
-      selectedRepository?.platform === 'github'
+      selectedRepository?.platform === 'github' && !selectedRepository.platformIntegrationId
         ? JSON.stringify({
             prompt,
             mode,
@@ -314,6 +315,7 @@ export function useNewSessionCreator({
 function resolveRepoFingerprint(repository: NewSessionRepository | null): {
   platform: RepositoryPlatform;
   fullName: string;
+  platformIntegrationId?: string;
   workspaceUuid?: string | null;
   repositoryUuid?: string | null;
 } | null {
@@ -326,6 +328,15 @@ function resolveRepoFingerprint(repository: NewSessionRepository | null): {
       fullName: repository.fullName,
       workspaceUuid: repository.workspaceUuid ?? null,
       repositoryUuid: repository.repositoryUuid ?? null,
+    };
+  }
+  if (repository.platform === 'github') {
+    return {
+      platform: repository.platform,
+      fullName: repository.fullName,
+      ...(repository.platformIntegrationId
+        ? { platformIntegrationId: repository.platformIntegrationId }
+        : {}),
     };
   }
   return { platform: repository.platform, fullName: repository.fullName };
@@ -346,6 +357,9 @@ function setRepositoryField(
   }
   if (repository.platform === 'github') {
     input.githubRepo = repository.fullName;
+    if (repository.platformIntegrationId) {
+      input.githubIntegrationId = repository.platformIntegrationId;
+    }
     return;
   }
   if (repository.platform === 'gitlab') {

--- a/apps/mobile/src/lib/picker-bridge.test.ts
+++ b/apps/mobile/src/lib/picker-bridge.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   areModelPickerSelectionScopesEqual,
   commitModelPickerSelection,
+  getRepoOptionKey,
   resolveModelPickerSelection,
+  resolveRepoOptionByKey,
 } from './picker-bridge';
 
 const remoteOption = {
@@ -115,5 +117,31 @@ describe('model picker bridge', () => {
 
     expect(commitModelPickerSelection(bridge, remoteOption.id, 'high')).toBe(true);
     expect(onSelect).toHaveBeenCalledWith({ option: remoteOption, variant: 'high' });
+  });
+});
+
+describe('repository picker identity', () => {
+  const repository = {
+    platform: 'github' as const,
+    fullName: 'owner/repo',
+  };
+
+  it('distinguishes duplicate GitHub repositories across integrations', () => {
+    expect(getRepoOptionKey({ ...repository, platformIntegrationId: 'integration-1' })).not.toBe(
+      getRepoOptionKey({ ...repository, platformIntegrationId: 'integration-2' })
+    );
+  });
+
+  it('keeps the existing platform-qualified key when provenance is absent', () => {
+    expect(getRepoOptionKey(repository)).toBe('github:owner/repo');
+  });
+
+  it('returns null instead of binding a stale or unknown key', () => {
+    const repositories = [
+      { ...repository, isPrivate: false, platformIntegrationId: 'integration-1' },
+    ];
+
+    expect(resolveRepoOptionByKey(repositories, 'github:integration-2:owner/repo')).toBeNull();
+    expect(resolveRepoOptionByKey(repositories, 'github:owner/repo')).toBeNull();
   });
 });

--- a/apps/mobile/src/lib/picker-bridge.ts
+++ b/apps/mobile/src/lib/picker-bridge.ts
@@ -54,14 +54,33 @@ export type RepoOption = {
   platform: RepoPlatform;
   fullName: string;
   isPrivate: boolean;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
   workspaceUuid?: string;
   repositoryUuid?: string;
 };
 
+export function getRepoOptionKey(repository: {
+  platform: RepoPlatform;
+  fullName: string;
+  platformIntegrationId?: string;
+}): string {
+  return repository.platformIntegrationId
+    ? `${repository.platform}:${repository.platformIntegrationId}:${repository.fullName}`
+    : `${repository.platform}:${repository.fullName}`;
+}
+
+export function resolveRepoOptionByKey<
+  T extends { platform: RepoPlatform; fullName: string; platformIntegrationId?: string },
+>(repositories: readonly T[], key: string): T | null {
+  return repositories.find(repository => getRepoOptionKey(repository) === key) ?? null;
+}
+
 export type RepoPickerSection = {
-  key: 'recents' | RepoPlatform;
-  /** i18n key the picker resolves for the section header. */
-  titleKey: string;
+  key: string;
+  /** Exactly one title field is set for each section. */
+  titleKey?: string;
+  title?: string;
   repos: RepoOption[];
 };
 

--- a/apps/mobile/src/lib/repo-picker-filter.test.ts
+++ b/apps/mobile/src/lib/repo-picker-filter.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
 import { type RepoOption } from './picker-bridge';
-import { filterRepoPickerOptions } from './repo-picker-filter';
+import { filterRepoPickerOptions, groupRepoPickerOptions } from './repo-picker-filter';
 
 const repositories: RepoOption[] = [
-  { fullName: 'Kilo-Org/cloud', isPrivate: true, platform: 'github' },
+  {
+    fullName: 'Kilo-Org/cloud',
+    isPrivate: true,
+    platform: 'github',
+    platformIntegrationId: 'integration-1',
+    platformAccountLogin: 'Kilo-Org',
+  },
   { fullName: 'octocat/Hello-World', isPrivate: false, platform: 'github' },
   { fullName: 'acme/widgets', isPrivate: true, platform: 'github' },
 ];
@@ -16,5 +22,39 @@ describe('filterRepoPickerOptions', () => {
 
   it('filters repositories by full name case-insensitively', () => {
     expect(filterRepoPickerOptions({ repositories, search: 'hello' })).toEqual([repositories[1]]);
+  });
+
+  it('filters repositories by GitHub account case-insensitively', () => {
+    expect(filterRepoPickerOptions({ repositories, search: 'kilo-org' })).toEqual([
+      repositories[0],
+    ]);
+  });
+});
+
+describe('groupRepoPickerOptions', () => {
+  it('groups GitHub repositories by account and retains provenance-free rows', () => {
+    expect(groupRepoPickerOptions(repositories)).toEqual([
+      { key: 'github:Kilo-Org', title: 'Kilo-Org', repos: [repositories[0]] },
+      {
+        key: 'github',
+        titleKey: 'agentChat.repoPicker.platformGithub',
+        repos: [repositories[1], repositories[2]],
+      },
+    ]);
+  });
+
+  it('keeps duplicate full names from separate integrations as separate rows', () => {
+    const firstRepository = repositories[0];
+    if (!firstRepository) {
+      throw new Error('Expected GitHub repository fixture');
+    }
+    const duplicate = {
+      ...firstRepository,
+      platformIntegrationId: 'integration-2',
+      platformAccountLogin: 'Second Account',
+    };
+
+    const sections = groupRepoPickerOptions([firstRepository, duplicate]);
+    expect(sections.flatMap(section => section.repos)).toEqual([firstRepository, duplicate]);
   });
 });

--- a/apps/mobile/src/lib/repo-picker-filter.ts
+++ b/apps/mobile/src/lib/repo-picker-filter.ts
@@ -1,4 +1,11 @@
-import { type RepoOption } from '@/lib/picker-bridge';
+import {
+  REPO_PLATFORM_LABEL_KEYS,
+  type RepoOption,
+  type RepoPickerSection,
+  type RepoPlatform,
+} from '@/lib/picker-bridge';
+
+const PROVIDER_SECTION_ORDER: readonly RepoPlatform[] = ['github', 'gitlab', 'bitbucket'];
 
 export function filterRepoPickerOptions({
   repositories,
@@ -11,5 +18,38 @@ export function filterRepoPickerOptions({
   if (!query) {
     return repositories;
   }
-  return repositories.filter(repo => repo.fullName.toLowerCase().includes(query));
+  return repositories.filter(
+    repo =>
+      repo.fullName.toLowerCase().includes(query) ||
+      repo.platformAccountLogin?.toLowerCase().includes(query)
+  );
+}
+
+export function groupRepoPickerOptions(repositories: RepoOption[]): RepoPickerSection[] {
+  const sections: RepoPickerSection[] = [];
+  for (const platform of PROVIDER_SECTION_ORDER) {
+    const providerRepositories = repositories.filter(repo => repo.platform === platform);
+    if (platform === 'github') {
+      const byAccount = new Map<string | undefined, RepoOption[]>();
+      for (const repository of providerRepositories) {
+        const group = byAccount.get(repository.platformAccountLogin) ?? [];
+        group.push(repository);
+        byAccount.set(repository.platformAccountLogin, group);
+      }
+      for (const [accountLogin, repos] of byAccount) {
+        sections.push(
+          accountLogin
+            ? { key: `github:${accountLogin}`, title: accountLogin, repos }
+            : { key: 'github', titleKey: REPO_PLATFORM_LABEL_KEYS.github, repos }
+        );
+      }
+    } else if (providerRepositories.length > 0) {
+      sections.push({
+        key: platform,
+        titleKey: REPO_PLATFORM_LABEL_KEYS[platform],
+        repos: providerRepositories,
+      });
+    }
+  }
+  return sections;
 }

--- a/apps/mobile/src/lib/use-new-session-repos.ts
+++ b/apps/mobile/src/lib/use-new-session-repos.ts
@@ -5,7 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner-native';
 
 import {
-  dedupeRepositoriesByPlatformAndFullName,
+  dedupeRepositoriesByIdentity,
   detectRepositoryPlatform,
   type NewSessionRepository,
   type RepositoryGroup,
@@ -14,6 +14,7 @@ import {
   resolveBitbucketStatus,
   resolveProviderStatus,
   resolveRepositoryGroups,
+  toNewSessionGitHubRepository,
 } from '@/components/agents/new-session-repository-state';
 import { formatGitUrlProject } from '@/components/agents/session-list-helpers';
 import { i18n } from '@/i18n';
@@ -24,6 +25,7 @@ import { openAuthorizationAndWaitForReturn } from '@/lib/pr-review/connect-gate-
 import { useExternalAuthReturn } from '@/lib/external-auth/use-external-auth-return';
 import { useGitHubReposRefresh } from '@/lib/use-github-repos-refresh';
 import { useTRPC } from '@/lib/trpc';
+import { getRepoOptionKey } from '@/lib/picker-bridge';
 
 type UseNewSessionReposArgs = {
   organizationId: string | undefined;
@@ -91,12 +93,7 @@ export function useNewSessionRepos({
   });
 
   const githubRepositories = useMemo<NewSessionRepository[]>(
-    () =>
-      (githubQuery.data?.repositories ?? []).map(repo => ({
-        platform: 'github',
-        fullName: repo.fullName,
-        isPrivate: repo.private,
-      })),
+    () => (githubQuery.data?.repositories ?? []).map(repo => toNewSessionGitHubRepository(repo)),
     [githubQuery.data]
   );
 
@@ -125,23 +122,28 @@ export function useNewSessionRepos({
   }, [bitbucketQuery.data]);
 
   // Recently used rows: only recents that resolve to a connected repository
-  // appear, and they are deduped by platform + fullName.
+  // appear. Recent-session data has no integration provenance, so an
+  // ambiguous GitHub full name retains the existing first-match behavior.
   const recentlyUsed = useMemo<NewSessionRepository[]>(() => {
     const recentList = recentRepoData?.repositories;
     if (!recentList?.length) {
       return [];
     }
     const unified = [...githubRepositories, ...gitlabRepositories, ...bitbucketRepositories];
-    const byKey = new Map(unified.map(repo => [repoKey(repo), repo]));
     const seen = new Set<string>();
     const result: NewSessionRepository[] = [];
     for (const recent of recentList) {
       const platform = detectRepositoryPlatform(recent.gitUrl);
       const fullName = formatGitUrlProject(recent.gitUrl);
       const match =
-        platform && fullName ? byKey.get(`${platform}/${fullName.toLowerCase()}`) : undefined;
+        platform && fullName
+          ? unified.find(
+              repo =>
+                repo.platform === platform && repo.fullName.toLowerCase() === fullName.toLowerCase()
+            )
+          : undefined;
       if (match) {
-        const key = repoKey(match);
+        const key = getRepoOptionKey(match);
         if (!seen.has(key)) {
           seen.add(key);
           result.push(match);
@@ -153,7 +155,7 @@ export function useNewSessionRepos({
 
   const repositories = useMemo(
     () =>
-      dedupeRepositoriesByPlatformAndFullName([
+      dedupeRepositoriesByIdentity([
         ...recentlyUsed,
         ...githubRepositories,
         ...gitlabRepositories,
@@ -368,8 +370,4 @@ export function useNewSessionRepos({
     openIntegration,
     refreshReposForceFresh,
   };
-}
-
-function repoKey(repository: NewSessionRepository): string {
-  return `${repository.platform}/${repository.fullName.toLowerCase()}`;
 }


### PR DESCRIPTION
## Why this PR exists

Mobile can receive repositories from several GitHub App installations, but its picker and retry logic currently identify a repository only by provider and full name. When two installations expose the same repository, one row can overwrite or impersonate the other, and the selected installation is lost before session creation.

The server already accepts and enforces exact `githubIntegrationId`. This PR makes mobile preserve that identity from API response through visible selection, submission, and safe retry.

## Place in the rollout

This is the new-session mobile slice of the broader rollout. Prefill ambiguity and continuation are separate PRs (#5545 and #5546) so this review can focus on the picker and new-session submission path.

## What changes

- Preserve GitHub integration ID and account login in the mobile repository model.
- Use installation-qualified option keys so duplicate names remain separate.
- Group and search GitHub repositories by organization account.
- Submit canonical `githubRepo` plus the selected `githubIntegrationId`.
- Include installation identity in retry fingerprints and reject stale option keys.

## What stays unchanged

- GitLab and Bitbucket selection semantics remain unchanged.
- Legacy GitHub responses without provenance remain supported.
- This PR does not change continuation or deep-link ambiguity behavior.

## Why this touches several mobile files

Selection identity crosses the API adapter, repository state, native picker bridge, picker UI, submit payload, and retry fingerprint. Splitting those pieces would create an intermediate app that displays duplicate rows but cannot submit them safely, so they are intentionally one deployable client change.

## Review guide

Follow one repository through `toNewSessionGitHubRepository`, `getRepoOptionKey`, picker state, and `setRepositoryField`. The key invariant is that the composite key is UI-only; `githubRepo` remains canonical `owner/repo`, and `githubIntegrationId` carries authorization provenance.

## Validation

- Focused mobile selector tests
- Mobile typecheck, lint, unused-code check, and format check
- `git diff --check`