### PR TITLE
fix(auth): prioritize reset magic-link state

### DIFF
--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -539,6 +539,26 @@ describe('User', () => {
       });
     });
 
+    it('treats a rowless UUID account as Email despite a stale provider sentinel', async () => {
+      const user = await insertTestUser({
+        id: randomUUID(),
+        google_user_email: 'reset-email@example.com',
+        google_user_name: 'Reset Email User',
+        normalized_email: 'reset-email@example.com',
+        hosted_domain: hosted_domain_specials.github,
+      });
+
+      await expect(getAllUserProviders('reset-email@example.com')).resolves.toEqual({
+        kind: 'found',
+        user: {
+          kiloUserId: user.id,
+          providers: ['email'],
+          primaryEmail: 'reset-email@example.com',
+          workosHostedDomain: undefined,
+        },
+      });
+    });
+
     it('uses the canonical UUID validator for rowless Email recovery', async () => {
       const email = 'nil-uuid-email@example.com';
       const user = await insertTestUser({

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -1963,6 +1963,7 @@ export function inferRowlessAuthProviders(
 ): AuthProviderId[] {
   const legacyOAuthProvider = parseLegacyOAuthProvider(user.id);
   if (legacyOAuthProvider) return [legacyOAuthProvider];
+  if (isUuidUserId(user.id)) return ['email'];
 
   switch (user.hosted_domain) {
     case hosted_domain_specials.non_workspace_google_account:
@@ -1982,7 +1983,7 @@ export function inferRowlessAuthProviders(
     case hosted_domain_specials.email:
       return ['email'];
     default:
-      return isUuidUserId(user.id) ? ['email'] : [];
+      return [];
   }
 }
 


### PR DESCRIPTION
## Summary

- Make provider-row-less UUID accounts resolve to Email before consulting stale legacy provider metadata.
- Restore the intended reset-to-magic-link recovery flow after email-first discovery.
- Preserve recognized historical OAuth ID and non-UUID legacy sentinel inference.

## Verification


## Visual Changes

after reseting to magic link, email now becomes inferred (because there is 0 providers)

<img width="428" height="266" alt="Screenshot 2026-08-27 at 11 16 36 AM" src="https://github.com/user-attachments/assets/d4aa4fe1-fd1f-4a4d-96aa-8fa007c5680b" />


## Reviewer Notes

Reset-to-magic-link removes linked provider rows but intentionally leaves legacy user metadata unchanged. Before email-first discovery, users selected Email directly, so stale metadata was irrelevant. Discovery must therefore treat a rowless UUID account as the reset Email state before considering legacy hosted-domain sentinels.

Recognized historical OAuth IDs remain authoritative because they are non-UUID identities. Required SSO checks still run after provider inference and before Email is returned.

Automated checks run locally:

- Focused auth/admin suites: 156 tests
- `pnpm --filter web typecheck`
- `pnpm --filter web lint`
- `git diff --check`

Independent static review: `NO FINDINGS`.

---

From me the human:

The email-first flow inserted a new step: Enter email → discover provider → offer method → authenticate

- That discovery step incorrectly interpreted the stale GitHub hosted_domain marker before recognizing the UUIDaccount as a reset magic-link account.
- This PR changes the precedence to: Historical OAuth ID → UUID rowless account as Email → legacy sentinel
- Therefore, after reset: Email →→account email → INFERRED

is displayed and Email discovery sends the user into the same mailbox-verification and account-linking path that worked before the refactor.