### PR TITLE
feat(auto-triage): handle issues from every connected GitHub org

### DIFF
--- a/apps/web/src/app/api/internal/triage/add-label/route.ts
+++ b/apps/web/src/app/api/internal/triage/add-label/route.ts
@@ -20,8 +20,8 @@ import { logExceptInTest, errorExceptInTest } from '@/lib/utils.server';
 import { captureException } from '@sentry/nextjs';
 import { INTERNAL_API_SECRET } from '@/lib/config.server';
 import { addIssueLabel } from '@/lib/auto-triage/github/add-label';
-import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
 import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
+import { generateAutoTriageInstallationToken } from '@/lib/auto-triage/github/installation-token';
 
 const addLabelRequestSchema = z.object({
   ticketId: z.string().uuid(),
@@ -66,7 +66,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'No platform installation found' }, { status: 400 });
     }
 
-    const tokenData = await generateGitHubInstallationToken(integration.platform_installation_id);
+    const tokenData = await generateAutoTriageInstallationToken(integration);
 
     // Add labels to the GitHub issue in parallel (best-effort: partial failures don't abort the batch)
     logExceptInTest('[auto-triage:labels] Applying labels to GitHub issue', {

--- a/apps/web/src/app/api/internal/triage/classify-config/route.ts
+++ b/apps/web/src/app/api/internal/triage/classify-config/route.ts
@@ -22,8 +22,8 @@ import { captureException } from '@sentry/nextjs';
 import { INTERNAL_API_SECRET } from '@/lib/config.server';
 import type { Owner } from '@/lib/auto-triage/db/types';
 import type { AutoTriageAgentConfig } from '@/lib/auto-triage/core/schemas';
-import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
 import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
+import { generateAutoTriageInstallationToken } from '@/lib/auto-triage/github/installation-token';
 
 interface ClassifyConfigRequest {
   ticketId: string;
@@ -72,9 +72,7 @@ export async function POST(req: NextRequest) {
         const integration = await getIntegrationById(ticket.platform_integration_id);
 
         if (integration?.platform_installation_id) {
-          const tokenData = await generateGitHubInstallationToken(
-            integration.platform_installation_id
-          );
+          const tokenData = await generateAutoTriageInstallationToken(integration);
           githubToken = tokenData.token;
 
           logExceptInTest('[classify-config] GitHub token obtained', {

--- a/apps/web/src/app/api/internal/triage/post-comment/route.ts
+++ b/apps/web/src/app/api/internal/triage/post-comment/route.ts
@@ -19,9 +19,9 @@ import { logExceptInTest, errorExceptInTest } from '@/lib/utils.server';
 import { captureException } from '@sentry/nextjs';
 import { INTERNAL_API_SECRET } from '@/lib/config.server';
 import { postIssueComment } from '@/lib/auto-triage/github/post-comment';
-import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
 import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
 import { z } from 'zod';
+import { generateAutoTriageInstallationToken } from '@/lib/auto-triage/github/installation-token';
 
 const postCommentRequestSchema = z.object({
   ticketId: z.string().uuid(),
@@ -67,7 +67,7 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'No platform installation found' }, { status: 400 });
     }
 
-    const tokenData = await generateGitHubInstallationToken(integration.platform_installation_id);
+    const tokenData = await generateAutoTriageInstallationToken(integration);
 
     logExceptInTest('[post-comment] Posting comment on GitHub issue', {
       ticketId,

--- a/apps/web/src/lib/auto-triage/application/routers/shared-router-factory.test.ts
+++ b/apps/web/src/lib/auto-triage/application/routers/shared-router-factory.test.ts
@@ -1,0 +1,61 @@
+const mockTryDispatchPendingTickets = jest.fn();
+
+jest.mock('@/lib/auto-triage/db/triage-tickets', () => ({
+  listTriageTickets: jest.fn(),
+  countTriageTickets: jest.fn(),
+  getTriageTicketById: jest.fn(),
+  resetTriageTicketForRetry: jest.fn(),
+  interruptTriageTicket: jest.fn(),
+}));
+jest.mock('@/lib/auto-triage/dispatch/dispatch-pending-tickets', () => ({
+  tryDispatchPendingTickets: (...args: unknown[]) => mockTryDispatchPendingTickets(...args),
+}));
+jest.mock('@/lib/bot-users/bot-user-service', () => ({
+  ensureBotUserForOrg: jest.fn(),
+}));
+
+import { createAutoTriageRouter } from './shared-router-factory';
+
+describe('Auto Triage repository configuration', () => {
+  it('returns repositories from every installation with provenance intact', async () => {
+    const repositories = [
+      {
+        id: 1,
+        name: 'api',
+        fullName: 'acme-core/api',
+        private: true,
+        platformIntegrationId: 'integration-core',
+        platformAccountLogin: 'acme-core',
+      },
+      {
+        id: 2,
+        name: 'scanner',
+        fullName: 'acme-security/scanner',
+        private: true,
+        platformIntegrationId: 'integration-security',
+        platformAccountLogin: 'acme-security',
+      },
+    ];
+    const repositoryFetcher = jest.fn().mockResolvedValue({
+      integrationInstalled: true,
+      repositories,
+    });
+    const handlers = createAutoTriageRouter({
+      ownerResolver: async () => ({ type: 'org', id: crypto.randomUUID(), userId: 'user-1' }),
+      integrationGetter: async () => null,
+      repositoryFetcher,
+      agentConfigGetter: async () => null,
+      agentConfigUpserter: async () => undefined,
+      agentEnabledSetter: async () => undefined,
+      ticketOwnershipVerifier: () => true,
+    });
+
+    const result = await handlers.listGitHubRepositories({
+      ctx: { user: { id: 'user-1' } } as never,
+      input: {},
+    });
+
+    expect(result.repositories).toEqual(repositories);
+    expect(repositoryFetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/auto-triage/application/routers/shared-router-factory.ts
+++ b/apps/web/src/lib/auto-triage/application/routers/shared-router-factory.ts
@@ -45,6 +45,8 @@ type GitHubRepositoriesResult = {
     name: string;
     fullName: string;
     private: boolean;
+    platformIntegrationId?: string;
+    platformAccountLogin?: string;
   }[];
   errorMessage?: string;
 };

--- a/apps/web/src/lib/auto-triage/github/fetch-issue.test.ts
+++ b/apps/web/src/lib/auto-triage/github/fetch-issue.test.ts
@@ -1,0 +1,45 @@
+const mockGetIntegrationForOwner = jest.fn();
+const mockResolveOrganizationGitHubIntegrationForRepository = jest.fn();
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationForOwner: (...args: unknown[]) => mockGetIntegrationForOwner(...args),
+  resolveOrganizationGitHubIntegrationForRepository: (...args: unknown[]) =>
+    mockResolveOrganizationGitHubIntegrationForRepository(...args),
+}));
+
+import { resolveIssueIntegration } from './fetch-issue';
+
+describe('resolveIssueIntegration', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the exact organization integration resolved for the issue repository', async () => {
+    const integration = { id: 'secondary-integration', github_app_type: 'lite' };
+    mockResolveOrganizationGitHubIntegrationForRepository.mockResolvedValue({
+      success: true,
+      integration,
+    });
+
+    await expect(
+      resolveIssueIntegration({ type: 'org', id: 'org-1' }, 'acme-secondary/api')
+    ).resolves.toEqual({ success: true, integration });
+    expect(mockResolveOrganizationGitHubIntegrationForRepository).toHaveBeenCalledWith({
+      organizationId: 'org-1',
+      repositoryFullName: 'acme-secondary/api',
+    });
+    expect(mockGetIntegrationForOwner).not.toHaveBeenCalled();
+  });
+
+  it('preserves ambiguity instead of falling back to a primary installation', async () => {
+    mockResolveOrganizationGitHubIntegrationForRepository.mockResolvedValue({
+      success: false,
+      reason: 'ambiguous_installation',
+    });
+
+    await expect(
+      resolveIssueIntegration({ type: 'org', id: 'org-1' }, 'acme/api')
+    ).resolves.toEqual({ success: false, reason: 'ambiguous_installation' });
+    expect(mockGetIntegrationForOwner).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/auto-triage/github/fetch-issue.ts
+++ b/apps/web/src/lib/auto-triage/github/fetch-issue.ts
@@ -1,5 +1,5 @@
 /**
- * Fetch a GitHub issue via an owner's platform installation.
+ * Fetch a GitHub issue via an exact platform installation.
  *
  * Used by the admin "submit issue for triage" form to populate the
  * `issue_title` / `issue_body` / `issue_author` / `issue_labels` fields
@@ -8,9 +8,14 @@
  */
 
 import 'server-only';
-import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
-import type { Owner } from '../core';
+import type { PlatformIntegration } from '@kilocode/db/schema';
+import type { Owner as IntegrationOwner } from '@/lib/integrations/core/types';
+import {
+  getIntegrationForOwner,
+  resolveOrganizationGitHubIntegrationForRepository,
+  type OrganizationGitHubIntegrationResolution,
+} from '@/lib/integrations/db/platform-integrations';
+import { generateAutoTriageInstallationToken } from './installation-token';
 
 export type ParsedIssueUrl = {
   repoOwner: string;
@@ -56,28 +61,41 @@ export type FetchedIssue = {
   labels: string[];
 };
 
+export async function resolveIssueIntegration(
+  owner: IntegrationOwner,
+  repositoryFullName: string
+): Promise<OrganizationGitHubIntegrationResolution> {
+  if (owner.type === 'org') {
+    return resolveOrganizationGitHubIntegrationForRepository({
+      organizationId: owner.id,
+      repositoryFullName,
+    });
+  }
+
+  const integration = await getIntegrationForOwner(owner, 'github');
+  return integration
+    ? { success: true, integration }
+    : { success: false, reason: 'no_installation_found' };
+}
+
 /**
- * Fetch an issue via the GitHub REST API using the installation token
- * associated with the given owner. Returns the subset of fields we need
- * to build a triage ticket.
+ * Fetch an issue via the GitHub REST API using the resolved installation.
+ * Returns the subset of fields we need to build a triage ticket.
  *
  * Throws with a user-facing message for the common failure modes
  * (no installation, not found, etc.) so the admin UI can surface them.
  */
-export async function fetchIssueForOwner(owner: Owner, url: ParsedIssueUrl): Promise<FetchedIssue> {
-  const integration = await getIntegrationForOwner(owner, 'github');
-  if (!integration) {
-    throw new Error(
-      'No GitHub App installation found for this owner. Install the Kilo GitHub App first.'
-    );
-  }
+export async function fetchIssueForIntegration(
+  integration: PlatformIntegration,
+  url: ParsedIssueUrl
+): Promise<FetchedIssue> {
   if (!integration.platform_installation_id) {
     throw new Error(
       'GitHub integration is missing an installation id. Reinstall the Kilo GitHub App.'
     );
   }
 
-  const tokenData = await generateGitHubInstallationToken(integration.platform_installation_id);
+  const tokenData = await generateAutoTriageInstallationToken(integration);
 
   const apiUrl = `https://api.github.com/repos/${url.repoOwner}/${url.repoName}/issues/${url.issueNumber}`;
   const response = await fetch(apiUrl, {

--- a/apps/web/src/lib/auto-triage/github/installation-token.test.ts
+++ b/apps/web/src/lib/auto-triage/github/installation-token.test.ts
@@ -1,0 +1,24 @@
+import { generateAutoTriageInstallationToken } from './installation-token';
+
+describe('generateAutoTriageInstallationToken', () => {
+  it('mints retries with the pinned installation and app identity', async () => {
+    const generateToken = jest.fn().mockResolvedValue({
+      token: 'lite-token',
+      expires_at: '2099-01-01T00:00:00.000Z',
+    });
+
+    const integration = {
+      platform_installation_id: 'secondary-installation',
+      github_app_type: 'lite' as const,
+    };
+
+    await expect(generateAutoTriageInstallationToken(integration, generateToken)).resolves.toEqual({
+      token: 'lite-token',
+      expires_at: '2099-01-01T00:00:00.000Z',
+    });
+    await generateAutoTriageInstallationToken(integration, generateToken);
+
+    expect(generateToken).toHaveBeenNthCalledWith(1, 'secondary-installation', 'lite');
+    expect(generateToken).toHaveBeenNthCalledWith(2, 'secondary-installation', 'lite');
+  });
+});

--- a/apps/web/src/lib/auto-triage/github/installation-token.ts
+++ b/apps/web/src/lib/auto-triage/github/installation-token.ts
@@ -1,0 +1,25 @@
+import type { PlatformIntegration } from '@kilocode/db/schema';
+import type { InstallationToken } from '@/lib/integrations/core/types';
+import {
+  generateGitHubInstallationToken,
+  type GitHubAppType,
+} from '@/lib/integrations/platforms/github/adapter';
+
+type InstallationTokenGenerator = (
+  installationId: string,
+  appType: GitHubAppType
+) => Promise<InstallationToken>;
+
+export async function generateAutoTriageInstallationToken(
+  integration: Pick<PlatformIntegration, 'platform_installation_id' | 'github_app_type'>,
+  generateToken: InstallationTokenGenerator = generateGitHubInstallationToken
+) {
+  if (!integration.platform_installation_id) {
+    throw new Error('GitHub integration is missing an installation id.');
+  }
+
+  return generateToken(
+    integration.platform_installation_id,
+    integration.github_app_type ?? 'standard'
+  );
+}

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -8,6 +8,7 @@ const mockGetIntegrationForOrganization = jest.fn();
 const mockLogWebhookEvent = jest.fn();
 const mockUpdateWebhookEvent = jest.fn();
 const mockHandlePullRequest = jest.fn();
+const mockHandleIssue = jest.fn();
 const mockHandlePRReviewComment = jest.fn();
 const mockHandleGitHubReviewCommentReply = jest.fn();
 const mockHandleInstallationTargetRenamed = jest.fn();
@@ -16,6 +17,10 @@ const mockHandleInstallationDeleted = jest.fn();
 const mockHandleInstallationSuspend = jest.fn();
 const mockHandleInstallationUnsuspend = jest.fn();
 const mockHandleInstallationRepositories = jest.fn();
+
+jest.mock('@/lib/utils.server', () => ({
+  logExceptInTest: jest.fn(),
+}));
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   verifyGitHubWebhookSignature: (payload: string, signature: string, appType: string) =>
@@ -55,7 +60,8 @@ jest.mock('@/lib/integrations/platforms/github/webhook-handlers', () => ({
     mockHandleInstallationUnsuspend(payload, appType),
   handleInstallationTargetRenamed: (payload: unknown, integrationId: string, appType: string) =>
     mockHandleInstallationTargetRenamed(payload, integrationId, appType),
-  handleIssue: jest.fn(),
+  handleIssue: (payload: unknown, platformIntegration: unknown) =>
+    mockHandleIssue(payload, platformIntegration),
   handlePRReviewComment: (payload: unknown, platformIntegration: unknown) =>
     mockHandlePRReviewComment(payload, platformIntegration),
   handlePullRequest: (payload: unknown, platformIntegration: unknown) =>
@@ -184,6 +190,30 @@ function issueCommentPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function issuePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'opened',
+    installation: { id: 98765 },
+    repository: {
+      id: 123,
+      name: 'widgets',
+      full_name: 'acme/widgets',
+      private: false,
+      owner: { login: 'acme' },
+    },
+    issue: {
+      number: 7,
+      html_url: 'https://github.com/acme/widgets/issues/7',
+      title: 'Broken widget',
+      body: 'The widget is broken.',
+      user: { login: 'alice', type: 'User' },
+      labels: [],
+    },
+    sender: { login: 'alice', type: 'User' },
+    ...overrides,
+  };
+}
+
 async function waitForAfterTask() {
   await new Promise(resolve => setTimeout(resolve, 0));
 }
@@ -197,6 +227,7 @@ describe('handleGitHubWebhook', () => {
     mockLogWebhookEvent.mockResolvedValue({ id: 'we_1', isDuplicate: false });
     mockUpdateWebhookEvent.mockResolvedValue(undefined);
     mockHandlePullRequest.mockResolvedValue(Response.json({ message: 'review queued' }));
+    mockHandleIssue.mockResolvedValue(Response.json({ message: 'triage queued' }));
     mockHandlePRReviewComment.mockResolvedValue(undefined);
     mockHandleGitHubReviewCommentReply.mockResolvedValue({
       recorded: false,
@@ -336,6 +367,31 @@ describe('handleGitHubWebhook', () => {
       'we_1',
       expect.objectContaining({ handlers_triggered: ['code_review', 'cli_session_pr_upsert'] })
     );
+  });
+
+  it('pins secondary installation issue events to the receiving integration', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'pi_primary' });
+    const payload = issuePayload();
+
+    const response = await handleGitHubWebhook(signedGitHubRequest('issues', payload), 'lite');
+
+    expect(response.status).toBe(200);
+    expect(mockHandleIssue).toHaveBeenCalledWith(expect.objectContaining(payload), integration);
+  });
+
+  it('does not enable Auto Fix labeled events for secondary installations', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'pi_primary' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest(
+        'issues',
+        issuePayload({ action: 'labeled', label: { name: 'kilo-auto-fix' } })
+      ),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockHandleIssue).not.toHaveBeenCalled();
   });
 
   it('keeps pull_request_review_comment created events on the legacy auto-fix path', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -466,7 +466,15 @@ export async function handleGitHubWebhook(
       ? await getIntegrationForOrganization(integration.owned_by_organization_id, PLATFORM.GITHUB)
       : integration;
     const isSecondaryOrganizationInstallation = primaryIntegration?.id !== integration.id;
-    if (isSecondaryOrganizationInstallation && eventType !== GITHUB_EVENT.PULL_REQUEST) {
+    const action = (payload as { action?: string }).action;
+    const isAutoTriageIssueEvent =
+      eventType === GITHUB_EVENT.ISSUES &&
+      (action === GITHUB_ACTION.OPENED || action === GITHUB_ACTION.REOPENED);
+    if (
+      isSecondaryOrganizationInstallation &&
+      eventType !== GITHUB_EVENT.PULL_REQUEST &&
+      !isAutoTriageIssueEvent
+    ) {
       logExceptInTest('Secondary GitHub installation event suppressed', {
         integration_id: integration.id,
         event_type: eventType,

--- a/apps/web/src/routers/auto-triage/auto-triage-router.ts
+++ b/apps/web/src/routers/auto-triage/auto-triage-router.ts
@@ -34,9 +34,12 @@ import {
 } from '@/lib/auto-triage/db/triage-tickets';
 import { getAgentConfig, upsertAgentConfig } from '@/lib/agent-config/db/agent-configs';
 import { DEFAULT_AUTO_TRIAGE_CONFIG } from '@/lib/auto-triage';
-import { parseGitHubIssueUrl, fetchIssueForOwner } from '@/lib/auto-triage/github/fetch-issue';
+import {
+  parseGitHubIssueUrl,
+  fetchIssueForIntegration,
+  resolveIssueIntegration,
+} from '@/lib/auto-triage/github/fetch-issue';
 import { tryDispatchPendingTickets } from '@/lib/auto-triage/dispatch/dispatch-pending-tickets';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 
 export const autoTriageRouter = createTRPCRouter({
@@ -354,20 +357,24 @@ export const autoTriageRouter = createTRPCRouter({
       // For orgs we mirror issue-webhook-processor.resolveOwner() by
       // preferring the bot user id with a fallback to the integration
       // creator. For personal we use the admin's own user id.
+      const integrationOwner =
+        input.owner.type === 'org'
+          ? { type: 'org' as const, id: input.owner.organizationId }
+          : { type: 'user' as const, id: ctx.user.id };
+      const resolution = await resolveIssueIntegration(integrationOwner, parsedUrl.repoFullName);
+      if (!resolution.success) {
+        throw new TRPCError({
+          code: resolution.reason === 'ambiguous_installation' ? 'CONFLICT' : 'PRECONDITION_FAILED',
+          message:
+            resolution.reason === 'ambiguous_installation'
+              ? 'Multiple GitHub App installations can access this repository. Update the installations so exactly one has access.'
+              : 'No GitHub App installation for this owner can access this repository.',
+        });
+      }
+      const integration = resolution.integration;
+
       let owner: Owner;
       if (input.owner.type === 'org') {
-        // `getIntegrationForOwner` takes the integrations-module `Owner`
-        // which only needs { type, id } — don't synthesise a userId here.
-        const integration = await getIntegrationForOwner(
-          { type: 'org', id: input.owner.organizationId },
-          'github'
-        );
-        if (!integration) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'No GitHub App installation found for this organization.',
-          });
-        }
         const botUserId = await getBotUserId(input.owner.organizationId, 'auto-triage');
         const fallbackUserId = botUserId ?? integration.kilo_requester_user_id;
         if (!fallbackUserId) {
@@ -389,7 +396,7 @@ export const autoTriageRouter = createTRPCRouter({
       // Pull title/body/labels from GitHub via the owner's installation.
       let issue;
       try {
-        issue = await fetchIssueForOwner(owner, parsedUrl);
+        issue = await fetchIssueForIntegration(integration, parsedUrl);
       } catch (error) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -397,13 +404,9 @@ export const autoTriageRouter = createTRPCRouter({
         });
       }
 
-      // Look up the integration again for owner.type==='user' to attach
-      // platformIntegrationId on the ticket for parity with the webhook path.
-      const integration = await getIntegrationForOwner(owner, 'github');
-
       const ticketId = await createTriageTicket({
         owner,
-        platformIntegrationId: integration?.id,
+        platformIntegrationId: integration.id,
         repoFullName: parsedUrl.repoFullName,
         issueNumber: parsedUrl.issueNumber,
         issueUrl: parsedUrl.issueUrl,

--- a/apps/web/src/routers/organizations/organization-auto-triage-router.ts
+++ b/apps/web/src/routers/organizations/organization-auto-triage-router.ts
@@ -11,7 +11,7 @@ import {
   upsertAgentConfig,
   setAgentEnabled,
 } from '@/lib/agent-config/db/agent-configs';
-import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
+import { fetchAllGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
 import { createAutoTriageRouter } from '@/lib/auto-triage/application/routers/shared-router-factory';
 import { ensureBotUserForOrg } from '@/lib/bot-users/bot-user-service';
 
@@ -51,7 +51,7 @@ const sharedHandlers = createAutoTriageRouter({
         errorMessage: 'Invalid owner type',
       };
     }
-    return await fetchGitHubRepositoriesForOrganization(owner.id);
+    return await fetchAllGitHubRepositoriesForOrganization(owner.id);
   },
 
   agentConfigGetter: async (owner, agentType, platform) => {

--- a/apps/web/src/tests/setup/__mocks__/lib/integrations/platforms/github/adapter.ts
+++ b/apps/web/src/tests/setup/__mocks__/lib/integrations/platforms/github/adapter.ts
@@ -9,7 +9,8 @@ export function verifyGitHubWebhookSignature(_payload: string, _signature: strin
 }
 
 export async function generateGitHubInstallationToken(
-  _installationId: string
+  _installationId: string,
+  _appType: GitHubAppType = 'standard'
 ): Promise<{ token: string; expires_at: string }> {
   return { token: `mock-token-${_installationId}`, expires_at: '2099-01-01T00:00:00.000Z' };
 }


### PR DESCRIPTION
## Why this PR exists

Auto Triage currently derives organization repositories and tokens from one GitHub installation. Issues opened on a secondary connected organization are suppressed, while manually submitted issue URLs can be fetched through an arbitrary matching installation. That means connecting another GitHub organization does not actually make Auto Triage work there, and overlapping access can cross credential boundaries.

This PR enables only the Auto Triage issue lifecycle after making ticket creation and all downstream GitHub calls carry exact installation identity.

## Place in the rollout

This is the Auto Triage product slice. Auto Fix uses different webhook actions and ticket behavior and remains isolated in #5572.

## Dependency

Depends on #5547 for unique repository-to-installation resolution. After #5547 merges, retarget this PR to `main`.

## What changes

- Aggregate Auto Triage repository configuration across healthy installations with account and integration provenance.
- Resolve manual issue URLs to exactly one installation before fetching or creating a ticket.
- Persist `platform_integration_id` on the ticket and use its app type for classification, comments, labels, and retries.
- Admit secondary `issues.opened` and `issues.reopened` events.

## What stays unchanged

- Secondary label events remain suppressed for Auto Fix.
- Ambiguous manual URLs fail with a conflict instead of choosing an installation.
- Personal Auto Triage behavior is unchanged.

## Why routes and internal callbacks change too

A triage ticket is asynchronous: webhook/manual creation, classification, comment, label, and retry can occur in different requests. Every stage must recover credentials from the persisted integration, or the initial correct choice is lost later.

## Review guide

Trace `platform_integration_id` from repository listing/manual resolution or webhook delivery into ticket creation, then inspect `installation-token.ts` use in internal routes. Finally review the narrow secondary-event predicate.

## Validation

- 5 focused suites, 34 tests
- Web typecheck and lint
- `git diff --check`

The standard DB-backed Jest harness was unavailable; focused tests used isolated mocks.