### PR TITLE
feat(deployments): rebuild only from the GitHub install that pushed

### DIFF
--- a/apps/web/src/lib/integrations/platforms/github/adapter.installation-token.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.installation-token.test.ts
@@ -1,0 +1,37 @@
+const mockAuth = jest.fn();
+
+jest.mock('@octokit/auth-app', () => ({
+  createAppAuth: jest.fn(() => mockAuth),
+}));
+
+jest.mock('@/lib/integrations/platforms/github/app-selector', () => ({
+  getGitHubAppCredentials: jest.fn(() => ({
+    appId: 'app-id',
+    privateKey: 'private-key',
+    webhookSecret: 'webhook-secret',
+  })),
+}));
+
+import { generateGitHubInstallationToken } from './adapter';
+
+describe('generateGitHubInstallationToken', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockAuth.mockResolvedValue({ token: 'token', expiresAt: '2099-01-01T00:00:00.000Z' });
+  });
+
+  it('requests a token scoped to the exact repository name', async () => {
+    await generateGitHubInstallationToken('installation-1', 'lite', 'widgets');
+
+    expect(mockAuth).toHaveBeenCalledWith({
+      type: 'installation',
+      repositoryNames: ['widgets'],
+    });
+  });
+
+  it('preserves unscoped token minting for existing callers', async () => {
+    await generateGitHubInstallationToken('installation-1', 'standard');
+
+    expect(mockAuth).toHaveBeenCalledWith({ type: 'installation' });
+  });
+});

--- a/apps/web/src/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/lib/integrations/platforms/github/adapter.ts
@@ -63,10 +63,12 @@ export function verifyGitHubWebhookSignature(
 /**
  * Generates GitHub App installation token
  * @param appType - The type of GitHub App to use (defaults to 'standard')
+ * @param repositoryName - Optional repository name to scope the token to
  */
 export async function generateGitHubInstallationToken(
   installationId: string,
-  appType: GitHubAppType = 'standard'
+  appType: GitHubAppType = 'standard',
+  repositoryName?: string
 ): Promise<InstallationToken> {
   const credentials = getGitHubAppCredentials(appType);
 
@@ -80,7 +82,10 @@ export async function generateGitHubInstallationToken(
     installationId,
   });
 
-  const authResult = await auth({ type: 'installation' });
+  const authResult = await auth({
+    type: 'installation',
+    ...(repositoryName ? { repositoryNames: [repositoryName] } : {}),
+  });
 
   return {
     token: authResult.token,

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -16,6 +16,8 @@ const mockHandleInstallationDeleted = jest.fn();
 const mockHandleInstallationSuspend = jest.fn();
 const mockHandleInstallationUnsuspend = jest.fn();
 const mockHandleInstallationRepositories = jest.fn();
+const mockHandlePushEvent = jest.fn();
+const mockHandleIssue = jest.fn();
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   verifyGitHubWebhookSignature: (payload: string, signature: string, appType: string) =>
@@ -55,12 +57,14 @@ jest.mock('@/lib/integrations/platforms/github/webhook-handlers', () => ({
     mockHandleInstallationUnsuspend(payload, appType),
   handleInstallationTargetRenamed: (payload: unknown, integrationId: string, appType: string) =>
     mockHandleInstallationTargetRenamed(payload, integrationId, appType),
-  handleIssue: jest.fn(),
+  handleIssue: (payload: unknown, platformIntegration: unknown) =>
+    mockHandleIssue(payload, platformIntegration),
   handlePRReviewComment: (payload: unknown, platformIntegration: unknown) =>
     mockHandlePRReviewComment(payload, platformIntegration),
   handlePullRequest: (payload: unknown, platformIntegration: unknown) =>
     mockHandlePullRequest(payload, platformIntegration),
-  handlePushEvent: jest.fn(),
+  handlePushEvent: (payload: unknown, platformIntegration: unknown) =>
+    mockHandlePushEvent(payload, platformIntegration),
   upsertCliSessionPullRequestsFromWebhook: jest.fn(),
   upsertCliSessionPullRequestReviewFromWebhook: jest.fn(),
 }));
@@ -184,6 +188,16 @@ function issueCommentPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function pushPayload(overrides: Record<string, unknown> = {}) {
+  return {
+    installation: { id: 98765 },
+    ref: 'refs/heads/main',
+    repository: { full_name: 'acme/widgets' },
+    deleted: false,
+    ...overrides,
+  };
+}
+
 async function waitForAfterTask() {
   await new Promise(resolve => setTimeout(resolve, 0));
 }
@@ -218,6 +232,8 @@ describe('handleGitHubWebhook', () => {
     mockHandleInstallationRepositories.mockResolvedValue(
       Response.json({ message: 'Repositories updated' })
     );
+    mockHandlePushEvent.mockResolvedValue(undefined);
+    mockHandleIssue.mockResolvedValue(Response.json({ message: 'issue handled' }));
   });
 
   it('routes installation_target renamed events through authoritative login synchronization', async () => {
@@ -317,6 +333,38 @@ describe('handleGitHubWebhook', () => {
 
     expect(response.status).toBe(200);
     expect(mockFindIntegrationByInstallationId).toHaveBeenCalledWith('github', '98765', 'lite');
+  });
+
+  it('dispatches push events from a secondary organization installation', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValueOnce({ ...integration, id: 'pi_primary' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('push', pushPayload()),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockHandlePushEvent).toHaveBeenCalledWith(
+      expect.objectContaining({ repository: { full_name: 'acme/widgets' } }),
+      integration
+    );
+  });
+
+  it('continues to suppress unrelated events from a secondary organization installation', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValueOnce({ ...integration, id: 'pi_primary' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('issues', {
+        installation: { id: 98765 },
+        action: 'opened',
+      }),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ message: 'Event received' });
+    expect(mockHandleIssue).not.toHaveBeenCalled();
+    expect(mockHandlePushEvent).not.toHaveBeenCalled();
   });
 
   it('keeps pull_request webhooks on the code review path', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -466,7 +466,11 @@ export async function handleGitHubWebhook(
       ? await getIntegrationForOrganization(integration.owned_by_organization_id, PLATFORM.GITHUB)
       : integration;
     const isSecondaryOrganizationInstallation = primaryIntegration?.id !== integration.id;
-    if (isSecondaryOrganizationInstallation && eventType !== GITHUB_EVENT.PULL_REQUEST) {
+    if (
+      isSecondaryOrganizationInstallation &&
+      eventType !== GITHUB_EVENT.PULL_REQUEST &&
+      eventType !== GITHUB_EVENT.PUSH
+    ) {
       logExceptInTest('Secondary GitHub installation event suppressed', {
         integration_id: integration.id,
         event_type: eventType,

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/push-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/push-handler.test.ts
@@ -1,0 +1,163 @@
+import { eq, inArray } from 'drizzle-orm';
+import { db } from '@/lib/drizzle';
+import {
+  app_builder_projects,
+  deployments,
+  kilocode_users,
+  organizations,
+  platform_integrations,
+} from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { createTestOrganization } from '@/tests/helpers/organization.helper';
+
+const mockRedeploy = jest.fn();
+const mockTriggerBuild = jest.fn();
+
+jest.mock('@/lib/user-deployments/deployments-service', () => ({
+  redeploy: (deployment: unknown) => mockRedeploy(deployment),
+}));
+
+jest.mock('@/lib/app-builder/app-builder-client', () => ({
+  triggerBuild: (projectId: string) => mockTriggerBuild(projectId),
+}));
+
+import { handlePushEvent } from './push-handler';
+
+describe('GitHub push deployment dispatch', () => {
+  const integrationIds: string[] = [];
+  const deploymentIds: string[] = [];
+  const projectIds: string[] = [];
+  let ownerUserId: string;
+  let organizationId: string;
+
+  beforeAll(async () => {
+    const owner = await insertTestUser();
+    ownerUserId = owner.id;
+    const organization = await createTestOrganization(
+      `push-dispatch-${crypto.randomUUID()}`,
+      ownerUserId,
+      0
+    );
+    organizationId = organization.id;
+  });
+
+  afterAll(async () => {
+    if (projectIds.length > 0) {
+      await db.delete(app_builder_projects).where(inArray(app_builder_projects.id, projectIds));
+    }
+    if (deploymentIds.length > 0) {
+      await db.delete(deployments).where(inArray(deployments.id, deploymentIds));
+    }
+    if (integrationIds.length > 0) {
+      await db
+        .delete(platform_integrations)
+        .where(inArray(platform_integrations.id, integrationIds));
+    }
+    await db.delete(organizations).where(eq(organizations.id, organizationId));
+    await db.delete(kilocode_users).where(eq(kilocode_users.id, ownerUserId));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRedeploy.mockResolvedValue(undefined);
+    mockTriggerBuild.mockResolvedValue(undefined);
+  });
+
+  async function createIntegration(installationId: string) {
+    const [integration] = await db
+      .insert(platform_integrations)
+      .values({
+        owned_by_organization_id: organizationId,
+        platform: 'github',
+        integration_type: 'app',
+        integration_status: 'active',
+        platform_installation_id: installationId,
+        github_app_type: 'standard',
+      })
+      .returning();
+    integrationIds.push(integration.id);
+    return integration;
+  }
+
+  async function createDeployment(integrationId: string, branch: string) {
+    const [deployment] = await db
+      .insert(deployments)
+      .values({
+        owned_by_organization_id: organizationId,
+        deployment_slug: `push-${crypto.randomUUID()}`,
+        internal_worker_name: `dpl-${crypto.randomUUID()}`,
+        repository_source: 'acme/widgets',
+        branch,
+        deployment_url: `https://${crypto.randomUUID()}.example.com`,
+        platform_integration_id: integrationId,
+        source_type: 'github',
+        last_build_id: crypto.randomUUID(),
+        created_from: 'deploy',
+      })
+      .returning();
+    deploymentIds.push(deployment.id);
+    return deployment;
+  }
+
+  async function createAppBuilderProject(integrationId: string) {
+    const [project] = await db
+      .insert(app_builder_projects)
+      .values({
+        owned_by_organization_id: organizationId,
+        title: `Project ${crypto.randomUUID()}`,
+        model_id: 'test-model',
+        git_repo_full_name: 'acme/widgets',
+        git_platform_integration_id: integrationId,
+      })
+      .returning();
+    projectIds.push(project.id);
+    return project;
+  }
+
+  it('dispatches overlapping repository rows only for the event integration', async () => {
+    const eventIntegration = await createIntegration(`event-${crypto.randomUUID()}`);
+    const siblingIntegration = await createIntegration(`sibling-${crypto.randomUUID()}`);
+    const matchingDeployment = await createDeployment(eventIntegration.id, 'main');
+    await createDeployment(siblingIntegration.id, 'main');
+    await createDeployment(eventIntegration.id, 'release');
+    const matchingProject = await createAppBuilderProject(eventIntegration.id);
+    await createAppBuilderProject(siblingIntegration.id);
+
+    await handlePushEvent(
+      {
+        ref: 'refs/heads/main',
+        repository: { full_name: 'acme/widgets' },
+        deleted: false,
+      },
+      eventIntegration
+    );
+
+    expect(mockRedeploy).toHaveBeenCalledTimes(1);
+    expect(mockRedeploy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: matchingDeployment.id })
+    );
+    expect(mockTriggerBuild).toHaveBeenCalledTimes(1);
+    expect(mockTriggerBuild).toHaveBeenCalledWith(matchingProject.id);
+  });
+
+  it('preserves main-only App Builder preview rebuilds', async () => {
+    const eventIntegration = await createIntegration(`feature-${crypto.randomUUID()}`);
+    const matchingDeployment = await createDeployment(eventIntegration.id, 'feature/one');
+    await createAppBuilderProject(eventIntegration.id);
+
+    await handlePushEvent(
+      {
+        ref: 'refs/heads/feature/one',
+        repository: { full_name: 'acme/widgets' },
+        deleted: false,
+      },
+      eventIntegration
+    );
+
+    expect(mockRedeploy).toHaveBeenCalledTimes(1);
+    expect(mockRedeploy).toHaveBeenCalledWith(
+      expect.objectContaining({ id: matchingDeployment.id })
+    );
+    expect(mockTriggerBuild).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/push-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/push-handler.ts
@@ -1,14 +1,8 @@
 import { captureException } from '@sentry/nextjs';
 import { db } from '@/lib/drizzle';
-import {
-  deployments,
-  platform_integrations,
-  app_builder_projects,
-  type PlatformIntegration,
-} from '@kilocode/db/schema';
+import { deployments, app_builder_projects, type PlatformIntegration } from '@kilocode/db/schema';
 import { eq, and } from 'drizzle-orm';
 import { redeploy } from '@/lib/user-deployments/deployments-service';
-import { PLATFORM } from '@/lib/integrations/core/constants';
 import { logExceptInTest } from '@/lib/utils.server';
 import type { PushEventPayload } from '@/lib/integrations/platforms/github/webhook-schemas';
 import { extractBranchNameFromRef } from '@/lib/integrations/platforms/github/utils';
@@ -19,28 +13,25 @@ export async function handlePushEvent(event: PushEventPayload, integration: Plat
   const repositoryFullName = event.repository.full_name;
 
   await Promise.allSettled([
-    redeployMatchingDeployments(repositoryFullName, branchName),
+    redeployMatchingDeployments(repositoryFullName, branchName, integration),
     rebuildMatchingAppBuilderPreviews(repositoryFullName, branchName, integration),
   ]);
 }
 
-async function redeployMatchingDeployments(repositoryFullName: string, branchName: string) {
+async function redeployMatchingDeployments(
+  repositoryFullName: string,
+  branchName: string,
+  integration: PlatformIntegration
+) {
   const githubDeployments = await db
-    .select({
-      deployment: deployments,
-      integration: platform_integrations,
-    })
+    .select({ deployment: deployments })
     .from(deployments)
-    .innerJoin(
-      platform_integrations,
-      eq(deployments.platform_integration_id, platform_integrations.id)
-    )
     .where(
       and(
         eq(deployments.repository_source, repositoryFullName),
         eq(deployments.branch, branchName),
         eq(deployments.source_type, 'github'),
-        eq(platform_integrations.platform, PLATFORM.GITHUB)
+        eq(deployments.platform_integration_id, integration.id)
       )
     );
 

--- a/apps/web/src/lib/user-deployments/deployments-service.test.ts
+++ b/apps/web/src/lib/user-deployments/deployments-service.test.ts
@@ -5,10 +5,14 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 
 const mockGenerateGitHubInstallationToken = jest.fn();
 const mockCreateDeployment = jest.fn();
+const mockSetSlugMapping = jest.fn();
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
-  generateGitHubInstallationToken: (installationId: string, appType: string) =>
-    mockGenerateGitHubInstallationToken(installationId, appType),
+  generateGitHubInstallationToken: (
+    installationId: string,
+    appType: string,
+    repositoryName?: string
+  ) => mockGenerateGitHubInstallationToken(installationId, appType, repositoryName),
 }));
 
 jest.mock('@/lib/user-deployments/deployment-builder-client', () => ({
@@ -17,7 +21,20 @@ jest.mock('@/lib/user-deployments/deployment-builder-client', () => ({
   },
 }));
 
-import { redeploy } from './deployments-service';
+jest.mock('@/lib/creditTransactions', () => ({
+  hasUserEverPaid: jest.fn().mockResolvedValue(true),
+  hasOrganizationEverPaid: jest.fn().mockResolvedValue(true),
+}));
+
+jest.mock('@/lib/user-deployments/dispatcher-client', () => ({
+  DispatcherSlugTakenError: class DispatcherSlugTakenError extends Error {},
+  dispatcherClient: {
+    setSlugMapping: (...args: unknown[]) => mockSetSlugMapping(...args),
+    deleteSlugMapping: jest.fn(),
+  },
+}));
+
+import { createDeployment, redeploy } from './deployments-service';
 
 describe('deployment GitHub token selection', () => {
   let ownerUserId: string;
@@ -37,6 +54,15 @@ describe('deployment GitHub token selection', () => {
         integration_status: 'active',
         platform_installation_id: `lite-${crypto.randomUUID()}`,
         github_app_type: 'lite',
+        repository_access: 'selected',
+        repositories: [
+          {
+            id: 1,
+            name: 'stale-positive',
+            full_name: 'acme/stale-positive',
+            private: true,
+          },
+        ],
       })
       .returning();
     integrationId = integration.id;
@@ -60,7 +86,7 @@ describe('deployment GitHub token selection', () => {
   });
 
   afterAll(async () => {
-    await db.delete(deployments).where(eq(deployments.id, deploymentId));
+    await db.delete(deployments).where(eq(deployments.owned_by_user_id, ownerUserId));
     await db.delete(platform_integrations).where(eq(platform_integrations.id, integrationId));
     await db.delete(kilocode_users).where(eq(kilocode_users.id, ownerUserId));
   });
@@ -72,6 +98,7 @@ describe('deployment GitHub token selection', () => {
       expires_at: '2099-01-01T00:00:00.000Z',
     });
     mockCreateDeployment.mockResolvedValue({ buildId: crypto.randomUUID(), status: 'queued' });
+    mockSetSlugMapping.mockResolvedValue({ success: true });
   });
 
   it('mints redeployment credentials with the integration app type', async () => {
@@ -84,7 +111,8 @@ describe('deployment GitHub token selection', () => {
 
     expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledWith(
       expect.stringMatching(/^lite-/),
-      'lite'
+      'lite',
+      'lite-repo'
     );
     expect(mockCreateDeployment).toHaveBeenCalledWith(
       'github',
@@ -95,5 +123,61 @@ describe('deployment GitHub token selection', () => {
       undefined,
       undefined
     );
+  });
+
+  it('lets GitHub authorize a repository missing from the selected-repository cache', async () => {
+    await createDeployment({
+      owner: { type: 'user', id: ownerUserId },
+      source: {
+        type: 'github',
+        platformIntegrationId: integrationId,
+        repositoryFullName: 'acme/stale-negative',
+      },
+      branch: 'main',
+      createdByUserId: ownerUserId,
+      createdFrom: 'deploy',
+    });
+
+    expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledWith(
+      expect.stringMatching(/^lite-/),
+      'lite',
+      'stale-negative'
+    );
+    expect(mockCreateDeployment).toHaveBeenCalledWith(
+      'github',
+      'acme/stale-negative',
+      expect.stringMatching(/^dpl-/),
+      'main',
+      'lite-installation-token',
+      undefined,
+      undefined
+    );
+  });
+
+  it('lets GitHub reject a repository still present in the selected-repository cache', async () => {
+    mockGenerateGitHubInstallationToken.mockRejectedValueOnce(
+      new Error('Repository is not accessible to this installation')
+    );
+
+    await expect(
+      createDeployment({
+        owner: { type: 'user', id: ownerUserId },
+        source: {
+          type: 'github',
+          platformIntegrationId: integrationId,
+          repositoryFullName: 'acme/stale-positive',
+        },
+        branch: 'main',
+        createdByUserId: ownerUserId,
+        createdFrom: 'deploy',
+      })
+    ).rejects.toThrow('Repository is not accessible to this installation');
+
+    expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledWith(
+      expect.stringMatching(/^lite-/),
+      'lite',
+      'stale-positive'
+    );
+    expect(mockCreateDeployment).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/user-deployments/deployments-service.test.ts
+++ b/apps/web/src/lib/user-deployments/deployments-service.test.ts
@@ -1,0 +1,99 @@
+import { eq } from 'drizzle-orm';
+import { db } from '@/lib/drizzle';
+import { deployments, kilocode_users, platform_integrations } from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+
+const mockGenerateGitHubInstallationToken = jest.fn();
+const mockCreateDeployment = jest.fn();
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  generateGitHubInstallationToken: (installationId: string, appType: string) =>
+    mockGenerateGitHubInstallationToken(installationId, appType),
+}));
+
+jest.mock('@/lib/user-deployments/deployment-builder-client', () => ({
+  apiClient: {
+    createDeployment: (...args: unknown[]) => mockCreateDeployment(...args),
+  },
+}));
+
+import { redeploy } from './deployments-service';
+
+describe('deployment GitHub token selection', () => {
+  let ownerUserId: string;
+  let integrationId: string;
+  let deploymentId: string;
+
+  beforeAll(async () => {
+    const owner = await insertTestUser();
+    ownerUserId = owner.id;
+
+    const [integration] = await db
+      .insert(platform_integrations)
+      .values({
+        owned_by_user_id: ownerUserId,
+        platform: 'github',
+        integration_type: 'app',
+        integration_status: 'active',
+        platform_installation_id: `lite-${crypto.randomUUID()}`,
+        github_app_type: 'lite',
+      })
+      .returning();
+    integrationId = integration.id;
+
+    const [deployment] = await db
+      .insert(deployments)
+      .values({
+        owned_by_user_id: ownerUserId,
+        deployment_slug: `token-${crypto.randomUUID()}`,
+        internal_worker_name: `dpl-${crypto.randomUUID()}`,
+        repository_source: 'acme/lite-repo',
+        branch: 'main',
+        deployment_url: `https://${crypto.randomUUID()}.example.com`,
+        platform_integration_id: integrationId,
+        source_type: 'github',
+        last_build_id: crypto.randomUUID(),
+        created_from: 'deploy',
+      })
+      .returning();
+    deploymentId = deployment.id;
+  });
+
+  afterAll(async () => {
+    await db.delete(deployments).where(eq(deployments.id, deploymentId));
+    await db.delete(platform_integrations).where(eq(platform_integrations.id, integrationId));
+    await db.delete(kilocode_users).where(eq(kilocode_users.id, ownerUserId));
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateGitHubInstallationToken.mockResolvedValue({
+      token: 'lite-installation-token',
+      expires_at: '2099-01-01T00:00:00.000Z',
+    });
+    mockCreateDeployment.mockResolvedValue({ buildId: crypto.randomUUID(), status: 'queued' });
+  });
+
+  it('mints redeployment credentials with the integration app type', async () => {
+    const [deployment] = await db
+      .select()
+      .from(deployments)
+      .where(eq(deployments.id, deploymentId));
+
+    await redeploy(deployment);
+
+    expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledWith(
+      expect.stringMatching(/^lite-/),
+      'lite'
+    );
+    expect(mockCreateDeployment).toHaveBeenCalledWith(
+      'github',
+      'acme/lite-repo',
+      deployment.internal_worker_name,
+      'main',
+      'lite-installation-token',
+      undefined,
+      undefined
+    );
+  });
+});

--- a/apps/web/src/lib/user-deployments/deployments-service.ts
+++ b/apps/web/src/lib/user-deployments/deployments-service.ts
@@ -384,7 +384,8 @@ async function getGithubTokenFromIntegrationId(
     integration[0].platform_installation_id
   ) {
     const tokenData = await generateGitHubInstallationToken(
-      integration[0].platform_installation_id
+      integration[0].platform_installation_id,
+      integration[0].github_app_type ?? 'standard'
     );
     return tokenData.token;
   }
@@ -553,7 +554,8 @@ async function resolveGitHubSource(
 
   // Generate GitHub installation token
   const tokenData = await generateGitHubInstallationToken(
-    platformIntegration.platform_installation_id
+    platformIntegration.platform_installation_id,
+    platformIntegration.github_app_type ?? 'standard'
   );
 
   return {

--- a/apps/web/src/lib/user-deployments/deployments-service.ts
+++ b/apps/web/src/lib/user-deployments/deployments-service.ts
@@ -36,6 +36,7 @@ import { encryptAuthToken, decryptAuthToken } from './auth-token-encryption';
 import { hasUserEverPaid, hasOrganizationEverPaid } from '@/lib/creditTransactions';
 import { slugSchema } from './validation';
 import { DispatcherSlugTakenError, dispatcherClient } from './dispatcher-client';
+import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
 
 type PaymentCheckResult = { hasPaid: true } | { hasPaid: false };
 
@@ -364,33 +365,54 @@ export async function redeployByDeploymentId(deploymentId: string, owner: Owner)
   await redeploy(deployment[0]);
 }
 
-async function getGithubTokenFromIntegrationId(
-  platformIntegrationId: string
-): Promise<string | undefined> {
-  const integration = await db
+async function mintGitHubRepositoryToken(
+  owner: Owner,
+  platformIntegrationId: string,
+  repositoryFullName: string
+): Promise<string> {
+  const ownershipCondition =
+    owner.type === 'user'
+      ? eq(platform_integrations.owned_by_user_id, owner.id)
+      : eq(platform_integrations.owned_by_organization_id, owner.id);
+  const [integration] = await db
     .select()
     .from(platform_integrations)
-    .where(
-      and(
-        eq(platform_integrations.id, platformIntegrationId),
-        eq(platform_integrations.integration_status, 'active')
-      )
-    )
+    .where(and(eq(platform_integrations.id, platformIntegrationId), ownershipCondition))
     .limit(1);
 
-  if (
-    integration.length > 0 &&
-    integration[0].platform === 'github' &&
-    integration[0].platform_installation_id
-  ) {
-    const tokenData = await generateGitHubInstallationToken(
-      integration[0].platform_installation_id,
-      integration[0].github_app_type ?? 'standard'
-    );
-    return tokenData.token;
+  if (!integration) {
+    throw new TRPCError({ code: 'NOT_FOUND', message: 'Platform integration not found' });
+  }
+  if (integration.platform !== 'github' || integration.integration_type !== 'app') {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'Platform integration is not a GitHub App installation',
+    });
+  }
+  if (!isPlatformIntegrationHealthy(integration)) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'GitHub App installation is not active',
+    });
+  }
+  if (!integration.platform_installation_id) {
+    throw new TRPCError({
+      code: 'PRECONDITION_FAILED',
+      message: 'GitHub App installation ID not found',
+    });
   }
 
-  return undefined;
+  const repositoryParts = repositoryFullName.split('/');
+  if (repositoryParts.length !== 2 || !repositoryParts[0] || !repositoryParts[1]) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'Invalid GitHub repository name' });
+  }
+
+  const tokenData = await generateGitHubInstallationToken(
+    integration.platform_installation_id,
+    integration.github_app_type ?? 'standard',
+    repositoryParts[1]
+  );
+  return tokenData.token;
 }
 
 export async function redeploy(deployment: Deployment) {
@@ -414,10 +436,19 @@ export async function redeploy(deployment: Deployment) {
     if (!deployment.platform_integration_id) {
       throw new Error('Platform integration ID is required for GitHub redeployment');
     }
-    accessToken = await getGithubTokenFromIntegrationId(deployment.platform_integration_id);
-    if (!accessToken) {
-      throw new Error('GitHub token is required for redeployment');
+    const owner = deployment.owned_by_organization_id
+      ? { type: 'org' as const, id: deployment.owned_by_organization_id }
+      : deployment.owned_by_user_id
+        ? { type: 'user' as const, id: deployment.owned_by_user_id }
+        : null;
+    if (!owner) {
+      throw new Error('Deployment owner is required for GitHub redeployment');
     }
+    accessToken = await mintGitHubRepositoryToken(
+      owner,
+      deployment.platform_integration_id,
+      deployment.repository_source
+    );
     provider = 'github';
   }
 
@@ -513,55 +544,16 @@ async function resolveGitHubSource(
 ): Promise<ResolvedSourceDetails> {
   const { platformIntegrationId, repositoryFullName } = source;
 
-  // Verify platform integration exists and belongs to the owner
-  const ownershipCondition =
-    owner.type === 'user'
-      ? eq(platform_integrations.owned_by_user_id, owner.id)
-      : eq(platform_integrations.owned_by_organization_id, owner.id);
-
-  const [platformIntegration] = await db
-    .select()
-    .from(platform_integrations)
-    .where(and(eq(platform_integrations.id, platformIntegrationId), ownershipCondition))
-    .limit(1);
-
-  if (!platformIntegration) {
-    throw new TRPCError({
-      code: 'NOT_FOUND',
-      message: 'Platform integration not found',
-    });
-  }
-
-  if (!platformIntegration.platform_installation_id) {
-    throw new TRPCError({
-      code: 'INTERNAL_SERVER_ERROR',
-      message: 'Platform installation ID not found',
-    });
-  }
-
-  // Verify repository access for selected repositories
-  if (platformIntegration.repository_access === 'selected') {
-    const repositories = platformIntegration.repositories || [];
-    const hasAccess = repositories.some(repo => repo.full_name === repositoryFullName);
-
-    if (!hasAccess) {
-      throw new TRPCError({
-        code: 'FORBIDDEN',
-        message: 'Repository not accessible by this integration',
-      });
-    }
-  }
-
-  // Generate GitHub installation token
-  const tokenData = await generateGitHubInstallationToken(
-    platformIntegration.platform_installation_id,
-    platformIntegration.github_app_type ?? 'standard'
+  const authToken = await mintGitHubRepositoryToken(
+    owner,
+    platformIntegrationId,
+    repositoryFullName
   );
 
   return {
     repositorySource: repositoryFullName,
     repoName: repositoryFullName.split('/')[1],
-    authToken: tokenData.token,
+    authToken,
     encryptedToken: null, // GitHub tokens are regenerated, not stored
     platformIntegrationId,
     sourceType: 'github',

--- a/apps/web/src/tests/setup/__mocks__/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/tests/setup/__mocks__/lib/integrations/platforms/github/adapter.ts
@@ -9,7 +9,9 @@ export function verifyGitHubWebhookSignature(_payload: string, _signature: strin
 }
 
 export async function generateGitHubInstallationToken(
-  _installationId: string
+  _installationId: string,
+  _appType: GitHubAppType = 'standard',
+  _repositoryName?: string
 ): Promise<{ token: string; expires_at: string }> {
   return { token: `mock-token-${_installationId}`, expires_at: '2099-01-01T00:00:00.000Z' };
 }


### PR DESCRIPTION
## Why this PR exists

Secondary GitHub installations are currently prevented from delivering `push` behavior. Simply allowing those webhooks would be unsafe: deployment matching historically used repository and branch, so a push from one installation could redeploy a record associated with another installation that exposes the same repository.

This PR enables the deployment use case only after making the handler installation-aware. The webhook can rebuild deployments and App Builder previews, but only records pinned to the installation that delivered the push.

## Place in the rollout

This is the deployment-specific webhook slice of the multiple-GitHub-organizations rollout. Other secondary event types remain suppressed until their owning product PRs establish equivalent provenance.

## What changes

- Admit `push` events from secondary organization installations.
- Match deployments by repository, branch, source type, and exact `platform_integration_id`.
- Keep App Builder preview matching tied to the delivering integration.
- Mint deployment credentials with the actual Standard or Lite app type from the integration row.

## What stays unchanged

- Unrelated secondary webhook events remain suppressed.
- Deployment records without the matching installation are not touched.
- App Builder migration identity persistence and destination selection are handled separately in #5597 and #5600.

## Review guide

Review the admission predicate in `webhook-handler.ts`, then the exact deployment query in `push-handler.ts`. The critical negative test is that a sibling installation with the same repository and branch is not redeployed.

## Validation

- 3 focused Jest suites, 19 tests
- Web typecheck and lint
- Changed-file format check
- `git diff --check`