### PR TITLE
feat(mobile): add account-owned local access state

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches: [main]
   pull_request:
-    branches: [main]
 
 # Cancel in-progress runs when a new commit is pushed to the same PR
 concurrency:
@@ -41,6 +40,9 @@ jobs:
 
       - name: Install root dependencies
         run: pnpm --filter kilocode-monorepo install --frozen-lockfile --ignore-scripts
+
+      - name: Check stacked CI admission
+        run: node --test scripts/stacked-ci.test.mjs
 
       - name: Test dependency change detection
         run: node --test scripts/changed-dependencies.test.mjs

--- a/.github/workflows/kilo-app-ci.yml
+++ b/.github/workflows/kilo-app-ci.yml
@@ -15,8 +15,9 @@ on:
       - 'packages/cloud-agent-sdk/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/kilo-app-ci.yml'
+      - '.github/workflows/ci.yml'
+      - 'scripts/stacked-ci.test.mjs'
   pull_request:
-    branches: [main]
     paths:
       - 'apps/mobile/**'
       - 'packages/trpc/**'
@@ -29,6 +30,8 @@ on:
       - 'packages/cloud-agent-sdk/**'
       - 'pnpm-lock.yaml'
       - '.github/workflows/kilo-app-ci.yml'
+      - '.github/workflows/ci.yml'
+      - 'scripts/stacked-ci.test.mjs'
   workflow_call:
 
 concurrency:
@@ -193,6 +196,9 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
+
+      - name: Check stacked CI admission
+        run: node --test scripts/stacked-ci.test.mjs
 
       - name: Build trpc types
         run: pnpm --filter @kilocode/trpc run build

--- a/apps/mobile/app.config.ts
+++ b/apps/mobile/app.config.ts
@@ -180,6 +180,12 @@ const config: ExpoConfig = {
     'expo-image',
     'expo-font',
     'expo-secure-store',
+    [
+      'expo-local-authentication',
+      {
+        faceIDPermission: 'Allow Kilo to use Face ID to unlock this account on this device.',
+      },
+    ],
     'expo-sharing',
     // Encrypts the local persistence database (kilo-persist.db) with SQLCipher.
     // The key is generated from expo-crypto and held in SecureStore; see

--- a/apps/mobile/package.json
+++ b/apps/mobile/package.json
@@ -77,6 +77,7 @@
     "expo-keep-awake": "~57.0.1",
     "expo-linear-gradient": "~57.0.1",
     "expo-linking": "57.0.5",
+    "expo-local-authentication": "~57.0.2",
     "expo-localization": "~57.0.1",
     "expo-location": "~57.0.7",
     "expo-notifications": "~57.0.8",

--- a/apps/mobile/src/lib/local-access-storage.test.ts
+++ b/apps/mobile/src/lib/local-access-storage.test.ts
@@ -1,0 +1,167 @@
+import { describe, expect, it, vi } from 'vitest';
+import { type SecureStoreOptions } from 'expo-secure-store';
+
+import { createLocalAccessStorage, localAccessStorageKey } from './local-access-storage';
+import { AUTH_TOKEN_KEY, REFRESH_TOKEN_KEY, TOKEN_EXPIRES_AT_KEY } from './storage-keys';
+
+vi.mock('expo-secure-store', () => ({ WHEN_UNLOCKED_THIS_DEVICE_ONLY: 6 }));
+
+function memoryStore() {
+  const bytes = new Map<string, string>();
+  const store = {
+    getItemAsync: vi.fn(async (key: string, options?: SecureStoreOptions) => {
+      if (options?.requireAuthentication) {
+        throw new Error('Unexpected biometric read');
+      }
+      const result = await Promise.resolve(bytes.get(key) ?? null);
+      return result;
+    }),
+    setItemAsync: vi.fn(async (key: string, value: string, options?: SecureStoreOptions) => {
+      if (options?.requireAuthentication) {
+        throw new Error('Unexpected biometric record');
+      }
+      await Promise.resolve();
+      bytes.set(key, value);
+    }),
+  };
+  return { bytes, store, storage: createLocalAccessStorage(store) };
+}
+
+describe('account-owned security records', () => {
+  it.each([
+    [null, { status: 'absent' }],
+    ['{"version":1,"enabled":true}', { status: 'present', enabled: true }],
+    ['{"version":1,"enabled":false}', { status: 'present', enabled: false }],
+  ] as const)('reads confirmed state %s', async (value, expected) => {
+    const { bytes, storage } = memoryStore();
+    if (value !== null) {
+      bytes.set(localAccessStorageKey('A'), value);
+    }
+    expect(await storage.read('A')).toEqual(expected);
+  });
+
+  it.each([
+    '',
+    '{',
+    'null',
+    'false',
+    '42',
+    '[]',
+    '{}',
+    '{"version":0,"enabled":true}',
+    '{"version":2,"enabled":false}',
+    '{"version":"1","enabled":true}',
+    '{"enabled":true}',
+    '{"version":1}',
+    '{"version":1,"enabled":"false"}',
+    '{"version":1,"enabled":null}',
+    '{"version":1,"enabled":false,"extra":true}',
+  ])('protects malformed bytes without replacing them: %s', async value => {
+    const { bytes, storage } = memoryStore();
+    bytes.set(localAccessStorageKey('A'), value);
+    expect(await storage.read('A')).toEqual({ status: 'malformed' });
+    expect(bytes.get(localAccessStorageKey('A'))).toBe(value);
+  });
+
+  it('distinguishes failed reads and permits a nondestructive retry', async () => {
+    const { bytes, store, storage } = memoryStore();
+    bytes.set(localAccessStorageKey('A'), '{"version":1,"enabled":true}');
+    store.getItemAsync.mockRejectedValueOnce(new Error('Storage unavailable'));
+    expect(await storage.read('A')).toEqual({ status: 'failed' });
+    expect(await storage.read('A')).toEqual({ status: 'present', enabled: true });
+  });
+
+  it('isolates arbitrary account IDs and leaves existing credentials unchanged', async () => {
+    const { bytes, storage } = memoryStore();
+    const credentials = new Map([
+      [AUTH_TOKEN_KEY, 'bearer'],
+      [REFRESH_TOKEN_KEY, 'refresh'],
+      [TOKEN_EXPIRES_AT_KEY, '123'],
+    ]);
+    for (const [key, value] of credentials) {
+      bytes.set(key, value);
+    }
+    const users = ['a:b', 'a_b', 'a.b', 'a/b', 'a%2Fb', 'å', 'a', '61'];
+    const writes = await Promise.all(
+      users.map(async (user, index) => {
+        const result = await storage.write(user, index % 2 === 0, () => true);
+        return result;
+      })
+    );
+    expect(writes).toEqual(users.map(() => 'committed'));
+    const restored = await Promise.all(
+      users.map(async user => {
+        const result = await storage.read(user);
+        return result;
+      })
+    );
+    for (const [index, record] of restored.entries()) {
+      expect(record).toEqual({ status: 'present', enabled: index % 2 === 0 });
+    }
+    for (const [key, value] of credentials) {
+      expect(bytes.get(key)).toBe(value);
+    }
+    expect(bytes.size).toBe(users.length + credentials.size);
+  });
+
+  it('returns failed writes and preserves the last stored value', async () => {
+    const { store, storage } = memoryStore();
+    await storage.write('A', true, () => true);
+    store.setItemAsync.mockRejectedValueOnce(new Error('Write failed'));
+    expect(await storage.write('A', false, () => true)).toBe('failed');
+    expect(await storage.read('A')).toEqual({ status: 'present', enabled: true });
+    expect(await storage.write('A', false, () => true)).toBe('committed');
+    expect(await storage.read('A')).toEqual({ status: 'present', enabled: false });
+  });
+
+  it('serializes an account and skips a stale queued write without claiming commit', async () => {
+    const { bytes, store, storage } = memoryStore();
+    const release = Promise.withResolvers<undefined>();
+    store.setItemAsync.mockImplementationOnce(async (key, value) => {
+      await release.promise;
+      bytes.set(key, value);
+    });
+    const first = storage.write('A', true, () => true);
+    let current = true;
+    const second = storage.write('A', false, () => current);
+    current = false;
+    release.resolve(undefined);
+    expect(await first).toBe('committed');
+    expect(await second).toBe('stale');
+    expect(await storage.read('A')).toEqual({ status: 'present', enabled: true });
+  });
+
+  it('reports an already-started stale write and never retargets it to another account', async () => {
+    const { bytes, store, storage } = memoryStore();
+    const release = Promise.withResolvers<undefined>();
+    store.setItemAsync.mockImplementationOnce(async (key, value) => {
+      await release.promise;
+      bytes.set(key, value);
+    });
+    let current = true;
+    const pending = storage.write('A', true, () => current);
+    current = false;
+    expect(await storage.write('B', false, () => true)).toBe('committed');
+    release.resolve(undefined);
+    expect(await pending).toBe('stale');
+    expect(await storage.read('A')).toEqual({ status: 'present', enabled: true });
+    expect(await storage.read('B')).toEqual({ status: 'present', enabled: false });
+  });
+
+  it('orders re-entry reads behind writes and commits later writes last', async () => {
+    const { bytes, store, storage } = memoryStore();
+    const release = Promise.withResolvers<undefined>();
+    store.setItemAsync.mockImplementationOnce(async (key, value) => {
+      await release.promise;
+      bytes.set(key, value);
+    });
+    const first = storage.write('A', true, () => true);
+    const read = storage.read('A');
+    const second = storage.write('A', false, () => true);
+    release.resolve(undefined);
+    expect(await first).toBe('committed');
+    expect(await read).toEqual({ status: 'present', enabled: true });
+    expect(await second).toBe('committed');
+    expect(await storage.read('A')).toEqual({ status: 'present', enabled: false });
+  });
+});

--- a/apps/mobile/src/lib/local-access-storage.ts
+++ b/apps/mobile/src/lib/local-access-storage.ts
@@ -1,0 +1,73 @@
+import * as SecureStore from 'expo-secure-store';
+import { z } from 'zod';
+
+import { chainSave } from '@/lib/hooks/save-chain';
+import { encodeStorageKey } from '@/lib/storage-keys';
+
+const recordSchema = z.strictObject({ version: z.literal(1), enabled: z.boolean() });
+
+export type LocalAccessReadResult =
+  | Readonly<{ status: 'present'; enabled: boolean }>
+  | Readonly<{ status: 'absent' | 'malformed' | 'failed' }>;
+export type LocalAccessWriteResult = 'committed' | 'failed' | 'stale';
+export type LocalAccessStorage = {
+  read: (userId: string) => Promise<LocalAccessReadResult>;
+  write: (
+    userId: string,
+    enabled: boolean,
+    isCurrent: () => boolean
+  ) => Promise<LocalAccessWriteResult>;
+};
+type SecurityStore = Pick<typeof SecureStore, 'getItemAsync' | 'setItemAsync'>;
+
+// Unlike account metadata, these keys survive logout. Credentials keep their existing keys/options.
+export function localAccessStorageKey(userId: string): string {
+  return encodeStorageKey('local-access-v1-', userId);
+}
+
+function parseRecord(bytes: string): LocalAccessReadResult {
+  try {
+    const parsed = recordSchema.safeParse(JSON.parse(bytes));
+    return parsed.success
+      ? { status: 'present', enabled: parsed.data.enabled }
+      : { status: 'malformed' };
+  } catch {
+    return { status: 'malformed' };
+  }
+}
+
+export function createLocalAccessStorage(store: SecurityStore = SecureStore): LocalAccessStorage {
+  const options = { keychainAccessible: SecureStore.WHEN_UNLOCKED_THIS_DEVICE_ONLY };
+  return {
+    read: async userId => {
+      const key = localAccessStorageKey(userId);
+      // Re-entry must wait for any already-started write for this account, not read its old bytes.
+      const result = await chainSave<LocalAccessReadResult>(key, async () => {
+        try {
+          const bytes = await store.getItemAsync(key, options);
+          return bytes === null ? { status: 'absent' } : parseRecord(bytes);
+        } catch {
+          return { status: 'failed' };
+        }
+      });
+      return result;
+    },
+    write: async (userId, enabled, isCurrent) => {
+      const key = localAccessStorageKey(userId);
+      const result = await chainSave<LocalAccessWriteResult>(key, async () => {
+        if (!isCurrent()) {
+          return 'stale';
+        }
+        try {
+          await store.setItemAsync(key, JSON.stringify({ version: 1, enabled }), options);
+          // A native write already in progress can commit to its original account. Never publish
+          // that completion as the current attempt's setting after its owner or generation changes.
+          return isCurrent() ? 'committed' : 'stale';
+        } catch {
+          return isCurrent() ? 'failed' : 'stale';
+        }
+      });
+      return result;
+    },
+  };
+}

--- a/apps/mobile/src/lib/local-access.test.ts
+++ b/apps/mobile/src/lib/local-access.test.ts
@@ -1,0 +1,953 @@
+/* eslint-disable max-lines -- the complete protected-state matrix shares one isolated process owner */
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { type AppStateStatus } from 'react-native';
+
+import {
+  assertLocalAccessLease,
+  assertLocalAccessOwner,
+  captureLocalAccessLease,
+  getLocalAccessSnapshot,
+  initializeLocalAccess,
+  LocalAccessDeniedError,
+  lockLocalAccess,
+  reloadLocalAccessPreference,
+  requestLocalAccess,
+  setLocalAccessContextReady,
+  setLocalAccessOwner,
+  subscribeLocalAccess,
+} from './local-access';
+import { type LocalAccessReadResult, type LocalAccessStorage } from './local-access-storage';
+import { type LocalAuthenticationOutcome } from './local-authentication';
+
+let stop: (() => void) | undefined = undefined;
+const absent: LocalAccessReadResult = { status: 'absent' };
+const releases: (() => void)[] = [];
+function deferred<T>(fallback: T) {
+  const pending = Promise.withResolvers<T>();
+  releases.push(() => {
+    pending.resolve(fallback);
+  });
+  return pending;
+}
+afterEach(async () => {
+  stop?.();
+  stop = undefined;
+  for (const release of releases.splice(0)) {
+    release();
+  }
+  await requestLocalAccess();
+  vi.useRealTimers();
+});
+
+function setup(initial: LocalAccessReadResult = absent, state: AppStateStatus = 'active') {
+  let now = 1000;
+  let appState = state;
+  const listeners = new Set<(state: AppStateStatus) => void>();
+  const records = new Map<string, LocalAccessReadResult>([['A', initial]]);
+  const storage = {
+    read: vi.fn<LocalAccessStorage['read']>(async userId => {
+      const result = await Promise.resolve(records.get(userId) ?? absent);
+      return result;
+    }),
+    write: vi.fn<LocalAccessStorage['write']>(async (userId, enabled, isCurrent) => {
+      await Promise.resolve();
+      if (!isCurrent()) {
+        return 'stale';
+      }
+      records.set(userId, { status: 'present', enabled });
+      return 'committed';
+    }),
+  };
+  const authenticate = vi
+    .fn<() => Promise<LocalAuthenticationOutcome>>()
+    .mockResolvedValue({ status: 'retryable', reason: 'user_cancel' });
+  stop = initializeLocalAccess({
+    storage,
+    authenticate,
+    now: () => now,
+    lifecycle: {
+      getCurrentState: () => appState,
+      subscribe: listener => {
+        listeners.add(listener);
+        return () => {
+          listeners.delete(listener);
+        };
+      },
+    },
+  });
+  return {
+    storage,
+    authenticate,
+    records,
+    setTime: (time: number) => {
+      now = time;
+    },
+    emit: (next: AppStateStatus) => {
+      appState = next;
+      for (const listener of listeners) {
+        listener(next);
+      }
+    },
+    queue: (next: AppStateStatus) => {
+      const queued = [...listeners];
+      return () => {
+        for (const listener of queued) {
+          listener(next);
+        }
+      };
+    },
+  };
+}
+async function bind(userId = 'A', epoch = 1) {
+  await setLocalAccessOwner(userId, epoch);
+  setLocalAccessContextReady(true);
+  await requestLocalAccess('unlock', true);
+}
+async function ready(enabled = true) {
+  const fixture = setup({ status: 'present', enabled });
+  fixture.authenticate.mockResolvedValue({ status: 'authenticated' });
+  await bind();
+  return fixture;
+}
+const scope = { userId: 'A', organizationId: null } as const;
+
+function expectDenied() {
+  expect(() => captureLocalAccessLease(scope)).toThrow(LocalAccessDeniedError);
+}
+
+describe('initialization and security restoration', () => {
+  it('denies absent services, unresolved owners, and unresolved context', async () => {
+    expectDenied();
+    setup();
+    setLocalAccessContextReady(true);
+    expectDenied();
+    await setLocalAccessOwner('A', 1);
+    expectDenied();
+    setLocalAccessContextReady(true);
+    expect(() => captureLocalAccessLease(scope)).not.toThrow();
+  });
+
+  it.each([
+    [{ status: 'absent' }, false, true],
+    [{ status: 'present', enabled: false }, false, true],
+    [{ status: 'present', enabled: true }, true, false],
+    [{ status: 'malformed' }, null, false],
+    [{ status: 'failed' }, null, false],
+  ] satisfies [LocalAccessReadResult, boolean | null, boolean][])(
+    'separates loading from restored %j',
+    async (record, enabled, unlocked) => {
+      const fixture = setup(record);
+      const read = deferred<LocalAccessReadResult>({ status: 'failed' });
+      fixture.storage.read.mockReturnValueOnce(read.promise);
+      const loading = setLocalAccessOwner('A', 1);
+      setLocalAccessContextReady(true);
+      expect(getLocalAccessSnapshot()).toMatchObject({
+        preference: 'loading',
+        enabled: null,
+        unlocked: false,
+      });
+      expectDenied();
+      read.resolve(record);
+      await loading;
+      await requestLocalAccess('unlock', true);
+      expect(getLocalAccessSnapshot()).toMatchObject({
+        preference: record.status,
+        enabled,
+        unlocked,
+      });
+      if (unlocked) {
+        expect(getLocalAccessSnapshot().recovery).toBeNull();
+      } else {
+        expectDenied();
+      }
+    }
+  );
+
+  it('retries failed reads without treating them as malformed or disabled', async () => {
+    const fixture = setup({ status: 'present', enabled: true });
+    fixture.storage.read.mockRejectedValueOnce(new Error('Read failed'));
+    await bind();
+    expect(getLocalAccessSnapshot()).toMatchObject({
+      preference: 'failed',
+      recovery: { status: 'retryable', reason: 'read_failed' },
+    });
+    expect(await requestLocalAccess('repair')).toBe('denied');
+    expect(await requestLocalAccess('disable')).toBe('denied');
+    await reloadLocalAccessPreference();
+    await requestLocalAccess('unlock', true);
+    expect(getLocalAccessSnapshot()).toMatchObject({ enabled: true, unlocked: false });
+    expect(fixture.records.get('A')).toEqual({ status: 'present', enabled: true });
+  });
+
+  it('fences a delayed A read after direct replacement by B', async () => {
+    const fixture = setup();
+    const read = deferred<LocalAccessReadResult>({ status: 'failed' });
+    fixture.storage.read.mockReturnValueOnce(read.promise);
+    const oldRead = setLocalAccessOwner('A', 1);
+    await bind('B', 2);
+    read.resolve({ status: 'present', enabled: true });
+    await oldRead;
+    expect(getLocalAccessSnapshot()).toMatchObject({
+      userId: 'B',
+      authEpoch: 2,
+      preference: 'absent',
+      enabled: false,
+      unlocked: true,
+    });
+    expectDenied();
+  });
+
+  it('keeps enabled security across logout and same-account re-entry', async () => {
+    const fixture = await ready();
+    const oldLease = captureLocalAccessLease(scope);
+    await setLocalAccessOwner(null, 2);
+    expectDenied();
+    await bind('B', 3);
+    expect(getLocalAccessSnapshot()).toMatchObject({ userId: 'B', enabled: false, unlocked: true });
+    fixture.authenticate.mockResolvedValue({ status: 'retryable', reason: 'user_cancel' });
+    await bind('A', 4);
+    expect(getLocalAccessSnapshot()).toMatchObject({ userId: 'A', enabled: true, unlocked: false });
+    expect(fixture.records.get('A')).toEqual({ status: 'present', enabled: true });
+    expect(() => {
+      assertLocalAccessLease(oldLease);
+    }).toThrow(LocalAccessDeniedError);
+  });
+
+  it('never carries an unlock grant into a fresh process owner', async () => {
+    await ready();
+    const oldLease = captureLocalAccessLease(scope);
+    stop?.();
+    setup({ status: 'present', enabled: true });
+    await bind();
+    expect(getLocalAccessSnapshot().unlocked).toBe(false);
+    expect(() => {
+      assertLocalAccessOwner(oldLease);
+    }).toThrow(LocalAccessDeniedError);
+  });
+
+  it('keeps immutable snapshots and removes subscriptions on cleanup', async () => {
+    const fixture = await ready(false);
+    const observed: boolean[] = [];
+    const unsubscribe = subscribeLocalAccess(() => {
+      observed.push(getLocalAccessSnapshot().foregroundReady);
+    });
+    const previous = getLocalAccessSnapshot();
+    fixture.emit('inactive');
+    expect(previous.foregroundReady).toBe(true);
+    expect(getLocalAccessSnapshot().foregroundReady).toBe(false);
+    expect(() => Object.assign(previous, { unlocked: false })).toThrow(TypeError);
+    unsubscribe();
+    fixture.emit('active');
+    expect(observed).toEqual([false]);
+    stop?.();
+    const disposed = getLocalAccessSnapshot();
+    fixture.emit('background');
+    expect(getLocalAccessSnapshot()).toBe(disposed);
+    expectDenied();
+  });
+});
+
+describe('authenticated setting changes and repair', () => {
+  it.each([false, true])('authenticates and commits before changing enabled=%s', async enabled => {
+    const fixture = await ready(enabled);
+    const prompt = deferred<LocalAuthenticationOutcome>({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    const write = deferred<'committed' | 'failed'>('failed');
+    const writing = deferred<undefined>(undefined);
+    fixture.authenticate.mockReturnValue(prompt.promise);
+    fixture.storage.write.mockImplementationOnce(async (userId, value) => {
+      writing.resolve(undefined);
+      const result = await write.promise;
+      if (result === 'committed') {
+        fixture.records.set(userId, { status: 'present', enabled: value });
+      }
+      return result;
+    });
+    const change = requestLocalAccess(enabled ? 'disable' : 'enable');
+    expect(getLocalAccessSnapshot()).toMatchObject({ enabled, operation: 'authenticating' });
+    expect(await requestLocalAccess('enable')).toBe('busy');
+    prompt.resolve({ status: 'authenticated' });
+    await writing.promise;
+    expect(getLocalAccessSnapshot()).toMatchObject({ enabled, operation: 'writing' });
+    expect(fixture.records.get('A')).toEqual({ status: 'present', enabled });
+    expect(await requestLocalAccess('disable')).toBe('busy');
+    write.resolve('committed');
+    expect(await change).toBe('committed');
+    expect(getLocalAccessSnapshot()).toMatchObject({
+      enabled: !enabled,
+      operation: 'idle',
+      unlocked: true,
+    });
+    expect(fixture.records.get('A')).toEqual({ status: 'present', enabled: !enabled });
+  });
+
+  it.each([
+    { status: 'retryable', reason: 'user_cancel' },
+    { status: 'retryable', reason: 'system_cancel' },
+    { status: 'retryable', reason: 'lockout' },
+    { status: 'retryable', reason: 'rejected' },
+    { status: 'unavailable', reason: 'not_enrolled' },
+    { status: 'unavailable', reason: 'passcode_not_set' },
+    { status: 'terminal', reason: 'invalid_context' },
+    { status: 'terminal', reason: 'missing_usage_description' },
+  ] satisfies LocalAuthenticationOutcome[])('preserves both prior values on %j', async outcome => {
+    const fixture = await ready(false);
+    fixture.authenticate.mockResolvedValue(outcome);
+    expect(await requestLocalAccess('enable')).toEqual(outcome);
+    expect(getLocalAccessSnapshot()).toMatchObject({ enabled: false, recovery: outcome });
+    fixture.records.set('A', { status: 'present', enabled: true });
+    await setLocalAccessOwner('A', 2);
+    await requestLocalAccess('unlock', true);
+    expect(await requestLocalAccess('disable')).toEqual(outcome);
+    expect(getLocalAccessSnapshot()).toMatchObject({
+      enabled: true,
+      unlocked: false,
+      recovery: outcome,
+    });
+    expect(fixture.records.get('A')).toEqual({ status: 'present', enabled: true });
+    expectDenied();
+  });
+
+  it.each([
+    [false, 'failed'],
+    [false, 'stale'],
+    [false, 'rejected'],
+    [true, 'failed'],
+    [true, 'stale'],
+    [true, 'rejected'],
+  ] as const)('preserves enabled=%s on a %s write', async (enabled, outcome) => {
+    const fixture = await ready(enabled);
+    if (outcome === 'rejected') {
+      fixture.storage.write.mockRejectedValueOnce(new Error('Write failed'));
+    } else {
+      fixture.storage.write.mockResolvedValueOnce(outcome);
+    }
+    expect(await requestLocalAccess(enabled ? 'disable' : 'enable')).toBe(
+      outcome === 'rejected' ? 'failed' : outcome
+    );
+    expect(getLocalAccessSnapshot()).toMatchObject({
+      enabled,
+      recovery: { status: 'retryable', reason: 'write_failed' },
+    });
+    expect(fixture.records.get('A')).toEqual({ status: 'present', enabled });
+  });
+
+  it('protects adapter promise rejection and never writes the setting', async () => {
+    const fixture = await ready(false);
+    fixture.authenticate.mockRejectedValueOnce(new Error('Adapter failed'));
+    expect(await requestLocalAccess('enable')).toEqual({ status: 'retryable', reason: 'rejected' });
+    expect(getLocalAccessSnapshot().enabled).toBe(false);
+    expect(fixture.records.get('A')).toEqual({ status: 'present', enabled: false });
+  });
+
+  it('fences native success after account replacement and requires a new attempt', async () => {
+    const fixture = setup({ status: 'present', enabled: true });
+    fixture.records.set('B', { status: 'present', enabled: true });
+    const prompt = deferred<LocalAuthenticationOutcome>({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    fixture.authenticate.mockReturnValueOnce(prompt.promise);
+    await setLocalAccessOwner('A', 1);
+    const old = requestLocalAccess();
+    await setLocalAccessOwner('B', 2);
+    setLocalAccessContextReady(true);
+    prompt.resolve({ status: 'authenticated' });
+    expect(await old).toBe('stale');
+    expect(getLocalAccessSnapshot()).toMatchObject({ userId: 'B', enabled: true, unlocked: false });
+    fixture.authenticate.mockResolvedValue({ status: 'authenticated' });
+    expect(await requestLocalAccess()).toBe('unlocked');
+    expect(captureLocalAccessLease({ userId: 'B', organizationId: null }).userId).toBe('B');
+  });
+
+  it.each([
+    ['enable', 'account'],
+    ['disable', 'account'],
+    ['repair', 'account'],
+    ['enable', 'lock'],
+    ['disable', 'lock'],
+    ['repair', 'lock'],
+  ] as const)(
+    'never publishes a delayed %s write after %s invalidation',
+    async (action, invalidation) => {
+      const prior: LocalAccessReadResult =
+        action === 'repair'
+          ? { status: 'malformed' }
+          : { status: 'present', enabled: action === 'disable' };
+      const fixture = setup(prior);
+      fixture.authenticate.mockResolvedValue({ status: 'authenticated' });
+      fixture.records.set('B', { status: 'present', enabled: true });
+      await bind();
+      const writing = deferred<undefined>(undefined);
+      const write = deferred<'committed' | 'failed'>('failed');
+      fixture.storage.write.mockImplementationOnce(async (userId, enabled) => {
+        writing.resolve(undefined);
+        const result = await write.promise;
+        fixture.records.set(userId, { status: 'present', enabled });
+        return result;
+      });
+      const old = requestLocalAccess(action);
+      await writing.promise;
+      if (invalidation === 'account') {
+        await setLocalAccessOwner('B', 2);
+      } else {
+        lockLocalAccess();
+      }
+      const protectedSnapshot = getLocalAccessSnapshot();
+      write.resolve('committed');
+      expect(await old).toBe('stale');
+      expect(getLocalAccessSnapshot()).toMatchObject({
+        userId: protectedSnapshot.userId,
+        enabled: protectedSnapshot.enabled,
+        preference: protectedSnapshot.preference,
+        unlocked: protectedSnapshot.unlocked,
+      });
+      expect(fixture.records.get('B')).toEqual({ status: 'present', enabled: true });
+    }
+  );
+
+  it.each(['committed', 'failed', 'stale'] as const)(
+    'repairs malformed security only after an enabled write: %s',
+    async outcome => {
+      const fixture = setup({ status: 'malformed' });
+      fixture.authenticate.mockResolvedValue({ status: 'authenticated' });
+      await bind();
+      expect(getLocalAccessSnapshot()).toMatchObject({
+        recovery: { status: 'repair', reason: 'malformed' },
+        unlocked: false,
+      });
+      expect(await requestLocalAccess('disable')).toBe('denied');
+      const writing = deferred<undefined>(undefined);
+      const write = deferred<typeof outcome>(outcome);
+      fixture.storage.write.mockImplementationOnce(async (userId, enabled) => {
+        writing.resolve(undefined);
+        const result = await write.promise;
+        if (result === 'committed') {
+          fixture.records.set(userId, { status: 'present', enabled });
+        }
+        return result;
+      });
+      const repair = requestLocalAccess('repair');
+      await writing.promise;
+      expect(getLocalAccessSnapshot()).toMatchObject({
+        preference: 'malformed',
+        enabled: null,
+        unlocked: false,
+      });
+      write.resolve(outcome);
+      expect(await repair).toBe(outcome);
+      expect(getLocalAccessSnapshot()).toMatchObject(
+        outcome === 'committed'
+          ? { preference: 'present', enabled: true, unlocked: true }
+          : { preference: 'malformed', enabled: null, unlocked: false }
+      );
+      expect(fixture.records.get('A')).toEqual(
+        outcome === 'committed' ? { status: 'present', enabled: true } : { status: 'malformed' }
+      );
+    }
+  );
+
+  it('cannot repair malformed security after cancelled authentication', async () => {
+    const fixture = setup({ status: 'malformed' });
+    await bind();
+    expect(await requestLocalAccess('repair')).toEqual({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    expect(getLocalAccessSnapshot()).toMatchObject({ enabled: null, unlocked: false });
+    expect(fixture.records.get('A')).toEqual({ status: 'malformed' });
+  });
+});
+
+describe.each([
+  ['repair', { status: 'malformed' }, { enabled: null, nextEnabled: true }],
+  ['enable', { status: 'present', enabled: false }, { enabled: false, nextEnabled: true }],
+  ['disable', { status: 'present', enabled: true }, { enabled: true, nextEnabled: false }],
+] as const)('pending %s authentication', (action, prior, { enabled, nextEnabled }) => {
+  it.each([
+    [1000, 300_999, { expected: 'committed', reason: null }],
+    [1000, 301_000, { expected: 'stale', reason: null }],
+    [1000, 301_001, { expected: 'stale', reason: null }],
+    [1000, 999, { expected: 'stale', reason: 'invalid_clock' }],
+    [1000, Number.NaN, { expected: 'stale', reason: 'invalid_clock' }],
+    [1000, Infinity, { expected: 'stale', reason: 'invalid_clock' }],
+    [1000, -Infinity, { expected: 'stale', reason: 'invalid_clock' }],
+    [Number.NaN, 1000, { expected: 'stale', reason: 'invalid_clock' }],
+    [Infinity, Infinity, { expected: 'stale', reason: 'invalid_clock' }],
+  ] as const)(
+    'fences delayed persistence across background time %s to %s',
+    async (start, end, { expected, reason }) => {
+      const fixture = setup(prior);
+      fixture.authenticate.mockResolvedValue({ status: 'authenticated' });
+      await bind();
+      const lease = enabled === null ? null : captureLocalAccessLease(scope);
+      const writing = deferred<undefined>(undefined);
+      const write = deferred<'committed' | 'failed'>('failed');
+      fixture.storage.write.mockImplementationOnce(async (userId, value) => {
+        writing.resolve(undefined);
+        const result = await write.promise;
+        if (result === 'committed') {
+          fixture.records.set(userId, { status: 'present', enabled: value });
+        }
+        return result;
+      });
+      const pending = requestLocalAccess(action);
+      await writing.promise;
+      fixture.setTime(start);
+      fixture.emit('background');
+      fixture.setTime(end);
+      const published: (boolean | null)[] = [];
+      const unsubscribe = subscribeLocalAccess(() => {
+        published.push(getLocalAccessSnapshot().enabled);
+      });
+      try {
+        fixture.emit('active');
+        write.resolve('committed');
+        expect(await pending).toBe(expected);
+        expect(fixture.records.get('A')).toEqual({ status: 'present', enabled: nextEnabled });
+        expect(getLocalAccessSnapshot().recovery).toEqual(
+          reason ? { status: 'retryable', reason } : null
+        );
+        if (expected === 'committed') {
+          expect(getLocalAccessSnapshot()).toMatchObject({ enabled: nextEnabled, unlocked: true });
+          if (lease) {
+            expect(() => {
+              assertLocalAccessLease(lease);
+            }).not.toThrow();
+          }
+          return;
+        }
+        expect(published).not.toContain(nextEnabled);
+        expect(getLocalAccessSnapshot()).toMatchObject({
+          preference: prior.status,
+          enabled,
+          operation: 'idle',
+        });
+        if (enabled !== false) {
+          expectDenied();
+        }
+        if (lease) {
+          expect(() => {
+            assertLocalAccessLease(lease);
+          }).toThrow(LocalAccessDeniedError);
+        }
+
+        const cancelled = { status: 'retryable', reason: 'user_cancel' } as const;
+        fixture.authenticate.mockResolvedValueOnce(cancelled);
+        expect(await requestLocalAccess(action)).toEqual(cancelled);
+        expect(getLocalAccessSnapshot().enabled).toBe(enabled);
+        fixture.emit('inactive');
+        fixture.emit('active');
+        expect(await requestLocalAccess('unlock', true)).toBe('denied');
+        expect(await requestLocalAccess(action)).toBe('committed');
+        expect(getLocalAccessSnapshot()).toMatchObject({ enabled: nextEnabled, unlocked: true });
+        expect(() => captureLocalAccessLease(scope)).not.toThrow();
+        if (lease) {
+          expect(() => {
+            assertLocalAccessLease(lease);
+          }).toThrow(LocalAccessDeniedError);
+        }
+      } finally {
+        unsubscribe();
+      }
+    }
+  );
+
+  it.each([301_000, Number.NaN])('fences a native result after background time %s', async end => {
+    const fixture = setup(prior);
+    fixture.authenticate.mockResolvedValue({ status: 'authenticated' });
+    await bind();
+    const prompt = deferred<LocalAuthenticationOutcome>({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    fixture.authenticate.mockReturnValueOnce(prompt.promise);
+    const pending = requestLocalAccess(action);
+    await Promise.resolve();
+    fixture.emit('background');
+    fixture.setTime(end);
+    fixture.emit('active');
+    prompt.resolve({ status: 'authenticated' });
+    expect(await pending).toBe('stale');
+    expect(fixture.records.get('A')).toEqual(prior);
+    expect(getLocalAccessSnapshot()).toMatchObject({ preference: prior.status, enabled });
+  });
+
+  it('holds inactive-only success until foreground without expiring it', async () => {
+    const fixture = setup(prior);
+    fixture.authenticate.mockResolvedValue({ status: 'authenticated' });
+    await bind();
+    const prompt = deferred<LocalAuthenticationOutcome>({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    fixture.authenticate.mockReturnValueOnce(prompt.promise);
+    const pending = requestLocalAccess(action);
+    await Promise.resolve();
+    fixture.emit('inactive');
+    fixture.setTime(900_000);
+    prompt.resolve({ status: 'authenticated' });
+    expect(await pending).toBe('committed');
+    expect(getLocalAccessSnapshot()).toMatchObject({
+      enabled: nextEnabled,
+      foregroundReady: false,
+      unlocked: false,
+    });
+    expectDenied();
+    fixture.emit('active');
+    expect(getLocalAccessSnapshot().unlocked).toBe(true);
+    expect(() => captureLocalAccessLease(scope)).not.toThrow();
+  });
+});
+
+describe('lifecycle and attempt fencing', () => {
+  it.each([299_999, 300_000, 300_001, -1, Number.NaN, Infinity, -Infinity])(
+    'preserves idle disabled-account access across %sms in background',
+    async elapsed => {
+      const fixture = await ready(false);
+      const lease = captureLocalAccessLease(scope);
+      fixture.emit('background');
+      fixture.setTime(1000 + elapsed);
+      fixture.emit('active');
+      expect(getLocalAccessSnapshot()).toMatchObject({
+        enabled: false,
+        unlocked: true,
+        operation: 'idle',
+        recovery: null,
+      });
+      expect(() => {
+        assertLocalAccessLease(lease);
+      }).not.toThrow();
+    }
+  );
+
+  it.each([
+    [299_999, true],
+    [300_000, false],
+    [300_001, false],
+  ] as const)('evaluates %sms before publishing foreground access', async (elapsed, preserved) => {
+    const fixture = await ready();
+    const lease = captureLocalAccessLease(scope);
+    const prompt = deferred<LocalAuthenticationOutcome>({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    fixture.authenticate.mockReturnValue(prompt.promise);
+    fixture.emit('background');
+    expectDenied();
+    fixture.setTime(1000 + elapsed);
+    const exposures: boolean[] = [];
+    const unsubscribe = subscribeLocalAccess(() => {
+      exposures.push(getLocalAccessSnapshot().unlocked);
+    });
+    fixture.emit('active');
+    expect(getLocalAccessSnapshot().unlocked).toBe(preserved);
+    expect(exposures.some(Boolean)).toBe(preserved);
+    unsubscribe();
+    if (preserved) {
+      expect(() => {
+        assertLocalAccessLease(lease);
+      }).not.toThrow();
+    } else {
+      const pending = requestLocalAccess();
+      prompt.resolve({ status: 'retryable', reason: 'user_cancel' });
+      await pending;
+      expect(() => {
+        assertLocalAccessLease(lease);
+      }).toThrow(LocalAccessDeniedError);
+    }
+  });
+
+  it('retains the earliest background entry across repeated background and inactive events', async () => {
+    const fixture = await ready();
+    fixture.authenticate.mockResolvedValue({ status: 'retryable', reason: 'user_cancel' });
+    fixture.emit('background');
+    fixture.setTime(200_000);
+    fixture.emit('inactive');
+    fixture.emit('background');
+    fixture.setTime(301_000);
+    fixture.emit('active');
+    await requestLocalAccess('unlock', true);
+    expectDenied();
+    expect(getLocalAccessSnapshot().unlocked).toBe(false);
+  });
+
+  it.each([
+    [1000, 999],
+    [1000, Number.NaN],
+    [1000, Infinity],
+    [1000, -Infinity],
+    [Number.NaN, 1000],
+    [Infinity, Infinity],
+  ] as const)('protects invalid elapsed time from %s to %s', async (start, end) => {
+    const fixture = await ready();
+    fixture.authenticate.mockResolvedValue({ status: 'retryable', reason: 'user_cancel' });
+    fixture.setTime(start);
+    fixture.emit('background');
+    fixture.setTime(end);
+    fixture.emit('active');
+    await requestLocalAccess('unlock', true);
+    expect(getLocalAccessSnapshot().unlocked).toBe(false);
+    expectDenied();
+  });
+
+  it('does not start a deadline for inactive-only transitions', async () => {
+    const fixture = await ready();
+    const lease = captureLocalAccessLease(scope);
+    fixture.emit('inactive');
+    expect(() => {
+      assertLocalAccessLease(lease);
+    }).toThrow(LocalAccessDeniedError);
+    fixture.setTime(900_000);
+    fixture.emit('active');
+    expect(getLocalAccessSnapshot().unlocked).toBe(true);
+    expect(() => {
+      assertLocalAccessLease(lease);
+    }).not.toThrow();
+  });
+
+  it.each(['inactive', 'background'] as const)(
+    'starts protected while the process is %s',
+    async state => {
+      const fixture = setup({ status: 'present', enabled: true }, state);
+      await bind();
+      expectDenied();
+      fixture.emit('active');
+      await requestLocalAccess('unlock', true);
+      expect(getLocalAccessSnapshot().unlocked).toBe(false);
+    }
+  );
+
+  it('uses no suspended timer', async () => {
+    vi.useFakeTimers();
+    const fixture = await ready();
+    fixture.emit('background');
+    expect(vi.getTimerCount()).toBe(0);
+    vi.advanceTimersByTime(300_001);
+    expect(getLocalAccessSnapshot()).toMatchObject({ foregroundReady: false, operation: 'idle' });
+  });
+
+  it('holds inactive success until foreground and coalesces prompt-related active events', async () => {
+    const fixture = setup({ status: 'present', enabled: true });
+    const prompt = deferred<LocalAuthenticationOutcome>({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    fixture.authenticate.mockReturnValue(prompt.promise);
+    await setLocalAccessOwner('A', 1);
+    setLocalAccessContextReady(true);
+    const first = requestLocalAccess();
+    fixture.emit('inactive');
+    fixture.emit('active');
+    const coalesced = requestLocalAccess('unlock', true);
+    fixture.emit('inactive');
+    fixture.setTime(900_000);
+    prompt.resolve({ status: 'authenticated' });
+    expect(await first).toBe('pending-foreground');
+    expect(await coalesced).toBe('pending-foreground');
+    expect(getLocalAccessSnapshot().unlocked).toBe(false);
+    fixture.emit('active');
+    expect(getLocalAccessSnapshot().unlocked).toBe(true);
+  });
+
+  it('requires explicit Retry after cancellation even after long background events', async () => {
+    const fixture = setup({ status: 'present', enabled: true });
+    await bind();
+    fixture.authenticate.mockResolvedValue({ status: 'authenticated' });
+    fixture.emit('inactive');
+    fixture.emit('active');
+    fixture.emit('background');
+    fixture.setTime(301_000);
+    fixture.emit('active');
+    expect(await requestLocalAccess('unlock', true)).toBe('denied');
+    expect(getLocalAccessSnapshot().unlocked).toBe(false);
+    expect(await requestLocalAccess()).toBe('unlocked');
+  });
+
+  it('rejects old-attempt success after locking and permits only a later attempt', async () => {
+    const fixture = await ready();
+    lockLocalAccess();
+    const prompt = deferred<LocalAuthenticationOutcome>({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    fixture.authenticate.mockReturnValueOnce(prompt.promise);
+    const old = requestLocalAccess();
+    await Promise.resolve();
+    lockLocalAccess();
+    prompt.resolve({ status: 'authenticated' });
+    expect(await old).toBe('stale');
+    expect(getLocalAccessSnapshot().unlocked).toBe(false);
+    expect(await requestLocalAccess()).toBe('unlocked');
+  });
+
+  it('invalidates pending authentication when security restoration restarts', async () => {
+    const fixture = await ready();
+    lockLocalAccess();
+    const prompt = deferred<LocalAuthenticationOutcome>({
+      status: 'retryable',
+      reason: 'user_cancel',
+    });
+    fixture.authenticate.mockReturnValueOnce(prompt.promise);
+    const old = requestLocalAccess();
+    await Promise.resolve();
+    fixture.records.set('A', { status: 'malformed' });
+    await reloadLocalAccessPreference();
+    prompt.resolve({ status: 'authenticated' });
+    expect(await old).toBe('stale');
+    expect(getLocalAccessSnapshot()).toMatchObject({ preference: 'malformed', unlocked: false });
+  });
+  it.each(['account', 'lock', 'expired'] as const)(
+    'rejects inactive success after %s invalidation',
+    async invalidation => {
+      const fixture = setup({ status: 'present', enabled: true });
+      fixture.records.set('B', { status: 'present', enabled: true });
+      const prompt = deferred<LocalAuthenticationOutcome>({
+        status: 'retryable',
+        reason: 'user_cancel',
+      });
+      fixture.authenticate.mockReturnValueOnce(prompt.promise);
+      await setLocalAccessOwner('A', 1);
+      const pending = requestLocalAccess();
+      fixture.emit('inactive');
+      prompt.resolve({ status: 'authenticated' });
+      expect(await pending).toBe('pending-foreground');
+      if (invalidation === 'account') {
+        await setLocalAccessOwner('B', 2);
+      } else if (invalidation === 'lock') {
+        lockLocalAccess();
+      } else {
+        fixture.emit('background');
+        fixture.setTime(301_000);
+      }
+      setLocalAccessContextReady(true);
+      fixture.emit('active');
+      await requestLocalAccess('unlock', true);
+      expect(getLocalAccessSnapshot().unlocked).toBe(false);
+      expectDenied();
+    }
+  );
+
+  it('rejects an older same-account read after a newer read settles', async () => {
+    const fixture = setup({ status: 'present', enabled: false });
+    const read = deferred<LocalAccessReadResult>({ status: 'failed' });
+    fixture.storage.read.mockReturnValueOnce(read.promise);
+    const old = setLocalAccessOwner('A', 1);
+    setLocalAccessContextReady(true);
+    await reloadLocalAccessPreference();
+    read.resolve({ status: 'present', enabled: true });
+    await old;
+    expect(getLocalAccessSnapshot()).toMatchObject({ userId: 'A', enabled: false, unlocked: true });
+    expect(() => captureLocalAccessLease(scope)).not.toThrow();
+  });
+  it('ignores a late lifecycle callback from a disposed owner', async () => {
+    const original = await ready(false);
+    const deliver = original.queue('active');
+    stop?.();
+    setup({ status: 'present', enabled: false }, 'background');
+    await bind();
+    deliver();
+    expect(getLocalAccessSnapshot()).toMatchObject({ foregroundReady: false, unlocked: false });
+    expectDenied();
+  });
+
+  it('cannot grant a replacement account access through a setting subscriber', async () => {
+    const fixture = await ready(false);
+    fixture.records.set('B', { status: 'present', enabled: true });
+    fixture.authenticate
+      .mockResolvedValue({ status: 'retryable', reason: 'user_cancel' })
+      .mockResolvedValueOnce({ status: 'authenticated' });
+    const replacements: Promise<void>[] = [];
+    const exposures: boolean[] = [];
+    const unsubscribe = subscribeLocalAccess(() => {
+      const current = getLocalAccessSnapshot();
+      if (current.userId === 'B') {
+        exposures.push(current.unlocked);
+      }
+      if (current.userId === 'A' && current.enabled && current.operation === 'writing') {
+        replacements.push(setLocalAccessOwner('B', 2));
+      }
+    });
+    try {
+      await requestLocalAccess('enable');
+      await Promise.all(replacements);
+      setLocalAccessContextReady(true);
+      await requestLocalAccess('unlock', true);
+      expect(getLocalAccessSnapshot()).toMatchObject({
+        userId: 'B',
+        enabled: true,
+        unlocked: false,
+      });
+      expect(exposures).not.toContain(true);
+      expect(() => captureLocalAccessLease({ userId: 'B', organizationId: null })).toThrow(
+        LocalAccessDeniedError
+      );
+    } finally {
+      unsubscribe();
+    }
+  });
+});
+
+describe('immutable operation admission and passive completion', () => {
+  it('captures context without retargeting an operation during context selection', async () => {
+    await ready(false);
+    const source = { userId: 'A', organizationId: 'old-org' };
+    const lease = captureLocalAccessLease(source);
+    source.organizationId = 'new-org';
+    setLocalAccessContextReady(false);
+    expect(() => {
+      assertLocalAccessLease(lease);
+    }).toThrow(LocalAccessDeniedError);
+    setLocalAccessContextReady(true);
+    const next = captureLocalAccessLease(source);
+    expect(() => {
+      assertLocalAccessLease(lease);
+    }).not.toThrow();
+    expect([lease.organizationId, next.organizationId]).toEqual(['old-org', 'new-org']);
+    expect(() => Object.assign(lease, { organizationId: 'new-org' })).toThrow(TypeError);
+  });
+
+  it('never revives a locked lease but retains owner-safe accepted completion', async () => {
+    const fixture = await ready();
+    const lease = captureLocalAccessLease(scope);
+    lockLocalAccess();
+    fixture.emit('inactive');
+    expect(() => {
+      assertLocalAccessLease(lease);
+    }).toThrow(LocalAccessDeniedError);
+    expect(() => {
+      assertLocalAccessOwner(lease);
+    }).not.toThrow();
+    fixture.emit('active');
+    await requestLocalAccess();
+    expect(getLocalAccessSnapshot().unlocked).toBe(true);
+    expect(() => {
+      assertLocalAccessLease(lease);
+    }).toThrow(LocalAccessDeniedError);
+    expect(() => {
+      assertLocalAccessOwner(lease);
+    }).not.toThrow();
+    expect(() => captureLocalAccessLease(scope)).not.toThrow();
+    await setLocalAccessOwner('B', 2);
+    expect(() => {
+      assertLocalAccessOwner(lease);
+    }).toThrow(LocalAccessDeniedError);
+  });
+
+  it('rejects forged leases and same-user leases from an older auth epoch', async () => {
+    await ready(false);
+    const lease = captureLocalAccessLease(scope);
+    expect(() => {
+      assertLocalAccessOwner({ ...lease });
+    }).toThrow(LocalAccessDeniedError);
+    await bind('A', 2);
+    expect(() => {
+      assertLocalAccessOwner(lease);
+    }).toThrow(LocalAccessDeniedError);
+    expect(() => {
+      assertLocalAccessLease(lease);
+    }).toThrow(LocalAccessDeniedError);
+  });
+});

--- a/apps/mobile/src/lib/local-access.ts
+++ b/apps/mobile/src/lib/local-access.ts
@@ -1,0 +1,395 @@
+/* eslint-disable max-lines -- one process owner keeps lifecycle, setting publication, and lease fencing atomic */
+import { type AppStateStatus } from 'react-native';
+
+import {
+  type LocalAccessReadResult,
+  type LocalAccessStorage,
+  type LocalAccessWriteResult,
+} from '@/lib/local-access-storage';
+import {
+  type LocalAuthenticationFailure,
+  type LocalAuthenticationOutcome,
+} from '@/lib/local-authentication';
+
+export type LocalAccessScope = Readonly<{ userId: string; organizationId: string | null }>;
+export type LocalAccessLease = LocalAccessScope &
+  Readonly<{ authEpoch: number; unlockGeneration: number }>;
+type Recovery =
+  | LocalAuthenticationFailure
+  | Readonly<{ status: 'retryable'; reason: 'read_failed' | 'write_failed' | 'invalid_clock' }>
+  | Readonly<{ status: 'repair'; reason: 'malformed' }>;
+export type LocalAccessSnapshot = Readonly<{
+  userId: string | null;
+  authEpoch: number;
+  unlockGeneration: number;
+  contextReady: boolean;
+  foregroundReady: boolean;
+  unlocked: boolean;
+  preference: LocalAccessReadResult['status'] | 'uninitialized' | 'loading';
+  enabled: boolean | null;
+  operation: 'idle' | 'authenticating' | 'writing';
+  recovery: Recovery | null;
+}>;
+export type LocalAccessDependencies = {
+  storage: LocalAccessStorage;
+  authenticate: () => Promise<LocalAuthenticationOutcome>;
+  lifecycle: {
+    getCurrentState: () => AppStateStatus;
+    subscribe: (listener: (state: AppStateStatus) => void) => () => void;
+  };
+  now?: () => number;
+};
+export type LocalAccessAction = 'unlock' | 'enable' | 'disable' | 'repair';
+export type LocalAccessActionResult =
+  | LocalAccessWriteResult
+  | LocalAuthenticationFailure
+  | 'unlocked'
+  | 'pending-foreground'
+  | 'busy'
+  | 'denied';
+
+let snapshot: LocalAccessSnapshot = Object.freeze({
+  userId: null,
+  authEpoch: 0,
+  unlockGeneration: 0,
+  contextReady: false,
+  foregroundReady: false,
+  unlocked: false,
+  preference: 'uninitialized',
+  enabled: null,
+  operation: 'idle',
+  recovery: null,
+});
+let dependencies: LocalAccessDependencies | null = null;
+let ownerGeneration = 0;
+let attemptGeneration = 0;
+let readGeneration = 0;
+let granted = false;
+let pendingGrant: number | null = null;
+let backgroundAt: number | null = null;
+let automaticAllowed = true;
+let inFlight: Promise<LocalAccessActionResult> | null = null;
+const listeners = new Set<() => void>();
+const leaseOwners = new WeakMap<LocalAccessLease, number>();
+
+function publish(patch: Partial<LocalAccessSnapshot>): void {
+  const next = { ...snapshot, ...patch };
+  snapshot = Object.freeze({
+    ...next,
+    recovery: next.recovery ? Object.freeze(next.recovery) : null,
+    unlocked: Boolean(
+      dependencies &&
+      next.userId &&
+      next.foregroundReady &&
+      (next.enabled === false || (next.enabled === true && granted))
+    ),
+  });
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function getLocalAccessSnapshot(): LocalAccessSnapshot {
+  return snapshot;
+}
+
+export function subscribeLocalAccess(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function resetOwner(userId: string | null, authEpoch: number): void {
+  ownerGeneration += 1;
+  readGeneration += 1;
+  attemptGeneration += 1;
+  granted = false;
+  pendingGrant = null;
+  automaticAllowed = true;
+  publish({
+    userId,
+    authEpoch,
+    unlockGeneration: snapshot.unlockGeneration + 1,
+    contextReady: false,
+    preference: 'uninitialized',
+    enabled: null,
+    operation: 'idle',
+    recovery: null,
+  });
+}
+
+/** Install exactly one process owner. Cleanup denies admission and fences every pending completion. */
+export function initializeLocalAccess(input: LocalAccessDependencies): () => void {
+  if (dependencies) {
+    throw new Error('Local access is already initialized');
+  }
+  const installed = { ...input };
+  dependencies = installed;
+  backgroundAt = null;
+  resetOwner(null, snapshot.authEpoch);
+  onLifecycle(installed.lifecycle.getCurrentState());
+  const unsubscribe = installed.lifecycle.subscribe(state => {
+    if (dependencies === installed) {
+      onLifecycle(state);
+    }
+  });
+  return () => {
+    if (dependencies !== installed) {
+      return;
+    }
+    unsubscribe();
+    dependencies = null;
+    backgroundAt = null;
+    resetOwner(null, snapshot.authEpoch);
+    publish({ foregroundReady: false });
+  };
+}
+
+export async function reloadLocalAccessPreference(): Promise<void> {
+  const installed = dependencies;
+  const userId = snapshot.userId;
+  if (!installed || !userId) {
+    return;
+  }
+  const owner = ownerGeneration;
+  readGeneration += 1;
+  const read = readGeneration;
+  attemptGeneration += 1;
+  granted = false;
+  pendingGrant = null;
+  automaticAllowed = true;
+  publish({
+    preference: 'loading',
+    enabled: null,
+    recovery: null,
+    unlockGeneration: snapshot.unlockGeneration + 1,
+  });
+  let result: LocalAccessReadResult = { status: 'failed' };
+  try {
+    result = await installed.storage.read(userId);
+  } catch {
+    // Keep the failed-read result; rejection is not evidence of absence or malformed bytes.
+  }
+  if (owner !== ownerGeneration || read !== readGeneration || dependencies !== installed) {
+    return;
+  }
+  const enabled = result.status === 'present' ? result.enabled : null;
+  const recovery: Recovery | null =
+    result.status === 'failed' ? { status: 'retryable', reason: 'read_failed' } : null;
+  publish({
+    preference: result.status,
+    enabled: result.status === 'absent' ? false : enabled,
+    recovery: result.status === 'malformed' ? { status: 'repair', reason: 'malformed' } : recovery,
+  });
+  if (snapshot.enabled) {
+    void requestLocalAccess('unlock', true);
+  }
+}
+
+/** The auth provider supplies its runtime epoch only after it validates the durable user identity. */
+export async function setLocalAccessOwner(userId: string | null, authEpoch: number): Promise<void> {
+  if (!dependencies || (snapshot.userId === userId && snapshot.authEpoch === authEpoch)) {
+    return;
+  }
+  resetOwner(userId, authEpoch);
+  if (userId) {
+    await reloadLocalAccessPreference();
+  }
+}
+
+export function setLocalAccessContextReady(ready: boolean): void {
+  publish({ contextReady: Boolean(dependencies && snapshot.userId && ready) });
+}
+
+/** Revoke a grant, not the durable preference. Cancellation still requires explicit Retry. */
+export function lockLocalAccess(): void {
+  const hadGrant = granted || pendingGrant !== null;
+  automaticAllowed ||= hadGrant;
+  granted = false;
+  pendingGrant = null;
+  attemptGeneration += 1;
+  publish({
+    unlockGeneration: snapshot.unlockGeneration + 1,
+    recovery: hadGrant ? null : snapshot.recovery,
+  });
+}
+
+function onLifecycle(state: AppStateStatus): void {
+  if (state === 'background' && backgroundAt === null) {
+    backgroundAt = (dependencies?.now ?? Date.now)();
+  }
+  if (state === 'active' && backgroundAt !== null) {
+    const elapsed = (dependencies?.now ?? Date.now)() - backgroundAt;
+    backgroundAt = null;
+    const invalid = !Number.isFinite(elapsed) || elapsed < 0;
+    // Repair and enable attempts need expiry fencing before the enabled preference publishes.
+    if ((snapshot.enabled || snapshot.operation !== 'idle') && (invalid || elapsed >= 300_000)) {
+      lockLocalAccess();
+      if (invalid) {
+        publish({ recovery: { status: 'retryable', reason: 'invalid_clock' } });
+      }
+    }
+  }
+  // Evaluate expiry before any foreground publication. A prompt can finish while iOS is inactive.
+  if (state === 'active' && pendingGrant === attemptGeneration) {
+    granted = true;
+    pendingGrant = null;
+  }
+  publish({ foregroundReady: state === 'active' });
+  if (snapshot.foregroundReady && snapshot.enabled && !snapshot.unlocked) {
+    void requestLocalAccess('unlock', true);
+  }
+}
+
+function acceptAuthentication(
+  patch?: Pick<LocalAccessSnapshot, 'preference' | 'enabled'>
+): 'unlocked' | 'pending-foreground' {
+  if (snapshot.foregroundReady) {
+    granted = true;
+  } else {
+    pendingGrant = attemptGeneration;
+  }
+  // Publish the committed setting and its grant together. A subscriber can replace the account.
+  publish({ ...patch, recovery: null });
+  return snapshot.foregroundReady ? 'unlocked' : 'pending-foreground';
+}
+
+/** Automatic calls coalesce. Cancellation never schedules another prompt; Retry uses automatic=false. */
+export async function requestLocalAccess(
+  action: LocalAccessAction = 'unlock',
+  automatic = false
+): Promise<LocalAccessActionResult> {
+  if (inFlight) {
+    if (action !== 'unlock') {
+      return 'busy';
+    }
+    const result = await inFlight;
+    return result;
+  }
+  const installed = dependencies;
+  const userId = snapshot.userId;
+  const settingAllowed =
+    action === 'repair' ? snapshot.preference === 'malformed' : snapshot.enabled !== null;
+  const allowed = action === 'unlock' ? snapshot.enabled === true : settingAllowed;
+  if (
+    !installed ||
+    !userId ||
+    !snapshot.foregroundReady ||
+    !allowed ||
+    (automatic && !automaticAllowed)
+  ) {
+    return 'denied';
+  }
+  automaticAllowed = false;
+  const owner = ownerGeneration;
+  attemptGeneration += 1;
+  const attempt = attemptGeneration;
+  const isCurrent = () =>
+    dependencies === installed && owner === ownerGeneration && attempt === attemptGeneration;
+  const run = async (): Promise<LocalAccessActionResult> => {
+    let writing = false;
+    try {
+      // Reserve the single flight before subscribers or the native adapter can re-enter the owner.
+      await Promise.resolve();
+      if (!isCurrent() || !snapshot.foregroundReady) {
+        return 'stale';
+      }
+      const outcome = await installed.authenticate();
+      if (!isCurrent()) {
+        return 'stale';
+      }
+      if (outcome.status !== 'authenticated') {
+        publish({ recovery: outcome });
+        return outcome;
+      }
+      if (action === 'unlock') {
+        const result = acceptAuthentication();
+        return isCurrent() ? result : 'stale';
+      }
+      writing = true;
+      publish({ operation: 'writing' });
+      const enabled = action !== 'disable';
+      const result = await installed.storage.write(userId, enabled, isCurrent);
+      if (!isCurrent()) {
+        return 'stale';
+      }
+      if (result !== 'committed') {
+        publish({ recovery: { status: 'retryable', reason: 'write_failed' } });
+        return result;
+      }
+      acceptAuthentication({ preference: 'present', enabled });
+      return isCurrent() ? 'committed' : 'stale';
+    } catch {
+      if (!isCurrent()) {
+        return 'stale';
+      }
+      const recovery: Recovery = {
+        status: 'retryable',
+        reason: writing ? 'write_failed' : 'rejected',
+      };
+      publish({ recovery });
+      return writing ? 'failed' : { status: 'retryable', reason: 'rejected' };
+    } finally {
+      inFlight = null;
+      if (owner === ownerGeneration && dependencies === installed) {
+        publish({ operation: 'idle' });
+      }
+    }
+  };
+  inFlight = run();
+  publish({ operation: 'authenticating', recovery: null });
+  const result = await inFlight;
+  return result;
+}
+
+export class LocalAccessDeniedError extends Error {
+  readonly code = 'LOCAL_ACCESS_DENIED';
+  readonly reason: 'owner' | 'stale' | 'inactive' | 'context' | 'locked';
+  constructor(reason: LocalAccessDeniedError['reason']) {
+    super(`Local access denied: ${reason}`);
+    this.name = 'LocalAccessDeniedError';
+    this.reason = reason;
+  }
+}
+
+/** Only passive completion of already accepted work uses this check; it cannot admit new effects. */
+export function assertLocalAccessOwner(lease: LocalAccessLease): void {
+  if (
+    !dependencies ||
+    leaseOwners.get(lease) !== ownerGeneration ||
+    lease.userId !== snapshot.userId ||
+    lease.authEpoch !== snapshot.authEpoch
+  ) {
+    throw new LocalAccessDeniedError('owner');
+  }
+}
+
+/** Native effects also need a native foreground assertion; JavaScript readiness is not native proof. */
+export function assertLocalAccessLease(lease: LocalAccessLease): void {
+  assertLocalAccessOwner(lease);
+  if (lease.unlockGeneration !== snapshot.unlockGeneration) {
+    throw new LocalAccessDeniedError('stale');
+  }
+  if (!snapshot.foregroundReady) {
+    throw new LocalAccessDeniedError('inactive');
+  }
+  if (!snapshot.contextReady) {
+    throw new LocalAccessDeniedError('context');
+  }
+  if (!snapshot.unlocked) {
+    throw new LocalAccessDeniedError('locked');
+  }
+}
+
+export function captureLocalAccessLease(scope: LocalAccessScope): LocalAccessLease {
+  const lease = Object.freeze({
+    userId: scope.userId,
+    organizationId: scope.organizationId,
+    authEpoch: snapshot.authEpoch,
+    unlockGeneration: snapshot.unlockGeneration,
+  });
+  leaseOwners.set(lease, ownerGeneration);
+  assertLocalAccessLease(lease);
+  return lease;
+}

--- a/apps/mobile/src/lib/local-authentication.test.ts
+++ b/apps/mobile/src/lib/local-authentication.test.ts
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import {
+  type LocalAuthenticationError,
+  type LocalAuthenticationOptions,
+  type LocalAuthenticationResult,
+  type SecurityLevel,
+} from 'expo-local-authentication';
+
+import { authenticateLocalAccess } from './local-authentication';
+
+const native = vi.hoisted(() => ({
+  getEnrolledLevelAsync: vi.fn<() => Promise<SecurityLevel>>(),
+  authenticateAsync:
+    vi.fn<(options?: LocalAuthenticationOptions) => Promise<LocalAuthenticationResult>>(),
+}));
+vi.mock('expo-local-authentication', () => ({
+  ...native,
+  SecurityLevel: { NONE: 0, SECRET: 1, BIOMETRIC_WEAK: 2, BIOMETRIC_STRONG: 3 },
+}));
+
+beforeEach(() => {
+  native.getEnrolledLevelAsync.mockReset().mockResolvedValue(3);
+  native.authenticateAsync.mockReset().mockResolvedValue({ success: true });
+});
+
+describe('native device-owner authentication', () => {
+  it.each([1, 2, 3] as const)(
+    'authenticates level %s with compatible native fallback',
+    async level => {
+      native.getEnrolledLevelAsync.mockResolvedValue(level);
+      native.authenticateAsync.mockImplementation(async options => {
+        const result: LocalAuthenticationResult = await Promise.resolve(
+          options?.disableDeviceFallback === false &&
+            options.biometricsSecurityLevel === undefined &&
+            options.promptMessage === 'Unlock this account'
+            ? { success: true }
+            : { success: false, error: 'not_available' }
+        );
+        return result;
+      });
+      expect(await authenticateLocalAccess('Unlock this account')).toEqual({
+        status: 'authenticated',
+      });
+    }
+  );
+
+  it('does not treat capability as authentication', async () => {
+    const prompt = Promise.withResolvers<LocalAuthenticationResult>();
+    native.authenticateAsync.mockReturnValue(prompt.promise);
+    const result = authenticateLocalAccess('Unlock');
+    prompt.resolve({ success: false, error: 'authentication_failed' });
+    expect(await result).toEqual({ status: 'retryable', reason: 'authentication_failed' });
+  });
+
+  it('rechecks removed enrollment and accepts a newly authenticated device owner', async () => {
+    native.getEnrolledLevelAsync
+      .mockResolvedValueOnce(3)
+      .mockResolvedValueOnce(0)
+      .mockResolvedValueOnce(1);
+    expect(await authenticateLocalAccess('Unlock')).toEqual({ status: 'authenticated' });
+    expect(await authenticateLocalAccess('Unlock')).toEqual({
+      status: 'unavailable',
+      reason: 'not_enrolled',
+    });
+    expect(await authenticateLocalAccess('Unlock')).toEqual({ status: 'authenticated' });
+  });
+
+  it.each([
+    ['not_enrolled', 'unavailable'],
+    ['user_cancel', 'retryable'],
+    ['app_cancel', 'retryable'],
+    ['not_available', 'unavailable'],
+    ['lockout', 'retryable'],
+    ['no_space', 'terminal'],
+    ['timeout', 'retryable'],
+    ['unable_to_process', 'retryable'],
+    ['unknown', 'retryable'],
+    ['system_cancel', 'retryable'],
+    ['user_fallback', 'retryable'],
+    ['invalid_context', 'terminal'],
+    ['passcode_not_set', 'unavailable'],
+    ['authentication_failed', 'retryable'],
+    ['missing_usage_description', 'terminal'],
+  ] as const)('protects %s with %s recovery', async (reason, status) => {
+    // Expo's native implementation also returns missing_usage_description, outside its declared union.
+    native.authenticateAsync.mockResolvedValue({
+      success: false,
+      error: reason as LocalAuthenticationError,
+    });
+    expect(await authenticateLocalAccess('Unlock')).toEqual({ status, reason });
+  });
+
+  it.each(['getEnrolledLevelAsync', 'authenticateAsync'] as const)(
+    'protects a rejected %s promise',
+    async method => {
+      native[method].mockRejectedValue(new Error('Native failure'));
+      expect(await authenticateLocalAccess('Unlock')).toEqual({
+        status: 'retryable',
+        reason: 'rejected',
+      });
+    }
+  );
+
+  it('does not expose unknown native error text or grant access', async () => {
+    native.authenticateAsync.mockResolvedValue({
+      success: false,
+      error: 'unknown: native detail' as LocalAuthenticationError,
+    });
+    expect(await authenticateLocalAccess('Unlock')).toEqual({
+      status: 'terminal',
+      reason: 'unexpected_error',
+    });
+  });
+});

--- a/apps/mobile/src/lib/local-authentication.ts
+++ b/apps/mobile/src/lib/local-authentication.ts
@@ -1,0 +1,70 @@
+import type * as ExpoAuthentication from 'expo-local-authentication';
+
+type RecoveryStatus = 'retryable' | 'unavailable' | 'terminal';
+export type LocalAuthenticationFailure = Readonly<{
+  status: RecoveryStatus;
+  reason:
+    | ExpoAuthentication.LocalAuthenticationError
+    | 'missing_usage_description'
+    | 'rejected'
+    | 'unexpected_error';
+}>;
+export type LocalAuthenticationOutcome =
+  | Readonly<{ status: 'authenticated' }>
+  | LocalAuthenticationFailure;
+type NativeAuthentication = Pick<
+  typeof ExpoAuthentication,
+  'authenticateAsync' | 'getEnrolledLevelAsync' | 'SecurityLevel'
+>;
+
+// Retry stays explicit. Unavailable authentication requires OS configuration; terminal failures
+// require an app/device fix or sign-out. Neither recovery silently disables account protection.
+const recoveryByError = new Map<string, RecoveryStatus>(
+  Object.entries({
+    not_enrolled: 'unavailable',
+    user_cancel: 'retryable',
+    app_cancel: 'retryable',
+    not_available: 'unavailable',
+    lockout: 'retryable',
+    no_space: 'terminal',
+    timeout: 'retryable',
+    unable_to_process: 'retryable',
+    unknown: 'retryable',
+    system_cancel: 'retryable',
+    user_fallback: 'retryable',
+    invalid_context: 'terminal',
+    passcode_not_set: 'unavailable',
+    authentication_failed: 'retryable',
+    missing_usage_description: 'terminal',
+  } satisfies Record<
+    ExpoAuthentication.LocalAuthenticationError | 'missing_usage_description',
+    RecoveryStatus
+  >)
+);
+
+export async function authenticateLocalAccess(
+  promptMessage: string,
+  adapter?: NativeAuthentication
+): Promise<LocalAuthenticationOutcome> {
+  try {
+    const native = adapter ?? (await import('expo-local-authentication'));
+    // SECRET permits a passcode-only device. Hardware/enrollment checks cannot authenticate a user
+    // or identify a previous biometric enrollment. Recheck device-owner capability on every attempt.
+    const level = await native.getEnrolledLevelAsync();
+    if (level === native.SecurityLevel.NONE) {
+      return { status: 'unavailable', reason: 'not_enrolled' };
+    }
+    const result = await native.authenticateAsync({ promptMessage, disableDeviceFallback: false });
+    // Leave Android strength at Expo's default: Class 2-or-better plus device credentials also
+    // supports Android 9/10, unlike strong-plus-credential authentication.
+    if (result.success) {
+      return { status: 'authenticated' };
+    }
+    const status = recoveryByError.get(result.error);
+    return status
+      ? { status, reason: result.error }
+      : { status: 'terminal', reason: 'unexpected_error' };
+  } catch {
+    return { status: 'retryable', reason: 'rejected' };
+  }
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -481,6 +481,9 @@ importers:
       expo-linking:
         specifier: 57.0.5
         version: 57.0.5(expo@57.0.10)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)
+      expo-local-authentication:
+        specifier: ~57.0.2
+        version: 57.0.2(expo@57.0.10)
       expo-localization:
         specifier: ~57.0.1
         version: 57.0.1(expo@57.0.10)(react@19.2.3)
@@ -12713,6 +12716,11 @@ packages:
     peerDependencies:
       react: '*'
       react-native: '*'
+
+  expo-local-authentication@57.0.2:
+    resolution: {integrity: sha512-8K4zcrQ5wZkRS1rwEWY8qHbeGVMNh35e9D1VTVKlMHz1O47itW+pW6iBVuqwGFLozN4fRBeEDQH8hu9Gt58YuQ==}
+    peerDependencies:
+      expo: '*'
 
   expo-localization@57.0.1:
     resolution: {integrity: sha512-8Ffl4UTbOsQeGT0v5fxMbyPHyPMPnhSPDFQJa8p9rjJrthFoAtNi+fL6Ssmrvf1/7dmPq1mVY52MEt0TMEfgjA==}
@@ -30126,6 +30134,11 @@ snapshots:
       - expo
       - supports-color
     optional: true
+
+  expo-local-authentication@57.0.2(expo@57.0.10):
+    dependencies:
+      expo: 57.0.10(@babel/core@7.29.7)(@expo/metro-runtime@57.0.8)(bufferutil@4.1.0)(expo-router@57.0.10)(react-dom@19.2.6(react@19.2.3))(react-native-worklets@0.10.1(@babel/core@7.29.7)(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3))(react-native@0.86.2(@types/react@19.2.14)(bufferutil@4.1.0)(react@19.2.3)(utf-8-validate@6.0.6))(react@19.2.3)(typescript@6.0.3)(utf-8-validate@6.0.6)
+      invariant: 2.2.4
 
   expo-localization@57.0.1(expo@57.0.10)(react@19.2.3):
     dependencies:

--- a/scripts/stacked-ci.test.mjs
+++ b/scripts/stacked-ci.test.mjs
@@ -1,0 +1,254 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { matchesGlob } from 'node:path';
+import test from 'node:test';
+
+import { load } from 'js-yaml';
+
+const rootPath = '.github/workflows/ci.yml';
+const mobilePath = '.github/workflows/kilo-app-ci.yml';
+const checkPath = 'scripts/stacked-ci.test.mjs';
+const command = `node --test ${checkPath}`;
+const originalMobilePaths = [
+  'apps/mobile/**',
+  'packages/trpc/**',
+  'apps/web/src/routers/**',
+  'packages/app-shared/**',
+  'packages/kilo-chat/**',
+  'packages/kilo-chat-hooks/**',
+  'packages/event-service/**',
+  'packages/notifications/**',
+  'packages/cloud-agent-sdk/**',
+  'pnpm-lock.yaml',
+  mobilePath,
+];
+
+function readWorkflows() {
+  return [rootPath, mobilePath].map(path =>
+    load(readFileSync(new URL(`../${path}`, import.meta.url), 'utf8'))
+  );
+}
+
+function admits(workflow, event, base, files) {
+  if (!(event in workflow.on)) return false;
+  const trigger = workflow.on[event] ?? {};
+  if (trigger.branches && !trigger.branches.some(pattern => matchesGlob(base, pattern)))
+    return false;
+  if (trigger['branches-ignore']?.some(pattern => matchesGlob(base, pattern))) return false;
+  if (
+    trigger.paths &&
+    !files.some(file => trigger.paths.some(pattern => matchesGlob(file, pattern)))
+  )
+    return false;
+  return (
+    !trigger['paths-ignore'] ||
+    files.some(file => !trigger['paths-ignore'].some(pattern => matchesGlob(file, pattern)))
+  );
+}
+
+function validateCheck(workflow, jobName) {
+  const job = workflow.jobs[jobName];
+  assert.equal(job.if, undefined, `${jobName}: check job must be unconditional`);
+  assert.equal(job.needs, undefined, `${jobName}: check job must not depend on filtering`);
+  assert.equal(job['continue-on-error'], undefined, `${jobName}: check failure must fail the job`);
+  const steps = job.steps;
+  const checks = steps.filter(step => step.run === command);
+  assert.equal(checks.length, 1, `${jobName}: run the check exactly once`);
+  const step = checks[0];
+  assert.equal(step.if, undefined, `${jobName}: check step must be unconditional`);
+  assert.equal(
+    step['continue-on-error'],
+    undefined,
+    `${jobName}: check failure must not be ignored`
+  );
+  assert.equal(
+    step['working-directory'] ??
+      job.defaults?.run?.['working-directory'] ??
+      workflow.defaults?.run?.['working-directory'] ??
+      '.',
+    '.',
+    `${jobName}: check must run from the repository root`
+  );
+  const installIndex = steps.findIndex(item => /\bpnpm\b.*\binstall\b/.test(item.run ?? ''));
+  const checkIndex = steps.indexOf(step);
+  assert.ok(installIndex >= 0 && installIndex < checkIndex, `${jobName}: install before the check`);
+  if (jobName === 'changes') {
+    const filterIndex = steps.findIndex(item => item.id === 'filter');
+    assert.ok(filterIndex > checkIndex, 'changes: check before filtering');
+  }
+}
+
+function validate(root, mobile) {
+  for (const workflow of [root, mobile]) {
+    assert.ok('pull_request' in workflow.on, 'pull_request must be enabled');
+    const trigger = workflow.on.pull_request ?? {};
+    assert.equal(trigger.branches, undefined, 'pull_request must admit every base');
+    assert.equal(trigger['branches-ignore'], undefined, 'pull_request must not exclude bases');
+    assert.deepEqual(workflow.on.push.branches, ['main'], 'push must remain main-only');
+    assert.equal(workflow.on.push['branches-ignore'], undefined);
+  }
+  assert.equal(root.on.pull_request?.paths, undefined, 'root admission must not filter paths');
+  assert.equal(root.on.pull_request?.['paths-ignore'], undefined);
+  assert.deepEqual(root.permissions, { contents: 'read', 'pull-requests': 'read' });
+  assert.deepEqual(mobile.permissions, { contents: 'read' });
+  assert.ok('workflow_call' in mobile.on, 'mobile release caller must remain enabled');
+  for (const event of ['push', 'pull_request']) {
+    assert.deepEqual(mobile.on[event].paths, [...originalMobilePaths, rootPath, checkPath]);
+    assert.equal(mobile.on[event]['paths-ignore'], undefined);
+  }
+  validateCheck(root, 'changes');
+  validateCheck(mobile, 'test');
+}
+
+test('both live workflows validate triggers and unconditional check invocations', () => {
+  validate(...readWorkflows());
+});
+
+for (const base of ['main', 'stack/level-one', 'arbitrary/parent-42']) {
+  for (const file of [rootPath, mobilePath, checkPath, 'apps/mobile/src/app/_layout.tsx']) {
+    test(`isolated ${file} admits both workflows on ${base}`, () => {
+      for (const workflow of readWorkflows()) {
+        assert.equal(admits(workflow, 'pull_request', base, [file]), true);
+      }
+    });
+  }
+}
+
+test('mobile keeps every existing path and main-only pushes', () => {
+  const [root, mobile] = readWorkflows();
+  for (const pattern of originalMobilePaths) {
+    const file = pattern.replace('**', 'fixture.ts');
+    assert.equal(admits(mobile, 'pull_request', 'stack/parent', [file]), true);
+    assert.equal(admits(mobile, 'push', 'main', [file]), true);
+    assert.equal(admits(mobile, 'push', 'stack/parent', [file]), false);
+  }
+  assert.equal(admits(root, 'push', 'stack/parent', [rootPath]), false);
+  assert.equal(admits(mobile, 'pull_request', 'stack/parent', ['README.md']), false);
+});
+
+test('mobile catches an isolated root main-only regression on a stacked base', () => {
+  const [root, mobile] = readWorkflows();
+  root.on.pull_request = { branches: ['main'] };
+  assert.equal(admits(root, 'pull_request', 'stack/parent', [rootPath]), false);
+  assert.equal(admits(mobile, 'pull_request', 'stack/parent', [rootPath]), true);
+  assert.throws(() => validate(root, mobile), /pull_request must admit every base/);
+});
+
+for (const [index, jobName] of [
+  [0, 'changes'],
+  [1, 'test'],
+]) {
+  for (const defect of [
+    'missing',
+    'conditional-step',
+    'conditional-job',
+    'ignored',
+    'directory',
+    'before-install',
+  ]) {
+    test(`${jobName} rejects a ${defect} check`, () => {
+      const workflows = readWorkflows();
+      const job = workflows[index].jobs[jobName];
+      const checkIndex = job.steps.findIndex(step => step.run === command);
+      const check = job.steps[checkIndex];
+      if (defect === 'missing') job.steps.splice(checkIndex, 1);
+      if (defect === 'conditional-step') check.if = 'false';
+      if (defect === 'conditional-job') job.if = 'false';
+      if (defect === 'ignored') check['continue-on-error'] = true;
+      if (defect === 'directory') job.defaults = { run: { 'working-directory': 'apps/mobile' } };
+      if (defect === 'before-install') job.steps.unshift(...job.steps.splice(checkIndex, 1));
+      assert.throws(() => validate(...workflows), assert.AssertionError);
+    });
+  }
+}
+
+test('CI keeps its existing event types and excludes tag pushes', () => {
+  const [root, mobile] = readWorkflows();
+  assert.deepEqual(Object.keys(root.on).sort(), ['pull_request', 'push']);
+  assert.deepEqual(Object.keys(mobile.on).sort(), ['pull_request', 'push', 'workflow_call']);
+  assert.deepEqual(root.on.push, { branches: ['main'] });
+  assert.deepEqual(mobile.on.push, {
+    branches: ['main'],
+    paths: [...originalMobilePaths, rootPath, checkPath],
+  });
+});
+
+test('admission file pushes start both workflows only on main', () => {
+  for (const workflow of readWorkflows()) {
+    for (const file of [rootPath, mobilePath, checkPath]) {
+      assert.equal(admits(workflow, 'push', 'main', [file]), true);
+      assert.equal(admits(workflow, 'push', 'stack/level-one', [file]), false);
+      assert.equal(admits(workflow, 'push', 'arbitrary/parent-42', [file]), false);
+    }
+  }
+});
+
+test('unrelated files start root CI but not mobile CI', () => {
+  const [root, mobile] = readWorkflows();
+  for (const [event, base] of [
+    ['pull_request', 'stack/parent'],
+    ['push', 'main'],
+  ]) {
+    assert.equal(admits(root, event, base, ['README.md']), true);
+    assert.equal(admits(mobile, event, base, ['README.md']), false);
+  }
+});
+
+test('CI jobs keep the workflow read-only permissions', () => {
+  for (const workflow of readWorkflows()) {
+    for (const [name, job] of Object.entries(workflow.jobs)) {
+      assert.equal(job.permissions, undefined, `${name}: do not override read-only permissions`);
+    }
+  }
+});
+
+test('only the main failure notification can access CI secrets', () => {
+  const [root, mobile] = readWorkflows();
+  const { 'notify-main-failure': notification, ...jobs } = root.jobs;
+  assert.doesNotMatch(JSON.stringify({ ...root, jobs }), /\bsecrets\b/);
+  assert.doesNotMatch(JSON.stringify(mobile), /\bsecrets\b/);
+  assert.equal(
+    notification.if,
+    "${{ always() && github.ref == 'refs/heads/main' && contains(join(needs.*.result, ','), 'failure') }}"
+  );
+  assert.equal(
+    notification.steps[0].with.webhook,
+    '${{ secrets.DEPLOY_NOTIFY_SLACK_WEBHOOK_URL }}'
+  );
+});
+
+const release = load(
+  readFileSync(new URL('../.github/workflows/kilo-app-release.yml', import.meta.url), 'utf8')
+);
+
+test('release retains only scheduled and manual entry points', () => {
+  assert.deepEqual(release.on, {
+    schedule: [{ cron: '0 6 * * *' }],
+    workflow_dispatch: null,
+  });
+});
+
+test('release validation keeps the local CI call without inherited secrets', () => {
+  const [, mobile] = readWorkflows();
+  assert.deepEqual(release.jobs.validate, { uses: `./${mobilePath}` });
+  assert.equal(mobile.on.workflow_call, null);
+});
+
+for (const [name, needs] of [
+  ['preflight', ['check-changes']],
+  ['build-and-submit', ['check-changes', 'validate', 'preflight']],
+]) {
+  test(`release ${name} requires changed main and its existing checks`, () => {
+    assert.equal(
+      release.jobs[name].if,
+      "needs.check-changes.outputs.should_build == 'true' && github.ref == 'refs/heads/main'"
+    );
+    assert.deepEqual(release.jobs[name].needs, needs);
+  });
+}
+
+test('release retains its existing permission boundaries', () => {
+  assert.deepEqual(release.permissions, { contents: 'write' });
+  assert.deepEqual(release.jobs.preflight.permissions, { contents: 'read' });
+  assert.equal(release.jobs['build-and-submit'].permissions, undefined);
+});


### PR DESCRIPTION
No new behavior — account protection is not yet available in the app.

---

## Summary

`LocalAccessDependencies`, `LocalAccessSnapshot`, `LocalAccessAction`, `LocalAccessActionResult`, and `Recovery` define one account owner to publish setting changes and access grants atomically.
`LocalAccessScope`, `LocalAccessLease`, and `LocalAccessDeniedError` (`LOCAL_ACCESS_DENIED`) enforce `authEpoch`, `unlockGeneration`, foreground readiness, context readiness, and unlocked access.
Callers must validate account ownership and separately verify native foreground activity; five-minute background expiry revokes grants without changing the saved preference.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/local-access.ts` — Source, added (A), 395 changed lines. Adds a dependency-injected singleton, frozen snapshots, subscriptions, and lifecycle cleanup that clears ownership and denies admission. Account or epoch changes clear context readiness and grants, invalidate leases and pending results, then load the account's preference. Preference reloads revoke grants and invalidate earlier reads or authentication attempts. Absent or disabled preferences allow foreground access; malformed records require repair, while failed reads produce retryable `read_failed` recovery. Unlock requests share one active attempt, while concurrent setting requests return `busy`. A microtask defers authentication so the owner can reserve the attempt before native callbacks or subscribers re-enter. Cancellation requires an explicit retry instead of another automatic prompt. Enable, disable, and repair authenticate before writing; repair enables protection. The owner publishes only a current committed setting together with its grant. Authentication completed while inactive holds the grant until foreground activation. When protection or an operation is active, five background minutes or invalid elapsed time revoke grants and invalidate attempts before foreground publication. Negative or nonfinite elapsed time sets `invalid_clock` recovery. Locking leaves the preference intact; a current attempt with an uncommitted write reports retryable `write_failed` recovery instead of publishing a new setting. Leases capture the organization without proving membership; owner-only checks permit passive completion, not new effects. Full lease checks also require matching ownership and generation, foreground activity, context readiness, and unlocked access. `LocalAccessDeniedError` distinguishes `owner`, `stale`, `inactive`, `context`, and `locked` denials. No provider, screen, or tool-bridge integration activates these contracts.
- `apps/mobile/src/lib/local-access.test.ts` — Test, added (A), 953 changed lines. Adds coordinator regression tests.

</details>

`LocalAccessStorage`, `LocalAccessReadResult`, `LocalAccessWriteResult`, and `SecurityStore` introduce account-specific preferences that survive logout without altering credential storage.
`recordSchema` accepts only `version: 1` and a Boolean `enabled`; `local-access-v1-` uses `keychainAccessible: WHEN_UNLOCKED_THIS_DEVICE_ONLY`.
Missing records leave protection off; invalid records and read errors deny access, while serialization and `isCurrent` checks block stale authorization.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/local-access-storage.ts` — Source, added (A), 73 changed lines. Adds an injectable store and encoded keys for each account. Reads wait behind writes for the same key, preventing re-entry from observing old bytes. Invalid JSON, extra fields, and unsupported versions return `malformed`; storage read exceptions return `failed`. Writes check `isCurrent` before the native call and after completion, returning `committed`, `failed`, or `stale`. A native write already in progress can alter its original account, but a stale result cannot authorize the current account.
- `apps/mobile/src/lib/local-access-storage.test.ts` — Test, added (A), 167 changed lines. Adds tests for account-specific preference storage.

</details>

`authenticateLocalAccess` checks device capability on each attempt through `NativeAuthentication`, permitting passcode-only devices with `disableDeviceFallback: false`.
`LocalAuthenticationOutcome`, `LocalAuthenticationFailure`, and `RecoveryStatus` distinguish success from explicit retry, device setup, or terminal recovery without changing the protection preference.
Expo's default Android strength accepts Class 2-or-better authentication plus device credentials on Android 9/10; enrollment checks do not identify earlier biometric enrollment.

<details>
<summary>Files</summary>

- `apps/mobile/src/lib/local-authentication.ts` — Source, added (A), 70 changed lines. Loads the native module on demand and accepts a supplied adapter and prompt. If enrollment returns `SecurityLevel.NONE`, authentication returns `unavailable` with `not_enrolled`. `not_enrolled`, `not_available`, and `passcode_not_set` require device setup. Cancellation, fallback, lockout, timeout, processing errors, `unknown`, and failed authentication return retryable failures. `no_space`, `invalid_context`, and `missing_usage_description` return terminal failures. Unmapped errors become terminal `unexpected_error`; thrown errors become retryable `rejected`. Terminal failures require an app/device fix or sign-out, not automatic removal of protection.
- `apps/mobile/src/lib/local-authentication.test.ts` — Test, added (A), 114 changed lines. Adds tests for native authentication outcomes.

</details>

`expo-local-authentication` at `~57.0.2` adds the native dependency, and `faceIDPermission` supplies an account-unlock explanation for Face ID.
Development apps need a rebuild to include the module and permission; these additions do not enable biometric controls.

<details>
<summary>Files</summary>

- `apps/mobile/app.config.ts` — Source, modified (M), 6 changed lines. Adds the native authentication plugin with the Face ID explanation for unlocking this account on this device.
- `apps/mobile/package.json` — Source, modified (M), 1 changed line. Declares the new native authentication dependency at `~57.0.2`.
- `pnpm-lock.yaml` — Generated, modified (M), 13 changed lines. Updates the lockfile alongside the native dependency addition.

</details>

`CI` and `kilo-app CI` now accept `pull_request` events for any target branch, allowing continuous integration (CI) for stacked pull requests.
Both workflows keep `push` restricted to `main`; `kilo-app CI` retains `workflow_call` and expands its `paths` filters to cover admission checks.
New admission regressions run before change detection or mobile test preparation; existing jobs, permissions, and cancellation behavior remain intact.

<details>
<summary>Files</summary>

- `.github/workflows/ci.yml` — Source, modified (M), 4 changed lines. Accepts pull requests against all branches and runs the admission tests before dependency-change tests and workspace detection.
- `.github/workflows/kilo-app-ci.yml` — Source, modified (M), 8 changed lines. Accepts pull requests against all branches. Both event filters now include the main workflow and admission tests, alongside the existing mobile workflow. Runs the admission tests before type generation and mobile tests.
- `scripts/stacked-ci.test.mjs` — Test, added (A), 254 changed lines. Adds regression tests for stacked CI admission.

</details>

Tests: 4 files added, with 1,488 changed lines: `local-access.test.ts`, `local-access-storage.test.ts`, `local-authentication.test.ts`, and `stacked-ci.test.mjs`.
Generated: 1 lockfile updated (`pnpm-lock.yaml`), with 13 changed lines.

---

## Verification

- No manual device tests ran because this level does not expose biometric controls.
- Device verification remains pending in the final tip's `bot-e2e` workflow; the orchestrator performs it before completion, not a human tester.
- The section remains `bot-e2e`, not `human-e2e`.

## Visual Changes

Visual Changes: N/A

## Reviewer Notes

### Human steps

- **after merge — Rebuild and install the iOS and Android development apps before testing native authentication.**
- This level needs no environment setup, new secrets, data migration, or flag changes before merge.

### Supplied verification evidence

- The handoff reports five passing scoped checks and 37 passing CI regression tests.
- The handoff reports 156 core tests, including 43 expiry regressions.

### Scope

- Repository: `Kilo-Org/cloud`.
- Worktree: `/Users/igor/Projects/.worktrees/mobile-context-lock-758a`.
- Branch: `mobile-context-lock-758a`; base: `origin/main`.
- Commits: `7503e72a5` and `cf2150203`; level 1 only.

### Notes

This level does not expose biometric controls. Full iOS and Android verification runs on the final stack level.

Full iOS and Android runtime verification remains bot-e2e on the final level.

<!-- kilo-stack -->
**Stacked PRs — merge bottom to top.** Each level shows only its own diff.

Runtime verification (E2E, user advocacy, simplify) runs on the tip PR over every level.
Every level keeps its own checks, its own bot review, and its own threads; each one is answered on its own PR.
Each level is its own deliverable: it builds and passes its own checks alone.
A finding on a level is repaired on that level, then carried upward with stack.sh forward.

1. `mobile-context-lock-758a` — #5642 ← this PR
2. `mobile-context-lock-758a-s2` — #5651
3. `mobile-context-lock-758a-s3` — #5658
4. `mobile-context-lock-758a-s4` — #5664
5. `mobile-context-lock-758a-s5` — #5683 (tip)
