### PR TITLE
feat(auto-triage): preserve the GitHub install that owns each issue

### DIFF
--- a/apps/web/src/app/api/internal/triage/add-label/route.test.ts
+++ b/apps/web/src/app/api/internal/triage/add-label/route.test.ts
@@ -1,0 +1,57 @@
+const mockGetTriageTicketById = jest.fn();
+const mockGetIntegrationById = jest.fn();
+const mockGenerateGitHubInstallationToken = jest.fn();
+const mockAddIssueLabel = jest.fn();
+
+jest.mock('@/lib/config.server', () => ({ INTERNAL_API_SECRET: 'internal-secret' }));
+jest.mock('@/lib/auto-triage/db/triage-tickets', () => ({
+  getTriageTicketById: (...args: unknown[]) => mockGetTriageTicketById(...args),
+}));
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationById: (...args: unknown[]) => mockGetIntegrationById(...args),
+}));
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  generateGitHubInstallationToken: (...args: unknown[]) =>
+    mockGenerateGitHubInstallationToken(...args),
+}));
+jest.mock('@/lib/auto-triage/github/add-label', () => ({
+  addIssueLabel: (...args: unknown[]) => mockAddIssueLabel(...args),
+}));
+
+import { POST } from './route';
+
+describe('POST /api/internal/triage/add-label', () => {
+  it('uses the exact integration id and app type persisted on the ticket', async () => {
+    const ticketId = '00000000-0000-4000-8000-000000000001';
+    const integrationId = '00000000-0000-4000-8000-000000000002';
+    mockGetTriageTicketById.mockResolvedValue({
+      platform_integration_id: integrationId,
+      repo_full_name: 'acme/widgets',
+      issue_number: 7,
+    });
+    mockGetIntegrationById.mockResolvedValue({
+      platform_installation_id: '123',
+      github_app_type: 'lite',
+    });
+    mockGenerateGitHubInstallationToken.mockResolvedValue({ token: 'lite-token' });
+    mockAddIssueLabel.mockResolvedValue(undefined);
+
+    const response = await POST(
+      new Request('https://app.example.test/api/internal/triage/add-label', {
+        method: 'POST',
+        headers: { 'X-Internal-Secret': 'internal-secret', 'Content-Type': 'application/json' },
+        body: JSON.stringify({ ticketId, labels: ['triaged'] }),
+      }) as never
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockGetIntegrationById).toHaveBeenCalledWith(integrationId);
+    expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledWith('123', 'lite');
+    expect(mockAddIssueLabel).toHaveBeenCalledWith({
+      repoFullName: 'acme/widgets',
+      issueNumber: 7,
+      label: 'triaged',
+      githubToken: 'lite-token',
+    });
+  });
+});

--- a/apps/web/src/app/api/internal/triage/add-label/route.ts
+++ b/apps/web/src/app/api/internal/triage/add-label/route.ts
@@ -66,7 +66,10 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'No platform installation found' }, { status: 400 });
     }
 
-    const tokenData = await generateGitHubInstallationToken(integration.platform_installation_id);
+    const tokenData = await generateGitHubInstallationToken(
+      integration.platform_installation_id,
+      integration.github_app_type ?? 'standard'
+    );
 
     // Add labels to the GitHub issue in parallel (best-effort: partial failures don't abort the batch)
     logExceptInTest('[auto-triage:labels] Applying labels to GitHub issue', {

--- a/apps/web/src/app/api/internal/triage/classify-config/route.ts
+++ b/apps/web/src/app/api/internal/triage/classify-config/route.ts
@@ -73,7 +73,8 @@ export async function POST(req: NextRequest) {
 
         if (integration?.platform_installation_id) {
           const tokenData = await generateGitHubInstallationToken(
-            integration.platform_installation_id
+            integration.platform_installation_id,
+            integration.github_app_type ?? 'standard'
           );
           githubToken = tokenData.token;
 

--- a/apps/web/src/app/api/internal/triage/post-comment/route.ts
+++ b/apps/web/src/app/api/internal/triage/post-comment/route.ts
@@ -67,7 +67,10 @@ export async function POST(req: NextRequest) {
       return NextResponse.json({ error: 'No platform installation found' }, { status: 400 });
     }
 
-    const tokenData = await generateGitHubInstallationToken(integration.platform_installation_id);
+    const tokenData = await generateGitHubInstallationToken(
+      integration.platform_installation_id,
+      integration.github_app_type ?? 'standard'
+    );
 
     logExceptInTest('[post-comment] Posting comment on GitHub issue', {
       ticketId,

--- a/apps/web/src/components/auto-triage/AdminTestingCard.tsx
+++ b/apps/web/src/components/auto-triage/AdminTestingCard.tsx
@@ -9,7 +9,17 @@ import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { ShieldCheck, Play, AlertCircle } from 'lucide-react';
+
+const GITHUB_ISSUE_URL_PATTERN =
+  /^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/\d+(?:[/?#].*)?$/;
 
 type Props =
   | {
@@ -33,6 +43,7 @@ export function AdminTestingCard(props: Props) {
   const queryClient = useQueryClient();
 
   const [issueUrl, setIssueUrl] = useState('');
+  const [selectedIntegrationId, setSelectedIntegrationId] = useState('');
   const { data: repositoriesData } = useQuery(
     props.owner.type === 'org'
       ? trpc.organizations.autoTriage.listGitHubRepositories.queryOptions({
@@ -40,6 +51,14 @@ export function AdminTestingCard(props: Props) {
         })
       : trpc.personalAutoTriage.listGitHubRepositories.queryOptions()
   );
+  const match = issueUrl.trim().match(GITHUB_ISSUE_URL_PATTERN);
+  const repoFullName = match ? `${match[1]}/${match[2]}` : null;
+  const matchingRepositories = repoFullName
+    ? (repositoriesData?.repositories.filter(
+        repository => repository.fullName.toLowerCase() === repoFullName.toLowerCase()
+      ) ?? [])
+    : [];
+  const requiresIntegrationSelection = matchingRepositories.length > 1;
 
   const mutation = useMutation(
     trpc.autoTriage.adminSubmitForTriage.mutationOptions({
@@ -69,17 +88,10 @@ export function AdminTestingCard(props: Props) {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    const match = issueUrl
-      .trim()
-      .match(/^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/\d+(?:[/?#].*)?$/);
-    const repoFullName = match ? `${match[1]}/${match[2]}` : null;
-    const matchingRepositories = repoFullName
-      ? (repositoriesData?.repositories.filter(
-          repository => repository.fullName.toLowerCase() === repoFullName.toLowerCase()
-        ) ?? [])
-      : [];
     const platformIntegrationId =
-      matchingRepositories.length === 1 ? matchingRepositories[0].platformIntegrationId : undefined;
+      matchingRepositories.length === 1
+        ? matchingRepositories[0].platformIntegrationId
+        : selectedIntegrationId || undefined;
 
     mutation.mutate({
       issueUrl,
@@ -117,13 +129,49 @@ export function AdminTestingCard(props: Props) {
               type="url"
               placeholder="https://github.com/owner/repo/issues/123"
               value={issueUrl}
-              onChange={e => setIssueUrl(e.target.value)}
+              onChange={e => {
+                setIssueUrl(e.target.value);
+                setSelectedIntegrationId('');
+              }}
               disabled={mutation.isPending}
               required
             />
           </div>
+          {requiresIntegrationSelection && (
+            <div className="space-y-2">
+              <Label htmlFor="admin-triage-github-integration">GitHub connection</Label>
+              <Select value={selectedIntegrationId} onValueChange={setSelectedIntegrationId}>
+                <SelectTrigger id="admin-triage-github-integration" className="w-full">
+                  <SelectValue placeholder="Choose the connection for this repository" />
+                </SelectTrigger>
+                <SelectContent>
+                  {matchingRepositories.map(repository => (
+                    <SelectItem
+                      key={repository.platformIntegrationId}
+                      value={repository.platformIntegrationId ?? ''}
+                    >
+                      {repository.platformAccountLogin ?? repository.fullName} (
+                      {repository.platformIntegrationId})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-muted-foreground text-xs">
+                This repository appears in multiple GitHub connections. Choose the exact connection
+                to use.
+              </p>
+            </div>
+          )}
           <div className="flex items-center gap-2">
-            <Button type="submit" size="sm" disabled={mutation.isPending || !issueUrl.trim()}>
+            <Button
+              type="submit"
+              size="sm"
+              disabled={
+                mutation.isPending ||
+                !issueUrl.trim() ||
+                (requiresIntegrationSelection && !selectedIntegrationId)
+              }
+            >
               <Play className="mr-2 h-3 w-3" />
               {mutation.isPending ? 'Dispatching…' : 'Dispatch triage'}
             </Button>

--- a/apps/web/src/components/auto-triage/AdminTestingCard.tsx
+++ b/apps/web/src/components/auto-triage/AdminTestingCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState } from 'react';
-import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/utils';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -33,6 +33,13 @@ export function AdminTestingCard(props: Props) {
   const queryClient = useQueryClient();
 
   const [issueUrl, setIssueUrl] = useState('');
+  const { data: repositoriesData } = useQuery(
+    props.owner.type === 'org'
+      ? trpc.organizations.autoTriage.listGitHubRepositories.queryOptions({
+          organizationId: props.owner.organizationId,
+        })
+      : trpc.personalAutoTriage.listGitHubRepositories.queryOptions()
+  );
 
   const mutation = useMutation(
     trpc.autoTriage.adminSubmitForTriage.mutationOptions({
@@ -62,9 +69,22 @@ export function AdminTestingCard(props: Props) {
 
   const onSubmit = (e: React.FormEvent) => {
     e.preventDefault();
+    const match = issueUrl
+      .trim()
+      .match(/^https:\/\/github\.com\/([^/\s]+)\/([^/\s]+)\/issues\/\d+(?:[/?#].*)?$/);
+    const repoFullName = match ? `${match[1]}/${match[2]}` : null;
+    const matchingRepositories = repoFullName
+      ? (repositoriesData?.repositories.filter(
+          repository => repository.fullName.toLowerCase() === repoFullName.toLowerCase()
+        ) ?? [])
+      : [];
+    const platformIntegrationId =
+      matchingRepositories.length === 1 ? matchingRepositories[0].platformIntegrationId : undefined;
+
     mutation.mutate({
       issueUrl,
       owner: props.owner,
+      ...(platformIntegrationId ? { platformIntegrationId } : {}),
     });
   };
 

--- a/apps/web/src/lib/auto-triage/application/routers/shared-router-factory.ts
+++ b/apps/web/src/lib/auto-triage/application/routers/shared-router-factory.ts
@@ -45,6 +45,8 @@ type GitHubRepositoriesResult = {
     name: string;
     fullName: string;
     private: boolean;
+    platformIntegrationId?: string;
+    platformAccountLogin?: string;
   }[];
   errorMessage?: string;
 };

--- a/apps/web/src/lib/auto-triage/github/fetch-issue.ts
+++ b/apps/web/src/lib/auto-triage/github/fetch-issue.ts
@@ -1,5 +1,5 @@
 /**
- * Fetch a GitHub issue via an owner's platform installation.
+ * Fetch a GitHub issue with repository-scoped authorization.
  *
  * Used by the admin "submit issue for triage" form to populate the
  * `issue_title` / `issue_body` / `issue_author` / `issue_labels` fields
@@ -8,9 +8,6 @@
  */
 
 import 'server-only';
-import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
-import type { Owner } from '../core';
 
 export type ParsedIssueUrl = {
   repoOwner: string;
@@ -57,32 +54,17 @@ export type FetchedIssue = {
 };
 
 /**
- * Fetch an issue via the GitHub REST API using the installation token
- * associated with the given owner. Returns the subset of fields we need
- * to build a triage ticket.
+ * Fetch an issue via the GitHub REST API using authorization already resolved
+ * for this exact repository.
  *
  * Throws with a user-facing message for the common failure modes
  * (no installation, not found, etc.) so the admin UI can surface them.
  */
-export async function fetchIssueForOwner(owner: Owner, url: ParsedIssueUrl): Promise<FetchedIssue> {
-  const integration = await getIntegrationForOwner(owner, 'github');
-  if (!integration) {
-    throw new Error(
-      'No GitHub App installation found for this owner. Install the Kilo GitHub App first.'
-    );
-  }
-  if (!integration.platform_installation_id) {
-    throw new Error(
-      'GitHub integration is missing an installation id. Reinstall the Kilo GitHub App.'
-    );
-  }
-
-  const tokenData = await generateGitHubInstallationToken(integration.platform_installation_id);
-
+export async function fetchIssue(url: ParsedIssueUrl, githubToken: string): Promise<FetchedIssue> {
   const apiUrl = `https://api.github.com/repos/${url.repoOwner}/${url.repoName}/issues/${url.issueNumber}`;
   const response = await fetch(apiUrl, {
     headers: {
-      Authorization: `Bearer ${tokenData.token}`,
+      Authorization: `Bearer ${githubToken}`,
       Accept: 'application/vnd.github+json',
       'X-GitHub-Api-Version': '2022-11-28',
     },

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.test.ts
@@ -13,6 +13,7 @@ const mockUpdateRepositoriesForIntegration =
   jest.fn<(integrationId: string, repositories: unknown[]) => Promise<void>>();
 const mockGetIntegrationsByOrganization =
   jest.fn<(organizationId: string, platform: string) => Promise<PlatformIntegration[]>>();
+const mockGetAllIntegrationsForOwner = jest.fn<(owner: Owner) => Promise<PlatformIntegration[]>>();
 const mockFetchGitHubRepositories =
   jest.fn<(installationId: string, appType: string) => Promise<unknown[]>>();
 const mockGenerateGitHubInstallationToken =
@@ -33,6 +34,7 @@ jest.mock('@/lib/integrations/db/platform-integrations', () => ({
   getIntegrationForOwner: mockGetIntegrationForOwner,
   getPrimaryGitHubIntegrationForOrganization: mockGetPrimaryGitHubIntegrationForOrganization,
   getIntegrationsByOrganization: mockGetIntegrationsByOrganization,
+  getAllIntegrationsForOwner: mockGetAllIntegrationsForOwner,
   updateRepositoriesForIntegration: mockUpdateRepositoriesForIntegration,
 }));
 
@@ -152,6 +154,39 @@ describe('github-integration-helpers', () => {
       ]);
       expect(mockUpdateRepositoriesForIntegration).toHaveBeenCalledWith('integration-1', [
         { id: 2, name: 'fresh', full_name: 'org/fresh', private: true },
+      ]);
+    });
+  });
+
+  describe('fetchAllGitHubRepositoriesForUser', () => {
+    it('preserves exact integration identity for every healthy personal installation', async () => {
+      mockGetAllIntegrationsForOwner.mockResolvedValue([
+        buildIntegration({ platform_account_login: 'acme' }),
+        buildIntegration({
+          id: 'integration-2',
+          platform_installation_id: 'installation-2',
+          platform_account_login: 'acme',
+        }),
+        buildIntegration({
+          id: 'integration-3',
+          platform: 'gitlab',
+        }),
+      ]);
+
+      const { fetchAllGitHubRepositoriesForUser } = await import('./github-integration-helpers');
+      const result = await fetchAllGitHubRepositoriesForUser('user-123');
+
+      expect(result.repositories).toEqual([
+        expect.objectContaining({
+          fullName: 'org/repo',
+          platformIntegrationId: 'integration-1',
+          platformAccountLogin: 'acme',
+        }),
+        expect.objectContaining({
+          fullName: 'org/repo',
+          platformIntegrationId: 'integration-2',
+          platformAccountLogin: 'acme',
+        }),
       ]);
     });
   });

--- a/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
+++ b/apps/web/src/lib/cloud-agent/github-integration-helpers.ts
@@ -1,5 +1,6 @@
 import { TRPCError } from '@trpc/server';
 import {
+  getAllIntegrationsForOwner,
   getIntegrationsByOrganization,
   getIntegrationForOrganization,
   getIntegrationForOwner,
@@ -194,6 +195,17 @@ export async function fetchAllGitHubRepositoriesForOrganization(
   const integrations = (
     await getIntegrationsByOrganization(organizationId, PLATFORM.GITHUB)
   ).filter(isPlatformIntegrationHealthy);
+  return fetchRepositoriesForIntegrations(integrations, forceRefresh);
+}
+
+export async function fetchAllGitHubRepositoriesForUser(
+  userId: string,
+  forceRefresh: boolean = false
+): Promise<GitHubRepositoriesResult> {
+  const integrations = (await getAllIntegrationsForOwner({ type: 'user', id: userId })).filter(
+    integration =>
+      integration.platform === PLATFORM.GITHUB && isPlatformIntegrationHealthy(integration)
+  );
   return fetchRepositoriesForIntegrations(integrations, forceRefresh);
 }
 

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -8,6 +8,7 @@ const mockGetIntegrationForOrganization = jest.fn();
 const mockLogWebhookEvent = jest.fn();
 const mockUpdateWebhookEvent = jest.fn();
 const mockHandlePullRequest = jest.fn();
+const mockHandleIssue = jest.fn();
 const mockHandlePRReviewComment = jest.fn();
 const mockHandleGitHubReviewCommentReply = jest.fn();
 const mockHandleInstallationTargetRenamed = jest.fn();
@@ -16,6 +17,10 @@ const mockHandleInstallationDeleted = jest.fn();
 const mockHandleInstallationSuspend = jest.fn();
 const mockHandleInstallationUnsuspend = jest.fn();
 const mockHandleInstallationRepositories = jest.fn();
+
+jest.mock('@/lib/utils.server', () => ({
+  logExceptInTest: jest.fn(),
+}));
 
 jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
   verifyGitHubWebhookSignature: (payload: string, signature: string, appType: string) =>
@@ -55,7 +60,8 @@ jest.mock('@/lib/integrations/platforms/github/webhook-handlers', () => ({
     mockHandleInstallationUnsuspend(payload, appType),
   handleInstallationTargetRenamed: (payload: unknown, integrationId: string, appType: string) =>
     mockHandleInstallationTargetRenamed(payload, integrationId, appType),
-  handleIssue: jest.fn(),
+  handleIssue: (payload: unknown, platformIntegration: unknown) =>
+    mockHandleIssue(payload, platformIntegration),
   handlePRReviewComment: (payload: unknown, platformIntegration: unknown) =>
     mockHandlePRReviewComment(payload, platformIntegration),
   handlePullRequest: (payload: unknown, platformIntegration: unknown) =>
@@ -184,6 +190,30 @@ function issueCommentPayload(overrides: Record<string, unknown> = {}) {
   };
 }
 
+function issuePayload(overrides: Record<string, unknown> = {}) {
+  return {
+    action: 'opened',
+    installation: { id: 98765 },
+    repository: {
+      id: 123,
+      name: 'widgets',
+      full_name: 'acme/widgets',
+      private: false,
+      owner: { login: 'acme' },
+    },
+    issue: {
+      number: 7,
+      html_url: 'https://github.com/acme/widgets/issues/7',
+      title: 'Broken widget',
+      body: 'The widget is broken.',
+      user: { login: 'alice', type: 'User' },
+      labels: [],
+    },
+    sender: { login: 'alice', type: 'User' },
+    ...overrides,
+  };
+}
+
 async function waitForAfterTask() {
   await new Promise(resolve => setTimeout(resolve, 0));
 }
@@ -197,6 +227,7 @@ describe('handleGitHubWebhook', () => {
     mockLogWebhookEvent.mockResolvedValue({ id: 'we_1', isDuplicate: false });
     mockUpdateWebhookEvent.mockResolvedValue(undefined);
     mockHandlePullRequest.mockResolvedValue(Response.json({ message: 'review queued' }));
+    mockHandleIssue.mockResolvedValue(Response.json({ message: 'triage queued' }));
     mockHandlePRReviewComment.mockResolvedValue(undefined);
     mockHandleGitHubReviewCommentReply.mockResolvedValue({
       recorded: false,
@@ -336,6 +367,31 @@ describe('handleGitHubWebhook', () => {
       'we_1',
       expect.objectContaining({ handlers_triggered: ['code_review', 'cli_session_pr_upsert'] })
     );
+  });
+
+  it.each(['opened', 'reopened'])(
+    'routes secondary %s issues with delivering identity',
+    async action => {
+      mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'pi_primary' });
+      const payload = issuePayload({ action });
+
+      const response = await handleGitHubWebhook(signedGitHubRequest('issues', payload), 'lite');
+
+      expect(response.status).toBe(200);
+      expect(mockHandleIssue).toHaveBeenCalledWith(expect.objectContaining(payload), integration);
+    }
+  );
+
+  it('keeps secondary labeled issues suppressed for Auto Fix isolation', async () => {
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'pi_primary' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('issues', issuePayload({ action: 'labeled' })),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    expect(mockHandleIssue).not.toHaveBeenCalled();
   });
 
   it('keeps pull_request_review_comment created events on the legacy auto-fix path', async () => {

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -466,7 +466,15 @@ export async function handleGitHubWebhook(
       ? await getIntegrationForOrganization(integration.owned_by_organization_id, PLATFORM.GITHUB)
       : integration;
     const isSecondaryOrganizationInstallation = primaryIntegration?.id !== integration.id;
-    if (isSecondaryOrganizationInstallation && eventType !== GITHUB_EVENT.PULL_REQUEST) {
+    const action = (payload as { action?: string }).action;
+    const isAutoTriageIssueEvent =
+      eventType === GITHUB_EVENT.ISSUES &&
+      (action === GITHUB_ACTION.OPENED || action === GITHUB_ACTION.REOPENED);
+    if (
+      isSecondaryOrganizationInstallation &&
+      eventType !== GITHUB_EVENT.PULL_REQUEST &&
+      !isAutoTriageIssueEvent
+    ) {
       logExceptInTest('Secondary GitHub installation event suppressed', {
         integration_id: integration.id,
         event_type: eventType,

--- a/apps/web/src/routers/auto-triage/auto-triage-router.test.ts
+++ b/apps/web/src/routers/auto-triage/auto-triage-router.test.ts
@@ -96,7 +96,7 @@ describe('adminSubmitForTriage integration selection', () => {
     );
   });
 
-  it('rejects a selected integration whose repository cache does not contain the issue repository', async () => {
+  it('lets the live issue fetch prove access instead of cached repository membership', async () => {
     mockGetGitHubIntegrationById.mockResolvedValue(
       integration({
         repositories: [{ id: 8, name: 'other', full_name: 'acme/other', private: true }],
@@ -109,11 +109,16 @@ describe('adminSubmitForTriage integration selection', () => {
         platformIntegrationId: integrationId,
         owner,
       })
-    ).rejects.toMatchObject({
-      code: 'PRECONDITION_FAILED',
-      message: 'The selected GitHub App installation does not include this repository.',
-    });
-    expect(mockGenerateGitHubInstallationToken).not.toHaveBeenCalled();
+    ).resolves.toMatchObject({ success: true, ticketId: 'ticket-1' });
+    expect(globalThis.fetch).toHaveBeenCalledWith(
+      'https://api.github.com/repos/acme/widgets/issues/7',
+      expect.objectContaining({
+        headers: expect.objectContaining({ Authorization: 'Bearer github-token' }),
+      })
+    );
+    expect(mockCreateTriageTicket).toHaveBeenCalledWith(
+      expect.objectContaining({ platformIntegrationId: integrationId })
+    );
   });
 
   it('fails closed for legacy input when multiple healthy integrations exist', async () => {

--- a/apps/web/src/routers/auto-triage/auto-triage-router.test.ts
+++ b/apps/web/src/routers/auto-triage/auto-triage-router.test.ts
@@ -1,0 +1,136 @@
+import { createCallerFactory } from '@/lib/trpc/init';
+
+const mockGetGitHubIntegrationById = jest.fn();
+const mockGetAllIntegrationsForOwner = jest.fn();
+const mockGenerateGitHubInstallationToken = jest.fn();
+const mockCreateTriageTicket = jest.fn();
+const mockTryDispatchPendingTickets = jest.fn();
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getGitHubIntegrationById: (...args: unknown[]) => mockGetGitHubIntegrationById(...args),
+  getAllIntegrationsForOwner: (...args: unknown[]) => mockGetAllIntegrationsForOwner(...args),
+}));
+jest.mock('@/lib/integrations/platforms/github/adapter', () => ({
+  generateGitHubInstallationToken: (...args: unknown[]) =>
+    mockGenerateGitHubInstallationToken(...args),
+}));
+jest.mock('@/lib/auto-triage/db/triage-tickets', () => ({
+  listTriageTickets: jest.fn(),
+  countTriageTickets: jest.fn(),
+  getTriageTicketById: jest.fn(),
+  resetTriageTicketForRetry: jest.fn(),
+  createTriageTicket: (...args: unknown[]) => mockCreateTriageTicket(...args),
+}));
+jest.mock('@/lib/auto-triage/dispatch/dispatch-pending-tickets', () => ({
+  tryDispatchPendingTickets: (...args: unknown[]) => mockTryDispatchPendingTickets(...args),
+}));
+jest.mock('@/lib/agent-config/db/agent-configs', () => ({
+  getAgentConfig: jest.fn(),
+  upsertAgentConfig: jest.fn(),
+}));
+jest.mock('@/lib/bot-users/bot-user-service', () => ({ getBotUserId: jest.fn() }));
+jest.mock('@/lib/organizations/trial-middleware', () => ({
+  requireActiveSubscriptionOrTrial: jest.fn(),
+}));
+
+import { autoTriageRouter } from './auto-triage-router';
+
+const createCaller = createCallerFactory(autoTriageRouter);
+const owner = { type: 'user' as const };
+const integrationId = '00000000-0000-4000-8000-000000000001';
+
+function caller() {
+  return createCaller({ user: { id: 'admin-1', is_admin: true } } as never);
+}
+
+function integration(overrides: Record<string, unknown> = {}) {
+  return {
+    id: integrationId,
+    platform: 'github',
+    platform_installation_id: '123',
+    github_app_type: 'lite',
+    integration_status: 'active',
+    suspended_at: null,
+    auth_invalid_at: null,
+    repositories: [{ id: 7, name: 'widgets', full_name: 'acme/widgets', private: true }],
+    ...overrides,
+  };
+}
+
+describe('adminSubmitForTriage integration selection', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockGenerateGitHubInstallationToken.mockResolvedValue({ token: 'github-token' });
+    mockCreateTriageTicket.mockResolvedValue('ticket-1');
+    jest.spyOn(globalThis, 'fetch').mockResolvedValue(
+      Response.json({
+        title: 'Broken widget',
+        body: 'Details',
+        user: { login: 'alice' },
+        labels: [{ name: 'bug' }],
+      })
+    );
+  });
+
+  it('uses and persists the healthy owner integration supplied by repository selection', async () => {
+    mockGetGitHubIntegrationById.mockResolvedValue(integration());
+
+    await expect(
+      caller().adminSubmitForTriage({
+        issueUrl: 'https://github.com/acme/widgets/issues/7',
+        platformIntegrationId: integrationId,
+        owner,
+      })
+    ).resolves.toMatchObject({ success: true, ticketId: 'ticket-1' });
+
+    expect(mockGetGitHubIntegrationById).toHaveBeenCalledWith(
+      { type: 'user', id: 'admin-1' },
+      integrationId
+    );
+    expect(mockGenerateGitHubInstallationToken).toHaveBeenCalledWith('123', 'lite');
+    expect(mockCreateTriageTicket).toHaveBeenCalledWith(
+      expect.objectContaining({
+        platformIntegrationId: integrationId,
+        repoFullName: 'acme/widgets',
+      })
+    );
+  });
+
+  it('rejects a selected integration whose repository cache does not contain the issue repository', async () => {
+    mockGetGitHubIntegrationById.mockResolvedValue(
+      integration({
+        repositories: [{ id: 8, name: 'other', full_name: 'acme/other', private: true }],
+      })
+    );
+
+    await expect(
+      caller().adminSubmitForTriage({
+        issueUrl: 'https://github.com/acme/widgets/issues/7',
+        platformIntegrationId: integrationId,
+        owner,
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'The selected GitHub App installation does not include this repository.',
+    });
+    expect(mockGenerateGitHubInstallationToken).not.toHaveBeenCalled();
+  });
+
+  it('fails closed for legacy input when multiple healthy integrations exist', async () => {
+    mockGetAllIntegrationsForOwner.mockResolvedValue([
+      integration(),
+      integration({ id: '00000000-0000-4000-8000-000000000002' }),
+    ]);
+
+    await expect(
+      caller().adminSubmitForTriage({
+        issueUrl: 'https://github.com/acme/widgets/issues/7',
+        owner,
+      })
+    ).rejects.toMatchObject({
+      code: 'PRECONDITION_FAILED',
+      message: 'Select a repository from one exact GitHub App installation before submitting.',
+    });
+    expect(mockGenerateGitHubInstallationToken).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/routers/auto-triage/auto-triage-router.ts
+++ b/apps/web/src/routers/auto-triage/auto-triage-router.ts
@@ -41,7 +41,6 @@ import {
   getGitHubIntegrationById,
 } from '@/lib/integrations/db/platform-integrations';
 import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
-import { requireNumericPlatformRepositories } from '@/lib/integrations/core/types';
 import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 
@@ -382,17 +381,6 @@ export const autoTriageRouter = createTRPCRouter({
         throw new TRPCError({
           code: 'PRECONDITION_FAILED',
           message: 'The selected GitHub integration is missing its installation ID.',
-        });
-      }
-      const repositories = requireNumericPlatformRepositories(integration.repositories);
-      if (
-        !repositories?.some(
-          repository => repository.full_name.toLowerCase() === parsedUrl.repoFullName.toLowerCase()
-        )
-      ) {
-        throw new TRPCError({
-          code: 'PRECONDITION_FAILED',
-          message: 'The selected GitHub App installation does not include this repository.',
         });
       }
 

--- a/apps/web/src/routers/auto-triage/auto-triage-router.ts
+++ b/apps/web/src/routers/auto-triage/auto-triage-router.ts
@@ -34,9 +34,15 @@ import {
 } from '@/lib/auto-triage/db/triage-tickets';
 import { getAgentConfig, upsertAgentConfig } from '@/lib/agent-config/db/agent-configs';
 import { DEFAULT_AUTO_TRIAGE_CONFIG } from '@/lib/auto-triage';
-import { parseGitHubIssueUrl, fetchIssueForOwner } from '@/lib/auto-triage/github/fetch-issue';
+import { parseGitHubIssueUrl, fetchIssue } from '@/lib/auto-triage/github/fetch-issue';
 import { tryDispatchPendingTickets } from '@/lib/auto-triage/dispatch/dispatch-pending-tickets';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
+import {
+  getAllIntegrationsForOwner,
+  getGitHubIntegrationById,
+} from '@/lib/integrations/db/platform-integrations';
+import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
+import { requireNumericPlatformRepositories } from '@/lib/integrations/core/types';
+import { generateGitHubInstallationToken } from '@/lib/integrations/platforms/github/adapter';
 import { getBotUserId } from '@/lib/bot-users/bot-user-service';
 
 export const autoTriageRouter = createTRPCRouter({
@@ -333,6 +339,7 @@ export const autoTriageRouter = createTRPCRouter({
     .input(
       z.object({
         issueUrl: z.string().min(1),
+        platformIntegrationId: z.string().uuid().optional(),
         owner: z.discriminatedUnion('type', [
           z.object({ type: z.literal('org'), organizationId: z.string() }),
           z.object({ type: z.literal('user') }),
@@ -350,24 +357,51 @@ export const autoTriageRouter = createTRPCRouter({
         });
       }
 
+      const integrationOwner =
+        input.owner.type === 'org'
+          ? { type: 'org' as const, id: input.owner.organizationId }
+          : { type: 'user' as const, id: ctx.user.id };
+      let integration;
+      if (input.platformIntegrationId) {
+        integration = await getGitHubIntegrationById(integrationOwner, input.platformIntegrationId);
+      } else {
+        const healthyIntegrations = (await getAllIntegrationsForOwner(integrationOwner)).filter(
+          candidate => candidate.platform === 'github' && isPlatformIntegrationHealthy(candidate)
+        );
+        integration = healthyIntegrations.length === 1 ? healthyIntegrations[0] : null;
+      }
+      if (!integration || !isPlatformIntegrationHealthy(integration)) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: input.platformIntegrationId
+            ? 'The selected GitHub App installation is not available for this owner.'
+            : 'Select a repository from one exact GitHub App installation before submitting.',
+        });
+      }
+      if (!integration.platform_installation_id) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'The selected GitHub integration is missing its installation ID.',
+        });
+      }
+      const repositories = requireNumericPlatformRepositories(integration.repositories);
+      if (
+        !repositories?.some(
+          repository => repository.full_name.toLowerCase() === parsedUrl.repoFullName.toLowerCase()
+        )
+      ) {
+        throw new TRPCError({
+          code: 'PRECONDITION_FAILED',
+          message: 'The selected GitHub App installation does not include this repository.',
+        });
+      }
+
       // Resolve the Owner we'll store on the ticket and use for dispatch.
       // For orgs we mirror issue-webhook-processor.resolveOwner() by
       // preferring the bot user id with a fallback to the integration
       // creator. For personal we use the admin's own user id.
       let owner: Owner;
       if (input.owner.type === 'org') {
-        // `getIntegrationForOwner` takes the integrations-module `Owner`
-        // which only needs { type, id } — don't synthesise a userId here.
-        const integration = await getIntegrationForOwner(
-          { type: 'org', id: input.owner.organizationId },
-          'github'
-        );
-        if (!integration) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'No GitHub App installation found for this organization.',
-          });
-        }
         const botUserId = await getBotUserId(input.owner.organizationId, 'auto-triage');
         const fallbackUserId = botUserId ?? integration.kilo_requester_user_id;
         if (!fallbackUserId) {
@@ -386,10 +420,15 @@ export const autoTriageRouter = createTRPCRouter({
         owner = { type: 'user', id: ctx.user.id, userId: ctx.user.id };
       }
 
-      // Pull title/body/labels from GitHub via the owner's installation.
+      const tokenData = await generateGitHubInstallationToken(
+        integration.platform_installation_id,
+        integration.github_app_type ?? 'standard'
+      );
+
+      // The GitHub fetch is the authoritative proof that this installation still has access.
       let issue;
       try {
-        issue = await fetchIssueForOwner(owner, parsedUrl);
+        issue = await fetchIssue(parsedUrl, tokenData.token);
       } catch (error) {
         throw new TRPCError({
           code: 'BAD_REQUEST',
@@ -397,13 +436,9 @@ export const autoTriageRouter = createTRPCRouter({
         });
       }
 
-      // Look up the integration again for owner.type==='user' to attach
-      // platformIntegrationId on the ticket for parity with the webhook path.
-      const integration = await getIntegrationForOwner(owner, 'github');
-
       const ticketId = await createTriageTicket({
         owner,
-        platformIntegrationId: integration?.id,
+        platformIntegrationId: integration.id,
         repoFullName: parsedUrl.repoFullName,
         issueNumber: parsedUrl.issueNumber,
         issueUrl: parsedUrl.issueUrl,

--- a/apps/web/src/routers/organizations/organization-auto-triage-router.ts
+++ b/apps/web/src/routers/organizations/organization-auto-triage-router.ts
@@ -11,7 +11,7 @@ import {
   upsertAgentConfig,
   setAgentEnabled,
 } from '@/lib/agent-config/db/agent-configs';
-import { fetchGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
+import { fetchAllGitHubRepositoriesForOrganization } from '@/lib/cloud-agent/github-integration-helpers';
 import { createAutoTriageRouter } from '@/lib/auto-triage/application/routers/shared-router-factory';
 import { ensureBotUserForOrg } from '@/lib/bot-users/bot-user-service';
 
@@ -51,7 +51,7 @@ const sharedHandlers = createAutoTriageRouter({
         errorMessage: 'Invalid owner type',
       };
     }
-    return await fetchGitHubRepositoriesForOrganization(owner.id);
+    return await fetchAllGitHubRepositoriesForOrganization(owner.id);
   },
 
   agentConfigGetter: async (owner, agentType, platform) => {

--- a/apps/web/src/routers/personal-auto-triage-router.ts
+++ b/apps/web/src/routers/personal-auto-triage-router.ts
@@ -5,7 +5,7 @@ import {
   upsertAgentConfigForOwner,
   setAgentEnabledForOwner,
 } from '@/lib/agent-config/db/agent-configs';
-import { fetchGitHubRepositoriesForUser } from '@/lib/cloud-agent/github-integration-helpers';
+import { fetchAllGitHubRepositoriesForUser } from '@/lib/cloud-agent/github-integration-helpers';
 import { createAutoTriageRouter } from '@/lib/auto-triage/application/routers/shared-router-factory';
 
 const sharedHandlers = createAutoTriageRouter({
@@ -32,7 +32,7 @@ const sharedHandlers = createAutoTriageRouter({
         errorMessage: 'Invalid owner type',
       };
     }
-    return await fetchGitHubRepositoriesForUser(owner.id);
+    return await fetchAllGitHubRepositoriesForUser(owner.id);
   },
 
   agentConfigGetter: async (owner, agentType, platform) => {


### PR DESCRIPTION
## Why
Secondary issue webhooks already identify their installation; manual issue submission should accept the installation selected by repository UI rather than introducing another general resolver. Every asynchronous triage operation then uses the persisted exact row.

## Dependency
Based on #5590 for the shared central-resolution rollout, though Auto Triage direct GitHub work remains exact-row based.

## What changes
- Aggregate organization repository options with provenance.
- Accept optional platformIntegrationId on manual submission and validate exact ownership/health/repository cache; the GitHub issue fetch proves actual access.
- Fail legacy manual input closed when multiple healthy installations exist.
- Persist delivering integration for secondary opened/reopened webhooks.
- Use persisted installation/app type for classification, comments, and labels.

## What this removes
No #5547 resolver and no new Git Token Service HTTP bridge.

## Review guide
Review manual exact-ID validation, webhook admission, then downstream persisted-row token use.

## Validation
- 4 focused suites, 35 tests
- Web and affected-package typechecks/lint
- `git diff --check`