### PR TITLE
feat(gastown): keep each rig on the GitHub install it was created from

### DIFF
--- a/services/gastown/container/src/control-server.test.ts
+++ b/services/gastown/container/src/control-server.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { app } from './control-server';
+
+const originalGitToken = process.env.GIT_TOKEN;
+
+afterEach(() => {
+  if (originalGitToken === undefined) delete process.env.GIT_TOKEN;
+  else process.env.GIT_TOKEN = originalGitToken;
+});
+
+describe('town config git identity', () => {
+  it('clears process-global GitHub credentials for rig-scoped identity', async () => {
+    process.env.GIT_TOKEN = 'other-rig-token';
+
+    const response = await app.request('/sync-config', {
+      method: 'POST',
+      headers: {
+        'X-Town-Config': JSON.stringify({
+          rig_scoped_git_identity: true,
+          git_auth: { github_token: 'town-token' },
+        }),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(process.env.GIT_TOKEN).toBeUndefined();
+  });
+});

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -113,11 +113,16 @@ function syncTownConfigToProcessEnv(): void {
   const gitAuth = cfg.git_auth;
   if (typeof gitAuth === 'object' && gitAuth !== null) {
     const auth = gitAuth as Record<string, unknown>;
-    for (const [authKey, envKey] of [
-      ['github_token', 'GIT_TOKEN'],
+    const authMapping: Array<[string, string]> = [
       ['gitlab_token', 'GITLAB_TOKEN'],
       ['gitlab_instance_url', 'GITLAB_INSTANCE_URL'],
-    ] as const) {
+    ];
+    if (cfg.rig_scoped_git_identity !== true) {
+      authMapping.unshift(['github_token', 'GIT_TOKEN']);
+    } else {
+      delete process.env.GIT_TOKEN;
+    }
+    for (const [authKey, envKey] of authMapping) {
       const val = auth[authKey];
       if (typeof val === 'string' && val) {
         process.env[envKey] = val;

--- a/services/gastown/container/src/git-manager.test.ts
+++ b/services/gastown/container/src/git-manager.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { refreshGitToken } from './git-manager';
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.unstubAllGlobals();
+});
+
+describe('refreshGitToken', () => {
+  it('refreshes one rig without replacing another rig token in process.env', async () => {
+    process.env.GASTOWN_API_URL = 'https://gastown.example.com';
+    process.env.GASTOWN_TOWN_ID = 'town-1';
+    process.env.GASTOWN_CONTAINER_TOKEN = 'container-token';
+    process.env.GIT_TOKEN = 'other-rig-token';
+    const fetchMock = vi
+      .fn()
+      .mockResolvedValue(Response.json({ success: true, data: { token: 'rig-one-token' } }));
+    vi.stubGlobal('fetch', fetchMock);
+
+    await expect(refreshGitToken('rig-one')).resolves.toBe('rig-one-token');
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      'https://gastown.example.com/api/towns/town-1/rigs/rig-one/refresh-git-token',
+      expect.objectContaining({ method: 'POST' })
+    );
+    expect(process.env.GIT_TOKEN).toBe('other-rig-token');
+  });
+});

--- a/services/gastown/container/src/git-manager.ts
+++ b/services/gastown/container/src/git-manager.ts
@@ -199,8 +199,7 @@ async function assertInsideWorkspace(targetPath: string): Promise<void> {
 
 /**
  * Call the worker's refresh-git-token endpoint to obtain a fresh GitHub
- * App installation token. Updates process.env.GIT_TOKEN and rewrites
- * per-repo credential-store files so subsequent git operations (including
+ * App installation token. Rewrites per-repo credential-store files so subsequent git operations (including
  * the agent's own `git push`) pick up the new token.
  *
  * Returns the new token on success, or null if the refresh failed (no
@@ -246,10 +245,6 @@ export async function refreshGitToken(rigId: string): Promise<string | null> {
       return null;
     }
     const freshToken = (raw.data as { token: string }).token;
-
-    // Update process.env so subsequent exec() calls (which inherit
-    // process.env) see the new token via authenticateGitUrl.
-    process.env.GIT_TOKEN = freshToken;
 
     // Rewrite the per-rig /tmp/.git-credentials* files that currently
     // store a token. The credential helper reads these verbatim, so the

--- a/services/gastown/scripts/patch-worker-types.mjs
+++ b/services/gastown/scripts/patch-worker-types.mjs
@@ -43,17 +43,18 @@ const RPC_TYPES = `\
 type GetTokenForRepoSuccess = {
 \tsuccess: true;
 \ttoken: string;
+\tplatformIntegrationId: string;
 \tinstallationId: string;
 \taccountLogin: string;
 \tappType: 'standard' | 'lite';
 };
 type GetTokenForRepoFailure = {
 \tsuccess: false;
-\treason: 'database_not_configured' | 'invalid_repo_format' | 'no_installation_found' | 'invalid_org_id';
+\treason: 'database_not_configured' | 'invalid_repo_format' | 'no_installation_found' | 'ambiguous_installation' | 'repository_not_installed' | 'invalid_org_id' | 'integration_mismatch';
 };
 type GetTokenForRepoResult = GetTokenForRepoSuccess | GetTokenForRepoFailure;
 type GitTokenService = {
-\tgetTokenForRepo(params: { githubRepo: string; userId: string; orgId?: string }): Promise<GetTokenForRepoResult>;
+\tgetTokenForRepo(params: { githubRepo: string; userId: string; orgId?: string; expectedIntegrationId?: string }): Promise<GetTokenForRepoResult>;
 \tgetToken(installationId: string, appType?: 'standard' | 'lite'): Promise<string>;
 };
 type WastelandRpcSuccess<T> = { success: true; data: T };

--- a/services/gastown/src/db/tables/user-rigs.table.test.ts
+++ b/services/gastown/src/db/tables/user-rigs.table.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { createTableUserRigs, migrateUserRigs } from './user-rigs.table';
+
+function fakeSql(columns: string[]) {
+  const statements: string[] = [];
+  const sql = {
+    exec(query: string) {
+      statements.push(query);
+      if (query.startsWith('PRAGMA')) return columns.map(name => ({ name }));
+      if (query.startsWith('ALTER TABLE')) columns.push('platform_integration_id');
+      return [];
+    },
+  } as unknown as SqlStorage;
+  return { sql, statements };
+}
+
+describe('user_rigs platform integration migration', () => {
+  it('adds the identity column to legacy owner storage and is idempotent', () => {
+    const { sql, statements } = fakeSql([
+      'id',
+      'town_id',
+      'name',
+      'git_url',
+      'default_branch',
+      'created_at',
+      'updated_at',
+    ]);
+
+    migrateUserRigs(sql);
+    migrateUserRigs(sql);
+
+    expect(statements.filter(statement => statement.startsWith('ALTER TABLE'))).toHaveLength(1);
+  });
+
+  it('declares platform_integration_id for newly created owner storage', () => {
+    expect(createTableUserRigs()).toContain('"platform_integration_id" text');
+  });
+});

--- a/services/gastown/src/db/tables/user-rigs.table.ts
+++ b/services/gastown/src/db/tables/user-rigs.table.ts
@@ -30,3 +30,14 @@ export function createTableUserRigs(): string {
     updated_at: `text not null`,
   });
 }
+
+export function migrateUserRigs(sql: SqlStorage): void {
+  const columns = z
+    .object({ name: z.string() })
+    .array()
+    .parse([...sql.exec(/* sql */ `PRAGMA table_info(${user_rigs})`)]);
+  if (columns.some(column => column.name === user_rigs.columns.platform_integration_id)) return;
+  sql.exec(
+    /* sql */ `ALTER TABLE ${user_rigs} ADD COLUMN ${user_rigs.columns.platform_integration_id} text`
+  );
+}

--- a/services/gastown/src/dos/GastownOrg.do.ts
+++ b/services/gastown/src/dos/GastownOrg.do.ts
@@ -1,6 +1,11 @@
 import { DurableObject } from 'cloudflare:workers';
 import { createTableOrgTowns, org_towns, OrgTownRecord } from '../db/tables/org-towns.table';
-import { createTableUserRigs, user_rigs, UserRigRecord } from '../db/tables/user-rigs.table';
+import {
+  createTableUserRigs,
+  migrateUserRigs,
+  user_rigs,
+  UserRigRecord,
+} from '../db/tables/user-rigs.table';
 import { query } from '../util/query.util';
 import { getTownDOStub } from './Town.do';
 
@@ -50,6 +55,7 @@ export class GastownOrgDO extends DurableObject<Env> {
   private async initializeDatabase(): Promise<void> {
     query(this.sql, createTableOrgTowns(), []);
     query(this.sql, createTableUserRigs(), []);
+    migrateUserRigs(this.sql);
     // Arm the watchdog on every initialization so existing orgs (who
     // created towns before the watchdog was added) get health checks.
     await this.armWatchdogIfNeeded();

--- a/services/gastown/src/dos/GastownUser.do.ts
+++ b/services/gastown/src/dos/GastownUser.do.ts
@@ -1,6 +1,11 @@
 import { DurableObject } from 'cloudflare:workers';
 import { createTableUserTowns, user_towns, UserTownRecord } from '../db/tables/user-towns.table';
-import { createTableUserRigs, user_rigs, UserRigRecord } from '../db/tables/user-rigs.table';
+import {
+  createTableUserRigs,
+  migrateUserRigs,
+  user_rigs,
+  UserRigRecord,
+} from '../db/tables/user-rigs.table';
 import { query } from '../util/query.util';
 import { getTownDOStub } from './Town.do';
 
@@ -53,6 +58,7 @@ export class GastownUserDO extends DurableObject<Env> {
   private async initializeDatabase(): Promise<void> {
     query(this.sql, createTableUserTowns(), []);
     query(this.sql, createTableUserRigs(), []);
+    migrateUserRigs(this.sql);
     // Arm the watchdog on every initialization so existing users (who
     // created towns before the watchdog was added) get health checks.
     await this.armWatchdogIfNeeded();

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -160,6 +160,11 @@ function now(): string {
   return new Date().toISOString();
 }
 
+function extractGithubRepo(gitUrl: string): string | null {
+  const match = gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/);
+  return match?.[1] ?? null;
+}
+
 // ── Rig config stored per-rig in KV (mirrors what was in Rig DO) ────
 type RigConfig = {
   townId: string;
@@ -169,9 +174,32 @@ type RigConfig = {
   userId: string;
   kilocodeToken?: string;
   platformIntegrationId?: string;
+  platform_integration_id?: string;
   /** Per-rig merge strategy override. When unset, inherits from town config. */
   merge_strategy?: MergeStrategy;
 };
+
+const RigConfigSchema = z.object({
+  townId: z.string(),
+  rigId: z.string(),
+  gitUrl: z.string(),
+  defaultBranch: z.string(),
+  userId: z.string(),
+  kilocodeToken: z.string().optional(),
+  platformIntegrationId: z.string().optional(),
+  platform_integration_id: z.string().optional(),
+  merge_strategy: z.enum(['direct', 'pr']).optional(),
+});
+
+function normalizeRigConfig(value: unknown): RigConfig | null {
+  const parsed = RigConfigSchema.safeParse(value);
+  if (!parsed.success) return null;
+  const { platform_integration_id, ...config } = parsed.data;
+  return {
+    ...config,
+    platformIntegrationId: config.platformIntegrationId ?? platform_integration_id,
+  };
+}
 
 // ── Escalation API type (derived from EscalationBeadRecord) ─────────
 type EscalationEntry = {
@@ -387,21 +415,54 @@ export class TownDO extends DurableObject<Env> {
       stopAgent: async agentId => {
         await dispatch.stopAgentInContainer(this.env, this.townId, agentId);
       },
-      checkPRStatus: async prUrl => {
+      checkPRStatus: async (prUrl, rigId) => {
+        const rig = rigs.getRig(this.sql, rigId);
+        const rigConfig = await this.getRigConfig(rigId);
+        const townConfig = await this.getTownConfig();
         return scm.checkPRStatus(
-          { env: this.env, townId: this.townId, getTownConfig: () => this.getTownConfig() },
+          {
+            env: this.env,
+            townId: this.townId,
+            getTownConfig: () => Promise.resolve(townConfig),
+            githubRepo: rig ? (extractGithubRepo(rig.git_url) ?? undefined) : undefined,
+            userId: townConfig.owner_user_id ?? rigConfig?.userId,
+            orgId: townConfig.organization_id,
+            platformIntegrationId: rigConfig?.platformIntegrationId,
+          },
           prUrl
         );
       },
-      checkPRFeedback: async prUrl => {
+      checkPRFeedback: async (prUrl, rigId) => {
+        const rig = rigs.getRig(this.sql, rigId);
+        const rigConfig = await this.getRigConfig(rigId);
+        const townConfig = await this.getTownConfig();
         return scm.checkPRFeedback(
-          { env: this.env, townId: this.townId, getTownConfig: () => this.getTownConfig() },
+          {
+            env: this.env,
+            townId: this.townId,
+            getTownConfig: () => Promise.resolve(townConfig),
+            githubRepo: rig ? (extractGithubRepo(rig.git_url) ?? undefined) : undefined,
+            userId: townConfig.owner_user_id ?? rigConfig?.userId,
+            orgId: townConfig.organization_id,
+            platformIntegrationId: rigConfig?.platformIntegrationId,
+          },
           prUrl
         );
       },
-      mergePR: async prUrl => {
+      mergePR: async (prUrl, rigId) => {
+        const rig = rigs.getRig(this.sql, rigId);
+        const rigConfig = await this.getRigConfig(rigId);
+        const townConfig = await this.getTownConfig();
         return scm.mergePR(
-          { env: this.env, townId: this.townId, getTownConfig: () => this.getTownConfig() },
+          {
+            env: this.env,
+            townId: this.townId,
+            getTownConfig: () => Promise.resolve(townConfig),
+            githubRepo: rig ? (extractGithubRepo(rig.git_url) ?? undefined) : undefined,
+            userId: townConfig.owner_user_id ?? rigConfig?.userId,
+            orgId: townConfig.organization_id,
+            platformIntegrationId: rigConfig?.platformIntegrationId,
+          },
           prUrl
         );
       },
@@ -1135,22 +1196,9 @@ export class TownDO extends DurableObject<Env> {
     const townConfig = await this.getTownConfig();
     const container = getTownContainerStub(this.env, townId);
 
-    // Resolve a fresh GitHub token here too — this method runs both at
-    // initial config push and on every config change, so the persisted
-    // GIT_TOKEN must be live rather than the stale value stored in
-    // git_auth.github_token from rig creation. The container's
-    // syncTownConfigToProcessEnv path reads `git_auth.github_token`
-    // from the X-Town-Config header on every request, so the in-process
-    // GIT_TOKEN follows the same source-of-truth as the persisted one.
-    const githubToken = await scm.resolveGitHubTokenString({
-      env: this.env,
-      townId,
-      getTownConfig: () => Promise.resolve(townConfig),
-    });
-
     // Phase 1: Persist to DO storage for next boot.
     const envMapping: Array<[string, string | undefined]> = [
-      ['GIT_TOKEN', githubToken ?? undefined],
+      ['GIT_TOKEN', undefined],
       ['GITLAB_TOKEN', townConfig.git_auth?.gitlab_token],
       ['GITLAB_INSTANCE_URL', townConfig.git_auth?.gitlab_instance_url],
       ['GITHUB_CLI_PAT', townConfig.github_cli_pat],
@@ -1317,6 +1365,9 @@ export class TownDO extends DurableObject<Env> {
   }
 
   private async _configureRig(rigConfig: RigConfig): Promise<void> {
+    const normalizedRigConfig = normalizeRigConfig(rigConfig);
+    if (!normalizedRigConfig) throw new Error('Invalid rig config');
+    rigConfig = normalizedRigConfig;
     logger.setTags({ rigId: rigConfig.rigId, userId: rigConfig.userId });
     logger.info('configureRig: start', { hasKilocodeToken: !!rigConfig.kilocodeToken });
     await this.ctx.storage.put(`rig:${rigConfig.rigId}:config`, rigConfig);
@@ -1380,6 +1431,9 @@ export class TownDO extends DurableObject<Env> {
       env: this.env,
       townId: this.townId,
       getTownConfig: () => Promise.resolve(townConfig),
+      githubRepo: extractGithubRepo(rigConfig.gitUrl) ?? undefined,
+      userId: townConfig.owner_user_id ?? rigConfig.userId,
+      orgId: townConfig.organization_id,
       platformIntegrationId: rigConfig.platformIntegrationId,
     });
     if (githubToken) {
@@ -1431,7 +1485,7 @@ export class TownDO extends DurableObject<Env> {
   }
 
   async getRigConfig(rigId: string): Promise<RigConfig | null> {
-    return (await this.ctx.storage.get<RigConfig>(`rig:${rigId}:config`)) ?? null;
+    return normalizeRigConfig(await this.ctx.storage.get(`rig:${rigId}:config`));
   }
 
   // ══════════════════════════════════════════════════════════════════
@@ -3805,12 +3859,16 @@ export class TownDO extends DurableObject<Env> {
     const rig = rigs.getRig(this.sql, input.rigId);
     if (rig) {
       const rigConfig = await this.getRigConfig(input.rigId);
+      const townConfig = await this.getTownConfig();
       await scm
         .createConvoyBranch(
           {
             env: this.env,
             townId: this.townId,
-            getTownConfig: () => this.getTownConfig(),
+            getTownConfig: () => Promise.resolve(townConfig),
+            githubRepo: extractGithubRepo(rig.git_url) ?? undefined,
+            userId: townConfig.owner_user_id ?? rigConfig?.userId,
+            orgId: townConfig.organization_id,
             platformIntegrationId: rigConfig?.platformIntegrationId,
           },
           {

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -312,11 +312,11 @@ export type ApplyActionContext = {
   /** Stop an agent's container process. */
   stopAgent: (agentId: string) => Promise<void>;
   /** Check a PR's status via GitHub/GitLab API. Returns PRStatusOutcome. */
-  checkPRStatus: (prUrl: string) => Promise<PRStatusOutcome>;
+  checkPRStatus: (prUrl: string, rigId: string) => Promise<PRStatusOutcome>;
   /** Check PR for unresolved review comments and failing CI checks. */
-  checkPRFeedback: (prUrl: string) => Promise<PRFeedbackCheckResult | null>;
+  checkPRFeedback: (prUrl: string, rigId: string) => Promise<PRFeedbackCheckResult | null>;
   /** Merge a PR via GitHub/GitLab API. */
-  mergePR: (prUrl: string) => Promise<boolean>;
+  mergePR: (prUrl: string, rigId: string) => Promise<boolean>;
   /** Queue a nudge message for an agent. */
   queueNudge: (agentId: string, message: string, tier: string) => Promise<void>;
   /** Insert a town_event for deferred processing (e.g. pr_status_changed). */
@@ -836,6 +836,8 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
     }
 
     case 'poll_pr': {
+      const polledBead = beadOps.getBead(sql, action.bead_id);
+      const rigId = polledBead?.rig_id ?? '';
       // Touch updated_at and record last_poll_at synchronously so the bead
       // doesn't look stale to Rule 4 (orphaned PR review, 30 min timeout).
       // Without this, active polling keeps the PR alive but updated_at was
@@ -858,7 +860,7 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
 
       return async () => {
         try {
-          const outcome = await ctx.checkPRStatus(action.pr_url);
+          const outcome = await ctx.checkPRStatus(action.pr_url, rigId);
           if (outcome.ok) {
             // Successful poll — reset both consecutive error counters
             query(
@@ -1018,7 +1020,9 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             // Each checkPRFeedback call makes 3+ GitHub API requests (GraphQL +
             // check-runs + commit status), so deduplicating halves our API usage.
             const feedback =
-              wantsAutoResolve || wantsAutoMerge ? await ctx.checkPRFeedback(action.pr_url) : null;
+              wantsAutoResolve || wantsAutoMerge
+                ? await ctx.checkPRFeedback(action.pr_url, rigId)
+                : null;
 
             if (feedback) {
               const prevAwaitingRows = z
@@ -1163,7 +1167,7 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               // If the PR was merged externally during that window, inserting
               // pr_feedback_detected would create a feedback bead for a merged
               // PR — leading to a duplicate PR on an already-merged branch.
-              const freshOutcome = await ctx.checkPRStatus(action.pr_url);
+              const freshOutcome = await ctx.checkPRStatus(action.pr_url, rigId);
               if (!freshOutcome.ok || freshOutcome.result.status !== 'open') {
                 console.log(
                   `${LOG} poll_pr: PR status changed to '${freshOutcome.ok ? freshOutcome.result.status : 'error'}' during feedback check, skipping feedback for bead=${action.bead_id}`
@@ -1526,7 +1530,8 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
           // Re-check feedback immediately before merging to avoid acting on
           // stale state. If a reviewer posted new comments or CI regressed
           // since the last poll, abort and reset the timer.
-          const freshFeedback = await ctx.checkPRFeedback(action.pr_url);
+          const mergeRigId = mrBead?.rig_id ?? '';
+          const freshFeedback = await ctx.checkPRFeedback(action.pr_url, mergeRigId);
           if (
             freshFeedback &&
             (freshFeedback.hasUnresolvedComments ||
@@ -1560,7 +1565,7 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             return;
           }
 
-          const merged = await ctx.mergePR(action.pr_url);
+          const merged = await ctx.mergePR(action.pr_url, mergeRigId);
           if (merged) {
             ctx.insertEvent('pr_status_changed', {
               bead_id: action.bead_id,

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -297,11 +297,9 @@ export function resolveRigConfig(
  * Build the ContainerConfig payload for X-Town-Config header.
  * Sent with every fetch() to the container.
  *
- * The container's `syncTownConfigToProcessEnv` reads `git_auth.github_token`
- * from this payload on every request and writes it to `process.env.GIT_TOKEN`,
- * which the SDK server's `gh` CLI inherits via `GH_TOKEN`. To prevent serving
- * an expired installation token (TTL ~1h) we resolve through `resolveGitHubToken`
- * so a configured platform integration always returns a fresh value.
+ * Legacy containers read `git_auth.github_token` into `process.env.GIT_TOKEN`.
+ * New containers honor `rig_scoped_git_identity` and keep GitHub credentials
+ * on each agent/repository request instead of mutating process-global state.
  *
  * `townId` is required so we can always perform the integration lookup.
  * Making it optional was a foot-gun — a forgotten arg silently re-introduces
@@ -342,6 +340,7 @@ export async function buildContainerConfig(
     git_author_name: config.git_author_name,
     git_author_email: config.git_author_email,
     disable_ai_coauthor: config.disable_ai_coauthor,
+    rig_scoped_git_identity: true,
     kilo_api_url: env.KILO_API_URL ?? '',
     gastown_api_url: env.GASTOWN_API_URL ?? '',
     organization_id: config.organization_id,

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -449,6 +449,9 @@ export async function startAgentInContainer(
       env,
       townId: params.townId,
       getTownConfig: () => Promise.resolve(params.townConfig),
+      githubRepo: params.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1],
+      userId: params.userId,
+      orgId: params.townConfig.organization_id,
       platformIntegrationId: params.platformIntegrationId,
     });
     if (githubToken) {
@@ -633,6 +636,7 @@ export async function startMergeInContainer(
     gitUrl: string;
     kilocodeToken?: string;
     townConfig: TownConfig;
+    platformIntegrationId?: string;
   }
 ): Promise<boolean> {
   try {
@@ -667,6 +671,10 @@ export async function startMergeInContainer(
       env,
       townId: params.townId,
       getTownConfig: () => Promise.resolve(params.townConfig),
+      githubRepo: params.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1],
+      userId,
+      orgId: params.townConfig.organization_id,
+      platformIntegrationId: params.platformIntegrationId,
     });
     if (mergeGithubToken) {
       envVars.GIT_TOKEN = mergeGithubToken;

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -14,11 +14,10 @@ export type SCMContext = {
   env: Env;
   townId: string;
   getTownConfig: () => Promise<TownConfig>;
-  /**
-   * Rig-level platform integration ID. When provided, it is tried as a
-   * fallback after town-level git_auth so that rigs authenticated solely
-   * through a rig-scoped GitHub App installation can still resolve a token.
-   */
+  githubRepo?: string;
+  userId?: string;
+  orgId?: string;
+  /** Exact Kilo platform integration identity persisted for the rig. */
   platformIntegrationId?: string;
 };
 
@@ -30,12 +29,13 @@ export type GitHubTokenResolution =
  * Resolve a GitHub API token from the town config.
  *
  * Priority chain (most to least preferred):
- *   1. `github_cli_pat` — user-supplied long-lived PAT, never expires.
- *   2. Platform integration (GitHub App installation) — minted fresh by
+ *   1. Exact rig platform integration — repository-scoped and fail-closed.
+ *   2. `github_cli_pat` — legacy user-supplied long-lived PAT.
+ *   3. Legacy town platform integration — minted fresh by
  *      git-token-service with KV-backed caching that auto-invalidates
  *      before each token's 1h TTL elapses. This is the authoritative
  *      live source whenever an integration is configured.
- *   3. `git_auth.github_token` — stored installation token from a past
+ *   4. `git_auth.github_token` — stored installation token from a past
  *      `refreshGitCredentials()` write. Kept as a fallback for towns that
  *      never had an integration wired up. NOT preferred over the integration
  *      because the stored value is typically stale (1h TTL, never updated
@@ -54,40 +54,80 @@ export async function resolveGitHubToken(ctx: SCMContext): Promise<GitHubTokenRe
   const tried: string[] = [];
   const townConfig = await ctx.getTownConfig();
 
-  // 1. github_cli_pat — long-lived user PAT
+  // 1. Exact rig platform integration — fresh repo-scoped App token.
+  // A pinned failure must not fall through to unrelated town credentials.
+  if (ctx.platformIntegrationId && ctx.env.GIT_TOKEN_SERVICE) {
+    tried.push('rig platform integration');
+    if (!ctx.githubRepo || !ctx.userId) {
+      tried.push('rig integration context incomplete');
+      return { ok: false, tried };
+    }
+    try {
+      const result = await ctx.env.GIT_TOKEN_SERVICE.getTokenForRepo({
+        githubRepo: ctx.githubRepo,
+        userId: ctx.userId,
+        ...(ctx.orgId ? { orgId: ctx.orgId } : {}),
+        expectedIntegrationId: ctx.platformIntegrationId,
+      });
+      if (result.success) {
+        return { ok: true, token: result.token, source: 'rig platform integration' };
+      }
+      tried.push(`rig platform integration (${result.reason})`);
+    } catch (err) {
+      console.warn(`${TOWN_LOG} resolveGitHubToken: exact rig integration lookup failed`, err);
+      tried.push('rig platform integration (lookup failed)');
+    }
+    return { ok: false, tried };
+  }
+  if (ctx.platformIntegrationId) {
+    tried.push('rig platform integration (GIT_TOKEN_SERVICE not bound)');
+    return { ok: false, tried };
+  }
+
+  // 2. github_cli_pat — legacy town credential, used only by unpinned rigs.
   if (townConfig.github_cli_pat) {
     return { ok: true, token: townConfig.github_cli_pat, source: 'town.github_cli_pat' };
   }
   tried.push('town.github_cli_pat');
 
-  // 2. Platform integration — fresh App installation token
-  const integrationId = townConfig.git_auth?.platform_integration_id ?? ctx.platformIntegrationId;
-  const sourceLabel = townConfig.git_auth?.platform_integration_id
-    ? 'town platform integration'
-    : 'rig platform integration';
-  if (integrationId && ctx.env.GIT_TOKEN_SERVICE) {
-    tried.push(sourceLabel);
-    try {
-      const fresh = await ctx.env.GIT_TOKEN_SERVICE.getToken(integrationId);
-      if (typeof fresh === 'string' && fresh.length > 0) {
-        return { ok: true, token: fresh, source: sourceLabel };
+  // 3. Legacy town platform integration. Old rigs remain readable, but
+  // ambiguous owner/repository resolution fails closed in git-token-service.
+  const legacyIntegrationId = townConfig.git_auth?.platform_integration_id;
+  if (legacyIntegrationId && ctx.env.GIT_TOKEN_SERVICE) {
+    tried.push('legacy town platform integration');
+    if (ctx.githubRepo && ctx.userId) {
+      try {
+        const result = await ctx.env.GIT_TOKEN_SERVICE.getTokenForRepo({
+          githubRepo: ctx.githubRepo,
+          userId: ctx.userId,
+          ...(ctx.orgId ? { orgId: ctx.orgId } : {}),
+        });
+        if (result.success) {
+          return { ok: true, token: result.token, source: 'legacy town platform integration' };
+        }
+        tried.push(`legacy town platform integration (${result.reason})`);
+        if (result.reason === 'ambiguous_installation') return { ok: false, tried };
+      } catch (err) {
+        console.warn(`${TOWN_LOG} resolveGitHubToken: legacy town integration lookup failed`, err);
+        tried.push('legacy town platform integration (lookup failed)');
       }
-      console.warn(
-        `${TOWN_LOG} resolveGitHubToken: platform integration ${integrationId} returned empty token; falling back to stored github_token`
-      );
-    } catch (err) {
-      console.warn(
-        `${TOWN_LOG} resolveGitHubToken: platform integration token lookup failed for ${integrationId}; falling back to stored github_token`,
-        err
-      );
+    } else {
+      try {
+        const fresh = await ctx.env.GIT_TOKEN_SERVICE.getToken(legacyIntegrationId);
+        if (fresh) {
+          return { ok: true, token: fresh, source: 'legacy town platform integration' };
+        }
+      } catch (err) {
+        console.warn(`${TOWN_LOG} resolveGitHubToken: legacy installation lookup failed`, err);
+      }
     }
-  } else if (!integrationId) {
+  } else if (!legacyIntegrationId) {
     tried.push('platform integration (none configured)');
   } else {
-    tried.push(`${sourceLabel} (GIT_TOKEN_SERVICE not bound)`);
+    tried.push('legacy town platform integration (GIT_TOKEN_SERVICE not bound)');
   }
 
-  // 3. Stored git_auth.github_token — last-resort fallback
+  // 4. Stored git_auth.github_token — last-resort fallback for legacy rigs only.
   if (townConfig.git_auth?.github_token) {
     return {
       ok: true,

--- a/services/gastown/src/handlers/refresh-git-token.handler.ts
+++ b/services/gastown/src/handlers/refresh-git-token.handler.ts
@@ -44,12 +44,20 @@ export async function handleRefreshGitToken(
 
   const town = getTownDOStub(c.env, params.townId);
   const rigConfig = await town.getRigConfig(params.rigId);
+  if (!rigConfig) {
+    return c.json(resError('Rig not found'), 404);
+  }
+  const townConfig = await town.getTownConfig();
+  const githubRepo = rigConfig.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1];
 
   const freshToken = await resolveGitHubToken({
     env: c.env,
     townId: params.townId,
-    getTownConfig: () => town.getTownConfig(),
-    platformIntegrationId: rigConfig?.platformIntegrationId,
+    getTownConfig: () => Promise.resolve(townConfig),
+    githubRepo,
+    userId: townConfig.owner_user_id ?? rigConfig.userId,
+    orgId: townConfig.organization_id,
+    platformIntegrationId: rigConfig.platformIntegrationId,
   });
 
   if (!freshToken.ok) {

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -54,28 +54,32 @@ function extractGithubRepo(gitUrl: string): string | null {
 /** Best-effort refresh of git credentials for a town via the git-token-service. */
 async function refreshGitCredentials(
   env: Env,
-  townId: string,
   gitUrl: string,
   userId: string,
-  orgId?: string
-): Promise<void> {
+  orgId?: string,
+  expectedIntegrationId?: string
+): Promise<string | undefined> {
   if (!env.GIT_TOKEN_SERVICE) return;
   const githubRepo = extractGithubRepo(gitUrl);
   if (!githubRepo) return;
 
-  const result = await env.GIT_TOKEN_SERVICE.getTokenForRepo({ githubRepo, userId, orgId });
+  const result = await env.GIT_TOKEN_SERVICE.getTokenForRepo({
+    githubRepo,
+    userId,
+    ...(orgId ? { orgId } : {}),
+    ...(expectedIntegrationId ? { expectedIntegrationId } : {}),
+  });
   if (!result.success) {
     console.warn(`[gastown-trpc] git credential refresh failed: ${result.reason}`);
-    return;
+    if (expectedIntegrationId || result.reason === 'ambiguous_installation') {
+      throw new TRPCError({
+        code: 'PRECONDITION_FAILED',
+        message: 'The selected repository integration is unavailable or ambiguous',
+      });
+    }
+    return undefined;
   }
-
-  const townStub = getTownDOStub(env, townId);
-  await townStub.updateTownConfig({
-    git_auth: {
-      github_token: result.token,
-      platform_integration_id: result.installationId,
-    },
-  });
+  return result.platformIntegrationId;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -506,25 +510,20 @@ export const gastownRouter = router({
         await townStub.updateTownConfig({ kilocode_token: kilocodeToken });
       }
 
-      // Resolve git credentials using the town owner's identity
-      try {
-        await refreshGitCredentials(
-          ctx.env,
-          input.townId,
-          input.gitUrl,
-          credentialUserId,
-          townConfig.organization_id
-        );
-      } catch (err) {
-        console.warn('[gastown-trpc] createRig: git credential refresh failed', err);
-      }
+      const platformIntegrationId = await refreshGitCredentials(
+        ctx.env,
+        input.gitUrl,
+        credentialUserId,
+        townConfig.organization_id,
+        input.platformIntegrationId
+      );
 
       const rig = await ownerStub.createRig({
         town_id: input.townId,
         name: input.name,
         git_url: input.gitUrl,
         default_branch: input.defaultBranch,
-        platform_integration_id: input.platformIntegrationId,
+        platform_integration_id: platformIntegrationId,
       });
 
       // Configure the Town DO with rig metadata so dispatchAgent can find it.
@@ -537,7 +536,7 @@ export const gastownRouter = router({
           defaultBranch: input.defaultBranch,
           userId: credentialUserId,
           kilocodeToken,
-          platformIntegrationId: input.platformIntegrationId,
+          platformIntegrationId,
         });
         await townStub.addRig({
           rigId: rig.id,
@@ -851,10 +850,10 @@ export const gastownRouter = router({
       try {
         await refreshGitCredentials(
           ctx.env,
-          rig.town_id,
           rig.git_url,
           credentialUserId,
-          townConfig.organization_id
+          townConfig.organization_id,
+          rig.platform_integration_id ?? undefined
         );
       } catch (err) {
         console.warn('[gastown-trpc] sling: git credential refresh failed', err);
@@ -1081,12 +1080,11 @@ export const gastownRouter = router({
           if (extractGithubRepo(rig.git_url)) {
             await refreshGitCredentials(
               ctx.env,
-              input.townId,
               rig.git_url,
               credentialUserId,
-              townConfig.organization_id
+              townConfig.organization_id,
+              rig.platform_integration_id ?? undefined
             );
-            break;
           }
         }
       } catch (err) {
@@ -1684,25 +1682,20 @@ export const gastownRouter = router({
         await townStub.updateTownConfig({ kilocode_token: kilocodeToken });
       }
 
-      // Resolve git credentials using the town owner's identity
-      try {
-        await refreshGitCredentials(
-          ctx.env,
-          input.townId,
-          input.gitUrl,
-          credentialUserId,
-          townConfig.organization_id
-        );
-      } catch (err) {
-        console.warn('[gastown-trpc] createOrgRig: git credential refresh failed', err);
-      }
+      const platformIntegrationId = await refreshGitCredentials(
+        ctx.env,
+        input.gitUrl,
+        credentialUserId,
+        townConfig.organization_id,
+        input.platformIntegrationId
+      );
 
       const rig = await orgStub.createRig({
         town_id: input.townId,
         name: input.name,
         git_url: input.gitUrl,
         default_branch: input.defaultBranch,
-        platform_integration_id: input.platformIntegrationId,
+        platform_integration_id: platformIntegrationId,
       });
 
       try {
@@ -1713,7 +1706,7 @@ export const gastownRouter = router({
           defaultBranch: input.defaultBranch,
           userId: credentialUserId,
           kilocodeToken,
-          platformIntegrationId: input.platformIntegrationId,
+          platformIntegrationId,
         });
         await townStub.addRig({
           rigId: rig.id,

--- a/services/gastown/test/integration/rig-alarm.test.ts
+++ b/services/gastown/test/integration/rig-alarm.test.ts
@@ -1,4 +1,4 @@
-import { env, runDurableObjectAlarm } from 'cloudflare:test';
+import { abortAllDurableObjects, env, runDurableObjectAlarm } from 'cloudflare:test';
 import { describe, it, expect, beforeEach } from 'vitest';
 
 function getTownStub(name = 'test-town') {
@@ -36,6 +36,47 @@ describe('Town DO Alarm', () => {
     it('should return null when no rig config is set', async () => {
       const retrieved = await town.getRigConfig('nonexistent');
       expect(retrieved).toBeNull();
+    });
+
+    it('stores independent integration identities for two rigs across object reconstruction', async () => {
+      const first = testRigConfig('rig-one');
+      const second = testRigConfig('rig-two');
+      await town.configureRig({ ...first, platformIntegrationId: 'integration-one' });
+      await town.configureRig({ ...second, platformIntegrationId: 'integration-two' });
+
+      expect(await town.getRigConfig(first.rigId)).toMatchObject({
+        ...first,
+        platformIntegrationId: 'integration-one',
+      });
+      expect(await town.getRigConfig(second.rigId)).toMatchObject({
+        ...second,
+        platformIntegrationId: 'integration-two',
+      });
+
+      await abortAllDurableObjects();
+      const reconstructed = getTownStub(townName);
+      expect(await reconstructed.getRigConfig(first.rigId)).toMatchObject({
+        ...first,
+        platformIntegrationId: 'integration-one',
+      });
+      expect(await reconstructed.getRigConfig(second.rigId)).toMatchObject({
+        ...second,
+        platformIntegrationId: 'integration-two',
+      });
+    });
+
+    it('reads legacy snake-case integration identity as platformIntegrationId', async () => {
+      const legacyRigId = 'legacy-rig';
+      await town.configureRig({
+        ...testRigConfig(legacyRigId),
+        platformIntegrationId: undefined,
+        platform_integration_id: 'legacy-integration',
+      });
+
+      expect(await town.getRigConfig(legacyRigId)).toMatchObject({
+        rigId: legacyRigId,
+        platformIntegrationId: 'legacy-integration',
+      });
     });
   });
 

--- a/services/gastown/test/integration/rig-owner-identity.test.ts
+++ b/services/gastown/test/integration/rig-owner-identity.test.ts
@@ -1,0 +1,37 @@
+import { env } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+
+async function createOrgRig(orgName: string, integrationId: string) {
+  const org = env.GASTOWN_ORG.get(env.GASTOWN_ORG.idFromName(orgName));
+  const town = await org.createTown({
+    name: `${orgName} town`,
+    owner_org_id: orgName,
+    created_by_user_id: `${orgName} owner`,
+  });
+  return org.createRig({
+    town_id: town.id,
+    name: `${orgName} rig`,
+    git_url: `https://github.com/${orgName}/repo.git`,
+    default_branch: 'main',
+    platform_integration_id: integrationId,
+  });
+}
+
+describe('Gastown rig owner identity', () => {
+  it('isolates platform integrations for rigs owned by different organizations', async () => {
+    const first = await createOrgRig('org-one', 'integration-one');
+    const second = await createOrgRig('org-two', 'integration-two');
+
+    const firstOrg = env.GASTOWN_ORG.get(env.GASTOWN_ORG.idFromName('org-one'));
+    const secondOrg = env.GASTOWN_ORG.get(env.GASTOWN_ORG.idFromName('org-two'));
+
+    expect(await firstOrg.getRigAsync(first.id)).toMatchObject({
+      platform_integration_id: 'integration-one',
+    });
+    expect(await secondOrg.getRigAsync(second.id)).toMatchObject({
+      platform_integration_id: 'integration-two',
+    });
+    expect(await firstOrg.getRigAsync(second.id)).toBeNull();
+    expect(await secondOrg.getRigAsync(first.id)).toBeNull();
+  });
+});

--- a/services/gastown/test/unit/pr-poll-errors.test.ts
+++ b/services/gastown/test/unit/pr-poll-errors.test.ts
@@ -65,7 +65,7 @@ describe('resolveGitHubToken', () => {
     const result = await resolveGitHubToken(ctx);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.tried).toContain('town platform integration');
+      expect(result.tried).toContain('rig platform integration');
     }
   });
 
@@ -92,7 +92,7 @@ describe('resolveGitHubToken', () => {
     const result = await resolveGitHubToken(ctx);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.tried).toContain('town platform integration (GIT_TOKEN_SERVICE not bound)');
+      expect(result.tried).toContain('rig platform integration (GIT_TOKEN_SERVICE not bound)');
     }
   });
 });

--- a/services/gastown/test/unit/town-scm.test.ts
+++ b/services/gastown/test/unit/town-scm.test.ts
@@ -1,11 +1,12 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { resolveGitHubToken } from '../../src/dos/town/town-scm';
 import { TownConfigSchema, type TownConfig } from '../../src/types';
 
 const STORED_GITHUB_TOKEN = 'ghs_stored_stale_token';
 const FRESH_INSTALLATION_TOKEN = 'ghs_fresh_from_integration';
 const USER_PAT = 'ghp_user_long_lived_pat';
-const INTEGRATION_ID = '119277743';
+const INTEGRATION_ID = '123e4567-e89b-12d3-a456-426614174001';
+const ORG_ID = '123e4567-e89b-12d3-a456-426614174002';
 
 function buildConfig(overrides: {
   github_token?: string;
@@ -24,9 +25,24 @@ function buildConfig(overrides: {
 function fakeEnv(opts: {
   tokenServiceResponse?: string | null;
   tokenServiceShouldThrow?: boolean;
+  repoResult?: GetTokenForRepoResult;
+  getTokenForRepo?: ReturnType<typeof vi.fn>;
 }): Env {
+  const getTokenForRepo =
+    opts.getTokenForRepo ??
+    vi.fn().mockResolvedValue(
+      opts.repoResult ?? {
+        success: true,
+        token: FRESH_INSTALLATION_TOKEN,
+        platformIntegrationId: INTEGRATION_ID,
+        installationId: '119277743',
+        accountLogin: 'acme',
+        appType: 'standard',
+      }
+    );
   return {
     GIT_TOKEN_SERVICE: {
+      getTokenForRepo,
       getToken: async (_id: string) => {
         if (opts.tokenServiceShouldThrow) {
           throw new Error('integration lookup failed');
@@ -42,7 +58,6 @@ describe('resolveGitHubToken priority chain', () => {
     const cfg = buildConfig({
       github_cli_pat: USER_PAT,
       github_token: STORED_GITHUB_TOKEN,
-      platform_integration_id: INTEGRATION_ID,
     });
     const result = await resolveGitHubToken({
       env: fakeEnv({}),
@@ -65,7 +80,7 @@ describe('resolveGitHubToken priority chain', () => {
     expect(result).toEqual({
       ok: true,
       token: FRESH_INSTALLATION_TOKEN,
-      source: 'town platform integration',
+      source: 'legacy town platform integration',
     });
   });
 
@@ -103,15 +118,126 @@ describe('resolveGitHubToken priority chain', () => {
   it('uses the rig-level platformIntegrationId when town config does not carry one', async () => {
     const cfg = buildConfig({});
     const result = await resolveGitHubToken({
-      env: fakeEnv({ tokenServiceResponse: FRESH_INSTALLATION_TOKEN }),
+      env: fakeEnv({}),
       townId: 'town-1',
       getTownConfig: () => Promise.resolve(cfg),
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      orgId: ORG_ID,
       platformIntegrationId: INTEGRATION_ID,
     });
     expect(result).toEqual({
       ok: true,
       token: FRESH_INSTALLATION_TOKEN,
       source: 'rig platform integration',
+    });
+  });
+
+  it('pins repo token resolution to the rig platform integration', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: FRESH_INSTALLATION_TOKEN,
+      platformIntegrationId: INTEGRATION_ID,
+      installationId: '119277743',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const cfg = buildConfig({ github_token: STORED_GITHUB_TOKEN });
+
+    await expect(
+      resolveGitHubToken({
+        env: fakeEnv({ getTokenForRepo }),
+        townId: 'town-1',
+        getTownConfig: () => Promise.resolve(cfg),
+        githubRepo: 'acme/repo',
+        userId: 'user-1',
+        orgId: ORG_ID,
+        platformIntegrationId: INTEGRATION_ID,
+      })
+    ).resolves.toEqual({
+      ok: true,
+      token: FRESH_INSTALLATION_TOKEN,
+      source: 'rig platform integration',
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      orgId: ORG_ID,
+      expectedIntegrationId: INTEGRATION_ID,
+    });
+  });
+
+  it('pins a personal rig integration without requiring an organization', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: FRESH_INSTALLATION_TOKEN,
+      platformIntegrationId: INTEGRATION_ID,
+      installationId: '119277743',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+
+    await expect(
+      resolveGitHubToken({
+        env: fakeEnv({ getTokenForRepo }),
+        townId: 'town-1',
+        getTownConfig: () => Promise.resolve(buildConfig({})),
+        githubRepo: 'acme/repo',
+        userId: 'user-1',
+        platformIntegrationId: INTEGRATION_ID,
+      })
+    ).resolves.toMatchObject({ ok: true, source: 'rig platform integration' });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      expectedIntegrationId: INTEGRATION_ID,
+    });
+  });
+
+  it('fails ambiguous legacy lookup closed instead of using a stored token', async () => {
+    const result = await resolveGitHubToken({
+      env: fakeEnv({ repoResult: { success: false, reason: 'ambiguous_installation' } }),
+      townId: 'town-1',
+      getTownConfig: () =>
+        Promise.resolve(
+          buildConfig({
+            github_token: STORED_GITHUB_TOKEN,
+            platform_integration_id: INTEGRATION_ID,
+          })
+        ),
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      orgId: ORG_ID,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      tried: [
+        'town.github_cli_pat',
+        'legacy town platform integration',
+        'legacy town platform integration (ambiguous_installation)',
+      ],
+    });
+  });
+
+  it('fails a pinned rig closed instead of falling back to town credentials', async () => {
+    const cfg = buildConfig({
+      github_token: STORED_GITHUB_TOKEN,
+      platform_integration_id: '123e4567-e89b-12d3-a456-426614174099',
+    });
+    const result = await resolveGitHubToken({
+      env: fakeEnv({ repoResult: { success: false, reason: 'integration_mismatch' } }),
+      townId: 'town-1',
+      getTownConfig: () => Promise.resolve(cfg),
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      orgId: ORG_ID,
+      platformIntegrationId: INTEGRATION_ID,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      tried: ['rig platform integration', 'rig platform integration (integration_mismatch)'],
     });
   });
 

--- a/services/gastown/worker-configuration.d.ts
+++ b/services/gastown/worker-configuration.d.ts
@@ -31,17 +31,18 @@ interface __BaseEnv_Env {
 type GetTokenForRepoSuccess = {
 	success: true;
 	token: string;
+	platformIntegrationId: string;
 	installationId: string;
 	accountLogin: string;
 	appType: 'standard' | 'lite';
 };
 type GetTokenForRepoFailure = {
 	success: false;
-	reason: 'database_not_configured' | 'invalid_repo_format' | 'no_installation_found' | 'invalid_org_id';
+	reason: 'database_not_configured' | 'invalid_repo_format' | 'no_installation_found' | 'ambiguous_installation' | 'repository_not_installed' | 'invalid_org_id' | 'integration_mismatch';
 };
 type GetTokenForRepoResult = GetTokenForRepoSuccess | GetTokenForRepoFailure;
 type GitTokenService = {
-	getTokenForRepo(params: { githubRepo: string; userId: string; orgId?: string }): Promise<GetTokenForRepoResult>;
+	getTokenForRepo(params: { githubRepo: string; userId: string; orgId?: string; expectedIntegrationId?: string }): Promise<GetTokenForRepoResult>;
 	getToken(installationId: string, appType?: 'standard' | 'lite'): Promise<string>;
 };
 type WastelandRpcSuccess<T> = { success: true; data: T };

--- a/services/gastown/wrangler.test.jsonc
+++ b/services/gastown/wrangler.test.jsonc
@@ -19,6 +19,7 @@
   "durable_objects": {
     "bindings": [
       { "name": "GASTOWN_USER", "class_name": "GastownUserDO" },
+      { "name": "GASTOWN_ORG", "class_name": "GastownOrgDO" },
       { "name": "AGENT_IDENTITY", "class_name": "AgentIdentityDO" },
       { "name": "TOWN", "class_name": "TownDO" },
       { "name": "TOWN_CONTAINER", "class_name": "TownContainerDO" },
@@ -32,6 +33,7 @@
     { "tag": "v3", "new_sqlite_classes": ["MayorDO"] },
     { "tag": "v4", "new_sqlite_classes": ["TownDO"] },
     { "tag": "v5", "new_sqlite_classes": ["AgentDO"], "deleted_classes": ["RigDO", "MayorDO"] },
+    { "tag": "v6", "new_sqlite_classes": ["GastownOrgDO"] },
   ],
 
   // Test secrets — plain text vars used in place of secrets_store_secrets

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -518,6 +518,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
   it('mints repository-scoped tokens after resolving an authorized installation', async () => {
     serviceMocks.findInstallationId.mockResolvedValue({
       success: true,
+      platformIntegrationId: '00000000-0000-4000-8000-000000000003',
       installationId: '123',
       accountLogin: 'old-owner',
       githubAppType: 'lite',
@@ -533,6 +534,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     expect(result).toEqual({
       success: true,
       token: 'scoped-token',
+      platformIntegrationId: '00000000-0000-4000-8000-000000000003',
       installationId: '123',
       accountLogin: 'old-owner',
       appType: 'lite',
@@ -546,6 +548,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       .mockResolvedValueOnce({ success: false, reason: 'no_installation_found' })
       .mockResolvedValueOnce({
         success: true,
+        platformIntegrationId: '00000000-0000-4000-8000-000000000003',
         installationId: '123',
         accountLogin: 'renamed-owner',
         githubAppType: 'standard',
@@ -671,7 +674,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       userId: 'user-1',
     });
 
-    expect(result).toEqual({ success: false, reason: 'no_installation_found' });
+    expect(result).toEqual({ success: false, reason: 'ambiguous_installation' });
     expect(serviceMocks.findRefreshCandidates).not.toHaveBeenCalled();
     expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
@@ -694,6 +697,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
   it('does not fall back to an installation-wide token when scoped minting fails', async () => {
     serviceMocks.findInstallationId.mockResolvedValue({
       success: true,
+      platformIntegrationId: '00000000-0000-4000-8000-000000000003',
       installationId: '123',
       accountLogin: 'old-owner',
       githubAppType: 'standard',
@@ -717,6 +721,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       .mockResolvedValueOnce({ success: false, reason: 'integration_mismatch' })
       .mockResolvedValueOnce({
         success: true,
+        platformIntegrationId: params.expectedIntegrationId,
         installationId: '123',
         accountLogin: 'acme',
         githubAppType: 'standard',

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -101,6 +101,7 @@ export type GetTokenForRepoParams = {
 export type GetTokenForRepoSuccess = {
   success: true;
   token: string;
+  platformIntegrationId: string;
   installationId: string;
   accountLogin: string;
   appType: GitHubAppType;
@@ -112,6 +113,7 @@ export type GetTokenForRepoFailure = {
     | 'database_not_configured'
     | 'invalid_repo_format'
     | 'no_installation_found'
+    | 'ambiguous_installation'
     | 'repository_not_installed'
     | 'invalid_org_id'
     | 'integration_mismatch';
@@ -810,7 +812,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     if (!installation.success) {
       switch (installation.reason) {
         case 'ambiguous_installation':
-          return { success: false, reason: 'no_installation_found' };
+          return { success: false, reason: installation.reason };
         case 'database_not_configured':
         case 'invalid_repo_format':
         case 'no_installation_found':
@@ -834,6 +836,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     return {
       success: true,
       token,
+      platformIntegrationId: installation.platformIntegrationId,
       installationId: installation.installationId,
       accountLogin: installation.accountLogin,
       appType: installation.githubAppType,

--- a/services/git-token-service/src/installation-lookup-service.behavior.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.behavior.test.ts
@@ -58,6 +58,7 @@ describe('InstallationLookupService', () => {
   it('fails closed when multiple active personal installations match the requested owner', async () => {
     const service = createService([
       {
+        id: '00000000-0000-4000-8000-000000000003',
         platform_installation_id: '100',
         platform_account_login: 'old-owner',
         github_app_type: 'standard',
@@ -142,6 +143,7 @@ describe('InstallationLookupService', () => {
   it('resolves an exact-login integration using the legacy standard app type', async () => {
     const service = createService([
       {
+        id: '00000000-0000-4000-8000-000000000003',
         platform_installation_id: '100',
         platform_account_login: 'renamed-owner',
         github_app_type: null,
@@ -156,6 +158,7 @@ describe('InstallationLookupService', () => {
 
     expect(result).toEqual({
       success: true,
+      platformIntegrationId: '00000000-0000-4000-8000-000000000003',
       installationId: '100',
       accountLogin: 'renamed-owner',
       githubAppType: 'standard',
@@ -260,6 +263,7 @@ describe('InstallationLookupService', () => {
       })
     ).resolves.toEqual({
       success: true,
+      platformIntegrationId: integrationId,
       installationId: '100',
       accountLogin: 'renamed-owner',
       githubAppType: 'standard',
@@ -306,17 +310,34 @@ describe('InstallationLookupService', () => {
     ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
   });
 
-  it('does not accept an expected integration without an organization', async () => {
-    const service = createService([]);
+  it('resolves an exact personal integration without an organization', async () => {
+    const integrationId = '00000000-0000-4000-8000-000000000002';
+    const service = createService([
+      {
+        id: integrationId,
+        platform_installation_id: '100',
+        platform_account_login: 'renamed-owner',
+        github_app_type: 'standard',
+        integration_status: 'active',
+        owned_by_organization_id: null,
+        owned_by_user_id: 'user-1',
+        repository_access: 'all',
+        repositories: null,
+        permissions: null,
+      },
+    ]);
 
     await expect(
       service.findManagedInstallationForRepo({
         githubRepo: 'renamed-owner/repository',
         userId: 'user-1',
-        expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
+        expectedIntegrationId: integrationId,
       })
-    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
-    expect(getWorkerDb).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({
+      success: true,
+      platformIntegrationId: integrationId,
+      installationId: '100',
+    });
   });
 
   it('returns integration_mismatch when the expected row is not visible to the fenced query', async () => {

--- a/services/git-token-service/src/installation-lookup-service.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.test.ts
@@ -76,4 +76,20 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.params).toContain('renamed-owner');
     expect(query.params).toContain(1);
   });
+
+  it('uses a supplied integration ID as an exact personal authorization fence', () => {
+    const db = getWorkerDb('postgres://unused:unused@localhost:0/unused');
+    const expectedIntegrationId = '00000000-0000-4000-8000-000000000002';
+    const query = buildManagedInstallationLookupQuery(db, {
+      githubRepo: params.githubRepo,
+      userId: params.userId,
+      expectedIntegrationId,
+    }).toSQL();
+
+    expect(query.sql).toContain('"platform_integrations"."id" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_organization_id" is null');
+    expect(query.params).toContain(expectedIntegrationId);
+    expect(query.params).toContain(params.userId);
+  });
 });

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -15,6 +15,7 @@ export type FindInstallationParams = {
 };
 
 const InstallationLookupResultSchema = z.object({
+  id: z.string().uuid().optional(),
   platform_installation_id: z.string(),
   platform_account_login: z.string().nullable(),
   github_app_type: z.enum(['standard', 'lite']).nullable().optional(),
@@ -47,6 +48,7 @@ const MAX_INSTALLATION_LOGIN_REFRESH_CANDIDATES = 10;
 
 export type InstallationLookupSuccess = {
   success: true;
+  platformIntegrationId: string;
   installationId: string;
   accountLogin: string;
   githubAppType: 'standard' | 'lite';
@@ -112,13 +114,17 @@ function buildAuthorizedInstallationsQuery(
   const exactIntegrationOwner =
     params.expectedIntegrationId === undefined
       ? undefined
-      : params.orgId === undefined
-        ? sql`false`
-        : and(
+      : params.orgId !== undefined
+        ? and(
             eq(platform_integrations.id, params.expectedIntegrationId),
             eq(platform_integrations.owned_by_organization_id, params.orgId),
             isNull(platform_integrations.owned_by_user_id),
             isNotNull(organization_memberships.id)
+          )
+        : and(
+            eq(platform_integrations.id, params.expectedIntegrationId),
+            eq(platform_integrations.owned_by_user_id, params.userId),
+            isNull(platform_integrations.owned_by_organization_id)
           );
   const legacyAuthorizedOwner =
     params.expectedIntegrationId === undefined
@@ -228,8 +234,7 @@ export class InstallationLookupService {
 
     if (
       params.expectedIntegrationId !== undefined &&
-      (params.orgId === undefined ||
-        !z.string().uuid().safeParse(params.expectedIntegrationId).success)
+      !z.string().uuid().safeParse(params.expectedIntegrationId).success
     ) {
       return { success: false, reason: 'integration_mismatch' };
     }
@@ -258,6 +263,7 @@ export class InstallationLookupService {
 
       return {
         success: true,
+        platformIntegrationId: selected.data.id,
         installationId: selected.data.platform_installation_id,
         accountLogin: selected.data.platform_account_login ?? '',
         githubAppType: selected.data.github_app_type ?? 'standard',
@@ -282,8 +288,12 @@ export class InstallationLookupService {
       return { success: false, reason: 'ambiguous_installation' };
     }
 
+    if (!selected.id) {
+      return { success: false, reason: 'no_installation_found' };
+    }
     return {
       success: true,
+      platformIntegrationId: selected.id,
       installationId: selected.platform_installation_id,
       accountLogin: selected.platform_account_login ?? '',
       githubAppType: selected.github_app_type ?? 'standard',
@@ -348,6 +358,7 @@ export class InstallationLookupService {
 
       return {
         success: true,
+        platformIntegrationId: selected.data.id,
         installationId: selected.data.platform_installation_id,
         accountLogin: selected.data.platform_account_login ?? '',
         githubAppType: selected.data.github_app_type ?? 'standard',
@@ -383,8 +394,12 @@ export class InstallationLookupService {
       return { success: false, reason: 'repository_not_installed' };
     }
 
+    if (!selected.id) {
+      return { success: false, reason: 'no_installation_found' };
+    }
     return {
       success: true,
+      platformIntegrationId: selected.id,
       installationId: selected.platform_installation_id,
       accountLogin: selected.platform_account_login ?? '',
       githubAppType: selected.github_app_type ?? 'standard',
@@ -400,10 +415,22 @@ export class InstallationLookupService {
     if (
       selected.id !== params.expectedIntegrationId ||
       selected.integration_status !== 'active' ||
-      selected.owned_by_organization_id !== params.orgId ||
-      selected.owned_by_user_id !== null ||
       selected.platform_account_login?.toLowerCase() !==
         params.githubRepo.split('/')[0]?.toLowerCase()
+    ) {
+      return false;
+    }
+
+    if (params.orgId !== undefined) {
+      if (
+        selected.owned_by_organization_id !== params.orgId ||
+        selected.owned_by_user_id !== null
+      ) {
+        return false;
+      }
+    } else if (
+      selected.owned_by_user_id !== params.userId ||
+      selected.owned_by_organization_id !== null
     ) {
       return false;
     }


### PR DESCRIPTION
## Why this PR exists

A Gastown can contain several rigs, and an organization can now connect several GitHub installations. Gastown currently keeps repository and credentials largely at town scope, so adding or refreshing one rig can cause another rig to use the wrong installation. This is especially dangerous after a restart, when in-memory context is gone and only persisted rig state remains.

This PR makes GitHub installation identity a property of each rig and uses it for every Git operation.

## Place in the rollout

This is the Gastown backend-safety layer. It must land before the repository selector in #5570 exposes secondary-installation repositories to users.

## Dependency

Depends on #5547 for fail-closed legacy repository resolution. After #5547 merges, retarget this PR to `main`.

## What changes

- Persist Kilo `platformIntegrationId` per rig in owner and Town Durable Object state.
- Use the rig installation for clone, push, PR polling, feedback, merge, branch creation, and token refresh.
- Keep credentials rig-scoped instead of mutating process-global GitHub token state.
- Preserve old rigs without identity, but resolve them only when one installation matches.

## What stays unchanged

- Existing rigs remain readable.
- This PR does not add or redesign repository selection UI.
- Town-level fallback exists only for legacy unpinned rigs and fails closed on ambiguity.

## Why this crosses Gastown, container, and token-service code

A rig moves through persisted Durable Object state, container startup, runtime Git commands, and credential refresh. Pinning only creation would be lost at restart; pinning only token refresh would leave clone and PR operations unsafe. The changes follow one identity across those existing boundaries.

## Review guide

Start with `user-rigs.table.ts` and Town config normalization, then trace `platformIntegrationId` into `town-scm.ts` and refresh handling. Finally verify the container no longer relies on a process-global token. Tests cover persistence, two-rig isolation, legacy ambiguity, and refresh.

## Validation

- Gastown, Git Token Service, and container typechecks/lint
- 166 shared resolver tests
- 32 Gastown identity tests
- Focused container and Durable Object identity tests
- `git diff --check`