### PR TITLE
feat(gastown): let each rig choose its GitHub organization

### DIFF
--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingContext.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingContext.tsx
@@ -11,6 +11,7 @@ import { presetToConfig } from './onboarding.domain';
 
 type OnboardingRepo = {
   platform: 'github' | 'gitlab' | 'manual';
+  selectionKey: string;
   fullName: string;
   gitUrl: string;
   defaultBranch: string;

--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
@@ -5,11 +5,15 @@ import { useQuery, useMutation } from '@tanstack/react-query';
 import { useSearchParams } from 'next/navigation';
 import { toast } from 'sonner';
 import { useTRPC } from '@/lib/trpc/utils';
-import { RepositoryCombobox, type RepositoryOption } from '@/components/shared/RepositoryCombobox';
+import {
+  buildGastownRepositoryRigInput,
+  findGastownRepository,
+  GastownRepositorySelector,
+  type GastownRepositoryOption,
+} from '@/components/gastown/GastownRepositorySelector';
 import { Button } from '@/components/ui/button';
 import { ExternalLink, GitBranch } from 'lucide-react';
 import { useOnboarding } from './OnboardingContext';
-import { resolveGitUrlFromRepo } from './onboarding.domain';
 import { buildGitHubInstallState } from '@/components/integrations/github-install-state';
 
 export function OnboardingStepRepo() {
@@ -18,7 +22,7 @@ export function OnboardingStepRepo() {
 
   const mintInstallState = useMutation(mainTrpc.githubApps.mintInstallState.mutationOptions());
 
-  const [selectedRepoFullName, setSelectedRepoFullName] = useState(state.repo?.fullName ?? '');
+  const [selectedRepoKey, setSelectedRepoKey] = useState(state.repo?.selectionKey ?? '');
 
   // Use org-scoped endpoints when onboarding within an org, personal otherwise
   const orgId = state.orgId;
@@ -41,12 +45,15 @@ export function OnboardingStepRepo() {
       : mainTrpc.cloudAgentNext.listGitLabRepositories.queryOptions({ forceRefresh: false })),
   });
 
-  const unifiedRepositories = useMemo<RepositoryOption[]>(() => {
+  const unifiedRepositories = useMemo<GastownRepositoryOption[]>(() => {
     const github = (githubReposQuery.data?.repositories ?? []).map(repo => ({
       id: repo.id,
       fullName: repo.fullName,
       private: repo.private,
       platform: 'github' as const,
+      defaultBranch: repo.defaultBranch,
+      platformIntegrationId: repo.platformIntegrationId,
+      platformAccountLogin: repo.platformAccountLogin,
     }));
     const gitlab = (gitlabReposQuery.data?.repositories ?? []).map(repo => ({
       id: repo.id,
@@ -58,6 +65,7 @@ export function OnboardingStepRepo() {
   }, [githubReposQuery.data, gitlabReposQuery.data]);
 
   const isLoadingRepos = githubReposQuery.isLoading || gitlabReposQuery.isLoading;
+  const selectedRepository = findGastownRepository(unifiedRepositories, selectedRepoKey);
   // Derive integration availability from repo results (works for both personal and org scope)
   const hasAnyIntegration =
     (githubReposQuery.data?.repositories?.length ?? 0) > 0 ||
@@ -91,10 +99,16 @@ export function OnboardingStepRepo() {
     }
   }, [githubInstallParam, refetchGithubRepos]);
 
+  useEffect(() => {
+    if (isLoadingRepos || !selectedRepoKey || selectedRepository) return;
+    setSelectedRepoKey('');
+    setRepo(null);
+  }, [isLoadingRepos, selectedRepoKey, selectedRepository, setRepo]);
+
   const handleRepoSelect = useCallback(
-    (fullName: string) => {
-      setSelectedRepoFullName(fullName);
-      const repo = unifiedRepositories.find(r => r.fullName === fullName);
+    (selectionKey: string) => {
+      setSelectedRepoKey(selectionKey);
+      const repo = findGastownRepository(unifiedRepositories, selectionKey);
       if (!repo) return;
 
       const platform = repo.platform ?? 'github';
@@ -104,20 +118,20 @@ export function OnboardingStepRepo() {
       }
       const gitlabInstanceUrl = (gitlabReposQuery.data as { instanceUrl?: string } | undefined)
         ?.instanceUrl;
-      const gitUrl = resolveGitUrlFromRepo(platform, fullName, gitlabInstanceUrl);
+      const rigInput = buildGastownRepositoryRigInput(repo, gitlabInstanceUrl);
+      if (!rigInput) return;
 
       // Auto-derive town name from repo name, but only if the user hasn't explicitly edited it
-      const repoName = fullName.split('/').pop() ?? fullName;
+      const repoName = repo.fullName.split('/').pop() ?? repo.fullName;
       if (!state.townNameSetByUser) {
         setTownName(repoName);
       }
 
       setRepo({
         platform,
-        fullName,
-        gitUrl,
-        defaultBranch: 'main',
-        platformIntegrationId: undefined,
+        selectionKey,
+        fullName: repo.fullName,
+        ...rigInput,
       });
     },
     [unifiedRepositories, gitlabReposQuery.data, state.townNameSetByUser, setTownName, setRepo]
@@ -133,19 +147,16 @@ export function OnboardingStepRepo() {
           {/* Repo picker */}
           {isLoadingRepos ? (
             <div className="space-y-2">
-              <div className="h-9 w-full animate-pulse rounded-md bg-white/[0.06]" />
+              <div className="h-11 w-full animate-pulse rounded-md bg-white/[0.06] sm:h-9" />
               <p className="text-xs text-white/30">Loading repositories...</p>
             </div>
           ) : hasAnyIntegration ? (
-            <RepositoryCombobox
+            <GastownRepositorySelector
               repositories={unifiedRepositories}
-              value={selectedRepoFullName}
+              value={selectedRepoKey}
               onValueChange={handleRepoSelect}
               isLoading={isLoadingRepos}
               placeholder="Select a repository..."
-              searchPlaceholder="Search repositories..."
-              groupByPlatform
-              hideLabel
             />
           ) : (
             <div className="space-y-3">
@@ -173,8 +184,12 @@ export function OnboardingStepRepo() {
           {state.repo && state.repo.platform !== 'manual' && (
             <div className="flex items-center gap-2 rounded-lg border border-emerald-500/20 bg-emerald-500/5 px-3 py-2 text-sm text-emerald-400/80">
               <GitBranch className="size-4" />
-              <span className="truncate">{state.repo.fullName}</span>
-              <span className="ml-auto text-xs text-white/30">main</span>
+              <span className="min-w-0 truncate" title={state.repo.fullName}>
+                {state.repo.fullName}
+              </span>
+              <span className="ml-auto shrink-0 text-xs text-white/30">
+                {state.repo.defaultBranch}
+              </span>
             </div>
           )}
         </div>

--- a/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
+++ b/apps/web/src/app/(app)/gastown/onboarding/OnboardingStepRepo.tsx
@@ -118,7 +118,7 @@ export function OnboardingStepRepo() {
       }
       const gitlabInstanceUrl = (gitlabReposQuery.data as { instanceUrl?: string } | undefined)
         ?.instanceUrl;
-      const rigInput = buildGastownRepositoryRigInput(repo, gitlabInstanceUrl);
+      const rigInput = buildGastownRepositoryRigInput(repo, gitlabInstanceUrl, unifiedRepositories);
       if (!rigInput) return;
 
       // Auto-derive town name from repo name, but only if the user hasn't explicitly edited it

--- a/apps/web/src/components/gastown/CreateRigDialog.tsx
+++ b/apps/web/src/components/gastown/CreateRigDialog.tsx
@@ -132,7 +132,10 @@ export function CreateRigDialog({ townId, isOpen, onClose, organizationId }: Cre
     if (!selectedRepository) return '';
     const instanceUrl = (gitlabReposQuery.data as { instanceUrl?: string } | undefined)
       ?.instanceUrl;
-    return buildGastownRepositoryRigInput(selectedRepository, instanceUrl)?.gitUrl ?? '';
+    return (
+      buildGastownRepositoryRigInput(selectedRepository, instanceUrl, unifiedRepositories)
+        ?.gitUrl ?? ''
+    );
   }
 
   const handleSubmit = (e: React.FormEvent) => {
@@ -142,7 +145,8 @@ export function CreateRigDialog({ townId, isOpen, onClose, organizationId }: Cre
     const repositoryInput = selectedRepository
       ? buildGastownRepositoryRigInput(
           selectedRepository,
-          (gitlabReposQuery.data as { instanceUrl?: string } | undefined)?.instanceUrl
+          (gitlabReposQuery.data as { instanceUrl?: string } | undefined)?.instanceUrl,
+          unifiedRepositories
         )
       : null;
     createRig.mutate({

--- a/apps/web/src/components/gastown/CreateRigDialog.tsx
+++ b/apps/web/src/components/gastown/CreateRigDialog.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useMemo } from 'react';
+import { useEffect, useState, useMemo } from 'react';
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
 import { useGastownTRPC } from '@/lib/gastown/trpc';
 import { useTRPC } from '@/lib/trpc/utils';
@@ -13,7 +13,12 @@ import {
 } from '@/components/ui/dialog';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-import { RepositoryCombobox, type RepositoryOption } from '@/components/shared/RepositoryCombobox';
+import {
+  buildGastownRepositoryRigInput,
+  findGastownRepository,
+  GastownRepositorySelector,
+  type GastownRepositoryOption,
+} from '@/components/gastown/GastownRepositorySelector';
 import { toast } from 'sonner';
 
 type CreateRigDialogProps = {
@@ -31,8 +36,7 @@ export function CreateRigDialog({ townId, isOpen, onClose, organizationId }: Cre
   const [gitUrl, setGitUrl] = useState('');
   const [defaultBranch, setDefaultBranch] = useState('main');
   const [mode, setMode] = useState<RepoMode>('integration');
-  const [selectedRepo, setSelectedRepo] = useState('');
-  const [selectedPlatform, setSelectedPlatform] = useState<'github' | 'gitlab' | null>(null);
+  const [selectedRepoKey, setSelectedRepoKey] = useState('');
   const trpc = useGastownTRPC();
   const mainTrpc = useTRPC();
   const queryClient = useQueryClient();
@@ -58,12 +62,15 @@ export function CreateRigDialog({ townId, isOpen, onClose, organizationId }: Cre
     enabled: isOpen && mode === 'integration',
   });
 
-  const unifiedRepositories = useMemo<RepositoryOption[]>(() => {
+  const unifiedRepositories = useMemo<GastownRepositoryOption[]>(() => {
     const github = (githubReposQuery.data?.repositories ?? []).map(repo => ({
       id: repo.id,
       fullName: repo.fullName,
       private: repo.private,
       platform: 'github' as const,
+      defaultBranch: repo.defaultBranch,
+      platformIntegrationId: repo.platformIntegrationId,
+      platformAccountLogin: repo.platformAccountLogin,
     }));
     const gitlab = (gitlabReposQuery.data?.repositories ?? []).map(repo => ({
       id: repo.id,
@@ -73,12 +80,18 @@ export function CreateRigDialog({ townId, isOpen, onClose, organizationId }: Cre
     }));
     return [...github, ...gitlab];
   }, [githubReposQuery.data, gitlabReposQuery.data]);
+  const selectedRepository = findGastownRepository(unifiedRepositories, selectedRepoKey);
 
   const hasIntegrations =
     (githubReposQuery.data?.repositories?.length ?? 0) > 0 ||
     (gitlabReposQuery.data?.repositories?.length ?? 0) > 0;
 
   const isLoadingRepos = githubReposQuery.isLoading || gitlabReposQuery.isLoading;
+
+  useEffect(() => {
+    if (isLoadingRepos || !selectedRepoKey || selectedRepository) return;
+    setSelectedRepoKey('');
+  }, [isLoadingRepos, selectedRepoKey, selectedRepository]);
 
   const createRig = useMutation(
     trpc.gastown.createRig.mutationOptions({
@@ -98,53 +111,53 @@ export function CreateRigDialog({ townId, isOpen, onClose, organizationId }: Cre
     setName('');
     setGitUrl('');
     setDefaultBranch('main');
-    setSelectedRepo('');
-    setSelectedPlatform(null);
+    setSelectedRepoKey('');
   }
 
-  function handleRepoSelect(fullName: string) {
-    setSelectedRepo(fullName);
-    // Determine platform from the selection
-    const repo = unifiedRepositories.find(r => r.fullName === fullName);
+  function handleRepoSelect(selectionKey: string) {
+    setSelectedRepoKey(selectionKey);
+    const repo = findGastownRepository(unifiedRepositories, selectionKey);
     // TODO: Add Bitbucket support to Gastown.
-    if (repo?.platform && repo.platform !== 'bitbucket') {
-      setSelectedPlatform(repo.platform);
-    }
+    if (!repo || repo.platform === 'bitbucket') return;
     // Auto-fill name from repo name
-    const repoName = fullName.split('/').pop() ?? fullName;
+    const repoName = repo.fullName.split('/').pop() ?? repo.fullName;
     if (!name) {
       setName(repoName);
     }
+    setDefaultBranch(repo.defaultBranch || 'main');
   }
 
   function resolveGitUrl(): string {
     if (mode === 'manual') return gitUrl.trim();
-    if (!selectedRepo) return '';
-    if (selectedPlatform === 'gitlab') {
-      const instanceUrl =
-        (gitlabReposQuery.data as { instanceUrl?: string } | undefined)?.instanceUrl ??
-        'https://gitlab.com';
-      return `${instanceUrl.replace(/\/+$/, '')}/${selectedRepo}.git`;
-    }
-    return `https://github.com/${selectedRepo}.git`;
+    if (!selectedRepository) return '';
+    const instanceUrl = (gitlabReposQuery.data as { instanceUrl?: string } | undefined)
+      ?.instanceUrl;
+    return buildGastownRepositoryRigInput(selectedRepository, instanceUrl)?.gitUrl ?? '';
   }
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
     const resolvedUrl = resolveGitUrl();
     if (!name.trim() || !resolvedUrl) return;
+    const repositoryInput = selectedRepository
+      ? buildGastownRepositoryRigInput(
+          selectedRepository,
+          (gitlabReposQuery.data as { instanceUrl?: string } | undefined)?.instanceUrl
+        )
+      : null;
     createRig.mutate({
       townId,
       name: name.trim(),
       gitUrl: resolvedUrl,
       defaultBranch: defaultBranch.trim() || 'main',
-      // platformIntegrationId is auto-resolved server-side from the git URL
-      // when not provided, so we don't need to pass it here.
+      ...(mode === 'integration' && repositoryInput?.platformIntegrationId
+        ? { platformIntegrationId: repositoryInput.platformIntegrationId }
+        : {}),
     });
   };
 
   const canSubmit =
-    name.trim() && (mode === 'manual' ? gitUrl.trim() : selectedRepo) && !createRig.isPending;
+    name.trim() && (mode === 'manual' ? gitUrl.trim() : selectedRepository) && !createRig.isPending;
 
   return (
     <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
@@ -210,15 +223,12 @@ export function CreateRigDialog({ townId, isOpen, onClose, organizationId }: Cre
                     first, or use Manual URL.
                   </div>
                 ) : (
-                  <RepositoryCombobox
+                  <GastownRepositorySelector
                     repositories={unifiedRepositories}
-                    value={selectedRepo}
+                    value={selectedRepoKey}
                     onValueChange={handleRepoSelect}
                     isLoading={isLoadingRepos}
                     placeholder="Select a repository..."
-                    searchPlaceholder="Search repositories..."
-                    groupByPlatform
-                    hideLabel
                   />
                 )}
               </div>
@@ -252,7 +262,7 @@ export function CreateRigDialog({ townId, isOpen, onClose, organizationId }: Cre
               Cancel
             </Button>
             <Button variant="default" type="submit" disabled={!canSubmit}>
-              {createRig.isPending ? 'Creating...' : 'Create'}
+              {createRig.isPending ? 'Creating rig...' : 'Create rig'}
             </Button>
           </DialogFooter>
         </form>

--- a/apps/web/src/components/gastown/GastownRepositorySelector.test.ts
+++ b/apps/web/src/components/gastown/GastownRepositorySelector.test.ts
@@ -42,7 +42,9 @@ describe('Gastown onboarding repository selection', () => {
       defaultBranch: 'trunk',
       platformIntegrationId: secondIntegrationId,
     });
-    expect(selected && buildGastownRepositoryRigInput(selected)).toEqual({
+    expect(
+      selected && buildGastownRepositoryRigInput(selected, undefined, [first, duplicate])
+    ).toEqual({
       gitUrl: 'https://github.com/acme/widgets.git',
       defaultBranch: 'trunk',
       platformIntegrationId: secondIntegrationId,
@@ -52,7 +54,7 @@ describe('Gastown onboarding repository selection', () => {
 });
 
 describe('Gastown later rig repository selection', () => {
-  it('keeps the integration ID needed by the createRig mutation', () => {
+  it('omits the integration ID for authoritative resolution of a unique repository', () => {
     const selected = findGastownRepository(
       [githubRepository()],
       gastownRepositoryKey(githubRepository())
@@ -61,7 +63,6 @@ describe('Gastown later rig repository selection', () => {
     expect(selected && buildGastownRepositoryRigInput(selected)).toEqual({
       gitUrl: 'https://github.com/acme/widgets.git',
       defaultBranch: 'trunk',
-      platformIntegrationId: firstIntegrationId,
     });
   });
 

--- a/apps/web/src/components/gastown/GastownRepositorySelector.test.ts
+++ b/apps/web/src/components/gastown/GastownRepositorySelector.test.ts
@@ -1,0 +1,130 @@
+import { describe, expect, it } from '@jest/globals';
+import { createElement } from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+
+import {
+  buildGastownRepositoryRigInput,
+  findGastownRepository,
+  GastownRepositoryOptionLabel,
+  gastownRepositoryKey,
+  getGastownRepositoryDiscriminator,
+  groupGastownRepositories,
+  type GastownRepositoryOption,
+} from './GastownRepositorySelector';
+
+const firstIntegrationId = '11111111-1111-4111-8111-111111111111';
+const secondIntegrationId = '22222222-2222-4222-8222-222222222222';
+
+function githubRepository(
+  overrides: Partial<GastownRepositoryOption> = {}
+): GastownRepositoryOption {
+  return {
+    id: 101,
+    fullName: 'acme/widgets',
+    private: true,
+    platform: 'github',
+    defaultBranch: 'trunk',
+    platformIntegrationId: firstIntegrationId,
+    platformAccountLogin: 'acme',
+    ...overrides,
+  };
+}
+
+describe('Gastown onboarding repository selection', () => {
+  it('restores the exact GitHub installation and preserves its rig provenance', () => {
+    const first = githubRepository();
+    const duplicate = githubRepository({ platformIntegrationId: secondIntegrationId });
+
+    const selected = findGastownRepository([first, duplicate], gastownRepositoryKey(duplicate));
+
+    expect(selected).toMatchObject({
+      fullName: 'acme/widgets',
+      defaultBranch: 'trunk',
+      platformIntegrationId: secondIntegrationId,
+    });
+    expect(selected && buildGastownRepositoryRigInput(selected)).toEqual({
+      gitUrl: 'https://github.com/acme/widgets.git',
+      defaultBranch: 'trunk',
+      platformIntegrationId: secondIntegrationId,
+    });
+    expect(gastownRepositoryKey(first)).not.toBe(gastownRepositoryKey(duplicate));
+  });
+});
+
+describe('Gastown later rig repository selection', () => {
+  it('keeps the integration ID needed by the createRig mutation', () => {
+    const selected = findGastownRepository(
+      [githubRepository()],
+      gastownRepositoryKey(githubRepository())
+    );
+
+    expect(selected && buildGastownRepositoryRigInput(selected)).toEqual({
+      gitUrl: 'https://github.com/acme/widgets.git',
+      defaultBranch: 'trunk',
+      platformIntegrationId: firstIntegrationId,
+    });
+  });
+
+  it('rejects a stale selection after its repository option disappears', () => {
+    const staleKey = gastownRepositoryKey(githubRepository());
+
+    expect(findGastownRepository([], staleKey)).toBeNull();
+    expect(
+      findGastownRepository(
+        [githubRepository({ platformIntegrationId: secondIntegrationId })],
+        staleKey
+      )
+    ).toBeNull();
+  });
+});
+
+describe('Gastown GitHub repository grouping', () => {
+  it('groups GitHub repositories by organization and distinguishes duplicate rows', () => {
+    const repositories = [
+      githubRepository(),
+      githubRepository({ platformIntegrationId: secondIntegrationId }),
+      githubRepository({
+        id: 202,
+        fullName: 'octo/api',
+        platformIntegrationId: '33333333-3333-4333-8333-333333333333',
+        platformAccountLogin: 'octo',
+      }),
+    ];
+
+    expect(
+      groupGastownRepositories(repositories).map(group => ({
+        label: group.label,
+        repositories: group.repositories.map(repository => repository.fullName),
+      }))
+    ).toEqual([
+      { label: 'acme', repositories: ['acme/widgets', 'acme/widgets'] },
+      { label: 'octo', repositories: ['octo/api'] },
+    ]);
+
+    const duplicateNames = new Set(['acme/widgets']);
+    expect(getGastownRepositoryDiscriminator(repositories[0], duplicateNames)).toBe(
+      `Connection ${firstIntegrationId}`
+    );
+    expect(getGastownRepositoryDiscriminator(repositories[1], duplicateNames)).toBe(
+      `Connection ${secondIntegrationId}`
+    );
+    expect(getGastownRepositoryDiscriminator(repositories[2], duplicateNames)).toBeNull();
+  });
+});
+
+describe('Gastown repository labels', () => {
+  it('bounds long labels while retaining the full repository name', () => {
+    const fullName = `organization-with-a-long-name/${'repository-segment-'.repeat(8)}`;
+    const html = renderToStaticMarkup(
+      createElement(GastownRepositoryOptionLabel, {
+        repository: githubRepository({ fullName }),
+        discriminator: `Connection ${firstIntegrationId}`,
+      })
+    );
+
+    expect(html).toContain('class="truncate font-mono"');
+    expect(html).toContain(`title="${fullName}"`);
+    expect(html).toContain(fullName);
+    expect(html).toContain(`Connection ${firstIntegrationId}`);
+  });
+});

--- a/apps/web/src/components/gastown/GastownRepositorySelector.tsx
+++ b/apps/web/src/components/gastown/GastownRepositorySelector.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useRef, useState } from 'react';
+import React, { useRef, useState } from 'react';
 import { Check, ChevronsUpDown, Lock, Unlock } from 'lucide-react';
 
 import type { RepositoryOption } from '@/components/shared/RepositoryCombobox';
@@ -111,7 +111,8 @@ export function GastownRepositoryOptionLabel({
 
 export function buildGastownRepositoryRigInput(
   repository: GastownRepositoryOption,
-  gitlabInstanceUrl?: string
+  gitlabInstanceUrl?: string,
+  repositories: GastownRepositoryOption[] = [repository]
 ): {
   gitUrl: string;
   defaultBranch: string;
@@ -127,7 +128,9 @@ export function buildGastownRepositoryRigInput(
   return {
     gitUrl,
     defaultBranch: repository.defaultBranch || 'main',
-    ...(repository.platformIntegrationId
+    ...(repository.platformIntegrationId &&
+    (repository.platform !== 'github' ||
+      duplicateRepositoryNames(repositories).has(repository.fullName))
       ? { platformIntegrationId: repository.platformIntegrationId }
       : {}),
   };

--- a/apps/web/src/components/gastown/GastownRepositorySelector.tsx
+++ b/apps/web/src/components/gastown/GastownRepositorySelector.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+import { useRef, useState } from 'react';
+import { Check, ChevronsUpDown, Lock, Unlock } from 'lucide-react';
+
+import type { RepositoryOption } from '@/components/shared/RepositoryCombobox';
+import { Button } from '@/components/ui/button';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command';
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
+import { Skeleton } from '@/components/ui/skeleton';
+import { cn } from '@/lib/utils';
+
+export type GastownRepositoryOption = RepositoryOption & {
+  defaultBranch?: string;
+};
+
+type RepositoryGroup = {
+  key: string;
+  label: string;
+  repositories: GastownRepositoryOption[];
+};
+
+export function gastownRepositoryKey(repository: GastownRepositoryOption): string {
+  return JSON.stringify([
+    repository.platform ?? 'other',
+    repository.platformIntegrationId ?? '',
+    repository.id,
+  ]);
+}
+
+export function findGastownRepository(
+  repositories: GastownRepositoryOption[],
+  selectionKey: string
+): GastownRepositoryOption | null {
+  return repositories.find(repository => gastownRepositoryKey(repository) === selectionKey) ?? null;
+}
+
+export function groupGastownRepositories(
+  repositories: GastownRepositoryOption[]
+): RepositoryGroup[] {
+  const groups = new Map<string, RepositoryGroup>();
+
+  for (const repository of repositories) {
+    const key =
+      repository.platform === 'github'
+        ? `github:${repository.platformAccountLogin ?? 'GitHub'}`
+        : (repository.platform ?? 'other');
+    const label =
+      repository.platform === 'github'
+        ? (repository.platformAccountLogin ?? 'GitHub')
+        : repository.platform === 'gitlab'
+          ? 'GitLab'
+          : 'Other';
+    const group = groups.get(key);
+
+    if (group) {
+      group.repositories.push(repository);
+    } else {
+      groups.set(key, { key, label, repositories: [repository] });
+    }
+  }
+
+  return [...groups.values()];
+}
+
+function duplicateRepositoryNames(repositories: GastownRepositoryOption[]): Set<string> {
+  const counts = new Map<string, number>();
+  for (const repository of repositories) {
+    if (repository.platform !== 'github') continue;
+    counts.set(repository.fullName, (counts.get(repository.fullName) ?? 0) + 1);
+  }
+  return new Set([...counts].filter(([, count]) => count > 1).map(([fullName]) => fullName));
+}
+
+export function getGastownRepositoryDiscriminator(
+  repository: GastownRepositoryOption,
+  duplicateNames: ReadonlySet<string>
+): string | null {
+  if (repository.platform !== 'github' || !duplicateNames.has(repository.fullName)) return null;
+  if (repository.platformIntegrationId) {
+    return `Connection ${repository.platformIntegrationId}`;
+  }
+  return `Repository ${repository.id}`;
+}
+
+export function GastownRepositoryOptionLabel({
+  repository,
+  discriminator,
+}: {
+  repository: GastownRepositoryOption;
+  discriminator: string | null;
+}) {
+  return (
+    <span className="flex min-w-0 flex-1 flex-col" title={repository.fullName}>
+      <span className="truncate font-mono">{repository.fullName}</span>
+      {discriminator && (
+        <span className="text-muted-foreground truncate text-[11px]" title={discriminator}>
+          {discriminator}
+        </span>
+      )}
+    </span>
+  );
+}
+
+export function buildGastownRepositoryRigInput(
+  repository: GastownRepositoryOption,
+  gitlabInstanceUrl?: string
+): {
+  gitUrl: string;
+  defaultBranch: string;
+  platformIntegrationId?: string;
+} | null {
+  if (repository.platform === 'bitbucket') return null;
+
+  const gitUrl =
+    repository.platform === 'gitlab'
+      ? `${(gitlabInstanceUrl ?? 'https://gitlab.com').replace(/\/+$/, '')}/${repository.fullName}.git`
+      : `https://github.com/${repository.fullName}.git`;
+
+  return {
+    gitUrl,
+    defaultBranch: repository.defaultBranch || 'main',
+    ...(repository.platformIntegrationId
+      ? { platformIntegrationId: repository.platformIntegrationId }
+      : {}),
+  };
+}
+
+export function GastownRepositorySelector({
+  repositories,
+  value,
+  onValueChange,
+  isLoading = false,
+  placeholder = 'Select a repository...',
+}: {
+  repositories: GastownRepositoryOption[];
+  value: string;
+  onValueChange: (selectionKey: string) => void;
+  isLoading?: boolean;
+  placeholder?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const selectedRepository = findGastownRepository(repositories, value);
+  const duplicateNames = duplicateRepositoryNames(repositories);
+  const selectedDiscriminator = selectedRepository
+    ? getGastownRepositoryDiscriminator(selectedRepository, duplicateNames)
+    : null;
+  const groups = groupGastownRepositories(repositories);
+
+  if (isLoading) {
+    return (
+      <div className="space-y-2">
+        <Skeleton className="h-11 w-full sm:h-9" />
+        <p className="text-muted-foreground text-xs">Loading repositories...</p>
+      </div>
+    );
+  }
+
+  return (
+    <Popover open={open} onOpenChange={setOpen}>
+      <PopoverTrigger asChild>
+        <Button
+          ref={triggerRef}
+          type="button"
+          variant="outline"
+          role="combobox"
+          aria-label="Repository"
+          aria-expanded={open}
+          className="min-h-11 w-full min-w-0 justify-between gap-2 border-white/10 bg-black/25 px-3 py-1.5 font-normal sm:min-h-9"
+          title={selectedRepository?.fullName}
+        >
+          {selectedRepository ? (
+            <GastownRepositoryOptionLabel
+              repository={selectedRepository}
+              discriminator={selectedDiscriminator}
+            />
+          ) : (
+            <span className="min-w-0 truncate font-mono text-white/40">{placeholder}</span>
+          )}
+          <ChevronsUpDown className="size-4 shrink-0 opacity-50" />
+        </Button>
+      </PopoverTrigger>
+      <PopoverContent
+        align="start"
+        className="w-[min(32rem,calc(100vw-2rem))] p-0"
+        style={{ minWidth: triggerRef.current?.offsetWidth }}
+      >
+        <Command>
+          <CommandInput placeholder="Search repositories..." />
+          <CommandEmpty>No repositories match your search.</CommandEmpty>
+          <CommandList className="max-h-72">
+            {groups.map(group => (
+              <CommandGroup key={group.key} heading={group.label}>
+                {group.repositories.map(repository => {
+                  const selectionKey = gastownRepositoryKey(repository);
+                  const discriminator = getGastownRepositoryDiscriminator(
+                    repository,
+                    duplicateNames
+                  );
+                  return (
+                    <CommandItem
+                      key={selectionKey}
+                      value={`${repository.fullName} ${repository.platformAccountLogin ?? ''} ${repository.platformIntegrationId ?? ''}`}
+                      onSelect={() => {
+                        onValueChange(selectionKey);
+                        setOpen(false);
+                      }}
+                      className="min-h-11 min-w-0 gap-2 sm:min-h-9"
+                    >
+                      {repository.private ? (
+                        <Lock className="size-3.5 shrink-0 text-yellow-500" />
+                      ) : (
+                        <Unlock className="text-muted-foreground size-3.5 shrink-0" />
+                      )}
+                      <GastownRepositoryOptionLabel
+                        repository={repository}
+                        discriminator={discriminator}
+                      />
+                      <Check
+                        className={cn(
+                          'ml-auto size-4 shrink-0',
+                          selectionKey === value ? 'opacity-100' : 'opacity-0'
+                        )}
+                      />
+                    </CommandItem>
+                  );
+                })}
+              </CommandGroup>
+            ))}
+          </CommandList>
+        </Command>
+      </PopoverContent>
+    </Popover>
+  );
+}

--- a/apps/web/src/routers/cloud-agent-next-router.ts
+++ b/apps/web/src/routers/cloud-agent-next-router.ts
@@ -537,6 +537,8 @@ export const cloudAgentNextRouter = createTRPCRouter({
             fullName: z.string(),
             private: z.boolean(),
             defaultBranch: z.string().optional(),
+            platformIntegrationId: z.string().uuid().optional(),
+            platformAccountLogin: z.string().optional(),
           })
         ),
         integrationInstalled: z.boolean(),


### PR DESCRIPTION
## Why
#5595 persists authoritative installation identity per rig. This child lets onboarding and Create Rig populate that identity while keeping duplicate repositories distinct.

## Dependency
Depends on #5595.

## What changes
- Group repository options by GitHub organization.
- Use integration-qualified selection keys.
- Submit platformIntegrationId and default branch.
- Reject stale selections instead of switching installations.

## Validation
- 53 focused tests
- Web/affected-package typechecks and lint
- `git diff --check`