### PR TITLE
feat(cloud-agent): resolve and inherit GitHub installations server-side

### DIFF
--- a/packages/session-ingest-contracts/src/rpc-contract.ts
+++ b/packages/session-ingest-contracts/src/rpc-contract.ts
@@ -85,6 +85,12 @@ export type ResolveCloudAgentRootSessionForKiloSessionParams = z.input<
 >;
 export type ResolveCloudAgentRootSessionForKiloSessionResult = {
   cloudAgentSessionId: string;
+  /**
+   * Sanitized repository identity recorded for the authorized root. Optional
+   * for compatibility with roots and Session Ingest workers created before
+   * repository identity was returned by this RPC.
+   */
+  repository?: { type: 'github'; repo: string };
 } | null;
 
 export const kiloSdkSessionInfoSchema = z.object({

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.test.ts
@@ -20,6 +20,7 @@ const {
   mergeProfileConfigurationMock,
   assertKiloModelAvailableMock,
   assertBitbucketRepositoryAccessMock,
+  canonicalizeRepositoryMock,
   assertOrganizationMembershipMock,
   registerNewSessionMock,
   startNewSessionMock,
@@ -28,6 +29,7 @@ const {
   mergeProfileConfigurationMock: vi.fn().mockResolvedValue({}),
   assertKiloModelAvailableMock: vi.fn().mockResolvedValue(undefined),
   assertBitbucketRepositoryAccessMock: vi.fn().mockResolvedValue(undefined),
+  canonicalizeRepositoryMock: vi.fn(async ({ request }) => request),
   assertOrganizationMembershipMock: vi.fn().mockResolvedValue(undefined),
   registerNewSessionMock: vi.fn().mockResolvedValue({
     cloudAgentSessionId: 'agent_12345678-1234-1234-1234-123456789abc',
@@ -76,6 +78,7 @@ vi.mock('../../model-validation.js', () => ({
 
 vi.mock('../../session/validate-repository-access.js', () => ({
   assertRepositoryAccessBeforeSessionCreation: assertBitbucketRepositoryAccessMock,
+  canonicalizeRepositoryBeforeSessionCreation: canonicalizeRepositoryMock,
 }));
 
 vi.mock('./organization-membership.js', () => ({
@@ -126,6 +129,7 @@ describe('prepareSession operation-ledger admission gate', () => {
     mergeProfileConfigurationMock.mockResolvedValue({});
     assertKiloModelAvailableMock.mockResolvedValue(undefined);
     assertBitbucketRepositoryAccessMock.mockResolvedValue(undefined);
+    canonicalizeRepositoryMock.mockImplementation(async ({ request }) => request);
     assertOrganizationMembershipMock.mockResolvedValue(undefined);
     registerNewSessionMock.mockResolvedValue({
       cloudAgentSessionId: 'agent_12345678-1234-1234-1234-123456789abc',

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -47,7 +47,10 @@ import type { Env } from '../../types.js';
 import type { SessionProfileBundle } from '../../session-profile.js';
 import type { SessionCreateRequest } from '../../session/session-requests.js';
 import { assertKiloModelAvailable } from '../../model-validation.js';
-import { assertRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
+import {
+  assertRepositoryAccessBeforeSessionCreation,
+  canonicalizeRepositoryBeforeSessionCreation,
+} from '../../session/validate-repository-access.js';
 import { assertOrganizationMembership } from './organization-membership.js';
 
 type SessionPrepareHandlers = {
@@ -339,14 +342,24 @@ const prepareSessionHandler = internalApiProtectedProcedure
           input.kilocodeOrganizationId
         );
       }
+      const canonicalRequest = await canonicalizeRepositoryBeforeSessionCreation({
+        env: ctx.env,
+        userId: ctx.userId,
+        orgId: input.kilocodeOrganizationId,
+        request,
+      });
       await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,
         orgId: input.kilocodeOrganizationId,
-        repository: request.repository,
+        repository: canonicalRequest.repository,
       });
       const policy = profileResolutionPolicyForSessionCreateOrigin(input.createdOnPlatform);
-      const requestWithProfile = await resolveEffectiveSessionConfiguration(ctx, request, policy);
+      const requestWithProfile = await resolveEffectiveSessionConfiguration(
+        ctx,
+        canonicalRequest,
+        policy
+      );
       assertModeAvailableForProfile(
         requestWithProfile.agent.mode,
         requestWithProfile.profile?.resolved ?? {}

--- a/services/cloud-agent-next/src/router/handlers/session-start.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-start.ts
@@ -24,7 +24,10 @@ import {
 } from './session-prepare.js';
 import type { SessionCreateRequest } from '../../session/session-requests.js';
 import { assertKiloModelAvailable } from '../../model-validation.js';
-import { assertRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
+import {
+  assertRepositoryAccessBeforeSessionCreation,
+  canonicalizeRepositoryBeforeSessionCreation,
+} from '../../session/validate-repository-access.js';
 import { assertOrganizationMembership } from './organization-membership.js';
 
 type SessionStartHandlers = {
@@ -106,11 +109,17 @@ const startSessionHandler = protectedProcedure
         db = getPgDb(ctx.env);
         await assertOrganizationMembership(db, ctx.userId, organizationId);
       }
+      const canonicalRequest = await canonicalizeRepositoryBeforeSessionCreation({
+        env: ctx.env,
+        userId: ctx.userId,
+        orgId: organizationId,
+        request,
+      });
       await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,
         orgId: organizationId,
-        repository: request.repository,
+        repository: canonicalRequest.repository,
       });
 
       const policy = profileResolutionPolicyForSessionCreateOrigin(
@@ -118,7 +127,7 @@ const startSessionHandler = protectedProcedure
       );
       const requestWithProfile = await resolveEffectiveSessionConfiguration(
         ctx,
-        request,
+        canonicalRequest,
         policy,
         db
       );

--- a/services/cloud-agent-next/src/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session-prepare.test.ts
@@ -171,6 +171,7 @@ function createInternalApiContext(options: {
   doStub?: ReturnType<typeof createMockDOStub>;
   getTokenForRepo?: ReturnType<typeof vi.fn>;
   getBitbucketToken?: ReturnType<typeof vi.fn>;
+  resolveCloudAgentRootSessionForKiloSession?: ReturnType<typeof vi.fn>;
   githubTokenContainmentOrgIds?: string;
   gitlabTokenContainmentOrgIds?: string;
   kilocodeTokenContainmentOrgIds?: string;
@@ -222,6 +223,8 @@ function createInternalApiContext(options: {
         fetch: vi.fn(),
         createSessionForCloudAgent: vi.fn().mockResolvedValue({ created: true }),
         deleteSessionForCloudAgent: vi.fn().mockResolvedValue({ deleted: true }),
+        resolveCloudAgentRootSessionForKiloSession:
+          options.resolveCloudAgentRootSessionForKiloSession ?? vi.fn().mockResolvedValue(null),
       } as unknown as TRPCContext['env']['SESSION_INGEST'],
       INTERNAL_API_SECRET: effectiveInternalApiSecret,
       NEXTAUTH_SECRET: 'test-secret',
@@ -233,6 +236,7 @@ function createInternalApiContext(options: {
           vi.fn().mockResolvedValue({
             success: true,
             token: 'managed-github-token',
+            platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
             installationId: '123',
             accountLogin: 'acme',
             appType: 'standard',
@@ -544,6 +548,7 @@ describe('prepareSession endpoint', () => {
         repository: {
           type: 'github',
           repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
           branch: 'feature/test-branch',
         },
         profile: {
@@ -1415,6 +1420,7 @@ describe('start endpoint', () => {
     const getTokenForRepo = vi.fn().mockResolvedValue({
       success: true,
       token: 'managed-github-token',
+      platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -1436,6 +1442,36 @@ describe('start endpoint', () => {
     expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
       expect.objectContaining({
         repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+      })
+    );
+  });
+
+  it('canonicalizes unpinned grouped starts before persisting session metadata', async () => {
+    const doStub = createMockDOStub();
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'managed-github-token',
+      platformIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+      installationId: '456',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const caller = appRouter.createCaller(createInternalApiContext({ doStub, getTokenForRepo }));
+
+    await caller.start({
+      message: { prompt: 'Resolve this repository server-side' },
+      agent: { mode: 'code', model: 'anthropic/claude-sonnet-4-20250514' },
+      repository: { type: 'github', repo: 'acme/repo' },
+    });
+
+    expect(getTokenForRepo).toHaveBeenCalledOnce();
+    expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+        },
       })
     );
   });

--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -9,9 +9,9 @@
  * one grouped operation. Legacy
  * `prepareSession` retains registration-only behavior and can queue later.
  *
- * Managed git-token resolution (GitHub App installation, managed GitLab) is
- * NOT performed here; it happens lazily in the flusher's workspace preparation
- * path. Provider credentials are intentionally not stored in registration
+ * GitHub repository identity is canonicalized by the handler before entering
+ * this module. Managed credentials are still resolved lazily in the flusher's
+ * workspace preparation path and are intentionally not stored in registration
  * metadata; generic git repositories may still carry an explicit token.
  */
 import { TRPCError } from '@trpc/server';

--- a/services/cloud-agent-next/src/session/validate-repository-access.test.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it, vi } from 'vitest';
-import { assertRepositoryAccessBeforeSessionCreation } from './validate-repository-access.js';
+import {
+  assertRepositoryAccessBeforeSessionCreation,
+  canonicalizeRepositoryBeforeSessionCreation,
+} from './validate-repository-access.js';
+import { sessionCreateIntentFingerprint } from './session-registration.js';
+
+const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+function githubResolution(platformIntegrationId = githubIntegrationId) {
+  return {
+    success: true as const,
+    token: 'token',
+    platformIntegrationId,
+    installationId: '123',
+    accountLogin: 'acme',
+    appType: 'standard' as const,
+  };
+}
+
+function githubRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    initialTurn: { type: 'prompt' as const, prompt: 'Build it' },
+    agent: { mode: 'code', model: 'model' },
+    repository: { type: 'github' as const, repo: 'acme/repo' },
+    ...overrides,
+  };
+}
 
 const repository = {
   type: 'bitbucket' as const,
@@ -9,47 +35,63 @@ const repository = {
 };
 
 describe('GitHub session creation preflight', () => {
-  it('skips legacy GitHub repositories without an integration pin', async () => {
-    const getTokenForRepo = vi.fn();
+  it('canonicalizes an unpinned GitHub repository to the live resolved integration', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
 
     await expect(
-      assertRepositoryAccessBeforeSessionCreation({
+      canonicalizeRepositoryBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
         userId: 'user-1',
-        repository: { type: 'github', repo: 'acme/repo' },
+        request: githubRequest(),
       })
-    ).resolves.toBeUndefined();
-    expect(getTokenForRepo).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({
+      repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+    });
   });
 
-  it('preflights a pinned GitHub repository against the exact integration', async () => {
-    const getTokenForRepo = vi.fn().mockResolvedValue({
-      success: true,
-      token: 'token',
-      installationId: '123',
-      accountLogin: 'acme',
-      appType: 'standard',
+  it('includes the canonical integration in the operation fingerprint', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
+    const canonical = await canonicalizeRepositoryBeforeSessionCreation({
+      env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+      userId: 'user-1',
+      request: githubRequest(),
     });
+    const alternate = {
+      ...canonical,
+      repository: {
+        ...canonical.repository,
+        githubIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+      },
+    };
+
+    expect(await sessionCreateIntentFingerprint(canonical)).not.toBe(
+      await sessionCreateIntentFingerprint(alternate)
+    );
+  });
+
+  it('canonicalizes a pinned GitHub repository against the exact integration', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
     const orgId = '123e4567-e89b-12d3-a456-426614174030';
-    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
 
     await expect(
-      assertRepositoryAccessBeforeSessionCreation({
+      canonicalizeRepositoryBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
         userId: 'user-1',
         orgId,
-        repository: {
-          type: 'github',
-          repo: 'acme/repo',
-          githubIntegrationId: expectedIntegrationId,
-        },
+        request: githubRequest({
+          repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+        }),
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ repository: { githubIntegrationId } });
     expect(getTokenForRepo).toHaveBeenCalledWith({
       githubRepo: 'acme/repo',
       userId: 'user-1',
       orgId,
-      expectedIntegrationId,
+      expectedIntegrationId: githubIntegrationId,
     });
   });
 
@@ -60,19 +102,154 @@ describe('GitHub session creation preflight', () => {
     });
 
     await expect(
-      assertRepositoryAccessBeforeSessionCreation({
+      canonicalizeRepositoryBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
         userId: 'user-1',
-        repository: {
-          type: 'github',
-          repo: 'acme/repo',
-          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
-        },
+        request: githubRequest({
+          repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+        }),
       })
     ).rejects.toMatchObject({
       code: 'BAD_REQUEST',
       message: 'GitHub repository authorization failed (integration_mismatch)',
     });
+  });
+
+  it.each([
+    ['ambiguous_installation', 'BAD_REQUEST'],
+    ['repository_not_installed', 'BAD_REQUEST'],
+    ['temporarily_unavailable', 'SERVICE_UNAVAILABLE'],
+    ['database_not_configured', 'SERVICE_UNAVAILABLE'],
+  ])('maps %s to %s before allocation', async (reason, code) => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({ success: false, reason });
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+        userId: 'user-1',
+        request: githubRequest(),
+      })
+    ).rejects.toMatchObject({ code });
+  });
+
+  it('inherits the source GitHub pin and accepts repository case differences', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
+    const getMetadata = vi.fn().mockResolvedValue({
+      repository: { type: 'github', repo: 'Acme/Repo', githubIntegrationId },
+    });
+    const env = {
+      SESSION_INGEST: {
+        resolveCloudAgentRootSessionForKiloSession: vi.fn().mockResolvedValue({
+          cloudAgentSessionId: 'agent-source',
+          repository: { type: 'github', repo: 'Acme/Repo' },
+        }),
+      },
+      CLOUD_AGENT_SESSION: {
+        idFromName: vi.fn(name => name),
+        get: vi.fn(() => ({ getMetadata })),
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          repository: { type: 'github', repo: 'acme/repo' },
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).resolves.toMatchObject({
+      repository: { repo: 'Acme/Repo', githubIntegrationId },
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'Acme/Repo',
+      userId: 'user-1',
+      expectedIntegrationId: githubIntegrationId,
+    });
+  });
+
+  it.each([
+    [
+      'repository',
+      { type: 'github', repo: 'Acme/Repo', githubIntegrationId },
+      { type: 'github', repo: 'other/repo', githubIntegrationId },
+      'clone_repository_mismatch',
+    ],
+    [
+      'integration',
+      { type: 'github', repo: 'acme/repo', githubIntegrationId },
+      {
+        type: 'github',
+        repo: 'Acme/Repo',
+        githubIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+      },
+      'clone_integration_mismatch',
+    ],
+  ])(
+    'rejects a clone %s mismatch before live resolution',
+    async (_kind, sourceRepo, submitted, message) => {
+      const getTokenForRepo = vi.fn();
+      const env = {
+        SESSION_INGEST: {
+          resolveCloudAgentRootSessionForKiloSession: vi.fn().mockResolvedValue({
+            cloudAgentSessionId: 'agent-source',
+            repository: { type: 'github', repo: 'Acme/Repo' },
+          }),
+        },
+        CLOUD_AGENT_SESSION: {
+          idFromName: vi.fn(name => name),
+          get: vi.fn(() => ({
+            getMetadata: vi.fn().mockResolvedValue({ repository: sourceRepo }),
+          })),
+        },
+        GIT_TOKEN_SERVICE: { getTokenForRepo },
+      };
+
+      await expect(
+        canonicalizeRepositoryBeforeSessionCreation({
+          env: env as never,
+          userId: 'user-1',
+          request: githubRequest({
+            repository: submitted,
+            clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+          }),
+        })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST', message });
+      expect(getTokenForRepo).not.toHaveBeenCalled();
+    }
+  );
+
+  it('uses live resolution for a legacy source without an integration pin', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
+    const env = {
+      SESSION_INGEST: {
+        resolveCloudAgentRootSessionForKiloSession: vi.fn().mockResolvedValue({
+          cloudAgentSessionId: 'agent-source',
+        }),
+      },
+      CLOUD_AGENT_SESSION: {
+        idFromName: vi.fn(name => name),
+        get: vi.fn(() => ({
+          getMetadata: vi.fn().mockResolvedValue({
+            repository: { type: 'github', repo: 'acme/repo' },
+          }),
+        })),
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).resolves.toMatchObject({ repository: { githubIntegrationId } });
+    expect(getTokenForRepo).toHaveBeenCalledWith({ githubRepo: 'acme/repo', userId: 'user-1' });
   });
 });
 

--- a/services/cloud-agent-next/src/session/validate-repository-access.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.ts
@@ -5,7 +5,147 @@ import {
   resolveGitHubTokenForRepo,
   resolveManagedBitbucketToken,
 } from '../services/git-token-service-client.js';
-import type { SessionRepositoryRequest } from './session-requests.js';
+import type { SessionCreateRequest, SessionRepositoryRequest } from './session-requests.js';
+import { withDORetry } from '../utils/do-retry.js';
+import { resolveSessionStub } from '../sandbox-session/session-stub.js';
+
+const TEMPORARY_GITHUB_RESOLUTION_REASONS = new Set([
+  'database_not_configured',
+  'service_not_configured',
+  'temporarily_unavailable',
+  'rpc_error',
+  'source_unavailable',
+]);
+
+function githubRepositoryAuthorizationError(reason: string): TRPCError {
+  return new TRPCError({
+    code: TEMPORARY_GITHUB_RESOLUTION_REASONS.has(reason) ? 'SERVICE_UNAVAILABLE' : 'BAD_REQUEST',
+    message: `GitHub repository authorization failed (${reason})`,
+  });
+}
+
+function repositoriesMatch(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function readGitHubRepository(
+  value: unknown
+): { type: 'github'; repo: string; githubIntegrationId?: string } | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const repository = (value as { repository?: unknown }).repository;
+  if (typeof repository !== 'object' || repository === null) return undefined;
+  const fields = repository as {
+    type?: unknown;
+    repo?: unknown;
+    githubIntegrationId?: unknown;
+  };
+  if (fields.type !== 'github' || typeof fields.repo !== 'string') return undefined;
+  return {
+    type: 'github',
+    repo: fields.repo,
+    ...(typeof fields.githubIntegrationId === 'string'
+      ? { githubIntegrationId: fields.githubIntegrationId }
+      : {}),
+  };
+}
+
+async function resolveCloneSourceGitHubRepository(input: {
+  env: PersistenceEnv;
+  userId: string;
+  request: SessionCreateRequest;
+}): Promise<{ repo: string; githubIntegrationId?: string } | null> {
+  const sourceKiloSessionId = input.request.clone?.cloneFromKiloSessionId;
+  if (!sourceKiloSessionId) return null;
+
+  let source;
+  try {
+    source = await input.env.SESSION_INGEST.resolveCloudAgentRootSessionForKiloSession({
+      kiloUserId: input.userId,
+      kiloSessionId: sourceKiloSessionId,
+    });
+  } catch {
+    throw githubRepositoryAuthorizationError('source_unavailable');
+  }
+  if (!source) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'source_access_denied' });
+  }
+
+  let sourceMetadata: unknown;
+  try {
+    sourceMetadata = await withDORetry(
+      () => resolveSessionStub(input.env, input.userId, source.cloudAgentSessionId),
+      stub => stub.getMetadata(),
+      'CloudAgentSession.getMetadataForCloneRepository'
+    );
+  } catch {
+    throw githubRepositoryAuthorizationError('source_unavailable');
+  }
+
+  const metadataRepository = readGitHubRepository(sourceMetadata);
+  if (!metadataRepository) {
+    throw githubRepositoryAuthorizationError('source_unavailable');
+  }
+  const mappedRepository = readGitHubRepository(source);
+  if (
+    mappedRepository &&
+    metadataRepository &&
+    !repositoriesMatch(mappedRepository.repo, metadataRepository.repo)
+  ) {
+    throw githubRepositoryAuthorizationError('source_unavailable');
+  }
+
+  const repo = mappedRepository?.repo ?? metadataRepository.repo;
+  return {
+    repo,
+    ...(metadataRepository.githubIntegrationId
+      ? { githubIntegrationId: metadataRepository.githubIntegrationId }
+      : {}),
+  };
+}
+
+/**
+ * Resolves and pins GitHub repository identity before any operation-ledger or
+ * session allocation work. The returned request contains no resolved token.
+ */
+export async function canonicalizeRepositoryBeforeSessionCreation(input: {
+  env: PersistenceEnv;
+  userId: string;
+  orgId?: string;
+  request: SessionCreateRequest;
+}): Promise<SessionCreateRequest> {
+  if (input.request.repository.type !== 'github') return input.request;
+
+  const submitted = input.request.repository;
+  const source = await resolveCloneSourceGitHubRepository(input);
+  if (source && !repositoriesMatch(submitted.repo, source.repo)) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'clone_repository_mismatch' });
+  }
+  if (
+    source?.githubIntegrationId &&
+    submitted.githubIntegrationId &&
+    source.githubIntegrationId.toLowerCase() !== submitted.githubIntegrationId.toLowerCase()
+  ) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'clone_integration_mismatch' });
+  }
+
+  const expectedIntegrationId = source?.githubIntegrationId ?? submitted.githubIntegrationId;
+  const result = await resolveGitHubTokenForRepo(input.env, {
+    githubRepo: source?.repo ?? submitted.repo,
+    userId: input.userId,
+    ...(input.orgId ? { orgId: input.orgId } : {}),
+    ...(expectedIntegrationId ? { expectedIntegrationId } : {}),
+  });
+  if (!result.success) throw githubRepositoryAuthorizationError(result.error.reason);
+
+  return {
+    ...input.request,
+    repository: {
+      ...submitted,
+      ...(source ? { repo: source.repo } : {}),
+      githubIntegrationId: result.value.platformIntegrationId,
+    },
+  };
+}
 
 export async function assertRepositoryAccessBeforeSessionCreation(input: {
   env: PersistenceEnv;
@@ -13,25 +153,6 @@ export async function assertRepositoryAccessBeforeSessionCreation(input: {
   orgId?: string;
   repository: SessionRepositoryRequest;
 }): Promise<void> {
-  if (input.repository.type === 'github' && input.repository.githubIntegrationId) {
-    const result = await resolveGitHubTokenForRepo(input.env, {
-      githubRepo: input.repository.repo,
-      userId: input.userId,
-      ...(input.orgId ? { orgId: input.orgId } : {}),
-      expectedIntegrationId: input.repository.githubIntegrationId,
-    });
-    if (!result.success) {
-      throw new TRPCError({
-        code:
-          result.error.reason === 'service_not_configured' || result.error.reason === 'rpc_error'
-            ? 'SERVICE_UNAVAILABLE'
-            : 'BAD_REQUEST',
-        message: `GitHub repository authorization failed (${result.error.reason})`,
-      });
-    }
-    return;
-  }
-
   if (input.repository.type !== 'bitbucket') return;
   if (!input.orgId) {
     throw new TRPCError({

--- a/services/session-ingest/src/session-ingest-rpc.test.ts
+++ b/services/session-ingest/src/session-ingest-rpc.test.ts
@@ -99,6 +99,7 @@ const sdkStoredMessageFixture = { info: sdkUserMessageFixture, parts: [sdkTextPa
 type MappingRow = {
   kiloSessionId?: string;
   cloudAgentSessionId?: string | null;
+  gitUrl?: string | null;
   title?: string | null;
   createdAt?: string;
   updatedAt?: string;
@@ -1435,7 +1436,12 @@ describe('SessionIngestRPC.resolveCloudAgentRootSessionForKiloSession', () => {
   });
 
   it('returns the Cloud Agent session ID for an owned root Kilo session mapping', async () => {
-    const { db, select } = makeDbFakes([{ cloudAgentSessionId: 'agent_owned_root' }]);
+    const { db, select } = makeDbFakes([
+      {
+        cloudAgentSessionId: 'agent_owned_root',
+        gitUrl: 'https://github.com/Acme/Repo',
+      },
+    ]);
     const rpc = makeRpc(db);
 
     const result = await rpc.resolveCloudAgentRootSessionForKiloSession({
@@ -1443,10 +1449,28 @@ describe('SessionIngestRPC.resolveCloudAgentRootSessionForKiloSession', () => {
       kiloSessionId: 'ses_12345678901234567890123456',
     });
 
-    expect(result).toEqual({ cloudAgentSessionId: 'agent_owned_root' });
-    expect(db.select).toHaveBeenCalledWith({ cloudAgentSessionId: expect.anything() });
+    expect(result).toEqual({
+      cloudAgentSessionId: 'agent_owned_root',
+      repository: { type: 'github', repo: 'Acme/Repo' },
+    });
+    expect(db.select).toHaveBeenCalledWith({
+      cloudAgentSessionId: expect.anything(),
+      gitUrl: expect.anything(),
+    });
     expect(select.leftJoin).toHaveBeenCalledWith(organization_memberships, expect.anything());
     expect(or).toHaveBeenCalled();
+  });
+
+  it('keeps the legacy result shape when the root has no sanitized GitHub repository', async () => {
+    const { db } = makeDbFakes([{ cloudAgentSessionId: 'agent_legacy_root', gitUrl: null }]);
+    const rpc = makeRpc(db);
+
+    await expect(
+      rpc.resolveCloudAgentRootSessionForKiloSession({
+        kiloUserId: 'usr_owner',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({ cloudAgentSessionId: 'agent_legacy_root' });
   });
 
   it('returns null when no owned Cloud Agent root mapping is found', async () => {

--- a/services/session-ingest/src/session-ingest-rpc.ts
+++ b/services/session-ingest/src/session-ingest-rpc.ts
@@ -31,7 +31,7 @@ import {
 import type { Env } from './env';
 import { getSessionIngestDO, type InspectCloneStageResult } from './dos/SessionIngestDO';
 import { getSessionAccessCacheDO } from './dos/SessionAccessCacheDO';
-import { normalizeGitUrl, withDORetry } from '@kilocode/worker-utils';
+import { normalizeGitUrl, parseGitUrl, withDORetry } from '@kilocode/worker-utils';
 import { app } from './app';
 import { mapSessionEventRow, notifyUserSessionEvent } from './session-events';
 import { cloneSessionIntoDestination } from './clone/session-clone';
@@ -351,7 +351,20 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
   ): Promise<ResolveCloudAgentRootSessionForKiloSessionResult> {
     const parsed = resolveCloudAgentRootSessionSchema.parse(params);
     const mapping = await this.findOwnedRootCloudAgentMapping(parsed);
-    return mapping ? { cloudAgentSessionId: mapping.cloudAgentSessionId } : null;
+    if (!mapping) return null;
+
+    const parsedRepository = mapping.gitUrl ? parseGitUrl(mapping.gitUrl) : null;
+    return {
+      cloudAgentSessionId: mapping.cloudAgentSessionId,
+      ...(parsedRepository?.platform === 'github'
+        ? {
+            repository: {
+              type: 'github' as const,
+              repo: `${parsedRepository.owner}/${parsedRepository.repo}`,
+            },
+          }
+        : {}),
+    };
   }
 
   async getCloudAgentRootSessionSnapshot(
@@ -504,10 +517,13 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
   private async findOwnedRootCloudAgentMapping(params: {
     kiloUserId: string;
     kiloSessionId: string;
-  }): Promise<{ cloudAgentSessionId: string } | null> {
+  }): Promise<{ cloudAgentSessionId: string; gitUrl: string | null } | null> {
     const db = getWorkerDb(this.env.HYPERDRIVE.connectionString);
     const rows = await db
-      .select({ cloudAgentSessionId: cli_sessions_v2.cloud_agent_session_id })
+      .select({
+        cloudAgentSessionId: cli_sessions_v2.cloud_agent_session_id,
+        gitUrl: cli_sessions_v2.git_url,
+      })
       .from(cli_sessions_v2)
       .leftJoin(organization_memberships, organizationMembershipJoinCondition(params.kiloUserId))
       .where(
@@ -522,7 +538,7 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
       .limit(1);
 
     const cloudAgentSessionId = rows[0]?.cloudAgentSessionId;
-    return cloudAgentSessionId ? { cloudAgentSessionId } : null;
+    return cloudAgentSessionId ? { cloudAgentSessionId, gitUrl: rows[0]?.gitUrl ?? null } : null;
   }
 
   /**


### PR DESCRIPTION
## Why this PR exists

Cloud Agent callers currently have to determine which GitHub installation owns `owner/repo` and pass it through session creation. That duplicates authorization logic in mobile, extension, bots, and continuation flows. It is especially wrong for continuation: the server already owns the source session metadata, so mobile should not download repository options and reverse-map the source repository itself.

#5584 makes Git Token Service return the uniquely authorized live installation. This PR makes Cloud Agent consume that result once, before session identity is fingerprinted or persisted.

## Place in the rollout

This replaces the client-side continuation approach in #5546 and becomes the Cloud Agent boundary for all clients. Clients may submit only `owner/repo`; an optional `githubIntegrationId` remains useful as an explicit user or webhook fence, but is no longer required for ordinary unambiguous creation.

## Dependency

Depends on #5584 for authoritative live resolution and the returned Kilo `platformIntegrationId`.

## What changes

- Canonicalize every GitHub session request through Git Token Service before profile resolution, operation-ledger admission, allocation, or Durable Object registration.
- Add/replace `repository.githubIntegrationId` with the resolved Kilo integration ID.
- Persist that canonical repository identity through the existing session metadata and operation fingerprint.
- For clone continuations, map the source Kilo session to its source Cloud Agent session through Session Ingest.
- Read the source session repository identity from its Durable Object and inherit its installation pin.
- Reject a caller-provided repository or installation that conflicts with the source session.
- Resolve legacy unpinned source sessions live and persist the result on the destination.

## What stays unchanged

- No GitHub token is persisted; the canonicalization token is discarded and workspace preparation resolves fresh authorization later.
- Personal sessions and non-GitHub providers retain existing behavior.
- Authoritative webhook/review/finding callers may still supply an expected integration ID.
- Session Ingest adds only optional sanitized repository data to an existing RPC result.

## Failure policy

Ambiguous, inaccessible, or mismatched repositories are user errors. Provider, database, binding, or source-metadata uncertainty is service-unavailable. Cloud Agent never allocates or fingerprints a session before this decision is complete.

## Review guide

1. Review `canonicalizeRepositoryBeforeSessionCreation` and its error mapping.
2. Verify both `start` and `prepareSession` call it before profile resolution and session registration.
3. Follow clone source identity through the additive Session Ingest RPC response and source Durable Object metadata.
4. Verify operation fingerprints and persisted metadata receive the canonical request, with no token field.

## Replaces

Replaces #5546, which made mobile infer continuation installation identity from repository DTOs.

## Validation

- Cloud Agent Next: 170 files, 3,237 tests passed, 3 skipped
- Session Ingest: 29 files, 920 tests passed, 3 skipped
- 189 focused canonicalization/continuation/persistence tests
- Root typecheck across 59 workspaces
- Root lint with zero errors/warnings
- Cloud Agent, Session Ingest, and contract formatting/typechecks
- `git diff --check`