### PR TITLE
feat(app-builder): persist the GitHub install resolved at migration

### DIFF
--- a/apps/web/src/lib/app-builder/github-migration-service.test.ts
+++ b/apps/web/src/lib/app-builder/github-migration-service.test.ts
@@ -1,0 +1,241 @@
+import { beforeAll, beforeEach, describe, expect, it, jest } from '@jest/globals';
+import type { SQL } from 'drizzle-orm';
+import { PgDialect } from 'drizzle-orm/pg-core';
+import type * as migrationService from './github-migration-service';
+
+type ProjectState = {
+  id: string;
+  title: string;
+  session_id: string | null;
+  deployment_id: string | null;
+  git_repo_full_name: string | null;
+  git_platform_integration_id: string | null;
+  migrated_at: string | null;
+};
+type WorkerMigrationResult =
+  | { success: true; platformIntegrationId: string }
+  | { success: false; error: string };
+
+const projectState: ProjectState = {
+  id: 'project-1',
+  title: 'Test project',
+  session_id: 'session-1',
+  deployment_id: null,
+  git_repo_full_name: null,
+  git_platform_integration_id: null,
+  migrated_at: null,
+};
+const dialect = new PgDialect();
+const migrationPredicates: SQL[] = [];
+const mockMigrateToGithub = jest.fn<() => Promise<WorkerMigrationResult>>();
+const mockGetProjectWithOwnershipCheck = jest.fn<() => Promise<ProjectState>>(async () => ({
+  ...projectState,
+}));
+
+function compile(predicate: SQL) {
+  return dialect.sqlToQuery(predicate);
+}
+
+function matchesClaimPredicate(predicate: SQL) {
+  const { sql } = compile(predicate);
+  return (
+    projectState.migrated_at === null &&
+    projectState.git_repo_full_name === null &&
+    /"migrated_at" is null/i.test(sql) &&
+    /"git_repo_full_name" is null/i.test(sql)
+  );
+}
+
+function matchesOwnedClaim(predicate: SQL) {
+  if (!projectState.migrated_at || projectState.git_repo_full_name !== null) return false;
+  const { sql, params } = compile(predicate);
+  return (
+    /"migrated_at"\s*=\s*\$\d+/i.test(sql) &&
+    /"git_repo_full_name" is null/i.test(sql) &&
+    params.includes(projectState.migrated_at)
+  );
+}
+
+function update() {
+  return {
+    set(values: Partial<ProjectState>) {
+      return {
+        where(predicate: SQL) {
+          migrationPredicates.push(predicate);
+
+          const returning = async () => {
+            if (values.migrated_at && matchesClaimPredicate(predicate)) {
+              projectState.migrated_at = values.migrated_at;
+              return [{ ...projectState }];
+            }
+            if (values.git_repo_full_name && matchesOwnedClaim(predicate)) {
+              projectState.git_repo_full_name = values.git_repo_full_name;
+              projectState.git_platform_integration_id = values.git_platform_integration_id ?? null;
+              return [{ id: projectState.id }];
+            }
+            return [];
+          };
+
+          if (values.migrated_at === null && matchesOwnedClaim(predicate)) {
+            projectState.migrated_at = null;
+          }
+
+          return Object.assign(Promise.resolve([]), { returning });
+        },
+      };
+    },
+  };
+}
+
+jest.mock('@/lib/drizzle', () => ({
+  db: {
+    update,
+    transaction: async (callback: (tx: { update: typeof update }) => Promise<unknown>) =>
+      callback({ update }),
+  },
+}));
+
+jest.mock('@/lib/app-builder/app-builder-client', () => ({
+  migrateToGithub: () => mockMigrateToGithub(),
+}));
+
+jest.mock('@/lib/app-builder/project-ownership', () => ({
+  getProjectWithOwnershipCheck: () => mockGetProjectWithOwnershipCheck(),
+}));
+
+jest.mock('@/lib/integrations/db/platform-integrations', () => ({
+  getIntegrationForOwner: jest.fn(),
+}));
+
+let migrateProjectToGitHub: typeof migrationService.migrateProjectToGitHub;
+
+const owner = { type: 'user', id: 'user-1' } as const;
+const resolvedIntegrationId = '123e4567-e89b-12d3-a456-426614174003';
+
+function migrate(repoFullName = 'acme/app', expectedPlatformIntegrationId?: string) {
+  return migrateProjectToGitHub({
+    projectId: projectState.id,
+    owner,
+    userId: owner.id,
+    repoFullName,
+    expectedPlatformIntegrationId,
+  });
+}
+
+beforeAll(async () => {
+  ({ migrateProjectToGitHub } = await import('./github-migration-service'));
+});
+
+beforeEach(() => {
+  projectState.session_id = 'session-1';
+  projectState.deployment_id = null;
+  projectState.git_repo_full_name = null;
+  projectState.git_platform_integration_id = null;
+  projectState.migrated_at = null;
+  migrationPredicates.length = 0;
+  jest.clearAllMocks();
+  mockMigrateToGithub.mockResolvedValue({
+    success: true,
+    platformIntegrationId: resolvedIntegrationId,
+  });
+});
+
+describe('GitHub migration claim', () => {
+  it('allows only one concurrent request to call the Worker', async () => {
+    const worker = Promise.withResolvers<WorkerMigrationResult>();
+    const started = Promise.withResolvers<void>();
+    mockMigrateToGithub.mockImplementationOnce(() => {
+      started.resolve();
+      return worker.promise;
+    });
+
+    const winner = migrate();
+    await started.promise;
+    const loser = await migrate();
+
+    expect(loser).toEqual({ success: false, error: 'already_migrated' });
+    expect(mockMigrateToGithub).toHaveBeenCalledTimes(1);
+
+    worker.resolve({ success: true, platformIntegrationId: resolvedIntegrationId });
+    await expect(winner).resolves.toMatchObject({ success: true });
+
+    const claimSql = compile(migrationPredicates[0]).sql;
+    expect(claimSql).toMatch(/"migrated_at" is null/i);
+    expect(claimSql).toMatch(/"git_repo_full_name" is null/i);
+  });
+
+  it('returns the completed result when the same migration is retried', async () => {
+    await expect(migrate()).resolves.toMatchObject({ success: true });
+    await expect(migrate()).resolves.toEqual({
+      success: true,
+      githubRepoUrl: 'https://github.com/acme/app',
+      newSessionId: 'session-1',
+    });
+
+    expect(mockMigrateToGithub).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a conflicting migration without calling the Worker again', async () => {
+    await expect(migrate()).resolves.toMatchObject({ success: true });
+    await expect(migrate('acme/other-app')).resolves.toEqual({
+      success: false,
+      error: 'already_migrated',
+    });
+
+    expect(mockMigrateToGithub).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a same-repository retry fenced to a different integration', async () => {
+    await expect(migrate()).resolves.toMatchObject({ success: true });
+    await expect(migrate('acme/app', '123e4567-e89b-12d3-a456-426614174099')).resolves.toEqual({
+      success: false,
+      error: 'already_migrated',
+    });
+
+    expect(mockMigrateToGithub).toHaveBeenCalledTimes(1);
+  });
+
+  it('releases only its own claim when the Worker fails before pushing', async () => {
+    mockMigrateToGithub.mockResolvedValueOnce({ success: false, error: 'repo_not_empty' });
+
+    await expect(migrate()).resolves.toEqual({ success: false, error: 'repo_not_empty' });
+    expect(projectState.migrated_at).toBeNull();
+
+    const releasePredicate = migrationPredicates.at(-1);
+    if (!releasePredicate) throw new Error('Claim release predicate was not recorded');
+    const { sql, params } = compile(releasePredicate);
+    expect(sql).toMatch(/"migrated_at"\s*=\s*\$\d+/i);
+    expect(sql).toMatch(/"git_repo_full_name" is null/i);
+    expect(params).toContainEqual(expect.stringMatching(/^\d{4}-\d{2}-\d{2}T/));
+
+    await expect(migrate()).resolves.toMatchObject({ success: true });
+    expect(mockMigrateToGithub).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not release a claim token it no longer owns', async () => {
+    const worker = Promise.withResolvers<WorkerMigrationResult>();
+    const started = Promise.withResolvers<void>();
+    mockMigrateToGithub.mockImplementationOnce(() => {
+      started.resolve();
+      return worker.promise;
+    });
+
+    const migration = migrate();
+    await started.promise;
+    projectState.migrated_at = '2026-08-27T15:00:00.000Z';
+    worker.resolve({ success: false, error: 'repo_not_empty' });
+
+    await expect(migration).resolves.toEqual({ success: false, error: 'repo_not_empty' });
+    expect(projectState.migrated_at).toBe('2026-08-27T15:00:00.000Z');
+  });
+
+  it('retains the claim after an ambiguous Worker failure', async () => {
+    mockMigrateToGithub.mockRejectedValueOnce(new Error('Response was lost'));
+
+    await expect(migrate()).resolves.toEqual({ success: false, error: 'push_failed' });
+    expect(projectState.migrated_at).not.toBeNull();
+
+    await expect(migrate()).resolves.toEqual({ success: false, error: 'already_migrated' });
+    expect(mockMigrateToGithub).toHaveBeenCalledTimes(1);
+  });
+});

--- a/apps/web/src/lib/app-builder/github-migration-service.ts
+++ b/apps/web/src/lib/app-builder/github-migration-service.ts
@@ -7,7 +7,6 @@ import { eq, and, isNull } from 'drizzle-orm';
 import {
   fetchGitHubInstallationDetails,
   fetchGitHubRepositories,
-  getRepositoryDetails,
   getInstallationSettingsUrl,
 } from '@/lib/integrations/platforms/github/adapter';
 import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
@@ -189,80 +188,55 @@ export async function migrateProjectToGitHub(
   }
 
   try {
-    // 2. Get GitHub integration for the owner
-    const integration = await getIntegrationForOwner(
-      owner,
-      PLATFORM.GITHUB,
-      INTEGRATION_STATUS.ACTIVE
-    );
-
-    if (!integration || !integration.platform_installation_id) {
-      throw new MigrationError('github_app_not_installed');
-    }
-
-    // 3. Validate the target repo exists, is accessible, and is empty
-    let repoDetails: {
-      fullName: string;
-      cloneUrl: string;
-      htmlUrl: string;
-      isEmpty: boolean;
-      isPrivate: boolean;
-    } | null;
-
-    try {
-      repoDetails = await getRepositoryDetails(integration.platform_installation_id, repoFullName);
-    } catch (error) {
-      throw new MigrationError('internal_error', { cause: error });
-    }
-
-    if (!repoDetails) {
-      throw new MigrationError('repo_not_found');
-    }
-
-    if (!repoDetails.isEmpty) {
-      throw new MigrationError('repo_not_empty');
-    }
-
-    // 4. Migrate on the worker (push + preview switch + schedule repo deletion)
+    // 2. Resolve access authoritatively and migrate on the Worker that performs the Git push.
+    let platformIntegrationId: string;
     try {
       const migrateResult = await appBuilderClient.migrateToGithub(projectId, {
-        githubRepo: repoDetails.fullName,
+        githubRepo: repoFullName,
         userId,
         orgId: owner.type === 'org' ? owner.id : undefined,
+        expectedPlatformIntegrationId: params.expectedPlatformIntegrationId,
       });
 
       if (!migrateResult.success) {
-        throw new MigrationError('push_failed', { cause: migrateResult });
+        const error =
+          migrateResult.error === 'repo_not_found' ||
+          migrateResult.error === 'repo_not_empty' ||
+          migrateResult.error === 'internal_error'
+            ? migrateResult.error
+            : 'push_failed';
+        throw new MigrationError(error, { cause: migrateResult });
       }
+      platformIntegrationId = migrateResult.platformIntegrationId;
     } catch (error) {
       if (error instanceof MigrationError) throw error;
       throw new MigrationError('push_failed', { cause: error });
     }
 
-    // 5. Update deployment if exists
+    // 3. Update deployment if exists
     if (project.deployment_id) {
       await db
         .update(deployments)
         .set({
           source_type: 'github',
-          repository_source: repoDetails.fullName,
-          platform_integration_id: integration.id,
+          repository_source: repoFullName,
+          platform_integration_id: platformIntegrationId,
         })
         .where(eq(deployments.id, project.deployment_id));
     }
 
-    // 6. Finalize project record (migrated_at already set by the atomic claim)
+    // 4. Finalize project record (migrated_at already set by the atomic claim)
     await db
       .update(app_builder_projects)
       .set({
-        git_repo_full_name: repoDetails.fullName,
-        git_platform_integration_id: integration.id,
+        git_repo_full_name: repoFullName,
+        git_platform_integration_id: platformIntegrationId,
       })
       .where(eq(app_builder_projects.id, projectId));
 
     return {
       success: true,
-      githubRepoUrl: repoDetails.htmlUrl,
+      githubRepoUrl: `https://github.com/${repoFullName}`,
       newSessionId: project.session_id ?? '',
     };
   } catch (error) {

--- a/apps/web/src/lib/app-builder/github-migration-service.ts
+++ b/apps/web/src/lib/app-builder/github-migration-service.ts
@@ -171,26 +171,43 @@ export async function migrateProjectToGitHub(
   // 0. Validate ownership (throws NOT_FOUND if project doesn't exist or wrong owner)
   await getProjectWithOwnershipCheck(projectId, owner);
 
-  // 1. Atomically claim this project for migration (prevents concurrent migrations)
-  // Sets migrated_at as a claim — only one concurrent caller can win.
-  // We also require git_repo_full_name IS NULL so that a crashed previous attempt
-  // (migrated_at set but git_repo_full_name never written) doesn't permanently block retries.
+  // 1. Atomically claim this project for migration (prevents concurrent migrations).
+  // Keep the claim after any successful Worker response because the push cannot be rolled back.
+  const claimStartedAt = new Date().toISOString();
   const [project] = await db
     .update(app_builder_projects)
-    .set({ migrated_at: new Date().toISOString() })
+    .set({ migrated_at: claimStartedAt })
     .where(
-      and(eq(app_builder_projects.id, projectId), isNull(app_builder_projects.git_repo_full_name))
+      and(
+        eq(app_builder_projects.id, projectId),
+        isNull(app_builder_projects.migrated_at),
+        isNull(app_builder_projects.git_repo_full_name)
+      )
     )
     .returning();
 
   if (!project) {
+    const currentProject = await getProjectWithOwnershipCheck(projectId, owner);
+    if (
+      currentProject.git_repo_full_name === repoFullName &&
+      (!params.expectedPlatformIntegrationId ||
+        currentProject.git_platform_integration_id === params.expectedPlatformIntegrationId)
+    ) {
+      return {
+        success: true,
+        githubRepoUrl: `https://github.com/${repoFullName}`,
+        newSessionId: currentProject.session_id ?? '',
+      };
+    }
     return { success: false, error: 'already_migrated' };
   }
 
+  let releaseClaimOnFailure = true;
   try {
     // 2. Resolve access authoritatively and migrate on the Worker that performs the Git push.
     let platformIntegrationId: string;
     try {
+      releaseClaimOnFailure = false;
       const migrateResult = await appBuilderClient.migrateToGithub(projectId, {
         githubRepo: repoFullName,
         userId,
@@ -199,6 +216,10 @@ export async function migrateProjectToGitHub(
       });
 
       if (!migrateResult.success) {
+        releaseClaimOnFailure =
+          migrateResult.error === 'token_failed' ||
+          migrateResult.error === 'repo_not_found' ||
+          migrateResult.error === 'repo_not_empty';
         const error =
           migrateResult.error === 'repo_not_found' ||
           migrateResult.error === 'repo_not_empty' ||
@@ -213,26 +234,38 @@ export async function migrateProjectToGitHub(
       throw new MigrationError('push_failed', { cause: error });
     }
 
-    // 3. Update deployment if exists
-    if (project.deployment_id) {
-      await db
-        .update(deployments)
-        .set({
-          source_type: 'github',
-          repository_source: repoFullName,
-          platform_integration_id: platformIntegrationId,
-        })
-        .where(eq(deployments.id, project.deployment_id));
-    }
+    // 3. Commit all database state only if this operation still owns the claim.
+    await db.transaction(async tx => {
+      if (project.deployment_id) {
+        await tx
+          .update(deployments)
+          .set({
+            source_type: 'github',
+            repository_source: repoFullName,
+            platform_integration_id: platformIntegrationId,
+          })
+          .where(eq(deployments.id, project.deployment_id));
+      }
 
-    // 4. Finalize project record (migrated_at already set by the atomic claim)
-    await db
-      .update(app_builder_projects)
-      .set({
-        git_repo_full_name: repoFullName,
-        git_platform_integration_id: platformIntegrationId,
-      })
-      .where(eq(app_builder_projects.id, projectId));
+      const [finalizedProject] = await tx
+        .update(app_builder_projects)
+        .set({
+          git_repo_full_name: repoFullName,
+          git_platform_integration_id: platformIntegrationId,
+        })
+        .where(
+          and(
+            eq(app_builder_projects.id, projectId),
+            eq(app_builder_projects.migrated_at, claimStartedAt),
+            isNull(app_builder_projects.git_repo_full_name)
+          )
+        )
+        .returning({ id: app_builder_projects.id });
+
+      if (!finalizedProject) {
+        throw new Error('GitHub migration claim was lost before finalization');
+      }
+    });
 
     return {
       success: true,
@@ -240,11 +273,18 @@ export async function migrateProjectToGitHub(
       newSessionId: project.session_id ?? '',
     };
   } catch (error) {
-    // Release the migration claim on any failure
-    await db
-      .update(app_builder_projects)
-      .set({ migrated_at: null })
-      .where(eq(app_builder_projects.id, projectId));
+    if (releaseClaimOnFailure) {
+      await db
+        .update(app_builder_projects)
+        .set({ migrated_at: null })
+        .where(
+          and(
+            eq(app_builder_projects.id, projectId),
+            eq(app_builder_projects.migrated_at, claimStartedAt),
+            isNull(app_builder_projects.git_repo_full_name)
+          )
+        );
+    }
 
     if (error instanceof MigrationError) {
       if (error.cause) {

--- a/apps/web/src/lib/app-builder/types.ts
+++ b/apps/web/src/lib/app-builder/types.ts
@@ -137,6 +137,7 @@ export type MigrateToGitHubInput = {
   /** Kilo user ID - needed by preview DO to resolve GitHub tokens */
   userId: string;
   repoFullName: string; // e.g., "org/my-repo" - user-created repo
+  expectedPlatformIntegrationId?: string;
 };
 
 /**

--- a/apps/web/src/routers/app-builder-router.ts
+++ b/apps/web/src/routers/app-builder-router.ts
@@ -235,6 +235,7 @@ export const appBuilderRouter = createTRPCRouter({
       owner,
       userId: ctx.user.id,
       repoFullName: input.repoFullName,
+      expectedPlatformIntegrationId: input.expectedPlatformIntegrationId,
     });
   }),
 });

--- a/apps/web/src/routers/app-builder/schemas.ts
+++ b/apps/web/src/routers/app-builder/schemas.ts
@@ -54,6 +54,7 @@ export const legacySessionMessagesBaseSchema = z.object({
 // User-created repository approach: users provide full repo name (owner/repo)
 export const migrateToGitHubSchema = z.object({
   projectId: z.uuid(),
+  expectedPlatformIntegrationId: z.uuid().optional(),
   repoFullName: z
     .string()
     .min(3)

--- a/apps/web/src/routers/organizations/organization-app-builder-router.ts
+++ b/apps/web/src/routers/organizations/organization-app-builder-router.ts
@@ -281,6 +281,7 @@ export const organizationAppBuilderRouter = createTRPCRouter({
         owner,
         userId: ctx.user.id,
         repoFullName: input.repoFullName,
+        expectedPlatformIntegrationId: input.expectedPlatformIntegrationId,
       });
     }),
 });

--- a/services/app-builder/src/api-schemas.ts
+++ b/services/app-builder/src/api-schemas.ts
@@ -141,19 +141,28 @@ export type DeleteErrorResponse = z.infer<typeof DeleteErrorResponseSchema>;
 
 export const MigrateToGithubRequestSchema = z.object({
   githubRepo: z.string().regex(/^[^/]+\/[^/]+$/, 'Must be in "owner/repo" format'),
-  userId: z.string().uuid(),
+  userId: z.string().min(1),
   orgId: z.string().uuid().optional(),
+  expectedPlatformIntegrationId: z.string().uuid().optional(),
 });
 
 export type MigrateToGithubRequest = z.infer<typeof MigrateToGithubRequestSchema>;
 
 export const MigrateToGithubSuccessResponseSchema = z.object({
   success: z.literal(true),
+  platformIntegrationId: z.string().uuid(),
 });
 
 export const MigrateToGithubErrorResponseSchema = z.object({
   success: z.literal(false),
-  error: z.enum(['invalid_request', 'internal_error', 'token_failed', 'push_failed']),
+  error: z.enum([
+    'invalid_request',
+    'internal_error',
+    'token_failed',
+    'repo_not_found',
+    'repo_not_empty',
+    'push_failed',
+  ]),
   message: z.string(),
 });
 

--- a/services/app-builder/src/handlers/migrate-to-github.test.ts
+++ b/services/app-builder/src/handlers/migrate-to-github.test.ts
@@ -1,0 +1,137 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { handleMigrateToGithub } from './migrate-to-github';
+import type { Env, GetTokenForRepoResult } from '../types';
+
+const expectedPlatformIntegrationId = '123e4567-e89b-12d3-a456-426614174002';
+const resolvedPlatformIntegrationId = '123e4567-e89b-12d3-a456-426614174003';
+const orgId = '123e4567-e89b-12d3-a456-426614174001';
+
+function createEnv(tokenResult: GetTokenForRepoResult) {
+  const getTokenForRepo = vi.fn().mockResolvedValue(tokenResult);
+  const gitStub = {
+    isInitialized: vi.fn().mockResolvedValue(true),
+    pushToRemote: vi.fn().mockResolvedValue({ success: true }),
+    scheduleDelete: vi.fn().mockResolvedValue(undefined),
+  };
+  const previewStub = { setGitHubSource: vi.fn().mockResolvedValue(undefined) };
+  return {
+    env: {
+      AUTH_TOKEN: 'worker-auth',
+      GIT_TOKEN_SERVICE: { getTokenForRepo },
+      GIT_REPOSITORY: {
+        idFromName: vi.fn(() => 'git-id'),
+        get: vi.fn(() => gitStub),
+      },
+      PREVIEW: {
+        idFromName: vi.fn(() => 'preview-id'),
+        get: vi.fn(() => previewStub),
+      },
+    } as unknown as Env,
+    getTokenForRepo,
+    gitStub,
+    previewStub,
+  };
+}
+
+function request(expectedId?: string) {
+  return new Request('https://builder.example.com/apps/app-1/migrate-to-github', {
+    method: 'POST',
+    headers: {
+      Authorization: 'Bearer worker-auth',
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      githubRepo: 'acme/secondary',
+      userId: 'oauth/example-user',
+      orgId,
+      expectedPlatformIntegrationId: expectedId,
+    }),
+  });
+}
+
+const successfulToken: GetTokenForRepoResult = {
+  success: true,
+  token: 'github-token',
+  platformIntegrationId: resolvedPlatformIntegrationId,
+  installationId: 'installation-1',
+  accountLogin: 'acme',
+  appType: 'standard',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 409 })));
+});
+
+describe('migrate-to-github integration identity', () => {
+  it('persists and returns the integration resolved by Git Token Service', async () => {
+    const harness = createEnv(successfulToken);
+
+    const response = await handleMigrateToGithub(request(), harness.env, 'app-1');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toEqual({
+      success: true,
+      platformIntegrationId: resolvedPlatformIntegrationId,
+    });
+    expect(harness.getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: 'acme/secondary',
+      userId: 'oauth/example-user',
+      orgId,
+      expectedIntegrationId: undefined,
+    });
+    expect(harness.previewStub.setGitHubSource).toHaveBeenCalledWith({
+      githubRepo: 'acme/secondary',
+      userId: 'oauth/example-user',
+      orgId,
+      platformIntegrationId: resolvedPlatformIntegrationId,
+    });
+  });
+
+  it('preserves token resolution failures without mutating Git or preview state', async () => {
+    const harness = createEnv({ success: false, reason: 'temporarily_unavailable' });
+
+    const response = await handleMigrateToGithub(request(), harness.env, 'app-1');
+
+    expect(response.status).toBe(500);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'token_failed',
+      message: 'Failed to get GitHub token: temporarily_unavailable',
+    });
+    expect(harness.gitStub.pushToRemote).not.toHaveBeenCalled();
+    expect(harness.previewStub.setGitHubSource).not.toHaveBeenCalled();
+  });
+
+  it('uses an exact selected integration only as a resolution fence', async () => {
+    const harness = createEnv({ success: false, reason: 'integration_mismatch' });
+
+    const response = await handleMigrateToGithub(
+      request(expectedPlatformIntegrationId),
+      harness.env,
+      'app-1'
+    );
+
+    expect(response.status).toBe(500);
+    expect(harness.getTokenForRepo).toHaveBeenCalledWith(
+      expect.objectContaining({ expectedIntegrationId: expectedPlatformIntegrationId })
+    );
+    expect(harness.gitStub.pushToRemote).not.toHaveBeenCalled();
+    expect(harness.previewStub.setGitHubSource).not.toHaveBeenCalled();
+  });
+
+  it('preserves the non-empty repository failure before pushing', async () => {
+    vi.mocked(fetch).mockResolvedValueOnce(Response.json([{ sha: 'existing-commit' }]));
+    const harness = createEnv(successfulToken);
+
+    const response = await handleMigrateToGithub(request(), harness.env, 'app-1');
+
+    expect(response.status).toBe(200);
+    await expect(response.json()).resolves.toMatchObject({
+      success: false,
+      error: 'repo_not_empty',
+    });
+    expect(harness.gitStub.pushToRemote).not.toHaveBeenCalled();
+    expect(harness.previewStub.setGitHubSource).not.toHaveBeenCalled();
+  });
+});

--- a/services/app-builder/src/handlers/migrate-to-github.ts
+++ b/services/app-builder/src/handlers/migrate-to-github.ts
@@ -57,10 +57,15 @@ export async function handleMigrateToGithub(
       );
     }
 
-    const { githubRepo, userId, orgId } = result.data;
+    const { githubRepo, userId, orgId, expectedPlatformIntegrationId } = result.data;
 
     // 1. Fetch a GitHub token via git-token-service
-    const tokenResult = await env.GIT_TOKEN_SERVICE.getTokenForRepo({ githubRepo, userId, orgId });
+    const tokenResult = await env.GIT_TOKEN_SERVICE.getTokenForRepo({
+      githubRepo,
+      userId,
+      orgId,
+      expectedIntegrationId: expectedPlatformIntegrationId,
+    });
     if (!tokenResult.success) {
       logger.error({ source: 'MigrateToGithubHandler', appId }, 'Failed to get GitHub token', {
         reason: tokenResult.reason,
@@ -72,6 +77,75 @@ export async function handleMigrateToGithub(
           message: `Failed to get GitHub token: ${tokenResult.reason}`,
         }),
         { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+
+    const [repoOwner, repoName] = githubRepo.split('/');
+    if (!repoOwner || !repoName) {
+      return Response.json(
+        {
+          success: false,
+          error: 'invalid_request',
+          message: 'Invalid repository name',
+        },
+        { status: 400 }
+      );
+    }
+    try {
+      const commitsResponse = await fetch(
+        `https://api.github.com/repos/${encodeURIComponent(repoOwner)}/${encodeURIComponent(repoName)}/commits?per_page=1`,
+        {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            Authorization: `Bearer ${tokenResult.token}`,
+            'User-Agent': 'Kilo-App-Builder',
+            'X-GitHub-Api-Version': '2022-11-28',
+          },
+        }
+      );
+
+      if (commitsResponse.status === 404) {
+        return Response.json(
+          {
+            success: false,
+            error: 'repo_not_found',
+            message: 'Repository not found',
+          },
+          { status: 200 }
+        );
+      }
+      if (commitsResponse.status !== 409) {
+        if (!commitsResponse.ok) {
+          throw new Error(`GitHub returned ${commitsResponse.status}`);
+        }
+        const commits: unknown = await commitsResponse.json();
+        if (!Array.isArray(commits)) {
+          throw new Error('GitHub returned an invalid commits response');
+        }
+        if (commits.length > 0) {
+          return Response.json(
+            {
+              success: false,
+              error: 'repo_not_empty',
+              message: 'Repository is not empty',
+            },
+            { status: 200 }
+          );
+        }
+      }
+    } catch (error) {
+      logger.error(
+        { source: 'MigrateToGithubHandler', appId },
+        'Failed to validate GitHub repository',
+        formatError(error)
+      );
+      return Response.json(
+        {
+          success: false,
+          error: 'internal_error',
+          message: 'Failed to validate GitHub repository',
+        },
+        { status: 200 }
       );
     }
 
@@ -123,17 +197,28 @@ export async function handleMigrateToGithub(
     const previewId = env.PREVIEW.idFromName(appId);
     const previewStub = env.PREVIEW.get(previewId);
 
-    await previewStub.setGitHubSource({ githubRepo, userId, orgId });
+    await previewStub.setGitHubSource({
+      githubRepo,
+      userId,
+      orgId,
+      platformIntegrationId: tokenResult.platformIntegrationId,
+    });
 
     // Schedule internal git repo deletion after a 7-day grace period (for rollback safety)
     await gitStub.scheduleDelete(7 * 24 * 60 * 60 * 1000);
 
     logger.info({ source: 'MigrateToGithubHandler', appId }, 'Successfully migrated to GitHub');
 
-    return new Response(JSON.stringify({ success: true }), {
-      status: 200,
-      headers: { 'Content-Type': 'application/json' },
-    });
+    return new Response(
+      JSON.stringify({
+        success: true,
+        platformIntegrationId: tokenResult.platformIntegrationId,
+      }),
+      {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      }
+    );
   } catch (error) {
     logger.error(
       { source: 'MigrateToGithubHandler' },

--- a/services/app-builder/src/preview-do.test.ts
+++ b/services/app-builder/src/preview-do.test.ts
@@ -1,0 +1,165 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const sandbox = {
+  exec: vi.fn(),
+  execStream: vi.fn(),
+  gitCheckout: vi.fn(),
+  startProcess: vi.fn(),
+  listProcesses: vi.fn(),
+  destroy: vi.fn(),
+};
+
+vi.mock('cloudflare:workers', () => ({
+  DurableObject: class<Environment> {
+    protected readonly ctx: DurableObjectState;
+    protected readonly env: Environment;
+
+    constructor(ctx: DurableObjectState, env: Environment) {
+      this.ctx = ctx;
+      this.env = env;
+    }
+  },
+}));
+
+vi.mock('@cloudflare/sandbox', () => ({
+  getSandbox: () => sandbox,
+  parseSSEStream: vi.fn(() =>
+    (async function* () {
+      yield { type: 'complete', exitCode: 0, data: '' };
+    })()
+  ),
+}));
+
+vi.mock('./db-provisioner', () => ({
+  DBProvisionResult: { PROVISIONED: 'provisioned', EXISTS: 'exists' },
+  createDBProvisioner: () => ({
+    provisionIfNeeded: vi.fn(async () => 'exists'),
+  }),
+}));
+
+import { PreviewDO } from './preview-do';
+import type { Env, PreviewPersistedState } from './types';
+
+function createStorage(initialState?: PreviewPersistedState) {
+  const values = new Map<string, unknown>();
+  if (initialState) values.set('state', initialState);
+  return {
+    values,
+    get: vi.fn(async (key: string) => values.get(key)),
+    put: vi.fn(async (key: string, value: unknown) => {
+      values.set(key, structuredClone(value));
+    }),
+    deleteAll: vi.fn(async () => values.clear()),
+  };
+}
+
+function createPreview(
+  storage: ReturnType<typeof createStorage>,
+  getTokenForRepo: ReturnType<typeof vi.fn>
+) {
+  const startup: Promise<unknown>[] = [];
+  const waits: Promise<unknown>[] = [];
+  const ctx = {
+    id: { name: 'app-1' },
+    storage,
+    blockConcurrencyWhile: vi.fn((callback: () => Promise<unknown>) => {
+      const promise = callback();
+      startup.push(promise);
+      return promise;
+    }),
+    waitUntil: vi.fn((promise: Promise<unknown>) => waits.push(promise)),
+  } as unknown as DurableObjectState;
+  const env = {
+    SANDBOX: {},
+    GIT_TOKEN_SERVICE: { getTokenForRepo },
+    BUILDER_HOSTNAME: 'builder.example.com',
+    GIT_JWT_SECRET: 'test-secret',
+  } as unknown as Env;
+  return { preview: new PreviewDO(ctx, env), startup, waits };
+}
+
+const source = {
+  githubRepo: 'acme/secondary',
+  userId: 'oauth/example-user',
+  orgId: '123e4567-e89b-12d3-a456-426614174001',
+  platformIntegrationId: '123e4567-e89b-12d3-a456-426614174002',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  sandbox.exec.mockImplementation(async (command: string) =>
+    command === 'test -d /workspace/.git'
+      ? { exitCode: 1, success: false, stderr: '' }
+      : { exitCode: 0, success: true, stderr: '' }
+  );
+  sandbox.gitCheckout.mockResolvedValue({ success: true });
+  sandbox.execStream.mockResolvedValue({});
+  sandbox.startProcess.mockResolvedValue(undefined);
+  sandbox.listProcesses.mockResolvedValue([]);
+  sandbox.destroy.mockResolvedValue(undefined);
+});
+
+describe('PreviewDO GitHub source identity', () => {
+  it('persists the resolved integration and reuses it after restart', async () => {
+    const storage = createStorage();
+    const first = createPreview(storage, vi.fn());
+    await Promise.all(first.startup);
+    await first.preview.initWithAppId('app-1');
+    await first.preview.setGitHubSource(source);
+
+    expect((storage.values.get('state') as PreviewPersistedState).githubSource).toEqual(source);
+
+    const restartedTokenLookup = vi.fn().mockResolvedValue({
+      success: true,
+      token: 'github-token',
+      platformIntegrationId: source.platformIntegrationId,
+      installationId: 'installation-2',
+      accountLogin: 'acme',
+      appType: 'lite',
+    });
+    const restarted = createPreview(storage, restartedTokenLookup);
+    await Promise.all(restarted.startup);
+    await restarted.preview.triggerBuild();
+    await Promise.all(restarted.waits);
+
+    expect(restartedTokenLookup).toHaveBeenCalledWith({
+      githubRepo: source.githubRepo,
+      userId: source.userId,
+      orgId: source.orgId,
+      expectedIntegrationId: source.platformIntegrationId,
+    });
+  });
+
+  it('keeps legacy unpinned state readable and lets authoritative resolution fail closed', async () => {
+    const storage = createStorage({
+      appId: 'app-1',
+      lastError: null,
+      dbCredentials: null,
+      githubSource: {
+        githubRepo: source.githubRepo,
+        userId: source.userId,
+        orgId: source.orgId,
+      },
+    });
+    const getTokenForRepo = vi.fn().mockResolvedValue({
+      success: false,
+      reason: 'ambiguous_installation',
+    });
+    const { preview, startup, waits } = createPreview(storage, getTokenForRepo);
+    await Promise.all(startup);
+    await preview.triggerBuild();
+    await expect(Promise.all(waits)).rejects.toThrow(
+      'Failed to get GitHub token: ambiguous_installation'
+    );
+
+    expect(getTokenForRepo).toHaveBeenCalledWith({
+      githubRepo: source.githubRepo,
+      userId: source.userId,
+      orgId: source.orgId,
+      expectedIntegrationId: undefined,
+    });
+    expect((storage.values.get('state') as PreviewPersistedState).lastError).toBe(
+      'Failed to get GitHub token: ambiguous_installation'
+    );
+  });
+});

--- a/services/app-builder/src/preview-do.ts
+++ b/services/app-builder/src/preview-do.ts
@@ -201,13 +201,14 @@ export class PreviewDO extends DurableObject<Env> {
   private async getRepoUrl(repoId: string): Promise<string> {
     // Check if project is migrated to GitHub
     if (this.persistedState.githubSource) {
-      const { githubRepo, userId, orgId } = this.persistedState.githubSource;
+      const { githubRepo, userId, orgId, platformIntegrationId } = this.persistedState.githubSource;
 
       // Get fresh token from git-token-service
       const result: GetTokenForRepoResult = await this.env.GIT_TOKEN_SERVICE.getTokenForRepo({
         githubRepo,
         userId,
         orgId,
+        expectedIntegrationId: platformIntegrationId,
       });
 
       if (!result.success) {

--- a/services/app-builder/src/types.ts
+++ b/services/app-builder/src/types.ts
@@ -55,6 +55,7 @@ type GitTokenService = {
     githubRepo: string;
     userId: string;
     orgId?: string;
+    expectedIntegrationId?: string;
   }): Promise<GetTokenForRepoResult>;
 
   /**
@@ -173,6 +174,7 @@ export type GitHubSourceConfig = {
   githubRepo: string; // "owner/repo" format
   userId: string; // Kilo user ID for token lookup
   orgId?: string; // Kilo org ID (if org-owned project)
+  platformIntegrationId?: string;
 };
 
 /**


### PR DESCRIPTION
## Why

App Builder performs direct Git operations and preview work survives restarts. Migration must resolve one installation authoritatively, persist it, and reuse it for every later clone or rebuild. Cached web metadata is not sufficient.

A migration can also perform an irreversible Git push before the web process receives its result. Concurrent requests therefore need one exclusive database claim before any request reaches the Worker; a lost response must not release that claim and permit a second push.

## Dependency

Depends on #5584.

## What changes

- Atomically acquire an exclusive migration claim only while both `migrated_at` and `git_repo_full_name` are unset.
- Allow only the claim winner to call the migration Worker; concurrent losers fail without pushing.
- Bind finalization and claim release to the exact claim timestamp so one request cannot finalize or release another request claim.
- Replay a completed retry only when repository and optional integration fence match the persisted result.
- Release the claim only for definitive pre-push failures; retain it after ambiguous Worker failures where a push may already have happened.
- Resolve migration `owner/repo` through Git Token Service.
- Treat optional selected `platformIntegrationId` as an exact fence.
- Persist the returned identity on PreviewDO, project, and deployment state.
- Reuse it for preview clone, fetch or rebuild, and restart token requests.
- Keep old unpinned preview state readable with authoritative fail-closed resolution.

## What this removes

No #5547 cached web resolver or resolver tests. Empty-repository validation now occurs in the Worker using the authoritative token.

## Review guide

1. Review the exclusive claim predicate, claim ownership token, and concurrent winner or loser tests in `github-migration-service.ts`.
2. Review which definitive failures release the claim and why ambiguous responses retain it.
3. Trace the Git Token Service result through the migration response into PreviewDO, project, and deployment state.
4. Verify later token calls use the persisted integration as an exact fence.

## Validation

- 46 App Builder tests
- Exclusive concurrent-claim, retry, conflicting-fence, owned-release, and ambiguous-response coverage
- App Builder and web typecheck or lint
- `git diff --check`