### PR TITLE
feat(cli-sessions): refresh PR status with the session's GitHub install

### DIFF
--- a/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
+++ b/apps/web/src/lib/cloud-agent-next/cloud-agent-client.ts
@@ -282,6 +282,7 @@ export type GetSessionOutput = {
 
   // Repository info (no tokens)
   githubRepo?: string;
+  githubIntegrationId?: string;
   gitUrl?: string;
   platform?: 'github' | 'gitlab' | 'bitbucket';
 

--- a/apps/web/src/lib/integrations/platforms/github/batch-review-decisions.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/batch-review-decisions.test.ts
@@ -1,5 +1,9 @@
 import { db } from '@/lib/drizzle';
-import { cli_sessions_v2, github_branch_pull_requests } from '@kilocode/db/schema';
+import {
+  cli_sessions_v2,
+  github_branch_pull_requests,
+  platform_integrations,
+} from '@kilocode/db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import {
@@ -12,20 +16,11 @@ jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   fetchBatchedReviewDecisions: jest.fn(),
 }));
 
-jest.mock('@/lib/integrations/db/platform-integrations', () => ({
-  getIntegrationForOwner: jest.fn(),
-}));
-
 import { fetchBatchedReviewDecisions } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
 
 const mockFetchBatch = fetchBatchedReviewDecisions as jest.MockedFunction<
   typeof fetchBatchedReviewDecisions
 >;
-const mockGetIntegration = getIntegrationForOwner as jest.MockedFunction<
-  typeof getIntegrationForOwner
->;
-
 const REPO = 'acme/batch-test';
 const GIT_URL = `https://github.com/${REPO}`;
 
@@ -34,6 +29,8 @@ describe('batch-review-decisions', () => {
   let testOwner: TenantOwner;
   const userIdsToCleanup: string[] = [];
   const sessionIdsToCleanup: string[] = [];
+  const integrationIdsToCleanup: string[] = [];
+  let integrationId: string;
   let counter = 0;
 
   async function seedSession(branch: string) {
@@ -52,12 +49,14 @@ describe('batch-review-decisions', () => {
   async function seedPrRow(
     branch: string,
     prNumber: number,
-    opts: { pending?: boolean; fetchingAt?: string } = {}
+    opts: { pending?: boolean; fetchingAt?: string; integrationId?: string | null } = {}
   ) {
     await db.insert(github_branch_pull_requests).values({
       git_url: GIT_URL,
       git_branch: branch,
       owned_by_user_id: testUserId,
+      platform_integration_id:
+        opts.integrationId === undefined ? integrationId : opts.integrationId,
       pr_number: prNumber,
       pr_state: 'open',
       review_decision_pending: opts.pending ?? true,
@@ -79,11 +78,25 @@ describe('batch-review-decisions', () => {
     return rows[0] ?? null;
   }
 
-  function fakeIntegration(installationId = '42') {
-    return {
-      platform_installation_id: installationId,
-      github_app_type: 'standard',
-    } as ReturnType<typeof getIntegrationForOwner> extends Promise<infer T> ? T : never;
+  async function seedIntegration(input: {
+    installationId: string;
+    appType: 'standard' | 'lite';
+  }): Promise<string> {
+    const [integration] = await db
+      .insert(platform_integrations)
+      .values({
+        owned_by_user_id: testUserId,
+        platform: 'github',
+        integration_type: 'app',
+        platform_installation_id: input.installationId,
+        platform_account_login: 'acme',
+        repository_access: 'all',
+        github_app_type: input.appType,
+        integration_status: 'active',
+      })
+      .returning({ id: platform_integrations.id });
+    integrationIdsToCleanup.push(integration.id);
+    return integration.id;
   }
 
   beforeAll(async () => {
@@ -94,20 +107,36 @@ describe('batch-review-decisions', () => {
   });
 
   afterAll(async () => {
-    if (sessionIdsToCleanup.length > 0) {
-      await db
-        .delete(cli_sessions_v2)
-        .where(inArray(cli_sessions_v2.session_id, sessionIdsToCleanup));
-    }
-    if (userIdsToCleanup.length > 0) {
-      await db
-        .delete(github_branch_pull_requests)
-        .where(inArray(github_branch_pull_requests.owned_by_user_id, userIdsToCleanup));
-    }
+    await db
+      .delete(github_branch_pull_requests)
+      .where(inArray(github_branch_pull_requests.owned_by_user_id, userIdsToCleanup));
   });
 
   beforeEach(() => {
     jest.clearAllMocks();
+  });
+
+  beforeEach(async () => {
+    integrationId = await seedIntegration({
+      installationId: `42-${counter++}`,
+      appType: 'standard',
+    });
+  });
+
+  afterEach(async () => {
+    await db
+      .delete(github_branch_pull_requests)
+      .where(eq(github_branch_pull_requests.owned_by_user_id, testUserId));
+    if (sessionIdsToCleanup.length > 0) {
+      await db
+        .delete(cli_sessions_v2)
+        .where(inArray(cli_sessions_v2.session_id, sessionIdsToCleanup.splice(0)));
+    }
+    if (integrationIdsToCleanup.length > 0) {
+      await db
+        .delete(platform_integrations)
+        .where(inArray(platform_integrations.id, integrationIdsToCleanup.splice(0)));
+    }
   });
 
   describe('executeBatchReviewDecisionFetch', () => {
@@ -126,8 +155,7 @@ describe('batch-review-decisions', () => {
       await seedSession(branch);
       await seedPrRow(branch, 2, { pending: true });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      mockGetIntegration.mockResolvedValue(null as any);
+      await db.delete(platform_integrations).where(eq(platform_integrations.id, integrationId));
 
       await executeBatchReviewDecisionFetch(testOwner);
 
@@ -145,7 +173,6 @@ describe('batch-review-decisions', () => {
       await seedSession(branch);
       await seedPrRow(branch, 10, { pending: true });
 
-      mockGetIntegration.mockResolvedValue(fakeIntegration());
       mockFetchBatch.mockResolvedValue(new Map([['pr0', 'approved']]));
 
       await executeBatchReviewDecisionFetch(testOwner);
@@ -161,7 +188,6 @@ describe('batch-review-decisions', () => {
       await seedSession(branch);
       await seedPrRow(branch, 11, { pending: true });
 
-      mockGetIntegration.mockResolvedValue(fakeIntegration());
       mockFetchBatch.mockResolvedValue(new Map([['pr0', null]]));
 
       await executeBatchReviewDecisionFetch(testOwner);
@@ -186,8 +212,6 @@ describe('batch-review-decisions', () => {
         review_decision_pending: true,
       });
 
-      mockGetIntegration.mockResolvedValue(fakeIntegration());
-
       await executeBatchReviewDecisionFetch(testOwner);
 
       // fetchBatch not called because no row with a pr_number was batch-able.
@@ -202,7 +226,6 @@ describe('batch-review-decisions', () => {
       await seedSession(branch);
       await seedPrRow(branch, 20, { pending: true });
 
-      mockGetIntegration.mockResolvedValue(fakeIntegration());
       mockFetchBatch.mockResolvedValue(new Map([['pr0', 'approved']]));
 
       // First call claims the row
@@ -223,7 +246,6 @@ describe('batch-review-decisions', () => {
       const olderFetchingAt = new Date(Date.now() - 60_000).toISOString();
       await seedPrRow(branch, 30, { pending: true, fetchingAt: olderFetchingAt });
 
-      mockGetIntegration.mockResolvedValue(fakeIntegration());
       // fetchBatch won't be called because the claim UPDATE won't match:
       // fetching_at is recent (< 2 minutes ago) so it's not stale, so claim skips it
       await executeBatchReviewDecisionFetch(testOwner);
@@ -234,14 +256,51 @@ describe('batch-review-decisions', () => {
       // pending still true, fetching_at unchanged
       expect(row?.review_decision_pending).toBe(true);
     });
+
+    it('groups two installations by exact integration and app type', async () => {
+      const standardBranch = 'batch/two-installations-standard';
+      const liteBranch = 'batch/two-installations-lite';
+      const liteIntegrationId = await seedIntegration({
+        installationId: '84',
+        appType: 'lite',
+      });
+      await seedSession(standardBranch);
+      await seedSession(liteBranch);
+      await seedPrRow(standardBranch, 41, { integrationId });
+      await seedPrRow(liteBranch, 42, { integrationId: liteIntegrationId });
+      mockFetchBatch.mockImplementation(
+        async ({ prs, appType }) =>
+          new Map(prs.map(pr => [pr.alias, appType === 'lite' ? 'changes_requested' : 'approved']))
+      );
+
+      await executeBatchReviewDecisionFetch(testOwner);
+
+      expect(mockFetchBatch).toHaveBeenCalledTimes(2);
+      expect(mockFetchBatch).toHaveBeenCalledWith(expect.objectContaining({ appType: 'standard' }));
+      expect(mockFetchBatch).toHaveBeenCalledWith(
+        expect.objectContaining({ installationId: '84', appType: 'lite' })
+      );
+      expect((await readRow(standardBranch))?.pr_review_decision).toBe('approved');
+      expect((await readRow(liteBranch))?.pr_review_decision).toBe('changes_requested');
+    });
+
+    it('fails closed for an old unpinned row when installations overlap', async () => {
+      const branch = 'batch/legacy-overlap';
+      await seedIntegration({ installationId: 'overlap-lite', appType: 'lite' });
+      await seedSession(branch);
+      await seedPrRow(branch, 43, { integrationId: null });
+
+      await executeBatchReviewDecisionFetch(testOwner);
+
+      expect(mockFetchBatch).not.toHaveBeenCalled();
+      expect((await readRow(branch))?.review_decision_pending).toBe(false);
+    });
   });
 
   describe('triggerBatchReviewDecisionFetchIfNeeded', () => {
     it('does not call executeBatch when hasPendingRows=false', () => {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      mockGetIntegration.mockResolvedValue(null as any);
       triggerBatchReviewDecisionFetchIfNeeded(false, testOwner);
-      expect(mockGetIntegration).not.toHaveBeenCalled();
+      expect(mockFetchBatch).not.toHaveBeenCalled();
     });
 
     // Flaky in CI due to setTimeout(0)-based wait for fire-and-forget async work.
@@ -256,7 +315,6 @@ describe('batch-review-decisions', () => {
       await seedSession(branch);
       await seedPrRow(branch, 40, { pending: true });
 
-      mockGetIntegration.mockResolvedValue(fakeIntegration());
       mockFetchBatch.mockResolvedValue(new Map([['pr0', 'review_required']]));
 
       triggerBatchReviewDecisionFetchIfNeeded(true, testOwner);
@@ -264,7 +322,7 @@ describe('batch-review-decisions', () => {
       // Give it a tick for any resolved promises
       await new Promise(r => setTimeout(r, 0));
 
-      expect(mockGetIntegration).toHaveBeenCalled();
+      expect(mockFetchBatch).toHaveBeenCalled();
     });
   });
 });

--- a/apps/web/src/lib/integrations/platforms/github/batch-review-decisions.ts
+++ b/apps/web/src/lib/integrations/platforms/github/batch-review-decisions.ts
@@ -4,9 +4,11 @@ import { captureException } from '@sentry/nextjs';
 import { db } from '@/lib/drizzle';
 import { github_branch_pull_requests } from '@kilocode/db/schema';
 import { fetchBatchedReviewDecisions } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
-import { PLATFORM } from '@/lib/integrations/core/constants';
-import { logExceptInTest } from '@/lib/utils.server';
+import {
+  getPinnedCliSessionGitHubIntegration,
+  resolveLegacyCliSessionGitHubIntegration,
+  type CliSessionGitHubIntegration,
+} from './cli-session-integration';
 
 export type TenantOwner = {
   userId: string;
@@ -29,6 +31,7 @@ type ClaimedRow = {
   pr_number: number | null;
   owned_by_organization_id: string | null;
   owned_by_user_id: string | null;
+  platform_integration_id: string | null;
   review_decision_fetching_at: string | null;
 };
 
@@ -63,6 +66,7 @@ async function claimPendingReviewRows(owner: TenantOwner): Promise<ClaimedRow[]>
       pr_number: github_branch_pull_requests.pr_number,
       owned_by_organization_id: github_branch_pull_requests.owned_by_organization_id,
       owned_by_user_id: github_branch_pull_requests.owned_by_user_id,
+      platform_integration_id: github_branch_pull_requests.platform_integration_id,
       review_decision_fetching_at: github_branch_pull_requests.review_decision_fetching_at,
     });
 }
@@ -72,6 +76,7 @@ type FlushedRow = {
   git_branch: string;
   owned_by_organization_id: string | null;
   owned_by_user_id: string | null;
+  platform_integration_id: string | null;
   fetching_at: string;
   decision: string | null;
 };
@@ -121,6 +126,9 @@ async function flushBatchResults(results: FlushedRow[]): Promise<void> {
             eq(github_branch_pull_requests.git_url, row.git_url),
             eq(github_branch_pull_requests.git_branch, row.git_branch),
             tenantPredicate,
+            row.platform_integration_id
+              ? eq(github_branch_pull_requests.platform_integration_id, row.platform_integration_id)
+              : isNull(github_branch_pull_requests.platform_integration_id),
             // TOCTOU guard: only clear the flag if we still hold the claim.
             // A concurrent webhook that re-set review_decision_pending=true will
             // have bumped review_decision_fetching_at via a new claim, so this
@@ -137,6 +145,7 @@ type AbandonedRow = {
   git_branch: string;
   owned_by_organization_id: string | null;
   owned_by_user_id: string | null;
+  platform_integration_id: string | null;
   fetching_at: string;
 };
 
@@ -170,6 +179,9 @@ async function abandonClaimedRows(rows: AbandonedRow[]): Promise<void> {
             eq(github_branch_pull_requests.git_url, row.git_url),
             eq(github_branch_pull_requests.git_branch, row.git_branch),
             tenantPredicate,
+            row.platform_integration_id
+              ? eq(github_branch_pull_requests.platform_integration_id, row.platform_integration_id)
+              : isNull(github_branch_pull_requests.platform_integration_id),
             // Same TOCTOU guard as flushBatchResults: a concurrent webhook
             // that re-flagged the row will have a different fetching_at,
             // so we leave it pending for the next batch.
@@ -189,6 +201,7 @@ function abandonRowsFromClaimed(rows: ClaimedRow[]): AbandonedRow[] {
       git_branch: row.git_branch,
       owned_by_organization_id: row.owned_by_organization_id,
       owned_by_user_id: row.owned_by_user_id,
+      platform_integration_id: row.platform_integration_id,
       fetching_at: row.review_decision_fetching_at,
     });
   }
@@ -206,49 +219,21 @@ export async function executeBatchReviewDecisionFetch(owner: TenantOwner): Promi
 
   if (claimed.length === 0) return;
 
-  let integration: {
-    platform_installation_id: string | null;
-    github_app_type: string | null;
-  } | null;
-  try {
-    integration = await getIntegrationForOwner(
-      owner.organizationId !== null
-        ? { type: 'org', id: owner.organizationId }
-        : { type: 'user', id: owner.userId },
-      PLATFORM.GITHUB
-    );
-  } catch (error) {
-    captureException(error, { tags: { source: 'batch_review_decision_get_integration' } });
-    return;
-  }
-
-  if (!integration?.platform_installation_id) {
-    logExceptInTest('batch review decision: no GitHub integration, abandoning claimed rows', {
-      userId: owner.userId,
-      organizationId: owner.organizationId,
-      claimedCount: claimed.length,
-    });
-    try {
-      await abandonClaimedRows(abandonRowsFromClaimed(claimed));
-    } catch (error) {
-      captureException(error, { tags: { source: 'batch_review_decision_abandon_no_integration' } });
-    }
-    return;
-  }
-
-  const installationId = integration.platform_installation_id;
-  const appType = (integration.github_app_type as 'standard' | 'lite' | null) ?? 'standard';
-
   type BatchEntry = {
     alias: string;
     owner: string;
     repo: string;
     number: number;
     row: ClaimedRow;
+    integration: CliSessionGitHubIntegration;
   };
 
   const batchEntries: BatchEntry[] = [];
   const unactionableRows: ClaimedRow[] = [];
+  const integrationOwner =
+    owner.organizationId !== null
+      ? ({ type: 'org', id: owner.organizationId } as const)
+      : ({ type: 'user', id: owner.userId } as const);
   for (let i = 0; i < claimed.length; i++) {
     const row = claimed[i];
     const parsed = row.git_url ? parseGitHubOwnerRepo(row.git_url) : null;
@@ -258,12 +243,34 @@ export async function executeBatchReviewDecisionFetch(owner: TenantOwner): Promi
       unactionableRows.push(row);
       continue;
     }
+    let integration: CliSessionGitHubIntegration | null;
+    try {
+      integration = row.platform_integration_id
+        ? await getPinnedCliSessionGitHubIntegration({
+            owner: integrationOwner,
+            repositoryFullName: `${parsed.owner}/${parsed.repo}`,
+            integrationId: row.platform_integration_id,
+          })
+        : await resolveLegacyCliSessionGitHubIntegration({
+            owner: integrationOwner,
+            repositoryFullName: `${parsed.owner}/${parsed.repo}`,
+          });
+    } catch (error) {
+      captureException(error, { tags: { source: 'batch_review_decision_get_integration' } });
+      unactionableRows.push(row);
+      continue;
+    }
+    if (!integration) {
+      unactionableRows.push(row);
+      continue;
+    }
     batchEntries.push({
       alias: `pr${i}`,
       owner: parsed.owner,
       repo: parsed.repo,
       number: row.pr_number,
       row,
+      integration,
     });
   }
 
@@ -277,36 +284,44 @@ export async function executeBatchReviewDecisionFetch(owner: TenantOwner): Promi
 
   if (batchEntries.length === 0) return;
 
-  let decisions: Map<string, string | null>;
-  try {
-    decisions = await fetchBatchedReviewDecisions({
-      installationId,
-      prs: batchEntries.map(({ alias, owner, repo, number }) => ({
-        alias,
-        owner,
-        repo,
-        number,
-      })),
-      appType,
-    });
-  } catch (error) {
-    captureException(error, { tags: { source: 'batch_review_decision_graphql' } });
-    return;
-  }
-
   const toFlush: FlushedRow[] = [];
-  for (const { alias, row } of batchEntries) {
-    // claimPendingReviewRows always sets review_decision_fetching_at to now();
-    // skip the row if a concurrent writer somehow cleared it.
-    if (!row.review_decision_fetching_at) continue;
-    toFlush.push({
-      git_url: row.git_url,
-      git_branch: row.git_branch,
-      owned_by_organization_id: row.owned_by_organization_id,
-      owned_by_user_id: row.owned_by_user_id,
-      fetching_at: row.review_decision_fetching_at,
-      decision: decisions.get(alias) ?? null,
-    });
+  const batches = new Map<string, BatchEntry[]>();
+  for (const entry of batchEntries) {
+    const key = JSON.stringify([
+      entry.integration.id,
+      entry.integration.platform_installation_id,
+      entry.integration.github_app_type ?? 'standard',
+    ]);
+    const batch = batches.get(key);
+    if (batch) batch.push(entry);
+    else batches.set(key, [entry]);
+  }
+  for (const entries of batches.values()) {
+    const integration = entries[0]?.integration;
+    if (!integration) continue;
+    let decisions: Map<string, string | null>;
+    try {
+      decisions = await fetchBatchedReviewDecisions({
+        installationId: integration.platform_installation_id,
+        prs: entries.map(({ alias, owner, repo, number }) => ({ alias, owner, repo, number })),
+        appType: integration.github_app_type ?? 'standard',
+      });
+    } catch (error) {
+      captureException(error, { tags: { source: 'batch_review_decision_graphql' } });
+      continue;
+    }
+    for (const { alias, row } of entries) {
+      if (!row.review_decision_fetching_at) continue;
+      toFlush.push({
+        git_url: row.git_url,
+        git_branch: row.git_branch,
+        owned_by_organization_id: row.owned_by_organization_id,
+        owned_by_user_id: row.owned_by_user_id,
+        platform_integration_id: row.platform_integration_id,
+        fetching_at: row.review_decision_fetching_at,
+        decision: decisions.get(alias) ?? null,
+      });
+    }
   }
 
   try {

--- a/apps/web/src/lib/integrations/platforms/github/cli-session-integration.ts
+++ b/apps/web/src/lib/integrations/platforms/github/cli-session-integration.ts
@@ -1,0 +1,99 @@
+import 'server-only';
+import { and, eq, isNotNull, isNull } from 'drizzle-orm';
+import { db } from '@/lib/drizzle';
+import { platform_integrations, type PlatformIntegration } from '@kilocode/db/schema';
+import type { Owner } from '@/lib/integrations/core/types';
+import { PLATFORM } from '@/lib/integrations/core/constants';
+import { platformIntegrationHealthSql } from '@/lib/integrations/core/health';
+
+export type CliSessionGitHubIntegration = Pick<
+  PlatformIntegration,
+  'id' | 'platform_installation_id' | 'github_app_type'
+> & {
+  platform_installation_id: string;
+};
+
+function repositoryMatches(integration: PlatformIntegration, repositoryFullName: string): boolean {
+  const repositoryParts = repositoryFullName.split('/');
+  if (repositoryParts.length !== 2 || repositoryParts.some(part => part.length === 0)) return false;
+  const [repositoryOwner] = repositoryParts;
+  if (
+    !repositoryOwner ||
+    integration.platform_account_login?.toLowerCase() !== repositoryOwner.toLowerCase()
+  ) {
+    return false;
+  }
+  if (integration.repository_access === 'all') return true;
+  if (integration.repository_access !== 'selected') return false;
+  return Boolean(
+    integration.repositories?.some(
+      repository =>
+        typeof repository.full_name === 'string' &&
+        repository.full_name.toLowerCase() === repositoryFullName.toLowerCase()
+    )
+  );
+}
+
+function ownerCondition(owner: Owner) {
+  return owner.type === 'org'
+    ? and(
+        eq(platform_integrations.owned_by_organization_id, owner.id),
+        isNull(platform_integrations.owned_by_user_id)
+      )
+    : and(
+        eq(platform_integrations.owned_by_user_id, owner.id),
+        isNull(platform_integrations.owned_by_organization_id)
+      );
+}
+
+async function getHealthyGitHubIntegrations(
+  owner: Owner,
+  expectedIntegrationId?: string
+): Promise<PlatformIntegration[]> {
+  return db
+    .select()
+    .from(platform_integrations)
+    .where(
+      and(
+        ownerCondition(owner),
+        eq(platform_integrations.platform, PLATFORM.GITHUB),
+        eq(platform_integrations.integration_type, 'app'),
+        isNotNull(platform_integrations.platform_installation_id),
+        platformIntegrationHealthSql(),
+        expectedIntegrationId ? eq(platform_integrations.id, expectedIntegrationId) : undefined
+      )
+    );
+}
+
+function toResolvedIntegration(
+  integration: PlatformIntegration | undefined
+): CliSessionGitHubIntegration | null {
+  if (!integration?.platform_installation_id) return null;
+  return {
+    id: integration.id,
+    platform_installation_id: integration.platform_installation_id,
+    github_app_type: integration.github_app_type,
+  };
+}
+
+export async function getPinnedCliSessionGitHubIntegration(input: {
+  owner: Owner;
+  repositoryFullName: string;
+  integrationId: string;
+}): Promise<CliSessionGitHubIntegration | null> {
+  const integrations = await getHealthyGitHubIntegrations(input.owner, input.integrationId);
+  return toResolvedIntegration(
+    integrations.find(integration => repositoryMatches(integration, input.repositoryFullName))
+  );
+}
+
+export async function resolveLegacyCliSessionGitHubIntegration(input: {
+  owner: Owner;
+  repositoryFullName: string;
+}): Promise<CliSessionGitHubIntegration | null> {
+  const integrations = await getHealthyGitHubIntegrations(input.owner);
+  const matches = integrations.filter(integration =>
+    repositoryMatches(integration, input.repositoryFullName)
+  );
+  return matches.length === 1 ? toResolvedIntegration(matches[0]) : null;
+}

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -17,6 +17,7 @@ const mockHandleInstallationSuspend = jest.fn();
 const mockHandleInstallationUnsuspend = jest.fn();
 const mockHandleInstallationRepositories = jest.fn();
 const mockUpsertCliSessionPullRequestsFromWebhook = jest.fn();
+const mockUpsertCliSessionPullRequestReviewFromWebhook = jest.fn();
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   verifyGitHubWebhookSignature: (payload: string, signature: string, appType: string) =>
@@ -64,7 +65,8 @@ jest.mock('@/lib/integrations/platforms/github/webhook-handlers', () => ({
   handlePushEvent: jest.fn(),
   upsertCliSessionPullRequestsFromWebhook: (payload: unknown, owner: unknown) =>
     mockUpsertCliSessionPullRequestsFromWebhook(payload, owner),
-  upsertCliSessionPullRequestReviewFromWebhook: jest.fn(),
+  upsertCliSessionPullRequestReviewFromWebhook: (payload: unknown, owner: unknown) =>
+    mockUpsertCliSessionPullRequestReviewFromWebhook(payload, owner),
 }));
 
 jest.mock('@/lib/code-reviews/review-memory/github-feedback', () => ({
@@ -155,6 +157,35 @@ function reviewCommentPayload(overrides: Record<string, unknown> = {}) {
       base: { ref: 'main' },
     },
     ...overrides,
+  };
+}
+
+function pullRequestReviewPayload() {
+  return {
+    action: 'submitted',
+    installation: { id: 98765 },
+    repository: {
+      id: 123,
+      name: 'widgets',
+      full_name: 'acme/widgets',
+      owner: { login: 'acme' },
+    },
+    review: { id: 789, state: 'approved', user: { login: 'reviewer' } },
+    pull_request: {
+      number: 42,
+      title: 'Add widgets',
+      state: 'open',
+      html_url: 'https://github.com/acme/widgets/pull/42',
+      head: {
+        sha: 'abc123',
+        ref: 'feature/widgets',
+        repo: {
+          full_name: 'acme/widgets',
+          clone_url: 'https://github.com/acme/widgets.git',
+          html_url: 'https://github.com/acme/widgets',
+        },
+      },
+    },
   };
 }
 
@@ -345,6 +376,38 @@ describe('handleGitHubWebhook', () => {
     expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
       'we_1',
       expect.objectContaining({ handlers_triggered: ['code_review', 'cli_session_pr_upsert'] })
+    );
+  });
+
+  it('enables secondary pull request and review cache updates with exact integration scope', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValueOnce({ ...integration, id: 'pi_primary' });
+
+    const pullResponse = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request', pullRequestPayload()),
+      'standard'
+    );
+
+    expect(pullResponse.status).toBe(200);
+    expect(mockUpsertCliSessionPullRequestsFromWebhook).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ platformIntegrationId: integration.id })
+    );
+
+    jest.clearAllMocks();
+    mockVerifyGitHubWebhookSignature.mockReturnValue(true);
+    mockFindIntegrationByInstallationId.mockResolvedValue(integration);
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'pi_primary' });
+    mockLogWebhookEvent.mockResolvedValue({ id: 'we_2', isDuplicate: false });
+
+    const reviewResponse = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request_review', pullRequestReviewPayload()),
+      'standard'
+    );
+
+    expect(reviewResponse.status).toBe(200);
+    expect(mockUpsertCliSessionPullRequestReviewFromWebhook).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.objectContaining({ platformIntegrationId: integration.id })
     );
   });
 

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -466,7 +466,11 @@ export async function handleGitHubWebhook(
       ? await getIntegrationForOrganization(integration.owned_by_organization_id, PLATFORM.GITHUB)
       : integration;
     const isSecondaryOrganizationInstallation = primaryIntegration?.id !== integration.id;
-    if (isSecondaryOrganizationInstallation && eventType !== GITHUB_EVENT.PULL_REQUEST) {
+    if (
+      isSecondaryOrganizationInstallation &&
+      eventType !== GITHUB_EVENT.PULL_REQUEST &&
+      eventType !== GITHUB_EVENT.PULL_REQUEST_REVIEW
+    ) {
       logExceptInTest('Secondary GitHub installation event suppressed', {
         integration_id: integration.id,
         event_type: eventType,
@@ -529,21 +533,19 @@ export async function handleGitHubWebhook(
       // to avoid blocking the webhook response — when a matching session is on
       // a supported platform the function makes an outbound GitHub GraphQL
       // call, which can add significant latency.
-      const upsertOwner = isSecondaryOrganizationInstallation
-        ? null
-        : integration.owned_by_organization_id
+      const upsertOwner = integration.owned_by_organization_id
+        ? ({
+            kind: 'organization',
+            organizationId: integration.owned_by_organization_id,
+            platformIntegrationId: integration.id,
+          } as const)
+        : integration.owned_by_user_id
           ? ({
-              kind: 'organization',
-              organizationId: integration.owned_by_organization_id,
+              kind: 'user',
+              userId: integration.owned_by_user_id,
               platformIntegrationId: integration.id,
             } as const)
-          : integration.owned_by_user_id
-            ? ({
-                kind: 'user',
-                userId: integration.owned_by_user_id,
-                platformIntegrationId: integration.id,
-              } as const)
-            : null;
+          : null;
 
       // `closed` events are not routed to the code-review pipeline.
       if (action === GITHUB_ACTION.CLOSED) {
@@ -614,9 +616,17 @@ export async function handleGitHubWebhook(
       }
 
       const upsertOwner = integration.owned_by_organization_id
-        ? ({ kind: 'organization', organizationId: integration.owned_by_organization_id } as const)
+        ? ({
+            kind: 'organization',
+            organizationId: integration.owned_by_organization_id,
+            platformIntegrationId: integration.id,
+          } as const)
         : integration.owned_by_user_id
-          ? ({ kind: 'user', userId: integration.owned_by_user_id } as const)
+          ? ({
+              kind: 'user',
+              userId: integration.owned_by_user_id,
+              platformIntegrationId: integration.id,
+            } as const)
           : null;
 
       if (upsertOwner) {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-request-review.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-request-review.test.ts
@@ -1,5 +1,9 @@
 import { db } from '@/lib/drizzle';
-import { cli_sessions_v2, github_branch_pull_requests } from '@kilocode/db/schema';
+import {
+  cli_sessions_v2,
+  github_branch_pull_requests,
+  platform_integrations,
+} from '@kilocode/db/schema';
 import { and, eq, inArray } from 'drizzle-orm';
 import { insertTestUser } from '@/tests/helpers/user.helper';
 import type { PullRequestReviewPayload } from '@/lib/integrations/platforms/github/webhook-schemas';
@@ -51,6 +55,8 @@ function makeReviewPayload(overrides: {
 describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
   let testUserId: string;
   let testOwner: WebhookInstallationOwner;
+  let integrationId: string;
+  let otherIntegrationId: string;
   const userIdsToCleanup: string[] = [];
   const sessionIdsToCleanup: string[] = [];
   let sessionCounter = 0;
@@ -71,12 +77,17 @@ describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
   async function seedPrCacheRow(
     branch: string,
     userId: string,
-    opts?: { reviewDecision?: string; reviewDecisionPending?: boolean }
+    opts?: {
+      reviewDecision?: string;
+      reviewDecisionPending?: boolean;
+      integrationId?: string;
+    }
   ) {
     await db.insert(github_branch_pull_requests).values({
       git_url: NORMALIZED_GIT_URL,
       git_branch: branch,
       owned_by_user_id: userId,
+      platform_integration_id: opts?.integrationId,
       pr_url: `https://github.com/${REPO}/pull/1`,
       pr_number: 1,
       pr_state: 'open',
@@ -102,7 +113,38 @@ describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
   beforeAll(async () => {
     const user = await insertTestUser();
     testUserId = user.id;
-    testOwner = { kind: 'user', userId: testUserId };
+    const [integration, otherIntegration] = await db
+      .insert(platform_integrations)
+      .values([
+        {
+          owned_by_user_id: testUserId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: `review-${crypto.randomUUID()}`,
+          platform_account_login: 'acme',
+          repository_access: 'all',
+          github_app_type: 'standard',
+          integration_status: 'active',
+        },
+        {
+          owned_by_user_id: testUserId,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: `review-${crypto.randomUUID()}`,
+          platform_account_login: 'acme',
+          repository_access: 'all',
+          github_app_type: 'lite',
+          integration_status: 'active',
+        },
+      ])
+      .returning({ id: platform_integrations.id });
+    integrationId = integration.id;
+    otherIntegrationId = otherIntegration.id;
+    testOwner = {
+      kind: 'user',
+      userId: testUserId,
+      platformIntegrationId: integrationId,
+    };
     userIdsToCleanup.push(testUserId);
   });
 
@@ -117,6 +159,9 @@ describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
         .delete(github_branch_pull_requests)
         .where(inArray(github_branch_pull_requests.owned_by_user_id, userIdsToCleanup));
     }
+    await db
+      .delete(platform_integrations)
+      .where(inArray(platform_integrations.id, [integrationId, otherIntegrationId]));
   });
 
   it('returns 0 when no matching session exists', async () => {
@@ -159,7 +204,9 @@ describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
   it('sets review_decision_pending=true when a supported-platform session and cache row both exist', async () => {
     const branch = 'feature/update-review';
     await seedSession(branch, 'cloud-agent-web');
-    await seedPrCacheRow(branch, testUserId);
+    await seedPrCacheRow(branch, testUserId, {
+      integrationId: testOwner.platformIntegrationId,
+    });
 
     const result = await upsertCliSessionPullRequestReviewFromWebhook(
       makeReviewPayload({ prNumber: 1, branch }),
@@ -174,7 +221,10 @@ describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
   it('does not overwrite existing pr_review_decision (lazy fetch handles it)', async () => {
     const branch = 'feature/review-no-overwrite';
     await seedSession(branch, 'cloud-agent-web');
-    await seedPrCacheRow(branch, testUserId, { reviewDecision: 'approved' });
+    await seedPrCacheRow(branch, testUserId, {
+      reviewDecision: 'approved',
+      integrationId: testOwner.platformIntegrationId,
+    });
 
     await upsertCliSessionPullRequestReviewFromWebhook(
       makeReviewPayload({ prNumber: 1, branch }),
@@ -184,6 +234,22 @@ describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
     const rows = await readRow(branch, testUserId);
     expect(rows[0].pr_review_decision).toBe('approved');
     expect(rows[0].review_decision_pending).toBe(true);
+  });
+
+  it('does not flag a cache row pinned to another installation', async () => {
+    const branch = 'feature/review-other-installation';
+    await seedSession(branch, 'cloud-agent-web');
+    await seedPrCacheRow(branch, testUserId, {
+      integrationId: otherIntegrationId,
+    });
+
+    const result = await upsertCliSessionPullRequestReviewFromWebhook(
+      makeReviewPayload({ prNumber: 1, branch }),
+      testOwner
+    );
+
+    expect(result).toBe(0);
+    expect((await readRow(branch, testUserId))[0]?.review_decision_pending).toBe(false);
   });
 
   it('does not match sessions belonging to a different tenant', async () => {
@@ -216,7 +282,9 @@ describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
     async action => {
       const branch = `feature/action-${action}-review`;
       await seedSession(branch, 'cloud-agent-web');
-      await seedPrCacheRow(branch, testUserId);
+      await seedPrCacheRow(branch, testUserId, {
+        integrationId: testOwner.platformIntegrationId,
+      });
 
       const result = await upsertCliSessionPullRequestReviewFromWebhook(
         makeReviewPayload({ prNumber: 1, branch, action }),
@@ -232,7 +300,9 @@ describe('upsertCliSessionPullRequestReviewFromWebhook', () => {
   it('slack platform is supported', async () => {
     const branch = 'feature/slack-platform';
     await seedSession(branch, 'slack');
-    await seedPrCacheRow(branch, testUserId);
+    await seedPrCacheRow(branch, testUserId, {
+      integrationId: testOwner.platformIntegrationId,
+    });
 
     const result = await upsertCliSessionPullRequestReviewFromWebhook(
       makeReviewPayload({ prNumber: 1, branch }),

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-request-review.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handlers/upsert-cli-session-pull-request-review.ts
@@ -76,6 +76,9 @@ export async function upsertCliSessionPullRequestReviewFromWebhook(
         and(
           eq(github_branch_pull_requests.git_url, gitUrl),
           eq(github_branch_pull_requests.git_branch, branch),
+          owner.platformIntegrationId
+            ? eq(github_branch_pull_requests.platform_integration_id, owner.platformIntegrationId)
+            : sql`false`,
           tenantPredicate
         )
       )

--- a/apps/web/src/routers/cli-sessions-v2-router.test.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.test.ts
@@ -2143,6 +2143,8 @@ describe('cli-sessions-v2-router', () => {
           platform: 'github',
           integration_type: 'app',
           platform_installation_id: '12345',
+          platform_account_login: 'kilo',
+          repository_access: 'all',
           github_app_type: 'standard',
           integration_status: 'active',
         })
@@ -2150,6 +2152,7 @@ describe('cli-sessions-v2-router', () => {
       integrationId = integration.id;
 
       mockedFetchPullRequestByNumber.mockReset();
+      mockGetSession.mockReset().mockRejectedValue(new Error('not mocked'));
     });
 
     afterEach(async () => {
@@ -2205,10 +2208,85 @@ describe('cli-sessions-v2-router', () => {
         git_branch: SESSION_BRANCH,
         owned_by_user_id: regularUser.id,
         owned_by_organization_id: null,
+        platform_integration_id: integrationId,
         pr_url: SESSION_PR_URL,
         pr_number: 7,
         pr_state: 'open',
       });
+    });
+
+    it('uses the exact Cloud Agent session installation and app type', async () => {
+      const [liteIntegration] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: regularUser.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: '54321',
+          platform_account_login: 'kilo',
+          repository_access: 'all',
+          github_app_type: 'lite',
+          integration_status: 'active',
+        })
+        .returning({ id: platform_integrations.id });
+      await db
+        .update(cli_sessions_v2)
+        .set({ cloud_agent_session_id: 'agent_refresh_pr_pinned' })
+        .where(eq(cli_sessions_v2.session_id, sessionId));
+      mockGetSession.mockResolvedValue({ githubIntegrationId: liteIntegration.id });
+      mockedFetchPullRequestByNumber.mockResolvedValue({
+        number: 7,
+        htmlUrl: SESSION_PR_URL,
+        state: 'open',
+        title: 'Pinned installation',
+        headSha: 'pinned-sha',
+        updatedAt: '2026-01-01T00:00:00Z',
+      });
+
+      try {
+        const caller = await createCallerForUser(regularUser.id);
+        await caller.cliSessionsV2.refreshAssociatedPullRequest({ sessionId });
+
+        expect(mockGetSession).toHaveBeenCalledWith('agent_refresh_pr_pinned');
+        expect(mockedFetchPullRequestByNumber).toHaveBeenCalledWith(
+          expect.objectContaining({ installationId: 54321, appType: 'lite' })
+        );
+        expect((await readCacheRows())[0]?.platform_integration_id).toBe(liteIntegration.id);
+      } finally {
+        await db
+          .update(cli_sessions_v2)
+          .set({ cloud_agent_session_id: null })
+          .where(eq(cli_sessions_v2.session_id, sessionId));
+        await db
+          .delete(platform_integrations)
+          .where(eq(platform_integrations.id, liteIntegration.id));
+      }
+    });
+
+    it('fails closed for an old unpinned session when two installations overlap', async () => {
+      const [overlapping] = await db
+        .insert(platform_integrations)
+        .values({
+          owned_by_user_id: regularUser.id,
+          platform: 'github',
+          integration_type: 'app',
+          platform_installation_id: '67890',
+          platform_account_login: 'kilo',
+          repository_access: 'all',
+          github_app_type: 'lite',
+          integration_status: 'active',
+        })
+        .returning({ id: platform_integrations.id });
+
+      try {
+        const caller = await createCallerForUser(regularUser.id);
+        await expect(
+          caller.cliSessionsV2.refreshAssociatedPullRequest({ sessionId })
+        ).rejects.toMatchObject({ code: 'BAD_REQUEST' });
+        expect(mockedFetchPullRequestByNumber).not.toHaveBeenCalled();
+      } finally {
+        await db.delete(platform_integrations).where(eq(platform_integrations.id, overlapping.id));
+      }
     });
 
     it('writes one cache row per (url, branch, tenant) across repeated refreshes', async () => {
@@ -2367,6 +2445,7 @@ describe('cli-sessions-v2-router', () => {
         git_url: SESSION_GIT_URL,
         git_branch: SESSION_BRANCH,
         owned_by_user_id: regularUser.id,
+        platform_integration_id: integrationId,
         pr_url: SESSION_PR_URL,
         pr_number: 7,
         pr_state: 'open',

--- a/apps/web/src/routers/cli-sessions-v2-router.ts
+++ b/apps/web/src/routers/cli-sessions-v2-router.ts
@@ -48,12 +48,14 @@ import {
   fetchPullRequestReviewDecision,
   GitHubRateLimitError,
 } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
-import { PLATFORM } from '@/lib/integrations/core/constants';
 import { normalizeGitUrl } from '@/lib/integrations/platforms/github/normalize-git-url';
 import { triggerBatchReviewDecisionFetchIfNeeded } from '@/lib/integrations/platforms/github/batch-review-decisions';
 import { notifyCliSessionRenamed } from '@/lib/cloud-agent/session-events';
 import { after } from 'next/server';
+import {
+  getPinnedCliSessionGitHubIntegration,
+  resolveLegacyCliSessionGitHubIntegration,
+} from '@/lib/integrations/platforms/github/cli-session-integration';
 
 /**
  * Check if an error indicates the session was not found in the cloud-agent DO.
@@ -1290,6 +1292,7 @@ export const cliSessionsV2Router = createTRPCRouter({
           pr_last_synced_at: github_branch_pull_requests.pr_last_synced_at,
           pr_review_decision: github_branch_pull_requests.pr_review_decision,
           review_decision_pending: github_branch_pull_requests.review_decision_pending,
+          platform_integration_id: github_branch_pull_requests.platform_integration_id,
         })
         .from(cli_sessions_v2)
         .leftJoin(github_branch_pull_requests, sessionPrJoinPredicate)
@@ -1347,10 +1350,55 @@ export const cliSessionsV2Router = createTRPCRouter({
         return { associatedPr: formatAssociatedPr(sessionPr, cacheRow) };
       }
 
-      // Throttle: skip the fetch only when the cache row already matches the
-      // session's stored link and was synced recently. A mismatched cache row
-      // must not short-circuit.
+      const integrationOwner = session.organization_id
+        ? ({ type: 'org', id: session.organization_id } as const)
+        : ({ type: 'user', id: ctx.user.id } as const);
+      const repositoryFullName = `${parsed.owner}/${parsed.repo}`;
+      let pinnedIntegrationId: string | undefined;
+      if (session.cloud_agent_session_id) {
+        try {
+          const authToken = generateApiToken(ctx.user);
+          const cloudSession = await createCloudAgentNextClient(authToken).getSession(
+            session.cloud_agent_session_id
+          );
+          pinnedIntegrationId = cloudSession.githubIntegrationId;
+        } catch (error) {
+          captureException(error, {
+            tags: {
+              source: 'cli-sessions-v2-router',
+              endpoint: 'refreshAssociatedPullRequest',
+              operation: 'resolveCloudAgentIntegration',
+            },
+            extra: { sessionId },
+          });
+          throw new TRPCError({
+            code: 'INTERNAL_SERVER_ERROR',
+            message: 'Could not resolve the GitHub installation pinned to this Cloud Agent session',
+          });
+        }
+      }
+
+      const integration = pinnedIntegrationId
+        ? await getPinnedCliSessionGitHubIntegration({
+            owner: integrationOwner,
+            repositoryFullName,
+            integrationId: pinnedIntegrationId,
+          })
+        : await resolveLegacyCliSessionGitHubIntegration({
+            owner: integrationOwner,
+            repositoryFullName,
+          });
+
+      if (!integration?.platform_installation_id) {
+        throw new TRPCError({
+          code: 'BAD_REQUEST',
+          message: 'Could not uniquely resolve a GitHub installation for this session',
+        });
+      }
+
+      // Only a cache row from this exact integration may satisfy the throttle.
       if (
+        row.platform_integration_id === integration.id &&
         cacheRow.pr_url !== null &&
         samePullRequest(sessionPrUrl, cacheRow.pr_url) &&
         cacheRow.pr_last_synced_at !== null
@@ -1359,27 +1407,6 @@ export const cliSessionsV2Router = createTRPCRouter({
         if (Number.isFinite(lastSyncedMs) && Date.now() - lastSyncedMs < REFRESH_THROTTLE_MS) {
           return { associatedPr: formatAssociatedPr(sessionPr, cacheRow) };
         }
-      }
-
-      // Resolve the GitHub installation for this session's owner.
-      let integration;
-      if (session.organization_id) {
-        integration = await getIntegrationForOwner(
-          { type: 'org', id: session.organization_id },
-          PLATFORM.GITHUB
-        );
-      } else {
-        integration = await getIntegrationForOwner(
-          { type: 'user', id: ctx.user.id },
-          PLATFORM.GITHUB
-        );
-      }
-
-      if (!integration?.platform_installation_id) {
-        throw new TRPCError({
-          code: 'BAD_REQUEST',
-          message: 'No GitHub integration configured for this session',
-        });
       }
 
       const installationId = Number(integration.platform_installation_id);
@@ -1517,6 +1544,7 @@ export const cliSessionsV2Router = createTRPCRouter({
             git_url: normalizedGitUrl,
             git_branch: branch,
             ...ownerValues,
+            platform_integration_id: integration.id,
             ...prColumns,
             review_decision_pending: hasPrToRefresh && !reviewDecisionFetched,
             review_decision_fetching_at: null,
@@ -1527,6 +1555,7 @@ export const cliSessionsV2Router = createTRPCRouter({
             targetWhere: conflictTargetWhere,
             set: {
               pr_url: sql`excluded.pr_url`,
+              platform_integration_id: sql`excluded.platform_integration_id`,
               pr_number: sql`excluded.pr_number`,
               pr_state: sql`excluded.pr_state`,
               pr_title: sql`excluded.pr_title`,

--- a/apps/web/src/routers/cloud-agent-next-schemas.ts
+++ b/apps/web/src/routers/cloud-agent-next-schemas.ts
@@ -615,6 +615,7 @@ export const baseGetSessionNextOutputSchema = z.object({
 
   // Repository info (no tokens)
   githubRepo: z.string().optional(),
+  githubIntegrationId: z.uuid().optional(),
   gitUrl: z.string().optional(),
   platform: z.enum(['github', 'gitlab', 'bitbucket']).optional(),
 

--- a/services/cloud-agent-next/src/router.test.ts
+++ b/services/cloud-agent-next/src/router.test.ts
@@ -1063,6 +1063,24 @@ describe('router sessionId validation', () => {
           expect(cloudAgentSession.idFromName).toHaveBeenCalledWith(`test-user-123:${sessionId}`);
         });
 
+        it('returns the GitHub integration pinned to a current session', async () => {
+          const sessionId: SessionId = 'agent_12345678-1234-1234-1234-123456789abd';
+          const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+          mockGetMetadata.mockResolvedValue(
+            parseSessionMetadata({
+              metadataSchemaVersion: 2,
+              identity: { sessionId, userId: 'test-user-123' },
+              auth: {},
+              repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+              lifecycle: { version: 1, timestamp: 1 },
+            })
+          );
+
+          const result = await caller.getSession({ cloudAgentSessionId: sessionId });
+
+          expect(result.githubIntegrationId).toBe(githubIntegrationId);
+        });
+
         it('returns only the logical sandbox identity for Vercel-pinned sessions', async () => {
           const sessionId: SessionId = 'agent_10101010-1010-1010-1010-101010101011';
           mockGetMetadata.mockResolvedValue(

--- a/services/cloud-agent-next/src/router/handlers/session-management.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-management.ts
@@ -38,6 +38,7 @@ import { SANDBOX_USAGE_SKUS } from '../../container-usage-context.js';
 
 function publicRepositoryFields(metadata: CloudAgentSessionState): {
   githubRepo?: string;
+  githubIntegrationId?: string;
   gitUrl?: string;
   platform?: 'github' | 'gitlab' | 'bitbucket';
 } {
@@ -45,7 +46,11 @@ function publicRepositoryFields(metadata: CloudAgentSessionState): {
   if (!repository) return {};
   switch (repository.type) {
     case 'github':
-      return { githubRepo: repository.repo, platform: repository.platform ?? 'github' };
+      return {
+        githubRepo: repository.repo,
+        githubIntegrationId: repository.githubIntegrationId,
+        platform: repository.platform ?? 'github',
+      };
     case 'gitlab':
       return { gitUrl: repository.url, platform: 'gitlab' };
     case 'bitbucket':
@@ -336,6 +341,7 @@ export function createSessionManagementHandlers() {
             sandboxId,
 
             githubRepo: repositoryFields.githubRepo,
+            githubIntegrationId: repositoryFields.githubIntegrationId,
             gitUrl: repositoryFields.gitUrl,
             platform: repositoryFields.platform,
             // githubToken: OMITTED

--- a/services/cloud-agent-next/src/router/schemas.test.ts
+++ b/services/cloud-agent-next/src/router/schemas.test.ts
@@ -628,6 +628,17 @@ describe('message ID schema validation', () => {
       }).success
     ).toBe(true);
     expect(
+      GetSessionOutput.safeParse({
+        sessionId: validSessionId,
+        userId: 'user_test',
+        githubRepo: 'acme/repo',
+        githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+        execution: null,
+        timestamp: 1,
+        version: 1,
+      }).success
+    ).toBe(true);
+    expect(
       ExecutionResponse.safeParse({
         cloudAgentSessionId: validSessionId,
         status: 'started',

--- a/services/cloud-agent-next/src/router/schemas.ts
+++ b/services/cloud-agent-next/src/router/schemas.ts
@@ -1090,6 +1090,11 @@ export const GetSessionOutput = z.object({
 
   // Repository info (no tokens)
   githubRepo: z.string().optional().describe('GitHub repository in org/repo format'),
+  githubIntegrationId: z
+    .string()
+    .uuid()
+    .optional()
+    .describe('GitHub platform integration pinned to this session'),
   gitUrl: z.string().optional().describe('Generic git URL'),
   platform: z.enum(['github', 'gitlab', 'bitbucket']).optional().describe('Git platform type'),
 


### PR DESCRIPTION
## Why this PR exists

#5565 records which GitHub installation produced cached PR data. Readers still need to honor that provenance. Today manual refresh and batched review-decision fetches can use a primary installation, and secondary review webhooks are suppressed because their cache side effects are not isolated.

This PR makes refresh, batching, and webhook updates operate on the exact installation associated with the session/cache row, then safely admits those secondary events.

## Place in the rollout

This is the behavior child of #5565. The parent is a backward-compatible schema/write PR; this PR is where CLI sessions gain correct secondary-installation PR badges and review decisions.

## Dependency

Depends on #5565. Merge its schema first, then retarget this PR to `main`.

## What changes

- Use a Cloud Agent session's pinned `githubIntegrationId` for manual PR refresh.
- Resolve old unpinned sessions only when repository/account access identifies one installation.
- Group review-decision requests by integration, provider installation, and app type.
- Scope compare-and-set batching and cache updates by integration.
- Admit secondary `pull_request` and `pull_request_review` cache events only after those writes are isolated.

## What stays unchanged

- Ambiguous legacy sessions fail closed.
- Cache schema/write ownership remains in #5565.
- Code Reviewer dispatch is not changed by this PR.

## Why this crosses web and Cloud Agent contracts

The web refresh endpoint needs the session's persisted installation identity, but that metadata is owned by Cloud Agent. A small contract addition exposes it; the remaining changes keep cache and GitHub API work grouped under the same identity.

## Review guide

Review `cli-session-integration.ts` and manual refresh first, then the batch grouping key, then webhook admission and integration-scoped writes. Verify old unpinned sessions never select the first overlapping installation.

## Validation

- Web and Cloud Agent typechecks
- 148 focused Cloud Agent tests
- Changed-file lint and formatting
- `git diff --check`

DB-backed web tests were typechecked but not executed because their setup requires environment files.