### PR TITLE
feat(code-review): keep review follow-ups on the originating GitHub install

### DIFF
--- a/apps/web/src/app/cloud-agent-fork/review/[reviewId]/route.test.ts
+++ b/apps/web/src/app/cloud-agent-fork/review/[reviewId]/route.test.ts
@@ -35,6 +35,7 @@ type ReviewResult =
 
 type PrepareSessionInput = {
   githubRepo: string;
+  githubIntegrationId?: string;
   prompt: string;
   mode: string;
   model: string;
@@ -231,6 +232,7 @@ describe('GET /cloud-agent-fork/review/[reviewId]', () => {
     expect(mockGetIntegrationById).toHaveBeenCalledTimes(1);
     expect(mockPersonalPrepareSession).toHaveBeenCalledWith({
       githubRepo: 'owner/repo',
+      githubIntegrationId: REVIEW_INTEGRATION_ID,
       prompt: buildFixReviewPrompt(PR_URL),
       mode: DEFAULT_CODE_REVIEW_MODE,
       model: CONFIGURED_BOT_MODEL,
@@ -264,6 +266,7 @@ describe('GET /cloud-agent-fork/review/[reviewId]', () => {
     expect(mockPersonalPrepareSession).not.toHaveBeenCalled();
     expect(mockOrganizationPrepareSession).toHaveBeenCalledWith({
       githubRepo: 'owner/repo',
+      githubIntegrationId: REVIEW_INTEGRATION_ID,
       prompt: buildFixReviewPrompt(PR_URL),
       mode: DEFAULT_CODE_REVIEW_MODE,
       model: CONFIGURED_BOT_MODEL,
@@ -362,6 +365,7 @@ describe('GET /cloud-agent-fork/review/[reviewId]', () => {
     expect(mockGetIntegrationById).toHaveBeenCalledTimes(1);
     expect(mockPersonalPrepareSession).toHaveBeenCalledWith({
       githubRepo: 'owner/repo',
+      githubIntegrationId: REVIEW_INTEGRATION_ID,
       prompt: buildFixReviewPrompt(PR_URL),
       mode: DEFAULT_CODE_REVIEW_MODE,
       model: DEFAULT_BOT_MODEL,

--- a/apps/web/src/app/cloud-agent-fork/review/[reviewId]/route.ts
+++ b/apps/web/src/app/cloud-agent-fork/review/[reviewId]/route.ts
@@ -88,6 +88,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const sessionInput = {
       githubRepo: review.repo_full_name,
+      githubIntegrationId: review.platform_integration_id ?? undefined,
       prompt: buildFixReviewPrompt(review.pr_url),
       mode: DEFAULT_CODE_REVIEW_MODE,
       model: resolveBotModelSlug(integration),

--- a/apps/web/src/lib/code-reviews/review-memory/change-request.test.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/change-request.test.ts
@@ -4,6 +4,7 @@ import { insertTestUser } from '@/tests/helpers/user.helper';
 import {
   code_review_memory_proposals,
   kilocode_users,
+  platform_integrations,
   type CodeReviewMemoryProposal,
 } from '@kilocode/db/schema';
 
@@ -15,11 +16,16 @@ import {
   upsertScopeProposal,
   type ReviewMemoryOwner,
 } from './db';
-import { buildChangeRequestBody, isStaleOpeningChangeRequest } from './change-request';
+import {
+  approveAndOpenReviewMemoryChangeRequest,
+  buildChangeRequestBody,
+  isStaleOpeningChangeRequest,
+} from './change-request';
 
 describe('review memory change requests', () => {
   afterEach(async () => {
     await db.delete(code_review_memory_proposals);
+    await db.delete(platform_integrations);
     await db.delete(kilocode_users);
   });
 
@@ -72,6 +78,40 @@ describe('review memory change requests', () => {
     expect(isStaleOpeningChangeRequest('2026-06-01T11:31:00.000Z', now)).toBe(false);
     expect(isStaleOpeningChangeRequest('2026-06-01T11:30:00.000Z', now)).toBe(true);
     expect(isStaleOpeningChangeRequest('not-a-date', now)).toBe(false);
+  });
+
+  it('fails closed when multiple GitHub installations match a proposal repository', async () => {
+    const user = await insertTestUser();
+    const owner = { type: 'user' as const, id: user.id };
+    const proposal = await seedProposal(owner, 'acme/widgets');
+    await db.insert(platform_integrations).values(
+      ['standard', 'lite'].map((githubAppType, index) => ({
+        owned_by_user_id: user.id,
+        platform: 'github',
+        integration_type: 'app',
+        integration_status: 'active',
+        platform_installation_id: `review-memory-${crypto.randomUUID()}`,
+        platform_account_login: 'acme',
+        repository_access: 'selected',
+        repositories: [
+          { id: index + 1, name: 'widgets', full_name: 'acme/widgets', private: true },
+        ],
+        github_app_type: githubAppType as 'standard' | 'lite',
+        permissions: { contents: 'write', pull_requests: 'write' },
+      }))
+    );
+
+    await expect(
+      approveAndOpenReviewMemoryChangeRequest({ owner, proposalId: proposal.id })
+    ).rejects.toMatchObject({
+      code: 'BAD_REQUEST',
+      message: 'Multiple active GitHub integrations have access to this repository.',
+    });
+    await expect(
+      db.query.code_review_memory_proposals.findFirst({
+        where: (table, { eq }) => eq(table.id, proposal.id),
+      })
+    ).resolves.toMatchObject({ status: 'open' });
   });
 });
 

--- a/apps/web/src/lib/code-reviews/review-memory/change-request.ts
+++ b/apps/web/src/lib/code-reviews/review-memory/change-request.ts
@@ -1,8 +1,7 @@
 import type { CodeReviewMemoryProposal, PlatformIntegration } from '@kilocode/db/schema';
 import type { ReviewMemoryProposalStatus } from '@kilocode/db/schema-types';
 
-import { getAllIntegrationsForOwner } from '@/lib/integrations/db/platform-integrations';
-import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
+import { resolveGitHubIntegrationForRepository } from '@/lib/integrations/db/platform-integrations';
 import {
   createGitHubBranch,
   createGitHubPullRequest,
@@ -203,28 +202,19 @@ async function findGitHubIntegrationForProposal(
   owner: ReviewMemoryOwner,
   proposal: CodeReviewMemoryProposal
 ): Promise<PlatformIntegration> {
-  const integrations = await getAllIntegrationsForOwner(owner);
-  const integration = integrations.find(
-    integration =>
-      integration.platform === PLATFORM.GITHUB &&
-      integration.integration_status === INTEGRATION_STATUS.ACTIVE &&
-      !integration.suspended_at &&
-      integration.platform_installation_id &&
-      hasRepositoryAccess(integration, proposal.repo_full_name)
-  );
-
-  if (!integration) {
+  const resolution = await resolveGitHubIntegrationForRepository({
+    owner,
+    repositoryFullName: proposal.repo_full_name,
+  });
+  if (!resolution.success) {
     throw new ReviewMemoryChangeRequestError(
       'BAD_REQUEST',
-      'No active GitHub integration has access to this repository.'
+      resolution.reason === 'ambiguous_installation'
+        ? 'Multiple active GitHub integrations have access to this repository.'
+        : 'No active GitHub integration has access to this repository.'
     );
   }
-  return integration;
-}
-
-function hasRepositoryAccess(integration: PlatformIntegration, repoFullName: string): boolean {
-  if (integration.repository_access === 'all') return true;
-  return integration.repositories?.some(repo => repo.full_name === repoFullName) ?? false;
+  return resolution.integration;
 }
 
 function assertGitHubPermissions(integration: PlatformIntegration): void {

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
@@ -943,7 +943,7 @@ describe('prepareReviewPayload', () => {
     expect(payload.sessionInput).not.toHaveProperty('gitlabCodeReviewTokenRef');
   });
 
-  it('does not continue previous cloud-agent sessions for GitHub pull-ref reviews', async () => {
+  it('continues GitHub pull-ref reviews on the exact integration session', async () => {
     const prNumber = 1235;
     mockFindPreviousCompletedReview.mockResolvedValueOnce({
       head_sha: 'sha-previous',
@@ -972,9 +972,10 @@ describe('prepareReviewPayload', () => {
       platform: 'github',
     });
 
-    expect(payload.previousCloudAgentSessionId).toBeUndefined();
+    expect(payload.previousCloudAgentSessionId).toBe('previous-cloud-agent-session');
     expect(payload.sessionInput).toMatchObject({
       githubRepo: REPO,
+      githubIntegrationId: integration.id,
       platform: 'github',
       upstreamBranch: 'refs/pull/1235/head',
     });

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -107,6 +107,8 @@ export type PreparePayloadParams = {
 export type SessionInput = {
   /** GitHub repo in format "owner/repo" (for GitHub platform) */
   githubRepo?: string;
+  /** Exact GitHub integration selected by the review webhook. */
+  githubIntegrationId?: string;
   /** Full git URL for cloning (for GitLab and other platforms) */
   gitUrl?: string;
   kilocodeOrganizationId?: string;
@@ -639,8 +641,7 @@ export async function prepareReviewPayload(
     }
 
     // 4. Check for previous completed review (incremental review optimization).
-    // Keep previousHeadSha for prompt diff context, but disable GitHub session
-    // continuation because sendMessageV2 does not refetch refs/pull/<n>/head.
+    // Keep previousHeadSha for prompt diff context and reuse the prior provider session.
     let previousHeadSha: string | null = null;
     let previousCloudAgentSessionId: string | undefined;
     try {
@@ -656,15 +657,6 @@ export async function prepareReviewPayload(
       if (previousReview?.session_id) {
         switch (platform) {
           case PLATFORM.GITHUB:
-            logExceptInTest(
-              '[prepareReviewPayload] Disabling GitHub session continuation for pull-ref checkout safety',
-              {
-                reviewId,
-                previousCloudAgentSessionId: previousReview.session_id,
-                upstreamBranch: getGitHubPullRequestCheckoutRef(review.pr_number),
-              }
-            );
-            break;
           case PLATFORM.GITLAB:
             previousCloudAgentSessionId = previousReview.session_id;
             break;
@@ -791,6 +783,7 @@ export async function prepareReviewPayload(
           : {
               // GitHub: use owner/repo format
               githubRepo: review.repo_full_name,
+              githubIntegrationId: review.platform_integration_id ?? undefined,
               githubToken,
               platform: 'github',
               kilocodeOrganizationId: owner.type === 'org' ? owner.id : undefined,

--- a/apps/web/src/lib/integrations/db/github-installation-resolver.test.ts
+++ b/apps/web/src/lib/integrations/db/github-installation-resolver.test.ts
@@ -1,11 +1,16 @@
 import { afterEach, describe, expect, it } from '@jest/globals';
 import { db } from '@/lib/drizzle';
-import { organizations, platform_integrations } from '@kilocode/db/schema';
+import { insertTestUser } from '@/tests/helpers/user.helper';
+import { kilocode_users, organizations, platform_integrations } from '@kilocode/db/schema';
 import { inArray } from 'drizzle-orm';
-import { resolveOrganizationGitHubIntegrationForRepository } from './platform-integrations';
+import {
+  resolveGitHubIntegrationForRepository,
+  resolveOrganizationGitHubIntegrationForRepository,
+} from './platform-integrations';
 
 const organizationIds = [crypto.randomUUID(), crypto.randomUUID()];
 const installationIds: string[] = [];
+const userIds: string[] = [];
 
 async function insertOrganization(organizationId: string) {
   await db.insert(organizations).values({
@@ -46,6 +51,10 @@ afterEach(async () => {
     installationIds.length = 0;
   }
   await db.delete(organizations).where(inArray(organizations.id, organizationIds));
+  if (userIds.length > 0) {
+    await db.delete(kilocode_users).where(inArray(kilocode_users.id, userIds));
+    userIds.length = 0;
+  }
 });
 
 describe('resolveOrganizationGitHubIntegrationForRepository', () => {
@@ -209,5 +218,54 @@ describe('resolveOrganizationGitHubIntegrationForRepository', () => {
         repositoryFullName: 'acme/api',
       })
     ).resolves.toEqual({ success: false, reason: 'no_installation_found' });
+  });
+});
+
+describe('resolveGitHubIntegrationForRepository', () => {
+  it('resolves an exact personal installation and fails closed on ambiguity', async () => {
+    const user = await insertTestUser();
+    userIds.push(user.id);
+    const first = await db
+      .insert(platform_integrations)
+      .values({
+        owned_by_user_id: user.id,
+        platform: 'github',
+        integration_type: 'app',
+        integration_status: 'active',
+        platform_installation_id: `resolver-${crypto.randomUUID()}`,
+        platform_account_login: 'acme',
+        repository_access: 'all',
+        github_app_type: 'standard',
+      })
+      .returning();
+    const second = await db
+      .insert(platform_integrations)
+      .values({
+        owned_by_user_id: user.id,
+        platform: 'github',
+        integration_type: 'app',
+        integration_status: 'active',
+        platform_installation_id: `resolver-${crypto.randomUUID()}`,
+        platform_account_login: 'acme',
+        repository_access: 'all',
+        github_app_type: 'lite',
+      })
+      .returning();
+    const integrations = [...first, ...second];
+    installationIds.push(...integrations.map(integration => integration.platform_installation_id!));
+
+    await expect(
+      resolveGitHubIntegrationForRepository({
+        owner: { type: 'user', id: user.id },
+        repositoryFullName: 'acme/api',
+        expectedPlatformIntegrationId: integrations[0].id,
+      })
+    ).resolves.toEqual({ success: true, integration: integrations[0] });
+    await expect(
+      resolveGitHubIntegrationForRepository({
+        owner: { type: 'user', id: user.id },
+        repositoryFullName: 'acme/api',
+      })
+    ).resolves.toEqual({ success: false, reason: 'ambiguous_installation' });
   });
 });

--- a/apps/web/src/lib/integrations/db/platform-integrations.ts
+++ b/apps/web/src/lib/integrations/db/platform-integrations.ts
@@ -94,32 +94,41 @@ export async function getPrimaryGitHubIntegrationForOrganization(organizationId:
   return integration ?? null;
 }
 
-export type OrganizationGitHubIntegrationResolution =
+export type GitHubIntegrationResolution =
   | { success: true; integration: PlatformIntegration }
   | { success: false; reason: 'no_installation_found' | 'ambiguous_installation' };
 
 /**
- * Resolves the one healthy organization installation authorized for a GitHub repository.
+ * Resolves the one healthy owner installation authorized for a GitHub repository.
  * Repository-specific resolution is intentionally separate from deterministic primary selection.
  */
-export async function resolveOrganizationGitHubIntegrationForRepository(input: {
-  organizationId: string;
+export async function resolveGitHubIntegrationForRepository(input: {
+  owner: Owner;
   repositoryFullName: string;
   expectedPlatformIntegrationId?: string;
-}): Promise<OrganizationGitHubIntegrationResolution> {
+}): Promise<GitHubIntegrationResolution> {
   const repositoryParts = input.repositoryFullName.split('/');
   if (repositoryParts.length !== 2 || repositoryParts.some(part => part.length === 0)) {
     return { success: false, reason: 'no_installation_found' };
   }
   const [repositoryOwner] = repositoryParts;
+  const ownershipConditions =
+    input.owner.type === 'org'
+      ? [
+          eq(platform_integrations.owned_by_organization_id, input.owner.id),
+          isNull(platform_integrations.owned_by_user_id),
+        ]
+      : [
+          eq(platform_integrations.owned_by_user_id, input.owner.id),
+          isNull(platform_integrations.owned_by_organization_id),
+        ];
 
   const integrations = await db
     .select()
     .from(platform_integrations)
     .where(
       and(
-        eq(platform_integrations.owned_by_organization_id, input.organizationId),
-        isNull(platform_integrations.owned_by_user_id),
+        ...ownershipConditions,
         eq(platform_integrations.platform, PLATFORM.GITHUB),
         eq(platform_integrations.integration_type, 'app'),
         isNotNull(platform_integrations.platform_installation_id),
@@ -155,6 +164,18 @@ export async function resolveOrganizationGitHubIntegrationForRepository(input: {
     return { success: false, reason: 'no_installation_found' };
   }
   return { success: true, integration };
+}
+
+export async function resolveOrganizationGitHubIntegrationForRepository(input: {
+  organizationId: string;
+  repositoryFullName: string;
+  expectedPlatformIntegrationId?: string;
+}): Promise<GitHubIntegrationResolution> {
+  return resolveGitHubIntegrationForRepository({
+    owner: { type: 'org', id: input.organizationId },
+    repositoryFullName: input.repositoryFullName,
+    expectedPlatformIntegrationId: input.expectedPlatformIntegrationId,
+  });
 }
 
 export async function getAllIntegationsForOrganization(organizationId: string) {

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -41,6 +41,7 @@ export type CloudAgentPrepareSessionInput = {
   model: string;
   variant?: string;
   githubRepo?: string;
+  githubIntegrationId?: string;
   githubToken?: string;
   gitUrl?: string;
   gitToken?: string;

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -1703,6 +1703,67 @@ describe('SessionService.prepareWorkspace', () => {
     );
   });
 
+  it('refreshes a warm review pull ref while preserving the resolved GitHub app type', async () => {
+    const session = createSession(true);
+    const sandbox = createSandbox(session, true);
+    const integrationId = '123e4567-e89b-12d3-a456-426614174022';
+    tokenMocks.issueCloudAgentGitHubSessionCapability.mockResolvedValueOnce({
+      success: true,
+      value: {
+        capability: 'kgh2.lite',
+        installationId: '987',
+        accountLogin: 'acme',
+        appType: 'lite',
+        source: 'installation',
+        gitAuthor: { name: 'kilocode-lite[bot]', email: 'lite@example.com' },
+      },
+    });
+    const parsedMetadata = createMetadata({
+      createdOnPlatform: 'code-review',
+      githubRepo: 'acme/repo',
+      githubInstallationId: '987',
+      githubAppType: 'lite',
+      gitUrl: undefined,
+      gitToken: undefined,
+      platform: 'github',
+      upstreamBranch: 'refs/pull/42/head',
+      workspacePath: '/workspace/user/sessions/agent_test',
+      sessionHome: '/home/agent_test',
+      branchName: 'refs/pull/42/head',
+      sandboxId: 'ses-abcdef',
+    });
+    if (parsedMetadata.repository?.type !== 'github') {
+      throw new Error('Expected GitHub session metadata');
+    }
+    const metadata = {
+      ...parsedMetadata,
+      repository: { ...parsedMetadata.repository, githubIntegrationId: integrationId },
+    } satisfies CloudAgentSessionState;
+
+    const result = await new SessionService().prepareWorkspace({
+      sandbox,
+      sandboxId: 'ses-abcdef',
+      userId: 'user_test',
+      sessionId: 'agent_test' as SessionId,
+      env: createEnv(),
+      metadata,
+      kilocodeModel: 'test-model',
+    });
+
+    expect(tokenMocks.issueCloudAgentGitHubSessionCapability).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ expectedIntegrationId: integrationId })
+    );
+    expect(workspaceMocks.manageBranch).toHaveBeenCalledWith(
+      session,
+      '/workspace/user/sessions/agent_test',
+      'refs/pull/42/head',
+      true
+    );
+    expect(result.ready.githubInstallationId).toBe('987');
+    expect(result.ready.githubAppType).toBe('lite');
+  });
+
   it('refreshes the warm fast path GitLab remote with direct managed authentication', async () => {
     const session = createSession(true);
     const sandbox = createSandbox(session, true);

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -2389,6 +2389,13 @@ export class SessionService {
       ) {
         await this.refreshGitRemoteToken(session, context, metadata, resolvedTokens);
       }
+      const upstreamBranch = metadata.repository?.upstreamBranch;
+      if (
+        metadata.identity.createdOnPlatform === 'code-review' &&
+        upstreamBranch?.startsWith('refs/pull/')
+      ) {
+        await manageBranch(session, workspacePath, upstreamBranch, true);
+      }
 
       const detectedDevcontainer =
         metadata.workspace?.devcontainerRequested && !metadata.devcontainer

--- a/services/code-review-infra/src/types.ts
+++ b/services/code-review-infra/src/types.ts
@@ -20,6 +20,8 @@ export type CodeReviewStatus = 'queued' | 'running' | 'completed' | 'failed' | '
 export interface SessionInput {
   /** GitHub repo in format "owner/repo" (for GitHub platform) */
   githubRepo?: string;
+  /** Exact GitHub integration selected by the review webhook. */
+  githubIntegrationId?: string;
   /** Full git URL for cloning (for GitLab and other platforms) */
   gitUrl?: string;
   kilocodeOrganizationId?: string;


### PR DESCRIPTION
## Why this PR exists

Code Reviewer already records the GitHub installation that produced a review, but several follow-up paths discard it. `Fix with Cloud Agent`, incremental review continuation, and Review Memory change requests can then resolve a different organization installation by repository name. That is both a correctness problem and a credential-boundary problem when installations overlap.

This PR makes every review follow-up continue through the installation that owns the review, and makes legacy repository-only Review Memory changes fail closed when more than one installation could serve them.

## Place in the rollout

This is the follow-up/continuation slice for Code Reviewer. Initial multi-install review dispatch was piloted in merged #5486. Installation health and action-required isolation are intentionally separate in #5579.

## Dependency

Depends on #5547 for shared fail-closed repository resolution. After #5547 merges, retarget this PR to `main`.

## What changes

- Pass `review.platform_integration_id` into `Fix with Cloud Agent`.
- Pin incremental review sessions to the exact integration.
- Refresh moving GitHub pull refs when a warm review session is reused.
- Resolve Review Memory change requests uniquely instead of selecting the first installation.
- Preserve the resolved Standard or Lite app type for follow-up token issuance.

## What stays unchanged

- Initial webhook dispatch and reviewer configuration are not redesigned here.
- GitLab continuation behavior is preserved.
- This PR does not change organization-wide status or action-required UI.

## Why this crosses web and Cloud Agent services

The integration ID is chosen in the web review flow but must survive the worker contract and warm-session preparation. Changing only one side would create a partial pin that is lost during continuation.

## Review guide

Trace `platform_integration_id` from `prepare-review-payload.ts` and the fork route into Cloud Agent session state, then inspect the warm pull-ref refresh. Review Memory resolution is a separate, small use of the same safety contract.

## Validation

- 53 focused web tests
- 111 Cloud Agent session-service tests
- 57 code-review worker tests
- 355 worker-utils tests
- Affected-package typechecks, lint, and formatting
- `git diff --check`