### PR TITLE
feat(app-builder): choose the destination GitHub installation

### DIFF
--- a/apps/web/src/components/app-builder/MigrateToGitHubDialog.tsx
+++ b/apps/web/src/components/app-builder/MigrateToGitHubDialog.tsx
@@ -36,8 +36,21 @@ import {
   DialogTrigger,
   DialogFooter,
 } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import { RepositoryCombobox, type RepositoryOption } from '@/components/shared/RepositoryCombobox';
-import type { CanMigrateToGitHubResult, MigrateToGitHubErrorCode } from '@/lib/app-builder/types';
+import type {
+  CanMigrateToGitHubResult,
+  GitHubMigrationTarget,
+  MigrateToGitHubErrorCode,
+} from '@/lib/app-builder/types';
+import { getMigrationTargetLabel, resolveMigrationTarget } from './migration-target-selector';
 
 type MigrateToGitHubDialogProps = {
   projectId: string;
@@ -70,6 +83,7 @@ export function MigrateToGitHubDialog({
   const [isOpen, setIsOpen] = useState(false);
   const [step, setStep] = useState<Step>('create');
   const [selectedRepo, setSelectedRepo] = useState<string>('');
+  const [pinnedTarget, setPinnedTarget] = useState<GitHubMigrationTarget>();
 
   const [migrationResult, setMigrationResult] = useState<{
     success: true;
@@ -96,6 +110,9 @@ export function MigrateToGitHubDialog({
 
   const canMigrateQuery = organizationId ? orgCanMigrateQuery : personalCanMigrateQuery;
   const canMigrateData: CanMigrateToGitHubResult | undefined = canMigrateQuery.data;
+  const migrationTargets = canMigrateData?.migrationTargets ?? [];
+  const { target: selectedTarget, isUnavailable: selectedTargetIsUnavailable } =
+    resolveMigrationTarget(migrationTargets, pinnedTarget);
 
   // Migration mutations for personal/org context
   const handleMigrationSuccess = useCallback(
@@ -148,13 +165,29 @@ export function MigrateToGitHubDialog({
   // Map available repos to RepositoryCombobox format
   const repositoryOptions: RepositoryOption[] = useMemo(
     () =>
-      (canMigrateData?.availableRepos ?? []).map(repo => ({
-        id: repo.fullName,
+      (selectedTargetIsUnavailable ? [] : (selectedTarget?.availableRepos ?? [])).map(repo => ({
+        id: `${selectedTarget?.platformIntegrationId}:${repo.fullName}`,
         fullName: repo.fullName,
         private: repo.isPrivate,
         platform: 'github' as const,
+        platformIntegrationId: selectedTarget?.platformIntegrationId,
+        platformAccountLogin: selectedTarget?.platformAccountLogin,
       })),
-    [canMigrateData?.availableRepos]
+    [selectedTarget, selectedTargetIsUnavailable]
+  );
+
+  const handleTargetChange = useCallback(
+    (platformIntegrationId: string) => {
+      const target = migrationTargets.find(
+        candidate => candidate.platformIntegrationId === platformIntegrationId
+      );
+      if (!target) return;
+
+      setPinnedTarget(target);
+      setSelectedRepo('');
+      setMigrationError(null);
+    },
+    [migrationTargets]
   );
 
   const handleOpenChange = useCallback(
@@ -164,6 +197,7 @@ export function MigrateToGitHubDialog({
         // Reset state when closing
         setStep('create');
         setSelectedRepo('');
+        setPinnedTarget(undefined);
         setMigrationResult(null);
         setMigrationError(null);
         reset();
@@ -188,28 +222,43 @@ export function MigrateToGitHubDialog({
   }, [organizationId, queryClient, trpc, projectId]);
 
   const handleMigrate = useCallback(() => {
-    if (!selectedRepo) return;
+    if (!selectedRepo || !selectedTarget || selectedTargetIsUnavailable) return;
 
     setMigrationError(null);
+    const expectedPlatformIntegrationId = selectedTarget.platformIntegrationId;
 
     if (organizationId) {
-      orgMigrate({ projectId, organizationId, repoFullName: selectedRepo });
+      orgMigrate({
+        projectId,
+        organizationId,
+        repoFullName: selectedRepo,
+        expectedPlatformIntegrationId,
+      });
     } else {
-      personalMigrate({ projectId, repoFullName: selectedRepo });
+      personalMigrate({ projectId, repoFullName: selectedRepo, expectedPlatformIntegrationId });
     }
-  }, [organizationId, orgMigrate, personalMigrate, projectId, selectedRepo]);
+  }, [
+    organizationId,
+    orgMigrate,
+    personalMigrate,
+    projectId,
+    selectedRepo,
+    selectedTarget,
+    selectedTargetIsUnavailable,
+  ]);
 
   // Skip grant-access step if user has "all repositories" access
-  const needsGrantAccess = canMigrateData?.repositorySelection === 'selected';
+  const needsGrantAccess = selectedTarget?.repositorySelection === 'selected';
 
   const handleNext = useCallback(() => {
     if (step === 'create') {
+      if (selectedTarget) setPinnedTarget(selectedTarget);
       // Skip grant-access step if user has access to all repos
       setStep(needsGrantAccess ? 'grant-access' : 'select');
     } else if (step === 'grant-access') {
       setStep('select');
     }
-  }, [step, needsGrantAccess]);
+  }, [step, needsGrantAccess, selectedTarget]);
 
   const handleBack = useCallback(() => {
     if (step === 'grant-access') {
@@ -308,6 +357,41 @@ export function MigrateToGitHubDialog({
           {/* Step 1: Create Repository */}
           {canMigrate && step === 'create' && (
             <div className="space-y-4">
+              {(migrationTargets.length > 1 || selectedTargetIsUnavailable) && selectedTarget && (
+                <div className="space-y-2">
+                  <Label htmlFor="github-migration-target">GitHub installation</Label>
+                  <Select
+                    value={selectedTarget.platformIntegrationId}
+                    onValueChange={handleTargetChange}
+                  >
+                    <SelectTrigger
+                      id="github-migration-target"
+                      className="h-11 w-full font-mono sm:h-control-default"
+                    >
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {selectedTargetIsUnavailable && (
+                        <SelectItem value={selectedTarget.platformIntegrationId} disabled>
+                          {getMigrationTargetLabel(selectedTarget, migrationTargets)} (unavailable)
+                        </SelectItem>
+                      )}
+                      {migrationTargets.map(target => (
+                        <SelectItem
+                          key={target.platformIntegrationId}
+                          value={target.platformIntegrationId}
+                        >
+                          {getMigrationTargetLabel(target, migrationTargets)}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <p className="text-muted-foreground text-xs">
+                    Choose where to create and migrate the repository.
+                  </p>
+                </div>
+              )}
+
               <div className="rounded-md border p-4">
                 <h4 className="font-medium">Create an empty repository</h4>
                 <p className="text-muted-foreground mt-1 text-sm">
@@ -333,7 +417,11 @@ export function MigrateToGitHubDialog({
               </div>
 
               <Button asChild className="w-full gap-2">
-                <a href={canMigrateData.newRepoUrl} target="_blank" rel="noopener noreferrer">
+                <a
+                  href={selectedTarget?.newRepoUrl ?? canMigrateData.newRepoUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                >
                   <Github className="h-4 w-4" />
                   Create Repository on GitHub
                   <ExternalLink className="h-3 w-3" />
@@ -357,10 +445,14 @@ export function MigrateToGitHubDialog({
                 </p>
               </div>
 
-              {canMigrateData.installationSettingsUrl && (
+              {(selectedTarget?.installationSettingsUrl ??
+                canMigrateData.installationSettingsUrl) && (
                 <Button asChild variant="outline" className="w-full gap-2">
                   <a
-                    href={canMigrateData.installationSettingsUrl}
+                    href={
+                      selectedTarget?.installationSettingsUrl ??
+                      canMigrateData.installationSettingsUrl
+                    }
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -381,6 +473,18 @@ export function MigrateToGitHubDialog({
                 <div className="flex items-start gap-3 rounded-md bg-red-500/10 p-4 text-sm text-red-400">
                   <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
                   <span>{errorMessages[migrationError]}</span>
+                </div>
+              )}
+
+              {selectedTargetIsUnavailable && (
+                <div className="flex items-start gap-3 rounded-md bg-yellow-500/10 p-4 text-sm text-yellow-400">
+                  <AlertCircle className="mt-0.5 h-4 w-4 shrink-0" />
+                  <div>
+                    <p>The selected GitHub installation is no longer available.</p>
+                    <p className="text-muted-foreground mt-1">
+                      Select another installation or refresh after restoring access.
+                    </p>
+                  </div>
                 </div>
               )}
 
@@ -407,7 +511,8 @@ export function MigrateToGitHubDialog({
                   onClick={handleRefreshRepos}
                   disabled={canMigrateQuery.isFetching || isPending}
                   title="Refresh repository list"
-                  className="mb-6 shrink-0"
+                  aria-label="Refresh repository list"
+                  className="mb-6 size-11 shrink-0 sm:size-control-default"
                 >
                   <RefreshCw
                     className={`h-4 w-4 ${canMigrateQuery.isFetching ? 'animate-spin' : ''}`}
@@ -461,7 +566,7 @@ export function MigrateToGitHubDialog({
             {step === 'select' ? (
               <Button
                 onClick={handleMigrate}
-                disabled={isPending || !selectedRepo}
+                disabled={isPending || !selectedRepo || selectedTargetIsUnavailable}
                 className="gap-2"
               >
                 {isPending ? (

--- a/apps/web/src/components/app-builder/migration-target-selector.test.ts
+++ b/apps/web/src/components/app-builder/migration-target-selector.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from '@jest/globals';
+import type { GitHubMigrationTarget } from '@/lib/app-builder/types';
+import { getMigrationTargetLabel, resolveMigrationTarget } from './migration-target-selector';
+
+function target(
+  platformIntegrationId: string,
+  platformAccountLogin: string,
+  githubAppType: 'standard' | 'lite'
+): GitHubMigrationTarget {
+  return {
+    platformIntegrationId,
+    platformAccountLogin,
+    githubAppType,
+    newRepoUrl: `https://github.com/organizations/${platformAccountLogin}/repositories/new`,
+    installationSettingsUrl: `https://github.com/settings/installations/${platformIntegrationId}`,
+    availableRepos: [],
+    repositorySelection: 'all',
+  };
+}
+
+describe('App Builder migration target selection', () => {
+  it('selects a secondary installation by integration identity', () => {
+    const primary = target('integration-standard', 'acme-core', 'standard');
+    const secondary = target('integration-lite', 'acme-apps', 'lite');
+
+    expect(resolveMigrationTarget([primary, secondary], secondary)).toEqual({
+      target: secondary,
+      isUnavailable: false,
+    });
+  });
+
+  it('keeps an unavailable pin instead of falling back to another installation', () => {
+    const available = target('integration-standard', 'acme-core', 'standard');
+    const unavailable = target('integration-lite', 'acme-apps', 'lite');
+
+    expect(resolveMigrationTarget([available], unavailable)).toEqual({
+      target: unavailable,
+      isUnavailable: true,
+    });
+  });
+
+  it('distinguishes duplicate account names by Standard and Lite app type', () => {
+    const standard = target('integration-standard', 'acme', 'standard');
+    const lite = target('integration-lite', 'acme', 'lite');
+
+    expect(getMigrationTargetLabel(standard, [standard, lite])).toBe('acme (Standard app)');
+    expect(getMigrationTargetLabel(lite, [standard, lite])).toBe('acme (Lite app)');
+  });
+});

--- a/apps/web/src/components/app-builder/migration-target-selector.ts
+++ b/apps/web/src/components/app-builder/migration-target-selector.ts
@@ -1,0 +1,32 @@
+import type { GitHubMigrationTarget } from '@/lib/app-builder/types';
+
+export function resolveMigrationTarget(
+  targets: GitHubMigrationTarget[],
+  pinnedTarget?: GitHubMigrationTarget
+): { target: GitHubMigrationTarget | undefined; isUnavailable: boolean } {
+  if (!pinnedTarget) {
+    return { target: targets[0], isUnavailable: false };
+  }
+
+  const currentTarget = targets.find(
+    target => target.platformIntegrationId === pinnedTarget.platformIntegrationId
+  );
+  return {
+    target: currentTarget ?? pinnedTarget,
+    isUnavailable: currentTarget === undefined,
+  };
+}
+
+export function getMigrationTargetLabel(
+  target: GitHubMigrationTarget,
+  targets: GitHubMigrationTarget[]
+): string {
+  const duplicateAccount = targets.some(
+    candidate =>
+      candidate.platformIntegrationId !== target.platformIntegrationId &&
+      candidate.platformAccountLogin.toLowerCase() === target.platformAccountLogin.toLowerCase()
+  );
+  if (!duplicateAccount) return target.platformAccountLogin;
+
+  return `${target.platformAccountLogin} (${target.githubAppType === 'lite' ? 'Lite app' : 'Standard app'})`;
+}

--- a/apps/web/src/lib/app-builder/github-migration-service.ts
+++ b/apps/web/src/lib/app-builder/github-migration-service.ts
@@ -2,7 +2,7 @@ import 'server-only';
 import type { Owner } from '@/lib/integrations/core/types';
 import * as appBuilderClient from '@/lib/app-builder/app-builder-client';
 import { db } from '@/lib/drizzle';
-import { app_builder_projects, deployments } from '@kilocode/db/schema';
+import { app_builder_projects, deployments, type PlatformIntegration } from '@kilocode/db/schema';
 import { eq, and, isNull } from 'drizzle-orm';
 import {
   fetchGitHubInstallationDetails,
@@ -10,13 +10,18 @@ import {
   getInstallationSettingsUrl,
 } from '@/lib/integrations/platforms/github/adapter';
 import { INTEGRATION_STATUS, PLATFORM } from '@/lib/integrations/core/constants';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
+import {
+  getIntegrationForOwner,
+  getIntegrationsByOrganization,
+} from '@/lib/integrations/db/platform-integrations';
+import { isPlatformIntegrationHealthy } from '@/lib/integrations/core/health';
 import { getProjectWithOwnershipCheck } from '@/lib/app-builder/project-ownership';
 import type {
   MigrateToGitHubInput,
   MigrateToGitHubResult,
   MigrateToGitHubErrorCode,
   CanMigrateToGitHubResult,
+  GitHubMigrationTarget,
 } from '@/lib/app-builder/types';
 
 class MigrationError extends Error {
@@ -27,6 +32,37 @@ class MigrationError extends Error {
     super(`Migration failed: ${code}`, options);
     this.name = 'MigrationError';
   }
+}
+
+function getGitHubAppType(integration: PlatformIntegration): 'standard' | 'lite' {
+  return integration.github_app_type ?? 'standard';
+}
+
+function getNewRepositoryUrl(accountLogin: string, accountType: string): string {
+  return accountType === 'Organization'
+    ? `https://github.com/organizations/${accountLogin}/repositories/new`
+    : 'https://github.com/new';
+}
+
+async function getMigrationIntegrations(owner: Owner): Promise<PlatformIntegration[]> {
+  if (owner.type === 'user') {
+    const integration = await getIntegrationForOwner(
+      owner,
+      PLATFORM.GITHUB,
+      INTEGRATION_STATUS.ACTIVE
+    );
+    return integration?.platform_installation_id && isPlatformIntegrationHealthy(integration)
+      ? [integration]
+      : [];
+  }
+
+  const integrations = await getIntegrationsByOrganization(owner.id, PLATFORM.GITHUB);
+  return integrations.filter(
+    integration =>
+      integration.integration_type === 'app' &&
+      integration.platform_installation_id !== null &&
+      isPlatformIntegrationHealthy(integration)
+  );
 }
 
 /** Convert a project title to a valid GitHub repository name. */
@@ -63,6 +99,7 @@ export async function canMigrateToGitHub(
     installationSettingsUrl: '',
     availableRepos: [],
     repositorySelection: 'all',
+    migrationTargets: [],
   };
 
   // Check if already migrated
@@ -76,43 +113,46 @@ export async function canMigrateToGitHub(
       installationSettingsUrl: '',
       availableRepos: [],
       repositorySelection: 'all',
+      migrationTargets: [],
     };
   }
 
-  // Check for GitHub integration
-  const integration = await getIntegrationForOwner(
-    owner,
-    PLATFORM.GITHUB,
-    INTEGRATION_STATUS.ACTIVE
-  );
-
-  if (!integration || !integration.platform_installation_id) {
+  const integrations = await getMigrationIntegrations(owner);
+  const integration = integrations[0];
+  if (!integration) {
     return noIntegrationResult;
   }
 
-  // Fetch installation details and available repos in parallel
-  const installationId = integration.platform_installation_id;
   let targetAccountName = integration.platform_account_login ?? null;
   let installationSettingsUrl = '';
-  let availableRepos: CanMigrateToGitHubResult['availableRepos'] = [];
-  let accountType = 'User';
-  let repositorySelection: 'all' | 'selected' = 'all';
+  const integrationData = await Promise.all(
+    integrations.map(async candidate => {
+      const installationId = candidate.platform_installation_id;
+      if (!installationId) return null;
 
-  try {
-    const [installationDetails, settingsUrl, repos] = await Promise.all([
-      fetchGitHubInstallationDetails(installationId),
-      getInstallationSettingsUrl(installationId),
-      fetchGitHubRepositories(installationId),
-    ]);
+      const appType = getGitHubAppType(candidate);
+      try {
+        const [installationDetails, settingsUrl, repos] = await Promise.all([
+          fetchGitHubInstallationDetails(installationId, appType),
+          getInstallationSettingsUrl(installationId, appType),
+          fetchGitHubRepositories(installationId, appType),
+        ]);
+        return { integration: candidate, installationDetails, settingsUrl, repos };
+      } catch (error) {
+        console.error('Failed to fetch GitHub installation details:', error);
+        return null;
+      }
+    })
+  );
 
-    targetAccountName = installationDetails.account.login || targetAccountName;
-    accountType = installationDetails.account.type;
-    repositorySelection =
-      installationDetails.repository_selection === 'selected' ? 'selected' : 'all';
-    installationSettingsUrl = settingsUrl;
+  const migrationTargets = integrationData.flatMap<GitHubMigrationTarget>(data => {
+    if (!data) return [];
 
-    // Map to AvailableRepo shape, sort newest first, take last 10
-    availableRepos = repos
+    const platformAccountLogin =
+      data.installationDetails.account.login || data.integration.platform_account_login;
+    if (!platformAccountLogin) return [];
+
+    const availableRepos = data.repos
       .map(repo => ({
         fullName: repo.full_name,
         createdAt: repo.created_at,
@@ -120,28 +160,45 @@ export async function canMigrateToGitHub(
       }))
       .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
       .slice(0, 10);
-  } catch (error) {
-    console.error('Failed to fetch GitHub installation details:', error);
-    // Continue with partial data
+
+    return [
+      {
+        platformIntegrationId: data.integration.id,
+        platformAccountLogin,
+        githubAppType: getGitHubAppType(data.integration),
+        newRepoUrl: getNewRepositoryUrl(
+          platformAccountLogin,
+          data.installationDetails.account.type
+        ),
+        installationSettingsUrl: data.settingsUrl,
+        availableRepos,
+        repositorySelection:
+          data.installationDetails.repository_selection === 'selected' ? 'selected' : 'all',
+      },
+    ];
+  });
+
+  const primaryTarget = migrationTargets[0];
+  if (primaryTarget) {
+    targetAccountName = primaryTarget.platformAccountLogin;
+    installationSettingsUrl = primaryTarget.installationSettingsUrl;
   }
 
-  // Build the URL for creating a new repo
-  // For orgs: https://github.com/organizations/{org}/repositories/new
-  // For users: https://github.com/new
-  const newRepoUrl =
-    accountType === 'Organization' && targetAccountName
-      ? `https://github.com/organizations/${targetAccountName}/repositories/new`
-      : 'https://github.com/new';
+  const availableRepos = migrationTargets
+    .flatMap(target => target.availableRepos)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
+    .slice(0, 10);
 
   return {
     hasGitHubIntegration: true,
     targetAccountName,
     alreadyMigrated: false,
     suggestedRepoName,
-    newRepoUrl,
+    newRepoUrl: primaryTarget?.newRepoUrl ?? 'https://github.com/new',
     installationSettingsUrl,
     availableRepos,
-    repositorySelection,
+    repositorySelection: primaryTarget?.repositorySelection ?? 'all',
+    migrationTargets,
   };
 }
 

--- a/apps/web/src/lib/app-builder/types.ts
+++ b/apps/web/src/lib/app-builder/types.ts
@@ -165,6 +165,16 @@ export type AvailableRepo = {
   isPrivate: boolean;
 };
 
+export type GitHubMigrationTarget = {
+  platformIntegrationId: string;
+  platformAccountLogin: string;
+  githubAppType: 'standard' | 'lite';
+  newRepoUrl: string;
+  installationSettingsUrl: string;
+  availableRepos: AvailableRepo[];
+  repositorySelection: 'all' | 'selected';
+};
+
 /**
  * Pre-flight check result for GitHub migration
  * User-created repository approach: returns info needed to guide user through creating repo
@@ -186,4 +196,6 @@ export type CanMigrateToGitHubResult = {
   availableRepos: AvailableRepo[];
   /** Whether the GitHub App has access to all repos ('all') or only selected repos ('selected') */
   repositorySelection: 'all' | 'selected';
+  /** Healthy GitHub installations available as migration targets */
+  migrationTargets: GitHubMigrationTarget[];
 };


### PR DESCRIPTION
## Why
#5597 resolves and persists migration identity authoritatively in the Worker. This child exposes an explicit destination choice and sends it as an exact fence.

## Dependency
Depends on #5597.

## What changes
- List healthy migration targets across installations.
- Select by account/integration/app type.
- Distinguish duplicate account labels.
- Preserve unavailable pins rather than falling back.
- Submit expectedPlatformIntegrationId.

## What this removes
Does not restore the old web cached resolver or its deleted tests.

## Validation
- Changed-project typechecks/lint/format
- Focused selector tests
- `git diff --check`