### PR TITLE
fix(auth): recover rowless magic-link accounts

### DIFF
--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.test.ts
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.test.ts
@@ -2,13 +2,39 @@ import { describe, expect, it } from '@jest/globals';
 import { getLoginMethods } from './UserAdminAccountInfo';
 
 describe('getLoginMethods', () => {
-  it('shows the names of each associated login provider', () => {
+  it('shows the name and email associated with each login provider', () => {
     expect(
-      getLoginMethods(['anaconda', 'github', 'workos']).map(provider => provider.name)
-    ).toEqual(['Anaconda', 'GitHub', 'Enterprise SSO']);
+      getLoginMethods([
+        { provider: 'anaconda', email: 'anaconda@example.com', source: 'linked' },
+        { provider: 'github', email: 'github@example.com', source: 'linked' },
+        { provider: 'workos', email: 'sso@example.com', source: 'linked' },
+      ]).map(method => ({ name: method.metadata.name, email: method.email }))
+    ).toEqual([
+      { name: 'Anaconda', email: 'anaconda@example.com' },
+      { name: 'GitHub', email: 'github@example.com' },
+      { name: 'Enterprise SSO', email: 'sso@example.com' },
+    ]);
   });
 
   it('shows magic-link email login', () => {
-    expect(getLoginMethods(['email']).map(provider => provider.name)).toEqual(['Email']);
+    expect(
+      getLoginMethods([{ provider: 'email', email: 'user@example.com', source: 'inferred' }])
+    ).toEqual([
+      expect.objectContaining({
+        metadata: expect.objectContaining({ name: 'Email' }),
+        email: 'user@example.com',
+        source: 'inferred',
+      }),
+    ]);
+  });
+
+  it('keeps distinct emails for the same provider visible', () => {
+    const longEmail = `${'long-address-'.repeat(8)}@example.com`;
+    const methods = getLoginMethods([
+      { provider: 'github', email: 'github@example.com', source: 'linked' },
+      { provider: 'github', email: longEmail, source: 'linked' },
+    ]);
+
+    expect(methods.map(method => method.email)).toEqual(['github@example.com', longEmail]);
   });
 });

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
@@ -15,7 +15,7 @@ import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip
 import Link from 'next/link';
 import { Info, SquareArrowOutUpRight, Webhook } from 'lucide-react';
 import { createHash } from 'crypto';
-import { getProviderById, type AuthProviderId } from '@/lib/auth/provider-metadata';
+import { getProviderById } from '@/lib/auth/provider-metadata';
 import { Badge } from '@/components/ui/badge';
 
 function getGravatarUrl(email: string, size: number = 80): string {
@@ -112,7 +112,7 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
             {user.google_user_email} <CopyTextButton text={user.google_user_email} />
           </Field>
           <Field label="Login Methods">
-            <UserLoginMethods providers={user.login_methods} />
+            <UserLoginMethods methods={user.login_methods} />
           </Field>
           <Field label="Normalized Email">
             {user.normalized_email ?? <span className="text-muted-foreground">N/A</span>}
@@ -174,16 +174,31 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
   );
 }
 
-export function UserLoginMethods({ providers }: { providers: AuthProviderId[] }) {
+export function UserLoginMethods({ methods }: { methods: UserDetailProps['login_methods'] }) {
   return (
     <div className="flex flex-wrap gap-1.5">
-      {getLoginMethods(providers).map(metadata => {
+      {getLoginMethods(methods).map(({ metadata, email, source }) => {
         return (
-          <Badge key={metadata.id} variant="secondary" className="gap-1.5 font-normal">
+          <Badge
+            key={`${metadata.id}:${email}`}
+            variant="secondary"
+            className="max-w-full gap-1.5 font-normal"
+          >
             <span className="flex size-3.5 items-center justify-center [&>svg]:size-3.5">
               {metadata.icon}
             </span>
-            {metadata.name}
+            <span>{metadata.name}</span>
+            <span aria-hidden className="text-muted-foreground">
+              ·
+            </span>
+            <span className="text-muted-foreground min-w-0 truncate font-mono" title={email}>
+              {email}
+            </span>
+            {source === 'inferred' ? (
+              <span className="text-muted-foreground text-[10px] uppercase tracking-wide">
+                inferred
+              </span>
+            ) : null}
           </Badge>
         );
       })}
@@ -191,8 +206,12 @@ export function UserLoginMethods({ providers }: { providers: AuthProviderId[] })
   );
 }
 
-export function getLoginMethods(providers: AuthProviderId[]) {
-  return providers.map(getProviderById);
+export function getLoginMethods(methods: UserDetailProps['login_methods']) {
+  return methods.map(method => ({
+    metadata: getProviderById(method.provider),
+    email: method.email,
+    source: method.source,
+  }));
 }
 
 function Field({

--- a/apps/web/src/app/admin/users/[id]/page.tsx
+++ b/apps/web/src/app/admin/users/[id]/page.tsx
@@ -14,7 +14,7 @@ import {
   user_auth_provider,
 } from '@kilocode/db/schema';
 import { eq, inArray, desc } from 'drizzle-orm';
-import { findUserById } from '@/lib/user';
+import { findUserById, inferRowlessAuthProviders } from '@/lib/user';
 import { getBalanceForUser } from '@/lib/user/balance';
 import { hasReceivedAnyFreeWelcomeCredits } from '@/lib/welcomeCredits';
 import { redirect } from 'next/navigation';
@@ -67,7 +67,10 @@ async function getUserData(userId: string): Promise<UserDetailProps | null> {
   const creditInfo = await getBalanceForUser(user);
   const hasReceivedCardValidationCredits = await hasReceivedAnyFreeWelcomeCredits(user.id);
   const authProviders = await db
-    .selectDistinct({ provider: user_auth_provider.provider })
+    .selectDistinct({
+      provider: user_auth_provider.provider,
+      email: user_auth_provider.email,
+    })
     .from(user_auth_provider)
     .where(eq(user_auth_provider.kilo_user_id, userId))
     .orderBy(user_auth_provider.provider);
@@ -98,7 +101,14 @@ async function getUserData(userId: string): Promise<UserDetailProps | null> {
     organization_memberships: organizationMemberships,
     autoTopUpConfig,
     is_sso_protected_domain: isSSOProtectedDomain,
-    login_methods: authProviders.length > 0 ? authProviders.map(row => row.provider) : ['email'],
+    login_methods:
+      authProviders.length > 0
+        ? authProviders.map(method => ({ ...method, source: 'linked' as const }))
+        : inferRowlessAuthProviders(user).map(provider => ({
+            provider,
+            email: user.google_user_email,
+            source: 'inferred' as const,
+          })),
   };
 }
 

--- a/apps/web/src/app/api/sso/organizations/route.test.ts
+++ b/apps/web/src/app/api/sso/organizations/route.test.ts
@@ -117,13 +117,13 @@ describe('POST /api/sso/organizations', () => {
     });
   });
 
-  it('enforces required SSO for a discovered legacy Google Workspace account', async () => {
+  it('enforces required SSO before returning rowless UUID account Email discovery', async () => {
     mockGetAllUserProviders.mockResolvedValue({
       kind: 'found',
       user: {
-        kiloUserId: 'oauth/google:synthetic-account',
-        providers: ['google'],
-        primaryEmail: 'legacy-workspace@example.com',
+        kiloUserId: '123e4567-e89b-42d3-a456-426614174000',
+        providers: ['email'],
+        primaryEmail: 'rowless-email@example.com',
       },
     });
     mockResolveSsoAuthorityForDomain.mockResolvedValue({
@@ -134,8 +134,9 @@ describe('POST /api/sso/organizations', () => {
     mockGetWorkOSOrganization.mockResolvedValue({ id: 'workos-organization-1' } as never);
 
     await expect(
-      (await POST(request({ email: 'legacy-workspace@example.com' }))).json()
+      (await POST(request({ email: 'rowless-email@example.com' }))).json()
     ).resolves.toEqual({ kind: 'sso', organizationId: 'workos-organization-1' });
+    expect(mockIsNewAccountEligibleForMagicLink).not.toHaveBeenCalled();
   });
 
   it('returns server-authorized account-creation choices for an eligible unknown email', async () => {

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -519,20 +519,42 @@ describe('User', () => {
       }
     );
 
-    it('does not infer a provider from an unknown legacy hosted domain', async () => {
+    it('recovers email discovery for a rowless UUID-era account', async () => {
       const user = await insertTestUser({
-        google_user_email: 'unknown-legacy@example.com',
-        google_user_name: 'Unknown Legacy User',
-        normalized_email: 'unknown-legacy@example.com',
-        hosted_domain: 'unknown.example.com',
+        id: randomUUID(),
+        google_user_email: 'rowless-email@example.com',
+        google_user_name: 'Rowless Email User',
+        normalized_email: 'rowless-email@example.com',
+        hosted_domain: 'example.com',
       });
 
-      await expect(getAllUserProviders('unknown-legacy@example.com')).resolves.toEqual({
+      await expect(getAllUserProviders('rowless-email@example.com')).resolves.toEqual({
         kind: 'found',
         user: {
           kiloUserId: user.id,
-          providers: [],
-          primaryEmail: 'unknown-legacy@example.com',
+          providers: ['email'],
+          primaryEmail: 'rowless-email@example.com',
+          workosHostedDomain: undefined,
+        },
+      });
+    });
+
+    it('uses the canonical UUID validator for rowless Email recovery', async () => {
+      const email = 'nil-uuid-email@example.com';
+      const user = await insertTestUser({
+        id: '00000000-0000-0000-0000-000000000000',
+        google_user_email: email,
+        google_user_name: 'Nil UUID Email User',
+        normalized_email: email,
+        hosted_domain: 'example.com',
+      });
+
+      await expect(getAllUserProviders(email)).resolves.toEqual({
+        kind: 'found',
+        user: {
+          kiloUserId: user.id,
+          providers: ['email'],
+          primaryEmail: email,
           workosHostedDomain: undefined,
         },
       });

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -126,6 +126,7 @@ import type { UUID } from 'node:crypto';
 import { checkDiscordGuildMembership } from '@/lib/integrations/discord-guild-membership';
 import type { AuthProviderId } from '@/lib/auth/provider-metadata';
 import { hosted_domain_specials } from '@/lib/auth/constants';
+import * as z from 'zod';
 import {
   generateOpenRouterDownstreamSafetyIdentifier,
   generateOpenRouterUpstreamSafetyIdentifier,
@@ -1979,7 +1980,7 @@ function legacyProviderFromHostedDomain(user: User): AuthProviderId[] {
     case hosted_domain_specials.email:
       return ['email'];
     default:
-      return [];
+      return isUuidUserId(user.id) ? ['email'] : [];
   }
 }
 
@@ -1993,6 +1994,10 @@ function parseLegacyOAuthProvider(userId: string): AuthProviderId | null {
     default:
       return null;
   }
+}
+
+function isUuidUserId(userId: string): boolean {
+  return z.uuid().safeParse(userId).success;
 }
 
 /**

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -1945,7 +1945,7 @@ async function getUserProviderInfo(user: User): Promise<UserProviderLookupResult
 
   const workosProvider = providers.find(p => p.provider === 'workos');
   const discoveredProviders =
-    providers.length > 0 ? providers.map(p => p.provider) : legacyProviderFromHostedDomain(user);
+    providers.length > 0 ? providers.map(p => p.provider) : inferRowlessAuthProviders(user);
 
   return {
     kind: 'found',
@@ -1958,7 +1958,9 @@ async function getUserProviderInfo(user: User): Promise<UserProviderLookupResult
   };
 }
 
-function legacyProviderFromHostedDomain(user: User): AuthProviderId[] {
+export function inferRowlessAuthProviders(
+  user: Pick<User, 'id' | 'hosted_domain'>
+): AuthProviderId[] {
   const legacyOAuthProvider = parseLegacyOAuthProvider(user.id);
   if (legacyOAuthProvider) return [legacyOAuthProvider];
 

--- a/apps/web/src/types/admin.ts
+++ b/apps/web/src/types/admin.ts
@@ -37,7 +37,11 @@ export type HasSSOProtectedDomain = {
   is_sso_protected_domain: boolean;
 };
 export type HasLoginMethods = {
-  login_methods: AuthProviderId[];
+  login_methods: {
+    provider: AuthProviderId;
+    email: string;
+    source: 'linked' | 'inferred';
+  }[];
 };
 export type UserDetailProps = UserTableProps &
   HasCreditInfo &


### PR DESCRIPTION
## Summary

- Restore Email discovery for modern accounts intentionally left without linked provider rows by the magic-link recovery workflow.
- Preserve actual provider rows, strict historical OAuth provenance, and explicit legacy provider sentinels as higher-authority signals.
- Share the rowless inference logic with the admin user view so troubleshooting reflects the same login method discovery will offer.
- Show each linked provider email in the admin login-method pill and visibly mark rowless methods as inferred.

## Verification

- [x] Seeded a synthetic account with Google and GitHub provider rows using different emails; confirmed both provider-email pairs appear in the admin login-method pills.
- [x] Seeded a synthetic UUID account with no provider rows; confirmed the admin page shows `Email`, the primary account email, and an `INFERRED` marker.
- [x] Removed all synthetic user and provider records after verification.

## Visual Changes

| Linked provider emails | Rowless recovery method |
|---|---|
| ![Admin login methods showing distinct synthetic Google and GitHub emails](https://github.com/user-attachments/assets/ed0b9212-7874-409d-99ab-8734507ab626) | ![Admin login method showing a synthetic inferred Email method](https://github.com/user-attachments/assets/83e526d9-a321-4826-9a01-3a75cc8e7e2f) |

## Reviewer Notes

The existing admin recovery action intentionally removes linked provider rows so the next mailbox-verified magic-link callback can attach Email to the existing account. Email-first discovery incorrectly interpreted that intermediate state as having no supported method.

The fallback applies only when an existing account has no provider rows, no recognized historical OAuth ID, and no explicit legacy provider sentinel. A canonically valid UUID then resolves to Email. Required SSO is evaluated before Email is returned, and the existing Turnstile, mailbox proof, Email rate limit, domain policy, and provider-linking checks remain unchanged.

The admin query returns distinct `(provider, email)` pairs. Persisted rows are labeled `linked`; rowless methods reuse the exact discovery inference function and are labeled `inferred`, with the primary account email shown as the diagnostic identity.

Automated checks run locally:

- Focused auth/admin suites: 155 tests
- `pnpm --filter web typecheck`
- `pnpm --filter web dependency-cycle-check`
- `pnpm --filter web lint`
- `git diff --check`

Final independent static review: `NO FINDINGS`.