### PR TITLE
feat(gastown): resolve and persist one GitHub install per rig

### DIFF
--- a/services/gastown/container/src/agent-runner.test.ts
+++ b/services/gastown/container/src/agent-runner.test.ts
@@ -39,6 +39,24 @@ function baseRequest(overrides: Partial<StartAgentRequest> = {}): StartAgentRequ
 }
 
 describe('buildAgentEnv', () => {
+  it('prefers a rig-scoped integration token over town-wide GitHub credentials', () => {
+    const originalGitToken = process.env.GIT_TOKEN;
+    const originalCliPat = process.env.GITHUB_CLI_PAT;
+    process.env.GIT_TOKEN = 'other-rig-token';
+    process.env.GITHUB_CLI_PAT = 'town-pat';
+    try {
+      const env = buildAgentEnv(
+        baseRequest({ envVars: { GIT_TOKEN: 'this-rig-token', KILOCODE_TOKEN: 'kilo-token' } })
+      );
+      expect(env.GIT_TOKEN).toBe('this-rig-token');
+      expect(env.GH_TOKEN).toBe('this-rig-token');
+    } finally {
+      if (originalGitToken === undefined) delete process.env.GIT_TOKEN;
+      else process.env.GIT_TOKEN = originalGitToken;
+      if (originalCliPat === undefined) delete process.env.GITHUB_CLI_PAT;
+      else process.env.GITHUB_CLI_PAT = originalCliPat;
+    }
+  });
   it('sets KILO_AUTH_CONTENT with valid JSON auth for the kilo provider when KILOCODE_TOKEN is present', () => {
     const env = buildAgentEnv(
       baseRequest({

--- a/services/gastown/container/src/agent-runner.ts
+++ b/services/gastown/container/src/agent-runner.ts
@@ -198,12 +198,13 @@ GASTOWN_TOWN_ID="${env.GASTOWN_TOWN_ID}"`);
     env.KILO_ORG_ID = request.organizationId;
   }
 
-  // Authenticate the gh CLI via GH_TOKEN. Prefer the user's GitHub CLI PAT
-  // (which makes PRs/issues appear under their identity) over the integration
-  // token (which appears as the GitHub App bot).
-  const ghCliPat = resolveEnv(request, 'GITHUB_CLI_PAT');
+  // A request-scoped integration token must win over town-wide process state.
+  const scopedGitToken = request.envVars?.GIT_TOKEN ?? request.envVars?.GITHUB_TOKEN;
   const ghToken =
-    ghCliPat ?? resolveEnv(request, 'GIT_TOKEN') ?? resolveEnv(request, 'GITHUB_TOKEN');
+    scopedGitToken ??
+    resolveEnv(request, 'GITHUB_CLI_PAT') ??
+    resolveEnv(request, 'GIT_TOKEN') ??
+    resolveEnv(request, 'GITHUB_TOKEN');
   if (ghToken) {
     env.GH_TOKEN = ghToken;
   }
@@ -263,89 +264,6 @@ async function configureGitCredentials(
   } catch (err) {
     console.warn('Failed to configure git credentials:', err);
   }
-}
-
-/**
- * If no GIT_TOKEN/GITLAB_TOKEN is present in envVars but a platformIntegrationId
- * is available, call the Next.js server to resolve fresh credentials.
- * Returns the (potentially enriched) envVars.
- */
-export async function resolveGitCredentials(params: {
-  envVars?: Record<string, string>;
-  platformIntegrationId?: string;
-}): Promise<Record<string, string>> {
-  const envVars = { ...(params.envVars ?? {}) };
-  const hasToken = !!(envVars.GIT_TOKEN || envVars.GITHUB_TOKEN || envVars.GITLAB_TOKEN);
-
-  if (hasToken) return envVars;
-
-  const integrationId = params.platformIntegrationId;
-  const kiloToken = envVars.KILOCODE_TOKEN;
-  // The Next.js server URL — in dev it's localhost:3000, in prod it's the main app URL.
-  // We derive it from KILO_API_URL (the gateway URL) or fall back to localhost.
-  const apiBase = process.env.KILO_CLOUD_URL ?? process.env.NEXTAUTH_URL ?? 'http://localhost:3000';
-
-  if (!integrationId) {
-    console.warn(
-      '[resolveGitCredentialsIfMissing] No git token and no platformIntegrationId — clone will likely fail'
-    );
-    return envVars;
-  }
-
-  if (!kiloToken) {
-    console.warn(
-      '[resolveGitCredentialsIfMissing] No KILOCODE_TOKEN — cannot authenticate to credential API'
-    );
-    return envVars;
-  }
-
-  console.log(
-    `[resolveGitCredentialsIfMissing] Fetching fresh credentials for integration=${integrationId}`
-  );
-
-  try {
-    const resp = await fetch(`${apiBase}/api/gastown/git-credentials`, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${kiloToken}`,
-      },
-      body: JSON.stringify({ platform_integration_id: integrationId }),
-    });
-
-    if (!resp.ok) {
-      const text = await resp.text();
-      console.error(
-        `[resolveGitCredentialsIfMissing] API returned ${resp.status}: ${text.slice(0, 200)}`
-      );
-      return envVars;
-    }
-
-    const rawCreds: unknown = await resp.json();
-    const creds = z
-      .object({
-        github_token: z.string().optional(),
-        gitlab_token: z.string().optional(),
-        gitlab_instance_url: z.string().optional(),
-      })
-      .parse(rawCreds);
-
-    if (creds.github_token) {
-      envVars.GIT_TOKEN = creds.github_token;
-      console.log('[resolveGitCredentialsIfMissing] Got fresh GitHub token');
-    }
-    if (creds.gitlab_token) {
-      envVars.GITLAB_TOKEN = creds.gitlab_token;
-      console.log('[resolveGitCredentialsIfMissing] Got fresh GitLab token');
-    }
-    if (creds.gitlab_instance_url) {
-      envVars.GITLAB_INSTANCE_URL = creds.gitlab_instance_url;
-    }
-  } catch (err) {
-    console.error('[resolveGitCredentialsIfMissing] Failed to fetch credentials:', err);
-  }
-
-  return envVars;
 }
 
 /**
@@ -524,15 +442,9 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
     // up for all known rigs before writing AGENTS.md so the mayor (and its
     // sub-agents) can immediately browse codebases.
     if (request.rigs?.length) {
-      // Resolve credentials per-rig since each may use a different
-      // GitHub App installation (platformIntegrationId).
-      const baseEnvVars = request.envVars ?? {};
       const rigSetupResults = await Promise.allSettled(
         request.rigs.map(async rig => {
-          const envVars = await resolveGitCredentials({
-            envVars: baseEnvVars,
-            platformIntegrationId: rig.platformIntegrationId,
-          });
+          const envVars = { ...(request.envVars ?? {}), ...(rig.envVars ?? {}) };
           const hasGitToken = !!(envVars.GIT_TOKEN || envVars.GITHUB_TOKEN || envVars.GITLAB_TOKEN);
           console.log(
             `[runAgent] setting up browse worktree: rig=${rig.rigId} gitUrl=${rig.gitUrl} hasGitToken=${hasGitToken}`
@@ -580,16 +492,7 @@ export async function runAgent(originalRequest: StartAgentRequest): Promise<Mana
       await writeMayorSystemPromptToAgentsMd(workdir, request.systemPrompt);
     }
   } else {
-    // Resolve git credentials if missing. When the town config doesn't have
-    // a token (common on first dispatch after rig creation), fetch one from
-    // the Next.js server using the platform_integration_id.
-    const envVars = await resolveGitCredentials(request);
-
-    // Merge resolved credentials back into the request so buildAgentEnv
-    // can propagate GIT_TOKEN/GH_TOKEN to the spawned kilo serve process.
-    // Without this, rigs using platformIntegrationId would clone successfully
-    // but the agent session itself would lack git push / gh credentials.
-    request = { ...request, envVars };
+    const envVars = request.envVars ?? {};
 
     await cloneRepo({
       rigId: request.rigId,

--- a/services/gastown/container/src/control-server.test.ts
+++ b/services/gastown/container/src/control-server.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { app } from './control-server';
+
+const originalGitToken = process.env.GIT_TOKEN;
+
+afterEach(() => {
+  if (originalGitToken === undefined) delete process.env.GIT_TOKEN;
+  else process.env.GIT_TOKEN = originalGitToken;
+});
+
+describe('town config git identity', () => {
+  it('clears process-global GitHub credentials for rig-scoped identity', async () => {
+    process.env.GIT_TOKEN = 'other-rig-token';
+
+    const response = await app.request('/sync-config', {
+      method: 'POST',
+      headers: {
+        'X-Town-Config': JSON.stringify({
+          rig_scoped_git_identity: true,
+          git_auth: { github_token: 'town-token' },
+        }),
+      },
+    });
+
+    expect(response.status).toBe(200);
+    expect(process.env.GIT_TOKEN).toBeUndefined();
+  });
+});

--- a/services/gastown/container/src/control-server.ts
+++ b/services/gastown/container/src/control-server.ts
@@ -1,6 +1,6 @@
 import { Hono } from 'hono';
 import { z } from 'zod';
-import { runAgent, resolveGitCredentials, writeMayorSystemPromptToAgentsMd } from './agent-runner';
+import { runAgent, writeMayorSystemPromptToAgentsMd } from './agent-runner';
 import {
   stopAgent,
   sendMessage,
@@ -113,11 +113,16 @@ function syncTownConfigToProcessEnv(): void {
   const gitAuth = cfg.git_auth;
   if (typeof gitAuth === 'object' && gitAuth !== null) {
     const auth = gitAuth as Record<string, unknown>;
-    for (const [authKey, envKey] of [
-      ['github_token', 'GIT_TOKEN'],
+    const authMapping: Array<[string, string]> = [
       ['gitlab_token', 'GITLAB_TOKEN'],
       ['gitlab_instance_url', 'GITLAB_INSTANCE_URL'],
-    ] as const) {
+    ];
+    if (cfg.rig_scoped_git_identity !== true) {
+      authMapping.unshift(['github_token', 'GIT_TOKEN']);
+    } else {
+      delete process.env.GIT_TOKEN;
+    }
+    for (const [authKey, envKey] of authMapping) {
       const val = auth[authKey];
       if (typeof val === 'string' && val) {
         process.env[envKey] = val;
@@ -561,16 +566,11 @@ app.post('/repos/setup', async c => {
   // Errors are caught and logged — never propagated as unhandled rejections.
   const doSetup = async () => {
     try {
-      // Resolve git credentials from platformIntegrationId if no token
-      // is present in envVars (e.g. rigs using GitHub App installations).
-      const envVars = await resolveGitCredentials({
-        envVars: req.envVars,
-        platformIntegrationId: req.platformIntegrationId,
-      });
+      const envVars = req.envVars ?? {};
 
       const hasGitToken = !!(envVars.GIT_TOKEN || envVars.GITHUB_TOKEN || envVars.GITLAB_TOKEN);
       console.log(
-        `[control-server] /repos/setup: cloning rigId=${req.rigId} hasGitToken=${hasGitToken} hasPlatformIntegration=${!!req.platformIntegrationId}`
+        `[control-server] /repos/setup: cloning rigId=${req.rigId} hasGitToken=${hasGitToken}`
       );
 
       const browseDir = await setupRigBrowseWorktree({

--- a/services/gastown/container/src/git-manager.test.ts
+++ b/services/gastown/container/src/git-manager.test.ts
@@ -1,0 +1,25 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { refreshGitToken } from './git-manager';
+
+const originalEnv = { ...process.env };
+
+afterEach(() => {
+  process.env = { ...originalEnv };
+  vi.unstubAllGlobals();
+});
+
+describe('refreshGitToken', () => {
+  it('refreshes one rig without replacing another rig token in process.env', async () => {
+    process.env.GASTOWN_API_URL = 'https://gastown.example.com';
+    process.env.GASTOWN_TOWN_ID = 'town-1';
+    process.env.GASTOWN_CONTAINER_TOKEN = 'container-token';
+    process.env.GIT_TOKEN = 'other-rig-token';
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue(Response.json({ success: true, data: { token: 'rig-one-token' } }))
+    );
+
+    await expect(refreshGitToken('rig-one')).resolves.toBe('rig-one-token');
+    expect(process.env.GIT_TOKEN).toBe('other-rig-token');
+  });
+});

--- a/services/gastown/container/src/git-manager.ts
+++ b/services/gastown/container/src/git-manager.ts
@@ -199,8 +199,7 @@ async function assertInsideWorkspace(targetPath: string): Promise<void> {
 
 /**
  * Call the worker's refresh-git-token endpoint to obtain a fresh GitHub
- * App installation token. Updates process.env.GIT_TOKEN and rewrites
- * per-repo credential-store files so subsequent git operations (including
+ * App installation token. Rewrites per-repo credential-store files so subsequent git operations (including
  * the agent's own `git push`) pick up the new token.
  *
  * Returns the new token on success, or null if the refresh failed (no
@@ -246,10 +245,6 @@ export async function refreshGitToken(rigId: string): Promise<string | null> {
       return null;
     }
     const freshToken = (raw.data as { token: string }).token;
-
-    // Update process.env so subsequent exec() calls (which inherit
-    // process.env) see the new token via authenticateGitUrl.
-    process.env.GIT_TOKEN = freshToken;
 
     // Rewrite the per-rig /tmp/.git-credentials* files that currently
     // store a token. The credential helper reads these verbatim, so the

--- a/services/gastown/container/src/process-manager.test.ts
+++ b/services/gastown/container/src/process-manager.test.ts
@@ -14,7 +14,6 @@ vi.mock('./agent-runner', () => ({
     (kilocodeToken: string, model: string, smallModel: string, organizationId?: string) =>
       JSON.stringify({ kilocodeToken, model, smallModel, organizationId })
   ),
-  resolveGitCredentials: vi.fn(),
   writeMayorSystemPromptToAgentsMd: vi.fn(),
   ensureMayorWorkspaceForTown: vi.fn(async (_townId: string) => TEST_WORKSPACE),
   mayorWorkdirForTown: vi.fn((_townId: string) => TEST_WORKSPACE),

--- a/services/gastown/container/src/process-manager.ts
+++ b/services/gastown/container/src/process-manager.ts
@@ -1571,7 +1571,6 @@ const MAYOR_STARTUP_PROMPT = 'Mayor ready. Waiting for instructions.';
  */
 const LIVE_ENV_KEYS = new Set([
   'GASTOWN_CONTAINER_TOKEN',
-  'GIT_TOKEN',
   'GITLAB_TOKEN',
   'GITLAB_INSTANCE_URL',
   'GITHUB_CLI_PAT',
@@ -1607,8 +1606,8 @@ const LIVE_ENV_KEYS = new Set([
  *   `LIVE_ENV_KEYS` and `RESERVED_ENV_KEYS` always win.
  * - Remove custom keys that were previously applied but have been
  *   dropped from the town config.
- * - Re-derive `GH_TOKEN` from the live `GITHUB_CLI_PAT` > `GIT_TOKEN`
- *   > `GITHUB_TOKEN` chain so a rotated token takes effect.
+ * - Re-derive `GH_TOKEN` from the agent's scoped integration token before
+ *   considering the town-wide GitHub CLI PAT.
  */
 function buildLiveHotSwapEnv(agent: ManagedAgent): Record<string, string> {
   const env: Record<string, string> = {};
@@ -1654,10 +1653,8 @@ function buildLiveHotSwapEnv(agent: ManagedAgent): Record<string, string> {
     }
   }
 
-  // Re-derive GH_TOKEN from live values using the same priority chain
-  // as buildAgentEnv: GITHUB_CLI_PAT > GIT_TOKEN > GITHUB_TOKEN.
-  const liveGhToken =
-    process.env.GITHUB_CLI_PAT ?? process.env.GIT_TOKEN ?? process.env.GITHUB_TOKEN;
+  // Keep integration credentials scoped to the agent that was dispatched.
+  const liveGhToken = env.GIT_TOKEN ?? env.GITHUB_TOKEN ?? env.GITHUB_CLI_PAT;
   if (liveGhToken) {
     env.GH_TOKEN = liveGhToken;
   } else {

--- a/services/gastown/container/src/types.ts
+++ b/services/gastown/container/src/types.ts
@@ -23,8 +23,6 @@ export const StartAgentRequest = z.object({
   branch: z.string(),
   defaultBranch: z.string(),
   envVars: z.record(z.string(), z.string()).optional(),
-  /** Platform integration ID for resolving fresh git credentials at startup */
-  platformIntegrationId: z.string().optional(),
   /** Git ref to branch from (e.g. convoy feature branch). Falls back to HEAD if absent. */
   startPoint: z.string().optional(),
   /** Skip repo clone — use a lightweight git-init-only workspace (for reasoning-only agents like triage). */
@@ -38,7 +36,7 @@ export const StartAgentRequest = z.object({
         rigId: z.string(),
         gitUrl: z.string(),
         defaultBranch: z.string(),
-        platformIntegrationId: z.string().optional(),
+        envVars: z.record(z.string(), z.string()).optional(),
       })
     )
     .optional(),
@@ -327,8 +325,6 @@ export const SetupRepoRequest = z.object({
   gitUrl: z.string().min(1),
   defaultBranch: z.string().min(1),
   envVars: z.record(z.string(), z.string()).optional(),
-  /** Platform integration ID for resolving git credentials when no token is in envVars */
-  platformIntegrationId: z.string().optional(),
 });
 export type SetupRepoRequest = z.infer<typeof SetupRepoRequest>;
 

--- a/services/gastown/scripts/patch-worker-types.mjs
+++ b/services/gastown/scripts/patch-worker-types.mjs
@@ -43,17 +43,18 @@ const RPC_TYPES = `\
 type GetTokenForRepoSuccess = {
 \tsuccess: true;
 \ttoken: string;
+\tplatformIntegrationId: string;
 \tinstallationId: string;
 \taccountLogin: string;
 \tappType: 'standard' | 'lite';
 };
 type GetTokenForRepoFailure = {
 \tsuccess: false;
-\treason: 'database_not_configured' | 'invalid_repo_format' | 'no_installation_found' | 'invalid_org_id';
+\treason: 'database_not_configured' | 'invalid_repo_format' | 'no_installation_found' | 'repository_not_installed' | 'ambiguous_installation' | 'temporarily_unavailable' | 'integration_mismatch' | 'invalid_org_id';
 };
 type GetTokenForRepoResult = GetTokenForRepoSuccess | GetTokenForRepoFailure;
 type GitTokenService = {
-\tgetTokenForRepo(params: { githubRepo: string; userId: string; orgId?: string }): Promise<GetTokenForRepoResult>;
+\tgetTokenForRepo(params: { githubRepo: string; userId: string; orgId?: string; expectedIntegrationId?: string }): Promise<GetTokenForRepoResult>;
 \tgetToken(installationId: string, appType?: 'standard' | 'lite'): Promise<string>;
 };
 type WastelandRpcSuccess<T> = { success: true; data: T };

--- a/services/gastown/src/db/tables/user-rigs.table.test.ts
+++ b/services/gastown/src/db/tables/user-rigs.table.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { createTableUserRigs, migrateUserRigs } from './user-rigs.table';
+
+function fakeSql(columns: string[]) {
+  const statements: string[] = [];
+  const sql = {
+    exec(query: string) {
+      statements.push(query);
+      if (query.startsWith('PRAGMA')) return columns.map(name => ({ name }));
+      if (query.startsWith('ALTER TABLE')) columns.push('platform_integration_id');
+      return [];
+    },
+  } as unknown as SqlStorage;
+  return { sql, statements };
+}
+
+describe('user_rigs platform integration migration', () => {
+  it('adds the identity column to legacy owner storage and is idempotent', () => {
+    const { sql, statements } = fakeSql([
+      'id',
+      'town_id',
+      'name',
+      'git_url',
+      'default_branch',
+      'created_at',
+      'updated_at',
+    ]);
+
+    migrateUserRigs(sql);
+    migrateUserRigs(sql);
+
+    expect(statements.filter(statement => statement.startsWith('ALTER TABLE'))).toHaveLength(1);
+  });
+
+  it('declares platform_integration_id for newly created owner storage', () => {
+    expect(createTableUserRigs()).toContain('"platform_integration_id" text');
+  });
+});

--- a/services/gastown/src/db/tables/user-rigs.table.ts
+++ b/services/gastown/src/db/tables/user-rigs.table.ts
@@ -30,3 +30,14 @@ export function createTableUserRigs(): string {
     updated_at: `text not null`,
   });
 }
+
+export function migrateUserRigs(sql: SqlStorage): void {
+  const columns = z
+    .object({ name: z.string() })
+    .array()
+    .parse([...sql.exec(/* sql */ `PRAGMA table_info(${user_rigs})`)]);
+  if (columns.some(column => column.name === user_rigs.columns.platform_integration_id)) return;
+  sql.exec(
+    /* sql */ `ALTER TABLE ${user_rigs} ADD COLUMN ${user_rigs.columns.platform_integration_id} text`
+  );
+}

--- a/services/gastown/src/dos/GastownOrg.do.ts
+++ b/services/gastown/src/dos/GastownOrg.do.ts
@@ -1,6 +1,11 @@
 import { DurableObject } from 'cloudflare:workers';
 import { createTableOrgTowns, org_towns, OrgTownRecord } from '../db/tables/org-towns.table';
-import { createTableUserRigs, user_rigs, UserRigRecord } from '../db/tables/user-rigs.table';
+import {
+  createTableUserRigs,
+  migrateUserRigs,
+  user_rigs,
+  UserRigRecord,
+} from '../db/tables/user-rigs.table';
 import { query } from '../util/query.util';
 import { getTownDOStub } from './Town.do';
 
@@ -50,6 +55,7 @@ export class GastownOrgDO extends DurableObject<Env> {
   private async initializeDatabase(): Promise<void> {
     query(this.sql, createTableOrgTowns(), []);
     query(this.sql, createTableUserRigs(), []);
+    migrateUserRigs(this.sql);
     // Arm the watchdog on every initialization so existing orgs (who
     // created towns before the watchdog was added) get health checks.
     await this.armWatchdogIfNeeded();

--- a/services/gastown/src/dos/GastownUser.do.ts
+++ b/services/gastown/src/dos/GastownUser.do.ts
@@ -1,6 +1,11 @@
 import { DurableObject } from 'cloudflare:workers';
 import { createTableUserTowns, user_towns, UserTownRecord } from '../db/tables/user-towns.table';
-import { createTableUserRigs, user_rigs, UserRigRecord } from '../db/tables/user-rigs.table';
+import {
+  createTableUserRigs,
+  migrateUserRigs,
+  user_rigs,
+  UserRigRecord,
+} from '../db/tables/user-rigs.table';
 import { query } from '../util/query.util';
 import { getTownDOStub } from './Town.do';
 
@@ -53,6 +58,7 @@ export class GastownUserDO extends DurableObject<Env> {
   private async initializeDatabase(): Promise<void> {
     query(this.sql, createTableUserTowns(), []);
     query(this.sql, createTableUserRigs(), []);
+    migrateUserRigs(this.sql);
     // Arm the watchdog on every initialization so existing users (who
     // created towns before the watchdog was added) get health checks.
     await this.armWatchdogIfNeeded();

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -160,6 +160,10 @@ function now(): string {
   return new Date().toISOString();
 }
 
+function extractGithubRepo(gitUrl: string): string | null {
+  return gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1] ?? null;
+}
+
 // ── Rig config stored per-rig in KV (mirrors what was in Rig DO) ────
 type RigConfig = {
   townId: string;
@@ -169,9 +173,32 @@ type RigConfig = {
   userId: string;
   kilocodeToken?: string;
   platformIntegrationId?: string;
+  platform_integration_id?: string;
   /** Per-rig merge strategy override. When unset, inherits from town config. */
   merge_strategy?: MergeStrategy;
 };
+
+const RigConfigSchema = z.object({
+  townId: z.string(),
+  rigId: z.string(),
+  gitUrl: z.string(),
+  defaultBranch: z.string(),
+  userId: z.string(),
+  kilocodeToken: z.string().optional(),
+  platformIntegrationId: z.string().optional(),
+  platform_integration_id: z.string().optional(),
+  merge_strategy: z.enum(['direct', 'pr']).optional(),
+});
+
+function normalizeRigConfig(value: unknown): RigConfig | null {
+  const parsed = RigConfigSchema.safeParse(value);
+  if (!parsed.success) return null;
+  const { platform_integration_id, ...config } = parsed.data;
+  return {
+    ...config,
+    platformIntegrationId: config.platformIntegrationId ?? platform_integration_id,
+  };
+}
 
 // ── Escalation API type (derived from EscalationBeadRecord) ─────────
 type EscalationEntry = {
@@ -387,23 +414,14 @@ export class TownDO extends DurableObject<Env> {
       stopAgent: async agentId => {
         await dispatch.stopAgentInContainer(this.env, this.townId, agentId);
       },
-      checkPRStatus: async prUrl => {
-        return scm.checkPRStatus(
-          { env: this.env, townId: this.townId, getTownConfig: () => this.getTownConfig() },
-          prUrl
-        );
+      checkPRStatus: async (prUrl, rigId) => {
+        return scm.checkPRStatus(await this.getRigSCMContext(rigId), prUrl);
       },
-      checkPRFeedback: async prUrl => {
-        return scm.checkPRFeedback(
-          { env: this.env, townId: this.townId, getTownConfig: () => this.getTownConfig() },
-          prUrl
-        );
+      checkPRFeedback: async (prUrl, rigId) => {
+        return scm.checkPRFeedback(await this.getRigSCMContext(rigId), prUrl);
       },
-      mergePR: async prUrl => {
-        return scm.mergePR(
-          { env: this.env, townId: this.townId, getTownConfig: () => this.getTownConfig() },
-          prUrl
-        );
+      mergePR: async (prUrl, rigId) => {
+        return scm.mergePR(await this.getRigSCMContext(rigId), prUrl);
       },
       getTownConfig: async () => {
         return this.getTownConfig();
@@ -1135,22 +1153,9 @@ export class TownDO extends DurableObject<Env> {
     const townConfig = await this.getTownConfig();
     const container = getTownContainerStub(this.env, townId);
 
-    // Resolve a fresh GitHub token here too — this method runs both at
-    // initial config push and on every config change, so the persisted
-    // GIT_TOKEN must be live rather than the stale value stored in
-    // git_auth.github_token from rig creation. The container's
-    // syncTownConfigToProcessEnv path reads `git_auth.github_token`
-    // from the X-Town-Config header on every request, so the in-process
-    // GIT_TOKEN follows the same source-of-truth as the persisted one.
-    const githubToken = await scm.resolveGitHubTokenString({
-      env: this.env,
-      townId,
-      getTownConfig: () => Promise.resolve(townConfig),
-    });
-
     // Phase 1: Persist to DO storage for next boot.
     const envMapping: Array<[string, string | undefined]> = [
-      ['GIT_TOKEN', githubToken ?? undefined],
+      ['GIT_TOKEN', undefined],
       ['GITLAB_TOKEN', townConfig.git_auth?.gitlab_token],
       ['GITLAB_INSTANCE_URL', townConfig.git_auth?.gitlab_instance_url],
       ['GITHUB_CLI_PAT', townConfig.github_cli_pat],
@@ -1223,11 +1228,7 @@ export class TownDO extends DurableObject<Env> {
     // /sync-config endpoint. The X-Town-Config header delivers the
     // full config; the endpoint applies CONFIG_ENV_MAP to process.env.
     try {
-      const containerConfig = await config.buildContainerConfig(
-        this.ctx.storage,
-        this.env,
-        this.townId
-      );
+      const containerConfig = await config.buildContainerConfig(this.ctx.storage, this.env);
       await container.fetch('http://container/sync-config', {
         method: 'POST',
         headers: {
@@ -1317,6 +1318,9 @@ export class TownDO extends DurableObject<Env> {
   }
 
   private async _configureRig(rigConfig: RigConfig): Promise<void> {
+    const normalizedRigConfig = normalizeRigConfig(rigConfig);
+    if (!normalizedRigConfig) throw new Error('Invalid rig config');
+    rigConfig = normalizedRigConfig;
     logger.setTags({ rigId: rigConfig.rigId, userId: rigConfig.userId });
     logger.info('configureRig: start', { hasKilocodeToken: !!rigConfig.kilocodeToken });
     await this.ctx.storage.put(`rig:${rigConfig.rigId}:config`, rigConfig);
@@ -1380,6 +1384,9 @@ export class TownDO extends DurableObject<Env> {
       env: this.env,
       townId: this.townId,
       getTownConfig: () => Promise.resolve(townConfig),
+      githubRepo: extractGithubRepo(rigConfig.gitUrl) ?? undefined,
+      userId: townConfig.owner_user_id ?? rigConfig.userId,
+      orgId: townConfig.organization_id,
       platformIntegrationId: rigConfig.platformIntegrationId,
     });
     if (githubToken) {
@@ -1391,18 +1398,12 @@ export class TownDO extends DurableObject<Env> {
     if (townConfig.git_auth?.gitlab_instance_url) {
       envVars.GITLAB_INSTANCE_URL = townConfig.git_auth.gitlab_instance_url;
     }
-    // resolveGitCredentials in the container needs KILOCODE_TOKEN to
-    // authenticate against the credential API for platform integrations.
     const kilocodeToken = rigConfig.kilocodeToken ?? townConfig.kilocode_token;
     if (kilocodeToken) {
       envVars.KILOCODE_TOKEN = kilocodeToken;
     }
 
-    const containerConfig = await config.buildContainerConfig(
-      this.ctx.storage,
-      this.env,
-      this.townId
-    );
+    const containerConfig = await config.buildContainerConfig(this.ctx.storage, this.env);
     const container = getTownContainerStub(this.env, this.townId);
     const response = await container.fetch('http://container/repos/setup', {
       method: 'POST',
@@ -1415,7 +1416,6 @@ export class TownDO extends DurableObject<Env> {
         gitUrl: rigConfig.gitUrl,
         defaultBranch: rigConfig.defaultBranch,
         envVars: Object.keys(envVars).length > 0 ? envVars : undefined,
-        platformIntegrationId: rigConfig.platformIntegrationId,
       }),
     });
 
@@ -1431,7 +1431,22 @@ export class TownDO extends DurableObject<Env> {
   }
 
   async getRigConfig(rigId: string): Promise<RigConfig | null> {
-    return (await this.ctx.storage.get<RigConfig>(`rig:${rigId}:config`)) ?? null;
+    return normalizeRigConfig(await this.ctx.storage.get(`rig:${rigId}:config`));
+  }
+
+  private async getRigSCMContext(rigId: string): Promise<scm.SCMContext> {
+    const rig = rigs.getRig(this.sql, rigId);
+    const rigConfig = await this.getRigConfig(rigId);
+    const townConfig = await this.getTownConfig();
+    return {
+      env: this.env,
+      townId: this.townId,
+      getTownConfig: () => Promise.resolve(townConfig),
+      githubRepo: rig ? (extractGithubRepo(rig.git_url) ?? undefined) : undefined,
+      userId: townConfig.owner_user_id ?? rigConfig?.userId,
+      orgId: townConfig.organization_id,
+      platformIntegrationId: rigConfig?.platformIntegrationId,
+    };
   }
 
   // ══════════════════════════════════════════════════════════════════
@@ -2888,18 +2903,28 @@ export class TownDO extends DurableObject<Env> {
       rigId: string;
       gitUrl: string;
       defaultBranch: string;
-      platformIntegrationId?: string;
+      envVars?: Record<string, string>;
     }>
   > {
     const rigRecords = rigs.listRigs(this.sql);
     return Promise.all(
       rigRecords.map(async r => {
         const rc = await this.getRigConfig(r.id);
+        const townConfig = await this.getTownConfig();
+        const githubToken = await scm.resolveGitHubTokenString({
+          env: this.env,
+          townId: this.townId,
+          getTownConfig: () => Promise.resolve(townConfig),
+          githubRepo: extractGithubRepo(r.git_url) ?? undefined,
+          userId: townConfig.owner_user_id ?? rc?.userId,
+          orgId: townConfig.organization_id,
+          platformIntegrationId: rc?.platformIntegrationId,
+        });
         return {
           rigId: r.id,
           gitUrl: r.git_url,
           defaultBranch: r.default_branch,
-          platformIntegrationId: rc?.platformIntegrationId,
+          envVars: githubToken ? { GIT_TOKEN: githubToken } : undefined,
         };
       })
     );
@@ -3106,18 +3131,6 @@ export class TownDO extends DurableObject<Env> {
 
     const townConfig = await this.getTownConfig();
 
-    // Resolve the GitHub token using the same chain as startAgentInContainer
-    // so the prewarmed mayor SDK boots with `gh` CLI auth (`GH_TOKEN`)
-    // already populated. Without this, the mayor's bash tool sees an
-    // empty environment for git/gh until the SDK is torn down and the
-    // /agents/start path's buildAgentEnv runs — which never happens
-    // while ensureMayor short-circuits on a warm session.
-    const githubToken = await scm.resolveGitHubTokenString({
-      env: this.env,
-      townId: this.townId,
-      getTownConfig: () => Promise.resolve(townConfig),
-    });
-
     // _ensureMayor dispatches the mayor without a per-rig override
     // (Town.do.ts:2766-2790). Match that resolution here so the prewarm
     // KILO_CONFIG_CONTENT is byte-identical to what /agents/start will
@@ -3128,7 +3141,6 @@ export class TownDO extends DurableObject<Env> {
       smallModel: config.resolveSmallModel(townConfig),
       kilocodeToken,
       organizationId: townConfig.organization_id ?? null,
-      ...(githubToken ? { githubToken } : {}),
       ...(townConfig.github_cli_pat ? { githubCliPat: townConfig.github_cli_pat } : {}),
     };
   }
@@ -3294,11 +3306,7 @@ export class TownDO extends DurableObject<Env> {
     if (isAlive) {
       // Attach fresh town config so the container can update process.env
       // before restarting the SDK server (tokens, git identity, etc.).
-      const containerConfig = await config.buildContainerConfig(
-        this.ctx.storage,
-        this.env,
-        this.townId
-      );
+      const containerConfig = await config.buildContainerConfig(this.ctx.storage, this.env);
 
       // Resolve townConfig to thread the organization_id into the request body
       // (belt-and-suspenders: ensures org billing survives even if X-Town-Config
@@ -3805,12 +3813,16 @@ export class TownDO extends DurableObject<Env> {
     const rig = rigs.getRig(this.sql, input.rigId);
     if (rig) {
       const rigConfig = await this.getRigConfig(input.rigId);
+      const townConfig = await this.getTownConfig();
       await scm
         .createConvoyBranch(
           {
             env: this.env,
             townId: this.townId,
-            getTownConfig: () => this.getTownConfig(),
+            getTownConfig: () => Promise.resolve(townConfig),
+            githubRepo: extractGithubRepo(rig.git_url) ?? undefined,
+            userId: townConfig.owner_user_id ?? rigConfig?.userId,
+            orgId: townConfig.organization_id,
             platformIntegrationId: rigConfig?.platformIntegrationId,
           },
           {
@@ -5254,11 +5266,7 @@ export class TownDO extends DurableObject<Env> {
       // This ensures org context and credentials are available immediately
       // after a container restart when the first request is a model update
       // (PATCH /model) rather than a new agent start.
-      const containerConfig = await config.buildContainerConfig(
-        this.ctx.storage,
-        this.env,
-        this.townId
-      );
+      const containerConfig = await config.buildContainerConfig(this.ctx.storage, this.env);
       const headers: Record<string, string> = {
         'X-Town-Config': JSON.stringify(containerConfig),
       };

--- a/services/gastown/src/dos/Town.do.ts
+++ b/services/gastown/src/dos/Town.do.ts
@@ -71,6 +71,7 @@ import { kiloTokenPayload } from '@kilocode/worker-utils';
 import { jwtVerify } from 'jose';
 import { generateKiloApiToken } from '../util/kilo-token.util';
 import { resolveSecret } from '../util/secret.util';
+import { extractGitHubRepo } from '../util/repository-integration.util';
 import { writeEvent, type GastownEventData } from '../util/analytics.util';
 import { logger, withLogTags } from '../util/log.util';
 import {
@@ -158,10 +159,6 @@ function generateId(): string {
 
 function now(): string {
   return new Date().toISOString();
-}
-
-function extractGithubRepo(gitUrl: string): string | null {
-  return gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1] ?? null;
 }
 
 // ── Rig config stored per-rig in KV (mirrors what was in Rig DO) ────
@@ -1384,7 +1381,7 @@ export class TownDO extends DurableObject<Env> {
       env: this.env,
       townId: this.townId,
       getTownConfig: () => Promise.resolve(townConfig),
-      githubRepo: extractGithubRepo(rigConfig.gitUrl) ?? undefined,
+      githubRepo: extractGitHubRepo(rigConfig.gitUrl),
       userId: townConfig.owner_user_id ?? rigConfig.userId,
       orgId: townConfig.organization_id,
       platformIntegrationId: rigConfig.platformIntegrationId,
@@ -1442,7 +1439,7 @@ export class TownDO extends DurableObject<Env> {
       env: this.env,
       townId: this.townId,
       getTownConfig: () => Promise.resolve(townConfig),
-      githubRepo: rig ? (extractGithubRepo(rig.git_url) ?? undefined) : undefined,
+      githubRepo: rig ? extractGitHubRepo(rig.git_url) : undefined,
       userId: townConfig.owner_user_id ?? rigConfig?.userId,
       orgId: townConfig.organization_id,
       platformIntegrationId: rigConfig?.platformIntegrationId,
@@ -2915,7 +2912,7 @@ export class TownDO extends DurableObject<Env> {
           env: this.env,
           townId: this.townId,
           getTownConfig: () => Promise.resolve(townConfig),
-          githubRepo: extractGithubRepo(r.git_url) ?? undefined,
+          githubRepo: extractGitHubRepo(r.git_url),
           userId: townConfig.owner_user_id ?? rc?.userId,
           orgId: townConfig.organization_id,
           platformIntegrationId: rc?.platformIntegrationId,
@@ -3820,7 +3817,7 @@ export class TownDO extends DurableObject<Env> {
             env: this.env,
             townId: this.townId,
             getTownConfig: () => Promise.resolve(townConfig),
-            githubRepo: extractGithubRepo(rig.git_url) ?? undefined,
+            githubRepo: extractGitHubRepo(rig.git_url),
             userId: townConfig.owner_user_id ?? rigConfig?.userId,
             orgId: townConfig.organization_id,
             platformIntegrationId: rigConfig?.platformIntegrationId,

--- a/services/gastown/src/dos/town/actions.ts
+++ b/services/gastown/src/dos/town/actions.ts
@@ -312,11 +312,11 @@ export type ApplyActionContext = {
   /** Stop an agent's container process. */
   stopAgent: (agentId: string) => Promise<void>;
   /** Check a PR's status via GitHub/GitLab API. Returns PRStatusOutcome. */
-  checkPRStatus: (prUrl: string) => Promise<PRStatusOutcome>;
+  checkPRStatus: (prUrl: string, rigId: string) => Promise<PRStatusOutcome>;
   /** Check PR for unresolved review comments and failing CI checks. */
-  checkPRFeedback: (prUrl: string) => Promise<PRFeedbackCheckResult | null>;
+  checkPRFeedback: (prUrl: string, rigId: string) => Promise<PRFeedbackCheckResult | null>;
   /** Merge a PR via GitHub/GitLab API. */
-  mergePR: (prUrl: string) => Promise<boolean>;
+  mergePR: (prUrl: string, rigId: string) => Promise<boolean>;
   /** Queue a nudge message for an agent. */
   queueNudge: (agentId: string, message: string, tier: string) => Promise<void>;
   /** Insert a town_event for deferred processing (e.g. pr_status_changed). */
@@ -836,6 +836,7 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
     }
 
     case 'poll_pr': {
+      const rigId = beadOps.getBead(sql, action.bead_id)?.rig_id ?? '';
       // Touch updated_at and record last_poll_at synchronously so the bead
       // doesn't look stale to Rule 4 (orphaned PR review, 30 min timeout).
       // Without this, active polling keeps the PR alive but updated_at was
@@ -858,7 +859,7 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
 
       return async () => {
         try {
-          const outcome = await ctx.checkPRStatus(action.pr_url);
+          const outcome = await ctx.checkPRStatus(action.pr_url, rigId);
           if (outcome.ok) {
             // Successful poll — reset both consecutive error counters
             query(
@@ -1018,7 +1019,9 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             // Each checkPRFeedback call makes 3+ GitHub API requests (GraphQL +
             // check-runs + commit status), so deduplicating halves our API usage.
             const feedback =
-              wantsAutoResolve || wantsAutoMerge ? await ctx.checkPRFeedback(action.pr_url) : null;
+              wantsAutoResolve || wantsAutoMerge
+                ? await ctx.checkPRFeedback(action.pr_url, rigId)
+                : null;
 
             if (feedback) {
               const prevAwaitingRows = z
@@ -1163,7 +1166,7 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
               // If the PR was merged externally during that window, inserting
               // pr_feedback_detected would create a feedback bead for a merged
               // PR — leading to a duplicate PR on an already-merged branch.
-              const freshOutcome = await ctx.checkPRStatus(action.pr_url);
+              const freshOutcome = await ctx.checkPRStatus(action.pr_url, rigId);
               if (!freshOutcome.ok || freshOutcome.result.status !== 'open') {
                 console.log(
                   `${LOG} poll_pr: PR status changed to '${freshOutcome.ok ? freshOutcome.result.status : 'error'}' during feedback check, skipping feedback for bead=${action.bead_id}`
@@ -1526,7 +1529,8 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
           // Re-check feedback immediately before merging to avoid acting on
           // stale state. If a reviewer posted new comments or CI regressed
           // since the last poll, abort and reset the timer.
-          const freshFeedback = await ctx.checkPRFeedback(action.pr_url);
+          const rigId = mrBead?.rig_id ?? '';
+          const freshFeedback = await ctx.checkPRFeedback(action.pr_url, rigId);
           if (
             freshFeedback &&
             (freshFeedback.hasUnresolvedComments ||
@@ -1560,7 +1564,7 @@ export function applyAction(ctx: ApplyActionContext, action: Action): (() => Pro
             return;
           }
 
-          const merged = await ctx.mergePR(action.pr_url);
+          const merged = await ctx.mergePR(action.pr_url, rigId);
           if (merged) {
             ctx.insertEvent('pr_status_changed', {
               bead_id: action.bead_id,

--- a/services/gastown/src/dos/town/config.ts
+++ b/services/gastown/src/dos/town/config.ts
@@ -9,7 +9,6 @@ import {
   type MergeStrategy,
   type RigOverrideConfig,
 } from '../../types';
-import { resolveGitHubTokenString } from './town-scm';
 
 const CONFIG_KEY = 'town:config';
 const NEW_TOWN_DEFAULTS_SEEDED_KEY = 'town:config:newDefaultsSeeded';
@@ -297,37 +296,14 @@ export function resolveRigConfig(
  * Build the ContainerConfig payload for X-Town-Config header.
  * Sent with every fetch() to the container.
  *
- * The container's `syncTownConfigToProcessEnv` reads `git_auth.github_token`
- * from this payload on every request and writes it to `process.env.GIT_TOKEN`,
- * which the SDK server's `gh` CLI inherits via `GH_TOKEN`. To prevent serving
- * an expired installation token (TTL ~1h) we resolve through `resolveGitHubToken`
- * so a configured platform integration always returns a fresh value.
- *
- * `townId` is required so we can always perform the integration lookup.
- * Making it optional was a foot-gun — a forgotten arg silently re-introduces
- * the stale-token bug this function exists to prevent.
+ * GitHub credentials are resolved per rig and must not be copied into this
+ * town-wide payload or the container process environment.
  */
 export async function buildContainerConfig(
   storage: DurableObjectStorage,
-  env: Env,
-  townId: string
+  env: Env
 ): Promise<Record<string, unknown>> {
   const config = await getTownConfig(storage);
-
-  let resolvedGithubToken = config.git_auth?.github_token;
-  try {
-    const fresh = await resolveGitHubTokenString({
-      env,
-      townId,
-      getTownConfig: () => Promise.resolve(config),
-    });
-    if (fresh) resolvedGithubToken = fresh;
-  } catch (err) {
-    console.warn(
-      `${TOWN_LOG} buildContainerConfig: resolveGitHubTokenString failed; falling back to stored token`,
-      err
-    );
-  }
 
   return {
     env_vars: config.env_vars,
@@ -335,13 +311,14 @@ export async function buildContainerConfig(
     small_model: resolveSmallModel(config),
     git_auth: {
       ...config.git_auth,
-      github_token: resolvedGithubToken,
+      github_token: undefined,
     },
     kilocode_token: config.kilocode_token,
     github_cli_pat: config.github_cli_pat,
     git_author_name: config.git_author_name,
     git_author_email: config.git_author_email,
     disable_ai_coauthor: config.disable_ai_coauthor,
+    rig_scoped_git_identity: true,
     kilo_api_url: env.KILO_API_URL ?? '',
     gastown_api_url: env.GASTOWN_API_URL ?? '',
     organization_id: config.organization_id,

--- a/services/gastown/src/dos/town/container-dispatch.test.ts
+++ b/services/gastown/src/dos/town/container-dispatch.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { TownConfig } from '../../types';
+import { getTownContainerStub } from '../TownContainer.do';
+import { startAgentInContainer, startMergeInContainer } from './container-dispatch';
+
+vi.mock('../TownContainer.do', () => ({ getTownContainerStub: vi.fn() }));
+vi.mock('../../util/jwt.util', () => ({
+  signAgentJWT: vi.fn(() => 'agent-token'),
+  signContainerJWT: vi.fn(() => 'container-token'),
+}));
+vi.mock('../../util/analytics.util', () => ({ writeEvent: vi.fn() }));
+vi.mock('./config', () => ({
+  buildContainerConfig: vi.fn().mockResolvedValue({}),
+  resolveModel: vi.fn(() => 'test-model'),
+  resolveSmallModel: vi.fn(() => 'test-small-model'),
+  resolveRigConfig: vi.fn(() => ({ custom_instructions: {} })),
+}));
+
+const townConfig: TownConfig = {
+  env_vars: {},
+  git_auth: {},
+  owner_user_id: 'owner-user',
+  owner_type: 'user',
+  merge_strategy: 'direct',
+  staged_convoys_default: false,
+  convoy_merge_mode: 'review-and-merge',
+  disable_ai_coauthor: false,
+};
+
+function createEnv(getTokenForRepo: ReturnType<typeof vi.fn>): Env {
+  return {
+    GASTOWN_JWT_SECRET: 'test-secret',
+    GIT_TOKEN_SERVICE: { getTokenForRepo },
+  } as unknown as Env;
+}
+
+describe('container dispatch GitHub token resolution', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(getTownContainerStub).mockReturnValue({
+      setEnvVar: vi.fn().mockResolvedValue(undefined),
+      fetch: vi.fn().mockResolvedValue(new Response(null, { status: 200 })),
+    } as unknown as ReturnType<typeof getTownContainerStub>);
+  });
+
+  it('resolves the exact dotted repository when starting an agent', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'fresh-token',
+      platformIntegrationId: 'pinned-integration',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+
+    await expect(
+      startAgentInContainer(createEnv(getTokenForRepo), {} as DurableObjectStorage, {
+        townId: 'town-1',
+        rigId: 'rig-1',
+        userId: 'owner-user',
+        agentId: 'agent-1',
+        agentName: 'Agent One',
+        role: 'polecat',
+        identity: 'Agent One',
+        beadId: 'bead-1',
+        beadTitle: 'Test bead',
+        beadBody: '',
+        checkpoint: null,
+        gitUrl: 'git@github.com:acme/repo.with.dots.git',
+        defaultBranch: 'main',
+        townConfig,
+        platformIntegrationId: 'pinned-integration',
+      })
+    ).resolves.toMatchObject({ started: true });
+
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo.with.dots',
+      userId: 'owner-user',
+      expectedIntegrationId: 'pinned-integration',
+    });
+  });
+
+  it('resolves the exact dotted repository when starting a merge', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'fresh-token',
+      platformIntegrationId: 'pinned-integration',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+
+    await expect(
+      startMergeInContainer(createEnv(getTokenForRepo), {} as DurableObjectStorage, {
+        townId: 'town-1',
+        rigId: 'rig-1',
+        agentId: 'agent-1',
+        entryId: 'entry-1',
+        beadId: 'bead-1',
+        branch: 'gt/agent-one/bead-1',
+        targetBranch: 'main',
+        gitUrl: 'https://github.com/acme/repo.with.dots.git',
+        townConfig,
+        platformIntegrationId: 'pinned-integration',
+      })
+    ).resolves.toBe(true);
+
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo.with.dots',
+      userId: 'owner-user',
+      expectedIntegrationId: 'pinned-integration',
+    });
+  });
+});

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -11,6 +11,7 @@ import { buildMayorSystemPrompt } from '../../prompts/mayor-system.prompt';
 import type { TownConfig, RigOverrideConfig } from '../../types';
 import { buildContainerConfig, resolveModel, resolveSmallModel, resolveRigConfig } from './config';
 import { writeEvent } from '../../util/analytics.util';
+import { extractGitHubRepo } from '../../util/repository-integration.util';
 import { resolveGitHubTokenString } from './town-scm';
 
 const TOWN_LOG = '[Town.do]';
@@ -449,7 +450,7 @@ export async function startAgentInContainer(
       env,
       townId: params.townId,
       getTownConfig: () => Promise.resolve(params.townConfig),
-      githubRepo: params.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1],
+      githubRepo: extractGitHubRepo(params.gitUrl),
       userId: params.userId,
       orgId: params.townConfig.organization_id,
       platformIntegrationId: params.platformIntegrationId,
@@ -670,7 +671,7 @@ export async function startMergeInContainer(
       env,
       townId: params.townId,
       getTownConfig: () => Promise.resolve(params.townConfig),
-      githubRepo: params.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1],
+      githubRepo: extractGitHubRepo(params.gitUrl),
       userId,
       orgId: params.townConfig.organization_id,
       platformIntegrationId: params.platformIntegrationId,

--- a/services/gastown/src/dos/town/container-dispatch.ts
+++ b/services/gastown/src/dos/town/container-dispatch.ts
@@ -406,7 +406,7 @@ export async function startAgentInContainer(
       rigId: string;
       gitUrl: string;
       defaultBranch: string;
-      platformIntegrationId?: string;
+      envVars?: Record<string, string>;
     }>;
   }
 ): Promise<{ started: boolean; containerFetchMs: number }> {
@@ -449,6 +449,9 @@ export async function startAgentInContainer(
       env,
       townId: params.townId,
       getTownConfig: () => Promise.resolve(params.townConfig),
+      githubRepo: params.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1],
+      userId: params.userId,
+      orgId: params.townConfig.organization_id,
       platformIntegrationId: params.platformIntegrationId,
     });
     if (githubToken) {
@@ -463,7 +466,7 @@ export async function startAgentInContainer(
 
     // GitHub CLI PAT — used exclusively for `gh` CLI operations (PRs, issues).
     // Separate from GIT_TOKEN which is used for git clone/push.
-    if (params.townConfig.github_cli_pat) {
+    if (!params.platformIntegrationId && params.townConfig.github_cli_pat) {
       envVars.GITHUB_CLI_PAT = params.townConfig.github_cli_pat;
     }
 
@@ -490,7 +493,7 @@ export async function startAgentInContainer(
       `${TOWN_LOG} startAgentInContainer: envVars built: keys=[${Object.keys(envVars).join(',')}] hasGitToken=${!!envVars.GIT_TOKEN} hasGitlabToken=${!!envVars.GITLAB_TOKEN} hasContainerToken=${!!containerToken} hasAgentJwt=${!!agentToken} hasKilocodeToken=${!!kilocodeToken} git_auth_keys=[${Object.keys(params.townConfig.git_auth ?? {}).join(',')}]`
     );
 
-    const containerConfig = await buildContainerConfig(storage, env, params.townId);
+    const containerConfig = await buildContainerConfig(storage, env);
     const container = getTownContainerStub(env, params.townId);
 
     const rigOverride = params.rigOverride ?? null;
@@ -551,7 +554,6 @@ export async function startAgentInContainer(
         // at the convoy's feature branch tip.
         defaultBranch: params.defaultBranch,
         envVars,
-        platformIntegrationId: params.platformIntegrationId,
         // For convoy agents, start from the convoy's feature branch so the
         // worktree includes all previously merged convoy work.
         startPoint: params.convoyFeatureBranch ? `origin/${params.convoyFeatureBranch}` : undefined,
@@ -633,6 +635,7 @@ export async function startMergeInContainer(
     gitUrl: string;
     kilocodeToken?: string;
     townConfig: TownConfig;
+    platformIntegrationId?: string;
   }
 ): Promise<boolean> {
   try {
@@ -667,6 +670,10 @@ export async function startMergeInContainer(
       env,
       townId: params.townId,
       getTownConfig: () => Promise.resolve(params.townConfig),
+      githubRepo: params.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1],
+      userId,
+      orgId: params.townConfig.organization_id,
+      platformIntegrationId: params.platformIntegrationId,
     });
     if (mergeGithubToken) {
       envVars.GIT_TOKEN = mergeGithubToken;
@@ -683,7 +690,7 @@ export async function startMergeInContainer(
     const mergeKilocodeToken = params.kilocodeToken ?? params.townConfig.kilocode_token;
     if (mergeKilocodeToken) envVars.KILOCODE_TOKEN = mergeKilocodeToken;
 
-    const containerConfig = await buildContainerConfig(storage, env, params.townId);
+    const containerConfig = await buildContainerConfig(storage, env);
     const container = getTownContainerStub(env, params.townId);
 
     const response = await container.fetch('http://container/git/merge', {

--- a/services/gastown/src/dos/town/town-scm.ts
+++ b/services/gastown/src/dos/town/town-scm.ts
@@ -14,11 +14,10 @@ export type SCMContext = {
   env: Env;
   townId: string;
   getTownConfig: () => Promise<TownConfig>;
-  /**
-   * Rig-level platform integration ID. When provided, it is tried as a
-   * fallback after town-level git_auth so that rigs authenticated solely
-   * through a rig-scoped GitHub App installation can still resolve a token.
-   */
+  githubRepo?: string;
+  userId?: string;
+  orgId?: string;
+  /** Exact Kilo platform integration identity persisted for the rig. */
   platformIntegrationId?: string;
 };
 
@@ -29,22 +28,9 @@ export type GitHubTokenResolution =
 /**
  * Resolve a GitHub API token from the town config.
  *
- * Priority chain (most to least preferred):
- *   1. `github_cli_pat` — user-supplied long-lived PAT, never expires.
- *   2. Platform integration (GitHub App installation) — minted fresh by
- *      git-token-service with KV-backed caching that auto-invalidates
- *      before each token's 1h TTL elapses. This is the authoritative
- *      live source whenever an integration is configured.
- *   3. `git_auth.github_token` — stored installation token from a past
- *      `refreshGitCredentials()` write. Kept as a fallback for towns that
- *      never had an integration wired up. NOT preferred over the integration
- *      because the stored value is typically stale (1h TTL, never updated
- *      by anything in the request path).
- *
- * Historically this preferred the stored token over the integration,
- * which made every consumer (PR poller, /refresh-git-token, agent
- * dispatch's `GIT_TOKEN`) hand out an expired token whenever the rig
- * had been registered more than ~1 hour ago. See ce15a6fe7 for the fix.
+ * Persisted rig integrations are exact fences and always resolve through the
+ * Git Token Service's authoritative repository lookup. Legacy town credentials
+ * remain available only to rigs without a persisted integration identity.
  *
  * Returns a `GitHubTokenResolution`: `ok: true` with the token + source on
  * success, or `ok: false` with the `tried` chain on failure. Used by
@@ -54,40 +40,87 @@ export async function resolveGitHubToken(ctx: SCMContext): Promise<GitHubTokenRe
   const tried: string[] = [];
   const townConfig = await ctx.getTownConfig();
 
-  // 1. github_cli_pat — long-lived user PAT
+  if (ctx.platformIntegrationId) {
+    tried.push('rig platform integration');
+    if (!ctx.env.GIT_TOKEN_SERVICE) {
+      tried.push('rig platform integration (GIT_TOKEN_SERVICE not bound)');
+      return { ok: false, tried };
+    }
+    if (!ctx.githubRepo || !ctx.userId) {
+      tried.push('rig integration context incomplete');
+      return { ok: false, tried };
+    }
+
+    try {
+      const result = await ctx.env.GIT_TOKEN_SERVICE.getTokenForRepo({
+        githubRepo: ctx.githubRepo,
+        userId: ctx.userId,
+        ...(ctx.orgId ? { orgId: ctx.orgId } : {}),
+        expectedIntegrationId: ctx.platformIntegrationId,
+      });
+      if (result.success) {
+        return { ok: true, token: result.token, source: 'rig platform integration' };
+      }
+      tried.push(`rig platform integration (${result.reason})`);
+    } catch (err) {
+      console.warn(`${TOWN_LOG} resolveGitHubToken: exact rig integration lookup failed`, err);
+      tried.push('rig platform integration (lookup failed)');
+    }
+    return { ok: false, tried };
+  }
+
+  // Legacy unpinned rigs retain their existing credential priority.
   if (townConfig.github_cli_pat) {
     return { ok: true, token: townConfig.github_cli_pat, source: 'town.github_cli_pat' };
   }
   tried.push('town.github_cli_pat');
 
-  // 2. Platform integration — fresh App installation token
-  const integrationId = townConfig.git_auth?.platform_integration_id ?? ctx.platformIntegrationId;
-  const sourceLabel = townConfig.git_auth?.platform_integration_id
-    ? 'town platform integration'
-    : 'rig platform integration';
-  if (integrationId && ctx.env.GIT_TOKEN_SERVICE) {
-    tried.push(sourceLabel);
-    try {
-      const fresh = await ctx.env.GIT_TOKEN_SERVICE.getToken(integrationId);
-      if (typeof fresh === 'string' && fresh.length > 0) {
-        return { ok: true, token: fresh, source: sourceLabel };
+  const legacyIntegrationId = townConfig.git_auth?.platform_integration_id;
+  if (legacyIntegrationId && ctx.env.GIT_TOKEN_SERVICE) {
+    tried.push('legacy town platform integration');
+    if (ctx.githubRepo && ctx.userId) {
+      try {
+        const result = await ctx.env.GIT_TOKEN_SERVICE.getTokenForRepo({
+          githubRepo: ctx.githubRepo,
+          userId: ctx.userId,
+          ...(ctx.orgId ? { orgId: ctx.orgId } : {}),
+        });
+        if (result.success) {
+          return { ok: true, token: result.token, source: 'legacy town platform integration' };
+        }
+        tried.push(`legacy town platform integration (${result.reason})`);
+        if (
+          result.reason === 'ambiguous_installation' ||
+          result.reason === 'temporarily_unavailable'
+        ) {
+          return { ok: false, tried };
+        }
+      } catch (err) {
+        console.warn(`${TOWN_LOG} resolveGitHubToken: legacy repository lookup failed`, err);
+        tried.push('legacy town platform integration (lookup failed)');
       }
-      console.warn(
-        `${TOWN_LOG} resolveGitHubToken: platform integration ${integrationId} returned empty token; falling back to stored github_token`
-      );
-    } catch (err) {
-      console.warn(
-        `${TOWN_LOG} resolveGitHubToken: platform integration token lookup failed for ${integrationId}; falling back to stored github_token`,
-        err
-      );
+    } else {
+      try {
+        const fresh = await ctx.env.GIT_TOKEN_SERVICE.getToken(legacyIntegrationId);
+        if (typeof fresh === 'string' && fresh.length > 0) {
+          return { ok: true, token: fresh, source: 'legacy town platform integration' };
+        }
+        console.warn(
+          `${TOWN_LOG} resolveGitHubToken: legacy platform integration returned empty token; falling back to stored github_token`
+        );
+      } catch (err) {
+        console.warn(
+          `${TOWN_LOG} resolveGitHubToken: legacy platform integration lookup failed; falling back to stored github_token`,
+          err
+        );
+      }
     }
-  } else if (!integrationId) {
+  } else if (!legacyIntegrationId) {
     tried.push('platform integration (none configured)');
   } else {
-    tried.push(`${sourceLabel} (GIT_TOKEN_SERVICE not bound)`);
+    tried.push('legacy town platform integration (GIT_TOKEN_SERVICE not bound)');
   }
 
-  // 3. Stored git_auth.github_token — last-resort fallback
   if (townConfig.git_auth?.github_token) {
     return {
       ok: true,

--- a/services/gastown/src/handlers/org-towns.handler.ts
+++ b/services/gastown/src/handlers/org-towns.handler.ts
@@ -5,6 +5,7 @@ import { getTownDOStub } from '../dos/Town.do';
 import { resSuccess, resError } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
 import type { GastownEnv } from '../gastown.worker';
+import { resolveRepositoryIntegration } from '../util/repository-integration.util';
 
 const ORG_TOWNS_LOG = '[org-towns.handler]';
 
@@ -91,7 +92,25 @@ export async function handleCreateOrgRig(c: Context<GastownEnv>, params: { orgId
   const town = await orgDO.getTownAsync(parsed.data.town_id);
   if (!town) return c.json(resError('Town not found in this org'), 404);
 
-  const rig = await orgDO.createRig(parsed.data);
+  const integration = await resolveRepositoryIntegration(c.env, {
+    gitUrl: parsed.data.git_url,
+    userId,
+    orgId: params.orgId,
+    expectedIntegrationId: parsed.data.platform_integration_id,
+  });
+  if (!integration.success) {
+    const status =
+      integration.reason === 'service_unavailable' ||
+      integration.reason === 'temporarily_unavailable'
+        ? 503
+        : 412;
+    return c.json(resError('No unambiguous GitHub integration can access this repository'), status);
+  }
+  const rigInput = {
+    ...parsed.data,
+    platform_integration_id: integration.platformIntegrationId,
+  };
+  const rig = await orgDO.createRig(rigInput);
   console.log(
     `${ORG_TOWNS_LOG} handleCreateOrgRig: rig created id=${rig.id}, now configuring Town DO`
   );
@@ -109,7 +128,7 @@ export async function handleCreateOrgRig(c: Context<GastownEnv>, params: { orgId
       // Never trust caller-supplied kilocode tokens for org rigs — the
       // town's existing token (minted by the owner) is used instead.
       kilocodeToken: undefined,
-      platformIntegrationId: parsed.data.platform_integration_id,
+      platformIntegrationId: integration.platformIntegrationId,
     });
     // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC stub returns Rpc.Promisified
     await townDOStub.addRig({

--- a/services/gastown/src/handlers/refresh-git-token.handler.test.ts
+++ b/services/gastown/src/handlers/refresh-git-token.handler.test.ts
@@ -1,0 +1,60 @@
+import { Hono } from 'hono';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GastownEnv } from '../gastown.worker';
+import { getTownDOStub } from '../dos/Town.do';
+import { resolveGitHubToken } from '../dos/town/town-scm';
+import { handleRefreshGitToken } from './refresh-git-token.handler';
+
+vi.mock('../dos/Town.do', () => ({ getTownDOStub: vi.fn() }));
+vi.mock('../dos/town/town-scm', () => ({ resolveGitHubToken: vi.fn() }));
+vi.mock('../util/jwt.util', () => ({
+  verifyContainerJWT: vi.fn(() => ({
+    success: true,
+    payload: { townId: 'town-1', userId: 'user-1', scope: 'container' },
+  })),
+}));
+vi.mock('../util/secret.util', () => ({ resolveSecret: vi.fn(() => 'test-secret') }));
+
+describe('handleRefreshGitToken', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('refreshes a dotted SSH repository through its exact pinned integration', async () => {
+    vi.mocked(getTownDOStub).mockReturnValue({
+      getRigConfig: vi.fn().mockResolvedValue({
+        gitUrl: 'git@github.com:acme/repo.with.dots.git',
+        userId: 'rig-user',
+        platformIntegrationId: 'pinned-integration',
+      }),
+      getTownConfig: vi.fn().mockResolvedValue({
+        owner_user_id: 'owner-user',
+        organization_id: 'org-1',
+      }),
+    } as unknown as ReturnType<typeof getTownDOStub>);
+    vi.mocked(resolveGitHubToken).mockResolvedValue({
+      ok: true,
+      token: 'fresh-token',
+      source: 'rig platform integration',
+    });
+
+    const app = new Hono<GastownEnv>();
+    app.post('/refresh', c => handleRefreshGitToken(c, { townId: 'town-1', rigId: 'rig-1' }));
+
+    const response = await app.request(
+      '/refresh',
+      { method: 'POST', headers: { Authorization: 'Bearer container-token' } },
+      {} as Env
+    );
+
+    expect(response.status).toBe(200);
+    expect(resolveGitHubToken).toHaveBeenCalledWith(
+      expect.objectContaining({
+        githubRepo: 'acme/repo.with.dots',
+        userId: 'owner-user',
+        orgId: 'org-1',
+        platformIntegrationId: 'pinned-integration',
+      })
+    );
+  });
+});

--- a/services/gastown/src/handlers/refresh-git-token.handler.ts
+++ b/services/gastown/src/handlers/refresh-git-token.handler.ts
@@ -44,12 +44,20 @@ export async function handleRefreshGitToken(
 
   const town = getTownDOStub(c.env, params.townId);
   const rigConfig = await town.getRigConfig(params.rigId);
+  if (!rigConfig) {
+    return c.json(resError('Rig not found'), 404);
+  }
+  const townConfig = await town.getTownConfig();
+  const githubRepo = rigConfig.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1];
 
   const freshToken = await resolveGitHubToken({
     env: c.env,
     townId: params.townId,
-    getTownConfig: () => town.getTownConfig(),
-    platformIntegrationId: rigConfig?.platformIntegrationId,
+    getTownConfig: () => Promise.resolve(townConfig),
+    githubRepo,
+    userId: townConfig.owner_user_id ?? rigConfig.userId,
+    orgId: townConfig.organization_id,
+    platformIntegrationId: rigConfig.platformIntegrationId,
   });
 
   if (!freshToken.ok) {

--- a/services/gastown/src/handlers/refresh-git-token.handler.ts
+++ b/services/gastown/src/handlers/refresh-git-token.handler.ts
@@ -5,6 +5,7 @@ import { getTownDOStub } from '../dos/Town.do';
 import { verifyContainerJWT } from '../util/jwt.util';
 import { resolveSecret } from '../util/secret.util';
 import { resSuccess, resError } from '../util/res.util';
+import { extractGitHubRepo } from '../util/repository-integration.util';
 import { resolveGitHubToken } from '../dos/town/town-scm';
 
 /**
@@ -48,7 +49,7 @@ export async function handleRefreshGitToken(
     return c.json(resError('Rig not found'), 404);
   }
   const townConfig = await town.getTownConfig();
-  const githubRepo = rigConfig.gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1];
+  const githubRepo = extractGitHubRepo(rigConfig.gitUrl);
 
   const freshToken = await resolveGitHubToken({
     env: c.env,

--- a/services/gastown/src/handlers/towns.handler.ts
+++ b/services/gastown/src/handlers/towns.handler.ts
@@ -5,6 +5,7 @@ import { getTownDOStub } from '../dos/Town.do';
 import { resSuccess, resError } from '../util/res.util';
 import { parseJsonBody } from '../util/parse-json-body.util';
 import type { GastownEnv } from '../gastown.worker';
+import { resolveRepositoryIntegration } from '../util/repository-integration.util';
 
 const TOWNS_LOG = '[towns.handler]';
 
@@ -70,7 +71,24 @@ export async function handleCreateRig(c: Context<GastownEnv>, params: { userId: 
   );
 
   const townDO = getGastownUserStub(c.env, params.userId);
-  const rig = await townDO.createRig(parsed.data);
+  const integration = await resolveRepositoryIntegration(c.env, {
+    gitUrl: parsed.data.git_url,
+    userId: params.userId,
+    expectedIntegrationId: parsed.data.platform_integration_id,
+  });
+  if (!integration.success) {
+    const status =
+      integration.reason === 'service_unavailable' ||
+      integration.reason === 'temporarily_unavailable'
+        ? 503
+        : 412;
+    return c.json(resError('No unambiguous GitHub integration can access this repository'), status);
+  }
+  const rigInput = {
+    ...parsed.data,
+    platform_integration_id: integration.platformIntegrationId,
+  };
+  const rig = await townDO.createRig(rigInput);
   console.log(`${TOWNS_LOG} handleCreateRig: rig created id=${rig.id}, now configuring Rig DO`);
 
   // Configure the Town DO with rig metadata and register the rig.
@@ -84,7 +102,7 @@ export async function handleCreateRig(c: Context<GastownEnv>, params: { userId: 
       defaultBranch: parsed.data.default_branch,
       userId: params.userId,
       kilocodeToken: parsed.data.kilocode_token,
-      platformIntegrationId: parsed.data.platform_integration_id,
+      platformIntegrationId: integration.platformIntegrationId,
     });
     // eslint-disable-next-line @typescript-eslint/await-thenable -- DO RPC stub returns Rpc.Promisified
     await townDOStub.addRig({

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -39,6 +39,7 @@ import {
 } from './schemas';
 import type { TRPCContext } from './init';
 import { ContainerBillingError } from '../billing/ContainerBilling.error';
+import { resolveRepositoryIntegration } from '../util/repository-integration.util';
 
 // rpcSafe wrapper for TownConfigSchema (imported from ../types, not ./schemas)
 const RpcTownConfigSchema = z.any().pipe(TownConfigSchema);
@@ -51,31 +52,31 @@ function extractGithubRepo(gitUrl: string): string | null {
   return m ? m[1] : null;
 }
 
-/** Best-effort refresh of git credentials for a town via the git-token-service. */
-async function refreshGitCredentials(
+/** Resolve and optionally fence the GitHub integration that can access a repository. */
+async function resolvePlatformIntegration(
   env: Env,
-  townId: string,
   gitUrl: string,
   userId: string,
-  orgId?: string
-): Promise<void> {
-  if (!env.GIT_TOKEN_SERVICE) return;
-  const githubRepo = extractGithubRepo(gitUrl);
-  if (!githubRepo) return;
-
-  const result = await env.GIT_TOKEN_SERVICE.getTokenForRepo({ githubRepo, userId, orgId });
-  if (!result.success) {
-    console.warn(`[gastown-trpc] git credential refresh failed: ${result.reason}`);
-    return;
-  }
-
-  const townStub = getTownDOStub(env, townId);
-  await townStub.updateTownConfig({
-    git_auth: {
-      github_token: result.token,
-      platform_integration_id: result.installationId,
-    },
+  orgId?: string,
+  expectedIntegrationId?: string
+): Promise<string | undefined> {
+  const result = await resolveRepositoryIntegration(env, {
+    gitUrl,
+    userId,
+    orgId,
+    expectedIntegrationId,
   });
+  if (!result.success) {
+    console.warn(`[gastown-trpc] repository integration resolution failed: ${result.reason}`);
+    throw new TRPCError({
+      code:
+        result.reason === 'temporarily_unavailable' || result.reason === 'service_unavailable'
+          ? 'SERVICE_UNAVAILABLE'
+          : 'PRECONDITION_FAILED',
+      message: 'No unambiguous GitHub integration can access this repository',
+    });
+  }
+  return result.platformIntegrationId;
 }
 
 // ── Helpers ────────────────────────────────────────────────────────────
@@ -506,25 +507,20 @@ export const gastownRouter = router({
         await townStub.updateTownConfig({ kilocode_token: kilocodeToken });
       }
 
-      // Resolve git credentials using the town owner's identity
-      try {
-        await refreshGitCredentials(
-          ctx.env,
-          input.townId,
-          input.gitUrl,
-          credentialUserId,
-          townConfig.organization_id
-        );
-      } catch (err) {
-        console.warn('[gastown-trpc] createRig: git credential refresh failed', err);
-      }
+      const platformIntegrationId = await resolvePlatformIntegration(
+        ctx.env,
+        input.gitUrl,
+        credentialUserId,
+        townConfig.organization_id,
+        input.platformIntegrationId
+      );
 
       const rig = await ownerStub.createRig({
         town_id: input.townId,
         name: input.name,
         git_url: input.gitUrl,
         default_branch: input.defaultBranch,
-        platform_integration_id: input.platformIntegrationId,
+        platform_integration_id: platformIntegrationId,
       });
 
       // Configure the Town DO with rig metadata so dispatchAgent can find it.
@@ -537,7 +533,7 @@ export const gastownRouter = router({
           defaultBranch: input.defaultBranch,
           userId: credentialUserId,
           kilocodeToken,
-          platformIntegrationId: input.platformIntegrationId,
+          platformIntegrationId,
         });
         await townStub.addRig({
           rigId: rig.id,
@@ -845,19 +841,17 @@ export const gastownRouter = router({
       const user = userFromCtx(ctx);
       const rig = await verifyRigOwnership(ctx.env, ctx, input.rigId);
 
-      // Best-effort: refresh git credentials using the town owner's identity
+      // Validate the rig's persisted integration fence before creating work.
       const townConfig = await getTownDOStub(ctx.env, rig.town_id).getTownConfig();
       const credentialUserId = townConfig.owner_user_id ?? user.id;
-      try {
-        await refreshGitCredentials(
+      if (rig.platform_integration_id) {
+        await resolvePlatformIntegration(
           ctx.env,
-          rig.town_id,
           rig.git_url,
           credentialUserId,
-          townConfig.organization_id
+          townConfig.organization_id,
+          rig.platform_integration_id
         );
-      } catch (err) {
-        console.warn('[gastown-trpc] sling: git credential refresh failed', err);
       }
 
       const townStub = getTownDOStub(ctx.env, rig.town_id);
@@ -1072,25 +1066,20 @@ export const gastownRouter = router({
     .mutation(async ({ ctx, input }) => {
       const ownerStub = await resolveRigOwnerStub(ctx.env, ctx, input.townId);
 
-      // Best-effort: refresh git credentials using the town owner's identity
+      // Validate every persisted integration fence before exposing its rig to the mayor.
       const townConfig = await getTownDOStub(ctx.env, input.townId).getTownConfig();
       const credentialUserId = townConfig.owner_user_id ?? ctx.userId;
-      try {
-        const rigList = await ownerStub.listRigs(input.townId);
-        for (const rig of rigList) {
-          if (extractGithubRepo(rig.git_url)) {
-            await refreshGitCredentials(
-              ctx.env,
-              input.townId,
-              rig.git_url,
-              credentialUserId,
-              townConfig.organization_id
-            );
-            break;
-          }
+      const rigList = await ownerStub.listRigs(input.townId);
+      for (const rig of rigList) {
+        if (extractGithubRepo(rig.git_url) && rig.platform_integration_id) {
+          await resolvePlatformIntegration(
+            ctx.env,
+            rig.git_url,
+            credentialUserId,
+            townConfig.organization_id,
+            rig.platform_integration_id
+          );
         }
-      } catch (err) {
-        console.warn('[gastown-trpc] ensureMayor: git credential refresh failed', err);
       }
 
       const townStub = getTownDOStub(ctx.env, input.townId);
@@ -1684,25 +1673,20 @@ export const gastownRouter = router({
         await townStub.updateTownConfig({ kilocode_token: kilocodeToken });
       }
 
-      // Resolve git credentials using the town owner's identity
-      try {
-        await refreshGitCredentials(
-          ctx.env,
-          input.townId,
-          input.gitUrl,
-          credentialUserId,
-          townConfig.organization_id
-        );
-      } catch (err) {
-        console.warn('[gastown-trpc] createOrgRig: git credential refresh failed', err);
-      }
+      const platformIntegrationId = await resolvePlatformIntegration(
+        ctx.env,
+        input.gitUrl,
+        credentialUserId,
+        townConfig.organization_id,
+        input.platformIntegrationId
+      );
 
       const rig = await orgStub.createRig({
         town_id: input.townId,
         name: input.name,
         git_url: input.gitUrl,
         default_branch: input.defaultBranch,
-        platform_integration_id: input.platformIntegrationId,
+        platform_integration_id: platformIntegrationId,
       });
 
       try {
@@ -1713,7 +1697,7 @@ export const gastownRouter = router({
           defaultBranch: input.defaultBranch,
           userId: credentialUserId,
           kilocodeToken,
-          platformIntegrationId: input.platformIntegrationId,
+          platformIntegrationId,
         });
         await townStub.addRig({
           rigId: rig.id,

--- a/services/gastown/src/trpc/router.ts
+++ b/services/gastown/src/trpc/router.ts
@@ -39,18 +39,15 @@ import {
 } from './schemas';
 import type { TRPCContext } from './init';
 import { ContainerBillingError } from '../billing/ContainerBilling.error';
-import { resolveRepositoryIntegration } from '../util/repository-integration.util';
+import {
+  extractGitHubRepo,
+  resolveRepositoryIntegration,
+} from '../util/repository-integration.util';
 
 // rpcSafe wrapper for TownConfigSchema (imported from ../types, not ./schemas)
 const RpcTownConfigSchema = z.any().pipe(TownConfigSchema);
 
 // ── Git credential helpers ─────────────────────────────────────────────
-
-/** Extract 'owner/repo' from a GitHub URL, or null if not a GitHub URL. */
-function extractGithubRepo(gitUrl: string): string | null {
-  const m = gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/);
-  return m ? m[1] : null;
-}
 
 /** Resolve and optionally fence the GitHub integration that can access a repository. */
 async function resolvePlatformIntegration(
@@ -1071,7 +1068,7 @@ export const gastownRouter = router({
       const credentialUserId = townConfig.owner_user_id ?? ctx.userId;
       const rigList = await ownerStub.listRigs(input.townId);
       for (const rig of rigList) {
-        if (extractGithubRepo(rig.git_url) && rig.platform_integration_id) {
+        if (extractGitHubRepo(rig.git_url) && rig.platform_integration_id) {
           await resolvePlatformIntegration(
             ctx.env,
             rig.git_url,

--- a/services/gastown/src/util/repository-integration.util.test.ts
+++ b/services/gastown/src/util/repository-integration.util.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { resolveRepositoryIntegration } from './repository-integration.util';
 
 describe('resolveRepositoryIntegration', () => {
-  it('returns and persists the authoritative integration identity', async () => {
+  it('resolves a dotted HTTPS repository for pinned rig creation', async () => {
     const getTokenForRepo = vi.fn().mockResolvedValue({
       success: true,
       token: 'token',
@@ -14,14 +14,14 @@ describe('resolveRepositoryIntegration', () => {
 
     await expect(
       resolveRepositoryIntegration({ GIT_TOKEN_SERVICE: { getTokenForRepo } } as unknown as Env, {
-        gitUrl: 'https://github.com/acme/repo.git',
+        gitUrl: 'https://github.com/acme/repo.with.dots.git',
         userId: 'user-1',
         orgId: 'org-1',
         expectedIntegrationId: 'selected-integration',
       })
     ).resolves.toEqual({ success: true, platformIntegrationId: 'resolved-integration' });
     expect(getTokenForRepo).toHaveBeenCalledWith({
-      githubRepo: 'acme/repo',
+      githubRepo: 'acme/repo.with.dots',
       userId: 'user-1',
       orgId: 'org-1',
       expectedIntegrationId: 'selected-integration',

--- a/services/gastown/src/util/repository-integration.util.test.ts
+++ b/services/gastown/src/util/repository-integration.util.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { resolveRepositoryIntegration } from './repository-integration.util';
+
+describe('resolveRepositoryIntegration', () => {
+  it('returns and persists the authoritative integration identity', async () => {
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'token',
+      platformIntegrationId: 'resolved-integration',
+      installationId: '123',
+      accountLogin: 'acme',
+      appType: 'standard',
+    });
+
+    await expect(
+      resolveRepositoryIntegration({ GIT_TOKEN_SERVICE: { getTokenForRepo } } as unknown as Env, {
+        gitUrl: 'https://github.com/acme/repo.git',
+        userId: 'user-1',
+        orgId: 'org-1',
+        expectedIntegrationId: 'selected-integration',
+      })
+    ).resolves.toEqual({ success: true, platformIntegrationId: 'resolved-integration' });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      orgId: 'org-1',
+      expectedIntegrationId: 'selected-integration',
+    });
+  });
+
+  it('does not require Git Token Service for non-GitHub repositories', async () => {
+    await expect(
+      resolveRepositoryIntegration({} as Env, {
+        gitUrl: 'https://gitlab.com/acme/repo.git',
+        userId: 'user-1',
+      })
+    ).resolves.toEqual({ success: true });
+  });
+});

--- a/services/gastown/src/util/repository-integration.util.ts
+++ b/services/gastown/src/util/repository-integration.util.ts
@@ -1,0 +1,30 @@
+export type RepositoryIntegrationResolution =
+  | { success: true; platformIntegrationId?: string }
+  | { success: false; reason: GetTokenForRepoFailure['reason'] | 'service_unavailable' };
+
+function extractGithubRepo(gitUrl: string): string | null {
+  return gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1] ?? null;
+}
+
+export async function resolveRepositoryIntegration(
+  env: Env,
+  input: {
+    gitUrl: string;
+    userId: string;
+    orgId?: string;
+    expectedIntegrationId?: string;
+  }
+): Promise<RepositoryIntegrationResolution> {
+  const githubRepo = extractGithubRepo(input.gitUrl);
+  if (!githubRepo) return { success: true };
+  if (!env.GIT_TOKEN_SERVICE) return { success: false, reason: 'service_unavailable' };
+
+  const result = await env.GIT_TOKEN_SERVICE.getTokenForRepo({
+    githubRepo,
+    userId: input.userId,
+    ...(input.orgId ? { orgId: input.orgId } : {}),
+    ...(input.expectedIntegrationId ? { expectedIntegrationId: input.expectedIntegrationId } : {}),
+  });
+  if (!result.success) return result;
+  return { success: true, platformIntegrationId: result.platformIntegrationId };
+}

--- a/services/gastown/src/util/repository-integration.util.ts
+++ b/services/gastown/src/util/repository-integration.util.ts
@@ -1,9 +1,13 @@
+import { parseGitUrl } from '@kilocode/worker-utils/git-url';
+
 export type RepositoryIntegrationResolution =
   | { success: true; platformIntegrationId?: string }
   | { success: false; reason: GetTokenForRepoFailure['reason'] | 'service_unavailable' };
 
-function extractGithubRepo(gitUrl: string): string | null {
-  return gitUrl.match(/github\.com[/:]([^/]+\/[^/.]+)/)?.[1] ?? null;
+export function extractGitHubRepo(gitUrl: string): string | undefined {
+  const coordinates = parseGitUrl(gitUrl);
+  if (coordinates?.platform !== 'github') return undefined;
+  return `${coordinates.owner}/${coordinates.repo}`;
 }
 
 export async function resolveRepositoryIntegration(
@@ -15,7 +19,7 @@ export async function resolveRepositoryIntegration(
     expectedIntegrationId?: string;
   }
 ): Promise<RepositoryIntegrationResolution> {
-  const githubRepo = extractGithubRepo(input.gitUrl);
+  const githubRepo = extractGitHubRepo(input.gitUrl);
   if (!githubRepo) return { success: true };
   if (!env.GIT_TOKEN_SERVICE) return { success: false, reason: 'service_unavailable' };
 

--- a/services/gastown/test/integration/dotted-repository-runtime.test.ts
+++ b/services/gastown/test/integration/dotted-repository-runtime.test.ts
@@ -1,0 +1,135 @@
+import { env, runInDurableObject } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+import type { TownDO } from '../../src/dos/Town.do';
+import type { ApplyActionContext } from '../../src/dos/town/actions';
+
+const GIT_URL = 'git@github.com:acme/repo.with.dots.git';
+const EXPECTED_LOOKUP = {
+  githubRepo: 'acme/repo.with.dots',
+  userId: 'user-1',
+  expectedIntegrationId: 'integration-1',
+};
+
+type LookupParams = typeof EXPECTED_LOOKUP & { orgId?: string };
+type RuntimeTown = {
+  setupRigRepoInContainer: (rigConfig: RigConfig) => Promise<void>;
+  rigListForMayor: () => Promise<unknown>;
+  applyActionCtx: ApplyActionContext;
+};
+type RigConfig = {
+  townId: string;
+  rigId: string;
+  gitUrl: string;
+  defaultBranch: string;
+  userId: string;
+  platformIntegrationId: string;
+};
+
+function getTown() {
+  return env.TOWN.get(env.TOWN.idFromName(`dotted-runtime-${crypto.randomUUID()}`));
+}
+
+function installRejectingTokenService(instance: TownDO): LookupParams[] {
+  const calls: LookupParams[] = [];
+  const runtime = instance as unknown as { env: Env };
+  runtime.env = {
+    ...runtime.env,
+    GIT_TOKEN_SERVICE: {
+      getTokenForRepo: async params => {
+        calls.push(params as LookupParams);
+        return { success: false, reason: 'integration_mismatch' };
+      },
+      getToken: async () => '',
+    },
+  };
+  return calls;
+}
+
+async function seedRig(instance: TownDO, state: DurableObjectState): Promise<RigConfig> {
+  const rigConfig = {
+    townId: 'town-1',
+    rigId: 'rig-1',
+    gitUrl: GIT_URL,
+    defaultBranch: 'main',
+    userId: 'user-1',
+    platformIntegrationId: 'integration-1',
+  };
+  await instance.addRig({
+    rigId: rigConfig.rigId,
+    name: 'dotted-rig',
+    gitUrl: rigConfig.gitUrl,
+    defaultBranch: rigConfig.defaultBranch,
+  });
+  await state.storage.put(`rig:${rigConfig.rigId}:config`, rigConfig);
+  return rigConfig;
+}
+
+describe('dotted repository runtime paths', () => {
+  it('preserves the repository during proactive rig clone setup', async () => {
+    const town = getTown();
+
+    const calls = await runInDurableObject(town, async (instance: TownDO) => {
+      const lookups = installRejectingTokenService(instance);
+      const rigConfig = {
+        townId: 'town-1',
+        rigId: 'rig-1',
+        gitUrl: GIT_URL,
+        defaultBranch: 'main',
+        userId: 'user-1',
+        platformIntegrationId: 'integration-1',
+      };
+      await (instance as unknown as RuntimeTown).setupRigRepoInContainer(rigConfig);
+      return lookups;
+    });
+
+    expect(calls).toEqual([EXPECTED_LOOKUP]);
+  });
+
+  it('preserves the repository for PR status, feedback, and merge operations', async () => {
+    const town = getTown();
+
+    const calls = await runInDurableObject(town, async (instance: TownDO, state) => {
+      await seedRig(instance, state);
+      const lookups = installRejectingTokenService(instance);
+      const actions = (instance as unknown as RuntimeTown).applyActionCtx;
+
+      await actions.checkPRStatus('https://github.com/acme/repo.with.dots/pull/1', 'rig-1');
+      await actions.checkPRFeedback('https://github.com/acme/repo.with.dots/pull/1', 'rig-1');
+      await actions.mergePR('https://github.com/acme/repo.with.dots/pull/1', 'rig-1');
+      return lookups;
+    });
+
+    expect(calls).toEqual([EXPECTED_LOOKUP, EXPECTED_LOOKUP, EXPECTED_LOOKUP]);
+  });
+
+  it('preserves the repository while preparing mayor browse worktrees', async () => {
+    const town = getTown();
+
+    const calls = await runInDurableObject(town, async (instance: TownDO, state) => {
+      await seedRig(instance, state);
+      const lookups = installRejectingTokenService(instance);
+      await (instance as unknown as RuntimeTown).rigListForMayor();
+      return lookups;
+    });
+
+    expect(calls).toEqual([EXPECTED_LOOKUP]);
+  });
+
+  it('preserves the repository when creating a convoy branch', async () => {
+    const town = getTown();
+
+    const calls = await runInDurableObject(town, async (instance: TownDO, state) => {
+      await seedRig(instance, state);
+      const lookups = installRejectingTokenService(instance);
+      await instance.slingConvoy({
+        rigId: 'rig-1',
+        convoyTitle: 'Dotted repository convoy',
+        tasks: [{ title: 'Task one' }],
+        staged: true,
+      });
+      return lookups;
+    });
+
+    expect(calls).toEqual([EXPECTED_LOOKUP]);
+  });
+});

--- a/services/gastown/test/integration/rig-integration-identity.test.ts
+++ b/services/gastown/test/integration/rig-integration-identity.test.ts
@@ -1,0 +1,34 @@
+import { env } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+
+describe('rig integration identity', () => {
+  it('persists independent integration identities per rig', async () => {
+    const town = env.TOWN.get(env.TOWN.idFromName(`rig-identity-${crypto.randomUUID()}`));
+    const base = {
+      townId: 'town-1',
+      gitUrl: 'https://github.com/acme/repo.git',
+      defaultBranch: 'main',
+      userId: 'user-1',
+    };
+
+    await town.configureRig({
+      ...base,
+      rigId: 'rig-one',
+      platformIntegrationId: 'integration-one',
+    });
+    await town.configureRig({
+      ...base,
+      rigId: 'rig-two',
+      platformIntegrationId: 'integration-two',
+    });
+
+    expect(await town.getRigConfig('rig-one')).toMatchObject({
+      rigId: 'rig-one',
+      platformIntegrationId: 'integration-one',
+    });
+    expect(await town.getRigConfig('rig-two')).toMatchObject({
+      rigId: 'rig-two',
+      platformIntegrationId: 'integration-two',
+    });
+  });
+});

--- a/services/gastown/test/integration/rig-owner-identity.test.ts
+++ b/services/gastown/test/integration/rig-owner-identity.test.ts
@@ -1,0 +1,37 @@
+import { env } from 'cloudflare:test';
+import { describe, expect, it } from 'vitest';
+
+async function createOrgRig(orgName: string, integrationId: string) {
+  const org = env.GASTOWN_ORG.get(env.GASTOWN_ORG.idFromName(orgName));
+  const town = await org.createTown({
+    name: `${orgName} town`,
+    owner_org_id: orgName,
+    created_by_user_id: `${orgName} owner`,
+  });
+  return org.createRig({
+    town_id: town.id,
+    name: `${orgName} rig`,
+    git_url: `https://github.com/${orgName}/repo.git`,
+    default_branch: 'main',
+    platform_integration_id: integrationId,
+  });
+}
+
+describe('Gastown rig owner identity', () => {
+  it('isolates persisted integrations for rigs owned by different organizations', async () => {
+    const first = await createOrgRig('org-one', 'integration-one');
+    const second = await createOrgRig('org-two', 'integration-two');
+
+    const firstOrg = env.GASTOWN_ORG.get(env.GASTOWN_ORG.idFromName('org-one'));
+    const secondOrg = env.GASTOWN_ORG.get(env.GASTOWN_ORG.idFromName('org-two'));
+
+    expect(await firstOrg.getRigAsync(first.id)).toMatchObject({
+      platform_integration_id: 'integration-one',
+    });
+    expect(await secondOrg.getRigAsync(second.id)).toMatchObject({
+      platform_integration_id: 'integration-two',
+    });
+    expect(await firstOrg.getRigAsync(second.id)).toBeNull();
+    expect(await secondOrg.getRigAsync(first.id)).toBeNull();
+  });
+});

--- a/services/gastown/test/unit/pr-poll-errors.test.ts
+++ b/services/gastown/test/unit/pr-poll-errors.test.ts
@@ -58,14 +58,20 @@ describe('resolveGitHubToken', () => {
   it('includes platform integration source label in resolution chain', async () => {
     const ctx = mockSCMContext({
       platformIntegrationId: 'integration-123',
-      env: { GIT_TOKEN_SERVICE: { getToken: async () => null } } as unknown as SCMContext['env'],
+      env: {
+        GIT_TOKEN_SERVICE: {
+          getTokenForRepo: async () => ({ success: false, reason: 'integration_mismatch' }),
+        },
+      } as unknown as SCMContext['env'],
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
       getTownConfig: async () =>
         ({ git_auth: { platform_integration_id: 'integration-123' } }) as TownConfig,
     });
     const result = await resolveGitHubToken(ctx);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.tried).toContain('town platform integration');
+      expect(result.tried).toContain('rig platform integration');
     }
   });
 
@@ -92,7 +98,7 @@ describe('resolveGitHubToken', () => {
     const result = await resolveGitHubToken(ctx);
     expect(result.ok).toBe(false);
     if (!result.ok) {
-      expect(result.tried).toContain('town platform integration (GIT_TOKEN_SERVICE not bound)');
+      expect(result.tried).toContain('rig platform integration (GIT_TOKEN_SERVICE not bound)');
     }
   });
 });

--- a/services/gastown/test/unit/town-scm.test.ts
+++ b/services/gastown/test/unit/town-scm.test.ts
@@ -1,11 +1,11 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { resolveGitHubToken } from '../../src/dos/town/town-scm';
 import { TownConfigSchema, type TownConfig } from '../../src/types';
 
 const STORED_GITHUB_TOKEN = 'ghs_stored_stale_token';
 const FRESH_INSTALLATION_TOKEN = 'ghs_fresh_from_integration';
 const USER_PAT = 'ghp_user_long_lived_pat';
-const INTEGRATION_ID = '119277743';
+const INTEGRATION_ID = '123e4567-e89b-12d3-a456-426614174001';
 
 function buildConfig(overrides: {
   github_token?: string;
@@ -24,9 +24,23 @@ function buildConfig(overrides: {
 function fakeEnv(opts: {
   tokenServiceResponse?: string | null;
   tokenServiceShouldThrow?: boolean;
+  repoResult?: GetTokenForRepoResult;
+  getTokenForRepo?: ReturnType<typeof vi.fn>;
 }): Env {
   return {
     GIT_TOKEN_SERVICE: {
+      getTokenForRepo:
+        opts.getTokenForRepo ??
+        vi.fn().mockResolvedValue(
+          opts.repoResult ?? {
+            success: true,
+            token: FRESH_INSTALLATION_TOKEN,
+            platformIntegrationId: INTEGRATION_ID,
+            installationId: '119277743',
+            accountLogin: 'acme',
+            appType: 'standard',
+          }
+        ),
       getToken: async (_id: string) => {
         if (opts.tokenServiceShouldThrow) {
           throw new Error('integration lookup failed');
@@ -65,7 +79,7 @@ describe('resolveGitHubToken priority chain', () => {
     expect(result).toEqual({
       ok: true,
       token: FRESH_INSTALLATION_TOKEN,
-      source: 'town platform integration',
+      source: 'legacy town platform integration',
     });
   });
 
@@ -106,12 +120,70 @@ describe('resolveGitHubToken priority chain', () => {
       env: fakeEnv({ tokenServiceResponse: FRESH_INSTALLATION_TOKEN }),
       townId: 'town-1',
       getTownConfig: () => Promise.resolve(cfg),
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
       platformIntegrationId: INTEGRATION_ID,
     });
     expect(result).toEqual({
       ok: true,
       token: FRESH_INSTALLATION_TOKEN,
       source: 'rig platform integration',
+    });
+  });
+
+  it('uses an exact integration fence and does not fall back to town credentials', async () => {
+    const getTokenForRepo = vi
+      .fn()
+      .mockResolvedValue({ success: false, reason: 'integration_mismatch' });
+    const result = await resolveGitHubToken({
+      env: fakeEnv({ getTokenForRepo }),
+      townId: 'town-1',
+      getTownConfig: () =>
+        Promise.resolve(
+          buildConfig({
+            github_token: STORED_GITHUB_TOKEN,
+            github_cli_pat: USER_PAT,
+            platform_integration_id: 'other-integration',
+          })
+        ),
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      platformIntegrationId: INTEGRATION_ID,
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      tried: ['rig platform integration', 'rig platform integration (integration_mismatch)'],
+    });
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+      expectedIntegrationId: INTEGRATION_ID,
+    });
+  });
+
+  it('fails an ambiguous legacy repository lookup closed', async () => {
+    const result = await resolveGitHubToken({
+      env: fakeEnv({ repoResult: { success: false, reason: 'ambiguous_installation' } }),
+      townId: 'town-1',
+      getTownConfig: () =>
+        Promise.resolve(
+          buildConfig({
+            github_token: STORED_GITHUB_TOKEN,
+            platform_integration_id: INTEGRATION_ID,
+          })
+        ),
+      githubRepo: 'acme/repo',
+      userId: 'user-1',
+    });
+
+    expect(result).toEqual({
+      ok: false,
+      tried: [
+        'town.github_cli_pat',
+        'legacy town platform integration',
+        'legacy town platform integration (ambiguous_installation)',
+      ],
     });
   });
 

--- a/services/gastown/worker-configuration.d.ts
+++ b/services/gastown/worker-configuration.d.ts
@@ -42,7 +42,7 @@ type GetTokenForRepoFailure = {
 };
 type GetTokenForRepoResult = GetTokenForRepoSuccess | GetTokenForRepoFailure;
 type GitTokenService = {
-	getTokenForRepo(params: { githubRepo: string; userId: string; orgId?: string }): Promise<GetTokenForRepoResult>;
+	getTokenForRepo(params: { githubRepo: string; userId: string; orgId?: string; expectedIntegrationId?: string }): Promise<GetTokenForRepoResult>;
 	getToken(installationId: string, appType?: 'standard' | 'lite'): Promise<string>;
 };
 type WastelandRpcSuccess<T> = { success: true; data: T };

--- a/services/gastown/wrangler.test.jsonc
+++ b/services/gastown/wrangler.test.jsonc
@@ -19,6 +19,7 @@
   "durable_objects": {
     "bindings": [
       { "name": "GASTOWN_USER", "class_name": "GastownUserDO" },
+      { "name": "GASTOWN_ORG", "class_name": "GastownOrgDO" },
       { "name": "AGENT_IDENTITY", "class_name": "AgentIdentityDO" },
       { "name": "TOWN", "class_name": "TownDO" },
       { "name": "TOWN_CONTAINER", "class_name": "TownContainerDO" },
@@ -32,6 +33,7 @@
     { "tag": "v3", "new_sqlite_classes": ["MayorDO"] },
     { "tag": "v4", "new_sqlite_classes": ["TownDO"] },
     { "tag": "v5", "new_sqlite_classes": ["AgentDO"], "deleted_classes": ["RigDO", "MayorDO"] },
+    { "tag": "v6", "new_sqlite_classes": ["GastownOrgDO"] },
   ],
 
   // Test secrets — plain text vars used in place of secrets_store_secrets


### PR DESCRIPTION
## Why

Gastown rigs perform Git operations outside Cloud Agent and survive restarts, so each rig needs durable installation identity. Resolution should come from Git Token Service live access, not cached web metadata, and credentials from one rig must never leak into town-wide process state used by another.

## Dependency

Depends on #5584.

## What changes

- Resolve `owner/repo` authoritatively through Git Token Service at rig creation.
- Persist the returned `platformIntegrationId` per rig.
- Reuse it as an exact fence for clone, push, PR operations, and refresh.
- Keep credentials rig-scoped and remove town or process-global token behavior.
- Preserve legacy rigs with fail-closed resolution.
- Use shared Git URL parsing in the rig-creation and token-refresh paths, with focused coverage for dotted repository names in HTTPS and SSH URLs.

## Dotted repository scope

All known Gastown runtime repository extraction paths now use the shared Git URL parser. Focused runtime coverage verifies dotted repository names through proactive rig clone/setup, rig-scoped PR status/feedback/merge resolution, mayor browse-worktree setup, convoy branch creation, container dispatch, rig creation, and token refresh.

## What this removes

No web resolver, helper, or tests and no dependency on #5547.

## Review guide

Trace rig identity from owner Durable Object storage into Town SCM and container credential refresh. For dotted repository names, review the shared parser use in `Town.do.ts`, `trpc/router.ts`, `container-dispatch.ts`, and `refresh-git-token.handler.ts`, plus `dotted-repository-runtime.test.ts`.

## Validation

- Gastown unit and container tests: 325 passed
- Focused dotted runtime worker integration tests: 4 passed
- Gastown typecheck and lint
- Full Gastown format check
- `git diff --check`
