### PR TITLE
feat(cloud-agent): resolve and inherit GitHub installations server-side

### DIFF
--- a/packages/session-ingest-contracts/src/rpc-contract.ts
+++ b/packages/session-ingest-contracts/src/rpc-contract.ts
@@ -93,6 +93,19 @@ export type ResolveCloudAgentRootSessionForKiloSessionResult = {
   repository?: { type: 'github'; repo: string };
 } | null;
 
+export const resolveAuthorizedSessionSourceSchema = resolveCloudAgentRootSessionSchema;
+export type ResolveAuthorizedSessionSourceParams = z.input<
+  typeof resolveAuthorizedSessionSourceSchema
+>;
+export type AuthorizedSessionSourceDescriptor = {
+  organizationId: string | null;
+  repository?:
+    | { type: 'github'; repo: string }
+    | { type: 'git'; url: string; platform?: 'gitlab' | 'bitbucket' };
+  cloudAgentSessionId?: string;
+};
+export type ResolveAuthorizedSessionSourceResult = AuthorizedSessionSourceDescriptor | null;
+
 export const kiloSdkSessionInfoSchema = z.object({
   id: sessionIdSchema,
   slug: z.string(),
@@ -746,6 +759,10 @@ export type SessionIngestRpcMethods = {
   resolveCloudAgentRootSessionForKiloSession: (
     params: ResolveCloudAgentRootSessionForKiloSessionParams
   ) => Promise<ResolveCloudAgentRootSessionForKiloSessionResult>;
+  /** Optional while older Session Ingest deployments remain in service. */
+  resolveAuthorizedSessionSource?: (
+    params: ResolveAuthorizedSessionSourceParams
+  ) => Promise<ResolveAuthorizedSessionSourceResult>;
   getCloudAgentRootSessionSnapshot: (
     params: GetCloudAgentRootSessionSnapshotParams
   ) => Promise<GetCloudAgentRootSessionSnapshotResult>;

--- a/packages/session-ingest-contracts/src/rpc-contract.ts
+++ b/packages/session-ingest-contracts/src/rpc-contract.ts
@@ -85,6 +85,12 @@ export type ResolveCloudAgentRootSessionForKiloSessionParams = z.input<
 >;
 export type ResolveCloudAgentRootSessionForKiloSessionResult = {
   cloudAgentSessionId: string;
+  /**
+   * Sanitized repository identity recorded for the authorized root. Optional
+   * for compatibility with roots and Session Ingest workers created before
+   * repository identity was returned by this RPC.
+   */
+  repository?: { type: 'github'; repo: string };
 } | null;
 
 export const kiloSdkSessionInfoSchema = z.object({

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.test.ts
@@ -20,6 +20,7 @@ const {
   mergeProfileConfigurationMock,
   assertKiloModelAvailableMock,
   assertBitbucketRepositoryAccessMock,
+  canonicalizeRepositoryMock,
   assertOrganizationMembershipMock,
   registerNewSessionMock,
   startNewSessionMock,
@@ -28,6 +29,7 @@ const {
   mergeProfileConfigurationMock: vi.fn().mockResolvedValue({}),
   assertKiloModelAvailableMock: vi.fn().mockResolvedValue(undefined),
   assertBitbucketRepositoryAccessMock: vi.fn().mockResolvedValue(undefined),
+  canonicalizeRepositoryMock: vi.fn(async ({ request }) => request),
   assertOrganizationMembershipMock: vi.fn().mockResolvedValue(undefined),
   registerNewSessionMock: vi.fn().mockResolvedValue({
     cloudAgentSessionId: 'agent_12345678-1234-1234-1234-123456789abc',
@@ -76,6 +78,7 @@ vi.mock('../../model-validation.js', () => ({
 
 vi.mock('../../session/validate-repository-access.js', () => ({
   assertRepositoryAccessBeforeSessionCreation: assertBitbucketRepositoryAccessMock,
+  canonicalizeRepositoryBeforeSessionCreation: canonicalizeRepositoryMock,
 }));
 
 vi.mock('./organization-membership.js', () => ({
@@ -126,6 +129,7 @@ describe('prepareSession operation-ledger admission gate', () => {
     mergeProfileConfigurationMock.mockResolvedValue({});
     assertKiloModelAvailableMock.mockResolvedValue(undefined);
     assertBitbucketRepositoryAccessMock.mockResolvedValue(undefined);
+    canonicalizeRepositoryMock.mockImplementation(async ({ request }) => request);
     assertOrganizationMembershipMock.mockResolvedValue(undefined);
     registerNewSessionMock.mockResolvedValue({
       cloudAgentSessionId: 'agent_12345678-1234-1234-1234-123456789abc',

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -342,12 +342,15 @@ const prepareSessionHandler = internalApiProtectedProcedure
           input.kilocodeOrganizationId
         );
       }
-      const canonicalRequest = await canonicalizeRepositoryBeforeSessionCreation({
-        env: ctx.env,
-        userId: ctx.userId,
-        orgId: input.kilocodeOrganizationId,
-        request,
-      });
+      const ledgerBackedCreate = input.autoInitiate === true && request.options?.operationKey;
+      const canonicalRequest = ledgerBackedCreate
+        ? request
+        : await canonicalizeRepositoryBeforeSessionCreation({
+            env: ctx.env,
+            userId: ctx.userId,
+            orgId: input.kilocodeOrganizationId,
+            request,
+          });
       await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,

--- a/services/cloud-agent-next/src/router/handlers/session-prepare.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-prepare.ts
@@ -47,7 +47,10 @@ import type { Env } from '../../types.js';
 import type { SessionProfileBundle } from '../../session-profile.js';
 import type { SessionCreateRequest } from '../../session/session-requests.js';
 import { assertKiloModelAvailable } from '../../model-validation.js';
-import { assertRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
+import {
+  assertRepositoryAccessBeforeSessionCreation,
+  canonicalizeRepositoryBeforeSessionCreation,
+} from '../../session/validate-repository-access.js';
 import { assertOrganizationMembership } from './organization-membership.js';
 
 type SessionPrepareHandlers = {
@@ -339,14 +342,24 @@ const prepareSessionHandler = internalApiProtectedProcedure
           input.kilocodeOrganizationId
         );
       }
+      const canonicalRequest = await canonicalizeRepositoryBeforeSessionCreation({
+        env: ctx.env,
+        userId: ctx.userId,
+        orgId: input.kilocodeOrganizationId,
+        request,
+      });
       await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,
         orgId: input.kilocodeOrganizationId,
-        repository: request.repository,
+        repository: canonicalRequest.repository,
       });
       const policy = profileResolutionPolicyForSessionCreateOrigin(input.createdOnPlatform);
-      const requestWithProfile = await resolveEffectiveSessionConfiguration(ctx, request, policy);
+      const requestWithProfile = await resolveEffectiveSessionConfiguration(
+        ctx,
+        canonicalRequest,
+        policy
+      );
       assertModeAvailableForProfile(
         requestWithProfile.agent.mode,
         requestWithProfile.profile?.resolved ?? {}

--- a/services/cloud-agent-next/src/router/handlers/session-start.ts
+++ b/services/cloud-agent-next/src/router/handlers/session-start.ts
@@ -24,7 +24,10 @@ import {
 } from './session-prepare.js';
 import type { SessionCreateRequest } from '../../session/session-requests.js';
 import { assertKiloModelAvailable } from '../../model-validation.js';
-import { assertRepositoryAccessBeforeSessionCreation } from '../../session/validate-repository-access.js';
+import {
+  assertRepositoryAccessBeforeSessionCreation,
+  canonicalizeRepositoryBeforeSessionCreation,
+} from '../../session/validate-repository-access.js';
 import { assertOrganizationMembership } from './organization-membership.js';
 
 type SessionStartHandlers = {
@@ -106,11 +109,17 @@ const startSessionHandler = protectedProcedure
         db = getPgDb(ctx.env);
         await assertOrganizationMembership(db, ctx.userId, organizationId);
       }
+      const canonicalRequest = await canonicalizeRepositoryBeforeSessionCreation({
+        env: ctx.env,
+        userId: ctx.userId,
+        orgId: organizationId,
+        request,
+      });
       await assertRepositoryAccessBeforeSessionCreation({
         env: ctx.env,
         userId: ctx.userId,
         orgId: organizationId,
-        repository: request.repository,
+        repository: canonicalRequest.repository,
       });
 
       const policy = profileResolutionPolicyForSessionCreateOrigin(
@@ -118,7 +127,7 @@ const startSessionHandler = protectedProcedure
       );
       const requestWithProfile = await resolveEffectiveSessionConfiguration(
         ctx,
-        request,
+        canonicalRequest,
         policy,
         db
       );

--- a/services/cloud-agent-next/src/sandbox-session/attach-payload.test.ts
+++ b/services/cloud-agent-next/src/sandbox-session/attach-payload.test.ts
@@ -119,23 +119,34 @@ describe('buildSessionAttachPayload', () => {
       },
       auth: { kiloSessionId: 'kilo_1' },
       agent: { mode: 'code', model: 'kilo/test' },
-      repository: { type: 'github', repo: 'acme/demo' },
+      repository: {
+        type: 'github',
+        repo: 'acme/demo',
+        githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      },
       workspace: { workspacePath: '/workspace/a' },
       lifecycle: { version: 1, timestamp: 1 },
     });
     const payload = buildSessionAttachPayload(metadata);
     expect(payload.git?.token).toBeUndefined();
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'ghs_resolved',
+      platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      installationId: '1',
+      appType: 'standard',
+      accountLogin: 'acme',
+    });
     const filled = await fillAttachGitToken(metadata, payload, {
       GIT_TOKEN_SERVICE: {
-        getTokenForRepo: vi.fn().mockResolvedValue({
-          success: true,
-          token: 'ghs_resolved',
-          installationId: '1',
-          appType: 'standard',
-          accountLogin: 'acme',
-        }),
+        getTokenForRepo,
       } as never,
     });
     expect(filled.git?.token).toBe('ghs_resolved');
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/demo',
+      userId: 'user-1',
+      expectedIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+    });
   });
 });

--- a/services/cloud-agent-next/src/sandbox-session/attach-payload.ts
+++ b/services/cloud-agent-next/src/sandbox-session/attach-payload.ts
@@ -86,6 +86,9 @@ export async function fillAttachGitToken(
     githubRepo: repository.repo,
     userId: metadata.identity.userId,
     ...(metadata.identity.orgId ? { orgId: metadata.identity.orgId } : {}),
+    ...(repository.githubIntegrationId
+      ? { expectedIntegrationId: repository.githubIntegrationId }
+      : {}),
   });
   if (!resolved.success) return payload;
   return { ...payload, git: { ...payload.git, token: resolved.value.token } };

--- a/services/cloud-agent-next/src/services/git-token-service-client.test.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.test.ts
@@ -5,9 +5,12 @@ import {
   issueCloudAgentGitHubSessionCapability,
   issueCloudAgentGitLabSessionCapability,
   resolveCloudAgentGitHubAuthForRepo,
+  resolveGitHubTokenForRepo,
   resolveManagedBitbucketToken,
   resolveManagedGitLabToken,
 } from './git-token-service-client.js';
+
+const platformIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
 
 vi.mock('../logger.js', () => ({
   logger: {
@@ -35,6 +38,31 @@ function createGitTokenService() {
 function createEnv(service: Partial<GitTokenService>) {
   return { GIT_TOKEN_SERVICE: service as GitTokenService };
 }
+
+describe('resolveGitHubTokenForRepo', () => {
+  it('returns a retryable incompatibility when a rolling-deploy success omits its UUID pin', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'installation-token',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+
+    await expect(
+      resolveGitHubTokenForRepo(createEnv({ getTokenForRepo }), {
+        githubRepo: 'acme/repo',
+        userId: 'user_1',
+      })
+    ).resolves.toEqual({
+      success: false,
+      error: {
+        reason: 'service_incompatible',
+        message: 'git-token-service returned an incompatible success response',
+      },
+    });
+  });
+});
 
 describe('resolveManagedBitbucketToken', () => {
   const repositoryParams = {
@@ -196,6 +224,7 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
     const getTokenForRepo = vi.fn().mockResolvedValue({
       success: true,
       token: 'installation-token',
+      platformIntegrationId,
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -213,6 +242,7 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
       success: true,
       value: {
         githubToken: 'installation-token',
+        platformIntegrationId,
         installationId: '123',
         accountLogin: 'acme',
         appType: 'standard',
@@ -225,6 +255,7 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
     const issueGitHubSessionCapability = vi.fn().mockResolvedValue({
       success: true,
       capability: 'kgh2.opaque',
+      platformIntegrationId,
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -267,6 +298,7 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
     const issueGitHubSessionCapability = vi.fn().mockResolvedValue({
       success: true,
       capability: 'kgh2.opaque',
+      platformIntegrationId,
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -328,6 +360,7 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
     const getCloudAgentAuthForRepo = vi.fn().mockResolvedValue({
       success: true,
       githubToken: 'user-token',
+      platformIntegrationId,
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -350,6 +383,7 @@ describe('issueCloudAgentGitHubSessionCapability', () => {
       success: true,
       value: {
         githubToken: 'user-token',
+        platformIntegrationId,
         installationId: '123',
         accountLogin: 'acme',
         appType: 'standard',
@@ -460,6 +494,7 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
     const getCloudAgentAuthForRepo = vi.fn().mockResolvedValue({
       success: true,
       githubToken: 'user-token',
+      platformIntegrationId,
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -494,6 +529,7 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
     const getCloudAgentAuthForRepo = vi.fn().mockResolvedValue({
       success: true,
       githubToken: 'installation-token',
+      platformIntegrationId,
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -517,6 +553,7 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
       success: true,
       value: {
         githubToken: 'installation-token',
+        platformIntegrationId,
         installationId: '123',
         accountLogin: 'acme',
         appType: 'standard',
@@ -534,6 +571,7 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
     const getTokenForRepo = vi.fn().mockResolvedValue({
       success: true,
       token: 'installation-token',
+      platformIntegrationId,
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -572,6 +610,7 @@ describe('resolveCloudAgentGitHubAuthForRepo', () => {
     const getTokenForRepo = vi.fn().mockResolvedValue({
       success: true,
       token: 'installation-token',
+      platformIntegrationId,
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',

--- a/services/cloud-agent-next/src/services/git-token-service-client.ts
+++ b/services/cloud-agent-next/src/services/git-token-service-client.ts
@@ -1,4 +1,5 @@
 import { logger } from '../logger.js';
+import { z } from 'zod';
 import type {
   BitbucketTokenFailureReason,
   GitAuthorConfig,
@@ -10,6 +11,25 @@ import type {
 type GitTokenServiceEnv = {
   GIT_TOKEN_SERVICE?: GitTokenService;
 };
+
+const platformIntegrationIdSchema = z.string().uuid();
+
+function incompatibleGitHubServiceResult(): {
+  success: false;
+  error: ResolveGitHubTokenError;
+} {
+  return {
+    success: false,
+    error: {
+      reason: 'service_incompatible',
+      message: 'git-token-service returned an incompatible success response',
+    },
+  };
+}
+
+function validPlatformIntegrationId(value: unknown): value is string {
+  return platformIntegrationIdSchema.safeParse(value).success;
+}
 
 export type ResolvedGitHubToken = {
   token: string;
@@ -44,6 +64,10 @@ export async function resolveGitHubTokenForRepo(
     }
     const result = await env.GIT_TOKEN_SERVICE.getTokenForRepo(params);
     if (result.success) {
+      if (!validPlatformIntegrationId(result.platformIntegrationId)) {
+        logger.warn('GitHub token RPC success omitted a valid platform integration ID');
+        return incompatibleGitHubServiceResult();
+      }
       logger
         .withFields({
           installationId: result.installationId,
@@ -184,6 +208,10 @@ export async function resolveCloudAgentGitHubAuthForRepo(
         },
       };
     }
+    if (!validPlatformIntegrationId(result.platformIntegrationId)) {
+      logger.warn('Managed GitHub auth RPC success omitted a valid platform integration ID');
+      return incompatibleGitHubServiceResult();
+    }
     logger
       .withFields({
         installationId: result.installationId,
@@ -259,6 +287,10 @@ export async function issueCloudAgentGitHubSessionCapability(
           message: `GitHub managed auth lookup failed (${result.reason})`,
         },
       };
+    }
+    if (!validPlatformIntegrationId(result.platformIntegrationId)) {
+      logger.warn('GitHub capability RPC success omitted a valid platform integration ID');
+      return incompatibleGitHubServiceResult();
     }
     logger
       .withFields({

--- a/services/cloud-agent-next/src/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session-prepare.test.ts
@@ -171,6 +171,7 @@ function createInternalApiContext(options: {
   doStub?: ReturnType<typeof createMockDOStub>;
   getTokenForRepo?: ReturnType<typeof vi.fn>;
   getBitbucketToken?: ReturnType<typeof vi.fn>;
+  resolveCloudAgentRootSessionForKiloSession?: ReturnType<typeof vi.fn>;
   githubTokenContainmentOrgIds?: string;
   gitlabTokenContainmentOrgIds?: string;
   kilocodeTokenContainmentOrgIds?: string;
@@ -222,6 +223,8 @@ function createInternalApiContext(options: {
         fetch: vi.fn(),
         createSessionForCloudAgent: vi.fn().mockResolvedValue({ created: true }),
         deleteSessionForCloudAgent: vi.fn().mockResolvedValue({ deleted: true }),
+        resolveCloudAgentRootSessionForKiloSession:
+          options.resolveCloudAgentRootSessionForKiloSession ?? vi.fn().mockResolvedValue(null),
       } as unknown as TRPCContext['env']['SESSION_INGEST'],
       INTERNAL_API_SECRET: effectiveInternalApiSecret,
       NEXTAUTH_SECRET: 'test-secret',
@@ -233,6 +236,7 @@ function createInternalApiContext(options: {
           vi.fn().mockResolvedValue({
             success: true,
             token: 'managed-github-token',
+            platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
             installationId: '123',
             accountLogin: 'acme',
             appType: 'standard',
@@ -544,6 +548,7 @@ describe('prepareSession endpoint', () => {
         repository: {
           type: 'github',
           repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
           branch: 'feature/test-branch',
         },
         profile: {
@@ -1415,6 +1420,7 @@ describe('start endpoint', () => {
     const getTokenForRepo = vi.fn().mockResolvedValue({
       success: true,
       token: 'managed-github-token',
+      platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
       installationId: '123',
       accountLogin: 'acme',
       appType: 'standard',
@@ -1436,6 +1442,36 @@ describe('start endpoint', () => {
     expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
       expect.objectContaining({
         repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+      })
+    );
+  });
+
+  it('canonicalizes unpinned grouped starts before persisting session metadata', async () => {
+    const doStub = createMockDOStub();
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'managed-github-token',
+      platformIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+      installationId: '456',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+    const caller = appRouter.createCaller(createInternalApiContext({ doStub, getTokenForRepo }));
+
+    await caller.start({
+      message: { prompt: 'Resolve this repository server-side' },
+      agent: { mode: 'code', model: 'anthropic/claude-sonnet-4-20250514' },
+      repository: { type: 'github', repo: 'acme/repo' },
+    });
+
+    expect(getTokenForRepo).toHaveBeenCalledOnce();
+    expect(doStub.createSessionWithInitialAdmission).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repository: {
+          type: 'github',
+          repo: 'acme/repo',
+          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+        },
       })
     );
   });

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -585,6 +585,18 @@ function createCloneMetadata(): CloudAgentSessionState {
 describe('SessionService.resolveWorkspaceTokens', () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    tokenMocks.resolveCloudAgentGitHubAuthForRepo.mockResolvedValue({
+      success: true,
+      value: {
+        githubToken: 'resolved-gh-token',
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+        installationId: '123',
+        accountLogin: 'acme',
+        appType: 'standard',
+        source: 'installation',
+        gitAuthor: { name: 'kiloconnect[bot]', email: 'bot@example.com' },
+      },
+    });
     tokenMocks.resolveManagedBitbucketToken.mockResolvedValue({
       success: true,
       token: 'opaque-workspace-token',
@@ -664,6 +676,38 @@ describe('SessionService.resolveWorkspaceTokens', () => {
       retryable: true,
       message: 'Bitbucket repository authorization failed (service_not_configured).',
     });
+  });
+
+  it('keeps rolling-deploy GitHub service incompatibility retryable', async () => {
+    tokenMocks.resolveCloudAgentGitHubAuthForRepo.mockResolvedValueOnce({
+      success: false,
+      error: {
+        reason: 'service_incompatible',
+        message: 'git-token-service returned an incompatible success response',
+      },
+    });
+    const integrationId = '123e4567-e89b-12d3-a456-426614174022';
+    const metadata = parseSessionMetadata({
+      metadataSchemaVersion: 2,
+      identity: { sessionId: 'agent_test', userId: 'user_test' },
+      auth: { kiloSessionId: 'kilo-session', kilocodeToken: 'kilo-token' },
+      agent: { mode: 'code', model: 'kilo/test-model' },
+      repository: { type: 'github', repo: 'acme/repo', githubIntegrationId: integrationId },
+      lifecycle: { version: 1, timestamp: 1 },
+    });
+
+    await expect(
+      new SessionService().resolveWorkspaceTokens(createEnv(), metadata, 'ses-abcdef')
+    ).rejects.toMatchObject({
+      code: 'WORKSPACE_SETUP_FAILED',
+      retryable: true,
+      message:
+        'GitHub token or active app installation required for this repository (service_incompatible)',
+    });
+    expect(tokenMocks.resolveCloudAgentGitHubAuthForRepo).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ expectedIntegrationId: integrationId })
+    );
   });
 });
 

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -151,7 +151,8 @@ function isRetryableKiloCapabilityIssuanceFailure(reason: string): boolean {
   return (
     reason === 'rpc_error' ||
     reason === 'service_not_configured' ||
-    reason === 'temporarily_unavailable'
+    reason === 'temporarily_unavailable' ||
+    reason === 'service_incompatible'
   );
 }
 
@@ -1748,9 +1749,10 @@ export class SessionService {
           })
         : await resolveCloudAgentGitHubAuthForRepo(env, authParams);
       if (!result.success) {
-        throw ExecutionError.invalidRequest(
-          `GitHub token or active app installation required for this repository (${result.error.reason})`
-        );
+        const message = `GitHub token or active app installation required for this repository (${result.error.reason})`;
+        throw isRetryableKiloCapabilityIssuanceFailure(result.error.reason)
+          ? ExecutionError.workspaceSetupFailed(message)
+          : ExecutionError.invalidRequest(message);
       }
       githubToken =
         'capability' in result.value ? result.value.capability : result.value.githubToken;

--- a/services/cloud-agent-next/src/session/session-prepare.test.ts
+++ b/services/cloud-agent-next/src/session/session-prepare.test.ts
@@ -24,6 +24,7 @@ import {
   sessionCreateIntentFingerprint,
   SESSION_CREATE_ABANDON_AFTER_SECONDS,
   SESSION_CREATE_ABANDONED_OUTCOME_CODE,
+  SESSION_CREATE_CANONICAL_REPOSITORY_KEY,
   SESSION_CREATE_INTENT_FINGERPRINT_KEY,
   SESSION_CREATE_TOMBSTONED_IDS_KEY,
   type SessionRegistrationContext,
@@ -48,7 +49,7 @@ const {
   admitOperationMock: vi.fn(),
   settleOperationMock: vi.fn().mockResolvedValue({ settled: true }),
   markReconcilePendingMock: vi.fn().mockResolvedValue({}),
-  recordOperationProgressMock: vi.fn().mockResolvedValue(undefined),
+  recordOperationProgressMock: vi.fn().mockResolvedValue({}),
   getPgDbMock: vi.fn(),
   createCliSessionMock: vi.fn().mockResolvedValue(undefined),
   deleteCliSessionMock: vi.fn().mockResolvedValue(undefined),
@@ -126,6 +127,7 @@ const WORKSPACE_SESSION_ID = 'workspace_12345678-1234-1234-1234-123456789abc';
 const KILO_SESSION_ID = 'ses_12345678901234567890123456';
 const INITIAL_MESSAGE_ID = 'msg_018f1e2d3c4bAbCdEfGhIjKlMn';
 const ROW_ID = 'f47ac10b-58cc-4372-a567-0e02b2c3d479';
+const GITHUB_INTEGRATION_ID = '123e4567-e89b-12d3-a456-426614174022';
 
 function makeLedgerRow(overrides: Partial<OperationLedgerRow> = {}): OperationLedgerRow {
   return {
@@ -213,6 +215,22 @@ function makeEnv(doStub: ReturnType<typeof makeDoStub>): Env {
     HYPERDRIVE: {
       connectionString: 'postgres://session-create-test',
     } as Env['HYPERDRIVE'],
+    GIT_TOKEN_SERVICE: {
+      getTokenForRepo: vi.fn().mockResolvedValue({
+        success: true,
+        token: 'github-token',
+        platformIntegrationId: GITHUB_INTEGRATION_ID,
+        installationId: '123',
+        accountLogin: 'acme',
+        appType: 'standard',
+      }),
+    } as unknown as Env['GIT_TOKEN_SERVICE'],
+    SESSION_INGEST: {
+      resolveAuthorizedSessionSource: vi.fn().mockResolvedValue({
+        organizationId: null,
+        repository: { type: 'github', repo: 'acme/repo' },
+      }),
+    } as unknown as Env['SESSION_INGEST'],
   } as unknown as Env;
 }
 
@@ -262,13 +280,13 @@ describe('createSessionWithLedger admission ladder', () => {
       kind: 'isolated',
       sandboxId: 'sb-test-123',
     });
-    admitOperationMock.mockResolvedValue({
+    admitOperationMock.mockReset().mockResolvedValue({
       admission: 'admitted',
       row: makeLedgerRow({}),
     });
     settleOperationMock.mockResolvedValue({ settled: true });
     markReconcilePendingMock.mockResolvedValue({});
-    recordOperationProgressMock.mockResolvedValue(undefined);
+    recordOperationProgressMock.mockReset().mockResolvedValue({});
   });
 
   it('admits with the operation identity and settles completed with canonical IDs', async () => {
@@ -672,6 +690,11 @@ describe('createSessionWithLedger admission ladder', () => {
       kiloSessionId: KILO_SESSION_ID,
       initialMessageId: INITIAL_MESSAGE_ID,
       createIntentFingerprint: expect.any(String),
+      canonicalRepository: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: GITHUB_INTEGRATION_ID,
+      },
     });
   });
 
@@ -790,7 +813,7 @@ describe('createSessionWithLedger takeover reconciliation ladder', () => {
     });
     settleOperationMock.mockResolvedValue({ settled: true });
     markReconcilePendingMock.mockResolvedValue({});
-    recordOperationProgressMock.mockResolvedValue(undefined);
+    recordOperationProgressMock.mockReset().mockResolvedValue({});
   });
 
   const canonicalIds = {
@@ -1432,6 +1455,11 @@ describe('createSessionWithLedger takeover reconciliation ladder', () => {
       kiloSessionId: KILO_SESSION_ID,
       initialMessageId: INITIAL_MESSAGE_ID,
       createIntentFingerprint: expect.any(String),
+      canonicalRepository: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: GITHUB_INTEGRATION_ID,
+      },
     });
     expect(markReconcilePendingMock).toHaveBeenCalledWith(expect.any(Object), {
       rowId: ROW_ID,
@@ -1472,13 +1500,13 @@ describe('createSessionWithLedger changed-intent rejection', () => {
       kind: 'isolated',
       sandboxId: 'sb-test-123',
     });
-    admitOperationMock.mockResolvedValue({
+    admitOperationMock.mockReset().mockResolvedValue({
       admission: 'admitted',
       row: makeLedgerRow({}),
     });
     settleOperationMock.mockResolvedValue({ settled: true });
     markReconcilePendingMock.mockResolvedValue({});
-    recordOperationProgressMock.mockResolvedValue(undefined);
+    recordOperationProgressMock.mockReset().mockResolvedValue({});
   });
 
   const ORIGINAL_OPTIONS = {
@@ -1536,6 +1564,11 @@ describe('createSessionWithLedger changed-intent rejection', () => {
       kiloSessionId: KILO_SESSION_ID,
       initialMessageId: INITIAL_MESSAGE_ID,
       createIntentFingerprint: await sessionCreateIntentFingerprint(request),
+      canonicalRepository: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: GITHUB_INTEGRATION_ID,
+      },
     });
     expect(result).toEqual({
       cloudAgentSessionId: CLOUD_AGENT_SESSION_ID,
@@ -1561,6 +1594,86 @@ describe('createSessionWithLedger changed-intent rejection', () => {
     });
     expect(doStub.createSessionWithInitialAdmission).not.toHaveBeenCalled();
     expect(settleOperationMock).not.toHaveBeenCalled();
+  });
+
+  it('replays a settled GitHub create without live canonicalization', async () => {
+    const request = originalRequest();
+    const row = await completedRowFor(request);
+    row.canonical_result = {
+      ...row.canonical_result,
+      [SESSION_CREATE_CANONICAL_REPOSITORY_KEY]: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: GITHUB_INTEGRATION_ID,
+      },
+    };
+    admitOperationMock.mockResolvedValueOnce({ admission: 'duplicate_settled', row });
+    const ctx = makeContext(makeDoStub());
+    const getTokenForRepo = vi.spyOn(ctx.env.GIT_TOKEN_SERVICE, 'getTokenForRepo');
+    getTokenForRepo.mockRejectedValue(new Error('provider unavailable'));
+
+    await expect(runCreate(ctx, request)).resolves.toEqual({
+      cloudAgentSessionId: CLOUD_AGENT_SESSION_ID,
+      kiloSessionId: KILO_SESSION_ID,
+      replayed: true,
+    });
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('reconciles with the stored GitHub pin without live canonicalization', async () => {
+    const request = originalRequest();
+    admitOperationMock.mockResolvedValueOnce({
+      admission: 'takeover',
+      row: makeLedgerRow({
+        canonical_result: {
+          cloudAgentSessionId: CLOUD_AGENT_SESSION_ID,
+          kiloSessionId: KILO_SESSION_ID,
+          initialMessageId: INITIAL_MESSAGE_ID,
+          [SESSION_CREATE_INTENT_FINGERPRINT_KEY]: await sessionCreateIntentFingerprint(request),
+          [SESSION_CREATE_CANONICAL_REPOSITORY_KEY]: {
+            type: 'github',
+            repo: 'acme/repo',
+            githubIntegrationId: GITHUB_INTEGRATION_ID,
+          },
+        },
+      }),
+    });
+    getPgDbMock.mockReturnValue(
+      makeDb([[{ sessionId: KILO_SESSION_ID }], [{ email: 'test@example.com' }]])
+    );
+    const ctx = makeContext(makeDoStub());
+    const getTokenForRepo = vi.spyOn(ctx.env.GIT_TOKEN_SERVICE, 'getTokenForRepo');
+    getTokenForRepo.mockRejectedValue(new Error('provider unavailable'));
+
+    await expect(runCreate(ctx, request)).resolves.toEqual({
+      cloudAgentSessionId: CLOUD_AGENT_SESSION_ID,
+      kiloSessionId: KILO_SESSION_ID,
+      replayed: true,
+    });
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('admits the operation before the first live GitHub resolution', async () => {
+    const order: string[] = [];
+    admitOperationMock.mockImplementationOnce(async () => {
+      order.push('admit');
+      return { admission: 'admitted', row: makeLedgerRow({}) };
+    });
+    const ctx = makeContext(makeDoStub());
+    vi.spyOn(ctx.env.GIT_TOKEN_SERVICE, 'getTokenForRepo').mockImplementationOnce(async () => {
+      order.push('resolve');
+      return {
+        success: true,
+        token: 'github-token',
+        platformIntegrationId: GITHUB_INTEGRATION_ID,
+        installationId: '123',
+        accountLogin: 'acme',
+        appType: 'standard',
+      };
+    });
+
+    await runCreate(ctx, originalRequest());
+    expect(order).toEqual(['admit', 'resolve']);
   });
 
   /**
@@ -1893,13 +2006,13 @@ describe('createSessionWithLedger clone allocation outcomes', () => {
       kind: 'isolated',
       sandboxId: 'sb-test-123',
     });
-    admitOperationMock.mockResolvedValue({
+    admitOperationMock.mockReset().mockResolvedValue({
       admission: 'admitted',
       row: makeLedgerRow({}),
     });
     settleOperationMock.mockResolvedValue({ settled: true });
     markReconcilePendingMock.mockResolvedValue({});
-    recordOperationProgressMock.mockResolvedValue(undefined);
+    recordOperationProgressMock.mockReset().mockResolvedValue({});
     createCliSessionMock.mockResolvedValue(undefined);
   });
 
@@ -2235,6 +2348,11 @@ describe('createSessionWithLedger clone allocation outcomes', () => {
       cloudAgentSessionId: CLOUD_AGENT_SESSION_ID,
       kiloSessionId: KILO_SESSION_ID,
       createIntentFingerprint: await sessionCreateIntentFingerprint(cloneRequest()),
+      canonicalRepository: {
+        type: 'github',
+        repo: 'acme/repo',
+        githubIntegrationId: GITHUB_INTEGRATION_ID,
+      },
     });
     // A clone-only create has no synthetic initial turn, so no initialMessageId
     // is recorded and the fingerprint differs from a prompt create.
@@ -2261,7 +2379,7 @@ describe('createSessionWithLedger clone reconciliation', () => {
     });
     settleOperationMock.mockResolvedValue({ settled: true });
     markReconcilePendingMock.mockResolvedValue({});
-    recordOperationProgressMock.mockResolvedValue(undefined);
+    recordOperationProgressMock.mockReset().mockResolvedValue({});
     createCliSessionMock.mockResolvedValue(undefined);
   });
 

--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -9,9 +9,9 @@
  * one grouped operation. Legacy
  * `prepareSession` retains registration-only behavior and can queue later.
  *
- * Managed git-token resolution (GitHub App installation, managed GitLab) is
- * NOT performed here; it happens lazily in the flusher's workspace preparation
- * path. Provider credentials are intentionally not stored in registration
+ * GitHub repository identity is canonicalized by the handler before entering
+ * this module. Managed credentials are still resolved lazily in the flusher's
+ * workspace preparation path and are intentionally not stored in registration
  * metadata; generic git repositories may still carry an explicit token.
  */
 import { TRPCError } from '@trpc/server';

--- a/services/cloud-agent-next/src/session/session-registration.ts
+++ b/services/cloud-agent-next/src/session/session-registration.ts
@@ -61,6 +61,7 @@ import type {
 } from '../execution/types.js';
 import { throwAdmissionError } from './queue-message.js';
 import type { SessionCreateRequest, SessionRepositoryRequest } from './session-requests.js';
+import { canonicalizeRepositoryBeforeSessionCreation } from './validate-repository-access.js';
 
 export type SessionRegistrationInput = SessionCreateRequest;
 
@@ -194,12 +195,19 @@ type SessionLedgerFailureStage =
 type SessionCreationLedgerHooks = {
   db: WorkerDb;
   rowId: string;
+  intentFingerprint?: string;
+  canonicalRepository?: Extract<SessionRepositoryRequest, { type: 'github' }>;
   /** Settle the row `failed` at the given stage. */
   onFailure: (stage: SessionLedgerFailureStage, outcomeCode: string) => Promise<void>;
   /** The DO RPC threw; the commit outcome is unknown. */
   onTransportFailure: () => Promise<void>;
   /** The DO confirmed registration (and initial admission when one exists). */
   onSuccess: (result: { cloudAgentSessionId: string; kiloSessionId: string }) => Promise<void>;
+};
+
+type CanonicalCreateProgress = {
+  intentFingerprint?: string;
+  canonicalRepository?: Extract<SessionRepositoryRequest, { type: 'github' }>;
 };
 
 /** Result returned to the prepare handler for ledger-guarded creates. */
@@ -241,6 +249,9 @@ export const SESSION_CREATE_ABANDONED_OUTCOME_CODE = 'create_rpc_abandoned';
  * the next intent allocates fresh IDs.
  */
 export const SESSION_CREATE_TOMBSTONED_IDS_KEY = 'tombstonedDestinationIds';
+
+/** Canonical GitHub repository selected after ledger admission. */
+export const SESSION_CREATE_CANONICAL_REPOSITORY_KEY = 'canonicalRepository';
 
 /** Carries the allocation failure stage so the ledger can settle it. */
 class SessionAllocationStageError extends Error {
@@ -465,7 +476,12 @@ async function allocateNewSession(
         cloudAgentSessionId,
         kiloSessionId,
         ...(initialTurn ? { initialMessageId: initialTurn.messageId } : {}),
-        [SESSION_CREATE_INTENT_FINGERPRINT_KEY]: await sessionCreateIntentFingerprint(input),
+        ...(ledger.intentFingerprint
+          ? { [SESSION_CREATE_INTENT_FINGERPRINT_KEY]: ledger.intentFingerprint }
+          : {}),
+        ...(ledger.canonicalRepository
+          ? { [SESSION_CREATE_CANONICAL_REPOSITORY_KEY]: ledger.canonicalRepository }
+          : {}),
       });
     }
 
@@ -1285,6 +1301,7 @@ export async function createSessionWithLedger(
 ): Promise<LedgerSessionCreateResult> {
   assertSupportedSandboxAllocation(input, ctx, { billingOrigin: options.billingOrigin });
   const db = getPgDb(ctx.env);
+  const intentFingerprint = await sessionCreateIntentFingerprint(input);
   const admission = await admitOperation(db, {
     userId: ctx.userId,
     orgId: input.options?.kilocodeOrganizationId,
@@ -1296,8 +1313,17 @@ export async function createSessionWithLedger(
   });
 
   switch (admission.admission) {
-    case 'admitted':
-      return executeLedgerCreate(input, ctx, options, db, admission.row, 'new');
+    case 'admitted': {
+      const canonicalInput = await canonicalizeCreateInput(input, ctx).catch(async error => {
+        await bestEffortLedgerWrite(() => markReconcilePending(db, { rowId: admission.row.id }));
+        throw error;
+      });
+      return executeLedgerCreate(canonicalInput, ctx, options, db, admission.row, 'new', {
+        intentFingerprint,
+        canonicalRepository:
+          canonicalInput.repository.type === 'github' ? canonicalInput.repository : undefined,
+      });
+    }
     case 'duplicate_settled':
       return replaySettledCreate(admission.row, input);
     case 'duplicate_in_flight':
@@ -1305,8 +1331,77 @@ export async function createSessionWithLedger(
       throw creationInProgressError();
     case 'takeover':
     case 'duplicate_reconcile_pending':
-      return reconcileLedgerCreate(input, ctx, options, db, admission.row);
+      return reconcileLedgerCreate(
+        await resolveRecordedCanonicalCreateInput(input, ctx, db, admission.row),
+        input,
+        ctx,
+        options,
+        db,
+        admission.row
+      );
   }
+}
+
+function readCanonicalGitHubRepository(
+  row: OperationLedgerRow
+): Extract<SessionRepositoryRequest, { type: 'github' }> | undefined {
+  const value = row.canonical_result?.[SESSION_CREATE_CANONICAL_REPOSITORY_KEY];
+  if (typeof value !== 'object' || value === null) return undefined;
+  const repository = value as Record<string, unknown>;
+  if (
+    repository.type !== 'github' ||
+    typeof repository.repo !== 'string' ||
+    typeof repository.githubIntegrationId !== 'string'
+  ) {
+    return undefined;
+  }
+  return {
+    type: 'github',
+    repo: repository.repo,
+    githubIntegrationId: repository.githubIntegrationId,
+    ...(typeof repository.branch === 'string' ? { branch: repository.branch } : {}),
+  };
+}
+
+async function canonicalizeCreateInput(
+  input: SessionRegistrationInput,
+  ctx: SessionRegistrationContext
+): Promise<SessionRegistrationInput> {
+  return canonicalizeRepositoryBeforeSessionCreation({
+    env: ctx.env,
+    userId: ctx.userId,
+    orgId: input.options?.kilocodeOrganizationId,
+    request: input,
+  });
+}
+
+async function resolveRecordedCanonicalCreateInput(
+  input: SessionRegistrationInput,
+  ctx: SessionRegistrationContext,
+  db: WorkerDb,
+  row: OperationLedgerRow
+): Promise<SessionRegistrationInput> {
+  await assertCreateIntentUnchanged(input, row);
+  if (input.repository.type !== 'github') return input;
+
+  const recorded = readCanonicalGitHubRepository(row);
+  if (recorded) {
+    return { ...input, repository: recorded };
+  }
+
+  // Compatibility for operations admitted before canonical repository pins
+  // were recorded. New operations never rediscover GitHub identity on replay.
+  const canonicalInput = await canonicalizeCreateInput(input, ctx).catch(async error => {
+    await bestEffortLedgerWrite(() => markReconcilePending(db, { rowId: row.id }));
+    throw error;
+  });
+  if (canonicalInput.repository.type === 'github') {
+    const progress = await recordOperationProgress(db, row.id, {
+      [SESSION_CREATE_CANONICAL_REPOSITORY_KEY]: canonicalInput.repository,
+    });
+    if (progress === null) throw creationInProgressError();
+  }
+  return canonicalInput;
 }
 
 async function replaySettledCreate(
@@ -1358,7 +1453,8 @@ async function buildLedgerHooks(
   options: SessionLedgerCreateOptions,
   db: WorkerDb,
   row: OperationLedgerRow,
-  admissionKind: 'new' | 'takeover'
+  admissionKind: 'new' | 'takeover',
+  canonical?: CanonicalCreateProgress
 ): Promise<SessionCreationLedgerHooks> {
   const distinctId = await resolveSessionCreateDistinctId(db, ctx.userId);
   const inOrganization = input.options?.kilocodeOrganizationId != null;
@@ -1366,6 +1462,7 @@ async function buildLedgerHooks(
   return {
     db,
     rowId: row.id,
+    ...canonical,
     onFailure: (stage, outcomeCode) =>
       bestEffortLedgerWrite(() =>
         settleOperation(db, {
@@ -1417,9 +1514,10 @@ async function executeLedgerCreate(
   options: SessionLedgerCreateOptions,
   db: WorkerDb,
   row: OperationLedgerRow,
-  admissionKind: 'new' | 'takeover'
+  admissionKind: 'new' | 'takeover',
+  canonical?: CanonicalCreateProgress
 ): Promise<LedgerSessionCreateResult> {
-  const hooks = await buildLedgerHooks(input, ctx, options, db, row, admissionKind);
+  const hooks = await buildLedgerHooks(input, ctx, options, db, row, admissionKind, canonical);
   const billingOrigin = { billingOrigin: options.billingOrigin };
   let result: { cloudAgentSessionId: string; kiloSessionId: string };
   if (input.initialTurn === undefined) {
@@ -1626,6 +1724,7 @@ function isCreateAbandonable(row: OperationLedgerRow): boolean {
  */
 async function reconcileLedgerCreate(
   input: SessionRegistrationInput,
+  intentInput: SessionRegistrationInput,
   ctx: SessionRegistrationContext,
   options: SessionLedgerCreateOptions,
   db: WorkerDb,
@@ -1633,13 +1732,20 @@ async function reconcileLedgerCreate(
 ): Promise<LedgerSessionCreateResult> {
   // A changed same-key create intent is rejected before ANY reconcile step: no
   // fresh create, no ownership-row lookup, and no DO metadata read.
-  await assertCreateIntentUnchanged(input, row);
+  await assertCreateIntentUnchanged(intentInput, row);
+
+  const canonicalProgress = {
+    ...(typeof row.canonical_result?.[SESSION_CREATE_INTENT_FINGERPRINT_KEY] === 'string'
+      ? {}
+      : { intentFingerprint: await sessionCreateIntentFingerprint(intentInput) }),
+    ...(input.repository.type === 'github' ? { canonicalRepository: input.repository } : {}),
+  };
 
   const ids = canonicalSessionIds(row);
 
   // (a) No progress IDs recorded → nothing external happened.
   if (!ids) {
-    return executeLedgerCreate(input, ctx, options, db, row, 'takeover');
+    return executeLedgerCreate(input, ctx, options, db, row, 'takeover', canonicalProgress);
   }
 
   // (b) Ownership row lookup by kiloSessionId.
@@ -1648,7 +1754,7 @@ async function reconcileLedgerCreate(
     // A tombstoned destination must never be resumed: the clone was explicitly
     // rejected and its IDs are dead, so fall through to a fresh allocation.
     if (hasTombstoneForIds(row, ids)) {
-      return executeLedgerCreate(input, ctx, options, db, row, 'takeover');
+      return executeLedgerCreate(input, ctx, options, db, row, 'takeover', canonicalProgress);
     }
     // A clone create with no ownership row resumes the stored destination IDs
     // instead of allocating fresh ones.
@@ -1658,7 +1764,7 @@ async function reconcileLedgerCreate(
     // Old non-clone create: the ownership row is absent, so the DO never
     // registered. Keep the existing fresh allocation. Remove this path only
     // once every non-clone create is tombstoned on rejection (out of scope).
-    return executeLedgerCreate(input, ctx, options, db, row, 'takeover');
+    return executeLedgerCreate(input, ctx, options, db, row, 'takeover', canonicalProgress);
   }
 
   const confirm = () =>

--- a/services/cloud-agent-next/src/session/validate-repository-access.test.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.test.ts
@@ -273,6 +273,30 @@ describe('GitHub session creation preflight', () => {
     expect(getTokenForRepo).not.toHaveBeenCalled();
   });
 
+  it('treats an invalid undefined canonical result as access denial without legacy fallback', async () => {
+    const legacyResolver = vi.fn();
+    const getTokenForRepo = vi.fn();
+    const env = {
+      SESSION_INGEST: {
+        resolveAuthorizedSessionSource: vi.fn().mockResolvedValue(undefined),
+        resolveCloudAgentRootSessionForKiloSession: legacyResolver,
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: 'source_access_denied' });
+    expect(legacyResolver).not.toHaveBeenCalled();
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
   it('rejects a source organization mismatch before live GitHub resolution', async () => {
     const getTokenForRepo = vi.fn();
     const env = {

--- a/services/cloud-agent-next/src/session/validate-repository-access.test.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.test.ts
@@ -170,6 +170,81 @@ describe('GitHub session creation preflight', () => {
     });
   });
 
+  it('continues from an authorized remote CLI source without requiring a Cloud Agent mapping', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
+    const getMetadata = vi.fn();
+    const env = {
+      SESSION_INGEST: {
+        resolveAuthorizedSessionSource: vi.fn().mockResolvedValue({
+          organizationId: null,
+          repository: { type: 'github', repo: 'Acme/Repo' },
+        }),
+      },
+      CLOUD_AGENT_SESSION: {
+        idFromName: vi.fn(),
+        get: vi.fn(() => ({ getMetadata })),
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).resolves.toMatchObject({ repository: { repo: 'Acme/Repo', githubIntegrationId } });
+    expect(getMetadata).not.toHaveBeenCalled();
+  });
+
+  it('rejects a source organization mismatch before live GitHub resolution', async () => {
+    const getTokenForRepo = vi.fn();
+    const env = {
+      SESSION_INGEST: {
+        resolveAuthorizedSessionSource: vi.fn().mockResolvedValue({
+          organizationId: '123e4567-e89b-12d3-a456-426614174099',
+          repository: { type: 'github', repo: 'acme/repo' },
+        }),
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        orgId: '123e4567-e89b-12d3-a456-426614174030',
+        request: githubRequest({
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: 'organization_mismatch' });
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('preserves indistinguishable source access denial before live GitHub resolution', async () => {
+    const getTokenForRepo = vi.fn();
+    const env = {
+      SESSION_INGEST: {
+        resolveAuthorizedSessionSource: vi.fn().mockResolvedValue(null),
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).rejects.toMatchObject({ code: 'BAD_REQUEST', message: 'source_access_denied' });
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
   it.each([
     [
       'repository',

--- a/services/cloud-agent-next/src/session/validate-repository-access.test.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.test.ts
@@ -1,5 +1,31 @@
 import { describe, expect, it, vi } from 'vitest';
-import { assertRepositoryAccessBeforeSessionCreation } from './validate-repository-access.js';
+import {
+  assertRepositoryAccessBeforeSessionCreation,
+  canonicalizeRepositoryBeforeSessionCreation,
+} from './validate-repository-access.js';
+import { sessionCreateIntentFingerprint } from './session-registration.js';
+
+const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
+
+function githubResolution(platformIntegrationId = githubIntegrationId) {
+  return {
+    success: true as const,
+    token: 'token',
+    platformIntegrationId,
+    installationId: '123',
+    accountLogin: 'acme',
+    appType: 'standard' as const,
+  };
+}
+
+function githubRequest(overrides: Record<string, unknown> = {}) {
+  return {
+    initialTurn: { type: 'prompt' as const, prompt: 'Build it' },
+    agent: { mode: 'code', model: 'model' },
+    repository: { type: 'github' as const, repo: 'acme/repo' },
+    ...overrides,
+  };
+}
 
 const repository = {
   type: 'bitbucket' as const,
@@ -9,47 +35,63 @@ const repository = {
 };
 
 describe('GitHub session creation preflight', () => {
-  it('skips legacy GitHub repositories without an integration pin', async () => {
-    const getTokenForRepo = vi.fn();
+  it('canonicalizes an unpinned GitHub repository to the live resolved integration', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
 
     await expect(
-      assertRepositoryAccessBeforeSessionCreation({
+      canonicalizeRepositoryBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
         userId: 'user-1',
-        repository: { type: 'github', repo: 'acme/repo' },
+        request: githubRequest(),
       })
-    ).resolves.toBeUndefined();
-    expect(getTokenForRepo).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({
+      repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+    });
   });
 
-  it('preflights a pinned GitHub repository against the exact integration', async () => {
-    const getTokenForRepo = vi.fn().mockResolvedValue({
-      success: true,
-      token: 'token',
-      installationId: '123',
-      accountLogin: 'acme',
-      appType: 'standard',
+  it('includes the canonical integration in the operation fingerprint', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
+    const canonical = await canonicalizeRepositoryBeforeSessionCreation({
+      env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+      userId: 'user-1',
+      request: githubRequest(),
     });
+    const alternate = {
+      ...canonical,
+      repository: {
+        ...canonical.repository,
+        githubIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+      },
+    };
+
+    expect(await sessionCreateIntentFingerprint(canonical)).not.toBe(
+      await sessionCreateIntentFingerprint(alternate)
+    );
+  });
+
+  it('canonicalizes a pinned GitHub repository against the exact integration', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
     const orgId = '123e4567-e89b-12d3-a456-426614174030';
-    const expectedIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
 
     await expect(
-      assertRepositoryAccessBeforeSessionCreation({
+      canonicalizeRepositoryBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
         userId: 'user-1',
         orgId,
-        repository: {
-          type: 'github',
-          repo: 'acme/repo',
-          githubIntegrationId: expectedIntegrationId,
-        },
+        request: githubRequest({
+          repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+        }),
       })
-    ).resolves.toBeUndefined();
+    ).resolves.toMatchObject({ repository: { githubIntegrationId } });
     expect(getTokenForRepo).toHaveBeenCalledWith({
       githubRepo: 'acme/repo',
       userId: 'user-1',
       orgId,
-      expectedIntegrationId,
+      expectedIntegrationId: githubIntegrationId,
     });
   });
 
@@ -60,19 +102,154 @@ describe('GitHub session creation preflight', () => {
     });
 
     await expect(
-      assertRepositoryAccessBeforeSessionCreation({
+      canonicalizeRepositoryBeforeSessionCreation({
         env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
         userId: 'user-1',
-        repository: {
-          type: 'github',
-          repo: 'acme/repo',
-          githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
-        },
+        request: githubRequest({
+          repository: { type: 'github', repo: 'acme/repo', githubIntegrationId },
+        }),
       })
     ).rejects.toMatchObject({
       code: 'BAD_REQUEST',
       message: 'GitHub repository authorization failed (integration_mismatch)',
     });
+  });
+
+  it.each([
+    ['ambiguous_installation', 'BAD_REQUEST'],
+    ['repository_not_installed', 'BAD_REQUEST'],
+    ['temporarily_unavailable', 'SERVICE_UNAVAILABLE'],
+    ['database_not_configured', 'SERVICE_UNAVAILABLE'],
+  ])('maps %s to %s before allocation', async (reason, code) => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({ success: false, reason });
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: { GIT_TOKEN_SERVICE: { getTokenForRepo } } as never,
+        userId: 'user-1',
+        request: githubRequest(),
+      })
+    ).rejects.toMatchObject({ code });
+  });
+
+  it('inherits the source GitHub pin and accepts repository case differences', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
+    const getMetadata = vi.fn().mockResolvedValue({
+      repository: { type: 'github', repo: 'Acme/Repo', githubIntegrationId },
+    });
+    const env = {
+      SESSION_INGEST: {
+        resolveCloudAgentRootSessionForKiloSession: vi.fn().mockResolvedValue({
+          cloudAgentSessionId: 'agent-source',
+          repository: { type: 'github', repo: 'Acme/Repo' },
+        }),
+      },
+      CLOUD_AGENT_SESSION: {
+        idFromName: vi.fn(name => name),
+        get: vi.fn(() => ({ getMetadata })),
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          repository: { type: 'github', repo: 'acme/repo' },
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).resolves.toMatchObject({
+      repository: { repo: 'Acme/Repo', githubIntegrationId },
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'Acme/Repo',
+      userId: 'user-1',
+      expectedIntegrationId: githubIntegrationId,
+    });
+  });
+
+  it.each([
+    [
+      'repository',
+      { type: 'github', repo: 'Acme/Repo', githubIntegrationId },
+      { type: 'github', repo: 'other/repo', githubIntegrationId },
+      'clone_repository_mismatch',
+    ],
+    [
+      'integration',
+      { type: 'github', repo: 'acme/repo', githubIntegrationId },
+      {
+        type: 'github',
+        repo: 'Acme/Repo',
+        githubIntegrationId: '123e4567-e89b-12d3-a456-426614174099',
+      },
+      'clone_integration_mismatch',
+    ],
+  ])(
+    'rejects a clone %s mismatch before live resolution',
+    async (_kind, sourceRepo, submitted, message) => {
+      const getTokenForRepo = vi.fn();
+      const env = {
+        SESSION_INGEST: {
+          resolveCloudAgentRootSessionForKiloSession: vi.fn().mockResolvedValue({
+            cloudAgentSessionId: 'agent-source',
+            repository: { type: 'github', repo: 'Acme/Repo' },
+          }),
+        },
+        CLOUD_AGENT_SESSION: {
+          idFromName: vi.fn(name => name),
+          get: vi.fn(() => ({
+            getMetadata: vi.fn().mockResolvedValue({ repository: sourceRepo }),
+          })),
+        },
+        GIT_TOKEN_SERVICE: { getTokenForRepo },
+      };
+
+      await expect(
+        canonicalizeRepositoryBeforeSessionCreation({
+          env: env as never,
+          userId: 'user-1',
+          request: githubRequest({
+            repository: submitted,
+            clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+          }),
+        })
+      ).rejects.toMatchObject({ code: 'BAD_REQUEST', message });
+      expect(getTokenForRepo).not.toHaveBeenCalled();
+    }
+  );
+
+  it('uses live resolution for a legacy source without an integration pin', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
+    const env = {
+      SESSION_INGEST: {
+        resolveCloudAgentRootSessionForKiloSession: vi.fn().mockResolvedValue({
+          cloudAgentSessionId: 'agent-source',
+        }),
+      },
+      CLOUD_AGENT_SESSION: {
+        idFromName: vi.fn(name => name),
+        get: vi.fn(() => ({
+          getMetadata: vi.fn().mockResolvedValue({
+            repository: { type: 'github', repo: 'acme/repo' },
+          }),
+        })),
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).resolves.toMatchObject({ repository: { githubIntegrationId } });
+    expect(getTokenForRepo).toHaveBeenCalledWith({ githubRepo: 'acme/repo', userId: 'user-1' });
   });
 });
 

--- a/services/cloud-agent-next/src/session/validate-repository-access.test.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.test.ts
@@ -199,6 +199,80 @@ describe('GitHub session creation preflight', () => {
     expect(getMetadata).not.toHaveBeenCalled();
   });
 
+  it('falls back to the legacy resolver when an old deployment rejects the canonical RPC method', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue(githubResolution());
+    const resolveAuthorizedSessionSource = vi
+      .fn()
+      .mockRejectedValue(
+        new TypeError(
+          'The RPC receiver does not implement the method "resolveAuthorizedSessionSource".'
+        )
+      );
+    const resolveCloudAgentRootSessionForKiloSession = vi.fn().mockResolvedValue({
+      cloudAgentSessionId: 'agent-source',
+      repository: { type: 'github', repo: 'Acme/Repo' },
+    });
+    const env = {
+      SESSION_INGEST: {
+        resolveAuthorizedSessionSource,
+        resolveCloudAgentRootSessionForKiloSession,
+      },
+      CLOUD_AGENT_SESSION: {
+        idFromName: vi.fn(name => name),
+        get: vi.fn(() => ({
+          getMetadata: vi.fn().mockResolvedValue({
+            repository: { type: 'github', repo: 'Acme/Repo', githubIntegrationId },
+          }),
+        })),
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).resolves.toMatchObject({
+      repository: { repo: 'Acme/Repo', githubIntegrationId },
+    });
+    expect(resolveAuthorizedSessionSource).toHaveBeenCalledOnce();
+    expect(resolveCloudAgentRootSessionForKiloSession).toHaveBeenCalledOnce();
+  });
+
+  it.each([
+    new Error('Provider failed while calling resolveAuthorizedSessionSource'),
+    new TypeError('The RPC receiver does not implement the method "anotherMethod".'),
+  ])('does not mask a true canonical resolver failure: %s', async error => {
+    const legacyResolver = vi.fn();
+    const getTokenForRepo = vi.fn();
+    const env = {
+      SESSION_INGEST: {
+        resolveAuthorizedSessionSource: vi.fn().mockRejectedValue(error),
+        resolveCloudAgentRootSessionForKiloSession: legacyResolver,
+      },
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+    };
+
+    await expect(
+      canonicalizeRepositoryBeforeSessionCreation({
+        env: env as never,
+        userId: 'user-1',
+        request: githubRequest({
+          clone: { cloneFromKiloSessionId: 'ses_12345678901234567890123456' },
+        }),
+      })
+    ).rejects.toMatchObject({
+      code: 'SERVICE_UNAVAILABLE',
+      message: 'GitHub repository authorization failed (source_unavailable)',
+    });
+    expect(legacyResolver).not.toHaveBeenCalled();
+    expect(getTokenForRepo).not.toHaveBeenCalled();
+  });
+
   it('rejects a source organization mismatch before live GitHub resolution', async () => {
     const getTokenForRepo = vi.fn();
     const env = {

--- a/services/cloud-agent-next/src/session/validate-repository-access.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.ts
@@ -108,6 +108,7 @@ async function resolveCloneSourceGitHubRepository(input: {
   const sessionIngest = input.env.SESSION_INGEST;
   if (typeof sessionIngest?.resolveAuthorizedSessionSource === 'function') {
     let source;
+    let methodUnavailable = false;
     try {
       source = await sessionIngest.resolveAuthorizedSessionSource({
         kiloUserId: input.userId,
@@ -117,9 +118,9 @@ async function resolveCloneSourceGitHubRepository(input: {
       if (!isMissingAuthorizedSessionSourceRpc(error)) {
         throw githubRepositoryAuthorizationError('source_unavailable');
       }
-      source = undefined;
+      methodUnavailable = true;
     }
-    if (source !== undefined) {
+    if (!methodUnavailable) {
       if (!source) throw sourceAccessDenied();
       if (source.organizationId !== (input.orgId ?? null)) {
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'organization_mismatch' });

--- a/services/cloud-agent-next/src/session/validate-repository-access.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.ts
@@ -59,6 +59,15 @@ function sourceAccessDenied(): TRPCError {
   return new TRPCError({ code: 'BAD_REQUEST', message: 'source_access_denied' });
 }
 
+function isMissingAuthorizedSessionSourceRpc(error: unknown): boolean {
+  return (
+    error instanceof TypeError &&
+    /^The RPC receiver does not implement the method ["']resolveAuthorizedSessionSource["']\.?$/.test(
+      error.message
+    )
+  );
+}
+
 async function readOptionalCloudAgentGitHubPin(input: {
   env: PersistenceEnv;
   userId: string;
@@ -104,25 +113,30 @@ async function resolveCloneSourceGitHubRepository(input: {
         kiloUserId: input.userId,
         kiloSessionId: sourceKiloSessionId,
       });
-    } catch {
-      throw githubRepositoryAuthorizationError('source_unavailable');
+    } catch (error) {
+      if (!isMissingAuthorizedSessionSourceRpc(error)) {
+        throw githubRepositoryAuthorizationError('source_unavailable');
+      }
+      source = undefined;
     }
-    if (!source) throw sourceAccessDenied();
-    if (source.organizationId !== (input.orgId ?? null)) {
-      throw new TRPCError({ code: 'BAD_REQUEST', message: 'organization_mismatch' });
-    }
+    if (source !== undefined) {
+      if (!source) throw sourceAccessDenied();
+      if (source.organizationId !== (input.orgId ?? null)) {
+        throw new TRPCError({ code: 'BAD_REQUEST', message: 'organization_mismatch' });
+      }
 
-    const repo = source.repository?.type === 'github' ? source.repository.repo : undefined;
-    const githubIntegrationId = await readOptionalCloudAgentGitHubPin({
-      env: input.env,
-      userId: input.userId,
-      cloudAgentSessionId: source.cloudAgentSessionId,
-      authoritativeRepo: repo,
-    });
-    return {
-      ...(repo ? { repo } : {}),
-      ...(githubIntegrationId ? { githubIntegrationId } : {}),
-    };
+      const repo = source.repository?.type === 'github' ? source.repository.repo : undefined;
+      const githubIntegrationId = await readOptionalCloudAgentGitHubPin({
+        env: input.env,
+        userId: input.userId,
+        cloudAgentSessionId: source.cloudAgentSessionId,
+        authoritativeRepo: repo,
+      });
+      return {
+        ...(repo ? { repo } : {}),
+        ...(githubIntegrationId ? { githubIntegrationId } : {}),
+      };
+    }
   }
 
   // Rolling-deploy compatibility: an older Session Ingest worker can only

--- a/services/cloud-agent-next/src/session/validate-repository-access.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.ts
@@ -14,6 +14,7 @@ const TEMPORARY_GITHUB_RESOLUTION_REASONS = new Set([
   'service_not_configured',
   'temporarily_unavailable',
   'rpc_error',
+  'service_incompatible',
   'source_unavailable',
 ]);
 
@@ -49,63 +50,115 @@ function readGitHubRepository(
   };
 }
 
+type CloneSourceRepository = {
+  repo?: string;
+  githubIntegrationId?: string;
+};
+
+function sourceAccessDenied(): TRPCError {
+  return new TRPCError({ code: 'BAD_REQUEST', message: 'source_access_denied' });
+}
+
+async function readOptionalCloudAgentGitHubPin(input: {
+  env: PersistenceEnv;
+  userId: string;
+  cloudAgentSessionId: string | undefined;
+  authoritativeRepo: string | undefined;
+}): Promise<string | undefined> {
+  if (!input.cloudAgentSessionId) return undefined;
+  const cloudAgentSessionId = input.cloudAgentSessionId;
+  try {
+    const sourceMetadata = await withDORetry(
+      () => resolveSessionStub(input.env, input.userId, cloudAgentSessionId),
+      stub => stub.getMetadata(),
+      'CloudAgentSession.getMetadataForCloneRepository'
+    );
+    const metadataRepository = readGitHubRepository(sourceMetadata);
+    if (
+      !metadataRepository ||
+      (input.authoritativeRepo &&
+        !repositoriesMatch(input.authoritativeRepo, metadataRepository.repo))
+    ) {
+      return undefined;
+    }
+    return metadataRepository.githubIntegrationId;
+  } catch {
+    return undefined;
+  }
+}
+
 async function resolveCloneSourceGitHubRepository(input: {
   env: PersistenceEnv;
   userId: string;
+  orgId?: string;
   request: SessionCreateRequest;
-}): Promise<{ repo: string; githubIntegrationId?: string } | null> {
+}): Promise<CloneSourceRepository | null> {
   const sourceKiloSessionId = input.request.clone?.cloneFromKiloSessionId;
   if (!sourceKiloSessionId) return null;
 
+  const sessionIngest = input.env.SESSION_INGEST;
+  if (typeof sessionIngest?.resolveAuthorizedSessionSource === 'function') {
+    let source;
+    try {
+      source = await sessionIngest.resolveAuthorizedSessionSource({
+        kiloUserId: input.userId,
+        kiloSessionId: sourceKiloSessionId,
+      });
+    } catch {
+      throw githubRepositoryAuthorizationError('source_unavailable');
+    }
+    if (!source) throw sourceAccessDenied();
+    if (source.organizationId !== (input.orgId ?? null)) {
+      throw new TRPCError({ code: 'BAD_REQUEST', message: 'organization_mismatch' });
+    }
+
+    const repo = source.repository?.type === 'github' ? source.repository.repo : undefined;
+    const githubIntegrationId = await readOptionalCloudAgentGitHubPin({
+      env: input.env,
+      userId: input.userId,
+      cloudAgentSessionId: source.cloudAgentSessionId,
+      authoritativeRepo: repo,
+    });
+    return {
+      ...(repo ? { repo } : {}),
+      ...(githubIntegrationId ? { githubIntegrationId } : {}),
+    };
+  }
+
+  // Rolling-deploy compatibility: an older Session Ingest worker can only
+  // expose Cloud Agent roots. A missing mapping is not an authorization
+  // decision; the final clone RPC retains the generic source access check.
   let source;
+  if (!sessionIngest?.resolveCloudAgentRootSessionForKiloSession) return {};
   try {
-    source = await input.env.SESSION_INGEST.resolveCloudAgentRootSessionForKiloSession({
+    source = await sessionIngest.resolveCloudAgentRootSessionForKiloSession({
       kiloUserId: input.userId,
       kiloSessionId: sourceKiloSessionId,
     });
   } catch {
     throw githubRepositoryAuthorizationError('source_unavailable');
   }
-  if (!source) {
-    throw new TRPCError({ code: 'BAD_REQUEST', message: 'source_access_denied' });
-  }
-
-  let sourceMetadata: unknown;
-  try {
-    sourceMetadata = await withDORetry(
-      () => resolveSessionStub(input.env, input.userId, source.cloudAgentSessionId),
-      stub => stub.getMetadata(),
-      'CloudAgentSession.getMetadataForCloneRepository'
-    );
-  } catch {
-    throw githubRepositoryAuthorizationError('source_unavailable');
-  }
-
-  const metadataRepository = readGitHubRepository(sourceMetadata);
-  if (!metadataRepository) {
-    throw githubRepositoryAuthorizationError('source_unavailable');
-  }
+  if (!source) return {};
   const mappedRepository = readGitHubRepository(source);
-  if (
-    mappedRepository &&
-    metadataRepository &&
-    !repositoriesMatch(mappedRepository.repo, metadataRepository.repo)
-  ) {
-    throw githubRepositoryAuthorizationError('source_unavailable');
-  }
-
-  const repo = mappedRepository?.repo ?? metadataRepository.repo;
+  const githubIntegrationId = await readOptionalCloudAgentGitHubPin({
+    env: input.env,
+    userId: input.userId,
+    cloudAgentSessionId: source.cloudAgentSessionId,
+    authoritativeRepo: mappedRepository?.repo,
+  });
   return {
-    repo,
-    ...(metadataRepository.githubIntegrationId
-      ? { githubIntegrationId: metadataRepository.githubIntegrationId }
-      : {}),
+    ...(mappedRepository?.repo ? { repo: mappedRepository.repo } : {}),
+    ...(githubIntegrationId ? { githubIntegrationId } : {}),
   };
 }
 
 /**
  * Resolves and pins GitHub repository identity before any operation-ledger or
- * session allocation work. The returned request contains no resolved token.
+ * session allocation work on non-ledger paths. Ledger-backed creates call this
+ * only after admission and persist the pin with allocation progress. The token
+ * is deliberately discarded: creation proves repository access, while delayed
+ * workspace preparation reauthorizes the persisted integration exactly because
+ * credentials may expire or access may be revoked between those phases.
  */
 export async function canonicalizeRepositoryBeforeSessionCreation(input: {
   env: PersistenceEnv;
@@ -117,7 +170,7 @@ export async function canonicalizeRepositoryBeforeSessionCreation(input: {
 
   const submitted = input.request.repository;
   const source = await resolveCloneSourceGitHubRepository(input);
-  if (source && !repositoriesMatch(submitted.repo, source.repo)) {
+  if (source?.repo && !repositoriesMatch(submitted.repo, source.repo)) {
     throw new TRPCError({ code: 'BAD_REQUEST', message: 'clone_repository_mismatch' });
   }
   if (
@@ -141,7 +194,7 @@ export async function canonicalizeRepositoryBeforeSessionCreation(input: {
     ...input.request,
     repository: {
       ...submitted,
-      ...(source ? { repo: source.repo } : {}),
+      ...(source?.repo ? { repo: source.repo } : {}),
       githubIntegrationId: result.value.platformIntegrationId,
     },
   };

--- a/services/cloud-agent-next/src/session/validate-repository-access.ts
+++ b/services/cloud-agent-next/src/session/validate-repository-access.ts
@@ -5,7 +5,147 @@ import {
   resolveGitHubTokenForRepo,
   resolveManagedBitbucketToken,
 } from '../services/git-token-service-client.js';
-import type { SessionRepositoryRequest } from './session-requests.js';
+import type { SessionCreateRequest, SessionRepositoryRequest } from './session-requests.js';
+import { withDORetry } from '../utils/do-retry.js';
+import { resolveSessionStub } from '../sandbox-session/session-stub.js';
+
+const TEMPORARY_GITHUB_RESOLUTION_REASONS = new Set([
+  'database_not_configured',
+  'service_not_configured',
+  'temporarily_unavailable',
+  'rpc_error',
+  'source_unavailable',
+]);
+
+function githubRepositoryAuthorizationError(reason: string): TRPCError {
+  return new TRPCError({
+    code: TEMPORARY_GITHUB_RESOLUTION_REASONS.has(reason) ? 'SERVICE_UNAVAILABLE' : 'BAD_REQUEST',
+    message: `GitHub repository authorization failed (${reason})`,
+  });
+}
+
+function repositoriesMatch(left: string, right: string): boolean {
+  return left.toLowerCase() === right.toLowerCase();
+}
+
+function readGitHubRepository(
+  value: unknown
+): { type: 'github'; repo: string; githubIntegrationId?: string } | undefined {
+  if (typeof value !== 'object' || value === null) return undefined;
+  const repository = (value as { repository?: unknown }).repository;
+  if (typeof repository !== 'object' || repository === null) return undefined;
+  const fields = repository as {
+    type?: unknown;
+    repo?: unknown;
+    githubIntegrationId?: unknown;
+  };
+  if (fields.type !== 'github' || typeof fields.repo !== 'string') return undefined;
+  return {
+    type: 'github',
+    repo: fields.repo,
+    ...(typeof fields.githubIntegrationId === 'string'
+      ? { githubIntegrationId: fields.githubIntegrationId }
+      : {}),
+  };
+}
+
+async function resolveCloneSourceGitHubRepository(input: {
+  env: PersistenceEnv;
+  userId: string;
+  request: SessionCreateRequest;
+}): Promise<{ repo: string; githubIntegrationId?: string } | null> {
+  const sourceKiloSessionId = input.request.clone?.cloneFromKiloSessionId;
+  if (!sourceKiloSessionId) return null;
+
+  let source;
+  try {
+    source = await input.env.SESSION_INGEST.resolveCloudAgentRootSessionForKiloSession({
+      kiloUserId: input.userId,
+      kiloSessionId: sourceKiloSessionId,
+    });
+  } catch {
+    throw githubRepositoryAuthorizationError('source_unavailable');
+  }
+  if (!source) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'source_access_denied' });
+  }
+
+  let sourceMetadata: unknown;
+  try {
+    sourceMetadata = await withDORetry(
+      () => resolveSessionStub(input.env, input.userId, source.cloudAgentSessionId),
+      stub => stub.getMetadata(),
+      'CloudAgentSession.getMetadataForCloneRepository'
+    );
+  } catch {
+    throw githubRepositoryAuthorizationError('source_unavailable');
+  }
+
+  const metadataRepository = readGitHubRepository(sourceMetadata);
+  if (!metadataRepository) {
+    throw githubRepositoryAuthorizationError('source_unavailable');
+  }
+  const mappedRepository = readGitHubRepository(source);
+  if (
+    mappedRepository &&
+    metadataRepository &&
+    !repositoriesMatch(mappedRepository.repo, metadataRepository.repo)
+  ) {
+    throw githubRepositoryAuthorizationError('source_unavailable');
+  }
+
+  const repo = mappedRepository?.repo ?? metadataRepository.repo;
+  return {
+    repo,
+    ...(metadataRepository.githubIntegrationId
+      ? { githubIntegrationId: metadataRepository.githubIntegrationId }
+      : {}),
+  };
+}
+
+/**
+ * Resolves and pins GitHub repository identity before any operation-ledger or
+ * session allocation work. The returned request contains no resolved token.
+ */
+export async function canonicalizeRepositoryBeforeSessionCreation(input: {
+  env: PersistenceEnv;
+  userId: string;
+  orgId?: string;
+  request: SessionCreateRequest;
+}): Promise<SessionCreateRequest> {
+  if (input.request.repository.type !== 'github') return input.request;
+
+  const submitted = input.request.repository;
+  const source = await resolveCloneSourceGitHubRepository(input);
+  if (source && !repositoriesMatch(submitted.repo, source.repo)) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'clone_repository_mismatch' });
+  }
+  if (
+    source?.githubIntegrationId &&
+    submitted.githubIntegrationId &&
+    source.githubIntegrationId.toLowerCase() !== submitted.githubIntegrationId.toLowerCase()
+  ) {
+    throw new TRPCError({ code: 'BAD_REQUEST', message: 'clone_integration_mismatch' });
+  }
+
+  const expectedIntegrationId = source?.githubIntegrationId ?? submitted.githubIntegrationId;
+  const result = await resolveGitHubTokenForRepo(input.env, {
+    githubRepo: source?.repo ?? submitted.repo,
+    userId: input.userId,
+    ...(input.orgId ? { orgId: input.orgId } : {}),
+    ...(expectedIntegrationId ? { expectedIntegrationId } : {}),
+  });
+  if (!result.success) throw githubRepositoryAuthorizationError(result.error.reason);
+
+  return {
+    ...input.request,
+    repository: {
+      ...submitted,
+      ...(source ? { repo: source.repo } : {}),
+      githubIntegrationId: result.value.platformIntegrationId,
+    },
+  };
+}
 
 export async function assertRepositoryAccessBeforeSessionCreation(input: {
   env: PersistenceEnv;
@@ -13,25 +153,6 @@ export async function assertRepositoryAccessBeforeSessionCreation(input: {
   orgId?: string;
   repository: SessionRepositoryRequest;
 }): Promise<void> {
-  if (input.repository.type === 'github' && input.repository.githubIntegrationId) {
-    const result = await resolveGitHubTokenForRepo(input.env, {
-      githubRepo: input.repository.repo,
-      userId: input.userId,
-      ...(input.orgId ? { orgId: input.orgId } : {}),
-      expectedIntegrationId: input.repository.githubIntegrationId,
-    });
-    if (!result.success) {
-      throw new TRPCError({
-        code:
-          result.error.reason === 'service_not_configured' || result.error.reason === 'rpc_error'
-            ? 'SERVICE_UNAVAILABLE'
-            : 'BAD_REQUEST',
-        message: `GitHub repository authorization failed (${result.error.reason})`,
-      });
-    }
-    return;
-  }
-
   if (input.repository.type !== 'bitbucket') return;
   if (!input.orgId) {
     throw new TRPCError({

--- a/services/session-ingest/src/session-ingest-rpc.test.ts
+++ b/services/session-ingest/src/session-ingest-rpc.test.ts
@@ -99,6 +99,7 @@ const sdkStoredMessageFixture = { info: sdkUserMessageFixture, parts: [sdkTextPa
 type MappingRow = {
   kiloSessionId?: string;
   cloudAgentSessionId?: string | null;
+  gitUrl?: string | null;
   title?: string | null;
   createdAt?: string;
   updatedAt?: string;
@@ -1435,7 +1436,12 @@ describe('SessionIngestRPC.resolveCloudAgentRootSessionForKiloSession', () => {
   });
 
   it('returns the Cloud Agent session ID for an owned root Kilo session mapping', async () => {
-    const { db, select } = makeDbFakes([{ cloudAgentSessionId: 'agent_owned_root' }]);
+    const { db, select } = makeDbFakes([
+      {
+        cloudAgentSessionId: 'agent_owned_root',
+        gitUrl: 'https://github.com/Acme/Repo',
+      },
+    ]);
     const rpc = makeRpc(db);
 
     const result = await rpc.resolveCloudAgentRootSessionForKiloSession({
@@ -1443,10 +1449,28 @@ describe('SessionIngestRPC.resolveCloudAgentRootSessionForKiloSession', () => {
       kiloSessionId: 'ses_12345678901234567890123456',
     });
 
-    expect(result).toEqual({ cloudAgentSessionId: 'agent_owned_root' });
-    expect(db.select).toHaveBeenCalledWith({ cloudAgentSessionId: expect.anything() });
+    expect(result).toEqual({
+      cloudAgentSessionId: 'agent_owned_root',
+      repository: { type: 'github', repo: 'Acme/Repo' },
+    });
+    expect(db.select).toHaveBeenCalledWith({
+      cloudAgentSessionId: expect.anything(),
+      gitUrl: expect.anything(),
+    });
     expect(select.leftJoin).toHaveBeenCalledWith(organization_memberships, expect.anything());
     expect(or).toHaveBeenCalled();
+  });
+
+  it('keeps the legacy result shape when the root has no sanitized GitHub repository', async () => {
+    const { db } = makeDbFakes([{ cloudAgentSessionId: 'agent_legacy_root', gitUrl: null }]);
+    const rpc = makeRpc(db);
+
+    await expect(
+      rpc.resolveCloudAgentRootSessionForKiloSession({
+        kiloUserId: 'usr_owner',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({ cloudAgentSessionId: 'agent_legacy_root' });
   });
 
   it('returns null when no owned Cloud Agent root mapping is found', async () => {

--- a/services/session-ingest/src/session-ingest-rpc.test.ts
+++ b/services/session-ingest/src/session-ingest-rpc.test.ts
@@ -99,6 +99,7 @@ const sdkStoredMessageFixture = { info: sdkUserMessageFixture, parts: [sdkTextPa
 type MappingRow = {
   kiloSessionId?: string;
   cloudAgentSessionId?: string | null;
+  organizationId?: string | null;
   gitUrl?: string | null;
   title?: string | null;
   createdAt?: string;
@@ -661,6 +662,7 @@ describe('createSessionForCloudAgent clone path', () => {
 
   function makeCloneDb(options: {
     sourceRows: Array<{ sessionId: string; organizationId: string | null }>;
+    transactionSourceRows?: Array<{ organizationId: string | null }>;
     destinationRows?: Array<Record<string, unknown>>;
     created?: Record<string, unknown>;
     existing?: Record<string, unknown>;
@@ -698,8 +700,12 @@ describe('createSessionForCloudAgent clone path', () => {
     };
     const txSelect = {
       from: vi.fn(() => txSelect),
+      leftJoin: vi.fn(() => txSelect),
       where: vi.fn(() => txSelect),
       limit: vi.fn(() => txSelect),
+      then: vi.fn((resolve: (value: unknown) => unknown) =>
+        resolve(options.transactionSourceRows ?? options.sourceRows)
+      ),
       for: vi.fn(async () => (options.existing ? [options.existing] : [])),
     };
     const update = {
@@ -888,6 +894,24 @@ describe('createSessionForCloudAgent clone path', () => {
     });
     expect(values).not.toHaveBeenCalled();
     expect(sourceStub.exportCloneBatch).not.toHaveBeenCalled();
+  });
+
+  it('revalidates source access in the final insert transaction', async () => {
+    const sourceStub = makePagedSourceStub([sourceSessionItem()], 100);
+    const dest = makeDestinationStub();
+    const r2 = { get: vi.fn(async () => null), put: vi.fn(async () => {}) };
+    const { db, values } = makeCloneDb({
+      sourceRows: [{ sessionId: sourceSessionId, organizationId }],
+      transactionSourceRows: [],
+    });
+    const rpc = makeCloneRpc({ db, sourceStub, destStub: dest.stub, r2 });
+
+    await expect(rpc.createSessionForCloudAgent(cloneParams())).resolves.toEqual({
+      status: 'rejected',
+      code: 'source_access_denied',
+    });
+    expect(values).not.toHaveBeenCalled();
+    expect(dest.stub.resetCloneStage).toHaveBeenCalled();
   });
 
   it('rejects with malformed_source_data and resets the destination stage', async () => {
@@ -1508,6 +1532,72 @@ describe('SessionIngestRPC.resolveCloudAgentRootSessionForKiloSession', () => {
       })
     ).rejects.toThrow();
     expect(db.select).not.toHaveBeenCalled();
+  });
+});
+
+describe('SessionIngestRPC.resolveAuthorizedSessionSource', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('returns organization, sanitized repository, and optional Cloud Agent mapping', async () => {
+    const { db } = makeDbFakes([
+      {
+        kiloSessionId: 'ses_12345678901234567890123456',
+        organizationId: '11111111-1111-4111-8111-111111111111',
+        gitUrl: 'git@github.com:Acme/Repo.git',
+        cloudAgentSessionId: 'agent_owned_root',
+      },
+    ]);
+    const rpc = makeRpc(db);
+
+    await expect(
+      rpc.resolveAuthorizedSessionSource({
+        kiloUserId: 'usr_owner',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({
+      organizationId: '11111111-1111-4111-8111-111111111111',
+      repository: { type: 'github', repo: 'Acme/Repo' },
+      cloudAgentSessionId: 'agent_owned_root',
+    });
+  });
+
+  it('supports child and remote CLI sources without a Cloud Agent mapping', async () => {
+    const { db } = makeDbFakes([
+      {
+        kiloSessionId: 'ses_12345678901234567890123456',
+        organizationId: null,
+        gitUrl: 'https://gitlab.com/acme/repo.git',
+        cloudAgentSessionId: null,
+      },
+    ]);
+    const rpc = makeRpc(db);
+
+    await expect(
+      rpc.resolveAuthorizedSessionSource({
+        kiloUserId: 'usr_owner',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toEqual({
+      organizationId: null,
+      repository: {
+        type: 'git',
+        url: 'https://gitlab.com/acme/repo',
+        platform: 'gitlab',
+      },
+    });
+  });
+
+  it('returns null for both missing and inaccessible sources', async () => {
+    const { db } = makeDbFakes([]);
+    const rpc = makeRpc(db);
+    await expect(
+      rpc.resolveAuthorizedSessionSource({
+        kiloUserId: 'usr_owner',
+        kiloSessionId: 'ses_12345678901234567890123456',
+      })
+    ).resolves.toBeNull();
   });
 });
 

--- a/services/session-ingest/src/session-ingest-rpc.ts
+++ b/services/session-ingest/src/session-ingest-rpc.ts
@@ -10,6 +10,7 @@ import {
   kiloSdkSessionSnapshotOutcomeSchema,
   listCloudAgentRootSessionsSchema,
   persistedKiloSdkMessageHistorySchema,
+  resolveAuthorizedSessionSourceSchema,
   resolveCloudAgentRootSessionSchema,
   type CloudAgentRootSessionSnapshot,
   type CloudAgentRootSessionSummary,
@@ -25,6 +26,8 @@ import {
   type ListCloudAgentRootSessionsParams,
   type ResolveCloudAgentRootSessionForKiloSessionParams,
   type ResolveCloudAgentRootSessionForKiloSessionResult,
+  type ResolveAuthorizedSessionSourceParams,
+  type ResolveAuthorizedSessionSourceResult,
   type SessionIngestRpcMethods,
 } from '@kilocode/session-ingest-contracts';
 
@@ -43,6 +46,13 @@ import {
 const MAX_CLOUD_AGENT_ROOT_SESSION_TITLE_CHARACTERS = 512;
 const CLOUD_AGENT_ROOT_SESSION_IDENTITY_CONFLICT_ERROR =
   'Cloud Agent root session identity conflict';
+
+class ClonePublicationError extends Error {
+  constructor(readonly code: 'source_access_denied' | 'organization_mismatch') {
+    super(code);
+    this.name = 'ClonePublicationError';
+  }
+}
 
 type CliSessionsV2Row = typeof cli_sessions_v2.$inferSelect;
 
@@ -167,6 +177,18 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
         // Never clear that other session's Durable Object data.
         return { status: 'rejected', code: 'destination_conflict' };
       }
+      if (error instanceof ClonePublicationError) {
+        await withDORetry(
+          () =>
+            getSessionIngestDO(this.env, {
+              kiloUserId: parsed.kiloUserId,
+              sessionId: parsed.sessionId,
+            }),
+          stub => stub.resetCloneStage(),
+          'SessionIngestDO.resetCloneStage'
+        );
+        return { status: 'rejected', code: error.code };
+      }
       if (await this.findMatchingCommittedRootSession(parsed)) {
         return { status: 'ready', clone: { sessionId: parsed.sessionId, copiedItemCount } };
       }
@@ -260,6 +282,29 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
     return db.transaction(async tx => {
       if (!(await canCreateCliSessionForUser(tx, parsed.kiloUserId))) {
         throw new Error(USER_SESSION_ADMISSION_ERROR);
+      }
+
+      const cloneSourceSessionId = parsed.cloneFromKiloSessionId;
+      if (cloneSourceSessionId !== undefined) {
+        const [source] = await tx
+          .select({ organizationId: cli_sessions_v2.organization_id })
+          .from(cli_sessions_v2)
+          .leftJoin(
+            organization_memberships,
+            organizationMembershipJoinCondition(parsed.kiloUserId)
+          )
+          .where(
+            and(
+              eq(cli_sessions_v2.session_id, cloneSourceSessionId),
+              eq(cli_sessions_v2.kilo_user_id, parsed.kiloUserId),
+              personalOrAccessibleOrganizationCondition()
+            )
+          )
+          .limit(1);
+        if (!source) throw new ClonePublicationError('source_access_denied');
+        if (source.organizationId !== (parsed.organizationId ?? null)) {
+          throw new ClonePublicationError('organization_mismatch');
+        }
       }
 
       const [created] = await tx
@@ -364,6 +409,37 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
             },
           }
         : {}),
+    };
+  }
+
+  async resolveAuthorizedSessionSource(
+    params: ResolveAuthorizedSessionSourceParams
+  ): Promise<ResolveAuthorizedSessionSourceResult> {
+    const parsed = resolveAuthorizedSessionSourceSchema.parse(params);
+    const source = await this.findOwnedAccessibleSession(parsed);
+    if (!source) return null;
+
+    const parsedRepository = source.gitUrl ? parseGitUrl(source.gitUrl) : null;
+    const repository =
+      parsedRepository?.platform === 'github'
+        ? {
+            type: 'github' as const,
+            repo: `${parsedRepository.owner}/${parsedRepository.repo}`,
+          }
+        : source.gitUrl
+          ? {
+              type: 'git' as const,
+              url: normalizeGitUrl(source.gitUrl),
+              ...(parsedRepository?.platform === 'gitlab' ||
+              parsedRepository?.platform === 'bitbucket'
+                ? { platform: parsedRepository.platform }
+                : {}),
+            }
+          : undefined;
+    return {
+      organizationId: source.organizationId,
+      ...(repository ? { repository } : {}),
+      ...(source.cloudAgentSessionId ? { cloudAgentSessionId: source.cloudAgentSessionId } : {}),
     };
   }
 
@@ -550,12 +626,19 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
   private async findOwnedAccessibleSession(params: {
     kiloUserId: string;
     kiloSessionId: string;
-  }): Promise<{ kiloSessionId: string; organizationId: string | null } | null> {
+  }): Promise<{
+    kiloSessionId: string;
+    organizationId: string | null;
+    gitUrl: string | null;
+    cloudAgentSessionId: string | null;
+  } | null> {
     const db = getWorkerDb(this.env.HYPERDRIVE.connectionString);
     const rows = await db
       .select({
         sessionId: cli_sessions_v2.session_id,
         organizationId: cli_sessions_v2.organization_id,
+        gitUrl: cli_sessions_v2.git_url,
+        cloudAgentSessionId: cli_sessions_v2.cloud_agent_session_id,
       })
       .from(cli_sessions_v2)
       .leftJoin(organization_memberships, organizationMembershipJoinCondition(params.kiloUserId))
@@ -568,7 +651,12 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
       )
       .limit(1);
     return rows[0]
-      ? { kiloSessionId: rows[0].sessionId, organizationId: rows[0].organizationId }
+      ? {
+          kiloSessionId: rows[0].sessionId,
+          organizationId: rows[0].organizationId,
+          gitUrl: rows[0].gitUrl,
+          cloudAgentSessionId: rows[0].cloudAgentSessionId,
+        }
       : null;
   }
 

--- a/services/session-ingest/src/session-ingest-rpc.ts
+++ b/services/session-ingest/src/session-ingest-rpc.ts
@@ -31,7 +31,7 @@ import {
 import type { Env } from './env';
 import { getSessionIngestDO, type InspectCloneStageResult } from './dos/SessionIngestDO';
 import { getSessionAccessCacheDO } from './dos/SessionAccessCacheDO';
-import { normalizeGitUrl, withDORetry } from '@kilocode/worker-utils';
+import { normalizeGitUrl, parseGitUrl, withDORetry } from '@kilocode/worker-utils';
 import { app } from './app';
 import { mapSessionEventRow, notifyUserSessionEvent } from './session-events';
 import { cloneSessionIntoDestination } from './clone/session-clone';
@@ -351,7 +351,20 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
   ): Promise<ResolveCloudAgentRootSessionForKiloSessionResult> {
     const parsed = resolveCloudAgentRootSessionSchema.parse(params);
     const mapping = await this.findOwnedRootCloudAgentMapping(parsed);
-    return mapping ? { cloudAgentSessionId: mapping.cloudAgentSessionId } : null;
+    if (!mapping) return null;
+
+    const parsedRepository = mapping.gitUrl ? parseGitUrl(mapping.gitUrl) : null;
+    return {
+      cloudAgentSessionId: mapping.cloudAgentSessionId,
+      ...(parsedRepository?.platform === 'github'
+        ? {
+            repository: {
+              type: 'github' as const,
+              repo: `${parsedRepository.owner}/${parsedRepository.repo}`,
+            },
+          }
+        : {}),
+    };
   }
 
   async getCloudAgentRootSessionSnapshot(
@@ -504,10 +517,13 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
   private async findOwnedRootCloudAgentMapping(params: {
     kiloUserId: string;
     kiloSessionId: string;
-  }): Promise<{ cloudAgentSessionId: string } | null> {
+  }): Promise<{ cloudAgentSessionId: string; gitUrl: string | null } | null> {
     const db = getWorkerDb(this.env.HYPERDRIVE.connectionString);
     const rows = await db
-      .select({ cloudAgentSessionId: cli_sessions_v2.cloud_agent_session_id })
+      .select({
+        cloudAgentSessionId: cli_sessions_v2.cloud_agent_session_id,
+        gitUrl: cli_sessions_v2.git_url,
+      })
       .from(cli_sessions_v2)
       .leftJoin(organization_memberships, organizationMembershipJoinCondition(params.kiloUserId))
       .where(
@@ -522,7 +538,7 @@ export class SessionIngestRPC extends WorkerEntrypoint<Env> implements SessionIn
       .limit(1);
 
     const cloudAgentSessionId = rows[0]?.cloudAgentSessionId;
-    return cloudAgentSessionId ? { cloudAgentSessionId } : null;
+    return cloudAgentSessionId ? { cloudAgentSessionId, gitUrl: rows[0]?.gitUrl ?? null } : null;
   }
 
   /**


### PR DESCRIPTION
## Why this PR exists

Cloud Agent callers should not independently decide which GitHub installation owns `owner/repo`. Duplicated client-side selection made continuation especially fragile: mobile was reverse-mapping repository DTOs even though the server owns the source session.

#5584 resolves live repository installation identity authoritatively. This PR makes Cloud Agent canonicalize that identity once, persist it safely, and reuse it through session creation and continuation.

## Place in the rollout

This replaces #5587 and the client-side mobile continuation PR #5546. Clients may submit `owner/repo`; explicit installation IDs remain optional fences for true user choice, webhooks, reviews, and persisted records.

## Dependency

Depends on #5584.

## What changes

- Canonicalize GitHub session requests to the resolved Kilo integration ID.
- Persist canonical identity in session metadata and operation-ledger progress.
- Resolve clone source identity server-side for Cloud Agent, remote CLI, and child Kilo sessions.
- Inherit a source Cloud Agent pin when available; otherwise resolve the source repository live.
- Reject repository, integration, and organization mismatches before allocation.
- Preserve the original caller intent fingerprint, including any explicit integration fence.
- Revalidate clone source access in the final Session Ingest publication transaction.
- Keep attach and control-plane token resolution fenced to persisted identity.
- Runtime-validate rolling Git Token Service responses.

## Ledger safety

Canonicalization is a live provider call, so a ledger-backed create computes caller intent and checks the operation key before invoking GitHub. The first admitted attempt then canonicalizes the repository and records the resolved integration with allocation progress.

Settled retries replay stored results without requiring GitHub. Takeover and reconcile-pending retries reuse the recorded canonical repository rather than rediscovering a possibly different installation. Compatibility rows admitted before canonical pins existed may resolve once and record the result. A canonicalization failure marks the admitted row reconcile-pending rather than opening an untracked second allocation path, and execution still reauthorizes the persisted integration when credentials are needed.

## Exact rolling-deploy fallback

Cloudflare service-binding stubs expose callable properties even when an older Session Ingest deployment does not implement the method. Cloud Agent therefore calls the canonical source resolver and falls back to `resolveCloudAgentRootSessionForKiloSession` only for the exact old-deployment signal `TypeError: The RPC receiver does not implement the method "resolveAuthorizedSessionSource".`

Provider or database failures, a different missing method, and invalid or `undefined` canonical results do not use the legacy fallback and are not misclassified as capability absence.

## What stays unchanged

- Tokens are never persisted; delayed workspace preparation reauthorizes the exact stored installation.
- Personal and non-GitHub behavior remains unchanged.
- Existing remote CLI and child-session continuation remains supported.
- Older Session Ingest deployments remain compatible through the exact missing-RPC fallback above.

## Review guide

1. Review the generic authorized source descriptor in Session Ingest.
2. Review GitHub canonicalization, source pin inheritance, and exact fallback predicate.
3. Review ledger admission, intent fingerprinting, canonical progress storage, and settled or reconcile replay.
4. Review exact runtime and attach reauthorization plus final clone-source publication checks.

## Replaces

- #5587, recreated on the corrected #5584 foundation.
- #5546, which made mobile resolve continuation identity.

## Validation

- Cloud Agent unit: 3,249 passed, 3 skipped
- Cloud Agent Workers integration: 278 passed
- Cloud Agent serialized wrapper: 411 passed
- Session Ingest unit: 924 passed, 3 skipped
- Session Ingest Workers integration: 84 passed
- Git Token Service: 557 passed
- Web environment: 17 passed
- Local development tooling: 302 passed
- Full repository typecheck and lint
- Affected formatting and `git diff --check`