### PR TITLE
feat(github-bot): start sessions with the installation that received the mention

### DIFF
--- a/apps/web/src/lib/bot.ts
+++ b/apps/web/src/lib/bot.ts
@@ -17,6 +17,7 @@ import { slackAdapter } from '@/lib/bot/slack-adapter';
 import { botPlatforms } from '@/lib/bot/platforms';
 import { createLinearWebhookHandler } from '@/lib/bot/platforms/linear-webhook';
 import { createSlackWebhookHandler } from '@/lib/bot/platforms/slack-webhook';
+import { PLATFORM } from '@/lib/integrations/core/constants';
 
 function createKiloBot(
   slackAdapter: SlackAdapter,
@@ -44,7 +45,10 @@ function createKiloBot(
     const botPlatform = botPlatforms.requireByAdapter(thread.adapter);
     const identity = await botPlatform.getIdentity({ thread, message });
     const [platformIntegration, kiloUserId] = await Promise.all([
-      getPlatformIntegration(identity),
+      getPlatformIntegration(
+        identity,
+        identity.platform === PLATFORM.GITHUB ? 'standard' : undefined
+      ),
       resolveKiloUserId(chatBot.getState(), identity),
     ]);
 

--- a/apps/web/src/lib/bot/platform-helpers.test.ts
+++ b/apps/web/src/lib/bot/platform-helpers.test.ts
@@ -1,5 +1,6 @@
 const mockLimit = jest.fn();
 const mockIsOrganizationMember = jest.fn();
+const mockFindIntegrationByInstallationId = jest.fn();
 
 jest.mock('@/lib/drizzle', () => ({
   db: {
@@ -16,6 +17,10 @@ jest.mock('@/lib/organizations/organizations', () => ({
   isOrganizationMember: (organizationId: string, kiloUserId: string) =>
     mockIsOrganizationMember(organizationId, kiloUserId),
 }));
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  findIntegrationByInstallationId: (...args: unknown[]) =>
+    mockFindIntegrationByInstallationId(...args),
+}));
 
 import { PLATFORM } from '@/lib/integrations/core/constants';
 import {
@@ -30,6 +35,7 @@ describe('platform helpers', () => {
   beforeEach(() => {
     mockLimit.mockReset();
     mockIsOrganizationMember.mockReset();
+    mockFindIntegrationByInstallationId.mockReset();
   });
 
   it('returns the platform integration for a given identity', async () => {
@@ -59,6 +65,28 @@ describe('platform helpers', () => {
     });
 
     expect(result).toBeNull();
+  });
+
+  it('selects the GitHub integration by installation ID and app type', async () => {
+    const standardIntegration = { id: 'pi_standard', github_app_type: 'standard' };
+    const liteIntegration = { id: 'pi_lite', github_app_type: 'lite' };
+    mockFindIntegrationByInstallationId.mockImplementation(
+      (_platform: string, _installationId: string, appType: string) =>
+        appType === 'standard' ? standardIntegration : liteIntegration
+    );
+
+    const result = await getPlatformIntegration(
+      { platform: 'github', teamId: 'shared-installation', userId: '123' },
+      'standard'
+    );
+
+    expect(result).toBe(standardIntegration);
+    expect(mockFindIntegrationByInstallationId).toHaveBeenCalledWith(
+      'github',
+      'shared-installation',
+      'standard'
+    );
+    expect(mockLimit).not.toHaveBeenCalled();
   });
 
   it('returns the platform integration for a given id', async () => {

--- a/apps/web/src/lib/bot/platform-helpers.ts
+++ b/apps/web/src/lib/bot/platform-helpers.ts
@@ -3,12 +3,22 @@ import { db } from '@/lib/drizzle';
 import { eq, and, sql } from 'drizzle-orm';
 import { platform_integrations, type PlatformIntegration } from '@kilocode/db';
 import { isOrganizationMember } from '@/lib/organizations/organizations';
+import { findIntegrationByInstallationId } from '@/lib/integrations/db/platform-integrations';
+import type { GitHubAppType } from '@/lib/integrations/platforms/github/app-selector';
 
 /**
- * Look up the platform integration row for a given identity.
- * Platform-agnostic: queries by identity.platform + identity.teamId.
+ * Look up the platform integration row for a given identity. GitHub callers
+ * that know their app type must supply it because installation IDs can collide
+ * between the standard and lite apps.
  */
-export async function getPlatformIntegration(identity: PlatformIdentity) {
+export async function getPlatformIntegration(
+  identity: PlatformIdentity,
+  githubAppType?: GitHubAppType
+) {
+  if (identity.platform === 'github' && githubAppType) {
+    return await findIntegrationByInstallationId(identity.platform, identity.teamId, githubAppType);
+  }
+
   const [integration] = await db
     .select()
     .from(platform_integrations)

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.test.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.test.ts
@@ -21,6 +21,10 @@ jest.mock('@/lib/constants', () => ({
   APP_URL: 'https://app.example.test',
 }));
 
+jest.mock('@/lib/bot-users/bot-user-service', () => ({
+  getBotUserId: jest.fn(),
+}));
+
 jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
   createCloudAgentNextClient: jest.fn(),
 }));
@@ -28,6 +32,12 @@ jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
 jest.mock('@/lib/cloud-agent/github-integration-helpers', () => ({
   getGitHubTokenForOrganization: jest.fn(),
   getGitHubTokenForUser: jest.fn(),
+}));
+
+const mockGenerateGitHubInstallationToken =
+  jest.fn<(...args: unknown[]) => Promise<{ token: string }>>();
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  generateGitHubInstallationToken: mockGenerateGitHubInstallationToken,
 }));
 
 jest.mock('@/lib/cloud-agent/gitlab-integration-helpers', () => ({
@@ -47,6 +57,14 @@ const userIntegration = {
   owned_by_user_id: 'owner-1',
 } as PlatformIntegration;
 const organizationIntegration = {
+  owned_by_organization_id: 'organization-1',
+  owned_by_user_id: null,
+} as PlatformIntegration;
+const secondaryGitHubIntegration = {
+  id: '10000000-0000-4000-8000-000000000002',
+  platform: 'github',
+  platform_installation_id: 'secondary-installation',
+  github_app_type: 'standard',
   owned_by_organization_id: 'organization-1',
   owned_by_user_id: null,
 } as PlatformIntegration;
@@ -101,6 +119,7 @@ describe('spawnCloudAgentSession delegation', () => {
       kiloSessionId: 'kilo-session-1',
     });
     mockInitiateFromPreparedSession.mockResolvedValue({});
+    mockGenerateGitHubInstallationToken.mockResolvedValue({ token: 'secondary-github-token' });
     mockGetGitHubTokenForOrganization.mockResolvedValue('organization-github-token');
     mockGetGitHubTokenForUser.mockResolvedValue('github-token');
     mockGetGitLabTokenForUser.mockResolvedValue('gitlab-token');
@@ -177,6 +196,29 @@ describe('spawnCloudAgentSession delegation', () => {
     for (const field of profileDerivedInlineFields) {
       expect(prepareInput).not.toHaveProperty(field);
     }
+  });
+
+  it('uses the triggering secondary GitHub integration for the session input', async () => {
+    await spawnCloudAgentSession(
+      { githubRepo: 'owner/secondary-repo', prompt: 'Fix the issue', mode: 'code' },
+      'model',
+      secondaryGitHubIntegration,
+      'auth-token',
+      'request-secondary'
+    );
+
+    expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledWith(
+      'secondary-installation',
+      'standard'
+    );
+    expect(mockGetGitHubTokenForOrganization).not.toHaveBeenCalled();
+    expect(mockPrepareSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubRepo: 'owner/secondary-repo',
+        githubIntegrationId: secondaryGitHubIntegration.id,
+        githubToken: 'secondary-github-token',
+      })
+    );
   });
 
   it.each(['slack', 'github', 'linear'])(

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -8,6 +8,7 @@ import {
   getGitHubTokenForOrganization,
   getGitHubTokenForUser,
 } from '@/lib/cloud-agent/github-integration-helpers';
+import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
 import {
   getGitLabTokenForOrganization,
   getGitLabTokenForUser,
@@ -26,6 +27,7 @@ import { captureException } from '@sentry/nextjs';
 import type { PlatformIntegration } from '@kilocode/db';
 import z from 'zod';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
+import { PLATFORM } from '@/lib/integrations/core/constants';
 
 /**
  * Derive a per-request callback token so the dedicated callback HMAC secret
@@ -184,8 +186,17 @@ export default async function spawnCloudAgentSession(
     };
   } else {
     // GitHub path: get token, use githubRepo/githubToken
-    const githubToken =
-      owner.type === 'org'
+    const isGitHubBotSession = platformIntegration.platform === PLATFORM.GITHUB;
+    const githubToken = isGitHubBotSession
+      ? platformIntegration.platform_installation_id
+        ? (
+            await generateGitHubInstallationToken(
+              platformIntegration.platform_installation_id,
+              platformIntegration.github_app_type ?? 'standard'
+            )
+          ).token
+        : undefined
+      : owner.type === 'org'
         ? await getGitHubTokenForOrganization(owner.id)
         : await getGitHubTokenForUser(owner.id);
 
@@ -198,6 +209,7 @@ export default async function spawnCloudAgentSession(
 
     prepareInput = {
       githubRepo: args.githubRepo,
+      githubIntegrationId: isGitHubBotSession ? platformIntegration.id : undefined,
       prompt,
       mode,
       model,


### PR DESCRIPTION
## Why this PR exists

A GitHub bot mention arrives through one specific GitHub App and installation. The bot path currently looks up an integration too loosely and then uses the organization's primary GitHub credentials. With multiple installations, that can start a Cloud Agent session under a sibling installation instead of the one where the conversation occurred.

This PR treats the webhook identity as authoritative: the delivering app type and installation select one Kilo integration row, and that row is passed into session creation.

## Place in the rollout

This is the incoming GitHub-bot slice. Slack and Discord start from a user-selected repository rather than a GitHub webhook, so their repository-selection work is separate in #5558.

## What changes

- Resolve GitHub bot identity by provider installation ID and GitHub app type.
- Pass the triggering Kilo integration ID as `githubIntegrationId`.
- Mint credentials from that integration rather than using organization-primary helpers.

## What stays unchanged

- Slack and Linear platform lookup behavior is unchanged.
- The bot does not gain access to repositories outside the delivering installation.
- No secondary event class is enabled here; this changes the already-supported GitHub bot path.

## Review guide

Review `getPlatformIntegration` first: GitHub uses the exact installation plus app type, other platforms retain their query. Then verify `spawn-cloud-agent-session.ts` uses that same row for both token and session provenance.

## Validation

- 2 focused Jest suites, 16 tests
- Web typecheck and lint
- Targeted format check
- `git diff --check`

No DB-backed suite is needed for this pure identity-routing change.