### PR TITLE
fix(github): summarize multiple installations safely

### DIFF
--- a/apps/web/src/app/collab/_components/setup-status.test.ts
+++ b/apps/web/src/app/collab/_components/setup-status.test.ts
@@ -65,6 +65,26 @@ describe('collab setup status', () => {
     expect(hasAnyConfiguredOrSelectedPlatform(CODE_PLATFORM_IDS, [], statuses)).toBe(true);
   });
 
+  test('shows a deterministic count for multiple GitHub installations', () => {
+    const statuses = buildPlatformSetupStatuses({
+      data: [
+        {
+          platform: 'github',
+          installed: true,
+          installation: { installationCount: 2 },
+        },
+      ],
+      isError: false,
+      isLoading: false,
+    });
+
+    expect(statuses.github).toEqual({
+      kind: 'connected',
+      label: 'Already set up',
+      detail: '2 installations',
+    });
+  });
+
   test('filters connected services out of the authorization queue', () => {
     const statuses = buildPlatformSetupStatuses({
       data: [

--- a/apps/web/src/app/collab/_components/setup-status.ts
+++ b/apps/web/src/app/collab/_components/setup-status.ts
@@ -39,6 +39,9 @@ function getConnectedAccountLabel(
   if (platformId === 'discord') return installation.guildName ?? undefined;
   if (platformId === 'linear') return installation.workspaceName ?? undefined;
   if (platformId === 'github' || platformId === 'gitlab') {
+    if (platformId === 'github' && installation.installationCount) {
+      return `${installation.installationCount} installation${installation.installationCount === 1 ? '' : 's'}`;
+    }
     return installation.accountLogin ?? undefined;
   }
 

--- a/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
+++ b/apps/web/src/components/integrations/GitHubIntegrationDetails.tsx
@@ -388,7 +388,11 @@ function GitHubIntegrationDetailsContent({
   const handleModelChange = (modelSlug: string) => {
     setSelectedModel(modelSlug);
     updateModel.mutate(
-      { modelSlug, organizationId },
+      {
+        modelSlug,
+        organizationId,
+        integrationId: organizationId ? installationData?.installation?.id : undefined,
+      },
       {
         onSuccess: result => {
           if (result.success) {

--- a/apps/web/src/lib/integrations/github-apps-service.test.ts
+++ b/apps/web/src/lib/integrations/github-apps-service.test.ts
@@ -7,7 +7,7 @@ import {
   getIntegrationForOwner,
   getPrimaryGitHubIntegrationForOrganization,
 } from '@/lib/integrations/db/platform-integrations';
-import { getInstallation, isInstallationGoneError } from './github-apps-service';
+import { getInstallation, isInstallationGoneError, updateModel } from './github-apps-service';
 
 describe('getInstallation', () => {
   it('prefers a healthy installation when the owner has multiple GitHub rows', async () => {
@@ -118,6 +118,57 @@ describe('getInstallation', () => {
       expect(visibleIntegration?.id).toBe(row.id);
       expect(primaryIntegration).toBeNull();
       expect(ownerIntegration).toBeNull();
+    } finally {
+      await db.delete(organizations).where(eq(organizations.id, organization.id));
+    }
+  });
+});
+
+describe('updateModel', () => {
+  it('updates only the selected organization installation', async () => {
+    const [organization] = await db
+      .insert(organizations)
+      .values({ name: `GitHub model update ${crypto.randomUUID()}` })
+      .returning();
+    const rows = await db
+      .insert(platform_integrations)
+      .values([
+        {
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: crypto.randomUUID(),
+          integration_status: 'active',
+          repository_access: 'all',
+          metadata: { model_slug: 'first-model' },
+        },
+        {
+          owned_by_organization_id: organization.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: crypto.randomUUID(),
+          integration_status: 'active',
+          repository_access: 'all',
+          metadata: { model_slug: 'second-model' },
+        },
+      ])
+      .returning();
+
+    try {
+      await expect(
+        updateModel({ type: 'org', id: organization.id }, 'updated-model', rows[1].id)
+      ).resolves.toEqual({ success: true });
+
+      const integrations = await db
+        .select({ id: platform_integrations.id, metadata: platform_integrations.metadata })
+        .from(platform_integrations)
+        .where(eq(platform_integrations.owned_by_organization_id, organization.id));
+      expect(integrations).toEqual(
+        expect.arrayContaining([
+          { id: rows[0].id, metadata: { model_slug: 'first-model' } },
+          { id: rows[1].id, metadata: { model_slug: 'updated-model' } },
+        ])
+      );
     } finally {
       await db.delete(organizations).where(eq(organizations.id, organization.id));
     }

--- a/apps/web/src/lib/integrations/github-apps-service.ts
+++ b/apps/web/src/lib/integrations/github-apps-service.ts
@@ -298,9 +298,14 @@ export async function listBranches(
  */
 export async function updateModel(
   owner: Owner,
-  modelSlug: string
+  modelSlug: string,
+  integrationId?: string
 ): Promise<{ success: boolean; error?: string }> {
-  const integration = await getInstallation(owner);
+  const integration = integrationId
+    ? await getGitHubIntegrationById(owner, integrationId)
+    : owner.type === 'user'
+      ? await getInstallation(owner)
+      : null;
 
   if (!integration) {
     return { success: false, error: 'No GitHub App installation found' };

--- a/apps/web/src/lib/integrations/platform-integration-setup-status.ts
+++ b/apps/web/src/lib/integrations/platform-integration-setup-status.ts
@@ -1,5 +1,6 @@
 import type { PlatformIntegration } from '@kilocode/db/schema';
 import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
+import type { Owner } from '@/lib/integrations/core/types';
 
 export const SETUP_STATUS_PLATFORMS = [
   PLATFORM.SLACK,
@@ -19,6 +20,7 @@ export type PlatformIntegrationSetupStatus = {
   installation: {
     accountLogin?: string | null;
     guildName?: string | null;
+    installationCount?: number;
     teamName?: string | null;
     workspaceName?: string | null;
   } | null;
@@ -80,13 +82,18 @@ function shouldPreferStatus(
 }
 
 export function summarizePlatformIntegrationsForSetupStatus(
-  integrations: PlatformIntegration[]
+  integrations: PlatformIntegration[],
+  ownerType: Owner['type']
 ): PlatformIntegrationSetupStatus[] {
   const byPlatform = new Map<SetupStatusPlatform, PlatformIntegrationSetupStatus>();
+  let githubInstallationCount = 0;
 
   for (const integration of integrations) {
     const status = toSetupStatus(integration);
     if (!status) continue;
+    if (ownerType === 'org' && status.platform === PLATFORM.GITHUB) {
+      githubInstallationCount += 1;
+    }
 
     const current = byPlatform.get(status.platform);
     if (!current || shouldPreferStatus(current, status)) {
@@ -96,6 +103,9 @@ export function summarizePlatformIntegrationsForSetupStatus(
 
   return SETUP_STATUS_PLATFORMS.flatMap(platform => {
     const status = byPlatform.get(platform);
+    if (status && platform === PLATFORM.GITHUB && githubInstallationCount > 1) {
+      return [{ ...status, installation: { installationCount: githubInstallationCount } }];
+    }
     return status ? [status] : [];
   });
 }

--- a/apps/web/src/routers/github-apps-router.test.ts
+++ b/apps/web/src/routers/github-apps-router.test.ts
@@ -36,8 +36,19 @@ const mockSeedUserGithubToken =
   jest.fn<
     (input: Record<string, unknown>) => Promise<{ upserted: boolean; githubLogin: string }>
   >();
+const mockUpdateModel =
+  jest.fn<
+    (
+      owner: Owner,
+      modelSlug: string,
+      integrationId?: string
+    ) => Promise<{ success: boolean; error?: string }>
+  >();
 
-jest.mock('@/lib/integrations/github-apps-service', () => ({}));
+jest.mock('@/lib/integrations/github-apps-service', () => ({
+  updateModel: (owner: Owner, modelSlug: string, integrationId?: string) =>
+    mockUpdateModel(owner, modelSlug, integrationId),
+}));
 
 jest.mock('@/lib/integrations/db/platform-integrations', () => ({
   getIntegrationForOwner: (owner: Owner, platform: string) =>
@@ -62,7 +73,15 @@ jest.mock('@/lib/github-pr-review/dev-seed', () => ({
 }));
 
 let createCaller: (ctx: { user: User }) => {
-  refreshInstallation: (input?: { organizationId?: string }) => Promise<{ success: boolean }>;
+  refreshInstallation: (input?: {
+    organizationId?: string;
+    integrationId?: string;
+  }) => Promise<{ success: boolean }>;
+  updateModel: (input: {
+    organizationId?: string;
+    integrationId?: string;
+    modelSlug: string;
+  }) => Promise<{ success: boolean; error?: string }>;
   devSeedUserGithubToken: (input: {
     token: string;
     githubLogin: string;
@@ -124,6 +143,40 @@ describe('githubAppsRouter.refreshInstallation', () => {
     expect(mockUpsertPlatformIntegrationForOwner).not.toHaveBeenCalled();
     expect(mockFetchGitHubRepositories).not.toHaveBeenCalled();
     expect(mockUpdateRepositoriesForIntegration).not.toHaveBeenCalled();
+  });
+});
+
+describe('githubAppsRouter.updateModel', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpdateModel.mockResolvedValue({ success: true });
+  });
+
+  it('requires an exact integration for organization updates', async () => {
+    const caller = createCaller({ user: { id: 'user-1' } as User });
+
+    await expect(
+      caller.updateModel({
+        organizationId: '11111111-1111-4111-8111-111111111111',
+        modelSlug: 'anthropic/claude-sonnet-4',
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: 'Integration ID is required' });
+
+    expect(mockUpdateModel).not.toHaveBeenCalled();
+  });
+
+  it('preserves personal update behavior without an integration ID', async () => {
+    const caller = createCaller({ user: { id: 'user-1' } as User });
+
+    await expect(caller.updateModel({ modelSlug: 'anthropic/claude-sonnet-4' })).resolves.toEqual({
+      success: true,
+    });
+
+    expect(mockUpdateModel).toHaveBeenCalledWith(
+      { type: 'user', id: 'user-1' },
+      'anthropic/claude-sonnet-4',
+      undefined
+    );
   });
 });
 

--- a/apps/web/src/routers/github-apps-router.ts
+++ b/apps/web/src/routers/github-apps-router.ts
@@ -225,15 +225,23 @@ export const githubAppsRouter = createTRPCRouter({
     .input(
       z.object({
         organizationId: z.string().uuid().optional(),
+        integrationId: z.string().uuid().optional(),
         modelSlug: z.string(),
       })
     )
     .mutation(async ({ ctx, input }) => {
+      if (input.organizationId && !input.integrationId) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'Integration ID is required' });
+      }
       if (input.organizationId) {
         await ensureOrganizationAccess(ctx, input.organizationId);
       }
       const owner = await resolveAuthorizedOwner(ctx, input.organizationId);
-      const result = await githubAppsService.updateModel(owner, input.modelSlug);
+      const result = await githubAppsService.updateModel(
+        owner,
+        input.modelSlug,
+        input.integrationId
+      );
 
       if (input.organizationId && result.success) {
         await createAuditLog({

--- a/apps/web/src/routers/platform-integrations-router.test.ts
+++ b/apps/web/src/routers/platform-integrations-router.test.ts
@@ -148,6 +148,34 @@ describe('platformIntegrationsRouter', () => {
     ]);
   });
 
+  test('summarizes multiple organization GitHub installations without an arbitrary account', async () => {
+    await insertPlatformIntegration({
+      organizationId: organization.id,
+      platform: PLATFORM.GITHUB,
+      platformAccountLogin: 'acme-secondary',
+      status: INTEGRATION_STATUS.SUSPENDED,
+    });
+    await insertPlatformIntegration({
+      organizationId: organization.id,
+      platform: PLATFORM.GITHUB,
+      platformAccountLogin: 'acme-primary',
+      status: INTEGRATION_STATUS.ACTIVE,
+    });
+
+    const caller = await createCallerForUser(memberUser.id);
+    const result = await caller.platformIntegrations.listSetupStatus({
+      organizationId: organization.id,
+    });
+
+    expect(result).toEqual([
+      {
+        platform: PLATFORM.GITHUB,
+        installed: true,
+        installation: { installationCount: 2 },
+      },
+    ]);
+  });
+
   test('rejects organization setup status reads for non-members', async () => {
     const caller = await createCallerForUser(nonMemberUser.id);
 

--- a/apps/web/src/routers/platform-integrations-router.ts
+++ b/apps/web/src/routers/platform-integrations-router.ts
@@ -22,6 +22,6 @@ export const platformIntegrationsRouter = createTRPCRouter({
           integration.integration_type === 'oauth')
       );
     });
-    return summarizePlatformIntegrationsForSetupStatus(visibleIntegrations);
+    return summarizePlatformIntegrationsForSetupStatus(visibleIntegrations, owner.type);
   }),
 });


### PR DESCRIPTION
## Summary
- replace arbitrary organization GitHub account labels with deterministic installation counts
- render multi-install setup status consistently in Collab
- require an exact integration ID for organization model mutations while preserving personal behavior

## Validation
- 4 focused suites, 32 tests
- web typecheck and lint
- changed-file format check
- git diff --check