### PR TITLE
feat(code-review): preserve review identity in follow-up sessions

### DIFF
--- a/apps/web/src/app/cloud-agent-fork/review-md/route.ts
+++ b/apps/web/src/app/cloud-agent-fork/review-md/route.ts
@@ -30,9 +30,9 @@ import {
 } from '@/lib/code-reviews/core/constants';
 import { PRIMARY_DEFAULT_MODEL } from '@/lib/ai-gateway/models';
 import { buildReviewMdConversionPrompt } from '@/lib/code-reviews/prompts/review-md-conversion-prompt';
+import { buildAllowedRepositoryFullNames } from '@/lib/code-reviews/core/selectable-repositories';
 import { isFeatureFlagEnabledOrDevelopment } from '@/lib/posthog-feature-flags';
 import { redisClient } from '@/lib/redis';
-import { buildAllowedRepositoryFullNames } from '@/lib/code-reviews/core/selectable-repositories';
 
 const createCaller = createCallerFactory(rootRouter);
 
@@ -51,6 +51,7 @@ const QuerySchema = z.object({
       'Invalid repository path'
     ),
   organizationId: z.uuid().optional(),
+  platformIntegrationId: z.uuid().optional(),
 });
 
 /**
@@ -110,13 +111,17 @@ export async function GET(request: NextRequest) {
     platform: url.searchParams.get('platform') ?? undefined,
     repo: url.searchParams.get('repo') ?? undefined,
     organizationId: url.searchParams.get('organizationId') ?? undefined,
+    platformIntegrationId: url.searchParams.get('platformIntegrationId') ?? undefined,
   });
 
   if (!parsed.success) {
     return redirectToError(undefined, 'invalid_conversion_request');
   }
 
-  const { platform, repo, organizationId } = parsed.data;
+  const { platform, repo, organizationId, platformIntegrationId } = parsed.data;
+  if (platform !== 'github' && platformIntegrationId) {
+    return redirectToError(organizationId, 'invalid_conversion_request');
+  }
 
   // CSRF defense for this mutating, credit-spending GET. Fail CLOSED: allow only same-origin dialog
   // clicks (`same-origin`/`same-site`) and deliberate direct navigation (`none`, e.g. typing the URL
@@ -169,28 +174,17 @@ export async function GET(request: NextRequest) {
       return redirectToError(organizationId, 'conversion_rate_limited');
     }
 
-    // Authorize the repo against the caller's FETCHED integration repositories only. Manually-added
-    // config entries are client-supplied and only shape-validated at save time (no proof the
-    // integration actually covers them), so they must NOT gate this credit-spending, PR-opening
-    // action — otherwise a user could add an arbitrary full_name to their config and pass this
-    // check. The worker enforces installation scope regardless; this keeps the fail-fast honest.
-    const repositoryList = organizationId
-      ? platform === 'gitlab'
+    if (platform === 'gitlab') {
+      const repositoryList = organizationId
         ? await caller.organizations.reviewAgent.listGitLabRepositories({
             organizationId,
             forceRefresh: false,
           })
-        : await caller.organizations.reviewAgent.listGitHubRepositories({
-            organizationId,
-            forceRefresh: false,
-          })
-      : platform === 'gitlab'
-        ? await caller.personalReviewAgent.listGitLabRepositories({ forceRefresh: false })
-        : await caller.personalReviewAgent.listGitHubRepositories({ forceRefresh: false });
-
-    const allowedRepoFullNames = buildAllowedRepositoryFullNames(repositoryList.repositories, []);
-    if (!allowedRepoFullNames.has(repo)) {
-      return redirectToError(organizationId, 'repository_not_allowed');
+        : await caller.personalReviewAgent.listGitLabRepositories({ forceRefresh: false });
+      const allowedRepoFullNames = buildAllowedRepositoryFullNames(repositoryList.repositories, []);
+      if (!allowedRepoFullNames.has(repo)) {
+        return redirectToError(organizationId, 'repository_not_allowed');
+      }
     }
 
     const customInstructions = config.customInstructions?.trim();
@@ -199,7 +193,9 @@ export async function GET(request: NextRequest) {
     }
 
     const sessionInput = {
-      ...(platform === 'gitlab' ? { gitlabProject: repo } : { githubRepo: repo }),
+      ...(platform === 'gitlab'
+        ? { gitlabProject: repo }
+        : { githubRepo: repo, githubIntegrationId: platformIntegrationId }),
       prompt: buildReviewMdConversionPrompt({
         platform,
         repoFullName: repo,

--- a/apps/web/src/app/cloud-agent-fork/review/[reviewId]/route.test.ts
+++ b/apps/web/src/app/cloud-agent-fork/review/[reviewId]/route.test.ts
@@ -35,6 +35,7 @@ type ReviewResult =
 
 type PrepareSessionInput = {
   githubRepo: string;
+  githubIntegrationId?: string;
   prompt: string;
   mode: string;
   model: string;
@@ -231,6 +232,7 @@ describe('GET /cloud-agent-fork/review/[reviewId]', () => {
     expect(mockGetIntegrationById).toHaveBeenCalledTimes(1);
     expect(mockPersonalPrepareSession).toHaveBeenCalledWith({
       githubRepo: 'owner/repo',
+      githubIntegrationId: REVIEW_INTEGRATION_ID,
       prompt: buildFixReviewPrompt(PR_URL),
       mode: DEFAULT_CODE_REVIEW_MODE,
       model: CONFIGURED_BOT_MODEL,
@@ -264,6 +266,7 @@ describe('GET /cloud-agent-fork/review/[reviewId]', () => {
     expect(mockPersonalPrepareSession).not.toHaveBeenCalled();
     expect(mockOrganizationPrepareSession).toHaveBeenCalledWith({
       githubRepo: 'owner/repo',
+      githubIntegrationId: REVIEW_INTEGRATION_ID,
       prompt: buildFixReviewPrompt(PR_URL),
       mode: DEFAULT_CODE_REVIEW_MODE,
       model: CONFIGURED_BOT_MODEL,
@@ -362,6 +365,7 @@ describe('GET /cloud-agent-fork/review/[reviewId]', () => {
     expect(mockGetIntegrationById).toHaveBeenCalledTimes(1);
     expect(mockPersonalPrepareSession).toHaveBeenCalledWith({
       githubRepo: 'owner/repo',
+      githubIntegrationId: REVIEW_INTEGRATION_ID,
       prompt: buildFixReviewPrompt(PR_URL),
       mode: DEFAULT_CODE_REVIEW_MODE,
       model: DEFAULT_BOT_MODEL,

--- a/apps/web/src/app/cloud-agent-fork/review/[reviewId]/route.ts
+++ b/apps/web/src/app/cloud-agent-fork/review/[reviewId]/route.ts
@@ -88,6 +88,7 @@ export async function GET(request: NextRequest, context: RouteContext) {
 
     const sessionInput = {
       githubRepo: review.repo_full_name,
+      githubIntegrationId: review.platform_integration_id ?? undefined,
       prompt: buildFixReviewPrompt(review.pr_url),
       mode: DEFAULT_CODE_REVIEW_MODE,
       model: resolveBotModelSlug(integration),

--- a/apps/web/src/components/code-reviews/ReviewMdConversionDialog.test.ts
+++ b/apps/web/src/components/code-reviews/ReviewMdConversionDialog.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from '@jest/globals';
+
+import { buildConversionHref } from './ReviewMdConversionDialog';
+
+describe('buildConversionHref', () => {
+  it('forwards authoritative GitHub integration identity to Cloud Agent creation', () => {
+    const href = buildConversionHref({
+      organizationId: '00000000-0000-4000-8000-000000000001',
+      platform: 'github',
+      repoFullName: 'acme/widgets',
+      platformIntegrationId: '00000000-0000-4000-8000-000000000002',
+    });
+    const url = new URL(href, 'https://kilo.test');
+
+    expect(url.searchParams.get('repo')).toBe('acme/widgets');
+    expect(url.searchParams.get('platformIntegrationId')).toBe(
+      '00000000-0000-4000-8000-000000000002'
+    );
+  });
+
+  it('submits repository identity without inventing an integration ID', () => {
+    const href = buildConversionHref({
+      platform: 'github',
+      repoFullName: 'acme/widgets',
+    });
+    const url = new URL(href, 'https://kilo.test');
+
+    expect(url.searchParams.get('repo')).toBe('acme/widgets');
+    expect(url.searchParams.has('platformIntegrationId')).toBe(false);
+  });
+});

--- a/apps/web/src/components/code-reviews/ReviewMdConversionDialog.test.ts
+++ b/apps/web/src/components/code-reviews/ReviewMdConversionDialog.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from '@jest/globals';
 
-import { buildConversionHref } from './ReviewMdConversionDialog';
+import {
+  buildConversionHref,
+  conversionIntegrationId,
+  conversionRepositoryDiscriminator,
+} from './ReviewMdConversionDialog';
 
 describe('buildConversionHref', () => {
   it('forwards authoritative GitHub integration identity to Cloud Agent creation', () => {
@@ -27,5 +31,29 @@ describe('buildConversionHref', () => {
 
     expect(url.searchParams.get('repo')).toBe('acme/widgets');
     expect(url.searchParams.has('platformIntegrationId')).toBe(false);
+  });
+});
+
+describe('REVIEW.md repository selection', () => {
+  const repository = {
+    id: 1,
+    full_name: 'acme/widgets',
+    platformIntegrationId: '00000000-0000-4000-8000-000000000002',
+    platformAccountLogin: 'acme',
+    githubAppType: 'lite',
+  };
+
+  it('omits integration identity for a unique repository', () => {
+    expect(conversionIntegrationId(repository, new Set())).toBeUndefined();
+    expect(conversionRepositoryDiscriminator(repository, new Set())).toBeNull();
+  });
+
+  it('visibly distinguishes and submits an explicit duplicate repository choice', () => {
+    const duplicates = new Set(['acme/widgets']);
+
+    expect(conversionIntegrationId(repository, duplicates)).toBe(
+      '00000000-0000-4000-8000-000000000002'
+    );
+    expect(conversionRepositoryDiscriminator(repository, duplicates)).toBe('acme · lite app');
   });
 });

--- a/apps/web/src/components/code-reviews/ReviewMdConversionDialog.tsx
+++ b/apps/web/src/components/code-reviews/ReviewMdConversionDialog.tsx
@@ -17,6 +17,7 @@ import {
 export type ConvertibleRepository = {
   id: number | string;
   full_name: string;
+  platformIntegrationId?: string;
 };
 
 type ReviewMdConversionDialogProps = {
@@ -27,10 +28,11 @@ type ReviewMdConversionDialogProps = {
   repositories: ConvertibleRepository[];
 };
 
-function buildConversionHref(input: {
+export function buildConversionHref(input: {
   organizationId?: string;
   platform: 'github' | 'gitlab';
   repoFullName: string;
+  platformIntegrationId?: string;
 }): string {
   const params = new URLSearchParams({
     platform: input.platform,
@@ -39,7 +41,14 @@ function buildConversionHref(input: {
   if (input.organizationId) {
     params.set('organizationId', input.organizationId);
   }
+  if (input.platformIntegrationId) {
+    params.set('platformIntegrationId', input.platformIntegrationId);
+  }
   return `/cloud-agent-fork/review-md?${params.toString()}`;
+}
+
+function repositorySelectionKey(repository: ConvertibleRepository): string {
+  return `${repository.id}:${repository.platformIntegrationId ?? ''}`;
 }
 
 /**
@@ -67,7 +76,9 @@ export function ReviewMdConversionDialog({
     [repositories]
   );
 
-  const selectedRepositories = sortedRepositories.filter(repo => selectedIds.has(String(repo.id)));
+  const selectedRepositories = sortedRepositories.filter(repo =>
+    selectedIds.has(repositorySelectionKey(repo))
+  );
   // Count only currently-selected repos that were started, so deselecting a started repo (or
   // selecting a new unstarted one) doesn't leave the progress text overstating "N started".
   const startedSelectedCount = selectedRepositories.filter(repo =>
@@ -107,7 +118,7 @@ export function ReviewMdConversionDialog({
           <div className="space-y-4">
             <div className="max-h-64 space-y-1 overflow-y-auto rounded-md border p-2">
               {sortedRepositories.map(repo => {
-                const repositoryId = String(repo.id);
+                const repositoryId = repositorySelectionKey(repo);
                 const isSelected = selectedIds.has(repositoryId);
                 const isStarted = startedIds.has(repositoryId);
 
@@ -138,6 +149,7 @@ export function ReviewMdConversionDialog({
                           organizationId,
                           platform,
                           repoFullName: repo.full_name,
+                          platformIntegrationId: repo.platformIntegrationId,
                         })}
                         target="_blank"
                         rel="noopener noreferrer"

--- a/apps/web/src/components/code-reviews/ReviewMdConversionDialog.tsx
+++ b/apps/web/src/components/code-reviews/ReviewMdConversionDialog.tsx
@@ -18,6 +18,8 @@ export type ConvertibleRepository = {
   id: number | string;
   full_name: string;
   platformIntegrationId?: string;
+  platformAccountLogin?: string;
+  githubAppType?: string;
 };
 
 type ReviewMdConversionDialogProps = {
@@ -51,6 +53,31 @@ function repositorySelectionKey(repository: ConvertibleRepository): string {
   return `${repository.id}:${repository.platformIntegrationId ?? ''}`;
 }
 
+function duplicateRepositoryNames(repositories: ConvertibleRepository[]): Set<string> {
+  const counts = new Map<string, number>();
+  for (const repository of repositories) {
+    counts.set(repository.full_name, (counts.get(repository.full_name) ?? 0) + 1);
+  }
+  return new Set([...counts].filter(([, count]) => count > 1).map(([fullName]) => fullName));
+}
+
+export function conversionIntegrationId(
+  repository: ConvertibleRepository,
+  duplicateNames: ReadonlySet<string>
+): string | undefined {
+  return duplicateNames.has(repository.full_name) ? repository.platformIntegrationId : undefined;
+}
+
+export function conversionRepositoryDiscriminator(
+  repository: ConvertibleRepository,
+  duplicateNames: ReadonlySet<string>
+): string | null {
+  if (!duplicateNames.has(repository.full_name)) return null;
+  const account = repository.platformAccountLogin ?? repository.full_name.split('/')[0];
+  if (repository.githubAppType) return `${account} · ${repository.githubAppType} app`;
+  return `${account} · Connection ${repository.platformIntegrationId ?? repository.id}`;
+}
+
 /**
  * Repository picker for the Custom Instructions -> REVIEW.md conversion (PoC).
  *
@@ -79,10 +106,11 @@ export function ReviewMdConversionDialog({
   const selectedRepositories = sortedRepositories.filter(repo =>
     selectedIds.has(repositorySelectionKey(repo))
   );
+  const duplicateNames = duplicateRepositoryNames(sortedRepositories);
   // Count only currently-selected repos that were started, so deselecting a started repo (or
   // selecting a new unstarted one) doesn't leave the progress text overstating "N started".
   const startedSelectedCount = selectedRepositories.filter(repo =>
-    startedIds.has(String(repo.id))
+    startedIds.has(repositorySelectionKey(repo))
   ).length;
 
   function toggleRepository(repositoryId: string, checked: boolean) {
@@ -121,6 +149,7 @@ export function ReviewMdConversionDialog({
                 const repositoryId = repositorySelectionKey(repo);
                 const isSelected = selectedIds.has(repositoryId);
                 const isStarted = startedIds.has(repositoryId);
+                const discriminator = conversionRepositoryDiscriminator(repo, duplicateNames);
 
                 return (
                   <div
@@ -135,11 +164,13 @@ export function ReviewMdConversionDialog({
                           toggleRepository(repositoryId, checked === true)
                         }
                       />
-                      <label
-                        htmlFor={`convert-${repositoryId}`}
-                        className="cursor-pointer truncate text-sm"
-                      >
-                        {repo.full_name}
+                      <label htmlFor={`convert-${repositoryId}`} className="min-w-0 cursor-pointer">
+                        <span className="block truncate text-sm">{repo.full_name}</span>
+                        {discriminator && (
+                          <span className="text-muted-foreground block truncate text-xs">
+                            {discriminator}
+                          </span>
+                        )}
                       </label>
                     </div>
 
@@ -149,7 +180,7 @@ export function ReviewMdConversionDialog({
                           organizationId,
                           platform,
                           repoFullName: repo.full_name,
-                          platformIntegrationId: repo.platformIntegrationId,
+                          platformIntegrationId: conversionIntegrationId(repo, duplicateNames),
                         })}
                         target="_blank"
                         rel="noopener noreferrer"

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
@@ -31,6 +31,7 @@ type GitHubRepositoriesResult = {
     private: boolean;
     platformIntegrationId?: string;
     platformAccountLogin?: string;
+    githubAppType?: string;
   }[];
   syncedAt?: string | null;
   errorMessage?: string;
@@ -38,7 +39,11 @@ type GitHubRepositoriesResult = {
 
 const mapRepositories = (
   repositories: PlatformRepository[],
-  integration?: { id: string; platform_account_login: string | null }
+  integration?: {
+    id: string;
+    platform_account_login: string | null;
+    github_app_type: string | null;
+  }
 ): GitHubRepositoriesResult['repositories'] => {
   return repositories.map(repo => ({
     id: repo.id,
@@ -49,6 +54,7 @@ const mapRepositories = (
       ? {
           platformIntegrationId: integration.id,
           platformAccountLogin: integration.platform_account_login ?? undefined,
+          githubAppType: integration.github_app_type ?? undefined,
         }
       : {}),
   }));

--- a/apps/web/src/lib/code-reviews/core/selectable-repositories.test.ts
+++ b/apps/web/src/lib/code-reviews/core/selectable-repositories.test.ts
@@ -16,6 +16,20 @@ describe('buildSelectableRepositories', () => {
     const result = buildSelectableRepositories(fetched, manual);
     expect(result.map(repo => repo.full_name)).toEqual(['org/a', 'org/b']);
   });
+
+  it('preserves authoritative integration identity from fetched repositories', () => {
+    expect(
+      buildSelectableRepositories(
+        [
+          {
+            ...fetched[0],
+            platformIntegrationId: '00000000-0000-4000-8000-000000000001',
+          },
+        ],
+        []
+      )[0]
+    ).toMatchObject({ platformIntegrationId: '00000000-0000-4000-8000-000000000001' });
+  });
 });
 
 describe('buildAllowedRepositoryFullNames', () => {

--- a/apps/web/src/lib/code-reviews/core/selectable-repositories.test.ts
+++ b/apps/web/src/lib/code-reviews/core/selectable-repositories.test.ts
@@ -24,11 +24,17 @@ describe('buildSelectableRepositories', () => {
           {
             ...fetched[0],
             platformIntegrationId: '00000000-0000-4000-8000-000000000001',
+            platformAccountLogin: 'acme',
+            githubAppType: 'standard',
           },
         ],
         []
       )[0]
-    ).toMatchObject({ platformIntegrationId: '00000000-0000-4000-8000-000000000001' });
+    ).toMatchObject({
+      platformIntegrationId: '00000000-0000-4000-8000-000000000001',
+      platformAccountLogin: 'acme',
+      githubAppType: 'standard',
+    });
   });
 });
 

--- a/apps/web/src/lib/code-reviews/core/selectable-repositories.ts
+++ b/apps/web/src/lib/code-reviews/core/selectable-repositories.ts
@@ -19,6 +19,8 @@ export type FetchedRepository = {
   fullName: string;
   private: boolean;
   platformIntegrationId?: string;
+  platformAccountLogin?: string;
+  githubAppType?: string;
 };
 
 export type ManuallyAddedRepository = {
@@ -34,6 +36,8 @@ export type SelectableRepository = {
   full_name: string;
   private: boolean;
   platformIntegrationId?: string;
+  platformAccountLogin?: string;
+  githubAppType?: string;
 };
 
 /** The deduped repository list offered for review config / conversion (fetched + legacy manual). */
@@ -47,6 +51,8 @@ export function buildSelectableRepositories(
     full_name: repo.fullName,
     private: repo.private,
     platformIntegrationId: repo.platformIntegrationId,
+    platformAccountLogin: repo.platformAccountLogin,
+    githubAppType: repo.githubAppType,
   }));
   const seenIds = new Set(canonical.map(repo => repo.id));
   const legacy = manuallyAdded.filter(repo => !seenIds.has(repo.id));

--- a/apps/web/src/lib/code-reviews/core/selectable-repositories.ts
+++ b/apps/web/src/lib/code-reviews/core/selectable-repositories.ts
@@ -18,6 +18,7 @@ export type FetchedRepository = {
   name: string;
   fullName: string;
   private: boolean;
+  platformIntegrationId?: string;
 };
 
 export type ManuallyAddedRepository = {
@@ -32,6 +33,7 @@ export type SelectableRepository = {
   name: string;
   full_name: string;
   private: boolean;
+  platformIntegrationId?: string;
 };
 
 /** The deduped repository list offered for review config / conversion (fetched + legacy manual). */
@@ -44,6 +46,7 @@ export function buildSelectableRepositories(
     name: repo.name,
     full_name: repo.fullName,
     private: repo.private,
+    platformIntegrationId: repo.platformIntegrationId,
   }));
   const seenIds = new Set(canonical.map(repo => repo.id));
   const legacy = manuallyAdded.filter(repo => !seenIds.has(repo.id));

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.test.ts
@@ -303,6 +303,7 @@ describe('prepareReviewPayload', () => {
         platform: 'github',
         repoFullName: REPO,
         prNumber: 123,
+        platformIntegrationId: integration.id,
       },
       'headsha123'
     );
@@ -943,7 +944,7 @@ describe('prepareReviewPayload', () => {
     expect(payload.sessionInput).not.toHaveProperty('gitlabCodeReviewTokenRef');
   });
 
-  it('does not continue previous cloud-agent sessions for GitHub pull-ref reviews', async () => {
+  it('continues GitHub pull-ref reviews on the exact integration session', async () => {
     const prNumber = 1235;
     mockFindPreviousCompletedReview.mockResolvedValueOnce({
       head_sha: 'sha-previous',
@@ -972,9 +973,14 @@ describe('prepareReviewPayload', () => {
       platform: 'github',
     });
 
-    expect(payload.previousCloudAgentSessionId).toBeUndefined();
+    expect(mockFindPreviousCompletedReview).toHaveBeenCalledWith(
+      expect.objectContaining({ platformIntegrationId: integration.id }),
+      expect.any(String)
+    );
+    expect(payload.previousCloudAgentSessionId).toBe('previous-cloud-agent-session');
     expect(payload.sessionInput).toMatchObject({
       githubRepo: REPO,
+      githubIntegrationId: integration.id,
       platform: 'github',
       upstreamBranch: 'refs/pull/1235/head',
     });

--- a/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
+++ b/apps/web/src/lib/code-reviews/triggers/prepare-review-payload.ts
@@ -107,6 +107,8 @@ export type PreparePayloadParams = {
 export type SessionInput = {
   /** GitHub repo in format "owner/repo" (for GitHub platform) */
   githubRepo?: string;
+  /** Exact GitHub integration selected by the review webhook. */
+  githubIntegrationId?: string;
   /** Full git URL for cloning (for GitLab and other platforms) */
   gitUrl?: string;
   kilocodeOrganizationId?: string;
@@ -370,6 +372,9 @@ export async function prepareReviewPayload(
       platform,
       repoFullName: review.repo_full_name,
       prNumber: review.pr_number,
+      ...(platform === PLATFORM.GITHUB && review.platform_integration_id
+        ? { platformIntegrationId: review.platform_integration_id }
+        : {}),
     };
     let gitlabInstanceUrl: string | undefined;
     let existingReviewState: ExistingReviewState | null = null;
@@ -639,8 +644,7 @@ export async function prepareReviewPayload(
     }
 
     // 4. Check for previous completed review (incremental review optimization).
-    // Keep previousHeadSha for prompt diff context, but disable GitHub session
-    // continuation because sendMessageV2 does not refetch refs/pull/<n>/head.
+    // Keep previousHeadSha for prompt diff context and reuse the prior provider session.
     let previousHeadSha: string | null = null;
     let previousCloudAgentSessionId: string | undefined;
     try {
@@ -656,15 +660,6 @@ export async function prepareReviewPayload(
       if (previousReview?.session_id) {
         switch (platform) {
           case PLATFORM.GITHUB:
-            logExceptInTest(
-              '[prepareReviewPayload] Disabling GitHub session continuation for pull-ref checkout safety',
-              {
-                reviewId,
-                previousCloudAgentSessionId: previousReview.session_id,
-                upstreamBranch: getGitHubPullRequestCheckoutRef(review.pr_number),
-              }
-            );
-            break;
           case PLATFORM.GITLAB:
             previousCloudAgentSessionId = previousReview.session_id;
             break;
@@ -791,6 +786,7 @@ export async function prepareReviewPayload(
           : {
               // GitHub: use owner/repo format
               githubRepo: review.repo_full_name,
+              githubIntegrationId: review.platform_integration_id ?? undefined,
               githubToken,
               platform: 'github',
               kilocodeOrganizationId: owner.type === 'org' ? owner.id : undefined,

--- a/packages/worker-utils/src/cloud-agent-next-client.ts
+++ b/packages/worker-utils/src/cloud-agent-next-client.ts
@@ -41,6 +41,7 @@ export type CloudAgentPrepareSessionInput = {
   model: string;
   variant?: string;
   githubRepo?: string;
+  githubIntegrationId?: string;
   githubToken?: string;
   gitUrl?: string;
   gitToken?: string;

--- a/services/cloud-agent-next/src/session-service.test.ts
+++ b/services/cloud-agent-next/src/session-service.test.ts
@@ -1796,6 +1796,42 @@ describe('SessionService.prepareWorkspace', () => {
     );
   });
 
+  it('refreshes a warm code-review pull ref', async () => {
+    const session = createSession(true);
+    const sandbox = createSandbox(session, true);
+    const metadata = createMetadata({
+      createdOnPlatform: 'code-review',
+      githubRepo: 'acme/repo',
+      githubInstallationId: '123',
+      githubAppType: 'standard',
+      gitUrl: undefined,
+      gitToken: undefined,
+      platform: 'github',
+      upstreamBranch: 'refs/pull/42/head',
+      workspacePath: '/workspace/user/sessions/agent_test',
+      sessionHome: '/home/agent_test',
+      branchName: 'refs/pull/42/head',
+      sandboxId: 'ses-abcdef',
+    });
+
+    await new SessionService().prepareWorkspace({
+      sandbox,
+      sandboxId: 'ses-abcdef',
+      userId: 'user_test',
+      sessionId: 'agent_test' as SessionId,
+      env: createEnv(),
+      metadata,
+      kilocodeModel: 'test-model',
+    });
+
+    expect(workspaceMocks.manageBranch).toHaveBeenCalledWith(
+      session,
+      '/workspace/user/sessions/agent_test',
+      'refs/pull/42/head',
+      true
+    );
+  });
+
   it('refreshes the warm fast path GitLab remote with direct managed authentication', async () => {
     const session = createSession(true);
     const sandbox = createSandbox(session, true);

--- a/services/cloud-agent-next/src/session-service.ts
+++ b/services/cloud-agent-next/src/session-service.ts
@@ -2390,6 +2390,13 @@ export class SessionService {
       );
       await this.sanitizeGitRemote(session, context.workspacePath, metadata, resolvedTokens);
       await this.refreshGitAuthor(session, context, metadata, resolvedTokens);
+      const upstreamBranch = metadata.repository?.upstreamBranch;
+      if (
+        metadata.identity.createdOnPlatform === 'code-review' &&
+        upstreamBranch?.startsWith('refs/pull/')
+      ) {
+        await manageBranch(session, workspacePath, upstreamBranch, true);
+      }
 
       const detectedDevcontainer =
         metadata.workspace?.devcontainerRequested && !metadata.devcontainer

--- a/services/code-review-infra/src/types.ts
+++ b/services/code-review-infra/src/types.ts
@@ -20,6 +20,8 @@ export type CodeReviewStatus = 'queued' | 'running' | 'completed' | 'failed' | '
 export interface SessionInput {
   /** GitHub repo in format "owner/repo" (for GitHub platform) */
   githubRepo?: string;
+  /** Exact GitHub integration selected by the review webhook. */
+  githubIntegrationId?: string;
   /** Full git URL for cloning (for GitLab and other platforms) */
   gitUrl?: string;
   kilocodeOrganizationId?: string;


### PR DESCRIPTION
## Why
Reviews already record the exact GitHub installation that produced them. Follow-up Cloud Agent sessions must preserve that authoritative identity, while repository-only REVIEW.md conversion can delegate to central Cloud Agent resolution instead of using a cached web resolver.

## Dependency
Depends on #5590.

## What changes
- Forward the review row integration for Fix with Cloud Agent and incremental reviews.
- Scope previous-review reuse to the same integration.
- Refresh warm pull refs before continuation.
- Let REVIEW.md conversion submit owner/repo to Cloud Agent and forward an ID only when its selected repository DTO already has one.
- Keep duplicate repository options distinct.

## What this removes
No #5547 cached web resolver or resolver tests. Direct review GitHub operations continue using persisted exact identity.

## Review guide
Review review-row propagation first, warm ref refresh second, and the small REVIEW.md conversion simplification last.

## Validation
- 41 focused web tests
- 113 Cloud Agent session-service tests
- 355 worker-utils tests
- 57 code-review worker tests
- Affected typechecks/lint and `git diff --check`