### PR TITLE
feat(security): configure repositories from every GitHub installation

### DIFF
--- a/apps/mobile/src/components/security-agent/repository-settings-screen.tsx
+++ b/apps/mobile/src/components/security-agent/repository-settings-screen.tsx
@@ -21,6 +21,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { TabScreenScrollView } from '@/components/tab-screen';
 import { getGitHubIntegrationUrl } from '@/lib/agent-github-integration';
+import { i18n } from '@/i18n';
 import { WEB_BASE_URL } from '@/lib/config';
 import { openExternalUrl } from '@/lib/external-link';
 import { trpcClient } from '@/lib/trpc';
@@ -32,11 +33,21 @@ import {
   useSaveSecurityAgentConfig,
   useSecurityAgentCapability,
   useSecurityAgentConfig,
+  useSecurityAgentPermissionStatus,
   useSecurityAgentRepositories,
 } from '@/lib/hooks/use-security-agent';
 import { type FlattenedSecurityAgentConfig, type SecurityAgentConfig } from '@/lib/security-agent';
 
 type RepositorySelectionMode = SecurityAgentConfig['repositorySelectionMode'];
+
+function installationStatusLabel(input: { active: boolean; hasPermissions: boolean }): string {
+  if (!input.active) {
+    return i18n.t('securityAgent.dashboard.syncStatusUnavailable');
+  }
+  return input.hasPermissions
+    ? i18n.t('securityAgent.settingsOverview.enabled')
+    : i18n.t('securityAgent.scopeEntry.reauthorizeTitle');
+}
 
 function RepositorySettingsSkeleton() {
   const { t } = useTranslation();
@@ -58,6 +69,7 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
   const canManage = useSecurityAgentCapability(scope).canManage;
   const config = useSecurityAgentConfig(scope);
   const repositories = useSecurityAgentRepositories(scope);
+  const permission = useSecurityAgentPermissionStatus(scope);
   const save = useSaveSecurityAgentConfig(scope);
 
   const [mode, setMode] = useState<RepositorySelectionMode>('all');
@@ -120,6 +132,21 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
       current.includes(id) ? current.filter(existing => existing !== id) : [...current, id]
     );
   };
+  const repositoryGroups = new Map<
+    string,
+    { accountLogin: string | null; repositories: NonNullable<typeof repositories.data> }
+  >();
+  for (const repository of repositories.data ?? []) {
+    const group = repositoryGroups.get(repository.integrationId);
+    if (group) {
+      group.repositories.push(repository);
+    } else {
+      repositoryGroups.set(repository.integrationId, {
+        accountLogin: repository.accountLogin,
+        repositories: [repository],
+      });
+    }
+  }
 
   return (
     <View className="flex-1 bg-background">
@@ -162,6 +189,45 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
             />
           ))}
         </RadioGroup>
+
+        {(permission.data?.installations.length ?? 0) > 0 ? (
+          <View className="mt-6 rounded-lg bg-secondary px-3">
+            {permission.data?.installations.map((installation, index, installations) => (
+              <View
+                key={installation.integrationId}
+                className={`min-h-14 flex-row items-center justify-between gap-3 py-3 ${
+                  index < installations.length - 1 ? 'border-b-[0.5px] border-hair-soft' : ''
+                }`}
+              >
+                <View className="min-w-0 flex-1">
+                  <Text className="text-sm font-medium" numberOfLines={1}>
+                    {installation.accountLogin ?? installation.integrationId}
+                  </Text>
+                  <Text variant="muted" className="text-xs">
+                    {installationStatusLabel(installation)}
+                  </Text>
+                </View>
+                {installation.reauthorizeUrl ? (
+                  <Button
+                    variant="ghost"
+                    size="sm"
+                    onPress={() => {
+                      const reauthorizeUrl = installation.reauthorizeUrl;
+                      if (!reauthorizeUrl) {
+                        return;
+                      }
+                      void openExternalUrl(reauthorizeUrl, {
+                        label: t('securityAgent.scopeEntry.reauthorizeButton'),
+                      });
+                    }}
+                  >
+                    <Text>{t('securityAgent.scopeEntry.reauthorizeButton')}</Text>
+                  </Button>
+                ) : null}
+              </View>
+            ))}
+          </View>
+        ) : null}
 
         {mode === 'selected' && (
           <View className="mt-6">
@@ -219,17 +285,24 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
             ) : null}
             {!repositories.isLoading &&
               !repositories.isError &&
-              (repositories.data ?? []).map(repo => (
-                <RepoToggleRow
-                  key={repo.id}
-                  repo={repo}
-                  selected={selectedIds.includes(repo.id)}
-                  disabled={!canManage}
-                  className="border-b-[0.5px] border-hair-soft"
-                  onPress={() => {
-                    toggleRepo(repo.id);
-                  }}
-                />
+              [...repositoryGroups.entries()].map(([integrationId, group]) => (
+                <View key={integrationId} className="mb-4">
+                  <Text className="min-h-11 py-3 text-sm font-medium" numberOfLines={1}>
+                    {group.accountLogin ?? integrationId}
+                  </Text>
+                  {group.repositories.map(repo => (
+                    <RepoToggleRow
+                      key={`${integrationId}:${repo.id}`}
+                      repo={repo}
+                      selected={selectedIds.includes(repo.id)}
+                      disabled={!canManage}
+                      className="border-b-[0.5px] border-hair-soft"
+                      onPress={() => {
+                        toggleRepo(repo.id);
+                      }}
+                    />
+                  ))}
+                </View>
               ))}
             {!repositories.isLoading &&
               !repositories.isError &&

--- a/apps/mobile/src/components/security-agent/repository-settings-screen.tsx
+++ b/apps/mobile/src/components/security-agent/repository-settings-screen.tsx
@@ -21,7 +21,6 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { Text } from '@/components/ui/text';
 import { TabScreenScrollView } from '@/components/tab-screen';
 import { getGitHubIntegrationUrl } from '@/lib/agent-github-integration';
-import { i18n } from '@/i18n';
 import { WEB_BASE_URL } from '@/lib/config';
 import { openExternalUrl } from '@/lib/external-link';
 import { trpcClient } from '@/lib/trpc';
@@ -37,33 +36,14 @@ import {
   useSecurityAgentRepositories,
 } from '@/lib/hooks/use-security-agent';
 import { type FlattenedSecurityAgentConfig, type SecurityAgentConfig } from '@/lib/security-agent';
+import {
+  installationStatusLabel,
+  RepositorySettingsSkeleton,
+  toggleRepositorySelection,
+} from './repository-settings-support';
 
 type RepositorySelectionMode = SecurityAgentConfig['repositorySelectionMode'];
-
-function installationStatusLabel(input: { active: boolean; hasPermissions: boolean }): string {
-  if (!input.active) {
-    return i18n.t('securityAgent.dashboard.syncStatusUnavailable');
-  }
-  return input.hasPermissions
-    ? i18n.t('securityAgent.settingsOverview.enabled')
-    : i18n.t('securityAgent.scopeEntry.reauthorizeTitle');
-}
-
-function RepositorySettingsSkeleton() {
-  const { t } = useTranslation();
-  return (
-    <View className="flex-1 bg-background">
-      <ScreenHeader title={t('securityAgent.repositories.title')} />
-      <View className="gap-3 px-6 pt-4">
-        <Skeleton className="h-11 w-full rounded-lg" />
-        <Skeleton className="h-11 w-full rounded-lg" />
-        <Skeleton className="h-12 w-full rounded-lg" />
-        <Skeleton className="h-12 w-full rounded-lg" />
-      </View>
-    </View>
-  );
-}
-
+type SelectedRepository = SecurityAgentConfig['selectedRepositories'][number];
 export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>) {
   const { t } = useTranslation();
   const canManage = useSecurityAgentCapability(scope).canManage;
@@ -73,31 +53,36 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
   const save = useSaveSecurityAgentConfig(scope);
 
   const [mode, setMode] = useState<RepositorySelectionMode>('all');
-  const [selectedIds, setSelectedIds] = useState<number[]>([]);
+  const [selectedRepositories, setSelectedRepositories] = useState<SelectedRepository[]>([]);
   const hydratedRef = useRef(false);
   const initialConfigRef = useRef<Partial<FlattenedSecurityAgentConfig>>({});
 
-  // Local state initialized from the loaded config exactly once — later
-  // config refetches (e.g. after this screen's own save) shouldn't clobber
-  // in-progress edits.
   useEffect(() => {
-    if (hydratedRef.current || !config.data) {
+    if (hydratedRef.current || !config.data || !repositories.data) {
       return;
     }
     hydratedRef.current = true;
     initialConfigRef.current = config.data;
     setMode(config.data.repositorySelectionMode);
-    setSelectedIds(config.data.selectedRepositoryIds);
-  }, [config.data]);
+    setSelectedRepositories(
+      config.data.selectedRepositories.length > 0
+        ? config.data.selectedRepositories
+        : repositories.data
+            .filter(repository => config.data.selectedRepositoryIds.includes(repository.id))
+            .map(repository => ({
+              repositoryId: repository.id,
+              platformIntegrationId: repository.integrationId,
+            }))
+    );
+  }, [config.data, repositories.data]);
 
-  // The repositories screen stays reachable while the agent is disabled so a
-  // user with integration repos but no effective selection can pick repos and
-  // then enable (the overview's "Select repositories" CTA lands here). Opt out
-  // of the disabled-state redirect; every other sub-screen keeps it.
   useSecurityAgentSettingsRedirect(scope, config.data?.isEnabled, true);
 
-  const valid = mode === 'all' || selectedIds.length > 0;
-  const patch = { repositorySelectionMode: mode, selectedRepositoryIds: selectedIds };
+  const selectedRepositoryIds = [
+    ...new Set(selectedRepositories.map(selection => selection.repositoryId)),
+  ];
+  const valid = mode === 'all' || selectedRepositories.length > 0;
+  const patch = { repositorySelectionMode: mode, selectedRepositoryIds, selectedRepositories };
   const dirty =
     hydratedRef.current &&
     getSettingsDirtyState(initialConfigRef.current, patch, valid) !== 'clean';
@@ -127,9 +112,9 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
     setMode(option);
   };
 
-  const toggleRepo = (id: number) => {
-    setSelectedIds(current =>
-      current.includes(id) ? current.filter(existing => existing !== id) : [...current, id]
+  const toggleRepo = (repositoryId: number, platformIntegrationId: string) => {
+    setSelectedRepositories(current =>
+      toggleRepositorySelection(current, repositoryId, platformIntegrationId)
     );
   };
   const repositoryGroups = new Map<
@@ -294,11 +279,15 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
                     <RepoToggleRow
                       key={`${integrationId}:${repo.id}`}
                       repo={repo}
-                      selected={selectedIds.includes(repo.id)}
+                      selected={selectedRepositories.some(
+                        selection =>
+                          selection.repositoryId === repo.id &&
+                          selection.platformIntegrationId === integrationId
+                      )}
                       disabled={!canManage}
                       className="border-b-[0.5px] border-hair-soft"
                       onPress={() => {
-                        toggleRepo(repo.id);
+                        toggleRepo(repo.id, integrationId);
                       }}
                     />
                   ))}
@@ -307,7 +296,7 @@ export function RepositorySettingsScreen({ scope }: Readonly<{ scope: string }>)
             {!repositories.isLoading &&
               !repositories.isError &&
               (repositories.data?.length ?? 0) > 0 &&
-              selectedIds.length === 0 && (
+              selectedRepositories.length === 0 && (
                 <Text className="pt-2 text-xs text-destructive">
                   {t('securityAgent.repositories.selectAtLeastOne')}
                 </Text>

--- a/apps/mobile/src/components/security-agent/repository-settings-support.tsx
+++ b/apps/mobile/src/components/security-agent/repository-settings-support.tsx
@@ -1,0 +1,63 @@
+import { useTranslation } from 'react-i18next';
+import { View } from 'react-native';
+
+import { ScreenHeader } from '@/components/screen-header';
+import { Skeleton } from '@/components/ui/skeleton';
+import { i18n } from '@/i18n';
+
+export function repositorySelectionKey(
+  repositoryId: number,
+  platformIntegrationId: string
+): string {
+  return `${platformIntegrationId}:${repositoryId}`;
+}
+
+type SelectedRepository = {
+  repositoryId: number;
+  platformIntegrationId: string;
+};
+
+export function toggleRepositorySelection(
+  current: SelectedRepository[],
+  repositoryId: number,
+  platformIntegrationId: string
+): SelectedRepository[] {
+  const key = repositorySelectionKey(repositoryId, platformIntegrationId);
+  const selected = current.some(
+    selection =>
+      repositorySelectionKey(selection.repositoryId, selection.platformIntegrationId) === key
+  );
+  return selected
+    ? current.filter(
+        selection =>
+          repositorySelectionKey(selection.repositoryId, selection.platformIntegrationId) !== key
+      )
+    : [...current, { repositoryId, platformIntegrationId }];
+}
+
+export function installationStatusLabel(input: {
+  active: boolean;
+  hasPermissions: boolean;
+}): string {
+  if (!input.active) {
+    return i18n.t('securityAgent.dashboard.syncStatusUnavailable');
+  }
+  return input.hasPermissions
+    ? i18n.t('securityAgent.settingsOverview.enabled')
+    : i18n.t('securityAgent.scopeEntry.reauthorizeTitle');
+}
+
+export function RepositorySettingsSkeleton() {
+  const { t } = useTranslation();
+  return (
+    <View className="flex-1 bg-background">
+      <ScreenHeader title={t('securityAgent.repositories.title')} />
+      <View className="gap-3 px-6 pt-4">
+        <Skeleton className="h-11 w-full rounded-lg" />
+        <Skeleton className="h-11 w-full rounded-lg" />
+        <Skeleton className="h-12 w-full rounded-lg" />
+        <Skeleton className="h-12 w-full rounded-lg" />
+      </View>
+    </View>
+  );
+}

--- a/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
+++ b/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
@@ -21,6 +21,7 @@ export type RepositoryMultiSelectProps<TId extends RepositoryId = number> = {
   repositories: Repository<TId>[];
   selectedIds: TId[];
   onSelectionChange: (selectedIds: TId[]) => void;
+  getRepositoryKey?: (repository: Repository<TId>) => TId;
   renderRepositoryAccessory?: (repository: Repository<TId>) => React.ReactNode;
 };
 
@@ -28,6 +29,7 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
   repositories,
   selectedIds,
   onSelectionChange,
+  getRepositoryKey = repository => repository.id,
   renderRepositoryAccessory,
 }: RepositoryMultiSelectProps<TId>) {
   const [searchQuery, setSearchQuery] = useState('');
@@ -58,14 +60,16 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
   };
 
   const handleSelectAll = () => {
-    onSelectionChange(repositories.map(repo => repo.id));
+    onSelectionChange(repositories.map(getRepositoryKey));
   };
 
   const handleDeselectAll = () => {
     onSelectionChange([]);
   };
 
-  const isAllSelected = selectedIds.length === repositories.length && repositories.length > 0;
+  const isAllSelected =
+    repositories.length > 0 &&
+    repositories.every(repository => selectedIds.includes(getRepositoryKey(repository)));
   const isNoneSelected = selectedIds.length === 0;
 
   return (
@@ -119,23 +123,24 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
                   </div>
                 ) : null}
                 {group.repositories.map(repo => {
-                  const isChecked = selectedIds.includes(repo.id);
+                  const repositoryKey = getRepositoryKey(repo);
+                  const isChecked = selectedIds.includes(repositoryKey);
 
                   return (
                     <div
-                      key={repo.id}
+                      key={String(repositoryKey)}
                       className={cn(
                         'hover:bg-accent flex items-center gap-3 rounded-md p-2 transition-colors',
                         isChecked && 'bg-accent text-accent-foreground'
                       )}
                     >
                       <Checkbox
-                        id={`repo-${repo.id}`}
+                        id={`repo-${repositoryKey}`}
                         checked={isChecked}
-                        onCheckedChange={() => handleToggle(repo.id)}
+                        onCheckedChange={() => handleToggle(repositoryKey)}
                       />
                       <label
-                        htmlFor={`repo-${repo.id}`}
+                        htmlFor={`repo-${repositoryKey}`}
                         className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-sm"
                       >
                         {repo.private ? (

--- a/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
+++ b/apps/web/src/components/code-reviews/RepositoryMultiSelect.tsx
@@ -14,6 +14,7 @@ export type Repository<TId extends RepositoryId = number> = {
   name: string;
   full_name: string;
   private: boolean;
+  group?: { id: string; label: string };
 };
 
 export type RepositoryMultiSelectProps<TId extends RepositoryId = number> = {
@@ -37,6 +38,16 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
     const query = searchQuery.toLowerCase();
     return repositories.filter(repo => repo.full_name.toLowerCase().includes(query));
   }, [repositories, searchQuery]);
+  const repositoryGroups = useMemo(() => {
+    const groups = new Map<string, { label: string; repositories: Repository<TId>[] }>();
+    for (const repository of filteredRepositories) {
+      const group = repository.group ?? { id: '', label: '' };
+      const current = groups.get(group.id);
+      if (current) current.repositories.push(repository);
+      else groups.set(group.id, { label: group.label, repositories: [repository] });
+    }
+    return [...groups.entries()];
+  }, [filteredRepositories]);
 
   const handleToggle = (repoId: TId) => {
     const newSelection = selectedIds.includes(repoId)
@@ -100,37 +111,46 @@ export function RepositoryMultiSelect<TId extends RepositoryId = number>({
               {searchQuery ? 'No repositories match your search' : 'No repositories available'}
             </div>
           ) : (
-            filteredRepositories.map(repo => {
-              const isChecked = selectedIds.includes(repo.id);
+            repositoryGroups.map(([groupId, group]) => (
+              <div key={groupId || 'repositories'} className="space-y-1">
+                {group.label ? (
+                  <div className="text-muted-foreground px-2 pt-1 pb-2 text-xs font-medium">
+                    {group.label}
+                  </div>
+                ) : null}
+                {group.repositories.map(repo => {
+                  const isChecked = selectedIds.includes(repo.id);
 
-              return (
-                <div
-                  key={repo.id}
-                  className={cn(
-                    'hover:bg-accent flex items-center gap-3 rounded-md p-2 transition-colors',
-                    isChecked && 'bg-accent text-accent-foreground'
-                  )}
-                >
-                  <Checkbox
-                    id={`repo-${repo.id}`}
-                    checked={isChecked}
-                    onCheckedChange={() => handleToggle(repo.id)}
-                  />
-                  <label
-                    htmlFor={`repo-${repo.id}`}
-                    className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-sm"
-                  >
-                    {repo.private ? (
-                      <Lock className="text-primary h-3.5 w-3.5 shrink-0" />
-                    ) : (
-                      <Unlock className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
-                    )}
-                    <span className="truncate font-mono">{repo.full_name}</span>
-                    {renderRepositoryAccessory?.(repo)}
-                  </label>
-                </div>
-              );
-            })
+                  return (
+                    <div
+                      key={repo.id}
+                      className={cn(
+                        'hover:bg-accent flex items-center gap-3 rounded-md p-2 transition-colors',
+                        isChecked && 'bg-accent text-accent-foreground'
+                      )}
+                    >
+                      <Checkbox
+                        id={`repo-${repo.id}`}
+                        checked={isChecked}
+                        onCheckedChange={() => handleToggle(repo.id)}
+                      />
+                      <label
+                        htmlFor={`repo-${repo.id}`}
+                        className="flex min-w-0 flex-1 cursor-pointer items-center gap-2 text-sm"
+                      >
+                        {repo.private ? (
+                          <Lock className="text-primary h-3.5 w-3.5 shrink-0" />
+                        ) : (
+                          <Unlock className="text-muted-foreground h-3.5 w-3.5 shrink-0" />
+                        )}
+                        <span className="truncate font-mono">{repo.full_name}</span>
+                        {renderRepositoryAccessory?.(repo)}
+                      </label>
+                    </div>
+                  );
+                })}
+              </div>
+            ))
           )}
         </div>
       </div>

--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -17,11 +17,14 @@ import {
   type SecurityCommandType,
 } from '@kilocode/app-shared/security-agent';
 import type { SecurityAgentUiInteraction } from '@/lib/security-agent/core/schemas';
-import type { DependabotAlertsAvailability } from '@/lib/security-agent/core/types';
 import { isGitHubIntegrationError } from '@/lib/security-agent/core/error-display';
 import type { DismissReason } from './DismissFindingDialog';
 import { getRemediationUnavailableCopy } from './remediation-unavailable-copy';
-import type { SlaConfig } from './security-config-types';
+import type {
+  SecurityInstallationStatus,
+  SecurityRepository,
+  SlaConfig,
+} from './security-config-types';
 import {
   getSecurityAgentCommandFailureTitle,
   getSecurityAgentDismissalTerminalTitle,
@@ -44,6 +47,7 @@ type SecurityAgentContextValue = {
   isLoadingPermission: boolean;
   isLoadingConfig: boolean;
   reauthorizeUrl: string | undefined;
+  installationStatuses: SecurityInstallationStatus[];
   isEnabled: boolean | undefined;
   hasConfig: boolean;
   configData:
@@ -82,20 +86,8 @@ type SecurityAgentContextValue = {
   refetchConfig: () => Promise<unknown>;
 
   // Repositories
-  allRepositories: Array<{
-    id: number;
-    fullName: string;
-    name: string;
-    private: boolean;
-    dependabotAlerts: DependabotAlertsAvailability;
-  }>;
-  filteredRepositories: Array<{
-    id: number;
-    fullName: string;
-    name: string;
-    private: boolean;
-    dependabotAlerts: DependabotAlertsAvailability;
-  }>;
+  allRepositories: SecurityRepository[];
+  filteredRepositories: SecurityRepository[];
 
   // Mutation handlers
   trackUiInteraction: (interaction: SecurityAgentUiInteraction) => void;
@@ -204,6 +196,7 @@ export function refetchConfigOnConflictError(
 
 const COMMAND_POLL_INTERVAL_MS = 3000;
 const EMPTY_REPOSITORIES: SecurityAgentContextValue['allRepositories'] = [];
+const EMPTY_INSTALLATION_STATUSES: SecurityInstallationStatus[] = [];
 const EMPTY_REPOSITORY_IDS: number[] = [];
 const EMPTY_ORPHANED_REPOSITORIES: SecurityAgentContextValue['orphanedRepositories'] = [];
 
@@ -1385,6 +1378,7 @@ function useSecurityAgentProviderValue(
   const hasPermission = permissionData?.hasPermissions ?? false;
   const integrationId = permissionData?.integrationId ?? null;
   const reauthorizeUrl = permissionData?.reauthorizeUrl ?? undefined;
+  const installationStatuses = permissionData?.installations ?? EMPTY_INSTALLATION_STATUSES;
   const isEnabled = configData ? configData.isEnabled : undefined;
   const hasConfig = configData?.hasConfig ?? false;
   const allRepositories = reposData ?? EMPTY_REPOSITORIES;
@@ -1413,6 +1407,7 @@ function useSecurityAgentProviderValue(
       isLoadingPermission,
       isLoadingConfig,
       reauthorizeUrl,
+      installationStatuses,
       isEnabled,
       hasConfig,
       configData: configData
@@ -1477,6 +1472,7 @@ function useSecurityAgentProviderValue(
       isLoadingPermission,
       isLoadingConfig,
       reauthorizeUrl,
+      installationStatuses,
       isEnabled,
       hasConfig,
       configData,

--- a/apps/web/src/components/security-agent/SecurityAgentContext.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentContext.tsx
@@ -61,6 +61,7 @@ type SecurityAgentContextValue = {
         slaEnabled: boolean;
         repositorySelectionMode: 'all' | 'selected';
         selectedRepositoryIds: number[];
+        selectedRepositories: Array<{ repositoryId: number; platformIntegrationId: string }>;
         modelSlug?: string;
         triageModelSlug?: string;
         analysisModelSlug?: string;
@@ -103,6 +104,7 @@ type SecurityAgentContextValue = {
       slaEnabled: boolean;
       repositorySelectionMode: 'all' | 'selected';
       selectedRepositoryIds: number[];
+      selectedRepositories: Array<{ repositoryId: number; platformIntegrationId: string }>;
       triageModelSlug: string;
       analysisModelSlug: string;
       modelSlug?: string;
@@ -130,6 +132,7 @@ type SecurityAgentContextValue = {
     repositorySelection: {
       repositorySelectionMode: 'all' | 'selected';
       selectedRepositoryIds: number[];
+      selectedRepositories: Array<{ repositoryId: number; platformIntegrationId: string }>;
     }
   ) => void;
   handleStartAnalysis: (
@@ -1175,6 +1178,7 @@ function useSecurityAgentProviderValue(
         slaEnabled: boolean;
         repositorySelectionMode: 'all' | 'selected';
         selectedRepositoryIds: number[];
+        selectedRepositories: Array<{ repositoryId: number; platformIntegrationId: string }>;
         triageModelSlug: string;
         analysisModelSlug: string;
         modelSlug?: string;
@@ -1216,6 +1220,7 @@ function useSecurityAgentProviderValue(
             slaEnabled: config.slaEnabled,
             repositorySelectionMode: config.repositorySelectionMode,
             selectedRepositoryIds: config.selectedRepositoryIds,
+            selectedRepositories: config.selectedRepositories,
             analysisMode: config.analysisMode,
             autoDismissEnabled: config.autoDismissEnabled,
             autoDismissConfidenceThreshold: config.autoDismissConfidenceThreshold,
@@ -1246,6 +1251,7 @@ function useSecurityAgentProviderValue(
             slaEnabled: config.slaEnabled,
             repositorySelectionMode: config.repositorySelectionMode,
             selectedRepositoryIds: config.selectedRepositoryIds,
+            selectedRepositories: config.selectedRepositories,
             analysisMode: config.analysisMode,
             autoDismissEnabled: config.autoDismissEnabled,
             autoDismissConfidenceThreshold: config.autoDismissConfidenceThreshold,
@@ -1276,6 +1282,7 @@ function useSecurityAgentProviderValue(
       repositorySelection: {
         repositorySelectionMode: 'all' | 'selected';
         selectedRepositoryIds: number[];
+        selectedRepositories: Array<{ repositoryId: number; platformIntegrationId: string }>;
       }
     ) => {
       if (toggleEnabledInFlightRef.current) return;
@@ -1384,13 +1391,22 @@ function useSecurityAgentProviderValue(
   const allRepositories = reposData ?? EMPTY_REPOSITORIES;
   const repositorySelectionMode = configData?.repositorySelectionMode ?? 'selected';
   const selectedRepositoryIds = configData?.selectedRepositoryIds ?? EMPTY_REPOSITORY_IDS;
+  const selectedRepositories = configData?.selectedRepositories ?? [];
 
   const filteredRepositories = useMemo(
     () =>
       repositorySelectionMode === 'all'
         ? allRepositories
-        : allRepositories.filter(repo => selectedRepositoryIds.includes(repo.id)),
-    [repositorySelectionMode, allRepositories, selectedRepositoryIds]
+        : allRepositories.filter(repo =>
+            selectedRepositories.length > 0
+              ? selectedRepositories.some(
+                  selection =>
+                    selection.repositoryId === repo.id &&
+                    selection.platformIntegrationId === repo.integrationId
+                )
+              : selectedRepositoryIds.includes(repo.id)
+          ),
+    [repositorySelectionMode, allRepositories, selectedRepositoryIds, selectedRepositories]
   );
 
   const triageModelSlug = getOptionalStringField(configData, 'triageModelSlug');
@@ -1416,6 +1432,7 @@ function useSecurityAgentProviderValue(
             slaEnabled: configData.slaEnabled ?? true,
             repositorySelectionMode: configData.repositorySelectionMode ?? 'selected',
             selectedRepositoryIds: configData.selectedRepositoryIds ?? [],
+            selectedRepositories: configData.selectedRepositories ?? [],
             triageModelSlug,
             analysisModelSlug,
             analysisMode: configData.analysisMode ?? 'auto',

--- a/apps/web/src/components/security-agent/SecurityAgentLayout.tsx
+++ b/apps/web/src/components/security-agent/SecurityAgentLayout.tsx
@@ -302,6 +302,7 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
     hasIntegration,
     hasPermission,
     integrationId,
+    installationStatuses,
     isLoadingPermission,
     isLoadingConfig,
     isEnabled,
@@ -361,6 +362,9 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
   };
 
   const showPermissionRequired = hasIntegration && !hasPermission && !isLoadingPermission;
+  const installationsNeedingAttention = installationStatuses.filter(
+    installation => installation.active && !installation.hasPermissions
+  );
 
   function isActive(href: string) {
     if (href === basePath) {
@@ -462,6 +466,41 @@ export function SecurityAgentLayout({ children }: SecurityAgentLayoutProps) {
             </AlertDescription>
           </Alert>
         )}
+
+        {!showPermissionRequired && installationsNeedingAttention.length > 0 ? (
+          <Alert variant="warning">
+            <AlertTriangle className="size-4" aria-hidden="true" />
+            <AlertTitle>
+              {installationsNeedingAttention.length}{' '}
+              {installationsNeedingAttention.length === 1
+                ? 'installation needs'
+                : 'installations need'}{' '}
+              attention
+            </AlertTitle>
+            <AlertDescription className="space-y-3">
+              <p>
+                Healthy GitHub installations continue syncing. Update the affected installation
+                permissions to include its repositories.
+              </p>
+              <div className="flex flex-wrap gap-2">
+                {installationsNeedingAttention.map(installation =>
+                  installation.reauthorizeUrl ? (
+                    <Button key={installation.integrationId} variant="outline" size="sm" asChild>
+                      <a
+                        href={installation.reauthorizeUrl}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                      >
+                        <ExternalLink className="size-4" aria-hidden="true" />
+                        Re-authorize {installation.accountLogin ?? 'GitHub App'}
+                      </a>
+                    </Button>
+                  ) : null
+                )}
+              </div>
+            </AlertDescription>
+          </Alert>
+        ) : null}
 
         {children}
       </div>

--- a/apps/web/src/components/security-agent/SecurityConfigForm.test.ts
+++ b/apps/web/src/components/security-agent/SecurityConfigForm.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from '@jest/globals';
 import {
   buildSecurityConfigFormState,
   buildSecurityConfigSavePayload,
+  toRepositoryOptions,
   type SecurityConfigFormState,
 } from './security-config-types';
 
@@ -48,5 +49,26 @@ describe('SecurityConfigForm config round-trip', () => {
     const formState = buildSecurityConfigFormState(undefined);
 
     expect(formState.autoRemediationRequireApproval).toBe(true);
+  });
+
+  it('preserves installation provenance for repository grouping and selection', () => {
+    expect(
+      toRepositoryOptions([
+        {
+          id: 42,
+          fullName: 'acme-labs/app',
+          name: 'app',
+          private: true,
+          dependabotAlerts: 'enabled',
+          integrationId: 'integration-labs',
+          accountLogin: 'acme-labs',
+        },
+      ])
+    ).toEqual([
+      expect.objectContaining({
+        id: 42,
+        group: { id: 'integration-labs', label: 'acme-labs' },
+      }),
+    ]);
   });
 });

--- a/apps/web/src/components/security-agent/SecurityConfigForm.test.ts
+++ b/apps/web/src/components/security-agent/SecurityConfigForm.test.ts
@@ -11,6 +11,7 @@ const baseFormState: SecurityConfigFormState = {
   slaEnabled: true,
   repositorySelectionMode: 'selected',
   selectedRepositoryIds: [],
+  selectedRepositories: [],
   triageModelSlug: 'triage-model',
   analysisModelSlug: 'analysis-model',
   analysisMode: 'auto',
@@ -70,5 +71,21 @@ describe('SecurityConfigForm config round-trip', () => {
         group: { id: 'integration-labs', label: 'acme-labs' },
       }),
     ]);
+  });
+
+  it('round trips duplicate repository IDs from separate installations', () => {
+    const selectedRepositories = [
+      { repositoryId: 42, platformIntegrationId: 'integration-core' },
+      { repositoryId: 42, platformIntegrationId: 'integration-labs' },
+    ];
+    const state = buildSecurityConfigFormState({
+      selectedRepositoryIds: [42],
+      selectedRepositories,
+    });
+
+    expect(buildSecurityConfigSavePayload(state)).toMatchObject({
+      selectedRepositoryIds: [42],
+      selectedRepositories,
+    });
   });
 });

--- a/apps/web/src/components/security-agent/SecurityConfigForm.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigForm.tsx
@@ -51,6 +51,7 @@ import {
 import type {
   SecurityConfigFormState,
   SecurityConfigSavePayload,
+  SecurityInstallationStatus,
   SecurityRepository,
   SlaConfig,
 } from './security-config-types';
@@ -62,6 +63,7 @@ type SecurityConfigFormProps = {
   organizationId?: string;
   initialConfig: SecurityConfigFormState;
   repositories: SecurityRepository[];
+  installationStatuses: SecurityInstallationStatus[];
   viewState: {
     enabled: boolean;
     isLoadingRepositories?: boolean;
@@ -218,6 +220,7 @@ export function SecurityConfigForm({
   organizationId,
   initialConfig,
   repositories,
+  installationStatuses,
   viewState,
   onSave,
   onToggleEnabled,
@@ -440,6 +443,7 @@ export function SecurityConfigForm({
             availableRepositoryCount={repositories.length}
             repositoryCount={repositoryCount}
             slaEnabled={state.slaEnabled}
+            installationStatuses={installationStatuses}
             onToggle={nextEnabled =>
               onToggleEnabled(nextEnabled, {
                 repositorySelectionMode: state.repositorySelectionMode,

--- a/apps/web/src/components/security-agent/SecurityConfigForm.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigForm.tsx
@@ -78,7 +78,7 @@ type SecurityConfigFormProps = {
     enabled: boolean,
     repositorySelection: Pick<
       SecurityConfigFormState,
-      'repositorySelectionMode' | 'selectedRepositoryIds'
+      'repositorySelectionMode' | 'selectedRepositoryIds' | 'selectedRepositories'
     >
   ) => void;
 };
@@ -103,6 +103,7 @@ const DEFAULT_FORM_CONFIG: SecurityConfigFormState = {
   slaEnabled: true,
   repositorySelectionMode: 'selected',
   selectedRepositoryIds: [],
+  selectedRepositories: [],
   triageModelSlug: DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
   analysisModelSlug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
   analysisMode: 'auto',
@@ -132,6 +133,9 @@ function configFingerprint(config: SecurityConfigFormState) {
     config.slaEnabled,
     config.repositorySelectionMode,
     sortedIds(config.selectedRepositoryIds),
+    config.selectedRepositories
+      .map(selection => `${selection.platformIntegrationId}:${selection.repositoryId}`)
+      .toSorted(),
     config.triageModelSlug,
     config.analysisModelSlug,
     config.analysisMode,
@@ -265,7 +269,7 @@ export function SecurityConfigForm({
   const repositoryCount =
     state.repositorySelectionMode === 'all'
       ? repositories.length
-      : state.selectedRepositoryIds.length;
+      : state.selectedRepositories.length || state.selectedRepositoryIds.length;
   const stateProps = { state, setState };
 
   const handleSave = (options?: { onSuccess?: () => void; onError?: () => void }) => {
@@ -408,6 +412,7 @@ export function SecurityConfigForm({
                       ...DEFAULT_FORM_CONFIG,
                       slaConfig: { ...DEFAULT_FORM_CONFIG.slaConfig },
                       selectedRepositoryIds: [],
+                      selectedRepositories: [],
                     })
                   }
                   disabled={isSaving}
@@ -448,6 +453,7 @@ export function SecurityConfigForm({
               onToggleEnabled(nextEnabled, {
                 repositorySelectionMode: state.repositorySelectionMode,
                 selectedRepositoryIds: state.selectedRepositoryIds,
+                selectedRepositories: state.selectedRepositories,
               })
             }
           />

--- a/apps/web/src/components/security-agent/SecurityConfigPage.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigPage.tsx
@@ -59,6 +59,7 @@ export function SecurityConfigPage() {
     slaEnabled: configData?.slaEnabled ?? true,
     repositorySelectionMode: configData?.repositorySelectionMode ?? 'selected',
     selectedRepositoryIds: configData?.selectedRepositoryIds ?? [],
+    selectedRepositories: configData?.selectedRepositories ?? [],
     triageModelSlug:
       configData?.triageModelSlug ?? configData?.modelSlug ?? DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
     analysisModelSlug:

--- a/apps/web/src/components/security-agent/SecurityConfigPage.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigPage.tsx
@@ -21,6 +21,7 @@ export function SecurityConfigPage() {
     isEnabled,
     configData,
     allRepositories,
+    installationStatuses,
     handleSaveConfig,
     handleToggleEnabled,
     handleDeleteFindings,
@@ -92,6 +93,7 @@ export function SecurityConfigPage() {
         organizationId={organizationId}
         initialConfig={initialConfig}
         repositories={allRepositories}
+        installationStatuses={installationStatuses}
         viewState={{
           enabled: isEnabled ?? false,
           isSaving: isSavingConfig,

--- a/apps/web/src/components/security-agent/SecurityConfigSections.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigSections.tsx
@@ -30,6 +30,7 @@ import type {
   AutoRemediationMinSeverity,
   NotificationMinSeverity,
   SecurityConfigFormState,
+  SecurityInstallationStatus,
   SecurityRepository,
   SlaConfig,
 } from './security-config-types';
@@ -451,6 +452,7 @@ export function AgentStatusSection({
   availableRepositoryCount,
   repositoryCount,
   slaEnabled,
+  installationStatuses,
   onToggle,
 }: {
   enabled: boolean;
@@ -458,6 +460,7 @@ export function AgentStatusSection({
   availableRepositoryCount: number;
   repositoryCount: number;
   slaEnabled: boolean;
+  installationStatuses: SecurityInstallationStatus[];
   onToggle: (enabled: boolean) => void;
 }) {
   const description = enabled
@@ -474,7 +477,7 @@ export function AgentStatusSection({
         icon={Settings}
         title="Security Agent"
         description={description}
-        hasContent={false}
+        hasContent={installationStatuses.length > 0}
         action={
           <SectionToggle
             id="security-agent-enabled"
@@ -485,6 +488,44 @@ export function AgentStatusSection({
           />
         }
       />
+      {installationStatuses.length > 0 ? (
+        <CardContent>
+          <div className="border-border divide-border divide-y rounded-lg border">
+            {installationStatuses.map(installation => {
+              const status = !installation.active
+                ? 'Installation unavailable'
+                : installation.hasPermissions
+                  ? 'Ready to sync'
+                  : installation.authInvalidAt
+                    ? 'Re-authorization required'
+                    : 'Additional permission required';
+              return (
+                <div
+                  key={installation.integrationId}
+                  className="flex min-h-11 flex-wrap items-center justify-between gap-3 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium">
+                      {installation.accountLogin ?? 'GitHub account'}
+                    </p>
+                    <p className="text-muted-foreground text-xs">{status}</p>
+                  </div>
+                  {installation.reauthorizeUrl ? (
+                    <a
+                      href={installation.reauthorizeUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-primary focus-visible:ring-ring rounded-sm text-xs font-medium underline-offset-4 hover:underline focus-visible:ring-2 focus-visible:outline-none"
+                    >
+                      Re-authorize GitHub App
+                    </a>
+                  ) : null}
+                </div>
+              );
+            })}
+          </div>
+        </CardContent>
+      ) : null}
     </Card>
   );
 }

--- a/apps/web/src/components/security-agent/SecurityConfigSections.tsx
+++ b/apps/web/src/components/security-agent/SecurityConfigSections.tsx
@@ -336,17 +336,33 @@ export function RepositorySection({
   repositories: SecurityRepository[];
   isLoading?: boolean;
 }) {
-  const dependabotAlertsByRepositoryId = new Map(
-    repositories.map(repository => [repository.id, repository.dependabotAlerts])
+  const repositoryKey = (repository: SecurityRepository) =>
+    `${repository.integrationId}:${repository.id}`;
+  const dependabotAlertsByRepositoryKey = new Map(
+    repositories.map(repository => [repositoryKey(repository), repository.dependabotAlerts])
   );
   const disabledRepositories = repositories.filter(
     repository => repository.dependabotAlerts === 'disabled'
   );
-  const selectedRepositoryIds = new Set(state.selectedRepositoryIds);
+  const selectedRepositoryKeys = new Set(
+    state.selectedRepositories.map(
+      selection => `${selection.platformIntegrationId}:${selection.repositoryId}`
+    )
+  );
+  const usesCompositeSelection = state.selectedRepositories.length > 0;
+  const selectedRepositoryOptionKeys = usesCompositeSelection
+    ? [...selectedRepositoryKeys]
+    : repositories
+        .filter(repository => state.selectedRepositoryIds.includes(repository.id))
+        .map(repositoryKey);
   const selectedDisabledRepositories =
     state.repositorySelectionMode === 'all'
       ? disabledRepositories
-      : disabledRepositories.filter(repository => selectedRepositoryIds.has(repository.id));
+      : disabledRepositories.filter(repository =>
+          usesCompositeSelection
+            ? selectedRepositoryKeys.has(repositoryKey(repository))
+            : state.selectedRepositoryIds.includes(repository.id)
+        );
   const displayedDisabledRepositories = selectedDisabledRepositories.slice(0, 5);
   const additionalDisabledRepositoryCount =
     selectedDisabledRepositories.length - displayedDisabledRepositories.length;
@@ -417,13 +433,28 @@ export function RepositorySection({
               <div className="space-y-2">
                 <Label>Repositories</Label>
                 <RepositoryMultiSelect
-                  repositories={toRepositoryOptions(repositories)}
-                  selectedIds={state.selectedRepositoryIds}
-                  onSelectionChange={selectedRepositoryIds =>
-                    setState(current => ({ ...current, selectedRepositoryIds }))
+                  repositories={toRepositoryOptions(repositories).map(repository => ({
+                    ...repository,
+                    id: `${repository.group?.id}:${repository.id}`,
+                  }))}
+                  selectedIds={selectedRepositoryOptionKeys}
+                  onSelectionChange={selectedRepositoryKeys =>
+                    setState(current => {
+                      const selectedRepositories = selectedRepositoryKeys.map(key => {
+                        const [platformIntegrationId, repositoryId] = key.split(':');
+                        return { repositoryId: Number(repositoryId), platformIntegrationId };
+                      });
+                      return {
+                        ...current,
+                        selectedRepositories,
+                        selectedRepositoryIds: [
+                          ...new Set(selectedRepositories.map(selection => selection.repositoryId)),
+                        ],
+                      };
+                    })
                   }
                   renderRepositoryAccessory={repository => {
-                    if (dependabotAlertsByRepositoryId.get(repository.id) !== 'disabled') {
+                    if (dependabotAlertsByRepositoryKey.get(repository.id) !== 'disabled') {
                       return null;
                     }
 

--- a/apps/web/src/components/security-agent/security-config-types.ts
+++ b/apps/web/src/components/security-agent/security-config-types.ts
@@ -26,6 +26,18 @@ export type SecurityRepository = {
   name: string;
   private: boolean;
   dependabotAlerts: DependabotAlertsAvailability;
+  integrationId: string;
+  accountLogin: string | null;
+};
+
+export type SecurityInstallationStatus = {
+  integrationId: string;
+  accountLogin: string | null;
+  active: boolean;
+  hasPermissions: boolean;
+  reauthorizeUrl: string | null;
+  authInvalidAt: string | null;
+  authInvalidReason: string | null;
 };
 
 export type SecurityConfigFormState = {
@@ -166,5 +178,9 @@ export function toRepositoryOptions(repositories: SecurityRepository[]): Reposit
     name: repository.name,
     full_name: repository.fullName,
     private: repository.private,
+    group: {
+      id: repository.integrationId,
+      label: repository.accountLogin ?? 'GitHub account',
+    },
   }));
 }

--- a/apps/web/src/components/security-agent/security-config-types.ts
+++ b/apps/web/src/components/security-agent/security-config-types.ts
@@ -19,6 +19,10 @@ export type AutoAnalysisMinSeverity = 'critical' | 'high' | 'medium' | 'all';
 export type AutoRemediationMinSeverity = 'critical' | 'high' | 'medium' | 'all';
 export type NotificationMinSeverity = 'critical' | 'high' | 'medium' | 'low';
 export type RepositorySelectionMode = 'all' | 'selected';
+export type SelectedSecurityRepository = {
+  repositoryId: number;
+  platformIntegrationId: string;
+};
 
 export type SecurityRepository = {
   id: number;
@@ -45,6 +49,7 @@ export type SecurityConfigFormState = {
   slaEnabled: boolean;
   repositorySelectionMode: RepositorySelectionMode;
   selectedRepositoryIds: number[];
+  selectedRepositories: SelectedSecurityRepository[];
   triageModelSlug: string;
   analysisModelSlug: string;
   analysisMode: AnalysisMode;
@@ -79,6 +84,7 @@ export type SecurityConfigFormSource = {
   slaEnabled?: boolean;
   repositorySelectionMode?: RepositorySelectionMode;
   selectedRepositoryIds?: number[];
+  selectedRepositories?: SelectedSecurityRepository[];
   triageModelSlug?: string;
   analysisModelSlug?: string;
   modelSlug?: string;
@@ -113,6 +119,7 @@ export function buildSecurityConfigFormState(
     slaEnabled: configData?.slaEnabled ?? true,
     repositorySelectionMode: configData?.repositorySelectionMode ?? 'selected',
     selectedRepositoryIds: configData?.selectedRepositoryIds ?? [],
+    selectedRepositories: configData?.selectedRepositories ?? [],
     triageModelSlug:
       configData?.triageModelSlug ?? configData?.modelSlug ?? DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
     analysisModelSlug:
@@ -150,6 +157,7 @@ export function buildSecurityConfigSavePayload(
     slaEnabled: state.slaEnabled,
     repositorySelectionMode: state.repositorySelectionMode,
     selectedRepositoryIds: state.selectedRepositoryIds,
+    selectedRepositories: state.selectedRepositories,
     triageModelSlug: state.triageModelSlug,
     analysisModelSlug: state.analysisModelSlug,
     modelSlug: state.analysisModelSlug,

--- a/apps/web/src/lib/security-agent/core/schemas.ts
+++ b/apps/web/src/lib/security-agent/core/schemas.ts
@@ -55,6 +55,14 @@ export const SaveSecurityConfigInputSchema = z.object({
   autoSyncEnabled: z.boolean().optional(),
   repositorySelectionMode: RepositorySelectionModeSchema.optional(),
   selectedRepositoryIds: z.array(z.number()).optional(),
+  selectedRepositories: z
+    .array(
+      z.object({
+        repositoryId: z.number().int().positive(),
+        platformIntegrationId: z.string().uuid(),
+      })
+    )
+    .optional(),
   modelSlug: z.string().optional(),
   triageModelSlug: z.string().optional(),
   analysisModelSlug: z.string().optional(),
@@ -126,6 +134,14 @@ export const SetEnabledInputSchema = z.object({
   isEnabled: z.boolean(),
   repositorySelectionMode: RepositorySelectionModeSchema.optional(),
   selectedRepositoryIds: z.array(z.number()).optional(),
+  selectedRepositories: z
+    .array(
+      z.object({
+        repositoryId: z.number().int().positive(),
+        platformIntegrationId: z.string().uuid(),
+      })
+    )
+    .optional(),
 });
 
 export const AnalysisStatusSchema = z.enum(['pending', 'running', 'completed', 'failed']);

--- a/apps/web/src/lib/security-agent/core/types.ts
+++ b/apps/web/src/lib/security-agent/core/types.ts
@@ -61,6 +61,14 @@ export const SecurityAgentConfigSchema = z
     auto_sync_enabled: z.boolean().default(true),
     repository_selection_mode: z.enum(['all', 'selected']).default('all'),
     selected_repository_ids: z.array(z.number()).optional(),
+    selected_repositories: z
+      .array(
+        z.object({
+          repositoryId: z.number().int().positive(),
+          platformIntegrationId: z.string().uuid(),
+        })
+      )
+      .optional(),
     model_slug: z.string().optional(),
     triage_model_slug: z.string().optional(),
     analysis_model_slug: z.string().optional(),

--- a/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
@@ -102,7 +102,11 @@ jest.mock('@kilocode/db/operation-ledger', () => ({
   settleOperation: mockSettleOperation,
 }));
 jest.mock('../github/permissions', () => ({
-  hasSecurityReviewPermissions: () => true,
+  hasSecurityReviewPermissions: (integration: { permissions?: Record<string, string> }) => {
+    if (!integration.permissions) return true;
+    const permission = integration.permissions.vulnerability_alerts;
+    return permission === 'read' || permission === 'write';
+  },
   getReauthorizeUrl: mockGetReauthorizeUrl,
 }));
 jest.mock('../github/dependabot-api', () => ({
@@ -203,6 +207,10 @@ function createHandlers() {
         id: 'integration-123',
         integration_status: 'active',
         platform_installation_id: 'installation-123',
+        platform_account_login: 'kilo',
+        permissions: { vulnerability_alerts: 'read' },
+        suspended_at: null,
+        auth_invalid_at: null,
         repositories: [{ id: 1, full_name: 'kilo/repo', name: 'repo', private: true }],
       }) as never,
     trackingExtras: () => ({}),
@@ -295,8 +303,80 @@ describe('getPermissionStatus', () => {
       reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-123',
       authInvalidAt: '2026-06-25 18:00:00+00',
       authInvalidReason: 'installation_token_auth_failed',
+      installations: [
+        {
+          integrationId: 'integration-123',
+          accountLogin: null,
+          active: true,
+          hasPermissions: false,
+          reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-123',
+          authInvalidAt: '2026-06-25 18:00:00+00',
+          authInvalidReason: 'installation_token_auth_failed',
+        },
+      ],
     });
     expect(mockGetReauthorizeUrl).toHaveBeenCalledWith('installation-123');
+  });
+
+  it('keeps the aggregate ready when an unhealthy sibling needs reauthorization', async () => {
+    const handlers = createSecurityAgentHandlers({
+      resolveOwner: () => ({ type: 'org', id: 'org-1', userId: 'user-123' }),
+      resolveSecurityOwner: () => ({ organizationId: 'org-1' }),
+      resolveResourceId: () => 'org-1',
+      verifyFindingOwnership: () => true,
+      getIntegration: async () => null,
+      getIntegrations: async () =>
+        [
+          {
+            id: 'healthy',
+            integration_status: 'active',
+            platform_installation_id: 'installation-1',
+            platform_account_login: 'acme-core',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+          },
+          {
+            id: 'unhealthy',
+            integration_status: 'active',
+            platform_installation_id: 'installation-2',
+            platform_account_login: 'acme-labs',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: '2026-08-20 12:00:00+00',
+            auth_invalid_reason: 'github_dependabot_401',
+          },
+          {
+            id: 'missing-permission',
+            integration_status: 'active',
+            platform_installation_id: 'installation-3',
+            platform_account_login: 'acme-public',
+            permissions: {},
+            suspended_at: null,
+            auth_invalid_at: null,
+          },
+        ] as never,
+      trackingExtras: () => ({}),
+    });
+
+    await expect(handlers.getPermissionStatus({ ctx: context, input: {} })).resolves.toMatchObject({
+      hasIntegration: true,
+      hasPermissions: true,
+      integrationId: 'healthy',
+      installations: [
+        expect.objectContaining({ integrationId: 'healthy', hasPermissions: true }),
+        expect.objectContaining({
+          integrationId: 'unhealthy',
+          hasPermissions: false,
+          reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-2',
+        }),
+        expect.objectContaining({
+          integrationId: 'missing-permission',
+          hasPermissions: false,
+          reauthorizeUrl: 'https://github.com/apps/kilocode/installations/installation-3',
+        }),
+      ],
+    });
   });
 });
 
@@ -365,6 +445,8 @@ describe('getRepositories', () => {
         fullName: 'kilo/repo',
         name: 'repo',
         private: true,
+        integrationId: 'integration-123',
+        accountLogin: 'kilo',
         dependabotAlerts: 'disabled',
       },
     ]);
@@ -378,6 +460,8 @@ describe('getRepositories', () => {
           fullName: 'kilo/repo',
           name: 'repo',
           private: true,
+          integrationId: 'integration-123',
+          accountLogin: 'kilo',
         },
       ]
     );
@@ -389,6 +473,117 @@ describe('getRepositories', () => {
     await expect(createHandlers().getRepositories({ ctx: context, input: {} })).resolves.toEqual([
       expect.objectContaining({ id: 1, dependabotAlerts: 'unknown' }),
     ]);
+  });
+
+  it('groups repositories by healthy installation and ignores an unhealthy sibling', async () => {
+    const handlers = createSecurityAgentHandlers({
+      resolveOwner: () => ({ type: 'org', id: 'org-1', userId: 'user-123' }),
+      resolveSecurityOwner: () => ({ organizationId: 'org-1' }),
+      resolveResourceId: () => 'org-1',
+      verifyFindingOwnership: () => true,
+      getIntegration: async () => null,
+      getIntegrations: async () =>
+        [
+          {
+            id: 'healthy-1',
+            platform: 'github',
+            integration_status: 'active',
+            platform_installation_id: 'installation-1',
+            platform_account_login: 'acme-core',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 11, full_name: 'acme-core/api', name: 'api', private: true }],
+          },
+          {
+            id: 'healthy-2',
+            platform: 'github',
+            integration_status: 'active',
+            platform_installation_id: 'installation-2',
+            platform_account_login: 'acme-labs',
+            permissions: { vulnerability_alerts: 'write' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 22, full_name: 'acme-labs/app', name: 'app', private: false }],
+          },
+          {
+            id: 'unhealthy',
+            platform: 'github',
+            integration_status: 'active',
+            platform_installation_id: 'installation-3',
+            platform_account_login: 'acme-old',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: '2026-08-20 12:00:00+00',
+            repositories: [{ id: 33, full_name: 'acme-old/legacy', name: 'legacy', private: true }],
+          },
+        ] as never,
+      trackingExtras: () => ({}),
+    });
+
+    await expect(handlers.getRepositories({ ctx: context, input: {} })).resolves.toEqual([
+      expect.objectContaining({
+        id: 11,
+        integrationId: 'healthy-1',
+        accountLogin: 'acme-core',
+      }),
+      expect.objectContaining({
+        id: 22,
+        integrationId: 'healthy-2',
+        accountLogin: 'acme-labs',
+      }),
+    ]);
+  });
+});
+
+describe('multi-installation selection', () => {
+  it('accepts a selected repository from a secondary healthy installation', async () => {
+    mockSubmitManualSecuritySync.mockResolvedValue({
+      accepted: true,
+      commandId,
+      runId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      messageId: 'enable-sync-message-123',
+    });
+    const handlers = createSecurityAgentHandlers({
+      resolveOwner: () => ({ type: 'org', id: 'org-1', userId: 'user-123' }),
+      resolveSecurityOwner: () => ({ organizationId: 'org-1' }),
+      resolveResourceId: () => 'org-1',
+      verifyFindingOwnership: () => true,
+      getIntegration: async () => null,
+      getIntegrations: async () =>
+        [
+          {
+            id: 'primary',
+            integration_status: 'active',
+            platform_installation_id: 'installation-1',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 11, full_name: 'acme-core/api', name: 'api', private: true }],
+          },
+          {
+            id: 'secondary',
+            integration_status: 'active',
+            platform_installation_id: 'installation-2',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 22, full_name: 'acme-labs/app', name: 'app', private: false }],
+          },
+        ] as never,
+      trackingExtras: () => ({}),
+    });
+
+    await expect(
+      handlers.setEnabled.handler({
+        ctx: context,
+        input: {
+          isEnabled: true,
+          repositorySelectionMode: 'selected',
+          selectedRepositoryIds: [22],
+        },
+      })
+    ).resolves.toMatchObject({ success: true });
   });
 });
 

--- a/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.test.ts
@@ -585,6 +585,71 @@ describe('multi-installation selection', () => {
       })
     ).resolves.toMatchObject({ success: true });
   });
+
+  it('distinguishes duplicate repository IDs by installation', async () => {
+    mockSubmitManualSecuritySync.mockResolvedValue({
+      accepted: true,
+      commandId,
+      runId: 'dddddddd-dddd-4ddd-8ddd-dddddddddddd',
+      messageId: 'enable-sync-message-123',
+    });
+    const handlers = createSecurityAgentHandlers({
+      resolveOwner: () => ({ type: 'org', id: 'org-1', userId: 'user-123' }),
+      resolveSecurityOwner: () => ({ organizationId: 'org-1' }),
+      resolveResourceId: () => 'org-1',
+      verifyFindingOwnership: () => true,
+      getIntegration: async () => null,
+      getIntegrations: async () =>
+        [
+          {
+            id: 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa',
+            integration_status: 'active',
+            platform_installation_id: 'installation-1',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 22, full_name: 'acme-core/app', name: 'app', private: true }],
+          },
+          {
+            id: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+            integration_status: 'active',
+            platform_installation_id: 'installation-2',
+            permissions: { vulnerability_alerts: 'read' },
+            suspended_at: null,
+            auth_invalid_at: null,
+            repositories: [{ id: 22, full_name: 'acme-labs/app', name: 'app', private: false }],
+          },
+        ] as never,
+      trackingExtras: () => ({}),
+    });
+    const selectedRepositories = [
+      {
+        repositoryId: 22,
+        platformIntegrationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      },
+    ];
+
+    await expect(
+      handlers.setEnabled.handler({
+        ctx: context,
+        input: {
+          isEnabled: true,
+          repositorySelectionMode: 'selected',
+          selectedRepositoryIds: [22],
+          selectedRepositories,
+        },
+      })
+    ).resolves.toMatchObject({ success: true });
+
+    expect(mockUpsertSecurityAgentConfig).toHaveBeenCalledWith(
+      { type: 'org', id: 'org-1', userId: 'user-123' },
+      expect.objectContaining({
+        selected_repository_ids: [22],
+        selected_repositories: selectedRepositories,
+      }),
+      'user-123'
+    );
+  });
 });
 
 describe('getConfig', () => {
@@ -749,6 +814,34 @@ describe('setEnabled', () => {
 });
 
 describe('saveConfig', () => {
+  it('persists composite selections alongside compatibility IDs', async () => {
+    const selectedRepositories = [
+      {
+        repositoryId: 22,
+        platformIntegrationId: 'bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb',
+      },
+    ];
+
+    await createHandlers().saveConfig.handler({
+      ctx: context,
+      input: {
+        expectedRevision: null,
+        repositorySelectionMode: 'selected',
+        selectedRepositoryIds: [22],
+        selectedRepositories,
+      },
+    });
+
+    expect(mockSaveSecurityAgentConfigWithRevision).toHaveBeenCalledWith(
+      expect.objectContaining({
+        config: expect.objectContaining({
+          selected_repository_ids: [22],
+          selected_repositories: selectedRepositories,
+        }),
+      })
+    );
+  });
+
   it('delegates to the CAS save and returns the queued count', async () => {
     mockSaveSecurityAgentConfigWithRevision.mockResolvedValue({
       newRevision: 2,

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/admin/admin-access-log';
 import { TRPCError } from '@trpc/server';
 import {
+  type getAllIntegrationsForOwner,
   type getIntegrationForOwner,
   updateRepositoriesForIntegration,
 } from '@/lib/integrations/db/platform-integrations';
@@ -146,7 +147,8 @@ import {
 
 type Owner = { type: 'user' | 'org'; id: string; userId: string };
 
-type Integration = Awaited<ReturnType<typeof getIntegrationForOwner>> | null;
+type Integration = NonNullable<Awaited<ReturnType<typeof getIntegrationForOwner>>>;
+type Integrations = Awaited<ReturnType<typeof getAllIntegrationsForOwner>>;
 
 /**
  * TExtra represents additional input fields injected by the tRPC procedure middleware.
@@ -158,16 +160,19 @@ type SecurityAgentDeps<TExtra = {}> = {
   resolveSecurityOwner: (ctx: TRPCContext, input: TExtra) => SecurityReviewOwner;
   resolveResourceId: (ctx: TRPCContext, input: TExtra) => string;
   verifyFindingOwnership: (finding: SecurityFinding, ctx: TRPCContext, input: TExtra) => boolean;
-  getIntegration: (ctx: TRPCContext, input: TExtra) => Promise<Integration>;
-  getStatusIntegration?: (ctx: TRPCContext, input: TExtra) => Promise<Integration>;
+  getIntegration: (ctx: TRPCContext, input: TExtra) => Promise<Integration | null>;
+  getStatusIntegration?: (ctx: TRPCContext, input: TExtra) => Promise<Integration | null>;
+  getIntegrations?: (ctx: TRPCContext, input: TExtra) => Promise<Integrations>;
   trackingExtras: (ctx: TRPCContext, input: TExtra) => { organizationId?: string };
 };
 
 function getRepoFullNamesInScope(
-  integration: Integration,
+  integrations: Integration[],
   config: { repository_selection_mode?: 'all' | 'selected'; selected_repository_ids?: number[] }
 ): string[] {
-  const repositories = requireNumericPlatformRepositories(integration?.repositories ?? null) ?? [];
+  const repositories = integrations.flatMap(
+    integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+  );
   if (config.repository_selection_mode === 'all') {
     return repositories.map(repo => repo.full_name).filter((name): name is string => !!name);
   }
@@ -176,6 +181,18 @@ function getRepoFullNamesInScope(
     .filter(repo => selectedIds.has(repo.id))
     .map(repo => repo.full_name)
     .filter((name): name is string => !!name);
+}
+
+function isIntegrationHealthy(integration: Integration): boolean {
+  return (
+    integration.integration_status === 'active' &&
+    !integration.suspended_at &&
+    !integration.auth_invalid_at
+  );
+}
+
+function isSecurityIntegrationReady(integration: Integration): boolean {
+  return isIntegrationHealthy(integration) && hasSecurityReviewPermissions(integration);
 }
 
 async function resolveAuditReportOwner(
@@ -701,6 +718,12 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const toExtra = (input: unknown): TExtra => (input ?? {}) as any;
 
+  const getIntegrations = async (ctx: TRPCContext, input: TExtra): Promise<Integration[]> => {
+    if (deps.getIntegrations) return deps.getIntegrations(ctx, input);
+    const integration = await deps.getIntegration(ctx, input);
+    return integration ? [integration] : [];
+  };
+
   return {
     trackUiInteraction: {
       inputSchema: TrackSecurityAgentUiInteractionInputSchema,
@@ -727,35 +750,46 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
     // -----------------------------------------------------------------------
     getPermissionStatus: async ({ ctx, input }: { ctx: TRPCContext; input: unknown }) => {
       const extra = toExtra(input);
-      const integration = await (deps.getStatusIntegration ?? deps.getIntegration)(ctx, extra);
-
-      if (!integration || integration.integration_status !== 'active') {
+      const integrations = deps.getIntegrations
+        ? await deps.getIntegrations(ctx, extra)
+        : await (async () => {
+            const integration = await (deps.getStatusIntegration ?? deps.getIntegration)(
+              ctx,
+              extra
+            );
+            return integration ? [integration] : [];
+          })();
+      const installations = integrations.map(integration => {
+        const active = integration.integration_status === 'active' && !integration.suspended_at;
+        const hasPermissions = active && isSecurityIntegrationReady(integration);
         return {
-          hasIntegration: false,
-          hasPermissions: false,
-          integrationId: null,
-          reauthorizeUrl: null,
-          authInvalidAt: integration?.auth_invalid_at ?? null,
-          authInvalidReason: integration?.auth_invalid_reason ?? null,
+          integrationId: integration.id,
+          accountLogin: integration.platform_account_login ?? null,
+          active,
+          hasPermissions,
+          reauthorizeUrl:
+            active && !hasPermissions && integration.platform_installation_id
+              ? getReauthorizeUrl(integration.platform_installation_id)
+              : null,
+          authInvalidAt: integration.auth_invalid_at ?? null,
+          authInvalidReason: integration.auth_invalid_reason ?? null,
         };
-      }
-
-      const hasPermissions = hasSecurityReviewPermissions(integration);
-      // UI reauthorization state is intentionally time-invariant: once GitHub returns
-      // auth-invalid, keep prompting until a sync or install-refresh path clears the flag.
-      const hasEffectivePermissions = hasPermissions && !integration.auth_invalid_at;
+      });
+      const activeInstallations = installations.filter(installation => installation.active);
+      const authorizedInstallation = activeInstallations.find(
+        installation => installation.hasPermissions
+      );
+      const fallbackInstallation = activeInstallations[0];
 
       return {
-        hasIntegration: true,
-        integrationId: integration.id,
-        hasPermissions: hasEffectivePermissions,
-        reauthorizeUrl: hasEffectivePermissions
-          ? null
-          : integration.platform_installation_id
-            ? getReauthorizeUrl(integration.platform_installation_id)
-            : null,
-        authInvalidAt: integration.auth_invalid_at,
-        authInvalidReason: integration.auth_invalid_reason,
+        hasIntegration: activeInstallations.length > 0,
+        integrationId:
+          authorizedInstallation?.integrationId ?? fallbackInstallation?.integrationId ?? null,
+        hasPermissions: authorizedInstallation !== undefined,
+        reauthorizeUrl: fallbackInstallation?.reauthorizeUrl ?? null,
+        authInvalidAt: fallbackInstallation?.authInvalidAt ?? null,
+        authInvalidReason: fallbackInstallation?.authInvalidReason ?? null,
+        installations,
       };
     },
 
@@ -1143,12 +1177,11 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         const securityOwner = deps.resolveSecurityOwner(ctx, input);
         const resourceId = deps.resolveResourceId(ctx, input);
 
-        // Get integration (needed for both permission check and sync)
-        const integration = await deps.getIntegration(ctx, input);
+        const integrations = (await getIntegrations(ctx, input)).filter(isSecurityIntegrationReady);
 
         // Check permissions before enabling
         if (input.isEnabled) {
-          if (!integration || !hasSecurityReviewPermissions(integration)) {
+          if (integrations.length === 0) {
             throw new TRPCError({
               code: 'PRECONDITION_FAILED',
               message: 'GitHub App does not have vulnerability_alerts permission',
@@ -1168,7 +1201,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         // Refuse enabling with an empty effective repo set: no repository would
         // be synced or analyzed, so an enabled state would be misleading.
         if (input.isEnabled) {
-          const effectiveRepos = getRepoFullNamesInScope(integration, {
+          const effectiveRepos = getRepoFullNamesInScope(integrations, {
             repository_selection_mode: selectionMode,
             selected_repository_ids: selectedIds,
           });
@@ -1195,74 +1228,75 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         await setSecurityAgentEnabled(owner, input.isEnabled);
 
         // When enabling, trigger an initial sync of repositories
-        if (input.isEnabled && integration) {
-          const installationId = integration.platform_installation_id;
-          if (installationId) {
-            const allRepos = requireNumericPlatformRepositories(integration.repositories) ?? [];
+        if (input.isEnabled && integrations.length > 0) {
+          const allRepos = integrations.flatMap(
+            integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+          );
 
-            let repositoriesToSync: string[];
+          let repositoriesToSync: string[];
 
-            if (selectionMode === 'all') {
-              repositoriesToSync = allRepos
-                .map(r => r.full_name)
-                .filter((name): name is string => !!name);
-            } else {
-              repositoriesToSync = allRepos
-                .filter(r => selectedIds.includes(r.id))
-                .map(r => r.full_name)
-                .filter((name): name is string => !!name);
-            }
+          if (selectionMode === 'all') {
+            repositoriesToSync = allRepos
+              .map(r => r.full_name)
+              .filter((name): name is string => !!name);
+          } else {
+            repositoriesToSync = allRepos
+              .filter(r => selectedIds.includes(r.id))
+              .map(r => r.full_name)
+              .filter((name): name is string => !!name);
+          }
 
-            if (repositoriesToSync.length > 0) {
-              let initialSync: Awaited<ReturnType<typeof submitManualSecuritySync>> | undefined;
-              let initialSyncAdmissionFailed = false;
-              try {
-                initialSync = await submitManualSecuritySync({
-                  owner: securityOwner,
-                  actor: {
-                    id: ctx.user.id,
-                    email: ctx.user.google_user_email,
-                    name: ctx.user.google_user_name,
-                  },
-                  origin: 'enable_initial_sync',
-                });
-              } catch (error) {
-                initialSyncAdmissionFailed = true;
-                console.error('Security Agent enabled but initial sync admission failed', error);
-              }
-
-              trackSecurityAgentEnabled({
-                distinctId: ctx.user.id,
-                userId: ctx.user.id,
-                ...deps.trackingExtras(ctx, input),
-                isEnabled: input.isEnabled,
-                repositorySelectionMode: selectionMode,
-                selectedRepoCount: repositoriesToSync.length,
-              });
-
-              logSecurityAudit({
+          if (repositoriesToSync.length > 0) {
+            let initialSync: Awaited<ReturnType<typeof submitManualSecuritySync>> | undefined;
+            let initialSyncAdmissionFailed = false;
+            try {
+              initialSync = await submitManualSecuritySync({
                 owner: securityOwner,
-                actor_id: ctx.user.id,
-                actor_email: ctx.user.google_user_email,
-                actor_name: ctx.user.google_user_name,
-                action: SecurityAuditLogAction.ConfigEnabled,
-                resource_type: 'agent_config',
-                resource_id: resourceId,
-                after_state: { isEnabled: true, repositorySelectionMode: selectionMode },
+                actor: {
+                  id: ctx.user.id,
+                  email: ctx.user.google_user_email,
+                  name: ctx.user.google_user_name,
+                },
+                origin: 'enable_initial_sync',
               });
-
-              return {
-                success: true,
-                initialSync,
-                initialSyncAdmissionFailed,
-              };
+            } catch (error) {
+              initialSyncAdmissionFailed = true;
+              console.error('Security Agent enabled but initial sync admission failed', error);
             }
+
+            trackSecurityAgentEnabled({
+              distinctId: ctx.user.id,
+              userId: ctx.user.id,
+              ...deps.trackingExtras(ctx, input),
+              isEnabled: input.isEnabled,
+              repositorySelectionMode: selectionMode,
+              selectedRepoCount: repositoriesToSync.length,
+            });
+
+            logSecurityAudit({
+              owner: securityOwner,
+              actor_id: ctx.user.id,
+              actor_email: ctx.user.google_user_email,
+              actor_name: ctx.user.google_user_name,
+              action: SecurityAuditLogAction.ConfigEnabled,
+              resource_type: 'agent_config',
+              resource_id: resourceId,
+              after_state: { isEnabled: true, repositorySelectionMode: selectionMode },
+            });
+
+            return {
+              success: true,
+              initialSync,
+              initialSyncAdmissionFailed,
+            };
           }
         }
 
         const effectiveRepoCount =
           selectionMode === 'all'
-            ? (integration?.repositories || []).filter(r => !!r.full_name).length
+            ? integrations.flatMap(
+                integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+              ).length
             : selectedIds.length;
 
         trackSecurityAgentEnabled({
@@ -1296,61 +1330,62 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
     // -----------------------------------------------------------------------
     getRepositories: async ({ ctx, input }: { ctx: TRPCContext; input: unknown }) => {
       const extra = toExtra(input);
-      const integration = await deps.getIntegration(ctx, extra);
+      const integrations = (await getIntegrations(ctx, extra)).filter(isSecurityIntegrationReady);
+      const repositoryGroups = await Promise.all(
+        integrations.map(async integration => {
+          const installationId = integration.platform_installation_id;
+          if (!installationId) return [];
 
-      if (!integration || integration.integration_status !== 'active') {
-        return [];
-      }
+          const appType = integration.github_app_type || 'standard';
+          let repos = requireNumericPlatformRepositories(integration.repositories) ?? [];
+          if (repos.length === 0) {
+            try {
+              repos = await fetchGitHubRepositories(installationId, appType);
+              await updateRepositoriesForIntegration(integration.id, repos);
+            } catch (error) {
+              console.error('Failed to load repositories for GitHub installation', {
+                integrationId: integration.id,
+                error: error instanceof Error ? error.message : String(error),
+              });
+              return [];
+            }
+          }
 
-      // Auto-fetch repositories from GitHub if not cached
-      let repos = requireNumericPlatformRepositories(integration.repositories) ?? [];
-      if (repos.length === 0 && integration.platform_installation_id) {
-        const appType = integration.github_app_type || 'standard';
-        const fetchedRepos = await fetchGitHubRepositories(
-          integration.platform_installation_id,
-          appType
-        );
-        await updateRepositoriesForIntegration(integration.id, fetchedRepos);
-        repos = fetchedRepos;
-      }
+          const repositories = repos.map(repo => ({
+            id: repo.id,
+            fullName: repo.full_name,
+            name: repo.name,
+            private: repo.private,
+            integrationId: integration.id,
+            accountLogin: integration.platform_account_login ?? null,
+          }));
+          try {
+            const availability = await checkDependabotAlertsAvailability(
+              installationId,
+              appType,
+              repositories
+            );
+            const availabilityById = new Map(
+              availability.map(result => [result.id, result.status])
+            );
+            return repositories.map(repository => ({
+              ...repository,
+              dependabotAlerts: availabilityById.get(repository.id) ?? ('unknown' as const),
+            }));
+          } catch (error) {
+            console.error('Failed to check Dependabot alerts availability', {
+              integrationId: integration.id,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return repositories.map(repository => ({
+              ...repository,
+              dependabotAlerts: 'unknown' as const,
+            }));
+          }
+        })
+      );
 
-      const repositoryDetails = repos.map(repo => ({
-        id: repo.id,
-        fullName: repo.full_name,
-        name: repo.name,
-        private: repo.private,
-      }));
-      const installationId = integration.platform_installation_id;
-      if (!installationId || !hasSecurityReviewPermissions(integration)) {
-        return repositoryDetails.map(repository => ({
-          ...repository,
-          dependabotAlerts: 'unknown' as const,
-        }));
-      }
-
-      const appType = integration.github_app_type || 'standard';
-      let availability: Awaited<ReturnType<typeof checkDependabotAlertsAvailability>>;
-      try {
-        availability = await checkDependabotAlertsAvailability(
-          installationId,
-          appType,
-          repositoryDetails
-        );
-      } catch (error) {
-        console.error('Failed to check Dependabot alerts availability', {
-          error: error instanceof Error ? error.message : String(error),
-        });
-        return repositoryDetails.map(repository => ({
-          ...repository,
-          dependabotAlerts: 'unknown' as const,
-        }));
-      }
-      const availabilityById = new Map(availability.map(result => [result.id, result.status]));
-
-      return repositoryDetails.map(repository => ({
-        ...repository,
-        dependabotAlerts: availabilityById.get(repository.id) ?? ('unknown' as const),
-      }));
+      return repositoryGroups.flat();
     },
 
     // -----------------------------------------------------------------------
@@ -1382,16 +1417,19 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         });
 
         const concurrencyCheck = await canStartAnalysis(securityOwner);
-        const [configWithStatus, integration] = await Promise.all([
+        const [configWithStatus, integrations] = await Promise.all([
           getSecurityAgentConfigWithStatus(owner),
-          deps.getIntegration(ctx, input),
+          getIntegrations(ctx, input),
         ]);
         const config = configWithStatus?.config ?? DEFAULT_SECURITY_AGENT_CONFIG;
         const decoratedFindings = await decorateFindingsWithRemediation({
           findings,
           config,
           isAgentEnabled: configWithStatus?.isEnabled ?? false,
-          repoFullNamesInScope: getRepoFullNamesInScope(integration, config),
+          repoFullNamesInScope: getRepoFullNamesInScope(
+            integrations.filter(isSecurityIntegrationReady),
+            config
+          ),
         });
 
         return {
@@ -1433,16 +1471,19 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           });
         }
 
-        const [configWithStatus, integration] = await Promise.all([
+        const [configWithStatus, integrations] = await Promise.all([
           getSecurityAgentConfigWithStatus(owner),
-          deps.getIntegration(ctx, input),
+          getIntegrations(ctx, input),
         ]);
         const config = configWithStatus?.config ?? DEFAULT_SECURITY_AGENT_CONFIG;
         return decorateFindingWithRemediation({
           finding,
           config,
           isAgentEnabled: configWithStatus?.isEnabled ?? false,
-          repoFullNamesInScope: getRepoFullNamesInScope(integration, config),
+          repoFullNamesInScope: getRepoFullNamesInScope(
+            integrations.filter(isSecurityIntegrationReady),
+            config
+          ),
         });
       },
     },
@@ -1495,32 +1536,17 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         const securityOwner = deps.resolveSecurityOwner(ctx, input);
         const resourceId = deps.resolveResourceId(ctx, input);
 
-        // Get integration
-        const integration = await deps.getIntegration(ctx, input);
-        if (!integration || integration.integration_status !== 'active') {
+        const integrations = (await getIntegrations(ctx, input)).filter(isSecurityIntegrationReady);
+        if (integrations.length === 0) {
           throw new TRPCError({
             code: 'PRECONDITION_FAILED',
             message: 'GitHub integration not found or inactive',
           });
         }
 
-        // Check permissions
-        if (!hasSecurityReviewPermissions(integration)) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'GitHub App does not have vulnerability_alerts permission',
-          });
-        }
-
-        const installationId = integration.platform_installation_id;
-        if (!installationId) {
-          throw new TRPCError({
-            code: 'PRECONDITION_FAILED',
-            message: 'GitHub installation ID not found',
-          });
-        }
-
-        const allRepos = requireNumericPlatformRepositories(integration.repositories) ?? [];
+        const allRepos = integrations.flatMap(
+          integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+        );
 
         // Resolve the sync scope (a specific repo, or every enabled repo).
         let syncScope:
@@ -1658,8 +1684,14 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           });
         }
 
-        // Get integration for GitHub API call
-        const integration = await deps.getIntegration(ctx, input);
+        const integrations = (await getIntegrations(ctx, input)).filter(isSecurityIntegrationReady);
+        const integration =
+          integrations.find(candidate => candidate.id === finding.platform_integration_id) ??
+          integrations.find(candidate =>
+            (requireNumericPlatformRepositories(candidate.repositories) ?? []).some(
+              repository => repository.full_name === finding.repo_full_name
+            )
+          );
         if (!integration || integration.integration_status !== 'active') {
           throw new TRPCError({
             code: 'PRECONDITION_FAILED',
@@ -1975,10 +2007,10 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         }
 
         const owner = deps.resolveOwner(ctx, input);
-        const [configWithStatus, integration, remediationAttempts, remediationTimeline] =
+        const [configWithStatus, integrations, remediationAttempts, remediationTimeline] =
           await Promise.all([
             getSecurityAgentConfigWithStatus(owner),
-            deps.getIntegration(ctx, input),
+            getIntegrations(ctx, input),
             getRemediationAttemptHistory(input.findingId),
             getRemediationTimeline(input.findingId),
           ]);
@@ -1987,7 +2019,10 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           finding,
           config,
           isAgentEnabled: configWithStatus?.isEnabled ?? false,
-          repoFullNamesInScope: getRepoFullNamesInScope(integration, config),
+          repoFullNamesInScope: getRepoFullNamesInScope(
+            integrations.filter(isSecurityIntegrationReady),
+            config
+          ),
         });
 
         return {
@@ -2075,11 +2110,11 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
       const securityOwner = deps.resolveSecurityOwner(ctx, extra);
 
       // Get the current GitHub integration
-      const integration = await deps.getIntegration(ctx, extra);
+      const integrations = (await getIntegrations(ctx, extra)).filter(isSecurityIntegrationReady);
 
       // Get list of accessible repository full names
       const accessibleRepoFullNames: string[] = [];
-      if (integration && integration.integration_status === 'active') {
+      for (const integration of integrations) {
         const repos = requireNumericPlatformRepositories(integration.repositories) ?? [];
         for (const repo of repos) {
           if (repo.full_name) {

--- a/apps/web/src/lib/security-agent/router/shared-handlers.ts
+++ b/apps/web/src/lib/security-agent/router/shared-handlers.ts
@@ -168,13 +168,34 @@ type SecurityAgentDeps<TExtra = {}> = {
 
 function getRepoFullNamesInScope(
   integrations: Integration[],
-  config: { repository_selection_mode?: 'all' | 'selected'; selected_repository_ids?: number[] }
+  config: {
+    repository_selection_mode?: 'all' | 'selected';
+    selected_repository_ids?: number[];
+    selected_repositories?: Array<{ repositoryId: number; platformIntegrationId: string }>;
+  }
 ): string[] {
-  const repositories = integrations.flatMap(
-    integration => requireNumericPlatformRepositories(integration.repositories) ?? []
+  const repositories = integrations.flatMap(integration =>
+    (requireNumericPlatformRepositories(integration.repositories) ?? []).map(repository => ({
+      ...repository,
+      platformIntegrationId: integration.id,
+    }))
   );
   if (config.repository_selection_mode === 'all') {
     return repositories.map(repo => repo.full_name).filter((name): name is string => !!name);
+  }
+  const selectedRepositories = config.selected_repositories;
+  if (selectedRepositories !== undefined) {
+    const selectedKeys = new Set(
+      selectedRepositories.map(
+        selection => `${selection.repositoryId}:${selection.platformIntegrationId}`
+      )
+    );
+    return repositories
+      .filter(repository =>
+        selectedKeys.has(`${repository.id}:${repository.platformIntegrationId}`)
+      )
+      .map(repository => repository.full_name)
+      .filter((name): name is string => !!name);
   }
   const selectedIds = new Set(config.selected_repository_ids ?? []);
   return repositories
@@ -814,6 +835,10 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           autoSyncEnabled: true,
           repositorySelectionMode: 'selected' as const,
           selectedRepositoryIds: [] as number[],
+          selectedRepositories: [] as Array<{
+            repositoryId: number;
+            platformIntegrationId: string;
+          }>,
           modelSlug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
           triageModelSlug: DEFAULT_SECURITY_AGENT_TRIAGE_MODEL,
           analysisModelSlug: DEFAULT_SECURITY_AGENT_ANALYSIS_MODEL,
@@ -867,6 +892,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
         autoSyncEnabled: result.config.auto_sync_enabled,
         repositorySelectionMode: result.config.repository_selection_mode || 'selected',
         selectedRepositoryIds: result.config.selected_repository_ids || [],
+        selectedRepositories: result.config.selected_repositories || [],
         modelSlug: result.config.model_slug || analysisModelSlug,
         triageModelSlug,
         analysisModelSlug,
@@ -940,6 +966,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
               analysisModelSlug: existingAnalysisModelSlug,
               repositorySelectionMode: existingConfig.config.repository_selection_mode,
               selectedRepositoryIds: existingConfig.config.selected_repository_ids,
+              selectedRepositories: existingConfig.config.selected_repositories,
               slaCriticalDays: existingConfig.config.sla_critical_days,
               slaHighDays: existingConfig.config.sla_high_days,
               slaMediumDays: existingConfig.config.sla_medium_days,
@@ -1032,6 +1059,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
             auto_sync_enabled: input.autoSyncEnabled,
             repository_selection_mode: input.repositorySelectionMode,
             selected_repository_ids: input.selectedRepositoryIds,
+            selected_repositories: input.selectedRepositories,
             model_slug: modelSlug,
             triage_model_slug: triageModelSlug,
             analysis_model_slug: analysisModelSlug,
@@ -1197,6 +1225,8 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           'selected';
         const selectedIds =
           input.selectedRepositoryIds ?? existingConfig?.config.selected_repository_ids ?? [];
+        const selectedRepositories =
+          input.selectedRepositories ?? existingConfig?.config.selected_repositories;
 
         // Refuse enabling with an empty effective repo set: no repository would
         // be synced or analyzed, so an enabled state would be misleading.
@@ -1204,6 +1234,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
           const effectiveRepos = getRepoFullNamesInScope(integrations, {
             repository_selection_mode: selectionMode,
             selected_repository_ids: selectedIds,
+            selected_repositories: selectedRepositories,
           });
           if (effectiveRepos.length === 0) {
             throw new TRPCError({
@@ -1220,6 +1251,7 @@ export function createSecurityAgentHandlers<TExtra = {}>(deps: SecurityAgentDeps
             {
               repository_selection_mode: selectionMode,
               selected_repository_ids: selectedIds,
+              selected_repositories: selectedRepositories,
             },
             ctx.user.id
           );

--- a/apps/web/src/routers/organizations/organization-security-agent-router.ts
+++ b/apps/web/src/routers/organizations/organization-security-agent-router.ts
@@ -8,6 +8,7 @@ import {
 } from './utils';
 
 import {
+  getAllIntegrationsForOwner,
   getIntegrationForOrganization,
   getPrimaryGitHubIntegrationForOrganization,
 } from '@/lib/integrations/db/platform-integrations';
@@ -29,6 +30,10 @@ const handlers = createSecurityAgentHandlers<{ organizationId: string }>({
     await getPrimaryGitHubIntegrationForOrganization(input.organizationId),
   getStatusIntegration: async (_ctx, input) =>
     await getIntegrationForOrganization(input.organizationId, 'github'),
+  getIntegrations: async (_ctx, input) =>
+    (await getAllIntegrationsForOwner({ type: 'org', id: input.organizationId })).filter(
+      integration => integration.platform === 'github'
+    ),
   trackingExtras: (_ctx, input) => ({
     organizationId: input.organizationId,
   }),

--- a/apps/web/src/routers/security-agent-router.ts
+++ b/apps/web/src/routers/security-agent-router.ts
@@ -1,5 +1,8 @@
 import { createTRPCRouter, baseProcedure } from '@/lib/trpc/init';
-import { getIntegrationForOwner } from '@/lib/integrations/db/platform-integrations';
+import {
+  getAllIntegrationsForOwner,
+  getIntegrationForOwner,
+} from '@/lib/integrations/db/platform-integrations';
 import { createSecurityAgentHandlers } from '@/lib/security-agent/router/shared-handlers';
 
 const handlers = createSecurityAgentHandlers({
@@ -16,6 +19,12 @@ const handlers = createSecurityAgentHandlers({
   getIntegration: async ctx => {
     const owner = { type: 'user' as const, id: ctx.user.id, userId: ctx.user.id };
     return await getIntegrationForOwner(owner, 'github');
+  },
+  getIntegrations: async ctx => {
+    const owner = { type: 'user' as const, id: ctx.user.id };
+    return (await getAllIntegrationsForOwner(owner)).filter(
+      integration => integration.platform === 'github'
+    );
   },
   trackingExtras: () => ({}),
 });


### PR DESCRIPTION
## Why
#5593 makes Security Sync installation-aware. Repository IDs alone cannot represent explicit selections when the same repository appears through multiple GitHub installations.

## Dependency
Depends on #5593. The branch includes a normal merge of the latest #5593 parent commit.

## What changes
- Persist additive `selected_repositories` entries with `repositoryId` and `platformIntegrationId`.
- Continue writing `selected_repository_ids` for compatibility with existing consumers.
- Hydrate, save, enable, filter, and count Security Agent repositories using composite identity.
- Use composite keys in web and mobile selectors so duplicate numeric repository IDs remain independently selectable.
- Keep repository grouping and per-installation recovery state from the original UI change.

## Design guidance
Uses the Kilo Cloud overlay and interaction-quality guidance while preserving the existing Security Agent settings patterns.

## Validation
- Web typecheck
- Web lint
- Mobile typecheck
- Mobile lint
- `pnpm format`
- `git diff --check`
- Focused web tests added for composite persistence and duplicate IDs; execution is currently blocked because the repository-managed Postgres test container is not running.