### PR TITLE
feat(mobile): distinguish GitHub installs without authorizing in the client

### DIFF
--- a/apps/mobile/src/app/(app)/agent-chat/repo-picker.tsx
+++ b/apps/mobile/src/app/(app)/agent-chat/repo-picker.tsx
@@ -10,12 +10,12 @@ import { EmptyState } from '@/components/empty-state';
 import { PickerSheet } from '@/components/picker-sheet';
 import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
-import { REPO_PLATFORM_LABEL_KEYS, type RepoOption } from '@/lib/picker-bridge';
+import { getRepoOptionKey, REPO_PLATFORM_LABEL_KEYS, type RepoOption } from '@/lib/picker-bridge';
 import { repoPickerSlot, UNFENCED_ROUTE_KEY, useRouteRegistry } from '@/lib/route-registry';
-import { filterRepoPickerOptions } from '@/lib/repo-picker-filter';
+import { filterRepoPickerOptions, groupRepoPickerOptions } from '@/lib/repo-picker-filter';
 
 type PickerListItem =
-  | { key: string; kind: 'header'; titleKey: string }
+  | { key: string; kind: 'header'; title?: string; titleKey?: string }
   | { key: string; kind: 'repo'; repo: RepoOption };
 
 export default function RepoPickerScreen() {
@@ -56,20 +56,18 @@ export default function RepoPickerScreen() {
   // per-provider); when it is non-empty, render the flat filtered list exactly
   // as before.
   const listItems = useMemo<PickerListItem[]>(() => {
-    if (search.trim()) {
-      return filtered.map(repo => ({
-        key: `${repo.platform}:${repo.fullName}`,
-        kind: 'repo',
-        repo,
-      }));
-    }
-    const sections = bridge?.sections ?? [];
+    const sections = search.trim() ? groupRepoPickerOptions(filtered) : (bridge?.sections ?? []);
     const items: PickerListItem[] = [];
     for (const section of sections) {
       if (section.repos.length > 0) {
-        items.push({ key: `header:${section.key}`, kind: 'header', titleKey: section.titleKey });
+        items.push({
+          key: `header:${section.key}`,
+          kind: 'header',
+          title: section.title,
+          titleKey: section.titleKey,
+        });
         for (const repo of section.repos) {
-          items.push({ key: `${repo.platform}:${repo.fullName}`, kind: 'repo', repo });
+          items.push({ key: getRepoOptionKey(repo), kind: 'repo', repo });
         }
       }
     }
@@ -144,7 +142,7 @@ export default function RepoPickerScreen() {
           if (item.kind === 'header') {
             return (
               <Text className="px-4 pt-4 pb-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                {t(item.titleKey)}
+                {item.title ?? (item.titleKey ? t(item.titleKey) : '')}
               </Text>
             );
           }
@@ -155,7 +153,7 @@ export default function RepoPickerScreen() {
             <Pressable
               className="flex-row items-center gap-3 border-b border-border px-4 py-3 active:bg-secondary will-change-pressable"
               onPress={() => {
-                handleSelect(`${repo.platform}:${repo.fullName}`);
+                handleSelect(getRepoOptionKey(repo));
               }}
               accessibilityRole="button"
               accessibilityLabel={rowLabel}
@@ -174,7 +172,7 @@ export default function RepoPickerScreen() {
               <Text className="flex-1 text-base text-foreground" numberOfLines={1}>
                 {repo.fullName}
               </Text>
-              {bridge.currentValue === `${repo.platform}:${repo.fullName}` ? (
+              {bridge.currentValue === getRepoOptionKey(repo) ? (
                 <Check size={18} color={colors.primary} />
               ) : null}
             </Pressable>

--- a/apps/mobile/src/components/agents/new-session-prefill.test.ts
+++ b/apps/mobile/src/components/agents/new-session-prefill.test.ts
@@ -243,6 +243,14 @@ describe('resolvePrefillRepo', () => {
     expect(result).toBe('Kilo-Org/cloud');
   });
 
+  it('returns null when multiple options match case-insensitively', () => {
+    const result = resolvePrefillRepo(
+      [{ fullName: 'Kilo-Org/cloud' }, { fullName: 'kilo-org/CLOUD' }],
+      { mode: 'code', repo: 'KILO-ORG/cloud' }
+    );
+    expect(result).toBeNull();
+  });
+
   it.each([
     { repo: 'other/repo', reposOverride: undefined, desc: 'no match' },
     { repo: 'Kilo-Org/cloud', reposOverride: [] as { fullName: string }[], desc: 'empty list' },
@@ -265,12 +273,12 @@ describe('resolvePrefillRepoSelection', () => {
     { platform: 'github', fullName: 'Kilo-Org/cloud' },
   ];
 
-  it('selects the GitHub row and never a same-named GitLab/Bitbucket row', () => {
+  it('returns a personal or legacy GitHub row key without provenance', () => {
     const result = resolvePrefillRepoSelection(repos, { mode: 'code', repo: 'kilo-org/cloud' });
     expect(result).toBe('github:Kilo-Org/cloud');
   });
 
-  it('returns the GitHub row when only the GitLab row shares the name', () => {
+  it('returns the GitHub row key when only other providers share the name', () => {
     const result = resolvePrefillRepoSelection(
       [
         { platform: 'gitlab', fullName: 'owner/repo' },
@@ -289,9 +297,37 @@ describe('resolvePrefillRepoSelection', () => {
     expect(result).toBeNull();
   });
 
-  it('matches case-insensitively and returns the canonical GitHub casing', () => {
-    const result = resolvePrefillRepoSelection(repos, { mode: 'code', repo: 'kilo-Org/Cloud' });
-    expect(result).toBe('github:Kilo-Org/cloud');
+  it('matches case-insensitively and returns organization provenance with canonical casing', () => {
+    const result = resolvePrefillRepoSelection(
+      [
+        {
+          platform: 'github',
+          fullName: 'Kilo-Org/Cloud',
+          platformIntegrationId: 'integration-1',
+        },
+      ],
+      { mode: 'code', repo: 'kilo-org/cloud' }
+    );
+    expect(result).toBe('github:integration-1:Kilo-Org/Cloud');
+  });
+
+  it('returns null for duplicate GitHub names with explicit integration ids', () => {
+    const result = resolvePrefillRepoSelection(
+      [
+        {
+          platform: 'github',
+          fullName: 'Kilo-Org/cloud',
+          platformIntegrationId: 'integration-1',
+        },
+        {
+          platform: 'github',
+          fullName: 'kilo-org/CLOUD',
+          platformIntegrationId: 'integration-2',
+        },
+      ],
+      { mode: 'code', repo: 'KILO-ORG/cloud' }
+    );
+    expect(result).toBeNull();
   });
 
   it.each([

--- a/apps/mobile/src/components/agents/new-session-prefill.ts
+++ b/apps/mobile/src/components/agents/new-session-prefill.ts
@@ -1,6 +1,7 @@
 import { type AgentMode, normalizeAgentMode } from '@/components/agents/mode-normalize';
 import { formatGitUrlProject } from '@/components/agents/session-list-helpers';
 import { i18n } from '@/i18n';
+import { getRepoOptionKey } from '@/lib/picker-bridge';
 
 export type NewSessionPrefillParams = {
   repo?: string;
@@ -160,8 +161,8 @@ export function resolvePrefillModel(
 /**
  * Resolve a prefill repository against the loaded repository list.
  * Match is **case-insensitive**; returns the **matched entry's
- * `fullName`** (GitHub's canonical casing). Returns `null` when
- * `prefill.repo` is absent or nothing matches.
+ * `fullName`** (GitHub's canonical casing). Returns `null` unless exactly
+ * one entry matches.
  */
 export function resolvePrefillRepo(
   repositories: { fullName: string }[],
@@ -172,20 +173,19 @@ export function resolvePrefillRepo(
   }
 
   const lower = prefill.repo.toLowerCase();
-  const match = repositories.find(r => r.fullName.toLowerCase() === lower);
-  return match?.fullName ?? null;
+  const matches = repositories.filter(repository => repository.fullName.toLowerCase() === lower);
+  return matches.length === 1 ? (matches[0]?.fullName ?? null) : null;
 }
 
 /**
- * Resolve a prefill repository to a platform-qualified picker key
- * `platform:fullName`. Continuation prefill is GitHub-only (see
+ * Resolve a prefill repository to its exact picker key. Continuation prefill is GitHub-only (see
  * `buildContinuePrefillParams` + `isGitHubUrl`), so only a GitHub row may
  * satisfy it: a same-named GitLab/Bitbucket row must never be selected.
  * Kept separate from `resolvePrefillRepo`, which returns the bare matched
  * `fullName` and is still used by `continuation-seed.ts`.
  */
 export function resolvePrefillRepoSelection(
-  repositories: { platform: string; fullName: string }[],
+  repositories: { platform: string; fullName: string; platformIntegrationId?: string }[],
   prefill: NewSessionPrefill
 ): string | null {
   if (!prefill.repo) {
@@ -193,10 +193,19 @@ export function resolvePrefillRepoSelection(
   }
 
   const lower = prefill.repo.toLowerCase();
-  const match = repositories.find(
+  const matches = repositories.filter(
     repository => repository.platform === 'github' && repository.fullName.toLowerCase() === lower
   );
-  return match ? `github:${match.fullName}` : null;
+  const match = matches[0];
+  return matches.length === 1 && match
+    ? getRepoOptionKey({
+        platform: 'github',
+        fullName: match.fullName,
+        ...(match.platformIntegrationId
+          ? { platformIntegrationId: match.platformIntegrationId }
+          : {}),
+      })
+    : null;
 }
 
 /**

--- a/apps/mobile/src/components/agents/new-session-repository-state.test.ts
+++ b/apps/mobile/src/components/agents/new-session-repository-state.test.ts
@@ -1,13 +1,88 @@
 import { describe, expect, it } from 'vitest';
 
 import {
-  dedupeRepositoriesByPlatformAndFullName,
+  dedupeRepositoriesByIdentity,
   type NewSessionRepository,
   type RepositoryGroup,
   resolveBitbucketStatus,
+  resolveGitHubIntegrationIdForSubmission,
   resolveProviderStatus,
   resolveRepositoryGroups,
+  toNewSessionGitHubRepository,
 } from './new-session-repository-state';
+
+describe('toNewSessionGitHubRepository', () => {
+  it('preserves integration provenance from the tRPC DTO', () => {
+    expect(
+      toNewSessionGitHubRepository({
+        fullName: 'owner/repo',
+        private: true,
+        platformIntegrationId: 'integration-1',
+        platformAccountLogin: 'owner',
+      })
+    ).toEqual({
+      platform: 'github',
+      fullName: 'owner/repo',
+      isPrivate: true,
+      platformIntegrationId: 'integration-1',
+      platformAccountLogin: 'owner',
+    });
+  });
+
+  it('supports older tRPC responses without provenance', () => {
+    expect(toNewSessionGitHubRepository({ fullName: 'owner/repo', private: false })).toEqual({
+      platform: 'github',
+      fullName: 'owner/repo',
+      isPrivate: false,
+    });
+  });
+});
+
+describe('resolveGitHubIntegrationIdForSubmission', () => {
+  const selected = {
+    platform: 'github' as const,
+    fullName: 'Owner/Repo',
+    isPrivate: false,
+    platformIntegrationId: 'integration-1',
+  };
+
+  it('uses central live resolution for a unique repository name', () => {
+    expect(resolveGitHubIntegrationIdForSubmission(selected, [selected])).toBeUndefined();
+  });
+
+  it('does not treat a same-name repository on another provider as ambiguous', () => {
+    expect(
+      resolveGitHubIntegrationIdForSubmission(selected, [
+        selected,
+        { platform: 'gitlab', fullName: 'owner/repo', isPrivate: false },
+      ])
+    ).toBeUndefined();
+  });
+
+  it('preserves the selected integration for case-insensitive duplicate names', () => {
+    expect(
+      resolveGitHubIntegrationIdForSubmission(selected, [
+        selected,
+        {
+          ...selected,
+          fullName: 'owner/repo',
+          platformIntegrationId: 'integration-2',
+        },
+      ])
+    ).toBe('integration-1');
+  });
+
+  it('does not fence a provenance-free duplicate selection', () => {
+    const provenanceFree = {
+      platform: 'github' as const,
+      fullName: 'owner/repo',
+      isPrivate: false,
+    };
+    expect(
+      resolveGitHubIntegrationIdForSubmission(provenanceFree, [selected, provenanceFree])
+    ).toBeUndefined();
+  });
+});
 
 describe('resolveProviderStatus', () => {
   it('returns loading while the provider query is loading', () => {
@@ -145,22 +220,25 @@ const gitlab = (fullName: string): NewSessionRepository => ({
   isPrivate: false,
 });
 
-describe('dedupeRepositoriesByPlatformAndFullName', () => {
+describe('dedupeRepositoriesByIdentity', () => {
   it('keeps the same fullName on two platforms as two rows', () => {
-    const deduped = dedupeRepositoriesByPlatformAndFullName([
-      github('owner/repo'),
-      gitlab('owner/repo'),
-    ]);
+    const deduped = dedupeRepositoriesByIdentity([github('owner/repo'), gitlab('owner/repo')]);
     expect(deduped).toHaveLength(2);
     expect(deduped.map(repo => repo.platform)).toEqual(['github', 'gitlab']);
   });
 
   it('collapses duplicate rows that share platform and fullName', () => {
-    const deduped = dedupeRepositoriesByPlatformAndFullName([
-      github('owner/repo'),
-      github('owner/repo'),
-    ]);
+    const deduped = dedupeRepositoriesByIdentity([github('owner/repo'), github('owner/repo')]);
     expect(deduped).toHaveLength(1);
+  });
+
+  it('keeps same-name GitHub rows from separate integrations', () => {
+    const deduped = dedupeRepositoriesByIdentity([
+      { ...github('owner/repo'), platformIntegrationId: 'integration-1' },
+      { ...github('owner/repo'), platformIntegrationId: 'integration-2' },
+    ]);
+
+    expect(deduped).toHaveLength(2);
   });
 });
 

--- a/apps/mobile/src/components/agents/new-session-repository-state.ts
+++ b/apps/mobile/src/components/agents/new-session-repository-state.ts
@@ -1,4 +1,4 @@
-import { type RepoPlatform } from '@/lib/picker-bridge';
+import { getRepoOptionKey, type RepoPlatform } from '@/lib/picker-bridge';
 
 export type RepositoryPlatform = RepoPlatform;
 
@@ -12,9 +12,49 @@ export type NewSessionRepository = {
   platform: RepositoryPlatform;
   fullName: string;
   isPrivate: boolean;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
   workspaceUuid?: string;
   repositoryUuid?: string;
 };
+
+export function toNewSessionGitHubRepository(repository: {
+  fullName: string;
+  private: boolean;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
+}): NewSessionRepository {
+  const result: NewSessionRepository = {
+    platform: 'github',
+    fullName: repository.fullName,
+    isPrivate: repository.private,
+  };
+  if (repository.platformIntegrationId) {
+    result.platformIntegrationId = repository.platformIntegrationId;
+  }
+  if (repository.platformAccountLogin) {
+    result.platformAccountLogin = repository.platformAccountLogin;
+  }
+  return result;
+}
+
+/**
+ * Preserve an explicit installation choice only when the repository name is
+ * ambiguous. Unique names are resolved live by Cloud Agent at submission.
+ */
+export function resolveGitHubIntegrationIdForSubmission(
+  repository: NewSessionRepository | null,
+  repositories: readonly NewSessionRepository[]
+): string | undefined {
+  if (repository?.platform !== 'github' || !repository.platformIntegrationId) {
+    return undefined;
+  }
+  const normalizedFullName = repository.fullName.toLowerCase();
+  const matchingOptions = repositories.filter(
+    option => option.platform === 'github' && option.fullName.toLowerCase() === normalizedFullName
+  );
+  return matchingOptions.length > 1 ? repository.platformIntegrationId : undefined;
+}
 
 export type RepositoryProviderStatus =
   | 'loading'
@@ -110,20 +150,17 @@ export function resolveBitbucketStatus({
 
 // ── Dedup and grouping ───────────────────────────────────────────────
 
-const repositoryKey = (repository: NewSessionRepository): string =>
-  `${repository.platform}/${repository.fullName}`;
-
 /**
- * Deduplicate repository rows by `platform + fullName`, so the same
- * `fullName` on two platforms stays two rows.
+ * Deduplicate repository rows by their picker identity. GitHub rows with the
+ * same full name remain distinct when they came from different integrations.
  */
-export function dedupeRepositoriesByPlatformAndFullName(
+export function dedupeRepositoriesByIdentity(
   repositories: readonly NewSessionRepository[]
 ): NewSessionRepository[] {
   const seen = new Set<string>();
   const result: NewSessionRepository[] = [];
   for (const repository of repositories) {
-    const key = repositoryKey(repository);
+    const key = getRepoOptionKey(repository);
     if (!seen.has(key)) {
       seen.add(key);
       result.push(repository);

--- a/apps/mobile/src/components/agents/new-session-screen-body.tsx
+++ b/apps/mobile/src/components/agents/new-session-screen-body.tsx
@@ -8,6 +8,7 @@ import { useQuery } from '@tanstack/react-query';
 import { type RemoteModelOverride } from '@kilocode/cloud-agent-sdk';
 
 import { NewSessionConfigureForm } from '@/components/agents/new-session-configure-form';
+import { resolveGitHubIntegrationIdForSubmission } from '@/components/agents/new-session-repository-state';
 import { resolveNewSessionModelView } from '@/components/agents/new-session-model-view';
 import { useNewSessionCreator } from '@/components/agents/use-new-session-creator';
 import { useEffectiveAgentProfile } from '@/components/agents/use-effective-agent-profile';
@@ -36,7 +37,11 @@ import {
 } from '@/lib/persist/drafts';
 import { useDraftFlushOnBackground } from '@/lib/persist/use-draft-flush';
 import { useFencedDraftLoad, useRemoteSpawnDraftCleanup } from '@/lib/persist/use-draft-load';
-import { type InstancePickerInstance, type ModelPickerSelection } from '@/lib/picker-bridge';
+import {
+  type InstancePickerInstance,
+  type ModelPickerSelection,
+  resolveRepoOptionByKey,
+} from '@/lib/picker-bridge';
 import { shouldShowRunOnSelector } from '@/lib/should-show-run-on-selector';
 import { peekSharePayload } from '@/lib/share-payload';
 import { useNewSessionShareRemote } from '@/lib/use-new-session-share-remote';
@@ -168,20 +173,18 @@ export function NewSessionScreenBody() {
     modelsSettled: !isLoadingModels && !isModelsError && models.length > 0,
   });
 
-  // The picker reports a `platform:fullName` key; resolve it to the full row so
-  // the creator can send the platform-specific repository field. The prefill
-  // seeds the same platform-qualified key, so no bare-fullName fallback is
-  // needed (and one would bind a same-named GitLab/Bitbucket row).
+  // Resolve the picker identity back to the full row and preserve a GitHub
+  // installation fence only for an explicit choice among duplicate names.
   const selectedRepository = useMemo(() => {
     if (!selectedRepo) {
       return null;
     }
-    return (
-      repositories.find(
-        repository => `${repository.platform}:${repository.fullName}` === selectedRepo
-      ) ?? null
-    );
+    return resolveRepoOptionByKey(repositories, selectedRepo);
   }, [repositories, selectedRepo]);
+  const githubIntegrationId = useMemo(
+    () => resolveGitHubIntegrationIdForSubmission(selectedRepository, repositories),
+    [repositories, selectedRepository]
+  );
 
   const {
     profile,
@@ -243,6 +246,7 @@ export function NewSessionScreenBody() {
     model: displayModel,
     organizationId,
     onCreated: handleCreated,
+    githubIntegrationId,
     selectedRepository,
     setIsCreating,
     variant: displayVariant,

--- a/apps/mobile/src/components/agents/repo-selector.tsx
+++ b/apps/mobile/src/components/agents/repo-selector.tsx
@@ -7,11 +7,14 @@ import { Text } from '@/components/ui/text';
 import { useThemeColors } from '@/lib/hooks/use-theme-colors';
 import {
   type RepoOption as BridgeRepoOption,
+  getRepoOptionKey,
   REPO_PLATFORM_LABEL_KEYS,
   type RepoPickerSection,
   type RepoPlatform,
+  resolveRepoOptionByKey,
 } from '@/lib/picker-bridge';
 import { repoPickerSlot, UNFENCED_ROUTE_KEY } from '@/lib/route-registry';
+import { groupRepoPickerOptions } from '@/lib/repo-picker-filter';
 import { cn } from '@/lib/utils';
 
 type RepoOption = {
@@ -19,6 +22,8 @@ type RepoOption = {
   isPrivate: boolean;
   /** Provider platform; omitted rows are treated as GitHub until d1 fills it. */
   platform?: RepoPlatform;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
   workspaceUuid?: string;
   repositoryUuid?: string;
 };
@@ -33,18 +38,17 @@ type RepoSelectorProps = {
   disabled?: boolean;
 };
 
-function isRepoPlatform(platform: string): platform is RepoPlatform {
-  return platform === 'github' || platform === 'gitlab' || platform === 'bitbucket';
-}
-
-/** Constant order for provider sections (Bitbucket only when its rows exist, i.e. an org is set). */
-const PROVIDER_SECTION_ORDER: readonly RepoPlatform[] = ['github', 'gitlab', 'bitbucket'];
-
 function toBridgeRepo(repo: RepoOption): BridgeRepoOption {
   return {
     platform: repo.platform ?? 'github',
     fullName: repo.fullName,
     isPrivate: repo.isPrivate,
+    ...(repo.platformIntegrationId !== undefined
+      ? { platformIntegrationId: repo.platformIntegrationId }
+      : {}),
+    ...(repo.platformAccountLogin !== undefined
+      ? { platformAccountLogin: repo.platformAccountLogin }
+      : {}),
     ...(repo.workspaceUuid !== undefined ? { workspaceUuid: repo.workspaceUuid } : {}),
     ...(repo.repositoryUuid !== undefined ? { repositoryUuid: repo.repositoryUuid } : {}),
   };
@@ -63,9 +67,7 @@ function buildRepoSections({
   repositories: RepoOption[];
   recents: RepoOption[];
 }): RepoPickerSection[] {
-  const recentKeys = new Set(
-    recents.map(repo => `${repo.platform ?? 'github'}/${repo.fullName.toLowerCase()}`)
-  );
+  const recentKeys = new Set(recents.map(repo => getRepoOptionKey(toBridgeRepo(repo))));
   const sections: RepoPickerSection[] = [];
   if (recents.length > 0) {
     sections.push({
@@ -74,23 +76,13 @@ function buildRepoSections({
       repos: recents.map(repo => toBridgeRepo(repo)),
     });
   }
-  for (const platform of PROVIDER_SECTION_ORDER) {
-    const repos = repositories.filter(repo => {
-      const repoPlatform = repo.platform ?? 'github';
-      return (
-        repoPlatform === platform &&
-        !recentKeys.has(`${repoPlatform}/${repo.fullName.toLowerCase()}`)
-      );
-    });
-    if (repos.length > 0) {
-      sections.push({
-        key: platform,
-        titleKey: REPO_PLATFORM_LABEL_KEYS[platform],
-        repos: repos.map(repo => toBridgeRepo(repo)),
-      });
-    }
-  }
-  return sections;
+  const nonRecentRepositories = repositories.filter(
+    repo => !recentKeys.has(getRepoOptionKey(toBridgeRepo(repo)))
+  );
+  return [
+    ...sections,
+    ...groupRepoPickerOptions(nonRecentRepositories.map(repo => toBridgeRepo(repo))),
+  ];
 }
 
 export function RepoSelector({
@@ -106,23 +98,21 @@ export function RepoSelector({
   const { t } = useTranslation();
   const effectivelyDisabled = disabled || isLoading || repositories.length === 0;
 
-  // The selection value is `platform:fullName`; show the platform name next to
-  // the fullName so two same-name repos on different providers stay distinct in
-  // the closed state. A bare fullName (legacy prefill) falls back to the
-  // matching row's platform.
-  const colonIndex = value.indexOf(':');
-  const rawPlatform = colonIndex !== -1 ? value.slice(0, colonIndex) : '';
-  const selectedPlatform: RepoPlatform | undefined =
-    colonIndex !== -1 && isRepoPlatform(rawPlatform)
-      ? rawPlatform
-      : repositories.find(repo => repo.fullName === value)?.platform;
-  const displayValue = colonIndex !== -1 ? value.slice(colonIndex + 1) : value;
-  const platformName = selectedPlatform ? t(REPO_PLATFORM_LABEL_KEYS[selectedPlatform]) : undefined;
-  let label = displayValue;
+  const selectedRepository = resolveRepoOptionByKey(
+    repositories.map(repo => toBridgeRepo(repo)),
+    value
+  );
+  const selectedPlatform = selectedRepository?.platform ?? 'github';
+  const platformName = selectedRepository
+    ? t(REPO_PLATFORM_LABEL_KEYS[selectedPlatform])
+    : undefined;
+  let label = selectedRepository?.fullName ?? '';
   if (!label) {
     label = isLoading ? t('agentChat.repoPicker.loading') : t('agentChat.repoPicker.title');
   } else if (platformName) {
-    label = `${platformName} · ${displayValue}`;
+    label = [platformName, selectedRepository?.platformAccountLogin, label]
+      .filter(Boolean)
+      .join(' · ');
   }
 
   function handlePress() {

--- a/apps/mobile/src/components/agents/use-new-session-creator.test.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.test.ts
@@ -280,6 +280,7 @@ function runCreator(args: {
   model?: string;
   variant?: string;
   organizationId?: string;
+  githubIntegrationId?: string;
   selectedRepository?: NewSessionRepository | null;
   autoCommit?: boolean;
   profileId?: string | null;
@@ -321,6 +322,7 @@ function runCreator(args: {
       mode: (args.mode ?? 'code') as never,
       model: args.model ?? 'model-1',
       organizationId: args.organizationId,
+      githubIntegrationId: args.githubIntegrationId,
       selectedRepository: args.selectedRepository ?? {
         platform: 'github' as const,
         fullName: 'owner/repo',
@@ -711,6 +713,46 @@ describe('useNewSessionCreator repository platform payload', () => {
     expect(payload).not.toHaveProperty('bitbucketRepo');
   });
 
+  it('omits the DTO integration id for an ordinary unique GitHub repository', async () => {
+    prepareSessionMutate.mockResolvedValue(sessionResult());
+    const creator = runCreator({
+      selectedRepository: {
+        platform: 'github',
+        fullName: 'owner/repo',
+        isPrivate: false,
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+        platformAccountLogin: 'owner',
+      },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).toMatchObject({ githubRepo: 'owner/repo' });
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).not.toHaveProperty('githubIntegrationId');
+  });
+
+  it('sends the exact integration id for an explicit ambiguous GitHub selection', async () => {
+    prepareSessionMutate.mockResolvedValue(sessionResult());
+    const creator = runCreator({
+      githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      selectedRepository: {
+        platform: 'github',
+        fullName: 'owner/repo',
+        isPrivate: false,
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    expect(prepareSessionMutate.mock.calls[0]?.[0]).toMatchObject({
+      githubRepo: 'owner/repo',
+      githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+    });
+  });
+
   it('sends only gitlabProject for a GitLab row and never githubRepo', async () => {
     prepareSessionMutate.mockResolvedValue(sessionResult());
     const creator = runCreator({
@@ -808,6 +850,72 @@ describe('useNewSessionCreator intentFingerprint repo identity', () => {
       workspaceUuid: 'ws-1234',
       repositoryUuid: 'repo-5678',
     });
+  });
+
+  it('omits the integration id from a unique GitHub repository fingerprint', async () => {
+    const creator = runCreator({
+      selectedRepository: {
+        platform: 'github',
+        fullName: 'owner/repo',
+        isPrivate: false,
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    const fingerprint = outboxMock.writeSafeRetry.mock.calls[0]?.[0].fingerprint ?? '';
+    expect((JSON.parse(fingerprint) as { repo: unknown }).repo).toEqual({
+      platform: 'github',
+      fullName: 'owner/repo',
+    });
+  });
+
+  it('includes an explicitly sent GitHub integration id in the fingerprint', async () => {
+    const creator = runCreator({
+      githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      selectedRepository: {
+        platform: 'github',
+        fullName: 'owner/repo',
+        isPrivate: false,
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    const fingerprint = outboxMock.writeSafeRetry.mock.calls[0]?.[0].fingerprint ?? '';
+    expect((JSON.parse(fingerprint) as { repo: unknown }).repo).toEqual({
+      platform: 'github',
+      fullName: 'owner/repo',
+      platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+    });
+  });
+
+  it('does not reuse a legacy bare-name key when the integration id is sent', async () => {
+    outboxMock.getStoredOperationKey.mockImplementation((fingerprint: string) => {
+      const parsed = JSON.parse(fingerprint) as { repo: unknown };
+      return typeof parsed.repo === 'string' ? 'legacy-stored-key' : null;
+    });
+    const creator = runCreator({
+      githubIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      selectedRepository: {
+        platform: 'github',
+        fullName: 'owner/repo',
+        isPrivate: false,
+        platformIntegrationId: '123e4567-e89b-12d3-a456-426614174022',
+      },
+    });
+
+    creator.promptRef.current = 'hello';
+    await creator.createSessionFromDraft();
+
+    expect(prepareSessionMutate).toHaveBeenCalledWith(
+      expect.not.objectContaining({ operationKey: 'legacy-stored-key' })
+    );
+    expect(outboxMock.getStoredOperationKey).toHaveBeenCalledTimes(1);
   });
 
   // The deployed app persisted safe-retry rows with the bare `fullName` as

--- a/apps/mobile/src/components/agents/use-new-session-creator.ts
+++ b/apps/mobile/src/components/agents/use-new-session-creator.ts
@@ -31,6 +31,8 @@ type UseNewSessionCreatorInput = {
   organizationId?: string;
   /** Invoked on the success path before navigation; failures never fire it. */
   onCreated?: () => void;
+  /** Exact GitHub installation fence for an explicit ambiguous selection. */
+  githubIntegrationId?: string;
   selectedRepository: NewSessionRepository | null;
   setIsCreating: (value: boolean) => void;
   variant: string;
@@ -48,6 +50,7 @@ type PrepareSessionInput = {
   variant: string | undefined;
   /** Exactly one repository field is set, matching the selected row's platform. */
   githubRepo?: string;
+  githubIntegrationId?: string;
   gitlabProject?: string;
   bitbucketRepo?: { fullName: string; workspaceUuid: string; repositoryUuid: string };
   autoCommit: boolean;
@@ -75,6 +78,7 @@ export function useNewSessionCreator({
   model,
   organizationId,
   onCreated,
+  githubIntegrationId,
   selectedRepository,
   setIsCreating,
   variant,
@@ -139,7 +143,7 @@ export function useNewSessionCreator({
       mode,
       model,
       variant: variant || undefined,
-      repo: resolveRepoFingerprint(selectedRepository),
+      repo: resolveRepoFingerprint(selectedRepository, githubIntegrationId),
       autoCommit,
       organizationId: organizationId ?? null,
       profileId: profileId ?? null,
@@ -150,7 +154,7 @@ export function useNewSessionCreator({
     // intents fall back to the legacy bare-name lookup: two same-named
     // GitLab/Bitbucket rows must never share the stale retry key.
     const legacyIntentFingerprint =
-      selectedRepository?.platform === 'github'
+      selectedRepository?.platform === 'github' && !githubIntegrationId
         ? JSON.stringify({
             prompt,
             mode,
@@ -200,7 +204,7 @@ export function useNewSessionCreator({
         autoInitiate: true,
         operationKey,
       };
-      setRepositoryField(baseInput, selectedRepository);
+      setRepositoryField(baseInput, selectedRepository, githubIntegrationId);
       if (profileId) {
         baseInput.profileId = profileId;
       }
@@ -283,6 +287,7 @@ export function useNewSessionCreator({
     }
   }, [
     selectedRepository,
+    githubIntegrationId,
     model,
     mode,
     variant,
@@ -311,9 +316,13 @@ export function useNewSessionCreator({
  * same-named repos on different providers mint distinct retry keys, and the
  * Bitbucket workspace/repository uuids so a workspace rename cannot collide.
  */
-function resolveRepoFingerprint(repository: NewSessionRepository | null): {
+function resolveRepoFingerprint(
+  repository: NewSessionRepository | null,
+  githubIntegrationId: string | undefined
+): {
   platform: RepositoryPlatform;
   fullName: string;
+  platformIntegrationId?: string;
   workspaceUuid?: string | null;
   repositoryUuid?: string | null;
 } | null {
@@ -328,6 +337,13 @@ function resolveRepoFingerprint(repository: NewSessionRepository | null): {
       repositoryUuid: repository.repositoryUuid ?? null,
     };
   }
+  if (repository.platform === 'github') {
+    return {
+      platform: repository.platform,
+      fullName: repository.fullName,
+      ...(githubIntegrationId ? { platformIntegrationId: githubIntegrationId } : {}),
+    };
+  }
   return { platform: repository.platform, fullName: repository.fullName };
 }
 
@@ -339,13 +355,17 @@ function resolveRepoFingerprint(repository: NewSessionRepository | null): {
  */
 function setRepositoryField(
   input: PrepareSessionInput,
-  repository: NewSessionRepository | null
+  repository: NewSessionRepository | null,
+  githubIntegrationId: string | undefined
 ): void {
   if (!repository) {
     return;
   }
   if (repository.platform === 'github') {
     input.githubRepo = repository.fullName;
+    if (githubIntegrationId) {
+      input.githubIntegrationId = githubIntegrationId;
+    }
     return;
   }
   if (repository.platform === 'gitlab') {

--- a/apps/mobile/src/lib/picker-bridge.test.ts
+++ b/apps/mobile/src/lib/picker-bridge.test.ts
@@ -3,7 +3,9 @@ import { describe, expect, it, vi } from 'vitest';
 import {
   areModelPickerSelectionScopesEqual,
   commitModelPickerSelection,
+  getRepoOptionKey,
   resolveModelPickerSelection,
+  resolveRepoOptionByKey,
 } from './picker-bridge';
 
 const remoteOption = {
@@ -115,5 +117,31 @@ describe('model picker bridge', () => {
 
     expect(commitModelPickerSelection(bridge, remoteOption.id, 'high')).toBe(true);
     expect(onSelect).toHaveBeenCalledWith({ option: remoteOption, variant: 'high' });
+  });
+});
+
+describe('repository picker identity', () => {
+  const repository = {
+    platform: 'github' as const,
+    fullName: 'owner/repo',
+  };
+
+  it('distinguishes duplicate GitHub repositories across integrations', () => {
+    expect(getRepoOptionKey({ ...repository, platformIntegrationId: 'integration-1' })).not.toBe(
+      getRepoOptionKey({ ...repository, platformIntegrationId: 'integration-2' })
+    );
+  });
+
+  it('keeps the existing platform-qualified key when provenance is absent', () => {
+    expect(getRepoOptionKey(repository)).toBe('github:owner/repo');
+  });
+
+  it('returns null instead of binding a stale or unknown key', () => {
+    const repositories = [
+      { ...repository, isPrivate: false, platformIntegrationId: 'integration-1' },
+    ];
+
+    expect(resolveRepoOptionByKey(repositories, 'github:integration-2:owner/repo')).toBeNull();
+    expect(resolveRepoOptionByKey(repositories, 'github:owner/repo')).toBeNull();
   });
 });

--- a/apps/mobile/src/lib/picker-bridge.ts
+++ b/apps/mobile/src/lib/picker-bridge.ts
@@ -54,14 +54,33 @@ export type RepoOption = {
   platform: RepoPlatform;
   fullName: string;
   isPrivate: boolean;
+  platformIntegrationId?: string;
+  platformAccountLogin?: string;
   workspaceUuid?: string;
   repositoryUuid?: string;
 };
 
+export function getRepoOptionKey(repository: {
+  platform: RepoPlatform;
+  fullName: string;
+  platformIntegrationId?: string;
+}): string {
+  return repository.platformIntegrationId
+    ? `${repository.platform}:${repository.platformIntegrationId}:${repository.fullName}`
+    : `${repository.platform}:${repository.fullName}`;
+}
+
+export function resolveRepoOptionByKey<
+  T extends { platform: RepoPlatform; fullName: string; platformIntegrationId?: string },
+>(repositories: readonly T[], key: string): T | null {
+  return repositories.find(repository => getRepoOptionKey(repository) === key) ?? null;
+}
+
 export type RepoPickerSection = {
-  key: 'recents' | RepoPlatform;
-  /** i18n key the picker resolves for the section header. */
-  titleKey: string;
+  key: string;
+  /** Exactly one title field is set for each section. */
+  titleKey?: string;
+  title?: string;
   repos: RepoOption[];
 };
 

--- a/apps/mobile/src/lib/repo-picker-filter.test.ts
+++ b/apps/mobile/src/lib/repo-picker-filter.test.ts
@@ -1,10 +1,16 @@
 import { describe, expect, it } from 'vitest';
 
 import { type RepoOption } from './picker-bridge';
-import { filterRepoPickerOptions } from './repo-picker-filter';
+import { filterRepoPickerOptions, groupRepoPickerOptions } from './repo-picker-filter';
 
 const repositories: RepoOption[] = [
-  { fullName: 'Kilo-Org/cloud', isPrivate: true, platform: 'github' },
+  {
+    fullName: 'Kilo-Org/cloud',
+    isPrivate: true,
+    platform: 'github',
+    platformIntegrationId: 'integration-1',
+    platformAccountLogin: 'Kilo-Org',
+  },
   { fullName: 'octocat/Hello-World', isPrivate: false, platform: 'github' },
   { fullName: 'acme/widgets', isPrivate: true, platform: 'github' },
 ];
@@ -16,5 +22,39 @@ describe('filterRepoPickerOptions', () => {
 
   it('filters repositories by full name case-insensitively', () => {
     expect(filterRepoPickerOptions({ repositories, search: 'hello' })).toEqual([repositories[1]]);
+  });
+
+  it('filters repositories by GitHub account case-insensitively', () => {
+    expect(filterRepoPickerOptions({ repositories, search: 'kilo-org' })).toEqual([
+      repositories[0],
+    ]);
+  });
+});
+
+describe('groupRepoPickerOptions', () => {
+  it('groups GitHub repositories by account and retains provenance-free rows', () => {
+    expect(groupRepoPickerOptions(repositories)).toEqual([
+      { key: 'github:Kilo-Org', title: 'Kilo-Org', repos: [repositories[0]] },
+      {
+        key: 'github',
+        titleKey: 'agentChat.repoPicker.platformGithub',
+        repos: [repositories[1], repositories[2]],
+      },
+    ]);
+  });
+
+  it('keeps duplicate full names from separate integrations as separate rows', () => {
+    const firstRepository = repositories[0];
+    if (!firstRepository) {
+      throw new Error('Expected GitHub repository fixture');
+    }
+    const duplicate = {
+      ...firstRepository,
+      platformIntegrationId: 'integration-2',
+      platformAccountLogin: 'Second Account',
+    };
+
+    const sections = groupRepoPickerOptions([firstRepository, duplicate]);
+    expect(sections.flatMap(section => section.repos)).toEqual([firstRepository, duplicate]);
   });
 });

--- a/apps/mobile/src/lib/repo-picker-filter.ts
+++ b/apps/mobile/src/lib/repo-picker-filter.ts
@@ -1,4 +1,11 @@
-import { type RepoOption } from '@/lib/picker-bridge';
+import {
+  REPO_PLATFORM_LABEL_KEYS,
+  type RepoOption,
+  type RepoPickerSection,
+  type RepoPlatform,
+} from '@/lib/picker-bridge';
+
+const PROVIDER_SECTION_ORDER: readonly RepoPlatform[] = ['github', 'gitlab', 'bitbucket'];
 
 export function filterRepoPickerOptions({
   repositories,
@@ -11,5 +18,38 @@ export function filterRepoPickerOptions({
   if (!query) {
     return repositories;
   }
-  return repositories.filter(repo => repo.fullName.toLowerCase().includes(query));
+  return repositories.filter(
+    repo =>
+      repo.fullName.toLowerCase().includes(query) ||
+      repo.platformAccountLogin?.toLowerCase().includes(query)
+  );
+}
+
+export function groupRepoPickerOptions(repositories: RepoOption[]): RepoPickerSection[] {
+  const sections: RepoPickerSection[] = [];
+  for (const platform of PROVIDER_SECTION_ORDER) {
+    const providerRepositories = repositories.filter(repo => repo.platform === platform);
+    if (platform === 'github') {
+      const byAccount = new Map<string | undefined, RepoOption[]>();
+      for (const repository of providerRepositories) {
+        const group = byAccount.get(repository.platformAccountLogin) ?? [];
+        group.push(repository);
+        byAccount.set(repository.platformAccountLogin, group);
+      }
+      for (const [accountLogin, repos] of byAccount) {
+        sections.push(
+          accountLogin
+            ? { key: `github:${accountLogin}`, title: accountLogin, repos }
+            : { key: 'github', titleKey: REPO_PLATFORM_LABEL_KEYS.github, repos }
+        );
+      }
+    } else if (providerRepositories.length > 0) {
+      sections.push({
+        key: platform,
+        titleKey: REPO_PLATFORM_LABEL_KEYS[platform],
+        repos: providerRepositories,
+      });
+    }
+  }
+  return sections;
 }

--- a/apps/mobile/src/lib/use-new-session-repos.ts
+++ b/apps/mobile/src/lib/use-new-session-repos.ts
@@ -5,7 +5,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query';
 import { toast } from 'sonner-native';
 
 import {
-  dedupeRepositoriesByPlatformAndFullName,
+  dedupeRepositoriesByIdentity,
   detectRepositoryPlatform,
   type NewSessionRepository,
   type RepositoryGroup,
@@ -14,6 +14,7 @@ import {
   resolveBitbucketStatus,
   resolveProviderStatus,
   resolveRepositoryGroups,
+  toNewSessionGitHubRepository,
 } from '@/components/agents/new-session-repository-state';
 import { formatGitUrlProject } from '@/components/agents/session-list-helpers';
 import { i18n } from '@/i18n';
@@ -24,6 +25,7 @@ import { openAuthorizationAndWaitForReturn } from '@/lib/pr-review/connect-gate-
 import { useExternalAuthReturn } from '@/lib/external-auth/use-external-auth-return';
 import { useGitHubReposRefresh } from '@/lib/use-github-repos-refresh';
 import { useTRPC } from '@/lib/trpc';
+import { getRepoOptionKey } from '@/lib/picker-bridge';
 
 type UseNewSessionReposArgs = {
   organizationId: string | undefined;
@@ -91,12 +93,7 @@ export function useNewSessionRepos({
   });
 
   const githubRepositories = useMemo<NewSessionRepository[]>(
-    () =>
-      (githubQuery.data?.repositories ?? []).map(repo => ({
-        platform: 'github',
-        fullName: repo.fullName,
-        isPrivate: repo.private,
-      })),
+    () => (githubQuery.data?.repositories ?? []).map(repo => toNewSessionGitHubRepository(repo)),
     [githubQuery.data]
   );
 
@@ -125,23 +122,28 @@ export function useNewSessionRepos({
   }, [bitbucketQuery.data]);
 
   // Recently used rows: only recents that resolve to a connected repository
-  // appear, and they are deduped by platform + fullName.
+  // appear. Recent-session data has no integration provenance, so an
+  // ambiguous GitHub full name retains the existing first-match behavior.
   const recentlyUsed = useMemo<NewSessionRepository[]>(() => {
     const recentList = recentRepoData?.repositories;
     if (!recentList?.length) {
       return [];
     }
     const unified = [...githubRepositories, ...gitlabRepositories, ...bitbucketRepositories];
-    const byKey = new Map(unified.map(repo => [repoKey(repo), repo]));
     const seen = new Set<string>();
     const result: NewSessionRepository[] = [];
     for (const recent of recentList) {
       const platform = detectRepositoryPlatform(recent.gitUrl);
       const fullName = formatGitUrlProject(recent.gitUrl);
       const match =
-        platform && fullName ? byKey.get(`${platform}/${fullName.toLowerCase()}`) : undefined;
+        platform && fullName
+          ? unified.find(
+              repo =>
+                repo.platform === platform && repo.fullName.toLowerCase() === fullName.toLowerCase()
+            )
+          : undefined;
       if (match) {
-        const key = repoKey(match);
+        const key = getRepoOptionKey(match);
         if (!seen.has(key)) {
           seen.add(key);
           result.push(match);
@@ -153,7 +155,7 @@ export function useNewSessionRepos({
 
   const repositories = useMemo(
     () =>
-      dedupeRepositoriesByPlatformAndFullName([
+      dedupeRepositoriesByIdentity([
         ...recentlyUsed,
         ...githubRepositories,
         ...gitlabRepositories,
@@ -368,8 +370,4 @@ export function useNewSessionRepos({
     openIntegration,
     refreshReposForceFresh,
   };
-}
-
-function repoKey(repository: NewSessionRepository): string {
-  return `${repository.platform}/${repository.fullName.toLowerCase()}`;
 }


### PR DESCRIPTION
## Why
Mobile must distinguish duplicate repository rows for user intent, but Cloud Agent #5590 should perform live authorization. The client should not turn every cached repository DTO into a hard installation decision.

## Dependency
Depends on #5590.

## What changes
- Keep integration-qualified picker keys and account grouping/search.
- Preserve duplicate rows and reject stale selections.
- Submit only owner/repo for unique repository names.
- Submit exact githubIntegrationId only when the user selected among duplicate same-name installations.
- Fingerprint the ID only when sent.

## Validation
- 586 mobile files, 6,262 tests
- Mobile typecheck/lint/format
- `git diff --check`