### PR TITLE
feat(admin): flag login email conflicts

### DIFF
--- a/apps/web/src/app/admin/components/UserAdmin/ResetToMagicLinkLoginButton.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/ResetToMagicLinkLoginButton.tsx
@@ -15,16 +15,19 @@ import {
 import { useMutation } from '@tanstack/react-query';
 import { useTRPC } from '@/lib/trpc/utils';
 import { toast } from 'sonner';
+import { useRouter } from 'next/navigation';
 
 export default function ResetToMagicLinkLoginButton({ userId }: { userId: string }) {
   const [isDialogOpen, setDialogOpen] = useState(false);
   const trpc = useTRPC();
+  const router = useRouter();
 
   const resetToMagicLinkMutation = useMutation(
     trpc.admin.users.resetToMagicLinkLogin.mutationOptions({
       onSuccess: () => {
         toast.success('Account reset to magic link login!');
         setDialogOpen(false);
+        router.refresh();
       },
     })
   );

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.test.ts
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.test.ts
@@ -1,13 +1,28 @@
 import { describe, expect, it } from '@jest/globals';
-import { getLoginMethods } from './UserAdminAccountInfo';
+import { getLoginMethodDiagnostic, getLoginMethods } from './UserAdminAccountInfo';
 
 describe('getLoginMethods', () => {
   it('shows the name and email associated with each login provider', () => {
     expect(
       getLoginMethods([
-        { provider: 'anaconda', email: 'anaconda@example.com', source: 'linked' },
-        { provider: 'github', email: 'github@example.com', source: 'linked' },
-        { provider: 'workos', email: 'sso@example.com', source: 'linked' },
+        {
+          provider: 'anaconda',
+          email: 'anaconda@example.com',
+          source: 'linked',
+          email_relation: 'primary',
+        },
+        {
+          provider: 'github',
+          email: 'github@example.com',
+          source: 'linked',
+          email_relation: 'different',
+        },
+        {
+          provider: 'workos',
+          email: 'sso@example.com',
+          source: 'linked',
+          email_relation: 'conflict',
+        },
       ]).map(method => ({ name: method.metadata.name, email: method.email }))
     ).toEqual([
       { name: 'Anaconda', email: 'anaconda@example.com' },
@@ -18,12 +33,20 @@ describe('getLoginMethods', () => {
 
   it('shows magic-link email login', () => {
     expect(
-      getLoginMethods([{ provider: 'email', email: 'user@example.com', source: 'inferred' }])
+      getLoginMethods([
+        {
+          provider: 'email',
+          email: 'user@example.com',
+          source: 'inferred',
+          email_relation: 'primary',
+        },
+      ])
     ).toEqual([
       expect.objectContaining({
         metadata: expect.objectContaining({ name: 'Email' }),
         email: 'user@example.com',
         source: 'inferred',
+        emailRelation: 'primary',
       }),
     ]);
   });
@@ -31,10 +54,34 @@ describe('getLoginMethods', () => {
   it('keeps distinct emails for the same provider visible', () => {
     const longEmail = `${'long-address-'.repeat(8)}@example.com`;
     const methods = getLoginMethods([
-      { provider: 'github', email: 'github@example.com', source: 'linked' },
-      { provider: 'github', email: longEmail, source: 'linked' },
+      {
+        provider: 'github',
+        email: 'github@example.com',
+        source: 'linked',
+        email_relation: 'different',
+      },
+      {
+        provider: 'github',
+        email: longEmail,
+        source: 'linked',
+        email_relation: 'different',
+      },
     ]);
 
     expect(methods.map(method => method.email)).toEqual(['github@example.com', longEmail]);
+  });
+
+  it('uses destructive presentation only for cross-account conflicts', () => {
+    expect(getLoginMethodDiagnostic('conflict')).toEqual({
+      hasConflict: true,
+      variant: 'destructive',
+      title:
+        'This email also resolves to another Kilo account. Email-first discovery will fail closed.',
+    });
+    expect(getLoginMethodDiagnostic('different')).toEqual({
+      hasConflict: false,
+      variant: 'secondary',
+      title: undefined,
+    });
   });
 });

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
@@ -13,7 +13,7 @@ import PersonalAccountDisabledToggle from './PersonalAccountDisabledToggle';
 import { Button } from '@/components/ui/button';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
 import Link from 'next/link';
-import { Info, SquareArrowOutUpRight, Webhook } from 'lucide-react';
+import { AlertTriangle, Info, SquareArrowOutUpRight, Webhook } from 'lucide-react';
 import { createHash } from 'crypto';
 import { getProviderById } from '@/lib/auth/provider-metadata';
 import { Badge } from '@/components/ui/badge';
@@ -177,13 +177,16 @@ export function UserAdminAccountInfo(user: UserAdminAccountInfoProps) {
 export function UserLoginMethods({ methods }: { methods: UserDetailProps['login_methods'] }) {
   return (
     <div className="flex flex-wrap gap-1.5">
-      {getLoginMethods(methods).map(({ metadata, email, source }) => {
+      {getLoginMethods(methods).map(({ metadata, email, source, emailRelation }) => {
+        const diagnostic = getLoginMethodDiagnostic(emailRelation);
         return (
           <Badge
             key={`${metadata.id}:${email}`}
-            variant="secondary"
+            variant={diagnostic.variant}
             className="max-w-full gap-1.5 font-normal"
+            title={diagnostic.title}
           >
+            {diagnostic.hasConflict ? <AlertTriangle className="size-3.5 shrink-0" /> : null}
             <span className="flex size-3.5 items-center justify-center [&>svg]:size-3.5">
               {metadata.icon}
             </span>
@@ -199,6 +202,9 @@ export function UserLoginMethods({ methods }: { methods: UserDetailProps['login_
                 inferred
               </span>
             ) : null}
+            {diagnostic.hasConflict ? (
+              <span className="text-[10px] uppercase tracking-wide">conflict</span>
+            ) : null}
           </Badge>
         );
       })}
@@ -211,7 +217,19 @@ export function getLoginMethods(methods: UserDetailProps['login_methods']) {
     metadata: getProviderById(method.provider),
     email: method.email,
     source: method.source,
+    emailRelation: method.email_relation,
   }));
+}
+
+export function getLoginMethodDiagnostic(emailRelation: 'primary' | 'different' | 'conflict') {
+  const hasConflict = emailRelation === 'conflict';
+  return {
+    hasConflict,
+    variant: hasConflict ? ('destructive' as const) : ('secondary' as const),
+    title: hasConflict
+      ? 'This email also resolves to another Kilo account. Email-first discovery will fail closed.'
+      : undefined,
+  };
 }
 
 function Field({

--- a/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
+++ b/apps/web/src/app/admin/components/UserAdmin/UserAdminAccountInfo.tsx
@@ -203,7 +203,7 @@ export function UserLoginMethods({ methods }: { methods: UserDetailProps['login_
               </span>
             ) : null}
             {diagnostic.hasConflict ? (
-              <span className="text-[10px] uppercase tracking-wide">conflict</span>
+              <span className="sr-only">Cross-account conflict</span>
             ) : null}
           </Badge>
         );

--- a/apps/web/src/app/admin/users/[id]/page.tsx
+++ b/apps/web/src/app/admin/users/[id]/page.tsx
@@ -14,12 +14,12 @@ import {
   user_auth_provider,
 } from '@kilocode/db/schema';
 import { eq, inArray, desc } from 'drizzle-orm';
-import { findUserById, inferRowlessAuthProviders } from '@/lib/user';
+import { findUserById, getCrossAccountEmailConflicts, inferRowlessAuthProviders } from '@/lib/user';
 import { getBalanceForUser } from '@/lib/user/balance';
 import { hasReceivedAnyFreeWelcomeCredits } from '@/lib/welcomeCredits';
 import { redirect } from 'next/navigation';
 import { resolveSsoAuthorityForDomain } from '@/lib/organizations/organization-sso-policy';
-import { getLowerDomainFromEmail } from '@/lib/utils';
+import { getLowerDomainFromEmail, normalizeEmail } from '@/lib/utils';
 
 async function getUserData(userId: string): Promise<UserDetailProps | null> {
   const user = await findUserById(userId);
@@ -85,6 +85,18 @@ async function getUserData(userId: string): Promise<UserDetailProps | null> {
   const emailDomain = getLowerDomainFromEmail(user.google_user_email);
   const ssoAuthority = emailDomain ? await resolveSsoAuthorityForDomain(emailDomain) : null;
   const isSSOProtectedDomain = ssoAuthority?.status !== 'not_required' && ssoAuthority !== null;
+  const loginMethods: Omit<UserDetailProps['login_methods'][number], 'email_relation'>[] =
+    authProviders.length > 0
+      ? authProviders.map(method => ({ ...method, source: 'linked' }))
+      : inferRowlessAuthProviders(user).map(provider => ({
+          provider,
+          email: user.google_user_email,
+          source: 'inferred',
+        }));
+  const conflictByEmail = await getCrossAccountEmailConflicts(
+    loginMethods.map(method => method.email),
+    user.id
+  );
 
   return {
     ...user,
@@ -101,14 +113,14 @@ async function getUserData(userId: string): Promise<UserDetailProps | null> {
     organization_memberships: organizationMemberships,
     autoTopUpConfig,
     is_sso_protected_domain: isSSOProtectedDomain,
-    login_methods:
-      authProviders.length > 0
-        ? authProviders.map(method => ({ ...method, source: 'linked' as const }))
-        : inferRowlessAuthProviders(user).map(provider => ({
-            provider,
-            email: user.google_user_email,
-            source: 'inferred' as const,
-          })),
+    login_methods: loginMethods.map(method => ({
+      ...method,
+      email_relation: conflictByEmail.get(method.email)
+        ? 'conflict'
+        : normalizeEmail(method.email) === normalizeEmail(user.google_user_email)
+          ? 'primary'
+          : 'different',
+    })),
   };
 }
 

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -610,6 +610,60 @@ describe('User', () => {
       });
     });
 
+    it('recovers a reset UUID account through mailbox-verified Email linking', async () => {
+      const email = 'reset-recovery@example.com';
+      const user = await insertTestUser({
+        id: randomUUID(),
+        google_user_email: email,
+        google_user_name: 'Reset Recovery User',
+        normalized_email: email,
+        hosted_domain: hosted_domain_specials.github,
+      });
+      await db.insert(user_auth_provider).values({
+        kilo_user_id: user.id,
+        provider: 'github',
+        provider_account_id: 'synthetic-reset-github',
+        email,
+        avatar_url: '',
+        hosted_domain: hosted_domain_specials.github,
+      });
+
+      await db.delete(user_auth_provider).where(eq(user_auth_provider.kilo_user_id, user.id));
+      await expect(getAllUserProviders(email)).resolves.toEqual({
+        kind: 'found',
+        user: {
+          kiloUserId: user.id,
+          providers: ['email'],
+          primaryEmail: email,
+          workosHostedDomain: undefined,
+        },
+      });
+
+      const result = await createOrUpdateUser(
+        {
+          google_user_email: email,
+          google_user_name: 'Reset Recovery User',
+          google_user_image_url: '',
+          hosted_domain: 'example.com',
+          provider: 'email',
+          provider_account_id: email,
+        },
+        undefined,
+        true
+      );
+
+      expect(result.success).toBe(true);
+      if (!result.success) return;
+      expect(result.user.id).toBe(user.id);
+      expect(result.isNew).toBe(false);
+      await expect(
+        db
+          .select({ provider: user_auth_provider.provider })
+          .from(user_auth_provider)
+          .where(eq(user_auth_provider.kilo_user_id, user.id))
+      ).resolves.toEqual([{ provider: 'email' }]);
+    });
+
     it('uses the canonical UUID validator for rowless Email recovery', async () => {
       const email = 'nil-uuid-email@example.com';
       const user = await insertTestUser({

--- a/apps/web/src/lib/user/index.test.ts
+++ b/apps/web/src/lib/user/index.test.ts
@@ -140,6 +140,7 @@ import {
   findUsersByIds,
   createOrUpdateUser,
   getAllUserProviders,
+  getCrossAccountEmailConflicts,
 } from '@/lib/user';
 import { hashNormalizedEmailForDeletionTombstone } from '@/lib/impact/referral';
 import { generateOpenRouterDownstreamSafetyIdentifier } from '@/lib/ai-gateway/providerHash';
@@ -417,6 +418,56 @@ describe('User', () => {
       await expect(getAllUserProviders('shared@example.com')).resolves.toEqual({
         kind: 'ambiguous',
       });
+      await expect(
+        getCrossAccountEmailConflicts(['shared@example.com'], firstUser.id)
+      ).resolves.toEqual(new Map([['shared@example.com', true]]));
+      await expect(
+        getCrossAccountEmailConflicts(['shared@example.com'], secondUser.id)
+      ).resolves.toEqual(new Map([['shared@example.com', true]]));
+    });
+
+    it('does not report a conflict when provider emails resolve to one account', async () => {
+      const user = await insertTestUser({
+        google_user_email: 'primary-only@example.com',
+        google_user_name: 'Single Account User',
+        normalized_email: 'primary-only@example.com',
+      });
+      await db.insert(user_auth_provider).values({
+        kilo_user_id: user.id,
+        provider: 'github',
+        provider_account_id: `github-${user.id}`,
+        email: 'different-provider@example.com',
+        avatar_url: '',
+        hosted_domain: null,
+      });
+
+      await expect(
+        getCrossAccountEmailConflicts(
+          [' DIFFERENT-PROVIDER@example.com ', 'primary-only@example.com'],
+          user.id
+        )
+      ).resolves.toEqual(
+        new Map([
+          [' DIFFERENT-PROVIDER@example.com ', false],
+          ['primary-only@example.com', false],
+        ])
+      );
+    });
+
+    it('reports normalized-primary conflicts without a provider email match', async () => {
+      const currentUser = await insertTestUser({
+        google_user_email: 'current@example.com',
+        google_user_name: 'Current User',
+      });
+      await insertTestUser({
+        google_user_email: 'normalized-owner@example.com',
+        google_user_name: 'Normalized Owner',
+        normalized_email: 'normalized-conflict@example.com',
+      });
+
+      await expect(
+        getCrossAccountEmailConflicts(['normalized-conflict@example.com'], currentUser.id)
+      ).resolves.toEqual(new Map([['normalized-conflict@example.com', true]]));
     });
 
     it('returns null for an email that is not linked to an account', async () => {

--- a/apps/web/src/lib/user/index.ts
+++ b/apps/web/src/lib/user/index.ts
@@ -114,7 +114,7 @@ import {
   user_moderation_mutes,
   user_terms_acceptances,
 } from '@kilocode/db/schema';
-import { eq, and, inArray, isNotNull, isNull, sql, or, gte, count } from 'drizzle-orm';
+import { eq, and, inArray, isNotNull, isNull, sql, or, gte, count, ne } from 'drizzle-orm';
 import { allow_fake_login, IS_DEVELOPMENT } from '@/lib/constants';
 import type { AuthErrorType } from '@/lib/auth/constants';
 import { shouldAutoProvisionPlatformAdmin } from '@/lib/admin/platform-admin';
@@ -1888,11 +1888,8 @@ export type UserProviderLookupResult =
   | { kind: 'not_found' }
   | { kind: 'ambiguous' };
 
-export async function getAllUserProviders(email: string): Promise<UserProviderLookupResult> {
+async function getEmailAccountCandidates(email: string) {
   const lowerEmail = email.toLowerCase().trim();
-
-  // A submitted email only determines discovery options; provider callbacks
-  // and magic-link verification remain the authentication authority.
   const linkedProviders = await db
     .selectDistinct({ kilo_user_id: user_auth_provider.kilo_user_id })
     .from(user_auth_provider)
@@ -1915,6 +1912,69 @@ export async function getAllUserProviders(email: string): Promise<UserProviderLo
     ...linkedProviders.map(provider => provider.kilo_user_id),
     ...normalizedUsers.map(user => user.id),
   ]);
+
+  return { candidateUserIds, normalizedUsers };
+}
+
+export async function getCrossAccountEmailConflicts(
+  emails: string[],
+  currentUserId: string
+): Promise<Map<string, boolean>> {
+  const uniqueEmails = [...new Set(emails)];
+  if (uniqueEmails.length === 0) return new Map();
+
+  const lowerEmails = [...new Set(uniqueEmails.map(email => email.toLowerCase().trim()))];
+  const normalizedEmails = [...new Set(uniqueEmails.map(normalizeEmail))];
+  const [linkedProviderMatches, primaryEmailMatches] = await Promise.all([
+    db
+      .select({ email: user_auth_provider.email })
+      .from(user_auth_provider)
+      .where(
+        and(
+          inArray(sql`lower(${user_auth_provider.email})`, lowerEmails),
+          ne(user_auth_provider.kilo_user_id, currentUserId)
+        )
+      ),
+    db
+      .select({
+        normalizedEmail: kilocode_users.normalized_email,
+        primaryEmail: kilocode_users.google_user_email,
+      })
+      .from(kilocode_users)
+      .where(
+        and(
+          ne(kilocode_users.id, currentUserId),
+          or(
+            inArray(kilocode_users.normalized_email, normalizedEmails),
+            and(
+              isNull(kilocode_users.normalized_email),
+              inArray(sql`lower(${kilocode_users.google_user_email})`, lowerEmails)
+            )
+          )
+        )
+      ),
+  ]);
+
+  return new Map(
+    uniqueEmails.map(email => {
+      const lowerEmail = email.toLowerCase().trim();
+      const normalizedEmail = normalizeEmail(email);
+      const hasConflict =
+        linkedProviderMatches.some(match => match.email.toLowerCase() === lowerEmail) ||
+        primaryEmailMatches.some(match =>
+          match.normalizedEmail
+            ? match.normalizedEmail === normalizedEmail
+            : match.primaryEmail.toLowerCase() === lowerEmail
+        );
+      return [email, hasConflict];
+    })
+  );
+}
+
+export async function getAllUserProviders(email: string): Promise<UserProviderLookupResult> {
+  // A submitted email only determines discovery options; provider callbacks
+  // and magic-link verification remain the authentication authority.
+  const { candidateUserIds, normalizedUsers } = await getEmailAccountCandidates(email);
   if (candidateUserIds.size > 1) {
     return { kind: 'ambiguous' };
   }

--- a/apps/web/src/types/admin.ts
+++ b/apps/web/src/types/admin.ts
@@ -41,6 +41,7 @@ export type HasLoginMethods = {
     provider: AuthProviderId;
     email: string;
     source: 'linked' | 'inferred';
+    email_relation: 'primary' | 'different' | 'conflict';
   }[];
 };
 export type UserDetailProps = UserTableProps &


### PR DESCRIPTION
## Summary

- Show the stored email beside each linked authentication provider in the admin user view.
- Reuse sign-in discovery authorities to detect provider emails that also resolve to another Kilo account.
- Highlight only true cross-account conflicts; alternate provider emails belonging exclusively to the current account remain neutral.
- Keep rowless login-method inference aligned with sign-in discovery, label inferred methods explicitly, and refresh the admin page after a successful magic-link reset.

## Verification

- [x] Seeded two synthetic accounts whose shared login email resolves across accounts; confirmed the affected provider pill uses compact destructive styling, a warning icon, and explanatory hover text.
- [x] Confirmed the current account primary email remains neutral and the warning remains available to assistive technology without widening the pill.
- [x] Seeded a synthetic UUID account with a linked provider and stale provider metadata, used the real admin reset dialog, and confirmed the refreshed page immediately changed from the linked provider to inferred Email.
- [x] Confirmed the reset deleted all provider rows while retaining stale metadata, then removed all synthetic records.

## Visual Changes

| Cross-account login email conflict |
|---|
| ![Admin login method showing a compact synthetic cross-account email conflict](https://github.com/user-attachments/assets/9a3d7642-8195-4a42-aa3d-009ec1df6157) |

## Reviewer Notes

Stacked on #5614 so rowless UUID accounts use the corrected Email-before-stale-sentinel precedence. Retarget this PR to `main` after #5614 merges.

Conflict detection uses the same two identity authorities as email-first discovery: case-insensitive linked provider emails and normalized primary account emails with the legacy null-normalization fallback. It returns only booleans to the admin UI and never exposes conflicting account IDs. All displayed emails are classified with two batched database queries regardless of provider count.

A DB-backed recovery-chain regression now proves provider deletion, inferred Email discovery, mailbox-proof-authorized linking, preservation of the original user ID, and persistence of exactly one Email provider row. This is confirmed for a UUID account using its exact primary email.

Remaining recovery hardening outside this PR: reset does not revoke existing browser sessions; concurrent auth callbacks can race with reset; non-UUID legacy accounts are not universally converted to Email; and normalized/case-variant discovery is broader than the callback settlement exact-email lookup. These should be addressed separately before treating reset as a complete credential-revocation control.

Automated checks run locally:

- Focused auth/admin suites: 160 tests
- `pnpm --filter web typecheck`
- `pnpm --filter web dependency-cycle-check`
- `pnpm --filter web lint`
- `git diff --check`

Independent reset-flow audit completed; immediate stale-admin-state issue fixed with `router.refresh()`.