### PR TITLE
feat(mobile): stable native build keys and CI-offloaded native builds

### DIFF
--- a/.github/workflows/mobile-native-build.yml
+++ b/.github/workflows/mobile-native-build.yml
@@ -34,7 +34,10 @@ on:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: false
+  # Never cancel a push build: it is producing an artifact hosts will
+  # install. A superseded pull_request build produces nothing anyone
+  # keeps, so it must not hold a macOS runner for 90 minutes.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:
   contents: read

--- a/.github/workflows/mobile-native-build.yml
+++ b/.github/workflows/mobile-native-build.yml
@@ -1,0 +1,208 @@
+# Build the mobile debug dev-client natively and publish it as a run
+# artifact named mobile-native-<platform>-<nativeHash>. The nativeHash is
+# input-deterministic (dev/local/mobile-{ios,android}-build.ts), so any
+# machine with the same native inputs computes the same name and can install
+# the artifact instead of compiling (dev/local/mobile-remote-native.ts).
+#
+# Runs on pushes to main that can change native inputs, and on demand for
+# any pushed branch via workflow_dispatch. The gate job skips platforms
+# whose artifact already exists.
+name: mobile-native-build
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: Platform to build
+        type: choice
+        options: [all, ios, android]
+        default: all
+  push:
+    branches: [main]
+    paths:
+      - 'apps/mobile/**'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - 'patches/**'
+      - '.github/workflows/mobile-native-build.yml'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  actions: read
+
+jobs:
+  gate:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      ios_hash: ${{ steps.decide.outputs.ios_hash }}
+      android_hash: ${{ steps.decide.outputs.android_hash }}
+      need_ios: ${{ steps.decide.outputs.need_ios }}
+      need_android: ${{ steps.decide.outputs.need_android }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Compute hashes and check existing artifacts
+        id: decide
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PLATFORM: ${{ inputs.platform || 'all' }}
+        run: |
+          set -euo pipefail
+          ios_hash=$(pnpm exec tsx dev/local/mobile-native-hash.ts ios)
+          android_hash=$(pnpm exec tsx dev/local/mobile-native-hash.ts android)
+          echo "ios_hash=$ios_hash" >> "$GITHUB_OUTPUT"
+          echo "android_hash=$android_hash" >> "$GITHUB_OUTPUT"
+          exists() {
+            count=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=$1&per_page=10" \
+              --jq '[.artifacts[] | select(.expired | not)] | length')
+            [ "$count" -gt 0 ]
+          }
+          need() {
+            platform=$1 hash=$2
+            if [ "$PLATFORM" != all ] && [ "$PLATFORM" != "$platform" ]; then
+              echo false; return
+            fi
+            if exists "mobile-native-$platform-$hash"; then
+              echo "artifact mobile-native-$platform-$hash already exists" >&2
+              echo false
+            else
+              echo true
+            fi
+          }
+          echo "need_ios=$(need ios "$ios_hash")" >> "$GITHUB_OUTPUT"
+          echo "need_android=$(need android "$android_hash")" >> "$GITHUB_OUTPUT"
+
+  ios:
+    needs: gate
+    if: needs.gate.outputs.need_ios == 'true'
+    runs-on: macos-26
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build trpc types
+        run: pnpm --filter @kilocode/trpc run build
+
+      # A consumer computes the hash on macOS; the gate computed it on
+      # Linux. A mismatch would publish an artifact nobody can ever find,
+      # so fail loudly instead.
+      - name: Verify the hash is platform-independent
+        run: |
+          set -euo pipefail
+          mac_hash=$(pnpm exec tsx dev/local/mobile-native-hash.ts ios)
+          if [ "$mac_hash" != "${{ needs.gate.outputs.ios_hash }}" ]; then
+            echo "::error::nativeHash differs between Linux (${{ needs.gate.outputs.ios_hash }}) and macOS ($mac_hash)"
+            exit 1
+          fi
+
+      - name: Expo prebuild
+        run: CI=1 pnpm --filter kilo-app exec expo prebuild --platform ios
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          xcodebuild \
+            -workspace apps/mobile/ios/Kilo.xcworkspace \
+            -scheme Kilo \
+            -configuration Debug \
+            -sdk iphonesimulator \
+            -destination 'generic/platform=iOS Simulator' \
+            -derivedDataPath "$RUNNER_TEMP/DerivedData" \
+            build
+
+      # A tarball keeps the executable bit that upload-artifact's zip drops.
+      - name: Package
+        run: |
+          set -euo pipefail
+          tar -C "$RUNNER_TEMP/DerivedData/Build/Products/Debug-iphonesimulator" \
+            -czf "ios-${{ needs.gate.outputs.ios_hash }}.tar.gz" Kilo.app
+
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: mobile-native-ios-${{ needs.gate.outputs.ios_hash }}
+          path: ios-${{ needs.gate.outputs.ios_hash }}.tar.gz
+          compression-level: 0
+          retention-days: 90
+          if-no-files-found: error
+
+  android:
+    needs: gate
+    if: needs.gate.outputs.need_android == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          lfs: true
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v4.4.0
+
+      - name: Setup Node
+        uses: actions/setup-node@53b83947a5a98c8d113130e565377fae1a50d02f # v6.3.0
+        with:
+          node-version-file: '.nvmrc'
+          cache: 'pnpm'
+
+      - name: Setup Java
+        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
+        with:
+          distribution: temurin
+          java-version: '17'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build trpc types
+        run: pnpm --filter @kilocode/trpc run build
+
+      - name: Expo prebuild
+        run: CI=1 pnpm --filter kilo-app exec expo prebuild --platform android
+
+      - name: Build
+        run: |
+          set -euo pipefail
+          cd apps/mobile/android
+          ./gradlew --no-daemon app:assembleDebug
+          cp app/build/outputs/apk/debug/app-debug.apk "$RUNNER_TEMP/Kilo.apk"
+
+      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+        with:
+          name: mobile-native-android-${{ needs.gate.outputs.android_hash }}
+          path: ${{ runner.temp }}/Kilo.apk
+          compression-level: 0
+          retention-days: 90
+          if-no-files-found: error

--- a/.github/workflows/mobile-native-build.yml
+++ b/.github/workflows/mobile-native-build.yml
@@ -186,7 +186,7 @@ jobs:
           tar -C "$products" \
             -czf "ios-${{ needs.gate.outputs.ios_hash }}.tar.gz" Kilo.app toolchain.json
 
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ needs.gate.outputs.prefix }}mobile-native-ios-${{ needs.gate.outputs.ios_hash }}
           path: ios-${{ needs.gate.outputs.ios_hash }}.tar.gz
@@ -214,7 +214,7 @@ jobs:
           cache: 'pnpm'
 
       - name: Setup Java
-        uses: actions/setup-java@cf277c60eb25467037889841efdb72551f06f6c3 # v4.9.1
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           distribution: temurin
           java-version: '17'
@@ -235,7 +235,7 @@ jobs:
           ./gradlew --no-daemon app:assembleDebug
           cp app/build/outputs/apk/debug/app-debug.apk "$RUNNER_TEMP/Kilo.apk"
 
-      - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ needs.gate.outputs.prefix }}mobile-native-android-${{ needs.gate.outputs.android_hash }}
           path: ${{ runner.temp }}/Kilo.apk

--- a/.github/workflows/mobile-native-build.yml
+++ b/.github/workflows/mobile-native-build.yml
@@ -25,6 +25,11 @@ on:
       - 'pnpm-workspace.yaml'
       - 'patches/**'
       - '.github/workflows/mobile-native-build.yml'
+  # Self-validation: a PR that edits this workflow runs it once.
+  # (workflow_dispatch only works after the file exists on main.)
+  pull_request:
+    paths:
+      - '.github/workflows/mobile-native-build.yml'
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/.github/workflows/mobile-native-build.yml
+++ b/.github/workflows/mobile-native-build.yml
@@ -137,15 +137,20 @@ jobs:
 
       # A consumer computes the hash on macOS; the gate computed it on
       # Linux. A mismatch would publish an artifact nobody can ever find,
-      # so fail loudly instead.
-      - name: Verify the hash is platform-independent
+      # so fail loudly instead. Android is checked here too: it builds on
+      # Linux but is consumed on macOS, and nothing else compares the two.
+      - name: Verify the hashes are platform-independent
         run: |
           set -euo pipefail
-          mac_hash=$(pnpm exec tsx dev/local/mobile-native-hash.ts ios)
-          if [ "$mac_hash" != "${{ needs.gate.outputs.ios_hash }}" ]; then
-            echo "::error::nativeHash differs between Linux (${{ needs.gate.outputs.ios_hash }}) and macOS ($mac_hash)"
-            exit 1
-          fi
+          check() {
+            mac_hash=$(pnpm exec tsx dev/local/mobile-native-hash.ts "$1")
+            if [ "$mac_hash" != "$2" ]; then
+              echo "::error::$1 nativeHash differs between Linux ($2) and macOS ($mac_hash)"
+              exit 1
+            fi
+          }
+          check ios "${{ needs.gate.outputs.ios_hash }}"
+          check android "${{ needs.gate.outputs.android_hash }}"
 
       - name: Expo prebuild
         run: CI=1 pnpm --filter kilo-app exec expo prebuild --platform ios
@@ -163,11 +168,21 @@ jobs:
             build
 
       # A tarball keeps the executable bit that upload-artifact's zip drops.
+      # The artifact name keys only on nativeHash, but the local cache key
+      # also keys on the Xcode and simulator SDK. Record them so a consumer
+      # on a different toolchain refuses the binary (see
+      # dev/local/mobile-remote-native.ts) instead of caching an app its
+      # simulator runtime cannot launch.
       - name: Package
         run: |
           set -euo pipefail
-          tar -C "$RUNNER_TEMP/DerivedData/Build/Products/Debug-iphonesimulator" \
-            -czf "ios-${{ needs.gate.outputs.ios_hash }}.tar.gz" Kilo.app
+          products="$RUNNER_TEMP/DerivedData/Build/Products/Debug-iphonesimulator"
+          xcode=$(xcodebuild -version | sed -n 's/^Build version \(.*\)$/\1/p')
+          sdk=$(xcrun --sdk iphonesimulator --show-sdk-version)
+          printf '{"xcodeBuildVersion":"%s","simulatorSdkVersion":"%s"}\n' "$xcode" "$sdk" \
+            > "$products/toolchain.json"
+          tar -C "$products" \
+            -czf "ios-${{ needs.gate.outputs.ios_hash }}.tar.gz" Kilo.app toolchain.json
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:

--- a/.github/workflows/mobile-native-build.yml
+++ b/.github/workflows/mobile-native-build.yml
@@ -25,8 +25,8 @@ on:
       - 'pnpm-workspace.yaml'
       - 'patches/**'
       - '.github/workflows/mobile-native-build.yml'
-  # Self-validation: a PR that edits this workflow builds both platforms,
-  # under a pr<N>- artifact prefix so hosts never install it.
+  # Self-validation: a PR that edits this workflow builds it once, under a
+  # pr<N>-<workflow hash>- artifact prefix so hosts never install it.
   # (workflow_dispatch only works after the file exists on main.)
   pull_request:
     paths:
@@ -82,12 +82,14 @@ jobs:
           android_hash=$(pnpm exec tsx dev/local/mobile-native-hash.ts android)
           echo "ios_hash=$ios_hash" >> "$GITHUB_OUTPUT"
           echo "android_hash=$android_hash" >> "$GITHUB_OUTPUT"
-          # A pull_request run validates this workflow, so it must always
-          # build, and it must not publish into the namespace hosts install
-          # from (dev/local/mobile-remote-native.ts).
+          # A pull_request run validates this workflow. Its artifacts stay out
+          # of the namespace hosts install from (dev/local/mobile-remote-native.ts)
+          # and are keyed on the workflow file as well, so each edit of it
+          # builds exactly once and a re-push of the same file skips.
           prefix=''
           if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
-            prefix="pr$PR_NUMBER-"
+            workflow_hash=$(sha256sum .github/workflows/mobile-native-build.yml | cut -c1-8)
+            prefix="pr$PR_NUMBER-$workflow_hash-"
           fi
           echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
           exists() {
@@ -100,11 +102,8 @@ jobs:
             if [ "$PLATFORM" != all ] && [ "$PLATFORM" != "$platform" ]; then
               echo false; return
             fi
-            if [ -n "$prefix" ]; then
-              echo true; return
-            fi
-            if exists "mobile-native-$platform-$hash"; then
-              echo "artifact mobile-native-$platform-$hash already exists" >&2
+            if exists "${prefix}mobile-native-$platform-$hash"; then
+              echo "artifact ${prefix}mobile-native-$platform-$hash already exists" >&2
               echo false
             else
               echo true
@@ -192,7 +191,7 @@ jobs:
           name: ${{ needs.gate.outputs.prefix }}mobile-native-ios-${{ needs.gate.outputs.ios_hash }}
           path: ios-${{ needs.gate.outputs.ios_hash }}.tar.gz
           compression-level: 0
-          retention-days: 90
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 90 }}
           if-no-files-found: error
 
   android:
@@ -241,5 +240,5 @@ jobs:
           name: ${{ needs.gate.outputs.prefix }}mobile-native-android-${{ needs.gate.outputs.android_hash }}
           path: ${{ runner.temp }}/Kilo.apk
           compression-level: 0
-          retention-days: 90
+          retention-days: ${{ github.event_name == 'pull_request' && 1 || 90 }}
           if-no-files-found: error

--- a/.github/workflows/mobile-native-build.yml
+++ b/.github/workflows/mobile-native-build.yml
@@ -25,7 +25,8 @@ on:
       - 'pnpm-workspace.yaml'
       - 'patches/**'
       - '.github/workflows/mobile-native-build.yml'
-  # Self-validation: a PR that edits this workflow runs it once.
+  # Self-validation: a PR that edits this workflow builds both platforms,
+  # under a pr<N>- artifact prefix so hosts never install it.
   # (workflow_dispatch only works after the file exists on main.)
   pull_request:
     paths:
@@ -48,6 +49,7 @@ jobs:
       android_hash: ${{ steps.decide.outputs.android_hash }}
       need_ios: ${{ steps.decide.outputs.need_ios }}
       need_android: ${{ steps.decide.outputs.need_android }}
+      prefix: ${{ steps.decide.outputs.prefix }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -70,12 +72,21 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
           PLATFORM: ${{ inputs.platform || 'all' }}
+          PR_NUMBER: ${{ github.event.number }}
         run: |
           set -euo pipefail
           ios_hash=$(pnpm exec tsx dev/local/mobile-native-hash.ts ios)
           android_hash=$(pnpm exec tsx dev/local/mobile-native-hash.ts android)
           echo "ios_hash=$ios_hash" >> "$GITHUB_OUTPUT"
           echo "android_hash=$android_hash" >> "$GITHUB_OUTPUT"
+          # A pull_request run validates this workflow, so it must always
+          # build, and it must not publish into the namespace hosts install
+          # from (dev/local/mobile-remote-native.ts).
+          prefix=''
+          if [ "$GITHUB_EVENT_NAME" = pull_request ]; then
+            prefix="pr$PR_NUMBER-"
+          fi
+          echo "prefix=$prefix" >> "$GITHUB_OUTPUT"
           exists() {
             count=$(gh api "repos/${GITHUB_REPOSITORY}/actions/artifacts?name=$1&per_page=10" \
               --jq '[.artifacts[] | select(.expired | not)] | length')
@@ -85,6 +96,9 @@ jobs:
             platform=$1 hash=$2
             if [ "$PLATFORM" != all ] && [ "$PLATFORM" != "$platform" ]; then
               echo false; return
+            fi
+            if [ -n "$prefix" ]; then
+              echo true; return
             fi
             if exists "mobile-native-$platform-$hash"; then
               echo "artifact mobile-native-$platform-$hash already exists" >&2
@@ -157,7 +171,7 @@ jobs:
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: mobile-native-ios-${{ needs.gate.outputs.ios_hash }}
+          name: ${{ needs.gate.outputs.prefix }}mobile-native-ios-${{ needs.gate.outputs.ios_hash }}
           path: ios-${{ needs.gate.outputs.ios_hash }}.tar.gz
           compression-level: 0
           retention-days: 90
@@ -206,7 +220,7 @@ jobs:
 
       - uses: actions/upload-artifact@330a01c490aca151604b8cf639adc76d48f6c5d4 # v5.0.0
         with:
-          name: mobile-native-android-${{ needs.gate.outputs.android_hash }}
+          name: ${{ needs.gate.outputs.prefix }}mobile-native-android-${{ needs.gate.outputs.android_hash }}
           path: ${{ runner.temp }}/Kilo.apk
           compression-level: 0
           retention-days: 90

--- a/dev/local/mobile-android-build.test.ts
+++ b/dev/local/mobile-android-build.test.ts
@@ -76,6 +76,9 @@ test('Android fingerprint skips only Expo extra beyond defaults', () => {
   assert.deepEqual(options.platforms, ['android']);
   assert.equal(options.silent, true);
   assert.notEqual(options.sourceSkips, 0);
+  // The generated tree is ignored so the hash is input-deterministic across
+  // worktrees and machines.
+  assert.deepEqual(options.ignorePaths, ['android/**']);
   assert.deepEqual(
     options.extraSources.map(source => ({
       type: source.type,

--- a/dev/local/mobile-android-build.ts
+++ b/dev/local/mobile-android-build.ts
@@ -41,6 +41,10 @@ export type AndroidBuildDeps = {
   readPackageId: (apkPath: string) => string | undefined;
   install: (serial: string, apkPath: string) => void;
   now: () => Date;
+  // Fetch a prebuilt Kilo.apk for this nativeHash into destDir and return
+  // its path, or undefined on a miss. When set, a cache miss tries this
+  // before compiling locally.
+  fetchRemote?: (args: { nativeHash: string; destDir: string }) => Promise<string | undefined>;
 };
 
 // Repo-root inputs that shape the native build but live outside
@@ -49,12 +53,17 @@ export type AndroidBuildDeps = {
 export function buildAndroidFingerprintOptions(): {
   platforms: ['android'];
   sourceSkips: number;
+  ignorePaths: string[];
   extraSources: HashSourceContents[];
   silent: boolean;
 } {
   return {
     platforms: ['android'],
     sourceSkips: DEFAULT_SOURCE_SKIPS | SourceSkips.ExpoConfigExtraSection,
+    // The generated android/ tree is output, not an input: its bytes differ
+    // per worktree. Pin it out of the hash so no fingerprint version can key
+    // builds on it.
+    ignorePaths: ['android/**'],
     extraSources: [
       {
         type: 'contents',
@@ -128,6 +137,11 @@ export async function runAndroidBuild(serial: string, deps: AndroidBuildDeps): P
   };
   const key = buildAndroidCompatibilityKey(compatibility);
   let entry = await lookup(deps.cacheRoot, key, compatibility, deps.readPackageId);
+  if (!entry && deps.fetchRemote) {
+    // Outside the native-build semaphore: a download (or a wait on a remote
+    // runner) burns no local CPU, so it must not block a local compile.
+    entry = await tryRemotePublish(serial, key, compatibility, deps);
+  }
   if (!entry) {
     entry = await deps.withNativeBuildSlot(async () => {
       const queuedHit = await lookup(deps.cacheRoot, key, compatibility, deps.readPackageId);
@@ -136,6 +150,39 @@ export async function runAndroidBuild(serial: string, deps: AndroidBuildDeps): P
     });
   }
   deps.install(serial, entry.apkPath);
+}
+
+// Publish a cache entry from a remote-built APK instead of a local compile.
+// Reuses publish() unchanged — only the build step is swapped for a fetch
+// into staging — so the package-id check, checksum, manifest, and atomic
+// publish all still apply. Any failure returns undefined and the caller
+// compiles locally.
+async function tryRemotePublish(
+  serial: string,
+  key: string,
+  compatibility: AndroidCompatibility,
+  deps: AndroidBuildDeps
+): Promise<{ apkPath: string; manifest: AndroidManifest } | undefined> {
+  const fetchRemote = deps.fetchRemote;
+  if (!fetchRemote) return undefined;
+  try {
+    return await publish(serial, key, compatibility, {
+      ...deps,
+      build: async staging => {
+        const apkPath = await fetchRemote({
+          nativeHash: compatibility.nativeHash,
+          destDir: staging,
+        });
+        if (!apkPath) throw new Error('remote native artifact unavailable');
+        return apkPath;
+      },
+    });
+  } catch (error) {
+    process.stderr.write(
+      `remote native build unavailable (${error instanceof Error ? error.message : error}); building locally\n`
+    );
+    return undefined;
+  }
 }
 
 async function lookup(

--- a/dev/local/mobile-android.ts
+++ b/dev/local/mobile-android.ts
@@ -13,6 +13,7 @@ import {
   runAndroidBuild,
 } from './mobile-android-build';
 import { withNativeBuildSemaphore } from './mobile-native-build';
+import { fetchAndroidApk } from './mobile-remote-native';
 import { withProcessLock, withProcessLockAsync } from './process-lock';
 
 type AndroidEnvironment = {
@@ -670,6 +671,7 @@ async function main(): Promise<void> {
           run: runBuild,
         }),
       build: staging => buildAndroidApk(env, mobileRoot, staging),
+      fetchRemote: async ({ nativeHash, destDir }) => fetchAndroidApk({ nativeHash, destDir }),
       readPackageId: apkPath => readAndroidPackageId(env, apkPath),
       install: (deviceSerial, apkPath) => {
         const command = buildAndroidInstallCommand(env.adb, deviceSerial, apkPath);

--- a/dev/local/mobile-ios-build.test.ts
+++ b/dev/local/mobile-ios-build.test.ts
@@ -99,6 +99,9 @@ test('fingerprint options include iOS platform and only skip the Expo extra sect
   const options = buildFingerprintOptions();
   assert.deepEqual(options.platforms, ['ios']);
   assert.equal(options.silent, true);
+  // The generated tree is ignored so the hash is input-deterministic across
+  // worktrees and machines.
+  assert.deepEqual(options.ignorePaths, ['ios/**']);
   // SourceSkips.ExpoConfigExtraSection === 4096
   assert.equal(options.sourceSkips & 4096, 4096);
   assert.deepEqual(
@@ -888,6 +891,115 @@ test('runBuild on miss invokes the builder once, publishes, and installs', async
       onMiss: async () => undefined,
     });
     assert.ok(hit);
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('runBuild on miss publishes a remote-fetched app without the local builder or the build slot', async () => {
+  const cacheRoot = makeTempDir('build-remote');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-remote';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let builderCalls = 0;
+  let slots = 0;
+  let fetches = 0;
+  const installs: string[] = [];
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    build: async () => {
+      builderCalls += 1;
+    },
+    withNativeBuildSlot: async run => {
+      slots += 1;
+      return run();
+    },
+    fetchRemote: async ({ nativeHash, productsDir }) => {
+      fetches += 1;
+      assert.equal(nativeHash, 'native-hash');
+      const app = path.join(productsDir, 'Kilo.app');
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(path.join(app, 'Info.plist'), '<plist/>');
+      return true;
+    },
+    install: (_udid, app) => {
+      installs.push(app);
+    },
+  });
+  try {
+    await runBuild(udid, deps);
+    assert.equal(fetches, 1);
+    assert.equal(builderCalls, 0);
+    assert.equal(slots, 0);
+    assert.equal(installs.length, 1);
+    const key = buildCompatibilityKey({
+      nativeHash: 'native-hash',
+      xcodeBuildVersion: '16A0000',
+      simulatorSdkVersion: '17.5',
+      hostArch: 'arm64',
+      buildMode: 'debug-dev-client',
+    });
+    // The remote-fetched app went through the full publish path: the
+    // installed path is the validated on-disk cache entry.
+    assert.equal(installs[0], path.join(cacheRoot, 'entries', key, 'Kilo.app'));
+  } finally {
+    fs.rmSync(cacheRoot, { recursive: true, force: true });
+    fs.rmSync(claimRoot, { recursive: true, force: true });
+    fs.rmSync(worktree, { recursive: true, force: true });
+  }
+});
+
+test('runBuild falls back to the local builder when the remote fetch misses', async () => {
+  const cacheRoot = makeTempDir('build-remote-miss');
+  const claimRoot = makeTempDir('claims');
+  const worktree = makeTempDir('wt');
+  const udid = 'UDID-remote-miss';
+  fs.writeFileSync(
+    path.join(claimRoot, `${udid}.json`),
+    JSON.stringify({
+      worktreeRoot: worktree,
+      claimId: 'c',
+      status: 'ready',
+      claimedAt: new Date().toISOString(),
+      deviceId: udid,
+    })
+  );
+  let builderCalls = 0;
+  const deps: BuildDeps = makeBuildDeps({
+    env: fixedEnv({ cacheRoot }),
+    worktreeRoot: worktree,
+    claimRoot,
+    fetchRemote: async () => false,
+    build: async ({ derivedDataPath }) => {
+      builderCalls += 1;
+      const app = path.join(
+        derivedDataPath,
+        'Build',
+        'Products',
+        'Debug-iphonesimulator',
+        'Kilo.app'
+      );
+      fs.mkdirSync(app, { recursive: true });
+      fs.writeFileSync(path.join(app, 'Info.plist'), '<plist/>');
+    },
+  });
+  try {
+    await runBuild(udid, deps);
+    assert.equal(builderCalls, 1);
   } finally {
     fs.rmSync(cacheRoot, { recursive: true, force: true });
     fs.rmSync(claimRoot, { recursive: true, force: true });

--- a/dev/local/mobile-ios-build.ts
+++ b/dev/local/mobile-ios-build.ts
@@ -901,8 +901,14 @@ export type BuildDeps = {
   sleep?: (ms: number) => Promise<void>;
   // Fetch a prebuilt Kilo.app for this nativeHash into productsDir (the
   // directory locateProducedApp reads). Returns false on a miss. When set,
-  // a cache miss tries this before compiling locally.
-  fetchRemote?: (args: { nativeHash: string; productsDir: string }) => Promise<boolean>;
+  // a cache miss tries this before compiling locally. `toolchain` is the
+  // host's own Xcode and simulator SDK: the artifact is keyed on nativeHash
+  // alone, so the fetcher must reject one built by a different toolchain.
+  fetchRemote?: (args: {
+    nativeHash: string;
+    productsDir: string;
+    toolchain: { xcodeBuildVersion: string; simulatorSdkVersion: string };
+  }) => Promise<boolean>;
 };
 
 export type RunFingerprintDeps = {
@@ -1083,6 +1089,10 @@ async function tryRemotePublish(args: {
           const fetched = await fetchRemote({
             nativeHash: args.compatibility.nativeHash,
             productsDir,
+            toolchain: {
+              xcodeBuildVersion: args.compatibility.xcodeBuildVersion,
+              simulatorSdkVersion: args.compatibility.simulatorSdkVersion,
+            },
           });
           if (!fetched) throw new Error('remote native artifact unavailable');
         },
@@ -1273,7 +1283,8 @@ async function main(): Promise<void> {
         }),
       validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) =>
         validateSimulatorClaim(udid, worktreeRoot, claimRoot),
-      fetchRemote: async ({ nativeHash, productsDir }) => fetchIosApp({ nativeHash, productsDir }),
+      fetchRemote: async ({ nativeHash, productsDir, toolchain }) =>
+        fetchIosApp({ nativeHash, productsDir, toolchain }),
     });
     process.stdout.write(`Installed ${parsed.udid}\n`);
     return;

--- a/dev/local/mobile-ios-build.ts
+++ b/dev/local/mobile-ios-build.ts
@@ -12,6 +12,7 @@ import {
 } from '@expo/fingerprint';
 
 import { hashRootNativeInputs, withNativeBuildSemaphore } from './mobile-native-build';
+import { fetchIosApp } from './mobile-remote-native';
 
 // Compatibility dimensions hashed into the cache key. Any change must
 // invalidate the key so cached artifacts are not reused for an
@@ -149,12 +150,17 @@ export type CliArgs =
 export function buildFingerprintOptions(): {
   platforms: ['ios'];
   sourceSkips: number;
+  ignorePaths: string[];
   extraSources: HashSourceContents[];
   silent: boolean;
 } {
   return {
     platforms: ['ios'],
     sourceSkips: DEFAULT_SOURCE_SKIPS | SourceSkips.ExpoConfigExtraSection,
+    // The generated ios/ tree is output, not an input: its bytes differ per
+    // worktree (pbxproj UUIDs, absolute paths in Podfile.lock). Pin it out of
+    // the hash so no fingerprint version can key builds on it.
+    ignorePaths: ['ios/**'],
     extraSources: [
       {
         type: 'contents',
@@ -893,6 +899,10 @@ export type BuildDeps = {
   withNativeBuildSlot: <T>(run: () => Promise<T>) => Promise<T>;
   validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) => void;
   sleep?: (ms: number) => Promise<void>;
+  // Fetch a prebuilt Kilo.app for this nativeHash into productsDir (the
+  // directory locateProducedApp reads). Returns false on a miss. When set,
+  // a cache miss tries this before compiling locally.
+  fetchRemote?: (args: { nativeHash: string; productsDir: string }) => Promise<boolean>;
 };
 
 export type RunFingerprintDeps = {
@@ -1039,6 +1049,53 @@ function validateKey(key: string): void {
   }
 }
 
+// Publish a cache entry from a remote-built artifact instead of a local
+// compile. Reuses publishCacheEntry unchanged — only the build step is
+// swapped for a fetch into the products directory it already reads — so the
+// bundle-id check, checksum, manifest, and atomic publish all still apply.
+// Any failure returns undefined and the caller compiles locally.
+async function tryRemotePublish(args: {
+  key: string;
+  compatibility: CompatibilityDimensions;
+  udid: string;
+  deps: BuildDeps;
+}): Promise<LookupCacheResult | undefined> {
+  const { deps } = args;
+  const fetchRemote = deps.fetchRemote;
+  if (!fetchRemote) return undefined;
+  try {
+    return await publishCacheEntry({
+      env: deps.env,
+      key: args.key,
+      compatibility: args.compatibility,
+      worktreeRoot: deps.worktreeRoot,
+      udid: args.udid,
+      deps: {
+        ...deps,
+        build: async ({ derivedDataPath }) => {
+          const productsDir = path.join(
+            derivedDataPath,
+            'Build',
+            'Products',
+            'Debug-iphonesimulator'
+          );
+          fs.mkdirSync(productsDir, { recursive: true });
+          const fetched = await fetchRemote({
+            nativeHash: args.compatibility.nativeHash,
+            productsDir,
+          });
+          if (!fetched) throw new Error('remote native artifact unavailable');
+        },
+      },
+    });
+  } catch (error) {
+    process.stderr.write(
+      `remote native build unavailable (${error instanceof Error ? error.message : error}); building locally\n`
+    );
+    return undefined;
+  }
+}
+
 export async function runBuild(udid: string, deps: BuildDeps): Promise<void> {
   // 1. Validate exclusive claim for the current worktree.
   deps.validateClaim(udid, deps.worktreeRoot, deps.claimRoot);
@@ -1078,8 +1135,13 @@ export async function runBuild(udid: string, deps: BuildDeps): Promise<void> {
     key,
     lockRoot,
     deps: lockDeps,
-    producer: () =>
-      deps.withNativeBuildSlot(() =>
+    // A remote artifact is tried first, outside the native-build semaphore:
+    // downloading (or waiting on a remote runner) burns no local CPU, so it
+    // must not serialize behind or block a local compile.
+    producer: async () => {
+      const remote = await tryRemotePublish({ key, compatibility, udid, deps });
+      if (remote) return remote;
+      return deps.withNativeBuildSlot(() =>
         publishCacheEntry({
           env: deps.env,
           key,
@@ -1088,7 +1150,8 @@ export async function runBuild(udid: string, deps: BuildDeps): Promise<void> {
           udid,
           deps,
         })
-      ),
+      );
+    },
     readResult: async () =>
       lookupCache({
         env: deps.env,
@@ -1210,6 +1273,7 @@ async function main(): Promise<void> {
         }),
       validateClaim: (udid: string, worktreeRoot: string, claimRoot: string) =>
         validateSimulatorClaim(udid, worktreeRoot, claimRoot),
+      fetchRemote: async ({ nativeHash, productsDir }) => fetchIosApp({ nativeHash, productsDir }),
     });
     process.stdout.write(`Installed ${parsed.udid}\n`);
     return;

--- a/dev/local/mobile-native-build.test.ts
+++ b/dev/local/mobile-native-build.test.ts
@@ -4,7 +4,11 @@ import os from 'node:os';
 import path from 'node:path';
 import test from 'node:test';
 
-import { hashRootNativeInputs, withNativeBuildSemaphore } from './mobile-native-build';
+import {
+  hashRootNativeInputs,
+  mobileLockfileSlice,
+  withNativeBuildSemaphore,
+} from './mobile-native-build';
 
 test('serializes native producers across different platform builds', async () => {
   const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-native-build-'));
@@ -205,6 +209,49 @@ test('root native inputs hash changes with patch, workspace, and lockfile edits'
     assert.equal(seen.includes(next), false);
     seen.push(next);
   }
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+function lockfileWith(mobileVersion: string, webVersion: string): string {
+  return [
+    "lockfileVersion: '9.0'",
+    'importers:',
+    '  apps/mobile:',
+    '    dependencies:',
+    '      expo:',
+    '        specifier: ^57.0.0',
+    `        version: ${mobileVersion}`,
+    '',
+    '  apps/web:',
+    '    dependencies:',
+    '      next:',
+    '        specifier: ^15.0.0',
+    `        version: ${webVersion}`,
+    '',
+  ].join('\n');
+}
+
+test('lockfile hash input ignores changes outside the apps/mobile importer block', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-lock-slice-'));
+  writeRootNativeInputs(root);
+  const lockPath = path.join(root, 'pnpm-lock.yaml');
+  fs.writeFileSync(lockPath, lockfileWith('57.0.10', '15.0.1'));
+  const before = hashRootNativeInputs(root);
+  // A web-only resolution change must not re-key the mobile native build.
+  fs.writeFileSync(lockPath, lockfileWith('57.0.10', '15.0.2'));
+  assert.equal(hashRootNativeInputs(root), before);
+  // A mobile resolution change must re-key it.
+  fs.writeFileSync(lockPath, lockfileWith('57.0.11', '15.0.2'));
+  assert.notEqual(hashRootNativeInputs(root), before);
+  fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('lockfile slice falls back to the whole file when no apps/mobile importer block exists', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-lock-slice-'));
+  const lockPath = path.join(root, 'pnpm-lock.yaml');
+  fs.writeFileSync(lockPath, 'lockfileVersion: 9\n');
+  assert.equal(mobileLockfileSlice(lockPath).toString(), 'lockfileVersion: 9\n');
+  assert.equal(mobileLockfileSlice(path.join(root, 'missing.yaml')).toString(), '<missing>');
   fs.rmSync(root, { recursive: true, force: true });
 });
 

--- a/dev/local/mobile-native-build.ts
+++ b/dev/local/mobile-native-build.ts
@@ -75,12 +75,35 @@ export function hashRootNativeInputs(repoRoot: string): string {
     hash.update('\0');
   };
   add('pnpm-workspace.yaml', path.join(repoRoot, 'pnpm-workspace.yaml'));
-  add('pnpm-lock.yaml', path.join(repoRoot, 'pnpm-lock.yaml'));
+  hash.update('pnpm-lock.yaml#apps/mobile');
+  hash.update('\0');
+  hash.update(mobileLockfileSlice(path.join(repoRoot, 'pnpm-lock.yaml')));
+  hash.update('\0');
   const patchesRoot = path.join(repoRoot, 'patches');
   for (const relativePath of listFilesRecursively(patchesRoot)) {
     add(`patches/${relativePath}`, path.join(patchesRoot, relativePath));
   }
   return hash.digest('hex');
+}
+
+// The full lockfile churns on every dependency change anywhere in the
+// monorepo, re-keying mobile native builds whose inputs did not change
+// (observed: byte-identical APKs cached under distinct keys). Only the
+// apps/mobile importer block records resolutions the native build can see —
+// autolinked native modules are direct dependencies, and the block pins
+// their full resolved versions — so hash just that block. On any format
+// surprise, fall back to the whole file: over-keying is safe, under-keying
+// is not.
+export function mobileLockfileSlice(lockPath: string): Buffer {
+  let body: string;
+  try {
+    body = fs.readFileSync(lockPath, 'utf8');
+  } catch (error) {
+    if (hasCode(error, 'ENOENT')) return Buffer.from('<missing>');
+    throw error;
+  }
+  const block = body.match(/^ {2}apps\/mobile:\n(?:(?: {4}.*)?\n)*/m);
+  return Buffer.from(block ? block[0] : body);
 }
 
 function listFilesRecursively(root: string): string[] {

--- a/dev/local/mobile-native-hash.ts
+++ b/dev/local/mobile-native-hash.ts
@@ -1,0 +1,31 @@
+// Print the platform's nativeHash and exit. Unlike `dev:mobile:ios
+// fingerprint`, this needs no Xcode or Android SDK, so CI gates can run it
+// on any Linux runner to decide whether a native build is required.
+import path from 'node:path';
+
+import { createProjectHashAsync } from '@expo/fingerprint';
+
+import { buildAndroidFingerprintOptions } from './mobile-android-build';
+import { buildFingerprintOptions, mobileRoot } from './mobile-ios-build';
+
+async function main(): Promise<void> {
+  const platform = process.argv[2];
+  if (platform !== 'ios' && platform !== 'android') {
+    throw new Error('Usage: tsx dev/local/mobile-native-hash.ts <ios|android>');
+  }
+  const options = platform === 'ios' ? buildFingerprintOptions() : buildAndroidFingerprintOptions();
+  const hash = await createProjectHashAsync(
+    mobileRoot(),
+    options as Parameters<typeof createProjectHashAsync>[1]
+  );
+  process.stdout.write(`${hash}\n`);
+}
+
+const isMain =
+  process.argv[1] && path.resolve(process.argv[1]) === path.resolve(import.meta.filename);
+if (isMain) {
+  main().catch(error => {
+    process.stderr.write(`${error instanceof Error ? error.message : error}\n`);
+    process.exit(1);
+  });
+}

--- a/dev/local/mobile-remote-native.test.ts
+++ b/dev/local/mobile-remote-native.test.ts
@@ -1,0 +1,32 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { artifactName, pickDispatchedRun } from './mobile-remote-native';
+
+const HEAD = 'a'.repeat(40);
+const OTHER = 'b'.repeat(40);
+
+test('ignores runs that already existed before the dispatch', () => {
+  const before = new Set([10, 9]);
+  const runs = [
+    { databaseId: 10, headSha: HEAD },
+    { databaseId: 9, headSha: HEAD },
+  ];
+  assert.equal(pickDispatchedRun(runs, before, HEAD), undefined);
+});
+
+test('takes the newest new run on this commit', () => {
+  const before = new Set([9]);
+  const runs = [
+    { databaseId: 12, headSha: OTHER },
+    { databaseId: 11, headSha: HEAD },
+    { databaseId: 10, headSha: HEAD },
+    { databaseId: 9, headSha: HEAD },
+  ];
+  assert.equal(pickDispatchedRun(runs, before, HEAD), 11);
+});
+
+test('artifact names stay hash-keyed per platform', () => {
+  assert.equal(artifactName('ios', 'deadbeef'), 'mobile-native-ios-deadbeef');
+  assert.equal(artifactName('android', 'deadbeef'), 'mobile-native-android-deadbeef');
+});

--- a/dev/local/mobile-remote-native.test.ts
+++ b/dev/local/mobile-remote-native.test.ts
@@ -1,7 +1,7 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
-import { artifactName, pickDispatchedRun } from './mobile-remote-native';
+import { artifactName, assertToolchainMatches, pickDispatchedRun } from './mobile-remote-native';
 
 const HEAD = 'a'.repeat(40);
 const OTHER = 'b'.repeat(40);
@@ -29,4 +29,21 @@ test('takes the newest new run on this commit', () => {
 test('artifact names stay hash-keyed per platform', () => {
   assert.equal(artifactName('ios', 'deadbeef'), 'mobile-native-ios-deadbeef');
   assert.equal(artifactName('android', 'deadbeef'), 'mobile-native-android-deadbeef');
+});
+
+const TOOLCHAIN = { xcodeBuildVersion: '17A324', simulatorSdkVersion: '26.0' };
+
+test('accepts an artifact built by the same toolchain', () => {
+  assertToolchainMatches({ ...TOOLCHAIN }, TOOLCHAIN);
+});
+
+test('rejects an artifact built by a different simulator SDK', () => {
+  assert.throws(
+    () => assertToolchainMatches({ ...TOOLCHAIN, simulatorSdkVersion: '18.4' }, TOOLCHAIN),
+    /does not match local/
+  );
+});
+
+test('rejects an artifact with no recorded toolchain', () => {
+  assert.throws(() => assertToolchainMatches(null, TOOLCHAIN), /does not match local/);
 });

--- a/dev/local/mobile-remote-native.ts
+++ b/dev/local/mobile-remote-native.ts
@@ -156,6 +156,7 @@ export function pickDispatchedRun(
 // Only possible when HEAD is exactly the pushed upstream commit — the
 // runner builds from the remote ref, so anything else builds the wrong tree.
 function dispatchAndWatch(platform: 'ios' | 'android'): boolean {
+  const startedAt = Date.now();
   const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
   if (!branch || branch === 'HEAD') {
     log('detached HEAD; cannot dispatch a remote build');
@@ -201,22 +202,64 @@ function dispatchAndWatch(platform: 'ios' | 'android'): boolean {
       stdio: ['ignore', process.stderr, process.stderr],
       timeout: WATCH_TIMEOUT_MS,
     });
+    log(`remote build run ${runId} finished after ${waited(startedAt)}`);
     return true;
   } catch (error) {
-    log(`remote build run ${runId} failed or timed out (${message(error)})`);
+    log(
+      `remote build run ${runId} failed or timed out after ${waited(startedAt)} (${message(error)})`
+    );
     return false;
+  }
+}
+
+// Wall clock spent waiting on CI. Waiting only pays while it stays under a
+// local compile; log it so that stays measurable instead of assumed.
+function waited(since: number): string {
+  return `${((Date.now() - since) / 60000).toFixed(1)}m`;
+}
+
+export type IosToolchain = { xcodeBuildVersion: string; simulatorSdkVersion: string };
+
+// The artifact name keys on nativeHash alone, but the local cache key also
+// keys on the Xcode and simulator SDK that produced the binary. Without this
+// check a host publishes a runner-built .app under its own toolchain's key;
+// when the runner's simulator SDK is newer than the host's runtime the app
+// never launches, and the entry sticks under a key the host keeps
+// recomputing. Throwing here drops us onto the local build instead.
+export function assertToolchainMatches(actual: unknown, expected: IosToolchain): void {
+  const found = actual as Partial<IosToolchain> | null;
+  if (
+    !found ||
+    found.xcodeBuildVersion !== expected.xcodeBuildVersion ||
+    found.simulatorSdkVersion !== expected.simulatorSdkVersion
+  ) {
+    throw new Error(
+      `artifact toolchain ${found?.xcodeBuildVersion}/${found?.simulatorSdkVersion} does not match local ${expected.xcodeBuildVersion}/${expected.simulatorSdkVersion}`
+    );
   }
 }
 
 // Unpack a remote iOS artifact's Kilo.app into the products directory the
 // local build pipeline reads from. The artifact carries a tarball because
 // upload-artifact's zip drops the executable bit.
-export function fetchIosApp(args: { nativeHash: string; productsDir: string }): boolean {
+export function fetchIosApp(args: {
+  nativeHash: string;
+  productsDir: string;
+  toolchain: IosToolchain;
+}): boolean {
   return withArtifact('ios', args.nativeHash, unpacked => {
     const tarball = path.join(unpacked, `ios-${args.nativeHash}.tar.gz`);
     if (!fs.existsSync(tarball))
       throw new Error(`artifact is missing ios-${args.nativeHash}.tar.gz`);
-    execFileSync('tar', ['-xzf', tarball, '-C', args.productsDir], { stdio: 'ignore' });
+    // Read the toolchain first, into scratch, so productsDir only ever
+    // receives Kilo.app. An artifact built before toolchain.json existed
+    // fails this extract, which is the same fall-back-to-local path.
+    execFileSync('tar', ['-xzf', tarball, '-C', unpacked, 'toolchain.json'], { stdio: 'ignore' });
+    assertToolchainMatches(
+      JSON.parse(fs.readFileSync(path.join(unpacked, 'toolchain.json'), 'utf8')),
+      args.toolchain
+    );
+    execFileSync('tar', ['-xzf', tarball, '-C', args.productsDir, 'Kilo.app'], { stdio: 'ignore' });
     if (!fs.existsSync(path.join(args.productsDir, 'Kilo.app'))) {
       throw new Error('artifact tarball did not contain Kilo.app');
     }

--- a/dev/local/mobile-remote-native.ts
+++ b/dev/local/mobile-remote-native.ts
@@ -1,0 +1,222 @@
+// Fetch prebuilt native artifacts from the `mobile-native-build` GitHub
+// workflow so a host installs a cached binary instead of compiling one.
+// The artifact is keyed by the platform's input-deterministic nativeHash
+// (see buildFingerprintOptions / buildAndroidFingerprintOptions), so any
+// machine that computes the same hash can reuse the same binary.
+//
+// Every failure path returns false/undefined so the caller falls back to
+// the local build — the failure path stays today's path. Set
+// KILO_REMOTE_NATIVE=off to skip remote fetching entirely.
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+const WORKFLOW_FILE = 'mobile-native-build.yml';
+// A queued + running macOS build fits well inside this; a hung run must not
+// pin an agent forever, so time out and build locally.
+const WATCH_TIMEOUT_MS = 45 * 60 * 1000;
+const GH_TIMEOUT_MS = 60 * 1000;
+// Artifact zips run to a few hundred MB.
+const DOWNLOAD_MAX_BUFFER = 2 * 1024 * 1024 * 1024;
+
+export function remoteNativeDisabled(env: NodeJS.ProcessEnv = process.env): boolean {
+  return env.KILO_REMOTE_NATIVE === 'off';
+}
+
+export function artifactName(platform: 'ios' | 'android', nativeHash: string): string {
+  return `mobile-native-${platform}-${nativeHash}`;
+}
+
+function log(message: string): void {
+  process.stderr.write(`mobile-remote-native: ${message}\n`);
+}
+
+function gh(args: string[], opts: { timeout?: number; maxBuffer?: number } = {}): string {
+  return execFileSync('gh', args, {
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe'],
+    timeout: opts.timeout ?? GH_TIMEOUT_MS,
+    maxBuffer: opts.maxBuffer ?? 16 * 1024 * 1024,
+  });
+}
+
+function git(args: string[]): string | undefined {
+  try {
+    return execFileSync('git', args, {
+      encoding: 'utf8',
+      stdio: ['ignore', 'pipe', 'pipe'],
+    }).trim();
+  } catch {
+    return undefined;
+  }
+}
+
+type ArtifactRecord = { id: number; expired: boolean };
+
+function findArtifact(name: string): ArtifactRecord | undefined {
+  // `gh api` resolves {owner}/{repo} from the current repository. Name
+  // lookup returns newest first across all workflow runs.
+  const raw = gh(['api', `repos/{owner}/{repo}/actions/artifacts?name=${name}&per_page=10`]);
+  const parsed = JSON.parse(raw) as { artifacts?: Array<{ id: number; expired: boolean }> };
+  return parsed.artifacts?.find(artifact => !artifact.expired);
+}
+
+// Download an artifact zip and hand the caller its unpacked directory.
+// Returns false when the artifact does not exist (after a dispatch attempt)
+// or anything in the chain fails.
+function withArtifact(
+  platform: 'ios' | 'android',
+  nativeHash: string,
+  use: (unpackedDir: string) => void
+): boolean {
+  if (remoteNativeDisabled()) return false;
+  const name = artifactName(platform, nativeHash);
+  let artifact: ArtifactRecord | undefined;
+  try {
+    artifact = findArtifact(name);
+  } catch (error) {
+    // No gh, no auth, or no network: local build is the fallback.
+    log(`artifact lookup failed (${message(error)})`);
+    return false;
+  }
+  if (!artifact) {
+    log(`no artifact ${name}; trying a remote build dispatch`);
+    if (!dispatchAndWatch(platform)) return false;
+    try {
+      artifact = findArtifact(name);
+    } catch (error) {
+      log(`artifact lookup failed after dispatch (${message(error)})`);
+      return false;
+    }
+    if (!artifact) {
+      // The dispatched run built a different hash (local uncommitted native
+      // changes) or uploaded nothing.
+      log(`remote build finished but produced no artifact ${name}`);
+      return false;
+    }
+  }
+  const scratch = fs.mkdtempSync(path.join(os.tmpdir(), 'kilo-remote-native-'));
+  try {
+    const zipPath = path.join(scratch, 'artifact.zip');
+    const zip = execFileSync(
+      'gh',
+      ['api', `repos/{owner}/{repo}/actions/artifacts/${artifact.id}/zip`],
+      { maxBuffer: DOWNLOAD_MAX_BUFFER, timeout: 10 * 60 * 1000 }
+    );
+    fs.writeFileSync(zipPath, zip);
+    const unpacked = path.join(scratch, 'unpacked');
+    fs.mkdirSync(unpacked);
+    execFileSync('unzip', ['-o', '-q', zipPath, '-d', unpacked], { stdio: 'ignore' });
+    use(unpacked);
+    log(`installed remote artifact ${name}`);
+    return true;
+  } catch (error) {
+    log(`artifact download failed (${message(error)})`);
+    return false;
+  } finally {
+    fs.rmSync(scratch, { recursive: true, force: true });
+  }
+}
+
+// Dispatch the workflow for the current branch and wait for it to finish.
+// Only possible when HEAD is exactly the pushed upstream commit — the
+// runner builds from the remote ref, so anything else builds the wrong tree.
+function dispatchAndWatch(platform: 'ios' | 'android'): boolean {
+  const branch = git(['rev-parse', '--abbrev-ref', 'HEAD']);
+  if (!branch || branch === 'HEAD') {
+    log('detached HEAD; cannot dispatch a remote build');
+    return false;
+  }
+  const head = git(['rev-parse', 'HEAD']);
+  const upstream = git(['rev-parse', '@{u}']);
+  if (!head || !upstream || head !== upstream) {
+    log(`branch ${branch} is not pushed to its upstream; cannot dispatch a remote build`);
+    return false;
+  }
+  const dispatchedAt = Date.now();
+  try {
+    gh(['workflow', 'run', WORKFLOW_FILE, '--ref', branch, '-f', `platform=${platform}`]);
+  } catch (error) {
+    // Typical cause: the workflow file does not exist on this branch yet.
+    log(`workflow dispatch failed (${message(error)})`);
+    return false;
+  }
+  log(`dispatched ${WORKFLOW_FILE} for ${platform} on ${branch}; waiting for the run`);
+  let runId: number | undefined;
+  for (let attempt = 0; attempt < 12 && runId === undefined; attempt++) {
+    sleepSync(5000);
+    try {
+      const raw = gh([
+        'run',
+        'list',
+        '--workflow',
+        WORKFLOW_FILE,
+        '--branch',
+        branch,
+        '--event',
+        'workflow_dispatch',
+        '--limit',
+        '1',
+        '--json',
+        'databaseId,createdAt',
+      ]);
+      const runs = JSON.parse(raw) as Array<{ databaseId: number; createdAt: string }>;
+      const run = runs[0];
+      if (run && Date.parse(run.createdAt) >= dispatchedAt - 2 * 60 * 1000) {
+        runId = run.databaseId;
+      }
+    } catch {
+      // Keep polling; the run can lag the dispatch.
+    }
+  }
+  if (runId === undefined) {
+    log('dispatched run never appeared');
+    return false;
+  }
+  try {
+    execFileSync('gh', ['run', 'watch', String(runId), '--exit-status', '--interval', '30'], {
+      stdio: ['ignore', process.stderr, process.stderr],
+      timeout: WATCH_TIMEOUT_MS,
+    });
+    return true;
+  } catch (error) {
+    log(`remote build run ${runId} failed or timed out (${message(error)})`);
+    return false;
+  }
+}
+
+// Unpack a remote iOS artifact's Kilo.app into the products directory the
+// local build pipeline reads from. The artifact carries a tarball because
+// upload-artifact's zip drops the executable bit.
+export function fetchIosApp(args: { nativeHash: string; productsDir: string }): boolean {
+  return withArtifact('ios', args.nativeHash, unpacked => {
+    const tarball = path.join(unpacked, `ios-${args.nativeHash}.tar.gz`);
+    if (!fs.existsSync(tarball))
+      throw new Error(`artifact is missing ios-${args.nativeHash}.tar.gz`);
+    execFileSync('tar', ['-xzf', tarball, '-C', args.productsDir], { stdio: 'ignore' });
+    if (!fs.existsSync(path.join(args.productsDir, 'Kilo.app'))) {
+      throw new Error('artifact tarball did not contain Kilo.app');
+    }
+  });
+}
+
+// Copy a remote Android artifact's Kilo.apk into destDir and return its path.
+export function fetchAndroidApk(args: { nativeHash: string; destDir: string }): string | undefined {
+  const target = path.join(args.destDir, 'Kilo-remote.apk');
+  const ok = withArtifact('android', args.nativeHash, unpacked => {
+    const apk = path.join(unpacked, 'Kilo.apk');
+    if (!fs.existsSync(apk)) throw new Error('artifact is missing Kilo.apk');
+    fs.copyFileSync(apk, target);
+  });
+  return ok ? target : undefined;
+}
+
+function message(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+function sleepSync(ms: number): void {
+  const shared = new SharedArrayBuffer(4);
+  Atomics.wait(new Int32Array(shared), 0, 0, ms);
+}

--- a/dev/local/mobile-remote-native.ts
+++ b/dev/local/mobile-remote-native.ts
@@ -119,6 +119,39 @@ function withArtifact(
   }
 }
 
+type DispatchRun = { databaseId: number; headSha: string };
+
+function listDispatchRuns(branch: string): DispatchRun[] {
+  const raw = gh([
+    'run',
+    'list',
+    '--workflow',
+    WORKFLOW_FILE,
+    '--branch',
+    branch,
+    '--event',
+    'workflow_dispatch',
+    '--limit',
+    '30',
+    '--json',
+    'databaseId,headSha',
+  ]);
+  return JSON.parse(raw) as DispatchRun[];
+}
+
+// `gh workflow run` reports no run id, and no listing exposes the dispatch
+// inputs, so take the newest run on this commit that did not exist before
+// the dispatch. `gh run list` returns newest first. Two hosts dispatching
+// different platforms in the same poll window can still cross; that ends in
+// the local build, which is the fallback anyway.
+export function pickDispatchedRun(
+  runs: DispatchRun[],
+  before: ReadonlySet<number>,
+  headSha: string
+): number | undefined {
+  return runs.find(run => !before.has(run.databaseId) && run.headSha === headSha)?.databaseId;
+}
+
 // Dispatch the workflow for the current branch and wait for it to finish.
 // Only possible when HEAD is exactly the pushed upstream commit — the
 // runner builds from the remote ref, so anything else builds the wrong tree.
@@ -134,7 +167,13 @@ function dispatchAndWatch(platform: 'ios' | 'android'): boolean {
     log(`branch ${branch} is not pushed to its upstream; cannot dispatch a remote build`);
     return false;
   }
-  const dispatchedAt = Date.now();
+  let before: Set<number>;
+  try {
+    before = new Set(listDispatchRuns(branch).map(run => run.databaseId));
+  } catch (error) {
+    log(`cannot list existing runs (${message(error)})`);
+    return false;
+  }
   try {
     gh(['workflow', 'run', WORKFLOW_FILE, '--ref', branch, '-f', `platform=${platform}`]);
   } catch (error) {
@@ -148,25 +187,7 @@ function dispatchAndWatch(platform: 'ios' | 'android'): boolean {
   for (let attempt = 0; attempt < 12 && runId === undefined; attempt++) {
     sleepSync(5000);
     try {
-      const raw = gh([
-        'run',
-        'list',
-        '--workflow',
-        WORKFLOW_FILE,
-        '--branch',
-        branch,
-        '--event',
-        'workflow_dispatch',
-        '--limit',
-        '1',
-        '--json',
-        'databaseId,createdAt',
-      ]);
-      const runs = JSON.parse(raw) as Array<{ databaseId: number; createdAt: string }>;
-      const run = runs[0];
-      if (run && Date.parse(run.createdAt) >= dispatchedAt - 2 * 60 * 1000) {
-        runId = run.databaseId;
-      }
+      runId = pickDispatchedRun(listDispatchRuns(branch), before, head);
     } catch {
       // Keep polling; the run can lag the dispatch.
     }

--- a/dev/local/mobile-remote-native.ts
+++ b/dev/local/mobile-remote-native.ts
@@ -138,7 +138,8 @@ function dispatchAndWatch(platform: 'ios' | 'android'): boolean {
   try {
     gh(['workflow', 'run', WORKFLOW_FILE, '--ref', branch, '-f', `platform=${platform}`]);
   } catch (error) {
-    // Typical cause: the workflow file does not exist on this branch yet.
+    // Typical cause: the workflow is not on the default branch yet —
+    // workflow_dispatch only resolves workflows registered there.
     log(`workflow dispatch failed (${message(error)})`);
     return false;
   }


### PR DESCRIPTION
## Symptom

The machine-global native build caches almost never hit. Evidence from the e2e host:

- 23 iOS producer locks since Aug 19 with 23 distinct cache keys — every build was a full xcodebuild.
- 15 Android entries under 15 distinct keys, including byte-identical APKs (same artifactChecksum) stored under different keys.

## Cause

`hashRootNativeInputs` hashes all of `pnpm-lock.yaml`. The lockfile changed in 14 commits over the last 14 days, so any dependency change anywhere in the monorepo re-keys mobile native builds whose inputs did not change. (The generated `ios/`/`android` trees were checked and are **not** part of the hash — the earlier prebuild-tree-cache diagnosis attributed the churn to them, but `@expo/fingerprint` never included them.)

## Fix

1. **Key on true inputs.** Hash only the `apps/mobile` importer block of `pnpm-lock.yaml`. The block pins the full resolved versions of every direct dependency, which is exactly what autolinking can see. A missing block falls back to the whole file. Pin `ios/**`/`android/**` out of the fingerprint so no future `@expo/fingerprint` version can key builds on generated output.
2. **Offload the build to CI.** New `mobile-native-build.yml` builds the debug dev-client and uploads it as an artifact named `mobile-native-<platform>-<nativeHash>`. It runs on main pushes that can change native inputs and on `workflow_dispatch` for any pushed branch. A gate job skips platforms whose artifact already exists; the iOS job fails if the hash differs between Linux and macOS (a divergence would publish artifacts nobody can find).
3. **Fetch before compiling.** On a local cache miss, `dev:mobile:{ios,android} build` now downloads that artifact — and dispatches a run for the current pushed branch when none exists — before compiling locally. The fetched binary passes the existing publish pipeline unchanged: bundle-id/package-id check, checksum, manifest, atomic rename. Any remote failure falls back to today's local build. `KILO_REMOTE_NATIVE=off` disables it.

## Why this matters

A native build is the expensive part of an e2e slot; installing a cached binary is cheap. With stable keys plus CI-built artifacts, agent hosts stop paying local xcodebuild/gradle for unchanged native inputs, which frees CPU for more concurrent e2e slots.

## Tests

- `pnpm run test:mobile-workflow` — 104 pass (new: remote-fetch publish path, remote-miss fallback, lockfile-slice keying).
- Hash stability proven empirically: web-only lockfile changes no longer re-key; `apps/mobile` importer changes do.
- `dev/local/tmux.test.ts` has one pre-existing failure on this host on clean `origin/main` (timing-sensitive; unrelated).