### PR TITLE
feat(auto-fix): fix issues from every connected GitHub org safely

### DIFF
--- a/apps/web/src/app/api/internal/auto-fix/pr-callback/route.test.ts
+++ b/apps/web/src/app/api/internal/auto-fix/pr-callback/route.test.ts
@@ -1,6 +1,9 @@
 import { beforeEach, describe, expect, it, jest } from '@jest/globals';
 import type { NextRequest } from 'next/server';
 import type * as fixTicketsModule from '@/lib/auto-fix/db/fix-tickets';
+import type * as resolveIntegrationModule from '@/lib/auto-fix/github/resolve-integration';
+import type * as githubAdapterModule from '@/lib/integrations/platforms/github/adapter';
+import type { PlatformIntegration } from '@kilocode/db/schema';
 import { deriveCallbackToken } from '@kilocode/worker-utils/callback-token';
 
 const mockGetFixTicketBySessionId = jest.fn() as jest.MockedFunction<
@@ -12,8 +15,12 @@ const mockUpdateFixTicketStatus = jest.fn() as jest.MockedFunction<
 const mockTryDispatchPendingFixes = jest.fn();
 const mockGetBotUserId = jest.fn();
 const mockPostIssueComment = jest.fn();
-const mockGenerateGitHubInstallationToken = jest.fn();
-const mockGetIntegrationById = jest.fn();
+const mockGenerateGitHubInstallationToken = jest.fn() as jest.MockedFunction<
+  typeof githubAdapterModule.generateGitHubInstallationToken
+>;
+const mockResolveAutoFixGitHubIntegration = jest.fn() as jest.MockedFunction<
+  typeof resolveIntegrationModule.resolveAutoFixGitHubIntegration
+>;
 const mockHandleCommentReply = jest.fn();
 const mockHandleCreateIssuePR = jest.fn();
 
@@ -42,8 +49,8 @@ jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   generateGitHubInstallationToken: mockGenerateGitHubInstallationToken,
 }));
 
-jest.mock('@/lib/integrations/db/platform-integrations', () => ({
-  getIntegrationById: mockGetIntegrationById,
+jest.mock('@/lib/auto-fix/github/resolve-integration', () => ({
+  resolveAutoFixGitHubIntegration: mockResolveAutoFixGitHubIntegration,
 }));
 
 jest.mock('@/lib/auto-fix/github/handle-comment-reply', () => ({
@@ -176,5 +183,52 @@ describe('POST /api/internal/auto-fix/pr-callback', () => {
 
     expect(response.status).toBe(403);
     await expect(response.json()).resolves.toMatchObject({ error: 'Ticket ID mismatch' });
+  });
+
+  it('uses the ticket-pinned installation and app type for failure callbacks', async () => {
+    const callbackToken = await deriveCallbackToken({
+      secret: CALLBACK_SECRET,
+      scope: 'auto-fix-pr-callback',
+      resourceParts: [TICKET_ID],
+    });
+    mockGetFixTicketBySessionId.mockResolvedValue({
+      id: TICKET_ID,
+      status: 'running',
+      review_comment_id: null,
+      trigger_source: 'label',
+      platform_integration_id: 'integration-lite',
+      owned_by_organization_id: null,
+      owned_by_user_id: 'user-1',
+      repo_full_name: 'acme/widgets',
+      issue_number: 7,
+    } as Awaited<ReturnType<typeof mockGetFixTicketBySessionId>>);
+    mockResolveAutoFixGitHubIntegration.mockResolvedValue({
+      success: true,
+      integration: {
+        id: 'integration-lite',
+        platform_installation_id: 'installation-lite',
+        github_app_type: 'lite',
+      } as PlatformIntegration,
+    });
+    mockGenerateGitHubInstallationToken.mockResolvedValue({
+      token: 'lite-token',
+      expires_at: '2026-08-27T12:00:00.000Z',
+    });
+
+    const response = await POST(
+      makeRequest(
+        { sessionId: SESSION_ID, status: 'failed', errorMessage: 'execution failed' },
+        { ticketId: TICKET_ID, callbackToken }
+      )
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockResolveAutoFixGitHubIntegration).toHaveBeenCalledWith(
+      expect.objectContaining({ platform_integration_id: 'integration-lite' })
+    );
+    expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledWith('installation-lite', 'lite');
+    expect(mockPostIssueComment).toHaveBeenCalledWith(
+      expect.objectContaining({ githubToken: 'lite-token' })
+    );
   });
 });

--- a/apps/web/src/app/api/internal/auto-fix/pr-callback/route.ts
+++ b/apps/web/src/app/api/internal/auto-fix/pr-callback/route.ts
@@ -31,7 +31,7 @@ import { CALLBACK_TOKEN_SECRET } from '@/lib/config.server';
 import { verifyCallbackToken } from '@kilocode/worker-utils/callback-token';
 import { postIssueComment } from '@/lib/auto-fix/github/post-comment';
 import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
+import { resolveAutoFixGitHubIntegration } from '@/lib/auto-fix/github/resolve-integration';
 import {
   handleCommentReply,
   sanitizePublicErrorMessage,
@@ -206,12 +206,13 @@ export async function POST(req: NextRequest) {
       // Review-comment-triggered tickets are notified on their original review thread.
       if (!isReviewCommentTrigger) {
         try {
-          if (ticket.platform_integration_id) {
-            const integration = await getIntegrationById(ticket.platform_integration_id);
-
-            if (integration?.platform_installation_id) {
+          const integrationResult = await resolveAutoFixGitHubIntegration(ticket);
+          if (integrationResult.success) {
+            const integration = integrationResult.integration;
+            if (integration.platform_installation_id) {
               const tokenData = await generateGitHubInstallationToken(
-                integration.platform_installation_id
+                integration.platform_installation_id,
+                integration.github_app_type ?? 'standard'
               );
 
               await postIssueComment({

--- a/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.test.ts
+++ b/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.test.ts
@@ -16,7 +16,11 @@ import type { PlatformIntegration } from '@kilocode/db/schema';
 import type { PullRequestReviewCommentPayload } from '@/lib/integrations/platforms/github/webhook-schemas';
 
 const mockGetAgentConfigForOwner = jest.fn();
+const mockCreateFixTicket = jest.fn();
 const mockFindExistingReviewCommentFixTicket = jest.fn();
+const mockResetFixTicketForRetry = jest.fn();
+const mockTryDispatchPendingFixes = jest.fn();
+const mockGetBotUserId = jest.fn();
 const mockParseFixCommand = jest.fn();
 const mockAddReactionToPRReviewComment = jest.fn().mockResolvedValue(undefined);
 const mockGetCollaboratorPermissionLevel = jest.fn();
@@ -27,18 +31,18 @@ jest.mock('@/lib/agent-config/db/agent-configs', () => ({
 }));
 
 jest.mock('../../db/fix-tickets', () => ({
-  createFixTicket: jest.fn(),
+  createFixTicket: (...args: unknown[]) => mockCreateFixTicket(...args),
   findExistingReviewCommentFixTicket: (...args: unknown[]) =>
     mockFindExistingReviewCommentFixTicket(...args),
-  resetFixTicketForRetry: jest.fn(),
+  resetFixTicketForRetry: (...args: unknown[]) => mockResetFixTicketForRetry(...args),
 }));
 
 jest.mock('../../dispatch/dispatch-pending-fixes', () => ({
-  tryDispatchPendingFixes: jest.fn().mockResolvedValue(undefined),
+  tryDispatchPendingFixes: (...args: unknown[]) => mockTryDispatchPendingFixes(...args),
 }));
 
 jest.mock('@/lib/bot-users/bot-user-service', () => ({
-  getBotUserId: jest.fn(),
+  getBotUserId: (...args: unknown[]) => mockGetBotUserId(...args),
 }));
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
@@ -102,8 +106,28 @@ const integration = {
   id: 'integration-1',
   owned_by_user_id: 'user-1',
   owned_by_organization_id: null,
+  platform_installation_id: 'installation-1',
   github_app_type: 'standard',
 } as unknown as PlatformIntegration;
+
+const enabledConfig = {
+  is_enabled: true,
+  config: {
+    enabled_for_issues: true,
+    enabled_for_review_comments: true,
+    repository_selection_mode: 'all',
+    selected_repository_ids: [],
+    skip_labels: [],
+    required_labels: [],
+    model_slug: 'anthropic/claude-sonnet-4.5',
+    custom_instructions: null,
+    pr_title_template: 'Fix #{issue_number}: {issue_title}',
+    pr_body_template: null,
+    pr_base_branch: 'main',
+    max_pr_creation_time_minutes: 15,
+    max_concurrent_per_owner: 3,
+  },
+};
 
 describe('ReviewCommentWebhookProcessor admission', () => {
   let processor: ReviewCommentWebhookProcessor;
@@ -112,6 +136,10 @@ describe('ReviewCommentWebhookProcessor admission', () => {
     jest.clearAllMocks();
     // Default: comments are authored by humans, so admission proceeds.
     mockIsLikelyKiloBotActor.mockReturnValue(false);
+    mockFindExistingReviewCommentFixTicket.mockResolvedValue(null);
+    mockResetFixTicketForRetry.mockResolvedValue(true);
+    mockTryDispatchPendingFixes.mockResolvedValue(undefined);
+    mockCreateFixTicket.mockResolvedValue('ticket-1');
     processor = new ReviewCommentWebhookProcessor();
   });
 
@@ -185,5 +213,78 @@ describe('ReviewCommentWebhookProcessor admission', () => {
     expect(mockGetCollaboratorPermissionLevel).not.toHaveBeenCalled();
     expect(mockAddReactionToPRReviewComment).not.toHaveBeenCalled();
     expect(mockGetAgentConfigForOwner).not.toHaveBeenCalled();
+  });
+
+  it('pins a new ticket and GitHub operations to the delivering integration row', async () => {
+    const liteIntegration = {
+      ...integration,
+      id: 'integration-lite',
+      platform_installation_id: 'installation-lite',
+      github_app_type: 'lite',
+    } as PlatformIntegration;
+    mockParseFixCommand.mockReturnValue(true);
+    mockGetAgentConfigForOwner.mockResolvedValue(enabledConfig);
+
+    await processor.process(buildPayload('@kilo fix'), liteIntegration);
+
+    expect(mockCreateFixTicket).toHaveBeenCalledWith(
+      expect.objectContaining({ platformIntegrationId: 'integration-lite' })
+    );
+    expect(mockAddReactionToPRReviewComment).toHaveBeenCalledWith(
+      'installation-lite',
+      'acme',
+      'widgets',
+      1,
+      'eyes',
+      'lite'
+    );
+  });
+
+  it('pins a legacy unpinned ticket when retrying from its delivering integration', async () => {
+    mockParseFixCommand.mockReturnValue(true);
+    mockGetAgentConfigForOwner.mockResolvedValue(enabledConfig);
+    mockFindExistingReviewCommentFixTicket.mockResolvedValue({
+      id: 'ticket-existing',
+      status: 'failed',
+      platform_integration_id: null,
+    });
+
+    await processor.process(buildPayload('@kilo fix'), integration);
+
+    expect(mockResetFixTicketForRetry).toHaveBeenCalledWith('ticket-existing', 'integration-1');
+    expect(mockTryDispatchPendingFixes).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not retry or react through a sibling installation', async () => {
+    mockParseFixCommand.mockReturnValue(true);
+    mockGetAgentConfigForOwner.mockResolvedValue(enabledConfig);
+    mockFindExistingReviewCommentFixTicket.mockResolvedValue({
+      id: 'ticket-existing',
+      status: 'failed',
+      platform_integration_id: 'integration-sibling',
+    });
+
+    await processor.process(buildPayload('@kilo fix'), integration);
+
+    expect(mockResetFixTicketForRetry).not.toHaveBeenCalled();
+    expect(mockTryDispatchPendingFixes).not.toHaveBeenCalled();
+    expect(mockAddReactionToPRReviewComment).not.toHaveBeenCalled();
+  });
+
+  it('does not react or dispatch when a sibling installation wins legacy pinning', async () => {
+    mockParseFixCommand.mockReturnValue(true);
+    mockGetAgentConfigForOwner.mockResolvedValue(enabledConfig);
+    mockFindExistingReviewCommentFixTicket.mockResolvedValue({
+      id: 'ticket-existing',
+      status: 'failed',
+      platform_integration_id: null,
+    });
+    mockResetFixTicketForRetry.mockResolvedValue(false);
+
+    await processor.process(buildPayload('@kilo fix'), integration);
+
+    expect(mockResetFixTicketForRetry).toHaveBeenCalledWith('ticket-existing', 'integration-1');
+    expect(mockTryDispatchPendingFixes).not.toHaveBeenCalled();
+    expect(mockAddReactionToPRReviewComment).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.ts
+++ b/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.ts
@@ -52,11 +52,12 @@ export class ReviewCommentWebhookProcessor {
     payload: PullRequestReviewCommentPayload,
     integration: PlatformIntegration
   ): Promise<void> {
-    const { comment, pull_request, repository, installation } = payload;
-    const installationId = installation.id.toString();
+    const { comment, pull_request, repository } = payload;
+    const installationId = integration.platform_installation_id;
+    const appType = integration.github_app_type ?? 'standard';
     const [repoOwner, repoName] = repository.full_name.split('/');
 
-    if (!repoOwner || !repoName) {
+    if (!repoOwner || !repoName || !installationId) {
       errorExceptInTest(
         '[ReviewCommentWebhookProcessor] Malformed repository.full_name, cannot proceed',
         { fullName: repository.full_name }
@@ -108,7 +109,8 @@ export class ReviewCommentWebhookProcessor {
         installationId,
         repoOwner,
         repoName,
-        comment.user.login
+        comment.user.login,
+        appType
       );
 
       if (!permission || !WRITE_PERMISSION_LEVELS.has(permission)) {
@@ -120,7 +122,14 @@ export class ReviewCommentWebhookProcessor {
         });
         // Add thumbs-down reaction to indicate permission denied
         try {
-          await addReactionToPRReviewComment(installationId, repoOwner, repoName, comment.id, '-1');
+          await addReactionToPRReviewComment(
+            installationId,
+            repoOwner,
+            repoName,
+            comment.id,
+            '-1',
+            appType
+          );
         } catch {
           // Best-effort reaction
         }
@@ -209,6 +218,18 @@ export class ReviewCommentWebhookProcessor {
       comment.id
     );
 
+    if (
+      existingTicket?.platform_integration_id &&
+      existingTicket.platform_integration_id !== integration.id
+    ) {
+      logExceptInTest('[ReviewCommentWebhookProcessor] Ignoring sibling installation retry', {
+        ticketId: existingTicket.id,
+        ticketIntegrationId: existingTicket.platform_integration_id,
+        deliveringIntegrationId: integration.id,
+      });
+      return;
+    }
+
     // 8. Resolve dispatch owner (org bot user or personal owner)
     let dispatchOwner: Owner;
     if (owner.type === 'org') {
@@ -224,7 +245,8 @@ export class ReviewCommentWebhookProcessor {
             repoOwner,
             repoName,
             comment.id,
-            'confused'
+            'confused',
+            appType
           );
         } catch {
           // Best-effort reaction
@@ -252,7 +274,14 @@ export class ReviewCommentWebhookProcessor {
           }
         );
         try {
-          await addReactionToPRReviewComment(installationId, repoOwner, repoName, comment.id, '+1');
+          await addReactionToPRReviewComment(
+            installationId,
+            repoOwner,
+            repoName,
+            comment.id,
+            '+1',
+            appType
+          );
         } catch {
           // Best-effort reaction
         }
@@ -266,7 +295,14 @@ export class ReviewCommentWebhookProcessor {
       });
 
       try {
-        await resetFixTicketForRetry(existingTicket.id);
+        const reset = await resetFixTicketForRetry(existingTicket.id, integration.id);
+        if (!reset) {
+          logExceptInTest('[ReviewCommentWebhookProcessor] Sibling installation won retry pin', {
+            ticketId: existingTicket.id,
+            deliveringIntegrationId: integration.id,
+          });
+          return;
+        }
 
         try {
           await addReactionToPRReviewComment(
@@ -274,7 +310,8 @@ export class ReviewCommentWebhookProcessor {
             repoOwner,
             repoName,
             comment.id,
-            'eyes'
+            'eyes',
+            appType
           );
         } catch (reactionError) {
           errorExceptInTest(
@@ -302,7 +339,8 @@ export class ReviewCommentWebhookProcessor {
             repoOwner,
             repoName,
             comment.id,
-            'confused'
+            'confused',
+            appType
           );
         } catch {
           // Best-effort reaction
@@ -314,7 +352,14 @@ export class ReviewCommentWebhookProcessor {
 
     // 10. Add eyes reaction to acknowledge the mention
     try {
-      await addReactionToPRReviewComment(installationId, repoOwner, repoName, comment.id, 'eyes');
+      await addReactionToPRReviewComment(
+        installationId,
+        repoOwner,
+        repoName,
+        comment.id,
+        'eyes',
+        appType
+      );
     } catch (reactionError) {
       errorExceptInTest(
         '[ReviewCommentWebhookProcessor] Failed to add eyes reaction:',
@@ -372,7 +417,8 @@ export class ReviewCommentWebhookProcessor {
           repoOwner,
           repoName,
           comment.id,
-          'confused'
+          'confused',
+          appType
         );
       } catch {
         // Best-effort reaction

--- a/apps/web/src/lib/auto-fix/db/fix-tickets.ts
+++ b/apps/web/src/lib/auto-fix/db/fix-tickets.ts
@@ -7,7 +7,7 @@
 
 import { db } from '@/lib/drizzle';
 import { auto_fix_tickets } from '@kilocode/db/schema';
-import { eq, and, desc, count, or } from 'drizzle-orm';
+import { eq, and, desc, count, or, isNull } from 'drizzle-orm';
 import { captureException } from '@sentry/nextjs';
 import { AUTO_FIX_CONSTANTS } from '../core/schemas';
 import type {
@@ -340,12 +340,16 @@ export async function countFixTickets(params: {
  * Resets a failed fix ticket for retry
  * Clears status back to 'pending' and removes error/session data
  */
-export async function resetFixTicketForRetry(ticketId: string): Promise<void> {
+export async function resetFixTicketForRetry(
+  ticketId: string,
+  platformIntegrationId: string
+): Promise<boolean> {
   try {
-    await db
+    const resetTickets = await db
       .update(auto_fix_tickets)
       .set({
         status: 'pending',
+        platform_integration_id: platformIntegrationId,
         session_id: null,
         cli_session_id: null,
         error_message: null,
@@ -353,7 +357,17 @@ export async function resetFixTicketForRetry(ticketId: string): Promise<void> {
         completed_at: null,
         updated_at: new Date().toISOString(),
       })
-      .where(eq(auto_fix_tickets.id, ticketId));
+      .where(
+        and(
+          eq(auto_fix_tickets.id, ticketId),
+          or(
+            isNull(auto_fix_tickets.platform_integration_id),
+            eq(auto_fix_tickets.platform_integration_id, platformIntegrationId)
+          )
+        )
+      )
+      .returning({ id: auto_fix_tickets.id });
+    return resetTickets.length === 1;
   } catch (error) {
     captureException(error, {
       tags: { operation: 'resetFixTicketForRetry' },

--- a/apps/web/src/lib/auto-fix/github/get-fix-config.test.ts
+++ b/apps/web/src/lib/auto-fix/github/get-fix-config.test.ts
@@ -1,0 +1,64 @@
+const mockGetFixTicketById = jest.fn();
+const mockResolveAutoFixGitHubIntegration = jest.fn();
+const mockGenerateGitHubInstallationToken = jest.fn();
+
+jest.mock('@/lib/auto-fix/db/fix-tickets', () => ({
+  getFixTicketById: (...args: unknown[]) => mockGetFixTicketById(...args),
+}));
+
+jest.mock('./resolve-integration', () => ({
+  resolveAutoFixGitHubIntegration: (...args: unknown[]) =>
+    mockResolveAutoFixGitHubIntegration(...args),
+}));
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  generateGitHubInstallationToken: (...args: unknown[]) =>
+    mockGenerateGitHubInstallationToken(...args),
+}));
+
+jest.mock('@/lib/agent-config/db/agent-configs', () => ({
+  getAgentConfigForOwner: jest.fn(),
+}));
+
+jest.mock('@/lib/bot-users/bot-user-service', () => ({
+  getBotUserId: jest.fn(),
+}));
+
+jest.mock('@/lib/utils.server', () => ({
+  logExceptInTest: jest.fn(),
+  errorExceptInTest: jest.fn(),
+}));
+
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+import { getFixConfig } from './get-fix-config';
+
+describe('getFixConfig installation resolution', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGetFixTicketById.mockResolvedValue({
+      id: 'ticket-1',
+      owned_by_organization_id: 'org-1',
+      owned_by_user_id: null,
+      platform_integration_id: null,
+      repo_full_name: 'acme/widgets',
+    });
+  });
+
+  it('fails closed when a legacy unpinned ticket matches multiple installations', async () => {
+    mockResolveAutoFixGitHubIntegration.mockResolvedValue({
+      success: false,
+      reason: 'ambiguous_installation',
+    });
+
+    await expect(getFixConfig('ticket-1')).resolves.toEqual({
+      ok: false,
+      error: 'Multiple GitHub installations can access this repository',
+      status: 409,
+    });
+    expect(mockGenerateGitHubInstallationToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/auto-fix/github/get-fix-config.ts
+++ b/apps/web/src/lib/auto-fix/github/get-fix-config.ts
@@ -12,9 +12,9 @@ import { logExceptInTest, errorExceptInTest } from '@/lib/utils.server';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
 import { AutoFixAgentConfigSchema } from '@/lib/auto-fix/core/schemas';
 import type { Owner } from '@/lib/auto-fix/core/schemas';
+import { resolveAutoFixGitHubIntegration } from './resolve-integration';
 
 type GetFixConfigResult =
   | {
@@ -45,30 +45,39 @@ export async function getFixConfig(ticketId: string): Promise<GetFixConfigResult
     return { ok: false, error: 'Ticket not found', status: 404 };
   }
 
-  let githubToken: string | undefined;
+  const integrationResult = await resolveAutoFixGitHubIntegration(ticket);
+  if (!integrationResult.success) {
+    const error =
+      integrationResult.reason === 'ambiguous_installation'
+        ? 'Multiple GitHub installations can access this repository'
+        : 'GitHub installation not found for this ticket';
+    return {
+      ok: false,
+      error,
+      status: integrationResult.reason === 'ambiguous_installation' ? 409 : 404,
+    };
+  }
 
-  if (ticket.platform_integration_id) {
-    try {
-      const integration = await getIntegrationById(ticket.platform_integration_id);
+  const integration = integrationResult.integration;
+  const installationId = integration.platform_installation_id;
+  if (!installationId) {
+    return { ok: false, error: 'GitHub installation not found for this ticket', status: 404 };
+  }
 
-      if (integration?.platform_installation_id) {
-        const tokenData = await generateGitHubInstallationToken(
-          integration.platform_installation_id
-        );
-        githubToken = tokenData.token;
-
-        logExceptInTest('[auto-fix-config] GitHub token obtained', {
-          ticketId,
-          hasToken: !!githubToken,
-        });
-      }
-    } catch (authError) {
-      errorExceptInTest('[auto-fix-config] Failed to get GitHub token:', authError);
-      captureException(authError, {
-        tags: { operation: 'auto-fix-config', step: 'get-github-token' },
-        extra: { ticketId, platformIntegrationId: ticket.platform_integration_id },
-      });
-    }
+  let githubToken: string;
+  try {
+    const tokenData = await generateGitHubInstallationToken(
+      installationId,
+      integration.github_app_type ?? 'standard'
+    );
+    githubToken = tokenData.token;
+  } catch (authError) {
+    errorExceptInTest('[auto-fix-config] Failed to get GitHub token:', authError);
+    captureException(authError, {
+      tags: { operation: 'auto-fix-config', step: 'get-github-token' },
+      extra: { ticketId, platformIntegrationId: integration.id },
+    });
+    return { ok: false, error: 'Failed to authenticate with GitHub', status: 500 };
   }
 
   if (!ticket.owned_by_organization_id && !ticket.owned_by_user_id) {

--- a/apps/web/src/lib/auto-fix/github/handle-comment-reply.ts
+++ b/apps/web/src/lib/auto-fix/github/handle-comment-reply.ts
@@ -18,7 +18,7 @@ import {
   addReactionToPRReviewComment,
   getPRHeadCommit,
 } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
+import { resolveAutoFixGitHubIntegration } from './resolve-integration';
 import { z } from 'zod';
 
 export const CommentReplyPayloadSchema = z.object({
@@ -172,21 +172,14 @@ export async function handleCommentReply(
     return { ok: true, action: 'skipped_terminal' };
   }
 
-  // Resolve GitHub installation ID
-  let installationId: string | undefined;
-  if (ticket.platform_integration_id) {
-    try {
-      const integration = await getIntegrationById(ticket.platform_integration_id);
-      installationId = integration?.platform_installation_id ?? undefined;
-    } catch (error) {
-      errorExceptInTest('[auto-fix-comment-reply] Failed to get integration:', error);
-    }
-  }
-
-  if (!installationId) {
+  const integrationResult = await resolveAutoFixGitHubIntegration(ticket);
+  const integration = integrationResult.success ? integrationResult.integration : null;
+  const installationId = integration?.platform_installation_id;
+  if (!installationId || !integration) {
     errorExceptInTest('[auto-fix-comment-reply] No installation ID found', { ticketId });
     return { ok: false, error: 'GitHub installation not found', status: 500 };
   }
+  const appType = integration.github_app_type ?? 'standard';
 
   const [repoOwner, repoName] = ticket.repo_full_name.split('/');
 
@@ -203,7 +196,8 @@ export async function handleCommentReply(
           repoOwner,
           repoName,
           ticket.review_comment_id,
-          '+1'
+          '+1',
+          appType
         );
         logExceptInTest('[auto-fix-comment-reply] Added +1 reaction on review comment', {
           ticketId,
@@ -225,7 +219,8 @@ export async function handleCommentReply(
           installationId,
           repoOwner,
           repoName,
-          ticket.issue_number
+          ticket.issue_number,
+          appType
         );
         const shortSha = headCommitSha.slice(0, 8);
         const commitUrl = `https://github.com/${repoOwner}/${repoName}/commit/${headCommitSha}`;
@@ -244,7 +239,8 @@ export async function handleCommentReply(
           repoName,
           ticket.issue_number,
           ticket.review_comment_id,
-          successReplyBody
+          successReplyBody,
+          appType
         );
         logExceptInTest('[auto-fix-comment-reply] Posted success reply on review thread', {
           ticketId,
@@ -300,7 +296,8 @@ export async function handleCommentReply(
       repoName,
       ticket.issue_number,
       ticket.review_comment_id,
-      replyBody
+      replyBody,
+      appType
     );
 
     logExceptInTest('[auto-fix-comment-reply] Posted failure reply on review thread', {
@@ -316,7 +313,8 @@ export async function handleCommentReply(
         repoOwner,
         repoName,
         ticket.review_comment_id,
-        'confused'
+        'confused',
+        appType
       );
     } catch {
       // Best-effort reaction
@@ -343,7 +341,8 @@ export async function handleCommentReply(
         repoOwner,
         repoName,
         ticket.review_comment_id,
-        'confused'
+        'confused',
+        appType
       );
     } catch {
       // Best-effort reaction

--- a/apps/web/src/lib/auto-fix/github/resolve-integration.ts
+++ b/apps/web/src/lib/auto-fix/github/resolve-integration.ts
@@ -1,0 +1,46 @@
+import type { AutoFixTicket, PlatformIntegration } from '@kilocode/db/schema';
+import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
+import {
+  getGitHubIntegrationById,
+  resolveOrganizationGitHubIntegrationForRepository,
+  type OrganizationGitHubIntegrationResolution,
+} from '@/lib/integrations/db/platform-integrations';
+
+export type AutoFixGitHubIntegrationResolution = OrganizationGitHubIntegrationResolution;
+
+export async function resolveAutoFixGitHubIntegration(
+  ticket: Pick<
+    AutoFixTicket,
+    'owned_by_organization_id' | 'owned_by_user_id' | 'platform_integration_id' | 'repo_full_name'
+  >
+): Promise<AutoFixGitHubIntegrationResolution> {
+  if (ticket.owned_by_organization_id) {
+    return resolveOrganizationGitHubIntegrationForRepository({
+      organizationId: ticket.owned_by_organization_id,
+      repositoryFullName: ticket.repo_full_name,
+      expectedPlatformIntegrationId: ticket.platform_integration_id ?? undefined,
+    });
+  }
+
+  if (!ticket.owned_by_user_id || !ticket.platform_integration_id) {
+    return { success: false, reason: 'no_installation_found' };
+  }
+
+  const integration = await getGitHubIntegrationById(
+    { type: 'user', id: ticket.owned_by_user_id },
+    ticket.platform_integration_id
+  );
+  if (!isUsablePersonalIntegration(integration)) {
+    return { success: false, reason: 'no_installation_found' };
+  }
+
+  return { success: true, integration };
+}
+
+function isUsablePersonalIntegration(
+  integration: PlatformIntegration | null
+): integration is PlatformIntegration {
+  return Boolean(
+    integration?.platform_installation_id && isPlatformIntegrationHealthy(integration)
+  );
+}

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -8,6 +8,7 @@ const mockGetIntegrationForOrganization = jest.fn();
 const mockLogWebhookEvent = jest.fn();
 const mockUpdateWebhookEvent = jest.fn();
 const mockHandlePullRequest = jest.fn();
+const mockHandleIssue = jest.fn();
 const mockHandlePRReviewComment = jest.fn();
 const mockHandleGitHubReviewCommentReply = jest.fn();
 const mockHandleInstallationTargetRenamed = jest.fn();
@@ -55,7 +56,8 @@ jest.mock('@/lib/integrations/platforms/github/webhook-handlers', () => ({
     mockHandleInstallationUnsuspend(payload, appType),
   handleInstallationTargetRenamed: (payload: unknown, integrationId: string, appType: string) =>
     mockHandleInstallationTargetRenamed(payload, integrationId, appType),
-  handleIssue: jest.fn(),
+  handleIssue: (payload: unknown, platformIntegration: unknown) =>
+    mockHandleIssue(payload, platformIntegration),
   handlePRReviewComment: (payload: unknown, platformIntegration: unknown) =>
     mockHandlePRReviewComment(payload, platformIntegration),
   handlePullRequest: (payload: unknown, platformIntegration: unknown) =>
@@ -184,6 +186,30 @@ function issueCommentPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function issuePayload(action: string) {
+  return {
+    action,
+    installation: { id: 98765 },
+    repository: {
+      id: 123,
+      name: 'widgets',
+      full_name: 'acme/widgets',
+      private: true,
+      owner: { login: 'acme' },
+    },
+    issue: {
+      number: 7,
+      html_url: 'https://github.com/acme/widgets/issues/7',
+      title: 'Broken widget',
+      body: 'Please fix it',
+      user: { login: 'alice' },
+      labels: [{ name: 'kilo-auto-fix' }],
+    },
+    label: { name: 'kilo-auto-fix' },
+    sender: { login: 'alice' },
+  };
+}
+
 async function waitForAfterTask() {
   await new Promise(resolve => setTimeout(resolve, 0));
 }
@@ -197,6 +223,7 @@ describe('handleGitHubWebhook', () => {
     mockLogWebhookEvent.mockResolvedValue({ id: 'we_1', isDuplicate: false });
     mockUpdateWebhookEvent.mockResolvedValue(undefined);
     mockHandlePullRequest.mockResolvedValue(Response.json({ message: 'review queued' }));
+    mockHandleIssue.mockResolvedValue(Response.json({ message: 'fix queued' }));
     mockHandlePRReviewComment.mockResolvedValue(undefined);
     mockHandleGitHubReviewCommentReply.mockResolvedValue({
       recorded: false,
@@ -354,6 +381,45 @@ describe('handleGitHubWebhook', () => {
     expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
       'we_1',
       expect.objectContaining({ handlers_triggered: ['pr_review_comment_fix'] })
+    );
+  });
+
+  it('allows only Auto Fix review comments through a secondary installation', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request_review_comment', reviewCommentPayload()),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    await waitForAfterTask();
+    expect(mockHandlePRReviewComment).toHaveBeenCalledWith(expect.anything(), integration);
+    expect(mockHandleGitHubReviewCommentReply).not.toHaveBeenCalled();
+  });
+
+  it('allows labeled Auto Fix issues but suppresses other issues on a secondary installation', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
+
+    const labeledResponse = await handleGitHubWebhook(
+      signedGitHubRequest('issues', issuePayload('labeled')),
+      'standard'
+    );
+    const openedResponse = await handleGitHubWebhook(
+      signedGitHubRequest('issues', issuePayload('opened')),
+      'standard'
+    );
+
+    expect(labeledResponse.status).toBe(200);
+    expect(openedResponse.status).toBe(200);
+    expect(mockHandleIssue).toHaveBeenCalledTimes(1);
+    expect(mockHandleIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'labeled' }),
+      integration
+    );
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'we_1',
+      expect.objectContaining({ handlers_triggered: ['auto_fix'] })
     );
   });
 

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -466,7 +466,15 @@ export async function handleGitHubWebhook(
       ? await getIntegrationForOrganization(integration.owned_by_organization_id, PLATFORM.GITHUB)
       : integration;
     const isSecondaryOrganizationInstallation = primaryIntegration?.id !== integration.id;
-    if (isSecondaryOrganizationInstallation && eventType !== GITHUB_EVENT.PULL_REQUEST) {
+    const action = (payload as { action?: string }).action;
+    const isSecondaryAutoFixEvent =
+      (eventType === GITHUB_EVENT.ISSUES && action === GITHUB_ACTION.LABELED) ||
+      (eventType === GITHUB_EVENT.PULL_REQUEST_REVIEW_COMMENT && action === GITHUB_ACTION.CREATED);
+    if (
+      isSecondaryOrganizationInstallation &&
+      eventType !== GITHUB_EVENT.PULL_REQUEST &&
+      !isSecondaryAutoFixEvent
+    ) {
       logExceptInTest('Secondary GitHub installation event suppressed', {
         integration_id: integration.id,
         event_type: eventType,
@@ -694,12 +702,14 @@ export async function handleGitHubWebhook(
         try {
           await handlePRReviewComment(parseResult.data, integration);
           try {
-            const reviewMemoryResult = await handleGitHubReviewCommentReply({
-              payload: parseResult.data,
-              integration,
-              deliveryId: eventSignature,
-            });
-            if (reviewMemoryResult.recorded) handlersTriggered.push('review_memory_feedback');
+            if (!isSecondaryOrganizationInstallation) {
+              const reviewMemoryResult = await handleGitHubReviewCommentReply({
+                payload: parseResult.data,
+                integration,
+                deliveryId: eventSignature,
+              });
+              if (reviewMemoryResult.recorded) handlersTriggered.push('review_memory_feedback');
+            }
           } catch (error) {
             logExceptInTest(`Error handling review memory feedback${logSuffix}:`, error);
             captureException(error, {
@@ -772,7 +782,7 @@ export async function handleGitHubWebhook(
           await updateWebhookEvent(logResult.webhookEventId, {
             processed: true,
             processed_at: new Date().toISOString(),
-            handlers_triggered: ['auto_triage'],
+            handlers_triggered: [action === GITHUB_ACTION.LABELED ? 'auto_fix' : 'auto_triage'],
             errors: null,
           });
         } catch (error) {

--- a/apps/web/src/routers/auto-fix/auto-fix-router.ts
+++ b/apps/web/src/routers/auto-fix/auto-fix-router.ts
@@ -42,6 +42,8 @@ import {
   upsertAgentConfigForOwner,
 } from '@/lib/agent-config/db/agent-configs';
 import { tryDispatchPendingFixes } from '@/lib/auto-fix/dispatch/dispatch-pending-fixes';
+import { getBotUserId } from '@/lib/bot-users/bot-user-service';
+import { resolveAutoFixGitHubIntegration } from '@/lib/auto-fix/github/resolve-integration';
 
 export const autoFixRouter = createTRPCRouter({
   /**
@@ -230,20 +232,47 @@ export const autoFixRouter = createTRPCRouter({
       }
 
       // Determine owner for dispatch
-      const owner: Owner = ticket.owned_by_organization_id
-        ? {
-            type: 'org',
-            id: ticket.owned_by_organization_id,
-            userId: ctx.user.id,
-          }
-        : {
-            type: 'user',
-            id: ticket.owned_by_user_id || ctx.user.id,
-            userId: ctx.user.id,
-          };
+      let owner: Owner;
+      if (ticket.owned_by_organization_id) {
+        const botUserId = await getBotUserId(ticket.owned_by_organization_id, 'auto-fix');
+        if (!botUserId) {
+          throw new TRPCError({
+            code: 'PRECONDITION_FAILED',
+            message: 'Auto Fix bot user is not configured for this organization',
+          });
+        }
+        owner = {
+          type: 'org',
+          id: ticket.owned_by_organization_id,
+          userId: botUserId,
+        };
+      } else {
+        owner = {
+          type: 'user',
+          id: ticket.owned_by_user_id || ctx.user.id,
+          userId: ctx.user.id,
+        };
+      }
+
+      const integrationResult = await resolveAutoFixGitHubIntegration(ticket);
+      if (!integrationResult.success) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message:
+            integrationResult.reason === 'ambiguous_installation'
+              ? 'Multiple GitHub installations can access this repository'
+              : 'The GitHub installation for this fix is unavailable',
+        });
+      }
 
       // Reset the ticket for retry
-      await resetFixTicketForRetry(input.ticketId);
+      const reset = await resetFixTicketForRetry(input.ticketId, integrationResult.integration.id);
+      if (!reset) {
+        throw new TRPCError({
+          code: 'CONFLICT',
+          message: 'The GitHub installation for this fix changed during retry',
+        });
+      }
 
       // Trigger dispatch to process pending tickets
       await tryDispatchPendingFixes(owner);

--- a/apps/web/src/routers/organizations/organization-auto-fix-router.ts
+++ b/apps/web/src/routers/organizations/organization-auto-fix-router.ts
@@ -4,7 +4,7 @@ import {
   organizationMemberMutationProcedure,
   organizationBillingMutationProcedure,
 } from './utils';
-import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
+import { fetchAllGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
 import {
   getAgentConfigForOwner,
   upsertAgentConfigForOwner,
@@ -42,7 +42,7 @@ const ToggleAutoFixAgentInputSchema = z
 
 export const organizationAutoFixRouter = createTRPCRouter({
   listGitHubRepositories: organizationMemberProcedure.query(async ({ input }) => {
-    return await fetchGitHubRepositoriesForOrganization(input.organizationId);
+    return await fetchAllGitHubRepositoriesForOrganization(input.organizationId);
   }),
 
   getAutoFixConfig: organizationMemberProcedure.query(async ({ input, ctx }) => {


### PR DESCRIPTION
## Why this PR exists

Auto Fix currently assumes one organization GitHub installation. Secondary label and review-comment events are suppressed, repository configuration omits secondary installations, and retry/callback paths can re-resolve credentials by repository name. With overlapping installations, that can either make Auto Fix unavailable or continue a fix through the wrong GitHub App.

This PR enables only the Auto Fix event lifecycle after pinning each ticket and callback to one exact installation.

## Place in the rollout

This is the Auto Fix product slice. Auto Triage uses different issue actions and is separate in #5563. Review Memory feedback shares the review-comment event but remains a distinct side effect in #5577.

## Dependency

Depends on #5547 for unique repository-to-installation resolution. After #5547 merges, retarget this PR to `main`.

## What changes

- Aggregate Auto Fix repository configuration across healthy installations with provenance.
- Pin new tickets to the delivering or selected integration.
- Atomically pin legacy retry tickets so sibling events cannot race to claim them.
- Resolve callbacks, configuration, reactions, replies, permissions, and PR-head lookups through the pinned row and app type.
- Admit only secondary `issues.labeled` and created `pull_request_review_comment` events required by Auto Fix.

## What stays unchanged

- Auto Triage event behavior is not changed here.
- Other review-comment side effects remain primary-only until #5577.
- Ambiguous legacy tickets and repositories fail closed.

## Why this touches several Auto Fix modules

A fix ticket crosses webhook processing, retry persistence, configuration lookup, comment replies, and an asynchronous PR callback. Pinning only the first webhook would be lost later, so each existing boundary must consume the same stored integration. The changes remain within Auto Fix plus the narrow webhook admission predicate.

## Review guide

Start with `resolve-integration.ts` and ticket pinning, then follow the integration through review-comment processing and the PR callback. Review `webhook-handler.ts` last to verify only Auto Fix event/action combinations are admitted.

## Validation

- 5 focused suites, 45 tests
- Web typecheck and lint
- Formatting and `git diff --check`

The standard Jest DB harness was unavailable; focused suites used isolated mocks.