### PR TITLE
feat(security): let users configure repositories from every GitHub org

### DIFF
--- a/apps/mobile/src/components/security-agent/repository-settings-screen.tsx
+++ b/apps/mobile/src/components/security-agent/repository-settings-screen.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { TabScreenScrollView } from '@/components/tab-screen';
 import { getGitHubIntegrationUrl } from '@/lib/agent-github-integration';
+import { i18n } from '@/i18n';
 import { WEB_BASE_URL } from '@/lib/config';
 import { openExternalUrl } from '@/lib/external-link';
 import { trpcClient } from '@/lib/trpc';
@@ -32,11 +33,21 @@ import {
   useSaveSecurityAgentConfig,
   useSecurityAgentCapability,
   useSecurityAgentConfig,
+  useSecurityAgentPermissionStatus,
   useSecurityAgentRepositories,
 } from '@/lib/hooks/use-security-agent';
 import { type FlattenedSecurityAgentConfig, type SecurityAgentConfig } from '@/lib/security-agent';
 
 type RepositorySelectionMode = SecurityAgentConfig['repositorySelectionMode'];
+
+function installationStatusLabel(input: { active: boolean; hasPermissions: boolean }): string {
+  if (!input.active) {
+    return i18n.t('securityAgent.dashboard.syncStatusUnavailable');
+  }
+  return input.hasPermissions
+    ? i18n.t('securityAgent.settingsOverview.enabled')
+    : i18n.t('securityAgent.scopeEntry.reauthorizeTitle');
+}
 
 function RepositorySettingsSkeleton() {
   const { t } = useTranslation();
@@ -58,6 +69,7 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
   const canManage = useSecurityAgentCapability(scope).canManage;
   const config = useSecurityAgentConfig(scope);
   const repositories = useSecurityAgentRepositories(scope);
+  const permission = useSecurityAgentPermissionStatus(scope);
   const save = useSaveSecurityAgentConfig(scope);
 
   const [mode, setMode] = useState<RepositorySelectionMode>('all');
@@ -120,6 +132,21 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
       current.includes(id) ? current.filter(existing => existing !== id) : [...current, id]
     );
   };
+  const repositoryGroups = new Map<
+    string,
+    { accountLogin: string | null; repositories: NonNullable<typeof repositories.data> }
+  >();
+  for (const repository of repositories.data ?? []) {
+    const group = repositoryGroups.get(repository.integrationId);
+    if (group) {
+      group.repositories.push(repository);
+    } else {
+      repositoryGroups.set(repository.integrationId, {
+        accountLogin: repository.accountLogin,
+        repositories: [repository],
+      });
+    }
+  }
 
   return (
     <View className="flex-1 bg-background">
@@ -162,6 +189,45 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
             />
           ))}
         </RadioGroup>
+
+        {(permission.data?.installations.length ?? 0) > 0 ? (
+          <View className="mt-6 rounded-lg bg-secondary px-3">
+            {permission.data?.installations.map((installation, index, installations) => (
+              <View
+                key={installation.integrationId}
+                className={`min-h-14 flex-row items-center justify-between gap-3 py-3 ${
+                  index < installations.length - 1 ? 'border-b-[0.5px] border-hair-soft' : ''
+                }`}
+              >
+                <View className="min-w-0 flex-1">
+                  <Text className="text-sm font-medium" numberOfLines={1}>
+                    {installation.accountLogin ?? installation.integrationId}
+                  </Text>
+                  <Text variant="muted" className="text-xs">
+                    {installationStatusLabel(installation)}
+                  </Text>
+                </View>
+                {installation.reauthorizeUrl ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onPress={() => {
+                      const reauthorizeUrl = installation.reauthorizeUrl;
+                      if (!reauthorizeUrl) {
+                        return;
+                      }
+                      void openExternalUrl(reauthorizeUrl, {
+                        label: t('securityAgent.scopeEntry.reauthorizeButton'),
+                      });
+                    }}
+                  >
+                    <Text>{t('securityAgent.scopeEntry.reauthorizeButton')}</Text>
+                  </Button>
+                ) : null}
+              </View>
+            ))}
+          </View>
+        ) : null}
 
         {mode === 'selected' && (
           <View className="mt-6">
@@ -219,17 +285,24 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
             ) : null}
             {!repositories.isLoading &&
               !repositories.isError &&
-              (repositories.data ?? []).map(repo => (
-                <RepoToggleRow
-                  key={repo.id}
-                  repo={repo}
-                  selected={selectedIds.includes(repo.id)}
-                  disabled={!canManage}
-                  className="border-b-[0.5px] border-hair-soft"
-                  onPress={() => {
-                    toggleRepo(repo.id);
-                  }}
-                />
+              [...repositoryGroups.entries()].map(([integrationId, group]) => (
+                <View key={integrationId} className="mb-4">
+                  <Text className="min-h-11 py-3 text-sm font-medium" numberOfLines={1}>
+                    {group.accountLogin ?? integrationId}
+                  </Text>
+                  {group.repositories.map(repo => (
+                    <RepoToggleRow
+                      key={`${integrationId}:${repo.id}`}
+                      repo={repo}
+                      selected={selectedIds.includes(repo.id)}
+                      disabled={!canManage}
+                      className="border-b-[0.5px] border-hair-soft"
+                      onPress={() => {
+                        toggleRepo(repo.id);
+                      }}
+                    />
+                  ))}
+                </View>
               ))}
             {!repositories.isLoading &&
               !repositories.isError &&

--- a/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
+++ b/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
@@ -14,6 +14,7 @@ export type Repository<TId extends RepositoryId = number> = {
   name: string;
   full_name: string;
   private: boolean;
+  group?: { id: string; label: string };
 };
 
 export type RepositoryMultiSelectProps<TId extends RepositoryId = number> = {
@@ -37,6 +38,16 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
     const query = searchQuery.toLowerCase();
     return repositories.filter(repo => repo.full_name.toLowerCase().includes(query));
   }, [repositories, searchQuery]);
+  const repositoryGroups = useMemo(() => {
+    const groups = new Map<string, { label: string; repositories: Repository<TId>[] }>();
+    for (const repository of filteredRepositories) {
+      const group = repository.group ?? { id: '', label: '' };
+      const current = groups.get(group.id);
+      if (current) current.repositories.push(repository);
+      else groups.set(group.id, { label: group.label, repositories: [repository] });
+    }
+    return [...groups.entries()];
+  }, [filteredRepositories]);
 
   const handleToggle = (repoId: TId) => {
     const newSelection = selectedIds.includes(repoId)
@@ -100,37 +111,46 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
               {searchQuery ? 'No repositories match your search' : 'No repositories available'}
             </div>
           ) : (
-            filteredRepositories.map(repo => {
-              const isChecked = selectedIds.includes(repo.id);
+            repositoryGroups.map(([groupId, group]) => (
+              <div key={groupId || 'repositories'} className="space-y-1">
+                {group.label ? (
+                  <div className="text-muted-foreground px-2 pt-1 pb-2 text-xs font-medium">
+                    {group.label}
+                  </div>
+                ) : null}
+                {group.repositories.map(repo => {
+                  const isChecked = selectedIds.includes(repo.id);
 
-              return (
-                <div
-                  key={repo.id}
-                  className={cn(
-                    'hover:bg-accent flex items-center gap-3 rounded-md p-2 transition-colors',
-                    isChecked && 'bg-accent text-accent-foreground'
-                  )}
-                >
-                  <Checkbox
-                    id={`repo-${repo.id}`}
-                    checked={isChecked}
-                    onCheckedChange={() => handleToggle(repo.id)}
-                  />
-                  <label
-                    htmlFor={`repo-${repo.id}`}
-                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-sm"
-                  >
-                    {repo.private ? (
-                      <Lock className="text-primary h-3.5 w-3.5 shrink-0" />
-                    ) : (
-                      <Unlock className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-                    )}
-                    <span className="truncate font-mono">{repo.full_name}</span>
-                    {renderRepositoryAccessory?.(repo)}
-                  </label>
-                </div>
-              );
-            })
+                  return (
+                    <div
+                      key={repo.id}
+                      className={cn(
+                        'hover:bg-accent flex items-center gap-3 rounded-md p-2 transition-colors',
+                        isChecked && 'bg-accent text-accent-foreground'
+                      )}
+                    >
+                      <Checkbox
+                        id={`repo-${repo.id}`}
+                        checked={isChecked}
+                        onCheckedChange={() => handleToggle(repo.id)}
+                      />
+                      <label
+                        htmlFor={`repo-${repo.id}`}
+                        className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-sm"
+                      >
+                        {repo.private ? (
+                          <Lock className="text-primary h-3.5 w-3.5 shrink-0" />
+                        ) : (
+                          <Unlock className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+                        )}
+                        <span className="truncate font-mono">{repo.full_name}</span>
+                        {renderRepositoryAccessory?.(repo)}
+                      </label>
+                    </div>
+                  );
+                })}
+              </div>
+            ))
           )}
         </div>
       </div>

--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -17,11 +17,14 @@ import {
   type SecurityCommandType,
 } from '@kilocode/app-shared/security-agent';
 import type { SecurityAgentUiInteraction } from '@/lib/security-agent/core/schemas';
-import type { DependabotAlertsAvailability } from '@/lib/security-agent/core/types';
 import { isGitHubIntegrationError } from '@/lib/security-agent/core/error-display';
 import type { DismissReason } from './DismissFindingDialog';
 import { getRemediationUnavailableCopy } from './remediation-unavailable-copy';
-import type { SlaConfig } from './security-config-types';
+import type {
+  SecurityInstallationStatus,
+  SecurityRepository,
+  SlaConfig,
+} from './security-config-types';
 import {
   getSecurityAgentCommandFailureTitle,
   getSecurityAgentDismissalTerminalTitle,
@@ -44,6 +47,7 @@ type SecurityAgentContextValue = {
   isLoadingPermission: boolean;
   isLoadingConfig: boolean;
   reauthorizeUrl: string | undefined;
+  installationStatuses: SecurityInstallationStatus[];
   isEnabled: boolean | undefined;
   hasConfig: boolean;
   configData:
@@ -82,20 +86,8 @@ type SecurityAgentContextValue = {
   refetchConfig: () => Promise<unknown>;
 
   // Repositories
-  allRepositories: Array<{
-    id: number;
-    fullName: string;
-    name: string;
-    private: boolean;
-    dependabotAlerts: DependabotAlertsAvailability;
-  }>;
-  filteredRepositories: Array<{
-    id: number;
-    fullName: string;
-    name: string;
-    private: boolean;
-    dependabotAlerts: DependabotAlertsAvailability;
-  }>;
+  allRepositories: SecurityRepository[];
+  filteredRepositories: SecurityRepository[];
 
   // Mutation handlers
   trackUiInteraction: (interaction: SecurityAgentUiInteraction) => void;
@@ -204,6 +196,7 @@ export function refetchConfigOnConflictError(
 
 const COMMAND_POLL_INTERVAL_MS = 3000;
 const EMPTY_REPOSITORIES: SecurityAgentContextValue['allRepositories'] = [];
+const EMPTY_INSTALLATION_STATUSES: SecurityInstallationStatus[] = [];
 const EMPTY_REPOSITORY_IDS: number[] = [];
 const EMPTY_ORPHANED_REPOSITORIES: SecurityAgentContextValue['orphanedRepositories'] = [];
 
@@ -1385,6 +1378,7 @@ function useSecurityAgentProviderValue(
   const hasPermission = permissionData?.hasPermissions ?? false;
   const integrationId = permissionData?.integrationId ?? null;
   const reauthorizeUrl = permissionData?.reauthorizeUrl ?? undefined;
+  const installationStatuses = permissionData?.installations ?? EMPTY_INSTALLATION_STATUSES;
   const isEnabled = configData ? configData.isEnabled : undefined;
   const hasConfig = configData?.hasConfig ?? false;
   const allRepositories = reposData ?? EMPTY_REPOSITORIES;
@@ -1413,6 +1407,7 @@ function useSecurityAgentProviderValue(
       isLoadingPermission,
       isLoadingConfig,
       reauthorizeUrl,
+      installationStatuses,
       isEnabled,
       hasConfig,
       configData: configData
@@ -1477,6 +1472,7 @@ function useSecurityAgentProviderValue(
       isLoadingPermission,
       isLoadingConfig,
       reauthorizeUrl,
+      installationStatuses,
       isEnabled,
       hasConfig,
       configData,

--- a/apps/web/src/components/security-agent/SecurityAgentLayout.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentLayout.tsx
@@ -302,6 +302,7 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
     hasIntegration,
     hasPermission,
     integrationId,
+    installationStatuses,
     isLoadingPermission,
     isLoadingConfig,
     isEnabled,
@@ -361,6 +362,9 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
   };
 
   const showPermissionRequired = hasIntegration && !hasPermission && !isLoadingPermission;
+  const installationsNeedingAttention = installationStatuses.filter(
+    installation => installation.active && !installation.hasPermissions
+  );
 
   function isActive(href: string) {
     if (href === basePath) {
@@ -462,6 +466,41 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
             </AlertDescription>
           </Alert>
         )}
+
+        {!showPermissionRequired && installationsNeedingAttention.length > 0 ? (
+          <Alert variant="warning">
+            <AlertTriangle className="size-4" aria-hidden="true" />
+            <AlertTitle>
+              {installationsNeedingAttention.length}{' '}
+              {installationsNeedingAttention.length === 1
+                ? 'installation needs'
+                : 'installations need'}{' '}
+              attention
+            </AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>
+                Healthy GitHub installations continue syncing. Update the affected installation
+                permissions to include its repositories.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {installationsNeedingAttention.map(installation =>
+                  installation.reauthorizeUrl ? (
+                    <Button key={installation.integrationId} variant="outline" size="sm" asChild>
+                      <a
+                        href={installation.reauthorizeUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <ExternalLink className="size-4" aria-hidden="true" />
+                        Re-authorize {installation.accountLogin ?? 'GitHub App'}
+                      </a>
+                    </Button>
+                  ) : null
+                )}
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
         {children}
       </div>

--- a/apps/web/src/components/security-agent/SecurityConfigForm.test.ts
+++ b/apps/web/src/components/security-agent/SecurityConfigForm.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import {
   buildSecurityConfigFormState,
   buildSecurityConfigSavePayload,
+  toRepositoryOptions,
   type SecurityConfigFormState,
 } from './security-config-types';
 
@@ -48,5 +49,26 @@ describe('SecurityConfigForm config round-trip', () => {
     const formState = buildSecurityConfigFormState(undefined);
 
     expect(formState.autoRemediationRequireApproval).toBe(true);
+  });
+
+  it('preserves installation provenance for repository grouping and selection', () => {
+    expect(
+      toRepositoryOptions([
+        {
+          id: 42,
+          fullName: 'acme-labs/app',
+          name: 'app',
+          private: true,
+          dependabotAlerts: 'enabled',
+          integrationId: 'integration-labs',
+          accountLogin: 'acme-labs',
+        },
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        id: 42,
+        group: { id: 'integration-labs', label: 'acme-labs' },
+      }),
+    ]);
   });
 });

--- a/apps/web/src/components/security-agent/SecurityConfigForm.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigForm.tsx
@@ -51,6 +51,7 @@ import {
 import type {
   SecurityConfigFormState,
   SecurityConfigSavePayload,
+  SecurityInstallationStatus,
   SecurityRepository,
   SlaConfig,
 } from './security-config-types';
@@ -62,6 +63,7 @@ type SecurityConfigFormProps = {
   organizationId?: string;
   initialConfig: SecurityConfigFormState;
   repositories: SecurityRepository[];
+  installationStatuses: SecurityInstallationStatus[];
   viewState: {
     enabled: boolean;
     isLoadingRepositories?: boolean;
@@ -218,6 +220,7 @@ export function SecurityConfigForm({
   organizationId,
   initialConfig,
   repositories,
+  installationStatuses,
   viewState,
   onSave,
   onToggleEnabled,
@@ -440,6 +443,7 @@ export function SecurityConfigForm({
             availableRepositoryCount={repositories.length}
             repositoryCount={repositoryCount}
             slaEnabled={state.slaEnabled}
+            installationStatuses={installationStatuses}
             onToggle={nextEnabled =>
               onToggleEnabled(nextEnabled, {
                 repositorySelectionMode: state.repositorySelectionMode,

--- a/apps/web/src/components/security-agent/SecurityConfigPage.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigPage.tsx
@@ -21,6 +21,7 @@ export function SecurityConfigPage() {
     isEnabled,
     configData,
     allRepositories,
+    installationStatuses,
     handleSaveConfig,
     handleToggleEnabled,
     handleDeleteFindings,
@@ -92,6 +93,7 @@ export function SecurityConfigPage() {
         organizationId={organizationId}
         initialConfig={initialConfig}
         repositories={allRepositories}
+        installationStatuses={installationStatuses}
         viewState={{
           enabled: isEnabled ?? false,
           isSaving: isSavingConfig,

--- a/apps/web/src/components/security-agent/SecurityConfigSections.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigSections.tsx
@@ -30,6 +30,7 @@ import type {
   AutoRemediationMinSeverity,
   NotificationMinSeverity,
   SecurityConfigFormState,
+  SecurityInstallationStatus,
   SecurityRepository,
   SlaConfig,
 } from './security-config-types';
@@ -451,6 +452,7 @@ export function AgentStatusSection({
   availableRepositoryCount,
   repositoryCount,
   slaEnabled,
+  installationStatuses,
   onToggle,
 }: {
   enabled: boolean;
@@ -458,6 +460,7 @@ export function AgentStatusSection({
   availableRepositoryCount: number;
   repositoryCount: number;
   slaEnabled: boolean;
+  installationStatuses: SecurityInstallationStatus[];
   onToggle: (enabled: boolean) => void;
 }) {
   const description = enabled
@@ -474,7 +477,7 @@ export function AgentStatusSection({
         icon={Settings}
         title="Security Agent"
         description={description}
-        hasContent={false}
+        hasContent={installationStatuses.length > 0}
         action={
           <SectionToggle
             id="security-agent-enabled"
@@ -485,6 +488,44 @@ export function AgentStatusSection({
           />
         }
       />
+      {installationStatuses.length > 0 ? (
+        <CardContent>
+          <div className="border-border divide-border divide-y rounded-lg border">
+            {installationStatuses.map(installation => {
+              const status = !installation.active
+                ? 'Installation unavailable'
+                : installation.hasPermissions
+                  ? 'Ready to sync'
+                  : installation.authInvalidAt
+                    ? 'Re-authorization required'
+                    : 'Additional permission required';
+              return (
+                <div
+                  key={installation.integrationId}
+                  className="flex min-h-11 flex-wrap items-center justify-between gap-3 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">
+                      {installation.accountLogin ?? 'GitHub account'}
+                    </p>
+                    <p className="text-muted-foreground text-xs">{status}</p>
+                  </div>
+                  {installation.reauthorizeUrl ? (
+                    <a
+                      href={installation.reauthorizeUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary focus-visible:ring-ring rounded-sm text-xs font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+                    >
+                      Re-authorize GitHub App
+                    </a>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      ) : null}
     </Card>
   );
 }

--- a/apps/web/src/components/security-agent/security-config-types.ts
+++ b/apps/web/src/components/security-agent/security-config-types.ts
@@ -26,6 +26,18 @@ export type SecurityRepository = {
   name: string;
   private: boolean;
   dependabotAlerts: DependabotAlertsAvailability;
+  integrationId: string;
+  accountLogin: string | null;
+};
+
+export type SecurityInstallationStatus = {
+  integrationId: string;
+  accountLogin: string | null;
+  active: boolean;
+  hasPermissions: boolean;
+  reauthorizeUrl: string | null;
+  authInvalidAt: string | null;
+  authInvalidReason: string | null;
 };
 
 export type SecurityConfigFormState = {
@@ -166,5 +178,9 @@ export function toRepositoryOptions(repositories: SecurityRepository[]): Reposit
     name: repository.name,
     full_name: repository.fullName,
     private: repository.private,
+    group: {
+      id: repository.integrationId,
+      label: repository.accountLogin ?? 'GitHub account',
+    },
   }));
 }

--- a/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
@@ -102,7 +102,11 @@ jest.mock('@kilocode/db/operation-ledger', () => ({
   settleOperation: mockSettleOperation,
 }));
 jest.mock('../github/permissions', () => ({
-  hasSecurityReviewPermissions: () => true,
+  hasSecurityReviewPermissions: (integration: { permissions?: Record<string, string> }) => {
+    if (!integration.permissions) return true;
+    const permission = integration.permissions.vulnerability_alerts;
+    return permission === 'read' || permission === 'write';
+  },
   getReauthorizeUrl: mockGetReauthorizeUrl,
 }));
 jest.mock('../github/dependabot-api', () => ({
@@ -203,6 +207,10 @@ function createHandlers() {
         id: 'integration-123',
         integration_status: 'active',
         platform_installation_id: 'installation-123',
+        platform_account_login: 'kilo',
+        permissions: { vulnerability_alerts: 'read' },
+        suspended_at: null,
+        auth_invalid_at: null,
         repositories: [{ id: 1, full_name: 'kilo/repo', name: 'repo', private: true }],
       }) as never,
     trackingExtras: () => ({}),
@@ -295,8 +303,80 @@ describe('getPermissionStatus', () => {
       reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-123',
       authInvalidAt: '2026-06-25 18:00:00+00',
       authInvalidReason: 'installation_token_auth_failed',
+      installations: [
+        {
+          integrationId: 'integration-123',
+          accountLogin: null,
+          active: true,
+          hasPermissions: false,
+          reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-123',
+          authInvalidAt: '2026-06-25 18:00:00+00',
+          authInvalidReason: 'installation_token_auth_failed',
+        },
+      ],
     });
     expect(mockGetReauthorizeUrl).toHaveBeenCalledWith('installation-123');
+  });
+
+  it('keeps the aggregate ready when an unhealthy sibling needs reauthorization', async () => {
+    const handlers = createSecurityAgentHandlers({
+      resolveOwner: () => ({ type: 'org', id: 'org-1', userId: 'user-123' }),
+      resolveSecurityOwner: () => ({ organizationId: 'org-1' }),
+      resolveResourceId: () => 'org-1',
+      verifyFindingOwnership: () => true,
+      getIntegration: async () => null,
+      getIntegrations: async () =>
+        [
+          {
+            id: 'healthy',
+            integration_status: 'active',
+            platform_installation_id: 'installation-1',
+            platform_account_login: 'acme-core',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+          },
+          {
+            id: 'unhealthy',
+            integration_status: 'active',
+            platform_installation_id: 'installation-2',
+            platform_account_login: 'acme-labs',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: '2026-08-20 12:00:00+00',
+            auth_invalid_reason: 'github_dependabot_401',
+          },
+          {
+            id: 'missing-permission',
+            integration_status: 'active',
+            platform_installation_id: 'installation-3',
+            platform_account_login: 'acme-public',
+            permissions: {},
+            suspended_at: null,
+            auth_invalid_at: null,
+          },
+        ] as never,
+      trackingExtras: () => ({}),
+    });
+
+    await expect(handlers.getPermissionStatus({ ctx: context, input: {} })).resolves.toMatchObject({
+      hasIntegration: true,
+      hasPermissions: true,
+      integrationId: 'healthy',
+      installations: [
+        expect.objectContaining({ integrationId: 'healthy', hasPermissions: true }),
+        expect.objectContaining({
+          integrationId: 'unhealthy',
+          hasPermissions: false,
+          reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-2',
+        }),
+        expect.objectContaining({
+          integrationId: 'missing-permission',
+          hasPermissions: false,
+          reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-3',
+        }),
+      ],
+    });
   });
 });
 
@@ -365,6 +445,8 @@ describe('getRepositories', () => {
         fullName: 'kilo/repo',
         name: 'repo',
         private: true,
+        integrationId: 'integration-123',
+        accountLogin: 'kilo',
         dependabotAlerts: 'disabled',
       },
     ]);
@@ -378,6 +460,8 @@ describe('getRepositories', () => {
           fullName: 'kilo/repo',
           name: 'repo',
           private: true,
+          integrationId: 'integration-123',
+          accountLogin: 'kilo',
         },
       ]
     );
@@ -389,6 +473,117 @@ describe('getRepositories', () => {
     await expect(createHandlers().getRepositories({ ctx: context, input: {} })).resolves.toEqual([
       expect.objectContaining({ id: 1, dependabotAlerts: 'unknown' }),
     ]);
+  });
+
+  it('groups repositories by healthy installation and ignores an unhealthy sibling', async () => {
+    const handlers = createSecurityAgentHandlers({
+      resolveOwner: () => ({ type: 'org', id: 'org-1', userId: 'user-123' }),
+      resolveSecurityOwner: () => ({ organizationId: 'org-1' }),
+      resolveResourceId: () => 'org-1',
+      verifyFindingOwnership: () => true,
+      getIntegration: async () => null,
+      getIntegrations: async () =>
+        [
+          {
+            id: 'healthy-1',
+            platform: 'github',
+            integration_status: 'active',
+            platform_installation_id: 'installation-1',
+            platform_account_login: 'acme-core',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 11, full_name: 'acme-core/api', name: 'api', private: true }],
+          },
+          {
+            id: 'healthy-2',
+            platform: 'github',
+            integration_status: 'active',
+            platform_installation_id: 'installation-2',
+            platform_account_login: 'acme-labs',
+            permissions: { vulnerability_alerts: 'write' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 22, full_name: 'acme-labs/app', name: 'app', private: false }],
+          },
+          {
+            id: 'unhealthy',
+            platform: 'github',
+            integration_status: 'active',
+            platform_installation_id: 'installation-3',
+            platform_account_login: 'acme-old',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: '2026-08-20 12:00:00+00',
+            repositories: [{ id: 33, full_name: 'acme-old/legacy', name: 'legacy', private: true }],
+          },
+        ] as never,
+      trackingExtras: () => ({}),
+    });
+
+    await expect(handlers.getRepositories({ ctx: context, input: {} })).resolves.toEqual([
+      expect.objectContaining({
+        id: 11,
+        integrationId: 'healthy-1',
+        accountLogin: 'acme-core',
+      }),
+      expect.objectContaining({
+        id: 22,
+        integrationId: 'healthy-2',
+        accountLogin: 'acme-labs',
+      }),
+    ]);
+  });
+});
+
+describe('multi-installation selection', () => {
+  it('accepts a selected repository from a secondary healthy installation', async () => {
+    mockSubmitManualSecuritySync.mockResolvedValue({
+      accepted: true,
+      commandId,
+      runId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      messageId: 'enable-sync-message-123',
+    });
+    const handlers = createSecurityAgentHandlers({
+      resolveOwner: () => ({ type: 'org', id: 'org-1', userId: 'user-123' }),
+      resolveSecurityOwner: () => ({ organizationId: 'org-1' }),
+      resolveResourceId: () => 'org-1',
+      verifyFindingOwnership: () => true,
+      getIntegration: async () => null,
+      getIntegrations: async () =>
+        [
+          {
+            id: 'primary',
+            integration_status: 'active',
+            platform_installation_id: 'installation-1',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 11, full_name: 'acme-core/api', name: 'api', private: true }],
+          },
+          {
+            id: 'secondary',
+            integration_status: 'active',
+            platform_installation_id: 'installation-2',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 22, full_name: 'acme-labs/app', name: 'app', private: false }],
+          },
+        ] as never,
+      trackingExtras: () => ({}),
+    });
+
+    await expect(
+      handlers.setEnabled.handler({
+        ctx: context,
+        input: {
+          isEnabled: true,
+          repositorySelectionMode: 'selected',
+          selectedRepositoryIds: [22],
+        },
+      })
+    ).resolves.toMatchObject({ success: true });
   });
 });
 

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/admin/admin-access-log';
 import { TRPCError } from '@trpc/server';
 import {
+  type getAllIntegrationsForOwner,
   type getIntegrationForOwner,
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
@@ -146,7 +147,8 @@ import {
 
 type Owner = { type: 'user' | 'org'; id: string; userId: string };
 
-type Integration = Awaited<ReturnType<typeof getIntegrationForOwner>> | null;
+type Integration = NonNullable<Awaited<ReturnType<typeof getIntegrationForOwner>>>;
+type Integrations = Awaited<ReturnType<typeof getAllIntegrationsForOwner>>;
 
 /**
  * TExtra represents additional input fields injected by the tRPC procedure middleware.
@@ -158,16 +160,19 @@ type SecurityAgentDeps<TExtra = {}> = {
   resolveSecurityOwner: (ctx: TRPCContext, input: TExtra) => SecurityReviewOwner;
   resolveResourceId: (ctx: TRPCContext, input: TExtra) => string;
   verifyFindingOwnership: (finding: SecurityFinding, ctx: TRPCContext, input: TExtra) => boolean;
-  getIntegration: (ctx: TRPCContext, input: TExtra) => Promise<Integration>;
-  getStatusIntegration?: (ctx: TRPCContext, input: TExtra) => Promise<Integration>;
+  getIntegration: (ctx: TRPCContext, input: TExtra) => Promise<Integration | null>;
+  getStatusIntegration?: (ctx: TRPCContext, input: TExtra) => Promise<Integration | null>;
+  getIntegrations?: (ctx: TRPCContext, input: TExtra) => Promise<Integrations>;
   trackingExtras: (ctx: TRPCContext, input: TExtra) => { organizationId?: string };
 };
 
 function getRepoFullNamesInScope(
-  integration: Integration,
+  integrations: Integration[],
   config: { repository_selection_mode?: 'all' | 'selected'; selected_repository_ids?: number[] }
 ): string[] {
-  const repositories = requireNumericPlatformRepositories(integration?.repositories ?? null) ?? [];
+  const repositories = integrations.flatMap(
+    integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+  );
   if (config.repository_selection_mode === 'all') {
     return repositories.map(repo => repo.full_name).filter((name): name is string => !!name);
   }
@@ -176,6 +181,18 @@ function getRepoFullNamesInScope(
     .filter(repo => selectedIds.has(repo.id))
     .map(repo => repo.full_name)
     .filter((name): name is string => !!name);
+}
+
+function isIntegrationHealthy(integration: Integration): boolean {
+  return (
+    integration.integration_status === 'active' &&
+    !integration.suspended_at &&
+    !integration.auth_invalid_at
+  );
+}
+
+function isSecurityIntegrationReady(integration: Integration): boolean {
+  return isIntegrationHealthy(integration) && hasSecurityReviewPermissions(integration);
 }
 
 async function resolveAuditReportOwner(
@@ -701,6 +718,12 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const toExtra = (input: unknown): TExtra => (input ?? {}) as any;
 
+  const getIntegrations = async (ctx: TRPCContext, input: TExtra): Promise<Integration[]> => {
+    if (deps.getIntegrations) return deps.getIntegrations(ctx, input);
+    const integration = await deps.getIntegration(ctx, input);
+    return integration ? [integration] : [];
+  };
+
   return {
     trackUiInteraction: {
       inputSchema: TrackSecurityAgentUiInteractionInputSchema,
@@ -727,35 +750,46 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
     // -----------------------------------------------------------------------
     getPermissionStatus: async ({ ctx, input }: { ctx: TRPCContext; input: unknown }) => {
       const extra = toExtra(input);
-      const integration = await (deps.getStatusIntegration ?? deps.getIntegration)(ctx, extra);
-
-      if (!integration || integration.integration_status !== 'active') {
+      const integrations = deps.getIntegrations
+        ? await deps.getIntegrations(ctx, extra)
+        : await (async () => {
+            const integration = await (deps.getStatusIntegration ?? deps.getIntegration)(
+              ctx,
+              extra
+            );
+            return integration ? [integration] : [];
+          })();
+      const installations = integrations.map(integration => {
+        const active = integration.integration_status === 'active' && !integration.suspended_at;
+        const hasPermissions = active && isSecurityIntegrationReady(integration);
         return {
-          hasIntegration: false,
-          hasPermissions: false,
-          integrationId: null,
-          reauthorizeUrl: null,
-          authInvalidAt: integration?.auth_invalid_at ?? null,
-          authInvalidReason: integration?.auth_invalid_reason ?? null,
+          integrationId: integration.id,
+          accountLogin: integration.platform_account_login ?? null,
+          active,
+          hasPermissions,
+          reauthorizeUrl:
+            active && !hasPermissions && integration.platform_installation_id
+              ? getReauthorizeUrl(integration.platform_installation_id)
+              : null,
+          authInvalidAt: integration.auth_invalid_at ?? null,
+          authInvalidReason: integration.auth_invalid_reason ?? null,
         };
-      }
-
-      const hasPermissions = hasSecurityReviewPermissions(integration);
-      // UI reauthorization state is intentionally time-invariant: once GitHub returns
-      // auth-invalid, keep prompting until a sync or install-refresh path clears the flag.
-      const hasEffectivePermissions = hasPermissions && !integration.auth_invalid_at;
+      });
+      const activeInstallations = installations.filter(installation => installation.active);
+      const authorizedInstallation = activeInstallations.find(
+        installation => installation.hasPermissions
+      );
+      const fallbackInstallation = activeInstallations[0];
 
       return {
-        hasIntegration: true,
-        integrationId: integration.id,
-        hasPermissions: hasEffectivePermissions,
-        reauthorizeUrl: hasEffectivePermissions
-          ? null
-          : integration.platform_installation_id
-            ? getReauthorizeUrl(integration.platform_installation_id)
-            : null,
-        authInvalidAt: integration.auth_invalid_at,
-        authInvalidReason: integration.auth_invalid_reason,
+        hasIntegration: activeInstallations.length > 0,
+        integrationId:
+          authorizedInstallation?.integrationId ?? fallbackInstallation?.integrationId ?? null,
+        hasPermissions: authorizedInstallation !== undefined,
+        reauthorizeUrl: fallbackInstallation?.reauthorizeUrl ?? null,
+        authInvalidAt: fallbackInstallation?.authInvalidAt ?? null,
+        authInvalidReason: fallbackInstallation?.authInvalidReason ?? null,
+        installations,
       };
     },
 
@@ -1143,12 +1177,11 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         const securityOwner = deps.resolveSecurityOwner(ctx, input);
         const resourceId = deps.resolveResourceId(ctx, input);
 
-        // Get integration (needed for both permission check and sync)
-        const integration = await deps.getIntegration(ctx, input);
+        const integrations = (await getIntegrations(ctx, input)).filter(isSecurityIntegrationReady);
 
         // Check permissions before enabling
         if (input.isEnabled) {
-          if (!integration || !hasSecurityReviewPermissions(integration)) {
+          if (integrations.length === 0) {
             throw new TRPCError({
               code: 'PRECONDITION_FAILED',
               message: 'GitHub App does not have vulnerability_alerts permission',
@@ -1168,7 +1201,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         // Refuse enabling with an empty effective repo set: no repository would
         // be synced or analyzed, so an enabled state would be misleading.
         if (input.isEnabled) {
-          const effectiveRepos = getRepoFullNamesInScope(integration, {
+          const effectiveRepos = getRepoFullNamesInScope(integrations, {
             repository_selection_mode: selectionMode,
             selected_repository_ids: selectedIds,
           });
@@ -1195,74 +1228,75 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         await setSecurityAgentEnabled(owner, input.isEnabled);
 
         // When enabling, trigger an initial sync of repositories
-        if (input.isEnabled && integration) {
-          const installationId = integration.platform_installation_id;
-          if (installationId) {
-            const allRepos = requireNumericPlatformRepositories(integration.repositories) ?? [];
+        if (input.isEnabled && integrations.length > 0) {
+          const allRepos = integrations.flatMap(
+            integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+          );
 
-            let repositoriesToSync: string[];
+          let repositoriesToSync: string[];
 
-            if (selectionMode === 'all') {
-              repositoriesToSync = allRepos
-                .map(r => r.full_name)
-                .filter((name): name is string => !!name);
-            } else {
-              repositoriesToSync = allRepos
-                .filter(r => selectedIds.includes(r.id))
-                .map(r => r.full_name)
-                .filter((name): name is string => !!name);
-            }
+          if (selectionMode === 'all') {
+            repositoriesToSync = allRepos
+              .map(r => r.full_name)
+              .filter((name): name is string => !!name);
+          } else {
+            repositoriesToSync = allRepos
+              .filter(r => selectedIds.includes(r.id))
+              .map(r => r.full_name)
+              .filter((name): name is string => !!name);
+          }
 
-            if (repositoriesToSync.length > 0) {
-              let initialSync: Awaited<ReturnType<typeof submitManualSecuritySync>> | undefined;
-              let initialSyncAdmissionFailed = false;
-              try {
-                initialSync = await submitManualSecuritySync({
-                  owner: securityOwner,
-                  actor: {
-                    id: ctx.user.id,
-                    email: ctx.user.google_user_email,
-                    name: ctx.user.google_user_name,
-                  },
-                  origin: 'enable_initial_sync',
-                });
-              } catch (error) {
-                initialSyncAdmissionFailed = true;
-                console.error('Security Agent enabled but initial sync admission failed', error);
-              }
-
-              trackSecurityAgentEnabled({
-                distinctId: ctx.user.id,
-                userId: ctx.user.id,
-                ...deps.trackingExtras(ctx, input),
-                isEnabled: input.isEnabled,
-                repositorySelectionMode: selectionMode,
-                selectedRepoCount: repositoriesToSync.length,
-              });
-
-              logSecurityAudit({
+          if (repositoriesToSync.length > 0) {
+            let initialSync: Awaited<ReturnType<typeof submitManualSecuritySync>> | undefined;
+            let initialSyncAdmissionFailed = false;
+            try {
+              initialSync = await submitManualSecuritySync({
                 owner: securityOwner,
-                actor_id: ctx.user.id,
-                actor_email: ctx.user.google_user_email,
-                actor_name: ctx.user.google_user_name,
-                action: SecurityAuditLogAction.ConfigEnabled,
-                resource_type: 'agent_config',
-                resource_id: resourceId,
-                after_state: { isEnabled: true, repositorySelectionMode: selectionMode },
+                actor: {
+                  id: ctx.user.id,
+                  email: ctx.user.google_user_email,
+                  name: ctx.user.google_user_name,
+                },
+                origin: 'enable_initial_sync',
               });
-
-              return {
-                success: true,
-                initialSync,
-                initialSyncAdmissionFailed,
-              };
+            } catch (error) {
+              initialSyncAdmissionFailed = true;
+              console.error('Security Agent enabled but initial sync admission failed', error);
             }
+
+            trackSecurityAgentEnabled({
+              distinctId: ctx.user.id,
+              userId: ctx.user.id,
+              ...deps.trackingExtras(ctx, input),
+              isEnabled: input.isEnabled,
+              repositorySelectionMode: selectionMode,
+              selectedRepoCount: repositoriesToSync.length,
+            });
+
+            logSecurityAudit({
+              owner: securityOwner,
+              actor_id: ctx.user.id,
+              actor_email: ctx.user.google_user_email,
+              actor_name: ctx.user.google_user_name,
+              action: SecurityAuditLogAction.ConfigEnabled,
+              resource_type: 'agent_config',
+              resource_id: resourceId,
+              after_state: { isEnabled: true, repositorySelectionMode: selectionMode },
+            });
+
+            return {
+              success: true,
+              initialSync,
+              initialSyncAdmissionFailed,
+            };
           }
         }
 
         const effectiveRepoCount =
           selectionMode === 'all'
-            ? (integration?.repositories || []).filter(r => !!r.full_name).length
+            ? integrations.flatMap(
+                integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+              ).length
             : selectedIds.length;
 
         trackSecurityAgentEnabled({
@@ -1296,61 +1330,62 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
     // -----------------------------------------------------------------------
     getRepositories: async ({ ctx, input }: { ctx: TRPCContext; input: unknown }) => {
       const extra = toExtra(input);
-      const integration = await deps.getIntegration(ctx, extra);
+      const integrations = (await getIntegrations(ctx, extra)).filter(isSecurityIntegrationReady);
+      const repositoryGroups = await Promise.all(
+        integrations.map(async integration => {
+          const installationId = integration.platform_installation_id;
+          if (!installationId) return [];
 
-      if (!integration || integration.integration_status !== 'active') {
-        return [];
-      }
+          const appType = integration.github_app_type || 'standard';
+          let repos = requireNumericPlatformRepositories(integration.repositories) ?? [];
+          if (repos.length === 0) {
+            try {
+              repos = await fetchGitHubRepositories(installationId, appType);
+              await updateRepositoriesForIntegration(integration.id, repos);
+            } catch (error) {
+              console.error('Failed to load repositories for GitHub installation', {
+                integrationId: integration.id,
+                error: error instanceof Error ? error.message : String(error),
+              });
+              return [];
+            }
+          }
 
-      // Auto-fetch repositories from GitHub if not cached
-      let repos = requireNumericPlatformRepositories(integration.repositories) ?? [];
-      if (repos.length === 0 && integration.platform_installation_id) {
-        const appType = integration.github_app_type || 'standard';
-        const fetchedRepos = await fetchGitHubRepositories(
-          integration.platform_installation_id,
-          appType
-        );
-        await updateRepositoriesForIntegration(integration.id, fetchedRepos);
-        repos = fetchedRepos;
-      }
+          const repositories = repos.map(repo => ({
+            id: repo.id,
+            fullName: repo.full_name,
+            name: repo.name,
+            private: repo.private,
+            integrationId: integration.id,
+            accountLogin: integration.platform_account_login ?? null,
+          }));
+          try {
+            const availability = await checkDependabotAlertsAvailability(
+              installationId,
+              appType,
+              repositories
+            );
+            const availabilityById = new Map(
+              availability.map(result => [result.id, result.status])
+            );
+            return repositories.map(repository => ({
+              ...repository,
+              dependabotAlerts: availabilityById.get(repository.id) ?? ('unknown' as const),
+            }));
+          } catch (error) {
+            console.error('Failed to check Dependabot alerts availability', {
+              integrationId: integration.id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return repositories.map(repository => ({
+              ...repository,
+              dependabotAlerts: 'unknown' as const,
+            }));
+          }
+        })
+      );
 
-      const repositoryDetails = repos.map(repo => ({
-        id: repo.id,
-        fullName: repo.full_name,
-        name: repo.name,
-        private: repo.private,
-      }));
-      const installationId = integration.platform_installation_id;
-      if (!installationId || !hasSecurityReviewPermissions(integration)) {
-        return repositoryDetails.map(repository => ({
-          ...repository,
-          dependabotAlerts: 'unknown' as const,
-        }));
-      }
-
-      const appType = integration.github_app_type || 'standard';
-      let availability: Awaited<ReturnType<typeof checkDependabotAlertsAvailability>>;
-      try {
-        availability = await checkDependabotAlertsAvailability(
-          installationId,
-          appType,
-          repositoryDetails
-        );
-      } catch (error) {
-        console.error('Failed to check Dependabot alerts availability', {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return repositoryDetails.map(repository => ({
-          ...repository,
-          dependabotAlerts: 'unknown' as const,
-        }));
-      }
-      const availabilityById = new Map(availability.map(result => [result.id, result.status]));
-
-      return repositoryDetails.map(repository => ({
-        ...repository,
-        dependabotAlerts: availabilityById.get(repository.id) ?? ('unknown' as const),
-      }));
+      return repositoryGroups.flat();
     },
 
     // -----------------------------------------------------------------------
@@ -1382,16 +1417,19 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         });
 
         const concurrencyCheck = await canStartAnalysis(securityOwner);
-        const [configWithStatus, integration] = await Promise.all([
+        const [configWithStatus, integrations] = await Promise.all([
           getSecurityAgentConfigWithStatus(owner),
-          deps.getIntegration(ctx, input),
+          getIntegrations(ctx, input),
         ]);
         const config = configWithStatus?.config ?? DEFAULT_SECURITY_AGENT_CONFIG;
         const decoratedFindings = await decorateFindingsWithRemediation({
           findings,
           config,
           isAgentEnabled: configWithStatus?.isEnabled ?? false,
-          repoFullNamesInScope: getRepoFullNamesInScope(integration, config),
+          repoFullNamesInScope: getRepoFullNamesInScope(
+            integrations.filter(isSecurityIntegrationReady),
+            config
+          ),
         });
 
         return {
@@ -1433,16 +1471,19 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           });
         }
 
-        const [configWithStatus, integration] = await Promise.all([
+        const [configWithStatus, integrations] = await Promise.all([
           getSecurityAgentConfigWithStatus(owner),
-          deps.getIntegration(ctx, input),
+          getIntegrations(ctx, input),
         ]);
         const config = configWithStatus?.config ?? DEFAULT_SECURITY_AGENT_CONFIG;
         return decorateFindingWithRemediation({
           finding,
           config,
           isAgentEnabled: configWithStatus?.isEnabled ?? false,
-          repoFullNamesInScope: getRepoFullNamesInScope(integration, config),
+          repoFullNamesInScope: getRepoFullNamesInScope(
+            integrations.filter(isSecurityIntegrationReady),
+            config
+          ),
         });
       },
     },
@@ -1495,32 +1536,17 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         const securityOwner = deps.resolveSecurityOwner(ctx, input);
         const resourceId = deps.resolveResourceId(ctx, input);
 
-        // Get integration
-        const integration = await deps.getIntegration(ctx, input);
-        if (!integration || integration.integration_status !== 'active') {
+        const integrations = (await getIntegrations(ctx, input)).filter(isSecurityIntegrationReady);
+        if (integrations.length === 0) {
           throw new TRPCError({
             code: 'PRECONDITION_FAILED',
             message: 'GitHub integration not found or inactive',
           });
         }
 
-        // Check permissions
-        if (!hasSecurityReviewPermissions(integration)) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'GitHub App does not have vulnerability_alerts permission',
-          });
-        }
-
-        const installationId = integration.platform_installation_id;
-        if (!installationId) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'GitHub installation ID not found',
-          });
-        }
-
-        const allRepos = requireNumericPlatformRepositories(integration.repositories) ?? [];
+        const allRepos = integrations.flatMap(
+          integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+        );
 
         // Resolve the sync scope (a specific repo, or every enabled repo).
         let syncScope:
@@ -1658,8 +1684,14 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           });
         }
 
-        // Get integration for GitHub API call
-        const integration = await deps.getIntegration(ctx, input);
+        const integrations = (await getIntegrations(ctx, input)).filter(isSecurityIntegrationReady);
+        const integration =
+          integrations.find(candidate => candidate.id === finding.platform_integration_id) ??
+          integrations.find(candidate =>
+            (requireNumericPlatformRepositories(candidate.repositories) ?? []).some(
+              repository => repository.full_name === finding.repo_full_name
+            )
+          );
         if (!integration || integration.integration_status !== 'active') {
           throw new TRPCError({
             code: 'PRECONDITION_FAILED',
@@ -1975,10 +2007,10 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         }
 
         const owner = deps.resolveOwner(ctx, input);
-        const [configWithStatus, integration, remediationAttempts, remediationTimeline] =
+        const [configWithStatus, integrations, remediationAttempts, remediationTimeline] =
           await Promise.all([
             getSecurityAgentConfigWithStatus(owner),
-            deps.getIntegration(ctx, input),
+            getIntegrations(ctx, input),
             getRemediationAttemptHistory(input.findingId),
             getRemediationTimeline(input.findingId),
           ]);
@@ -1987,7 +2019,10 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           finding,
           config,
           isAgentEnabled: configWithStatus?.isEnabled ?? false,
-          repoFullNamesInScope: getRepoFullNamesInScope(integration, config),
+          repoFullNamesInScope: getRepoFullNamesInScope(
+            integrations.filter(isSecurityIntegrationReady),
+            config
+          ),
         });
 
         return {
@@ -2075,11 +2110,11 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
       const securityOwner = deps.resolveSecurityOwner(ctx, extra);
 
       // Get the current GitHub integration
-      const integration = await deps.getIntegration(ctx, extra);
+      const integrations = (await getIntegrations(ctx, extra)).filter(isSecurityIntegrationReady);
 
       // Get list of accessible repository full names
       const accessibleRepoFullNames: string[] = [];
-      if (integration && integration.integration_status === 'active') {
+      for (const integration of integrations) {
         const repos = requireNumericPlatformRepositories(integration.repositories) ?? [];
         for (const repo of repos) {
           if (repo.full_name) {

--- a/apps/web/src/routers/organizations/organization-security-agent-router.ts
+++ b/apps/web/src/routers/organizations/organization-security-agent-router.ts
@@ -8,6 +8,7 @@ import {
 } from './utils';
 
 import {
+  getAllIntegrationsForOwner,
   getIntegrationForOrganization,
   getPrimaryGitHubIntegrationForOrganization,
 } from '@/lib/integrations/db/platform-integrations';
@@ -29,6 +30,10 @@ const handlers = createSecurityAgentHandlers<{ organizationId: string }>({
     await getPrimaryGitHubIntegrationForOrganization(input.organizationId),
   getStatusIntegration: async (_ctx, input) =>
     await getIntegrationForOrganization(input.organizationId, 'github'),
+  getIntegrations: async (_ctx, input) =>
+    (await getAllIntegrationsForOwner({ type: 'org', id: input.organizationId })).filter(
+      integration => integration.platform === 'github'
+    ),
   trackingExtras: (_ctx, input) => ({
     organizationId: input.organizationId,
   }),

--- a/apps/web/src/routers/security-agent-router.ts
+++ b/apps/web/src/routers/security-agent-router.ts
@@ -1,5 +1,8 @@
 import { createTRPCRouter, baseProcedure } from '@/lib/trpc/init';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
+import {
+  getAllIntegrationsForOwner,
+  getIntegrationForOwner,
+} from '@/lib/integrations/db/platform-integrations';
 import { createSecurityAgentHandlers } from '@/lib/security-agent/router/shared-handlers';
 
 const handlers = createSecurityAgentHandlers({
@@ -16,6 +19,12 @@ const handlers = createSecurityAgentHandlers({
   getIntegration: async ctx => {
     const owner = { type: 'user' as const, id: ctx.user.id, userId: ctx.user.id };
     return await getIntegrationForOwner(owner, 'github');
+  },
+  getIntegrations: async ctx => {
+    const owner = { type: 'user' as const, id: ctx.user.id };
+    return (await getAllIntegrationsForOwner(owner)).filter(
+      integration => integration.platform === 'github'
+    );
   },
   trackingExtras: () => ({}),
 });


### PR DESCRIPTION
## Why this PR exists

#5562 teaches Security Agent sync to process every healthy GitHub installation, but the current web/mobile configuration still projects one installation. Users cannot select secondary repositories or tell which connected GitHub organization lacks required permissions.

This PR exposes only repositories the backend can now sync, preserves their installation identity, and makes recovery installation-specific.

## Place in the rollout

This is the Security Agent configuration/UI child of #5562. Finding execution is separate in #5571 so this review can focus on repository discovery, selection, and installation health.

## Dependency

Depends on #5562. Merge and deploy sync support first, then retarget this PR to `main`.

## What changes

- Aggregate repository APIs across healthy GitHub installations.
- Include account and integration ID on each repository.
- Group repositories by GitHub organization in web and mobile selectors.
- Expose permission, authentication, and reauthorization state per installation.
- Keep healthy repositories selectable when a sibling installation is unhealthy.

## What stays unchanged

- Security Agent remains one organization-wide configuration.
- The sync semantics are defined in #5562.
- Analysis, remediation, and writeback use finding provenance in #5571.

## Why this touches shared selector code

Security Agent reuses `RepositoryMultiSelect`, which previously assumed one label space. The change adds optional grouping/provenance support while preserving existing consumers; the Security-specific components supply installation health and recovery behavior.

## Review guide

Start with `shared-handlers.ts` output: verify every repository carries its integration. Then review selector grouping and the per-installation status rendering. The key negative case is one unhealthy installation not hiding healthy siblings.

## Validation

- Workspace typecheck and lint
- Full mobile suite: 6,244 tests
- 4 database-free web grouping tests
- `git diff --check`

DB-backed web and browser checks were unavailable because no test database/server was running.