### PR TITLE
feat(auto-fix): keep webhook fixes on their delivering GitHub install

### DIFF
--- a/apps/web/src/app/api/internal/auto-fix/pr-callback/route.ts
+++ b/apps/web/src/app/api/internal/auto-fix/pr-callback/route.ts
@@ -30,8 +30,7 @@ import { captureException, captureMessage } from '@sentry/nextjs';
 import { CALLBACK_TOKEN_SECRET } from '@/lib/config.server';
 import { verifyCallbackToken } from '@kilocode/worker-utils/callback-token';
 import { postIssueComment } from '@/lib/auto-fix/github/post-comment';
-import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
+import { getAutoFixTicketGitHubToken } from '@/lib/auto-fix/github/get-fix-config';
 import {
   handleCommentReply,
   sanitizePublicErrorMessage,
@@ -206,23 +205,16 @@ export async function POST(req: NextRequest) {
       // Review-comment-triggered tickets are notified on their original review thread.
       if (!isReviewCommentTrigger) {
         try {
-          if (ticket.platform_integration_id) {
-            const integration = await getIntegrationById(ticket.platform_integration_id);
+          const githubToken = await getAutoFixTicketGitHubToken(ticket);
+          if (githubToken) {
+            await postIssueComment({
+              repoFullName: ticket.repo_full_name,
+              issueNumber: ticket.issue_number,
+              body: `🤖 **Auto-Fix Update**\n\nI attempted to create a pull request to fix this issue, but encountered an error:\n\n\`\`\`\n${sanitizePublicErrorMessage(failureMessage)}\n\`\`\`\n\nThis issue may require manual attention.`,
+              githubToken,
+            });
 
-            if (integration?.platform_installation_id) {
-              const tokenData = await generateGitHubInstallationToken(
-                integration.platform_installation_id
-              );
-
-              await postIssueComment({
-                repoFullName: ticket.repo_full_name,
-                issueNumber: ticket.issue_number,
-                body: `🤖 **Auto-Fix Update**\n\nI attempted to create a pull request to fix this issue, but encountered an error:\n\n\`\`\`\n${sanitizePublicErrorMessage(failureMessage)}\n\`\`\`\n\nThis issue may require manual attention.`,
-                githubToken: tokenData.token,
-              });
-
-              logExceptInTest('[auto-fix-pr-callback] Posted failure comment', { ticketId });
-            }
+            logExceptInTest('[auto-fix-pr-callback] Posted failure comment', { ticketId });
           }
         } catch (commentError) {
           errorExceptInTest('[auto-fix-pr-callback] Failed to post failure comment:', commentError);

--- a/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.test.ts
+++ b/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.test.ts
@@ -16,29 +16,34 @@ import type { PlatformIntegration } from '@kilocode/db/schema';
 import type { PullRequestReviewCommentPayload } from '@/lib/integrations/platforms/github/webhook-schemas';
 
 const mockGetAgentConfigForOwner = jest.fn();
+const mockCreateFixTicket = jest.fn();
 const mockFindExistingReviewCommentFixTicket = jest.fn();
+const mockResetFixTicketForRetry = jest.fn();
+const mockTryDispatchPendingFixes = jest.fn();
+const mockGetBotUserId = jest.fn();
 const mockParseFixCommand = jest.fn();
 const mockAddReactionToPRReviewComment = jest.fn().mockResolvedValue(undefined);
 const mockGetCollaboratorPermissionLevel = jest.fn();
 const mockIsLikelyKiloBotActor = jest.fn();
+const mockGetPrimaryGitHubIntegrationForOrganization = jest.fn();
 
 jest.mock('@/lib/agent-config/db/agent-configs', () => ({
   getAgentConfigForOwner: (...args: unknown[]) => mockGetAgentConfigForOwner(...args),
 }));
 
 jest.mock('../../db/fix-tickets', () => ({
-  createFixTicket: jest.fn(),
+  createFixTicket: (...args: unknown[]) => mockCreateFixTicket(...args),
   findExistingReviewCommentFixTicket: (...args: unknown[]) =>
     mockFindExistingReviewCommentFixTicket(...args),
-  resetFixTicketForRetry: jest.fn(),
+  resetFixTicketForRetry: (...args: unknown[]) => mockResetFixTicketForRetry(...args),
 }));
 
 jest.mock('../../dispatch/dispatch-pending-fixes', () => ({
-  tryDispatchPendingFixes: jest.fn().mockResolvedValue(undefined),
+  tryDispatchPendingFixes: (...args: unknown[]) => mockTryDispatchPendingFixes(...args),
 }));
 
 jest.mock('@/lib/bot-users/bot-user-service', () => ({
-  getBotUserId: jest.fn(),
+  getBotUserId: (...args: unknown[]) => mockGetBotUserId(...args),
 }));
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
@@ -57,6 +62,11 @@ jest.mock('@kilocode/app-shared/code-review', () => ({
 
 jest.mock('@/lib/code-reviews/review-memory/github-feedback', () => ({
   isLikelyKiloBotActor: (...args: unknown[]) => mockIsLikelyKiloBotActor(...args),
+}));
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getPrimaryGitHubIntegrationForOrganization: (...args: unknown[]) =>
+    mockGetPrimaryGitHubIntegrationForOrganization(...args),
 }));
 
 import { ReviewCommentWebhookProcessor } from './review-comment-webhook-processor';
@@ -98,12 +108,32 @@ function buildPayload(body: string): PullRequestReviewCommentPayload {
   };
 }
 
+const integrationId = '123e4567-e89b-12d3-a456-426614174001';
 const integration = {
-  id: 'integration-1',
+  id: integrationId,
   owned_by_user_id: 'user-1',
   owned_by_organization_id: null,
   github_app_type: 'standard',
 } as unknown as PlatformIntegration;
+
+const enabledConfig = {
+  is_enabled: true,
+  config: {
+    enabled_for_issues: true,
+    enabled_for_review_comments: true,
+    repository_selection_mode: 'all',
+    selected_repository_ids: [],
+    skip_labels: [],
+    required_labels: [],
+    model_slug: 'anthropic/claude-sonnet-4.5',
+    custom_instructions: null,
+    pr_title_template: 'Fix #{issue_number}: {issue_title}',
+    pr_body_template: null,
+    pr_base_branch: 'main',
+    max_pr_creation_time_minutes: 15,
+    max_concurrent_per_owner: 3,
+  },
+};
 
 describe('ReviewCommentWebhookProcessor admission', () => {
   let processor: ReviewCommentWebhookProcessor;
@@ -112,6 +142,11 @@ describe('ReviewCommentWebhookProcessor admission', () => {
     jest.clearAllMocks();
     // Default: comments are authored by humans, so admission proceeds.
     mockIsLikelyKiloBotActor.mockReturnValue(false);
+    mockFindExistingReviewCommentFixTicket.mockResolvedValue(null);
+    mockResetFixTicketForRetry.mockResolvedValue(undefined);
+    mockTryDispatchPendingFixes.mockResolvedValue(undefined);
+    mockCreateFixTicket.mockResolvedValue('ticket-1');
+    mockGetPrimaryGitHubIntegrationForOrganization.mockResolvedValue(integration);
     processor = new ReviewCommentWebhookProcessor();
   });
 
@@ -185,5 +220,64 @@ describe('ReviewCommentWebhookProcessor admission', () => {
     expect(mockGetCollaboratorPermissionLevel).not.toHaveBeenCalled();
     expect(mockAddReactionToPRReviewComment).not.toHaveBeenCalled();
     expect(mockGetAgentConfigForOwner).not.toHaveBeenCalled();
+  });
+
+  it('keeps legacy retry GitHub API operations on the delivering installation', async () => {
+    mockParseFixCommand.mockReturnValue(true);
+    mockGetAgentConfigForOwner.mockResolvedValue(enabledConfig);
+    mockFindExistingReviewCommentFixTicket.mockResolvedValue({
+      id: 'ticket-existing',
+      status: 'failed',
+      platform_integration_id: null,
+    });
+
+    await processor.process(buildPayload('@kilo fix'), integration);
+
+    expect(mockResetFixTicketForRetry).toHaveBeenCalledWith('ticket-existing');
+    expect(mockAddReactionToPRReviewComment).toHaveBeenCalledWith(
+      '123',
+      'acme',
+      'widgets',
+      1,
+      'eyes',
+      'standard'
+    );
+  });
+
+  it('does not retry through a sibling installation', async () => {
+    mockParseFixCommand.mockReturnValue(true);
+    mockGetAgentConfigForOwner.mockResolvedValue(enabledConfig);
+    mockFindExistingReviewCommentFixTicket.mockResolvedValue({
+      id: 'ticket-existing',
+      status: 'failed',
+      platform_integration_id: '123e4567-e89b-12d3-a456-426614174002',
+    });
+
+    await processor.process(buildPayload('@kilo fix'), integration);
+
+    expect(mockResetFixTicketForRetry).not.toHaveBeenCalled();
+    expect(mockTryDispatchPendingFixes).not.toHaveBeenCalled();
+  });
+
+  it('does not infer a secondary installation for an unpinned legacy ticket', async () => {
+    const organizationIntegration = {
+      ...integration,
+      owned_by_user_id: null,
+      owned_by_organization_id: 'organization-1',
+    } as PlatformIntegration;
+    mockParseFixCommand.mockReturnValue(true);
+    mockFindExistingReviewCommentFixTicket.mockResolvedValue({
+      id: 'ticket-existing',
+      status: 'failed',
+      platform_integration_id: null,
+    });
+    mockGetPrimaryGitHubIntegrationForOrganization.mockResolvedValue({
+      id: '123e4567-e89b-12d3-a456-426614174003',
+    });
+
+    await processor.process(buildPayload('@kilo fix'), organizationIntegration);
+
+    expect(mockResetFixTicketForRetry).not.toHaveBeenCalled();
+    expect(mockTryDispatchPendingFixes).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.ts
+++ b/apps/web/src/lib/auto-fix/application/webhook/review-comment-webhook-processor.ts
@@ -32,6 +32,7 @@ import type {
 } from '@/lib/integrations/platforms/github/webhook-schemas';
 import { parseFixCommand } from '@kilocode/app-shared/code-review';
 import { isLikelyKiloBotActor } from '@/lib/code-reviews/review-memory/github-feedback';
+import { getPrimaryGitHubIntegrationForOrganization } from '@/lib/integrations/db/platform-integrations';
 
 /**
  * author_association values that imply write access.
@@ -54,6 +55,7 @@ export class ReviewCommentWebhookProcessor {
   ): Promise<void> {
     const { comment, pull_request, repository, installation } = payload;
     const installationId = installation.id.toString();
+    const appType = integration.github_app_type ?? 'standard';
     const [repoOwner, repoName] = repository.full_name.split('/');
 
     if (!repoOwner || !repoName) {
@@ -99,6 +101,27 @@ export class ReviewCommentWebhookProcessor {
       return;
     }
 
+    const existingTicket = await findExistingReviewCommentFixTicket(
+      repository.full_name,
+      comment.id
+    );
+    if (
+      existingTicket?.platform_integration_id &&
+      existingTicket.platform_integration_id !== integration.id
+    ) {
+      return;
+    }
+    if (
+      existingTicket &&
+      !existingTicket.platform_integration_id &&
+      integration.owned_by_organization_id
+    ) {
+      const primary = await getPrimaryGitHubIntegrationForOrganization(
+        integration.owned_by_organization_id
+      );
+      if (primary?.id !== integration.id) return;
+    }
+
     // 2. Check author permissions for write access
     //    author_association from the webhook payload is checked first, but it is
     //    unreliable (e.g. org members may appear as CONTRIBUTOR). When the fast
@@ -108,7 +131,8 @@ export class ReviewCommentWebhookProcessor {
         installationId,
         repoOwner,
         repoName,
-        comment.user.login
+        comment.user.login,
+        appType
       );
 
       if (!permission || !WRITE_PERMISSION_LEVELS.has(permission)) {
@@ -120,7 +144,14 @@ export class ReviewCommentWebhookProcessor {
         });
         // Add thumbs-down reaction to indicate permission denied
         try {
-          await addReactionToPRReviewComment(installationId, repoOwner, repoName, comment.id, '-1');
+          await addReactionToPRReviewComment(
+            installationId,
+            repoOwner,
+            repoName,
+            comment.id,
+            '-1',
+            appType
+          );
         } catch {
           // Best-effort reaction
         }
@@ -203,13 +234,7 @@ export class ReviewCommentWebhookProcessor {
       }
     }
 
-    // 7. Check for existing fix ticket (dedup by comment ID)
-    const existingTicket = await findExistingReviewCommentFixTicket(
-      repository.full_name,
-      comment.id
-    );
-
-    // 8. Resolve dispatch owner (org bot user or personal owner)
+    // 7. Resolve dispatch owner (org bot user or personal owner)
     let dispatchOwner: Owner;
     if (owner.type === 'org') {
       const botUserId = await getBotUserId(owner.id, 'auto-fix');
@@ -224,7 +249,8 @@ export class ReviewCommentWebhookProcessor {
             repoOwner,
             repoName,
             comment.id,
-            'confused'
+            'confused',
+            appType
           );
         } catch {
           // Best-effort reaction
@@ -240,7 +266,7 @@ export class ReviewCommentWebhookProcessor {
       dispatchOwner = owner;
     }
 
-    // 9. Handle existing ticket before creating a new one
+    // 8. Handle existing ticket before creating a new one
     if (existingTicket) {
       if (existingTicket.status === 'pending' || existingTicket.status === 'running') {
         logExceptInTest(
@@ -252,7 +278,14 @@ export class ReviewCommentWebhookProcessor {
           }
         );
         try {
-          await addReactionToPRReviewComment(installationId, repoOwner, repoName, comment.id, '+1');
+          await addReactionToPRReviewComment(
+            installationId,
+            repoOwner,
+            repoName,
+            comment.id,
+            '+1',
+            appType
+          );
         } catch {
           // Best-effort reaction
         }
@@ -274,7 +307,8 @@ export class ReviewCommentWebhookProcessor {
             repoOwner,
             repoName,
             comment.id,
-            'eyes'
+            'eyes',
+            appType
           );
         } catch (reactionError) {
           errorExceptInTest(
@@ -302,7 +336,8 @@ export class ReviewCommentWebhookProcessor {
             repoOwner,
             repoName,
             comment.id,
-            'confused'
+            'confused',
+            appType
           );
         } catch {
           // Best-effort reaction
@@ -312,9 +347,16 @@ export class ReviewCommentWebhookProcessor {
       return;
     }
 
-    // 10. Add eyes reaction to acknowledge the mention
+    // 9. Add eyes reaction to acknowledge the mention
     try {
-      await addReactionToPRReviewComment(installationId, repoOwner, repoName, comment.id, 'eyes');
+      await addReactionToPRReviewComment(
+        installationId,
+        repoOwner,
+        repoName,
+        comment.id,
+        'eyes',
+        appType
+      );
     } catch (reactionError) {
       errorExceptInTest(
         '[ReviewCommentWebhookProcessor] Failed to add eyes reaction:',
@@ -323,7 +365,7 @@ export class ReviewCommentWebhookProcessor {
       // Continue — reaction failure is not critical
     }
 
-    // 11. Create fix ticket with review comment context
+    // 10. Create fix ticket with review comment context
     // Populate issue fields with PR-level data to satisfy NOT NULL constraints
     try {
       const ticketId = await createFixTicket({
@@ -352,7 +394,7 @@ export class ReviewCommentWebhookProcessor {
         commentId: comment.id,
       });
 
-      // 12. Dispatch to Auto Fix worker
+      // 11. Dispatch to Auto Fix worker
       await tryDispatchPendingFixes(dispatchOwner);
     } catch (error) {
       errorExceptInTest('[ReviewCommentWebhookProcessor] Error creating fix ticket:', error);
@@ -372,7 +414,8 @@ export class ReviewCommentWebhookProcessor {
           repoOwner,
           repoName,
           comment.id,
-          'confused'
+          'confused',
+          appType
         );
       } catch {
         // Best-effort reaction

--- a/apps/web/src/lib/auto-fix/core/schemas.ts
+++ b/apps/web/src/lib/auto-fix/core/schemas.ts
@@ -360,6 +360,7 @@ export const DispatchFixRequestSchema = z.object({
   triggerSource: TriggerSourceSchema.optional(),
   sessionInput: z.object({
     repoFullName: z.string(),
+    platformIntegrationId: z.string().uuid().optional(),
     issueNumber: z.number().int().positive(),
     issueTitle: z.string(),
     issueBody: z.string().nullable(),

--- a/apps/web/src/lib/auto-fix/github/get-fix-config.ts
+++ b/apps/web/src/lib/auto-fix/github/get-fix-config.ts
@@ -12,7 +12,10 @@ import { logExceptInTest, errorExceptInTest } from '@/lib/utils.server';
 import { captureException, captureMessage } from '@sentry/nextjs';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
+import {
+  getIntegrationById,
+  getIntegrationForOwner,
+} from '@/lib/integrations/db/platform-integrations';
 import { AutoFixAgentConfigSchema } from '@/lib/auto-fix/core/schemas';
 import type { Owner } from '@/lib/auto-fix/core/schemas';
 
@@ -30,6 +33,35 @@ type GetFixConfigResult =
       };
     }
   | { ok: false; error: string; status: number };
+
+type TicketGitHubIdentity = Pick<
+  AutoFixTicket,
+  'owned_by_organization_id' | 'owned_by_user_id' | 'platform_integration_id'
+>;
+
+export async function getAutoFixTicketGitHubInstallation(ticket: TicketGitHubIdentity) {
+  const integration = ticket.platform_integration_id
+    ? await getIntegrationById(ticket.platform_integration_id)
+    : await getIntegrationForOwner(
+        ticket.owned_by_organization_id
+          ? { type: 'org', id: ticket.owned_by_organization_id }
+          : { type: 'user', id: ticket.owned_by_user_id ?? '' },
+        'github'
+      );
+  if (!integration?.platform_installation_id) return null;
+
+  return {
+    installationId: integration.platform_installation_id,
+    appType: integration.github_app_type ?? 'standard',
+  };
+}
+
+export async function getAutoFixTicketGitHubToken(ticket: TicketGitHubIdentity) {
+  const integration = await getAutoFixTicketGitHubInstallation(ticket);
+  if (!integration) return null;
+  return (await generateGitHubInstallationToken(integration.installationId, integration.appType))
+    .token;
+}
 
 export async function getFixConfig(ticketId: string): Promise<GetFixConfigResult> {
   if (!ticketId) {
@@ -49,13 +81,10 @@ export async function getFixConfig(ticketId: string): Promise<GetFixConfigResult
 
   if (ticket.platform_integration_id) {
     try {
-      const integration = await getIntegrationById(ticket.platform_integration_id);
+      const token = await getAutoFixTicketGitHubToken(ticket);
 
-      if (integration?.platform_installation_id) {
-        const tokenData = await generateGitHubInstallationToken(
-          integration.platform_installation_id
-        );
-        githubToken = tokenData.token;
+      if (token) {
+        githubToken = token;
 
         logExceptInTest('[auto-fix-config] GitHub token obtained', {
           ticketId,

--- a/apps/web/src/lib/auto-fix/github/handle-comment-reply.ts
+++ b/apps/web/src/lib/auto-fix/github/handle-comment-reply.ts
@@ -18,7 +18,7 @@ import {
   addReactionToPRReviewComment,
   getPRHeadCommit,
 } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationById } from '@/lib/integrations/db/platform-integrations';
+import { getAutoFixTicketGitHubInstallation } from './get-fix-config';
 import { z } from 'zod';
 
 export const CommentReplyPayloadSchema = z.object({
@@ -172,19 +172,9 @@ export async function handleCommentReply(
     return { ok: true, action: 'skipped_terminal' };
   }
 
-  // Resolve GitHub installation ID
-  let installationId: string | undefined;
-  if (ticket.platform_integration_id) {
-    try {
-      const integration = await getIntegrationById(ticket.platform_integration_id);
-      installationId = integration?.platform_installation_id ?? undefined;
-    } catch (error) {
-      errorExceptInTest('[auto-fix-comment-reply] Failed to get integration:', error);
-    }
-  }
-
-  if (!installationId) {
-    errorExceptInTest('[auto-fix-comment-reply] No installation ID found', { ticketId });
+  const github = await getAutoFixTicketGitHubInstallation(ticket);
+  if (!github) {
+    errorExceptInTest('[auto-fix-comment-reply] No GitHub installation found', { ticketId });
     return { ok: false, error: 'GitHub installation not found', status: 500 };
   }
 
@@ -199,11 +189,12 @@ export async function handleCommentReply(
       // +1 reaction on the review comment
       try {
         await addReactionToPRReviewComment(
-          installationId,
+          github.installationId,
           repoOwner,
           repoName,
           ticket.review_comment_id,
-          '+1'
+          '+1',
+          github.appType
         );
         logExceptInTest('[auto-fix-comment-reply] Added +1 reaction on review comment', {
           ticketId,
@@ -222,10 +213,11 @@ export async function handleCommentReply(
 
       try {
         const headCommitSha = await getPRHeadCommit(
-          installationId,
+          github.installationId,
           repoOwner,
           repoName,
-          ticket.issue_number
+          ticket.issue_number,
+          github.appType
         );
         const shortSha = headCommitSha.slice(0, 8);
         const commitUrl = `https://github.com/${repoOwner}/${repoName}/commit/${headCommitSha}`;
@@ -239,12 +231,13 @@ export async function handleCommentReply(
 
       try {
         await replyToReviewComment(
-          installationId,
+          github.installationId,
           repoOwner,
           repoName,
           ticket.issue_number,
           ticket.review_comment_id,
-          successReplyBody
+          successReplyBody,
+          github.appType
         );
         logExceptInTest('[auto-fix-comment-reply] Posted success reply on review thread', {
           ticketId,
@@ -295,12 +288,13 @@ export async function handleCommentReply(
     ].join('\n');
 
     await replyToReviewComment(
-      installationId,
+      github.installationId,
       repoOwner,
       repoName,
       ticket.issue_number,
       ticket.review_comment_id,
-      replyBody
+      replyBody,
+      github.appType
     );
 
     logExceptInTest('[auto-fix-comment-reply] Posted failure reply on review thread', {
@@ -312,11 +306,12 @@ export async function handleCommentReply(
     // confused reaction on failure (best effort)
     try {
       await addReactionToPRReviewComment(
-        installationId,
+        github.installationId,
         repoOwner,
         repoName,
         ticket.review_comment_id,
-        'confused'
+        'confused',
+        github.appType
       );
     } catch {
       // Best-effort reaction
@@ -339,11 +334,12 @@ export async function handleCommentReply(
     // Try to add failure reaction
     try {
       await addReactionToPRReviewComment(
-        installationId,
+        github.installationId,
         repoOwner,
         repoName,
         ticket.review_comment_id,
-        'confused'
+        'confused',
+        github.appType
       );
     } catch {
       // Best-effort reaction

--- a/apps/web/src/lib/auto-fix/triggers/prepare-fix-payload.ts
+++ b/apps/web/src/lib/auto-fix/triggers/prepare-fix-payload.ts
@@ -68,6 +68,7 @@ export async function prepareFixPayload(params: PreparePayloadParams): Promise<D
     // 6. Prepare session input
     const sessionInput: DispatchFixRequest['sessionInput'] = {
       repoFullName: ticket.repo_full_name,
+      platformIntegrationId: ticket.platform_integration_id ?? undefined,
       issueNumber: ticket.issue_number,
       issueTitle: ticket.issue_title,
       issueBody: ticket.issue_body,

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -8,6 +8,7 @@ const mockGetIntegrationForOrganization = jest.fn();
 const mockLogWebhookEvent = jest.fn();
 const mockUpdateWebhookEvent = jest.fn();
 const mockHandlePullRequest = jest.fn();
+const mockHandleIssue = jest.fn();
 const mockHandlePRReviewComment = jest.fn();
 const mockHandleGitHubReviewCommentReply = jest.fn();
 const mockHandleInstallationTargetRenamed = jest.fn();
@@ -55,7 +56,8 @@ jest.mock('@/lib/integrations/platforms/github/webhook-handlers', () => ({
     mockHandleInstallationUnsuspend(payload, appType),
   handleInstallationTargetRenamed: (payload: unknown, integrationId: string, appType: string) =>
     mockHandleInstallationTargetRenamed(payload, integrationId, appType),
-  handleIssue: jest.fn(),
+  handleIssue: (payload: unknown, platformIntegration: unknown) =>
+    mockHandleIssue(payload, platformIntegration),
   handlePRReviewComment: (payload: unknown, platformIntegration: unknown) =>
     mockHandlePRReviewComment(payload, platformIntegration),
   handlePullRequest: (payload: unknown, platformIntegration: unknown) =>
@@ -184,6 +186,30 @@ function issueCommentPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function issuePayload(action: string) {
+  return {
+    action,
+    installation: { id: 98765 },
+    repository: {
+      id: 123,
+      name: 'widgets',
+      full_name: 'acme/widgets',
+      private: true,
+      owner: { login: 'acme' },
+    },
+    issue: {
+      number: 7,
+      html_url: 'https://github.com/acme/widgets/issues/7',
+      title: 'Broken widget',
+      body: 'Please fix it',
+      user: { login: 'alice' },
+      labels: [{ name: 'kilo-auto-fix' }],
+    },
+    label: { name: 'kilo-auto-fix' },
+    sender: { login: 'alice' },
+  };
+}
+
 async function waitForAfterTask() {
   await new Promise(resolve => setTimeout(resolve, 0));
 }
@@ -197,6 +223,7 @@ describe('handleGitHubWebhook', () => {
     mockLogWebhookEvent.mockResolvedValue({ id: 'we_1', isDuplicate: false });
     mockUpdateWebhookEvent.mockResolvedValue(undefined);
     mockHandlePullRequest.mockResolvedValue(Response.json({ message: 'review queued' }));
+    mockHandleIssue.mockResolvedValue(Response.json({ message: 'fix queued' }));
     mockHandlePRReviewComment.mockResolvedValue(undefined);
     mockHandleGitHubReviewCommentReply.mockResolvedValue({
       recorded: false,
@@ -354,6 +381,43 @@ describe('handleGitHubWebhook', () => {
     expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
       'we_1',
       expect.objectContaining({ handlers_triggered: ['pr_review_comment_fix'] })
+    );
+  });
+
+  it('admits only Auto Fix event actions from a secondary installation', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
+
+    const reviewResponse = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request_review_comment', reviewCommentPayload()),
+      'standard'
+    );
+    const labeledResponse = await handleGitHubWebhook(
+      signedGitHubRequest('issues', issuePayload('labeled')),
+      'standard'
+    );
+    const openedResponse = await handleGitHubWebhook(
+      signedGitHubRequest('issues', issuePayload('opened')),
+      'standard'
+    );
+    const otherLabelResponse = await handleGitHubWebhook(
+      signedGitHubRequest('issues', {
+        ...issuePayload('labeled'),
+        label: { name: 'needs-triage' },
+      }),
+      'standard'
+    );
+
+    expect(reviewResponse.status).toBe(200);
+    expect(labeledResponse.status).toBe(200);
+    expect(openedResponse.status).toBe(200);
+    expect(otherLabelResponse.status).toBe(200);
+    await waitForAfterTask();
+    expect(mockHandlePRReviewComment).toHaveBeenCalledWith(expect.anything(), integration);
+    expect(mockHandleGitHubReviewCommentReply).not.toHaveBeenCalled();
+    expect(mockHandleIssue).toHaveBeenCalledTimes(1);
+    expect(mockHandleIssue).toHaveBeenCalledWith(
+      expect.objectContaining({ action: 'labeled' }),
+      integration
     );
   });
 

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -466,7 +466,18 @@ export async function handleGitHubWebhook(
       ? await getIntegrationForOrganization(integration.owned_by_organization_id, PLATFORM.GITHUB)
       : integration;
     const isSecondaryOrganizationInstallation = primaryIntegration?.id !== integration.id;
-    if (isSecondaryOrganizationInstallation && eventType !== GITHUB_EVENT.PULL_REQUEST) {
+    const webhookAction = (payload as { action?: string }).action;
+    const isSecondaryAutoFixEvent =
+      (eventType === GITHUB_EVENT.ISSUES &&
+        webhookAction === GITHUB_ACTION.LABELED &&
+        (payload as { label?: { name?: string } }).label?.name === 'kilo-auto-fix') ||
+      (eventType === GITHUB_EVENT.PULL_REQUEST_REVIEW_COMMENT &&
+        webhookAction === GITHUB_ACTION.CREATED);
+    if (
+      isSecondaryOrganizationInstallation &&
+      eventType !== GITHUB_EVENT.PULL_REQUEST &&
+      !isSecondaryAutoFixEvent
+    ) {
       logExceptInTest('Secondary GitHub installation event suppressed', {
         integration_id: integration.id,
         event_type: eventType,
@@ -694,12 +705,14 @@ export async function handleGitHubWebhook(
         try {
           await handlePRReviewComment(parseResult.data, integration);
           try {
-            const reviewMemoryResult = await handleGitHubReviewCommentReply({
-              payload: parseResult.data,
-              integration,
-              deliveryId: eventSignature,
-            });
-            if (reviewMemoryResult.recorded) handlersTriggered.push('review_memory_feedback');
+            if (!isSecondaryOrganizationInstallation) {
+              const reviewMemoryResult = await handleGitHubReviewCommentReply({
+                payload: parseResult.data,
+                integration,
+                deliveryId: eventSignature,
+              });
+              if (reviewMemoryResult.recorded) handlersTriggered.push('review_memory_feedback');
+            }
           } catch (error) {
             logExceptInTest(`Error handling review memory feedback${logSuffix}:`, error);
             captureException(error, {
@@ -772,7 +785,7 @@ export async function handleGitHubWebhook(
           await updateWebhookEvent(logResult.webhookEventId, {
             processed: true,
             processed_at: new Date().toISOString(),
-            handlers_triggered: ['auto_triage'],
+            handlers_triggered: [action === GITHUB_ACTION.LABELED ? 'auto_fix' : 'auto_triage'],
             errors: null,
           });
         } catch (error) {

--- a/apps/web/src/routers/organizations/organization-auto-fix-router.ts
+++ b/apps/web/src/routers/organizations/organization-auto-fix-router.ts
@@ -4,7 +4,7 @@ import {
   organizationMemberMutationProcedure,
   organizationBillingMutationProcedure,
 } from './utils';
-import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
+import { fetchAllGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
 import {
   getAgentConfigForOwner,
   upsertAgentConfigForOwner,
@@ -42,7 +42,7 @@ const ToggleAutoFixAgentInputSchema = z
 
 export const organizationAutoFixRouter = createTRPCRouter({
   listGitHubRepositories: organizationMemberProcedure.query(async ({ input }) => {
-    return await fetchGitHubRepositoriesForOrganization(input.organizationId);
+    return await fetchAllGitHubRepositoriesForOrganization(input.organizationId);
   }),
 
   getAutoFixConfig: organizationMemberProcedure.query(async ({ input, ctx }) => {

--- a/services/auto-fix-infra/src/fix-orchestrator.ts
+++ b/services/auto-fix-infra/src/fix-orchestrator.ts
@@ -139,13 +139,11 @@ export class AutoFixOrchestrator extends DurableObject<Env> {
     }
 
     const configData: {
-      githubToken?: string;
       config: {
         model_slug: string;
         custom_instructions?: string | null;
       };
     } = await configResponse.json();
-    const githubToken = configData.githubToken;
     const config = configData.config;
 
     // Build callback target for Cloud Agent
@@ -212,7 +210,6 @@ export class AutoFixOrchestrator extends DurableObject<Env> {
     await this.createFixWithCloudAgentNext({
       prompt,
       model: config.model_slug,
-      githubToken,
       callbackTarget,
       upstreamBranch: reviewCommentUpstreamBranch,
     });
@@ -221,7 +218,6 @@ export class AutoFixOrchestrator extends DurableObject<Env> {
   private async createFixWithCloudAgentNext(params: {
     prompt: string;
     model: string;
-    githubToken?: string;
     callbackTarget: AutoFixPrCallbackTarget;
     upstreamBranch?: string;
   }): Promise<void> {
@@ -236,11 +232,11 @@ export class AutoFixOrchestrator extends DurableObject<Env> {
 
     const prepareInput = {
       githubRepo: this.state.sessionInput.repoFullName,
+      githubIntegrationId: this.state.sessionInput.platformIntegrationId,
       kilocodeOrganizationId: this.state.owner.type === 'org' ? this.state.owner.id : undefined,
       prompt: params.prompt,
       mode: 'code' as const,
       model: params.model,
-      githubToken: params.githubToken,
       autoCommit: true,
       createdOnPlatform: 'autofix',
       ...(params.upstreamBranch ? { upstreamBranch: params.upstreamBranch } : {}),

--- a/services/auto-fix-infra/src/services/cloud-agent-next-client.ts
+++ b/services/auto-fix-infra/src/services/cloud-agent-next-client.ts
@@ -10,11 +10,11 @@ type CallbackTarget = {
 
 type PrepareSessionInput = {
   githubRepo: string;
+  githubIntegrationId?: string;
   kilocodeOrganizationId?: string;
   prompt: string;
   mode: 'ask' | 'code';
   model: string;
-  githubToken?: string;
   autoCommit?: boolean;
   upstreamBranch?: string;
   createdOnPlatform?: string;

--- a/services/auto-fix-infra/src/types.ts
+++ b/services/auto-fix-infra/src/types.ts
@@ -24,6 +24,7 @@ export type TriggerSource = 'label' | 'review_comment';
 
 export interface SessionInput {
   repoFullName: string;
+  platformIntegrationId?: string;
   issueNumber: number;
   issueTitle: string;
   issueBody: string | null;
@@ -31,7 +32,6 @@ export interface SessionInput {
   confidence?: number;
   intentSummary?: string;
   relatedFiles?: string[];
-  githubToken?: string;
   kilocodeOrganizationId?: string;
   customInstructions?: string | null;
   modelSlug: string;


### PR DESCRIPTION
## Why
Auto Fix webhooks provide authoritative installation identity. New tickets should retain that identity through replies, callbacks, PR creation, and Cloud Agent; legacy unpinned tickets should keep existing primary compatibility rather than trying to infer a secondary.

## Dependency
Depends on #5590 for central Cloud Agent owner/repo resolution on legacy session creation.

## What changes
- Persist the delivering integration on new label/review-comment tickets.
- Use the exact row and app type for direct GitHub operations.
- Pass exact identity to Cloud Agent for pinned tickets.
- Keep unpinned legacy tickets on deterministic primary compatibility and prohibit secondary retries.
- Aggregate organization repositories and narrowly admit Auto Fix secondary events.

## What this removes
No #5547 resolver, no general Git Token Service HTTP bridge, and no new cross-service canonical-ID callback plumbing.

## Review guide
Review ticket provenance and direct GitHub row lookup first, then webhook admission and Cloud Agent input.

## Validation
- 27 focused web tests and focused worker test
- Affected-package typechecks/lint
- Formatting and `git diff --check`