### PR TITLE
feat(github): choose installations by live repository access

### DIFF
--- a/services/app-builder/src/types.ts
+++ b/services/app-builder/src/types.ts
@@ -24,6 +24,7 @@ export type GetTokenForRepoResult =
   | {
       success: true;
       token: string;
+      platformIntegrationId: string;
       installationId: string;
       accountLogin: string;
       appType: 'standard' | 'lite';
@@ -34,6 +35,10 @@ export type GetTokenForRepoResult =
         | 'database_not_configured'
         | 'invalid_repo_format'
         | 'no_installation_found'
+        | 'repository_not_installed'
+        | 'ambiguous_installation'
+        | 'temporarily_unavailable'
+        | 'integration_mismatch'
         | 'invalid_org_id';
     };
 

--- a/services/cloud-agent-next/src/services/git-token-service-client.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.ts
@@ -13,6 +13,7 @@ type GitTokenServiceEnv = {
 
 export type ResolvedGitHubToken = {
   token: string;
+  platformIntegrationId: string;
   installationId: string;
   appType: 'standard' | 'lite';
   accountLogin: string;
@@ -54,6 +55,7 @@ export async function resolveGitHubTokenForRepo(
         success: true,
         value: {
           token: result.token,
+          platformIntegrationId: result.platformIntegrationId,
           installationId: result.installationId,
           appType: result.appType,
           accountLogin: result.accountLogin,
@@ -82,6 +84,7 @@ export async function resolveGitHubTokenForRepo(
 
 export type ResolvedCloudAgentGitHubAuth = {
   githubToken: string;
+  platformIntegrationId: string;
   installationId: string;
   appType: 'standard' | 'lite';
   accountLogin: string;
@@ -93,6 +96,7 @@ export type ResolvedCloudAgentGitHubAuth = {
 
 export type ResolvedCloudAgentGitHubCapability = {
   capability: string;
+  platformIntegrationId: string;
   installationId: string;
   appType: 'standard' | 'lite';
   accountLogin: string;
@@ -137,6 +141,7 @@ async function resolveLegacyInstallationAuthForRepo(
     success: true,
     value: {
       githubToken: result.value.token,
+      platformIntegrationId: result.value.platformIntegrationId,
       installationId: result.value.installationId,
       appType: result.value.appType,
       accountLogin: result.value.accountLogin,
@@ -192,6 +197,7 @@ export async function resolveCloudAgentGitHubAuthForRepo(
       success: true,
       value: {
         githubToken: result.githubToken,
+        platformIntegrationId: result.platformIntegrationId,
         installationId: result.installationId,
         appType: result.appType,
         accountLogin: result.accountLogin,
@@ -267,6 +273,7 @@ export async function issueCloudAgentGitHubSessionCapability(
       success: true,
       value: {
         capability: result.capability,
+        platformIntegrationId: result.platformIntegrationId,
         installationId: result.installationId,
         appType: result.appType,
         accountLogin: result.accountLogin,

--- a/services/cloud-agent-next/src/types.ts
+++ b/services/cloud-agent-next/src/types.ts
@@ -181,6 +181,7 @@ type GetTokenForRepoResult =
   | {
       success: true;
       token: string;
+      platformIntegrationId: string;
       installationId: string;
       accountLogin: string;
       appType: 'standard' | 'lite';
@@ -192,6 +193,8 @@ type GetTokenForRepoResult =
         | 'invalid_repo_format'
         | 'no_installation_found'
         | 'repository_not_installed'
+        | 'ambiguous_installation'
+        | 'temporarily_unavailable'
         | 'integration_mismatch'
         | 'invalid_org_id';
     };
@@ -222,6 +225,7 @@ type GetCloudAgentAuthForRepoResult =
   | {
       success: true;
       githubToken: string;
+      platformIntegrationId: string;
       installationId: string;
       accountLogin: string;
       appType: 'standard' | 'lite';
@@ -237,6 +241,8 @@ type GetCloudAgentAuthForRepoResult =
         | 'invalid_repo_format'
         | 'no_installation_found'
         | 'repository_not_installed'
+        | 'ambiguous_installation'
+        | 'temporarily_unavailable'
         | 'integration_mismatch'
         | 'invalid_org_id';
     };
@@ -245,6 +251,7 @@ type IssueGitHubSessionCapabilityResult =
   | {
       success: true;
       capability: string;
+      platformIntegrationId: string;
       installationId: string;
       accountLogin: string;
       appType: 'standard' | 'lite';
@@ -260,6 +267,8 @@ type IssueGitHubSessionCapabilityResult =
         | 'invalid_repo_format'
         | 'no_installation_found'
         | 'repository_not_installed'
+        | 'ambiguous_installation'
+        | 'temporarily_unavailable'
         | 'integration_mismatch'
         | 'invalid_org_id'
         | 'capability_configuration_error';

--- a/services/gastown/worker-configuration.d.ts
+++ b/services/gastown/worker-configuration.d.ts
@@ -31,13 +31,14 @@ interface __BaseEnv_Env {
 type GetTokenForRepoSuccess = {
 	success: true;
 	token: string;
+	platformIntegrationId: string;
 	installationId: string;
 	accountLogin: string;
 	appType: 'standard' | 'lite';
 };
 type GetTokenForRepoFailure = {
 	success: false;
-	reason: 'database_not_configured' | 'invalid_repo_format' | 'no_installation_found' | 'invalid_org_id';
+	reason: 'database_not_configured' | 'invalid_repo_format' | 'no_installation_found' | 'repository_not_installed' | 'ambiguous_installation' | 'temporarily_unavailable' | 'integration_mismatch' | 'invalid_org_id';
 };
 type GetTokenForRepoResult = GetTokenForRepoSuccess | GetTokenForRepoFailure;
 type GitTokenService = {

--- a/services/git-token-service/src/github-token-service.test.ts
+++ b/services/git-token-service/src/github-token-service.test.ts
@@ -32,6 +32,7 @@ describe('GitHubTokenService', () => {
     vi.mocked(createAppAuth).mockReset();
     vi.mocked(Octokit).mockReset();
     mockGetInstallation.mockReset();
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response('{}', { status: 200 })));
     vi.mocked(Octokit).mockImplementation(function MockOctokit() {
       return { apps: { getInstallation: mockGetInstallation } } as unknown as Octokit;
     });
@@ -147,5 +148,68 @@ describe('GitHubTokenService', () => {
       })
     );
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain('sensitive-upstream-data');
+  });
+
+  it.each([404, 422])(
+    'classifies provider status %s as definitive repository non-access',
+    async status => {
+      vi.mocked(createAppAuth).mockReturnValue(
+        vi
+          .fn()
+          .mockRejectedValue(
+            Object.assign(new Error('not installed'), { status })
+          ) as unknown as ReturnType<typeof createAppAuth>
+      );
+      vi.spyOn(console, 'error').mockImplementation(() => {});
+      const service = new GitHubTokenService({
+        GITHUB_APP_ID: 'app-id',
+        GITHUB_APP_PRIVATE_KEY: 'private-key',
+      } as CloudflareEnv);
+
+      await expect(service.tryGetTokenForRepo('123', 'acme/repository')).resolves.toEqual({
+        status: 'not_installed',
+      });
+    }
+  );
+
+  it('classifies provider and configuration uncertainty as temporary unavailability', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi
+        .fn()
+        .mockRejectedValue(
+          Object.assign(new Error('unavailable'), { status: 503 })
+        ) as unknown as ReturnType<typeof createAppAuth>
+    );
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+    } as CloudflareEnv);
+
+    await expect(service.tryGetTokenForRepo('123', 'acme/repository')).resolves.toEqual({
+      status: 'temporarily_unavailable',
+    });
+  });
+
+  it('requires the minted token to access the exact owner and repository', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({
+        token: 'scoped-token',
+        expiresAt: new Date(Date.now() + 60_000),
+      }) as unknown as ReturnType<typeof createAppAuth>
+    );
+    vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 404 }));
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+    } as CloudflareEnv);
+
+    await expect(service.tryGetTokenForRepo('123', 'acme/repository')).resolves.toEqual({
+      status: 'not_installed',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/acme/repository',
+      expect.objectContaining({ method: 'GET' })
+    );
   });
 });

--- a/services/git-token-service/src/github-token-service.test.ts
+++ b/services/git-token-service/src/github-token-service.test.ts
@@ -150,53 +150,40 @@ describe('GitHubTokenService', () => {
     expect(JSON.stringify(consoleError.mock.calls)).not.toContain('sensitive-upstream-data');
   });
 
-  it.each([404, 422])(
-    'classifies provider status %s as definitive repository non-access',
-    async status => {
-      vi.mocked(createAppAuth).mockReturnValue(
-        vi
-          .fn()
-          .mockRejectedValue(
-            Object.assign(new Error('not installed'), { status })
-          ) as unknown as ReturnType<typeof createAppAuth>
-      );
-      vi.spyOn(console, 'error').mockImplementation(() => {});
-      const service = new GitHubTokenService({
-        GITHUB_APP_ID: 'app-id',
-        GITHUB_APP_PRIVATE_KEY: 'private-key',
-      } as CloudflareEnv);
-
-      await expect(service.tryGetTokenForRepo('123', 'acme/repository')).resolves.toEqual({
-        status: 'not_installed',
-      });
-    }
-  );
-
-  it('classifies provider and configuration uncertainty as temporary unavailability', async () => {
+  it('looks up the authoritative repository installation as the selected app', async () => {
     vi.mocked(createAppAuth).mockReturnValue(
-      vi
-        .fn()
-        .mockRejectedValue(
-          Object.assign(new Error('unavailable'), { status: 503 })
-        ) as unknown as ReturnType<typeof createAppAuth>
+      vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
     );
-    vi.spyOn(console, 'error').mockImplementation(() => {});
+    vi.mocked(fetch).mockResolvedValueOnce(
+      Response.json({ id: 987654 }, { headers: { 'Content-Length': '13' } })
+    );
     const service = new GitHubTokenService({
-      GITHUB_APP_ID: 'app-id',
-      GITHUB_APP_PRIVATE_KEY: 'private-key',
+      GITHUB_LITE_APP_ID: 'lite-app-id',
+      GITHUB_LITE_APP_PRIVATE_KEY: 'lite-private-key',
     } as CloudflareEnv);
 
-    await expect(service.tryGetTokenForRepo('123', 'acme/repository')).resolves.toEqual({
-      status: 'temporarily_unavailable',
+    await expect(service.findRepositoryInstallation('acme/repository', 'lite')).resolves.toEqual({
+      status: 'installed',
+      installationId: '987654',
     });
+    expect(createAppAuth).toHaveBeenCalledWith({
+      appId: 'lite-app-id',
+      privateKey: 'lite-private-key',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/acme/repository/installation',
+      expect.objectContaining({
+        method: 'GET',
+        redirect: 'manual',
+        signal: expect.any(AbortSignal),
+        headers: expect.objectContaining({ Authorization: 'Bearer app-jwt' }),
+      })
+    );
   });
 
-  it('requires the minted token to access the exact owner and repository', async () => {
+  it('treats only a repository installation 404 as definitive no installation', async () => {
     vi.mocked(createAppAuth).mockReturnValue(
-      vi.fn().mockResolvedValue({
-        token: 'scoped-token',
-        expiresAt: new Date(Date.now() + 60_000),
-      }) as unknown as ReturnType<typeof createAppAuth>
+      vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
     );
     vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status: 404 }));
     const service = new GitHubTokenService({
@@ -204,12 +191,113 @@ describe('GitHubTokenService', () => {
       GITHUB_APP_PRIVATE_KEY: 'private-key',
     } as CloudflareEnv);
 
-    await expect(service.tryGetTokenForRepo('123', 'acme/repository')).resolves.toEqual({
+    await expect(service.findRepositoryInstallation('acme/repository')).resolves.toEqual({
       status: 'not_installed',
     });
-    expect(fetch).toHaveBeenCalledWith(
-      'https://api.github.com/repos/acme/repository',
-      expect.objectContaining({ method: 'GET' })
+  });
+
+  it.each([401, 403, 422, 429, 500, 503])(
+    'treats repository installation status %s as temporary failure',
+    async status => {
+      vi.mocked(createAppAuth).mockReturnValue(
+        vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<
+          typeof createAppAuth
+        >
+      );
+      vi.mocked(fetch).mockResolvedValueOnce(new Response(null, { status }));
+      const service = new GitHubTokenService({
+        GITHUB_APP_ID: 'app-id',
+        GITHUB_APP_PRIVATE_KEY: 'private-key',
+      } as CloudflareEnv);
+
+      await expect(service.findRepositoryInstallation('acme/repository')).resolves.toEqual({
+        status: 'temporarily_unavailable',
+      });
+    }
+  );
+
+  it('rejects redirects without following them', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
     );
+    vi.mocked(fetch).mockResolvedValueOnce(
+      new Response(null, { status: 302, headers: { Location: 'https://example.com' } })
+    );
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+    } as CloudflareEnv);
+
+    await expect(service.findRepositoryInstallation('acme/repository')).resolves.toEqual({
+      status: 'temporarily_unavailable',
+    });
+    expect(fetch).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ redirect: 'manual' })
+    );
+  });
+
+  it('classifies lookup timeout as temporary failure', async () => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
+    );
+    vi.spyOn(AbortSignal, 'timeout').mockReturnValue(AbortSignal.abort());
+    vi.mocked(fetch).mockRejectedValueOnce(new DOMException('Timed out', 'TimeoutError'));
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+    } as CloudflareEnv);
+
+    await expect(service.findRepositoryInstallation('acme/repository')).resolves.toEqual({
+      status: 'temporarily_unavailable',
+    });
+  });
+
+  it.each([
+    new Response('{"id":"123"}', { headers: { 'Content-Type': 'application/json' } }),
+    new Response('{"id":123}', { headers: { 'Content-Type': 'text/plain' } }),
+    new Response('{"id":123}', {
+      headers: { 'Content-Type': 'application/json', 'Content-Length': '64001' },
+    }),
+  ])('rejects an invalid or unbounded installation response', async response => {
+    vi.mocked(createAppAuth).mockReturnValue(
+      vi.fn().mockResolvedValue({ token: 'app-jwt' }) as unknown as ReturnType<typeof createAppAuth>
+    );
+    vi.mocked(fetch).mockResolvedValueOnce(response);
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+    } as CloudflareEnv);
+
+    await expect(service.findRepositoryInstallation('acme/repository')).resolves.toEqual({
+      status: 'temporarily_unavailable',
+    });
+  });
+
+  it('reuses a cached scoped token only after authoritative resolution selects its row', async () => {
+    const expiresAt = Date.now() + 60 * 60_000;
+    let cached: unknown = null;
+    const tokenCache = {
+      get: vi.fn(async (_key: string, type?: string) => (type === 'json' ? cached : null)),
+      put: vi.fn(async (_key: string, value: string) => {
+        cached = JSON.parse(value);
+      }),
+    };
+    const installationAuth = vi.fn().mockResolvedValue({ token: 'scoped-token', expiresAt });
+    vi.mocked(createAppAuth).mockReturnValue(
+      installationAuth as unknown as ReturnType<typeof createAppAuth>
+    );
+    const service = new GitHubTokenService({
+      GITHUB_APP_ID: 'app-id',
+      GITHUB_APP_PRIVATE_KEY: 'private-key',
+      TOKEN_CACHE: tokenCache,
+    } as unknown as CloudflareEnv);
+
+    await expect(service.getTokenForRepo('123', 'repository')).resolves.toBe('scoped-token');
+    await expect(service.getTokenForRepo('123', 'repository')).resolves.toBe('scoped-token');
+
+    expect(installationAuth).toHaveBeenCalledOnce();
+    expect(tokenCache.get).toHaveBeenCalledWith('gh-token:123:standard:repository', 'json');
+    expect(tokenCache.put).toHaveBeenCalledOnce();
   });
 });

--- a/services/git-token-service/src/github-token-service.ts
+++ b/services/git-token-service/src/github-token-service.ts
@@ -20,8 +20,8 @@ type GitHubAppCredentials = {
  */
 export type GitHubAppType = 'standard' | 'lite';
 
-export type GitHubRepositoryTokenResult =
-  | { status: 'available'; token: string }
+export type GitHubRepositoryInstallationResult =
+  | { status: 'installed'; installationId: string }
   | { status: 'not_installed' }
   | { status: 'temporarily_unavailable' };
 
@@ -31,6 +31,12 @@ const MIN_TTL_SECONDS = 60;
 const EXPIRY_BUFFER_MS = 5 * 60 * 1000;
 const INSTALLATION_LOGIN_REFRESH_CACHE_KEY_PREFIX = 'gh-installation-login-refresh:v1:';
 const INSTALLATION_LOGIN_REFRESH_TTL_SECONDS = 15 * 60;
+const REPOSITORY_INSTALLATION_LOOKUP_TIMEOUT_MS = 10_000;
+const REPOSITORY_INSTALLATION_MAX_RESPONSE_BYTES = 64_000;
+
+const GitHubRepositoryInstallationSchema = z.object({
+  id: z.number().int().positive().safe(),
+});
 
 const GitHubInstallationAccountSchema = z.object({
   account: z.object({
@@ -85,39 +91,58 @@ export class GitHubTokenService {
     return token;
   }
 
-  async tryGetTokenForRepo(
-    installationId: string,
+  async findRepositoryInstallation(
     githubRepo: string,
     appType: GitHubAppType = 'standard'
-  ): Promise<GitHubRepositoryTokenResult> {
+  ): Promise<GitHubRepositoryInstallationResult> {
     const [owner, repoName] = githubRepo.split('/');
     if (!owner || !repoName) return { status: 'temporarily_unavailable' };
+
+    const endpoint = `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repoName)}/installation`;
+    const signal = AbortSignal.timeout(REPOSITORY_INSTALLATION_LOOKUP_TIMEOUT_MS);
     try {
-      const numericId = this.validateInstallationId(installationId);
       const credentials = this.getCredentials(appType);
-      const { token, expiresAt } = await this.generateToken(numericId, credentials, [repoName]);
-      const response = await fetch(
-        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repoName)}`,
-        {
-          method: 'GET',
-          headers: {
-            Accept: 'application/vnd.github+json',
-            Authorization: `Bearer ${token}`,
-            'User-Agent': 'Kilo-Git-Token-Service',
-          },
-        }
-      );
-      await response.body?.cancel();
-      if (response.status === 404) return { status: 'not_installed' };
-      if (!response.ok) return { status: 'temporarily_unavailable' };
-      await this.cacheToken(`${installationId}:${appType}:${repoName}`, token, expiresAt);
+      const auth = createAppAuth({
+        appId: credentials.appId,
+        privateKey: credentials.privateKey,
+      });
+      const { token } = await auth({ type: 'app' });
+      const response = await fetch(endpoint, {
+        method: 'GET',
+        headers: {
+          Accept: 'application/vnd.github+json',
+          Authorization: `Bearer ${token}`,
+          'User-Agent': 'Kilo-Git-Token-Service',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        redirect: 'manual',
+        signal,
+      });
+      if (
+        (response.status >= 300 && response.status < 400) ||
+        response.redirected ||
+        (response.url !== '' && response.url !== endpoint)
+      ) {
+        await this.cancelResponse(response);
+        return { status: 'temporarily_unavailable' };
+      }
+      if (response.status === 404) {
+        await this.cancelResponse(response);
+        return { status: 'not_installed' };
+      }
+      if (response.status !== 200 || !this.isBoundedJsonResponse(response)) {
+        await this.cancelResponse(response);
+        return { status: 'temporarily_unavailable' };
+      }
+
+      const payload = await this.readBoundedJson(response, signal);
+      const installation = GitHubRepositoryInstallationSchema.safeParse(payload);
+      if (!installation.success) return { status: 'temporarily_unavailable' };
       return {
-        status: 'available',
-        token,
+        status: 'installed',
+        installationId: String(installation.data.id),
       };
-    } catch (error) {
-      const status = this.getProviderStatus(error);
-      if (status === 404 || status === 422) return { status: 'not_installed' };
+    } catch {
       return { status: 'temporarily_unavailable' };
     }
   }
@@ -229,6 +254,56 @@ export class GitHubTokenService {
   private getProviderStatus(error: unknown): number | null {
     if (typeof error !== 'object' || error === null || !('status' in error)) return null;
     return typeof error.status === 'number' ? error.status : null;
+  }
+
+  private isBoundedJsonResponse(response: Response): boolean {
+    const contentType = response.headers.get('Content-Type')?.split(';', 1)[0].trim().toLowerCase();
+    if (contentType !== 'application/json') return false;
+
+    const contentLength = response.headers.get('Content-Length');
+    return (
+      contentLength === null ||
+      (/^[0-9]+$/.test(contentLength) &&
+        Number(contentLength) <= REPOSITORY_INSTALLATION_MAX_RESPONSE_BYTES)
+    );
+  }
+
+  private async readBoundedJson(response: Response, signal: AbortSignal): Promise<unknown> {
+    if (!response.body) throw new Error('Invalid GitHub response');
+
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let totalBytes = 0;
+    try {
+      while (true) {
+        const chunk = await reader.read();
+        if (chunk.done) break;
+        const value: unknown = chunk.value;
+        if (!(value instanceof Uint8Array)) throw new Error('Invalid GitHub response');
+        totalBytes += value.byteLength;
+        if (totalBytes > REPOSITORY_INSTALLATION_MAX_RESPONSE_BYTES) {
+          await reader.cancel().catch(() => undefined);
+          throw new Error('GitHub response too large');
+        }
+        chunks.push(value);
+      }
+    } catch {
+      throw new Error(signal.aborted ? 'GitHub request timed out' : 'Invalid GitHub response');
+    } finally {
+      reader.releaseLock();
+    }
+
+    const body = new Uint8Array(totalBytes);
+    let offset = 0;
+    for (const chunk of chunks) {
+      body.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return JSON.parse(new TextDecoder('utf-8', { fatal: true, ignoreBOM: false }).decode(body));
+  }
+
+  private async cancelResponse(response: Response): Promise<void> {
+    await response.body?.cancel().catch(() => undefined);
   }
 
   private async getCachedToken(cacheKey: string): Promise<string | null> {

--- a/services/git-token-service/src/github-token-service.ts
+++ b/services/git-token-service/src/github-token-service.ts
@@ -20,6 +20,11 @@ type GitHubAppCredentials = {
  */
 export type GitHubAppType = 'standard' | 'lite';
 
+export type GitHubRepositoryTokenResult =
+  | { status: 'available'; token: string }
+  | { status: 'not_installed' }
+  | { status: 'temporarily_unavailable' };
+
 const CACHE_TTL_MS = 30 * 60 * 1000;
 const CACHE_KEY_PREFIX = 'gh-token:';
 const MIN_TTL_SECONDS = 60;
@@ -32,6 +37,16 @@ const GitHubInstallationAccountSchema = z.object({
     login: z.string().min(1),
   }),
 });
+
+class GitHubTokenGenerationError extends Error {
+  constructor(
+    message: string,
+    readonly status: number | null
+  ) {
+    super(message);
+    this.name = 'GitHubTokenGenerationError';
+  }
+}
 
 export class GitHubTokenService {
   constructor(private env: CloudflareEnv) {}
@@ -68,6 +83,43 @@ export class GitHubTokenService {
     await this.cacheToken(cacheKey, token, expiresAt);
 
     return token;
+  }
+
+  async tryGetTokenForRepo(
+    installationId: string,
+    githubRepo: string,
+    appType: GitHubAppType = 'standard'
+  ): Promise<GitHubRepositoryTokenResult> {
+    const [owner, repoName] = githubRepo.split('/');
+    if (!owner || !repoName) return { status: 'temporarily_unavailable' };
+    try {
+      const numericId = this.validateInstallationId(installationId);
+      const credentials = this.getCredentials(appType);
+      const { token, expiresAt } = await this.generateToken(numericId, credentials, [repoName]);
+      const response = await fetch(
+        `https://api.github.com/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repoName)}`,
+        {
+          method: 'GET',
+          headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${token}`,
+            'User-Agent': 'Kilo-Git-Token-Service',
+          },
+        }
+      );
+      await response.body?.cancel();
+      if (response.status === 404) return { status: 'not_installed' };
+      if (!response.ok) return { status: 'temporarily_unavailable' };
+      await this.cacheToken(`${installationId}:${appType}:${repoName}`, token, expiresAt);
+      return {
+        status: 'available',
+        token,
+      };
+    } catch (error) {
+      const status = this.getProviderStatus(error);
+      if (status === 404 || status === 422) return { status: 'not_installed' };
+      return { status: 'temporarily_unavailable' };
+    }
   }
 
   async refreshInstallationAccountLoginIfDue(
@@ -174,6 +226,11 @@ export class GitHubTokenService {
     return numericId;
   }
 
+  private getProviderStatus(error: unknown): number | null {
+    if (typeof error !== 'object' || error === null || !('status' in error)) return null;
+    return typeof error.status === 'number' ? error.status : null;
+  }
+
   private async getCachedToken(cacheKey: string): Promise<string | null> {
     if (!this.env.TOKEN_CACHE) {
       return null;
@@ -222,7 +279,10 @@ export class GitHubTokenService {
         })
       );
       const message = error instanceof Error ? error.message : 'Unknown error';
-      throw new Error(`Failed to generate GitHub installation token: ${message}`);
+      throw new GitHubTokenGenerationError(
+        `Failed to generate GitHub installation token: ${message}`,
+        this.getProviderStatus(error)
+      );
     }
   }
 

--- a/services/git-token-service/src/github-user-authorization-entrypoint.test.ts
+++ b/services/git-token-service/src/github-user-authorization-entrypoint.test.ts
@@ -11,7 +11,7 @@ const serviceMocks = vi.hoisted(() => ({
   findRefreshCandidates: vi.fn(),
   updateAccountLogin: vi.fn(),
   getTokenForRepo: vi.fn(),
-  tryGetTokenForRepo: vi.fn(),
+  findRepositoryInstallation: vi.fn(),
   refreshInstallationAccountLoginIfDue: vi.fn(),
   selectUserAuthorization: vi.fn(),
   disconnectUserAuthorization: vi.fn(),
@@ -31,7 +31,7 @@ vi.mock('cloudflare:workers', () => ({
 vi.mock('./github-token-service.js', () => ({
   GitHubTokenService: class GitHubTokenService {
     getTokenForRepo = serviceMocks.getTokenForRepo;
-    tryGetTokenForRepo = serviceMocks.tryGetTokenForRepo;
+    findRepositoryInstallation = serviceMocks.findRepositoryInstallation;
     refreshInstallationAccountLoginIfDue = serviceMocks.refreshInstallationAccountLoginIfDue;
   },
 }));
@@ -100,16 +100,10 @@ describe('GitTokenRPCEntrypoint.getCloudAgentAuthForRepo', () => {
         ],
       };
     });
-    serviceMocks.tryGetTokenForRepo.mockImplementation(
-      async (installationId, githubRepo, appType) => ({
-        status: 'available',
-        token: await serviceMocks.getTokenForRepo(
-          installationId,
-          githubRepo.split('/')[1],
-          appType
-        ),
-      })
-    );
+    serviceMocks.findRepositoryInstallation.mockResolvedValue({
+      status: 'installed',
+      installationId: '123',
+    });
     serviceMocks.selectUserAuthorization.mockResolvedValue({
       selected: true,
       token: 'user-token',

--- a/services/git-token-service/src/github-user-authorization-entrypoint.test.ts
+++ b/services/git-token-service/src/github-user-authorization-entrypoint.test.ts
@@ -7,9 +7,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const serviceMocks = vi.hoisted(() => ({
   findManagedInstallationForRepo: vi.fn(),
+  findAuthorizedInstallationsForRepo: vi.fn(),
   findRefreshCandidates: vi.fn(),
   updateAccountLogin: vi.fn(),
   getTokenForRepo: vi.fn(),
+  tryGetTokenForRepo: vi.fn(),
   refreshInstallationAccountLoginIfDue: vi.fn(),
   selectUserAuthorization: vi.fn(),
   disconnectUserAuthorization: vi.fn(),
@@ -29,6 +31,7 @@ vi.mock('cloudflare:workers', () => ({
 vi.mock('./github-token-service.js', () => ({
   GitHubTokenService: class GitHubTokenService {
     getTokenForRepo = serviceMocks.getTokenForRepo;
+    tryGetTokenForRepo = serviceMocks.tryGetTokenForRepo;
     refreshInstallationAccountLoginIfDue = serviceMocks.refreshInstallationAccountLoginIfDue;
   },
 }));
@@ -36,6 +39,7 @@ vi.mock('./github-token-service.js', () => ({
 vi.mock('./installation-lookup-service.js', () => ({
   InstallationLookupService: class InstallationLookupService {
     findManagedInstallationForRepo = serviceMocks.findManagedInstallationForRepo;
+    findAuthorizedInstallationsForRepo = serviceMocks.findAuthorizedInstallationsForRepo;
     findRefreshCandidates = serviceMocks.findRefreshCandidates;
     updateAccountLogin = serviceMocks.updateAccountLogin;
   },
@@ -77,6 +81,35 @@ describe('GitTokenRPCEntrypoint.getCloudAgentAuthForRepo', () => {
       permissions: { contents: 'write', pull_requests: 'write' },
     });
     serviceMocks.getTokenForRepo.mockResolvedValue('installation-token');
+    serviceMocks.findAuthorizedInstallationsForRepo.mockImplementation(async params => {
+      const result = await serviceMocks.findManagedInstallationForRepo(params);
+      if (!result?.success) return result;
+      return {
+        success: true,
+        candidates: [
+          {
+            ...result,
+            integrationId:
+              result.integrationId ??
+              params.expectedIntegrationId ??
+              '00000000-0000-4000-8000-000000000099',
+            repositoryAccess: 'all',
+            repositories: null,
+            repoName: result.repoName ?? params.githubRepo.split('/')[1],
+          },
+        ],
+      };
+    });
+    serviceMocks.tryGetTokenForRepo.mockImplementation(
+      async (installationId, githubRepo, appType) => ({
+        status: 'available',
+        token: await serviceMocks.getTokenForRepo(
+          installationId,
+          githubRepo.split('/')[1],
+          appType
+        ),
+      })
+    );
     serviceMocks.selectUserAuthorization.mockResolvedValue({
       selected: true,
       token: 'user-token',
@@ -125,7 +158,7 @@ describe('GitTokenRPCEntrypoint.getCloudAgentAuthForRepo', () => {
     });
 
     expect(serviceMocks.selectUserAuthorization).toHaveBeenCalledOnce();
-    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
+    expect(serviceMocks.getTokenForRepo).toHaveBeenCalledOnce();
     expect(result).toMatchObject({
       success: true,
       githubToken: 'user-token',
@@ -138,7 +171,7 @@ describe('GitTokenRPCEntrypoint.getCloudAgentAuthForRepo', () => {
     });
   });
 
-  it('repairs stale login metadata before resolving fenced Cloud Agent auth', async () => {
+  it('preserves an exact integration fence for Cloud Agent auth', async () => {
     const params = {
       githubRepo: 'acme/repo',
       userId: 'user_1',
@@ -146,42 +179,28 @@ describe('GitTokenRPCEntrypoint.getCloudAgentAuthForRepo', () => {
       expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
       allowUserAuthorization: true,
     };
-    serviceMocks.findManagedInstallationForRepo
-      .mockResolvedValueOnce({ success: false, reason: 'integration_mismatch' })
-      .mockResolvedValueOnce({
-        success: true,
-        installationId: '123',
-        accountLogin: 'acme',
-        githubAppType: 'standard',
-        repoName: 'repo',
-        permissions: { contents: 'write', pull_requests: 'write' },
-      });
-    serviceMocks.findRefreshCandidates.mockResolvedValue({
+    serviceMocks.findAuthorizedInstallationsForRepo.mockResolvedValue({
       success: true,
       candidates: [
         {
           integrationId: params.expectedIntegrationId,
           installationId: '123',
-          accountLogin: 'old-acme',
+          accountLogin: 'acme',
           githubAppType: 'standard',
+          repoName: 'repo',
+          permissions: { contents: 'write', pull_requests: 'write' },
+          repositoryAccess: 'selected',
+          repositories: [{ full_name: 'acme/repo' }],
         },
       ],
     });
-    serviceMocks.refreshInstallationAccountLoginIfDue.mockResolvedValue('acme');
-    serviceMocks.updateAccountLogin.mockResolvedValue(true);
-    vi.spyOn(console, 'log').mockImplementation(() => {});
 
     await expect(createService().getCloudAgentAuthForRepo(params)).resolves.toMatchObject({
       success: true,
       source: 'user',
       githubToken: 'user-token',
     });
-    expect(serviceMocks.findManagedInstallationForRepo).toHaveBeenCalledTimes(2);
-    expect(serviceMocks.findRefreshCandidates).toHaveBeenCalledWith(params);
-    expect(serviceMocks.updateAccountLogin).toHaveBeenCalledWith(
-      params.expectedIntegrationId,
-      'acme'
-    );
+    expect(serviceMocks.findAuthorizedInstallationsForRepo).toHaveBeenCalledWith(params);
   });
 
   it.each(['credential_unreadable', 'credential_configuration_error'] as const)(

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -11,7 +11,7 @@ const serviceMocks = vi.hoisted(() => ({
   updateAccountLogin: vi.fn(),
   getToken: vi.fn(),
   getTokenForRepo: vi.fn(),
-  tryGetTokenForRepo: vi.fn(),
+  findRepositoryInstallation: vi.fn(),
   refreshInstallationAccountLoginIfDue: vi.fn(),
   selectUserAuthorization: vi.fn(),
   findGitLabIntegration: vi.fn(),
@@ -38,7 +38,7 @@ vi.mock('./github-token-service.js', () => ({
   GitHubTokenService: class GitHubTokenService {
     getToken = serviceMocks.getToken;
     getTokenForRepo = serviceMocks.getTokenForRepo;
-    tryGetTokenForRepo = serviceMocks.tryGetTokenForRepo;
+    findRepositoryInstallation = serviceMocks.findRepositoryInstallation;
     refreshInstallationAccountLoginIfDue = serviceMocks.refreshInstallationAccountLoginIfDue;
   },
 }));
@@ -125,12 +125,10 @@ beforeEach(() => {
       ],
     };
   });
-  serviceMocks.tryGetTokenForRepo.mockImplementation(
-    async (installationId, githubRepo, appType) => ({
-      status: 'available',
-      token: await serviceMocks.getTokenForRepo(installationId, githubRepo.split('/')[1], appType),
-    })
-  );
+  serviceMocks.findRepositoryInstallation.mockResolvedValue({
+    status: 'installed',
+    installationId: '123',
+  });
   serviceMocks.hasGitLabProjectCredentialCandidates.mockReset().mockResolvedValue(false);
   serviceMocks.resolveGitLabCredential.mockReset().mockImplementation(async (actor, selector) => {
     const latestIntegrationLookup = serviceMocks.findGitLabIntegration.mock.results.at(-1)?.value;
@@ -545,16 +543,10 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     serviceMocks.getTokenForRepo.mockReset();
-    serviceMocks.tryGetTokenForRepo.mockImplementation(
-      async (installationId, githubRepo, appType) => ({
-        status: 'available',
-        token: await serviceMocks.getTokenForRepo(
-          installationId,
-          githubRepo.split('/')[1],
-          appType
-        ),
-      })
-    );
+    serviceMocks.findRepositoryInstallation.mockResolvedValue({
+      status: 'installed',
+      installationId: '123',
+    });
   });
 
   it('mints repository-scoped tokens after resolving an authorized installation', async () => {
@@ -622,7 +614,9 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       accountLogin: 'old-owner',
       githubAppType: 'standard',
     });
-    serviceMocks.tryGetTokenForRepo.mockResolvedValueOnce({ status: 'temporarily_unavailable' });
+    serviceMocks.findRepositoryInstallation.mockResolvedValueOnce({
+      status: 'temporarily_unavailable',
+    });
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'renamed-owner/repository', userId: 'user-1' })
@@ -658,9 +652,10 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
         },
       ],
     });
-    serviceMocks.tryGetTokenForRepo
+    serviceMocks.findRepositoryInstallation
       .mockResolvedValueOnce({ status: 'not_installed' })
-      .mockResolvedValueOnce({ status: 'available', token: 'lite-token' });
+      .mockResolvedValueOnce({ status: 'installed', installationId: '200' });
+    serviceMocks.getTokenForRepo.mockResolvedValueOnce('lite-token');
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
@@ -692,20 +687,55 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
           ...candidate,
           integrationId: '00000000-0000-4000-8000-000000000002',
           installationId: '200',
+          githubAppType: 'lite',
         },
       ],
     });
-    serviceMocks.tryGetTokenForRepo
-      .mockResolvedValueOnce({ status: 'available', token: 'first-token' })
-      .mockResolvedValueOnce({ status: 'available', token: 'second-token' });
+    serviceMocks.findRepositoryInstallation
+      .mockResolvedValueOnce({ status: 'installed', installationId: '100' })
+      .mockResolvedValueOnce({ status: 'installed', installationId: '200' });
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
     ).resolves.toEqual({ success: false, reason: 'ambiguous_installation' });
+    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('matches the authoritative provider installation ID instead of a public same-name repo', async () => {
+    const candidate = {
+      success: true as const,
+      integrationId: '00000000-0000-4000-8000-000000000001',
+      installationId: '100',
+      accountLogin: 'acme',
+      githubAppType: 'standard' as const,
+      repoName: 'repository',
+      permissions: null,
+      repositoryAccess: 'all',
+      repositories: null,
+    };
+    serviceMocks.findAuthorizedInstallationsForRepo.mockResolvedValue({
+      success: true,
+      candidates: [candidate, { ...candidate, installationId: '200' }],
+    });
+    serviceMocks.findRepositoryInstallation.mockResolvedValue({
+      status: 'installed',
+      installationId: '200',
+    });
+    serviceMocks.getTokenForRepo.mockResolvedValue('matched-token');
+
+    await expect(
+      createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
+    ).resolves.toMatchObject({
+      success: true,
+      token: 'matched-token',
+      installationId: '200',
+    });
+    expect(serviceMocks.findRepositoryInstallation).toHaveBeenCalledOnce();
+    expect(serviceMocks.getTokenForRepo).toHaveBeenCalledWith('200', 'repository', 'standard');
   });
 
   it('returns repository_not_installed when every candidate definitively lacks access', async () => {
-    serviceMocks.tryGetTokenForRepo.mockResolvedValue({ status: 'not_installed' });
+    serviceMocks.findRepositoryInstallation.mockResolvedValue({ status: 'not_installed' });
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
@@ -728,9 +758,9 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       success: true,
       candidates: [candidate, { ...candidate, installationId: '200' }],
     });
-    serviceMocks.tryGetTokenForRepo
-      .mockResolvedValueOnce({ status: 'available', token: 'first-token' })
-      .mockResolvedValueOnce({ status: 'temporarily_unavailable' });
+    serviceMocks.findRepositoryInstallation.mockResolvedValueOnce({
+      status: 'temporarily_unavailable',
+    });
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
@@ -767,6 +797,40 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       token: 'scoped-token',
     });
     expect(serviceMocks.findAuthorizedInstallationsForRepo).toHaveBeenCalledWith(params);
+    expect(serviceMocks.findRepositoryInstallation).toHaveBeenCalledOnce();
+  });
+
+  it('rejects an exact integration when GitHub returns a different provider installation ID', async () => {
+    const expectedIntegrationId = '00000000-0000-4000-8000-000000000002';
+    serviceMocks.findAuthorizedInstallationsForRepo.mockResolvedValue({
+      success: true,
+      candidates: [
+        {
+          integrationId: expectedIntegrationId,
+          installationId: '123',
+          accountLogin: 'acme',
+          githubAppType: 'lite',
+          repoName: 'repository',
+          permissions: null,
+          repositoryAccess: 'all',
+          repositories: null,
+        },
+      ],
+    });
+    serviceMocks.findRepositoryInstallation.mockResolvedValue({
+      status: 'installed',
+      installationId: '999',
+    });
+
+    await expect(
+      createService().getTokenForRepo({
+        githubRepo: 'acme/repository',
+        userId: 'user-1',
+        expectedIntegrationId,
+      })
+    ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
+    expect(serviceMocks.findRepositoryInstallation).toHaveBeenCalledWith('acme/repository', 'lite');
+    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
 });
 
@@ -1411,6 +1475,10 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
       githubAppType: 'standard',
       repoName: 'repo',
       permissions: { contents: 'write', pull_requests: 'write' },
+    });
+    serviceMocks.findRepositoryInstallation.mockResolvedValueOnce({
+      status: 'installed',
+      installationId: '456',
     });
 
     await expect(

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -576,7 +576,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     expect(serviceMocks.getToken).not.toHaveBeenCalled();
   });
 
-  it('preserves an ambiguous installation result', async () => {
+  it('maps an ambiguous installation to the legacy no-installation result', async () => {
     serviceMocks.findInstallationId.mockResolvedValue({
       success: false,
       reason: 'ambiguous_installation',
@@ -587,7 +587,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       userId: 'user-1',
     });
 
-    expect(result).toEqual({ success: false, reason: 'ambiguous_installation' });
+    expect(result).toEqual({ success: false, reason: 'no_installation_found' });
     expect(serviceMocks.findRefreshCandidates).not.toHaveBeenCalled();
     expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
@@ -607,7 +607,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
 
-  it('fails closed when scoped minting is indeterminate', async () => {
+  it('preserves the legacy thrown failure when scoped minting is indeterminate', async () => {
     serviceMocks.findInstallationId.mockResolvedValue({
       success: true,
       installationId: '123',
@@ -620,7 +620,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'renamed-owner/repository', userId: 'user-1' })
-    ).resolves.toEqual({ success: false, reason: 'temporarily_unavailable' });
+    ).rejects.toThrow('GitHub repository authorization is temporarily unavailable');
     expect(serviceMocks.getToken).not.toHaveBeenCalled();
   });
 
@@ -697,7 +697,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
-    ).resolves.toEqual({ success: false, reason: 'ambiguous_installation' });
+    ).resolves.toEqual({ success: false, reason: 'no_installation_found' });
     expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
 
@@ -742,7 +742,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     ).resolves.toEqual({ success: false, reason: 'repository_not_installed' });
   });
 
-  it('fails closed when provider uncertainty could hide another live match', async () => {
+  it('keeps provider uncertainty on the legacy thrown retry path', async () => {
     const candidate = {
       success: true as const,
       integrationId: '00000000-0000-4000-8000-000000000001',
@@ -764,7 +764,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
-    ).resolves.toEqual({ success: false, reason: 'temporarily_unavailable' });
+    ).rejects.toThrow('GitHub repository authorization is temporarily unavailable');
   });
 
   it('resolves the exact expected integration', async () => {

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -1302,14 +1302,12 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
   });
 
   it.each([
-    ['POST', 'https://api.github.com/graphql'],
-    ['GET', 'https://api.github.com/user/repos'],
-    ['DELETE', 'https://api.github.com/repos/acme/other/issues/42/comments/1'],
     ['GET', 'https://api.github.com/repos/acme/repo/contents/src%2Findex.ts'],
-    ['POST', 'https://uploads.github.com/repos/acme/other/releases/1/assets?name=asset.zip'],
-    ['GET', 'https://github.com/acme/other.git/info/refs?service=git-upload-pack'],
+    ['DELETE', 'https://api.github.com/repos/acme/repo/issues/comments/1'],
+    ['POST', 'https://uploads.github.com/repos/acme/repo/releases/1/assets?name=asset.zip'],
+    ['GET', 'https://github.com/acme/repo.git/info/refs?service=git-upload-pack'],
   ] as const)(
-    'redeems a selected-user capability for unrestricted GitHub request %s %s',
+    'redeems a selected-user capability for claimed-repository request %s %s',
     async (requestMethod, requestUrl) => {
       const service = createService();
       const issued = await service.issueGitHubSessionCapability({
@@ -1336,6 +1334,51 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
           : 'Bearer user-token',
       });
       expect(serviceMocks.selectUserAuthorization).toHaveBeenCalledOnce();
+    }
+  );
+
+  it.each([
+    ['POST', 'https://api.github.com/graphql', 'repository_mismatch'],
+    ['GET', 'https://api.github.com/user/repos', 'repository_mismatch'],
+    [
+      'DELETE',
+      'https://api.github.com/repos/acme/other/issues/42/comments/1',
+      'repository_mismatch',
+    ],
+    [
+      'POST',
+      'https://uploads.github.com/repos/acme/other/releases/1/assets?name=asset.zip',
+      'repository_mismatch',
+    ],
+    [
+      'GET',
+      'https://github.com/acme/other.git/info/refs?service=git-upload-pack',
+      'repository_mismatch',
+    ],
+    ['CONNECT', 'https://api.github.com/repos/acme/repo', 'invalid_upstream_request'],
+  ] as const)(
+    'rejects a selected-user capability outside its repository REST and smart HTTP scope for %s %s',
+    async (requestMethod, requestUrl, reason) => {
+      const service = createService();
+      const issued = await service.issueGitHubSessionCapability({
+        githubRepo: 'acme/repo',
+        userId: 'user_1',
+        outboundContainerId,
+        allowUserAuthorization: true,
+      });
+      if (!issued.success) throw new Error('Expected successful issuance');
+      expect(issued.source).toBe('user');
+      serviceMocks.selectUserAuthorization.mockClear();
+
+      await expect(
+        service.redeemGitHubSessionCapability({
+          capability: issued.capability,
+          outboundContainerId,
+          requestMethod,
+          requestUrl,
+        })
+      ).resolves.toEqual({ success: false, reason });
+      expect(serviceMocks.selectUserAuthorization).not.toHaveBeenCalled();
     }
   );
 

--- a/services/git-token-service/src/index.test.ts
+++ b/services/git-token-service/src/index.test.ts
@@ -6,10 +6,12 @@ import type * as GitLabLookupServiceModule from './gitlab-lookup-service.js';
 const serviceMocks = vi.hoisted(() => ({
   findInstallationId: vi.fn(),
   findManagedInstallationForRepo: vi.fn(),
+  findAuthorizedInstallationsForRepo: vi.fn(),
   findRefreshCandidates: vi.fn(),
   updateAccountLogin: vi.fn(),
   getToken: vi.fn(),
   getTokenForRepo: vi.fn(),
+  tryGetTokenForRepo: vi.fn(),
   refreshInstallationAccountLoginIfDue: vi.fn(),
   selectUserAuthorization: vi.fn(),
   findGitLabIntegration: vi.fn(),
@@ -36,6 +38,7 @@ vi.mock('./github-token-service.js', () => ({
   GitHubTokenService: class GitHubTokenService {
     getToken = serviceMocks.getToken;
     getTokenForRepo = serviceMocks.getTokenForRepo;
+    tryGetTokenForRepo = serviceMocks.tryGetTokenForRepo;
     refreshInstallationAccountLoginIfDue = serviceMocks.refreshInstallationAccountLoginIfDue;
   },
 }));
@@ -44,6 +47,7 @@ vi.mock('./installation-lookup-service.js', () => ({
   InstallationLookupService: class InstallationLookupService {
     findInstallationId = serviceMocks.findInstallationId;
     findManagedInstallationForRepo = serviceMocks.findManagedInstallationForRepo;
+    findAuthorizedInstallationsForRepo = serviceMocks.findAuthorizedInstallationsForRepo;
     findRefreshCandidates = serviceMocks.findRefreshCandidates;
     updateAccountLogin = serviceMocks.updateAccountLogin;
   },
@@ -100,6 +104,33 @@ vi.mock('./bitbucket-runtime-token-resolver.js', () => ({
 import gitTokenServiceWorker, { GitTokenRPCEntrypoint } from './index.js';
 
 beforeEach(() => {
+  serviceMocks.findAuthorizedInstallationsForRepo.mockImplementation(async params => {
+    const result =
+      (await serviceMocks.findManagedInstallationForRepo(params)) ??
+      (await serviceMocks.findInstallationId(params));
+    if (!result?.success) return result;
+    return {
+      success: true,
+      candidates: [
+        {
+          ...result,
+          integrationId:
+            result.integrationId ??
+            params.expectedIntegrationId ??
+            '00000000-0000-4000-8000-000000000099',
+          repositoryAccess: 'all',
+          repositories: null,
+          repoName: result.repoName ?? params.githubRepo.split('/')[1],
+        },
+      ],
+    };
+  });
+  serviceMocks.tryGetTokenForRepo.mockImplementation(
+    async (installationId, githubRepo, appType) => ({
+      status: 'available',
+      token: await serviceMocks.getTokenForRepo(installationId, githubRepo.split('/')[1], appType),
+    })
+  );
   serviceMocks.hasGitLabProjectCredentialCandidates.mockReset().mockResolvedValue(false);
   serviceMocks.resolveGitLabCredential.mockReset().mockImplementation(async (actor, selector) => {
     const latestIntegrationLookup = serviceMocks.findGitLabIntegration.mock.results.at(-1)?.value;
@@ -513,6 +544,17 @@ afterEach(() => {
 describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    serviceMocks.getTokenForRepo.mockReset();
+    serviceMocks.tryGetTokenForRepo.mockImplementation(
+      async (installationId, githubRepo, appType) => ({
+        status: 'available',
+        token: await serviceMocks.getTokenForRepo(
+          installationId,
+          githubRepo.split('/')[1],
+          appType
+        ),
+      })
+    );
   });
 
   it('mints repository-scoped tokens after resolving an authorized installation', async () => {
@@ -533,6 +575,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     expect(result).toEqual({
       success: true,
       token: 'scoped-token',
+      platformIntegrationId: '00000000-0000-4000-8000-000000000099',
       installationId: '123',
       accountLogin: 'old-owner',
       appType: 'lite',
@@ -541,126 +584,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     expect(serviceMocks.getToken).not.toHaveBeenCalled();
   });
 
-  it('repairs stale login metadata after a lookup miss before minting a token', async () => {
-    serviceMocks.findInstallationId
-      .mockResolvedValueOnce({ success: false, reason: 'no_installation_found' })
-      .mockResolvedValueOnce({
-        success: true,
-        installationId: '123',
-        accountLogin: 'renamed-owner',
-        githubAppType: 'standard',
-      });
-    serviceMocks.findRefreshCandidates.mockResolvedValue({
-      success: true,
-      candidates: [
-        {
-          integrationId: 'integration-1',
-          installationId: '123',
-          accountLogin: 'old-owner',
-          githubAppType: 'standard',
-        },
-      ],
-    });
-    serviceMocks.updateAccountLogin.mockResolvedValue(true);
-    serviceMocks.refreshInstallationAccountLoginIfDue.mockResolvedValue('renamed-owner');
-    serviceMocks.getTokenForRepo.mockResolvedValue('scoped-token');
-    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
-
-    const result = await createService().getTokenForRepo({
-      githubRepo: 'renamed-owner/repository',
-      userId: 'user-1',
-    });
-
-    expect(result).toMatchObject({ success: true, token: 'scoped-token' });
-    expect(serviceMocks.updateAccountLogin).toHaveBeenCalledWith('integration-1', 'renamed-owner');
-    expect(consoleLog).toHaveBeenCalledWith(
-      JSON.stringify({
-        message: 'Repaired GitHub installation account login after token lookup miss',
-        integrationId: 'integration-1',
-        installationId: '123',
-        appType: 'standard',
-      })
-    );
-    expect(JSON.stringify(consoleLog.mock.calls)).not.toContain('old-owner');
-    expect(JSON.stringify(consoleLog.mock.calls)).not.toContain('renamed-owner');
-    expect(serviceMocks.findInstallationId).toHaveBeenCalledTimes(2);
-    expect(serviceMocks.getTokenForRepo).toHaveBeenCalledWith('123', 'repository', 'standard');
-  });
-
-  it('warns instead of reporting success when a repaired integration no longer exists', async () => {
-    serviceMocks.findInstallationId.mockResolvedValue({
-      success: false,
-      reason: 'no_installation_found',
-    });
-    serviceMocks.findRefreshCandidates.mockResolvedValue({
-      success: true,
-      candidates: [
-        {
-          integrationId: 'integration-1',
-          installationId: '123',
-          accountLogin: 'old-owner',
-          githubAppType: 'standard',
-        },
-      ],
-    });
-    serviceMocks.updateAccountLogin.mockResolvedValue(false);
-    serviceMocks.refreshInstallationAccountLoginIfDue.mockResolvedValue('renamed-owner');
-    const consoleLog = vi.spyOn(console, 'log').mockImplementation(() => {});
-    const consoleWarn = vi.spyOn(console, 'warn').mockImplementation(() => {});
-
-    const result = await createService().getTokenForRepo({
-      githubRepo: 'renamed-owner/repository',
-      userId: 'user-1',
-    });
-
-    expect(result).toEqual({ success: false, reason: 'no_installation_found' });
-    expect(consoleLog).not.toHaveBeenCalled();
-    expect(consoleWarn).toHaveBeenCalledWith(
-      JSON.stringify({
-        message: 'GitHub installation login repair found no integration row to update',
-        integrationId: 'integration-1',
-        installationId: '123',
-        appType: 'standard',
-      })
-    );
-    expect(JSON.stringify(consoleWarn.mock.calls)).not.toContain('old-owner');
-    expect(JSON.stringify(consoleWarn.mock.calls)).not.toContain('renamed-owner');
-  });
-
-  it('does not mint when refreshed metadata identifies a different repository owner', async () => {
-    serviceMocks.findInstallationId.mockResolvedValue({
-      success: false,
-      reason: 'no_installation_found',
-    });
-    serviceMocks.findRefreshCandidates.mockResolvedValue({
-      success: true,
-      candidates: [
-        {
-          integrationId: 'integration-1',
-          installationId: '123',
-          accountLogin: 'old-owner',
-          githubAppType: 'standard',
-        },
-      ],
-    });
-    serviceMocks.updateAccountLogin.mockResolvedValue(true);
-    serviceMocks.refreshInstallationAccountLoginIfDue.mockResolvedValue('different-owner');
-    vi.spyOn(console, 'log').mockImplementation(() => {});
-
-    const result = await createService().getTokenForRepo({
-      githubRepo: 'requested-owner/repository',
-      userId: 'user-1',
-    });
-
-    expect(result).toEqual({ success: false, reason: 'no_installation_found' });
-    expect(serviceMocks.updateAccountLogin).toHaveBeenCalledWith(
-      'integration-1',
-      'different-owner'
-    );
-    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
-  });
-
-  it('fails closed without metadata repair when exact owner selection is ambiguous', async () => {
+  it('preserves an ambiguous installation result', async () => {
     serviceMocks.findInstallationId.mockResolvedValue({
       success: false,
       reason: 'ambiguous_installation',
@@ -671,7 +595,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       userId: 'user-1',
     });
 
-    expect(result).toEqual({ success: false, reason: 'no_installation_found' });
+    expect(result).toEqual({ success: false, reason: 'ambiguous_installation' });
     expect(serviceMocks.findRefreshCandidates).not.toHaveBeenCalled();
     expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
@@ -691,49 +615,150 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
     expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
 
-  it('does not fall back to an installation-wide token when scoped minting fails', async () => {
+  it('fails closed when scoped minting is indeterminate', async () => {
     serviceMocks.findInstallationId.mockResolvedValue({
       success: true,
       installationId: '123',
       accountLogin: 'old-owner',
       githubAppType: 'standard',
     });
-    serviceMocks.getTokenForRepo.mockRejectedValueOnce(new Error('repository not accessible'));
+    serviceMocks.tryGetTokenForRepo.mockResolvedValueOnce({ status: 'temporarily_unavailable' });
 
     await expect(
       createService().getTokenForRepo({ githubRepo: 'renamed-owner/repository', userId: 'user-1' })
-    ).rejects.toThrow('repository not accessible');
+    ).resolves.toEqual({ success: false, reason: 'temporarily_unavailable' });
     expect(serviceMocks.getToken).not.toHaveBeenCalled();
   });
 
-  it('repairs stale login metadata within the expected integration fence', async () => {
+  it('selects the only installation with live repository access', async () => {
+    serviceMocks.findAuthorizedInstallationsForRepo.mockResolvedValue({
+      success: true,
+      candidates: [
+        {
+          success: true,
+          integrationId: '00000000-0000-4000-8000-000000000001',
+          installationId: '100',
+          accountLogin: 'acme',
+          githubAppType: 'standard',
+          repoName: 'repository',
+          permissions: null,
+          repositoryAccess: 'selected',
+          repositories: [{ full_name: 'acme/repository' }],
+        },
+        {
+          success: true,
+          integrationId: '00000000-0000-4000-8000-000000000002',
+          installationId: '200',
+          accountLogin: 'acme',
+          githubAppType: 'lite',
+          repoName: 'repository',
+          permissions: null,
+          repositoryAccess: 'all',
+          repositories: null,
+        },
+      ],
+    });
+    serviceMocks.tryGetTokenForRepo
+      .mockResolvedValueOnce({ status: 'not_installed' })
+      .mockResolvedValueOnce({ status: 'available', token: 'lite-token' });
+
+    await expect(
+      createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
+    ).resolves.toMatchObject({
+      success: true,
+      token: 'lite-token',
+      platformIntegrationId: '00000000-0000-4000-8000-000000000002',
+      appType: 'lite',
+    });
+  });
+
+  it('returns ambiguity when two installations have live repository access', async () => {
+    const candidate = {
+      success: true as const,
+      integrationId: '00000000-0000-4000-8000-000000000001',
+      installationId: '100',
+      accountLogin: 'acme',
+      githubAppType: 'standard' as const,
+      repoName: 'repository',
+      permissions: null,
+      repositoryAccess: 'all',
+      repositories: null,
+    };
+    serviceMocks.findAuthorizedInstallationsForRepo.mockResolvedValue({
+      success: true,
+      candidates: [
+        candidate,
+        {
+          ...candidate,
+          integrationId: '00000000-0000-4000-8000-000000000002',
+          installationId: '200',
+        },
+      ],
+    });
+    serviceMocks.tryGetTokenForRepo
+      .mockResolvedValueOnce({ status: 'available', token: 'first-token' })
+      .mockResolvedValueOnce({ status: 'available', token: 'second-token' });
+
+    await expect(
+      createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
+    ).resolves.toEqual({ success: false, reason: 'ambiguous_installation' });
+  });
+
+  it('returns repository_not_installed when every candidate definitively lacks access', async () => {
+    serviceMocks.tryGetTokenForRepo.mockResolvedValue({ status: 'not_installed' });
+
+    await expect(
+      createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
+    ).resolves.toEqual({ success: false, reason: 'repository_not_installed' });
+  });
+
+  it('fails closed when provider uncertainty could hide another live match', async () => {
+    const candidate = {
+      success: true as const,
+      integrationId: '00000000-0000-4000-8000-000000000001',
+      installationId: '100',
+      accountLogin: 'acme',
+      githubAppType: 'standard' as const,
+      repoName: 'repository',
+      permissions: null,
+      repositoryAccess: 'all',
+      repositories: null,
+    };
+    serviceMocks.findAuthorizedInstallationsForRepo.mockResolvedValue({
+      success: true,
+      candidates: [candidate, { ...candidate, installationId: '200' }],
+    });
+    serviceMocks.tryGetTokenForRepo
+      .mockResolvedValueOnce({ status: 'available', token: 'first-token' })
+      .mockResolvedValueOnce({ status: 'temporarily_unavailable' });
+
+    await expect(
+      createService().getTokenForRepo({ githubRepo: 'acme/repository', userId: 'user-1' })
+    ).resolves.toEqual({ success: false, reason: 'temporarily_unavailable' });
+  });
+
+  it('resolves the exact expected integration', async () => {
     const params = {
       githubRepo: 'acme/repository',
       userId: 'user-1',
       orgId: '00000000-0000-4000-8000-000000000001',
       expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
     };
-    serviceMocks.findInstallationId
-      .mockResolvedValueOnce({ success: false, reason: 'integration_mismatch' })
-      .mockResolvedValueOnce({
-        success: true,
-        installationId: '123',
-        accountLogin: 'acme',
-        githubAppType: 'standard',
-      });
-    serviceMocks.findRefreshCandidates.mockResolvedValue({
+    serviceMocks.findAuthorizedInstallationsForRepo.mockResolvedValue({
       success: true,
       candidates: [
         {
           integrationId: params.expectedIntegrationId,
           installationId: '123',
-          accountLogin: 'old-acme',
+          accountLogin: 'acme',
           githubAppType: 'standard',
+          repoName: 'repository',
+          permissions: null,
+          repositoryAccess: 'all',
+          repositories: null,
         },
       ],
     });
-    serviceMocks.refreshInstallationAccountLoginIfDue.mockResolvedValue('acme');
-    serviceMocks.updateAccountLogin.mockResolvedValue(true);
     serviceMocks.getTokenForRepo.mockResolvedValue('scoped-token');
     vi.spyOn(console, 'log').mockImplementation(() => {});
 
@@ -741,12 +766,7 @@ describe('GitTokenRPCEntrypoint.getTokenForRepo', () => {
       success: true,
       token: 'scoped-token',
     });
-    expect(serviceMocks.findInstallationId).toHaveBeenCalledTimes(2);
-    expect(serviceMocks.findRefreshCandidates).toHaveBeenCalledWith(params);
-    expect(serviceMocks.updateAccountLogin).toHaveBeenCalledWith(
-      params.expectedIntegrationId,
-      'acme'
-    );
+    expect(serviceMocks.findAuthorizedInstallationsForRepo).toHaveBeenCalledWith(params);
   });
 });
 
@@ -845,6 +865,33 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     });
   });
 
+  it('pins an authoritatively resolved integration through capability redemption', async () => {
+    const resolvedIntegrationId = '00000000-0000-4000-8000-000000000099';
+    const service = createService();
+    const issued = await service.issueGitHubSessionCapability({
+      githubRepo: 'acme/repo',
+      userId: 'user_1',
+      outboundContainerId,
+    });
+    if (!issued.success) throw new Error('Expected successful issuance');
+    expect(issued.platformIntegrationId).toBe(resolvedIntegrationId);
+    serviceMocks.findAuthorizedInstallationsForRepo.mockClear();
+
+    await expect(
+      service.redeemGitHubSessionCapability({
+        capability: issued.capability,
+        outboundContainerId,
+        requestMethod: 'GET',
+        requestUrl: 'https://github.com/acme/repo.git/info/refs?service=git-upload-pack',
+      })
+    ).resolves.toMatchObject({ success: true });
+    expect(serviceMocks.findAuthorizedInstallationsForRepo).toHaveBeenCalledWith({
+      userId: 'user_1',
+      expectedIntegrationId: resolvedIntegrationId,
+      githubRepo: 'acme/repo',
+    });
+  });
+
   it('returns integration_mismatch when repair cannot restore a capability fence', async () => {
     const service = createService();
     const issued = await service.issueGitHubSessionCapability({
@@ -857,12 +904,11 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
     });
     if (!issued.success) throw new Error('Expected successful issuance');
     serviceMocks.getTokenForRepo.mockClear();
-    serviceMocks.findManagedInstallationForRepo.mockClear();
-    serviceMocks.findManagedInstallationForRepo.mockResolvedValue({
+    serviceMocks.findAuthorizedInstallationsForRepo.mockClear();
+    serviceMocks.findAuthorizedInstallationsForRepo.mockResolvedValue({
       success: false,
       reason: 'integration_mismatch',
     });
-    serviceMocks.findRefreshCandidates.mockResolvedValue({ success: true, candidates: [] });
 
     await expect(
       service.redeemGitHubSessionCapability({
@@ -872,13 +918,7 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
         requestUrl: 'https://github.com/acme/repo.git/info/refs?service=git-upload-pack',
       })
     ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
-    expect(serviceMocks.findManagedInstallationForRepo).toHaveBeenCalledTimes(2);
-    expect(serviceMocks.findRefreshCandidates).toHaveBeenCalledWith({
-      userId: 'user_1',
-      orgId: '00000000-0000-4000-8000-000000000001',
-      expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
-      githubRepo: 'acme/repo',
-    });
+    expect(serviceMocks.findAuthorizedInstallationsForRepo).toHaveBeenCalledOnce();
     expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
   });
 
@@ -1328,7 +1368,7 @@ describe('GitTokenRPCEntrypoint GitHub session capability RPCs', () => {
         requestUrl: 'https://api.github.com/repos/acme/repo/pulls/42',
       })
     ).resolves.toEqual({ success: false, reason: 'source_unavailable' });
-    expect(serviceMocks.getTokenForRepo).not.toHaveBeenCalled();
+    expect(serviceMocks.getTokenForRepo).toHaveBeenCalledOnce();
   });
 
   it('rejects a user capability if selected attribution identity changes before redemption', async () => {

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -721,29 +721,54 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
       await this.installationLookupService.findAuthorizedInstallationsForRepo(params);
     if (!installations.success) return installations;
 
-    let selected: ((typeof installations.candidates)[number] & { token: string }) | undefined;
+    let selected: (typeof installations.candidates)[number] | undefined;
     let providerUncertain = false;
-    for (const candidate of installations.candidates) {
-      const tokenResult = await this.githubService.tryGetTokenForRepo(
-        candidate.installationId,
+    const appTypes = [
+      ...new Set(installations.candidates.map(candidate => candidate.githubAppType)),
+    ];
+    for (const appType of appTypes) {
+      const installationResult = await this.githubService.findRepositoryInstallation(
         params.githubRepo,
-        candidate.githubAppType
+        appType
       );
-      if (tokenResult.status === 'temporarily_unavailable') {
+      if (installationResult.status === 'temporarily_unavailable') {
         providerUncertain = true;
         continue;
       }
-      if (tokenResult.status === 'not_installed') continue;
-      if (selected) return { success: false as const, reason: 'ambiguous_installation' as const };
-      selected = { ...candidate, token: tokenResult.token };
+      if (installationResult.status === 'not_installed') continue;
+
+      const matches = installations.candidates.filter(
+        candidate =>
+          candidate.githubAppType === appType &&
+          candidate.installationId === installationResult.installationId
+      );
+      if (matches.length > 1 || (matches.length === 1 && selected)) {
+        return { success: false as const, reason: 'ambiguous_installation' as const };
+      }
+      if (matches[0]) selected = matches[0];
     }
     if (providerUncertain) {
       return { success: false as const, reason: 'temporarily_unavailable' as const };
     }
     if (!selected) {
-      return { success: false as const, reason: 'repository_not_installed' as const };
+      return {
+        success: false as const,
+        reason:
+          params.expectedIntegrationId === undefined
+            ? ('repository_not_installed' as const)
+            : ('integration_mismatch' as const),
+      };
     }
-    return { success: true as const, installation: selected };
+    try {
+      const token = await this.githubService.getTokenForRepo(
+        selected.installationId,
+        selected.repoName,
+        selected.githubAppType
+      );
+      return { success: true as const, installation: { ...selected, token } };
+    } catch {
+      return { success: false as const, reason: 'temporarily_unavailable' as const };
+    }
   }
 
   /**

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -784,7 +784,14 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
    */
   async getTokenForRepo(params: GetTokenForRepoParams): Promise<GetTokenForRepoResult> {
     const resolved = await this.resolveAuthoritativeInstallation(params);
-    if (!resolved.success) return resolved;
+    if (!resolved.success) {
+      if (resolved.reason === 'temporarily_unavailable') {
+        throw new Error('GitHub repository authorization is temporarily unavailable');
+      }
+      return resolved.reason === 'ambiguous_installation'
+        ? { success: false, reason: 'no_installation_found' }
+        : resolved;
+    }
     const { installation } = resolved;
 
     return {
@@ -801,7 +808,14 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     params: GetCloudAgentAuthForRepoParams
   ): Promise<GetCloudAgentAuthForRepoResult> {
     const resolved = await this.resolveAuthoritativeInstallation(params);
-    if (!resolved.success) return resolved;
+    if (!resolved.success) {
+      if (resolved.reason === 'temporarily_unavailable') {
+        throw new Error('GitHub repository authorization is temporarily unavailable');
+      }
+      return resolved.reason === 'ambiguous_installation'
+        ? { success: false, reason: 'no_installation_found' }
+        : resolved;
+    }
     const { installation } = resolved;
 
     const installationAuthor = this.getInstallationAuthor(installation.githubAppType);

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -43,10 +43,7 @@ import {
   handleGitLabCredentialBrokerRequest,
 } from './gitlab-credential-broker-handler.js';
 import type { GitLabCredentialBroker } from './gitlab-credential-broker.js';
-import {
-  InstallationLookupService,
-  type InstallationLookupFailure,
-} from './installation-lookup-service.js';
+import { InstallationLookupService } from './installation-lookup-service.js';
 import {
   GitHubSessionCapabilityCodec,
   GitHubSessionCapabilityError,
@@ -101,6 +98,7 @@ export type GetTokenForRepoParams = {
 export type GetTokenForRepoSuccess = {
   success: true;
   token: string;
+  platformIntegrationId: string;
   installationId: string;
   accountLogin: string;
   appType: GitHubAppType;
@@ -113,6 +111,8 @@ export type GetTokenForRepoFailure = {
     | 'invalid_repo_format'
     | 'no_installation_found'
     | 'repository_not_installed'
+    | 'ambiguous_installation'
+    | 'temporarily_unavailable'
     | 'invalid_org_id'
     | 'integration_mismatch';
 };
@@ -139,6 +139,7 @@ export type GetCloudAgentAuthForRepoParams = GetTokenForRepoParams & {
 export type GetCloudAgentAuthForRepoSuccess = {
   success: true;
   githubToken: string;
+  platformIntegrationId: string;
   installationId: string;
   accountLogin: string;
   appType: GitHubAppType;
@@ -715,83 +716,34 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     this.githubUserAuthorizationService = new GitHubUserAuthorizationService(env);
   }
 
-  private async refreshGitHubInstallationLogins(params: GetTokenForRepoParams): Promise<void> {
-    const candidates = await this.installationLookupService.findRefreshCandidates(params);
-    if (!candidates.success) {
-      return;
-    }
+  private async resolveAuthoritativeInstallation(params: GetTokenForRepoParams) {
+    const installations =
+      await this.installationLookupService.findAuthorizedInstallationsForRepo(params);
+    if (!installations.success) return installations;
 
-    for (const candidate of candidates.candidates) {
-      const refreshedAccountLogin = await this.githubService.refreshInstallationAccountLoginIfDue(
+    let selected: ((typeof installations.candidates)[number] & { token: string }) | undefined;
+    let providerUncertain = false;
+    for (const candidate of installations.candidates) {
+      const tokenResult = await this.githubService.tryGetTokenForRepo(
         candidate.installationId,
+        params.githubRepo,
         candidate.githubAppType
       );
-      if (
-        !refreshedAccountLogin ||
-        refreshedAccountLogin.toLowerCase() === candidate.accountLogin?.toLowerCase()
-      ) {
+      if (tokenResult.status === 'temporarily_unavailable') {
+        providerUncertain = true;
         continue;
       }
-
-      const wasUpdated = await this.installationLookupService.updateAccountLogin(
-        candidate.integrationId,
-        refreshedAccountLogin
-      );
-      if (!wasUpdated) {
-        console.warn(
-          JSON.stringify({
-            message: 'GitHub installation login repair found no integration row to update',
-            integrationId: candidate.integrationId,
-            installationId: candidate.installationId,
-            appType: candidate.githubAppType,
-          })
-        );
-        continue;
-      }
-
-      console.log(
-        JSON.stringify({
-          message: 'Repaired GitHub installation account login after token lookup miss',
-          integrationId: candidate.integrationId,
-          installationId: candidate.installationId,
-          appType: candidate.githubAppType,
-        })
-      );
+      if (tokenResult.status === 'not_installed') continue;
+      if (selected) return { success: false as const, reason: 'ambiguous_installation' as const };
+      selected = { ...candidate, token: tokenResult.token };
     }
-  }
-
-  private shouldRepairGitHubInstallationLogin(
-    params: GetTokenForRepoParams,
-    reason: InstallationLookupFailure['reason'] | 'repository_not_installed'
-  ): boolean {
-    return (
-      reason === 'no_installation_found' ||
-      (params.expectedIntegrationId !== undefined && reason === 'integration_mismatch')
-    );
-  }
-
-  private async findInstallationIdWithLoginRepair(params: GetTokenForRepoParams) {
-    let installation = await this.installationLookupService.findInstallationId(params);
-    if (
-      !installation.success &&
-      this.shouldRepairGitHubInstallationLogin(params, installation.reason)
-    ) {
-      await this.refreshGitHubInstallationLogins(params);
-      installation = await this.installationLookupService.findInstallationId(params);
+    if (providerUncertain) {
+      return { success: false as const, reason: 'temporarily_unavailable' as const };
     }
-    return installation;
-  }
-
-  private async findManagedInstallationWithLoginRepair(params: GetTokenForRepoParams) {
-    let installation = await this.installationLookupService.findManagedInstallationForRepo(params);
-    if (
-      !installation.success &&
-      this.shouldRepairGitHubInstallationLogin(params, installation.reason)
-    ) {
-      await this.refreshGitHubInstallationLogins(params);
-      installation = await this.installationLookupService.findManagedInstallationForRepo(params);
+    if (!selected) {
+      return { success: false as const, reason: 'repository_not_installed' as const };
     }
-    return installation;
+    return { success: true as const, installation: selected };
   }
 
   /**
@@ -806,34 +758,14 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
    * @returns Token and installation details, or a failure reason
    */
   async getTokenForRepo(params: GetTokenForRepoParams): Promise<GetTokenForRepoResult> {
-    const installation = await this.findInstallationIdWithLoginRepair(params);
-    if (!installation.success) {
-      switch (installation.reason) {
-        case 'ambiguous_installation':
-          return { success: false, reason: 'no_installation_found' };
-        case 'database_not_configured':
-        case 'invalid_repo_format':
-        case 'no_installation_found':
-        case 'invalid_org_id':
-        case 'integration_mismatch':
-          return { success: false, reason: installation.reason };
-      }
-    }
-
-    const [, repoName] = params.githubRepo.split('/');
-    if (!repoName) {
-      return { success: false, reason: 'invalid_repo_format' };
-    }
-
-    const token = await this.githubService.getTokenForRepo(
-      installation.installationId,
-      repoName,
-      installation.githubAppType
-    );
+    const resolved = await this.resolveAuthoritativeInstallation(params);
+    if (!resolved.success) return resolved;
+    const { installation } = resolved;
 
     return {
       success: true,
-      token,
+      token: installation.token,
+      platformIntegrationId: installation.integrationId,
       installationId: installation.installationId,
       accountLogin: installation.accountLogin,
       appType: installation.githubAppType,
@@ -843,31 +775,17 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
   async getCloudAgentAuthForRepo(
     params: GetCloudAgentAuthForRepoParams
   ): Promise<GetCloudAgentAuthForRepoResult> {
-    const installation = await this.findManagedInstallationWithLoginRepair(params);
-    if (!installation.success) {
-      switch (installation.reason) {
-        case 'ambiguous_installation':
-          return { success: false, reason: 'no_installation_found' };
-        case 'database_not_configured':
-        case 'invalid_repo_format':
-        case 'no_installation_found':
-        case 'repository_not_installed':
-        case 'invalid_org_id':
-        case 'integration_mismatch':
-          return { success: false, reason: installation.reason };
-      }
-    }
+    const resolved = await this.resolveAuthoritativeInstallation(params);
+    if (!resolved.success) return resolved;
+    const { installation } = resolved;
 
     const installationAuthor = this.getInstallationAuthor(installation.githubAppType);
     const installationAuth = async (
       fallbackReason?: ManagedGitHubFallbackReason
     ): Promise<GetCloudAgentAuthForRepoSuccess> => ({
       success: true,
-      githubToken: await this.githubService.getTokenForRepo(
-        installation.installationId,
-        installation.repoName,
-        installation.githubAppType
-      ),
+      githubToken: installation.token,
+      platformIntegrationId: installation.integrationId,
       installationId: installation.installationId,
       accountLogin: installation.accountLogin,
       appType: installation.githubAppType,
@@ -891,6 +809,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     return {
       success: true,
       githubToken: selection.token,
+      platformIntegrationId: installation.integrationId,
       installationId: installation.installationId,
       accountLogin: installation.accountLogin,
       appType: installation.githubAppType,
@@ -921,9 +840,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
           ? { outboundContainerId: params.outboundContainerId }
           : {}),
         ...(params.orgId !== undefined ? { orgId: params.orgId } : {}),
-        ...(params.expectedIntegrationId !== undefined
-          ? { integrationId: params.expectedIntegrationId }
-          : {}),
+        integrationId: auth.platformIntegrationId,
         ...repository,
         source: auth.source,
         identity: this.getSessionIdentity(auth),
@@ -934,6 +851,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     return {
       success: true,
       capability,
+      platformIntegrationId: auth.platformIntegrationId,
       installationId: auth.installationId,
       accountLogin: auth.accountLogin,
       appType: auth.appType,
@@ -1027,11 +945,13 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
   private async redeemPinnedUserAuthorization(
     params: GetTokenForRepoParams
   ): Promise<GetCloudAgentAuthForRepoResult | null> {
-    const installation = await this.findManagedInstallationWithLoginRepair(params);
-    if (!installation.success && installation.reason === 'integration_mismatch') {
+    const resolved = await this.resolveAuthoritativeInstallation(params);
+    if (!resolved.success && resolved.reason === 'integration_mismatch') {
       return { success: false, reason: 'integration_mismatch' };
     }
-    if (!installation.success || installation.githubAppType === 'lite') return null;
+    if (!resolved.success) return null;
+    const { installation } = resolved;
+    if (installation.githubAppType === 'lite') return null;
     if (
       installation.permissions?.contents !== 'write' ||
       installation.permissions?.pull_requests !== 'write'
@@ -1043,6 +963,7 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     return {
       success: true,
       githubToken: selection.token,
+      platformIntegrationId: installation.integrationId,
       installationId: installation.installationId,
       accountLogin: installation.accountLogin,
       appType: installation.githubAppType,

--- a/services/git-token-service/src/index.ts
+++ b/services/git-token-service/src/index.ts
@@ -417,6 +417,48 @@ function validateGitHubCapabilityUpstream(
   return null;
 }
 
+function validateUserGitHubCapabilityUpstream(
+  requestMethod: string,
+  requestUrl: string,
+  repository: { owner: string; repo: string }
+): RedeemGitHubSessionCapabilityFailureReason | null {
+  let url: URL;
+  try {
+    url = new URL(requestUrl);
+  } catch {
+    return 'invalid_upstream_url';
+  }
+  if (url.protocol !== 'https:' || url.username || url.password || url.hash) {
+    return 'invalid_upstream_url';
+  }
+  if (url.port !== '') return 'upstream_host_not_allowed';
+
+  if (url.hostname === 'github.com') {
+    return validateLegacyGitHubCapabilityUpstream(requestMethod, requestUrl, repository);
+  }
+  if (url.hostname !== 'api.github.com' && url.hostname !== 'uploads.github.com') {
+    return 'upstream_host_not_allowed';
+  }
+
+  const method = requestMethod.toUpperCase();
+  if (!['GET', 'HEAD', 'POST', 'PUT', 'PATCH', 'DELETE'].includes(method)) {
+    return 'invalid_upstream_request';
+  }
+  const decodedPathname = decodePathnameIteratively(url.pathname);
+  if (
+    decodedPathname === null ||
+    decodedPathname.includes('\\') ||
+    /(?:^|\/)\.{1,2}(?:\/|$)/.test(decodedPathname)
+  ) {
+    return 'invalid_upstream_url';
+  }
+  const repositoryApiPath = `/repos/${repository.owner}/${repository.repo}`.toLowerCase();
+  const path = url.pathname.toLowerCase();
+  return path === repositoryApiPath || path.startsWith(`${repositoryApiPath}/`)
+    ? null
+    : 'repository_mismatch';
+}
+
 function validateLegacyGitHubCapabilityUpstream(
   requestMethod: string,
   requestUrl: string,
@@ -920,9 +962,11 @@ export class GitTokenRPCEntrypoint extends WorkerEntrypoint<CloudflareEnv> {
     }
 
     const upstreamFailure =
-      claims.version === 2
-        ? validateGitHubCapabilityUpstream(params.requestUrl)
-        : validateLegacyGitHubCapabilityUpstream(params.requestMethod, params.requestUrl, claims);
+      claims.version === 2 && claims.source === 'user'
+        ? validateUserGitHubCapabilityUpstream(params.requestMethod, params.requestUrl, claims)
+        : claims.version === 2
+          ? validateGitHubCapabilityUpstream(params.requestUrl)
+          : validateLegacyGitHubCapabilityUpstream(params.requestMethod, params.requestUrl, claims);
     if (upstreamFailure) return { success: false, reason: upstreamFailure };
 
     const authParams = {

--- a/services/git-token-service/src/installation-lookup-service.behavior.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.behavior.test.ts
@@ -138,7 +138,7 @@ describe('InstallationLookupService', () => {
     expect(db.updateQuery.where).toHaveBeenCalled();
   });
 
-  it('prioritizes a selected-repository cache match without dropping other candidates', async () => {
+  it('returns authorized rows without treating cached repository metadata as proof', async () => {
     const service = createService([
       {
         platform_installation_id: '100',
@@ -163,8 +163,8 @@ describe('InstallationLookupService', () => {
     });
 
     expect(result.success && result.candidates.map(candidate => candidate.installationId)).toEqual([
-      '200',
       '100',
+      '200',
     ]);
   });
 

--- a/services/git-token-service/src/installation-lookup-service.behavior.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.behavior.test.ts
@@ -43,7 +43,19 @@ function createDb(rows: InstallationRow[], updatedRows = [{ id: 'integration-1' 
 }
 
 function createService(rows: InstallationRow[]) {
-  vi.mocked(getWorkerDb).mockReturnValue(createDb(rows) as never);
+  vi.mocked(getWorkerDb).mockReturnValue(
+    createDb(
+      rows.map((row, index) => ({
+        id: `00000000-0000-4000-8000-${String(index + 1).padStart(12, '0')}`,
+        integration_status: 'active',
+        owned_by_user_id: 'user-1',
+        repository_access: null,
+        repositories: null,
+        permissions: null,
+        ...row,
+      }))
+    ) as never
+  );
   return new InstallationLookupService({
     HYPERDRIVE: { connectionString: 'postgres://test' },
   } as CloudflareEnv);
@@ -126,6 +138,63 @@ describe('InstallationLookupService', () => {
     expect(db.updateQuery.where).toHaveBeenCalled();
   });
 
+  it('prioritizes a selected-repository cache match without dropping other candidates', async () => {
+    const service = createService([
+      {
+        platform_installation_id: '100',
+        platform_account_login: 'acme',
+        github_app_type: 'standard',
+        owned_by_organization_id: null,
+        repository_access: 'all',
+      },
+      {
+        platform_installation_id: '200',
+        platform_account_login: 'stale-owner',
+        github_app_type: 'lite',
+        owned_by_organization_id: null,
+        repository_access: 'selected',
+        repositories: [{ full_name: 'acme/repository' }],
+      },
+    ]);
+
+    const result = await service.findAuthorizedInstallationsForRepo({
+      githubRepo: 'acme/repository',
+      userId: 'user-1',
+    });
+
+    expect(result.success && result.candidates.map(candidate => candidate.installationId)).toEqual([
+      '200',
+      '100',
+    ]);
+  });
+
+  it('keeps stale selected caches and all-repository caches as live-validation candidates', async () => {
+    const service = createService([
+      {
+        platform_installation_id: '100',
+        platform_account_login: 'stale-owner',
+        github_app_type: 'standard',
+        owned_by_organization_id: null,
+        repository_access: 'selected',
+        repositories: [{ full_name: 'acme/other' }],
+      },
+      {
+        platform_installation_id: '200',
+        platform_account_login: 'acme',
+        github_app_type: 'lite',
+        owned_by_organization_id: null,
+        repository_access: 'all',
+      },
+    ]);
+
+    const result = await service.findAuthorizedInstallationsForRepo({
+      githubRepo: 'acme/repository',
+      userId: 'user-1',
+    });
+
+    expect(result.success && result.candidates).toHaveLength(2);
+  });
+
   it('reports when refreshed account login metadata no longer has a target row', async () => {
     const db = createDb([], []);
     vi.mocked(getWorkerDb).mockReturnValue(db as never);
@@ -156,6 +225,7 @@ describe('InstallationLookupService', () => {
 
     expect(result).toEqual({
       success: true,
+      integrationId: '00000000-0000-4000-8000-000000000001',
       installationId: '100',
       accountLogin: 'renamed-owner',
       githubAppType: 'standard',
@@ -260,6 +330,7 @@ describe('InstallationLookupService', () => {
       })
     ).resolves.toEqual({
       success: true,
+      integrationId,
       installationId: '100',
       accountLogin: 'renamed-owner',
       githubAppType: 'standard',
@@ -273,10 +344,6 @@ describe('InstallationLookupService', () => {
     ['personal row', { owned_by_organization_id: null, owned_by_user_id: 'user-1' }],
     ['suspended row', { integration_status: 'suspended' }],
     ['repository owner mismatch', { platform_account_login: 'other-owner' }],
-    [
-      'selected repository mismatch',
-      { repositories: [{ full_name: 'renamed-owner/other-repository' }] },
-    ],
   ])('rejects an expected integration with %s', async (_reason, override) => {
     const integrationId = '00000000-0000-4000-8000-000000000002';
     const orgId = '00000000-0000-4000-8000-000000000001';
@@ -306,7 +373,7 @@ describe('InstallationLookupService', () => {
     ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
   });
 
-  it('does not accept an expected integration without an organization', async () => {
+  it('returns integration_mismatch when an expected personal integration is unavailable', async () => {
     const service = createService([]);
 
     await expect(
@@ -316,7 +383,7 @@ describe('InstallationLookupService', () => {
         expectedIntegrationId: '00000000-0000-4000-8000-000000000002',
       })
     ).resolves.toEqual({ success: false, reason: 'integration_mismatch' });
-    expect(getWorkerDb).not.toHaveBeenCalled();
+    expect(getWorkerDb).toHaveBeenCalledOnce();
   });
 
   it('returns integration_mismatch when the expected row is not visible to the fenced query', async () => {

--- a/services/git-token-service/src/installation-lookup-service.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.test.ts
@@ -29,6 +29,7 @@ describe('buildInstallationLookupQuery', () => {
     const query = buildQuery();
 
     expect(query.sql).toContain('"platform_integrations"."platform_installation_id" is not null');
+    expect(query.sql).toContain('"platform_integrations"."auth_invalid_at" is null');
     expect(query.sql).toContain('"kilocode_users"."blocked_reason" is null');
     expect(query.sql).toContain('"organization_memberships"."kilo_user_id" =');
     expect(query.sql).toContain('"organization_memberships"."id" is not null');
@@ -36,7 +37,7 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" =');
     expect(query.params.filter(param => param === 'user-1')).toHaveLength(4);
     expect(query.params).toContain('00000000-0000-4000-8000-000000000001');
-    expect(query.params).toContain(2);
+    expect(query.sql).not.toContain(' limit ');
   });
 
   it('requires current membership for every organization-scoped credential candidate', () => {
@@ -74,6 +75,6 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.params).toContain(expectedIntegrationId);
     expect(query.params).toContain(params.orgId);
     expect(query.params).toContain('renamed-owner');
-    expect(query.params).toContain(1);
+    expect(query.sql).not.toContain(' limit ');
   });
 });

--- a/services/git-token-service/src/installation-lookup-service.test.ts
+++ b/services/git-token-service/src/installation-lookup-service.test.ts
@@ -34,8 +34,9 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.sql).toContain('"organization_memberships"."kilo_user_id" =');
     expect(query.sql).toContain('"organization_memberships"."id" is not null');
     expect(query.sql).toContain('"platform_integrations"."owned_by_organization_id" =');
-    expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" =');
-    expect(query.params.filter(param => param === 'user-1')).toHaveLength(4);
+    expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" is null');
+    expect(query.sql).not.toContain('"platform_integrations"."owned_by_user_id" =');
+    expect(query.params.filter(param => param === 'user-1')).toHaveLength(3);
     expect(query.params).toContain('00000000-0000-4000-8000-000000000001');
     expect(query.sql).not.toContain(' limit ');
   });
@@ -45,7 +46,7 @@ describe('buildInstallationLookupQuery', () => {
 
     expect(query.sql).toContain('exists (select');
     expect(query.params.filter(param => param === params.orgId)).toHaveLength(2);
-    expect(query.params.filter(param => param === params.userId)).toHaveLength(4);
+    expect(query.params.filter(param => param === params.userId)).toHaveLength(3);
   });
 
   it('loads up to ten authorized repair candidates without relying on stale account login metadata', () => {
@@ -76,5 +77,27 @@ describe('buildInstallationLookupQuery', () => {
     expect(query.params).toContain(params.orgId);
     expect(query.params).toContain('renamed-owner');
     expect(query.sql).not.toContain(' limit ');
+  });
+
+  it('selects only organization-owned rows for unpinned organization sessions', () => {
+    const query = buildInstallationRefreshCandidatesQuery(
+      getWorkerDb('postgres://unused:unused@localhost:0/unused'),
+      params
+    ).toSQL();
+
+    expect(query.sql).toContain('"platform_integrations"."owned_by_organization_id" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" is null');
+    expect(query.sql).not.toContain('"platform_integrations"."owned_by_user_id" =');
+  });
+
+  it('selects only user-owned rows for unpinned personal sessions', () => {
+    const query = buildInstallationRefreshCandidatesQuery(
+      getWorkerDb('postgres://unused:unused@localhost:0/unused'),
+      { githubRepo: 'renamed-owner/repository', userId: 'user-1' }
+    ).toSQL();
+
+    expect(query.sql).toContain('"platform_integrations"."owned_by_user_id" =');
+    expect(query.sql).toContain('"platform_integrations"."owned_by_organization_id" is null');
+    expect(query.params).not.toContain(params.orgId);
   });
 });

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -5,7 +5,7 @@ import {
   organization_memberships,
   kilocode_users,
 } from '@kilocode/db/schema';
-import { eq, and, exists, isNull, isNotNull, or, sql } from 'drizzle-orm';
+import { eq, and, exists, isNull, isNotNull, sql } from 'drizzle-orm';
 
 export type FindInstallationParams = {
   githubRepo: string;
@@ -136,17 +136,16 @@ function buildAuthorizedInstallationsQuery(
         );
   const legacyAuthorizedOwner =
     params.expectedIntegrationId === undefined
-      ? or(
-          and(
-            isNotNull(platform_integrations.owned_by_organization_id),
-            eq(platform_integrations.owned_by_organization_id, sql`${params.orgId ?? null}::uuid`),
-            isNotNull(organization_memberships.id)
-          ),
-          and(
-            isNotNull(platform_integrations.owned_by_user_id),
-            eq(platform_integrations.owned_by_user_id, params.userId)
+      ? params.orgId === undefined
+        ? and(
+            eq(platform_integrations.owned_by_user_id, params.userId),
+            isNull(platform_integrations.owned_by_organization_id)
           )
-        )
+        : and(
+            eq(platform_integrations.owned_by_organization_id, sql`${params.orgId}::uuid`),
+            isNull(platform_integrations.owned_by_user_id),
+            isNotNull(organization_memberships.id)
+          )
       : undefined;
 
   return db
@@ -444,17 +443,6 @@ export class InstallationLookupService {
         repositoryAccess: parsed.repository_access,
         repositories: parsed.repositories,
       };
-    });
-    const normalizedRepo = params.githubRepo.toLowerCase();
-    candidates.sort((left, right) => {
-      const cachedForRepo = (candidate: AuthorizedInstallationCandidate) =>
-        candidate.repositoryAccess === 'selected' &&
-        candidate.repositories?.some(
-          repository => repository.full_name.toLowerCase() === normalizedRepo
-        )
-          ? 0
-          : 1;
-      return cachedForRepo(left) - cachedForRepo(right);
     });
     return { success: true, candidates };
   }

--- a/services/git-token-service/src/installation-lookup-service.ts
+++ b/services/git-token-service/src/installation-lookup-service.ts
@@ -15,15 +15,14 @@ export type FindInstallationParams = {
 };
 
 const InstallationLookupResultSchema = z.object({
+  id: z.string(),
   platform_installation_id: z.string(),
   platform_account_login: z.string().nullable(),
   github_app_type: z.enum(['standard', 'lite']).nullable().optional(),
   owned_by_organization_id: z.string().nullable(),
 });
 
-const InstallationRefreshCandidateSchema = InstallationLookupResultSchema.extend({
-  id: z.string(),
-});
+const InstallationRefreshCandidateSchema = InstallationLookupResultSchema;
 
 const ManagedInstallationLookupResultSchema = InstallationLookupResultSchema.extend({
   repository_access: z.string().nullable(),
@@ -47,6 +46,7 @@ const MAX_INSTALLATION_LOGIN_REFRESH_CANDIDATES = 10;
 
 export type InstallationLookupSuccess = {
   success: true;
+  integrationId: string;
   installationId: string;
   accountLogin: string;
   githubAppType: 'standard' | 'lite';
@@ -81,6 +81,15 @@ export type ManagedInstallationLookupSuccess = InstallationLookupSuccess & {
   permissions: Record<string, unknown> | null;
 };
 
+export type AuthorizedInstallationCandidate = ManagedInstallationLookupSuccess & {
+  repositoryAccess: string | null;
+  repositories: { full_name: string }[] | null;
+};
+
+export type AuthorizedInstallationCandidatesResult =
+  | { success: true; candidates: AuthorizedInstallationCandidate[] }
+  | InstallationLookupFailure;
+
 export type ManagedInstallationLookupResult =
   | ManagedInstallationLookupSuccess
   | InstallationLookupFailure
@@ -112,14 +121,19 @@ function buildAuthorizedInstallationsQuery(
   const exactIntegrationOwner =
     params.expectedIntegrationId === undefined
       ? undefined
-      : params.orgId === undefined
-        ? sql`false`
-        : and(
-            eq(platform_integrations.id, params.expectedIntegrationId),
-            eq(platform_integrations.owned_by_organization_id, params.orgId),
-            isNull(platform_integrations.owned_by_user_id),
-            isNotNull(organization_memberships.id)
-          );
+      : and(
+          eq(platform_integrations.id, params.expectedIntegrationId),
+          params.orgId === undefined
+            ? and(
+                eq(platform_integrations.owned_by_user_id, params.userId),
+                isNull(platform_integrations.owned_by_organization_id)
+              )
+            : and(
+                eq(platform_integrations.owned_by_organization_id, params.orgId),
+                isNull(platform_integrations.owned_by_user_id),
+                isNotNull(organization_memberships.id)
+              )
+        );
   const legacyAuthorizedOwner =
     params.expectedIntegrationId === undefined
       ? or(
@@ -168,6 +182,7 @@ function buildAuthorizedInstallationsQuery(
         eq(platform_integrations.platform, 'github'),
         eq(platform_integrations.integration_type, 'app'),
         eq(platform_integrations.integration_status, 'active'),
+        isNull(platform_integrations.auth_invalid_at),
         accountLoginFilter,
         isNotNull(platform_integrations.platform_installation_id),
         requestedOrganizationMembership,
@@ -182,9 +197,7 @@ function buildAuthorizedInstallationsQuery(
 
 export function buildInstallationLookupQuery(db: WorkerDb, params: FindInstallationParams) {
   const [repoOwner = ''] = params.githubRepo.split('/');
-  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(
-    params.expectedIntegrationId === undefined ? 2 : 1
-  );
+  return buildAuthorizedInstallationsQuery(db, params, repoOwner);
 }
 
 export function buildInstallationRefreshCandidatesQuery(
@@ -198,9 +211,14 @@ export function buildInstallationRefreshCandidatesQuery(
 
 export function buildManagedInstallationLookupQuery(db: WorkerDb, params: FindInstallationParams) {
   const [repoOwner = ''] = params.githubRepo.split('/');
-  return buildAuthorizedInstallationsQuery(db, params, repoOwner).limit(
-    params.expectedIntegrationId === undefined ? 2 : 1
-  );
+  return buildAuthorizedInstallationsQuery(db, params, repoOwner);
+}
+
+export function buildAuthorizedInstallationCandidatesQuery(
+  db: WorkerDb,
+  params: FindInstallationParams
+) {
+  return buildAuthorizedInstallationsQuery(db, params);
 }
 
 export class InstallationLookupService {
@@ -228,8 +246,7 @@ export class InstallationLookupService {
 
     if (
       params.expectedIntegrationId !== undefined &&
-      (params.orgId === undefined ||
-        !z.string().uuid().safeParse(params.expectedIntegrationId).success)
+      !z.string().uuid().safeParse(params.expectedIntegrationId).success
     ) {
       return { success: false, reason: 'integration_mismatch' };
     }
@@ -258,6 +275,7 @@ export class InstallationLookupService {
 
       return {
         success: true,
+        integrationId: selected.data.id,
         installationId: selected.data.platform_installation_id,
         accountLogin: selected.data.platform_account_login ?? '',
         githubAppType: selected.data.github_app_type ?? 'standard',
@@ -284,6 +302,7 @@ export class InstallationLookupService {
 
     return {
       success: true,
+      integrationId: selected.id,
       installationId: selected.platform_installation_id,
       accountLogin: selected.platform_account_login ?? '',
       githubAppType: selected.github_app_type ?? 'standard',
@@ -348,6 +367,7 @@ export class InstallationLookupService {
 
       return {
         success: true,
+        integrationId: selected.data.id,
         installationId: selected.data.platform_installation_id,
         accountLogin: selected.data.platform_account_login ?? '',
         githubAppType: selected.data.github_app_type ?? 'standard',
@@ -385,12 +405,58 @@ export class InstallationLookupService {
 
     return {
       success: true,
+      integrationId: selected.id,
       installationId: selected.platform_installation_id,
       accountLogin: selected.platform_account_login ?? '',
       githubAppType: selected.github_app_type ?? 'standard',
       repoName,
       permissions: selected.permissions,
     };
+  }
+
+  async findAuthorizedInstallationsForRepo(
+    params: FindInstallationParams
+  ): Promise<AuthorizedInstallationCandidatesResult> {
+    const validationFailure = this.validateParams(params);
+    if (validationFailure) return validationFailure;
+
+    const [, repoName] = params.githubRepo.split('/');
+    if (!repoName) return { success: false, reason: 'invalid_repo_format' };
+
+    const rows = await buildAuthorizedInstallationCandidatesQuery(this.getDb(), params);
+    if (rows.length === 0) {
+      return {
+        success: false,
+        reason: params.expectedIntegrationId ? 'integration_mismatch' : 'no_installation_found',
+      };
+    }
+
+    const candidates = rows.map(row => {
+      const parsed = ExactManagedInstallationLookupResultSchema.parse(row);
+      return {
+        success: true as const,
+        integrationId: parsed.id,
+        installationId: parsed.platform_installation_id,
+        accountLogin: parsed.platform_account_login ?? '',
+        githubAppType: parsed.github_app_type ?? 'standard',
+        repoName,
+        permissions: parsed.permissions,
+        repositoryAccess: parsed.repository_access,
+        repositories: parsed.repositories,
+      };
+    });
+    const normalizedRepo = params.githubRepo.toLowerCase();
+    candidates.sort((left, right) => {
+      const cachedForRepo = (candidate: AuthorizedInstallationCandidate) =>
+        candidate.repositoryAccess === 'selected' &&
+        candidate.repositories?.some(
+          repository => repository.full_name.toLowerCase() === normalizedRepo
+        )
+          ? 0
+          : 1;
+      return cachedForRepo(left) - cachedForRepo(right);
+    });
+    return { success: true, candidates };
   }
 
   private matchesExpectedIntegration(
@@ -400,20 +466,14 @@ export class InstallationLookupService {
     if (
       selected.id !== params.expectedIntegrationId ||
       selected.integration_status !== 'active' ||
-      selected.owned_by_organization_id !== params.orgId ||
-      selected.owned_by_user_id !== null ||
       selected.platform_account_login?.toLowerCase() !==
         params.githubRepo.split('/')[0]?.toLowerCase()
     ) {
       return false;
     }
 
-    if (selected.repository_access === 'all') return true;
-    if (selected.repository_access !== 'selected') return false;
-    return Boolean(
-      selected.repositories?.some(
-        repository => repository.full_name.toLowerCase() === params.githubRepo.toLowerCase()
-      )
-    );
+    return params.orgId === undefined
+      ? selected.owned_by_user_id === params.userId && selected.owned_by_organization_id === null
+      : selected.owned_by_organization_id === params.orgId && selected.owned_by_user_id === null;
   }
 }

--- a/services/security-auto-analysis/worker-configuration.d.ts
+++ b/services/security-auto-analysis/worker-configuration.d.ts
@@ -27,6 +27,7 @@ declare type GitTokenForRepoResult =
   | {
       success: true;
       token: string;
+      platformIntegrationId: string;
       installationId: string;
       accountLogin: string;
       appType: 'standard' | 'lite';
@@ -37,6 +38,10 @@ declare type GitTokenForRepoResult =
         | 'database_not_configured'
         | 'invalid_repo_format'
         | 'no_installation_found'
+        | 'repository_not_installed'
+        | 'ambiguous_installation'
+        | 'temporarily_unavailable'
+        | 'integration_mismatch'
         | 'invalid_org_id';
     };
 


### PR DESCRIPTION
## Why this PR exists

Organizations can connect several GitHub App installations, while cached account and selected-repository metadata can become stale. Credential selection therefore needs GitHub to identify the installation that currently serves the exact `owner/repo`, with Kilo still enforcing user or organization authorization and installation health.

The previous proposed foundation in #5547 resolved from database metadata. This replacement moves the authoritative decision into Git Token Service without minting and testing a token for every candidate.

## Place in the rollout

This is the central resolution boundary for Cloud Agent and other server-side GitHub operations that know `owner/repo` but do not already have authoritative installation provenance. Callers that do know the installation, such as webhooks and persisted reviews or findings, continue supplying `expectedIntegrationId` as an exact fence.

The PR is standalone and rollout-compatible with existing retry behavior. Definitive lookup failures stay in the existing result contract, while provider uncertainty follows the existing thrown RPC failure path so callers retry instead of selecting a sibling installation by accident.

## Resolution algorithm

- Load all authorized, active, non-auth-invalid GitHub App rows in the exact personal or organization ownership scope, including current organization membership checks. Cached repository lists are not treated as proof.
- Derive the relevant app types from those rows, bounding provider work to at most one Standard probe and one Lite probe.
- For each relevant app type, app-authenticate and call `GET /repos/{owner}/{repo}/installation` once.
- Match the provider installation ID returned for that app type against the authorized healthy database rows.
- Detect duplicate-row or cross-app ambiguity before issuing credentials.
- After exactly one row is selected, mint one repository-scoped installation token and return its Kilo `platformIntegrationId` with the token and app metadata.
- Preserve exact `expectedIntegrationId` ownership and health checks when a caller supplies a fence.

## Provider safety and failure policy

- Repository-installation probes use a 10-second timeout, `redirect: manual`, fixed GitHub API origin and path construction, strict JSON shape validation, and a 64 KiB bounded response read.
- Only `404` definitively excludes an app type. Authentication, permission, rate-limit, validation, redirect, malformed-response, timeout, network, and 5xx outcomes remain temporary uncertainty.
- A positive match cannot win while another relevant app-type probe is uncertain.
- Internal ambiguity is detected explicitly; the legacy token RPC preserves its existing `no_installation_found` mapping.

## Capability confinement

- Generated session capabilities are pinned to the authoritatively resolved Kilo integration ID even when the caller supplied only `owner/repo`.
- Selected-user authorization is confined to the claimed repository REST and uploads paths plus Git smart HTTP.
- Global GraphQL or user endpoints, unsupported methods, and cross-repository requests are rejected before credentials are resolved.

## What stays unchanged

- Personal and organization ownership and membership authorization remain enforced.
- Standard and Lite app credentials remain separate.
- User-authorized Cloud Agent credentials still require a valid managed installation and preserve existing fallback behavior.
- Webhook and persisted-record flows may continue to provide an exact expected integration.

## Review guide

1. Review authorized and healthy row selection in `installation-lookup-service.ts`.
2. Review bounded app-authenticated repository-installation lookup in `github-token-service.ts`.
3. Review Standard/Lite provider-ID matching and the single scoped-token mint in `resolveAuthoritativeInstallation`.
4. Verify capability claims and redemption remain confined to the resolved integration and repository.

## Replaces

Replaces #5547, which relied on cached integration metadata in the web app.

## Validation

- Git Token Service: 24 files, 557 tests
- Git Token Service typecheck and lint
- Cloud Agent typecheck and 23 Git-token client tests
- App Builder, Security Auto Analysis, and Gastown typechecks
- Repository CI typecheck, lint, format, and affected service suites
- Changed-file format check
- `git diff --check`