### PR TITLE
feat(app-builder): keep previews on the GitHub install chosen at migration

### DIFF
--- a/apps/web/src/components/app-builder/MigrateToGitHubDialog.tsx
+++ b/apps/web/src/components/app-builder/MigrateToGitHubDialog.tsx
@@ -51,6 +51,8 @@ type Step = 'create' | 'grant-access' | 'select' | 'success';
 
 const errorMessages: Record<MigrateToGitHubErrorCode, string> = {
   github_app_not_installed: 'GitHub App is not installed. Please install the GitHub App first.',
+  github_integration_unavailable:
+    'The GitHub installation selected for this repository is no longer available.',
   already_migrated: 'This project has already been migrated to GitHub.',
   repo_not_found:
     "Repository not found or not accessible. Make sure you've granted the Kilo GitHub App access to this repository.",
@@ -149,10 +151,11 @@ export function MigrateToGitHubDialog({
   const repositoryOptions: RepositoryOption[] = useMemo(
     () =>
       (canMigrateData?.availableRepos ?? []).map(repo => ({
-        id: repo.fullName,
+        id: `${repo.platformIntegrationId ?? 'legacy'}:${repo.fullName}`,
         fullName: repo.fullName,
         private: repo.isPrivate,
         platform: 'github' as const,
+        platformIntegrationId: repo.platformIntegrationId,
       })),
     [canMigrateData?.availableRepos]
   );
@@ -191,13 +194,21 @@ export function MigrateToGitHubDialog({
     if (!selectedRepo) return;
 
     setMigrationError(null);
+    const expectedPlatformIntegrationId = repositoryOptions.find(
+      repo => repo.fullName === selectedRepo
+    )?.platformIntegrationId;
 
     if (organizationId) {
-      orgMigrate({ projectId, organizationId, repoFullName: selectedRepo });
+      orgMigrate({
+        projectId,
+        organizationId,
+        repoFullName: selectedRepo,
+        expectedPlatformIntegrationId,
+      });
     } else {
       personalMigrate({ projectId, repoFullName: selectedRepo });
     }
-  }, [organizationId, orgMigrate, personalMigrate, projectId, selectedRepo]);
+  }, [organizationId, orgMigrate, personalMigrate, projectId, repositoryOptions, selectedRepo]);
 
   // Skip grant-access step if user has "all repositories" access
   const needsGrantAccess = canMigrateData?.repositorySelection === 'selected';

--- a/apps/web/src/lib/app-builder/github-migration-service.test.ts
+++ b/apps/web/src/lib/app-builder/github-migration-service.test.ts
@@ -1,0 +1,220 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { PlatformIntegration } from '@kilocode/db/schema';
+import type * as GitHubMigrationService from './github-migration-service';
+
+const mockGetProjectWithOwnershipCheck = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockGetIntegrationForOwner = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockGetIntegrationsByOrganization = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockResolveOrganizationIntegration = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockUpdateRepositoriesForIntegration = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockFetchInstallationDetails = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockFetchRepositories = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockGetRepositoryDetails = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockGetInstallationSettingsUrl = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const mockMigrateToGithub = jest.fn<(...args: unknown[]) => Promise<unknown>>();
+const returningRows: unknown[][] = [];
+const mockReturning = jest.fn(async () => returningRows.shift() ?? []);
+const mockWhere = jest.fn(() => ({ returning: mockReturning }));
+const mockSet = jest.fn(() => ({ where: mockWhere }));
+
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    update: jest.fn(() => ({ set: mockSet })),
+  },
+}));
+
+jest.mock('@/lib/config.server', () => ({
+  APP_BUILDER_URL: 'https://builder.example.com',
+  APP_BUILDER_AUTH_TOKEN: 'test-auth',
+}));
+
+jest.mock('@/lib/app-builder/project-ownership', () => ({
+  getProjectWithOwnershipCheck: (...args: unknown[]) => mockGetProjectWithOwnershipCheck(...args),
+}));
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationForOwner: (...args: unknown[]) => mockGetIntegrationForOwner(...args),
+  getIntegrationsByOrganization: (...args: unknown[]) => mockGetIntegrationsByOrganization(...args),
+  resolveOrganizationGitHubIntegrationForRepository: (...args: unknown[]) =>
+    mockResolveOrganizationIntegration(...args),
+  updateRepositoriesForIntegration: (...args: unknown[]) =>
+    mockUpdateRepositoriesForIntegration(...args),
+}));
+
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  fetchGitHubInstallationDetails: (...args: unknown[]) => mockFetchInstallationDetails(...args),
+  fetchGitHubRepositories: (...args: unknown[]) => mockFetchRepositories(...args),
+  getRepositoryDetails: (...args: unknown[]) => mockGetRepositoryDetails(...args),
+  getInstallationSettingsUrl: (...args: unknown[]) => mockGetInstallationSettingsUrl(...args),
+}));
+
+jest.mock('@/lib/app-builder/app-builder-client', () => ({
+  migrateToGithub: (...args: unknown[]) => mockMigrateToGithub(...args),
+}));
+
+let canMigrateToGitHub: typeof GitHubMigrationService.canMigrateToGitHub;
+let migrateProjectToGitHub: typeof GitHubMigrationService.migrateProjectToGitHub;
+
+const organizationId = '123e4567-e89b-12d3-a456-426614174001';
+const standardIntegrationId = '123e4567-e89b-12d3-a456-426614174002';
+const liteIntegrationId = '123e4567-e89b-12d3-a456-426614174003';
+
+function integration(
+  id: string,
+  installationId: string,
+  appType: 'standard' | 'lite',
+  accountLogin: string
+): PlatformIntegration {
+  return {
+    id,
+    platform: 'github',
+    integration_type: 'app',
+    integration_status: 'active',
+    platform_installation_id: installationId,
+    platform_account_login: accountLogin,
+    github_app_type: appType,
+    suspended_at: null,
+    auth_invalid_at: null,
+  } as PlatformIntegration;
+}
+
+const standardIntegration = integration(
+  standardIntegrationId,
+  'installation-standard',
+  'standard',
+  'acme-core'
+);
+const liteIntegration = integration(liteIntegrationId, 'installation-lite', 'lite', 'acme-apps');
+const project = {
+  id: '123e4567-e89b-12d3-a456-426614174004',
+  title: 'Identity test',
+  git_repo_full_name: null,
+  deployment_id: null,
+  session_id: 'session-1',
+};
+
+beforeAll(async () => {
+  ({ canMigrateToGitHub, migrateProjectToGitHub } = await import('./github-migration-service'));
+});
+
+beforeEach(() => {
+  jest.clearAllMocks();
+  returningRows.length = 0;
+  mockGetProjectWithOwnershipCheck.mockResolvedValue(project);
+  mockGetIntegrationsByOrganization.mockResolvedValue([standardIntegration, liteIntegration]);
+  mockFetchInstallationDetails.mockImplementation(async (installationId: unknown) => ({
+    account: {
+      login: installationId === 'installation-lite' ? 'acme-apps' : 'acme-core',
+      type: 'Organization',
+    },
+    repository_selection: installationId === 'installation-lite' ? 'selected' : 'all',
+  }));
+  mockGetInstallationSettingsUrl.mockResolvedValue('https://github.com/settings/installations/1');
+  mockFetchRepositories.mockImplementation(async (installationId: unknown) =>
+    installationId === 'installation-lite'
+      ? [
+          {
+            id: 2,
+            name: 'secondary',
+            full_name: 'acme-apps/secondary',
+            private: true,
+            created_at: '2026-08-27T10:00:00.000Z',
+          },
+        ]
+      : [
+          {
+            id: 1,
+            name: 'primary',
+            full_name: 'acme-core/primary',
+            private: false,
+            created_at: '2026-08-26T10:00:00.000Z',
+          },
+        ]
+  );
+});
+
+describe('App Builder GitHub integration identity', () => {
+  it('returns secondary repositories with their integration identity and preserves app type', async () => {
+    const result = await canMigrateToGitHub(project.id, { type: 'org', id: organizationId });
+
+    expect(result.availableRepos).toEqual([
+      expect.objectContaining({
+        fullName: 'acme-apps/secondary',
+        platformIntegrationId: liteIntegrationId,
+      }),
+      expect.objectContaining({
+        fullName: 'acme-core/primary',
+        platformIntegrationId: standardIntegrationId,
+      }),
+    ]);
+    expect(mockFetchRepositories).toHaveBeenCalledWith('installation-standard', 'standard');
+    expect(mockFetchRepositories).toHaveBeenCalledWith('installation-lite', 'lite');
+    expect(mockUpdateRepositoriesForIntegration).toHaveBeenCalledWith(
+      liteIntegrationId,
+      expect.arrayContaining([expect.objectContaining({ full_name: 'acme-apps/secondary' })])
+    );
+  });
+
+  it('uses the exact secondary integration for validation and worker migration', async () => {
+    returningRows.push([project]);
+    mockResolveOrganizationIntegration.mockResolvedValue({
+      success: true,
+      integration: liteIntegration,
+    });
+    mockGetRepositoryDetails.mockResolvedValue({
+      fullName: 'acme-apps/secondary',
+      cloneUrl: 'https://github.com/acme-apps/secondary.git',
+      htmlUrl: 'https://github.com/acme-apps/secondary',
+      isEmpty: true,
+      isPrivate: true,
+    });
+    mockMigrateToGithub.mockResolvedValue({ success: true });
+
+    await expect(
+      migrateProjectToGitHub({
+        projectId: project.id,
+        owner: { type: 'org', id: organizationId },
+        userId: 'oauth/example-user',
+        repoFullName: 'acme-apps/secondary',
+        expectedPlatformIntegrationId: liteIntegrationId,
+      })
+    ).resolves.toMatchObject({ success: true });
+
+    expect(mockResolveOrganizationIntegration).toHaveBeenCalledWith({
+      organizationId,
+      repositoryFullName: 'acme-apps/secondary',
+      expectedPlatformIntegrationId: liteIntegrationId,
+    });
+    expect(mockGetRepositoryDetails).toHaveBeenCalledWith(
+      'installation-lite',
+      'acme-apps/secondary',
+      'lite'
+    );
+    expect(mockMigrateToGithub).toHaveBeenCalledWith(project.id, {
+      githubRepo: 'acme-apps/secondary',
+      userId: 'oauth/example-user',
+      orgId: organizationId,
+      expectedPlatformIntegrationId: liteIntegrationId,
+    });
+  });
+
+  it('does not fall back when the expected integration is stale', async () => {
+    returningRows.push([project]);
+    mockResolveOrganizationIntegration.mockResolvedValue({
+      success: false,
+      reason: 'no_installation_found',
+    });
+
+    await expect(
+      migrateProjectToGitHub({
+        projectId: project.id,
+        owner: { type: 'org', id: organizationId },
+        userId: 'user-1',
+        repoFullName: 'acme-apps/secondary',
+        expectedPlatformIntegrationId: liteIntegrationId,
+      })
+    ).resolves.toEqual({ success: false, error: 'github_integration_unavailable' });
+    expect(mockGetRepositoryDetails).not.toHaveBeenCalled();
+    expect(mockMigrateToGithub).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/app-builder/github-migration-service.ts
+++ b/apps/web/src/lib/app-builder/github-migration-service.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import type { Owner } from '@/lib/integrations/core/types';
 import * as appBuilderClient from '@/lib/app-builder/app-builder-client';
 import { db } from '@/lib/drizzle';
-import { app_builder_projects, deployments } from '@kilocode/db/schema';
+import { app_builder_projects, deployments, type PlatformIntegration } from '@kilocode/db/schema';
 import { eq, and, isNull } from 'drizzle-orm';
 import {
   fetchGitHubInstallationDetails,
@@ -11,7 +11,13 @@ import {
   getInstallationSettingsUrl,
 } from '@/lib/integrations/platforms/github/adapter';
 import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
+import {
+  getIntegrationForOwner,
+  getIntegrationsByOrganization,
+  resolveOrganizationGitHubIntegrationForRepository,
+  updateRepositoriesForIntegration,
+} from '@/lib/integrations/db/platform-integrations';
+import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
 import { getProjectWithOwnershipCheck } from '@/lib/app-builder/project-ownership';
 import type {
   MigrateToGitHubInput,
@@ -28,6 +34,29 @@ class MigrationError extends Error {
     super(`Migration failed: ${code}`, options);
     this.name = 'MigrationError';
   }
+}
+
+function getGitHubAppType(integration: PlatformIntegration): 'standard' | 'lite' {
+  return integration.github_app_type ?? 'standard';
+}
+
+async function getMigrationIntegrations(owner: Owner): Promise<PlatformIntegration[]> {
+  if (owner.type === 'user') {
+    const integration = await getIntegrationForOwner(
+      owner,
+      PLATFORM.GITHUB,
+      INTEGRATION_STATUS.ACTIVE
+    );
+    return integration?.platform_installation_id ? [integration] : [];
+  }
+
+  const integrations = await getIntegrationsByOrganization(owner.id, PLATFORM.GITHUB);
+  return integrations.filter(
+    integration =>
+      integration.integration_type === 'app' &&
+      integration.platform_installation_id !== null &&
+      isPlatformIntegrationHealthy(integration)
+  );
 }
 
 /** Convert a project title to a valid GitHub repository name. */
@@ -80,51 +109,72 @@ export async function canMigrateToGitHub(
     };
   }
 
-  // Check for GitHub integration
-  const integration = await getIntegrationForOwner(
-    owner,
-    PLATFORM.GITHUB,
-    INTEGRATION_STATUS.ACTIVE
-  );
-
-  if (!integration || !integration.platform_installation_id) {
+  const integrations = await getMigrationIntegrations(owner);
+  const integration = integrations[0];
+  if (!integration?.platform_installation_id) {
     return noIntegrationResult;
   }
 
   // Fetch installation details and available repos in parallel
-  const installationId = integration.platform_installation_id;
   let targetAccountName = integration.platform_account_login ?? null;
   let installationSettingsUrl = '';
   let availableRepos: CanMigrateToGitHubResult['availableRepos'] = [];
   let accountType = 'User';
   let repositorySelection: 'all' | 'selected' = 'all';
 
-  try {
-    const [installationDetails, settingsUrl, repos] = await Promise.all([
-      fetchGitHubInstallationDetails(installationId),
-      getInstallationSettingsUrl(installationId),
-      fetchGitHubRepositories(installationId),
-    ]);
+  const integrationData = await Promise.all(
+    integrations.map(async candidate => {
+      const candidateInstallationId = candidate.platform_installation_id;
+      if (!candidateInstallationId) return null;
+      const appType = getGitHubAppType(candidate);
+      try {
+        const [installationDetails, settingsUrl, repos] = await Promise.all([
+          fetchGitHubInstallationDetails(candidateInstallationId, appType),
+          getInstallationSettingsUrl(candidateInstallationId, appType),
+          fetchGitHubRepositories(candidateInstallationId, appType),
+        ]);
+        await updateRepositoriesForIntegration(candidate.id, repos);
+        return { integration: candidate, installationDetails, settingsUrl, repos };
+      } catch (error) {
+        console.error('Failed to fetch GitHub installation details:', error);
+        return null;
+      }
+    })
+  );
 
-    targetAccountName = installationDetails.account.login || targetAccountName;
-    accountType = installationDetails.account.type;
+  const primaryData = integrationData[0];
+  if (primaryData) {
+    targetAccountName = primaryData.installationDetails.account.login || targetAccountName;
+    accountType = primaryData.installationDetails.account.type;
     repositorySelection =
-      installationDetails.repository_selection === 'selected' ? 'selected' : 'all';
-    installationSettingsUrl = settingsUrl;
+      primaryData.installationDetails.repository_selection === 'selected' ? 'selected' : 'all';
+    installationSettingsUrl = primaryData.settingsUrl;
+  }
 
-    // Map to AvailableRepo shape, sort newest first, take last 10
-    availableRepos = repos
-      .map(repo => ({
+  const reposByFullName = new Map<string, CanMigrateToGitHubResult['availableRepos']>();
+  for (const data of integrationData) {
+    if (!data) continue;
+    for (const repo of data.repos) {
+      const key = repo.full_name.toLowerCase();
+      const matches = reposByFullName.get(key) ?? [];
+      matches.push({
         fullName: repo.full_name,
         createdAt: repo.created_at,
         isPrivate: repo.private,
-      }))
-      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
-      .slice(0, 10);
-  } catch (error) {
-    console.error('Failed to fetch GitHub installation details:', error);
-    // Continue with partial data
+        platformIntegrationId: data.integration.id,
+      });
+      reposByFullName.set(key, matches);
+    }
   }
+  availableRepos = [...reposByFullName.values()]
+    .map(matches => {
+      const [repo] = matches;
+      if (!repo) return null;
+      return matches.length === 1 ? repo : { ...repo, platformIntegrationId: undefined };
+    })
+    .filter(repo => repo !== null)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .slice(0, 10);
 
   // Build the URL for creating a new repo
   // For orgs: https://github.com/organizations/{org}/repositories/new
@@ -189,15 +239,19 @@ export async function migrateProjectToGitHub(
   }
 
   try {
-    // 2. Get GitHub integration for the owner
-    const integration = await getIntegrationForOwner(
-      owner,
-      PLATFORM.GITHUB,
-      INTEGRATION_STATUS.ACTIVE
-    );
+    const integration =
+      owner.type === 'org'
+        ? await resolveOrganizationGitHubIntegrationForRepository({
+            organizationId: owner.id,
+            repositoryFullName: repoFullName,
+            expectedPlatformIntegrationId: params.expectedPlatformIntegrationId,
+          }).then(result => (result.success ? result.integration : null))
+        : await getIntegrationForOwner(owner, PLATFORM.GITHUB, INTEGRATION_STATUS.ACTIVE);
 
     if (!integration || !integration.platform_installation_id) {
-      throw new MigrationError('github_app_not_installed');
+      throw new MigrationError(
+        owner.type === 'org' ? 'github_integration_unavailable' : 'github_app_not_installed'
+      );
     }
 
     // 3. Validate the target repo exists, is accessible, and is empty
@@ -210,7 +264,11 @@ export async function migrateProjectToGitHub(
     } | null;
 
     try {
-      repoDetails = await getRepositoryDetails(integration.platform_installation_id, repoFullName);
+      repoDetails = await getRepositoryDetails(
+        integration.platform_installation_id,
+        repoFullName,
+        getGitHubAppType(integration)
+      );
     } catch (error) {
       throw new MigrationError('internal_error', { cause: error });
     }
@@ -229,6 +287,7 @@ export async function migrateProjectToGitHub(
         githubRepo: repoDetails.fullName,
         userId,
         orgId: owner.type === 'org' ? owner.id : undefined,
+        expectedPlatformIntegrationId: owner.type === 'org' ? integration.id : undefined,
       });
 
       if (!migrateResult.success) {

--- a/apps/web/src/lib/app-builder/types.ts
+++ b/apps/web/src/lib/app-builder/types.ts
@@ -137,6 +137,7 @@ export type MigrateToGitHubInput = {
   /** Kilo user ID - needed by preview DO to resolve GitHub tokens */
   userId: string;
   repoFullName: string; // e.g., "org/my-repo" - user-created repo
+  expectedPlatformIntegrationId?: string;
 };
 
 /**
@@ -148,6 +149,7 @@ export type MigrateToGitHubResult =
 
 export type MigrateToGitHubErrorCode =
   | 'github_app_not_installed'
+  | 'github_integration_unavailable'
   | 'already_migrated'
   | 'repo_not_found' // Specified repo doesn't exist or not accessible
   | 'repo_not_empty' // Repo has commits, must be empty
@@ -162,6 +164,7 @@ export type AvailableRepo = {
   fullName: string;
   createdAt: string;
   isPrivate: boolean;
+  platformIntegrationId?: string;
 };
 
 /**

--- a/apps/web/src/routers/app-builder-router.ts
+++ b/apps/web/src/routers/app-builder-router.ts
@@ -235,6 +235,7 @@ export const appBuilderRouter = createTRPCRouter({
       owner,
       userId: ctx.user.id,
       repoFullName: input.repoFullName,
+      expectedPlatformIntegrationId: input.expectedPlatformIntegrationId,
     });
   }),
 });

--- a/apps/web/src/routers/app-builder/schemas.ts
+++ b/apps/web/src/routers/app-builder/schemas.ts
@@ -54,6 +54,7 @@ export const legacySessionMessagesBaseSchema = z.object({
 // User-created repository approach: users provide full repo name (owner/repo)
 export const migrateToGitHubSchema = z.object({
   projectId: z.uuid(),
+  expectedPlatformIntegrationId: z.uuid().optional(),
   repoFullName: z
     .string()
     .min(3)

--- a/apps/web/src/routers/organizations/organization-app-builder-router.ts
+++ b/apps/web/src/routers/organizations/organization-app-builder-router.ts
@@ -281,6 +281,7 @@ export const organizationAppBuilderRouter = createTRPCRouter({
         owner,
         userId: ctx.user.id,
         repoFullName: input.repoFullName,
+        expectedPlatformIntegrationId: input.expectedPlatformIntegrationId,
       });
     }),
 });

--- a/services/app-builder/src/api-schemas.ts
+++ b/services/app-builder/src/api-schemas.ts
@@ -141,8 +141,9 @@ export type DeleteErrorResponse = z.infer<typeof DeleteErrorResponseSchema>;
 
 export const MigrateToGithubRequestSchema = z.object({
   githubRepo: z.string().regex(/^[^/]+\/[^/]+$/, 'Must be in "owner/repo" format'),
-  userId: z.string().uuid(),
+  userId: z.string().min(1),
   orgId: z.string().uuid().optional(),
+  expectedPlatformIntegrationId: z.string().uuid().optional(),
 });
 
 export type MigrateToGithubRequest = z.infer<typeof MigrateToGithubRequestSchema>;

--- a/services/app-builder/src/handlers/migrate-to-github.test.ts
+++ b/services/app-builder/src/handlers/migrate-to-github.test.ts
@@ -1,0 +1,100 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleMigrateToGithub } from './migrate-to-github';
+import type { Env } from '../types';
+
+const expectedPlatformIntegrationId = '123e4567-e89b-12d3-a456-426614174002';
+const orgId = '123e4567-e89b-12d3-a456-426614174001';
+
+function createEnv(
+  tokenResult: { success: false; reason: 'integration_mismatch' } | { success: true }
+) {
+  const getTokenForRepo = vi.fn().mockResolvedValue(
+    tokenResult.success
+      ? {
+          success: true,
+          token: 'github-token',
+          installationId: 'installation-1',
+          accountLogin: 'acme',
+          appType: 'standard',
+        }
+      : tokenResult
+  );
+  const gitStub = {
+    isInitialized: vi.fn().mockResolvedValue(true),
+    pushToRemote: vi.fn().mockResolvedValue({ success: true }),
+    scheduleDelete: vi.fn().mockResolvedValue(undefined),
+  };
+  const previewStub = { setGitHubSource: vi.fn().mockResolvedValue(undefined) };
+  return {
+    env: {
+      AUTH_TOKEN: 'worker-auth',
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+      GIT_REPOSITORY: {
+        idFromName: vi.fn(() => 'git-id'),
+        get: vi.fn(() => gitStub),
+      },
+      PREVIEW: {
+        idFromName: vi.fn(() => 'preview-id'),
+        get: vi.fn(() => previewStub),
+      },
+    } as unknown as Env,
+    getTokenForRepo,
+    gitStub,
+    previewStub,
+  };
+}
+
+function request() {
+  return new Request('https://builder.example.com/apps/app-1/migrate-to-github', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer worker-auth',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      githubRepo: 'acme/secondary',
+      userId: 'oauth/example-user',
+      orgId,
+      expectedPlatformIntegrationId,
+    }),
+  });
+}
+
+beforeEach(() => vi.clearAllMocks());
+
+describe('migrate-to-github integration identity', () => {
+  it('fences the initial push and persisted preview source to the expected integration', async () => {
+    const harness = createEnv({ success: true });
+
+    const response = await handleMigrateToGithub(request(), harness.env, 'app-1');
+
+    expect(response.status).toBe(200);
+    expect(harness.getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/secondary',
+      userId: 'oauth/example-user',
+      orgId,
+      expectedIntegrationId: expectedPlatformIntegrationId,
+    });
+    expect(harness.previewStub.setGitHubSource).toHaveBeenCalledWith({
+      githubRepo: 'acme/secondary',
+      userId: 'oauth/example-user',
+      orgId,
+      expectedPlatformIntegrationId,
+    });
+  });
+
+  it('fails a stale integration before pushing or changing preview source', async () => {
+    const harness = createEnv({ success: false, reason: 'integration_mismatch' });
+
+    const response = await handleMigrateToGithub(request(), harness.env, 'app-1');
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'token_failed',
+      message: 'Failed to get GitHub token: integration_mismatch',
+    });
+    expect(harness.gitStub.pushToRemote).not.toHaveBeenCalled();
+    expect(harness.previewStub.setGitHubSource).not.toHaveBeenCalled();
+  });
+});

--- a/services/app-builder/src/handlers/migrate-to-github.ts
+++ b/services/app-builder/src/handlers/migrate-to-github.ts
@@ -57,10 +57,15 @@ export async function handleMigrateToGithub(
       );
     }
 
-    const { githubRepo, userId, orgId } = result.data;
+    const { githubRepo, userId, orgId, expectedPlatformIntegrationId } = result.data;
 
     // 1. Fetch a GitHub token via git-token-service
-    const tokenResult = await env.GIT_TOKEN_SERVICE.getTokenForRepo({ githubRepo, userId, orgId });
+    const tokenResult = await env.GIT_TOKEN_SERVICE.getTokenForRepo({
+      githubRepo,
+      userId,
+      orgId,
+      expectedIntegrationId: expectedPlatformIntegrationId,
+    });
     if (!tokenResult.success) {
       logger.error({ source: 'MigrateToGithubHandler', appId }, 'Failed to get GitHub token', {
         reason: tokenResult.reason,
@@ -123,7 +128,12 @@ export async function handleMigrateToGithub(
     const previewId = env.PREVIEW.idFromName(appId);
     const previewStub = env.PREVIEW.get(previewId);
 
-    await previewStub.setGitHubSource({ githubRepo, userId, orgId });
+    await previewStub.setGitHubSource({
+      githubRepo,
+      userId,
+      orgId,
+      expectedPlatformIntegrationId,
+    });
 
     // Schedule internal git repo deletion after a 7-day grace period (for rollback safety)
     await gitStub.scheduleDelete(7 * 24 * 60 * 60 * 1000);

--- a/services/app-builder/src/preview-do.test.ts
+++ b/services/app-builder/src/preview-do.test.ts
@@ -1,0 +1,167 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sandbox = {
+  exec: vi.fn(),
+  execStream: vi.fn(),
+  gitCheckout: vi.fn(),
+  startProcess: vi.fn(),
+  listProcesses: vi.fn(),
+  destroy: vi.fn(),
+};
+
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class<Environment> {
+    protected readonly ctx: DurableObjectState;
+    protected readonly env: Environment;
+
+    constructor(ctx: DurableObjectState, env: Environment) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+  },
+}));
+
+vi.mock('@cloudflare/sandbox', () => ({
+  getSandbox: () => sandbox,
+  parseSSEStream: vi.fn(() =>
+    (async function* () {
+      yield { type: 'complete', exitCode: 0, data: '' };
+    })()
+  ),
+}));
+
+vi.mock('./db-provisioner', () => ({
+  DBProvisionResult: { PROVISIONED: 'provisioned', EXISTS: 'exists' },
+  createDBProvisioner: () => ({
+    provisionIfNeeded: vi.fn(async () => 'exists'),
+  }),
+}));
+
+import { PreviewDO } from './preview-do';
+import type { Env, PreviewPersistedState } from './types';
+
+function createStorage(initialState?: PreviewPersistedState) {
+  const values = new Map<string, unknown>();
+  if (initialState) values.set('state', initialState);
+  return {
+    values,
+    get: vi.fn(async (key: string) => values.get(key)),
+    put: vi.fn(async (key: string, value: unknown) => {
+      values.set(key, structuredClone(value));
+    }),
+    deleteAll: vi.fn(async () => values.clear()),
+  };
+}
+
+function createPreview(
+  storage: ReturnType<typeof createStorage>,
+  getTokenForRepo: ReturnType<typeof vi.fn>
+) {
+  const startup: Promise<unknown>[] = [];
+  const waits: Promise<unknown>[] = [];
+  const ctx = {
+    id: { name: 'app-1' },
+    storage,
+    blockConcurrencyWhile: vi.fn((callback: () => Promise<unknown>) => {
+      const promise = callback();
+      startup.push(promise);
+      return promise;
+    }),
+    waitUntil: vi.fn((promise: Promise<unknown>) => waits.push(promise)),
+  } as unknown as DurableObjectState;
+  const env = {
+    SANDBOX: {},
+    GIT_TOKEN_SERVICE: { getTokenForRepo },
+    BUILDER_HOSTNAME: 'builder.example.com',
+    GIT_JWT_SECRET: 'test-secret',
+  } as unknown as Env;
+  return { preview: new PreviewDO(ctx, env), startup, waits };
+}
+
+const source = {
+  githubRepo: 'acme/secondary',
+  userId: 'oauth/example-user',
+  orgId: '123e4567-e89b-12d3-a456-426614174001',
+  expectedPlatformIntegrationId: '123e4567-e89b-12d3-a456-426614174002',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sandbox.exec.mockImplementation(async (command: string) =>
+    command === 'test -d /workspace/.git'
+      ? { exitCode: 1, success: false, stderr: '' }
+      : { exitCode: 0, success: true, stderr: '' }
+  );
+  sandbox.gitCheckout.mockResolvedValue({ success: true });
+  sandbox.execStream.mockResolvedValue({});
+  sandbox.startProcess.mockResolvedValue(undefined);
+  sandbox.listProcesses.mockResolvedValue([]);
+  sandbox.destroy.mockResolvedValue(undefined);
+});
+
+describe('PreviewDO GitHub source identity', () => {
+  it('persists the expected integration and reuses it after restart', async () => {
+    const storage = createStorage();
+    const firstTokenLookup = vi.fn();
+    const first = createPreview(storage, firstTokenLookup);
+    await Promise.all(first.startup);
+    await first.preview.initWithAppId('app-1');
+    await first.preview.setGitHubSource(source);
+
+    const persisted = storage.values.get('state') as PreviewPersistedState;
+    expect(persisted.githubSource).toEqual(source);
+
+    const restartedTokenLookup = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'github-token',
+      installationId: 'installation-2',
+      accountLogin: 'acme',
+      appType: 'lite',
+    });
+    const restarted = createPreview(storage, restartedTokenLookup);
+    await Promise.all(restarted.startup);
+    await restarted.preview.triggerBuild();
+    await Promise.all(restarted.waits);
+
+    expect(restartedTokenLookup).toHaveBeenCalledWith({
+      githubRepo: source.githubRepo,
+      userId: source.userId,
+      orgId: source.orgId,
+      expectedIntegrationId: source.expectedPlatformIntegrationId,
+    });
+  });
+
+  it('keeps legacy unpinned state readable and lets ambiguous resolution fail closed', async () => {
+    const legacyState: PreviewPersistedState = {
+      appId: 'app-1',
+      lastError: null,
+      dbCredentials: null,
+      githubSource: {
+        githubRepo: source.githubRepo,
+        userId: source.userId,
+        orgId: source.orgId,
+      },
+    };
+    const storage = createStorage(legacyState);
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: false,
+      reason: 'no_installation_found',
+    });
+    const { preview, startup, waits } = createPreview(storage, getTokenForRepo);
+    await Promise.all(startup);
+    await preview.triggerBuild();
+    await expect(Promise.all(waits)).rejects.toThrow(
+      'Failed to get GitHub token: no_installation_found'
+    );
+
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: source.githubRepo,
+      userId: source.userId,
+      orgId: source.orgId,
+      expectedIntegrationId: undefined,
+    });
+    expect((storage.values.get('state') as PreviewPersistedState).lastError).toBe(
+      'Failed to get GitHub token: no_installation_found'
+    );
+  });
+});

--- a/services/app-builder/src/preview-do.ts
+++ b/services/app-builder/src/preview-do.ts
@@ -201,13 +201,15 @@ export class PreviewDO extends DurableObject<Env> {
   private async getRepoUrl(repoId: string): Promise<string> {
     // Check if project is migrated to GitHub
     if (this.persistedState.githubSource) {
-      const { githubRepo, userId, orgId } = this.persistedState.githubSource;
+      const { githubRepo, userId, orgId, expectedPlatformIntegrationId } =
+        this.persistedState.githubSource;
 
       // Get fresh token from git-token-service
       const result: GetTokenForRepoResult = await this.env.GIT_TOKEN_SERVICE.getTokenForRepo({
         githubRepo,
         userId,
         orgId,
+        expectedIntegrationId: expectedPlatformIntegrationId,
       });
 
       if (!result.success) {

--- a/services/app-builder/src/types.ts
+++ b/services/app-builder/src/types.ts
@@ -34,7 +34,9 @@ export type GetTokenForRepoResult =
         | 'database_not_configured'
         | 'invalid_repo_format'
         | 'no_installation_found'
-        | 'invalid_org_id';
+        | 'repository_not_installed'
+        | 'invalid_org_id'
+        | 'integration_mismatch';
     };
 
 /**
@@ -50,6 +52,7 @@ type GitTokenService = {
     githubRepo: string;
     userId: string;
     orgId?: string;
+    expectedIntegrationId?: string;
   }): Promise<GetTokenForRepoResult>;
 
   /**
@@ -168,6 +171,7 @@ export type GitHubSourceConfig = {
   githubRepo: string; // "owner/repo" format
   userId: string; // Kilo user ID for token lookup
   orgId?: string; // Kilo org ID (if org-owned project)
+  expectedPlatformIntegrationId?: string;
 };
 
 /**


### PR DESCRIPTION
## Why this PR exists

App Builder migration is not a one-time GitHub operation. The selected repository is used for the initial push, then later preview clones, rebuilds, and restarts inside a Durable Object. If only `owner/repo` is stored, a project can switch to another matching installation after restart or repository movement.

This PR makes installation identity part of App Builder source state and enforces it throughout the preview lifecycle.

## Place in the rollout

This is the App Builder backend-safety layer. #5576 adds the user-facing installation selector only after this PR can persist and honor the choice.

## Dependency

Depends on #5547 for exact and fail-closed legacy repository resolution. Retarget to `main` after #5547 merges.

## What changes

- Add optional expected integration identity to web migration and App Builder Worker contracts.
- Persist it in Preview Durable Object GitHub source state.
- Enforce it for migration validation, initial push, preview clone, fetch/rebuild, and restart.
- Preserve Standard/Lite app type when listing and validating repositories.
- Return a specific stale-installation error when the selected row is no longer usable.
- Keep old preview state readable; unpinned ambiguity fails closed.

## What stays unchanged

- The existing dialog does not gain a full installation selector here; that is #5576.
- Old projects without a stored integration continue through unique legacy resolution.
- This PR does not change deployment push routing, which is #5554.

## Why web and Worker both change

The web app chooses and validates the migration target, but the Worker owns persisted preview state and later Git operations. Both sides must share the optional contract or the choice disappears after the initial request. Most added lines are focused migration and PreviewDO tests.

## Review guide

Trace `expectedPlatformIntegrationId` from router schema through migration service and Worker API into PreviewDO state. Then verify every later Git credential/clone path reads the persisted value.

## Validation

- 44 App Builder tests
- App Builder and web typechecks/lint
- 3 focused web migration tests
- `git diff --check`