### PR TITLE
fix(code-review): isolate installation access failures

### DIFF
--- a/apps/mobile/src/components/code-reviewer/platform-overview-screen.mounted.test.tsx
+++ b/apps/mobile/src/components/code-reviewer/platform-overview-screen.mounted.test.tsx
@@ -195,7 +195,7 @@ describe('PlatformOverviewScreen actionRequired banner', () => {
 
     expect(texts).toContain('Code Reviewer needs attention');
     expect(texts).toContain(
-      'Code Reviewer was disabled because Kilo cannot access this repository with an active GitHub App installation. Update the GitHub App installation, then enable Code Reviewer again.'
+      'Kilo cannot access this repository with its GitHub App installation. Update the affected GitHub App installation before retrying this review.'
     );
     expect(texts).toContain('Update GitHub App');
   });

--- a/apps/mobile/src/i18n/locales/en.json
+++ b/apps/mobile/src/i18n/locales/en.json
@@ -1444,17 +1444,17 @@
     "actionRequired": {
       "githubInstallationRequired": {
         "title": "Code Reviewer needs attention",
-        "description": "Code Reviewer was disabled because Kilo cannot access this repository with an active GitHub App installation. Update the GitHub App installation, then enable Code Reviewer again.",
+        "description": "Kilo cannot access this repository with its GitHub App installation. Update the affected GitHub App installation before retrying this review.",
         "recoveryLabel": "Update GitHub App"
       },
       "githubIpAllowList": {
         "title": "Code Reviewer needs attention",
-        "description": "Code Reviewer was disabled because this GitHub organization uses an IP allow list that blocks Kilo. Contact hi@kilocode.ai for help, then enable Code Reviewer again.",
+        "description": "This repository belongs to a GitHub organization whose IP allow list blocks Kilo. Contact hi@kilocode.ai for help before retrying this review.",
         "recoveryLabel": "Contact support"
       },
       "gitlabProjectAccessRequired": {
         "title": "Code Reviewer needs attention",
-        "description": "Code Reviewer was disabled because Kilo cannot create a GitLab Project Access Token for this project. Grant Maintainer access or enable Project Access Tokens, then enable Code Reviewer again.",
+        "description": "Kilo cannot create a GitLab Project Access Token for this project. Grant Maintainer access or enable Project Access Tokens before retrying this review.",
         "recoveryLabel": "Update GitLab integration"
       },
       "byokInvalidKey": {

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.test.ts
@@ -893,7 +893,7 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         'abc123',
         'failed',
         expect.objectContaining({
-          description: 'Code Reviewer disabled: GitLab token setup required',
+          description: 'Code Reviewer needs GitLab token access',
         }),
         'https://gitlab.com'
       );
@@ -935,6 +935,8 @@ describe('POST /api/internal/code-review-status/[reviewId]', () => {
         reviewId: REVIEW_ID,
         reason: 'selected_model_unavailable',
         errorMessage,
+        integrationId: 'int-1',
+        repositoryFullName: 'owner/repo',
       });
       expect(mockUpdateCheckRun).not.toHaveBeenCalled();
       expect(mockSetCommitStatus).not.toHaveBeenCalled();

--- a/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
+++ b/apps/web/src/app/api/internal/code-review-status/[reviewId]/route.ts
@@ -1560,10 +1560,12 @@ export async function POST(
             reviewId,
             reason: actionRequiredReason,
             errorMessage: errorMessage ?? actionRequiredReason,
+            integrationId: review.platform_integration_id,
+            repositoryFullName: review.repo_full_name,
           });
         } catch (disableError) {
           logExceptInTest(
-            '[code-review-status] Failed to disable Code Reviewer for action-required failure:',
+            '[code-review-status] Failed to record Code Reviewer action-required failure:',
             disableError
           );
           captureException(disableError, {

--- a/apps/web/src/components/code-reviews/CodeReviewActionRequiredAlert.tsx
+++ b/apps/web/src/components/code-reviews/CodeReviewActionRequiredAlert.tsx
@@ -25,7 +25,8 @@ export function CodeReviewActionRequiredAlert({
   const recoveryHref = getCodeReviewActionRequiredRecoveryHref(
     actionRequired.reason,
     organizationId,
-    platform
+    platform,
+    actionRequired.integrationId
   );
   const isMailto = recoveryHref.startsWith('mailto:');
 

--- a/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
+++ b/apps/web/src/components/code-reviews/ReviewConfigForm.tsx
@@ -453,9 +453,9 @@ export function ReviewConfigForm({
       );
       setCouncilRequiredLabelsInput((loadedCouncil?.required_labels ?? []).join(', '));
       setCouncilEnabledRepositoryIds(
-        new Set(
-          (configData.councilEnabledRepositoryIds ?? []).filter(
-            (repositoryId): repositoryId is number => typeof repositoryId === 'number'
+        new Set<number>(
+          (configData.councilEnabledRepositoryIds ?? []).flatMap(repositoryId =>
+            typeof repositoryId === 'number' ? [repositoryId] : []
           )
         )
       );

--- a/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
+++ b/apps/web/src/components/integrations/OrganizationGitHubInstallations.tsx
@@ -154,7 +154,11 @@ export function OrganizationGitHubInstallations({
                   : `${selectedCount} selected ${selectedCount === 1 ? 'repository' : 'repositories'}`;
               const accountName = installation.accountLogin ?? 'GitHub organization';
               return (
-                <Collapsible key={installation.id}>
+                <Collapsible
+                  key={installation.id}
+                  id={`github-installation-${installation.id}`}
+                  className="scroll-mt-6"
+                >
                   <div className="flex min-w-0 items-center gap-3 px-4 py-4 sm:px-5">
                     <Github className="size-5 shrink-0 text-muted-foreground" aria-hidden="true" />
                     <div className="min-w-0 flex-1">

--- a/apps/web/src/lib/code-reviews/action-required-shared.ts
+++ b/apps/web/src/lib/code-reviews/action-required-shared.ts
@@ -12,6 +12,8 @@ export {
 };
 
 export const CODE_REVIEW_ACTION_REQUIRED_RUNTIME_STATE_KEY = 'code_review_action_required';
+export const CODE_REVIEW_SCOPED_ACTION_REQUIRED_RUNTIME_STATE_KEY =
+  'code_review_scoped_action_required';
 
 export type CodeReviewActionRequiredCopy = {
   title: string;
@@ -32,16 +34,16 @@ const WEB_COPY_BY_REASON: Record<
   { checkTitle: string; gitlabDescription: string }
 > = {
   github_installation_required: {
-    checkTitle: 'Code Reviewer disabled: GitHub App access',
-    gitlabDescription: 'Code Reviewer disabled: GitHub App access required',
+    checkTitle: 'Code Reviewer needs GitHub App access',
+    gitlabDescription: 'Code Reviewer needs GitHub App access',
   },
   github_ip_allow_list: {
-    checkTitle: 'Code Reviewer disabled: IP allow list',
-    gitlabDescription: 'Code Reviewer disabled: GitHub IP allow list blocks Kilo',
+    checkTitle: 'Code Reviewer blocked by IP allow list',
+    gitlabDescription: 'Code Reviewer blocked by GitHub IP allow list',
   },
   gitlab_project_access_required: {
-    checkTitle: 'Code Reviewer disabled: GitLab token setup',
-    gitlabDescription: 'Code Reviewer disabled: GitLab token setup required',
+    checkTitle: 'Code Reviewer needs GitLab token access',
+    gitlabDescription: 'Code Reviewer needs GitLab token access',
   },
   byok_invalid_key: {
     checkTitle: 'Code Reviewer disabled: BYOK key issue',
@@ -81,12 +83,16 @@ export function getCodeReviewActionRequiredCopy(
 export function getCodeReviewActionRequiredRecoveryHref(
   reason: CodeReviewActionRequiredReason,
   organizationId?: string,
-  platform?: 'github' | 'gitlab' | 'bitbucket'
+  platform?: 'github' | 'gitlab' | 'bitbucket',
+  integrationId?: string
 ): string {
   if (reason === 'github_installation_required') {
-    return organizationId
+    const path = organizationId
       ? `/organizations/${organizationId}/integrations/github`
       : '/integrations/github';
+    return integrationId
+      ? `${path}#github-installation-${encodeURIComponent(integrationId)}`
+      : path;
   }
 
   if (reason === 'github_ip_allow_list') {

--- a/apps/web/src/lib/code-reviews/action-required.test.ts
+++ b/apps/web/src/lib/code-reviews/action-required.test.ts
@@ -15,11 +15,14 @@ import {
 import { and, eq } from 'drizzle-orm';
 import {
   classifyCodeReviewActionRequiredFailure,
+  clearScopedCodeReviewActionRequiredState,
   disableCodeReviewForActionRequiredFailure,
   disableCodeReviewForRepeatedCloneTimeoutsToday,
   getCodeReviewActionRequiredCopy,
   getCodeReviewActionRequiredRecoveryHref,
   getCodeReviewActionRequiredState,
+  getCodeReviewActionRequiredStateForScope,
+  getCodeReviewScopedActionRequiredStates,
 } from './action-required';
 import { CODE_REVIEW_ACTION_REQUIRED_REASONS } from './action-required-shared';
 
@@ -172,12 +175,12 @@ describe('classifyCodeReviewActionRequiredFailure', () => {
   });
 
   it.each(CODE_REVIEW_ACTION_REQUIRED_REASONS)(
-    'uses disabled-state copy for %s',
+    'uses actionable copy for %s',
     actionRequiredReason => {
       const copy = getCodeReviewActionRequiredCopy(actionRequiredReason);
 
-      expect(copy.emailReason).toMatch(/Code Reviewer was disabled/);
-      expect(copy.checkSummary).toMatch(/Code Reviewer was disabled/);
+      expect(copy.emailReason.trim()).not.toBe('');
+      expect(copy.checkSummary).toBe(copy.emailReason);
       expect(copy.recoveryLabel.trim()).not.toBe('');
       expect(copy.checkTitle.trim()).not.toBe('');
       expect(copy.gitlabDescription.trim()).not.toBe('');
@@ -326,6 +329,87 @@ describe('disableCodeReviewForActionRequiredFailure', () => {
     expect(state?.emailSentAt).toBeTruthy();
     expect(JSON.stringify(config?.runtime_state)).not.toContain(testUser.google_user_email);
     expect(mockSendCodeReviewDisabledEmail).toHaveBeenCalledTimes(1);
+  });
+
+  it('isolates a repository access failure to its GitHub integration and repository', async () => {
+    const owner = { type: 'user' as const, id: testUser.id, userId: testUser.id };
+
+    await disableCodeReviewForActionRequiredFailure({
+      owner,
+      platform: 'github',
+      reviewId: 'review-1',
+      reason: 'github_installation_required',
+      errorMessage:
+        'GitHub token or active app installation required for this repository (repository_not_installed)',
+      integrationId: 'integration-unhealthy',
+      repositoryFullName: 'acme/private-repo',
+    });
+
+    const config = await getStoredConfig();
+    expect(config?.is_enabled).toBe(true);
+    expect(getCodeReviewActionRequiredState(config)).toBeNull();
+    expect(getCodeReviewScopedActionRequiredStates(config)).toEqual([
+      expect.objectContaining({
+        reason: 'github_installation_required',
+        integrationId: 'integration-unhealthy',
+        repositoryFullName: 'acme/private-repo',
+        triggeringReviewId: 'review-1',
+      }),
+    ]);
+    expect(
+      getCodeReviewActionRequiredStateForScope(config, {
+        integrationId: 'integration-unhealthy',
+        repositoryFullName: 'acme/private-repo',
+      })
+    ).toEqual(expect.objectContaining({ reason: 'github_installation_required' }));
+    expect(
+      getCodeReviewActionRequiredStateForScope(config, {
+        integrationId: 'integration-healthy',
+        repositoryFullName: 'acme/healthy-repo',
+      })
+    ).toBeNull();
+    expect(
+      getCodeReviewActionRequiredStateForScope(config, {
+        integrationId: 'integration-unhealthy',
+        repositoryFullName: 'acme/other-repo',
+      })
+    ).toBeNull();
+    expect(mockSendCodeReviewDisabledEmail).not.toHaveBeenCalled();
+
+    await clearScopedCodeReviewActionRequiredState({
+      owner,
+      platform: 'github',
+      integrationId: 'integration-unhealthy',
+    });
+    expect(getCodeReviewScopedActionRequiredStates(await getStoredConfig())).toEqual([]);
+  });
+
+  it('isolates a GitHub IP allow-list failure to the affected integration', async () => {
+    const owner = { type: 'user' as const, id: testUser.id, userId: testUser.id };
+
+    await disableCodeReviewForActionRequiredFailure({
+      owner,
+      platform: 'github',
+      reason: 'github_ip_allow_list',
+      errorMessage:
+        'Although you appear to have the correct authorization credentials, the organization has an IP allow list enabled.',
+      integrationId: 'integration-blocked',
+      repositoryFullName: 'acme/repo',
+    });
+
+    const config = await getStoredConfig();
+    expect(
+      getCodeReviewActionRequiredStateForScope(config, {
+        integrationId: 'integration-blocked',
+        repositoryFullName: 'acme/another-repo',
+      })
+    ).toEqual(expect.objectContaining({ reason: 'github_ip_allow_list' }));
+    expect(
+      getCodeReviewActionRequiredStateForScope(config, {
+        integrationId: 'integration-healthy',
+        repositoryFullName: 'acme/repo',
+      })
+    ).toBeNull();
   });
 
   it('retries email when notification delivery fails', async () => {

--- a/apps/web/src/lib/code-reviews/action-required.ts
+++ b/apps/web/src/lib/code-reviews/action-required.ts
@@ -13,6 +13,7 @@ import type { CodeReviewPlatform } from '@/lib/code-reviews/core/schemas';
 import {
   CODE_REVIEW_ACTION_REQUIRED_REASONS,
   CODE_REVIEW_ACTION_REQUIRED_RUNTIME_STATE_KEY,
+  CODE_REVIEW_SCOPED_ACTION_REQUIRED_RUNTIME_STATE_KEY,
   type CodeReviewActionRequiredReason,
   type CodeReviewActionRequiredState,
   getCodeReviewActionRequiredCopy,
@@ -32,6 +33,8 @@ const CodeReviewActionRequiredStateSchema = z.object({
   detectedAt: z.string(),
   lastSeenAt: z.string(),
   triggeringReviewId: z.string().optional(),
+  integrationId: z.string().optional(),
+  repositoryFullName: z.string().optional(),
   lastErrorMessage: z.string(),
   emailSentAt: z.string().optional(),
 });
@@ -60,6 +63,8 @@ type DisableCodeReviewForActionRequiredFailureArgs = {
   reviewId?: string;
   reason: CodeReviewActionRequiredReason;
   errorMessage: string;
+  integrationId?: string | null;
+  repositoryFullName?: string | null;
 };
 
 type DisableCodeReviewForRepeatedCloneTimeoutsTodayArgs = {
@@ -74,6 +79,12 @@ type ClearCodeReviewActionRequiredStateArgs = {
   platform: CodeReviewPlatform;
 };
 
+type ClearScopedCodeReviewActionRequiredStateArgs = {
+  owner: Pick<Owner, 'type' | 'id'>;
+  platform: CodeReviewPlatform;
+  integrationId: string;
+};
+
 type MarkActionRequiredEmailSentArgs = {
   owner: Owner;
   platform: CodeReviewPlatform;
@@ -86,6 +97,11 @@ type PersistActionRequiredDisableArgs = {
   platform: CodeReviewPlatform;
   reviewId?: string;
   reason: CodeReviewActionRequiredReason;
+};
+
+type CodeReviewActionRequiredScope = {
+  integrationId?: string | null;
+  repositoryFullName?: string | null;
 };
 
 type PersistActionRequiredBeforeUpdate = (tx: DrizzleTransaction) => Promise<boolean>;
@@ -169,6 +185,44 @@ export function getCodeReviewActionRequiredState(
   );
 
   return parsed.success ? parsed.data : null;
+}
+
+export function getCodeReviewScopedActionRequiredStates(
+  config: AgentConfigWithRuntimeState | null | undefined
+): CodeReviewActionRequiredState[] {
+  const runtimeState = config?.runtime_state;
+  if (!runtimeState) return [];
+
+  const parsed = z
+    .array(CodeReviewActionRequiredStateSchema)
+    .safeParse(runtimeState[CODE_REVIEW_SCOPED_ACTION_REQUIRED_RUNTIME_STATE_KEY]);
+  return parsed.success ? parsed.data : [];
+}
+
+export function getCodeReviewActionRequiredStateForScope(
+  config: AgentConfigWithRuntimeState | null | undefined,
+  scope: CodeReviewActionRequiredScope
+): CodeReviewActionRequiredState | null {
+  const ownerWideState = getCodeReviewActionRequiredState(config);
+  if (ownerWideState) return ownerWideState;
+  if (!scope.integrationId) return null;
+
+  return (
+    getCodeReviewScopedActionRequiredStates(config).find(
+      state =>
+        state.integrationId === scope.integrationId &&
+        (!state.repositoryFullName || state.repositoryFullName === scope.repositoryFullName)
+    ) ?? null
+  );
+}
+
+function isIntegrationScopedFailure(args: DisableCodeReviewForActionRequiredFailureArgs): boolean {
+  return (
+    Boolean(args.integrationId) &&
+    (args.reason === 'github_installation_required' ||
+      args.reason === 'github_ip_allow_list' ||
+      args.reason === 'gitlab_project_access_required')
+  );
 }
 
 function ownerConditions(owner: Pick<Owner, 'type' | 'id'>, platform: CodeReviewPlatform): SQL[] {
@@ -418,6 +472,69 @@ async function persistActionRequiredDisable(
   });
 }
 
+async function persistScopedActionRequired(
+  args: DisableCodeReviewForActionRequiredFailureArgs
+): Promise<void> {
+  if (!args.integrationId) return;
+  const integrationId = args.integrationId;
+
+  await db.transaction(async tx => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${`code-review-action-required:${args.owner.type}:${args.owner.id}:${args.platform}`}))`
+    );
+
+    const conditions = ownerConditions(args.owner, args.platform);
+    const [config] = await tx
+      .select()
+      .from(agent_configs)
+      .where(and(...conditions))
+      .for('update')
+      .limit(1);
+    if (!config) {
+      throw new Error(
+        `Code Review agent config not found for owner ${args.owner.type}:${args.owner.id} on ${args.platform}`
+      );
+    }
+
+    const now = new Date().toISOString();
+    const repositoryFullName =
+      args.reason === 'github_ip_allow_list' ? undefined : (args.repositoryFullName ?? undefined);
+    const states = getCodeReviewScopedActionRequiredStates(config);
+    const existingState = states.find(
+      state =>
+        state.integrationId === integrationId && state.repositoryFullName === repositoryFullName
+    );
+    const nextState: CodeReviewActionRequiredState = {
+      reason: args.reason,
+      detectedAt:
+        existingState?.reason === args.reason && existingState.detectedAt
+          ? existingState.detectedAt
+          : now,
+      lastSeenAt: now,
+      ...(args.reviewId ? { triggeringReviewId: args.reviewId } : {}),
+      integrationId,
+      ...(repositoryFullName ? { repositoryFullName } : {}),
+      lastErrorMessage: getCodeReviewActionRequiredCopy(args.reason).description,
+    };
+    const nextStates = states.filter(
+      state =>
+        state.integrationId !== integrationId || state.repositoryFullName !== repositoryFullName
+    );
+    nextStates.push(nextState);
+
+    await tx
+      .update(agent_configs)
+      .set({
+        runtime_state: {
+          ...(config.runtime_state ?? {}),
+          [CODE_REVIEW_SCOPED_ACTION_REQUIRED_RUNTIME_STATE_KEY]: nextStates,
+        },
+        updated_at: now,
+      })
+      .where(and(...conditions));
+  });
+}
+
 async function sendAndMarkActionRequiredEmailNotifications(
   args: PersistActionRequiredDisableArgs,
   shouldSendEmail: boolean
@@ -458,6 +575,11 @@ async function sendAndMarkActionRequiredEmailNotifications(
 export async function disableCodeReviewForActionRequiredFailure(
   args: DisableCodeReviewForActionRequiredFailureArgs
 ): Promise<void> {
+  if (isIntegrationScopedFailure(args)) {
+    await persistScopedActionRequired(args);
+    return;
+  }
+
   const shouldSendEmail = await persistActionRequiredDisable(args);
   if (shouldSendEmail === null) return;
   await sendAndMarkActionRequiredEmailNotifications(args, shouldSendEmail);
@@ -517,8 +639,40 @@ export async function clearCodeReviewActionRequiredState(
   await db
     .update(agent_configs)
     .set({
-      runtime_state: sql`COALESCE(${agent_configs.runtime_state}, '{}'::jsonb) - ${CODE_REVIEW_ACTION_REQUIRED_RUNTIME_STATE_KEY}`,
+      runtime_state: sql`COALESCE(${agent_configs.runtime_state}, '{}'::jsonb) - ${CODE_REVIEW_ACTION_REQUIRED_RUNTIME_STATE_KEY} - ${CODE_REVIEW_SCOPED_ACTION_REQUIRED_RUNTIME_STATE_KEY}`,
       updated_at: new Date().toISOString(),
     })
     .where(and(...conditions));
+}
+
+export async function clearScopedCodeReviewActionRequiredState(
+  args: ClearScopedCodeReviewActionRequiredStateArgs
+): Promise<void> {
+  const conditions = ownerConditions(args.owner, args.platform);
+  await db.transaction(async tx => {
+    await tx.execute(
+      sql`SELECT pg_advisory_xact_lock(hashtext(${`code-review-action-required:${args.owner.type}:${args.owner.id}:${args.platform}`}))`
+    );
+    const [config] = await tx
+      .select()
+      .from(agent_configs)
+      .where(and(...conditions))
+      .for('update')
+      .limit(1);
+    if (!config) return;
+
+    const remainingStates = getCodeReviewScopedActionRequiredStates(config).filter(
+      state => state.integrationId !== args.integrationId
+    );
+    const runtimeState = { ...(config.runtime_state ?? {}) };
+    if (remainingStates.length === 0) {
+      delete runtimeState[CODE_REVIEW_SCOPED_ACTION_REQUIRED_RUNTIME_STATE_KEY];
+    } else {
+      runtimeState[CODE_REVIEW_SCOPED_ACTION_REQUIRED_RUNTIME_STATE_KEY] = remainingStates;
+    }
+    await tx
+      .update(agent_configs)
+      .set({ runtime_state: runtimeState, updated_at: new Date().toISOString() })
+      .where(and(...conditions));
+  });
 }

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.test.ts
@@ -514,7 +514,7 @@ describe('tryDispatchPendingReviews', () => {
     expect(mockDispatchReview).toHaveBeenCalledTimes(1);
   });
 
-  it('disables Code Reviewer for pre-worker GitHub installation failures', async () => {
+  it('keeps Code Reviewer enabled for a repository-specific GitHub installation failure', async () => {
     const recentTimestamp = minutesAgo(1);
     const owner = { type: 'user', id: testUser.id } satisfies ReviewOwner;
     const agentConfig = await insertAgentConfigForUser();
@@ -557,8 +557,18 @@ describe('tryDispatchPendingReviews', () => {
         dispatchReservationId: null,
       })
     );
-    expect(storedConfig?.is_enabled).toBe(false);
-    expect(mockSendCodeReviewDisabledEmail).toHaveBeenCalledTimes(1);
+    expect(storedConfig?.is_enabled).toBe(true);
+    expect(storedConfig?.runtime_state).toEqual(
+      expect.objectContaining({
+        code_review_scoped_action_required: [
+          expect.objectContaining({
+            reason: 'github_installation_required',
+            repositoryFullName: REPO,
+          }),
+        ],
+      })
+    );
+    expect(mockSendCodeReviewDisabledEmail).not.toHaveBeenCalled();
   });
 
   it('disables Code Reviewer for selected-model worker status failures', async () => {

--- a/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
+++ b/apps/web/src/lib/code-reviews/dispatch/dispatch-pending-reviews.ts
@@ -51,7 +51,7 @@ import {
   classifyCodeReviewActionRequiredFailure,
   disableCodeReviewForActionRequiredFailure,
   getCodeReviewActionRequiredCopy,
-  getCodeReviewActionRequiredState,
+  getCodeReviewActionRequiredStateForScope,
   isCodeReviewActionRequiredReason,
   type CodeReviewActionRequiredReason,
 } from '../action-required';
@@ -324,7 +324,7 @@ export async function tryDispatchPendingReviews(
         if (actionRequiredReason) {
           if (!actionRequiredStateAlreadyPresent && !isManualReview) {
             logExceptInTest(
-              '[tryDispatchPendingReviews] Disabling Code Reviewer after action-required failure',
+              '[tryDispatchPendingReviews] Recording Code Reviewer action-required failure',
               {
                 reviewId: reservation.review.id,
                 owner,
@@ -339,9 +339,11 @@ export async function tryDispatchPendingReviews(
                 reviewId: reservation.review.id,
                 reason: actionRequiredReason,
                 errorMessage,
+                integrationId: reservation.review.platform_integration_id,
+                repositoryFullName: reservation.review.repo_full_name,
               });
             } catch (disableError) {
-              errorExceptInTest('[tryDispatchPendingReviews] Failed to disable Code Reviewer', {
+              errorExceptInTest('[tryDispatchPendingReviews] Failed to record action-required', {
                 reviewId: reservation.review.id,
                 owner,
                 reason: actionRequiredReason,
@@ -489,7 +491,10 @@ async function dispatchReservedReview(reservation: ReservedReview, owner: Owner)
       );
     }
 
-    const actionRequiredState = getCodeReviewActionRequiredState(persistedAgentConfig);
+    const actionRequiredState = getCodeReviewActionRequiredStateForScope(persistedAgentConfig, {
+      integrationId: review.platform_integration_id,
+      repositoryFullName: review.repo_full_name,
+    });
     if (actionRequiredState) {
       throw new CodeReviewActionRequiredDispatchError(actionRequiredState.reason);
     }
@@ -690,10 +695,12 @@ async function handleAmbiguousDispatchFailure(
           reviewId: review.id,
           reason: actionRequiredReason,
           errorMessage: workerStatus.errorMessage ?? actionRequiredReason,
+          integrationId: review.platform_integration_id,
+          repositoryFullName: review.repo_full_name,
         });
         await finalizeActionRequiredGateCheck(review, actionRequiredReason);
       } catch (disableError) {
-        errorExceptInTest('[dispatchReview] Failed to disable Code Reviewer', {
+        errorExceptInTest('[dispatchReview] Failed to record action-required', {
           reviewId: review.id,
           reason: actionRequiredReason,
           disableError,

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/pull-request-handler.ts
@@ -36,7 +36,7 @@ import { codeReviewWorkerClient } from '@/lib/code-reviews/client/code-review-wo
 import { updateCheckRunId } from '@/lib/code-reviews/db/code-reviews';
 import { resolvePullRequestCheckoutRef } from './pull-request-checkout-ref';
 import { APP_URL } from '@/lib/constants';
-import { getCodeReviewActionRequiredState } from '@/lib/code-reviews/action-required';
+import { getCodeReviewActionRequiredStateForScope } from '@/lib/code-reviews/action-required';
 
 /**
  * GitHub Pull Request Event Handler
@@ -124,7 +124,14 @@ export async function handlePullRequestCodeReview(
     // 2. Check if code review agent is enabled for this owner
     const agentConfig = await getAgentConfigForOwner(owner, 'code_review', 'github');
 
-    if (!agentConfig || !agentConfig.is_enabled || getCodeReviewActionRequiredState(agentConfig)) {
+    if (
+      !agentConfig ||
+      !agentConfig.is_enabled ||
+      getCodeReviewActionRequiredStateForScope(agentConfig, {
+        integrationId: integration.id,
+        repositoryFullName: repository.full_name,
+      })
+    ) {
       logExceptInTest(
         `Code review agent not enabled for ${owner.type} ${owner.id} (repo: ${repository.full_name})`
       );

--- a/apps/web/src/routers/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews-router.ts
@@ -24,6 +24,7 @@ import { logExceptInTest } from '@/lib/utils.server';
 import {
   clearCodeReviewActionRequiredState,
   getCodeReviewActionRequiredState,
+  getCodeReviewScopedActionRequiredStates,
 } from '@/lib/code-reviews/action-required';
 import { getReviewMemoryEnabledFromConfig } from '@/lib/code-reviews/review-memory/settings';
 import {
@@ -304,7 +305,10 @@ export const personalReviewAgentRouter = createTRPCRouter({
         council: cfg.council ?? null,
         councilEnabledRepositoryIds: cfg.council_enabled_repository_ids ?? [],
         reviewMemoryEnabled: getReviewMemoryEnabledFromConfig(config.config),
-        actionRequired: getCodeReviewActionRequiredState(config),
+        actionRequired:
+          getCodeReviewActionRequiredState(config) ??
+          getCodeReviewScopedActionRequiredStates(config)[0] ??
+          null,
       };
     }),
 

--- a/apps/web/src/routers/code-reviews/code-reviews-router.ts
+++ b/apps/web/src/routers/code-reviews/code-reviews-router.ts
@@ -55,7 +55,7 @@ import { codeReviewWorkerClient } from '@/lib/code-reviews/client/code-review-wo
 import { tryDispatchPendingReviews } from '@/lib/code-reviews/dispatch/dispatch-pending-reviews';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 import { getAgentConfigForOwner } from '@/lib/agent-config/db/agent-configs';
-import { getCodeReviewActionRequiredState } from '@/lib/code-reviews/action-required';
+import { getCodeReviewActionRequiredStateForScope } from '@/lib/code-reviews/action-required';
 import type { CloudAgentCodeReview } from '@kilocode/db/schema';
 import { cliSessions, cli_sessions_v2 } from '@kilocode/db/schema';
 import { isNewSession } from '@/lib/cloud-agent/session-type';
@@ -669,7 +669,10 @@ export const codeReviewRouter = createTRPCRouter({
 
         if (!manualConfig) {
           const agentConfig = await getAgentConfigForOwner(owner, 'code_review', platform);
-          const actionRequiredState = getCodeReviewActionRequiredState(agentConfig);
+          const actionRequiredState = getCodeReviewActionRequiredStateForScope(agentConfig, {
+            integrationId: review.platform_integration_id,
+            repositoryFullName: review.repo_full_name,
+          });
           if (actionRequiredState) {
             throw new TRPCError({
               code: 'BAD_REQUEST',

--- a/apps/web/src/routers/github-apps-router.test.ts
+++ b/apps/web/src/routers/github-apps-router.test.ts
@@ -36,6 +36,7 @@ const mockSeedUserGithubToken =
   jest.fn<
     (input: Record<string, unknown>) => Promise<{ upserted: boolean; githubLogin: string }>
   >();
+const mockClearScopedCodeReviewActionRequiredState = jest.fn<() => Promise<void>>();
 
 jest.mock('@/lib/integrations/github-apps-service', () => ({}));
 
@@ -59,6 +60,11 @@ jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
 
 jest.mock('@/lib/github-pr-review/dev-seed', () => ({
   seedUserGithubToken: (...args: [Record<string, unknown>]) => mockSeedUserGithubToken(...args),
+}));
+
+jest.mock('@/lib/code-reviews/action-required', () => ({
+  clearScopedCodeReviewActionRequiredState: (..._args: unknown[]) =>
+    mockClearScopedCodeReviewActionRequiredState(),
 }));
 
 let createCaller: (ctx: { user: User }) => {
@@ -94,6 +100,7 @@ describe('githubAppsRouter.refreshInstallation', () => {
     mockFetchGitHubRepositories.mockResolvedValue([]);
     mockUpsertPlatformIntegrationForOwner.mockResolvedValue({ ok: true });
     mockUpdateRepositoriesForIntegration.mockResolvedValue(undefined);
+    mockClearScopedCodeReviewActionRequiredState.mockResolvedValue(undefined);
   });
 
   it('persists the current account login returned by GitHub', async () => {
@@ -105,6 +112,7 @@ describe('githubAppsRouter.refreshInstallation', () => {
       { type: 'user', id: 'user-1' },
       expect.objectContaining({ platformAccountLogin: 'renamed-owner' })
     );
+    expect(mockClearScopedCodeReviewActionRequiredState).toHaveBeenCalledTimes(1);
   });
 
   it('does not clear stored identity when GitHub returns no current account login', async () => {

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -36,6 +36,7 @@ import {
 } from '@/lib/integrations/platforms/github/user-authorization';
 import { seedUserGithubToken } from '@/lib/github-pr-review/dev-seed';
 import { createInstallState } from '@/lib/integrations/github/install-state';
+import { clearScopedCodeReviewActionRequiredState } from '@/lib/code-reviews/action-required';
 
 export const githubAppsRouter = createTRPCRouter({
   // List all integrations
@@ -463,6 +464,11 @@ export const githubAppsRouter = createTRPCRouter({
 
       const repositories = await fetchGitHubRepositories(installationId, appType);
       await updateRepositoriesForIntegration(integration.id, repositories);
+      await clearScopedCodeReviewActionRequiredState({
+        owner,
+        platform: 'github',
+        integrationId: integration.id,
+      });
 
       if (input?.organizationId) {
         await createAuditLog({

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.test.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.test.ts
@@ -130,6 +130,56 @@ describe('organization review agent router: toggleReviewAgent', () => {
   });
 });
 
+describe('organization review agent router: GitHub status', () => {
+  afterAll(async () => {
+    for (const organizationId of createdOrganizationIds) {
+      await db
+        .delete(platform_integrations)
+        .where(eq(platform_integrations.owned_by_organization_id, organizationId));
+      await db.delete(organizations).where(eq(organizations.id, organizationId));
+    }
+  });
+
+  it('reports aggregate and per-installation health when one installation is healthy', async () => {
+    const { owner, organization } = await createFixtureOrganization();
+    const [healthy, unhealthy] = await db
+      .insert(platform_integrations)
+      .values([
+        {
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          integration_status: 'active',
+          platform_installation_id: `healthy-${crypto.randomUUID()}`,
+          platform_account_login: 'healthy-org',
+        },
+        {
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          integration_status: 'suspended',
+          platform_installation_id: `unhealthy-${crypto.randomUUID()}`,
+          platform_account_login: 'unhealthy-org',
+          suspended_at: new Date().toISOString(),
+        },
+      ])
+      .returning();
+    const caller = await createCallerForUser(owner.id);
+
+    const status = await caller.organizations.reviewAgent.getGitHubStatus({
+      organizationId: organization.id,
+    });
+
+    expect(status.connected).toBe(true);
+    expect(status.integration?.accountLogin).toBe('healthy-org');
+    expect(status.health).toEqual({ total: 2, healthy: 1, requiresAction: 1 });
+    expect(status.installations).toEqual([
+      expect.objectContaining({ id: healthy.id, isHealthy: true }),
+      expect.objectContaining({ id: unhealthy.id, isHealthy: false }),
+    ]);
+  });
+});
+
 describe('organization review agent router: council config', () => {
   afterAll(async () => {
     for (const organizationId of createdOrganizationIds) {

--- a/apps/web/src/routers/organizations/organization-code-reviews-router.ts
+++ b/apps/web/src/routers/organizations/organization-code-reviews-router.ts
@@ -11,6 +11,7 @@ import {
 import { createAuditLog } from '@/lib/organizations/organization-audit-logs';
 import {
   getIntegrationForOrganization,
+  getIntegrationsByOrganization,
   updateIntegrationMetadata,
 } from '@/lib/integrations/db/platform-integrations';
 import {
@@ -45,6 +46,7 @@ import { logExceptInTest } from '@/lib/utils.server';
 import {
   clearCodeReviewActionRequiredState,
   getCodeReviewActionRequiredState,
+  getCodeReviewScopedActionRequiredStates,
 } from '@/lib/code-reviews/action-required';
 import { getReviewMemoryEnabledFromConfig } from '@/lib/code-reviews/review-memory/settings';
 import { randomBytes } from 'node:crypto';
@@ -444,12 +446,24 @@ export const organizationReviewAgentRouter = createTRPCRouter({
    * (Replaces getGitHubStatus - now checks for GitHub App instead of OAuth)
    */
   getGitHubStatus: organizationMemberProcedure.query(async ({ input }) => {
-    const integration = await getIntegrationForOrganization(input.organizationId, 'github');
+    const integrations = await getIntegrationsByOrganization(input.organizationId, PLATFORM.GITHUB);
+    const healthyIntegrations = integrations.filter(isPlatformIntegrationHealthy);
+    const integration = healthyIntegrations[0];
 
-    if (!isPlatformIntegrationHealthy(integration)) {
+    if (!integration) {
       return {
         connected: false,
         integration: null,
+        health: {
+          total: integrations.length,
+          healthy: 0,
+          requiresAction: integrations.length,
+        },
+        installations: integrations.map(item => ({
+          id: item.id,
+          accountLogin: item.platform_account_login,
+          isHealthy: false,
+        })),
       };
     }
 
@@ -461,6 +475,16 @@ export const organizationReviewAgentRouter = createTRPCRouter({
         installedAt: integration.installed_at,
         isValid: true,
       },
+      health: {
+        total: integrations.length,
+        healthy: healthyIntegrations.length,
+        requiresAction: integrations.length - healthyIntegrations.length,
+      },
+      installations: integrations.map(item => ({
+        id: item.id,
+        accountLogin: item.platform_account_login,
+        isHealthy: isPlatformIntegrationHealthy(item),
+      })),
     };
   }),
 
@@ -601,7 +625,10 @@ export const organizationReviewAgentRouter = createTRPCRouter({
         council: cfg.council ?? null,
         councilEnabledRepositoryIds: cfg.council_enabled_repository_ids ?? [],
         reviewMemoryEnabled: isBitbucket ? false : getReviewMemoryEnabledFromConfig(config.config),
-        actionRequired: getCodeReviewActionRequiredState(config),
+        actionRequired:
+          getCodeReviewActionRequiredState(config) ??
+          getCodeReviewScopedActionRequiredStates(config)[0] ??
+          null,
       };
     }),
 

--- a/packages/app-shared/src/code-reviews/action-required.ts
+++ b/packages/app-shared/src/code-reviews/action-required.ts
@@ -20,6 +20,8 @@ export type CodeReviewActionRequiredState = {
   detectedAt: string;
   lastSeenAt: string;
   triggeringReviewId?: string;
+  integrationId?: string;
+  repositoryFullName?: string;
   lastErrorMessage: string;
   emailSentAt?: string;
 };
@@ -34,19 +36,19 @@ const COPY_BY_REASON: Record<CodeReviewActionRequiredReason, CodeReviewActionReq
   github_installation_required: {
     title: 'Code Reviewer needs attention',
     description:
-      'Code Reviewer was disabled because Kilo cannot access this repository with an active GitHub App installation. Update the GitHub App installation, then enable Code Reviewer again.',
+      'Kilo cannot access this repository with its GitHub App installation. Update the affected GitHub App installation before retrying this review.',
     recoveryLabel: 'Update GitHub App',
   },
   github_ip_allow_list: {
     title: 'Code Reviewer needs attention',
     description:
-      'Code Reviewer was disabled because this GitHub organization uses an IP allow list that blocks Kilo. Contact hi@kilocode.ai for help, then enable Code Reviewer again.',
+      'This repository belongs to a GitHub organization whose IP allow list blocks Kilo. Contact hi@kilocode.ai for help before retrying this review.',
     recoveryLabel: 'Contact support',
   },
   gitlab_project_access_required: {
     title: 'Code Reviewer needs attention',
     description:
-      'Code Reviewer was disabled because Kilo cannot create a GitLab Project Access Token for this project. Grant Maintainer access or enable Project Access Tokens, then enable Code Reviewer again.',
+      'Kilo cannot create a GitLab Project Access Token for this project. Grant Maintainer access or enable Project Access Tokens before retrying this review.',
     recoveryLabel: 'Update GitLab integration',
   },
   byok_invalid_key: {


### PR DESCRIPTION
## Summary
- report aggregate and per-installation GitHub health for organization Code Reviewer
- scope repository and IP allow-list failures to the affected integration
- keep healthy sibling installations enabled and link recovery to the affected row

## Validation
- affected web, mobile, and shared-package typechecks/lint
- focused action-required, dispatch, organization reviewer, recovery, callback, and mobile tests
- git diff --check