### PR TITLE
fix(mobile): start the splash reveal on a rendered frame

### DIFF
--- a/apps/mobile/src/components/animated-splash-overlay-reveal.mounted.test.tsx
+++ b/apps/mobile/src/components/animated-splash-overlay-reveal.mounted.test.tsx
@@ -138,6 +138,31 @@ describe('AnimatedSplashOverlay reveal start', () => {
     vi.useRealTimers();
   });
 
+  it('stays armed when the logo-waive timer re-renders after the handover', async () => {
+    const renderer = await mountAndReachHandover();
+
+    // The 500ms logo-waive timer fires whether or not the logo loaded, so it
+    // re-renders after the handover. That must not disarm the reveal.
+    act(() => {
+      vi.advanceTimersByTime(500);
+    });
+    expect(reanimated.active).toBe(true);
+
+    const frame = reanimated.frame;
+    if (!frame) {
+      throw new Error('the frame callback was not registered');
+    }
+    act(() => {
+      frame({ timeSincePreviousFrame: 16 });
+    });
+    expect(reanimated.sequences).toBe(1);
+
+    act(() => {
+      renderer.unmount();
+    });
+    vi.useRealTimers();
+  });
+
   it('starts the reveal anyway when no healthy frame ever arrives', async () => {
     const renderer = await mountAndReachHandover();
     expect(reanimated.sequences).toBe(0);

--- a/apps/mobile/src/components/animated-splash-overlay-reveal.mounted.test.tsx
+++ b/apps/mobile/src/components/animated-splash-overlay-reveal.mounted.test.tsx
@@ -1,0 +1,155 @@
+/* eslint-disable typescript-eslint/no-deprecated -- react-test-renderer is the DOM-free renderer used to mount React/RN trees under vitest (same pattern as animated-splash-overlay.mounted.test.tsx) */
+import { createElement } from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { AnimatedSplashOverlay } from './animated-splash-overlay';
+
+type FrameInfo = { timeSincePreviousFrame: number | null };
+
+// `withSequence` is used once, by the reveal, so counting it proves exactly
+// when the reveal ran.
+const reanimated = vi.hoisted(() => ({
+  sequences: 0,
+  frame: undefined as ((info: FrameInfo) => void) | undefined,
+  active: false,
+}));
+
+vi.mock('react-native-reanimated', () => ({
+  default: { View: 'Animated.View' },
+  useSharedValue: (initial: unknown) => ({ value: initial }),
+  useAnimatedStyle: () => ({}),
+  useFrameCallback: (onFrame: (info: FrameInfo) => void) => {
+    reanimated.frame = onFrame;
+    return {
+      setActive: (next: boolean) => {
+        reanimated.active = next;
+      },
+    };
+  },
+  useReducedMotion: () => false,
+  withTiming: (value: unknown) => value,
+  withDelay: (_delay: number, value: unknown) => value,
+  withSequence: (...values: unknown[]) => {
+    reanimated.sequences += 1;
+    return values.at(-1);
+  },
+  makeMutable: (value: unknown) => ({ value }),
+  Easing: { out: (v: unknown) => v, in: (v: unknown) => v, quad: 0, cubic: 0 },
+}));
+vi.mock('react-native-worklets', () => ({ scheduleOnRN: vi.fn() }));
+vi.mock('expo-splash-screen', () => ({
+  hideAsync: vi.fn().mockResolvedValue(undefined),
+  preventAutoHideAsync: vi.fn(),
+}));
+vi.mock('@sentry/react-native', () => ({ TimeToFullDisplay: () => null }));
+vi.mock('@/components/ui/image', () => ({ Image: 'Image' }));
+vi.mock('@/../assets/images/logo.png', () => ({ default: 1 }));
+
+// Owned by the test so each case starts from an incomplete launch.
+const startup = vi.hoisted(() => ({ complete: false, listeners: new Set<() => void>() }));
+vi.mock('@/lib/startup-timing', () => ({
+  isStartupComplete: () => startup.complete,
+  subscribeStartupComplete: (listener: () => void) => {
+    startup.listeners.add(listener);
+    return () => {
+      startup.listeners.delete(listener);
+    };
+  },
+}));
+
+function markStartupComplete(): void {
+  startup.complete = true;
+  for (const listener of startup.listeners) {
+    listener();
+  }
+}
+
+async function mountAndReachHandover(): Promise<TestRenderer.ReactTestRenderer> {
+  const ref: { current: TestRenderer.ReactTestRenderer | undefined } = { current: undefined };
+  await act(async () => {
+    await Promise.resolve();
+    ref.current = TestRenderer.create(createElement(AnimatedSplashOverlay));
+  });
+  const renderer = ref.current;
+  if (!renderer) {
+    throw new Error('renderer was not created');
+  }
+  const image = renderer.root.findAll(
+    node => typeof node.type === 'string' && (node.type as string) === 'Image'
+  )[0];
+  if (!image) {
+    throw new Error('expected one Image host');
+  }
+  act(() => {
+    (image.props.onLoad as () => void)();
+  });
+  act(() => {
+    markStartupComplete();
+  });
+  await act(async () => {
+    await Promise.resolve();
+  });
+  return renderer;
+}
+
+describe('AnimatedSplashOverlay reveal start', () => {
+  beforeEach(() => {
+    (globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }).IS_REACT_ACT_ENVIRONMENT = true;
+    startup.complete = false;
+    startup.listeners.clear();
+    reanimated.sequences = 0;
+    reanimated.frame = undefined;
+    reanimated.active = false;
+    vi.useFakeTimers();
+  });
+
+  it('holds the logo at rest until the device renders a healthy frame', async () => {
+    const renderer = await mountAndReachHandover();
+    const frame = reanimated.frame;
+    if (!frame) {
+      throw new Error('the frame callback was not registered');
+    }
+
+    // Handover done, reveal armed, nothing animating yet.
+    expect(reanimated.active).toBe(true);
+    expect(reanimated.sequences).toBe(0);
+
+    // First frame reports no delta, the next one is a 300ms handover stall.
+    // Starting on either would paint the reveal already part-way through.
+    act(() => {
+      frame({ timeSincePreviousFrame: null });
+    });
+    expect(reanimated.sequences).toBe(0);
+    act(() => {
+      frame({ timeSincePreviousFrame: 300 });
+    });
+    expect(reanimated.sequences).toBe(0);
+
+    // A frame the device actually rendered starts the reveal.
+    act(() => {
+      frame({ timeSincePreviousFrame: 16 });
+    });
+    expect(reanimated.sequences).toBe(1);
+
+    act(() => {
+      renderer.unmount();
+    });
+    vi.useRealTimers();
+  });
+
+  it('starts the reveal anyway when no healthy frame ever arrives', async () => {
+    const renderer = await mountAndReachHandover();
+    expect(reanimated.sequences).toBe(0);
+
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(reanimated.sequences).toBe(1);
+
+    act(() => {
+      renderer.unmount();
+    });
+    vi.useRealTimers();
+  });
+});

--- a/apps/mobile/src/components/animated-splash-overlay.mounted.test.tsx
+++ b/apps/mobile/src/components/animated-splash-overlay.mounted.test.tsx
@@ -19,6 +19,7 @@ vi.mock('react-native-reanimated', () => ({
   withSequence: (...values: unknown[]) => values.at(-1),
   makeMutable: (v: unknown) => ({ value: v }),
   Easing: { out: (v: unknown) => v, in: (v: unknown) => v, quad: 0, cubic: 0 },
+  useFrameCallback: () => ({ setActive: () => undefined }),
   // Reduced motion keeps animation callbacks out of the test.
   useReducedMotion: () => true,
 }));

--- a/apps/mobile/src/components/animated-splash-overlay.tsx
+++ b/apps/mobile/src/components/animated-splash-overlay.tsx
@@ -1,9 +1,10 @@
 import * as SplashScreen from 'expo-splash-screen';
 import { TimeToFullDisplay } from '@sentry/react-native';
-import { useEffect, useRef, useState, useSyncExternalStore } from 'react';
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from 'react';
 import Animated, {
   Easing,
   useAnimatedStyle,
+  useFrameCallback,
   useReducedMotion,
   useSharedValue,
   withDelay,
@@ -19,6 +20,7 @@ import { isStartupComplete, subscribeStartupComplete } from '@/lib/startup-timin
 
 const HIDE_SAFETY_MS = 2000;
 const LOGO_LOAD_SAFETY_MS = 500;
+const REVEAL_START_SAFETY_MS = 1000;
 
 // Reveal timeline. The logo dips, punches through the viewer and clears the
 // frame, and only then does a disc of the app's own background wipe the yellow
@@ -42,6 +44,11 @@ const HANDOVER_MS = 170;
  * speed instead of shooting off in the first few frames.
  */
 const DISC_COVER_SCALE = 16;
+/**
+ * Longest gap that still counts as a rendered frame, at 60Hz plus slack. A
+ * longer gap means the render thread is still busy with the handover.
+ */
+const HEALTHY_FRAME_MS = 34;
 
 export function AnimatedSplashOverlay() {
   const complete = useSyncExternalStore(subscribeStartupComplete, isStartupComplete);
@@ -56,6 +63,51 @@ export function AnimatedSplashOverlay() {
   const discScale = useSharedValue(0);
   const logoScale = useSharedValue(1);
   const logoOpacity = useSharedValue(1);
+  const revealStarted = useSharedValue(false);
+
+  const startReveal = useCallback(() => {
+    'worklet';
+    logoScale.value = withSequence(
+      withTiming(DIP_SCALE, { duration: DIP_MS, easing: Easing.out(Easing.quad) }),
+      withTiming(PUNCH_SCALE, { duration: PUNCH_MS, easing: Easing.in(Easing.cubic) })
+    );
+    logoOpacity.value = withDelay(PUNCH_DELAY_MS, withTiming(0, { duration: PUNCH_MS }));
+    discScale.value = withDelay(
+      DISC_DELAY_MS,
+      withTiming(DISC_COVER_SCALE, { duration: DISC_MS, easing: Easing.linear })
+    );
+    splashContentScale.value = withDelay(
+      HANDOVER_DELAY_MS,
+      withTiming(1, { duration: HANDOVER_MS, easing: Easing.out(Easing.cubic) })
+    );
+    overlayOpacity.value = withDelay(
+      HANDOVER_DELAY_MS,
+      withTiming(0, { duration: HANDOVER_MS }, finished => {
+        if (finished) {
+          scheduleOnRN(setDismissed, true);
+        }
+      })
+    );
+  }, [discScale, logoOpacity, logoScale, overlayOpacity]);
+
+  // Hiding the native splash uncovers the whole app tree, and compositing it
+  // costs a few hundred milliseconds on a cold start. Reanimated drives the
+  // reveal off the render clock, so starting it in the same tick spends that
+  // time on frames nobody sees: the first painted frame lands a third of the
+  // way in, and the logo appears to jump to a smaller size. Wait for a frame
+  // the device actually rendered. The overlay is pixel-identical to the native
+  // splash, so the wait is invisible.
+  const frameCallback = useFrameCallback(({ timeSincePreviousFrame }) => {
+    'worklet';
+    if (revealStarted.value) {
+      return;
+    }
+    if (timeSincePreviousFrame === null || timeSincePreviousFrame > HEALTHY_FRAME_MS) {
+      return;
+    }
+    revealStarted.value = true;
+    startReveal();
+  }, false);
 
   useEffect(() => {
     const timer = setTimeout(() => {
@@ -68,11 +120,9 @@ export function AnimatedSplashOverlay() {
 
   useEffect(() => {
     if (!complete || dismissed || !(logoLoaded || logoWaived) || exitStartedRef.current) {
-      return;
+      return undefined;
     }
-    const finish = () => {
-      setDismissed(true);
-    };
+    let safety: ReturnType<typeof setTimeout> | undefined = undefined;
 
     async function hideAndExit() {
       try {
@@ -88,47 +138,38 @@ export function AnimatedSplashOverlay() {
         // Ignore — parity with today's behavior.
       }
       if (reducedMotion) {
-        finish();
+        setDismissed(true);
         return;
       }
-      logoScale.value = withSequence(
-        withTiming(DIP_SCALE, { duration: DIP_MS, easing: Easing.out(Easing.quad) }),
-        withTiming(PUNCH_SCALE, { duration: PUNCH_MS, easing: Easing.in(Easing.cubic) })
-      );
-      logoOpacity.value = withDelay(PUNCH_DELAY_MS, withTiming(0, { duration: PUNCH_MS }));
-      discScale.value = withDelay(
-        DISC_DELAY_MS,
-        withTiming(DISC_COVER_SCALE, { duration: DISC_MS, easing: Easing.linear })
-      );
       // The tree is already mounted behind the disc, so the overscan is set
-      // instantly and only its settle is visible.
+      // before the wait and only its settle is visible.
       splashContentScale.value = SPLASH_CONTENT_OVERSCAN;
-      splashContentScale.value = withDelay(
-        HANDOVER_DELAY_MS,
-        withTiming(1, { duration: HANDOVER_MS, easing: Easing.out(Easing.cubic) })
-      );
-      overlayOpacity.value = withDelay(
-        HANDOVER_DELAY_MS,
-        withTiming(0, { duration: HANDOVER_MS }, finished => {
-          if (finished) {
-            scheduleOnRN(finish);
-          }
-        })
-      );
+      frameCallback.setActive(true);
+      // A device that never reports a healthy frame must not strand the
+      // overlay on screen.
+      safety = setTimeout(() => {
+        if (!revealStarted.value) {
+          revealStarted.value = true;
+          startReveal();
+        }
+      }, REVEAL_START_SAFETY_MS);
     }
 
     exitStartedRef.current = true;
     void hideAndExit();
+    return () => {
+      clearTimeout(safety);
+      frameCallback.setActive(false);
+    };
   }, [
     complete,
     dismissed,
     logoLoaded,
     logoWaived,
     reducedMotion,
-    overlayOpacity,
-    discScale,
-    logoScale,
-    logoOpacity,
+    frameCallback,
+    revealStarted,
+    startReveal,
   ]);
 
   const overlayStyle = useAnimatedStyle(() => ({ opacity: overlayOpacity.value }));

--- a/apps/mobile/src/components/animated-splash-overlay.tsx
+++ b/apps/mobile/src/components/animated-splash-overlay.tsx
@@ -58,6 +58,7 @@ export function AnimatedSplashOverlay() {
   const [logoLoaded, setLogoLoaded] = useState(false);
   const [logoWaived, setLogoWaived] = useState(false);
   const exitStartedRef = useRef(false);
+  const revealSafetyRef = useRef<ReturnType<typeof setTimeout> | undefined>(undefined);
   const reducedMotion = useReducedMotion();
   const overlayOpacity = useSharedValue(1);
   const discScale = useSharedValue(0);
@@ -120,9 +121,8 @@ export function AnimatedSplashOverlay() {
 
   useEffect(() => {
     if (!complete || dismissed || !(logoLoaded || logoWaived) || exitStartedRef.current) {
-      return undefined;
+      return;
     }
-    let safety: ReturnType<typeof setTimeout> | undefined = undefined;
 
     async function hideAndExit() {
       try {
@@ -147,7 +147,7 @@ export function AnimatedSplashOverlay() {
       frameCallback.setActive(true);
       // A device that never reports a healthy frame must not strand the
       // overlay on screen.
-      safety = setTimeout(() => {
+      revealSafetyRef.current = setTimeout(() => {
         if (!revealStarted.value) {
           revealStarted.value = true;
           startReveal();
@@ -157,10 +157,6 @@ export function AnimatedSplashOverlay() {
 
     exitStartedRef.current = true;
     void hideAndExit();
-    return () => {
-      clearTimeout(safety);
-      frameCallback.setActive(false);
-    };
   }, [
     complete,
     dismissed,
@@ -171,6 +167,17 @@ export function AnimatedSplashOverlay() {
     revealStarted,
     startReveal,
   ]);
+
+  // Teardown is keyed on the overlay being gone, not on the handover effect's
+  // deps: the logo-load and logo-waive flags can still flip after the handover,
+  // and a cleanup on those would disarm the reveal before it ever starts.
+  useEffect(() => {
+    if (!dismissed) {
+      return;
+    }
+    clearTimeout(revealSafetyRef.current);
+    frameCallback.setActive(false);
+  }, [dismissed, frameCallback]);
 
   const overlayStyle = useAnimatedStyle(() => ({ opacity: overlayOpacity.value }));
   const discStyle = useAnimatedStyle(() => ({ transform: [{ scale: discScale.value }] }));


### PR DESCRIPTION
## Problem

Your screen recording, frame by frame at 60 fps:

| frame | time | state |
|---|---|---|
| 250 | 4.317 s | splash at rest, logo at scale 1 |
| 251 | 4.333 s | logo already at scale 0.9 and fading, wipe disc already covering half the screen |

Between two consecutive display frames the reveal jumped about 310 ms into its own timeline. Frames 251 onward then advance at the correct rate, so the animation itself is fine — its first ~310 ms were simply never painted.

The logo is not mis-sized. Native splash and overlay both render a 100 pt image at the exact screen centre; measured identical on iPhone SE 3rd gen (130x130 px glyph) and iPhone 17 Pro (196x196 px). What the eye reads as a size difference is the reveal appearing part-way through, with the logo already dipped to 0.9.

## Cause

`hideAsync()` removes the native splash, which uncovers the whole app tree for the first time. Compositing it costs a few hundred milliseconds on a cold start. Reanimated drives the reveal off the render clock, so starting it in the same tick spends that time on frames nobody sees.

## Fix

Arm a `useFrameCallback` at the handover and start the reveal on the first frame the device actually rendered — a frame whose delta is at most 34 ms. The overlay is pixel-identical to the native splash, so the wait is invisible. A one second safety timer starts the reveal anyway if no healthy frame is ever reported.

## Verification

- Two new tests in `animated-splash-overlay-reveal.mounted.test.tsx`: the reveal holds while frames report no delta or a 300 ms stall, and starts on a 16 ms frame; the safety timer starts it when no healthy frame arrives.
- Recorded a cold launch on the simulator at 60 fps before and after. The dip still runs smoothly from scale 1 over six frames, so no regression.
- `pnpm format && pnpm typecheck && pnpm lint && pnpm check:unused && pnpm test` pass in `apps/mobile`.

The stall does not reproduce on the simulator, so the end-to-end result needs a check on a real device.
