### PR TITLE
test(kilo-pass): Fix intermittently failing test

### DIFF
--- a/apps/web/src/lib/stripe/index.test.ts
+++ b/apps/web/src/lib/stripe/index.test.ts
@@ -2819,10 +2819,19 @@ describe('releaseScheduledChangeForSubscription', () => {
         };
       },
     });
+    let markClaimObserved: (() => void) | null = null;
+    const claimObserved = new Promise<void>(resolve => {
+      markClaimObserved = resolve;
+    });
     const release = jest.fn(async (_scheduleId: string) => {
+      // Keep the winning release in flight until the other caller observes its claim.
+      await claimObserved;
       throw new Error('stripe release failed');
     });
-    const retrieve = jest.fn(async (_scheduleId: string) => ({ status: 'active' }));
+    const retrieve = jest.fn(async (_scheduleId: string) => {
+      markClaimObserved?.();
+      return { status: 'active' };
+    });
     const params = {
       dbOrTx: concurrentDb,
       stripe: { subscriptionSchedules: { release, retrieve } },


### PR DESCRIPTION
## Summary

- keep the mocked Stripe release in flight until the losing concurrent caller observes the database claim
- make the test exercise the intended in-progress interleaving deterministically
- preserve production retry behavior after a failed release restores the scheduled-change row

## Root cause

The test synchronized both initial reads but let the mocked Stripe release reject immediately. Depending on scheduling, the second caller could attempt its claim either before the first caller restored the row (one Stripe call) or after restoration (a valid retry and two Stripe calls).

## Testing

- `pnpm --filter web exec jest src/lib/stripe/index.test.ts --runInBand --testNamePattern "releaseScheduledChangeForSubscription"`
- formerly failing test passed in 25 fresh Jest processes
- `pnpm exec oxfmt --check apps/web/src/lib/stripe/index.test.ts`
- structured autoreview: no accepted/actionable findings

Failure observed in https://github.com/Kilo-Org/cloud/actions/runs/33054025580/job/98457039625?pr=5551