### PR TITLE
feat(review-memory): learn from replies on secondary GitHub orgs

### DIFF
--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -71,6 +71,10 @@ jest.mock('@/lib/code-reviews/review-memory/github-feedback', () => ({
   handleGitHubReviewCommentReply: (input: unknown) => mockHandleGitHubReviewCommentReply(input),
 }));
 
+jest.mock('@/lib/utils.server', () => ({
+  logExceptInTest: jest.fn(),
+}));
+
 jest.mock('next/server', () => {
   const actual = jest.requireActual('next/server');
   return {
@@ -86,6 +90,7 @@ const integration = {
   owned_by_organization_id: 'org_1',
   owned_by_user_id: null,
   platform_installation_id: '98765',
+  github_app_type: 'standard',
   suspended_at: null,
 };
 
@@ -384,7 +389,58 @@ describe('handleGitHubWebhook', () => {
     );
   });
 
-  it('allows only Auto Fix review comments through a secondary installation', async () => {
+  it('runs Auto Fix and records reply feedback through the exact secondary installation', async () => {
+    const secondaryIntegration = {
+      ...integration,
+      id: 'secondary',
+      github_app_type: 'lite',
+    };
+    const payload = reviewCommentPayload({
+      comment: {
+        ...reviewCommentPayload().comment,
+        in_reply_to_id: 455,
+      },
+    });
+    mockFindIntegrationByInstallationId.mockResolvedValue(secondaryIntegration);
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
+    mockHandleGitHubReviewCommentReply.mockResolvedValue({ recorded: true, eventId: 'evt_1' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request_review_comment', payload),
+      'lite'
+    );
+
+    expect(response.status).toBe(200);
+    await waitForAfterTask();
+    expect(mockHandlePRReviewComment).toHaveBeenCalledTimes(1);
+    expect(mockHandlePRReviewComment).toHaveBeenCalledWith(
+      expect.objectContaining(payload),
+      secondaryIntegration
+    );
+    expect(mockHandlePRReviewComment.mock.calls[0]?.[1]).toBe(secondaryIntegration);
+    expect(mockHandleGitHubReviewCommentReply).toHaveBeenCalledTimes(1);
+    expect(mockHandleGitHubReviewCommentReply).toHaveBeenCalledWith({
+      payload: expect.objectContaining(payload),
+      integration: secondaryIntegration,
+      deliveryId: 'delivery-pull_request_review_comment',
+    });
+    expect(mockHandleGitHubReviewCommentReply.mock.calls[0]?.[0].integration).toBe(
+      secondaryIntegration
+    );
+    expect(mockHandleGitHubReviewCommentReply.mock.calls[0]?.[0].integration.github_app_type).toBe(
+      'lite'
+    );
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'we_1',
+      expect.objectContaining({
+        handlers_triggered: ['pr_review_comment_fix', 'review_memory_feedback'],
+      })
+    );
+  });
+
+  it('runs Auto Fix without recording feedback for a secondary non-reply comment', async () => {
+    const secondaryIntegration = { ...integration, id: 'secondary' };
+    mockFindIntegrationByInstallationId.mockResolvedValue(secondaryIntegration);
     mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
 
     const response = await handleGitHubWebhook(
@@ -394,8 +450,12 @@ describe('handleGitHubWebhook', () => {
 
     expect(response.status).toBe(200);
     await waitForAfterTask();
-    expect(mockHandlePRReviewComment).toHaveBeenCalledWith(expect.anything(), integration);
-    expect(mockHandleGitHubReviewCommentReply).not.toHaveBeenCalled();
+    expect(mockHandlePRReviewComment).toHaveBeenCalledTimes(1);
+    expect(mockHandleGitHubReviewCommentReply).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'we_1',
+      expect.objectContaining({ handlers_triggered: ['pr_review_comment_fix'] })
+    );
   });
 
   it('allows labeled Auto Fix issues but suppresses other issues on a secondary installation', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -702,14 +702,12 @@ export async function handleGitHubWebhook(
         try {
           await handlePRReviewComment(parseResult.data, integration);
           try {
-            if (!isSecondaryOrganizationInstallation) {
-              const reviewMemoryResult = await handleGitHubReviewCommentReply({
-                payload: parseResult.data,
-                integration,
-                deliveryId: eventSignature,
-              });
-              if (reviewMemoryResult.recorded) handlersTriggered.push('review_memory_feedback');
-            }
+            const reviewMemoryResult = await handleGitHubReviewCommentReply({
+              payload: parseResult.data,
+              integration,
+              deliveryId: eventSignature,
+            });
+            if (reviewMemoryResult.recorded) handlersTriggered.push('review_memory_feedback');
           } catch (error) {
             logExceptInTest(`Error handling review memory feedback${logSuffix}:`, error);
             captureException(error, {


### PR DESCRIPTION
## Why this PR exists

#5572 safely admits created pull-request review comments from secondary installations for Auto Fix. The same GitHub event also carries replies to Kilo review comments, which Review Memory uses as feedback. That side effect is still explicitly skipped for secondary installations even though its handler already receives the exact delivering integration and app type.

The result is inconsistent learning: identical reviewer feedback is recorded on the primary GitHub organization but ignored on every secondary one.

## Place in the rollout

This is a small gap found during the final singular-caller/webhook audit. It is separate from Auto Fix because Review Memory is an independent product side effect sharing the same admitted event.

## Dependency

Depends on #5572 because that PR admits the secondary `pull_request_review_comment.created` event. After #5572 merges, retarget this PR to `main`.

## What changes

- Run `handleGitHubReviewCommentReply` for secondary installations.
- Pass the exact delivering `PlatformIntegration`, including Standard/Lite app type.
- Keep Auto Fix and Review Memory as independent same-event handlers.

## What stays unchanged

- Non-replies do not create Review Memory feedback.
- No schema or feedback model changes are introduced.
- Other secondary review-comment actions remain governed by the existing admission predicate.

## Review guide

This is a two-file PR. Review the removal of the secondary-only guard and the four focused webhook cases: reply, non-reply, coexistence with Auto Fix, and Lite app type.

## Validation

- 17 isolated webhook tests
- Focused lint and formatting
- `git diff --check`