### PR TITLE
feat(review-memory): learn from secondary installation replies

### DIFF
--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.test.ts
@@ -71,6 +71,10 @@ jest.mock('@/lib/code-reviews/review-memory/github-feedback', () => ({
   handleGitHubReviewCommentReply: (input: unknown) => mockHandleGitHubReviewCommentReply(input),
 }));
 
+jest.mock('@/lib/utils.server', () => ({
+  logExceptInTest: jest.fn(),
+}));
+
 jest.mock('next/server', () => {
   const actual = jest.requireActual('next/server');
   return {
@@ -86,6 +90,7 @@ const integration = {
   owned_by_organization_id: 'org_1',
   owned_by_user_id: null,
   platform_installation_id: '98765',
+  github_app_type: 'standard',
   suspended_at: null,
 };
 
@@ -384,11 +389,145 @@ describe('handleGitHubWebhook', () => {
     );
   });
 
+  it('records reply feedback through the exact secondary installation', async () => {
+    const secondaryIntegration = {
+      ...integration,
+      id: 'secondary',
+      github_app_type: 'standard',
+    };
+    const payload = reviewCommentPayload({
+      comment: {
+        ...reviewCommentPayload().comment,
+        in_reply_to_id: 455,
+      },
+    });
+    mockFindIntegrationByInstallationId.mockResolvedValue(secondaryIntegration);
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
+    mockHandleGitHubReviewCommentReply.mockResolvedValue({ recorded: true, eventId: 'evt_1' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request_review_comment', payload),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    await waitForAfterTask();
+    expect(mockHandleGitHubReviewCommentReply).toHaveBeenCalledTimes(1);
+    expect(mockHandleGitHubReviewCommentReply).toHaveBeenCalledWith({
+      payload: expect.objectContaining(payload),
+      integration: secondaryIntegration,
+      deliveryId: 'delivery-pull_request_review_comment',
+    });
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'we_1',
+      expect.objectContaining({
+        handlers_triggered: ['pr_review_comment_fix', 'review_memory_feedback'],
+      })
+    );
+  });
+
+  it('runs Auto Fix without recording feedback for a secondary non-reply comment', async () => {
+    const secondaryIntegration = { ...integration, id: 'secondary' };
+    const payload = reviewCommentPayload();
+    mockFindIntegrationByInstallationId.mockResolvedValue(secondaryIntegration);
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request_review_comment', payload),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    await waitForAfterTask();
+    expect(mockHandleGitHubReviewCommentReply).toHaveBeenCalledWith({
+      payload: expect.objectContaining(payload),
+      integration: secondaryIntegration,
+      deliveryId: 'delivery-pull_request_review_comment',
+    });
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'we_1',
+      expect.objectContaining({ handlers_triggered: ['pr_review_comment_fix'] })
+    );
+  });
+
+  it('keeps Auto Fix and Review Memory side effects together for a secondary reply', async () => {
+    const secondaryIntegration = { ...integration, id: 'secondary' };
+    const payload = reviewCommentPayload({
+      comment: {
+        ...reviewCommentPayload().comment,
+        in_reply_to_id: 455,
+      },
+    });
+    mockFindIntegrationByInstallationId.mockResolvedValue(secondaryIntegration);
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
+    mockHandleGitHubReviewCommentReply.mockResolvedValue({ recorded: true, eventId: 'evt_1' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request_review_comment', payload),
+      'standard'
+    );
+
+    expect(response.status).toBe(200);
+    await waitForAfterTask();
+    expect(mockHandlePRReviewComment).toHaveBeenCalledTimes(1);
+    expect(mockHandlePRReviewComment).toHaveBeenCalledWith(
+      expect.objectContaining(payload),
+      secondaryIntegration
+    );
+    expect(mockHandleGitHubReviewCommentReply).toHaveBeenCalledTimes(1);
+    expect(mockUpdateWebhookEvent).toHaveBeenCalledWith(
+      'we_1',
+      expect.objectContaining({
+        handlers_triggered: ['pr_review_comment_fix', 'review_memory_feedback'],
+      })
+    );
+  });
+
+  it('uses the exact lite integration that delivered secondary reply feedback', async () => {
+    const secondaryIntegration = {
+      ...integration,
+      id: 'secondary',
+      github_app_type: 'lite',
+    };
+    const payload = reviewCommentPayload({
+      comment: {
+        ...reviewCommentPayload().comment,
+        in_reply_to_id: 455,
+      },
+    });
+    mockFindIntegrationByInstallationId.mockResolvedValue(secondaryIntegration);
+    mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
+    mockHandleGitHubReviewCommentReply.mockResolvedValue({ recorded: true, eventId: 'evt_1' });
+
+    const response = await handleGitHubWebhook(
+      signedGitHubRequest('pull_request_review_comment', payload),
+      'lite'
+    );
+
+    expect(response.status).toBe(200);
+    await waitForAfterTask();
+    expect(mockFindIntegrationByInstallationId).toHaveBeenCalledWith('github', '98765', 'lite');
+    expect(mockHandlePRReviewComment.mock.calls[0]?.[1]).toBe(secondaryIntegration);
+    expect(mockHandleGitHubReviewCommentReply.mock.calls[0]?.[0].integration).toBe(
+      secondaryIntegration
+    );
+    expect(mockHandleGitHubReviewCommentReply.mock.calls[0]?.[0].integration.github_app_type).toBe(
+      'lite'
+    );
+  });
+
   it('admits only Auto Fix event actions from a secondary installation', async () => {
     mockGetIntegrationForOrganization.mockResolvedValue({ ...integration, id: 'primary' });
 
     const reviewResponse = await handleGitHubWebhook(
       signedGitHubRequest('pull_request_review_comment', reviewCommentPayload()),
+      'standard'
+    );
+    const editedReviewResponse = await handleGitHubWebhook(
+      signedGitHubRequest(
+        'pull_request_review_comment',
+        reviewCommentPayload({ action: 'edited' })
+      ),
       'standard'
     );
     const labeledResponse = await handleGitHubWebhook(
@@ -408,12 +547,12 @@ describe('handleGitHubWebhook', () => {
     );
 
     expect(reviewResponse.status).toBe(200);
+    expect(editedReviewResponse.status).toBe(200);
     expect(labeledResponse.status).toBe(200);
     expect(openedResponse.status).toBe(200);
     expect(otherLabelResponse.status).toBe(200);
     await waitForAfterTask();
-    expect(mockHandlePRReviewComment).toHaveBeenCalledWith(expect.anything(), integration);
-    expect(mockHandleGitHubReviewCommentReply).not.toHaveBeenCalled();
+    expect(mockHandlePRReviewComment).toHaveBeenCalledTimes(1);
     expect(mockHandleIssue).toHaveBeenCalledTimes(1);
     expect(mockHandleIssue).toHaveBeenCalledWith(
       expect.objectContaining({ action: 'labeled' }),

--- a/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
+++ b/apps/web/src/lib/integrations/platforms/github/webhook-handler.ts
@@ -705,14 +705,12 @@ export async function handleGitHubWebhook(
         try {
           await handlePRReviewComment(parseResult.data, integration);
           try {
-            if (!isSecondaryOrganizationInstallation) {
-              const reviewMemoryResult = await handleGitHubReviewCommentReply({
-                payload: parseResult.data,
-                integration,
-                deliveryId: eventSignature,
-              });
-              if (reviewMemoryResult.recorded) handlersTriggered.push('review_memory_feedback');
-            }
+            const reviewMemoryResult = await handleGitHubReviewCommentReply({
+              payload: parseResult.data,
+              integration,
+              deliveryId: eventSignature,
+            });
+            if (reviewMemoryResult.recorded) handlersTriggered.push('review_memory_feedback');
           } catch (error) {
             logExceptInTest(`Error handling review memory feedback${logSuffix}:`, error);
             captureException(error, {


### PR DESCRIPTION
## Why
#5594 admits secondary review-comment events for Auto Fix. Review Memory is an independent side effect on the same event and should use the exact delivering integration rather than remain primary-only.

## Dependency
Depends on #5594.

## What changes
- Process secondary review replies with the delivering integration/app type.
- Preserve Auto Fix as a separate same-event side effect.
- Ignore non-replies and avoid duplicate feedback.

## Validation
- 19 focused webhook tests
- Lint/format and `git diff --check`