### PR TITLE
fix(mobile): defer async initial link updates until mount

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,12 @@ jobs:
         with:
           node-version-file: '.nvmrc'
 
+      - name: Install root dependencies
+        run: pnpm --filter kilocode-monorepo install --frozen-lockfile --ignore-scripts
+
+      - name: Test dependency change detection
+        run: node --test scripts/changed-dependencies.test.mjs
+
       - name: Detect changes
         id: filter
         uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d # v4.0.1

--- a/.github/workflows/extension-ci.yml
+++ b/.github/workflows/extension-ci.yml
@@ -3,20 +3,8 @@ name: extension CI
 on:
   push:
     branches: [main]
-    paths:
-      - 'apps/extension/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '.nvmrc'
-      - '.github/workflows/extension-ci.yml'
   pull_request:
     branches: [main]
-    paths:
-      - 'apps/extension/**'
-      - 'pnpm-lock.yaml'
-      - 'pnpm-workspace.yaml'
-      - '.nvmrc'
-      - '.github/workflows/extension-ci.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -27,9 +15,59 @@ permissions:
   pull-requests: read
 
 jobs:
+  changes:
+    runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
+    timeout-minutes: 5
+    outputs:
+      extension: ${{ steps.filter.outputs.extension == 'true' || steps.workspaces.outputs.extension == 'true' }}
+    steps:
+      - uses: useblacksmith/checkout@41cdeedae8edb2e684ba22896a5fd2a3cb85db6b
+        with:
+          fetch-depth: 0
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f
+        with:
+          node-version-file: '.nvmrc'
+
+      - name: Install root dependencies
+        run: pnpm --filter kilocode-monorepo install --frozen-lockfile --ignore-scripts
+
+      - name: Detect explicit changes
+        id: filter
+        uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d
+        with:
+          filters: |
+            extension:
+              - 'apps/extension/**'
+              - '.github/workflows/extension-ci.yml'
+              - 'scripts/changed-workspaces.sh'
+              - 'scripts/changed-dependencies.mjs'
+              - 'scripts/changed-dependencies.test.mjs'
+              - 'package.json'
+              - '.nvmrc'
+              - '.npmrc'
+              - '.pnpmfile.cjs'
+              - '.oxlintrc.json'
+              - '.oxfmtrc.json'
+              - '.prettierignore'
+              - 'tools/oxlint/**'
+              - 'apps/web/src/**'
+
+      - name: Detect affected workspaces
+        id: workspaces
+        run: |
+          matrix=$(scripts/changed-workspaces.sh)
+          echo "extension=$(jq -r 'any(.[]; .dir == "apps/extension")' <<< "$matrix")" >> "$GITHUB_OUTPUT"
+
   # Compiler, linter, formatting and unit tests, via the extension's own `verify`
   # script so the extension's stricter (type-aware) oxlint config is what runs.
   verify:
+    needs: changes
+    if: needs.changes.outputs.extension == 'true'
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
@@ -54,6 +92,8 @@ jobs:
 
   # Prove the Firefox MV3 target still builds (the Chrome build runs inside e2e).
   build-firefox:
+    needs: changes
+    if: needs.changes.outputs.extension == 'true'
     runs-on: ${{ vars.RUNNER_DEFAULT_LABEL || 'ubuntu-latest' }}
     timeout-minutes: 15
     steps:
@@ -80,7 +120,8 @@ jobs:
   # also covers the Chrome build. Firefox Selenium e2e (`e2e:firefox`) is intentionally
   # not run here: it relies on geckodriver tab detection that is unreliable headless.
   e2e-chrome:
-    needs: verify
+    needs: [changes, verify]
+    if: needs.changes.outputs.extension == 'true'
     runs-on: ${{ vars.RUNNER_LARGE_LABEL || 'ubuntu-24.04-8core' }}
     timeout-minutes: 20
     env:

--- a/apps/mobile/.oxlintrc.json
+++ b/apps/mobile/.oxlintrc.json
@@ -215,6 +215,13 @@
   },
   "overrides": [
     {
+      "files": ["src/lib/expo-router-linking.mounted.test.tsx"],
+      "rules": {
+        "import/no-nodejs-modules": "off",
+        "@typescript-eslint/no-deprecated": "off"
+      }
+    },
+    {
       "files": ["src/components/ui/image.tsx"],
       "rules": {
         "no-restricted-imports": "off"

--- a/apps/mobile/src/lib/expo-router-linking.mounted.test.tsx
+++ b/apps/mobile/src/lib/expo-router-linking.mounted.test.tsx
@@ -1,0 +1,237 @@
+import { readFileSync } from 'node:fs';
+import { createRequire } from 'node:module';
+import { runInNewContext } from 'node:vm';
+
+import type * as NativeLinking from 'expo-router/build/fork/useLinking.native';
+import { useThenable } from 'expo-router/build/fork/useThenable';
+import * as React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const moduleExports = {};
+const initialState = { routes: [{ name: 'index' }] };
+const extractExpoPathFromURL = (_prefixes: string[], url: string) => url.replace('kiloapp://', '');
+
+runInNewContext(
+  readFileSync(require.resolve('expo-router/build/fork/useLinking.native.js'), 'utf8'),
+  {
+    exports: moduleExports,
+    process,
+    require: (id: string) => {
+      switch (id) {
+        case 'react': {
+          return React;
+        }
+        case 'react-native': {
+          return { Platform: { OS: 'android' } };
+        }
+        case 'expo-linking': {
+          return {};
+        }
+        case './extractPathFromURL': {
+          return { extractExpoPathFromURL };
+        }
+        case '../react-navigation/native': {
+          return { useNavigationIndependentTree: () => false };
+        }
+        default: {
+          throw new Error(`Unexpected router dependency: ${id}`);
+        }
+      }
+    },
+  }
+);
+
+const { useLinking } = moduleExports as typeof NativeLinking;
+const prefixes: string[] = [];
+const neverResolves = Promise.withResolvers<undefined>().promise;
+let renderer: TestRenderer.ReactTestRenderer | undefined = undefined;
+
+type HarnessProps = { linkPrefixes?: string[] };
+
+function createHarness(initialURL: string | null | Promise<string | null>, suspend = false) {
+  const onUnhandledLinking = vi.fn<(path: string | undefined) => void>();
+  const onCommit = vi.fn();
+  const getInitialURL = (): string | null | Promise<string | null> => initialURL;
+  const getStateFromPath = vi.fn(() => initialState);
+  const action = { type: 'NAVIGATE' as const, payload: { name: 'index' } };
+  const getActionFromState = () => action;
+  const navigation = {
+    getRootState: () => ({
+      key: 'root',
+      index: 0,
+      routeNames: ['index'],
+      routes: [{ key: 'index', name: 'index' }],
+      type: 'stack',
+      stale: false as const,
+    }),
+    dispatch: vi.fn(),
+    resetRoot: vi.fn(),
+  };
+  const listeners = new Set<(url: string) => void>();
+  const subscribe = (listener: (url: string) => void) => {
+    listeners.add(listener);
+    return () => {
+      listeners.delete(listener);
+    };
+  };
+  const snapshots: ReturnType<typeof useThenable>[] = [];
+
+  function NavigationContainer({ linkPrefixes = prefixes }: HarnessProps) {
+    const ref = React.useRef<Partial<Parameters<typeof useLinking>[0]['current']>>(navigation);
+    const { getInitialState } = useLinking(
+      ref as Parameters<typeof useLinking>[0],
+      { prefixes: linkPrefixes, getInitialURL, getStateFromPath, getActionFromState, subscribe },
+      onUnhandledLinking
+    );
+    snapshots.push(useThenable(getInitialState));
+    React.useEffect(() => {
+      onCommit();
+    }, []);
+    if (suspend) {
+      React.use(neverResolves);
+    }
+    return null;
+  }
+
+  return {
+    NavigationContainer,
+    onUnhandledLinking,
+    onCommit,
+    getStateFromPath,
+    snapshots,
+    listeners,
+    navigation,
+    action,
+  };
+}
+
+async function renderHarness(
+  NavigationContainer: React.ComponentType<HarnessProps>,
+  linkPrefixes = prefixes
+) {
+  await act(() => {
+    const tree = React.createElement(
+      React.StrictMode,
+      null,
+      React.createElement(
+        React.Suspense,
+        { fallback: null },
+        React.createElement(NavigationContainer, { linkPrefixes })
+      )
+    );
+    if (renderer) {
+      renderer.update(tree);
+    } else {
+      renderer = TestRenderer.create(tree);
+    }
+  });
+}
+
+describe('Expo Router native initial linking', () => {
+  beforeEach(() => {
+    vi.stubGlobal('IS_REACT_ACT_ENVIRONMENT', true);
+  });
+
+  afterEach(async () => {
+    await act(() => {
+      renderer?.unmount();
+    });
+    renderer = undefined;
+    vi.unstubAllGlobals();
+  });
+
+  it('does not update an initial render that has not mounted', async () => {
+    const initialURL = Promise.withResolvers<string | null>();
+    const harness = createHarness(initialURL.promise, true);
+    await renderHarness(harness.NavigationContainer);
+    expect(harness.onCommit).not.toHaveBeenCalled();
+
+    await act(() => {
+      initialURL.resolve('kiloapp:///');
+    });
+
+    expect(harness.onUnhandledLinking).not.toHaveBeenCalled();
+  });
+
+  it('preserves initial navigation and unhandled links after mounting', async () => {
+    const initialURL = Promise.withResolvers<string | null>();
+    const harness = createHarness(initialURL.promise);
+    await renderHarness(harness.NavigationContainer);
+    expect(harness.onCommit).toHaveBeenCalled();
+
+    await act(() => {
+      initialURL.resolve('kiloapp:///settings');
+    });
+
+    expect(harness.onUnhandledLinking).toHaveBeenCalledExactlyOnceWith('/settings');
+    expect(harness.getStateFromPath).toHaveBeenCalledWith('/settings', undefined);
+    expect(harness.snapshots.at(-1)).toEqual([true, initialState]);
+  });
+
+  it('ignores an initial URL that resolves after unmounting', async () => {
+    const initialURL = Promise.withResolvers<string | null>();
+    const harness = createHarness(initialURL.promise);
+    await renderHarness(harness.NavigationContainer);
+    await act(() => {
+      renderer?.unmount();
+    });
+    renderer = undefined;
+
+    await act(() => {
+      initialURL.resolve('kiloapp:///settings');
+    });
+
+    expect(harness.onUnhandledLinking).not.toHaveBeenCalled();
+  });
+
+  it('keeps synchronous initial URLs ready on the first render', async () => {
+    const harness = createHarness('kiloapp:///settings');
+    await renderHarness(harness.NavigationContainer);
+
+    expect(harness.snapshots[0]).toEqual([true, initialState]);
+    expect(harness.onUnhandledLinking).toHaveBeenCalledWith('/settings');
+  });
+
+  it('does not report a null initial URL', async () => {
+    const initialURL = Promise.withResolvers<string | null>();
+    initialURL.resolve(null);
+    const harness = createHarness(initialURL.promise);
+    await renderHarness(harness.NavigationContainer);
+
+    expect(harness.onUnhandledLinking).not.toHaveBeenCalled();
+    expect(harness.snapshots.at(-1)).toEqual([true, undefined]);
+  });
+
+  it('reports an already resolved initial URL once after mounting', async () => {
+    const initialURL = Promise.withResolvers<string | null>();
+    initialURL.resolve('kiloapp:///settings');
+    const harness = createHarness(initialURL.promise);
+    await renderHarness(harness.NavigationContainer);
+
+    expect(harness.onUnhandledLinking).toHaveBeenCalledExactlyOnceWith('/settings');
+    expect(harness.snapshots.at(-1)).toEqual([true, initialState]);
+  });
+
+  it('handles warm links without replaying the initial URL on rerender', async () => {
+    const initialURL = Promise.withResolvers<string | null>();
+    initialURL.resolve('kiloapp:///settings');
+    const harness = createHarness(initialURL.promise);
+    await renderHarness(harness.NavigationContainer);
+    expect(harness.listeners.size).toBe(1);
+    harness.onUnhandledLinking.mockClear();
+
+    await act(() => {
+      for (const listener of harness.listeners) {
+        listener('kiloapp:///profile');
+      }
+    });
+    await renderHarness(harness.NavigationContainer, []);
+
+    expect(harness.onUnhandledLinking).toHaveBeenCalledExactlyOnceWith('/profile');
+    expect(harness.navigation.dispatch).toHaveBeenCalledExactlyOnceWith(harness.action);
+    expect(harness.navigation.resetRoot).not.toHaveBeenCalled();
+    expect(harness.listeners.size).toBe(1);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "eslint-plugin-zod-utils": "1.0.11",
     "husky": "9.1.7",
     "ink": "6.8.0",
+    "js-yaml": "4.3.1",
     "oxfmt": "0.40.0",
     "oxlint": "1.55.0",
     "oxlint-plugin-react-native": "0.2.17",

--- a/patches/expo-router@57.0.10.patch
+++ b/patches/expo-router@57.0.10.patch
@@ -1,0 +1,42 @@
+diff --git a/build/fork/useLinking.native.js b/build/fork/useLinking.native.js
+--- a/build/fork/useLinking.native.js
++++ b/build/fork/useLinking.native.js
+@@ -114,20 +114,30 @@ function useLinking(ref, { enabled = true, prefixes, filter, config, getInitialU
+         const path = (0, extractPathFromURL_1.extractExpoPathFromURL)(prefixesRef.current, url);
+         return path !== undefined ? getStateFromPathRef.current(path, configRef.current) : undefined;
+     }, []);
++    const initialURLRef = (0, react_1.useRef)(undefined);
++    (0, react_1.useEffect)(() => {
++        let cancelled = false;
++        initialURLRef.current?.then((url) => {
++            if (cancelled) {
++                return;
++            }
++            initialURLRef.current = undefined;
++            if (typeof url === 'string') {
++                onUnhandledLinking((0, extractPathFromURL_1.extractExpoPathFromURL)(prefixes, url));
++            }
++        }, () => undefined);
++        return () => {
++            cancelled = true;
++        };
++    }, [onUnhandledLinking, prefixes]);
+     const getInitialState = (0, react_1.useCallback)(() => {
+         let state;
+         if (enabledRef.current) {
+             const url = getInitialURLRef.current();
+             if (url != null) {
+                 if (typeof url !== 'string') {
+-                    return url.then((url) => {
+-                        const state = getStateFromURL(url);
+-                        if (typeof url === 'string') {
+-                            // If the link were handled, it gets cleared in NavigationContainer
+-                            onUnhandledLinking((0, extractPathFromURL_1.extractExpoPathFromURL)(prefixes, url));
+-                        }
+-                        return state;
+-                    });
++                    initialURLRef.current = url;
++                    return url.then(getStateFromURL);
+                 }
+                 else {
+                     onUnhandledLinking((0, extractPathFromURL_1.extractExpoPathFromURL)(prefixes, url));

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -151,6 +151,7 @@ overrides:
 packageExtensionsChecksum: sha256-1pgKZxx87NNMe1poF5N5u5kZB/qlEyILBQPxofM1shE=
 
 patchedDependencies:
+  expo-router@57.0.10: 616f8a79932a3ebc7d31343b53b3fc425a14bfb89bb86cdafa614cefa4e603ed
   expo-server-sdk: 7850520582b5b394397b35d1ea195192fe78589d8a6a748fe15177b818c4ed0b
   react-native-appsflyer@6.18.0: 82df99378c830e774b0f01796d8be595da114d1d13393d85ddd47d565c5c2aab
 
@@ -488,7 +489,7 @@ importers:
         version: 57.0.8(expo@57.0.10)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)
       expo-router:
         specifier: ~57.0.10
-        version: 57.0.10(95016413e10ac4b2f99a030c8fabf35b)
+        version: 57.0.10(patch_hash=616f8a79932a3ebc7d31343b53b3fc425a14bfb89bb86cdafa614cefa4e603ed)(95016413e10ac4b2f99a030c8fabf35b)
       expo-screen-capture:
         specifier: 57.0.1
         version: 57.0.1(expo@57.0.10)(react@19.2.3)
@@ -21219,7 +21220,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.10(95016413e10ac4b2f99a030c8fabf35b)
+      expo-router: 57.0.10(patch_hash=616f8a79932a3ebc7d31343b53b3fc425a14bfb89bb86cdafa614cefa4e603ed)(95016413e10ac4b2f99a030c8fabf35b)
       react-native: 0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/metro-runtime'
@@ -21295,7 +21296,7 @@ snapshots:
       ws: 8.21.0(bufferutil@4.1.0)(utf-8-validate@6.0.6)
       zod: 3.25.76
     optionalDependencies:
-      expo-router: 57.0.10(a55ba02c2fb18b26174eabf24192d484)
+      expo-router: 57.0.10(patch_hash=616f8a79932a3ebc7d31343b53b3fc425a14bfb89bb86cdafa614cefa4e603ed)(a55ba02c2fb18b26174eabf24192d484)
       react-native: 0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6)
     transitivePeerDependencies:
       - '@expo/metro-runtime'
@@ -21773,7 +21774,7 @@ snapshots:
       react: 19.2.3
     optionalDependencies:
       '@expo/metro-runtime': 57.0.8(expo@57.0.10)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
-      expo-router: 57.0.10(95016413e10ac4b2f99a030c8fabf35b)
+      expo-router: 57.0.10(patch_hash=616f8a79932a3ebc7d31343b53b3fc425a14bfb89bb86cdafa614cefa4e603ed)(95016413e10ac4b2f99a030c8fabf35b)
       react-dom: 19.2.6(react@19.2.3)
     transitivePeerDependencies:
       - supports-color
@@ -21788,7 +21789,7 @@ snapshots:
       react: 19.2.6
     optionalDependencies:
       '@expo/metro-runtime': 57.0.8(expo@57.0.10)(react-dom@19.2.6(react@19.2.6))(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
-      expo-router: 57.0.10(a55ba02c2fb18b26174eabf24192d484)
+      expo-router: 57.0.10(patch_hash=616f8a79932a3ebc7d31343b53b3fc425a14bfb89bb86cdafa614cefa4e603ed)(a55ba02c2fb18b26174eabf24192d484)
       react-dom: 19.2.6(react@19.2.6)
     transitivePeerDependencies:
       - supports-color
@@ -30204,7 +30205,7 @@ snapshots:
       - supports-color
       - typescript
 
-  expo-router@57.0.10(95016413e10ac4b2f99a030c8fabf35b):
+  expo-router@57.0.10(patch_hash=616f8a79932a3ebc7d31343b53b3fc425a14bfb89bb86cdafa614cefa4e603ed)(95016413e10ac4b2f99a030c8fabf35b):
     dependencies:
       '@expo/log-box': 57.0.2(expo@57.0.10)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
       '@expo/metro-runtime': 57.0.8(expo@57.0.10)(react-dom@19.2.6(react@19.2.3))(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
@@ -30254,7 +30255,7 @@ snapshots:
       - react-native-worklets
       - supports-color
 
-  expo-router@57.0.10(a55ba02c2fb18b26174eabf24192d484):
+  expo-router@57.0.10(patch_hash=616f8a79932a3ebc7d31343b53b3fc425a14bfb89bb86cdafa614cefa4e603ed)(a55ba02c2fb18b26174eabf24192d484):
     dependencies:
       '@expo/log-box': 57.0.2(expo@57.0.10)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)
       '@expo/metro-runtime': 57.0.8(expo@57.0.10)(react-dom@19.2.6(react@19.2.6))(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.6)(utf-8-validate@6.0.6))(react@19.2.6)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,9 @@ importers:
       ink:
         specifier: 6.8.0
         version: 6.8.0(@types/react@19.2.14)(bufferutil@4.1.0)(react-devtools-core@6.1.5(bufferutil@4.1.0)(utf-8-validate@6.0.6))(react@19.2.6)(utf-8-validate@6.0.6)
+      js-yaml:
+        specifier: 4.3.1
+        version: 4.3.1
       oxfmt:
         specifier: 0.40.0
         version: 0.40.0

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -155,6 +155,7 @@ packageExtensions:
     dependencies:
       '@expo/config-plugins': '*'
 patchedDependencies:
+  expo-router@57.0.10: patches/expo-router@57.0.10.patch
   expo-server-sdk: patches/expo-server-sdk.patch
   react-native-appsflyer@6.18.0: patches/react-native-appsflyer@6.18.0.patch
 publicHoistPattern:

--- a/scripts/changed-dependencies.mjs
+++ b/scripts/changed-dependencies.mjs
@@ -1,0 +1,190 @@
+import { execFileSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
+import { posix } from 'node:path';
+import { isDeepStrictEqual } from 'node:util';
+
+import { load } from 'js-yaml';
+
+function withoutKeys(value, keys) {
+  const result = { ...value };
+  for (const key of keys) delete result[key];
+  return result;
+}
+
+function dependencyGraph(lockfile, workspace, patches, directory) {
+  const graph = new Map();
+  const names = new Set();
+  const nativeNames = new Set();
+
+  function visitDependencies(dependencies, owner) {
+    for (const [name, dependency] of Object.entries(dependencies ?? {})) {
+      const version = typeof dependency === 'string' ? dependency : dependency.version;
+      if (version.startsWith('link:')) {
+        visitImporter(posix.join(owner, version.slice(5)));
+        continue;
+      }
+      const id = Object.hasOwn(lockfile.snapshots, `${name}@${version}`)
+        ? `${name}@${version}`
+        : version;
+      if (graph.has(id)) continue;
+      const snapshot = lockfile.snapshots[id];
+      const packageId = id.split('(')[0];
+      const metadata = lockfile.packages[packageId];
+      if (!snapshot || !metadata) throw new Error(`Missing lockfile entry: ${id}`);
+      graph.set(id, { snapshot, metadata });
+      const packageName = packageId.slice(0, packageId.indexOf('@', 1));
+      names.add(packageName);
+      if (Object.hasOwn(metadata.peerDependencies ?? {}, 'react-native'))
+        nativeNames.add(packageName);
+      visitDependencies(snapshot.dependencies, '.');
+      visitDependencies(snapshot.optionalDependencies, '.');
+    }
+  }
+
+  function visitImporter(directory) {
+    const key = `importer:${directory}`;
+    if (graph.has(key)) return;
+    const importer = lockfile.importers[directory];
+    if (!importer) throw new Error(`Missing lockfile importer: ${directory}`);
+    graph.set(key, importer);
+    visitDependencies(importer.dependencies, directory);
+    visitDependencies(importer.devDependencies, directory);
+    visitDependencies(importer.optionalDependencies, directory);
+  }
+
+  visitImporter(directory);
+  const importer = lockfile.importers[directory];
+  const usesNative = ['dependencies', 'devDependencies', 'optionalDependencies'].some(group =>
+    Object.hasOwn(importer[group] ?? {}, 'react-native')
+  );
+  const ignoredHashes = [];
+  for (const [selector, path] of Object.entries(workspace.patchedDependencies ?? {})) {
+    const name = [...names].find(name => selector === name || selector.startsWith(`${name}@`));
+    if (name) {
+      if (!Object.hasOwn(patches, path)) throw new Error(`Missing dependency patch: ${path}`);
+      const hash = lockfile.patchedDependencies?.[selector];
+      if (
+        !usesNative &&
+        nativeNames.has(name) &&
+        nativeOnlyPatch(patches[path]) &&
+        typeof hash === 'string'
+      ) {
+        ignoredHashes.push(`(patch_hash=${hash})`);
+      } else {
+        graph.set(`patch:${selector}`, { path, content: patches[path], hash });
+      }
+    }
+  }
+  if (ignoredHashes.length === 0) return graph;
+  let serialized = JSON.stringify([...graph]);
+  for (const hash of ignoredHashes) serialized = serialized.replaceAll(hash, '');
+  return new Map(JSON.parse(serialized));
+}
+
+function nativeOnlyPatch(content) {
+  const lines = content.split('\n');
+  const headers = lines.filter(line => line.startsWith('diff --git '));
+  const targets = lines.filter(line => line.startsWith('--- ') || line.startsWith('+++ '));
+  const isNative = path => /\.(native|ios|android)\.[cm]?[jt]sx?$/.test(path);
+  return (
+    headers.length > 0 &&
+    targets.length >= 2 &&
+    headers.every(header => {
+      const paths = /^diff --git a\/(\S+) b\/(\S+)$/.exec(header);
+      return paths && paths.slice(1).every(isNative);
+    }) &&
+    targets.every(header => {
+      if (header === '--- /dev/null' || header === '+++ /dev/null') return true;
+      const path = /^(?:--- a\/|\+\+\+ b\/)(\S+)$/.exec(header);
+      return path && isNative(path[1]);
+    })
+  );
+}
+
+export function changedDependencyWorkspaces(before, after) {
+  for (const { lockfile } of [before, after]) {
+    if (lockfile.lockfileVersion !== '9.0' || !lockfile.importers || !lockfile.snapshots) {
+      throw new Error('Unsupported pnpm lockfile');
+    }
+  }
+  const lockfileSections = [
+    'importers',
+    'packages',
+    'snapshots',
+    'catalogs',
+    'overrides',
+    'packageExtensionsChecksum',
+    'patchedDependencies',
+  ];
+  const workspaceSections = [
+    'catalog',
+    'catalogs',
+    'overrides',
+    'packageExtensions',
+    'patchedDependencies',
+  ];
+  if (
+    !isDeepStrictEqual(
+      withoutKeys(before.lockfile, lockfileSections),
+      withoutKeys(after.lockfile, lockfileSections)
+    ) ||
+    !isDeepStrictEqual(
+      withoutKeys(before.workspace, workspaceSections),
+      withoutKeys(after.workspace, workspaceSections)
+    )
+  ) {
+    return ['*'];
+  }
+
+  const graph = (snapshot, directory) =>
+    dependencyGraph(snapshot.lockfile, snapshot.workspace, snapshot.patches, directory);
+  if (!isDeepStrictEqual(graph(before, '.'), graph(after, '.'))) return ['*'];
+
+  const directories = new Set([
+    ...Object.keys(before.lockfile.importers),
+    ...Object.keys(after.lockfile.importers),
+  ]);
+  directories.delete('.');
+  return [...directories].filter(directory => {
+    if (!before.lockfile.importers[directory] || !after.lockfile.importers[directory]) return true;
+    return !isDeepStrictEqual(graph(before, directory), graph(after, directory));
+  });
+}
+
+function readSnapshot(read) {
+  const workspace = load(read('pnpm-workspace.yaml'));
+  const patches = {};
+  for (const path of Object.values(workspace.patchedDependencies ?? {})) {
+    if (typeof path !== 'string' || posix.isAbsolute(path) || path.split('/').includes('..')) {
+      throw new Error('Invalid dependency patch path');
+    }
+    patches[path] = read(path);
+  }
+  return { lockfile: load(read('pnpm-lock.yaml')), workspace, patches };
+}
+
+if (import.meta.main) {
+  try {
+    const base = process.argv[2];
+    if (!base) throw new Error('A Git base revision is required');
+    const before = readSnapshot(path =>
+      execFileSync('git', ['show', `${base}:${path}`], {
+        encoding: 'utf8',
+        maxBuffer: 16 * 1024 * 1024,
+      })
+    );
+    const head = process.argv[3];
+    const after = readSnapshot(path =>
+      head
+        ? execFileSync('git', ['show', `${head}:${path}`], {
+            encoding: 'utf8',
+            maxBuffer: 16 * 1024 * 1024,
+          })
+        : readFileSync(path, 'utf8')
+    );
+    console.log(changedDependencyWorkspaces(before, after).join('\n'));
+  } catch (error) {
+    console.error(`Cannot scope dependency changes; selecting all workspaces: ${error.message}`);
+    console.log('*');
+  }
+}

--- a/scripts/changed-dependencies.test.mjs
+++ b/scripts/changed-dependencies.test.mjs
@@ -1,0 +1,258 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { changedDependencyWorkspaces } from './changed-dependencies.mjs';
+
+function snapshot() {
+  return {
+    workspace: { packages: ['apps/*', 'packages/*'], autoInstallPeers: false },
+    patches: {},
+    lockfile: {
+      lockfileVersion: '9.0',
+      settings: { autoInstallPeers: false },
+      importers: {
+        '.': { devDependencies: { lint: { specifier: '1.0.0', version: '1.0.0' } } },
+        'apps/mobile': { dependencies: { router: { specifier: '1.0.0', version: '1.0.0' } } },
+        'apps/extension': {
+          dependencies: {
+            shared: { specifier: 'workspace:*', version: 'link:../../packages/shared' },
+          },
+          devDependencies: { bundler: { specifier: '1.0.0', version: '1.0.0' } },
+        },
+        'packages/shared': { dependencies: { parser: { specifier: '1.0.0', version: '1.0.0' } } },
+      },
+      packages: {
+        'lint@1.0.0': { resolution: { integrity: 'lint-integrity' } },
+        'router@1.0.0': { resolution: { integrity: 'router-integrity' } },
+        'bundler@1.0.0': { resolution: { integrity: 'bundler-integrity' } },
+        'parser@1.0.0': { resolution: { integrity: 'parser-integrity' } },
+        'leaf@1.0.0': { resolution: { integrity: 'leaf-integrity' } },
+        'leaf@2.0.0': { resolution: { integrity: 'other-leaf-integrity' } },
+      },
+      snapshots: {
+        'lint@1.0.0': {},
+        'router@1.0.0': {},
+        'bundler@1.0.0': { dependencies: { leaf: '1.0.0' } },
+        'parser@1.0.0': {},
+        'leaf@1.0.0': {},
+        'leaf@2.0.0': {},
+      },
+    },
+  };
+}
+
+function addPatch(value, name, hash, content) {
+  const selector = `${name}@1.0.0`;
+  const path = `patches/${selector}.patch`;
+  value.workspace.patchedDependencies = { [selector]: path };
+  value.lockfile.patchedDependencies = { [selector]: hash };
+  value.patches[path] = content;
+}
+
+test('unchanged dependencies select no workspace', () => {
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), snapshot()), []);
+});
+
+test('a mobile router patch does not select the extension', () => {
+  const before = snapshot();
+  const after = snapshot();
+  addPatch(after, 'router', 'new-hash', 'router lifecycle fix');
+  after.lockfile.importers['apps/mobile'].dependencies.router.version =
+    '1.0.0(patch_hash=new-hash)';
+  after.lockfile.snapshots['router@1.0.0(patch_hash=new-hash)'] = {};
+  delete after.lockfile.snapshots['router@1.0.0'];
+
+  assert.deepEqual(changedDependencyWorkspaces(before, after), ['apps/mobile']);
+  assert.deepEqual(changedDependencyWorkspaces(after, before), ['apps/mobile']);
+});
+
+test('a transitive development dependency change selects the extension', () => {
+  const after = snapshot();
+  after.lockfile.snapshots['bundler@1.0.0'].dependencies.leaf = '2.0.0';
+
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), after), ['apps/extension']);
+});
+
+test('an optional dependency change selects its consumer', () => {
+  const after = snapshot();
+  after.lockfile.snapshots['router@1.0.0'].optionalDependencies = { leaf: '2.0.0' };
+
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), after), ['apps/mobile']);
+});
+
+test('an integrity change selects the workspace and its transitive consumers', () => {
+  const after = snapshot();
+  after.lockfile.packages['parser@1.0.0'].resolution.integrity = 'updated-integrity';
+
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), after), [
+    'apps/extension',
+    'packages/shared',
+  ]);
+});
+
+test('a root tool dependency change selects all workspaces', () => {
+  const after = snapshot();
+  after.lockfile.packages['lint@1.0.0'].resolution.integrity = 'updated-integrity';
+
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), after), ['*']);
+});
+
+test('an unused catalog or override change does not select the extension', () => {
+  const after = snapshot();
+  after.workspace.catalog = { router: '1.0.0' };
+  after.workspace.overrides = { router: '1.0.0' };
+  after.lockfile.catalogs = { default: { router: { specifier: '1.0.0', version: '1.0.0' } } };
+  after.lockfile.overrides = { router: '1.0.0' };
+
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), after), []);
+});
+
+test('a workspace installation policy change selects all workspaces', () => {
+  const after = snapshot();
+  after.workspace.autoInstallPeers = true;
+
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), after), ['*']);
+});
+
+test('a lockfile setting change selects all workspaces', () => {
+  const after = snapshot();
+  after.lockfile.settings.autoInstallPeers = true;
+
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), after), ['*']);
+});
+
+test('a patch content change selects consumers even when the lock hash is unchanged', () => {
+  const before = snapshot();
+  const after = snapshot();
+  addPatch(before, 'parser', 'same-hash', 'before');
+  addPatch(after, 'parser', 'same-hash', 'after');
+
+  assert.deepEqual(changedDependencyWorkspaces(before, after), [
+    'apps/extension',
+    'packages/shared',
+  ]);
+});
+
+test('dependency cycles do not prevent change detection', () => {
+  const before = snapshot();
+  before.lockfile.snapshots['parser@1.0.0'].dependencies = { leaf: '1.0.0' };
+  before.lockfile.snapshots['leaf@1.0.0'].dependencies = { parser: '1.0.0' };
+  const after = structuredClone(before);
+  after.lockfile.packages['leaf@1.0.0'].resolution.integrity = 'updated-integrity';
+
+  assert.deepEqual(changedDependencyWorkspaces(before, after), [
+    'apps/extension',
+    'packages/shared',
+  ]);
+});
+
+test('aliased packages use the resolved package identity', () => {
+  const before = snapshot();
+  before.lockfile.importers['packages/shared'].dependencies.parser.version = 'leaf@1.0.0';
+  const after = structuredClone(before);
+  after.lockfile.importers['packages/shared'].dependencies.parser.version = 'leaf@2.0.0';
+
+  assert.deepEqual(changedDependencyWorkspaces(before, after), [
+    'apps/extension',
+    'packages/shared',
+  ]);
+});
+
+test('new and deleted importers are selected', () => {
+  const after = snapshot();
+  after.lockfile.importers['apps/new'] = {};
+
+  assert.deepEqual(changedDependencyWorkspaces(snapshot(), after), ['apps/new']);
+  assert.deepEqual(changedDependencyWorkspaces(after, snapshot()), ['apps/new']);
+});
+
+test('injected workspace snapshots resolve links from the repository root', () => {
+  const before = snapshot();
+  before.lockfile.importers['apps/mobile'].dependencies.copied = {
+    version: 'file:packages/copied',
+  };
+  before.lockfile.packages['copied@file:packages/copied'] = {
+    resolution: { directory: 'packages/copied', type: 'directory' },
+  };
+  before.lockfile.snapshots['copied@file:packages/copied'] = {
+    dependencies: { shared: 'link:packages/shared' },
+  };
+  const after = structuredClone(before);
+  after.lockfile.packages['parser@1.0.0'].resolution.integrity = 'updated-integrity';
+
+  assert.deepEqual(changedDependencyWorkspaces(before, after), [
+    'apps/mobile',
+    'apps/extension',
+    'packages/shared',
+  ]);
+});
+
+test('resolved optional peers remain part of their consumer graph', () => {
+  const before = snapshot();
+  before.lockfile.packages['parser@1.0.0'].peerDependenciesMeta = { router: { optional: true } };
+  before.lockfile.snapshots['parser@1.0.0'].optionalDependencies = { router: '1.0.0' };
+  const after = structuredClone(before);
+  after.lockfile.packages['router@1.0.0'].resolution.integrity = 'updated-integrity';
+
+  assert.deepEqual(changedDependencyWorkspaces(before, after), [
+    'apps/mobile',
+    'apps/extension',
+    'packages/shared',
+  ]);
+});
+
+test('native-only patches do not affect web consumers through optional peers', () => {
+  const before = snapshot();
+  before.lockfile.importers['apps/mobile'].dependencies['react-native'] = { version: '1.0.0' };
+  before.lockfile.packages['react-native@1.0.0'] = {};
+  before.lockfile.packages['router@1.0.0'].peerDependencies = { 'react-native': '*' };
+  before.lockfile.snapshots['react-native@1.0.0'] = {};
+  before.lockfile.packages['parser@1.0.0'].peerDependenciesMeta = { router: { optional: true } };
+  before.lockfile.snapshots['parser@1.0.0'].optionalDependencies = { router: '1.0.0' };
+  const after = structuredClone(before);
+  const nativePatch = [
+    'diff --git a/useLinking.native.js b/useLinking.native.js',
+    '--- a/useLinking.native.js',
+    '+++ b/useLinking.native.js',
+    '',
+  ].join('\n');
+  addPatch(after, 'router', 'new-hash', nativePatch);
+  after.lockfile.importers['apps/mobile'].dependencies.router.version =
+    '1.0.0(patch_hash=new-hash)';
+  after.lockfile.snapshots['parser@1.0.0'].optionalDependencies.router =
+    '1.0.0(patch_hash=new-hash)';
+  after.lockfile.snapshots['router@1.0.0(patch_hash=new-hash)'] = {};
+  delete after.lockfile.snapshots['router@1.0.0'];
+
+  assert.deepEqual(changedDependencyWorkspaces(before, after), ['apps/mobile']);
+  assert.deepEqual(changedDependencyWorkspaces(after, before), ['apps/mobile']);
+
+  after.patches['patches/router@1.0.0.patch'] += '--- a/useLinking.js\n+++ b/useLinking.js\n';
+  assert.deepEqual(changedDependencyWorkspaces(before, after), [
+    'apps/mobile',
+    'apps/extension',
+    'packages/shared',
+  ]);
+
+  after.patches['patches/router@1.0.0.patch'] =
+    nativePatch + 'diff --git a/useLinking.js b/useLinking.js\n';
+  assert.deepEqual(changedDependencyWorkspaces(before, after), [
+    'apps/mobile',
+    'apps/extension',
+    'packages/shared',
+  ]);
+});
+
+test('an unsupported lockfile cannot silently skip tests', () => {
+  const after = snapshot();
+  after.lockfile.lockfileVersion = '10.0';
+
+  assert.throws(() => changedDependencyWorkspaces(snapshot(), after), /Unsupported pnpm lockfile/);
+});
+
+test('a missing dependency cannot silently skip tests', () => {
+  const after = snapshot();
+  delete after.lockfile.snapshots['leaf@1.0.0'];
+
+  assert.throws(() => changedDependencyWorkspaces(snapshot(), after), /Missing lockfile entry/);
+});

--- a/scripts/changed-workspaces.sh
+++ b/scripts/changed-workspaces.sh
@@ -43,52 +43,47 @@ else
   base=$(git merge-base origin/main HEAD 2>/dev/null || true)
 fi
 
-# Decide selection mode:
-#   force_all=true — include every workspace (lockfile/workspace-yaml changes
-#     genuinely can break any downstream workspace, and loose `packages/*` files
-#     outside any package dir don't have a single owner to derive dependents of).
-#   force_all=false and dependent_dirs_file populated — a `packages/<name>/**`
-#     path changed; only include that package plus its transitive workspace:*
-#     dependents.
-#   force_all=false and dependent_dirs_file empty — fall back to per-workspace
-#     direct file-diff check.
 force_all=false
 dependent_dirs_file=$(mktemp)
 trap 'rm -f "$dependent_dirs_file"' EXIT
 if [ -n "$base" ]; then
-  if git diff --name-only "$base" -- pnpm-lock.yaml pnpm-workspace.yaml | grep -q .; then
-    force_all=true
-  else
-    # List files changed under packages/**. Anything that doesn't match
-    # `packages/<name>/` (e.g. `packages/README.md`) is a loose file with no
-    # single owning package — fall back to force_all.
-    pkg_changes=$(git diff --name-only "$base" -- 'packages/**' || true)
-    if [ -n "$pkg_changes" ]; then
-      loose=$(printf '%s\n' "$pkg_changes" | grep -vE '^packages/[^/]+/' | head -1 || true)
-      if [ -n "$loose" ]; then
-        force_all=true
-      else
-        # Collect the top-level changed package dirs and union their transitive
-        # workspace:* dependents via pnpm's `...^<name>` selector.
-        changed_pkg_dirs=$(printf '%s\n' "$pkg_changes" | awk -F/ '{print $1"/"$2}' | sort -u)
-        for pkg_dir in $changed_pkg_dirs; do
-          [ -f "$pkg_dir/package.json" ] || continue
-          pkg_name=$(node -e "console.log(require('./$pkg_dir/package.json').name)" 2>/dev/null) || continue
-          [ -n "$pkg_name" ] || continue
-          pnpm --filter "...^$pkg_name" ls --json --depth -1 2>/dev/null | node -e "
-            const pkgs = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
-            for (const p of pkgs) {
-              if (!p.path) continue;
-              const rel = require('path').relative(process.cwd(), p.path);
-              if (rel && rel !== '.') console.log(rel);
-            }
-          " 2>/dev/null >> "$dependent_dirs_file" || true
-          # Always include the changed package itself; `...^<name>` only matches
-          # true dependents, not the named package.
-          echo "$pkg_dir" >> "$dependent_dirs_file"
-        done
-        sort -u "$dependent_dirs_file" -o "$dependent_dirs_file"
-      fi
+  if ! git diff --quiet "$base" -- pnpm-lock.yaml pnpm-workspace.yaml 'patches/**'; then
+    if ! node scripts/changed-dependencies.mjs "$base" > "$dependent_dirs_file"; then
+      force_all=true
+    elif grep -qxF '*' "$dependent_dirs_file"; then
+      force_all=true
+    fi
+  fi
+
+  # List files changed under packages/**. Anything that doesn't match
+  # `packages/<name>/` (e.g. `packages/README.md`) is a loose file with no
+  # single owning package — fall back to force_all.
+  pkg_changes=$(git diff --name-only "$base" -- 'packages/**' || true)
+  if [ -n "$pkg_changes" ]; then
+    loose=$(printf '%s\n' "$pkg_changes" | grep -vE '^packages/[^/]+/' | head -1 || true)
+    if [ -n "$loose" ]; then
+      force_all=true
+    else
+      # Collect the top-level changed package dirs and union their transitive
+      # workspace:* dependents via pnpm's `...^<name>` selector.
+      changed_pkg_dirs=$(printf '%s\n' "$pkg_changes" | awk -F/ '{print $1"/"$2}' | sort -u)
+      for pkg_dir in $changed_pkg_dirs; do
+        [ -f "$pkg_dir/package.json" ] || continue
+        pkg_name=$(node -e "console.log(require('./$pkg_dir/package.json').name)" 2>/dev/null) || continue
+        [ -n "$pkg_name" ] || continue
+        pnpm --filter "...^$pkg_name" ls --json --depth -1 2>/dev/null | node -e "
+          const pkgs = JSON.parse(require('fs').readFileSync('/dev/stdin','utf8'));
+          for (const p of pkgs) {
+            if (!p.path) continue;
+            const rel = require('path').relative(process.cwd(), p.path);
+            if (rel && rel !== '.') console.log(rel);
+          }
+        " 2>/dev/null >> "$dependent_dirs_file" || true
+        # Always include the changed package itself; `...^<name>` only matches
+        # true dependents, not the named package.
+        echo "$pkg_dir" >> "$dependent_dirs_file"
+      done
+      sort -u "$dependent_dirs_file" -o "$dependent_dirs_file"
     fi
   fi
 fi
@@ -131,7 +126,7 @@ for dir in $workspace_dirs; do
   # Check for file changes (if we have a merge base)
   if [ -n "$base" ] && ! $force_all; then
     if [ -s "$dependent_dirs_file" ] && grep -qxF "$dir" "$dependent_dirs_file"; then
-      : # include: workspace is a transitive dependent of a changed package
+      :
     else
       changed_file=$(git diff --name-only "$base" -- "$dir/" | head -1 || true)
       [ -n "$changed_file" ] || continue


### PR DESCRIPTION
## Summary

- Patch Expo Router 57.0.10 to report asynchronous initial links from an effect, not a render-started callback.
- Cancel the report on unmount and consume it once, preserving synchronous startup and warm links.
- Add seven mounted regression tests against the installed router under Strict Mode.

## Verification

- [x] Built and installed the Android development app on kilo_pixel9_api35, emulator-5554.
- [x] Confirmed this worktree's Metro provenance and signed in with the dedicated test account.
- [x] Terminated and relaunched the app three times. Each run reached Home with the tab bar visible.
- [x] Rebooted Android, verified an increased boot count and completed boot, then relaunched the app and reached Home.
- [x] Checked runtime logs for the reported React state-update warning and useLinking.native. No matches appeared.

An earlier repeat stopped at the development-client chooser after the host network changed. After regenerating endpoints, all four checks passed.

Local screenshots and logs: `/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo/pr-5613-android/stable-network/`.

## Visual Changes

N/A

## Reviewer Notes

- The original router failed both lifecycle assertions: before mount and after unmount.
- Targeted startup checks passed: 113 pure tests and 11 mounted tests.
- Mobile typecheck, lint, unused-code checks, repository format check, and git diff --check passed.
- The frozen offline install passed with the patch.
- Expo Doctor passed 20 of 21 checks. It reported existing patch-version mismatches across 21 packages; this PR changes no package versions.
- The branch starts at e186f2d0d, the latest origin/main when work began.

## CI scoping follow-up

- Compare resolved dependency graphs, package metadata, and dependency patches instead of selecting every workspace for shared pnpm edits.
- Keep resolved optional peers in coverage. Ignore native-only React Native patches for non-native consumers.
- Gate extension verification and browser tests on extension source, shared dependencies, workflow, and tooling changes.
- Run all packages when global configuration changes or dependency detection fails.
- Verified the original mobile-only range with `node scripts/changed-dependencies.mjs e186f2d0d 71698a97c`; it selects only `apps/mobile`.
- All 18 selector tests, repository lint, typecheck, format checks, and 78 mobile link checks passed.

This PR still exercises extension CI because it changes the extension workflow and root tooling. Repository-wide checks and the web CI gate remain broader. Device verification results are below.

## iOS and link verification

- [x] Built and installed the iOS development app on an iPhone 17 Pro simulator.
- [x] iOS cold startup passed both signed in and signed out.
- [x] iOS warm profile and preferences links reached the requested destinations.
- [x] iOS cold profile and preferences links reached the requested destinations.
- [x] A signed-out iOS cold preferences link showed login, then resumed Preferences after email-code verification. No second link was sent.
- [x] Android warm profile and preferences links reached the requested destinations.
- [x] Runtime log checks showed no matching React mount warnings.
- [x] All 71 pure link checks and seven mounted router checks passed. These include universal-link mapping.

**Remaining device coverage:** Android cold custom-scheme navigation stopped in Expo DevLauncherActivity before the app loaded. One documented recovery failed. Cold profile navigation remains unverified; cold preferences navigation did not run. Native OS delivery of universal links was not tested.

Local evidence:
- `/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo/pr-5613-links-ios/`
- `/var/folders/pz/_kmbp8vs2755j415slh2hz100000gn/T/kilo/pr-5613-links-android/`

All current PR checks passed after the CI-scoping commit, including Chrome extension tests.