### PR TITLE
feat(app-builder): let migrations choose the destination GitHub org

### DIFF
--- a/apps/web/src/components/app-builder/MigrateToGitHubDialog.tsx
+++ b/apps/web/src/components/app-builder/MigrateToGitHubDialog.tsx
@@ -36,8 +36,21 @@ import {
   DialogTrigger,
   DialogFooter,
 } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { RepositoryCombobox, type RepositoryOption } from '@/components/shared/RepositoryCombobox';
-import type { CanMigrateToGitHubResult, MigrateToGitHubErrorCode } from '@/lib/app-builder/types';
+import type {
+  CanMigrateToGitHubResult,
+  GitHubMigrationTarget,
+  MigrateToGitHubErrorCode,
+} from '@/lib/app-builder/types';
+import { getMigrationTargetLabel, resolveMigrationTarget } from './migration-target-selector';
 
 type MigrateToGitHubDialogProps = {
   projectId: string;
@@ -72,6 +85,7 @@ export function MigrateToGitHubDialog({
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useState<Step>('create');
   const [selectedRepo, setSelectedRepo] = useState<string>('');
+  const [pinnedTarget, setPinnedTarget] = useState<GitHubMigrationTarget>();
 
   const [migrationResult, setMigrationResult] = useState<{
     success: true;
@@ -98,6 +112,9 @@ export function MigrateToGitHubDialog({
 
   const canMigrateQuery = organizationId ? orgCanMigrateQuery : personalCanMigrateQuery;
   const canMigrateData: CanMigrateToGitHubResult | undefined = canMigrateQuery.data;
+  const migrationTargets = canMigrateData?.migrationTargets ?? [];
+  const { target: selectedTarget, isUnavailable: selectedTargetIsUnavailable } =
+    resolveMigrationTarget(migrationTargets, pinnedTarget);
 
   // Migration mutations for personal/org context
   const handleMigrationSuccess = useCallback(
@@ -150,14 +167,29 @@ export function MigrateToGitHubDialog({
   // Map available repos to RepositoryCombobox format
   const repositoryOptions: RepositoryOption[] = useMemo(
     () =>
-      (canMigrateData?.availableRepos ?? []).map(repo => ({
-        id: `${repo.platformIntegrationId ?? 'legacy'}:${repo.fullName}`,
+      (selectedTargetIsUnavailable ? [] : (selectedTarget?.availableRepos ?? [])).map(repo => ({
+        id: `${selectedTarget?.platformIntegrationId}:${repo.fullName}`,
         fullName: repo.fullName,
         private: repo.isPrivate,
         platform: 'github' as const,
-        platformIntegrationId: repo.platformIntegrationId,
+        platformIntegrationId: selectedTarget?.platformIntegrationId,
+        platformAccountLogin: selectedTarget?.platformAccountLogin,
       })),
-    [canMigrateData?.availableRepos]
+    [selectedTarget, selectedTargetIsUnavailable]
+  );
+
+  const handleTargetChange = useCallback(
+    (platformIntegrationId: string) => {
+      const target = migrationTargets.find(
+        candidate => candidate.platformIntegrationId === platformIntegrationId
+      );
+      if (!target) return;
+
+      setPinnedTarget(target);
+      setSelectedRepo('');
+      setMigrationError(null);
+    },
+    [migrationTargets]
   );
 
   const handleOpenChange = useCallback(
@@ -167,6 +199,7 @@ export function MigrateToGitHubDialog({
         // Reset state when closing
         setStep('create');
         setSelectedRepo('');
+        setPinnedTarget(undefined);
         setMigrationResult(null);
         setMigrationError(null);
         reset();
@@ -191,12 +224,10 @@ export function MigrateToGitHubDialog({
   }, [organizationId, queryClient, trpc, projectId]);
 
   const handleMigrate = useCallback(() => {
-    if (!selectedRepo) return;
+    if (!selectedRepo || !selectedTarget || selectedTargetIsUnavailable) return;
 
     setMigrationError(null);
-    const expectedPlatformIntegrationId = repositoryOptions.find(
-      repo => repo.fullName === selectedRepo
-    )?.platformIntegrationId;
+    const expectedPlatformIntegrationId = selectedTarget.platformIntegrationId;
 
     if (organizationId) {
       orgMigrate({
@@ -206,21 +237,30 @@ export function MigrateToGitHubDialog({
         expectedPlatformIntegrationId,
       });
     } else {
-      personalMigrate({ projectId, repoFullName: selectedRepo });
+      personalMigrate({ projectId, repoFullName: selectedRepo, expectedPlatformIntegrationId });
     }
-  }, [organizationId, orgMigrate, personalMigrate, projectId, repositoryOptions, selectedRepo]);
+  }, [
+    organizationId,
+    orgMigrate,
+    personalMigrate,
+    projectId,
+    selectedRepo,
+    selectedTarget,
+    selectedTargetIsUnavailable,
+  ]);
 
   // Skip grant-access step if user has "all repositories" access
-  const needsGrantAccess = canMigrateData?.repositorySelection === 'selected';
+  const needsGrantAccess = selectedTarget?.repositorySelection === 'selected';
 
   const handleNext = useCallback(() => {
     if (step === 'create') {
+      if (selectedTarget) setPinnedTarget(selectedTarget);
       // Skip grant-access step if user has access to all repos
       setStep(needsGrantAccess ? 'grant-access' : 'select');
     } else if (step === 'grant-access') {
       setStep('select');
     }
-  }, [step, needsGrantAccess]);
+  }, [step, needsGrantAccess, selectedTarget]);
 
   const handleBack = useCallback(() => {
     if (step === 'grant-access') {
@@ -255,7 +295,7 @@ export function MigrateToGitHubDialog({
             {step === 'create' && 'Step 1: Create an empty repository on GitHub'}
             {step === 'grant-access' && 'Step 2: Grant access to your repository'}
             {step === 'select' && `Step ${needsGrantAccess ? '3' : '2'}: Select your repository`}
-            {step === 'success' && 'Migration complete!'}
+            {step === 'success' && 'Migration complete'}
           </DialogDescription>
         </DialogHeader>
 
@@ -264,7 +304,9 @@ export function MigrateToGitHubDialog({
           {canMigrateQuery.isPending && (
             <div className="flex items-center justify-center py-8">
               <Loader2 className="text-muted-foreground h-6 w-6 animate-spin" />
-              <span className="text-muted-foreground ml-2 text-sm">Loading...</span>
+              <span className="text-muted-foreground ml-2 text-sm">
+                Loading migration options...
+              </span>
             </div>
           )}
 
@@ -319,6 +361,41 @@ export function MigrateToGitHubDialog({
           {/* Step 1: Create Repository */}
           {canMigrate && step === 'create' && (
             <div className="space-y-4">
+              {(migrationTargets.length > 1 || selectedTargetIsUnavailable) && selectedTarget && (
+                <div className="space-y-2">
+                  <Label htmlFor="github-migration-target">GitHub installation</Label>
+                  <Select
+                    value={selectedTarget.platformIntegrationId}
+                    onValueChange={handleTargetChange}
+                  >
+                    <SelectTrigger
+                      id="github-migration-target"
+                      className="h-11 w-full font-mono sm:h-control-default"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {selectedTargetIsUnavailable && (
+                        <SelectItem value={selectedTarget.platformIntegrationId} disabled>
+                          {getMigrationTargetLabel(selectedTarget, migrationTargets)} (unavailable)
+                        </SelectItem>
+                      )}
+                      {migrationTargets.map(target => (
+                        <SelectItem
+                          key={target.platformIntegrationId}
+                          value={target.platformIntegrationId}
+                        >
+                          {getMigrationTargetLabel(target, migrationTargets)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-muted-foreground text-xs">
+                    Choose where to create and migrate the repository.
+                  </p>
+                </div>
+              )}
+
               <div className="rounded-md border p-4">
                 <h4 className="font-medium">Create an empty repository</h4>
                 <p className="text-muted-foreground mt-1 text-sm">
@@ -344,7 +421,11 @@ export function MigrateToGitHubDialog({
               </div>
 
               <Button asChild className="w-full gap-2">
-                <a href={canMigrateData.newRepoUrl} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={selectedTarget?.newRepoUrl ?? canMigrateData.newRepoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <Github className="h-4 w-4" />
                   Create Repository on GitHub
                   <ExternalLink className="h-3 w-3" />
@@ -368,10 +449,14 @@ export function MigrateToGitHubDialog({
                 </p>
               </div>
 
-              {canMigrateData.installationSettingsUrl && (
+              {(selectedTarget?.installationSettingsUrl ??
+                canMigrateData.installationSettingsUrl) && (
                 <Button asChild variant="outline" className="w-full gap-2">
                   <a
-                    href={canMigrateData.installationSettingsUrl}
+                    href={
+                      selectedTarget?.installationSettingsUrl ??
+                      canMigrateData.installationSettingsUrl
+                    }
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -391,7 +476,44 @@ export function MigrateToGitHubDialog({
               {migrationError && (
                 <div className="flex items-start gap-3 rounded-md bg-red-500/10 p-4 text-sm text-red-400">
                   <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
-                  <span>{errorMessages[migrationError]}</span>
+                  <div>
+                    <p>{errorMessages[migrationError]}</p>
+                    {migrationError === 'github_integration_unavailable' &&
+                      selectedTarget?.installationSettingsUrl && (
+                        <a
+                          href={selectedTarget.installationSettingsUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="mt-2 inline-flex items-center gap-1 underline underline-offset-4"
+                        >
+                          Manage affected GitHub installation
+                          <ExternalLink className="size-3" />
+                        </a>
+                      )}
+                  </div>
+                </div>
+              )}
+
+              {selectedTargetIsUnavailable && (
+                <div className="flex items-start gap-3 rounded-md bg-yellow-500/10 p-4 text-sm text-yellow-400">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <div>
+                    <p>The selected GitHub installation is no longer available.</p>
+                    <p className="text-muted-foreground mt-1">
+                      Refresh the repository list after restoring this installation.
+                    </p>
+                    {selectedTarget?.installationSettingsUrl && (
+                      <a
+                        href={selectedTarget.installationSettingsUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="mt-2 inline-flex items-center gap-1 underline underline-offset-4"
+                      >
+                        Manage affected GitHub installation
+                        <ExternalLink className="size-3" />
+                      </a>
+                    )}
+                  </div>
                 </div>
               )}
 
@@ -418,7 +540,8 @@ export function MigrateToGitHubDialog({
                   onClick={handleRefreshRepos}
                   disabled={canMigrateQuery.isFetching || isPending}
                   title="Refresh repository list"
-                  className="mb-6 shrink-0"
+                  aria-label="Refresh repository list"
+                  className="mb-6 size-11 shrink-0 sm:size-control-default"
                 >
                   <RefreshCw
                     className={`h-4 w-4 ${canMigrateQuery.isFetching ? 'animate-spin' : ''}`}
@@ -434,7 +557,7 @@ export function MigrateToGitHubDialog({
               <div className="flex items-start gap-3 rounded-md bg-green-500/10 p-4 text-sm text-green-400">
                 <Check className="mt-0.5 h-4 w-4 shrink-0" />
                 <div>
-                  <p className="font-medium">Export successful!</p>
+                  <p className="font-medium">Project exported</p>
                   <p className="text-muted-foreground mt-1">
                     Your project has been exported to GitHub. You can now clone, push, and
                     collaborate using Git.
@@ -472,7 +595,7 @@ export function MigrateToGitHubDialog({
             {step === 'select' ? (
               <Button
                 onClick={handleMigrate}
-                disabled={isPending || !selectedRepo}
+                disabled={isPending || !selectedRepo || selectedTargetIsUnavailable}
                 className="gap-2"
               >
                 {isPending ? (
@@ -483,12 +606,16 @@ export function MigrateToGitHubDialog({
                 ) : (
                   <>
                     <Github className="h-4 w-4" />
-                    Export
+                    Export project
                   </>
                 )}
               </Button>
             ) : (
-              <Button onClick={handleNext} className="gap-1">
+              <Button
+                variant={step === 'create' ? 'outline' : 'default'}
+                onClick={handleNext}
+                className="gap-1"
+              >
                 Next
                 <ChevronRight className="h-4 w-4" />
               </Button>

--- a/apps/web/src/components/app-builder/migration-target-selector.test.ts
+++ b/apps/web/src/components/app-builder/migration-target-selector.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import type { GitHubMigrationTarget } from '@/lib/app-builder/types';
+import { getMigrationTargetLabel, resolveMigrationTarget } from './migration-target-selector';
+
+function target(
+  platformIntegrationId: string,
+  platformAccountLogin: string,
+  githubAppType: 'standard' | 'lite'
+): GitHubMigrationTarget {
+  return {
+    platformIntegrationId,
+    platformAccountLogin,
+    githubAppType,
+    newRepoUrl: `https://github.com/organizations/${platformAccountLogin}/repositories/new`,
+    installationSettingsUrl: `https://github.com/settings/installations/${platformIntegrationId}`,
+    availableRepos: [],
+    repositorySelection: 'all',
+  };
+}
+
+describe('App Builder migration target selection', () => {
+  it('selects a secondary installation by integration identity', () => {
+    const primary = target('integration-standard', 'acme-core', 'standard');
+    const secondary = target('integration-lite', 'acme-apps', 'lite');
+
+    expect(resolveMigrationTarget([primary, secondary], secondary)).toEqual({
+      target: secondary,
+      isUnavailable: false,
+    });
+  });
+
+  it('keeps an unavailable pin instead of falling back to another installation', () => {
+    const available = target('integration-standard', 'acme-core', 'standard');
+    const unavailable = target('integration-lite', 'acme-apps', 'lite');
+
+    expect(resolveMigrationTarget([available], unavailable)).toEqual({
+      target: unavailable,
+      isUnavailable: true,
+    });
+  });
+
+  it('distinguishes duplicate account names by Standard and Lite app type', () => {
+    const standard = target('integration-standard', 'acme', 'standard');
+    const lite = target('integration-lite', 'acme', 'lite');
+
+    expect(getMigrationTargetLabel(standard, [standard, lite])).toBe('acme (Standard app)');
+    expect(getMigrationTargetLabel(lite, [standard, lite])).toBe('acme (Lite app)');
+  });
+});

--- a/apps/web/src/components/app-builder/migration-target-selector.ts
+++ b/apps/web/src/components/app-builder/migration-target-selector.ts
@@ -1,0 +1,32 @@
+import type { GitHubMigrationTarget } from '@/lib/app-builder/types';
+
+export function resolveMigrationTarget(
+  targets: GitHubMigrationTarget[],
+  pinnedTarget?: GitHubMigrationTarget
+): { target: GitHubMigrationTarget | undefined; isUnavailable: boolean } {
+  if (!pinnedTarget) {
+    return { target: targets[0], isUnavailable: false };
+  }
+
+  const currentTarget = targets.find(
+    target => target.platformIntegrationId === pinnedTarget.platformIntegrationId
+  );
+  return {
+    target: currentTarget ?? pinnedTarget,
+    isUnavailable: currentTarget === undefined,
+  };
+}
+
+export function getMigrationTargetLabel(
+  target: GitHubMigrationTarget,
+  targets: GitHubMigrationTarget[]
+): string {
+  const duplicateAccount = targets.some(
+    candidate =>
+      candidate.platformIntegrationId !== target.platformIntegrationId &&
+      candidate.platformAccountLogin.toLowerCase() === target.platformAccountLogin.toLowerCase()
+  );
+  if (!duplicateAccount) return target.platformAccountLogin;
+
+  return `${target.platformAccountLogin} (${target.githubAppType === 'lite' ? 'Lite app' : 'Standard app'})`;
+}

--- a/apps/web/src/lib/app-builder/github-migration-service.test.ts
+++ b/apps/web/src/lib/app-builder/github-migration-service.test.ts
@@ -109,7 +109,9 @@ beforeEach(() => {
     },
     repository_selection: installationId === 'installation-lite' ? 'selected' : 'all',
   }));
-  mockGetInstallationSettingsUrl.mockResolvedValue('https://github.com/settings/installations/1');
+  mockGetInstallationSettingsUrl.mockImplementation(
+    async (installationId: unknown) => `https://github.com/settings/installations/${installationId}`
+  );
   mockFetchRepositories.mockImplementation(async (installationId: unknown) =>
     installationId === 'installation-lite'
       ? [
@@ -147,12 +149,98 @@ describe('App Builder GitHub integration identity', () => {
         platformIntegrationId: standardIntegrationId,
       }),
     ]);
+    expect(result.migrationTargets).toEqual([
+      expect.objectContaining({
+        platformIntegrationId: standardIntegrationId,
+        platformAccountLogin: 'acme-core',
+        githubAppType: 'standard',
+        newRepoUrl: 'https://github.com/organizations/acme-core/repositories/new',
+        installationSettingsUrl: 'https://github.com/settings/installations/installation-standard',
+        repositorySelection: 'all',
+        availableRepos: [
+          expect.objectContaining({
+            fullName: 'acme-core/primary',
+            platformIntegrationId: standardIntegrationId,
+            platformAccountLogin: 'acme-core',
+          }),
+        ],
+      }),
+      expect.objectContaining({
+        platformIntegrationId: liteIntegrationId,
+        platformAccountLogin: 'acme-apps',
+        githubAppType: 'lite',
+        installationSettingsUrl: 'https://github.com/settings/installations/installation-lite',
+        repositorySelection: 'selected',
+        availableRepos: [
+          expect.objectContaining({
+            fullName: 'acme-apps/secondary',
+            platformIntegrationId: liteIntegrationId,
+            platformAccountLogin: 'acme-apps',
+          }),
+        ],
+      }),
+    ]);
     expect(mockFetchRepositories).toHaveBeenCalledWith('installation-standard', 'standard');
     expect(mockFetchRepositories).toHaveBeenCalledWith('installation-lite', 'lite');
     expect(mockUpdateRepositoriesForIntegration).toHaveBeenCalledWith(
       liteIntegrationId,
       expect.arrayContaining([expect.objectContaining({ full_name: 'acme-apps/secondary' })])
     );
+  });
+
+  it('keeps duplicate repository names distinct across migration targets', async () => {
+    mockFetchInstallationDetails.mockResolvedValue({
+      account: { login: 'acme', type: 'Organization' },
+      repository_selection: 'selected',
+    });
+    mockFetchRepositories.mockResolvedValue([
+      {
+        id: 3,
+        name: 'shared',
+        full_name: 'acme/shared',
+        private: true,
+        created_at: '2026-08-27T11:00:00.000Z',
+      },
+    ]);
+
+    const result = await canMigrateToGitHub(project.id, { type: 'org', id: organizationId });
+
+    expect(result.migrationTargets).toHaveLength(2);
+    expect(result.migrationTargets.map(target => target.availableRepos[0])).toEqual([
+      expect.objectContaining({
+        fullName: 'acme/shared',
+        platformIntegrationId: standardIntegrationId,
+      }),
+      expect.objectContaining({
+        fullName: 'acme/shared',
+        platformIntegrationId: liteIntegrationId,
+      }),
+    ]);
+  });
+
+  it('excludes unhealthy organization installations from migration targets', async () => {
+    const unhealthyIntegration = {
+      ...integration(
+        '123e4567-e89b-12d3-a456-426614174005',
+        'installation-unhealthy',
+        'standard',
+        'acme-legacy'
+      ),
+      auth_invalid_at: '2026-08-27T09:00:00.000Z',
+    };
+    mockGetIntegrationsByOrganization.mockResolvedValue([
+      standardIntegration,
+      unhealthyIntegration,
+      liteIntegration,
+    ]);
+
+    const result = await canMigrateToGitHub(project.id, { type: 'org', id: organizationId });
+
+    expect(result.migrationTargets.map(target => target.platformIntegrationId)).toEqual([
+      standardIntegrationId,
+      liteIntegrationId,
+    ]);
+    expect(mockFetchRepositories).not.toHaveBeenCalledWith('installation-unhealthy', 'standard');
   });
 
   it('uses the exact secondary integration for validation and worker migration', async () => {

--- a/apps/web/src/lib/app-builder/github-migration-service.ts
+++ b/apps/web/src/lib/app-builder/github-migration-service.ts
@@ -24,6 +24,7 @@ import type {
   MigrateToGitHubResult,
   MigrateToGitHubErrorCode,
   CanMigrateToGitHubResult,
+  GitHubMigrationTarget,
 } from '@/lib/app-builder/types';
 
 class MigrationError extends Error {
@@ -38,6 +39,12 @@ class MigrationError extends Error {
 
 function getGitHubAppType(integration: PlatformIntegration): 'standard' | 'lite' {
   return integration.github_app_type ?? 'standard';
+}
+
+function getNewRepositoryUrl(accountLogin: string, accountType: string): string {
+  return accountType === 'Organization'
+    ? `https://github.com/organizations/${accountLogin}/repositories/new`
+    : 'https://github.com/new';
 }
 
 async function getMigrationIntegrations(owner: Owner): Promise<PlatformIntegration[]> {
@@ -93,6 +100,7 @@ export async function canMigrateToGitHub(
     installationSettingsUrl: '',
     availableRepos: [],
     repositorySelection: 'all',
+    migrationTargets: [],
   };
 
   // Check if already migrated
@@ -106,6 +114,7 @@ export async function canMigrateToGitHub(
       installationSettingsUrl: '',
       availableRepos: [],
       repositorySelection: 'all',
+      migrationTargets: [],
     };
   }
 
@@ -118,10 +127,6 @@ export async function canMigrateToGitHub(
   // Fetch installation details and available repos in parallel
   let targetAccountName = integration.platform_account_login ?? null;
   let installationSettingsUrl = '';
-  let availableRepos: CanMigrateToGitHubResult['availableRepos'] = [];
-  let accountType = 'User';
-  let repositorySelection: 'all' | 'selected' = 'all';
-
   const integrationData = await Promise.all(
     integrations.map(async candidate => {
       const candidateInstallationId = candidate.platform_installation_id;
@@ -142,57 +147,62 @@ export async function canMigrateToGitHub(
     })
   );
 
-  const primaryData = integrationData[0];
-  if (primaryData) {
-    targetAccountName = primaryData.installationDetails.account.login || targetAccountName;
-    accountType = primaryData.installationDetails.account.type;
-    repositorySelection =
-      primaryData.installationDetails.repository_selection === 'selected' ? 'selected' : 'all';
-    installationSettingsUrl = primaryData.settingsUrl;
-  }
+  const migrationTargets = integrationData.flatMap<GitHubMigrationTarget>(data => {
+    if (!data) return [];
 
-  const reposByFullName = new Map<string, CanMigrateToGitHubResult['availableRepos']>();
-  for (const data of integrationData) {
-    if (!data) continue;
-    for (const repo of data.repos) {
-      const key = repo.full_name.toLowerCase();
-      const matches = reposByFullName.get(key) ?? [];
-      matches.push({
+    const platformAccountLogin =
+      data.installationDetails.account.login || data.integration.platform_account_login;
+    if (!platformAccountLogin) return [];
+
+    const availableRepos = data.repos
+      .map(repo => ({
         fullName: repo.full_name,
         createdAt: repo.created_at,
         isPrivate: repo.private,
         platformIntegrationId: data.integration.id,
-      });
-      reposByFullName.set(key, matches);
-    }
+        platformAccountLogin,
+      }))
+      .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+      .slice(0, 10);
+
+    return [
+      {
+        platformIntegrationId: data.integration.id,
+        platformAccountLogin,
+        githubAppType: getGitHubAppType(data.integration),
+        newRepoUrl: getNewRepositoryUrl(
+          platformAccountLogin,
+          data.installationDetails.account.type
+        ),
+        installationSettingsUrl: data.settingsUrl,
+        availableRepos,
+        repositorySelection:
+          data.installationDetails.repository_selection === 'selected' ? 'selected' : 'all',
+      },
+    ];
+  });
+
+  const primaryTarget = migrationTargets[0];
+  if (primaryTarget) {
+    targetAccountName = primaryTarget.platformAccountLogin;
+    installationSettingsUrl = primaryTarget.installationSettingsUrl;
   }
-  availableRepos = [...reposByFullName.values()]
-    .map(matches => {
-      const [repo] = matches;
-      if (!repo) return null;
-      return matches.length === 1 ? repo : { ...repo, platformIntegrationId: undefined };
-    })
-    .filter(repo => repo !== null)
+
+  const availableRepos = migrationTargets
+    .flatMap(target => target.availableRepos)
     .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
     .slice(0, 10);
-
-  // Build the URL for creating a new repo
-  // For orgs: https://github.com/organizations/{org}/repositories/new
-  // For users: https://github.com/new
-  const newRepoUrl =
-    accountType === 'Organization' && targetAccountName
-      ? `https://github.com/organizations/${targetAccountName}/repositories/new`
-      : 'https://github.com/new';
 
   return {
     hasGitHubIntegration: true,
     targetAccountName,
     alreadyMigrated: false,
     suggestedRepoName,
-    newRepoUrl,
+    newRepoUrl: primaryTarget?.newRepoUrl ?? 'https://github.com/new',
     installationSettingsUrl,
     availableRepos,
-    repositorySelection,
+    repositorySelection: primaryTarget?.repositorySelection ?? 'all',
+    migrationTargets,
   };
 }
 

--- a/apps/web/src/lib/app-builder/types.ts
+++ b/apps/web/src/lib/app-builder/types.ts
@@ -165,6 +165,17 @@ export type AvailableRepo = {
   createdAt: string;
   isPrivate: boolean;
   platformIntegrationId?: string;
+  platformAccountLogin?: string;
+};
+
+export type GitHubMigrationTarget = {
+  platformIntegrationId: string;
+  platformAccountLogin: string;
+  githubAppType: 'standard' | 'lite';
+  newRepoUrl: string;
+  installationSettingsUrl: string;
+  availableRepos: AvailableRepo[];
+  repositorySelection: 'all' | 'selected';
 };
 
 /**
@@ -188,4 +199,6 @@ export type CanMigrateToGitHubResult = {
   availableRepos: AvailableRepo[];
   /** Whether the GitHub App has access to all repos ('all') or only selected repos ('selected') */
   repositorySelection: 'all' | 'selected';
+  /** Healthy GitHub installations available as migration targets */
+  migrationTargets: GitHubMigrationTarget[];
 };


### PR DESCRIPTION
## Why this PR exists

#5573 gives App Builder a safe way to persist one GitHub installation, but the migration dialog still projects a single organization installation. Users cannot choose a secondary destination, and duplicate GitHub account/repository names provide no visible installation distinction.

This PR exposes the backend pin as an explicit migration-target choice and refuses to substitute another installation if the selected one becomes unavailable.

## Place in the rollout

This is the App Builder UI child of #5573. The split ensures the Worker can honor the choice before the UI offers it.

## Dependency

Depends on #5573. Merge/deploy App Builder identity first, then retarget this PR to `main`.

## What changes

- Aggregate migration targets from all healthy organization GitHub installations.
- Let the user select the destination GitHub organization/installation.
- Distinguish duplicate account names by Standard/Lite app type.
- Scope repository options to the selected installation.
- Submit its `platformIntegrationId`.
- Keep a stale pinned selection visible with installation-specific recovery instead of falling back.

## What stays unchanged

- Initial push, preview clone, rebuild, and restart enforcement remain in #5573.
- Personal migration behavior remains compatible.
- The selector does not auto-switch when an installation disappears.

## Review guide

Review the pure `migration-target-selector.ts` rules first, then the dialog state and payload. The key invariant is that refresh preserves identity, including unavailable pins, rather than selecting the first current target.

## Validation

- 8 isolated App Builder suites
- Web typecheck, lint, and format check
- `git diff --check`