### PR TITLE
feat(cloud-agent-next): contain managed sandbox credentials

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -338,7 +338,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-sandbox-rest-client.test.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-sandbox-rest-client.test.ts
@@ -6,6 +6,7 @@ import {
   VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG,
   VercelSandboxRestClient,
   type VercelSandboxCommand,
+  type VercelSandboxNetworkPolicy,
   type VercelSandboxResource,
   type VercelSandboxSession,
 } from './vercel-sandbox-rest-client.js';
@@ -13,6 +14,7 @@ import {
 const sandboxName = 'ses-exact-runtime';
 const sessionId = 'sbox_session_exact';
 const commandId = 'cmd_exact';
+const injectedCredential = 'secret-firewall-injected-credential';
 
 function sandbox(overrides: Partial<VercelSandboxResource> = {}): VercelSandboxResource {
   return {
@@ -84,6 +86,32 @@ function createInput() {
   };
 }
 
+function networkPolicy(): VercelSandboxNetworkPolicy {
+  return {
+    mode: 'custom',
+    allowedDomains: ['api.kilo.ai', '*'],
+    injectionRules: [
+      {
+        domain: 'api.kilo.ai',
+        headers: {
+          authorization: `Bearer ${injectedCredential}`,
+          host: 'api.kilo.ai',
+        },
+        match: {
+          headers: [
+            {
+              key: { exact: 'authorization' },
+              value: { exact: 'Bearer harmless-kilo-placeholder' },
+            },
+          ],
+          path: { startsWith: '/api/provider/' },
+          method: ['POST'],
+        },
+      },
+    ],
+  };
+}
+
 function jsonResponse(body: unknown, init?: ResponseInit): Response {
   return Response.json(body, init);
 }
@@ -105,6 +133,7 @@ describe('VercelSandboxRestClient', () => {
     const [url, init] = providerFetch.mock.calls[0];
     expect(url).toBe('https://api.vercel.com/v2/sandboxes?teamId=team_test');
     expect(init.method).toBe('POST');
+    expect(init.redirect).toBe('manual');
     expect(JSON.parse(init.body as string)).toEqual({
       projectId: 'prj_test',
       name: sandboxName,
@@ -117,6 +146,33 @@ describe('VercelSandboxRestClient', () => {
         [VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG]: 'operation-123',
         [VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG]: 'runtime-build-123',
       },
+    });
+  });
+
+  it('creates a contained sandbox with a nested REST-native policy and redirects disabled', async () => {
+    const providerFetch = vi
+      .fn()
+      .mockResolvedValue(jsonResponse({ sandbox: sandbox(), session: session(), routes: [] }));
+    const policy = networkPolicy();
+
+    await clientFor(providerFetch).createSandbox({ ...createInput(), networkPolicy: policy });
+
+    const [url, init] = providerFetch.mock.calls[0];
+    expect(url).toBe('https://api.vercel.com/v2/sandboxes?teamId=team_test');
+    expect(init.redirect).toBe('manual');
+    expect(JSON.parse(init.body as string)).toEqual({
+      projectId: 'prj_test',
+      name: sandboxName,
+      source: { type: 'snapshot', snapshotId: 'snap_base' },
+      runtime: 'node24',
+      timeout: 300_000,
+      persistent: false,
+      tags: {
+        [VERCEL_CLOUD_AGENT_RESOURCE_TAG]: VERCEL_CLOUD_AGENT_RESOURCE_TAG_VALUE,
+        [VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG]: 'operation-123',
+        [VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG]: 'runtime-build-123',
+      },
+      networkPolicy: policy,
     });
   });
 
@@ -196,6 +252,7 @@ describe('VercelSandboxRestClient', () => {
     expect(providerFetch.mock.calls[0][0]).toBe(
       'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact?teamId=team_test'
     );
+    expect(providerFetch.mock.calls[0][1].redirect).toBe('manual');
   });
 
   it('executes a detached command and correlates its session', async () => {
@@ -343,6 +400,203 @@ describe('VercelSandboxRestClient', () => {
           : client.killCommand(sessionId, commandId, 9);
     await expect(call).rejects.toThrow(`Vercel Sandbox ${operation} failed (correlation_mismatch)`);
   });
+
+  it('updates the exact physical session with an unwrapped REST-native network policy', async () => {
+    const providerFetch = vi.fn().mockResolvedValue(jsonResponse({ session: session() }));
+    const policy = networkPolicy();
+
+    const result = await clientFor(providerFetch).updateNetworkPolicy(
+      sessionId,
+      sandboxName,
+      policy
+    );
+
+    expect(result).toEqual(session());
+    const [url, init] = providerFetch.mock.calls[0];
+    expect(url).toBe(
+      'https://api.vercel.com/v2/sandboxes/sessions/sbox_session_exact/network-policy?teamId=team_test'
+    );
+    expect(init.method).toBe('POST');
+    expect(init.redirect).toBe('manual');
+    expect(new Headers(init.headers).get('content-type')).toBe('application/json');
+    expect(JSON.parse(init.body as string)).toEqual(policy);
+  });
+
+  it.each([
+    ['session', session({ id: 'sbox_other' })],
+    ['sandbox', session({ sourceSandboxName: 'ses-other' })],
+  ])('rejects a network-policy response with a mismatched %s', async (_field, returnedSession) => {
+    const client = clientFor(vi.fn().mockResolvedValue(jsonResponse({ session: returnedSession })));
+
+    await expect(
+      client.updateNetworkPolicy(sessionId, sandboxName, networkPolicy())
+    ).rejects.toMatchObject({
+      kind: 'correlation_mismatch',
+      operation: 'update-network-policy',
+      message: 'Vercel Sandbox update-network-policy failed (correlation_mismatch)',
+    });
+  });
+
+  it.each(['create', 'get-session'] as const)(
+    'rejects redirects for ordinary authenticated %s requests without exposing the management token',
+    async operation => {
+      const reflectedResponse = 'secret-access-token reflected-provider-body';
+      const providerFetch = vi.fn().mockResolvedValue(
+        new Response(reflectedResponse, {
+          status: 307,
+          headers: { location: 'https://redirect.example/management' },
+        })
+      );
+      const client = clientFor(providerFetch);
+      const request =
+        operation === 'create'
+          ? client.createSandbox(createInput())
+          : client.getSession(sessionId, sandboxName);
+
+      const error = await request.catch(cause => cause);
+
+      expect(error).toMatchObject({
+        kind: 'request_failed',
+        operation,
+        status: 307,
+        message: `Vercel Sandbox ${operation} failed (request_failed, status 307)`,
+      });
+      expect(String(error)).not.toContain('secret-access-token');
+      expect(String(error)).not.toContain('reflected-provider-body');
+      expect(providerFetch).toHaveBeenCalledTimes(1);
+      expect(providerFetch.mock.calls[0][1].redirect).toBe('manual');
+    }
+  );
+
+  it.each(['create', 'get-session'] as const)(
+    'sanitizes redirect failures for ordinary authenticated %s requests',
+    async operation => {
+      const providerFetch = vi
+        .fn()
+        .mockRejectedValue(new TypeError('redirect failed for secret-access-token'));
+      const client = clientFor(providerFetch);
+      const request =
+        operation === 'create'
+          ? client.createSandbox(createInput())
+          : client.getSession(sessionId, sandboxName);
+
+      const error = await request.catch(cause => cause);
+
+      expect(error).toMatchObject({
+        kind: 'request_failed',
+        operation,
+        message: `Vercel Sandbox ${operation} failed (request_failed)`,
+      });
+      expect(String(error)).not.toContain('secret-access-token');
+      expect(providerFetch).toHaveBeenCalledTimes(1);
+      expect(providerFetch.mock.calls[0][1].redirect).toBe('manual');
+    }
+  );
+
+  it.each(['create', 'update-network-policy'] as const)(
+    'rejects a redirect response for secret-bearing %s requests without forwarding the policy',
+    async operation => {
+      const providerFetch = vi.fn().mockResolvedValue(
+        new Response(injectedCredential, {
+          status: 307,
+          headers: { location: 'https://redirect.example/network-policy' },
+        })
+      );
+      const client = clientFor(providerFetch);
+      const request =
+        operation === 'create'
+          ? client.createSandbox({ ...createInput(), networkPolicy: networkPolicy() })
+          : client.updateNetworkPolicy(sessionId, sandboxName, networkPolicy());
+
+      const error = await request.catch(cause => cause);
+
+      expect(error).toMatchObject({
+        kind: 'request_failed',
+        operation,
+        status: 307,
+        message: `Vercel Sandbox ${operation} failed (request_failed, status 307)`,
+      });
+      expect(String(error)).not.toContain(injectedCredential);
+      expect(providerFetch).toHaveBeenCalledTimes(1);
+      expect(providerFetch.mock.calls[0][1].redirect).toBe('manual');
+    }
+  );
+
+  it.each(['create', 'update-network-policy'] as const)(
+    'sanitizes redirect failures for secret-bearing %s requests',
+    async operation => {
+      const providerFetch = vi
+        .fn()
+        .mockRejectedValue(new TypeError(`redirect failed for ${injectedCredential}`));
+      const client = clientFor(providerFetch);
+      const request =
+        operation === 'create'
+          ? client.createSandbox({ ...createInput(), networkPolicy: networkPolicy() })
+          : client.updateNetworkPolicy(sessionId, sandboxName, networkPolicy());
+
+      const error = await request.catch(cause => cause);
+
+      expect(error).toMatchObject({
+        kind: 'request_failed',
+        operation,
+        message: `Vercel Sandbox ${operation} failed (request_failed)`,
+      });
+      expect(String(error)).not.toContain(injectedCredential);
+      expect(providerFetch).toHaveBeenCalledTimes(1);
+      expect(providerFetch.mock.calls[0][1].redirect).toBe('manual');
+    }
+  );
+
+  it.each(['create', 'update-network-policy'] as const)(
+    'never exposes reflected credentials from rejected %s policy requests',
+    async operation => {
+      const reflectedResponse = `${injectedCredential} secret-access-token reflected-provider-body`;
+      const providerFetch = vi
+        .fn()
+        .mockResolvedValue(new Response(reflectedResponse, { status: 403 }));
+      const client = clientFor(providerFetch);
+      const request =
+        operation === 'create'
+          ? client.createSandbox({ ...createInput(), networkPolicy: networkPolicy() })
+          : client.updateNetworkPolicy(sessionId, sandboxName, networkPolicy());
+
+      const error = await request.catch(cause => cause);
+
+      expect(error).toMatchObject({
+        kind: 'request_failed',
+        operation,
+        status: 403,
+        message: `Vercel Sandbox ${operation} failed (request_failed, status 403)`,
+      });
+      expect(String(error)).not.toContain(injectedCredential);
+      expect(String(error)).not.toContain('secret-access-token');
+      expect(String(error)).not.toContain('reflected-provider-body');
+    }
+  );
+
+  it.each(['create', 'update-network-policy'] as const)(
+    'never exposes reflected credentials from invalid successful %s responses',
+    async operation => {
+      const providerFetch = vi
+        .fn()
+        .mockResolvedValue(jsonResponse({ token: injectedCredential, reflected: 'provider-body' }));
+      const client = clientFor(providerFetch);
+      const request =
+        operation === 'create'
+          ? client.createSandbox({ ...createInput(), networkPolicy: networkPolicy() })
+          : client.updateNetworkPolicy(sessionId, sandboxName, networkPolicy());
+
+      const error = await request.catch(cause => cause);
+
+      expect(error).toMatchObject({
+        kind: 'invalid_response',
+        operation,
+        message: `Vercel Sandbox ${operation} failed (invalid_response)`,
+      });
+      expect(String(error)).not.toContain(injectedCredential);
+      expect(String(error)).not.toContain('provider-body');
+    }
+  );
 
   it('extends and stops the exact correlated session without a named DELETE API', async () => {
     const providerFetch = vi

--- a/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-sandbox-rest-client.ts
+++ b/services/cloud-agent-next/src/agent-sandbox/vercel/vercel-sandbox-rest-client.ts
@@ -91,6 +91,24 @@ export type VercelSandboxSession = z.infer<typeof sessionSchema>;
 export type VercelSandboxRoute = z.infer<typeof routeSchema>;
 export type VercelSandboxCommand = z.infer<typeof commandSchema>;
 
+export type VercelSandboxMatcher = { exact: string } | { startsWith: string };
+
+export type VercelSandboxInjectionRule = {
+  domain: string;
+  headers: Record<string, string>;
+  match: {
+    headers: Array<{ key: { exact: string }; value: { exact: string } }>;
+    path?: VercelSandboxMatcher;
+    method?: string[];
+  };
+};
+
+export type VercelSandboxNetworkPolicy = {
+  mode: 'custom';
+  allowedDomains: string[];
+  injectionRules: VercelSandboxInjectionRule[];
+};
+
 export type VercelSandboxRestClientConfig = {
   accessToken: string;
   projectId?: string;
@@ -105,6 +123,7 @@ export type CreateSandboxInput = {
   snapshotId: string;
   runtime: VercelSandboxRuntime;
   timeoutMs: number;
+  networkPolicy?: VercelSandboxNetworkPolicy;
 };
 
 export type VercelSandboxCreateEnvelope = {
@@ -145,6 +164,7 @@ type VercelSandboxOperation =
   | 'write-files'
   | 'read-file'
   | 'extend-timeout'
+  | 'update-network-policy'
   | 'stop-session';
 export type VercelSandboxErrorKind =
   | 'invalid_configuration'
@@ -291,6 +311,7 @@ export class VercelSandboxRestClient {
           [VERCEL_CLOUD_AGENT_CREATE_OPERATION_TAG]: input.operationId,
           [VERCEL_CLOUD_AGENT_RUNTIME_BUILD_TAG]: input.runtimeBuildId,
         },
+        ...(input.networkPolicy === undefined ? {} : { networkPolicy: input.networkPolicy }),
       }),
     });
     await this.requireSuccessfulResponse(response, operation);
@@ -461,6 +482,28 @@ export class VercelSandboxRestClient {
     });
     await this.requireSuccessfulResponse(response, operation);
     return this.readBoundedBytes(response, maxBytes, operation);
+  }
+
+  async updateNetworkPolicy(
+    sessionId: string,
+    expectedSandboxName: string,
+    networkPolicy: VercelSandboxNetworkPolicy
+  ): Promise<VercelSandboxSession> {
+    const operation = 'update-network-policy';
+    this.validateSessionTarget(sessionId, expectedSandboxName, operation);
+    const response = await this.fetchProvider(
+      operation,
+      this.sessionActionUrl(sessionId, 'network-policy'),
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(networkPolicy),
+      }
+    );
+    await this.requireSuccessfulResponse(response, operation);
+    const envelope = await this.parseJson(response, sessionEnvelopeSchema, operation);
+    correlateSession(envelope.session, sessionId, expectedSandboxName, operation);
+    return envelope.session;
   }
 
   async extendSessionTimeout(
@@ -645,7 +688,12 @@ export class VercelSandboxRestClient {
     const signal = init.signal ? AbortSignal.any([init.signal, deadlineSignal]) : deadlineSignal;
     try {
       const fetchImpl = this.config.fetch;
-      const response = await fetchImpl(url.toString(), { ...init, headers, signal });
+      const response = await fetchImpl(url.toString(), {
+        ...init,
+        headers,
+        signal,
+        redirect: 'manual',
+      });
       this.responseSignals.set(response, signal);
       return response;
     } catch {

--- a/services/cloud-agent-next/src/kilo/kilo-targets.test.ts
+++ b/services/cloud-agent-next/src/kilo/kilo-targets.test.ts
@@ -104,4 +104,111 @@ describe('deriveKiloSandboxTargets', () => {
       reason: 'invalid_target',
     });
   });
+
+  it('preserves HTTPS target base paths, ports, and token-selected provider precedence', () => {
+    expect(
+      deriveKiloSandboxTargets(
+        {
+          KILOCODE_BACKEND_BASE_URL: 'https://backend.example.com:8443/tenant/api/',
+          KILO_OPENROUTER_BASE: 'https://configured.example.com/ignored',
+          KILO_SESSION_INGEST_URL: 'https://ingest.example.com:9443/events/',
+        },
+        'https://provider.example.com:7443/custom/api/openrouter/:real-provider-token',
+        { requireHttps: true }
+      )
+    ).toEqual({
+      success: true,
+      targets: {
+        backendBaseUrl: 'https://backend.example.com:8443/tenant/api',
+        providerBaseUrl: 'https://provider.example.com:7443/custom/api/openrouter',
+        sessionIngestBaseUrl: 'https://ingest.example.com:9443/events',
+      },
+    });
+  });
+
+  it.each([
+    ['production HTTP', 'http://api.example.com/base'],
+    ['local HTTP', 'http://localhost:3000/base'],
+    ['HTTPS localhost', 'https://localhost/base'],
+    ['localhost DNS suffix', 'https://service.localhost/base'],
+    ['Docker host', 'https://host.docker.internal/base'],
+    ['IPv4 address', 'https://127.0.0.1/base'],
+    ['alternative IPv4 address', 'https://2130706433/base'],
+    ['IPv6 address', 'https://[::1]/base'],
+    ['single-label hostname', 'https://internal/base'],
+    ['invalid DNS hostname', 'https://bad_host.example.com/base'],
+    ['invalid DNS label', 'https://-bad.example.com/base'],
+    ['userinfo', 'https://user:password@example.com/base'],
+    ['query string', 'https://api.example.com/base?target=other'],
+    ['empty query string', 'https://api.example.com/base?'],
+    ['fragment', 'https://api.example.com/base#other'],
+    ['malformed URL', 'https://api.example.com:99999/base'],
+    ['malformed percent encoding', 'https://api.example.com/base/%GG'],
+    ['malformed UTF-8 percent encoding', 'https://api.example.com/base/%E0%A4%A'],
+    ['raw parent traversal', 'https://api.example.com/base/../escape'],
+    ['raw current-directory traversal', 'https://api.example.com/base/./escape'],
+    ['encoded parent traversal', 'https://api.example.com/base/%2e%2e/escape'],
+    ['mixed encoded parent traversal', 'https://api.example.com/base/.%2e/escape'],
+    ['double-encoded parent traversal', 'https://api.example.com/base/%252e%252e/escape'],
+    ['encoded slash', 'https://api.example.com/base%2fescape'],
+    ['encoded backslash', 'https://api.example.com/base%5cescape'],
+    ['double-encoded slash', 'https://api.example.com/base%252fescape'],
+    ['triple-encoded backslash', 'https://api.example.com/base%25255cescape'],
+    ['raw backslash', 'https://api.example.com/base\\escape'],
+    ['duplicate path boundary', 'https://api.example.com/base//escape'],
+    ['encoded control character', 'https://api.example.com/base%00escape'],
+    ['leading whitespace', ' https://api.example.com/base'],
+  ] as const)('rejects %s before normalizing any contained target', (_description, target) => {
+    for (const key of [
+      'KILOCODE_BACKEND_BASE_URL',
+      'KILO_OPENROUTER_BASE',
+      'KILO_SESSION_INGEST_URL',
+    ] as const) {
+      expect(
+        deriveKiloSandboxTargets({ [key]: target }, 'user-token', { requireHttps: true })
+      ).toEqual({
+        success: false,
+        reason: 'invalid_target',
+      });
+    }
+  });
+
+  it.each([
+    'http://localhost:9911/api/openrouter:real-token',
+    'https://provider.example.com/api/openrouter/../session:real-token',
+    'https://provider.example.com/api/openrouter/%252e%252e/session:real-token',
+    'https://provider.example.com/api/openrouter%252fescape:real-token',
+    'https://provider.example.com/api/openrouter/%GG:real-token',
+  ])('rejects unsafe token-encoded provider targets before URL normalization: %s', token => {
+    expect(
+      deriveKiloSandboxTargets(
+        { KILO_OPENROUTER_BASE: 'https://safe-provider.example.com/api/openrouter' },
+        token,
+        { requireHttps: true }
+      )
+    ).toEqual({ success: false, reason: 'invalid_target' });
+  });
+
+  it('preserves legacy local Cloudflare target behavior unless HTTPS is explicitly required', () => {
+    const env = {
+      KILOCODE_BACKEND_BASE_URL: 'http://localhost:3000/root/',
+      KILO_SESSION_INGEST_URL: 'http://127.0.0.1:8800/ingest/',
+    };
+
+    expect(deriveKiloSandboxTargets(env, 'user-token')).toMatchObject({
+      success: true,
+      targets: {
+        backendBaseUrl: 'http://host.docker.internal:3000/root',
+        providerBaseUrl: 'http://host.docker.internal:3000/root',
+        sessionIngestBaseUrl: 'http://host.docker.internal:8800/ingest',
+      },
+    });
+    expect(deriveKiloSandboxTargets(env, 'user-token', { requireHttps: false })).toMatchObject({
+      success: true,
+    });
+    expect(deriveKiloSandboxTargets(env, 'user-token', { requireHttps: true })).toEqual({
+      success: false,
+      reason: 'invalid_target',
+    });
+  });
 });

--- a/services/cloud-agent-next/src/kilo/kilo-targets.ts
+++ b/services/cloud-agent-next/src/kilo/kilo-targets.ts
@@ -2,6 +2,7 @@ import { DEFAULT_BACKEND_URL } from '../constants.js';
 
 const DEFAULT_SESSION_INGEST_URL = 'https://ingest.kilosessions.ai';
 const LOCAL_SANDBOX_HOSTNAME = 'host.docker.internal';
+const TOKEN_PROVIDER_URL = /^(https?:\/\/[^:]+(?::\d+)?(?:\/[^:]*)?):/;
 
 export type KiloTargetEnv = {
   KILOCODE_BACKEND_BASE_URL?: string;
@@ -24,7 +25,7 @@ export type DerivedKiloSandboxTargets =
 
 export function providerBaseUrlEncodedInToken(token: string | undefined): string | undefined {
   if (!token) return undefined;
-  const match = token.match(/^(https?:\/\/[^:]+(?::\d+)?(?:\/[^:]*)?):/);
+  const match = token.match(TOKEN_PROVIDER_URL);
   if (!match?.[1]) return undefined;
   try {
     return new URL(match[1]).toString().replace(/\/+$/, '');
@@ -45,8 +46,71 @@ export function backendUrlForSandbox(workerBackendUrl: string): string {
   }
 }
 
-function normalizeSandboxTarget(value: string): string | null {
+function hasUnsafeTargetEncoding(value: string): boolean {
+  let decoded = value;
+  for (let depth = 0; depth < 8; depth++) {
+    if (
+      decoded.includes('\\') ||
+      /%(?:2f|5c)/i.test(decoded) ||
+      /(?:^|\/)(?:\.|%2e){1,2}(?=\/|[?#]|$)/i.test(decoded) ||
+      [...decoded].some(character => {
+        const code = character.charCodeAt(0);
+        return code <= 0x20 || code === 0x7f;
+      })
+    ) {
+      return true;
+    }
+
+    let next: string;
+    try {
+      next = decodeURIComponent(decoded);
+    } catch {
+      return true;
+    }
+    if (next === decoded) return false;
+    decoded = next;
+  }
+  return true;
+}
+
+function isValidHttpsSandboxTarget(value: string): boolean {
+  if (hasUnsafeTargetEncoding(value)) return false;
+  const rawTarget = /^https:\/\/([^/?#]+)(\/[^?#]*)?$/i.exec(value);
+  if (!rawTarget?.[1] || !/^[A-Za-z0-9.-]+(?::\d+)?$/.test(rawTarget[1])) return false;
+
+  let url: URL;
+  try {
+    url = new URL(value);
+  } catch {
+    return false;
+  }
+
+  if (
+    url.protocol !== 'https:' ||
+    url.username ||
+    url.password ||
+    url.search ||
+    url.hash ||
+    url.pathname.includes('//') ||
+    url.hostname === 'localhost' ||
+    url.hostname.endsWith('.localhost') ||
+    url.hostname === LOCAL_SANDBOX_HOSTNAME
+  ) {
+    return false;
+  }
+
+  const labels = url.hostname.split('.');
+  return (
+    url.hostname.length <= 253 &&
+    labels.length > 1 &&
+    labels.some(label => !/^\d+$/.test(label)) &&
+    labels.every(label => /^[A-Za-z0-9](?:[A-Za-z0-9-]{0,61}[A-Za-z0-9])?$/.test(label))
+  );
+}
+
+function normalizeSandboxTarget(value: string, requireHttps = false): string | null {
   if (/%(?:2f|5c)/i.test(value)) return null;
+  if (requireHttps && !isValidHttpsSandboxTarget(value)) return null;
   let url: URL;
   try {
     url = new URL(backendUrlForSandbox(value));
@@ -64,18 +128,33 @@ function normalizeSandboxTarget(value: string): string | null {
 
 export function deriveKiloSandboxTargets(
   env: KiloTargetEnv,
-  userToken: string
+  userToken: string,
+  options?: { requireHttps?: boolean }
 ): DerivedKiloSandboxTargets {
+  const requireHttps = options?.requireHttps === true;
   const backendBaseUrl = normalizeSandboxTarget(
-    env.KILOCODE_BACKEND_BASE_URL ?? DEFAULT_BACKEND_URL
+    env.KILOCODE_BACKEND_BASE_URL ?? DEFAULT_BACKEND_URL,
+    requireHttps
   );
   if (!backendBaseUrl) return { success: false, reason: 'invalid_target' };
 
+  const rawTokenProviderSource = TOKEN_PROVIDER_URL.exec(userToken)?.[1];
+  if (
+    requireHttps &&
+    rawTokenProviderSource &&
+    !isValidHttpsSandboxTarget(rawTokenProviderSource)
+  ) {
+    return { success: false, reason: 'invalid_target' };
+  }
+  const encodedProviderSource = providerBaseUrlEncodedInToken(userToken);
   const providerSource =
-    providerBaseUrlEncodedInToken(userToken) ?? env.KILO_OPENROUTER_BASE ?? backendBaseUrl;
-  const providerBaseUrl = normalizeSandboxTarget(providerSource);
+    (requireHttps && encodedProviderSource ? rawTokenProviderSource : encodedProviderSource) ??
+    env.KILO_OPENROUTER_BASE ??
+    backendBaseUrl;
+  const providerBaseUrl = normalizeSandboxTarget(providerSource, requireHttps);
   const sessionIngestBaseUrl = normalizeSandboxTarget(
-    env.KILO_SESSION_INGEST_URL ?? DEFAULT_SESSION_INGEST_URL
+    env.KILO_SESSION_INGEST_URL ?? DEFAULT_SESSION_INGEST_URL,
+    requireHttps
   );
   if (!providerBaseUrl || !sessionIngestBaseUrl) {
     return { success: false, reason: 'invalid_target' };

--- a/services/cloud-agent-next/src/persistence/SandboxControl.ts
+++ b/services/cloud-agent-next/src/persistence/SandboxControl.ts
@@ -3,6 +3,7 @@ import { getSandbox } from '@cloudflare/sandbox';
 import { withTimeout } from '@kilocode/worker-utils';
 import { z } from 'zod';
 import type { Env } from '../types.js';
+import { getSandboxProvider, type SessionMetadata } from './session-metadata.js';
 import { getSandboxSessionStub } from '../sandbox-session/session-stub.js';
 import { logger } from '../logger.js';
 import {
@@ -24,6 +25,7 @@ import {
   sessionRequestIdentitySchema,
   wrapperInstanceIdSchema,
   type ResponseFrame,
+  type SessionAttachPayload,
   type SandboxHeartbeatPayload,
   type SessionEventIdentity,
   type SessionEventPayload,
@@ -50,6 +52,8 @@ import {
   observe,
   recordStopAttempt,
   sameAllocation,
+  WORKTREE_CREDENTIAL_CONTAINMENT,
+  type CredentialContainmentRequirements,
   type ObserveResult,
   type PhysicalRecord,
 } from '../sandbox-control/physical-lifecycle.js';
@@ -88,7 +92,17 @@ import {
   savePhysicalRecord,
   saveRouteTable,
   saveTransitionLog,
+  loadSessionCredentialGrants,
+  saveSessionCredentialGrants,
 } from '../sandbox-control/durable-state.js';
+import {
+  buildControlNetworkPolicy,
+  prepareSessionCredentials as prepareCredentials,
+  removeSessionCredentialMembership,
+  resolveSessionCredential,
+  type SessionCredentialGrant,
+} from '../sandbox-control/session-credentials.js';
+import { parseControlPlaneCredential } from '../sandbox-control/managed-credential.js';
 import { withDORetry } from '../utils/do-retry.js';
 import type {
   ProviderAdapter,
@@ -100,8 +114,15 @@ import {
   planReconciliation,
   shouldRearmReconciliation,
 } from '../sandbox-control/reconciliation.js';
-import { createCloudflareProviderAdapter } from '../sandbox-control/cloudflare-provider.js';
-import { createVercelProviderAdapter } from '../sandbox-control/vercel-provider.js';
+import {
+  createCloudflareProviderAdapter,
+  decodeCloudflareProviderRef,
+} from '../sandbox-control/cloudflare-provider.js';
+import {
+  createVercelProviderAdapter,
+  decodeVercelProviderRef,
+} from '../sandbox-control/vercel-provider.js';
+import type { VercelSandboxNetworkPolicy } from '../agent-sandbox/vercel/vercel-sandbox-rest-client.js';
 import {
   parseVercelSandboxRuntimeConfig,
   resolveVercelSandboxRuntimeConfig,
@@ -114,7 +135,11 @@ import {
   type SandboxBillingInput,
 } from '../container-usage-context.js';
 import { isCloudAgentContainerBillingEnabled } from '../container-billing-rollout.js';
-import { deriveSandboxAllocationId, getSandboxNamespace } from '../sandbox-id.js';
+import {
+  deriveSandboxAllocationId,
+  getOutboundContainerId,
+  getSandboxNamespace,
+} from '../sandbox-id.js';
 import {
   validateTerminalBillingRuntime,
   type SandboxTerminalAccessInput,
@@ -130,6 +155,8 @@ const DIAGNOSTIC_BUNDLE_KEY = 'diagnostic_bundle';
 const PROVIDER_KIND_KEY = 'provider_kind';
 const BILLING_INPUT_KEY = 'billing_input';
 const ACQUISITION_RECEIPTS_KEY = 'acquisition_receipts';
+const CREDENTIAL_POLICY_DIRTY_KEY = 'credential_policy_dirty';
+const TERMINAL_CREDENTIAL_RENEWAL_WINDOW_MS = 60 * 60 * 1000;
 
 const sandboxAcquisitionSchema = z.object({
   id: z.string().min(1).max(128),
@@ -169,6 +196,7 @@ type TerminalRuntimeSnapshot = {
   physical: PhysicalRecord;
   provider: AgentSandboxProvider;
   route: SessionRoute;
+  grant: SessionCredentialGrant;
 };
 
 type TerminalRuntimeRejection = {
@@ -194,6 +222,7 @@ export class SandboxControl extends DurableObject<Env> {
   private readyConnectionId: string | null = null;
   private providerKind: AgentSandboxProvider = 'cloudflare';
   private readonly sessionForwardChains = new Map<string, Promise<void>>();
+  private credentialUpdates: Promise<void> = Promise.resolve();
   private provider: ProviderAdapter;
   private stopAttemptInFlight: {
     physical: PhysicalRecord;
@@ -212,6 +241,7 @@ export class SandboxControl extends DurableObject<Env> {
       new WebSocketRequestResponsePair(SANDBOX_CONTROL_AUTO_PING, SANDBOX_CONTROL_AUTO_PONG)
     );
     this.socketHandler = createSandboxControlSocketHandler(ctx, this.sandboxId, undefined, {
+      validateHandshake: providerInstanceId => this.validateHandshake(providerInstanceId),
       onHandshakeComplete: identity => this.onHandshakeComplete(identity),
       onReady: identity => this.onWrapperReady(identity),
       onHeartbeat: (payload, identity) => this.onHeartbeat(payload, identity),
@@ -466,14 +496,185 @@ export class SandboxControl extends DurableObject<Env> {
     return { quarantined: true };
   }
 
+  async prepareSessionCredentials(input: {
+    ownerId: string;
+    sessionId: string;
+  }): Promise<SessionAttachPayload> {
+    await this.initializeOwner(input.ownerId);
+    return this.withCredentialUpdate(() => this.prepareOwnedSessionCredentials(input));
+  }
+
+  private async prepareOwnedSessionCredentials(
+    input: { ownerId: string; sessionId: string },
+    terminal?: { access: SandboxTerminalAccessInput; runtime: TerminalRuntimeSnapshot },
+    deadlineAt?: number
+  ): Promise<SessionAttachPayload> {
+    if (deadlineAt !== undefined && Date.now() >= deadlineAt) {
+      throw new Error('Sandbox credential preparation expired');
+    }
+    const metadata = await this.readCredentialMetadata(input);
+    const provider = getSandboxProvider(metadata);
+    await this.pinProvider(provider);
+    const physical = await loadPhysicalRecord(this.ctx.storage);
+    if (!this.matchesContainment(physical, WORKTREE_CREDENTIAL_CONTAINMENT)) {
+      throw new Error('Sandbox credential containment is unavailable');
+    }
+    const outboundContainerId =
+      provider === 'cloudflare'
+        ? getOutboundContainerId(
+            this.env,
+            decodeCloudflareProviderRef(physical.providerRef)?.sandboxId ??
+              physical.createIntent?.allocationName ??
+              this.sandboxId,
+            { managedScmContainment: true }
+          )
+        : undefined;
+    const grants = await loadSessionCredentialGrants(this.ctx.storage);
+    const scopeId = metadata.workspace?.worktreeId ?? metadata.identity.sessionId;
+    const existing = grants.find(grant => grant.scopeId === scopeId);
+    const prepared = await prepareCredentials({
+      env: this.env,
+      metadata,
+      sandboxId: this.sandboxId,
+      ...(outboundContainerId ? { outboundContainerId } : {}),
+      ...(existing ? { existing } : {}),
+    });
+    if (
+      grants.some(
+        grant =>
+          grant.scopeId !== scopeId &&
+          (grant.directory === prepared.grant.directory ||
+            grant.members.some(
+              member =>
+                member.sessionId === metadata.identity.sessionId ||
+                member.kiloSessionId === metadata.auth.kiloSessionId
+            ))
+      )
+    ) {
+      throw new Error('Worktree credential scope mismatch');
+    }
+    const current = await this.readCredentialMetadata(input);
+    if (
+      JSON.stringify([current.identity, current.auth, current.repository, current.workspace]) !==
+      JSON.stringify([metadata.identity, metadata.auth, metadata.repository, metadata.workspace])
+    ) {
+      throw new Error('Session changed during credential preparation');
+    }
+    await this.ctx.storage.transaction(async () => {
+      const currentPhysical = await loadPhysicalRecord(this.ctx.storage);
+      if (
+        (deadlineAt !== undefined && Date.now() >= deadlineAt) ||
+        !sameAllocation(physical, currentPhysical) ||
+        !this.matchesContainment(currentPhysical, WORKTREE_CREDENTIAL_CONTAINMENT)
+      ) {
+        throw new Error('Sandbox changed during credential preparation');
+      }
+      if (terminal) {
+        const currentRuntime = await this.readTerminalRuntime(terminal.access, true);
+        if (
+          !currentRuntime.allowed ||
+          !this.sameTerminalRuntime(currentRuntime, terminal.runtime) ||
+          prepared.grant.scopeId !== terminal.runtime.grant.scopeId ||
+          prepared.grant.kilo.alias !== terminal.runtime.grant.kilo.alias
+        ) {
+          throw new Error('Terminal runtime changed during credential preparation');
+        }
+      }
+      const updated = [...grants.filter(grant => grant.scopeId !== scopeId), prepared.grant];
+      if (provider === 'vercel') await this.ctx.storage.put(CREDENTIAL_POLICY_DIRTY_KEY, true);
+      await saveSessionCredentialGrants(this.ctx.storage, updated);
+      if (provider === 'vercel') {
+        const deadlines = await loadDeadlines(this.ctx.storage);
+        const next = armDeadline(
+          deadlines,
+          'credentialExpiry',
+          Math.min(...updated.map(grant => grant.expiresAt))
+        );
+        await saveDeadlines(this.ctx.storage, next);
+        if (deadlines.credentialExpiry === undefined) {
+          await this.appendLog(deadlineTransition(Date.now(), 'credentialExpiry', 'armed'));
+        }
+        await this.scheduleAlarm(next);
+      }
+    });
+    return prepared.payload;
+  }
+
+  async resolveCredential(input: {
+    credential: string;
+    outboundContainerId: string;
+    url: string;
+    method: string;
+  }): Promise<{ credential: string; organizationId?: string } | null> {
+    return this.withCredentialUpdate(async () => {
+      try {
+        const alias = parseControlPlaneCredential(input.credential);
+        const physical = await loadPhysicalRecord(this.ctx.storage);
+        const native = decodeCloudflareProviderRef(physical.providerRef);
+        if (
+          alias?.sandboxId !== this.sandboxId ||
+          this.providerKind !== 'cloudflare' ||
+          physical.state !== 'running' ||
+          !native ||
+          input.outboundContainerId !==
+            getOutboundContainerId(this.env, native.sandboxId, { managedScmContainment: true })
+        ) {
+          return null;
+        }
+        if (!this.matchesContainment(physical, WORKTREE_CREDENTIAL_CONTAINMENT)) return null;
+        const ownerId = await this.requireOwner();
+        const grants = await loadSessionCredentialGrants(this.ctx.storage);
+        for (const grant of grants) {
+          const expected = alias.purpose === 'kilo' ? grant.kilo.alias : grant.scm?.alias;
+          if (
+            grant.userId !== ownerId ||
+            !expected ||
+            !(await sandboxCredentialMatchesHash(
+              input.credential,
+              await hashSandboxCredential(expected)
+            ))
+          ) {
+            continue;
+          }
+          const resolved = await resolveSessionCredential({ env: this.env, grant, ...input });
+          if (!resolved) return null;
+          return await this.ctx.storage.transaction(async () => {
+            const current = await loadPhysicalRecord(this.ctx.storage);
+            if (
+              current.providerRef !== physical.providerRef ||
+              !sameAllocation(current, physical) ||
+              !this.matchesContainment(current, WORKTREE_CREDENTIAL_CONTAINMENT) ||
+              Date.now() >= resolved.grant.expiresAt
+            ) {
+              return null;
+            }
+            await saveSessionCredentialGrants(
+              this.ctx.storage,
+              grants.map(value => (value.scopeId === grant.scopeId ? resolved.grant : value))
+            );
+            return {
+              credential: resolved.credential,
+              ...(alias.purpose === 'kilo'
+                ? { organizationId: resolved.organizationId ?? '' }
+                : {}),
+            };
+          });
+        }
+        return null;
+      } catch {
+        return null;
+      }
+    });
+  }
+
   async ensureReady(input: {
     ownerId: string;
+    sessionId: string;
     provider?: AgentSandboxProvider;
-    kiloToken?: string;
     allowCreate?: boolean;
     acquisition?: SandboxAcquisition;
     billing?: SandboxBillingInput;
-  }): Promise<SandboxControlStatus> {
+  }): Promise<SandboxControlStatus & { attachment?: SessionAttachPayload }> {
     const acquisition =
       input.acquisition === undefined
         ? undefined
@@ -512,18 +713,96 @@ export class SandboxControl extends DurableObject<Env> {
         physical = await this.observeCurrentProvider(physical);
       }
       if (nextEnsureReadyStep(physical.state, allowCreate) === 'create') {
-        const intentId = crypto.randomUUID();
-        const allocationName = await deriveSandboxAllocationId(this.sandboxId, intentId);
-        physical = await this.claimCreate(intentId, this.provider.resumable, allocationName);
-        creating = true;
+        physical = await this.withCredentialUpdate(async () => {
+          const current = await loadPhysicalRecord(this.ctx.storage, this.provider.resumable);
+          if (nextEnsureReadyStep(current.state, allowCreate) !== 'create') return current;
+          const intentId = crypto.randomUUID();
+          const allocationName = await deriveSandboxAllocationId(this.sandboxId, intentId);
+          const claimed = await this.claimCreate(
+            intentId,
+            this.provider.resumable,
+            allocationName,
+            WORKTREE_CREDENTIAL_CONTAINMENT
+          );
+          creating = true;
+          return claimed;
+        });
       }
     }
     const currentStatus = () =>
       acquisition ? this.acquisitionStatus(acquisition, physical) : this.getStatus();
+    if (creating) this.provider = this.createProviderAdapter(this.providerKind, physical);
+    if (physical.stopTombstone || (physical.state !== 'creating' && physical.state !== 'running')) {
+      return currentStatus();
+    }
+    if (!this.matchesContainment(physical, WORKTREE_CREDENTIAL_CONTAINMENT)) {
+      await this.beginStop('credential_containment_unavailable');
+      await this.recordStopAttempt();
+      return currentStatus();
+    }
+    if (!creating && physical.state === 'running' && physical.providerRef !== null) {
+      await withTimeout(
+        this.provider.ensureBillingAdmission(physical.providerRef, billing),
+        DEADLINE_MS.stopAttempt,
+        'Sandbox billing admission timed out'
+      );
+      const current = await loadPhysicalRecord(this.ctx.storage);
+      if (
+        !sameAllocation(current, physical) ||
+        current.providerRef !== physical.providerRef ||
+        current.state !== 'running' ||
+        current.stopTombstone
+      ) {
+        throw new Error('Sandbox runtime changed during billing admission');
+      }
+    }
+    const preparationDeadline = Math.min(
+      acquisition?.deadlineAt ?? Number.MAX_SAFE_INTEGER,
+      Date.now() + DEADLINE_MS.startup
+    );
+    let attachment: SessionAttachPayload;
+    try {
+      attachment = await withTimeout(
+        this.withCredentialUpdate(() =>
+          withTimeout(
+            this.prepareOwnedSessionCredentials(
+              { ownerId, sessionId: input.sessionId },
+              undefined,
+              preparationDeadline
+            ),
+            Math.max(1, preparationDeadline - Date.now()),
+            'Sandbox credential preparation timed out'
+          )
+        ),
+        Math.max(1, preparationDeadline - Date.now()),
+        'Sandbox credential preparation timed out'
+      );
+    } catch (error) {
+      const current = await loadPhysicalRecord(this.ctx.storage);
+      if (
+        creating &&
+        sameAllocation(current, physical) &&
+        !current.stopTombstone &&
+        (current.state === 'creating' || current.state === 'running')
+      ) {
+        await this.markFailed();
+      }
+      throw error;
+    }
     if (creating) {
       this.provider = this.createProviderAdapter(this.providerKind, physical);
       const intent = physical.createIntent;
       if (!intent) throw new Error('Sandbox create intent is unavailable');
+      const networkPolicy =
+        this.providerKind === 'vercel'
+          ? await this.withCredentialUpdate(async () =>
+              buildControlNetworkPolicy(
+                (await loadSessionCredentialGrants(this.ctx.storage)).filter(
+                  grant => grant.expiresAt > Date.now()
+                )
+              )
+            )
+          : undefined;
       const credential = generateSandboxCredential();
       const credentialHash = await hashSandboxCredential(credential);
       const beforeCreate = await loadPhysicalRecord(this.ctx.storage);
@@ -532,10 +811,15 @@ export class SandboxControl extends DurableObject<Env> {
       }
       await this.ctx.storage.put(CREDENTIAL_HASH_KEY, credentialHash);
       await this.appendLog(credentialTransition(Date.now(), 'issued'));
+      const provider = this.provider;
       try {
         if (acquisition) assertAcquisitionDeadline(acquisition);
         const created = await withTimeout(
-          this.provider.create({ ...intent, ...(billing ? { billing } : {}) }),
+          provider.create({
+            ...intent,
+            ...(billing ? { billing } : {}),
+            ...(networkPolicy ? { networkPolicy } : {}),
+          }),
           DEADLINE_MS.startup,
           'Sandbox allocation timed out'
         );
@@ -556,10 +840,7 @@ export class SandboxControl extends DurableObject<Env> {
           }
           if (acquisition) assertAcquisitionDeadline(acquisition);
           await withTimeout(
-            this.provider.launch(
-              created.providerRef,
-              this.wrapperLaunchEnv(credential, input.kiloToken)
-            ),
+            provider.launch(created.providerRef, this.wrapperLaunchEnv(credential)),
             DEADLINE_MS.startup,
             'Sandbox wrapper launch timed out'
           );
@@ -578,27 +859,25 @@ export class SandboxControl extends DurableObject<Env> {
           await this.markFailed();
         }
       }
-    } else if (
-      physical.state === 'running' &&
-      physical.providerRef !== null &&
-      !physical.stopTombstone
+    }
+    if (
+      this.providerKind === 'vercel' &&
+      (await loadPhysicalRecord(this.ctx.storage)).state === 'running'
     ) {
-      await withTimeout(
-        this.provider.ensureBillingAdmission(physical.providerRef, billing),
-        DEADLINE_MS.stopAttempt,
-        'Sandbox billing admission timed out'
-      );
+      await this.enforceWorktreeNetworkPolicy(ownerId);
+    }
+    const status = await this.ctx.storage.transaction(async () => {
       const current = await loadPhysicalRecord(this.ctx.storage);
       if (
         !sameAllocation(current, physical) ||
-        current.providerRef !== physical.providerRef ||
-        current.state !== 'running' ||
-        current.stopTombstone
+        (physical.providerRef !== null && current.providerRef !== physical.providerRef) ||
+        (acquisition && !(await this.bindAcquisition(acquisition, current)))
       ) {
-        throw new Error('Sandbox runtime changed during billing admission');
+        throw new Error('Sandbox allocation changed during readiness');
       }
-    }
-    return currentStatus();
+      return this.statusForPhysical(current);
+    });
+    return { ...status, attachment };
   }
 
   private async acquirePhysical(acquisition: SandboxAcquisition): Promise<{
@@ -613,7 +892,13 @@ export class SandboxControl extends DurableObject<Env> {
       if (physical.state !== 'stopped' || physical.stopTombstone) {
         return { physical, action: 'wait' };
       }
-      const next = claimCreate(physical, intentId, Date.now(), allocationName);
+      const next = claimCreate(
+        physical,
+        intentId,
+        Date.now(),
+        allocationName,
+        WORKTREE_CREDENTIAL_CONTAINMENT
+      );
       await this.persistPhysicalState(physical, next, 'demand');
       await this.bindAcquisition(acquisition, next);
       return { physical: next, action: 'create' };
@@ -670,23 +955,113 @@ export class SandboxControl extends DurableObject<Env> {
     });
   }
 
-  async attachSession(input: AttachSessionInput): Promise<SessionRoute> {
+  async updateNetworkPolicy(input: {
+    ownerId: string;
+    networkPolicy: VercelSandboxNetworkPolicy;
+    requiredContainment: CredentialContainmentRequirements;
+  }): Promise<void> {
     const ownerId = await this.requireOwner();
-    const table = await loadRouteTable(this.ctx.storage);
-    const result = attachRoute(table, input, ownerId);
-    await saveRouteTable(this.ctx.storage, result.table);
-    if (result.changed) {
-      await this.appendLog(
-        routeTransition(Date.now(), 'attach', input.sessionId, input.kiloSessionId)
-      );
+    if (ownerId !== input.ownerId) {
+      throw new Error('Sandbox owner mismatch');
     }
-    return result.route;
+    const providerKind = await this.ctx.storage.get<AgentSandboxProvider>(PROVIDER_KIND_KEY);
+    if (providerKind !== 'vercel') {
+      throw new Error('Sandbox network policy requires a Vercel provider');
+    }
+    const physical = await loadPhysicalRecord(this.ctx.storage);
+    if (physical.state !== 'running' || physical.providerRef === null) {
+      throw new Error('Sandbox network policy requires a running instance');
+    }
+    const providerRef = physical.providerRef;
+    if (!this.matchesProviderReference(physical, providerRef)) {
+      throw new Error('Sandbox network policy requires an exact provider reference');
+    }
+    if (
+      (!input.requiredContainment.kilocode && !input.requiredContainment.github) ||
+      !this.matchesContainment(physical, input.requiredContainment)
+    ) {
+      throw new Error('Sandbox credential containment mismatch');
+    }
+    const provider = this.provider;
+    if (!provider.updateNetworkPolicy) {
+      throw new Error('Sandbox provider does not support network policy updates');
+    }
+    await withTimeout(
+      provider.updateNetworkPolicy(providerRef, input.networkPolicy),
+      DEADLINE_MS.stopAttempt,
+      'Sandbox network policy update timed out'
+    );
+
+    const currentProviderKind = await this.ctx.storage.get<AgentSandboxProvider>(PROVIDER_KIND_KEY);
+    const currentPhysical = await loadPhysicalRecord(this.ctx.storage);
+    const currentOwnerId = await this.readOwner();
+    if (
+      currentProviderKind !== 'vercel' ||
+      currentOwnerId !== ownerId ||
+      currentPhysical.state !== 'running' ||
+      currentPhysical.providerRef !== providerRef ||
+      !this.matchesContainment(currentPhysical, input.requiredContainment)
+    ) {
+      throw new Error('Sandbox instance changed during network policy update');
+    }
+  }
+
+  async attachSession(input: AttachSessionInput): Promise<SessionRoute> {
+    return this.withCredentialUpdate(async () => {
+      const ownerId = await this.requireOwner();
+      const grants = await loadSessionCredentialGrants(this.ctx.storage);
+      const grant = grants.find(
+        value =>
+          value.userId === ownerId &&
+          value.directory === input.directory &&
+          value.expiresAt > Date.now() &&
+          value.members.some(
+            member =>
+              member.sessionId === input.sessionId && member.kiloSessionId === input.kiloSessionId
+          )
+      );
+      const worktreeId = grant?.scopeId.startsWith('worktree_') ? grant.scopeId : undefined;
+      if (!grant || worktreeId !== input.worktreeId) {
+        throw new Error('Session has no matching worktree credential grant');
+      }
+      const table = await loadRouteTable(this.ctx.storage);
+      const result = attachRoute(table, input, ownerId);
+      await saveRouteTable(this.ctx.storage, result.table);
+      if (result.changed) {
+        await this.appendLog(
+          routeTransition(Date.now(), 'attach', input.sessionId, input.kiloSessionId)
+        );
+      }
+      return result.route;
+    });
   }
 
   async detachSession(sessionId: string): Promise<{ existed: boolean }> {
-    const table = await loadRouteTable(this.ctx.storage);
-    const result = detachRoute(table, sessionId);
-    await saveRouteTable(this.ctx.storage, result.table);
+    const result = await this.withCredentialUpdate(async () => {
+      const table = await loadRouteTable(this.ctx.storage);
+      const detached = detachRoute(table, sessionId);
+      await saveRouteTable(this.ctx.storage, detached.table);
+      const grants = await loadSessionCredentialGrants(this.ctx.storage);
+      const credentialsChanged = grants.some(grant =>
+        grant.members.some(member => member.sessionId === sessionId)
+      );
+      if (credentialsChanged) {
+        if (this.providerKind === 'vercel') {
+          await this.ctx.storage.put(CREDENTIAL_POLICY_DIRTY_KEY, true);
+        }
+        await saveSessionCredentialGrants(
+          this.ctx.storage,
+          removeSessionCredentialMembership(grants, sessionId)
+        );
+      }
+      return detached;
+    });
+    if (
+      this.providerKind === 'vercel' &&
+      (await this.ctx.storage.get<boolean>(CREDENTIAL_POLICY_DIRTY_KEY))
+    ) {
+      await this.enforceWorktreeNetworkPolicy(await this.requireOwner());
+    }
     if (result.existed) {
       await this.appendLog(routeTransition(Date.now(), 'detach', sessionId));
     }
@@ -707,23 +1082,25 @@ export class SandboxControl extends DurableObject<Env> {
   async validateTerminalAccess(
     input: SandboxTerminalAccessInput
   ): Promise<SandboxTerminalAccessResult> {
-    const runtime = await this.readTerminalRuntime(input);
+    const runtime = await this.readTerminalRuntime(input, true);
     if (!runtime.allowed) return runtime;
 
     const enforced = isCloudAgentContainerBillingEnabled(this.env, {
       userId: input.ownerId,
       ...(input.organizationId ? { orgId: input.organizationId } : {}),
     });
-    if (!enforced) return { allowed: true };
+    if (!enforced) return this.renewTerminalCredentialLease(input, runtime);
     if (runtime.provider !== 'cloudflare') {
       return { allowed: false, reason: 'billing_policy_unavailable' };
     }
 
     let billing: SandboxTerminalAccessResult;
     try {
-      const allocationId = runtime.physical.providerRef;
+      const allocationId = decodeCloudflareProviderRef(runtime.physical.providerRef)?.sandboxId;
       if (!allocationId) return { allowed: false, reason: 'runtime_not_running' };
-      const namespace = getSandboxNamespace(this.env, allocationId);
+      const namespace = getSandboxNamespace(this.env, allocationId, {
+        managedScmContainment: true,
+      });
       const sandbox = getSandbox(namespace, allocationId);
       billing = validateTerminalBillingRuntime({
         access: input,
@@ -741,18 +1118,59 @@ export class SandboxControl extends DurableObject<Env> {
     }
     if (!billing.allowed) return billing;
 
-    const current = await this.readTerminalRuntime(input);
+    const current = await this.readTerminalRuntime(input, true);
     if (!current.allowed) return current;
-    if (
-      !this.sameConnection(current.connection, runtime.connection) ||
-      current.provider !== runtime.provider ||
-      current.physical.providerRef !== runtime.physical.providerRef ||
-      current.route.kiloSessionId !== runtime.route.kiloSessionId ||
-      current.route.directory !== runtime.route.directory
-    ) {
+    if (!this.sameTerminalRuntime(current, runtime)) {
       return { allowed: false, reason: 'runtime_changed' };
     }
-    return { allowed: true };
+    return this.renewTerminalCredentialLease(input, current);
+  }
+
+  private sameTerminalRuntime(
+    left: TerminalRuntimeSnapshot,
+    right: TerminalRuntimeSnapshot
+  ): boolean {
+    return (
+      this.sameConnection(left.connection, right.connection) &&
+      left.provider === right.provider &&
+      left.physical.providerRef === right.physical.providerRef &&
+      left.route.kiloSessionId === right.route.kiloSessionId &&
+      left.route.directory === right.route.directory &&
+      left.grant.scopeId === right.grant.scopeId &&
+      left.grant.kilo.alias === right.grant.kilo.alias
+    );
+  }
+
+  private async renewTerminalCredentialLease(
+    input: SandboxTerminalAccessInput,
+    runtime: TerminalRuntimeSnapshot
+  ): Promise<SandboxTerminalAccessResult> {
+    if (runtime.grant.expiresAt > Date.now() + TERMINAL_CREDENTIAL_RENEWAL_WINDOW_MS) {
+      return { allowed: true };
+    }
+    try {
+      await this.withCredentialUpdate(async () => {
+        const current = await this.readTerminalRuntime(input, true);
+        if (!current.allowed || !this.sameTerminalRuntime(current, runtime)) {
+          throw new Error('Terminal runtime changed before credential renewal');
+        }
+        if (current.grant.expiresAt > Date.now() + TERMINAL_CREDENTIAL_RENEWAL_WINDOW_MS) return;
+        await this.prepareOwnedSessionCredentials(
+          { ownerId: input.ownerId, sessionId: input.sessionId },
+          { access: input, runtime: current }
+        );
+      });
+      if (runtime.provider === 'vercel') {
+        await this.enforceWorktreeNetworkPolicy(input.ownerId);
+      }
+    } catch {
+      return { allowed: false, reason: 'credential_scope_unavailable' };
+    }
+    const current = await this.readTerminalRuntime(input);
+    if (!current.allowed) return current;
+    return this.sameTerminalRuntime(current, runtime)
+      ? { allowed: true }
+      : { allowed: false, reason: 'runtime_changed' };
   }
 
   async recordTerminalActivity(
@@ -809,11 +1227,12 @@ export class SandboxControl extends DurableObject<Env> {
   async claimCreate(
     intentId: string,
     resumable = false,
-    allocationName?: string
+    allocationName?: string,
+    containment?: CredentialContainmentRequirements
   ): Promise<PhysicalRecord> {
     return this.ctx.storage.transaction(async () => {
       const current = await loadPhysicalRecord(this.ctx.storage, resumable);
-      const next = claimCreate(current, intentId, Date.now(), allocationName);
+      const next = claimCreate(current, intentId, Date.now(), allocationName, containment);
       const vercel =
         this.providerKind === 'vercel' ? parseVercelSandboxRuntimeConfig(this.env) : undefined;
       if (vercel && next.createIntent) {
@@ -1019,24 +1438,127 @@ export class SandboxControl extends DurableObject<Env> {
       PROVIDER_KIND_KEY,
       BILLING_INPUT_KEY,
       ACQUISITION_RECEIPTS_KEY,
+      CREDENTIAL_POLICY_DIRTY_KEY,
     ]);
+  }
+
+  private withCredentialUpdate<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.credentialUpdates.then(operation);
+    this.credentialUpdates = result.then(
+      () => undefined,
+      () => undefined
+    );
+    return result;
+  }
+
+  private async readCredentialMetadata(input: {
+    ownerId: string;
+    sessionId: string;
+  }): Promise<SessionMetadata> {
+    if (typeof input.sessionId !== 'string' || !input.sessionId.startsWith('workspace_')) {
+      throw new Error('Control-plane session credentials are required');
+    }
+    const metadata = await withDORetry<
+      ReturnType<typeof getSandboxSessionStub>,
+      SessionMetadata | null
+    >(
+      () => getSandboxSessionStub(this.env, input.ownerId, input.sessionId),
+      stub => stub.getCredentialMetadata(),
+      'getCredentialMetadata'
+    );
+    if (
+      !metadata ||
+      metadata.identity.userId !== input.ownerId ||
+      metadata.identity.sessionId !== input.sessionId ||
+      metadata.workspace?.sandboxId !== this.sandboxId
+    ) {
+      throw new Error('Session credential ownership mismatch');
+    }
+    return metadata;
+  }
+
+  private async scheduleCredentialExpiry(grants: SessionCredentialGrant[]): Promise<void> {
+    const expiry = Math.min(...grants.map(grant => grant.expiresAt));
+    if (Number.isFinite(expiry)) {
+      await this.armDeadlineAndAlarm('credentialExpiry', expiry);
+    } else {
+      await this.cancelDeadlineAndAlarm('credentialExpiry');
+    }
+  }
+
+  private refreshWorktreeNetworkPolicy(ownerId: string): Promise<void> {
+    return this.withCredentialUpdate(async () => {
+      if (this.providerKind !== 'vercel') return;
+      await this.ctx.storage.put(CREDENTIAL_POLICY_DIRTY_KEY, true);
+      const physical = await loadPhysicalRecord(this.ctx.storage);
+      if (physical.state === 'stopped') {
+        await this.ctx.storage.delete(CREDENTIAL_POLICY_DIRTY_KEY);
+        return;
+      }
+      if (physical.state !== 'running') {
+        throw new Error('Sandbox credential policy is unavailable');
+      }
+      const grants = await loadSessionCredentialGrants(this.ctx.storage);
+      const now = Date.now();
+      const authorized = grants.filter(grant => grant.preparedAt <= now && grant.expiresAt > now);
+      await this.updateNetworkPolicy({
+        ownerId,
+        networkPolicy: buildControlNetworkPolicy(authorized),
+        requiredContainment: WORKTREE_CREDENTIAL_CONTAINMENT,
+      });
+      await this.scheduleCredentialExpiry(authorized);
+      await this.ctx.storage.delete(CREDENTIAL_POLICY_DIRTY_KEY);
+    });
+  }
+
+  private async enforceWorktreeNetworkPolicy(ownerId: string): Promise<void> {
+    const expected = await loadPhysicalRecord(this.ctx.storage);
+    try {
+      await this.refreshWorktreeNetworkPolicy(ownerId);
+    } catch {
+      let physical = await loadPhysicalRecord(this.ctx.storage);
+      if (
+        !sameAllocation(physical, expected) ||
+        (expected.providerRef !== null && physical.providerRef !== expected.providerRef)
+      ) {
+        return;
+      }
+      if (physical.state === 'running' || physical.state === 'creating') {
+        physical = await this.markFailed();
+      }
+      if (physical.state === 'failed') {
+        physical = await this.releaseIfAuthoritativelyDead(physical);
+      }
+      if (physical.state !== 'stopped') {
+        throw new Error('Sandbox credential revocation is pending');
+      }
+    }
   }
 
   private createProviderAdapter(
     kind: AgentSandboxProvider,
     physical?: PhysicalRecord
   ): ProviderAdapter {
+    const allocationName = physical?.createIntent?.allocationName ?? this.sandboxId;
     if (kind === 'vercel') {
       return createVercelProviderAdapter({
-        sandboxName: this.sandboxId,
+        sandboxName: allocationName,
         config: resolveVercelSandboxRuntimeConfig(this.env, physical?.createIntent?.vercel),
       });
     }
     return createCloudflareProviderAdapter({
-      sandboxId: this.sandboxId,
-      getSandbox: id => getSandbox(getSandboxNamespace(this.env, id), id),
-      destroy: id =>
-        forceDestroyControlPlaneSandbox(getSandboxNamespace(this.env, id).getByName(id)),
+      sandboxId: allocationName,
+      getSandbox: (id, options) =>
+        getSandbox(
+          getSandboxNamespace(this.env, id, { managedScmContainment: options.containment }),
+          id
+        ),
+      destroy: (id, options) =>
+        forceDestroyControlPlaneSandbox(
+          getSandboxNamespace(this.env, id, {
+            managedScmContainment: options.containment,
+          }).getByName(id)
+        ),
     });
   }
 
@@ -1096,14 +1618,54 @@ export class SandboxControl extends DurableObject<Env> {
     return billing;
   }
 
-  private wrapperLaunchEnv(credential: string, kiloToken?: string): Record<string, string> {
+  private wrapperLaunchEnv(credential: string): Record<string, string> {
     return buildControlWrapperLaunchEnv({
       workerUrl: this.env.WORKER_URL,
       sandboxId: this.sandboxId,
       credential,
-      kiloToken,
-      kiloTargetEnv: this.env,
     });
+  }
+
+  private matchesProviderReference(physical: PhysicalRecord, providerRef: string): boolean {
+    if (physical.providerRef !== null && physical.providerRef !== providerRef) return false;
+    const allocationName = physical.createIntent?.allocationName ?? this.sandboxId;
+    if (this.providerKind === 'vercel') {
+      return decodeVercelProviderRef(providerRef)?.sandboxName === allocationName;
+    }
+    const native = decodeCloudflareProviderRef(providerRef);
+    return (
+      native?.sandboxId === allocationName &&
+      (!physical.createIntent || native.instanceId === physical.createIntent.intentId)
+    );
+  }
+
+  private matchesContainment(
+    physical: PhysicalRecord,
+    requiredContainment: CredentialContainmentRequirements
+  ): boolean {
+    if (physical.stopTombstone) return false;
+    if (physical.state === 'creating') {
+      const containment = physical.createIntent?.containment;
+      return (
+        containment !== undefined &&
+        containment.kilocode === requiredContainment.kilocode &&
+        containment.github === requiredContainment.github &&
+        containment.worktreeScoped === requiredContainment.worktreeScoped
+      );
+    }
+    if (physical.state !== 'running' || physical.providerRef === null) {
+      return false;
+    }
+    const referenceMatches = this.matchesProviderReference(physical, physical.providerRef);
+    const containment = physical.containment;
+    return (
+      referenceMatches &&
+      containment !== undefined &&
+      containment.providerRef === physical.providerRef &&
+      containment.kilocode === requiredContainment.kilocode &&
+      containment.github === requiredContainment.github &&
+      containment.worktreeScoped === requiredContainment.worktreeScoped
+    );
   }
 
   private async exhaustStop(): Promise<PhysicalRecord> {
@@ -1142,6 +1704,14 @@ export class SandboxControl extends DurableObject<Env> {
       await this.recordStopAttempt();
       return;
     }
+    if (id === 'credentialExpiry') {
+      try {
+        await this.enforceWorktreeNetworkPolicy(await this.requireOwner());
+      } catch {
+        await this.armDeadlineAndAlarm('credentialExpiry', Date.now() + DEADLINE_MS.reconciliation);
+      }
+      return;
+    }
     if (id === 'reconciliation') {
       const physical = await loadPhysicalRecord(this.ctx.storage);
       if (this.shouldSlowReap(physical)) {
@@ -1152,6 +1722,15 @@ export class SandboxControl extends DurableObject<Env> {
     }
   }
 
+  private async validateHandshake(providerInstanceId: string): Promise<boolean> {
+    const physical = await loadPhysicalRecord(this.ctx.storage);
+    return (
+      (this.providerKind !== 'vercel' || physical.state === 'running') &&
+      this.matchesProviderReference(physical, providerInstanceId) &&
+      this.matchesContainment(physical, WORKTREE_CREDENTIAL_CONTAINMENT)
+    );
+  }
+
   private async onHandshakeComplete(identity: SandboxControlConnectionIdentity): Promise<void> {
     const socketConnection = this.socketHandler.getConnectionIdentity();
     if (!socketConnection || !this.sameConnection(socketConnection, identity)) return;
@@ -1160,10 +1739,9 @@ export class SandboxControl extends DurableObject<Env> {
     if (
       physical.stopTombstone ||
       (physical.state !== 'running' && physical.state !== 'creating') ||
-      (physical.providerRef !== null && physical.providerRef !== identity.providerInstanceId) ||
-      (this.providerKind === 'cloudflare' &&
-        physical.createIntent?.allocationName !== undefined &&
-        physical.createIntent.allocationName !== identity.providerInstanceId)
+      (this.providerKind === 'vercel' && physical.state !== 'running') ||
+      !this.matchesProviderReference(physical, identity.providerInstanceId) ||
+      !this.matchesContainment(physical, WORKTREE_CREDENTIAL_CONTAINMENT)
     ) {
       this.socketHandler.closeAll('Sandbox runtime unavailable');
       return;
@@ -1555,7 +2133,8 @@ export class SandboxControl extends DurableObject<Env> {
   }
 
   private async readTerminalRuntime(
-    input: SandboxTerminalAccessInput
+    input: SandboxTerminalAccessInput,
+    allowExpiredCredentials = false
   ): Promise<TerminalRuntimeSnapshot | TerminalRuntimeRejection> {
     if (
       typeof input.sessionId !== 'string' ||
@@ -1571,10 +2150,11 @@ export class SandboxControl extends DurableObject<Env> {
       return { allowed: false, reason: 'invalid_terminal_access' };
     }
 
-    const [ownerId, routes, physical] = await Promise.all([
+    const [ownerId, routes, physical, grants] = await Promise.all([
       this.readOwner(),
       loadRouteTable(this.ctx.storage),
       loadPhysicalRecord(this.ctx.storage),
+      loadSessionCredentialGrants(this.ctx.storage),
     ]);
     if (ownerId !== input.ownerId) return { allowed: false, reason: 'owner_mismatch' };
     const route = routes.get(input.sessionId);
@@ -1584,6 +2164,24 @@ export class SandboxControl extends DurableObject<Env> {
     if (physical.state !== 'running' || physical.stopTombstone || physical.providerRef === null) {
       return { allowed: false, reason: 'runtime_not_running' };
     }
+    if (!this.matchesContainment(physical, WORKTREE_CREDENTIAL_CONTAINMENT)) {
+      return { allowed: false, reason: 'credential_containment_unavailable' };
+    }
+    const grant = grants.find(
+      grant =>
+        grant.userId === input.ownerId &&
+        grant.orgId === input.organizationId &&
+        grant.sandboxId === this.sandboxId &&
+        grant.provider === this.providerKind &&
+        grant.directory === route.directory &&
+        grant.preparedAt <= Date.now() &&
+        (allowExpiredCredentials || grant.expiresAt > Date.now()) &&
+        grant.members.some(
+          member =>
+            member.sessionId === input.sessionId && member.kiloSessionId === route.kiloSessionId
+        )
+    );
+    if (!grant) return { allowed: false, reason: 'credential_scope_unavailable' };
 
     const connection = this.readyWrapperRuntime();
     if (!connection) return { allowed: false, reason: 'runtime_not_ready' };
@@ -1594,7 +2192,7 @@ export class SandboxControl extends DurableObject<Env> {
       return { allowed: false, reason: 'wrapper_instance_mismatch' };
     }
 
-    return { allowed: true, connection, physical, provider: this.providerKind, route };
+    return { allowed: true, connection, physical, provider: this.providerKind, route, grant };
   }
 
   private connectionState(): ConnectionState {
@@ -1706,6 +2304,10 @@ export class SandboxControl extends DurableObject<Env> {
     const unavailable =
       to.stopTombstone !== null || (to.state !== 'creating' && to.state !== 'running');
     await savePhysicalRecord(this.ctx.storage, to);
+    if (to.state === 'stopped') {
+      await saveSessionCredentialGrants(this.ctx.storage, []);
+      await this.ctx.storage.delete(CREDENTIAL_POLICY_DIRTY_KEY);
+    }
     if (changed) {
       await this.appendLog(
         physicalTransition(Date.now(), from.state, to.state, cause, to.providerRef)
@@ -1714,6 +2316,13 @@ export class SandboxControl extends DurableObject<Env> {
     const deadlines = await loadDeadlines(this.ctx.storage);
     let next = deadlines;
     if (to.state === 'creating') {
+      if (from.state === 'stopped') {
+        await this.ctx.storage.delete([
+          CREDENTIAL_HASH_KEY,
+          ACTIVE_WRAPPER_RUNTIME_KEY,
+          WRAPPER_READY_AT_KEY,
+        ]);
+      }
       next = { startup: (to.createIntent?.createdAt ?? Date.now()) + DEADLINE_MS.startup };
     } else if (to.state === 'running' && from.state === 'unknown' && !unavailable) {
       const id = this.connectionState() === 'ready' ? 'heartbeatExpiry' : 'wrapperReadiness';
@@ -1750,6 +2359,9 @@ export class SandboxControl extends DurableObject<Env> {
           }
         }
       }
+    }
+    if (to.state !== 'stopped' && deadlines.credentialExpiry !== undefined) {
+      next = armDeadline(next, 'credentialExpiry', deadlines.credentialExpiry);
     }
     await saveDeadlines(this.ctx.storage, next);
     await this.scheduleAlarm(next);

--- a/services/cloud-agent-next/src/persistence/SandboxControl.ts
+++ b/services/cloud-agent-next/src/persistence/SandboxControl.ts
@@ -1529,6 +1529,17 @@ export class SandboxControl extends DurableObject<Env> {
       if (physical.state === 'failed') {
         physical = await this.releaseIfAuthoritativelyDead(physical);
       }
+      if (
+        this.providerKind === 'vercel' &&
+        physical.state === 'unknown' &&
+        physical.stopTombstone &&
+        physical.stopTombstone.attempts >= DEADLINE_MS.stopAttemptLadder.length &&
+        Date.now() >= physical.stopTombstone.createdAt + DEADLINE_MS.reconciliationWindow
+      ) {
+        const observed = await this.observeCurrentProvider(physical);
+        if (!sameAllocation(physical, observed)) return;
+        physical = observed;
+      }
       if (physical.state !== 'stopped') {
         throw new Error('Sandbox credential revocation is pending');
       }

--- a/services/cloud-agent-next/src/persistence/session-metadata.test.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.test.ts
@@ -81,6 +81,153 @@ describe('session metadata boundary', () => {
     expect(requiresContainmentSandbox(metadata)).toBe(false);
   });
 
+  describe.each(['cloudflare', 'vercel'] as const)(
+    '%s control-plane containment',
+    sandboxProvider => {
+      it.each([
+        {
+          name: 'GitHub',
+          repository: { type: 'github', repo: 'acme/repo' },
+          expected: { github: true, gitlab: false, bitbucket: false, kilocode: true },
+        },
+        {
+          name: 'GitLab',
+          repository: { type: 'gitlab', url: 'https://gitlab.com/acme/repo.git' },
+          expected: { github: false, gitlab: true, bitbucket: false, kilocode: true },
+        },
+        {
+          name: 'Bitbucket',
+          repository: {
+            type: 'bitbucket',
+            url: 'https://bitbucket.org/acme/repo.git',
+            workspaceUuid: '123e4567-e89b-12d3-a456-426614174000',
+            repositoryUuid: '123e4567-e89b-12d3-a456-426614174001',
+          },
+          expected: { github: false, gitlab: false, bitbucket: true, kilocode: true },
+        },
+        {
+          name: 'generic Git with a GitHub platform alias',
+          repository: { type: 'git', url: 'https://github.com/acme/repo.git', platform: 'github' },
+          expected: { github: false, gitlab: false, bitbucket: false, kilocode: true },
+        },
+        {
+          name: 'generic Git with a GitLab platform alias',
+          repository: { type: 'git', url: 'https://gitlab.com/acme/repo.git', platform: 'gitlab' },
+          expected: { github: false, gitlab: false, bitbucket: false, kilocode: true },
+        },
+        {
+          name: 'no repository',
+          repository: undefined,
+          expected: { github: false, gitlab: false, bitbucket: false, kilocode: true },
+        },
+      ])(
+        'requires only Kilo and the typed $name repository despite false metadata',
+        ({ repository, expected }) => {
+          const workspace = {
+            sandboxId: 'ses-abcdef',
+            sandboxProvider,
+            credentialContainment: {
+              github: false,
+              gitlab: false,
+              bitbucket: false,
+              kilocode: false,
+            },
+            managedScmContainment: true,
+          };
+          const metadata = parseSessionMetadata({
+            metadataSchemaVersion: 2,
+            identity: { sessionId: 'workspace_containment', userId: 'user_containment' },
+            auth: {},
+            repository,
+            workspace,
+            lifecycle: { version: 1, timestamp: 1 },
+          });
+
+          expect(getEffectiveCredentialContainment(metadata)).toEqual(expected);
+          expect(requiresContainmentSandbox(metadata)).toBe(true);
+          expect(serializeSessionMetadata(metadata).workspace).toEqual(workspace);
+        }
+      );
+
+      it.each([
+        { name: 'missing policy', fields: {} },
+        { name: 'disabled legacy alias', fields: { managedScmContainment: false } },
+        { name: 'enabled legacy alias', fields: { managedScmContainment: true } },
+        {
+          name: 'mixed policy',
+          fields: {
+            credentialContainment: {
+              github: false,
+              gitlab: true,
+              bitbucket: true,
+              kilocode: false,
+            },
+            managedScmContainment: false,
+          },
+        },
+      ])('ignores $name without rewriting stored fields', ({ fields }) => {
+        const workspace = { sandboxId: 'ses-abcdef', sandboxProvider, ...fields };
+        const metadata = parseSessionMetadata({
+          metadataSchemaVersion: 2,
+          identity: { sessionId: 'workspace_containment', userId: 'user_containment' },
+          auth: {},
+          repository: { type: 'gitlab', url: 'https://gitlab.com/acme/repo.git' },
+          workspace,
+          lifecycle: { version: 1, timestamp: 1 },
+        });
+
+        expect(getEffectiveCredentialContainment(metadata)).toEqual({
+          github: false,
+          gitlab: true,
+          bitbucket: false,
+          kilocode: true,
+        });
+        expect(requiresContainmentSandbox(metadata)).toBe(true);
+        expect(serializeSessionMetadata(metadata).workspace).toEqual(workspace);
+      });
+    }
+  );
+
+  it('requires Kilo containment for a control-plane session without workspace metadata', () => {
+    const metadata = parseSessionMetadata({
+      metadataSchemaVersion: 2,
+      identity: { sessionId: 'workspace_no_workspace', userId: 'user_containment' },
+      auth: {},
+      lifecycle: { version: 1, timestamp: 1 },
+    });
+
+    expect(getEffectiveCredentialContainment(metadata)).toEqual({
+      github: false,
+      gitlab: false,
+      bitbucket: false,
+      kilocode: true,
+    });
+    expect(requiresContainmentSandbox(metadata)).toBe(true);
+    expect(metadata.workspace).toBeUndefined();
+  });
+
+  it('preserves legacy policy even when its SCM flags do not match the repository', () => {
+    const metadata = parseSessionMetadata({
+      metadataSchemaVersion: 2,
+      identity: { sessionId: 'agent_mixed_containment', userId: 'user_containment' },
+      auth: {},
+      repository: { type: 'github', repo: 'acme/repo' },
+      workspace: {
+        credentialContainment: { github: false, gitlab: true, bitbucket: true, kilocode: false },
+        managedScmContainment: true,
+      },
+      lifecycle: { version: 1, timestamp: 1 },
+    });
+
+    expect(getEffectiveCredentialContainment(metadata)).toEqual({
+      github: false,
+      gitlab: true,
+      bitbucket: true,
+      kilocode: false,
+    });
+    expect(requiresContainmentSandbox(metadata)).toBe(true);
+  });
+
   it('parses and serializes current grouped metadata with canonical attachments', () => {
     const current = {
       metadataSchemaVersion: 2 as const,

--- a/services/cloud-agent-next/src/persistence/session-metadata.ts
+++ b/services/cloud-agent-next/src/persistence/session-metadata.ts
@@ -3,6 +3,7 @@ import { sessionIdSchema as kiloSessionIdSchema } from '@kilocode/session-ingest
 
 import { PROVIDER_CAPABILITIES } from '../agent-sandbox/capabilities.js';
 import { isGeneratedSharedSandboxId, isValidSandboxId } from '../sandbox-id.js';
+import { sessionPlaneFromId } from '../session-plane.js';
 import { SHARED_SANDBOX_FAILOVER_SUFFIX } from '../shared-sandbox-route.js';
 import { MESSAGE_ID_FORMAT_DESCRIPTION, MESSAGE_ID_PATTERN } from '../session/message-id.js';
 import { type AgentSandboxProvider, type SandboxId } from '../types.js';
@@ -236,6 +237,10 @@ const MetadataWorkspaceSchema = z
     sandboxProvider: SandboxProviderSchema.optional(),
     providerRuntime: ProviderRuntimeSchema.optional(),
     workspacePath: z.string().optional(),
+    worktreeId: z
+      .string()
+      .regex(/^worktree_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i)
+      .optional(),
     sessionHome: z.string().optional(),
     branchName: z.string().optional(),
     shallow: z.boolean().optional(),
@@ -346,9 +351,27 @@ export const CurrentSessionMetadataSchema = z
 export type SessionMetadata = z.infer<typeof CurrentSessionMetadataSchema>;
 export type CredentialContainment = z.infer<typeof CredentialContainmentSchema>;
 
+export function getControlPlaneCredentialContainment(
+  sessionId: string,
+  repository: SessionMetadata['repository']
+): CredentialContainment | undefined {
+  if (sessionPlaneFromId(sessionId) !== 'control') return undefined;
+  return {
+    github: repository?.type === 'github',
+    gitlab: repository?.type === 'gitlab',
+    bitbucket: repository?.type === 'bitbucket',
+    kilocode: true,
+  };
+}
+
 export function getEffectiveCredentialContainment(
   metadata: SessionMetadata
 ): CredentialContainment {
+  const controlPlaneContainment = getControlPlaneCredentialContainment(
+    metadata.identity.sessionId,
+    metadata.repository
+  );
+  if (controlPlaneContainment) return controlPlaneContainment;
   if (metadata.workspace?.credentialContainment) {
     return metadata.workspace.credentialContainment;
   }

--- a/services/cloud-agent-next/src/sandbox-control/cloudflare-provider.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/cloudflare-provider.test.ts
@@ -5,25 +5,43 @@ import {
   parseSandboxBillingInput,
   type MeteredSandboxInstance,
 } from '../container-usage-context.js';
-import { deriveSandboxAllocationId } from '../sandbox-id.js';
-import { createCloudflareProviderAdapter } from './cloudflare-provider.js';
+import {
+  createCloudflareProviderAdapter,
+  decodeCloudflareProviderRef,
+  encodeCloudflareProviderRef,
+  type CloudflareSandboxHandle,
+} from './cloudflare-provider.js';
 import { DEADLINE_MS } from './deadlines.js';
+import { WORKTREE_CREDENTIAL_CONTAINMENT } from './physical-lifecycle.js';
+import { deriveSandboxAllocationId } from '../sandbox-id.js';
 
-function fakeSandbox(overrides: Partial<MeteredSandboxInstance> = {}): MeteredSandboxInstance {
+const PROVIDER_REF = encodeCloudflareProviderRef({
+  sandboxId: 'sbx_1',
+  containment: true,
+  instanceId: 'op_1',
+});
+
+function fakeSandbox(overrides: Partial<MeteredSandboxInstance> = {}): CloudflareSandboxHandle {
   return {
     renewActivityTimeout: () => undefined,
     destroy: async () => undefined,
     isContainerRunning: async () => true,
+    setOutboundHandler: async () => undefined,
     startProcess: async () => ({ id: 'proc_1' }),
     configureBilling: async () => undefined,
     isBillingBlocked: async () => false,
     ensureBillingAdmission: async () => ({ success: true }),
     ...overrides,
-  } as MeteredSandboxInstance;
+  } as unknown as CloudflareSandboxHandle;
 }
 
 const logicalId = 'ses-abcdef';
-const intent = { intentId: 'op_1', createdAt: 1_000, allocationName: 'ses-123abc' };
+const intent = {
+  intentId: 'op_1',
+  createdAt: 1_000,
+  allocationName: 'ses-123abc',
+  containment: WORKTREE_CREDENTIAL_CONTAINMENT,
+};
 const billing = parseSandboxBillingInput({
   sandboxId: logicalId,
   subject: { type: 'user', id: 'owner_1' },
@@ -38,22 +56,29 @@ afterEach(() => vi.useRealTimers());
 describe('cloudflare provider adapter', () => {
   it('returns the physical identity without waking, then launches against that identity', async () => {
     const startProcess = vi.fn().mockResolvedValue({ id: 'proc_1' });
-    const getSandbox = vi.fn(() => fakeSandbox({ startProcess }));
+    const setOutboundHandler = vi.fn().mockResolvedValue(undefined);
+    const getSandbox = vi.fn(() => fakeSandbox({ startProcess, setOutboundHandler }));
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       getSandbox,
       destroy: async () => undefined,
     });
+    const providerRef = encodeCloudflareProviderRef({
+      sandboxId: intent.allocationName,
+      containment: true,
+      instanceId: intent.intentId,
+    });
     const created = await provider.create(intent);
-    expect(created).toEqual({ providerRef: intent.allocationName });
+    expect(created).toEqual({ providerRef });
     expect(getSandbox).not.toHaveBeenCalled();
     expect(startProcess).not.toHaveBeenCalled();
 
-    await provider.launch(intent.allocationName, {
+    await provider.launch(providerRef, {
       SANDBOX_CONTROL_URL: `wss://example.test/sandbox-control/${logicalId}`,
       SANDBOX_CONTROL_CREDENTIAL: 'test-credential',
     });
-    expect(getSandbox).toHaveBeenCalledWith(intent.allocationName);
+    expect(getSandbox).toHaveBeenCalledWith(intent.allocationName, { containment: true });
+    expect(setOutboundHandler).toHaveBeenCalledWith('managedScm');
     expect(startProcess).toHaveBeenCalledWith(
       'bun run /usr/local/bin/kilocode-control-wrapper.js',
       {
@@ -61,7 +86,7 @@ describe('cloudflare provider adapter', () => {
         env: {
           SANDBOX_CONTROL_URL: `wss://example.test/sandbox-control/${logicalId}`,
           SANDBOX_CONTROL_CREDENTIAL: 'test-credential',
-          PROVIDER_INSTANCE_ID: intent.allocationName,
+          PROVIDER_INSTANCE_ID: providerRef,
           WRAPPER_LOG_PATH: '/tmp/kilocode-control-wrapper.log',
         },
       }
@@ -76,7 +101,7 @@ describe('cloudflare provider adapter', () => {
       message: 'not enough credits',
     });
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       destroy: async () => undefined,
       getSandbox: () => fakeSandbox({ startProcess, ensureBillingAdmission }),
     });
@@ -93,7 +118,7 @@ describe('cloudflare provider adapter', () => {
     const sandbox = fakeSandbox({ startProcess });
     Reflect.deleteProperty(sandbox, 'ensureBillingAdmission');
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       destroy: async () => undefined,
       getSandbox: () => sandbox,
     });
@@ -116,12 +141,17 @@ describe('cloudflare provider adapter', () => {
       }),
     });
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       destroy: async () => undefined,
       getSandbox: () => sandbox,
     });
-    await provider.create({ ...intent, billing: { ...billing, enforcementRequested: false } });
-    await provider.launch(intent.allocationName, {});
+    const created = await provider.create({
+      ...intent,
+      billing: { ...billing, enforcementRequested: false },
+    });
+    if (!('providerRef' in created)) throw new Error('Missing allocation');
+    expect(actions).toEqual(['attributed']);
+    await provider.launch(created.providerRef, {});
     expect(actions).toEqual(['attributed', 'started']);
     expect(configureBilling).toHaveBeenCalledWith({
       ...billing,
@@ -130,32 +160,181 @@ describe('cloudflare provider adapter', () => {
     });
   });
 
-  it('uses a distinct class-compatible allocation for create-stop-create', async () => {
-    const names: string[] = [];
-    const destroy = vi.fn(async () => undefined);
-    const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
-      destroy,
-      getSandbox: id => {
-        names.push(id);
-        return fakeSandbox();
-      },
+  it('awaits native outbound interception before exposing the wrapper control environment', async () => {
+    const installed = Promise.withResolvers<void>();
+    const actions: string[] = [];
+    const startProcess = vi.fn().mockImplementation(async () => {
+      actions.push('started');
+      return { id: 'proc_1' };
     });
-    const first = await deriveSandboxAllocationId(logicalId, 'first');
-    const second = await deriveSandboxAllocationId(logicalId, 'second');
-    await provider.create({ ...intent, allocationName: first });
-    await provider.launch(first, {});
-    await expect(provider.stop(first)).resolves.toBe('terminal');
-    await provider.create({ ...intent, intentId: 'second', allocationName: second });
-    await provider.launch(second, {});
-    expect(first).not.toBe(second);
-    expect(names).toEqual([first, second]);
-    expect(destroy).toHaveBeenCalledExactlyOnceWith(first);
-    expect(first).toMatch(/^ses-[a-f0-9]{48}$/);
-    expect(second).toMatch(/^ses-[a-f0-9]{48}$/);
+    const provider = createCloudflareProviderAdapter({
+      sandboxId: 'sbx_1',
+      destroy: async () => undefined,
+      getSandbox: () =>
+        fakeSandbox({
+          startProcess,
+          setOutboundHandler: vi.fn(async () => {
+            actions.push('installing');
+            await installed.promise;
+            actions.push('installed');
+          }),
+        }),
+    });
+    const launching = provider.launch(PROVIDER_REF, { PROVIDER_INSTANCE_ID: 'guest-supplied' });
+    expect(actions).toEqual(['installing']);
+    expect(startProcess).not.toHaveBeenCalled();
+    installed.resolve();
+    await launching;
+    expect(actions).toEqual(['installing', 'installed', 'started']);
+    expect(startProcess).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({
+        env: expect.objectContaining({ PROVIDER_INSTANCE_ID: PROVIDER_REF }),
+      })
+    );
   });
 
-  it('observes a missing ref by its retained name without waking, and preserves settling uncertainty', async () => {
+  it.each(['setOutboundHandler', 'startProcess'] as const)(
+    'retains the exact contained allocation for native cleanup when %s fails',
+    async method => {
+      const startProcess = vi.fn().mockResolvedValue({ id: 'proc_1' });
+      const setOutboundHandler = vi.fn().mockResolvedValue(undefined);
+      const destroy = vi.fn(async () => undefined);
+      const getSandbox = vi.fn(() =>
+        fakeSandbox({
+          startProcess,
+          setOutboundHandler,
+          [method]: vi.fn().mockRejectedValue(new Error('startup failed')),
+        })
+      );
+      const provider = createCloudflareProviderAdapter({ sandboxId: 'sbx_1', getSandbox, destroy });
+      await expect(
+        provider.create({
+          intentId: 'op_1',
+          createdAt: 1000,
+          containment: WORKTREE_CREDENTIAL_CONTAINMENT,
+        })
+      ).resolves.toEqual({ providerRef: PROVIDER_REF });
+      await expect(provider.launch(PROVIDER_REF, {})).rejects.toThrow('startup failed');
+      if (method === 'setOutboundHandler') expect(startProcess).not.toHaveBeenCalled();
+      await expect(provider.stop(PROVIDER_REF)).resolves.toBe('terminal');
+      expect(getSandbox).toHaveBeenCalledExactlyOnceWith('sbx_1', { containment: true });
+      expect(destroy).toHaveBeenCalledExactlyOnceWith('sbx_1', { containment: true });
+    }
+  );
+
+  it.each([
+    { ref: PROVIDER_REF, containment: true },
+    { ref: 'sbx_1', containment: false },
+  ])(
+    'observes, renews, and destroys only the encoded namespace without waking',
+    async ({ ref, containment }) => {
+      const isContainerRunning = vi.fn().mockResolvedValue(true);
+      const startProcess = vi.fn();
+      const setOutboundHandler = vi.fn();
+      const renewActivityTimeout = vi.fn();
+      const sdkDestroy = vi.fn();
+      const destroy = vi.fn(async () => undefined);
+      const getSandbox = vi.fn(() =>
+        fakeSandbox({
+          isContainerRunning,
+          startProcess,
+          setOutboundHandler,
+          renewActivityTimeout,
+          destroy: sdkDestroy,
+        })
+      );
+      const provider = createCloudflareProviderAdapter({ sandboxId: 'sbx_1', getSandbox, destroy });
+      await expect(provider.observe(ref)).resolves.toEqual({ status: 'active', providerRef: ref });
+      isContainerRunning.mockResolvedValue(false);
+      await expect(provider.observe(ref)).resolves.toEqual({
+        status: 'terminal',
+        providerRef: ref,
+      });
+      isContainerRunning.mockRejectedValue(new Error('inspection failed'));
+      await expect(provider.observe(ref)).resolves.toEqual({ status: 'unknown', providerRef: ref });
+      await provider.ensureLeaseAtLeast(ref, 360_000);
+      await expect(provider.stop(ref)).resolves.toBe('terminal');
+      expect(getSandbox).toHaveBeenCalledWith('sbx_1', { containment });
+      expect(destroy).toHaveBeenCalledWith('sbx_1', { containment });
+      expect(renewActivityTimeout).toHaveBeenCalledOnce();
+      expect(startProcess).not.toHaveBeenCalled();
+      expect(setOutboundHandler).not.toHaveBeenCalled();
+      expect(sdkDestroy).not.toHaveBeenCalled();
+    }
+  );
+
+  it('keeps missing native destruction retryable without using SDK cleanup', async () => {
+    const sdkDestroy = vi.fn(async () => undefined);
+    const sandbox = fakeSandbox({ destroy: sdkDestroy });
+    const getSandbox = vi.fn(() => sandbox);
+    const provider = createCloudflareProviderAdapter({
+      sandboxId: 'sbx_1',
+      getSandbox,
+      destroy: () => forceDestroyControlPlaneSandbox(sandbox),
+    });
+    await expect(provider.stop(PROVIDER_REF)).resolves.toBe('retryable');
+    expect(sdkDestroy).not.toHaveBeenCalled();
+    expect(getSandbox).not.toHaveBeenCalled();
+  });
+
+  it('uses distinct class-compatible native allocations after confirmed cleanup', async () => {
+    const first = await deriveSandboxAllocationId(logicalId, 'first');
+    const second = await deriveSandboxAllocationId(logicalId, 'second');
+    const names: string[] = [];
+    const destroy = vi.fn(async () => undefined);
+    for (const [name, intentId] of [
+      [first, 'first'],
+      [second, 'second'],
+    ]) {
+      const provider = createCloudflareProviderAdapter({
+        sandboxId: name,
+        destroy,
+        getSandbox: id => {
+          names.push(id);
+          return fakeSandbox();
+        },
+      });
+      const created = await provider.create({ ...intent, allocationName: name, intentId });
+      if (!('providerRef' in created)) throw new Error('Missing allocation');
+      expect(decodeCloudflareProviderRef(created.providerRef)).toEqual({
+        sandboxId: name,
+        containment: true,
+        instanceId: intentId,
+      });
+      await provider.launch(created.providerRef, {});
+      if (name === first)
+        await expect(provider.stop(created.providerRef)).resolves.toBe('terminal');
+    }
+    expect(names).toEqual([first, second]);
+    expect(first).not.toBe(second);
+    expect(first).toMatch(/^ses-[a-f0-9]{48}$/);
+    expect(second).toMatch(/^ses-[a-f0-9]{48}$/);
+    expect(destroy).toHaveBeenCalledExactlyOnceWith(first, { containment: true });
+  });
+
+  it('uses the creation intent as the instance fence for each replacement', async () => {
+    const getSandbox = vi.fn(() => fakeSandbox());
+    const provider = createCloudflareProviderAdapter({
+      sandboxId: 'sbx_1',
+      getSandbox,
+      destroy: async () => undefined,
+    });
+    const first = await provider.create({ intentId: 'op_1', createdAt: 1_000 });
+    const second = await provider.create({ intentId: 'op_2', createdAt: 1_000 });
+
+    expect(first).toEqual({ providerRef: PROVIDER_REF });
+    expect(second).toEqual({
+      providerRef: encodeCloudflareProviderRef({
+        sandboxId: 'sbx_1',
+        containment: true,
+        instanceId: 'op_2',
+      }),
+    });
+    expect(first).not.toEqual(second);
+  });
+
+  it('observes a missing ref by its retained intent without waking, and preserves settling uncertainty', async () => {
     vi.useFakeTimers();
     vi.setSystemTime(intent.createdAt);
     let running = true;
@@ -167,32 +346,76 @@ describe('cloudflare provider adapter', () => {
       })
     );
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       getSandbox,
       destroy: async () => undefined,
     });
+    const expectedRef = encodeCloudflareProviderRef({
+      sandboxId: intent.allocationName,
+      containment: true,
+      instanceId: intent.intentId,
+    });
     await expect(provider.observe(null, intent)).resolves.toEqual({
       status: 'active',
-      providerRef: intent.allocationName,
+      providerRef: expectedRef,
     });
     running = false;
     await expect(provider.observe(null, intent)).resolves.toEqual({
       status: 'unknown',
-      providerRef: intent.allocationName,
+      providerRef: expectedRef,
     });
     vi.setSystemTime(intent.createdAt + DEADLINE_MS.createSettle);
     await expect(provider.observe(null, intent)).resolves.toEqual({
       status: 'terminal',
-      providerRef: intent.allocationName,
+      providerRef: expectedRef,
     });
     await expect(provider.observe(null)).resolves.toEqual({ status: 'unknown' });
-    expect(getSandbox).toHaveBeenCalledWith(intent.allocationName);
+    expect(getSandbox).toHaveBeenCalledWith(intent.allocationName, { containment: true });
     expect(startProcess).not.toHaveBeenCalled();
   });
 
-  it('keeps failed observations unknown rather than treating them as physical death', async () => {
+  it('keeps historical null-reference cleanup in its original uncontained namespace', async () => {
+    const getSandbox = vi.fn(() => fakeSandbox());
+    const destroy = vi.fn(async () => undefined);
+    const provider = createCloudflareProviderAdapter({ sandboxId: logicalId, getSandbox, destroy });
+    const legacyIntent = { intentId: 'legacy', createdAt: 1000 };
+    await expect(provider.observe(null, legacyIntent)).resolves.toEqual({
+      status: 'active',
+      providerRef: logicalId,
+    });
+    await expect(provider.stop(null, legacyIntent)).resolves.toBe('terminal');
+    expect(getSandbox).toHaveBeenCalledExactlyOnceWith(logicalId, { containment: false });
+    expect(destroy).toHaveBeenCalledExactlyOnceWith(logicalId, { containment: false });
+  });
+
+  it('keeps unavailable or failed native lookups unknown', async () => {
+    const getSandbox = vi.fn(() => fakeSandbox({ isContainerRunning: undefined }));
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: 'sbx_1',
+      getSandbox,
+      destroy: async () => undefined,
+    });
+    await expect(provider.observe(PROVIDER_REF)).resolves.toEqual({
+      status: 'unknown',
+      providerRef: PROVIDER_REF,
+    });
+    getSandbox.mockImplementation(() => {
+      throw new Error('lookup failed');
+    });
+    await expect(provider.observe(PROVIDER_REF)).resolves.toEqual({
+      status: 'unknown',
+      providerRef: PROVIDER_REF,
+    });
+  });
+
+  it('keeps failed observations unknown rather than treating them as physical death', async () => {
+    const providerRef = encodeCloudflareProviderRef({
+      sandboxId: intent.allocationName,
+      containment: true,
+      instanceId: intent.intentId,
+    });
+    const provider = createCloudflareProviderAdapter({
+      sandboxId: intent.allocationName,
       destroy: async () => undefined,
       getSandbox: () =>
         fakeSandbox({
@@ -201,9 +424,9 @@ describe('cloudflare provider adapter', () => {
           },
         }),
     });
-    await expect(provider.observe(intent.allocationName)).resolves.toEqual({
+    await expect(provider.observe(providerRef)).resolves.toEqual({
       status: 'unknown',
-      providerRef: intent.allocationName,
+      providerRef,
     });
   });
 
@@ -211,59 +434,58 @@ describe('cloudflare provider adapter', () => {
     let running = true;
     const startProcess = vi.fn();
     const destroy = vi.fn().mockRejectedValue(new Error('provider unavailable'));
+    const providerRef = encodeCloudflareProviderRef({
+      sandboxId: intent.allocationName,
+      containment: true,
+      instanceId: intent.intentId,
+    });
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       destroy,
       getSandbox: () => fakeSandbox({ startProcess, isContainerRunning: async () => running }),
     });
-    await expect(provider.stop(intent.allocationName)).resolves.toBe('retryable');
-    await expect(provider.observe(intent.allocationName)).resolves.toEqual({
+    await expect(provider.stop(providerRef)).resolves.toBe('retryable');
+    await expect(provider.observe(providerRef)).resolves.toEqual({
       status: 'active',
-      providerRef: intent.allocationName,
+      providerRef,
     });
     running = false;
-    await expect(provider.observe(intent.allocationName)).resolves.toEqual({
+    await expect(provider.observe(providerRef)).resolves.toEqual({
       status: 'terminal',
-      providerRef: intent.allocationName,
+      providerRef,
     });
     expect(destroy).toHaveBeenCalledTimes(1);
     expect(startProcess).not.toHaveBeenCalled();
   });
 
-  it.each([
-    { ref: intent.allocationName, createIntent: intent, expected: intent.allocationName },
-    { ref: null, createIntent: intent, expected: intent.allocationName },
-    {
-      ref: null,
-      createIntent: { intentId: 'older-allocation', createdAt: 1_000 },
-      expected: logicalId,
-    },
-  ])(
-    'destroys allocation $expected through a raw namespace stub without SDK acquisition',
-    async ({ ref, createIntent, expected }) => {
-      const runtime = {
-        running: true,
-        async forceDestroyForControlPlane() {
-          this.running = false;
-        },
-      };
-      const namespace = { getByName: vi.fn((_id: string) => runtime) };
-      const getSandbox = vi.fn(() => {
-        throw new Error('SDK acquisition must not run during physical destruction');
-      });
-      const provider = createCloudflareProviderAdapter({
-        sandboxId: logicalId,
-        getSandbox,
-        destroy: id => forceDestroyControlPlaneSandbox(namespace.getByName(id)),
-      });
+  it('destroys allocation through a raw namespace stub without SDK acquisition', async () => {
+    const providerRef = encodeCloudflareProviderRef({
+      sandboxId: intent.allocationName,
+      containment: true,
+      instanceId: intent.intentId,
+    });
+    const runtime = {
+      running: true,
+      async forceDestroyForControlPlane() {
+        this.running = false;
+      },
+    };
+    const namespace = { getByName: vi.fn((_id: string) => runtime) };
+    const getSandbox = vi.fn(() => {
+      throw new Error('SDK acquisition must not run during physical destruction');
+    });
+    const provider = createCloudflareProviderAdapter({
+      sandboxId: intent.allocationName,
+      getSandbox,
+      destroy: (id, _opts) => forceDestroyControlPlaneSandbox(namespace.getByName(id)),
+    });
 
-      await expect(provider.stop(ref, createIntent)).resolves.toBe('terminal');
+    await expect(provider.stop(providerRef)).resolves.toBe('terminal');
 
-      expect(runtime.running).toBe(false);
-      expect(namespace.getByName).toHaveBeenCalledExactlyOnceWith(expected);
-      expect(getSandbox).not.toHaveBeenCalled();
-    }
-  );
+    expect(runtime.running).toBe(false);
+    expect(namespace.getByName).toHaveBeenCalledExactlyOnceWith(intent.allocationName);
+    expect(getSandbox).not.toHaveBeenCalled();
+  });
 
   it('does not destroy anything without a retained allocation identity', async () => {
     const destroy = vi.fn(async () => undefined);
@@ -276,42 +498,31 @@ describe('cloudflare provider adapter', () => {
     expect(getSandbox).not.toHaveBeenCalled();
   });
 
-  it('keeps a missing native capability retryable without falling back to SDK destruction', async () => {
-    const sdkDestroy = vi.fn(async () => undefined);
-    const sandbox = fakeSandbox({ destroy: sdkDestroy });
-    const getSandbox = vi.fn(() => sandbox);
-    const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
-      getSandbox,
-      destroy: () => forceDestroyControlPlaneSandbox(sandbox),
-    });
-
-    await expect(provider.stop(intent.allocationName)).resolves.toBe('retryable');
-
-    expect(sdkDestroy).not.toHaveBeenCalled();
-    expect(getSandbox).not.toHaveBeenCalled();
-  });
-
   it('does not interpret a lost native stop acknowledgement as terminal success', async () => {
     let running = true;
     const startProcess = vi.fn();
+    const providerRef = encodeCloudflareProviderRef({
+      sandboxId: intent.allocationName,
+      containment: true,
+      instanceId: intent.intentId,
+    });
     const destroy = vi.fn(async () => {
       running = false;
       throw new Error('Native destroy acknowledgement lost');
     });
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       destroy,
       getSandbox: () => fakeSandbox({ startProcess, isContainerRunning: async () => running }),
     });
 
-    await expect(provider.stop(intent.allocationName)).resolves.toBe('retryable');
-    await expect(provider.observe(intent.allocationName)).resolves.toEqual({
+    await expect(provider.stop(providerRef)).resolves.toBe('retryable');
+    await expect(provider.observe(providerRef)).resolves.toEqual({
       status: 'terminal',
-      providerRef: intent.allocationName,
+      providerRef,
     });
 
-    expect(destroy).toHaveBeenCalledExactlyOnceWith(intent.allocationName);
+    expect(destroy).toHaveBeenCalledExactlyOnceWith(intent.allocationName, { containment: true });
     expect(startProcess).not.toHaveBeenCalled();
   });
 
@@ -320,6 +531,11 @@ describe('cloudflare provider adapter', () => {
     async runningAfterIssuance => {
       vi.useFakeTimers();
       let running = true;
+      const providerRef = encodeCloudflareProviderRef({
+        sandboxId: intent.allocationName,
+        containment: true,
+        instanceId: intent.intentId,
+      });
       const acknowledgement = Promise.withResolvers<void>();
       const destroy = vi.fn(async () => {
         running = runningAfterIssuance;
@@ -328,12 +544,12 @@ describe('cloudflare provider adapter', () => {
       });
       const getSandbox = vi.fn(() => fakeSandbox({ isContainerRunning: async () => running }));
       const provider = createCloudflareProviderAdapter({
-        sandboxId: logicalId,
+        sandboxId: intent.allocationName,
         getSandbox,
         destroy,
       });
       const settled = vi.fn();
-      const stopping = provider.stop(intent.allocationName).then(settled);
+      const stopping = provider.stop(providerRef).then(settled);
       const timedOut = expect(
         withTimeout(stopping, DEADLINE_MS.stopAttempt, 'Native destroy acknowledgement timed out')
       ).rejects.toThrow('Native destroy acknowledgement timed out');
@@ -342,11 +558,11 @@ describe('cloudflare provider adapter', () => {
       await timedOut;
 
       expect(settled).not.toHaveBeenCalled();
-      expect(destroy).toHaveBeenCalledExactlyOnceWith(intent.allocationName);
+      expect(destroy).toHaveBeenCalledExactlyOnceWith(intent.allocationName, { containment: true });
       expect(getSandbox).not.toHaveBeenCalled();
-      await expect(provider.observe(intent.allocationName)).resolves.toEqual({
+      await expect(provider.observe(providerRef)).resolves.toEqual({
         status: runningAfterIssuance ? 'active' : 'terminal',
-        providerRef: intent.allocationName,
+        providerRef,
       });
       acknowledgement.resolve();
       await stopping;
@@ -355,33 +571,131 @@ describe('cloudflare provider adapter', () => {
   );
 
   it('propagates launch failure without losing the known allocation', async () => {
+    const providerRef = encodeCloudflareProviderRef({
+      sandboxId: intent.allocationName,
+      containment: true,
+      instanceId: intent.intentId,
+    });
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       destroy: async () => undefined,
       getSandbox: () =>
         fakeSandbox({ startProcess: vi.fn().mockRejectedValue(new Error('launch failed')) }),
     });
-    await expect(provider.create(intent)).resolves.toEqual({ providerRef: intent.allocationName });
-    await expect(provider.launch(intent.allocationName, {})).rejects.toThrow('launch failed');
-    await expect(provider.observe(intent.allocationName)).resolves.toEqual({
+    await expect(provider.create(intent)).resolves.toEqual({ providerRef });
+    await expect(provider.launch(providerRef, {})).rejects.toThrow('launch failed');
+    await expect(provider.observe(providerRef)).resolves.toEqual({
       status: 'active',
-      providerRef: intent.allocationName,
+      providerRef,
     });
   });
 
   it('renews the lease on the physical ref', async () => {
+    const providerRef = encodeCloudflareProviderRef({
+      sandboxId: intent.allocationName,
+      containment: true,
+      instanceId: intent.intentId,
+    });
     const renewed: string[] = [];
     const provider = createCloudflareProviderAdapter({
-      sandboxId: logicalId,
+      sandboxId: intent.allocationName,
       destroy: async () => undefined,
-      getSandbox: id =>
+      getSandbox: (id, _opts) =>
         fakeSandbox({
           renewActivityTimeout: () => {
             renewed.push(id);
           },
         }),
     });
-    await provider.ensureLeaseAtLeast(intent.allocationName, 360_000);
+    await provider.ensureLeaseAtLeast(providerRef, 360_000);
     expect(renewed).toEqual([intent.allocationName]);
+  });
+
+  it.each([
+    '',
+    'not-json',
+    'sbx_other',
+    JSON.stringify({ sandboxId: 'sbx_1', containment: true }),
+    JSON.stringify({ sandboxId: 'sbx_1', containment: false, instanceId: 'op_1' }),
+    encodeCloudflareProviderRef({
+      sandboxId: 'sbx_other',
+      containment: true,
+      instanceId: 'op_1',
+    }),
+  ])('never looks up a sandbox for malformed or cross-sandbox refs', async ref => {
+    const getSandbox = vi.fn(() => fakeSandbox());
+    const provider = createCloudflareProviderAdapter({
+      sandboxId: 'sbx_1',
+      getSandbox,
+      destroy: async () => undefined,
+    });
+
+    await expect(provider.observe(ref)).resolves.toEqual({ status: 'unknown' });
+    await expect(provider.stop(ref)).resolves.toBe('retryable');
+    await provider.ensureLeaseAtLeast(ref, 360_000);
+    await provider.logs(ref);
+
+    expect(getSandbox).not.toHaveBeenCalled();
+  });
+
+  it('treats a missing ref without an intent as unknown', async () => {
+    const getSandbox = vi.fn(() => fakeSandbox());
+    const provider = createCloudflareProviderAdapter({
+      sandboxId: 'sbx_1',
+      getSandbox,
+      destroy: async () => undefined,
+    });
+
+    await expect(provider.observe(null)).resolves.toEqual({ status: 'unknown' });
+    expect(getSandbox).not.toHaveBeenCalled();
+  });
+
+  it('keeps historical cleanup separate from a newly created containment instance', async () => {
+    const destroy = vi.fn().mockResolvedValue(undefined);
+    const getSandbox = vi.fn(() => fakeSandbox({ destroy }));
+    const provider = createCloudflareProviderAdapter({
+      sandboxId: 'sbx_1',
+      getSandbox,
+      destroy: async () => undefined,
+    });
+    const providerRef = encodeCloudflareProviderRef({
+      sandboxId: 'sbx_1',
+      containment: true,
+      instanceId: 'op_1',
+    });
+
+    const created = await provider.create({ intentId: 'op_1', createdAt: 1_000 });
+    expect(created).toEqual({ providerRef });
+  });
+});
+
+describe('cloudflare provider references', () => {
+  it('round-trips the containment namespace and exact creation intent', () => {
+    expect(decodeCloudflareProviderRef(PROVIDER_REF)).toEqual({
+      sandboxId: 'sbx_1',
+      containment: true,
+      instanceId: 'op_1',
+    });
+  });
+
+  it.each([
+    null,
+    '',
+    'sbx_1',
+    '{',
+    'null',
+    '[]',
+    '{}',
+    JSON.stringify({ sandboxId: 'sbx_1', containment: true }),
+    JSON.stringify({ sandboxId: 'sbx_1', containment: true, instanceId: '' }),
+    JSON.stringify({ sandboxId: 'sbx_1', containment: true, instanceId: 1 }),
+    JSON.stringify({ sandboxId: 'sbx_1', containment: 'true', instanceId: 'op_1' }),
+    JSON.stringify({ sandboxId: 'sbx_1', containment: false, instanceId: 'op_1' }),
+    JSON.stringify({ sandboxId: '', containment: true, instanceId: 'op_1' }),
+    JSON.stringify({ sandboxId: 'sbx_1', containment: true, instanceId: 'op_1', extra: true }),
+    JSON.stringify({ sandboxId: 'a'.repeat(257), containment: true, instanceId: 'op_1' }),
+    JSON.stringify({ sandboxId: 'sbx_1', containment: true, instanceId: 'a'.repeat(129) }),
+  ])('rejects incomplete or invalid encoded refs', ref => {
+    expect(decodeCloudflareProviderRef(ref)).toBeNull();
   });
 });

--- a/services/cloud-agent-next/src/sandbox-control/cloudflare-provider.ts
+++ b/services/cloud-agent-next/src/sandbox-control/cloudflare-provider.ts
@@ -1,3 +1,4 @@
+import { z } from 'zod';
 import {
   configureSandboxBillingInput,
   ensureSandboxBillingAdmissionInput,
@@ -6,27 +7,71 @@ import {
   parseSandboxBillingInput,
 } from '../container-usage-context.js';
 import { AgentSandboxUnavailableError } from '../agent-sandbox/protocol.js';
+import { MANAGED_SCM_OUTBOUND_HANDLER } from '../sandbox-id.js';
 import type { SandboxInstance } from '../types.js';
 import { DEADLINE_MS } from './deadlines.js';
+import type { CreateIntent } from './physical-lifecycle.js';
 import type { ProviderAdapter, ProviderCreateIntent } from './provider.js';
 
 const CONTROL_WRAPPER_PATH = '/usr/local/bin/kilocode-control-wrapper.js';
 const CONTROL_WRAPPER_LOG_PATH = '/tmp/kilocode-control-wrapper.log';
 
+const providerRefSchema = z
+  .object({
+    sandboxId: z.string().min(1).max(256),
+    containment: z.literal(true),
+    instanceId: z.string().min(1).max(128),
+  })
+  .strict();
+
+export type CloudflareProviderRef = z.infer<typeof providerRefSchema>;
+
+export function encodeCloudflareProviderRef(ref: CloudflareProviderRef): string {
+  return JSON.stringify(ref);
+}
+
+export function decodeCloudflareProviderRef(raw: string | null): CloudflareProviderRef | null {
+  if (raw === null) return null;
+  try {
+    const parsed = providerRefSchema.safeParse(JSON.parse(raw));
+    return parsed.success ? parsed.data : null;
+  } catch {
+    return null;
+  }
+}
+
 export type CloudflareSandboxHandle = SandboxInstance;
+
+type SandboxOptions = { containment: boolean };
 
 export function createCloudflareProviderAdapter(deps: {
   sandboxId: string;
-  getSandbox: (id: string) => CloudflareSandboxHandle;
-  destroy: (allocationId: string) => Promise<void>;
+  getSandbox: (id: string, options: SandboxOptions) => CloudflareSandboxHandle;
+  destroy: (allocationId: string, options: SandboxOptions) => Promise<void>;
 }): ProviderAdapter {
+  const decodeOwnedProviderRef = (
+    ref: string | null
+  ): { sandboxId: string; containment: boolean } | null => {
+    if (ref === deps.sandboxId) return { sandboxId: deps.sandboxId, containment: false };
+    const parsed = decodeCloudflareProviderRef(ref);
+    return parsed?.sandboxId === deps.sandboxId ? parsed : null;
+  };
+  const resolveProviderRef = (ref: string | null, intent?: CreateIntent | null): string | null => {
+    if (ref !== null || !intent) return ref;
+    const sandboxId = intent.allocationName ?? deps.sandboxId;
+    return intent.containment?.worktreeScoped
+      ? encodeCloudflareProviderRef({ sandboxId, containment: true, instanceId: intent.intentId })
+      : sandboxId;
+  };
   const ensureBillingAdmission: ProviderAdapter['ensureBillingAdmission'] = async (
     ref,
     billing
   ) => {
     if (!billing) return;
-    const input = parseSandboxBillingInput({ ...billing, sandboxId: ref });
-    const sandbox = deps.getSandbox(ref);
+    const parsed = decodeOwnedProviderRef(ref);
+    if (!parsed) throw new Error('Invalid Cloudflare sandbox allocation');
+    const input = parseSandboxBillingInput({ ...billing, sandboxId: parsed.sandboxId });
+    const sandbox = deps.getSandbox(parsed.sandboxId, { containment: parsed.containment });
     const blocked = await isSandboxBillingBlocked(sandbox, input.enforcementRequested);
     if (input.enforcementRequested || blocked) {
       const admission = await ensureSandboxBillingAdmissionInput(sandbox, input);
@@ -47,12 +92,22 @@ export function createCloudflareProviderAdapter(deps: {
     resumable: false,
     ensureBillingAdmission,
     async create(intent: ProviderCreateIntent) {
-      const providerRef = intent.allocationName ?? deps.sandboxId;
+      const providerRef = encodeCloudflareProviderRef({
+        sandboxId: intent.allocationName ?? deps.sandboxId,
+        containment: true,
+        instanceId: intent.intentId,
+      });
       await ensureBillingAdmission(providerRef, intent.billing);
       return { providerRef };
     },
     async launch(ref, env) {
-      await deps.getSandbox(ref).startProcess(`bun run ${CONTROL_WRAPPER_PATH}`, {
+      const parsed = decodeCloudflareProviderRef(ref);
+      if (!parsed || parsed.sandboxId !== deps.sandboxId) {
+        throw new Error('Invalid contained Cloudflare sandbox allocation');
+      }
+      const sandbox = deps.getSandbox(parsed.sandboxId, { containment: true });
+      await sandbox.setOutboundHandler(MANAGED_SCM_OUTBOUND_HANDLER);
+      await sandbox.startProcess(`bun run ${CONTROL_WRAPPER_PATH}`, {
         cwd: '/',
         env: {
           ...env,
@@ -62,10 +117,13 @@ export function createCloudflareProviderAdapter(deps: {
       });
     },
     async observe(ref, intent) {
-      const providerRef = ref ?? intent?.allocationName ?? (intent ? deps.sandboxId : undefined);
-      if (!providerRef) return { status: 'unknown' };
+      const providerRef = resolveProviderRef(ref, intent);
+      const parsed = decodeOwnedProviderRef(providerRef);
+      if (!parsed || !providerRef) return { status: 'unknown' };
       try {
-        const running = await isSandboxContainerRunning(deps.getSandbox(providerRef));
+        const running = await isSandboxContainerRunning(
+          deps.getSandbox(parsed.sandboxId, { containment: parsed.containment })
+        );
         const settling = intent && Date.now() < intent.createdAt + DEADLINE_MS.createSettle;
         return {
           status:
@@ -77,17 +135,21 @@ export function createCloudflareProviderAdapter(deps: {
       }
     },
     async stop(ref, intent) {
-      const providerRef = ref ?? intent?.allocationName ?? (intent ? deps.sandboxId : undefined);
-      if (!providerRef) return 'retryable';
+      const parsed = decodeOwnedProviderRef(resolveProviderRef(ref, intent));
+      if (!parsed) return 'retryable';
       try {
-        await deps.destroy(providerRef);
+        await deps.destroy(parsed.sandboxId, { containment: parsed.containment });
         return 'terminal';
       } catch {
         return 'retryable';
       }
     },
     async ensureLeaseAtLeast(ref, _ms) {
-      return deps.getSandbox(ref).renewActivityTimeout();
+      const parsed = decodeOwnedProviderRef(ref);
+      if (parsed === null) return;
+      return deps
+        .getSandbox(parsed.sandboxId, { containment: parsed.containment })
+        .renewActivityTimeout();
     },
     async logs(ref) {
       return `cloudflare ${ref}`;

--- a/services/cloud-agent-next/src/sandbox-control/deadlines.ts
+++ b/services/cloud-agent-next/src/sandbox-control/deadlines.ts
@@ -7,6 +7,7 @@ export const DEADLINE_IDS = [
   'idleStop',
   'stopAttempt',
   'reconciliation',
+  'credentialExpiry',
 ] as const;
 export type DeadlineId = (typeof DEADLINE_IDS)[number];
 

--- a/services/cloud-agent-next/src/sandbox-control/durable-state.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/durable-state.test.ts
@@ -1,0 +1,208 @@
+import { describe, expect, it } from 'vitest';
+import {
+  eraseSandboxRecord,
+  loadDeadlines,
+  loadPhysicalRecord,
+  loadRouteTable,
+  loadSessionCredentialGrants,
+  loadTransitionLog,
+  saveDeadlines,
+  savePhysicalRecord,
+  saveRouteTable,
+  saveSessionCredentialGrants,
+  saveTransitionLog,
+} from './durable-state.js';
+import { createControlPlaneCredential } from './managed-credential.js';
+import {
+  claimCreate,
+  confirmRunning,
+  initialPhysicalRecord,
+  WORKTREE_CREDENTIAL_CONTAINMENT,
+} from './physical-lifecycle.js';
+import type { SessionCredentialGrant } from './session-credentials.js';
+import { attachRoute, emptyRouteTable, resolveSessionEventRoute } from './session-routes.js';
+
+const SESSION_ID = 'workspace_11111111-1111-4111-8111-111111111111';
+const SECOND_SESSION_ID = 'workspace_22222222-2222-4222-8222-222222222222';
+const LEGACY_SESSION_ID = 'workspace_33333333-3333-4333-8333-333333333333';
+const ROOT_ID = 'ses_abcdefghijklmnopqrstuvwxyz';
+const SECOND_ROOT_ID = 'ses_zyxwvutsrqponmlkjihgfedcba';
+const LEGACY_ROOT_ID = 'ses_01234567890123456789012345';
+
+function memoryStorage() {
+  const values = new Map<string, unknown>();
+  return {
+    async get<T = unknown>(key: string): Promise<T | undefined> {
+      return structuredClone(values.get(key)) as T | undefined;
+    },
+    async put<T>(key: string, value: T): Promise<void> {
+      values.set(key, structuredClone(value));
+    },
+    async delete(keys: string[]): Promise<number> {
+      let deleted = 0;
+      for (const key of keys) {
+        if (values.delete(key)) deleted++;
+      }
+      return deleted;
+    },
+  };
+}
+
+function credentialGrant(): SessionCredentialGrant {
+  return {
+    version: 1,
+    scopeId: 'worktree_1',
+    sandboxId: 'ses-a1b2c3',
+    directory: '/workspace/a',
+    userId: 'owner_1',
+    provider: 'vercel',
+    members: [
+      { sessionId: SESSION_ID, kiloSessionId: ROOT_ID },
+      { sessionId: SECOND_SESSION_ID, kiloSessionId: SECOND_ROOT_ID },
+    ],
+    kilo: {
+      alias: createControlPlaneCredential('ses-a1b2c3', 'kilo'),
+      token: 'test-kilo-token',
+      targets: {
+        backendBaseUrl: 'https://backend.example.com',
+        providerBaseUrl: 'https://provider.example.com/api/openrouter',
+        sessionIngestBaseUrl: 'https://ingest.example.com',
+      },
+      capabilities: {},
+    },
+    preparedAt: 1000,
+    expiresAt: 2000,
+  };
+}
+
+describe('sandbox control durable state', () => {
+  it('loads no credential grants from a pre-worktree record', async () => {
+    expect(await loadSessionCredentialGrants(memoryStorage())).toEqual([]);
+  });
+
+  it('round-trips multiple roots in a worktree grant alongside a legacy session-scoped grant', async () => {
+    const storage = memoryStorage();
+    const grants = [
+      credentialGrant(),
+      {
+        ...credentialGrant(),
+        scopeId: LEGACY_SESSION_ID,
+        directory: '/workspace/legacy',
+        members: [{ sessionId: LEGACY_SESSION_ID, kiloSessionId: LEGACY_ROOT_ID }],
+      },
+    ];
+    await saveSessionCredentialGrants(storage, grants);
+    expect(await loadSessionCredentialGrants(storage)).toStrictEqual(grants);
+  });
+
+  it.each([
+    { version: 2 },
+    { scopeId: '' },
+    { members: [] },
+    {
+      members: [
+        { sessionId: SESSION_ID, kiloSessionId: ROOT_ID },
+        { sessionId: SECOND_SESSION_ID, kiloSessionId: ROOT_ID },
+      ],
+    },
+  ])('rejects malformed persisted credential grants: %j', async overrides => {
+    const storage = memoryStorage();
+    await storage.put('worktree_credential_grants', [{ ...credentialGrant(), ...overrides }]);
+    await expect(loadSessionCredentialGrants(storage)).rejects.toThrow(
+      'Invalid stored worktree credentials'
+    );
+  });
+
+  it('rejects a non-array persisted credential state', async () => {
+    const storage = memoryStorage();
+    await storage.put('worktree_credential_grants', credentialGrant());
+    await expect(loadSessionCredentialGrants(storage)).rejects.toThrow(
+      'Invalid stored worktree credentials'
+    );
+  });
+
+  it('preserves shared-directory and legacy routes across a durable reload', async () => {
+    const storage = memoryStorage();
+    const grant = credentialGrant();
+    const table = emptyRouteTable();
+    for (const member of grant.members) {
+      attachRoute(
+        table,
+        {
+          ...member,
+          ownerId: grant.userId,
+          directory: grant.directory,
+          worktreeId: grant.scopeId,
+        },
+        grant.userId
+      );
+    }
+    const legacy = {
+      sessionId: LEGACY_SESSION_ID,
+      kiloSessionId: LEGACY_ROOT_ID,
+      ownerId: grant.userId,
+      directory: '/workspace/legacy',
+    };
+    attachRoute(table, legacy, grant.userId);
+    await saveRouteTable(storage, table);
+
+    const loaded = await loadRouteTable(storage);
+    expect(loaded).toStrictEqual(table);
+    expect(resolveSessionEventRoute(loaded, { directory: grant.directory })).toBeNull();
+    expect(
+      resolveSessionEventRoute(loaded, {
+        directory: grant.directory,
+        rootKiloSessionId: SECOND_ROOT_ID,
+        kiloSessionId: 'kilo_child',
+      })?.sessionId
+    ).toBe(SECOND_SESSION_ID);
+    expect(resolveSessionEventRoute(loaded, { directory: legacy.directory })?.sessionId).toBe(
+      LEGACY_SESSION_ID
+    );
+    expect(attachRoute(loaded, legacy, grant.userId).changed).toBe(false);
+  });
+
+  it('erases credential grants along with the sandbox record without clearing unrelated storage', async () => {
+    const storage = memoryStorage();
+    const grant = credentialGrant();
+    await saveSessionCredentialGrants(storage, [grant]);
+    await savePhysicalRecord(
+      storage,
+      confirmRunning(
+        claimCreate(
+          initialPhysicalRecord(false),
+          'intent_1',
+          1000,
+          undefined,
+          WORKTREE_CREDENTIAL_CONTAINMENT
+        ),
+        'ref_1',
+        1001
+      )
+    );
+    const { table } = attachRoute(
+      emptyRouteTable(),
+      {
+        sessionId: SESSION_ID,
+        kiloSessionId: ROOT_ID,
+        directory: grant.directory,
+        worktreeId: grant.scopeId,
+        ownerId: grant.userId,
+      },
+      grant.userId
+    );
+    await saveRouteTable(storage, table);
+    await saveDeadlines(storage, { heartbeatExpiry: 3000 });
+    await saveTransitionLog(storage, [{ at: 1001, kind: 'physical', to: 'running' }]);
+    await storage.put('owner', grant.userId);
+
+    await eraseSandboxRecord(storage);
+
+    expect(await loadSessionCredentialGrants(storage)).toEqual([]);
+    expect(await loadPhysicalRecord(storage)).toStrictEqual(initialPhysicalRecord(false));
+    expect(await loadRouteTable(storage)).toEqual(emptyRouteTable());
+    expect(await loadDeadlines(storage)).toEqual({});
+    expect(await loadTransitionLog(storage)).toEqual([]);
+    expect(await storage.get('owner')).toBe(grant.userId);
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-control/durable-state.ts
+++ b/services/cloud-agent-next/src/sandbox-control/durable-state.ts
@@ -2,12 +2,17 @@ import type { DeadlineTable } from './deadlines.js';
 import { emptyDeadlines } from './deadlines.js';
 import { initialPhysicalRecord, type PhysicalRecord } from './physical-lifecycle.js';
 import type { SessionRoute } from './session-routes.js';
+import {
+  sessionCredentialGrantSchema,
+  type SessionCredentialGrant,
+} from './session-credentials.js';
 import { emptyTransitionLog, type TransitionRow } from './transition-log.js';
 
 const PHYSICAL_KEY = 'physical_record';
 const ROUTES_KEY = 'session_routes';
 const DEADLINES_KEY = 'deadlines';
 const LOG_KEY = 'transition_log';
+const CREDENTIAL_GRANTS_KEY = 'worktree_credential_grants';
 
 type ControlStorage = {
   get<T = unknown>(key: string): Promise<T | undefined>;
@@ -61,6 +66,22 @@ export async function saveTransitionLog(
   await storage.put(LOG_KEY, log);
 }
 
+export async function loadSessionCredentialGrants(
+  storage: ControlStorage
+): Promise<SessionCredentialGrant[]> {
+  const stored = await storage.get(CREDENTIAL_GRANTS_KEY);
+  const parsed = sessionCredentialGrantSchema.array().safeParse(stored ?? []);
+  if (!parsed.success) throw new Error('Invalid stored worktree credentials');
+  return parsed.data;
+}
+
+export async function saveSessionCredentialGrants(
+  storage: ControlStorage,
+  grants: SessionCredentialGrant[]
+): Promise<void> {
+  await storage.put(CREDENTIAL_GRANTS_KEY, grants);
+}
+
 export async function eraseSandboxRecord(storage: ControlStorage): Promise<void> {
-  await storage.delete([PHYSICAL_KEY, ROUTES_KEY, DEADLINES_KEY, LOG_KEY]);
+  await storage.delete([PHYSICAL_KEY, ROUTES_KEY, DEADLINES_KEY, LOG_KEY, CREDENTIAL_GRANTS_KEY]);
 }

--- a/services/cloud-agent-next/src/sandbox-control/lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/lifecycle.test.ts
@@ -19,6 +19,9 @@ import type {
 import { DEADLINE_MS } from './deadlines.js';
 import { loadDeadlines } from './durable-state.js';
 import type * as cloudflareProvider from './cloudflare-provider.js';
+import { decodeCloudflareProviderRef } from './cloudflare-provider.js';
+import { WORKTREE_CREDENTIAL_CONTAINMENT } from './physical-lifecycle.js';
+import { parseSessionMetadata } from '../persistence/session-metadata.js';
 
 const mocks = vi.hoisted(() => ({
   getSandbox: vi.fn(),
@@ -61,8 +64,8 @@ const SANDBOX_ID = 'ses-abcdef';
 const OWNER = 'owner_1';
 const ROUTE = {
   ownerId: OWNER,
-  sessionId: 'workspace_1',
-  kiloSessionId: 'kilo_1',
+  sessionId: 'workspace_11111111-1111-4111-8111-111111111111',
+  kiloSessionId: 'ses_11111111111111111111111111',
   directory: '/workspace/a',
 };
 const PROMPT = {
@@ -104,6 +107,7 @@ function allocation() {
   const getBillingRuntimeStatus = vi.fn();
   const handle = {
     startProcess,
+    setOutboundHandler: vi.fn().mockResolvedValue(undefined),
     destroy,
     forceDestroyForControlPlane: destroy,
     renewActivityTimeout,
@@ -212,12 +216,39 @@ async function harness(
   };
   const env = {
     WORKER_URL: 'https://example.test',
-    Sandbox: namespace,
-    SandboxSmall: namespace,
+    Sandbox: { ...namespace, getByName: vi.fn(getAllocation) },
+    SandboxSmall: { ...namespace, getByName: vi.fn(getAllocation) },
+    SandboxContainment: namespace,
+    SandboxSmallContainment: namespace,
+    GIT_TOKEN_SERVICE: {
+      issueKiloSessionCapability: vi.fn(async () => ({
+        success: true,
+        capability: 'kka1.test-capability',
+      })),
+    },
+    KILOCODE_BACKEND_BASE_URL: 'https://backend.example.test',
+    KILO_OPENROUTER_BASE: 'https://provider.example.test',
+    KILO_SESSION_INGEST_URL: 'https://ingest.example.test',
     ...options.env,
   } as Env;
-  mocks.getSandbox.mockImplementation((_namespace, id: string) => getAllocation(id));
+  mocks.getSandbox.mockImplementation((selectedNamespace, id: string) => {
+    expect(selectedNamespace).toBe(namespace);
+    return getAllocation(id);
+  });
   const session = {
+    getCredentialMetadata: vi.fn(async () =>
+      parseSessionMetadata({
+        metadataSchemaVersion: 2,
+        identity: { sessionId: ROUTE.sessionId, userId: OWNER },
+        auth: { kiloSessionId: ROUTE.kiloSessionId, kilocodeToken: 'test-token' },
+        workspace: {
+          sandboxId: SANDBOX_ID,
+          workspacePath: ROUTE.directory,
+          sandboxProvider: options.env?.VERCEL_TOKEN ? 'vercel' : 'cloudflare',
+        },
+        lifecycle: { version: 1, timestamp: Date.now() },
+      })
+    ),
     receiveSandboxControlEvent: vi.fn().mockResolvedValue({ applied: true }),
     receiveSandboxControlPreparing: vi.fn().mockResolvedValue({ applied: true }),
     failWaitingMessages: vi.fn().mockResolvedValue(undefined),
@@ -249,7 +280,6 @@ async function harness(
   let control = new SandboxControl(ctx, env);
   await Promise.all(initializing);
   await control.initializeOwner(OWNER);
-  await control.attachSession(ROUTE);
   const flush = async () => {
     while (pending.length) await Promise.all(pending.splice(0));
   };
@@ -268,6 +298,7 @@ async function harness(
       return transactionActive;
     },
     allocations,
+    runtime: (ref: string) => allocations.get(decodeCloudflareProviderRef(ref)?.sandboxId ?? ref),
     session,
     socket,
     sendRequest,
@@ -276,10 +307,20 @@ async function harness(
     },
     flush,
     async create() {
-      return control.ensureReady({ ownerId: OWNER, allowCreate: true, billing: BILLING });
+      return control.ensureReady({
+        ownerId: OWNER,
+        sessionId: ROUTE.sessionId,
+        allowCreate: true,
+        billing: BILLING,
+      });
     },
     async acquire(acquisition: SandboxAcquisition) {
-      return control.ensureReady({ ownerId: OWNER, acquisition, billing: BILLING });
+      return control.ensureReady({
+        ownerId: OWNER,
+        sessionId: ROUTE.sessionId,
+        acquisition,
+        billing: BILLING,
+      });
     },
     async ready() {
       const physical = await control.getPhysicalRecord();
@@ -292,6 +333,7 @@ async function harness(
       const identity = connection;
       await hooks.onHandshakeComplete?.(identity);
       await hooks.onReady?.(identity);
+      await control.attachSession(ROUTE);
       return identity;
     },
     async fireAlarm() {
@@ -348,7 +390,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const physical = await h.control.getPhysicalRecord();
     expect(mocks.providerCreate).toHaveBeenCalledOnce();
     expect(h.allocations.size).toBe(1);
-    const runtime = h.allocations.get(physical.providerRef ?? '');
+    const runtime = h.runtime(physical.providerRef ?? '');
     expect(runtime?.startProcess).toHaveBeenCalledOnce();
     await h.evict();
     await h.acquire(acquisition);
@@ -360,7 +402,12 @@ describe('SandboxControl lifecycle boundaries', () => {
 
   it('binds a new acquisition to an existing create intent without issuing provider I/O', async () => {
     const h = await harness();
-    const claimed = await h.control.claimCreate('existing_intent');
+    const claimed = await h.control.claimCreate(
+      'existing_intent',
+      false,
+      SANDBOX_ID,
+      WORKTREE_CREDENTIAL_CONTAINMENT
+    );
     const acquisition = { id: 'attempt_a', deadlineAt: Date.now() + SESSION_DELIVERY_TIMEOUT_MS };
     await expect(h.acquire(acquisition)).resolves.toMatchObject({ physical: 'creating' });
     expect(h.records.get('acquisition_receipts')).toEqual([
@@ -455,7 +502,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     await h.control.recordStopAttempt();
     await h.flush();
     expect((await h.control.getPhysicalRecord()).state).toBe('stopped');
-    expect(h.allocations.get(original.providerInstanceId)?.state.running).toBe(false);
+    expect(h.runtime(original.providerInstanceId)?.state.running).toBe(false);
     await h.evict();
     await expect(h.acquire(acquisition)).rejects.toThrow('no longer owns this allocation');
     expect(mocks.providerCreate).toHaveBeenCalledOnce();
@@ -467,7 +514,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     expect((await h.control.getPhysicalRecord()).providerRef).toBe(replacement.providerInstanceId);
     expect(h.allocations.size).toBe(2);
     expect(mocks.providerCreate).toHaveBeenCalledTimes(2);
-    expect(h.allocations.get(replacement.providerInstanceId)?.startProcess).toHaveBeenCalledOnce();
+    expect(h.runtime(replacement.providerInstanceId)?.startProcess).toHaveBeenCalledOnce();
   });
 
   it('binds warm acquisition before billing and rejects its late reply after replacement', async () => {
@@ -477,7 +524,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const acquisition = { id: 'attempt_a', deadlineAt: Date.now() + SESSION_DELIVERY_TIMEOUT_MS };
     const billing = deferred<void>();
     const entered = deferred<void>();
-    h.allocations.get(original.providerInstanceId)?.configureBilling.mockImplementationOnce(() => {
+    h.runtime(original.providerInstanceId)?.configureBilling.mockImplementationOnce(() => {
       entered.resolve();
       return billing.promise;
     });
@@ -534,11 +581,11 @@ describe('SandboxControl lifecycle boundaries', () => {
       expect(h.records.has('acquisition_receipts')).toBe(false);
       expect((await h.control.getPhysicalRecord()).createIntent).toEqual(retired.createIntent);
       expect(h.allocations.size).toBe(1);
-      expect(h.allocations.get(original.providerInstanceId)?.startProcess).toHaveBeenCalledOnce();
+      expect(h.runtime(original.providerInstanceId)?.startProcess).toHaveBeenCalledOnce();
       await h.control.recordStopAttempt();
       await h.flush();
       expect((await h.control.getPhysicalRecord()).state).toBe('stopped');
-      expect(h.allocations.get(original.providerInstanceId)?.state.running).toBe(false);
+      expect(h.runtime(original.providerInstanceId)?.state.running).toBe(false);
       await h.evict();
       await h.acquire(acquisition);
       expect(h.allocations.size).toBe(2);
@@ -565,7 +612,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     await expect(h.acquire(acquisition)).rejects.toThrow('no longer owns this allocation');
     expect(h.allocations.size).toBe(1);
-    expect(h.allocations.get(original.providerInstanceId)?.startProcess).toHaveBeenCalledOnce();
+    expect(h.runtime(original.providerInstanceId)?.startProcess).toHaveBeenCalledOnce();
   });
 
   it.each([
@@ -624,7 +671,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     expect([...h.records]).toEqual(snapshot);
     expect(h.alarmAt).toBe(alarmAt);
     expect(closeAll).toHaveBeenCalledTimes(closes);
-    expect(h.allocations.get(identity.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+    expect(h.runtime(identity.providerInstanceId)?.destroy).not.toHaveBeenCalled();
     await expect(h.control.getStatus()).resolves.toMatchObject({
       physical: 'running',
       connection: 'ready',
@@ -682,7 +729,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       expect(await loadDeadlines(h.storage)).toEqual(repaired);
       expect((await h.control.getPhysicalRecord()).stopTombstone?.attempts).toBe(0);
       await h.fireAlarm();
-      expect(h.allocations.get(identity.providerInstanceId)?.state.running).toBe(false);
+      expect(h.runtime(identity.providerInstanceId)?.state.running).toBe(false);
       expect((await h.control.getPhysicalRecord()).state).toBe('stopped');
       expect(h.alarmAt).toBeNull();
     }
@@ -742,7 +789,7 @@ describe('SandboxControl lifecycle boundaries', () => {
           replacement.providerInstanceId
         );
         expect(mocks.providerCreate).toHaveBeenCalledTimes(2);
-        expect(h.allocations.get(replacement.providerInstanceId)?.state.running).toBe(true);
+        expect(h.runtime(replacement.providerInstanceId)?.state.running).toBe(true);
       });
 
       it.each(['', 'not-a-uuid', 123, null])(
@@ -871,7 +918,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       vi.setSystemTime(idleAt);
       await h.control.alarm();
       await h.flush();
-      expect(h.allocations.get(identity.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+      expect(h.runtime(identity.providerInstanceId)?.destroy).not.toHaveBeenCalled();
       await expect(h.control.getStatus()).resolves.toMatchObject({
         physical: 'running',
         connection: 'ready',
@@ -892,7 +939,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     await h.hooks.onHeartbeat?.(activeHeartbeat, identity);
     expect((await loadDeadlines(h.storage)).idleStop).toBeUndefined();
     await h.control.alarm();
-    expect(h.allocations.get(identity.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+    expect(h.runtime(identity.providerInstanceId)?.destroy).not.toHaveBeenCalled();
     await expect(h.control.getStatus()).resolves.toMatchObject({ reported: 'working' });
   });
 
@@ -966,7 +1013,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     expect((await h.control.getPhysicalRecord()).state).toBe('failed');
     vi.setSystemTime(Date.now() + DEADLINE_MS.createSettle);
     await h.fireAlarm();
-    expect(h.allocations.get(identity.providerInstanceId)?.state.running).toBe(false);
+    expect(h.runtime(identity.providerInstanceId)?.state.running).toBe(false);
     expect((await h.control.getPhysicalRecord()).state).toBe('stopped');
     await h.create();
     const replacement = await h.ready();
@@ -990,7 +1037,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const h = await harness();
     await h.create();
     const identity = await h.ready();
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     runtime.destroy.mockImplementation(async () => {
       expect(h.transactionActive).toBe(false);
@@ -1001,7 +1048,9 @@ describe('SandboxControl lifecycle boundaries', () => {
     mocks.getSandbox.mockClear();
     await h.control.beginStop('execution_failed');
     await h.control.recordStopAttempt();
-    expect(h.namespace.getByName).toHaveBeenCalledWith(identity.providerInstanceId);
+    expect(h.namespace.getByName).toHaveBeenCalledWith(
+      decodeCloudflareProviderRef(identity.providerInstanceId)?.sandboxId
+    );
     expect(mocks.getSandbox).not.toHaveBeenCalled();
     expect(runtime.state.running).toBe(false);
   });
@@ -1023,14 +1072,19 @@ describe('SandboxControl lifecycle boundaries', () => {
     await h.create();
     const physical = await h.control.getPhysicalRecord();
     expect(observed).toEqual([{ providerRef: physical.providerRef, alarmAt: expect.any(Number) }]);
-    expect(physical.providerRef).toMatch(/^ses-[a-f0-9]{48}$/);
-    expect(physical.providerRef).not.toBe(SANDBOX_ID);
-    expect(physical.createIntent?.allocationName).toBe(physical.providerRef);
+    const native = decodeCloudflareProviderRef(physical.providerRef);
+    expect(native?.sandboxId).toMatch(/^ses-[a-f0-9]{48}$/);
+    expect(native?.sandboxId).not.toBe(SANDBOX_ID);
+    expect(native).toEqual({
+      sandboxId: physical.createIntent?.allocationName,
+      containment: true,
+      instanceId: physical.createIntent?.intentId,
+    });
     expect(await loadDeadlines(h.storage)).toHaveProperty('startup');
-    const runtime = h.allocations.get(physical.providerRef ?? '');
+    const runtime = h.runtime(physical.providerRef ?? '');
     expect(runtime?.configureBilling).toHaveBeenCalledWith({
       ...BILLING,
-      sandboxId: physical.providerRef,
+      sandboxId: native?.sandboxId,
     });
     expect(runtime?.startProcess).toHaveBeenCalledWith(
       expect.any(String),
@@ -1057,6 +1111,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     const result = await h.control.ensureReady({
       ownerId: OWNER,
+      sessionId: ROUTE.sessionId,
       allowCreate: true,
       billing: { ...BILLING, enforcementRequested: true },
     });
@@ -1071,21 +1126,21 @@ describe('SandboxControl lifecycle boundaries', () => {
 
   it('adopts billing for an already-running unmetered Cloudflare allocation without waking it again', async () => {
     const h = await harness();
-    await h.control.ensureReady({ ownerId: OWNER, allowCreate: true });
+    await h.control.ensureReady({ ownerId: OWNER, sessionId: ROUTE.sessionId, allowCreate: true });
     const connection = await h.ready();
-    const runtime = h.allocations.get(connection.providerInstanceId);
+    const runtime = h.runtime(connection.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     let metered = false;
     runtime.configureBilling.mockImplementation(async () => {
       metered = true;
     });
     await expect(
-      h.control.ensureReady({ ownerId: OWNER, billing: BILLING })
+      h.control.ensureReady({ ownerId: OWNER, sessionId: ROUTE.sessionId, billing: BILLING })
     ).resolves.toMatchObject({ reported: 'ready' });
     expect(metered).toBe(true);
     expect(runtime.configureBilling).toHaveBeenCalledWith({
       ...BILLING,
-      sandboxId: connection.providerInstanceId,
+      sandboxId: decodeCloudflareProviderRef(connection.providerInstanceId)?.sandboxId,
     });
     expect(runtime.startProcess).toHaveBeenCalledTimes(1);
     expect(runtime.renewActivityTimeout).not.toHaveBeenCalled();
@@ -1093,7 +1148,12 @@ describe('SandboxControl lifecycle boundaries', () => {
     await h.control.recordStopAttempt();
     runtime.configureBilling.mockClear();
     await expect(
-      h.control.ensureReady({ ownerId: OWNER, billing: BILLING, allowCreate: false })
+      h.control.ensureReady({
+        ownerId: OWNER,
+        sessionId: ROUTE.sessionId,
+        billing: BILLING,
+        allowCreate: false,
+      })
     ).resolves.toMatchObject({ physical: 'stopped' });
     expect(runtime.configureBilling).not.toHaveBeenCalled();
     expect(runtime.ensureBillingAdmission).not.toHaveBeenCalled();
@@ -1103,9 +1163,9 @@ describe('SandboxControl lifecycle boundaries', () => {
 
   it('checks enforcement toggles before each warm Cloudflare handoff and denies without execution or wake', async () => {
     const h = await harness();
-    await h.control.ensureReady({ ownerId: OWNER, allowCreate: true });
+    await h.control.ensureReady({ ownerId: OWNER, sessionId: ROUTE.sessionId, allowCreate: true });
     const connection = await h.ready();
-    const runtime = h.allocations.get(connection.providerInstanceId);
+    const runtime = h.runtime(connection.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     h.env.CLOUD_AGENT_CONTAINER_BILLING_ENABLED = 'true';
     h.env.CLOUD_AGENT_CONTAINER_BILLING_USER_IDS = OWNER;
@@ -1115,17 +1175,19 @@ describe('SandboxControl lifecycle boundaries', () => {
       message: 'denied',
     });
     const handoff = () =>
-      h.control.ensureReady({ ownerId: OWNER, billing: BILLING }).then(() =>
-        h.control.request({
-          operation: 'session.prompt',
-          session: ROUTE,
-          payload: { ...PROMPT, messageId: 'message_B' },
-        })
-      );
+      h.control
+        .ensureReady({ ownerId: OWNER, sessionId: ROUTE.sessionId, billing: BILLING })
+        .then(() =>
+          h.control.request({
+            operation: 'session.prompt',
+            session: ROUTE,
+            payload: { ...PROMPT, messageId: 'message_B' },
+          })
+        );
     await expect(handoff()).rejects.toThrow('additional credits');
     expect(runtime.ensureBillingAdmission).toHaveBeenCalledWith({
       ...BILLING,
-      sandboxId: connection.providerInstanceId,
+      sandboxId: decodeCloudflareProviderRef(connection.providerInstanceId)?.sandboxId,
       enforcementRequested: true,
     });
     expect(h.sendRequest).not.toHaveBeenCalled();
@@ -1153,7 +1215,13 @@ describe('SandboxControl lifecycle boundaries', () => {
       },
     });
     await h.storage.put('provider_kind', 'vercel');
-    await h.control.claimCreate('existing_allocation');
+    await h.control.claimCreate(
+      'existing_allocation',
+      false,
+      'ses-123abc',
+      WORKTREE_CREDENTIAL_CONTAINMENT
+    );
+    await h.control.prepareSessionCredentials({ ownerId: OWNER, sessionId: ROUTE.sessionId });
     await h.control.confirmInstance(
       JSON.stringify({ sandboxName: 'ses-123abc', sessionId: 'vsess_1' })
     );
@@ -1162,13 +1230,20 @@ describe('SandboxControl lifecycle boundaries', () => {
     h.env.CLOUD_AGENT_CONTAINER_BILLING_ENABLED = 'true';
     h.env.CLOUD_AGENT_CONTAINER_BILLING_USER_IDS = OWNER;
     await expect(
-      h.control.ensureReady({ ownerId: OWNER, provider: 'vercel', billing: BILLING }).then(() =>
-        h.control.request({
-          operation: 'session.prompt',
-          session: ROUTE,
-          payload: { ...PROMPT, messageId: 'message_B' },
+      h.control
+        .ensureReady({
+          ownerId: OWNER,
+          sessionId: ROUTE.sessionId,
+          provider: 'vercel',
+          billing: BILLING,
         })
-      )
+        .then(() =>
+          h.control.request({
+            operation: 'session.prompt',
+            session: ROUTE,
+            payload: { ...PROMPT, messageId: 'message_B' },
+          })
+        )
     ).rejects.toThrow('billing admission is unavailable for Vercel');
     expect(fetchProvider).not.toHaveBeenCalled();
     expect(h.sendRequest).not.toHaveBeenCalled();
@@ -1177,14 +1252,18 @@ describe('SandboxControl lifecycle boundaries', () => {
 
   it('bounds a hanging warm admission without handing off new execution', async () => {
     const h = await harness();
-    await h.control.ensureReady({ ownerId: OWNER, allowCreate: true });
+    await h.control.ensureReady({ ownerId: OWNER, sessionId: ROUTE.sessionId, allowCreate: true });
     const connection = await h.ready();
-    const runtime = h.allocations.get(connection.providerInstanceId);
+    const runtime = h.runtime(connection.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     runtime.ensureBillingAdmission.mockImplementation(() => new Promise(() => undefined));
     const denied = expect(
       h.control
-        .ensureReady({ ownerId: OWNER, billing: { ...BILLING, enforcementRequested: true } })
+        .ensureReady({
+          ownerId: OWNER,
+          sessionId: ROUTE.sessionId,
+          billing: { ...BILLING, enforcementRequested: true },
+        })
         .then(() =>
           h.control.request({
             operation: 'session.prompt',
@@ -1204,16 +1283,15 @@ describe('SandboxControl lifecycle boundaries', () => {
     const admitted = deferred<{ success: true }>();
     const checking = deferred<void>();
     const h = await harness();
-    await h.control.ensureReady({ ownerId: OWNER, allowCreate: true });
+    await h.control.ensureReady({ ownerId: OWNER, sessionId: ROUTE.sessionId, allowCreate: true });
     const connection = await h.ready();
-    h.allocations
-      .get(connection.providerInstanceId)
-      ?.ensureBillingAdmission.mockImplementationOnce(() => {
-        checking.resolve();
-        return admitted.promise;
-      });
+    h.runtime(connection.providerInstanceId)?.ensureBillingAdmission.mockImplementationOnce(() => {
+      checking.resolve();
+      return admitted.promise;
+    });
     const previous = h.control.ensureReady({
       ownerId: OWNER,
+      sessionId: ROUTE.sessionId,
       billing: { ...BILLING, enforcementRequested: true },
     });
     await checking.promise;
@@ -1238,7 +1316,12 @@ describe('SandboxControl lifecycle boundaries', () => {
   it('rejects missing provider configuration and mismatched billing without an illegal transition', async () => {
     const h = await harness();
     await expect(
-      h.control.ensureReady({ ownerId: OWNER, provider: 'vercel', allowCreate: true })
+      h.control.ensureReady({
+        ownerId: OWNER,
+        sessionId: ROUTE.sessionId,
+        provider: 'vercel',
+        allowCreate: true,
+      })
     ).rejects.toThrow('configuration is unavailable');
     await expect(h.control.getPhysicalRecord()).resolves.toMatchObject({
       state: 'stopped',
@@ -1247,6 +1330,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     await expect(
       h.control.ensureReady({
         ownerId: OWNER,
+        sessionId: ROUTE.sessionId,
         allowCreate: true,
         billing: {
           ...BILLING,
@@ -1263,7 +1347,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const h = await harness();
     await h.create();
     const identity = await h.ready();
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     await h.hooks.onHeartbeat?.(activeHeartbeat, identity);
     expect(runtime?.renewActivityTimeout).toHaveBeenCalledTimes(1);
     await h.hooks.onHeartbeat?.({ ...activeHeartbeat, kilo: { ready: false } }, identity);
@@ -1283,7 +1367,12 @@ describe('SandboxControl lifecycle boundaries', () => {
       physical: 'stopped',
       connection: 'disconnected',
     });
-    await h.control.ensureReady({ ownerId: OWNER, allowCreate: false, billing: BILLING });
+    await h.control.ensureReady({
+      ownerId: OWNER,
+      sessionId: ROUTE.sessionId,
+      allowCreate: false,
+      billing: BILLING,
+    });
     expect(h.allocations.size).toBe(1);
     await h.create();
     const replacement = await h.ready();
@@ -1378,8 +1467,8 @@ describe('SandboxControl lifecycle boundaries', () => {
     expect(h.alarmAt).not.toBeNull();
     await h.evict();
     await h.fireAlarm();
-    expect(h.allocations.get(identity.providerInstanceId)?.state.running).toBe(false);
-    expect(h.allocations.get(identity.providerInstanceId)?.destroy).toHaveBeenCalledTimes(2);
+    expect(h.runtime(identity.providerInstanceId)?.state.running).toBe(false);
+    expect(h.runtime(identity.providerInstanceId)?.destroy).toHaveBeenCalledTimes(2);
     await expect(h.control.quarantineRuntime(input)).resolves.toEqual({ quarantined: false });
     expect((await h.control.getPhysicalRecord()).providerRef).toBeNull();
   });
@@ -1407,7 +1496,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     await h.create();
     const identity = await h.ready();
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     await h.control.beginStop('execution_failed');
     for (let attempt = 1; attempt <= DEADLINE_MS.stopAttemptLadder.length; attempt++) {
@@ -1419,7 +1508,12 @@ describe('SandboxControl lifecycle boundaries', () => {
       physical: 'unknown',
       connection: 'disconnected',
     });
-    await h.control.ensureReady({ ownerId: OWNER, allowCreate: true, billing: BILLING });
+    await h.control.ensureReady({
+      ownerId: OWNER,
+      sessionId: ROUTE.sessionId,
+      allowCreate: true,
+      billing: BILLING,
+    });
     await h.hooks.onReady?.(identity);
     expect(h.allocations.size).toBe(1);
     expect((await h.control.getPhysicalRecord()).state).toBe('unknown');
@@ -1477,7 +1571,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       stopTombstone: { attempts: 1 },
     });
     expect(h.alarmAt).toBeGreaterThan(Date.now());
-    expect(h.allocations.get(identity.providerInstanceId)?.destroy).toHaveBeenCalledTimes(1);
+    expect(h.runtime(identity.providerInstanceId)?.destroy).toHaveBeenCalledTimes(1);
     await h.flush();
   });
 
@@ -1487,11 +1581,16 @@ describe('SandboxControl lifecycle boundaries', () => {
     await h.create();
     const identity = await h.ready();
     await h.control.observeProvider('unknown');
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     runtime.isContainerRunning.mockImplementation(() => observation.promise);
 
-    const status = h.control.ensureReady({ ownerId: OWNER, allowCreate: true, billing: BILLING });
+    const status = h.control.ensureReady({
+      ownerId: OWNER,
+      sessionId: ROUTE.sessionId,
+      allowCreate: true,
+      billing: BILLING,
+    });
     await vi.advanceTimersByTimeAsync(DEADLINE_MS.stopAttempt);
     await expect(status).resolves.toMatchObject({ physical: 'unknown' });
     await expect(h.control.getPhysicalRecord()).resolves.toMatchObject({
@@ -1520,12 +1619,13 @@ describe('SandboxControl lifecycle boundaries', () => {
       }
     );
     await h.create();
+    await h.control.attachSession(ROUTE);
     const first = await h.control.getPhysicalRecord();
     await h.control.markFailed();
     vi.setSystemTime(Date.now() + DEADLINE_MS.createSettle);
     await h.control.recordStopAttempt();
     expect((await h.control.getPhysicalRecord()).state).toBe('stopped');
-    expect(h.allocations.get(first.providerRef ?? '')?.state.running).toBe(false);
+    expect(h.runtime(first.providerRef ?? '')?.state.running).toBe(false);
     await h.create();
     const replacement = await h.ready();
     const currentWrapperInstanceId = replacement.wrapperInstanceId;
@@ -1546,7 +1646,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const h = await harness();
     await h.create();
     const identity = await h.ready();
-    h.allocations.get(identity.providerInstanceId)?.destroy.mockImplementation(() => stop.promise);
+    h.runtime(identity.providerInstanceId)?.destroy.mockImplementation(() => stop.promise);
     await h.control.beginStop('execution_failed');
     const oldStop = h.control.recordStopAttempt();
     await vi.advanceTimersByTimeAsync(0);
@@ -1592,7 +1692,11 @@ describe('SandboxControl lifecycle boundaries', () => {
     const creating = h.create();
     await started.promise;
     const physical = await h.control.getPhysicalRecord();
-    expect(physical.providerRef).toBe(physical.createIntent?.allocationName);
+    expect(decodeCloudflareProviderRef(physical.providerRef)).toEqual({
+      sandboxId: physical.createIntent?.allocationName,
+      containment: true,
+      instanceId: physical.createIntent?.intentId,
+    });
     expect(h.alarmAt).not.toBeNull();
     await vi.advanceTimersByTimeAsync(DEADLINE_MS.startup);
     await expect(creating).resolves.toMatchObject({ physical: 'failed' });
@@ -1708,6 +1812,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     const creating = h.control.ensureReady({
       ownerId: OWNER,
+      sessionId: ROUTE.sessionId,
       provider: 'vercel',
       allowCreate: true,
       billing: BILLING,
@@ -1755,9 +1860,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       'control_disconnected'
     );
     await h.hooks.onHeartbeat?.(activeHeartbeat, identity);
-    expect(
-      h.allocations.get(identity.providerInstanceId)?.renewActivityTimeout
-    ).not.toHaveBeenCalled();
+    expect(h.runtime(identity.providerInstanceId)?.renewActivityTimeout).not.toHaveBeenCalled();
     expect(h.session.failWaitingMessages).toHaveBeenCalledWith(
       'control_disconnected',
       identity.wrapperInstanceId
@@ -1793,7 +1896,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       reported: 'working',
       wrapperInstanceId: connection.wrapperInstanceId,
     });
-    expect(h.allocations.get(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+    expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
     expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
   });
 
@@ -1827,7 +1930,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       reported: 'working',
       wrapperInstanceId: connection.wrapperInstanceId,
     });
-    expect(h.allocations.get(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+    expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
     expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
   });
 
@@ -1871,7 +1974,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       'session_delivery_failed',
       connection.wrapperInstanceId
     );
-    expect(h.allocations.get(connection.providerInstanceId)?.state.running).toBe(false);
+    expect(h.runtime(connection.providerInstanceId)?.state.running).toBe(false);
   });
 
   it('does not quarantine a route detached while its forwarding acknowledgement was pending', async () => {
@@ -1890,7 +1993,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     forwarding.reject(new Error('Session transport failed'));
     await h.flush();
     expect((await h.control.getPhysicalRecord()).stopTombstone).toBeNull();
-    expect(h.allocations.get(connection.providerInstanceId)?.state.running).toBe(true);
+    expect(h.runtime(connection.providerInstanceId)?.state.running).toBe(true);
     expect(h.session.failWaitingMessages).not.toHaveBeenCalled();
   });
 
@@ -1958,9 +2061,9 @@ describe('SandboxControl lifecycle boundaries', () => {
     }
     expect((await h.control.getPhysicalRecord()).state).toBe('running');
     expect(await loadDeadlines(h.storage)).not.toHaveProperty('idleStop');
-    expect(h.allocations.get(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+    expect(h.runtime(connection.providerInstanceId)?.destroy).not.toHaveBeenCalled();
     await h.fireAlarm();
-    expect(h.allocations.get(connection.providerInstanceId)?.state.running).toBe(false);
+    expect(h.runtime(connection.providerInstanceId)?.state.running).toBe(false);
     expect(h.session.failWaitingMessages).toHaveBeenCalledWith(
       'heartbeat_expired',
       connection.wrapperInstanceId
@@ -1975,7 +2078,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     await h.create();
     const identity = await h.ready();
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     await h.control.beginStop('execution_failed');
     for (let attempt = 0; attempt < 5; attempt++) await h.fireAlarm();
@@ -2003,7 +2106,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     await h.create();
     const identity = await h.ready();
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     await h.control.beginStop('execution_failed');
     for (let attempt = 0; attempt < 5; attempt++) await h.fireAlarm();
@@ -2029,7 +2132,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     await h.create();
     const identity = await h.ready();
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     await h.control.beginStop('execution_failed');
     const firstAttempt = h.fireAlarm();
@@ -2057,7 +2160,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       const h = await harness();
       await h.create();
       const identity = await h.ready();
-      const runtime = h.allocations.get(identity.providerInstanceId);
+      const runtime = h.runtime(identity.providerInstanceId);
       if (!runtime) throw new Error('Missing runtime');
       runtime.destroy
         .mockRejectedValue(new Error('provider unavailable'))
@@ -2106,7 +2209,7 @@ describe('SandboxControl lifecycle boundaries', () => {
         replacement.providerInstanceId
       );
       expect(h.alarmAt).toBe(replacementAlarm);
-      expect(h.allocations.get(replacement.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+      expect(h.runtime(replacement.providerInstanceId)?.destroy).not.toHaveBeenCalled();
     }
   );
 
@@ -2116,7 +2219,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const h = await harness();
     await h.create();
     const identity = await h.ready();
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     runtime.destroy
       .mockImplementationOnce(() => oldStop.promise)
@@ -2170,7 +2273,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       reconciliation: Date.now() + DEADLINE_MS.reconciliation,
     });
     await h.fireAlarm();
-    expect(h.allocations.get(identity.providerInstanceId)?.destroy).toHaveBeenCalledTimes(1);
+    expect(h.runtime(identity.providerInstanceId)?.destroy).toHaveBeenCalledTimes(1);
     expect((await h.control.getPhysicalRecord()).state).toBe('stopped');
   });
 
@@ -2179,7 +2282,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const h = await harness();
     await h.create();
     const identity = await h.ready();
-    const original = h.allocations.get(identity.providerInstanceId);
+    const original = h.runtime(identity.providerInstanceId);
     if (!original) throw new Error('Missing runtime');
     original.destroy.mockImplementation(async () => {
       original.state.running = false;
@@ -2194,7 +2297,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const replacement = await h.ready();
     await h.control.beginStop('replacement_failed');
     await h.control.recordStopAttempt();
-    expect(h.allocations.get(replacement.providerInstanceId)?.destroy).toHaveBeenCalledTimes(1);
+    expect(h.runtime(replacement.providerInstanceId)?.destroy).toHaveBeenCalledTimes(1);
     expect((await h.control.getPhysicalRecord()).state).toBe('stopped');
     acknowledged.resolve();
     await oldStop;
@@ -2206,7 +2309,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     const h = await harness();
     await h.create();
     const identity = await h.ready();
-    const runtime = h.allocations.get(identity.providerInstanceId);
+    const runtime = h.runtime(identity.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     const start = Date.now();
     for (let elapsed = 0; elapsed <= DEADLINE_MS.createSettle; elapsed += 30_000) {
@@ -2245,7 +2348,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       });
       await h.create();
       const identity = await h.ready();
-      const runtime = h.allocations.get(identity.providerInstanceId);
+      const runtime = h.runtime(identity.providerInstanceId);
       if (!runtime) throw new Error('Missing runtime');
       await h.control.beginStop('execution_failed');
       for (let attempt = 0; attempt < 5; attempt++) await h.fireAlarm();
@@ -2265,7 +2368,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       stop.resolve();
       await reaping;
       expect(runtime.destroy).toHaveBeenCalledTimes(stage === 'observation' ? 5 : 6);
-      expect(h.allocations.get(replacement.providerInstanceId)?.destroy).not.toHaveBeenCalled();
+      expect(h.runtime(replacement.providerInstanceId)?.destroy).not.toHaveBeenCalled();
       expect((await h.control.getPhysicalRecord()).providerRef).toBe(
         replacement.providerInstanceId
       );
@@ -2290,7 +2393,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     for (let attempt = 0; attempt < DEADLINE_MS.stopAttemptLadder.length; attempt++)
       await h.fireAlarm();
     const retired = await h.control.getPhysicalRecord();
-    const runtime = h.allocations.get(connection.providerInstanceId);
+    const runtime = h.runtime(connection.providerInstanceId);
     if (!runtime) throw new Error('Missing runtime');
     const billingCalls = runtime.configureBilling.mock.calls.length;
     for (let pass = 1; pass <= 14; pass++) {
@@ -2365,18 +2468,20 @@ describe('SandboxControl lifecycle boundaries', () => {
     });
     await h.create();
     const connection = await h.ready();
-    const runtime = h.allocations.get(connection.providerInstanceId);
+    const runtime = h.runtime(connection.providerInstanceId);
+    const native = decodeCloudflareProviderRef(connection.providerInstanceId);
+    if (!native) throw new Error('Missing native allocation');
     const context: BillingContext = {
-      service: 'cloud-agent-next-sandbox-small',
-      instanceId: connection.providerInstanceId,
-      sku: SANDBOX_USAGE_SKUS.SandboxSmall,
+      service: 'cloud-agent-next-sandbox-small-containment',
+      instanceId: native.sandboxId,
+      sku: SANDBOX_USAGE_SKUS.SandboxSmallContainment,
       subject: BILLING.subject,
       actor: BILLING.actor,
       sessionId: ROUTE.sessionId,
       metadata: {
         origin: 'cloud-agent',
-        container_class: 'SandboxSmall',
-        durable_object_id: `do:${connection.providerInstanceId}`,
+        container_class: 'SandboxSmallContainment',
+        durable_object_id: `do:${native.sandboxId}`,
       },
       startEpochMs: Date.now(),
       generation: crypto.randomUUID(),
@@ -2385,7 +2490,7 @@ describe('SandboxControl lifecycle boundaries', () => {
       usageMeasuredAtMs: Date.now(),
     };
     runtime?.getBillingRuntimeStatus.mockResolvedValue({
-      sandboxClassName: 'SandboxSmall',
+      sandboxClassName: 'SandboxSmallContainment',
       running: true,
       blocked: false,
       context,
@@ -2399,7 +2504,7 @@ describe('SandboxControl lifecycle boundaries', () => {
     ).resolves.toEqual({ allowed: true });
     expect(h.allocations.has(SANDBOX_ID)).toBe(false);
     runtime?.getBillingRuntimeStatus.mockResolvedValue({
-      sandboxClassName: 'SandboxSmall',
+      sandboxClassName: 'SandboxSmallContainment',
       running: true,
       blocked: false,
       context: { ...context, instanceId: SANDBOX_ID },

--- a/services/cloud-agent-next/src/sandbox-control/managed-credential.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/managed-credential.test.ts
@@ -1,0 +1,109 @@
+import { Buffer } from 'node:buffer';
+import { describe, expect, it } from 'vitest';
+import {
+  createControlPlaneCredential,
+  isControlPlaneCredential,
+  parseControlPlaneCredential,
+} from './managed-credential.js';
+
+const SECRET = 'a'.repeat(64);
+
+function credentialFor(sandboxId: string): string {
+  return `kcp1.${Buffer.from(sandboxId).toString('base64url')}.kilo.${SECRET}`;
+}
+
+const unsafeSandboxIds = [
+  '',
+  '.',
+  '..',
+  '../sbx_1',
+  'sbx_1/other',
+  'sbx_1\\other',
+  'sbx_1%2fother',
+  'sbx_1?other',
+  'sbx_1#other',
+  'sbx_1\u0000',
+  'sbx_1\n',
+  'sbx_1\r',
+  'sbx_1\t',
+  ' sbx_1',
+  'sbx_1 ',
+  'sandbox-\u00e9',
+  'a'.repeat(257),
+];
+
+describe('control-plane managed credential', () => {
+  it.each(['kilo', 'github', 'gitlab', 'bitbucket'] as const)(
+    'creates opaque random %s aliases with a canonical sandbox routing identity',
+    purpose => {
+      const sandboxId = 'org-0123456789abcdef';
+      const first = createControlPlaneCredential(sandboxId, purpose);
+      const second = createControlPlaneCredential(sandboxId, purpose);
+
+      expect(first).toMatch(/^kcp1\.[A-Za-z0-9_-]+\.[a-z]+\.[0-9a-f]{64}$/);
+      expect(first.split('.')[1]).toBe(Buffer.from(sandboxId).toString('base64url'));
+      expect(first).not.toBe(second);
+      expect(isControlPlaneCredential(first)).toBe(true);
+      expect(parseControlPlaneCredential(first)).toEqual({ sandboxId, purpose });
+      expect(parseControlPlaneCredential(second)).toEqual({ sandboxId, purpose });
+    }
+  );
+
+  it.each(['a', 'sbx_1', 'usr-abc', 'legacy:user__sandbox.name', 'a'.repeat(256)])(
+    'preserves safe sandbox identities without normalization',
+    sandboxId => {
+      const credential = createControlPlaneCredential(sandboxId, 'kilo');
+      expect(parseControlPlaneCredential(credential)).toEqual({ sandboxId, purpose: 'kilo' });
+    }
+  );
+
+  it.each(unsafeSandboxIds)('rejects an unsafe sandbox identity', sandboxId => {
+    expect(() => createControlPlaneCredential(sandboxId, 'kilo')).toThrow(
+      'Invalid control-plane credential scope'
+    );
+    expect(parseControlPlaneCredential(credentialFor(sandboxId))).toBeNull();
+  });
+
+  it.each([
+    '',
+    'kcp1',
+    'kcp1.',
+    `kcp1.YQ.kilo`,
+    `kcp1.YQ.kilo.${SECRET}.extra`,
+    `kcp2.YQ.kilo.${SECRET}`,
+    `KCP1.YQ.kilo.${SECRET}`,
+    `kcp1.YQ..${SECRET}`,
+    `kcp1.YQ.KILO.${SECRET}`,
+    `kcp1.YQ.other.${SECRET}`,
+    `kcp1.YQ=.kilo.${SECRET}`,
+    `kcp1.YQ==.kilo.${SECRET}`,
+    `kcp1.YR.kilo.${SECRET}`,
+    `kcp1.Y Q.kilo.${SECRET}`,
+    `kcp1.YQ!.kilo.${SECRET}`,
+    `kcp1._w.kilo.${SECRET}`,
+    `kcp1.YQ.kilo.`,
+    `kcp1.YQ.kilo.${'a'.repeat(63)}`,
+    `kcp1.YQ.kilo.${'a'.repeat(65)}`,
+    `kcp1.YQ.kilo.${'A'.repeat(64)}`,
+    `kcp1.YQ.kilo.${'g'.repeat(64)}`,
+    `kcp1.YQ.kilo.${SECRET}\n`,
+    `kcp1.${'Y'.repeat(513)}.kilo.${SECRET}`,
+  ])('strictly rejects malformed or noncanonical aliases', credential => {
+    expect(parseControlPlaneCredential(credential)).toBeNull();
+  });
+
+  it.each(['kcp1', 'kcp1.', 'kcp1.invalid', 'kcp1-invalid', `kcp1.${'x'.repeat(10_000)}`])(
+    'identifies malformed aliases independently of parsing',
+    credential => {
+      expect(isControlPlaneCredential(credential)).toBe(true);
+      expect(parseControlPlaneCredential(credential)).toBeNull();
+    }
+  );
+
+  it.each(['', 'kka1.opaque', 'kgh2.opaque', 'raw-upstream-token', 'prefix-kcp1.invalid'])(
+    'does not classify unrelated credentials as control-plane aliases',
+    credential => {
+      expect(isControlPlaneCredential(credential)).toBe(false);
+    }
+  );
+});

--- a/services/cloud-agent-next/src/sandbox-control/managed-credential.ts
+++ b/services/cloud-agent-next/src/sandbox-control/managed-credential.ts
@@ -1,0 +1,63 @@
+import { Buffer } from 'node:buffer';
+import { generateSandboxCredential } from './credential.js';
+
+export type ControlCredentialPurpose = 'kilo' | 'github' | 'gitlab' | 'bitbucket';
+
+const CONTROL_CREDENTIAL_PREFIX = 'kcp1';
+const MAX_CONTROL_CREDENTIAL_LENGTH = 512;
+
+function isSafeSandboxId(sandboxId: string): boolean {
+  return (
+    sandboxId.length > 0 &&
+    sandboxId.length <= 256 &&
+    !/[^A-Za-z0-9._:-]/.test(sandboxId) &&
+    sandboxId !== '.' &&
+    sandboxId !== '..'
+  );
+}
+
+function isControlCredentialPurpose(purpose: string): purpose is ControlCredentialPurpose {
+  return (
+    purpose === 'kilo' || purpose === 'github' || purpose === 'gitlab' || purpose === 'bitbucket'
+  );
+}
+
+export function createControlPlaneCredential(
+  sandboxId: string,
+  purpose: ControlCredentialPurpose
+): string {
+  if (!isSafeSandboxId(sandboxId) || !isControlCredentialPurpose(purpose)) {
+    throw new Error('Invalid control-plane credential scope');
+  }
+  return `${CONTROL_CREDENTIAL_PREFIX}.${Buffer.from(sandboxId).toString('base64url')}.${purpose}.${generateSandboxCredential()}`;
+}
+
+export function parseControlPlaneCredential(
+  credential: string
+): { sandboxId: string; purpose: ControlCredentialPurpose } | null {
+  if (credential.length > MAX_CONTROL_CREDENTIAL_LENGTH) return null;
+  const parts = credential.split('.');
+  if (parts.length !== 4) return null;
+  const [prefix, encodedSandboxId, purpose, secret] = parts;
+  if (
+    prefix !== CONTROL_CREDENTIAL_PREFIX ||
+    !encodedSandboxId ||
+    !isControlCredentialPurpose(purpose) ||
+    secret.length !== 64 ||
+    /[^0-9a-f]/.test(secret)
+  ) {
+    return null;
+  }
+  const sandboxId = Buffer.from(encodedSandboxId, 'base64url').toString('utf8');
+  if (
+    !isSafeSandboxId(sandboxId) ||
+    Buffer.from(sandboxId).toString('base64url') !== encodedSandboxId
+  ) {
+    return null;
+  }
+  return { sandboxId, purpose };
+}
+
+export function isControlPlaneCredential(credential: string): boolean {
+  return credential.startsWith(CONTROL_CREDENTIAL_PREFIX);
+}

--- a/services/cloud-agent-next/src/sandbox-control/physical-lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/physical-lifecycle.test.ts
@@ -9,12 +9,17 @@ import {
   initialPhysicalRecord,
   observe,
   recordStopAttempt,
+  WORKTREE_CREDENTIAL_CONTAINMENT,
   type PhysicalRecord,
 } from './physical-lifecycle.js';
 
 const NOW = 1_000;
 const INTENT_ID = 'intent_1';
 const PROVIDER_REF = 'ref_1';
+const CONTAINMENT_CASES = [
+  { name: 'legacy flags', containment: { kilocode: true, github: false } },
+  { name: 'worktree scope', containment: WORKTREE_CREDENTIAL_CONTAINMENT },
+];
 
 function stopped(resumable = true): PhysicalRecord {
   return initialPhysicalRecord(resumable);
@@ -50,6 +55,19 @@ describe('physical sandbox lifecycle', () => {
     expect(record.stopTombstone).toBeNull();
   });
 
+  it.each(CONTAINMENT_CASES)(
+    'claimCreate records only requested containment $name in the creation intent',
+    ({ containment }) => {
+      const record = claimCreate(stopped(), INTENT_ID, NOW, undefined, containment);
+      expect(record.createIntent).toStrictEqual({
+        intentId: INTENT_ID,
+        createdAt: NOW,
+        containment,
+      });
+      expect(record.containment).toBeUndefined();
+    }
+  );
+
   it('claimCreate from non-stopped throws', () => {
     expect(() => claimCreate(creating(), INTENT_ID, NOW)).toThrow('claimCreate from creating');
     expect(() => claimCreate(running(), INTENT_ID, NOW)).toThrow('claimCreate from running');
@@ -63,7 +81,49 @@ describe('physical sandbox lifecycle', () => {
     expect(record.state).toBe('running');
     expect(record.providerRef).toBe(PROVIDER_REF);
     expect(record.createIntent).toEqual({ intentId: INTENT_ID, createdAt: NOW });
+    expect(record.containment).toBeUndefined();
   });
+
+  it.each(CONTAINMENT_CASES)(
+    'confirmRunning atomically binds containment $name to the exact provider reference',
+    ({ containment }) => {
+      const record = confirmRunning(
+        claimCreate(stopped(), INTENT_ID, NOW, undefined, containment),
+        PROVIDER_REF,
+        NOW
+      );
+      expect(record.createIntent).toStrictEqual({
+        intentId: INTENT_ID,
+        createdAt: NOW,
+        containment,
+      });
+      expect(record.containment).toStrictEqual({ ...containment, providerRef: PROVIDER_REF });
+      expect(confirmRunning(record, PROVIDER_REF, NOW)).toBe(record);
+    }
+  );
+
+  it.each(CONTAINMENT_CASES)(
+    'active observation promotes containment $name to the observed provider reference',
+    ({ containment }) => {
+      const record = observe(
+        {
+          ...claimCreate(stopped(), INTENT_ID, NOW, undefined, containment),
+          providerRef: PROVIDER_REF,
+        },
+        'active'
+      );
+      expect(record).toMatchObject({
+        state: 'running',
+        providerRef: PROVIDER_REF,
+      });
+      expect(record.createIntent).toStrictEqual({
+        intentId: INTENT_ID,
+        createdAt: NOW,
+        containment,
+      });
+      expect(record.containment).toStrictEqual({ ...containment, providerRef: PROVIDER_REF });
+    }
+  );
 
   it('beginStop from creating with no ref still writes a tombstone', () => {
     const record = beginStop(creating(), 'idle', NOW);
@@ -89,6 +149,45 @@ describe('physical sandbox lifecycle', () => {
       resumable: true,
     });
   });
+
+  it.each(CONTAINMENT_CASES)(
+    'retains bound containment $name through failed and unknown states until stopped',
+    ({ containment }) => {
+      const contained = confirmRunning(
+        claimCreate(stopped(), INTENT_ID, NOW, undefined, containment),
+        PROVIDER_REF,
+        NOW
+      );
+      const marker = { ...containment, providerRef: PROVIDER_REF };
+      expect(fail(contained, NOW).containment).toStrictEqual(marker);
+      const unknown = observe(contained, 'unknown');
+      expect(unknown.containment).toStrictEqual(marker);
+      expect(observe(unknown, 'active').containment).toStrictEqual(marker);
+      const stopping = beginStop(contained, 'idle', NOW);
+      expect(exhaustStopRetries(stopping).containment).toStrictEqual(marker);
+      expect(confirmStopped(stopping).containment).toBeUndefined();
+      expect(observe(fail(contained, NOW), 'terminal').containment).toBeUndefined();
+      expect(confirmStopped(unknown).containment).toBeUndefined();
+    }
+  );
+
+  it.each(CONTAINMENT_CASES)(
+    'preserves creation containment $name through failure and unknown observation',
+    ({ containment }) => {
+      const claimed = {
+        ...claimCreate(stopped(), INTENT_ID, NOW, undefined, containment),
+        providerRef: PROVIDER_REF,
+      };
+      const failed = fail(claimed, NOW);
+      expect(failed.createIntent).toStrictEqual(claimed.createIntent);
+      const unknown = observe(failed, 'unknown');
+      expect(unknown.createIntent).toStrictEqual(claimed.createIntent);
+      expect(observe(unknown, 'active')).toStrictEqual(unknown);
+      expect(unknown.containment).toBeUndefined();
+      expect(unknown.stopTombstone).toStrictEqual(failed.stopTombstone);
+      expect(confirmStopped(unknown)).toStrictEqual(stopped());
+    }
+  );
 
   it('observe unknown never goes to stopped', () => {
     expect(observe(creating(), 'unknown').state).toBe('creating');

--- a/services/cloud-agent-next/src/sandbox-control/physical-lifecycle.ts
+++ b/services/cloud-agent-next/src/sandbox-control/physical-lifecycle.ts
@@ -2,6 +2,18 @@ import type { VercelSandboxRuntimeConfig } from '../agent-sandbox/vercel/vercel-
 
 export type PhysicalState = 'stopped' | 'creating' | 'running' | 'stopping' | 'failed' | 'unknown';
 
+export type CredentialContainmentRequirements = {
+  kilocode: boolean;
+  github: boolean;
+  worktreeScoped?: true;
+};
+
+export const WORKTREE_CREDENTIAL_CONTAINMENT = {
+  kilocode: true,
+  github: true,
+  worktreeScoped: true,
+} satisfies CredentialContainmentRequirements;
+
 export type CreateIntent = {
   intentId: string;
   createdAt: number;
@@ -10,6 +22,7 @@ export type CreateIntent = {
     VercelSandboxRuntimeConfig,
     'projectId' | 'snapshotId' | 'runtimeBuildId' | 'runtime'
   >;
+  containment?: CredentialContainmentRequirements;
 };
 
 export type StopTombstone = {
@@ -25,6 +38,7 @@ export type PhysicalRecord = {
   createIntent: CreateIntent | null;
   stopTombstone: StopTombstone | null;
   resumable: boolean;
+  containment?: CredentialContainmentRequirements & { providerRef: string };
 };
 
 export type ObserveResult = 'active' | 'terminal' | 'unknown';
@@ -43,7 +57,8 @@ export function claimCreate(
   record: PhysicalRecord,
   intentId: string,
   now: number,
-  allocationName?: string
+  allocationName?: string,
+  containment?: CredentialContainmentRequirements
 ): PhysicalRecord {
   if (record.state !== 'stopped') {
     throw illegal('claimCreate', record.state);
@@ -51,7 +66,20 @@ export function claimCreate(
   return {
     ...record,
     state: 'creating',
-    createIntent: { intentId, createdAt: now, ...(allocationName ? { allocationName } : {}) },
+    createIntent: {
+      intentId,
+      createdAt: now,
+      ...(allocationName ? { allocationName } : {}),
+      ...(containment
+        ? {
+            containment: {
+              kilocode: containment.kilocode,
+              github: containment.github,
+              ...(containment.worktreeScoped ? { worktreeScoped: true } : {}),
+            },
+          }
+        : {}),
+    },
   };
 }
 
@@ -176,10 +204,21 @@ export function exhaustStopRetries(record: PhysicalRecord): PhysicalRecord {
 }
 
 function toRunning(record: PhysicalRecord, providerRef: string): PhysicalRecord {
+  const containment = record.createIntent?.containment;
   return {
     ...record,
     state: 'running',
     providerRef,
+    ...(containment
+      ? {
+          containment: {
+            kilocode: containment.kilocode,
+            github: containment.github,
+            ...(containment.worktreeScoped ? { worktreeScoped: true } : {}),
+            providerRef,
+          },
+        }
+      : {}),
   };
 }
 

--- a/services/cloud-agent-next/src/sandbox-control/provider.ts
+++ b/services/cloud-agent-next/src/sandbox-control/provider.ts
@@ -1,4 +1,5 @@
 import type { SandboxBillingInput } from '../container-usage-context.js';
+import type { VercelSandboxNetworkPolicy } from '../agent-sandbox/vercel/vercel-sandbox-rest-client.js';
 import type { CreateIntent, ObserveResult } from './physical-lifecycle.js';
 
 export type { ObserveResult };
@@ -15,6 +16,7 @@ export function observeFromWrapperObservation(status: WrapperObservationStatus):
 
 export type ProviderCreateIntent = CreateIntent & {
   billing?: SandboxBillingInput;
+  networkPolicy?: VercelSandboxNetworkPolicy;
 };
 
 export type ProviderObservation = {
@@ -31,6 +33,10 @@ export type ProviderAdapter = {
   stop(ref: string | null, intent?: CreateIntent | null): Promise<StopResult>;
   ensureLeaseAtLeast(ref: string, ms: number): Promise<void>;
   logs(ref: string): Promise<string>;
+  updateNetworkPolicy?(
+    providerRef: string,
+    networkPolicy: VercelSandboxNetworkPolicy
+  ): Promise<void>;
 };
 
 export type MemoryProviderAdapter = ProviderAdapter & {

--- a/services/cloud-agent-next/src/sandbox-control/session-credentials.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/session-credentials.test.ts
@@ -1,0 +1,1256 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { logger } from '../logger.js';
+import type { SessionMetadata } from '../persistence/session-metadata.js';
+import type { Env, GitTokenService } from '../types.js';
+import { createControlPlaneCredential, parseControlPlaneCredential } from './managed-credential.js';
+import {
+  buildControlNetworkPolicy,
+  prepareSessionCredentials,
+  removeSessionCredentialMembership,
+  resolveSessionCredential,
+  sessionCredentialGrantSchema,
+  type SessionCredentialGrant,
+} from './session-credentials.js';
+import { findMatchingCredentialInjectionRule } from './vercel-network-policy.js';
+
+vi.mock('../logger.js', () => {
+  const logger = {
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+    withFields: vi.fn(),
+  };
+  logger.withFields.mockReturnValue(logger);
+  return { logger };
+});
+
+const NOW = 1_800_000_000_000;
+const HOUR = 60 * 60 * 1000;
+const SANDBOX_ID = 'usr-a1b2c3';
+const ALLOCATION_ID = 'usr-d4e5f6';
+const OUTBOUND_CONTAINER_ID = `contained:${ALLOCATION_ID}`;
+const VERCEL_SANDBOX_ID = 'ses-a1b2c3';
+const SESSION_ID = 'workspace_11111111-1111-4111-8111-111111111111';
+const SECOND_SESSION_ID = 'workspace_22222222-2222-4222-8222-222222222222';
+const THIRD_SESSION_ID = 'workspace_33333333-3333-4333-8333-333333333333';
+const ROOT_ID = 'ses_abcdefghijklmnopqrstuvwxyz';
+const SECOND_ROOT_ID = 'ses_zyxwvutsrqponmlkjihgfedcba';
+const THIRD_ROOT_ID = 'ses_01234567890123456789012345';
+const KILO_TOKEN = 'test-real-kilo-token';
+const GITHUB_TOKEN = 'test-real-github-token';
+const BROKER_ERROR_SECRET = 'fixture-secret-in-broker-exception';
+const INTEGRATION_ID = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+const WORKSPACE_UUID = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+const REPOSITORY_UUID = 'cccccccc-cccc-4ccc-8ccc-cccccccccccc';
+
+type CredentialEnv = Parameters<typeof prepareSessionCredentials>[0]['env'];
+type KiloSubject = Parameters<GitTokenService['issueKiloSessionCapability']>[0];
+
+function expectSecretSafeLogs(): void {
+  const mockedLogger = vi.mocked(logger);
+  const logs = JSON.stringify([
+    mockedLogger.info.mock.calls,
+    mockedLogger.warn.mock.calls,
+    mockedLogger.error.mock.calls,
+    mockedLogger.withFields.mock.calls,
+  ]);
+  for (const secret of [KILO_TOKEN, GITHUB_TOKEN, BROKER_ERROR_SECRET]) {
+    expect(logs).not.toContain(secret);
+  }
+}
+
+function createBroker() {
+  let serial = 0;
+  const kiloSubjects = new Map<string, KiloSubject>();
+  const broker = {
+    getTokenForRepo: vi.fn<GitTokenService['getTokenForRepo']>(async () => ({
+      success: true,
+      token: GITHUB_TOKEN,
+      installationId: '42',
+      accountLogin: 'acme',
+      appType: 'standard',
+    })),
+    getToken: vi.fn<GitTokenService['getToken']>(async () => GITHUB_TOKEN),
+    getCloudAgentAuthForRepo: vi.fn<NonNullable<GitTokenService['getCloudAgentAuthForRepo']>>(),
+    issueKiloSessionCapability: vi.fn<GitTokenService['issueKiloSessionCapability']>(
+      async subject => {
+        const capability = `kka1.test-${++serial}`;
+        kiloSubjects.set(capability, subject);
+        return { success: true, capability };
+      }
+    ),
+    issueGitHubSessionCapability: vi.fn<GitTokenService['issueGitHubSessionCapability']>(
+      async () => ({
+        success: true,
+        capability: `kgh2.test-${++serial}`,
+        installationId: '42',
+        accountLogin: 'acme',
+        appType: 'standard',
+        source: 'installation',
+        gitAuthor: { name: 'bot', email: 'bot@example.com' },
+      })
+    ),
+    issueGitLabSessionCapability: vi.fn<GitTokenService['issueGitLabSessionCapability']>(
+      async () => ({
+        success: true,
+        capability: `kgl2.test-${++serial}`,
+        instanceOrigin: 'https://gitlab.example.com:8443/gitlab',
+        instanceHost: 'gitlab.example.com:8443',
+        projectPath: 'acme/platform/repo',
+        integrationId: INTEGRATION_ID,
+        authType: 'pat',
+        identity: { accountId: '123', accountLogin: 'acme' },
+        source: { type: 'integration' },
+        glabIsOAuth2: false,
+      })
+    ),
+    issueBitbucketSessionCapability: vi.fn<
+      NonNullable<GitTokenService['issueBitbucketSessionCapability']>
+    >(async () => ({
+      success: true,
+      capability: `kbb1.test-${++serial}`,
+      gitUrl: 'https://bitbucket.org/acme/canonical-repo.git',
+    })),
+    getGitLabToken: vi.fn<GitTokenService['getGitLabToken']>(),
+    getBitbucketToken: vi.fn<NonNullable<GitTokenService['getBitbucketToken']>>(),
+    redeemKiloSessionCapability: vi.fn<GitTokenService['redeemKiloSessionCapability']>(),
+    redeemGitHubSessionCapability: vi.fn<GitTokenService['redeemGitHubSessionCapability']>(),
+    redeemGitLabSessionCapability: vi.fn<GitTokenService['redeemGitLabSessionCapability']>(),
+    redeemBitbucketSessionCapability:
+      vi.fn<NonNullable<GitTokenService['redeemBitbucketSessionCapability']>>(),
+  } satisfies GitTokenService;
+  return { broker, kiloSubjects };
+}
+
+function environment(broker?: GitTokenService): CredentialEnv {
+  const namespace = (name: string) =>
+    ({
+      idFromName: (id: string) => ({ toString: () => `${name}:${id}` }),
+    }) as Env['Sandbox'];
+  return {
+    Sandbox: namespace('standard'),
+    SandboxContainment: namespace('contained'),
+    SandboxSmall: namespace('small'),
+    SandboxSmallContainment: namespace('contained-small'),
+    SandboxCodeReview: namespace('review'),
+    SandboxCodeReviewContainment: namespace('contained-review'),
+    SandboxDIND: namespace('dind'),
+    ...(broker ? { GIT_TOKEN_SERVICE: broker } : {}),
+    KILOCODE_BACKEND_BASE_URL: 'https://backend.example.com',
+    KILO_OPENROUTER_BASE: 'https://provider.example.com/api/openrouter',
+    KILO_SESSION_INGEST_URL: 'https://ingest.example.com',
+  };
+}
+
+function metadata(
+  overrides: Partial<SessionMetadata> = {},
+  scopeId: string | null = 'worktree-a'
+): SessionMetadata {
+  return {
+    metadataSchemaVersion: 2,
+    identity: {
+      sessionId: SESSION_ID,
+      userId: 'user-a',
+      orgId: INTEGRATION_ID,
+      createdOnPlatform: 'cloud-agent-web',
+    },
+    auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
+    repository: { type: 'github', repo: 'acme/repo', githubIntegrationId: INTEGRATION_ID },
+    lifecycle: { version: 1, timestamp: NOW },
+    ...overrides,
+    workspace: {
+      sandboxId: SANDBOX_ID,
+      sandboxProvider: 'cloudflare',
+      workspacePath: '/workspace/worktree-a',
+      ...(scopeId ? { worktreeId: scopeId } : {}),
+      ...overrides.workspace,
+    },
+  };
+}
+
+function secondRoot(overrides: Partial<SessionMetadata> = {}): SessionMetadata {
+  return metadata({
+    identity: { ...metadata().identity, sessionId: SECOND_SESSION_ID },
+    auth: { kiloSessionId: SECOND_ROOT_ID, kilocodeToken: KILO_TOKEN },
+    ...overrides,
+  });
+}
+
+function prepare(
+  env: CredentialEnv,
+  data = metadata(),
+  existing?: SessionCredentialGrant,
+  now = NOW
+) {
+  return prepareSessionCredentials({
+    env,
+    metadata: data,
+    sandboxId: data.workspace?.sandboxId ?? SANDBOX_ID,
+    ...(data.workspace?.sandboxProvider === 'vercel'
+      ? {}
+      : { outboundContainerId: OUTBOUND_CONTAINER_ID }),
+    existing,
+    now,
+  });
+}
+
+function resolve(
+  env: CredentialEnv,
+  grant: SessionCredentialGrant,
+  overrides: Partial<Parameters<typeof resolveSessionCredential>[0]> = {}
+) {
+  return resolveSessionCredential({
+    env,
+    grant,
+    credential: grant.kilo.alias,
+    url: 'https://provider.example.com/api/openrouter/chat/completions',
+    method: 'POST',
+    outboundContainerId: OUTBOUND_CONTAINER_ID,
+    now: NOW,
+    ...overrides,
+  });
+}
+
+function vercelMetadata(overrides: Partial<SessionMetadata> = {}, scopeId = 'worktree-a') {
+  return metadata(
+    {
+      ...overrides,
+      workspace: {
+        sandboxId: VERCEL_SANDBOX_ID,
+        sandboxProvider: 'vercel',
+        ...overrides.workspace,
+      },
+    },
+    scopeId
+  );
+}
+
+describe('trusted worktree credential preparation', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('contains Kilo and managed GitHub tokens and derives targets from the real Kilo token', async () => {
+    const { broker, kiloSubjects } = createBroker();
+    const env = environment(broker);
+    const token = `https://selected-provider.example.com/api/openrouter:${KILO_TOKEN}`;
+    const data = metadata({
+      auth: { kiloSessionId: ROOT_ID, kilocodeToken: token },
+      profile: {
+        envVars: {
+          KILO_AUTH_CONTENT: JSON.stringify({ kilo: { type: 'api', key: token } }),
+          PUBLIC_VALUE: 'kept',
+        },
+        setupCommands: [`run --token=${token}`],
+      },
+    });
+    const { grant, payload } = await prepare(env, data);
+    const capability = grant.kilo.capabilities[SESSION_ID];
+
+    expect(grant.kilo.token).toBe(token);
+    expect(payload.kilo).toEqual({
+      scopeId: 'worktree-a',
+      token: grant.kilo.alias,
+      targets: grant.kilo.targets,
+    });
+    expect(payload.kilo.targets.providerBaseUrl).toBe(
+      'https://selected-provider.example.com/api/openrouter'
+    );
+    expect(payload.env).toMatchObject({
+      KILOCODE_TOKEN: grant.kilo.alias,
+      GH_TOKEN: grant.scm?.alias,
+      PUBLIC_VALUE: 'kept',
+    });
+    expect(JSON.parse(payload.env?.KILO_AUTH_CONTENT ?? '{}')).toEqual({
+      kilo: { type: 'api', key: grant.kilo.alias },
+    });
+    expect(payload.git).toEqual({
+      url: 'https://github.com/acme/repo.git',
+      platform: 'github',
+      token: grant.scm?.alias,
+    });
+    expect(capability && kiloSubjects.get(capability.credential)).toEqual({
+      userId: 'user-a',
+      cloudAgentSessionId: SESSION_ID,
+      kiloSessionId: ROOT_ID,
+      outboundContainerId: OUTBOUND_CONTAINER_ID,
+      userToken: token,
+      targets: grant.kilo.targets,
+    });
+    expect(broker.issueGitHubSessionCapability).toHaveBeenCalledWith({
+      userId: 'user-a',
+      orgId: INTEGRATION_ID,
+      githubRepo: 'acme/repo',
+      expectedIntegrationId: INTEGRATION_ID,
+      allowUserAuthorization: true,
+      outboundContainerId: OUTBOUND_CONTAINER_ID,
+    });
+    for (const secret of [
+      token,
+      KILO_TOKEN,
+      GITHUB_TOKEN,
+      capability?.credential,
+      grant.scm?.capability?.credential,
+    ]) {
+      if (secret) expect(JSON.stringify(payload)).not.toContain(secret);
+    }
+    expect(sessionCredentialGrantSchema.parse(JSON.parse(JSON.stringify(grant)))).toEqual(grant);
+    expect(data.auth.kilocodeToken).toBe(token);
+  });
+
+  it('keeps logical alias routing separate from its exact native container binding', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const data = metadata();
+    const { grant } = await prepare(env, data);
+
+    expect(parseControlPlaneCredential(grant.kilo.alias)?.sandboxId).toBe(SANDBOX_ID);
+    expect(grant.outboundContainerId).toBe(OUTBOUND_CONTAINER_ID);
+    expect(grant.kilo.capabilities[SESSION_ID].outboundContainerId).toBe(OUTBOUND_CONTAINER_ID);
+    expect(
+      await resolve(env, grant, { outboundContainerId: `contained:${SANDBOX_ID}` })
+    ).toBeNull();
+    await expect(
+      prepareSessionCredentials({
+        env,
+        metadata: data,
+        sandboxId: SANDBOX_ID,
+        outboundContainerId: 'contained:usr-replacement',
+        existing: grant,
+        now: NOW,
+      })
+    ).rejects.toThrow('Invalid contained worktree credentials');
+    expect(broker.issueKiloSessionCapability).toHaveBeenCalledTimes(1);
+  });
+
+  it('requires an explicit native binding before issuing Cloudflare capabilities', async () => {
+    const { broker } = createBroker();
+    await expect(
+      prepareSessionCredentials({
+        env: environment(broker),
+        metadata: metadata(),
+        sandboxId: SANDBOX_ID,
+        now: NOW,
+      })
+    ).rejects.toThrow('Invalid contained worktree credentials');
+    expect(broker.issueKiloSessionCapability).not.toHaveBeenCalled();
+    expect(broker.issueGitHubSessionCapability).not.toHaveBeenCalled();
+  });
+
+  it('shares aliases only across explicit roots of the same worktree and preserves exact family subjects', async () => {
+    const { broker, kiloSubjects } = createBroker();
+    const env = environment(broker);
+    const first = await prepare(env);
+    const second = await prepare(env, secondRoot(), first.grant);
+
+    expect(second.grant.members).toEqual([
+      { sessionId: SESSION_ID, kiloSessionId: ROOT_ID },
+      { sessionId: SECOND_SESSION_ID, kiloSessionId: SECOND_ROOT_ID },
+    ]);
+    expect(second.payload.kilo).toEqual(first.payload.kilo);
+    expect(second.payload.git?.token).toBe(first.payload.git?.token);
+    expect(first.grant.members).toHaveLength(1);
+    for (const [sessionId, rootId] of [
+      [SESSION_ID, ROOT_ID],
+      [SECOND_SESSION_ID, SECOND_ROOT_ID],
+    ]) {
+      for (const [operation, method] of [
+        ['export', 'GET'],
+        ['ingest', 'POST'],
+      ]) {
+        const result = await resolve(env, second.grant, {
+          url: `https://ingest.example.com/api/session/${rootId}/${operation}`,
+          method,
+        });
+        expect(result).not.toBeNull();
+        expect(result && kiloSubjects.get(result.credential)).toMatchObject({
+          cloudAgentSessionId: sessionId,
+          kiloSessionId: rootId,
+        });
+        expect(result?.organizationId).toBe(INTEGRATION_ID);
+        for (const rejected of [
+          {
+            url: `https://ingest.example.com/api/session/${rootId}/${operation}`,
+            method: method === 'GET' ? 'POST' : 'GET',
+          },
+          { url: `https://ingest.example.com/api/session/${rootId}/${operation}/extra`, method },
+          { url: `https://ingest.example.com/api/session/${rootId}-other/${operation}`, method },
+        ]) {
+          expect(await resolve(env, second.grant, rejected)).toBeNull();
+        }
+      }
+    }
+    for (const [operation, method] of [
+      ['export', 'GET'],
+      ['ingest', 'POST'],
+    ]) {
+      expect(
+        await resolve(env, second.grant, {
+          url: `https://ingest.example.com/api/session/${THIRD_ROOT_ID}/${operation}`,
+          method,
+        })
+      ).toBeNull();
+    }
+    const repeated = await prepare(env, secondRoot(), second.grant);
+    expect(repeated.grant.members).toEqual(second.grant.members);
+    expect(await resolve(env, second.grant)).toMatchObject({
+      credential: first.grant.kilo.capabilities[SESSION_ID]?.credential,
+    });
+  });
+
+  it('falls back to the session scope and trusted workspace path helper without a worktree id', async () => {
+    const { broker } = createBroker();
+    const data = metadata({ workspace: { workspacePath: undefined } }, null);
+    const { grant, payload } = await prepare(environment(broker), data);
+    expect(grant.scopeId).toBe(SESSION_ID);
+    expect(grant.directory).toBe(`/workspace/${INTEGRATION_ID}/user-a/sessions/${SESSION_ID}`);
+    expect(payload.directory).toBe(grant.directory);
+  });
+
+  it('renews warm credentials after the previous backing capability expired without replacing aliases', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const first = await prepare(env);
+    const renewed = await prepare(env, metadata(), first.grant, NOW + 5 * HOUR);
+
+    expect(renewed.grant.kilo.alias).toBe(first.grant.kilo.alias);
+    expect(renewed.grant.scm?.alias).toBe(first.grant.scm?.alias);
+    expect(renewed.grant.kilo.capabilities[SESSION_ID]?.credential).not.toBe(
+      first.grant.kilo.capabilities[SESSION_ID]?.credential
+    );
+    expect(renewed.grant.scm?.capability?.credential).not.toBe(
+      first.grant.scm?.capability?.credential
+    );
+    expect(renewed.grant.expiresAt).toBe(NOW + 9 * HOUR);
+    expect(await resolve(env, renewed.grant, { now: NOW + 5 * HOUR })).toMatchObject({
+      credential: renewed.grant.kilo.capabilities[SESSION_ID]?.credential,
+    });
+    expect(renewed.payload.kilo.token).toBe(first.payload.kilo.token);
+  });
+
+  it('refreshes backing capabilities during redemption without extending the trusted worktree lease', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const { grant } = await prepare(env);
+    const now = NOW + 3 * HOUR;
+    const kilo = await resolve(env, grant, { now });
+    const github = await resolve(env, grant, {
+      now,
+      credential: grant.scm?.alias,
+      url: 'https://api.github.com/repos/acme/repo',
+      method: 'GET',
+    });
+
+    expect(kilo?.credential).not.toBe(grant.kilo.capabilities[SESSION_ID]?.credential);
+    expect(github?.credential).not.toBe(grant.scm?.capability?.credential);
+    expect(kilo?.grant.expiresAt).toBe(grant.expiresAt);
+    expect(github?.grant.expiresAt).toBe(grant.expiresAt);
+    expect(kilo?.grant.preparedAt).toBe(NOW);
+    expect(grant.kilo.capabilities[SESSION_ID]?.issuedAt).toBe(NOW);
+    expect(await resolve(env, kilo?.grant ?? grant, { now: NOW + 4 * HOUR })).toBeNull();
+    expect(
+      await resolve(env, github?.grant ?? grant, {
+        now: NOW + 4 * HOUR,
+        credential: grant.scm?.alias,
+      })
+    ).toBeNull();
+    expect(broker.issueKiloSessionCapability).toHaveBeenCalledTimes(2);
+    expect(broker.issueGitHubSessionCapability).toHaveBeenCalledTimes(2);
+  });
+
+  it('invalidates all root capability caches when trusted preparation rotates the Kilo token', async () => {
+    const { broker, kiloSubjects } = createBroker();
+    const env = environment(broker);
+    const first = await prepare(env);
+    const second = await prepare(env, secondRoot(), first.grant);
+    const rotated = await prepare(
+      env,
+      metadata({ auth: { kiloSessionId: ROOT_ID, kilocodeToken: 'test-rotated-kilo-token' } }),
+      second.grant,
+      NOW + 1
+    );
+    expect(rotated.grant.kilo.capabilities[SECOND_SESSION_ID]).toBeUndefined();
+    const resolved = await resolve(env, rotated.grant, {
+      now: NOW + 2,
+      url: `https://ingest.example.com/api/session/${SECOND_ROOT_ID}/export`,
+      method: 'GET',
+    });
+    expect(resolved && kiloSubjects.get(resolved.credential)).toMatchObject({
+      userToken: 'test-rotated-kilo-token',
+      cloudAgentSessionId: SECOND_SESSION_ID,
+      kiloSessionId: SECOND_ROOT_ID,
+    });
+    expect(rotated.grant.kilo.alias).toBe(first.grant.kilo.alias);
+  });
+
+  it.each([
+    [
+      'owner',
+      () =>
+        secondRoot({
+          identity: { ...metadata().identity, sessionId: SECOND_SESSION_ID, userId: 'other-user' },
+        }),
+    ],
+    [
+      'organization',
+      () =>
+        secondRoot({
+          identity: {
+            ...metadata().identity,
+            sessionId: SECOND_SESSION_ID,
+            orgId: REPOSITORY_UUID,
+          },
+        }),
+    ],
+    ['directory', () => secondRoot({ workspace: { workspacePath: '/workspace/other' } })],
+    [
+      'worktree',
+      () =>
+        metadata(
+          {
+            auth: { kiloSessionId: SECOND_ROOT_ID, kilocodeToken: KILO_TOKEN },
+            identity: { ...metadata().identity, sessionId: SECOND_SESSION_ID },
+          },
+          'other-worktree'
+        ),
+    ],
+    [
+      'repository',
+      () =>
+        secondRoot({
+          repository: { type: 'github', repo: 'acme/other', githubIntegrationId: INTEGRATION_ID },
+        }),
+    ],
+    [
+      'integration',
+      () =>
+        secondRoot({
+          repository: { type: 'github', repo: 'acme/repo', githubIntegrationId: REPOSITORY_UUID },
+        }),
+    ],
+    [
+      'platform context',
+      () =>
+        secondRoot({
+          identity: {
+            ...metadata().identity,
+            sessionId: SECOND_SESSION_ID,
+            createdOnPlatform: 'code-review',
+          },
+        }),
+    ],
+    ['sandbox', () => secondRoot({ workspace: { sandboxId: 'usr-deadbeef' } })],
+    ['provider', () => secondRoot({ workspace: { sandboxProvider: 'vercel' } })],
+  ] as const)(
+    'rejects worktree %s mismatches before requesting more capabilities',
+    async (_name, createMetadata) => {
+      const { broker } = createBroker();
+      const env = environment(broker);
+      const first = await prepare(env);
+      await expect(prepare(env, createMetadata(), first.grant)).rejects.toThrow(
+        'Invalid contained worktree credentials'
+      );
+      expect(broker.issueKiloSessionCapability).toHaveBeenCalledTimes(1);
+      expect(broker.issueGitHubSessionCapability).toHaveBeenCalledTimes(1);
+    }
+  );
+
+  it.each([
+    'KILOCODE_BACKEND_BASE_URL',
+    'KILO_OPENROUTER_BASE',
+    'KILO_SESSION_INGEST_URL',
+  ] as const)('rejects a changed %s for an existing worktree', async key => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const first = await prepare(env);
+    await expect(
+      prepare({ ...env, [key]: 'https://different.example.com' }, secondRoot(), first.grant)
+    ).rejects.toThrow('Invalid contained worktree credentials');
+  });
+
+  it('rejects root identity replacement and ambiguous family membership', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const first = await prepare(env);
+    await expect(
+      prepare(
+        env,
+        metadata({ auth: { kiloSessionId: SECOND_ROOT_ID, kilocodeToken: KILO_TOKEN } }),
+        first.grant
+      )
+    ).rejects.toThrow('Invalid contained worktree credentials');
+    await expect(
+      prepare(
+        env,
+        secondRoot({ auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN } }),
+        first.grant
+      )
+    ).rejects.toThrow('Invalid contained worktree credentials');
+  });
+
+  it.each([undefined, '', 'with\nnewline', 'kka1.test-capability'])(
+    'requires a real nonempty Kilo token: %s',
+    async kilocodeToken => {
+      const { broker } = createBroker();
+      await expect(
+        prepare(environment(broker), metadata({ auth: { kiloSessionId: ROOT_ID, kilocodeToken } }))
+      ).rejects.toThrow('Invalid contained worktree credentials');
+      expect(broker.issueKiloSessionCapability).not.toHaveBeenCalled();
+    }
+  );
+
+  it('rejects DIND and devcontainer metadata', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    await expect(
+      prepare(env, metadata({ workspace: { sandboxId: 'dind-a1b2c3' } }))
+    ).rejects.toThrow('Invalid contained worktree credentials');
+    await expect(
+      prepare(env, metadata({ workspace: { devcontainerRequested: true } }))
+    ).rejects.toThrow('Invalid contained worktree credentials');
+  });
+
+  it.each(['cloudflare', 'vercel'] as const)(
+    'supports public generic Git with required Kilo containment on %s',
+    async provider => {
+      const { broker } = createBroker();
+      const data = metadata({
+        repository: { type: 'git', url: 'https://public.example.com/acme/repo.git' },
+        workspace: {
+          sandboxId: provider === 'vercel' ? VERCEL_SANDBOX_ID : SANDBOX_ID,
+          sandboxProvider: provider,
+        },
+      });
+      const { grant, payload } = await prepare(environment(broker), data);
+      expect(payload.git).toEqual({ url: 'https://public.example.com/acme/repo.git' });
+      expect(payload.kilo.token).toBe(grant.kilo.alias);
+      expect(grant.scm).toBeUndefined();
+      expect(broker.getTokenForRepo).not.toHaveBeenCalled();
+      expect(broker.issueGitHubSessionCapability).not.toHaveBeenCalled();
+      expect(JSON.stringify(payload)).not.toContain(KILO_TOKEN);
+    }
+  );
+
+  const credentialedRepositoryUrl = new URL('https://public.example.com/repo.git');
+  credentialedRepositoryUrl.username = 'fake-user';
+  credentialedRepositoryUrl.password = 'fake-password';
+
+  it.each([
+    { type: 'git', url: 'https://public.example.com/repo.git', token: 'custom-token' },
+    { type: 'git', url: credentialedRepositoryUrl.href },
+    { type: 'git', url: 'https://user@public.example.com/repo.git' },
+    { type: 'git', url: 'https://public.example.com/repo.git?token=custom-token' },
+    { type: 'github', repo: 'acme/repo', token: 'custom-token', githubInstallationId: '42' },
+    { type: 'gitlab', url: 'https://gitlab.example.com/acme/repo.git', token: 'custom-token' },
+  ] satisfies Array<SessionMetadata['repository']>)(
+    'never replaces unsupported custom repository authentication: $type',
+    async repository => {
+      const { broker } = createBroker();
+      await expect(prepare(environment(broker), metadata({ repository }))).rejects.toThrow(
+        'Invalid contained worktree credentials'
+      );
+      expect(broker.issueKiloSessionCapability).not.toHaveBeenCalled();
+      expect(broker.getTokenForRepo).not.toHaveBeenCalled();
+    }
+  );
+
+  it('does not add SCM auth to public encoded repository paths or repository-free worktrees', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const { payload } = await prepare(
+      env,
+      metadata({
+        repository: { type: 'git', url: 'https://public.example.com/acme/repo%20name.git' },
+      })
+    );
+    expect(payload.git).toEqual({ url: 'https://public.example.com/acme/repo%20name.git' });
+    const empty = await prepare(env, metadata({ repository: undefined }));
+    expect(empty.grant.scm).toBeUndefined();
+    expect(empty.payload.git).toBeUndefined();
+    expect(empty.payload.kilo.token).toBe(empty.grant.kilo.alias);
+  });
+
+  it('fails closed with a missing Kilo capability broker', async () => {
+    await expect(prepare(environment())).rejects.toThrow('Kilo capability issuance is unavailable');
+  });
+
+  it.each(['missing', 'throwing', 'raw-result'] as const)(
+    'never resolves raw GitHub auth when strict issuance is %s',
+    async mode => {
+      const { broker } = createBroker();
+      if (mode === 'throwing')
+        broker.issueGitHubSessionCapability.mockRejectedValue(new Error('unavailable'));
+      if (mode === 'raw-result')
+        broker.issueGitHubSessionCapability.mockResolvedValue({
+          success: true,
+          capability: GITHUB_TOKEN,
+          installationId: '42',
+          accountLogin: 'acme',
+          appType: 'standard',
+          source: 'installation',
+          gitAuthor: { name: 'bot', email: 'bot@example.com' },
+        });
+      const env = environment(
+        mode === 'missing'
+          ? ({ ...broker, issueGitHubSessionCapability: undefined } as never)
+          : broker
+      );
+      await expect(prepare(env)).rejects.toMatchObject({
+        name: 'Error',
+        message:
+          mode === 'raw-result'
+            ? 'Invalid contained worktree credentials'
+            : 'GitHub capability issuance is unavailable',
+      });
+      expectSecretSafeLogs();
+      expect(broker.getTokenForRepo).not.toHaveBeenCalled();
+      expect(broker.getCloudAgentAuthForRepo).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each<Record<string, string>>([
+    { GH_TOKEN: 'custom-gh', GITHUB_TOKEN: 'custom-github' },
+    { GITHUB_TOKEN: 'custom-github' },
+  ])(
+    'preserves user profile GitHub overrides and the GITHUB_TOKEN-only CLI precedence',
+    async envVars => {
+      const { broker } = createBroker();
+      const { payload } = await prepare(environment(broker), metadata({ profile: { envVars } }));
+      expect(payload.env?.GITHUB_TOKEN).toBe('custom-github');
+      expect(payload.env?.GH_TOKEN).toBe(envVars.GH_TOKEN ?? 'custom-github');
+      expect(payload.git?.token).not.toBe(payload.env?.GH_TOKEN);
+    }
+  );
+
+  it('uses canonical managed GitLab auth and replaces managed profile carriers', async () => {
+    const { broker } = createBroker();
+    const { grant, payload } = await prepare(
+      environment(broker),
+      metadata({
+        repository: {
+          type: 'gitlab',
+          url: 'https://gitlab.example.com:8443/gitlab/acme/platform/repo',
+          token: 'old-managed-gitlab-token',
+          gitlabTokenManaged: true,
+        },
+        identity: { ...metadata().identity, createdOnPlatform: 'code-review' },
+        profile: {
+          envVars: {
+            GITLAB_TOKEN: 'old-managed-gitlab-token',
+            GLAB_IS_OAUTH2: 'true',
+            GITLAB_HOST: 'stale.example.com',
+          },
+        },
+      })
+    );
+    expect(payload.git).toEqual({
+      url: 'https://gitlab.example.com:8443/gitlab/acme/platform/repo.git',
+      platform: 'gitlab',
+      token: grant.scm?.alias,
+    });
+    expect(payload.env).toMatchObject({
+      GITLAB_TOKEN: grant.scm?.alias,
+      GLAB_IS_OAUTH2: 'false',
+      GITLAB_HOST: 'gitlab.example.com:8443',
+      GITLAB_SUBFOLDER: 'gitlab',
+    });
+    expect(broker.issueGitLabSessionCapability).toHaveBeenCalledWith({
+      userId: 'user-a',
+      orgId: INTEGRATION_ID,
+      outboundContainerId: OUTBOUND_CONTAINER_ID,
+      gitUrl: 'https://gitlab.example.com:8443/gitlab/acme/platform/repo.git',
+      createdOnPlatform: 'code-review',
+    });
+    expect(JSON.stringify(payload)).not.toContain('old-managed-gitlab-token');
+    expect(broker.getGitLabToken).not.toHaveBeenCalled();
+  });
+
+  it('renews managed GitLab capabilities without changing pinned integration identity or aliases', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const { grant } = await prepare(
+      env,
+      metadata({
+        repository: {
+          type: 'gitlab',
+          url: 'https://gitlab.example.com:8443/gitlab/acme/platform/repo.git',
+        },
+      })
+    );
+    const result = await resolve(env, grant, {
+      credential: grant.scm?.alias,
+      url: 'https://gitlab.example.com:8443/gitlab/api/v4/projects/acme%2Fplatform%2Frepo',
+      method: 'GET',
+      now: NOW + 3 * HOUR,
+    });
+    expect(result).not.toBeNull();
+    expect(result?.credential).not.toBe(grant.scm?.capability?.credential);
+    expect(result?.grant.scm?.gitlab).toEqual(grant.scm?.gitlab);
+    expect(result?.grant.scm?.alias).toBe(grant.scm?.alias);
+    expect(result?.grant.expiresAt).toBe(grant.expiresAt);
+    broker.issueGitLabSessionCapability.mockResolvedValue({
+      success: true,
+      capability: 'kgl2.different-integration',
+      instanceOrigin: 'https://gitlab.example.com:8443/gitlab',
+      instanceHost: 'gitlab.example.com:8443',
+      projectPath: 'acme/platform/repo',
+      integrationId: REPOSITORY_UUID,
+      authType: 'pat',
+      identity: { accountId: '123', accountLogin: 'acme' },
+      source: { type: 'integration' },
+      glabIsOAuth2: false,
+    });
+    expect(
+      await resolve(env, grant, {
+        credential: grant.scm?.alias,
+        url: 'https://gitlab.example.com:8443/gitlab/api/v4/projects/acme%2Fplatform%2Frepo',
+        method: 'GET',
+        now: NOW + 3 * HOUR,
+      })
+    ).toBeNull();
+    expect(broker.getGitLabToken).not.toHaveBeenCalled();
+  });
+
+  it('uses canonical Bitbucket broker URLs while retaining exact UUID and integration scope', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const data = metadata({
+      repository: {
+        type: 'bitbucket',
+        url: 'https://bitbucket.org/acme/old-name.git',
+        workspaceUuid: WORKSPACE_UUID,
+        repositoryUuid: REPOSITORY_UUID,
+        bitbucketIntegrationId: INTEGRATION_ID,
+      },
+    });
+    const { grant, payload } = await prepare(env, data);
+    expect(payload.git).toEqual({
+      url: 'https://bitbucket.org/acme/canonical-repo.git',
+      platform: 'bitbucket',
+      token: grant.scm?.alias,
+    });
+    expect(payload.env).toMatchObject({
+      BITBUCKET_TOKEN: grant.scm?.alias,
+      KILO_BITBUCKET_WORKSPACE_SLUG: 'acme',
+      KILO_BITBUCKET_REPOSITORY_SLUG: 'canonical-repo',
+      KILO_BITBUCKET_WORKSPACE_UUID: `{${WORKSPACE_UUID}}`,
+      KILO_BITBUCKET_REPOSITORY_UUID: `{${REPOSITORY_UUID}}`,
+    });
+    expect(broker.issueBitbucketSessionCapability).toHaveBeenCalledWith({
+      userId: 'user-a',
+      orgId: INTEGRATION_ID,
+      expectedIntegrationId: INTEGRATION_ID,
+      workspaceUuid: WORKSPACE_UUID,
+      repositoryUuid: REPOSITORY_UUID,
+      repositoryUrl: 'https://bitbucket.org/acme/old-name.git',
+      outboundContainerId: OUTBOUND_CONTAINER_ID,
+    });
+    expect(
+      await resolve(env, grant, {
+        credential: grant.scm?.alias,
+        url: 'https://bitbucket.org/acme/canonical-repo.git/info/refs',
+        method: 'GET',
+      })
+    ).toMatchObject({ credential: grant.scm?.capability?.credential });
+    expect(broker.getBitbucketToken).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { type: 'gitlab', url: 'https://gitlab.example.com/acme/repo.git' },
+    {
+      type: 'bitbucket',
+      url: 'https://bitbucket.org/acme/repo.git',
+      workspaceUuid: WORKSPACE_UUID,
+      repositoryUuid: REPOSITORY_UUID,
+    },
+  ] satisfies Array<SessionMetadata['repository']>)(
+    'rejects unsupported Vercel SCM: $type',
+    async repository => {
+      const { broker } = createBroker();
+      await expect(prepare(environment(broker), vercelMetadata({ repository }))).rejects.toThrow(
+        'Invalid contained worktree credentials'
+      );
+      expect(broker.getGitLabToken).not.toHaveBeenCalled();
+      expect(broker.getBitbucketToken).not.toHaveBeenCalled();
+    }
+  );
+
+  it('allows local Cloudflare Kilo targets but requires HTTPS targets for Vercel', async () => {
+    const { broker } = createBroker();
+    const env = {
+      ...environment(broker),
+      KILOCODE_BACKEND_BASE_URL: 'http://localhost:3000',
+      KILO_OPENROUTER_BASE: 'http://localhost:3000',
+    };
+    const { grant } = await prepare(env);
+    expect(grant.kilo.targets.backendBaseUrl).toBe('http://host.docker.internal:3000');
+    expect(
+      await resolve(env, grant, { url: 'http://host.docker.internal:3000/api/user', method: 'GET' })
+    ).not.toBeNull();
+    await expect(prepare(env, vercelMetadata())).rejects.toThrow(
+      'Invalid contained worktree credentials'
+    );
+  });
+});
+
+describe('credential failure safety', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it.each([
+    {
+      name: 'Kilo',
+      rpc: 'issueKiloSessionCapability',
+      data: metadata(),
+      message: 'Kilo capability issuance is unavailable',
+    },
+    {
+      name: 'GitHub',
+      rpc: 'issueGitHubSessionCapability',
+      data: metadata(),
+      message: 'GitHub capability issuance is unavailable',
+    },
+    {
+      name: 'GitLab',
+      rpc: 'issueGitLabSessionCapability',
+      data: metadata({
+        repository: {
+          type: 'gitlab',
+          url: 'https://gitlab.example.com:8443/gitlab/acme/platform/repo.git',
+        },
+      }),
+      message: 'GitLab capability issuance is unavailable',
+    },
+    {
+      name: 'Bitbucket',
+      rpc: 'issueBitbucketSessionCapability',
+      data: metadata({
+        repository: {
+          type: 'bitbucket',
+          url: 'https://bitbucket.org/acme/repo.git',
+          workspaceUuid: WORKSPACE_UUID,
+          repositoryUuid: REPOSITORY_UUID,
+        },
+      }),
+      message: 'Bitbucket capability issuance is unavailable',
+    },
+    {
+      name: 'Vercel GitHub',
+      rpc: 'getTokenForRepo',
+      data: vercelMetadata(),
+      message: 'GitHub credential is unavailable',
+    },
+  ] as const)(
+    'keeps $name broker exceptions out of logs, preparation errors, and resolution output',
+    async ({ name, rpc, data, message }) => {
+      const { broker } = createBroker();
+      const env = environment(broker);
+      const { grant } = await prepare(env, data);
+      broker[rpc].mockRejectedValue(
+        new Error(`Broker rejected ${KILO_TOKEN}, ${GITHUB_TOKEN}, ${BROKER_ERROR_SECRET}`)
+      );
+
+      await expect(prepare(env, data, grant, NOW + 3 * HOUR)).rejects.toMatchObject({
+        name: 'Error',
+        message,
+      });
+      if (data.workspace?.sandboxProvider !== 'vercel') {
+        const credential = name === 'Kilo' ? grant.kilo.alias : grant.scm?.alias;
+        if (!credential) throw new Error('Expected credential alias');
+        expect(
+          await resolve(env, grant, {
+            credential,
+            ...(name === 'Kilo' ? {} : { url: `${grant.scm?.gitUrl}/info/refs`, method: 'GET' }),
+            now: NOW + 3 * HOUR,
+          })
+        ).toBeNull();
+        expect(broker.getTokenForRepo).not.toHaveBeenCalled();
+      }
+      expect(broker.getCloudAgentAuthForRepo).not.toHaveBeenCalled();
+      expect(broker.getGitLabToken).not.toHaveBeenCalled();
+      expect(broker.getBitbucketToken).not.toHaveBeenCalled();
+      expectSecretSafeLogs();
+    }
+  );
+
+  it('reports invalid metadata and persisted grant failures without Zod values', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const invalidTokenMetadata = metadata({
+      auth: { kiloSessionId: ROOT_ID, kilocodeToken: `${KILO_TOKEN}\n${BROKER_ERROR_SECRET}` },
+    });
+    await expect(prepare(env, invalidTokenMetadata)).rejects.toMatchObject({
+      name: 'Error',
+      message: 'Invalid contained worktree credentials',
+    });
+    const { grant } = await prepare(env);
+    const invalidGrant = {
+      ...grant,
+      kilo: { ...grant.kilo, [BROKER_ERROR_SECRET]: KILO_TOKEN },
+    };
+    await expect(prepare(env, metadata(), invalidGrant)).rejects.toMatchObject({
+      name: 'Error',
+      message: 'Invalid contained worktree credentials',
+    });
+    expect(() => buildControlNetworkPolicy([invalidGrant])).toThrow(
+      'Invalid contained worktree credentials'
+    );
+    expect(await resolve(env, invalidGrant)).toBeNull();
+    expectSecretSafeLogs();
+  });
+});
+
+describe('credential resolution boundaries', () => {
+  it.each([
+    ['/api/auth/native/exchange', 'POST'],
+    ['/api/organizations/acme/user-tokens', 'GET'],
+    ['/api/gastown/git-credentials', 'POST'],
+    ['/api/wasteland/token', 'POST'],
+    ['/api/mcp/connect-token', 'GET'],
+    ['/api/profile/tokens', 'GET'],
+    ['/api/user/token', 'GET'],
+    ['/api/user', 'POST'],
+    ['/api/session', 'POST'],
+    [`/api/session/${ROOT_ID}/import`, 'POST'],
+  ])('denies arbitrary or credential-returning Kilo route %s %s', async (path, method) => {
+    const { broker } = createBroker();
+    const env = {
+      ...environment(broker),
+      KILOCODE_BACKEND_BASE_URL: 'https://shared.example.com',
+      KILO_OPENROUTER_BASE: 'https://shared.example.com',
+      KILO_SESSION_INGEST_URL: 'https://shared.example.com',
+    };
+    const { grant } = await prepare(env);
+    expect(
+      await resolve(env, grant, { url: `https://shared.example.com${path}`, method })
+    ).toBeNull();
+  });
+
+  it('respects same-host session shadows even beneath broad provider prefixes', async () => {
+    const { broker } = createBroker();
+    const env = {
+      ...environment(broker),
+      KILO_SESSION_INGEST_URL: 'https://provider.example.com/api/openrouter',
+    };
+    const first = await prepare(env);
+    const { grant } = await prepare(env, secondRoot(), first.grant);
+    const collection = 'https://provider.example.com/api/openrouter/api/session';
+    expect(
+      await resolve(env, grant, { url: `${collection}/${SECOND_ROOT_ID}/export`, method: 'GET' })
+    ).not.toBeNull();
+    expect(
+      await resolve(env, grant, { url: `${collection}/${THIRD_ROOT_ID}/export`, method: 'GET' })
+    ).toBeNull();
+    expect(
+      await resolve(env, grant, { url: `${collection}/${THIRD_ROOT_ID}/ingest`, method: 'POST' })
+    ).toBeNull();
+    expect(await resolve(env, grant, { url: collection })).toBeNull();
+  });
+
+  it('rejects sibling aliases, wrong containers, wrong purposes, ports, and origins', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const first = await prepare(env);
+    const sibling = await prepare(
+      env,
+      metadata({ workspace: { workspacePath: '/workspace/other' } }, 'worktree-other')
+    );
+    expect(sibling.grant.kilo.alias).not.toBe(first.grant.kilo.alias);
+    for (const overrides of [
+      { credential: sibling.grant.kilo.alias },
+      { credential: createControlPlaneCredential(SANDBOX_ID, 'gitlab') },
+      { credential: createControlPlaneCredential('usr-deadbeef', 'kilo') },
+      { credential: KILO_TOKEN },
+      { credential: first.grant.kilo.capabilities[SESSION_ID]?.credential },
+      { outboundContainerId: `standard:${SANDBOX_ID}` },
+      { url: 'https://provider.example.com:8443/api/openrouter/chat/completions' },
+      { url: 'http://provider.example.com/api/openrouter/chat/completions' },
+      { url: 'https://other.example.com/api/openrouter/chat/completions' },
+      { url: 'https://user@provider.example.com/api/openrouter/chat/completions' },
+    ]) {
+      expect(await resolve(env, first.grant, overrides)).toBeNull();
+    }
+  });
+
+  it('does not fall back to expired or raw credentials if renewal fails', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const { grant } = await prepare(env);
+    broker.issueKiloSessionCapability.mockRejectedValue(new Error('unavailable'));
+    broker.issueGitHubSessionCapability.mockRejectedValue(new Error('unavailable'));
+    expect(await resolve(env, grant, { now: NOW + 3 * HOUR })).toBeNull();
+    expect(
+      await resolve(env, grant, {
+        now: NOW + 3 * HOUR,
+        credential: grant.scm?.alias,
+        url: 'https://api.github.com/repos/acme/repo',
+        method: 'GET',
+      })
+    ).toBeNull();
+    expect(broker.getTokenForRepo).not.toHaveBeenCalled();
+    expect(broker.getCloudAgentAuthForRepo).not.toHaveBeenCalled();
+  });
+
+  it('removes only the requested membership, its capabilities, and finally empty grants', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const first = await prepare(env);
+    const second = await prepare(env, secondRoot(), first.grant);
+    const sibling = await prepare(
+      env,
+      metadata({ workspace: { workspacePath: '/workspace/other' } }, 'worktree-other')
+    );
+    const grants = removeSessionCredentialMembership(
+      [second.grant, sibling.grant],
+      SECOND_SESSION_ID
+    );
+    expect(grants).toHaveLength(2);
+    expect(grants[0]?.members).toEqual(first.grant.members);
+    expect(grants[0]?.kilo.alias).toBe(second.grant.kilo.alias);
+    expect(grants[0]?.kilo.capabilities).not.toHaveProperty(SECOND_SESSION_ID);
+    expect(grants[1]).toBe(sibling.grant);
+    expect(second.grant.members).toHaveLength(2);
+    const retained = grants[0];
+    if (!retained) throw new Error('Expected retained worktree');
+    expect(
+      await resolve(env, retained, {
+        url: `https://ingest.example.com/api/session/${SECOND_ROOT_ID}/export`,
+        method: 'GET',
+      })
+    ).toBeNull();
+    expect(removeSessionCredentialMembership(grants, SESSION_ID)).toEqual([]);
+  });
+
+  it('validates persisted alias purpose, memberships, and bounded lease/cache lifetimes', async () => {
+    const { broker } = createBroker();
+    const { grant } = await prepare(environment(broker));
+    const capability = grant.kilo.capabilities[SESSION_ID];
+    if (!capability) throw new Error('Expected Kilo capability');
+    for (const invalid of [
+      { ...grant, members: [] },
+      { ...grant, members: [...grant.members, ...grant.members] },
+      { ...grant, expiresAt: NOW + 5 * HOUR },
+      { ...grant, kilo: { ...grant.kilo, alias: grant.scm?.alias } },
+      {
+        ...grant,
+        kilo: {
+          ...grant.kilo,
+          capabilities: { [SESSION_ID]: { ...capability, expiresAt: NOW + 4 * HOUR } },
+        },
+      },
+      { ...grant, kilo: { ...grant.kilo, capabilities: { [THIRD_SESSION_ID]: capability } } },
+      { ...grant, scm: { ...grant.scm, nativeToken: GITHUB_TOKEN } },
+    ]) {
+      expect(sessionCredentialGrantSchema.safeParse(invalid).success).toBe(false);
+    }
+  });
+});
+
+describe('native Vercel worktree policies', () => {
+  it('composes sibling worktree rules without losing registered roots or broadening aliases', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const first = await prepare(env, vercelMetadata());
+    const second = await prepare(
+      env,
+      vercelMetadata({ identity: secondRoot().identity, auth: secondRoot().auth }),
+      first.grant
+    );
+    const sibling = await prepare(
+      env,
+      vercelMetadata(
+        {
+          identity: { ...metadata().identity, sessionId: THIRD_SESSION_ID },
+          auth: { kiloSessionId: THIRD_ROOT_ID, kilocodeToken: 'test-sibling-kilo-token' },
+          workspace: { workspacePath: '/workspace/sibling' },
+          repository: { type: 'github', repo: 'acme/another' },
+        },
+        'worktree-sibling'
+      )
+    );
+    const policy = buildControlNetworkPolicy([second.grant, sibling.grant]);
+    const authorizationFor = (rootId: string, alias: string) =>
+      findMatchingCredentialInjectionRule(policy.injectionRules, {
+        url: new URL(`https://ingest.example.com/api/session/${rootId}/export`),
+        method: 'GET',
+        headers: new Headers({ authorization: `Bearer ${alias}` }),
+      })?.headers.authorization;
+
+    expect(second.grant.kilo.alias).toBe(first.grant.kilo.alias);
+    expect(authorizationFor(ROOT_ID, second.grant.kilo.alias)).toBe(`Bearer ${KILO_TOKEN}`);
+    expect(authorizationFor(SECOND_ROOT_ID, second.grant.kilo.alias)).toBe(`Bearer ${KILO_TOKEN}`);
+    expect(authorizationFor(THIRD_ROOT_ID, sibling.grant.kilo.alias)).toBe(
+      'Bearer test-sibling-kilo-token'
+    );
+    expect(authorizationFor(THIRD_ROOT_ID, second.grant.kilo.alias)).toBeUndefined();
+    expect(authorizationFor(ROOT_ID, sibling.grant.kilo.alias)).toBeUndefined();
+    expect(policy.allowedDomains).toContain('*');
+    expect(new Set(policy.allowedDomains).size).toBe(policy.allowedDomains.length);
+    expect(broker.issueKiloSessionCapability).not.toHaveBeenCalled();
+    expect(broker.issueGitHubSessionCapability).not.toHaveBeenCalled();
+    expect(buildControlNetworkPolicy([])).toEqual({
+      mode: 'custom',
+      allowedDomains: ['*'],
+      injectionRules: [],
+    });
+  });
+
+  it('refreshes native GitHub injection on trusted prepare while preserving the integration pin and alias', async () => {
+    const { broker } = createBroker();
+    const env = environment(broker);
+    const data = vercelMetadata({ profile: { envVars: { GH_TOKEN: GITHUB_TOKEN } } });
+    const first = await prepare(env, data);
+    broker.getTokenForRepo.mockResolvedValue({
+      success: true,
+      token: 'test-renewed-github-token',
+      installationId: '42',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const second = await prepare(env, data, first.grant, NOW + HOUR);
+    expect(second.grant.scm?.alias).toBe(first.grant.scm?.alias);
+    expect(second.payload.env?.GH_TOKEN).toBe(first.grant.scm?.alias);
+    expect(second.grant.scm?.nativeToken).toBe('test-renewed-github-token');
+    expect(broker.getTokenForRepo).toHaveBeenLastCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-a',
+      orgId: INTEGRATION_ID,
+      expectedIntegrationId: INTEGRATION_ID,
+    });
+    const policy = buildControlNetworkPolicy([second.grant]);
+    expect(
+      findMatchingCredentialInjectionRule(policy.injectionRules, {
+        url: new URL('https://api.github.com/repos/acme/repo'),
+        method: 'GET',
+        headers: new Headers({ authorization: `Bearer ${second.grant.scm?.alias}` }),
+      })?.headers.authorization
+    ).toBe('Bearer test-renewed-github-token');
+    expect(JSON.stringify(second.payload)).not.toContain(GITHUB_TOKEN);
+    expect(JSON.stringify(second.payload)).not.toContain('test-renewed-github-token');
+  });
+
+  it.each([false, true])(
+    'contains native GitHub tokens without replacing explicit authentication: explicit=%s',
+    async explicit => {
+      const { broker } = createBroker();
+      const { grant, payload } = await prepare(
+        environment(broker),
+        vercelMetadata({
+          repository: {
+            type: 'github',
+            repo: 'acme/repo',
+            ...(explicit ? { token: GITHUB_TOKEN } : {}),
+          },
+          profile: {
+            envVars: { GITHUB_TOKEN, KILO_CONFIG_CONTENT: JSON.stringify({ token: KILO_TOKEN }) },
+          },
+        })
+      );
+      expect(grant.scm?.nativeToken).toBe(GITHUB_TOKEN);
+      expect(grant.repository).toMatchObject({ authentication: explicit ? 'explicit' : 'managed' });
+      expect(payload.env?.GH_TOKEN).toBe(grant.scm?.alias);
+      expect(payload.env?.GITHUB_TOKEN).toBe(grant.scm?.alias);
+      expect(payload.git?.token).toBe(grant.scm?.alias);
+      expect(JSON.stringify(payload)).not.toContain(GITHUB_TOKEN);
+      expect(JSON.stringify(payload)).not.toContain(KILO_TOKEN);
+      expect(broker.getTokenForRepo).toHaveBeenCalledTimes(explicit ? 0 : 1);
+    }
+  );
+});

--- a/services/cloud-agent-next/src/sandbox-control/session-credentials.ts
+++ b/services/cloud-agent-next/src/sandbox-control/session-credentials.ts
@@ -1,0 +1,866 @@
+import { containedKiloSessionIdSchema } from '@kilocode/session-ingest-contracts';
+import { z } from 'zod';
+import type { VercelSandboxNetworkPolicy } from '../agent-sandbox/vercel/vercel-sandbox-rest-client.js';
+import { deriveKiloSandboxTargets, type KiloTargetEnv } from '../kilo/kilo-targets.js';
+import { getSandboxProvider, type SessionMetadata } from '../persistence/session-metadata.js';
+import { type getOutboundContainerId, isValidSandboxId } from '../sandbox-id.js';
+import { buildSessionAttachPayload } from '../sandbox-session/attach-payload.js';
+import {
+  issueCloudAgentBitbucketSessionCapability,
+  issueCloudAgentGitHubSessionCapability,
+  issueCloudAgentGitLabSessionCapability,
+  issueCloudAgentKiloSessionCapability,
+  resolveGitHubTokenForRepo,
+} from '../services/git-token-service-client.js';
+import { readProfileBundle } from '../session-profile.js';
+import type { SessionAttachPayload } from '../shared/sandbox-control-protocol.js';
+import { parseCanonicalBitbucketCloneUrl, sessionIdSchema, type Env } from '../types.js';
+import { createControlPlaneCredential, parseControlPlaneCredential } from './managed-credential.js';
+import {
+  buildKiloCredentialInjectionRules,
+  buildVercelCredentialNetworkPolicy,
+  findMatchingCredentialInjectionRule,
+} from './vercel-network-policy.js';
+
+const WORKTREE_LEASE_MS = 4 * 60 * 60 * 1000;
+const CAPABILITY_CACHE_MS = 3 * 60 * 60 * 1000;
+const timestampSchema = z.number().int().nonnegative();
+const tokenSchema = z
+  .string()
+  .min(1)
+  .max(64 * 1024)
+  .regex(/^\S+$/)
+  .refine(value => !hasControlCharacters(value));
+const realTokenSchema = tokenSchema.refine(token => !/^(?:kcp|kka|kgh|kgl|kbb)\d+\./.test(token));
+const scopeIdSchema = z
+  .string()
+  .min(1)
+  .max(256)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/);
+const organizationIdSchema = z.string().regex(/^[A-Za-z0-9][A-Za-z0-9._-]*$/);
+const memberSchema = z
+  .object({
+    sessionId: sessionIdSchema.refine(id => id.startsWith('workspace_')),
+    kiloSessionId: containedKiloSessionIdSchema,
+  })
+  .strict();
+const targetsSchema = z
+  .object({
+    backendBaseUrl: z.string().url(),
+    providerBaseUrl: z.string().url(),
+    sessionIngestBaseUrl: z.string().url(),
+  })
+  .strict();
+const capabilitySchema = z
+  .object({
+    credential: tokenSchema.regex(/^(?:kka1|kgh2|kgl2|kbb1)\./),
+    outboundContainerId: z.string().min(1),
+    issuedAt: timestampSchema,
+    expiresAt: timestampSchema,
+  })
+  .strict()
+  .refine(value => value.expiresAt > value.issuedAt)
+  .refine(value => value.expiresAt - value.issuedAt <= CAPABILITY_CACHE_MS);
+const repositorySchema = z.discriminatedUnion('type', [
+  z
+    .object({
+      type: z.literal('github'),
+      repo: z.string().min(1),
+      authentication: z.enum(['managed', 'explicit']),
+      expectedIntegrationId: z.string().uuid().optional(),
+      allowUserAuthorization: z.boolean(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('gitlab'),
+      url: z.string().url(),
+      createdOnPlatform: z.string().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('bitbucket'),
+      url: z.string().url(),
+      workspaceUuid: z.string().uuid(),
+      repositoryUuid: z.string().uuid(),
+      expectedIntegrationId: z.string().uuid().optional(),
+    })
+    .strict(),
+  z
+    .object({
+      type: z.literal('git'),
+      url: z.string().url(),
+      platform: z.enum(['github', 'gitlab']).optional(),
+    })
+    .strict(),
+]);
+const scmSchema = z
+  .object({
+    purpose: z.enum(['github', 'gitlab', 'bitbucket']),
+    alias: tokenSchema,
+    gitUrl: z.string().url(),
+    capability: capabilitySchema.optional(),
+    nativeToken: realTokenSchema.optional(),
+    gitlab: z
+      .object({
+        instanceOrigin: z.string().url(),
+        instanceHost: z.string().min(1),
+        projectPath: z.string().min(1),
+        integrationId: z.string().min(1),
+        authType: z.enum(['oauth', 'pat']),
+        identity: z
+          .object({ accountId: z.string().nullable(), accountLogin: z.string().nullable() })
+          .strict(),
+        glabIsOAuth2: z.boolean(),
+      })
+      .strict()
+      .optional(),
+  })
+  .strict();
+
+export const sessionCredentialGrantSchema = z
+  .object({
+    version: z.literal(1),
+    scopeId: scopeIdSchema,
+    sandboxId: z
+      .string()
+      .refine(isValidSandboxId)
+      .refine(id => !id.startsWith('dind-')),
+    directory: z
+      .string()
+      .min(1)
+      .max(1024)
+      .refine(
+        directory =>
+          directory.startsWith('/') &&
+          !directory.includes('\\') &&
+          !hasControlCharacters(directory) &&
+          directory
+            .split('/')
+            .slice(1)
+            .every(part => part !== '' && part !== '.' && part !== '..')
+      ),
+    userId: z.string().min(1),
+    orgId: organizationIdSchema.optional(),
+    provider: z.enum(['cloudflare', 'vercel']),
+    outboundContainerId: z.string().min(1).optional(),
+    members: z.array(memberSchema).min(1),
+    repository: repositorySchema.optional(),
+    kilo: z
+      .object({
+        alias: tokenSchema,
+        token: realTokenSchema,
+        targets: targetsSchema,
+        capabilities: z.record(z.string(), capabilitySchema),
+      })
+      .strict(),
+    scm: scmSchema.optional(),
+    preparedAt: timestampSchema,
+    expiresAt: timestampSchema,
+  })
+  .strict()
+  .superRefine((grant, context) => {
+    const reject = () => context.addIssue({ code: 'custom', message: 'Invalid credential grant' });
+    if (
+      grant.expiresAt <= grant.preparedAt ||
+      grant.expiresAt - grant.preparedAt > WORKTREE_LEASE_MS ||
+      new Set(grant.members.map(member => member.sessionId)).size !== grant.members.length ||
+      new Set(grant.members.map(member => member.kiloSessionId)).size !== grant.members.length ||
+      (grant.provider === 'cloudflare' && !grant.outboundContainerId)
+    ) {
+      reject();
+    }
+    const kiloAlias = parseControlPlaneCredential(grant.kilo.alias);
+    if (kiloAlias?.sandboxId !== grant.sandboxId || kiloAlias.purpose !== 'kilo') reject();
+    const targets = deriveKiloSandboxTargets(
+      {
+        KILOCODE_BACKEND_BASE_URL: grant.kilo.targets.backendBaseUrl,
+        KILO_OPENROUTER_BASE: grant.kilo.targets.providerBaseUrl,
+        KILO_SESSION_INGEST_URL: grant.kilo.targets.sessionIngestBaseUrl,
+      },
+      grant.kilo.token,
+      { requireHttps: grant.provider === 'vercel' }
+    );
+    if (
+      !targets.success ||
+      JSON.stringify(targets.targets) !== JSON.stringify(grant.kilo.targets)
+    ) {
+      reject();
+    }
+    for (const [sessionId, capability] of Object.entries(grant.kilo.capabilities)) {
+      if (
+        !grant.members.some(member => member.sessionId === sessionId) ||
+        !capability.credential.startsWith('kka1.') ||
+        grant.provider !== 'cloudflare'
+      ) {
+        reject();
+      }
+    }
+    if (grant.repository && grant.repository.type !== 'git') {
+      if (grant.scm?.purpose !== grant.repository.type) reject();
+    } else if (grant.scm) {
+      reject();
+    }
+    if (!grant.scm) return;
+    const alias = parseControlPlaneCredential(grant.scm.alias);
+    if (alias?.sandboxId !== grant.sandboxId || alias.purpose !== grant.scm.purpose) reject();
+    if (grant.provider === 'vercel') {
+      if (
+        grant.scm.purpose !== 'github' ||
+        !grant.scm.nativeToken ||
+        grant.scm.capability ||
+        grant.scm.gitlab
+      ) {
+        reject();
+      }
+    } else {
+      const prefixes = { github: 'kgh2.', gitlab: 'kgl2.', bitbucket: 'kbb1.' };
+      if (
+        grant.scm.nativeToken ||
+        !grant.scm.capability?.credential.startsWith(prefixes[grant.scm.purpose]) ||
+        (grant.scm.purpose === 'gitlab') !== (grant.scm.gitlab !== undefined)
+      ) {
+        reject();
+      }
+    }
+  });
+
+export type SessionCredentialGrant = z.infer<typeof sessionCredentialGrantSchema>;
+type CredentialMember = z.infer<typeof memberSchema>;
+type CredentialRepository = z.infer<typeof repositorySchema>;
+type ScmGrant = z.infer<typeof scmSchema>;
+type CachedCapability = z.infer<typeof capabilitySchema>;
+type CredentialEnv = Parameters<typeof getOutboundContainerId>[0] &
+  Partial<Pick<Env, 'GIT_TOKEN_SERVICE'>> &
+  KiloTargetEnv;
+
+type PreparedSessionAttachPayload = SessionAttachPayload & {
+  kilo: NonNullable<SessionAttachPayload['kilo']>;
+};
+
+function invalidCredentials(): never {
+  throw new Error('Invalid contained worktree credentials');
+}
+
+function validateGrant(value: unknown): SessionCredentialGrant {
+  const parsed = sessionCredentialGrantSchema.safeParse(value);
+  if (!parsed.success) invalidCredentials();
+  return parsed.data;
+}
+
+function hasControlCharacters(value: string): boolean {
+  return [...value].some(character => {
+    const code = character.charCodeAt(0);
+    return code < 0x20 || code === 0x7f;
+  });
+}
+
+function safeUrl(value: string): URL | null {
+  if (value.includes('\\') || /\s/.test(value) || hasControlCharacters(value)) return null;
+  try {
+    const url = new URL(value);
+    if (url.username || url.password || url.hash || /^\w+:\/\/[^/]*@/.test(value)) return null;
+    return url;
+  } catch {
+    return null;
+  }
+}
+
+function canonicalRepositoryUrl(value: string, managed = false): string {
+  const url = safeUrl(value);
+  if (!url || url.protocol !== 'https:' || url.search) invalidCredentials();
+  if (managed) {
+    const rawPath = /^https:\/\/[^/]+(\/.*)?$/i.exec(value)?.[1] ?? '/';
+    if (/%|\/\.{1,2}(?:\/|$)|\/\//.test(rawPath)) invalidCredentials();
+    const path = url.pathname.replace(/\.git$/, '').slice(1);
+    if (
+      path.split('/').length < 2 ||
+      path.split('/').some(part => !/^[A-Za-z0-9_.-]+$/.test(part) || part === '.' || part === '..')
+    ) {
+      invalidCredentials();
+    }
+    url.pathname = `/${path}.git`;
+  }
+  return url.toString();
+}
+
+function isKnownScmCredential(token: string | undefined, scm: ScmGrant | undefined): boolean {
+  return (
+    token !== undefined &&
+    scm !== undefined &&
+    (token === scm.alias || token === scm.capability?.credential || token === scm.nativeToken)
+  );
+}
+
+function repositoryFromMetadata(
+  metadata: SessionMetadata,
+  provider: SessionCredentialGrant['provider'],
+  existing: SessionCredentialGrant | undefined
+): CredentialRepository | undefined {
+  const repository = metadata.repository;
+  if (!repository) return undefined;
+  if (repository.type === 'github') {
+    if (
+      repository.repo.split('/').length !== 2 ||
+      repository.repo
+        .split('/')
+        .some(part => !/^[A-Za-z0-9_.-]+$/.test(part) || part === '.' || part === '..')
+    ) {
+      invalidCredentials();
+    }
+    const explicit =
+      Boolean(repository.token) && !isKnownScmCredential(repository.token, existing?.scm);
+    if (provider === 'cloudflare' && explicit) invalidCredentials();
+    return {
+      type: 'github',
+      repo: repository.repo,
+      authentication:
+        existing?.repository?.type === 'github' &&
+        isKnownScmCredential(repository.token, existing.scm)
+          ? existing.repository.authentication
+          : explicit
+            ? 'explicit'
+            : 'managed',
+      ...(repository.githubIntegrationId
+        ? { expectedIntegrationId: repository.githubIntegrationId }
+        : {}),
+      allowUserAuthorization:
+        metadata.identity.createdOnPlatform === 'cloud-agent-web' ||
+        metadata.identity.createdOnPlatform === 'slack',
+    };
+  }
+  const url = canonicalRepositoryUrl(repository.url, repository.type !== 'git');
+  if (repository.type === 'git') {
+    if (repository.token) invalidCredentials();
+    return { type: 'git', url, ...(repository.platform ? { platform: repository.platform } : {}) };
+  }
+  if (provider === 'vercel') invalidCredentials();
+  if (repository.type === 'gitlab') {
+    if (
+      repository.token &&
+      repository.gitlabTokenManaged !== true &&
+      !isKnownScmCredential(repository.token, existing?.scm)
+    ) {
+      invalidCredentials();
+    }
+    return {
+      type: 'gitlab',
+      url,
+      ...(metadata.identity.createdOnPlatform
+        ? { createdOnPlatform: metadata.identity.createdOnPlatform }
+        : {}),
+    };
+  }
+  if (!metadata.identity.orgId || !parseCanonicalBitbucketCloneUrl(url)) invalidCredentials();
+  return {
+    type: 'bitbucket',
+    url,
+    workspaceUuid: repository.workspaceUuid.toLowerCase(),
+    repositoryUuid: repository.repositoryUuid.toLowerCase(),
+    ...(repository.bitbucketIntegrationId
+      ? { expectedIntegrationId: repository.bitbucketIntegrationId }
+      : {}),
+  };
+}
+
+function cachedCapability(
+  credential: string,
+  prefix: string,
+  outboundContainerId: string,
+  now: number
+): CachedCapability {
+  if (!tokenSchema.safeParse(credential).success || !credential.startsWith(prefix)) {
+    invalidCredentials();
+  }
+  return { credential, outboundContainerId, issuedAt: now, expiresAt: now + CAPABILITY_CACHE_MS };
+}
+
+function isCapabilityCurrent(
+  capability: CachedCapability | undefined,
+  outboundContainerId: string,
+  now: number
+): capability is CachedCapability {
+  return (
+    capability !== undefined &&
+    capability.outboundContainerId === outboundContainerId &&
+    capability.issuedAt <= now &&
+    now < capability.expiresAt
+  );
+}
+
+async function refreshKiloCapability(
+  env: CredentialEnv,
+  grant: SessionCredentialGrant,
+  member: CredentialMember,
+  outboundContainerId: string,
+  now: number
+): Promise<SessionCredentialGrant> {
+  if (isCapabilityCurrent(grant.kilo.capabilities[member.sessionId], outboundContainerId, now)) {
+    return grant;
+  }
+  const issued = await issueCloudAgentKiloSessionCapability(env, {
+    userId: grant.userId,
+    cloudAgentSessionId: member.sessionId,
+    kiloSessionId: member.kiloSessionId,
+    outboundContainerId,
+    userToken: grant.kilo.token,
+    targets: grant.kilo.targets,
+  });
+  if (!issued.success) throw new Error('Kilo capability issuance is unavailable');
+  return {
+    ...grant,
+    kilo: {
+      ...grant.kilo,
+      capabilities: {
+        ...grant.kilo.capabilities,
+        [member.sessionId]: cachedCapability(
+          issued.value.capability,
+          'kka1.',
+          outboundContainerId,
+          now
+        ),
+      },
+    },
+  };
+}
+
+async function refreshScmCapability(
+  env: CredentialEnv,
+  grant: SessionCredentialGrant,
+  outboundContainerId: string,
+  now: number
+): Promise<SessionCredentialGrant> {
+  const repository = grant.repository;
+  if (!repository || repository.type === 'git') return grant;
+  if (isCapabilityCurrent(grant.scm?.capability, outboundContainerId, now)) return grant;
+  const common = {
+    userId: grant.userId,
+    ...(grant.orgId ? { orgId: grant.orgId } : {}),
+    outboundContainerId,
+  };
+  const alias = grant.scm?.alias ?? createControlPlaneCredential(grant.sandboxId, repository.type);
+  let scm: ScmGrant;
+  if (repository.type === 'github') {
+    const issued = await issueCloudAgentGitHubSessionCapability(env, {
+      ...common,
+      githubRepo: repository.repo,
+      allowUserAuthorization: repository.allowUserAuthorization,
+      ...(repository.expectedIntegrationId
+        ? { expectedIntegrationId: repository.expectedIntegrationId }
+        : {}),
+    });
+    if (!issued.success || !('capability' in issued.value)) {
+      throw new Error('GitHub capability issuance is unavailable');
+    }
+    scm = {
+      purpose: 'github',
+      alias,
+      gitUrl: `https://github.com/${repository.repo}.git`,
+      capability: cachedCapability(issued.value.capability, 'kgh2.', outboundContainerId, now),
+    };
+  } else if (repository.type === 'gitlab') {
+    const issued = await issueCloudAgentGitLabSessionCapability(env, {
+      ...common,
+      gitUrl: repository.url,
+      ...(repository.createdOnPlatform ? { createdOnPlatform: repository.createdOnPlatform } : {}),
+    });
+    if (!issued.success) throw new Error('GitLab capability issuance is unavailable');
+    const { capability, gitUrl, ...gitlab } = issued.value;
+    if (
+      canonicalRepositoryUrl(gitUrl, true) !== repository.url ||
+      (grant.scm?.gitlab && JSON.stringify(grant.scm.gitlab) !== JSON.stringify(gitlab))
+    ) {
+      invalidCredentials();
+    }
+    scm = {
+      purpose: 'gitlab',
+      alias,
+      gitUrl,
+      gitlab,
+      capability: cachedCapability(capability, 'kgl2.', outboundContainerId, now),
+    };
+  } else {
+    if (!grant.orgId) invalidCredentials();
+    const issued = await issueCloudAgentBitbucketSessionCapability(env, {
+      ...common,
+      orgId: grant.orgId,
+      workspaceUuid: repository.workspaceUuid,
+      repositoryUuid: repository.repositoryUuid,
+      repositoryUrl: repository.url,
+      ...(repository.expectedIntegrationId
+        ? { expectedIntegrationId: repository.expectedIntegrationId }
+        : {}),
+    });
+    if (!issued.success) throw new Error('Bitbucket capability issuance is unavailable');
+    const gitUrl = canonicalRepositoryUrl(issued.value.gitUrl, true);
+    if (!parseCanonicalBitbucketCloneUrl(gitUrl)) invalidCredentials();
+    scm = {
+      purpose: 'bitbucket',
+      alias,
+      gitUrl,
+      capability: cachedCapability(issued.value.capability, 'kbb1.', outboundContainerId, now),
+    };
+  }
+  return { ...grant, scm };
+}
+
+function sanitizedPayload(
+  metadata: SessionMetadata,
+  payload: SessionAttachPayload,
+  grant: SessionCredentialGrant,
+  existing: SessionCredentialGrant | undefined
+): PreparedSessionAttachPayload {
+  const replacements: Array<[string, string]> = [[grant.kilo.token, grant.kilo.alias]];
+  if (existing) replacements.push([existing.kilo.token, grant.kilo.alias]);
+  for (const capability of Object.values(grant.kilo.capabilities)) {
+    replacements.push([capability.credential, grant.kilo.alias]);
+  }
+  if (grant.scm) {
+    const repositoryToken =
+      metadata.repository && 'token' in metadata.repository ? metadata.repository.token : undefined;
+    for (const token of [
+      repositoryToken,
+      grant.scm.nativeToken,
+      grant.scm.capability?.credential,
+      existing?.scm?.nativeToken,
+      existing?.scm?.capability?.credential,
+    ]) {
+      if (token) replacements.push([token, grant.scm.alias]);
+    }
+  }
+  const sanitize = (value: string) =>
+    replacements.reduce((result, [token, alias]) => result.replaceAll(token, alias), value);
+  const profile = readProfileBundle(metadata);
+  const env = Object.fromEntries(
+    Object.entries({ ...profile.envVars, ...payload.env }).map(([key, value]) => [
+      key,
+      key === 'GH_TOKEN' || key === 'GITHUB_TOKEN'
+        ? (replacements.find(([token]) => token === value)?.[1] ?? value)
+        : sanitize(value),
+    ])
+  );
+  env.KILOCODE_TOKEN = grant.kilo.alias;
+  if (grant.scm?.purpose === 'github') {
+    if (env.GITHUB_TOKEN && env.GH_TOKEN === undefined) env.GH_TOKEN = env.GITHUB_TOKEN;
+    env.GH_TOKEN ??= grant.scm.alias;
+  } else if (grant.scm?.purpose === 'gitlab') {
+    const gitlab = grant.scm.gitlab;
+    if (!gitlab) invalidCredentials();
+    env.GITLAB_TOKEN ??= grant.scm.alias;
+    if (env.GITLAB_TOKEN === grant.scm.alias) {
+      env.GLAB_IS_OAUTH2 = gitlab.glabIsOAuth2 ? 'true' : 'false';
+      env.GITLAB_HOST = gitlab.instanceHost;
+      env.GITLAB_SUBFOLDER = new URL(gitlab.instanceOrigin).pathname.replace(/^\/+|\/+$/g, '');
+    }
+  } else if (grant.scm?.purpose === 'bitbucket') {
+    const repository = grant.repository;
+    const canonical = parseCanonicalBitbucketCloneUrl(grant.scm.gitUrl);
+    if (repository?.type !== 'bitbucket' || !canonical) invalidCredentials();
+    env.BITBUCKET_TOKEN = grant.scm.alias;
+    env.KILO_BITBUCKET_WORKSPACE_SLUG = canonical.workspaceSlug;
+    env.KILO_BITBUCKET_REPOSITORY_SLUG = canonical.repositorySlug;
+    env.KILO_BITBUCKET_WORKSPACE_UUID = `{${repository.workspaceUuid}}`;
+    env.KILO_BITBUCKET_REPOSITORY_UUID = `{${repository.repositoryUuid}}`;
+  }
+  return {
+    ...payload,
+    directory: grant.directory,
+    env,
+    ...(grant.scm
+      ? { git: { url: grant.scm.gitUrl, platform: grant.scm.purpose, token: grant.scm.alias } }
+      : grant.repository?.type === 'git'
+        ? {
+            git: {
+              url: grant.repository.url,
+              ...(grant.repository.platform ? { platform: grant.repository.platform } : {}),
+            },
+          }
+        : {}),
+    ...(payload.setupCommands ? { setupCommands: payload.setupCommands.map(sanitize) } : {}),
+    kilo: { scopeId: grant.scopeId, token: grant.kilo.alias, targets: grant.kilo.targets },
+  };
+}
+
+export async function prepareSessionCredentials(input: {
+  env: CredentialEnv;
+  metadata: SessionMetadata;
+  sandboxId: string;
+  outboundContainerId?: string;
+  existing?: SessionCredentialGrant;
+  now?: number;
+}): Promise<{ grant: SessionCredentialGrant; payload: PreparedSessionAttachPayload }> {
+  const { env, metadata, sandboxId } = input;
+  const now = input.now ?? Date.now();
+  if (!timestampSchema.safeParse(now).success) invalidCredentials();
+  if (
+    metadata.workspace?.sandboxId !== sandboxId ||
+    sandboxId.startsWith('dind-') ||
+    metadata.workspace?.devcontainerRequested ||
+    metadata.devcontainer
+  ) {
+    invalidCredentials();
+  }
+  const member = memberSchema.safeParse({
+    sessionId: metadata.identity.sessionId,
+    kiloSessionId: metadata.auth.kiloSessionId,
+  });
+  const token = realTokenSchema.safeParse(metadata.auth.kilocodeToken);
+  if (!member.success || !token.success) invalidCredentials();
+  const provider = getSandboxProvider(metadata);
+  const targets = deriveKiloSandboxTargets(env, token.data, {
+    requireHttps: provider === 'vercel',
+  });
+  if (!targets.success) invalidCredentials();
+  const existing = input.existing === undefined ? undefined : validateGrant(input.existing);
+  const payload = buildSessionAttachPayload(metadata);
+  const scopeId = scopeIdSchema.safeParse(
+    metadata.workspace?.worktreeId ?? metadata.identity.sessionId
+  );
+  if (!scopeId.success || !payload.directory) invalidCredentials();
+  const repository = repositoryFromMetadata(metadata, provider, existing);
+  if (
+    existing &&
+    (existing.scopeId !== scopeId.data ||
+      existing.directory !== payload.directory ||
+      existing.sandboxId !== sandboxId ||
+      existing.userId !== metadata.identity.userId ||
+      existing.orgId !== metadata.identity.orgId ||
+      existing.provider !== provider ||
+      existing.outboundContainerId !== input.outboundContainerId ||
+      existing.preparedAt > now ||
+      JSON.stringify(existing.kilo.targets) !== JSON.stringify(targets.targets) ||
+      JSON.stringify(existing.repository) !== JSON.stringify(repository))
+  ) {
+    invalidCredentials();
+  }
+  const members = existing?.members ?? [];
+  if (
+    members.some(
+      current =>
+        (current.sessionId === member.data.sessionId &&
+          current.kiloSessionId !== member.data.kiloSessionId) ||
+        (current.kiloSessionId === member.data.kiloSessionId &&
+          current.sessionId !== member.data.sessionId)
+    )
+  ) {
+    invalidCredentials();
+  }
+  let grant: SessionCredentialGrant = {
+    version: 1,
+    scopeId: scopeId.data,
+    directory: payload.directory,
+    sandboxId,
+    userId: metadata.identity.userId,
+    ...(metadata.identity.orgId === undefined ? {} : { orgId: metadata.identity.orgId }),
+    provider,
+    ...(input.outboundContainerId ? { outboundContainerId: input.outboundContainerId } : {}),
+    members: members.some(current => current.sessionId === member.data.sessionId)
+      ? [...members]
+      : [...members, member.data],
+    ...(repository ? { repository } : {}),
+    kilo: {
+      alias: existing?.kilo.alias ?? createControlPlaneCredential(sandboxId, 'kilo'),
+      token: token.data,
+      targets: targets.targets,
+      capabilities: existing?.kilo.token === token.data ? existing.kilo.capabilities : {},
+    },
+    ...(existing?.scm ? { scm: existing.scm } : {}),
+    preparedAt: now,
+    expiresAt: now + WORKTREE_LEASE_MS,
+  };
+  if (provider === 'cloudflare') {
+    const outboundContainerId = input.outboundContainerId;
+    if (!outboundContainerId) invalidCredentials();
+    grant = await refreshKiloCapability(env, grant, member.data, outboundContainerId, now);
+    grant = await refreshScmCapability(env, grant, outboundContainerId, now);
+  } else if (repository?.type === 'github') {
+    let nativeToken = payload.git?.token;
+    if (repository.authentication === 'managed') {
+      const resolved = await resolveGitHubTokenForRepo(env, {
+        githubRepo: repository.repo,
+        userId: grant.userId,
+        ...(grant.orgId ? { orgId: grant.orgId } : {}),
+        ...(repository.expectedIntegrationId
+          ? { expectedIntegrationId: repository.expectedIntegrationId }
+          : {}),
+      });
+      if (!resolved.success) throw new Error('GitHub credential is unavailable');
+      nativeToken = resolved.value.token;
+    }
+    if (!nativeToken) invalidCredentials();
+    grant = {
+      ...grant,
+      scm: {
+        purpose: 'github',
+        alias: existing?.scm?.alias ?? createControlPlaneCredential(sandboxId, 'github'),
+        gitUrl: `https://github.com/${repository.repo}.git`,
+        nativeToken,
+      },
+    };
+  }
+  grant = validateGrant(grant);
+  if (provider === 'vercel') buildControlNetworkPolicy([grant]);
+  else {
+    buildKiloCredentialInjectionRules(
+      {
+        token: grant.kilo.token,
+        placeholder: grant.kilo.alias,
+        targets: grant.kilo.targets,
+        rootSessionIds: grant.members.map(current => current.kiloSessionId),
+        organizationId: grant.orgId,
+      },
+      { requireHttps: false }
+    );
+  }
+  return { grant, payload: sanitizedPayload(metadata, payload, grant, existing) };
+}
+
+export function removeSessionCredentialMembership(
+  grants: readonly SessionCredentialGrant[],
+  sessionId: string
+): SessionCredentialGrant[] {
+  return grants.flatMap(grant => {
+    const members = grant.members.filter(member => member.sessionId !== sessionId);
+    if (members.length === grant.members.length) return [grant];
+    if (members.length === 0) return [];
+    return [
+      {
+        ...grant,
+        members,
+        kilo: {
+          ...grant.kilo,
+          capabilities: Object.fromEntries(
+            Object.entries(grant.kilo.capabilities).filter(([id]) => id !== sessionId)
+          ),
+        },
+      },
+    ];
+  });
+}
+
+export function buildControlNetworkPolicy(
+  grants: readonly SessionCredentialGrant[]
+): VercelSandboxNetworkPolicy {
+  const policies = grants.map(value => {
+    const grant = validateGrant(value);
+    if (grant.provider !== 'vercel' || grant.sandboxId !== grants[0]?.sandboxId)
+      invalidCredentials();
+    return buildVercelCredentialNetworkPolicy({
+      kilo: {
+        token: grant.kilo.token,
+        placeholder: grant.kilo.alias,
+        targets: grant.kilo.targets,
+        rootSessionIds: grant.members.map(member => member.kiloSessionId),
+        organizationId: grant.orgId,
+      },
+      ...(grant.repository?.type === 'github' && grant.scm?.nativeToken
+        ? {
+            github: {
+              token: grant.scm.nativeToken,
+              placeholder: grant.scm.alias,
+              repository: grant.repository.repo,
+            },
+          }
+        : {}),
+    });
+  });
+  const aliases = grants.flatMap(grant => [
+    grant.kilo.alias,
+    ...(grant.scm ? [grant.scm.alias] : []),
+  ]);
+  if (new Set(aliases).size !== aliases.length) invalidCredentials();
+  const injectionRules = policies.flatMap(policy => policy.injectionRules);
+  return {
+    mode: 'custom',
+    allowedDomains: [...new Set(injectionRules.map(rule => rule.domain)), '*'],
+    injectionRules,
+  };
+}
+
+export async function resolveSessionCredential(input: {
+  env: CredentialEnv;
+  grant: SessionCredentialGrant;
+  credential: string;
+  url: string;
+  method: string;
+  outboundContainerId: string;
+  now?: number;
+}): Promise<{ grant: SessionCredentialGrant; credential: string; organizationId?: string } | null> {
+  const now = input.now ?? Date.now();
+  const parsed = sessionCredentialGrantSchema.safeParse(input.grant);
+  if (!parsed.success || !timestampSchema.safeParse(now).success) return null;
+  let grant = parsed.data;
+  const alias = parseControlPlaneCredential(input.credential);
+  if (
+    grant.provider !== 'cloudflare' ||
+    now < grant.preparedAt ||
+    now >= grant.expiresAt ||
+    alias?.sandboxId !== grant.sandboxId ||
+    input.outboundContainerId !== grant.outboundContainerId
+  ) {
+    return null;
+  }
+  const expected = alias.purpose === 'kilo' ? grant.kilo.alias : grant.scm?.alias;
+  if (
+    input.credential !== expected ||
+    (alias.purpose !== 'kilo' && alias.purpose !== grant.scm?.purpose)
+  ) {
+    return null;
+  }
+  const url = safeUrl(input.url);
+  if (!url) return null;
+  try {
+    if (alias.purpose !== 'kilo') {
+      if (url.protocol !== 'https:') return null;
+      grant = await refreshScmCapability(input.env, grant, input.outboundContainerId, now);
+      return grant.scm?.capability ? { grant, credential: grant.scm.capability.credential } : null;
+    }
+    if (!Object.values(grant.kilo.targets).some(target => new URL(target).origin === url.origin)) {
+      return null;
+    }
+    const rules = buildKiloCredentialInjectionRules(
+      {
+        token: grant.kilo.token,
+        placeholder: grant.kilo.alias,
+        targets: grant.kilo.targets,
+        rootSessionIds: grant.members.map(member => member.kiloSessionId),
+        organizationId: grant.orgId,
+      },
+      { requireHttps: false }
+    );
+    const rule = findMatchingCredentialInjectionRule(rules, {
+      url,
+      method: input.method,
+      headers: new Headers({ authorization: `Bearer ${input.credential}` }),
+    });
+    if (
+      rule?.headers.authorization !== `Bearer ${grant.kilo.token}` ||
+      rule.headers.host !== url.host
+    ) {
+      return null;
+    }
+    const ingest = new URL(grant.kilo.targets.sessionIngestBaseUrl);
+    const member =
+      grant.members.find(
+        current =>
+          url.origin === ingest.origin &&
+          (url.pathname ===
+            `${ingest.pathname.replace(/\/+$/, '')}/api/session/${current.kiloSessionId}/export` ||
+            url.pathname ===
+              `${ingest.pathname.replace(/\/+$/, '')}/api/session/${current.kiloSessionId}/ingest`)
+      ) ?? grant.members[0];
+    if (!member) return null;
+    grant = await refreshKiloCapability(input.env, grant, member, input.outboundContainerId, now);
+    const capability = grant.kilo.capabilities[member.sessionId];
+    return capability
+      ? {
+          grant,
+          credential: capability.credential,
+          ...(grant.orgId ? { organizationId: grant.orgId } : {}),
+        }
+      : null;
+  } catch {
+    return null;
+  }
+}

--- a/services/cloud-agent-next/src/sandbox-control/session-routes.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/session-routes.test.ts
@@ -9,6 +9,7 @@ import {
   getRouteBySessionId,
   hasActiveWork,
   resolveSessionEventRoute,
+  type AttachRouteInput,
 } from './session-routes.js';
 
 const OWNER = 'owner_1';
@@ -20,8 +21,20 @@ const attachInput = {
   ownerId: OWNER,
 };
 
-function attachedTable() {
-  return attachRoute(emptyRouteTable(), attachInput, OWNER);
+const worktreeInput = { ...attachInput, worktreeId: 'worktree_1' };
+
+function attachedTable(input: AttachRouteInput = attachInput) {
+  return attachRoute(emptyRouteTable(), input, OWNER);
+}
+
+function sharedDirectoryTable() {
+  const { table, route: first } = attachedTable(worktreeInput);
+  const { route: second } = attachRoute(
+    table,
+    { ...worktreeInput, sessionId: 'ses_2', kiloSessionId: 'kilo_2' },
+    OWNER
+  );
+  return { table, first, second };
 }
 
 describe('session routes', () => {
@@ -40,12 +53,50 @@ describe('session routes', () => {
     expect(getRouteByKiloSessionId(table, 'kilo_1')).toBe(route);
   });
 
-  it('reattaches the same tuple idempotently', () => {
-    const { table, route } = attachedTable();
-    const again = attachRoute(table, attachInput, OWNER);
+  it.each([
+    { name: 'legacy', input: attachInput },
+    { name: 'worktree-scoped', input: worktreeInput },
+  ])('reattaches the same $name tuple idempotently without resetting state', ({ input }) => {
+    const { table, route } = attachedTable(input);
+    applyReportedSessionState(
+      table,
+      input.kiloSessionId,
+      { state: 'active', idleForMs: 10, waitingOn: 'model' },
+      1000
+    );
+    const before = structuredClone(route);
+
+    const again = attachRoute(table, input, OWNER);
     expect(again.changed).toBe(false);
     expect(again.route).toBe(route);
+    expect(again.route).toEqual(before);
     expect(table.size).toBe(1);
+  });
+
+  it('attaches multiple independent roots only to their shared explicit worktree', () => {
+    const { table, first, second } = sharedDirectoryTable();
+    const third = attachRoute(
+      table,
+      { ...worktreeInput, sessionId: 'ses_3', kiloSessionId: 'kilo_3' },
+      OWNER
+    );
+
+    expect(third.changed).toBe(true);
+    expect(table.size).toBe(3);
+    expect([...table.values()].map(route => route.worktreeId)).toEqual([
+      'worktree_1',
+      'worktree_1',
+      'worktree_1',
+    ]);
+    expect(getRouteBySessionId(table, 'ses_1')).toBe(first);
+    expect(getRouteByKiloSessionId(table, 'kilo_2')).toBe(second);
+    expect(getRouteByKiloSessionId(table, 'kilo_3')).toBe(third.route);
+    expect(getRouteByDirectory(table, worktreeInput.directory)).toBeUndefined();
+    expect(attachRoute(table, worktreeInput, OWNER)).toEqual({
+      table,
+      route: first,
+      changed: false,
+    });
   });
 
   it('rejects an owner mismatch', () => {
@@ -68,6 +119,67 @@ describe('session routes', () => {
         OWNER
       )
     ).toThrow('Directory already attached');
+  });
+
+  it.each([
+    [undefined, 'worktree_1'],
+    ['worktree_1', undefined],
+    ['worktree_1', 'worktree_2'],
+    ['', ''],
+    ['', 'worktree_1'],
+    ['worktree_1', ''],
+  ])('rejects directory sharing between worktree ids %j and %j', (existingId, worktreeId) => {
+    const { table, route } = attachedTable({ ...attachInput, worktreeId: existingId });
+    expect(() =>
+      attachRoute(
+        table,
+        { ...attachInput, sessionId: 'ses_2', kiloSessionId: 'kilo_2', worktreeId },
+        OWNER
+      )
+    ).toThrow('Directory already attached');
+    expect([...table.values()]).toEqual([route]);
+  });
+
+  it('rejects assigning the same worktree to a different directory', () => {
+    const { table, route } = attachedTable(worktreeInput);
+    expect(() =>
+      attachRoute(
+        table,
+        {
+          ...worktreeInput,
+          sessionId: 'ses_2',
+          kiloSessionId: 'kilo_2',
+          directory: '/workspace/b',
+        },
+        OWNER
+      )
+    ).toThrow('Worktree already attached to another directory');
+    expect([...table.values()]).toEqual([route]);
+  });
+
+  it('rejects sharing a worktree route across owners', () => {
+    const { table, route } = attachedTable(worktreeInput);
+    expect(() =>
+      attachRoute(
+        table,
+        {
+          ...worktreeInput,
+          sessionId: 'ses_2',
+          kiloSessionId: 'kilo_2',
+          ownerId: 'other_owner',
+        },
+        'other_owner'
+      )
+    ).toThrow('Directory already attached');
+    expect([...table.values()]).toEqual([route]);
+  });
+
+  it('rejects a duplicate root within the same worktree', () => {
+    const { table, route } = attachedTable(worktreeInput);
+    expect(() => attachRoute(table, { ...worktreeInput, sessionId: 'ses_2' }, OWNER)).toThrow(
+      'Kilo session already attached'
+    );
+    expect([...table.values()]).toEqual([route]);
   });
 
   it('rejects a kiloSessionId already attached to another session', () => {
@@ -100,12 +212,62 @@ describe('session routes', () => {
     ).toThrow('Session route conflict');
   });
 
+  it.each([
+    [undefined, 'worktree_1'],
+    ['worktree_1', undefined],
+    ['worktree_1', 'worktree_2'],
+  ])('rejects reattaching a session from worktree %j to %j', (existingId, worktreeId) => {
+    const { table, route } = attachedTable({ ...attachInput, worktreeId: existingId });
+    expect(() => attachRoute(table, { ...attachInput, worktreeId }, OWNER)).toThrow(
+      'Session route conflict'
+    );
+    expect([...table.values()]).toEqual([route]);
+    expect(route.worktreeId).toBe(existingId);
+  });
+
+  it('rejects replacing the root of an attached session', () => {
+    const { table } = attachedTable(worktreeInput);
+    expect(() => attachRoute(table, { ...worktreeInput, kiloSessionId: 'kilo_2' }, OWNER)).toThrow(
+      'Session route conflict'
+    );
+    expect(getRouteByKiloSessionId(table, 'kilo_2')).toBeUndefined();
+  });
+
+  it('rejects reattaching a route owned by a different sandbox owner', () => {
+    const { table, route } = attachedTable();
+    expect(() =>
+      attachRoute(table, { ...attachInput, ownerId: 'other_owner' }, 'other_owner')
+    ).toThrow('Session route conflict');
+    expect(route.ownerId).toBe(OWNER);
+  });
+
+  it('detaches a shared-directory root without removing the remaining route', () => {
+    const { table, second } = sharedDirectoryTable();
+    expect(detachRoute(table, 'ses_1')).toEqual({ table, existed: true });
+    expect(getRouteByKiloSessionId(table, 'kilo_1')).toBeUndefined();
+    expect(getRouteByDirectory(table, worktreeInput.directory)).toBe(second);
+    expect(resolveSessionEventRoute(table, { directory: worktreeInput.directory })).toBe(second);
+  });
+
   it('detaches a route', () => {
     const { table } = attachedTable();
     expect(detachRoute(table, 'ses_1')).toEqual({ table, existed: true });
     expect(getRouteBySessionId(table, 'ses_1')).toBeUndefined();
     expect(getRouteByDirectory(table, '/workspace/a')).toBeUndefined();
     expect(detachRoute(table, 'ses_1')).toEqual({ table, existed: false });
+  });
+
+  it('tracks activity independently for roots sharing a worktree directory', () => {
+    const { table, first, second } = sharedDirectoryTable();
+    applyReportedSessionState(table, 'kilo_1', { state: 'active', idleForMs: 0 }, 1000);
+    applyReportedSessionState(table, 'kilo_2', { state: 'idle', idleForMs: 20 }, 2000);
+
+    expect(first).toMatchObject({ lastState: 'active', lastStateAt: 1000 });
+    expect(second).toMatchObject({ lastState: 'idle', lastStateAt: 2000 });
+    expect(hasActiveWork(table)).toBe(true);
+    applyReportedSessionState(table, 'kilo_1', { state: 'idle', idleForMs: 0 }, 3000);
+    expect(second.lastStateAt).toBe(2000);
+    expect(hasActiveWork(table)).toBe(false);
   });
 
   it('applies a repeated session state without marking changed', () => {
@@ -173,6 +335,96 @@ describe('session routes', () => {
 });
 
 describe('resolveSessionEventRoute', () => {
+  it.each([
+    { kiloSessionId: 'kilo_2' },
+    { rootKiloSessionId: 'kilo_2' },
+    { kiloSessionId: 'kilo_2', rootKiloSessionId: 'kilo_2' },
+    { kiloSessionId: 'kilo_child', rootKiloSessionId: 'kilo_2' },
+  ])('selects the exact shared-directory route for identity %j', identity => {
+    const { table, second } = sharedDirectoryTable();
+    expect(
+      resolveSessionEventRoute(table, { directory: worktreeInput.directory, ...identity })
+    ).toBe(second);
+  });
+
+  it.each([
+    {},
+    { kiloSessionId: 'kilo_child' },
+    { rootKiloSessionId: 'kilo_unknown' },
+    { kiloSessionId: 'kilo_1', rootKiloSessionId: 'kilo_unknown' },
+    { kiloSessionId: 'kilo_1', rootKiloSessionId: 'kilo_2' },
+    { kiloSessionId: 'kilo_2', rootKiloSessionId: 'kilo_1' },
+  ])('rejects ambiguous or contradictory shared-directory identity %j', identity => {
+    const { table } = sharedDirectoryTable();
+    expect(
+      resolveSessionEventRoute(table, { directory: worktreeInput.directory, ...identity })
+    ).toBeNull();
+  });
+
+  it.each([
+    { kiloSessionId: 'kilo_1' },
+    { rootKiloSessionId: 'kilo_1' },
+    { kiloSessionId: 'kilo_child', rootKiloSessionId: 'kilo_1' },
+  ])('rejects late identity %j after its shared-worktree root detaches', identity => {
+    const { table, second } = sharedDirectoryTable();
+    detachRoute(table, 'ses_1');
+
+    expect(getRouteByDirectory(table, worktreeInput.directory)).toBe(second);
+    expect(
+      resolveSessionEventRoute(table, { directory: worktreeInput.directory, ...identity })
+    ).toBeNull();
+    expect(
+      resolveSessionEventRoute(table, {
+        directory: worktreeInput.directory,
+        kiloSessionId: 'kilo_child',
+        rootKiloSessionId: second.kiloSessionId,
+      })
+    ).toBe(second);
+  });
+
+  it.each([
+    { kiloSessionId: 'kilo_2' },
+    { rootKiloSessionId: 'kilo_2' },
+    { kiloSessionId: 'kilo_child', rootKiloSessionId: 'kilo_2' },
+  ])('prefers explicit identity %j over a different directory route', identity => {
+    const { table } = attachedTable();
+    const { route } = attachRoute(
+      table,
+      { ...attachInput, sessionId: 'ses_2', kiloSessionId: 'kilo_2', directory: '/workspace/b' },
+      OWNER
+    );
+    expect(resolveSessionEventRoute(table, { directory: attachInput.directory, ...identity })).toBe(
+      route
+    );
+  });
+
+  it('rejects conflicting explicit roots even when the directory has only one route', () => {
+    const { table } = attachedTable();
+    attachRoute(
+      table,
+      { ...attachInput, sessionId: 'ses_2', kiloSessionId: 'kilo_2', directory: '/workspace/b' },
+      OWNER
+    );
+    expect(
+      resolveSessionEventRoute(table, {
+        directory: attachInput.directory,
+        rootKiloSessionId: 'kilo_1',
+        kiloSessionId: 'kilo_2',
+      })
+    ).toBeNull();
+  });
+
+  it('does not fall back to a known session or directory when an explicit root is unknown', () => {
+    const { table } = attachedTable();
+    expect(
+      resolveSessionEventRoute(table, {
+        directory: attachInput.directory,
+        rootKiloSessionId: 'kilo_unknown',
+        kiloSessionId: 'kilo_1',
+      })
+    ).toBeNull();
+  });
+
   it('returns the route for a directory hit with no kilo ids', () => {
     const { table, route } = attachedTable();
     expect(resolveSessionEventRoute(table, { directory: '/workspace/a' })).toBe(route);
@@ -198,15 +450,18 @@ describe('resolveSessionEventRoute', () => {
     ).toBeNull();
   });
 
-  it('still routes when kiloSessionId is a child and rootKiloSessionId is absent', () => {
-    const { table, route } = attachedTable();
-    expect(
-      resolveSessionEventRoute(table, {
-        directory: '/workspace/a',
-        kiloSessionId: 'kilo_child',
-      })
-    ).toBe(route);
-  });
+  it.each(['kilo_child', 'kilo_unknown', ''])(
+    'rejects unknown explicit kiloSessionId %j without a known root even for a unique directory',
+    kiloSessionId => {
+      const { table } = attachedTable();
+      expect(
+        resolveSessionEventRoute(table, {
+          directory: '/workspace/a',
+          kiloSessionId,
+        })
+      ).toBeNull();
+    }
+  );
 
   it('routes a child kiloSessionId when rootKiloSessionId matches', () => {
     const { table, route } = attachedTable();

--- a/services/cloud-agent-next/src/sandbox-control/session-routes.ts
+++ b/services/cloud-agent-next/src/sandbox-control/session-routes.ts
@@ -4,6 +4,7 @@ export type SessionRoute = {
   sessionId: string;
   kiloSessionId: string;
   directory: string;
+  worktreeId?: string;
   ownerId: string;
   lastState: SessionActivityState | null;
   lastStateAt: number | null;
@@ -15,6 +16,7 @@ export type AttachRouteInput = {
   sessionId: string;
   kiloSessionId: string;
   directory: string;
+  worktreeId?: string;
   ownerId: string;
 };
 
@@ -45,15 +47,24 @@ export function attachRoute(
 
   const existing = table.get(input.sessionId);
   if (existing) {
-    if (existing.directory === input.directory && existing.kiloSessionId === input.kiloSessionId) {
+    if (
+      existing.directory === input.directory &&
+      existing.kiloSessionId === input.kiloSessionId &&
+      existing.worktreeId === input.worktreeId &&
+      existing.ownerId === input.ownerId
+    ) {
       return { table, route: existing, changed: false };
     }
     throw new Error('Session route conflict');
   }
 
   for (const route of table.values()) {
-    if (route.directory === input.directory) {
+    const sameWorktree = Boolean(input.worktreeId) && route.worktreeId === input.worktreeId;
+    if (route.directory === input.directory && (!sameWorktree || route.ownerId !== input.ownerId)) {
       throw new Error('Directory already attached');
+    }
+    if (sameWorktree && route.directory !== input.directory) {
+      throw new Error('Worktree already attached to another directory');
     }
     if (route.kiloSessionId === input.kiloSessionId) {
       throw new Error('Kilo session already attached');
@@ -64,6 +75,7 @@ export function attachRoute(
     sessionId: input.sessionId,
     kiloSessionId: input.kiloSessionId,
     directory: input.directory,
+    ...(input.worktreeId !== undefined ? { worktreeId: input.worktreeId } : {}),
     ownerId: input.ownerId,
     lastState: null,
     lastStateAt: null,
@@ -93,10 +105,13 @@ export function getRouteByDirectory(
   table: Map<string, SessionRoute>,
   directory: string
 ): SessionRoute | undefined {
+  let match: SessionRoute | undefined;
   for (const route of table.values()) {
-    if (route.directory === directory) return route;
+    if (route.directory !== directory) continue;
+    if (match) return undefined;
+    match = route;
   }
-  return undefined;
+  return match;
 }
 
 export function getRouteByKiloSessionId(
@@ -113,20 +128,16 @@ export function resolveSessionEventRoute(
   table: Map<string, SessionRoute>,
   identity: SessionEventIdentity
 ): SessionRoute | null {
-  const route =
-    getRouteByDirectory(table, identity.directory) ??
-    (identity.rootKiloSessionId
-      ? getRouteByKiloSessionId(table, identity.rootKiloSessionId)
-      : undefined) ??
-    (identity.kiloSessionId ? getRouteByKiloSessionId(table, identity.kiloSessionId) : undefined);
-  if (!route) return null;
-  if (
-    identity.rootKiloSessionId !== undefined &&
-    identity.rootKiloSessionId !== route.kiloSessionId
-  ) {
-    return null;
+  const sessionRoute = identity.kiloSessionId
+    ? getRouteByKiloSessionId(table, identity.kiloSessionId)
+    : undefined;
+  if (identity.rootKiloSessionId !== undefined) {
+    const rootRoute = getRouteByKiloSessionId(table, identity.rootKiloSessionId);
+    if (!rootRoute || (sessionRoute && sessionRoute !== rootRoute)) return null;
+    return rootRoute;
   }
-  return route;
+  if (identity.kiloSessionId !== undefined) return sessionRoute ?? null;
+  return getRouteByDirectory(table, identity.directory) ?? null;
 }
 
 export function applyReportedSessionState(

--- a/services/cloud-agent-next/src/sandbox-control/socket.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.test.ts
@@ -111,6 +111,107 @@ describe('sandbox control socket handler', () => {
     );
   });
 
+  it('rejects an invalid provisional handshake without replacing the current valid socket', async () => {
+    const current = createFakeWebSocket({
+      handshakeComplete: true,
+      acceptedAt: Date.now(),
+      protocolVersion: SANDBOX_CONTROL_PROTOCOL_VERSION,
+      providerInstanceId: 'inst_current',
+    });
+    const incoming = createFakeWebSocket({ handshakeComplete: false, acceptedAt: Date.now() });
+    const validateHandshake = vi.fn(async () => false);
+    const onHandshakeComplete = vi.fn();
+    const handler = createSandboxControlSocketHandler(
+      createFakeState([current, incoming]),
+      'sbx_test',
+      undefined,
+      { validateHandshake, onHandshakeComplete }
+    );
+    const pending = handler.sendRequest({ operation: 'sandbox.status', payload: {} });
+    const request = JSON.parse(current.send.mock.calls[0]?.[0] as string) as {
+      requestId: string;
+    };
+
+    await handler.handleMessage(
+      asWs(incoming),
+      JSON.stringify({
+        type: 'request',
+        requestId: 'req_rejected',
+        operation: 'sandbox.hello',
+        payload: { protocolVersion: 1, providerInstanceId: 'inst_stale' },
+      })
+    );
+
+    expect(validateHandshake).toHaveBeenCalledWith('inst_stale');
+    expect(incoming.serializeAttachment).not.toHaveBeenCalled();
+    expect(incoming.close).toHaveBeenCalledWith(1008, 'invalid_provider_instance');
+    expect(incoming.send).toHaveBeenCalledWith(
+      JSON.stringify({
+        type: 'response',
+        requestId: 'req_rejected',
+        ok: false,
+        error: {
+          code: 'unauthorized',
+          message: 'Invalid sandbox provider instance',
+          retryable: false,
+        },
+      })
+    );
+    expect(current.close).not.toHaveBeenCalled();
+    expect(onHandshakeComplete).not.toHaveBeenCalled();
+
+    await handler.handleMessage(
+      asWs(current),
+      JSON.stringify({ type: 'response', requestId: request.requestId, ok: true })
+    );
+    await expect(pending).resolves.toMatchObject({ ok: true, requestId: request.requestId });
+  });
+
+  it.each([true, false])(
+    'preserves the replacement connection when superseded provider validation resolves to %s',
+    async valid => {
+      const first = createFakeWebSocket();
+      const sockets = [first];
+      let finishValidation: ((valid: boolean) => void) | undefined;
+      const validation = new Promise<boolean>(resolve => {
+        finishValidation = resolve;
+      });
+      const onHandshakeComplete = vi.fn();
+      const handler = createSandboxControlSocketHandler(
+        createFakeState(sockets),
+        'sbx_test',
+        undefined,
+        {
+          validateHandshake: providerInstanceId =>
+            providerInstanceId === 'inst_pending' ? validation : true,
+          onHandshakeComplete,
+        }
+      );
+      const pending = handler.handleMessage(
+        asWs(first),
+        helloFrame('inst_pending', WRAPPER_INSTANCE_ID, 'req_first')
+      );
+      const second = createFakeWebSocket();
+      sockets.push(second);
+
+      await handler.handleMessage(
+        asWs(second),
+        helloFrame('inst_current', REPLACEMENT_WRAPPER_INSTANCE_ID, 'req_second')
+      );
+      first.readyState = 1;
+      finishValidation?.(valid);
+      await pending;
+
+      expect(first.send).not.toHaveBeenCalled();
+      expect(second.close).not.toHaveBeenCalled();
+      expect(handler.getConnectionIdentity()).toMatchObject({
+        providerInstanceId: 'inst_current',
+        wrapperInstanceId: REPLACEMENT_WRAPPER_INSTANCE_ID,
+      });
+      expect(onHandshakeComplete).toHaveBeenCalledTimes(1);
+    }
+  );
+
   it('replaces the previous handshaken socket after sandbox.hello and probes status', async () => {
     const current = createFakeWebSocket({
       handshakeComplete: true,

--- a/services/cloud-agent-next/src/sandbox-control/socket.ts
+++ b/services/cloud-agent-next/src/sandbox-control/socket.ts
@@ -50,6 +50,7 @@ export type SandboxControlConnectionIdentity = {
 };
 
 export type SandboxControlSocketHooks = {
+  validateHandshake?(providerInstanceId: string): boolean | Promise<boolean>;
   onHandshakeComplete?(identity: SandboxControlConnectionIdentity): void | Promise<void>;
   onReady?(identity: SandboxControlConnectionIdentity): void | Promise<void>;
   onHeartbeat?(
@@ -303,6 +304,25 @@ export function createSandboxControlSocketHandler(
             errorResponse(frame.requestId, 'protocol_error', 'Invalid sandbox.hello payload')
           );
           return;
+        }
+
+        if (hooks.validateHandshake) {
+          const valid = await hooks.validateHandshake(payload.providerInstanceId);
+          const currentAttachment = readAttachment(ws);
+          if (
+            !isProvisionalSocket(state, ws, currentAttachment) ||
+            currentAttachment.connectionId !== attachment.connectionId
+          ) {
+            return;
+          }
+          if (!valid) {
+            sendJson(
+              ws,
+              errorResponse(frame.requestId, 'unauthorized', 'Invalid sandbox provider instance')
+            );
+            closeSocket(ws, 1008, 'invalid_provider_instance');
+            return;
+          }
         }
 
         const identity: SandboxControlConnectionIdentity = {

--- a/services/cloud-agent-next/src/sandbox-control/terminal-billing.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/terminal-billing.test.ts
@@ -1,10 +1,13 @@
 import type { BillingContext } from '@kilocode/container-usage';
 import { describe, expect, it } from 'vitest';
 import { SANDBOX_USAGE_SKUS, type SandboxClassName } from '../container-usage-context.js';
+import { encodeCloudflareProviderRef } from './cloudflare-provider.js';
 import {
   validateTerminalBillingRuntime,
   type SandboxTerminalAccessInput,
 } from './terminal-billing.js';
+
+const PROVIDER_CREATION_ID = 'd1b3a0a8-a0a4-48a3-ab59-4be8bd63ba9a';
 
 const access: SandboxTerminalAccessInput = {
   sessionId: 'workspace_session',
@@ -14,14 +17,14 @@ const access: SandboxTerminalAccessInput = {
 
 function context(overrides: Partial<BillingContext> = {}): BillingContext {
   return {
-    service: 'cloud-agent-next-sandbox-small',
+    service: 'cloud-agent-next-sandbox-small-containment',
     instanceId: 'ses-abcdef',
-    sku: SANDBOX_USAGE_SKUS.SandboxSmall,
+    sku: SANDBOX_USAGE_SKUS.SandboxSmallContainment,
     subject: { type: 'user', id: access.ownerId },
     actor: { type: 'user', id: access.ownerId },
     sessionId: access.sessionId,
     metadata: {
-      container_class: 'SandboxSmall',
+      container_class: 'SandboxSmallContainment',
       durable_object_id: 'durable-object-small',
       origin: 'cloud-agent',
     },
@@ -50,10 +53,16 @@ function billingInput(
   return {
     access: options.access ?? access,
     sandboxId,
-    providerInstanceId: options.providerInstanceId ?? sandboxId,
+    providerInstanceId:
+      options.providerInstanceId ??
+      encodeCloudflareProviderRef({
+        sandboxId,
+        containment: true,
+        instanceId: PROVIDER_CREATION_ID,
+      }),
     sandboxDurableObjectId: options.sandboxDurableObjectId ?? 'durable-object-small',
     runtime: {
-      sandboxClassName: options.sandboxClassName ?? 'SandboxSmall',
+      sandboxClassName: options.sandboxClassName ?? 'SandboxSmallContainment',
       running: options.running ?? true,
       blocked: options.blocked ?? false,
       context: options.context ?? context(),
@@ -62,7 +71,7 @@ function billingInput(
 }
 
 describe('validateTerminalBillingRuntime', () => {
-  it('accepts a measured isolated runtime attributed to the session owner', () => {
+  it('accepts a measured contained runtime attributed to the session owner', () => {
     expect(validateTerminalBillingRuntime(billingInput())).toEqual({ allowed: true });
   });
 
@@ -71,37 +80,43 @@ describe('validateTerminalBillingRuntime', () => {
       sandboxId: 'istd-abcdef',
       sandboxClassName: 'Sandbox' as const,
       service: 'cloud-agent-next-sandbox',
+      expected: { allowed: false, reason: 'billing_runtime_mismatch' },
     },
     {
       sandboxId: 'crv-abcdef',
-      sandboxClassName: 'SandboxCodeReview' as const,
-      service: 'cloud-agent-next-sandbox-code-review',
+      sandboxClassName: 'SandboxCodeReviewContainment' as const,
+      service: 'cloud-agent-next-sandbox-code-review-containment',
+      expected: { allowed: true },
     },
     {
-      sandboxId: 'dind-abcdef',
-      sandboxClassName: 'SandboxDIND' as const,
-      service: 'cloud-agent-next-sandbox-dind',
+      sandboxId: 'istd-abcdef',
+      sandboxClassName: 'SandboxContainment' as const,
+      service: 'cloud-agent-next-sandbox-containment',
+      expected: { allowed: true },
     },
-  ])('accepts measured $sandboxClassName attribution in its actual namespace', input => {
-    expect(
-      validateTerminalBillingRuntime(
-        billingInput({
-          sandboxId: input.sandboxId,
-          sandboxClassName: input.sandboxClassName,
-          context: context({
-            service: input.service,
-            instanceId: input.sandboxId,
-            sku: SANDBOX_USAGE_SKUS[input.sandboxClassName],
-            metadata: {
-              container_class: input.sandboxClassName,
-              durable_object_id: 'durable-object-small',
-              origin: 'cloud-agent',
-            },
-          }),
-        })
-      )
-    ).toEqual({ allowed: true });
-  });
+  ])(
+    'validates measured $sandboxClassName attribution against the containment namespace',
+    input => {
+      expect(
+        validateTerminalBillingRuntime(
+          billingInput({
+            sandboxId: input.sandboxId,
+            sandboxClassName: input.sandboxClassName,
+            context: context({
+              service: input.service,
+              instanceId: input.sandboxId,
+              sku: SANDBOX_USAGE_SKUS[input.sandboxClassName],
+              metadata: {
+                container_class: input.sandboxClassName,
+                durable_object_id: 'durable-object-small',
+                origin: 'cloud-agent',
+              },
+            }),
+          })
+        )
+      ).toEqual(input.expected);
+    }
+  );
 
   it('accepts an organization bot acting for the matching payer', () => {
     const organizationAccess = { ...access, organizationId: 'org_team', botId: 'bot_worker' };
@@ -119,30 +134,36 @@ describe('validateTerminalBillingRuntime', () => {
     ).toEqual({ allowed: true });
   });
 
-  it('accepts a shared runtime only without session attribution', () => {
-    const shared = billingInput({
-      sandboxId: 'org-abcdef',
-      sandboxClassName: 'Sandbox',
-      context: context({
-        service: 'cloud-agent-next-sandbox',
-        instanceId: 'org-abcdef',
-        sku: SANDBOX_USAGE_SKUS.Sandbox,
-        sessionId: undefined,
-        metadata: { container_class: 'Sandbox', durable_object_id: 'durable-object-small' },
-      }),
-    });
+  it.each(['org-abcdef', 'usr-abcdef', 'bot-abcdef', 'ubt-abcdef'])(
+    'accepts shared containment runtime %s only without session attribution',
+    sandboxId => {
+      const shared = billingInput({
+        sandboxId,
+        sandboxClassName: 'SandboxContainment',
+        context: context({
+          service: 'cloud-agent-next-sandbox-containment',
+          instanceId: sandboxId,
+          sku: SANDBOX_USAGE_SKUS.SandboxContainment,
+          sessionId: undefined,
+          metadata: {
+            container_class: 'SandboxContainment',
+            durable_object_id: 'durable-object-small',
+          },
+        }),
+      });
 
-    expect(validateTerminalBillingRuntime(shared)).toEqual({ allowed: true });
-    expect(
-      validateTerminalBillingRuntime({
-        ...shared,
-        runtime: {
-          ...shared.runtime,
-          context: { ...shared.runtime.context, sessionId: access.sessionId },
-        },
-      })
-    ).toEqual({ allowed: false, reason: 'billing_session_mismatch' });
-  });
+      expect(validateTerminalBillingRuntime(shared)).toEqual({ allowed: true });
+      expect(
+        validateTerminalBillingRuntime({
+          ...shared,
+          runtime: {
+            ...shared.runtime,
+            context: { ...shared.runtime.context, sessionId: access.sessionId },
+          },
+        })
+      ).toEqual({ allowed: false, reason: 'billing_session_mismatch' });
+    }
+  );
 
   it.each([
     {
@@ -194,13 +215,94 @@ describe('validateTerminalBillingRuntime', () => {
   });
 
   it.each([
+    { name: 'raw sandbox ID', providerInstanceId: 'ses-abcdef' },
+    { name: 'empty reference', providerInstanceId: '' },
+    { name: 'invalid JSON', providerInstanceId: '{' },
+    { name: 'JSON sandbox ID string', providerInstanceId: JSON.stringify('ses-abcdef') },
     {
-      name: 'sandbox class',
-      input: billingInput({ sandboxClassName: 'SandboxCodeReview' }),
+      name: 'uncontained reference',
+      providerInstanceId: JSON.stringify({
+        sandboxId: 'ses-abcdef',
+        containment: false,
+        instanceId: PROVIDER_CREATION_ID,
+      }),
     },
     {
-      name: 'provider instance',
-      input: billingInput({ providerInstanceId: 'ses-other' }),
+      name: 'reference without a creation identity',
+      providerInstanceId: JSON.stringify({ sandboxId: 'ses-abcdef', containment: true }),
+    },
+  ])('rejects $name instead of falling back to an uncontained runtime', input => {
+    expect(validateTerminalBillingRuntime(billingInput(input))).toEqual({
+      allowed: false,
+      reason: 'billing_runtime_mismatch',
+    });
+  });
+
+  it.each([
+    {
+      sandboxId: 'ses-abcdef',
+      sandboxClassName: 'SandboxSmall' as const,
+      service: 'cloud-agent-next-sandbox-small',
+    },
+    {
+      sandboxId: 'crv-abcdef',
+      sandboxClassName: 'SandboxCodeReview' as const,
+      service: 'cloud-agent-next-sandbox-code-review',
+    },
+    {
+      sandboxId: 'org-abcdef',
+      sandboxClassName: 'Sandbox' as const,
+      service: 'cloud-agent-next-sandbox',
+    },
+    {
+      sandboxId: 'dind-abcdef',
+      sandboxClassName: 'SandboxDIND' as const,
+      service: 'cloud-agent-next-sandbox-dind',
+    },
+    {
+      sandboxId: 'invalid-id',
+      sandboxClassName: 'SandboxContainment' as const,
+      service: 'cloud-agent-next-sandbox-containment',
+    },
+  ])('rejects $sandboxId in $sandboxClassName despite otherwise matching billing', input => {
+    expect(
+      validateTerminalBillingRuntime(
+        billingInput({
+          sandboxId: input.sandboxId,
+          sandboxClassName: input.sandboxClassName,
+          context: context({
+            service: input.service,
+            instanceId: input.sandboxId,
+            sku: SANDBOX_USAGE_SKUS[input.sandboxClassName],
+            ...(input.sandboxId.startsWith('org-') ? { sessionId: undefined } : {}),
+            metadata: {
+              container_class: input.sandboxClassName,
+              durable_object_id: 'durable-object-small',
+            },
+          }),
+        })
+      )
+    ).toEqual({ allowed: false, reason: 'billing_runtime_mismatch' });
+  });
+
+  it.each([
+    {
+      name: 'sandbox class',
+      input: billingInput({ sandboxClassName: 'SandboxCodeReviewContainment' }),
+    },
+    {
+      name: 'provider sandbox',
+      input: billingInput({
+        providerInstanceId: encodeCloudflareProviderRef({
+          sandboxId: 'ses-fedcba',
+          containment: true,
+          instanceId: PROVIDER_CREATION_ID,
+        }),
+      }),
+    },
+    {
+      name: 'creation identity used as the billing instance',
+      input: billingInput({ context: context({ instanceId: PROVIDER_CREATION_ID }) }),
     },
     {
       name: 'billing instance',
@@ -258,11 +360,31 @@ describe('validateTerminalBillingRuntime', () => {
     ).toEqual({ allowed: false, reason: 'billing_actor_mismatch' });
   });
 
-  it('rejects isolated attribution for a different session', () => {
+  it.each([
+    undefined,
+    { type: 'org' as const, id: 'org_other' },
+    { type: 'user' as const, id: access.ownerId },
+  ])('rejects a bot whose on-behalf-of attribution does not match the payer: %s', onBehalfOf => {
     expect(
       validateTerminalBillingRuntime(
-        billingInput({ context: context({ sessionId: 'workspace_other' }) })
+        billingInput({
+          access: { ...access, organizationId: 'org_team', botId: 'bot_worker' },
+          context: context({
+            subject: { type: 'org', id: 'org_team' },
+            actor: { type: 'bot', id: 'bot_worker' },
+            onBehalfOf,
+          }),
+        })
       )
-    ).toEqual({ allowed: false, reason: 'billing_session_mismatch' });
+    ).toEqual({ allowed: false, reason: 'billing_context_unavailable' });
   });
+
+  it.each([undefined, 'workspace_other'])(
+    'rejects isolated attribution without the requested session: %s',
+    sessionId => {
+      expect(
+        validateTerminalBillingRuntime(billingInput({ context: context({ sessionId }) }))
+      ).toEqual({ allowed: false, reason: 'billing_session_mismatch' });
+    }
+  );
 });

--- a/services/cloud-agent-next/src/sandbox-control/terminal-billing.ts
+++ b/services/cloud-agent-next/src/sandbox-control/terminal-billing.ts
@@ -1,10 +1,11 @@
 import { billingContextSchema } from '@kilocode/container-usage';
-import { isIsolatedSandboxId } from '../sandbox-id.js';
 import {
   SANDBOX_USAGE_SKUS,
   type SandboxClassName,
   type getSandboxBillingRuntimeStatus,
 } from '../container-usage-context.js';
+import { classifySandboxId, isIsolatedSandboxId } from '../sandbox-id.js';
+import { decodeCloudflareProviderRef } from './cloudflare-provider.js';
 
 export type SandboxTerminalAccessInput = {
   sessionId: string;
@@ -31,11 +32,19 @@ type TerminalBillingRuntimeInput = {
   runtime: SandboxBillingRuntimeStatus | undefined;
 };
 
-function expectedSandboxClassName(sandboxId: string): SandboxClassName {
-  if (sandboxId.startsWith('dind-')) return 'SandboxDIND';
-  if (sandboxId.startsWith('crv-')) return 'SandboxCodeReview';
-  if (sandboxId.startsWith('ses-')) return 'SandboxSmall';
-  return 'Sandbox';
+function expectedSandboxClassName(sandboxId: string): SandboxClassName | undefined {
+  switch (classifySandboxId(sandboxId)) {
+    case 'isolated-small':
+      return 'SandboxSmallContainment';
+    case 'code-review':
+      return 'SandboxCodeReviewContainment';
+    case 'isolated-standard':
+    case 'shared':
+    case 'legacy-shared':
+      return 'SandboxContainment';
+    default:
+      return undefined;
+  }
 }
 
 function expectedUsageService(sandboxClassName: SandboxClassName): string {
@@ -64,9 +73,11 @@ export function validateTerminalBillingRuntime(
   }
 
   const sandboxClassName = expectedSandboxClassName(input.sandboxId);
+  const providerRef = decodeCloudflareProviderRef(input.providerInstanceId);
   if (
+    sandboxClassName === undefined ||
+    providerRef?.sandboxId !== input.sandboxId ||
     runtime.sandboxClassName !== sandboxClassName ||
-    input.providerInstanceId !== input.sandboxId ||
     context.instanceId !== input.sandboxId ||
     context.service !== expectedUsageService(sandboxClassName) ||
     context.sku !== SANDBOX_USAGE_SKUS[sandboxClassName] ||

--- a/services/cloud-agent-next/src/sandbox-control/vercel-network-policy.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/vercel-network-policy.test.ts
@@ -1,0 +1,1107 @@
+import { describe, expect, it } from 'vitest';
+import type {
+  VercelSandboxInjectionRule,
+  VercelSandboxNetworkPolicy,
+} from '../agent-sandbox/vercel/vercel-sandbox-rest-client.js';
+import {
+  buildKiloCredentialInjectionRules,
+  buildVercelCredentialNetworkPolicy,
+  findMatchingCredentialInjectionRule,
+  type VercelCredentialPolicyInput,
+} from './vercel-network-policy.js';
+
+const ROOT_SESSION_ID = 'ses_abcdefghijklmnopqrstuvwxyz';
+const OTHER_SESSION_ID = 'ses_zyxwvutsrqponmlkjihgfedcba';
+
+type PolicyRequestInput = {
+  url: string;
+  authorization?: string;
+  method?: string;
+  headers?: Record<string, string>;
+};
+
+function kiloInput(
+  overrides: Partial<NonNullable<VercelCredentialPolicyInput['kilo']>> = {}
+): NonNullable<VercelCredentialPolicyInput['kilo']> {
+  return {
+    token: 'actual-kilo-token',
+    placeholder: 'placeholder-kilo-token',
+    targets: {
+      backendBaseUrl: 'https://backend.example.com/tenant',
+      providerBaseUrl: 'https://provider.example.com/platform',
+      sessionIngestBaseUrl: 'https://ingest.example.com/history',
+    },
+    rootSessionIds: [ROOT_SESSION_ID],
+    ...overrides,
+  };
+}
+
+function githubInput(
+  overrides: Partial<NonNullable<VercelCredentialPolicyInput['github']>> = {}
+): NonNullable<VercelCredentialPolicyInput['github']> {
+  return {
+    token: 'actual-github-token',
+    placeholder: 'placeholder-github-token',
+    repository: 'Kilo-Org/Cloud.Repo',
+    ...overrides,
+  };
+}
+
+function firstMatchingRule(
+  policy: VercelSandboxNetworkPolicy,
+  input: PolicyRequestInput
+): VercelSandboxInjectionRule | undefined {
+  const url = new URL(input.url);
+  const headers = new Headers({ host: url.host, ...input.headers });
+  if (input.authorization !== undefined) headers.set('authorization', input.authorization);
+  const method = input.method ?? 'GET';
+
+  return findMatchingCredentialInjectionRule(policy.injectionRules, { url, method, headers });
+}
+
+function effectiveAuthorization(
+  policy: VercelSandboxNetworkPolicy,
+  input: PolicyRequestInput
+): string | undefined {
+  return firstMatchingRule(policy, input)?.headers.authorization;
+}
+
+describe('buildVercelCredentialNetworkPolicy', () => {
+  it('builds REST-native credential policies with deduplicated domains and unrestricted egress', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        targets: {
+          backendBaseUrl: 'https://shared.example.com/base',
+          providerBaseUrl: 'https://shared.example.com/provider',
+          sessionIngestBaseUrl: 'https://shared.example.com/ingest',
+        },
+      }),
+      github: githubInput(),
+    });
+
+    expect(policy.mode).toBe('custom');
+    expect(policy.allowedDomains).toEqual([
+      'shared.example.com',
+      'github.com',
+      'api.github.com',
+      '*',
+    ]);
+    expect(new Set(policy.allowedDomains).size).toBe(policy.allowedDomains.length);
+    expect(policy.allowedDomains.every(domain => domain === '*' || !domain.includes('/'))).toBe(
+      true
+    );
+    expect(policy.injectionRules.every(rule => rule.match.path !== undefined)).toBe(true);
+  });
+
+  it('retains wildcard egress without adding credential rules for empty input', () => {
+    expect(buildVercelCredentialNetworkPolicy({})).toEqual({
+      mode: 'custom',
+      allowedDomains: ['*'],
+      injectionRules: [],
+    });
+  });
+
+  it.each([
+    ['trusted organization', 'trusted-org', 'trusted-org'],
+    ['personal account', undefined, ''],
+  ] as const)(
+    'overrides a guest-supplied organization context for a %s',
+    (_description, organizationId, expectedOrganizationId) => {
+      const policy = buildVercelCredentialNetworkPolicy({
+        kilo: kiloInput(organizationId === undefined ? {} : { organizationId }),
+        github: githubInput(),
+      });
+      const guestOrganization = 'guest-selected-organization';
+      const incoming = { 'x-kilocode-organizationid': guestOrganization };
+
+      for (const url of [
+        'https://backend.example.com/tenant/api/user',
+        'https://provider.example.com/platform/api/openrouter/models',
+        `https://ingest.example.com/history/api/session/${ROOT_SESSION_ID}/export`,
+      ]) {
+        const rule = firstMatchingRule(policy, {
+          url,
+          authorization: 'Bearer placeholder-kilo-token',
+          headers: incoming,
+        });
+        expect(rule?.headers['x-kilocode-organizationid']).toBe(expectedOrganizationId);
+        const forwarded = new Headers({ ...incoming, ...rule?.headers });
+        expect(forwarded.get('x-kilocode-organizationid') || undefined).toBe(
+          expectedOrganizationId || undefined
+        );
+      }
+
+      const githubRule = firstMatchingRule(policy, {
+        url: 'https://api.github.com/repos/Kilo-Org/Cloud.Repo',
+        authorization: 'Bearer placeholder-github-token',
+        headers: incoming,
+      });
+      expect(githubRule?.headers).not.toHaveProperty('x-kilocode-organizationid');
+    }
+  );
+
+  it('authenticates only exact root-session snapshot export and ingest routes', () => {
+    const policy = buildVercelCredentialNetworkPolicy({ kilo: kiloInput() });
+    const authorization = 'Bearer placeholder-kilo-token';
+    const root = `https://ingest.example.com/history/api/session/${ROOT_SESSION_ID}`;
+
+    expect(effectiveAuthorization(policy, { url: `${root}/export?version=2`, authorization })).toBe(
+      'Bearer actual-kilo-token'
+    );
+    expect(
+      effectiveAuthorization(policy, { url: `${root}/ingest?v=2`, method: 'POST', authorization })
+    ).toBe('Bearer actual-kilo-token');
+
+    for (const rejected of [
+      { url: `${root}/export`, method: 'POST' },
+      { url: `${root}/ingest`, method: 'GET' },
+      { url: `${root}/import`, method: 'POST' },
+      { url: `${root}/export/additional` },
+      { url: 'https://ingest.example.com/history/api/session', method: 'POST' },
+      { url: `https://ingest.example.com/history/api/session/${OTHER_SESSION_ID}/export` },
+      {
+        url: `https://ingest.example.com/history/api/session/${OTHER_SESSION_ID}/ingest`,
+        method: 'POST',
+      },
+      { url: 'https://ingest.example.com/history/api/session/manage' },
+    ]) {
+      expect(effectiveAuthorization(policy, { ...rejected, authorization })).toBeUndefined();
+    }
+
+    expect(
+      effectiveAuthorization(policy, {
+        url: `${root}/export`,
+        authorization: 'Bearer wrong-placeholder',
+      })
+    ).toBeUndefined();
+    expect(effectiveAuthorization(policy, { url: `${root}/export` })).toBeUndefined();
+  });
+
+  it('authorizes every explicit root once while preserving overlapping session shadows', () => {
+    const targets = {
+      backendBaseUrl: 'https://shared.example.com',
+      providerBaseUrl: 'https://shared.example.com/api/openrouter',
+      sessionIngestBaseUrl: 'https://shared.example.com/api/openrouter',
+    };
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        rootSessionIds: [ROOT_SESSION_ID, OTHER_SESSION_ID, ROOT_SESSION_ID],
+        targets,
+      }),
+    });
+    const authorization = 'Bearer placeholder-kilo-token';
+    const collection = 'https://shared.example.com/api/openrouter/api/session';
+
+    for (const id of [ROOT_SESSION_ID, OTHER_SESSION_ID]) {
+      for (const [operation, method] of [
+        ['export', 'GET'],
+        ['ingest', 'POST'],
+      ]) {
+        const url = `${collection}/${id}/${operation}`;
+        expect(effectiveAuthorization(policy, { url, method, authorization })).toBe(
+          'Bearer actual-kilo-token'
+        );
+        expect(
+          policy.injectionRules.filter(
+            rule =>
+              rule.match.path &&
+              'exact' in rule.match.path &&
+              rule.match.path.exact === new URL(url).pathname
+          )
+        ).toHaveLength(1);
+        for (const rejected of [
+          { url, method: method === 'GET' ? 'POST' : 'GET' },
+          { url: `${url}/extra`, method },
+          { url: `${url}-extra`, method },
+          { url: `${collection}/${id}-other/${operation}`, method },
+        ]) {
+          expect(effectiveAuthorization(policy, { ...rejected, authorization })).toBe(
+            authorization
+          );
+        }
+      }
+    }
+    expect(
+      effectiveAuthorization(policy, {
+        url: `${collection}/ses_01234567890123456789012345/export`,
+        authorization,
+      })
+    ).toBe(authorization);
+    expect(
+      effectiveAuthorization(policy, {
+        url: collection,
+        method: 'POST',
+        authorization,
+      })
+    ).toBe(authorization);
+  });
+
+  it('requires a nonempty root membership list', () => {
+    expect(() =>
+      buildVercelCredentialNetworkPolicy({ kilo: kiloInput({ rootSessionIds: [] }) })
+    ).toThrow('Invalid Vercel credential network policy');
+  });
+
+  it('reuses identical route and authorization matching for local Cloudflare Kilo targets', () => {
+    const input = kiloInput({
+      targets: {
+        backendBaseUrl: 'http://host.docker.internal:3000',
+        providerBaseUrl: 'http://host.docker.internal:3000',
+        sessionIngestBaseUrl: 'http://host.docker.internal:8787',
+      },
+    });
+    const rules = buildKiloCredentialInjectionRules(input, { requireHttps: false });
+    const headers = new Headers({ Authorization: 'Bearer placeholder-kilo-token' });
+    expect(
+      findMatchingCredentialInjectionRule(rules, {
+        url: new URL('http://host.docker.internal:3000/api/user'),
+        method: 'GET',
+        headers,
+      })?.headers
+    ).toMatchObject({
+      authorization: 'Bearer actual-kilo-token',
+      host: 'host.docker.internal:3000',
+    });
+    expect(
+      findMatchingCredentialInjectionRule(rules, {
+        url: new URL('http://host.docker.internal:3000/api/user/token'),
+        method: 'GET',
+        headers,
+      })
+    ).toBeUndefined();
+    expect(
+      findMatchingCredentialInjectionRule(rules, {
+        url: new URL('http://host.docker.internal:3000/api/user'),
+        method: 'get',
+        headers,
+      })
+    ).toBeUndefined();
+    expect(
+      findMatchingCredentialInjectionRule(rules, {
+        url: new URL('http://host.docker.internal:3000/api/user'),
+        method: 'GET',
+        headers: new Headers({ authorization: 'bearer placeholder-kilo-token' }),
+      })
+    ).toBeUndefined();
+    expect(() => buildVercelCredentialNetworkPolicy({ kilo: input })).toThrow(
+      'Invalid Vercel credential network policy'
+    );
+  });
+
+  it('authenticates only explicit safe backend GET endpoints', () => {
+    const policy = buildVercelCredentialNetworkPolicy({ kilo: kiloInput() });
+    const authorization = 'Bearer placeholder-kilo-token';
+    const base = 'https://backend.example.com/tenant/api';
+
+    for (const route of [
+      '/user',
+      '/profile',
+      '/profile/balance',
+      '/defaults',
+      '/users/notifications',
+    ]) {
+      expect(effectiveAuthorization(policy, { url: `${base}${route}`, authorization })).toBe(
+        'Bearer actual-kilo-token'
+      );
+      expect(
+        effectiveAuthorization(policy, { url: `${base}${route}`, authorization, method: 'POST' })
+      ).toBeUndefined();
+      expect(
+        effectiveAuthorization(policy, { url: `${base}${route}/extra`, authorization })
+      ).toBeUndefined();
+    }
+  });
+
+  it('allows only the exact personal backend model-validation POST route', () => {
+    const policy = buildVercelCredentialNetworkPolicy({ kilo: kiloInput() });
+    const authorization = 'Bearer placeholder-kilo-token';
+    const url = 'https://backend.example.com/tenant/api/openrouter/models/validate';
+
+    expect(effectiveAuthorization(policy, { url, authorization, method: 'POST' })).toBe(
+      'Bearer actual-kilo-token'
+    );
+    expect(effectiveAuthorization(policy, { url, authorization })).toBeUndefined();
+    expect(
+      effectiveAuthorization(policy, { url: `${url}/other`, authorization, method: 'POST' })
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['/auth/native/exchange', 'POST'],
+    ['/organizations/acme/user-tokens', 'GET'],
+    ['/organizations/acme/user-tokens', 'POST'],
+    ['/gastown/git-credentials', 'POST'],
+    ['/wasteland/token', 'POST'],
+    ['/mcp/connect-token', 'GET'],
+    ['/mcp/connect-token', 'POST'],
+    ['/users/me', 'GET'],
+    ['/profile/tokens', 'GET'],
+    ['/user/token', 'GET'],
+    ['/defaults/token', 'GET'],
+  ])('never authenticates the credential-escalation route %s %s', (route, method) => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        organizationId: 'acme',
+        targets: {
+          backendBaseUrl: 'https://shared.example.com',
+          providerBaseUrl: 'https://shared.example.com',
+          sessionIngestBaseUrl: 'https://shared.example.com',
+        },
+      }),
+    });
+
+    expect(
+      effectiveAuthorization(policy, {
+        url: `https://shared.example.com/api${route}`,
+        authorization: 'Bearer placeholder-kilo-token',
+        method,
+      })
+    ).toBeUndefined();
+  });
+
+  it('scopes exact organization model, defaults, and mode access to the selected organization', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        organizationId: 'Acme-Org_1',
+        targets: {
+          backendBaseUrl: 'https://backend.example.com/tenant/api/',
+          providerBaseUrl: 'https://provider.example.com/api',
+          sessionIngestBaseUrl: 'https://ingest.example.com',
+        },
+      }),
+    });
+    const authorization = 'Bearer placeholder-kilo-token';
+    const base = 'https://backend.example.com/tenant/api/api/organizations/Acme-Org_1';
+
+    for (const suffix of ['models', 'defaults', 'modes']) {
+      expect(effectiveAuthorization(policy, { url: `${base}/${suffix}`, authorization })).toBe(
+        'Bearer actual-kilo-token'
+      );
+      expect(
+        effectiveAuthorization(policy, {
+          url: `${base}/${suffix}`,
+          authorization,
+          method: 'POST',
+        })
+      ).toBeUndefined();
+      expect(
+        effectiveAuthorization(policy, { url: `${base}/${suffix}/validate`, authorization })
+      ).toBeUndefined();
+    }
+
+    expect(
+      effectiveAuthorization(policy, {
+        url: `${base}/models/validate`,
+        authorization,
+        method: 'POST',
+      })
+    ).toBe('Bearer actual-kilo-token');
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://backend.example.com/tenant/api/api/organizations/other/models',
+        authorization,
+      })
+    ).toBeUndefined();
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://backend.example.com/tenant/api/api/user',
+        authorization,
+      })
+    ).toBe('Bearer actual-kilo-token');
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://backend.example.com/tenant/api/user',
+        authorization,
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not authorize any organization routes without an organization identity', () => {
+    const policy = buildVercelCredentialNetworkPolicy({ kilo: kiloInput() });
+
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://backend.example.com/tenant/api/organizations/acme/models',
+        authorization: 'Bearer placeholder-kilo-token',
+      })
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['https://provider.example.com/api/organizations/Acme-Org_1', '/api/organizations/Acme-Org_1'],
+    [
+      'https://provider.example.com/tenant/api/organizations/Acme-Org_1/custom',
+      '/tenant/api/organizations/Acme-Org_1/custom',
+    ],
+    ['https://provider.example.com/api', '/api/organizations/Acme-Org_1'],
+    ['https://provider.example.com/tenant', '/tenant/api/organizations/Acme-Org_1'],
+    [
+      'https://provider.example.com/tenant/api/custom',
+      '/tenant/api/custom/api/organizations/Acme-Org_1',
+    ],
+  ] as const)(
+    'authenticates exact trusted-organization provider catalog and validation paths for %s',
+    (providerBaseUrl, catalogBasePath) => {
+      const policy = buildVercelCredentialNetworkPolicy({
+        kilo: kiloInput({
+          organizationId: 'Acme-Org_1',
+          targets: { ...kiloInput().targets, providerBaseUrl },
+        }),
+      });
+      const authorization = 'Bearer placeholder-kilo-token';
+
+      expect(
+        firstMatchingRule(policy, {
+          url: `https://provider.example.com${catalogBasePath}/models`,
+          authorization,
+        })?.headers
+      ).toEqual({
+        authorization: 'Bearer actual-kilo-token',
+        host: 'provider.example.com',
+        'x-kilocode-organizationid': 'Acme-Org_1',
+      });
+      expect(
+        effectiveAuthorization(policy, {
+          url: `https://provider.example.com${catalogBasePath}/models/validate`,
+          authorization,
+          method: 'POST',
+        })
+      ).toBe('Bearer actual-kilo-token');
+      expect(
+        effectiveAuthorization(policy, {
+          url: `https://provider.example.com${catalogBasePath.replace('Acme-Org_1', 'other')}/models`,
+          authorization,
+        })
+      ).toBeUndefined();
+    }
+  );
+
+  it.each([
+    ['https://openrouter.example.com', '/models', '/api'],
+    ['https://openrouter.example.com/tenant', '/tenant/models', '/tenant/api'],
+    ['https://openrouter.example.com/tenant/nested', '/tenant/nested/models', '/tenant/nested/api'],
+  ] as const)(
+    'matches personal catalog paths when the provider hostname contains openrouter: %s',
+    (providerBaseUrl, catalogPath, inferencePrefix) => {
+      const policy = buildVercelCredentialNetworkPolicy({
+        kilo: kiloInput({ targets: { ...kiloInput().targets, providerBaseUrl } }),
+      });
+      const authorization = 'Bearer placeholder-kilo-token';
+      const catalog = `https://openrouter.example.com${catalogPath}`;
+
+      expect(firstMatchingRule(policy, { url: catalog, authorization })?.match.path).toEqual({
+        exact: catalogPath,
+      });
+      expect(
+        effectiveAuthorization(policy, {
+          url: `${catalog}/validate`,
+          authorization,
+          method: 'POST',
+        })
+      ).toBe('Bearer actual-kilo-token');
+      expect(
+        effectiveAuthorization(policy, {
+          url: `${catalog}/unapproved`,
+          authorization,
+        })
+      ).toBeUndefined();
+
+      for (const route of ['openrouter', 'gateway']) {
+        expect(
+          effectiveAuthorization(policy, {
+            url: `https://openrouter.example.com${inferencePrefix}/${route}/models`,
+            authorization,
+          })
+        ).toBe('Bearer actual-kilo-token');
+      }
+    }
+  );
+
+  it('preserves trusted-organization catalog scope on openrouter-named provider hosts', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        organizationId: 'Acme-Org_1',
+        targets: {
+          ...kiloInput().targets,
+          providerBaseUrl: 'https://openrouter.example.com/tenant',
+        },
+      }),
+    });
+    const authorization = 'Bearer placeholder-kilo-token';
+
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://openrouter.example.com/tenant/api/organizations/Acme-Org_1/models',
+        authorization,
+      })
+    ).toBe('Bearer actual-kilo-token');
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://openrouter.example.com/tenant/models',
+        authorization,
+      })
+    ).toBeUndefined();
+  });
+
+  it('authenticates personal catalog paths outside normalized provider prefixes exactly', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        targets: {
+          ...kiloInput().targets,
+          providerBaseUrl: 'https://provider.example.com/tenant/api/custom',
+        },
+      }),
+    });
+    const authorization = 'Bearer placeholder-kilo-token';
+    const catalog = 'https://provider.example.com/tenant/api/custom/api/openrouter/models';
+
+    expect(effectiveAuthorization(policy, { url: catalog, authorization })).toBe(
+      'Bearer actual-kilo-token'
+    );
+    expect(
+      effectiveAuthorization(policy, {
+        url: `${catalog}/validate`,
+        authorization,
+        method: 'POST',
+      })
+    ).toBe('Bearer actual-kilo-token');
+    expect(
+      effectiveAuthorization(policy, { url: `${catalog}/validate`, authorization })
+    ).toBeUndefined();
+    expect(
+      effectiveAuthorization(policy, { url: catalog, authorization, method: 'POST' })
+    ).toBeUndefined();
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://provider.example.com/tenant/api/custom/api/openrouter/completions',
+        authorization,
+        method: 'POST',
+      })
+    ).toBeUndefined();
+  });
+
+  it.each([
+    ['https://provider.example.com/api/organizations/other', 'Acme-Org_1'],
+    ['https://provider.example.com/api/organizations/Acme-Org_1', undefined],
+    ['https://provider.example.com/tenant/api/organizations/other/models', 'Acme-Org_1'],
+    [
+      'https://provider.example.com/api/organizations/Acme-Org_1/api/organizations/other',
+      'Acme-Org_1',
+    ],
+    ['https://provider.example.com/api/organizations', 'Acme-Org_1'],
+  ] as const)(
+    'rejects mismatched embedded provider organization paths: %s',
+    (providerBaseUrl, organizationId) => {
+      expect(() =>
+        buildVercelCredentialNetworkPolicy({
+          kilo: kiloInput({
+            ...(organizationId === undefined ? {} : { organizationId }),
+            targets: { ...kiloInput().targets, providerBaseUrl },
+          }),
+        })
+      ).toThrow('Invalid Vercel credential network policy');
+    }
+  );
+
+  it.each([
+    [
+      'https://provider.example.com/api/openrouter',
+      ['/api/openrouter/', '/api/gateway/'],
+      ['/api/openrouter-custom/models'],
+    ],
+    [
+      'https://provider.example.com/api/gateway',
+      ['/api/openrouter/', '/api/gateway/'],
+      ['/api/gateway-custom/models'],
+    ],
+    ['https://provider.example.com/api', ['/api/openrouter/', '/api/gateway/'], []],
+    [
+      'https://provider.example.com/tenant',
+      ['/tenant/api/openrouter/', '/tenant/api/gateway/'],
+      ['/api/openrouter/models'],
+    ],
+    [
+      'https://provider.example.com/tenant/api/custom',
+      ['/tenant/api/openrouter/', '/tenant/api/gateway/'],
+      ['/tenant/api/custom/api/gateway/models', '/tenant/api/custom/api/openrouter/completions'],
+    ],
+    [
+      'https://provider.example.com/tenant/api/custom/api/gateway',
+      ['/tenant/api/custom/api/openrouter/', '/tenant/api/custom/api/gateway/'],
+      ['/tenant/api/openrouter/models'],
+    ],
+  ] as const)(
+    'scopes model-provider prefixes for %s',
+    (providerBaseUrl, prefixes, rejectedPaths) => {
+      const policy = buildVercelCredentialNetworkPolicy({
+        kilo: kiloInput({ targets: { ...kiloInput().targets, providerBaseUrl } }),
+      });
+      const authorization = 'Bearer placeholder-kilo-token';
+
+      for (const prefix of prefixes) {
+        for (const method of ['GET', 'POST']) {
+          expect(
+            effectiveAuthorization(policy, {
+              url: `https://provider.example.com${prefix}models`,
+              authorization,
+              method,
+            })
+          ).toBe('Bearer actual-kilo-token');
+        }
+        expect(
+          effectiveAuthorization(policy, {
+            url: `https://provider.example.com${prefix}models`,
+            authorization,
+            method: 'DELETE',
+          })
+        ).toBeUndefined();
+        expect(
+          effectiveAuthorization(policy, {
+            url: `https://provider.example.com${prefix.slice(0, -1)}`,
+            authorization,
+          })
+        ).toBeUndefined();
+        expect(
+          effectiveAuthorization(policy, {
+            url: `https://provider.example.com${prefix.slice(0, -1)}-other/models`,
+            authorization,
+          })
+        ).toBeUndefined();
+      }
+
+      for (const pathname of rejectedPaths) {
+        expect(
+          effectiveAuthorization(policy, {
+            url: `https://provider.example.com${pathname}`,
+            authorization,
+          })
+        ).toBeUndefined();
+      }
+    }
+  );
+
+  it('rewrites each trusted host while preserving its explicit non-default port', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        targets: {
+          backendBaseUrl: 'https://shared.example.com:8443/backend',
+          providerBaseUrl: 'https://shared.example.com:9443/provider',
+          sessionIngestBaseUrl: 'https://shared.example.com:7443/ingest',
+        },
+      }),
+    });
+    const authorization = 'Bearer placeholder-kilo-token';
+
+    expect(
+      firstMatchingRule(policy, {
+        url: 'https://shared.example.com:8443/backend/api/user',
+        authorization,
+      })?.headers
+    ).toEqual({
+      authorization: 'Bearer actual-kilo-token',
+      host: 'shared.example.com:8443',
+      'x-kilocode-organizationid': '',
+    });
+    expect(
+      firstMatchingRule(policy, {
+        url: 'https://shared.example.com:9443/provider/api/openrouter/models',
+        authorization,
+      })?.headers
+    ).toEqual({
+      authorization: 'Bearer actual-kilo-token',
+      host: 'shared.example.com:9443',
+      'x-kilocode-organizationid': '',
+    });
+    expect(
+      firstMatchingRule(policy, {
+        url: `https://shared.example.com:7443/ingest/api/session/${ROOT_SESSION_ID}/export`,
+        authorization,
+      })?.headers
+    ).toEqual({
+      authorization: 'Bearer actual-kilo-token',
+      host: 'shared.example.com:7443',
+      'x-kilocode-organizationid': '',
+    });
+    expect(policy.allowedDomains).toEqual(['shared.example.com', '*']);
+  });
+
+  it('overwrites guest-supplied hosts without requiring unsupported Host matchers', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        targets: {
+          backendBaseUrl: 'https://shared.example.com:8443/backend',
+          providerBaseUrl: 'https://shared.example.com:9443/provider',
+          sessionIngestBaseUrl: 'https://shared.example.com:7443/ingest',
+        },
+      }),
+      github: githubInput(),
+    });
+
+    const backendRule = firstMatchingRule(policy, {
+      url: 'https://shared.example.com:8443/backend/api/user',
+      authorization: 'Bearer placeholder-kilo-token',
+      headers: { host: 'guest-selected.example.com' },
+    });
+    expect(backendRule?.headers.host).toBe('shared.example.com:8443');
+
+    const githubRule = firstMatchingRule(policy, {
+      url: 'https://api.github.com/repos/Kilo-Org/Cloud.Repo',
+      authorization: 'Bearer placeholder-github-token',
+      headers: { host: 'guest-selected.example.com' },
+    });
+    expect(githubRule?.headers.host).toBe('api.github.com');
+
+    expect(
+      policy.injectionRules.every(
+        rule =>
+          rule.match.headers.length === 1 && rule.match.headers[0]?.key.exact === 'authorization'
+      )
+    ).toBe(true);
+  });
+
+  it('shadows same-host session routes before an overlapping broad provider prefix', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        organizationId: 'trusted-org',
+        targets: {
+          backendBaseUrl: 'https://shared.example.com',
+          providerBaseUrl: 'https://shared.example.com:9443/api/openrouter',
+          sessionIngestBaseUrl: 'https://shared.example.com:9443/api/openrouter',
+        },
+      }),
+    });
+    const authorization = 'Bearer placeholder-kilo-token';
+    const collection = 'https://shared.example.com:9443/api/openrouter/api/session';
+    const root = `${collection}/${ROOT_SESSION_ID}`;
+
+    expect(effectiveAuthorization(policy, { url: `${root}/export`, authorization })).toBe(
+      'Bearer actual-kilo-token'
+    );
+    expect(
+      effectiveAuthorization(policy, { url: `${root}/ingest`, authorization, method: 'POST' })
+    ).toBe('Bearer actual-kilo-token');
+
+    for (const shadowed of [
+      { url: collection, method: 'POST' },
+      { url: `${collection}/${OTHER_SESSION_ID}/export` },
+      { url: `${collection}/${OTHER_SESSION_ID}/ingest`, method: 'POST' },
+      { url: `${collection}/${OTHER_SESSION_ID}/management`, method: 'POST' },
+      { url: `${root}/import`, method: 'POST' },
+      { url: `${root}/export`, method: 'POST' },
+      { url: `${root}/ingest`, method: 'GET' },
+    ]) {
+      const rule = firstMatchingRule(policy, { ...shadowed, authorization });
+      expect(rule?.headers).toEqual({
+        authorization: 'Bearer placeholder-kilo-token',
+        host: 'shared.example.com:9443',
+        'x-kilocode-organizationid': 'trusted-org',
+      });
+    }
+
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://shared.example.com:9443/api/openrouter/models',
+        authorization,
+      })
+    ).toBe('Bearer actual-kilo-token');
+
+    const rootIndex = policy.injectionRules.findIndex(
+      rule =>
+        rule.match.path && 'exact' in rule.match.path && rule.match.path.exact.endsWith('/export')
+    );
+    const shadowIndex = policy.injectionRules.findIndex(
+      rule => rule.headers.authorization === authorization
+    );
+    const backendIndex = policy.injectionRules.findIndex(
+      rule => rule.match.path && 'exact' in rule.match.path && rule.match.path.exact === '/api/user'
+    );
+    const providerIndex = policy.injectionRules.findIndex(
+      rule =>
+        rule.match.path &&
+        'startsWith' in rule.match.path &&
+        rule.match.path.startsWith === '/api/openrouter/'
+    );
+    expect(rootIndex).toBeLessThan(shadowIndex);
+    expect(shadowIndex).toBeLessThan(backendIndex);
+    expect(backendIndex).toBeLessThan(providerIndex);
+  });
+
+  it('shadows exact provider catalog routes nested below the protected session namespace', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        targets: {
+          backendBaseUrl: 'https://backend.example.com',
+          providerBaseUrl: `https://shared.example.com/api/session/${OTHER_SESSION_ID}`,
+          sessionIngestBaseUrl: 'https://shared.example.com',
+        },
+      }),
+    });
+
+    expect(
+      effectiveAuthorization(policy, {
+        url: `https://shared.example.com/api/session/${OTHER_SESSION_ID}/api/openrouter/models`,
+        authorization: 'Bearer placeholder-kilo-token',
+      })
+    ).toBe('Bearer placeholder-kilo-token');
+  });
+
+  it('shadows normalized provider prefixes nested below the protected session namespace', () => {
+    const policy = buildVercelCredentialNetworkPolicy({
+      kilo: kiloInput({
+        targets: {
+          backendBaseUrl: 'https://backend.example.com',
+          providerBaseUrl: `https://shared.example.com/api/session/${OTHER_SESSION_ID}/api/custom`,
+          sessionIngestBaseUrl: 'https://shared.example.com',
+        },
+      }),
+    });
+
+    for (const route of ['openrouter', 'gateway']) {
+      expect(
+        effectiveAuthorization(policy, {
+          url: `https://shared.example.com/api/session/${OTHER_SESSION_ID}/api/${route}/models`,
+          authorization: 'Bearer placeholder-kilo-token',
+        })
+      ).toBe('Bearer placeholder-kilo-token');
+    }
+  });
+
+  it('authenticates Git smart HTTP only for the exact case-preserving repository boundary', () => {
+    const input = githubInput();
+    const policy = buildVercelCredentialNetworkPolicy({ github: input });
+    const authorization = `Basic ${btoa(`x-access-token:${input.placeholder}`)}`;
+    const expected = `Basic ${btoa(`x-access-token:${input.token}`)}`;
+
+    for (const [pathname, method] of [
+      ['/Kilo-Org/Cloud.Repo.git/info/refs?service=git-upload-pack', 'GET'],
+      ['/Kilo-Org/Cloud.Repo.git/git-upload-pack', 'POST'],
+      ['/Kilo-Org/Cloud.Repo.git/git-receive-pack', 'POST'],
+    ]) {
+      expect(
+        firstMatchingRule(policy, {
+          url: `https://github.com${pathname}`,
+          authorization,
+          method,
+        })?.headers
+      ).toEqual({ authorization: expected, host: 'github.com' });
+    }
+
+    for (const pathname of [
+      '/Kilo-Org/Cloud.Repo.git',
+      '/Kilo-Org/Cloud.Repo.git-other/info/refs',
+      '/Kilo-Org/Cloud.Repo-other.git/info/refs',
+      '/Other-Org/Cloud.Repo.git/info/refs',
+      '/kilo-org/cloud.repo.git/info/refs',
+    ]) {
+      expect(
+        effectiveAuthorization(policy, { url: `https://github.com${pathname}`, authorization })
+      ).toBeUndefined();
+    }
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://github.com/Kilo-Org/Cloud.Repo.git/info/refs',
+        authorization,
+        method: 'PATCH',
+      })
+    ).toBeUndefined();
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://github.com/Kilo-Org/Cloud.Repo.git/info/refs',
+        authorization: `Basic ${btoa('x-access-token:wrong-placeholder')}`,
+      })
+    ).toBeUndefined();
+    expect(
+      effectiveAuthorization(policy, {
+        url: 'https://github.com/Kilo-Org/Cloud.Repo.git/info/refs',
+        authorization: `Basic ${btoa(`oauth2:${input.placeholder}`)}`,
+      })
+    ).toBeUndefined();
+  });
+
+  it.each(['Bearer', 'token'])(
+    'authenticates selected GitHub API routes using %s placeholders',
+    scheme => {
+      const input = githubInput();
+      const policy = buildVercelCredentialNetworkPolicy({ github: input });
+      const authorization = `${scheme} ${input.placeholder}`;
+      const repository = 'https://api.github.com/repos/Kilo-Org/Cloud.Repo';
+
+      for (const method of ['GET', 'HEAD', 'POST', 'PATCH']) {
+        for (const url of [repository, `${repository}/pulls/1?include=details`]) {
+          expect(firstMatchingRule(policy, { url, authorization, method })?.headers).toEqual({
+            authorization: 'Bearer actual-github-token',
+            host: 'api.github.com',
+          });
+        }
+      }
+
+      for (const method of ['DELETE', 'PUT']) {
+        expect(
+          effectiveAuthorization(policy, { url: repository, authorization, method })
+        ).toBeUndefined();
+      }
+      for (const url of [
+        `${repository}-other`,
+        `${repository}-other/pulls/1`,
+        'https://api.github.com/repos/Kilo-Org/Other',
+        'https://api.github.com/repos/kilo-org/cloud.repo',
+        'https://api.github.com/graphql',
+        'https://api.github.com/user',
+        'https://uploads.github.com/repos/Kilo-Org/Cloud.Repo/releases/1/assets',
+      ]) {
+        expect(
+          effectiveAuthorization(policy, { url, authorization, method: 'POST' })
+        ).toBeUndefined();
+      }
+      expect(
+        effectiveAuthorization(policy, {
+          url: repository,
+          authorization: `${scheme} wrong-placeholder`,
+        })
+      ).toBeUndefined();
+    }
+  );
+
+  it.each(['Bearer', 'token'])(
+    'shadows GitHub runner credential issuance before repository-prefix injection for %s',
+    scheme => {
+      const input = githubInput();
+      const policy = buildVercelCredentialNetworkPolicy({ github: input });
+      const authorization = `${scheme} ${input.placeholder}`;
+      const base = 'https://api.github.com/repos/Kilo-Org/Cloud.Repo';
+
+      for (const operation of ['registration-token', 'remove-token', 'generate-jitconfig']) {
+        const url = `${base}/actions/runners/${operation}`;
+        const shadow = firstMatchingRule(policy, { url, authorization, method: 'POST' });
+        expect(shadow?.headers).toEqual({ authorization, host: 'api.github.com' });
+        expect(shadow?.headers).not.toHaveProperty('x-kilocode-organizationid');
+
+        const shadowIndex = policy.injectionRules.findIndex(rule => rule === shadow);
+        const prefixIndex = policy.injectionRules.findIndex(
+          rule =>
+            rule.domain === 'api.github.com' &&
+            rule.match.path &&
+            'startsWith' in rule.match.path &&
+            rule.match.headers.some(matcher => matcher.value.exact === authorization)
+        );
+        expect(shadowIndex).toBeLessThan(prefixIndex);
+      }
+
+      expect(
+        effectiveAuthorization(policy, {
+          url: `${base}/issues/1/comments`,
+          authorization,
+          method: 'POST',
+        })
+      ).toBe('Bearer actual-github-token');
+      expect(
+        effectiveAuthorization(policy, {
+          url: 'https://api.github.com/repos/Kilo-Org/Other/actions/runners/registration-token',
+          authorization,
+          method: 'POST',
+        })
+      ).toBeUndefined();
+    }
+  );
+
+  it.each([
+    '',
+    'repo',
+    'owner/',
+    '/repo',
+    'owner/repo/extra',
+    './repo',
+    '../repo',
+    'owner/.',
+    'owner/..',
+    'owner/repo%2fother',
+    'owner/repo%252fother',
+    'owner/repo%5cother',
+    'owner/repo?other',
+    'owner/repo#other',
+    'owner/repo\\other',
+    'owner/repo name',
+  ])('rejects unsafe or ambiguous GitHub repository identity: %s', repository => {
+    expect(() =>
+      buildVercelCredentialNetworkPolicy({ github: githubInput({ repository }) })
+    ).toThrow('Invalid Vercel credential network policy');
+  });
+
+  it.each([
+    '',
+    '.',
+    '..',
+    'org/other',
+    'org%2fother',
+    'org%252fother',
+    'org\\other',
+    'org?other',
+    '.hidden-org',
+    'org name',
+  ])('rejects unsafe organization segments: %s', organizationId => {
+    expect(() =>
+      buildVercelCredentialNetworkPolicy({ kilo: kiloInput({ organizationId }) })
+    ).toThrow('Invalid Vercel credential network policy');
+  });
+
+  it.each([
+    '',
+    'ses_short',
+    'ses_abcdefghijklmnopqrstuvwxyzextra',
+    'ses_abcdefghijklmnopqrstuvwxy-',
+    'ses_abcdefghijklmnopqrstuvwx/yz',
+    'ses_abcdefghijklmnopqrstuvwx%2f',
+    'agent_abcdefghijklmnopqrstuvwxyz',
+  ])('rejects noncanonical root session identities: %s', rootSessionId => {
+    expect(() =>
+      buildVercelCredentialNetworkPolicy({
+        kilo: kiloInput({ rootSessionIds: [ROOT_SESSION_ID, rootSessionId] }),
+      })
+    ).toThrow('Invalid Vercel credential network policy');
+  });
+
+  it.each([
+    'http://localhost:3000/base',
+    'https://localhost/base',
+    'https://127.0.0.1/base',
+    'https://invalid_host.example.com/base',
+    'https://user@example.com/base',
+    'https://example.com/base?token=unsafe',
+    'https://example.com/base/../escape',
+    'https://example.com/base/%252e%252e/escape',
+    'https://example.com/base%252fescape',
+    'https://example.com/base%GG',
+  ])('defensively rejects malicious provided targets: %s', target => {
+    for (const key of ['backendBaseUrl', 'providerBaseUrl', 'sessionIngestBaseUrl'] as const) {
+      expect(() =>
+        buildVercelCredentialNetworkPolicy({
+          kilo: kiloInput({ targets: { ...kiloInput().targets, [key]: target } }),
+        })
+      ).toThrow('Invalid Vercel credential network policy');
+    }
+  });
+
+  it.each([
+    { token: '', placeholder: 'placeholder' },
+    { token: 'actual', placeholder: '' },
+    { token: 'same', placeholder: 'same' },
+    { token: 'actual\nother', placeholder: 'placeholder' },
+    { token: 'actual', placeholder: 'placeholder\rother' },
+  ])('rejects empty, colliding, or invalid credential values', credential => {
+    expect(() => buildVercelCredentialNetworkPolicy({ kilo: kiloInput(credential) })).toThrow(
+      'Invalid Vercel credential network policy'
+    );
+    expect(() => buildVercelCredentialNetworkPolicy({ github: githubInput(credential) })).toThrow(
+      'Invalid Vercel credential network policy'
+    );
+  });
+
+  it('rejects placeholder collisions between managed credential types', () => {
+    expect(() =>
+      buildVercelCredentialNetworkPolicy({
+        kilo: kiloInput({ placeholder: 'shared-placeholder' }),
+        github: githubInput({ placeholder: 'shared-placeholder' }),
+      })
+    ).toThrow('Invalid Vercel credential network policy');
+  });
+});

--- a/services/cloud-agent-next/src/sandbox-control/vercel-network-policy.ts
+++ b/services/cloud-agent-next/src/sandbox-control/vercel-network-policy.ts
@@ -1,0 +1,311 @@
+import { containedKiloSessionIdSchema } from '@kilocode/session-ingest-contracts';
+import type {
+  VercelSandboxInjectionRule,
+  VercelSandboxNetworkPolicy,
+} from '../agent-sandbox/vercel/vercel-sandbox-rest-client.js';
+import { deriveKiloSandboxTargets, type KiloSandboxTargets } from '../kilo/kilo-targets.js';
+
+export type VercelCredentialPolicyInput = {
+  kilo?: {
+    token: string;
+    placeholder: string;
+    targets: KiloSandboxTargets;
+    rootSessionIds: string[];
+    organizationId?: string;
+  };
+  github?: {
+    token: string;
+    placeholder: string;
+    repository: string;
+  };
+};
+
+type CredentialRuleInput = {
+  target: URL;
+  path: NonNullable<VercelSandboxInjectionRule['match']['path']>;
+  methods: string[];
+  expectedAuthorization: string;
+  injectedAuthorization: string;
+  organizationId?: string;
+};
+
+function invalidPolicy(): never {
+  throw new Error('Invalid Vercel credential network policy');
+}
+
+function validateCredential(token: string, placeholder: string): void {
+  if (
+    token.length === 0 ||
+    placeholder.length === 0 ||
+    token === placeholder ||
+    /[\r\n]/.test(token) ||
+    /[\r\n]/.test(placeholder)
+  ) {
+    invalidPolicy();
+  }
+}
+
+function createCredentialRule(input: CredentialRuleInput): VercelSandboxInjectionRule {
+  return {
+    domain: input.target.hostname,
+    headers: {
+      authorization: input.injectedAuthorization,
+      host: input.target.host,
+      ...(input.organizationId === undefined
+        ? {}
+        : { 'x-kilocode-organizationid': input.organizationId }),
+    },
+    match: {
+      headers: [
+        {
+          key: { exact: 'authorization' },
+          value: { exact: input.expectedAuthorization },
+        },
+      ],
+      path: input.path,
+      method: input.methods,
+    },
+  };
+}
+
+function basePath(target: URL): string {
+  return target.pathname === '/' ? '' : target.pathname.replace(/\/+$/, '');
+}
+
+function providerPrefixes(path: string): string[] {
+  const segments = path.split('/').filter(Boolean);
+  const apiIndex = segments.lastIndexOf('api');
+  const prefix = apiIndex < 0 ? segments : segments.slice(0, apiIndex);
+  return ['openrouter', 'gateway'].map(route => `/${[...prefix, 'api', route].join('/')}/`);
+}
+
+function providerCatalogBasePath(provider: URL, organizationId: string | undefined): string {
+  const path = basePath(provider);
+  const segments = path.split('/').filter(Boolean);
+  for (let index = 0; index < segments.length; index++) {
+    if (segments[index] === 'api' && segments[index + 1] === 'organizations') {
+      const embeddedOrganizationId = segments[index + 2];
+      if (!embeddedOrganizationId || embeddedOrganizationId !== organizationId) invalidPolicy();
+    }
+  }
+
+  if (organizationId !== undefined) {
+    if (path.includes('/api/organizations/')) return path;
+    if (path.endsWith('/api')) return `${path}/organizations/${organizationId}`;
+    return `${path}/api/organizations/${organizationId}`;
+  }
+
+  if (provider.toString().includes('/openrouter')) return path;
+  if (path.endsWith('/api')) return `${path}/openrouter`;
+  return `${path}/api/openrouter`;
+}
+
+export function buildKiloCredentialInjectionRules(
+  input: NonNullable<VercelCredentialPolicyInput['kilo']>,
+  options?: { requireHttps?: boolean }
+): VercelSandboxInjectionRule[] {
+  validateCredential(input.token, input.placeholder);
+  if (!Array.isArray(input.rootSessionIds) || input.rootSessionIds.length === 0) invalidPolicy();
+  const rootSessionIds = [...new Set(input.rootSessionIds)];
+  if (rootSessionIds.some(id => !containedKiloSessionIdSchema.safeParse(id).success))
+    invalidPolicy();
+  if (
+    input.organizationId !== undefined &&
+    !/^[A-Za-z0-9][A-Za-z0-9._-]*$/.test(input.organizationId)
+  ) {
+    invalidPolicy();
+  }
+
+  const validatedTargets = deriveKiloSandboxTargets(
+    {
+      KILOCODE_BACKEND_BASE_URL: input.targets.backendBaseUrl,
+      KILO_OPENROUTER_BASE: input.targets.providerBaseUrl,
+      KILO_SESSION_INGEST_URL: input.targets.sessionIngestBaseUrl,
+    },
+    '',
+    { requireHttps: options?.requireHttps !== false }
+  );
+  if (!validatedTargets.success) invalidPolicy();
+
+  const backend = new URL(validatedTargets.targets.backendBaseUrl);
+  const provider = new URL(validatedTargets.targets.providerBaseUrl);
+  const ingest = new URL(validatedTargets.targets.sessionIngestBaseUrl);
+  const catalogBasePath = providerCatalogBasePath(provider, input.organizationId);
+  const expectedAuthorization = `Bearer ${input.placeholder}`;
+  const injectedAuthorization = `Bearer ${input.token}`;
+  const rules: VercelSandboxInjectionRule[] = [];
+  const addRule = (
+    target: URL,
+    path: NonNullable<VercelSandboxInjectionRule['match']['path']>,
+    methods: string[],
+    authorization = injectedAuthorization
+  ) => {
+    rules.push(
+      createCredentialRule({
+        target,
+        path,
+        methods,
+        expectedAuthorization,
+        injectedAuthorization: authorization,
+        organizationId: input.organizationId ?? '',
+      })
+    );
+  };
+
+  const sessionCollection = `${basePath(ingest)}/api/session`;
+  for (const rootSessionId of rootSessionIds) {
+    const sessionPrefix = `${sessionCollection}/${rootSessionId}`;
+    addRule(ingest, { exact: `${sessionPrefix}/export` }, ['GET']);
+    addRule(ingest, { exact: `${sessionPrefix}/ingest` }, ['POST']);
+  }
+
+  const modelPrefixes = providerPrefixes(basePath(provider));
+  const catalogPaths = [`${catalogBasePath}/models`, `${catalogBasePath}/models/validate`];
+  const sessionNamespace = `${sessionCollection}/`;
+  const requiresSessionShadows =
+    provider.hostname === ingest.hostname &&
+    (modelPrefixes.some(
+      prefix =>
+        sessionCollection.startsWith(prefix) ||
+        sessionNamespace.startsWith(prefix) ||
+        prefix.startsWith(sessionNamespace)
+    ) ||
+      catalogPaths.some(path => path === sessionCollection || path.startsWith(sessionNamespace)));
+  if (requiresSessionShadows) {
+    addRule(ingest, { exact: sessionCollection }, ['GET', 'POST'], expectedAuthorization);
+    addRule(ingest, { startsWith: sessionNamespace }, ['GET', 'POST'], expectedAuthorization);
+  }
+
+  const backendApiPath = `${basePath(backend)}/api`;
+  for (const suffix of ['user', 'profile', 'profile/balance', 'defaults', 'users/notifications']) {
+    addRule(backend, { exact: `${backendApiPath}/${suffix}` }, ['GET']);
+  }
+
+  if (input.organizationId !== undefined) {
+    const organizationPath = `${backendApiPath}/organizations/${input.organizationId}`;
+    for (const suffix of ['models', 'defaults', 'modes']) {
+      addRule(backend, { exact: `${organizationPath}/${suffix}` }, ['GET']);
+    }
+    addRule(backend, { exact: `${organizationPath}/models/validate` }, ['POST']);
+  } else {
+    addRule(backend, { exact: `${backendApiPath}/openrouter/models/validate` }, ['POST']);
+  }
+
+  addRule(provider, { exact: `${catalogBasePath}/models` }, ['GET']);
+  addRule(provider, { exact: `${catalogBasePath}/models/validate` }, ['POST']);
+
+  for (const prefix of modelPrefixes) {
+    addRule(provider, { startsWith: prefix }, ['GET', 'POST']);
+  }
+  return rules;
+}
+
+function githubInjectionRules(
+  input: NonNullable<VercelCredentialPolicyInput['github']>
+): VercelSandboxInjectionRule[] {
+  validateCredential(input.token, input.placeholder);
+  const segments = input.repository.split('/');
+  if (
+    segments.length !== 2 ||
+    segments.some(
+      segment => !/^[A-Za-z0-9_.-]+$/.test(segment) || segment === '.' || segment === '..'
+    )
+  ) {
+    invalidPolicy();
+  }
+
+  const repositoryPath = input.repository;
+  const github = new URL('https://github.com');
+  const githubApi = new URL('https://api.github.com');
+  const placeholderBasic = btoa(`x-access-token:${input.placeholder}`);
+  const tokenBasic = btoa(`x-access-token:${input.token}`);
+  const rules = [
+    createCredentialRule({
+      target: github,
+      path: { startsWith: `/${repositoryPath}.git/` },
+      methods: ['GET', 'POST'],
+      expectedAuthorization: `Basic ${placeholderBasic}`,
+      injectedAuthorization: `Basic ${tokenBasic}`,
+    }),
+  ];
+
+  const apiPath = `/repos/${repositoryPath}`;
+  for (const operation of ['registration-token', 'remove-token', 'generate-jitconfig']) {
+    for (const scheme of ['Bearer', 'token']) {
+      const authorization = `${scheme} ${input.placeholder}`;
+      rules.push(
+        createCredentialRule({
+          target: githubApi,
+          path: { exact: `${apiPath}/actions/runners/${operation}` },
+          methods: ['POST'],
+          expectedAuthorization: authorization,
+          injectedAuthorization: authorization,
+        })
+      );
+    }
+  }
+
+  for (const path of [{ exact: apiPath }, { startsWith: `${apiPath}/` }]) {
+    for (const scheme of ['Bearer', 'token']) {
+      rules.push(
+        createCredentialRule({
+          target: githubApi,
+          path,
+          methods: ['GET', 'HEAD', 'POST', 'PATCH'],
+          expectedAuthorization: `${scheme} ${input.placeholder}`,
+          injectedAuthorization: `Bearer ${input.token}`,
+        })
+      );
+    }
+  }
+  return rules;
+}
+
+export function findMatchingCredentialInjectionRule(
+  rules: readonly VercelSandboxInjectionRule[],
+  request: { url: URL; method: string; headers: Headers }
+): VercelSandboxInjectionRule | undefined {
+  return rules.find(rule => {
+    if (
+      rule.domain !== request.url.hostname ||
+      (rule.match.method && !rule.match.method.includes(request.method))
+    ) {
+      return false;
+    }
+    const path = rule.match.path;
+    if (
+      path &&
+      ('exact' in path
+        ? path.exact !== request.url.pathname
+        : !request.url.pathname.startsWith(path.startsWith))
+    ) {
+      return false;
+    }
+    return rule.match.headers.every(
+      matcher => request.headers.get(matcher.key.exact) === matcher.value.exact
+    );
+  });
+}
+
+export function buildVercelCredentialNetworkPolicy(
+  input: VercelCredentialPolicyInput
+): VercelSandboxNetworkPolicy {
+  if (
+    input.kilo !== undefined &&
+    input.github !== undefined &&
+    input.kilo.placeholder === input.github.placeholder
+  ) {
+    invalidPolicy();
+  }
+
+  const injectionRules = [
+    ...(input.kilo === undefined ? [] : buildKiloCredentialInjectionRules(input.kilo)),
+    ...(input.github === undefined ? [] : githubInjectionRules(input.github)),
+  ];
+
+  return {
+    mode: 'custom',
+    allowedDomains: [...new Set(injectionRules.map(rule => rule.domain)), '*'],
+    injectionRules,
+  };
+}

--- a/services/cloud-agent-next/src/sandbox-control/vercel-provider.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/vercel-provider.test.ts
@@ -5,8 +5,8 @@ import {
 } from '../agent-sandbox/vercel/vercel-sandbox-rest-client.js';
 import type { VercelSandboxRuntimeConfig } from '../agent-sandbox/vercel/vercel-runtime-config.js';
 import { parseSandboxBillingInput } from '../container-usage-context.js';
-import { deriveSandboxAllocationId } from '../sandbox-id.js';
 import { DEADLINE_MS } from './deadlines.js';
+import { deriveSandboxAllocationId } from '../sandbox-id.js';
 import {
   createVercelProviderAdapter,
   decodeVercelProviderRef,
@@ -27,7 +27,7 @@ const config: VercelSandboxRuntimeConfig = {
 
 const runningSession = {
   id: 'vsess_1',
-  sourceSandboxName: 'ses-abc',
+  sourceSandboxName: 'ses-def',
   projectId: 'prj_1',
   runtime: 'node24',
   status: 'running' as const,
@@ -44,6 +44,12 @@ const runningSession = {
 
 const intent = { intentId: 'op_1', createdAt: 1_000, allocationName: 'ses-def' };
 const ref = encodeVercelProviderRef({ sandboxName: intent.allocationName, sessionId: 'vsess_1' });
+
+const networkPolicy = {
+  mode: 'custom' as const,
+  allowedDomains: ['api.kilo.ai', '*'],
+  injectionRules: [],
+};
 
 function envelope(name = intent.allocationName): VercelSandboxCreateEnvelope {
   return {
@@ -79,6 +85,7 @@ function fakeClient(overrides: Partial<VercelControlRestClient> = {}): VercelCon
     extendSessionTimeout: async () => runningSession,
     stopSession: async () => ({ ...runningSession, status: 'stopped' as const }),
     readFile: async () => new TextEncoder().encode('wrapper log'),
+    updateNetworkPolicy: async () => runningSession,
     ...overrides,
   };
 }
@@ -88,7 +95,7 @@ describe('vercel provider adapter', () => {
     const executeCommand = vi.fn().mockResolvedValue({});
     const createSandbox = vi.fn(fakeClient().createSandbox);
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       restClient: fakeClient({ executeCommand, createSandbox }),
     });
@@ -116,10 +123,44 @@ describe('vercel provider adapter', () => {
     });
   });
 
+  it('installs the creation policy before launching the control wrapper', async () => {
+    const createSandbox = vi.fn(fakeClient().createSandbox);
+    const executeCommand = vi.fn(fakeClient().executeCommand);
+    const provider = createVercelProviderAdapter({
+      sandboxName: intent.allocationName,
+      config,
+      restClient: fakeClient({ createSandbox, executeCommand }),
+    });
+
+    const created = await provider.create({ ...intent, networkPolicy });
+    if (!('providerRef' in created)) throw new Error('Missing allocation');
+    expect(executeCommand).not.toHaveBeenCalled();
+    expect(createSandbox).toHaveBeenCalledWith(
+      expect.objectContaining({ name: intent.allocationName, networkPolicy })
+    );
+    await provider.launch(created.providerRef, {});
+    expect(createSandbox.mock.invocationCallOrder[0]).toBeLessThan(
+      executeCommand.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('never launches the wrapper when sandbox creation rejects its policy', async () => {
+    const createSandbox = vi.fn().mockRejectedValue(new Error('policy rejected'));
+    const executeCommand = vi.fn(fakeClient().executeCommand);
+    const provider = createVercelProviderAdapter({
+      sandboxName: intent.allocationName,
+      config,
+      restClient: fakeClient({ createSandbox, executeCommand }),
+    });
+
+    await expect(provider.create({ ...intent, networkPolicy })).rejects.toThrow('policy rejected');
+    expect(executeCommand).not.toHaveBeenCalled();
+  });
+
   it('rejects enforced billing before allocating a Vercel sandbox', async () => {
     const createSandbox = vi.fn();
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       restClient: fakeClient({ createSandbox }),
     });
@@ -144,23 +185,29 @@ describe('vercel provider adapter', () => {
         return envelope(input.name);
       }
     );
-    const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+    const first = await deriveSandboxAllocationId('ses-abc', intent.intentId);
+    const second = await deriveSandboxAllocationId('ses-abc', 'op_2');
+    const original = createVercelProviderAdapter({
+      sandboxName: first,
       config,
       restClient: fakeClient({ createSandbox }),
     });
-    const first = await deriveSandboxAllocationId('ses-abc', intent.intentId);
-    const second = await deriveSandboxAllocationId('ses-abc', 'op_2');
-    const created = await provider.create({ ...intent, allocationName: first });
-    if (!('providerRef' in created)) throw new Error('allocation missing');
-    await expect(provider.stop(created.providerRef)).resolves.toBe('terminal');
-    const replacement = await provider.create({
+    const created = await original.create({ ...intent, allocationName: first });
+    if (!('providerRef' in created)) throw new Error('Missing allocation');
+    await expect(original.stop(created.providerRef)).resolves.toBe('terminal');
+    const replacement = createVercelProviderAdapter({
+      sandboxName: second,
+      config,
+      restClient: fakeClient({ createSandbox }),
+    });
+    const recreated = await replacement.create({
       ...intent,
       intentId: 'op_2',
       allocationName: second,
     });
     expect(retainedNames).toEqual(new Set([first, second]));
-    expect(replacement).not.toEqual(created);
+    expect(recreated).not.toEqual(created);
+    expect(first).not.toBe(second);
   });
 
   it('rediscovers an ambiguous create by its retained name and operation without a second create', async () => {
@@ -168,7 +215,7 @@ describe('vercel provider adapter', () => {
     const inspectByName = vi.fn(fakeClient().inspectByName);
     const executeCommand = vi.fn();
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       restClient: fakeClient({ createSandbox, inspectByName, executeCommand }),
     });
@@ -191,7 +238,7 @@ describe('vercel provider adapter', () => {
   it('does not call an early not-found authoritative until the create settling window closes', async () => {
     let now = intent.createdAt;
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       now: () => now,
       restClient: fakeClient({ inspectByName: async () => null }),
@@ -204,7 +251,7 @@ describe('vercel provider adapter', () => {
 
   it('propagates launch failure after returning the ref', async () => {
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       restClient: fakeClient({
         executeCommand: async () => {
@@ -220,7 +267,7 @@ describe('vercel provider adapter', () => {
   it('maps a running exact session to active, 404 to terminal, and other failures to unknown', async () => {
     const getSession = vi.fn(fakeClient().getSession);
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       restClient: fakeClient({ getSession }),
     });
@@ -237,7 +284,7 @@ describe('vercel provider adapter', () => {
   it('stop is terminal on 404 or stopped, retryable on failure or absent identity', async () => {
     const stopSession = vi.fn(fakeClient().stopSession);
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       restClient: fakeClient({ stopSession }),
     });
@@ -256,7 +303,7 @@ describe('vercel provider adapter', () => {
   });
 
   it('keeps Vercel identity unresolved when runtime configuration is missing', async () => {
-    const provider = createVercelProviderAdapter({ sandboxName: 'ses-abc' });
+    const provider = createVercelProviderAdapter({ sandboxName: intent.allocationName });
     await expect(provider.create(intent)).rejects.toThrow('configuration is unavailable');
     await expect(provider.observe(ref)).resolves.toEqual({ status: 'unknown' });
     await expect(provider.stop(ref)).resolves.toBe('retryable');
@@ -266,7 +313,7 @@ describe('vercel provider adapter', () => {
     let now = 1_000 + 250_000;
     const extendSessionTimeout = vi.fn(fakeClient().extendSessionTimeout);
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       now: () => now,
       restClient: fakeClient({ extendSessionTimeout }),
@@ -281,12 +328,143 @@ describe('vercel provider adapter', () => {
 
   it('reads bounded wrapper logs', async () => {
     const provider = createVercelProviderAdapter({
-      sandboxName: 'ses-abc',
+      sandboxName: intent.allocationName,
       config,
       restClient: fakeClient(),
     });
     await expect(provider.logs(ref)).resolves.toBe('wrapper log');
   });
+
+  it('does not inspect, extend, or read sessions from another logical sandbox', async () => {
+    const getSession = vi.fn(fakeClient().getSession);
+    const extendSessionTimeout = vi.fn(fakeClient().extendSessionTimeout);
+    const readFile = vi.fn(fakeClient().readFile);
+    const stopSession = vi.fn(fakeClient().stopSession);
+    const provider = createVercelProviderAdapter({
+      sandboxName: intent.allocationName,
+      config,
+      restClient: fakeClient({ getSession, extendSessionTimeout, readFile, stopSession }),
+    });
+    const otherRef = encodeVercelProviderRef({
+      sandboxName: 'ses-other',
+      sessionId: 'vsess_other',
+    });
+
+    await expect(provider.observe(otherRef)).resolves.toEqual({ status: 'unknown' });
+    await expect(provider.stop(otherRef)).resolves.toBe('retryable');
+    await provider.ensureLeaseAtLeast(otherRef, 60_000);
+    await provider.logs(otherRef);
+
+    expect(getSession).not.toHaveBeenCalled();
+    expect(stopSession).not.toHaveBeenCalled();
+    expect(extendSessionTimeout).not.toHaveBeenCalled();
+    expect(readFile).not.toHaveBeenCalled();
+  });
+
+  it('updates the firewall policy for the exact owned running session', async () => {
+    const updateNetworkPolicy = vi.fn(fakeClient().updateNetworkPolicy);
+    const provider = createVercelProviderAdapter({
+      sandboxName: intent.allocationName,
+      config,
+      restClient: fakeClient({ updateNetworkPolicy }),
+    });
+    const ownedRef = encodeVercelProviderRef({
+      sandboxName: intent.allocationName,
+      sessionId: 'vsess_1',
+    });
+
+    await expect(provider.updateNetworkPolicy?.(ownedRef, networkPolicy)).resolves.toBeUndefined();
+
+    expect(updateNetworkPolicy).toHaveBeenCalledWith(
+      'vsess_1',
+      intent.allocationName,
+      networkPolicy
+    );
+  });
+
+  it.each([
+    { description: 'null', ref: null },
+    { description: 'malformed', ref: 'not-json' },
+    { description: 'logical-only', ref: 'ses-abc' },
+    {
+      description: 'cross-sandbox',
+      ref: encodeVercelProviderRef({ sandboxName: 'ses-other', sessionId: 'vsess_1' }),
+    },
+  ])('rejects $description provider refs without sending a policy update', async ({ ref }) => {
+    const updateNetworkPolicy = vi.fn(fakeClient().updateNetworkPolicy);
+    const provider = createVercelProviderAdapter({
+      sandboxName: intent.allocationName,
+      config,
+      restClient: fakeClient({ updateNetworkPolicy }),
+    });
+
+    await expect(provider.updateNetworkPolicy?.(ref as string, networkPolicy)).rejects.toThrow(
+      'Invalid Vercel sandbox provider reference'
+    );
+    expect(updateNetworkPolicy).not.toHaveBeenCalled();
+  });
+
+  it('rejects a stale session without substituting the latest physical session', async () => {
+    const updateNetworkPolicy = vi.fn(fakeClient().updateNetworkPolicy);
+    const provider = createVercelProviderAdapter({
+      sandboxName: intent.allocationName,
+      config,
+      restClient: fakeClient({ updateNetworkPolicy }),
+    });
+    const staleRef = encodeVercelProviderRef({
+      sandboxName: intent.allocationName,
+      sessionId: 'vsess_old',
+    });
+
+    await expect(provider.updateNetworkPolicy?.(staleRef, networkPolicy)).rejects.toThrow(
+      'Vercel sandbox policy update returned a different session'
+    );
+    expect(updateNetworkPolicy).toHaveBeenCalledWith(
+      'vsess_old',
+      intent.allocationName,
+      networkPolicy
+    );
+  });
+
+  it('rejects a policy update response for another logical sandbox', async () => {
+    const updateNetworkPolicy = vi.fn().mockResolvedValue({
+      ...runningSession,
+      sourceSandboxName: 'ses-other',
+    });
+    const provider = createVercelProviderAdapter({
+      sandboxName: intent.allocationName,
+      config,
+      restClient: fakeClient({ updateNetworkPolicy }),
+    });
+    const ownedRef = encodeVercelProviderRef({
+      sandboxName: intent.allocationName,
+      sessionId: 'vsess_1',
+    });
+
+    await expect(provider.updateNetworkPolicy?.(ownedRef, networkPolicy)).rejects.toThrow(
+      'Vercel sandbox policy update returned a different session'
+    );
+  });
+
+  it.each(['pending', 'stopped', 'failed'] as const)(
+    'rejects a policy update when the session is %s',
+    async status => {
+      const updateNetworkPolicy = vi.fn().mockResolvedValue({ ...runningSession, status });
+      const provider = createVercelProviderAdapter({
+        sandboxName: intent.allocationName,
+        config,
+        restClient: fakeClient({ updateNetworkPolicy }),
+      });
+      const ownedRef = encodeVercelProviderRef({
+        sandboxName: intent.allocationName,
+        sessionId: 'vsess_1',
+      });
+
+      await expect(provider.updateNetworkPolicy?.(ownedRef, networkPolicy)).rejects.toThrow(
+        'Vercel sandbox session is not running'
+      );
+    }
+  );
 
   it('round-trips the opaque provider ref', () => {
     expect(decodeVercelProviderRef(ref)).toEqual({

--- a/services/cloud-agent-next/src/sandbox-control/vercel-provider.ts
+++ b/services/cloud-agent-next/src/sandbox-control/vercel-provider.ts
@@ -45,6 +45,7 @@ export type VercelControlRestClient = {
   extendSessionTimeout: VercelSandboxRestClient['extendSessionTimeout'];
   stopSession: VercelSandboxRestClient['stopSession'];
   readFile: VercelSandboxRestClient['readFile'];
+  updateNetworkPolicy: VercelSandboxRestClient['updateNetworkPolicy'];
 };
 
 export function encodeVercelProviderRef(ref: VercelProviderRef): string {
@@ -91,6 +92,7 @@ export function createVercelProviderAdapter(deps: {
       stop: async () => 'retryable',
       ensureLeaseAtLeast: unavailable,
       logs: async () => 'Vercel sandbox runtime configuration is unavailable',
+      updateNetworkPolicy: unavailable,
     };
   }
   const restClient =
@@ -102,6 +104,10 @@ export function createVercelProviderAdapter(deps: {
       fetch,
     });
   const now = deps.now ?? Date.now;
+  const decodeOwnedProviderRef = (ref: string | null): VercelProviderRef | null => {
+    const parsed = decodeVercelProviderRef(ref);
+    return parsed?.sandboxName === deps.sandboxName ? parsed : null;
+  };
   const ensureBillingAdmission: ProviderAdapter['ensureBillingAdmission'] = async (
     _ref,
     billing
@@ -126,11 +132,12 @@ export function createVercelProviderAdapter(deps: {
         snapshotId: config.snapshotId,
         runtime: config.runtime,
         timeoutMs: config.initialTimeoutMs,
+        ...(intent.networkPolicy === undefined ? {} : { networkPolicy: intent.networkPolicy }),
       });
       return { providerRef: encodeVercelProviderRef(created.runtime) };
     },
     async launch(ref, env) {
-      const parsed = decodeVercelProviderRef(ref);
+      const parsed = decodeOwnedProviderRef(ref);
       if (!parsed) throw new Error('Invalid Vercel sandbox allocation');
       await restClient.executeCommand(parsed.sessionId, {
         command: 'sh',
@@ -146,7 +153,7 @@ export function createVercelProviderAdapter(deps: {
       });
     },
     async observe(ref, intent) {
-      const parsed = decodeVercelProviderRef(ref);
+      const parsed = decodeOwnedProviderRef(ref);
       try {
         if (parsed) {
           const { session } = await restClient.getSession(parsed.sessionId, parsed.sandboxName);
@@ -174,7 +181,7 @@ export function createVercelProviderAdapter(deps: {
       }
     },
     async stop(ref) {
-      const parsed = decodeVercelProviderRef(ref);
+      const parsed = decodeOwnedProviderRef(ref);
       if (parsed === null) return 'retryable';
       try {
         const session = await restClient.stopSession(parsed.sessionId, parsed.sandboxName);
@@ -185,7 +192,7 @@ export function createVercelProviderAdapter(deps: {
       }
     },
     async ensureLeaseAtLeast(ref, ms) {
-      const parsed = decodeVercelProviderRef(ref);
+      const parsed = decodeOwnedProviderRef(ref);
       if (parsed === null) return;
       const { session } = await restClient.getSession(parsed.sessionId, parsed.sandboxName);
       if (session.status !== 'running') return;
@@ -199,7 +206,7 @@ export function createVercelProviderAdapter(deps: {
       );
     },
     async logs(ref) {
-      const parsed = decodeVercelProviderRef(ref);
+      const parsed = decodeOwnedProviderRef(ref);
       if (parsed === null) return `vercel ${ref}`;
       try {
         const bytes = await withTimeout(
@@ -211,6 +218,19 @@ export function createVercelProviderAdapter(deps: {
       } catch {
         return `vercel ${parsed.sessionId} logs unavailable`;
       }
+    },
+    async updateNetworkPolicy(providerRef, networkPolicy) {
+      const parsed = decodeOwnedProviderRef(providerRef);
+      if (parsed === null) throw new Error('Invalid Vercel sandbox provider reference');
+      const session = await restClient.updateNetworkPolicy(
+        parsed.sessionId,
+        parsed.sandboxName,
+        networkPolicy
+      );
+      if (session.id !== parsed.sessionId || session.sourceSandboxName !== parsed.sandboxName) {
+        throw new Error('Vercel sandbox policy update returned a different session');
+      }
+      if (session.status !== 'running') throw new Error('Vercel sandbox session is not running');
     },
   };
 }

--- a/services/cloud-agent-next/src/sandbox-control/wrapper-launch-env.test.ts
+++ b/services/cloud-agent-next/src/sandbox-control/wrapper-launch-env.test.ts
@@ -1,46 +1,57 @@
 import { describe, expect, it } from 'vitest';
-import { deriveKiloSandboxTargets } from '../kilo/kilo-targets.js';
 import { buildControlWrapperLaunchEnv } from './wrapper-launch-env.js';
 
 describe('buildControlWrapperLaunchEnv', () => {
-  it('passes derived ingest and backend URLs to the sandbox', () => {
-    const kiloTargetEnv = {
-      KILOCODE_BACKEND_BASE_URL: 'https://backend.example.com',
-      KILO_OPENROUTER_BASE: 'https://openrouter.example.com/api',
-      KILO_SESSION_INGEST_URL: 'https://ingest.example.com',
-    };
-    const derived = deriveKiloSandboxTargets(kiloTargetEnv, 'user-token');
-    if (!derived.success) throw new Error('expected valid targets');
-
-    const env = buildControlWrapperLaunchEnv({
-      workerUrl: 'https://worker.example.com',
+  it('keeps Kilo and SCM credentials out of the wrapper bootstrap environment', () => {
+    const input = {
+      workerUrl: 'https://worker.example.com/',
       sandboxId: 'sbx_1',
-      credential: 'cred',
-      kiloToken: 'user-token',
-      kiloTargetEnv,
-    });
-
-    expect(env.KILO_SESSION_INGEST_URL).toBe(derived.targets.sessionIngestBaseUrl);
-    expect(env.KILO_API_URL).toBe(derived.targets.backendBaseUrl);
-    expect(env.KILOCODE_BACKEND_BASE_URL).toBe(derived.targets.backendBaseUrl);
-    expect(env.KILO_OPENROUTER_BASE).toBe(derived.targets.providerBaseUrl);
-    expect(env.SANDBOX_CONTROL_URL).toBe('wss://worker.example.com/sandbox-control/sbx_1');
-    const config = JSON.parse(env.KILO_CONFIG_CONTENT) as {
-      permission: { bash: string; doom_loop: string };
+      credential: 'control-credential',
+      kiloToken: 'test-kilo-secret',
+      kiloTargets: {
+        backendBaseUrl: 'https://backend.example.com',
+        providerBaseUrl: 'https://provider.example.com/api',
+        sessionIngestBaseUrl: 'https://ingest.example.com',
+      },
+      githubTokenPlaceholder: 'github-placeholder',
+      kiloTargetEnv: {
+        KILO_OPENROUTER_BASE: 'https://fallback.example.com/api',
+        GH_TOKEN: 'test-github-secret',
+        GITHUB_TOKEN: 'test-github-secret',
+        GITLAB_TOKEN: 'test-gitlab-secret',
+        BITBUCKET_TOKEN: 'test-bitbucket-secret',
+      },
     };
-    expect(config.permission.bash).toBe('allow');
-    expect(config.permission.doom_loop).toBe('allow');
-    expect(env.OPENCODE_CONFIG_CONTENT).toBe(env.KILO_CONFIG_CONTENT);
+
+    expect(buildControlWrapperLaunchEnv(input)).toEqual({
+      SANDBOX_CONTROL_URL: 'wss://worker.example.com/sandbox-control/sbx_1',
+      SANDBOX_CONTROL_CREDENTIAL: input.credential,
+      PROVIDER_INSTANCE_ID: input.sandboxId,
+      KILO_PLATFORM: 'cloud-agent',
+      KILO_DISABLE_AUTOUPDATE: 'true',
+      KILO_DEBUG_SESSION_INGEST: '1',
+    });
   });
 
-  it('omits kilo targets when no token is provided', () => {
+  it.each([
+    { workerUrl: undefined, expectedBase: '' },
+    {
+      workerUrl: 'https://worker.example.com/agent/',
+      expectedBase: 'wss://worker.example.com/agent',
+    },
+    {
+      workerUrl: 'http://127.0.0.1:8794/agent/',
+      expectedBase: 'ws://127.0.0.1:8794/agent',
+    },
+  ])('builds a credential-free control URL from $workerUrl', ({ workerUrl, expectedBase }) => {
     const env = buildControlWrapperLaunchEnv({
-      workerUrl: 'https://worker.example.com',
-      sandboxId: 'sbx_1',
-      credential: 'cred',
-      kiloTargetEnv: { KILO_SESSION_INGEST_URL: 'https://ingest.example.com' },
+      workerUrl,
+      sandboxId: 'sbx/one?key=value#part',
+      credential: 'control-credential',
     });
-    expect(env.KILO_SESSION_INGEST_URL).toBeUndefined();
-    expect(env.KILOCODE_TOKEN).toBeUndefined();
+
+    expect(env.SANDBOX_CONTROL_URL).toBe(
+      `${expectedBase}/sandbox-control/sbx%2Fone%3Fkey%3Dvalue%23part`
+    );
   });
 });

--- a/services/cloud-agent-next/src/sandbox-control/wrapper-launch-env.ts
+++ b/services/cloud-agent-next/src/sandbox-control/wrapper-launch-env.ts
@@ -1,20 +1,16 @@
-import { deriveKiloSandboxTargets, type KiloTargetEnv } from '../kilo/kilo-targets.js';
-import { CONTROL_PLANE_SANDBOX_PERMISSION } from '../shared/control-plane-permission.js';
 import { sandboxControlWebSocketUrl } from './control-url.js';
 
 export type ControlWrapperLaunchEnvInput = {
   workerUrl?: string;
   sandboxId: string;
   credential: string;
-  kiloToken?: string;
-  kiloTargetEnv: KiloTargetEnv;
 };
 
 export function buildControlWrapperLaunchEnv(
   input: ControlWrapperLaunchEnvInput
 ): Record<string, string> {
   const workerUrl = input.workerUrl?.replace(/\/$/, '') ?? '';
-  const env: Record<string, string> = {
+  return {
     SANDBOX_CONTROL_URL: sandboxControlWebSocketUrl(workerUrl, input.sandboxId),
     SANDBOX_CONTROL_CREDENTIAL: input.credential,
     PROVIDER_INSTANCE_ID: input.sandboxId,
@@ -22,31 +18,4 @@ export function buildControlWrapperLaunchEnv(
     KILO_DISABLE_AUTOUPDATE: 'true',
     KILO_DEBUG_SESSION_INGEST: '1',
   };
-  if (!input.kiloToken) return env;
-
-  env.KILOCODE_TOKEN = input.kiloToken;
-  env.KILO_AUTH_CONTENT = JSON.stringify({ kilo: { type: 'api', key: input.kiloToken } });
-  const targets = deriveKiloSandboxTargets(input.kiloTargetEnv, input.kiloToken);
-  if (!targets.success) return env;
-
-  env.KILOCODE_BACKEND_BASE_URL = targets.targets.backendBaseUrl;
-  env.KILO_API_URL = targets.targets.backendBaseUrl;
-  env.KILO_OPENROUTER_BASE = targets.targets.providerBaseUrl;
-  env.KILO_SESSION_INGEST_URL = targets.targets.sessionIngestBaseUrl;
-  const configJson = JSON.stringify({
-    autoupdate: false,
-    permission: CONTROL_PLANE_SANDBOX_PERMISSION,
-    provider: {
-      kilo: {
-        options: {
-          apiKey: input.kiloToken,
-          kilocodeToken: input.kiloToken,
-          baseURL: targets.targets.providerBaseUrl,
-        },
-      },
-    },
-  });
-  env.KILO_CONFIG_CONTENT = configJson;
-  env.OPENCODE_CONFIG_CONTENT = configJson;
-  return env;
 }

--- a/services/cloud-agent-next/src/sandbox-outbound.test.ts
+++ b/services/cloud-agent-next/src/sandbox-outbound.test.ts
@@ -11,6 +11,7 @@ const logging = vi.hoisted(() => {
     debug: vi.fn(),
     info: vi.fn(),
     warn: vi.fn(),
+    error: vi.fn(),
     withFields: vi.fn(),
   };
   logger.withFields.mockReturnValue(logger);
@@ -36,6 +37,10 @@ import {
   MANAGED_SCM_OUTBOUND_HANDLER,
   handleManagedScmOutbound,
 } from './sandbox-outbound.js';
+import {
+  createControlPlaneCredential,
+  type ControlCredentialPurpose,
+} from './sandbox-control/managed-credential.js';
 
 const CAPABILITY = 'kgh2.opaque';
 const LEGACY_CAPABILITY = 'kgh1.opaque';
@@ -80,6 +85,7 @@ function serializedLogCalls(): string {
     debug: logging.logger.debug.mock.calls,
     info: logging.logger.info.mock.calls,
     warn: logging.logger.warn.mock.calls,
+    error: logging.logger.error.mock.calls,
   });
 }
 
@@ -1362,5 +1368,431 @@ describe('handleManagedScmOutbound Bitbucket', () => {
     );
     expect(redeem).not.toHaveBeenCalled();
     expect(response.status).toBe(502);
+  });
+});
+
+describe('handleManagedScmOutbound control-plane aliases', () => {
+  const capabilities = {
+    kilo: KILO_CAPABILITY,
+    github: CAPABILITY,
+    gitlab: GITLAB_CAPABILITY,
+    bitbucket: 'kbb1.opaque',
+  } satisfies Record<ControlCredentialPurpose, string>;
+
+  function fixture() {
+    const resolveCredential = vi.fn().mockResolvedValue(null);
+    const getByName = vi.fn(() => ({ resolveCredential }));
+    const redemptions = {
+      kilo: vi.fn().mockResolvedValue({
+        success: true,
+        authorization: REDEEMED_KILO_AUTHORIZATION,
+        routeClass: 'backend_api',
+      }),
+      github: vi.fn().mockResolvedValue({
+        success: true,
+        authorization: REDEEMED_GIT_AUTHORIZATION,
+      }),
+      gitlab: vi.fn().mockResolvedValue({
+        success: true,
+        headers: { authorization: REDEEMED_GITLAB_AUTHORIZATION },
+      }),
+      bitbucket: vi.fn().mockResolvedValue({
+        success: true,
+        headers: { authorization: basicCredential('upstream-token', 'Basic', 'x-token-auth') },
+      }),
+    };
+    const scopedFetch = vi.fn(async (_request: Request) => new Response('scoped'));
+    const env: Cloudflare.Env = {
+      ...createEnv(
+        redemptions.github,
+        redemptions.gitlab,
+        redemptions.kilo,
+        undefined,
+        scopedFetch
+      ),
+      GIT_TOKEN_SERVICE: {
+        redeemGitHubSessionCapability: redemptions.github,
+        redeemGitLabSessionCapability: redemptions.gitlab,
+        redeemKiloSessionCapability: redemptions.kilo,
+        redeemBitbucketSessionCapability: redemptions.bitbucket,
+      } as never,
+      SANDBOX_CONTROL: { getByName } as never,
+    };
+    const forward = vi.fn(async (_request: Request) => new Response('forwarded'));
+    vi.stubGlobal('fetch', forward);
+    return { env, resolveCredential, getByName, redemptions, forward, scopedFetch };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.unstubAllGlobals();
+  });
+
+  it.each([
+    { purpose: 'kilo', scheme: 'Bearer', username: undefined },
+    { purpose: 'kilo', scheme: 'token', username: undefined },
+    { purpose: 'github', scheme: 'bEaReR', username: undefined },
+    { purpose: 'github', scheme: 'ToKeN', username: undefined },
+    { purpose: 'github', scheme: 'bAsIc', username: 'x-access-token' },
+    { purpose: 'gitlab', scheme: 'Bearer', username: undefined },
+    { purpose: 'gitlab', scheme: 'Basic', username: 'oauth2' },
+    { purpose: 'bitbucket', scheme: 'Bearer', username: undefined },
+    { purpose: 'bitbucket', scheme: 'token', username: undefined },
+    { purpose: 'bitbucket', scheme: 'Basic', username: 'x-token-auth' },
+  ] as const)(
+    'resolves $purpose aliases carried by $scheme and redeems exactly once',
+    async ({ purpose, scheme, username }) => {
+      const { env, resolveCredential, getByName, redemptions, forward } = fixture();
+      const credential = createControlPlaneCredential('sbx_1', purpose);
+      resolveCredential.mockResolvedValue({ credential: capabilities[purpose] });
+      const authorization = username
+        ? basicCredential(credential, `${scheme}\t `, username)
+        : `${scheme}\t ${credential}`;
+      const request = new Request('https://example.test:8443/managed/resource?key=query-secret', {
+        method: 'POST',
+        headers: { Authorization: authorization, Host: 'guest-supplied.invalid' },
+        body: 'request-body',
+      });
+
+      const response = await handleOutbound(request, env);
+
+      expect(response.status).toBe(200);
+      expect(getByName).toHaveBeenCalledExactlyOnceWith('sbx_1');
+      expect(resolveCredential).toHaveBeenCalledExactlyOnceWith({
+        credential,
+        outboundContainerId: OUTBOUND_CONTEXT.containerId,
+        url: request.url,
+        method: request.method,
+      });
+      expect(redemptions[purpose]).toHaveBeenCalledExactlyOnceWith({
+        capability: capabilities[purpose],
+        outboundContainerId: OUTBOUND_CONTEXT.containerId,
+        requestUrl: request.url,
+        requestMethod: request.method,
+        ...(purpose === 'kilo'
+          ? { bootstrapKiloSessionId: undefined, sessionIngestProxyVersion: 1 }
+          : {}),
+      });
+      for (const [provider, redeem] of Object.entries(redemptions)) {
+        if (provider !== purpose) expect(redeem).not.toHaveBeenCalled();
+      }
+      expect(forward).toHaveBeenCalledOnce();
+      const forwarded = forward.mock.calls[0]?.[0];
+      expect(forwarded?.headers.get('Authorization')).not.toContain(credential);
+      expect(forwarded?.headers.get('Authorization')).not.toContain(capabilities[purpose]);
+      expect(forwarded?.headers.get('Host')).toBe('example.test:8443');
+      expect(forwarded?.redirect).toBe('manual');
+      expect(await forwarded?.text()).toBe('request-body');
+      expect(request.headers.get('Authorization')).toBe(authorization);
+      const logs = serializedLogCalls();
+      expect(logs).not.toContain(credential);
+      expect(logs).not.toContain(capabilities[purpose]);
+      expect(logs).not.toContain('query-secret');
+      expect(logs).not.toContain('upstream-token');
+    }
+  );
+
+  it.each([false, true])(
+    'resolves GitLab PRIVATE-TOKEN aliases once with duplicate bearer=%s',
+    async duplicate => {
+      const { env, resolveCredential, redemptions, forward } = fixture();
+      const credential = createControlPlaneCredential('sbx_1', 'gitlab');
+      resolveCredential.mockResolvedValue({ credential: GITLAB_CAPABILITY });
+      const headers = new Headers({ 'PRIVATE-TOKEN': credential });
+      if (duplicate) headers.set('Authorization', `Bearer ${credential}`);
+
+      const response = await handleOutbound(
+        new Request('https://gitlab.com/api/v4/projects/1/merge_requests', { headers }),
+        env
+      );
+
+      expect(response.status).toBe(200);
+      expect(resolveCredential).toHaveBeenCalledOnce();
+      expect(redemptions.gitlab).toHaveBeenCalledOnce();
+      expect(forward.mock.calls[0]?.[0].headers.get('PRIVATE-TOKEN')).toBeNull();
+      expect(forward.mock.calls[0]?.[0].headers.get('Authorization')).toBe(
+        REDEEMED_GITLAB_AUTHORIZATION
+      );
+    }
+  );
+
+  it.each(['trusted-organization', '', undefined])(
+    'overrides guest organization and Host headers using trusted Kilo scope',
+    async organizationId => {
+      const { env, resolveCredential, forward } = fixture();
+      resolveCredential.mockResolvedValue({ credential: KILO_CAPABILITY, organizationId });
+      const credential = createControlPlaneCredential('sbx_1', 'kilo');
+
+      await handleOutbound(
+        new Request('https://api.kilo.ai/api/openrouter/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${credential}`,
+            'x-kilocode-organizationid': 'forged-organization',
+            Host: 'guest-supplied.invalid',
+          },
+          body: '{}',
+        }),
+        env
+      );
+
+      const forwarded = forward.mock.calls[0]?.[0];
+      expect(forwarded?.headers.get('x-kilocode-organizationid')).toBe(organizationId ?? '');
+      expect(forwarded?.headers.get('Host')).toBe('api.kilo.ai');
+    }
+  );
+
+  it('uses the request-specific capability for multiple Kilo roots in one sandbox', async () => {
+    const { env, resolveCredential, redemptions, forward, scopedFetch, getByName } = fixture();
+    const credential = createControlPlaneCredential('sbx_1', 'kilo');
+    const roots = ['ses_12345678901234567890123456', 'ses_abcdefghijklmnopqrstuvwxyz'];
+    for (const [index, root] of roots.entries()) {
+      resolveCredential.mockResolvedValueOnce({
+        credential: `kka1.root-${index}`,
+        organizationId: 'trusted-organization',
+      });
+      redemptions.kilo.mockResolvedValueOnce({
+        success: true,
+        authorization: REDEEMED_KILO_AUTHORIZATION,
+        routeClass: 'session_ingest',
+        sessionIngestScope: { cloudAgentSessionId: 'workspace_1', rootKiloSessionId: root },
+      });
+      await handleOutbound(
+        new Request(`https://ingest.kilosessions.ai/api/session/${root}/ingest`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${credential}`,
+            'X-Kilo-Root-Session': 'forged-root',
+            'x-kilocode-organizationid': 'forged-organization',
+            Host: 'guest-supplied.invalid',
+          },
+          body: '{}',
+        }),
+        env
+      );
+    }
+
+    expect(resolveCredential).toHaveBeenCalledTimes(2);
+    expect(resolveCredential.mock.calls.map(([input]) => input.credential)).toEqual([
+      credential,
+      credential,
+    ]);
+    expect(getByName.mock.calls).toEqual([['sbx_1'], ['sbx_1']]);
+    expect(redemptions.kilo.mock.calls.map(([input]) => input.capability)).toEqual([
+      'kka1.root-0',
+      'kka1.root-1',
+    ]);
+    expect(
+      scopedFetch.mock.calls.map(([request]) => request.headers.get('X-Kilo-Root-Session'))
+    ).toEqual(roots);
+    for (const [request] of scopedFetch.mock.calls) {
+      expect(request.headers.get('Host')).toBe('ingest.kilosessions.ai');
+      expect(request.headers.get('x-kilocode-organizationid')).toBe('trusted-organization');
+    }
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'kcp1',
+    'kcp1.',
+    'kcp1-invalid',
+    'kcp1.invalid',
+    `kcp1.YR.github.${'a'.repeat(64)}`,
+    `kcp1.${Buffer.from('../other').toString('base64url')}.github.${'a'.repeat(64)}`,
+    `kcp1.${'x'.repeat(10_000)}`,
+  ])('never forwards malformed aliases in supported carriers', async credential => {
+    const { env, resolveCredential, getByName, redemptions, forward } = fixture();
+    const carriers: HeadersInit[] = [
+      { Authorization: `Bearer ${credential}` },
+      { Authorization: `token ${credential}` },
+      { Authorization: basicCredential(credential) },
+      { 'PRIVATE-TOKEN': credential },
+    ];
+    for (const headers of carriers) {
+      const response = await handleOutbound(new Request('https://example.test/', { headers }), env);
+      expect(response.status).toBe(502);
+      expect(await response.text()).toBe('SCM authorization unavailable');
+    }
+    expect(getByName).not.toHaveBeenCalled();
+    expect(resolveCredential).not.toHaveBeenCalled();
+    for (const redeem of Object.values(redemptions)) expect(redeem).not.toHaveBeenCalled();
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it('rejects noncanonical Basic aliases and aliases in the Basic username', async () => {
+    const { env, resolveCredential, forward } = fixture();
+    const credential = createControlPlaneCredential('sbx_12', 'github');
+    const authorization = basicCredential(credential);
+    for (const value of [
+      `${authorization}!`,
+      authorization.replace(/=+$/, ''),
+      basicCredential('unused', 'Basic', credential),
+      `Basic ${Buffer.from(credential).toString('base64')}`,
+    ]) {
+      const response = await handleOutbound(
+        new Request('https://example.test/', { headers: { Authorization: value } }),
+        env
+      );
+      expect(response.status).toBe(502);
+    }
+    expect(resolveCredential).not.toHaveBeenCalled();
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it('rejects unsupported or conflicting alias carriers before resolution', async () => {
+    const { env, resolveCredential, forward } = fixture();
+    const github = createControlPlaneCredential('sbx_1', 'github');
+    const gitlab = createControlPlaneCredential('sbx_1', 'gitlab');
+    const carriers: HeadersInit[] = [
+      { Authorization: basicCredential(github, 'Basic', 'oauth2') },
+      { Authorization: `token ${gitlab}` },
+      { 'PRIVATE-TOKEN': github },
+      { Authorization: `Bearer ${github}`, 'PRIVATE-TOKEN': gitlab },
+      {
+        Authorization: `Bearer ${gitlab}`,
+        'PRIVATE-TOKEN': createControlPlaneCredential('sbx_1', 'gitlab'),
+      },
+      { Authorization: `Bearer ${gitlab}`, 'PRIVATE-TOKEN': GITLAB_CAPABILITY },
+    ];
+    for (const headers of carriers) {
+      const response = await handleOutbound(new Request('https://example.test/', { headers }), env);
+      expect(response.status).toBe(502);
+    }
+    expect(resolveCredential).not.toHaveBeenCalled();
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it.each(['kilo', 'github', 'gitlab', 'bitbucket'] as const)(
+    'rejects raw, recursive, legacy, malformed, and cross-purpose %s resolution results',
+    async purpose => {
+      const { env, resolveCredential, redemptions, forward } = fixture();
+      const credential = createControlPlaneCredential('sbx_1', purpose);
+      const otherCapabilities = Object.entries(capabilities)
+        .filter(([provider]) => provider !== purpose)
+        .map(([, capability]) => ({ credential: capability }));
+      for (const resolved of [
+        null,
+        undefined,
+        'raw-upstream-token',
+        {},
+        { credential: null },
+        { credential: 'raw-upstream-token' },
+        { credential: 'Bearer raw-upstream-token' },
+        { credential },
+        { credential: 'kgh1.legacy' },
+        { credential: 'kgl1.legacy' },
+        { credential: 'kka2.future' },
+        { credential: capabilities[purpose], organizationId: 42 },
+        { credential: capabilities[purpose].slice(0, 5) },
+        { credential: `${capabilities[purpose]} secret` },
+        ...otherCapabilities,
+      ]) {
+        resolveCredential.mockResolvedValue(resolved);
+        const response = await handleOutbound(
+          new Request('https://example.test/', {
+            headers: { Authorization: `Bearer ${credential}` },
+          }),
+          env
+        );
+        expect(response.status).toBe(502);
+        expect(await response.text()).toBe('SCM authorization unavailable');
+      }
+      for (const redeem of Object.values(redemptions)) expect(redeem).not.toHaveBeenCalled();
+      expect(forward).not.toHaveBeenCalled();
+    }
+  );
+
+  it('fails closed when the control namespace or resolution RPC is unavailable', async () => {
+    const { env, resolveCredential, getByName, forward } = fixture();
+    const credential = createControlPlaneCredential('sbx_1', 'kilo');
+    for (const control of [undefined, {}, { getByName: () => ({}) }]) {
+      const response = await handleOutbound(
+        new Request('https://api.kilo.ai/api/users/me', {
+          headers: { Authorization: `Bearer ${credential}` },
+        }),
+        { ...env, SANDBOX_CONTROL: control } as never
+      );
+      expect(response.status).toBe(502);
+      expect(await response.text()).toBe('SCM authorization unavailable');
+    }
+    expect(getByName).not.toHaveBeenCalled();
+    expect(resolveCredential).not.toHaveBeenCalled();
+    expect(forward).not.toHaveBeenCalled();
+  });
+
+  it.each(['lookup', 'resolution', 'retry-exhausted'] as const)(
+    'fails closed and sanitizes %s errors before retry diagnostics',
+    async failure => {
+      const { env, resolveCredential, getByName, redemptions, forward } = fixture();
+      const credential = createControlPlaneCredential('sbx_1', 'kilo');
+      const error = Object.assign(new Error(`sensitive-error ${credential} upstream-secret`), {
+        retryable: failure === 'retry-exhausted',
+      });
+      vi.stubGlobal('scheduler', { wait: vi.fn().mockResolvedValue(undefined) });
+      if (failure === 'lookup')
+        getByName.mockImplementation(() => {
+          throw error;
+        });
+      else resolveCredential.mockRejectedValue(error);
+
+      const response = await handleOutbound(
+        new Request('https://api.kilo.ai/api/users/me', {
+          headers: { Authorization: `Bearer ${credential}` },
+        }),
+        env
+      );
+
+      expect(response.status).toBe(502);
+      expect(await response.text()).toBe('SCM authorization unavailable');
+      expect(getByName).toHaveBeenCalledTimes(failure === 'retry-exhausted' ? 3 : 1);
+      for (const redeem of Object.values(redemptions)) expect(redeem).not.toHaveBeenCalled();
+      expect(forward).not.toHaveBeenCalled();
+      const logs = serializedLogCalls();
+      expect(logs).not.toContain(credential);
+      expect(logs).not.toContain('upstream-secret');
+      expect(logs).not.toContain('sensitive-error');
+    }
+  );
+
+  it('retries resolution using a fresh stub without duplicating broker redemption', async () => {
+    const { env, resolveCredential, getByName, redemptions, forward } = fixture();
+    const credential = createControlPlaneCredential('sbx_1', 'kilo');
+    vi.stubGlobal('scheduler', { wait: vi.fn().mockResolvedValue(undefined) });
+    resolveCredential
+      .mockRejectedValueOnce(Object.assign(new Error(credential), { retryable: true }))
+      .mockResolvedValueOnce({ credential: KILO_CAPABILITY });
+
+    const response = await handleOutbound(
+      new Request('https://api.kilo.ai/api/users/me', {
+        headers: { Authorization: `Bearer ${credential}` },
+      }),
+      env
+    );
+
+    expect(response.status).toBe(200);
+    expect(getByName).toHaveBeenCalledTimes(2);
+    expect(resolveCredential).toHaveBeenCalledTimes(2);
+    expect(redemptions.kilo).toHaveBeenCalledOnce();
+    expect(forward).toHaveBeenCalledOnce();
+    expect(serializedLogCalls()).not.toContain(credential);
+  });
+
+  it('does not bypass the existing broker when a resolved capability is rejected', async () => {
+    const { env, resolveCredential, redemptions, forward } = fixture();
+    const credential = createControlPlaneCredential('sbx_1', 'kilo');
+    resolveCredential.mockResolvedValue({ credential: KILO_CAPABILITY });
+    redemptions.kilo.mockResolvedValue({ success: false, reason: 'upstream_not_allowed' });
+
+    const response = await handleOutbound(
+      new Request('https://untrusted.test/', {
+        headers: { Authorization: `Bearer ${credential}` },
+      }),
+      env
+    );
+
+    expect(response.status).toBe(502);
+    expect(resolveCredential).toHaveBeenCalledOnce();
+    expect(redemptions.kilo).toHaveBeenCalledOnce();
+    expect(forward).not.toHaveBeenCalled();
   });
 });

--- a/services/cloud-agent-next/src/sandbox-outbound.ts
+++ b/services/cloud-agent-next/src/sandbox-outbound.ts
@@ -1,7 +1,14 @@
 import { Buffer } from 'node:buffer';
 import { ContainerProxy } from '@cloudflare/sandbox';
+import { z } from 'zod';
 import { logger } from './logger.js';
 import { MANAGED_SCM_OUTBOUND_HANDLER } from './sandbox-id.js';
+import {
+  isControlPlaneCredential,
+  parseControlPlaneCredential,
+  type ControlCredentialPurpose,
+} from './sandbox-control/managed-credential.js';
+import { withDORetry } from './utils/do-retry.js';
 import type { GitTokenService } from './types.js';
 import { MeteredSandbox } from './container-usage.js';
 import type { SandboxClassName } from './container-usage-context.js';
@@ -17,6 +24,28 @@ const GITLAB_CAPABILITY_PREFIXES = ['kgl1.', 'kgl2.'];
 const KILO_CAPABILITY_PREFIXES = ['kka1.'];
 const BITBUCKET_CAPABILITY_PREFIXES = ['kbb1.'];
 const MAX_KILO_SESSION_BOOTSTRAP_BYTES = 16_000;
+const CONTROL_CREDENTIAL_CAPABILITY_PREFIXES = {
+  kilo: 'kka1.',
+  github: 'kgh2.',
+  gitlab: 'kgl2.',
+  bitbucket: 'kbb1.',
+} satisfies Record<ControlCredentialPurpose, string>;
+
+const resolvedControlCredentialSchema = z
+  .object({
+    credential: z.string().min(1),
+    organizationId: z.string().optional(),
+  })
+  .strict();
+
+type ControlCredentialResolutionBinding = {
+  resolveCredential(input: {
+    credential: string;
+    outboundContainerId: string;
+    url: string;
+    method: string;
+  }): Promise<unknown>;
+};
 
 type GitHubTokenRedemptionBinding = Pick<GitTokenService, 'redeemGitHubSessionCapability'>;
 type GitLabTokenRedemptionBinding = Pick<GitTokenService, 'redeemGitLabSessionCapability'>;
@@ -275,6 +304,12 @@ function supportsBitbucketSessionCapabilityRedemption(
 }
 
 function classifyCapability(capability: string): AuthorizationExtraction {
+  if (isControlPlaneCredential(capability)) {
+    const parsed = parseControlPlaneCredential(capability);
+    return parsed
+      ? { type: 'capability', value: { provider: parsed.purpose, capability } }
+      : { type: 'unsupported_capability' };
+  }
   if (GITHUB_CAPABILITY_PREFIXES.some(prefix => capability.startsWith(prefix))) {
     return { type: 'capability', value: { provider: 'github', capability } };
   }
@@ -292,29 +327,49 @@ function classifyCapability(capability: string): AuthorizationExtraction {
     : NO_AUTHORIZATION_CAPABILITY;
 }
 
-function extractGitCapability(authorization: string | null): AuthorizationExtraction {
-  if (!authorization) return NO_AUTHORIZATION_CAPABILITY;
-  const match = /^Basic[ \t]+(.+)$/i.exec(authorization);
-  if (!match) return NO_AUTHORIZATION_CAPABILITY;
-  const encodedCredential = match[1];
-  if (!encodedCredential) return NO_AUTHORIZATION_CAPABILITY;
-  if (!/^[A-Za-z0-9+/]+={0,2}$/.test(encodedCredential)) return NO_AUTHORIZATION_CAPABILITY;
+function parseGitAuthorization(authorization: string | null): {
+  prefix: string;
+  username: string;
+  password: string;
+  canonical: boolean;
+} | null {
+  if (!authorization) return null;
+  const match = /^(Basic[ \t]+)(.+)$/i.exec(authorization);
+  if (!match) return null;
+  const encodedCredential = match[2];
   const decodedCredential = Buffer.from(encodedCredential, 'base64');
-  if (decodedCredential.toString('base64') !== encodedCredential)
-    return NO_AUTHORIZATION_CAPABILITY;
   const credential = decodedCredential.toString('utf8');
   const separator = credential.indexOf(':');
-  if (separator === -1) return NO_AUTHORIZATION_CAPABILITY;
-  const username = credential.slice(0, separator);
-  const extraction = classifyCapability(credential.slice(separator + 1));
+  return {
+    prefix: match[1],
+    username: separator === -1 ? credential : credential.slice(0, separator),
+    password: separator === -1 ? '' : credential.slice(separator + 1),
+    canonical:
+      separator !== -1 &&
+      /^[A-Za-z0-9+/]+={0,2}$/.test(encodedCredential) &&
+      decodedCredential.toString('base64') === encodedCredential,
+  };
+}
+
+function extractGitCapability(authorization: string | null): AuthorizationExtraction {
+  const git = parseGitAuthorization(authorization);
+  if (!git) return NO_AUTHORIZATION_CAPABILITY;
+  if (
+    isControlPlaneCredential(git.username) ||
+    (!git.canonical && isControlPlaneCredential(git.password))
+  ) {
+    return { type: 'unsupported_capability' };
+  }
+  if (!git.canonical) return NO_AUTHORIZATION_CAPABILITY;
+  const extraction = classifyCapability(git.password);
   if (extraction.type !== 'capability') return extraction;
-  if (username === 'x-access-token' && extraction.value.provider === 'github') {
+  if (git.username === 'x-access-token' && extraction.value.provider === 'github') {
     return extraction;
   }
-  if (username === 'oauth2' && extraction.value.provider === 'gitlab') {
+  if (git.username === 'oauth2' && extraction.value.provider === 'gitlab') {
     return extraction;
   }
-  if (username === 'x-token-auth' && extraction.value.provider === 'bitbucket') {
+  if (git.username === 'x-token-auth' && extraction.value.provider === 'bitbucket') {
     return extraction;
   }
   return { type: 'unsupported_capability' };
@@ -777,6 +832,99 @@ async function handleManagedBitbucketOutbound(
   return response;
 }
 
+function supportsControlCredentialResolution(
+  service: unknown
+): service is ControlCredentialResolutionBinding {
+  return (
+    typeof service === 'object' &&
+    service !== null &&
+    'resolveCredential' in service &&
+    typeof service.resolveCredential === 'function'
+  );
+}
+
+function sanitizedCredentialResolutionError(error: unknown): Error {
+  return Object.assign(new Error('Control-plane authorization unavailable'), {
+    retryable: error instanceof Error && 'retryable' in error && error.retryable === true,
+  });
+}
+
+async function handleControlPlaneOutbound(
+  request: Request,
+  env: Cloudflare.Env,
+  capability: RedeemableAuthorization,
+  ctx: ManagedScmOutboundContext
+): Promise<Response> {
+  const parsed = parseControlPlaneCredential(capability.capability);
+  const namespace = env.SANDBOX_CONTROL;
+  if (!parsed || !namespace) {
+    return new Response('SCM authorization unavailable', { status: 502 });
+  }
+
+  try {
+    const resolved = resolvedControlCredentialSchema.safeParse(
+      await withDORetry(
+        () => {
+          try {
+            return namespace.getByName(parsed.sandboxId);
+          } catch (error) {
+            throw sanitizedCredentialResolutionError(error);
+          }
+        },
+        async stub => {
+          try {
+            if (!supportsControlCredentialResolution(stub)) return null;
+            return await stub.resolveCredential({
+              credential: capability.capability,
+              outboundContainerId: ctx.containerId,
+              url: request.url,
+              method: request.method,
+            });
+          } catch (error) {
+            throw sanitizedCredentialResolutionError(error);
+          }
+        },
+        'resolveControlPlaneCredential'
+      )
+    );
+    if (!resolved.success) {
+      return new Response('SCM authorization unavailable', { status: 502 });
+    }
+    const { credential, organizationId } = resolved.data;
+    const expectedPrefix = CONTROL_CREDENTIAL_CAPABILITY_PREFIXES[parsed.purpose];
+    if (
+      !credential.startsWith(expectedPrefix) ||
+      credential.length === expectedPrefix.length ||
+      /\s/.test(credential)
+    ) {
+      return new Response('SCM authorization unavailable', { status: 502 });
+    }
+
+    const headers = new Headers(request.headers);
+    const authorization = headers.get('Authorization');
+    const git = parseGitAuthorization(authorization);
+    const api = /^((?:token|Bearer)[ \t]+)(.+)$/i.exec(authorization ?? '');
+    if (git?.canonical && git.password === capability.capability) {
+      headers.set(
+        'Authorization',
+        `${git.prefix}${Buffer.from(`${git.username}:${credential}`).toString('base64')}`
+      );
+    } else if (api?.[2] === capability.capability) {
+      headers.set('Authorization', `${api[1]}${credential}`);
+    }
+    if (headers.get('PRIVATE-TOKEN')?.trim() === capability.capability) {
+      headers.set('PRIVATE-TOKEN', credential);
+    }
+    if (parsed.purpose === 'kilo') {
+      headers.set('x-kilocode-organizationid', organizationId ?? '');
+    }
+    headers.set('Host', new URL(request.url).host);
+    return await handleManagedScmOutbound(new Request(request, { headers }), env, ctx);
+  } catch {
+    return new Response('SCM authorization unavailable', { status: 502 });
+  }
+}
+
 export function handleManagedScmOutbound(
   request: Request,
   env: Cloudflare.Env,
@@ -829,6 +977,9 @@ export function handleManagedScmOutbound(
   }
   const capability = authorizationCapability ?? gitLabPrivateTokenCapability;
   if (!capability) return fetch(request);
+  if (isControlPlaneCredential(capability.capability)) {
+    return handleControlPlaneOutbound(request, env, capability, ctx);
+  }
   if (capability.provider === 'github') {
     return handleManagedGitHubOutbound(request, env, capability, ctx.containerId);
   }

--- a/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
+++ b/services/cloud-agent-next/src/sandbox-session/SandboxSession.ts
@@ -10,7 +10,6 @@ import { migrate } from 'drizzle-orm/durable-sqlite/migrator';
 import migrations from '../../drizzle/migrations';
 import type { Env } from '../types.js';
 import type { SessionId } from '../types/ids.js';
-import type { SessionMetadata } from '../persistence/session-metadata.js';
 import { dispatchedKilocodeModelId } from '../persistence/model-utils.js';
 import { nextMetadataAfterAdmittedAgentModel } from '../persistence/persist-admitted-agent-model.js';
 import { assertKiloModelAvailable } from '../model-validation.js';
@@ -18,6 +17,7 @@ import {
   getSandboxProvider,
   parseSessionMetadata,
   serializeSessionMetadata,
+  type SessionMetadata,
 } from '../persistence/session-metadata.js';
 import type { OperationResult } from '../persistence/types.js';
 import type { CallbackTarget } from '../callbacks/index.js';
@@ -51,11 +51,7 @@ import { logger } from '../logger.js';
 import { sandboxControlRpc } from './control-rpc.js';
 import { DEADLINE_MS } from '../sandbox-control/deadlines.js';
 import { createMessageId } from '../session/message-id.js';
-import {
-  buildSessionAttachPayload,
-  fillAttachGitToken,
-  validateControlSessionOptions,
-} from './attach-payload.js';
+import { validateControlSessionOptions } from './attach-payload.js';
 import { createPreparationProgressRecorder } from '../session/preparation-progress.js';
 import {
   finalizeOtherRunningAttemptsForMessage,
@@ -399,6 +395,10 @@ export class SandboxSession extends DurableObject<Env> {
 
   async getMetadata(): Promise<SessionMetadata | null> {
     return this.terminalLifecycle.isDeleted() ? null : this.terminalLifecycle.getStoredMetadata();
+  }
+
+  async getCredentialMetadata(): Promise<SessionMetadata | null> {
+    return this.terminalLifecycle.isBlocked() ? null : this.terminalLifecycle.getStoredMetadata();
   }
 
   async validateKiloGlobalFeedProducer(_params: {
@@ -1035,6 +1035,7 @@ export class SandboxSession extends DurableObject<Env> {
       return;
     }
     let phase: DispatchPhase = 'preparing';
+    let credentialsPrepared = false;
     try {
       validateControlSessionOptions(metadata);
       const session = { sessionId, kiloSessionId, directory: this.directory(metadata) };
@@ -1051,11 +1052,13 @@ export class SandboxSession extends DurableObject<Env> {
             )
           : [];
       if (!isCurrent()) return;
-      const ensureReady = () =>
-        wait(
+      const ensureReady = () => {
+        credentialsPrepared = true;
+        return wait(
           () =>
             control.ensureReady({
               ownerId: metadata.identity.userId,
+              sessionId,
               provider,
               ...(acquisition ? { acquisition } : { allowCreate }),
               billing: buildSandboxBillingInput(
@@ -1063,15 +1066,19 @@ export class SandboxSession extends DurableObject<Env> {
                 sandboxId,
                 isCloudAgentContainerBillingEnabled(this.env, metadata.identity)
               ),
-              ...(metadata.auth.kilocodeToken ? { kiloToken: metadata.auth.kilocodeToken } : {}),
             }),
           DEADLINE_MS.startup
         );
+      };
       if (!this.terminalLifecycle.getAttachedWrapperInstanceId()) {
         recorder.onProgress('workspace_setup', 'Preparing environment…');
       }
       let status = await ensureReady();
-      if (!isCurrent()) return;
+      if (!isCurrent()) {
+        if (!this.terminalLifecycle.isCurrent(epoch))
+          await this.compensateSessionAttachment(metadata);
+        return;
+      }
       recordRuntime(status.wrapperInstanceId);
       const stoppingDeadline = Math.min(deadlineAt, Date.now() + DEADLINE_MS.startup);
       while (allowCreate && status.physical === 'stopping') {
@@ -1091,7 +1098,11 @@ export class SandboxSession extends DurableObject<Env> {
         const provision = provisionPreparingStep(observed.physical, allowCreate);
         if (provision) recorder.onProgress(provision.step, provision.message);
         status = await ensureReady();
-        if (!isCurrent()) return;
+        if (!isCurrent()) {
+          if (!this.terminalLifecycle.isCurrent(epoch))
+            await this.compensateSessionAttachment(metadata);
+          return;
+        }
         recordRuntime(status.wrapperInstanceId);
       }
       const boot = bootPreparingStep(status.physical, status.connection);
@@ -1108,20 +1119,18 @@ export class SandboxSession extends DurableObject<Env> {
       if (!wrapperInstanceId) throw new Error('Wrapper identity is missing');
       if (this.terminalLifecycle.getAttachedWrapperInstanceId() !== wrapperInstanceId) {
         recorder.onProgress('workspace_setup', 'Setting up workspace…');
-        const attachPayload = await wait(() =>
-          fillAttachGitToken(
-            metadata,
-            buildSessionAttachPayload(metadata, {
-              attemptId: recorder.attemptId,
-              triggerMessageId: messageId,
-            }),
-            this.env
-          )
-        );
-        if (!isCurrent()) return;
+        if (!status.attachment?.kilo)
+          throw new Error('Contained session attachment is unavailable');
+        const attachPayload = {
+          ...status.attachment,
+          preparation: { attemptId: recorder.attemptId, triggerMessageId: messageId },
+        };
         phase = 'attach';
         await wait(() =>
           control.attachSession({
+            ...(metadata.workspace?.worktreeId
+              ? { worktreeId: metadata.workspace.worktreeId }
+              : {}),
             sessionId,
             kiloSessionId,
             directory: session.directory,
@@ -1204,7 +1213,10 @@ export class SandboxSession extends DurableObject<Env> {
       await this.armQueueRetry(Date.now() + DEADLINE_MS.acceptedAlarmCap);
     } catch (error) {
       if (!isCurrent()) {
-        if (phase !== 'preparing' && !this.terminalLifecycle.isCurrent(epoch)) {
+        if (
+          (credentialsPrepared || phase !== 'preparing') &&
+          !this.terminalLifecycle.isCurrent(epoch)
+        ) {
           await this.compensateSessionAttachment(metadata);
         }
         return;

--- a/services/cloud-agent-next/src/sandbox-session/attach-payload.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/attach-payload.test.ts
@@ -1,8 +1,8 @@
-import { describe, expect, it, vi } from 'vitest';
+import { describe, expect, it } from 'vitest';
 import { parseSessionMetadata } from '../persistence/session-metadata.js';
 import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../shared/runtime-environment.js';
 import { envVarsSchema } from '../types.js';
-import { buildSessionAttachPayload, fillAttachGitToken } from './attach-payload.js';
+import { buildSessionAttachPayload } from './attach-payload.js';
 
 describe('buildSessionAttachPayload', () => {
   it('packs directory, git clone, branch, snapshot identity, and session env', () => {
@@ -109,33 +109,4 @@ describe('buildSessionAttachPayload', () => {
       );
     });
   }
-
-  it('fills a GitHub token from git-token-service when metadata has none', async () => {
-    const metadata = parseSessionMetadata({
-      metadataSchemaVersion: 2,
-      identity: {
-        sessionId: 'workspace_aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa',
-        userId: 'user-1',
-      },
-      auth: { kiloSessionId: 'kilo_1' },
-      agent: { mode: 'code', model: 'kilo/test' },
-      repository: { type: 'github', repo: 'acme/demo' },
-      workspace: { workspacePath: '/workspace/a' },
-      lifecycle: { version: 1, timestamp: 1 },
-    });
-    const payload = buildSessionAttachPayload(metadata);
-    expect(payload.git?.token).toBeUndefined();
-    const filled = await fillAttachGitToken(metadata, payload, {
-      GIT_TOKEN_SERVICE: {
-        getTokenForRepo: vi.fn().mockResolvedValue({
-          success: true,
-          token: 'ghs_resolved',
-          installationId: '1',
-          appType: 'standard',
-          accountLogin: 'acme',
-        }),
-      } as never,
-    });
-    expect(filled.git?.token).toBe('ghs_resolved');
-  });
 });

--- a/services/cloud-agent-next/src/sandbox-session/attach-payload.ts
+++ b/services/cloud-agent-next/src/sandbox-session/attach-payload.ts
@@ -1,9 +1,7 @@
 import type { SessionMetadata } from '../persistence/session-metadata.js';
 import type { SessionAttachPayload } from '../shared/sandbox-control-protocol.js';
 import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../shared/runtime-environment.js';
-import { resolveGitHubTokenForRepo } from '../services/git-token-service-client.js';
 import { readProfileBundle } from '../session-profile.js';
-import type { GitTokenService } from '../types.js';
 import { getSessionWorkspacePath } from '../workspace.js';
 
 function rejectReservedControlRuntimeEnvironment(
@@ -21,14 +19,6 @@ export function validateControlSessionOptions(metadata: Pick<SessionMetadata, 'p
   const profile = readProfileBundle(metadata);
   rejectReservedControlRuntimeEnvironment(profile.envVars);
   rejectReservedControlRuntimeEnvironment(profile.encryptedSecrets);
-  if (
-    Object.keys(profile.envVars ?? {}).length ||
-    Object.keys(profile.encryptedSecrets ?? {}).length
-  ) {
-    throw new Error(
-      'Custom profile environment variables and secrets are not supported by control-plane sessions'
-    );
-  }
 }
 
 function gitFromMetadata(
@@ -85,21 +75,4 @@ export function buildSessionAttachPayload(
     ...(profile.setupCommands?.length ? { setupCommands: profile.setupCommands } : {}),
     ...(preparation ? { preparation } : {}),
   };
-}
-
-export async function fillAttachGitToken(
-  metadata: SessionMetadata,
-  payload: SessionAttachPayload,
-  env: { GIT_TOKEN_SERVICE?: GitTokenService }
-): Promise<SessionAttachPayload> {
-  if (!payload.git || payload.git.token) return payload;
-  const repository = metadata.repository;
-  if (repository?.type !== 'github') return payload;
-  const resolved = await resolveGitHubTokenForRepo(env, {
-    githubRepo: repository.repo,
-    userId: metadata.identity.userId,
-    ...(metadata.identity.orgId ? { orgId: metadata.identity.orgId } : {}),
-  });
-  if (!resolved.success) return payload;
-  return { ...payload, git: { ...payload.git, token: resolved.value.token } };
 }

--- a/services/cloud-agent-next/src/sandbox-session/control-rpc.ts
+++ b/services/cloud-agent-next/src/sandbox-session/control-rpc.ts
@@ -1,4 +1,6 @@
-import type { ResponseFrame } from '../shared/sandbox-control-protocol.js';
+import type { VercelSandboxNetworkPolicy } from '../agent-sandbox/vercel/vercel-sandbox-rest-client.js';
+import type { CredentialContainmentRequirements } from '../sandbox-control/physical-lifecycle.js';
+import type { ResponseFrame, SessionAttachPayload } from '../shared/sandbox-control-protocol.js';
 import type { SandboxControlOutboundRequest } from '../sandbox-control/socket.js';
 import type { AttachRouteInput } from '../sandbox-control/session-routes.js';
 import type { ConnectionState, PhysicalState } from '../sandbox-control/status-projection.js';
@@ -11,10 +13,14 @@ import type { SandboxAcquisition } from '../persistence/SandboxControl.js';
 import type { SandboxBillingInput } from '../container-usage-context.js';
 
 type SandboxControlRpc = {
+  prepareSessionCredentials(input: {
+    ownerId: string;
+    sessionId: string;
+  }): Promise<SessionAttachPayload>;
   ensureReady(input: {
     ownerId: string;
+    sessionId: string;
     provider?: 'cloudflare' | 'vercel';
-    kiloToken?: string;
     allowCreate?: boolean;
     acquisition?: SandboxAcquisition;
     billing?: SandboxBillingInput;
@@ -22,6 +28,7 @@ type SandboxControlRpc = {
     connection: ConnectionState;
     physical: PhysicalState;
     wrapperInstanceId?: string;
+    attachment?: SessionAttachPayload;
   }>;
   getStatus(): Promise<{
     connection: ConnectionState;
@@ -38,6 +45,11 @@ type SandboxControlRpc = {
   detachSession(sessionId: string): Promise<{ existed: boolean }>;
   validateTerminalAccess(input: SandboxTerminalAccessInput): Promise<SandboxTerminalAccessResult>;
   recordTerminalActivity(input: SandboxTerminalAccessInput): Promise<SandboxTerminalAccessResult>;
+  updateNetworkPolicy(input: {
+    ownerId: string;
+    networkPolicy: VercelSandboxNetworkPolicy;
+    requiredContainment: CredentialContainmentRequirements;
+  }): Promise<void>;
   request(input: SandboxControlOutboundRequest): Promise<ResponseFrame>;
 };
 

--- a/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/session-message-queue.test.ts
@@ -18,9 +18,11 @@ import {
   SANDBOX_CONTROL_REQUEST_TIMEOUT_MS,
   sessionPromptPayloadSchema,
   type ResponseFrame,
+  type SessionAttachPayload,
   type SessionMessageOutcome,
 } from '../shared/sandbox-control-protocol.js';
 import { DEADLINE_MS } from '../sandbox-control/deadlines.js';
+import { createControlPlaneCredential } from '../sandbox-control/managed-credential.js';
 import { SESSION_DELIVERY_TIMEOUT_MS } from './control-dispatch.js';
 import type {
   AcceptedCommandTurn,
@@ -737,9 +739,23 @@ const SANDBOX_ID = 'ses-11111111111141118111111111111111';
 const RUNTIME_ID = '22222222-2222-4222-8222-222222222222';
 const NEXT_RUNTIME_ID = '33333333-3333-4333-8333-333333333333';
 const DIRECTORY = '/workspace/session';
+const KILO_CREDENTIAL = createControlPlaneCredential(SANDBOX_ID, 'kilo');
+const ATTACHMENT: SessionAttachPayload = {
+  directory: DIRECTORY,
+  env: { KILOCODE_TOKEN: KILO_CREDENTIAL },
+  kilo: {
+    scopeId: SESSION_ID,
+    token: KILO_CREDENTIAL,
+    targets: {
+      backendBaseUrl: 'https://backend.example.test',
+      providerBaseUrl: 'https://provider.example.test',
+      sessionIngestBaseUrl: 'https://ingest.example.test',
+    },
+  },
+};
 
 type Control = ReturnType<typeof sandboxControlRpc>;
-type ControlStatus = Awaited<ReturnType<Control['getStatus']>>;
+type ControlStatus = Awaited<ReturnType<Control['ensureReady']>>;
 
 function deferred<T>() {
   let resolve: (value: T) => void = () => undefined;
@@ -844,6 +860,7 @@ function sessionFixture(overrides: Partial<SessionMetadata> = {}) {
     ensureReady: vi.fn(
       async (_input: Parameters<Control['ensureReady']>[0]): Promise<ControlStatus> => ({
         ...status,
+        attachment: { ...ATTACHMENT, setupCommands: metadata.profile?.setupCommands },
       })
     ),
     attachSession: vi.fn(async () => ({})),
@@ -853,6 +870,8 @@ function sessionFixture(overrides: Partial<SessionMetadata> = {}) {
     })),
     validateTerminalAccess: vi.fn(async () => ({ allowed: true })),
     recordTerminalActivity: vi.fn(async () => ({ allowed: true })),
+    prepareSessionCredentials: vi.fn(async () => ({})),
+    updateNetworkPolicy: vi.fn(async () => undefined),
     request,
   } satisfies Control;
   const env = {
@@ -1102,6 +1121,7 @@ describe('SandboxSession orchestration', () => {
         physical: 'running',
         connection: 'ready',
         wrapperInstanceId: NEXT_RUNTIME_ID,
+        attachment: ATTACHMENT,
       });
       fixture.setStatus({
         physical: 'running',
@@ -1222,7 +1242,7 @@ describe('SandboxSession orchestration', () => {
         wrapperInstanceId: NEXT_RUNTIME_ID,
       } satisfies ControlStatus;
       fixture.setStatus(ready);
-      return ready;
+      return { ...ready, attachment: ATTACHMENT };
     });
     await fixture.fireAlarm();
     expect(fixture.record('a')).toMatchObject({
@@ -1859,7 +1879,7 @@ describe('SandboxSession orchestration', () => {
         wrapperInstanceId: NEXT_RUNTIME_ID,
       } satisfies ControlStatus;
       fixture.setStatus(ready);
-      return ready;
+      return { ...ready, attachment: ATTACHMENT };
     });
     await fixture.fireAlarm();
     expect(fixture.record('b')).toMatchObject({
@@ -1999,7 +2019,7 @@ describe('SandboxSession orchestration', () => {
           wrapperInstanceId: NEXT_RUNTIME_ID,
         } satisfies ControlStatus;
         fixture.setStatus(ready);
-        return ready;
+        return { ...ready, attachment: ATTACHMENT };
       });
       await fixture.fireAlarm();
       expect(await fixture.session.isSandboxCleanupScheduled()).toBe(false);
@@ -2408,14 +2428,14 @@ describe('SandboxSession orchestration', () => {
       'session_metadata',
       serializeSessionMetadata({
         ...fixture.metadata,
-        profile: { envVars: { CUSTOM_TOKEN: 'raw-secret-must-not-leak' } },
+        profile: { envVars: { SANDBOX_CONTROL_CREDENTIAL: 'raw-secret-must-not-leak' } },
       })
     );
     const admission = await fixture.admit('warm');
     expect(admission).toMatchObject({
       success: false,
       code: 'BAD_REQUEST',
-      error: expect.stringContaining('Custom profile environment'),
+      error: expect.stringContaining('Reserved control runtime environment variable'),
     });
     expect(JSON.stringify(admission)).not.toContain('raw-secret-must-not-leak');
     expect(fixture.record('warm')).toBeUndefined();
@@ -2437,7 +2457,12 @@ describe('SandboxSession orchestration', () => {
         expect(fixture.control.getStatus).not.toHaveBeenCalled();
       }
       if (!allowed) throw new Error('Compute admission denied');
-      return { physical: 'running', connection: 'ready', wrapperInstanceId: RUNTIME_ID };
+      return {
+        physical: 'running',
+        connection: 'ready',
+        wrapperInstanceId: RUNTIME_ID,
+        attachment: ATTACHMENT,
+      };
     });
     await fixture.admit('a');
     await fixture.admit('b');
@@ -2566,10 +2591,10 @@ describe('SandboxSession orchestration', () => {
   });
 
   it.each([
-    { envVars: { CUSTOM_API_URL: 'not-logged' } },
+    { envVars: { SANDBOX_CONTROL_URL: 'not-logged' } },
     {
       encryptedSecrets: {
-        CUSTOM_SECRET: {
+        SANDBOX_CONTROL_CREDENTIAL: {
           encryptedData: 'not-logged',
           encryptedDEK: 'not-logged',
           algorithm: 'rsa-aes-256-gcm' as const,
@@ -2577,12 +2602,12 @@ describe('SandboxSession orchestration', () => {
         },
       },
     },
-  ])('rejects custom profile environment without rejecting injected auth', async profile => {
+  ])('rejects reserved profile environment without rejecting contained auth', async profile => {
     const fixture = sessionFixture({ profile });
     await expect(fixture.admit('a')).resolves.toMatchObject({
       success: false,
       code: 'BAD_REQUEST',
-      error: expect.stringContaining('Custom profile environment'),
+      error: expect.stringContaining('Reserved control runtime environment variable'),
     });
     expect(fixture.control.ensureReady).not.toHaveBeenCalled();
     const supported = sessionFixture({ profile: { envVars: {}, setupCommands: ['pnpm install'] } });
@@ -2594,7 +2619,12 @@ describe('SandboxSession orchestration', () => {
     const attach = supported.control.request.mock.calls.find(
       ([input]) => input.operation === 'session.attach'
     )?.[0];
-    expect(attach?.payload).toMatchObject({ env: { KILOCODE_TOKEN: 'test-token' } });
+    expect(attach?.payload).toMatchObject({
+      env: { KILOCODE_TOKEN: KILO_CREDENTIAL },
+      kilo: ATTACHMENT.kilo,
+      setupCommands: ['pnpm install'],
+    });
+    expect(JSON.stringify(attach?.payload)).not.toContain('test-token');
   });
 
   it.each(['rejected', 'malformed', 'error', 'timeout'] as const)(

--- a/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.test.ts
@@ -11,6 +11,7 @@ import {
   sessionTerminalResizePayloadSchema,
   type ResponseFrame,
 } from '../shared/sandbox-control-protocol.js';
+import type { sandboxControlRpc } from './control-rpc.js';
 import {
   createSandboxTerminalLifecycle,
   SANDBOX_SESSION_LIFECYCLE_KEY,
@@ -76,16 +77,16 @@ function createFixture(
     workspace: {
       sandboxId: SANDBOX_ID,
       sandboxProvider: 'cloudflare',
-      ...(options.containment
-        ? {
+      ...(options.containment === undefined
+        ? {}
+        : {
             credentialContainment: {
-              github: true,
+              github: options.containment,
               gitlab: false,
               bitbucket: false,
-              kilocode: false,
+              kilocode: options.containment,
             },
-          }
-        : {}),
+          }),
     },
     lifecycle: { version: 1, timestamp: 1 },
   });
@@ -118,10 +119,14 @@ function createFixture(
     if (input.operation === 'session.detach') return response({ detached: true });
     return response({ connected: true });
   });
+  type TerminalControl = ReturnType<typeof sandboxControlRpc>;
   const control = {
-    ensureReady: vi.fn(async () => ({
-      connection: 'ready' as const,
-      physical: 'running' as const,
+    prepareSessionCredentials: vi.fn<TerminalControl['prepareSessionCredentials']>(async () => ({
+      directory: DIRECTORY,
+    })),
+    ensureReady: vi.fn<TerminalControl['ensureReady']>(async () => ({
+      connection: 'ready',
+      physical: 'running',
     })),
     getStatus: vi.fn(async () => ({
       connection: 'ready' as const,
@@ -140,6 +145,7 @@ function createFixture(
         allowed: true,
       })
     ),
+    updateNetworkPolicy: vi.fn(async () => undefined),
     request,
   };
   const closeTerminalBridge = vi.fn();
@@ -207,9 +213,26 @@ describe('SandboxSession terminal lifecycle', () => {
     });
   });
 
+  it.each([undefined, false, true])(
+    'allows verified contained terminals with legacy containment metadata %s',
+    async containment => {
+      const fixture = createFixture({ containment });
+
+      await expect(
+        fixture.lifecycle.createTerminal({ operationId: FIRST_OPERATION_ID })
+      ).resolves.toMatchObject({ success: true, data: { pty: { id: 'pty_1', cwd: DIRECTORY } } });
+      expect(fixture.control.validateTerminalAccess).toHaveBeenCalledWith({
+        sessionId: SESSION_ID,
+        ownerId: 'user_1',
+        wrapperInstanceId: WRAPPER_INSTANCE_ID,
+      });
+      expect(fixture.control.ensureReady).not.toHaveBeenCalled();
+      expect(fixture.control.prepareSessionCredentials).not.toHaveBeenCalled();
+    }
+  );
+
   it.each([
     [{ platform: 'code-review' }, 'interactive Cloud Agent sessions'],
-    [{ containment: true }, 'credential containment'],
     [{ terminalCapable: false }, 'does not support terminals'],
   ])('permanently rejects unsupported terminal access', async (options, reason) => {
     const fixture = createFixture(options);
@@ -224,8 +247,12 @@ describe('SandboxSession terminal lifecycle', () => {
     expect(fixture.control.ensureReady).not.toHaveBeenCalled();
   });
 
-  it('verifies trusted billing attribution before creating a shell', async () => {
-    const fixture = createFixture({ organizationId: 'org_1', botId: 'bot_1' });
+  it('verifies trusted billing attribution before creating a contained shell', async () => {
+    const fixture = createFixture({
+      containment: true,
+      organizationId: 'org_1',
+      botId: 'bot_1',
+    });
     fixture.control.validateTerminalAccess.mockResolvedValue({
       allowed: false,
       reason: 'billing_context_unavailable',

--- a/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.ts
+++ b/services/cloud-agent-next/src/sandbox-session/terminal-lifecycle.ts
@@ -1,10 +1,6 @@
 import { z } from 'zod';
 import type { WrapperPty } from '../kilo/wrapper-client.js';
-import {
-  parseSessionMetadata,
-  requiresContainmentSandbox,
-  type SessionMetadata,
-} from '../persistence/session-metadata.js';
+import { parseSessionMetadata, type SessionMetadata } from '../persistence/session-metadata.js';
 import type { OperationResult } from '../persistence/types.js';
 import {
   sessionTerminalClosePayloadSchema,
@@ -495,9 +491,6 @@ export function createSandboxTerminalLifecycle(deps: TerminalLifecycleDeps) {
     if (!current) return unavailableSession();
     if (!isTerminalSessionPlatform(current.metadata.identity.createdOnPlatform)) {
       return denied('terminals are only available for interactive Cloud Agent sessions');
-    }
-    if (requiresContainmentSandbox(current.metadata)) {
-      return denied('this session requires unsupported credential containment');
     }
 
     const ready = await readyContext(current, { validateAccess: true });

--- a/services/cloud-agent-next/src/services/git-token-service-client.test.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.test.ts
@@ -2,22 +2,42 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { logger } from '../logger.js';
 import type { GitTokenService } from '../types.js';
 import {
+  issueCloudAgentBitbucketSessionCapability,
   issueCloudAgentGitHubSessionCapability,
   issueCloudAgentGitLabSessionCapability,
+  issueCloudAgentKiloSessionCapability,
   resolveCloudAgentGitHubAuthForRepo,
   resolveGitHubTokenForRepo,
   resolveManagedBitbucketToken,
   resolveManagedGitLabToken,
 } from './git-token-service-client.js';
 
-vi.mock('../logger.js', () => ({
-  logger: {
+vi.mock('../logger.js', () => {
+  const logger = {
     info: vi.fn(),
     warn: vi.fn(),
     error: vi.fn(),
-    withFields: vi.fn(() => ({ info: vi.fn(), error: vi.fn(), warn: vi.fn() })),
-  },
-}));
+    withFields: vi.fn(),
+  };
+  logger.withFields.mockReturnValue(logger);
+  return { logger };
+});
+
+const BROKER_ERROR_SECRET = 'fixture-managed-credential-in-broker-error';
+
+beforeEach(() => vi.clearAllMocks());
+
+function expectSecretSafeLogs(): void {
+  const mockedLogger = vi.mocked(logger);
+  expect(
+    JSON.stringify([
+      mockedLogger.info.mock.calls,
+      mockedLogger.warn.mock.calls,
+      mockedLogger.error.mock.calls,
+      mockedLogger.withFields.mock.calls,
+    ])
+  ).not.toContain(BROKER_ERROR_SECRET);
+}
 
 function createGitTokenService() {
   return {
@@ -36,6 +56,94 @@ function createGitTokenService() {
 function createEnv(service: Partial<GitTokenService>) {
   return { GIT_TOKEN_SERVICE: service as GitTokenService };
 }
+
+describe('broker exception safety', () => {
+  const params = { userId: 'user_1', outboundContainerId: 'container-test' };
+  const bitbucketParams = {
+    ...params,
+    orgId: '123e4567-e89b-12d3-a456-426614174030',
+    workspaceUuid: '123e4567-e89b-12d3-a456-426614174020',
+    repositoryUuid: '123e4567-e89b-12d3-a456-426614174021',
+    repositoryUrl: 'https://bitbucket.org/acme/repo.git',
+  };
+
+  it.each([
+    [
+      'GitHub lookup',
+      (env: ReturnType<typeof createEnv>) =>
+        resolveGitHubTokenForRepo(env, { userId: params.userId, githubRepo: 'acme/repo' }),
+    ],
+    [
+      'Kilo issuance',
+      (env: ReturnType<typeof createEnv>) =>
+        issueCloudAgentKiloSessionCapability(env, {
+          ...params,
+          cloudAgentSessionId: 'workspace_11111111-1111-4111-8111-111111111111',
+          kiloSessionId: 'ses_abcdefghijklmnopqrstuvwxyz',
+          userToken: BROKER_ERROR_SECRET,
+          targets: {
+            backendBaseUrl: 'https://backend.example.com',
+            providerBaseUrl: 'https://provider.example.com',
+            sessionIngestBaseUrl: 'https://ingest.example.com',
+          },
+        }),
+    ],
+    [
+      'GitLab issuance',
+      (env: ReturnType<typeof createEnv>) =>
+        issueCloudAgentGitLabSessionCapability(env, {
+          ...params,
+          gitUrl: 'https://gitlab.com/acme/repo.git',
+        }),
+    ],
+    [
+      'Bitbucket issuance',
+      (env: ReturnType<typeof createEnv>) =>
+        issueCloudAgentBitbucketSessionCapability(env, bitbucketParams),
+    ],
+    [
+      'GitLab lookup',
+      (env: ReturnType<typeof createEnv>) =>
+        resolveManagedGitLabToken(env, { userId: params.userId }),
+    ],
+    [
+      'Bitbucket lookup',
+      (env: ReturnType<typeof createEnv>) => resolveManagedBitbucketToken(env, bitbucketParams),
+    ],
+  ] as const)('keeps %s exception details out of logs and failure output', async (name, call) => {
+    const rejectedRpc = vi
+      .fn()
+      .mockRejectedValue(new Error(`Broker rejected Bearer ${BROKER_ERROR_SECRET}`));
+    const env = createEnv({
+      getTokenForRepo: rejectedRpc,
+      issueKiloSessionCapability: rejectedRpc,
+      issueGitLabSessionCapability: rejectedRpc,
+      issueBitbucketSessionCapability: rejectedRpc,
+      getGitLabToken: rejectedRpc,
+      getBitbucketToken: rejectedRpc,
+    });
+
+    const result = await call(env);
+
+    expect(JSON.stringify(result)).not.toContain(BROKER_ERROR_SECRET);
+    expectSecretSafeLogs();
+    expect(logger.error).toHaveBeenCalled();
+    expect(result).toEqual(
+      'error' in result
+        ? {
+            success: false,
+            error: {
+              reason: 'rpc_error',
+              message:
+                name === 'GitHub lookup'
+                  ? 'GitHub credential service is unavailable'
+                  : 'git-token-service RPC failed',
+            },
+          }
+        : { success: false, reason: 'rpc_error' }
+    );
+  });
+});
 
 describe('resolveManagedBitbucketToken', () => {
   const repositoryParams = {
@@ -327,7 +435,7 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
   it('fails closed without direct authentication when the capability RPC rejects', async () => {
     const issueGitHubSessionCapability = vi
       .fn()
-      .mockRejectedValue(new Error('service unavailable'));
+      .mockRejectedValue(new Error(`Broker rejected ${BROKER_ERROR_SECRET}`));
     const getCloudAgentAuthForRepo = vi.fn().mockResolvedValue({
       success: true,
       githubToken: 'user-token',
@@ -355,6 +463,8 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
     });
     expect(getCloudAgentAuthForRepo).not.toHaveBeenCalled();
     expect(getTokenForRepo).not.toHaveBeenCalled();
+    expectSecretSafeLogs();
+    expect(JSON.stringify(result)).not.toContain(BROKER_ERROR_SECRET);
   });
 });
 
@@ -592,7 +702,7 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
   it('does not fall back to a different authorization path when the managed RPC rejects', async () => {
     const getCloudAgentAuthForRepo = vi
       .fn()
-      .mockRejectedValue(new Error('RPC method getCloudAgentAuthForRepo is not available'));
+      .mockRejectedValue(new Error(`Broker rejected ${BROKER_ERROR_SECRET}`));
     const getTokenForRepo = vi.fn().mockResolvedValue({
       success: true,
       token: 'installation-token',
@@ -620,6 +730,8 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
       success: false,
       error: { reason: 'rpc_error', message: 'GitHub credential service is unavailable' },
     });
+    expectSecretSafeLogs();
+    expect(JSON.stringify(result)).not.toContain(BROKER_ERROR_SECRET);
   });
 
   it('preserves the expected integration id through direct and legacy authentication', async () => {

--- a/services/cloud-agent-next/src/services/git-token-service-client.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.ts
@@ -364,9 +364,8 @@ export async function issueCloudAgentBitbucketSessionCapability(
     if (!result.success) return { success: false, reason: result.reason };
     logger.info('Issued Bitbucket session capability via git-token-service');
     return { success: true, value: { capability: result.capability, gitUrl: result.gitUrl } };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.withFields({ error: message }).error('Failed to issue Bitbucket session capability');
+  } catch {
+    logger.error('Failed to issue Bitbucket session capability');
     return { success: false, reason: 'rpc_error' };
   }
 }
@@ -411,11 +410,8 @@ export async function issueCloudAgentGitLabSessionCapability(
         glabIsOAuth2: result.glabIsOAuth2,
       },
     };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger
-      .withFields({ error: message })
-      .error('Failed to issue managed GitLab session capability');
+  } catch {
+    logger.error('Failed to issue managed GitLab session capability');
     return { success: false, reason: 'rpc_error' };
   }
 }
@@ -445,9 +441,8 @@ export async function resolveManagedGitLabToken(
     }
     logger.withFields({ reason: result.reason }).info('GitLab token lookup failed');
     return { success: false, reason: result.reason };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.withFields({ error: message }).error('Failed to call git-token-service getGitLabToken');
+  } catch {
+    logger.error('Failed to call git-token-service getGitLabToken');
     return { success: false, reason: 'rpc_error' };
   }
 }
@@ -493,12 +488,11 @@ export async function issueCloudAgentKiloSessionCapability(
     }
     logger.info('Issued Kilo session capability via git-token-service');
     return { success: true, value: { capability: result.capability } };
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger.withFields({ error: message }).error('Failed to issue Kilo session capability');
+  } catch {
+    logger.error('Failed to issue Kilo session capability');
     return {
       success: false,
-      error: { reason: 'rpc_error', message: `git-token-service RPC failed: ${message}` },
+      error: { reason: 'rpc_error', message: 'git-token-service RPC failed' },
     };
   }
 }

--- a/services/cloud-agent-next/src/session/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session/session-prepare.test.ts
@@ -336,6 +336,136 @@ describe('createSessionWithLedger admission ladder', () => {
     });
   });
 
+  describe.each([undefined, 'true', 'false', ''] as const)(
+    'workspace containment ignores CREDENTIAL_CONTAINMENT_ENABLED=%s',
+    flag => {
+      it.each([
+        {
+          repository: { type: 'github', repo: 'acme/repo' },
+          expected: { github: true, gitlab: false, bitbucket: false, kilocode: true },
+        },
+        {
+          repository: { type: 'gitlab', url: 'https://gitlab.com/acme/repo.git' },
+          expected: { github: false, gitlab: true, bitbucket: false, kilocode: true },
+        },
+        {
+          repository: {
+            type: 'bitbucket',
+            url: 'https://bitbucket.org/acme/repo.git',
+            workspaceUuid: '123e4567-e89b-12d3-a456-426614174000',
+            repositoryUuid: '123e4567-e89b-12d3-a456-426614174001',
+          },
+          expected: { github: false, gitlab: false, bitbucket: true, kilocode: true },
+        },
+        {
+          repository: { type: 'git', url: 'https://example.com/acme/repo.git' },
+          expected: { github: false, gitlab: false, bitbucket: false, kilocode: true },
+        },
+      ] as const)(
+        'derives $repository.type containment from the allocated workspace ID',
+        async ({ repository, expected }) => {
+          generateSessionIdMock.mockReturnValue(WORKSPACE_SESSION_ID);
+          const doStub = makeDoStub();
+          const ctx = makeContext(doStub);
+          if (flag !== undefined) ctx.env.CREDENTIAL_CONTAINMENT_ENABLED = flag;
+
+          await runCreate(ctx, makeRequest({ repository }));
+
+          expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+            expect.objectContaining({
+              identity: expect.objectContaining({ sessionId: WORKSPACE_SESSION_ID }),
+              workspace: expect.objectContaining({ credentialContainment: expected }),
+            })
+          );
+        }
+      );
+    }
+  );
+
+  it('keeps mandatory workspace containment when CREDENTIAL_CONTAINMENT_ENABLED=false', async () => {
+    generateSessionIdMock.mockReturnValue(WORKSPACE_SESSION_ID);
+    const doStub = makeDoStub();
+    const ctx = makeContext(doStub);
+    ctx.env.CREDENTIAL_CONTAINMENT_ENABLED = 'false';
+
+    await runCreate(
+      ctx,
+      makeRequest({ repository: { type: 'gitlab', url: 'https://gitlab.com/acme/repo.git' } })
+    );
+
+    expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: expect.objectContaining({ sessionId: WORKSPACE_SESSION_ID }),
+        workspace: expect.objectContaining({
+          credentialContainment: {
+            github: false,
+            gitlab: true,
+            bitbucket: false,
+            kilocode: true,
+          },
+        }),
+      })
+    );
+  });
+
+  it('disables toggle containment for an agent ID when CREDENTIAL_CONTAINMENT_ENABLED=false', async () => {
+    const doStub = makeDoStub();
+    const ctx = makeContext(doStub);
+    ctx.env.CREDENTIAL_CONTAINMENT_ENABLED = 'false';
+
+    await runCreate(
+      ctx,
+      makeRequest({ repository: { type: 'gitlab', url: 'https://gitlab.com/acme/repo.git' } })
+    );
+
+    expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        identity: expect.objectContaining({ sessionId: CLOUD_AGENT_SESSION_ID }),
+        workspace: expect.objectContaining({
+          credentialContainment: {
+            github: false,
+            gitlab: false,
+            bitbucket: false,
+            kilocode: false,
+          },
+        }),
+      })
+    );
+  });
+
+  it.each([
+    {
+      sessionId: WORKSPACE_SESSION_ID,
+      expected: { github: true, gitlab: false, bitbucket: false, kilocode: true },
+    },
+    {
+      sessionId: CLOUD_AGENT_SESSION_ID,
+      expected: { github: false, gitlab: false, bitbucket: false, kilocode: false },
+    },
+  ])(
+    'excludes devcontainers from toggle containment for $sessionId',
+    async ({ sessionId, expected }) => {
+      generateSessionIdMock.mockReturnValue(sessionId);
+      generateSandboxRoutingTargetMock.mockResolvedValueOnce({
+        kind: 'isolated',
+        sandboxId: 'dind-abcdef',
+      });
+      const doStub = makeDoStub();
+      const ctx = makeContext(doStub);
+
+      await runCreate(ctx, makeRequest({ runtime: { devcontainer: true } }));
+
+      expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+        expect.objectContaining({
+          workspace: expect.objectContaining({
+            devcontainerRequested: true,
+            credentialContainment: expected,
+          }),
+        })
+      );
+    }
+  );
+
   it('routes and persists isolated Standard allocation for an agent session', async () => {
     const sandboxId = `istd-${'a'.repeat(48)}` as const;
     generateSandboxRoutingTargetMock.mockResolvedValueOnce({ kind: 'isolated', sandboxId });
@@ -1974,6 +2104,13 @@ describe('createSessionWithLedger clone allocation outcomes', () => {
       cloneFromKiloSessionId: SOURCE_KILO_SESSION_ID,
     });
     expect(recordOperationProgressMock.mock.calls[0]?.[2]).not.toHaveProperty('reportingCreatedAt');
+    expect(doStub.registerSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        workspace: expect.objectContaining({
+          credentialContainment: { github: true, gitlab: false, bitbucket: false, kilocode: true },
+        }),
+      })
+    );
   });
 
   it('rejects isolated Standard allocation for workspace sessions before external effects', async () => {
@@ -2439,33 +2576,58 @@ describe('createSessionWithLedger clone reconciliation', () => {
     expect(createSessionReportMock).not.toHaveBeenCalled();
   });
 
-  it('resumes a workspace clone with its persisted Vercel provider', async () => {
-    const request = cloneRequest();
-    admitOperationMock.mockResolvedValueOnce({
-      admission: 'takeover',
-      row: await cloneRow({ cloudAgentSessionId: WORKSPACE_SESSION_ID, sandboxProvider: 'vercel' }),
-    });
-    createCliSessionMock.mockResolvedValue({
-      status: 'ready',
-      clone: { sessionId: KILO_SESSION_ID, copiedItemCount: 1 },
-    });
-    getPgDbMock.mockReturnValue(makeDb([[], [{ email: 'test@example.com' }]]));
-    const doStub = makeDoStub();
-    const ctx = makeContext(doStub);
+  it.each([
+    {
+      sessionId: WORKSPACE_SESSION_ID,
+      sandboxProvider: 'vercel',
+      controlPlaneIds: undefined,
+      expected: { github: true, gitlab: false, bitbucket: false, kilocode: true },
+    },
+    {
+      sessionId: WORKSPACE_SESSION_ID,
+      sandboxProvider: 'cloudflare',
+      controlPlaneIds: '',
+      expected: { github: true, gitlab: false, bitbucket: false, kilocode: true },
+    },
+    {
+      sessionId: CLOUD_AGENT_SESSION_ID,
+      sandboxProvider: 'cloudflare',
+      controlPlaneIds: USER_ID,
+      expected: { github: true, gitlab: false, bitbucket: false, kilocode: true },
+    },
+  ])(
+    'resumes $sandboxProvider clone containment from the stored $sessionId, not current owner enrollment',
+    async ({ sessionId, sandboxProvider, controlPlaneIds, expected }) => {
+      const request = cloneRequest();
+      admitOperationMock.mockResolvedValueOnce({
+        admission: 'takeover',
+        row: await cloneRow({ cloudAgentSessionId: sessionId, sandboxProvider }),
+      });
+      createCliSessionMock.mockResolvedValue({
+        status: 'ready',
+        clone: { sessionId: KILO_SESSION_ID, copiedItemCount: 1 },
+      });
+      getPgDbMock.mockReturnValue(makeDb([[], [{ email: 'test@example.com' }]]));
+      const doStub = makeDoStub();
+      const ctx = makeContext(doStub);
+      ctx.env.CONTROL_PLANE_IDS = controlPlaneIds;
 
-    await expect(runCreate(ctx, request)).resolves.toEqual({
-      cloudAgentSessionId: WORKSPACE_SESSION_ID,
-      kiloSessionId: KILO_SESSION_ID,
-      replayed: true,
-    });
+      await expect(runCreate(ctx, request)).resolves.toEqual({
+        cloudAgentSessionId: sessionId,
+        kiloSessionId: KILO_SESSION_ID,
+        replayed: true,
+      });
 
-    expect(doStub.registerSession).toHaveBeenCalledWith(
-      expect.objectContaining({
-        identity: expect.objectContaining({ sessionId: WORKSPACE_SESSION_ID }),
-        workspace: expect.objectContaining({ sandboxProvider: 'vercel' }),
-      })
-    );
-  });
+      expect(doStub.registerSession).toHaveBeenCalledWith(
+        expect.objectContaining({
+          identity: expect.objectContaining({ sessionId }),
+          workspace: expect.objectContaining({ sandboxProvider, credentialContainment: expected }),
+        })
+      );
+      expect(generateSessionIdMock).not.toHaveBeenCalled();
+      expect(generateSandboxRoutingTargetMock).not.toHaveBeenCalled();
+    }
+  );
 
   it('rejects an unsupported persisted sandbox provider when resuming a clone', async () => {
     const request = cloneRequest();

--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -32,7 +32,11 @@ import { normalizeGitUrl } from '@kilocode/worker-utils';
 
 import type { Env, SandboxId } from '../types.js';
 import type { CloudAgentSession } from '../persistence/CloudAgentSession.js';
-import type { CredentialContainment, SessionMetadata } from '../persistence/session-metadata.js';
+import {
+  getControlPlaneCredentialContainment,
+  type CredentialContainment,
+  type SessionMetadata,
+} from '../persistence/session-metadata.js';
 import { logger } from '../logger.js';
 import { withDORetry } from '../utils/do-retry.js';
 import { resolveSessionStub } from '../sandbox-session/session-stub.js';
@@ -408,15 +412,13 @@ function deriveCanonicalRepositoryUrl(repository: SessionRepositoryRequest): str
   return normalizeGitUrl(repository.url);
 }
 
-/**
- * Credential containment for a create, derived from the repository type and
- * the devcontainer flag. Shared by the fresh allocation and the clone rebuild
- * so both compute it identically.
- */
 function computeCredentialContainment(
+  sessionId: string,
   input: SessionRegistrationInput,
   env: Env
 ): CredentialContainment {
+  const controlPlaneContainment = getControlPlaneCredentialContainment(sessionId, input.repository);
+  if (controlPlaneContainment) return controlPlaneContainment;
   const containmentEnabled =
     env.CREDENTIAL_CONTAINMENT_ENABLED !== 'false' && input.runtime?.devcontainer !== true;
   return {
@@ -475,7 +477,7 @@ async function allocateNewSession(
     rethrowAllocationFailure(ledger, 'report', error);
   }
 
-  const credentialContainment = computeCredentialContainment(input, ctx.env);
+  const credentialContainment = computeCredentialContainment(cloudAgentSessionId, input, ctx.env);
   let sandboxId: SandboxId;
   let sandboxRoute: SharedSandboxRouteMetadata | undefined;
   let sandboxProvider: SandboxSelection['provider'] = 'cloudflare';
@@ -739,7 +741,7 @@ function rebuildCloneAllocation(
       !initialTurn && cloudAgentSessionId.startsWith('agent_')
         ? reportingCreatedAt.data
         : undefined,
-    credentialContainment: computeCredentialContainment(input, ctx.env),
+    credentialContainment: computeCredentialContainment(cloudAgentSessionId, input, ctx.env),
     sessionService,
     rollbackCliSession: async () => {
       try {

--- a/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
+++ b/services/cloud-agent-next/src/shared/sandbox-control-protocol.ts
@@ -198,6 +198,20 @@ export const sessionAttachPayloadSchema = z
     snapshotIdentity: z.string().min(1).max(512).optional(),
     directory: z.string().min(1).max(1024).optional(),
     branch: z.string().min(1).max(256).optional(),
+    kilo: z
+      .object({
+        scopeId: z.string().min(1).max(256),
+        token: z.string().min(1).max(4096),
+        targets: z
+          .object({
+            backendBaseUrl: z.string().url(),
+            providerBaseUrl: z.string().url(),
+            sessionIngestBaseUrl: z.string().url(),
+          })
+          .strict(),
+      })
+      .strict()
+      .optional(),
     git: z
       .object({
         url: z.string().min(1).max(2048),

--- a/services/cloud-agent-next/test/e2e/README.md
+++ b/services/cloud-agent-next/test/e2e/README.md
@@ -28,18 +28,31 @@ cloud-agent-next refactor.
 
 ## Credential containment
 
-`CREDENTIAL_CONTAINMENT_ENABLED` controls GitHub, GitLab, Bitbucket, and Kilo
-credential containment together for new non-devcontainer sessions. Containment
-is enabled unless this variable is set to `false`.
+Control-plane sessions (`workspace_*`) always contain managed Kilo and repository
+credentials, including sessions whose older metadata disabled containment.
+`CREDENTIAL_CONTAINMENT_ENABLED` cannot disable control-plane containment.
+Cloudflare uses contained sandbox classes and the existing credential broker;
+Vercel uses native network policies. Each worktree has stable credential aliases
+shared by its registered Kilo roots, while different worktrees have separate Kilo
+authentication contexts. Unsupported credential configurations fail closed rather
+than exposing raw tokens.
 
-Local `dev` defaults to `false` because of Cloudflare's local outbound proxy
-limitations. Set `CREDENTIAL_CONTAINMENT_ENABLED=true` in `.dev.vars` to opt in
-when using proxy-compatible upstreams. Devcontainer sessions remain excluded
-because DIND does not support managed SCM containment.
+Cloudflare's native outbound handler intercepts ports 80 and 443. Local targets
+such as `http://host.docker.internal:<offset-port>` can bypass interception and
+reject the aliases with HTTP 401. A control-plane E2E run needs sandbox-facing
+endpoints that actually traverse the native handler, plus the running
+`cloudflare-git-token-service` and its capability-encryption configuration. Do not
+disable containment to work around a local transport limitation.
 
-Containment flags are persisted on the workspace at session creation, so
-changing this variable requires a new session; existing sessions keep their
-original containment flags.
+For new legacy sessions (`agent_*`), `CREDENTIAL_CONTAINMENT_ENABLED` controls
+GitHub, GitLab, Bitbucket, and Kilo credential containment together. Containment
+is enabled unless this variable is set to `false`. Local `dev` defaults to
+`false`; set `CREDENTIAL_CONTAINMENT_ENABLED=true` in `.dev.vars` when using
+proxy-compatible upstreams. Legacy devcontainer sessions remain excluded because
+DIND does not support managed SCM containment.
+
+Legacy containment flags are persisted at session creation, so changing the
+variable affects new legacy sessions, not existing ones.
 
 ## Running
 

--- a/services/cloud-agent-next/test/integration/sandbox-control.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-control.test.ts
@@ -10,40 +10,81 @@ import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { forceDestroyControlPlaneSandbox } from '../../src/container-usage-context.js';
 import type {
+  VercelSandboxNetworkPolicy,
+  VercelSandboxSession,
+} from '../../src/agent-sandbox/vercel/vercel-sandbox-rest-client.js';
+import { parseVercelSandboxRuntimeConfig } from '../../src/agent-sandbox/vercel/vercel-runtime-config.js';
+import type {
   AgentSelectionOverride,
   SubmittedSessionMessageRequest,
 } from '../../src/execution/types.js';
+import type { AttachSessionInput, SandboxControl } from '../../src/persistence/SandboxControl.js';
 import {
   serializeSessionMetadata,
   type SessionMetadata,
 } from '../../src/persistence/session-metadata.js';
-import { throwAdmissionError } from '../../src/session/queue-message.js';
+import {
+  createCloudflareProviderAdapter,
+  decodeCloudflareProviderRef,
+  encodeCloudflareProviderRef,
+  type CloudflareSandboxHandle,
+} from '../../src/sandbox-control/cloudflare-provider.js';
+import { createControlPlaneCredential } from '../../src/sandbox-control/managed-credential.js';
+import {
+  buildControlNetworkPolicy,
+  sessionCredentialGrantSchema,
+  type SessionCredentialGrant,
+} from '../../src/sandbox-control/session-credentials.js';
+import { findMatchingCredentialInjectionRule } from '../../src/sandbox-control/vercel-network-policy.js';
+import { MANAGED_SCM_OUTBOUND_HANDLER } from '../../src/sandbox-id.js';
+import type { SandboxSession } from '../../src/sandbox-session/SandboxSession.js';
+import {
+  SANDBOX_SESSION_LIFECYCLE_KEY,
+  SANDBOX_SESSION_METADATA_KEY,
+} from '../../src/sandbox-session/terminal-lifecycle.js';
+import type { AgentSandboxProvider, Env, GitTokenService, SandboxId } from '../../src/types.js';
 import {
   generateSandboxCredential,
   hashSandboxCredential,
 } from '../../src/sandbox-control/credential.js';
 import {
-  createCloudflareProviderAdapter,
-  type CloudflareSandboxHandle,
-} from '../../src/sandbox-control/cloudflare-provider.js';
-import { DEADLINE_MS, type DeadlineId } from '../../src/sandbox-control/deadlines.js';
+  DEADLINE_MS,
+  type DeadlineId,
+  type DeadlineTable,
+} from '../../src/sandbox-control/deadlines.js';
 import {
   loadDeadlines,
   loadRouteTable,
+  loadSessionCredentialGrants,
   saveDeadlines,
   savePhysicalRecord,
   saveRouteTable,
+  saveSessionCredentialGrants,
 } from '../../src/sandbox-control/durable-state.js';
-import { beginStop } from '../../src/sandbox-control/physical-lifecycle.js';
-import type { ProviderAdapter } from '../../src/sandbox-control/provider.js';
+import {
+  beginStop,
+  claimCreate,
+  confirmRunning,
+  initialPhysicalRecord,
+  WORKTREE_CREDENTIAL_CONTAINMENT,
+  type CredentialContainmentRequirements,
+  type PhysicalRecord,
+} from '../../src/sandbox-control/physical-lifecycle.js';
+import type { ProviderAdapter, ProviderCreateIntent } from '../../src/sandbox-control/provider.js';
 import { applyReportedSessionState } from '../../src/sandbox-control/session-routes.js';
 import { SESSION_DELIVERY_TIMEOUT_MS } from '../../src/sandbox-session/control-dispatch.js';
+import {
+  createVercelProviderAdapter,
+  encodeVercelProviderRef,
+  type VercelControlRestClient,
+} from '../../src/sandbox-control/vercel-provider.js';
 import {
   createSessionMessageRecord,
   type SessionMessageRecord,
 } from '../../src/sandbox-session/session-message-queue.js';
 import { getPreparationSnapshots } from '../../src/session/preparation-history.js';
 import { createEventQueries } from '../../src/session/queries/index.js';
+import { throwAdmissionError } from '../../src/session/queue-message.js';
 import {
   requestFrameSchema,
   sessionPromptPayloadSchema,
@@ -51,19 +92,106 @@ import {
   SANDBOX_CONTROL_AUTO_PONG,
   type RequestFrame,
   type ResponseFrame,
+  type SessionAttachPayload,
 } from '../../src/shared/sandbox-control-protocol.js';
 
-const sandboxId = 'sbx_control_smoke';
+const sandboxId = 'sbx__control_smoke';
+const ROOT_ID = 'ses_abcdefghijklmnopqrstuvwxyz';
+const SECOND_ROOT_ID = 'ses_zyxwvutsrqponmlkjihgfedcba';
+const THIRD_ROOT_ID = 'ses_01234567890123456789012345';
+const GRANT_SESSION_ID = 'workspace_11111111-1111-4111-8111-111111111111';
+const SECOND_GRANT_SESSION_ID = 'workspace_22222222-2222-4222-8222-222222222222';
+const WORKTREE_ID = 'worktree_11111111-1111-4111-8111-111111111111';
+const OTHER_WORKTREE_ID = 'worktree_22222222-2222-4222-8222-222222222222';
+type ProviderCreateResult = Awaited<ReturnType<ProviderAdapter['create']>>;
+const KILO_TOKEN = 'fixture-real-kilo-token';
+const GITHUB_TOKEN = 'fixture-real-github-token';
+const HOUR = 60 * 60 * 1000;
+
+function cloudflareRef(id: string, instanceId = 'inst_1'): string {
+  return encodeCloudflareProviderRef({ sandboxId: id, containment: true, instanceId });
+}
+
+async function seedRunningCloudflare(instance: SandboxControl): Promise<string> {
+  const providerRef = cloudflareRef(instance.sandboxId);
+  const physical = await instance.getPhysicalRecord();
+  if (physical.state === 'stopped') {
+    await instance.claimCreate(
+      'inst_1',
+      false,
+      instance.sandboxId,
+      WORKTREE_CREDENTIAL_CONTAINMENT
+    );
+  }
+  if (physical.state !== 'running') await instance.confirmInstance(providerRef);
+  Object.assign(instance, { provider: fakeProvider() });
+  return providerRef;
+}
+
+async function seedGrant(
+  instance: SandboxControl,
+  state: DurableObjectState,
+  input: AttachSessionInput = {
+    sessionId: GRANT_SESSION_ID,
+    kiloSessionId: ROOT_ID,
+    directory: '/workspace/contained',
+    ownerId: CONTAINMENT_OWNER,
+  },
+  provider: AgentSandboxProvider = 'cloudflare'
+): Promise<SessionCredentialGrant> {
+  const now = Date.now();
+  const grant = sessionCredentialGrantSchema.parse({
+    version: 1,
+    scopeId: input.worktreeId ?? input.sessionId,
+    sandboxId: instance.sandboxId,
+    directory: input.directory,
+    userId: input.ownerId,
+    provider,
+    ...(provider === 'cloudflare'
+      ? { outboundContainerId: `contained:${instance.sandboxId}` }
+      : {}),
+    members: [{ sessionId: input.sessionId, kiloSessionId: input.kiloSessionId }],
+    kilo: {
+      alias: createControlPlaneCredential(instance.sandboxId, 'kilo'),
+      token: KILO_TOKEN,
+      targets: CONTAINMENT_TARGETS,
+      capabilities: {},
+    },
+    preparedAt: now,
+    expiresAt: now + 4 * HOUR,
+  });
+  await saveSessionCredentialGrants(state.storage, [
+    ...(await loadSessionCredentialGrants(state.storage)),
+    grant,
+  ]);
+  return grant;
+}
+
+async function attachGrantedSession(
+  instance: SandboxControl,
+  state: DurableObjectState,
+  input: AttachSessionInput
+) {
+  await seedGrant(instance, state, input);
+  return instance.attachSession(input);
+}
 
 async function seedCredential(credential: string, id = sandboxId): Promise<void> {
   const stub = env.SANDBOX_CONTROL.getByName(id);
   await runInDurableObject(stub, async instance => {
     if ((await instance.getPhysicalRecord()).state === 'stopped') {
-      await instance.claimCreate(`intent_${id}`);
+      await instance.claimCreate('inst_1', false, id, WORKTREE_CREDENTIAL_CONTAINMENT);
     }
     await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
   });
 }
+
+async function seedRunningCredential(credential: string, id = sandboxId): Promise<void> {
+  await seedCredential(credential, id);
+  await runInDurableObject(env.SANDBOX_CONTROL.getByName(id), seedRunningCloudflare);
+}
+
+const socketSandboxIds = new WeakMap<WebSocket, string>();
 
 async function connect(credential: string, id = sandboxId): Promise<WebSocket> {
   const response = await SELF.fetch(`http://worker.test/sandbox-control/${id}`, {
@@ -76,6 +204,7 @@ async function connect(credential: string, id = sandboxId): Promise<WebSocket> {
     throw new Error(`Unexpected sandbox control upgrade: ${response.status}`);
   }
   response.webSocket.accept();
+  socketSandboxIds.set(response.webSocket, id);
   return response.webSocket;
 }
 
@@ -116,7 +245,8 @@ function sendHello(
       operation: 'sandbox.hello',
       payload: {
         protocolVersion: 1,
-        providerInstanceId: identity.providerInstanceId ?? 'inst_1',
+        providerInstanceId:
+          identity.providerInstanceId ?? cloudflareRef(socketSandboxIds.get(ws) ?? sandboxId),
         ...(identity.wrapperInstanceId ? { wrapperInstanceId: identity.wrapperInstanceId } : {}),
       },
     })
@@ -164,40 +294,32 @@ async function initializeTerminalRuntime(fixture: TerminalRuntimeFixture) {
   const credential = generateSandboxCredential();
   await seedCredential(credential, fixture.sandboxId);
   const control = env.SANDBOX_CONTROL.getByName(fixture.sandboxId);
-  const provider = await installProvider(control, fixture.sandboxId);
+  const sandboxProvider = fixture.sandboxProvider ?? 'cloudflare';
+  const providerRef =
+    sandboxProvider === 'vercel'
+      ? encodeVercelProviderRef({ sandboxName: fixture.sandboxId, sessionId: 'vercel_terminal' })
+      : cloudflareRef(fixture.sandboxId);
+  const provider = await installProvider(control, providerRef, sandboxProvider);
   await runInDurableObject(control, async (instance, state) => {
-    if (fixture.sandboxProvider === 'vercel') {
-      Object.assign(instance, {
-        providerKind: 'vercel',
-        env: {
-          ...env,
-          VERCEL_TOKEN: 'test-token',
-          VERCEL_TEAM_ID: 'test-team',
-          VERCEL_PROJECT_ID: 'test-project',
-          VERCEL_SANDBOX_SNAPSHOT_ID: 'test-snapshot',
-          VERCEL_SANDBOX_RUNTIME_BUILD_ID: 'test-build',
-          VERCEL_SANDBOX_RUNTIME: 'node24',
-          VERCEL_SANDBOX_INITIAL_TIMEOUT_MS: '300000',
-          VERCEL_SANDBOX_EXTEND_DURATION_MS: '600000',
-        },
-      });
-      await state.storage.put('provider_kind', 'vercel');
-      await instance.confirmInstance(fixture.sandboxId);
-    }
+    Object.assign(instance, { providerKind: sandboxProvider });
+    await state.storage.put('provider_kind', sandboxProvider);
     await instance.initializeOwner(fixture.ownerId);
-    await instance.attachSession({
+    await instance.confirmInstance(providerRef);
+    const attachment = {
       sessionId: fixture.sessionId,
-      kiloSessionId: 'kilo_terminal',
+      kiloSessionId: ROOT_ID,
       directory: '/workspace/terminal',
       ownerId: fixture.ownerId,
-    });
+    };
+    await seedGrant(instance, state, attachment, sandboxProvider);
+    await instance.attachSession(attachment);
   });
   const socket = await connect(credential, fixture.sandboxId);
   await completeHello(socket, `hello_${fixture.sandboxId}`, {
-    providerInstanceId: fixture.sandboxId,
+    providerInstanceId: providerRef,
     ...(fixture.wrapperInstanceId ? { wrapperInstanceId: fixture.wrapperInstanceId } : {}),
   });
-  return { control, credential, socket, ...provider };
+  return { control, credential, socket, providerRef, ...provider };
 }
 
 function signalWrapperReady(socket: WebSocket): void {
@@ -227,14 +349,14 @@ async function seedTerminalSession(fixture: TerminalRuntimeFixture, ptyId = 'pty
   await runInDurableObject(session, async (instance, state) => {
     await instance.registerSession({
       identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-      auth: { kiloSessionId: 'kilo_terminal' },
+      auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
       agent: {},
-      workspace: { sandboxId: fixture.sandboxId },
+      workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
     });
     const attachment = {
       ownerId: fixture.ownerId,
       sessionId: fixture.sessionId,
-      kiloSessionId: 'kilo_terminal',
+      kiloSessionId: ROOT_ID,
       directory: '/workspace/terminal',
       sandboxId: fixture.sandboxId,
       wrapperInstanceId: fixture.wrapperInstanceId,
@@ -287,20 +409,30 @@ function captureAndAcceptControlRequests(
 
 async function installProvider(
   control: ReturnType<typeof env.SANDBOX_CONTROL.getByName>,
-  initialRef?: string
+  initialRef?: string,
+  sandboxProvider: AgentSandboxProvider = 'cloudflare'
 ) {
   const allocations = new Set(initialRef ? [initialRef] : []);
+  const allocationRef = (sandboxName: string, instanceId: string) =>
+    sandboxProvider === 'vercel'
+      ? encodeVercelProviderRef({ sandboxName, sessionId: `vercel_${instanceId}` })
+      : cloudflareRef(sandboxName, instanceId);
   const provider = {
     resumable: false,
     ensureBillingAdmission: vi.fn<ProviderAdapter['ensureBillingAdmission']>(async () => undefined),
     create: vi.fn<ProviderAdapter['create']>(async intent => {
       if (!intent.allocationName) throw new Error('Expected a persisted allocation name');
-      allocations.add(intent.allocationName);
-      return { providerRef: intent.allocationName };
+      const providerRef = allocationRef(intent.allocationName, intent.intentId);
+      allocations.add(providerRef);
+      return { providerRef };
     }),
     launch: vi.fn<ProviderAdapter['launch']>(async () => undefined),
     observe: vi.fn<ProviderAdapter['observe']>(async (ref, intent) => {
-      const providerRef = ref ?? intent?.allocationName;
+      const providerRef =
+        ref ??
+        (intent?.allocationName
+          ? allocationRef(intent.allocationName, intent.intentId)
+          : undefined);
       return {
         status: providerRef && allocations.has(providerRef) ? 'active' : 'terminal',
         ...(providerRef ? { providerRef } : {}),
@@ -312,13 +444,37 @@ async function installProvider(
     }),
     ensureLeaseAtLeast: vi.fn<ProviderAdapter['ensureLeaseAtLeast']>(async () => undefined),
     logs: vi.fn<ProviderAdapter['logs']>(async () => ''),
+    updateNetworkPolicy: vi.fn<NonNullable<ProviderAdapter['updateNetworkPolicy']>>(
+      async () => undefined
+    ),
   } satisfies ProviderAdapter;
   await runInDurableObject(control, instance => {
     const prototype = Object.getPrototypeOf(instance) as {
       createProviderAdapter: () => ProviderAdapter;
     };
-    vi.spyOn(prototype, 'createProviderAdapter').mockReturnValue(provider);
-    Object.assign(instance, { provider });
+    const environment = {
+      ...env,
+      VERCEL_TOKEN: 'test-token',
+      VERCEL_TEAM_ID: 'test-team',
+      VERCEL_PROJECT_ID: 'test-project',
+      VERCEL_SANDBOX_SNAPSHOT_ID: 'test-snapshot',
+      VERCEL_SANDBOX_RUNTIME_BUILD_ID: 'test-build',
+      VERCEL_SANDBOX_RUNTIME: 'node24',
+      VERCEL_SANDBOX_INITIAL_TIMEOUT_MS: '300000',
+      VERCEL_SANDBOX_EXTEND_DURATION_MS: '600000',
+      ...fakeCloudflareContainers(() => instance.getPhysicalRecord()).bindings,
+      GIT_TOKEN_SERVICE: fakeCredentialBroker().binding,
+      KILOCODE_BACKEND_BASE_URL: CONTAINMENT_TARGETS.backendBaseUrl,
+      KILO_OPENROUTER_BASE: CONTAINMENT_TARGETS.providerBaseUrl,
+      KILO_SESSION_INGEST_URL: CONTAINMENT_TARGETS.sessionIngestBaseUrl,
+    };
+    vi.spyOn(prototype, 'createProviderAdapter').mockImplementation(
+      function (this: SandboxControl) {
+        Object.assign(this, { env: environment });
+        return provider;
+      }
+    );
+    Object.assign(instance, { provider, env: environment });
   });
   return { provider, allocations };
 }
@@ -339,6 +495,704 @@ afterEach(async () => {
   await reset();
   vi.restoreAllMocks();
 });
+
+async function rejectHello(
+  ws: WebSocket,
+  requestId: string,
+  providerInstanceId: string
+): Promise<void> {
+  const response = nextMessage(ws);
+  const closed = new Promise<number>(resolve => {
+    ws.addEventListener('close', event => resolve(event.code), { once: true });
+  });
+  ws.send(
+    JSON.stringify({
+      type: 'request',
+      requestId,
+      operation: 'sandbox.hello',
+      payload: { protocolVersion: 1, providerInstanceId },
+    })
+  );
+  await expect(response).resolves.toBe(
+    JSON.stringify({
+      type: 'response',
+      requestId,
+      ok: false,
+      error: {
+        code: 'unauthorized',
+        message: 'Invalid sandbox provider instance',
+        retryable: false,
+      },
+    })
+  );
+  await expect(closed).resolves.toBe(1008);
+}
+
+const CONTAINMENT_OWNER = 'github|oauth:user/123';
+const CONTAINMENT_REQUIREMENTS = WORKTREE_CREDENTIAL_CONTAINMENT;
+const CONTAINMENT_TARGETS = {
+  backendBaseUrl: 'https://api.kilo.ai',
+  providerBaseUrl: 'https://provider.kilo.ai',
+  sessionIngestBaseUrl: 'https://ingest.kilo.ai',
+};
+const CONTAINMENT_POLICY: VercelSandboxNetworkPolicy = {
+  mode: 'custom',
+  allowedDomains: ['api.kilo.ai', '*'],
+  injectionRules: [
+    {
+      domain: 'api.kilo.ai',
+      headers: {
+        authorization: 'Bearer managed-firewall-test-token',
+        host: 'api.kilo.ai',
+      },
+      match: {
+        headers: [
+          {
+            key: { exact: 'authorization' },
+            value: { exact: 'Bearer harmless-kilo-placeholder' },
+          },
+        ],
+      },
+    },
+  ],
+};
+
+function fakeProvider(overrides: Partial<ProviderAdapter> = {}): ProviderAdapter {
+  return {
+    resumable: false,
+    async ensureBillingAdmission() {},
+    async create() {
+      return { unresolved: true };
+    },
+    async launch() {},
+    async observe() {
+      return { status: 'active' };
+    },
+    async stop() {
+      return 'terminal';
+    },
+    async ensureLeaseAtLeast() {},
+    async logs() {
+      return '';
+    },
+    async updateNetworkPolicy() {},
+    ...overrides,
+  };
+}
+
+function unresolvableVercelProvider(sandboxName: string, nativeCalls: string[]): ProviderAdapter {
+  const config = parseVercelSandboxRuntimeConfig(VERCEL_ENV);
+  if (!config) throw new Error('Missing Vercel test configuration');
+  const unexpected = async (): Promise<never> => {
+    nativeCalls.push('native request');
+    throw new Error('Invalid provider reference reached the native API');
+  };
+  return createVercelProviderAdapter({
+    sandboxName,
+    config,
+    restClient: {
+      createSandbox: unexpected,
+      inspectByName: unexpected,
+      getSession: unexpected,
+      executeCommand: unexpected,
+      extendSessionTimeout: unexpected,
+      stopSession: unexpected,
+      readFile: unexpected,
+      updateNetworkPolicy: unexpected,
+    },
+  });
+}
+
+function containedRunningRecord(
+  providerRef: string,
+  containment: CredentialContainmentRequirements = CONTAINMENT_REQUIREMENTS
+): PhysicalRecord {
+  const cloudflare = decodeCloudflareProviderRef(providerRef);
+  return confirmRunning(
+    claimCreate(
+      initialPhysicalRecord(false),
+      cloudflare?.instanceId ?? 'intent_contained',
+      Date.now() - DEADLINE_MS.createSettle - 1,
+      cloudflare?.sandboxId,
+      containment
+    ),
+    providerRef,
+    1
+  );
+}
+
+async function seedRunningVercel(
+  instance: SandboxControl,
+  state: DurableObjectState,
+  requestedSandboxId: string,
+  provider: ProviderAdapter,
+  options?: {
+    ownerId?: string;
+    providerKind?: 'vercel' | 'cloudflare';
+    physical?: PhysicalRecord;
+    bypassPin?: boolean;
+  }
+): Promise<string> {
+  const providerRef = encodeVercelProviderRef({
+    sandboxName: requestedSandboxId,
+    sessionId: 'vsess_contained',
+  });
+  await instance.initializeOwner(options?.ownerId ?? CONTAINMENT_OWNER);
+  await state.storage.put('provider_kind', options?.providerKind ?? 'vercel');
+  await state.storage.put(
+    'physical_record',
+    options?.physical ?? containedRunningRecord(providerRef)
+  );
+  Object.assign(instance, {
+    provider,
+    createProviderAdapter: () => provider,
+    providerKind: options?.providerKind ?? 'vercel',
+    ...(options?.bypassPin ? { pinProvider: async () => true } : {}),
+  });
+  return providerRef;
+}
+
+function policyUpdateInput(ownerId = CONTAINMENT_OWNER): {
+  ownerId: string;
+  networkPolicy: VercelSandboxNetworkPolicy;
+  requiredContainment: CredentialContainmentRequirements;
+} {
+  return {
+    ownerId,
+    networkPolicy: CONTAINMENT_POLICY,
+    requiredContainment: CONTAINMENT_REQUIREMENTS,
+  };
+}
+
+type CredentialRegistration = Parameters<SandboxSession['registerSession']>[0];
+type KiloSubject = Parameters<GitTokenService['issueKiloSessionCapability']>[0];
+type GitHubSubject = Parameters<GitTokenService['issueGitHubSessionCapability']>[0];
+
+const VERCEL_ENV = {
+  VERCEL_TOKEN: 'fixture-vercel-token',
+  VERCEL_TEAM_ID: 'team_test',
+  VERCEL_PROJECT_ID: 'prj_test',
+  VERCEL_SANDBOX_SNAPSHOT_ID: 'snap_test',
+  VERCEL_SANDBOX_RUNTIME_BUILD_ID: 'build_test',
+  VERCEL_SANDBOX_RUNTIME: 'node24',
+  VERCEL_SANDBOX_INITIAL_TIMEOUT_MS: '300000',
+  VERCEL_SANDBOX_EXTEND_DURATION_MS: '120000',
+};
+
+function fakeCredentialBroker() {
+  const kiloSubjects = new Map<string, KiloSubject>();
+  const githubSubjects = new Map<string, GitHubSubject>();
+  const tokens = { github: GITHUB_TOKEN };
+  let serial = 0;
+  const unexpected = async (): Promise<never> => {
+    throw new Error('Unexpected raw credential lookup or capability redemption');
+  };
+  const binding: GitTokenService = {
+    async getTokenForRepo() {
+      return {
+        success: true,
+        token: tokens.github,
+        installationId: '42',
+        accountLogin: 'acme',
+        appType: 'standard',
+      };
+    },
+    getToken: unexpected,
+    getCloudAgentAuthForRepo: unexpected,
+    getGitLabToken: unexpected,
+    issueGitLabSessionCapability: unexpected,
+    redeemGitLabSessionCapability: unexpected,
+    issueBitbucketSessionCapability: unexpected,
+    redeemBitbucketSessionCapability: unexpected,
+    redeemGitHubSessionCapability: unexpected,
+    redeemKiloSessionCapability: unexpected,
+    async issueKiloSessionCapability(subject) {
+      const capability = `kka1.fixture-${++serial}`;
+      kiloSubjects.set(capability, subject);
+      return { success: true, capability };
+    },
+    async issueGitHubSessionCapability(subject) {
+      const capability = `kgh2.fixture-${++serial}`;
+      githubSubjects.set(capability, subject);
+      return {
+        success: true,
+        capability,
+        installationId: '42',
+        accountLogin: 'acme',
+        appType: 'standard',
+        source: 'installation',
+        gitAuthor: { name: 'fixture bot', email: 'fixture@example.com' },
+      };
+    },
+  };
+  return { binding, kiloSubjects, githubSubjects, tokens };
+}
+
+type WrapperLaunch = {
+  env: Record<string, string>;
+  physical: PhysicalRecord;
+  containerId?: string;
+  outboundHandler?: string;
+  networkPolicy?: VercelSandboxNetworkPolicy;
+};
+
+function fakeCloudflareContainers(readPhysical: () => Promise<PhysicalRecord>) {
+  const runtime = {
+    launches: [] as WrapperLaunch[],
+    destroyed: [] as string[],
+    running: new Set<string>(),
+    handlers: new Map<string, string>(),
+    failOutbound: false,
+  };
+  const namespace = (name: string) =>
+    Object.assign({} as Env['Sandbox'], {
+      idFromName: (id: string) => ({ toString: () => `${name}:${id}` }),
+      getByName(id: string) {
+        return this.get(this.idFromName(id) as DurableObjectId);
+      },
+      get: (id: DurableObjectId) => {
+        const containerId = id.toString();
+        return {
+          async configure() {},
+          async setOutboundHandler(handler: string) {
+            if (runtime.failOutbound) throw new Error('Outbound handler unavailable');
+            runtime.handlers.set(containerId, handler);
+          },
+          async startProcess(_command: string, options?: { env?: Record<string, string> }) {
+            runtime.launches.push({
+              env: options?.env ?? {},
+              containerId,
+              outboundHandler: runtime.handlers.get(containerId),
+              physical: await readPhysical(),
+            });
+            runtime.running.add(containerId);
+            return {};
+          },
+          async forceDestroyForControlPlane() {
+            runtime.destroyed.push(containerId);
+            runtime.running.delete(containerId);
+          },
+          async destroy() {
+            throw new Error('Legacy SDK destruction must not be used');
+          },
+          async isContainerRunning() {
+            return runtime.running.has(containerId);
+          },
+          async renewActivityTimeout() {},
+        };
+      },
+    });
+  return {
+    ...runtime,
+    bindings: {
+      Sandbox: namespace('standard'),
+      SandboxContainment: namespace('contained'),
+      SandboxSmall: namespace('small'),
+      SandboxSmallContainment: namespace('contained-small'),
+      SandboxCodeReview: namespace('review'),
+      SandboxCodeReviewContainment: namespace('contained-review'),
+      SandboxDIND: namespace('dind'),
+    },
+    setOutboundFailure: () => {
+      runtime.failOutbound = true;
+    },
+  };
+}
+
+function fakeVercelRuntime(sandboxName: string, readPhysical: () => Promise<PhysicalRecord>) {
+  const runtime = {
+    creates: 0,
+    launches: [] as WrapperLaunch[],
+    policy: undefined as VercelSandboxNetworkPolicy | undefined,
+    stoppedSessions: [] as string[],
+    failPolicy: false,
+    failStop: false,
+    beforeLaunch: undefined as (() => Promise<void>) | undefined,
+    beforePolicyUpdate: undefined as
+      | ((policy: VercelSandboxNetworkPolicy) => Promise<void>)
+      | undefined,
+  };
+  let session: VercelSandboxSession = {
+    id: 'vsess_joined_0',
+    sourceSandboxName: sandboxName,
+    projectId: VERCEL_ENV.VERCEL_PROJECT_ID,
+    runtime: 'node24',
+    status: 'running',
+    memory: 2048,
+    vcpus: 2,
+    region: 'iad1',
+    timeout: 300_000,
+    requestedAt: Date.now(),
+    startedAt: Date.now(),
+    cwd: '/',
+    createdAt: Date.now(),
+    updatedAt: Date.now(),
+  };
+  const client: VercelControlRestClient = {
+    async inspectByName(input) {
+      if (runtime.creates === 0 || input.name !== session.sourceSandboxName) return null;
+      return {
+        sandbox: {
+          name: sandboxName,
+          currentSessionId: session.id,
+          status: session.status === 'running' ? 'running' : 'stopped',
+          persistent: false,
+          createdAt: session.createdAt,
+          updatedAt: session.updatedAt,
+          tags: {},
+        },
+        session,
+        routes: [],
+        runtime: { sandboxName, sessionId: session.id },
+      };
+    },
+    async createSandbox(input) {
+      sandboxName = input.name;
+      runtime.creates += 1;
+      runtime.policy = input.networkPolicy;
+      session = {
+        ...session,
+        sourceSandboxName: sandboxName,
+        id: `vsess_joined_${runtime.creates}`,
+        status: 'running',
+      };
+      return {
+        sandbox: {
+          name: sandboxName,
+          currentSessionId: session.id,
+          status: 'running',
+          persistent: false,
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          tags: {},
+        },
+        session,
+        routes: [],
+        runtime: { sandboxName, sessionId: session.id },
+      };
+    },
+    async executeCommand(sessionId, input) {
+      await runtime.beforeLaunch?.();
+      runtime.launches.push({
+        env: input.env ?? {},
+        physical: await readPhysical(),
+        networkPolicy: runtime.policy,
+      });
+      return {
+        id: 'cmd_joined',
+        name: input.command,
+        args: input.args ?? [],
+        cwd: '/',
+        sessionId,
+        exitCode: null,
+        startedAt: Date.now(),
+      };
+    },
+    async updateNetworkPolicy(_sessionId, _sandboxName, policy) {
+      if (runtime.failPolicy) throw new Error('Native policy update unavailable');
+      await runtime.beforePolicyUpdate?.(policy);
+      runtime.policy = policy;
+      return session;
+    },
+    async getSession() {
+      return { session, routes: [] };
+    },
+    async extendSessionTimeout() {
+      return session;
+    },
+    async stopSession(sessionId) {
+      if (sessionId !== session.id) throw new Error('Unexpected native session stop');
+      if (runtime.failStop) throw new Error('Native stop temporarily unavailable');
+      runtime.stoppedSessions.push(sessionId);
+      session = { ...session, status: 'stopped' };
+      return session;
+    },
+    async readFile() {
+      return new Uint8Array();
+    },
+  };
+  const config = parseVercelSandboxRuntimeConfig(VERCEL_ENV);
+  if (!config) throw new Error('Invalid Vercel test configuration');
+  return {
+    runtime,
+    get provider() {
+      return createVercelProviderAdapter({ sandboxName, config, restClient: client });
+    },
+    createAdapter: (allocationName: string) =>
+      createVercelProviderAdapter({ sandboxName: allocationName, config, restClient: client }),
+  };
+}
+
+async function registerCredentialSession(registration: CredentialRegistration) {
+  const session = env.SANDBOX_SESSION.getByName(
+    `${registration.identity.userId}:${registration.identity.sessionId}`
+  );
+  await expect(session.registerSession(registration)).resolves.toEqual({ success: true });
+  return session;
+}
+
+async function credentialFixture(
+  provider: AgentSandboxProvider = 'cloudflare',
+  id: SandboxId = `${provider === 'vercel' ? 'ses' : 'usr'}-${crypto.randomUUID().replaceAll('-', '')}`
+) {
+  const control = env.SANDBOX_CONTROL.getByName(id);
+  const broker = fakeCredentialBroker();
+  const environment = {
+    ...env,
+    ...VERCEL_ENV,
+    GIT_TOKEN_SERVICE: broker.binding,
+    WORKER_URL: 'https://worker.test',
+    KILOCODE_BACKEND_BASE_URL: CONTAINMENT_TARGETS.backendBaseUrl,
+    KILO_OPENROUTER_BASE: CONTAINMENT_TARGETS.providerBaseUrl,
+    KILO_SESSION_INGEST_URL: CONTAINMENT_TARGETS.sessionIngestBaseUrl,
+  };
+  let containers: ReturnType<typeof fakeCloudflareContainers> | undefined;
+  let vercel: ReturnType<typeof fakeVercelRuntime> | undefined;
+  await runInDurableObject(control, instance => {
+    containers = fakeCloudflareContainers(() => instance.getPhysicalRecord());
+    vercel = fakeVercelRuntime(id, () => instance.getPhysicalRecord());
+    Object.assign(environment, containers.bindings);
+    Object.assign(instance, { env: environment });
+    if (provider === 'vercel') {
+      const runtime = vercel;
+      Object.assign(instance, {
+        createProviderAdapter: (_kind: AgentSandboxProvider, physical?: PhysicalRecord) =>
+          runtime.createAdapter(physical?.createIntent?.allocationName ?? id),
+      });
+    }
+  });
+  if (!containers || !vercel) throw new Error('Missing credential fixture');
+  const registration: CredentialRegistration = {
+    identity: {
+      sessionId: `workspace_${crypto.randomUUID()}`,
+      userId: CONTAINMENT_OWNER,
+      orgId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+      createdOnPlatform: 'cloud-agent-web',
+    },
+    auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
+    agent: { mode: 'code', model: 'test' },
+    repository: {
+      type: 'github',
+      repo: 'acme/repo',
+      githubIntegrationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+    },
+    workspace: {
+      sandboxId: id,
+      sandboxProvider: provider,
+      worktreeId: WORKTREE_ID,
+      workspacePath: '/workspace/joined',
+    },
+    profile: {
+      envVars: {
+        KILO_AUTH_CONTENT: JSON.stringify({ kilo: { type: 'api', key: KILO_TOKEN } }),
+        PUBLIC_VALUE: 'preserved',
+      },
+      setupCommands: [`fixture-command --credential=${KILO_TOKEN}`],
+    },
+  };
+  const session = await registerCredentialSession(registration);
+  const nativeContainers = containers;
+  return {
+    control,
+    broker,
+    containers,
+    vercel,
+    registration,
+    session,
+    environment,
+    sandboxId: id,
+    get outboundContainerId() {
+      if (provider === 'vercel') return '';
+      const value = nativeContainers.launches.at(-1)?.containerId;
+      if (!value) throw new Error('Missing native container identity');
+      return value;
+    },
+  };
+}
+
+async function credentialTerminalFixture(provider: AgentSandboxProvider) {
+  const fixture = await credentialFixture(provider);
+  const status = await fixture.control.ensureReady({
+    ...credentialInput(fixture.registration),
+    provider,
+    allowCreate: true,
+  });
+  const payload = status.attachment;
+  const launch =
+    provider === 'vercel' ? fixture.vercel.runtime.launches[0] : fixture.containers.launches[0];
+  if (!payload || !launch) throw new Error('Missing contained terminal runtime');
+  await fixture.control.attachSession(attachInput(fixture.registration, payload));
+  const wrapperInstanceId = crypto.randomUUID();
+  const socket = await connect(launch.env.SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
+  await completeHello(socket, 'hello-credential-terminal', {
+    providerInstanceId: launch.env.PROVIDER_INSTANCE_ID,
+    wrapperInstanceId,
+  });
+  signalWrapperReady(socket);
+  await vi.waitFor(async () => {
+    await expect(fixture.control.getStatus()).resolves.toMatchObject({
+      connection: 'ready',
+      wrapperInstanceId,
+    });
+  });
+  return {
+    ...fixture,
+    socket,
+    access: {
+      ...credentialInput(fixture.registration),
+      wrapperInstanceId,
+      ...(fixture.registration.identity.orgId
+        ? { organizationId: fixture.registration.identity.orgId }
+        : {}),
+    },
+  };
+}
+
+async function registerSiblingWorktree(registration: CredentialRegistration) {
+  const sibling: CredentialRegistration = {
+    ...registration,
+    identity: { ...registration.identity, sessionId: `workspace_${crypto.randomUUID()}` },
+    auth: { ...registration.auth, kiloSessionId: SECOND_ROOT_ID },
+    workspace: {
+      ...registration.workspace,
+      worktreeId: OTHER_WORKTREE_ID,
+      workspacePath: '/workspace/other',
+    },
+  };
+  await registerCredentialSession(sibling);
+  return sibling;
+}
+
+async function credentialExpiryDeadline(control: DurableObjectStub<SandboxControl>) {
+  return runInDurableObject(control, async (_instance, state) => {
+    const deadlines = await state.storage.get<{ credentialExpiry?: number }>('deadlines');
+    return deadlines?.credentialExpiry;
+  });
+}
+
+async function runCredentialExpiryAlarm(control: DurableObjectStub<SandboxControl>) {
+  await runInDurableObject(control, async (instance, state) => {
+    const deadlines = await state.storage.get<{ credentialExpiry?: number }>('deadlines');
+    await state.storage.put('deadlines', {
+      ...(deadlines?.credentialExpiry !== undefined
+        ? { credentialExpiry: deadlines.credentialExpiry }
+        : {}),
+    });
+    await instance.alarm();
+  });
+}
+
+async function finishFailedCreation(control: DurableObjectStub<SandboxControl>): Promise<void> {
+  const physical = await control.getPhysicalRecord();
+  if (!physical.createIntent) throw new Error('Missing retained creation intent');
+  const clock = vi
+    .spyOn(Date, 'now')
+    .mockReturnValue(physical.createIntent.createdAt + DEADLINE_MS.createSettle + 1);
+  try {
+    await control.recordStopAttempt();
+  } finally {
+    clock.mockRestore();
+  }
+  await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+    state: 'stopped',
+    providerRef: null,
+  });
+}
+
+async function readyAttachment(
+  control: DurableObjectStub<SandboxControl>,
+  input: { ownerId: string; sessionId: string }
+): Promise<SessionAttachPayload> {
+  const session = env.SANDBOX_SESSION.getByName(`${input.ownerId}:${input.sessionId}`);
+  const metadata = await runInDurableObject(session, instance => instance.getCredentialMetadata());
+  const status = await control.ensureReady({
+    ...input,
+    provider: metadata?.workspace?.sandboxProvider ?? 'cloudflare',
+    allowCreate: true,
+  });
+  if (!status.attachment) throw new Error('Missing contained readiness attachment');
+  return status.attachment;
+}
+
+function credentialInput(registration: CredentialRegistration) {
+  return { ownerId: registration.identity.userId, sessionId: registration.identity.sessionId };
+}
+
+function attachInput(registration: CredentialRegistration, payload: SessionAttachPayload) {
+  if (!payload.directory || !registration.auth.kiloSessionId) {
+    throw new Error('Missing prepared session identity');
+  }
+  return {
+    ...credentialInput(registration),
+    kiloSessionId: registration.auth.kiloSessionId,
+    directory: payload.directory,
+    ...(registration.workspace?.worktreeId
+      ? { worktreeId: registration.workspace.worktreeId }
+      : {}),
+  };
+}
+
+async function storedGrants(control: DurableObjectStub<SandboxControl>) {
+  return runInDurableObject(control, (_instance, state) =>
+    loadSessionCredentialGrants(state.storage)
+  );
+}
+
+async function updateCredentialMetadata(
+  session: DurableObjectStub<SandboxSession>,
+  update: (metadata: SessionMetadata) => SessionMetadata
+) {
+  await runInDurableObject(session, async (instance, state) => {
+    const metadata = await instance.getCredentialMetadata();
+    if (!metadata) throw new Error('Missing registered credential metadata');
+    state.storage.kv.put(SANDBOX_SESSION_METADATA_KEY, serializeSessionMetadata(update(metadata)));
+  });
+}
+
+function expectSanitized(value: unknown, broker: ReturnType<typeof fakeCredentialBroker>) {
+  const serialized = JSON.stringify(value);
+  for (const secret of [
+    KILO_TOKEN,
+    GITHUB_TOKEN,
+    broker.tokens.github,
+    ...broker.kiloSubjects.keys(),
+    ...broker.githubSubjects.keys(),
+  ]) {
+    expect(serialized).not.toContain(secret);
+  }
+}
+
+function expectCredentialFreeLaunch(
+  launch: WrapperLaunch,
+  broker: ReturnType<typeof fakeCredentialBroker>
+) {
+  for (const key of [
+    'KILOCODE_TOKEN',
+    'KILO_AUTH_CONTENT',
+    'KILO_CONFIG_CONTENT',
+    'OPENCODE_CONFIG_CONTENT',
+    'GH_TOKEN',
+    'GITHUB_TOKEN',
+    'GITLAB_TOKEN',
+    'BITBUCKET_TOKEN',
+  ]) {
+    expect(launch.env).not.toHaveProperty(key);
+  }
+  expectSanitized(launch.env, broker);
+}
+
+function policyAuthorization(
+  policy: VercelSandboxNetworkPolicy | undefined,
+  credential: string,
+  url: string,
+  method = 'GET'
+) {
+  return findMatchingCredentialInjectionRule(policy?.injectionRules ?? [], {
+    url: new URL(url),
+    method,
+    headers: new Headers({ authorization: `Bearer ${credential}` }),
+  })?.headers.authorization;
+}
 
 describe('SandboxControl in the Workers runtime', () => {
   it('rejects a missing credential', async () => {
@@ -362,9 +1216,9 @@ describe('SandboxControl in the Workers runtime', () => {
   it('accepts an authenticated hello but quarantines the runtime when its socket is replaced', async () => {
     const id = 'sbx_control_replaced';
     const credential = generateSandboxCredential();
-    await seedCredential(credential, id);
+    await seedRunningCredential(credential, id);
     const control = env.SANDBOX_CONTROL.getByName(id);
-    const { provider } = await installProvider(control, 'inst_1');
+    const { provider } = await installProvider(control, cloudflareRef(id));
     provider.stop.mockResolvedValue('retryable');
     const first = await connect(credential, id);
     await completeHello(first, 'hello-1');
@@ -383,7 +1237,7 @@ describe('SandboxControl in the Workers runtime', () => {
     await vi.waitFor(() => expect(provider.stop).toHaveBeenCalledTimes(1));
     await expect(control.getPhysicalRecord()).resolves.toMatchObject({
       state: 'stopping',
-      providerRef: 'inst_1',
+      providerRef: cloudflareRef(id),
       stopTombstone: { reason: 'control_replaced', attempts: 1 },
     });
     await runInDurableObject(control, async instance => {
@@ -395,12 +1249,12 @@ describe('SandboxControl in the Workers runtime', () => {
   });
 
   it('closes duplicate provisional sockets after a successful handshake', async () => {
-    const id = 'sbx_control_provisional_duplicates';
+    const id = 'sbx__control_provisional_duplicates';
     const credential = generateSandboxCredential();
     await seedCredential(credential, id);
     const stub = env.SANDBOX_CONTROL.getByName(id);
     await runInDurableObject(stub, async instance => {
-      await instance.confirmInstance('inst_1');
+      await seedRunningCloudflare(instance);
     });
 
     const provisional = await connect(credential, id);
@@ -409,7 +1263,9 @@ describe('SandboxControl in the Workers runtime', () => {
       provisional.addEventListener('close', event => resolve(event.code), { once: true });
     });
 
-    await completeHello(successful, 'hello-provisional-duplicates');
+    await completeHello(successful, 'hello-provisional-duplicates', {
+      providerInstanceId: cloudflareRef(id),
+    });
     await expect(provisionalClosed).resolves.toBe(1008);
     await runInDurableObject(stub, async (instance, state) => {
       await expect(instance.getStatus()).resolves.toMatchObject({
@@ -425,7 +1281,7 @@ describe('SandboxControl in the Workers runtime', () => {
   it('closes the live socket when the credential hash rotates', async () => {
     const sandboxId = 'sbx_control_rotate';
     const firstCredential = generateSandboxCredential();
-    await seedCredential(firstCredential, sandboxId);
+    await seedRunningCredential(firstCredential, sandboxId);
     const first = await connect(firstCredential, sandboxId);
     await completeHello(first, 'hello-rotate');
 
@@ -452,7 +1308,7 @@ describe('SandboxControl in the Workers runtime', () => {
   it('correlates an outbound request with the wrapper response', async () => {
     const sandboxId = 'sbx_control_rpc';
     const credential = generateSandboxCredential();
-    await seedCredential(credential, sandboxId);
+    await seedRunningCredential(credential, sandboxId);
     const ws = await connect(credential, sandboxId);
     await completeHello(ws, 'hello-rpc');
 
@@ -490,7 +1346,7 @@ describe('SandboxControl in the Workers runtime', () => {
 
 describe('SandboxControl auto-response ping', () => {
   it('registers a ping/pong pair that does not require a DO invocation', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_auto_ping');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_auto_ping');
     await runInDurableObject(stub, async (_instance, state) => {
       const pair = state.getWebSocketAutoResponse();
       expect(pair?.request).toBe(SANDBOX_CONTROL_AUTO_PING);
@@ -501,14 +1357,14 @@ describe('SandboxControl auto-response ping', () => {
 
 describe('SandboxControl owner identity', () => {
   it('returns null before initialize', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_owner_null');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_owner_null');
     await runInDurableObject(stub, async instance => {
       await expect(instance.getOwner()).resolves.toBeNull();
     });
   });
 
   it('stores the owner on first initialize', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_owner_init');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_owner_init');
     await runInDurableObject(stub, async instance => {
       await expect(instance.initializeOwner('user-1')).resolves.toEqual({ ownerId: 'user-1' });
       await expect(instance.getOwner()).resolves.toBe('user-1');
@@ -516,7 +1372,7 @@ describe('SandboxControl owner identity', () => {
   });
 
   it('is idempotent for the same owner', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_owner_idempotent');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_owner_idempotent');
     await runInDurableObject(stub, async instance => {
       await instance.initializeOwner('user-1');
       await expect(instance.initializeOwner('user-1')).resolves.toEqual({ ownerId: 'user-1' });
@@ -526,7 +1382,7 @@ describe('SandboxControl owner identity', () => {
   });
 
   it('rejects a different owner and keeps the original', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_owner_mismatch');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_owner_mismatch');
     await runInDurableObject(stub, async instance => {
       await instance.initializeOwner('user-1');
       await expect(instance.initializeOwner('user-2')).rejects.toThrow('Sandbox owner mismatch');
@@ -535,7 +1391,7 @@ describe('SandboxControl owner identity', () => {
   });
 
   it('rejects an empty ownerId', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_owner_empty');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_owner_empty');
     await runInDurableObject(stub, async instance => {
       await expect(instance.initializeOwner('')).rejects.toThrow(
         'ownerId must be a non-empty string'
@@ -549,13 +1405,3100 @@ describe('SandboxControl owner identity', () => {
 });
 
 describe('SandboxControl recovery watchdogs', () => {
+  it('retains the original cleanup deadline when an unknown disconnected provider reports active', async () => {
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_recovery_disconnected');
+    await runInDurableObject(stub, async (instance, state) => {
+      const providerRef = await seedRunningCloudflare(instance);
+      const uncertain = await instance.observeProvider('unknown');
+      expect(uncertain).toMatchObject({
+        state: 'unknown',
+        providerRef,
+        stopTombstone: { reason: 'provider_unknown' },
+      });
+      const deadlines = await loadDeadlines(state.storage);
+      expect(deadlines.wrapperReadiness).toBeUndefined();
+      expect(deadlines.heartbeatExpiry).toBeUndefined();
+      expect(deadlines.stopAttempt).toEqual(expect.any(Number));
+      await expect(instance.observeProvider('active')).resolves.toEqual(uncertain);
+      await instance.observeProvider('unknown');
+      await expect(instance.observeProvider('active')).resolves.toEqual(uncertain);
+      const after = await loadDeadlines(state.storage);
+      expect(after).toEqual({ ...deadlines, reconciliation: expect.any(Number) });
+      expect(after.reconciliation).toBeLessThanOrEqual(Date.now() + DEADLINE_MS.reconciliation);
+      expect(await state.storage.getAlarm()).toBe(deadlines.stopAttempt);
+    });
+  });
+
+  it('revokes heartbeat authority and rejects recovery of an unknown formerly ready provider', async () => {
+    const id = 'sbx__control_recovery_ready';
+    const credential = generateSandboxCredential();
+    await seedCredential(credential, id);
+    const stub = env.SANDBOX_CONTROL.getByName(id);
+    await runInDurableObject(stub, async instance => {
+      await seedRunningCloudflare(instance);
+    });
+
+    const ws = await connect(credential, id);
+    await completeHello(ws, 'hello-recovery-ready', { providerInstanceId: cloudflareRef(id) });
+    ws.send(
+      JSON.stringify({
+        type: 'event',
+        event: 'sandbox.ready',
+        payload: { kiloReady: true, globalFeedAttached: true },
+      })
+    );
+    await vi.waitFor(async () => {
+      await runInDurableObject(stub, async instance => {
+        await expect(instance.getStatus()).resolves.toMatchObject({ connection: 'ready' });
+      });
+    });
+
+    await runInDurableObject(stub, async (instance, state) => {
+      const initialDeadlines = await loadDeadlines(state.storage);
+      expect(initialDeadlines.heartbeatExpiry).toEqual(expect.any(Number));
+      delete initialDeadlines.heartbeatExpiry;
+      await saveDeadlines(state.storage, initialDeadlines);
+      await instance.observeProvider('unknown');
+
+      const uncertain = await instance.getPhysicalRecord();
+      await expect(instance.observeProvider('active')).resolves.toEqual(uncertain);
+      expect(uncertain).toMatchObject({
+        state: 'unknown',
+        providerRef: cloudflareRef(id),
+        stopTombstone: { reason: 'provider_unknown' },
+      });
+      const deadlines = await loadDeadlines(state.storage);
+      expect(deadlines.heartbeatExpiry).toBeUndefined();
+      expect(deadlines.wrapperReadiness).toBeUndefined();
+      expect(deadlines.stopAttempt).toEqual(expect.any(Number));
+      expect(await state.storage.getAlarm()).toBe(deadlines.stopAttempt);
+      await expect(instance.getStatus()).resolves.toMatchObject({ connection: 'disconnected' });
+      await instance.observeProvider('unknown');
+      await instance.observeProvider('active');
+      const after = await loadDeadlines(state.storage);
+      expect(after).toEqual({ ...deadlines, reconciliation: expect.any(Number) });
+      expect(after.reconciliation).toBeLessThanOrEqual(Date.now() + DEADLINE_MS.reconciliation);
+    });
+
+    ws.close();
+  });
+});
+
+describe('SandboxControl Vercel network policy updates', () => {
+  it('rejects an uninitialized owner without initializing ownership', async () => {
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__policy_owner_missing');
+    await runInDurableObject(stub, async instance => {
+      await expect(instance.updateNetworkPolicy(policyUpdateInput())).rejects.toThrow(
+        'Sandbox owner is not initialized'
+      );
+      await expect(instance.getOwner()).resolves.toBeNull();
+    });
+  });
+
+  it('requires an exact existing OAuth owner before invoking the provider', async () => {
+    const requestedSandboxId = 'sbx__policy_owner_mismatch';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      let updates = 0;
+      const provider = fakeProvider({
+        async updateNetworkPolicy() {
+          updates += 1;
+        },
+      });
+      await seedRunningVercel(instance, state, requestedSandboxId, provider);
+      await expect(
+        instance.updateNetworkPolicy(policyUpdateInput(`${CONTAINMENT_OWNER} `))
+      ).rejects.toThrow('Sandbox owner mismatch');
+      expect(updates).toBe(0);
+      await expect(instance.getOwner()).resolves.toBe(CONTAINMENT_OWNER);
+    });
+  });
+
+  it('rejects a non-Vercel provider', async () => {
+    const requestedSandboxId = 'sbx__policy_provider_kind';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      await seedRunningVercel(instance, state, requestedSandboxId, fakeProvider(), {
+        providerKind: 'cloudflare',
+      });
+      await expect(instance.updateNetworkPolicy(policyUpdateInput())).rejects.toThrow(
+        'Sandbox network policy requires a Vercel provider'
+      );
+    });
+  });
+
+  it.each(['stopped', 'creating', 'stopping', 'failed', 'unknown'] as const)(
+    'rejects a %s physical instance',
+    async physicalState => {
+      const requestedSandboxId = `sbx__policy_state_${physicalState}`;
+      const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+      await runInDurableObject(stub, async (instance, state) => {
+        const providerRef = encodeVercelProviderRef({
+          sandboxName: requestedSandboxId,
+          sessionId: 'vsess_not_running',
+        });
+        await seedRunningVercel(instance, state, requestedSandboxId, fakeProvider(), {
+          physical: { ...containedRunningRecord(providerRef), state: physicalState },
+        });
+        await expect(instance.updateNetworkPolicy(policyUpdateInput())).rejects.toThrow(
+          'Sandbox network policy requires a running instance'
+        );
+      });
+    }
+  );
+
+  it.each([
+    {
+      name: 'missing',
+      providerRef: null,
+      error: 'Sandbox network policy requires a running instance',
+    },
+    {
+      name: 'malformed',
+      providerRef: 'logical-name-only',
+      error: 'Sandbox network policy requires an exact provider reference',
+    },
+    {
+      name: 'different-sandbox',
+      providerRef: encodeVercelProviderRef({
+        sandboxName: 'sbx__someone_else',
+        sessionId: 'vsess_other',
+      }),
+      error: 'Sandbox network policy requires an exact provider reference',
+    },
+  ])('rejects a $name physical provider reference', async ({ name, providerRef, error }) => {
+    const requestedSandboxId = `sbx__policy_ref_${name}`;
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const physical: PhysicalRecord = {
+        state: 'running',
+        providerRef,
+        createIntent: null,
+        stopTombstone: null,
+        resumable: false,
+        ...(providerRef ? { containment: { ...CONTAINMENT_REQUIREMENTS, providerRef } } : {}),
+      };
+      await seedRunningVercel(instance, state, requestedSandboxId, fakeProvider(), { physical });
+      await expect(instance.updateNetworkPolicy(policyUpdateInput())).rejects.toThrow(error);
+    });
+  });
+
+  it.each(['missing', 'wrong-reference', 'wrong-flags', 'old-marker'] as const)(
+    'rejects a %s containment marker',
+    async markerKind => {
+      const requestedSandboxId = `sbx__policy_marker_${markerKind}`;
+      const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+      await runInDurableObject(stub, async (instance, state) => {
+        const providerRef = encodeVercelProviderRef({
+          sandboxName: requestedSandboxId,
+          sessionId: 'vsess_marked',
+        });
+        const marker =
+          markerKind === 'wrong-reference'
+            ? {
+                ...CONTAINMENT_REQUIREMENTS,
+                providerRef: encodeVercelProviderRef({
+                  sandboxName: requestedSandboxId,
+                  sessionId: 'vsess_previous',
+                }),
+              }
+            : markerKind === 'wrong-flags'
+              ? { ...CONTAINMENT_REQUIREMENTS, github: false, providerRef }
+              : markerKind === 'old-marker'
+                ? { kilocode: true, github: true, providerRef }
+                : undefined;
+        const physical: PhysicalRecord = {
+          state: 'running',
+          providerRef,
+          createIntent: null,
+          stopTombstone: null,
+          resumable: false,
+          ...(marker ? { containment: marker } : {}),
+        };
+        await seedRunningVercel(instance, state, requestedSandboxId, fakeProvider(), { physical });
+        await expect(instance.updateNetworkPolicy(policyUpdateInput())).rejects.toThrow(
+          'Sandbox credential containment mismatch'
+        );
+      });
+    }
+  );
+
+  it('rejects providers without an exact-session network policy capability', async () => {
+    const requestedSandboxId = 'sbx__policy_capability_missing';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      await seedRunningVercel(
+        instance,
+        state,
+        requestedSandboxId,
+        fakeProvider({ updateNetworkPolicy: undefined })
+      );
+      await expect(instance.updateNetworkPolicy(policyUpdateInput())).rejects.toThrow(
+        'Sandbox provider does not support network policy updates'
+      );
+    });
+  });
+
+  it('updates only the exact contained instance without persisting firewall credentials', async () => {
+    const requestedSandboxId = 'sbx__policy_exact_update';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const updates: Array<{ providerRef: string; networkPolicy: VercelSandboxNetworkPolicy }> = [];
+      const provider = fakeProvider({
+        async updateNetworkPolicy(providerRef, networkPolicy) {
+          updates.push({ providerRef, networkPolicy });
+        },
+      });
+      const providerRef = await seedRunningVercel(instance, state, requestedSandboxId, provider);
+      await expect(instance.updateNetworkPolicy(policyUpdateInput())).resolves.toBeUndefined();
+      expect(updates).toEqual([{ providerRef, networkPolicy: CONTAINMENT_POLICY }]);
+      expect(JSON.stringify([...(await state.storage.list())])).not.toContain(
+        'managed-firewall-test-token'
+      );
+    });
+  });
+
+  it('allows an overlapping readiness check to refresh the stateless provider adapter', async () => {
+    const {
+      control: stub,
+      sandboxId: requestedSandboxId,
+      registration,
+    } = await credentialFixture('vercel');
+    await runInDurableObject(stub, async (instance, state) => {
+      const replacementProvider = fakeProvider();
+      const provider = fakeProvider({
+        async updateNetworkPolicy() {
+          await expect(
+            instance.ensureReady({
+              ownerId: CONTAINMENT_OWNER,
+              provider: 'vercel',
+              allowCreate: false,
+              sessionId: registration.identity.sessionId,
+            })
+          ).resolves.toMatchObject({ physical: 'running' });
+        },
+      });
+      await seedRunningVercel(instance, state, requestedSandboxId, provider);
+      Object.assign(instance, {
+        pinProvider: async () => {
+          Object.assign(instance, { provider: replacementProvider });
+          return true;
+        },
+      });
+
+      await expect(instance.updateNetworkPolicy(policyUpdateInput())).resolves.toBeUndefined();
+    });
+  });
+
+  it('rejects a physical state change while the provider update is awaiting', async () => {
+    const requestedSandboxId = 'sbx__policy_stale_physical';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const provider = fakeProvider({
+        async updateNetworkPolicy() {
+          const physical = await state.storage.get<PhysicalRecord>('physical_record');
+          if (!physical) throw new Error('Missing test physical record');
+          await state.storage.put('physical_record', { ...physical, state: 'failed' });
+        },
+      });
+      await seedRunningVercel(instance, state, requestedSandboxId, provider);
+      await expect(instance.updateNetworkPolicy(policyUpdateInput())).rejects.toThrow(
+        'Sandbox instance changed during network policy update'
+      );
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({ state: 'failed' });
+    });
+  });
+
+  it('rejects a provider identity change while the provider update is awaiting', async () => {
+    const requestedSandboxId = 'sbx__policy_stale_provider';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const provider = fakeProvider({
+        async updateNetworkPolicy() {
+          await state.storage.put('provider_kind', 'cloudflare');
+        },
+      });
+      await seedRunningVercel(instance, state, requestedSandboxId, provider);
+      await expect(instance.updateNetworkPolicy(policyUpdateInput())).rejects.toThrow(
+        'Sandbox instance changed during network policy update'
+      );
+    });
+  });
+});
+
+describe('SandboxControl contained Vercel lifecycle', () => {
+  it.each(['malformed', 'cross-sandbox'] as const)(
+    'rejects a %s Vercel handshake before binding a creating instance',
+    async identityKind => {
+      const requestedSandboxId = `sbx__containment_handshake_${identityKind}`;
+      const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+      const credential = generateSandboxCredential();
+      const providerInstanceId =
+        identityKind === 'malformed'
+          ? requestedSandboxId
+          : encodeVercelProviderRef({
+              sandboxName: 'sbx__someone_else',
+              sessionId: 'vsess_other',
+            });
+      await runInDurableObject(stub, async (instance, state) => {
+        await instance.initializeOwner(CONTAINMENT_OWNER);
+        await state.storage.put('provider_kind', 'vercel');
+        Object.assign(instance, { provider: fakeProvider(), providerKind: 'vercel' });
+        await instance.claimCreate('intent_rejected', false, undefined, CONTAINMENT_REQUIREMENTS);
+        await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+      });
+
+      const ws = await connect(credential, requestedSandboxId);
+      await rejectHello(ws, `hello-rejected-${identityKind}`, providerInstanceId);
+      await runInDurableObject(stub, async instance => {
+        const physical = await instance.getPhysicalRecord();
+        expect(physical).toMatchObject({
+          state: 'creating',
+          providerRef: null,
+          createIntent: { containment: CONTAINMENT_REQUIREMENTS },
+        });
+        expect(physical.containment).toBeUndefined();
+        await expect(instance.getStatus()).resolves.toMatchObject({ connection: 'disconnected' });
+      });
+    }
+  );
+
+  it.each(['stopped', 'creating', 'stopping', 'failed', 'unknown'] as const)(
+    'rejects a valid-looking Vercel handshake while the instance is %s',
+    async physicalState => {
+      const requestedSandboxId = `sbx__containment_handshake_${physicalState}`;
+      const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+      const credential = generateSandboxCredential();
+      const providerRef = encodeVercelProviderRef({
+        sandboxName: requestedSandboxId,
+        sessionId: 'vsess_inactive',
+      });
+      await runInDurableObject(stub, async (instance, state) => {
+        await instance.initializeOwner(CONTAINMENT_OWNER);
+        await state.storage.put('provider_kind', 'vercel');
+        await state.storage.put('physical_record', {
+          ...containedRunningRecord(providerRef),
+          state: physicalState,
+        });
+        Object.assign(instance, { provider: fakeProvider(), providerKind: 'vercel' });
+        await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+      });
+
+      const ws = await connect(credential, requestedSandboxId);
+      await rejectHello(ws, `hello-inactive-${physicalState}`, providerRef);
+      await runInDurableObject(stub, async instance => {
+        await expect(instance.getPhysicalRecord()).resolves.toMatchObject({ state: physicalState });
+      });
+    }
+  );
+
+  it('preserves the current Vercel socket when a different physical session attempts a handshake', async () => {
+    const requestedSandboxId = 'sbx__containment_handshake_stale';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    const credential = generateSandboxCredential();
+    let providerRef = '';
+    await runInDurableObject(stub, async (instance, state) => {
+      providerRef = await seedRunningVercel(instance, state, requestedSandboxId, fakeProvider());
+      await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+    });
+
+    const current = await connect(credential, requestedSandboxId);
+    await completeHello(current, 'hello-current-instance', { providerInstanceId: providerRef });
+    const stale = await connect(credential, requestedSandboxId);
+    await rejectHello(
+      stale,
+      'hello-stale-instance',
+      encodeVercelProviderRef({
+        sandboxName: requestedSandboxId,
+        sessionId: 'vsess_previous',
+      })
+    );
+    expect(current.readyState).toBe(1);
+    await runInDurableObject(stub, async instance => {
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'running',
+        providerRef,
+        containment: { ...CONTAINMENT_REQUIREMENTS, providerRef },
+      });
+      await expect(instance.getStatus()).resolves.toMatchObject({ connection: 'connected' });
+    });
+
+    signalWrapperReady(current);
+    await vi.waitFor(async () => {
+      await expect(stub.getStatus()).resolves.toMatchObject({ connection: 'ready' });
+    });
+    const inbound = nextMessage(current);
+    const pending = runInDurableObject(stub, instance =>
+      instance.request({ operation: 'sandbox.status', payload: {} })
+    );
+    const request = JSON.parse(await inbound) as { requestId: string };
+    current.send(JSON.stringify({ type: 'response', requestId: request.requestId, ok: true }));
+    await expect(pending).resolves.toMatchObject({ ok: true });
+    current.close();
+  });
+
+  it('durably confirms the provider-created instance before its wrapper can launch', async () => {
+    const {
+      control: stub,
+      sandboxId: requestedSandboxId,
+      registration,
+    } = await credentialFixture('vercel');
+    let providerRef = '';
+    let credential = '';
+    await runInDurableObject(stub, async (instance, state) => {
+      const provider = fakeProvider({
+        async create(intent) {
+          providerRef = encodeVercelProviderRef({
+            sandboxName: intent.allocationName ?? requestedSandboxId,
+            sessionId: 'vsess_authoritative',
+          });
+          await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+            state: 'creating',
+            providerRef: null,
+          });
+          return { providerRef };
+        },
+        async launch(ref, launchEnv) {
+          expect(ref).toBe(providerRef);
+          await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+            state: 'running',
+            providerRef,
+            containment: { ...CONTAINMENT_REQUIREMENTS, providerRef },
+          });
+          credential = launchEnv.SANDBOX_CONTROL_CREDENTIAL ?? '';
+        },
+      });
+      await instance.initializeOwner(CONTAINMENT_OWNER);
+      await state.storage.put('provider_kind', 'vercel');
+      Object.assign(instance, {
+        provider,
+        createProviderAdapter: () => provider,
+        providerKind: 'vercel',
+        pinProvider: async () => true,
+      });
+
+      await expect(
+        instance.ensureReady({
+          ownerId: CONTAINMENT_OWNER,
+          provider: 'vercel',
+          allowCreate: true,
+          sessionId: registration.identity.sessionId,
+        })
+      ).resolves.toMatchObject({ physical: 'running', connection: 'disconnected' });
+    });
+
+    const stale = await connect(credential, requestedSandboxId);
+    let current: WebSocket | undefined;
+    try {
+      await rejectHello(
+        stale,
+        'hello-authoritative-stale',
+        encodeVercelProviderRef({
+          sandboxName: requestedSandboxId,
+          sessionId: 'vsess_stale',
+        })
+      );
+      current = await connect(credential, requestedSandboxId);
+      await completeHello(current, 'hello-authoritative-current', {
+        providerInstanceId: providerRef,
+      });
+    } finally {
+      await stub.detachSession(registration.identity.sessionId);
+      stale.close();
+      current?.close();
+    }
+  });
+
+  it.each(['wrapper-first', 'provider-first'] as const)(
+    'requires authoritative confirmation when startup confirmation is %s',
+    async order => {
+      const requestedSandboxId = `sbx__containment_${order}`;
+      const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+      const credential = generateSandboxCredential();
+      const providerRef = encodeVercelProviderRef({
+        sandboxName: requestedSandboxId,
+        sessionId: `vsess_${order}`,
+      });
+      await runInDurableObject(stub, async (instance, state) => {
+        await instance.initializeOwner(CONTAINMENT_OWNER);
+        await state.storage.put('provider_kind', 'vercel');
+        Object.assign(instance, { provider: fakeProvider(), providerKind: 'vercel' });
+        await instance.claimCreate('intent_race', false, undefined, CONTAINMENT_REQUIREMENTS);
+        await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+        if (order === 'provider-first') {
+          await instance.confirmInstance(providerRef);
+        }
+      });
+
+      if (order === 'wrapper-first') {
+        const premature = await connect(credential, requestedSandboxId);
+        await rejectHello(premature, 'hello-before-confirmation', providerRef);
+        await runInDurableObject(stub, async instance => {
+          await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+            state: 'creating',
+            providerRef: null,
+          });
+          await instance.confirmInstance(providerRef);
+        });
+      }
+      const ws = await connect(credential, requestedSandboxId);
+      await completeHello(ws, `hello-${order}`, { providerInstanceId: providerRef });
+      await runInDurableObject(stub, async instance => {
+        await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+          state: 'running',
+          providerRef,
+          createIntent: { intentId: 'intent_race', containment: CONTAINMENT_REQUIREMENTS },
+          containment: { ...CONTAINMENT_REQUIREMENTS, providerRef },
+        });
+      });
+      ws.close();
+    }
+  );
+
+  it('claims creation before credential rotation and fences competing readiness checks', async () => {
+    const { control: stub, registration } = await credentialFixture('vercel');
+    await runInDurableObject(stub, async (instance, state) => {
+      const previousHash = await hashSandboxCredential(generateSandboxCredential());
+      await instance.initializeOwner(CONTAINMENT_OWNER);
+      await state.storage.put('provider_kind', 'vercel');
+      await state.storage.put('wrapper_credential_hash', previousHash);
+      await state.storage.put('wrapper_ready_at', 123);
+      const input = {
+        ownerId: CONTAINMENT_OWNER,
+        provider: 'vercel' as const,
+        allowCreate: true,
+        sessionId: registration.identity.sessionId,
+      };
+      let creates = 0;
+      let claims = 0;
+      let competingReadiness: ReturnType<SandboxControl['ensureReady']> | undefined;
+      const provider = fakeProvider({
+        async create() {
+          creates += 1;
+          return { unresolved: true };
+        },
+      });
+      const claim = instance.claimCreate.bind(instance);
+      Object.assign(instance, {
+        provider,
+        createProviderAdapter: () => provider,
+        providerKind: 'vercel',
+        pinProvider: async () => true,
+        claimCreate: async (
+          intentId: string,
+          resumable = false,
+          allocationName?: string,
+          containment?: CredentialContainmentRequirements
+        ) => {
+          claims += 1;
+          expect(await state.storage.get<string>('wrapper_credential_hash')).toBe(previousHash);
+          expect(await state.storage.get<number>('wrapper_ready_at')).toBe(123);
+          const claimed = await claim(intentId, resumable, allocationName, containment);
+          competingReadiness = instance.ensureReady(input);
+          await expect(
+            instance.ensureReady({ ...input, ownerId: 'github|oauth:different-user' })
+          ).rejects.toThrow('Sandbox owner mismatch');
+          return claimed;
+        },
+      });
+
+      await expect(instance.ensureReady(input)).resolves.toMatchObject({ physical: 'creating' });
+      await expect(competingReadiness).resolves.toMatchObject({ physical: 'creating' });
+      expect(claims).toBe(1);
+      expect(creates).toBe(1);
+      expect(await state.storage.get<string>('wrapper_credential_hash')).not.toBe(previousHash);
+      expect(await state.storage.get<number>('wrapper_ready_at')).toBeUndefined();
+    });
+  });
+
+  it.each(['cloudflare', 'vercel'] as const)(
+    'joins concurrent %s cold starts after credential preparation',
+    async providerKind => {
+      const { control, registration, containers, vercel } = await credentialFixture(providerKind);
+      const sibling = await registerSiblingWorktree(registration);
+      await runInDurableObject(control, async instance => {
+        const statuses = await Promise.all(
+          [registration, sibling].map(value =>
+            instance.ensureReady({
+              ...credentialInput(value),
+              provider: providerKind,
+              allowCreate: true,
+            })
+          )
+        );
+        expect(statuses.every(status => ['creating', 'running'].includes(status.physical))).toBe(
+          true
+        );
+        expect(statuses.map(status => status.attachment?.kilo?.scopeId).sort()).toEqual(
+          [WORKTREE_ID, OTHER_WORKTREE_ID].sort()
+        );
+        expect((await instance.getPhysicalRecord()).state).toBe('running');
+      });
+      expect(providerKind === 'vercel' ? vercel.runtime.creates : containers.launches.length).toBe(
+        1
+      );
+      expect(await storedGrants(control)).toHaveLength(2);
+    }
+  );
+
+  it.each(['reconciliation', 'detach'] as const)(
+    'finishes %s cleanup after a Vercel create fails without a provider reference',
+    async cleanup => {
+      const { control, registration, vercel } = await credentialFixture('vercel');
+      await runInDurableObject(control, async (instance, state) => {
+        const observations: Array<string | null> = [];
+        const provider = fakeProvider({
+          async create() {
+            throw new Error('Create rejected before allocating an instance');
+          },
+          async stop() {
+            return 'retryable';
+          },
+          async observe(ref, intent) {
+            observations.push(ref);
+            return vercel.provider.observe(ref, intent);
+          },
+        });
+        Object.assign(instance, { createProviderAdapter: () => provider });
+        await expect(
+          instance.ensureReady({
+            ...credentialInput(registration),
+            provider: 'vercel',
+            allowCreate: true,
+          })
+        ).resolves.toMatchObject({ physical: 'failed' });
+        expect(await instance.getPhysicalRecord()).toMatchObject({ providerRef: null });
+        expect(await state.storage.get('credential_policy_dirty')).toBe(true);
+        if (cleanup === 'detach') {
+          await expect(instance.detachSession(registration.identity.sessionId)).rejects.toThrow(
+            'Sandbox credential revocation is pending'
+          );
+        }
+        const physical = await instance.getPhysicalRecord();
+        if (!physical.createIntent) throw new Error('Missing retained creation intent');
+        const clock = vi
+          .spyOn(Date, 'now')
+          .mockReturnValue(physical.createIntent.createdAt + DEADLINE_MS.createSettle + 1);
+        try {
+          await state.storage.put('deadlines', {
+            [cleanup === 'detach' ? 'stopAttempt' : 'reconciliation']: Date.now() - 1,
+          });
+          await instance.alarm();
+        } finally {
+          clock.mockRestore();
+        }
+        if (cleanup === 'detach') {
+          await expect(instance.detachSession(registration.identity.sessionId)).resolves.toEqual({
+            existed: false,
+          });
+        }
+        expect(observations).toEqual(cleanup === 'detach' ? [null, null] : [null]);
+        expect(await instance.getPhysicalRecord()).toMatchObject({
+          state: 'stopped',
+          providerRef: null,
+          createIntent: null,
+        });
+        expect(await loadSessionCredentialGrants(state.storage)).toEqual([]);
+        expect(await state.storage.get('credential_policy_dirty')).toBeUndefined();
+        expect(await loadDeadlines(state.storage)).not.toHaveProperty('reconciliation');
+        expect(await state.storage.getAlarm()).toBeNull();
+      });
+    }
+  );
+
+  it('retains a failed null-reference creation when the provider cannot confirm absence', async () => {
+    const { control, registration } = await credentialFixture('vercel');
+    await runInDurableObject(control, async (instance, state) => {
+      const provider = fakeProvider({
+        async create() {
+          throw new Error('Create outcome unavailable');
+        },
+        async observe() {
+          return { status: 'unknown' };
+        },
+      });
+      Object.assign(instance, { createProviderAdapter: () => provider });
+      await instance.ensureReady({
+        ...credentialInput(registration),
+        provider: 'vercel',
+        allowCreate: true,
+      });
+      const grants = await loadSessionCredentialGrants(state.storage);
+      await state.storage.put('deadlines', { reconciliation: Date.now() - 1 });
+      await instance.alarm();
+      expect(await instance.getPhysicalRecord()).toMatchObject({
+        state: 'unknown',
+        providerRef: null,
+        stopTombstone: { reason: 'environment_failed' },
+      });
+      expect(await loadSessionCredentialGrants(state.storage)).toEqual(grants);
+      expect(await state.storage.get('credential_policy_dirty')).toBe(true);
+      expect((await loadDeadlines(state.storage)).reconciliation).toBeGreaterThan(Date.now());
+    });
+  });
+
+  it('revokes the previous ready wrapper before provisioning a replacement', async () => {
+    const { control, registration, sandboxId, vercel, broker } = await credentialFixture('vercel');
+    const input = credentialInput(registration);
+    const initial = await control.ensureReady({ ...input, provider: 'vercel', allowCreate: true });
+    const payload = initial.attachment;
+    if (!payload?.kilo || !payload.git?.token)
+      throw new Error('Missing initial contained attachment');
+    await control.attachSession(attachInput(registration, payload));
+    const launch = vercel.runtime.launches[0];
+    const credential = launch.env.SANDBOX_CONTROL_CREDENTIAL;
+    const previousRef = launch.env.PROVIDER_INSTANCE_ID;
+    const previous = await connect(credential, sandboxId);
+    try {
+      await completeHello(previous, 'hello-previous-wrapper', { providerInstanceId: previousRef });
+      signalWrapperReady(previous);
+      await vi.waitFor(async () => {
+        await expect(control.getStatus()).resolves.toMatchObject({ connection: 'ready' });
+      });
+      await runInDurableObject(control, async (instance, state) => {
+        const physical = await instance.getPhysicalRecord();
+        await state.storage.put('physical_record', { ...physical, state: 'failed' });
+      });
+      const closed = new Promise<number>(resolve => {
+        previous.addEventListener('close', event => resolve(event.code), { once: true });
+      });
+      const result = await runInDurableObject(control, async (instance, state) => {
+        const stoppedRefs: Array<string | null> = [];
+        let connectionAtCreate = '';
+        let hadReadyMarkerAtCreate = true;
+        const createProviderAdapter = (
+          _kind: AgentSandboxProvider,
+          physical?: PhysicalRecord
+        ): ProviderAdapter => {
+          const adapter = vercel.createAdapter(physical?.createIntent?.allocationName ?? sandboxId);
+          return {
+            ...adapter,
+            async stop(ref, intent) {
+              stoppedRefs.push(ref);
+              return adapter.stop(ref, intent);
+            },
+            async create(intent) {
+              connectionAtCreate = (await instance.getStatus()).connection;
+              hadReadyMarkerAtCreate =
+                (await state.storage.get<number>('wrapper_ready_at')) !== undefined;
+              return adapter.create(intent);
+            },
+          };
+        };
+        Object.assign(instance, { createProviderAdapter });
+        await expect(instance.prepareSessionCredentials(input)).rejects.toThrow(
+          'Sandbox credential containment is unavailable'
+        );
+        expect(await loadSessionCredentialGrants(state.storage)).toHaveLength(1);
+        const status = await instance.ensureReady({ ...input, allowCreate: true });
+        return {
+          status,
+          stoppedRefs,
+          connectionAtCreate,
+          hadReadyMarkerAtCreate,
+        };
+      });
+      await expect(closed).resolves.toBe(4001);
+      expect(result.status).toMatchObject({ physical: 'running', connection: 'disconnected' });
+      expect(result.connectionAtCreate).toBe('disconnected');
+      expect(result.hadReadyMarkerAtCreate).toBe(false);
+      expect(result.stoppedRefs).toEqual([previousRef]);
+      expect(vercel.runtime.creates).toBe(2);
+      const replacementLaunch = vercel.runtime.launches[1];
+      expect(replacementLaunch.env.PROVIDER_INSTANCE_ID).not.toBe(previousRef);
+      const fresh = result.status.attachment;
+      if (!fresh?.kilo || !fresh.git?.token)
+        throw new Error('Missing replacement contained attachment');
+      expect(fresh.kilo.scopeId).toBe(payload.kilo.scopeId);
+      expect(fresh.kilo.token).not.toBe(payload.kilo.token);
+      expect(fresh.git.token).not.toBe(payload.git.token);
+      expect(fresh.directory).toBe(payload.directory);
+      expect(fresh.snapshotIdentity).toBe(ROOT_ID);
+      expect(JSON.stringify(fresh)).not.toContain(payload.kilo.token);
+      expect(JSON.stringify(fresh)).not.toContain(payload.git.token);
+      expectSanitized(fresh, broker);
+      const grants = await storedGrants(control);
+      expect(grants).toEqual([
+        expect.objectContaining({
+          scopeId: WORKTREE_ID,
+          members: [{ sessionId: input.sessionId, kiloSessionId: ROOT_ID }],
+          kilo: expect.objectContaining({ alias: fresh.kilo.token }),
+          scm: expect.objectContaining({ alias: fresh.git.token }),
+        }),
+      ]);
+      const exportUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`;
+      expect(
+        policyAuthorization(vercel.runtime.policy, payload.kilo.token, exportUrl)
+      ).toBeUndefined();
+      expect(policyAuthorization(vercel.runtime.policy, fresh.kilo.token, exportUrl)).toBe(
+        `Bearer ${KILO_TOKEN}`
+      );
+      expect(
+        policyAuthorization(
+          vercel.runtime.policy,
+          payload.git.token,
+          'https://api.github.com/repos/acme/repo'
+        )
+      ).toBeUndefined();
+      expect(
+        policyAuthorization(
+          vercel.runtime.policy,
+          fresh.git.token,
+          'https://api.github.com/repos/acme/repo'
+        )
+      ).toBe(`Bearer ${GITHUB_TOKEN}`);
+      const replacement = await connect(
+        replacementLaunch.env.SANDBOX_CONTROL_CREDENTIAL,
+        sandboxId
+      );
+      try {
+        await completeHello(replacement, 'hello-replacement-wrapper', {
+          providerInstanceId: replacementLaunch.env.PROVIDER_INSTANCE_ID,
+        });
+        signalWrapperReady(replacement);
+        await vi.waitFor(async () => {
+          await expect(control.getStatus()).resolves.toMatchObject({ connection: 'ready' });
+        });
+        const attachment = attachInput(registration, fresh);
+        await control.attachSession(attachment);
+        const inbound = nextMessage(replacement);
+        const pending = control.request({
+          operation: 'session.attach',
+          session: {
+            sessionId: attachment.sessionId,
+            kiloSessionId: attachment.kiloSessionId,
+            directory: attachment.directory,
+          },
+          payload: fresh,
+        });
+        const request = JSON.parse(await inbound) as {
+          requestId: string;
+          payload: SessionAttachPayload;
+        };
+        expect(request.payload).toEqual(fresh);
+        expect(JSON.stringify(request)).not.toContain(payload.kilo.token);
+        expect(JSON.stringify(request)).not.toContain(payload.git.token);
+        replacement.send(
+          JSON.stringify({ type: 'response', requestId: request.requestId, ok: true })
+        );
+        await expect(pending).resolves.toMatchObject({ ok: true });
+        expect(await control.listRoutes()).toEqual([expect.objectContaining(attachment)]);
+      } finally {
+        replacement.close();
+      }
+      const rejected = await SELF.fetch(`http://worker.test/sandbox-control/${sandboxId}`, {
+        headers: { Upgrade: 'websocket', Authorization: `Bearer ${credential}` },
+      });
+      expect(rejected.status).toBe(401);
+    } finally {
+      previous.close();
+    }
+  });
+
+  it.each(['unmarked', 'wrong-flags', 'wrong-reference', 'old-marker'] as const)(
+    'fails closed and retains the exact reference for a %s warm instance',
+    async markerKind => {
+      const requestedSandboxId = `sbx__containment_warm_${markerKind}`;
+      const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+      await runInDurableObject(stub, async (instance, state) => {
+        const providerRef = encodeVercelProviderRef({
+          sandboxName: requestedSandboxId,
+          sessionId: 'vsess_warm',
+        });
+        const marker =
+          markerKind === 'wrong-flags'
+            ? { kilocode: true, github: false, providerRef }
+            : markerKind === 'wrong-reference'
+              ? {
+                  ...CONTAINMENT_REQUIREMENTS,
+                  providerRef: encodeVercelProviderRef({
+                    sandboxName: requestedSandboxId,
+                    sessionId: 'vsess_previous',
+                  }),
+                }
+              : markerKind === 'old-marker'
+                ? { kilocode: true, github: true, providerRef }
+                : undefined;
+        const physical: PhysicalRecord = {
+          state: 'running',
+          providerRef,
+          createIntent: null,
+          stopTombstone: null,
+          resumable: false,
+          ...(marker ? { containment: marker } : {}),
+        };
+        let creates = 0;
+        const stoppedRefs: Array<string | null> = [];
+        const provider = fakeProvider({
+          async create() {
+            creates += 1;
+            return { unresolved: true };
+          },
+          async stop(ref) {
+            stoppedRefs.push(ref);
+            return 'retryable';
+          },
+        });
+        await seedRunningVercel(instance, state, requestedSandboxId, provider, {
+          physical,
+          bypassPin: true,
+        });
+
+        const status = await instance.ensureReady({
+          ownerId: CONTAINMENT_OWNER,
+          provider: 'vercel',
+          allowCreate: true,
+          sessionId: GRANT_SESSION_ID,
+        });
+        expect(status.physical).toBe('stopping');
+        await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+          state: 'stopping',
+          providerRef,
+          stopTombstone: { reason: 'credential_containment_unavailable', attempts: 1 },
+        });
+        expect(stoppedRefs).toEqual([providerRef]);
+        expect(creates).toBe(0);
+      });
+    }
+  );
+
+  it('preserves a newer creation when a stale failed-instance stop completes', async () => {
+    const {
+      control: stub,
+      sandboxId: requestedSandboxId,
+      registration,
+    } = await credentialFixture('vercel');
+    await runInDurableObject(stub, async (instance, state) => {
+      const previousRef = encodeVercelProviderRef({
+        sandboxName: requestedSandboxId,
+        sessionId: 'vsess_previous',
+      });
+      const replacement = claimCreate(
+        initialPhysicalRecord(false),
+        'intent_replacement',
+        Date.now(),
+        undefined,
+        CONTAINMENT_REQUIREMENTS
+      );
+      const stoppedRefs: Array<string | null> = [];
+      let creates = 0;
+      const provider = fakeProvider({
+        async stop(ref) {
+          stoppedRefs.push(ref);
+          await state.storage.put('physical_record', replacement);
+          return 'terminal';
+        },
+        async create() {
+          creates += 1;
+          return { unresolved: true };
+        },
+      });
+      await seedRunningVercel(instance, state, requestedSandboxId, provider, {
+        bypassPin: true,
+        physical: { ...containedRunningRecord(previousRef), state: 'failed' },
+      });
+
+      const status = await instance.ensureReady({
+        ownerId: CONTAINMENT_OWNER,
+        provider: 'vercel',
+        allowCreate: true,
+        sessionId: registration.identity.sessionId,
+      });
+      expect(status.physical).toBe('creating');
+      await expect(instance.getPhysicalRecord()).resolves.toEqual(replacement);
+      expect(stoppedRefs).toEqual([previousRef]);
+      expect(creates).toBe(0);
+    });
+  });
+
+  it('immediately reclaims an unmarked warm Vercel instance using its exact reference', async () => {
+    const requestedSandboxId = 'sbx__containment_warm_reclaimed';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const providerRef = encodeVercelProviderRef({
+        sandboxName: requestedSandboxId,
+        sessionId: 'vsess_unmarked',
+      });
+      const stoppedRefs: Array<string | null> = [];
+      let creates = 0;
+      const provider = fakeProvider({
+        async create() {
+          creates += 1;
+          return { unresolved: true };
+        },
+        async stop(ref) {
+          stoppedRefs.push(ref);
+          return 'terminal';
+        },
+      });
+      await seedRunningVercel(instance, state, requestedSandboxId, provider, {
+        bypassPin: true,
+        physical: {
+          state: 'running',
+          providerRef,
+          createIntent: null,
+          stopTombstone: null,
+          resumable: false,
+        },
+      });
+
+      const status = await instance.ensureReady({
+        ownerId: CONTAINMENT_OWNER,
+        provider: 'vercel',
+        allowCreate: true,
+        sessionId: GRANT_SESSION_ID,
+      });
+      expect(status.physical).toBe('stopped');
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'stopped',
+        providerRef: null,
+      });
+      expect(stoppedRefs).toEqual([providerRef]);
+      expect(creates).toBe(0);
+    });
+  });
+
+  it('never issues native cleanup using a logical-name-only Vercel reference', async () => {
+    const requestedSandboxId = 'sbx__containment_warm_logical_reference';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const nativeCalls: string[] = [];
+      const provider = unresolvableVercelProvider(requestedSandboxId, nativeCalls);
+      await seedRunningVercel(instance, state, requestedSandboxId, provider, {
+        bypassPin: true,
+        physical: {
+          state: 'running',
+          providerRef: requestedSandboxId,
+          createIntent: null,
+          stopTombstone: null,
+          resumable: false,
+        },
+      });
+
+      const status = await instance.ensureReady({
+        ownerId: CONTAINMENT_OWNER,
+        provider: 'vercel',
+        allowCreate: true,
+        sessionId: GRANT_SESSION_ID,
+      });
+      expect(status.physical).toBe('stopping');
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'stopping',
+        providerRef: requestedSandboxId,
+        stopTombstone: { reason: 'credential_containment_unavailable', attempts: 1 },
+      });
+      expect(nativeCalls).toEqual([]);
+    });
+  });
+
+  it('fails closed when an existing creation intent requests different containment', async () => {
+    const requestedSandboxId = 'sbx__containment_wrong_intent';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const physical = claimCreate(initialPhysicalRecord(false), 'intent_previous', 1, undefined, {
+        kilocode: false,
+        github: true,
+      });
+      await seedRunningVercel(instance, state, requestedSandboxId, fakeProvider(), {
+        physical,
+        bypassPin: true,
+      });
+
+      const status = await instance.ensureReady({
+        ownerId: CONTAINMENT_OWNER,
+        provider: 'vercel',
+        allowCreate: true,
+        sessionId: GRANT_SESSION_ID,
+      });
+      expect(status.physical).toBe('stopping');
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'stopping',
+        stopTombstone: { reason: 'credential_containment_unavailable', attempts: 1 },
+        createIntent: {
+          intentId: 'intent_previous',
+          containment: { kilocode: false, github: true },
+        },
+      });
+    });
+  });
+
+  it('requires authoritative session credentials even when a valid grant was already stored', async () => {
+    const requestedSandboxId = 'ses-abcd0001';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      let creates = 0;
+      const provider = fakeProvider({
+        async create() {
+          creates += 1;
+          return { unresolved: true };
+        },
+      });
+      await instance.initializeOwner(CONTAINMENT_OWNER);
+      await state.storage.put('provider_kind', 'vercel');
+      Object.assign(instance, {
+        provider,
+        createProviderAdapter: () => provider,
+        providerKind: 'vercel',
+        pinProvider: async () => true,
+      });
+      const grant = await seedGrant(instance, state, undefined, 'vercel');
+
+      await expect(
+        instance.ensureReady({
+          ownerId: CONTAINMENT_OWNER,
+          sessionId: GRANT_SESSION_ID,
+          provider: 'vercel',
+          allowCreate: true,
+        })
+      ).rejects.toThrow('Session credential ownership mismatch');
+      expect(await loadSessionCredentialGrants(state.storage)).toEqual([grant]);
+      expect(await state.storage.get('wrapper_credential_hash')).toBeUndefined();
+      expect(creates).toBe(0);
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'failed',
+        providerRef: null,
+        stopTombstone: { reason: 'environment_failed' },
+      });
+    });
+  });
+
+  it('persists the exact instance before failing a wrapper startup', async () => {
+    const {
+      control: stub,
+      sandboxId: requestedSandboxId,
+      registration,
+    } = await credentialFixture('vercel');
+    await runInDurableObject(stub, async (instance, state) => {
+      let providerRef = '';
+      let capturedIntent: ProviderCreateIntent | undefined;
+      let launchEnv: Record<string, string> | undefined;
+      const stoppedRefs: Array<string | null> = [];
+      const provider = fakeProvider({
+        async create(intent) {
+          capturedIntent = intent;
+          providerRef = encodeVercelProviderRef({
+            sandboxName: intent.allocationName ?? requestedSandboxId,
+            sessionId: 'vsess_startup_failed',
+          });
+          return { providerRef };
+        },
+        async launch(ref, environment) {
+          launchEnv = environment;
+          expect(ref).toBe(providerRef);
+          await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+            state: 'running',
+            providerRef,
+          });
+          throw new Error('Wrapper startup failed');
+        },
+        async stop(ref) {
+          stoppedRefs.push(ref);
+          return 'retryable';
+        },
+      });
+      await instance.initializeOwner(CONTAINMENT_OWNER);
+      await state.storage.put('provider_kind', 'vercel');
+      Object.assign(instance, {
+        provider,
+        createProviderAdapter: () => provider,
+        providerKind: 'vercel',
+        pinProvider: async () => true,
+      });
+
+      const status = await instance.ensureReady({
+        ownerId: CONTAINMENT_OWNER,
+        provider: 'vercel',
+        allowCreate: true,
+        sessionId: registration.identity.sessionId,
+      });
+      expect(status.physical).toBe('failed');
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'failed',
+        providerRef,
+        createIntent: {
+          intentId: capturedIntent?.intentId,
+          allocationName: capturedIntent?.allocationName,
+        },
+        containment: { ...CONTAINMENT_REQUIREMENTS, providerRef },
+      });
+      expect(stoppedRefs).toEqual([]);
+      await instance.recordStopAttempt();
+      expect(stoppedRefs).toEqual([providerRef]);
+      expect(capturedIntent?.networkPolicy).toEqual(
+        buildControlNetworkPolicy(await loadSessionCredentialGrants(state.storage))
+      );
+      expect(launchEnv).toMatchObject({
+        SANDBOX_CONTROL_CREDENTIAL: expect.any(String),
+        KILO_PLATFORM: 'cloud-agent',
+      });
+      for (const key of ['KILOCODE_TOKEN', 'KILO_AUTH_CONTENT', 'GH_TOKEN', 'GITHUB_TOKEN']) {
+        expect(launchEnv).not.toHaveProperty(key);
+      }
+      expect(JSON.stringify(launchEnv)).not.toContain(KILO_TOKEN);
+    });
+  });
+
+  it('stops the exact Vercel instance on the first cleanup attempt when wrapper startup fails', async () => {
+    const {
+      control: stub,
+      sandboxId: requestedSandboxId,
+      registration,
+    } = await credentialFixture('vercel');
+    await runInDurableObject(stub, async (instance, state) => {
+      let providerRef = '';
+      const stoppedRefs: Array<string | null> = [];
+      const provider = fakeProvider({
+        async create(intent) {
+          providerRef = encodeVercelProviderRef({
+            sandboxName: intent.allocationName ?? requestedSandboxId,
+            sessionId: 'vsess_startup_reclaimed',
+          });
+          return { providerRef };
+        },
+        async launch(ref) {
+          expect(ref).toBe(providerRef);
+          throw new Error('Wrapper startup failed');
+        },
+        async stop(ref) {
+          stoppedRefs.push(ref);
+          return 'terminal';
+        },
+        async observe() {
+          return { status: stoppedRefs.length > 0 ? 'terminal' : 'active' };
+        },
+      });
+      await instance.initializeOwner(CONTAINMENT_OWNER);
+      await state.storage.put('provider_kind', 'vercel');
+      Object.assign(instance, {
+        provider,
+        createProviderAdapter: () => provider,
+        providerKind: 'vercel',
+        pinProvider: async () => true,
+      });
+
+      const status = await instance.ensureReady({
+        ownerId: CONTAINMENT_OWNER,
+        provider: 'vercel',
+        allowCreate: true,
+        sessionId: registration.identity.sessionId,
+      });
+      expect(status.physical).toBe('failed');
+      await instance.recordStopAttempt();
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'stopped',
+        providerRef: null,
+      });
+      expect(stoppedRefs).toEqual([providerRef]);
+    });
+  });
+
+  it('requires worktree containment and a native policy even without an SCM repository', async () => {
+    const {
+      control: stub,
+      sandboxId: requestedSandboxId,
+      registration,
+      session,
+    } = await credentialFixture('vercel');
+    await updateCredentialMetadata(session, metadata => ({ ...metadata, repository: undefined }));
+    await runInDurableObject(stub, async (instance, state) => {
+      let providerRef = '';
+      let capturedIntent: ProviderCreateIntent | undefined;
+      let launchEnv: Record<string, string> | undefined;
+      const provider = fakeProvider({
+        async create(intent) {
+          capturedIntent = intent;
+          providerRef = encodeVercelProviderRef({
+            sandboxName: intent.allocationName ?? requestedSandboxId,
+            sessionId: 'vsess_github_only',
+          });
+          return { providerRef };
+        },
+        async launch(ref, environment) {
+          expect(ref).toBe(providerRef);
+          launchEnv = environment;
+        },
+      });
+      await instance.initializeOwner(CONTAINMENT_OWNER);
+      await state.storage.put('provider_kind', 'vercel');
+      Object.assign(instance, {
+        provider,
+        createProviderAdapter: () => provider,
+        providerKind: 'vercel',
+        pinProvider: async () => true,
+      });
+
+      const status = await instance.ensureReady({
+        ownerId: CONTAINMENT_OWNER,
+        provider: 'vercel',
+        allowCreate: true,
+        sessionId: registration.identity.sessionId,
+      });
+      expect(status.physical).toBe('running');
+      expect(status.attachment?.git).toBeUndefined();
+      expect(capturedIntent?.networkPolicy).toEqual(
+        buildControlNetworkPolicy(await loadSessionCredentialGrants(state.storage))
+      );
+      expect(launchEnv).not.toHaveProperty('KILOCODE_TOKEN');
+      expect(launchEnv).not.toHaveProperty('GH_TOKEN');
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        containment: { ...WORKTREE_CREDENTIAL_CONTAINMENT, providerRef },
+      });
+    });
+  });
+
+  it('confirms a contained Cloudflare reference without launching Kilo or SCM credentials', async () => {
+    const {
+      control: stub,
+      sandboxId: requestedSandboxId,
+      registration,
+    } = await credentialFixture();
+    await runInDurableObject(stub, async (instance, state) => {
+      let capturedIntent: ProviderCreateIntent | undefined;
+      let launchEnv: Record<string, string> | undefined;
+      let providerRef = '';
+      const provider = fakeProvider({
+        async create(intent) {
+          capturedIntent = intent;
+          providerRef = cloudflareRef(intent.allocationName ?? requestedSandboxId, intent.intentId);
+          return { providerRef };
+        },
+        async launch(ref, environment) {
+          expect(ref).toBe(providerRef);
+          launchEnv = environment;
+          await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+            state: 'running',
+            providerRef,
+            containment: { ...WORKTREE_CREDENTIAL_CONTAINMENT, providerRef },
+          });
+        },
+      });
+      await instance.initializeOwner(CONTAINMENT_OWNER);
+      await state.storage.put('provider_kind', 'cloudflare');
+      Object.assign(instance, {
+        provider,
+        createProviderAdapter: () => provider,
+        pinProvider: async () => true,
+      });
+
+      const status = await instance.ensureReady({
+        ownerId: CONTAINMENT_OWNER,
+        sessionId: registration.identity.sessionId,
+        provider: 'cloudflare',
+        allowCreate: true,
+      });
+      expect(status.physical).toBe('running');
+      expect(capturedIntent?.networkPolicy).toBeUndefined();
+      expect(launchEnv).not.toHaveProperty('KILOCODE_TOKEN');
+      expect(launchEnv).not.toHaveProperty('GH_TOKEN');
+      expect(JSON.stringify(launchEnv)).not.toContain(KILO_TOKEN);
+    });
+  });
+});
+
+describe('SandboxControl mandatory worktree credentials', () => {
+  it('joins authoritative session metadata, native containment, wrapper handshake, and sanitized attach', async () => {
+    const fixture = await credentialFixture();
+    const { control, registration, broker, containers } = fixture;
+    const input = credentialInput(registration);
+    expect(await storedGrants(control)).toEqual([]);
+    const ready = await control.ensureReady({ ...input, allowCreate: true });
+    expect(ready).toMatchObject({ physical: 'running', connection: 'disconnected' });
+    const payload = ready.attachment;
+    if (!payload?.kilo) throw new Error('Missing contained readiness attachment');
+    const [grant] = await storedGrants(control);
+    expect(grant).toBeDefined();
+    expect(payload.kilo).toEqual({
+      scopeId: WORKTREE_ID,
+      token: grant.kilo.alias,
+      targets: CONTAINMENT_TARGETS,
+    });
+    expect(payload.env).toMatchObject({
+      KILOCODE_TOKEN: grant.kilo.alias,
+      GH_TOKEN: grant.scm?.alias,
+      PUBLIC_VALUE: 'preserved',
+      KILO_AUTH_CONTENT: JSON.stringify({ kilo: { type: 'api', key: grant.kilo.alias } }),
+    });
+    expect(payload.git).toEqual({
+      url: 'https://github.com/acme/repo.git',
+      platform: 'github',
+      token: grant.scm?.alias,
+    });
+    expect(payload.setupCommands).toEqual([`fixture-command --credential=${grant.kilo.alias}`]);
+    expect(broker.kiloSubjects.get(grant.kilo.capabilities[input.sessionId].credential)).toEqual({
+      userId: input.ownerId,
+      cloudAgentSessionId: input.sessionId,
+      kiloSessionId: ROOT_ID,
+      outboundContainerId: fixture.outboundContainerId,
+      userToken: KILO_TOKEN,
+      targets: CONTAINMENT_TARGETS,
+    });
+    expect(grant.scm?.capability?.credential).toMatch(/^kgh2\./);
+    expectSanitized(payload, broker);
+
+    expect(containers.launches).toHaveLength(1);
+    const launch = containers.launches[0];
+    const providerRef = launch.env.PROVIDER_INSTANCE_ID;
+    const intent = launch.physical.createIntent;
+    expect(intent?.allocationName).not.toBe(fixture.sandboxId);
+    expect(decodeCloudflareProviderRef(providerRef)).toEqual({
+      sandboxId: intent?.allocationName,
+      containment: true,
+      instanceId: intent?.intentId,
+    });
+    expect(launch).toMatchObject({
+      containerId: fixture.outboundContainerId,
+      outboundHandler: MANAGED_SCM_OUTBOUND_HANDLER,
+      physical: {
+        state: 'running',
+        providerRef,
+        createIntent: intent,
+        containment: { ...WORKTREE_CREDENTIAL_CONTAINMENT, providerRef },
+      },
+    });
+    expectCredentialFreeLaunch(launch, broker);
+    const ws = await connect(launch.env.SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
+    try {
+      await completeHello(ws, 'hello-joined-containment', { providerInstanceId: providerRef });
+      const stale = await connect(launch.env.SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
+      await rejectHello(
+        stale,
+        'hello-stale-cloudflare-instance',
+        cloudflareRef(fixture.sandboxId, 'previous')
+      );
+      expect(ws.readyState).toBe(1);
+      signalWrapperReady(ws);
+      await vi.waitFor(async () => {
+        await expect(control.getStatus()).resolves.toMatchObject({ connection: 'ready' });
+      });
+      const attachment = attachInput(registration, payload);
+      await expect(control.attachSession(attachment)).resolves.toMatchObject(attachment);
+      const inbound = nextMessage(ws);
+      const pending = control.request({
+        operation: 'session.attach',
+        session: {
+          sessionId: attachment.sessionId,
+          kiloSessionId: attachment.kiloSessionId,
+          directory: attachment.directory,
+        },
+        payload,
+      });
+      const request = JSON.parse(await inbound) as {
+        requestId: string;
+        operation: string;
+        payload: SessionAttachPayload;
+      };
+      expect(request).toMatchObject({ operation: 'session.attach', payload });
+      expectSanitized(request, broker);
+      ws.send(JSON.stringify({ type: 'response', requestId: request.requestId, ok: true }));
+      await expect(pending).resolves.toMatchObject({ ok: true });
+      expect(await control.listRoutes()).toEqual([expect.objectContaining(attachment)]);
+      expectSanitized(await control.getTransitionLog(), broker);
+    } finally {
+      ws.close();
+    }
+  });
+
+  it('shares stable aliases across two roots of one worktree without granting access to another worktree', async () => {
+    const fixture = await credentialFixture();
+    const { control, registration, broker } = fixture;
+    const second: CredentialRegistration = {
+      ...registration,
+      identity: { ...registration.identity, sessionId: `workspace_${crypto.randomUUID()}` },
+      auth: { ...registration.auth, kiloSessionId: SECOND_ROOT_ID },
+    };
+    const other: CredentialRegistration = {
+      ...registration,
+      identity: { ...registration.identity, sessionId: `workspace_${crypto.randomUUID()}` },
+      auth: { ...registration.auth, kiloSessionId: THIRD_ROOT_ID },
+      repository: { type: 'github', repo: 'acme/other' },
+      workspace: {
+        ...registration.workspace,
+        workspacePath: '/workspace/other',
+        worktreeId: OTHER_WORKTREE_ID,
+      },
+    };
+    await registerCredentialSession(second);
+    await registerCredentialSession(other);
+    const firstPayload = await readyAttachment(control, credentialInput(registration));
+    const secondPayload = await readyAttachment(control, credentialInput(second));
+    const otherPayload = await readyAttachment(control, credentialInput(other));
+    expect(secondPayload.kilo).toEqual(firstPayload.kilo);
+    expect(secondPayload.git?.token).toBe(firstPayload.git?.token);
+    expect(otherPayload.kilo?.token).not.toBe(firstPayload.kilo?.token);
+    expect(otherPayload.git?.token).not.toBe(firstPayload.git?.token);
+    expect(await readyAttachment(control, credentialInput(second))).toEqual(secondPayload);
+    await control.ensureReady({ ...credentialInput(registration), allowCreate: true });
+    for (const [data, payload] of [
+      [registration, firstPayload],
+      [second, secondPayload],
+      [other, otherPayload],
+    ] as const) {
+      await control.attachSession(attachInput(data, payload));
+    }
+    expect(await control.listRoutes()).toHaveLength(3);
+    const grants = await storedGrants(control);
+    expect(grants).toHaveLength(2);
+    const shared = grants.find(grant => grant.scopeId === WORKTREE_ID);
+    const separate = grants.find(grant => grant.scopeId === OTHER_WORKTREE_ID);
+    if (!shared || !separate) throw new Error('Missing worktree grants');
+    expect(shared.members).toEqual([
+      { sessionId: registration.identity.sessionId, kiloSessionId: ROOT_ID },
+      { sessionId: second.identity.sessionId, kiloSessionId: SECOND_ROOT_ID },
+    ]);
+    const outboundContainerId = fixture.outboundContainerId;
+    for (const [sessionId, root] of [
+      [registration.identity.sessionId, ROOT_ID],
+      [second.identity.sessionId, SECOND_ROOT_ID],
+    ]) {
+      for (const [operation, method] of [
+        ['export', 'GET'],
+        ['ingest', 'POST'],
+      ]) {
+        const resolved = await control.resolveCredential({
+          credential: shared.kilo.alias,
+          outboundContainerId,
+          url: `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${root}/${operation}`,
+          method,
+        });
+        expect(resolved).toEqual({
+          credential: shared.kilo.capabilities[sessionId].credential,
+          organizationId: registration.identity.orgId,
+        });
+        expect(resolved && broker.kiloSubjects.get(resolved.credential)).toMatchObject({
+          cloudAgentSessionId: sessionId,
+          kiloSessionId: root,
+        });
+      }
+    }
+    for (const [alias, root] of [
+      [shared.kilo.alias, THIRD_ROOT_ID],
+      [separate.kilo.alias, ROOT_ID],
+    ]) {
+      await expect(
+        control.resolveCredential({
+          credential: alias,
+          outboundContainerId,
+          url: `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${root}/export`,
+          method: 'GET',
+        })
+      ).resolves.toBeNull();
+    }
+    for (const grant of [shared, separate]) {
+      if (!grant.scm) throw new Error('Missing SCM grant');
+      const resolved = await control.resolveCredential({
+        credential: grant.scm.alias,
+        outboundContainerId,
+        url: 'https://api.github.com/user',
+        method: 'GET',
+      });
+      expect(resolved).toEqual({ credential: grant.scm.capability?.credential });
+      expect(resolved && broker.githubSubjects.get(resolved.credential)).toMatchObject({
+        githubRepo: grant.repository?.type === 'github' ? grant.repository.repo : '',
+        outboundContainerId,
+        userId: registration.identity.userId,
+      });
+    }
+    await control.detachSession(registration.identity.sessionId);
+    const afterFirstDetach = (await storedGrants(control)).find(
+      grant => grant.scopeId === WORKTREE_ID
+    );
+    expect(afterFirstDetach?.kilo.alias).toBe(shared.kilo.alias);
+    expect(afterFirstDetach?.members).toEqual([
+      { sessionId: second.identity.sessionId, kiloSessionId: SECOND_ROOT_ID },
+    ]);
+    expect(afterFirstDetach?.kilo.capabilities[registration.identity.sessionId]).toBeUndefined();
+    await expect(
+      control.resolveCredential({
+        credential: shared.kilo.alias,
+        outboundContainerId,
+        url: `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`,
+        method: 'GET',
+      })
+    ).resolves.toBeNull();
+    await expect(
+      control.resolveCredential({
+        credential: shared.kilo.alias,
+        outboundContainerId,
+        url: `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${SECOND_ROOT_ID}/export`,
+        method: 'GET',
+      })
+    ).resolves.toMatchObject({
+      credential: shared.kilo.capabilities[second.identity.sessionId].credential,
+    });
+    await expect(async () =>
+      control.attachSession(attachInput(registration, firstPayload))
+    ).rejects.toThrow('Session has no matching worktree credential grant');
+    await control.detachSession(second.identity.sessionId);
+    expect(await storedGrants(control)).toEqual([separate]);
+    await expect(
+      control.resolveCredential({
+        credential: shared.scm?.alias ?? '',
+        outboundContainerId,
+        url: 'https://api.github.com/repos/acme/repo',
+        method: 'GET',
+      })
+    ).resolves.toBeNull();
+    expect(await control.listRoutes()).toEqual([
+      expect.objectContaining(attachInput(other, otherPayload)),
+    ]);
+    await control.beginStop('test');
+    await control.confirmStopped();
+    expect(await storedGrants(control)).toEqual([]);
+    await expect(
+      control.resolveCredential({
+        credential: separate.kilo.alias,
+        outboundContainerId,
+        url: `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${THIRD_ROOT_ID}/export`,
+        method: 'GET',
+      })
+    ).resolves.toBeNull();
+  });
+
+  it('refreshes an expired warm lease and broker capabilities without replacing aliases or the physical instance', async () => {
+    const fixture = await credentialFixture();
+    const { control, registration, broker, containers } = fixture;
+    const input = credentialInput(registration);
+    const initial = await control.ensureReady({ ...input, allowCreate: true });
+    const initialPayload = initial.attachment;
+    if (!initialPayload?.kilo) throw new Error('Missing initial contained attachment');
+    await control.attachSession(attachInput(registration, initialPayload));
+    const physical = await control.getPhysicalRecord();
+    const [original] = await storedGrants(control);
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(original.preparedAt + 5 * HOUR);
+    try {
+      const request = {
+        credential: original.kilo.alias,
+        outboundContainerId: fixture.outboundContainerId,
+        url: `${CONTAINMENT_TARGETS.providerBaseUrl}/api/openrouter/chat/completions`,
+        method: 'POST',
+      };
+      await expect(control.resolveCredential(request)).resolves.toBeNull();
+      const ready = await control.ensureReady({ ...input, allowCreate: false });
+      expect(ready.physical).toBe('running');
+      const payload = ready.attachment;
+      expect(payload).toEqual(initialPayload);
+      expect(await control.getPhysicalRecord()).toEqual(physical);
+      expect(containers.launches).toHaveLength(1);
+      const [renewed] = await storedGrants(control);
+      expect(renewed.expiresAt).toBe(original.preparedAt + 9 * HOUR);
+      expect(renewed.kilo.capabilities[input.sessionId].credential).not.toBe(
+        original.kilo.capabilities[input.sessionId].credential
+      );
+      expect(renewed.scm?.capability?.credential).not.toBe(original.scm?.capability?.credential);
+      await expect(control.resolveCredential(request)).resolves.toEqual({
+        credential: renewed.kilo.capabilities[input.sessionId].credential,
+        organizationId: registration.identity.orgId,
+      });
+      expectSanitized(payload, broker);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it.each(['deleted', 'revoked'] as const)(
+    'does not prepare or resolve credentials after the authoritative session is %s',
+    async action => {
+      const fixture = await credentialFixture();
+      const { control, registration, session } = fixture;
+      const input = credentialInput(registration);
+      const payload = await readyAttachment(control, input);
+      await control.ensureReady({ ...input, allowCreate: true });
+      await control.attachSession(attachInput(registration, payload));
+      if (action === 'deleted') await session.deleteSession();
+      else await session.closeOrgStreams(registration.identity.orgId ?? '');
+      expect(await session.getCredentialMetadata()).toBeNull();
+      await expect(async () => control.prepareSessionCredentials(input)).rejects.toThrow(
+        'Session credential ownership mismatch'
+      );
+      await expect(async () =>
+        control.ensureReady({ ...input, allowCreate: true })
+      ).rejects.toThrow('Session credential ownership mismatch');
+      expect(await storedGrants(control)).toEqual([]);
+      expect(await control.listRoutes()).toEqual([]);
+      await expect(
+        control.resolveCredential({
+          credential: payload.kilo?.token ?? '',
+          outboundContainerId: fixture.outboundContainerId,
+          url: `${CONTAINMENT_TARGETS.providerBaseUrl}/api/openrouter/chat/completions`,
+          method: 'POST',
+        })
+      ).resolves.toBeNull();
+      await expect(control.getPhysicalRecord()).resolves.toMatchObject({ state: 'running' });
+    }
+  );
+
+  it.each(['missing-binding', 'missing-github-rpc', 'raw-github-result'] as const)(
+    'fails closed before provisioning when the broker has %s',
+    async mode => {
+      const fixture = await credentialFixture();
+      const { control, registration, broker, containers, environment } = fixture;
+      if (mode === 'missing-binding') Object.assign(environment, { GIT_TOKEN_SERVICE: undefined });
+      else if (mode === 'missing-github-rpc') {
+        Object.assign(broker.binding, { issueGitHubSessionCapability: undefined });
+      } else {
+        const issue = broker.binding.issueGitHubSessionCapability.bind(broker.binding);
+        broker.binding.issueGitHubSessionCapability = async subject => ({
+          ...(await issue(subject)),
+          success: true,
+          capability: GITHUB_TOKEN,
+          installationId: '42',
+          accountLogin: 'acme',
+          appType: 'standard',
+          source: 'installation',
+          gitAuthor: { name: 'fixture bot', email: 'fixture@example.com' },
+        });
+      }
+      const input = credentialInput(registration);
+      const error =
+        mode === 'missing-binding'
+          ? 'Kilo capability issuance is unavailable'
+          : mode === 'missing-github-rpc'
+            ? 'GitHub capability issuance is unavailable'
+            : 'Invalid contained worktree credentials';
+      await expect(async () => control.prepareSessionCredentials(input)).rejects.toThrow(
+        'Sandbox credential containment is unavailable'
+      );
+      await expect(async () =>
+        control.ensureReady({ ...input, allowCreate: true })
+      ).rejects.toThrow(error);
+      expect(await storedGrants(control)).toEqual([]);
+      expect(containers.launches).toEqual([]);
+      await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'failed',
+        createIntent: { containment: WORKTREE_CREDENTIAL_CONTAINMENT },
+        stopTombstone: { reason: 'environment_failed' },
+      });
+      await finishFailedCreation(control);
+    }
+  );
+
+  it.each(['owner', 'session', 'sandbox', 'missing'] as const)(
+    'rejects authoritative %s metadata mismatches',
+    async mismatch => {
+      const fixture = await credentialFixture();
+      const { control, registration, session, broker } = fixture;
+      if (mismatch !== 'missing') {
+        await updateCredentialMetadata(session, metadata => ({
+          ...metadata,
+          identity: {
+            ...metadata.identity,
+            ...(mismatch === 'owner' ? { userId: 'other-owner' } : {}),
+            ...(mismatch === 'session' ? { sessionId: `workspace_${crypto.randomUUID()}` } : {}),
+          },
+          workspace: {
+            ...metadata.workspace,
+            ...(mismatch === 'sandbox' ? { sandboxId: 'usr-deadbeef' } : {}),
+          },
+        }));
+      }
+      const input = {
+        ...credentialInput(registration),
+        ...(mismatch === 'missing' ? { sessionId: `workspace_${crypto.randomUUID()}` } : {}),
+      };
+      await expect(async () => control.prepareSessionCredentials(input)).rejects.toThrow(
+        'Session credential ownership mismatch'
+      );
+      await expect(async () =>
+        control.ensureReady({ ...input, allowCreate: true })
+      ).rejects.toThrow('Session credential ownership mismatch');
+      expect(await storedGrants(control)).toEqual([]);
+      expect(broker.kiloSubjects.size).toBe(0);
+      expect(broker.githubSubjects.size).toBe(0);
+      await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'failed',
+        providerRef: null,
+      });
+      await finishFailedCreation(control);
+    }
+  );
+
+  it('rejects metadata changes while broker issuance is in flight without publishing a grant', async () => {
+    const fixture = await credentialFixture();
+    const { control, registration, session, broker } = fixture;
+    const issue = broker.binding.issueKiloSessionCapability.bind(broker.binding);
+    broker.binding.issueKiloSessionCapability = async subject => {
+      const currentSession = env.SANDBOX_SESSION.getByName(
+        `${registration.identity.userId}:${registration.identity.sessionId}`
+      );
+      await updateCredentialMetadata(currentSession, metadata => ({
+        ...metadata,
+        workspace: { ...metadata.workspace, workspacePath: '/workspace/replaced' },
+      }));
+      return issue(subject);
+    };
+    await expect(async () =>
+      control.ensureReady({ ...credentialInput(registration), allowCreate: true })
+    ).rejects.toThrow('Session changed during credential preparation');
+    await expect(session.getCredentialMetadata()).resolves.toMatchObject({
+      workspace: { workspacePath: '/workspace/replaced' },
+    });
+    expect(await storedGrants(control)).toEqual([]);
+    expect(fixture.containers.launches).toEqual([]);
+    broker.binding.issueKiloSessionCapability = issue;
+    await finishFailedCreation(control);
+    const ready = await control.ensureReady({
+      ...credentialInput(registration),
+      allowCreate: true,
+    });
+    expect(ready).toMatchObject({
+      physical: 'running',
+      attachment: { directory: '/workspace/replaced', kilo: { scopeId: WORKTREE_ID } },
+    });
+    expect((await storedGrants(control))[0]?.directory).toBe('/workspace/replaced');
+    expect(fixture.containers.launches).toHaveLength(1);
+  });
+
+  it('prepares a session-scoped grant and attaches without an explicit worktree id', async () => {
+    const { control, registration, session } = await credentialFixture();
+    await updateCredentialMetadata(session, metadata => ({
+      ...metadata,
+      workspace: { ...metadata.workspace, worktreeId: undefined },
+    }));
+    const payload = await readyAttachment(control, credentialInput(registration));
+    expect(payload.kilo?.scopeId).toBe(registration.identity.sessionId);
+    const attachment = {
+      ...credentialInput(registration),
+      kiloSessionId: ROOT_ID,
+      directory: '/workspace/joined',
+    };
+    await expect(control.attachSession(attachment)).resolves.toMatchObject(attachment);
+    const routes = await control.listRoutes();
+    expect(routes).toHaveLength(1);
+    expect(routes[0]).not.toHaveProperty('worktreeId');
+  });
+
+  it.each(['directory', 'root'] as const)(
+    'rejects a %s already granted to another worktree without changing the existing grant',
+    async conflict => {
+      const { control, registration } = await credentialFixture();
+      await readyAttachment(control, credentialInput(registration));
+      const original = await storedGrants(control);
+      const second: CredentialRegistration = {
+        ...registration,
+        identity: { ...registration.identity, sessionId: `workspace_${crypto.randomUUID()}` },
+        auth: {
+          ...registration.auth,
+          kiloSessionId: conflict === 'root' ? ROOT_ID : SECOND_ROOT_ID,
+        },
+        workspace: {
+          ...registration.workspace,
+          worktreeId: OTHER_WORKTREE_ID,
+          workspacePath: conflict === 'directory' ? '/workspace/joined' : '/workspace/other',
+        },
+      };
+      await registerCredentialSession(second);
+      await expect(async () =>
+        control.prepareSessionCredentials(credentialInput(second))
+      ).rejects.toThrow('Worktree credential scope mismatch');
+      expect(await storedGrants(control)).toEqual(original);
+      await expect(async () =>
+        control.ensureReady({ ...credentialInput(second), allowCreate: true })
+      ).rejects.toThrow('Worktree credential scope mismatch');
+      await expect(control.getPhysicalRecord()).resolves.toMatchObject({ state: 'running' });
+      expect(await storedGrants(control)).toEqual(original);
+    }
+  );
+
+  it('cannot refresh expired broker capabilities without a broker or extend the worktree lease during resolution', async () => {
+    const { control, registration, environment } = await credentialFixture();
+    const input = credentialInput(registration);
+    await readyAttachment(control, input);
+    await control.ensureReady({ ...input, allowCreate: true });
+    const [grant] = await storedGrants(control);
+    Object.assign(environment, { GIT_TOKEN_SERVICE: undefined });
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(grant.preparedAt + 3 * HOUR + 1);
+    try {
+      for (const [credential, url] of [
+        [
+          grant.kilo.alias,
+          `${CONTAINMENT_TARGETS.providerBaseUrl}/api/openrouter/chat/completions`,
+        ],
+        [grant.scm?.alias ?? '', 'https://api.github.com/repos/acme/repo'],
+      ]) {
+        await expect(
+          control.resolveCredential({
+            credential,
+            url,
+            outboundContainerId: grant.outboundContainerId ?? '',
+            method: 'POST',
+          })
+        ).resolves.toBeNull();
+      }
+      expect(await storedGrants(control)).toEqual([grant]);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('enforces the complete live grant identity before changing the route table', async () => {
+    const { control, registration } = await credentialFixture();
+    const payload = await readyAttachment(control, credentialInput(registration));
+    const attachment = attachInput(registration, payload);
+    await control.attachSession(attachment);
+    for (const invalid of [
+      { ...attachment, sessionId: `workspace_${crypto.randomUUID()}` },
+      { ...attachment, kiloSessionId: SECOND_ROOT_ID },
+      { ...attachment, directory: '/workspace/wrong' },
+      { ...attachment, worktreeId: OTHER_WORKTREE_ID },
+      { ...attachment, worktreeId: undefined },
+    ]) {
+      await expect(async () => control.attachSession(invalid)).rejects.toThrow(
+        'Session has no matching worktree credential grant'
+      );
+    }
+    await expect(async () =>
+      control.attachSession({ ...attachment, ownerId: 'other-owner' })
+    ).rejects.toThrow('Sandbox owner mismatch');
+    expect(await control.listRoutes()).toEqual([expect.objectContaining(attachment)]);
+    const [grant] = await storedGrants(control);
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(grant.expiresAt);
+    try {
+      await expect(async () => control.attachSession(attachment)).rejects.toThrow(
+        'Session has no matching worktree credential grant'
+      );
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('pins provider identity for preparation and readiness and fails closed without Vercel configuration', async () => {
+    const fixture = await credentialFixture('cloudflare', 'ses-b001');
+    const input = credentialInput(fixture.registration);
+    await readyAttachment(fixture.control, input);
+    await expect(async () =>
+      fixture.control.ensureReady({ ...input, provider: 'vercel', allowCreate: true })
+    ).rejects.toThrow('Sandbox provider mismatch');
+    await updateCredentialMetadata(fixture.session, metadata => ({
+      ...metadata,
+      workspace: { ...metadata.workspace, sandboxProvider: 'vercel' },
+    }));
+    await expect(async () => fixture.control.prepareSessionCredentials(input)).rejects.toThrow(
+      'Sandbox provider mismatch'
+    );
+    expect(fixture.containers.launches).toHaveLength(1);
+    const vercel = await credentialFixture('vercel');
+    Object.assign(vercel.environment, { VERCEL_TOKEN: undefined });
+    await expect(async () =>
+      vercel.control.prepareSessionCredentials(credentialInput(vercel.registration))
+    ).rejects.toThrow('Vercel sandbox runtime configuration is unavailable');
+    expect(await storedGrants(vercel.control)).toEqual([]);
+    expect(vercel.vercel.runtime.creates).toBe(0);
+  });
+
+  it('resolves only the exact alias, native binding, current physical instance, and permitted Kilo routes', async () => {
+    const fixture = await credentialFixture();
+    const { control, registration } = fixture;
+    const payload = await readyAttachment(control, credentialInput(registration));
+    await control.ensureReady({ ...credentialInput(registration), allowCreate: true });
+    const input = {
+      credential: payload.kilo?.token ?? '',
+      outboundContainerId: fixture.outboundContainerId,
+      url: `${CONTAINMENT_TARGETS.providerBaseUrl}/api/openrouter/chat/completions`,
+      method: 'POST',
+    };
+    const [grant] = await storedGrants(control);
+    await expect(control.resolveCredential(input)).resolves.toEqual({
+      credential: grant.kilo.capabilities[registration.identity.sessionId].credential,
+      organizationId: registration.identity.orgId,
+    });
+    for (const invalid of [
+      { ...input, credential: createControlPlaneCredential(fixture.sandboxId, 'kilo') },
+      { ...input, credential: createControlPlaneCredential('usr-deadbeef', 'kilo') },
+      { ...input, credential: KILO_TOKEN },
+      { ...input, credential: grant.kilo.capabilities[registration.identity.sessionId].credential },
+      { ...input, outboundContainerId: `standard:${fixture.sandboxId}` },
+      { ...input, outboundContainerId: 'contained:usr-deadbeef' },
+      { ...input, url: 'https://untrusted.example.com/api/openrouter/chat/completions' },
+      {
+        ...input,
+        url: `${CONTAINMENT_TARGETS.backendBaseUrl}/api/organizations/other/defaults`,
+        method: 'GET',
+      },
+      { ...input, url: `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session`, method: 'GET' },
+      {
+        ...input,
+        url: `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`,
+        method: 'POST',
+      },
+      { ...input, method: 'DELETE' },
+    ]) {
+      await expect(control.resolveCredential(invalid)).resolves.toBeNull();
+    }
+    await control.beginStop('test');
+    await expect(control.resolveCredential(input)).resolves.toBeNull();
+    await control.confirmStopped();
+    expect(await storedGrants(control)).toEqual([]);
+  });
+
+  it('discards a capability resolution when its physical instance is superseded during refresh', async () => {
+    const fixture = await credentialFixture();
+    const { control, registration, broker } = fixture;
+    const payload = await readyAttachment(control, credentialInput(registration));
+    await control.ensureReady({ ...credentialInput(registration), allowCreate: true });
+    const [grant] = await storedGrants(control);
+    const issue = broker.binding.issueKiloSessionCapability.bind(broker.binding);
+    await runInDurableObject(control, (_instance, state) => {
+      broker.binding.issueKiloSessionCapability = async subject => {
+        await state.storage.put(
+          'physical_record',
+          containedRunningRecord(cloudflareRef(fixture.sandboxId, 'replacement'))
+        );
+        return issue(subject);
+      };
+    });
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(grant.preparedAt + 3 * HOUR + 1);
+    try {
+      await expect(
+        control.resolveCredential({
+          credential: payload.kilo?.token ?? '',
+          outboundContainerId: fixture.outboundContainerId,
+          url: `${CONTAINMENT_TARGETS.providerBaseUrl}/api/openrouter/chat/completions`,
+          method: 'POST',
+        })
+      ).resolves.toBeNull();
+      expect(await storedGrants(control)).toEqual([grant]);
+      await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+        providerRef: cloudflareRef(fixture.sandboxId, 'replacement'),
+      });
+    } finally {
+      clock.mockRestore();
+    }
+  });
+});
+
+describe('SandboxControl native worktree containment', () => {
+  it('installs, refreshes, and removes the combined Vercel policy for exact worktree roots', async () => {
+    const fixture = await credentialFixture('vercel');
+    const { control, registration, session, broker, vercel } = fixture;
+    const second: CredentialRegistration = {
+      ...registration,
+      identity: { ...registration.identity, sessionId: `workspace_${crypto.randomUUID()}` },
+      auth: { ...registration.auth, kiloSessionId: SECOND_ROOT_ID },
+    };
+    const other: CredentialRegistration = {
+      ...registration,
+      identity: { ...registration.identity, sessionId: `workspace_${crypto.randomUUID()}` },
+      auth: { ...registration.auth, kiloSessionId: THIRD_ROOT_ID },
+      repository: { type: 'github', repo: 'acme/other' },
+      workspace: {
+        ...registration.workspace,
+        worktreeId: OTHER_WORKTREE_ID,
+        workspacePath: '/workspace/other',
+      },
+    };
+    await registerCredentialSession(second);
+    await registerCredentialSession(other);
+    const firstPayload = await readyAttachment(control, credentialInput(registration));
+    const secondPayload = await readyAttachment(control, credentialInput(second));
+    const otherPayload = await readyAttachment(control, credentialInput(other));
+    expect(firstPayload.kilo).toEqual(secondPayload.kilo);
+    await control.ensureReady({ ...credentialInput(registration), allowCreate: true });
+    for (const [data, payload] of [
+      [registration, firstPayload],
+      [second, secondPayload],
+      [other, otherPayload],
+    ] as const) {
+      await control.attachSession(attachInput(data, payload));
+      expectSanitized(payload, broker);
+    }
+    expect(vercel.runtime.creates).toBe(1);
+    expect(vercel.runtime.launches).toHaveLength(1);
+    const launch = vercel.runtime.launches[0];
+    const providerRef = encodeVercelProviderRef({
+      sandboxName: launch.physical.createIntent?.allocationName ?? '',
+      sessionId: 'vsess_joined_1',
+    });
+    expect(launch.physical).toMatchObject({
+      state: 'running',
+      providerRef,
+      containment: { ...WORKTREE_CREDENTIAL_CONTAINMENT, providerRef },
+    });
+    expect(launch.env.PROVIDER_INSTANCE_ID).toBe(providerRef);
+    expect(launch.physical.createIntent?.allocationName).not.toBe(fixture.sandboxId);
+    expect(
+      policyAuthorization(
+        launch.networkPolicy,
+        firstPayload.kilo?.token ?? '',
+        `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`
+      )
+    ).toBe(`Bearer ${KILO_TOKEN}`);
+    expect(
+      policyAuthorization(
+        launch.networkPolicy,
+        secondPayload.kilo?.token ?? '',
+        `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${SECOND_ROOT_ID}/export`
+      )
+    ).toBeUndefined();
+    expectCredentialFreeLaunch(launch, broker);
+    expect(broker.kiloSubjects.size).toBe(0);
+    expect(broker.githubSubjects.size).toBe(0);
+    const alias = firstPayload.kilo?.token ?? '';
+    const otherAlias = otherPayload.kilo?.token ?? '';
+    const ingestUrl = (root: string) =>
+      `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${root}/export`;
+    expect(policyAuthorization(vercel.runtime.policy, alias, ingestUrl(ROOT_ID))).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    expect(policyAuthorization(vercel.runtime.policy, alias, ingestUrl(SECOND_ROOT_ID))).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    expect(policyAuthorization(vercel.runtime.policy, otherAlias, ingestUrl(THIRD_ROOT_ID))).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    expect(
+      policyAuthorization(vercel.runtime.policy, alias, ingestUrl(THIRD_ROOT_ID))
+    ).toBeUndefined();
+    expect(
+      policyAuthorization(vercel.runtime.policy, otherAlias, ingestUrl(ROOT_ID))
+    ).toBeUndefined();
+    expect(
+      policyAuthorization(
+        vercel.runtime.policy,
+        firstPayload.git?.token ?? '',
+        'https://api.github.com/repos/acme/repo'
+      )
+    ).toBe(`Bearer ${GITHUB_TOKEN}`);
+    expect(
+      policyAuthorization(
+        vercel.runtime.policy,
+        firstPayload.git?.token ?? '',
+        'https://api.github.com/repos/acme/other'
+      )
+    ).toBeUndefined();
+    await expect(
+      control.resolveCredential({
+        credential: alias,
+        outboundContainerId: `contained-small:${fixture.sandboxId}`,
+        url: ingestUrl(ROOT_ID),
+        method: 'GET',
+      })
+    ).resolves.toBeNull();
+    const ws = await connect(launch.env.SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
+    await completeHello(ws, 'hello-native-vercel', { providerInstanceId: providerRef });
+
+    const rotatedKiloToken = 'fixture-rotated-kilo-token';
+    broker.tokens.github = 'fixture-rotated-github-token';
+    await updateCredentialMetadata(session, metadata => ({
+      ...metadata,
+      auth: { ...metadata.auth, kilocodeToken: rotatedKiloToken },
+    }));
+    const ready = await control.ensureReady({
+      ...credentialInput(registration),
+      allowCreate: false,
+    });
+    const refreshed = ready.attachment;
+    if (!refreshed?.kilo) throw new Error('Missing refreshed native attachment');
+    expect(refreshed.kilo).toEqual(firstPayload.kilo);
+    expect(refreshed.git).toEqual(firstPayload.git);
+    expect(policyAuthorization(vercel.runtime.policy, alias, ingestUrl(ROOT_ID))).toBe(
+      `Bearer ${rotatedKiloToken}`
+    );
+    expect(policyAuthorization(vercel.runtime.policy, alias, ingestUrl(SECOND_ROOT_ID))).toBe(
+      `Bearer ${rotatedKiloToken}`
+    );
+    expect(policyAuthorization(vercel.runtime.policy, otherAlias, ingestUrl(THIRD_ROOT_ID))).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    expect(
+      policyAuthorization(
+        vercel.runtime.policy,
+        firstPayload.git?.token ?? '',
+        'https://api.github.com/repos/acme/repo'
+      )
+    ).toBe(`Bearer ${broker.tokens.github}`);
+    expect(JSON.stringify(refreshed)).not.toContain(rotatedKiloToken);
+    expectSanitized(refreshed, broker);
+    expect(vercel.runtime.creates).toBe(1);
+
+    await control.detachSession(registration.identity.sessionId);
+    expect(policyAuthorization(vercel.runtime.policy, alias, ingestUrl(ROOT_ID))).toBeUndefined();
+    expect(policyAuthorization(vercel.runtime.policy, alias, ingestUrl(SECOND_ROOT_ID))).toBe(
+      `Bearer ${rotatedKiloToken}`
+    );
+    await control.detachSession(second.identity.sessionId);
+    expect(
+      policyAuthorization(vercel.runtime.policy, alias, ingestUrl(SECOND_ROOT_ID))
+    ).toBeUndefined();
+    expect(
+      policyAuthorization(
+        vercel.runtime.policy,
+        firstPayload.git?.token ?? '',
+        'https://api.github.com/repos/acme/repo'
+      )
+    ).toBeUndefined();
+    expect(policyAuthorization(vercel.runtime.policy, otherAlias, ingestUrl(THIRD_ROOT_ID))).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    expect(await control.listRoutes()).toEqual([
+      expect.objectContaining(attachInput(other, otherPayload)),
+    ]);
+    await control.detachSession(other.identity.sessionId);
+    expect(vercel.runtime.policy).toEqual({
+      mode: 'custom',
+      allowedDomains: ['*'],
+      injectionRules: [],
+    });
+    expect(await storedGrants(control)).toEqual([]);
+    await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+      state: 'running',
+      providerRef,
+    });
+    ws.close();
+  });
+
+  it('uses the latest grants when another worktree prepares during Vercel creation', async () => {
+    const fixture = await credentialFixture('vercel');
+    const { control, registration, vercel } = fixture;
+    const second: CredentialRegistration = {
+      ...registration,
+      identity: { ...registration.identity, sessionId: `workspace_${crypto.randomUUID()}` },
+      auth: { ...registration.auth, kiloSessionId: SECOND_ROOT_ID },
+      workspace: {
+        ...registration.workspace,
+        worktreeId: OTHER_WORKTREE_ID,
+        workspacePath: '/workspace/other',
+      },
+    };
+    await registerCredentialSession(second);
+    let secondPayload: SessionAttachPayload | undefined;
+    await runInDurableObject(control, instance => {
+      vercel.runtime.beforeLaunch = async () => {
+        secondPayload = await instance.prepareSessionCredentials(credentialInput(second));
+      };
+    });
+    const first = await readyAttachment(control, credentialInput(registration));
+    if (!secondPayload?.kilo) throw new Error('Second worktree was not prepared during creation');
+    const url = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${SECOND_ROOT_ID}/export`;
+    expect(
+      policyAuthorization(vercel.runtime.launches[0].networkPolicy, secondPayload.kilo.token, url)
+    ).toBeUndefined();
+    expect(policyAuthorization(vercel.runtime.policy, secondPayload.kilo.token, url)).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    expect(
+      policyAuthorization(vercel.runtime.policy, first.kilo?.token ?? '', url)
+    ).toBeUndefined();
+    expect(await storedGrants(control)).toHaveLength(2);
+    expect(vercel.runtime.creates).toBe(1);
+  });
+
+  it('acknowledges Vercel detach after failed policy revocation authoritatively stops the exact runtime', async () => {
+    const { control, registration, vercel } = await credentialFixture('vercel');
+    const payload = await readyAttachment(control, credentialInput(registration));
+    if (!payload.kilo) throw new Error('Missing contained attachment');
+    await control.ensureReady({ ...credentialInput(registration), allowCreate: true });
+    await control.attachSession(attachInput(registration, payload));
+    const physical = await control.getPhysicalRecord();
+    const exportUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`;
+    await expect(vercel.provider.observe(physical.providerRef)).resolves.toMatchObject({
+      status: 'active',
+    });
+    expect(policyAuthorization(vercel.runtime.policy, payload.kilo.token, exportUrl)).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    vercel.runtime.failPolicy = true;
+    await expect(control.detachSession(registration.identity.sessionId)).resolves.toEqual({
+      existed: true,
+    });
+    expect(await storedGrants(control)).toEqual([]);
+    expect(await control.listRoutes()).toEqual([]);
+    await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+      state: 'stopped',
+      providerRef: null,
+    });
+    await expect(vercel.provider.observe(physical.providerRef)).resolves.toMatchObject({
+      status: 'terminal',
+    });
+    expect(new Set(vercel.runtime.stoppedSessions)).toEqual(new Set(['vsess_joined_1']));
+    expect(policyAuthorization(vercel.runtime.policy, payload.kilo.token, exportUrl)).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    await runInDurableObject(control, async (_instance, state) => {
+      expect(await state.storage.get('credential_policy_dirty')).not.toBeTruthy();
+    });
+  });
+
+  it('does not acknowledge repeated detach while a failed Vercel policy still authorizes the removed alias', async () => {
+    const { control, registration, vercel } = await credentialFixture('vercel');
+    const ready = await control.ensureReady({
+      ...credentialInput(registration),
+      provider: 'vercel',
+      allowCreate: true,
+    });
+    const payload = ready.attachment;
+    if (!payload?.kilo) throw new Error('Missing contained attachment');
+    await control.attachSession(attachInput(registration, payload));
+    const physical = await control.getPhysicalRecord();
+    const exportUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`;
+    expect(policyAuthorization(vercel.runtime.policy, payload.kilo.token, exportUrl)).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    vercel.runtime.failPolicy = true;
+    vercel.runtime.failStop = true;
+    await expect(async () =>
+      control.detachSession(registration.identity.sessionId)
+    ).rejects.toThrow('Sandbox credential revocation is pending');
+    expect(await storedGrants(control)).toEqual([]);
+    expect(await control.listRoutes()).toEqual([]);
+    await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+      state: 'stopping',
+      providerRef: physical.providerRef,
+      stopTombstone: { reason: 'environment_failed' },
+    });
+    await expect(vercel.provider.observe(physical.providerRef)).resolves.toMatchObject({
+      status: 'active',
+    });
+    expect(policyAuthorization(vercel.runtime.policy, payload.kilo.token, exportUrl)).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+
+    await expect(async () =>
+      control.detachSession(registration.identity.sessionId)
+    ).rejects.toThrow('Sandbox credential revocation is pending');
+    await runInDurableObject(control, async (_instance, state) => {
+      expect(await state.storage.get('credential_policy_dirty')).toBeTruthy();
+    });
+    await expect(vercel.provider.observe(physical.providerRef)).resolves.toMatchObject({
+      status: 'active',
+    });
+    expect(policyAuthorization(vercel.runtime.policy, payload.kilo.token, exportUrl)).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    expect(vercel.runtime.stoppedSessions).toEqual([]);
+    vercel.runtime.failStop = false;
+    await fireControlDeadline(control, 'stopAttempt');
+    await expect(control.detachSession(registration.identity.sessionId)).resolves.toEqual({
+      existed: false,
+    });
+    await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+      state: 'stopped',
+      providerRef: null,
+    });
+    expect(new Set(vercel.runtime.stoppedSessions)).toEqual(new Set(['vsess_joined_1']));
+    expect(await storedGrants(control)).toEqual([]);
+    await runInDurableObject(control, async (_instance, state) => {
+      expect(await state.storage.get('credential_policy_dirty')).not.toBeTruthy();
+    });
+    await expect(vercel.provider.observe(physical.providerRef)).resolves.toMatchObject({
+      status: 'terminal',
+    });
+  });
+
+  it('reapplies a persisted dirty Vercel policy after membership removal even when retry detach changes nothing', async () => {
+    const { control, registration, vercel } = await credentialFixture('vercel');
+    const sibling = await registerSiblingWorktree(registration);
+    const first = await control.ensureReady({
+      ...credentialInput(registration),
+      provider: 'vercel',
+      allowCreate: true,
+    });
+    const second = await control.ensureReady({ ...credentialInput(sibling), allowCreate: false });
+    const firstPayload = first.attachment;
+    const secondPayload = second.attachment;
+    if (!firstPayload?.kilo || !secondPayload?.kilo) throw new Error('Missing sibling attachments');
+    await control.attachSession(attachInput(registration, firstPayload));
+    await control.attachSession(attachInput(sibling, secondPayload));
+    const physical = await control.getPhysicalRecord();
+    const originalGrants = await storedGrants(control);
+    const siblingGrants = originalGrants.filter(grant => grant.scopeId === OTHER_WORKTREE_ID);
+    const firstUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`;
+    const secondUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${SECOND_ROOT_ID}/export`;
+    await runInDurableObject(control, async (_instance, state) => {
+      await state.storage.put('credential_policy_dirty', true);
+      await saveSessionCredentialGrants(state.storage, siblingGrants);
+      const routes = await loadRouteTable(state.storage);
+      routes.delete(registration.identity.sessionId);
+      await saveRouteTable(state.storage, routes);
+    });
+    expect(await storedGrants(control)).toEqual(siblingGrants);
+    expect(policyAuthorization(vercel.runtime.policy, firstPayload.kilo.token, firstUrl)).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    await expect(control.detachSession(registration.identity.sessionId)).resolves.toEqual({
+      existed: false,
+    });
+    expect(
+      policyAuthorization(vercel.runtime.policy, firstPayload.kilo.token, firstUrl)
+    ).toBeUndefined();
+    expect(
+      policyAuthorization(
+        vercel.runtime.policy,
+        firstPayload.git?.token ?? '',
+        'https://api.github.com/repos/acme/repo'
+      )
+    ).toBeUndefined();
+    expect(policyAuthorization(vercel.runtime.policy, secondPayload.kilo.token, secondUrl)).toBe(
+      `Bearer ${KILO_TOKEN}`
+    );
+    expect(
+      policyAuthorization(
+        vercel.runtime.policy,
+        secondPayload.git?.token ?? '',
+        'https://api.github.com/repos/acme/repo'
+      )
+    ).toBe(`Bearer ${GITHUB_TOKEN}`);
+    expect(await control.getPhysicalRecord()).toEqual(physical);
+    expect(await storedGrants(control)).toEqual(siblingGrants);
+    expect(await control.listRoutes()).toEqual([
+      expect.objectContaining(attachInput(sibling, secondPayload)),
+    ]);
+    await runInDurableObject(control, async (_instance, state) => {
+      expect(await state.storage.get('credential_policy_dirty')).not.toBeTruthy();
+    });
+  });
+
+  it('durably schedules the earliest future Vercel grant expiry after preparation and renewal', async () => {
+    const { control, registration, vercel } = await credentialFixture('vercel');
+    const start = Date.now();
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(start);
+    try {
+      const first = await control.ensureReady({
+        ...credentialInput(registration),
+        provider: 'vercel',
+        allowCreate: true,
+      });
+      const afterFirst = await credentialExpiryDeadline(control);
+      const sibling = await registerSiblingWorktree(registration);
+      clock.mockReturnValue(start + HOUR);
+      const second = await control.ensureReady({ ...credentialInput(sibling), allowCreate: false });
+      const afterSibling = await credentialExpiryDeadline(control);
+      clock.mockReturnValue(start + 2 * HOUR);
+      const renewed = await control.ensureReady({
+        ...credentialInput(registration),
+        allowCreate: false,
+      });
+      const afterRenewal = await credentialExpiryDeadline(control);
+      expect(renewed.attachment?.kilo).toEqual(first.attachment?.kilo);
+      const grants = await storedGrants(control);
+      expect(grants.find(grant => grant.scopeId === WORKTREE_ID)?.expiresAt).toBe(start + 6 * HOUR);
+      expect(grants.find(grant => grant.scopeId === OTHER_WORKTREE_ID)?.expiresAt).toBe(
+        start + 5 * HOUR
+      );
+      expect(
+        policyAuthorization(
+          vercel.runtime.policy,
+          renewed.attachment?.kilo?.token ?? '',
+          `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`
+        )
+      ).toBe(`Bearer ${KILO_TOKEN}`);
+      expect(
+        policyAuthorization(
+          vercel.runtime.policy,
+          second.attachment?.kilo?.token ?? '',
+          `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${SECOND_ROOT_ID}/export`
+        )
+      ).toBe(`Bearer ${KILO_TOKEN}`);
+      expect([afterFirst, afterSibling, afterRenewal]).toEqual([
+        start + 4 * HOUR,
+        start + 4 * HOUR,
+        start + 5 * HOUR,
+      ]);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('expires native Vercel rules without preparing again while preserving a live sibling and renewable aliases', async () => {
+    const { control, registration, vercel } = await credentialFixture('vercel');
+    const start = Date.now();
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(start);
+    try {
+      const first = await control.ensureReady({
+        ...credentialInput(registration),
+        provider: 'vercel',
+        allowCreate: true,
+      });
+      const sibling = await registerSiblingWorktree(registration);
+      clock.mockReturnValue(start + HOUR);
+      const second = await control.ensureReady({ ...credentialInput(sibling), allowCreate: false });
+      const firstPayload = first.attachment;
+      const secondPayload = second.attachment;
+      if (!firstPayload?.kilo || !secondPayload?.kilo)
+        throw new Error('Missing expiring attachments');
+      await control.attachSession(attachInput(registration, firstPayload));
+      await control.attachSession(attachInput(sibling, secondPayload));
+      const physical = await control.getPhysicalRecord();
+      const originalGrants = await storedGrants(control);
+      const firstUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`;
+      const secondUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${SECOND_ROOT_ID}/export`;
+      expect(policyAuthorization(vercel.runtime.policy, firstPayload.kilo.token, firstUrl)).toBe(
+        `Bearer ${KILO_TOKEN}`
+      );
+      expect(policyAuthorization(vercel.runtime.policy, secondPayload.kilo.token, secondUrl)).toBe(
+        `Bearer ${KILO_TOKEN}`
+      );
+      clock.mockReturnValue(start + 4 * HOUR);
+      await runCredentialExpiryAlarm(control);
+
+      expect(
+        policyAuthorization(vercel.runtime.policy, firstPayload.kilo.token, firstUrl)
+      ).toBeUndefined();
+      expect(
+        policyAuthorization(
+          vercel.runtime.policy,
+          firstPayload.git?.token ?? '',
+          'https://api.github.com/repos/acme/repo'
+        )
+      ).toBeUndefined();
+      expect(policyAuthorization(vercel.runtime.policy, secondPayload.kilo.token, secondUrl)).toBe(
+        `Bearer ${KILO_TOKEN}`
+      );
+      expect(
+        policyAuthorization(
+          vercel.runtime.policy,
+          secondPayload.git?.token ?? '',
+          'https://api.github.com/repos/acme/repo'
+        )
+      ).toBe(`Bearer ${GITHUB_TOKEN}`);
+      expect(await storedGrants(control)).toEqual(originalGrants);
+      expect(await control.getPhysicalRecord()).toEqual(physical);
+      await expect(vercel.provider.observe(physical.providerRef)).resolves.toMatchObject({
+        status: 'active',
+      });
+      expect(await credentialExpiryDeadline(control)).toBe(start + 5 * HOUR);
+      await runInDurableObject(control, async (_instance, state) => {
+        expect(await state.storage.getAlarm()).toBe(start + 5 * HOUR);
+        expect(await state.storage.get('credential_policy_dirty')).not.toBeTruthy();
+      });
+
+      const renewed = await control.ensureReady({
+        ...credentialInput(registration),
+        allowCreate: false,
+      });
+      expect(renewed.attachment?.kilo).toEqual(firstPayload.kilo);
+      expect(renewed.attachment?.git).toEqual(firstPayload.git);
+      expect(policyAuthorization(vercel.runtime.policy, firstPayload.kilo.token, firstUrl)).toBe(
+        `Bearer ${KILO_TOKEN}`
+      );
+      expect(policyAuthorization(vercel.runtime.policy, secondPayload.kilo.token, secondUrl)).toBe(
+        `Bearer ${KILO_TOKEN}`
+      );
+      expect(await control.getPhysicalRecord()).toEqual(physical);
+      expect(await credentialExpiryDeadline(control)).toBe(start + 5 * HOUR);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it('keeps expiry due when a grant expires during the native policy PUT and cancels after removing the final rules', async () => {
+    const { control, registration, vercel } = await credentialFixture('vercel');
+    const start = Date.now();
+    const expiry = start + 4 * HOUR;
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(start);
+    try {
+      const first = await control.ensureReady({
+        ...credentialInput(registration),
+        provider: 'vercel',
+        allowCreate: true,
+      });
+      const sibling = await registerSiblingWorktree(registration);
+      clock.mockReturnValue(start + 1_000);
+      const second = await control.ensureReady({ ...credentialInput(sibling), allowCreate: false });
+      const firstPayload = first.attachment;
+      const secondPayload = second.attachment;
+      if (!firstPayload?.kilo || !secondPayload?.kilo)
+        throw new Error('Missing expiring attachments');
+      const physical = await control.getPhysicalRecord();
+      const originalGrants = await storedGrants(control);
+      expect(originalGrants.find(grant => grant.scopeId === WORKTREE_ID)?.expiresAt).toBe(expiry);
+      expect(originalGrants.find(grant => grant.scopeId === OTHER_WORKTREE_ID)?.expiresAt).toBe(
+        expiry + 1_000
+      );
+      expect(await credentialExpiryDeadline(control)).toBe(expiry);
+      const firstUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`;
+      const secondUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${SECOND_ROOT_ID}/export`;
+      let submittedPolicy: VercelSandboxNetworkPolicy | undefined;
+      let dirtyDuringPut: boolean | undefined;
+      await runInDurableObject(control, (_instance, state) => {
+        vercel.runtime.beforePolicyUpdate = async policy => {
+          submittedPolicy = policy;
+          dirtyDuringPut = await state.storage.get<boolean>('credential_policy_dirty');
+          clock.mockReturnValue(expiry + 2_000);
+        };
+      });
+      clock.mockReturnValue(expiry);
+      await runCredentialExpiryAlarm(control);
+      vercel.runtime.beforePolicyUpdate = undefined;
+
+      expect(Date.now()).toBe(expiry + 2_000);
+      expect(dirtyDuringPut).toBe(true);
+      expect(submittedPolicy).toEqual(vercel.runtime.policy);
+      expect(
+        policyAuthorization(submittedPolicy, firstPayload.kilo.token, firstUrl)
+      ).toBeUndefined();
+      expect(policyAuthorization(submittedPolicy, secondPayload.kilo.token, secondUrl)).toBe(
+        `Bearer ${KILO_TOKEN}`
+      );
+      expect(
+        policyAuthorization(
+          submittedPolicy,
+          secondPayload.git?.token ?? '',
+          'https://api.github.com/repos/acme/repo'
+        )
+      ).toBe(`Bearer ${GITHUB_TOKEN}`);
+      expect(await credentialExpiryDeadline(control)).toBe(expiry + 1_000);
+      expect(await credentialExpiryDeadline(control)).toBeLessThan(Date.now());
+      await runInDurableObject(control, async (_instance, state) => {
+        expect(await state.storage.getAlarm()).toBe(expiry + 1_000);
+        expect(await state.storage.get('credential_policy_dirty')).not.toBeTruthy();
+      });
+      expect(await storedGrants(control)).toEqual(originalGrants);
+      expect(await control.getPhysicalRecord()).toEqual(physical);
+
+      await runCredentialExpiryAlarm(control);
+      expect(vercel.runtime.policy).toEqual({
+        mode: 'custom',
+        allowedDomains: ['*'],
+        injectionRules: [],
+      });
+      expect(
+        policyAuthorization(vercel.runtime.policy, secondPayload.kilo.token, secondUrl)
+      ).toBeUndefined();
+      expect(
+        policyAuthorization(
+          vercel.runtime.policy,
+          secondPayload.git?.token ?? '',
+          'https://api.github.com/repos/acme/repo'
+        )
+      ).toBeUndefined();
+      expect(await credentialExpiryDeadline(control)).toBeUndefined();
+      await runInDurableObject(control, async (instance, state) => {
+        expect(await state.storage.getAlarm()).toBeNull();
+        expect(await state.storage.get('credential_policy_dirty')).not.toBeTruthy();
+        await instance.alarm();
+        expect(await state.storage.getAlarm()).toBeNull();
+      });
+      expect(await storedGrants(control)).toEqual(originalGrants);
+      expect(await control.getPhysicalRecord()).toEqual(physical);
+      await expect(vercel.provider.observe(physical.providerRef)).resolves.toMatchObject({
+        status: 'active',
+      });
+    } finally {
+      vercel.runtime.beforePolicyUpdate = undefined;
+      clock.mockRestore();
+    }
+  });
+
+  it('stops the exact Vercel runtime when expired credential rules cannot be revoked', async () => {
+    const { control, registration, vercel } = await credentialFixture('vercel');
+    const start = Date.now();
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(start);
+    try {
+      const ready = await control.ensureReady({
+        ...credentialInput(registration),
+        provider: 'vercel',
+        allowCreate: true,
+      });
+      const physical = await control.getPhysicalRecord();
+      const exportUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`;
+      expect(
+        policyAuthorization(vercel.runtime.policy, ready.attachment?.kilo?.token ?? '', exportUrl)
+      ).toBe(`Bearer ${KILO_TOKEN}`);
+      vercel.runtime.failPolicy = true;
+      clock.mockReturnValue(start + 4 * HOUR);
+      await runCredentialExpiryAlarm(control);
+      await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'stopped',
+        providerRef: null,
+      });
+      await expect(vercel.provider.observe(physical.providerRef)).resolves.toMatchObject({
+        status: 'terminal',
+      });
+      expect(new Set(vercel.runtime.stoppedSessions)).toEqual(new Set(['vsess_joined_1']));
+      expect(await storedGrants(control)).toEqual([]);
+      expect(await credentialExpiryDeadline(control)).toBeUndefined();
+      await runInDurableObject(control, async (_instance, state) => {
+        expect(await state.storage.get('credential_policy_dirty')).not.toBeTruthy();
+      });
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it.each(['resolve', 'reject'] as const)(
+    'does not retire a replacement allocation after a late Vercel policy %s',
+    async completion => {
+      const { control, registration, vercel } = await credentialFixture('vercel');
+      await control.ensureReady({
+        ...credentialInput(registration),
+        provider: 'vercel',
+        allowCreate: true,
+      });
+      await runInDurableObject(control, async instance => {
+        let replacement: PhysicalRecord | undefined;
+        vercel.runtime.beforePolicyUpdate = async () => {
+          await instance.beginStop('old_policy_allocation_retired');
+          await expect(instance.recordStopAttempt()).resolves.toMatchObject({ state: 'stopped' });
+          replacement = await instance.claimCreate(
+            crypto.randomUUID(),
+            false,
+            `ses-${crypto.randomUUID().replaceAll('-', '')}`,
+            WORKTREE_CREDENTIAL_CONTAINMENT
+          );
+          expect(replacement.state).toBe('creating');
+          if (completion === 'reject') throw new Error('Old allocation policy rejected');
+        };
+        const outcome = await instance.detachSession(registration.identity.sessionId).then(
+          result => ({ status: 'fulfilled', result }),
+          error => ({ status: 'rejected', error })
+        );
+        expect(replacement).toBeDefined();
+        await expect(instance.getPhysicalRecord()).resolves.toEqual(replacement);
+        expect(outcome).toEqual({ status: 'fulfilled', result: { existed: false } });
+      });
+    }
+  );
+
+  it.each(['resolve', 'startup-failed', 'reject'] as const)(
+    'fences a late Cloudflare create %s after its confirmed instance has been replaced',
+    async completion => {
+      const { control, registration, containers, sandboxId, broker } = await credentialFixture();
+      const deferred = Promise.withResolvers<ProviderCreateResult>();
+      const launchDeferred = Promise.withResolvers<void>();
+      let firstResult: ProviderCreateResult | undefined;
+      let firstIntentId: string | undefined;
+      let native: ProviderAdapter | undefined;
+      await runInDurableObject(control, instance => {
+        const factory = instance as unknown as {
+          createProviderAdapter(
+            kind: AgentSandboxProvider,
+            physical?: PhysicalRecord
+          ): ProviderAdapter;
+        };
+        const createAdapter = factory.createProviderAdapter.bind(instance);
+        Object.assign(instance, {
+          createProviderAdapter: (
+            kind: AgentSandboxProvider,
+            physical?: PhysicalRecord
+          ): ProviderAdapter => {
+            const adapter = createAdapter(kind, physical);
+            native = adapter;
+            return {
+              ...adapter,
+              async create(intent) {
+                firstIntentId ??= intent.intentId;
+                const result = await adapter.create(intent);
+                if (intent.intentId === firstIntentId) {
+                  firstResult = result;
+                  if (completion !== 'startup-failed') return deferred.promise;
+                }
+                return result;
+              },
+              async launch(ref, environment) {
+                await adapter.launch(ref, environment);
+                if (
+                  completion === 'startup-failed' &&
+                  decodeCloudflareProviderRef(ref)?.instanceId === firstIntentId
+                ) {
+                  await launchDeferred.promise;
+                }
+              },
+            };
+          },
+        });
+      });
+      const input = { ...credentialInput(registration), allowCreate: true };
+      const pending = Promise.resolve(control.ensureReady(input)).then(
+        status => ({ type: 'resolved' as const, status }),
+        error => ({
+          type: 'rejected' as const,
+          error: error instanceof Error ? error.message : String(error),
+        })
+      );
+      let currentSocket: WebSocket | undefined;
+      try {
+        await vi.waitFor(() => expect(firstResult).toBeDefined());
+        if (!firstResult || !('providerRef' in firstResult))
+          throw new Error('First instance was not confirmed');
+        const firstRef = firstResult.providerRef;
+        if (completion === 'startup-failed') {
+          await vi.waitFor(() => expect(containers.launches).toHaveLength(1));
+          await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+            state: 'running',
+            providerRef: firstRef,
+            containment: { ...WORKTREE_CREDENTIAL_CONTAINMENT, providerRef: firstRef },
+          });
+        } else {
+          await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+            state: 'creating',
+            providerRef: null,
+            createIntent: { intentId: firstIntentId },
+          });
+          expect(containers.launches).toEqual([]);
+        }
+        const [firstGrant] = await storedGrants(control);
+        if (!firstGrant?.scm) throw new Error('Missing first instance credentials');
+        await control.markFailed();
+        const firstPhysical = await control.getPhysicalRecord();
+        if (!firstPhysical.createIntent) throw new Error('Missing first allocation intent');
+        const clock = vi
+          .spyOn(Date, 'now')
+          .mockReturnValue(firstPhysical.createIntent.createdAt + DEADLINE_MS.createSettle + 1);
+        try {
+          await control.recordStopAttempt();
+        } finally {
+          clock.mockRestore();
+        }
+        await expect(control.getPhysicalRecord()).resolves.toMatchObject({ state: 'stopped' });
+        const replacement = await control.ensureReady(input);
+        const attachment = replacement.attachment;
+        if (!attachment?.kilo || !attachment.git?.token)
+          throw new Error('Missing replacement credentials');
+        const physical = await control.getPhysicalRecord();
+        if (!physical.providerRef) throw new Error('Missing replacement provider reference');
+        expect(physical.state).toBe('running');
+        expect(physical.providerRef).not.toBe(firstRef);
+        expect(attachment.kilo.token).not.toBe(firstGrant.kilo.alias);
+        expect(attachment.git.token).not.toBe(firstGrant.scm.alias);
+        const grants = await storedGrants(control);
+        const [replacementGrant] = grants;
+        expect(grants).toHaveLength(1);
+        expect(replacementGrant.members).toEqual([
+          { sessionId: registration.identity.sessionId, kiloSessionId: ROOT_ID },
+        ]);
+        await control.attachSession(attachInput(registration, attachment));
+        const launch = containers.launches[completion === 'startup-failed' ? 1 : 0];
+        expect(launch.physical).toEqual(physical);
+        expect(launch.env.PROVIDER_INSTANCE_ID).toBe(physical.providerRef);
+        currentSocket = await connect(launch.env.SANDBOX_CONTROL_CREDENTIAL, sandboxId);
+        await completeHello(currentSocket, `hello-current-${completion}`, {
+          providerInstanceId: physical.providerRef,
+        });
+        signalWrapperReady(currentSocket);
+        await vi.waitFor(async () => {
+          await expect(control.getStatus()).resolves.toMatchObject({
+            physical: 'running',
+            connection: 'ready',
+          });
+        });
+
+        if (completion === 'reject')
+          deferred.reject(new Error('Deferred Cloudflare creation failed'));
+        else if (completion === 'startup-failed')
+          launchDeferred.reject(new Error('Deferred wrapper launch failed'));
+        else deferred.resolve({ providerRef: firstRef });
+        const outcome = await pending;
+        expect(await control.getPhysicalRecord()).toEqual(physical);
+        await expect(control.getStatus()).resolves.toMatchObject({
+          physical: 'running',
+          connection: 'ready',
+        });
+        expect(currentSocket.readyState).toBe(1);
+        expect(containers.running.has(launch.containerId ?? '')).toBe(true);
+        if (!native) throw new Error('Missing current native adapter');
+        await expect(
+          native.observe(physical.providerRef, physical.createIntent)
+        ).resolves.toMatchObject({ status: 'active' });
+        expect(await storedGrants(control)).toEqual(grants);
+        if (outcome.type === 'resolved' && outcome.status.attachment) {
+          expect(outcome.status.attachment.kilo).toEqual(attachment.kilo);
+          expect(outcome.status.attachment.git).toEqual(attachment.git);
+        }
+        expect(JSON.stringify(outcome)).not.toContain(firstGrant.kilo.alias);
+        expect(JSON.stringify(outcome)).not.toContain(firstGrant.scm.alias);
+        expectSanitized(outcome, broker);
+        const request = {
+          outboundContainerId: replacementGrant.outboundContainerId ?? '',
+          url: `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`,
+          method: 'GET',
+        };
+        await expect(
+          control.resolveCredential({ ...request, credential: firstGrant.kilo.alias })
+        ).resolves.toBeNull();
+        await expect(
+          control.resolveCredential({ ...request, credential: attachment.kilo.token })
+        ).resolves.toEqual({
+          credential:
+            replacementGrant.kilo.capabilities[registration.identity.sessionId].credential,
+          organizationId: registration.identity.orgId,
+        });
+        expect(await control.listRoutes()).toEqual([
+          expect.objectContaining(attachInput(registration, attachment)),
+        ]);
+      } finally {
+        deferred.resolve(firstResult ?? { unresolved: true });
+        launchDeferred.resolve();
+        await pending;
+        currentSocket?.close();
+      }
+    }
+  );
+
+  it('cleans up a Cloudflare instance without launching if native outbound containment cannot be installed', async () => {
+    const { control, registration, containers, broker } = await credentialFixture();
+    containers.setOutboundFailure();
+    await expect(
+      control.ensureReady({ ...credentialInput(registration), allowCreate: true })
+    ).resolves.toMatchObject({ physical: 'failed' });
+    expect(containers.launches).toEqual([]);
+    const physical = await control.getPhysicalRecord();
+    const nativeId = decodeCloudflareProviderRef(physical.providerRef)?.sandboxId;
+    expect(nativeId).toBe(physical.createIntent?.allocationName);
+    expect(Array.from(broker.kiloSubjects.values())[0]?.outboundContainerId).toBe(
+      `contained:${nativeId}`
+    );
+    await control.recordStopAttempt();
+    expect(containers.destroyed).toEqual([`contained:${nativeId}`]);
+    await finishFailedCreation(control);
+    expect(await storedGrants(control)).toEqual([]);
+    await expect(control.getPhysicalRecord()).resolves.toMatchObject({
+      state: 'stopped',
+      providerRef: null,
+    });
+  });
+
+  it.each([
+    ['usr', 'standard', 'contained'],
+    ['istd', 'standard', 'contained'],
+    ['ses', 'small', 'contained-small'],
+    ['crv', 'review', 'contained-review'],
+  ] as const)(
+    'rejects and cleans legacy %s instances in their own native namespace',
+    async (prefix, rawNamespace, containedNamespace) => {
+      for (const marker of ['raw', 'unmarked', 'old-marker'] as const) {
+        const fixture = await credentialFixture(
+          'cloudflare',
+          `${prefix}-${crypto.randomUUID().replaceAll('-', '')}`
+        );
+        const { control, registration, containers, sandboxId } = fixture;
+        const providerRef = marker === 'raw' ? sandboxId : cloudflareRef(sandboxId);
+        const physical: PhysicalRecord = {
+          state: 'running',
+          providerRef,
+          resumable: false,
+          createIntent: null,
+          stopTombstone: null,
+          ...(marker === 'old-marker'
+            ? { containment: { kilocode: true, github: true, providerRef } }
+            : {}),
+        };
+        const originalContainer = `${marker === 'raw' ? rawNamespace : containedNamespace}:${sandboxId}`;
+        const otherContainer = `${marker === 'raw' ? containedNamespace : rawNamespace}:${sandboxId}`;
+        containers.running.add(originalContainer);
+        containers.running.add(otherContainer);
+        const credential = generateSandboxCredential();
+        await runInDurableObject(control, async (instance, state) => {
+          await state.storage.put('physical_record', physical);
+          await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+        });
+        const ws = await connect(credential, sandboxId);
+        await rejectHello(ws, `hello-legacy-${prefix}-${marker}`, providerRef);
+        await expect(control.getPhysicalRecord()).resolves.toEqual(physical);
+        await expect(
+          control.ensureReady({ ...credentialInput(registration), allowCreate: true })
+        ).resolves.toMatchObject({ physical: 'stopped' });
+        expect(containers.destroyed).toEqual([originalContainer]);
+        expect(containers.running.has(originalContainer)).toBe(false);
+        expect(containers.running.has(otherContainer)).toBe(true);
+        expect(containers.launches).toEqual([]);
+        expect(await storedGrants(control)).toEqual([]);
+      }
+    }
+  );
+
+  it.each(['cloudflare', 'vercel'] as const)(
+    'preserves explicit profile GitHub overrides on %s without changing managed git auth',
+    async provider => {
+      const { control, registration, session, broker } = await credentialFixture(provider);
+      let originalAlias: string | undefined;
+      const profileOverrides: Record<string, string>[] = [
+        { GH_TOKEN: 'profile-gh-token', GITHUB_TOKEN: 'profile-github-token' },
+        { GITHUB_TOKEN: 'profile-github-token' },
+      ];
+      for (const envVars of profileOverrides) {
+        await updateCredentialMetadata(session, metadata => ({
+          ...metadata,
+          profile: { ...metadata.profile, envVars },
+        }));
+        const payload = await readyAttachment(control, credentialInput(registration));
+        expect(payload.env?.GH_TOKEN).toBe(envVars.GH_TOKEN ?? envVars.GITHUB_TOKEN);
+        expect(payload.env?.GITHUB_TOKEN).toBe(envVars.GITHUB_TOKEN);
+        expect(payload.git?.token).not.toBe(payload.env?.GH_TOKEN);
+        expect(payload.git?.token).toMatch(/^kcp1\./);
+        if (originalAlias) expect(payload.git?.token).toBe(originalAlias);
+        originalAlias = payload.git?.token;
+        expectSanitized(payload, broker);
+      }
+    }
+  );
+
+  it.each([
+    'missing-kilo-token',
+    'capability-kilo-token',
+    'custom-github-token',
+    'custom-git-token',
+    'embedded-git-credential',
+    'devcontainer',
+    'vercel-gitlab',
+  ] as const)(
+    'rejects unsupported %s credentials before any provider create',
+    async configuration => {
+      const provider = configuration === 'vercel-gitlab' ? 'vercel' : 'cloudflare';
+      const { control, registration, session, broker, containers, vercel } =
+        await credentialFixture(provider);
+      await updateCredentialMetadata(session, metadata => {
+        if (configuration === 'missing-kilo-token' || configuration === 'capability-kilo-token') {
+          return {
+            ...metadata,
+            auth: {
+              ...metadata.auth,
+              kilocodeToken:
+                configuration === 'missing-kilo-token' ? undefined : 'kka1.existing-capability',
+            },
+          };
+        }
+        if (configuration === 'custom-github-token') {
+          return {
+            ...metadata,
+            repository: { type: 'github', repo: 'acme/repo', token: GITHUB_TOKEN },
+          };
+        }
+        if (configuration === 'custom-git-token' || configuration === 'embedded-git-credential') {
+          const repositoryUrl = new URL('https://git.example.com/acme/repo.git');
+          if (configuration === 'embedded-git-credential') {
+            repositoryUrl.username = 'fake-user';
+            repositoryUrl.password = 'fake-password';
+          }
+          return {
+            ...metadata,
+            repository: {
+              type: 'git',
+              url: repositoryUrl.href,
+              ...(configuration === 'custom-git-token' ? { token: 'fixture-custom-token' } : {}),
+            },
+          };
+        }
+        if (configuration === 'devcontainer') {
+          return { ...metadata, workspace: { ...metadata.workspace, devcontainerRequested: true } };
+        }
+        return {
+          ...metadata,
+          repository: { type: 'gitlab', url: 'https://gitlab.example.com/acme/repo.git' },
+        };
+      });
+      await expect(async () =>
+        control.prepareSessionCredentials(credentialInput(registration))
+      ).rejects.toThrow('Sandbox credential containment is unavailable');
+      await expect(async () =>
+        control.ensureReady({ ...credentialInput(registration), allowCreate: true })
+      ).rejects.toThrow('Invalid contained worktree credentials');
+      expect(await storedGrants(control)).toEqual([]);
+      expect(containers.launches).toEqual([]);
+      expect(vercel.runtime.creates).toBe(0);
+      expect(broker.kiloSubjects.size).toBe(0);
+      expect(broker.githubSubjects.size).toBe(0);
+    }
+  );
+});
+
+describe('SandboxControl recovery watchdogs', () => {
   it('repairs a partially persisted stop and its system alarm after a Durable Object reset', async () => {
     const id = 'usr-partial-stop';
     let control = env.SANDBOX_CONTROL.getByName(id);
-    const { provider, allocations } = await installProvider(control, id);
+    const { provider, allocations } = await installProvider(control, cloudflareRef(id));
     await control.initializeOwner('owner_partial_stop');
     await control.claimCreate('intent_partial_stop');
-    const running = await control.confirmInstance(id);
+    const running = await control.confirmInstance(cloudflareRef(id));
     const wrapperInstanceId = crypto.randomUUID();
     const partial = beginStop(running, 'preparation_interrupted', Date.now(), wrapperInstanceId);
     await runInDurableObject(control, async (_instance, state) => {
@@ -600,16 +4543,73 @@ describe('SandboxControl recovery watchdogs', () => {
       expect(await state.storage.getAlarm()).toBeNull();
     });
     expect(allocations.size).toBe(0);
-    expect(provider.stop).toHaveBeenCalledExactlyOnceWith(id, partial.createIntent);
+    expect(provider.stop).toHaveBeenCalledExactlyOnceWith(cloudflareRef(id), partial.createIntent);
     expect(provider.create).not.toHaveBeenCalled();
     expect(provider.launch).not.toHaveBeenCalled();
   });
 
+  describe('SandboxControl failed-instance reconciliation', () => {
+    it('retries exact Vercel cleanup without reviving a failed instance', async () => {
+      const requestedSandboxId = 'sbx__containment_reconciliation_retry';
+      const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+      await runInDurableObject(stub, async (instance, state) => {
+        const providerRef = encodeVercelProviderRef({
+          sandboxName: requestedSandboxId,
+          sessionId: 'vsess_retry',
+        });
+        const stoppedRefs: Array<string | null> = [];
+        const observedRefs: Array<string | null> = [];
+        const provider = fakeProvider({
+          async stop(ref) {
+            stoppedRefs.push(ref);
+            return stoppedRefs.length === 1 ? 'retryable' : 'terminal';
+          },
+          async observe(ref) {
+            observedRefs.push(ref);
+            return { status: 'active' };
+          },
+        });
+        await seedRunningVercel(instance, state, requestedSandboxId, provider, {
+          physical: containedRunningRecord(providerRef),
+        });
+        await instance.markFailed();
+        await state.storage.put('deadlines', { stopAttempt: Date.now() - 1 });
+        const startedAt = Date.now();
+
+        await instance.alarm();
+        await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+          state: 'stopping',
+          providerRef,
+          stopTombstone: { reason: 'environment_failed', attempts: 1 },
+        });
+        expect(stoppedRefs).toEqual([providerRef]);
+        expect(observedRefs).toEqual([providerRef]);
+        const rearmed = await state.storage.get<DeadlineTable>('deadlines');
+        expect(rearmed?.stopAttempt).toBeGreaterThanOrEqual(
+          startedAt + DEADLINE_MS.stopAttemptLadder[0]
+        );
+        expect(await state.storage.getAlarm()).toBe(rearmed?.stopAttempt);
+
+        await state.storage.put('deadlines', { stopAttempt: Date.now() - 1 });
+        await instance.alarm();
+        await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+          state: 'stopped',
+          providerRef: null,
+        });
+        expect(stoppedRefs).toEqual([providerRef, providerRef]);
+        expect(observedRefs).toEqual([providerRef]);
+        expect(
+          (await state.storage.get<DeadlineTable>('deadlines'))?.reconciliation
+        ).toBeUndefined();
+      });
+    });
+  });
+
   it('rolls back physical state, authority, deadlines, and the real alarm when retirement fails', async () => {
     const fixture = {
-      sandboxId: 'usr-rollback-stop',
+      sandboxId: 'usr-a010',
       ownerId: 'owner_rollback_stop',
-      sessionId: 'workspace_rollback_stop',
+      sessionId: GRANT_SESSION_ID,
       wrapperInstanceId: crypto.randomUUID(),
     } as const satisfies TerminalRuntimeFixture;
     const { control, socket, provider } = await initializeTerminalRuntime(fixture);
@@ -653,7 +4653,7 @@ describe('SandboxControl recovery watchdogs', () => {
           operation: 'session.sync',
           session: {
             sessionId: fixture.sessionId,
-            kiloSessionId: 'kilo_terminal',
+            kiloSessionId: ROOT_ID,
             directory: '/workspace/terminal',
           },
           payload: {},
@@ -668,9 +4668,9 @@ describe('SandboxControl recovery watchdogs', () => {
 
   it('retires a credential-rotated runtime when its replacement readiness alarm expires', async () => {
     const fixture = {
-      sandboxId: 'usr-rotation-watchdog',
+      sandboxId: 'usr-a011',
       ownerId: 'owner_rotation_watchdog',
-      sessionId: 'workspace_rotation_watchdog',
+      sessionId: GRANT_SESSION_ID,
       wrapperInstanceId: crypto.randomUUID(),
     } as const satisfies TerminalRuntimeFixture;
     const { control, socket, provider, allocations } = await initializeTerminalRuntime(fixture);
@@ -712,16 +4712,16 @@ describe('SandboxControl recovery watchdogs', () => {
   it('continues native reaping beyond one hour while the first underlying stop remains unresolved', async () => {
     const id = `usr-${crypto.randomUUID().replaceAll('-', '')}`;
     const control = env.SANDBOX_CONTROL.getByName(id);
-    const { provider, allocations } = await installProvider(control, id);
+    const { provider, allocations } = await installProvider(control, cloudflareRef(id));
     const firstNativeCall = Promise.withResolvers<void>();
     const nativeEntered = Promise.withResolvers<void>();
     let firstNativeSettled = false;
     let nativeAvailable = false;
     const native = {
-      isContainerRunning: vi.fn(async () => allocations.has(id)),
+      isContainerRunning: vi.fn(async () => allocations.has(cloudflareRef(id))),
       forceDestroyForControlPlane: vi.fn(async () => {
         if (!nativeAvailable) throw new Error('native stop temporarily unavailable');
-        allocations.delete(id);
+        allocations.delete(cloudflareRef(id));
       }),
       destroy: vi.fn(async () => {
         throw new Error('Legacy SDK destruction must not be used');
@@ -747,7 +4747,7 @@ describe('SandboxControl recovery watchdogs', () => {
     const clock = vi.spyOn(Date, 'now').mockReturnValue(startedAt);
     try {
       await control.claimCreate('intent_native_reaping');
-      await control.confirmInstance(id);
+      await control.confirmInstance(cloudflareRef(id));
       await control.beginStop('native_stop_unavailable');
       await runInDurableObject(control, async instance => {
         vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] });
@@ -773,7 +4773,7 @@ describe('SandboxControl recovery watchdogs', () => {
       const exhausted = await control.getPhysicalRecord();
       expect(exhausted).toMatchObject({
         state: 'unknown',
-        providerRef: id,
+        providerRef: cloudflareRef(id),
         stopTombstone: { createdAt: startedAt, attempts: 5 },
       });
       clock.mockReturnValue(startedAt + DEADLINE_MS.reconciliationWindow + 1);
@@ -790,14 +4790,18 @@ describe('SandboxControl recovery watchdogs', () => {
       expect(firstNativeSettled).toBe(false);
       await expect(control.getPhysicalRecord()).resolves.toEqual(exhausted);
       await expect(
-        control.ensureReady({ ownerId: 'owner_native_reaping', allowCreate: true })
+        control.ensureReady({
+          ownerId: 'owner_native_reaping',
+          sessionId: GRANT_SESSION_ID,
+          allowCreate: true,
+        })
       ).resolves.toMatchObject({ physical: 'unknown' });
       await runInDurableObject(control, async (_instance, state) => {
         expect(await loadDeadlines(state.storage)).toEqual({ reconciliation: nextPassAt });
         expect(await state.storage.getAlarm()).toBe(nextPassAt);
       });
       expect(native.forceDestroyForControlPlane).toHaveBeenCalledTimes(6);
-      expect(allocations).toEqual(new Set([id]));
+      expect(allocations).toEqual(new Set([cloudflareRef(id)]));
 
       nativeAvailable = true;
       clock.mockReturnValue(nextPassAt);
@@ -831,21 +4835,27 @@ describe('SandboxControl recovery watchdogs', () => {
       const fixture = {
         sandboxId: `usr-${id}`,
         ownerId: 'owner_recovery_watchdog',
-        sessionId: `workspace_watchdog_${id}`,
+        sessionId: `workspace_${crypto.randomUUID()}`,
         wrapperInstanceId: crypto.randomUUID(),
       } as const satisfies TerminalRuntimeFixture;
       const credential = generateSandboxCredential();
+      await registerCredentialSession({
+        identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
+        agent: {},
+        workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
+      });
       await seedCredential(credential, fixture.sandboxId);
       const control = env.SANDBOX_CONTROL.getByName(fixture.sandboxId);
-      const { provider } = await installProvider(control, fixture.sandboxId);
-      await control.confirmInstance(fixture.sandboxId);
+      const { provider } = await installProvider(control, cloudflareRef(fixture.sandboxId));
+      await control.confirmInstance(cloudflareRef(fixture.sandboxId));
       let socket: WebSocket | undefined;
       let replacement: WebSocket | undefined;
       try {
         if (connection === 'ready') {
           socket = await connect(credential, fixture.sandboxId);
           await completeHello(socket, 'hello_watchdog_original', {
-            providerInstanceId: fixture.sandboxId,
+            providerInstanceId: cloudflareRef(fixture.sandboxId),
             wrapperInstanceId: fixture.wrapperInstanceId,
           });
           signalWrapperReady(socket);
@@ -855,7 +4865,7 @@ describe('SandboxControl recovery watchdogs', () => {
           const uncertain = await instance.observeProvider('unknown');
           expect(uncertain).toMatchObject({
             state: 'unknown',
-            providerRef: fixture.sandboxId,
+            providerRef: cloudflareRef(fixture.sandboxId),
             stopTombstone: { reason: 'provider_unknown' },
           });
           const deadlines = await loadDeadlines(state.storage);
@@ -868,19 +4878,31 @@ describe('SandboxControl recovery watchdogs', () => {
           expect((await loadDeadlines(state.storage)).stopAttempt).toBe(deadlines.stopAttempt);
         });
         await expect(
-          control.ensureReady({ ownerId: fixture.ownerId, allowCreate: false })
+          control.ensureReady({
+            ownerId: fixture.ownerId,
+            sessionId: fixture.sessionId,
+            allowCreate: false,
+          })
         ).resolves.toMatchObject({ physical: 'unknown', connection: 'disconnected' });
         expect(provider.create).not.toHaveBeenCalled();
         await expect(control.observeProvider('terminal')).resolves.toMatchObject({
           state: 'stopped',
           providerRef: null,
         });
-        await control.ensureReady({ ownerId: fixture.ownerId, allowCreate: false });
+        await control.ensureReady({
+          ownerId: fixture.ownerId,
+          sessionId: fixture.sessionId,
+          allowCreate: false,
+        });
         expect(provider.create).not.toHaveBeenCalled();
-        await control.ensureReady({ ownerId: fixture.ownerId, allowCreate: true });
+        await control.ensureReady({
+          ownerId: fixture.ownerId,
+          sessionId: fixture.sessionId,
+          allowCreate: true,
+        });
         const launch = provider.launch.mock.calls[0];
         if (!launch) throw new Error('Expected replacement wrapper launch');
-        expect(launch[0]).not.toBe(fixture.sandboxId);
+        expect(launch[0]).not.toBe(cloudflareRef(fixture.sandboxId));
         replacement = await connect(launch[1].SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
         const recoveredAt = Date.now();
         const nextFixture = { ...fixture, wrapperInstanceId: crypto.randomUUID() };
@@ -921,7 +4943,7 @@ describe('SandboxControl recovery watchdogs', () => {
 
 describe('SandboxControl acquisition receipts', () => {
   it('does not allocate twice after a lost acquisition response, reaping, and reset', async () => {
-    const sandboxId = `usr-${crypto.randomUUID().replaceAll('-', '')}`;
+    const sandboxId = `usr-${crypto.randomUUID().replaceAll('-', '')}` as const;
     let control = env.SANDBOX_CONTROL.getByName(sandboxId);
     const { provider, allocations } = await installProvider(control);
     let responseHeld = false;
@@ -930,7 +4952,13 @@ describe('SandboxControl acquisition receipts', () => {
       id: crypto.randomUUID(),
       deadlineAt: Date.now() + SESSION_DELIVERY_TIMEOUT_MS,
     };
-    const input = { ownerId: 'owner_lost_acquisition', acquisition };
+    const input = { ownerId: 'owner_lost_acquisition', sessionId: GRANT_SESSION_ID, acquisition };
+    await registerCredentialSession({
+      identity: { sessionId: input.sessionId, userId: input.ownerId },
+      auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
+      agent: {},
+      workspace: { sandboxId, workspacePath: '/workspace/receipts' },
+    });
     const responseSpy = await runInDurableObject(control, instance => {
       const prototype = Object.getPrototypeOf(instance) as typeof instance;
       const ensureReady = instance.ensureReady.bind(instance);
@@ -998,7 +5026,11 @@ describe('SandboxControl acquisition receipts', () => {
         )
       ).rejects.toThrow('Sandbox acquisition expired');
       await expect(
-        control.ensureReady({ ownerId: input.ownerId, allowCreate: false })
+        control.ensureReady({
+          ownerId: input.ownerId,
+          sessionId: input.sessionId,
+          allowCreate: false,
+        })
       ).resolves.toMatchObject({
         physical: 'stopped',
       });
@@ -1034,9 +5066,99 @@ describe('SandboxControl acquisition receipts', () => {
   });
 });
 
+describe('SandboxControl failed-instance reconciliation', () => {
+  it('does not stop or revive a failed Vercel instance with a malformed reference', async () => {
+    const requestedSandboxId = 'sbx__containment_reconciliation_malformed';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const nativeCalls: string[] = [];
+      const provider = unresolvableVercelProvider(requestedSandboxId, nativeCalls);
+      await seedRunningVercel(instance, state, requestedSandboxId, provider, {
+        physical: {
+          state: 'failed',
+          providerRef: requestedSandboxId,
+          createIntent: null,
+          stopTombstone: null,
+          resumable: false,
+        },
+      });
+      await state.storage.put('deadlines', { reconciliation: Date.now() - 1 });
+
+      await instance.alarm();
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'unknown',
+        providerRef: requestedSandboxId,
+        stopTombstone: { reason: 'provider_unknown', attempts: 0 },
+      });
+      expect(nativeCalls).toEqual([]);
+      expect((await state.storage.get<DeadlineTable>('deadlines'))?.reconciliation).toBeGreaterThan(
+        Date.now()
+      );
+      await state.storage.put('deadlines', { stopAttempt: Date.now() - 1 });
+      await instance.alarm();
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'stopping',
+        providerRef: requestedSandboxId,
+        stopTombstone: { attempts: 1 },
+      });
+      expect(nativeCalls).toEqual([]);
+    });
+  });
+
+  it('reclaims a failed Cloudflare instance without reviving it', async () => {
+    const requestedSandboxId = 'sbx__containment_reconciliation_cloudflare';
+    const stub = env.SANDBOX_CONTROL.getByName(requestedSandboxId);
+    await runInDurableObject(stub, async (instance, state) => {
+      const providerRef = cloudflareRef(requestedSandboxId);
+      await seedGrant(instance, state);
+      const stoppedRefs: Array<string | null> = [];
+      const observedRefs: Array<string | null> = [];
+      const provider = fakeProvider({
+        async stop(ref) {
+          stoppedRefs.push(ref);
+          return 'terminal';
+        },
+        async observe(ref) {
+          observedRefs.push(ref);
+          return { status: 'active' };
+        },
+      });
+      await seedRunningVercel(instance, state, requestedSandboxId, provider, {
+        providerKind: 'cloudflare',
+        physical: {
+          state: 'failed',
+          providerRef,
+          createIntent: null,
+          stopTombstone: null,
+          resumable: false,
+        },
+      });
+      await state.storage.put('deadlines', { reconciliation: Date.now() - 1 });
+
+      await instance.alarm();
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'unknown',
+        providerRef,
+        stopTombstone: { attempts: 0 },
+      });
+      expect(observedRefs).toEqual([providerRef]);
+      expect(stoppedRefs).toEqual([]);
+      await state.storage.put('deadlines', { stopAttempt: Date.now() - 1 });
+      await instance.alarm();
+      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+        state: 'stopped',
+        providerRef: null,
+      });
+      expect(observedRefs).toEqual([providerRef]);
+      expect(stoppedRefs).toEqual([providerRef]);
+      expect(await loadSessionCredentialGrants(state.storage)).toEqual([]);
+    });
+  });
+});
+
 describe('SandboxControl durable remainder', () => {
   it('persists create intent before an instance ref exists', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_create_intent');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_create_intent');
     await runInDurableObject(stub, async instance => {
       const record = await instance.claimCreate('intent_1');
       expect(record.state).toBe('creating');
@@ -1051,37 +5173,37 @@ describe('SandboxControl durable remainder', () => {
   });
 
   it('attaches a session route and rejects owner or directory conflicts', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_routes');
-    await runInDurableObject(stub, async instance => {
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_routes');
+    await runInDurableObject(stub, async (instance, state) => {
       await instance.initializeOwner('owner_1');
-      const route = await instance.attachSession({
-        sessionId: 'ses_1',
-        kiloSessionId: 'kilo_1',
+      const route = await attachGrantedSession(instance, state, {
+        sessionId: GRANT_SESSION_ID,
+        kiloSessionId: ROOT_ID,
         directory: '/workspace/a',
         ownerId: 'owner_1',
       });
-      expect(route.sessionId).toBe('ses_1');
+      expect(route.sessionId).toBe(GRANT_SESSION_ID);
       await expect(
         instance.attachSession({
-          sessionId: 'ses_1',
-          kiloSessionId: 'kilo_1',
+          sessionId: GRANT_SESSION_ID,
+          kiloSessionId: ROOT_ID,
           directory: '/workspace/a',
           ownerId: 'owner_1',
         })
-      ).resolves.toMatchObject({ sessionId: 'ses_1' });
+      ).resolves.toMatchObject({ sessionId: GRANT_SESSION_ID });
       await expect(
-        instance.attachSession({
-          sessionId: 'ses_2',
-          kiloSessionId: 'kilo_2',
+        attachGrantedSession(instance, state, {
+          sessionId: SECOND_GRANT_SESSION_ID,
+          kiloSessionId: SECOND_ROOT_ID,
           directory: '/workspace/a',
           ownerId: 'owner_1',
         })
       ).rejects.toThrow('Directory already attached');
       await expect(
         instance.attachSession({
-          sessionId: 'ses_3',
-          kiloSessionId: 'kilo_3',
-          directory: '/workspace/b',
+          sessionId: GRANT_SESSION_ID,
+          kiloSessionId: ROOT_ID,
+          directory: '/workspace/a',
           ownerId: 'owner_other',
         })
       ).rejects.toThrow('Sandbox owner mismatch');
@@ -1089,29 +5211,23 @@ describe('SandboxControl durable remainder', () => {
   });
 
   it('rearms idle stop when its final active session is detached', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_detach_last_active');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_detach_last_active');
     await runInDurableObject(stub, async (instance, state) => {
       await instance.initializeOwner('owner_1');
-      await instance.claimCreate('intent_detach_last_active');
-      await instance.confirmInstance('inst_1');
-      await instance.attachSession({
-        sessionId: 'workspace_last_active',
-        kiloSessionId: 'kilo_last_active',
+      await seedRunningCloudflare(instance);
+      await attachGrantedSession(instance, state, {
+        sessionId: GRANT_SESSION_ID,
+        kiloSessionId: ROOT_ID,
         directory: '/workspace/last-active',
         ownerId: 'owner_1',
       });
       const routes = await loadRouteTable(state.storage);
-      applyReportedSessionState(
-        routes,
-        'kilo_last_active',
-        { state: 'active', idleForMs: 0 },
-        Date.now()
-      );
+      applyReportedSessionState(routes, ROOT_ID, { state: 'active', idleForMs: 0 }, Date.now());
       await saveRouteTable(state.storage, routes);
       expect((await loadDeadlines(state.storage)).idleStop).toBeUndefined();
 
       const detachedAt = Date.now();
-      await expect(instance.detachSession('workspace_last_active')).resolves.toEqual({
+      await expect(instance.detachSession(GRANT_SESSION_ID)).resolves.toEqual({
         existed: true,
       });
       const idleStop = (await loadDeadlines(state.storage)).idleStop;
@@ -1119,7 +5235,7 @@ describe('SandboxControl durable remainder', () => {
       await expect(instance.listRoutes()).resolves.toEqual([]);
       await expect(instance.getPhysicalRecord()).resolves.toMatchObject({ state: 'running' });
 
-      await expect(instance.detachSession('workspace_last_active')).resolves.toEqual({
+      await expect(instance.detachSession(GRANT_SESSION_ID)).resolves.toEqual({
         existed: false,
       });
       expect((await loadDeadlines(state.storage)).idleStop).toBe(idleStop);
@@ -1127,7 +5243,7 @@ describe('SandboxControl durable remainder', () => {
   });
 
   it('projects shutting-down after beginStop and retains the tombstone without a ref', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_stop_tombstone');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_stop_tombstone');
     await runInDurableObject(stub, async instance => {
       await instance.claimCreate('intent_stop');
       const stopping = await instance.beginStop('idle');
@@ -1143,16 +5259,16 @@ describe('SandboxControl durable remainder', () => {
   });
 
   it('arms idle stop on ready, cancels it for active work, and rearms it when work becomes idle', async () => {
-    const sandboxId = 'sbx_control_heartbeat_idle_stop';
+    const sandboxId = 'sbx__control_heartbeat_idle_stop';
     const credential = generateSandboxCredential();
     const stub = env.SANDBOX_CONTROL.getByName(sandboxId);
-    await runInDurableObject(stub, async instance => {
-      await instance.claimCreate(crypto.randomUUID());
-      await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+    await runInDurableObject(stub, async (instance, state) => {
       await instance.initializeOwner('owner_1');
-      await instance.attachSession({
-        sessionId: 'ses_1',
-        kiloSessionId: 'kilo_1',
+      await seedRunningCloudflare(instance);
+      await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+      await attachGrantedSession(instance, state, {
+        sessionId: GRANT_SESSION_ID,
+        kiloSessionId: ROOT_ID,
         directory: '/workspace/a',
         ownerId: 'owner_1',
       });
@@ -1169,7 +5285,9 @@ describe('SandboxControl durable remainder', () => {
     }
     const ws = response.webSocket;
     ws.accept();
-    await completeHello(ws, 'hello-heartbeat-idle-stop');
+    await completeHello(ws, 'hello-heartbeat-idle-stop', {
+      providerInstanceId: cloudflareRef(sandboxId),
+    });
 
     ws.send(
       JSON.stringify({
@@ -1192,7 +5310,7 @@ describe('SandboxControl durable remainder', () => {
           state: 'active',
           pendingMessages: 0,
           kilo: { ready: true },
-          sessions: [{ kiloSessionId: 'kilo_1', state: 'active', idleForMs: 0 }],
+          sessions: [{ kiloSessionId: ROOT_ID, state: 'active', idleForMs: 0 }],
         },
       })
     );
@@ -1200,7 +5318,7 @@ describe('SandboxControl durable remainder', () => {
       await runInDurableObject(stub, async (instance, state) => {
         expect((await loadDeadlines(state.storage)).idleStop).toBeUndefined();
         expect(await instance.listRoutes()).toEqual([
-          expect.objectContaining({ kiloSessionId: 'kilo_1', lastState: 'active' }),
+          expect.objectContaining({ kiloSessionId: ROOT_ID, lastState: 'active' }),
         ]);
       });
     });
@@ -1213,7 +5331,7 @@ describe('SandboxControl durable remainder', () => {
           state: 'idle',
           pendingMessages: 0,
           kilo: { ready: true },
-          sessions: [{ kiloSessionId: 'kilo_1', state: 'idle', idleForMs: 0 }],
+          sessions: [{ kiloSessionId: ROOT_ID, state: 'idle', idleForMs: 0 }],
         },
       })
     );
@@ -1221,7 +5339,7 @@ describe('SandboxControl durable remainder', () => {
       await runInDurableObject(stub, async (instance, state) => {
         expect((await loadDeadlines(state.storage)).idleStop).toEqual(expect.any(Number));
         expect(await instance.listRoutes()).toEqual([
-          expect.objectContaining({ kiloSessionId: 'kilo_1', lastState: 'idle' }),
+          expect.objectContaining({ kiloSessionId: ROOT_ID, lastState: 'idle' }),
         ]);
       });
     });
@@ -1232,9 +5350,9 @@ describe('SandboxControl durable remainder', () => {
     'persists valid %s demand before forwarding at the idle boundary',
     async operation => {
       const fixture = {
-        sandboxId: `usr-idle-${operation}`,
+        sandboxId: `usr-${crypto.randomUUID().replaceAll('-', '')}`,
         ownerId: 'owner_idle_boundary',
-        sessionId: 'workspace_idle_boundary',
+        sessionId: GRANT_SESSION_ID,
         wrapperInstanceId: crypto.randomUUID(),
       } as const satisfies TerminalRuntimeFixture;
       const { control, socket, provider } = await initializeTerminalRuntime(fixture);
@@ -1261,7 +5379,7 @@ describe('SandboxControl durable remainder', () => {
             operation,
             session: {
               sessionId: fixture.sessionId,
-              kiloSessionId: 'kilo_terminal',
+              kiloSessionId: ROOT_ID,
               directory: '/workspace/terminal',
             },
             payload:
@@ -1301,7 +5419,7 @@ describe('SandboxControl durable remainder', () => {
             payload: {
               state: 'active',
               kilo: { ready: true },
-              sessions: [{ kiloSessionId: 'kilo_terminal', state: 'active', idleForMs: 0 }],
+              sessions: [{ kiloSessionId: ROOT_ID, state: 'active', idleForMs: 0 }],
             },
           })
         );
@@ -1323,7 +5441,7 @@ describe('SandboxControl durable remainder', () => {
   );
 
   it('clears the transition log when the sandbox record is erased', async () => {
-    const stub = env.SANDBOX_CONTROL.getByName('sbx_control_erase_log');
+    const stub = env.SANDBOX_CONTROL.getByName('sbx__control_erase_log');
     await runInDurableObject(stub, async instance => {
       await instance.claimCreate('intent_erase');
       expect(await instance.getTransitionLog()).not.toHaveLength(0);
@@ -1334,69 +5452,74 @@ describe('SandboxControl durable remainder', () => {
     });
   });
 
-  it('does not mutate or quarantine an unrelated route for an unroutable session.event', async () => {
-    const sandboxId = 'sbx_control_event_unroutable';
-    const credential = generateSandboxCredential();
-    const stub = env.SANDBOX_CONTROL.getByName(sandboxId);
-    await runInDurableObject(stub, async instance => {
-      await instance.claimCreate(crypto.randomUUID());
-      await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
-      await instance.initializeOwner('owner_1');
-      await instance.attachSession({
-        sessionId: 'ses_1',
-        kiloSessionId: 'kilo_1',
-        directory: '/workspace/a',
-        ownerId: 'owner_1',
+  it.each([ROOT_ID, SECOND_ROOT_ID])(
+    'does not mutate or quarantine routes for an unroutable session.event from %s',
+    async rootKiloSessionId => {
+      const sandboxId = 'sbx__control_event_unroutable';
+      const credential = generateSandboxCredential();
+      const stub = env.SANDBOX_CONTROL.getByName(sandboxId);
+      await runInDurableObject(stub, async (instance, state) => {
+        await instance.initializeOwner('owner_1');
+        await seedRunningCloudflare(instance);
+        await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+        await attachGrantedSession(instance, state, {
+          sessionId: GRANT_SESSION_ID,
+          kiloSessionId: ROOT_ID,
+          directory: '/workspace/a',
+          ownerId: 'owner_1',
+        });
       });
-    });
 
-    const response = await SELF.fetch(`http://worker.test/sandbox-control/${sandboxId}`, {
-      headers: {
-        Upgrade: 'websocket',
-        Authorization: `Bearer ${credential}`,
-      },
-    });
-    if (response.status !== 101 || !response.webSocket) {
-      throw new Error(`Unexpected sandbox control upgrade: ${response.status}`);
-    }
-    response.webSocket.accept();
-    await completeHello(response.webSocket, 'hello-event');
-    const before = await stub.listRoutes();
-    response.webSocket.send(
-      JSON.stringify({
-        type: 'event',
-        event: 'session.event',
-        session: { directory: '/workspace/other', rootKiloSessionId: 'kilo_1' },
-        payload: { type: 'message.updated', properties: { id: 'msg_1' } },
-      })
-    );
-    await runInDurableObject(stub, async instance => {
-      await expect(instance.listRoutes()).resolves.toEqual(before);
-      await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
-        state: 'running',
-        stopTombstone: null,
+      const response = await SELF.fetch(`http://worker.test/sandbox-control/${sandboxId}`, {
+        headers: {
+          Upgrade: 'websocket',
+          Authorization: `Bearer ${credential}`,
+        },
       });
-    });
-    response.webSocket.close();
-  });
+      if (response.status !== 101 || !response.webSocket) {
+        throw new Error(`Unexpected sandbox control upgrade: ${response.status}`);
+      }
+      response.webSocket.accept();
+      await completeHello(response.webSocket, 'hello-event', {
+        providerInstanceId: cloudflareRef(sandboxId),
+      });
+      const before = await stub.listRoutes();
+      response.webSocket.send(
+        JSON.stringify({
+          type: 'event',
+          event: 'session.event',
+          session: { directory: '/workspace/other', rootKiloSessionId },
+          payload: { type: 'message.updated', properties: { id: 'msg_1' } },
+        })
+      );
+      await runInDurableObject(stub, async instance => {
+        await expect(instance.listRoutes()).resolves.toEqual(before);
+        await expect(instance.getPhysicalRecord()).resolves.toMatchObject({
+          state: 'running',
+          stopTombstone: null,
+        });
+      });
+      response.webSocket.close();
+    }
+  );
 
   it('isolates two session.prompt identities on one wrapper socket', async () => {
-    const twoSessionId = 'sbx_control_two_session';
+    const twoSessionId = 'sbx__control_two_session';
     const credential = generateSandboxCredential();
     const stub = env.SANDBOX_CONTROL.getByName(twoSessionId);
-    await runInDurableObject(stub, async instance => {
-      await instance.claimCreate(crypto.randomUUID());
-      await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+    await runInDurableObject(stub, async (instance, state) => {
       await instance.initializeOwner('owner_1');
-      await instance.attachSession({
-        sessionId: 'ses_a',
-        kiloSessionId: 'kilo_a',
+      await seedRunningCloudflare(instance);
+      await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+      await attachGrantedSession(instance, state, {
+        sessionId: GRANT_SESSION_ID,
+        kiloSessionId: ROOT_ID,
         directory: '/workspace/a',
         ownerId: 'owner_1',
       });
-      await instance.attachSession({
-        sessionId: 'ses_b',
-        kiloSessionId: 'kilo_b',
+      await attachGrantedSession(instance, state, {
+        sessionId: SECOND_GRANT_SESSION_ID,
+        kiloSessionId: SECOND_ROOT_ID,
         directory: '/workspace/b',
         ownerId: 'owner_1',
       });
@@ -1412,7 +5535,9 @@ describe('SandboxControl durable remainder', () => {
       throw new Error(`Unexpected sandbox control upgrade: ${response.status}`);
     }
     response.webSocket.accept();
-    await completeHello(response.webSocket, 'hello-two-session');
+    await completeHello(response.webSocket, 'hello-two-session', {
+      providerInstanceId: cloudflareRef(twoSessionId),
+    });
     signalWrapperReady(response.webSocket);
     await vi.waitFor(async () => {
       await expect(stub.getStatus()).resolves.toMatchObject({ connection: 'ready' });
@@ -1463,8 +5588,8 @@ describe('SandboxControl durable remainder', () => {
       });
     }
 
-    await prompt('ses_a', 'kilo_a', '/workspace/a', 'msg_a');
-    await prompt('ses_b', 'kilo_b', '/workspace/b', 'msg_b');
+    await prompt(GRANT_SESSION_ID, ROOT_ID, '/workspace/a', 'msg_a');
+    await prompt(SECOND_GRANT_SESSION_ID, SECOND_ROOT_ID, '/workspace/b', 'msg_b');
     response.webSocket.close();
   });
 });
@@ -1485,7 +5610,7 @@ describe('SandboxSession control-plane regressions', () => {
       sandboxId: `${sandboxProvider === 'vercel' ? 'ses' : 'usr'}-${id}`,
       sandboxProvider,
       ownerId: 'user_admission',
-      sessionId: `workspace_admission_${id}`,
+      sessionId: `workspace_${crypto.randomUUID()}`,
       wrapperInstanceId: crypto.randomUUID(),
     } as const satisfies TerminalRuntimeFixture;
     const session = env.SANDBOX_SESSION.getByName(`${fixture.ownerId}:${fixture.sessionId}`);
@@ -1501,7 +5626,7 @@ describe('SandboxSession control-plane regressions', () => {
         orgId: 'stored-org',
         createdOnPlatform: 'stored-platform',
       },
-      auth: { kiloSessionId: 'kilo_terminal', kilocodeToken: 'stored-test-token' },
+      auth: { kiloSessionId: ROOT_ID, kilocodeToken: 'stored-test-token' },
       agent,
     });
     await runInDurableObject(session, (_instance, state) => {
@@ -1530,7 +5655,7 @@ describe('SandboxSession control-plane regressions', () => {
 
   function completeTurn(session: SessionStub, messageId: string, wrapperInstanceId: string) {
     return session.receiveSandboxControlEvent({
-      identity: { directory: '/workspace/terminal', kiloSessionId: 'kilo_terminal' },
+      identity: { directory: '/workspace/terminal', kiloSessionId: ROOT_ID },
       wrapperInstanceId,
       payload: { type: 'session.message.outcome', properties: { messageId, status: 'completed' } },
     });
@@ -1545,7 +5670,7 @@ describe('SandboxSession control-plane regressions', () => {
       JSON.stringify({
         type: 'event',
         event: 'session.event',
-        session: { directory: '/workspace/terminal', kiloSessionId: 'kilo_terminal' },
+        session: { directory: '/workspace/terminal', kiloSessionId: ROOT_ID },
         payload: { type: 'session.message.outcome', properties: { messageId, status } },
       })
     );
@@ -1608,7 +5733,7 @@ describe('SandboxSession control-plane regressions', () => {
       await waitForWrapperReady(fixture);
       await session.createSessionWithInitialAdmission({
         identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-        auth: { kiloSessionId: 'kilo_terminal' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: agentA,
         workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
         message: { initialTurn: { type: 'prompt', messageId: 'msg_cancelled_a', prompt: 'A' } },
@@ -1715,7 +5840,7 @@ describe('SandboxSession control-plane regressions', () => {
         expect(state.storage.kv.get('pending_runtime_cleanup')).toEqual(cleanup);
       });
       await session.receiveSandboxControlPreparing({
-        identity: { directory: '/workspace/terminal', kiloSessionId: 'kilo_terminal' },
+        identity: { directory: '/workspace/terminal', kiloSessionId: ROOT_ID },
         wrapperInstanceId: fixture.wrapperInstanceId,
         payload: {
           version: 2,
@@ -1752,7 +5877,7 @@ describe('SandboxSession control-plane regressions', () => {
       await vi.waitFor(() => expect(provider.stop).toHaveBeenCalledTimes(1));
       await expect(control.getPhysicalRecord()).resolves.toMatchObject({
         state: 'stopping',
-        providerRef: fixture.sandboxId,
+        providerRef: cloudflareRef(fixture.sandboxId),
       });
       await runInDurableObject(session, (_instance, state) => {
         expect(state.storage.kv.get('pending_runtime_cleanup')).toBeUndefined();
@@ -1765,7 +5890,7 @@ describe('SandboxSession control-plane regressions', () => {
         ]);
       });
 
-      allocations.delete(fixture.sandboxId);
+      allocations.delete(cloudflareRef(fixture.sandboxId));
       await fireControlDeadline(control, 'stopAttempt');
       await expect(control.getPhysicalRecord()).resolves.toMatchObject({
         state: 'stopped',
@@ -1842,7 +5967,8 @@ describe('SandboxSession control-plane regressions', () => {
     'rejects delayed cancelled A $operation RPCs without reaching or renewing replacement B on $sandboxProvider',
     async ({ sandboxProvider, operation }) => {
       const { fixture, session } = messageFixture(sandboxProvider);
-      const { control, socket, provider, allocations } = await initializeTerminalRuntime(fixture);
+      const { control, socket, provider, allocations, providerRef } =
+        await initializeTerminalRuntime(fixture);
       const release = Promise.withResolvers<void>();
       let heldRequest: Parameters<typeof control.request>[0] | undefined;
       let delayedResponse: ResponseFrame | undefined;
@@ -1881,7 +6007,7 @@ describe('SandboxSession control-plane regressions', () => {
         await waitForWrapperReady(fixture);
         await session.createSessionWithInitialAdmission({
           identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-          auth: { kiloSessionId: 'kilo_terminal' },
+          auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
           agent: agentA,
           workspace: {
             sandboxId: fixture.sandboxId,
@@ -1895,7 +6021,7 @@ describe('SandboxSession control-plane regressions', () => {
           operation,
           session: {
             sessionId: fixture.sessionId,
-            kiloSessionId: 'kilo_terminal',
+            kiloSessionId: ROOT_ID,
             directory: '/workspace/terminal',
           },
         });
@@ -1940,9 +6066,9 @@ describe('SandboxSession control-plane regressions', () => {
         await vi.waitFor(() => expect(provider.stop).toHaveBeenCalledTimes(1));
         await expect(control.getPhysicalRecord()).resolves.toMatchObject({
           state: 'stopping',
-          providerRef: fixture.sandboxId,
+          providerRef,
         });
-        allocations.delete(fixture.sandboxId);
+        allocations.delete(providerRef);
         await fireControlDeadline(control, 'stopAttempt');
         await expect(control.getPhysicalRecord()).resolves.toMatchObject({
           state: 'stopped',
@@ -1951,6 +6077,7 @@ describe('SandboxSession control-plane regressions', () => {
         if (sandboxProvider === 'vercel') {
           await control.ensureReady({
             ownerId: fixture.ownerId,
+            sessionId: fixture.sessionId,
             provider: sandboxProvider,
             allowCreate: true,
           });
@@ -1959,7 +6086,7 @@ describe('SandboxSession control-plane regressions', () => {
         expect(provider.launch).toHaveBeenCalledTimes(1);
         const launch = provider.launch.mock.calls[0];
         if (!launch) throw new Error('Expected a replacement allocation for B');
-        expect(launch[0]).not.toBe(fixture.sandboxId);
+        expect(launch[0]).not.toBe(providerRef);
         const replacementFixture = { ...fixture, wrapperInstanceId: crypto.randomUUID() };
         replacement = await connect(launch[1].SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
         await completeHello(replacement, 'hello_delayed_rpc_replacement', {
@@ -2075,7 +6202,7 @@ describe('SandboxSession control-plane regressions', () => {
       await expect(
         session.createSessionWithInitialAdmission({
           identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-          auth: { kiloSessionId: 'kilo_terminal' },
+          auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
           agent: agentA,
           workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
           message: { initialTurn: { type: 'prompt', messageId: 'msg_stranded', prompt: 'head A' } },
@@ -2165,7 +6292,7 @@ describe('SandboxSession control-plane regressions', () => {
         });
         await session.createSessionWithInitialAdmission({
           identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-          auth: { kiloSessionId: 'kilo_terminal' },
+          auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
           agent: agentA,
           workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
           message: {
@@ -2244,7 +6371,7 @@ describe('SandboxSession control-plane regressions', () => {
       captureAndAcceptControlRequests(socket);
       await session.createSessionWithInitialAdmission({
         identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-        auth: { kiloSessionId: 'kilo_terminal' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: agentA,
         workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
         message: { initialTurn: { type: 'prompt', messageId: 'msg_old_a', prompt: 'A' } },
@@ -2264,7 +6391,7 @@ describe('SandboxSession control-plane regressions', () => {
         JSON.stringify({
           type: 'event',
           event: 'session.preparing',
-          session: { directory: '/workspace/terminal', kiloSessionId: 'kilo_terminal' },
+          session: { directory: '/workspace/terminal', kiloSessionId: ROOT_ID },
           payload: {
             version: 2,
             attemptId,
@@ -2281,10 +6408,10 @@ describe('SandboxSession control-plane regressions', () => {
         JSON.stringify({
           type: 'event',
           event: 'session.event',
-          session: { directory: '/workspace/terminal', kiloSessionId: 'kilo_terminal' },
+          session: { directory: '/workspace/terminal', kiloSessionId: ROOT_ID },
           payload: {
             type: 'session.status',
-            properties: { sessionID: 'kilo_terminal', status: { type: 'busy' } },
+            properties: { sessionID: ROOT_ID, status: { type: 'busy' } },
           },
         })
       );
@@ -2359,7 +6486,7 @@ describe('SandboxSession control-plane regressions', () => {
         await waitForWrapperReady(fixture);
         await session.createSessionWithInitialAdmission({
           identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-          auth: { kiloSessionId: 'kilo_terminal' },
+          auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
           agent: agentA,
           workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
           message: {
@@ -2390,7 +6517,7 @@ describe('SandboxSession control-plane regressions', () => {
             {
               session: {
                 sessionId: fixture.sessionId,
-                kiloSessionId: 'kilo_terminal',
+                kiloSessionId: ROOT_ID,
                 directory: '/workspace/terminal',
               },
               payload: { messageId: 'msg_interrupt' },
@@ -2405,7 +6532,7 @@ describe('SandboxSession control-plane regressions', () => {
             });
           });
           expect(provider.stop).toHaveBeenCalledTimes(1);
-          expect(provider.stop.mock.calls[0]?.[0]).toBe(fixture.sandboxId);
+          expect(provider.stop.mock.calls[0]?.[0]).toBe(cloudflareRef(fixture.sandboxId));
           expect(requests.filter(request => request.operation === 'session.prompt')).toEqual([]);
         }
         const events = await lifecycleEvents(session);
@@ -2447,7 +6574,7 @@ describe('SandboxSession control-plane regressions', () => {
       captureAndAcceptControlRequests(socket);
       await session.createSessionWithInitialAdmission({
         identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-        auth: { kiloSessionId: 'kilo_terminal' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: agentA,
         workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
         message: { initialTurn: { type: 'prompt', messageId: 'msg_unhealthy', prompt: 'A' } },
@@ -2488,13 +6615,13 @@ describe('SandboxSession control-plane regressions', () => {
       for (let attempt = 2; attempt <= DEADLINE_MS.stopAttemptLadder.length; attempt++) {
         await fireControlDeadline(control, 'stopAttempt');
         expect(provider.stop.mock.calls.map(([ref]) => ref)).toEqual(
-          Array.from({ length: attempt }, () => fixture.sandboxId)
+          Array.from({ length: attempt }, () => cloudflareRef(fixture.sandboxId))
         );
         expect((await control.getPhysicalRecord()).stopTombstone?.attempts).toBe(attempt);
       }
       await expect(control.getPhysicalRecord()).resolves.toMatchObject({
         state: 'unknown',
-        providerRef: fixture.sandboxId,
+        providerRef: cloudflareRef(fixture.sandboxId),
         stopTombstone: { attempts: 5, wrapperInstanceId: fixture.wrapperInstanceId },
       });
       await expect(control.getStatus()).resolves.toMatchObject({ connection: 'disconnected' });
@@ -2504,12 +6631,12 @@ describe('SandboxSession control-plane regressions', () => {
       await fireControlDeadline(control, 'reconciliation');
       expect(provider.observe).toHaveBeenCalledTimes(observations + 2);
       expect(provider.stop.mock.calls.map(([ref]) => ref)).toEqual(
-        Array.from({ length: 7 }, () => fixture.sandboxId)
+        Array.from({ length: 7 }, () => cloudflareRef(fixture.sandboxId))
       );
       expect((await control.getPhysicalRecord()).stopTombstone?.attempts).toBe(5);
       expect(provider.create).not.toHaveBeenCalled();
 
-      allocations.delete(fixture.sandboxId);
+      allocations.delete(cloudflareRef(fixture.sandboxId));
       await fireControlDeadline(control, 'reconciliation');
       await expect(control.getPhysicalRecord()).resolves.toMatchObject({
         state: 'stopped',
@@ -2529,7 +6656,7 @@ describe('SandboxSession control-plane regressions', () => {
       await vi.waitFor(() => expect(provider.launch).toHaveBeenCalledTimes(1));
       const launch = provider.launch.mock.calls[0];
       if (!launch) throw new Error('Expected replacement wrapper launch');
-      expect(launch[0]).not.toBe(fixture.sandboxId);
+      expect(launch[0]).not.toBe(cloudflareRef(fixture.sandboxId));
       expect((await control.getPhysicalRecord()).providerRef).toBe(launch[0]);
       replacement = await connect(launch[1].SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
       await completeHello(replacement, 'hello_cleanup_recovery', {
@@ -2579,7 +6706,7 @@ describe('SandboxSession control-plane regressions', () => {
       await expect(
         session.createSessionWithInitialAdmission({
           identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-          auth: { kiloSessionId: 'kilo_terminal' },
+          auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
           agent: { mode: 'architect', model: 'kilo/fake-deterministic', variant: 'high' },
           workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
           finalization,
@@ -2632,7 +6759,14 @@ describe('SandboxSession control-plane regressions', () => {
     let session = originalSession;
     const credential = generateSandboxCredential();
     await seedCredential(credential, fixture.sandboxId);
-    await installProvider(env.SANDBOX_CONTROL.getByName(fixture.sandboxId), fixture.sandboxId);
+    await runInDurableObject(
+      env.SANDBOX_CONTROL.getByName(fixture.sandboxId),
+      seedRunningCloudflare
+    );
+    await installProvider(
+      env.SANDBOX_CONTROL.getByName(fixture.sandboxId),
+      cloudflareRef(fixture.sandboxId)
+    );
     const socket = await connect(credential, fixture.sandboxId);
     let replacement: WebSocket | undefined;
     try {
@@ -2640,7 +6774,7 @@ describe('SandboxSession control-plane regressions', () => {
       await expect(
         session.createSessionWithInitialAdmission({
           identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-          auth: { kiloSessionId: 'kilo_terminal' },
+          auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
           agent: agentA,
           workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
           message: { initialTurn: { type: 'prompt', messageId: 'msg_a', prompt: 'A' } },
@@ -2680,11 +6814,15 @@ describe('SandboxSession control-plane regressions', () => {
       expect(globalThis.fetch).toHaveBeenCalledTimes(2);
 
       await abortAllDurableObjects();
+      await installProvider(
+        env.SANDBOX_CONTROL.getByName(fixture.sandboxId),
+        cloudflareRef(fixture.sandboxId)
+      );
       session = env.SANDBOX_SESSION.get(env.SANDBOX_SESSION.idFromString(session.id.toString()));
       expect(await admissionState(session)).toEqual(beforeReplay);
       replacement = await connect(credential, fixture.sandboxId);
       await completeHello(replacement, 'hello_frozen_recreated', {
-        providerInstanceId: fixture.sandboxId,
+        providerInstanceId: cloudflareRef(fixture.sandboxId),
         wrapperInstanceId: fixture.wrapperInstanceId,
       });
       const requests = captureAndAcceptControlRequests(replacement);
@@ -2746,7 +6884,7 @@ describe('SandboxSession control-plane regressions', () => {
     await expect(
       session.createSessionWithInitialAdmission({
         identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-        auth: { kiloSessionId: 'kilo_terminal' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: { mode: 'reviewer', model: agentA.model },
         message: { initialTurn: { type: 'prompt', messageId: 'msg_initial', prompt: 'initial' } },
       })
@@ -2774,7 +6912,7 @@ describe('SandboxSession control-plane regressions', () => {
       const requests = captureAndAcceptControlRequests(socket);
       await session.registerSession({
         identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-        auth: { kiloSessionId: 'kilo_terminal' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: { mode: 'code' },
         workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
       });
@@ -3038,7 +7176,7 @@ describe('SandboxSession control-plane regressions', () => {
       await waitForWrapperReady(fixture);
       await session.registerSession({
         identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-        auth: { kiloSessionId: 'kilo_terminal' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: agentA,
         workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
       });
@@ -3183,7 +7321,7 @@ describe('SandboxSession control-plane regressions', () => {
       await waitForWrapperReady(fixture);
       await session.registerSession({
         identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-        auth: { kiloSessionId: 'kilo_terminal' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: agentA,
         workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
       });
@@ -3258,7 +7396,7 @@ describe('SandboxSession control-plane regressions', () => {
       });
       await session.createSessionWithInitialAdmission({
         identity: { sessionId: fixture.sessionId, userId: fixture.ownerId },
-        auth: { kiloSessionId: 'kilo_terminal' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: agentA,
         workspace: { sandboxId: fixture.sandboxId, workspacePath: '/workspace/terminal' },
         message: { initialTurn: { type: 'prompt', messageId: 'msg_retry_a', prompt: 'retry A' } },
@@ -3384,36 +7522,45 @@ describe('SandboxSession control-plane regressions', () => {
 
   it('aborts and detaches a deleted session without stopping active sibling work', async () => {
     const userId = 'user_control_delete';
-    const sessionId = 'workspace_control_deleted';
-    const siblingSessionId = 'workspace_control_sibling';
+    const sessionId = GRANT_SESSION_ID;
+    const siblingSessionId = SECOND_GRANT_SESSION_ID;
     const controlId = 'usr-de1e7ed';
     const credential = generateSandboxCredential();
     const control = env.SANDBOX_CONTROL.getByName(controlId);
-    const { provider } = await installProvider(control, 'inst_1');
-    await runInDurableObject(control, async instance => {
-      await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+    const { provider } = await installProvider(control, cloudflareRef(controlId));
+    await runInDurableObject(control, async (instance, state) => {
       await instance.initializeOwner(userId);
-      await instance.claimCreate('intent_shared_delete');
-      await instance.confirmInstance('inst_1');
-      await instance.attachSession({
+      await seedRunningCloudflare(instance);
+      await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
+      await attachGrantedSession(instance, state, {
         sessionId,
-        kiloSessionId: 'kilo_deleted',
+        kiloSessionId: ROOT_ID,
         directory: '/workspace/deleted',
         ownerId: userId,
       });
-      await instance.attachSession({
+      await attachGrantedSession(instance, state, {
         sessionId: siblingSessionId,
-        kiloSessionId: 'kilo_sibling',
+        kiloSessionId: SECOND_ROOT_ID,
         directory: '/workspace/sibling',
         ownerId: userId,
       });
+      const routes = await loadRouteTable(state.storage);
+      for (const kiloSessionId of [ROOT_ID, SECOND_ROOT_ID]) {
+        applyReportedSessionState(
+          routes,
+          kiloSessionId,
+          { state: 'active', idleForMs: 0 },
+          Date.now()
+        );
+      }
+      await saveRouteTable(state.storage, routes);
     });
 
     const session = env.SANDBOX_SESSION.getByName(`${userId}:${sessionId}`);
     await runInDurableObject(session, async (instance, state) => {
       await instance.registerSession({
         identity: { sessionId, userId },
-        auth: { kiloSessionId: 'kilo_deleted' },
+        auth: { kiloSessionId: ROOT_ID, kilocodeToken: KILO_TOKEN },
         agent: { mode: 'code', model: 'test' },
         workspace: { sandboxId: controlId, workspacePath: '/workspace/deleted' },
       });
@@ -3428,7 +7575,10 @@ describe('SandboxSession control-plane regressions', () => {
     });
 
     const ws = await connect(credential, controlId);
-    await completeHello(ws, 'hello-shared-delete', { wrapperInstanceId: crypto.randomUUID() });
+    await completeHello(ws, 'hello-shared-delete', {
+      providerInstanceId: cloudflareRef(controlId),
+      wrapperInstanceId: crypto.randomUUID(),
+    });
     signalWrapperReady(ws);
     await vi.waitFor(async () => {
       await expect(control.getStatus()).resolves.toMatchObject({ connection: 'ready' });
@@ -3440,7 +7590,7 @@ describe('SandboxSession control-plane regressions', () => {
         payload: {
           state: 'active',
           kilo: { ready: true },
-          sessions: ['kilo_deleted', 'kilo_sibling'].map(kiloSessionId => ({
+          sessions: [ROOT_ID, SECOND_ROOT_ID].map(kiloSessionId => ({
             kiloSessionId,
             state: 'active',
             idleForMs: 0,
@@ -3491,7 +7641,7 @@ describe('SandboxSession control-plane regressions', () => {
       await expect(instance.listRoutes()).resolves.toEqual([
         expect.objectContaining({
           sessionId: siblingSessionId,
-          kiloSessionId: 'kilo_sibling',
+          kiloSessionId: SECOND_ROOT_ID,
           lastState: 'active',
         }),
       ]);
@@ -3506,7 +7656,7 @@ describe('SandboxSession control-plane regressions', () => {
         operation: 'session.abort',
         session: {
           sessionId,
-          kiloSessionId: 'kilo_deleted',
+          kiloSessionId: ROOT_ID,
           directory: '/workspace/deleted',
         },
       },
@@ -3653,11 +7803,182 @@ describe('SandboxSession control-plane regressions', () => {
 });
 
 describe('SandboxControl terminal runtime coordination', () => {
+  it.each(['cloudflare', 'vercel'] as const)(
+    'renews near-expiry and expired %s grants through authenticated terminal activity',
+    async provider => {
+      const fixture = await credentialTerminalFixture(provider);
+      const { control, access, socket, vercel } = fixture;
+      try {
+        for (const remainingMs of [HOUR / 2, -1_000]) {
+          const [original] = await storedGrants(control);
+          if (!original) throw new Error('Missing terminal credential grant');
+          const now = Date.now();
+          const aged = {
+            ...original,
+            preparedAt: now + remainingMs - 4 * HOUR,
+            expiresAt: now + remainingMs,
+          };
+          await runInDurableObject(control, async (_instance, state) => {
+            await saveSessionCredentialGrants(state.storage, [aged]);
+            if (provider === 'vercel') {
+              await state.storage.put('deadlines', { credentialExpiry: aged.expiresAt });
+            }
+          });
+          const exportUrl = `${CONTAINMENT_TARGETS.sessionIngestBaseUrl}/api/session/${ROOT_ID}/export`;
+          if (remainingMs < 0) {
+            if (provider === 'vercel') {
+              await runCredentialExpiryAlarm(control);
+              expect(
+                policyAuthorization(vercel.runtime.policy, original.kilo.alias, exportUrl)
+              ).toBeUndefined();
+            } else {
+              await expect(
+                control.resolveCredential({
+                  credential: original.kilo.alias,
+                  outboundContainerId: original.outboundContainerId ?? '',
+                  url: exportUrl,
+                  method: 'GET',
+                })
+              ).resolves.toBeNull();
+            }
+          }
+          const physical = await control.getPhysicalRecord();
+          await expect(
+            Promise.all([
+              control.recordTerminalActivity(access),
+              control.validateTerminalAccess(access),
+            ])
+          ).resolves.toEqual([{ allowed: true }, { allowed: true }]);
+          const renewed = await storedGrants(control);
+          expect(renewed).toHaveLength(1);
+          expect(renewed[0]).toMatchObject({
+            scopeId: original.scopeId,
+            members: original.members,
+            kilo: { alias: original.kilo.alias },
+            scm: { alias: original.scm?.alias },
+          });
+          expect(renewed[0].expiresAt).toBeGreaterThan(now + 3 * HOUR);
+          expect(await control.getPhysicalRecord()).toEqual(physical);
+          await expect(control.validateTerminalAccess(access)).resolves.toEqual({ allowed: true });
+          expect(await storedGrants(control)).toEqual(renewed);
+          if (provider === 'vercel') {
+            expect(policyAuthorization(vercel.runtime.policy, original.kilo.alias, exportUrl)).toBe(
+              `Bearer ${KILO_TOKEN}`
+            );
+            expect(await credentialExpiryDeadline(control)).toBe(renewed[0].expiresAt);
+          }
+        }
+        expect(
+          provider === 'vercel' ? vercel.runtime.creates : fixture.containers.launches.length
+        ).toBe(1);
+      } finally {
+        socket.close();
+      }
+    }
+  );
+
+  it.each(['missing', 'owner-changed', 'revoked'] as const)(
+    'does not renew terminal credentials when authoritative session metadata is %s',
+    async kind => {
+      const { control, access, socket, session } = await credentialTerminalFixture('cloudflare');
+      try {
+        const now = Date.now();
+        await runInDurableObject(control, async (_instance, state) => {
+          const grants = await loadSessionCredentialGrants(state.storage);
+          await saveSessionCredentialGrants(
+            state.storage,
+            grants.map(grant => ({
+              ...grant,
+              preparedAt: now - 3.5 * HOUR,
+              expiresAt: now + HOUR / 2,
+            }))
+          );
+        });
+        const grants = await storedGrants(control);
+        await runInDurableObject(session, async (instance, state) => {
+          const metadata = await instance.getCredentialMetadata();
+          if (!metadata) throw new Error('Missing terminal session metadata');
+          if (kind === 'missing') {
+            state.storage.kv.delete(SANDBOX_SESSION_METADATA_KEY);
+          } else if (kind === 'owner-changed') {
+            state.storage.kv.put(
+              SANDBOX_SESSION_METADATA_KEY,
+              serializeSessionMetadata({
+                ...metadata,
+                identity: { ...metadata.identity, userId: 'another-owner' },
+              })
+            );
+          } else {
+            state.storage.kv.put(SANDBOX_SESSION_LIFECYCLE_KEY, { epoch: 1, state: 'revoked' });
+          }
+        });
+        await expect(control.recordTerminalActivity(access)).resolves.toEqual({
+          allowed: false,
+          reason: 'credential_scope_unavailable',
+        });
+        expect(await storedGrants(control)).toEqual(grants);
+      } finally {
+        socket.close();
+      }
+    }
+  );
+
+  it.each(['runtime', 'route', 'membership'] as const)(
+    'does not publish terminal renewal when %s changes during credential issuance',
+    async changed => {
+      const { control, access, socket, broker, sandboxId } =
+        await credentialTerminalFixture('cloudflare');
+      try {
+        await runInDurableObject(control, async (instance, state) => {
+          const now = Date.now();
+          const grants = (await loadSessionCredentialGrants(state.storage)).map(grant => ({
+            ...grant,
+            preparedAt: now - 3.5 * HOUR,
+            expiresAt: now + HOUR / 2,
+            kilo: {
+              ...grant.kilo,
+              capabilities: Object.fromEntries(
+                Object.entries(grant.kilo.capabilities).map(([id, capability]) => [
+                  id,
+                  { ...capability, issuedAt: now - 4 * HOUR, expiresAt: now - HOUR },
+                ])
+              ),
+            },
+          }));
+          await saveSessionCredentialGrants(state.storage, grants);
+          const issue = broker.binding.issueKiloSessionCapability.bind(broker.binding);
+          broker.binding.issueKiloSessionCapability = async subject => {
+            if (changed === 'runtime') {
+              await state.storage.put(
+                'physical_record',
+                containedRunningRecord(cloudflareRef(sandboxId, 'replacement'))
+              );
+            } else if (changed === 'route') {
+              await state.storage.put('session_routes', []);
+            } else {
+              await saveSessionCredentialGrants(state.storage, []);
+            }
+            return issue(subject);
+          };
+          await expect(instance.recordTerminalActivity(access)).resolves.toEqual({
+            allowed: false,
+            reason: 'credential_scope_unavailable',
+          });
+          expect(await loadSessionCredentialGrants(state.storage)).toEqual(
+            changed === 'membership' ? [] : grants
+          );
+        });
+      } finally {
+        socket.close();
+      }
+    }
+  );
+
   it('exposes a wrapper instance only for the ready current connection', async () => {
     const fixture: TerminalRuntimeFixture = {
       sandboxId: 'usr-a001',
       ownerId: 'owner_wrapper_readiness',
-      sessionId: 'workspace_wrapper_readiness',
+      sessionId: GRANT_SESSION_ID,
       wrapperInstanceId: 'b40b8d7b-789f-4c2a-82ce-0c5c9aed4621',
     };
     const { control, socket } = await initializeTerminalRuntime(fixture);
@@ -3684,7 +8005,7 @@ describe('SandboxControl terminal runtime coordination', () => {
     await seedCredential(rotatedCredential, fixture.sandboxId);
     const replacement = await connect(rotatedCredential, fixture.sandboxId);
     await completeHello(replacement, 'hello_rotated_wrapper', {
-      providerInstanceId: fixture.sandboxId,
+      providerInstanceId: cloudflareRef(fixture.sandboxId),
       wrapperInstanceId: fixture.wrapperInstanceId,
     });
     await runInDurableObject(control, async (instance, state) => {
@@ -3707,7 +8028,7 @@ describe('SandboxControl terminal runtime coordination', () => {
     const fixture: TerminalRuntimeFixture = {
       sandboxId: 'usr-a002',
       ownerId: 'owner_legacy_wrapper',
-      sessionId: 'workspace_legacy_wrapper',
+      sessionId: GRANT_SESSION_ID,
     };
     const { control, socket } = await initializeTerminalRuntime(fixture);
     signalWrapperReady(socket);
@@ -3732,7 +8053,7 @@ describe('SandboxControl terminal runtime coordination', () => {
     const fixture: TerminalRuntimeFixture = {
       sandboxId: 'usr-a003',
       ownerId: 'owner_terminal_access',
-      sessionId: 'workspace_terminal_access',
+      sessionId: GRANT_SESSION_ID,
       wrapperInstanceId: '22c38b5a-5394-4a71-9c88-e3e998565fdb',
     };
     const { control, socket } = await initializeTerminalRuntime(fixture);
@@ -3770,16 +8091,16 @@ describe('SandboxControl terminal runtime coordination', () => {
   it('never provisions or wakes a stopped runtime for terminal access or activity', async () => {
     const control = env.SANDBOX_CONTROL.getByName('usr-a00a');
     const input = {
-      sessionId: 'workspace_stopped_access',
+      sessionId: GRANT_SESSION_ID,
       ownerId: 'owner_stopped_access',
       wrapperInstanceId: '594b4020-64a5-42d4-bcf0-7915af4a099d',
     };
 
-    await runInDurableObject(control, async instance => {
+    await runInDurableObject(control, async (instance, state) => {
       await instance.initializeOwner(input.ownerId);
-      await instance.attachSession({
+      await attachGrantedSession(instance, state, {
         sessionId: input.sessionId,
-        kiloSessionId: 'kilo_terminal',
+        kiloSessionId: ROOT_ID,
         directory: '/workspace/terminal',
         ownerId: input.ownerId,
       });
@@ -3799,84 +8120,97 @@ describe('SandboxControl terminal runtime coordination', () => {
     });
   });
 
-  it('ends PTYs after control replacement and fences late invalidation from the new runtime', async () => {
-    const fixture: TerminalRuntimeFixture = {
-      sandboxId: 'usr-a004',
-      ownerId: 'owner_runtime_replacement',
-      sessionId: 'workspace_runtime_replacement',
-      wrapperInstanceId: '2ece7e1a-6f7f-40b3-a4d8-307304eaaf93',
-    };
-    const { control, credential, socket, provider } = await initializeTerminalRuntime(fixture);
-    const session = await seedTerminalSession(fixture);
-    let newWrapper: WebSocket | undefined;
-    signalWrapperReady(socket);
-    await waitForWrapperReady(fixture);
-    const sameWrapper = await connect(credential, fixture.sandboxId);
-    try {
-      const replaced = new Promise<number>(resolve => {
-        sameWrapper.addEventListener('close', event => resolve(event.code), { once: true });
-      });
-      sendHello(sameWrapper, 'hello_replaced_runtime', {
-        providerInstanceId: fixture.sandboxId,
-        wrapperInstanceId: fixture.wrapperInstanceId,
-      });
-      await expect(replaced).resolves.toBe(4001);
-      await vi.waitFor(async () => {
-        await expect(control.getPhysicalRecord()).resolves.toMatchObject({ state: 'stopped' });
-        await runInDurableObject(session, (_instance, state) => {
-          expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
-            state: 'ended',
-          });
-          expect(state.storage.kv.get('terminal_attached_session')).toBeUndefined();
-        });
-      });
-      expect(provider.stop).toHaveBeenCalledTimes(1);
-      await control.ensureReady({ ownerId: fixture.ownerId, allowCreate: true });
-      const launch = provider.launch.mock.calls[0];
-      if (!launch) throw new Error('Expected replacement wrapper launch');
-      expect(launch[0]).not.toBe(fixture.sandboxId);
-      const replacementFixture = { ...fixture, wrapperInstanceId: crypto.randomUUID() };
-      newWrapper = await connect(launch[1].SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
-      await completeHello(newWrapper, 'hello_replacement_runtime', {
-        providerInstanceId: launch[0],
-        wrapperInstanceId: replacementFixture.wrapperInstanceId,
-      });
-      expect(await control.getStatus()).not.toHaveProperty('wrapperInstanceId');
-      signalWrapperReady(newWrapper);
-      await waitForWrapperReady(replacementFixture);
-      await seedTerminalSession(replacementFixture, 'pty_current');
-      await runInDurableObject(session, async (instance, state) => {
-        await instance.invalidateTerminalRuntime({
-          sandboxId: fixture.sandboxId,
-          wrapperInstanceId: fixture.wrapperInstanceId ?? '',
-          confirmed: true,
-        });
-        expect(state.storage.kv.get<{ state: string }>('terminal:pty_current')).toMatchObject({
+  it.each(['same', 'different'] as const)(
+    'ends PTYs after control replacement by the %s wrapper and fences late invalidation',
+    async replacementIdentity => {
+      const fixture: TerminalRuntimeFixture = {
+        sandboxId: 'usr-a004',
+        ownerId: 'owner_runtime_replacement',
+        sessionId: GRANT_SESSION_ID,
+        wrapperInstanceId: '2ece7e1a-6f7f-40b3-a4d8-307304eaaf93',
+      };
+      const { control, credential, socket, provider } = await initializeTerminalRuntime(fixture);
+      const session = await seedTerminalSession(fixture);
+      let newWrapper: WebSocket | undefined;
+      signalWrapperReady(socket);
+      await waitForWrapperReady(fixture);
+      await runInDurableObject(session, (_instance, state) => {
+        expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
           state: 'running',
         });
-        expect(state.storage.kv.get('terminal_attached_session')).toMatchObject({
-          wrapperInstanceId: replacementFixture.wrapperInstanceId,
-        });
       });
-      await expect(
-        control.validateTerminalAccess({
+      const sameWrapper = await connect(credential, fixture.sandboxId);
+      try {
+        const replaced = new Promise<number>(resolve => {
+          sameWrapper.addEventListener('close', event => resolve(event.code), { once: true });
+        });
+        sendHello(sameWrapper, 'hello_replaced_runtime', {
+          providerInstanceId: cloudflareRef(fixture.sandboxId),
+          wrapperInstanceId:
+            replacementIdentity === 'same' ? fixture.wrapperInstanceId : crypto.randomUUID(),
+        });
+        await expect(replaced).resolves.toBe(4001);
+        await vi.waitFor(async () => {
+          await expect(control.getPhysicalRecord()).resolves.toMatchObject({ state: 'stopped' });
+          await runInDurableObject(session, (_instance, state) => {
+            expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
+              state: 'ended',
+            });
+            expect(state.storage.kv.get('terminal_attached_session')).toBeUndefined();
+          });
+        });
+        expect(provider.stop).toHaveBeenCalledTimes(1);
+        await control.ensureReady({
           ownerId: fixture.ownerId,
           sessionId: fixture.sessionId,
+          allowCreate: true,
+        });
+        const launch = provider.launch.mock.calls[0];
+        if (!launch) throw new Error('Expected replacement wrapper launch');
+        expect(launch[0]).not.toBe(cloudflareRef(fixture.sandboxId));
+        const replacementFixture = { ...fixture, wrapperInstanceId: crypto.randomUUID() };
+        newWrapper = await connect(launch[1].SANDBOX_CONTROL_CREDENTIAL, fixture.sandboxId);
+        await completeHello(newWrapper, 'hello_post_replacement_runtime', {
+          providerInstanceId: launch[0],
           wrapperInstanceId: replacementFixture.wrapperInstanceId,
-        })
-      ).resolves.toEqual({ allowed: true });
-    } finally {
-      socket.close();
-      sameWrapper.close();
-      newWrapper?.close();
+        });
+        expect(await control.getStatus()).not.toHaveProperty('wrapperInstanceId');
+        signalWrapperReady(newWrapper);
+        await waitForWrapperReady(replacementFixture);
+        await seedTerminalSession(replacementFixture, 'pty_current');
+        await runInDurableObject(session, async (instance, state) => {
+          await instance.invalidateTerminalRuntime({
+            sandboxId: fixture.sandboxId,
+            wrapperInstanceId: fixture.wrapperInstanceId ?? '',
+            confirmed: true,
+          });
+          expect(state.storage.kv.get<{ state: string }>('terminal:pty_current')).toMatchObject({
+            state: 'running',
+          });
+          expect(state.storage.kv.get('terminal_attached_session')).toMatchObject({
+            wrapperInstanceId: replacementFixture.wrapperInstanceId,
+          });
+        });
+        await expect(
+          control.validateTerminalAccess({
+            ownerId: fixture.ownerId,
+            sessionId: fixture.sessionId,
+            wrapperInstanceId: replacementFixture.wrapperInstanceId,
+          })
+        ).resolves.toEqual({ allowed: true });
+      } finally {
+        socket.close();
+        sameWrapper.close();
+        newWrapper?.close();
+      }
     }
-  });
+  );
 
   it('keeps PTY ownership on uncertain physical observations', async () => {
     const fixture: TerminalRuntimeFixture = {
       sandboxId: 'usr-a005',
       ownerId: 'owner_uncertain_runtime',
-      sessionId: 'workspace_uncertain_runtime',
+      sessionId: GRANT_SESSION_ID,
       wrapperInstanceId: '6d1a1a6c-1153-4856-b07b-58b5b4f245aa',
     };
     const { control, socket } = await initializeTerminalRuntime(fixture);
@@ -3902,7 +8236,7 @@ describe('SandboxControl terminal runtime coordination', () => {
     const fixture: TerminalRuntimeFixture = {
       sandboxId: 'usr-a008',
       ownerId: 'owner_failed_runtime',
-      sessionId: 'workspace_failed_runtime',
+      sessionId: GRANT_SESSION_ID,
       wrapperInstanceId: '84114e6b-77c0-4792-88b9-2db90d789fe1',
     };
     const { control, socket, provider } = await initializeTerminalRuntime(fixture);
@@ -3923,7 +8257,7 @@ describe('SandboxControl terminal runtime coordination', () => {
       await expect(instance.recordStopAttempt()).resolves.toMatchObject({ state: 'stopped' });
     });
     expect(provider.stop).toHaveBeenCalledTimes(1);
-    expect(provider.stop.mock.calls[0]?.[0]).toBe(fixture.sandboxId);
+    expect(provider.stop.mock.calls[0]?.[0]).toBe(cloudflareRef(fixture.sandboxId));
     await vi.waitFor(async () => {
       await runInDurableObject(session, (_instance, state) => {
         expect(state.storage.kv.get<{ state: string }>('terminal:pty_original')).toMatchObject({
@@ -3937,7 +8271,7 @@ describe('SandboxControl terminal runtime coordination', () => {
     const fixture: TerminalRuntimeFixture = {
       sandboxId: 'usr-a009',
       ownerId: 'owner_stopped_runtime',
-      sessionId: 'workspace_stopped_runtime',
+      sessionId: GRANT_SESSION_ID,
       wrapperInstanceId: '78de88a1-a906-4e4f-bd9e-2447c21e6472',
     };
     const { control, socket } = await initializeTerminalRuntime(fixture);
@@ -3963,7 +8297,7 @@ describe('SandboxControl terminal runtime coordination', () => {
     const fixture: TerminalRuntimeFixture = {
       sandboxId: 'usr-a006',
       ownerId: 'owner_credential_rotation',
-      sessionId: 'workspace_credential_rotation',
+      sessionId: GRANT_SESSION_ID,
       wrapperInstanceId: 'bf73c60f-fd06-43f1-a93e-3412790a5ca4',
     };
     const { control, socket } = await initializeTerminalRuntime(fixture);
@@ -3989,10 +8323,10 @@ describe('SandboxControl terminal runtime coordination', () => {
         sandboxId: sandboxProvider === 'vercel' ? 'ses-a007' : 'usr-a007',
         sandboxProvider,
         ownerId: 'owner_terminal_activity',
-        sessionId: 'workspace_terminal_activity',
+        sessionId: GRANT_SESSION_ID,
         wrapperInstanceId: '5d1e54ed-31db-4646-a478-4864e87162c3',
       };
-      const { control, socket, provider } = await initializeTerminalRuntime(fixture);
+      const { control, socket, provider, providerRef } = await initializeTerminalRuntime(fixture);
       const clock = vi.spyOn(Date, 'now');
       try {
         signalWrapperReady(socket);
@@ -4030,7 +8364,7 @@ describe('SandboxControl terminal runtime coordination', () => {
           });
           expect(await state.storage.getAlarm()).toBe(current.heartbeatExpiry);
           expect(provider.ensureLeaseAtLeast).toHaveBeenCalledExactlyOnceWith(
-            fixture.sandboxId,
+            providerRef,
             DEADLINE_MS.idleStop + DEADLINE_MS.idleStopLeaseMargin
           );
         });

--- a/services/cloud-agent-next/test/integration/sandbox-control.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-control.test.ts
@@ -4115,6 +4115,179 @@ describe('SandboxControl native worktree containment', () => {
     }
   });
 
+  it('observes terminal Vercel cleanup at credential expiry after the reconciliation cutoff', async () => {
+    const { control, registration, vercel } = await credentialFixture('vercel');
+    const start = Date.now();
+    const clock = vi.spyOn(Date, 'now').mockReturnValue(start);
+    try {
+      await readyAttachment(control, credentialInput(registration));
+      vercel.runtime.failStop = true;
+      await control.beginStop('environment_failed');
+      for (let attempt = 0; attempt < DEADLINE_MS.stopAttemptLadder.length; attempt++) {
+        await fireControlDeadline(control, 'stopAttempt');
+      }
+      const retired = await control.getPhysicalRecord();
+      expect(retired).toMatchObject({ state: 'unknown', stopTombstone: { attempts: 5 } });
+      clock.mockReturnValue(start + DEADLINE_MS.reconciliationWindow);
+      await fireControlDeadline(control, 'reconciliation');
+      const expiry = await credentialExpiryDeadline(control);
+      if (expiry === undefined) throw new Error('Missing credential expiry');
+      await runInDurableObject(control, async (instance, state) => {
+        expect(await loadDeadlines(state.storage)).toEqual({ credentialExpiry: expiry });
+        const provider = {
+          ...vercel.provider,
+          observe: vi.fn<ProviderAdapter['observe']>(async () => ({ status: 'terminal' })),
+          stop: vi.fn<ProviderAdapter['stop']>(async () => 'retryable'),
+        };
+        Object.assign(instance, { provider });
+        clock.mockReturnValue(expiry);
+        await instance.alarm();
+        expect(await instance.getPhysicalRecord()).toMatchObject({
+          state: 'stopped',
+          providerRef: null,
+          createIntent: null,
+          stopTombstone: null,
+        });
+        expect(provider.observe).toHaveBeenCalledExactlyOnceWith(
+          retired.providerRef,
+          retired.createIntent
+        );
+        expect(provider.stop).not.toHaveBeenCalled();
+        expect(await loadSessionCredentialGrants(state.storage)).toEqual([]);
+        expect(await state.storage.get('credential_policy_dirty')).toBeUndefined();
+        expect(await loadDeadlines(state.storage)).toEqual({});
+        expect(await state.storage.getAlarm()).toBeNull();
+      });
+      expect(vercel.runtime.creates).toBe(1);
+      expect(vercel.runtime.launches).toHaveLength(1);
+      expect(vercel.runtime.stoppedSessions).toEqual([]);
+    } finally {
+      clock.mockRestore();
+    }
+  });
+
+  it.each(['active', 'unknown', 'error'] as const)(
+    'keeps Vercel credential expiry fail-closed after the cutoff when observation is %s',
+    async observation => {
+      const { control, registration, vercel } = await credentialFixture('vercel');
+      const start = Date.now();
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(start);
+      try {
+        await readyAttachment(control, credentialInput(registration));
+        const grants = await storedGrants(control);
+        vercel.runtime.failStop = true;
+        await control.beginStop('environment_failed');
+        for (let attempt = 0; attempt < DEADLINE_MS.stopAttemptLadder.length; attempt++) {
+          await fireControlDeadline(control, 'stopAttempt');
+        }
+        const retired = await control.getPhysicalRecord();
+        expect(retired).toMatchObject({ state: 'unknown', stopTombstone: { attempts: 5 } });
+        clock.mockReturnValue(start + DEADLINE_MS.reconciliationWindow);
+        await fireControlDeadline(control, 'reconciliation');
+        const expiry = await credentialExpiryDeadline(control);
+        if (expiry === undefined) throw new Error('Missing credential expiry');
+        await runInDurableObject(control, async (instance, state) => {
+          const provider = {
+            ...vercel.provider,
+            observe: vi.fn<ProviderAdapter['observe']>(async () => {
+              if (observation === 'error') throw new Error('Provider observation unavailable');
+              return { status: observation };
+            }),
+            stop: vi.fn<ProviderAdapter['stop']>(async () => 'terminal'),
+            updateNetworkPolicy: vi.fn(async () => undefined),
+          };
+          Object.assign(instance, { provider });
+          clock.mockReturnValue(expiry);
+          await instance.alarm();
+          expect(await instance.getPhysicalRecord()).toEqual(retired);
+          expect(await loadSessionCredentialGrants(state.storage)).toEqual(grants);
+          expect(await state.storage.get('credential_policy_dirty')).toBe(true);
+          expect(await loadDeadlines(state.storage)).toEqual({
+            credentialExpiry: expiry + DEADLINE_MS.reconciliation,
+          });
+          expect(await state.storage.getAlarm()).toBe(expiry + DEADLINE_MS.reconciliation);
+          expect(provider.observe).toHaveBeenCalledExactlyOnceWith(
+            retired.providerRef,
+            retired.createIntent
+          );
+          expect(provider.stop).not.toHaveBeenCalled();
+          expect(provider.updateNetworkPolicy).not.toHaveBeenCalled();
+        });
+        expect(vercel.runtime.creates).toBe(1);
+        expect(vercel.runtime.launches).toHaveLength(1);
+        expect(vercel.runtime.stoppedSessions).toEqual([]);
+      } finally {
+        clock.mockRestore();
+      }
+    }
+  );
+
+  it.each(['terminal', 'error'] as const)(
+    'fences a late Vercel credential-expiry observation %s from a replacement allocation',
+    async observation => {
+      const { control, registration, vercel } = await credentialFixture('vercel');
+      const start = Date.now();
+      const clock = vi.spyOn(Date, 'now').mockReturnValue(start);
+      try {
+        await readyAttachment(control, credentialInput(registration));
+        vercel.runtime.failStop = true;
+        await control.beginStop('environment_failed');
+        for (let attempt = 0; attempt < DEADLINE_MS.stopAttemptLadder.length; attempt++) {
+          await fireControlDeadline(control, 'stopAttempt');
+        }
+        const retired = await control.getPhysicalRecord();
+        clock.mockReturnValue(start + DEADLINE_MS.reconciliationWindow);
+        await fireControlDeadline(control, 'reconciliation');
+        const expiry = await credentialExpiryDeadline(control);
+        if (expiry === undefined) throw new Error('Missing credential expiry');
+        await runInDurableObject(control, async (instance, state) => {
+          let replacement: PhysicalRecord | undefined;
+          let replacementGrants: SessionCredentialGrant[] | undefined;
+          let replacementDeadlines: DeadlineTable | undefined;
+          let replacementAlarm: number | null | undefined;
+          const provider = {
+            ...vercel.provider,
+            observe: vi.fn<ProviderAdapter['observe']>(async () => {
+              await instance.confirmStopped();
+              replacement = await instance.claimCreate(
+                crypto.randomUUID(),
+                false,
+                `ses-${crypto.randomUUID().replaceAll('-', '')}`,
+                WORKTREE_CREDENTIAL_CONTAINMENT
+              );
+              await instance.prepareSessionCredentials(credentialInput(registration));
+              replacementGrants = await loadSessionCredentialGrants(state.storage);
+              replacementDeadlines = await loadDeadlines(state.storage);
+              replacementAlarm = await state.storage.getAlarm();
+              if (observation === 'error') throw new Error('Old provider observation unavailable');
+              return { status: observation };
+            }),
+            stop: vi.fn<ProviderAdapter['stop']>(async () => 'terminal'),
+          };
+          Object.assign(instance, { provider });
+          clock.mockReturnValue(expiry);
+          await instance.alarm();
+          expect(replacement).toMatchObject({ state: 'creating', stopTombstone: null });
+          expect(await instance.getPhysicalRecord()).toEqual(replacement);
+          expect(await loadSessionCredentialGrants(state.storage)).toEqual(replacementGrants);
+          expect(await state.storage.get('credential_policy_dirty')).toBe(true);
+          expect(await loadDeadlines(state.storage)).toEqual(replacementDeadlines);
+          expect(await state.storage.getAlarm()).toBe(replacementAlarm);
+          expect(provider.observe).toHaveBeenCalledExactlyOnceWith(
+            retired.providerRef,
+            retired.createIntent
+          );
+          expect(provider.stop).not.toHaveBeenCalled();
+        });
+        expect(vercel.runtime.creates).toBe(1);
+        expect(vercel.runtime.launches).toHaveLength(1);
+        expect(vercel.runtime.stoppedSessions).toEqual([]);
+      } finally {
+        clock.mockRestore();
+      }
+    }
+  );
+
   it.each(['resolve', 'reject'] as const)(
     'does not retire a replacement allocation after a late Vercel policy %s',
     async completion => {

--- a/services/cloud-agent-next/test/integration/sandbox-terminal.test.ts
+++ b/services/cloud-agent-next/test/integration/sandbox-terminal.test.ts
@@ -1,20 +1,35 @@
 import { SELF, env, runInDurableObject } from 'cloudflare:test';
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import { createMemoryProviderAdapter } from '../../src/sandbox-control/provider.js';
+import { deriveKiloSandboxTargets } from '../../src/kilo/kilo-targets.js';
+import {
+  decodeCloudflareProviderRef,
+  encodeCloudflareProviderRef,
+} from '../../src/sandbox-control/cloudflare-provider.js';
 import {
   generateSandboxCredential,
   hashSandboxCredential,
 } from '../../src/sandbox-control/credential.js';
-import { createMemoryProviderAdapter } from '../../src/sandbox-control/provider.js';
+import { createControlPlaneCredential } from '../../src/sandbox-control/managed-credential.js';
+import {
+  WORKTREE_CREDENTIAL_CONTAINMENT,
+  type PhysicalRecord,
+} from '../../src/sandbox-control/physical-lifecycle.js';
+import {
+  sessionCredentialGrantSchema,
+  type SessionCredentialGrant,
+} from '../../src/sandbox-control/session-credentials.js';
 import { getSandboxSessionStub } from '../../src/sandbox-session/session-stub.js';
 import {
   requestFrameSchema,
   responseFrameSchema,
+  sessionAttachPayloadSchema,
   sessionTerminalConnectPayloadSchema,
   type RequestFrame,
   type ResponseFrame,
   type SessionTerminalConnectPayload,
 } from '../../src/shared/sandbox-control-protocol.js';
-import type { SandboxId } from '../../src/types.js';
+import type { GitTokenService, SandboxId } from '../../src/types.js';
 import { getSessionWorkspacePath } from '../../src/workspace.js';
 
 type SocketFrame = string | ArrayBuffer;
@@ -119,8 +134,14 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
   const owner = ownerId ?? `user_${identity}`;
   const sessionId = `workspace_${identity}`;
   const sandboxId = `ses-${identity.replaceAll('-', '')}` as SandboxId;
-  const kiloSessionId = `ses_${identity.replaceAll('-', '')}`;
+  const kiloSessionId = `ses_${identity.replaceAll('-', '').slice(0, 26)}`;
   const wrapperInstanceId = crypto.randomUUID();
+  const creationId = crypto.randomUUID();
+  const providerInstanceId = encodeCloudflareProviderRef({
+    sandboxId,
+    containment: true,
+    instanceId: creationId,
+  });
   const ptyId = `pty_${identity.replaceAll('-', '')}`;
   const directory = getSessionWorkspacePath(organizationId, owner, sessionId);
   const sessionIdentity = {
@@ -130,22 +151,64 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
     ...(organizationId ? { orgId: organizationId } : {}),
   };
   const credential = generateSandboxCredential();
+  const kiloToken = 'terminal-fixture-kilo-token';
+  const targets = deriveKiloSandboxTargets({}, kiloToken);
+  if (!targets.success) throw new Error('Invalid terminal fixture targets');
+  const now = Date.now();
+  const grant = sessionCredentialGrantSchema.parse({
+    version: 1,
+    scopeId: sessionId,
+    sandboxId,
+    directory,
+    userId: owner,
+    ...(organizationId ? { orgId: organizationId } : {}),
+    provider: 'cloudflare',
+    outboundContainerId: `contained-small:${sandboxId}`,
+    members: [{ sessionId, kiloSessionId }],
+    kilo: {
+      alias: createControlPlaneCredential(sandboxId, 'kilo'),
+      token: kiloToken,
+      targets: targets.targets,
+      capabilities: {},
+    },
+    preparedAt: now,
+    expiresAt: now + 4 * 60 * 60 * 1000,
+  });
   const controlStub = env.SANDBOX_CONTROL.getByName(sandboxId);
   const sessionStub = getSandboxSessionStub(env, owner, sessionId);
 
-  await runInDurableObject(controlStub, async instance => {
+  await runInDurableObject(controlStub, async (instance, state) => {
     const provider = createMemoryProviderAdapter();
-    Object.assign(instance, { provider, createProviderAdapter: () => provider });
+    const broker = {
+      async issueKiloSessionCapability() {
+        return { success: true, capability: `kka1.${crypto.randomUUID()}` };
+      },
+    } satisfies Pick<GitTokenService, 'issueKiloSessionCapability'>;
+    Object.assign(instance, {
+      provider,
+      createProviderAdapter: () => provider,
+      env: {
+        ...env,
+        KILOCODE_BACKEND_BASE_URL: targets.targets.backendBaseUrl,
+        KILO_OPENROUTER_BASE: targets.targets.providerBaseUrl,
+        KILO_SESSION_INGEST_URL: targets.targets.sessionIngestBaseUrl,
+        GIT_TOKEN_SERVICE: broker,
+        SandboxSmallContainment: {
+          idFromName: (name: string) => ({ toString: () => `contained-small:${name}` }),
+        },
+      },
+    });
     await instance.initializeOwner(owner);
-    await instance.claimCreate(crypto.randomUUID());
-    await instance.confirmInstance(sandboxId);
+    await instance.claimCreate(creationId, false, sandboxId, WORKTREE_CREDENTIAL_CONTAINMENT);
+    await state.storage.put('worktree_credential_grants', [grant]);
+    await instance.confirmInstance(providerInstanceId);
     await instance.setWrapperCredentialHash(await hashSandboxCredential(credential));
   });
 
   await runInDurableObject(sessionStub, async instance => {
     const result = await instance.registerSession({
       identity: sessionIdentity,
-      auth: { kiloSessionId },
+      auth: { kiloSessionId, kilocodeToken: kiloToken },
       agent: { mode: 'code', model: 'test-model' },
       workspace: { sandboxId, sandboxProvider: 'cloudflare' },
     });
@@ -168,7 +231,7 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
       operation: 'sandbox.hello',
       payload: {
         protocolVersion: 1,
-        providerInstanceId: sandboxId,
+        providerInstanceId,
         wrapperInstanceId,
       },
     })
@@ -189,11 +252,7 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
     kiloReady: true,
   });
 
-  let resolvePreparation: (() => void) | undefined;
-  const prepared = new Promise<void>(resolve => {
-    resolvePreparation = resolve;
-  });
-
+  const prepared = Promise.withResolvers<void>();
   const fixture: TerminalFixture = {
     ownerId: owner,
     sessionId,
@@ -268,6 +327,10 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
 
     if (request.operation === 'session.attach') {
       expect(request.session).toEqual({ sessionId, kiloSessionId, directory });
+      expect(sessionAttachPayloadSchema.parse(request.payload)).toMatchObject({
+        directory,
+        kilo: { scopeId: grant.scopeId, token: grant.kilo.alias, targets: grant.kilo.targets },
+      });
       sendResponse(control, request.requestId, { attached: true });
       return;
     }
@@ -281,7 +344,7 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
         messageId: payload.messageId,
         status: 'accepted',
       });
-      resolvePreparation?.();
+      prepared.resolve();
       return;
     }
 
@@ -408,7 +471,7 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
   const admission = await runInDurableObject(sessionStub, instance =>
     instance.createSessionWithInitialAdmission({
       identity: sessionIdentity,
-      auth: { kiloSessionId },
+      auth: { kiloSessionId, kilocodeToken: kiloToken },
       agent: { mode: 'code', model: 'test-model' },
       workspace: { sandboxId, sandboxProvider: 'cloudflare' },
       message: {
@@ -417,7 +480,13 @@ async function createFixture(ownerId?: string, organizationId?: string): Promise
     })
   );
   if (!admission.success) throw new Error(`Session admission failed: ${admission.error}`);
-  await prepared;
+  await prepared.promise;
+  await vi.waitFor(async () => {
+    await expect(sessionStub.getMessageResult(`msg_${identity}`)).resolves.toMatchObject({
+      type: 'found',
+      result: { status: 'running' },
+    });
+  });
 
   const created = await runInDurableObject(sessionStub, instance =>
     instance.createTerminal({ cols: 80, rows: 24 })
@@ -434,6 +503,186 @@ afterEach(async () => {
 });
 
 describe('SandboxSession terminal bridge in the Workers runtime', () => {
+  it.each<{
+    name: string;
+    marker: (providerRef: string) => PhysicalRecord['containment'];
+  }>([
+    { name: 'missing', marker: () => undefined },
+    {
+      name: 'pre-worktree',
+      marker: providerRef => ({ kilocode: true, github: true, providerRef }),
+    },
+    {
+      name: 'uncontained Kilo credentials',
+      marker: providerRef => ({ ...WORKTREE_CREDENTIAL_CONTAINMENT, kilocode: false, providerRef }),
+    },
+    {
+      name: 'uncontained GitHub credentials',
+      marker: providerRef => ({ ...WORKTREE_CREDENTIAL_CONTAINMENT, github: false, providerRef }),
+    },
+    {
+      name: 'stale physical instance',
+      marker: providerRef => {
+        const ref = decodeCloudflareProviderRef(providerRef);
+        if (!ref) throw new Error('Invalid terminal fixture provider reference');
+        return {
+          ...WORKTREE_CREDENTIAL_CONTAINMENT,
+          providerRef: encodeCloudflareProviderRef({ ...ref, instanceId: crypto.randomUUID() }),
+        };
+      },
+    },
+  ])('denies terminal access with a $name containment marker', async ({ marker }) => {
+    const fixture = await createFixture();
+    const control = env.SANDBOX_CONTROL.getByName(fixture.sandboxId);
+    await runInDurableObject(control, async (instance, state) => {
+      const physical = await instance.getPhysicalRecord();
+      if (!physical.providerRef) throw new Error('Missing terminal fixture provider reference');
+      await state.storage.put('physical_record', {
+        ...physical,
+        containment: marker(physical.providerRef),
+      });
+    });
+
+    await expect(
+      runInDurableObject(control, instance =>
+        instance.validateTerminalAccess({
+          sessionId: fixture.sessionId,
+          ownerId: fixture.ownerId,
+          wrapperInstanceId: fixture.wrapperInstanceId,
+        })
+      )
+    ).resolves.toMatchObject({ allowed: false });
+    const session = getSandboxSessionStub(env, fixture.ownerId, fixture.sessionId);
+    await expect(
+      runInDurableObject(session, instance => instance.createTerminal())
+    ).resolves.toMatchObject({ success: false });
+  });
+
+  it('rejects a raw provider reference even with a matching containment marker', async () => {
+    const fixture = await createFixture();
+    const control = env.SANDBOX_CONTROL.getByName(fixture.sandboxId);
+    await runInDurableObject(control, async (instance, state) => {
+      const physical = await instance.getPhysicalRecord();
+      await state.storage.put('physical_record', {
+        ...physical,
+        providerRef: fixture.sandboxId,
+        containment: { ...WORKTREE_CREDENTIAL_CONTAINMENT, providerRef: fixture.sandboxId },
+      });
+    });
+
+    await expect(
+      runInDurableObject(control, instance =>
+        instance.validateTerminalAccess({
+          sessionId: fixture.sessionId,
+          ownerId: fixture.ownerId,
+          wrapperInstanceId: fixture.wrapperInstanceId,
+        })
+      )
+    ).resolves.toMatchObject({ allowed: false });
+  });
+
+  it.each<{
+    name: string;
+    update: (grant: SessionCredentialGrant) => SessionCredentialGrant | undefined;
+  }>([
+    { name: 'missing', update: () => undefined },
+    {
+      name: 'expired without a broker',
+      update: grant => ({
+        ...grant,
+        preparedAt: 0,
+        expiresAt: 1,
+        kilo: { ...grant.kilo, capabilities: {} },
+      }),
+    },
+    {
+      name: 'future-dated',
+      update: grant => ({
+        ...grant,
+        preparedAt: Date.now() + 60 * 60 * 1000,
+        expiresAt: Date.now() + 2 * 60 * 60 * 1000,
+      }),
+    },
+    { name: 'another owner', update: grant => ({ ...grant, userId: 'user_other' }) },
+    { name: 'another organization', update: grant => ({ ...grant, orgId: 'org_other' }) },
+    { name: 'another directory', update: grant => ({ ...grant, directory: '/workspace/other' }) },
+    {
+      name: 'another session',
+      update: grant => {
+        const sessionId = `workspace_${crypto.randomUUID()}`;
+        return {
+          ...grant,
+          scopeId: sessionId,
+          members: grant.members.map(member => ({ ...member, sessionId })),
+          kilo: { ...grant.kilo, capabilities: {} },
+        };
+      },
+    },
+    {
+      name: 'another Kilo root',
+      update: grant => ({
+        ...grant,
+        members: grant.members.map(member => ({
+          ...member,
+          kiloSessionId: 'ses_00000000000000000000000000',
+        })),
+      }),
+    },
+    {
+      name: 'another sandbox',
+      update: grant => ({
+        ...grant,
+        sandboxId: 'ses-fedcba',
+        kilo: { ...grant.kilo, alias: createControlPlaneCredential('ses-fedcba', 'kilo') },
+      }),
+    },
+    {
+      name: 'another provider',
+      update: grant => ({
+        ...grant,
+        provider: 'vercel',
+        outboundContainerId: undefined,
+        kilo: { ...grant.kilo, capabilities: {} },
+      }),
+    },
+  ])('denies terminal access with a grant for $name', async ({ name, update }) => {
+    const fixture = await createFixture(undefined, 'org_terminal_containment');
+    const control = env.SANDBOX_CONTROL.getByName(fixture.sandboxId);
+    await runInDurableObject(control, async (instance, state) => {
+      if (name === 'expired without a broker') {
+        const bindings = instance as unknown as { env: { GIT_TOKEN_SERVICE?: GitTokenService } };
+        delete bindings.env.GIT_TOKEN_SERVICE;
+      }
+      const grants = sessionCredentialGrantSchema
+        .array()
+        .parse(await state.storage.get('worktree_credential_grants'));
+      const grant = grants[0];
+      if (!grant) throw new Error('Missing terminal fixture grant');
+      const updated = update(grant);
+      await state.storage.put(
+        'worktree_credential_grants',
+        updated ? [sessionCredentialGrantSchema.parse(updated)] : []
+      );
+    });
+
+    await expect(
+      runInDurableObject(control, instance =>
+        instance.validateTerminalAccess({
+          sessionId: fixture.sessionId,
+          ownerId: fixture.ownerId,
+          organizationId: 'org_terminal_containment',
+          wrapperInstanceId: fixture.wrapperInstanceId,
+        })
+      )
+    ).resolves.toMatchObject({ allowed: false });
+    const session = getSandboxSessionStub(env, fixture.ownerId, fixture.sessionId);
+    await expect(
+      runInDurableObject(session, instance =>
+        instance.resizeTerminal({ ptyId: fixture.ptyId, cols: 100, rows: 30 })
+      )
+    ).resolves.toMatchObject({ success: false });
+  });
+
   it('pairs reentrant hibernating sockets and forwards native terminal frames', async () => {
     const fixture = await createFixture();
     const browser = await fixture.openBrowser({ initialOutput: 'initial output' });

--- a/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
@@ -27,7 +27,13 @@ vi.mock('../../../wrapper/src/utils.js', async () => {
 });
 
 // Import mocked functions so we can configure per-test return values
-import { git, getCurrentBranch, hasGitUpstream, logToFile } from '../../../wrapper/src/utils.js';
+import {
+  git,
+  getCurrentBranch,
+  hasGitUpstream,
+  logToFile,
+  withTimeoutAndAbort,
+} from '../../../wrapper/src/utils.js';
 
 const mockGetCurrentBranch = vi.mocked(getCurrentBranch);
 const mockHasGitUpstream = vi.mocked(hasGitUpstream);
@@ -503,6 +509,196 @@ describe('runAutoCommit', () => {
     const completed = events.find(e => e.streamEventType === 'autocommit_completed');
     expect(completed?.data.message).toContain('https://[REDACTED]@github.com/acme/repo.git');
     expect(completed?.data.message).not.toContain('user-secret');
+  });
+
+  it('cancels queued auto-commit without releasing its predecessor or blocking other worktrees', async () => {
+    const workspacePath = '/workspace/shared';
+    const otherDirectory = '/workspace/other';
+    const dirty = new Set([workspacePath, otherDirectory]);
+    const pushing = Promise.withResolvers<void>();
+    const stopped = Promise.withResolvers<Utils.ExecResult>();
+    const controllers = [new AbortController(), new AbortController(), new AbortController()];
+    const first = createOpts({ workspacePath, signal: controllers[0].signal });
+    const cancelled = createOpts({ workspacePath, signal: controllers[1].signal });
+    const next = createOpts({ workspacePath, signal: controllers[2].signal });
+    const other = createOpts({ workspacePath: otherDirectory });
+    const pending: ReturnType<typeof runAutoCommit>[] = [];
+    let firstSettled = false;
+    let nextSettled = false;
+    mockGetCurrentBranch.mockResolvedValue('work');
+    mockGit.mockImplementation(async (args, options) => {
+      const directory = options?.cwd ?? '';
+      if (args[0] === 'status') return ok(dirty.has(directory) ? ' M result.txt\n' : '');
+      if (args[0] === 'commit') dirty.delete(directory);
+      if (args[0] === 'rev-parse') return ok('abc1234');
+      if (args[0] === 'push' && directory === workspacePath) {
+        pushing.resolve();
+        return stopped.promise;
+      }
+      return ok();
+    });
+    try {
+      const firstCommit = runAutoCommit(first.opts).then(result => {
+        firstSettled = true;
+        return result;
+      });
+      pending.push(firstCommit);
+      await pushing.promise;
+      const cancelledCommit = runAutoCommit(cancelled.opts);
+      pending.push(cancelledCommit);
+      controllers[1].abort(new Error('Queued finalization cancelled'));
+      expect(
+        await withTimeoutAndAbort(cancelledCommit, {
+          timeoutMs: 1_000,
+          timeoutMessage: 'Queued auto-commit cancellation waited for its predecessor',
+          abortMessage: 'Test cancelled',
+        })
+      ).toEqual({ success: false, error: 'Queued finalization cancelled' });
+      expect(cancelled.events).toEqual([
+        expect.objectContaining({
+          streamEventType: 'autocommit_completed',
+          data: expect.objectContaining({ success: false }),
+        }),
+      ]);
+      const nextCommit = runAutoCommit(next.opts).then(result => {
+        nextSettled = true;
+        return result;
+      });
+      const otherCommit = runAutoCommit(other.opts);
+      pending.push(nextCommit, otherCommit);
+      expect(
+        await withTimeoutAndAbort(otherCommit, {
+          timeoutMs: 1_000,
+          timeoutMessage: 'Unrelated worktree auto-commit was blocked',
+          abortMessage: 'Test cancelled',
+        })
+      ).toEqual({ success: true });
+      expect(firstSettled).toBe(false);
+      expect(nextSettled).toBe(false);
+      expect(next.events).toEqual([]);
+
+      controllers[0].abort(new Error('Running finalization cancelled'));
+      await new Promise<void>(resolve => setImmediate(resolve));
+      expect(firstSettled).toBe(false);
+      expect(nextSettled).toBe(false);
+      stopped.resolve({ ...ok(), exitCode: 124, terminationReason: 'abort' });
+      await firstCommit;
+      expect(await nextCommit).toEqual({ success: true, skipped: true });
+      expect(cancelled.opts.kiloClient.generateCommitMessage).not.toHaveBeenCalled();
+      expect(next.opts.kiloClient.generateCommitMessage).not.toHaveBeenCalled();
+      expect(mockGetCurrentBranch.mock.calls.map(([directory]) => directory)).toEqual([
+        workspacePath,
+        otherDirectory,
+        workspacePath,
+      ]);
+    } finally {
+      for (const controller of controllers) controller.abort();
+      stopped.resolve({ ...ok(), exitCode: 124, terminationReason: 'abort' });
+      await Promise.allSettled(pending);
+      mockGit.mockReset();
+      mockGetCurrentBranch.mockReset();
+      mockHasGitUpstream.mockReset();
+    }
+  });
+
+  it('serializes same-worktree auto-commit through push and skips a clean sibling', async () => {
+    const actual = await vi.importActual<typeof Utils>('../../../wrapper/src/utils.js');
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'shared-worktree-autocommit-'));
+    const workspacePath = path.join(root, 'workspace');
+    const remote = path.join(root, 'remote.git');
+    const home = path.join(root, 'home');
+    const env = { PATH: process.env.PATH, HOME: home };
+    const generating = Promise.withResolvers<void>();
+    const generated = Promise.withResolvers<{ message: string }>();
+    const pushing = Promise.withResolvers<void>();
+    const pushed = Promise.withResolvers<void>();
+    const controllers = [new AbortController(), new AbortController()];
+    const pending: ReturnType<typeof runAutoCommit>[] = [];
+    const first = createOpts({
+      workspacePath,
+      env,
+      messageId: 'first',
+      signal: controllers[0].signal,
+    });
+    const second = createOpts({
+      workspacePath,
+      env,
+      messageId: 'second',
+      signal: controllers[1].signal,
+    });
+    let secondSettled = false;
+    vi.mocked(first.opts.kiloClient.generateCommitMessage).mockImplementation(() => {
+      generating.resolve();
+      return generated.promise;
+    });
+    mockGetCurrentBranch.mockImplementation(actual.getCurrentBranch);
+    mockHasGitUpstream.mockImplementation(actual.hasGitUpstream);
+    mockGit.mockImplementation(async (args, options) => {
+      if (args[0] === 'push') {
+        pushing.resolve();
+        await pushed.promise;
+      }
+      return actual.git(args, options);
+    });
+    const git = async (args: string[]) => {
+      const result = await actual.git(args, { cwd: workspacePath, env, inheritEnv: false });
+      expect(result.exitCode).toBe(0);
+      return result.stdout;
+    };
+    try {
+      await fs.mkdir(workspacePath);
+      await fs.mkdir(home);
+      await git(['init', '--bare', remote]);
+      await git(['init', '--initial-branch=work']);
+      await git(['config', 'user.name', 'Test Agent']);
+      await git(['config', 'user.email', 'test@example.com']);
+      await git(['config', 'commit.gpgsign', 'false']);
+      await git(['remote', 'add', 'origin', remote]);
+      await fs.writeFile(path.join(workspacePath, 'result.txt'), 'shared changes\n');
+
+      const firstCommit = runAutoCommit(first.opts);
+      pending.push(firstCommit);
+      await generating.promise;
+      const secondCommit = runAutoCommit(second.opts).then(result => {
+        secondSettled = true;
+        return result;
+      });
+      pending.push(secondCommit);
+      await new Promise<void>(resolve => setImmediate(resolve));
+      expect(mockGetCurrentBranch).toHaveBeenCalledTimes(1);
+      expect(second.events).toEqual([]);
+      expect(secondSettled).toBe(false);
+
+      generated.resolve({ message: 'Commit shared changes' });
+      await pushing.promise;
+      expect(await git(['status', '--porcelain'])).toBe('');
+      expect(mockGetCurrentBranch).toHaveBeenCalledTimes(1);
+      expect(secondSettled).toBe(false);
+      pushed.resolve();
+      expect(await firstCommit).toEqual({ success: true });
+      expect(await secondCommit).toEqual({ success: true, skipped: true });
+      expect(second.events).toEqual([
+        expect.objectContaining({
+          streamEventType: 'autocommit_completed',
+          data: expect.objectContaining({ success: true, skipped: true, messageId: 'second' }),
+        }),
+      ]);
+      expect(await git(['--git-dir', remote, 'show', 'refs/heads/work:result.txt'])).toBe(
+        'shared changes\n'
+      );
+      expect(
+        (await git(['--git-dir', remote, 'rev-list', '--count', 'refs/heads/work'])).trim()
+      ).toBe('1');
+    } finally {
+      for (const controller of controllers) controller.abort();
+      generated.resolve({ message: 'Commit shared changes' });
+      pushed.resolve();
+      await Promise.allSettled(pending);
+      mockGit.mockReset();
+      mockGetCurrentBranch.mockReset();
+      mockHasGitUpstream.mockReset();
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it('commits and pushes with the isolated worktree environment instead of wrapper credentials', async () => {

--- a/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
+++ b/services/cloud-agent-next/test/unit/wrapper/auto-commit.test.ts
@@ -2,6 +2,9 @@
  * Unit tests for auto-commit branch protection and upstream branch bypass.
  */
 
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
 import { afterEach, describe, expect, it, vi, beforeEach } from 'vitest';
 import { createKiloClient } from '@kilocode/sdk';
 import { runAutoCommit, type AutoCommitOptions } from '../../../wrapper/src/auto-commit.js';
@@ -24,7 +27,7 @@ vi.mock('../../../wrapper/src/utils.js', async () => {
 });
 
 // Import mocked functions so we can configure per-test return values
-import { git, getCurrentBranch, hasGitUpstream } from '../../../wrapper/src/utils.js';
+import { git, getCurrentBranch, hasGitUpstream, logToFile } from '../../../wrapper/src/utils.js';
 
 const mockGetCurrentBranch = vi.mocked(getCurrentBranch);
 const mockHasGitUpstream = vi.mocked(hasGitUpstream);
@@ -456,6 +459,30 @@ describe('runAutoCommit', () => {
     );
   });
 
+  it('redacts explicit worktree profile credentials from finalization failures and logs', async () => {
+    const secret = 'explicit-profile-github-credential';
+    mockGetCurrentBranch.mockResolvedValue('feature/worktree');
+    mockGit
+      .mockResolvedValueOnce(ok(' M file.ts'))
+      .mockResolvedValueOnce(ok())
+      .mockResolvedValueOnce(ok('[feature/worktree abc1234] test commit'))
+      .mockResolvedValueOnce(ok('abc1234'))
+      .mockResolvedValueOnce({
+        stdout: '',
+        stderr: `remote: rejected credential ${secret}`,
+        exitCode: 1,
+      });
+    const { opts, events } = createOpts({ env: { GH_TOKEN: secret } });
+
+    await runAutoCommit(opts);
+
+    expect(
+      events.find(event => event.streamEventType === 'autocommit_completed')?.data.message
+    ).toContain('push failed');
+    expect(JSON.stringify(events)).not.toContain(secret);
+    expect(JSON.stringify(vi.mocked(logToFile).mock.calls)).not.toContain(secret);
+  });
+
   it('redacts authenticated GitHub remotes from push failure events', async () => {
     mockGetCurrentBranch.mockResolvedValue('feature/cool-stuff');
     mockGit
@@ -474,8 +501,66 @@ describe('runAutoCommit', () => {
     await runAutoCommit(opts);
 
     const completed = events.find(e => e.streamEventType === 'autocommit_completed');
-    expect(completed?.data.message).toContain('x-access-token:***@github.com');
+    expect(completed?.data.message).toContain('https://[REDACTED]@github.com/acme/repo.git');
     expect(completed?.data.message).not.toContain('user-secret');
+  });
+
+  it('commits and pushes with the isolated worktree environment instead of wrapper credentials', async () => {
+    const actual = await vi.importActual<typeof Utils>('../../../wrapper/src/utils.js');
+    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'worktree-autocommit-'));
+    const workspacePath = path.join(root, 'workspace');
+    const remote = path.join(root, 'remote.git');
+    const home = path.join(root, 'home');
+    const report = path.join(root, 'hook-env.json');
+    const env = {
+      PATH: process.env.PATH,
+      HOME: home,
+      XDG_DATA_HOME: path.join(home, 'data'),
+      KILOCODE_TOKEN: 'guest-worktree-alias',
+      WORKTREE_ENV_REPORT: report,
+    };
+    vi.stubEnv('AUTOCOMMIT_PARENT_ONLY', 'wrapper-only-value');
+    mockGit.mockImplementation(actual.git);
+    mockGetCurrentBranch.mockImplementation(actual.getCurrentBranch);
+    mockHasGitUpstream.mockImplementation(actual.hasGitUpstream);
+    try {
+      await fs.mkdir(workspacePath);
+      await fs.mkdir(home);
+      const git = async (args: string[]) => {
+        const result = await actual.git(args, { cwd: workspacePath, env, inheritEnv: false });
+        expect(result.exitCode).toBe(0);
+        return result.stdout;
+      };
+      await git(['init', '--bare', remote]);
+      await git(['init', '--initial-branch=work']);
+      await git(['config', 'user.name', 'Test Agent']);
+      await git(['config', 'user.email', 'test@example.com']);
+      await git(['config', 'commit.gpgsign', 'false']);
+      await git(['remote', 'add', 'origin', remote]);
+      await fs.writeFile(path.join(workspacePath, 'result.txt'), 'contained finalization\n');
+      const hook = `#!/bin/sh\nnode -e 'require("node:fs").writeFileSync(process.env.WORKTREE_ENV_REPORT, JSON.stringify({home:process.env.HOME,data:process.env.XDG_DATA_HOME,token:process.env.KILOCODE_TOKEN,parent:process.env.AUTOCOMMIT_PARENT_ONLY ?? null}))'\n`;
+      await fs.writeFile(path.join(workspacePath, '.git', 'hooks', 'pre-commit'), hook, {
+        mode: 0o755,
+      });
+      const { opts } = createOpts({ workspacePath, env });
+
+      await expect(runAutoCommit(opts)).resolves.toEqual({ success: true });
+      expect(JSON.parse(await fs.readFile(report, 'utf8'))).toEqual({
+        home,
+        data: env.XDG_DATA_HOME,
+        token: env.KILOCODE_TOKEN,
+        parent: null,
+      });
+      expect(await git(['--git-dir', remote, 'show', 'refs/heads/work:result.txt'])).toBe(
+        'contained finalization\n'
+      );
+    } finally {
+      vi.unstubAllEnvs();
+      mockGit.mockReset();
+      mockGetCurrentBranch.mockReset();
+      mockHasGitUpstream.mockReset();
+      await fs.rm(root, { recursive: true, force: true });
+    }
   });
 
   it('aborts the generation request on caller cancellation without staging, committing, or pushing', async () => {

--- a/services/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/services/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -10,6 +10,7 @@ const GIT_LOCAL_TIMEOUT_MS = 30_000;
 const GIT_PUSH_TIMEOUT_MS = 60_000;
 /** Timeout for commit message generation API call */
 const COMMIT_MESSAGE_TIMEOUT_MS = 30_000;
+const worktreeAutoCommits = new Map<string, Promise<void>>();
 
 function appendCommitCoAuthor(
   commitMessage: string,
@@ -84,10 +85,29 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
   const { workspacePath, onEvent, kiloClient, messageId, signal, env } = opts;
   const redact = createSecretRedactor(process.env, env ?? {});
   const logToFile = (message: string): void => writeLog(redact(message));
+  const released = Promise.withResolvers<void>();
+  const previous = worktreeAutoCommits.get(workspacePath) ?? Promise.resolve();
+  const current = previous
+    .then(() => released.promise)
+    .finally(() => {
+      if (worktreeAutoCommits.get(workspacePath) === current)
+        worktreeAutoCommits.delete(workspacePath);
+    });
+  worktreeAutoCommits.set(workspacePath, current);
 
   logToFile(`auto-commit: starting workspacePath=${workspacePath}`);
 
   try {
+    signal?.throwIfAborted();
+    const cancelled = Promise.withResolvers<never>();
+    const onAbort = () => cancelled.reject(signal?.reason);
+    signal?.addEventListener('abort', onAbort, { once: true });
+    try {
+      await Promise.race([previous, cancelled.promise]);
+    } finally {
+      signal?.removeEventListener('abort', onAbort);
+    }
+    signal?.throwIfAborted();
     // Check current branch (agent may have switched branches during execution)
     const branch = await getCurrentBranch(workspacePath, GIT_LOCAL_TIMEOUT_MS, signal, env);
     logToFile(`auto-commit: branch=${branch || '(detached HEAD)'}`);
@@ -299,5 +319,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       messageId
     );
     return { success: false, error: errorMsg };
+  } finally {
+    released.resolve();
   }
 }

--- a/services/cloud-agent-next/wrapper/src/auto-commit.ts
+++ b/services/cloud-agent-next/wrapper/src/auto-commit.ts
@@ -1,7 +1,8 @@
 import type { IngestEvent } from '../../src/shared/protocol.js';
 import type { WrapperCommitCoAuthor } from '../../src/shared/wrapper-bootstrap.js';
 import type { WrapperKiloClient } from './kilo-api.js';
-import { git, getCurrentBranch, hasGitUpstream, logToFile } from './utils.js';
+import { git, getCurrentBranch, hasGitUpstream, logToFile as writeLog } from './utils.js';
+import { createSecretRedactor } from './redact-output.js';
 
 /** Timeout for local git operations (status, add, commit) */
 const GIT_LOCAL_TIMEOUT_MS = 30_000;
@@ -9,10 +10,6 @@ const GIT_LOCAL_TIMEOUT_MS = 30_000;
 const GIT_PUSH_TIMEOUT_MS = 60_000;
 /** Timeout for commit message generation API call */
 const COMMIT_MESSAGE_TIMEOUT_MS = 30_000;
-
-function sanitizeGitOutput(output: string): string {
-  return output.replace(/(oauth2|x-access-token|x-token-auth):([^@]+)@/gi, '$1:***@');
-}
 
 function appendCommitCoAuthor(
   commitMessage: string,
@@ -24,7 +21,7 @@ function appendCommitCoAuthor(
     /[\r\n<>]/.test(commitCoAuthor.email) ||
     commitCoAuthor.email.trim() !== commitCoAuthor.email
   ) {
-    logToFile('auto-commit: ignoring invalid commit co-author identity');
+    writeLog('auto-commit: ignoring invalid commit co-author identity');
     return commitMessage;
   }
   const trailer = `Co-authored-by: ${commitCoAuthor.name} <${commitCoAuthor.email}>`;
@@ -50,6 +47,7 @@ export type AutoCommitOptions = {
   upstreamBranch?: string;
   commitCoAuthor?: WrapperCommitCoAuthor;
   signal?: AbortSignal;
+  env?: NodeJS.ProcessEnv;
 };
 
 function emitStarted(
@@ -83,13 +81,15 @@ function emitCompleted(
 }
 
 export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommitResult> {
-  const { workspacePath, onEvent, kiloClient, messageId, signal } = opts;
+  const { workspacePath, onEvent, kiloClient, messageId, signal, env } = opts;
+  const redact = createSecretRedactor(process.env, env ?? {});
+  const logToFile = (message: string): void => writeLog(redact(message));
 
   logToFile(`auto-commit: starting workspacePath=${workspacePath}`);
 
   try {
     // Check current branch (agent may have switched branches during execution)
-    const branch = await getCurrentBranch(workspacePath, GIT_LOCAL_TIMEOUT_MS, signal);
+    const branch = await getCurrentBranch(workspacePath, GIT_LOCAL_TIMEOUT_MS, signal, env);
     logToFile(`auto-commit: branch=${branch || '(detached HEAD)'}`);
     if (!branch) {
       logToFile('auto-commit: skipping - detached HEAD state');
@@ -127,12 +127,13 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     }
 
     // Check actual git upstream (not stale config) to decide push strategy
-    const trackingUpstream = await hasGitUpstream(workspacePath, GIT_LOCAL_TIMEOUT_MS, signal);
+    const trackingUpstream = await hasGitUpstream(workspacePath, GIT_LOCAL_TIMEOUT_MS, signal, env);
     logToFile(`auto-commit: hasGitUpstream=${trackingUpstream}`);
 
     // Check for uncommitted changes
     const status = await git(['status', '--porcelain'], {
       cwd: workspacePath,
+      ...(env ? { env, inheritEnv: false } : {}),
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
       signal,
     });
@@ -195,11 +196,12 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     logToFile('auto-commit: staging changes');
     const addResult = await git(['add', '-A'], {
       cwd: workspacePath,
+      ...(env ? { env, inheritEnv: false } : {}),
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
       signal,
     });
     if (addResult.exitCode !== 0) {
-      const msg = `git add failed: ${sanitizeGitOutput(addResult.stderr.trim())}`;
+      const msg = `git add failed: ${redact(addResult.stderr.trim())}`;
       logToFile(`auto-commit: ${msg}`);
       emitCompleted(onEvent, { success: false, message: msg }, messageId);
       return { success: false, error: msg };
@@ -209,6 +211,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     logToFile('auto-commit: committing');
     let commitResult = await git(['commit', '-m', commitMessage], {
       cwd: workspacePath,
+      ...(env ? { env, inheritEnv: false } : {}),
       timeoutMs: GIT_LOCAL_TIMEOUT_MS,
       signal,
     });
@@ -216,11 +219,12 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
       logToFile('auto-commit: commit failed, retrying with --no-verify');
       commitResult = await git(['commit', '--no-verify', '-m', commitMessage], {
         cwd: workspacePath,
+        ...(env ? { env, inheritEnv: false } : {}),
         timeoutMs: GIT_LOCAL_TIMEOUT_MS,
         signal,
       });
       if (commitResult.exitCode !== 0) {
-        const msg = `git commit failed: ${sanitizeGitOutput(commitResult.stderr.trim())}`;
+        const msg = `git commit failed: ${redact(commitResult.stderr.trim())}`;
         logToFile(`auto-commit: ${msg}`);
         emitCompleted(onEvent, { success: false, message: msg }, messageId);
         return { success: false, error: msg };
@@ -233,6 +237,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     try {
       const hashResult = await git(['rev-parse', '--short', 'HEAD'], {
         cwd: workspacePath,
+        ...(env ? { env, inheritEnv: false } : {}),
         timeoutMs: GIT_LOCAL_TIMEOUT_MS,
         signal,
       });
@@ -250,12 +255,13 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
 
     const pushResult = await git(pushArgs, {
       cwd: workspacePath,
+      ...(env ? { env, inheritEnv: false } : {}),
       timeoutMs: GIT_PUSH_TIMEOUT_MS,
       signal,
     });
     if (pushResult.exitCode !== 0) {
       // Push failure is non-fatal — changes are committed locally
-      const sanitizedPushError = sanitizeGitOutput(pushResult.stderr.trim());
+      const sanitizedPushError = redact(pushResult.stderr.trim());
       const msg = `git push failed: ${sanitizedPushError}`;
       logToFile(`auto-commit: ${msg}`);
       emitCompleted(
@@ -285,7 +291,7 @@ export async function runAutoCommit(opts: AutoCommitOptions): Promise<AutoCommit
     );
     return { success: true };
   } catch (error) {
-    const errorMsg = sanitizeGitOutput(error instanceof Error ? error.message : String(error));
+    const errorMsg = redact(error instanceof Error ? error.message : String(error));
     logToFile(`auto-commit: error - ${errorMsg}`);
     emitCompleted(
       onEvent,

--- a/services/cloud-agent-next/wrapper/src/bitbucket-review-cli.test.ts
+++ b/services/cloud-agent-next/wrapper/src/bitbucket-review-cli.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, spyOn } from 'bun:test';
 import { runBitbucketReviewCli } from './bitbucket-review-cli';
+import { buildWorktreeKiloEnvironment } from './control/worktree-runtime';
 
 const API_ROOT = 'https://api.bitbucket.org/2.0';
 const principalUuid = '{55555555-5555-4555-8555-555555555555}';
@@ -265,6 +266,36 @@ describe('bb', () => {
       'Bearer secret-access-token'
     );
     expect(JSON.parse(result.stdout)).toEqual(pullRequestResponse());
+  });
+
+  it('accepts the worktree runtime environment with opaque Bitbucket and Kilo credentials', async () => {
+    const requests: RecordedRequest[] = [];
+    const env = buildWorktreeKiloEnvironment(
+      '/workspace/a',
+      '/home/worktree-a',
+      {
+        scopeId: 'worktree-a',
+        token: 'opaque-kilo-token',
+        targets: {
+          backendBaseUrl: 'https://backend.example.test',
+          providerBaseUrl: 'https://provider.example.test',
+          sessionIngestBaseUrl: 'https://ingest.example.test',
+        },
+      },
+      { ...trustedEnv(), BITBUCKET_TOKEN: 'opaque-bitbucket-token' },
+      {}
+    );
+    const result = await execute(['pr', 'view', '42'], providerFetch({ requests }), undefined, env);
+
+    expect(result.exitCode).toBe(0);
+    expect(result.stderr).toBe('');
+    expect(JSON.parse(result.stdout)).toEqual(pullRequestResponse());
+    expect(requests.map(request => request.url)).toEqual([pullRequestUrl]);
+    expect(new Headers(requests[0]?.init.headers).get('Authorization')).toBe(
+      'Bearer opaque-bitbucket-token'
+    );
+    expect(env.KILOCODE_TOKEN).toBe('opaque-kilo-token');
+    expect(JSON.stringify(env)).not.toContain('secret-access-token');
   });
 
   it('accepts unbraced UUIDs in Bitbucket pull request responses', async () => {

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.test.ts
@@ -1,14 +1,22 @@
-import fs from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { describe, expect, it, spyOn } from 'bun:test';
-import { applySessionAttach as applyAttach } from './apply-attach';
+import { applySessionAttach, type ApplyAttachDeps } from './apply-attach';
 import { KILO_CONTROL_REQUEST_TIMEOUT_MS } from './sandbox-control-runtime';
-import { runProcess } from '../utils';
+import { runProcess, withTimeoutAndAbort } from '../utils';
 import type { WrapperKiloClient } from '../kilo-api';
 import type { PreparingEventDataV2 } from '../../../src/shared/protocol.js';
 import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../../../src/shared/runtime-environment.js';
 import { sessionPreparingPayloadSchema } from '../../../src/shared/sandbox-control-protocol';
+import {
+  buildWorktreeKiloEnvironment,
+  WorktreeKiloRuntimeError,
+  type WorktreeKiloAuth,
+  type WorktreeKiloRuntime,
+  type WorktreeKiloRuntimes,
+} from './worktree-runtime';
+import { rememberAttachedRoot, resetSessionDirectoryState } from './session-directories';
 
 const session = {
   sessionId: 'workspace_1',
@@ -16,48 +24,100 @@ const session = {
   directory: '/workspace/a',
 };
 
-function fakeKilo(overrides: Partial<WrapperKiloClient> = {}): WrapperKiloClient {
-  return {
-    getSession: async id => ({ id }),
+const kilo: WorktreeKiloAuth = {
+  scopeId: 'worktree_a',
+  token: 'guest-kilo-credential',
+  targets: {
+    backendBaseUrl: 'https://backend.example.test',
+    providerBaseUrl: 'https://provider.example.test',
+    sessionIngestBaseUrl: 'https://ingest.example.test',
+  },
+};
+
+let homeRoot: string;
+
+function fakeKiloRuntimes(overrides: Partial<WrapperKiloClient> = {}): WorktreeKiloRuntimes {
+  const kiloClient = {
+    getSession: async (id: string) => ({ id }),
     ensureSession: async () => undefined,
     ...overrides,
   } as WrapperKiloClient;
+  const runtimes = new Map<string, WorktreeKiloRuntime>();
+  return {
+    attach(identity, auth, environment) {
+      const { directory } = identity;
+      let runtime = runtimes.get(directory);
+      if (!runtime) {
+        runtime = {
+          directory,
+          scopeId: auth.scopeId,
+          env: buildWorktreeKiloEnvironment(
+            directory,
+            fs.mkdtempSync(path.join(homeRoot, 'worktree-')),
+            auth,
+            environment,
+            {}
+          ),
+          kiloClient,
+          signal: new AbortController().signal,
+        };
+        runtimes.set(directory, runtime);
+      }
+      return {
+        ready: Promise.resolve(runtime),
+        signal: runtime.signal,
+        commit: () => {},
+        release: () => {},
+      };
+    },
+    detach: () => true,
+    get: directory => runtimes.get(directory),
+    isHealthy: () => true,
+    shutdown: () => {},
+  };
 }
+
+beforeEach(() => {
+  resetSessionDirectoryState();
+  homeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'apply-attach-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(homeRoot, { recursive: true, force: true });
+});
 
 const noFs = {
   hasBootstrapMarker: async () => false,
   writeBootstrapMarker: async () => undefined,
 };
 
-function applySessionAttach(
-  ...args: Parameters<typeof applyAttach>
-): ReturnType<typeof applyAttach> {
-  const [session, payload, deps] = args;
-  return applyAttach(session, payload, { sessionExists: async () => true, ...deps });
-}
-
 describe('applySessionAttach', () => {
   it('reuses setup-only workspaces without writing bootstrap state into their content', async () => {
-    const root = await fs.mkdtemp(path.join(os.tmpdir(), 'control-bootstrap-'));
+    const root = fs.mkdtempSync(path.join(os.tmpdir(), 'control-bootstrap-'));
     const directory = path.join(root, 'workspace');
     let setupRuns = 0;
-    const deps = {
-      kiloClient: fakeKilo(),
+    const deps: ApplyAttachDeps = {
+      kiloRuntimes: fakeKiloRuntimes(),
       runSetup: async () => {
         setupRuns += 1;
         return { stdout: '', stderr: '', exitCode: 0 };
       },
+      sessionExists: async () => true,
     };
     try {
       for (let attempt = 0; attempt < 2; attempt++) {
         expect(
-          await applySessionAttach({ ...session, directory }, { setupCommands: ['true'] }, deps)
+          await applySessionAttach(
+            { ...session, directory },
+            { kilo, setupCommands: ['true'] },
+            deps
+          )
         ).toEqual({ ok: true, result: { attached: true } });
       }
       expect(setupRuns).toBe(1);
-      expect(await fs.readdir(directory)).toEqual([]);
+      expect(fs.readdirSync(directory)).toEqual([]);
     } finally {
-      await fs.rm(root, { recursive: true, force: true });
+      fs.rmSync(root, { recursive: true, force: true });
     }
   });
 
@@ -68,14 +128,16 @@ describe('applySessionAttach', () => {
     const result = await applySessionAttach(
       session,
       {
+        kilo,
         directory: '/workspace/a',
         branch: 'feature/non-default',
         git: { url: 'https://github.com/acme/demo.git', token: 'secret', platform: 'github' },
         env: { KILOCODE_TOKEN: 'cap_1' },
       },
       {
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
         ...noFs,
+        sessionExists: async () => true,
         mkdir: async directory => {
           mkdirCalls.push(directory);
         },
@@ -104,10 +166,11 @@ describe('applySessionAttach', () => {
     const gitCalls: string[][] = [];
     const result = await applySessionAttach(
       session,
-      { git: { url: 'https://github.com/acme/demo.git' } },
+      { kilo, git: { url: 'https://github.com/acme/demo.git' } },
       {
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
         ...noFs,
+        sessionExists: async () => true,
         mkdir: async () => undefined,
         hasGit: async () => true,
         runGit: async args => {
@@ -127,10 +190,11 @@ describe('applySessionAttach', () => {
     const gitCalls: Array<{ args: string[]; cwd?: string }> = [];
     const result = await applySessionAttach(
       session,
-      { branch: 'feature/retry', git: { url: 'https://github.com/acme/demo.git' } },
+      { kilo, branch: 'feature/retry', git: { url: 'https://github.com/acme/demo.git' } },
       {
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
         ...noFs,
+        sessionExists: async () => true,
         mkdir: async () => undefined,
         hasGit: async () => true,
         runGit: async (args, cwd) => {
@@ -157,13 +221,15 @@ describe('applySessionAttach', () => {
     let markerWrites = 0;
     let checkoutAttempts = 0;
     const payload = {
+      kilo,
       branch: 'feature/retry',
       git: { url: 'https://github.com/acme/demo.git' },
       setupCommands: ['pnpm install'],
       preparation: { attemptId: 'att_1', triggerMessageId: 'msg_1' },
     };
-    const deps = {
-      kiloClient: fakeKilo(),
+    const deps: ApplyAttachDeps = {
+      kiloRuntimes: fakeKiloRuntimes(),
+      sessionExists: async () => true,
       mkdir: async () => undefined,
       hasGit: async () => gitExists,
       hasBootstrapMarker: async () => bootstrapComplete,
@@ -231,11 +297,13 @@ describe('applySessionAttach', () => {
     const result = await applySessionAttach(
       session,
       {
+        kilo,
         git: { url: 'https://github.com/acme/demo.git' },
         setupCommands: ['pnpm install'],
       },
       {
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
+        sessionExists: async () => true,
         hasBootstrapMarker: async () => true,
         writeBootstrapMarker: async () => undefined,
         mkdir: async () => undefined,
@@ -255,20 +323,218 @@ describe('applySessionAttach', () => {
     expect(setupCalls).toEqual([]);
   });
 
+  it('serializes sibling cold clone/setup but allows their Kilo restores to run independently', async () => {
+    const cloneStarted = Promise.withResolvers<void>();
+    const releaseClone = Promise.withResolvers<void>();
+    const setupStarted = Promise.withResolvers<void>();
+    const releaseSetup = Promise.withResolvers<void>();
+    const bothRestoring = Promise.withResolvers<void>();
+    const releaseRestore = Promise.withResolvers<void>();
+    let gitExists = false;
+    let bootstrapComplete = false;
+    let markerWrites = 0;
+    const gitOperations: string[] = [];
+    const setupCommands: string[] = [];
+    const restoredRoots: string[] = [];
+    const payload = {
+      kilo,
+      git: { url: 'https://github.com/acme/demo.git' },
+      branch: 'main',
+      setupCommands: ['prepare'],
+    };
+    const deps: ApplyAttachDeps = {
+      kiloRuntimes: fakeKiloRuntimes(),
+      mkdir: async () => {},
+      hasGit: async () => gitExists,
+      hasBootstrapMarker: async () => bootstrapComplete,
+      writeBootstrapMarker: async () => {
+        markerWrites += 1;
+        bootstrapComplete = true;
+      },
+      runGit: async args => {
+        gitOperations.push(args[0]);
+        if (args[0] === 'clone') {
+          cloneStarted.resolve();
+          await releaseClone.promise;
+          gitExists = true;
+        }
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      runSetup: async command => {
+        setupCommands.push(command);
+        setupStarted.resolve();
+        await releaseSetup.promise;
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      sessionExists: async () => false,
+      restoreSession: async id => {
+        restoredRoots.push(id);
+        if (restoredRoots.length === 2) bothRestoring.resolve();
+        await releaseRestore.promise;
+        return {
+          ok: true,
+          downloaded: true,
+          imported: true,
+          diffs: { applied: 0, skipped: 0, total: 0 },
+        };
+      },
+    };
+    const attaches = [applySessionAttach(session, payload, deps)];
+    try {
+      await cloneStarted.promise;
+      attaches.push(
+        applySessionAttach(
+          { ...session, sessionId: 'workspace_2', kiloSessionId: 'kilo_2' },
+          payload,
+          deps
+        )
+      );
+      await Bun.sleep(0);
+      expect(gitOperations).toEqual(['clone']);
+      releaseClone.resolve();
+      await setupStarted.promise;
+      await Bun.sleep(0);
+      expect(gitOperations).toEqual(['clone', 'checkout', 'config', 'config']);
+      expect(setupCommands).toEqual(['prepare']);
+      releaseSetup.resolve();
+      await withTimeoutAndAbort(bothRestoring.promise, {
+        timeoutMs: 1_000,
+        timeoutMessage: 'Sibling restore was serialized with workspace preparation',
+        abortMessage: 'Sibling restore cancelled',
+      });
+      releaseRestore.resolve();
+      expect(await Promise.all(attaches)).toEqual([
+        { ok: true, result: { attached: true } },
+        { ok: true, result: { attached: true } },
+      ]);
+      expect(markerWrites).toBe(1);
+      expect(restoredRoots.sort()).toEqual(['kilo_1', 'kilo_2']);
+    } finally {
+      releaseClone.resolve();
+      releaseSetup.resolve();
+      releaseRestore.resolve();
+      await Promise.allSettled(attaches);
+    }
+  });
+
+  it('releases failed cold setup so a waiting sibling can retry and warm attaches skip it', async () => {
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    let attempts = 0;
+    let bootstrapComplete = false;
+    let markerWrites = 0;
+    const payload = { kilo, setupCommands: ['prepare'] };
+    const deps: ApplyAttachDeps = {
+      kiloRuntimes: fakeKiloRuntimes(),
+      sessionExists: async () => true,
+      mkdir: async () => {},
+      hasBootstrapMarker: async () => bootstrapComplete,
+      writeBootstrapMarker: async () => {
+        markerWrites += 1;
+        bootstrapComplete = true;
+      },
+      runSetup: async () => {
+        const attempt = ++attempts;
+        if (attempt === 1) {
+          started.resolve();
+          await release.promise;
+        }
+        return { stdout: '', stderr: '', exitCode: attempt === 1 ? 1 : 0 };
+      },
+    };
+    const attaches = [applySessionAttach(session, payload, deps)];
+    try {
+      await started.promise;
+      attaches.push(
+        applySessionAttach(
+          { ...session, sessionId: 'workspace_2', kiloSessionId: 'kilo_2' },
+          payload,
+          deps
+        )
+      );
+      await Bun.sleep(0);
+      expect(attempts).toBe(1);
+      release.resolve();
+      expect(await Promise.all(attaches)).toEqual([
+        {
+          ok: false,
+          error: { code: 'not_ready', message: 'Setup command 1 failed', retryable: true },
+        },
+        { ok: true, result: { attached: true } },
+      ]);
+      expect(await applySessionAttach(session, payload, deps)).toEqual({
+        ok: true,
+        result: { attached: true },
+      });
+      expect(attempts).toBe(2);
+      expect(markerWrites).toBe(1);
+    } finally {
+      release.resolve();
+      await Promise.allSettled(attaches);
+    }
+  });
+
+  it('does not block another worktree while one directory is running cold setup', async () => {
+    const started = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const prepared: string[] = [];
+    const deps: ApplyAttachDeps = {
+      kiloRuntimes: fakeKiloRuntimes(),
+      ...noFs,
+      sessionExists: async () => true,
+      mkdir: async () => {},
+      runSetup: async (_command, directory) => {
+        if (directory === session.directory) {
+          started.resolve();
+          await release.promise;
+        }
+        prepared.push(directory);
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+    };
+    const attaches = [applySessionAttach(session, { kilo, setupCommands: ['prepare'] }, deps)];
+    try {
+      await started.promise;
+      const other = applySessionAttach(
+        {
+          sessionId: 'workspace_other',
+          kiloSessionId: 'kilo_other',
+          directory: '/workspace/other',
+        },
+        { kilo: { ...kilo, scopeId: 'worktree_other' }, setupCommands: ['prepare'] },
+        deps
+      );
+      attaches.push(other);
+      expect(
+        await withTimeoutAndAbort(other, {
+          timeoutMs: 1_000,
+          timeoutMessage: 'Other worktree was blocked by cold setup',
+          abortMessage: 'Other worktree setup cancelled',
+        })
+      ).toEqual({ ok: true, result: { attached: true } });
+      expect(prepared).toEqual(['/workspace/other']);
+    } finally {
+      release.resolve();
+      await Promise.allSettled(attaches);
+    }
+  });
+
   it('runs setup commands and emits preparing steps', async () => {
     const setupCalls: Array<{ command: string; env?: Record<string, string> }> = [];
     const events: PreparingEventDataV2[] = [];
     const result = await applySessionAttach(
       session,
       {
+        kilo,
         git: { url: 'https://github.com/acme/demo.git' },
         setupCommands: ['pnpm install'],
         env: { FOO: 'bar' },
         preparation: { attemptId: 'att_1', triggerMessageId: 'msg_1' },
       },
       {
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
         ...noFs,
+        sessionExists: async () => true,
         mkdir: async () => undefined,
         hasGit: async () => false,
         runGit: async () => ({ stdout: '', stderr: '', exitCode: 0 }),
@@ -282,7 +548,9 @@ describe('applySessionAttach', () => {
       }
     );
     expect(result.ok).toBe(true);
-    expect(setupCalls).toEqual([{ command: 'pnpm install', env: { FOO: 'bar' } }]);
+    expect(setupCalls).toMatchObject([
+      { command: 'pnpm install', env: { FOO: 'bar', KILOCODE_TOKEN: kilo.token } },
+    ]);
     expect(events[0]).toMatchObject({
       action: 'attempt_started',
       attemptId: 'att_1',
@@ -321,13 +589,15 @@ describe('applySessionAttach', () => {
     const result = await applySessionAttach(
       session,
       {
+        kilo,
         env,
         setupCommands: ['env; printf fake-config-sentinel-456'],
         preparation: { attemptId: 'attempt_1', triggerMessageId: 'msg_1' },
       },
       {
         ...noFs,
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
+        sessionExists: async () => true,
         mkdir: async () => {},
         emitPreparing: event => events.push(event),
         runSetup: async (_command, _directory, _env, onOutput) => {
@@ -358,10 +628,11 @@ describe('applySessionAttach', () => {
   it('fails attach when a setup command fails', async () => {
     const result = await applySessionAttach(
       session,
-      { setupCommands: ['false'] },
+      { kilo, setupCommands: ['false'] },
       {
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
         ...noFs,
+        sessionExists: async () => true,
         mkdir: async () => undefined,
         runSetup: async () => ({ stdout: '', stderr: 'nope', exitCode: 1 }),
       }
@@ -377,10 +648,10 @@ describe('applySessionAttach', () => {
     const ensured: string[] = [];
     const result = await applySessionAttach(
       session,
-      {},
+      { kilo },
       {
         sessionExists: async () => false,
-        kiloClient: fakeKilo({
+        kiloRuntimes: fakeKiloRuntimes({
           ensureSession: async (sessionId, directory) => {
             ensured.push(`${sessionId}:${directory}`);
           },
@@ -403,9 +674,9 @@ describe('applySessionAttach', () => {
     let restoredId: string | undefined;
     const result = await applySessionAttach(
       session,
-      {},
+      { kilo },
       {
-        kiloClient: fakeKilo({
+        kiloRuntimes: fakeKiloRuntimes({
           ensureSession: async () => {
             ensured = true;
           },
@@ -432,9 +703,9 @@ describe('applySessionAttach', () => {
     const ensured: Array<[string, string]> = [];
     const result = await applySessionAttach(
       session,
-      {},
+      { kilo },
       {
-        kiloClient: fakeKilo({
+        kiloRuntimes: fakeKiloRuntimes({
           ensureSession: async (sessionId, directory) => {
             ensured.push([sessionId, directory]);
           },
@@ -457,9 +728,9 @@ describe('applySessionAttach', () => {
     const ensured: Array<[string, string]> = [];
     const result = await applySessionAttach(
       session,
-      {},
+      { kilo },
       {
-        kiloClient: fakeKilo({
+        kiloRuntimes: fakeKiloRuntimes({
           ensureSession: async (sessionId, directory) => {
             ensured.push([sessionId, directory]);
           },
@@ -485,9 +756,9 @@ describe('applySessionAttach', () => {
     let ensured = false;
     const result = await applySessionAttach(
       session,
-      {},
+      { kilo },
       {
-        kiloClient: fakeKilo({
+        kiloRuntimes: fakeKiloRuntimes({
           ensureSession: async () => {
             ensured = true;
           },
@@ -513,9 +784,9 @@ describe('applySessionAttach', () => {
     let ensured = false;
     const result = await applySessionAttach(
       session,
-      {},
+      { kilo },
       {
-        kiloClient: fakeKilo({
+        kiloRuntimes: fakeKiloRuntimes({
           ensureSession: async () => {
             ensured = true;
           },
@@ -540,9 +811,9 @@ describe('applySessionAttach', () => {
     let ensured = false;
     const result = await applySessionAttach(
       session,
-      {},
+      { kilo },
       {
-        kiloClient: fakeKilo({
+        kiloRuntimes: fakeKiloRuntimes({
           ensureSession: async () => {
             ensured = true;
           },
@@ -565,13 +836,61 @@ describe('applySessionAttach', () => {
     expect(ensured).toBe(false);
   });
 
+  it.each([true, false])(
+    'seeds the authoritative root before session lookup (exists=%s)',
+    async exists => {
+      const runtimes = fakeKiloRuntimes();
+      const snapshotIdentity = 'snapshot_other';
+      const steps: string[] = [];
+      const assertRegistration = () => {
+        const runtime = runtimes.get(session.directory);
+        if (!runtime) throw new Error('Expected worktree runtime');
+        const storage = path.join(runtime.env.XDG_DATA_HOME, 'kilo', 'storage', 'session_share');
+        expect(
+          JSON.parse(fs.readFileSync(path.join(storage, `${session.kiloSessionId}.json`), 'utf8'))
+        ).toEqual({
+          id: session.kiloSessionId,
+          ingestPath: `/api/session/${session.kiloSessionId}/ingest`,
+        });
+        expect(fs.existsSync(path.join(storage, `${snapshotIdentity}.json`))).toBe(false);
+      };
+      const result = await applySessionAttach(
+        session,
+        { kilo, snapshotIdentity },
+        {
+          ...noFs,
+          kiloRuntimes: runtimes,
+          sessionExists: async id => {
+            expect(id).toBe(snapshotIdentity);
+            assertRegistration();
+            steps.push('probe');
+            return exists;
+          },
+          restoreSession: async id => {
+            expect(id).toBe(snapshotIdentity);
+            assertRegistration();
+            steps.push('restore');
+            return {
+              ok: true,
+              downloaded: true,
+              imported: true,
+              diffs: { applied: 0, skipped: 0, total: 0 },
+            };
+          },
+        }
+      );
+      expect(result).toEqual({ ok: true, result: { attached: true } });
+      expect(steps).toEqual(exists ? ['probe'] : ['probe', 'restore']);
+    }
+  );
+
   it('uses snapshotIdentity when present', async () => {
     const ids: string[] = [];
     const result = await applySessionAttach(
       session,
-      { snapshotIdentity: 'ses_other' },
+      { kilo, snapshotIdentity: 'ses_other' },
       {
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
         sessionExists: async kiloSessionId => {
           ids.push(kiloSessionId);
           return false;
@@ -601,10 +920,10 @@ describe('applySessionAttach', () => {
     try {
       const attaching = applySessionAttach(
         session,
-        {},
+        { kilo },
         {
           ...noFs,
-          kiloClient: fakeKilo({
+          kiloRuntimes: fakeKiloRuntimes({
             ensureSession: async () => {
               ensured = true;
             },
@@ -638,6 +957,11 @@ describe('applySessionAttach', () => {
 
   it('does not turn HTTP 500 from the directory-scoped session probe into a restore attempt', async () => {
     const requests: string[] = [];
+    const runtimes = fakeKiloRuntimes();
+    // Pre-attach to create the runtime so defaultSessionExists can find kiloClient.serverUrl
+    runtimes.attach(session, kilo, {});
+    const runtime = runtimes.get(session.directory);
+    if (!runtime) throw new Error('Expected runtime');
     const server = Bun.serve({
       port: 0,
       fetch(request) {
@@ -647,12 +971,14 @@ describe('applySessionAttach', () => {
     });
     let restored = false;
     try {
-      const result = await applyAttach(
+      const result = await applySessionAttach(
         session,
-        {},
+        { kilo },
         {
           ...noFs,
-          kiloClient: fakeKilo({ serverUrl: server.url.toString() }),
+          kiloRuntimes: fakeKiloRuntimes({
+            serverUrl: server.url.toString(),
+          } as Partial<WrapperKiloClient>),
           restoreSession: async () => {
             restored = true;
             return { ok: false, step: 'download', code: 404, error: 'not found' };
@@ -674,20 +1000,23 @@ describe('applySessionAttach', () => {
     const importing = Promise.withResolvers<void>();
     let quiesced = false;
     let ensured = false;
+    let restoreSignal: AbortSignal | undefined;
     const attaching = applySessionAttach(
       session,
-      {},
+      { kilo },
       {
         ...noFs,
         signal: controller.signal,
-        kiloClient: fakeKilo({
+        kiloRuntimes: fakeKiloRuntimes({
           ensureSession: async () => {
             ensured = true;
           },
         }),
         sessionExists: async () => false,
         restoreSession: async (_id, _directory, _file, options) => {
-          expect(options?.signal).toBe(controller.signal);
+          restoreSignal = options?.signal;
+          expect(restoreSignal).toBeInstanceOf(AbortSignal);
+          expect(restoreSignal?.aborted).toBe(false);
           await runProcess(
             process.execPath,
             ['-e', 'process.stdout.write("importing"); setInterval(() => {}, 1000)'],
@@ -705,6 +1034,7 @@ describe('applySessionAttach', () => {
     );
     await importing.promise;
     controller.abort();
+    expect(restoreSignal?.aborted).toBe(true);
     expect(await attaching).toMatchObject({ ok: false });
     expect(quiesced).toBe(true);
     expect(ensured).toBe(false);
@@ -715,15 +1045,17 @@ describe('applySessionAttach', () => {
     const cloning = Promise.withResolvers<void>();
     const calls: string[] = [];
     let quiesced = false;
+    let cloneSignal: AbortSignal | undefined;
     const attaching = applySessionAttach(
       session,
       {
+        kilo,
         git: { url: 'https://github.com/acme/demo.git' },
         branch: 'branch',
         setupCommands: ['setup'],
       },
       {
-        kiloClient: fakeKilo(),
+        kiloRuntimes: fakeKiloRuntimes(),
         signal: controller.signal,
         hasBootstrapMarker: async () => false,
         hasGit: async () => false,
@@ -737,7 +1069,9 @@ describe('applySessionAttach', () => {
         },
         runGit: async (args, _cwd, signal) => {
           calls.push(args[0] ?? '');
-          expect(signal).toBe(controller.signal);
+          cloneSignal = signal;
+          expect(cloneSignal).toBeInstanceOf(AbortSignal);
+          expect(cloneSignal?.aborted).toBe(false);
           const result = await runProcess(
             process.execPath,
             ['-e', 'process.stdout.write("cloning"); setInterval(() => {}, 1000)'],
@@ -755,6 +1089,7 @@ describe('applySessionAttach', () => {
     );
     await cloning.promise;
     controller.abort();
+    expect(cloneSignal?.aborted).toBe(true);
     expect(await attaching).toMatchObject({ ok: false });
     expect(quiesced).toBe(true);
     expect(calls).toEqual(['clone']);
@@ -763,11 +1098,199 @@ describe('applySessionAttach', () => {
   it('returns protocol_error for invalid payload', async () => {
     const result = await applySessionAttach(
       session,
-      { git: { url: 1 } },
-      { kiloClient: fakeKilo(), ...noFs }
+      { kilo, git: { url: 1 } },
+      { kiloRuntimes: fakeKiloRuntimes(), ...noFs }
     );
     expect(result.ok).toBe(false);
     if (!result.ok) expect(result.error.code).toBe('protocol_error');
+  });
+
+  it('requires an explicit auth context before any credential-bearing work', async () => {
+    const sideEffects: string[] = [];
+    const runtimes = fakeKiloRuntimes();
+    const result = await applySessionAttach(
+      session,
+      {
+        env: { KILOCODE_TOKEN: 'actual-managed-token' },
+        git: { url: 'https://github.com/acme/demo.git' },
+        setupCommands: ['pnpm install'],
+      },
+      {
+        kiloRuntimes: {
+          ...runtimes,
+          attach: (...args) => {
+            sideEffects.push('runtime');
+            return runtimes.attach(...args);
+          },
+        },
+        hasBootstrapMarker: async () => {
+          sideEffects.push('filesystem');
+          return false;
+        },
+        runSetup: async () => {
+          sideEffects.push('setup');
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+      }
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'protocol_error', message: 'Kilo auth context is required', retryable: false },
+    });
+    expect(sideEffects).toEqual([]);
+    expect(JSON.stringify(result)).not.toContain('actual-managed-token');
+  });
+
+  it('starts the worktree runtime before setup and restores with that exact environment', async () => {
+    const steps: string[] = [];
+    const runtimes = fakeKiloRuntimes();
+    const environment = { FOO: 'bar', KILOCODE_TOKEN: 'actual-managed-token' };
+    const attachment = runtimes.attach(session, kilo, environment);
+    const runtime = await attachment.ready;
+    let setupSignal: AbortSignal | undefined;
+    const result = await applySessionAttach(
+      session,
+      { kilo, env: environment, setupCommands: ['prepare'] },
+      {
+        ...noFs,
+        kiloRuntimes: {
+          ...runtimes,
+          attach: (identity, auth, env) => {
+            expect(identity).toEqual(session);
+            expect(auth).toEqual(kilo);
+            expect(env).toEqual(environment);
+            steps.push('runtime');
+            return attachment;
+          },
+        },
+        mkdir: async () => {
+          steps.push('mkdir');
+        },
+        runSetup: async (_command, directory, env, _onOutput, signal) => {
+          expect(directory).toBe(session.directory);
+          expect(env).toBe(runtime.env);
+          setupSignal = signal;
+          expect(signal).toBeInstanceOf(AbortSignal);
+          expect(signal?.aborted).toBe(false);
+          steps.push('setup');
+          return { stdout: '', stderr: '', exitCode: 0 };
+        },
+        sessionExists: async () => false,
+        restoreSession: async (id, directory, _file, options) => {
+          expect(id).toBe(session.kiloSessionId);
+          expect(directory).toBe(session.directory);
+          expect(options?.env).toBe(runtime.env);
+          expect(options?.signal).toBe(setupSignal);
+          steps.push('restore');
+          return {
+            ok: true,
+            downloaded: true,
+            imported: true,
+            diffs: { applied: 0, skipped: 0, total: 0 },
+          };
+        },
+      }
+    );
+
+    expect(result).toEqual({ ok: true, result: { attached: true } });
+    expect(steps).toEqual(['runtime', 'mkdir', 'setup', 'restore']);
+  });
+
+  it('runs real setup with Bitbucket metadata and opaque auth without inheriting control credentials', async () => {
+    const directory = fs.mkdtempSync(path.join(os.tmpdir(), 'worktree-setup-test-'));
+    const runtimes = fakeKiloRuntimes();
+    const saved = {
+      KILOCODE_TOKEN: process.env.KILOCODE_TOKEN,
+      SANDBOX_CONTROL_CREDENTIAL: process.env.SANDBOX_CONTROL_CREDENTIAL,
+      WRAPPER_ONLY_SETUP_VALUE: process.env.WRAPPER_ONLY_SETUP_VALUE,
+    };
+    try {
+      process.env.KILOCODE_TOKEN = 'actual-managed-token';
+      process.env.SANDBOX_CONTROL_CREDENTIAL = 'actual-control-credential';
+      process.env.WRAPPER_ONLY_SETUP_VALUE = 'wrapper-only-value';
+      const result = await applySessionAttach(
+        { ...session, directory },
+        {
+          kilo,
+          env: {
+            PATH: process.env.PATH ?? '',
+            KILOCODE_TOKEN: 'actual-attachment-token',
+            BITBUCKET_TOKEN: 'opaque-bitbucket-token',
+            KILO_BITBUCKET_WORKSPACE_SLUG: 'acme-workspace',
+            KILO_BITBUCKET_REPOSITORY_SLUG: 'widgets',
+            KILO_BITBUCKET_WORKSPACE_UUID: '{33333333-3333-4333-8333-333333333333}',
+            KILO_BITBUCKET_REPOSITORY_UUID: '{11111111-1111-4111-8111-111111111111}',
+          },
+          setupCommands: [
+            'printf "%s\\n" "$HOME" "$KILOCODE_TOKEN" "${SANDBOX_CONTROL_CREDENTIAL-absent}" "${WRAPPER_ONLY_SETUP_VALUE-absent}" "$BITBUCKET_TOKEN" "$KILO_BITBUCKET_WORKSPACE_SLUG" "$KILO_BITBUCKET_REPOSITORY_SLUG" "$KILO_BITBUCKET_WORKSPACE_UUID" "$KILO_BITBUCKET_REPOSITORY_UUID" > setup-env.txt',
+          ],
+        },
+        { ...noFs, kiloRuntimes: runtimes, sessionExists: async () => true }
+      );
+      expect(result).toEqual({ ok: true, result: { attached: true } });
+      const home = runtimes.get(directory)?.env.HOME;
+      expect(home).toStartWith(homeRoot);
+      expect(fs.readFileSync(path.join(directory, 'setup-env.txt'), 'utf8')).toBe(
+        `${home}\n${kilo.token}\nabsent\nabsent\nopaque-bitbucket-token\nacme-workspace\nwidgets\n{33333333-3333-4333-8333-333333333333}\n{11111111-1111-4111-8111-111111111111}\n`
+      );
+      expect(process.env.KILOCODE_TOKEN).toBe('actual-managed-token');
+    } finally {
+      for (const [name, value] of Object.entries(saved)) {
+        if (value === undefined) delete process.env[name];
+        else process.env[name] = value;
+      }
+      fs.rmSync(directory, { recursive: true, force: true });
+    }
+  });
+
+  it('fails closed on runtime identity conflicts before workspace preparation', async () => {
+    let prepared = false;
+    const result = await applySessionAttach(
+      session,
+      { kilo, setupCommands: ['prepare'] },
+      {
+        kiloRuntimes: {
+          ...fakeKiloRuntimes(),
+          attach: () => {
+            throw new WorktreeKiloRuntimeError(
+              'unauthorized',
+              'Kilo worktree auth context mismatch',
+              false
+            );
+          },
+        },
+        hasBootstrapMarker: async () => {
+          prepared = true;
+          return false;
+        },
+      }
+    );
+
+    expect(result).toEqual({
+      ok: false,
+      error: {
+        code: 'unauthorized',
+        message: 'Kilo worktree auth context mismatch',
+        retryable: false,
+      },
+    });
+    expect(prepared).toBe(false);
+  });
+
+  it('rejects directory overrides and rebinding an existing root to another worktree', async () => {
+    const deps: ApplyAttachDeps = { kiloRuntimes: fakeKiloRuntimes(), ...noFs };
+    expect(
+      await applySessionAttach(session, { kilo, directory: '/workspace/other' }, deps)
+    ).toEqual({
+      ok: false,
+      error: { code: 'protocol_error', message: 'Attachment directory mismatch', retryable: false },
+    });
+    rememberAttachedRoot(session.kiloSessionId, '/workspace/other');
+    expect(await applySessionAttach(session, { kilo }, deps)).toEqual({
+      ok: false,
+      error: { code: 'unauthorized', message: 'Session directory mismatch', retryable: false },
+    });
   });
 
   for (const key of CONTROL_RUNTIME_RESERVED_ENV_VARS) {
@@ -783,7 +1306,7 @@ describe('applySessionAttach', () => {
           preparation: { attemptId: 'att_1', triggerMessageId: 'msg_1' },
         },
         {
-          kiloClient: fakeKilo(),
+          kiloRuntimes: fakeKiloRuntimes(),
           hasBootstrapMarker: async () => {
             sideEffects.push('bootstrap');
             return false;

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
@@ -144,15 +144,27 @@ async function defaultRunSetup(
 
 async function serializeWorkspacePreparation(
   directory: string,
+  signal: AbortSignal,
   prepare: () => Promise<ControlHandlerResult | undefined>
 ): Promise<ControlHandlerResult | undefined> {
+  const cancelled = Promise.withResolvers<never>();
+  const onAbort = () => cancelled.reject(signal.reason);
+  const run = () => {
+    signal.removeEventListener('abort', onAbort);
+    signal.throwIfAborted();
+    return prepare();
+  };
   const previous = workspacePreparations.get(directory) ?? Promise.resolve();
-  const current = previous.then(prepare, prepare);
-  workspacePreparations.set(directory, current);
-  try {
-    return await current;
-  } finally {
+  const current = previous.then(run, run).finally(() => {
     if (workspacePreparations.get(directory) === current) workspacePreparations.delete(directory);
+  });
+  workspacePreparations.set(directory, current);
+  signal.addEventListener('abort', onAbort, { once: true });
+  if (signal.aborted) onAbort();
+  try {
+    return await Promise.race([current, cancelled.promise]);
+  } finally {
+    signal.removeEventListener('abort', onAbort);
   }
 }
 
@@ -275,7 +287,7 @@ export async function applySessionAttach(
       ...(attach.git?.token ? { GIT_TOKEN: attach.git.token } : {}),
     });
 
-    const workspaceFailure = await serializeWorkspacePreparation(directory, async () => {
+    const workspaceFailure = await serializeWorkspacePreparation(directory, signal, async () => {
       try {
         signal.throwIfAborted();
         const alreadyBootstrapped = await hasBootstrapMarker(directory);

--- a/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
+++ b/services/cloud-agent-next/wrapper/src/control/apply-attach.ts
@@ -13,28 +13,42 @@ import {
   isTimeoutTermination,
   logToFile,
   runProcess,
+  withTimeoutAndAbort,
   type ExecResult,
   type ProcessOutputStream,
 } from '../utils.js';
-import { rememberAttachedRoot, rememberSessionDirectory } from './session-directories';
+import {
+  directoryForSession,
+  forgetAttachedRoot,
+  rememberAttachedRoot,
+  rootForSession,
+} from './session-directories';
 import { authenticatedGitUrl } from './git-url';
 import { createOutputRedactor, createSecretRedactor } from '../redact-output';
 import { stripAnsi } from '../event-parser';
 import type { ControlHandlerResult } from './sandbox-control-handlers';
 import type { WrapperKiloClient } from '../kilo-api.js';
-import { restoreSession } from '../restore-session.js';
+import { restoreSession, seedSessionIngestRegistration } from '../restore-session.js';
 import { configureWorkspaceGitAuthor } from '../session-bootstrap.js';
 import { withKiloRequestDeadline } from './sandbox-control-runtime';
+import { ControlTerminalRuntimeError, type ControlTerminalRuntime } from './terminal-runtime.js';
+import {
+  WorktreeKiloRuntimeError,
+  type WorktreeKiloAttachment,
+  type WorktreeKiloRuntimes,
+} from './worktree-runtime.js';
 
 const BOOTSTRAP_MARKER = 'kilo-bootstrap-complete';
 const SETUP_COMMAND_INACTIVITY_TIMEOUT_MS = 4 * 60_000;
 const SETUP_COMMAND_HARD_TIMEOUT_MS = 300_000;
+const workspacePreparations = new Map<string, Promise<ControlHandlerResult | undefined>>();
 
 export type AttachPreparingEmitter = (event: PreparingEventDataV2) => void;
 
 export type ApplyAttachDeps = {
-  kiloClient?: WrapperKiloClient;
+  kiloRuntimes?: WorktreeKiloRuntimes;
   signal?: AbortSignal;
+  terminalRuntime?: Pick<ControlTerminalRuntime, 'rememberAttachedSession'>;
   mkdir?: (directory: string) => Promise<void>;
   hasGit?: (directory: string) => Promise<boolean>;
   hasBootstrapMarker?: (directory: string) => Promise<boolean>;
@@ -43,7 +57,7 @@ export type ApplyAttachDeps = {
   runSetup?: (
     command: string,
     directory: string,
-    env: Record<string, string> | undefined,
+    env: Record<string, string>,
     onOutput?: (stream: ProcessOutputStream, output: string) => void,
     signal?: AbortSignal
   ) => Promise<ExecResult>;
@@ -113,18 +127,33 @@ async function defaultSessionExists(
 async function defaultRunSetup(
   command: string,
   directory: string,
-  env: Record<string, string> | undefined,
+  env: Record<string, string>,
   onOutput?: (stream: ProcessOutputStream, output: string) => void,
   signal?: AbortSignal
 ): Promise<ExecResult> {
-  return runProcess('sh', ['-lc', command], {
+  return runProcess('sh', ['-c', command], {
     cwd: directory,
+    env,
+    inheritEnv: false,
     signal,
     inactivityTimeoutMs: SETUP_COMMAND_INACTIVITY_TIMEOUT_MS,
     hardTimeoutMs: SETUP_COMMAND_HARD_TIMEOUT_MS,
-    ...(env ? { env } : {}),
     ...(onOutput ? { onOutput } : {}),
   });
+}
+
+async function serializeWorkspacePreparation(
+  directory: string,
+  prepare: () => Promise<ControlHandlerResult | undefined>
+): Promise<ControlHandlerResult | undefined> {
+  const previous = workspacePreparations.get(directory) ?? Promise.resolve();
+  const current = previous.then(prepare, prepare);
+  workspacePreparations.set(directory, current);
+  try {
+    return await current;
+  } finally {
+    if (workspacePreparations.get(directory) === current) workspacePreparations.delete(directory);
+  }
 }
 
 function createProgress(
@@ -202,166 +231,205 @@ export async function applySessionAttach(
   deps: ApplyAttachDeps
 ): Promise<ControlHandlerResult> {
   const parsed = sessionAttachPayloadSchema.safeParse(payload ?? {});
-  if (!parsed.success) {
-    return fail('protocol_error', 'Invalid payload', false);
-  }
+  if (!parsed.success) return fail('protocol_error', 'Invalid payload', false);
   const attach = parsed.data;
-  const environment = attach.env;
   if (
-    environment &&
-    CONTROL_RUNTIME_RESERVED_ENV_VARS.some(key => Object.hasOwn(environment, key))
+    attach.env &&
+    CONTROL_RUNTIME_RESERVED_ENV_VARS.some(key => Object.hasOwn(attach.env ?? {}, key))
   ) {
     return fail('protocol_error', 'Reserved control runtime environment variable', false);
   }
-
-  const kiloClient = deps.kiloClient;
-  if (!kiloClient) return fail('not_ready', 'Kilo is not ready', true);
-  const signal = deps.signal ?? AbortSignal.timeout(SANDBOX_CONTROL_ATTACH_TIMEOUT_MS);
+  if (!attach.kilo) return fail('protocol_error', 'Kilo auth context is required', false);
   const directory = attach.directory ?? session.directory;
-  const mkdir = deps.mkdir ?? (dir => fs.mkdir(dir, { recursive: true }).then(() => undefined));
-  const hasGit = deps.hasGit ?? defaultHasGit;
-  const hasBootstrapMarker = deps.hasBootstrapMarker ?? defaultHasBootstrapMarker;
-  const writeBootstrapMarker = deps.writeBootstrapMarker ?? defaultWriteBootstrapMarker;
-  const runGit = deps.runGit ?? ((args, cwd, signal) => git(args, { cwd, signal }));
-  const runSetup = deps.runSetup ?? defaultRunSetup;
-  if (signal.aborted) return fail('not_ready', 'Session attachment cancelled', true);
-  const progress = createProgress(attach.preparation, deps.emitPreparing);
-  const redact = createSecretRedactor({
-    ...process.env,
-    ...environment,
-    ...(attach.git?.token ? { GIT_TOKEN: attach.git.token } : {}),
-  });
+  if (directory !== session.directory)
+    return fail('protocol_error', 'Attachment directory mismatch', false);
+  const existingDirectory = directoryForSession(session.kiloSessionId);
+  if (existingDirectory && existingDirectory !== directory) {
+    return fail('unauthorized', 'Session directory mismatch', false);
+  }
+  if (!deps.kiloRuntimes) return fail('not_ready', 'Kilo is not ready', true);
 
+  let attachment: WorktreeKiloAttachment | undefined;
+  const taskSignal = deps.signal ?? AbortSignal.timeout(SANDBOX_CONTROL_ATTACH_TIMEOUT_MS);
   try {
+    taskSignal.throwIfAborted();
+    attachment = deps.kiloRuntimes.attach(session, attach.kilo, attach.env);
+    const signal = AbortSignal.any([taskSignal, attachment.signal]);
+    const { kiloClient, env } = await withTimeoutAndAbort(attachment.ready, {
+      signal,
+      timeoutMs: SANDBOX_CONTROL_ATTACH_TIMEOUT_MS,
+      timeoutMessage: 'Session attachment timed out',
+      abortMessage: 'Session attachment cancelled',
+    });
     signal.throwIfAborted();
-    const alreadyBootstrapped = await hasBootstrapMarker(directory);
-    signal.throwIfAborted();
-    const setupCommands = attach.setupCommands ?? [];
-    const needsWorkspace = Boolean(attach.git) || setupCommands.length > 0;
-    if (!alreadyBootstrapped && needsWorkspace) {
-      await mkdir(directory);
-      signal.throwIfAborted();
-      if (attach.git) {
-        const needsClone = !(await hasGit(directory));
+    const mkdir = deps.mkdir ?? (dir => fs.mkdir(dir, { recursive: true }).then(() => undefined));
+    const hasGit = deps.hasGit ?? defaultHasGit;
+    const hasBootstrapMarker = deps.hasBootstrapMarker ?? defaultHasBootstrapMarker;
+    const writeBootstrapMarker = deps.writeBootstrapMarker ?? defaultWriteBootstrapMarker;
+    const runGit =
+      deps.runGit ?? ((args, cwd, signal) => git(args, { cwd, env, inheritEnv: false, signal }));
+    const runSetup = deps.runSetup ?? defaultRunSetup;
+    const progress = createProgress(attach.preparation, deps.emitPreparing);
+    const redact = createSecretRedactor(process.env, attach.env ?? {}, {
+      ...env,
+      ...(attach.git?.token ? { GIT_TOKEN: attach.git.token } : {}),
+    });
+
+    const workspaceFailure = await serializeWorkspacePreparation(directory, async () => {
+      try {
         signal.throwIfAborted();
-        if (needsClone || attach.branch) {
-          const cloneStepId = 'phase:cloning';
-          progress.start('cloning', cloneStepId, 'Cloning repository…');
-          if (needsClone) {
-            progress.progress('cloning', cloneStepId, 'Cloning repository…');
-            const cloneUrl = authenticatedGitUrl(
-              attach.git.url,
-              attach.git.token,
-              attach.git.platform
-            );
-            const cloned = await runGit(['clone', cloneUrl, directory], undefined, signal);
+        const alreadyBootstrapped = await hasBootstrapMarker(directory);
+        signal.throwIfAborted();
+        const setupCommands = attach.setupCommands ?? [];
+        const needsWorkspace = Boolean(attach.git) || setupCommands.length > 0;
+        if (!alreadyBootstrapped && needsWorkspace) {
+          await mkdir(directory);
+          signal.throwIfAborted();
+          if (attach.git) {
+            const needsClone = !(await hasGit(directory));
             signal.throwIfAborted();
-            if (cloned.exitCode !== 0) {
-              progress.fail('cloning', cloneStepId, 'git clone failed');
-              return fail('not_ready', 'git clone failed', true);
+            if (needsClone || attach.branch) {
+              const cloneStepId = 'phase:cloning';
+              progress.start('cloning', cloneStepId, 'Cloning repository…');
+              if (needsClone) {
+                progress.progress('cloning', cloneStepId, 'Cloning repository…');
+                const cloneUrl = authenticatedGitUrl(
+                  attach.git.url,
+                  attach.git.token,
+                  attach.git.platform
+                );
+                const cloned = await runGit(['clone', cloneUrl, directory], undefined, signal);
+                signal.throwIfAborted();
+                if (cloned.exitCode !== 0) {
+                  progress.fail('cloning', cloneStepId, 'git clone failed');
+                  return fail('not_ready', 'git clone failed', true);
+                }
+              }
+              if (attach.branch) {
+                const checked = await runGit(
+                  ['checkout', '-B', attach.branch, `origin/${attach.branch}`],
+                  directory,
+                  signal
+                );
+                signal.throwIfAborted();
+                if (checked.exitCode !== 0) {
+                  progress.fail('cloning', cloneStepId, 'git checkout failed');
+                  return fail('not_ready', 'git checkout failed', true);
+                }
+              }
+              progress.complete('cloning', cloneStepId);
             }
-          }
-          if (attach.branch) {
-            const checked = await runGit(
-              ['checkout', '-B', attach.branch, `origin/${attach.branch}`],
+            await configureWorkspaceGitAuthor(
               directory,
+              (args, options) => runGit(args, options?.cwd, options?.signal),
+              undefined,
               signal
             );
             signal.throwIfAborted();
-            if (checked.exitCode !== 0) {
-              progress.fail('cloning', cloneStepId, 'git checkout failed');
-              return fail('not_ready', 'git checkout failed', true);
+          }
+          for (const [index, command] of setupCommands.entries()) {
+            signal.throwIfAborted();
+            const stepId = `setup_command:${index}`;
+            progress.start('setup_commands', stepId, `Running setup command ${index + 1}`, {
+              kind: 'setup_command',
+              label: `Setup command ${index + 1}`,
+              command: redact(command),
+              commandIndex: index,
+              commandCount: setupCommands.length,
+            });
+            const output = createOutputRedactor(
+              text => redact(stripAnsi(text)),
+              text => {
+                if (signal.aborted) return;
+                const cleaned = text.trim();
+                if (cleaned) progress.output(stepId, `${cleaned}\n`);
+              }
+            );
+            const result = await runSetup(command, directory, env, output.onOutput, signal);
+            signal.throwIfAborted();
+            output.flush();
+            if (result.exitCode !== 0) {
+              const safeError = `Setup command ${index + 1} ${isTimeoutTermination(result) ? 'timed out' : 'failed'}`;
+              progress.fail('setup_commands', stepId, safeError);
+              return fail('not_ready', safeError, true);
             }
+            progress.complete('setup_commands', stepId);
           }
-          progress.complete('cloning', cloneStepId);
+          signal.throwIfAborted();
+          await writeBootstrapMarker(directory);
+          signal.throwIfAborted();
         }
-        await configureWorkspaceGitAuthor(
-          directory,
-          (args, options) => runGit(args, options?.cwd, options?.signal),
-          undefined,
-          signal
+      } catch {
+        return fail(
+          'not_ready',
+          signal.aborted ? 'Session attachment cancelled' : 'workspace restore failed',
+          true
         );
-        signal.throwIfAborted();
       }
-      for (const [index, command] of setupCommands.entries()) {
+    });
+    if (workspaceFailure) return workspaceFailure;
+
+    const kiloSessionId = attach.snapshotIdentity ?? session.kiloSessionId;
+    const restore = deps.restoreSession ?? restoreSession;
+    const sessionExists =
+      deps.sessionExists ??
+      ((id, directory, signal) => defaultSessionExists(kiloClient, id, directory, signal));
+    try {
+      signal.throwIfAborted();
+      progress.start('kilo_session', 'phase:kilo_session', 'Starting session…');
+      await seedSessionIngestRegistration(session.kiloSessionId, env, signal);
+      signal.throwIfAborted();
+      const exists = await withKiloRequestDeadline(
+        probeSignal => sessionExists(kiloSessionId, directory, probeSignal),
+        signal
+      );
+      signal.throwIfAborted();
+      if (!exists) {
+        progress.progress('kilo_session', 'phase:kilo_session', 'Restoring session…');
+        const restored = await restore(kiloSessionId, directory, undefined, { env, signal });
         signal.throwIfAborted();
-        const stepId = `setup_command:${index}`;
-        const safeCommand = redact(command);
-        progress.start('setup_commands', stepId, `Running setup command ${index + 1}`, {
-          kind: 'setup_command',
-          label: `Setup command ${index + 1}`,
-          command: safeCommand,
-          commandIndex: index,
-          commandCount: setupCommands.length,
-        });
-        const output = createOutputRedactor(
-          text => redact(stripAnsi(text)),
-          text => {
-            if (signal.aborted) return;
-            const cleaned = text.trim();
-            if (cleaned) progress.output(stepId, `${cleaned}\n`);
+        if (!restored.ok) {
+          if (restored.code !== 404 && !restored.emptySnapshot) {
+            progress.fail('kilo_session', 'phase:kilo_session', restored.error);
+            return fail('not_ready', 'kilo session is not ready', true);
           }
-        );
-        const result = await runSetup(command, directory, attach.env, output.onOutput, signal);
-        signal.throwIfAborted();
-        output.flush();
-        if (result.exitCode !== 0) {
-          const safeError = `Setup command ${index + 1} ${isTimeoutTermination(result) ? 'timed out' : 'failed'}`;
-          progress.fail('setup_commands', stepId, safeError);
-          return fail('not_ready', safeError, true);
+          progress.progress('kilo_session', 'phase:kilo_session', 'Starting session…');
+          await withKiloRequestDeadline(
+            probeSignal => kiloClient.ensureSession(kiloSessionId, directory, probeSignal),
+            signal
+          );
         }
-        progress.complete('setup_commands', stepId);
       }
       signal.throwIfAborted();
-      await writeBootstrapMarker(directory);
-      signal.throwIfAborted();
+      progress.complete('kilo_session', 'phase:kilo_session');
+    } catch {
+      const message = signal.aborted ? 'Session attachment cancelled' : 'kilo session is not ready';
+      progress.fail('kilo_session', 'phase:kilo_session', message);
+      return fail('not_ready', message, true);
     }
-  } catch {
+    signal.throwIfAborted();
+    const alreadyAttached = rootForSession(session.kiloSessionId) === session.kiloSessionId;
+    rememberAttachedRoot(session.kiloSessionId, directory);
+    try {
+      if (kiloSessionId === session.kiloSessionId)
+        deps.terminalRuntime?.rememberAttachedSession(session);
+      attachment.commit();
+    } catch (error) {
+      if (!alreadyAttached) forgetAttachedRoot(session.kiloSessionId, directory);
+      throw error;
+    }
+    logToFile(`session.attach ready directory=${directory}`);
+    return ok();
+  } catch (error) {
+    if (error instanceof WorktreeKiloRuntimeError || error instanceof ControlTerminalRuntimeError) {
+      return fail(error.code, error.message, error.retryable);
+    }
     return fail(
       'not_ready',
-      signal.aborted ? 'Session attachment cancelled' : 'workspace restore failed',
+      taskSignal.aborted ? 'Session attachment cancelled' : 'Session attachment failed',
       true
     );
+  } finally {
+    attachment?.release();
   }
-
-  const kiloSessionId = attach.snapshotIdentity ?? session.kiloSessionId;
-  const restore = deps.restoreSession ?? restoreSession;
-  const sessionExists =
-    deps.sessionExists ??
-    ((id, directory, signal) => defaultSessionExists(kiloClient, id, directory, signal));
-  try {
-    signal.throwIfAborted();
-    progress.start('kilo_session', 'phase:kilo_session', 'Starting session…');
-    const exists = await withKiloRequestDeadline(
-      probeSignal => sessionExists(kiloSessionId, directory, probeSignal),
-      signal
-    );
-    signal.throwIfAborted();
-    if (!exists) {
-      progress.progress('kilo_session', 'phase:kilo_session', 'Restoring session…');
-      const restored = await restore(kiloSessionId, directory, undefined, { signal });
-      signal.throwIfAborted();
-      if (!restored.ok) {
-        if (restored.code !== 404 && !restored.emptySnapshot) {
-          progress.fail('kilo_session', 'phase:kilo_session', restored.error);
-          return fail('not_ready', 'kilo session is not ready', true);
-        }
-        progress.progress('kilo_session', 'phase:kilo_session', 'Starting session…');
-        await withKiloRequestDeadline(
-          probeSignal => kiloClient.ensureSession(kiloSessionId, directory, probeSignal),
-          signal
-        );
-      }
-    }
-    signal.throwIfAborted();
-    progress.complete('kilo_session', 'phase:kilo_session');
-  } catch {
-    const message = signal.aborted ? 'Session attachment cancelled' : 'kilo session is not ready';
-    progress.fail('kilo_session', 'phase:kilo_session', message);
-    return fail('not_ready', message, true);
-  }
-  rememberSessionDirectory(session.kiloSessionId, directory);
-  rememberAttachedRoot(session.kiloSessionId, directory);
-  logToFile(`session.attach ready directory=${directory}`);
-  return ok();
 }

--- a/services/cloud-agent-next/wrapper/src/control/feed.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/feed.test.ts
@@ -205,14 +205,40 @@ describe('session event identity', () => {
     });
   });
 
-  it('uses a known directory root without inventing an event root', () => {
+  it('does not attribute an unknown session to another root in the same directory', () => {
     rememberAttachedRoot('root', '/ws');
 
     expect(sessionEventIdentity({ sessionId: 'unknown', directory: '/ws' })).toEqual({
       directory: '/ws',
       kiloSessionId: 'unknown',
-      rootKiloSessionId: 'root',
     });
+  });
+
+  it('keeps same-worktree root and child events distinct without guessing a directory-only owner', () => {
+    rememberAttachedRoot('first', '/ws');
+    rememberAttachedRoot('second', '/ws');
+    const root = childFromSessionCreated({ info: { id: 'first', directory: '/ws' } });
+    expect(root).toBeUndefined();
+    if (root) rememberChildSession(root);
+    const child = childFromSessionCreated({ info: { id: 'child', parentID: 'first' } });
+    if (child) rememberChildSession(child);
+
+    expect(sessionEventIdentity({ sessionId: 'first', directory: '/ws' })).toEqual({
+      directory: '/ws',
+      kiloSessionId: 'first',
+      rootKiloSessionId: 'first',
+    });
+    expect(sessionEventIdentity({ sessionId: 'second', directory: '/ws' })).toEqual({
+      directory: '/ws',
+      kiloSessionId: 'second',
+      rootKiloSessionId: 'second',
+    });
+    expect(sessionEventIdentity({ sessionId: 'child' })).toEqual({
+      directory: '/ws',
+      kiloSessionId: 'child',
+      rootKiloSessionId: 'first',
+    });
+    expect(sessionEventIdentity({ directory: '/ws' })).toEqual({ directory: '/ws' });
   });
 
   it('returns no identity when neither session nor directory is known', () => {

--- a/services/cloud-agent-next/wrapper/src/control/feed.ts
+++ b/services/cloud-agent-next/wrapper/src/control/feed.ts
@@ -20,11 +20,16 @@ export function eventKiloSessionId(properties: Record<string, unknown>): string 
 
 export function childFromSessionCreated(
   properties: Record<string, unknown>
-): { childId: string; parentId?: string; directory?: string } | undefined {
-  if (!isRecord(properties.info) || typeof properties.info.id !== 'string') return undefined;
+): { childId: string; parentId: string; directory?: string } | undefined {
+  if (
+    !isRecord(properties.info) ||
+    typeof properties.info.id !== 'string' ||
+    typeof properties.info.parentID !== 'string'
+  )
+    return undefined;
   return {
     childId: properties.info.id,
-    ...(typeof properties.info.parentID === 'string' ? { parentId: properties.info.parentID } : {}),
+    parentId: properties.info.parentID,
     ...(typeof properties.info.directory === 'string'
       ? { directory: properties.info.directory }
       : {}),

--- a/services/cloud-agent-next/wrapper/src/control/main.ts
+++ b/services/cloud-agent-next/wrapper/src/control/main.ts
@@ -1,15 +1,8 @@
-import fs from 'node:fs';
-import os from 'node:os';
-import path from 'node:path';
-import { createKilo } from '@kilocode/sdk';
-import { CONTROL_PLANE_SANDBOX_PERMISSION } from '../../../src/shared/control-plane-permission.js';
 import { WRAPPER_VERSION } from '../../../src/shared/wrapper-version.js';
-import { createWrapperKiloClient } from '../kilo-api.js';
 import { logToFile } from '../utils.js';
 import {
   KILO_CONTROL_REQUEST_TIMEOUT_MS,
   maybeStartSandboxControlClient,
-  startSandboxControlEventFeed,
 } from './sandbox-control-runtime';
 import {
   buildHeartbeatPayload,
@@ -21,26 +14,13 @@ import {
   childFromSessionCreated,
   eventKiloSessionId,
   sessionEventIdentity,
-  unfilteredKiloEvents,
   updateSessionSnapshots,
 } from './feed';
 import { rememberChildSession } from './session-directories';
 import { createControlTerminalRuntime } from './terminal-runtime';
+import { createWorktreeKiloRuntimes } from './worktree-runtime';
 
-const KILO_STARTUP_TIMEOUT_MS = 30_000;
-
-function writeKiloAuthFromEnv(): void {
-  const content = process.env.KILO_AUTH_CONTENT;
-  const token = process.env.KILOCODE_TOKEN;
-  const auth =
-    content ?? (token ? JSON.stringify({ kilo: { type: 'api', key: token } }) : undefined);
-  if (!auth) return;
-  const dir = path.join(os.homedir(), '.local', 'share', 'kilo');
-  fs.mkdirSync(dir, { recursive: true });
-  fs.writeFileSync(path.join(dir, 'auth.json'), auth, { mode: 0o600 });
-}
-
-async function main(): Promise<void> {
+function main(): void {
   const controlConfig = {
     SANDBOX_CONTROL_URL: process.env.SANDBOX_CONTROL_URL,
     SANDBOX_CONTROL_CREDENTIAL: process.env.SANDBOX_CONTROL_CREDENTIAL,
@@ -50,36 +30,45 @@ async function main(): Promise<void> {
   delete process.env.SANDBOX_CONTROL_CREDENTIAL;
 
   logToFile(`control-plane wrapper ${WRAPPER_VERSION} starting`);
-  writeKiloAuthFromEnv();
-
-  const result = await createKilo({
-    hostname: '127.0.0.1',
-    port: 0,
-    timeout: KILO_STARTUP_TIMEOUT_MS,
-    config: {
-      autoupdate: false,
-      permission: CONTROL_PLANE_SANDBOX_PERMISSION,
+  const abort = new AbortController();
+  let control: ReturnType<typeof maybeStartSandboxControlClient> = null;
+  let shuttingDown = false;
+  const kiloRuntimes = createWorktreeKiloRuntimes({
+    onEvent: (_runtime, event) => {
+      if (event.type === 'session.created') {
+        const child = childFromSessionCreated(event.properties);
+        if (child) rememberChildSession(child);
+      }
+      updateSessionSnapshots(event, deps.sessions);
+      const identity = sessionEventIdentity({
+        sessionId: eventKiloSessionId(event.properties),
+        directory: event.directory,
+      });
+      if (!identity?.rootKiloSessionId) return;
+      if (
+        !control?.sendEvent?.(
+          'session.event',
+          { type: event.type, properties: event.properties },
+          identity
+        )
+      ) {
+        throw new Error('Sandbox control event delivery failed');
+      }
     },
+    onUnexpectedClose: () => shutdown(1, 'Kilo event feed is no longer healthy'),
   });
-  const kiloClient = createWrapperKiloClient(result.client, result.server.url, '/');
   const terminalRuntime = controlConfig.SANDBOX_CONTROL_URL
     ? createControlTerminalRuntime({
         controlUrl: controlConfig.SANDBOX_CONTROL_URL,
         wrapperInstanceId: controlConfig.wrapperInstanceId,
-        kiloClient,
+        getKiloRuntime: directory => kiloRuntimes.get(directory),
       })
     : undefined;
-  logToFile(`kilo server started at ${result.server.url}`);
-
-  const abort = new AbortController();
-  let control: ReturnType<typeof maybeStartSandboxControlClient> = null;
-  let feed: Awaited<ReturnType<typeof startSandboxControlEventFeed>> | undefined;
-  let shuttingDown = false;
   const deps: HandlerDeps = {
-    kiloClient,
+    kiloRuntimes,
     version: WRAPPER_VERSION,
     get kiloReady() {
-      return !shuttingDown && feed?.isFresh() === true;
+      return !shuttingDown && kiloRuntimes.isHealthy();
     },
     sessions: [],
     tasks: new Map(),
@@ -110,7 +99,7 @@ async function main(): Promise<void> {
     terminalRuntime?.shutdown();
     const finish = (): void => {
       control?.close();
-      result.server.close();
+      kiloRuntimes.shutdown();
       process.exit(exitCode);
     };
     const deadline = setTimeout(finish, KILO_CONTROL_REQUEST_TIMEOUT_MS);
@@ -121,42 +110,6 @@ async function main(): Promise<void> {
   }
   process.once('SIGTERM', () => shutdown(0, 'Wrapper received SIGTERM'));
   process.once('SIGINT', () => shutdown(0, 'Wrapper received SIGINT'));
-
-  try {
-    feed = await startSandboxControlEventFeed({
-      signal: abort.signal,
-      open: signal => result.client.global.event({ signal, sseMaxRetryAttempts: 1 }),
-      consume: async stream => {
-        for await (const event of unfilteredKiloEvents(stream)) {
-          if (event.type === 'session.created') {
-            const child = childFromSessionCreated(event.properties);
-            if (child) rememberChildSession(child);
-          }
-          updateSessionSnapshots(event, deps.sessions);
-          const kiloSessionId = eventKiloSessionId(event.properties);
-          const identity = sessionEventIdentity({
-            sessionId: kiloSessionId,
-            directory: event.directory,
-          });
-          if (!identity?.rootKiloSessionId) continue;
-          if (
-            !control?.sendEvent?.(
-              'session.event',
-              { type: event.type, properties: event.properties },
-              identity
-            )
-          ) {
-            throw new Error('Sandbox control event delivery failed');
-          }
-        }
-      },
-      onUnexpectedClose: () => shutdown(1, 'Kilo event feed is no longer healthy'),
-    });
-  } catch {
-    shutdown(1, 'Kilo event feed failed to start');
-    return;
-  }
-  if (shuttingDown) return;
 
   control = maybeStartSandboxControlClient(controlConfig, logToFile, {
     wrapperVersion: WRAPPER_VERSION,
@@ -184,7 +137,9 @@ async function main(): Promise<void> {
   logToFile(`control-plane wrapper ready callHome=${Boolean(control)}`);
 }
 
-main().catch(() => {
+try {
+  main();
+} catch {
   logToFile('control-plane wrapper failed');
   process.exit(1);
-});
+}

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -1,7 +1,7 @@
-import fs from 'node:fs/promises';
+import { afterEach, beforeEach, describe, expect, it, setSystemTime, spyOn } from 'bun:test';
+import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
-import { afterEach, describe, expect, it, setSystemTime, spyOn } from 'bun:test';
 import { createKiloClient } from '@kilocode/sdk';
 import {
   SANDBOX_CONTROL_ATTACH_TIMEOUT_MS,
@@ -27,7 +27,17 @@ import {
   type HandlerDeps,
 } from './sandbox-control-handlers';
 import { KILO_CONTROL_REQUEST_TIMEOUT_MS } from './sandbox-control-runtime';
-import { ControlTerminalRuntimeError, type ControlTerminalRuntime } from './terminal-runtime';
+import {
+  ControlTerminalRuntimeError,
+  createControlTerminalRuntime,
+  type ControlTerminalRuntime,
+} from './terminal-runtime';
+import { directoryForSession, rootForSession } from './session-directories';
+import {
+  buildWorktreeKiloEnvironment,
+  type WorktreeKiloAuth,
+  type WorktreeKiloRuntime,
+} from './worktree-runtime';
 
 const session = {
   sessionId: 'ses_1',
@@ -78,9 +88,54 @@ function fakeKilo(overrides: Partial<WrapperKiloClient> = {}): WrapperKiloClient
   } as WrapperKiloClient;
 }
 
-function deps(overrides: Partial<HandlerDeps> = {}): HandlerDeps {
+const kilo: WorktreeKiloAuth = {
+  scopeId: 'worktree_1',
+  token: 'guest-kilo-token',
+  targets: {
+    backendBaseUrl: 'https://backend.example.test',
+    providerBaseUrl: 'https://provider.example.test',
+    sessionIngestBaseUrl: 'https://ingest.example.test',
+  },
+};
+
+let homeRoot: string;
+
+function deps(
+  overrides: Partial<HandlerDeps> & { kiloClient?: WrapperKiloClient } = {},
+  identity = session
+): HandlerDeps {
+  const { kiloClient, ...rest } = overrides;
+  const client = Object.hasOwn(overrides, 'kiloClient') ? kiloClient : fakeKilo();
+  const runtime: WorktreeKiloRuntime | undefined = client
+    ? {
+        scopeId: kilo.scopeId,
+        directory: identity.directory,
+        env: buildWorktreeKiloEnvironment(
+          identity.directory,
+          fs.mkdtempSync(path.join(homeRoot, 'worktree-')),
+          kilo,
+          {},
+          {}
+        ),
+        kiloClient: client,
+        signal: new AbortController().signal,
+      }
+    : undefined;
   return {
-    kiloClient: fakeKilo(),
+    kiloRuntimes: runtime
+      ? {
+          attach: () => ({
+            ready: Promise.resolve(runtime),
+            signal: runtime.signal,
+            commit: () => {},
+            release: () => {},
+          }),
+          detach: () => true,
+          get: directory => (directory === runtime.directory ? runtime : undefined),
+          isHealthy: () => true,
+          shutdown: () => {},
+        }
+      : undefined,
     version: '2.4.0',
     kiloReady: true,
     sessions: [],
@@ -89,7 +144,7 @@ function deps(overrides: Partial<HandlerDeps> = {}): HandlerDeps {
     retireRuntime: () => {},
     applyAttach: (session, payload, deps) =>
       applySessionAttach(session, payload, { ...deps, sessionExists: async () => true }),
-    ...overrides,
+    ...rest,
   };
 }
 
@@ -126,9 +181,15 @@ const promptPayload = {
   agent: { mode: 'architect', model: 'kilo/example', variant: 'high' },
 } as const;
 
+beforeEach(() => {
+  resetSessionDirectoryState();
+  rememberAttachedRoot(session.kiloSessionId, session.directory);
+  homeRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'control-handlers-test-'));
+});
+
 afterEach(() => {
   setSystemTime();
-  resetSessionDirectoryState();
+  fs.rmSync(homeRoot, { recursive: true, force: true });
 });
 
 const pty: WrapperPty = {
@@ -217,8 +278,9 @@ describe('handleControlRequest', () => {
         commands.push(opts);
         return completion();
       },
-      sendPromptAsync: async opts => {
+      sendPrompt: async opts => {
         prompts.push(opts);
+        return completion();
       },
     });
 
@@ -291,8 +353,9 @@ describe('handleControlRequest', () => {
   it('rejects a missing prompt model before calling Kilo', async () => {
     const calls: unknown[] = [];
     const kiloClient = fakeKilo({
-      sendPromptAsync: async opts => {
+      sendPrompt: async opts => {
         calls.push(opts);
+        return completion();
       },
       sendCommand: async opts => {
         calls.push(opts);
@@ -336,7 +399,7 @@ describe('handleControlRequest', () => {
   });
 
   it('attaches by verifying the kilo session', async () => {
-    const result = await handleControlRequest('session.attach', session, {}, deps());
+    const result = await handleControlRequest('session.attach', session, { kilo }, deps());
     expect(result).toEqual({ ok: true, result: { attached: true } });
   });
 
@@ -346,7 +409,12 @@ describe('handleControlRequest', () => {
       rememberAttachedSession: identity => attached.push(identity),
     });
 
-    const request = handleControlRequest('session.attach', session, {}, deps({ terminalRuntime }));
+    const request = handleControlRequest(
+      'session.attach',
+      session,
+      { kilo },
+      deps({ terminalRuntime })
+    );
     expect(attached).toEqual([]);
 
     expect(await request).toEqual({ ok: true, result: { attached: true } });
@@ -355,7 +423,7 @@ describe('handleControlRequest', () => {
     const failed = await handleControlRequest(
       'session.attach',
       { ...session, sessionId: 'ses_missing', kiloSessionId: 'kilo_missing' },
-      {},
+      { kilo },
       deps({ kiloClient: undefined, terminalRuntime })
     );
     expect(failed.ok).toBe(false);
@@ -371,7 +439,7 @@ describe('handleControlRequest', () => {
     const result = await handleControlRequest(
       'session.attach',
       session,
-      { snapshotIdentity: 'kilo_other' },
+      { kilo, snapshotIdentity: 'kilo_other' },
       deps({ terminalRuntime })
     );
 
@@ -379,7 +447,7 @@ describe('handleControlRequest', () => {
     expect(attached).toEqual([]);
   });
 
-  it('keeps mismatched attachment directories ineligible without breaking chat attachment', async () => {
+  it('rejects attachment directories that do not match the request identity', async () => {
     const attached: unknown[] = [];
     const terminalRuntime = fakeTerminalRuntime({
       rememberAttachedSession: identity => attached.push(identity),
@@ -388,11 +456,14 @@ describe('handleControlRequest', () => {
     const result = await handleControlRequest(
       'session.attach',
       session,
-      { directory: '/workspace/different' },
+      { kilo, directory: '/workspace/different' },
       deps({ terminalRuntime })
     );
 
-    expect(result).toEqual({ ok: true, result: { attached: true } });
+    expect(result).toEqual({
+      ok: false,
+      error: { code: 'protocol_error', message: 'Attachment directory mismatch', retryable: false },
+    });
     expect(attached).toEqual([]);
   });
 
@@ -466,6 +537,461 @@ describe('handleControlRequest', () => {
     const result = await handleControlRequest('session.abort', session, {}, deps({ kiloClient }));
     expect(result).toEqual({ ok: true, result: { status: 'already_idle' } });
     expect(aborted).toEqual([]);
+  });
+
+  it('routes independent roots and their children through the matching worktree client', async () => {
+    const sibling = { ...session, sessionId: 'ses_2', kiloSessionId: 'kilo_2' };
+    const other = { sessionId: 'ses_3', kiloSessionId: 'kilo_3', directory: '/workspace/other' };
+    const child = { ...session, kiloSessionId: 'kilo_child' };
+    rememberAttachedRoot(sibling.kiloSessionId, sibling.directory);
+    rememberAttachedRoot(other.kiloSessionId, other.directory);
+    rememberChildSession({
+      childId: child.kiloSessionId,
+      parentId: session.kiloSessionId,
+      directory: session.directory,
+    });
+    const calls: Array<{ directory: string; operation: string; value: unknown }> = [];
+    const pendingCommands = new Map<
+      string,
+      { started: PromiseWithResolvers<void>; completion: PromiseWithResolvers<Completion> }
+    >();
+    const runtimes = new Map<string, WorktreeKiloRuntime>();
+    for (const directory of [session.directory, other.directory]) {
+      const record = (operation: string, value: unknown) => {
+        calls.push({ directory, operation, value });
+      };
+      const kiloClient = fakeKilo({
+        sendPrompt: async value => {
+          record('prompt', value);
+          return completion();
+        },
+        sendCommand: async value => {
+          record('command', value);
+          const pending = pendingCommands.get(value.messageId ?? '');
+          if (pending) {
+            pending.started.resolve();
+            return pending.completion.promise;
+          }
+          return completion();
+        },
+        abortSession: async value => {
+          record('abort', value);
+          return true;
+        },
+        answerPermission: async (...value) => {
+          record('permission', value);
+          return true;
+        },
+        answerQuestion: async (...value) => {
+          record('question', value);
+          return true;
+        },
+        rejectQuestion: async (...value) => {
+          record('reject', value);
+          return true;
+        },
+        getSessionStatuses: async () => {
+          record('status', undefined);
+          return {};
+        },
+        getPermissions: async () => {
+          record('permissions', undefined);
+          return [session, sibling, other, child].map(identity => ({
+            id: `permission_${identity.kiloSessionId}`,
+            sessionID: identity.kiloSessionId,
+            permission: 'bash',
+            patterns: [],
+            metadata: {},
+            always: [],
+          }));
+        },
+        getQuestions: async () => {
+          record('questions', undefined);
+          return [session, sibling, other, child].map(identity => ({
+            id: `question_${identity.kiloSessionId}`,
+            sessionID: identity.kiloSessionId,
+            questions: [],
+          }));
+        },
+      });
+      runtimes.set(directory, {
+        directory,
+        scopeId: directory,
+        env: buildWorktreeKiloEnvironment(
+          directory,
+          fs.mkdtempSync(path.join(homeRoot, 'worktree-')),
+          kilo,
+          {},
+          {}
+        ),
+        signal: new AbortController().signal,
+        kiloClient,
+      });
+    }
+    const handlerDeps = deps({
+      kiloRuntimes: {
+        attach: () => {
+          throw new Error('Unexpected startup');
+        },
+        detach: () => true,
+        get: directory => runtimes.get(directory),
+        isHealthy: () => true,
+        shutdown: () => {},
+      },
+    });
+
+    for (const identity of [session, sibling, other]) {
+      const start = calls.length;
+      const messageId = `msg_${identity.kiloSessionId}`;
+      const prompt = {
+        messageId,
+        turn: { type: 'prompt', prompt: 'hello' },
+        agent: { mode: 'code', model: 'model' },
+      };
+      expect(await handleControlRequest('session.prompt', identity, prompt, handlerDeps)).toEqual({
+        ok: true,
+        result: { messageId, status: 'accepted' },
+      });
+      await waitForTasks(handlerDeps);
+      const commandId = `command_${identity.kiloSessionId}`;
+      expect(
+        await handleControlRequest(
+          'session.prompt',
+          identity,
+          {
+            ...prompt,
+            messageId: commandId,
+            turn: { type: 'command', command: 'review', arguments: '--all' },
+          },
+          handlerDeps
+        )
+      ).toEqual({ ok: true, result: { messageId: commandId, status: 'accepted' } });
+      await waitForTasks(handlerDeps);
+      const owned = identity === session ? [identity, child] : [identity];
+      for (const asking of owned) {
+        expect(
+          await handleControlRequest(
+            'session.permission.resolve',
+            identity,
+            { permissionId: `permission_${asking.kiloSessionId}`, response: 'once' },
+            handlerDeps
+          )
+        ).toEqual({ ok: true, result: { success: true } });
+        expect(
+          await handleControlRequest(
+            'session.question.resolve',
+            identity,
+            {
+              action: 'answer',
+              questionId: `question_${asking.kiloSessionId}`,
+              answers: [['answer']],
+            },
+            handlerDeps
+          )
+        ).toEqual({ ok: true, result: { success: true } });
+        expect(
+          await handleControlRequest(
+            'session.question.resolve',
+            identity,
+            { action: 'reject', questionId: `question_${asking.kiloSessionId}` },
+            handlerDeps
+          )
+        ).toEqual({ ok: true, result: { success: true } });
+      }
+      expect(await handleControlRequest('session.abort', identity, {}, handlerDeps)).toEqual({
+        ok: true,
+        result: { status: 'already_idle' },
+      });
+      expect(await handleControlRequest('session.sync', identity, {}, handlerDeps)).toEqual({
+        ok: true,
+        result: {
+          status: { type: 'idle' },
+          questions: owned.map(asking => ({
+            id: `question_${asking.kiloSessionId}`,
+            sessionID: asking.kiloSessionId,
+            questions: [],
+          })),
+          permissions: owned.map(asking => ({
+            id: `permission_${asking.kiloSessionId}`,
+            sessionID: asking.kiloSessionId,
+            permission: 'bash',
+            patterns: [],
+            metadata: {},
+            always: [],
+          })),
+        },
+      });
+      expect(calls.slice(start).every(call => call.directory === identity.directory)).toBe(true);
+      expect(calls[start]?.value).toEqual({
+        sessionId: identity.kiloSessionId,
+        directory: identity.directory,
+        signal: expect.any(AbortSignal),
+        messageId,
+        prompt: 'hello',
+        agent: 'code',
+        model: { providerID: 'kilo', modelID: 'model' },
+      });
+      expect(calls[start + 1]?.value).toEqual({
+        sessionId: identity.kiloSessionId,
+        directory: identity.directory,
+        signal: expect.any(AbortSignal),
+        messageId: commandId,
+        command: 'review',
+        args: '--all',
+        agent: 'code',
+        model: { providerID: 'kilo', modelID: 'model' },
+      });
+      expect(calls.slice(start).map(call => call.operation)).toEqual([
+        'prompt',
+        'command',
+        ...owned.flatMap(() => [
+          'permissions',
+          'permission',
+          'questions',
+          'question',
+          'questions',
+          'reject',
+        ]),
+        'status',
+        'questions',
+        'permissions',
+      ]);
+      for (const asking of owned) {
+        expect(calls.slice(start)).toContainEqual({
+          directory: identity.directory,
+          operation: 'permission',
+          value: [
+            `permission_${asking.kiloSessionId}`,
+            'once',
+            undefined,
+            true,
+            asking.directory,
+            expect.any(AbortSignal),
+          ],
+        });
+        expect(calls.slice(start)).toContainEqual({
+          directory: identity.directory,
+          operation: 'question',
+          value: [
+            `question_${asking.kiloSessionId}`,
+            [['answer']],
+            asking.directory,
+            expect.any(AbortSignal),
+          ],
+        });
+        expect(calls.slice(start)).toContainEqual({
+          directory: identity.directory,
+          operation: 'reject',
+          value: [`question_${asking.kiloSessionId}`, asking.directory, expect.any(AbortSignal)],
+        });
+      }
+      const cancellingId = `cancel_${identity.kiloSessionId}`;
+      const pending = {
+        started: Promise.withResolvers<void>(),
+        completion: Promise.withResolvers<Completion>(),
+      };
+      pendingCommands.set(cancellingId, pending);
+      try {
+        expect(
+          await handleControlRequest(
+            'session.prompt',
+            identity,
+            {
+              ...prompt,
+              messageId: cancellingId,
+              turn: { type: 'command', command: 'review', arguments: '--all' },
+            },
+            handlerDeps
+          )
+        ).toEqual({ ok: true, result: { messageId: cancellingId, status: 'accepted' } });
+        await pending.started.promise;
+        expect(
+          await handleControlRequest(
+            'session.abort',
+            identity,
+            { messageId: cancellingId },
+            handlerDeps
+          )
+        ).toEqual({
+          ok: true,
+          result: { status: 'aborted' },
+        });
+        expect(calls.at(-1)).toEqual({
+          directory: identity.directory,
+          operation: 'abort',
+          value: {
+            sessionId: identity.kiloSessionId,
+            directory: identity.directory,
+            signal: expect.any(AbortSignal),
+          },
+        });
+        expect(handlerDeps.tasks.has(identity.kiloSessionId)).toBe(false);
+      } finally {
+        pending.completion.resolve(completion());
+        await waitForTasks(handlerDeps);
+        pendingCommands.delete(cancellingId);
+      }
+    }
+
+    const before = calls.length;
+    expect(
+      (await handleControlRequest('session.prompt', child, promptPayload, handlerDeps)).ok
+    ).toBe(false);
+    const wrongDirectory = await handleControlRequest(
+      'session.prompt',
+      { ...session, directory: other.directory },
+      promptPayload,
+      handlerDeps
+    );
+    expect(wrongDirectory.ok).toBe(false);
+    expect(calls).toHaveLength(before);
+  });
+
+  it('detaches a root without stopping its worktree runtime or sibling roots', async () => {
+    const sibling = { ...session, sessionId: 'ses_sibling', kiloSessionId: 'kilo_sibling' };
+    rememberAttachedRoot(sibling.kiloSessionId, sibling.directory);
+    const started = Promise.withResolvers<void>();
+    const running = Promise.withResolvers<Completion>();
+    const events: SessionEventPayload[] = [];
+    const aborted: string[] = [];
+    const handlerDeps = deps({
+      kiloClient: fakeKilo({
+        sendPrompt: () => {
+          started.resolve();
+          return running.promise;
+        },
+        abortSession: async options => {
+          aborted.push(options.sessionId);
+          return true;
+        },
+      }),
+      emitSessionEvent: (_identity, event) => events.push(event),
+    });
+    let shutdowns = 0;
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Expected worktree runtime');
+    runtimes.shutdown = () => {
+      shutdowns += 1;
+    };
+    const runtime = runtimes.get(session.directory);
+    expect(
+      await handleControlRequest('session.prompt', sibling, promptPayload, handlerDeps)
+    ).toEqual({
+      ok: true,
+      result: { messageId: promptPayload.messageId, status: 'accepted' },
+    });
+    await started.promise;
+    expect(await handleControlRequest('session.detach', session, {}, handlerDeps)).toEqual({
+      ok: true,
+      result: { detached: true },
+    });
+    expect(shutdowns).toBe(0);
+    expect(runtimes.get(session.directory)).toBe(runtime);
+    expect(handlerDeps.tasks.get(sibling.kiloSessionId)?.signal.aborted).toBe(false);
+    expect(events).toEqual([]);
+    expect(await handleControlRequest('session.abort', sibling, {}, handlerDeps)).toEqual({
+      ok: true,
+      result: { status: 'aborted' },
+    });
+    expect(aborted).toEqual([sibling.kiloSessionId]);
+    expect(events).toEqual([
+      {
+        type: 'session.message.outcome',
+        properties: {
+          messageId: promptPayload.messageId,
+          status: 'cancelled',
+          reason: 'Session aborted',
+        },
+      },
+    ]);
+    running.resolve(completion());
+    expect(
+      (await handleControlRequest('session.prompt', session, promptPayload, handlerDeps)).ok
+    ).toBe(false);
+    await handleControlRequest('sandbox.shutdown', undefined, {}, handlerDeps);
+    expect(shutdowns).toBe(1);
+  });
+
+  it('preserves reattached routing and terminal state after delayed detach cleanup', async () => {
+    const deleting = Promise.withResolvers<void>();
+    const releaseDelete = Promise.withResolvers<void>();
+    let created = 0;
+    const handlerDeps = deps({
+      kiloClient: fakeKilo({
+        createPty: async () => ({ ...pty, id: `pty_${++created}` }),
+        deletePty: async id => {
+          if (id === 'pty_1') {
+            deleting.resolve();
+            await releaseDelete.promise;
+          }
+          return true;
+        },
+      }),
+    });
+    const runtimes = handlerDeps.kiloRuntimes;
+    if (!runtimes) throw new Error('Expected worktree runtimes');
+    const terminalRuntime = createControlTerminalRuntime({
+      controlUrl: 'ws://127.0.0.1:1/sandbox-control/test',
+      wrapperInstanceId: crypto.randomUUID(),
+      getKiloRuntime: directory => runtimes.get(directory),
+    });
+    handlerDeps.terminalRuntime = terminalRuntime;
+    const sibling = { ...session, sessionId: 'ses_sibling', kiloSessionId: 'kilo_sibling' };
+    const operationId = crypto.randomUUID();
+    let detachRequest: ReturnType<typeof handleControlRequest> | undefined;
+    try {
+      expect(
+        (await handleControlRequest('session.attach', session, { kilo }, handlerDeps)).ok
+      ).toBe(true);
+      expect(
+        (await handleControlRequest('session.attach', sibling, { kilo }, handlerDeps)).ok
+      ).toBe(true);
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            session,
+            { operationId },
+            handlerDeps
+          )
+        ).ok
+      ).toBe(true);
+
+      detachRequest = handleControlRequest('session.detach', session, {}, handlerDeps);
+      await deleting.promise;
+      expect(rootForSession(session.kiloSessionId)).toBeUndefined();
+      expect(directoryForSession(session.kiloSessionId)).toBeUndefined();
+      expect(handlerDeps.sessions).toEqual([
+        { kiloSessionId: sibling.kiloSessionId, lastActivityAt: expect.any(Number) },
+      ]);
+      expect(rootForSession(sibling.kiloSessionId)).toBe(sibling.kiloSessionId);
+      expect(
+        (await handleControlRequest('session.attach', session, { kilo }, handlerDeps)).ok
+      ).toBe(true);
+
+      const replacement = await handleControlRequest(
+        'session.terminal.create',
+        session,
+        { operationId },
+        handlerDeps
+      );
+      expect(replacement).toMatchObject({ ok: true, result: { pty: { id: 'pty_2' } } });
+      releaseDelete.resolve();
+      expect(await detachRequest).toEqual({ ok: true, result: { detached: true } });
+      expect(rootForSession(session.kiloSessionId)).toBe(session.kiloSessionId);
+      expect(directoryForSession(session.kiloSessionId)).toBe(session.directory);
+      expect(handlerDeps.sessions).toEqual([
+        { kiloSessionId: sibling.kiloSessionId, lastActivityAt: expect.any(Number) },
+        { kiloSessionId: session.kiloSessionId, lastActivityAt: expect.any(Number) },
+      ]);
+      expect(
+        await handleControlRequest('session.terminal.create', session, { operationId }, handlerDeps)
+      ).toEqual(replacement);
+    } finally {
+      releaseDelete.resolve();
+      await detachRequest;
+      terminalRuntime.shutdown();
+    }
   });
 
   it('routes validated terminal lifecycle requests to the exact session', async () => {
@@ -1203,31 +1729,38 @@ describe('control finalization and compact', () => {
   it.each([true, false])(
     'keeps bootstrap state out of auto-commit with repository edits=%s',
     async editRepository => {
-      const root = await fs.mkdtemp(path.join(os.tmpdir(), 'control-autocommit-'));
+      const root = fs.mkdtempSync(path.join(os.tmpdir(), 'control-autocommit-'));
       const source = path.join(root, 'source');
       const remote = path.join(root, 'remote.git');
       const workspace = path.join(root, 'workspace');
-      const identity = { ...session, directory: workspace };
+      const identity = {
+        sessionId: 'ses_autocommit',
+        kiloSessionId: 'kilo_autocommit',
+        directory: workspace,
+      };
       const events: SessionEventPayload[] = [];
       const git = async (args: string[], cwd = root): Promise<string> => {
         const result = await runProcess('git', args, { cwd });
         if (result.exitCode !== 0) throw new Error(`Fixture git ${args[0]} failed`);
         return result.stdout;
       };
-      const handlerDeps = deps({
-        kiloClient: fakeKilo({
-          sendPrompt: async () => {
-            if (editRepository)
-              await fs.writeFile(path.join(workspace, 'result.txt'), 'normal control turn');
-            return completion();
-          },
-        }),
-        emitSessionEvent: (_session, event) => events.push(event),
-      });
+      const handlerDeps = deps(
+        {
+          kiloClient: fakeKilo({
+            sendPrompt: async () => {
+              if (editRepository)
+                fs.writeFileSync(path.join(workspace, 'result.txt'), 'normal control turn');
+              return completion();
+            },
+          }),
+          emitSessionEvent: (_session, event) => events.push(event),
+        },
+        identity
+      );
       try {
         await git(['init', '--bare', remote]);
         await git(['init', '--initial-branch=work', source]);
-        await fs.writeFile(path.join(source, 'initial.txt'), 'initial');
+        fs.writeFileSync(path.join(source, 'initial.txt'), 'initial');
         await git(['add', '.'], source);
         await git(
           [
@@ -1248,7 +1781,7 @@ describe('control finalization and compact', () => {
           await handleControlRequest(
             'session.attach',
             identity,
-            { git: { url: remote } },
+            { kilo, git: { url: remote } },
             handlerDeps
           )
         ).toMatchObject({ ok: true });
@@ -1290,7 +1823,7 @@ describe('control finalization and compact', () => {
           properties: { messageId: 'msg_1', status: 'completed' },
         });
       } finally {
-        await fs.rm(root, { recursive: true, force: true });
+        fs.rmSync(root, { recursive: true, force: true });
       }
     }
   );
@@ -1619,7 +2152,7 @@ describe('control cancellation and attachments', () => {
       });
       const admission =
         phase === 'preparation'
-          ? handleControlRequest('session.attach', session, {}, handlerDeps)
+          ? handleControlRequest('session.attach', session, { kilo }, handlerDeps)
           : handleControlRequest(
               'session.prompt',
               session,
@@ -1649,12 +2182,6 @@ describe('control cancellation and attachments', () => {
     };
     let terminalStopped = false;
     const handlerDeps = deps({
-      kiloClient: fakeKilo({
-        sendCommand: opts => {
-          if (opts.signal) signals.push(opts.signal);
-          return running.promise;
-        },
-      }),
       applyAttach: (identity, payload, dependencies) =>
         applySessionAttach(identity, payload, {
           ...dependencies,
@@ -1675,14 +2202,44 @@ describe('control cancellation and attachments', () => {
         },
       }),
     });
-    const attaching = handleControlRequest('session.attach', session, {}, handlerDeps);
-    await preparing.promise;
-    await handleControlRequest(
-      'session.prompt',
-      secondSession,
-      { ...promptPayload, turn: { type: 'command', command: 'review', arguments: '' } },
-      handlerDeps
+    const runtimes = handlerDeps.kiloRuntimes;
+    const firstRuntime = runtimes?.get(session.directory);
+    if (!runtimes || !firstRuntime) throw new Error('Expected preparation runtime');
+    const secondDeps = deps(
+      {
+        kiloClient: fakeKilo({
+          sendCommand: opts => {
+            if (opts.signal) signals.push(opts.signal);
+            return running.promise;
+          },
+        }),
+      },
+      secondSession
     );
+    expect(
+      await handleControlRequest('session.attach', secondSession, { kilo }, secondDeps)
+    ).toEqual({
+      ok: true,
+      result: { attached: true },
+    });
+    const secondRuntime = secondDeps.kiloRuntimes?.get(secondSession.directory);
+    if (!secondRuntime) throw new Error('Expected execution runtime');
+    runtimes.get = directory =>
+      directory === session.directory
+        ? firstRuntime
+        : directory === secondSession.directory
+          ? secondRuntime
+          : undefined;
+    const attaching = handleControlRequest('session.attach', session, { kilo }, handlerDeps);
+    await preparing.promise;
+    expect(
+      await handleControlRequest(
+        'session.prompt',
+        secondSession,
+        { ...promptPayload, turn: { type: 'command', command: 'review', arguments: '' } },
+        handlerDeps
+      )
+    ).toEqual({ ok: true, result: { messageId: promptPayload.messageId, status: 'accepted' } });
     expect(handlerDeps.tasks.size).toBe(2);
     expect(await handleControlRequest('sandbox.shutdown', undefined, {}, handlerDeps)).toEqual({
       ok: true,
@@ -1692,7 +2249,9 @@ describe('control cancellation and attachments', () => {
     expect(signals).toHaveLength(2);
     expect(signals.every(signal => signal.aborted)).toBe(true);
     expect(terminalStopped).toBe(true);
-    expect(await handleControlRequest('session.attach', session, {}, handlerDeps)).toMatchObject({
+    expect(
+      await handleControlRequest('session.attach', session, { kilo }, handlerDeps)
+    ).toMatchObject({
       ok: false,
     });
     running.resolve(completion());
@@ -1730,7 +2289,7 @@ describe('control cancellation and attachments', () => {
       const attaching = handleControlRequest(
         'session.attach',
         session,
-        { setupCommands: ['setup'] },
+        { kilo, setupCommands: ['setup'] },
         handlerDeps
       );
       await started.promise;
@@ -1740,7 +2299,9 @@ describe('control cancellation and attachments', () => {
       if (typeof deadline !== 'function') throw new Error('missing attachment deadline');
       deadline();
       await cancelled.promise;
-      expect(await handleControlRequest('session.attach', session, {}, handlerDeps)).toMatchObject({
+      expect(
+        await handleControlRequest('session.attach', session, { kilo }, handlerDeps)
+      ).toMatchObject({
         ok: false,
       });
       expect(handlerDeps.tasks.size).toBe(1);
@@ -1750,7 +2311,9 @@ describe('control cancellation and attachments', () => {
       expect(handlerDeps.tasks.size).toBe(0);
       expect(retired).toEqual(['Session preparation timed out']);
       expect(buildHeartbeatPayload(handlerDeps).kilo.ready).toBe(false);
-      expect(await handleControlRequest('session.attach', session, {}, handlerDeps)).toMatchObject({
+      expect(
+        await handleControlRequest('session.attach', session, { kilo }, handlerDeps)
+      ).toMatchObject({
         ok: false,
       });
     } finally {
@@ -1792,6 +2355,7 @@ describe('control cancellation and attachments', () => {
         }),
     });
     const payload = {
+      kilo,
       setupCommands: ['first', 'second'],
       preparation: { attemptId: 'attempt_1', triggerMessageId: 'msg_1' },
     };
@@ -1812,14 +2376,18 @@ describe('control cancellation and attachments', () => {
       { messageId: 'msg_1' },
       handlerDeps
     );
-    expect(await handleControlRequest('session.attach', session, {}, handlerDeps)).toMatchObject({
+    expect(
+      await handleControlRequest('session.attach', session, { kilo }, handlerDeps)
+    ).toMatchObject({
       ok: false,
     });
     expect(await aborting).toMatchObject({ ok: true });
     expect(await attaching).toMatchObject({ ok: false });
     expect(quiesced).toBe(true);
     expect(calls).toEqual(['first']);
-    expect(await handleControlRequest('session.attach', session, {}, handlerDeps)).toMatchObject({
+    expect(
+      await handleControlRequest('session.attach', session, { kilo }, handlerDeps)
+    ).toMatchObject({
       ok: true,
     });
     expect(buildHeartbeatPayload(handlerDeps)).toMatchObject({ state: 'idle', pendingMessages: 0 });
@@ -1881,11 +2449,11 @@ describe('control cancellation and attachments', () => {
           ],
         }),
       ]);
-      expect(await fs.readFile(localPath, 'utf8')).toBe('image bytes');
+      expect(fs.readFileSync(localPath, 'utf8')).toBe('image bytes');
     } finally {
       download.resolve(new Response('image bytes'));
       await waitForTasks(handlerDeps);
-      await fs.rm(directory, { recursive: true, force: true });
+      fs.rmSync(directory, { recursive: true, force: true });
     }
   });
 
@@ -1945,7 +2513,7 @@ describe('control cancellation and attachments', () => {
         handlerDeps
       );
       await reading.promise;
-      expect((await fs.stat(localPath)).isFile()).toBe(true);
+      expect(fs.statSync(localPath).isFile()).toBe(true);
       expect(
         await handleControlRequest('session.abort', identity, { messageId: 'msg_1' }, handlerDeps)
       ).toMatchObject({ ok: true });
@@ -1953,13 +2521,17 @@ describe('control cancellation and attachments', () => {
       expect(prompts).toBe(0);
       expect(events[0]?.properties).toMatchObject({ messageId: 'msg_1', status: 'cancelled' });
       expect(
-        await fs.stat(localPath).then(
-          () => true,
-          () => false
-        )
+        (() => {
+          try {
+            fs.statSync(localPath);
+            return true;
+          } catch {
+            return false;
+          }
+        })()
       ).toBe(false);
     } finally {
-      await fs.rm(directory, { recursive: true, force: true });
+      fs.rmSync(directory, { recursive: true, force: true });
     }
   });
 
@@ -2201,7 +2773,9 @@ describe('control interactions and sync', () => {
       ok: true,
       result: { status: { type: 'busy' }, questions: [], permissions: [] },
     });
-    handlerDeps.kiloClient = fakeKilo({
+    const runtime = handlerDeps.kiloRuntimes?.get(session.directory);
+    if (!runtime) throw new Error('Expected worktree runtime');
+    (runtime as { kiloClient: WrapperKiloClient }).kiloClient = fakeKilo({
       getQuestions: async () => {
         throw new Error('HTTP 500');
       },

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.test.ts
@@ -11,7 +11,7 @@ import {
 } from '../../../src/shared/sandbox-control-protocol';
 import { createWrapperKiloClient, type WrapperKiloClient, type WrapperPty } from '../kilo-api';
 import { materializeMessageAttachments } from '../session-bootstrap';
-import { runProcess } from '../utils';
+import { runProcess, withTimeoutAndAbort } from '../utils';
 import { applySessionAttach } from './apply-attach';
 import { updateSessionSnapshots, unfilteredKiloEvents } from './feed';
 import {
@@ -2117,6 +2117,117 @@ describe('control finalization and compact', () => {
 });
 
 describe('control cancellation and attachments', () => {
+  it.each(['session.abort', 'session.detach'] as const)(
+    'cancels a queued sibling with %s without overtaking active preparation',
+    async operation => {
+      const sibling = { ...session, sessionId: 'ses_sibling', kiloSessionId: 'kilo_sibling' };
+      const next = { ...session, sessionId: 'ses_next', kiloSessionId: 'kilo_next' };
+      const started = Promise.withResolvers<AbortSignal>();
+      const siblingQueued = Promise.withResolvers<void>();
+      const nextQueued = Promise.withResolvers<void>();
+      const stopped = Promise.withResolvers<{ exitCode: number; stdout: string; stderr: string }>();
+      const setupCommands: string[] = [];
+      let markerWrites = 0;
+      let cancellationSettled = false;
+      const handlerDeps = deps({
+        emitPreparing: event => {
+          if (event.action !== 'attempt_started') return;
+          if (event.attemptId === 'sibling') siblingQueued.resolve();
+          if (event.attemptId === 'next') nextQueued.resolve();
+        },
+        applyAttach: (identity, payload, dependencies) =>
+          applySessionAttach(identity, payload, {
+            ...dependencies,
+            mkdir: async () => {},
+            hasBootstrapMarker: async () => false,
+            writeBootstrapMarker: async () => {
+              markerWrites += 1;
+            },
+            sessionExists: async () => true,
+            runSetup: async (command, _directory, _env, _output, signal) => {
+              setupCommands.push(command);
+              if (command === 'first') {
+                if (!signal) throw new Error('Expected preparation signal');
+                started.resolve(signal);
+                return stopped.promise;
+              }
+              return { exitCode: 0, stdout: '', stderr: '' };
+            },
+          }),
+      });
+      const attaching: ReturnType<typeof handleControlRequest>[] = [];
+      const attach = (identity: typeof session, command: string) => {
+        const request = handleControlRequest(
+          'session.attach',
+          identity,
+          {
+            kilo,
+            setupCommands: [command],
+            preparation: { attemptId: command, triggerMessageId: command },
+          },
+          handlerDeps
+        );
+        attaching.push(request);
+        return request;
+      };
+      const firstAttach = attach(session, 'first');
+      let cancellingFirst: ReturnType<typeof handleControlRequest> | undefined;
+      try {
+        const signal = await started.promise;
+        const siblingAttach = attach(sibling, 'sibling');
+        await siblingQueued.promise;
+        const cancelled = await withTimeoutAndAbort(
+          handleControlRequest(
+            operation,
+            sibling,
+            operation === 'session.abort' ? { messageId: 'sibling' } : {},
+            handlerDeps
+          ),
+          {
+            timeoutMs: 1_000,
+            timeoutMessage: 'Queued sibling cancellation waited for active preparation',
+            abortMessage: 'Test cancelled',
+          }
+        );
+        expect(cancelled).toMatchObject({ ok: true });
+        expect(await siblingAttach).toMatchObject({ ok: false });
+        expect(handlerDeps.tasks.has(sibling.kiloSessionId)).toBe(false);
+        expect(signal.aborted).toBe(false);
+        expect(buildHeartbeatPayload(handlerDeps).activeKiloSessions).toBe(1);
+
+        const nextAttach = attach(next, 'next');
+        await nextQueued.promise;
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(setupCommands).toEqual(['first']);
+        cancellingFirst = handleControlRequest(
+          'session.abort',
+          session,
+          { messageId: 'first' },
+          handlerDeps
+        ).then(result => {
+          cancellationSettled = true;
+          return result;
+        });
+        await new Promise<void>(resolve => setImmediate(resolve));
+        expect(signal.aborted).toBe(true);
+        expect(cancellationSettled).toBe(false);
+        expect(handlerDeps.tasks.has(session.kiloSessionId)).toBe(true);
+        expect(setupCommands).toEqual(['first']);
+
+        stopped.resolve({ exitCode: 0, stdout: '', stderr: '' });
+        expect(await cancellingFirst).toMatchObject({ ok: true });
+        expect(await firstAttach).toMatchObject({ ok: false });
+        expect(await nextAttach).toEqual({ ok: true, result: { attached: true } });
+        expect(setupCommands).toEqual(['first', 'next']);
+        expect(markerWrites).toBe(1);
+      } finally {
+        const cancelled = cancelControlTasks(handlerDeps, 'Test cleanup');
+        stopped.resolve({ exitCode: 0, stdout: '', stderr: '' });
+        await Promise.allSettled([...attaching, cancellingFirst, cancelled]);
+      }
+    }
+  );
+
   it.each(['preparation', 'execution'])(
     'cancels owned %s before detaching its terminal',
     async phase => {

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-handlers.ts
@@ -42,6 +42,11 @@ import {
 } from './session-directories';
 import { withKiloRequestDeadline } from './sandbox-control-runtime';
 import { ControlTerminalRuntimeError, type ControlTerminalRuntime } from './terminal-runtime.js';
+import {
+  WorktreeKiloRuntimeError,
+  type WorktreeKiloRuntime,
+  type WorktreeKiloRuntimes,
+} from './worktree-runtime.js';
 
 export type HandlerSessionSnapshot = {
   kiloSessionId: string;
@@ -61,7 +66,7 @@ export type OwnedSessionTask = TaskIdentity & {
 };
 
 export type HandlerDeps = {
-  kiloClient?: WrapperKiloClient;
+  kiloRuntimes?: WorktreeKiloRuntimes;
   version: string;
   kiloReady: boolean;
   sessions: HandlerSessionSnapshot[];
@@ -223,6 +228,7 @@ export async function handleControlRequest(
     deps.onShutdown?.();
     await cancelControlTasks(deps, 'Sandbox shutting down');
     deps.terminalRuntime?.shutdown();
+    deps.kiloRuntimes?.shutdown();
     return ok({ shuttingDown: true });
   }
   if (!SESSION_OPERATION_SET.has(operation)) {
@@ -308,8 +314,20 @@ function missingKilo(): ControlHandlerResult {
   return fail('not_ready', 'Kilo is not ready', true);
 }
 
+function sessionKiloRuntime(
+  session: SessionRequestIdentity,
+  deps: HandlerDeps
+): WorktreeKiloRuntime | undefined {
+  if (
+    directoryForSession(session.kiloSessionId) !== session.directory ||
+    rootForSession(session.kiloSessionId) !== session.kiloSessionId
+  )
+    return undefined;
+  return deps.kiloRuntimes?.get(session.directory);
+}
+
 function terminalFailure(error: unknown): ControlHandlerResult {
-  if (error instanceof ControlTerminalRuntimeError) {
+  if (error instanceof ControlTerminalRuntimeError || error instanceof WorktreeKiloRuntimeError) {
     return fail(error.code, error.message, error.retryable);
   }
   return fail('not_ready', 'Terminal request failed', isKiloServerUnreachableError(error));
@@ -339,24 +357,13 @@ async function handleAttach(
     deps,
     async owned => {
       const result = await (deps.applyAttach ?? applySessionAttach)(session, parsed.data, {
-        kiloClient: deps.kiloClient,
+        kiloRuntimes: deps.kiloRuntimes,
         signal: owned.signal,
+        ...(deps.terminalRuntime ? { terminalRuntime: deps.terminalRuntime } : {}),
         ...(deps.emitPreparing ? { emitPreparing: deps.emitPreparing } : {}),
       });
       if (owned.signal.aborted) {
         return fail('not_ready', 'Session attachment cancelled', true);
-      }
-      if (
-        result.ok &&
-        deps.terminalRuntime &&
-        (parsed.data.directory ?? session.directory) === session.directory &&
-        (parsed.data.snapshotIdentity ?? session.kiloSessionId) === session.kiloSessionId
-      ) {
-        try {
-          deps.terminalRuntime.rememberAttachedSession(session);
-        } catch (error) {
-          return terminalFailure(error);
-        }
       }
       return result;
     }
@@ -379,10 +386,12 @@ async function handleDetach(
     if (!result.ok && task.kind !== 'preparation') return result;
   }
   try {
-    await deps.terminalRuntime?.detachSession(session);
+    deps.kiloRuntimes?.detach(session);
+    const terminalCleanup = deps.terminalRuntime?.detachSession(session);
     forgetAttachedRoot(session.kiloSessionId, session.directory);
     const index = deps.sessions.findIndex(item => item.kiloSessionId === session.kiloSessionId);
     if (index !== -1) deps.sessions.splice(index, 1);
+    await terminalCleanup;
     return ok({ detached: true });
   } catch (error) {
     return terminalFailure(error);
@@ -442,8 +451,8 @@ function handlePrompt(
   payload: unknown,
   deps: HandlerDeps
 ): ControlHandlerResult {
-  const kiloClient = deps.kiloClient;
-  if (!kiloClient) return missingKilo();
+  const runtime = sessionKiloRuntime(session, deps);
+  if (!runtime) return missingKilo();
   const parsed = sessionPromptPayloadSchema.safeParse(payload);
   if (!parsed.success) return fail('protocol_error', 'Invalid payload', false);
   const request = parsed.data;
@@ -475,8 +484,14 @@ function handlePrompt(
     }
     return fail('not_ready', 'Session has work in progress', true);
   }
-  startSessionTask(session, { kind: 'execution', messageId: request.messageId }, deps, task =>
-    executePrompt(task, request, kiloClient, deps)
+  startSessionTask(
+    session,
+    { kind: 'execution', messageId: request.messageId },
+    {
+      ...deps,
+      signal: deps.signal ? AbortSignal.any([deps.signal, runtime.signal]) : runtime.signal,
+    },
+    task => executePrompt(task, request, runtime, deps)
   );
   return ok({ messageId: request.messageId, status: 'accepted' });
 }
@@ -537,10 +552,11 @@ async function summarizeOwnedSession(
 async function executePrompt(
   task: OwnedSessionTask,
   request: SessionPromptPayload,
-  kiloClient: WrapperKiloClient,
+  runtime: WorktreeKiloRuntime,
   deps: HandlerDeps
 ): Promise<ControlHandlerResult> {
   const { session, signal } = task;
+  const { kiloClient, env } = runtime;
   const { messageId, turn, agent } = request;
   let outcome: SessionMessageOutcome;
   let result = ok({});
@@ -617,6 +633,7 @@ async function executePrompt(
         const committed = await (deps.runAutoCommit ?? runAutoCommit)({
           workspacePath: session.directory,
           kiloClient,
+          env,
           messageId: completion?.info.id ?? messageId,
           signal,
           onEvent: event => emitFinalizationEvent(session, event, deps),
@@ -719,7 +736,7 @@ async function handlePermissionResolve(
   payload: unknown,
   deps: HandlerDeps
 ): Promise<ControlHandlerResult> {
-  const kiloClient = deps.kiloClient;
+  const kiloClient = sessionKiloRuntime(session, deps)?.kiloClient;
   if (!kiloClient) return missingKilo();
   const parsed = sessionPermissionResolvePayloadSchema.safeParse(payload);
   if (!parsed.success) return fail('protocol_error', 'Invalid payload', false);
@@ -755,7 +772,7 @@ async function handleQuestionResolve(
   payload: unknown,
   deps: HandlerDeps
 ): Promise<ControlHandlerResult> {
-  const kiloClient = deps.kiloClient;
+  const kiloClient = sessionKiloRuntime(session, deps)?.kiloClient;
   if (!kiloClient) return missingKilo();
   const parsed = sessionQuestionResolvePayloadSchema.safeParse(payload);
   if (!parsed.success) return fail('protocol_error', 'Invalid payload', false);
@@ -791,7 +808,7 @@ async function handleSync(
   payload: unknown,
   deps: HandlerDeps
 ): Promise<ControlHandlerResult> {
-  const kiloClient = deps.kiloClient;
+  const kiloClient = sessionKiloRuntime(session, deps)?.kiloClient;
   if (!kiloClient) return missingKilo();
   if (!sessionSyncPayloadSchema.safeParse(payload).success) {
     return fail('protocol_error', 'Invalid payload', false);

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.test.ts
@@ -352,6 +352,35 @@ describe('startSandboxControlEventFeed', () => {
     expect(failures).toEqual([]);
   });
 
+  it('returns the underlying iterator when a worktree stops consuming its feed', async () => {
+    const abort = new AbortController();
+    let closed = false;
+    const failures: unknown[] = [];
+    async function* stream(): AsyncGenerator<unknown> {
+      try {
+        yield { payload: { type: 'server.connected' } };
+        yield { payload: { type: 'session.created' } };
+      } finally {
+        closed = true;
+      }
+    }
+    await startSandboxControlEventFeed({
+      signal: abort.signal,
+      open: async () => ({ stream: stream() }),
+      consume: async events => {
+        for await (const event of events) {
+          expect(event).toEqual({ payload: { type: 'server.connected' } });
+          abort.abort();
+          break;
+        }
+      },
+      onUnexpectedClose: error => failures.push(error),
+    });
+    await new Promise<void>(resolve => setTimeout(resolve, 0));
+    expect(closed).toBe(true);
+    expect(failures).toEqual([]);
+  });
+
   it('rejects when the global feed subscription fails', async () => {
     const abort = new AbortController();
     let consumed = false;

--- a/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/sandbox-control-runtime.ts
@@ -117,15 +117,19 @@ export async function startSandboxControlEventFeed(
   signal.addEventListener('abort', () => clearInterval(freshnessTimer), { once: true });
 
   async function* establishedFeed(): AsyncGenerator<unknown> {
-    yield first.value;
-    while (!signal.aborted) {
-      const next = await iterator.next();
-      if (signal.aborted || next.done) return;
-      if (isFeedConnectedEvent(next.value)) {
-        throw new Error('Kilo global event feed reconnected with a delivery gap');
+    try {
+      yield first.value;
+      while (!signal.aborted) {
+        const next = await iterator.next();
+        if (signal.aborted || next.done) return;
+        if (isFeedConnectedEvent(next.value)) {
+          throw new Error('Kilo global event feed reconnected with a delivery gap');
+        }
+        lastEventAt = now();
+        yield next.value;
       }
-      lastEventAt = now();
-      yield next.value;
+    } finally {
+      await iterator.return?.();
     }
   }
 

--- a/services/cloud-agent-next/wrapper/src/control/session-directories.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-directories.test.ts
@@ -43,12 +43,16 @@ describe('session directory root mappings', () => {
     expect(rootForSession('unknown')).toBeUndefined();
   });
 
-  it('falls back to the attached directory for an unknown child', () => {
+  it('does not infer an unknown session or child root from its directory', () => {
     rememberAttachedRoot('root', '/ws');
 
     rememberChildSession({ childId: 'unknown', directory: '/ws' });
+    rememberChildSession({ childId: 'child', parentId: 'unattached-root', directory: '/ws' });
 
-    expect(rootForSession('unknown', '/ws')).toBe('root');
+    expect(rootForSession('unknown', '/ws')).toBeUndefined();
+    expect(rootForSession('child', '/ws')).toBeUndefined();
+    expect(directoryForSession('unknown')).toBeUndefined();
+    expect(directoryForSession('child')).toBeUndefined();
   });
 
   it('records children synchronously', () => {
@@ -56,6 +60,7 @@ describe('session directory root mappings', () => {
 
     expect(rememberChildSession({ childId: 'c1', parentId: 'root' })).toBeUndefined();
     expect(rootForSession('c1')).toBe('root');
+    expect(directoryForSession('c1')).toBe('/ws');
   });
 
   it('forgets only the detached root and its child sessions', () => {
@@ -74,6 +79,44 @@ describe('session directory root mappings', () => {
     expect(rootForSession('second')).toBe('second');
     expect(rootForSession('second-child')).toBe('second');
     expect(directoryForSession('second-child')).toBe('/second');
+  });
+
+  it('keeps multiple roots and nested children independent in the same worktree', () => {
+    rememberAttachedRoot('first', '/ws');
+    rememberChildSession({ childId: 'first-child', parentId: 'first' });
+    rememberAttachedRoot('second', '/ws');
+    rememberChildSession({ childId: 'second-child', parentId: 'second' });
+    rememberChildSession({ childId: 'first-grandchild', parentId: 'first-child' });
+    rememberAttachedRoot('first', '/ws');
+
+    expect(rootForSession('first', '/ws')).toBe('first');
+    expect(rootForSession('second', '/ws')).toBe('second');
+    expect(rootForSession('first-grandchild', '/ws')).toBe('first');
+    expect(directoryForSession('first-grandchild')).toBe('/ws');
+    expect(rootForSession(undefined, '/ws')).toBeUndefined();
+
+    forgetAttachedRoot('second', '/ws');
+    expect(rootForSession(undefined, '/ws')).toBe('first');
+    expect(rootForSession('second', '/ws')).toBeUndefined();
+    expect(rootForSession('second-child', '/ws')).toBeUndefined();
+    expect(rootForSession('first-grandchild')).toBe('first');
+    expect(directoryForSession('first-grandchild')).toBe('/ws');
+
+    forgetAttachedRoot('first', '/ws');
+    expect(rootForSession(undefined, '/ws')).toBeUndefined();
+  });
+
+  it('does not reparent an attached root or a known child to a sibling root', () => {
+    rememberAttachedRoot('first', '/ws');
+    rememberAttachedRoot('second', '/ws');
+    rememberChildSession({ childId: 'child', parentId: 'first' });
+
+    rememberChildSession({ childId: 'first', directory: '/ws' });
+    rememberChildSession({ childId: 'first', parentId: 'second', directory: '/ws' });
+    rememberChildSession({ childId: 'child', parentId: 'second', directory: '/ws' });
+
+    expect(rootForSession('first')).toBe('first');
+    expect(rootForSession('child')).toBe('first');
   });
 
   it('preserves a root when the requested detach directory does not match', () => {

--- a/services/cloud-agent-next/wrapper/src/control/session-directories.ts
+++ b/services/cloud-agent-next/wrapper/src/control/session-directories.ts
@@ -1,6 +1,6 @@
 const directories = new Map<string, string>();
 const rootBySessionId = new Map<string, string>();
-const rootByDirectory = new Map<string, string>();
+const rootsByDirectory = new Map<string, Set<string>>();
 
 export function rememberSessionDirectory(kiloSessionId: string, directory: string): void {
   directories.set(kiloSessionId, directory);
@@ -9,7 +9,9 @@ export function rememberSessionDirectory(kiloSessionId: string, directory: strin
 export function rememberAttachedRoot(rootKiloSessionId: string, directory: string): void {
   directories.set(rootKiloSessionId, directory);
   rootBySessionId.set(rootKiloSessionId, rootKiloSessionId);
-  rootByDirectory.set(directory, rootKiloSessionId);
+  const roots = rootsByDirectory.get(directory) ?? new Set<string>();
+  roots.add(rootKiloSessionId);
+  rootsByDirectory.set(directory, roots);
 }
 
 export function forgetAttachedRoot(rootKiloSessionId: string, directory: string): void {
@@ -26,9 +28,9 @@ export function forgetAttachedRoot(rootKiloSessionId: string, directory: string)
     directories.delete(kiloSessionId);
   }
 
-  if (rootByDirectory.get(directory) === rootKiloSessionId) {
-    rootByDirectory.delete(directory);
-  }
+  const roots = rootsByDirectory.get(directory);
+  roots?.delete(rootKiloSessionId);
+  if (roots?.size === 0) rootsByDirectory.delete(directory);
 }
 
 export function rememberChildSession(input: {
@@ -36,23 +38,23 @@ export function rememberChildSession(input: {
   parentId?: string;
   directory?: string;
 }): void {
-  const root =
-    (input.parentId ? rootBySessionId.get(input.parentId) : undefined) ??
-    (input.directory ? rootByDirectory.get(input.directory) : undefined);
+  if (!input.parentId) return;
+  const root = rootBySessionId.get(input.parentId);
   if (!root) return;
+  const existing = rootBySessionId.get(input.childId);
+  if (existing && existing !== root) return;
   rootBySessionId.set(input.childId, root);
-  if (input.directory) directories.set(input.childId, input.directory);
+  const directory = input.directory ?? directories.get(input.parentId) ?? directories.get(root);
+  if (directory) directories.set(input.childId, directory);
 }
 
 export function rootForSession(
   kiloSessionId: string | undefined,
   directory?: string
 ): string | undefined {
-  if (kiloSessionId) {
-    const root = rootBySessionId.get(kiloSessionId);
-    if (root) return root;
-  }
-  return directory ? rootByDirectory.get(directory) : undefined;
+  if (kiloSessionId) return rootBySessionId.get(kiloSessionId);
+  const roots = directory ? rootsByDirectory.get(directory) : undefined;
+  return roots?.size === 1 ? roots.values().next().value : undefined;
 }
 
 export function directoriesForRoot(rootKiloSessionId: string, directory: string): string[] {
@@ -68,7 +70,7 @@ export function directoriesForRoot(rootKiloSessionId: string, directory: string)
 export function resetSessionDirectoryState(): void {
   directories.clear();
   rootBySessionId.clear();
-  rootByDirectory.clear();
+  rootsByDirectory.clear();
 }
 
 export function directoryForSession(kiloSessionId: string | undefined): string | undefined {

--- a/services/cloud-agent-next/wrapper/src/control/terminal-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/terminal-runtime.test.ts
@@ -6,12 +6,9 @@ import type {
 } from '../../../src/shared/sandbox-control-protocol.js';
 import { PNPM_STORE_DIR, PNPM_STORE_ENV_VAR } from '../../../src/shared/runtime-environment.js';
 import type { WrapperKiloClient, WrapperPty } from '../kilo-api.js';
+import type { WorktreeKiloRuntime } from './worktree-runtime.js';
 import { createControlTerminalRuntime, type ControlTerminalRuntime } from './terminal-runtime.js';
-import {
-  rememberAttachedRoot,
-  resetSessionDirectoryState,
-  rootForSession,
-} from './session-directories.js';
+import { rememberAttachedRoot, resetSessionDirectoryState } from './session-directories.js';
 
 const firstSession: SessionRequestIdentity = {
   sessionId: 'workspace_first',
@@ -65,10 +62,24 @@ function createRuntime(
   kiloClient: WrapperKiloClient,
   controlUrl = 'ws://127.0.0.1:1/sandbox-control/sandbox'
 ): ControlTerminalRuntime {
+  const worktrees = new Map<string, WorktreeKiloRuntime>();
   const runtime = createControlTerminalRuntime({
     controlUrl,
     wrapperInstanceId,
-    kiloClient,
+    getKiloRuntime: directory => {
+      let worktree = worktrees.get(directory);
+      if (!worktree) {
+        worktree = {
+          scopeId: directory,
+          directory,
+          env: { WORKTREE_VALUE: directory },
+          kiloClient,
+          signal: new AbortController().signal,
+        };
+        worktrees.set(directory, worktree);
+      }
+      return worktree;
+    },
   });
   activeRuntimes.add(runtime);
   return runtime;
@@ -243,7 +254,7 @@ describe('control terminal PTY ownership', () => {
     );
   });
 
-  it('creates an idempotent directory-scoped PTY with the safe legacy terminal environment', async () => {
+  it('creates an idempotent directory-scoped PTY with its worktree environment', async () => {
     const createCalls: Array<{ cwd: string; title: string; env: Record<string, string> }> = [];
     const resizeCalls: Array<{ ptyId: string; cols: number; rows: number; directory?: string }> =
       [];
@@ -284,7 +295,7 @@ describe('control terminal PTY ownership', () => {
           PROMPT_COMMAND: "PS1='\\n\\W\\n\\$ '",
           PS1: '\\n\\W\\n\\$ ',
           [PNPM_STORE_ENV_VAR]: PNPM_STORE_DIR,
-          SANDBOX_CONTROL_CREDENTIAL: '',
+          WORKTREE_VALUE: firstSession.directory,
         },
       },
     ]);
@@ -405,8 +416,10 @@ describe('control terminal PTY ownership', () => {
 
     await runtime.detachSession(firstSession);
     expect(deleted).toEqual([{ ptyId: 'pty_1', directory: firstSession.directory }]);
-    expect(rootForSession(firstSession.kiloSessionId)).toBeUndefined();
-    expect(rootForSession(secondSession.kiloSessionId)).toBe(secondSession.kiloSessionId);
+    expect(await terminalFailure(runtime.create(firstSession, creationPayload()))).toMatchObject({
+      code: 'not_ready',
+      message: 'Terminal session is not attached',
+    });
 
     expect(await runtime.resize(secondSession, { ptyId: 'pty_2', cols: 110, rows: 40 })).toEqual({
       pty: makePty(secondSession.directory, 'pty_2'),
@@ -414,16 +427,103 @@ describe('control terminal PTY ownership', () => {
     expect(resized).toEqual([{ ptyId: 'pty_2', directory: secondSession.directory }]);
   });
 
-  it('compensates PTY creation that finishes after its session detaches', async () => {
-    let releaseCreation: (() => void) | undefined;
-    const creationGate = new Promise<void>(resolve => {
-      releaseCreation = resolve;
+  it('keeps independent same-worktree roots eligible when a sibling detaches', async () => {
+    const sibling = { ...secondSession, directory: firstSession.directory };
+    let count = 0;
+    const deleted: string[] = [];
+    const runtime = createRuntime(
+      fakeKilo({
+        createPty: async input => makePty(input.cwd, `pty_${++count}`),
+        deletePty: async id => {
+          deleted.push(id);
+          return true;
+        },
+      })
+    );
+    attach(runtime, firstSession);
+    attach(runtime, sibling);
+    await runtime.create(firstSession, creationPayload(firstOperationId));
+    await runtime.create(sibling, creationPayload(secondOperationId));
+
+    expect(await terminalFailure(runtime.close(sibling, { ptyId: 'pty_1' }))).toMatchObject({
+      code: 'unauthorized',
     });
+    await runtime.detachSession(sibling);
+    expect(deleted).toEqual(['pty_2']);
+    expect(await runtime.resize(firstSession, { ptyId: 'pty_1', cols: 100, rows: 30 })).toEqual({
+      pty: makePty(firstSession.directory, 'pty_1'),
+    });
+    expect(await runtime.create(firstSession, creationPayload(firstOperationId))).toEqual({
+      pty: makePty(firstSession.directory, 'pty_1'),
+    });
+  });
+
+  it('uses the owning worktree client and credentials for every PTY operation', async () => {
+    const calls: Array<{ operation: string; directory: string; env?: Record<string, string> }> = [];
+    const worktrees = new Map<string, WorktreeKiloRuntime>();
+    for (const identity of [firstSession, secondSession]) {
+      const directory = identity.directory;
+      worktrees.set(directory, {
+        directory,
+        scopeId: directory,
+        env: { HOME: `/home/${identity.sessionId}`, KILOCODE_TOKEN: `guest-${identity.sessionId}` },
+        signal: new AbortController().signal,
+        kiloClient: fakeKilo({
+          createPty: async input => {
+            calls.push({ operation: 'create', directory, env: input.env });
+            return makePty(input.cwd, `pty_${identity.sessionId}`);
+          },
+          resizePty: async (id, _size, cwd) => {
+            calls.push({ operation: 'resize', directory });
+            return makePty(cwd ?? '', id);
+          },
+          deletePty: async () => {
+            calls.push({ operation: 'delete', directory });
+            return true;
+          },
+        }),
+      });
+    }
+    const runtime = createControlTerminalRuntime({
+      controlUrl: 'ws://127.0.0.1:1/sandbox-control/sandbox',
+      wrapperInstanceId,
+      getKiloRuntime: directory => worktrees.get(directory),
+    });
+    activeRuntimes.add(runtime);
+    attach(runtime, firstSession);
+    attach(runtime, secondSession);
+
+    for (const identity of [firstSession, secondSession]) {
+      const created = await runtime.create(identity, creationPayload(crypto.randomUUID()));
+      await runtime.resize(identity, { ptyId: created.pty.id, cols: 90, rows: 30 });
+      await runtime.close(identity, { ptyId: created.pty.id });
+      expect(calls.at(-3)).toMatchObject({
+        operation: 'create',
+        directory: identity.directory,
+        env: worktrees.get(identity.directory)?.env,
+      });
+      expect(calls.at(-3)?.env).not.toHaveProperty('SANDBOX_CONTROL_CREDENTIAL');
+      expect(calls.slice(-2)).toEqual([
+        { operation: 'resize', directory: identity.directory },
+        { operation: 'delete', directory: identity.directory },
+      ]);
+    }
+
+    worktrees.delete(firstSession.directory);
+    expect(
+      await terminalFailure(runtime.create(firstSession, creationPayload(crypto.randomUUID())))
+    ).toMatchObject({ code: 'not_ready', message: 'Kilo worktree is not available' });
+  });
+
+  it('compensates late PTY creation without disturbing a reattached session', async () => {
+    const releaseCreation = Promise.withResolvers<void>();
     const deleted: Array<{ ptyId: string; directory?: string }> = [];
+    let creations = 0;
     const kiloClient = fakeKilo({
       createPty: async input => {
-        await creationGate;
-        return makePty(input.cwd);
+        const id = ++creations;
+        if (id === 1) await releaseCreation.promise;
+        return makePty(input.cwd, `pty_${id}`);
       },
       deletePty: async (ptyId, directory) => {
         deleted.push({ ptyId, directory });
@@ -434,17 +534,30 @@ describe('control terminal PTY ownership', () => {
     attach(runtime, firstSession);
 
     const creation = runtime.create(firstSession, creationPayload());
+    const failure = terminalFailure(creation);
     await Promise.resolve();
     const detached = runtime.detachSession(firstSession);
-    releaseCreation?.();
-
-    expect(await terminalFailure(creation)).toMatchObject({
-      code: 'not_ready',
-      message: 'Terminal session is no longer attached',
-      retryable: false,
-    });
-    await detached;
-    expect(deleted).toEqual([{ ptyId: 'pty_first', directory: firstSession.directory }]);
+    try {
+      attach(runtime, firstSession);
+      const replacement = await runtime.create(firstSession, creationPayload());
+      expect(replacement.pty.id).toBe('pty_2');
+      releaseCreation.resolve();
+      expect(await failure).toMatchObject({
+        code: 'not_ready',
+        message: 'Terminal session is no longer attached',
+        retryable: false,
+      });
+      await detached;
+      expect(deleted).toEqual([{ ptyId: 'pty_1', directory: firstSession.directory }]);
+      expect(await runtime.create(firstSession, creationPayload())).toEqual(replacement);
+      expect(await runtime.resize(firstSession, { ptyId: 'pty_2', cols: 100, rows: 30 })).toEqual({
+        pty: makePty(firstSession.directory, 'pty_2'),
+      });
+    } finally {
+      releaseCreation.resolve();
+      await detached;
+      await failure;
+    }
   });
 
   it('removes completed creation-operation state when its PTY is closed', async () => {
@@ -507,6 +620,55 @@ describe('control terminal reverse WebSocket bridge', () => {
     } finally {
       runtime.shutdown();
       servers.stop();
+    }
+  });
+
+  it('connects each terminal bridge to its owning worktree server', async () => {
+    const firstServers = createBridgeServers('first worktree');
+    const secondServers = createBridgeServers('second worktree');
+    const worktrees = new Map<string, WorktreeKiloRuntime>();
+    for (const [identity, servers, id] of [
+      [firstSession, firstServers, 'pty_first'],
+      [secondSession, secondServers, 'pty_second'],
+    ] as const) {
+      worktrees.set(identity.directory, {
+        scopeId: identity.directory,
+        directory: identity.directory,
+        env: {},
+        signal: new AbortController().signal,
+        kiloClient: fakeKilo({
+          serverUrl: servers.localUrl,
+          createPty: async input => makePty(input.cwd, id),
+        }),
+      });
+    }
+    const runtime = createControlTerminalRuntime({
+      controlUrl: firstServers.controlUrl,
+      wrapperInstanceId,
+      getKiloRuntime: directory => worktrees.get(directory),
+    });
+    activeRuntimes.add(runtime);
+    attach(runtime, firstSession);
+    attach(runtime, secondSession);
+
+    try {
+      await runtime.create(firstSession, creationPayload(firstOperationId));
+      await runtime.create(secondSession, creationPayload(secondOperationId));
+      await runtime.connect(secondSession, connectionPayload({ ptyId: 'pty_second' }));
+      expect(await firstServers.reverseFrames.next()).toBe('second worktree');
+      expect(firstServers.localRequests).toEqual([]);
+      expect(secondServers.localRequests[0]?.searchParams.get('directory')).toBe(
+        secondSession.directory
+      );
+      await runtime.connect(firstSession, connectionPayload());
+      expect(await firstServers.reverseFrames.next()).toBe('first worktree');
+      expect(firstServers.localRequests[0]?.searchParams.get('directory')).toBe(
+        firstSession.directory
+      );
+    } finally {
+      runtime.shutdown();
+      firstServers.stop();
+      secondServers.stop();
     }
   });
 

--- a/services/cloud-agent-next/wrapper/src/control/terminal-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/terminal-runtime.ts
@@ -13,11 +13,13 @@ import {
   type SessionTerminalResizeResult,
 } from '../../../src/shared/sandbox-control-protocol.js';
 import { PNPM_STORE_DIR, PNPM_STORE_ENV_VAR } from '../../../src/shared/runtime-environment.js';
-import { isKiloServerUnreachableError, type WrapperKiloClient } from '../kilo-api.js';
+import { isKiloServerUnreachableError } from '../kilo-api.js';
 import { directoryForSession, forgetAttachedRoot, rootForSession } from './session-directories.js';
+import type { WorktreeKiloRuntime } from './worktree-runtime.js';
 
 type AttachedTerminalSession = SessionRequestIdentity & {
   wrapperInstanceId: string;
+  kiloRuntime: WorktreeKiloRuntime;
 };
 
 type OwnedTerminal = AttachedTerminalSession & {
@@ -53,7 +55,6 @@ const WORKSPACE_TERMINAL_ENV = {
   PROMPT_COMMAND: "PS1='\\n\\W\\n\\$ '",
   PS1: '\\n\\W\\n\\$ ',
   [PNPM_STORE_ENV_VAR]: PNPM_STORE_DIR,
-  SANDBOX_CONTROL_CREDENTIAL: '',
 } satisfies Record<string, string>;
 
 export class ControlTerminalRuntimeError extends Error {
@@ -148,9 +149,9 @@ function waitForSocketOpen(socket: WebSocket): Promise<void> {
 export function createControlTerminalRuntime(options: {
   controlUrl: string;
   wrapperInstanceId: string;
-  kiloClient: WrapperKiloClient;
+  getKiloRuntime: (directory: string) => WorktreeKiloRuntime | undefined;
 }): ControlTerminalRuntime {
-  const { wrapperInstanceId, kiloClient } = options;
+  const { wrapperInstanceId } = options;
   const controlOrigin = new URL(options.controlUrl).origin;
   const attachedSessions = new Map<string, AttachedTerminalSession>();
   const terminals = new Map<string, OwnedTerminal>();
@@ -167,14 +168,16 @@ export function createControlTerminalRuntime(options: {
       attached.wrapperInstanceId !== wrapperInstanceId ||
       !sameSession(attached, identity) ||
       directoryForSession(identity.kiloSessionId) !== identity.directory ||
-      rootForSession(identity.kiloSessionId) !== identity.kiloSessionId ||
-      rootForSession(undefined, identity.directory) !== identity.kiloSessionId
+      rootForSession(identity.kiloSessionId) !== identity.kiloSessionId
     ) {
       throw new ControlTerminalRuntimeError(
         'unauthorized',
         'Terminal session ownership mismatch',
         false
       );
+    }
+    if (options.getKiloRuntime(identity.directory) !== attached.kiloRuntime) {
+      throw new ControlTerminalRuntimeError('not_ready', 'Kilo worktree is not available', true);
     }
     return attached;
   }
@@ -255,11 +258,12 @@ export function createControlTerminalRuntime(options: {
     payload: SessionTerminalCreatePayload
   ): Promise<SessionTerminalCreateResult> {
     let createdPtyId: string | undefined;
+    const { kiloClient, env } = attached.kiloRuntime;
     try {
       const created = await kiloClient.createPty({
         cwd: attached.directory,
         title: 'Workspace terminal',
-        env: WORKSPACE_TERMINAL_ENV,
+        env: { ...env, ...WORKSPACE_TERMINAL_ENV },
       });
       createdPtyId = created.id;
       if (attachedSessions.get(attached.sessionId) !== attached) {
@@ -326,7 +330,7 @@ export function createControlTerminalRuntime(options: {
 
       const localUrl = new URL(
         `/pty/${encodeURIComponent(bridge.terminal.ptyId)}/connect`,
-        kiloClient.serverUrl
+        bridge.terminal.kiloRuntime.kiloClient.serverUrl
       );
       localUrl.protocol = localUrl.protocol === 'https:' ? 'wss:' : 'ws:';
       localUrl.search = '';
@@ -368,11 +372,12 @@ export function createControlTerminalRuntime(options: {
 
   return {
     rememberAttachedSession(identity) {
+      const kiloRuntime = options.getKiloRuntime(identity.directory);
       if (
         shutDown ||
+        !kiloRuntime ||
         directoryForSession(identity.kiloSessionId) !== identity.directory ||
-        rootForSession(identity.kiloSessionId) !== identity.kiloSessionId ||
-        rootForSession(undefined, identity.directory) !== identity.kiloSessionId
+        rootForSession(identity.kiloSessionId) !== identity.kiloSessionId
       ) {
         throw new ControlTerminalRuntimeError(
           'unauthorized',
@@ -383,7 +388,7 @@ export function createControlTerminalRuntime(options: {
 
       const existing = attachedSessions.get(identity.sessionId);
       if (existing) {
-        if (!sameSession(existing, identity)) {
+        if (!sameSession(existing, identity) || existing.kiloRuntime !== kiloRuntime) {
           throw new ControlTerminalRuntimeError(
             'unauthorized',
             'Terminal session ownership mismatch',
@@ -394,10 +399,7 @@ export function createControlTerminalRuntime(options: {
       }
 
       for (const attached of attachedSessions.values()) {
-        if (
-          attached.kiloSessionId === identity.kiloSessionId ||
-          attached.directory === identity.directory
-        ) {
+        if (attached.kiloSessionId === identity.kiloSessionId) {
           throw new ControlTerminalRuntimeError(
             'unauthorized',
             'Terminal session ownership mismatch',
@@ -406,7 +408,7 @@ export function createControlTerminalRuntime(options: {
         }
       }
 
-      attachedSessions.set(identity.sessionId, { ...identity, wrapperInstanceId });
+      attachedSessions.set(identity.sessionId, { ...identity, wrapperInstanceId, kiloRuntime });
     },
 
     async detachSession(identity) {
@@ -421,7 +423,6 @@ export function createControlTerminalRuntime(options: {
       }
 
       attachedSessions.delete(identity.sessionId);
-      forgetAttachedRoot(identity.kiloSessionId, identity.directory);
 
       const pending: Promise<unknown>[] = [];
       for (const [operationId, operation] of operations) {
@@ -435,7 +436,7 @@ export function createControlTerminalRuntime(options: {
         const bridge = bridges.get(ptyId);
         if (bridge) closeBridge(bridge, 1000, 'PTY session ended');
         terminals.delete(ptyId);
-        pending.push(kiloClient.deletePty(ptyId, terminal.directory));
+        pending.push(terminal.kiloRuntime.kiloClient.deletePty(ptyId, terminal.directory));
       }
 
       await Promise.allSettled(pending);
@@ -480,7 +481,7 @@ export function createControlTerminalRuntime(options: {
     async resize(identity, payload) {
       const terminal = requireTerminal(identity, payload.ptyId);
       try {
-        const pty = await kiloClient.resizePty(
+        const pty = await terminal.kiloRuntime.kiloClient.resizePty(
           payload.ptyId,
           { cols: payload.cols, rows: payload.rows },
           terminal.directory
@@ -513,7 +514,10 @@ export function createControlTerminalRuntime(options: {
     async close(identity, payload) {
       const terminal = requireTerminal(identity, payload.ptyId, true);
       try {
-        const success = await kiloClient.deletePty(payload.ptyId, terminal.directory);
+        const success = await terminal.kiloRuntime.kiloClient.deletePty(
+          payload.ptyId,
+          terminal.directory
+        );
         if (success && terminals.get(payload.ptyId) === terminal) {
           const bridge = bridges.get(payload.ptyId);
           if (bridge) closeBridge(bridge, 1000, 'PTY session ended');

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.test.ts
@@ -1,0 +1,1470 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import {
+  buildWorktreeKiloEnvironment,
+  createWorktreeKiloRuntimes,
+  startWorktreeKiloServer,
+  type WorktreeKiloAuth,
+  type WorktreeKiloRuntimes,
+} from './worktree-runtime';
+import {
+  sessionMessageOutcomeSchema,
+  type SessionEventIdentity,
+  type SessionRequestIdentity,
+} from '../../../src/shared/sandbox-control-protocol';
+import { handleControlRequest, type HandlerDeps } from './sandbox-control-handlers';
+import type { WrapperKiloClient } from '../kilo-api';
+import {
+  ControlTerminalRuntimeError,
+  createControlTerminalRuntime,
+  type ControlTerminalRuntime,
+} from './terminal-runtime';
+import { applySessionAttach, type ApplyAttachDeps } from './apply-attach';
+import { childFromSessionCreated, eventKiloSessionId, sessionEventIdentity } from './feed';
+import {
+  directoryForSession,
+  rememberChildSession,
+  resetSessionDirectoryState,
+  rootForSession,
+} from './session-directories';
+
+const auth: WorktreeKiloAuth = {
+  scopeId: 'worktree_a',
+  token: 'opaque-guest-a',
+  targets: {
+    backendBaseUrl: 'https://backend.example.test/a',
+    providerBaseUrl: 'https://provider.example.test/a',
+    sessionIngestBaseUrl: 'https://ingest.example.test/a',
+  },
+};
+
+const bitbucketMetadata = {
+  KILO_BITBUCKET_WORKSPACE_SLUG: 'acme-workspace',
+  KILO_BITBUCKET_REPOSITORY_SLUG: 'widgets',
+  KILO_BITBUCKET_WORKSPACE_UUID: '{33333333-3333-4333-8333-333333333333}',
+  KILO_BITBUCKET_REPOSITORY_UUID: '{11111111-1111-4111-8111-111111111111}',
+};
+
+const inherited = {
+  PATH: process.env.PATH,
+  HOME: '/home/shared',
+  XDG_DATA_HOME: '/home/shared/data',
+  KILOCODE_TOKEN: 'actual-managed-kilo-token',
+  KILOCODE_TOKEN_FILE: '/actual-managed-token-file',
+  KILO_AUTH_CONTENT: JSON.stringify({ kilo: { type: 'api', key: 'actual-managed-auth-token' } }),
+  KILO_CONFIG_CONTENT: JSON.stringify({
+    provider: { kilo: { options: { apiKey: 'actual-managed-api-key' } } },
+  }),
+  OPENCODE_CONFIG_CONTENT: 'actual-managed-config',
+  KILO_CONFIG: '/actual-managed-config-file',
+  OPENCODE_CONFIG_DIR: '/actual-managed-config-directory',
+  GH_TOKEN: 'actual-managed-github-token',
+  GITHUB_TOKEN: 'actual-managed-github-token',
+  SANDBOX_CONTROL_CREDENTIAL: 'actual-control-credential',
+};
+
+let tmpDir: string;
+const registries: WorktreeKiloRuntimes[] = [];
+const terminalRuntimes: ControlTerminalRuntime[] = [];
+const servers: ReturnType<typeof createKiloStub>[] = [];
+const aborts: AbortController[] = [];
+
+async function waitUntil(predicate: () => boolean): Promise<void> {
+  const deadline = Date.now() + 5_000;
+  while (!predicate()) {
+    if (Date.now() >= deadline) throw new Error('Condition timed out');
+    await Bun.sleep(10);
+  }
+}
+
+async function rejected(operation: Promise<unknown>): Promise<unknown> {
+  try {
+    await operation;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected runtime operation to fail');
+}
+
+function createKiloStub() {
+  const requests: Array<{ pathname: string; directory: string | null; body?: unknown }> = [];
+  const permissions: Awaited<ReturnType<WrapperKiloClient['getPermissions']>> = [];
+  const feeds = new Set<ReadableStreamDefaultController<Uint8Array>>();
+  const encoder = new TextEncoder();
+  let feedConnections = 0;
+  const server = Bun.serve({
+    port: 0,
+    hostname: '127.0.0.1',
+    async fetch(request) {
+      const url = new URL(request.url);
+      if (url.pathname === '/global/event') {
+        feedConnections += 1;
+        let feed: ReadableStreamDefaultController<Uint8Array> | undefined;
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              feed = controller;
+              feeds.add(controller);
+              controller.enqueue(
+                encoder.encode('data: {"payload":{"type":"server.connected","properties":{}}}\n\n')
+              );
+            },
+            cancel() {
+              if (feed) feeds.delete(feed);
+            },
+          }),
+          { headers: { 'Content-Type': 'text/event-stream' } }
+        );
+      }
+      const text = await request.text();
+      const body = text ? (JSON.parse(text) as Record<string, unknown>) : undefined;
+      requests.push({
+        pathname: url.pathname,
+        directory:
+          url.searchParams.get('directory') ??
+          decodeURIComponent(request.headers.get('x-kilo-directory') ?? ''),
+        ...(body ? { body } : {}),
+      });
+      if (request.method === 'GET' && url.pathname === '/permission') {
+        return Response.json(permissions);
+      }
+      if (request.method === 'POST' && url.pathname.startsWith('/permission/')) {
+        const id = decodeURIComponent(url.pathname.split('/')[2]);
+        const index = permissions.findIndex(permission => permission.id === id);
+        if (index === -1) return new Response('Permission not pending', { status: 404 });
+        permissions.splice(index, 1);
+        return Response.json(true);
+      }
+      if (request.method === 'POST' && url.pathname.endsWith('/abort')) {
+        return Response.json(true);
+      }
+      if (request.method === 'POST' && /\/session\/[^/]+\/(message|command)$/.test(url.pathname)) {
+        const directory = requests.at(-1)?.directory ?? '';
+        const completion: Awaited<ReturnType<WrapperKiloClient['sendPrompt']>> = {
+          info: {
+            id: `assistant_${String(body?.messageID)}`,
+            sessionID: decodeURIComponent(url.pathname.split('/')[2]),
+            parentID: String(body?.messageID),
+            role: 'assistant',
+            time: { created: 1, completed: 2 },
+            modelID: 'test',
+            providerID: 'kilo',
+            mode: 'code',
+            agent: 'code',
+            path: { cwd: directory, root: directory },
+            cost: 0,
+            tokens: { input: 1, output: 1, reasoning: 0, cache: { read: 0, write: 0 } },
+          },
+          parts: [],
+        };
+        return Response.json(completion);
+      }
+      if (request.method === 'GET' && url.pathname.startsWith('/session/')) {
+        return Response.json({ id: decodeURIComponent(url.pathname.slice('/session/'.length)) });
+      }
+      if (request.method === 'POST' && url.pathname === '/pty') {
+        return Response.json({
+          id: `pty_${crypto.randomUUID()}`,
+          title: 'Workspace terminal',
+          command: '/bin/sh',
+          args: [],
+          cwd: body?.cwd,
+          status: 'running',
+          pid: 1,
+        });
+      }
+      return Response.json({});
+    },
+  });
+  return {
+    url: server.url.toString(),
+    requests,
+    permissions,
+    get feedConnections() {
+      return feedConnections;
+    },
+    emit(event: unknown) {
+      for (const feed of feeds) feed.enqueue(encoder.encode(`data: ${JSON.stringify(event)}\n\n`));
+    },
+    endFeeds() {
+      for (const feed of feeds) feed.close();
+      feeds.clear();
+    },
+    stop: () => server.stop(true),
+  };
+}
+
+function rootIdentity(directory: string, name = path.basename(directory)): SessionRequestIdentity {
+  return { sessionId: `workspace_${name}`, kiloSessionId: `root_${name}`, directory };
+}
+
+function createRegistry(overrides: Partial<Parameters<typeof createWorktreeKiloRuntimes>[0]> = {}) {
+  const launches: Array<Parameters<typeof startWorktreeKiloServer>[0]> = [];
+  let closes = 0;
+  let unexpectedCloses = 0;
+  const registry = createWorktreeKiloRuntimes({
+    homeRoot: path.join(tmpDir, 'homes'),
+    inheritedEnv: inherited,
+    startServer: async options => {
+      launches.push(options);
+      const server = createKiloStub();
+      servers.push(server);
+      return {
+        url: server.url,
+        close: () => {
+          closes += 1;
+        },
+      };
+    },
+    onUnexpectedClose: () => {
+      unexpectedCloses += 1;
+    },
+    ...overrides,
+  });
+  registries.push(registry);
+  return {
+    registry: {
+      ...registry,
+      async ensure(directory: string, kilo: WorktreeKiloAuth, env?: Record<string, string>) {
+        const attachment = registry.attach(rootIdentity(directory), kilo, env);
+        try {
+          const runtime = await attachment.ready;
+          attachment.commit();
+          return runtime;
+        } finally {
+          attachment.release();
+        }
+      },
+    },
+    launches,
+    get closes() {
+      return closes;
+    },
+    get unexpectedCloses() {
+      return unexpectedCloses;
+    },
+  };
+}
+
+function createHandlerDeps(registry: WorktreeKiloRuntimes): HandlerDeps {
+  const terminalRuntime = createControlTerminalRuntime({
+    controlUrl: 'ws://127.0.0.1:1/sandbox-control/test',
+    wrapperInstanceId: crypto.randomUUID(),
+    getKiloRuntime: directory => registry.get(directory),
+  });
+  terminalRuntimes.push(terminalRuntime);
+  return {
+    kiloRuntimes: registry,
+    terminalRuntime,
+    version: 'test',
+    kiloReady: true,
+    sessions: [],
+    tasks: new Map(),
+    emitSessionEvent: () => {},
+    retireRuntime: () => {},
+  };
+}
+
+beforeEach(() => {
+  resetSessionDirectoryState();
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'worktree-kilo-test-'));
+});
+
+afterEach(async () => {
+  for (const abort of aborts.splice(0)) abort.abort();
+  for (const terminal of terminalRuntimes.splice(0)) terminal.shutdown();
+  for (const registry of registries.splice(0)) registry.shutdown();
+  await Promise.all(servers.splice(0).map(server => server.stop()));
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('worktree Kilo environments', () => {
+  it('retains only the four trusted Bitbucket metadata keys from the attachment', () => {
+    const env = buildWorktreeKiloEnvironment(
+      '/workspace/a',
+      '/home/a',
+      auth,
+      {
+        ...bitbucketMetadata,
+        BITBUCKET_TOKEN: 'opaque-bitbucket-token',
+        KILO_BITBUCKET_INTEGRATION_ID: 'actual-managed-integration',
+        KILO_BITBUCKET_TOKEN: 'actual-managed-token',
+        KILO_BITBUCKET_WORKSPACE_SLUG_EXTRA: 'actual-managed-override',
+        KILO_CONFIG_CONTENT: 'actual-managed-config',
+        OPENCODE_CONFIG_CONTENT: 'actual-managed-config',
+        SANDBOX_CONTROL_CREDENTIAL: 'actual-control-credential',
+      },
+      inherited
+    );
+
+    expect(env).toMatchObject({
+      ...bitbucketMetadata,
+      BITBUCKET_TOKEN: 'opaque-bitbucket-token',
+      KILOCODE_TOKEN: auth.token,
+    });
+    expect(
+      Object.keys(env)
+        .filter(name => name.startsWith('KILO_BITBUCKET_'))
+        .sort()
+    ).toEqual(Object.keys(bitbucketMetadata).sort());
+    expect(JSON.stringify(env)).not.toContain('actual-');
+    expect(JSON.parse(env.KILO_AUTH_CONTENT)).toEqual({ kilo: { type: 'api', key: auth.token } });
+    expect(env.KILO_CONFIG_CONTENT).toBe(env.OPENCODE_CONFIG_CONTENT);
+    expect(
+      buildWorktreeKiloEnvironment(
+        '/workspace/other',
+        '/home/other',
+        auth,
+        {},
+        {
+          ...inherited,
+          ...bitbucketMetadata,
+        }
+      )
+    ).not.toHaveProperty('KILO_BITBUCKET_WORKSPACE_SLUG');
+  });
+
+  it('rebuilds all auth surfaces from the guest token and targets without managed credentials', () => {
+    const environment = {
+      CUSTOM_VALUE: 'profile-value',
+      GH_TOKEN: 'opaque-github-credential',
+      KILOCODE_TOKEN: 'actual-attachment-token',
+      KILO_AUTH_CONTENT: 'actual-attachment-auth',
+      KILO_CONFIG_CONTENT: 'actual-attachment-config',
+      OPENCODE_CONFIG_CONTENT: 'actual-attachment-config',
+      KILO_SESSION_INGEST_URL: 'https://wrong.example.test',
+      HOME: '/wrong-home',
+      XDG_DATA_HOME: '/wrong-data',
+    };
+    const env = buildWorktreeKiloEnvironment(
+      '/workspace/a',
+      '/home/worktree-a',
+      auth,
+      environment,
+      inherited
+    );
+
+    expect(env).toMatchObject({
+      CUSTOM_VALUE: 'profile-value',
+      GH_TOKEN: 'opaque-github-credential',
+      PWD: '/workspace/a',
+      HOME: '/home/worktree-a',
+      XDG_DATA_HOME: '/home/worktree-a/.local/share',
+      XDG_CONFIG_HOME: '/home/worktree-a/.config',
+      XDG_CACHE_HOME: '/home/worktree-a/.cache',
+      KILOCODE_TOKEN: auth.token,
+      KILO_API_URL: auth.targets.backendBaseUrl,
+      KILOCODE_BACKEND_BASE_URL: auth.targets.backendBaseUrl,
+      KILO_OPENROUTER_BASE: auth.targets.providerBaseUrl,
+      KILO_SESSION_INGEST_URL: auth.targets.sessionIngestBaseUrl,
+    });
+    expect(JSON.parse(env.KILO_AUTH_CONTENT)).toEqual({ kilo: { type: 'api', key: auth.token } });
+    expect(JSON.parse(env.KILO_CONFIG_CONTENT)).toMatchObject({
+      autoupdate: false,
+      provider: {
+        kilo: {
+          options: {
+            apiKey: auth.token,
+            kilocodeToken: auth.token,
+            baseURL: auth.targets.providerBaseUrl,
+          },
+        },
+      },
+    });
+    expect(env.OPENCODE_CONFIG_CONTENT).toBe(env.KILO_CONFIG_CONTENT);
+    for (const name of [
+      'SANDBOX_CONTROL_CREDENTIAL',
+      'KILOCODE_TOKEN_FILE',
+      'KILO_CONFIG',
+      'OPENCODE_CONFIG_DIR',
+      'GITHUB_TOKEN',
+    ]) {
+      expect(env).not.toHaveProperty(name);
+    }
+    expect(JSON.stringify(env)).not.toContain('actual-');
+    expect(inherited.KILOCODE_TOKEN).toBe('actual-managed-kilo-token');
+    expect(environment.KILOCODE_TOKEN).toBe('actual-attachment-token');
+  });
+});
+
+describe('worktree Kilo runtime registry', () => {
+  it('starts lazily and reuses one server and feed for concurrent same-worktree roots', async () => {
+    const { registry, launches } = createRegistry();
+    const directory = path.join(tmpDir, 'worktree-a');
+    expect(launches).toEqual([]);
+    expect(registry.get(directory)).toBeUndefined();
+
+    const [first, second, third] = await Promise.all([
+      registry.ensure(directory, auth),
+      registry.ensure(directory, auth),
+      registry.ensure(directory, { ...auth, targets: { ...auth.targets } }),
+    ]);
+    expect(second).toBe(first);
+    expect(third).toBe(first);
+    expect(await registry.ensure(directory, auth)).toBe(first);
+    expect(registry.get(directory)).toBe(first);
+    expect(launches).toHaveLength(1);
+    expect(servers[0]?.feedConnections).toBe(1);
+
+    await Promise.all(
+      ['root_one', 'root_two'].map(sessionId =>
+        first.kiloClient.sendPromptAsync({
+          sessionId,
+          messageId: `message_${sessionId}`,
+          prompt: sessionId,
+        })
+      )
+    );
+    expect(servers[0]?.requests.map(request => request.pathname).sort()).toEqual([
+      '/session/root_one/prompt_async',
+      '/session/root_two/prompt_async',
+    ]);
+    expect(servers[0]?.requests.every(request => request.directory === directory)).toBe(true);
+    expect(servers[0]?.requests.map(request => request.body)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ messageID: 'message_root_one' }),
+        expect.objectContaining({ messageID: 'message_root_two' }),
+      ])
+    );
+  });
+
+  it('isolates different worktrees with separate servers, homes, auth files, and event clients', async () => {
+    const events: Array<{ directory: string; scopeId: string; type: string }> = [];
+    const { registry, launches } = createRegistry({
+      onEvent: (runtime, event) =>
+        events.push({ directory: runtime.directory, scopeId: runtime.scopeId, type: event.type }),
+    });
+    const otherAuth = { ...auth, scopeId: 'worktree_b', token: 'opaque-guest-b' };
+    const [first, second] = await Promise.all([
+      registry.ensure(path.join(tmpDir, 'worktree-a'), auth),
+      registry.ensure(path.join(tmpDir, 'worktree-b'), otherAuth),
+    ]);
+    expect(launches).toHaveLength(2);
+    expect(first.kiloClient.serverUrl).not.toBe(second.kiloClient.serverUrl);
+    for (const key of [
+      'HOME',
+      'XDG_DATA_HOME',
+      'XDG_CONFIG_HOME',
+      'XDG_CACHE_HOME',
+      'XDG_STATE_HOME',
+      'XDG_RUNTIME_DIR',
+    ]) {
+      expect(first.env[key]).not.toBe(second.env[key]);
+    }
+    for (const runtime of [first, second]) {
+      const authPath = path.join(runtime.env.XDG_DATA_HOME, 'kilo', 'auth.json');
+      expect(JSON.parse(fs.readFileSync(authPath, 'utf8'))).toEqual({
+        kilo: { type: 'api', key: runtime.env.KILOCODE_TOKEN },
+      });
+      expect(fs.statSync(authPath).mode & 0o777).toBe(0o600);
+      expect(JSON.stringify(runtime.env)).not.toContain('actual-');
+    }
+    expect(first.env.KILOCODE_TOKEN).toBe(auth.token);
+    expect(second.env.KILOCODE_TOKEN).toBe(otherAuth.token);
+    for (const server of servers)
+      server.emit({ payload: { type: 'session.updated', properties: {} } });
+    await waitUntil(() => events.filter(event => event.type === 'session.updated').length === 2);
+    expect(events.filter(event => event.type === 'session.updated')).toEqual(
+      expect.arrayContaining([
+        { directory: first.directory, scopeId: auth.scopeId, type: 'session.updated' },
+        { directory: second.directory, scopeId: otherAuth.scopeId, type: 'session.updated' },
+      ])
+    );
+  });
+
+  it('routes separate SandboxSession roots sharing a worktree through one SDK runtime', async () => {
+    const identities = [
+      {
+        sessionId: 'workspace_first',
+        kiloSessionId: 'root_first',
+        directory: path.join(tmpDir, 'shared'),
+      },
+      {
+        sessionId: 'workspace_second',
+        kiloSessionId: 'root_second',
+        directory: path.join(tmpDir, 'shared'),
+      },
+      {
+        sessionId: 'workspace_other',
+        kiloSessionId: 'root_other',
+        directory: path.join(tmpDir, 'other'),
+      },
+    ];
+    const routedEvents: SessionEventIdentity[] = [];
+    const outcomes: Array<{ identity: SessionRequestIdentity; messageId: string; status: string }> =
+      [];
+    const harness = createRegistry({
+      onEvent: (_runtime, event) => {
+        if (event.type === 'session.created') {
+          const child = childFromSessionCreated(event.properties);
+          if (child) rememberChildSession(child);
+        }
+        const sessionId = eventKiloSessionId(event.properties);
+        if (!sessionId) return;
+        const identity = sessionEventIdentity({ sessionId, directory: event.directory });
+        if (identity) routedEvents.push(identity);
+      },
+    });
+    const terminals = createControlTerminalRuntime({
+      controlUrl: 'ws://127.0.0.1:1/sandbox-control/test',
+      wrapperInstanceId: crypto.randomUUID(),
+      getKiloRuntime: directory => harness.registry.get(directory),
+    });
+    const deps: HandlerDeps = {
+      kiloRuntimes: harness.registry,
+      terminalRuntime: terminals,
+      version: 'test',
+      kiloReady: true,
+      sessions: [],
+      tasks: new Map(),
+      emitSessionEvent: (identity, event) => {
+        if (event.type === 'session.message.outcome') {
+          const { messageId, status } = sessionMessageOutcomeSchema.parse(event.properties);
+          outcomes.push({ identity, messageId, status });
+        }
+      },
+      retireRuntime: () => {},
+    };
+    const waitForTasks = () => Promise.all([...deps.tasks.values()].map(task => task.done));
+    try {
+      const attached = await Promise.all(
+        identities.map((identity, index) =>
+          handleControlRequest(
+            'session.attach',
+            identity,
+            {
+              kilo:
+                index === 2 ? { ...auth, scopeId: 'worktree_other', token: 'opaque-other' } : auth,
+              env:
+                index === 2
+                  ? {}
+                  : { ...bitbucketMetadata, BITBUCKET_TOKEN: 'opaque-bitbucket-token' },
+            },
+            deps
+          )
+        )
+      );
+      expect(attached).toEqual(identities.map(() => ({ ok: true, result: { attached: true } })));
+      expect(harness.launches).toHaveLength(2);
+      expect(servers.map(server => server.feedConnections)).toEqual([1, 1]);
+
+      for (const identity of identities) {
+        const runtime = harness.registry.get(identity.directory);
+        const server = servers.find(server => server.url === runtime?.kiloClient.serverUrl);
+        if (!runtime || !server) throw new Error('Expected attached worktree runtime');
+        const before = server.requests.length;
+        const messageId = `message_${identity.kiloSessionId}`;
+        expect(
+          await handleControlRequest(
+            'session.prompt',
+            identity,
+            {
+              messageId,
+              turn: { type: 'prompt', prompt: 'hello' },
+              agent: { mode: 'code', model: 'test' },
+            },
+            deps
+          )
+        ).toEqual({ ok: true, result: { messageId, status: 'accepted' } });
+        await waitForTasks();
+        expect(
+          await handleControlRequest(
+            'session.prompt',
+            identity,
+            {
+              messageId: `command_${identity.kiloSessionId}`,
+              turn: { type: 'command', command: 'review', arguments: '--all' },
+              agent: { mode: 'code', model: 'test' },
+            },
+            deps
+          )
+        ).toEqual({
+          ok: true,
+          result: { messageId: `command_${identity.kiloSessionId}`, status: 'accepted' },
+        });
+        await waitForTasks();
+        expect(outcomes.slice(-2)).toEqual([
+          { identity, messageId, status: 'completed' },
+          { identity, messageId: `command_${identity.kiloSessionId}`, status: 'completed' },
+        ]);
+        server.permissions.push({
+          id: `permission_${identity.kiloSessionId}`,
+          sessionID: identity.kiloSessionId,
+          permission: 'bash',
+          patterns: [],
+          metadata: {},
+          always: [],
+        });
+        expect(
+          await handleControlRequest(
+            'session.permission.resolve',
+            identity,
+            {
+              permissionId: `permission_${identity.kiloSessionId}`,
+              response: 'once',
+            },
+            deps
+          )
+        ).toEqual({ ok: true, result: { success: true } });
+        expect(server.permissions).toEqual([]);
+        expect(
+          (
+            await handleControlRequest(
+              'session.terminal.create',
+              identity,
+              {
+                operationId: crypto.randomUUID(),
+              },
+              deps
+            )
+          ).ok
+        ).toBe(true);
+        expect(server.requests.slice(before)).toMatchObject([
+          {
+            pathname: `/session/${identity.kiloSessionId}/message`,
+            directory: identity.directory,
+            body: { messageID: messageId },
+          },
+          {
+            pathname: `/session/${identity.kiloSessionId}/command`,
+            directory: identity.directory,
+            body: { messageID: `command_${identity.kiloSessionId}`, command: 'review' },
+          },
+          {
+            pathname: '/permission',
+            directory: identity.directory,
+          },
+          {
+            pathname: `/permission/permission_${identity.kiloSessionId}/reply`,
+            directory: identity.directory,
+            body: { reply: 'once' },
+          },
+          {
+            pathname: '/pty',
+            directory: identity.directory,
+            body: { cwd: identity.directory, env: runtime.env },
+          },
+        ]);
+        if (runtime.scopeId === auth.scopeId) {
+          const expectedEnv = {
+            ...bitbucketMetadata,
+            BITBUCKET_TOKEN: 'opaque-bitbucket-token',
+            KILOCODE_TOKEN: auth.token,
+          };
+          expect(runtime.env).toMatchObject(expectedEnv);
+          expect(server.requests.at(-1)).toMatchObject({
+            pathname: '/pty',
+            body: { env: expectedEnv },
+          });
+        } else {
+          for (const key of Object.keys(bitbucketMetadata))
+            expect(runtime.env).not.toHaveProperty(key);
+        }
+        expect(JSON.stringify(server.requests.slice(before))).not.toContain('actual-');
+        server.emit({
+          directory: identity.directory,
+          payload: {
+            type: 'session.created',
+            properties: { info: { id: identity.kiloSessionId, directory: identity.directory } },
+          },
+        });
+        server.emit({
+          directory: identity.directory,
+          payload: {
+            type: 'session.created',
+            properties: {
+              info: { id: `child_${identity.kiloSessionId}`, parentID: identity.kiloSessionId },
+            },
+          },
+        });
+      }
+      await waitUntil(() => routedEvents.length === 6);
+      for (const identity of identities) {
+        expect(routedEvents).toContainEqual({
+          directory: identity.directory,
+          kiloSessionId: identity.kiloSessionId,
+          rootKiloSessionId: identity.kiloSessionId,
+        });
+        expect(routedEvents).toContainEqual({
+          directory: identity.directory,
+          kiloSessionId: `child_${identity.kiloSessionId}`,
+          rootKiloSessionId: identity.kiloSessionId,
+        });
+      }
+
+      const [first, second] = identities;
+      const runtime = harness.registry.get(first.directory);
+      expect(await handleControlRequest('session.detach', second, {}, deps)).toEqual({
+        ok: true,
+        result: { detached: true },
+      });
+      expect(harness.registry.get(first.directory)).toBe(runtime);
+      expect(harness.closes).toBe(0);
+      expect(rootForSession(undefined, first.directory)).toBe(first.kiloSessionId);
+      expect(rootForSession(`child_${second.kiloSessionId}`, first.directory)).toBeUndefined();
+      const survivingPrompt = {
+        messageId: 'surviving_root',
+        turn: { type: 'prompt', prompt: 'still attached' },
+        agent: { mode: 'code', model: 'test' },
+      };
+      expect(await handleControlRequest('session.prompt', first, survivingPrompt, deps)).toEqual({
+        ok: true,
+        result: { messageId: survivingPrompt.messageId, status: 'accepted' },
+      });
+      await waitForTasks();
+      expect(outcomes.at(-1)).toEqual({
+        identity: first,
+        messageId: survivingPrompt.messageId,
+        status: 'completed',
+      });
+      expect(await handleControlRequest('session.abort', first, {}, deps)).toEqual({
+        ok: true,
+        result: { status: 'already_idle' },
+      });
+      expect((await handleControlRequest('session.prompt', second, survivingPrompt, deps)).ok).toBe(
+        false
+      );
+      expect(harness.launches).toHaveLength(2);
+
+      expect(await handleControlRequest('session.detach', first, {}, deps)).toEqual({
+        ok: true,
+        result: { detached: true },
+      });
+      expect(runtime?.signal.aborted).toBe(true);
+      expect(harness.registry.get(first.directory)).toBeUndefined();
+      expect(harness.closes).toBe(1);
+      expect(rootForSession(first.kiloSessionId)).toBeUndefined();
+      expect(rootForSession(`child_${first.kiloSessionId}`)).toBeUndefined();
+      expect(
+        await handleControlRequest('session.prompt', identities[2], survivingPrompt, deps)
+      ).toEqual({
+        ok: true,
+        result: { messageId: survivingPrompt.messageId, status: 'accepted' },
+      });
+      await waitForTasks();
+      expect(outcomes.at(-1)).toEqual({
+        identity: identities[2],
+        messageId: survivingPrompt.messageId,
+        status: 'completed',
+      });
+      expect(await handleControlRequest('session.abort', identities[2], {}, deps)).toEqual({
+        ok: true,
+        result: { status: 'already_idle' },
+      });
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identities[2],
+            {
+              operationId: crypto.randomUUID(),
+            },
+            deps
+          )
+        ).ok
+      ).toBe(true);
+      expect(
+        (
+          await handleControlRequest(
+            'session.attach',
+            first,
+            {
+              kilo: { ...auth, token: 'replacement-token' },
+            },
+            deps
+          )
+        ).ok
+      ).toBe(true);
+      expect(harness.registry.get(first.directory)).not.toBe(runtime);
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            first,
+            {
+              operationId: crypto.randomUUID(),
+            },
+            deps
+          )
+        ).ok
+      ).toBe(true);
+      expect(harness.launches).toHaveLength(3);
+      expect(harness.unexpectedCloses).toBe(0);
+    } finally {
+      terminals.shutdown();
+    }
+  });
+
+  it('retires only the final root runtime and permits reuse without affecting another worktree', async () => {
+    const harness = createRegistry();
+    const directory = path.join(tmpDir, 'shared');
+    const first = await harness.registry.ensure(directory, auth);
+    const siblingIdentity = rootIdentity(directory, 'sibling');
+    const sibling = harness.registry.attach(siblingIdentity, auth);
+    const other = await harness.registry.ensure(path.join(tmpDir, 'other'), {
+      ...auth,
+      scopeId: 'other',
+    });
+    const marker = path.join(directory, '.kilo-bootstrap-complete');
+    fs.writeFileSync(marker, 'ready');
+
+    expect(harness.registry.detach(rootIdentity(directory))).toBe(true);
+    expect(harness.registry.get(directory)).toBe(first);
+    expect(sibling.signal.aborted).toBe(false);
+    expect(await sibling.ready).toBe(first);
+    sibling.commit();
+    sibling.release();
+    expect(harness.closes).toBe(0);
+
+    expect(harness.registry.detach(siblingIdentity)).toBe(true);
+    expect(first.signal.aborted).toBe(true);
+    expect(harness.registry.get(directory)).toBeUndefined();
+    expect(harness.closes).toBe(1);
+    expect(harness.registry.get(other.directory)).toBe(other);
+    await other.kiloClient.abortSession({ sessionId: 'root_other' });
+    const otherServer = servers.find(server => server.url === other.kiloClient.serverUrl);
+    expect(otherServer?.requests.at(-1)?.pathname).toBe('/session/root_other/abort');
+
+    const replacement = await harness.registry.ensure(directory, {
+      ...auth,
+      token: 'replacement-token',
+    });
+    expect(replacement).not.toBe(first);
+    expect(replacement.env.HOME).toBe(first.env.HOME);
+    expect(replacement.env.KILOCODE_TOKEN).toBe('replacement-token');
+    expect(fs.readFileSync(marker, 'utf8')).toBe('ready');
+    expect(harness.registry.get(other.directory)).toBe(other);
+    expect(harness.unexpectedCloses).toBe(0);
+    expect(harness.launches).toHaveLength(3);
+  });
+
+  it('does not accumulate duplicate roots or release a committed root on a failed retry', async () => {
+    const harness = createRegistry();
+    const identity = rootIdentity(path.join(tmpDir, 'shared'));
+    const first = harness.registry.attach(identity, auth);
+    const duplicate = harness.registry.attach(identity, auth);
+    first.release();
+    first.release();
+    const runtime = await duplicate.ready;
+    await first.ready;
+    duplicate.commit();
+    duplicate.release();
+    const retry = harness.registry.attach(identity, auth);
+    expect(await retry.ready).toBe(runtime);
+    retry.release();
+
+    expect(harness.registry.get(identity.directory)).toBe(runtime);
+    expect(harness.closes).toBe(0);
+    expect(harness.launches).toHaveLength(1);
+    expect(harness.registry.detach(identity)).toBe(true);
+    expect(harness.registry.detach(identity)).toBe(false);
+    expect(harness.closes).toBe(1);
+    expect(runtime.signal.aborted).toBe(true);
+  });
+
+  it('rejects mismatched root identities while startup is pending without disturbing ownership', async () => {
+    const harness = createRegistry();
+    const identity = rootIdentity(path.join(tmpDir, 'shared'));
+    const attachment = harness.registry.attach(identity, auth);
+    for (const mismatch of [
+      { ...identity, directory: path.join(tmpDir, 'other') },
+      { ...identity, sessionId: 'workspace_foreign' },
+      { ...identity, kiloSessionId: 'root_foreign' },
+    ]) {
+      expect(() => harness.registry.attach(mismatch, auth)).toThrow('Session identity mismatch');
+      expect(() => harness.registry.detach(mismatch)).toThrow('Session identity mismatch');
+    }
+    const runtime = await attachment.ready;
+    attachment.commit();
+    expect(harness.registry.get(identity.directory)).toBe(runtime);
+    expect(harness.registry.detach(rootIdentity(identity.directory, 'unknown'))).toBe(false);
+    expect(harness.closes).toBe(0);
+  });
+
+  it('keeps a pending sibling startup alive while cancelling only the detached root', async () => {
+    const launched = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const server = createKiloStub();
+    servers.push(server);
+    let closes = 0;
+    const { registry } = createRegistry({
+      startServer: async () => {
+        launched.resolve();
+        await release.promise;
+        return {
+          url: server.url,
+          close: () => {
+            closes += 1;
+          },
+        };
+      },
+    });
+    const directory = path.join(tmpDir, 'shared');
+    const firstIdentity = rootIdentity(directory, 'first');
+    const first = registry.attach(firstIdentity, auth);
+    const siblingIdentity = rootIdentity(directory, 'sibling');
+    const sibling = registry.attach(siblingIdentity, auth);
+    try {
+      await launched.promise;
+      expect(registry.detach(firstIdentity)).toBe(true);
+      expect(first.signal.aborted).toBe(true);
+      expect(sibling.signal.aborted).toBe(false);
+      release.resolve();
+      const runtime = await sibling.ready;
+      await first.ready;
+      expect(() => first.commit()).toThrow();
+      first.release();
+      sibling.commit();
+      expect(registry.get(directory)).toBe(runtime);
+      expect(closes).toBe(0);
+      expect(registry.detach(siblingIdentity)).toBe(true);
+      expect(closes).toBe(1);
+    } finally {
+      release.resolve();
+      await Promise.allSettled([first.ready, sibling.ready]);
+    }
+  });
+
+  it('fences late startup and cleanup from a replacement lifetime and its auth files', async () => {
+    const launched = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const oldServer = createKiloStub();
+    const newServer = createKiloStub();
+    servers.push(oldServer, newServer);
+    const steps: string[] = [];
+    const harness = createRegistry({
+      startServer: async options => {
+        const old = options.env.KILOCODE_TOKEN === auth.token;
+        steps.push(old ? 'start-old' : 'start-new');
+        if (old) {
+          launched.resolve();
+          await release.promise;
+        }
+        return {
+          url: old ? oldServer.url : newServer.url,
+          close: () => {
+            steps.push(old ? 'close-old' : 'close-new');
+          },
+        };
+      },
+    });
+    const identity = rootIdentity(path.join(tmpDir, 'shared'));
+    const old = harness.registry.attach(identity, auth);
+    const oldResult = rejected(old.ready);
+    try {
+      await launched.promise;
+      expect(harness.registry.detach(identity)).toBe(true);
+      const replacement = harness.registry.attach(identity, { ...auth, token: 'replacement' });
+      old.release();
+      await Promise.resolve();
+      expect(steps).toEqual(['start-old']);
+      release.resolve();
+      expect(await oldResult).toMatchObject({ code: 'not_ready' });
+      const runtime = await replacement.ready;
+      replacement.commit();
+      old.release();
+      expect(steps).toEqual(['start-old', 'close-old', 'start-new']);
+      expect(oldServer.feedConnections).toBe(0);
+      expect(newServer.feedConnections).toBe(1);
+      expect(harness.registry.get(identity.directory)).toBe(runtime);
+      expect(
+        JSON.parse(
+          fs.readFileSync(path.join(runtime.env.XDG_DATA_HOME, 'kilo', 'auth.json'), 'utf8')
+        )
+      ).toEqual({
+        kilo: { type: 'api', key: 'replacement' },
+      });
+      expect(() =>
+        harness.registry.attach(rootIdentity(path.join(tmpDir, 'other')), {
+          ...auth,
+          token: 'replacement',
+        })
+      ).toThrow('Kilo worktree auth context mismatch');
+      expect(harness.unexpectedCloses).toBe(0);
+    } finally {
+      release.resolve();
+      await oldResult;
+    }
+  });
+
+  it('rejects scope, directory, token, and target changes without launching another server', async () => {
+    const { registry, launches } = createRegistry();
+    const directory = path.join(tmpDir, 'worktree-a');
+    await registry.ensure(directory, auth);
+    const conflicts = [
+      { ...auth, scopeId: 'different-scope' },
+      { ...auth, token: 'different-token' },
+      ...Object.keys(auth.targets).map(key => ({
+        ...auth,
+        targets: { ...auth.targets, [key]: 'https://different.example.test' },
+      })),
+    ];
+    for (const conflict of conflicts) {
+      expect(await rejected(registry.ensure(directory, conflict))).toMatchObject({
+        code: 'unauthorized',
+        message: 'Kilo worktree auth context mismatch',
+        retryable: false,
+      });
+    }
+    expect(await rejected(registry.ensure(path.join(tmpDir, 'worktree-b'), auth))).toMatchObject({
+      code: 'unauthorized',
+    });
+    expect(launches).toHaveLength(1);
+  });
+
+  it('releases a failed sole attachment and permits retry with fresh auth', async () => {
+    let attempts = 0;
+    const stub = createKiloStub();
+    servers.push(stub);
+    const { registry } = createRegistry({
+      startServer: async () => {
+        attempts += 1;
+        if (attempts === 1) throw new Error('actual-managed-token');
+        return { url: stub.url, close: () => {} };
+      },
+    });
+    const directory = path.join(tmpDir, 'worktree-a');
+    expect(await rejected(registry.ensure(directory, auth))).toMatchObject({
+      message: 'Kilo worktree failed to start',
+    });
+    expect(registry.get(directory)).toBeUndefined();
+    const runtime = await registry.ensure(directory, { ...auth, token: 'changed-token' });
+    expect(runtime.scopeId).toBe(auth.scopeId);
+    expect(runtime.env.KILOCODE_TOKEN).toBe('changed-token');
+    expect(attempts).toBe(2);
+  });
+
+  it('closes all worktree servers and feeds once and prevents later use', async () => {
+    const harness = createRegistry();
+    const first = await harness.registry.ensure(path.join(tmpDir, 'a'), auth);
+    const second = await harness.registry.ensure(path.join(tmpDir, 'b'), {
+      ...auth,
+      scopeId: 'worktree_b',
+    });
+    harness.registry.shutdown();
+    harness.registry.shutdown();
+    expect(first.signal.aborted).toBe(true);
+    expect(second.signal.aborted).toBe(true);
+    expect(harness.closes).toBe(2);
+    expect(harness.registry.get(first.directory)).toBeUndefined();
+    expect(await rejected(harness.registry.ensure(first.directory, auth))).toMatchObject({
+      message: 'Kilo worktrees are closed',
+    });
+    await Bun.sleep(0);
+    expect(harness.unexpectedCloses).toBe(0);
+  });
+
+  it('closes a server whose launch completes after shutdown without opening its event feed', async () => {
+    const launched = Promise.withResolvers<void>();
+    const released = Promise.withResolvers<void>();
+    const stub = createKiloStub();
+    servers.push(stub);
+    let closes = 0;
+    const { registry } = createRegistry({
+      startServer: async () => {
+        launched.resolve();
+        await released.promise;
+        return {
+          url: stub.url,
+          close: () => {
+            closes += 1;
+          },
+        };
+      },
+    });
+    const pending = registry.ensure(path.join(tmpDir, 'a'), auth);
+    const failure = pending.catch((error: unknown) => error);
+    await launched.promise;
+    registry.shutdown();
+    released.resolve();
+    expect(await failure).toMatchObject({
+      code: 'not_ready',
+      message: 'Kilo worktree failed to start',
+    });
+    expect(closes).toBe(1);
+    expect(stub.feedConnections).toBe(0);
+  });
+
+  it('invalidates a runtime and reports an unexpected event-feed closure', async () => {
+    const harness = createRegistry();
+    const runtime = await harness.registry.ensure(path.join(tmpDir, 'a'), auth);
+    servers[0]?.endFeeds();
+    await waitUntil(() => harness.unexpectedCloses === 1);
+    expect(runtime.signal.aborted).toBe(true);
+    expect(harness.registry.get(runtime.directory)).toBeUndefined();
+    expect(harness.closes).toBe(1);
+  });
+});
+
+describe('worktree attachment lifecycle', () => {
+  it.each(['setup', 'restore', 'terminal'] as const)(
+    'releases a failed sole %s attachment and its routing',
+    async phase => {
+      const harness = createRegistry();
+      const identity = rootIdentity(path.join(tmpDir, 'worktree'));
+      const result = await applySessionAttach(
+        identity,
+        {
+          kilo: auth,
+          ...(phase === 'setup' ? { setupCommands: ['prepare'] } : {}),
+        },
+        {
+          kiloRuntimes: harness.registry,
+          hasBootstrapMarker: async () => false,
+          runSetup: async () => ({ stdout: '', stderr: '', exitCode: 1 }),
+          sessionExists: async () => phase === 'terminal',
+          restoreSession: async () => ({
+            ok: false,
+            error: 'restore failed',
+            code: 502,
+            step: 'download',
+          }),
+          terminalRuntime: {
+            rememberAttachedSession: () => {
+              throw new ControlTerminalRuntimeError(
+                'unauthorized',
+                'Terminal ownership mismatch',
+                false
+              );
+            },
+          },
+        }
+      );
+      expect(result.ok).toBe(false);
+      expect(harness.registry.get(identity.directory)).toBeUndefined();
+      expect(rootForSession(identity.kiloSessionId)).toBeUndefined();
+      expect(directoryForSession(identity.kiloSessionId)).toBeUndefined();
+      expect(harness.closes).toBe(1);
+      const deps = createHandlerDeps(harness.registry);
+      expect(
+        (
+          await handleControlRequest(
+            'session.attach',
+            identity,
+            {
+              kilo: { ...auth, token: 'replacement' },
+            },
+            deps
+          )
+        ).ok
+      ).toBe(true);
+      expect(harness.registry.get(identity.directory)?.env.KILOCODE_TOKEN).toBe('replacement');
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identity,
+            {
+              operationId: crypto.randomUUID(),
+            },
+            deps
+          )
+        ).ok
+      ).toBe(true);
+      expect(harness.unexpectedCloses).toBe(0);
+    }
+  );
+
+  it('keeps a restoring sibling alive after the last committed root detaches', async () => {
+    const harness = createRegistry();
+    const deps = createHandlerDeps(harness.registry);
+    const first = rootIdentity(path.join(tmpDir, 'shared'), 'first');
+    const sibling = rootIdentity(first.directory, 'sibling');
+    expect((await handleControlRequest('session.attach', first, { kilo: auth }, deps)).ok).toBe(
+      true
+    );
+    const runtime = harness.registry.get(first.directory);
+    const restoring = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const pending = applySessionAttach(
+      sibling,
+      { kilo: auth },
+      {
+        ...deps,
+        sessionExists: async () => false,
+        restoreSession: async () => {
+          restoring.resolve();
+          await release.promise;
+          return {
+            ok: true,
+            downloaded: true,
+            imported: true,
+            diffs: { applied: 0, skipped: 0, total: 0 },
+          };
+        },
+      }
+    );
+    try {
+      await restoring.promise;
+      expect((await handleControlRequest('session.detach', first, {}, deps)).ok).toBe(true);
+      expect(runtime?.signal.aborted).toBe(false);
+      expect(harness.closes).toBe(0);
+      release.resolve();
+      expect(await pending).toEqual({ ok: true, result: { attached: true } });
+      expect(harness.registry.get(first.directory)).toBe(runtime);
+      expect(rootForSession(first.kiloSessionId)).toBeUndefined();
+      expect(rootForSession(sibling.kiloSessionId)).toBe(sibling.kiloSessionId);
+      expect((await handleControlRequest('session.detach', sibling, {}, deps)).ok).toBe(true);
+      expect(runtime?.signal.aborted).toBe(true);
+      expect(harness.closes).toBe(1);
+    } finally {
+      release.resolve();
+      await pending;
+    }
+  });
+
+  it('does not let a failed duplicate attachment release a successful root', async () => {
+    const harness = createRegistry();
+    const deps = createHandlerDeps(harness.registry);
+    const identity = rootIdentity(path.join(tmpDir, 'shared'));
+    const restoring = Promise.withResolvers<void>();
+    const release = Promise.withResolvers<void>();
+    const pending = applySessionAttach(
+      identity,
+      { kilo: auth },
+      {
+        ...deps,
+        sessionExists: async () => false,
+        restoreSession: async () => {
+          restoring.resolve();
+          await release.promise;
+          return { ok: false, error: 'restore failed', code: 502, step: 'download' };
+        },
+      }
+    );
+    try {
+      await restoring.promise;
+      expect(
+        (await handleControlRequest('session.attach', identity, { kilo: auth }, deps)).ok
+      ).toBe(true);
+      const runtime = harness.registry.get(identity.directory);
+      release.resolve();
+      expect((await pending).ok).toBe(false);
+      expect(harness.registry.get(identity.directory)).toBe(runtime);
+      expect(rootForSession(identity.kiloSessionId)).toBe(identity.kiloSessionId);
+      expect(harness.closes).toBe(0);
+      expect((await handleControlRequest('session.detach', identity, {}, deps)).ok).toBe(true);
+      expect(harness.closes).toBe(1);
+      expect(runtime?.signal.aborted).toBe(true);
+    } finally {
+      release.resolve();
+      await pending;
+    }
+  });
+
+  it('fences a detached restore from reattaching over a replacement root while its sibling stays live', async () => {
+    const harness = createRegistry();
+    const deps = createHandlerDeps(harness.registry);
+    const sibling = rootIdentity(path.join(tmpDir, 'shared'), 'sibling');
+    const identity = rootIdentity(sibling.directory, 'first');
+    expect((await handleControlRequest('session.attach', sibling, { kilo: auth }, deps)).ok).toBe(
+      true
+    );
+    const runtime = harness.registry.get(identity.directory);
+    const restoring = Promise.withResolvers<AbortSignal>();
+    const release = Promise.withResolvers<void>();
+    const pending = applySessionAttach(
+      identity,
+      { kilo: auth },
+      {
+        ...deps,
+        sessionExists: async () => false,
+        restoreSession: async (_id, _directory, _file, options) => {
+          if (!options?.signal) throw new Error('Expected restore cancellation signal');
+          restoring.resolve(options.signal);
+          await release.promise;
+          return {
+            ok: true,
+            downloaded: true,
+            imported: true,
+            diffs: { applied: 0, skipped: 0, total: 0 },
+          };
+        },
+      }
+    );
+    try {
+      const signal = await restoring.promise;
+      expect(rootForSession(identity.kiloSessionId)).toBeUndefined();
+      expect((await handleControlRequest('session.detach', identity, {}, deps)).ok).toBe(true);
+      expect(signal.aborted).toBe(true);
+      expect(runtime?.signal.aborted).toBe(false);
+      expect(
+        (await handleControlRequest('session.attach', identity, { kilo: auth }, deps)).ok
+      ).toBe(true);
+      release.resolve();
+      expect((await pending).ok).toBe(false);
+      expect(harness.registry.get(identity.directory)).toBe(runtime);
+      expect(rootForSession(identity.kiloSessionId)).toBe(identity.kiloSessionId);
+      expect(rootForSession(sibling.kiloSessionId)).toBe(sibling.kiloSessionId);
+      expect(
+        (
+          await handleControlRequest(
+            'session.terminal.create',
+            identity,
+            {
+              operationId: crypto.randomUUID(),
+            },
+            deps
+          )
+        ).ok
+      ).toBe(true);
+      expect(harness.closes).toBe(0);
+      expect(harness.launches).toHaveLength(1);
+    } finally {
+      release.resolve();
+      await pending;
+    }
+  });
+
+  it('cancels detached workspace preparation before marking it complete and permits retry', async () => {
+    const harness = createRegistry();
+    const deps = createHandlerDeps(harness.registry);
+    const identity = rootIdentity(path.join(tmpDir, 'shared'));
+    const preparing = Promise.withResolvers<AbortSignal | undefined>();
+    const release = Promise.withResolvers<void>();
+    let markers = 0;
+    const preparation: ApplyAttachDeps = {
+      ...deps,
+      hasBootstrapMarker: async () => false,
+      runSetup: async (_command, _directory, _env, _output, signal) => {
+        preparing.resolve(signal);
+        await release.promise;
+        return { stdout: '', stderr: '', exitCode: 0 };
+      },
+      writeBootstrapMarker: async () => {
+        markers += 1;
+      },
+    };
+    const pending = applySessionAttach(
+      identity,
+      { kilo: auth, setupCommands: ['prepare'] },
+      preparation
+    );
+    try {
+      const signal = await preparing.promise;
+      expect((await handleControlRequest('session.detach', identity, {}, deps)).ok).toBe(true);
+      expect(signal?.aborted).toBe(true);
+      expect(harness.closes).toBe(1);
+      const replacement = handleControlRequest(
+        'session.attach',
+        identity,
+        {
+          kilo: { ...auth, token: 'replacement' },
+        },
+        deps
+      );
+      release.resolve();
+      expect((await pending).ok).toBe(false);
+      expect(await replacement).toEqual({ ok: true, result: { attached: true } });
+      expect(markers).toBe(0);
+      expect(rootForSession(identity.kiloSessionId)).toBe(identity.kiloSessionId);
+      expect(harness.registry.get(identity.directory)?.env.KILOCODE_TOKEN).toBe('replacement');
+    } finally {
+      release.resolve();
+      await pending;
+    }
+  });
+});
+
+describe('explicit Kilo child launcher', () => {
+  function launchEnvironment(script: string) {
+    const bin = path.join(tmpDir, 'bin');
+    const directory = path.join(tmpDir, 'workspace');
+    fs.mkdirSync(bin);
+    fs.mkdirSync(directory);
+    fs.writeFileSync(path.join(bin, 'kilo'), `#!${process.execPath}\n${script}`, { mode: 0o755 });
+    const env = buildWorktreeKiloEnvironment(
+      directory,
+      path.join(tmpDir, 'home'),
+      auth,
+      {
+        PATH: `${bin}:${process.env.PATH ?? ''}`,
+        PID_PATH: path.join(tmpDir, 'child.pid'),
+      },
+      inherited
+    );
+    const abort = new AbortController();
+    aborts.push(abort);
+    return { directory, env, signal: abort.signal, abort };
+  }
+
+  it('starts with the explicit cwd/env, handles split readiness output, and stops on close', async () => {
+    const options = launchEnvironment(`
+const server = Bun.serve({
+  port: 0,
+  hostname: '127.0.0.1',
+  fetch: () => Response.json({
+    pid: process.pid,
+    cwd: process.cwd(),
+    args: process.argv.slice(2),
+    token: process.env.KILOCODE_TOKEN,
+    home: process.env.HOME,
+    config: process.env.KILO_CONFIG_CONTENT,
+    control: process.env.SANDBOX_CONTROL_CREDENTIAL,
+    github: process.env.GH_TOKEN,
+  }),
+});
+const line = 'kilo server listening on ' + server.url.origin + '\\n';
+process.stdout.write(line.slice(0, -3));
+setTimeout(() => process.stdout.write(line.slice(-3)), 25);
+`);
+    const handle = await startWorktreeKiloServer(options);
+    const state = (await (await fetch(handle.url)).json()) as {
+      pid: number;
+      cwd: string;
+      args: string[];
+      token: string;
+      home: string;
+      config: string;
+    };
+    expect(state).toEqual({
+      pid: expect.any(Number),
+      cwd: fs.realpathSync(options.directory),
+      args: ['serve', '--hostname=127.0.0.1', '--port=0'],
+      token: auth.token,
+      home: options.env.HOME,
+      config: options.env.KILO_CONFIG_CONTENT,
+    });
+    handle.close();
+    handle.close();
+    await waitUntil(() => {
+      try {
+        process.kill(state.pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    });
+  });
+
+  it('terminates a startup timeout and does not expose child output in errors', async () => {
+    const options = launchEnvironment(`
+await Bun.write(process.env.PID_PATH, String(process.pid));
+console.error('actual-managed-token');
+setInterval(() => {}, 1000);
+`);
+    expect(await rejected(startWorktreeKiloServer({ ...options, timeoutMs: 500 }))).toMatchObject({
+      message: 'Kilo server failed to start',
+    });
+    const pid = Number(fs.readFileSync(options.env.PID_PATH, 'utf8'));
+    await waitUntil(() => {
+      try {
+        process.kill(pid, 0);
+        return false;
+      } catch {
+        return true;
+      }
+    });
+  });
+
+  it('does not spawn when the worktree has already shut down', async () => {
+    const options = launchEnvironment(
+      `await Bun.write(process.env.PID_PATH, String(process.pid));`
+    );
+    options.abort.abort();
+    expect(await rejected(startWorktreeKiloServer(options))).toBeInstanceOf(Error);
+    expect(fs.existsSync(options.env.PID_PATH)).toBe(false);
+  });
+});

--- a/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
+++ b/services/cloud-agent-next/wrapper/src/control/worktree-runtime.ts
@@ -1,0 +1,483 @@
+import { spawn } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import fs from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { createKiloClient } from '@kilocode/sdk';
+import { CONTROL_PLANE_SANDBOX_PERMISSION } from '../../../src/shared/control-plane-permission.js';
+import type {
+  ControlErrorCode,
+  SessionAttachPayload,
+  SessionRequestIdentity,
+} from '../../../src/shared/sandbox-control-protocol.js';
+import { CONTROL_RUNTIME_RESERVED_ENV_VARS } from '../../../src/shared/runtime-environment.js';
+import {
+  createWrapperKiloClient,
+  type KiloServerHandle,
+  type WrapperKiloClient,
+} from '../kilo-api.js';
+import { withTimeoutAndAbort } from '../utils.js';
+import { unfilteredKiloEvents } from './feed.js';
+import { startSandboxControlEventFeed } from './sandbox-control-runtime.js';
+
+export type WorktreeKiloAuth = NonNullable<SessionAttachPayload['kilo']>;
+
+export type WorktreeKiloRuntime = {
+  readonly scopeId: string;
+  readonly directory: string;
+  readonly env: Record<string, string>;
+  readonly kiloClient: WrapperKiloClient;
+  readonly signal: AbortSignal;
+};
+
+export type WorktreeKiloAttachment = {
+  ready: Promise<WorktreeKiloRuntime>;
+  signal: AbortSignal;
+  commit(): void;
+  release(): void;
+};
+
+export type WorktreeKiloRuntimes = {
+  attach(
+    identity: SessionRequestIdentity,
+    kilo: WorktreeKiloAuth,
+    env?: Record<string, string>
+  ): WorktreeKiloAttachment;
+  detach(identity: SessionRequestIdentity): boolean;
+  get(directory: string): WorktreeKiloRuntime | undefined;
+  isHealthy(): boolean;
+  shutdown(): void;
+};
+
+type WorktreeKiloEvent = {
+  type: string;
+  properties: Record<string, unknown>;
+  directory?: string;
+};
+
+type ServerOptions = {
+  directory: string;
+  env: Record<string, string>;
+  signal: AbortSignal;
+  timeoutMs?: number;
+};
+
+type RuntimeEntry = {
+  kilo: WorktreeKiloAuth;
+  directory: string;
+  env: Record<string, string>;
+  abort: AbortController;
+  roots: Set<RootAttachment>;
+  runtime?: WorktreeKiloRuntime;
+  feed?: Awaited<ReturnType<typeof startSandboxControlEventFeed>>;
+  starting?: Promise<WorktreeKiloRuntime>;
+  retiring?: Promise<void>;
+};
+
+type RootAttachment = {
+  identity: SessionRequestIdentity;
+  entry: RuntimeEntry;
+  abort: AbortController;
+  attached: boolean;
+  pending: Set<symbol>;
+};
+
+const KILO_STARTUP_TIMEOUT_MS = 30_000;
+const BITBUCKET_METADATA_ENV_VARS = new Set([
+  'KILO_BITBUCKET_WORKSPACE_SLUG',
+  'KILO_BITBUCKET_REPOSITORY_SLUG',
+  'KILO_BITBUCKET_WORKSPACE_UUID',
+  'KILO_BITBUCKET_REPOSITORY_UUID',
+]);
+const INHERITED_GIT_CREDENTIALS = new Set([
+  'GH_TOKEN',
+  'GITHUB_TOKEN',
+  'GITLAB_TOKEN',
+  'GITLAB_OAUTH_TOKEN',
+  'BITBUCKET_TOKEN',
+  'BITBUCKET_APP_PASSWORD',
+]);
+
+export class WorktreeKiloRuntimeError extends Error {
+  constructor(
+    readonly code: ControlErrorCode,
+    message: string,
+    readonly retryable: boolean
+  ) {
+    super(message);
+    this.name = 'WorktreeKiloRuntimeError';
+  }
+}
+
+export function buildWorktreeKiloEnvironment(
+  directory: string,
+  home: string,
+  kilo: WorktreeKiloAuth,
+  environment: Record<string, string> = {},
+  inherited: NodeJS.ProcessEnv = process.env
+): Record<string, string> {
+  const env: Record<string, string> = {};
+  const reserved = new Set<string>(CONTROL_RUNTIME_RESERVED_ENV_VARS);
+  const isRuntimeOwned = (name: string): boolean =>
+    reserved.has(name) ||
+    name === 'HOME' ||
+    name.startsWith('XDG_') ||
+    name.startsWith('KILO') ||
+    name.startsWith('OPENCODE');
+
+  for (const [name, value] of Object.entries(inherited)) {
+    if (value !== undefined && !isRuntimeOwned(name) && !INHERITED_GIT_CREDENTIALS.has(name)) {
+      env[name] = value;
+    }
+  }
+  for (const [name, value] of Object.entries(environment)) {
+    if (!isRuntimeOwned(name) || BITBUCKET_METADATA_ENV_VARS.has(name)) env[name] = value;
+  }
+
+  const config = JSON.stringify({
+    autoupdate: false,
+    permission: CONTROL_PLANE_SANDBOX_PERMISSION,
+    provider: {
+      kilo: {
+        options: {
+          apiKey: kilo.token,
+          kilocodeToken: kilo.token,
+          baseURL: kilo.targets.providerBaseUrl,
+        },
+      },
+    },
+  });
+
+  return {
+    ...env,
+    PWD: directory,
+    HOME: home,
+    XDG_DATA_HOME: path.join(home, '.local', 'share'),
+    XDG_CONFIG_HOME: path.join(home, '.config'),
+    XDG_CACHE_HOME: path.join(home, '.cache'),
+    XDG_STATE_HOME: path.join(home, '.local', 'state'),
+    XDG_RUNTIME_DIR: path.join(home, '.run'),
+    KILO_PLATFORM: 'cloud-agent',
+    KILO_DISABLE_AUTOUPDATE: 'true',
+    KILO_DEBUG_SESSION_INGEST: '1',
+    KILOCODE_TOKEN: kilo.token,
+    KILO_AUTH_CONTENT: JSON.stringify({ kilo: { type: 'api', key: kilo.token } }),
+    KILOCODE_BACKEND_BASE_URL: kilo.targets.backendBaseUrl,
+    KILO_API_URL: kilo.targets.backendBaseUrl,
+    KILO_OPENROUTER_BASE: kilo.targets.providerBaseUrl,
+    KILO_SESSION_INGEST_URL: kilo.targets.sessionIngestBaseUrl,
+    KILO_CONFIG_CONTENT: config,
+    OPENCODE_CONFIG_CONTENT: config,
+  };
+}
+
+export async function startWorktreeKiloServer(options: ServerOptions): Promise<KiloServerHandle> {
+  options.signal.throwIfAborted();
+  const proc = spawn('kilo', ['serve', '--hostname=127.0.0.1', '--port=0'], {
+    cwd: options.directory,
+    env: options.env,
+    stdio: ['ignore', 'pipe', 'ignore'],
+  });
+  let closed = false;
+  const close = (): void => {
+    if (closed) return;
+    closed = true;
+    options.signal.removeEventListener('abort', close);
+    if (proc.exitCode === null && proc.signalCode === null) proc.kill();
+  };
+  options.signal.addEventListener('abort', close, { once: true });
+
+  try {
+    const url = await new Promise<string>((resolve, reject) => {
+      let output = '';
+      const timeout = setTimeout(
+        () => fail('Kilo server startup timed out'),
+        options.timeoutMs ?? KILO_STARTUP_TIMEOUT_MS
+      );
+      const cleanup = (): void => {
+        clearTimeout(timeout);
+        options.signal.removeEventListener('abort', onAbort);
+        proc.stdout.removeListener('data', onOutput);
+        proc.removeListener('exit', onExit);
+      };
+      const fail = (message: string): void => {
+        cleanup();
+        reject(new Error(message));
+      };
+      const onAbort = (): void => fail('Kilo server startup aborted');
+      const onExit = (): void => fail('Kilo server exited before startup');
+      const onOutput = (chunk: Buffer): void => {
+        output = (output + chunk.toString()).slice(-65_536);
+        const match = /^kilo server listening on (http:\/\/127\.0\.0\.1:\d+)\r?\n/m.exec(output);
+        if (!match?.[1]) return;
+        cleanup();
+        resolve(match[1]);
+      };
+      proc.stdout.on('data', onOutput);
+      proc.once('exit', onExit);
+      proc.on('error', () => fail('Kilo server failed to start'));
+      options.signal.addEventListener('abort', onAbort, { once: true });
+      if (options.signal.aborted) onAbort();
+    });
+    proc.stdout.resume();
+    proc.once('exit', close);
+    return { url, close };
+  } catch {
+    close();
+    throw new Error('Kilo server failed to start');
+  }
+}
+
+function sameAuth(left: WorktreeKiloAuth, right: WorktreeKiloAuth): boolean {
+  return (
+    left.scopeId === right.scopeId &&
+    left.token === right.token &&
+    left.targets.backendBaseUrl === right.targets.backendBaseUrl &&
+    left.targets.providerBaseUrl === right.targets.providerBaseUrl &&
+    left.targets.sessionIngestBaseUrl === right.targets.sessionIngestBaseUrl
+  );
+}
+
+export function createWorktreeKiloRuntimes(options: {
+  homeRoot?: string;
+  inheritedEnv?: NodeJS.ProcessEnv;
+  startServer?: (options: ServerOptions) => Promise<KiloServerHandle>;
+  onEvent?: (runtime: WorktreeKiloRuntime, event: WorktreeKiloEvent) => void;
+  onUnexpectedClose: () => void;
+}): WorktreeKiloRuntimes {
+  const entries = new Map<string, RuntimeEntry>();
+  const directoriesByScope = new Map<string, string>();
+  const roots = new Map<string, RootAttachment>();
+  let closed = false;
+
+  function findRoot(identity: SessionRequestIdentity): RootAttachment | undefined {
+    for (const root of roots.values()) {
+      if (
+        root.identity.kiloSessionId !== identity.kiloSessionId &&
+        root.identity.sessionId !== identity.sessionId
+      ) {
+        continue;
+      }
+      if (
+        root.identity.sessionId !== identity.sessionId ||
+        root.identity.kiloSessionId !== identity.kiloSessionId ||
+        root.identity.directory !== identity.directory
+      ) {
+        throw new WorktreeKiloRuntimeError('unauthorized', 'Session identity mismatch', false);
+      }
+      return root;
+    }
+    return undefined;
+  }
+
+  function retire(entry: RuntimeEntry): void {
+    if (entry.retiring) return;
+    entry.retiring = Promise.resolve(entry.starting)
+      .catch(() => undefined)
+      .then(() => {
+        if (entries.get(entry.directory) === entry) entries.delete(entry.directory);
+      });
+    if (
+      entries.get(entry.directory) === entry &&
+      directoriesByScope.get(entry.kilo.scopeId) === entry.directory
+    ) {
+      directoriesByScope.delete(entry.kilo.scopeId);
+    }
+    entry.abort.abort();
+  }
+
+  function removeRoot(root: RootAttachment): void {
+    if (roots.get(root.identity.kiloSessionId) !== root) return;
+    roots.delete(root.identity.kiloSessionId);
+    root.entry.roots.delete(root);
+    root.abort.abort();
+    if (root.entry.roots.size === 0) retire(root.entry);
+  }
+
+  async function start(
+    entry: RuntimeEntry,
+    retiring: Promise<void> | undefined
+  ): Promise<WorktreeKiloRuntime> {
+    const { abort } = entry;
+    let server: KiloServerHandle | undefined;
+    let serverClosed = false;
+    const closeServer = (): void => {
+      if (!server || serverClosed) return;
+      serverClosed = true;
+      server.close();
+    };
+    abort.signal.addEventListener('abort', closeServer, { once: true });
+    try {
+      if (retiring) await retiring;
+      abort.signal.throwIfAborted();
+      const authDirectory = path.join(entry.env.XDG_DATA_HOME, 'kilo');
+      await fs.mkdir(authDirectory, { recursive: true, mode: 0o700 });
+      await fs.mkdir(entry.env.XDG_RUNTIME_DIR, { recursive: true, mode: 0o700 });
+      await fs.mkdir(entry.directory, { recursive: true });
+      await fs.writeFile(path.join(authDirectory, 'auth.json'), entry.env.KILO_AUTH_CONTENT, {
+        mode: 0o600,
+      });
+      abort.signal.throwIfAborted();
+      server = await (options.startServer ?? startWorktreeKiloServer)({
+        directory: entry.directory,
+        env: entry.env,
+        signal: abort.signal,
+      });
+      abort.signal.throwIfAborted();
+      const client = createKiloClient({ baseUrl: server.url, directory: entry.directory });
+      const runtime: WorktreeKiloRuntime = {
+        scopeId: entry.kilo.scopeId,
+        directory: entry.directory,
+        env: entry.env,
+        kiloClient: createWrapperKiloClient(client, server.url, entry.directory),
+        signal: abort.signal,
+      };
+      entry.feed = await withTimeoutAndAbort(
+        startSandboxControlEventFeed({
+          signal: abort.signal,
+          open: signal => client.global.event({ signal, sseMaxRetryAttempts: 1 }),
+          consume: async stream => {
+            for await (const event of unfilteredKiloEvents(stream)) {
+              if (abort.signal.aborted) return;
+              options.onEvent?.(runtime, event);
+            }
+          },
+          onUnexpectedClose: () => {
+            abort.abort();
+            options.onUnexpectedClose();
+          },
+        }),
+        {
+          timeoutMs: KILO_STARTUP_TIMEOUT_MS,
+          timeoutMessage: 'Kilo event feed startup timed out',
+          signal: abort.signal,
+          abortMessage: 'Kilo worktree closed',
+        }
+      );
+      abort.signal.throwIfAborted();
+      entry.runtime = runtime;
+      return runtime;
+    } catch {
+      abort.abort();
+      closeServer();
+      throw new WorktreeKiloRuntimeError('not_ready', 'Kilo worktree failed to start', true);
+    } finally {
+      entry.starting = undefined;
+    }
+  }
+
+  return {
+    attach(identity, kilo, environment) {
+      if (closed) {
+        throw new WorktreeKiloRuntimeError('not_ready', 'Kilo worktrees are closed', false);
+      }
+      const { directory } = identity;
+      if (!path.isAbsolute(directory) || path.resolve(directory) !== directory) {
+        throw new WorktreeKiloRuntimeError('protocol_error', 'Invalid worktree directory', false);
+      }
+      let root = findRoot(identity);
+      const scopeDirectory = directoriesByScope.get(kilo.scopeId);
+      const previous = entries.get(directory);
+      let entry = previous?.retiring ? undefined : previous;
+      if (
+        (scopeDirectory && scopeDirectory !== directory) ||
+        (entry && !sameAuth(entry.kilo, kilo))
+      ) {
+        throw new WorktreeKiloRuntimeError(
+          'unauthorized',
+          'Kilo worktree auth context mismatch',
+          false
+        );
+      }
+      if (entry?.abort.signal.aborted) {
+        throw new WorktreeKiloRuntimeError('not_ready', 'Kilo worktree is closed', true);
+      }
+      if (!entry) {
+        const homeId = createHash('sha256')
+          .update(kilo.scopeId)
+          .update('\0')
+          .update(directory)
+          .digest('hex');
+        const home = path.join(
+          options.homeRoot ?? path.join(os.tmpdir(), 'kilo-worktrees'),
+          homeId
+        );
+        entry = {
+          kilo: { ...kilo, targets: { ...kilo.targets } },
+          directory,
+          env: buildWorktreeKiloEnvironment(
+            directory,
+            home,
+            kilo,
+            environment,
+            options.inheritedEnv
+          ),
+          abort: new AbortController(),
+          roots: new Set(),
+        };
+        entries.set(directory, entry);
+        directoriesByScope.set(kilo.scopeId, directory);
+      }
+      if (!root) {
+        root = {
+          identity: { ...identity },
+          entry,
+          abort: new AbortController(),
+          attached: false,
+          pending: new Set(),
+        };
+        roots.set(identity.kiloSessionId, root);
+        entry.roots.add(root);
+      }
+      const attachedRoot = root;
+      const attempt = Symbol();
+      attachedRoot.pending.add(attempt);
+      const signal = AbortSignal.any([attachedRoot.abort.signal, entry.abort.signal]);
+      const ready = entry.runtime
+        ? Promise.resolve(entry.runtime)
+        : (entry.starting ??= start(entry, previous?.retiring));
+      return {
+        ready,
+        signal,
+        commit() {
+          signal.throwIfAborted();
+          if (!attachedRoot.pending.delete(attempt)) return;
+          attachedRoot.attached = true;
+        },
+        release() {
+          if (!attachedRoot.pending.delete(attempt)) return;
+          if (!attachedRoot.attached && attachedRoot.pending.size === 0) removeRoot(attachedRoot);
+        },
+      };
+    },
+    detach(identity) {
+      const root = findRoot(identity);
+      if (!root) return false;
+      removeRoot(root);
+      return true;
+    },
+    get(directory) {
+      const runtime = entries.get(directory)?.runtime;
+      return !closed && runtime && !runtime.signal.aborted ? runtime : undefined;
+    },
+    isHealthy() {
+      return (
+        !closed &&
+        [...entries.values()].every(
+          entry =>
+            entry.retiring !== undefined ||
+            (!entry.abort.signal.aborted && (!entry.runtime || entry.feed?.isFresh() === true))
+        )
+      );
+    },
+    shutdown() {
+      if (closed) return;
+      closed = true;
+      for (const root of roots.values()) root.abort.abort();
+      roots.clear();
+      for (const entry of entries.values()) retire(entry);
+      entries.clear();
+      directoriesByScope.clear();
+    },
+  };
+}

--- a/services/cloud-agent-next/wrapper/src/kilo-api.test.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.test.ts
@@ -556,6 +556,7 @@ describe('createWrapperKiloClient generated SDK HTTP boundary', () => {
     expect(stub.requests).toHaveLength(1);
     expect(stub.requests[0].method).toBe('POST');
     expect(stub.requests[0].pathname).toBe('/permission/perm_1/reply');
+    expect(stub.requests[0].directory).toBe('/workspace');
     expect(stub.requests[0].body).toEqual({ reply: 'once', interactive: true });
   });
 

--- a/services/cloud-agent-next/wrapper/src/kilo-api.ts
+++ b/services/cloud-agent-next/wrapper/src/kilo-api.ts
@@ -327,7 +327,7 @@ export function createWrapperKiloClient(
   workspacePath: string
 ): WrapperKiloClient {
   logToFile(`creating wrapper kilo client for ${serverUrl}`);
-  const v2Client = createV2Client({ baseUrl: serverUrl });
+  const v2Client = createV2Client({ baseUrl: serverUrl, directory: workspacePath });
 
   function promptParameters(opts: PromptOptions) {
     const rawParts =

--- a/services/cloud-agent-next/wrapper/src/redact-output.test.ts
+++ b/services/cloud-agent-next/wrapper/src/redact-output.test.ts
@@ -155,6 +155,18 @@ describe('known setup secret redaction', () => {
     expect(result).toContain('development');
   });
 
+  it('retains secrets from wrapper, attachment, and rebuilt worktree configurations', () => {
+    const configs = ['wrapper-auth-secret', 'attachment-auth-secret', 'guest-worktree-alias'].map(
+      key => ({
+        KILO_AUTH_CONTENT: JSON.stringify({ kilo: { type: 'api', key } }),
+      })
+    );
+    const redact = createSecretRedactor(configs[0], configs[1], configs[2]);
+    expect(redact('wrapper-auth-secret attachment-auth-secret guest-worktree-alias ready')).toBe(
+      '[REDACTED] [REDACTED] [REDACTED] ready'
+    );
+  });
+
   it.each([1, 7, 2049])(
     'redacts split chunks of %i characters on interleaved output streams',
     chunkSize => {

--- a/services/cloud-agent-next/wrapper/src/redact-output.ts
+++ b/services/cloud-agent-next/wrapper/src/redact-output.ts
@@ -56,7 +56,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 export function createSecretRedactor(
-  environment: Record<string, string | undefined>
+  environment: Record<string, string | undefined>,
+  ...additionalEnvironments: Record<string, string | undefined>[]
 ): (text: string) => string {
   const secrets = new Set<string>();
   const remember = (value: string): void => {
@@ -79,19 +80,21 @@ export function createSecretRedactor(
       }
     }
   };
-  for (const [name, value] of Object.entries(environment)) {
-    if (!value) continue;
-    if (CONFIG_ENV_NAME.test(name)) {
-      secrets.add(value);
-      secrets.add(JSON.stringify(value).slice(1, -1));
-      try {
-        const parsed: unknown = JSON.parse(value);
-        collect(parsed);
-      } catch {
+  for (const source of [environment, ...additionalEnvironments]) {
+    for (const [name, value] of Object.entries(source)) {
+      if (!value) continue;
+      if (CONFIG_ENV_NAME.test(name)) {
+        secrets.add(value);
+        secrets.add(JSON.stringify(value).slice(1, -1));
+        try {
+          const parsed: unknown = JSON.parse(value);
+          collect(parsed);
+        } catch {
+          remember(value);
+        }
+      } else if (SECRET_NAME.test(name)) {
         remember(value);
       }
-    } else if (SECRET_NAME.test(name)) {
-      remember(value);
     }
   }
   const known = [...secrets].sort((left, right) => right.length - left.length);

--- a/services/cloud-agent-next/wrapper/src/restore-session.test.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.test.ts
@@ -2,7 +2,8 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import fs from 'node:fs';
 import path from 'node:path';
 import os from 'node:os';
-import { restoreSession, extractDiffs } from './restore-session';
+import { restoreSession, extractDiffs, seedSessionIngestRegistration } from './restore-session';
+import { buildWorktreeKiloEnvironment } from './control/worktree-runtime';
 
 const SESSION_ID = 'ses_test123';
 
@@ -121,6 +122,232 @@ function writeSignalIgnoringDescendantMockKilo(binDir: string, descendantMarker:
 // Test suite
 // ---------------------------------------------------------------------------
 
+async function rejected(operation: Promise<void>): Promise<unknown> {
+  try {
+    await operation;
+  } catch (error) {
+    return error;
+  }
+  throw new Error('Expected operation to reject');
+}
+
+describe('seedSessionIngestRegistration', () => {
+  let tmpDir: string;
+  let dataHome: string;
+  let registrationDirectory: string;
+  const sessionId = 'root_01-kilo';
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'seed-ingest-test-'));
+    dataHome = path.join(tmpDir, 'worktree data');
+    registrationDirectory = path.join(dataHome, 'kilo', 'storage', 'session_share');
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('writes only the pinned registration with restrictive permissions in the explicit data home', async () => {
+    const home = path.join(tmpDir, 'unused-home');
+    await seedSessionIngestRegistration(sessionId, {
+      HOME: home,
+      XDG_DATA_HOME: dataHome,
+      KILOCODE_TOKEN: 'managed-token-must-not-persist',
+      KILO_AUTH_CONTENT: '{"kilo":{"type":"api","key":"auth-must-not-persist"}}',
+      SANDBOX_CONTROL_CREDENTIAL: 'control-must-not-persist',
+    });
+
+    const registrationPath = path.join(registrationDirectory, `${sessionId}.json`);
+    const contents = fs.readFileSync(registrationPath, 'utf8');
+    expect(JSON.parse(contents)).toEqual({
+      id: sessionId,
+      ingestPath: `/api/session/${sessionId}/ingest`,
+    });
+    expect(contents).not.toContain('must-not-persist');
+    expect(fs.statSync(registrationPath).mode & 0o777).toBe(0o600);
+    expect(fs.statSync(registrationDirectory).mode & 0o777).toBe(0o700);
+    expect(fs.readdirSync(registrationDirectory)).toEqual([`${sessionId}.json`]);
+    expect(fs.existsSync(home)).toBe(false);
+  });
+
+  it('isolates roots and data homes across concurrent and repeated seeds', async () => {
+    const otherRoot = 'kilo_2';
+    const otherDataHome = path.join(tmpDir, 'other-data');
+    await Promise.all([
+      seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: dataHome }),
+      seedSessionIngestRegistration(otherRoot, { XDG_DATA_HOME: dataHome }),
+      seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: dataHome }),
+      seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: otherDataHome }),
+    ]);
+
+    expect(fs.readdirSync(registrationDirectory).sort()).toEqual([
+      `${otherRoot}.json`,
+      `${sessionId}.json`,
+    ]);
+    const otherDirectory = path.join(otherDataHome, 'kilo', 'storage', 'session_share');
+    expect(fs.readdirSync(otherDirectory)).toEqual([`${sessionId}.json`]);
+    for (const [directory, root] of [
+      [registrationDirectory, sessionId],
+      [registrationDirectory, otherRoot],
+      [otherDirectory, sessionId],
+    ]) {
+      expect(JSON.parse(fs.readFileSync(path.join(directory, `${root}.json`), 'utf8'))).toEqual({
+        id: root,
+        ingestPath: `/api/session/${root}/ingest`,
+      });
+    }
+  });
+
+  it('accepts a 128-character safe session ID', async () => {
+    const root = 'a'.repeat(128);
+    await seedSessionIngestRegistration(root, { XDG_DATA_HOME: dataHome });
+    expect(
+      JSON.parse(fs.readFileSync(path.join(registrationDirectory, `${root}.json`), 'utf8'))
+    ).toEqual({ id: root, ingestPath: `/api/session/${root}/ingest` });
+  });
+
+  it.each([
+    '',
+    '.',
+    '..',
+    '../root',
+    '/root',
+    'root/other',
+    'root\\other',
+    'root.json',
+    'root?other',
+    'root#other',
+    'root\n',
+    'root\r',
+    'root\0',
+    'røot',
+    'a'.repeat(129),
+  ])('rejects unsafe session ID %j before writing', async root => {
+    expect(
+      await rejected(seedSessionIngestRegistration(root, { XDG_DATA_HOME: dataHome }))
+    ).toEqual(new Error('Invalid Kilo session ID for ingest registration'));
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it.each([undefined, '', 'relative/data', '../data', '~/.local/share'])(
+    'rejects a missing or relative XDG_DATA_HOME %j',
+    async invalidDataHome => {
+      expect(
+        await rejected(
+          seedSessionIngestRegistration(sessionId, {
+            HOME: tmpDir,
+            XDG_DATA_HOME: invalidDataHome,
+          })
+        )
+      ).toEqual(new Error('Ingest registration requires an explicit absolute XDG_DATA_HOME'));
+      expect(fs.readdirSync(tmpDir)).toEqual([]);
+    }
+  );
+
+  it.each(['\0', '\r', '\n'])('rejects XDG_DATA_HOME containing %j', async character => {
+    expect(
+      await rejected(
+        seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: `${dataHome}${character}` })
+      )
+    ).toEqual(new Error('Ingest registration requires an explicit absolute XDG_DATA_HOME'));
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it('does not fall back to process-global XDG_DATA_HOME', async () => {
+    const previous = process.env.XDG_DATA_HOME;
+    process.env.XDG_DATA_HOME = dataHome;
+    try {
+      expect(await rejected(seedSessionIngestRegistration(sessionId, {}))).toEqual(
+        new Error('Ingest registration requires an explicit absolute XDG_DATA_HOME')
+      );
+      expect(fs.readdirSync(tmpDir)).toEqual([]);
+    } finally {
+      if (previous === undefined) delete process.env.XDG_DATA_HOME;
+      else process.env.XDG_DATA_HOME = previous;
+    }
+  });
+
+  it('propagates a storage-directory creation failure without replacing the blocker', async () => {
+    fs.writeFileSync(dataHome, 'not a directory');
+    expect(
+      await rejected(seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: dataHome }))
+    ).toBeInstanceOf(Error);
+    expect(fs.readFileSync(dataHome, 'utf8')).toBe('not a directory');
+    expect(fs.readdirSync(tmpDir)).toEqual(['worktree data']);
+  });
+
+  it('cleans temporary files when the final rename fails', async () => {
+    const registrationPath = path.join(registrationDirectory, `${sessionId}.json`);
+    fs.mkdirSync(registrationPath, { recursive: true });
+    expect(
+      await rejected(seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: dataHome }))
+    ).toBeInstanceOf(Error);
+    expect(fs.statSync(registrationPath).isDirectory()).toBe(true);
+    expect(fs.readdirSync(registrationDirectory)).toEqual([`${sessionId}.json`]);
+  });
+
+  it('cleans a partial write and preserves the previous registration on write failure', async () => {
+    fs.mkdirSync(registrationDirectory, { recursive: true });
+    const registrationPath = path.join(registrationDirectory, `${sessionId}.json`);
+    fs.writeFileSync(registrationPath, 'previous registration');
+    const writeFile = fs.promises.writeFile.bind(fs.promises);
+    const failure = new Error('registration write failed');
+    const write = spyOn(fs.promises, 'writeFile').mockImplementation(
+      async (file, _data, options) => {
+        await writeFile(file, '{', options);
+        throw failure;
+      }
+    );
+    try {
+      expect(
+        await rejected(seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: dataHome }))
+      ).toBe(failure);
+    } finally {
+      write.mockRestore();
+    }
+    expect(fs.readFileSync(registrationPath, 'utf8')).toBe('previous registration');
+    expect(fs.readdirSync(registrationDirectory)).toEqual([`${sessionId}.json`]);
+  });
+
+  it('does not create storage when already cancelled', async () => {
+    const controller = new AbortController();
+    const reason = new Error('workspace cancelled');
+    controller.abort(reason);
+    expect(
+      await rejected(
+        seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: dataHome }, controller.signal)
+      )
+    ).toBe(reason);
+    expect(fs.readdirSync(tmpDir)).toEqual([]);
+  });
+
+  it('cleans a completed temporary write without publishing after cancellation', async () => {
+    fs.mkdirSync(registrationDirectory, { recursive: true });
+    const registrationPath = path.join(registrationDirectory, `${sessionId}.json`);
+    fs.writeFileSync(registrationPath, 'previous registration');
+    const controller = new AbortController();
+    const reason = new Error('workspace cancelled');
+    const writeFile = fs.promises.writeFile.bind(fs.promises);
+    const write = spyOn(fs.promises, 'writeFile').mockImplementation(
+      async (file, data, options) => {
+        await writeFile(file, data, options);
+        controller.abort(reason);
+      }
+    );
+    try {
+      expect(
+        await rejected(
+          seedSessionIngestRegistration(sessionId, { XDG_DATA_HOME: dataHome }, controller.signal)
+        )
+      ).toBe(reason);
+    } finally {
+      write.mockRestore();
+    }
+    expect(fs.readFileSync(registrationPath, 'utf8')).toBe('previous registration');
+    expect(fs.readdirSync(registrationDirectory)).toEqual([`${sessionId}.json`]);
+  });
+});
+
 describe('restoreSession', () => {
   let tmpDir: string;
   let workspace: string;
@@ -145,6 +372,8 @@ describe('restoreSession', () => {
       KILO_SESSION_INGEST_URL: process.env.KILO_SESSION_INGEST_URL,
       KILOCODE_TOKEN: process.env.KILOCODE_TOKEN,
       KILOCODE_TOKEN_FILE: process.env.KILOCODE_TOKEN_FILE,
+      SANDBOX_CONTROL_CREDENTIAL: process.env.SANDBOX_CONTROL_CREDENTIAL,
+      RESTORE_PROCESS_ONLY: process.env.RESTORE_PROCESS_ONLY,
       PATH: process.env.PATH,
       TMPDIR: process.env.TMPDIR,
     };
@@ -199,6 +428,98 @@ describe('restoreSession', () => {
       expect(result.code).toBeNull();
       expect(result.step).toBe('download');
     }
+  });
+
+  it('uses the supplied worktree auth for download and import without inheriting wrapper credentials', async () => {
+    process.env.KILOCODE_TOKEN = 'actual-managed-token';
+    process.env.SANDBOX_CONTROL_CREDENTIAL = 'actual-control-credential';
+    process.env.RESTORE_PROCESS_ONLY = 'wrapper-only-value';
+    const capturePath = path.join(tmpDir, 'import-env.json');
+    const home = path.join(tmpDir, 'worktree-home');
+    const kilo = {
+      scopeId: 'worktree_restore',
+      token: 'opaque-guest-token',
+      targets: {
+        backendBaseUrl: 'https://backend.example.test',
+        providerBaseUrl: 'https://provider.example.test',
+        sessionIngestBaseUrl: 'https://ingest.example.test/worktree',
+      },
+    };
+    const env = buildWorktreeKiloEnvironment(
+      workspace,
+      home,
+      kilo,
+      {
+        PATH: process.env.PATH ?? '',
+        RESTORE_CAPTURE_PATH: capturePath,
+      },
+      {}
+    );
+    fs.writeFileSync(
+      path.join(binDir, 'kilo'),
+      `#!${process.execPath}
+await Bun.write(process.env.RESTORE_CAPTURE_PATH, JSON.stringify({
+  cwd: process.cwd(),
+  args: process.argv.slice(2),
+  HOME: process.env.HOME,
+  XDG_DATA_HOME: process.env.XDG_DATA_HOME,
+  KILOCODE_TOKEN: process.env.KILOCODE_TOKEN,
+  KILO_AUTH_CONTENT: process.env.KILO_AUTH_CONTENT,
+  KILO_CONFIG_CONTENT: process.env.KILO_CONFIG_CONTENT,
+  OPENCODE_CONFIG_CONTENT: process.env.OPENCODE_CONFIG_CONTENT,
+  SANDBOX_CONTROL_CREDENTIAL: process.env.SANDBOX_CONTROL_CREDENTIAL,
+  RESTORE_PROCESS_ONLY: process.env.RESTORE_PROCESS_ONLY,
+  ingestRegistration: await Bun.file(process.env.XDG_DATA_HOME + '/kilo/storage/session_share/${SESSION_ID}.json').json(),
+}));
+`,
+      { mode: 0o755 }
+    );
+    const requests: Array<{ url: string; authorization: string | null }> = [];
+    globalThis.fetch = asFetch((url, init) => {
+      requests.push({
+        url: typeof url === 'string' ? url : url instanceof URL ? url.href : url.url,
+        authorization: new Headers(init?.headers).get('Authorization'),
+      });
+      return Promise.resolve(new Response(makeSnapshot([]), { status: 200 }));
+    });
+
+    await seedSessionIngestRegistration(SESSION_ID, env);
+    expect((await restoreSession(SESSION_ID, workspace, undefined, { env })).ok).toBe(true);
+    expect(requests).toEqual([
+      {
+        url: `${kilo.targets.sessionIngestBaseUrl}/api/session/${SESSION_ID}/export`,
+        authorization: `Bearer ${kilo.token}`,
+      },
+    ]);
+    const imported = JSON.parse(fs.readFileSync(capturePath, 'utf8')) as Record<string, unknown>;
+    const importArgs = imported.args as string[];
+    expect(importArgs[0]).toBe('import');
+    expect(importArgs[1]).toMatch(/kilo-session-export-.*\/snapshot\.json$/);
+    expect(imported).toMatchObject({
+      cwd: fs.realpathSync(workspace),
+      HOME: home,
+      XDG_DATA_HOME: env.XDG_DATA_HOME,
+      KILOCODE_TOKEN: kilo.token,
+      KILO_AUTH_CONTENT: env.KILO_AUTH_CONTENT,
+      KILO_CONFIG_CONTENT: env.KILO_CONFIG_CONTENT,
+      OPENCODE_CONFIG_CONTENT: env.OPENCODE_CONFIG_CONTENT,
+      ingestRegistration: { id: SESSION_ID, ingestPath: `/api/session/${SESSION_ID}/ingest` },
+    });
+    expect(JSON.stringify(imported)).not.toContain('actual-');
+    expect(process.env.KILOCODE_TOKEN).toBe('actual-managed-token');
+    expect(process.env.SANDBOX_CONTROL_CREDENTIAL).toBe('actual-control-credential');
+  });
+
+  it('does not fall back to process-global auth when an explicit restore environment omits it', async () => {
+    const result = await restoreSession(SESSION_ID, workspace, undefined, {
+      env: { KILO_SESSION_INGEST_URL: 'https://ingest.example.test' },
+    });
+    expect(result).toEqual({
+      ok: false,
+      error: 'missing env vars: KILOCODE_TOKEN',
+      code: null,
+      step: 'download',
+    });
   });
 
   it('reads KILOCODE_TOKEN_FILE when KILOCODE_TOKEN is missing', async () => {

--- a/services/cloud-agent-next/wrapper/src/restore-session.ts
+++ b/services/cloud-agent-next/wrapper/src/restore-session.ts
@@ -39,6 +39,7 @@ type SnapshotDiff = {
 };
 
 export type RestoreSessionOptions = {
+  env?: NodeJS.ProcessEnv;
   importTimeoutMs?: number;
   importTerminationGraceMs?: number;
   signal?: AbortSignal;
@@ -97,17 +98,62 @@ function tryUnlink(filePath: string): void {
   }
 }
 
-function resolveKilocodeToken(): string | undefined {
-  if (process.env.KILOCODE_TOKEN) {
-    return process.env.KILOCODE_TOKEN;
+function resolveKilocodeToken(env: NodeJS.ProcessEnv): string | undefined {
+  if (env.KILOCODE_TOKEN) {
+    return env.KILOCODE_TOKEN;
   }
 
-  const tokenFile = process.env.KILOCODE_TOKEN_FILE;
+  const tokenFile = env.KILOCODE_TOKEN_FILE;
   if (!tokenFile) {
     return undefined;
   }
 
   return fs.readFileSync(tokenFile, 'utf8').replace(/[\r\n]+$/, '');
+}
+
+export async function seedSessionIngestRegistration(
+  kiloSessionId: string,
+  env: NodeJS.ProcessEnv,
+  signal?: AbortSignal
+): Promise<void> {
+  signal?.throwIfAborted();
+  if (
+    kiloSessionId.length === 0 ||
+    kiloSessionId.length > 128 ||
+    /[^A-Za-z0-9_-]/.test(kiloSessionId)
+  ) {
+    throw new Error('Invalid Kilo session ID for ingest registration');
+  }
+  const dataHome = env.XDG_DATA_HOME;
+  if (
+    !dataHome ||
+    !path.isAbsolute(dataHome) ||
+    ['\0', '\r', '\n'].some(char => dataHome.includes(char))
+  ) {
+    throw new Error('Ingest registration requires an explicit absolute XDG_DATA_HOME');
+  }
+
+  const directory = path.join(dataHome, 'kilo', 'storage', 'session_share');
+  await fs.promises.mkdir(directory, { recursive: true, mode: 0o700 });
+  signal?.throwIfAborted();
+  const temporaryPath = path.join(directory, `.${kiloSessionId}.${crypto.randomUUID()}.tmp`);
+  const file = await fs.promises.open(temporaryPath, 'wx', 0o600);
+  try {
+    try {
+      signal?.throwIfAborted();
+      await fs.promises.writeFile(
+        file,
+        JSON.stringify({ id: kiloSessionId, ingestPath: `/api/session/${kiloSessionId}/ingest` }),
+        { encoding: 'utf8', signal }
+      );
+    } finally {
+      await file.close();
+    }
+    signal?.throwIfAborted();
+    await fs.promises.rename(temporaryPath, path.join(directory, `${kiloSessionId}.json`));
+  } finally {
+    await fs.promises.rm(temporaryPath, { force: true });
+  }
 }
 
 type SnapshotInfoValidation = 'valid' | 'empty' | 'missing' | 'invalid';
@@ -450,7 +496,8 @@ async function sanitizeSnapshotWithJq(
   snapshotPath: string,
   filter: string,
   logLabel: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  env?: NodeJS.ProcessEnv
 ): Promise<boolean> {
   const tempPath = tokenSanitizationTempPath(snapshotPath);
   try {
@@ -459,6 +506,7 @@ async function sanitizeSnapshotWithJq(
       stdout: 'pipe',
       stderr: 'ignore',
       signal,
+      env,
     });
     const writeOutput = proc.stdout.pipeTo(Writable.toWeb(fs.createWriteStream(tempPath)));
     const exitCode = await proc.exited;
@@ -479,9 +527,19 @@ async function sanitizeSnapshotWithJq(
   }
 }
 
-async function sanitizeSnapshot(snapshotPath: string, signal?: AbortSignal): Promise<void> {
+async function sanitizeSnapshot(
+  snapshotPath: string,
+  signal?: AbortSignal,
+  env?: NodeJS.ProcessEnv
+): Promise<void> {
   if (
-    await sanitizeSnapshotWithJq(snapshotPath, JQ_SANITIZE_SNAPSHOT_FILTER, 'sanitization', signal)
+    await sanitizeSnapshotWithJq(
+      snapshotPath,
+      JQ_SANITIZE_SNAPSHOT_FILTER,
+      'sanitization',
+      signal,
+      env
+    )
   ) {
     log('snapshot sanitized');
     return;
@@ -506,7 +564,8 @@ const JQ_EXTRACT_DIFFS_FILTER =
  */
 export async function extractDiffs(
   snapshotPath: string,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  env?: NodeJS.ProcessEnv
 ): Promise<SnapshotDiff[] | null> {
   signal?.throwIfAborted();
   try {
@@ -514,6 +573,7 @@ export async function extractDiffs(
       stdout: 'pipe',
       stderr: 'ignore',
       signal,
+      env,
     });
     const exitCode = await proc.exited;
     signal?.throwIfAborted();
@@ -583,13 +643,15 @@ async function runGitApply(
   workspacePath: string,
   patchFile: string,
   extraArgs: string[],
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  env?: NodeJS.ProcessEnv
 ): Promise<{ exitCode: number; stderr: string }> {
   const proc = Bun.spawn(['git', 'apply', ...extraArgs, '--whitespace=nowarn', patchFile], {
     cwd: workspacePath,
     stdout: 'pipe',
     stderr: 'pipe',
     signal,
+    env,
   });
   const stderr = await new Response(proc.stderr).text();
   const exitCode = await proc.exited;
@@ -599,7 +661,8 @@ async function runGitApply(
 async function applyPatch(
   workspacePath: string,
   diff: SnapshotDiff,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  env?: NodeJS.ProcessEnv
 ): Promise<boolean> {
   if (!diff.patch) return false;
   const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-session-diff-'));
@@ -607,7 +670,7 @@ async function applyPatch(
   try {
     signal?.throwIfAborted();
     fs.writeFileSync(file, diff.patch);
-    const threeWay = await runGitApply(workspacePath, file, ['--3way'], signal);
+    const threeWay = await runGitApply(workspacePath, file, ['--3way'], signal, env);
     signal?.throwIfAborted();
     if (threeWay.exitCode === 0) return true;
     log(
@@ -621,6 +684,7 @@ async function applyPatch(
       stdout: 'pipe',
       stderr: 'pipe',
       signal,
+      env,
     });
     const resetStderr = await new Response(reset.stderr).text();
     const resetExitCode = await reset.exited;
@@ -632,7 +696,7 @@ async function applyPatch(
       return false;
     }
 
-    const plain = await runGitApply(workspacePath, file, [], signal);
+    const plain = await runGitApply(workspacePath, file, [], signal, env);
     signal?.throwIfAborted();
     if (plain.exitCode === 0) {
       log(`git apply fallback succeeded file=${diff.file}`);
@@ -697,17 +761,18 @@ export async function restoreSession(
   }
   const downloaded = !filePath;
   const importTimeoutMs = options.importTimeoutMs ?? KILO_IMPORT_TIMEOUT_MS;
+  const env = options.env ?? process.env;
 
   try {
     log(
-      `starting kiloSessionId=${kiloSessionId} workspace=${workspacePath} input=${downloaded ? 'downloaded' : 'provided'} tmpPath=${tmpPath} home=${process.env.HOME ?? '(unset)'}`
+      `starting kiloSessionId=${kiloSessionId} workspace=${workspacePath} input=${downloaded ? 'downloaded' : 'provided'} tmpPath=${tmpPath} home=${env.HOME ?? '(unset)'}`
     );
 
     if (!filePath) {
-      const ingestUrl = process.env.KILO_SESSION_INGEST_URL;
+      const ingestUrl = env.KILO_SESSION_INGEST_URL;
       let token: string | undefined;
       try {
-        token = resolveKilocodeToken();
+        token = resolveKilocodeToken(env);
       } catch {
         return fail('failed to read KILOCODE_TOKEN_FILE', null, 'download');
       }
@@ -795,15 +860,17 @@ export async function restoreSession(
       }
     }
 
-    await sanitizeSnapshot(tmpPath, options.signal);
+    await sanitizeSnapshot(tmpPath, options.signal, env);
 
     // ---- Step 2: Run kilo import ----
     const importStartedAt = Date.now();
     log(
-      `running kilo import kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${process.env.HOME ?? '(unset)'} tmpPath=${tmpPath}`
+      `running kilo import kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${env.HOME ?? '(unset)'} tmpPath=${tmpPath}`
     );
     const importResult = await runProcess('kilo', ['import', tmpPath], {
       cwd: workspacePath,
+      env,
+      inheritEnv: false,
       timeoutMs: importTimeoutMs,
       signal: options.signal,
       terminationGraceMs: options.importTerminationGraceMs,
@@ -812,7 +879,7 @@ export async function restoreSession(
 
     if (isTimeoutTermination(importResult)) {
       log(
-        `kilo import finished outcome=timeout kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${process.env.HOME ?? '(unset)'} elapsedMs=${importElapsedMs} timeoutMs=${importTimeoutMs}`
+        `kilo import finished outcome=timeout kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${env.HOME ?? '(unset)'} elapsedMs=${importElapsedMs} timeoutMs=${importTimeoutMs}`
       );
       return fail(
         `kilo import timed out after ${importTimeoutMs}ms`,
@@ -825,7 +892,7 @@ export async function restoreSession(
 
     if (importResult.exitCode !== 0) {
       log(
-        `kilo import finished outcome=error exitCode=${importResult.exitCode} kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${process.env.HOME ?? '(unset)'} elapsedMs=${importElapsedMs}`
+        `kilo import finished outcome=error exitCode=${importResult.exitCode} kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${env.HOME ?? '(unset)'} elapsedMs=${importElapsedMs}`
       );
       return fail(
         `kilo import failed exitCode=${importResult.exitCode}`,
@@ -836,13 +903,13 @@ export async function restoreSession(
       );
     }
     log(
-      `kilo import finished outcome=ok exitCode=${importResult.exitCode} kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${process.env.HOME ?? '(unset)'} elapsedMs=${importElapsedMs}`
+      `kilo import finished outcome=ok exitCode=${importResult.exitCode} kiloSessionId=${kiloSessionId} input=${downloaded ? 'downloaded' : 'provided'} cwd=${workspacePath} home=${env.HOME ?? '(unset)'} elapsedMs=${importElapsedMs}`
     );
 
     // ---- Step 3: Apply diffs ----
     // Extract diffs in a subprocess so the full snapshot JSON is never loaded
     // into this process's heap — only the small diff array crosses the boundary.
-    const uniqueDiffs = await extractDiffs(tmpPath, options.signal);
+    const uniqueDiffs = await extractDiffs(tmpPath, options.signal, env);
     if (uniqueDiffs === null) {
       return fail('failed to parse snapshot JSON', null, 'diffs');
     }
@@ -868,7 +935,7 @@ export async function restoreSession(
       options.signal?.throwIfAborted();
       if (diff.patch) {
         try {
-          if (await applyPatch(workspacePath, diff, options.signal)) {
+          if (await applyPatch(workspacePath, diff, options.signal, env)) {
             applied++;
           } else {
             skipped++;

--- a/services/cloud-agent-next/wrapper/src/utils.ts
+++ b/services/cloud-agent-next/wrapper/src/utils.ts
@@ -16,6 +16,7 @@ export type ProcessOutputStream = 'stdout' | 'stderr';
 export type ProcessOptions = {
   cwd?: string;
   env?: NodeJS.ProcessEnv;
+  inheritEnv?: boolean;
   timeoutMs?: number;
   inactivityTimeoutMs?: number;
   hardTimeoutMs?: number;
@@ -121,7 +122,11 @@ export function runProcess(
   return new Promise((resolve, reject) => {
     const proc = spawn(command, args, {
       cwd: opts?.cwd,
-      ...(opts?.env ? { env: { ...process.env, ...opts.env } } : {}),
+      ...(opts?.inheritEnv === false
+        ? { env: opts.env ?? {} }
+        : opts?.env
+          ? { env: { ...process.env, ...opts.env } }
+          : {}),
       detached: true,
       stdio: ['ignore', 'pipe', 'pipe'],
     });
@@ -328,7 +333,8 @@ export async function withTimeoutAndAbort<T>(
 export async function getCurrentBranch(
   workspacePath: string,
   timeoutMs?: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  env?: NodeJS.ProcessEnv
 ): Promise<string> {
   let result: ExecResult;
   try {
@@ -336,6 +342,7 @@ export async function getCurrentBranch(
       cwd: workspacePath,
       timeoutMs,
       signal,
+      ...(env ? { env, inheritEnv: false } : {}),
     });
   } catch {
     return '';
@@ -353,13 +360,15 @@ export async function getCurrentBranch(
 export async function hasGitUpstream(
   workspacePath: string,
   timeoutMs?: number,
-  signal?: AbortSignal
+  signal?: AbortSignal,
+  env?: NodeJS.ProcessEnv
 ): Promise<boolean> {
   try {
     const result = await git(['rev-parse', '--abbrev-ref', '@{upstream}'], {
       cwd: workspacePath,
       timeoutMs,
       signal,
+      ...(env ? { env, inheritEnv: false } : {}),
     });
     return result.exitCode === 0 && result.stdout.trim() !== '';
   } catch {

--- a/services/git-token-service/src/bitbucket-authorization-service.test.ts
+++ b/services/git-token-service/src/bitbucket-authorization-service.test.ts
@@ -185,12 +185,29 @@ describe('BitbucketAuthorizationService', () => {
     vi.restoreAllMocks();
   });
 
-  it('returns a decrypted token only for an active selected workspace', async () => {
+  it('returns a decrypted token and credential identity only for an active selected workspace', async () => {
     await expect(service().getAuthorization({ userId: 'user-1' })).resolves.toMatchObject({
       status: 'available',
       token: 'access-token',
       integrationId: 'integration-1',
+      credentialId: 'credential-1',
       workspace: { slug: 'acme' },
+    });
+  });
+
+  it('does not return a revoked OAuth credential identity', async () => {
+    const row = activeRow();
+    database.row = {
+      ...row,
+      credential: {
+        ...row.credential,
+        revoked_at: new Date().toISOString(),
+        revocation_reason: 'refresh_token_rejected',
+      },
+    };
+
+    await expect(service().getAuthorization({ userId: 'user-1' })).resolves.toEqual({
+      status: 'reconnect_required',
     });
   });
 
@@ -324,7 +341,11 @@ describe('BitbucketAuthorizationService', () => {
       BITBUCKET_CLOUD_AGENT_MINIMUM_VALIDITY_MS
     );
 
-    expect(result).toMatchObject({ status: 'available', token: 'next-access-token' });
+    expect(result).toMatchObject({
+      status: 'available',
+      token: 'next-access-token',
+      credentialId: 'credential-1',
+    });
     expect(database.locks).toBe(1);
     const rotation = database.updates.find(update => 'access_token_encrypted' in update);
     expect(JSON.parse(String(rotation?.access_token_encrypted))).toMatchObject({

--- a/services/git-token-service/src/bitbucket-authorization-service.ts
+++ b/services/git-token-service/src/bitbucket-authorization-service.ts
@@ -65,6 +65,7 @@ export type BitbucketAuthorizationResult =
       status: 'available';
       token: string;
       integrationId: string;
+      credentialId: string;
       workspace: BitbucketWorkspaceIdentity;
     }
   | { status: 'not_connected' }
@@ -258,6 +259,7 @@ export class BitbucketAuthorizationService {
       status: 'available',
       token,
       integrationId: authorization.integrationId,
+      credentialId: authorization.credential.id,
       workspace: authorization.workspace,
     };
   }

--- a/services/git-token-service/src/bitbucket-runtime-token-resolver.test.ts
+++ b/services/git-token-service/src/bitbucket-runtime-token-resolver.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { BitbucketApiError, type BitbucketRepository } from './bitbucket-api.js';
 import {
   listBitbucketRepositories,
+  resolveBitbucketCapabilitySubject,
   resolveBitbucketToken,
   selectCachedBitbucketRepository,
 } from './bitbucket-runtime-token-resolver.js';
@@ -36,6 +37,7 @@ const oauthAuthorization: Extract<BitbucketAuthorizationResult, { status: 'avail
   status: 'available',
   token: 'oauth-runtime-token',
   integrationId: '123e4567-e89b-12d3-a456-426614174044',
+  credentialId: '123e4567-e89b-12d3-a456-426614174045',
   workspace: { uuid: workspaceUuid, slug: 'acme', name: 'Acme' },
 };
 
@@ -156,6 +158,43 @@ describe('Bitbucket runtime token resolver', () => {
       organizationId,
       workspace: oauthAuthorization.workspace,
       repositoryUuid,
+    });
+  });
+
+  it('pins OAuth capability subjects to the current credential row', async () => {
+    const deps = dependencies();
+    deps.authorizationService.getAuthorization.mockResolvedValue({ status: 'not_connected' });
+    deps.oauthAuthorizationService.getAuthorization.mockResolvedValue(oauthAuthorization);
+
+    await expect(
+      resolveBitbucketCapabilitySubject({} as CloudflareEnv, tokenParams(), deps)
+    ).resolves.toEqual({
+      success: true,
+      subject: {
+        integrationId: oauthAuthorization.integrationId,
+        workspaceUuid,
+        workspaceSlug: 'acme',
+        repositoryUuid,
+        repositoryFullName: 'acme/widgets',
+        token: oauthAuthorization.token,
+        oauthCredentialId: oauthAuthorization.credentialId,
+      },
+    });
+  });
+
+  it('omits OAuth identity from workspace access token capability subjects', async () => {
+    await expect(
+      resolveBitbucketCapabilitySubject({} as CloudflareEnv, tokenParams(), dependencies())
+    ).resolves.toEqual({
+      success: true,
+      subject: {
+        integrationId: authorization.integrationId,
+        workspaceUuid,
+        workspaceSlug: 'acme',
+        repositoryUuid,
+        repositoryFullName: 'acme/widgets',
+        token: authorization.token,
+      },
     });
   });
 

--- a/services/git-token-service/src/bitbucket-runtime-token-resolver.ts
+++ b/services/git-token-service/src/bitbucket-runtime-token-resolver.ts
@@ -408,12 +408,9 @@ export type BitbucketCapabilitySubject = {
   repositoryUuid: string;
   repositoryFullName: string;
   token: string;
+  oauthCredentialId?: string;
 };
 
-// Resolve the same authorized repository as resolveBitbucketToken, but return
-// the identity needed to mint an outbound session capability (and the token, so
-// the caller can bind a rotation digest). Used at capability issue time and, on
-// the redeem path, to re-resolve the current token for comparison.
 export async function resolveBitbucketCapabilitySubject(
   env: CloudflareEnv,
   params: GetBitbucketTokenParams,
@@ -431,6 +428,9 @@ export async function resolveBitbucketCapabilitySubject(
       repositoryUuid: repository.id,
       repositoryFullName: repository.fullName,
       token: authorization.token,
+      ...(authorization.source === 'oauth'
+        ? { oauthCredentialId: authorization.credentialId }
+        : {}),
     },
   };
 }

--- a/services/git-token-service/src/bitbucket-session-capability.test.ts
+++ b/services/git-token-service/src/bitbucket-session-capability.test.ts
@@ -1,3 +1,4 @@
+import { encryptWithSymmetricKey } from '@kilocode/encryption';
 import { describe, expect, it, vi } from 'vitest';
 import {
   BitbucketSessionCapabilityCodec,
@@ -43,6 +44,42 @@ describe('BitbucketSessionCapabilityCodec', () => {
     vi.useRealTimers();
   });
 
+  it('round-trips an OAuth credential identity inside the opaque capability', () => {
+    const codec = new BitbucketSessionCapabilityCodec(encryptionKey);
+    const oauthCredentialId = 'oauth-credential-1';
+    const capability = codec.issue({ ...subject, oauthCredentialId });
+
+    expect(capability).toMatch(/^kbb1\./);
+    expect(capability).not.toContain(oauthCredentialId);
+    expect(codec.decode(capability)).toMatchObject({ ...subject, oauthCredentialId });
+  });
+
+  it.each([
+    { oauthCredentialId: '' },
+    { oauthCredentialId: null },
+    { oauthCredentialId: 42 },
+    { oauthCredentialId: 'oauth-credential-1', tokenDigest: undefined },
+    { oauthCredentialId: 'oauth-credential-1', tokenDigest: 'invalid-digest' },
+    { oauthCredentialId: 'oauth-credential-1', unexpected: true },
+  ])('rejects malformed OAuth capability claims %#', overrides => {
+    const codec = new BitbucketSessionCapabilityCodec(encryptionKey);
+    const capability = `kbb1.${encryptWithSymmetricKey(
+      JSON.stringify({
+        purpose: 'bitbucket_scm_session',
+        version: 1,
+        ...subject,
+        issuedAt: Date.now(),
+        expiresAt: Date.now() + 60 * 60 * 1000,
+        ...overrides,
+      }),
+      encryptionKey
+    )}`;
+
+    expect(() => codec.decode(capability)).toThrow(
+      new BitbucketSessionCapabilityError('invalid_capability')
+    );
+  });
+
   it('rejects a capability encrypted with a different key', () => {
     const capability = new BitbucketSessionCapabilityCodec(encryptionKey).issue(subject);
     expect(() =>
@@ -58,16 +95,19 @@ describe('BitbucketSessionCapabilityCodec', () => {
     );
   });
 
-  it('rejects an expired capability', () => {
-    vi.useFakeTimers();
-    vi.setSystemTime(new Date('2026-05-31T12:00:00.000Z'));
-    const codec = new BitbucketSessionCapabilityCodec(encryptionKey);
-    const capability = codec.issue(subject);
+  it.each([undefined, 'oauth-credential-1'])(
+    'rejects an expired capability with OAuth identity %s',
+    oauthCredentialId => {
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date('2026-05-31T12:00:00.000Z'));
+      const codec = new BitbucketSessionCapabilityCodec(encryptionKey);
+      const capability = codec.issue({ ...subject, oauthCredentialId });
 
-    vi.setSystemTime(new Date('2026-05-31T16:00:00.001Z'));
-    expect(() => codec.decode(capability)).toThrow(
-      new BitbucketSessionCapabilityError('expired_capability')
-    );
-    vi.useRealTimers();
-  });
+      vi.setSystemTime(new Date('2026-05-31T16:00:00.001Z'));
+      expect(() => codec.decode(capability)).toThrow(
+        new BitbucketSessionCapabilityError('expired_capability')
+      );
+      vi.useRealTimers();
+    }
+  );
 });

--- a/services/git-token-service/src/bitbucket-session-capability.ts
+++ b/services/git-token-service/src/bitbucket-session-capability.ts
@@ -33,10 +33,8 @@ const BitbucketSessionCapabilityClaimsSchema = z
     workspaceSlug: WorkspaceSlugSchema,
     repositoryUuid: z.uuid(),
     repositoryFullName: RepositoryFullNameSchema,
-    // A digest of the resolved token at issue time. The redeem path re-resolves
-    // the current token and compares digests, so a rotated token invalidates the
-    // capability regardless of which Bitbucket auth source backs it.
     tokenDigest: TokenDigestSchema,
+    oauthCredentialId: z.string().min(1).optional(),
     outboundContainerId: z.string().min(1),
     issuedAt: z.number().int().nonnegative(),
     expiresAt: z.number().int().positive(),

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -349,6 +349,11 @@ describe('GitTokenRPCEntrypoint Bitbucket session capability', () => {
     repositoryFullName: 'acme/widgets',
     token: 'ATCT-runtime-token',
   };
+  const oauthSubject = {
+    ...subject,
+    token: 'oauth-runtime-token',
+    oauthCredentialId: '123e4567-e89b-12d3-a456-426614174023',
+  };
   const issueParams = {
     userId: 'user-1',
     orgId: '123e4567-e89b-12d3-a456-426614174030',
@@ -409,7 +414,100 @@ describe('GitTokenRPCEntrypoint Bitbucket session capability', () => {
     });
   });
 
-  it('rejects redemption from a different container', async () => {
+  it('redeems the same OAuth capability after the access token refreshes', async () => {
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: oauthSubject,
+    });
+    const capability = await issueCapability();
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: { ...oauthSubject, token: 'oauth-refreshed-token' },
+    });
+
+    await expect(
+      createService().redeemBitbucketSessionCapability({
+        capability,
+        outboundContainerId: 'outbound-container-1',
+        requestMethod: 'POST',
+        requestUrl: 'https://bitbucket.org/acme/widgets.git/git-upload-pack',
+      })
+    ).resolves.toEqual({
+      success: true,
+      headers: {
+        authorization: `Basic ${Buffer.from('x-token-auth:oauth-refreshed-token').toString('base64')}`,
+      },
+    });
+    expect(serviceMocks.resolveBitbucketCapabilitySubject).toHaveBeenLastCalledWith(
+      expect.anything(),
+      {
+        userId: issueParams.userId,
+        orgId: issueParams.orgId,
+        expectedIntegrationId: oauthSubject.integrationId,
+        workspaceUuid: oauthSubject.workspaceUuid,
+        repositoryUuid: oauthSubject.repositoryUuid,
+        repositoryUrl: issueParams.repositoryUrl,
+      }
+    );
+  });
+
+  it.each([
+    [
+      'a replaced OAuth credential',
+      { ...oauthSubject, oauthCredentialId: '123e4567-e89b-12d3-a456-426614174024' },
+    ],
+    ['a missing OAuth credential identity', { ...oauthSubject, oauthCredentialId: undefined }],
+    ['a workspace access token source', { ...subject, token: oauthSubject.token }],
+  ])('rejects %s even when token bytes are unchanged', async (_description, currentSubject) => {
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: oauthSubject,
+    });
+    const capability = await issueCapability();
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: currentSubject,
+    });
+
+    await expect(
+      createService().redeemBitbucketSessionCapability({
+        capability,
+        outboundContainerId: 'outbound-container-1',
+        requestMethod: 'POST',
+        requestUrl: 'https://bitbucket.org/acme/widgets.git/git-upload-pack',
+      })
+    ).resolves.toEqual({ success: false, reason: 'source_unavailable' });
+  });
+
+  it.each(['not_connected', 'reconnect_required', 'integration_mismatch'])(
+    'rejects OAuth redemption when the current source is %s',
+    async reason => {
+      serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+        success: true,
+        subject: oauthSubject,
+      });
+      const capability = await issueCapability();
+      serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({ success: false, reason });
+
+      await expect(
+        createService().redeemBitbucketSessionCapability({
+          capability,
+          outboundContainerId: 'outbound-container-1',
+          requestMethod: 'POST',
+          requestUrl: 'https://bitbucket.org/acme/widgets.git/git-upload-pack',
+        })
+      ).resolves.toEqual({ success: false, reason: 'source_unavailable' });
+    }
+  );
+
+  it.each([
+    ['workspace access token', subject],
+    ['OAuth', oauthSubject],
+  ])('rejects %s redemption from a different container', async (_source, currentSubject) => {
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: currentSubject,
+    });
     const capability = await issueCapability();
     await expect(
       createService().redeemBitbucketSessionCapability({
@@ -421,7 +519,14 @@ describe('GitTokenRPCEntrypoint Bitbucket session capability', () => {
     ).resolves.toEqual({ success: false, reason: 'container_mismatch' });
   });
 
-  it('rejects redemption for a different repository', async () => {
+  it.each([
+    ['workspace access token', subject],
+    ['OAuth', oauthSubject],
+  ])('rejects %s redemption for a different repository', async (_source, currentSubject) => {
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: currentSubject,
+    });
     const capability = await issueCapability();
     await expect(
       createService().redeemBitbucketSessionCapability({
@@ -433,7 +538,40 @@ describe('GitTokenRPCEntrypoint Bitbucket session capability', () => {
     ).resolves.toEqual({ success: false, reason: 'repository_mismatch' });
   });
 
-  it('rejects redemption when the token was rotated after issue', async () => {
+  it('keeps legacy OAuth capabilities digest-bound after refresh', async () => {
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: { ...subject, token: oauthSubject.token },
+    });
+    const capability = await issueCapability();
+    const redeemParams = {
+      capability,
+      outboundContainerId: 'outbound-container-1',
+      requestMethod: 'POST',
+      requestUrl: 'https://bitbucket.org/acme/widgets.git/git-upload-pack',
+    };
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: oauthSubject,
+    });
+
+    await expect(createService().redeemBitbucketSessionCapability(redeemParams)).resolves.toEqual({
+      success: true,
+      headers: {
+        authorization: `Basic ${Buffer.from(`x-token-auth:${oauthSubject.token}`).toString('base64')}`,
+      },
+    });
+    serviceMocks.resolveBitbucketCapabilitySubject.mockResolvedValue({
+      success: true,
+      subject: { ...oauthSubject, token: 'oauth-refreshed-token' },
+    });
+    await expect(createService().redeemBitbucketSessionCapability(redeemParams)).resolves.toEqual({
+      success: false,
+      reason: 'source_unavailable',
+    });
+  });
+
+  it('rejects workspace access token rotation after issue', async () => {
     const capability = await issueCapability();
     serviceMocks.resolveBitbucketCapabilitySubject
       .mockReset()

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -1148,6 +1148,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
         repositoryUuid: subject.repositoryUuid,
         repositoryFullName: subject.repositoryFullName,
         tokenDigest: await bitbucketTokenDigest(subject.token),
+        oauthCredentialId: subject.oauthCredentialId,
         outboundContainerId: params.outboundContainerId,
       });
       return {
@@ -1183,9 +1184,6 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     );
     if (upstream.failure) return { success: false, reason: upstream.failure };
 
-    // Re-resolve the current token and confirm the workspace/repo identity and
-    // token digest still match what the capability was issued for. A rotated
-    // token or a changed integration invalidates the capability.
     const resolved = await resolveBitbucketCapabilitySubject(this.env, {
       userId: claims.userId,
       orgId: claims.orgId,
@@ -1204,9 +1202,15 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     ) {
       return { success: false, reason: 'source_unavailable' };
     }
-    const currentDigest = await bitbucketTokenDigest(subject.token);
-    if (!timingSafeEqual(currentDigest, claims.tokenDigest)) {
-      return { success: false, reason: 'source_unavailable' };
+    if (claims.oauthCredentialId !== undefined) {
+      if (subject.oauthCredentialId !== claims.oauthCredentialId) {
+        return { success: false, reason: 'source_unavailable' };
+      }
+    } else {
+      const currentDigest = await bitbucketTokenDigest(subject.token);
+      if (!timingSafeEqual(currentDigest, claims.tokenDigest)) {
+        return { success: false, reason: 'source_unavailable' };
+      }
     }
     return {
       success: true,


### PR DESCRIPTION
## Summary

- Make managed credential containment mandatory for control-plane workspace sessions on Cloudflare and Vercel; guests receive opaque aliases, not managed upstream credentials.
- Reuse the existing broker and native outbound/network-policy enforcement, bound to the exact physical allocation and authorized worktree/root membership.
- Use one isolated Kilo process/auth environment per worktree, shared by its registered roots; preserve custom profile GitHub token overrides.
- Integrate hidden-summit lifecycle/acquisition/outcome fencing with glossy-gull legacy-only containment controls.
- Fix reproduced integration races in credential-expiry recovery, cancellation of queued worktree preparation, and complete per-worktree auto-commit serialization.
- Pin only the Cloud Agent CI job to Bun 1.3.14: floating latest selected Bun 1.4.0, which exposes an unhandled cancellation promise in the pinned SDK. No SDK, production Docker, or dependency changes.

## Native PR stack

Stack #5752: `main -> #5670 hidden-summit -> #5623 glossy-gull -> #5552 eager-hollow -> #5751 dreamy-marsh`.

The older Vercel-only remote lineage is replaced by the reviewed local implementation; its profile-token override fix is preserved.

## Verification

- Final-HEAD CI passed: 4,084 Node tests (3 existing skips), 453 Workers tests, 635 wrapper tests, running Bun 1.3.14.
- Final-HEAD TruffleHog passed with zero findings over the full commit range. Synthetic URI fixtures use explicit URL construction, folded into their introducing commit; assertions remain and no scanner rule was disabled.
- Broker full suite: 553 passed. Service/wrapper/broker lint and typechecks, explicit integration-file lint, formatting and whitespace checks passed.
- Reproduced the three integration regressions before fixing them, including actual temporary Git/local-remote auto-commit concurrency.
- Local mandatory Cloudflare containment passed private/public repository cloning, cold/warm turns, canonical interruption/follow-up, stable opaque aliases, native credential redemption, and nonempty persisted ingest. The top stack also verified same-worktree process/alias sharing, different-worktree isolation, terminals and scoped deletion.
- Final CI-only rewrite changes no production-code blobs, paths or modes; full local wrapper rerun passed 635/635.

## Rollout and limits

- A matching fresh wrapper image/snapshot is required. No production deployment or new live Vercel acceptance.
- Compatible Bitbucket broker readers must precede new OAuth credential-ID claims; rollback to old strict readers can reject outstanding capabilities.
- Native local workerd/egress can delay upstream cancellation after the client aborts. Independently reproduced below Kilo; the unchanged repository forwarder preserves signals. Canonical interruption and persisted MessageAbortedError pass; production transport behavior is not established.
- Existing lifecycle rollout limitations, including delayed destination-side launch fencing, remain explicit. Merging is not approval to enable the control-plane rollout.
- Plans and unrelated worktree changes are excluded.