### PR TITLE
feat(webhooks): let each trigger choose its GitHub organization

### DIFF
--- a/apps/web/src/app/(app)/cloud/webhooks/[triggerId]/EditWebhookTriggerContent.tsx
+++ b/apps/web/src/app/(app)/cloud/webhooks/[triggerId]/EditWebhookTriggerContent.tsx
@@ -40,6 +40,9 @@ export function EditWebhookTriggerContent({
 
   // Build URLs based on context
   const routes = getWebhookRoutes(organizationId);
+  const integrationsPath = organizationId
+    ? `/organizations/${organizationId}/integrations`
+    : '/integrations';
 
   // Fetch trigger configuration
   const {
@@ -81,6 +84,8 @@ export function EditWebhookTriggerContent({
       fullName: repo.fullName,
       private: repo.private,
       platform: 'github' as const,
+      platformIntegrationId: repo.platformIntegrationId,
+      platformAccountLogin: repo.platformAccountLogin,
     }));
   }, [githubRepoData?.repositories]);
 
@@ -106,6 +111,7 @@ export function EditWebhookTriggerContent({
       cronExpression: triggerData.cronExpression,
       cronTimezone: triggerData.cronTimezone,
       githubRepo: triggerData.githubRepo ?? '',
+      githubIntegrationId: triggerData.githubIntegrationId ?? undefined,
       mode: (triggerData.mode ?? 'code') as AgentMode,
       model: triggerData.model ?? '',
       promptTemplate: triggerData.promptTemplate,
@@ -161,6 +167,7 @@ export function EditWebhookTriggerContent({
         model: formData.model,
         promptTemplate: formData.promptTemplate,
         profileId: formData.profileId,
+        githubIntegrationId: formData.githubIntegrationId,
         autoCommit: formData.autoCommit ?? null,
         condenseOnComplete: formData.condenseOnComplete ?? null,
         isActive: formData.isActive,
@@ -376,6 +383,7 @@ export function EditWebhookTriggerContent({
           repositories={repositories}
           isLoadingRepositories={isLoadingRepos}
           repositoriesError={repoError?.message}
+          integrationsPath={integrationsPath}
           models={modelOptions}
           isLoadingModels={isLoadingModels}
           onSubmit={handleSubmit}

--- a/apps/web/src/app/(app)/cloud/webhooks/new/CreateWebhookTriggerContent.tsx
+++ b/apps/web/src/app/(app)/cloud/webhooks/new/CreateWebhookTriggerContent.tsx
@@ -67,6 +67,8 @@ export function CreateWebhookTriggerContent({ organizationId }: CreateWebhookTri
       fullName: repo.fullName,
       private: repo.private,
       platform: 'github' as const,
+      platformIntegrationId: repo.platformIntegrationId,
+      platformAccountLogin: repo.platformAccountLogin,
     }));
   }, [githubRepoData?.repositories]);
 
@@ -114,6 +116,7 @@ export function CreateWebhookTriggerContent({ organizationId }: CreateWebhookTri
         cronExpression: formData.cronExpression,
         cronTimezone: formData.cronTimezone,
         githubRepo: formData.githubRepo,
+        githubIntegrationId: formData.githubIntegrationId,
         mode: formData.mode,
         model: formData.model,
         promptTemplate: formData.promptTemplate,
@@ -199,6 +202,7 @@ export function CreateWebhookTriggerContent({ organizationId }: CreateWebhookTri
         repositories={repositories}
         isLoadingRepositories={isLoadingRepos}
         repositoriesError={repoError?.message}
+        integrationsPath={integrationsPath}
         models={modelOptions}
         isLoadingModels={isLoadingModels}
         onSubmit={handleSubmit}

--- a/apps/web/src/components/webhook-triggers/GitHubRepositorySelector.test.ts
+++ b/apps/web/src/components/webhook-triggers/GitHubRepositorySelector.test.ts
@@ -1,0 +1,24 @@
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { UnavailablePinnedGitHubInstallation } from './GitHubRepositorySelector';
+
+describe('GitHubRepositorySelector', () => {
+  it('shows an actionable warning for an unavailable saved installation', () => {
+    const html = renderToStaticMarkup(
+      createElement(UnavailablePinnedGitHubInstallation, {
+        selection: {
+          repository: 'acme/api',
+          platformIntegrationId: '11111111-1111-4111-8111-111111111111',
+          platformAccountLogin: 'acme',
+        },
+        integrationsPath: '/organizations/org-1/integrations',
+      })
+    );
+
+    expect(html).toContain('Saved GitHub installation unavailable');
+    expect(html).toContain('the acme installation');
+    expect(html).toContain('acme/api');
+    expect(html).toContain('href="/organizations/org-1/integrations"');
+    expect(html).toContain('Review GitHub integrations');
+  });
+});

--- a/apps/web/src/components/webhook-triggers/GitHubRepositorySelector.tsx
+++ b/apps/web/src/components/webhook-triggers/GitHubRepositorySelector.tsx
@@ -1,0 +1,219 @@
+'use client';
+
+import Link from 'next/link';
+import { useRef, useState } from 'react';
+import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Skeleton } from '@/components/ui/skeleton';
+import type { RepositoryOption } from '@/components/shared/RepositoryCombobox';
+import { cn } from '@/lib/utils';
+import { AlertTriangle, Check, ChevronsUpDown, Lock, Unlock } from 'lucide-react';
+import {
+  findSelectedRepository,
+  groupGitHubRepositories,
+  isSelectedRepository,
+  repositorySelection,
+  shortIntegrationId,
+  type GitHubRepositorySelection,
+} from './github-repository-selection';
+
+type GitHubRepositorySelectorProps = {
+  repositories: RepositoryOption[];
+  value: GitHubRepositorySelection;
+  onValueChange: (value: GitHubRepositorySelection) => void;
+  isLoading?: boolean;
+  error?: string;
+  repositoryReadOnly?: boolean;
+  integrationsPath: string;
+};
+
+type GitHubRepositorySelectorListProps = Pick<
+  GitHubRepositorySelectorProps,
+  'repositories' | 'value' | 'onValueChange'
+>;
+
+export function GitHubRepositorySelectorList({
+  repositories,
+  value,
+  onValueChange,
+}: GitHubRepositorySelectorListProps) {
+  return groupGitHubRepositories(repositories).map(group => (
+    <CommandGroup key={group.key} heading={group.label}>
+      {group.repositories.map(repository => (
+        <CommandItem
+          key={`${group.key}:${repository.id}:${repository.fullName}`}
+          value={`${repository.fullName} ${repository.platformAccountLogin ?? ''} ${repository.platformIntegrationId ?? ''}`}
+          onSelect={() => onValueChange(repositorySelection(repository))}
+          className="flex items-center gap-2"
+        >
+          {repository.private ? (
+            <Lock className="size-3.5 text-yellow-500" />
+          ) : (
+            <Unlock className="text-muted-foreground size-3.5" />
+          )}
+          <span className="truncate font-mono">{repository.fullName}</span>
+          <Check
+            className={cn(
+              'ml-auto size-4',
+              isSelectedRepository(repository, value) ? 'opacity-100' : 'opacity-0'
+            )}
+          />
+        </CommandItem>
+      ))}
+    </CommandGroup>
+  ));
+}
+
+export function UnavailablePinnedGitHubInstallation({
+  selection,
+  integrationsPath,
+}: {
+  selection: GitHubRepositorySelection;
+  integrationsPath: string;
+}) {
+  const installation = selection.platformAccountLogin
+    ? `the ${selection.platformAccountLogin} installation`
+    : selection.platformIntegrationId
+      ? `installation ${shortIntegrationId(selection.platformIntegrationId)}`
+      : 'the saved installation';
+
+  return (
+    <Alert variant="warning">
+      <AlertTriangle />
+      <AlertTitle>Saved GitHub installation unavailable</AlertTitle>
+      <AlertDescription>
+        <p>
+          This trigger is pinned to {installation}, which no longer provides access to{' '}
+          <span className="font-mono">{selection.repository}</span>. Restore it or choose another
+          installation with access to this repository.
+        </p>
+        <Link
+          href={integrationsPath}
+          className="text-link hover:text-link-hover font-medium underline underline-offset-4"
+        >
+          Review GitHub integrations
+        </Link>
+      </AlertDescription>
+    </Alert>
+  );
+}
+
+export function GitHubRepositorySelector({
+  repositories,
+  value,
+  onValueChange,
+  isLoading,
+  error,
+  repositoryReadOnly = false,
+  integrationsPath,
+}: GitHubRepositorySelectorProps) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const candidates = repositoryReadOnly
+    ? repositories.filter(repository => repository.fullName === value.repository)
+    : repositories;
+  const selectedRepository = findSelectedRepository(repositories, value);
+  const pinnedInstallationUnavailable =
+    value.platformIntegrationId !== undefined && selectedRepository === undefined;
+
+  if (isLoading) {
+    return <Skeleton className="h-9 w-full" />;
+  }
+
+  if (error) {
+    return (
+      <div
+        role="alert"
+        className="border-destructive/50 bg-destructive/10 text-destructive rounded-md border px-3 py-2 text-sm"
+      >
+        GitHub repositories could not be loaded: {error}
+      </div>
+    );
+  }
+
+  const accountLabel =
+    selectedRepository?.platformAccountLogin ??
+    value.platformAccountLogin ??
+    selectedRepository?.fullName.split('/')[0] ??
+    'GitHub installation';
+  const buttonLabel = repositoryReadOnly
+    ? selectedRepository
+      ? accountLabel
+      : 'Choose another installation'
+    : selectedRepository
+      ? `${selectedRepository.fullName} · ${accountLabel}`
+      : 'Select a repository';
+
+  return (
+    <div className="space-y-2">
+      {pinnedInstallationUnavailable && (
+        <UnavailablePinnedGitHubInstallation
+          selection={value}
+          integrationsPath={integrationsPath}
+        />
+      )}
+      {candidates.length > 0 ? (
+        <Popover open={open} onOpenChange={setOpen}>
+          <PopoverTrigger asChild>
+            <Button
+              ref={triggerRef}
+              type="button"
+              variant="outline"
+              role="combobox"
+              aria-expanded={open}
+              aria-label={repositoryReadOnly ? 'Select GitHub installation' : 'Select repository'}
+              className="w-full justify-between"
+            >
+              <span className="truncate text-left">{buttonLabel}</span>
+              <ChevronsUpDown className="ml-2 size-4 shrink-0 opacity-50" />
+            </Button>
+          </PopoverTrigger>
+          <PopoverContent
+            className="p-0"
+            align="start"
+            style={{ width: triggerRef.current?.offsetWidth }}
+          >
+            <Command>
+              <CommandInput placeholder="Search GitHub repositories..." />
+              <CommandEmpty>No repositories match your search</CommandEmpty>
+              <CommandList className="max-h-64 overflow-auto">
+                <GitHubRepositorySelectorList
+                  repositories={candidates}
+                  value={value}
+                  onValueChange={selection => {
+                    onValueChange(selection);
+                    setOpen(false);
+                  }}
+                />
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+      ) : !pinnedInstallationUnavailable ? (
+        <div className="border-border bg-muted/50 text-muted-foreground rounded-md border px-3 py-2 text-sm">
+          No GitHub repositories are available.{' '}
+          <Link
+            href={integrationsPath}
+            className="text-link hover:text-link-hover underline underline-offset-4"
+          >
+            Review GitHub integrations
+          </Link>
+        </div>
+      ) : null}
+      <p className="text-muted-foreground text-xs">
+        {repositoryReadOnly
+          ? 'Choose the GitHub App installation used when this trigger runs.'
+          : 'Repositories are grouped by the GitHub account where the Kilo App is installed.'}
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/components/webhook-triggers/TriggerForm.tsx
+++ b/apps/web/src/components/webhook-triggers/TriggerForm.tsx
@@ -9,7 +9,7 @@ import { Textarea } from '@/components/ui/textarea';
 import { Switch } from '@/components/ui/switch';
 import { Checkbox } from '@/components/ui/checkbox';
 import { ProfileSelector } from '@/components/cloud-agent/ProfileSelector';
-import { RepositoryCombobox, type RepositoryOption } from '@/components/shared/RepositoryCombobox';
+import type { RepositoryOption } from '@/components/shared/RepositoryCombobox';
 import { ModeCombobox } from '@/components/shared/ModeCombobox';
 import { ModelCombobox, type ModelOption } from '@/components/shared/ModelCombobox';
 import { InlineDeleteConfirmation } from '@/components/ui/inline-delete-confirmation';
@@ -33,6 +33,11 @@ import { cn } from '@/lib/utils';
 import { AlertCircle, Check, Clock, Copy, Loader2, Webhook } from 'lucide-react';
 import { toast } from 'sonner';
 import type { AgentMode } from '@/components/cloud-agent/types';
+import { GitHubRepositorySelector } from './GitHubRepositorySelector';
+import {
+  findSelectedRepository,
+  type GitHubRepositorySelection,
+} from './github-repository-selection';
 
 export type TriggerFormData = {
   triggerId: string;
@@ -40,6 +45,8 @@ export type TriggerFormData = {
   cronExpression?: string;
   cronTimezone?: string;
   githubRepo: string;
+  githubIntegrationId?: string;
+  githubAccountLogin?: string;
   mode: AgentMode;
   model: string;
   promptTemplate: string;
@@ -63,6 +70,8 @@ export type TriggerFormProps = {
     cronExpression?: string | null;
     cronTimezone?: string | null;
     githubRepo: string;
+    githubIntegrationId?: string;
+    githubAccountLogin?: string;
     mode: AgentMode;
     model: string;
     promptTemplate: string;
@@ -77,6 +86,7 @@ export type TriggerFormProps = {
   repositories: RepositoryOption[];
   isLoadingRepositories?: boolean;
   repositoriesError?: string;
+  integrationsPath: string;
   /** Models available for selection (should be fetched by parent) */
   models: ModelOption[];
   isLoadingModels?: boolean;
@@ -105,6 +115,7 @@ export function TriggerForm({
   repositories,
   isLoadingRepositories,
   repositoriesError,
+  integrationsPath,
   models,
   isLoadingModels,
   onSubmit,
@@ -127,6 +138,8 @@ export function TriggerForm({
   const [triggerId, setTriggerId] = useState(initialData?.triggerId ?? '');
   const [triggerIdError, setTriggerIdError] = useState<string | null>(null);
   const [githubRepo, setGithubRepo] = useState(initialData?.githubRepo ?? '');
+  const [githubIntegrationId, setGithubIntegrationId] = useState(initialData?.githubIntegrationId);
+  const [githubAccountLogin, setGithubAccountLogin] = useState(initialData?.githubAccountLogin);
   const [agentMode, setAgentMode] = useState<AgentMode>((initialData?.mode as AgentMode) ?? 'ask');
   const [model, setModel] = useState(initialData?.model ?? '');
   const WEBHOOK_DEFAULT_PROMPT = 'Describe this webhook request payload:\n\n{{body}}';
@@ -156,6 +169,10 @@ export function TriggerForm({
       setCronTimezone(initialData.cronTimezone ?? Intl.DateTimeFormat().resolvedOptions().timeZone);
       setTriggerId(initialData.triggerId);
       setGithubRepo(initialData.githubRepo);
+      setGithubIntegrationId(initialData.githubIntegrationId);
+      if (initialData.githubAccountLogin !== undefined) {
+        setGithubAccountLogin(initialData.githubAccountLogin);
+      }
       setAgentMode(initialData.mode ?? 'ask');
       setModel(initialData.model);
       setPromptTemplate(initialData.promptTemplate);
@@ -172,6 +189,26 @@ export function TriggerForm({
     }
     setWebhookAuthSecret('');
   }, [initialData]);
+
+  const githubSelection: GitHubRepositorySelection = {
+    repository: githubRepo,
+    platformIntegrationId: githubIntegrationId,
+    platformAccountLogin: githubAccountLogin,
+  };
+
+  const handleGitHubSelectionChange = useCallback((selection: GitHubRepositorySelection) => {
+    setGithubRepo(selection.repository);
+    setGithubIntegrationId(selection.platformIntegrationId);
+    setGithubAccountLogin(selection.platformAccountLogin);
+  }, []);
+
+  useEffect(() => {
+    if (githubAccountLogin || !githubIntegrationId) return;
+    const account = repositories.find(
+      repository => repository.platformIntegrationId === githubIntegrationId
+    )?.platformAccountLogin;
+    if (account) setGithubAccountLogin(account);
+  }, [githubAccountLogin, githubIntegrationId, repositories]);
 
   // Update default prompt when activation mode toggles (create mode only)
   useEffect(() => {
@@ -264,6 +301,23 @@ export function TriggerForm({
       errors.push('Repository is required');
     }
 
+    if (organizationId && !githubIntegrationId) {
+      errors.push('GitHub installation is required');
+    }
+
+    if (
+      organizationId &&
+      githubIntegrationId &&
+      !isLoadingRepositories &&
+      !repositoriesError &&
+      !findSelectedRepository(repositories, {
+        repository: githubRepo,
+        platformIntegrationId: githubIntegrationId,
+      })
+    ) {
+      errors.push('The saved GitHub installation is unavailable');
+    }
+
     if (!model) {
       errors.push('Model is required');
     }
@@ -291,6 +345,11 @@ export function TriggerForm({
     isScheduled,
     cronExpression,
     githubRepo,
+    organizationId,
+    githubIntegrationId,
+    isLoadingRepositories,
+    repositoriesError,
+    repositories,
     model,
     promptTemplate,
     profileId,
@@ -325,6 +384,8 @@ export function TriggerForm({
         cronExpression: isScheduled ? cronExpression.trim() : undefined,
         cronTimezone: isScheduled ? cronTimezone : undefined,
         githubRepo,
+        githubIntegrationId,
+        githubAccountLogin,
         mode: agentMode,
         model,
         promptTemplate: promptTemplate.trim(),
@@ -345,6 +406,8 @@ export function TriggerForm({
       cronTimezone,
       isScheduled,
       githubRepo,
+      githubIntegrationId,
+      githubAccountLogin,
       agentMode,
       model,
       promptTemplate,
@@ -470,7 +533,7 @@ export function TriggerForm({
               <Label>
                 Repository <span className="text-red-400">*</span>
               </Label>
-              {isEditMode ? (
+              {isEditMode && (
                 <>
                   <div className="bg-muted truncate rounded-md border px-3 py-2 font-mono text-sm">
                     {githubRepo || 'No repository selected'}
@@ -479,18 +542,16 @@ export function TriggerForm({
                     Repository cannot be changed after creation
                   </p>
                 </>
-              ) : (
-                <RepositoryCombobox
-                  repositories={repositories}
-                  value={githubRepo}
-                  onValueChange={setGithubRepo}
-                  isLoading={isLoadingRepositories}
-                  error={repositoriesError}
-                  placeholder="Select a repository"
-                  emptyStateText="Requires a GitHub integration — configure in Integrations"
-                  hideLabel
-                />
               )}
+              <GitHubRepositorySelector
+                repositories={repositories}
+                value={githubSelection}
+                onValueChange={handleGitHubSelectionChange}
+                isLoading={isLoadingRepositories}
+                error={repositoriesError}
+                repositoryReadOnly={isEditMode}
+                integrationsPath={integrationsPath}
+              />
             </div>
 
             {/* Mode and Model Row */}
@@ -697,7 +758,7 @@ export function TriggerForm({
               <div className="flex gap-2">
                 <Button
                   type="submit"
-                  disabled={!isFormValid || isLoading}
+                  disabled={!isFormValid || isLoading || isLoadingRepositories}
                   className="min-w-[120px]"
                 >
                   {isLoading && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}

--- a/apps/web/src/components/webhook-triggers/github-repository-selection.test.ts
+++ b/apps/web/src/components/webhook-triggers/github-repository-selection.test.ts
@@ -1,0 +1,62 @@
+import {
+  findSelectedRepository,
+  groupGitHubRepositories,
+  repositorySelection,
+} from './github-repository-selection';
+import type { RepositoryOption } from '@/components/shared/RepositoryCombobox';
+
+const repositories: RepositoryOption[] = [
+  {
+    id: 1,
+    fullName: 'acme/api',
+    platform: 'github',
+    platformIntegrationId: '11111111-1111-4111-8111-111111111111',
+    platformAccountLogin: 'acme',
+  },
+  {
+    id: 1,
+    fullName: 'acme/api',
+    platform: 'github',
+    platformIntegrationId: '22222222-2222-4222-8222-222222222222',
+    platformAccountLogin: 'acme',
+  },
+  {
+    id: 2,
+    fullName: 'octo/docs',
+    platform: 'github',
+    platformIntegrationId: '33333333-3333-4333-8333-333333333333',
+    platformAccountLogin: 'octo',
+  },
+];
+
+describe('GitHub repository selection', () => {
+  it('groups by installation account and distinguishes duplicate account installations', () => {
+    expect(groupGitHubRepositories(repositories).map(group => group.label)).toEqual([
+      'acme (11111111)',
+      'acme (22222222)',
+      'octo',
+    ]);
+  });
+
+  it('keeps repository, integration ID, and account together in selection state', () => {
+    expect(repositorySelection(repositories[0])).toEqual({
+      repository: 'acme/api',
+      platformIntegrationId: '11111111-1111-4111-8111-111111111111',
+      platformAccountLogin: 'acme',
+    });
+  });
+
+  it('does not switch an unavailable pin to another installation with the same repository', () => {
+    expect(
+      findSelectedRepository(repositories, {
+        repository: 'acme/api',
+        platformIntegrationId: '44444444-4444-4444-8444-444444444444',
+      })
+    ).toBeUndefined();
+  });
+
+  it('does not guess when a legacy unpinned repository is duplicated', () => {
+    expect(findSelectedRepository(repositories, { repository: 'acme/api' })).toBeUndefined();
+    expect(findSelectedRepository(repositories, { repository: 'octo/docs' })).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/webhook-triggers/github-repository-selection.ts
+++ b/apps/web/src/components/webhook-triggers/github-repository-selection.ts
@@ -1,0 +1,84 @@
+import type { RepositoryOption } from '@/components/shared/RepositoryCombobox';
+
+export type GitHubRepositorySelection = {
+  repository: string;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
+};
+
+export type GitHubRepositoryGroup = {
+  key: string;
+  label: string;
+  repositories: RepositoryOption[];
+};
+
+export function shortIntegrationId(platformIntegrationId: string): string {
+  return platformIntegrationId.slice(0, 8);
+}
+
+export function repositorySelection(option: RepositoryOption): GitHubRepositorySelection {
+  return {
+    repository: option.fullName,
+    platformIntegrationId: option.platformIntegrationId,
+    platformAccountLogin: option.platformAccountLogin,
+  };
+}
+
+export function isSelectedRepository(
+  option: RepositoryOption,
+  selection: GitHubRepositorySelection
+): boolean {
+  return (
+    option.fullName === selection.repository &&
+    option.platformIntegrationId === selection.platformIntegrationId
+  );
+}
+
+export function findSelectedRepository(
+  repositories: RepositoryOption[],
+  selection: GitHubRepositorySelection
+): RepositoryOption | undefined {
+  const matches = repositories.filter(option => isSelectedRepository(option, selection));
+  return matches.length === 1 ? matches[0] : undefined;
+}
+
+function repositoryAccount(option: RepositoryOption): string {
+  return option.platformAccountLogin ?? option.fullName.split('/')[0] ?? 'GitHub';
+}
+
+export function groupGitHubRepositories(repositories: RepositoryOption[]): GitHubRepositoryGroup[] {
+  const groups = new Map<
+    string,
+    { account: string; integrationId?: string; repositories: RepositoryOption[] }
+  >();
+
+  for (const repository of repositories) {
+    const account = repositoryAccount(repository);
+    const key = repository.platformIntegrationId ?? `account:${account.toLowerCase()}`;
+    const group = groups.get(key);
+    if (group) {
+      group.repositories.push(repository);
+    } else {
+      groups.set(key, {
+        account,
+        integrationId: repository.platformIntegrationId,
+        repositories: [repository],
+      });
+    }
+  }
+
+  const accountCounts = new Map<string, number>();
+  for (const group of groups.values()) {
+    const account = group.account.toLowerCase();
+    accountCounts.set(account, (accountCounts.get(account) ?? 0) + 1);
+  }
+
+  return [...groups.entries()].map(([key, group]) => ({
+    key,
+    label:
+      (accountCounts.get(group.account.toLowerCase()) ?? 0) > 1 && group.integrationId
+        ? `${group.account} (${shortIntegrationId(group.integrationId)})`
+        : group.account,
+    repositories: group.repositories,
+  }));
+}

--- a/apps/web/src/components/webhook-triggers/types.ts
+++ b/apps/web/src/components/webhook-triggers/types.ts
@@ -9,4 +9,6 @@ export type GitHubRepository = {
   id: number;
   fullName: string;
   private: boolean;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
 };


### PR DESCRIPTION
## Why this PR exists

#5564 gives webhook triggers a place to persist GitHub installation identity, but users still need a safe way to choose it. The current form identifies repositories by name, so duplicate repositories from different installations are indistinguishable and editing a trigger can silently switch to another installation.

This PR exposes the backend capability only after preserving repository + account + integration as one selection.

## Place in the rollout

This is the UI child of #5564. The split is intentional: #5564 makes storage and execution backward-compatible; this PR is the point where new triggers can actually target secondary GitHub organizations.

## Dependency

Depends on #5564. Merge and deploy the backend contract first, then retarget this PR to `main`.

## What changes

- Group trigger repositories by GitHub installation account.
- Distinguish duplicate accounts/installations.
- Preserve `platformIntegrationId` in create and edit form state.
- Submit the chosen integration with trigger mutations.
- If an edited trigger's pinned installation is missing, show an actionable warning and Integrations link instead of selecting another match.

## What stays unchanged

- Existing triggers without a pin still load through the backend compatibility path.
- Editing a trigger does not silently change its repository or installation.
- Trigger execution logic remains in #5564.

## Why this adds a selector component

The existing generic repository field cannot represent duplicate names or unavailable pinned values. The new component keeps that identity handling local to webhook forms rather than broadening a shared selector used by unrelated products.

## Review guide

Review `github-repository-selection.ts` first; it contains the pure grouping and stale-pin rules. Then verify `TriggerForm` sends the selected ID on both create and edit.

## Validation

- 2 focused selector suites, 5 tests
- Web typecheck and lint
- `git diff --check`

Browser testing was skipped because no local services were running.