### PR TITLE
feat(security): sync every GitHub installation with authoritative identity

### DIFF
--- a/services/security-sync/src/index.ts
+++ b/services/security-sync/src/index.ts
@@ -42,6 +42,14 @@ const SecuritySyncActorSchema = z.object({
   name: z.string().min(1).nullable().optional(),
 });
 
+const RepositoryInstallationPlanSchema = z.object({
+  repoFullName: z.string().min(1),
+  repositoryId: z.number().int().positive().optional(),
+  platformIntegrationId: z.string().uuid(),
+  installationId: z.string().min(1),
+  appType: z.enum(['standard', 'lite']),
+});
+
 const SecuritySyncMessageSchema = z
   .object({
     schemaVersion: z.literal(1),
@@ -56,6 +64,7 @@ const SecuritySyncMessageSchema = z
     dispatchedAt: z.string().datetime(),
     actor: SecuritySyncActorSchema.optional(),
     repoFullName: z.string().min(1).optional(),
+    repositoryPlans: z.array(RepositoryInstallationPlanSchema).optional(),
   })
   .refine(message => message.trigger === 'scheduled' || Boolean(message.commandId), {
     message: 'commandId is required for manual sync commands',
@@ -68,6 +77,7 @@ const ManualSecuritySyncCommandSchema = z.object({
   actor: SecuritySyncActorSchema,
   origin: z.enum(['manual', 'dashboard_refresh', 'enable_initial_sync']).default('manual'),
   repoFullName: z.string().min(1).optional(),
+  repositoryPlans: z.array(RepositoryInstallationPlanSchema).optional(),
   /** Stable web operation key (P1-A-08e); same-key retries reuse the original command. */
   operationKey: z.string().min(1).max(128).optional(),
 });
@@ -235,6 +245,7 @@ function buildManualSyncQueueMessage(
       dispatchedAt: new Date().toISOString(),
       actor: command.actor,
       repoFullName: command.repoFullName,
+      repositoryPlans: command.repositoryPlans,
     },
     contentType: 'json',
   };
@@ -449,6 +460,9 @@ function syncCommandTerminalState(result: Awaited<ReturnType<typeof syncOwner>>)
   if (result.commandResultCode === 'CONFIG_DISABLED') {
     return { status: 'no_op', resultCode: 'CONFIG_DISABLED' };
   }
+  if (result.commandResultCode === 'AMBIGUOUS_GITHUB_INTEGRATION') {
+    return { status: 'failed', resultCode: 'AMBIGUOUS_GITHUB_INTEGRATION' };
+  }
   if (result.commandResultCode === 'REPOSITORY_UNAVAILABLE' || result.staleRepos.length > 0) {
     return { status: 'failed', resultCode: 'REPOSITORY_UNAVAILABLE' };
   }
@@ -648,6 +662,7 @@ async function processSecuritySyncMessage(
     trigger: body.trigger,
     actor: body.actor,
     repoFullName: body.repoFullName,
+    repositoryPlans: body.repositoryPlans,
     notificationMaterializationEnabled: isStrictTrueRolloutFlag(
       env.SECURITY_NOTIFICATION_MATERIALIZATION_ENABLED,
       'SECURITY_NOTIFICATION_MATERIALIZATION_ENABLED'

--- a/services/security-sync/src/sync.test.ts
+++ b/services/security-sync/src/sync.test.ts
@@ -135,7 +135,14 @@ function createGitTokenService() {
         orgId?: string;
         expectedIntegrationId?: string;
       }) => Promise<GitTokenForRepoResult>
-    >(async () => ({ success: false, reason: 'repository_not_installed' })),
+    >(async () => ({
+      success: true,
+      token: 'github-token',
+      platformIntegrationId: 'integration-1',
+      installationId: 'installation-1',
+      accountLogin: 'acme',
+      appType: 'standard',
+    })),
   };
 }
 
@@ -215,6 +222,25 @@ describe('Worker GitHub repository integration planning', () => {
       ],
     });
     const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo.mockImplementation(async ({ githubRepo }) =>
+      githubRepo === 'other/api'
+        ? {
+            success: true,
+            token: 'lite-token',
+            platformIntegrationId: 'integration-lite',
+            installationId: 'installation-lite',
+            accountLogin: 'other',
+            appType: 'lite',
+          }
+        : {
+            success: true,
+            token: 'standard-token',
+            platformIntegrationId: 'integration-standard',
+            installationId: 'installation-standard',
+            accountLogin: 'acme',
+            appType: 'standard',
+          }
+    );
     const fetchStub = stubFetch(() => new Response(JSON.stringify([]), { status: 200 }));
 
     await expect(
@@ -226,13 +252,17 @@ describe('Worker GitHub repository integration planning', () => {
       })
     ).resolves.toMatchObject({ errors: 0, remainingRepoCount: 0 });
 
-    expect(gitTokenService.getToken).toHaveBeenNthCalledWith(
-      1,
-      'installation-standard',
-      'standard'
-    );
-    expect(gitTokenService.getToken).toHaveBeenNthCalledWith(2, 'installation-lite', 'lite');
-    expect(gitTokenService.getTokenForRepo).not.toHaveBeenCalled();
+    expect(gitTokenService.getTokenForRepo).toHaveBeenNthCalledWith(1, {
+      githubRepo: 'acme/widgets',
+      userId: 'user-1',
+      orgId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    });
+    expect(gitTokenService.getTokenForRepo).toHaveBeenNthCalledWith(2, {
+      githubRepo: 'other/api',
+      userId: 'user-1',
+      orgId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+    });
+    expect(gitTokenService.getToken).not.toHaveBeenCalled();
     expect(fetchStub).toHaveBeenCalledTimes(2);
   });
 
@@ -254,6 +284,14 @@ describe('Worker GitHub repository integration planning', () => {
       ],
     });
     const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo.mockResolvedValue({
+      success: true,
+      token: 'lite-token',
+      platformIntegrationId: exactIntegrationId,
+      installationId: 'installation-lite',
+      accountLogin: 'acme',
+      appType: 'lite',
+    });
     stubFetch(new Response(JSON.stringify([]), { status: 200 }));
 
     await syncOwner({
@@ -273,8 +311,13 @@ describe('Worker GitHub repository integration planning', () => {
       ],
     });
 
-    expect(gitTokenService.getToken).toHaveBeenCalledWith('installation-lite', 'lite');
-    expect(gitTokenService.getTokenForRepo).not.toHaveBeenCalled();
+    expect(gitTokenService.getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/widgets',
+      userId: 'user-1',
+      orgId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      expectedIntegrationId: exactIntegrationId,
+    });
+    expect(gitTokenService.getToken).not.toHaveBeenCalled();
   });
 
   it('uses authoritative Git Token Service resolution for an unpinned legacy repository', async () => {
@@ -332,6 +375,25 @@ describe('Worker GitHub repository integration planning', () => {
       ],
     });
     const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo.mockImplementation(async ({ githubRepo }) =>
+      githubRepo === 'other/api'
+        ? {
+            success: true,
+            token: 'healthy-token',
+            platformIntegrationId: 'integration-healthy',
+            installationId: 'installation-healthy',
+            accountLogin: 'other',
+            appType: 'lite',
+          }
+        : {
+            success: true,
+            token: 'invalid-token',
+            platformIntegrationId: 'integration-invalid',
+            installationId: 'installation-invalid',
+            accountLogin: 'acme',
+            appType: 'standard',
+          }
+    );
     const fetchStub = vi
       .fn()
       .mockResolvedValueOnce(new Response('Bad credentials', { status: 401 }))
@@ -352,8 +414,107 @@ describe('Worker GitHub repository integration planning', () => {
     });
 
     expect(fetchStub).toHaveBeenCalledTimes(2);
-    expect(gitTokenService.getToken).toHaveBeenNthCalledWith(1, 'installation-invalid', 'standard');
-    expect(gitTokenService.getToken).toHaveBeenNthCalledWith(2, 'installation-healthy', 'lite');
+    expect(gitTokenService.getToken).not.toHaveBeenCalled();
+    expect(gitTokenService.getTokenForRepo).toHaveBeenCalledTimes(3);
+  });
+
+  it('uses persisted composite selections as expected integration constraints', async () => {
+    const firstIntegrationId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const secondIntegrationId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const { db } = createFakeDb({
+      config: {
+        repository_selection_mode: 'selected',
+        selected_repository_ids: [1],
+        selected_repositories: [
+          { repositoryId: 1, platformIntegrationId: firstIntegrationId },
+          { repositoryId: 1, platformIntegrationId: secondIntegrationId },
+        ],
+      },
+      integrations: [
+        {
+          id: firstIntegrationId,
+          installationId: 'installation-standard',
+          repositories: [{ id: 1, fullName: 'acme/widgets' }],
+        },
+        {
+          id: secondIntegrationId,
+          installationId: 'installation-lite',
+          appType: 'lite',
+          repositories: [{ id: 1, fullName: 'acme/widgets' }],
+        },
+      ],
+    });
+    const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo.mockImplementation(async ({ expectedIntegrationId }) => ({
+      success: true,
+      token: expectedIntegrationId === firstIntegrationId ? 'standard-token' : 'lite-token',
+      platformIntegrationId: expectedIntegrationId ?? firstIntegrationId,
+      installationId:
+        expectedIntegrationId === firstIntegrationId
+          ? 'installation-standard'
+          : 'installation-lite',
+      accountLogin: 'acme',
+      appType: expectedIntegrationId === firstIntegrationId ? 'standard' : 'lite',
+    }));
+    const fetchStub = stubFetch(new Response(JSON.stringify([]), { status: 200 }));
+
+    await syncOwner({
+      db: db as never,
+      gitTokenService,
+      owner: { organizationId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' },
+      runId: 'run-composite-selection',
+    });
+
+    expect(gitTokenService.getTokenForRepo).toHaveBeenNthCalledWith(1, {
+      githubRepo: 'acme/widgets',
+      userId: 'user-1',
+      orgId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      expectedIntegrationId: firstIntegrationId,
+    });
+    expect(gitTokenService.getTokenForRepo).toHaveBeenNthCalledWith(2, {
+      githubRepo: 'acme/widgets',
+      userId: 'user-1',
+      orgId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+      expectedIntegrationId: secondIntegrationId,
+    });
+    expect(fetchStub).toHaveBeenNthCalledWith(
+      1,
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer standard-token' }),
+      })
+    );
+    expect(fetchStub).toHaveBeenNthCalledWith(
+      2,
+      expect.any(String),
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer lite-token' }),
+      })
+    );
+  });
+
+  it('does not prune a repository when authoritative lookup cannot find an installation', async () => {
+    const { db, sets } = createFakeDb({
+      config: { repository_selection_mode: 'selected', selected_repository_ids: [1] },
+    });
+    const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo.mockResolvedValue({
+      success: false,
+      reason: 'no_installation_found',
+    });
+    stubFetch(new Response('unexpected'));
+
+    await expect(
+      syncOwner({
+        db: db as never,
+        gitTokenService,
+        owner: { userId: 'user-1' },
+        runId: 'run-lookup-failure',
+      })
+    ).resolves.toMatchObject({ staleRepos: [], commandResultCode: 'REPOSITORY_UNAVAILABLE' });
+    expect(sets).not.toContainEqual(
+      expect.objectContaining({ config: expect.objectContaining({ selected_repository_ids: [] }) })
+    );
   });
 
   it('does not prune a selected repository that exists only on a suspended sibling', async () => {
@@ -378,6 +539,14 @@ describe('Worker GitHub repository integration planning', () => {
       ],
     });
     const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo.mockResolvedValue({
+      success: true,
+      token: 'healthy-token',
+      platformIntegrationId: 'integration-healthy',
+      installationId: 'installation-healthy',
+      accountLogin: 'other',
+      appType: 'standard',
+    });
     stubFetch(new Response(JSON.stringify([]), { status: 200 }));
 
     await syncOwner({
@@ -387,8 +556,8 @@ describe('Worker GitHub repository integration planning', () => {
       runId: 'run-suspended-sibling',
     });
 
-    expect(gitTokenService.getToken).toHaveBeenCalledOnce();
-    expect(gitTokenService.getToken).toHaveBeenCalledWith('installation-healthy', 'standard');
+    expect(gitTokenService.getToken).not.toHaveBeenCalled();
+    expect(gitTokenService.getTokenForRepo).toHaveBeenCalledOnce();
     expect(sets).not.toContainEqual(
       expect.objectContaining({
         config: expect.objectContaining({ selected_repository_ids: [2] }),
@@ -412,6 +581,15 @@ describe('Worker GitHub repository integration planning', () => {
       ],
     });
     const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo.mockImplementation(async ({ githubRepo }) => ({
+      success: true,
+      token: 'github-token',
+      platformIntegrationId:
+        githubRepo === 'other/api' ? 'integration-healthy' : 'integration-invalid',
+      installationId: githubRepo === 'other/api' ? 'installation-healthy' : 'installation-invalid',
+      accountLogin: githubRepo === 'other/api' ? 'other' : 'acme',
+      appType: 'standard',
+    }));
     const fetchStub = stubFetch(new Response('Bad credentials', { status: 401 }));
 
     await expect(
@@ -481,7 +659,8 @@ describe('Worker GitHub auth-invalid sync', () => {
     });
 
     expect(fetchStub).toHaveBeenCalledTimes(1);
-    expect(gitTokenService.getToken).toHaveBeenCalledTimes(1);
+    expect(gitTokenService.getToken).not.toHaveBeenCalled();
+    expect(gitTokenService.getTokenForRepo).toHaveBeenCalledTimes(2);
     expect(sets).toContainEqual(
       expect.objectContaining({ auth_invalid_reason: 'github_dependabot_401' })
     );

--- a/services/security-sync/src/sync.test.ts
+++ b/services/security-sync/src/sync.test.ts
@@ -1,10 +1,14 @@
 import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
 import {
   fetchAllDependabotAlerts,
   isFindingEligibleForAutoAnalysis,
   selectRepositoriesForSync,
   syncAutoAnalysisQueueForFinding,
   syncOwner,
+  upsertSecurityFinding,
+  type GitTokenForRepoResult,
 } from './sync.js';
 
 afterEach(() => {
@@ -14,8 +18,19 @@ afterEach(() => {
 
 type FakeDbOptions = {
   authInvalidAt?: string | null;
+  config?: Record<string, unknown>;
   repositories?: string[];
   runtimeState?: Record<string, unknown>;
+  integrations?: Array<{
+    id: string;
+    installationId: string;
+    appType?: 'standard' | 'lite';
+    status?: string;
+    suspendedAt?: string | null;
+    authInvalidAt?: string | null;
+    permissions?: Record<string, string>;
+    repositories: Array<{ id: number; fullName: string }>;
+  }>;
 };
 
 function createFakeDb(options: FakeDbOptions = {}) {
@@ -23,41 +38,64 @@ function createFakeDb(options: FakeDbOptions = {}) {
   const sets: Array<Record<string, unknown>> = [];
   let selectCount = 0;
 
+  const integrations = options.integrations?.map(integration => ({
+    id: integration.id,
+    platform_installation_id: integration.installationId,
+    permissions: integration.permissions ?? { vulnerability_alerts: 'read' },
+    repositories: integration.repositories.map(repository => ({
+      id: repository.id,
+      name: repository.fullName.split('/')[1] ?? repository.fullName,
+      full_name: repository.fullName,
+      private: true,
+    })),
+    authInvalidAt: integration.authInvalidAt ?? null,
+    integrationStatus: integration.status ?? 'active',
+    suspendedAt: integration.suspendedAt ?? null,
+    appType: integration.appType ?? 'standard',
+  })) ?? [
+    {
+      id: 'integration-1',
+      platform_installation_id: 'installation-1',
+      permissions: { vulnerability_alerts: 'read' },
+      repositories: repositories.map((full_name, index) => ({
+        id: index + 1,
+        name: full_name.split('/')[1] ?? full_name,
+        full_name,
+        private: true,
+      })),
+      authInvalidAt: options.authInvalidAt ?? null,
+      integrationStatus: 'active',
+      suspendedAt: null,
+      appType: 'standard' as const,
+    },
+  ];
+
   const db = {
-    select: () => ({
-      from: () => ({
-        where: () => ({
-          limit: async () => {
-            selectCount++;
-            if (selectCount === 1) {
-              return [
-                {
-                  id: 'agent-config',
-                  config: {},
-                  is_enabled: true,
-                  runtime_state: options.runtimeState ?? {},
-                },
-              ];
-            }
-            if (selectCount === 2) {
-              return [
-                {
-                  id: 'integration-1',
-                  platform_installation_id: 'installation-1',
-                  permissions: { vulnerability_alerts: 'read' },
-                  repositories: repositories.map((full_name, index) => ({
-                    id: index + 1,
-                    full_name,
-                  })),
-                  authInvalidAt: options.authInvalidAt ?? null,
-                },
-              ];
-            }
-            return [];
+    select: () => {
+      selectCount++;
+      const rows =
+        selectCount === 1
+          ? [
+              {
+                id: 'agent-config',
+                config: options.config ?? {},
+                is_enabled: true,
+                runtime_state: options.runtimeState ?? {},
+                created_by: 'user-1',
+              },
+            ]
+          : selectCount === 2
+            ? integrations
+            : [];
+      return {
+        from: () => ({
+          where: () => {
+            const query = Promise.resolve(rows);
+            return Object.assign(query, { limit: async () => rows });
           },
         }),
-      }),
-    }),
+      };
+    },
     update: () => ({
       set: (values: Record<string, unknown>) => {
         sets.push(values);
@@ -88,7 +126,17 @@ function runtimeStateSqlText(entry: Record<string, unknown>): string {
 }
 
 function createGitTokenService() {
-  return { getToken: vi.fn(async () => 'github-token') };
+  return {
+    getToken: vi.fn(async () => 'github-token'),
+    getTokenForRepo: vi.fn<
+      (params: {
+        githubRepo: string;
+        userId: string;
+        orgId?: string;
+        expectedIntegrationId?: string;
+      }) => Promise<GitTokenForRepoResult>
+    >(async () => ({ success: false, reason: 'repository_not_installed' })),
+  };
 }
 
 function stubFetch(response: Response | (() => Response)) {
@@ -149,6 +197,242 @@ describe('selectRepositoriesForSync', () => {
   });
 });
 
+describe('Worker GitHub repository integration planning', () => {
+  it('syncs repositories split across installations with each exact app type', async () => {
+    const { db } = createFakeDb({
+      integrations: [
+        {
+          id: 'integration-standard',
+          installationId: 'installation-standard',
+          repositories: [{ id: 1, fullName: 'acme/widgets' }],
+        },
+        {
+          id: 'integration-lite',
+          installationId: 'installation-lite',
+          appType: 'lite',
+          repositories: [{ id: 2, fullName: 'other/api' }],
+        },
+      ],
+    });
+    const gitTokenService = createGitTokenService();
+    const fetchStub = stubFetch(() => new Response(JSON.stringify([]), { status: 200 }));
+
+    await expect(
+      syncOwner({
+        db: db as never,
+        gitTokenService,
+        owner: { organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
+        runId: 'run-split',
+      })
+    ).resolves.toMatchObject({ errors: 0, remainingRepoCount: 0 });
+
+    expect(gitTokenService.getToken).toHaveBeenNthCalledWith(
+      1,
+      'installation-standard',
+      'standard'
+    );
+    expect(gitTokenService.getToken).toHaveBeenNthCalledWith(2, 'installation-lite', 'lite');
+    expect(gitTokenService.getTokenForRepo).not.toHaveBeenCalled();
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+  });
+
+  it('uses a received exact plan instead of an ambiguous cached repository mapping', async () => {
+    const exactIntegrationId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const { db } = createFakeDb({
+      integrations: [
+        {
+          id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+          installationId: 'installation-standard',
+          repositories: [{ id: 1, fullName: 'acme/widgets' }],
+        },
+        {
+          id: exactIntegrationId,
+          installationId: 'installation-lite',
+          appType: 'lite',
+          repositories: [{ id: 1, fullName: 'ACME/WIDGETS' }],
+        },
+      ],
+    });
+    const gitTokenService = createGitTokenService();
+    stubFetch(new Response(JSON.stringify([]), { status: 200 }));
+
+    await syncOwner({
+      db: db as never,
+      gitTokenService,
+      owner: { organizationId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' },
+      runId: 'run-exact-plan',
+      repoFullName: 'acme/widgets',
+      repositoryPlans: [
+        {
+          repoFullName: 'acme/widgets',
+          repositoryId: 1,
+          platformIntegrationId: exactIntegrationId,
+          installationId: 'installation-lite',
+          appType: 'lite',
+        },
+      ],
+    });
+
+    expect(gitTokenService.getToken).toHaveBeenCalledWith('installation-lite', 'lite');
+    expect(gitTokenService.getTokenForRepo).not.toHaveBeenCalled();
+  });
+
+  it('uses authoritative Git Token Service resolution for an unpinned legacy repository', async () => {
+    const { db } = createFakeDb();
+    const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo.mockResolvedValue({
+      success: true,
+      token: 'authoritative-token',
+      platformIntegrationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      installationId: 'installation-live',
+      accountLogin: 'renamed-owner',
+      appType: 'lite',
+    });
+    const fetchStub = stubFetch(new Response(JSON.stringify([]), { status: 200 }));
+
+    await syncOwner({
+      db: db as never,
+      gitTokenService,
+      owner: { userId: 'user-1' },
+      actor: { id: 'user-1' },
+      runId: 'run-legacy',
+      repoFullName: 'renamed-owner/legacy',
+    });
+
+    expect(gitTokenService.getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'renamed-owner/legacy',
+      userId: 'user-1',
+    });
+    expect(gitTokenService.getToken).not.toHaveBeenCalled();
+    expect(fetchStub).toHaveBeenCalledWith(
+      'https://api.github.com/repos/renamed-owner/legacy/dependabot/alerts?per_page=100',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer authoritative-token' }),
+      })
+    );
+  });
+
+  it('continues syncing a healthy sibling after another installation returns 401', async () => {
+    const { db } = createFakeDb({
+      integrations: [
+        {
+          id: 'integration-invalid',
+          installationId: 'installation-invalid',
+          repositories: [
+            { id: 1, fullName: 'acme/widgets' },
+            { id: 2, fullName: 'acme/website' },
+          ],
+        },
+        {
+          id: 'integration-healthy',
+          installationId: 'installation-healthy',
+          appType: 'lite',
+          repositories: [{ id: 3, fullName: 'other/api' }],
+        },
+      ],
+    });
+    const gitTokenService = createGitTokenService();
+    const fetchStub = vi
+      .fn()
+      .mockResolvedValueOnce(new Response('Bad credentials', { status: 401 }))
+      .mockResolvedValueOnce(new Response(JSON.stringify([]), { status: 200 }));
+    vi.stubGlobal('fetch', fetchStub);
+
+    await expect(
+      syncOwner({
+        db: db as never,
+        gitTokenService,
+        owner: { organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
+        runId: 'run-partial-auth',
+      })
+    ).resolves.toMatchObject({
+      authInvalid: 2,
+      authInvalidRepos: ['acme/widgets', 'acme/website'],
+      reauthRequired: true,
+    });
+
+    expect(fetchStub).toHaveBeenCalledTimes(2);
+    expect(gitTokenService.getToken).toHaveBeenNthCalledWith(1, 'installation-invalid', 'standard');
+    expect(gitTokenService.getToken).toHaveBeenNthCalledWith(2, 'installation-healthy', 'lite');
+  });
+
+  it('does not prune a selected repository that exists only on a suspended sibling', async () => {
+    const { db, sets } = createFakeDb({
+      config: {
+        repository_selection_mode: 'selected',
+        selected_repository_ids: [1, 2],
+      },
+      integrations: [
+        {
+          id: 'integration-suspended',
+          installationId: 'installation-suspended',
+          status: 'suspended',
+          suspendedAt: '2026-08-27T12:00:00.000Z',
+          repositories: [{ id: 1, fullName: 'old/private' }],
+        },
+        {
+          id: 'integration-healthy',
+          installationId: 'installation-healthy',
+          repositories: [{ id: 2, fullName: 'other/api' }],
+        },
+      ],
+    });
+    const gitTokenService = createGitTokenService();
+    stubFetch(new Response(JSON.stringify([]), { status: 200 }));
+
+    await syncOwner({
+      db: db as never,
+      gitTokenService,
+      owner: { organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
+      runId: 'run-suspended-sibling',
+    });
+
+    expect(gitTokenService.getToken).toHaveBeenCalledOnce();
+    expect(gitTokenService.getToken).toHaveBeenCalledWith('installation-healthy', 'standard');
+    expect(sets).not.toContainEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({ selected_repository_ids: [2] }),
+      })
+    );
+  });
+
+  it('requests continuation when one installation fails auth before healthy siblings', async () => {
+    const { db } = createFakeDb({
+      integrations: [
+        {
+          id: 'integration-invalid',
+          installationId: 'installation-invalid',
+          repositories: [{ id: 1, fullName: 'acme/widgets' }],
+        },
+        {
+          id: 'integration-healthy',
+          installationId: 'installation-healthy',
+          repositories: [{ id: 2, fullName: 'other/api' }],
+        },
+      ],
+    });
+    const gitTokenService = createGitTokenService();
+    const fetchStub = stubFetch(new Response('Bad credentials', { status: 401 }));
+
+    await expect(
+      syncOwner({
+        db: db as never,
+        gitTokenService,
+        owner: { organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
+        runId: 'run-auth-continuation',
+        budgetMs: 0,
+      })
+    ).resolves.toMatchObject({
+      authInvalid: 1,
+      reauthRequired: true,
+      exhaustedBudget: true,
+      remainingRepoCount: 1,
+    });
+
+    expect(fetchStub).toHaveBeenCalledOnce();
+  });
+});
+
 describe('Worker GitHub auth-invalid sync', () => {
   it('accepts Dependabot alerts with nullable advisory fields', async () => {
     const alert = createDependabotAlert({
@@ -177,7 +461,7 @@ describe('Worker GitHub auth-invalid sync', () => {
     });
   });
 
-  it('persists the first GitHub 401 and stops syncing remaining repos', async () => {
+  it('persists the first GitHub 401 and skips remaining repos on that installation', async () => {
     const { db, sets } = createFakeDb({ repositories: ['acme/widgets', 'acme/api'] });
     const gitTokenService = createGitTokenService();
     const fetchStub = stubFetch(new Response('Bad credentials', { status: 401 }));
@@ -190,8 +474,8 @@ describe('Worker GitHub auth-invalid sync', () => {
         runId: 'run-1',
       })
     ).resolves.toMatchObject({
-      authInvalid: 1,
-      authInvalidRepos: ['acme/widgets'],
+      authInvalid: 2,
+      authInvalidRepos: ['acme/widgets', 'acme/api'],
       reauthRequired: true,
       errors: 0,
     });
@@ -436,6 +720,59 @@ describe('Worker GitHub auth-invalid sync', () => {
         repo_full_name: 'acme/widgets',
       }),
     });
+  });
+
+  it('updates a finding integration when authoritative sync observes repository movement', async () => {
+    let upsertSql = '';
+    const execute = vi.fn<(query: SQL) => Promise<{ rows: unknown[] }>>(async query => {
+      upsertSql = new PgDialect().sqlToQuery(query).sql;
+      return {
+        rows: [
+          {
+            findingId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc',
+            wasInserted: false,
+            previousStatus: 'open',
+            previousSeverity: 'high',
+            effectiveStatus: 'open',
+            effectiveSeverity: 'high',
+            findingCreatedAt: '2026-05-18T10:00:00.000Z',
+            ownedByUserId: null,
+            ownedByOrganizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            source: 'dependabot',
+            sourceId: '23',
+            repoFullName: 'acme/widgets',
+            title: 'Prototype pollution in lodash',
+            packageName: 'lodash',
+            packageEcosystem: 'npm',
+            manifestPath: 'package.json',
+            patchedVersion: '4.17.21',
+            ghsaId: 'GHSA-1234-5678-90ab',
+            cveId: null,
+            cweIds: ['CWE-1321'],
+            cvssScore: '7.5',
+            dependabotHtmlUrl: 'https://github.com/acme/widgets/security/dependabot/23',
+            firstDetectedAt: '2026-05-18T10:00:00.000Z',
+            fixedAt: null,
+            slaDueAt: '2026-06-17T10:00:00.000Z',
+          },
+        ],
+      };
+    });
+
+    await expect(
+      upsertSecurityFinding({ execute } as never, {
+        finding: createDependabotAlert() as never,
+        owner: { organizationId: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa' },
+        platformIntegrationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+        repoFullName: 'acme/widgets',
+        slaDueAt: '2026-06-17T10:00:00.000Z',
+      })
+    ).resolves.toMatchObject({ findingId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' });
+
+    expect(upsertSql).toContain('"platform_integration_id" = EXCLUDED."platform_integration_id"');
+    expect(upsertSql).toContain(
+      '"security_findings"."platform_integration_id" IS DISTINCT FROM EXCLUDED."platform_integration_id"'
+    );
   });
 
   it('does not let unsafe source snapshot values block finding sync', async () => {

--- a/services/security-sync/src/sync.test.ts
+++ b/services/security-sync/src/sync.test.ts
@@ -74,7 +74,7 @@ function createFakeDb(options: FakeDbOptions = {}) {
     select: () => {
       selectCount++;
       const rows =
-        selectCount === 1
+        selectCount === 1 || selectCount === 4
           ? [
               {
                 id: 'agent-config',
@@ -514,6 +514,61 @@ describe('Worker GitHub repository integration planning', () => {
     ).resolves.toMatchObject({ staleRepos: [], commandResultCode: 'REPOSITORY_UNAVAILABLE' });
     expect(sets).not.toContainEqual(
       expect.objectContaining({ config: expect.objectContaining({ selected_repository_ids: [] }) })
+    );
+  });
+
+  it('prunes only the stale explicit installation when duplicate IDs remain selected', async () => {
+    const firstIntegrationId = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+    const secondIntegrationId = 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb';
+    const { db, sets } = createFakeDb({
+      config: {
+        repository_selection_mode: 'selected',
+        selected_repository_ids: [1],
+        selected_repositories: [
+          { repositoryId: 1, platformIntegrationId: firstIntegrationId },
+          { repositoryId: 1, platformIntegrationId: secondIntegrationId },
+        ],
+      },
+      integrations: [
+        {
+          id: firstIntegrationId,
+          installationId: 'installation-1',
+          repositories: [{ id: 1, fullName: 'acme/widgets' }],
+        },
+        {
+          id: secondIntegrationId,
+          installationId: 'installation-2',
+          repositories: [{ id: 1, fullName: 'acme/widgets' }],
+        },
+      ],
+    });
+    const gitTokenService = createGitTokenService();
+    gitTokenService.getTokenForRepo
+      .mockResolvedValueOnce({ success: false, reason: 'repository_not_installed' })
+      .mockResolvedValueOnce({
+        success: true,
+        token: 'healthy-token',
+        platformIntegrationId: secondIntegrationId,
+        installationId: 'installation-2',
+        accountLogin: 'acme',
+        appType: 'standard',
+      });
+    stubFetch(new Response(JSON.stringify([]), { status: 200 }));
+
+    await syncOwner({
+      db: db as never,
+      gitTokenService,
+      owner: { organizationId: 'cccccccc-cccc-4ccc-8ccc-cccccccccccc' },
+      runId: 'run-stale-duplicate',
+    });
+
+    expect(sets).toContainEqual(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          selected_repository_ids: [1],
+          selected_repositories: [{ repositoryId: 1, platformIntegrationId: secondIntegrationId }],
+        }),
+      })
     );
   });
 

--- a/services/security-sync/src/sync.ts
+++ b/services/security-sync/src/sync.ts
@@ -164,6 +164,47 @@ type SecurityReviewOwner =
   | { organizationId: string; userId?: never }
   | { userId: string; organizationId?: never };
 
+type GitHubAppType = 'standard' | 'lite';
+
+export type RepositoryInstallationPlan = {
+  repoFullName: string;
+  repositoryId?: number;
+  platformIntegrationId: string;
+  installationId: string;
+  appType: GitHubAppType;
+};
+
+export type GitTokenForRepoResult =
+  | {
+      success: true;
+      token: string;
+      platformIntegrationId: string;
+      installationId: string;
+      accountLogin: string;
+      appType: GitHubAppType;
+    }
+  | {
+      success: false;
+      reason:
+        | 'database_not_configured'
+        | 'invalid_repo_format'
+        | 'no_installation_found'
+        | 'repository_not_installed'
+        | 'ambiguous_installation'
+        | 'temporarily_unavailable'
+        | 'invalid_org_id'
+        | 'integration_mismatch';
+    };
+
+type SecuritySyncGitTokenService = GitTokenService & {
+  getTokenForRepo?: (params: {
+    githubRepo: string;
+    userId: string;
+    orgId?: string;
+    expectedIntegrationId?: string;
+  }) => Promise<GitTokenForRepoResult>;
+};
+
 export const SECURITY_SYNC_OWNER_BUDGET_MS = 8 * 60 * 1000;
 
 const SyncRunProgressSchema = z.object({
@@ -176,6 +217,7 @@ const SyncRunProgressSchema = z.object({
   skipped: z.number().int().nonnegative(),
   authInvalid: z.number().int().nonnegative(),
   reauthRequired: z.boolean(),
+  commandResultCode: z.string().optional(),
 });
 
 type SyncRunProgress = z.infer<typeof SyncRunProgressSchema>;
@@ -235,6 +277,7 @@ function applySyncRunProgress(result: SyncResult, progress: SyncRunProgress): vo
   result.authInvalidRepos = [...progress.authInvalidRepos];
   result.reauthRequired = progress.reauthRequired;
   result.staleRepos = [...progress.staleRepos];
+  result.commandResultCode = progress.commandResultCode;
 }
 
 function toSyncRunProgress(
@@ -252,6 +295,7 @@ function toSyncRunProgress(
     skipped: result.skipped,
     authInvalid: result.authInvalid,
     reauthRequired: result.reauthRequired,
+    commandResultCode: result.commandResultCode,
   };
 }
 
@@ -355,25 +399,213 @@ function findingOwnerPartitionColumn(owner: SecurityReviewOwner) {
     : security_findings.owned_by_user_id;
 }
 
+type RepositorySyncPlan = {
+  repoFullName: string;
+  repositoryId?: number;
+  platformIntegrationId?: string;
+  installationId?: string;
+  appType?: GitHubAppType;
+  authInvalidAt: string | null;
+};
+
+type IntegrationCandidate = {
+  id: string;
+  platform_installation_id: string | null;
+  permissions: Record<string, unknown> | null;
+  repositories: PlatformRepository<number | string>[] | null;
+  authInvalidAt: string | null;
+  integrationStatus: string | null;
+  suspendedAt: string | null;
+  appType: GitHubAppType | null;
+};
+
 type EnabledOwnerConfig = {
-  owner: SecurityReviewOwner;
-  platformIntegrationId: string;
-  installationId: string;
   repositories: string[];
   repoNameToId: Map<string, number>;
+  repositoryPlanByName: Map<string, RepositorySyncPlan>;
+  integrationsById: Map<string, IntegrationCandidate>;
+  knownRepositoryIds: Set<number>;
+  resolverUserId: string;
   slaConfig: SecurityAgentConfig;
   notificationPolicy: SecurityNotificationPolicy | null;
   autoAnalysisEnabledAt: string | null;
-  authInvalidAt: string | null;
-  /** Number of selected_repository_ids that are no longer accessible via the installation.
+  /** Number of selected_repository_ids that are no longer present on any owner installation.
    *  Non-zero means the app lost access to a configured repo — freshness must not advance. */
   missingSelectedRepoCount: number;
   runtimeState: Record<string, unknown>;
 };
 
+function hasSecuritySyncPermission(integration: IntegrationCandidate): boolean {
+  const permission = integration.permissions?.vulnerability_alerts;
+  return permission === 'read' || permission === 'write';
+}
+
+function isSyncableIntegration(
+  owner: SecurityReviewOwner,
+  integration: IntegrationCandidate
+): boolean {
+  return (
+    !isOrgOwner(owner) ||
+    (integration.integrationStatus === 'active' && integration.suspendedAt === null)
+  );
+}
+
+function validIntegrationRepositories(integration: IntegrationCandidate): PlatformRepository[] {
+  return (integration.repositories ?? []).filter(
+    (repository): repository is PlatformRepository =>
+      typeof repository.id === 'number' &&
+      typeof repository.full_name === 'string' &&
+      repository.full_name.length > 0
+  );
+}
+
+function normalizedRepoName(repoFullName: string): string {
+  return repoFullName.toLowerCase();
+}
+
+function buildRepositorySyncPlan(
+  owner: SecurityReviewOwner,
+  integrations: IntegrationCandidate[],
+  securityConfig: Partial<SecurityAgentConfig>
+): Pick<
+  EnabledOwnerConfig,
+  | 'repositories'
+  | 'repoNameToId'
+  | 'repositoryPlanByName'
+  | 'knownRepositoryIds'
+  | 'missingSelectedRepoCount'
+> {
+  const knownRepositoryIds = new Set<number>();
+  const candidatesByName = new Map<string, RepositorySyncPlan[]>();
+  const candidatesById = new Map<number, RepositorySyncPlan[]>();
+
+  for (const integration of integrations) {
+    const repositories = validIntegrationRepositories(integration);
+    for (const repository of repositories) knownRepositoryIds.add(repository.id);
+    if (
+      !integration.platform_installation_id ||
+      !hasSecuritySyncPermission(integration) ||
+      !isSyncableIntegration(owner, integration)
+    ) {
+      continue;
+    }
+
+    const seenRepoNames = new Set<string>();
+    for (const repository of repositories) {
+      const normalizedName = normalizedRepoName(repository.full_name);
+      if (seenRepoNames.has(normalizedName)) continue;
+      seenRepoNames.add(normalizedName);
+      const candidate: RepositorySyncPlan = {
+        repoFullName: repository.full_name,
+        repositoryId: repository.id,
+        platformIntegrationId: integration.id,
+        installationId: integration.platform_installation_id,
+        appType: integration.appType ?? 'standard',
+        authInvalidAt: integration.authInvalidAt,
+      };
+      candidatesByName.set(normalizedName, [
+        ...(candidatesByName.get(normalizedName) ?? []),
+        candidate,
+      ]);
+      candidatesById.set(repository.id, [...(candidatesById.get(repository.id) ?? []), candidate]);
+    }
+  }
+
+  const repositoryPlanByName = new Map<string, RepositorySyncPlan>();
+  const repoNameToId = new Map<string, number>();
+  const addCandidates = (candidates: RepositorySyncPlan[]) => {
+    const candidate = candidates[0];
+    if (!candidate || candidate.repositoryId === undefined) return;
+    const normalizedName = normalizedRepoName(candidate.repoFullName);
+    if (repositoryPlanByName.has(normalizedName)) return;
+    repoNameToId.set(candidate.repoFullName, candidate.repositoryId);
+    repositoryPlanByName.set(
+      normalizedName,
+      candidates.length === 1
+        ? candidate
+        : {
+            repoFullName: candidate.repoFullName,
+            repositoryId: candidate.repositoryId,
+            authInvalidAt: null,
+          }
+    );
+  };
+
+  for (const candidates of candidatesByName.values()) addCandidates(candidates);
+
+  const repositories: string[] = [];
+  const selectedNames = new Set<string>();
+  let missingSelectedRepoCount = 0;
+  if (securityConfig.repository_selection_mode === 'selected') {
+    for (const selectedId of new Set(securityConfig.selected_repository_ids ?? [])) {
+      const candidates = candidatesById.get(selectedId) ?? [];
+      if (candidates.length === 0) {
+        if (!knownRepositoryIds.has(selectedId)) missingSelectedRepoCount++;
+        continue;
+      }
+      const candidate = candidates[0];
+      if (!candidate) continue;
+      const normalizedName = normalizedRepoName(candidate.repoFullName);
+      const planned = repositoryPlanByName.get(normalizedName);
+      if (planned && !selectedNames.has(normalizedName)) {
+        repositories.push(planned.repoFullName);
+        selectedNames.add(normalizedName);
+      }
+    }
+  } else {
+    repositories.push(...[...repositoryPlanByName.values()].map(plan => plan.repoFullName));
+  }
+
+  return {
+    repositories,
+    repoNameToId,
+    repositoryPlanByName,
+    knownRepositoryIds,
+    missingSelectedRepoCount,
+  };
+}
+
+function mergeReceivedRepositoryPlans(
+  config: Pick<
+    EnabledOwnerConfig,
+    'repositories' | 'repositoryPlanByName' | 'repoNameToId' | 'integrationsById'
+  >,
+  plans: RepositoryInstallationPlan[]
+): void {
+  for (const plan of plans) {
+    const integration = config.integrationsById.get(plan.platformIntegrationId);
+    if (
+      !integration ||
+      !integration.platform_installation_id ||
+      integration.platform_installation_id !== plan.installationId ||
+      (integration.appType ?? 'standard') !== plan.appType ||
+      !hasSecuritySyncPermission(integration) ||
+      integration.integrationStatus !== 'active' ||
+      integration.suspendedAt !== null
+    ) {
+      continue;
+    }
+
+    const normalizedName = normalizedRepoName(plan.repoFullName);
+    config.repositoryPlanByName.set(normalizedName, {
+      ...plan,
+      authInvalidAt: integration.authInvalidAt,
+    });
+    if (
+      !config.repositories.some(repository => normalizedRepoName(repository) === normalizedName)
+    ) {
+      config.repositories.push(plan.repoFullName);
+    }
+    if (plan.repositoryId !== undefined) {
+      config.repoNameToId.set(plan.repoFullName, plan.repositoryId);
+    }
+  }
+}
+
 export async function getOwnerConfig(
   db: WorkerDb,
-  owner: SecurityReviewOwner
+  owner: SecurityReviewOwner,
+  allowEmptyRepositoryPlan = false
 ): Promise<EnabledOwnerConfig | null> {
   // Get agent config
   const configs = await db
@@ -382,6 +614,7 @@ export async function getOwnerConfig(
       config: agent_configs.config,
       is_enabled: agent_configs.is_enabled,
       runtime_state: agent_configs.runtime_state,
+      created_by: agent_configs.created_by,
     })
     .from(agent_configs)
     .where(
@@ -397,7 +630,6 @@ export async function getOwnerConfig(
   if (configs.length === 0) return null;
   const agentConfig = configs[0];
 
-  // Get platform integration
   const integrations = await db
     .select({
       id: platform_integrations.id,
@@ -405,39 +637,21 @@ export async function getOwnerConfig(
       permissions: platform_integrations.permissions,
       repositories: platform_integrations.repositories,
       authInvalidAt: platform_integrations.auth_invalid_at,
+      integrationStatus: platform_integrations.integration_status,
+      suspendedAt: platform_integrations.suspended_at,
+      appType: platform_integrations.github_app_type,
     })
     .from(platform_integrations)
     .where(
       and(
         integrationOwnerFilter(owner),
         eq(platform_integrations.platform, 'github'),
+        eq(platform_integrations.integration_type, 'app'),
         isNotNull(platform_integrations.platform_installation_id)
       )
-    )
-    .limit(1);
+    );
 
   if (integrations.length === 0) return null;
-  const integration = integrations[0];
-
-  if (!integration.platform_installation_id) return null;
-
-  // Check vulnerability_alerts permission
-  const perms = integration.permissions;
-  if (!perms || (perms.vulnerability_alerts !== 'read' && perms.vulnerability_alerts !== 'write')) {
-    console.warn(`Integration ${integration.id} missing vulnerability_alerts permission, skipping`);
-    return null;
-  }
-
-  // Filter repositories
-  const allRepos = (integration.repositories ?? []).filter(
-    (repository): repository is PlatformRepository =>
-      typeof repository.id === 'number' &&
-      typeof repository.full_name === 'string' &&
-      repository.full_name.length > 0
-  );
-  if (allRepos.length === 0) return null;
-
-  const repoNameToId = new Map(allRepos.map(r => [r.full_name, r.id]));
 
   const parsed = securityAgentConfigSchema.partial().safeParse(agentConfig.config);
   if (!parsed.success) {
@@ -445,28 +659,21 @@ export async function getOwnerConfig(
     return null;
   }
   const securityConfig = parsed.data;
-  let selectedRepos: string[];
-  let missingSelectedRepoCount = 0;
-  if (securityConfig.repository_selection_mode === 'selected') {
-    const selectedIds = new Set(securityConfig.selected_repository_ids ?? []);
-    if (selectedIds.size > 0) {
-      const accessibleIds = new Set(allRepos.map(r => r.id));
-      selectedRepos = allRepos.filter(r => selectedIds.has(r.id)).map(r => r.full_name);
-      missingSelectedRepoCount = [...selectedIds].filter(id => !accessibleIds.has(id)).length;
-    } else {
-      // Mode is 'selected' but no repos are configured — don't fall through to 'all'
-      selectedRepos = [];
-    }
-  } else {
-    selectedRepos = allRepos.map(r => r.full_name);
+  const repositoryPlan = buildRepositorySyncPlan(owner, integrations, securityConfig);
+
+  if (
+    !allowEmptyRepositoryPlan &&
+    repositoryPlan.repositories.length === 0 &&
+    repositoryPlan.missingSelectedRepoCount === 0
+  ) {
+    return null;
   }
 
-  if (selectedRepos.length === 0 && missingSelectedRepoCount === 0) return null;
-
-  if (missingSelectedRepoCount > 0) {
-    console.warn(`${missingSelectedRepoCount} selected repo(s) no longer accessible for owner`, {
-      owner,
-    });
+  if (repositoryPlan.missingSelectedRepoCount > 0) {
+    console.warn(
+      `${repositoryPlan.missingSelectedRepoCount} selected repo(s) no longer present on any installation for owner`,
+      { owner }
+    );
   }
 
   const parsedNotificationPolicy = SecurityNotificationPolicySchema.safeParse(
@@ -489,16 +696,12 @@ export async function getOwnerConfig(
     .limit(1);
 
   return {
-    owner,
-    platformIntegrationId: integration.id,
-    installationId: integration.platform_installation_id,
-    repositories: selectedRepos,
-    repoNameToId,
+    ...repositoryPlan,
+    integrationsById: new Map(integrations.map(integration => [integration.id, integration])),
+    resolverUserId: agentConfig.created_by,
     slaConfig: { ...DEFAULT_SLA_CONFIG, ...securityConfig },
     notificationPolicy,
     autoAnalysisEnabledAt: ownerStates[0]?.autoAnalysisEnabledAt ?? null,
-    authInvalidAt: integration.authInvalidAt,
-    missingSelectedRepoCount,
     runtimeState:
       agentConfig.runtime_state && typeof agentConfig.runtime_state === 'object'
         ? agentConfig.runtime_state
@@ -756,7 +959,7 @@ const supersededSecurityFindingResultSchema = upsertSecurityFindingResultSchema.
 });
 type SupersededSecurityFindingResult = z.infer<typeof supersededSecurityFindingResultSchema>;
 
-async function upsertSecurityFinding(
+export async function upsertSecurityFinding(
   db: Pick<WorkerDb, 'execute'>,
   params: {
     finding: ParsedSecurityFinding;
@@ -778,14 +981,15 @@ async function upsertSecurityFinding(
   // Every stored column is derived from the Dependabot alert (see parseDependabotAlert),
   // and GitHub only advances the alert's updated_at on real changes, so comparing the
   // stored raw_data (jsonb, order-independent) detects any source-driven change in one
-  // check. sla_due_at is the only value we compute ourselves, so it is compared separately
-  // to catch SLA-policy changes. When neither differs the DO UPDATE matches no row and the
+  // check. sla_due_at and the authoritative repository integration are compared separately
+  // to catch SLA-policy changes and legitimate repository movement. When none differs, the
   // fallback SELECT below returns the existing finding with wasInserted=false and no
   // status/severity delta, so notifications and audit events behave exactly as they did for
   // an unchanged re-sync.
   const materialChangePredicate = sql`(
         ${security_findings.raw_data} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.raw_data.name)}
         OR ${security_findings.sla_due_at} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.sla_due_at.name)}
+        OR ${security_findings.platform_integration_id} IS DISTINCT FROM EXCLUDED.${sql.identifier(security_findings.platform_integration_id.name)}
       )`;
 
   const result = await db.execute<Record<string, unknown>>(sql`
@@ -862,6 +1066,7 @@ async function upsertSecurityFinding(
       LEFT JOIN existing_match ON true
       ON CONFLICT ${findingOwnerConflictTarget(owner)} DO UPDATE
       SET
+        ${sql.identifier(security_findings.platform_integration_id.name)} = EXCLUDED.${sql.identifier(security_findings.platform_integration_id.name)},
         ${sql.identifier(security_findings.severity.name)} = EXCLUDED.${sql.identifier(security_findings.severity.name)},
         ${sql.identifier(security_findings.ghsa_id.name)} = EXCLUDED.${sql.identifier(security_findings.ghsa_id.name)},
         ${sql.identifier(security_findings.cve_id.name)} = EXCLUDED.${sql.identifier(security_findings.cve_id.name)},
@@ -1645,7 +1850,7 @@ async function pruneStaleReposFromConfig(
   );
 }
 
-/** Remove selected_repository_ids that are no longer accessible via the GitHub installation.
+/** Remove selected_repository_ids that are no longer present on any owner installation.
  *  Unlike pruneStaleReposFromConfig (which prunes by repo name after sync), this handles
  *  repos that silently vanished from the installation and were never synced at all. */
 async function pruneMissingSelectedRepos(
@@ -1696,21 +1901,25 @@ async function pruneMissingSelectedRepos(
 }
 
 export function selectRepositoriesForSync(
-  config: Pick<EnabledOwnerConfig, 'repositories' | 'repoNameToId'>,
+  config: Pick<EnabledOwnerConfig, 'repositories' | 'repoNameToId'> &
+    Partial<Pick<EnabledOwnerConfig, 'repositoryPlanByName'>>,
   repoFullName?: string
 ): string[] {
   if (!repoFullName) return config.repositories;
+  const plannedRepository = config.repositoryPlanByName?.get(normalizedRepoName(repoFullName));
+  if (plannedRepository) return [plannedRepository.repoFullName];
   return config.repoNameToId.has(repoFullName) ? [repoFullName] : [];
 }
 
 export async function syncOwner(params: {
   db: WorkerDb;
-  gitTokenService: GitTokenService;
+  gitTokenService: SecuritySyncGitTokenService;
   owner: SecurityReviewOwner;
   runId: string;
   trigger?: 'scheduled' | 'manual';
   actor?: { id: string; email?: string | null; name?: string | null };
   repoFullName?: string;
+  repositoryPlans?: RepositoryInstallationPlan[];
   notificationMaterializationEnabled?: boolean;
   budgetMs?: number;
 }): Promise<SyncResult> {
@@ -1718,35 +1927,25 @@ export async function syncOwner(params: {
   const trigger = params.trigger ?? 'scheduled';
   const startTime = Date.now();
 
-  const config = await getOwnerConfig(database, owner);
+  const config = await getOwnerConfig(
+    database,
+    owner,
+    Boolean(repoFullName || params.repositoryPlans?.length)
+  );
   if (!config) {
     console.info(`No enabled config for owner, skipping`, { runId, owner });
     return { ...createEmptySyncResult(), commandResultCode: 'CONFIG_DISABLED' };
   }
 
-  const repositories = selectRepositoriesForSync(config, repoFullName);
-  if (repoFullName && repositories.length === 0) {
-    console.warn('Manual sync repository is not accessible for owner, skipping', {
-      runId,
-      owner,
-      repoFullName,
-    });
-    await recordSecurityAgentRepositorySyncFailure(database, {
-      owner: toSecurityAgentCommandOwner(owner),
-      repoFullName,
-      failureCode: 'REPOSITORY_UNAVAILABLE',
-    });
-    return { ...createEmptySyncResult(), commandResultCode: 'REPOSITORY_UNAVAILABLE' };
-  }
+  if (params.repositoryPlans) mergeReceivedRepositoryPlans(config, params.repositoryPlans);
 
-  if (isRecentTimestamp(config.authInvalidAt, AUTH_INVALID_SHORT_CIRCUIT_MS)) {
-    console.warn('Skipping security sync because GitHub installation needs reauthorization', {
-      runId,
-      owner,
-      repositoryCount: repositories.length,
-      authInvalidAt: config.authInvalidAt,
+  let repositories = selectRepositoriesForSync(config, repoFullName);
+  if (repoFullName && repositories.length === 0) {
+    config.repositoryPlanByName.set(normalizedRepoName(repoFullName), {
+      repoFullName,
+      authInvalidAt: null,
     });
-    return createAuthInvalidSyncResult(repositories);
+    repositories = [repoFullName];
   }
 
   const previousProgress = repoFullName ? null : readSyncRunProgress(config.runtimeState, runId);
@@ -1766,6 +1965,7 @@ export async function syncOwner(params: {
   let processedThisPass = 0;
   let incompleteFailures = 0;
   let exhaustedBudget = false;
+  const authInvalidIntegrationIds = new Set<string>();
   const notificationPolicy = params.notificationMaterializationEnabled
     ? config.notificationPolicy
     : null;
@@ -1784,13 +1984,38 @@ export async function syncOwner(params: {
     }
 
     try {
+      const repositoryPlan = config.repositoryPlanByName.get(
+        normalizedRepoName(selectedRepoFullName)
+      );
+      if (!repositoryPlan) {
+        throw new Error(`No GitHub integration plan for ${selectedRepoFullName}`);
+      }
+
+      if (
+        (repositoryPlan.platformIntegrationId &&
+          authInvalidIntegrationIds.has(repositoryPlan.platformIntegrationId)) ||
+        isRecentTimestamp(repositoryPlan.authInvalidAt, AUTH_INVALID_SHORT_CIRCUIT_MS)
+      ) {
+        await recordSecurityAgentRepositorySyncFailure(database, {
+          owner: toSecurityAgentCommandOwner(owner),
+          repoFullName: selectedRepoFullName,
+          failureCode: 'GITHUB_AUTH_INVALID',
+        });
+        totalResult.authInvalid++;
+        totalResult.authInvalidRepos.push(selectedRepoFullName);
+        totalResult.reauthRequired = true;
+        completedRepos.add(selectedRepoFullName);
+        processedThisPass++;
+        continue;
+      }
+
       const repoResult = await syncRepo({
         db: database,
         gitTokenService,
-        installationId: config.installationId,
+        repositoryPlan,
+        resolverUserId: actor?.id ?? config.resolverUserId,
         owner,
         runId,
-        platformIntegrationId: config.platformIntegrationId,
         repoFullName: selectedRepoFullName,
         slaConfig: config.slaConfig,
         notificationPolicy,
@@ -1804,12 +2029,13 @@ export async function syncOwner(params: {
       totalResult.authInvalidRepos.push(...repoResult.authInvalidRepos);
       totalResult.reauthRequired = totalResult.reauthRequired || repoResult.reauthRequired;
       totalResult.staleRepos.push(...repoResult.staleRepos);
+      totalResult.commandResultCode ??= repoResult.commandResultCode;
       successfulRepos++;
       completedRepos.add(selectedRepoFullName);
       processedThisPass++;
 
-      if (repoResult.reauthRequired) {
-        break;
+      if (repoResult.reauthRequired && repositoryPlan.platformIntegrationId) {
+        authInvalidIntegrationIds.add(repositoryPlan.platformIntegrationId);
       }
     } catch (error) {
       incompleteFailures++;
@@ -1829,7 +2055,7 @@ export async function syncOwner(params: {
   }
 
   const remainingRepoCount = repositories.filter(name => !completedRepos.has(name)).length;
-  if (exhaustedBudget && remainingRepoCount > 0 && !totalResult.reauthRequired) {
+  if (exhaustedBudget && remainingRepoCount > 0) {
     await writeSyncRunProgress(
       database,
       owner,
@@ -1866,8 +2092,7 @@ export async function syncOwner(params: {
   // inspection already loaded full accessible repositories for both sync scopes.
   if (config.missingSelectedRepoCount > 0) {
     try {
-      const accessibleRepoIds = new Set(config.repoNameToId.values());
-      await pruneMissingSelectedRepos(database, owner, accessibleRepoIds);
+      await pruneMissingSelectedRepos(database, owner, config.knownRepositoryIds);
     } catch (error) {
       console.error('Failed to prune missing selected repos from config', {
         error: error instanceof Error ? error.message : String(error),
@@ -1915,6 +2140,7 @@ export async function syncOwner(params: {
     totalResult.errors === 0 &&
     totalResult.authInvalid === 0 &&
     totalResult.staleRepos.length === 0 &&
+    totalResult.commandResultCode === undefined &&
     config.missingSelectedRepoCount === 0;
   if (shouldAdvanceFreshness) {
     try {
@@ -1979,11 +2205,11 @@ export async function syncOwner(params: {
 
 async function syncRepo(params: {
   db: WorkerDb;
-  gitTokenService: GitTokenService;
-  installationId: string;
+  gitTokenService: SecuritySyncGitTokenService;
+  repositoryPlan: RepositorySyncPlan;
+  resolverUserId: string;
   owner: SecurityReviewOwner;
   runId: string;
-  platformIntegrationId: string;
   repoFullName: string;
   slaConfig: SecurityAgentConfig;
   notificationPolicy: SecurityNotificationPolicy | null;
@@ -1993,10 +2219,10 @@ async function syncRepo(params: {
   const {
     db: database,
     gitTokenService,
-    installationId,
+    repositoryPlan,
+    resolverUserId,
     owner,
     runId,
-    platformIntegrationId,
     repoFullName,
     slaConfig,
     notificationPolicy,
@@ -2004,8 +2230,36 @@ async function syncRepo(params: {
   } = params;
   const commandOwner = toSecurityAgentCommandOwner(owner);
   await recordSecurityAgentRepositorySyncAttempt(database, { owner: commandOwner, repoFullName });
-  const token = await gitTokenService.getToken(installationId);
   const result = createEmptySyncResult();
+
+  const resolved = await resolveRepositoryToken({
+    gitTokenService,
+    repositoryPlan,
+    owner,
+    repoFullName,
+    resolverUserId,
+  });
+  if (!resolved.success) {
+    if (
+      resolved.reason === 'database_not_configured' ||
+      resolved.reason === 'temporarily_unavailable'
+    ) {
+      throw new Error(`GitHub repository installation resolution failed: ${resolved.reason}`);
+    }
+    const failureCode =
+      resolved.reason === 'ambiguous_installation'
+        ? 'AMBIGUOUS_GITHUB_INTEGRATION'
+        : 'REPOSITORY_UNAVAILABLE';
+    await recordSecurityAgentRepositorySyncFailure(database, {
+      owner: commandOwner,
+      repoFullName,
+      failureCode,
+    });
+    result.commandResultCode = failureCode;
+    if (failureCode === 'REPOSITORY_UNAVAILABLE') result.staleRepos.push(repoFullName);
+    return result;
+  }
+  const { token, installationId, platformIntegrationId } = resolved;
 
   const [repoOwner, repoName] = repoFullName.split('/');
   if (!repoOwner || !repoName) {
@@ -2172,4 +2426,47 @@ async function syncRepo(params: {
     await recordSecurityAgentRepositorySyncSuccess(database, { owner: commandOwner, repoFullName });
   }
   return result;
+}
+
+type ResolvedRepositoryToken = {
+  success: true;
+  token: string;
+  platformIntegrationId: string;
+  installationId: string;
+  appType: GitHubAppType;
+};
+
+async function resolveRepositoryToken(params: {
+  gitTokenService: SecuritySyncGitTokenService;
+  repositoryPlan: RepositorySyncPlan;
+  owner: SecurityReviewOwner;
+  repoFullName: string;
+  resolverUserId: string;
+}): Promise<ResolvedRepositoryToken | Extract<GitTokenForRepoResult, { success: false }>> {
+  const { repositoryPlan } = params;
+  if (
+    repositoryPlan.platformIntegrationId &&
+    repositoryPlan.installationId &&
+    repositoryPlan.appType
+  ) {
+    return {
+      success: true,
+      token: await params.gitTokenService.getToken(
+        repositoryPlan.installationId,
+        repositoryPlan.appType
+      ),
+      platformIntegrationId: repositoryPlan.platformIntegrationId,
+      installationId: repositoryPlan.installationId,
+      appType: repositoryPlan.appType,
+    };
+  }
+
+  if (!params.gitTokenService.getTokenForRepo) {
+    throw new Error('Git Token Service does not support repository resolution');
+  }
+  return params.gitTokenService.getTokenForRepo({
+    githubRepo: params.repoFullName,
+    userId: params.resolverUserId,
+    ...(isOrgOwner(params.owner) ? { orgId: params.owner.organizationId } : {}),
+  });
 }

--- a/services/security-sync/src/sync.ts
+++ b/services/security-sync/src/sync.ts
@@ -220,6 +220,7 @@ const SyncRunProgressSchema = z.object({
   runId: z.string().min(1),
   completedRepos: z.array(z.string().min(1)),
   staleRepos: z.array(z.string()),
+  staleSelections: z.array(z.string()).optional(),
   authInvalidRepos: z.array(z.string()),
   synced: z.number().int().nonnegative(),
   errors: z.number().int().nonnegative(),
@@ -292,12 +293,14 @@ function applySyncRunProgress(result: SyncResult, progress: SyncRunProgress): vo
 function toSyncRunProgress(
   runId: string,
   result: SyncResult,
-  completedRepos: string[]
+  completedRepos: string[],
+  staleSelections: string[]
 ): SyncRunProgress {
   return {
     runId,
     completedRepos,
     staleRepos: result.staleRepos,
+    staleSelections,
     authInvalidRepos: result.authInvalidRepos,
     synced: result.synced,
     errors: result.errors,
@@ -1811,7 +1814,8 @@ async function pruneStaleReposFromConfig(
   db: WorkerDb,
   owner: SecurityReviewOwner,
   staleRepoNames: string[],
-  repoNameToId: Map<string, number>
+  repoNameToId: Map<string, number>,
+  staleSelectionKeys: Set<string>
 ): Promise<void> {
   if (staleRepoNames.length === 0) return;
 
@@ -1853,14 +1857,27 @@ async function pruneStaleReposFromConfig(
   }
 
   const prunedIds = config.selected_repository_ids.filter(id => !staleIds.has(id));
-  if (prunedIds.length === config.selected_repository_ids.length) return;
-
   const prunedSelections = config.selected_repositories?.filter(
-    selection => !staleIds.has(selection.repositoryId)
+    selection =>
+      !staleSelectionKeys.has(`${selection.repositoryId}:${selection.platformIntegrationId}`)
   );
+  const survivingCompositeIds = new Set(
+    prunedSelections?.map(selection => selection.repositoryId) ?? []
+  );
+  const compatibilityIds = prunedSelections
+    ? config.selected_repository_ids.filter(
+        id => !staleIds.has(id) || survivingCompositeIds.has(id)
+      )
+    : prunedIds;
+  if (
+    compatibilityIds.length === config.selected_repository_ids.length &&
+    (!prunedSelections || prunedSelections.length === config.selected_repositories?.length)
+  ) {
+    return;
+  }
   const updatedConfig = {
     ...config,
-    selected_repository_ids: prunedIds,
+    selected_repository_ids: compatibilityIds,
     ...(prunedSelections ? { selected_repositories: prunedSelections } : {}),
   };
   await db
@@ -1868,9 +1885,7 @@ async function pruneStaleReposFromConfig(
     .set({ config: updatedConfig, updated_at: sql`now()` })
     .where(eq(agent_configs.id, rows[0].id));
 
-  console.warn(
-    `Pruned ${config.selected_repository_ids.length - prunedIds.length} stale repo(s) from config`
-  );
+  console.warn('Pruned stale repository selection(s) from config');
 }
 
 /** Remove selected_repository_ids that are no longer present on any owner installation.
@@ -2009,6 +2024,7 @@ export async function syncOwner(params: {
     plan => !completedRepos.has(repositoryPlanKey(plan))
   );
   const totalResult = createEmptySyncResult();
+  const staleSelectionKeys = new Set(previousProgress?.staleSelections ?? []);
   if (previousProgress) {
     applySyncRunProgress(totalResult, previousProgress);
     console.info('Resuming security sync owner run', {
@@ -2066,6 +2082,7 @@ export async function syncOwner(params: {
       totalResult.reauthRequired = totalResult.reauthRequired || repoResult.result.reauthRequired;
       totalResult.staleRepos.push(...repoResult.result.staleRepos);
       totalResult.commandResultCode ??= repoResult.result.commandResultCode;
+      if (repoResult.staleSelectionKey) staleSelectionKeys.add(repoResult.staleSelectionKey);
       successfulRepos++;
       completedRepos.add(planKey);
       processedThisPass++;
@@ -2097,7 +2114,7 @@ export async function syncOwner(params: {
     await writeSyncRunProgress(
       database,
       owner,
-      toSyncRunProgress(runId, totalResult, [...completedRepos])
+      toSyncRunProgress(runId, totalResult, [...completedRepos], [...staleSelectionKeys])
     );
     console.info('Security sync owner budget exhausted; continuation required', {
       runId,
@@ -2118,7 +2135,13 @@ export async function syncOwner(params: {
   // sync do not disagree about owner configuration after GitHub reports permanent loss.
   if (totalResult.staleRepos.length > 0) {
     try {
-      await pruneStaleReposFromConfig(database, owner, totalResult.staleRepos, config.repoNameToId);
+      await pruneStaleReposFromConfig(
+        database,
+        owner,
+        totalResult.staleRepos,
+        config.repoNameToId,
+        staleSelectionKeys
+      );
     } catch (error) {
       console.error('Failed to prune stale repos from config', {
         error: error instanceof Error ? error.message : String(error),
@@ -2260,7 +2283,11 @@ async function syncRepo(params: {
   autoAnalysisEnabledAt: string | null;
   authInvalidIntegrationIds: Set<string>;
   integrationsById: Map<string, IntegrationCandidate>;
-}): Promise<{ result: SyncResult; resolvedIntegrationId?: string }> {
+}): Promise<{
+  result: SyncResult;
+  resolvedIntegrationId?: string;
+  staleSelectionKey?: string;
+}> {
   const {
     db: database,
     gitTokenService,
@@ -2302,7 +2329,16 @@ async function syncRepo(params: {
     });
     result.commandResultCode = failureCode;
     if (resolved.reason === 'repository_not_installed') result.staleRepos.push(repoFullName);
-    return { result };
+    return {
+      result,
+      ...(resolved.reason === 'repository_not_installed' &&
+      repositoryPlan.repositoryId !== undefined &&
+      repositoryPlan.platformIntegrationId
+        ? {
+            staleSelectionKey: `${repositoryPlan.repositoryId}:${repositoryPlan.platformIntegrationId}`,
+          }
+        : {}),
+    };
   }
   const { token, installationId, platformIntegrationId } = resolved;
 
@@ -2357,7 +2393,13 @@ async function syncRepo(params: {
       repoFullName,
       failureCode: 'REPOSITORY_UNAVAILABLE',
     });
-    return { result, resolvedIntegrationId: platformIntegrationId };
+    return {
+      result,
+      resolvedIntegrationId: platformIntegrationId,
+      ...(repositoryPlan.repositoryId !== undefined
+        ? { staleSelectionKey: `${repositoryPlan.repositoryId}:${platformIntegrationId}` }
+        : {}),
+    };
   }
 
   if (fetchResult.status === 'alerts_disabled') {
@@ -2379,7 +2421,13 @@ async function syncRepo(params: {
       repoFullName,
       failureCode: 'REPOSITORY_UNAVAILABLE',
     });
-    return { result, resolvedIntegrationId: platformIntegrationId };
+    return {
+      result,
+      resolvedIntegrationId: platformIntegrationId,
+      ...(repositoryPlan.repositoryId !== undefined
+        ? { staleSelectionKey: `${repositoryPlan.repositoryId}:${platformIntegrationId}` }
+        : {}),
+    };
   }
 
   await clearIntegrationAuthInvalid(database, platformIntegrationId);

--- a/services/security-sync/src/sync.ts
+++ b/services/security-sync/src/sync.ts
@@ -132,6 +132,7 @@ type SecurityAgentConfig = {
   sla_low_days: number;
   repository_selection_mode: 'all' | 'selected';
   selected_repository_ids?: number[];
+  selected_repositories?: Array<{ repositoryId: number; platformIntegrationId: string }>;
   auto_analysis_enabled: boolean;
   auto_analysis_min_severity: AutoAnalysisMinSeverity;
   auto_analysis_include_existing: boolean;
@@ -144,6 +145,14 @@ const securityAgentConfigSchema = z.object({
   sla_low_days: z.number(),
   repository_selection_mode: z.enum(['all', 'selected']),
   selected_repository_ids: z.array(z.number()).optional(),
+  selected_repositories: z
+    .array(
+      z.object({
+        repositoryId: z.number().int().positive(),
+        platformIntegrationId: z.string().uuid(),
+      })
+    )
+    .optional(),
   auto_analysis_enabled: z.boolean(),
   auto_analysis_min_severity: z.enum(['critical', 'high', 'medium', 'all']),
   auto_analysis_include_existing: z.boolean(),
@@ -402,9 +411,8 @@ function findingOwnerPartitionColumn(owner: SecurityReviewOwner) {
 type RepositorySyncPlan = {
   repoFullName: string;
   repositoryId?: number;
+  /** Explicit persisted/request selection; cache membership never authorizes a repository. */
   platformIntegrationId?: string;
-  installationId?: string;
-  appType?: GitHubAppType;
   authInvalidAt: string | null;
 };
 
@@ -422,9 +430,10 @@ type IntegrationCandidate = {
 type EnabledOwnerConfig = {
   repositories: string[];
   repoNameToId: Map<string, number>;
-  repositoryPlanByName: Map<string, RepositorySyncPlan>;
+  repositoryPlans: RepositorySyncPlan[];
   integrationsById: Map<string, IntegrationCandidate>;
   knownRepositoryIds: Set<number>;
+  knownRepositorySelectionKeys: Set<string>;
   resolverUserId: string;
   slaConfig: SecurityAgentConfig;
   notificationPolicy: SecurityNotificationPolicy | null;
@@ -471,17 +480,23 @@ function buildRepositorySyncPlan(
   EnabledOwnerConfig,
   | 'repositories'
   | 'repoNameToId'
-  | 'repositoryPlanByName'
+  | 'repositoryPlans'
   | 'knownRepositoryIds'
+  | 'knownRepositorySelectionKeys'
   | 'missingSelectedRepoCount'
 > {
   const knownRepositoryIds = new Set<number>();
+  const knownRepositorySelectionKeys = new Set<string>();
   const candidatesByName = new Map<string, RepositorySyncPlan[]>();
   const candidatesById = new Map<number, RepositorySyncPlan[]>();
+  const candidatesBySelection = new Map<string, RepositorySyncPlan>();
 
   for (const integration of integrations) {
     const repositories = validIntegrationRepositories(integration);
-    for (const repository of repositories) knownRepositoryIds.add(repository.id);
+    for (const repository of repositories) {
+      knownRepositoryIds.add(repository.id);
+      knownRepositorySelectionKeys.add(`${repository.id}:${integration.id}`);
+    }
     if (
       !integration.platform_installation_id ||
       !hasSecuritySyncPermission(integration) ||
@@ -499,8 +514,6 @@ function buildRepositorySyncPlan(
         repoFullName: repository.full_name,
         repositoryId: repository.id,
         platformIntegrationId: integration.id,
-        installationId: integration.platform_installation_id,
-        appType: integration.appType ?? 'standard',
         authInvalidAt: integration.authInvalidAt,
       };
       candidatesByName.set(normalizedName, [
@@ -508,59 +521,62 @@ function buildRepositorySyncPlan(
         candidate,
       ]);
       candidatesById.set(repository.id, [...(candidatesById.get(repository.id) ?? []), candidate]);
+      candidatesBySelection.set(`${repository.id}:${integration.id}`, candidate);
     }
   }
 
-  const repositoryPlanByName = new Map<string, RepositorySyncPlan>();
+  const repositoryPlans: RepositorySyncPlan[] = [];
   const repoNameToId = new Map<string, number>();
-  const addCandidates = (candidates: RepositorySyncPlan[]) => {
+  const selectedPlanKeys = new Set<string>();
+  const addUnpinnedCandidates = (candidates: RepositorySyncPlan[]) => {
     const candidate = candidates[0];
     if (!candidate || candidate.repositoryId === undefined) return;
     const normalizedName = normalizedRepoName(candidate.repoFullName);
-    if (repositoryPlanByName.has(normalizedName)) return;
+    if (selectedPlanKeys.has(normalizedName)) return;
+    selectedPlanKeys.add(normalizedName);
     repoNameToId.set(candidate.repoFullName, candidate.repositoryId);
-    repositoryPlanByName.set(
-      normalizedName,
-      candidates.length === 1
-        ? candidate
-        : {
-            repoFullName: candidate.repoFullName,
-            repositoryId: candidate.repositoryId,
-            authInvalidAt: null,
-          }
-    );
+    repositoryPlans.push({
+      repoFullName: candidate.repoFullName,
+      repositoryId: candidate.repositoryId,
+      authInvalidAt: null,
+    });
   };
 
-  for (const candidates of candidatesByName.values()) addCandidates(candidates);
-
-  const repositories: string[] = [];
-  const selectedNames = new Set<string>();
   let missingSelectedRepoCount = 0;
   if (securityConfig.repository_selection_mode === 'selected') {
-    for (const selectedId of new Set(securityConfig.selected_repository_ids ?? [])) {
-      const candidates = candidatesById.get(selectedId) ?? [];
-      if (candidates.length === 0) {
-        if (!knownRepositoryIds.has(selectedId)) missingSelectedRepoCount++;
-        continue;
+    if (securityConfig.selected_repositories !== undefined) {
+      for (const selection of securityConfig.selected_repositories) {
+        const selectionKey = `${selection.repositoryId}:${selection.platformIntegrationId}`;
+        if (selectedPlanKeys.has(selectionKey)) continue;
+        selectedPlanKeys.add(selectionKey);
+        const candidate = candidatesBySelection.get(selectionKey);
+        if (!candidate) {
+          if (!knownRepositorySelectionKeys.has(selectionKey)) missingSelectedRepoCount++;
+          continue;
+        }
+        repoNameToId.set(candidate.repoFullName, selection.repositoryId);
+        repositoryPlans.push(candidate);
       }
-      const candidate = candidates[0];
-      if (!candidate) continue;
-      const normalizedName = normalizedRepoName(candidate.repoFullName);
-      const planned = repositoryPlanByName.get(normalizedName);
-      if (planned && !selectedNames.has(normalizedName)) {
-        repositories.push(planned.repoFullName);
-        selectedNames.add(normalizedName);
+    } else {
+      for (const selectedId of new Set(securityConfig.selected_repository_ids ?? [])) {
+        const candidates = candidatesById.get(selectedId) ?? [];
+        if (candidates.length === 0) {
+          if (!knownRepositoryIds.has(selectedId)) missingSelectedRepoCount++;
+          continue;
+        }
+        addUnpinnedCandidates(candidates);
       }
     }
   } else {
-    repositories.push(...[...repositoryPlanByName.values()].map(plan => plan.repoFullName));
+    for (const candidates of candidatesByName.values()) addUnpinnedCandidates(candidates);
   }
 
   return {
-    repositories,
+    repositories: repositoryPlans.map(plan => plan.repoFullName),
     repoNameToId,
-    repositoryPlanByName,
+    repositoryPlans,
     knownRepositoryIds,
+    knownRepositorySelectionKeys,
     missingSelectedRepoCount,
   };
 }
@@ -568,7 +584,7 @@ function buildRepositorySyncPlan(
 function mergeReceivedRepositoryPlans(
   config: Pick<
     EnabledOwnerConfig,
-    'repositories' | 'repositoryPlanByName' | 'repoNameToId' | 'integrationsById'
+    'repositories' | 'repositoryPlans' | 'repoNameToId' | 'integrationsById'
   >,
   plans: RepositoryInstallationPlan[]
 ): void {
@@ -577,8 +593,6 @@ function mergeReceivedRepositoryPlans(
     if (
       !integration ||
       !integration.platform_installation_id ||
-      integration.platform_installation_id !== plan.installationId ||
-      (integration.appType ?? 'standard') !== plan.appType ||
       !hasSecuritySyncPermission(integration) ||
       integration.integrationStatus !== 'active' ||
       integration.suspendedAt !== null
@@ -587,15 +601,17 @@ function mergeReceivedRepositoryPlans(
     }
 
     const normalizedName = normalizedRepoName(plan.repoFullName);
-    config.repositoryPlanByName.set(normalizedName, {
-      ...plan,
+    const receivedPlan: RepositorySyncPlan = {
+      repoFullName: plan.repoFullName,
+      repositoryId: plan.repositoryId,
+      platformIntegrationId: plan.platformIntegrationId,
       authInvalidAt: integration.authInvalidAt,
-    });
-    if (
-      !config.repositories.some(repository => normalizedRepoName(repository) === normalizedName)
-    ) {
-      config.repositories.push(plan.repoFullName);
-    }
+    };
+    config.repositoryPlans = config.repositoryPlans.filter(
+      existing => normalizedRepoName(existing.repoFullName) !== normalizedName
+    );
+    config.repositoryPlans.push(receivedPlan);
+    config.repositories = config.repositoryPlans.map(existing => existing.repoFullName);
     if (plan.repositoryId !== undefined) {
       config.repoNameToId.set(plan.repoFullName, plan.repositoryId);
     }
@@ -1839,7 +1855,14 @@ async function pruneStaleReposFromConfig(
   const prunedIds = config.selected_repository_ids.filter(id => !staleIds.has(id));
   if (prunedIds.length === config.selected_repository_ids.length) return;
 
-  const updatedConfig = { ...config, selected_repository_ids: prunedIds };
+  const prunedSelections = config.selected_repositories?.filter(
+    selection => !staleIds.has(selection.repositoryId)
+  );
+  const updatedConfig = {
+    ...config,
+    selected_repository_ids: prunedIds,
+    ...(prunedSelections ? { selected_repositories: prunedSelections } : {}),
+  };
   await db
     .update(agent_configs)
     .set({ config: updatedConfig, updated_at: sql`now()` })
@@ -1856,7 +1879,8 @@ async function pruneStaleReposFromConfig(
 async function pruneMissingSelectedRepos(
   db: WorkerDb,
   owner: SecurityReviewOwner,
-  accessibleRepoIds: Set<number>
+  accessibleRepoIds: Set<number>,
+  accessibleRepositorySelectionKeys: Set<string>
 ): Promise<void> {
   const rows = await db
     .select({
@@ -1879,19 +1903,32 @@ async function pruneMissingSelectedRepos(
   if (!parsed.success) return;
   const config = parsed.data;
 
+  if (config.repository_selection_mode !== 'selected') {
+    return;
+  }
+
+  const selectedIds = config.selected_repository_ids ?? [];
+  const selectedRepositories = config.selected_repositories ?? [];
+  const prunedIds = selectedIds.filter(id => accessibleRepoIds.has(id));
+  const prunedSelections = selectedRepositories.filter(selection =>
+    accessibleRepositorySelectionKeys.has(
+      `${selection.repositoryId}:${selection.platformIntegrationId}`
+    )
+  );
   if (
-    config.repository_selection_mode !== 'selected' ||
-    !config.selected_repository_ids ||
-    config.selected_repository_ids.length === 0
+    prunedIds.length === selectedIds.length &&
+    prunedSelections.length === selectedRepositories.length
   ) {
     return;
   }
 
-  const prunedIds = config.selected_repository_ids.filter(id => accessibleRepoIds.has(id));
-  if (prunedIds.length === config.selected_repository_ids.length) return;
-
-  const removedCount = config.selected_repository_ids.length - prunedIds.length;
-  const updatedConfig = { ...config, selected_repository_ids: prunedIds };
+  const removedCount =
+    selectedIds.length - prunedIds.length + selectedRepositories.length - prunedSelections.length;
+  const updatedConfig = {
+    ...config,
+    selected_repository_ids: prunedIds,
+    ...(config.selected_repositories ? { selected_repositories: prunedSelections } : {}),
+  };
   await db
     .update(agent_configs)
     .set({ config: updatedConfig, updated_at: sql`now()` })
@@ -1901,14 +1938,30 @@ async function pruneMissingSelectedRepos(
 }
 
 export function selectRepositoriesForSync(
-  config: Pick<EnabledOwnerConfig, 'repositories' | 'repoNameToId'> &
-    Partial<Pick<EnabledOwnerConfig, 'repositoryPlanByName'>>,
+  config: Pick<EnabledOwnerConfig, 'repositories' | 'repoNameToId'>,
   repoFullName?: string
 ): string[] {
   if (!repoFullName) return config.repositories;
-  const plannedRepository = config.repositoryPlanByName?.get(normalizedRepoName(repoFullName));
-  if (plannedRepository) return [plannedRepository.repoFullName];
+  const configuredRepository = config.repositories.find(
+    repository => normalizedRepoName(repository) === normalizedRepoName(repoFullName)
+  );
+  if (configuredRepository) return [configuredRepository];
   return config.repoNameToId.has(repoFullName) ? [repoFullName] : [];
+}
+
+function repositoryPlanKey(plan: RepositorySyncPlan): string {
+  const repoName = normalizedRepoName(plan.repoFullName);
+  return plan.platformIntegrationId ? `${repoName}:${plan.platformIntegrationId}` : repoName;
+}
+
+function selectRepositoryPlansForSync(
+  config: Pick<EnabledOwnerConfig, 'repositoryPlans'>,
+  repoFullName?: string
+): RepositorySyncPlan[] {
+  if (!repoFullName) return config.repositoryPlans;
+  return config.repositoryPlans.filter(
+    plan => normalizedRepoName(plan.repoFullName) === normalizedRepoName(repoFullName)
+  );
 }
 
 export async function syncOwner(params: {
@@ -1939,25 +1992,29 @@ export async function syncOwner(params: {
 
   if (params.repositoryPlans) mergeReceivedRepositoryPlans(config, params.repositoryPlans);
 
-  let repositories = selectRepositoriesForSync(config, repoFullName);
-  if (repoFullName && repositories.length === 0) {
-    config.repositoryPlanByName.set(normalizedRepoName(repoFullName), {
-      repoFullName,
-      authInvalidAt: null,
-    });
-    repositories = [repoFullName];
+  let repositoryPlans = selectRepositoryPlansForSync(config, repoFullName);
+  if (repoFullName && repositoryPlans.length === 0) {
+    repositoryPlans = [
+      {
+        repoFullName,
+        authInvalidAt: null,
+      },
+    ];
   }
+  const repositories = repositoryPlans.map(plan => plan.repoFullName);
 
   const previousProgress = repoFullName ? null : readSyncRunProgress(config.runtimeState, runId);
   const completedRepos = new Set(previousProgress?.completedRepos ?? []);
-  const remainingRepositories = repositories.filter(name => !completedRepos.has(name));
+  const remainingRepositoryPlans = repositoryPlans.filter(
+    plan => !completedRepos.has(repositoryPlanKey(plan))
+  );
   const totalResult = createEmptySyncResult();
   if (previousProgress) {
     applySyncRunProgress(totalResult, previousProgress);
     console.info('Resuming security sync owner run', {
       runId,
       completedRepoCount: completedRepos.size,
-      remainingRepoCount: remainingRepositories.length,
+      remainingRepoCount: remainingRepositoryPlans.length,
     });
   }
   let firstError: Error | null = null;
@@ -1973,7 +2030,9 @@ export async function syncOwner(params: {
     ? await resolveNotificationRecipientUserIds(database, owner)
     : [];
 
-  for (const selectedRepoFullName of remainingRepositories) {
+  for (const repositoryPlan of remainingRepositoryPlans) {
+    const selectedRepoFullName = repositoryPlan.repoFullName;
+    const planKey = repositoryPlanKey(repositoryPlan);
     if (
       processedThisPass > 0 &&
       params.budgetMs !== undefined &&
@@ -1984,31 +2043,6 @@ export async function syncOwner(params: {
     }
 
     try {
-      const repositoryPlan = config.repositoryPlanByName.get(
-        normalizedRepoName(selectedRepoFullName)
-      );
-      if (!repositoryPlan) {
-        throw new Error(`No GitHub integration plan for ${selectedRepoFullName}`);
-      }
-
-      if (
-        (repositoryPlan.platformIntegrationId &&
-          authInvalidIntegrationIds.has(repositoryPlan.platformIntegrationId)) ||
-        isRecentTimestamp(repositoryPlan.authInvalidAt, AUTH_INVALID_SHORT_CIRCUIT_MS)
-      ) {
-        await recordSecurityAgentRepositorySyncFailure(database, {
-          owner: toSecurityAgentCommandOwner(owner),
-          repoFullName: selectedRepoFullName,
-          failureCode: 'GITHUB_AUTH_INVALID',
-        });
-        totalResult.authInvalid++;
-        totalResult.authInvalidRepos.push(selectedRepoFullName);
-        totalResult.reauthRequired = true;
-        completedRepos.add(selectedRepoFullName);
-        processedThisPass++;
-        continue;
-      }
-
       const repoResult = await syncRepo({
         db: database,
         gitTokenService,
@@ -2021,21 +2055,23 @@ export async function syncOwner(params: {
         notificationPolicy,
         notificationRecipientUserIds,
         autoAnalysisEnabledAt: config.autoAnalysisEnabledAt,
+        authInvalidIntegrationIds,
+        integrationsById: config.integrationsById,
       });
-      totalResult.synced += repoResult.synced;
-      totalResult.errors += repoResult.errors;
-      totalResult.skipped += repoResult.skipped;
-      totalResult.authInvalid += repoResult.authInvalid;
-      totalResult.authInvalidRepos.push(...repoResult.authInvalidRepos);
-      totalResult.reauthRequired = totalResult.reauthRequired || repoResult.reauthRequired;
-      totalResult.staleRepos.push(...repoResult.staleRepos);
-      totalResult.commandResultCode ??= repoResult.commandResultCode;
+      totalResult.synced += repoResult.result.synced;
+      totalResult.errors += repoResult.result.errors;
+      totalResult.skipped += repoResult.result.skipped;
+      totalResult.authInvalid += repoResult.result.authInvalid;
+      totalResult.authInvalidRepos.push(...repoResult.result.authInvalidRepos);
+      totalResult.reauthRequired = totalResult.reauthRequired || repoResult.result.reauthRequired;
+      totalResult.staleRepos.push(...repoResult.result.staleRepos);
+      totalResult.commandResultCode ??= repoResult.result.commandResultCode;
       successfulRepos++;
-      completedRepos.add(selectedRepoFullName);
+      completedRepos.add(planKey);
       processedThisPass++;
 
-      if (repoResult.reauthRequired && repositoryPlan.platformIntegrationId) {
-        authInvalidIntegrationIds.add(repositoryPlan.platformIntegrationId);
+      if (repoResult.result.reauthRequired && repoResult.resolvedIntegrationId) {
+        authInvalidIntegrationIds.add(repoResult.resolvedIntegrationId);
       }
     } catch (error) {
       incompleteFailures++;
@@ -2054,7 +2090,9 @@ export async function syncOwner(params: {
     }
   }
 
-  const remainingRepoCount = repositories.filter(name => !completedRepos.has(name)).length;
+  const remainingRepoCount = repositoryPlans.filter(
+    plan => !completedRepos.has(repositoryPlanKey(plan))
+  ).length;
   if (exhaustedBudget && remainingRepoCount > 0) {
     await writeSyncRunProgress(
       database,
@@ -2092,7 +2130,12 @@ export async function syncOwner(params: {
   // inspection already loaded full accessible repositories for both sync scopes.
   if (config.missingSelectedRepoCount > 0) {
     try {
-      await pruneMissingSelectedRepos(database, owner, config.knownRepositoryIds);
+      await pruneMissingSelectedRepos(
+        database,
+        owner,
+        config.knownRepositoryIds,
+        config.knownRepositorySelectionKeys
+      );
     } catch (error) {
       console.error('Failed to prune missing selected repos from config', {
         error: error instanceof Error ? error.message : String(error),
@@ -2215,7 +2258,9 @@ async function syncRepo(params: {
   notificationPolicy: SecurityNotificationPolicy | null;
   notificationRecipientUserIds: string[];
   autoAnalysisEnabledAt: string | null;
-}): Promise<SyncResult> {
+  authInvalidIntegrationIds: Set<string>;
+  integrationsById: Map<string, IntegrationCandidate>;
+}): Promise<{ result: SyncResult; resolvedIntegrationId?: string }> {
   const {
     db: database,
     gitTokenService,
@@ -2256,10 +2301,28 @@ async function syncRepo(params: {
       failureCode,
     });
     result.commandResultCode = failureCode;
-    if (failureCode === 'REPOSITORY_UNAVAILABLE') result.staleRepos.push(repoFullName);
-    return result;
+    if (resolved.reason === 'repository_not_installed') result.staleRepos.push(repoFullName);
+    return { result };
   }
   const { token, installationId, platformIntegrationId } = resolved;
+
+  if (
+    params.authInvalidIntegrationIds.has(platformIntegrationId) ||
+    isRecentTimestamp(
+      params.integrationsById.get(platformIntegrationId)?.authInvalidAt,
+      AUTH_INVALID_SHORT_CIRCUIT_MS
+    )
+  ) {
+    await recordSecurityAgentRepositorySyncFailure(database, {
+      owner: commandOwner,
+      repoFullName,
+      failureCode: 'GITHUB_AUTH_INVALID',
+    });
+    return {
+      result: createAuthInvalidSyncResult([repoFullName]),
+      resolvedIntegrationId: platformIntegrationId,
+    };
+  }
 
   const [repoOwner, repoName] = repoFullName.split('/');
   if (!repoOwner || !repoName) {
@@ -2280,7 +2343,10 @@ async function syncRepo(params: {
       repoFullName,
       failureCode: 'GITHUB_AUTH_INVALID',
     });
-    return createAuthInvalidSyncResult([repoFullName]);
+    return {
+      result: createAuthInvalidSyncResult([repoFullName]),
+      resolvedIntegrationId: platformIntegrationId,
+    };
   }
 
   if (fetchResult.status === 'repo_not_found') {
@@ -2291,7 +2357,7 @@ async function syncRepo(params: {
       repoFullName,
       failureCode: 'REPOSITORY_UNAVAILABLE',
     });
-    return result;
+    return { result, resolvedIntegrationId: platformIntegrationId };
   }
 
   if (fetchResult.status === 'alerts_disabled') {
@@ -2302,7 +2368,7 @@ async function syncRepo(params: {
       repoFullName,
       failureCode: 'DEPENDABOT_ALERTS_DISABLED',
     });
-    return result;
+    return { result, resolvedIntegrationId: platformIntegrationId };
   }
 
   if (fetchResult.status === 'access_blocked') {
@@ -2313,7 +2379,7 @@ async function syncRepo(params: {
       repoFullName,
       failureCode: 'REPOSITORY_UNAVAILABLE',
     });
-    return result;
+    return { result, resolvedIntegrationId: platformIntegrationId };
   }
 
   await clearIntegrationAuthInvalid(database, platformIntegrationId);
@@ -2425,7 +2491,7 @@ async function syncRepo(params: {
   } else {
     await recordSecurityAgentRepositorySyncSuccess(database, { owner: commandOwner, repoFullName });
   }
-  return result;
+  return { result, resolvedIntegrationId: platformIntegrationId };
 }
 
 type ResolvedRepositoryToken = {
@@ -2443,24 +2509,6 @@ async function resolveRepositoryToken(params: {
   repoFullName: string;
   resolverUserId: string;
 }): Promise<ResolvedRepositoryToken | Extract<GitTokenForRepoResult, { success: false }>> {
-  const { repositoryPlan } = params;
-  if (
-    repositoryPlan.platformIntegrationId &&
-    repositoryPlan.installationId &&
-    repositoryPlan.appType
-  ) {
-    return {
-      success: true,
-      token: await params.gitTokenService.getToken(
-        repositoryPlan.installationId,
-        repositoryPlan.appType
-      ),
-      platformIntegrationId: repositoryPlan.platformIntegrationId,
-      installationId: repositoryPlan.installationId,
-      appType: repositoryPlan.appType,
-    };
-  }
-
   if (!params.gitTokenService.getTokenForRepo) {
     throw new Error('Git Token Service does not support repository resolution');
   }
@@ -2468,5 +2516,8 @@ async function resolveRepositoryToken(params: {
     githubRepo: params.repoFullName,
     userId: params.resolverUserId,
     ...(isOrgOwner(params.owner) ? { orgId: params.owner.organizationId } : {}),
+    ...(params.repositoryPlan.platformIntegrationId
+      ? { expectedIntegrationId: params.repositoryPlan.platformIntegrationId }
+      : {}),
   });
 }

--- a/services/security-sync/worker-configuration.d.ts
+++ b/services/security-sync/worker-configuration.d.ts
@@ -24,8 +24,36 @@ declare type Queue<T> = {
 };
 
 declare type GitTokenService = {
+  getTokenForRepo?(params: {
+    githubRepo: string;
+    userId: string;
+    orgId?: string;
+    expectedIntegrationId?: string;
+  }): Promise<GitTokenForRepoResult>;
   getToken(installationId: string, appType?: 'standard' | 'lite'): Promise<string>;
 };
+
+declare type GitTokenForRepoResult =
+  | {
+      success: true;
+      token: string;
+      platformIntegrationId: string;
+      installationId: string;
+      accountLogin: string;
+      appType: 'standard' | 'lite';
+    }
+  | {
+      success: false;
+      reason:
+        | 'database_not_configured'
+        | 'invalid_repo_format'
+        | 'no_installation_found'
+        | 'repository_not_installed'
+        | 'ambiguous_installation'
+        | 'temporarily_unavailable'
+        | 'invalid_org_id'
+        | 'integration_mismatch';
+    };
 
 declare type SecretBinding = {
   get(): Promise<string>;


### PR DESCRIPTION
## Why
Security Sync is a long-running non-Cloud-Agent worker. Cached platform integration repositories are discovery metadata, not authorization to bind a repository to an installation.

## Dependency
Depends on #5584.

## What changes
- Discover sync candidates across every healthy GitHub installation without trusting cached repository membership as authorization.
- Call Git Token Service `getTokenForRepo` for every repository sync.
- Pass only persisted or explicitly received integration identity as `expectedIntegrationId`; cache-derived plans stay unpinned.
- Use the authoritative result token, installation, app type, and integration identity for GitHub API calls, sibling auth isolation, and finding provenance movement.
- Consume additive `selected_repositories` entries (`repositoryId`, `platformIntegrationId`) while preserving legacy `selected_repository_ids`.
- Do not prune selections for lookup/authorization failures; only definitive repository loss remains stale.
- Isolate stale duplicate selections to the exact installation while retaining the shared compatibility repository ID for healthy siblings.

## Security boundary
No Security Sync path mints a cache-derived installation-wide token with raw `getToken`. Cached `platform_integrations.repositories` cannot select an installation on its own.

## Review guide
Review repository-plan construction, then `resolveRepositoryToken`, then auth-invalid sibling partitioning and exact stale-selection pruning.

## Validation
- Security Sync typecheck
- Security Sync lint
- 71 Security Sync tests
- `pnpm format`
- `git diff --check`