### PR TITLE
fix(github): restrict organization integration installs

### DIFF
--- a/apps/web/src/app/api/integrations/github/callback/route.test.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.test.ts
@@ -17,6 +17,7 @@ import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { assertUserAdministersInstallation } from '@/lib/integrations/platforms/github/app-selector';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import type { StateAdapter } from 'chat';
+import { ensureOrganizationAccess } from '@/routers/organizations/utils';
 
 const mockState = { kind: 'state' } as unknown as StateAdapter;
 
@@ -95,6 +96,7 @@ const mockedConsumeInstallState = jest.mocked(consumeInstallState);
 const mockedAssertUserAdministersInstallation = jest.mocked(assertUserAdministersInstallation);
 const mockedCaptureException = jest.mocked(captureException);
 const mockedCaptureMessage = jest.mocked(captureMessage);
+const mockedEnsureOrganizationAccess = jest.mocked(ensureOrganizationAccess);
 
 const USER_ID = '034489e8-19e0-4479-9d69-2edad719e847';
 const OTHER_USER_ID = 'c00b91a1-6959-4b04-9ef8-e8d37b340f4a';
@@ -524,6 +526,36 @@ describe('GET /api/integrations/github/callback database-backed install flow', (
       { type: 'org', id: 'org-db-owner' },
       expect.objectContaining({ platform: 'github' })
     );
+    expect(mockedEnsureOrganizationAccess).toHaveBeenCalledWith(
+      expect.objectContaining({ user: expect.objectContaining({ id: USER_ID }) }),
+      'org-db-owner',
+      ['owner', 'admin']
+    );
+  });
+
+  test('revalidates organization management access before storing an installation', async () => {
+    mockedConsumeInstallState.mockResolvedValue({
+      token: DB_TOKEN,
+      kilo_user_id: USER_ID,
+      owner_type: 'org',
+      owner_id: 'org-demoted',
+      github_app_type: 'standard',
+      return_to: '/organizations/org-demoted/integrations/github',
+      expires_at: new Date(Date.now() + 300_000).toISOString(),
+      consumed_at: null,
+      created_at: new Date().toISOString(),
+    });
+    mockedEnsureOrganizationAccess.mockRejectedValueOnce(new Error('Organization role required'));
+
+    const { GET } = await import('./route');
+    const response = await GET(
+      makeRequest(
+        `/api/integrations/github/callback?installation_id=${INSTALLATION_ID}&setup_action=install&state=${DB_TOKEN}`
+      ) as never
+    );
+
+    expectRedirectLocation(response, '/?error=installation_failed');
+    expect(mockedUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
   });
 
   test('handles a database-minted token with returnTo', async () => {

--- a/apps/web/src/app/api/integrations/github/callback/route.ts
+++ b/apps/web/src/app/api/integrations/github/callback/route.ts
@@ -1,7 +1,7 @@
 import type { NextRequest } from 'next/server';
 import { NextResponse } from 'next/server';
 import { getUserFromAuth } from '@/lib/user/server';
-import { platform_integrations, type User } from '@kilocode/db/schema';
+import { platform_integrations, type GitHubInstallState, type User } from '@kilocode/db/schema';
 import { Octokit } from '@octokit/rest';
 import { createAppAuth } from '@octokit/auth-app';
 import {
@@ -34,7 +34,7 @@ import { isOrganizationMember } from '@/lib/organizations/organizations';
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import { APP_URL } from '@/lib/constants';
 import { consumeInstallState } from '@/lib/integrations/github/install-state';
-import type { GitHubInstallState } from '@kilocode/db/schema';
+import { ORGANIZATION_MANAGE_ROLES } from '@kilocode/app-shared/organizations';
 
 const appendQueryParam = (path: string, queryParam: string): string =>
   `${path}${path.includes('?') ? '&' : '?'}${queryParam}`;
@@ -273,7 +273,11 @@ async function handleCoreInstallFlow(params: {
 
   // Verify user has access to the owner
   if (owner.type === 'org') {
-    await ensureOrganizationAccess({ user: user as unknown as User }, owner.id);
+    await ensureOrganizationAccess(
+      { user: user as unknown as User },
+      owner.id,
+      ORGANIZATION_MANAGE_ROLES
+    );
   } else {
     if (user.id !== owner.id) {
       return NextResponse.redirect(new URL('/', APP_URL));

--- a/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
+++ b/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
@@ -141,8 +141,9 @@ export function OrganizationGitHubInstallations({
           </p>
         ) : installations.length === 0 ? (
           <p className="border-border border-t px-5 py-8 text-center text-sm text-muted-foreground sm:px-6">
-            No GitHub organizations are connected yet. GitHub will let you choose an organization
-            and repository access.
+            {query.data?.canAdd
+              ? 'No GitHub organizations are connected yet. GitHub will let you choose an organization and repository access.'
+              : 'No GitHub organizations are connected yet. Ask an organization owner or admin to connect one.'}
           </p>
         ) : (
           <div className="divide-border border-border divide-y border-t">

--- a/apps/web/src/routers/github-apps-router.test.ts
+++ b/apps/web/src/routers/github-apps-router.test.ts
@@ -135,6 +135,7 @@ const organizationRoles = [
   'billing_manager',
   'member',
 ] satisfies OrganizationRole[];
+const organizationManageRoles = ['owner', 'admin'] satisfies OrganizationRole[];
 
 function organizationIntegration(): PlatformIntegration {
   const timestamp = '2026-01-01T00:00:00.000Z';
@@ -177,8 +178,8 @@ describe('githubAppsRouter organization install capability', () => {
     mockListIntegrations.mockResolvedValue([]);
   });
 
-  it.each(organizationRoles)(
-    'preserves first-install access for organization %s roles',
+  it.each(organizationManageRoles)(
+    'allows organization %s roles to start an install',
     async role => {
       mockEnsureOrganizationAccess.mockResolvedValue(role);
       const caller = createCaller({ user: { id: 'user-1', is_admin: false } as User });
@@ -190,7 +191,7 @@ describe('githubAppsRouter organization install capability', () => {
       expect(mockEnsureOrganizationAccess).toHaveBeenCalledWith(
         expect.objectContaining({ user: expect.objectContaining({ id: 'user-1' }) }),
         organizationId,
-        organizationRoles
+        organizationManageRoles
       );
       expect(mockCreateInstallState).toHaveBeenCalledWith({
         kiloUserId: 'user-1',
@@ -202,19 +203,34 @@ describe('githubAppsRouter organization install capability', () => {
     }
   );
 
-  it('allows a non-platform-admin organization member to add after an existing installation', async () => {
+  it.each(['billing_manager', 'member'] satisfies OrganizationRole[])(
+    'denies organization %s roles before minting install state',
+    async role => {
+      mockEnsureOrganizationAccess.mockImplementation(async (_ctx, _organizationId, roles) => {
+        if (roles && !roles.includes(role)) {
+          throw new TRPCError({ code: 'UNAUTHORIZED', message: 'Organization role required' });
+        }
+        return role;
+      });
+      const caller = createCaller({ user: { id: 'user-1', is_admin: false } as User });
+
+      await expect(caller.mintInstallState({ organizationId })).rejects.toMatchObject({
+        code: 'UNAUTHORIZED',
+      });
+
+      expect(mockCreateInstallState).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(organizationRoles)('reports add capability for organization %s roles', async role => {
+    mockEnsureOrganizationAccess.mockResolvedValue(role);
     mockListIntegrations.mockResolvedValue([organizationIntegration()]);
     const caller = createCaller({ user: { id: 'user-1', is_admin: false } as User });
 
     const listed = await caller.listOrganizationInstallations({ organizationId });
-    const minted = await caller.mintInstallState({ organizationId, returnTo: '/settings' });
 
-    expect(listed.canAdd).toBe(true);
+    expect(listed.canAdd).toBe(role === 'owner' || role === 'admin');
     expect(listed.installations).toHaveLength(1);
-    expect(minted).toEqual({ token: 'install-token' });
-    expect(mockCreateInstallState).toHaveBeenCalledWith(
-      expect.objectContaining({ ownerType: 'org', ownerId: organizationId, returnTo: '/settings' })
-    );
   });
 
   it('still denies callers outside the organization role matrix before minting state', async () => {

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -29,7 +29,10 @@ import {
 import { requireNumericPlatformRepositories } from '@/lib/integrations/core/types';
 import { createGitHubUserAuthorizationState } from '@/lib/integrations/platforms/github/user-authorization-state';
 import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
-import { ORGANIZATION_MANAGE_ROLES } from '@kilocode/app-shared/organizations';
+import {
+  canManageOrganization,
+  ORGANIZATION_MANAGE_ROLES,
+} from '@kilocode/app-shared/organizations';
 import {
   disconnectGitHubUserAuthorization,
   getGitHubUserAuthorizationStatus,
@@ -58,7 +61,7 @@ export const githubAppsRouter = createTRPCRouter({
       const primaryId = integrations.find(isPlatformIntegrationHealthy)?.id ?? null;
 
       return {
-        canAdd: true,
+        canAdd: canManageOrganization(role),
         installations: integrations.map(integration => {
           const repositories = requireNumericPlatformRepositories(integration.repositories) ?? [];
           const status: 'connected' | 'pending' | 'suspended' | 'needs_attention' =
@@ -145,14 +148,11 @@ export const githubAppsRouter = createTRPCRouter({
       })
     )
     .mutation(async ({ ctx, input }) => {
-      // Any org member can start an install, matching the pre-C1 callback,
-      // which called ensureOrganizationAccess with no role filter.
-      const owner = await resolveAuthorizedOwner(ctx, input.organizationId, [
-        'owner',
-        'admin',
-        'billing_manager',
-        'member',
-      ]);
+      const owner = await resolveAuthorizedOwner(
+        ctx,
+        input.organizationId,
+        input.organizationId ? ORGANIZATION_MANAGE_ROLES : undefined
+      );
       const appType = await getGitHubAppTypeForOrganization(input.organizationId ?? null);
 
       const token = await createInstallState({
@@ -485,6 +485,10 @@ export const githubAppsRouter = createTRPCRouter({
           code: 'FORBIDDEN',
           message: 'This endpoint is only available in development mode',
         });
+      }
+
+      if (input.organizationId) {
+        await ensureOrganizationAccess(ctx, input.organizationId, ORGANIZATION_MANAGE_ROLES);
       }
 
       const appType = input.appType;


### PR DESCRIPTION
## Summary

- allow only organization owners and admins to add GitHub integrations
- report the role-based capability to the UI and guide other roles to an owner or admin
- revalidate management access in the callback and development install path
