### PR TITLE
feat(triggers): persist isolated Standard allocation

### DIFF
--- a/services/webhook-agent-ingest/drizzle/0004_bumpy_firebird.sql
+++ b/services/webhook-agent-ingest/drizzle/0004_bumpy_firebird.sql
@@ -1,0 +1,1 @@
+ALTER TABLE `trigger_config` ADD `sandbox_allocation` text;

--- a/services/webhook-agent-ingest/drizzle/meta/0004_snapshot.json
+++ b/services/webhook-agent-ingest/drizzle/meta/0004_snapshot.json
@@ -1,0 +1,360 @@
+{
+  "version": "6",
+  "dialect": "sqlite",
+  "id": "7e247709-c693-43c2-b574-533e581e250e",
+  "prevId": "325bf974-c52d-4ae4-9f8a-decce1424e73",
+  "tables": {
+    "requests": {
+      "name": "requests",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "method": {
+          "name": "method",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "path": {
+          "name": "path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "query_string": {
+          "name": "query_string",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "headers": {
+          "name": "headers",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "body": {
+          "name": "body",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "content_type": {
+          "name": "content_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "source_ip": {
+          "name": "source_ip",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "(unixepoch())"
+        },
+        "started_at": {
+          "name": "started_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "completed_at": {
+          "name": "completed_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "process_status": {
+          "name": "process_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'captured'"
+        },
+        "cloud_agent_session_id": {
+          "name": "cloud_agent_session_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "trigger_source": {
+          "name": "trigger_source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        }
+      },
+      "indexes": {
+        "idx_requests_timestamp": {
+          "name": "idx_requests_timestamp",
+          "columns": [
+            "\"timestamp\" desc"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_status": {
+          "name": "idx_requests_status",
+          "columns": [
+            "process_status"
+          ],
+          "isUnique": false
+        },
+        "idx_requests_session": {
+          "name": "idx_requests_session",
+          "columns": [
+            "cloud_agent_session_id"
+          ],
+          "isUnique": false
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {
+        "process_status_check": {
+          "name": "process_status_check",
+          "value": "process_status in ('captured', 'inprogress', 'success', 'failed')"
+        }
+      }
+    },
+    "trigger_config": {
+      "name": "trigger_config",
+      "columns": {
+        "trigger_id": {
+          "name": "trigger_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "namespace": {
+          "name": "namespace",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "is_active": {
+          "name": "is_active",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": 1
+        },
+        "target_type": {
+          "name": "target_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'cloud_agent'"
+        },
+        "kiloclaw_instance_id": {
+          "name": "kiloclaw_instance_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "github_repo": {
+          "name": "github_repo",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "mode": {
+          "name": "mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "variant": {
+          "name": "variant",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "sandbox_allocation": {
+          "name": "sandbox_allocation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "prompt_template": {
+          "name": "prompt_template",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false
+        },
+        "profile_id": {
+          "name": "profile_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "auto_commit": {
+          "name": "auto_commit",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "condense_on_complete": {
+          "name": "condense_on_complete",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_auth_header": {
+          "name": "webhook_auth_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "webhook_auth_secret_hash": {
+          "name": "webhook_auth_secret_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "activation_mode": {
+          "name": "activation_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "autoincrement": false,
+          "default": "'webhook'"
+        },
+        "cron_expression": {
+          "name": "cron_expression",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "cron_timezone": {
+          "name": "cron_timezone",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false,
+          "default": "'UTC'"
+        },
+        "last_scheduled_at": {
+          "name": "last_scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        },
+        "next_scheduled_at": {
+          "name": "next_scheduled_at",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false,
+          "autoincrement": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "checkConstraints": {}
+    }
+  },
+  "views": {},
+  "enums": {},
+  "_meta": {
+    "schemas": {},
+    "tables": {},
+    "columns": {}
+  },
+  "internal": {
+    "indexes": {
+      "idx_requests_timestamp": {
+        "columns": {
+          "\"timestamp\" desc": {
+            "isExpression": true
+          }
+        }
+      }
+    }
+  }
+}

--- a/services/webhook-agent-ingest/drizzle/meta/_journal.json
+++ b/services/webhook-agent-ingest/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1787853332345,
       "tag": "0003_sparkling_kate_bishop",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "6",
+      "when": 1787867066482,
+      "tag": "0004_bumpy_firebird",
+      "breakpoints": true
     }
   ]
 }

--- a/services/webhook-agent-ingest/drizzle/migrations.js
+++ b/services/webhook-agent-ingest/drizzle/migrations.js
@@ -3,6 +3,7 @@ import m0000 from './0000_lumpy_loners.sql';
 import m0001 from './0001_dear_tombstone.sql';
 import m0002 from './0002_first_mephisto.sql';
 import m0003 from './0003_sparkling_kate_bishop.sql';
+import m0004 from './0004_bumpy_firebird.sql';
 
 export default {
   journal,
@@ -11,5 +12,6 @@ export default {
     m0001,
     m0002,
     m0003,
+    m0004,
   },
 };

--- a/services/webhook-agent-ingest/src/db/sqlite-schema.migration.test.ts
+++ b/services/webhook-agent-ingest/src/db/sqlite-schema.migration.test.ts
@@ -1,9 +1,7 @@
 import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { DatabaseSync } from 'node:sqlite';
-import { drizzle } from 'drizzle-orm/sqlite-proxy';
 import { describe, expect, it } from 'vitest';
-import { triggerConfig } from './sqlite-schema';
 
 type Row = Record<string, unknown>;
 
@@ -14,67 +12,76 @@ async function executeMigration(db: DatabaseSync, filename: string): Promise<voi
   }
 }
 
-describe('trigger config variant migration', () => {
-  it('preserves legacy webhook and scheduled rows and leaves variants unset', async () => {
+function insertLegacyRows(db: DatabaseSync, includeVariant: boolean): void {
+  const insert = db.prepare(
+    `INSERT INTO trigger_config (
+      trigger_id, namespace, user_id, created_at, is_active, target_type, github_repo,
+      mode, model, ${includeVariant ? 'variant, ' : ''}prompt_template, profile_id, auto_commit,
+      condense_on_complete, activation_mode, cron_expression, cron_timezone, last_scheduled_at,
+      next_scheduled_at
+    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ${includeVariant ? '?, ' : ''}?, ?, ?, ?, ?, ?, ?, ?, ?)`
+  );
+  for (const [triggerId, activationMode, cronExpression, variant] of [
+    ['legacy-scheduled', 'scheduled', '* * * * *', 'high'],
+    ['legacy-webhook', 'webhook', null, null],
+  ] as const) {
+    insert.run(
+      triggerId,
+      'user/user-1',
+      'user-1',
+      '2026-01-01T00:00:00.000Z',
+      1,
+      'cloud_agent',
+      'owner/repo',
+      'code',
+      'openai/gpt-4.1',
+      ...(includeVariant ? [variant] : []),
+      'Process {{body}}',
+      'profile-1',
+      1,
+      0,
+      activationMode,
+      cronExpression,
+      'UTC',
+      '2026-01-01T00:00:00.000Z',
+      '2026-01-01T00:01:00.000Z'
+    );
+  }
+}
+
+describe('trigger config sandbox allocation migration', () => {
+  it('preserves legacy webhook and scheduled rows when migrating from 0002 to 0003', async () => {
     const db = new DatabaseSync(':memory:');
     try {
       await executeMigration(db, '0000_lumpy_loners.sql');
       await executeMigration(db, '0001_dear_tombstone.sql');
       await executeMigration(db, '0002_first_mephisto.sql');
-      const insert = db.prepare(
-        `INSERT INTO trigger_config (
-          trigger_id, namespace, user_id, created_at, is_active, target_type, github_repo,
-          mode, model, prompt_template, profile_id, auto_commit, condense_on_complete,
-          activation_mode, cron_expression, cron_timezone, last_scheduled_at, next_scheduled_at
-        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`
-      );
-      for (const [triggerId, activationMode, cronExpression] of [
-        ['legacy-scheduled', 'scheduled', '* * * * *'],
-        ['legacy-webhook', 'webhook', null],
-      ] as const) {
-        insert.run(
-          triggerId,
-          'user/user-1',
-          'user-1',
-          '2026-01-01T00:00:00.000Z',
-          1,
-          'cloud_agent',
-          'owner/repo',
-          'code',
-          'openai/gpt-4.1',
-          'Process {{body}}',
-          'profile-1',
-          1,
-          0,
-          activationMode,
-          cronExpression,
-          'UTC',
-          '2026-01-01T00:00:00.000Z',
-          '2026-01-01T00:01:00.000Z'
-        );
-      }
+      insertLegacyRows(db, false);
       const before = db.prepare('SELECT * FROM trigger_config ORDER BY trigger_id').all() as Row[];
 
       await executeMigration(db, '0003_sparkling_kate_bishop.sql');
-
-      const orm = drizzle(
-        async (query, params, method) => {
-          const statement = db.prepare(query);
-          if (method === 'run') {
-            statement.run(...params);
-            return { rows: [] };
-          }
-          if (method === 'get') {
-            const row = statement.get(...params) as Row | undefined;
-            return { rows: row ? [Object.values(row)] : [] };
-          }
-          return { rows: (statement.all(...params) as Row[]).map(row => Object.values(row)) };
-        },
-        { schema: { triggerConfig } }
-      );
-      const after = await orm.select().from(triggerConfig).orderBy(triggerConfig.trigger_id);
+      const after = db.prepare('SELECT * FROM trigger_config ORDER BY trigger_id').all() as Row[];
 
       expect(after).toEqual(before.map(row => ({ ...row, variant: null })));
+    } finally {
+      db.close();
+    }
+  });
+
+  it('preserves existing configurations and variants from 0003 to 0004', async () => {
+    const db = new DatabaseSync(':memory:');
+    try {
+      await executeMigration(db, '0000_lumpy_loners.sql');
+      await executeMigration(db, '0001_dear_tombstone.sql');
+      await executeMigration(db, '0002_first_mephisto.sql');
+      await executeMigration(db, '0003_sparkling_kate_bishop.sql');
+      insertLegacyRows(db, true);
+      const before = db.prepare('SELECT * FROM trigger_config ORDER BY trigger_id').all() as Row[];
+
+      await executeMigration(db, '0004_bumpy_firebird.sql');
+      const after = db.prepare('SELECT * FROM trigger_config ORDER BY trigger_id').all() as Row[];
+
+      expect(after).toEqual(before.map(row => ({ ...row, sandbox_allocation: null })));
     } finally {
       db.close();
     }

--- a/services/webhook-agent-ingest/src/db/sqlite-schema.ts
+++ b/services/webhook-agent-ingest/src/db/sqlite-schema.ts
@@ -51,6 +51,7 @@ export const triggerConfig = sqliteTable('trigger_config', {
   mode: text('mode'),
   model: text('model'),
   variant: text('variant'),
+  sandbox_allocation: text('sandbox_allocation'),
   prompt_template: text('prompt_template').notNull(),
   profile_id: text('profile_id'),
   auto_commit: integer('auto_commit'),

--- a/services/webhook-agent-ingest/src/dos/TriggerDO.ts
+++ b/services/webhook-agent-ingest/src/dos/TriggerDO.ts
@@ -30,6 +30,8 @@ import { computeNextCronTime } from '../util/cron';
 
 export type { ProcessStatus, RequestUpdates } from '../db/types';
 
+const SandboxAllocation = z.literal('isolated-standard');
+
 export const TriggerConfig = z.object({
   triggerId: z.string(),
   namespace: z.string(),
@@ -43,6 +45,7 @@ export const TriggerConfig = z.object({
   mode: z.string().nullable().optional(),
   model: z.string().nullable().optional(),
   variant: z.string().optional(),
+  sandboxAllocation: SandboxAllocation.optional(),
   promptTemplate: z.string(),
   profileId: z.string().nullable().optional(),
   autoCommit: z.boolean().optional(),
@@ -87,6 +90,7 @@ type ConfigureInput = {
   mode?: string;
   model?: string;
   variant?: string;
+  sandboxAllocation?: 'isolated-standard';
   promptTemplate: string;
   profileId?: string;
   autoCommit?: boolean;
@@ -106,6 +110,7 @@ type UpdateConfigInput = {
   mode?: string;
   model?: string;
   variant?: string | null;
+  sandboxAllocation?: 'isolated-standard' | null;
   promptTemplate?: string;
   isActive?: boolean;
   profileId?: string;
@@ -138,6 +143,12 @@ export class TriggerDO extends DurableObject<Env> {
       throw new Error('Trigger configuration is required');
     }
 
+    const targetType = configOverrides.targetType ?? 'cloud_agent';
+    const sandboxAllocation = SandboxAllocation.optional().parse(configOverrides.sandboxAllocation);
+    if (sandboxAllocation !== undefined && targetType === 'kiloclaw_chat') {
+      throw new Error('Sandbox allocation is only supported for cloud agent triggers');
+    }
+
     const webhookAuth = await this.resolveWebhookAuthOnCreate(configOverrides.webhookAuth);
 
     const config: TriggerConfig = {
@@ -147,12 +158,13 @@ export class TriggerDO extends DurableObject<Env> {
       orgId,
       createdAt: new Date().toISOString(),
       isActive: true,
-      targetType: configOverrides.targetType ?? 'cloud_agent',
+      targetType,
       kiloclawInstanceId: configOverrides.kiloclawInstanceId ?? null,
       githubRepo: configOverrides.githubRepo ?? null,
       mode: configOverrides.mode ?? null,
       model: configOverrides.model ?? null,
       variant: configOverrides.variant,
+      sandboxAllocation,
       promptTemplate: configOverrides.promptTemplate,
       profileId: configOverrides.profileId ?? null,
       autoCommit: configOverrides.autoCommit,
@@ -163,8 +175,6 @@ export class TriggerDO extends DurableObject<Env> {
       cronExpression: configOverrides.cronExpression ?? null,
       cronTimezone: configOverrides.cronTimezone ?? 'UTC',
     };
-
-    await this.ctx.storage.put('config', config);
 
     const insertValues = {
       trigger_id: config.triggerId,
@@ -179,6 +189,7 @@ export class TriggerDO extends DurableObject<Env> {
       mode: config.mode ?? null,
       model: config.model ?? null,
       variant: config.variant ?? null,
+      sandbox_allocation: config.sandboxAllocation ?? null,
       prompt_template: config.promptTemplate,
       profile_id: config.profileId ?? null,
       auto_commit: config.autoCommit !== undefined ? (config.autoCommit ? 1 : 0) : null,
@@ -202,6 +213,8 @@ export class TriggerDO extends DurableObject<Env> {
         set: updateValues,
       })
       .run();
+
+    await this.ctx.storage.put('config', config);
 
     // Set initial alarm for scheduled triggers
     if (config.activationMode === 'scheduled' && config.cronExpression) {
@@ -246,6 +259,7 @@ export class TriggerDO extends DurableObject<Env> {
       mode: record.mode ?? null,
       model: record.model ?? null,
       variant: record.variant ?? undefined,
+      sandboxAllocation: parseSandboxAllocation(record.sandbox_allocation),
       promptTemplate: record.prompt_template,
       profileId: record.profile_id ?? null,
       autoCommit: record.auto_commit !== null ? record.auto_commit === 1 : undefined,
@@ -281,6 +295,11 @@ export class TriggerDO extends DurableObject<Env> {
       return { success: false };
     }
 
+    const sandboxAllocationUpdate = SandboxAllocation.nullish().parse(updates.sandboxAllocation);
+    if (sandboxAllocationUpdate !== undefined && existingConfig.targetType === 'kiloclaw_chat') {
+      throw new Error('Sandbox allocation is only supported for cloud agent triggers');
+    }
+
     const resolveNullable = <T>(
       update: T | null | undefined,
       existing: T | undefined
@@ -297,6 +316,7 @@ export class TriggerDO extends DurableObject<Env> {
       mode: updates.mode ?? existingConfig.mode,
       model: updates.model ?? existingConfig.model,
       variant: resolveNullable(updates.variant, existingConfig.variant),
+      sandboxAllocation: resolveNullable(sandboxAllocationUpdate, existingConfig.sandboxAllocation),
       promptTemplate: updates.promptTemplate ?? existingConfig.promptTemplate,
       isActive: updates.isActive ?? existingConfig.isActive,
       profileId: updates.profileId ?? existingConfig.profileId,
@@ -311,14 +331,13 @@ export class TriggerDO extends DurableObject<Env> {
       cronTimezone: updates.cronTimezone ?? existingConfig.cronTimezone,
     };
 
-    await this.ctx.storage.put('config', updatedConfig);
-
     this.db
       .update(triggerConfigTable)
       .set({
         mode: updatedConfig.mode,
         model: updatedConfig.model,
         variant: updatedConfig.variant ?? null,
+        sandbox_allocation: updatedConfig.sandboxAllocation ?? null,
         prompt_template: updatedConfig.promptTemplate,
         is_active: updatedConfig.isActive ? 1 : 0,
         profile_id: updatedConfig.profileId,
@@ -337,6 +356,8 @@ export class TriggerDO extends DurableObject<Env> {
       })
       .where(eq(triggerConfigTable.trigger_id, updatedConfig.triggerId))
       .run();
+
+    await this.ctx.storage.put('config', updatedConfig);
 
     // Alarm lifecycle for scheduled triggers
     if (updatedConfig.activationMode === 'scheduled') {
@@ -834,6 +855,13 @@ function extractStoredWebhookAuth(config: TriggerConfig | null): StoredWebhookAu
     header: config.webhookAuthHeader,
     secretHash: config.webhookAuthSecretHash,
   };
+}
+
+function parseSandboxAllocation(value: string | null): 'isolated-standard' | undefined {
+  if (value === null) {
+    return undefined;
+  }
+  return SandboxAllocation.parse(value);
 }
 
 function recordToCapturedRequest(record: RequestRow): CapturedRequest {

--- a/services/webhook-agent-ingest/src/queue-consumer.test.ts
+++ b/services/webhook-agent-ingest/src/queue-consumer.test.ts
@@ -331,13 +331,19 @@ describe('handleWebhookDeliveryBatch Cloud Agent callback target', () => {
   });
 
   it.each([
-    ['webhook', undefined],
-    ['scheduled', 'high'],
-    ['scheduled', undefined],
+    ['webhook', undefined, undefined],
+    ['webhook', 'high', undefined],
+    ['webhook', undefined, 'isolated-standard'],
+    ['webhook', 'high', 'isolated-standard'],
+    ['scheduled', undefined, undefined],
+    ['scheduled', 'high', undefined],
+    ['scheduled', undefined, 'isolated-standard'],
+    ['scheduled', 'high', 'isolated-standard'],
   ] as const)(
-    'forwards variant only when set for %s dispatches',
-    async (triggerSource, variant) => {
+    'forwards configured variant %s/%s and allocation %s only to prepareSession',
+    async (triggerSource, variant, sandboxAllocation) => {
       const prepareRequests: Request[] = [];
+      const initiateRequests: Request[] = [];
       const webhook = makeWebhook();
       const stub = {
         getRequest: vi.fn(async () =>
@@ -352,6 +358,7 @@ describe('handleWebhookDeliveryBatch Cloud Agent callback target', () => {
             profileId: 'profile-1',
             activationMode: triggerSource,
             ...(variant !== undefined ? { variant } : {}),
+            ...(sandboxAllocation !== undefined ? { sandboxAllocation } : {}),
           })
         ),
         updateRequest: vi.fn(async () => ({ success: true })),
@@ -376,21 +383,28 @@ describe('handleWebhookDeliveryBatch Cloud Agent callback target', () => {
                 result: { data: { cloudAgentSessionId: 'cloud-session-1' } },
               });
             }
+            initiateRequests.push(request);
             return Response.json({
               result: { data: { executionId: 'execution-1', status: 'running' } },
             });
           }),
         },
       } as unknown as Env;
+      const ack = vi.fn();
+      const retry = vi.fn();
       const batch = {
         queue: 'webhook-delivery',
-        messages: [{ body: webhook, attempts: 1, ack: vi.fn(), retry: vi.fn() }],
+        messages: [{ body: webhook, attempts: 1, ack, retry }],
       } as unknown as MessageBatch<ReturnType<typeof makeWebhook>>;
 
       await handleWebhookDeliveryBatch(batch, env);
 
-      const prepareBody = await prepareRequests[0]?.json<{
+      expect(stub.getConfig).toHaveBeenCalledTimes(1);
+      expect(prepareRequests).toHaveLength(1);
+      expect(initiateRequests).toHaveLength(1);
+      const prepareBody = await prepareRequests[0].json<{
         variant?: string;
+        sandboxAllocation?: string;
         createdOnPlatform: string;
       }>();
       if (variant === undefined) {
@@ -398,7 +412,70 @@ describe('handleWebhookDeliveryBatch Cloud Agent callback target', () => {
       } else {
         expect(prepareBody).toHaveProperty('variant', variant);
       }
-      expect(prepareBody?.createdOnPlatform).toBe(triggerSource);
+      if (sandboxAllocation === undefined) {
+        expect(prepareBody).not.toHaveProperty('sandboxAllocation');
+      } else {
+        expect(prepareBody).toHaveProperty('sandboxAllocation', sandboxAllocation);
+      }
+      expect(prepareBody.createdOnPlatform).toBe(triggerSource);
+      expect(await initiateRequests[0].json()).not.toHaveProperty('sandboxAllocation');
+      expect(ack).toHaveBeenCalledTimes(1);
+      expect(retry).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each(['webhook', 'scheduled'] as const)(
+    'keeps %s KiloClaw dispatch independent of Cloud Agent allocation',
+    async activationMode => {
+      mockFindActiveSandboxIdForInstance.mockReset();
+      mockPostMessageAsUser.mockReset();
+      mockFindActiveSandboxIdForInstance.mockResolvedValue('sandbox-1');
+      mockPostMessageAsUser.mockResolvedValue({
+        ok: true,
+        conversationId: 'conv-1',
+        messageId: 'msg-1',
+        conversationCreated: true,
+      });
+      const stub = {
+        getRequest: vi.fn(async () =>
+          makeRequest('captured', { method: activationMode === 'scheduled' ? 'SCHEDULED' : 'POST' })
+        ),
+        getConfig: vi.fn(async () => makeTriggerConfig({ activationMode })),
+        updateRequest: vi.fn(async () => ({ success: true })),
+      };
+      const cloudAgentFetch = vi.fn();
+      const env = {
+        ...makeEnv(),
+        TRIGGER_DO: {
+          idFromName: vi.fn((name: string) => name),
+          get: vi.fn(() => stub),
+        },
+        CLOUD_AGENT: { fetch: cloudAgentFetch },
+      } as unknown as Env;
+      const ack = vi.fn();
+      const retry = vi.fn();
+      const batch = {
+        queue: 'webhook-delivery',
+        messages: [{ body: makeWebhook(), attempts: 1, ack, retry }],
+      } as unknown as MessageBatch<ReturnType<typeof makeWebhook>>;
+
+      await handleWebhookDeliveryBatch(batch, env);
+
+      expect(cloudAgentFetch).not.toHaveBeenCalled();
+      expect(mockPostMessageAsUser).toHaveBeenCalledTimes(1);
+      expect(mockPostMessageAsUser.mock.calls[0][0]).toMatchObject({
+        userId: 'user-1',
+        sandboxId: 'sandbox-1',
+        source: 'webhook',
+        correlation: { triggerId: 'trigger-1', webhookRequestId: 'req-1' },
+      });
+      expect(mockPostMessageAsUser.mock.calls[0][0]).not.toHaveProperty('sandboxAllocation');
+      expect(stub.updateRequest).toHaveBeenLastCalledWith(
+        'req-1',
+        expect.objectContaining({ process_status: 'success' })
+      );
+      expect(ack).toHaveBeenCalledTimes(1);
+      expect(retry).not.toHaveBeenCalled();
     }
   );
 });

--- a/services/webhook-agent-ingest/src/queue-consumer.ts
+++ b/services/webhook-agent-ingest/src/queue-consumer.ts
@@ -412,6 +412,7 @@ async function processWebhookMessage(
         mode: string;
         model: string;
         variant?: string;
+        sandboxAllocation?: 'isolated-standard';
         githubRepo: string;
         kilocodeOrganizationId?: string;
         callbackTarget: { url: string; headers: Record<string, string> };
@@ -442,6 +443,9 @@ async function processWebhookMessage(
       }
       if (triggerConfig.variant !== undefined) {
         prepareSessionBody.variant = triggerConfig.variant;
+      }
+      if (triggerConfig.sandboxAllocation !== undefined) {
+        prepareSessionBody.sandboxAllocation = triggerConfig.sandboxAllocation;
       }
 
       logger.debug('Calling prepareSession', {

--- a/services/webhook-agent-ingest/src/routes/api.test.ts
+++ b/services/webhook-agent-ingest/src/routes/api.test.ts
@@ -1,5 +1,13 @@
-import { describe, expect, it } from 'vitest';
-import { TriggerConfigInput, TriggerConfigUpdateInput } from './api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('../util/do-retry', () => ({
+  withDORetry: async <TStub, TResult>(
+    getStub: () => TStub,
+    operation: (stub: TStub) => Promise<TResult>
+  ): Promise<TResult> => operation(getStub()),
+}));
+
+import { api, TriggerConfigInput, TriggerConfigUpdateInput } from './api';
 
 describe('trigger variant validation', () => {
   const createInput = {
@@ -30,5 +38,253 @@ describe('trigger variant validation', () => {
     expect(TriggerConfigUpdateInput.safeParse({ variant: null }).success).toBe(true);
     expect(TriggerConfigUpdateInput.safeParse({ variant: 'medium' }).success).toBe(true);
     expect(TriggerConfigUpdateInput.safeParse({ variant: 'medium-1' }).success).toBe(false);
+  });
+});
+
+describe('trigger sandbox allocation validation', () => {
+  const cloudAgentInput = {
+    githubRepo: 'owner/repo',
+    mode: 'code',
+    model: 'openai/gpt-4.1',
+    promptTemplate: 'Process {{body}}',
+    profileId: '5d08c60b-7755-4dd3-b3fc-7ae96bf50e22',
+  };
+
+  const kiloclawInput = {
+    targetType: 'kiloclaw_chat' as const,
+    kiloclawInstanceId: '5d08c60b-7755-4dd3-b3fc-7ae96bf50e22',
+    promptTemplate: 'Process {{body}}',
+  };
+
+  it('defaults target and activation modes while accepting cloud allocation', () => {
+    const result = TriggerConfigInput.parse({
+      ...cloudAgentInput,
+      sandboxAllocation: 'isolated-standard',
+    });
+
+    expect(result.targetType).toBe('cloud_agent');
+    expect(result.activationMode).toBe('webhook');
+    expect(result.sandboxAllocation).toBe('isolated-standard');
+  });
+
+  it.each([
+    { activationMode: 'webhook' as const },
+    { activationMode: 'scheduled' as const, cronExpression: '* * * * *' },
+  ])('accepts allocation for $activationMode cloud triggers', input => {
+    expect(
+      TriggerConfigInput.safeParse({
+        ...cloudAgentInput,
+        ...input,
+        sandboxAllocation: 'isolated-standard',
+      }).success
+    ).toBe(true);
+  });
+
+  it('rejects invalid or null create allocation values', () => {
+    expect(
+      TriggerConfigInput.safeParse({ ...cloudAgentInput, sandboxAllocation: 'standard' }).success
+    ).toBe(false);
+    expect(
+      TriggerConfigInput.safeParse({ ...cloudAgentInput, sandboxAllocation: null }).success
+    ).toBe(false);
+  });
+
+  it.each([
+    { activationMode: 'webhook' as const },
+    { activationMode: 'scheduled' as const, cronExpression: '* * * * *' },
+  ])('rejects allocation for $activationMode KiloClaw triggers', input => {
+    expect(
+      TriggerConfigInput.safeParse({
+        ...kiloclawInput,
+        ...input,
+        sandboxAllocation: 'isolated-standard',
+      }).success
+    ).toBe(false);
+  });
+
+  it('accepts allocation updates and null clears while rejecting invalid values', () => {
+    expect(
+      TriggerConfigUpdateInput.safeParse({ sandboxAllocation: 'isolated-standard' }).success
+    ).toBe(true);
+    expect(TriggerConfigUpdateInput.safeParse({ sandboxAllocation: null }).success).toBe(true);
+    expect(TriggerConfigUpdateInput.safeParse({ sandboxAllocation: 'standard' }).success).toBe(
+      false
+    );
+  });
+});
+
+const INTERNAL_API_SECRET = 'test-internal-secret';
+const NAMESPACE = 'user/user-1';
+const TRIGGER_ID = 'trigger-1';
+
+type StoredConfig = {
+  targetType: 'cloud_agent' | 'kiloclaw_chat';
+  activationMode: string;
+  sandboxAllocation?: 'isolated-standard';
+};
+
+function existingConfig(
+  targetType: StoredConfig['targetType'],
+  activationMode = 'webhook',
+  sandboxAllocation?: StoredConfig['sandboxAllocation']
+): StoredConfig {
+  return {
+    targetType,
+    activationMode,
+    ...(sandboxAllocation ? { sandboxAllocation } : {}),
+  };
+}
+
+function createRouteHarness(initialConfig: StoredConfig | null) {
+  const config = initialConfig;
+  const configure = vi.fn(async () => ({ success: true }));
+  const getConfig = vi.fn(async () => config);
+  const updateConfig = vi.fn(
+    async (updates: { sandboxAllocation?: 'isolated-standard' | null }) => {
+      if (config && updates.sandboxAllocation !== undefined) {
+        if (updates.sandboxAllocation === null) {
+          delete config.sandboxAllocation;
+        } else {
+          config.sandboxAllocation = updates.sandboxAllocation;
+        }
+      }
+      return { success: true };
+    }
+  );
+  const getConfigForResponse = vi.fn(async () => config);
+  const stub = { configure, getConfig, updateConfig, getConfigForResponse };
+  const env = {
+    INTERNAL_API_SECRET: { get: vi.fn(async () => INTERNAL_API_SECRET) },
+    TRIGGER_DO: {
+      idFromName: vi.fn((name: string) => name),
+      get: vi.fn(() => stub),
+    },
+  } as unknown as Env;
+
+  return { configure, env, getConfig, getConfigForResponse, updateConfig };
+}
+
+async function requestTrigger(env: Env, method: 'POST' | 'PUT', payload: Record<string, unknown>) {
+  return api.request(
+    `/triggers/user/user-1/${TRIGGER_ID}`,
+    {
+      method,
+      headers: {
+        'Content-Type': 'application/json',
+        'X-Internal-API-Key': INTERNAL_API_SECRET,
+      },
+      body: JSON.stringify(payload),
+    },
+    env
+  );
+}
+
+describe('trigger sandbox allocation routes', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    { activationMode: 'webhook', extra: {} },
+    { activationMode: 'scheduled', extra: { cronExpression: '* * * * *' } },
+  ])(
+    'passes allocation through for $activationMode trigger creation',
+    async ({ activationMode, extra }) => {
+      const { configure, env } = createRouteHarness(null);
+
+      const response = await requestTrigger(env, 'POST', {
+        githubRepo: 'owner/repo',
+        mode: 'code',
+        model: 'openai/gpt-4.1',
+        promptTemplate: 'Process {{body}}',
+        profileId: '5d08c60b-7755-4dd3-b3fc-7ae96bf50e22',
+        activationMode,
+        sandboxAllocation: 'isolated-standard',
+        ...extra,
+      });
+
+      expect(response.status).toBe(201);
+      expect(configure).toHaveBeenCalledWith(
+        NAMESPACE,
+        TRIGGER_ID,
+        expect.objectContaining({ sandboxAllocation: 'isolated-standard' })
+      );
+    }
+  );
+
+  it('rejects KiloClaw allocation before configuring a trigger', async () => {
+    const { configure, env } = createRouteHarness(null);
+
+    const response = await requestTrigger(env, 'POST', {
+      targetType: 'kiloclaw_chat',
+      kiloclawInstanceId: '5d08c60b-7755-4dd3-b3fc-7ae96bf50e22',
+      promptTemplate: 'Process {{body}}',
+      sandboxAllocation: 'isolated-standard',
+    });
+
+    expect(response.status).toBe(400);
+    expect(configure).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    { payload: { sandboxAllocation: 'isolated-standard' } },
+    {
+      payload: {
+        sandboxAllocation: null,
+        targetType: 'cloud_agent',
+        activationMode: 'scheduled',
+      },
+    },
+  ])('rejects KiloClaw allocation based on stored target configuration', async ({ payload }) => {
+    const { env, updateConfig } = createRouteHarness(existingConfig('kiloclaw_chat'));
+
+    const response = await requestTrigger(env, 'PUT', payload);
+
+    expect(response.status).toBe(400);
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('returns 404 before target validation for an unknown trigger', async () => {
+    const { env, updateConfig } = createRouteHarness(null);
+
+    const response = await requestTrigger(env, 'PUT', { sandboxAllocation: null });
+
+    expect(response.status).toBe(404);
+    expect(updateConfig).not.toHaveBeenCalled();
+  });
+
+  it('allows unrelated KiloClaw updates', async () => {
+    const { env, updateConfig } = createRouteHarness(existingConfig('kiloclaw_chat'));
+
+    const response = await requestTrigger(env, 'PUT', { isActive: false });
+
+    expect(response.status).toBe(200);
+    expect(updateConfig).toHaveBeenCalledWith({ isActive: false });
+    const body = (await response.json()) as { data: Record<string, unknown> };
+    expect(body).toMatchObject({ data: { targetType: 'kiloclaw_chat' } });
+    expect(body.data).not.toHaveProperty('sandboxAllocation');
+  });
+
+  it.each([
+    { activationMode: 'webhook', sandboxAllocation: 'isolated-standard' as const },
+    { activationMode: 'webhook', sandboxAllocation: null },
+    { activationMode: 'scheduled', sandboxAllocation: 'isolated-standard' as const },
+    { activationMode: 'scheduled', sandboxAllocation: null },
+  ])('updates allocation for stored $activationMode cloud triggers', async updates => {
+    const { env, updateConfig } = createRouteHarness(
+      existingConfig('cloud_agent', updates.activationMode, 'isolated-standard')
+    );
+
+    const response = await requestTrigger(env, 'PUT', updates);
+
+    expect(response.status).toBe(200);
+    expect(updateConfig).toHaveBeenCalledWith({ sandboxAllocation: updates.sandboxAllocation });
+    const body = (await response.json()) as { data: Record<string, unknown> };
+    if (updates.sandboxAllocation === null) {
+      expect(body).toMatchObject({ data: {} });
+      expect(body.data).not.toHaveProperty('sandboxAllocation');
+    } else {
+      expect(body).toMatchObject({ data: { sandboxAllocation: 'isolated-standard' } });
+    }
   });
 });

--- a/services/webhook-agent-ingest/src/routes/api.ts
+++ b/services/webhook-agent-ingest/src/routes/api.ts
@@ -176,6 +176,7 @@ export const TriggerConfigInput = z
       .max(50)
       .regex(/^[a-zA-Z]+$/)
       .optional(),
+    sandboxAllocation: z.literal('isolated-standard').optional(),
     promptTemplate: z.string().trim().min(1, 'promptTemplate is required'),
     profileId: z.string().uuid().optional(),
     autoCommit: z.boolean().optional(),
@@ -262,6 +263,13 @@ export const TriggerConfigInput = z
           message: 'kiloclawInstanceId is required for kiloclaw_chat triggers',
           path: ['kiloclawInstanceId'],
         });
+      if (data.sandboxAllocation !== undefined) {
+        ctx.addIssue({
+          code: 'custom',
+          message: 'sandboxAllocation is not applicable for kiloclaw_chat triggers',
+          path: ['sandboxAllocation'],
+        });
+      }
     }
   });
 
@@ -279,6 +287,7 @@ export const TriggerConfigUpdateInput = z
       .regex(/^[a-zA-Z]+$/)
       .nullable()
       .optional(),
+    sandboxAllocation: z.literal('isolated-standard').nullable().optional(),
     promptTemplate: z.string().trim().min(1).optional(),
     isActive: z.boolean().optional(),
     profileId: z.string().uuid().optional(),
@@ -447,6 +456,13 @@ async function handleUpdateTrigger(c: RouteContext, namespace: string, triggerId
 
     if (!existingConfig) {
       return c.json(resError('Trigger not found'), 404);
+    }
+
+    if (existingConfig.targetType === 'kiloclaw_chat' && updates.sandboxAllocation !== undefined) {
+      return c.json(
+        resError('sandboxAllocation is not applicable for kiloclaw_chat triggers'),
+        400
+      );
     }
 
     const result = await withDORetry(

--- a/services/webhook-agent-ingest/test/integration/trigger-do.test.ts
+++ b/services/webhook-agent-ingest/test/integration/trigger-do.test.ts
@@ -2,6 +2,24 @@ import { env, runInDurableObject } from 'cloudflare:test';
 import { drizzle } from 'drizzle-orm/durable-sqlite';
 import { describe, it, expect } from 'vitest';
 import { triggerConfig } from '../../src/db/sqlite-schema';
+import type { TriggerDO } from '../../src/dos/TriggerDO';
+
+async function expectSandboxAllocation(
+  stub: DurableObjectStub<TriggerDO>,
+  sandboxAllocation: 'isolated-standard' | undefined
+): Promise<void> {
+  expect((await stub.getConfig())?.sandboxAllocation).toBe(sandboxAllocation);
+  expect((await stub.getConfigForResponse())?.sandboxAllocation).toBe(sandboxAllocation);
+  await runInDurableObject(stub, async (_instance, state) => {
+    const config = await state.storage.get<{ sandboxAllocation?: 'isolated-standard' }>('config');
+    expect(config?.sandboxAllocation).toBe(sandboxAllocation);
+    const row = drizzle(state.storage)
+      .select({ sandboxAllocation: triggerConfig.sandbox_allocation })
+      .from(triggerConfig)
+      .get();
+    expect(row?.sandboxAllocation).toBe(sandboxAllocation ?? null);
+  });
+}
 
 describe('TriggerDO', () => {
   const testUserId = 'user123';
@@ -11,6 +29,178 @@ describe('TriggerDO', () => {
   const testOrgNamespace = `org/${testOrgId}`;
 
   describe('configure', () => {
+    it.each([
+      ['webhook', undefined],
+      ['scheduled', '* * * * *'],
+    ] as const)(
+      'persists sandbox allocation for %s triggers independently from KV hydration',
+      async (activationMode, cronExpression) => {
+        const triggerId = `sandbox-allocation-${activationMode}`;
+        const id = env.TRIGGER_DO.idFromName(`${testUserNamespace}/${triggerId}`);
+        const stub = env.TRIGGER_DO.get(id);
+
+        await stub.configure(testUserNamespace, triggerId, {
+          githubRepo: 'owner/repo',
+          mode: 'code',
+          model: 'openai/gpt-4.1',
+          promptTemplate: 'Process {{body}}',
+          sandboxAllocation: 'isolated-standard',
+          activationMode,
+          cronExpression,
+        });
+
+        await runInDurableObject(stub, async (_instance, state) => {
+          const config = await state.storage.get<{ sandboxAllocation?: 'isolated-standard' }>(
+            'config'
+          );
+          expect(config?.sandboxAllocation).toBe('isolated-standard');
+          const row = drizzle(state.storage)
+            .select({ sandboxAllocation: triggerConfig.sandbox_allocation })
+            .from(triggerConfig)
+            .get();
+          expect(row?.sandboxAllocation).toBe('isolated-standard');
+          await state.storage.delete('config');
+        });
+
+        expect((await stub.getConfig())?.sandboxAllocation).toBe('isolated-standard');
+      }
+    );
+
+    it.each([
+      ['webhook', undefined],
+      ['scheduled', '* * * * *'],
+    ] as const)(
+      'updates, preserves, and clears sandbox allocation in SQLite and KV for %s triggers',
+      async (activationMode, cronExpression) => {
+        const triggerId = `sandbox-allocation-update-${activationMode}`;
+        const id = env.TRIGGER_DO.idFromName(`${testUserNamespace}/${triggerId}`);
+        const stub = env.TRIGGER_DO.get(id);
+
+        await stub.configure(testUserNamespace, triggerId, {
+          githubRepo: 'owner/repo',
+          mode: 'code',
+          model: 'openai/gpt-4.1',
+          promptTemplate: 'Process {{body}}',
+          activationMode,
+          cronExpression,
+        });
+        await stub.updateConfig({ sandboxAllocation: 'isolated-standard' });
+        await expectSandboxAllocation(stub, 'isolated-standard');
+
+        await stub.updateConfig({ promptTemplate: 'Updated {{body}}' });
+        await expectSandboxAllocation(stub, 'isolated-standard');
+
+        await stub.updateConfig({ sandboxAllocation: undefined });
+        await expectSandboxAllocation(stub, 'isolated-standard');
+
+        await stub.updateConfig({ sandboxAllocation: null });
+        await expectSandboxAllocation(stub, undefined);
+      }
+    );
+
+    it('hydrates an existing SQLite row with a null sandbox allocation', async () => {
+      const triggerId = 'sandbox-allocation-legacy';
+      const id = env.TRIGGER_DO.idFromName(`${testUserNamespace}/${triggerId}`);
+      const stub = env.TRIGGER_DO.get(id);
+
+      await runInDurableObject(stub, async (_instance, state) => {
+        drizzle(state.storage)
+          .insert(triggerConfig)
+          .values({
+            trigger_id: triggerId,
+            namespace: testUserNamespace,
+            user_id: testUserId,
+            org_id: null,
+            created_at: '2026-01-01T00:00:00.000Z',
+            is_active: 1,
+            target_type: 'cloud_agent',
+            github_repo: 'owner/repo',
+            prompt_template: 'Process {{body}}',
+            activation_mode: 'webhook',
+          })
+          .run();
+      });
+
+      expect((await stub.getConfig())?.sandboxAllocation).toBeUndefined();
+    });
+
+    it('rejects an invalid persisted sandbox allocation', async () => {
+      const triggerId = 'sandbox-allocation-invalid';
+      const id = env.TRIGGER_DO.idFromName(`${testUserNamespace}/${triggerId}`);
+      const stub = env.TRIGGER_DO.get(id);
+
+      await stub.configure(testUserNamespace, triggerId, {
+        githubRepo: 'owner/repo',
+        mode: 'code',
+        model: 'openai/gpt-4.1',
+        promptTemplate: 'Process {{body}}',
+      });
+      await runInDurableObject(stub, async (_instance, state) => {
+        drizzle(state.storage).update(triggerConfig).set({ sandbox_allocation: 'invalid' }).run();
+      });
+
+      await runInDurableObject(stub, async instance => {
+        await expect(instance.getConfig()).rejects.toThrow();
+      });
+    });
+
+    it('rejects sandbox allocation for KiloClaw without mutating it or normal configs', async () => {
+      const kiloclawId = env.TRIGGER_DO.idFromName(
+        `${testUserNamespace}/sandbox-allocation-kiloclaw`
+      );
+      const normalId = env.TRIGGER_DO.idFromName(`${testUserNamespace}/sandbox-allocation-normal`);
+      const kiloclawStub = env.TRIGGER_DO.get(kiloclawId);
+      const normalStub = env.TRIGGER_DO.get(normalId);
+      const baseConfig = {
+        githubRepo: 'owner/repo',
+        mode: 'code',
+        model: 'openai/gpt-4.1',
+        promptTemplate: 'Process {{body}}',
+      };
+
+      await runInDurableObject(kiloclawStub, async (instance, state) => {
+        await expect(
+          instance.configure(testUserNamespace, 'sandbox-allocation-kiloclaw', {
+            ...baseConfig,
+            targetType: 'kiloclaw_chat',
+            sandboxAllocation: 'isolated-standard',
+          })
+        ).rejects.toThrow('Sandbox allocation is only supported for cloud agent triggers');
+        expect(await instance.getConfig()).toBeNull();
+        expect(await state.storage.get('config')).toBeUndefined();
+      });
+
+      await kiloclawStub.configure(testUserNamespace, 'sandbox-allocation-kiloclaw', {
+        ...baseConfig,
+        targetType: 'kiloclaw_chat',
+      });
+      await normalStub.configure(testUserNamespace, 'sandbox-allocation-normal', {
+        ...baseConfig,
+        sandboxAllocation: 'isolated-standard',
+      });
+      const before = await kiloclawStub.getConfig();
+
+      await runInDurableObject(kiloclawStub, async instance => {
+        await expect(
+          instance.updateConfig({ sandboxAllocation: 'isolated-standard' })
+        ).rejects.toThrow('Sandbox allocation is only supported for cloud agent triggers');
+        await expect(instance.updateConfig({ sandboxAllocation: null })).rejects.toThrow(
+          'Sandbox allocation is only supported for cloud agent triggers'
+        );
+      });
+      expect(await kiloclawStub.getConfig()).toEqual(before);
+      await expectSandboxAllocation(kiloclawStub, undefined);
+
+      await expect(
+        kiloclawStub.updateConfig({ promptTemplate: 'Updated {{body}}' })
+      ).resolves.toEqual({ success: true });
+      expect(await kiloclawStub.getConfig()).toMatchObject({
+        ...before,
+        promptTemplate: 'Updated {{body}}',
+      });
+      await expectSandboxAllocation(normalStub, 'isolated-standard');
+    });
+
     it('round-trips an omitted variant as undefined', async () => {
       const id = env.TRIGGER_DO.idFromName(`${testUserNamespace}/variant-omitted`);
       const stub = env.TRIGGER_DO.get(id);


### PR DESCRIPTION
## Summary

PR 2 of the three-PR Dedicated Standard trigger rollout, following merged #5520.

- Persist optional `sandboxAllocation: "isolated-standard"` in TriggerDO SQLite and its existing KV configuration mirror. Generated Durable SQLite migration `0004_bumpy_firebird` adds nullable `sandbox_allocation`; existing rows remain Automatic. No shared PostgreSQL migration.
- Accept the allocation only for Cloud Agent targets in both webhook and scheduled modes. Updates validate the authoritative stored target: omission preserves the value, `null` clears it, and `isolated-standard` sets it. Direct DO calls are guarded too.
- Reload current trigger configuration during queue consumption and forward the value only to trusted `prepareSession`; omit it for Automatic. Queue messages and captured request payloads are unchanged.
- Leave browser mutation/router/client inputs and UI untouched. KiloClaw execution behavior is unchanged.

## Verification

Manual local smoke exercised real webhook and scheduled execution through Docker sandboxes and completion callbacks, plus clearing allocation back to Automatic. Two isolated webhook runs, a fresh scheduled run, and the Automatic run completed. The first scheduled attempt allocated correctly but failed with an unresolved wrapper_no_output runtime stall. Full evidence and limitations: https://github.com/Kilo-Org/cloud/pull/5624#issuecomment-5446065904

No deployed production or UI tests were run; no services were deployed.

### Automated checks

- `pnpm --filter cloudflare-webhook-agent-ingest test` — 115 tests passed.
- `pnpm --filter cloudflare-webhook-agent-ingest test:integration` — 36 tests passed using real Durable Object SQLite.
- `pnpm --filter cloudflare-webhook-agent-ingest typecheck` — passed.
- `pnpm --filter cloudflare-webhook-agent-ingest lint` — passed, zero warnings/errors.
- Package format check, targeted formatting/checks including integration tests and migration artifacts, integration-file lint, and `git diff --check` — passed.
- Migration regressions cover 0002→0003 and 0003→0004 row preservation. Tests cover set/hydrate/preserve/clear, NULL Automatic, invalid persisted values, both activation modes, stored-target validation, omitted forwarding, and unchanged KiloClaw dispatch. No live PostgreSQL was required.

## Visual Changes

N/A

## Reviewer Notes

- Deploy the Cloud Agent capability from #5520 before this worker forwards allocation intent. Keep the later PR 3 feature flag disabled until all participating services are deployed.
- PR 3 will add server-side PostHog eligibility, authorized web mutation inputs, and the Automatic/Dedicated Standard selector.
- Existing Cloud Agent containment, Standard SKU billing, and fail-closed restrictions remain authoritative. Explicit allocation still does not support `workspace_*` control-plane sessions.
- Configuration edits affect future session creations; already-queued requests may observe current configuration. This does not strengthen the existing split prepareSession/request-association idempotency guarantees.
- SQLite is authoritative and written before the retained KV mirror. These remain separate operations; this PR does not replace the mirror or claim transactional atomicity between them.
