### PR TITLE
feat(ai-gateway): route free MiniMax models through Vercel

### DIFF
--- a/apps/web/src/lib/ai-gateway/models.test.ts
+++ b/apps/web/src/lib/ai-gateway/models.test.ts
@@ -22,6 +22,7 @@ import { gpt_5_6_sol_discounted_model } from './providers/openai-exclusive';
 import { tencent_hy3_free_model } from './providers/tencent';
 import { gemma_4_26b_a4b_it_free_model } from './providers/google';
 import { longcat_2_free_model } from './providers/longcat';
+import { minimax_m27_free_model, minimax_m3_free_model } from './providers/minimax';
 import { getRandomNumber } from './getRandomNumber';
 
 describe('rate-limited Kilo-exclusive models', () => {
@@ -102,6 +103,44 @@ describe('isFreeModel', () => {
       expect(preferredModels).toContain(longcat_2_free_model.public_id);
       expect(getAiSdkProvider(longcat_2_free_model.public_id, null)).toBeUndefined();
     });
+
+    test.each([
+      {
+        name: 'MiniMax M3',
+        model: minimax_m3_free_model,
+        publicId: 'minimax/minimax-m3:free',
+        internalId: 'minimax/minimax-m3-free',
+        contextLength: 1_048_576,
+        vision: true,
+      },
+      {
+        name: 'MiniMax M2.7',
+        model: minimax_m27_free_model,
+        publicId: 'minimax/minimax-m2.7:free',
+        internalId: 'minimax/minimax-m2.7-free',
+        contextLength: 196_608,
+        vision: false,
+      },
+    ])(
+      'registers $name as a free Vercel GMI Cloud model',
+      async ({ model, publicId, internalId, contextLength, vision }) => {
+        expect(findKiloExclusiveModel(model.public_id)).toBe(model);
+        expect(await isFreeModel(model.public_id)).toBe(true);
+        expect(model).toMatchObject({
+          public_id: publicId,
+          internal_id: internalId,
+          gateway: 'vercel',
+          context_length: contextLength,
+          max_completion_tokens: contextLength,
+          status: 'public',
+          inference_provider_restriction: ['gmicloud'],
+        });
+        expect(model.flags.includes('reasoning')).toBe(true);
+        expect(model.flags.includes('vision')).toBe(vision);
+        expect(getInferenceProvider(model)?.slug).toBe('gmicloud');
+        expect(preferredModels).not.toContain(model.public_id);
+      }
+    );
 
     test('routes the discounted Claude Opus offering through the stealth provider identity', () => {
       expect(getInferenceProvider(claude_opus_4_7_stealth_model)?.slug).toBe('stealth');

--- a/apps/web/src/lib/ai-gateway/models.ts
+++ b/apps/web/src/lib/ai-gateway/models.ts
@@ -18,7 +18,11 @@ import {
 } from '@/lib/ai-gateway/providers/anthropic.constants';
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { isMuseModel } from '@/lib/ai-gateway/providers/meta';
-import { MINIMAX_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/minimax';
+import {
+  MINIMAX_CURRENT_MODEL_ID,
+  minimax_m27_free_model,
+  minimax_m3_free_model,
+} from '@/lib/ai-gateway/providers/minimax';
 import { KIMI_CURRENT_MODEL_ID } from '@/lib/ai-gateway/providers/moonshotai';
 import { gemma_4_26b_a4b_it_free_model, isGeminiModel } from '@/lib/ai-gateway/providers/google';
 import { qwen36_plus_stealth_model } from '@/lib/ai-gateway/providers/qwen';
@@ -140,6 +144,8 @@ export function isKiloExclusiveRateLimitedModel(model: string): boolean {
 
 export const kiloExclusiveModels = [
   gemma_4_26b_a4b_it_free_model,
+  minimax_m3_free_model,
+  minimax_m27_free_model,
   qwen36_plus_stealth_model,
   gpt_5_6_sol_discounted_model,
   claude_opus_4_8_stealth_model,

--- a/apps/web/src/lib/ai-gateway/providers/get-provider.local-fake.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/get-provider.local-fake.test.ts
@@ -1,6 +1,6 @@
 import { afterEach, describe, expect, test } from '@jest/globals';
 import { getProvider } from '@/lib/ai-gateway/providers/get-provider';
-import { OPENROUTER } from '@/lib/ai-gateway/providers/provider-definitions';
+import { OPENROUTER, VERCEL_AI_GATEWAY } from '@/lib/ai-gateway/providers/provider-definitions';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
 import type { User } from '@kilocode/db/schema';
 
@@ -110,4 +110,16 @@ describe('getProvider local fake deterministic routing', () => {
     });
     missingUrl.restore();
   });
+
+  test.each(['minimax/minimax-m3:free', 'minimax/minimax-m2.7:free'])(
+    'routes %s through Vercel AI Gateway',
+    async model => {
+      expect(await getProvider(providerInput(model))).toEqual({
+        kind: 'provider',
+        provider: VERCEL_AI_GATEWAY,
+        userByok: null,
+        bypassAccessCheck: false,
+      });
+    }
+  );
 });

--- a/apps/web/src/lib/ai-gateway/providers/minimax.ts
+++ b/apps/web/src/lib/ai-gateway/providers/minimax.ts
@@ -1,4 +1,37 @@
+import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+
 export const MINIMAX_CURRENT_MODEL_ID = 'minimax/minimax-m3';
+
+// Remove both routing overrides when Vercel's GMI Cloud promotion ends 2026-09-06.
+export const minimax_m3_free_model: KiloExclusiveModel = {
+  public_id: 'minimax/minimax-m3:free',
+  display_name: 'MiniMax: MiniMax M3 (free)',
+  description:
+    'MiniMax-M3 is a frontier-class foundation model that combines a 1M-token context window, coding and agentic performance, and native multimodality. Available free through Vercel AI Gateway via GMI Cloud until September 6, 2026.',
+  context_length: 1_048_576,
+  max_completion_tokens: 1_048_576,
+  status: 'public',
+  flags: ['reasoning', 'vision'],
+  gateway: 'vercel',
+  internal_id: 'minimax/minimax-m3-free',
+  pricing: null,
+  inference_provider_restriction: ['gmicloud'],
+};
+
+export const minimax_m27_free_model: KiloExclusiveModel = {
+  public_id: 'minimax/minimax-m2.7:free',
+  display_name: 'MiniMax: MiniMax M2.7 (free)',
+  description:
+    'MiniMax M2.7 is designed for real-world software engineering, including full-project delivery, log analysis and debugging, code security, and machine learning. Available free through Vercel AI Gateway via GMI Cloud until September 6, 2026.',
+  context_length: 196_608,
+  max_completion_tokens: 196_608,
+  status: 'public',
+  flags: ['reasoning'],
+  gateway: 'vercel',
+  internal_id: 'minimax/minimax-m2.7-free',
+  pricing: null,
+  inference_provider_restriction: ['gmicloud'],
+};
 
 export function isMinimaxModel(model: string) {
   return model.includes('minimax');

--- a/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/openrouter/index.test.ts
@@ -17,6 +17,7 @@ import {
 import type { KiloExclusiveModel } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
 import { isFableModel } from '@/lib/ai-gateway/providers/anthropic.constants';
 import { KILO_AUTO_EFFICIENT_MODEL } from '@/lib/ai-gateway/auto-model';
+import { minimax_m27_free_model, minimax_m3_free_model } from '@/lib/ai-gateway/providers/minimax';
 
 jest.mock('@/lib/ai-gateway/providers/gateway-models-cache', () => ({
   getOpenRouterModelsMetadataFromDatabase: jest.fn(() => Promise.resolve({})),
@@ -221,6 +222,33 @@ describe('auto models', () => {
     expect(models.data.some(model => model.id === 'vendor/model')).toBe(true);
     expect(models.data.some(model => model.id === 'vendor/model:batch')).toBe(false);
   });
+});
+
+describe('MiniMax Vercel promotion models', () => {
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it.each([minimax_m3_free_model, minimax_m27_free_model])(
+    'replaces the OpenRouter catalog entry for $public_id without duplicating it',
+    async model => {
+      global.fetch = jest.fn(() =>
+        Promise.resolve(
+          createMockResponse({
+            jsonData: {
+              data: [buildModel({ id: model.public_id, name: 'OpenRouter catalog name' })],
+            },
+          })
+        )
+      ) as unknown as typeof fetch;
+
+      const models = await getEnhancedOpenRouterModels();
+      const matches = models.data.filter(entry => entry.id === model.public_id);
+
+      expect(matches).toHaveLength(1);
+      expect(matches[0]?.name).toBe(model.display_name);
+    }
+  );
 });
 
 describe('reasoning variants', () => {

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.test.ts
@@ -11,6 +11,8 @@ import {
 } from '@/lib/ai-gateway/providers/vercel';
 import { getRandomNumber } from '@/lib/ai-gateway/getRandomNumber';
 import type { GatewayRequest } from '@/lib/ai-gateway/providers/openrouter/types';
+import { applyKiloExclusiveModelSettings } from '@/lib/ai-gateway/providers/kilo-exclusive-model';
+import { minimax_m27_free_model, minimax_m3_free_model } from '@/lib/ai-gateway/providers/minimax';
 
 const originalFriendliApiKey = process.env.FRIENDLI_API_KEY;
 const originalOpenAiApiKey = process.env.OPENAI_API_KEY;
@@ -192,6 +194,37 @@ describe('convertProviderOptions', () => {
       only: ['future-provider'],
       order: ['another-future-provider'],
     });
+  });
+
+  it('filters ignored providers from an explicit only list when metadata is unavailable', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'vendor/model',
+        messages: [{ role: 'user', content: 'hello' }],
+        provider: {
+          only: ['gmicloud', 'openai'],
+          ignore: ['openai'],
+        },
+      },
+    };
+
+    expect(convertProviderOptions(request, null).gateway?.only).toEqual(['gmicloud']);
+  });
+
+  it('still rejects ignore-only routing when metadata is unavailable', () => {
+    const request: GatewayRequest = {
+      kind: 'chat_completions',
+      body: {
+        model: 'vendor/model',
+        messages: [{ role: 'user', content: 'hello' }],
+        provider: { ignore: ['openai'] },
+      },
+    };
+
+    expect(() => convertProviderOptions(request, null)).toThrow(
+      'Vercel inference provider data became unavailable during request transform'
+    );
   });
 });
 
@@ -416,6 +449,46 @@ describe('applyVercelSettings managed requests', () => {
       },
     };
   }
+
+  function managedRequestForApi(kind: GatewayRequest['kind'], model: string): GatewayRequest {
+    const provider = { ignore: ['openai'] };
+    if (kind === 'responses') {
+      return { kind, body: { model, input: 'hello', provider } };
+    }
+    if (kind === 'messages') {
+      return {
+        kind,
+        body: {
+          model,
+          max_tokens: 128,
+          messages: [{ role: 'user', content: 'hello' }],
+          provider,
+        },
+      };
+    }
+    return {
+      kind,
+      body: { model, messages: [{ role: 'user', content: 'hello' }], provider },
+    };
+  }
+
+  it.each(
+    [minimax_m3_free_model, minimax_m27_free_model].flatMap(model =>
+      (['chat_completions', 'messages', 'responses'] as const).map(kind => ({ model, kind }))
+    )
+  )(
+    'routes $model.public_id $kind requests with unrelated ignores when metadata is unavailable',
+    async ({ model, kind }) => {
+      const request = managedRequestForApi(kind, model.public_id);
+      applyKiloExclusiveModelSettings(request, model);
+
+      await applyManagedVercelSettings(model.public_id, request, null);
+
+      expect(request.body.model).toBe(model.internal_id);
+      expect(request.body.provider).toBeUndefined();
+      expect(request.body.providerOptions?.gateway?.only).toEqual(['gmicloud']);
+    }
+  );
 
   it('does not add managed Friendli credentials from the environment', async () => {
     process.env.FRIENDLI_API_KEY = 'friendli-managed-key';

--- a/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
+++ b/apps/web/src/lib/ai-gateway/providers/vercel/index.ts
@@ -145,6 +145,13 @@ export function convertProviderOptions(
       return provider?.only?.map(openRouterToVercelInferenceProviderId);
     }
     if (!vercelInferenceProviders) {
+      if (provider.only) {
+        return getVercelInferenceProvidersExcludingIgnored(
+          provider.ignore,
+          provider.only,
+          provider.only.map(openRouterToVercelInferenceProviderId)
+        );
+      }
       throw new Error('Vercel inference provider data became unavailable during request transform');
     }
     return getVercelInferenceProvidersExcludingIgnored(


### PR DESCRIPTION
## Summary

- add the existing MiniMax M3 and M2.7 free model IDs as zero-priced Kilo catalog overrides
- route only those free variants through Vercel AI Gateway's GMI Cloud provider while leaving paid MiniMax models unchanged
- preserve routing when Vercel provider metadata is unavailable, including provider ignore filters
- cover catalog precedence, OpenRouter exclusion, Vercel mapping, and Chat Completions, Messages, and Responses routing

## Verification

- [x] Selected MiniMax M3 (free) in the Kilo TUI against the local Cloud server and received a response; server logs showed Vercel routing, GMI Cloud selection, and an upstream 200 response
- [x] Sent MiniMax M2.7 (free) through the local Cloud route and received `M2.7 OK`; Vercel resolved it to GMI Cloud with HTTP 200 and zero reported cost

## Visual Changes

<img width="1044" height="745" alt="Screenshot 2026-08-27 at 13 58 17" src="https://github.com/user-attachments/assets/d3bce0fc-ac06-4f15-a303-0a717c1f4b8b" />

## Reviewer Notes

- The Vercel/GMI Cloud promotion ends September 6, 2026. Remove or reassess the two routing overrides after the promotion.
- Automated verification: 374 tests across 11 AI Gateway suites, web typecheck, changed-file lint, formatting, and whitespace checks passed.
- The verification shell used Node 22.23.2 although the repository requests Node 24; all listed checks completed successfully.
