### PR TITLE
feat(chat-bots): expose repositories from every connected GitHub org

### DIFF
--- a/apps/web/src/lib/bot/agent-runner.ts
+++ b/apps/web/src/lib/bot/agent-runner.ts
@@ -115,13 +115,13 @@ Today's date: ${currentDate}
 ## Context you may receive
 Additional context may be appended to this prompt:
 - Conversation context (recent messages, thread context)
-${githubContext.repositories ? '- Available GitHub repositories for this integration' : ''}
+${githubContext.installations.some(installation => installation.repositories?.length) ? '- Available GitHub repositories for this integration' : ''}
 ${gitlabContext.repositories ? '- Available GitLab projects for this integration' : ''}
 
 ${formatGitHubRepositoriesForPrompt(githubContext)}
 ${formatGitLabRepositoriesForPrompt(gitlabContext)}
 
-Treat this context as authoritative. Prefer selecting a repo from the provided repository list. If the user requests work on a repo that isn't in the list, ask them to confirm the exact owner/repo (or group/project for GitLab) and ensure it's accessible to the integration. Never invent repository names.
+Use this context to select repositories, not to authorize access. Prefer selecting a repo from the provided repository list. If the user requests work on a repo that isn't in the list, ask them to confirm the exact owner/repo (or group/project for GitLab). Cloud Agent resolves and authorizes GitHub repositories. Never invent repository names.
 
 ## Cloud Agent tool
 If the user asks you to analyze or act on an attached image or file (PDF, Markdown, text, CSV), you must use the spawnCloudAgentSession tool to start a Cloud Agent session that will process the attachment.

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.test.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.test.ts
@@ -2,10 +2,7 @@ import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals
 import type { PlatformIntegration } from '@kilocode/db';
 import type { CloudAgentAttachments } from '@/lib/cloud-agent/constants';
 import type { createCloudAgentNextClient as CreateCloudAgentNextClient } from '@/lib/cloud-agent-next/cloud-agent-client';
-import type {
-  getGitHubTokenForOrganization as GetGitHubTokenForOrganization,
-  getGitHubTokenForUser as GetGitHubTokenForUser,
-} from '@/lib/cloud-agent/github-integration-helpers';
+import type { getGitHubTokenForUser as GetGitHubTokenForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import type {
   buildGitLabCloneUrl as BuildGitLabCloneUrl,
   getGitLabInstanceUrlForUser as GetGitLabInstanceUrlForUser,
@@ -26,8 +23,11 @@ jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
 }));
 
 jest.mock('@/lib/cloud-agent/github-integration-helpers', () => ({
-  getGitHubTokenForOrganization: jest.fn(),
   getGitHubTokenForUser: jest.fn(),
+}));
+
+jest.mock('@/lib/bot-users/bot-user-service', () => ({
+  getBotUserId: jest.fn(),
 }));
 
 jest.mock('@/lib/cloud-agent/gitlab-integration-helpers', () => ({
@@ -50,6 +50,7 @@ const organizationIntegration = {
   owned_by_organization_id: 'organization-1',
   owned_by_user_id: null,
 } as PlatformIntegration;
+const githubIntegrationId = '123e4567-e89b-12d3-a456-426614174022';
 const attachments: CloudAgentAttachments = {
   path: 'message-attachments',
   files: ['image.png', 'requirements.md'],
@@ -68,7 +69,6 @@ const mockPrepareSession =
 const mockInitiateFromPreparedSession = jest.fn<(input: unknown) => Promise<unknown>>();
 let spawnCloudAgentSession: typeof SpawnCloudAgentSession;
 let mockCreateCloudAgentNextClient: jest.MockedFunction<typeof CreateCloudAgentNextClient>;
-let mockGetGitHubTokenForOrganization: jest.MockedFunction<typeof GetGitHubTokenForOrganization>;
 let mockGetGitHubTokenForUser: jest.MockedFunction<typeof GetGitHubTokenForUser>;
 let mockGetGitLabTokenForUser: jest.MockedFunction<typeof GetGitLabTokenForUser>;
 let mockGetGitLabInstanceUrlForUser: jest.MockedFunction<typeof GetGitLabInstanceUrlForUser>;
@@ -82,7 +82,6 @@ describe('spawnCloudAgentSession delegation', () => {
     const spawn = await import('./spawn-cloud-agent-session');
 
     mockCreateCloudAgentNextClient = jest.mocked(client.createCloudAgentNextClient);
-    mockGetGitHubTokenForOrganization = jest.mocked(github.getGitHubTokenForOrganization);
     mockGetGitHubTokenForUser = jest.mocked(github.getGitHubTokenForUser);
     mockGetGitLabTokenForUser = jest.mocked(gitlab.getGitLabTokenForUser);
     mockGetGitLabInstanceUrlForUser = jest.mocked(gitlab.getGitLabInstanceUrlForUser);
@@ -101,7 +100,6 @@ describe('spawnCloudAgentSession delegation', () => {
       kiloSessionId: 'kilo-session-1',
     });
     mockInitiateFromPreparedSession.mockResolvedValue({});
-    mockGetGitHubTokenForOrganization.mockResolvedValue('organization-github-token');
     mockGetGitHubTokenForUser.mockResolvedValue('github-token');
     mockGetGitLabTokenForUser.mockResolvedValue('gitlab-token');
     mockGetGitLabInstanceUrlForUser.mockResolvedValue('https://gitlab.com');
@@ -112,7 +110,13 @@ describe('spawnCloudAgentSession delegation', () => {
     const onSessionReady = jest.fn();
 
     await spawnCloudAgentSession(
-      { githubRepo: 'owner/repo', prompt: 'Use the files', mode: 'code' },
+      {
+        githubRepo: 'owner/repo',
+        githubAccount: 'owner',
+        githubIntegrationId,
+        prompt: 'Use the files',
+        mode: 'code',
+      },
       'model',
       organizationIntegration,
       'auth-token',
@@ -125,7 +129,7 @@ describe('spawnCloudAgentSession delegation', () => {
     expect(prepareInput).toEqual(
       expect.objectContaining({
         githubRepo: 'owner/repo',
-        githubToken: 'organization-github-token',
+        githubIntegrationId,
         kilocodeOrganizationId: 'organization-1',
         createdOnPlatform: 'slack',
         attachments,
@@ -136,6 +140,8 @@ describe('spawnCloudAgentSession delegation', () => {
       })
     );
     expect(prepareInput).not.toHaveProperty('images');
+    expect(prepareInput).not.toHaveProperty('githubToken');
+    expect(mockGetGitHubTokenForUser).not.toHaveBeenCalled();
     for (const field of profileDerivedInlineFields) {
       expect(prepareInput).not.toHaveProperty(field);
     }

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.test.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.test.ts
@@ -9,6 +9,18 @@ import type {
   getGitLabTokenForUser as GetGitLabTokenForUser,
 } from '@/lib/cloud-agent/gitlab-integration-helpers';
 import type SpawnCloudAgentSession from './spawn-cloud-agent-session';
+import type { GitHubRepositoryContext } from '@/lib/slack-bot/github-repository-context';
+
+const mockGetGitHubRepositoryContext =
+  jest.fn<(...args: unknown[]) => Promise<GitHubRepositoryContext>>();
+const mockResolveDisplayedGitHubIntegrationId =
+  jest.fn<
+    (
+      context: GitHubRepositoryContext,
+      repositoryFullName: string,
+      requestedIntegrationId: string | undefined
+    ) => string | undefined
+  >();
 
 jest.mock('@/lib/config.server', () => ({
   CALLBACK_TOKEN_SECRET: 'callback-secret',
@@ -24,6 +36,15 @@ jest.mock('@/lib/cloud-agent-next/cloud-agent-client', () => ({
 
 jest.mock('@/lib/cloud-agent/github-integration-helpers', () => ({
   getGitHubTokenForUser: jest.fn(),
+}));
+
+jest.mock('@/lib/slack-bot/github-repository-context', () => ({
+  getGitHubRepositoryContext: (...args: unknown[]) => mockGetGitHubRepositoryContext(...args),
+  resolveDisplayedGitHubIntegrationId: (
+    context: GitHubRepositoryContext,
+    repositoryFullName: string,
+    requestedIntegrationId: string | undefined
+  ) => mockResolveDisplayedGitHubIntegrationId(context, repositoryFullName, requestedIntegrationId),
 }));
 
 jest.mock('@/lib/bot-users/bot-user-service', () => ({
@@ -101,9 +122,62 @@ describe('spawnCloudAgentSession delegation', () => {
     });
     mockInitiateFromPreparedSession.mockResolvedValue({});
     mockGetGitHubTokenForUser.mockResolvedValue('github-token');
+    mockResolveDisplayedGitHubIntegrationId.mockImplementation(
+      (_context, _repository, requestedIntegrationId) => requestedIntegrationId
+    );
+    mockGetGitHubRepositoryContext.mockResolvedValue({
+      installations: [
+        {
+          platformIntegrationId: githubIntegrationId,
+          accountLogin: 'owner',
+          repositoryAccess: 'selected',
+          repositoriesSyncedAt: null,
+          repositories: [{ id: 1, name: 'repo', full_name: 'owner/repo', private: true }],
+        },
+        {
+          platformIntegrationId: '123e4567-e89b-12d3-a456-426614174023',
+          accountLogin: 'owner',
+          repositoryAccess: 'selected',
+          repositoriesSyncedAt: null,
+          repositories: [{ id: 1, name: 'repo', full_name: 'owner/repo', private: true }],
+        },
+      ],
+    });
     mockGetGitLabTokenForUser.mockResolvedValue('gitlab-token');
     mockGetGitLabInstanceUrlForUser.mockResolvedValue('https://gitlab.com');
     mockBuildGitLabCloneUrl.mockReturnValue('https://gitlab.com/group/repo.git');
+  });
+
+  it('omits a supplied integration ID when the displayed repository choice is unique', async () => {
+    mockResolveDisplayedGitHubIntegrationId.mockReturnValueOnce(undefined);
+    mockGetGitHubRepositoryContext.mockResolvedValueOnce({
+      installations: [
+        {
+          platformIntegrationId: githubIntegrationId,
+          accountLogin: 'owner',
+          repositoryAccess: 'selected',
+          repositoriesSyncedAt: null,
+          repositories: [{ id: 1, name: 'repo', full_name: 'owner/repo', private: true }],
+        },
+      ],
+    });
+
+    await spawnCloudAgentSession(
+      {
+        githubRepo: 'owner/repo',
+        githubIntegrationId,
+        prompt: 'Inspect the repository',
+        mode: 'ask',
+      },
+      'model',
+      organizationIntegration,
+      'auth-token',
+      'request-unique'
+    );
+
+    expect(mockPrepareSession).toHaveBeenCalledWith(
+      expect.objectContaining({ githubRepo: 'owner/repo', githubIntegrationId: undefined })
+    );
   });
 
   it('delegates GitHub profile resolution while preserving repository and organization context', async () => {

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -4,10 +4,7 @@ import {
   type PrepareSessionInput,
 } from '@/lib/cloud-agent-next/cloud-agent-client';
 import type { RunSessionInput } from '@/lib/cloud-agent-next/run-session';
-import {
-  getGitHubTokenForOrganization,
-  getGitHubTokenForUser,
-} from '@/lib/cloud-agent/github-integration-helpers';
+import { getGitHubTokenForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import {
   getGitLabTokenForOrganization,
   getGitLabTokenForUser,
@@ -59,6 +56,16 @@ export const spawnCloudAgentInputSchema = z.object({
     .string()
     .regex(/^[-a-zA-Z0-9_.]+\/[-a-zA-Z0-9_.]+$/)
     .describe('The GitHub repository in owner/repo format (e.g., "facebook/react")')
+    .optional(),
+  githubAccount: z
+    .string()
+    .min(1)
+    .describe('Optional account hint shown with an explicitly selected repository entry')
+    .optional(),
+  githubIntegrationId: z
+    .string()
+    .uuid()
+    .describe('Optional integration ID for an explicit choice between duplicate repository entries')
     .optional(),
   gitlabProject: z
     .string()
@@ -183,13 +190,11 @@ export default async function spawnCloudAgentSession(
       attachments: options?.attachments,
     };
   } else {
-    // GitHub path: get token, use githubRepo/githubToken
-    const githubToken =
-      owner.type === 'org'
-        ? await getGitHubTokenForOrganization(owner.id)
-        : await getGitHubTokenForUser(owner.id);
+    // Cloud Agent resolves organization repository access and persists its canonical identity.
+    // Personal sessions keep their existing token path.
+    const githubToken = owner.type === 'user' ? await getGitHubTokenForUser(owner.id) : undefined;
 
-    if (!githubToken) {
+    if (owner.type === 'user' && !githubToken) {
       return {
         response:
           'Error: No GitHub token available. Please ensure a GitHub integration is connected in your Kilo Code settings.',
@@ -198,10 +203,11 @@ export default async function spawnCloudAgentSession(
 
     prepareInput = {
       githubRepo: args.githubRepo,
+      githubIntegrationId: args.githubIntegrationId,
       prompt,
       mode,
       model,
-      githubToken,
+      ...(githubToken ? { githubToken } : {}),
       kilocodeOrganizationId,
       createdOnPlatform: chatPlatform,
       callbackTarget,

--- a/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
+++ b/apps/web/src/lib/bot/tools/spawn-cloud-agent-session.ts
@@ -18,6 +18,10 @@ import { CALLBACK_TOKEN_SECRET } from '@/lib/config.server';
 import { parseBotCallbackStep } from '@/lib/bot/step-budget';
 import { ownerFromIntegration } from '@/lib/integrations/core/owner';
 import type { Owner } from '@/lib/integrations/core/types';
+import {
+  getGitHubRepositoryContext,
+  resolveDisplayedGitHubIntegrationId,
+} from '@/lib/slack-bot/github-repository-context';
 import { createHmac } from 'crypto';
 import { captureException } from '@sentry/nextjs';
 import type { PlatformIntegration } from '@kilocode/db';
@@ -190,6 +194,10 @@ export default async function spawnCloudAgentSession(
       attachments: options?.attachments,
     };
   } else {
+    const githubRepo = args.githubRepo;
+    if (!githubRepo) {
+      return { response: 'Error: You must specify a githubRepo.' };
+    }
     // Cloud Agent resolves organization repository access and persists its canonical identity.
     // Personal sessions keep their existing token path.
     const githubToken = owner.type === 'user' ? await getGitHubTokenForUser(owner.id) : undefined;
@@ -201,9 +209,21 @@ export default async function spawnCloudAgentSession(
       };
     }
 
+    const githubRepositoryContext = await getGitHubRepositoryContext(owner);
+    let githubIntegrationId: string | undefined;
+    try {
+      githubIntegrationId = resolveDisplayedGitHubIntegrationId(
+        githubRepositoryContext,
+        githubRepo,
+        args.githubIntegrationId
+      );
+    } catch (error) {
+      return { response: `Error: ${error instanceof Error ? error.message : String(error)}` };
+    }
+
     prepareInput = {
-      githubRepo: args.githubRepo,
-      githubIntegrationId: args.githubIntegrationId,
+      githubRepo,
+      githubIntegrationId,
       prompt,
       mode,
       model,

--- a/apps/web/src/lib/discord-bot.ts
+++ b/apps/web/src/lib/discord-bot.ts
@@ -1,13 +1,7 @@
 import 'server-only';
-import {
-  createCloudAgentNextClient,
-  type PrepareSessionInput,
-} from '@/lib/cloud-agent-next/cloud-agent-client';
+import { createCloudAgentNextClient } from '@/lib/cloud-agent-next/cloud-agent-client';
 import { runSessionToCompletion } from '@/lib/cloud-agent-next/run-session';
-import {
-  getGitHubTokenForUser,
-  getGitHubTokenForOrganization,
-} from '@/lib/cloud-agent/github-integration-helpers';
+import { getGitHubTokenForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import type OpenAI from 'openai';
 import type { Owner } from '@/lib/integrations/core/types';
 import {
@@ -28,6 +22,7 @@ import {
 import { getDiscordBotAuthTokenForOwner } from '@/lib/discord/auth';
 import { buildDiscordMessageLink } from '@/lib/discord-bot/discord-utils';
 import type { PlatformIntegration } from '@kilocode/db';
+import { z } from 'zod';
 
 // Version string for API requests
 const DISCORD_BOT_VERSION = '5.0.0';
@@ -63,7 +58,7 @@ Additional context may be appended to this prompt:
 - Discord conversation context (recent messages)
 - Available GitHub repositories for this Discord integration
 
-Treat this context as authoritative. Prefer selecting a repo from the provided repository list. If the user requests work on a repo that isn't in the list, ask them to confirm the exact owner/repo and ensure it's accessible to the integration. Never invent repository names.
+Use this context to select repositories, not to authorize access. Prefer selecting a repo from the provided repository list. If the user requests work on a repo that isn't in the list, ask them to confirm the exact owner/repo. Cloud Agent resolves and authorizes repositories. Never invent repository names.
 
 ## Tool: spawn_cloud_agent
 You can call the tool "spawn_cloud_agent" to run a Cloud Agent session for coding work on a GitHub repository.
@@ -114,6 +109,16 @@ const SPAWN_CLOUD_AGENT_TOOL: OpenAI.Chat.Completions.ChatCompletionTool = {
           description: 'The GitHub repository in owner/repo format (e.g., "facebook/react")',
           pattern: '^[-a-zA-Z0-9_.]+/[-a-zA-Z0-9_.]+$',
         },
+        githubAccount: {
+          type: 'string',
+          description: 'Optional account hint shown with an explicitly selected repository entry',
+        },
+        githubIntegrationId: {
+          type: 'string',
+          format: 'uuid',
+          description:
+            'Optional integration ID for an explicit choice between duplicate repository entries',
+        },
         prompt: {
           type: 'string',
           description:
@@ -131,6 +136,16 @@ const SPAWN_CLOUD_AGENT_TOOL: OpenAI.Chat.Completions.ChatCompletionTool = {
     },
   },
 };
+
+const DiscordCloudAgentToolInputSchema = z.object({
+  githubRepo: z.string().regex(/^[-a-zA-Z0-9_.]+\/[-a-zA-Z0-9_.]+$/),
+  githubAccount: z.string().min(1).optional(),
+  githubIntegrationId: z.string().uuid().optional(),
+  prompt: z.string(),
+  mode: z.enum(['architect', 'code', 'ask', 'debug', 'orchestrator']).optional(),
+});
+
+type DiscordCloudAgentToolInput = z.infer<typeof DiscordCloudAgentToolInputSchema>;
 
 type DiscordRequesterInfo = {
   displayName: string;
@@ -155,7 +170,7 @@ Built for ${requesterPart} by [Kilo for Discord](https://kilo.ai)`;
  * Spawn a Cloud Agent session
  */
 async function spawnCloudAgentSession(
-  args: { githubRepo: string; prompt: string; mode?: string },
+  args: DiscordCloudAgentToolInput,
   owner: Owner,
   model: string,
   authToken: string,
@@ -168,15 +183,8 @@ async function spawnCloudAgentSession(
   );
   console.log('[DiscordBot] Owner:', JSON.stringify(owner, null, 2));
 
-  let githubToken: string | undefined;
-  let kilocodeOrganizationId: string | undefined;
-
-  if (owner.type === 'org') {
-    githubToken = await getGitHubTokenForOrganization(owner.id);
-    kilocodeOrganizationId = owner.id;
-  } else {
-    githubToken = await getGitHubTokenForUser(owner.id);
-  }
+  const githubToken = owner.type === 'user' ? await getGitHubTokenForUser(owner.id) : undefined;
+  const kilocodeOrganizationId = owner.type === 'org' ? owner.id : undefined;
 
   const promptWithSignature = requesterInfo
     ? args.prompt + buildPrSignature(requesterInfo)
@@ -186,10 +194,11 @@ async function spawnCloudAgentSession(
     client: createCloudAgentNextClient(authToken, { skipBalanceCheck: true }),
     prepareInput: {
       githubRepo: args.githubRepo,
+      githubIntegrationId: args.githubIntegrationId,
       prompt: promptWithSignature,
-      mode: (args.mode as PrepareSessionInput['mode']) || 'code',
+      mode: args.mode || 'code',
       model,
-      githubToken,
+      ...(githubToken ? { githubToken } : {}),
       kilocodeOrganizationId,
       createdOnPlatform: 'discord',
     },
@@ -318,9 +327,14 @@ export async function processDiscordBotMessage(
         return { content: `Error executing tool: Unknown tool ${toolCall.function.name}` };
       }
 
-      const args = JSON.parse(toolCall.function.arguments);
+      const args = DiscordCloudAgentToolInputSchema.safeParse(
+        JSON.parse(toolCall.function.arguments)
+      );
+      if (!args.success) {
+        return { content: 'Error executing tool: Invalid Cloud Agent arguments.' };
+      }
       const toolResult = await spawnCloudAgentSession(
-        args,
+        args.data,
         owner,
         selectedModel,
         authToken,

--- a/apps/web/src/lib/discord-bot.ts
+++ b/apps/web/src/lib/discord-bot.ts
@@ -13,6 +13,8 @@ import { runBot } from '@/lib/bots/core/run-bot';
 import {
   formatGitHubRepositoriesForPrompt,
   getGitHubRepositoryContext,
+  resolveDisplayedGitHubIntegrationId,
+  type GitHubRepositoryContext,
 } from '@/lib/slack-bot/github-repository-context';
 import {
   formatDiscordConversationContextForPrompt,
@@ -175,6 +177,7 @@ async function spawnCloudAgentSession(
   model: string,
   authToken: string,
   ticketUserId: string,
+  githubRepositoryContext: GitHubRepositoryContext,
   requesterInfo?: DiscordRequesterInfo
 ): Promise<{ response: string; sessionId?: string }> {
   console.log(
@@ -189,12 +192,22 @@ async function spawnCloudAgentSession(
   const promptWithSignature = requesterInfo
     ? args.prompt + buildPrSignature(requesterInfo)
     : args.prompt;
+  let githubIntegrationId: string | undefined;
+  try {
+    githubIntegrationId = resolveDisplayedGitHubIntegrationId(
+      githubRepositoryContext,
+      args.githubRepo,
+      args.githubIntegrationId
+    );
+  } catch (error) {
+    return { response: `Error: ${error instanceof Error ? error.message : String(error)}` };
+  }
 
   const result = await runSessionToCompletion({
     client: createCloudAgentNextClient(authToken, { skipBalanceCheck: true }),
     prepareInput: {
       githubRepo: args.githubRepo,
-      githubIntegrationId: args.githubIntegrationId,
+      githubIntegrationId,
       prompt: promptWithSignature,
       mode: args.mode || 'code',
       model,
@@ -339,6 +352,7 @@ export async function processDiscordBotMessage(
         selectedModel,
         authToken,
         authUserId,
+        repoContext,
         requesterInfo
       );
 

--- a/apps/web/src/lib/slack-bot/github-repository-context.test.ts
+++ b/apps/web/src/lib/slack-bot/github-repository-context.test.ts
@@ -1,0 +1,93 @@
+import { beforeAll, describe, expect, it, jest } from '@jest/globals';
+import type { PlatformIntegration } from '@kilocode/db';
+import type {
+  getIntegrationForOwner,
+  getIntegrationsByOrganization,
+} from '@/lib/integrations/db/platform-integrations';
+import type * as GitHubRepositoryContextModule from './github-repository-context';
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationForOwner: jest.fn(),
+  getIntegrationsByOrganization: jest.fn(),
+}));
+
+let formatGitHubRepositoriesForPrompt: typeof GitHubRepositoryContextModule.formatGitHubRepositoriesForPrompt;
+let getGitHubRepositoryContext: typeof GitHubRepositoryContextModule.getGitHubRepositoryContext;
+
+function integration(overrides: Partial<PlatformIntegration>): PlatformIntegration {
+  return {
+    id: '123e4567-e89b-12d3-a456-426614174022',
+    platform: 'github',
+    integration_type: 'app',
+    integration_status: 'active',
+    suspended_at: null,
+    auth_invalid_at: null,
+    platform_account_login: 'acme',
+    repository_access: 'selected',
+    repositories_synced_at: null,
+    repositories: [{ id: 1, name: 'web', full_name: 'acme/web', private: true }],
+    ...overrides,
+  } as PlatformIntegration;
+}
+
+describe('GitHub repository context for chat bots', () => {
+  beforeAll(async () => {
+    ({ formatGitHubRepositoriesForPrompt, getGitHubRepositoryContext } =
+      await import('./github-repository-context'));
+  });
+
+  it('shows repositories from every healthy organization installation', async () => {
+    const getIntegrationForOwnerMock = jest.fn<typeof getIntegrationForOwner>();
+    const getIntegrationsByOrganizationMock = jest
+      .fn<typeof getIntegrationsByOrganization>()
+      .mockResolvedValue([
+        integration({}),
+        integration({
+          id: '123e4567-e89b-12d3-a456-426614174023',
+          platform_account_login: 'other',
+          repositories: [{ id: 2, name: 'api', full_name: 'other/api', private: false }],
+        }),
+        integration({
+          id: '123e4567-e89b-12d3-a456-426614174024',
+          integration_status: 'suspended',
+          suspended_at: '2026-08-27 07:00:00+00',
+        }),
+      ]);
+
+    const context = await getGitHubRepositoryContext(
+      { type: 'org', id: 'chat-workspace' },
+      {
+        getIntegrationForOwner: getIntegrationForOwnerMock,
+        getIntegrationsByOrganization: getIntegrationsByOrganizationMock,
+      }
+    );
+    const prompt = formatGitHubRepositoriesForPrompt(context);
+
+    expect(context.installations).toHaveLength(2);
+    expect(prompt).toContain('acme/web');
+    expect(prompt).toContain('other/api');
+    expect(prompt).toContain('Submit owner/repo and let Cloud Agent resolve and authorize it.');
+  });
+
+  it('keeps personal repository context on the existing single-integration path', async () => {
+    const personalIntegration = integration({
+      integration_status: 'suspended',
+      suspended_at: '2026-08-27 07:00:00+00',
+    });
+    const getIntegrationForOwnerMock = jest
+      .fn<typeof getIntegrationForOwner>()
+      .mockResolvedValue(personalIntegration);
+
+    const context = await getGitHubRepositoryContext(
+      { type: 'user', id: 'user-1' },
+      {
+        getIntegrationForOwner: getIntegrationForOwnerMock,
+        getIntegrationsByOrganization: jest.fn<typeof getIntegrationsByOrganization>(),
+      }
+    );
+
+    expect(context.installations).toEqual([
+      expect.objectContaining({ platformIntegrationId: personalIntegration.id }),
+    ]);
+  });
+});

--- a/apps/web/src/lib/slack-bot/github-repository-context.test.ts
+++ b/apps/web/src/lib/slack-bot/github-repository-context.test.ts
@@ -13,6 +13,7 @@ jest.mock('@/lib/integrations/db/platform-integrations', () => ({
 
 let formatGitHubRepositoriesForPrompt: typeof GitHubRepositoryContextModule.formatGitHubRepositoriesForPrompt;
 let getGitHubRepositoryContext: typeof GitHubRepositoryContextModule.getGitHubRepositoryContext;
+let resolveDisplayedGitHubIntegrationId: typeof GitHubRepositoryContextModule.resolveDisplayedGitHubIntegrationId;
 
 function integration(overrides: Partial<PlatformIntegration>): PlatformIntegration {
   return {
@@ -32,8 +33,11 @@ function integration(overrides: Partial<PlatformIntegration>): PlatformIntegrati
 
 describe('GitHub repository context for chat bots', () => {
   beforeAll(async () => {
-    ({ formatGitHubRepositoriesForPrompt, getGitHubRepositoryContext } =
-      await import('./github-repository-context'));
+    ({
+      formatGitHubRepositoriesForPrompt,
+      getGitHubRepositoryContext,
+      resolveDisplayedGitHubIntegrationId,
+    } = await import('./github-repository-context'));
   });
 
   it('shows repositories from every healthy organization installation', async () => {
@@ -89,5 +93,55 @@ describe('GitHub repository context for chat bots', () => {
     expect(context.installations).toEqual([
       expect.objectContaining({ platformIntegrationId: personalIntegration.id }),
     ]);
+  });
+});
+
+describe('displayed GitHub repository identity', () => {
+  const firstId = '123e4567-e89b-12d3-a456-426614174022';
+  const secondId = '123e4567-e89b-12d3-a456-426614174023';
+  const repository = { id: 1, name: 'web', full_name: 'acme/web', private: true };
+
+  it('omits an integration ID when the displayed repository is unique', () => {
+    expect(
+      resolveDisplayedGitHubIntegrationId(
+        {
+          installations: [
+            {
+              platformIntegrationId: firstId,
+              accountLogin: 'acme',
+              repositoryAccess: 'selected',
+              repositoriesSyncedAt: null,
+              repositories: [repository],
+            },
+          ],
+        },
+        'acme/web',
+        firstId
+      )
+    ).toBeUndefined();
+  });
+
+  it('keeps only an ID belonging to a displayed duplicate choice', () => {
+    const context = {
+      installations: [firstId, secondId].map(platformIntegrationId => ({
+        platformIntegrationId,
+        accountLogin: 'acme',
+        repositoryAccess: 'selected',
+        repositoriesSyncedAt: null,
+        repositories: [repository],
+      })),
+    };
+
+    expect(resolveDisplayedGitHubIntegrationId(context, 'acme/web', secondId)).toBe(secondId);
+    expect(() =>
+      resolveDisplayedGitHubIntegrationId(
+        context,
+        'acme/web',
+        '123e4567-e89b-12d3-a456-426614174024'
+      )
+    ).toThrow('does not match a displayed duplicate repository choice');
+    expect(() => resolveDisplayedGitHubIntegrationId(context, 'other/repo', firstId)).toThrow(
+      'does not match a displayed duplicate repository choice'
+    );
   });
 });

--- a/apps/web/src/lib/slack-bot/github-repository-context.ts
+++ b/apps/web/src/lib/slack-bot/github-repository-context.ts
@@ -22,6 +22,30 @@ export type GitHubRepositoryContext = {
   installations: GitHubInstallationRepositoryContext[];
 };
 
+export function resolveDisplayedGitHubIntegrationId(
+  context: GitHubRepositoryContext,
+  repositoryFullName: string,
+  requestedIntegrationId: string | undefined
+): string | undefined {
+  if (!requestedIntegrationId) return undefined;
+
+  const matchingInstallations = context.installations.filter(installation =>
+    installation.repositories?.some(
+      repository => repository.full_name.toLowerCase() === repositoryFullName.toLowerCase()
+    )
+  );
+  const matchingIntegrationIds = new Set(
+    matchingInstallations.map(installation => installation.platformIntegrationId)
+  );
+
+  if (matchingIntegrationIds.size === 1) return undefined;
+  if (matchingIntegrationIds.has(requestedIntegrationId)) return requestedIntegrationId;
+
+  throw new Error(
+    'The selected GitHub integration does not match a displayed duplicate repository choice.'
+  );
+}
+
 type GitHubRepositoryContextLoaders = {
   getIntegrationForOwner: typeof getIntegrationForOwner;
   getIntegrationsByOrganization: typeof getIntegrationsByOrganization;

--- a/apps/web/src/lib/slack-bot/github-repository-context.ts
+++ b/apps/web/src/lib/slack-bot/github-repository-context.ts
@@ -4,75 +4,109 @@ import {
   type PlatformRepository,
 } from '@/lib/integrations/core/types';
 import { PLATFORM } from '@/lib/integrations/core/constants';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
+import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
+import {
+  getIntegrationForOwner,
+  getIntegrationsByOrganization,
+} from '@/lib/integrations/db/platform-integrations';
 
-export type GitHubRepositoryContext = {
+export type GitHubInstallationRepositoryContext = {
+  platformIntegrationId: string;
   accountLogin: string | null;
   repositoryAccess: string | null;
   repositoriesSyncedAt: string | null;
   repositories: PlatformRepository[] | null;
 };
 
-/**
- * Get GitHub repository context for an owner from their GitHub integration.
- * This does not perform extra API requests; it uses data stored on the integration row.
- */
-export async function getGitHubRepositoryContext(owner: Owner): Promise<GitHubRepositoryContext> {
-  const integration = await getIntegrationForOwner(owner, PLATFORM.GITHUB);
-  if (!integration) {
-    return {
-      accountLogin: null,
-      repositoryAccess: null,
-      repositoriesSyncedAt: null,
-      repositories: null,
-    };
-  }
+export type GitHubRepositoryContext = {
+  installations: GitHubInstallationRepositoryContext[];
+};
 
-  const repositories = requireNumericPlatformRepositories(integration.repositories);
+type GitHubRepositoryContextLoaders = {
+  getIntegrationForOwner: typeof getIntegrationForOwner;
+  getIntegrationsByOrganization: typeof getIntegrationsByOrganization;
+};
+
+function toInstallationContext(
+  integration: Awaited<ReturnType<typeof getIntegrationForOwner>>
+): GitHubInstallationRepositoryContext | null {
+  if (!integration) return null;
 
   return {
+    platformIntegrationId: integration.id,
     accountLogin: integration.platform_account_login,
     repositoryAccess: integration.repository_access,
     repositoriesSyncedAt: integration.repositories_synced_at,
-    repositories,
+    repositories: requireNumericPlatformRepositories(integration.repositories),
+  };
+}
+
+/**
+ * Get GitHub repository context for an owner from their GitHub integrations.
+ * This does not perform extra API requests; it uses data stored on the integration row.
+ */
+export async function getGitHubRepositoryContext(
+  owner: Owner,
+  loaders: GitHubRepositoryContextLoaders = {
+    getIntegrationForOwner,
+    getIntegrationsByOrganization,
+  }
+): Promise<GitHubRepositoryContext> {
+  const integrations =
+    owner.type === 'org'
+      ? (await loaders.getIntegrationsByOrganization(owner.id, PLATFORM.GITHUB)).filter(
+          isPlatformIntegrationHealthy
+        )
+      : [await loaders.getIntegrationForOwner(owner, PLATFORM.GITHUB)];
+
+  return {
+    installations: integrations
+      .map(toInstallationContext)
+      .filter((integration): integration is GitHubInstallationRepositoryContext => !!integration),
   };
 }
 
 export function formatGitHubRepositoriesForPrompt(context: GitHubRepositoryContext): string {
-  const headerLines: string[] = ['\n\nGitHub repository context for this workspace:'];
-
-  if (context.accountLogin) {
-    headerLines.push(`- Installation account: ${context.accountLogin}`);
-  }
-  if (context.repositoryAccess) {
-    headerLines.push(`- Repository access: ${context.repositoryAccess}`);
-  }
-  if (context.repositoriesSyncedAt) {
-    headerLines.push(`- Repositories synced at: ${context.repositoriesSyncedAt}`);
+  const header = '\n\nGitHub repository context for this workspace:';
+  if (context.installations.length === 0) {
+    return `${header}\n- No GitHub installations are connected.`;
   }
 
-  const header = headerLines.join('\n');
-
-  if (!context.repositories || context.repositories.length === 0) {
-    if (context.repositoryAccess === 'all') {
-      return `${header}
-- Repository list: not stored for "all" access (no repo list to show without extra requests).
-
-When the user asks you to work on code, ask them to specify the repository explicitly in owner/repo format.`;
+  const installations = context.installations.map(installation => {
+    const account = installation.accountLogin ?? 'unknown';
+    const lines = [
+      `Installation account: ${account}`,
+      `- platformIntegrationId: ${installation.platformIntegrationId}`,
+    ];
+    if (installation.repositoryAccess) {
+      lines.push(`- Repository access: ${installation.repositoryAccess}`);
+    }
+    if (installation.repositoriesSyncedAt) {
+      lines.push(`- Repositories synced at: ${installation.repositoriesSyncedAt}`);
     }
 
-    return `${header}
-- No GitHub repositories are currently connected. The user will need to specify a repository manually.`;
-  }
+    if (!installation.repositories?.length) {
+      lines.push(
+        installation.repositoryAccess === 'all'
+          ? '- Repository list: not stored for "all" access. Ask for the repository in owner/repo format.'
+          : '- No repositories are currently connected through this installation.'
+      );
+      return lines.join('\n');
+    }
 
-  const repoList = context.repositories
-    .map(repo => `- ${repo.full_name}${repo.private ? ' (private)' : ''} [id: ${repo.id}]`)
-    .join('\n');
+    lines.push(
+      '- Available repositories:',
+      ...installation.repositories.map(
+        repository =>
+          `  - ${repository.full_name}${repository.private ? ' (private)' : ''} [repositoryId: ${repository.id}; account: ${account}; platformIntegrationId: ${installation.platformIntegrationId}]`
+      )
+    );
+    return lines.join('\n');
+  });
 
   return `${header}
 
-Available repositories:
-${repoList}
+${installations.join('\n\n')}
 
-When the user asks you to work on code without specifying a repository, try to infer the correct repository from context or ask them to clarify which repository they want to use.`;
+Use this context to choose a repository, not to authorize access. Submit owner/repo and let Cloud Agent resolve and authorize it. Only include githubIntegrationId when preserving an explicit choice between duplicate repository entries. If no repository is specified, infer an unambiguous listed repository or ask for clarification.`;
 }


### PR DESCRIPTION
## Why
Slack and Discord need repository context from every connected GitHub organization, but they should not reimplement credential authorization. Cloud Agent #5590 can resolve owner/repo centrally.

## Dependency
Depends on #5590.

## What changes
- Aggregate healthy organization installation repository context.
- Show account/integration hints so duplicate choices can be distinguished.
- Submit owner/repo to Cloud Agent without cached web authorization or primary-token prefetch.
- Forward an optional exact ID only for an explicitly disambiguated choice.
- Preserve personal bot behavior.

## What this removes
No #5547 cached resolver. Account and integration metadata are selection hints; Cloud Agent remains the authorization boundary.

## Review guide
Review context formatting, then verify organization session spawn no longer fetches or validates a GitHub token in web.

## Validation
- Web typecheck and lint
- 2 focused suites, 7 tests
- Formatting and `git diff --check`